### PR TITLE
fix(mithril): empty snapshot handling

### DIFF
--- a/internal/integration/mithril_test.go
+++ b/internal/integration/mithril_test.go
@@ -16,6 +16,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -77,6 +78,9 @@ func TestImportLedgerStateFromMithril(t *testing.T) {
 			},
 		},
 	)
+	if errors.Is(err, mithril.ErrNoSnapshotsAvailable) {
+		t.Skipf("Mithril aggregator has no snapshots: %v", err)
+	}
 	require.NoError(t, err, "bootstrapping from Mithril")
 	t.Logf(
 		"snapshot extracted: epoch=%d, immutable=%s",

--- a/mithril/client.go
+++ b/mithril/client.go
@@ -562,6 +562,12 @@ type NetworkConfig struct {
 	AncillaryVerificationKeyURL string
 }
 
+// ErrNoSnapshotsAvailable indicates that the aggregator responded
+// successfully but currently has no snapshots to serve.
+var ErrNoSnapshotsAvailable = errors.New(
+	"no snapshots available from aggregator",
+)
+
 // Default network configuration for each supported Cardano network. The
 // verification key URLs follow the official Mithril network configurations.
 var defaultNetworkConfigs = map[string]NetworkConfig{
@@ -884,7 +890,7 @@ func (c *Client) GetLatestSnapshot(
 		return nil, err
 	}
 	if len(snapshots) == 0 {
-		return nil, errors.New("no snapshots available from aggregator")
+		return nil, ErrNoSnapshotsAvailable
 	}
 	slices.SortFunc(snapshots, func(a, b SnapshotListItem) int {
 		if a.Beacon.Epoch != b.Beacon.Epoch {

--- a/mithril/client_test.go
+++ b/mithril/client_test.go
@@ -328,7 +328,7 @@ func TestGetLatestSnapshotEmpty(t *testing.T) {
 
 	client := NewClient(server.URL)
 	_, err := client.GetLatestSnapshot(context.Background())
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoSnapshotsAvailable)
 	require.Contains(t, err.Error(), "no snapshots available")
 }
 

--- a/mithril/integration_test.go
+++ b/mithril/integration_test.go
@@ -47,7 +47,9 @@ func TestIntegrationVerifyCertificateChainPreview(t *testing.T) {
 	// List snapshots and pick the latest one.
 	snapshots, err := client.ListSnapshots(ctx)
 	require.NoError(t, err)
-	require.NotEmpty(t, snapshots, "no snapshots available")
+	if len(snapshots) == 0 {
+		t.Skip("Mithril preview aggregator has no snapshots")
+	}
 
 	latest := snapshots[0]
 	t.Logf(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handle empty `mithril` snapshot lists gracefully. Return a specific error and skip integration tests when no snapshots are available.

- **Bug Fixes**
  - Added `mithril.ErrNoSnapshotsAvailable`; `GetLatestSnapshot` now returns it when aggregators have no snapshots.
  - Updated tests: integration tests skip when snapshots are missing; unit test asserts `ErrorIs` for the new error.

<sup>Written for commit e452a432b37821eec424048a87f4eec06f04bb84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `ErrNoSnapshotsAvailable` error type to provide clearer error reporting when the aggregator returns no available snapshots.

* **Tests**
  * Improved integration test reliability with enhanced edge-case handling for scenarios where snapshots are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->