### PR TITLE
feat: offline metadata fetching

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -587,6 +587,7 @@ type Node struct {
     historyExpiry  *historyexpiry.Pruner          // Local block history expiry
     blockfrostAPI  *blockfrost.Blockfrost         // Blockfrost REST API
     meshAPI        *mesh.Server                   // Mesh (Rosetta) API
+    offchainMetadataFetcher *offchainmetadata.Fetcher // Off-chain metadata
     ouroboros      *ouroboros.Ouroboros            // Protocol handlers
     blockForger    *forging.BlockForger           // Block production
     leaderElection *leader.Election               // Slot leader checks
@@ -620,8 +621,9 @@ When `Node.Run()` is called, components are initialized in this order:
 18. Bark C2/archive server (if port configured)
 19. Blockfrost API (if API storage mode and port configured)
 20. Mesh API (if API storage mode and port configured)
-21. Block forger + leader election (if block producer mode)
-22. Wait for shutdown signal
+21. Off-chain metadata fetcher (if API storage mode)
+22. Block forger + leader election (if block producer mode)
+23. Wait for shutdown signal
 ```
 
 ### Shutdown Flow
@@ -632,7 +634,8 @@ Graceful shutdown proceeds in phases:
 Phase 1: Stop accepting new work
   Block forger, leader election, chain selector,
   peer governor, snapshot manager, UTxO RPC,
-  Bark C2/archive server, Blockfrost API, Mesh API
+  Bark C2/archive server, Blockfrost API, Mesh API,
+  off-chain metadata fetcher
 
 Phase 2: Drain and close connections
   Mempool, ConnectionManager
@@ -737,6 +740,40 @@ Dingo supports two storage modes, configured via `storageMode`:
 
 - `core` (default): Minimal storage for chain following and block production.
 - `api`: Extended storage with transaction indexes, address lookups, and asset tracking. Required when any client-facing API server (Blockfrost, Mesh, UTxO RPC) is enabled. Bark is a separate Dingo-to-Dingo protocol and is not part of that API surface.
+
+### Off-chain Metadata Fetching
+
+In `storageMode: api`, `node.go` also starts `internal/offchainmetadata.Fetcher`
+as a background worker. The worker asks the metadata store to discover on-chain
+URL/hash pointers from pool registrations, DRep anchors, governance
+proposal/vote anchors, constitutions, and committee resignations. It then fetches
+due rows asynchronously into the `offchain_metadata` table.
+
+Fetched content is never fed back into consensus or ledger validation. The
+on-chain Blake2b-256 hash remains authoritative: fetched bytes are stored as
+usable only when their Blake2b-256 digest matches the ledger-provided hash.
+Failed, unsupported, or oversized fetches remain in the table with retry
+metadata and diagnostic state. HTTP(S) pointers are fetched directly. `ipfs://`
+pointers are translated to the fetcher's configured IPFS gateway URL, which
+defaults to `https://gateway.pinata.cloud/ipfs/`, while the cache key remains
+the original on-chain URL. Operators can override fetch interval, request
+timeout, user agent, IPFS gateway URL, batch size, max response bytes, and
+private-address allowance through the `offchainMetadata` YAML block, matching
+`DINGO_OFFCHAIN_METADATA_*` environment variables, or
+`--offchain-metadata-*` CLI flags.
+If the worker context is canceled while a request is in flight, the worker drops
+that in-memory result instead of recording a failed fetch, so shutdown does not
+advance retry state. Metadata-store discovery, batch claim, and result update
+calls receive the same worker context, and the worker returns before issuing new
+store work after cancellation.
+The default HTTP transport caps response bytes, follows a small redirect budget,
+and refuses localhost, private, link-local, multicast, and other non-public
+targets so arbitrary ledger URLs and gateway targets do not become unrestricted
+node-side network access.
+
+The worker is intentionally composed at the node boundary. Ledger and database
+indexing code persist the URL/hash pointers; APIs read the local cache through
+the metadata store when they need off-chain documents.
 
 ### Archive And History Expiry Topology
 
@@ -1284,6 +1321,8 @@ Key configuration areas:
 - Peer targets and quotas
 - CBOR cache sizing (hot entries, block LRU)
 - Chainsync client limits and stall timeout
+- Off-chain metadata fetcher interval, request timeout, IPFS gateway, batch
+  size, response cap, and private-address policy
 - Block producer credentials (VRF key, KES key, operational certificate)
 - External interface ports (Blockfrost, Mesh, UTxO RPC, Bark)
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -15,7 +15,7 @@ Use the Go APIs when code runs inside Dingo:
 
 - `database.Database` in `database/database.go` owns both stores and exposes `Blob()`, `Metadata()`, `Transaction()`, `BlobTxn()`, `MetadataTxn()`, `StorageMode()`, and `Close()`.
 - `database.Txn` in `database/txn.go` coordinates sibling metadata/blob transactions. Write commits update commit timestamps in both stores, commit the blob transaction first, then commit metadata.
-- `metadata.MetadataStore` in `database/plugin/metadata/store.go` is the SQL-facing interface. It groups ledger state, transactions, UTxO, accounts, pools, stake snapshots, rewards, governance, committee, rollback, sync-state, and backfill methods.
+- `metadata.MetadataStore` in `database/plugin/metadata/store.go` is the SQL-facing interface. It groups ledger state, transactions, UTxO, accounts, pools, stake snapshots, rewards, governance, committee, rollback, sync-state, backfill, and off-chain metadata cache/fetch methods.
 - `blob.BlobStore` in `database/plugin/blob/store.go` is the blob-facing interface. It provides raw `Get`/`Set`/`Delete`/iteration plus block, UTxO, transaction, signed-URL, tombstone, and commit-timestamp methods.
 - `types.Txn`, `types.BlobIterator`, `types.BlockMetadata`, and blob key helpers live in `database/types/`.
 
@@ -51,7 +51,7 @@ flowchart LR
 - Many relations are logical joins rather than explicit foreign keys. Certificate rows have two logical pointers: each specialized certificate table has `certificate_id -> certs.id`, and `certs.certificate_id` is the polymorphic back-pointer to that specialized row chosen by `certs.cert_type`.
 - Live UTxOs have `utxo.deleted_slot = 0`. Governance/committee/constitution soft deletes use nullable `deleted_slot`; `NULL` means active.
 - Certificate history ordering must use `added_slot DESC`, the producing transaction's `block_index DESC`, and `cert_index DESC`. `cert_index` resets per transaction.
-- Storage mode is persisted in `node_settings.storage_mode`. `core` mode stores consensus and ledger state. `api` mode additionally populates address, witness, datum, redeemer, script, and metadata-label indexes. API-only tables are still migrated in `core` mode but may be empty.
+- Storage mode is persisted in `node_settings.storage_mode`. `core` mode stores consensus and ledger state. `api` mode additionally populates address, witness, datum, redeemer, script, metadata-label indexes, and the best-effort `offchain_metadata` cache. API-only tables are still migrated in `core` mode but may be empty.
 
 ## ER Diagrams
 
@@ -231,6 +231,21 @@ erDiagram
 | `committee_quorum` | `id`, `quorum`, `added_slot` | PK `id`; unique `added_slot` | Enacted committee quorum threshold. `quorum` is stored through `types.Rat`. |
 | `auth_committee_hot` | `id`, `cold_credential`, `host_credential`, `certificate_id`, `added_slot` | PK `id`; indexes `cold_credential`, `host_credential`, `certificate_id`, `added_slot` | Committee hot-key authorization certificate. The SQL column is `host_credential` for backward compatibility. |
 | `resign_committee_cold` | `id`, `cold_credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `cold_credential`, `certificate_id`, `added_slot` | Committee cold-key resignation certificate. |
+
+### Off-chain Metadata Cache
+
+| Table | Columns | Keys / indexes | Relationships and notes |
+|---|---|---|---|
+| `offchain_metadata` | `id`, `source_type`, `url`, `hash`, `status`, `content_type`, `content`, `body_hash`, `last_error`, `last_http_status`, `fetch_attempts`, `fetched_at`, `next_fetch_after`, `created_at`, `updated_at` | PK `id`; unique `(source_type, url, hash)`; index `(status, next_fetch_after)` | Best-effort cache for documents referenced by pool metadata URLs and governance anchors. `url` keeps the original on-chain pointer, including HTTP(S) and `ipfs://` URLs; IPFS content is fetched through a gateway. `hash` is the on-chain Blake2b-256 hash. `body_hash` is the Blake2b-256 of the fetched bytes. Only rows with `status = 'fetched'` have hash-verified `content`; failed rows keep retry state and diagnostics. `content_type` is normalized to `application/json`, `application/ld+json`, or `text/plain`; any other response media type is stored as `application/octet-stream` (the header is not covered by the on-chain hash). |
+
+`source_type` values are `pool`, `drep`, `drep_registration`, `drep_update`, `gov_proposal`, `gov_vote`, `constitution`, and `committee_resign`. `status` values are `pending`, `fetched`, and `failed`.
+
+The API-mode off-chain metadata fetcher discovers pointers from `pool_registration.metadata_url`, DRep anchor rows, governance proposal/vote anchors, constitutions, and committee resignations. The cache is not consensus state: rollbacks may leave old cache rows behind, and APIs should join/cache-hit by the current on-chain `(source_type, url, hash)` pointer.
+
+`metadata.MetadataStore` off-chain fetch methods accept a `context.Context`.
+`GetOffchainMetadataFetchBatch` claims due rows before returning them by moving
+`next_fetch_after` forward for a short lease, so concurrent fetchers do not
+process the same pointer unless the claim expires before a result is recorded.
 
 ### Stake Snapshots and Rewards
 

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"net/http"
 	"runtime"
 	"slices"
 	"strconv"
@@ -81,6 +82,19 @@ func (m StorageMode) IsAPI() bool {
 type HistoryExpiryConfig struct {
 	Enabled   bool
 	Frequency time.Duration
+}
+
+// OffchainMetadataConfig controls API-mode off-chain metadata fetching.
+// Zero values use the internal fetcher defaults.
+type OffchainMetadataConfig struct {
+	HTTPClient            *http.Client
+	Interval              time.Duration
+	RequestTimeout        time.Duration
+	UserAgent             string
+	IPFSGatewayURL        string
+	BatchSize             int
+	MaxBytes              int64
+	AllowPrivateAddresses bool
 }
 
 type Config struct {
@@ -160,6 +174,8 @@ type Config struct {
 	leiosPipelineTiming *leios.PipelineTiming
 	// Blockfrost API port (0 = disabled)
 	blockfrostPort uint
+	// Off-chain metadata fetcher configuration
+	offchainMetadata OffchainMetadataConfig
 	// Chainsync multi-client configuration
 	chainsyncMaxClients   int
 	chainsyncStallTimeout time.Duration
@@ -900,6 +916,14 @@ func WithHistoryExpiry(cfg HistoryExpiryConfig) ConfigOptionFunc {
 func WithCORSAllowedOrigins(origins []string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.corsAllowedOrigins = slices.Clone(origins)
+	}
+}
+
+// WithOffchainMetadataConfig configures the API-mode off-chain metadata
+// fetcher. Zero values use the fetcher's internal defaults.
+func WithOffchainMetadataConfig(cfg OffchainMetadataConfig) ConfigOptionFunc {
+	return func(c *Config) {
+		c.offchainMetadata = cfg
 	}
 }
 

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -40,6 +40,7 @@ var MigrateModels = []any{
 	&MoveInstantaneousRewards{},
 	&MoveInstantaneousRewardsReward{},
 	&NetworkState{},
+	&OffchainMetadata{},
 	&Pool{},
 	&PoolOpCertSequence{},
 	&PoolRegistration{},

--- a/database/models/offchain_metadata.go
+++ b/database/models/offchain_metadata.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package models
+
+import "time"
+
+const (
+	OffchainMetadataSourcePool               = "pool"
+	OffchainMetadataSourceDrep               = "drep"
+	OffchainMetadataSourceDrepRegistration   = "drep_registration"
+	OffchainMetadataSourceDrepUpdate         = "drep_update"
+	OffchainMetadataSourceGovernanceProposal = "gov_proposal"
+	OffchainMetadataSourceGovernanceVote     = "gov_vote"
+	OffchainMetadataSourceConstitution       = "constitution"
+	OffchainMetadataSourceCommitteeResign    = "committee_resign"
+
+	OffchainMetadataStatusPending = "pending"
+	OffchainMetadataStatusFetched = "fetched"
+	OffchainMetadataStatusFailed  = "failed"
+)
+
+// OffchainMetadata stores a fetched copy of content referenced by on-chain
+// metadata and governance anchors. The on-chain URL/hash pair remains
+// authoritative; this table is a best-effort API cache.
+type OffchainMetadata struct {
+	FetchedAt      *time.Time
+	NextFetchAfter *time.Time `gorm:"index:idx_offchain_metadata_status_next,priority:2"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	URL            string `gorm:"size:512;not null;uniqueIndex:idx_offchain_metadata_source_url_hash,priority:2"`
+	SourceType     string `gorm:"size:32;not null;uniqueIndex:idx_offchain_metadata_source_url_hash,priority:1"`
+	Status         string `gorm:"size:16;not null;index:idx_offchain_metadata_status_next,priority:1"`
+	ContentType    string `gorm:"size:128"`
+	LastError      string `gorm:"size:1024"`
+	Hash           []byte `gorm:"size:32;not null;uniqueIndex:idx_offchain_metadata_source_url_hash,priority:3"`
+	BodyHash       []byte `gorm:"size:32"`
+	Content        []byte
+	ID             uint `gorm:"primarykey"`
+	FetchAttempts  uint
+	LastHTTPStatus uint
+}
+
+func (OffchainMetadata) TableName() string {
+	return "offchain_metadata"
+}

--- a/database/plugin/metadata/mysql/offchain_metadata.go
+++ b/database/plugin/metadata/mysql/offchain_metadata.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mysql
+
+import (
+	"context"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/offchain"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+func (d *MetadataStoreMysql) EnsureOffchainMetadataPointers(
+	ctx context.Context,
+	now time.Time,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	return offchain.EnsurePointers(ctx, db, now)
+}
+
+func (d *MetadataStoreMysql) GetOffchainMetadataFetchBatch(
+	ctx context.Context,
+	limit int,
+	now time.Time,
+	txn types.Txn,
+) ([]models.OffchainMetadata, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.FetchBatch(ctx, db, limit, now)
+}
+
+func (d *MetadataStoreMysql) SetOffchainMetadataFetchResult(
+	ctx context.Context,
+	doc *models.OffchainMetadata,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return offchain.SetFetchResult(ctx, db, doc)
+}
+
+func (d *MetadataStoreMysql) GetOffchainMetadata(
+	sourceType string,
+	url string,
+	hash []byte,
+	txn types.Txn,
+) (*models.OffchainMetadata, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.Get(db, sourceType, url, hash)
+}

--- a/database/plugin/metadata/offchain/offchain.go
+++ b/database/plugin/metadata/offchain/offchain.go
@@ -1,0 +1,317 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package offchain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type pointerSource struct {
+	SourceType string
+	Table      string
+	URLColumn  string
+	HashColumn string
+}
+
+var pointerSources = []pointerSource{
+	{
+		SourceType: models.OffchainMetadataSourcePool,
+		Table:      "pool_registration",
+		URLColumn:  "metadata_url",
+		HashColumn: "metadata_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceDrep,
+		Table:      "drep",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceDrepRegistration,
+		Table:      "registration_drep",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceDrepUpdate,
+		Table:      "update_drep",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceGovernanceProposal,
+		Table:      "governance_proposal",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceGovernanceVote,
+		Table:      "governance_vote",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceConstitution,
+		Table:      "constitution",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+	{
+		SourceType: models.OffchainMetadataSourceCommitteeResign,
+		Table:      "resign_committee_cold",
+		URLColumn:  "anchor_url",
+		HashColumn: "anchor_hash",
+	},
+}
+
+var fetchableStatuses = []string{
+	models.OffchainMetadataStatusPending,
+	models.OffchainMetadataStatusFailed,
+}
+
+const fetchClaimLease = 30 * time.Minute
+
+type pointerRow struct {
+	URL  string `gorm:"column:url"`
+	Hash []byte `gorm:"column:hash"`
+}
+
+// EnsurePointers adds pending off-chain metadata cache rows for every
+// currently known on-chain URL/hash pointer.
+func EnsurePointers(
+	ctx context.Context,
+	db *gorm.DB,
+	now time.Time,
+) (int, error) {
+	db = withContext(ctx, db)
+	created := 0
+	seen := make(map[string]struct{})
+	for _, source := range pointerSources {
+		rows, err := queryPointers(db, source)
+		if err != nil {
+			return created, err
+		}
+		for _, row := range rows {
+			url := strings.TrimSpace(row.URL)
+			if url == "" || len(row.Hash) != 32 {
+				continue
+			}
+			key := source.SourceType + "\x00" + url + "\x00" + string(row.Hash)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			doc := models.OffchainMetadata{
+				SourceType:     source.SourceType,
+				URL:            url,
+				Hash:           row.Hash,
+				Status:         models.OffchainMetadataStatusPending,
+				NextFetchAfter: &now,
+			}
+			result := db.Clauses(clause.OnConflict{
+				Columns: []clause.Column{
+					{Name: "source_type"},
+					{Name: "url"},
+					{Name: "hash"},
+				},
+				DoNothing: true,
+			}).Create(&doc)
+			if result.Error != nil {
+				return created, fmt.Errorf(
+					"insert off-chain metadata pointer from %s: %w",
+					source.Table,
+					result.Error,
+				)
+			}
+			created += int(result.RowsAffected)
+		}
+	}
+	return created, nil
+}
+
+func queryPointers(
+	db *gorm.DB,
+	source pointerSource,
+) ([]pointerRow, error) {
+	var rows []pointerRow
+	selectExpr := fmt.Sprintf(
+		"%s AS url, %s AS hash",
+		source.URLColumn,
+		source.HashColumn,
+	)
+	result := db.Table(source.Table).
+		Select(selectExpr).
+		Where(source.URLColumn + " <> ''").
+		Group(source.URLColumn + ", " + source.HashColumn).
+		Scan(&rows)
+	if result.Error != nil {
+		return nil, fmt.Errorf(
+			"query off-chain metadata pointers from %s: %w",
+			source.Table,
+			result.Error,
+		)
+	}
+	return rows, nil
+}
+
+// FetchBatch claims and returns pending or failed cache rows that are due for
+// another fetch attempt.
+func FetchBatch(
+	ctx context.Context,
+	db *gorm.DB,
+	limit int,
+	now time.Time,
+) ([]models.OffchainMetadata, error) {
+	if limit <= 0 {
+		limit = 1
+	}
+	db = withContext(ctx, db)
+	claimUntil := now.Add(fetchClaimLease)
+	docs := make([]models.OffchainMetadata, 0, limit)
+	for len(docs) < limit {
+		remaining := limit - len(docs)
+		var candidates []models.OffchainMetadata
+		result := db.
+			Where(
+				"status IN ? AND (next_fetch_after IS NULL OR next_fetch_after <= ?)",
+				fetchableStatuses,
+				now,
+			).
+			Order("next_fetch_after ASC, id ASC").
+			Limit(remaining).
+			Find(&candidates)
+		if result.Error != nil {
+			return nil, fmt.Errorf(
+				"query off-chain metadata fetch batch: %w",
+				result.Error,
+			)
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		for i := range candidates {
+			claimed, err := claimFetch(db, candidates[i].ID, now, claimUntil)
+			if err != nil {
+				return nil, err
+			}
+			if !claimed {
+				continue
+			}
+			doc := candidates[i]
+			nextFetchAfter := claimUntil
+			doc.NextFetchAfter = &nextFetchAfter
+			docs = append(docs, doc)
+			if len(docs) == limit {
+				break
+			}
+		}
+	}
+	return docs, nil
+}
+
+func claimFetch(
+	db *gorm.DB,
+	id uint,
+	now time.Time,
+	claimUntil time.Time,
+) (bool, error) {
+	result := db.Model(&models.OffchainMetadata{}).
+		Where(
+			"id = ? AND status IN ? AND "+
+				"(next_fetch_after IS NULL OR next_fetch_after <= ?)",
+			id,
+			fetchableStatuses,
+			now,
+		).
+		Update("next_fetch_after", claimUntil)
+	if result.Error != nil {
+		return false, fmt.Errorf(
+			"claim off-chain metadata fetch row %d: %w",
+			id,
+			result.Error,
+		)
+	}
+	return result.RowsAffected > 0, nil
+}
+
+// SetFetchResult persists the worker's latest fetch status for an existing
+// off-chain metadata cache row.
+func SetFetchResult(
+	ctx context.Context,
+	db *gorm.DB,
+	doc *models.OffchainMetadata,
+) error {
+	if doc == nil || doc.ID == 0 {
+		return errors.New("off-chain metadata fetch result missing row ID")
+	}
+	db = withContext(ctx, db)
+	updates := map[string]any{
+		"status":           doc.Status,
+		"content_type":     doc.ContentType,
+		"last_error":       doc.LastError,
+		"body_hash":        doc.BodyHash,
+		"content":          doc.Content,
+		"fetched_at":       doc.FetchedAt,
+		"next_fetch_after": doc.NextFetchAfter,
+		"fetch_attempts":   doc.FetchAttempts,
+		"last_http_status": doc.LastHTTPStatus,
+	}
+	result := db.Model(&models.OffchainMetadata{}).
+		Where("id = ?", doc.ID).
+		Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("update off-chain metadata fetch result: %w", result.Error)
+	}
+	return nil
+}
+
+func withContext(ctx context.Context, db *gorm.DB) *gorm.DB {
+	if ctx == nil {
+		return db
+	}
+	return db.WithContext(ctx)
+}
+
+// Get retrieves one cached off-chain metadata document by source and on-chain
+// URL/hash pointer. It returns nil when no cache row exists yet.
+func Get(
+	db *gorm.DB,
+	sourceType string,
+	url string,
+	hash []byte,
+) (*models.OffchainMetadata, error) {
+	var doc models.OffchainMetadata
+	result := db.Where(
+		"source_type = ? AND url = ? AND hash = ?",
+		sourceType,
+		url,
+		hash,
+	).First(&doc)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get off-chain metadata: %w", result.Error)
+	}
+	return &doc, nil
+}

--- a/database/plugin/metadata/offchain/offchain_test.go
+++ b/database/plugin/metadata/offchain/offchain_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package offchain
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestFetchBatchClaimsDueRows(t *testing.T) {
+	db := newOffchainTestDB(t)
+	now := time.Unix(1000, 0).UTC()
+	dueAt := now.Add(-time.Minute)
+	future := now.Add(fetchClaimLease + time.Minute)
+
+	pending := createOffchainTestDoc(
+		t,
+		db,
+		0x01,
+		models.OffchainMetadataStatusPending,
+		nil,
+	)
+	failed := createOffchainTestDoc(
+		t,
+		db,
+		0x02,
+		models.OffchainMetadataStatusFailed,
+		&dueAt,
+	)
+	createOffchainTestDoc(
+		t,
+		db,
+		0x03,
+		models.OffchainMetadataStatusPending,
+		&future,
+	)
+	createOffchainTestDoc(
+		t,
+		db,
+		0x04,
+		models.OffchainMetadataStatusFetched,
+		nil,
+	)
+
+	firstBatch, err := FetchBatch(context.Background(), db, 10, now)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{pending.ID, failed.ID}, docIDs(firstBatch))
+
+	secondBatch, err := FetchBatch(context.Background(), db, 10, now)
+	require.NoError(t, err)
+	require.Empty(t, secondBatch)
+
+	for _, doc := range firstBatch {
+		var stored models.OffchainMetadata
+		require.NoError(t, db.First(&stored, doc.ID).Error)
+		require.NotNil(t, stored.NextFetchAfter)
+		require.True(t, stored.NextFetchAfter.After(now))
+		require.WithinDuration(
+			t,
+			now.Add(fetchClaimLease),
+			*stored.NextFetchAfter,
+			time.Second,
+		)
+		require.Equal(t, doc.Status, stored.Status)
+	}
+
+	afterLease, err := FetchBatch(
+		context.Background(),
+		db,
+		10,
+		now.Add(fetchClaimLease+time.Second),
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{pending.ID, failed.ID}, docIDs(afterLease))
+}
+
+func TestFetchBatchConcurrentCallersClaimRowOnce(t *testing.T) {
+	db := newOffchainTestDB(t)
+	now := time.Unix(2000, 0).UTC()
+	doc := createOffchainTestDoc(
+		t,
+		db,
+		0x11,
+		models.OffchainMetadataStatusPending,
+		nil,
+	)
+
+	const callers = 8
+	start := make(chan struct{})
+	results := make(chan fetchBatchResult, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			batch, err := FetchBatch(context.Background(), db, 1, now)
+			results <- fetchBatchResult{
+				batch: batch,
+				err:   err,
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	claimCounts := map[uint]int{}
+	for result := range results {
+		require.NoError(t, result.err)
+		for _, claimed := range result.batch {
+			claimCounts[claimed.ID]++
+		}
+	}
+	require.Equal(t, map[uint]int{doc.ID: 1}, claimCounts)
+}
+
+type fetchBatchResult struct {
+	batch []models.OffchainMetadata
+	err   error
+}
+
+func newOffchainTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "metadata.sqlite")
+	db, err := gorm.Open(
+		sqlite.Open(
+			fmt.Sprintf(
+				"file:%s?_pragma=busy_timeout(30000)&_pragma=foreign_keys(1)",
+				dbPath,
+			),
+		),
+		&gorm.Config{SkipDefaultTransaction: true},
+	)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+	require.NoError(t, db.AutoMigrate(&models.OffchainMetadata{}))
+	return db
+}
+
+func createOffchainTestDoc(
+	t *testing.T,
+	db *gorm.DB,
+	seed byte,
+	status string,
+	nextFetchAfter *time.Time,
+) models.OffchainMetadata {
+	t.Helper()
+	doc := models.OffchainMetadata{
+		SourceType:     models.OffchainMetadataSourcePool,
+		URL:            fmt.Sprintf("https://metadata.example.test/%02x.json", seed),
+		Hash:           bytes.Repeat([]byte{seed}, 32),
+		Status:         status,
+		NextFetchAfter: nextFetchAfter,
+	}
+	require.NoError(t, db.Create(&doc).Error)
+	return doc
+}
+
+func docIDs(docs []models.OffchainMetadata) []uint {
+	ids := make([]uint, 0, len(docs))
+	for _, doc := range docs {
+		ids = append(ids, doc.ID)
+	}
+	return ids
+}

--- a/database/plugin/metadata/postgres/offchain_metadata.go
+++ b/database/plugin/metadata/postgres/offchain_metadata.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/offchain"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+func (d *MetadataStorePostgres) EnsureOffchainMetadataPointers(
+	ctx context.Context,
+	now time.Time,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	return offchain.EnsurePointers(ctx, db, now)
+}
+
+func (d *MetadataStorePostgres) GetOffchainMetadataFetchBatch(
+	ctx context.Context,
+	limit int,
+	now time.Time,
+	txn types.Txn,
+) ([]models.OffchainMetadata, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.FetchBatch(ctx, db, limit, now)
+}
+
+func (d *MetadataStorePostgres) SetOffchainMetadataFetchResult(
+	ctx context.Context,
+	doc *models.OffchainMetadata,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return offchain.SetFetchResult(ctx, db, doc)
+}
+
+func (d *MetadataStorePostgres) GetOffchainMetadata(
+	sourceType string,
+	url string,
+	hash []byte,
+	txn types.Txn,
+) (*models.OffchainMetadata, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.Get(db, sourceType, url, hash)
+}

--- a/database/plugin/metadata/sqlite/offchain_metadata.go
+++ b/database/plugin/metadata/sqlite/offchain_metadata.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/offchain"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+func (d *MetadataStoreSqlite) EnsureOffchainMetadataPointers(
+	ctx context.Context,
+	now time.Time,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	return offchain.EnsurePointers(ctx, db, now)
+}
+
+func (d *MetadataStoreSqlite) GetOffchainMetadataFetchBatch(
+	ctx context.Context,
+	limit int,
+	now time.Time,
+	txn types.Txn,
+) ([]models.OffchainMetadata, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.FetchBatch(ctx, db, limit, now)
+}
+
+func (d *MetadataStoreSqlite) SetOffchainMetadataFetchResult(
+	ctx context.Context,
+	doc *models.OffchainMetadata,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return offchain.SetFetchResult(ctx, db, doc)
+}
+
+func (d *MetadataStoreSqlite) GetOffchainMetadata(
+	sourceType string,
+	url string,
+	hash []byte,
+	txn types.Txn,
+) (*models.OffchainMetadata, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.Get(db, sourceType, url, hash)
+}

--- a/database/plugin/metadata/sqlite/offchain_metadata_test.go
+++ b/database/plugin/metadata/sqlite/offchain_metadata_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOffchainMetadataPointersRoundTrip(t *testing.T) {
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+	url := "https://pool.example.test/metadata.json"
+	hash := bytes.Repeat([]byte{0x42}, 32)
+	pool := models.Pool{
+		PoolKeyHash: bytes.Repeat([]byte{0x11}, 28),
+		VrfKeyHash:  bytes.Repeat([]byte{0x22}, 32),
+	}
+	require.NoError(t, store.DB().Create(&pool).Error)
+	reg := models.PoolRegistration{
+		PoolID:       pool.ID,
+		PoolKeyHash:  pool.PoolKeyHash,
+		VrfKeyHash:   pool.VrfKeyHash,
+		MetadataUrl:  url,
+		MetadataHash: hash,
+		AddedSlot:    10,
+	}
+	require.NoError(t, store.DB().Create(&reg).Error)
+
+	now := time.Unix(100, 0).UTC()
+	created, err := store.EnsureOffchainMetadataPointers(
+		context.Background(),
+		now,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, created)
+
+	created, err = store.EnsureOffchainMetadataPointers(
+		context.Background(),
+		now,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Zero(t, created)
+
+	batch, err := store.GetOffchainMetadataFetchBatch(
+		context.Background(),
+		10,
+		now,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	require.Equal(t, models.OffchainMetadataSourcePool, batch[0].SourceType)
+	require.Equal(t, url, batch[0].URL)
+	require.Equal(t, hash, batch[0].Hash)
+
+	fetchedAt := now.Add(time.Second)
+	batch[0].Status = models.OffchainMetadataStatusFetched
+	batch[0].ContentType = "application/json"
+	batch[0].Content = []byte(`{"ticker":"TEST"}`)
+	batch[0].BodyHash = bytes.Repeat([]byte{0x24}, 32)
+	batch[0].FetchedAt = &fetchedAt
+	batch[0].NextFetchAfter = nil
+	batch[0].FetchAttempts = 1
+	batch[0].LastHTTPStatus = http.StatusOK
+	require.NoError(t, store.SetOffchainMetadataFetchResult(
+		context.Background(),
+		&batch[0],
+		nil,
+	))
+
+	got, err := store.GetOffchainMetadata(
+		models.OffchainMetadataSourcePool,
+		url,
+		hash,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, models.OffchainMetadataStatusFetched, got.Status)
+	require.Equal(t, []byte(`{"ticker":"TEST"}`), got.Content)
+	require.Equal(t, uint(http.StatusOK), got.LastHTTPStatus)
+	require.NotNil(t, got.FetchedAt)
+	require.True(t, got.FetchedAt.Equal(fetchedAt))
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -15,7 +15,9 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin"
@@ -126,6 +128,40 @@ type MetadataStore interface {
 		checkpoint *models.ImportCheckpoint,
 		txn types.Txn,
 	) error
+
+	// EnsureOffchainMetadataPointers creates pending cache rows for
+	// on-chain pool metadata and governance anchor URL/hash pointers.
+	EnsureOffchainMetadataPointers(
+		ctx context.Context,
+		now time.Time,
+		txn types.Txn,
+	) (int, error)
+
+	// GetOffchainMetadataFetchBatch returns pending or failed
+	// off-chain metadata rows that are due to be fetched.
+	GetOffchainMetadataFetchBatch(
+		ctx context.Context,
+		limit int,
+		now time.Time,
+		txn types.Txn,
+	) ([]models.OffchainMetadata, error)
+
+	// SetOffchainMetadataFetchResult updates a cache row after a fetch
+	// attempt.
+	SetOffchainMetadataFetchResult(
+		ctx context.Context,
+		doc *models.OffchainMetadata,
+		txn types.Txn,
+	) error
+
+	// GetOffchainMetadata retrieves a cached off-chain document by its
+	// source type and on-chain URL/hash pointer.
+	GetOffchainMetadata(
+		sourceType string,
+		url string,
+		hash []byte,
+		txn types.Txn,
+	) (*models.OffchainMetadata, error)
 
 	// GetPoolRegistrations retrieves all registration certificates for a pool.
 	GetPoolRegistrations(

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/getsops/sops/v3 v3.13.1
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-sql-driver/mysql v1.10.0
+	github.com/ipfs/go-cid v0.6.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/klauspost/compress v1.18.6
 	github.com/orandin/slog-gorm v1.4.0
@@ -181,6 +182,12 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mr-tron/base58 v1.3.0 // indirect
+	github.com/multiformats/go-base32 v0.1.0 // indirect
+	github.com/multiformats/go-base36 v0.2.0 // indirect
+	github.com/multiformats/go-multibase v0.3.0 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
+	github.com/multiformats/go-varint v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
@@ -197,6 +204,7 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tjfoc/gmsm v1.4.1 // indirect
 	github.com/urfave/cli v1.22.17 // indirect
@@ -223,6 +231,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 	gorm.io/driver/clickhouse v0.7.0 // indirect
+	lukechampine.com/blake3 v1.1.6 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.195 h1:DFdcGWtp9htuXqVjhogF/tw
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.195/go.mod h1:M+yna96Fx9o5GbIUnF3OvVvQGjgfVSyeJbV9Yb1z/wI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/ipfs/go-cid v0.6.1 h1:T5TnNb08+ueovG76Z5gx1L4Y7QOaGTXHg1F6raWFxIc=
+github.com/ipfs/go-cid v0.6.1/go.mod h1:zrY0SwOhjrrIdfPQ/kf+k1sXyJ0QE7cMxfCployLBs0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -352,6 +354,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -400,6 +403,18 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mr-tron/base58 v1.3.0 h1:K6Y13R2h+dku0wOqKtecgRnBUBPrZzLZy5aIj8lCcJI=
+github.com/mr-tron/base58 v1.3.0/go.mod h1:2BuubE67DCSWwVfx37JWNG8emOC0sHEU4/HpcYgCLX8=
+github.com/multiformats/go-base32 v0.1.0 h1:pVx9xoSPqEIQG8o+UbAe7DNi51oej1NtK+aGkbLYxPE=
+github.com/multiformats/go-base32 v0.1.0/go.mod h1:Kj3tFY6zNr+ABYMqeUNeGvkIC/UYgtWibDcT0rExnbI=
+github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9rQyccr0=
+github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
+github.com/multiformats/go-multibase v0.3.0 h1:8helZD2+4Db7NNWFiktk2NePbF0boolBe6bDQvM4r68=
+github.com/multiformats/go-multibase v0.3.0/go.mod h1:MoBLQPCkRTOL3eveIPO81860j2AQY8JwcnNlRkGRUfI=
+github.com/multiformats/go-multihash v0.2.3 h1:7Lyc8XfX/IY2jWb/gI7JP+o7JEq9hOa7BFvVU9RSh+U=
+github.com/multiformats/go-multihash v0.2.3/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=
+github.com/multiformats/go-varint v0.1.0 h1:i2wqFp4sdl3IcIxfAonHQV9qU5OsZ4Ts9IOoETFs5dI=
+github.com/multiformats/go-varint v0.1.0/go.mod h1:5KVAVXegtfmNQQm/lCY+ATvDzvJJhSkUlGQV9wgObdI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -452,6 +467,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -683,6 +700,8 @@ gorm.io/plugin/opentelemetry v0.1.16 h1:Kypj2YYAliJqkIczDZDde6P6sFMhKSlG5IpngMFQ
 gorm.io/plugin/opentelemetry v0.1.16/go.mod h1:P3RmTeZXT+9n0F1ccUqR5uuTvEXDxF8k2UpO7mTIB2Y=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+lukechampine.com/blake3 v1.1.6 h1:H3cROdztr7RCfoaTpGZFQsrqvweFLrqS73j7L7cmR5c=
+lukechampine.com/blake3 v1.1.6/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=
 modernc.org/libc v1.22.5 h1:91BNch/e5B0uPbJFgqbxXuOnxBQjlS//icfQEGmvyjE=
 modernc.org/libc v1.22.5/go.mod h1:jj+Z7dTNX8fBScMVNRAYZ/jF91K8fdT2hYMThc3YjBY=
 modernc.org/mathutil v1.5.0 h1:rV0Ko/6SfM+8G+yKiyI830l3Wuz1zRutdslNoQ0kfiQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,6 +185,26 @@ type HistoryExpiryConfig struct {
 	Frequency time.Duration `yaml:"frequency" envconfig:"DINGO_HISTORY_EXPIRY_FREQUENCY"`
 }
 
+// OffchainMetadataConfig holds API-mode off-chain metadata fetcher settings.
+// Zero values fall back to the fetcher's internal defaults.
+type OffchainMetadataConfig struct {
+	// Interval controls how often the fetcher discovers and fetches due rows.
+	Interval time.Duration `yaml:"interval" envconfig:"DINGO_OFFCHAIN_METADATA_INTERVAL"`
+	// RequestTimeout limits each HTTP(S) metadata request.
+	RequestTimeout time.Duration `yaml:"requestTimeout" envconfig:"DINGO_OFFCHAIN_METADATA_REQUEST_TIMEOUT"`
+	// UserAgent is sent with outbound metadata requests.
+	UserAgent string `yaml:"userAgent" envconfig:"DINGO_OFFCHAIN_METADATA_USER_AGENT"`
+	// IPFSGatewayURL is the gateway prefix used for ipfs:// URLs.
+	IPFSGatewayURL string `yaml:"ipfsGatewayUrl" envconfig:"DINGO_OFFCHAIN_METADATA_IPFS_GATEWAY_URL"`
+	// BatchSize bounds the number of due rows claimed per fetcher pass.
+	BatchSize int `yaml:"batchSize" envconfig:"DINGO_OFFCHAIN_METADATA_BATCH_SIZE"`
+	// MaxBytes bounds the response body bytes read from each document.
+	MaxBytes int64 `yaml:"maxBytes" envconfig:"DINGO_OFFCHAIN_METADATA_MAX_BYTES"`
+	// AllowPrivateAddresses permits fetching private, loopback, and link-local
+	// addresses. Leave false for the default SSRF guard.
+	AllowPrivateAddresses bool `yaml:"allowPrivateAddresses" envconfig:"DINGO_OFFCHAIN_METADATA_ALLOW_PRIVATE_ADDRESSES"`
+}
+
 // DefaultChainsyncConfig returns the default chainsync configuration.
 // StallTimeout must match chainsync.DefaultStallTimeout and the
 // fallback in internal/node/node.go.
@@ -330,6 +350,9 @@ type Config struct {
 
 	// History expiry configuration for local immutable block CBOR expiry.
 	HistoryExpiry HistoryExpiryConfig `yaml:"historyExpiry"`
+
+	// Off-chain metadata fetcher configuration.
+	OffchainMetadata OffchainMetadataConfig `yaml:"offchainMetadata"`
 
 	// Logging configuration (output format and level)
 	Logging LoggingConfig `yaml:"logging"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -972,6 +972,51 @@ func TestLoad_APIPortsDefault(t *testing.T) {
 	}
 }
 
+func TestLoad_OffchainMetadataConfig(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+offchainMetadata:
+  interval: 2m
+  requestTimeout: 10s
+  userAgent: "dingo-test/1"
+  ipfsGatewayUrl: "https://ipfs.example.test/ipfs/"
+  batchSize: 7
+  maxBytes: 65536
+  allowPrivateAddresses: true
+network: "preview"
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-offchain-metadata.yaml")
+
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	expected := OffchainMetadataConfig{
+		Interval:              2 * time.Minute,
+		RequestTimeout:        10 * time.Second,
+		UserAgent:             "dingo-test/1",
+		IPFSGatewayURL:        "https://ipfs.example.test/ipfs/",
+		BatchSize:             7,
+		MaxBytes:              65536,
+		AllowPrivateAddresses: true,
+	}
+	if cfg.OffchainMetadata != expected {
+		t.Fatalf(
+			"expected off-chain metadata config %+v, got %+v",
+			expected,
+			cfg.OffchainMetadata,
+		)
+	}
+}
+
 func TestLoad_StorageMode(t *testing.T) {
 	resetGlobalConfig()
 	yamlContent := `

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -77,6 +77,13 @@ var flagSpecs = []flagSpec{
 	uintFlag("BlockfrostPort", "blockfrost-port", "Blockfrost-compatible API port"),
 	uintFlag("MeshPort", "mesh-port", "Mesh API port"),
 	stringSliceFlag("CORSAllowedOrigins", "cors-allowed-origins", "CORS allowed origins for API servers"),
+	durationFlag("OffchainMetadata.Interval", "offchain-metadata-interval", "off-chain metadata fetch interval (0 = default)"),
+	durationFlag("OffchainMetadata.RequestTimeout", "offchain-metadata-request-timeout", "off-chain metadata HTTP request timeout (0 = default)"),
+	stringFlag("OffchainMetadata.UserAgent", "offchain-metadata-user-agent", "", "off-chain metadata HTTP user agent (empty = default)"),
+	stringFlag("OffchainMetadata.IPFSGatewayURL", "offchain-metadata-ipfs-gateway-url", "", "IPFS gateway URL for off-chain metadata (empty = default)"),
+	intFlag("OffchainMetadata.BatchSize", "offchain-metadata-batch-size", "off-chain metadata rows to claim per pass (0 = default)"),
+	int64Flag("OffchainMetadata.MaxBytes", "offchain-metadata-max-bytes", "off-chain metadata max response bytes (0 = default)"),
+	boolFlag("OffchainMetadata.AllowPrivateAddresses", "offchain-metadata-allow-private-addresses", "allow off-chain metadata fetches to private, loopback, and link-local addresses"),
 
 	// Bark
 	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive fallback base URL"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -73,6 +73,11 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 	t.Setenv("DINGO_DATABASE_WORKERS", "9")
 	t.Setenv("DINGO_BACKFILL_BATCH_SIZE", "50")
 	t.Setenv("DINGO_HISTORY_EXPIRY_FREQUENCY", "15m")
+	t.Setenv("DINGO_OFFCHAIN_METADATA_MAX_BYTES", "1024")
+	t.Setenv(
+		"DINGO_OFFCHAIN_METADATA_IPFS_GATEWAY_URL",
+		"https://env.example/ipfs/",
+	)
 
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")
@@ -108,6 +113,18 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 			cfg.HistoryExpiry.Frequency,
 		)
 	}
+	if cfg.OffchainMetadata.MaxBytes != 1024 {
+		t.Fatalf(
+			"expected env var to set offchain metadata max bytes=1024, got %d",
+			cfg.OffchainMetadata.MaxBytes,
+		)
+	}
+	if cfg.OffchainMetadata.IPFSGatewayURL != "https://env.example/ipfs/" {
+		t.Fatalf(
+			"expected env var to set offchain metadata IPFS gateway, got %q",
+			cfg.OffchainMetadata.IPFSGatewayURL,
+		)
+	}
 
 	cmd := &cobra.Command{Use: "dingo"}
 	RegisterFlags(cmd)
@@ -117,6 +134,8 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		"--backfill-batch-size=200",
 		"--history-expiry-enabled=true",
 		"--history-expiry-frequency=30m",
+		"--offchain-metadata-max-bytes=2048",
+		"--offchain-metadata-ipfs-gateway-url=https://flag.example/ipfs/",
 	}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -156,6 +175,18 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		t.Fatalf(
 			"expected --history-expiry-frequency to set 30m, got %s",
 			cfg.HistoryExpiry.Frequency,
+		)
+	}
+	if cfg.OffchainMetadata.MaxBytes != 2048 {
+		t.Fatalf(
+			"expected flag to override offchain metadata max bytes to 2048, got %d",
+			cfg.OffchainMetadata.MaxBytes,
+		)
+	}
+	if cfg.OffchainMetadata.IPFSGatewayURL != "https://flag.example/ipfs/" {
+		t.Fatalf(
+			"expected flag to override offchain metadata IPFS gateway, got %q",
+			cfg.OffchainMetadata.IPFSGatewayURL,
 		)
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -304,6 +304,20 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				Frequency: cfg.HistoryExpiry.Frequency,
 			}),
 			dingo.WithCORSAllowedOrigins(cfg.CORSAllowedOrigins),
+			dingo.WithOffchainMetadataConfig(
+				dingo.OffchainMetadataConfig{
+					Interval: cfg.OffchainMetadata.Interval,
+					RequestTimeout: cfg.OffchainMetadata.
+						RequestTimeout,
+					UserAgent: cfg.OffchainMetadata.UserAgent,
+					IPFSGatewayURL: cfg.OffchainMetadata.
+						IPFSGatewayURL,
+					BatchSize: cfg.OffchainMetadata.BatchSize,
+					MaxBytes:  cfg.OffchainMetadata.MaxBytes,
+					AllowPrivateAddresses: cfg.OffchainMetadata.
+						AllowPrivateAddresses,
+				},
+			),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
 			dingo.WithRunMode(string(cfg.RunMode)),
 			dingo.WithStartEra(string(cfg.StartEra)),

--- a/internal/offchainmetadata/fetcher.go
+++ b/internal/offchainmetadata/fetcher.go
@@ -1,0 +1,742 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package offchainmetadata
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	cidlib "github.com/ipfs/go-cid"
+	"golang.org/x/crypto/blake2b"
+)
+
+const (
+	defaultInterval       = 5 * time.Minute
+	defaultRequestTimeout = 15 * time.Second
+	defaultBatchSize      = 25
+	defaultMaxBytes       = 1 << 20
+	defaultUserAgent      = "dingo-offchain-metadata/1"
+	defaultIPFSGatewayURL = "https://gateway.pinata.cloud/ipfs/"
+	maxRedirects          = 5
+)
+
+var errFetchCanceled = errors.New("off-chain metadata fetch canceled")
+
+type Store interface {
+	EnsureOffchainMetadataPointers(
+		ctx context.Context,
+		now time.Time,
+		txn types.Txn,
+	) (int, error)
+	GetOffchainMetadataFetchBatch(
+		ctx context.Context,
+		limit int,
+		now time.Time,
+		txn types.Txn,
+	) ([]models.OffchainMetadata, error)
+	SetOffchainMetadataFetchResult(
+		ctx context.Context,
+		doc *models.OffchainMetadata,
+		txn types.Txn,
+	) error
+}
+
+type Config struct {
+	Logger *slog.Logger
+	Store  Store
+	// HTTPClient customizes fetch requests. When private addresses are not
+	// allowed, New clones the client and replaces unsafe transport dial hooks.
+	HTTPClient            *http.Client
+	Interval              time.Duration
+	RequestTimeout        time.Duration
+	UserAgent             string
+	IPFSGatewayURL        string
+	BatchSize             int
+	MaxBytes              int64
+	AllowPrivateAddresses bool
+}
+
+type Fetcher struct {
+	logger                *slog.Logger
+	store                 Store
+	client                *http.Client
+	interval              time.Duration
+	timeout               time.Duration
+	userAgent             string
+	ipfsGatewayURL        string
+	batchSize             int
+	maxBytes              int64
+	allowPrivateAddresses bool
+	now                   func() time.Time
+	mu                    sync.Mutex
+	cancel                context.CancelFunc
+	done                  chan struct{}
+}
+
+func New(cfg Config) (*Fetcher, error) {
+	if cfg.Store == nil {
+		return nil, errors.New("off-chain metadata store is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger = logger.With("component", "offchain-metadata")
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+	timeout := cfg.RequestTimeout
+	if timeout <= 0 {
+		timeout = defaultRequestTimeout
+	}
+	client, err := secureHTTPClient(
+		cfg.HTTPClient,
+		timeout,
+		cfg.AllowPrivateAddresses,
+	)
+	if err != nil {
+		return nil, err
+	}
+	userAgent := cfg.UserAgent
+	if userAgent == "" {
+		userAgent = defaultUserAgent
+	}
+	ipfsGatewayURL := cfg.IPFSGatewayURL
+	if ipfsGatewayURL == "" {
+		ipfsGatewayURL = defaultIPFSGatewayURL
+	}
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	maxBytes := cfg.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBytes
+	}
+	return &Fetcher{
+		logger:                logger,
+		store:                 cfg.Store,
+		client:                client,
+		interval:              interval,
+		timeout:               timeout,
+		userAgent:             userAgent,
+		ipfsGatewayURL:        ipfsGatewayURL,
+		batchSize:             batchSize,
+		maxBytes:              maxBytes,
+		allowPrivateAddresses: cfg.AllowPrivateAddresses,
+		now:                   time.Now,
+	}, nil
+}
+
+func (f *Fetcher) Start(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.done != nil {
+		return errors.New("off-chain metadata fetcher already started")
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	f.cancel = cancel
+	f.done = make(chan struct{})
+	go f.loop(runCtx)
+	return nil
+}
+
+func (f *Fetcher) Stop(ctx context.Context) error {
+	f.mu.Lock()
+	cancel := f.cancel
+	done := f.done
+	f.mu.Unlock()
+	if cancel == nil || done == nil {
+		return nil
+	}
+	cancel()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (f *Fetcher) loop(ctx context.Context) {
+	defer close(f.done)
+	f.runOnce(ctx)
+	ticker := time.NewTicker(f.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			f.runOnce(ctx)
+		}
+	}
+}
+
+func (f *Fetcher) runOnce(ctx context.Context) {
+	now := f.now()
+	if ctx.Err() != nil {
+		return
+	}
+	created, err := f.store.EnsureOffchainMetadataPointers(ctx, now, nil)
+	if err != nil {
+		f.logger.Warn("off-chain metadata pointer discovery failed", "error", err)
+		return
+	}
+	if created > 0 {
+		f.logger.Debug("off-chain metadata pointers discovered", "count", created)
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	batch, err := f.store.GetOffchainMetadataFetchBatch(
+		ctx,
+		f.batchSize,
+		now,
+		nil,
+	)
+	if err != nil {
+		f.logger.Warn("off-chain metadata fetch batch failed", "error", err)
+		return
+	}
+	for i := range batch {
+		if ctx.Err() != nil {
+			return
+		}
+		doc := batch[i]
+		if err := f.fetchOne(ctx, &doc); err != nil {
+			if errors.Is(err, errFetchCanceled) {
+				return
+			}
+			f.logger.Warn(
+				"off-chain metadata fetch failed without result",
+				"id", doc.ID,
+				"url", doc.URL,
+				"error", err,
+			)
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if err := f.store.SetOffchainMetadataFetchResult(ctx, &doc, nil); err != nil {
+			f.logger.Warn(
+				"off-chain metadata fetch result update failed",
+				"id", doc.ID,
+				"url", doc.URL,
+				"error", err,
+			)
+		}
+	}
+}
+
+func (f *Fetcher) fetchOne(
+	ctx context.Context,
+	doc *models.OffchainMetadata,
+) error {
+	if ctx.Err() != nil {
+		return errFetchCanceled
+	}
+	originalAttempts := doc.FetchAttempts
+	doc.FetchAttempts++
+	fetchURL, err := resolveFetchURL(
+		doc.URL,
+		f.ipfsGatewayURL,
+		f.allowPrivateAddresses,
+	)
+	if err != nil {
+		f.markFailure(doc, 0, fmt.Errorf("unsupported URL: %w", err))
+		return nil
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, f.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		f.markFailure(doc, 0, err)
+		return nil
+	}
+	req.Header.Set("User-Agent", f.userAgent)
+	req.Header.Set("Accept", "application/json, text/plain;q=0.8, */*;q=0.1")
+	resp, err := f.client.Do(req) //nolint:gosec // URL is ledger-provided but validated and fetched through the enforced client policy.
+	if err != nil {
+		if ctx.Err() != nil {
+			doc.FetchAttempts = originalAttempts
+			return errFetchCanceled
+		}
+		f.markFailure(doc, 0, err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		f.markFailure(
+			doc,
+			uint(resp.StatusCode),
+			fmt.Errorf("unexpected HTTP status %d", resp.StatusCode),
+		)
+		return nil
+	}
+	body, err := readLimited(resp.Body, f.maxBytes)
+	if err != nil {
+		if ctx.Err() != nil {
+			doc.FetchAttempts = originalAttempts
+			return errFetchCanceled
+		}
+		f.markFailure(doc, uint(resp.StatusCode), err)
+		return nil
+	}
+	sum := blake2b.Sum256(body)
+	doc.BodyHash = append(doc.BodyHash[:0], sum[:]...)
+	if !bytes.Equal(sum[:], doc.Hash) {
+		f.markFailure(
+			doc,
+			uint(resp.StatusCode),
+			errors.New("metadata hash mismatch"),
+		)
+		return nil
+	}
+	now := f.now()
+	doc.Content = body
+	doc.ContentType = sanitizeContentType(resp.Header.Get("Content-Type"))
+	doc.LastError = ""
+	doc.LastHTTPStatus = uint(resp.StatusCode)
+	doc.Status = models.OffchainMetadataStatusFetched
+	doc.FetchedAt = &now
+	doc.NextFetchAfter = nil
+	return nil
+}
+
+func (f *Fetcher) markFailure(
+	doc *models.OffchainMetadata,
+	status uint,
+	err error,
+) {
+	now := f.now()
+	next := now.Add(retryDelay(doc.FetchAttempts))
+	doc.Status = models.OffchainMetadataStatusFailed
+	doc.LastHTTPStatus = status
+	doc.LastError = truncate(err.Error(), 1024)
+	doc.NextFetchAfter = &next
+}
+
+func readLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, errors.New("max response bytes must be positive")
+	}
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxBytes)
+	}
+	return body, nil
+}
+
+func retryDelay(attempts uint) time.Duration {
+	if attempts == 0 {
+		attempts = 1
+	}
+	exp := min(attempts-1, 6)
+	delay := 15 * time.Minute * time.Duration(1<<exp)
+	if delay > 24*time.Hour || delay <= 0 {
+		return 24 * time.Hour
+	}
+	return delay
+}
+
+// allowedContentTypes are the media types persisted verbatim from fetch
+// responses. The Content-Type header is attacker-controlled (unlike the
+// body, it is not bound by the on-chain hash), so anything outside this
+// list is stored as application/octet-stream to keep a future serving
+// endpoint from echoing types like text/html under the API origin.
+var allowedContentTypes = map[string]struct{}{
+	"application/json":    {},
+	"application/ld+json": {},
+	"text/plain":          {},
+}
+
+func sanitizeContentType(header string) string {
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return "application/octet-stream"
+	}
+	if _, ok := allowedContentTypes[mediaType]; !ok {
+		return "application/octet-stream"
+	}
+	return mediaType
+}
+
+func truncate(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
+}
+
+func newHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     newRestrictedTransport(timeout, allowPrivate),
+		CheckRedirect: restrictedRedirectPolicy(nil, allowPrivate),
+	}
+}
+
+func secureHTTPClient(
+	client *http.Client,
+	timeout time.Duration,
+	allowPrivate bool,
+) (*http.Client, error) {
+	if client == nil {
+		return newHTTPClient(timeout, allowPrivate), nil
+	}
+	secured := *client
+	secured.CheckRedirect = restrictedRedirectPolicy(
+		client.CheckRedirect,
+		allowPrivate,
+	)
+	if allowPrivate {
+		return &secured, nil
+	}
+	transport, err := secureHTTPTransport(client.Transport, timeout)
+	if err != nil {
+		return nil, err
+	}
+	secured.Transport = transport
+	return &secured, nil
+}
+
+func secureHTTPTransport(
+	base http.RoundTripper,
+	timeout time.Duration,
+) (http.RoundTripper, error) {
+	if base == nil {
+		return newRestrictedTransport(timeout, false), nil
+	}
+	transport, ok := base.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf(
+			"off-chain metadata HTTP transport %T cannot enforce private-address restrictions",
+			base,
+		)
+	}
+	secured := transport.Clone()
+	applyRestrictedTransport(secured, timeout, false)
+	return secured, nil
+}
+
+func newRestrictedTransport(
+	timeout time.Duration,
+	allowPrivate bool,
+) *http.Transport {
+	transport := &http.Transport{}
+	applyRestrictedTransport(transport, timeout, allowPrivate)
+	return transport
+}
+
+func applyRestrictedTransport(
+	transport *http.Transport,
+	timeout time.Duration,
+	allowPrivate bool,
+) {
+	dialer := &restrictedDialer{
+		dialer:       &net.Dialer{Timeout: timeout},
+		allowPrivate: allowPrivate,
+	}
+	transport.Proxy = nil
+	transport.DialContext = dialer.DialContext
+	transport.Dial = nil    //nolint:staticcheck // deprecated hook is cleared so it cannot bypass the restricted dialer
+	transport.DialTLS = nil //nolint:staticcheck // deprecated hook is cleared so it cannot bypass the restricted dialer
+	transport.DialTLSContext = nil
+	if transport.TLSHandshakeTimeout <= 0 {
+		transport.TLSHandshakeTimeout = timeout
+	}
+	if transport.ResponseHeaderTimeout <= 0 {
+		transport.ResponseHeaderTimeout = timeout
+	}
+}
+
+func restrictedRedirectPolicy(
+	next func(*http.Request, []*http.Request) error,
+	allowPrivate bool,
+) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return errors.New("too many redirects")
+		}
+		if err := validateURL(req.URL.String(), allowPrivate); err != nil {
+			return err
+		}
+		if next != nil {
+			return next(req, via)
+		}
+		return nil
+	}
+}
+
+func validateURL(raw string, allowPrivate bool) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("scheme %q is not supported", u.Scheme)
+	}
+	if u.User != nil {
+		return errors.New("userinfo is not allowed")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("host is required")
+	}
+	if !allowPrivate && isBlockedHost(host) {
+		return fmt.Errorf("host %q is not allowed", host)
+	}
+	if ip := net.ParseIP(host); ip != nil && !allowPrivate && isBlockedIP(ip) {
+		return fmt.Errorf("IP %s is not allowed", ip)
+	}
+	return nil
+}
+
+func resolveFetchURL(
+	raw string,
+	ipfsGatewayURL string,
+	allowPrivate bool,
+) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		if err := validateURL(raw, allowPrivate); err != nil {
+			return "", err
+		}
+		return raw, nil
+	case "ipfs":
+		return resolveIPFSFetchURL(u, ipfsGatewayURL, allowPrivate)
+	default:
+		return "", fmt.Errorf("scheme %q is not supported", u.Scheme)
+	}
+}
+
+func resolveIPFSFetchURL(
+	u *url.URL,
+	gatewayRaw string,
+	allowPrivate bool,
+) (string, error) {
+	if u.User != nil {
+		return "", errors.New("userinfo is not allowed")
+	}
+	if u.RawQuery != "" {
+		return "", errors.New("query is not allowed in IPFS URL")
+	}
+	if u.Fragment != "" {
+		return "", errors.New("fragment is not allowed in IPFS URL")
+	}
+	cid, pathSegments, err := parseIPFSPath(u)
+	if err != nil {
+		return "", err
+	}
+	gateway, err := url.Parse(gatewayRaw)
+	if err != nil {
+		return "", fmt.Errorf("parse IPFS gateway URL: %w", err)
+	}
+	if err := validateURL(gatewayRaw, allowPrivate); err != nil {
+		return "", fmt.Errorf("IPFS gateway URL: %w", err)
+	}
+	if gateway.RawQuery != "" {
+		return "", errors.New("IPFS gateway query is not allowed")
+	}
+	if gateway.Fragment != "" {
+		return "", errors.New("IPFS gateway fragment is not allowed")
+	}
+	basePath := strings.TrimRight(gateway.Path, "/")
+	if basePath == "" {
+		basePath = "/ipfs"
+	}
+	segments := append([]string{cid}, pathSegments...)
+	gateway.Path = basePath + "/" + strings.Join(segments, "/")
+	return gateway.String(), nil
+}
+
+func parseIPFSPath(u *url.URL) (string, []string, error) {
+	var rawPath string
+	switch {
+	case u.Opaque != "":
+		rawPath = u.Opaque
+	case u.Host != "" && !strings.EqualFold(u.Host, "ipfs"):
+		rawPath = strings.TrimRight(u.Host, "/")
+		if u.Path != "" {
+			rawPath += "/" + strings.TrimLeft(u.Path, "/")
+		}
+	default:
+		rawPath = strings.TrimLeft(u.Path, "/")
+	}
+	parts, err := cleanIPFSPathSegments(rawPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(parts) > 0 && strings.EqualFold(parts[0], "ipfs") {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return "", nil, errors.New("IPFS CID is required")
+	}
+	cid := parts[0]
+	if err := validateIPFSCID(cid); err != nil {
+		return "", nil, err
+	}
+	return cid, parts[1:], nil
+}
+
+func cleanIPFSPathSegments(rawPath string) ([]string, error) {
+	rawPath = strings.Trim(rawPath, "/")
+	if rawPath == "" {
+		return nil, nil
+	}
+	rawParts := strings.Split(rawPath, "/")
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		if part == "" {
+			return nil, errors.New("empty IPFS path segment")
+		}
+		if part == "." || part == ".." {
+			return nil, fmt.Errorf("invalid IPFS path segment %q", part)
+		}
+		for _, r := range part {
+			if r < 0x20 || r == 0x7f {
+				return nil, errors.New("IPFS path contains control character")
+			}
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+func validateIPFSCID(cidStr string) error {
+	if cidStr == "" {
+		return errors.New("IPFS CID is required")
+	}
+	if len(cidStr) > 256 {
+		return errors.New("IPFS CID is too long")
+	}
+	if _, err := cidlib.Decode(cidStr); err != nil {
+		return fmt.Errorf("invalid IPFS CID: %w", err)
+	}
+	return nil
+}
+
+type restrictedDialer struct {
+	dialer       *net.Dialer
+	allowPrivate bool
+}
+
+func (d *restrictedDialer) DialContext(
+	ctx context.Context,
+	network string,
+	address string,
+) (net.Conn, error) {
+	if d.allowPrivate {
+		return d.dialer.DialContext(ctx, network, address)
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if isBlockedHost(host) {
+		return nil, fmt.Errorf("host %q is not allowed", host)
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no addresses resolved for host %q", host)
+	}
+	for _, addr := range addrs {
+		if isBlockedIP(addr.IP) {
+			return nil, fmt.Errorf("resolved IP %s is not allowed", addr.IP)
+		}
+	}
+	var lastErr error
+	for _, addr := range addrs {
+		target := net.JoinHostPort(addr.IP.String(), port)
+		conn, err := d.dialer.DialContext(ctx, network, target)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errors.New("dial failed")
+	}
+	return nil, lastErr
+}
+
+func isBlockedHost(host string) bool {
+	h := strings.TrimSuffix(strings.ToLower(host), ".")
+	return h == "localhost" || strings.HasSuffix(h, ".localhost")
+}
+
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return ip.IsUnspecified() ||
+		ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		isSpecialUseIPv4(ip)
+}
+
+func isSpecialUseIPv4(ip net.IP) bool {
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	// RFC 6598 carrier-grade NAT and documentation ranges are not routable
+	// public internet targets and should not be fetched from ledger URLs.
+	return v4[0] == 100 && v4[1]&0xc0 == 64 ||
+		v4[0] == 192 && v4[1] == 0 && v4[2] == 0 ||
+		v4[0] == 192 && v4[1] == 0 && v4[2] == 2 ||
+		v4[0] == 198 && (v4[1] == 18 || v4[1] == 19) ||
+		v4[0] == 198 && v4[1] == 51 && v4[2] == 100 ||
+		v4[0] == 203 && v4[1] == 0 && v4[2] == 113 ||
+		v4[0] >= 240 ||
+		v4[0] == 255 && v4[1] == 255 &&
+			v4[2] == 255 && v4[3] == 255
+}

--- a/internal/offchainmetadata/fetcher_test.go
+++ b/internal/offchainmetadata/fetcher_test.go
@@ -1,0 +1,525 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package offchainmetadata
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/blake2b"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type fakeStore struct{}
+
+func (fakeStore) EnsureOffchainMetadataPointers(
+	context.Context,
+	time.Time,
+	types.Txn,
+) (int, error) {
+	return 0, nil
+}
+
+func (fakeStore) GetOffchainMetadataFetchBatch(
+	context.Context,
+	int,
+	time.Time,
+	types.Txn,
+) ([]models.OffchainMetadata, error) {
+	return nil, nil
+}
+
+func (fakeStore) SetOffchainMetadataFetchResult(
+	context.Context,
+	*models.OffchainMetadata,
+	types.Txn,
+) error {
+	return nil
+}
+
+type batchStore struct {
+	fakeStore
+	batch   []models.OffchainMetadata
+	results []models.OffchainMetadata
+}
+
+func (s *batchStore) GetOffchainMetadataFetchBatch(
+	context.Context,
+	int,
+	time.Time,
+	types.Txn,
+) ([]models.OffchainMetadata, error) {
+	return append([]models.OffchainMetadata(nil), s.batch...), nil
+}
+
+func (s *batchStore) SetOffchainMetadataFetchResult(
+	_ context.Context,
+	doc *models.OffchainMetadata,
+	_ types.Txn,
+) error {
+	s.results = append(s.results, *doc)
+	return nil
+}
+
+type cancelCheckStore struct {
+	called bool
+}
+
+func (s *cancelCheckStore) EnsureOffchainMetadataPointers(
+	context.Context,
+	time.Time,
+	types.Txn,
+) (int, error) {
+	s.called = true
+	return 0, nil
+}
+
+func (s *cancelCheckStore) GetOffchainMetadataFetchBatch(
+	context.Context,
+	int,
+	time.Time,
+	types.Txn,
+) ([]models.OffchainMetadata, error) {
+	s.called = true
+	return nil, nil
+}
+
+func (s *cancelCheckStore) SetOffchainMetadataFetchResult(
+	context.Context,
+	*models.OffchainMetadata,
+	types.Txn,
+) error {
+	s.called = true
+	return nil
+}
+
+func TestFetchOneStoresVerifiedContent(t *testing.T) {
+	body := []byte(`{"name":"Test Pool"}`)
+	hash := blake2b.Sum256(body)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		},
+	))
+	t.Cleanup(server.Close)
+
+	fetcher, err := New(Config{
+		Store:                 fakeStore{},
+		HTTPClient:            server.Client(),
+		AllowPrivateAddresses: true,
+	})
+	require.NoError(t, err)
+	now := time.Unix(100, 0).UTC()
+	fetcher.now = func() time.Time { return now }
+
+	doc := models.OffchainMetadata{
+		URL:  server.URL,
+		Hash: hash[:],
+	}
+	fetcher.fetchOne(context.Background(), &doc)
+
+	require.Equal(t, models.OffchainMetadataStatusFetched, doc.Status)
+	require.Equal(t, body, doc.Content)
+	require.Equal(t, hash[:], doc.BodyHash)
+	require.Equal(t, "application/json", doc.ContentType)
+	require.Equal(t, uint(1), doc.FetchAttempts)
+	require.Equal(t, uint(http.StatusOK), doc.LastHTTPStatus)
+	require.NotNil(t, doc.FetchedAt)
+	require.True(t, doc.FetchedAt.Equal(now))
+	require.Nil(t, doc.NextFetchAfter)
+	require.Empty(t, doc.LastError)
+}
+
+func TestFetchOneStoresVerifiedIPFSContent(t *testing.T) {
+	body := []byte(`{"abstract":"Proposal metadata"}`)
+	hash := blake2b.Sum256(body)
+	requestedPath := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			requestedPath <- r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		},
+	))
+	t.Cleanup(server.Close)
+
+	fetcher, err := New(Config{
+		Store:                 fakeStore{},
+		HTTPClient:            server.Client(),
+		IPFSGatewayURL:        server.URL + "/ipfs/",
+		AllowPrivateAddresses: true,
+	})
+	require.NoError(t, err)
+	now := time.Unix(150, 0).UTC()
+	fetcher.now = func() time.Time { return now }
+
+	doc := models.OffchainMetadata{
+		URL:  "ipfs://bafkqaaa/proposal.json",
+		Hash: hash[:],
+	}
+	fetcher.fetchOne(context.Background(), &doc)
+
+	select {
+	case path := <-requestedPath:
+		require.Equal(t, "/ipfs/bafkqaaa/proposal.json", path)
+	default:
+		require.Fail(t, "expected IPFS gateway request")
+	}
+	require.Equal(t, models.OffchainMetadataStatusFetched, doc.Status)
+	require.Equal(t, body, doc.Content)
+	require.Equal(t, hash[:], doc.BodyHash)
+	require.Equal(t, "application/json", doc.ContentType)
+	require.Equal(t, uint(1), doc.FetchAttempts)
+	require.Equal(t, uint(http.StatusOK), doc.LastHTTPStatus)
+	require.NotNil(t, doc.FetchedAt)
+	require.True(t, doc.FetchedAt.Equal(now))
+	require.Nil(t, doc.NextFetchAfter)
+	require.Empty(t, doc.LastError)
+}
+
+func TestResolveFetchURLAcceptsBase64URLCID(t *testing.T) {
+	cidStr := "uAVUSIGZoeq34Yr13bI_Bi46fjiAIlxSFbuIzs5AqWR0NXykl"
+
+	resolved, err := resolveFetchURL(
+		"ipfs://"+cidStr+"/metadata.json",
+		"https://gateway.example/ipfs/",
+		true,
+	)
+
+	require.NoError(t, err)
+	require.Contains(t, cidStr, "_")
+	require.Contains(t, resolved, cidStr+"/metadata.json")
+}
+
+func TestFetchOneSanitizesContentType(t *testing.T) {
+	testCases := []struct {
+		name         string
+		responseType string
+		expected     string
+	}{
+		{
+			name:         "html is not stored verbatim",
+			responseType: "text/html; charset=utf-8",
+			expected:     "application/octet-stream",
+		},
+		{
+			name:         "json parameters are dropped",
+			responseType: "application/json; charset=utf-8",
+			expected:     "application/json",
+		},
+		{
+			name:         "media type is lowercased",
+			responseType: "APPLICATION/JSON",
+			expected:     "application/json",
+		},
+		{
+			name:         "json-ld is allowed",
+			responseType: "application/ld+json",
+			expected:     "application/ld+json",
+		},
+		{
+			name:         "plain text is allowed",
+			responseType: "text/plain; charset=utf-8",
+			expected:     "text/plain",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"name":"Test Pool"}`)
+			hash := blake2b.Sum256(body)
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", tc.responseType)
+					_, _ = w.Write(body)
+				},
+			))
+			t.Cleanup(server.Close)
+
+			fetcher, err := New(Config{
+				Store:                 fakeStore{},
+				HTTPClient:            server.Client(),
+				AllowPrivateAddresses: true,
+			})
+			require.NoError(t, err)
+
+			doc := models.OffchainMetadata{
+				URL:  server.URL,
+				Hash: hash[:],
+			}
+			fetcher.fetchOne(context.Background(), &doc)
+
+			require.Equal(t, models.OffchainMetadataStatusFetched, doc.Status)
+			require.Equal(t, tc.expected, doc.ContentType)
+		})
+	}
+}
+
+func TestFetchOneRejectsHashMismatch(t *testing.T) {
+	body := []byte(`{"name":"bad"}`)
+	wrongHash := blake2b.Sum256([]byte("expected"))
+	actualHash := blake2b.Sum256(body)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(body)
+		},
+	))
+	t.Cleanup(server.Close)
+
+	fetcher, err := New(Config{
+		Store:                 fakeStore{},
+		HTTPClient:            server.Client(),
+		AllowPrivateAddresses: true,
+	})
+	require.NoError(t, err)
+	now := time.Unix(200, 0).UTC()
+	fetcher.now = func() time.Time { return now }
+
+	doc := models.OffchainMetadata{
+		URL:  server.URL,
+		Hash: wrongHash[:],
+	}
+	fetcher.fetchOne(context.Background(), &doc)
+
+	require.Equal(t, models.OffchainMetadataStatusFailed, doc.Status)
+	require.Contains(t, doc.LastError, "metadata hash mismatch")
+	require.Empty(t, doc.Content)
+	require.Equal(t, actualHash[:], doc.BodyHash)
+	require.NotNil(t, doc.NextFetchAfter)
+	require.True(t, doc.NextFetchAfter.After(now))
+}
+
+func TestFetchOneRejectsPrivateURLByDefault(t *testing.T) {
+	body := []byte(`{"name":"local"}`)
+	hash := blake2b.Sum256(body)
+	fetcher, err := New(Config{
+		Store: fakeStore{},
+	})
+	require.NoError(t, err)
+	now := time.Unix(300, 0).UTC()
+	fetcher.now = func() time.Time { return now }
+
+	doc := models.OffchainMetadata{
+		URL:  "http://127.0.0.1/metadata.json",
+		Hash: hash[:],
+	}
+	fetcher.fetchOne(context.Background(), &doc)
+
+	require.Equal(t, models.OffchainMetadataStatusFailed, doc.Status)
+	require.Contains(t, doc.LastError, "not allowed")
+	require.Empty(t, doc.Content)
+}
+
+func TestNewSecuresCustomHTTPClientRedirects(t *testing.T) {
+	fetcher, err := New(Config{
+		Store: fakeStore{},
+		HTTPClient: &http.Client{
+			Transport: http.DefaultTransport,
+		},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://127.0.0.1/metadata.json",
+		nil,
+	)
+	require.NoError(t, err)
+	viaReq, err := http.NewRequest(
+		http.MethodGet,
+		"http://metadata.example/pool.json",
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = fetcher.client.CheckRedirect(req, []*http.Request{viaReq})
+	require.ErrorContains(t, err, "not allowed")
+}
+
+func TestNewSecuresCustomHTTPClientTransportDialers(t *testing.T) {
+	customDialCalled := false
+	customDial := func(context.Context, string, string) (net.Conn, error) {
+		customDialCalled = true
+		return nil, errors.New("custom dial should not be used")
+	}
+	customDialNoContext := func(string, string) (net.Conn, error) {
+		customDialCalled = true
+		return nil, errors.New("custom dial should not be used")
+	}
+	fetcher, err := New(Config{
+		Store: fakeStore{},
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy:          http.ProxyFromEnvironment,
+				Dial:           customDialNoContext,
+				DialContext:    customDial,
+				DialTLS:        customDialNoContext,
+				DialTLSContext: customDial,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	transport, ok := fetcher.client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Nil(t, transport.Proxy)
+	require.Nil(t, transport.Dial)
+	require.Nil(t, transport.DialTLS)
+	require.Nil(t, transport.DialTLSContext)
+	_, err = transport.DialContext(
+		context.Background(),
+		"tcp",
+		"127.0.0.1:80",
+	)
+	require.ErrorContains(t, err, "not allowed")
+	require.False(t, customDialCalled)
+}
+
+func TestNewRejectsCustomRoundTripperWhenPrivateAddressesBlocked(t *testing.T) {
+	_, err := New(Config{
+		Store: fakeStore{},
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+				}, nil
+			}),
+		},
+	})
+
+	require.ErrorContains(t, err, "cannot enforce private-address restrictions")
+}
+
+func TestRunOnceSkipsFetchResultWhenCanceled(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(
+		func(_ http.ResponseWriter, r *http.Request) {
+			close(requestStarted)
+			<-r.Context().Done()
+		},
+	))
+	t.Cleanup(server.Close)
+
+	hash := blake2b.Sum256([]byte("metadata"))
+	store := &batchStore{
+		batch: []models.OffchainMetadata{
+			{
+				ID:   1,
+				URL:  server.URL,
+				Hash: hash[:],
+			},
+		},
+	}
+	fetcher, err := New(Config{
+		Store:                 store,
+		HTTPClient:            server.Client(),
+		AllowPrivateAddresses: true,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fetcher.runOnce(ctx)
+	}()
+
+	testutil.RequireReceive(
+		t,
+		requestStarted,
+		time.Second,
+		"off-chain metadata request should start",
+	)
+	cancel()
+	testutil.RequireReceive(
+		t,
+		done,
+		time.Second,
+		"runOnce should return after parent context cancellation",
+	)
+	require.Empty(t, store.results)
+}
+
+func TestRunOnceSkipsStoreWhenCanceled(t *testing.T) {
+	store := &cancelCheckStore{}
+	fetcher, err := New(Config{
+		Store: store,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fetcher.runOnce(ctx)
+
+	require.False(t, store.called)
+}
+
+func TestReadLimitedRejectsOversizeBody(t *testing.T) {
+	_, err := readLimited(bytes.NewReader([]byte("abcd")), 3)
+	require.ErrorContains(t, err, "exceeds 3 bytes")
+}
+
+func TestResolveIPFSURLUsesGatewayIPFSPath(t *testing.T) {
+	fetchURL, err := resolveFetchURL(
+		"ipfs://bafkqaaa/some file.json",
+		"https://gateway.example",
+		false,
+	)
+
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"https://gateway.example/ipfs/bafkqaaa/some%20file.json",
+		fetchURL,
+	)
+}
+
+func TestResolveIPFSURLRejectsPathTraversal(t *testing.T) {
+	_, err := resolveFetchURL(
+		"ipfs://bafkqaaa/../secret.json",
+		"https://gateway.example/ipfs/",
+		false,
+	)
+
+	require.ErrorContains(t, err, "invalid IPFS path segment")
+}
+
+func TestResolveFetchURLRejectsBroadcastIPv4(t *testing.T) {
+	_, err := resolveFetchURL(
+		"http://255.255.255.255/metadata.json",
+		"https://gateway.example/ipfs/",
+		false,
+	)
+
+	require.ErrorContains(t, err, "not allowed")
+}

--- a/node.go
+++ b/node.go
@@ -35,6 +35,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/historyexpiry"
+	"github.com/blinklabs-io/dingo/internal/offchainmetadata"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	"github.com/blinklabs-io/dingo/ledger/leader"
@@ -67,6 +68,7 @@ type Node struct {
 	historyExpiry                    *historyexpiry.Pruner
 	blockfrostAPI                    *blockfrost.Blockfrost
 	meshAPI                          *mesh.Server
+	offchainMetadataFetcher          *offchainmetadata.Fetcher
 	ouroboros                        *ouroborosPkg.Ouroboros
 	blockForger                      *forging.BlockForger
 	leaderElection                   *leader.Election
@@ -940,6 +942,36 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 
 	if n.config.storageMode.IsAPI() {
+		fetcher, err := offchainmetadata.New(
+			offchainmetadata.Config{
+				Logger:                n.config.logger,
+				Store:                 n.db.Metadata(),
+				HTTPClient:            n.config.offchainMetadata.HTTPClient,
+				Interval:              n.config.offchainMetadata.Interval,
+				RequestTimeout:        n.config.offchainMetadata.RequestTimeout,
+				UserAgent:             n.config.offchainMetadata.UserAgent,
+				IPFSGatewayURL:        n.config.offchainMetadata.IPFSGatewayURL,
+				BatchSize:             n.config.offchainMetadata.BatchSize,
+				MaxBytes:              n.config.offchainMetadata.MaxBytes,
+				AllowPrivateAddresses: n.config.offchainMetadata.AllowPrivateAddresses,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("creating off-chain metadata fetcher: %w", err)
+		}
+		n.offchainMetadataFetcher = fetcher
+		if err := n.offchainMetadataFetcher.Start(n.ctx); err != nil { //nolint:contextcheck
+			return fmt.Errorf("starting off-chain metadata fetcher: %w", err)
+		}
+		started = append(started, func() { //nolint:contextcheck
+			if err := n.offchainMetadataFetcher.Stop(context.Background()); err != nil {
+				n.config.logger.Error(
+					"failed to stop off-chain metadata fetcher during cleanup",
+					"error",
+					err,
+				)
+			}
+		})
 		started = append(started, n.startDeferredIndexMaintenance())
 	}
 

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -169,6 +169,15 @@ func (n *Node) shutdown() error {
 		}
 	}
 
+	if n.offchainMetadataFetcher != nil {
+		if stopErr := n.offchainMetadataFetcher.Stop(ctx); stopErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("off-chain metadata fetcher shutdown: %w", stopErr),
+			)
+		}
+	}
+
 	n.config.logger.Info(
 		"shutdown phase 1 complete",
 		"elapsed", time.Since(shutdownStart).Round(time.Millisecond),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an off-chain metadata fetcher that discovers on-chain URL/hash pointers and caches hash-verified documents in `offchain_metadata`, improving API reads with local copies, strict network limits, and CID-validated IPFS support. Runs only in API mode and is configurable via YAML, env vars, and CLI flags.

- **New Features**
  - Starts `internal/offchainmetadata.Fetcher` in `storageMode: api` and integrates it into node startup and graceful shutdown.
  - Discovers pointers from pools, DReps (registrations/updates), governance proposals/votes, constitutions, and committee resignations.
  - Adds `offchain_metadata` table and `MetadataStore` APIs to seed pointers, claim due rows with a short lease, persist results, and fetch by `(sourceType, url, hash)`.
  - Supports HTTP(S) and `ipfs://` via a configurable gateway (default `https://gateway.pinata.cloud/ipfs/`); validates IPFS CIDs; verifies Blake2b-256; caps bytes, limits redirects, blocks localhost/private/link-local/multicast by default, sanitizes response Content-Type, respects cancellations without marking failures, and retries with backoff.
  - Configurable via `offchainMetadata` YAML, `DINGO_OFFCHAIN_METADATA_*` env vars, and `--offchain-metadata-*` flags (interval, request timeout, user agent, IPFS gateway URL, batch size, max bytes, allow private addresses).

- **Migration**
  - No manual steps; `offchain_metadata` auto-migrates.
  - Runs only in `storageMode: api`.

<sup>Written for commit 2c7ae14011cbed651e9ed0d1e398230f618e2913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added off-chain metadata caching in API mode with asynchronous discovery, secure fetching (IPFS gateway support, network/address restrictions, size limits, and hash verification), and lifecycle integration into node startup/shutdown.

* **Documentation**
  * Updated architecture and database docs describing discovery behavior, cache schema, validation, retry/diagnostic state, and startup/shutdown flow.

* **Tests**
  * Added unit and integration tests covering pointer discovery, fetch/verify flows, error handling, cancellation, and IPFS handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->