### PR TITLE
refactor(ledger): move peer-governance adapter out of ledger package

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,6 +166,7 @@ graph LR
     topology["topology"]
     intcfg["internal/config"]
     intnode["internal/node"]
+    intnode_ledgerpeers["internal/node/ledgerpeers"]
     utxorpc["api/utxorpc"]
     blockfrost["api/blockfrost"]
     mesh["api/mesh"]
@@ -176,6 +177,7 @@ graph LR
     root --> chain & chainsync & chainsel & connmgr & db & ev
     root --> ledger & ledger_forging & ledger_leader & ledger_leios & ledger_snapshot
     root --> mempool & ouroboros & peergov & topology
+    root --> intnode_ledgerpeers
     root --> utxorpc & blockfrost & mesh & bark & cardano_cfg
 
     cmd --> root & cardano_cfg & db & db_models & db_plugin
@@ -187,6 +189,7 @@ graph LR
     chainsel --> ev & peergov
     connmgr --> ev
     peergov --> connmgr & ev & topology
+    intnode_ledgerpeers --> ledger & peergov
 
     ouroboros --> chain & chainsel & chainsync & connmgr
     ouroboros --> ev & ledger & mempool & peergov
@@ -194,7 +197,7 @@ graph LR
     ledger --> chain & chainsel & cardano_cfg & connmgr
     ledger --> db & db_models & db_meta & db_types & ev
     ledger --> ledger_eras & ledger_forging & ledger_governance & ledger_hardfork
-    ledger --> mempool & peergov
+    ledger --> mempool
     ledger_eras --> cardano_cfg & ledger_hardfork
     ledger_forging --> ev & ledger_eras
     ledger_governance --> db & db_models & db_types & ledger_eras
@@ -1101,6 +1104,11 @@ later ledger peer refreshes still query the live ledger/database provider.
 If the snapshot produces no usable peers, startup falls back to topology
 bootstrap peers.
 
+Live ledger peer discovery is adapted at the node composition boundary:
+`ledger/` exposes stake pool relay data and current slot through neutral
+ledger/database types, while `internal/node/ledgerpeers` converts that data to
+the `peergov.LedgerPeerProvider` interface consumed by the peer governor.
+
 Bootstrap peers are used during initial sync and recovery. Bootstrap exit can
 be triggered by enough connected ledger peers, or by the configured slot/progress
 thresholds once at least one non-bootstrap client-capable successor is
@@ -1310,6 +1318,8 @@ Package isolation is enforced by direction, ownership, and composition:
 - `ledger/` owns validation, ledger state, rollback state repair, nonce/epoch
   logic, and ledger queries. Network connection action should be requested via
   neutral events or callbacks rather than direct connection-manager coupling.
+  Peer-governance policy types should be adapted outside `ledger/`, at the
+  node composition boundary.
 - `mempool/` owns pending transaction admission, eviction, and relay state. It
   depends on a transaction-validation interface supplied by ledger, not on a
   concrete ledger implementation.
@@ -1339,7 +1349,7 @@ Storage backends are loaded dynamically through a plugin registry, allowing exte
 
 ### Adapter Pattern
 
-The block production system uses adapters (`mempoolAdapter`, `stakeDistributionAdapter`, `epochInfoAdapter`, `slotClockAdapter`) to decouple forging interfaces from concrete implementations.
+The block production system uses adapters (`mempoolAdapter`, `stakeDistributionAdapter`, `epochInfoAdapter`, `slotClockAdapter`) to decouple forging interfaces from concrete implementations. Node wiring also adapts neutral ledger relay data to `peergov.LedgerPeerProvider` in `internal/node/ledgerpeers`.
 
 ### Observer Pattern
 

