### PR TITLE
feat(ledger): keep treasury in sync with Conway transaction donations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -864,7 +864,8 @@ Key models in `database/models/`:
 | `PoolStakeSnapshot` | Per-pool stake at epoch boundary |
 | `EpochSummary` | Network-wide aggregates per epoch |
 | `BackfillCheckpoint` | Mithril backfill progress tracking |
-| `NetworkState` | Network-wide state tracking |
+| `NetworkState` | Network-wide state tracking (treasury/reserves) |
+| `NetworkDonation` | Per-block treasury donations, applied to treasury at the epoch boundary |
 | `GovernanceAction` | Governance proposals |
 | `CommitteeMember` | Constitutional committee members |
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -163,6 +163,7 @@ erDiagram
 | `epoch` | `id`, `epoch_id`, `start_slot`, `era_id`, `slot_length`, `length_in_slots`, `nonce`, `evolving_nonce`, `candidate_nonce`, `last_epoch_block_nonce` | PK `id`; unique `epoch_id` | Epoch nonce and era boundary state. Join snapshots and rewards with `epoch.epoch_id = ... .epoch`. |
 | `block_nonce` | `id`, `hash`, `slot`, `nonce`, `is_checkpoint` | PK `id`; unique `(hash, slot)` | Per-block nonce history used by Praos nonce computation. |
 | `network_state` | `id`, `treasury`, `reserves`, `slot` | PK `id`; unique `slot` | Treasury/reserves at a slot. |
+| `network_donation` | `id`, `slot`, `epoch`, `amount` | PK `id`; unique `slot`; index `epoch` | Per-block Conway treasury donation, tagged with its epoch. `amount` is a plain integer column (not `types.Uint64`) so `SUM` aggregates directly across backends. Donations accumulate during an epoch and are moved into `network_state.treasury` at the next epoch boundary; rows are kept (not deleted on apply) so a rollback drops them by slot and re-application re-derives the same total. |
 | `pparams` | `id`, `cbor`, `added_slot`, `epoch`, `era_id` | PK `id`; index `added_slot` | CBOR protocol parameters. Query by `epoch <= ?` and matching `era_id`. |
 | `pparam_update` | `id`, `genesis_hash`, `cbor`, `added_slot`, `epoch` | PK `id`; index `added_slot` | Proposed protocol-parameter updates by epoch. |
 | `sync_state` | `sync_key`, `value` | PK `sync_key` | Ephemeral key/value state for one-time sync/load work. |

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -39,6 +39,7 @@ var MigrateModels = []any{
 	&KeyWitness{},
 	&MoveInstantaneousRewards{},
 	&MoveInstantaneousRewardsReward{},
+	&NetworkDonation{},
 	&NetworkState{},
 	&OffchainMetadata{},
 	&Pool{},

--- a/database/models/network_donation.go
+++ b/database/models/network_donation.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// NetworkDonation records the total Conway treasury donation contributed by a
+// block, tagged with the epoch the block belongs to. Donations accumulate
+// during an epoch and are moved into the treasury at the next epoch boundary
+// (see NetworkState). Rows are keyed by slot so a chain rollback can drop them
+// with DeleteNetworkDonationsAfterSlot, mirroring NetworkState.
+//
+// Amount is a plain uint64 (stored as an integer, like Slot/Epoch) rather than
+// types.Uint64: donation totals are bounded well below 2^63, so an integer
+// column lets SUM aggregate directly across SQLite/Postgres/MySQL without the
+// per-backend CAST that the text-encoded types.Uint64 would require.
+type NetworkDonation struct {
+	ID     uint   `gorm:"primarykey"`
+	Slot   uint64 `gorm:"uniqueIndex;not null"`
+	Epoch  uint64 `gorm:"index;not null"`
+	Amount uint64 `gorm:"not null"`
+}
+
+// TableName returns the table name for NetworkDonation.
+func (NetworkDonation) TableName() string {
+	return "network_donation"
+}

--- a/database/network_donation.go
+++ b/database/network_donation.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "fmt"
+
+// DeleteNetworkDonationsAfterSlot removes donation records added after the
+// given slot. This is used during chain rollbacks, alongside
+// DeleteNetworkStateAfterSlot.
+func (d *Database) DeleteNetworkDonationsAfterSlot(
+	slot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer func() {
+			if owned {
+				txn.Rollback() //nolint:errcheck
+			}
+		}()
+	}
+	if err := d.metadata.DeleteNetworkDonationsAfterSlot(
+		slot,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"failed to delete network donations after slot %d: %w",
+			slot,
+			err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf("commit transaction: %w", err)
+		}
+		owned = false
+	}
+	return nil
+}

