### PR TITLE
refactor(ledger): extract pure Praos selection primitives

### DIFF
--- a/chainselection/comparison.go
+++ b/chainselection/comparison.go
@@ -14,119 +14,35 @@
 
 package chainselection
 
-import (
-	"bytes"
+// This file re-exports pure Praos comparison primitives from consensus/praos.
+// New code should import consensus/praos directly.
 
+import (
+	"github.com/blinklabs-io/dingo/consensus/praos"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
 
-// ChainComparisonResult indicates the result of comparing two chains.
-type ChainComparisonResult int
+// ChainComparisonResult is aliased from consensus/praos.
+type ChainComparisonResult = praos.ChainComparisonResult
 
 const (
-	ChainEqual             ChainComparisonResult = 0
-	ChainABetter           ChainComparisonResult = 1
-	ChainBBetter           ChainComparisonResult = -1
-	ChainComparisonUnknown ChainComparisonResult = 2
+	ChainEqual             = praos.ChainEqual
+	ChainABetter           = praos.ChainABetter
+	ChainBBetter           = praos.ChainBBetter
+	ChainComparisonUnknown = praos.ChainComparisonUnknown
 )
 
-// ComparePraosTips compares two Praos-era tips using cardano-node's
-// equal-length tiebreaker shape:
-//  1. Higher block number wins.
-//  2. At equal block number, prefer a candidate with the same issuer and slot
-//     only when it has a higher opcert issue number.
-//  3. Otherwise compare the tip VRF only when the era's VRF tiebreaker flavor
-//     is armed. Conway restricts this to tips at most 5 slots apart.
-//
-// If neither reference implementation rule applies, this returns ChainEqual so
-// callers keep the incumbent.
+// ComparePraosTips delegates to consensus/praos.
 func ComparePraosTips(
 	tipA, tipB ochainsync.Tip,
 	viewA, viewB PraosTiebreakerView,
 ) ChainComparisonResult {
-	if tipA.BlockNumber > tipB.BlockNumber {
-		return ChainABetter
-	}
-	if tipB.BlockNumber > tipA.BlockNumber {
-		return ChainBBetter
-	}
-
-	if tipA.Point.Slot == tipB.Point.Slot &&
-		bytes.Equal(tipA.Point.Hash, tipB.Point.Hash) {
-		return ChainEqual
-	}
-
-	if PreferPraosCandidate(viewB, viewA) {
-		return ChainABetter
-	}
-	if PreferPraosCandidate(viewA, viewB) {
-		return ChainBBetter
-	}
-	return ChainEqual
+	return praos.ComparePraosTips(tipA, tipB, viewA, viewB)
 }
 
-// PreferPraosCandidate mirrors ouroboros-consensus'
-// preferCandidate cfg ours cand for equal-length Praos chains.
+// PreferPraosCandidate delegates to consensus/praos.
 func PreferPraosCandidate(
 	ours, cand PraosTiebreakerView,
 ) bool {
-	if praosIssueNoArmed(ours, cand) {
-		if cand.IssueNo > ours.IssueNo {
-			return true
-		}
-		if cand.IssueNo < ours.IssueNo {
-			return false
-		}
-	}
-	if !praosVRFArmed(ours, cand) {
-		return false
-	}
-	return CompareVRFOutputs(
-		cand.TieBreakVRF,
-		ours.TieBreakVRF,
-	) == ChainABetter
-}
-
-func praosIssueNoArmed(ours, cand PraosTiebreakerView) bool {
-	return ours.Slot == cand.Slot &&
-		ours.hasIssuerIssueNo() &&
-		cand.hasIssuerIssueNo() &&
-		bytes.Equal(ours.Issuer, cand.Issuer)
-}
-
-func praosVRFArmed(ours, cand PraosTiebreakerView) bool {
-	config, ok := praosTiebreakerConfig(ours, cand)
-	if !ok {
-		return false
-	}
-	switch config.Flavor {
-	case PraosTiebreakerUnknown:
-		return false
-	case PraosTiebreakerUnrestricted:
-		return true
-	case PraosTiebreakerRestricted:
-		return praosSlotDistance(ours.Slot, cand.Slot) <=
-			config.MaxSlotDistance
-	default:
-		return false
-	}
-}
-
-func praosTiebreakerConfig(
-	ours, cand PraosTiebreakerView,
-) (PraosTiebreakerConfig, bool) {
-	if ours.TiebreakerConfig.known() {
-		return ours.TiebreakerConfig, true
-	}
-	if cand.TiebreakerConfig.known() {
-		return cand.TiebreakerConfig, true
-	}
-	return PraosTiebreakerConfig{}, false
-}
-
-func praosSlotDistance(a, b uint64) uint64 {
-	if a >= b {
-		return a - b
-	}
-	return b - a
+	return praos.PreferPraosCandidate(ours, cand)
 }

--- a/chainselection/vrf.go
+++ b/chainselection/vrf.go
@@ -14,193 +14,87 @@
 
 package chainselection
 
-import (
-	"bytes"
+// This file re-exports the pure Praos VRF and header-view primitives from
+// consensus/praos so that chainselection internals and existing call sites
+// continue to compile without change. New code should import
+// consensus/praos directly.
 
-	"github.com/blinklabs-io/gouroboros/ledger"
-	"github.com/blinklabs-io/gouroboros/ledger/allegra"
-	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
-	"github.com/blinklabs-io/gouroboros/ledger/babbage"
-	"github.com/blinklabs-io/gouroboros/ledger/conway"
-	"github.com/blinklabs-io/gouroboros/ledger/mary"
-	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+import (
+	"github.com/blinklabs-io/dingo/consensus/praos"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
 
-// VRFOutputSize is the expected size of a VRF output in bytes.
-const VRFOutputSize = 64
+// VRFOutputSize is re-exported from consensus/praos.
+const VRFOutputSize = praos.VRFOutputSize
 
-const praosRestrictedTiebreakerMaxSlotDistance = 5
-
-// PraosTiebreakerFlavor matches ouroboros-consensus' VRFTiebreakerFlavor.
-type PraosTiebreakerFlavor uint8
+// PraosTiebreakerFlavor and its constants are type-aliased from
+// consensus/praos so that chainselection.PraosTiebreakerFlavor and
+// praos.PraosTiebreakerFlavor are the same type.
+type PraosTiebreakerFlavor = praos.PraosTiebreakerFlavor
 
 const (
-	PraosTiebreakerUnknown PraosTiebreakerFlavor = iota
-	PraosTiebreakerUnrestricted
-	PraosTiebreakerRestricted
+	PraosTiebreakerUnknown      = praos.PraosTiebreakerUnknown
+	PraosTiebreakerUnrestricted = praos.PraosTiebreakerUnrestricted
+	PraosTiebreakerRestricted   = praos.PraosTiebreakerRestricted
 )
 
-// PraosTiebreakerConfig is the chain-order config projected from the current
-// Shelley-family block config. The reference implementation uses unrestricted
-// VRF before Conway and restricted VRF with max distance 5 from Conway onward.
-type PraosTiebreakerConfig struct {
-	Flavor          PraosTiebreakerFlavor
-	MaxSlotDistance uint64
-}
+// PraosTiebreakerConfig is aliased from consensus/praos.
+type PraosTiebreakerConfig = praos.PraosTiebreakerConfig
 
-// PraosTiebreakerView mirrors ouroboros-consensus' PraosTiebreakerView for
-// equal-length chain selection.
-type PraosTiebreakerView struct {
-	Slot              uint64
-	Issuer            []byte
-	IssueNo           uint64
-	TieBreakVRF       []byte
-	TiebreakerConfig  PraosTiebreakerConfig
-	hasIssuerAndIssue bool
-}
+// PraosTiebreakerView is aliased from consensus/praos.
+type PraosTiebreakerView = praos.PraosTiebreakerView
 
+// PraosTiebreakerConfigBeforeConway delegates to consensus/praos.
 func PraosTiebreakerConfigBeforeConway() PraosTiebreakerConfig {
-	return PraosTiebreakerConfig{
-		Flavor: PraosTiebreakerUnrestricted,
-	}
+	return praos.PraosTiebreakerConfigBeforeConway()
 }
 
+// PraosTiebreakerConfigConway delegates to consensus/praos.
 func PraosTiebreakerConfigConway() PraosTiebreakerConfig {
-	return PraosTiebreakerConfig{
-		Flavor:          PraosTiebreakerRestricted,
-		MaxSlotDistance: praosRestrictedTiebreakerMaxSlotDistance,
-	}
+	return praos.PraosTiebreakerConfigConway()
 }
 
+// PraosTiebreakerConfigUnknown delegates to consensus/praos.
 func PraosTiebreakerConfigUnknown() PraosTiebreakerConfig {
-	return PraosTiebreakerConfig{}
+	return praos.PraosTiebreakerConfigUnknown()
 }
 
-func (c PraosTiebreakerConfig) known() bool {
-	return c.Flavor == PraosTiebreakerUnrestricted ||
-		c.Flavor == PraosTiebreakerRestricted
-}
-
-func (v PraosTiebreakerView) hasIssuerIssueNo() bool {
-	return v.hasIssuerAndIssue && len(v.Issuer) > 0
-}
-
-// PraosTiebreakerViewFromTip builds a partial view when only a chainsync tip
-// and VRF are available. The issuer/opcert rule cannot be applied to partial
-// views.
+// PraosTiebreakerViewFromTip delegates to consensus/praos.
 func PraosTiebreakerViewFromTip(
 	tip ochainsync.Tip,
 	vrfOutput []byte,
 	config PraosTiebreakerConfig,
 ) PraosTiebreakerView {
-	return PraosTiebreakerView{
-		Slot:             tip.Point.Slot,
-		TieBreakVRF:      cloneBytes(vrfOutput),
-		TiebreakerConfig: config,
-	}
+	return praos.PraosTiebreakerViewFromTip(tip, vrfOutput, config)
 }
 
-// GetPraosTiebreakerView extracts the Praos select-view fields from a
-// Shelley-family header.
+// NewPraosTiebreakerViewFull delegates to consensus/praos.
+func NewPraosTiebreakerViewFull(
+	tip ochainsync.Tip,
+	issuer []byte,
+	issueNo uint64,
+	vrfOutput []byte,
+	config PraosTiebreakerConfig,
+) PraosTiebreakerView {
+	return praos.NewPraosTiebreakerViewFull(tip, issuer, issueNo, vrfOutput, config)
+}
+
+// GetPraosTiebreakerView delegates to consensus/praos.
 func GetPraosTiebreakerView(
-	header ledger.BlockHeader,
+	header gledger.BlockHeader,
 ) (PraosTiebreakerView, bool) {
-	if header == nil {
-		return PraosTiebreakerView{}, false
-	}
-	issueNo, ok := headerIssueNo(header)
-	if !ok {
-		return PraosTiebreakerView{}, false
-	}
-	issuer := header.IssuerVkey()
-	return PraosTiebreakerView{
-		Slot:              header.SlotNumber(),
-		Issuer:            cloneBytes(issuer[:]),
-		IssueNo:           issueNo,
-		TieBreakVRF:       cloneBytes(GetVRFOutput(header)),
-		TiebreakerConfig:  praosTiebreakerConfigForHeader(header),
-		hasIssuerAndIssue: true,
-	}, true
+	return praos.GetPraosTiebreakerView(header)
 }
 
-func headerIssueNo(header ledger.BlockHeader) (uint64, bool) {
-	switch h := header.(type) {
-	case *shelley.ShelleyBlockHeader:
-		return uint64(h.Body.OpCertSequenceNumber), true
-	case *allegra.AllegraBlockHeader:
-		return uint64(h.Body.OpCertSequenceNumber), true
-	case *mary.MaryBlockHeader:
-		return uint64(h.Body.OpCertSequenceNumber), true
-	case *alonzo.AlonzoBlockHeader:
-		return uint64(h.Body.OpCertSequenceNumber), true
-	case *babbage.BabbageBlockHeader:
-		return uint64(h.Body.OpCert.SequenceNumber), true
-	case *conway.ConwayBlockHeader:
-		return uint64(h.Body.OpCert.SequenceNumber), true
-	default:
-		return 0, false
-	}
+// GetVRFOutput delegates to consensus/praos.
+func GetVRFOutput(header gledger.BlockHeader) []byte {
+	return praos.GetVRFOutput(header)
 }
 
-func praosTiebreakerConfigForHeader(
-	header ledger.BlockHeader,
-) PraosTiebreakerConfig {
-	if header.Era().Id >= conway.EraIdConway {
-		return PraosTiebreakerConfigConway()
-	}
-	return PraosTiebreakerConfigBeforeConway()
-}
-
-// GetVRFOutput extracts the VRF output from a block header.
-// Returns nil if the header type is not supported or doesn't contain VRF data.
-//
-// The VRF output is used for tie-breaking in chain selection when two chains
-// have equal block numbers and equal density. The chain with the LOWER VRF
-// output (lexicographically) wins.
-func GetVRFOutput(header ledger.BlockHeader) []byte {
-	switch h := header.(type) {
-	case *shelley.ShelleyBlockHeader:
-		return h.Body.LeaderVrf.Output
-	case *allegra.AllegraBlockHeader:
-		return h.Body.LeaderVrf.Output
-	case *mary.MaryBlockHeader:
-		return h.Body.LeaderVrf.Output
-	case *alonzo.AlonzoBlockHeader:
-		return h.Body.LeaderVrf.Output
-	case *babbage.BabbageBlockHeader:
-		return h.Body.VrfResult.Output
-	case *conway.ConwayBlockHeader:
-		return h.Body.VrfResult.Output
-	default:
-		return nil
-	}
-}
-
-// CompareVRFOutputs compares two VRF outputs for chain selection tie-breaking.
-// Returns:
-//   - ChainABetter (1) if vrfA is lower (A wins)
-//   - ChainBBetter (-1) if vrfB is lower (B wins)
-//   - ChainEqual (0) if equal, either is nil, or either has invalid length
-//
-// Per Ouroboros Praos: the chain with the LOWER VRF output wins the tie-break.
-// Both outputs must be exactly VRFOutputSize (64) bytes; outputs of any other
-// length are treated the same as nil to prevent truncated values from winning.
+// CompareVRFOutputs delegates to consensus/praos.
 func CompareVRFOutputs(vrfA, vrfB []byte) ChainComparisonResult {
-	// Can't compare if either is nil or has invalid length
-	if len(vrfA) != VRFOutputSize || len(vrfB) != VRFOutputSize {
-		return ChainEqual
-	}
-
-	// Lower VRF output wins
-	cmp := bytes.Compare(vrfA, vrfB)
-	if cmp < 0 {
-		return ChainABetter // vrfA is lower, A wins
-	}
-	if cmp > 0 {
-		return ChainBBetter // vrfB is lower, B wins
-	}
-	return ChainEqual
+	return praos.CompareVRFOutputs(vrfA, vrfB)
 }
 
 func cloneBytes(src []byte) []byte {

--- a/chainselection/vrf_test.go
+++ b/chainselection/vrf_test.go
@@ -188,22 +188,12 @@ func TestComparePraosTipsSameIssuerSlotHigherOCertWins(t *testing.T) {
 		BlockNumber: 50,
 	}
 	issuer := []byte("issuer")
-	oursView := PraosTiebreakerViewFromTip(
-		ours,
-		make64ByteVRFFirstByte(0xAA),
-		PraosTiebreakerConfigConway(),
+	oursView := NewPraosTiebreakerViewFull(
+		ours, issuer, 1, make64ByteVRFFirstByte(0xAA), PraosTiebreakerConfigConway(),
 	)
-	oursView.Issuer = issuer
-	oursView.IssueNo = 1
-	oursView.hasIssuerAndIssue = true
-	candidateView := PraosTiebreakerViewFromTip(
-		candidate,
-		make64ByteVRFFirstByte(0xAA),
-		PraosTiebreakerConfigConway(),
+	candidateView := NewPraosTiebreakerViewFull(
+		candidate, issuer, 2, make64ByteVRFFirstByte(0xAA), PraosTiebreakerConfigConway(),
 	)
-	candidateView.Issuer = issuer
-	candidateView.IssueNo = 2
-	candidateView.hasIssuerAndIssue = true
 
 	result := ComparePraosTips(ours, candidate, oursView, candidateView)
 

--- a/consensus/praos/comparison.go
+++ b/consensus/praos/comparison.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package praos
+
+import (
+	"bytes"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// ChainComparisonResult indicates the result of comparing two chains.
+type ChainComparisonResult int
+
+const (
+	ChainEqual             ChainComparisonResult = 0
+	ChainABetter           ChainComparisonResult = 1
+	ChainBBetter           ChainComparisonResult = -1
+	ChainComparisonUnknown ChainComparisonResult = 2
+)
+
+// ComparePraosTips compares two Praos-era tips using cardano-node's
+// equal-length tiebreaker shape:
+//  1. Higher block number wins.
+//  2. At equal block number, prefer a candidate with the same issuer and slot
+//     only when it has a higher opcert issue number.
+//  3. Otherwise compare the tip VRF only when the era's VRF tiebreaker flavor
+//     is armed. Conway restricts this to tips at most 5 slots apart.
+//
+// If neither reference implementation rule applies, this returns ChainEqual so
+// callers keep the incumbent.
+func ComparePraosTips(
+	tipA, tipB ochainsync.Tip,
+	viewA, viewB PraosTiebreakerView,
+) ChainComparisonResult {
+	if tipA.BlockNumber > tipB.BlockNumber {
+		return ChainABetter
+	}
+	if tipB.BlockNumber > tipA.BlockNumber {
+		return ChainBBetter
+	}
+
+	if tipA.Point.Slot == tipB.Point.Slot &&
+		bytes.Equal(tipA.Point.Hash, tipB.Point.Hash) {
+		return ChainEqual
+	}
+
+	if PreferPraosCandidate(viewB, viewA) {
+		return ChainABetter
+	}
+	if PreferPraosCandidate(viewA, viewB) {
+		return ChainBBetter
+	}
+	return ChainEqual
+}
+
+// PreferPraosCandidate mirrors ouroboros-consensus'
+// preferCandidate cfg ours cand for equal-length Praos chains.
+func PreferPraosCandidate(
+	ours, cand PraosTiebreakerView,
+) bool {
+	if praosIssueNoArmed(ours, cand) {
+		if cand.IssueNo > ours.IssueNo {
+			return true
+		}
+		if cand.IssueNo < ours.IssueNo {
+			return false
+		}
+	}
+	if !praosVRFArmed(ours, cand) {
+		return false
+	}
+	return CompareVRFOutputs(
+		cand.TieBreakVRF,
+		ours.TieBreakVRF,
+	) == ChainABetter
+}
+
+func praosIssueNoArmed(ours, cand PraosTiebreakerView) bool {
+	return ours.Slot == cand.Slot &&
+		ours.hasIssuerIssueNo() &&
+		cand.hasIssuerIssueNo() &&
+		bytes.Equal(ours.Issuer, cand.Issuer)
+}
+
+func praosVRFArmed(ours, cand PraosTiebreakerView) bool {
+	config, ok := praosTiebreakerConfig(ours, cand)
+	if !ok {
+		return false
+	}
+	switch config.Flavor {
+	case PraosTiebreakerUnknown:
+		return false
+	case PraosTiebreakerUnrestricted:
+		return true
+	case PraosTiebreakerRestricted:
+		return praosSlotDistance(ours.Slot, cand.Slot) <=
+			config.MaxSlotDistance
+	default:
+		return false
+	}
+}
+
+func praosTiebreakerConfig(
+	ours, cand PraosTiebreakerView,
+) (PraosTiebreakerConfig, bool) {
+	if ours.TiebreakerConfig.known() {
+		return ours.TiebreakerConfig, true
+	}
+	if cand.TiebreakerConfig.known() {
+		return cand.TiebreakerConfig, true
+	}
+	return PraosTiebreakerConfig{}, false
+}
+
+func praosSlotDistance(a, b uint64) uint64 {
+	if a >= b {
+		return a - b
+	}
+	return b - a
+}

--- a/consensus/praos/praos_test.go
+++ b/consensus/praos/praos_test.go
@@ -304,23 +304,29 @@ func TestCompareVRFOutputs_InvalidLength(t *testing.T) {
 // for Byron<->Shelley boundaries. Byron blocks have no VRF (PBFT, not Praos),
 // so any chain-selection tie that includes a Byron tip must not use a
 // VRF-derived field.
+//
+// The Shelley header is populated with a real 64-byte VRF output so the
+// comparison is nil vs. valid — not nil vs. nil — making this a meaningful
+// assertion that the Byron nil does not win the tiebreaker even against a
+// fully-populated peer.
 func TestGetVRFOutput_ByronReturnsNil(t *testing.T) {
 	byronHeader := &byron.ByronMainBlockHeader{}
 	assert.Nil(t, GetVRFOutput(byronHeader),
 		"Byron headers must yield nil VRF output (no VRF in PBFT)")
 
 	shelleyHeader := &shelley.ShelleyBlockHeader{}
-	cmp := CompareVRFOutputs(
-		GetVRFOutput(byronHeader),
-		GetVRFOutput(shelleyHeader),
-	)
+	shelleyHeader.Body.LeaderVrf.Output = make64ByteVRF(0x01)
+
+	shelleyVRF := GetVRFOutput(shelleyHeader)
+	assert.Len(t, shelleyVRF, VRFOutputSize,
+		"Shelley header with populated LeaderVrf must return a 64-byte VRF output")
+
+	cmp := CompareVRFOutputs(GetVRFOutput(byronHeader), shelleyVRF)
 	assert.Equal(t, ChainEqual, cmp,
-		"a tie that includes a Byron tip must not be broken by VRF "+
+		"Byron nil VRF vs. valid Shelley VRF must not break the tie "+
 			"(NoTiebreakerAcrossEras at Byron<->Shelley)")
-	cmp = CompareVRFOutputs(
-		GetVRFOutput(shelleyHeader),
-		GetVRFOutput(byronHeader),
-	)
+
+	cmp = CompareVRFOutputs(shelleyVRF, GetVRFOutput(byronHeader))
 	assert.Equal(t, ChainEqual, cmp,
 		"NoTiebreakerAcrossEras must be symmetric")
 }

--- a/consensus/praos/praos_test.go
+++ b/consensus/praos/praos_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package praos
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- comparison tests -------------------------------------------------------
+
+func TestComparePraosTipsLongerChainWins(t *testing.T) {
+	shorter := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("shorter")},
+		BlockNumber: 40,
+	}
+	longer := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 101, Hash: []byte("longer")},
+		BlockNumber: 41,
+	}
+
+	assert.Equal(t, ChainBBetter,
+		ComparePraosTips(shorter, longer, PraosTiebreakerView{}, PraosTiebreakerView{}))
+	assert.Equal(t, ChainABetter,
+		ComparePraosTips(longer, shorter, PraosTiebreakerView{}, PraosTiebreakerView{}))
+}
+
+func TestComparePraosTipsEqualLengthDoesNotUseSlotOrHashFallback(t *testing.T) {
+	lowerSlotLowerHash := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 90, Hash: []byte("a")},
+		BlockNumber: 50,
+	}
+	higherSlotHigherHash := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("z")},
+		BlockNumber: 50,
+	}
+
+	assert.Equal(t, ChainEqual,
+		ComparePraosTips(lowerSlotLowerHash, higherSlotHigherHash,
+			PraosTiebreakerView{}, PraosTiebreakerView{}))
+}
+
+func TestComparePraosTipsSameIssuerSlotHigherOCertWins(t *testing.T) {
+	ours := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("ours")},
+		BlockNumber: 50,
+	}
+	candidate := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("candidate")},
+		BlockNumber: 50,
+	}
+	issuer := []byte("issuer")
+	oursView := NewPraosTiebreakerViewFull(
+		ours, issuer, 1, make64ByteVRFFirstByte(0xAA), PraosTiebreakerConfigConway(),
+	)
+	candidateView := NewPraosTiebreakerViewFull(
+		candidate, issuer, 2, make64ByteVRFFirstByte(0xAA), PraosTiebreakerConfigConway(),
+	)
+
+	assert.Equal(t, ChainBBetter, ComparePraosTips(ours, candidate, oursView, candidateView),
+		"higher opcert issue number must win at equal slot+issuer")
+}
+
+func TestComparePraosTipsVRFPrecedesSlot(t *testing.T) {
+	lowerSlotHigherVRF := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 111962097, Hash: []byte("ours")},
+		BlockNumber: 4275844,
+	}
+	laterSlotLowerVRF := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 111962102, Hash: []byte("candidate")},
+		BlockNumber: 4275844,
+	}
+
+	result := ComparePraosTips(
+		lowerSlotHigherVRF,
+		laterSlotLowerVRF,
+		PraosTiebreakerViewFromTip(lowerSlotHigherVRF, make64ByteVRFFirstByte(0xBD), PraosTiebreakerConfigConway()),
+		PraosTiebreakerViewFromTip(laterSlotLowerVRF, make64ByteVRFFirstByte(0x6E), PraosTiebreakerConfigConway()),
+	)
+	assert.Equal(t, ChainBBetter, result,
+		"equal-height Praos comparison must use VRF before slot")
+}
+
+func TestComparePraosTipsDoesNotInventFallbackWithoutVRF(t *testing.T) {
+	lowerSlot := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 90, Hash: []byte("lower-slot")},
+		BlockNumber: 50,
+	}
+	higherSlot := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("higher-slot")},
+		BlockNumber: 50,
+	}
+
+	result := ComparePraosTips(
+		lowerSlot, higherSlot,
+		PraosTiebreakerViewFromTip(lowerSlot, nil, PraosTiebreakerConfigConway()),
+		PraosTiebreakerViewFromTip(higherSlot, nil, PraosTiebreakerConfigConway()),
+	)
+	assert.Equal(t, ChainEqual, result)
+}
+
+func TestComparePraosTipsConwayRestrictionDisarmsDistantVRF(t *testing.T) {
+	ours := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("ours")},
+		BlockNumber: 50,
+	}
+	candidate := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 106, Hash: []byte("candidate")},
+		BlockNumber: 50,
+	}
+
+	result := ComparePraosTips(
+		ours, candidate,
+		PraosTiebreakerViewFromTip(ours, make64ByteVRFFirstByte(0xBD), PraosTiebreakerConfigConway()),
+		PraosTiebreakerViewFromTip(candidate, make64ByteVRFFirstByte(0x6E), PraosTiebreakerConfigConway()),
+	)
+	assert.Equal(t, ChainEqual, result,
+		"Conway restriction must disarm VRF tiebreaker when tips are >5 slots apart")
+}
+
+func TestComparePraosTipsSlotBattleWithoutSelectViewDoesNotInventHashTieBreak(t *testing.T) {
+	dingoTip := ochainsync.Tip{
+		BlockNumber: 11,
+		Point: ocommon.Point{
+			Slot: 40,
+			Hash: []byte{
+				0x5c, 0x25, 0x9f, 0x44, 0x42, 0xe1, 0x49, 0x33,
+				0x72, 0xe2, 0x07, 0x83, 0xaa, 0xb3, 0x06, 0x39,
+				0x13, 0x75, 0x44, 0x42, 0xe5, 0x98, 0xa0, 0x54,
+				0xad, 0xe8, 0xb6, 0x26, 0xef, 0xe7, 0x4c, 0xe1,
+			},
+		},
+	}
+	cardanoTip := ochainsync.Tip{
+		BlockNumber: 11,
+		Point: ocommon.Point{
+			Slot: 40,
+			Hash: []byte{
+				0x0c, 0x54, 0x11, 0x82, 0xc9, 0xa9, 0xa6, 0x6d,
+				0xa2, 0xf7, 0xc3, 0x1a, 0x1f, 0x9b, 0x9e, 0x4a,
+				0xeb, 0xf0, 0xfe, 0x0f, 0xed, 0x41, 0xe8, 0x04,
+				0xb7, 0x21, 0xac, 0xf5, 0x78, 0x3a, 0x64, 0x03,
+			},
+		},
+	}
+
+	got := ComparePraosTips(
+		dingoTip, cardanoTip,
+		PraosTiebreakerViewFromTip(dingoTip, nil, PraosTiebreakerConfigConway()),
+		PraosTiebreakerViewFromTip(cardanoTip, nil, PraosTiebreakerConfigConway()),
+	)
+	require.Equal(t, ChainEqual, got)
+}
+
+// --- VRF comparison tests ---------------------------------------------------
+
+func TestCompareVRFOutputs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		vrfA     []byte
+		vrfB     []byte
+		expected ChainComparisonResult
+	}{
+		{
+			name:     "full 64-byte VRF - A lower wins",
+			vrfA:     make64ByteVRF(0x00),
+			vrfB:     make64ByteVRF(0x01),
+			expected: ChainABetter,
+		},
+		{
+			name:     "full 64-byte VRF - B lower wins",
+			vrfA:     make64ByteVRF(0x01),
+			vrfB:     make64ByteVRF(0x00),
+			expected: ChainBBetter,
+		},
+		{
+			name:     "full 64-byte VRF - equal",
+			vrfA:     make64ByteVRF(0x50),
+			vrfB:     make64ByteVRF(0x50),
+			expected: ChainEqual,
+		},
+		{
+			name:     "64-byte VRF first byte different - A lower wins",
+			vrfA:     make64ByteVRFFirstByte(0x00),
+			vrfB:     make64ByteVRFFirstByte(0xFF),
+			expected: ChainABetter,
+		},
+		{
+			name:     "64-byte VRF first byte different - B lower wins",
+			vrfA:     make64ByteVRFFirstByte(0xFF),
+			vrfB:     make64ByteVRFFirstByte(0x00),
+			expected: ChainBBetter,
+		},
+		{
+			name:     "vrfA nil - equal",
+			vrfA:     nil,
+			vrfB:     make64ByteVRF(0x01),
+			expected: ChainEqual,
+		},
+		{
+			name:     "vrfB nil - equal",
+			vrfA:     make64ByteVRF(0x01),
+			vrfB:     nil,
+			expected: ChainEqual,
+		},
+		{
+			name:     "both nil - equal",
+			vrfA:     nil,
+			vrfB:     nil,
+			expected: ChainEqual,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, CompareVRFOutputs(tc.vrfA, tc.vrfB))
+		})
+	}
+}
+
+func TestCompareVRFOutputs_InvalidLength(t *testing.T) {
+	testCases := []struct {
+		name     string
+		vrfA     []byte
+		vrfB     []byte
+		expected ChainComparisonResult
+	}{
+		{
+			name:     "short vrfA should not win despite lower value",
+			vrfA:     []byte{0x00},
+			vrfB:     make64ByteVRF(0x01),
+			expected: ChainEqual,
+		},
+		{
+			name:     "short vrfB should not win despite lower value",
+			vrfA:     make64ByteVRF(0x01),
+			vrfB:     []byte{0x00},
+			expected: ChainEqual,
+		},
+		{
+			name:     "both short - equal",
+			vrfA:     []byte{0x00, 0x00, 0x00, 0x01},
+			vrfB:     []byte{0x00, 0x00, 0x00, 0x02},
+			expected: ChainEqual,
+		},
+		{
+			name:     "empty vrfA - equal",
+			vrfA:     []byte{},
+			vrfB:     make64ByteVRF(0x01),
+			expected: ChainEqual,
+		},
+		{
+			name:     "empty vrfB - equal",
+			vrfA:     make64ByteVRF(0x01),
+			vrfB:     []byte{},
+			expected: ChainEqual,
+		},
+		{
+			name:     "both empty - equal",
+			vrfA:     []byte{},
+			vrfB:     []byte{},
+			expected: ChainEqual,
+		},
+		{
+			name:     "oversized vrfA - equal",
+			vrfA:     make([]byte, VRFOutputSize+1),
+			vrfB:     make64ByteVRF(0xFF),
+			expected: ChainEqual,
+		},
+		{
+			name:     "oversized vrfB - equal",
+			vrfA:     make64ByteVRF(0xFF),
+			vrfB:     make([]byte, VRFOutputSize+1),
+			expected: ChainEqual,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, CompareVRFOutputs(tc.vrfA, tc.vrfB))
+		})
+	}
+}
+
+// TestGetVRFOutput_ByronReturnsNil pins the cross-era no-tiebreaker invariant
+// for Byron<->Shelley boundaries. Byron blocks have no VRF (PBFT, not Praos),
+// so any chain-selection tie that includes a Byron tip must not use a
+// VRF-derived field.
+func TestGetVRFOutput_ByronReturnsNil(t *testing.T) {
+	byronHeader := &byron.ByronMainBlockHeader{}
+	assert.Nil(t, GetVRFOutput(byronHeader),
+		"Byron headers must yield nil VRF output (no VRF in PBFT)")
+
+	shelleyHeader := &shelley.ShelleyBlockHeader{}
+	cmp := CompareVRFOutputs(
+		GetVRFOutput(byronHeader),
+		GetVRFOutput(shelleyHeader),
+	)
+	assert.Equal(t, ChainEqual, cmp,
+		"a tie that includes a Byron tip must not be broken by VRF "+
+			"(NoTiebreakerAcrossEras at Byron<->Shelley)")
+	cmp = CompareVRFOutputs(
+		GetVRFOutput(shelleyHeader),
+		GetVRFOutput(byronHeader),
+	)
+	assert.Equal(t, ChainEqual, cmp,
+		"NoTiebreakerAcrossEras must be symmetric")
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func make64ByteVRF(fill byte) []byte {
+	vrf := make([]byte, VRFOutputSize)
+	for i := range vrf {
+		vrf[i] = fill
+	}
+	return vrf
+}
+
+func make64ByteVRFFirstByte(first byte) []byte {
+	vrf := make([]byte, VRFOutputSize)
+	vrf[0] = first
+	return vrf
+}

--- a/consensus/praos/view.go
+++ b/consensus/praos/view.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package praos contains pure Praos chain-selection primitives: the select
+// view projected from a Shelley-family block header, VRF output extraction,
+// and the equal-length tiebreaker comparison functions that mirror
+// ouroboros-consensus' PraosTiebreakerView and preferCandidate logic.
+//
+// This package has no dependency on peer-selection lifecycle code; it is safe
+// to import from ledger, chain-selection, or any other component that needs
+// Praos ordering without pulling in the full ChainSelector.
+package praos
+
+import (
+	"bytes"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// VRFOutputSize is the expected size of a VRF output in bytes.
+const VRFOutputSize = 64
+
+const praosRestrictedTiebreakerMaxSlotDistance = 5
+
+// PraosTiebreakerFlavor matches ouroboros-consensus' VRFTiebreakerFlavor.
+type PraosTiebreakerFlavor uint8
+
+const (
+	PraosTiebreakerUnknown PraosTiebreakerFlavor = iota
+	PraosTiebreakerUnrestricted
+	PraosTiebreakerRestricted
+)
+
+// PraosTiebreakerConfig is the chain-order config projected from the current
+// Shelley-family block config. The reference implementation uses unrestricted
+// VRF before Conway and restricted VRF with max distance 5 from Conway onward.
+type PraosTiebreakerConfig struct {
+	Flavor          PraosTiebreakerFlavor
+	MaxSlotDistance uint64
+}
+
+// PraosTiebreakerView mirrors ouroboros-consensus' PraosTiebreakerView for
+// equal-length chain selection.
+type PraosTiebreakerView struct {
+	Slot              uint64
+	Issuer            []byte
+	IssueNo           uint64
+	TieBreakVRF       []byte
+	TiebreakerConfig  PraosTiebreakerConfig
+	hasIssuerAndIssue bool
+}
+
+// PraosTiebreakerConfigBeforeConway returns the unrestricted VRF tiebreaker
+// config used in eras before Conway.
+func PraosTiebreakerConfigBeforeConway() PraosTiebreakerConfig {
+	return PraosTiebreakerConfig{
+		Flavor: PraosTiebreakerUnrestricted,
+	}
+}
+
+// PraosTiebreakerConfigConway returns the restricted VRF tiebreaker config
+// used from Conway onward (max slot distance 5).
+func PraosTiebreakerConfigConway() PraosTiebreakerConfig {
+	return PraosTiebreakerConfig{
+		Flavor:          PraosTiebreakerRestricted,
+		MaxSlotDistance: praosRestrictedTiebreakerMaxSlotDistance,
+	}
+}
+
+// PraosTiebreakerConfigUnknown returns a zero-value config (flavor Unknown).
+func PraosTiebreakerConfigUnknown() PraosTiebreakerConfig {
+	return PraosTiebreakerConfig{}
+}
+
+func (c PraosTiebreakerConfig) known() bool {
+	return c.Flavor == PraosTiebreakerUnrestricted ||
+		c.Flavor == PraosTiebreakerRestricted
+}
+
+func (v PraosTiebreakerView) hasIssuerIssueNo() bool {
+	return v.hasIssuerAndIssue && len(v.Issuer) > 0
+}
+
+// PraosTiebreakerViewFromTip builds a partial view when only a chainsync tip
+// and VRF are available. The issuer/opcert rule cannot be applied to partial
+// views.
+func PraosTiebreakerViewFromTip(
+	tip ochainsync.Tip,
+	vrfOutput []byte,
+	config PraosTiebreakerConfig,
+) PraosTiebreakerView {
+	return PraosTiebreakerView{
+		Slot:             tip.Point.Slot,
+		TieBreakVRF:      cloneBytes(vrfOutput),
+		TiebreakerConfig: config,
+	}
+}
+
+// NewPraosTiebreakerViewFull constructs a complete view with issuer and opcert
+// issue number set. Use this when full header data is available (e.g. in
+// tests, or when constructing views from decoded block headers manually).
+func NewPraosTiebreakerViewFull(
+	tip ochainsync.Tip,
+	issuer []byte,
+	issueNo uint64,
+	vrfOutput []byte,
+	config PraosTiebreakerConfig,
+) PraosTiebreakerView {
+	return PraosTiebreakerView{
+		Slot:              tip.Point.Slot,
+		Issuer:            cloneBytes(issuer),
+		IssueNo:           issueNo,
+		TieBreakVRF:       cloneBytes(vrfOutput),
+		TiebreakerConfig:  config,
+		hasIssuerAndIssue: true,
+	}
+}
+
+// GetPraosTiebreakerView extracts the Praos select-view fields from a
+// Shelley-family header.
+func GetPraosTiebreakerView(
+	header ledger.BlockHeader,
+) (PraosTiebreakerView, bool) {
+	if header == nil {
+		return PraosTiebreakerView{}, false
+	}
+	issueNo, ok := headerIssueNo(header)
+	if !ok {
+		return PraosTiebreakerView{}, false
+	}
+	issuer := header.IssuerVkey()
+	return PraosTiebreakerView{
+		Slot:              header.SlotNumber(),
+		Issuer:            cloneBytes(issuer[:]),
+		IssueNo:           issueNo,
+		TieBreakVRF:       cloneBytes(GetVRFOutput(header)),
+		TiebreakerConfig:  praosTiebreakerConfigForHeader(header),
+		hasIssuerAndIssue: true,
+	}, true
+}
+
+func headerIssueNo(header ledger.BlockHeader) (uint64, bool) {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *allegra.AllegraBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *mary.MaryBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *alonzo.AlonzoBlockHeader:
+		return uint64(h.Body.OpCertSequenceNumber), true
+	case *babbage.BabbageBlockHeader:
+		return uint64(h.Body.OpCert.SequenceNumber), true
+	case *conway.ConwayBlockHeader:
+		return uint64(h.Body.OpCert.SequenceNumber), true
+	default:
+		return 0, false
+	}
+}
+
+func praosTiebreakerConfigForHeader(
+	header ledger.BlockHeader,
+) PraosTiebreakerConfig {
+	if header.Era().Id >= conway.EraIdConway {
+		return PraosTiebreakerConfigConway()
+	}
+	return PraosTiebreakerConfigBeforeConway()
+}
+
+// GetVRFOutput extracts the VRF output from a block header.
+// Returns nil if the header type is not supported or doesn't contain VRF data.
+//
+// The VRF output is used for tie-breaking in chain selection when two chains
+// have equal block numbers and equal density. The chain with the LOWER VRF
+// output (lexicographically) wins.
+func GetVRFOutput(header ledger.BlockHeader) []byte {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *allegra.AllegraBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *mary.MaryBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *alonzo.AlonzoBlockHeader:
+		return h.Body.LeaderVrf.Output
+	case *babbage.BabbageBlockHeader:
+		return h.Body.VrfResult.Output
+	case *conway.ConwayBlockHeader:
+		return h.Body.VrfResult.Output
+	default:
+		return nil
+	}
+}
+
+// CompareVRFOutputs compares two VRF outputs for chain selection tie-breaking.
+// Returns:
+//   - ChainABetter (1) if vrfA is lower (A wins)
+//   - ChainBBetter (-1) if vrfB is lower (B wins)
+//   - ChainEqual (0) if equal, either is nil, or either has invalid length
+//
+// Per Ouroboros Praos: the chain with the LOWER VRF output wins the tie-break.
+// Both outputs must be exactly VRFOutputSize (64) bytes; outputs of any other
+// length are treated the same as nil to prevent truncated values from winning.
+func CompareVRFOutputs(vrfA, vrfB []byte) ChainComparisonResult {
+	if len(vrfA) != VRFOutputSize || len(vrfB) != VRFOutputSize {
+		return ChainEqual
+	}
+	cmp := bytes.Compare(vrfA, vrfB)
+	if cmp < 0 {
+		return ChainABetter
+	}
+	if cmp > 0 {
+		return ChainBBetter
+	}
+	return ChainEqual
+}
+
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/dingo/chainselection"
 	cardano "github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/consensus/praos"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
