### PR TITLE
fix(blockfrost): align transaction detail endpoints with OpenAPI 0.1.88

### DIFF
--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"slices"
 	"strconv"
 
@@ -36,7 +37,9 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gscript "github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
@@ -1817,6 +1820,7 @@ func (a *NodeAdapter) Transaction(
 		OutputAmount:       outputAmount,
 		Fees:               strconv.FormatUint(uint64(tx.Fee), 10),
 		Deposit:            strconv.FormatUint(deposit, 10),
+		TreasuryDonation:   bigIntString(decodedTx.Donation()),
 		Size:               size,
 		UtxoCount:          utxoCount,
 		WithdrawalCount:    withdrawalCount,
@@ -2043,6 +2047,15 @@ func utxoRef(utxo models.Utxo) database.UtxoRef {
 	}
 }
 
+func transactionInputRef(input lcommon.TransactionInput) database.UtxoRef {
+	var txID [32]byte
+	copy(txID[:], input.Id().Bytes())
+	return database.UtxoRef{
+		TxId:      txID,
+		OutputIdx: input.Index(),
+	}
+}
+
 // TransactionDelegations returns delegation certificates in the requested
 // transaction.
 func (a *NodeAdapter) TransactionDelegations(
@@ -2110,6 +2123,7 @@ func (a *NodeAdapter) TransactionDelegations(
 		ret = append(ret, TransactionDelegationInfo{
 			Address:     address,
 			PoolID:      lcommon.PoolId(poolKeyHash).String(),
+			Index:       cert.Index,
 			CertIndex:   cert.Index,
 			ActiveEpoch: activeEpoch,
 		})
@@ -2405,20 +2419,9 @@ func (a *NodeAdapter) TransactionPoolRetires(
 func (a *NodeAdapter) TransactionRedeemers(
 	hash []byte,
 ) ([]TransactionRedeemerInfo, error) {
-	tx, err := a.ledgerState.TransactionByHash(hash)
+	tx, _, decodedTx, err := a.decodedTransactionByHash(hash)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"get transaction by hash %x: %w",
-			hash,
-			err,
-		)
-	}
-	if tx == nil {
-		return nil, fmt.Errorf(
-			"transaction %x: %w",
-			hash,
-			ErrTransactionNotFound,
-		)
+		return nil, err
 	}
 
 	redeemers := slices.Clone(tx.Redeemers)
@@ -2429,18 +2432,48 @@ func (a *NodeAdapter) TransactionRedeemers(
 		return cmp.Compare(a.Index, b.Index)
 	})
 
+	metadata, err := a.transactionRedeemerMetadata(hash, tx, decodedTx)
+	if err != nil {
+		return nil, err
+	}
+	pparams, err := a.protocolParamsForSlot(tx.Slot)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get protocol parameters for transaction %x redeemer fees: %w",
+			hash,
+			err,
+		)
+	}
+	executionCosts, err := executionCostsFromPParams(pparams)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get execution prices for transaction %x redeemer fees: %w",
+			hash,
+			err,
+		)
+	}
 	ret := make([]TransactionRedeemerInfo, 0, len(redeemers))
 	for _, redeemer := range redeemers {
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTag(redeemer.Tag),
+			Index: redeemer.Index,
+		}
 		dataHash := lcommon.Blake2b256Hash(redeemer.Data)
+		redeemerMetadata := metadata[key]
+		fee := redeemerExecutionFee(
+			executionCosts,
+			redeemer.ExUnitsMemory,
+			redeemer.ExUnitsCPU,
+		)
 		ret = append(ret, TransactionRedeemerInfo{
-			TxIndex: int(redeemer.Index),
-			Purpose: redeemerPurpose(lcommon.RedeemerTag(redeemer.Tag)),
-			// TODO: Populate script_hash once redeemer-to-script mapping is stored.
-			ScriptHash:       "",
+			DatumHash:        redeemerMetadata.DatumHash,
+			TxIndex:          int(redeemer.Index),
+			Purpose:          redeemerPurpose(lcommon.RedeemerTag(redeemer.Tag)),
+			ScriptHash:       redeemerMetadata.ScriptHash,
 			RedeemerDataHash: hex.EncodeToString(dataHash.Bytes()),
 			UnitMem:          strconv.FormatUint(redeemer.ExUnitsMemory, 10),
 			UnitSteps:        strconv.FormatUint(redeemer.ExUnitsCPU, 10),
-			Fee:              "0",
+			Fee:              strconv.FormatUint(fee, 10),
 		})
 	}
 	return ret, nil
