### PR TITLE
fix(chain): live reconcile lock order

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -113,6 +113,16 @@ func (cm *ChainManager) primaryChainLocked() *Chain {
 	return cm.chains[primaryChainId]
 }
 
+func (cm *ChainManager) primaryChain() (*Chain, error) {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+	chain := cm.primaryChainLocked()
+	if chain == nil {
+		return nil, errors.New("primary chain not available")
+	}
+	return chain, nil
+}
+
 func (cm *ChainManager) Chain(id ChainId) *Chain {
 	cm.mutex.RLock()
 	defer cm.mutex.RUnlock()
@@ -121,15 +131,18 @@ func (cm *ChainManager) Chain(id ChainId) *Chain {
 
 // NewChain creates a new Chain that forks from the primary chain at the specified point. This is useful for managing outbound ChainSync clients
 func (cm *ChainManager) NewChain(point ocommon.Point) (*Chain, error) {
-	cm.mutex.Lock()
-	defer cm.mutex.Unlock()
-	primaryChain := cm.primaryChainLocked()
-	if primaryChain == nil {
-		return nil, errors.New("primary chain not available")
+	primaryChain, err := cm.primaryChain()
+	if err != nil {
+		return nil, err
 	}
 	primaryChain.mutex.Lock()
 	defer primaryChain.mutex.Unlock()
-	intersectBlock, err := cm.BlockByPoint(point, nil)
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+	if cm.primaryChainLocked() != primaryChain {
+		return nil, errors.New("primary chain changed during fork creation")
+	}
+	intersectBlock, err := cm.blockByPoint(point, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -159,18 +172,20 @@ func (cm *ChainManager) NewChain(point ocommon.Point) (*Chain, error) {
 func (cm *ChainManager) NewChainFromIntersect(
 	points []ocommon.Point,
 ) (*Chain, error) {
-	cm.mutex.Lock()
-	defer cm.mutex.Unlock()
-	primaryChain := cm.primaryChainLocked()
-	if primaryChain == nil {
-		return nil, errors.New("primary chain not available")
+	primaryChain, err := cm.primaryChain()
+	if err != nil {
+		return nil, err
 	}
 	primaryChain.mutex.Lock()
 	defer primaryChain.mutex.Unlock()
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+	if cm.primaryChainLocked() != primaryChain {
+		return nil, errors.New("primary chain changed during fork creation")
+	}
 	tip := primaryChain.currentTip
 	var intersectPoint ocommon.Point
 	var intersectBlock models.Block
-	var err error
 	foundOrigin := false
 	txn := cm.db.BlobTxn(false)
 	err = txn.Do(func(txn *database.Txn) error {
@@ -347,22 +362,25 @@ func (cm *ChainManager) loadPrimaryChain() error {
 func (cm *ChainManager) RewindPrimaryChainToPoint(
 	point ocommon.Point,
 ) error {
+	primaryChain, err := cm.primaryChain()
+	if err != nil {
+		return err
+	}
+	primaryChain.mutex.Lock()
+	defer primaryChain.mutex.Unlock()
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
-	primaryChain := cm.primaryChainLocked()
-	if primaryChain == nil {
-		return errors.New("primary chain not available")
+	if cm.primaryChainLocked() != primaryChain {
+		return errors.New("primary chain changed during rewind")
 	}
 	if !primaryChain.persistent {
 		return errors.New("primary chain is not persistent")
 	}
-	primaryChain.mutex.Lock()
-	defer primaryChain.mutex.Unlock()
 
 	rollbackIndex := uint64(0)
 	rollbackBlockNumber := uint64(0)
 	targetTip := ochainsync.Tip{}
-	err := func() error {
+	err = func() error {
 		if point.Slot > 0 || len(point.Hash) > 0 {
 			readTxn := cm.db.BlobTxn(false)
 			defer readTxn.Rollback() //nolint:errcheck

--- a/chain/manager_lock_test.go
+++ b/chain/manager_lock_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+func TestRewindPrimaryChainToPointDoesNotDeadlockWithIterator(t *testing.T) {
+	cm, err := NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("NewManager: %s", err)
+	}
+	primaryChain := cm.PrimaryChain()
+	primaryChain.persistent = true
+
+	cm.mutex.Lock()
+	iter := &ChainIterator{
+		chain:          primaryChain,
+		nextBlockIndex: initialBlockIndex,
+		ctx:            context.Background(),
+	}
+	iterDone := make(chan error, 1)
+	go func() {
+		_, err := primaryChain.iterNext(iter, false)
+		iterDone <- err
+	}()
+	testutil.WaitForCondition(t, func() bool {
+		if primaryChain.mutex.TryLock() {
+			primaryChain.mutex.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, "iterator should hold primary chain lock")
+
+	rewindStarted := make(chan struct{})
+	rewindDone := make(chan error, 1)
+	go func() {
+		close(rewindStarted)
+		rewindDone <- cm.RewindPrimaryChainToPoint(ocommon.NewPointOrigin())
+	}()
+	testutil.RequireReceive(
+		t,
+		rewindStarted,
+		time.Second,
+		"rewind goroutine should start",
+	)
+	runtime.Gosched()
+	cm.mutex.Unlock()
+
+	err = testutil.RequireReceive(
+		t,
+		iterDone,
+		time.Second,
+		"iterator should complete after manager lock is released",
+	)
+	if !errors.Is(err, ErrIteratorChainTip) {
+		t.Fatalf("iterator error = %v, want %v", err, ErrIteratorChainTip)
+	}
+	err = testutil.RequireReceive(
+		t,
+		rewindDone,
+		time.Second,
+		"rewind should complete after iterator releases chain lock",
+	)
+	if err != nil {
+		t.Fatalf("rewind: %s", err)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix deadlock during live reconcile by enforcing a consistent lock order between the manager and the primary chain. Adds checks and a test to ensure rewinds don’t block iterators.

- **Bug Fixes**
  - Lock primary chain before `ChainManager` in `NewChain`, `NewChainFromIntersect`, and `RewindPrimaryChainToPoint`.
  - Add `primaryChain()` helper and guard against the primary chain changing after locks; return clear errors.
  - Add test to verify `RewindPrimaryChainToPoint` doesn’t deadlock when an iterator holds the chain lock.

<sup>Written for commit ba73234980a3c1e4b4ca50508a3626f62deafa44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling to prevent potential deadlocks during concurrent chain operations.
  * Enhanced error reporting when the primary chain becomes unavailable during rewind operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->