@@ -1398,9 +1399,9 @@ func observedHeaderTip(e ChainsyncEvent) ochainsync.Tip {
 
 func (ls *LedgerState) localTipPraosView(
 	localTip ochainsync.Tip,
-) chainselection.PraosTiebreakerView {
+) praos.PraosTiebreakerView {
 	if ls == nil || ls.db == nil || len(localTip.Point.Hash) == 0 {
-		return chainselection.PraosTiebreakerView{}
+		return praos.PraosTiebreakerView{}
 	}
 	block, err := database.BlockByHash(ls.db, localTip.Point.Hash)
 	if err != nil {
@@ -1413,7 +1414,7 @@ func (ls *LedgerState) localTipPraosView(
 				"error", err,
 			)
 		}
-		return chainselection.PraosTiebreakerView{}
+		return praos.PraosTiebreakerView{}
 	}
 	decoded, err := block.Decode()
 	if err != nil {
@@ -1426,32 +1427,32 @@ func (ls *LedgerState) localTipPraosView(
 				"error", err,
 			)
 		}
-		return chainselection.PraosTiebreakerView{}
+		return praos.PraosTiebreakerView{}
 	}
 	if decoded == nil {
-		return chainselection.PraosTiebreakerView{}
+		return praos.PraosTiebreakerView{}
 	}
