### PR TITLE
refactor(ledger): decouple connection recycling from validation

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -28,7 +28,6 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	cardano "github.com/blinklabs-io/dingo/config/cardano"
-	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/consensus/praos"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -291,10 +290,10 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 					"hash", hex.EncodeToString(e.Point.Hash),
 				)
 				ls.config.EventBus.Publish(
-					connmanager.ConnectionRecycleRequestedEventType,
+					ConnectionRecycleRequestedEventType,
 					event.NewEvent(
-						connmanager.ConnectionRecycleRequestedEventType,
-						connmanager.ConnectionRecycleRequestedEvent{
+						ConnectionRecycleRequestedEventType,
+						ConnectionRecycleRequestedEvent{
 							ConnectionId: e.ConnectionId,
 							Reason:       "block_header_verification_failure",
 						},
@@ -396,7 +395,7 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 }
 
 func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
-	e, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+	e, ok := evt.Data.(ConnectionClosedEvent)
 	if !ok {
 		return
 	}
@@ -1701,10 +1700,10 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 					"hash", hex.EncodeToString(e.Point.Hash),
 				)
 				ls.config.EventBus.Publish(
-					connmanager.ConnectionRecycleRequestedEventType,
+					ConnectionRecycleRequestedEventType,
 					event.NewEvent(
-						connmanager.ConnectionRecycleRequestedEventType,
-						connmanager.ConnectionRecycleRequestedEvent{
+						ConnectionRecycleRequestedEventType,
+						ConnectionRecycleRequestedEvent{
 							ConnectionId: e.ConnectionId,
 							Reason:       "header_verification_failure",
 						},

--- a/ledger/chainsync_recycle_test.go
+++ b/ledger/chainsync_recycle_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testRecycleConnId() ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+	}
+}
+
+// TestChainsyncHeaderVerificationFailurePublishesRecycleEvent verifies that
+// a header crypto verification failure on the chainsync path publishes a
+// ledger.ConnectionRecycleRequestedEvent with reason "header_verification_failure".
+func TestChainsyncHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	connId := testRecycleConnId()
+
+	recycled := make(chan ConnectionRecycleRequestedEvent, 1)
+	bus.SubscribeFunc(
+		ConnectionRecycleRequestedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(ConnectionRecycleRequestedEvent)
+			if ok {
+				recycled <- e
+			}
+		},
+	)
+
+	ls := &LedgerState{
+		validationEnabled: true,
+		config: LedgerStateConfig{
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EventBus: bus,
+		},
+	}
+
+	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: connId,
+		BlockHeader:  mockHeader{slot: 1000, blockNumber: 100},
+		Point:        ocommon.Point{Slot: 1000},
+	})
+	require.Error(t, err)
+
+	got := testutil.RequireReceive(t, recycled, 2*time.Second, "recycle event not published")
+	assert.Equal(t, connId, got.ConnectionId)
+	assert.Equal(t, "header_verification_failure", got.Reason)
+}
+
+// TestBlockfetchHeaderVerificationFailurePublishesRecycleEvent verifies that
+// a block header crypto verification failure on the blockfetch path publishes a
+// ledger.ConnectionRecycleRequestedEvent with reason "block_header_verification_failure".
+func TestBlockfetchHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	connId := testRecycleConnId()
+
+	recycled := make(chan ConnectionRecycleRequestedEvent, 1)
+	bus.SubscribeFunc(
+		ConnectionRecycleRequestedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(ConnectionRecycleRequestedEvent)
+			if ok {
+				recycled <- e
+			}
+		},
+	)
+
+	ls := &LedgerState{
+		validationEnabled:            true,
+		activeBlockfetchConnId:       connId,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		chain:                        &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EventBus: bus,
+		},
+	}
+
+	ls.handleEventBlockfetch(event.NewEvent(
+		BlockfetchEventType,
+		BlockfetchEvent{
+			ConnectionId: connId,
+			Block:        &mockBabbageBlock{slot: 500},
+			Point:        ocommon.Point{Slot: 500, Hash: []byte("fake-hash")},
+		},
+	))
+
+	got := testutil.RequireReceive(t, recycled, 2*time.Second, "recycle event not published")
+	assert.Equal(t, connId, got.ConnectionId)
+	assert.Equal(t, "block_header_verification_failure", got.Reason)
+}

