### PR TITLE
feat(midnight): Add midnight config section with YAML, env, and CLI parsing

### DIFF
--- a/config.go
+++ b/config.go
@@ -97,6 +97,25 @@ type OffchainMetadataConfig struct {
 	AllowPrivateAddresses bool
 }
 
+// MidnightConfig controls the Midnight indexer and optional gRPC listener.
+// Indexing is only active in API storage mode. Port 0 disables the gRPC
+// listener while leaving indexing eligible to run.
+type MidnightConfig struct {
+	Port uint
+	Host string
+
+	CNightPolicyID              string
+	CNightAssetName             string
+	MappingValidatorAddress     string
+	AuthTokenAssetName          string
+	CommitteeCandidateAddress   string
+	TechnicalCommitteeAddress   string
+	TechnicalCommitteePolicyID  string
+	CouncilAddress              string
+	CouncilPolicyID             string
+	PermissionedCandidatePolicy string
+}
+
 type Config struct {
 	promRegistry             prometheus.Registerer
 	topologyConfig           *topology.TopologyConfig
@@ -176,6 +195,8 @@ type Config struct {
 	blockfrostPort uint
 	// Off-chain metadata fetcher configuration
 	offchainMetadata OffchainMetadataConfig
+	// Midnight indexer and gRPC API configuration
+	midnight MidnightConfig
 	// Chainsync multi-client configuration
 	chainsyncMaxClients   int
 	chainsyncStallTimeout time.Duration
@@ -422,6 +443,10 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 		genesisBootstrap: true,
 		historyExpiry: HistoryExpiryConfig{
 			Frequency: time.Hour,
+		},
+		midnight: MidnightConfig{
+			Port: 50051,
+			Host: "0.0.0.0",
 		},
 		corsAllowedOrigins: []string{
 			"*",
@@ -924,6 +949,13 @@ func WithCORSAllowedOrigins(origins []string) ConfigOptionFunc {
 func WithOffchainMetadataConfig(cfg OffchainMetadataConfig) ConfigOptionFunc {
 	return func(c *Config) {
 		c.offchainMetadata = cfg
+	}
+}
+
+// WithMidnightConfig configures the Midnight indexer and optional gRPC API.
+func WithMidnightConfig(cfg MidnightConfig) ConfigOptionFunc {
+	return func(c *Config) {
+		c.midnight = cfg
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -64,6 +64,28 @@ func TestWithStorageMode(t *testing.T) {
 	assert.Equal(t, StorageModeCore, cfg.storageMode)
 }
 
+func TestWithMidnightConfig(t *testing.T) {
+	cfg := &Config{}
+	midnightCfg := MidnightConfig{
+		Port:                        50052,
+		Host:                        "127.0.0.1",
+		CNightPolicyID:              "policy1",
+		CNightAssetName:             "434e49474854",
+		MappingValidatorAddress:     "addr_mapping",
+		AuthTokenAssetName:          "auth",
+		CommitteeCandidateAddress:   "addr_candidate",
+		TechnicalCommitteeAddress:   "addr_technical",
+		TechnicalCommitteePolicyID:  "policy_technical",
+		CouncilAddress:              "addr_council",
+		CouncilPolicyID:             "policy_council",
+		PermissionedCandidatePolicy: "policy_permissioned",
+	}
+
+	WithMidnightConfig(midnightCfg)(cfg)
+
+	assert.Equal(t, midnightCfg, cfg.midnight)
+}
+
 func TestExperimentalDijkstraEnabled(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -422,16 +422,16 @@ midnight:
   host: "0.0.0.0"
   # Midnight network constants. Known network defaults are applied when
   # available; set these explicitly for custom networks or overrides.
-  cnight_policy_id: ""
-  cnight_asset_name: ""
-  mapping_validator_address: ""
-  auth_token_asset_name: ""
-  committee_candidate_address: ""
-  technical_committee_address: ""
-  technical_committee_policy_id: ""
-  council_address: ""
-  council_policy_id: ""
-  permissioned_candidate_policy: ""
+  cnightPolicyId: ""
+  cnightAssetName: ""
+  mappingValidatorAddress: ""
+  authTokenAssetName: ""
+  committeeCandidateAddress: ""
+  technicalCommitteeAddress: ""
+  technicalCommitteePolicyId: ""
+  councilAddress: ""
+  councilPolicyId: ""
+  permissionedCandidatePolicy: ""
 
 # Cache configuration for tiered CBOR cache system
 # This controls the in-memory caching of UTxO and transaction CBOR data

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -409,6 +409,30 @@ genesisBootstrap:
   # 0 uses the peer-governor default.
   promotionMinDiversityGroups: 0
 
+# Midnight indexer configuration
+# Indexing is active only in API storage mode. Setting port to 0 disables
+# the Midnight gRPC server while leaving indexing eligible to run.
+# CLI: --midnight-port, --midnight-host
+# Env: DINGO_MIDNIGHT_PORT, DINGO_MIDNIGHT_HOST
+# Address and policy fields are YAML/env only.
+midnight:
+  # gRPC listen port
+  port: 50051
+  # gRPC listen address
+  host: "0.0.0.0"
+  # Midnight network constants. Known network defaults are applied when
+  # available; set these explicitly for custom networks or overrides.
+  cnight_policy_id: ""
+  cnight_asset_name: ""
+  mapping_validator_address: ""
+  auth_token_asset_name: ""
+  committee_candidate_address: ""
+  technical_committee_address: ""
+  technical_committee_policy_id: ""
+  council_address: ""
+  council_policy_id: ""
+  permissioned_candidate_policy: ""
+
 # Cache configuration for tiered CBOR cache system
 # This controls the in-memory caching of UTxO and transaction CBOR data
 cache:

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -414,7 +414,7 @@ genesisBootstrap:
 # the Midnight gRPC server while leaving indexing eligible to run.
 # CLI: --midnight-port, --midnight-host
 # Env: DINGO_MIDNIGHT_PORT, DINGO_MIDNIGHT_HOST
-# Address and policy fields are YAML/env only.
+# Address and policy fields are YAML only.
 midnight:
   # gRPC listen port
   port: 50051

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,16 +286,16 @@ type MidnightConfig struct {
 	Port uint   `yaml:"port" envconfig:"DINGO_MIDNIGHT_PORT"`
 	Host string `yaml:"host" envconfig:"DINGO_MIDNIGHT_HOST"`
 
-	CNightPolicyID              string `yaml:"cnight_policy_id"`
-	CNightAssetName             string `yaml:"cnight_asset_name"`
-	MappingValidatorAddress     string `yaml:"mapping_validator_address"`
-	AuthTokenAssetName          string `yaml:"auth_token_asset_name"`
-	CommitteeCandidateAddress   string `yaml:"committee_candidate_address"`
-	TechnicalCommitteeAddress   string `yaml:"technical_committee_address"`
-	TechnicalCommitteePolicyID  string `yaml:"technical_committee_policy_id"`
-	CouncilAddress              string `yaml:"council_address"`
-	CouncilPolicyID             string `yaml:"council_policy_id"`
-	PermissionedCandidatePolicy string `yaml:"permissioned_candidate_policy"`
+	CNightPolicyID              string `yaml:"cnightPolicyId"`
+	CNightAssetName             string `yaml:"cnightAssetName"`
+	MappingValidatorAddress     string `yaml:"mappingValidatorAddress"`
+	AuthTokenAssetName          string `yaml:"authTokenAssetName"`
+	CommitteeCandidateAddress   string `yaml:"committeeCandidateAddress"`
+	TechnicalCommitteeAddress   string `yaml:"technicalCommitteeAddress"`
+	TechnicalCommitteePolicyID  string `yaml:"technicalCommitteePolicyId"`
+	CouncilAddress              string `yaml:"councilAddress"`
+	CouncilPolicyID             string `yaml:"councilPolicyId"`
+	PermissionedCandidatePolicy string `yaml:"permissionedCandidatePolicy"`
 }
 
 // DefaultMidnightConfig returns the default Midnight indexer settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -445,6 +445,8 @@ type Config struct {
 }
 
 // midnightNetworkDefaults holds per-network Midnight constants sourced from
+// Acropolis. At the time these defaults were added, Acropolis published
+// constants for mainnet and preview only.
 // https://github.com/input-output-hk/acropolis/tree/master/processes/midnight_indexer
 var midnightNetworkDefaults = map[string]MidnightConfig{
 	"mainnet": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,48 @@ type databaseConfig struct {
 	Metadata map[string]any `yaml:"metadata,omitempty"`
 }
 
+var midnightYAMLFields map[string]struct{}
+
+func collectMidnightYAMLFields(buf []byte) map[string]struct{} {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(buf, &doc); err != nil {
+		return nil
+	}
+	if len(doc.Content) == 0 {
+		return nil
+	}
+	root := doc.Content[0]
+	midnight := mappingValue(root, "midnight")
+	if configNode := mappingValue(root, "config"); configNode != nil {
+		midnight = mappingValue(configNode, "midnight")
+	}
+	if midnight == nil || midnight.Kind != yaml.MappingNode {
+		return nil
+	}
+	fields := map[string]struct{}{}
+	for i := 0; i+1 < len(midnight.Content); i += 2 {
+		fields[midnight.Content[i].Value] = struct{}{}
+	}
+	return fields
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func midnightYAMLFieldSet(field string) bool {
+	_, ok := midnightYAMLFields[field]
+	return ok
+}
+
 // ChainsyncConfig holds configuration for the multi-client chainsync
 // subsystem.
 type ChainsyncConfig struct {
@@ -513,34 +555,44 @@ func clearMidnightNetworkDefaults(cfg *Config, network string) {
 	if !ok {
 		return
 	}
-	if cfg.Midnight.CNightPolicyID == defaults.CNightPolicyID {
+	if !midnightYAMLFieldSet("cnightPolicyId") &&
+		cfg.Midnight.CNightPolicyID == defaults.CNightPolicyID {
 		cfg.Midnight.CNightPolicyID = ""
 	}
-	if cfg.Midnight.CNightAssetName == defaults.CNightAssetName {
+	if !midnightYAMLFieldSet("cnightAssetName") &&
+		cfg.Midnight.CNightAssetName == defaults.CNightAssetName {
 		cfg.Midnight.CNightAssetName = ""
 	}
-	if cfg.Midnight.MappingValidatorAddress == defaults.MappingValidatorAddress {
+	if !midnightYAMLFieldSet("mappingValidatorAddress") &&
+		cfg.Midnight.MappingValidatorAddress == defaults.MappingValidatorAddress {
 		cfg.Midnight.MappingValidatorAddress = ""
 	}
-	if cfg.Midnight.AuthTokenAssetName == defaults.AuthTokenAssetName {
+	if !midnightYAMLFieldSet("authTokenAssetName") &&
+		cfg.Midnight.AuthTokenAssetName == defaults.AuthTokenAssetName {
 		cfg.Midnight.AuthTokenAssetName = ""
 	}
-	if cfg.Midnight.CommitteeCandidateAddress == defaults.CommitteeCandidateAddress {
+	if !midnightYAMLFieldSet("committeeCandidateAddress") &&
+		cfg.Midnight.CommitteeCandidateAddress == defaults.CommitteeCandidateAddress {
 		cfg.Midnight.CommitteeCandidateAddress = ""
 	}
-	if cfg.Midnight.TechnicalCommitteeAddress == defaults.TechnicalCommitteeAddress {
+	if !midnightYAMLFieldSet("technicalCommitteeAddress") &&
+		cfg.Midnight.TechnicalCommitteeAddress == defaults.TechnicalCommitteeAddress {
 		cfg.Midnight.TechnicalCommitteeAddress = ""
 	}
-	if cfg.Midnight.TechnicalCommitteePolicyID == defaults.TechnicalCommitteePolicyID {
+	if !midnightYAMLFieldSet("technicalCommitteePolicyId") &&
+		cfg.Midnight.TechnicalCommitteePolicyID == defaults.TechnicalCommitteePolicyID {
 		cfg.Midnight.TechnicalCommitteePolicyID = ""
 	}
-	if cfg.Midnight.CouncilAddress == defaults.CouncilAddress {
+	if !midnightYAMLFieldSet("councilAddress") &&
+		cfg.Midnight.CouncilAddress == defaults.CouncilAddress {
 		cfg.Midnight.CouncilAddress = ""
 	}
-	if cfg.Midnight.CouncilPolicyID == defaults.CouncilPolicyID {
+	if !midnightYAMLFieldSet("councilPolicyId") &&
+		cfg.Midnight.CouncilPolicyID == defaults.CouncilPolicyID {
 		cfg.Midnight.CouncilPolicyID = ""
 	}
-	if cfg.Midnight.PermissionedCandidatePolicy == defaults.PermissionedCandidatePolicy {
+	if !midnightYAMLFieldSet("permissionedCandidatePolicy") &&
+		cfg.Midnight.PermissionedCandidatePolicy == defaults.PermissionedCandidatePolicy {
 		cfg.Midnight.PermissionedCandidatePolicy = ""
 	}
 }
@@ -701,6 +753,8 @@ var globalConfig = &Config{
 }
 
 func LoadConfig(configFile string) (*Config, error) {
+	midnightYAMLFields = nil
+
 	// Load config file as YAML if provided
 	if configFile == "" {
 		// Check for config file in this path: ~/.dingo/dingo.yaml
@@ -725,6 +779,7 @@ func LoadConfig(configFile string) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
+		midnightYAMLFields = collectMidnightYAMLFields(buf)
 
 		// First unmarshal into temp config to handle plugin sections
 		var tempCfg tempConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,16 +286,16 @@ type MidnightConfig struct {
 	Port uint   `yaml:"port" envconfig:"DINGO_MIDNIGHT_PORT"`
 	Host string `yaml:"host" envconfig:"DINGO_MIDNIGHT_HOST"`
 
-	CNightPolicyID              string `yaml:"cnight_policy_id" envconfig:"DINGO_MIDNIGHT_CNIGHT_POLICY_ID"`
-	CNightAssetName             string `yaml:"cnight_asset_name" envconfig:"DINGO_MIDNIGHT_CNIGHT_ASSET_NAME"`
-	MappingValidatorAddress     string `yaml:"mapping_validator_address" envconfig:"DINGO_MIDNIGHT_MAPPING_VALIDATOR_ADDRESS"`
-	AuthTokenAssetName          string `yaml:"auth_token_asset_name" envconfig:"DINGO_MIDNIGHT_AUTH_TOKEN_ASSET_NAME"`
-	CommitteeCandidateAddress   string `yaml:"committee_candidate_address" envconfig:"DINGO_MIDNIGHT_COMMITTEE_CANDIDATE_ADDRESS"`
-	TechnicalCommitteeAddress   string `yaml:"technical_committee_address" envconfig:"DINGO_MIDNIGHT_TECHNICAL_COMMITTEE_ADDRESS"`
-	TechnicalCommitteePolicyID  string `yaml:"technical_committee_policy_id" envconfig:"DINGO_MIDNIGHT_TECHNICAL_COMMITTEE_POLICY_ID"`
-	CouncilAddress              string `yaml:"council_address" envconfig:"DINGO_MIDNIGHT_COUNCIL_ADDRESS"`
-	CouncilPolicyID             string `yaml:"council_policy_id" envconfig:"DINGO_MIDNIGHT_COUNCIL_POLICY_ID"`
-	PermissionedCandidatePolicy string `yaml:"permissioned_candidate_policy" envconfig:"DINGO_MIDNIGHT_PERMISSIONED_CANDIDATE_POLICY"`
+	CNightPolicyID              string `yaml:"cnight_policy_id"`
+	CNightAssetName             string `yaml:"cnight_asset_name"`
+	MappingValidatorAddress     string `yaml:"mapping_validator_address"`
+	AuthTokenAssetName          string `yaml:"auth_token_asset_name"`
+	CommitteeCandidateAddress   string `yaml:"committee_candidate_address"`
+	TechnicalCommitteeAddress   string `yaml:"technical_committee_address"`
+	TechnicalCommitteePolicyID  string `yaml:"technical_committee_policy_id"`
+	CouncilAddress              string `yaml:"council_address"`
+	CouncilPolicyID             string `yaml:"council_policy_id"`
+	PermissionedCandidatePolicy string `yaml:"permissioned_candidate_policy"`
 }
 
 // DefaultMidnightConfig returns the default Midnight indexer settings.
@@ -448,13 +448,13 @@ type Config struct {
 // https://github.com/input-output-hk/acropolis/tree/master/processes/midnight_indexer
 var midnightNetworkDefaults = map[string]MidnightConfig{
 	"mainnet": {
-		CNightPolicyID:             "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa",
-		CNightAssetName:            "NIGHT",
-		MappingValidatorAddress:    "addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng",
-		TechnicalCommitteeAddress:  "addr_test1wqx3yfmsp82nmtyjj4k86s3l04l6lvwaqh2vk2ygcge7kdsk4xc7j",
-		TechnicalCommitteePolicyID: "0d12277009d53dac92956c7d423f7d7fafb1dd05d4cb2888c233eb36",
-		CouncilAddress:             "addr_test1wqqwkauz0ypglg5e4u780kcp8hzt75u72yg6z7td62gnk0qed0p06",
-		CouncilPolicyID:            "00eb778279028fa299af3c77db013dc4bf539e5111a1796dd2913b3c",
+		CNightPolicyID:              "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa",
+		CNightAssetName:             "4e49474854",
+		MappingValidatorAddress:     "addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng",
+		TechnicalCommitteeAddress:   "addr_test1wqx3yfmsp82nmtyjj4k86s3l04l6lvwaqh2vk2ygcge7kdsk4xc7j",
+		TechnicalCommitteePolicyID:  "0d12277009d53dac92956c7d423f7d7fafb1dd05d4cb2888c233eb36",
+		CouncilAddress:              "addr_test1wqqwkauz0ypglg5e4u780kcp8hzt75u72yg6z7td62gnk0qed0p06",
+		CouncilPolicyID:             "00eb778279028fa299af3c77db013dc4bf539e5111a1796dd2913b3c",
 		PermissionedCandidatePolicy: "f8625f11a58fa5ab5b85502a8fe5c843ece460c9c5f9273be17d3424",
 	},
 	"preview": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,6 +279,33 @@ func DefaultLoggingConfig() LoggingConfig {
 	}
 }
 
+// MidnightConfig holds configuration for the Midnight indexer and its
+// optional gRPC API surface. Indexing is only active when Dingo is running
+// in API storage mode; Port 0 disables only the gRPC server.
+type MidnightConfig struct {
+	Port uint   `yaml:"port" envconfig:"DINGO_MIDNIGHT_PORT"`
+	Host string `yaml:"host" envconfig:"DINGO_MIDNIGHT_HOST"`
+
+	CNightPolicyID              string `yaml:"cnight_policy_id" envconfig:"DINGO_MIDNIGHT_CNIGHT_POLICY_ID"`
+	CNightAssetName             string `yaml:"cnight_asset_name" envconfig:"DINGO_MIDNIGHT_CNIGHT_ASSET_NAME"`
+	MappingValidatorAddress     string `yaml:"mapping_validator_address" envconfig:"DINGO_MIDNIGHT_MAPPING_VALIDATOR_ADDRESS"`
+	AuthTokenAssetName          string `yaml:"auth_token_asset_name" envconfig:"DINGO_MIDNIGHT_AUTH_TOKEN_ASSET_NAME"`
+	CommitteeCandidateAddress   string `yaml:"committee_candidate_address" envconfig:"DINGO_MIDNIGHT_COMMITTEE_CANDIDATE_ADDRESS"`
+	TechnicalCommitteeAddress   string `yaml:"technical_committee_address" envconfig:"DINGO_MIDNIGHT_TECHNICAL_COMMITTEE_ADDRESS"`
+	TechnicalCommitteePolicyID  string `yaml:"technical_committee_policy_id" envconfig:"DINGO_MIDNIGHT_TECHNICAL_COMMITTEE_POLICY_ID"`
+	CouncilAddress              string `yaml:"council_address" envconfig:"DINGO_MIDNIGHT_COUNCIL_ADDRESS"`
+	CouncilPolicyID             string `yaml:"council_policy_id" envconfig:"DINGO_MIDNIGHT_COUNCIL_POLICY_ID"`
+	PermissionedCandidatePolicy string `yaml:"permissioned_candidate_policy" envconfig:"DINGO_MIDNIGHT_PERMISSIONED_CANDIDATE_POLICY"`
+}
+
+// DefaultMidnightConfig returns the default Midnight indexer settings.
+func DefaultMidnightConfig() MidnightConfig {
+	return MidnightConfig{
+		Port: 50051,
+		Host: "0.0.0.0",
+	}
+}
+
 type Config struct {
 	MetadataPlugin       string   `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
 	TlsKeyFilePath       string   `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
@@ -357,6 +384,9 @@ type Config struct {
 	// Logging configuration (output format and level)
 	Logging LoggingConfig `yaml:"logging"`
 
+	// Midnight indexer and gRPC API configuration.
+	Midnight MidnightConfig `yaml:"midnight"`
+
 	// KES (Key Evolving Signature) configuration for block production
 	// SlotsPerKESPeriod is the number of slots in a KES period.
 	// After this many slots, the KES key must be evolved to the next period.
@@ -412,6 +442,68 @@ type Config struct {
 
 	// Mithril snapshot bootstrap configuration
 	Mithril MithrilConfig `yaml:"mithril"`
+}
+
+// midnightNetworkDefaults holds per-network Midnight constants sourced from
+// https://github.com/input-output-hk/acropolis/tree/master/processes/midnight_indexer
+var midnightNetworkDefaults = map[string]MidnightConfig{
+	"mainnet": {
+		CNightPolicyID:             "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa",
+		CNightAssetName:            "NIGHT",
+		MappingValidatorAddress:    "addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng",
+		TechnicalCommitteeAddress:  "addr_test1wqx3yfmsp82nmtyjj4k86s3l04l6lvwaqh2vk2ygcge7kdsk4xc7j",
+		TechnicalCommitteePolicyID: "0d12277009d53dac92956c7d423f7d7fafb1dd05d4cb2888c233eb36",
+		CouncilAddress:             "addr_test1wqqwkauz0ypglg5e4u780kcp8hzt75u72yg6z7td62gnk0qed0p06",
+		CouncilPolicyID:            "00eb778279028fa299af3c77db013dc4bf539e5111a1796dd2913b3c",
+		PermissionedCandidatePolicy: "f8625f11a58fa5ab5b85502a8fe5c843ece460c9c5f9273be17d3424",
+	},
+	"preview": {
+		CNightPolicyID:              "d2dbff622e509dda256fedbd31ef6e9fd98ed49ad91d5c0e07f68af1",
+		MappingValidatorAddress:     "addr_test1wplxjzranravtp574s2wz00md7vz9rzpucu252je68u9a8qzjheng",
+		CommitteeCandidateAddress:   "addr_test1wz5ax0hjvhx2uqef8sqrxnmfywd37hea4truhqxu4yxp9hsvggkfm",
+		TechnicalCommitteeAddress:   "addr_test1wptcy7h9rmkhdnhn3jvm6tuhehcq2hhhzntvn00nq79ph8c44v43j",
+		TechnicalCommitteePolicyID:  "57827ae51eed76cef38c99bd2f97cdf0055ef714d6c9bdf3078a1b9f",
+		CouncilAddress:              "addr_test1wzy47zdsq22pg9l48c5v0f835ljdjzkz47sa5za9cehcejcw28k2d",
+		CouncilPolicyID:             "895f09b002941417f53e28c7a4f1a7e4d90ac2afa1da0ba5c66f8ccb",
+		PermissionedCandidatePolicy: "24dccfce2576ae6fa7149bc485850656ae6faf9f4158891316773a78",
+	},
+}
+
+func applyMidnightNetworkDefaults(cfg *Config) {
+	defaults, ok := midnightNetworkDefaults[cfg.Network]
+	if !ok {
+		return
+	}
+	if cfg.Midnight.CNightPolicyID == "" {
+		cfg.Midnight.CNightPolicyID = defaults.CNightPolicyID
+	}
+	if cfg.Midnight.CNightAssetName == "" {
+		cfg.Midnight.CNightAssetName = defaults.CNightAssetName
+	}
+	if cfg.Midnight.MappingValidatorAddress == "" {
+		cfg.Midnight.MappingValidatorAddress = defaults.MappingValidatorAddress
+	}
+	if cfg.Midnight.AuthTokenAssetName == "" {
+		cfg.Midnight.AuthTokenAssetName = defaults.AuthTokenAssetName
+	}
+	if cfg.Midnight.CommitteeCandidateAddress == "" {
+		cfg.Midnight.CommitteeCandidateAddress = defaults.CommitteeCandidateAddress
+	}
+	if cfg.Midnight.TechnicalCommitteeAddress == "" {
+		cfg.Midnight.TechnicalCommitteeAddress = defaults.TechnicalCommitteeAddress
+	}
+	if cfg.Midnight.TechnicalCommitteePolicyID == "" {
+		cfg.Midnight.TechnicalCommitteePolicyID = defaults.TechnicalCommitteePolicyID
+	}
+	if cfg.Midnight.CouncilAddress == "" {
+		cfg.Midnight.CouncilAddress = defaults.CouncilAddress
+	}
+	if cfg.Midnight.CouncilPolicyID == "" {
+		cfg.Midnight.CouncilPolicyID = defaults.CouncilPolicyID
+	}
+	if cfg.Midnight.PermissionedCandidatePolicy == "" {
+		cfg.Midnight.PermissionedCandidatePolicy = defaults.PermissionedCandidatePolicy
+	}
 }
 
 // MithrilConfig holds configuration for Mithril snapshot bootstrapping.
@@ -552,6 +644,8 @@ var globalConfig = &Config{
 	HistoryExpiry: DefaultHistoryExpiryConfig(),
 	// Logging defaults (text output at info level)
 	Logging: DefaultLoggingConfig(),
+	// Midnight defaults
+	Midnight: DefaultMidnightConfig(),
 	// KES configuration defaults (mainnet values)
 	SlotsPerKESPeriod: 129600, // 1.5 days at 1 second per slot
 	MaxKESEvolutions:  62,     // 2^6 - 2 for KES depth 6
@@ -819,6 +913,7 @@ func LoadConfig(configFile string) (*Config, error) {
 	if err := ValidateNetworkName(globalConfig.Network); err != nil {
 		return nil, err
 	}
+	applyMidnightNetworkDefaults(globalConfig)
 
 	// NOTE: Do not set a default CardanoConfig here. The network flag
 	// can be overridden after LoadConfig returns (see main.go

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -508,6 +508,43 @@ func applyMidnightNetworkDefaults(cfg *Config) {
 	}
 }
 
+func clearMidnightNetworkDefaults(cfg *Config, network string) {
+	defaults, ok := midnightNetworkDefaults[network]
+	if !ok {
+		return
+	}
+	if cfg.Midnight.CNightPolicyID == defaults.CNightPolicyID {
+		cfg.Midnight.CNightPolicyID = ""
+	}
+	if cfg.Midnight.CNightAssetName == defaults.CNightAssetName {
+		cfg.Midnight.CNightAssetName = ""
+	}
+	if cfg.Midnight.MappingValidatorAddress == defaults.MappingValidatorAddress {
+		cfg.Midnight.MappingValidatorAddress = ""
+	}
+	if cfg.Midnight.AuthTokenAssetName == defaults.AuthTokenAssetName {
+		cfg.Midnight.AuthTokenAssetName = ""
+	}
+	if cfg.Midnight.CommitteeCandidateAddress == defaults.CommitteeCandidateAddress {
+		cfg.Midnight.CommitteeCandidateAddress = ""
+	}
+	if cfg.Midnight.TechnicalCommitteeAddress == defaults.TechnicalCommitteeAddress {
+		cfg.Midnight.TechnicalCommitteeAddress = ""
+	}
+	if cfg.Midnight.TechnicalCommitteePolicyID == defaults.TechnicalCommitteePolicyID {
+		cfg.Midnight.TechnicalCommitteePolicyID = ""
+	}
+	if cfg.Midnight.CouncilAddress == defaults.CouncilAddress {
+		cfg.Midnight.CouncilAddress = ""
+	}
+	if cfg.Midnight.CouncilPolicyID == defaults.CouncilPolicyID {
+		cfg.Midnight.CouncilPolicyID = ""
+	}
+	if cfg.Midnight.PermissionedCandidatePolicy == defaults.PermissionedCandidatePolicy {
+		cfg.Midnight.PermissionedCandidatePolicy = ""
+	}
+}
+
 // MithrilConfig holds configuration for Mithril snapshot bootstrapping.
 type MithrilConfig struct {
 	// Enabled controls whether Mithril integration is available.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1006,31 +1006,6 @@ func TestLoad_APIPortsDefault(t *testing.T) {
 	}
 }
 
-func TestLoad_MidnightDefaults(t *testing.T) {
-	resetGlobalConfig()
-	// Use preprod, which has no midnight network defaults, so only
-	// DefaultMidnightConfig values should be present.
-	yamlContent := "network: \"preprod\"\n"
-	tmpDir := t.TempDir()
-	tmpFile := filepath.Join(tmpDir, "dingo.yaml")
-	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	cfg, err := LoadConfig(tmpFile)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	expected := DefaultMidnightConfig()
-	if cfg.Midnight != expected {
-		t.Fatalf(
-			"expected Midnight defaults %+v, got %+v",
-			expected,
-			cfg.Midnight,
-		)
-	}
-}
-
 func TestLoad_MidnightConfig(t *testing.T) {
 	resetGlobalConfig()
 	yamlContent := `

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,39 +227,39 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 
 	// Expected is the updated default values from globalConfig
 	expected := &Config{
-		MempoolCapacity:             1048576,
-		EvictionWatermark:           0.90,
-		RejectionWatermark:          0.95,
-		BindAddr:                    "0.0.0.0",
-		CardanoConfig:               "", // Resolved by consumers using cfg.Network
-		DatabasePath:                ".dingo",
-		SocketPath:                  "dingo.socket",
-		IntersectTip:                false,
-		ValidateHistorical:          false,
-		Network:                     "preview",
-		MetricsPort:                 12798,
-		PrivateBindAddr:             "127.0.0.1",
-		PrivatePort:                 3002,
-		RelayPort:                   3001,
-		UtxorpcPort:                 9090,
-		CORSAllowedOrigins:          []string{"*"},
-		BlockfrostPort:              3000,
-		MeshPort:                    8080,
-		Topology:                    "",
-		TlsCertFilePath:             "",
-		TlsKeyFilePath:              "",
-		BlobPlugin:                  DefaultBlobPlugin,
-		MetadataPlugin:              DefaultMetadataPlugin,
-		RunMode:                     RunModeServe,
-		StartEra:                    StartEraDefault,
-		ImmutableDbPath:             "",
-		ShutdownTimeout:             DefaultShutdownTimeout,
-		LedgerCatchupTimeout:        DefaultLedgerCatchupTimeout,
-		DatabaseWorkers:             5,
-		DatabaseQueueSize:           50,
-		BackfillBatchSize:           100,
-		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
-		HistoryExpiry:               DefaultHistoryExpiryConfig(),
+		MempoolCapacity:      1048576,
+		EvictionWatermark:    0.90,
+		RejectionWatermark:   0.95,
+		BindAddr:             "0.0.0.0",
+		CardanoConfig:        "", // Resolved by consumers using cfg.Network
+		DatabasePath:         ".dingo",
+		SocketPath:           "dingo.socket",
+		IntersectTip:         false,
+		ValidateHistorical:   false,
+		Network:              "preview",
+		MetricsPort:          12798,
+		PrivateBindAddr:      "127.0.0.1",
+		PrivatePort:          3002,
+		RelayPort:            3001,
+		UtxorpcPort:          9090,
+		CORSAllowedOrigins:   []string{"*"},
+		BlockfrostPort:       3000,
+		MeshPort:             8080,
+		Topology:             "",
+		TlsCertFilePath:      "",
+		TlsKeyFilePath:       "",
+		BlobPlugin:           DefaultBlobPlugin,
+		MetadataPlugin:       DefaultMetadataPlugin,
+		RunMode:              RunModeServe,
+		StartEra:             StartEraDefault,
+		ImmutableDbPath:      "",
+		ShutdownTimeout:      DefaultShutdownTimeout,
+		LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
+		DatabaseWorkers:      5,
+		DatabaseQueueSize:    50,
+		BackfillBatchSize:    100,
+		GenesisBootstrap:     DefaultGenesisBootstrapConfig(),
+		HistoryExpiry:        DefaultHistoryExpiryConfig(),
 		Midnight: func() MidnightConfig {
 			m := midnightNetworkDefaults["preview"]
 			m.Port = DefaultMidnightConfig().Port
@@ -1115,6 +1115,44 @@ network: "preview"
 	}
 	if cfg.Midnight.Host != "127.0.0.3" {
 		t.Fatalf("expected env midnight host 127.0.0.3, got %q", cfg.Midnight.Host)
+	}
+}
+
+func TestLoad_MidnightAddressAndPolicyFieldsAreYAMLOnly(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("DINGO_MIDNIGHT_CNIGHT_POLICY_ID", "env-policy")
+	t.Setenv("DINGO_MIDNIGHT_MAPPING_VALIDATOR_ADDRESS", "env-address")
+	yamlContent := `
+midnight:
+  cnight_policy_id: "yaml-policy"
+  mapping_validator_address: "yaml-address"
+network: "preprod"
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-midnight-yaml-only.yaml")
+
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if cfg.Midnight.CNightPolicyID != "yaml-policy" {
+		t.Fatalf(
+			"expected YAML cnight policy to win, got %q",
+			cfg.Midnight.CNightPolicyID,
+		)
+	}
+	if cfg.Midnight.MappingValidatorAddress != "yaml-address" {
+		t.Fatalf(
+			"expected YAML mapping validator address to win, got %q",
+			cfg.Midnight.MappingValidatorAddress,
+		)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func resetGlobalConfig() {
+	midnightYAMLFields = nil
 	globalConfig = &Config{
 		// MempoolCapacity left as the zero sentinel; LoadConfig fills
 		// it in from RunMode after CLI/env/YAML processing.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,6 +62,7 @@ func resetGlobalConfig() {
 		BackfillBatchSize:           100,
 		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
 		HistoryExpiry:               DefaultHistoryExpiryConfig(),
+		Midnight:                    DefaultMidnightConfig(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
@@ -102,6 +103,19 @@ genesisBootstrap:
   enabled: false
   windowSlots: 4321
   promotionMinDiversityGroups: 4
+midnight:
+  port: 50052
+  host: "127.0.0.1"
+  cnight_policy_id: "policy1"
+  cnight_asset_name: "434e49474854"
+  mapping_validator_address: "addr_mapping"
+  auth_token_asset_name: "auth"
+  committee_candidate_address: "addr_candidate"
+  technical_committee_address: "addr_technical"
+  technical_committee_policy_id: "policy_technical"
+  council_address: "addr_council"
+  council_policy_id: "policy_council"
+  permissioned_candidate_policy: "policy_permissioned"
 mithril:
   enabled: false
   aggregatorUrl: "https://mithril.example.net"
@@ -161,7 +175,21 @@ mithril:
 			WindowSlots:                 4321,
 			PromotionMinDiversityGroups: 4,
 		},
-		HistoryExpiry:               DefaultHistoryExpiryConfig(),
+		HistoryExpiry: DefaultHistoryExpiryConfig(),
+		Midnight: MidnightConfig{
+			Port:                        50052,
+			Host:                        "127.0.0.1",
+			CNightPolicyID:              "policy1",
+			CNightAssetName:             "434e49474854",
+			MappingValidatorAddress:     "addr_mapping",
+			AuthTokenAssetName:          "auth",
+			CommitteeCandidateAddress:   "addr_candidate",
+			TechnicalCommitteeAddress:   "addr_technical",
+			TechnicalCommitteePolicyID:  "policy_technical",
+			CouncilAddress:              "addr_council",
+			CouncilPolicyID:             "policy_council",
+			PermissionedCandidatePolicy: "policy_permissioned",
+		},
 		ForgeSyncToleranceSlots:     321,
 		ForgeStaleGapThresholdSlots: 654,
 		Mithril: MithrilConfig{
@@ -232,6 +260,12 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 		BackfillBatchSize:           100,
 		GenesisBootstrap:            DefaultGenesisBootstrapConfig(),
 		HistoryExpiry:               DefaultHistoryExpiryConfig(),
+		Midnight: func() MidnightConfig {
+			m := midnightNetworkDefaults["preview"]
+			m.Port = DefaultMidnightConfig().Port
+			m.Host = DefaultMidnightConfig().Host
+			return m
+		}(),
 		ForgeSyncToleranceSlots:     DefaultForgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: DefaultForgeStaleGapThresholdSlots,
 		Mithril: MithrilConfig{
@@ -968,6 +1002,187 @@ func TestLoad_APIPortsDefault(t *testing.T) {
 		t.Errorf(
 			"expected MeshPort default to be 8080, got %d",
 			cfg.MeshPort,
+		)
+	}
+}
+
+func TestLoad_MidnightDefaults(t *testing.T) {
+	resetGlobalConfig()
+	// Use preprod, which has no midnight network defaults, so only
+	// DefaultMidnightConfig values should be present.
+	yamlContent := "network: \"preprod\"\n"
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := DefaultMidnightConfig()
+	if cfg.Midnight != expected {
+		t.Fatalf(
+			"expected Midnight defaults %+v, got %+v",
+			expected,
+			cfg.Midnight,
+		)
+	}
+}
+
+func TestLoad_MidnightConfig(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+midnight:
+  port: 50060
+  host: "127.0.0.2"
+  cnight_policy_id: "cnight-policy"
+  cnight_asset_name: "434e49474854"
+  mapping_validator_address: "addr_mapping"
+  auth_token_asset_name: "auth-token"
+  committee_candidate_address: "addr_candidate"
+  technical_committee_address: "addr_technical"
+  technical_committee_policy_id: "technical-policy"
+  council_address: "addr_council"
+  council_policy_id: "council-policy"
+  permissioned_candidate_policy: "permissioned-policy"
+network: "preview"
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-midnight.yaml")
+
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	expected := MidnightConfig{
+		Port:                        50060,
+		Host:                        "127.0.0.2",
+		CNightPolicyID:              "cnight-policy",
+		CNightAssetName:             "434e49474854",
+		MappingValidatorAddress:     "addr_mapping",
+		AuthTokenAssetName:          "auth-token",
+		CommitteeCandidateAddress:   "addr_candidate",
+		TechnicalCommitteeAddress:   "addr_technical",
+		TechnicalCommitteePolicyID:  "technical-policy",
+		CouncilAddress:              "addr_council",
+		CouncilPolicyID:             "council-policy",
+		PermissionedCandidatePolicy: "permissioned-policy",
+	}
+	if cfg.Midnight != expected {
+		t.Fatalf(
+			"expected Midnight config %+v, got %+v",
+			expected,
+			cfg.Midnight,
+		)
+	}
+}
+
+func TestLoad_MidnightEnvOverridesYAML(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("DINGO_MIDNIGHT_PORT", "50070")
+	t.Setenv("DINGO_MIDNIGHT_HOST", "127.0.0.3")
+	yamlContent := `
+midnight:
+  port: 50060
+  host: "127.0.0.2"
+network: "preview"
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-midnight-env.yaml")
+
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if cfg.Midnight.Port != 50070 {
+		t.Fatalf("expected env midnight port 50070, got %d", cfg.Midnight.Port)
+	}
+	if cfg.Midnight.Host != "127.0.0.3" {
+		t.Fatalf("expected env midnight host 127.0.0.3, got %q", cfg.Midnight.Host)
+	}
+}
+
+func TestLoad_MidnightNetworkDefaults(t *testing.T) {
+	tests := []struct {
+		network  string
+		expected MidnightConfig
+	}{
+		{
+			network:  "mainnet",
+			expected: midnightNetworkDefaults["mainnet"],
+		},
+		{
+			network:  "preview",
+			expected: midnightNetworkDefaults["preview"],
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.network, func(t *testing.T) {
+			resetGlobalConfig()
+			yamlContent := "network: \"" + tc.network + "\"\n"
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "dingo.yaml")
+			if err := os.WriteFile(tmpFile, []byte(yamlContent), 0644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			cfg, err := LoadConfig(tmpFile)
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			got := cfg.Midnight
+			// Port and Host come from DefaultMidnightConfig, not network defaults.
+			got.Port = 0
+			got.Host = ""
+			want := tc.expected
+			want.Port = 0
+			want.Host = ""
+			if got != want {
+				t.Fatalf("network %q: expected %+v, got %+v", tc.network, want, got)
+			}
+		})
+	}
+}
+
+func TestLoad_MidnightExplicitOverridesNetworkDefault(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+network: "preview"
+midnight:
+  cnight_policy_id: "explicit-override"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Midnight.CNightPolicyID != "explicit-override" {
+		t.Fatalf("expected explicit override, got %q", cfg.Midnight.CNightPolicyID)
+	}
+	// Other fields should still get the network default.
+	if cfg.Midnight.CouncilPolicyID != midnightNetworkDefaults["preview"].CouncilPolicyID {
+		t.Fatalf(
+			"expected network default for CouncilPolicyID, got %q",
+			cfg.Midnight.CouncilPolicyID,
 		)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,16 +106,16 @@ genesisBootstrap:
 midnight:
   port: 50052
   host: "127.0.0.1"
-  cnight_policy_id: "policy1"
-  cnight_asset_name: "434e49474854"
-  mapping_validator_address: "addr_mapping"
-  auth_token_asset_name: "auth"
-  committee_candidate_address: "addr_candidate"
-  technical_committee_address: "addr_technical"
-  technical_committee_policy_id: "policy_technical"
-  council_address: "addr_council"
-  council_policy_id: "policy_council"
-  permissioned_candidate_policy: "policy_permissioned"
+  cnightPolicyId: "policy1"
+  cnightAssetName: "434e49474854"
+  mappingValidatorAddress: "addr_mapping"
+  authTokenAssetName: "auth"
+  committeeCandidateAddress: "addr_candidate"
+  technicalCommitteeAddress: "addr_technical"
+  technicalCommitteePolicyId: "policy_technical"
+  councilAddress: "addr_council"
+  councilPolicyId: "policy_council"
+  permissionedCandidatePolicy: "policy_permissioned"
 mithril:
   enabled: false
   aggregatorUrl: "https://mithril.example.net"
@@ -1012,16 +1012,16 @@ func TestLoad_MidnightConfig(t *testing.T) {
 midnight:
   port: 50060
   host: "127.0.0.2"
-  cnight_policy_id: "cnight-policy"
-  cnight_asset_name: "434e49474854"
-  mapping_validator_address: "addr_mapping"
-  auth_token_asset_name: "auth-token"
-  committee_candidate_address: "addr_candidate"
-  technical_committee_address: "addr_technical"
-  technical_committee_policy_id: "technical-policy"
-  council_address: "addr_council"
-  council_policy_id: "council-policy"
-  permissioned_candidate_policy: "permissioned-policy"
+  cnightPolicyId: "cnight-policy"
+  cnightAssetName: "434e49474854"
+  mappingValidatorAddress: "addr_mapping"
+  authTokenAssetName: "auth-token"
+  committeeCandidateAddress: "addr_candidate"
+  technicalCommitteeAddress: "addr_technical"
+  technicalCommitteePolicyId: "technical-policy"
+  councilAddress: "addr_council"
+  councilPolicyId: "council-policy"
+  permissionedCandidatePolicy: "permissioned-policy"
 network: "preview"
 `
 
@@ -1099,8 +1099,8 @@ func TestLoad_MidnightAddressAndPolicyFieldsAreYAMLOnly(t *testing.T) {
 	t.Setenv("DINGO_MIDNIGHT_MAPPING_VALIDATOR_ADDRESS", "env-address")
 	yamlContent := `
 midnight:
-  cnight_policy_id: "yaml-policy"
-  mapping_validator_address: "yaml-address"
+  cnightPolicyId: "yaml-policy"
+  mappingValidatorAddress: "yaml-address"
 network: "preprod"
 `
 
@@ -1177,7 +1177,7 @@ func TestLoad_MidnightExplicitOverridesNetworkDefault(t *testing.T) {
 	yamlContent := `
 network: "preview"
 midnight:
-  cnight_policy_id: "explicit-override"
+  cnightPolicyId: "explicit-override"
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "dingo.yaml")

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -84,6 +84,8 @@ var flagSpecs = []flagSpec{
 	intFlag("OffchainMetadata.BatchSize", "offchain-metadata-batch-size", "off-chain metadata rows to claim per pass (0 = default)"),
 	int64Flag("OffchainMetadata.MaxBytes", "offchain-metadata-max-bytes", "off-chain metadata max response bytes (0 = default)"),
 	boolFlag("OffchainMetadata.AllowPrivateAddresses", "offchain-metadata-allow-private-addresses", "allow off-chain metadata fetches to private, loopback, and link-local addresses"),
+	uintFlag("Midnight.Port", "midnight-port", "Midnight gRPC port (0 disables gRPC server)"),
+	stringFlag("Midnight.Host", "midnight-host", "", "Midnight gRPC listen address"),
 
 	// Bark
 	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive fallback base URL"),
@@ -187,6 +189,7 @@ func ApplyFlags(cmd *cobra.Command, cfg *Config) error {
 			return err
 		}
 	}
+	applyMidnightNetworkDefaults(cfg)
 	globalConfig = cfg
 	if _, err := LoadTopologyConfig(); err != nil {
 		return fmt.Errorf("loading topology after flags: %w", err)

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -184,10 +184,14 @@ func RegisterFlags(cmd *cobra.Command) {
 // not pass are ignored so YAML and env-var values survive.
 func ApplyFlags(cmd *cobra.Command, cfg *Config) error {
 	flags := cmd.Root().PersistentFlags()
+	previousNetwork := cfg.Network
 	for _, spec := range flagSpecs {
 		if err := spec.apply(flags, cfg); err != nil {
 			return err
 		}
+	}
+	if cfg.Network != previousNetwork {
+		clearMidnightNetworkDefaults(cfg, previousNetwork)
 	}
 	applyMidnightNetworkDefaults(cfg)
 	globalConfig = cfg

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -259,6 +259,91 @@ func TestRegisterFlags_MidnightAddressAndPolicyFieldsAreYAMLOnly(t *testing.T) {
 	}
 }
 
+func TestApplyFlags_NetworkOverrideReappliesMidnightDefaults(t *testing.T) {
+	resetGlobalConfig()
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.Network != "preview" {
+		t.Fatalf("expected initial network preview, got %q", cfg.Network)
+	}
+	if cfg.Midnight.CNightPolicyID != midnightNetworkDefaults["preview"].CNightPolicyID {
+		t.Fatalf(
+			"expected preview Midnight default before flags, got %q",
+			cfg.Midnight.CNightPolicyID,
+		)
+	}
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	if err := cmd.ParseFlags([]string{"--network=mainnet"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := ApplyFlags(cmd, cfg); err != nil {
+		t.Fatalf("failed to apply flags: %v", err)
+	}
+
+	if cfg.Network != "mainnet" {
+		t.Fatalf("expected network mainnet, got %q", cfg.Network)
+	}
+	if cfg.Midnight.CNightPolicyID != midnightNetworkDefaults["mainnet"].CNightPolicyID {
+		t.Fatalf(
+			"expected mainnet Midnight policy default, got %q",
+			cfg.Midnight.CNightPolicyID,
+		)
+	}
+	if cfg.Midnight.CouncilPolicyID != midnightNetworkDefaults["mainnet"].CouncilPolicyID {
+		t.Fatalf(
+			"expected mainnet Midnight council policy default, got %q",
+			cfg.Midnight.CouncilPolicyID,
+		)
+	}
+}
+
+func TestApplyFlags_NetworkOverridePreservesExplicitMidnightYAML(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+network: "preview"
+midnight:
+  cnight_policy_id: "yaml-policy"
+`
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(configFile, []byte(yamlContent), 0o600); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	if err := cmd.ParseFlags([]string{"--network=mainnet"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := ApplyFlags(cmd, cfg); err != nil {
+		t.Fatalf("failed to apply flags: %v", err)
+	}
+
+	if cfg.Midnight.CNightPolicyID != "yaml-policy" {
+		t.Fatalf(
+			"expected explicit Midnight YAML policy to be preserved, got %q",
+			cfg.Midnight.CNightPolicyID,
+		)
+	}
+	if cfg.Midnight.CouncilPolicyID != midnightNetworkDefaults["mainnet"].CouncilPolicyID {
+		t.Fatalf(
+			"expected remaining Midnight defaults to switch to mainnet, got %q",
+			cfg.Midnight.CouncilPolicyID,
+		)
+	}
+}
+
 func TestApplyFlags_NetworkMagicRejectsOverflow(t *testing.T) {
 	resetGlobalConfig()
 

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -32,6 +32,18 @@ func TestRegisterFlags_CoversAllExportedConfigFields(t *testing.T) {
 	RegisterFlags(cmd)
 
 	specFields := map[string]string{}
+	yamlOnlyFields := map[string]struct{}{
+		"Midnight.CNightPolicyID":              {},
+		"Midnight.CNightAssetName":             {},
+		"Midnight.MappingValidatorAddress":     {},
+		"Midnight.AuthTokenAssetName":          {},
+		"Midnight.CommitteeCandidateAddress":   {},
+		"Midnight.TechnicalCommitteeAddress":   {},
+		"Midnight.TechnicalCommitteePolicyID":  {},
+		"Midnight.CouncilAddress":              {},
+		"Midnight.CouncilPolicyID":             {},
+		"Midnight.PermissionedCandidatePolicy": {},
+	}
 	for _, spec := range flagSpecs {
 		if prev, ok := specFields[spec.field]; ok {
 			t.Fatalf(
@@ -52,6 +64,9 @@ func TestRegisterFlags_CoversAllExportedConfigFields(t *testing.T) {
 	collectExportedLeafFields(reflect.TypeFor[Config](), "", leafFields)
 
 	for fieldPath := range leafFields {
+		if _, ok := yamlOnlyFields[fieldPath]; ok {
+			continue
+		}
 		if _, ok := specFields[fieldPath]; !ok {
 			t.Fatalf("config field %q has no flag spec", fieldPath)
 		}
@@ -78,6 +93,8 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		"DINGO_OFFCHAIN_METADATA_IPFS_GATEWAY_URL",
 		"https://env.example/ipfs/",
 	)
+	t.Setenv("DINGO_MIDNIGHT_PORT", "50070")
+	t.Setenv("DINGO_MIDNIGHT_HOST", "127.0.0.3")
 
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")
@@ -125,6 +142,18 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 			cfg.OffchainMetadata.IPFSGatewayURL,
 		)
 	}
+	if cfg.Midnight.Port != 50070 {
+		t.Fatalf(
+			"expected env var to set midnight port=50070, got %d",
+			cfg.Midnight.Port,
+		)
+	}
+	if cfg.Midnight.Host != "127.0.0.3" {
+		t.Fatalf(
+			"expected env var to set midnight host, got %q",
+			cfg.Midnight.Host,
+		)
+	}
 
 	cmd := &cobra.Command{Use: "dingo"}
 	RegisterFlags(cmd)
@@ -136,6 +165,8 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 		"--history-expiry-frequency=30m",
 		"--offchain-metadata-max-bytes=2048",
 		"--offchain-metadata-ipfs-gateway-url=https://flag.example/ipfs/",
+		"--midnight-port=50080",
+		"--midnight-host=127.0.0.4",
 	}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
@@ -188,6 +219,43 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 			"expected flag to override offchain metadata IPFS gateway, got %q",
 			cfg.OffchainMetadata.IPFSGatewayURL,
 		)
+	}
+	if cfg.Midnight.Port != 50080 {
+		t.Fatalf(
+			"expected flag to override midnight port to 50080, got %d",
+			cfg.Midnight.Port,
+		)
+	}
+	if cfg.Midnight.Host != "127.0.0.4" {
+		t.Fatalf(
+			"expected flag to override midnight host, got %q",
+			cfg.Midnight.Host,
+		)
+	}
+}
+
+func TestRegisterFlags_MidnightAddressAndPolicyFieldsAreYAMLOnly(t *testing.T) {
+	resetGlobalConfig()
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+
+	yamlOnlyFlags := []string{
+		"midnight-cnight-policy-id",
+		"midnight-cnight-asset-name",
+		"midnight-mapping-validator-address",
+		"midnight-auth-token-asset-name",
+		"midnight-committee-candidate-address",
+		"midnight-technical-committee-address",
+		"midnight-technical-committee-policy-id",
+		"midnight-council-address",
+		"midnight-council-policy-id",
+		"midnight-permissioned-candidate-policy",
+	}
+	for _, flag := range yamlOnlyFlags {
+		if cmd.PersistentFlags().Lookup(flag) != nil {
+			t.Fatalf("expected --%s to be YAML/env only", flag)
+		}
 	}
 }
 

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -305,10 +305,11 @@ func TestApplyFlags_NetworkOverrideReappliesMidnightDefaults(t *testing.T) {
 
 func TestApplyFlags_NetworkOverridePreservesExplicitMidnightYAML(t *testing.T) {
 	resetGlobalConfig()
+	previewPolicy := midnightNetworkDefaults["preview"].CNightPolicyID
 	yamlContent := `
 network: "preview"
 midnight:
-  cnightPolicyId: "yaml-policy"
+  cnightPolicyId: "` + previewPolicy + `"
 `
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")
@@ -330,7 +331,7 @@ midnight:
 		t.Fatalf("failed to apply flags: %v", err)
 	}
 
-	if cfg.Midnight.CNightPolicyID != "yaml-policy" {
+	if cfg.Midnight.CNightPolicyID != previewPolicy {
 		t.Fatalf(
 			"expected explicit Midnight YAML policy to be preserved, got %q",
 			cfg.Midnight.CNightPolicyID,

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -308,7 +308,7 @@ func TestApplyFlags_NetworkOverridePreservesExplicitMidnightYAML(t *testing.T) {
 	yamlContent := `
 network: "preview"
 midnight:
-  cnight_policy_id: "yaml-policy"
+  cnightPolicyId: "yaml-policy"
 `
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -276,6 +276,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		"blockfrost", storageMode.IsAPI() && cfg.BlockfrostPort > 0,
 		"utxorpc", storageMode.IsAPI() && cfg.UtxorpcPort > 0,
 		"mesh", storageMode.IsAPI() && cfg.MeshPort > 0,
+		"midnight", storageMode.IsAPI(),
+		"midnight_grpc", storageMode.IsAPI() && cfg.Midnight.Port > 0,
 	)
 
 	d, err := dingo.New(
@@ -318,6 +320,20 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 						AllowPrivateAddresses,
 				},
 			),
+			dingo.WithMidnightConfig(dingo.MidnightConfig{
+				Port:                        cfg.Midnight.Port,
+				Host:                        cfg.Midnight.Host,
+				CNightPolicyID:              cfg.Midnight.CNightPolicyID,
+				CNightAssetName:             cfg.Midnight.CNightAssetName,
+				MappingValidatorAddress:     cfg.Midnight.MappingValidatorAddress,
+				AuthTokenAssetName:          cfg.Midnight.AuthTokenAssetName,
+				CommitteeCandidateAddress:   cfg.Midnight.CommitteeCandidateAddress,
+				TechnicalCommitteeAddress:   cfg.Midnight.TechnicalCommitteeAddress,
+				TechnicalCommitteePolicyID:  cfg.Midnight.TechnicalCommitteePolicyID,
+				CouncilAddress:              cfg.Midnight.CouncilAddress,
+				CouncilPolicyID:             cfg.Midnight.CouncilPolicyID,
+				PermissionedCandidatePolicy: cfg.Midnight.PermissionedCandidatePolicy,
+			}),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
 			dingo.WithRunMode(string(cfg.RunMode)),
 			dingo.WithStartEra(string(cfg.StartEra)),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -276,7 +276,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		"blockfrost", storageMode.IsAPI() && cfg.BlockfrostPort > 0,
 		"utxorpc", storageMode.IsAPI() && cfg.UtxorpcPort > 0,
 		"mesh", storageMode.IsAPI() && cfg.MeshPort > 0,
-		"midnight", storageMode.IsAPI(),
+		"midnight_indexing", storageMode.IsAPI(),
 		"midnight_grpc", storageMode.IsAPI() && cfg.Midnight.Port > 0,
 	)
 


### PR DESCRIPTION
1. Added midnight config plumbing for future indexer support
2. Added a new midnight config section with gRPC host/port and Midnight policy/address fields.
3. Added `--midnight-port` and `--midnight-host` CLI flags with default values such as `midnight.port` to `50051` and `midnight.host` to `0.0.0.0`.
4. I have Shipped known midnight defaults from Acropolis for mainnet and preview(https://github.com/input-output-hk/acropolis/tree/master/processes/midnight_indexer).
5. Made changes to keep midnight address/policy fields as YAML only.
6. Made changes to apply midnight network defaults only when the corresponding YAML field is unset, so explicit operator values are preserved.
7. Made changes to pass the parsed midnight configuration through to the root `dingo.Config` for future indexer/server wiring.
8. Updated the `dingo.yaml.example` with this midnight configuration.

Closes #2113 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Midnight config for the indexer and optional gRPC server with YAML/env/CLI parsing and per-network defaults (implements #2113). Applies Acropolis defaults for mainnet/preview when unset and wires the config into runtime; setting port 0 disables gRPC.

- **Bug Fixes**
  - Recompute Midnight defaults when `--network` changes by clearing prior network defaults and reapplying; explicitly set YAML fields are tracked and preserved.

- **Migration**
  - Configure `midnight.port`/`midnight.host` via YAML or `--midnight-port`/`--midnight-host` (env: `DINGO_MIDNIGHT_PORT`, `DINGO_MIDNIGHT_HOST`); set `port: 0` to disable gRPC.
  - Address/policy fields are YAML-only; leave unset to use per-network defaults. Indexing and gRPC run only in API storage mode. Midnight YAML keys use camelCase (e.g., `cnightPolicyId`, `technicalCommitteePolicyId`).

<sup>Written for commit 9a49da9a57cf69e16e86077f9184992ee31d39cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Midnight indexer configuration support with YAML and CLI flag options.
  * Introduced `--midnight-port` and `--midnight-host` CLI flags for server configuration.
  * Network-specific Midnight defaults now applied for mainnet and preview environments.

* **Tests**
  * Added comprehensive test coverage for Midnight configuration loading, environment variable overrides, and network defaults precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->