@@ -2577,6 +2610,11 @@ type transactionCertificate struct {
 	Index       int
 }
 
+type transactionRedeemerMetadata struct {
+	DatumHash  *string
+	ScriptHash string
+}
+
 func (a *NodeAdapter) transactionMetadataEntries(
 	hash []byte,
 ) ([]labelcodec.Entry, error) {
@@ -2643,6 +2681,105 @@ func transactionCertificatesByType(
 	slices.SortFunc(ret, func(a, b transactionCertificate) int {
 		return cmp.Compare(a.Index, b.Index)
 	})
+	return ret, nil
+}
+
+func (a *NodeAdapter) transactionRedeemerMetadata(
+	hash []byte,
+	tx *models.Transaction,
+	decodedTx lcommon.Transaction,
+) (map[lcommon.RedeemerKey]transactionRedeemerMetadata, error) {
+	ret := make(map[lcommon.RedeemerKey]transactionRedeemerMetadata)
+	if len(tx.Redeemers) == 0 {
+		return ret, nil
+	}
+
+	inputCbor, err := a.transactionInputCbor(tx.Inputs)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve transaction redeemer input CBOR for %x: %w",
+			hash,
+			err,
+		)
+	}
+	inputsByRef := make(map[database.UtxoRef]models.Utxo, len(tx.Inputs))
+	for _, input := range tx.Inputs {
+		inputsByRef[utxoRef(input)] = input
+	}
+
+	resolvedInputs := make(map[string]lcommon.Utxo, len(decodedTx.Inputs()))
+	for _, input := range decodedTx.Inputs() {
+		ref := transactionInputRef(input)
+		utxo, ok := inputsByRef[ref]
+		if !ok {
+			continue
+		}
+		utxo.Cbor = inputCbor[ref]
+		if len(utxo.Cbor) == 0 {
+			continue
+		}
+		output, err := gledger.NewTransactionOutputFromCbor(utxo.Cbor)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"decode redeemer input output %s for transaction %x: %w",
+				input.String(),
+				hash,
+				err,
+			)
+		}
+		resolvedInputs[input.String()] = lcommon.Utxo{
+			Id:     input,
+			Output: output,
+		}
+	}
+
+	witnessDatums := map[lcommon.Blake2b256]*lcommon.Datum{}
+	if witnesses := decodedTx.Witnesses(); witnesses != nil {
+		for _, datum := range witnesses.PlutusData() {
+			tmpDatum := datum
+			witnessDatums[datum.Hash()] = &tmpDatum
+		}
+	}
+
+	var mint lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
+	if decodedTx.AssetMint() != nil {
+		mint = *decodedTx.AssetMint()
+	}
+
+	for _, redeemer := range tx.Redeemers {
+		key := lcommon.RedeemerKey{
+			Tag:   lcommon.RedeemerTag(redeemer.Tag),
+			Index: redeemer.Index,
+		}
+		purpose := gscript.BuildScriptPurpose(
+			key,
+			resolvedInputs,
+			decodedTx.Inputs(),
+			mint,
+			decodedTx.Certificates(),
+			decodedTx.Withdrawals(),
+			decodedTx.VotingProcedures(),
+			decodedTx.ProposalProcedures(),
+			witnessDatums,
+		)
+		if purpose == nil {
+			continue
+		}
+		metadata := transactionRedeemerMetadata{
+			ScriptHash: hex.EncodeToString(purpose.ScriptHash().Bytes()),
+		}
+		if spending, ok := purpose.(gscript.ScriptPurposeSpending); ok {
+			if datum := spending.Input.Output.Datum(); datum != nil {
+				hash := datum.Hash()
+				hashStr := hex.EncodeToString(hash.Bytes())
+				metadata.DatumHash = &hashStr
+			} else if datumHash := spending.Input.Output.DatumHash(); datumHash != nil {
+				hashStr := hex.EncodeToString(datumHash.Bytes())
+				metadata.DatumHash = &hashStr
+			}
+		}
+		ret[key] = metadata
+	}
 	return ret, nil
 }
 
@@ -2762,6 +2899,61 @@ func redeemerPurpose(tag lcommon.RedeemerTag) string {
 	default:
 		return ""
 	}
