### PR TITLE
fix: chainsync stale peer handling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1036,6 +1036,18 @@ a dial loop exited early. Gossip churn never demotes the peer holding the last
 eligible upstream connection, so routine churn cannot leave the node without a
 chainsync source.
 
+Reconnect backoff after short-lived sessions escalates exponentially. The
+reconnect goroutine consumes and zeroes the stored delay before dialing, so
+the close handler derives the next rung from a count of consecutive
+short-lived outbound sessions (1s doubling to a 128s cap) rather than from
+the stored delay; a stable session resets the count, as does an inbound
+connection from a topology peer, which proves reachability. Separately, chainsync
+resync reasons that indicate a peer chain we cannot follow (rollback or fork
+resolution exceeding the security parameter K, and both Mithril
+trust-boundary reasons) place the peer on the deny list for a cooldown in
+addition to closing the connection, so the node does not redial a peer that
+will deterministically be rejected again moments later.
+
 Topology configuration is loaded from an explicit topology file when provided,
 otherwise from the embedded `network/topology.json` for built-in networks,
 falling back to the legacy network bootstrap-peer list only when no embedded
@@ -1148,6 +1160,18 @@ snapshot manager to ensure the initial stake snapshot state before starting the
 client APIs. If the imported database already contains a non-empty Mark snapshot
 window for the current epoch, N-1, and N-2, the snapshot manager reuses that
 window instead of recalculating stake distribution from live UTxO state.
+
+The Mithril snapshot also acts as the local trust anchor during live
+chainsync. The ledger refuses any rollback below the imported ledger slot
+(`mithrilLedgerSlot`), since blocks at or below that boundary were certified
+as a single ledger state and intermediate UTxO states for a replacement fork
+cannot be reconstructed. The boundary block is always offered as an intersect
+point, so the peer's reported tip classifies the refusal: a peer whose own
+tip is below the boundary is treated as stale (it is simply behind and
+matched an old rung of the intersect ladder), while a peer claiming a tip at
+or above the boundary that still demands a rollback below it is rejected as
+genuinely divergent. Both classifications close the connection for a fresh
+intersect and deny the peer for a cooldown via peer governance.
 
 In API storage mode, the SQLite metadata plugin can defer selected query indexes
 during bulk load. Deferred indexes are classified as critical or lazy in

