### PR TITLE
refactor(chainselection): decouple peer eligibility from peergov events

### DIFF
--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
@@ -141,14 +140,6 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 		cs.mode = SelectionModeGenesis
 	}
 	if cfg.EventBus != nil {
-		cfg.EventBus.SubscribeFunc(
-			peergov.PeerEligibilityChangedEventType,
-			cs.handlePeerEligibilityChangedEvent,
-		)
-		cfg.EventBus.SubscribeFunc(
-			peergov.PeerPriorityChangedEventType,
-			cs.handlePeerPriorityChangedEvent,
-		)
 		cfg.EventBus.SubscribeFunc(
 			PeerRollbackEventType,
 			cs.handlePeerRollbackEvent,
@@ -954,24 +945,28 @@ func sameSelectionTip(a, b ochainsync.Tip) bool {
 		bytes.Equal(a.Point.Hash, b.Point.Hash)
 }
 
-func (cs *ChainSelector) handlePeerEligibilityChangedEvent(evt event.Event) {
-	e, ok := evt.Data.(peergov.PeerEligibilityChangedEvent)
-	if !ok {
-		return
-	}
+// SetConnectionEligible marks whether a peer connection is eligible for chain
+// selection. Ineligible peers are skipped during best-peer evaluation.
+// Calling this triggers a re-evaluation of the best peer.
+func (cs *ChainSelector) SetConnectionEligible(
+	connId ouroboros.ConnectionId,
+	eligible bool,
+) {
 	cs.mutex.Lock()
-	cs.eligible[e.ConnectionId] = e.Eligible
+	cs.eligible[connId] = eligible
 	cs.mutex.Unlock()
 	cs.triggerEvaluation()
 }
 
-func (cs *ChainSelector) handlePeerPriorityChangedEvent(evt event.Event) {
-	e, ok := evt.Data.(peergov.PeerPriorityChangedEvent)
-	if !ok {
-		return
-	}
+// SetConnectionPriority sets the selection priority for a peer connection.
+// When two peers advertise the same chain tip, the peer with the higher
+// priority wins. Calling this triggers a re-evaluation of the best peer.
+func (cs *ChainSelector) SetConnectionPriority(
+	connId ouroboros.ConnectionId,
+	priority int,
+) {
 	cs.mutex.Lock()
-	cs.priority[e.ConnectionId] = e.Priority
+	cs.priority[connId] = priority
 	cs.mutex.Unlock()
 	cs.triggerEvaluation()
 }

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -948,12 +948,20 @@ func sameSelectionTip(a, b ochainsync.Tip) bool {
 // SetConnectionEligible marks whether a peer connection is eligible for chain
 // selection. Ineligible peers are skipped during best-peer evaluation.
 // Calling this triggers a re-evaluation of the best peer.
+//
+// eligible=true is the default (absent key), so we delete instead of storing
+// it. This prevents a stale entry when an out-of-order eligible=true event
+// arrives after RemovePeer has already cleaned up the maps.
 func (cs *ChainSelector) SetConnectionEligible(
 	connId ouroboros.ConnectionId,
 	eligible bool,
 ) {
 	cs.mutex.Lock()
-	cs.eligible[connId] = eligible
+	if eligible {
+		delete(cs.eligible, connId)
+	} else {
+		cs.eligible[connId] = false
+	}
 	cs.mutex.Unlock()
 	cs.triggerEvaluation()
 }
@@ -961,12 +969,20 @@ func (cs *ChainSelector) SetConnectionEligible(
 // SetConnectionPriority sets the selection priority for a peer connection.
 // When two peers advertise the same chain tip, the peer with the higher
 // priority wins. Calling this triggers a re-evaluation of the best peer.
+//
+// priority=0 is the default (absent key), so we delete instead of storing it.
+// This prevents a stale entry when an out-of-order priority=0 event arrives
+// after RemovePeer has already cleaned up the maps.
 func (cs *ChainSelector) SetConnectionPriority(
 	connId ouroboros.ConnectionId,
 	priority int,
 ) {
 	cs.mutex.Lock()
-	cs.priority[connId] = priority
+	if priority == 0 {
+		delete(cs.priority, connId)
+	} else {
+		cs.priority[connId] = priority
+	}
 	cs.mutex.Unlock()
 	cs.triggerEvaluation()
 }

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -710,57 +709,23 @@ func TestChainSelectorPreservesEqualTipIncumbentAtSamePriorityWithVRF(
 	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 }
 
-func TestChainSelectorUpdatesConnectionStateFromPeerGovEvents(t *testing.T) {
-	eventBus := event.NewEventBus(nil, nil)
-	defer eventBus.Stop()
-
-	cs := NewChainSelector(ChainSelectorConfig{
-		EventBus: eventBus,
-	})
+func TestChainSelectorUpdatesConnectionStateViaSetters(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
 	connId := newTestConnectionId(1)
 
-	require.Eventually(t, func() bool {
-		cs.mutex.RLock()
-		defer cs.mutex.RUnlock()
-		return cs.isConnectionEligible(connId) &&
-			cs.connectionPriority(connId) == 0
-	}, time.Second, 5*time.Millisecond)
+	// Default state: eligible (not in map), priority 0.
+	assert.True(t, cs.isConnectionEligible(connId))
+	assert.Equal(t, 0, cs.connectionPriority(connId))
 
-	eventBus.Publish(
-		peergov.PeerEligibilityChangedEventType,
-		event.NewEvent(
-			peergov.PeerEligibilityChangedEventType,
-			peergov.PeerEligibilityChangedEvent{
-				ConnectionId: connId,
-				Eligible:     false,
-			},
-		),
-	)
-	eventBus.Publish(
-		peergov.PeerPriorityChangedEventType,
-		event.NewEvent(
-			peergov.PeerPriorityChangedEventType,
-			peergov.PeerPriorityChangedEvent{
-				ConnectionId: connId,
-				Priority:     40,
-			},
-		),
-	)
+	cs.SetConnectionEligible(connId, false)
+	cs.SetConnectionPriority(connId, 40)
 
-	require.Eventually(t, func() bool {
-		cs.mutex.RLock()
-		defer cs.mutex.RUnlock()
-		return !cs.isConnectionEligible(connId) &&
-			cs.connectionPriority(connId) == 40
-	}, time.Second, 5*time.Millisecond)
+	assert.False(t, cs.isConnectionEligible(connId))
+	assert.Equal(t, 40, cs.connectionPriority(connId))
 }
 
-func TestChainSelectorSwitchesImmediatelyOnEligibilityEvent(t *testing.T) {
-	eventBus := event.NewEventBus(nil, nil)
-	defer eventBus.Stop()
-
+func TestChainSelectorSwitchesImmediatelyOnEligibilityChange(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
-		EventBus:           eventBus,
 		EvaluationInterval: time.Hour,
 	})
 	ctx := t.Context()
@@ -778,16 +743,7 @@ func TestChainSelectorSwitchesImmediatelyOnEligibilityEvent(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 
-	eventBus.Publish(
-		peergov.PeerEligibilityChangedEventType,
-		event.NewEvent(
-			peergov.PeerEligibilityChangedEventType,
-			peergov.PeerEligibilityChangedEvent{
-				ConnectionId: incumbentConn,
-				Eligible:     false,
-			},
-		),
-	)
+	cs.SetConnectionEligible(incumbentConn, false)
 
 	require.Eventually(t, func() bool {
 		bestPeer := cs.GetBestPeer()
@@ -795,14 +751,10 @@ func TestChainSelectorSwitchesImmediatelyOnEligibilityEvent(t *testing.T) {
 	}, time.Second, 5*time.Millisecond)
 }
 
-func TestChainSelectorDoesNotSwitchEqualTipIncumbentOnPriorityEvent(
+func TestChainSelectorDoesNotSwitchEqualTipIncumbentOnPriorityChange(
 	t *testing.T,
 ) {
-	eventBus := event.NewEventBus(nil, nil)
-	defer eventBus.Stop()
-
 	cs := NewChainSelector(ChainSelectorConfig{
-		EventBus:           eventBus,
 		EvaluationInterval: time.Hour,
 	})
 	ctx := t.Context()
@@ -820,16 +772,7 @@ func TestChainSelectorDoesNotSwitchEqualTipIncumbentOnPriorityEvent(
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 
-	eventBus.Publish(
-		peergov.PeerPriorityChangedEventType,
-		event.NewEvent(
-			peergov.PeerPriorityChangedEventType,
-			peergov.PeerPriorityChangedEvent{
-				ConnectionId: challengerConn,
-				Priority:     40,
-			},
-		),
-	)
+	cs.SetConnectionPriority(challengerConn, 40)
 
 	require.Never(t, func() bool {
 		bestPeer := cs.GetBestPeer()

--- a/node.go
+++ b/node.go
@@ -582,6 +582,29 @@ func (n *Node) Run(ctx context.Context) error {
 			n.deleteChainsyncIngressEligibility(e.ConnectionId)
 		},
 	)
+	// Forward peer-governance eligibility and priority updates to the chain
+	// selector. Subscription is placed here (node composition layer) so that
+	// chainselection/ has no dependency on peergov/.
+	n.eventBus.SubscribeFunc(
+		peergov.PeerEligibilityChangedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(peergov.PeerEligibilityChangedEvent)
+			if !ok {
+				return
+			}
+			n.chainSelector.SetConnectionEligible(e.ConnectionId, e.Eligible)
+		},
+	)
+	n.eventBus.SubscribeFunc(
+		peergov.PeerPriorityChangedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(peergov.PeerPriorityChangedEvent)
+			if !ok {
+				return
+			}
+			n.chainSelector.SetConnectionPriority(e.ConnectionId, e.Priority)
+		},
+	)
 	// Start the chain selector
 	if err := n.chainSelector.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("failed to start chain selector: %w", err)

--- a/node_test.go
+++ b/node_test.go
@@ -708,3 +708,90 @@ func TestCloseWithShutdownTimeoutReturnsTimeoutError(t *testing.T) {
 		"close function completion",
 	)
 }
+
+// TestNodePeerEligibilityEventUpdatesChainSelector verifies the node wiring:
+// a PeerEligibilityChangedEvent published on the event bus must be forwarded
+// to the ChainSelector so that the now-ineligible peer is no longer selected.
+func TestNodePeerEligibilityEventUpdatesChainSelector(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+
+	cs := chainselection.NewChainSelector(chainselection.ChainSelectorConfig{
+		EvaluationInterval: time.Hour, // driven by trigger, not ticker
+	})
+	require.NoError(t, cs.Start(t.Context()))
+
+	connId := newNodeTestConnId(5001)
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, []byte("tip")),
+		BlockNumber: 50,
+	}, nil)
+	require.NotNil(t, cs.GetBestPeer(), "peer should be selected before ineligibility")
+
+	// Mirror the subscription wiring in node.go.
+	bus.SubscribeFunc(peergov.PeerEligibilityChangedEventType, func(evt event.Event) {
+		e, ok := evt.Data.(peergov.PeerEligibilityChangedEvent)
+		if !ok {
+			return
+		}
+		cs.SetConnectionEligible(e.ConnectionId, e.Eligible)
+	})
+
+	bus.Publish(
+		peergov.PeerEligibilityChangedEventType,
+		event.NewEvent(
+			peergov.PeerEligibilityChangedEventType,
+			peergov.PeerEligibilityChangedEvent{ConnectionId: connId, Eligible: false},
+		),
+	)
+
+	require.Eventually(t, func() bool {
+		return cs.GetBestPeer() == nil
+	}, time.Second, 5*time.Millisecond,
+		"ineligible peer must not be selected after eligibility event")
+}
+
+// TestNodePeerPriorityEventUpdatesChainSelector verifies the node wiring:
+// a PeerPriorityChangedEvent published on the event bus must be forwarded
+// to the ChainSelector so that the higher-priority peer wins equal-tip
+// selection.
+func TestNodePeerPriorityEventUpdatesChainSelector(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+
+	cs := chainselection.NewChainSelector(chainselection.ChainSelectorConfig{})
+	lowPrioConn := newNodeTestConnId(5002)
+	highPrioConn := newNodeTestConnId(5003)
+
+	equalTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, []byte("equal")),
+		BlockNumber: 50,
+	}
+	cs.UpdatePeerTip(lowPrioConn, equalTip, nil)
+	cs.UpdatePeerTip(highPrioConn, equalTip, nil)
+
+	// Mirror the subscription wiring in node.go.
+	bus.SubscribeFunc(peergov.PeerPriorityChangedEventType, func(evt event.Event) {
+		e, ok := evt.Data.(peergov.PeerPriorityChangedEvent)
+		if !ok {
+			return
+		}
+		cs.SetConnectionPriority(e.ConnectionId, e.Priority)
+	})
+
+	bus.Publish(
+		peergov.PeerPriorityChangedEventType,
+		event.NewEvent(
+			peergov.PeerPriorityChangedEventType,
+			peergov.PeerPriorityChangedEvent{ConnectionId: highPrioConn, Priority: 50},
+		),
+	)
+
+	// SelectBestChain does a pure comparison with no incumbent bias, so once
+	// the priority event has been processed the higher-priority peer wins.
+	require.Eventually(t, func() bool {
+		best := cs.SelectBestChain()
+		return best != nil && *best == highPrioConn
+	}, time.Second, 5*time.Millisecond,
+		"higher-priority peer must win equal-tip selection after priority event")
+}


### PR DESCRIPTION
Closes #2384 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled `chainselection` from `peergov` by adding setters for peer eligibility and priority, and moving event subscriptions to the `Node` layer. Behavior stays the same and tests now cover setter logic and node-level forwarding. Closes #2384.

- **Refactors**
  - Removed `peergov` dependency and event subscriptions from `chainselection`.
  - Added `SetConnectionEligible(connId, eligible)` and `SetConnectionPriority(connId, priority)` (both trigger re-evaluation).
  - Use delete-on-default (`eligible=true`, `priority=0`) to avoid stale entries from out-of-order updates.
  - Subscribed in `node.go` to `peergov` events and forward to the setters; updated tests to cover setters and node wiring.

- **Migration**
  - If you use `chainselection` directly, call the new setters or wire your own event forwarding.
  - No changes if you use `Node` and the shared event bus; behavior is unchanged.

<sup>Written for commit 7375a0e6e8a3c119714ac2d25cea8263512d5b84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated chain selector to use direct setter methods for managing peer eligibility and priority instead of event-based updates. This decouples the chain selection logic from peer governance event handling.

* **Tests**
  * Updated and added tests to verify peer eligibility and priority updates trigger appropriate chain selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->