--- a/database/plugin/metadata/mysql/network_donation.go
+++ b/database/plugin/metadata/mysql/network_donation.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm/clause"
+)
+
+// AddNetworkDonation records a block's total Conway treasury donation for the
+// given slot and epoch. It is idempotent per slot so re-applying a block (e.g.
+// after a rollback) overwrites rather than double-counts.
+func (d *MetadataStoreMysql) AddNetworkDonation(
+	slot, epoch, amount uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("add network donation: %w", err)
+	}
+	rec := &models.NetworkDonation{
+		Slot:   slot,
+		Epoch:  epoch,
+		Amount: amount,
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{"epoch", "amount"}),
+	}).Create(rec)
+	if result.Error != nil {
+		return fmt.Errorf("add network donation: %w", result.Error)
+	}
+	return nil
+}
+
+// SumNetworkDonationsForEpoch returns the total donation contributed by blocks
+// in the given epoch.
+func (d *MetadataStoreMysql) SumNetworkDonationsForEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf("sum network donations: %w", err)
+	}
+	var total uint64
+	result := db.Model(&models.NetworkDonation{}).
+		Where("epoch = ?", epoch).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"sum network donations for epoch %d: %w", epoch, result.Error,
+		)
+	}
+	return total, nil
+}
+
+// DeleteNetworkDonationsAfterSlot removes donation records added after the
+// given slot. This is used during chain rollbacks.
+func (d *MetadataStoreMysql) DeleteNetworkDonationsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("delete network donations after slot: %w", err)
+	}
+	result := db.Where("slot > ?", slot).
+		Delete(&models.NetworkDonation{})
+	if result.Error != nil {
+		return fmt.Errorf(
+			"delete network donations after slot %d: %w", slot, result.Error,
+		)
+	}
+	return nil
+}

--- a/database/plugin/metadata/postgres/network_donation.go
+++ b/database/plugin/metadata/postgres/network_donation.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm/clause"
+)
+
+// AddNetworkDonation records a block's total Conway treasury donation for the
+// given slot and epoch. It is idempotent per slot so re-applying a block (e.g.
+// after a rollback) overwrites rather than double-counts.
+func (d *MetadataStorePostgres) AddNetworkDonation(
+	slot, epoch, amount uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("add network donation: %w", err)
+	}
+	rec := &models.NetworkDonation{
+		Slot:   slot,
+		Epoch:  epoch,
+		Amount: amount,
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{"epoch", "amount"}),
+	}).Create(rec)
+	if result.Error != nil {
+		return fmt.Errorf("add network donation: %w", result.Error)
+	}
+	return nil
+}
+
+// SumNetworkDonationsForEpoch returns the total donation contributed by blocks
+// in the given epoch.
+func (d *MetadataStorePostgres) SumNetworkDonationsForEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf("sum network donations: %w", err)
+	}
+	var total uint64
+	result := db.Model(&models.NetworkDonation{}).
+		Where("epoch = ?", epoch).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"sum network donations for epoch %d: %w", epoch, result.Error,
+		)
+	}
+	return total, nil
+}
+
+// DeleteNetworkDonationsAfterSlot removes donation records added after the
+// given slot. This is used during chain rollbacks.
+func (d *MetadataStorePostgres) DeleteNetworkDonationsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("delete network donations after slot: %w", err)
+	}
+	result := db.Where("slot > ?", slot).
+		Delete(&models.NetworkDonation{})
+	if result.Error != nil {
+		return fmt.Errorf(
+			"delete network donations after slot %d: %w", slot, result.Error,
+		)
+	}
+	return nil
+}

