### PR TITLE
refactor(chainsync): depend on chain iterator interface instead of le…

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -17,6 +17,7 @@ package chainsync
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -24,9 +25,9 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/connection"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -149,13 +150,34 @@ func DefaultConfig() Config {
 	}
 }
 
+// ChainProvider is the minimal interface chainsync requires from the ledger
+// layer: local chain iteration for N2C server clients and the stability-window
+// value used to bound the seen-header deduplication cache.
+type ChainProvider interface {
+	GetChainFromPoint(point ocommon.Point, inclusive bool) (*chain.ChainIterator, error)
+	StabilityWindow() uint64
+}
+
+// ObservedHeader is a chainsync-owned record of a header received from a peer
+// before cross-peer deduplication may suppress it. It carries enough context
+// for fork resolution to reconstruct a peer's candidate fragment later.
+type ObservedHeader struct {
+	ConnectionId ouroboros.ConnectionId
+	BlockHeader  gledger.BlockHeader
+	Point        ocommon.Point
+	Tip          ochainsync.Tip
+	BlockNumber  uint64
+	Type         uint
+	Rollback     bool
+}
+
 // State manages chainsync client connections and header
 // tracking for both server-side (N2C) and outbound (N2N)
 // connections.
 type State struct {
-	eventBus    *event.EventBus
-	ledgerState *ledger.LedgerState
-	config      Config
+	eventBus      *event.EventBus
+	chainProvider ChainProvider
+	config        Config
 
 	// Server-side clients (node-to-client connections)
 	clients map[ouroboros.ConnectionId]*ChainsyncClientState
@@ -195,7 +217,7 @@ type headerRecord struct {
 }
 
 type observedHeaderRecord struct {
-	event    ledger.ChainsyncEvent
+	header   ObservedHeader
 	prevHash []byte
 }
 
@@ -207,19 +229,19 @@ type observedHeaderChain struct {
 const maxObservedHeadersPerConn = 256
 
 // NewState creates a new chainsync State with the given
-// event bus and ledger state using default configuration.
+// event bus and chain provider using default configuration.
 func NewState(
 	eventBus *event.EventBus,
-	ledgerState *ledger.LedgerState,
+	chainProvider ChainProvider,
 ) *State {
-	return NewStateWithConfig(eventBus, ledgerState, DefaultConfig())
+	return NewStateWithConfig(eventBus, chainProvider, DefaultConfig())
 }
 
 // NewStateWithConfig creates a new chainsync State with the
-// given event bus, ledger state, and configuration.
+// given event bus, chain provider, and configuration.
 func NewStateWithConfig(
 	eventBus *event.EventBus,
-	ledgerState *ledger.LedgerState,
+	chainProvider ChainProvider,
 	cfg Config,
 ) *State {
 	if cfg.MaxClients <= 0 {
@@ -230,7 +252,7 @@ func NewStateWithConfig(
 	}
 	s := &State{
 		eventBus:       eventBus,
-		ledgerState:    ledgerState,
+		chainProvider:  chainProvider,
 		config:         cfg,
 		clients:        make(map[ouroboros.ConnectionId]*ChainsyncClientState),
 		trackedClients: make(map[ouroboros.ConnectionId]*TrackedClient),
@@ -262,7 +284,10 @@ func (s *State) AddClient(
 		return existing, nil
 	}
 	// Create initial chainsync state for connection
-	chainIter, err := s.ledgerState.GetChainFromPoint(
+	if s.chainProvider == nil {
+		return nil, errors.New("no chain provider available")
+	}
+	chainIter, err := s.chainProvider.GetChainFromPoint(
 		intersectPoint,
 		false,
 	)
@@ -733,11 +758,11 @@ func (s *State) RewindTrackedClientsTo(
 // cross-peer dedup can suppress delivery into the ledger queue. This lets
 // fork resolution reconstruct the selected peer's candidate fragment even
 // when earlier headers were first seen from another peer.
-func (s *State) RecordObservedHeader(e ledger.ChainsyncEvent) {
-	if e.BlockHeader == nil || len(e.Point.Hash) == 0 {
+func (s *State) RecordObservedHeader(h ObservedHeader) {
+	if h.BlockHeader == nil || len(h.Point.Hash) == 0 {
 		return
 	}
-	prevHash := e.BlockHeader.PrevHash().Bytes()
+	prevHash := h.BlockHeader.PrevHash().Bytes()
 	if len(prevHash) == 0 {
 		return
 	}
@@ -745,23 +770,23 @@ func (s *State) RecordObservedHeader(e ledger.ChainsyncEvent) {
 	s.observedHeadersMutex.Lock()
 	defer s.observedHeadersMutex.Unlock()
 
-	chainHistory := s.observedHeaders[e.ConnectionId]
+	chainHistory := s.observedHeaders[h.ConnectionId]
 	if chainHistory == nil {
 		chainHistory = &observedHeaderChain{
 			order: make([]string, 0, maxObservedHeadersPerConn),
 			byHash: make(map[string]observedHeaderRecord,
 				maxObservedHeadersPerConn),
 		}
-		s.observedHeaders[e.ConnectionId] = chainHistory
+		s.observedHeaders[h.ConnectionId] = chainHistory
 	}
 
-	hashKey := hex.EncodeToString(e.Point.Hash)
+	hashKey := hex.EncodeToString(h.Point.Hash)
 	if _, exists := chainHistory.byHash[hashKey]; exists {
 		return
 	}
 	chainHistory.order = append(chainHistory.order, hashKey)
 	chainHistory.byHash[hashKey] = observedHeaderRecord{
-		event:    e,
+		header:   h,
 		prevHash: append([]byte(nil), prevHash...),
 	}
 	if len(chainHistory.order) <= maxObservedHeadersPerConn {
@@ -777,21 +802,21 @@ func (s *State) RecordObservedHeader(e ledger.ChainsyncEvent) {
 func (s *State) LookupObservedHeader(
 	connId ouroboros.ConnectionId,
 	hash []byte,
-) (ledger.ChainsyncEvent, []byte, bool) {
+) (ObservedHeader, []byte, bool) {
 	s.observedHeadersMutex.RLock()
 	defer s.observedHeadersMutex.RUnlock()
 
 	chainHistory := s.observedHeaders[connId]
 	if chainHistory == nil {
-		return ledger.ChainsyncEvent{}, nil, false
+		return ObservedHeader{}, nil, false
 	}
 	record, ok := chainHistory.byHash[hex.EncodeToString(hash)]
 	if !ok {
-		return ledger.ChainsyncEvent{}, nil, false
+		return ObservedHeader{}, nil, false
 	}
-	record.event.Point.Hash = cloneBytes(record.event.Point.Hash)
-	record.event.Tip.Point.Hash = cloneBytes(record.event.Tip.Point.Hash)
-	return record.event, append([]byte(nil), record.prevHash...), true
+	record.header.Point.Hash = cloneBytes(record.header.Point.Hash)
+	record.header.Tip.Point.Hash = cloneBytes(record.header.Tip.Point.Hash)
+	return record.header, append([]byte(nil), record.prevHash...), true
 }
 
 func (s *State) clearObservedHeaderHistory(
@@ -1118,8 +1143,8 @@ func (s *State) seenHeadersRetention() uint64 {
 	if s.config.SeenHeadersRetention > 0 {
 		return s.config.SeenHeadersRetention
 	}
-	if s.ledgerState != nil {
-		if w := s.ledgerState.StabilityWindow(); w > 0 {
+	if s.chainProvider != nil {
+		if w := s.chainProvider.StabilityWindow(); w > 0 {
 			return w
 		}
 	}

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -784,6 +784,8 @@ func (s *State) RecordObservedHeader(h ObservedHeader) {
 	if _, exists := chainHistory.byHash[hashKey]; exists {
 		return
 	}
+	h.Point.Hash = cloneBytes(h.Point.Hash)
+	h.Tip.Point.Hash = cloneBytes(h.Tip.Point.Hash)
 	chainHistory.order = append(chainHistory.order, hashKey)
 	chainHistory.byHash[hashKey] = observedHeaderRecord{
 		header:   h,

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
-	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -521,19 +521,19 @@ func TestObservedHeaderHistoryPersistsAcrossDedupAndClearsOnRemove(
 		slot:        point.Slot,
 	}
 
-	s.RecordObservedHeader(ledger.ChainsyncEvent{
+	s.RecordObservedHeader(chainsync.ObservedHeader{
 		ConnectionId: conn,
 		Point:        point,
 		BlockHeader:  header,
 		Tip:          tip,
 	})
 
-	recordedEvent, recordedPrevHash, ok := s.LookupObservedHeader(
+	recordedHeader, recordedPrevHash, ok := s.LookupObservedHeader(
 		conn,
 		hash,
 	)
 	require.True(t, ok)
-	require.Equal(t, point, recordedEvent.Point)
+	require.Equal(t, point, recordedHeader.Point)
 	require.Equal(t, header.prevHash.Bytes(), recordedPrevHash)
 
 	s.RemoveClientConnId(conn)
@@ -1429,4 +1429,109 @@ func TestTryAddClientConnIdWithDirection_LimitEnforced(t *testing.T) {
 	require.True(t, s.TryAddClientConnIdWithDirection(connA, 1, true))
 	require.False(t, s.TryAddClientConnIdWithDirection(connB, 1, true))
 	require.Equal(t, 1, s.ClientConnCount())
+}
+
+// --- ChainProvider interface and ObservedHeader record tests ---
+
+// mockChainProvider is a test double for the ChainProvider interface.
+type mockChainProvider struct {
+	iter          *chain.ChainIterator
+	iterErr       error
+	stabilityWin  uint64
+}
+
+func (m *mockChainProvider) GetChainFromPoint(
+	_ ocommon.Point,
+	_ bool,
+) (*chain.ChainIterator, error) {
+	return m.iter, m.iterErr
+}
+
+func (m *mockChainProvider) StabilityWindow() uint64 {
+	return m.stabilityWin
+}
+
+// TestAddClient_NilChainProvider_ReturnsError verifies that AddClient returns
+// an error rather than panicking when no ChainProvider has been wired.
+func TestAddClient_NilChainProvider_ReturnsError(t *testing.T) {
+	s := chainsync.NewStateWithConfig(nil, nil, chainsync.DefaultConfig())
+	conn := newTestConnId(1)
+	_, err := s.AddClient(conn, ocommon.Point{})
+	require.Error(t, err)
+}
+
+// TestAddClient_ChainProviderErrorPropagated verifies that an error from
+// ChainProvider.GetChainFromPoint is returned by AddClient unchanged.
+func TestAddClient_ChainProviderErrorPropagated(t *testing.T) {
+	provider := &mockChainProvider{iterErr: fmt.Errorf("chain lookup failed")}
+	s := chainsync.NewStateWithConfig(nil, provider, chainsync.DefaultConfig())
+	conn := newTestConnId(1)
+	_, err := s.AddClient(conn, ocommon.Point{})
+	require.ErrorContains(t, err, "chain lookup failed")
+}
+
+// TestSeenHeadersRetention_DerivedFromChainProvider verifies that the
+// stability window reported by ChainProvider drives the header dedup cache
+// pruning boundary when no explicit SeenHeadersRetention override is set.
+func TestSeenHeadersRetention_DerivedFromChainProvider(t *testing.T) {
+	const providerWindow = 500
+	provider := &mockChainProvider{stabilityWin: providerWindow}
+	cfg := chainsync.DefaultConfig() // SeenHeadersRetention == 0, falls back to provider
+	s := chainsync.NewStateWithConfig(nil, provider, cfg)
+
+	conn := newTestConnId(1)
+	s.AddClientConnId(conn)
+
+	// Seed an old header then advance the frontier past the prune interval
+	// (seenHeadersPruneInterval = 1000) so a prune scan fires.
+	// slot 100 is older than frontier(1600) − window(500) = 1100, so it
+	// should be evicted.
+	require.True(t, feedHeader(s, conn, 100, "old"))
+	require.True(t, feedHeader(s, conn, 1600, "new"))
+
+	require.Equal(t, 1, s.SeenHeadersLen(),
+		"slot 100 should be pruned by the provider stability window")
+}
+
+// TestObservedHeader_RoundTrip verifies that an ObservedHeader recorded via
+// RecordObservedHeader is returned intact by LookupObservedHeader, with the
+// prev-hash extracted from BlockHeader.PrevHash().
+func TestObservedHeader_RoundTrip(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(42)
+	s.AddClientConnId(conn)
+
+	hash := []byte("block-hash")
+	prev := []byte("prev-hash")
+	point := ocommon.NewPoint(200, hash)
+	tip := ochainsync.Tip{Point: point, BlockNumber: 5}
+	hdr := testBlockHeader{
+		hash:        lcommon.NewBlake2b256(hash),
+		prevHash:    lcommon.NewBlake2b256(prev),
+		blockNumber: 5,
+		slot:        200,
+	}
+
+	s.RecordObservedHeader(chainsync.ObservedHeader{
+		ConnectionId: conn,
+		BlockHeader:  hdr,
+		Point:        point,
+		Tip:          tip,
+		BlockNumber:  5,
+		Type:         1,
+	})
+
+	got, gotPrev, ok := s.LookupObservedHeader(conn, hash)
+	require.True(t, ok)
+	require.Equal(t, point, got.Point)
+	require.Equal(t, tip, got.Tip)
+	require.Equal(t, uint64(5), got.BlockNumber)
+	require.Equal(t, uint(1), got.Type)
+	require.Equal(t, hdr.PrevHash().Bytes(), gotPrev)
+
+	// LookupObservedHeader must not be visible from a different connection.
+	_, _, ok = s.LookupObservedHeader(newTestConnId(99), hash)
+	require.False(t, ok)
 }

--- a/node.go
+++ b/node.go
@@ -317,7 +317,19 @@ func (n *Node) Run(ctx context.Context) error {
 				if n.chainsyncState == nil {
 					return ledger.ChainsyncEvent{}, nil, false
 				}
-				return n.chainsyncState.LookupObservedHeader(connId, hash)
+				h, prevHash, ok := n.chainsyncState.LookupObservedHeader(connId, hash)
+				if !ok {
+					return ledger.ChainsyncEvent{}, nil, false
+				}
+				return ledger.ChainsyncEvent{
+					ConnectionId: h.ConnectionId,
+					BlockHeader:  h.BlockHeader,
+					Point:        h.Point,
+					Tip:          h.Tip,
+					BlockNumber:  h.BlockNumber,
+					Type:         h.Type,
+					Rollback:     h.Rollback,
+				}, prevHash, true
 			},
 			FatalErrorFunc: func(err error) {
 				n.config.logger.Error(

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -742,7 +743,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		}
 		if ingressEligible && o.ChainsyncState != nil {
 			o.ChainsyncState.RecordObservedHeader(
-				ledger.ChainsyncEvent{
+				chainsync.ObservedHeader{
 					ConnectionId: ctx.ConnectionId,
 					Point:        point,
 					Type:         blockType,


### PR DESCRIPTION
Closes #2383 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `chainsync` to depend on a small `ChainProvider` interface instead of `ledger.LedgerState`, and added an internal `ObservedHeader` to support cross‑peer dedup and fork handling. Also fixed observed-header hash handling by cloning hash bytes to prevent mutation. Closes #2383.

- **Refactors**
  - Added `ChainProvider` with `GetChainFromPoint` and `StabilityWindow`; `State` and constructors now take a provider, and `AddClient` errors if missing and propagates provider errors.
  - Replaced `RecordObservedHeader(ledger.ChainsyncEvent)`/`LookupObservedHeader` with `chainsync.ObservedHeader`; updated `ouroboros/chainsync` to record it and `node.go` to map back to `ledger.ChainsyncEvent` for compatibility.
  - `seenHeadersRetention` now falls back to `ChainProvider.StabilityWindow`.
  - Breaking: replace `NewState(eventBus, ledgerState)` with `NewState(eventBus, chainProvider)` and pass `chainsync.ObservedHeader` to `RecordObservedHeader`.

- **Bug Fixes**
  - Clone header hash bytes when recording and returning `ObservedHeader` to prevent mutation leaking across peers or callers.

<sup>Written for commit eda4efcf17f144d6e893ed6dd61d2cfdcecca107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal chain synchronization architecture by enhancing component separation
  * Refined header observation handling for more robust chain event tracking
  * Updated retention window calculation for optimized header pruning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->