--- a/ledger/chainsync_recycle_test.go
+++ b/ledger/chainsync_recycle_test.go
@@ -42,6 +42,7 @@ func testRecycleConnId() ouroboros.ConnectionId {
 // ledger.ConnectionRecycleRequestedEvent with reason "header_verification_failure".
 func TestChainsyncHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) {
 	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
 	connId := testRecycleConnId()
 
 	recycled := make(chan ConnectionRecycleRequestedEvent, 1)
@@ -80,6 +81,7 @@ func TestChainsyncHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) {
 // ledger.ConnectionRecycleRequestedEvent with reason "block_header_verification_failure".
 func TestBlockfetchHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) {
 	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
 	connId := testRecycleConnId()
 
 	recycled := make(chan ConnectionRecycleRequestedEvent, 1)

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
-	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -185,8 +184,8 @@ func TestHandleConnectionClosedEventClearsUpstreamTipWhenActiveUnavailable(
 			ls.syncUpstreamTipSlot.Store(114220800)
 
 			ls.handleConnectionClosedEvent(event.NewEvent(
-				connmanager.ConnectionClosedEventType,
-				connmanager.ConnectionClosedEvent{
+				ConnectionClosedEventType,
+				ConnectionClosedEvent{
 					ConnectionId: closedConnId,
 				},
 			))

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -24,13 +24,15 @@ import (
 )
 
 const (
-	BlockfetchEventType          event.EventType = "ledger.blockfetch"
-	BlockEventType               event.EventType = "ledger.block"
-	ChainsyncEventType           event.EventType = "ledger.chainsync"
-	ChainsyncAwaitReplyEventType event.EventType = "ledger.chainsync_await_reply"
-	LedgerErrorEventType         event.EventType = "ledger.error"
-	PoolStateRestoredEventType   event.EventType = "ledger.pool_restored"
-	TransactionEventType         event.EventType = "ledger.tx"
+	BlockfetchEventType                 event.EventType = "ledger.blockfetch"
+	BlockEventType                      event.EventType = "ledger.block"
+	ChainsyncEventType                  event.EventType = "ledger.chainsync"
+	ChainsyncAwaitReplyEventType        event.EventType = "ledger.chainsync_await_reply"
+	ConnectionClosedEventType           event.EventType = "ledger.conn_closed"
+	ConnectionRecycleRequestedEventType event.EventType = "ledger.connection_recycle_requested"
+	LedgerErrorEventType                event.EventType = "ledger.error"
+	PoolStateRestoredEventType          event.EventType = "ledger.pool_restored"
+	TransactionEventType                event.EventType = "ledger.tx"
 )
 
 // It represents the direction a block is applied to the ledger.
@@ -97,4 +99,20 @@ type TransactionEvent struct {
 	BlockNumber uint64
 	TxIndex     uint32
 	Rollback    bool
+}
+
+// ConnectionClosedEvent is emitted by the node layer when a connection closes.
+// Ledger subscribes to this ledger-owned event type instead of connmanager directly,
+// so ledger/ does not need to import connmanager/.
+type ConnectionClosedEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	Error        error
+}
+
+// ConnectionRecycleRequestedEvent is emitted by the ledger when header or block
+// crypto verification fails on a peer connection. Node wiring translates this to
+// a connmanager recycle request, keeping ledger/ free of connmanager/ imports.
+type ConnectionRecycleRequestedEvent struct {
+	ConnectionId ouroboros.ConnectionId
+	Reason       string
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -34,7 +34,6 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/config/cardano"
-	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
@@ -740,7 +739,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 			ls.handleChainSwitchEvent,
 		)
 		ls.connClosedSubID = ls.config.EventBus.SubscribeFunc(
-			connmanager.ConnectionClosedEventType,
+			ConnectionClosedEventType,
 			ls.handleConnectionClosedEvent,
 		)
 	}
@@ -1082,7 +1081,7 @@ func (ls *LedgerState) Close() error {
 			ls.chainSwitchSubID,
 		)
 		ls.config.EventBus.Unsubscribe(
-			connmanager.ConnectionClosedEventType,
+			ConnectionClosedEventType,
 			ls.connClosedSubID,
 		)
 	}