--- a/database/plugin/metadata/sqlite/network_donation.go
+++ b/database/plugin/metadata/sqlite/network_donation.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm/clause"
+)
+
+// AddNetworkDonation records a block's total Conway treasury donation for the
+// given slot and epoch. It is idempotent per slot so re-applying a block (e.g.
+// after a rollback) overwrites rather than double-counts.
+func (d *MetadataStoreSqlite) AddNetworkDonation(
+	slot, epoch, amount uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("add network donation: %w", err)
+	}
+	rec := &models.NetworkDonation{
+		Slot:   slot,
+		Epoch:  epoch,
+		Amount: amount,
+	}
+	result := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "slot"}},
+		DoUpdates: clause.AssignmentColumns([]string{"epoch", "amount"}),
+	}).Create(rec)
+	if result.Error != nil {
+		return fmt.Errorf("add network donation: %w", result.Error)
+	}
+	return nil
+}
+
+// SumNetworkDonationsForEpoch returns the total donation contributed by blocks
+// in the given epoch.
+func (d *MetadataStoreSqlite) SumNetworkDonationsForEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf("sum network donations: %w", err)
+	}
+	var total uint64
+	result := db.Model(&models.NetworkDonation{}).
+		Where("epoch = ?", epoch).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"sum network donations for epoch %d: %w", epoch, result.Error,
+		)
+	}
+	return total, nil
+}
+
+// DeleteNetworkDonationsAfterSlot removes donation records added after the
+// given slot. This is used during chain rollbacks.
+func (d *MetadataStoreSqlite) DeleteNetworkDonationsAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf("delete network donations after slot: %w", err)
+	}
+	result := db.Where("slot > ?", slot).
+		Delete(&models.NetworkDonation{})
+	if result.Error != nil {
+		return fmt.Errorf(
+			"delete network donations after slot %d: %w", slot, result.Error,
+		)
+	}
+	return nil
+}