--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -33,6 +33,7 @@ const (
 	ChainsyncResyncReasonPersistentFork               = "persistent chain fork"
 	ChainsyncResyncReasonRollbackExceedsK             = "rollback exceeds security parameter K"
 	ChainsyncResyncReasonRollbackExceedsMithril       = "rollback exceeds Mithril trust boundary"
+	ChainsyncResyncReasonPeerTipBehindMithril         = "peer tip behind Mithril trust boundary"
 	ChainsyncResyncReasonForkResolutionExceedsK       = "fork resolution exceeds security parameter K"
 	ChainsyncResyncReasonLocalLedgerRollback          = "local ledger rollback"
 	ChainsyncResyncReasonLiveTxValidationRecovery     = "live tx validation recovery"

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1304,16 +1304,45 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			// The Mithril snapshot is the local trust anchor. Blocks at
 			// or below its boundary were certified as a single ledger
 			// state, so we cannot reconstruct intermediate UTxO states
-			// for a replacement fork below that point. Reject the peer
-			// chain and force a fresh intersection instead.
-			ls.config.Logger.Error(
-				"chainsync rollback exceeds Mithril trust boundary, rejecting peer chain",
-				"component", "ledger",
-				"slot", e.Point.Slot,
-				"hash", hex.EncodeToString(e.Point.Hash),
-				"mithril_ledger_slot", ls.mithrilLedgerSlot,
-				"connection_id", e.ConnectionId.String(),
-			)
+			// for a replacement fork below that point. Refuse the
+			// rollback and force a fresh intersection instead.
+			//
+			// The peer's reported tip distinguishes two situations that
+			// both surface here as a rollback below the boundary:
+			//   - tip below the boundary: the peer is simply behind
+			//     (still syncing or stuck) and its FindIntersect matched
+			//     an old rung of our intersect ladder — stale, not a
+			//     competing fork;
+			//   - tip at/above the boundary: the peer's chain does not
+			//     contain our certified boundary block (always offered
+			//     as an intersect point), so it genuinely diverges below
+			//     the trust anchor.
+			// A zero tip means the peer's tip is unknown; treat it as
+			// divergent to fail safe.
+			reason := event.ChainsyncResyncReasonRollbackExceedsMithril
+			peerTipSlot := e.Tip.Point.Slot
+			if peerTipSlot > 0 && peerTipSlot < ls.mithrilLedgerSlot {
+				reason = event.ChainsyncResyncReasonPeerTipBehindMithril
+				ls.config.Logger.Warn(
+					"chainsync peer tip behind Mithril trust boundary, treating peer chain as stale",
+					"component", "ledger",
+					"slot", e.Point.Slot,
+					"hash", hex.EncodeToString(e.Point.Hash),
+					"peer_tip_slot", peerTipSlot,
+					"mithril_ledger_slot", ls.mithrilLedgerSlot,
+					"connection_id", e.ConnectionId.String(),
+				)
+			} else {
+				ls.config.Logger.Error(
+					"chainsync rollback exceeds Mithril trust boundary, rejecting peer chain",
+					"component", "ledger",
+					"slot", e.Point.Slot,
+					"hash", hex.EncodeToString(e.Point.Hash),
+					"peer_tip_slot", peerTipSlot,
+					"mithril_ledger_slot", ls.mithrilLedgerSlot,
+					"connection_id", e.ConnectionId.String(),
+				)
+			}
 			ls.resetChainsyncResyncState()
 			ls.chainsyncState = SyncingChainsyncState
 			if ls.config.EventBus != nil {
@@ -1323,7 +1352,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 						event.ChainsyncResyncEventType,
 						event.ChainsyncResyncEvent{
 							ConnectionId: e.ConnectionId,
-							Reason:       event.ChainsyncResyncReasonRollbackExceedsMithril,
+							Reason:       reason,
 						},
 					),
 				)

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1679,3 +1679,128 @@ func testHashBytes(seed string) []byte {
 	sum := sha256.Sum256([]byte(seed))
 	return append([]byte(nil), sum[:]...)
 }
+
+// A peer whose own reported tip is below the Mithril trust boundary is
+// merely behind (still syncing or stuck) — its FindIntersect matched an
+// old rung of our intersect ladder, which is not evidence of a competing
+// fork. The rollback must still be refused, but the resync reason must
+// classify the peer as stale rather than divergent so peer governance
+// can back off instead of treating it as hostile.
+func TestHandleEventChainsyncRollbackClassifiesStalePeerBelowMithrilBoundary(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+	fixture.ls.mithrilLedgerSlot = fixture.currentTip.Point.Slot
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+			// The peer's own tip sits below our trust boundary.
+			Tip: fixture.ancestorTip,
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
+
+	e := testutil.RequireReceive(
+		t,
+		resyncCh,
+		time.Second,
+		"expected stale-peer resync event",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonPeerTipBehindMithril,
+		e.Reason,
+	)
+	assert.Equal(t, fixture.connId, e.ConnectionId)
+}
+
+// A peer that claims a tip at or above the Mithril trust boundary yet
+// asks us to roll back below it does not carry our certified boundary
+// block (always offered as an intersect point), so its chain genuinely
+// diverges below the trust anchor and must be rejected as divergent.
+func TestHandleEventChainsyncRollbackRejectsDivergentPeerTipAboveMithrilBoundary(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	fixture.ls.config.EventBus = bus
+	fixture.ls.mithrilLedgerSlot = fixture.currentTip.Point.Slot
+
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	err := fixture.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        fixture.ancestorTip.Point,
+			// The peer claims a tip past our boundary while demanding a
+			// rollback below it.
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					fixture.currentTip.Point.Slot+10,
+					testHashBytes("divergent-peer-tip"),
+				),
+				BlockNumber: fixture.currentTip.BlockNumber + 1,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
+
+	e := testutil.RequireReceive(
+		t,
+		resyncCh,
+		time.Second,
+		"expected divergent-peer resync event",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonRollbackExceedsMithril,
+		e.Reason,
+	)
+	assert.Equal(t, fixture.connId, e.ConnectionId)
+}

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -154,6 +154,7 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 		event.ChainsyncResyncReasonPersistentFork,
 		event.ChainsyncResyncReasonRollbackExceedsK,
 		event.ChainsyncResyncReasonRollbackExceedsMithril,