-	view, _ := chainselection.GetPraosTiebreakerView(decoded.Header())
+	view, _ := praos.GetPraosTiebreakerView(decoded.Header())
 	return view
 }
 
 func (ls *LedgerState) compareIncomingHeaderToLocalTip(
 	e ChainsyncEvent,
 	localTip ochainsync.Tip,
-) chainselection.ChainComparisonResult {
+) praos.ChainComparisonResult {
 	observedTip := observedHeaderTip(e)
 	if observedTip.BlockNumber == 0 && e.Tip.BlockNumber > 0 {
 		observedTip = e.Tip
 	}
 
-	incomingView, _ := chainselection.GetPraosTiebreakerView(e.BlockHeader)
-	result := chainselection.ComparePraosTips(
+	incomingView, _ := praos.GetPraosTiebreakerView(e.BlockHeader)
+	result := praos.ComparePraosTips(
 		observedTip,
 		localTip,
 		incomingView,
 		ls.localTipPraosView(localTip),
 	)
-	if result != chainselection.ChainEqual {
+	if result != praos.ChainEqual {
 		return result
 	}
 
@@ -1461,9 +1462,9 @@ func (ls *LedgerState) compareIncomingHeaderToLocalTip(
 	if e.Tip.BlockNumber > observedTip.BlockNumber {
 		switch {
 		case e.Tip.BlockNumber > localTip.BlockNumber:
-			return chainselection.ChainABetter
+			return praos.ChainABetter
 		case e.Tip.BlockNumber < localTip.BlockNumber:
-			return chainselection.ChainBBetter
+			return praos.ChainBBetter
 		}
 	}
 	return result
@@ -1480,13 +1481,13 @@ func (ls *LedgerState) earlierHeaderCanBeatLocalTip(
 	if observedTip.BlockNumber < localTip.BlockNumber {
 		return false
 	}
-	incomingView, _ := chainselection.GetPraosTiebreakerView(e.BlockHeader)
-	return chainselection.ComparePraosTips(
+	incomingView, _ := praos.GetPraosTiebreakerView(e.BlockHeader)
+	return praos.ComparePraosTips(
 		observedTip,
 		localTip,
 		incomingView,
 		ls.localTipPraosView(localTip),
-	) == chainselection.ChainABetter
+	) == praos.ChainABetter
 }
 
 type LocalRollbackRecoveryResult struct {
@@ -1985,7 +1986,7 @@ func (ls *LedgerState) tryResolveFork(
 	if ls.compareIncomingHeaderToLocalTip(
 		e,
 		localTip,
-	) != chainselection.ChainABetter {
+	) != praos.ChainABetter {
 		return false, nil
 	}
 

--- a/ledger/forging/bootstrap_forge_gate_test.go
+++ b/ledger/forging/bootstrap_forge_gate_test.go
@@ -17,7 +17,7 @@ package forging
 import (
 	"testing"
 
-	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/consensus/praos"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
@@ -120,12 +120,12 @@ func TestChainSelectionPrefersLongerChainOverLowerSlot(t *testing.T) {
 
 	require.Truef(
 		t,
-		chainselection.ComparePraosTips(
+		praos.ComparePraosTips(
 			cardanoIncomingTip,
 			dingoLocalTip,
-			chainselection.PraosTiebreakerView{},
-			chainselection.PraosTiebreakerView{},
-		) == chainselection.ChainABetter,
+			praos.PraosTiebreakerView{},
+			praos.PraosTiebreakerView{},
+		) == praos.ChainABetter,
 		"cardano's longer (block_number=3) chain must beat dingo's "+
 			"local (block_number=1) chain even though dingo's tip "+
 			"slot is lower (%d < %d).",
@@ -133,12 +133,12 @@ func TestChainSelectionPrefersLongerChainOverLowerSlot(t *testing.T) {
 	)
 	require.Falsef(
 		t,
-		chainselection.ComparePraosTips(
+		praos.ComparePraosTips(
 			dingoLocalTip,
 			cardanoIncomingTip,
-			chainselection.PraosTiebreakerView{},
-			chainselection.PraosTiebreakerView{},
-		) == chainselection.ChainABetter,
+			praos.PraosTiebreakerView{},
+			praos.PraosTiebreakerView{},
+		) == praos.ChainABetter,
 		"dingo's local chain at lower slot but fewer blocks must "+
 			"NOT win against cardano's longer chain. If it did, "+
 			"dingo would entrench a forked solo-extension chain "+

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/consensus/praos"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -677,8 +678,8 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		// Extract VRF output from block header once for chain
 		// selection tie-breaking (used in both dedup and normal
 		// paths below).
-		vrfOutput := chainselection.GetVRFOutput(v)
-		praosView, _ := chainselection.GetPraosTiebreakerView(v)
+		vrfOutput := praos.GetVRFOutput(v)
+		praosView, _ := praos.GetPraosTiebreakerView(v)
 		// Ingress eligibility is the sole gate for feeding the ledger
 		// and chain selection. reconcileChainsyncIngressAdmission
 		// defers to ChainsyncIngressEligible (peergov), which already


### PR DESCRIPTION
Closes #2438 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Praos chain-selection primitives into a new `consensus/praos` package and switched `ledger` and `ouroboros` to use it. VRF, issuer/opcert, and Conway-restricted tiebreaker logic are now pure, reusable, and covered by dedicated tests.

- **Refactors**
  - Added `consensus/praos` with `PraosTiebreakerView`, VRF extraction, `ComparePraosTips`, `PreferPraosCandidate`, `CompareVRFOutputs`, and `NewPraosTiebreakerViewFull`.
  - Centralized era rules (unrestricted vs. restricted VRF, Conway max slot distance) in `consensus/praos`.
  - Kept `chainselection` as a thin re-export layer for backward compatibility.
  - Updated `ledger` and `ouroboros` chainsync to call `praos` for view extraction and comparisons; adjusted tests.

- **Migration**
  - New code should import `github.com/blinklabs-io/dingo/consensus/praos`.
  - Existing `chainselection` imports continue to work via re-exports.

<sup>Written for commit 5c9dddec9dd5c084fdd0007a75b9f66e325f3145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Praos chain selection and tiebreaking logic into a centralized reference implementation for improved code maintainability and consistency across the system.

* **Tests**
  * Added extensive test suite validating Praos chain-tip comparison, VRF output handling, and configuration-specific tiebreaking behavior across different blockchain eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->