### PR TITLE
refactor(api): narrow concrete adapters for blockfrost mesh utxorpc

### DIFF
--- a/api/mesh/adapter.go
+++ b/api/mesh/adapter.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// meshDatabaseAdapter adapts *database.Database to MeshDatabase.
+// BlockByHash is a package-level function in the database package rather than
+// a method, so this adapter bridges the gap while keeping the Mesh server free
+// of a direct *database.Database dependency.
+type meshDatabaseAdapter struct {
+	db *database.Database
+}
+
+// NewMeshDatabase wraps a *database.Database as a MeshDatabase for use in
+// the Mesh server config.
+func NewMeshDatabase(db *database.Database) MeshDatabase {
+	return &meshDatabaseAdapter{db: db}
+}
+
+func (a *meshDatabaseAdapter) BlockByHash(
+	hash []byte,
+) (models.Block, error) {
+	return database.BlockByHash(a.db, hash)
+}
+
+func (a *meshDatabaseAdapter) BlockByIndex(
+	idx uint64,
+) (models.Block, error) {
+	return a.db.BlockByIndex(idx, nil)
+}
+
+func (a *meshDatabaseAdapter) GetTransactionByHash(
+	hash []byte,
+) (*models.Transaction, error) {
+	return a.db.GetTransactionByHash(hash, nil)
+}
+
+func (a *meshDatabaseAdapter) GetTransactionsByBlockHash(
+	hash []byte,
+) ([]models.Transaction, error) {
+	return a.db.GetTransactionsByBlockHash(hash, nil)
+}

--- a/api/mesh/block.go
+++ b/api/mesh/block.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 )
 