--- a/node.go
+++ b/node.go
@@ -641,6 +641,27 @@ func (n *Node) Run(ctx context.Context) error {
 		connmanager.ConnectionRecycleRequestedEventType,
 		n.connManager.HandleConnectionRecycleRequestedEvent,
 	)
+	// Translate ledger-owned recycle events to connmanager recycle events so
+	// ledger/ does not import connmanager/.
+	n.eventBus.SubscribeFunc(
+		ledger.ConnectionRecycleRequestedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(ledger.ConnectionRecycleRequestedEvent)
+			if !ok {
+				return
+			}
+			n.eventBus.Publish(
+				connmanager.ConnectionRecycleRequestedEventType,
+				event.NewEvent(
+					connmanager.ConnectionRecycleRequestedEventType,
+					connmanager.ConnectionRecycleRequestedEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       e.Reason,
+					},
+				),
+			)
+		},
+	)
 	n.ouroboros.ConnManager = n.connManager
 	// Subscribe ouroboros to chainsync resync events from the
 	// ledger. This replaces the previous ChainsyncResyncFunc
@@ -653,6 +674,27 @@ func (n *Node) Run(ctx context.Context) error {
 	n.eventBus.SubscribeFunc(
 		connmanager.ConnectionClosedEventType,
 		n.ouroboros.HandleConnClosedEvent,
+	)
+	// Translate connmanager connection-closed events to ledger-owned events so
+	// ledger/ does not import connmanager/.
+	n.eventBus.SubscribeFunc(
+		connmanager.ConnectionClosedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+			if !ok {
+				return
+			}
+			n.eventBus.Publish(
+				ledger.ConnectionClosedEventType,
+				event.NewEvent(
+					ledger.ConnectionClosedEventType,
+					ledger.ConnectionClosedEvent{
+						ConnectionId: e.ConnectionId,
+						Error:        e.Error,
+					},
+				),
+			)
+		},
 	)
 	n.eventBus.SubscribeFunc(
 		connmanager.InboundConnectionEventType,

--- a/node.go
+++ b/node.go
@@ -657,6 +657,8 @@ func (n *Node) Run(ctx context.Context) error {
 					connmanager.ConnectionRecycleRequestedEvent{
 						ConnectionId: e.ConnectionId,
 						Reason:       e.Reason,
+						// ConnKey is intentionally omitted: HandleConnectionRecycleRequestedEvent
+						// closes the connection by ConnectionId alone and never reads ConnKey.
 					},
 				),
 			)


### PR DESCRIPTION
Closes #2381 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decoupled connection recycling from validation in `ledger` by introducing ledger-owned recycle and connection-closed events, with translations in `node`. Removes `connmanager` imports from `ledger`, keeps behavior the same, and adds tests for chainsync and blockfetch header verification failures.

- **Refactors**
  - Added `ConnectionClosedEventType` and `ConnectionRecycleRequestedEventType` (and structs) in `ledger/event.go`.
  - Updated `chainsync.go`, `state.go`, and tests to use `ledger` events instead of `connmanager`.
  - In `node`, translate `ledger.ConnectionRecycleRequestedEventType` to `connmanager.ConnectionRecycleRequestedEventType`, and `connmanager.ConnectionClosedEventType` to `ledger.ConnectionClosedEventType`.
  - Added `ledger/chainsync_recycle_test.go` to assert recycle events on chainsync and blockfetch header verification failures.

<sup>Written for commit ed877e786cff76fbaad68dbce12d8ec56b3e33f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability by automatically recycling connections when block header verification failures occur during chain synchronization.

* **Tests**
  * Added comprehensive tests validating automatic connection recycling behavior when header verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->