+		event.ChainsyncResyncReasonPeerTipBehindMithril,
 		event.ChainsyncResyncReasonForkResolutionExceedsK,
 		event.ChainsyncResyncReasonRollbackLoop:
 		return true
@@ -165,7 +166,9 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 func chainsyncResyncDeniesPeer(reason string) bool {
 	switch reason {
 	case event.ChainsyncResyncReasonRollbackExceedsK,
-		event.ChainsyncResyncReasonForkResolutionExceedsK:
+		event.ChainsyncResyncReasonForkResolutionExceedsK,
+		event.ChainsyncResyncReasonRollbackExceedsMithril,
+		event.ChainsyncResyncReasonPeerTipBehindMithril:
 		return true
 	default:
 		return false
@@ -184,7 +187,7 @@ func (o *Ouroboros) denyDivergentChainsyncPeer(
 	address := connId.RemoteAddr.String()
 	o.PeerGov.DenyPeer(address, chainsyncDivergentPeerCooldown)
 	o.config.Logger.Warn(
-		"temporarily denying divergent chainsync peer",
+		"temporarily denying chainsync peer whose chain we cannot follow",
 		"connection_id", connId.String(),
 		"address", address,
 		"reason", reason,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1597,3 +1597,53 @@ func TestChainsyncServerFindIntersect_NormalPointListAccepted(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
+// Both Mithril-boundary rejection reasons must close the connection for a
+// fresh intersect AND deny the peer for a cooldown. Without the deny, a
+// peer whose chain is refused at the trust boundary is redialed roughly
+// every backoff interval and rejected ~600ms later, forever.
+func TestChainsyncResyncMithrilReasonsDenyPeerAndRequireFreshConnection(
+	t *testing.T,
+) {
+	tests := []struct {
+		reason         string
+		wantFresh      bool
+		wantDeniesPeer bool
+	}{
+		{
+			reason:         event.ChainsyncResyncReasonRollbackExceedsMithril,
+			wantFresh:      true,
+			wantDeniesPeer: true,
+		},
+		{
+			reason:         event.ChainsyncResyncReasonPeerTipBehindMithril,
+			wantFresh:      true,
+			wantDeniesPeer: true,
+		},
+		// Existing behavior pins
+		{
+			reason:         event.ChainsyncResyncReasonRollbackExceedsK,
+			wantFresh:      true,
+			wantDeniesPeer: true,
+		},
+		{
+			reason:         event.ChainsyncResyncReasonLocalTipPlateau,
+			wantFresh:      true,
+			wantDeniesPeer: false,
+		},
+	}
+	for _, tt := range tests {
+		if got := chainsyncResyncRequiresFreshConnection(tt.reason); got != tt.wantFresh {
+			t.Errorf(
+				"chainsyncResyncRequiresFreshConnection(%q) = %v, want %v",
+				tt.reason, got, tt.wantFresh,
+			)
+		}
+		if got := chainsyncResyncDeniesPeer(tt.reason); got != tt.wantDeniesPeer {
+			t.Errorf(
+				"chainsyncResyncDeniesPeer(%q) = %v, want %v",
+				tt.reason, got, tt.wantDeniesPeer,
+			)
+		}
+	}
+}

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -57,6 +57,20 @@ func isExpectedNetworkDialError(err error) bool {
 		strings.Contains(msg, "timeout waiting on transition")
 }
 
+// shortLivedReconnectDelay returns the exponential backoff rung for the
+// given count of consecutive short-lived outbound sessions, capped at
+// maxReconnectDelay.
+func shortLivedReconnectDelay(count uint32) time.Duration {
+	delay := initialReconnectDelay
+	for i := uint32(1); i < count; i++ {
+		delay *= reconnectBackoffFactor
+		if delay >= maxReconnectDelay {
+			return maxReconnectDelay
+		}
+	}
+	return delay
+}
+
 // isAddrInUseError returns true if the error is a "cannot assign
 // requested address" or EADDRINUSE, indicating a TCP 4-tuple collision.
 func isAddrInUseError(err error) bool {
@@ -624,6 +638,7 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 	if tmpPeer.Source != PeerSourceInboundConn {
 		tmpPeer.ReconnectDelay = 0
 		tmpPeer.ReconnectCount = 0
+		tmpPeer.OutboundShortLivedCount = 0
 	}
 	selectionEvents = p.appendChainSelectionEventsLocked(
 		selectionEvents,
@@ -735,10 +750,18 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 					// Connection was stable, reset backoff
 					peer.ReconnectCount = 0
 					peer.ReconnectDelay = 0
+					peer.OutboundShortLivedCount = 0
 				} else if !peer.ConnectedAt.IsZero() {
-					// Short-lived connection: apply exponential backoff
+					// Short-lived connection: apply exponential backoff.
+					// The stored delay is usually zero here because the
+					// reconnect goroutine consumes and zeroes it before
+					// dialing, so derive the rung from the consecutive
+					// short-lived session count instead.
+					peer.OutboundShortLivedCount++
 					if peer.ReconnectDelay == 0 {
-						peer.ReconnectDelay = initialReconnectDelay
+						peer.ReconnectDelay = shortLivedReconnectDelay(
+							peer.OutboundShortLivedCount,
+						)
 					} else if peer.ReconnectDelay < maxReconnectDelay {
 						peer.ReconnectDelay *= reconnectBackoffFactor
 						if peer.ReconnectDelay > maxReconnectDelay {

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -500,3 +500,70 @@ func outboundTestConnId() ouroboros.ConnectionId {
 		},
 	}
 }
+
+// Repeated short-lived sessions must keep escalating the reconnect delay
+// even though the reconnect goroutine consumes and zeroes ReconnectDelay
+// before each redial. Without escalation a peer that accepts connections
+// but is rejected ~600ms later (e.g. its chain fails the Mithril trust
+// boundary check) is redialed every ~2s forever.
+func TestHandleConnectionClosedEvent_ShortLivedBackoffEscalatesAfterDelayConsumed(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	connId := outboundTestConnId()
+	peer := &Peer{
+		Address:           "192.168.12.101:3003",
+		NormalizedAddress: "192.168.12.101:3003",
+		Source:            PeerSourceTopologyLocalRoot,
+		// Suppress reconnect goroutine; this test only checks close accounting.
+		Reconnecting: true,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	wantDelays := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		64 * time.Second,
+		128 * time.Second,
+		128 * time.Second, // capped at maxReconnectDelay
+	}
+	for i, want := range wantDelays {
+		// Simulate the production cycle: the reconnect goroutine consumed
+		// and zeroed the stored delay, redialed successfully, and the new
+		// session lasted well under minStableConnectionDuration.
+		pg.mu.Lock()
+		peer.ReconnectDelay = 0
+		peer.Connection = &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		}
+		peer.State = PeerStateWarm
+		peer.ConnectedAt = time.Now().Add(-600 * time.Millisecond)
+		pg.mu.Unlock()
+
+		pg.handleConnectionClosedEvent(event.NewEvent(
+			connmanager.ConnectionClosedEventType,
+			connmanager.ConnectionClosedEvent{
+				ConnectionId: connId,
+			},
+		))
+
+		pg.mu.Lock()
+		got := peer.ReconnectDelay
+		pg.mu.Unlock()
+		if got != want {
+			t.Fatalf(
+				"close %d: ReconnectDelay = %s, want %s",
+				i+1, got, want,
+			)
+		}
+	}
+}

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -92,14 +92,19 @@ type Peer struct {
 	Address            string
 	NormalizedAddress  string // Cached normalized form of Address for deduplication
 	// Performance metrics (used by the peer scoring system)
-	BlockFetchLatencyMs     float64 // Average block fetch latency in ms (EMA)
-	BlockFetchSuccessRate   float64 // Average block fetch success rate 0..1 (EMA)
-	ConnectionStability     float64 // Connection stability score 0..1
-	ReconnectDelay          time.Duration
-	ConnectedAt             time.Time // When current outbound connection was established
-	InboundConnectedAt      time.Time // When current inbound connection was established
-	PerformanceScore        float64   // Composite score from the above metrics
-	ReconnectCount          int
+	BlockFetchLatencyMs   float64 // Average block fetch latency in ms (EMA)
+	BlockFetchSuccessRate float64 // Average block fetch success rate 0..1 (EMA)
+	ConnectionStability   float64 // Connection stability score 0..1
+	ReconnectDelay        time.Duration
+	ConnectedAt           time.Time // When current outbound connection was established
+	InboundConnectedAt    time.Time // When current inbound connection was established
+	PerformanceScore      float64   // Composite score from the above metrics
+	ReconnectCount        int
+	// OutboundShortLivedCount counts consecutive short-lived outbound
+	// sessions (duration < minStableConnectionDuration). The reconnect
+	// goroutine consumes and zeroes ReconnectDelay before each redial,
+	// so this counter is what carries the backoff rung across sessions.
+	OutboundShortLivedCount uint32
 	Reconnecting            bool // Whether a reconnect goroutine is active for this peer
 	State                   PeerState
 	Source                  PeerSource

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -7376,6 +7376,57 @@ func TestHandleInboundConnection_TopologyHostMatch(t *testing.T) {
 		"event-carried IsDuplex must be recorded when no connmanager is wired")
 }
 
+// TestHandleInboundConnection_ResetsOutboundBackoff pins the invariant
+// that an inbound connection from a topology peer clears the full
+// outbound backoff state, including OutboundShortLivedCount — the
+// counter shortLivedReconnectDelay derives the backoff rung from. If
+// only ReconnectDelay/ReconnectCount were cleared, the next
+// short-lived outbound session would resume at the old elevated rung
+// instead of restarting from initialReconnectDelay.
+func TestHandleInboundConnection_ResetsOutboundBackoff(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	seedTopologyPeer(
+		pg,
+		"44.0.0.1:3001",
+		"44.0.0.1:3001",
+		"local-root-0",
+		PeerSourceTopologyLocalRoot,
+	)
+	pg.mu.Lock()
+	pg.peers[0].ReconnectDelay = 8 * time.Second
+	pg.peers[0].ReconnectCount = 3
+	pg.peers[0].OutboundShortLivedCount = 5
+	pg.mu.Unlock()
+
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr:  localAddr,
+				RemoteAddr: remoteAddr,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	peer := peers[0]
+	assert.Equal(t, time.Duration(0), peer.ReconnectDelay,
+		"inbound from topology peer must clear ReconnectDelay")
+	assert.Equal(t, 0, peer.ReconnectCount,
+		"inbound from topology peer must clear ReconnectCount")
+	assert.Equal(t, uint32(0), peer.OutboundShortLivedCount,
+		"inbound from topology peer must clear OutboundShortLivedCount so the next short-lived outbound restarts from the initial backoff rung")
+}
+
 func TestHandleInboundConnection_AmbiguousHostCreatesNewPeer(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix chainsync handling around the Mithril trust boundary to prevent redial loops and misclassifying peers. Stale peers are now distinguished from divergent ones, and short-lived sessions back off correctly.

- **Bug Fixes**
  - Ledger: refuse rollbacks below the Mithril boundary and classify by peer tip:
    - tip below boundary → `ChainsyncResyncReasonPeerTipBehindMithril` (stale)
    - tip at/above boundary or unknown (0) → `ChainsyncResyncReasonRollbackExceedsMithril` (divergent)
  - `ouroboros`: both Mithril reasons now require a fresh connection and deny the peer for a cooldown; clearer log message.
  - `peergov`: added `OutboundShortLivedCount` and exponential backoff for consecutive short-lived outbound sessions (1s → 2s → … → 128s cap) even when `ReconnectDelay` is consumed before redial; reset on stable sessions and on inbound connections from topology peers.
  - Tests: coverage for Mithril classification, deny/fresh behavior, backoff escalation with consumed delay, and inbound-reset of backoff.
  - Docs: `ARCHITECTURE.md` updated for reconnect backoff, inbound-reset behavior, and Mithril-boundary handling.

<sup>Written for commit efeb4e691eb18562d799ab53c2b66c155085f11d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced peer classification when Mithril trust boundary is crossed—now correctly identifies stale peers versus genuinely divergent chains.

* **Improvements**
  * Implemented exponential backoff for reconnection attempts following consecutive unstable sessions.
  * Strengthened peer denial mechanisms for Mithril boundary violations.

* **Documentation**
  * Architecture documentation updated with detailed behavior specifications for peer governance and Mithril bootstrap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->