### PR TITLE
chore(deps): bump gouroboros to v0.183.0 and ouroboros-mock to v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/aws/smithy-go v1.27.2
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.182.0
-	github.com/blinklabs-io/ouroboros-mock v0.12.0
+	github.com/blinklabs-io/gouroboros v0.183.0
+	github.com/blinklabs-io/ouroboros-mock v0.13.0
 	github.com/blinklabs-io/plutigo v0.1.15
 	github.com/blockfrost/blockfrost-go v0.4.0
 	github.com/btcsuite/btcd/btcutil v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -133,10 +133,10 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.182.0 h1:qZN0DCFaSmbWdI7RF9r/J5lzq88VmtdWyysiMGEjPnA=
-github.com/blinklabs-io/gouroboros v0.182.0/go.mod h1:ZiABPLvB5+7qYPB8a2WgfYNr71RfUFQME3n/O3fFv5o=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/gouroboros v0.183.0 h1:mzTJlRDgjs8YC8K1oWjxA7pXIEVefkFAV+V5xuFmiSE=
+github.com/blinklabs-io/gouroboros v0.183.0/go.mod h1:ZiABPLvB5+7qYPB8a2WgfYNr71RfUFQME3n/O3fFv5o=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=

--- a/ledger/candidate_nonce_window_test.go
+++ b/ledger/candidate_nonce_window_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
-	"github.com/blinklabs-io/gouroboros/ledger/leios"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
@@ -52,10 +52,10 @@ func shelleyGenesisCfgForNonceWindow(t *testing.T) *cardano.CardanoNodeConfig {
 //
 //   - Shelley, Allegra, Mary, Alonzo (TPraos): 3k/f
 //   - Babbage (Praos, but 3k/f for backwards compatibility): 3k/f
-//   - Conway, Leios (Praos): 4k/f
+//   - Conway, Dijkstra (Praos): 4k/f
 //
 // Each Praos era is enumerated explicitly in
-// nonceStabilityWindowKMultiplier; the Leios row here is the
+// nonceStabilityWindowKMultiplier; the Dijkstra row here is the
 // regression guard that the post-Conway Praos cohort still gets 4k/f
 // after the Babbage→Conway split moved.
 //
@@ -79,7 +79,7 @@ func TestNonceStabilityWindow_EraDispatch(t *testing.T) {
 		{name: "alonzo", eraId: alonzo.EraIdAlonzo, expectedSlot: 60},
 		{name: "babbage", eraId: babbage.EraIdBabbage, expectedSlot: 60},
 		{name: "conway", eraId: conway.EraIdConway, expectedSlot: 80},
-		{name: "leios", eraId: leios.EraIdLeios, expectedSlot: 80},
+		{name: "dijkstra", eraId: dijkstra.EraIdDijkstra, expectedSlot: 80},
 	}
 
 	for _, tc := range cases {

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
-	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -770,7 +769,7 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 func buildLeiosEB(
 	txs []MempoolTransaction,
 ) (cbor []byte, hash []byte, txRefCount int, err error) {
-	refs := make([]gleios.LeiosTransactionReference, 0, len(txs))
+	refs := make([]lcommon.LeiosTransactionReference, 0, len(txs))
 	for _, tx := range txs {
 		raw, hexErr := hex.DecodeString(tx.Hash)
 		if hexErr != nil || len(raw) != 32 {
@@ -780,7 +779,7 @@ func buildLeiosEB(
 		if sz == 0 || sz > math.MaxUint16 {
 			continue
 		}
-		refs = append(refs, gleios.LeiosTransactionReference{
+		refs = append(refs, lcommon.LeiosTransactionReference{
 			TransactionHash: lcommon.NewBlake2b256(raw),
 			TransactionSize: uint16(sz), // #nosec G115 -- bounded above
 		})
@@ -788,7 +787,7 @@ func buildLeiosEB(
 	if len(refs) == 0 {
 		return nil, nil, 0, errNoValidTxRefs
 	}
-	eb := gleios.LeiosEndorserBlock{TransactionReferences: refs}
+	eb := lcommon.LeiosEndorserBlock{TransactionReferences: refs}
 	ebCbor, marshalErr := eb.MarshalCBOR()
 	if marshalErr != nil {
 		return nil, nil, 0, fmt.Errorf("marshal leios EB: %w", marshalErr)

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -26,7 +26,6 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
-	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -71,7 +70,7 @@ func (o *Ouroboros) storeLeiosEndorserBlock(
 	if len(blockRaw) == 0 {
 		return errors.New("leios endorser block cache: empty block")
 	}
-	block, err := gleios.NewLeiosEndorserBlockFromCbor(blockRaw)
+	block, err := lcommon.NewLeiosEndorserBlockFromCbor(blockRaw)
 	if err != nil {
 		return fmt.Errorf("decode leios endorser block: %w", err)
 	}

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
-	gleios "github.com/blinklabs-io/gouroboros/ledger/leios"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
@@ -98,17 +97,17 @@ func testLeiosEndorserBlockRawWithRefs(
 	refCount int,
 ) (ocommon.Point, cbor.RawMessage) {
 	t.Helper()
-	refs := make([]gleios.LeiosTransactionReference, refCount)
+	refs := make([]lcommon.LeiosTransactionReference, refCount)
 	for refIdx := range refs {
 		var hashSeed [12]byte
 		binary.BigEndian.PutUint64(hashSeed[:8], uint64(idx))
 		binary.BigEndian.PutUint32(hashSeed[8:], uint32(refIdx))
-		refs[refIdx] = gleios.LeiosTransactionReference{
+		refs[refIdx] = lcommon.LeiosTransactionReference{
 			TransactionHash: lcommon.Blake2b256Hash(hashSeed[:]),
 			TransactionSize: uint16(refIdx + 1),
 		}
 	}
-	block := gleios.LeiosEndorserBlock{
+	block := lcommon.LeiosEndorserBlock{
 		TransactionReferences: refs,
 	}
 	raw, err := cbor.Encode(&block)


### PR DESCRIPTION
## Summary

Bumps gOuroboros `v0.182.0 → v0.183.0` and ouroboros-mock `v0.12.0 → v0.13.0`, absorbing the one breaking change in gOuroboros's range: **#1817 "remove leios as an era"**.

In v0.183.0 gOuroboros:
- moved the endorser-block types (`LeiosEndorserBlock`, `LeiosTransactionReference`, `NewLeiosEndorserBlockFromCbor`) from `ledger/leios` → `ledger/common` (shapes unchanged), and
- dropped the leios ledger-era id and its block/tx/header type constants.

## Changes

- **`ouroboros/leios_merged.go`**, **`ledger/forging/forger.go`** — repoint the three endorser-block usages from `gleios.*` to `lcommon.*` (already-imported `ledger/common`); drop the now-empty `ledger/leios` import.
- **`ledger/candidate_nonce_window_test.go`** — the era-dispatch test used the removed `leios.EraIdLeios` as the "post-Conway Praos cohort still gets 4k/f" regression guard. Replace it with **Dijkstra** — the real post-Conway era `nonceStabilityWindowKMultiplier` already enumerates (`conway, dijkstra → 4`) — which strengthens the guard (Dijkstra was previously untested).
- **`go.mod`** — bump ouroboros-mock to **v0.13.0**. v0.12.0's fixture era decoders reference the removed leios constants (`BlockTypeLeiosRanking`/`TxTypeLeios`/`BlockHeaderTypeLeios`) and fail to compile against gOuroboros v0.183.0 (this is what broke the first CI run); v0.13.0 renames them to the `*Dijkstra` constants.

No production behavior change: the endorser-block CBOR and the post-Conway 4k/f window are unchanged.

## Verification

`go build ./...`, `go vet ./...` (the full test compile that previously failed on ouroboros-mock), `gofmt`, `golangci-lint` (0), `modernize` (0), `go test -race ./ledger/...` (incl. the new `dijkstra` nonce-window subtest), the previously-failing `./chain/`, and **conformance** all pass against the released modules.

⚠️ Touches forging/leios consensus-adjacent code, so per `CLAUDE.md` it warrants a **DevNet** run before merge, even though the change is a pure import relocation (types byte-identical).

Prerequisite for **#2547** (GetAccountState), which needs v0.183.0 and stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)