### PR TITLE
WIP:   ci: updated the workflow to use re-useble workflows

### DIFF
--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,19 +1,12 @@
 name: Test Issue Close Trigger
-permissions:
-  contents: read
+
 on:
   issues:
     types: [closed]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print closed issue info
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          echo "Issue Number: $ISSUE_NUMBER"
-          echo "Title: $ISSUE_TITLE"
-          echo "Workflow triggered successfully when issue was closed."
+    uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -4,36 +4,12 @@ on:
   issues:
     types: [closed]
 
-permissions:
-  contents: read
-  issues: read
-
-env:
-  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
-  CLOSED_DATE_FIELD: "Closed Date"
-
 jobs:
   set-date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve closed date
-        id: when
-        shell: bash
-        run: |
-          ts='${{ github.event.issue.closed_at }}'
-          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
-            d=$(date -u +%F)
-          else
-            d=$(date -u -d "$ts" +%F)
-          fi
-          echo "date=$d" >> "$GITHUB_OUTPUT"
-          echo "Closed date -> $d"
-
-      # Update the "Closed Date" field on that project item
-      - name: Update Closed Date field
-        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
-        with:
-          project-url: ${{ env.PROJECT_URL }}
-          github-token: ${{ secrets.ORG_PROJECT_PAT }}
-          field-name: ${{ env.CLOSED_DATE_FIELD }}
-          field-value: ${{ steps.when.outputs.date }}
+    uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main
+    with:
+      project_url: https://github.com/orgs/blinklabs-io/projects/11
+      closed_date_field: Closed Date
+      closed_at: ${{ github.event.issue.closed_at }}
+    secrets:
+      project_pat: ${{ secrets.ORG_PROJECT_PAT }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   set-date:
     uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch issue-close workflows to reusable workflows in `blinklabs-io/actions` to standardize behavior and reduce maintenance. No behavior change.

- **Refactors**
  - `test-issue-on-close.yml`: now calls `blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main` with `issue_number` and `issue_title`.
  - `update-issue-on-close.yml`: now calls `blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main` with `project_url`, `closed_date_field`, and `closed_at`; passes `project_pat` from `secrets.ORG_PROJECT_PAT`.

<sup>Written for commit 6bc7afba1fa2f597d2fd5f1e6c421b5e404fe5cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