--- a/internal/node/ledgerpeers/provider.go
+++ b/internal/node/ledgerpeers/provider.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerpeers
+
+import (
+	"net"
+
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/peergov"
+)
+
+type relayProvider interface {
+	GetPoolRelays() ([]ledger.PoolRelay, error)
+	CurrentSlot() uint64
+}
+
+// Provider adapts ledger relay data to the peer-governance provider interface.
+type Provider struct {
+	relays relayProvider
+}
+
+// NewProvider creates a peer-governance ledger peer provider from a neutral
+// ledger relay provider.
+func NewProvider(relays relayProvider) *Provider {
+	return &Provider{
+		relays: relays,
+	}
+}
+
+// GetPoolRelays returns active stake pool relays in peer-governance terms.
+func (p *Provider) GetPoolRelays() ([]peergov.PoolRelay, error) {
+	relays, err := p.relays.GetPoolRelays()
+	if err != nil {
+		return nil, err
+	}
+	return toPeerGovRelays(relays), nil
+}
+
+// CurrentSlot returns the current chain tip slot number.
+func (p *Provider) CurrentSlot() uint64 {
+	return p.relays.CurrentSlot()
+}
+
+func toPeerGovRelays(relays []ledger.PoolRelay) []peergov.PoolRelay {
+	result := make([]peergov.PoolRelay, len(relays))
+	for i, relay := range relays {
+		result[i] = peergov.PoolRelay{
+			Hostname: relay.Hostname,
+			Port:     relay.Port,
+			IPv4:     copyIP(relay.IPv4),
+			IPv6:     copyIP(relay.IPv6),
+		}
+	}
+	return result
+}
+
+func copyIP(ip *net.IP) *net.IP {
+	if ip == nil {
+		return nil
+	}
+	ipCopy := make(net.IP, len(*ip))
+	copy(ipCopy, *ip)
+	return &ipCopy
+}
+
+var _ peergov.LedgerPeerProvider = (*Provider)(nil)

--- a/internal/node/ledgerpeers/provider_test.go
+++ b/internal/node/ledgerpeers/provider_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledgerpeers
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+type testRelayProvider struct {
+	relays []ledger.PoolRelay
+	slot   uint64
+	err    error
+}
+
+func (p *testRelayProvider) GetPoolRelays() ([]ledger.PoolRelay, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.relays, nil
+}
+
+func (p *testRelayProvider) CurrentSlot() uint64 {
+	return p.slot
+}
+
+func TestProviderConvertsLedgerRelays(t *testing.T) {
+	ipv4 := net.ParseIP("44.0.1.1").To4()
+	ipv6 := net.ParseIP("2001:db8::1")
+	provider := NewProvider(&testRelayProvider{
+		relays: []ledger.PoolRelay{
+			{
+				Hostname: "relay.example.com",
+				Port:     3002,
+			},
+			{
+				IPv4: &ipv4,
+				Port: 3003,
+			},
+			{
+				IPv6: &ipv6,
+				Port: 3004,
+			},
+			{
+				Hostname: "default-port.example.com",
+			},
+		},
+	})
+
+	relays, err := provider.GetPoolRelays()
+	require.NoError(t, err)
+	require.Len(t, relays, 4)
+
+	require.Equal(t, "relay.example.com", relays[0].Hostname)
+	require.Equal(t, uint(3002), relays[0].Port)
+
+	require.NotNil(t, relays[1].IPv4)
+	require.Equal(t, net.ParseIP("44.0.1.1").To4(), *relays[1].IPv4)
+	require.Equal(t, uint(3003), relays[1].Port)
+
+	require.NotNil(t, relays[2].IPv6)
+	require.Equal(t, net.ParseIP("2001:db8::1"), *relays[2].IPv6)
+	require.Equal(t, uint(3004), relays[2].Port)
+
+	require.Equal(t, "default-port.example.com", relays[3].Hostname)
+	require.Zero(t, relays[3].Port)
+}
+
+func TestProviderCurrentSlot(t *testing.T) {
+	provider := NewProvider(&testRelayProvider{slot: 12345})
+
+	require.Equal(t, uint64(12345), provider.CurrentSlot())
+}
+
+func TestProviderReturnsRelayCopy(t *testing.T) {
+	ipv4 := net.ParseIP("44.0.1.1").To4()
+	source := &testRelayProvider{
+		relays: []ledger.PoolRelay{
+			{
+				Hostname: "relay.example.com",
+				IPv4:     &ipv4,
+				Port:     3001,
+			},
+		},
+	}
+	provider := NewProvider(source)
+
+	relays, err := provider.GetPoolRelays()
+	require.NoError(t, err)
+	require.Len(t, relays, 1)
+	relays[0].Hostname = "mutated.example.com"
+	(*relays[0].IPv4)[0] = 99
+
+	require.Equal(t, "relay.example.com", source.relays[0].Hostname)
+	require.Equal(t, net.ParseIP("44.0.1.1").To4(), *source.relays[0].IPv4)
+}
+
+func TestProviderReturnsRelayProviderError(t *testing.T) {
+	expectedErr := errors.New("relay read failed")
+	provider := NewProvider(&testRelayProvider{err: expectedErr})
+
+	relays, err := provider.GetPoolRelays()
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, relays)
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3895,8 +3895,7 @@ func (ls *LedgerState) logSyncProgress(currentSlot uint64) {
 }
 
 // SyncProgress returns the current sync progress as a value between
