### PR TITLE
feat(leios): EB forging integration into Praos slot leader

### DIFF
--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -730,7 +730,12 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 
 	ebCbor, ebHash, txRefCount, err := buildLeiosEB(txs)
 	if err != nil {
-		return fmt.Errorf("build leios EB: %w", err)
+		// No valid transaction references is a skip, not a hard failure.
+		f.logger.Debug("leios EB skipped: no valid tx refs", "slot", slot, "error", err)
+		if f.metrics != nil {
+			f.metrics.leiosEbSkipped.WithLabelValues("no_valid_tx_refs").Inc()
+		}
+		return nil
 	}
 
 	if err := f.leiosEBCaster.BroadcastEndorserBlock(slot, ebHash, ebCbor); err != nil {
@@ -749,10 +754,10 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 	return nil
 }
 
-// buildLeiosEB assembles a LeiosEndorserBlock from mempool transactions,
-// returning its CBOR encoding, blake2b-256 hash, number of tx references,
-// and any error. Transactions with invalid hashes or sizes exceeding uint16
-// are silently dropped; the call fails only when no valid references remain.
+// buildLeiosEB assembles a LeiosEndorserBlock from mempool transactions.
+// Transactions with invalid hex hashes, non-32-byte hashes, zero sizes,
+// or sizes exceeding uint16 are silently dropped. Returns an error only
+// when no valid references remain after filtering.
 func buildLeiosEB(
 	txs []MempoolTransaction,
 ) (cbor []byte, hash []byte, txRefCount int, err error) {

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -32,6 +32,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// errNoValidTxRefs is returned by buildLeiosEB when all mempool transactions
+// are filtered out (invalid hash, zero size, or size > uint16). It is
+// treated as a skip rather than a hard failure by checkAndForgeLeiosEB.
+var errNoValidTxRefs = errors.New(
+	"no valid transaction references for endorser block",
+)
+
 // Mode represents the forging mode.
 type Mode int
 
@@ -730,6 +737,13 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 
 	ebCbor, ebHash, txRefCount, err := buildLeiosEB(txs)
 	if err != nil {
+		if errors.Is(err, errNoValidTxRefs) {
+			f.logger.Debug("leios EB skipped: no valid tx refs", "slot", slot)
+			if f.metrics != nil {
+				f.metrics.leiosEbSkipped.WithLabelValues("no_valid_tx_refs").Inc()
+			}
+			return nil
+		}
 		return fmt.Errorf("build leios EB: %w", err)
 	}
 
@@ -772,9 +786,7 @@ func buildLeiosEB(
 		})
 	}
 	if len(refs) == 0 {
-		return nil, nil, 0, errors.New(
-			"no valid transaction references for endorser block",
-		)
+		return nil, nil, 0, errNoValidTxRefs
 	}
 	eb := gleios.LeiosEndorserBlock{TransactionReferences: refs}
 	ebCbor, marshalErr := eb.MarshalCBOR()

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -730,12 +730,7 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 
 	ebCbor, ebHash, txRefCount, err := buildLeiosEB(txs)
 	if err != nil {
-		// No valid transaction references is a skip, not a hard failure.
-		f.logger.Debug("leios EB skipped: no valid tx refs", "slot", slot, "error", err)
-		if f.metrics != nil {
-			f.metrics.leiosEbSkipped.WithLabelValues("no_valid_tx_refs").Inc()
-		}
-		return nil
+		return fmt.Errorf("build leios EB: %w", err)
 	}
 
 	if err := f.leiosEBCaster.BroadcastEndorserBlock(slot, ebHash, ebCbor); err != nil {

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -72,6 +74,11 @@ type BlockForger struct {
 	// Slot battle detection
 	slotTracker *SlotTracker
 
+	// Optional Leios EB forging (nil = relay or pre-Dijkstra era)
+	leiosChecker  LeiosProduceChecker
+	leiosEBCaster EndorserBlockBroadcaster
+	leiosMempool  MempoolProvider
+
 	// Prometheus metrics
 	metrics *forgingMetrics
 
@@ -115,6 +122,20 @@ type BlockForgedObserver func(
 	latency time.Duration,
 )
 
+// LeiosProduceChecker is the forge-loop seam into the Leios pipeline.
+// It reports whether the slot leader may produce an endorser block for
+// the given slot (respects the single-EB-per-slot rule and produce window).
+// A nil checker means Leios EB forging is disabled (relay or pre-Dijkstra era).
+type LeiosProduceChecker interface {
+	MayProduceEndorserBlock(slot uint64) (allowed bool, reason string, err error)
+}
+
+// EndorserBlockBroadcaster stores a locally-forged endorser block and
+// notifies connected peers via the LeiosNotify protocol.
+type EndorserBlockBroadcaster interface {
+	BroadcastEndorserBlock(slot uint64, hash []byte, cbor []byte) error
+}
+
 // SlotClockProvider provides current slot information from the slot clock.
 type SlotClockProvider interface {
 	// CurrentSlot returns the current slot number based on wall-clock time.
@@ -143,6 +164,15 @@ type ForgerConfig struct {
 	BlockBroadcaster BlockBroadcaster
 	BlockForged      BlockForgedObserver
 	SlotClock        SlotClockProvider
+
+	// LeiosProduceChecker enables EB forging when non-nil. Requires
+	// LeiosEBBroadcaster and LeiosMempool to also be set.
+	LeiosProduceChecker LeiosProduceChecker
+	// LeiosEBBroadcaster propagates locally-forged EBs to peers.
+	LeiosEBBroadcaster EndorserBlockBroadcaster
+	// LeiosMempool provides transactions for EB building. May reuse the
+	// same MempoolProvider as the RB builder.
+	LeiosMempool MempoolProvider
 
 	// ForgeSyncToleranceSlots controls how far the local chain can lag the
 	// upstream tip before forging is skipped. Zero uses the default.
@@ -176,6 +206,9 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		blockForged:      cfg.BlockForged,
 		slotClock:        cfg.SlotClock,
 		slotTracker:      NewSlotTracker(),
+		leiosChecker:     cfg.LeiosProduceChecker,
+		leiosEBCaster:    cfg.LeiosEBBroadcaster,
+		leiosMempool:     cfg.LeiosMempool,
 	}
 	if cfg.ForgeSyncToleranceSlots == 0 {
 		cfg.ForgeSyncToleranceSlots = forgeSyncToleranceSlots
@@ -201,6 +234,14 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		}
 		if cfg.SlotClock == nil {
 			return nil, errors.New("production mode requires slot clock")
+		}
+	}
+	if cfg.LeiosProduceChecker != nil {
+		if cfg.LeiosEBBroadcaster == nil {
+			return nil, errors.New("LeiosProduceChecker requires LeiosEBBroadcaster")
+		}
+		if cfg.LeiosMempool == nil {
+			return nil, errors.New("LeiosProduceChecker requires LeiosMempool")
 		}
 	}
 
@@ -472,6 +513,22 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		f.metrics.forgeNodeIsLeader.Inc()
 	}
 
+	// Leios EB production: attempt before the RB so the EB can begin
+	// diffusing while the RB is being assembled. Failure is non-fatal
+	// for the RB — a missed EB is better than a missed block.
+	if f.leiosChecker != nil {
+		if err := f.checkAndForgeLeiosEB(currentSlot); err != nil {
+			f.logger.Warn(
+				"leios endorser block production failed",
+				"slot", currentSlot,
+				"error", err,
+			)
+			if f.metrics != nil {
+				f.metrics.leiosEbFailed.Inc()
+			}
+		}
+	}
+
 	f.logger.Info("producing block", "slot", currentSlot)
 
 	// Calculate KES period for this slot
@@ -640,6 +697,92 @@ func (f *BlockForger) SignBlockHeader(
 // by other components (e.g., chainsync) to detect slot battles.
 func (f *BlockForger) SlotTracker() *SlotTracker {
 	return f.slotTracker
+}
+
+// checkAndForgeLeiosEB attempts to produce and broadcast a Leios endorser
+// block for the given slot. It is called by the slot leader before RB
+// construction so the EB can begin diffusing while the RB is assembled.
+func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
+	allowed, reason, err := f.leiosChecker.MayProduceEndorserBlock(slot)
+	if err != nil {
+		return fmt.Errorf("leios produce check: %w", err)
+	}
+	if !allowed {
+		f.logger.Debug(
+			"leios EB skipped",
+			"slot", slot,
+			"reason", reason,
+		)
+		if f.metrics != nil {
+			f.metrics.leiosEbSkipped.WithLabelValues(reason).Inc()
+		}
+		return nil
+	}
+
+	txs := f.leiosMempool.Transactions()
+	if len(txs) == 0 {
+		f.logger.Debug("leios EB skipped: mempool empty", "slot", slot)
+		if f.metrics != nil {
+			f.metrics.leiosEbSkipped.WithLabelValues("no_transactions").Inc()
+		}
+		return nil
+	}
+
+	ebCbor, ebHash, txRefCount, err := buildLeiosEB(txs)
+	if err != nil {
+		return fmt.Errorf("build leios EB: %w", err)
+	}
+
+	if err := f.leiosEBCaster.BroadcastEndorserBlock(slot, ebHash, ebCbor); err != nil {
+		return fmt.Errorf("broadcast leios EB: %w", err)
+	}
+
+	f.logger.Info(
+		"leios endorser block produced",
+		"slot", slot,
+		"hash", hex.EncodeToString(ebHash),
+		"tx_refs", txRefCount,
+	)
+	if f.metrics != nil {
+		f.metrics.leiosEbForged.Inc()
+	}
+	return nil
+}
+
+// buildLeiosEB assembles a LeiosEndorserBlock from mempool transactions,
+// returning its CBOR encoding, blake2b-256 hash, number of tx references,
+// and any error. Transactions with invalid hashes or sizes exceeding uint16
+// are silently dropped; the call fails only when no valid references remain.
+func buildLeiosEB(
+	txs []MempoolTransaction,
+) (cbor []byte, hash []byte, txRefCount int, err error) {
+	refs := make([]gleios.LeiosTransactionReference, 0, len(txs))
+	for _, tx := range txs {
+		raw, hexErr := hex.DecodeString(tx.Hash)
+		if hexErr != nil || len(raw) != 32 {
+			continue
+		}
+		sz := len(tx.Cbor)
+		if sz == 0 || sz > math.MaxUint16 {
+			continue
+		}
+		refs = append(refs, gleios.LeiosTransactionReference{
+			TransactionHash: lcommon.NewBlake2b256(raw),
+			TransactionSize: uint16(sz), // #nosec G115 -- bounded above
+		})
+	}
+	if len(refs) == 0 {
+		return nil, nil, 0, errors.New(
+			"no valid transaction references for endorser block",
+		)
+	}
+	eb := gleios.LeiosEndorserBlock{TransactionReferences: refs}
+	ebCbor, marshalErr := eb.MarshalCBOR()
+	if marshalErr != nil {
+		return nil, nil, 0, fmt.Errorf("marshal leios EB: %w", marshalErr)
+	}
+	h := lcommon.Blake2b256Hash(ebCbor)
+	return ebCbor, h.Bytes(), len(refs), nil
 }
 
 // modeString returns a string representation of the forging mode.

--- a/ledger/forging/metrics.go
+++ b/ledger/forging/metrics.go
@@ -45,6 +45,11 @@ type forgingMetrics struct {
 	forgeSyncSkip    prometheus.Counter
 	slotClockErrors  prometheus.Counter
 	tipGapSlots      prometheus.Gauge
+
+	// Leios EB forging outcomes
+	leiosEbForged  prometheus.Counter
+	leiosEbSkipped *prometheus.CounterVec
+	leiosEbFailed  prometheus.Counter
 }
 
 // initForgingMetrics initializes all forging metrics using the
@@ -160,6 +165,25 @@ func initForgingMetrics(
 		prometheus.GaugeOpts{
 			Name: "dingo_forge_tip_gap_slots",
 			Help: "latest observed tip gap in slots",
+		},
+	)
+	m.leiosEbForged = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_metrics_leios_forge_eb_forged_total",
+			Help: "endorser blocks successfully forged and broadcast",
+		},
+	)
+	m.leiosEbSkipped = factory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dingo_metrics_leios_forge_eb_skipped_total",
+			Help: "endorser block production attempts skipped, by reason",
+		},
+		[]string{"reason"},
+	)
+	m.leiosEbFailed = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_metrics_leios_forge_eb_failed_total",
+			Help: "endorser block production attempts that returned an error",
 		},
 	)
 