+}
+
+func executionCostsFromPParams(
+	pparams lcommon.ProtocolParameters,
+) (lcommon.ExUnitPrice, error) {
+	switch pp := pparams.(type) {
+	case *alonzo.AlonzoProtocolParameters:
+		return pp.ExecutionCosts, nil
+	case *babbage.BabbageProtocolParameters:
+		return pp.ExecutionCosts, nil
+	case *conway.ConwayProtocolParameters:
+		return pp.ExecutionCosts, nil
+	case *dijkstra.DijkstraProtocolParameters:
+		return pp.ExecutionCosts, nil
+	default:
+		return lcommon.ExUnitPrice{}, fmt.Errorf(
+			"protocol parameters %T do not include execution prices",
+			pparams,
+		)
+	}
+}
+
+func redeemerExecutionFee(
+	executionCosts lcommon.ExUnitPrice,
+	memory uint64,
+	steps uint64,
+) uint64 {
+	if executionCosts.MemPrice == nil || executionCosts.StepPrice == nil {
+		return 0
+	}
+	memCost := new(big.Rat).Mul(
+		executionCosts.MemPrice.ToBigRat(),
+		new(big.Rat).SetUint64(memory),
+	)
+	stepCost := new(big.Rat).Mul(
+		executionCosts.StepPrice.ToBigRat(),
+		new(big.Rat).SetUint64(steps),
+	)
+	return ceilRatToUint64(new(big.Rat).Add(memCost, stepCost))
+}
+
+func ceilRatToUint64(v *big.Rat) uint64 {
+	if v == nil || v.Sign() <= 0 {
+		return 0
+	}
+	num := new(big.Int).Set(v.Num())
+	den := new(big.Int).Set(v.Denom())
+	q, r := new(big.Int).QuoRem(num, den, new(big.Int))
+	if r.Sign() > 0 {
+		q.Add(q, big.NewInt(1))
+	}
+	if !q.IsUint64() {
+		return math.MaxUint64
+	}
+	return q.Uint64()
 }
 
 func transactionPoolRelaysInfo(
@@ -2975,6 +3167,13 @@ func optionalHexString(data []byte) *string {
 	}
 	ret := hex.EncodeToString(data)
 	return &ret
+}
+
+func bigIntString(v *big.Int) string {
+	if v == nil {
+		return "0"
+	}
+	return v.String()
 }
 
 func paginateUtxos(

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -2431,6 +2431,9 @@ func (a *NodeAdapter) TransactionRedeemers(
 		}
 		return cmp.Compare(a.Index, b.Index)
 	})