-// 0.0 (unknown/just started) and 1.0 (fully synced). This implements
-// the peergov.SyncProgressProvider interface, allowing the peer
+// 0.0 (unknown/just started) and 1.0 (fully synced), allowing the peer
 // governor to exit bootstrap mode once sync reaches its threshold.
 func (ls *LedgerState) SyncProgress() float64 {
 	upstreamTip := ls.syncUpstreamTipSlot.Load()

--- a/ledger/peer_provider.go
+++ b/ledger/peer_provider.go
@@ -23,39 +23,47 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/peergov"
 )
 
 const defaultRelayCacheTTL = 1 * time.Minute
 
-// LedgerPeerProviderAdapter implements peergov.LedgerPeerProvider using
-// the ledger state and database to discover stake pool relays.
-type LedgerPeerProviderAdapter struct {
+// PoolRelay represents a stake pool relay as exposed by the ledger/database
+// boundary.
+type PoolRelay struct {
+	Hostname string
+	IPv4     *net.IP
+	IPv6     *net.IP
+	Port     uint
+}
+
+// PoolRelayProvider exposes active stake pool relays from the ledger/database
+// without depending on peer-governance policy types.
+type PoolRelayProvider struct {
 	ledgerState *LedgerState
 	db          *database.Database
 
 	// Cache for pool relays
 	cacheMu      sync.RWMutex
-	cachedRelays []peergov.PoolRelay
+	cachedRelays []PoolRelay
 	cacheTime    time.Time
 	cacheTTL     time.Duration
 	cacheGen     uint64
 }
 
-// NewLedgerPeerProvider creates a new LedgerPeerProvider adapter.
+// NewPoolRelayProvider creates a new ledger pool relay provider.
 // Returns an error if ledgerState or db is nil.
-func NewLedgerPeerProvider(
+func NewPoolRelayProvider(
 	ledgerState *LedgerState,
 	db *database.Database,
 	eventBus *event.EventBus,
-) (*LedgerPeerProviderAdapter, error) {
+) (*PoolRelayProvider, error) {
 	if ledgerState == nil {
 		return nil, errors.New("ledgerState cannot be nil")
 	}
 	if db == nil {
 		return nil, errors.New("db cannot be nil")
 	}
-	adapter := &LedgerPeerProviderAdapter{
+	provider := &PoolRelayProvider{
 		ledgerState: ledgerState,
 		db:          db,
 		cacheTTL:    defaultRelayCacheTTL,
@@ -64,16 +72,16 @@ func NewLedgerPeerProvider(
 		eventBus.SubscribeFunc(
 			PoolStateRestoredEventType,
 			func(_ event.Event) {
-				adapter.InvalidateCache()
+				provider.InvalidateCache()
 			},
 		)
 	}
-	return adapter, nil
+	return provider, nil
 }
 
 // GetPoolRelays returns all active pool relays from the ledger.
-func (p *LedgerPeerProviderAdapter) GetPoolRelays() (
-	[]peergov.PoolRelay,
+func (p *PoolRelayProvider) GetPoolRelays() (
+	[]PoolRelay,
 	error,
 ) {
 	// Check cache first (read lock)
@@ -92,9 +100,9 @@ func (p *LedgerPeerProviderAdapter) GetPoolRelays() (
 		return nil, fmt.Errorf("GetActivePoolRelays: fetch relays: %w", err)
 	}
 
-	result := make([]peergov.PoolRelay, 0, len(relays))
+	result := make([]PoolRelay, 0, len(relays))
 	for _, relay := range relays {
-		pr := peergov.PoolRelay{
+		pr := PoolRelay{
 			Hostname: relay.Hostname,
 			Port:     relay.Port,
 		}
@@ -121,7 +129,7 @@ func (p *LedgerPeerProviderAdapter) GetPoolRelays() (
 
 // InvalidateCache clears the cached pool relays, forcing the next
 // GetPoolRelays call to fetch fresh data from the database.
-func (p *LedgerPeerProviderAdapter) InvalidateCache() {
+func (p *PoolRelayProvider) InvalidateCache() {
 	p.cacheMu.Lock()
 	p.cachedRelays = nil
 	p.cacheTime = time.Time{}
@@ -130,17 +138,17 @@ func (p *LedgerPeerProviderAdapter) InvalidateCache() {
 }
 
 // CurrentSlot returns the current chain tip slot number.
-func (p *LedgerPeerProviderAdapter) CurrentSlot() uint64 {
+func (p *PoolRelayProvider) CurrentSlot() uint64 {
 	tip := p.ledgerState.Tip()
 	return tip.Point.Slot
 }
 
 // copyPoolRelays returns a deep copy of the given relay slice so that
 // callers cannot mutate cached state through shared IP pointers.
-func copyPoolRelays(relays []peergov.PoolRelay) []peergov.PoolRelay {
-	result := make([]peergov.PoolRelay, len(relays))
+func copyPoolRelays(relays []PoolRelay) []PoolRelay {
+	result := make([]PoolRelay, len(relays))
 	for i, r := range relays {
-		result[i] = peergov.PoolRelay{
+		result[i] = PoolRelay{
 			Hostname: r.Hostname,
 			Port:     r.Port,
 		}
@@ -157,6 +165,3 @@ func copyPoolRelays(relays []peergov.PoolRelay) []peergov.PoolRelay {
 	}
 	return result
 }
-
-// Ensure LedgerPeerProviderAdapter implements LedgerPeerProvider
-var _ peergov.LedgerPeerProvider = (*LedgerPeerProviderAdapter)(nil)

--- a/ledger/peer_provider_test.go
+++ b/ledger/peer_provider_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/peergov"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +38,7 @@ func newTestDB(t *testing.T) *database.Database {
 	return db
 }
 
-// newTestAdapter creates a LedgerPeerProviderAdapter with the given
+// newTestAdapter creates a PoolRelayProvider with the given
 // parameters. It uses a minimal LedgerState and the provided database.
 // The cacheTTL is set to the given value.
 func newTestAdapter(
@@ -47,20 +46,20 @@ func newTestAdapter(
 	db *database.Database,
 	eventBus *event.EventBus,
 	cacheTTL time.Duration,
-) *LedgerPeerProviderAdapter {
+) *PoolRelayProvider {
 	t.Helper()
 	ls := &LedgerState{db: db}
-	adapter, err := NewLedgerPeerProvider(ls, db, eventBus)
+	adapter, err := NewPoolRelayProvider(ls, db, eventBus)
 	require.NoError(t, err)
 	adapter.cacheTTL = cacheTTL
 	return adapter
 }
 
 // sampleRelays returns a slice of pool relays for use in tests.
-func sampleRelays() []peergov.PoolRelay {
+func sampleRelays() []PoolRelay {
 	ipv4 := net.ParseIP("192.168.1.1").To4()
 	ipv6 := net.ParseIP("::1")
-	return []peergov.PoolRelay{
+	return []PoolRelay{
 		{
 			Hostname: "relay1.example.com",
 			Port:     3001,
@@ -77,8 +76,8 @@ func sampleRelays() []peergov.PoolRelay {
 // seedCache injects relay data directly into the adapter's cache,
 // simulating a previous successful fetch from the database.
 func seedCache(
-	adapter *LedgerPeerProviderAdapter,
-	relays []peergov.PoolRelay,
+	adapter *PoolRelayProvider,
+	relays []PoolRelay,
 ) {
 	adapter.cacheMu.Lock()
 	adapter.cachedRelays = relays
@@ -86,24 +85,24 @@ func seedCache(
 	adapter.cacheMu.Unlock()
 }
 
-func TestLedgerPeerProviderNewErrors(t *testing.T) {
+func TestPoolRelayProviderNewErrors(t *testing.T) {
 	db := newTestDB(t)
 	ls := &LedgerState{db: db}
 
 	t.Run("nil ledgerState", func(t *testing.T) {
-		_, err := NewLedgerPeerProvider(nil, db, nil)
+		_, err := NewPoolRelayProvider(nil, db, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "ledgerState")
 	})
 
 	t.Run("nil db", func(t *testing.T) {
-		_, err := NewLedgerPeerProvider(ls, nil, nil)
+		_, err := NewPoolRelayProvider(ls, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "db")
 	})
 }
 
-func TestLedgerPeerProviderCacheHit(t *testing.T) {
+func TestPoolRelayProviderCacheHit(t *testing.T) {
 	db := newTestDB(t)
 	// Use a long TTL so the cache never expires during the test
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
@@ -131,7 +130,7 @@ func TestLedgerPeerProviderCacheHit(t *testing.T) {
 	adapter.cacheMu.RUnlock()
 }
 
-func TestLedgerPeerProviderCacheTTLExpiry(t *testing.T) {
+func TestPoolRelayProviderCacheTTLExpiry(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Millisecond)
 
@@ -158,7 +157,7 @@ func TestLedgerPeerProviderCacheTTLExpiry(t *testing.T) {
 	require.Empty(t, result, "expected empty relays after TTL expiry since DB has no data")
 }
 
-func TestLedgerPeerProviderInvalidateCache(t *testing.T) {
+func TestPoolRelayProviderInvalidateCache(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
 
@@ -189,7 +188,7 @@ func TestLedgerPeerProviderInvalidateCache(t *testing.T) {
 	)
 }
 
-func TestLedgerPeerProviderEventDrivenInvalidation(t *testing.T) {
+func TestPoolRelayProviderEventDrivenInvalidation(t *testing.T) {
 	db := newTestDB(t)
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(func() { bus.Stop() })
@@ -229,7 +228,7 @@ func TestLedgerPeerProviderEventDrivenInvalidation(t *testing.T) {
 	require.Empty(t, result)
 }
 
-func TestLedgerPeerProviderDeepCopy(t *testing.T) {
+func TestPoolRelayProviderDeepCopy(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
 
@@ -249,7 +248,7 @@ func TestLedgerPeerProviderDeepCopy(t *testing.T) {
 	}
 
 	// Append to the slice to verify slice header independence
-	result1 = append(result1, peergov.PoolRelay{
+	result1 = append(result1, PoolRelay{
 		Hostname: "extra.example.com",
 		Port:     1234,
 	})
@@ -286,12 +285,12 @@ func TestLedgerPeerProviderDeepCopy(t *testing.T) {
 	require.Equal(t, net.ParseIP("::1"), *result2[1].IPv6)
 }
 
-func TestLedgerPeerProviderDeepCopyIPv6(t *testing.T) {
+func TestPoolRelayProviderDeepCopyIPv6(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
 
 	ipv6 := net.ParseIP("2001:db8::1")
-	relays := []peergov.PoolRelay{
+	relays := []PoolRelay{
 		{
 			Hostname: "relay.example.com",
 			Port:     3001,
@@ -318,12 +317,12 @@ func TestLedgerPeerProviderDeepCopyIPv6(t *testing.T) {
 	)
 }
 
-func TestLedgerPeerProviderNilEventBus(t *testing.T) {
+func TestPoolRelayProviderNilEventBus(t *testing.T) {
 	db := newTestDB(t)
 	ls := &LedgerState{db: db}
 
 	// Constructing with nil eventBus should not panic
-	adapter, err := NewLedgerPeerProvider(ls, db, nil)
+	adapter, err := NewPoolRelayProvider(ls, db, nil)
 	require.NoError(t, err)
 	require.NotNil(t, adapter)
 
@@ -336,7 +335,7 @@ func TestLedgerPeerProviderNilEventBus(t *testing.T) {
 	adapter.InvalidateCache()
 }
 
-func TestLedgerPeerProviderCacheMissFetchesFromDB(t *testing.T) {
+func TestPoolRelayProviderCacheMissFetchesFromDB(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
 
@@ -352,18 +351,18 @@ func TestLedgerPeerProviderCacheMissFetchesFromDB(t *testing.T) {
 	adapter.cacheMu.RUnlock()
 }
 
-func TestLedgerPeerProviderCurrentSlot(t *testing.T) {
+func TestPoolRelayProviderCurrentSlot(t *testing.T) {
 	db := newTestDB(t)
 	ls := &LedgerState{db: db}
 
-	adapter, err := NewLedgerPeerProvider(ls, db, nil)
+	adapter, err := NewPoolRelayProvider(ls, db, nil)
 	require.NoError(t, err)
 
 	// Default tip is zero
 	require.Equal(t, uint64(0), adapter.CurrentSlot())
 }
 
-func TestLedgerPeerProviderInvalidateCacheIdempotent(t *testing.T) {
+func TestPoolRelayProviderInvalidateCacheIdempotent(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
 
@@ -379,7 +378,7 @@ func TestLedgerPeerProviderInvalidateCacheIdempotent(t *testing.T) {
 	adapter.cacheMu.RUnlock()
 }
 
-func TestLedgerPeerProviderConcurrentAccess(t *testing.T) {
+func TestPoolRelayProviderConcurrentAccess(t *testing.T) {
 	db := newTestDB(t)
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(func() { bus.Stop() })
@@ -429,12 +428,12 @@ func TestLedgerPeerProviderConcurrentAccess(t *testing.T) {
 	}
 }
 
-func TestLedgerPeerProviderCacheNilIPFields(t *testing.T) {
+func TestPoolRelayProviderCacheNilIPFields(t *testing.T) {
 	db := newTestDB(t)
 	adapter := newTestAdapter(t, db, nil, 10*time.Minute)
 
 	// Relay with no IP addresses (hostname-only relay)
-	relays := []peergov.PoolRelay{
+	relays := []PoolRelay{
 		{
 			Hostname: "hostname-only.example.com",
 			Port:     3001,
@@ -453,11 +452,11 @@ func TestLedgerPeerProviderCacheNilIPFields(t *testing.T) {
 	require.Nil(t, result[0].IPv6)
 }
 
-func TestLedgerPeerProviderDefaultTTL(t *testing.T) {
+func TestPoolRelayProviderDefaultTTL(t *testing.T) {
 	db := newTestDB(t)
 	ls := &LedgerState{db: db}
 
-	adapter, err := NewLedgerPeerProvider(ls, db, nil)
+	adapter, err := NewPoolRelayProvider(ls, db, nil)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -471,7 +470,7 @@ func TestCopyPoolRelaysEmpty(t *testing.T) {
 	result := copyPoolRelays(nil)
 	require.Empty(t, result)
 
-	result = copyPoolRelays([]peergov.PoolRelay{})
+	result = copyPoolRelays([]PoolRelay{})
 	require.Empty(t, result)
 	require.NotNil(t, result)
 }
@@ -479,7 +478,7 @@ func TestCopyPoolRelaysEmpty(t *testing.T) {
 func TestCopyPoolRelaysFull(t *testing.T) {
 	ipv4 := net.ParseIP("10.0.0.1").To4()
 	ipv6 := net.ParseIP("fe80::1")
-	original := []peergov.PoolRelay{
+	original := []PoolRelay{
 		{
 			Hostname: "test.example.com",
 			Port:     3001,

--- a/node.go
+++ b/node.go
@@ -37,6 +37,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/historyexpiry"
+	"github.com/blinklabs-io/dingo/internal/node/ledgerpeers"
 	"github.com/blinklabs-io/dingo/internal/offchainmetadata"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
@@ -624,15 +625,16 @@ func (n *Node) Run(ctx context.Context) error {
 	)
 	// Configure peer governor before opening listeners so topology-driven
 	// outbound connections start first and do not lose the race to inbounds.
-	// Create ledger peer provider for discovering peers from stake pool relays.
-	ledgerPeerProvider, err := ledger.NewLedgerPeerProvider(
+	// Create ledger relay provider for discovering peers from stake pool relays.
+	ledgerRelayProvider, err := ledger.NewPoolRelayProvider(
 		n.ledgerState,
 		n.db,
 		n.eventBus,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create ledger peer provider: %w", err)
+		return fmt.Errorf("failed to create ledger relay provider: %w", err)
 	}
+	ledgerPeerProvider := ledgerpeers.NewProvider(ledgerRelayProvider)
 
 	// Get UseLedgerAfterSlot from topology config (defaults to -1 = disabled).
 	var useLedgerAfterSlot int64 = -1


### PR DESCRIPTION
1. Made changes to move the ledger peer-governance adapter out of ledger/ and into node composition wiring where `ledger/` now exposes active pool relay data through neutral ledger-owned types, while `internal/node/ledgerpeers` adapts that data to `peergov.LedgerPeerProvider`.
2. Added neutral ledger.PoolRelay/ ledger.PoolRelayProvider.
3. Moved `peergov.LedgerPeerProvider` implementation to `internal/node/ledgerpeers`.
4. Updated `node.go` to wrap the ledger relay provider before passing it to peer governance.
5. Preserved relay cache behavior, current-slot reporting, and pool-state cache invalidation
6. Updated `ARCHITECTURE.md` for the new package boundary

Closes #2382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal peer discovery architecture to improve separation of concerns between ledger relay data and peer-governance interaction.

* **Documentation**
  * Updated architecture documentation to reflect the new composition of ledger peer discovery components.

* **Tests**
  * Added and updated comprehensive test coverage for peer relay provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored peer-governance wiring by moving the adapter out of `ledger/` into node composition. `ledger/` now exposes neutral pool relay data, and `internal/node/ledgerpeers` adapts it to `peergov.LedgerPeerProvider`.

- **Refactors**
  - Introduced `ledger.PoolRelay` and `ledger.PoolRelayProvider`; moved the provider adapter to `internal/node/ledgerpeers`.
  - Updated `node.go` to wrap the ledger relay provider with the new adapter.
  - Preserved relay caching, current-slot reporting, and event-driven cache invalidation.
  - Updated `ARCHITECTURE.md` and added tests covering adapter conversion and deep-copy behavior.

<sup>Written for commit a39c5ee6d7f69feefbffee7d7660a92ca5aee5ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

