### PR TITLE
fix(peergov): chainsync stall after disconnect

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1023,6 +1023,18 @@ The `PeerGovernor` (`peergov/peergov.go`) manages peer selection and topology:
     -------------------------------------------------
 ```
 
+Connection recovery is both edge-triggered and level-triggered. The
+connection-closed event spawns a one-shot reconnect goroutine for the affected
+peer, and each reconcile cycle additionally redials known peers that have no
+connection and no active reconnect goroutine: topology local/public roots
+always (and bootstrap peers while bootstrap promotion is still allowed),
+gossip/ledger peers only when the node has no chain-selection-eligible
+upstream connection left, capped per cycle. This guarantees the node converges
+back to connected even when a close event cannot be attributed to its peer or
+a dial loop exited early. Gossip churn never demotes the peer holding the last
+eligible upstream connection, so routine churn cannot leave the node without a
+chainsync source.
+
 Topology configuration is loaded from an explicit topology file when provided,
 otherwise from the embedded `network/topology.json` for built-in networks,
 falling back to the legacy network bootstrap-peer list only when no embedded

--- a/peergov/churn.go
+++ b/peergov/churn.go
@@ -63,11 +63,28 @@ func (p *PeerGovernor) gossipChurn() {
 
 	// Demote the lowest-scoring peers
 	demoted := 0
+	eligibleUpstreams := p.countEligibleUpstreamsLocked()
 	for i := 0; i < len(hotNonRoot) && demoted < churnCount; i++ {
 		peer := hotNonRoot[i]
 		targetState, canDemote := p.demotionTarget(peer.Source)
 		if !canDemote {
 			continue // Never demote this peer (e.g., local roots)
+		}
+		demotionRemovesEligibleUpstream := targetState == PeerStateCold &&
+			chainSelectionState(
+				p.bootstrapExited,
+				peer.Source,
+				peer.Connection,
+			).eligible
+		// Never close the node's last eligible upstream connection.
+		// Demoting it to cold would leave the node with no chainsync
+		// source until the reconcile redial path recovers it.
+		if demotionRemovesEligibleUpstream && eligibleUpstreams <= 1 {
+			p.config.Logger.Info(
+				"gossip churn: skipping demotion of last eligible upstream peer",
+				"address", peer.Address,
+			)
+			continue
 		}
 		oldSource := peer.Source
 		oldConn := clonePeerConnection(peer.Connection)
@@ -97,6 +114,9 @@ func (p *PeerGovernor) gossipChurn() {
 			oldConn,
 			peer,
 		)
+		if demotionRemovesEligibleUpstream {
+			eligibleUpstreams--
+		}
 
 		demoted++
 		p.config.Logger.Debug(

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -146,8 +146,19 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		)
 		return
 	}
-	currentPeer.Reconnecting = true
-	reconnectPeer := currentPeer
+	// Capture the stop channel while holding the lock. Stop() nils
+	// p.stopCh after closing it, so reading the field again without
+	// the lock races with shutdown; the captured copy still receives
+	// the close signal.
+	stopCh := p.stopCh
+	if stopCh == nil {
+		p.mu.Unlock()
+		p.config.Logger.Debug(
+			"outbound: peer governor stopped, skipping connection attempts",
+			"address", peer.Address,
+		)
+		return
+	}
 	// Read any pre-existing reconnect delay set by
 	// handleConnectionClosedEvent for short-lived connections.
 	preDelay := currentPeer.ReconnectDelay
@@ -155,6 +166,8 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 	// loop's backoff starts cleanly from the intended rung
 	// and does not double-apply the pre-delay.
 	currentPeer.ReconnectDelay = 0
+	currentPeer.Reconnecting = true
+	reconnectPeer := currentPeer
 	p.mu.Unlock()
 	// Ensure Reconnecting is cleared when this goroutine exits
 	defer func() {
@@ -174,7 +187,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			),
 		)
 		select {
-		case <-p.stopCh:
+		case <-stopCh:
 			return
 		case <-time.After(preDelay):
 		}
@@ -182,7 +195,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 	for {
 		// Check if PeerGovernor is stopping
 		select {
-		case <-p.stopCh:
+		case <-stopCh:
 			p.config.Logger.Debug(
 				"outbound: stopping connection attempts due to shutdown",
 				"address", peer.Address,
@@ -251,7 +264,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 				"address", peer.Address,
 			)
 			select {
-			case <-p.stopCh:
+			case <-stopCh:
 				return
 			case <-time.After(inboundCheckDelay):
 			}
@@ -314,7 +327,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		}
 		if isConnectionCancellationError(err) {
 			select {
-			case <-p.stopCh:
+			case <-stopCh:
 				p.config.Logger.Debug(
 					"outbound: connection attempt canceled during shutdown",
 					"address", peer.Address,
@@ -357,7 +370,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 				"delay", reconnectDelay,
 			)
 			select {
-			case <-p.stopCh:
+			case <-stopCh:
 				return
 			case <-time.After(reconnectDelay):
 			}
@@ -449,7 +462,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		}
 		p.mu.Unlock()
 		select {
-		case <-p.stopCh:
+		case <-stopCh:
 			p.config.Logger.Debug(
 				"outbound: stopping connection attempts due to shutdown",
 				"address", peer.Address,
@@ -467,7 +480,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		)
 		// Use select with stopCh for interruptible sleep
 		select {
-		case <-p.stopCh:
+		case <-stopCh:
 			p.config.Logger.Debug(
 				"outbound: stopping connection attempts due to shutdown",
 				"address", peer.Address,

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -456,6 +456,38 @@ func TestCreateOutboundConnection_SuppressesRetryWhenReusableInboundSatisfiesVal
 	}
 }
 
+func TestCreateOutboundConnection_ReturnsWhenGovernorStopped(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	peer := &Peer{
+		Address:           "127.0.0.1:1",
+		NormalizedAddress: "127.0.0.1:1",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateCold,
+		ReconnectDelay:    time.Nanosecond,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	// A nil stopCh means the governor has not started or has already stopped.
+	pg.stopCh = nil
+	pg.mu.Unlock()
+
+	pg.createOutboundConnection(peer)
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	if peer.Reconnecting {
+		t.Fatal("reconnecting flag should remain clear when governor is stopped")
+	}
+	if peer.ReconnectCount != 0 {
+		t.Fatalf("reconnect count changed unexpectedly: %d", peer.ReconnectCount)
+	}
+	if peer.ReconnectDelay != time.Nanosecond {
+		t.Fatalf("reconnect delay changed unexpectedly: %s", peer.ReconnectDelay)
+	}
+}
+
 func outboundTestConnId() ouroboros.ConnectionId {
 	return ouroboros.ConnectionId{
 		LocalAddr: &net.TCPAddr{

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -5872,7 +5872,9 @@ func TestPeerGovernor_EventsPublished(t *testing.T) {
 		MinScoreThreshold:   0.0,
 	})
 
-	// Add a hot gossip peer to be churned
+	// Add a hot gossip peer to be churned, plus a second higher-scoring
+	// upstream so the churned peer is not the node's last eligible
+	// upstream (churn refuses to close the last one).
 	pg.mu.Lock()
 	pg.peers = []*Peer{
 		{
@@ -5881,6 +5883,13 @@ func TestPeerGovernor_EventsPublished(t *testing.T) {
 			State:            PeerStateHot,
 			Connection:       &PeerConnection{IsClient: true},
 			PerformanceScore: 0.5,
+		},
+		{
+			Address:          "192.168.1.2:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateHot,
+			Connection:       &PeerConnection{IsClient: true},
+			PerformanceScore: 0.9,
 		},
 	}
 	pg.mu.Unlock()

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -445,6 +445,11 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 		"ledger_quota", p.config.ActivePeersLedgerQuota,
 	)
 
+	// Redial known peers that lost their connection. The close-event
+	// reconnect is one-shot; this is the level-triggered fallback that
+	// keeps the node converging back to connected.
+	p.redialDisconnectedPeersLocked()
+
 	// Collect eligible peers for peer sharing
 	// Copy peer data while holding lock to avoid race conditions
 	var eligiblePeersCopy []Peer

--- a/peergov/recovery.go
+++ b/peergov/recovery.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+// Connection recovery used to be edge-triggered only: the single
+// reconnect goroutine spawned by handleConnectionClosedEvent was the
+// only thing that ever redialed a known peer. Any path that missed
+// that one chance (a close event that no longer matches the peer, an
+// intentional churn close, a dial loop that exited because inbound
+// connections satisfied valency) left the peer cold forever, and a
+// node whose last upstream hit one of those paths silently stopped
+// following the chain. The reconcile loop now level-triggers recovery
+// through redialDisconnectedPeersLocked.
+
+// maxEmergencyRedialsPerReconcile bounds how many gossip/ledger peers a
+// single reconcile cycle will redial when the node has no eligible
+// upstream connection left.
+const maxEmergencyRedialsPerReconcile = 3
+
+// countEligibleUpstreamsLocked returns the number of peers whose current
+// connection can feed chainsync ingress. Must be called with p.mu held.
+func (p *PeerGovernor) countEligibleUpstreamsLocked() int {
+	count := 0
+	for _, peer := range p.peers {
+		if peer == nil {
+			continue
+		}
+		if chainSelectionState(
+			p.bootstrapExited,
+			peer.Source,
+			peer.Connection,
+		).eligible {
+			count++
+		}
+	}
+	return count
+}
+
+// redialCandidatesLocked returns known peers that should get a new
+// outbound connection attempt. Topology peers are always redialed:
+// they are operator-configured and must converge back to connected.
+// Gossip/ledger peers are only redialed when the node has no eligible
+// upstream connection at all, capped per cycle, so normal churn still
+// retires them as designed. Must be called with p.mu held.
+func (p *PeerGovernor) redialCandidatesLocked() []*Peer {
+	var candidates []*Peer
+	emergencyBudget := 0
+	if p.countEligibleUpstreamsLocked() == 0 {
+		emergencyBudget = maxEmergencyRedialsPerReconcile
+	}
+	for _, peer := range p.peers {
+		if peer == nil || peer.Connection != nil || peer.Reconnecting {
+			continue
+		}
+		if p.isPeerDeniedLocked(peer) {
+			continue
+		}
+		switch peer.Source {
+		case PeerSourceTopologyLocalRoot, PeerSourceTopologyPublicRoot:
+			if p.inboundSatisfiesTopologyValencyLocked(peer) {
+				continue
+			}
+		case PeerSourceTopologyBootstrapPeer:
+			if !p.canPromoteBootstrapPeer() {
+				continue
+			}
+		case PeerSourceP2PGossip, PeerSourceP2PLedger:
+			if emergencyBudget == 0 {
+				continue
+			}
+			emergencyBudget--
+		default:
+			continue
+		}
+		candidates = append(candidates, peer)
+	}
+	return candidates
+}
+
+// redialDisconnectedPeersLocked spawns outbound connection attempts for
+// redialCandidatesLocked. Must be called with p.mu held; the spawned
+// goroutines acquire the lock themselves and are deduplicated by the
+// per-peer Reconnecting flag inside createOutboundConnection.
+func (p *PeerGovernor) redialDisconnectedPeersLocked() {
+	if p.config.DisableOutbound ||
+		p.config.ConnManager == nil ||
+		p.stopCh == nil {
+		return
+	}
+	for _, peer := range p.redialCandidatesLocked() {
+		p.config.Logger.Info(
+			"redialing disconnected peer",
+			"address", peer.Address,
+			"source", peer.Source.String(),
+		)
+		go p.createOutboundConnection(peer)
+	}
+}

--- a/peergov/recovery_test.go
+++ b/peergov/recovery_test.go
@@ -1,0 +1,455 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for the silent chain-stall wedge: connection recovery
+// was edge-triggered only (one-shot reconnect on the close event), so a
+// node that lost its last upstream connection could never get it back.
+
+func TestPeerGovernor_GossipChurn_SkipsLastEligibleUpstream(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		GossipChurnPercent: 1.0,
+		MinScoreThreshold:  0.3,
+	})
+	pg.peers = []*Peer{
+		{
+			Address:          "gossip1:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateHot,
+			PerformanceScore: 0.5,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.gossipChurn()
+
+	assert.Equal(
+		t,
+		PeerStateHot,
+		pg.peers[0].State,
+		"last eligible upstream must not be churned",
+	)
+	assert.NotNil(
+		t,
+		pg.peers[0].Connection,
+		"last eligible upstream connection must stay open",
+	)
+}
+
+func TestPeerGovernor_GossipChurn_KeepsOneUpstreamWhenChurningAll(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		GossipChurnPercent: 1.0,
+		MinScoreThreshold:  0.3,
+	})
+	pg.peers = []*Peer{
+		{
+			Address:          "gossip1:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateHot,
+			PerformanceScore: 0.2,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+		{
+			Address:          "gossip2:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateHot,
+			PerformanceScore: 0.9,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.gossipChurn()
+
+	// Lowest-scoring peer churns first; the survivor must keep its
+	// connection even though the churn percentage requested both.
+	assert.Equal(t, PeerStateCold, pg.peers[0].State)
+	assert.Nil(t, pg.peers[0].Connection)
+	assert.Equal(t, PeerStateHot, pg.peers[1].State)
+	assert.NotNil(
+		t,
+		pg.peers[1].Connection,
+		"churn must never close the last remaining upstream connection",
+	)
+}
+
+func TestPeerGovernor_GossipChurn_ChurnsGossipWhenTopologyUpstreamExists(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		GossipChurnPercent: 1.0,
+		MinScoreThreshold:  0.3,
+	})
+	pg.peers = []*Peer{
+		{
+			Address:          "gossip1:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateHot,
+			PerformanceScore: 0.5,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+		{
+			Address:          "root1:3001",
+			Source:           PeerSourceTopologyLocalRoot,
+			State:            PeerStateHot,
+			PerformanceScore: 0.9,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.gossipChurn()
+
+	assert.Equal(
+		t,
+		PeerStateCold,
+		pg.peers[0].State,
+		"gossip peer should still churn while another upstream exists",
+	)
+	assert.Equal(t, PeerStateHot, pg.peers[1].State)
+	assert.NotNil(t, pg.peers[1].Connection)
+}
+
+func TestPeerGovernor_RedialCandidates_TopologyPeersWithoutConnection(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+	pg.peers = []*Peer{
+		{
+			Address:           "root1:3001",
+			NormalizedAddress: "root1:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateCold,
+		},
+		{
+			Address:           "public1:3001",
+			NormalizedAddress: "public1:3001",
+			Source:            PeerSourceTopologyPublicRoot,
+			State:             PeerStateCold,
+		},
+		{
+			Address:           "root2:3001",
+			NormalizedAddress: "root2:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateHot,
+			Connection:        &PeerConnection{IsClient: true},
+		},
+	}
+
+	pg.mu.Lock()
+	candidates := pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+
+	addrs := make([]string, 0, len(candidates))
+	for _, peer := range candidates {
+		addrs = append(addrs, peer.Address)
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{"root1:3001", "public1:3001"},
+		addrs,
+		"disconnected topology peers must be redial candidates; connected ones must not",
+	)
+}
+
+func TestPeerGovernor_RedialCandidates_SkipsDeniedAndReconnecting(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+	pg.peers = []*Peer{
+		{
+			Address:           "denied:3001",
+			NormalizedAddress: "denied:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateCold,
+		},
+		{
+			Address:           "reconnecting:3001",
+			NormalizedAddress: "reconnecting:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateCold,
+			Reconnecting:      true,
+		},
+	}
+	pg.denyList["denied:3001"] = time.Now().Add(time.Hour)
+
+	pg.mu.Lock()
+	candidates := pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+
+	assert.Empty(
+		t,
+		candidates,
+		"denied peers and peers with an active reconnect goroutine must not be redialed",
+	)
+}
+
+func TestPeerGovernor_RedialCandidates_BootstrapGatedOnBootstrapExit(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+	pg.peers = []*Peer{
+		{
+			Address:           "bootstrap1:3001",
+			NormalizedAddress: "bootstrap1:3001",
+			Source:            PeerSourceTopologyBootstrapPeer,
+			State:             PeerStateCold,
+		},
+	}
+
+	pg.mu.Lock()
+	candidates := pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+	require.Len(
+		t,
+		candidates,
+		1,
+		"bootstrap peers should be redialed while bootstrap is active",
+	)
+
+	pg.mu.Lock()
+	pg.bootstrapExited = true
+	candidates = pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+	assert.Empty(
+		t,
+		candidates,
+		"bootstrap peers must not be redialed after bootstrap exit",
+	)
+}
+
+func TestPeerGovernor_RedialCandidates_EmergencyOnlyWhenNoEligibleUpstream(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+	pg.peers = []*Peer{
+		{
+			Address:           "gossip1:3001",
+			NormalizedAddress: "gossip1:3001",
+			Source:            PeerSourceP2PGossip,
+			State:             PeerStateCold,
+		},
+		{
+			Address:           "ledger1:3001",
+			NormalizedAddress: "ledger1:3001",
+			Source:            PeerSourceP2PLedger,
+			State:             PeerStateCold,
+		},
+	}
+
+	// No eligible upstream at all: gossip/ledger peers become
+	// emergency redial candidates.
+	pg.mu.Lock()
+	candidates := pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+	addrs := make([]string, 0, len(candidates))
+	for _, peer := range candidates {
+		addrs = append(addrs, peer.Address)
+	}
+	assert.ElementsMatch(
+		t,
+		[]string{"gossip1:3001", "ledger1:3001"},
+		addrs,
+		"gossip/ledger peers must be redialed when the node has no upstream left",
+	)
+
+	// With a healthy upstream present, churned gossip/ledger peers
+	// must stay cold so churn keeps working as designed.
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "root1:3001",
+		NormalizedAddress: "root1:3001",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateHot,
+		Connection:        &PeerConnection{IsClient: true},
+	})
+	candidates = pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+	assert.Empty(
+		t,
+		candidates,
+		"gossip/ledger peers must not be redialed while an eligible upstream exists",
+	)
+}
+
+func TestPeerGovernor_RedialCandidates_EmergencyCapped(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+	for _, addr := range []string{
+		"gossip1:3001",
+		"gossip2:3001",
+		"gossip3:3001",
+		"gossip4:3001",
+		"gossip5:3001",
+	} {
+		pg.peers = append(pg.peers, &Peer{
+			Address:           addr,
+			NormalizedAddress: addr,
+			Source:            PeerSourceP2PGossip,
+			State:             PeerStateCold,
+		})
+	}
+
+	pg.mu.Lock()
+	candidates := pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+
+	assert.Len(
+		t,
+		candidates,
+		maxEmergencyRedialsPerReconcile,
+		"emergency redials must be capped per reconcile cycle",
+	)
+}
+
+func TestPeerGovernor_RedialCandidates_SkipsValencySatisfiedTopologyPeer(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+	pg.peers = []*Peer{
+		{
+			Address:           "root1:3001",
+			NormalizedAddress: "root1:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateCold,
+			GroupID:           "g1",
+			Valency:           1,
+		},
+		{
+			// Same topology group already satisfied by a reusable
+			// inbound duplex connection.
+			Address:           "root1-inbound:3001",
+			NormalizedAddress: "root1-inbound:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateHot,
+			GroupID:           "g1",
+			Valency:           1,
+			Connection:        &PeerConnection{IsClient: true},
+			InboundDuplex:     true,
+		},
+	}
+
+	pg.mu.Lock()
+	candidates := pg.redialCandidatesLocked()
+	pg.mu.Unlock()
+
+	assert.Empty(
+		t,
+		candidates,
+		"topology peers whose group valency is satisfied by inbound duplex must not be redialed",
+	)
+}
+
+func TestPeerGovernor_Reconcile_RedialsDisconnectedTopologyPeer(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	connManager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{Logger: logger},
+	)
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:      logger,
+		EventBus:    newMockEventBus(),
+		ConnManager: connManager,
+	})
+	pg.mu.Lock()
+	pg.ctx = t.Context()
+	pg.stopCh = make(chan struct{})
+	pg.peers = []*Peer{
+		{
+			// Nothing listens here; the dial fails fast and the
+			// reconnect loop records the attempt.
+			Address:           "127.0.0.1:1",
+			NormalizedAddress: "127.0.0.1:1",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateCold,
+		},
+	}
+	pg.mu.Unlock()
+	t.Cleanup(pg.Stop)
+
+	pg.reconcile(t.Context())
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		return pg.peers[0].Reconnecting || pg.peers[0].ReconnectCount > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"reconcile must spawn an outbound connection attempt for a disconnected topology peer")
+}
+
+func TestPeerGovernor_Reconcile_RedialsGossipPeerWhenNoUpstream(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	connManager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{Logger: logger},
+	)
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:      logger,
+		EventBus:    newMockEventBus(),
+		ConnManager: connManager,
+	})
+	pg.mu.Lock()
+	pg.ctx = t.Context()
+	pg.stopCh = make(chan struct{})
+	pg.peers = []*Peer{
+		{
+			Address:           "127.0.0.1:1",
+			NormalizedAddress: "127.0.0.1:1",
+			Source:            PeerSourceP2PGossip,
+			State:             PeerStateCold,
+		},
+	}
+	pg.mu.Unlock()
+	t.Cleanup(pg.Stop)
+
+	pg.reconcile(t.Context())
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		return pg.peers[0].Reconnecting || pg.peers[0].ReconnectCount > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"reconcile must redial a known gossip peer when the node has no upstream left")
+}


### PR DESCRIPTION
Closes #2541 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents chainsync stalls after disconnects by making `peergov` recovery both edge- and level-triggered, and by protecting the last eligible upstream from churn. Also hardens outbound shutdown handling to avoid races and no-op retries when stopped.

- **Bug Fixes**
  - Reconcile redials disconnected peers: topology peers always (honors inbound valency and bootstrap gating); gossip/ledger only when no eligible upstream remains (max 3 per cycle).
  - Gossip churn never demotes the last chainsync-eligible upstream connection.
  - Outbound reconnect loop captures a stable stop channel and returns early when nil, making sleeps interruptible and preventing work after shutdown.

<sup>Written for commit 7d5e5d83ed6436fc378c260e0aa00ce45c2bfe3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic recovery mechanism for reconnecting to peers when connections are lost.
  * Improved peer selection to prevent network isolation by maintaining at least one active upstream connection.

* **Bug Fixes**
  * Fixed peer demotion logic to prevent losing the last eligible upstream connection during network churn.
  * Enhanced shutdown robustness to prevent race conditions during peer connection cleanup.

* **Tests**
  * Added comprehensive test coverage for connection recovery and peer selection behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->