@@ -52,7 +51,7 @@ func (s *Server) handleBlock(
 
 	txs, err := s.config.Database.
 		GetTransactionsByBlockHash(
-			block.Hash, nil,
+			block.Hash,
 		)
 	if err != nil {
 		s.logger.Error(
@@ -114,7 +113,7 @@ func (s *Server) handleBlockTransaction(
 	}
 
 	tx, err := s.config.Database.GetTransactionByHash(
-		hashBytes, nil,
+		hashBytes,
 	)
 	if err != nil {
 		s.logger.Error(
@@ -176,8 +175,8 @@ func (s *Server) lookupBlock(
 				ErrInvalidRequest, decErr,
 			)
 		}
-		block, err = database.BlockByHash(
-			s.config.Database, hashBytes,
+		block, err = s.config.Database.BlockByHash(
+			hashBytes,
 		)
 	case id.Index != nil:
 		if *id.Index < 0 {
@@ -185,7 +184,7 @@ func (s *Server) lookupBlock(
 		}
 		// #nosec G115 -- validated non-negative
 		block, err = s.config.Database.BlockByIndex(
-			uint64(*id.Index), nil,
+			uint64(*id.Index),
 		)
 	default:
 		return block, ErrInvalidRequest

--- a/api/mesh/mesh.go
+++ b/api/mesh/mesh.go
@@ -27,12 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blinklabs-io/dingo/chain"
-	"github.com/blinklabs-io/dingo/database"
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
-	"github.com/blinklabs-io/dingo/ledger"
-	"github.com/blinklabs-io/dingo/mempool"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
@@ -55,21 +50,19 @@ const (
 
 // ServerConfig holds configuration for the Mesh API server.
 type ServerConfig struct {
-	Logger        *slog.Logger
-	EventBus      *event.EventBus
-	LedgerState   *ledger.LedgerState
-	Database      *database.Database
-	Chain         *chain.Chain
-	Mempool       *mempool.Mempool
+	Logger      *slog.Logger
+	LedgerState MeshLedgerState
+	Database    MeshDatabase
+	Chain       MeshChain
+	Mempool     MeshMempool
+	// ListenAddress is the TCP address to listen on (e.g. ":8080").
 	ListenAddress string
 	Network       string
 	NetworkMagic  uint32
-	// GenesisHash is the Byron genesis block hash
-	// (hex-encoded).
+	// GenesisHash is the Byron genesis block hash (hex-encoded).
 	GenesisHash string
-	// GenesisStartTimeSec is the Unix timestamp (seconds)
-	// of slot 0 for the configured network. Used to
-	// convert slot numbers to absolute timestamps.
+	// GenesisStartTimeSec is the Unix timestamp (seconds) of slot 0 for the
+	// configured network. Used to convert slot numbers to absolute timestamps.
 	GenesisStartTimeSec int64
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.

--- a/api/mesh/node_interface.go
+++ b/api/mesh/node_interface.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/mempool"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// MeshChain is the subset of chain.Chain needed by the Mesh server.
+type MeshChain interface {
+	Tip() ochainsync.Tip
+}
+
+// MeshDatabase is the subset of database.Database needed by the Mesh server.
+// All calls implicitly use a nil transaction (auto-transaction per method).
+type MeshDatabase interface {
+	BlockByHash(hash []byte) (models.Block, error)
+	BlockByIndex(idx uint64) (models.Block, error)
+	GetTransactionByHash(hash []byte) (*models.Transaction, error)
+	GetTransactionsByBlockHash(hash []byte) ([]models.Transaction, error)
+}
+
+// MeshLedgerState is the subset of ledger.LedgerState needed by the Mesh server.
+type MeshLedgerState interface {
+	GetCurrentPParams() lcommon.ProtocolParameters
+	SlotToTime(slot uint64) (time.Time, error)
+	UtxosByAddress(addr lcommon.Address) ([]models.Utxo, error)
+}
+
+// MeshMempool is the subset of mempool.Mempool needed by the Mesh server.
+type MeshMempool interface {
+	AddTransaction(txType uint, txBytes []byte) error
+	GetTransaction(hash string) (mempool.MempoolTransaction, bool)
+	Transactions() []mempool.MempoolTransaction
+}

--- a/api/utxorpc/node_interface.go
+++ b/api/utxorpc/node_interface.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/mempool"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// UtxorpcLedgerState is the subset of ledger.LedgerState needed by the UTxO
+// RPC server. Using this interface keeps the server and service handlers free
+// of a direct *ledger.LedgerState dependency.
+type UtxorpcLedgerState interface {
+	BlockByHash(hash []byte) (models.Block, error)
+	CardanoNodeConfig() *cardano.CardanoNodeConfig
+	Datum(hash []byte) (*models.Datum, error)
+	EvaluateTx(tx lcommon.Transaction) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error)
+	GetBlock(point ocommon.Point) (models.Block, error)
+	GetChainFromPointContext(ctx context.Context, point ocommon.Point, inclusive bool) (*chain.ChainIterator, error)
+	GetCurrentPParams() lcommon.ProtocolParameters
+	GetEpochs() ([]models.Epoch, error)
+	GetIntersectPoint(points []ocommon.Point) (*ocommon.Point, error)
+	GetPParamsForEpoch(epoch uint64, era eras.EraDesc) (lcommon.ProtocolParameters, error)
+	SlotToTime(slot uint64) (time.Time, error)
+	SystemStart() (time.Time, error)
+	Tip() ochainsync.Tip
+	TransactionByHash(hash []byte) (*models.Transaction, error)
+	UtxoByRef(txId []byte, outputIdx uint32) (*models.Utxo, error)
+	UtxosByAddressWithOrdering(q *models.UtxoWithOrderingQuery) ([]models.UtxoWithOrdering, error)
+}
+
+// UtxorpcMempool is the subset of mempool.Mempool needed by the UTxO RPC
+// server.
+type UtxorpcMempool interface {
+	AddTransaction(txType uint, txBytes []byte) error
+	Transactions() []mempool.MempoolTransaction
+}
+
+// UtxorpcEventBus is the subset of event.EventBus needed by the UTxO RPC
+// server.
+type UtxorpcEventBus interface {
+	SubscribeFunc(eventType event.EventType, handlerFunc event.EventHandlerFunc) event.EventSubscriberId
+	Unsubscribe(eventType event.EventType, subId event.EventSubscriberId)
+}

--- a/api/utxorpc/node_interface.go
+++ b/api/utxorpc/node_interface.go
@@ -25,8 +25,8 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/mempool"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
-	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // UtxorpcLedgerState is the subset of ledger.LedgerState needed by the UTxO

--- a/api/utxorpc/utxorpc.go
+++ b/api/utxorpc/utxorpc.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
@@ -108,7 +109,36 @@ func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
 	}
 }
 
+// isNilInterface reports whether v is nil at either the interface level
+// (untyped nil) or the underlying pointer level (typed nil such as
+// (*T)(nil) stored in an interface). Calling methods on either kind of
+// nil interface value causes a runtime panic, so both must be rejected.
+func isNilInterface(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() { //nolint:exhaustive
+	case reflect.Chan, reflect.Func, reflect.Interface,
+		reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	}
+	return false
+}
+
 func (u *Utxorpc) Start(ctx context.Context) error {
+	if isNilInterface(u.config.EventBus) {
+		return errors.New("utxorpc: EventBus is required")
+	}
+	// Typed-nil guard for optional deps — untyped nil is allowed at startup
+	// (handlers check per-request), but a typed nil (*T)(nil) stored in the
+	// interface field would bypass handler nil-checks and cause a panic.
+	if u.config.LedgerState != nil && isNilInterface(u.config.LedgerState) {
+		return errors.New("utxorpc: LedgerState must not be a typed nil")
+	}
+	if u.config.Mempool != nil && isNilInterface(u.config.Mempool) {
+		return errors.New("utxorpc: Mempool must not be a typed nil")
+	}
 	u.mu.Lock()
 	if u.server != nil {
 		u.mu.Unlock()

--- a/api/utxorpc/utxorpc.go
+++ b/api/utxorpc/utxorpc.go
@@ -29,10 +29,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
 	"connectrpc.com/grpcreflect"
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
-	"github.com/blinklabs-io/dingo/ledger"
-	"github.com/blinklabs-io/dingo/mempool"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit/submitconnect"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync/syncconnect"
@@ -57,9 +54,9 @@ type Utxorpc struct {
 
 type UtxorpcConfig struct {
 	Logger          *slog.Logger
-	EventBus        *event.EventBus
-	LedgerState     *ledger.LedgerState
-	Mempool         *mempool.Mempool
+	EventBus        UtxorpcEventBus
+	LedgerState     UtxorpcLedgerState
+	Mempool         UtxorpcMempool
 	TlsCertFilePath string
 	TlsKeyFilePath  string
 	Host            string

--- a/node.go
+++ b/node.go
@@ -908,9 +908,8 @@ func (n *Node) Run(ctx context.Context) error {
 		n.meshAPI, meshErr = mesh.NewServer(
 			mesh.ServerConfig{
 				Logger:              n.config.logger,
-				EventBus:            n.eventBus,
 				LedgerState:         n.ledgerState,
-				Database:            n.db,
+				Database:            mesh.NewMeshDatabase(n.db),
 				Chain:               n.ledgerState.Chain(),
 				Mempool:             n.mempool,
 				ListenAddress:       listenAddr,


### PR DESCRIPTION
Closes #2386 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples the `mesh` and `utxorpc` servers from concrete node types by introducing narrow interfaces and a small DB adapter. Adds startup nil checks in `utxorpc` to prevent panics and improve robustness.

- **Refactors**
  - Introduced minimal interfaces for chain, ledger, mempool, database, and event bus used by `mesh` and `utxorpc`.
  - Added `meshDatabaseAdapter` with `NewMeshDatabase(db)` to adapt `*database.Database`.
  - Updated `mesh` handlers/config to use these interfaces and removed `EventBus`.
  - `UtxorpcConfig` now takes `UtxorpcLedgerState`, `UtxorpcMempool`, `UtxorpcEventBus`; `Start` now validates `EventBus` and guards typed‑nil `LedgerState`/`Mempool` to avoid panics.

- **Migration**
  - When creating the `mesh` server, wrap the DB: `mesh.NewMeshDatabase(db)`, and do not pass `EventBus`.
  - Provide dependencies that satisfy the new interfaces for `mesh` and `utxorpc`.

<sup>Written for commit 830fdb3b4e77d1ffa07b3420fc2a4bc831ae668b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal API architecture by introducing interface-based abstractions for core system components (database, chain, ledger state, and mempool) across Mesh and UTxO RPC APIs, improving modularity and system flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->