--- a/node_forging.go
+++ b/node_forging.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	"github.com/blinklabs-io/dingo/ledger/leader"
+	"github.com/blinklabs-io/dingo/ledger/leios"
 	"github.com/blinklabs-io/dingo/mempool"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -247,6 +248,18 @@ func (n *Node) initBlockForger(
 	// Create slot clock adapter for the forger
 	slotClock := &slotClockAdapter{ledgerState: n.ledgerState}
 
+	// Wire Leios EB forging when the pipeline manager is available
+	// (i.e. Dijkstra era is enabled). Relay nodes and pre-Dijkstra
+	// block producers leave these nil and skip EB production.
+	var leiosChecker forging.LeiosProduceChecker
+	var leiosEBCaster forging.EndorserBlockBroadcaster
+	var leiosMempool forging.MempoolProvider
+	if n.leiosPipelineManager != nil && n.ouroboros != nil {
+		leiosChecker = &leiosPipelineAdapter{mgr: n.leiosPipelineManager}
+		leiosEBCaster = n.ouroboros
+		leiosMempool = mempoolAdapter
+	}
+
 	// Create the block forger with the real leader election
 	forger, err := forging.NewBlockForger(forging.ForgerConfig{
 		Mode:                        forging.ModeProduction,
@@ -260,6 +273,9 @@ func (n *Node) initBlockForger(
 		ForgeSyncToleranceSlots:     n.config.forgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: n.config.forgeStaleGapThresholdSlots,
 		PromRegistry:                n.config.promRegistry,
+		LeiosProduceChecker:         leiosChecker,
+		LeiosEBBroadcaster:          leiosEBCaster,
+		LeiosMempool:                leiosMempool,
 	})
 	if err != nil {
 		// Stop election to prevent goroutine leak
@@ -496,6 +512,23 @@ func (a *slotClockAdapter) NextSlotTime() (time.Time, error) {
 
 func (a *slotClockAdapter) UpstreamTipSlot() uint64 {
 	return a.ledgerState.UpstreamTipSlot()
+}
+
+// leiosPipelineAdapter adapts leios.PipelineManager to
+// forging.LeiosProduceChecker. It translates the ProduceDecision return
+// value into the (bool, string, error) form the forge loop expects.
+type leiosPipelineAdapter struct {
+	mgr *leios.PipelineManager
+}
+
+func (a *leiosPipelineAdapter) MayProduceEndorserBlock(
+	slot uint64,
+) (bool, string, error) {
+	dec, err := a.mgr.MayProduceEndorserBlock(slot)
+	if err != nil {
+		return false, "", err
+	}
+	return dec.Allowed, dec.Reason, nil
 }
 
 // epochNonceAdapter adapts ledger.LedgerState to forging.EpochNonceProvider.

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -108,6 +108,18 @@ func (l *leiosForgedEBLog) removeConn(connKey string) {
 	l.mu.Unlock()
 }
 
+// registerConn pre-registers connKey at the current tail so that EBs
+// appended between connection open and the peer's first RequestNext are
+// not pruned before the cursor is established. It is a no-op when connKey
+// is already registered (e.g. on reconnect within the same session).
+func (l *leiosForgedEBLog) registerConn(connKey string) {
+	l.mu.Lock()
+	if _, exists := l.cursors[connKey]; !exists {
+		l.cursors[connKey] = l.base + len(l.items)
+	}
+	l.mu.Unlock()
+}
+
 // pruneLocked drops head entries whose logical index falls below every
 // registered connection's cursor (i.e. all connections have advanced past
 // them, whether by consuming the entry or by registering after it). When
@@ -327,6 +339,15 @@ func (o *Ouroboros) leiosnotifyServerRequestNext(
 	}
 	connKey := leiosConnectionIdString(ctx.ConnectionId)
 	done := ctx.Server.DoneChan()
+
+	// If the connection is already closing, return without touching the
+	// cursor map. This prevents re-registering a stale cursor after
+	// removeConn has already run (which would block future log pruning).
+	select {
+	case <-done:
+		return nil, nil
+	default:
+	}
 
 	for {
 		entry, wakeCh := o.leiosEBLog.next(connKey)

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -37,39 +37,102 @@ type leiosForgedEBEntry struct {
 	point ocommon.Point
 }
 
-// leiosForgedEBLog is an append-only log of locally-forged EBs.
-// Each per-connection RequestNext goroutine holds a cursor (index) into
-// the log; when the log grows past the cursor the goroutine wakes up and
-// serves the next entry. The wake channel is closed and replaced on every
-// append so all blocked callers unblock at once.
+// leiosForgedEBLog is an append-only log of locally-forged EBs with
+// per-connection cursors owned by the log itself.
+//
+// Head entries are pruned whenever every registered connection's cursor
+// has advanced past them, so memory scales with the largest per-connection
+// backlog rather than total uptime. When no connections are registered the
+// log is always empty. A new connection registers at the current tail and
+// does not receive EBs forged before it connected. Connections are
+// removed via removeConn, which triggers an immediate prune.
+//
+// The wake channel is closed and replaced on every append so all server
+// goroutines waiting for new entries unblock at once.
 type leiosForgedEBLog struct {
-	mu     sync.Mutex
-	items  []leiosForgedEBEntry
-	wakeCh chan struct{}
+	mu      sync.Mutex
+	items   []leiosForgedEBEntry
+	base    int            // logical index of items[0]
+	cursors map[string]int // connKey → next logical index to serve
+	wakeCh  chan struct{}
 }
 
 func newLeiosForgedEBLog() *leiosForgedEBLog {
-	return &leiosForgedEBLog{wakeCh: make(chan struct{})}
+	return &leiosForgedEBLog{
+		cursors: make(map[string]int),
+		wakeCh:  make(chan struct{}),
+	}
 }
 
-// append adds an entry and wakes all blocked callers.
+// append adds an entry, prunes head entries that all registered connections
+// have advanced past (or all entries when none are registered), and signals
+// all server goroutines waiting for new entries to wake and retry.
 func (l *leiosForgedEBLog) append(entry leiosForgedEBEntry) {
 	l.mu.Lock()
 	l.items = append(l.items, entry)
+	l.pruneLocked()
 	wake := l.wakeCh
 	l.wakeCh = make(chan struct{})
 	l.mu.Unlock()
 	close(wake)
 }
 
-// since returns the entries starting at cursor and the current wake channel.
-func (l *leiosForgedEBLog) since(cursor int) ([]leiosForgedEBEntry, chan struct{}) {
+// next returns the next unserved entry for connKey and the current wake
+// channel. If no entry is available it returns (nil, wakeCh); the caller
+// should wait on wakeCh and retry. A connKey that has never called next
+// is registered at the current tail so it does not receive stale EBs.
+func (l *leiosForgedEBLog) next(connKey string) (*leiosForgedEBEntry, chan struct{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if cursor < len(l.items) {
-		return l.items[cursor:], l.wakeCh
+	cursor, exists := l.cursors[connKey]
+	if !exists {
+		// New connection: start at the current tail.
+		cursor = l.base + len(l.items)
+		l.cursors[connKey] = cursor
+	}
+	idx := cursor - l.base
+	if idx < len(l.items) {
+		entry := l.items[idx]
+		l.cursors[connKey] = cursor + 1
+		l.pruneLocked()
+		return &entry, l.wakeCh
 	}
 	return nil, l.wakeCh
+}
+
+// removeConn unregisters a connection cursor and prunes newly freed entries.
+func (l *leiosForgedEBLog) removeConn(connKey string) {
+	l.mu.Lock()
+	delete(l.cursors, connKey)
+	l.pruneLocked()
+	l.mu.Unlock()
+}
+
+// pruneLocked drops head entries whose logical index falls below every
+// registered connection's cursor (i.e. all connections have advanced past
+// them, whether by consuming the entry or by registering after it). When
+// no connections are registered the entire log is pruned. Callers must
+// hold l.mu.
+func (l *leiosForgedEBLog) pruneLocked() {
+	if len(l.items) == 0 {
+		return
+	}
+	// Start at the tail: if no cursors constrain it, prune the full log.
+	minCursor := l.base + len(l.items)
+	for _, c := range l.cursors {
+		if c < minCursor {
+			minCursor = c
+		}
+	}
+	prunable := minCursor - l.base
+	if prunable <= 0 {
+		return
+	}
+	// Zero pruned slots so the GC can reclaim the point.Hash []byte
+	// backing arrays before the backing slice is eventually reallocated.
+	clear(l.items[:prunable])
+	l.items = l.items[prunable:]
+	l.base += prunable
 }
 
 // BroadcastEndorserBlock stores a locally-forged EB and notifies waiting
@@ -259,24 +322,15 @@ func (o *Ouroboros) fetchCachedLeiosEndorserBlockTxs(
 func (o *Ouroboros) leiosnotifyServerRequestNext(
 	ctx oleiosnotify.CallbackContext,
 ) (protocol.Message, error) {
-	connKey := leiosConnectionIdString(ctx.ConnectionId)
-
-	o.leiosMu.Lock()
-	cursor := o.leiosNotifyCursors[connKey]
-	o.leiosMu.Unlock()
-
-	var done <-chan struct{}
-	if ctx.Server != nil {
-		done = ctx.Server.DoneChan()
+	if ctx.Server == nil {
+		return nil, nil
 	}
+	connKey := leiosConnectionIdString(ctx.ConnectionId)
+	done := ctx.Server.DoneChan()
 
 	for {
-		entries, wakeCh := o.leiosEBLog.since(cursor)
-		if len(entries) > 0 {
-			entry := entries[0]
-			o.leiosMu.Lock()
-			o.leiosNotifyCursors[connKey] = cursor + 1
-			o.leiosMu.Unlock()
+		entry, wakeCh := o.leiosEBLog.next(connKey)
+		if entry != nil {
 			return &oleiosnotify.MsgBlockOffer{Point: entry.point}, nil
 		}
 		select {

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -120,11 +120,19 @@ func (l *leiosForgedEBLog) registerConn(connKey string) {
 	l.mu.Unlock()
 }
 
+// leiosEBLogMaxEntries is the maximum number of forged-EB entries the log
+// retains. When the log grows beyond this limit, the oldest entries are
+// evicted and any lagging cursors are advanced to the new base. This
+// bounds memory even when a pre-registered or slow peer never calls next.
+const leiosEBLogMaxEntries = 64
+
 // pruneLocked drops head entries whose logical index falls below every
 // registered connection's cursor (i.e. all connections have advanced past
 // them, whether by consuming the entry or by registering after it). When
-// no connections are registered the entire log is pruned. Callers must
-// hold l.mu.
+// no connections are registered the entire log is pruned. If the log still
+// exceeds leiosEBLogMaxEntries after cursor-based pruning, the oldest
+// entries are evicted and lagging cursors are advanced to the new base.
+// Callers must hold l.mu.
 func (l *leiosForgedEBLog) pruneLocked() {
 	if len(l.items) == 0 {
 		return
@@ -137,6 +145,19 @@ func (l *leiosForgedEBLog) pruneLocked() {
 		}
 	}
 	prunable := minCursor - l.base
+	// Size cap: if the log still exceeds leiosEBLogMaxEntries after
+	// cursor-based pruning, evict the excess from the head. Any cursor
+	// that falls behind the new base (e.g. a pre-registered idle peer)
+	// is advanced to the new base so it does not pin future entries.
+	if capped := len(l.items) - prunable - leiosEBLogMaxEntries; capped > 0 {
+		prunable += capped
+		newBase := l.base + prunable
+		for k, c := range l.cursors {
+			if c < newBase {
+				l.cursors[k] = newBase
+			}
+		}
+	}
 	if prunable <= 0 {
 		return
 	}

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -193,10 +193,16 @@ func (o *Ouroboros) leiosnotifyClientStart(connId ouroboros.ConnectionId) error 
 		)
 	}
 	if conn.LeiosNotify() == nil {
-		// Return silently if LeiosNotify protocol is not supported by peer
+		// Peer does not support LeiosNotify; skip cursor registration.
 		return nil
 	}
+	connKey := leiosConnectionIdString(connId)
+	// Pre-register the server-side cursor now that we know the peer
+	// supports LeiosNotify. This ensures EBs forged between here and
+	// the peer's first RequestNext are not pruned.
+	o.leiosEBLog.registerConn(connKey)
 	if err := conn.LeiosNotify().Client.Sync(); err != nil {
+		o.leiosEBLog.removeConn(connKey)
 		return err
 	}
 	return nil

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -29,6 +30,63 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
 )
+
+// leiosForgedEBEntry holds one locally-forged endorser block ready to
+// be announced to peers via LeiosNotify.
+type leiosForgedEBEntry struct {
+	point ocommon.Point
+}
+
+// leiosForgedEBLog is an append-only log of locally-forged EBs.
+// Each per-connection RequestNext goroutine holds a cursor (index) into
+// the log; when the log grows past the cursor the goroutine wakes up and
+// serves the next entry. The wake channel is closed and replaced on every
+// append so all blocked callers unblock at once.
+type leiosForgedEBLog struct {
+	mu     sync.Mutex
+	items  []leiosForgedEBEntry
+	wakeCh chan struct{}
+}
+
+func newLeiosForgedEBLog() *leiosForgedEBLog {
+	return &leiosForgedEBLog{wakeCh: make(chan struct{})}
+}
+
+// append adds an entry and wakes all blocked callers.
+func (l *leiosForgedEBLog) append(entry leiosForgedEBEntry) {
+	l.mu.Lock()
+	l.items = append(l.items, entry)
+	wake := l.wakeCh
+	l.wakeCh = make(chan struct{})
+	l.mu.Unlock()
+	close(wake)
+}
+
+// since returns the entries starting at cursor and the current wake channel.
+func (l *leiosForgedEBLog) since(cursor int) ([]leiosForgedEBEntry, chan struct{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if cursor < len(l.items) {
+		return l.items[cursor:], l.wakeCh
+	}
+	return nil, l.wakeCh
+}
+
+// BroadcastEndorserBlock stores a locally-forged EB and notifies waiting
+// LeiosNotify server goroutines so they can announce it to peers.
+// It satisfies forging.EndorserBlockBroadcaster.
+func (o *Ouroboros) BroadcastEndorserBlock(
+	slot uint64,
+	hash []byte,
+	data []byte,
+) error {
+	point := ocommon.Point{Slot: slot, Hash: hash}
+	if err := o.storeLeiosEndorserBlock(point, data, nil); err != nil {
+		return fmt.Errorf("store forged endorser block: %w", err)
+	}
+	o.leiosEBLog.append(leiosForgedEBEntry{point: point})
+	return nil
+}
 
 func (o *Ouroboros) leiosnotifyServerConnOpts() []oleiosnotify.LeiosNotifyOptionFunc {
 	return []oleiosnotify.LeiosNotifyOptionFunc{
@@ -201,6 +259,31 @@ func (o *Ouroboros) fetchCachedLeiosEndorserBlockTxs(
 func (o *Ouroboros) leiosnotifyServerRequestNext(
 	ctx oleiosnotify.CallbackContext,
 ) (protocol.Message, error) {
-	// TODO
-	return nil, nil
+	connKey := leiosConnectionIdString(ctx.ConnectionId)
+
+	o.leiosMu.Lock()
+	cursor := o.leiosNotifyCursors[connKey]
+	o.leiosMu.Unlock()
+
+	var done <-chan struct{}
+	if ctx.Server != nil {
+		done = ctx.Server.DoneChan()
+	}
+
+	for {
+		entries, wakeCh := o.leiosEBLog.since(cursor)
+		if len(entries) > 0 {
+			entry := entries[0]
+			o.leiosMu.Lock()
+			o.leiosNotifyCursors[connKey] = cursor + 1
+			o.leiosMu.Unlock()
+			return &oleiosnotify.MsgBlockOffer{Point: entry.point}, nil
+		}
+		select {
+		case <-wakeCh:
+			// new EB appended — re-check
+		case <-done:
+			return nil, nil
+		}
+	}
 }

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -529,6 +529,9 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	}
 	// Start leiosnotify client
 	if o.config.EnableLeios {
+		// Pre-register cursor so EBs forged before the peer's first
+		// RequestNext are not pruned during the connection setup window.
+		o.leiosEBLog.registerConn(leiosConnectionIdString(connId))
 		if err := o.leiosnotifyClientStart(connId); err != nil {
 			o.config.Logger.Error(
 				"failed to start leiosnotify client",
@@ -661,6 +664,9 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 		}
 	}
 	if o.config.EnableLeios {
+		// Pre-register cursor so EBs forged before the peer's first
+		// RequestNext are not pruned during the connection setup window.
+		o.leiosEBLog.registerConn(leiosConnectionIdString(connId))
 		if err := o.leiosnotifyClientStart(connId); err != nil {
 			o.config.Logger.Warn(
 				"leiosnotify client failed on inbound connection",

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -90,9 +90,8 @@ type Ouroboros struct {
 	leiosEndorserBlocks map[string]*leiosEndorserBlockData
 	leiosMu             sync.RWMutex
 
-	// Locally-forged EB broadcast log and per-connection serve cursors.
-	leiosEBLog        *leiosForgedEBLog
-	leiosNotifyCursors map[string]int
+	// Locally-forged EB broadcast log (cursors are owned by the log).
+	leiosEBLog *leiosForgedEBLog
 }
 
 // chainsyncPeerStats tracks ChainSync performance metrics per peer connection.
@@ -160,7 +159,6 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		chainsyncStats:           make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
 		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
 		leiosEBLog:               newLeiosForgedEBLog(),
-		leiosNotifyCursors:       make(map[string]int),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond
@@ -437,6 +435,9 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	if o.LeiosVotes != nil {
 		o.LeiosVotes.RemoveConnection(leiosConnectionIdString(connId))
 	}
+	// Release the EB log cursor for this connection; frees any log
+	// entries that were only being held for this connection.
+	o.leiosEBLog.removeConn(leiosConnectionIdString(connId))
 }
 
 func (o *Ouroboros) HandlePeerEligibilityChangedEvent(evt event.Event) {

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -529,9 +529,6 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	}
 	// Start leiosnotify client
 	if o.config.EnableLeios {
-		// Pre-register cursor so EBs forged before the peer's first
-		// RequestNext are not pruned during the connection setup window.
-		o.leiosEBLog.registerConn(leiosConnectionIdString(connId))
 		if err := o.leiosnotifyClientStart(connId); err != nil {
 			o.config.Logger.Error(
 				"failed to start leiosnotify client",
@@ -664,9 +661,6 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 		}
 	}
 	if o.config.EnableLeios {
-		// Pre-register cursor so EBs forged before the peer's first
-		// RequestNext are not pruned during the connection setup window.
-		o.leiosEBLog.registerConn(leiosConnectionIdString(connId))
 		if err := o.leiosnotifyClientStart(connId); err != nil {
 			o.config.Logger.Warn(
 				"leiosnotify client failed on inbound connection",

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -89,6 +89,10 @@ type Ouroboros struct {
 	// package to Leios prototype protocols.
 	leiosEndorserBlocks map[string]*leiosEndorserBlockData
 	leiosMu             sync.RWMutex
+
+	// Locally-forged EB broadcast log and per-connection serve cursors.
+	leiosEBLog        *leiosForgedEBLog
+	leiosNotifyCursors map[string]int
 }
 
 // chainsyncPeerStats tracks ChainSync performance metrics per peer connection.
@@ -155,6 +159,8 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		blockfetchNoBlocksCounts: make(map[ouroboros.ConnectionId]blockfetchNoBlocksState),
 		chainsyncStats:           make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
 		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
+		leiosEBLog:               newLeiosForgedEBLog(),
+		leiosNotifyCursors:       make(map[string]int),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond


### PR DESCRIPTION
Closes #1862 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates Leios Endorser Block (EB) forging into the Praos slot leader so producers build and broadcast an EB before the regular block when Dijkstra/Leios is enabled. Improves EB diffusion without impacting regular block forging.

- **New Features**
  - Added `LeiosProduceChecker`, `EndorserBlockBroadcaster`, and `MempoolProvider` seams in `ledger/forging`; EB is built from mempool tx refs (filters invalid hashes/sizes; skips on empty or no valid refs), CBOR-encoded, hashed, and broadcast; failures are non-fatal and labeled.
  - Node wiring enables EB forging only when the Leios pipeline is present; `node_forging` adapts `leios.PipelineManager`; `ouroboros/leiosnotify` implements `BroadcastEndorserBlock`, an in-memory EB log with per-connection cursors and a wake channel, and a `RequestNext` loop that offers `MsgBlockOffer`s.
  - Prometheus: `dingo_metrics_leios_forge_eb_forged_total`, `dingo_metrics_leios_forge_eb_skipped_total{reason}`, `dingo_metrics_leios_forge_eb_failed_total`.

- **Bug Fixes**
  - EB log now prunes head entries once all connections advance past them, caps retention to 64 entries and advances lagging cursors to the new base, zeroes pruned slots to free memory, removes cursors on peer close or failed sync, pre-registers cursors only when the peer supports LeiosNotify, and avoids re-registering while closing to prevent stale offers and unbounded growth.

<sup>Written for commit d37b2bcfa041dc097169dcb071fab714c5800848. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Leios endorser-block forging support integrated into the production forging loop
  * Endorser blocks are now produced and broadcast before regular blocks during each production slot
  * Endorser-block production failures are logged as warnings but do not prevent subsequent regular block production
  * Added metrics for tracking endorser-block forging outcomes (successful, skipped, and failed attempts)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->