--- a/database/plugin/metadata/sqlite/network_donation_test.go
+++ b/database/plugin/metadata/sqlite/network_donation_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNetworkDonation exercises the donation accumulator: per-epoch summing,
+// idempotent-per-slot writes, and rollback via DeleteNetworkDonationsAfterSlot.
+func TestNetworkDonation(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	require.NoError(t, store.AddNetworkDonation(100, 5, 1_000_000, nil))
+	require.NoError(t, store.AddNetworkDonation(200, 5, 2_000_000, nil))
+	require.NoError(t, store.AddNetworkDonation(600, 6, 3_000_000, nil))
+
+	sum5, err := store.SumNetworkDonationsForEpoch(5, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3_000_000), sum5)
+
+	sum6, err := store.SumNetworkDonationsForEpoch(6, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3_000_000), sum6)
+
+	// An epoch with no donations sums to zero (not an error).
+	sum7, err := store.SumNetworkDonationsForEpoch(7, nil)
+	require.NoError(t, err)
+	require.Zero(t, sum7)
+
+	// Re-applying the same slot overwrites rather than double-counting.
+	require.NoError(t, store.AddNetworkDonation(200, 5, 5_000_000, nil))
+	sum5, err = store.SumNetworkDonationsForEpoch(5, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(6_000_000), sum5) // 1_000_000 + 5_000_000
+
+	// Rollback to slot 150 drops the slot-200 (epoch 5) and slot-600 (epoch 6)
+	// rows; the slot-100 row survives.
+	require.NoError(t, store.DeleteNetworkDonationsAfterSlot(150, nil))
+
+	sum5, err = store.SumNetworkDonationsForEpoch(5, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_000_000), sum5)
+
+	sum6, err = store.SumNetworkDonationsForEpoch(6, nil)
+	require.NoError(t, err)
+	require.Zero(t, sum6)
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1163,6 +1163,23 @@ type MetadataStore interface {
 	// rollbacks.
 	DeleteNetworkStateAfterSlot(uint64, types.Txn) error
 
+	// Network donation methods
+
+	// AddNetworkDonation records a block's total Conway treasury
+	// donation for the given slot and epoch. Idempotent per slot.
+	AddNetworkDonation(
+		slot, epoch, amount uint64,
+		txn types.Txn,
+	) error
+
+	// SumNetworkDonationsForEpoch returns the total donation
+	// contributed by blocks in the given epoch.
+	SumNetworkDonationsForEpoch(epoch uint64, txn types.Txn) (uint64, error)
+
+	// DeleteNetworkDonationsAfterSlot removes donation records added
+	// after the given slot. This is used during chain rollbacks.
+	DeleteNetworkDonationsAfterSlot(uint64, types.Txn) error
+
 	// Governance rollback methods
 
 	// DeleteGovernanceProposalsAfterSlot removes proposals added after the given slot

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3147,6 +3147,49 @@ func (ls *LedgerState) calculateEpochNonce(
 //   - currentEra: current era descriptor (read-only input)
 //   - currentPParams: current protocol parameters (read-only input)
 //
+// applyEpochDonations moves the treasury donations accumulated during the
+// ended epoch into the treasury at the epoch boundary. The donation rows are
+// left in place (keyed by slot) so a rollback past the boundary drops both the
+// donation rows and the boundary NetworkState row, and re-applying the
+// boundary re-derives the same total. It writes the updated treasury at the
+// boundary slot, the same slot governance treasury-withdrawal enactment uses,
+// so the row reflects withdrawals first and donations second.
+func (ls *LedgerState) applyEpochDonations(
+	txn *database.Txn,
+	endedEpoch uint64,
+	boundarySlot uint64,
+) error {
+	donations, err := ls.db.Metadata().SumNetworkDonationsForEpoch(
+		endedEpoch, txn.Metadata(),
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"sum donations for epoch %d: %w", endedEpoch, err,
+		)
+	}
+	if donations == 0 {
+		return nil
+	}
+	state, err := ls.db.Metadata().GetNetworkState(txn.Metadata())
+	if err != nil {
+		return fmt.Errorf("get network state: %w", err)
+	}
+	var treasury, reserves uint64
+	if state != nil {
+		treasury = uint64(state.Treasury)
+		reserves = uint64(state.Reserves)
+	}
+	if err := ls.db.Metadata().SetNetworkState(
+		treasury+donations,
+		reserves,
+		boundarySlot,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf("set network state with donations: %w", err)
+	}
+	return nil
+}
+
 // Returns EpochRolloverResult with all computed state, or an error.
 // The caller is responsible for:
 //   - Applying the result to in-memory state after successful commit
@@ -3292,6 +3335,16 @@ func (ls *LedgerState) processEpochRollover(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("process governance epoch: %w", err)
+	}
+	// Move the ending epoch's accumulated treasury donations into the
+	// treasury. Per the Conway EPOCH rule, donations are added after enacted
+	// treasury withdrawals (handled in governance.ProcessEpoch above), so a
+	// withdrawal is checked against the pre-donation treasury and the donation
+	// is reflected for subsequent epochs' accounting.
+	if err := ls.applyEpochDonations(
+		txn, currentEpoch.EpochId, epochStartSlot,
+	); err != nil {
+		return nil, fmt.Errorf("apply epoch donations: %w", err)
 	}
 	if govOut.PParamsChanged {
 		newPParams = govOut.UpdatedPParams

--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -161,6 +161,35 @@ func (d *LedgerDelta) apply(ls *LedgerState, txn *database.Txn) error {
 		}
 	}
 
+	// Accumulate Conway treasury donations from this block. Donations move
+	// into the treasury at the next epoch boundary (see processEpochRollover);
+	// they are recorded here keyed by block slot so a rollback drops them.
+	// Only valid transactions contribute: an invalid (phase-2 failed)
+	// transaction consumes collateral and its body, including any donation,
+	// is not applied.
+	var donation uint64
+	for _, tr := range d.Transactions {
+		if !tr.Tx.IsValid() {
+			continue
+		}
+		if don := tr.Tx.Donation(); don != nil && don.Sign() > 0 {
+			donation += don.Uint64()
+		}
+	}
+	if donation > 0 {
+		ls.RLock()
+		epoch := ls.currentEpoch.EpochId
+		ls.RUnlock()
+		if err := ls.db.Metadata().AddNetworkDonation(
+			d.Point.Slot,
+			epoch,
+			donation,
+			txn.Metadata(),
+		); err != nil {
+			return fmt.Errorf("record network donation: %w", err)
+		}
+	}
+
 	// Emit transaction events only after all processing succeeds,
 	// so subscribers never see an "applied" event for a transaction
 	// whose governance processing failed and caused the apply to abort.

--- a/ledger/network_donation_test.go
+++ b/ledger/network_donation_test.go
@@ -15,9 +15,16 @@
 package ledger
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/governance"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -122,4 +129,139 @@ func TestEpochDonationWithdrawalRollback(t *testing.T) {
 	sum, err := db.Metadata().SumNetworkDonationsForEpoch(7, nil)
 	require.NoError(t, err)
 	assert.Zero(t, sum, "rolled-back donation rows are gone")
+}
+
+// donationTestConwayPParams builds Conway pparams with voting thresholds so
+// governance.ProcessEpoch's ratification phase has the fields it reads.
+func donationTestConwayPParams(major uint) *conway.ConwayProtocolParameters {
+	rat := func(n, d int64) cbor.Rat { return cbor.Rat{Rat: big.NewRat(n, d)} }
+	p := &conway.ConwayProtocolParameters{}
+	p.ProtocolVersion.Major = major
+	p.MinCommitteeSize = 3
+	p.DRepVotingThresholds = conway.DRepVotingThresholds{
+		MotionNoConfidence:    rat(67, 100),
+		CommitteeNormal:       rat(67, 100),
+		CommitteeNoConfidence: rat(60, 100),
+		UpdateToConstitution:  rat(75, 100),
+		HardForkInitiation:    rat(60, 100),
+		PpNetworkGroup:        rat(67, 100),
+		PpEconomicGroup:       rat(67, 100),
+		PpTechnicalGroup:      rat(67, 100),
+		PpGovGroup:            rat(75, 100),
+		TreasuryWithdrawal:    rat(67, 100),
+	}
+	p.PoolVotingThresholds = conway.PoolVotingThresholds{
+		MotionNoConfidence:    rat(51, 100),
+		CommitteeNormal:       rat(51, 100),
+		CommitteeNoConfidence: rat(51, 100),
+		HardForkInitiation:    rat(51, 100),
+		PpSecurityGroup:       rat(51, 100),
+	}
+	return p
+}
+
+// TestEpochProcessWithdrawalThenDonation drives the real Conway enactment path:
+// a ratified treasury withdrawal is enacted by governance.ProcessEpoch and then
+// the ending epoch's donation is applied, exactly as processEpochRollover
+// sequences them. It proves the withdrawal is checked/applied against the
+// pre-donation treasury (the value the ledger uses at the boundary) and the
+// donation is added afterwards.
+func TestEpochProcessWithdrawalThenDonation(t *testing.T) {
+	db := newDonationTestDB(t)
+	ls := &LedgerState{db: db}
+
+	const (
+		initialTreasury = uint64(1_000)
+		initialReserves = uint64(200)
+		withdrawal      = uint64(400)
+		donation        = uint64(300)
+		endedEpoch      = uint64(4)
+		boundarySlot    = uint64(500)
+	)
+
+	// Registered reward account that the withdrawal pays out to.
+	stakeCred := make([]byte, 28)
+	for i := range stakeCred {
+		stakeCred[i] = 0x42
+	}
+	withdrawAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	withdrawAddrBytes, err := withdrawAddr.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}))
+
+	// A ratified treasury-withdrawal proposal so ProcessEpoch enacts it.
+	withdrawalCbor, err := cbor.Encode(&lcommon.TreasuryWithdrawalGovAction{
+		Type:        2,
+		Withdrawals: map[*lcommon.Address]uint64{&withdrawAddr: withdrawal},
+	})
+	require.NoError(t, err)
+	ratifiedEpoch := endedEpoch
+	ratifiedSlot := uint64(400)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        make([]byte, 32),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		ProposedEpoch: 3,
+		ExpiresEpoch:  10,
+		RatifiedEpoch: &ratifiedEpoch,
+		RatifiedSlot:  &ratifiedSlot,
+		AnchorURL:     "https://example.invalid/withdrawal",
+		AnchorHash:    make([]byte, 32),
+		Deposit:       0,
+		ReturnAddress: withdrawAddrBytes,
+		GovActionCbor: withdrawalCbor,
+		AddedSlot:     101,
+	}, nil))
+
+	// Initial treasury/reserves and the ending epoch's donation.
+	require.NoError(t, db.Metadata().SetNetworkState(
+		initialTreasury, initialReserves, 1, nil,
+	))
+	require.NoError(t, db.Metadata().AddNetworkDonation(
+		70, endedEpoch, donation, nil,
+	))
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		if _, err := governance.ProcessEpoch(&governance.EpochInput{
+			DB:           db,
+			Txn:          txn,
+			PrevEpoch:    endedEpoch,
+			NewEpoch:     endedEpoch + 1,
+			BoundarySlot: boundarySlot,
+			PParams:      donationTestConwayPParams(10),
+			UpdateFn: func(
+				p lcommon.ProtocolParameters, _ any,
+			) (lcommon.ProtocolParameters, error) {
+				return p, nil
+			},
+		}); err != nil {
+			return err
+		}
+		return ls.applyEpochDonations(txn, endedEpoch, boundarySlot)
+	}))
+
+	// Withdrawal (400) was applied against the pre-donation treasury (1000),
+	// then the donation (300) was added: 1000 - 400 + 300 = 900.
+	treasury, reserves, _ := networkState(t, db)
+	assert.Equal(t, uint64(900), treasury,
+		"treasury = initial - withdrawal + donation")
+	assert.Equal(t, initialReserves, reserves)
+
+	// The withdrawal credited the registered reward account.
+	account, err := db.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, withdrawal, uint64(account.Reward),
+		"withdrawal paid to the reward account")
 }