+	if len(redeemers) == 0 {
+		return []TransactionRedeemerInfo{}, nil
+	}
 
 	metadata, err := a.transactionRedeemerMetadata(hash, tx, decodedTx)
 	if err != nil {
@@ -2459,7 +2462,15 @@ func (a *NodeAdapter) TransactionRedeemers(
 			Index: redeemer.Index,
 		}
 		dataHash := lcommon.Blake2b256Hash(redeemer.Data)
-		redeemerMetadata := metadata[key]
+		redeemerMetadata, ok := metadata[key]
+		if !ok {
+			return nil, fmt.Errorf(
+				"resolve redeemer metadata for transaction %x tag=%d index=%d",
+				hash,
+				redeemer.Tag,
+				redeemer.Index,
+			)
+		}
 		fee := redeemerExecutionFee(
 			executionCosts,
 			redeemer.ExUnitsMemory,
@@ -2763,7 +2774,12 @@ func (a *NodeAdapter) transactionRedeemerMetadata(
 			witnessDatums,
 		)
 		if purpose == nil {
-			continue
+			return nil, fmt.Errorf(
+				"build script purpose for transaction %x tag=%d index=%d",
+				hash,
+				redeemer.Tag,
+				redeemer.Index,
+			)
 		}
 		metadata := transactionRedeemerMetadata{
 			ScriptHash: hex.EncodeToString(purpose.ScriptHash().Bytes()),

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,6 +26,8 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +35,18 @@ import (
 //go:fix inline
 func intPtr(v int) *int {
 	return new(v)
+}
+
+func TestRedeemerExecutionFee(t *testing.T) {
+	fee := redeemerExecutionFee(
+		lcommon.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(577, 10000)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(721, 10000000)},
+		},
+		245264,
+		103956223,
+	)
+	assert.Equal(t, uint64(21647), fee)
 }
 
 // mockNode implements BlockfrostNode for testing.
@@ -1021,6 +1036,7 @@ func TestHandleTransaction(t *testing.T) {
 			OutputAmount:     []AddressAmountInfo{{Unit: "lovelace", Quantity: "5000"}},
 			Fees:             "170000",
 			Deposit:          "0",
+			TreasuryDonation: "12345",
 			Size:             512,
 			UtxoCount:        3,
 			StakeCertCount:   1,
@@ -1057,6 +1073,7 @@ func TestHandleTransaction(t *testing.T) {
 	assert.Equal(t, int64(1700000000), resp.BlockTime)
 	assert.Equal(t, 2, resp.Index)
 	assert.Equal(t, "170000", resp.Fees)
+	assert.Equal(t, "12345", resp.TreasuryDonation)
 	require.Len(t, resp.OutputAmount, 1)
 	assert.Equal(t, "lovelace", resp.OutputAmount[0].Unit)
 	assert.Equal(t, "5000", resp.OutputAmount[0].Quantity)
@@ -1477,6 +1494,7 @@ func TestHandleTransactionDelegations(t *testing.T) {
 			{
 				Address:     "stake_test1...",
 				PoolID:      "pool1...",
+				Index:       2,
 				CertIndex:   2,
 				ActiveEpoch: 10,
 			},
@@ -1501,7 +1519,53 @@ func TestHandleTransactionDelegations(t *testing.T) {
 	require.Len(t, resp, 1)
 	assert.Equal(t, "stake_test1...", resp[0].Address)
 	assert.Equal(t, "pool1...", resp[0].PoolID)
+	assert.Equal(t, 2, resp[0].Index)
+	assert.Equal(t, 2, resp[0].CertIndex)
 	assert.Equal(t, uint64(10), resp[0].ActiveEpoch)
+}
+
+func TestHandleTransactionRedeemers(t *testing.T) {
+	datumHash := "923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec"
+	b := newTestBlockfrost(&mockNode{
+		transactionRedeemers: []TransactionRedeemerInfo{
+			{
+				DatumHash:        &datumHash,
+				TxIndex:          0,
+				Purpose:          "spend",
+				ScriptHash:       "f00dbeef00112233445566778899aabbccddeeff0011223344556677",
+				RedeemerDataHash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				UnitMem:          "1700",
+				UnitSteps:        "200000",
+				Fee:              "172345",
+			},
+		},
+	})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/txs/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/redeemers",
+		nil,
+	)
+	req.SetPathValue(
+		"hash",
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	)
+	w := httptest.NewRecorder()
+	b.handleTransactionRedeemers(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp []TransactionRedeemerResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	require.NotNil(t, resp[0].DatumHash)
+	assert.Equal(t, datumHash, *resp[0].DatumHash)
+	assert.Equal(t, 0, resp[0].TxIndex)
+	assert.Equal(t, "spend", resp[0].Purpose)
+	assert.Equal(t, "f00dbeef00112233445566778899aabbccddeeff0011223344556677", resp[0].ScriptHash)
+	assert.Equal(t, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", resp[0].RedeemerDataHash)
+	assert.Equal(t, "1700", resp[0].UnitMem)
+	assert.Equal(t, "200000", resp[0].UnitSteps)
+	assert.Equal(t, "172345", resp[0].Fee)
 }
 
 func TestHandleTransactionStakeAddresses(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -805,6 +805,11 @@ func (b *Blockfrost) handleTransaction(
 		return
 	}
 
+	treasuryDonation := tx.TreasuryDonation
+	if treasuryDonation == "" {
+		treasuryDonation = "0"
+	}
+
 	writeJSON(w, http.StatusOK, TransactionResponse{
 		Hash:               tx.Hash,
 		Block:              tx.Block,
@@ -815,6 +820,7 @@ func (b *Blockfrost) handleTransaction(
 		OutputAmount:       convertAddressAmounts(tx.OutputAmount),
 		Fees:               tx.Fees,
 		Deposit:            tx.Deposit,
+		TreasuryDonation:   treasuryDonation,
 		Size:               tx.Size,
 		UtxoCount:          tx.UtxoCount,
 		WithdrawalCount:    tx.WithdrawalCount,

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -401,6 +401,7 @@ type TransactionInfo struct {
 	Block              string
 	Deposit            string
 	Fees               string
+	TreasuryDonation   string
 	Slot               uint64
 	BlockHeight        uint64
 	BlockTime          int64
@@ -466,6 +467,7 @@ type TransactionOutputInfo struct {
 type TransactionDelegationInfo struct {
 	Address     string
 	PoolID      string
+	Index       int
 	CertIndex   int
 	ActiveEpoch uint64
 }
@@ -530,6 +532,7 @@ type TransactionPoolRetireInfo struct {
 
 // TransactionRedeemerInfo holds one Plutus redeemer.
 type TransactionRedeemerInfo struct {
+	DatumHash        *string
 	TxIndex          int
 	Purpose          string
 	ScriptHash       string

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -304,6 +304,7 @@ type TransactionResponse struct {
 	Block              string                  `json:"block"`
 	Deposit            string                  `json:"deposit"`
 	Fees               string                  `json:"fees"`
+	TreasuryDonation   string                  `json:"treasury_donation"`
 	Slot               uint64                  `json:"slot"`
 	BlockHeight        uint64                  `json:"block_height"`
 	BlockTime          int64                   `json:"block_time"`
@@ -378,6 +379,7 @@ type TransactionOutputResponse struct {
 type TransactionDelegationResponse struct {
 	Address     string `json:"address"`
 	PoolID      string `json:"pool_id"`
+	Index       int    `json:"index"`
 	CertIndex   int    `json:"cert_index"`
 	ActiveEpoch uint64 `json:"active_epoch"`
 }
@@ -442,13 +444,14 @@ type TransactionPoolRetireResponse struct {
 
 // TransactionRedeemerResponse represents one Plutus redeemer.
 type TransactionRedeemerResponse struct {
-	TxIndex          int    `json:"tx_index"`
-	Purpose          string `json:"purpose"`
-	ScriptHash       string `json:"script_hash"`
-	RedeemerDataHash string `json:"redeemer_data_hash"`
-	UnitMem          string `json:"unit_mem"`
-	UnitSteps        string `json:"unit_steps"`
-	Fee              string `json:"fee"`
+	DatumHash        *string `json:"datum_hash"`
+	TxIndex          int     `json:"tx_index"`
+	Purpose          string  `json:"purpose"`
+	ScriptHash       string  `json:"script_hash"`
+	RedeemerDataHash string  `json:"redeemer_data_hash"`
+	UnitMem          string  `json:"unit_mem"`
+	UnitSteps        string  `json:"unit_steps"`
+	Fee              string  `json:"fee"`
 }
 
 // TransactionRequiredSignerResponse represents one required signing key hash.


### PR DESCRIPTION
1. Added `treasury_donation` to `GET /txs/{hash}` responses.
2. Added `index` alongside `cert_index` to `GET /txs/{hash}/delegations`.
3. Added `datum_hash` to `GET /txs/{hash}/redeemers`.
4. Made changes to populate redeemer `script_hash` from resolved script purpose instead of returning a placeholder.
5. Made changes to populate redeemer `fee` as the per-redeemer execution fee from ex-units and historical protocol execution prices.
6. Made changes for redeemer `redeemer_data_hash`, `unit_mem`, and `unit_steps` populated from stored redeemer data.

Closes #2491 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `blockfrost` transaction detail endpoints with OpenAPI 0.1.88 by adding missing fields and fixing redeemer metadata and fee calculations. Improves spec compliance and data accuracy. Closes #2491.

- **Bug Fixes**
  - Added `treasury_donation` to `GET /txs/{hash}` (defaults to "0" when absent).
  - Added `index` to `GET /txs/{hash}/delegations`.
  - Updated `GET /txs/{hash}/redeemers`: added `datum_hash`; populate `script_hash` from resolved script purpose; populate `redeemer_data_hash`, `unit_mem`, and `unit_steps`; compute per-redeemer `fee` from ex-units using historical protocol execution prices.

<sup>Written for commit 8c6155e7d5e44cdce9cc7aef6d29cb5bb0f6bc70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Treasury donation amounts now displayed in transaction details.
  * Delegation certificate indices now included in responses.
  * Redeemer datum hashes now available in redeemer information.

* **Bug Fixes**
  * Redeemer execution fees now correctly calculated based on protocol parameters instead of returning placeholder values.

* **Tests**
  * Added test coverage for redeemer execution fee calculations and transaction redeemers endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->