--- a/ledger/network_donation_test.go
+++ b/ledger/network_donation_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDonationTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	return db
+}
+
+func networkState(t *testing.T, db *database.Database) (treasury, reserves, slot uint64) {
+	t.Helper()
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	return uint64(state.Treasury), uint64(state.Reserves), state.Slot
+}
+
+// TestApplyEpochDonations verifies that the ending epoch's donations are added
+// to the treasury at the boundary slot, leaving reserves untouched, and that
+// only the ended epoch's donations are moved.
+func TestApplyEpochDonations(t *testing.T) {
+	db := newDonationTestDB(t)
+	ls := &LedgerState{db: db}
+
+	// Post-withdrawal treasury/reserves baseline at an earlier slot.
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+	// Donations for the ending epoch (7) and a later epoch (8) that must not move.
+	require.NoError(t, db.Metadata().AddNetworkDonation(60, 7, 100, nil))
+	require.NoError(t, db.Metadata().AddNetworkDonation(70, 7, 200, nil))
+	require.NoError(t, db.Metadata().AddNetworkDonation(600, 8, 999, nil))
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyEpochDonations(txn, 7, 80)
+	}))
+
+	treasury, reserves, slot := networkState(t, db)
+	assert.Equal(t, uint64(1_300), treasury, "treasury += epoch-7 donations (100+200)")
+	assert.Equal(t, uint64(5_000), reserves, "reserves untouched by donations")
+	assert.Equal(t, uint64(80), slot, "updated at the boundary slot")
+}
+
+// TestApplyEpochDonations_NoDonations is a no-op when the ended epoch had none.
+func TestApplyEpochDonations_NoDonations(t *testing.T) {
+	db := newDonationTestDB(t)
+	ls := &LedgerState{db: db}
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyEpochDonations(txn, 7, 80)
+	}))
+
+	treasury, reserves, slot := networkState(t, db)
+	assert.Equal(t, uint64(1_000), treasury)
+	assert.Equal(t, uint64(5_000), reserves)
+	assert.Equal(t, uint64(50), slot, "no boundary row written when no donations")
+}
+
+// TestEpochDonationWithdrawalRollback exercises the acceptance scenario: a
+// treasury withdrawal (modelled as a debited treasury) followed by a donation
+// at the boundary, then a rollback past the boundary that restores the prior
+// treasury and drops the donation rows so re-application is deterministic.
+func TestEpochDonationWithdrawalRollback(t *testing.T) {
+	db := newDonationTestDB(t)
+	ls := &LedgerState{db: db}
+
+	// Epoch 7 starts with treasury 1_000 (slot 50).
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+	// A donation block lands mid-epoch.
+	require.NoError(t, db.Metadata().AddNetworkDonation(70, 7, 300, nil))
+	// At the 7->8 boundary (slot 80) a treasury withdrawal of 400 is enacted
+	// first (checked against the pre-donation treasury of 1_000), debiting the
+	// treasury to 600...
+	require.NoError(t, db.Metadata().SetNetworkState(600, 5_000, 80, nil))
+	// ...then the epoch's donations are added on top.
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyEpochDonations(txn, 7, 80)
+	}))
+	treasury, reserves, slot := networkState(t, db)
+	require.Equal(t, uint64(900), treasury, "1_000 - 400 withdrawal + 300 donation")
+	require.Equal(t, uint64(5_000), reserves)
+	require.Equal(t, uint64(80), slot)
+
+	// Roll back past the boundary (to slot 60): the boundary NetworkState row
+	// and the donation row are dropped, restoring epoch 7's starting treasury.
+	require.NoError(t, db.DeleteNetworkStateAfterSlot(60, nil))
+	require.NoError(t, db.DeleteNetworkDonationsAfterSlot(60, nil))
+
+	treasury, reserves, slot = networkState(t, db)
+	assert.Equal(t, uint64(1_000), treasury, "treasury restored to pre-boundary value")
+	assert.Equal(t, uint64(5_000), reserves)
+	assert.Equal(t, uint64(50), slot)
+	sum, err := db.Metadata().SumNetworkDonationsForEpoch(7, nil)
+	require.NoError(t, err)
+	assert.Zero(t, sum, "rolled-back donation rows are gone")
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1708,6 +1708,16 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 				err,
 			)
 		}
+		// Delete rolled-back treasury donation records
+		if err := ls.db.DeleteNetworkDonationsAfterSlot(
+			point.Slot,
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"delete network donations after rollback: %w",
+				err,
+			)
+		}
 		// Delete rolled-back UTxOs (blob offsets and metadata).
 		//
 		// Floor the deletion slot at mithrilLedgerSlot. UTxOs produced


### PR DESCRIPTION
## Summary

Closes #2374. Dingo tracks treasury/reserves in the `NetworkState` table, and treasury-withdrawal enactment validates against that tracked value — but `SetNetworkState` was only called from import and governance paths, never from normal block/epoch accounting. In particular **Conway transaction donations were not tracked at all**, so the local treasury drifts from the value the ledger computes, which can make a future treasury-withdrawal enactment accept or reject an action based on stale state.

This PR implements the donation source of treasury change and the rollback-safe machinery the sibling issues plug into.

## What changed

- **`NetworkDonation` accumulator** (`database/...`) — a slot-keyed table recording each block's total donation, tagged with its epoch. Store methods `AddNetworkDonation` / `SumNetworkDonationsForEpoch` / `DeleteNetworkDonationsAfterSlot` across sqlite/postgres/mysql, plus the `Database` rollback wrapper. `amount` is a plain integer column so `SUM` aggregates directly across all backends.
- **Extraction** (`ledger/delta.go`) — block application sums the `Donation()` of each *valid* transaction (invalid/phase-2-failed txs don't apply their body) and records one row per block.
- **Epoch-boundary application** (`ledger/chainsync.go`) — `processEpochRollover` moves the ending epoch's donations into the treasury via `applyEpochDonations`, **after** `governance.ProcessEpoch`. This ordering matches the Conway EPOCH rule (enacted withdrawals first, donations after), so a withdrawal is checked against the pre-donation treasury and the donation is reflected for subsequent epochs.
- **Rollback** (`ledger/state.go`) — donation rows are dropped after the rollback slot alongside `NetworkState`, so treasury/reserves are restored and re-application re-derives the same total.

## Acceptance criteria (#2374)

- ✅ Treasury withdrawal checked against the treasury value the ledger uses at the boundary — `applyEpochDonations` runs after `ProcessEpoch`; proven by `TestEpochProcessWithdrawalThenDonation`, which drives a real ratified withdrawal (1000 − 400) then a donation (+300 = 900) and asserts the reward account is credited.
- ✅ Transaction donations reflected in `NetworkState` after the boundary.
- ✅ Rollback restores the previous treasury/reserves values.
- ✅ Tests cover a donation + governance-withdrawal sequence.

## Scope

This is the **donation** source plus the rollback-safe `NetworkState` machinery. The other sources of treasury/reserves change are the sibling issues, which feed the same state: pool-reap **#2375**, MIR **#2376**, orphaned-gov-action refunds **#2372**, and reward/fee accounting **#1902**. Import/bootstrap of treasury/reserves already existed.

## Verification

`go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0), `modernize` (0), `go test -race ./ledger/... ./database/...`, and conformance all pass.

**DevNet:** `TestEpochBoundaryConsensus` passed — Dingo and cardano-node converged on the identical tip (slot 700, block 270) across the epoch-0→1 boundary (tolerance and tight checks). The live rollover ran `applyEpochDonations` with no errors and migrated `network_donation` cleanly. So the epoch-accounting change is consensus-safe against the reference node.

`DATABASE.md` and `ARCHITECTURE.md` updated for the new table/model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the on-disk treasury in sync with the ledger by tracking Conway transaction donations and applying them at epoch boundaries. Prevents stale treasury checks for withdrawals by updating `NetworkState` in the correct order.

- **New Features**
  - Added `NetworkDonation` accumulator (per-slot, tagged by epoch) with store methods for sqlite/postgres/mysql.
  - Block processing sums donations from valid transactions and records one row per block.
  - Epoch rollover adds the ended epoch’s donations to the treasury after `governance.ProcessEpoch`, matching the Conway EPOCH rule.
  - Rollbacks drop donation rows after the rollback slot; re-apply re-derives the same total.
  - Meets #2374 acceptance: withdrawal is checked against the pre-donation treasury; donations are reflected for subsequent epochs.

<sup>Written for commit c67924ab90d2fa4791f9aabea61ef0ecb5ef1e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network treasury donation tracking that accumulates donations per block and applies them to the network treasury at epoch boundaries.
  * Integrated donation processing with Conway governance withdrawals for coordinated treasury management.
  * Implemented rollback support to ensure data consistency.

* **Documentation**
  * Updated architecture and database reference documentation for network donation support.

* **Tests**
  * Added comprehensive test coverage for donation accumulation, epoch application, rollback scenarios, and governance integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->