### PR TITLE
feat(ledger): apply POOLREAP pool-deposit refunds at epoch boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -863,7 +863,7 @@ Key models in `database/models/`:
 | `PoolStakeSnapshot` | Per-pool stake at epoch boundary |
 | `EpochSummary` | Network-wide aggregates per epoch |
 | `BackfillCheckpoint` | Mithril backfill progress tracking |
-| `NetworkState` | Network-wide state tracking (treasury/reserves) |
+| `NetworkState` | Network-wide state tracking (treasury/reserves); updated at the epoch boundary by treasury withdrawals, donations, and unclaimed pool-retirement deposit refunds |
 | `NetworkDonation` | Per-block treasury donations, applied to treasury at the epoch boundary |
 | `GovernanceAction` | Governance proposals |
 | `CommitteeMember` | Constitutional committee members |
@@ -1491,8 +1491,31 @@ slot clock only emits proactive epoch transitions when the ledger tip is within
 the current era's stability window of the upstream tip; while farther behind,
 block processing owns historical epoch transitions during catch-up.
 
+### Epoch Boundary State Transitions
+
+`processEpochRollover` (ledger) applies the Conway EPOCH rule's state changes in
+a fixed order, mirroring `cardano-ledger`'s sequencing:
+
+1. Shelley-style protocol-parameter updates (`ComputeAndApplyPParamUpdates`).
+2. Embedded POOLREAP (`applyPoolRetirements`): refund the deposits of pools
+   whose retirement epoch is the new epoch. Each deposit is credited to the
+   pool's registered, active reward account, or added to the treasury when that
+   account is missing or inactive. Active pool membership itself is query-derived
+   (`GetActivePoolKeyHashesAtSlot`), so no separate pool-state delete is needed;
+   the retirement certificate rows remain for rollback safety.
+3. Governance enactment (`governance.ProcessEpoch`): treasury withdrawals and
+   proposal-deposit returns, which observe the post-POOLREAP treasury.
+4. Treasury donations (`applyEpochDonations`), added after withdrawals.
+
+POOLREAP runs before governance so any deposit that lands in the treasury is
+visible to the withdrawals checked in step 3. The ordering is locked in by
+`TestProcessEpochRollover_OrderingInvariant`.
+
 ### Rollback Support
 
 On chain rollback past an epoch boundary:
 - Delete snapshots for epochs after rollback point
 - Recalculate affected snapshots on forward replay
+- Reward-account credits (`account_reward_delta` journal) and treasury/reserves
+  writes (`network_state`) from governance refunds and POOLREAP deposit refunds
+  are slot-keyed, so they are reverted by slot and re-derived on forward replay

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -697,6 +697,64 @@ ORDER BY r.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_ind
 LIMIT 1;
 ```
 
+### `GetPoolsRetiringAtEpoch`
+
+Pools whose effective retirement takes effect at a given epoch, with the reward
+account and deposit needed to refund their POOLREAP deposit at the epoch
+boundary. A pool is included when, as of the boundary slot, its latest
+retirement certificate names the target epoch and has not been cancelled by a
+later re-registration (same-slot disambiguation uses `block_index` then
+`cert_index`, matching `GetActivePoolKeyHashesAtSlot`). The deposit and reward
+account come from the latest registration. Backends differ only in identifier
+quoting (`"transaction"` on SQLite/Postgres, `` `transaction` `` on MySQL).
+
+```sql
+WITH latest_reg AS (
+  SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+    COALESCE(t.block_index, 0) AS blk_idx,
+    COALESCE(c.cert_index, 0)  AS cert_idx,
+    ROW_NUMBER() OVER (
+      PARTITION BY pr.pool_id
+      ORDER BY pr.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+    ) AS rn
+  FROM pool_registration pr
+  LEFT JOIN certs c ON c.id = pr.certificate_id
+  LEFT JOIN "transaction" t ON t.id = c.transaction_id
+  WHERE pr.added_slot < $boundarySlot
+),
+latest_ret AS (
+  SELECT rt.pool_id, rt.added_slot, rt.epoch,
+    COALESCE(t.block_index, 0) AS blk_idx,
+    COALESCE(c.cert_index, 0)  AS cert_idx,
+    ROW_NUMBER() OVER (
+      PARTITION BY rt.pool_id
+      ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+    ) AS rn
+  FROM pool_retirement rt
+  LEFT JOIN certs c ON c.id = rt.certificate_id
+  LEFT JOIN "transaction" t ON t.id = c.transaction_id
+  WHERE rt.added_slot < $boundarySlot
+)
+SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+FROM pool p
+INNER JOIN latest_reg lr  ON lr.pool_id = p.id  AND lr.rn = 1
+INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+WHERE lrt.epoch = $epoch
+  AND NOT (
+    lrt.added_slot < lr.added_slot
+    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
+    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+  );
+```
+
+The `reward_account` is the 28-byte stake credential stored on the registration,
+used directly to look up the reward account (see `AddAccountReward`). Deposit
+refunds are applied in `applyPoolRetirements` (ledger): the deposit is credited
+to the registered, active reward account, or added to `network_state.treasury`
+when that account is missing or inactive. Both writes are slot-keyed (the
+`account_reward_delta` journal and the boundary `network_state` row), so a
+rollback past the boundary reverts them and re-application is deterministic.
+
 ### `GetGovernanceProposal` and `GetGovernanceVotes`
 
 Governance proposal and votes:

--- a/database/models/pool.go
+++ b/database/models/pool.go
@@ -114,6 +114,15 @@ type PoolRetirement struct {
 	AddedSlot     uint64 `gorm:"index"`
 }
 
+// PoolRetirementRefund identifies a pool retiring at an epoch boundary along
+// with the reward account and deposit needed to refund its POOLREAP deposit.
+// It is a query result, not a persisted table.
+type PoolRetirementRefund struct {
+	PoolKeyHash   []byte
+	RewardAccount []byte
+	DepositAmount types.Uint64
+}
+
 func (PoolRetirement) TableName() string {
 	return "pool_retirement"
 }

--- a/database/plugin/metadata/mysql/poolreap.go
+++ b/database/plugin/metadata/mysql/poolreap.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetPoolsRetiringAtEpoch returns the pools whose effective retirement takes
+// effect at the given epoch as of the boundary slot, together with the reward
+// account and deposit from their active registration. A retirement is
+// "effective" when it is the latest pool certificate (registration or
+// retirement) before the boundary — i.e. it was not cancelled by a later
+// re-registration. Same-slot ordering uses block_index then cert_index, the
+// same disambiguation GetActivePoolKeyHashesAtSlot uses.
+func (d *MetadataStoreMysql) GetPoolsRetiringAtEpoch(
+	epoch uint64,
+	boundarySlot uint64,
+	txn types.Txn,
+) ([]models.PoolRetirementRefund, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetPoolsRetiringAtEpoch: resolve db: %w", err)
+	}
+
+	type row struct {
+		PoolKeyHash   []byte
+		RewardAccount []byte
+		DepositAmount types.Uint64
+	}
+	var rows []row
+
+	query := `
+		WITH latest_reg AS (
+			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+				COALESCE(t.block_index, 0) as blk_idx,
+				COALESCE(c.cert_index, 0) as cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY pr.pool_id
+					ORDER BY pr.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+				) as rn
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN ` + "`transaction`" + ` t ON t.id = c.transaction_id
+			WHERE pr.added_slot < ?
+		),
+		latest_ret AS (
+			SELECT rt.pool_id, rt.added_slot, rt.epoch,
+				COALESCE(t.block_index, 0) as blk_idx,
+				COALESCE(c.cert_index, 0) as cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY rt.pool_id
+					ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+				) as rn
+			FROM pool_retirement rt
+			LEFT JOIN certs c ON c.id = rt.certificate_id
+			LEFT JOIN ` + "`transaction`" + ` t ON t.id = c.transaction_id
+			WHERE rt.added_slot < ?
+		)
+		SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+		FROM pool p
+		INNER JOIN latest_reg lr ON lr.pool_id = p.id AND lr.rn = 1
+		INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+		WHERE lrt.epoch = ?
+			AND NOT (
+				lrt.added_slot < lr.added_slot
+				OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
+				OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+			)`
+
+	if err := db.Raw(
+		query, boundarySlot, boundarySlot, epoch,
+	).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"GetPoolsRetiringAtEpoch: query pools: %w", err,
+		)
+	}
+
+	refunds := make([]models.PoolRetirementRefund, len(rows))
+	for i, r := range rows {
+		refunds[i] = models.PoolRetirementRefund{
+			PoolKeyHash:   r.PoolKeyHash,
+			RewardAccount: r.RewardAccount,
+			DepositAmount: r.DepositAmount,
+		}
+	}
+	return refunds, nil
+}

--- a/database/plugin/metadata/postgres/poolreap.go
+++ b/database/plugin/metadata/postgres/poolreap.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetPoolsRetiringAtEpoch returns the pools whose effective retirement takes
+// effect at the given epoch as of the boundary slot, together with the reward
+// account and deposit from their active registration. A retirement is
+// "effective" when it is the latest pool certificate (registration or
+// retirement) before the boundary — i.e. it was not cancelled by a later
+// re-registration. Same-slot ordering uses block_index then cert_index, the
+// same disambiguation GetActivePoolKeyHashesAtSlot uses.
+func (d *MetadataStorePostgres) GetPoolsRetiringAtEpoch(
+	epoch uint64,
+	boundarySlot uint64,
+	txn types.Txn,
+) ([]models.PoolRetirementRefund, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetPoolsRetiringAtEpoch: resolve db: %w", err)
+	}
+
+	type row struct {
+		PoolKeyHash   []byte
+		RewardAccount []byte
+		DepositAmount types.Uint64
+	}
+	var rows []row
+
+	query := `
+		WITH latest_reg AS (
+			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+				COALESCE(t.block_index, 0) as blk_idx,
+				COALESCE(c.cert_index, 0) as cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY pr.pool_id
+					ORDER BY pr.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+				) as rn
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+			WHERE pr.added_slot < ?
+		),
+		latest_ret AS (
+			SELECT rt.pool_id, rt.added_slot, rt.epoch,
+				COALESCE(t.block_index, 0) as blk_idx,
+				COALESCE(c.cert_index, 0) as cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY rt.pool_id
+					ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+				) as rn
+			FROM pool_retirement rt
+			LEFT JOIN certs c ON c.id = rt.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+			WHERE rt.added_slot < ?
+		)
+		SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+		FROM pool p
+		INNER JOIN latest_reg lr ON lr.pool_id = p.id AND lr.rn = 1
+		INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+		WHERE lrt.epoch = ?
+			AND NOT (
+				lrt.added_slot < lr.added_slot
+				OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
+				OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+			)`
+
+	if err := db.Raw(
+		query, boundarySlot, boundarySlot, epoch,
+	).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"GetPoolsRetiringAtEpoch: query pools: %w", err,
+		)
+	}
+
+	refunds := make([]models.PoolRetirementRefund, len(rows))
+	for i, r := range rows {
+		refunds[i] = models.PoolRetirementRefund{
+			PoolKeyHash:   r.PoolKeyHash,
+			RewardAccount: r.RewardAccount,
+			DepositAmount: r.DepositAmount,
+		}
+	}
+	return refunds, nil
+}

--- a/database/plugin/metadata/sqlite/poolreap.go
+++ b/database/plugin/metadata/sqlite/poolreap.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetPoolsRetiringAtEpoch returns the pools whose effective retirement takes
+// effect at the given epoch as of the boundary slot, together with the reward
+// account and deposit from their active registration. A retirement is
+// "effective" when it is the latest pool certificate (registration or
+// retirement) before the boundary — i.e. it was not cancelled by a later
+// re-registration. Same-slot ordering uses block_index then cert_index, the
+// same disambiguation GetActivePoolKeyHashesAtSlot uses.
+func (d *MetadataStoreSqlite) GetPoolsRetiringAtEpoch(
+	epoch uint64,
+	boundarySlot uint64,
+	txn types.Txn,
+) ([]models.PoolRetirementRefund, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetPoolsRetiringAtEpoch: resolve db: %w", err)
+	}
+
+	type row struct {
+		PoolKeyHash   []byte
+		RewardAccount []byte
+		DepositAmount types.Uint64
+	}
+	var rows []row
+
+	query := `
+		WITH latest_reg AS (
+			SELECT pr.pool_id, pr.added_slot, pr.reward_account, pr.deposit_amount,
+				COALESCE(t.block_index, 0) as blk_idx,
+				COALESCE(c.cert_index, 0) as cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY pr.pool_id
+					ORDER BY pr.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+				) as rn
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+			WHERE pr.added_slot < ?
+		),
+		latest_ret AS (
+			SELECT rt.pool_id, rt.added_slot, rt.epoch,
+				COALESCE(t.block_index, 0) as blk_idx,
+				COALESCE(c.cert_index, 0) as cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY rt.pool_id
+					ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+				) as rn
+			FROM pool_retirement rt
+			LEFT JOIN certs c ON c.id = rt.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+			WHERE rt.added_slot < ?
+		)
+		SELECT p.pool_key_hash, lr.reward_account, lr.deposit_amount
+		FROM pool p
+		INNER JOIN latest_reg lr ON lr.pool_id = p.id AND lr.rn = 1
+		INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+		WHERE lrt.epoch = ?
+			AND NOT (
+				lrt.added_slot < lr.added_slot
+				OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
+				OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+			)`
+
+	if err := db.Raw(
+		query, boundarySlot, boundarySlot, epoch,
+	).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"GetPoolsRetiringAtEpoch: query pools: %w", err,
+		)
+	}
+
+	refunds := make([]models.PoolRetirementRefund, len(rows))
+	for i, r := range rows {
+		refunds[i] = models.PoolRetirementRefund{
+			PoolKeyHash:   r.PoolKeyHash,
+			RewardAccount: r.RewardAccount,
+			DepositAmount: r.DepositAmount,
+		}
+	}
+	return refunds, nil
+}

--- a/database/plugin/metadata/sqlite/poolreap_test.go
+++ b/database/plugin/metadata/sqlite/poolreap_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func poolreapBytes(seed byte) []byte {
+	out := make([]byte, 28)
+	for i := range out {
+		out[i] = seed
+	}
+	return out
+}
+
+// seedRetiringPool creates a pool with a registration and (optionally) a
+// retirement, returning the pool ID.
+func seedRetiringPool(
+	t *testing.T,
+	store *MetadataStoreSqlite,
+	keyHash, rewardAccount []byte,
+	deposit, regSlot uint64,
+) *models.Pool {
+	t.Helper()
+	pool := &models.Pool{PoolKeyHash: keyHash}
+	require.NoError(t, store.DB().Create(pool).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:        pool.ID,
+		PoolKeyHash:   keyHash,
+		RewardAccount: rewardAccount,
+		DepositAmount: types.Uint64(deposit),
+		AddedSlot:     regSlot,
+	}).Error)
+	return pool
+}
+
+// TestGetPoolsRetiringAtEpoch covers: a pool retiring at the target epoch is
+// returned with its reward account and deposit; a pool retiring at a different
+// epoch is excluded; and a pool that re-registers after its retirement (later
+// slot) is excluded because the retirement was cancelled.
+func TestGetPoolsRetiringAtEpoch(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	// Pool A: retires at epoch 5 — expected in results.
+	poolA := seedRetiringPool(t, store, poolreapBytes(0xAA), poolreapBytes(0x11), 500, 100)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID: poolA.ID, PoolKeyHash: poolA.PoolKeyHash, Epoch: 5, AddedSlot: 200,
+	}).Error)
+
+	// Pool B: retires at epoch 6 — excluded (wrong epoch).
+	poolB := seedRetiringPool(t, store, poolreapBytes(0xBB), poolreapBytes(0x22), 500, 100)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID: poolB.ID, PoolKeyHash: poolB.PoolKeyHash, Epoch: 6, AddedSlot: 200,
+	}).Error)
+
+	// Pool C: retires at epoch 5 then re-registers at a later slot — excluded
+	// (retirement cancelled).
+	poolC := seedRetiringPool(t, store, poolreapBytes(0xCC), poolreapBytes(0x33), 500, 100)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID: poolC.ID, PoolKeyHash: poolC.PoolKeyHash, Epoch: 5, AddedSlot: 200,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID: poolC.ID, PoolKeyHash: poolC.PoolKeyHash,
+		RewardAccount: poolreapBytes(0x33), DepositAmount: types.Uint64(500), AddedSlot: 300,
+	}).Error)
+
+	refunds, err := store.GetPoolsRetiringAtEpoch(5, 1000, nil)
+	require.NoError(t, err)
+	require.Len(t, refunds, 1, "only pool A retires at epoch 5")
+	assert.Equal(t, poolA.PoolKeyHash, refunds[0].PoolKeyHash)
+	assert.Equal(t, poolreapBytes(0x11), refunds[0].RewardAccount)
+	assert.Equal(t, uint64(500), uint64(refunds[0].DepositAmount))
+
+	// Retirement certs added at/after the boundary slot are not yet effective.
+	none, err := store.GetPoolsRetiringAtEpoch(5, 150, nil)
+	require.NoError(t, err)
+	assert.Empty(t, none, "retirement cert added at slot 200 is excluded before slot 150")
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -253,6 +253,17 @@ type MetadataStore interface {
 	// for the requested slot. Callers should use errors.Is() to check.
 	GetActivePoolKeyHashesAtSlot(uint64, types.Txn) ([][]byte, error)
 
+	// GetPoolsRetiringAtEpoch returns the pools whose effective retirement
+	// (the latest retirement not cancelled by a later re-registration, as of
+	// the boundary slot) takes effect at the given epoch, along with the
+	// reward account and deposit from their active registration. Used to apply
+	// POOLREAP deposit refunds at the epoch boundary.
+	GetPoolsRetiringAtEpoch(
+		epoch uint64,
+		boundarySlot uint64,
+		txn types.Txn,
+	) ([]models.PoolRetirementRefund, error)
+
 	// GetStakeByPool returns the total delegated stake and delegator count for a pool.
 	// This aggregates all accounts delegated to the pool and sums their UTxO values.
 	GetStakeByPool(

--- a/database/poolreap.go
+++ b/database/poolreap.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "github.com/blinklabs-io/dingo/database/models"
+
+// GetPoolsRetiringAtEpoch returns the pools whose effective retirement takes
+// effect at the given epoch as of the boundary slot, with the reward account
+// and deposit needed to refund their POOLREAP deposit.
+func (d *Database) GetPoolsRetiringAtEpoch(
+	epoch uint64,
+	boundarySlot uint64,
+	txn *Txn,
+) ([]models.PoolRetirementRefund, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetPoolsRetiringAtEpoch(
+		epoch, boundarySlot, txn.Metadata(),
+	)
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3283,15 +3283,19 @@ func (ls *LedgerState) processEpochRollover(
 	//   1. ComputeAndApplyPParamUpdates  — Shelley-style ppuProtocolVersion
 	//      voting path; produces newPParams from on-chain pparam-update
 	//      proposals.
-	//   2. governance.ProcessEpoch       — Conway-style HardForkInitiation /
+	//   2. applyPoolRetirements          — embedded Shelley POOLREAP: refund
+	//      deposits of pools whose retirement epoch is the new epoch. Runs
+	//      before enactment so any deposit landing in the treasury is visible
+	//      to the treasury withdrawals checked in step 3.
+	//   3. governance.ProcessEpoch       — Conway-style HardForkInitiation /
 	//      ParameterChange enactment; may further mutate pparams.
-	//   3. SetPParams                    — persist the enacted pparams.
-	//   4. IsHardForkTransition check    — detect inter-era boundary from
+	//   4. SetPParams                    — persist the enacted pparams.
+	//   5. IsHardForkTransition check    — detect inter-era boundary from
 	//      the now-final pparams.
-	//   5. applyIntraEraHardForkRule     — dispatch the per-major-version
+	//   6. applyIntraEraHardForkRule     — dispatch the per-major-version
 	//      HARDFORK STS rule (e.g. pv3 AVVM removal, pv10 DRep clear).
 	//
-	// Steps 4 and 5 must observe the post-enactment major version. Step 5
+	// Steps 5 and 6 must observe the post-enactment major version. Step 6
 	// must observe the persisted pparams (not just the in-memory ones)
 	// because its body issues SQL within `txn` that may join against
 	// `pparams` rows.
@@ -3311,6 +3315,17 @@ func (ls *LedgerState) processEpochRollover(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("apply pparam updates: %w", err)
+	}
+
+	// Apply the embedded Shelley POOLREAP transition: refund the deposits of
+	// pools whose retirement epoch is the new epoch. Per the Conway EPOCH rule
+	// this runs before governance enactment and treasury accounting, so any
+	// deposit that lands in the treasury (unregistered/inactive reward account)
+	// is visible to the withdrawals checked in governance.ProcessEpoch below.
+	if err := ls.applyPoolRetirements(
+		txn, currentEpoch.EpochId+1, epochStartSlot,
+	); err != nil {
+		return nil, fmt.Errorf("apply pool retirements: %w", err)
 	}
 
 	// Run the CIP-1694 governance tick: enact proposals ratified in the

--- a/ledger/chainsync_ordering_test.go
+++ b/ledger/chainsync_ordering_test.go
@@ -46,10 +46,11 @@ func TestProcessEpochRollover_OrderingInvariant(t *testing.T) {
 	// Ident for unqualified calls).
 	wantOrder := []string{
 		"ComputeAndApplyPParamUpdates", // (1) Shelley-style pparam updates
-		"ProcessEpoch",                 // (2) Conway-style governance enact
-		"SetPParams",                   // (3) persist enacted pparams
-		"isHardForkTransition",         // (4) inter-era boundary detection
-		"applyIntraEraHardForkRule",    // (5) per-major-version HARDFORK rule
+		"applyPoolRetirements",         // (2) embedded POOLREAP deposit refunds
+		"ProcessEpoch",                 // (3) Conway-style governance enact
+		"SetPParams",                   // (4) persist enacted pparams
+		"isHardForkTransition",         // (5) inter-era boundary detection
+		"applyIntraEraHardForkRule",    // (6) per-major-version HARDFORK rule
 	}
 
 	fset := token.NewFileSet()

--- a/ledger/governance/enact.go
+++ b/ledger/governance/enact.go
@@ -259,7 +259,7 @@ func applyTreasuryWithdrawal(
 		if err != nil {
 			return fmt.Errorf("treasury withdrawal reward account: %w", err)
 		}
-		credited, err := creditRegisteredRewardAccount(
+		credited, err := CreditRegisteredRewardAccount(
 			ctx.DB,
 			ctx.Txn,
 			stakeCredential,
@@ -284,7 +284,13 @@ func applyTreasuryWithdrawal(
 	)
 }
 
-func creditRegisteredRewardAccount(
+// CreditRegisteredRewardAccount credits a reward account by its stake
+// credential, returning (true, nil) when the account exists and is active. It
+// returns (false, nil) when no active account matches — the caller is expected
+// to route the amount to the treasury instead. Shared by governance deposit
+// refunds and POOLREAP pool-deposit refunds so both follow identical
+// registered-vs-unclaimed accounting.
+func CreditRegisteredRewardAccount(
 	db *database.Database,
 	txn *database.Txn,
 	stakeCredential []byte,
@@ -301,7 +307,11 @@ func creditRegisteredRewardAccount(
 	return false, fmt.Errorf("credit reward account: %w", err)
 }
 
-func addUnclaimedToTreasury(
+// AddUnclaimedToTreasury adds an unclaimable amount (e.g. a deposit refund
+// whose reward account is missing or inactive) to the treasury, leaving
+// reserves unchanged and writing the updated NetworkState at the given slot.
+// Shared by governance and POOLREAP for consistent treasury accounting.
+func AddUnclaimedToTreasury(
 	db *database.Database,
 	txn *database.Txn,
 	amount uint64,

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -514,7 +514,7 @@ func refundProposalDeposit(
 	if err != nil {
 		return err
 	}
-	credited, err := creditRegisteredRewardAccount(
+	credited, err := CreditRegisteredRewardAccount(
 		db,
 		txn,
 		stakeCredential,
@@ -525,7 +525,7 @@ func refundProposalDeposit(
 		return err
 	}
 	if !credited {
-		if err := addUnclaimedToTreasury(
+		if err := AddUnclaimedToTreasury(
 			db,
 			txn,
 			proposal.Deposit,

--- a/ledger/poolreap.go
+++ b/ledger/poolreap.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/ledger/governance"
+)
+
+// applyPoolRetirements applies the Shelley-era POOLREAP transition at an epoch
+// boundary, embedded in the Conway EPOCH rule before governance enactment and
+// treasury accounting (cardano-ledger Conway Epoch.hs). A pool retirement
+// certificate names the epoch at which the pool retires; its deposit is not
+// refunded in the submitting transaction but at the boundary into that epoch.
+//
+// For each pool whose effective retirement epoch is newEpoch, the deposit
+// recorded with its active registration is refunded to the pool's reward
+// account when that account is registered and active; otherwise the deposit is
+// added to the treasury. This reuses the governance refund helpers so deposit
+// returns follow identical registered-vs-unclaimed accounting.
+//
+// The refunded amount and reward account come from the pool's latest
+// registration. This equals the originally-held deposit whenever the
+// poolDeposit parameter is stable across the pool's lifetime, which is the case
+// on all live networks; a governance change to poolDeposit between a pool's
+// first and last registration is the only scenario where the two could differ.
+//
+// Removal from active pool state is not a separate write: dingo derives the
+// active pool set from the latest registration/retirement certificates
+// (GetActivePoolKeyHashesAtSlot excludes pools once retirement.epoch <=
+// epochAtSlot), so once the boundary into newEpoch is crossed the pool is no
+// longer active. Keeping the certificate rows — rather than deleting pool
+// state — is what makes the transition rollback-safe: the reward-account
+// credits (AccountRewardDelta journal) and treasury writes (NetworkState) are
+// slot-keyed and reverted by the normal rollback path, after which re-applying
+// the boundary re-derives the same refunds.
+func (ls *LedgerState) applyPoolRetirements(
+	txn *database.Txn,
+	newEpoch uint64,
+	boundarySlot uint64,
+) error {
+	refunds, err := ls.db.GetPoolsRetiringAtEpoch(
+		newEpoch, boundarySlot, txn,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"get pools retiring at epoch %d: %w", newEpoch, err,
+		)
+	}
+	if len(refunds) == 0 {
+		return nil
+	}
+	for _, refund := range refunds {
+		deposit := uint64(refund.DepositAmount)
+		// The reward account on a pool registration is the 28-byte stake
+		// credential hash, the same form AddAccountReward looks up.
+		credited, err := governance.CreditRegisteredRewardAccount(
+			ls.db,
+			txn,
+			refund.RewardAccount,
+			deposit,
+			boundarySlot,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"refund pool %x deposit: %w",
+				refund.PoolKeyHash, err,
+			)
+		}
+		if !credited {
+			if err := governance.AddUnclaimedToTreasury(
+				ls.db,
+				txn,
+				deposit,
+				boundarySlot,
+			); err != nil {
+				return fmt.Errorf(
+					"return unclaimed pool %x deposit to treasury: %w",
+					refund.PoolKeyHash, err,
+				)
+			}
+		}
+		ls.config.Logger.Debug(
+			"applied pool retirement deposit refund",
+			"pool", hex.EncodeToString(refund.PoolKeyHash),
+			"epoch", newEpoch,
+			"deposit", deposit,
+			"credited_reward_account", credited,
+			"component", "ledger",
+		)
+	}
+	return nil
+}

--- a/ledger/poolreap_test.go
+++ b/ledger/poolreap_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func reapCred28(seed byte) []byte {
+	out := make([]byte, 28)
+	for i := range out {
+		out[i] = seed
+	}
+	return out
+}
+
+// newPoolreapTestLedger builds a LedgerState backed by an in-memory sqlite
+// metadata store and returns the gorm handle for seeding pool/account rows.
+func newPoolreapTestLedger(
+	t *testing.T,
+) (*LedgerState, *database.Database, *gorm.DB) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	store, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok, "expected sqlite metadata store")
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	return ls, db, store.DB()
+}
+
+// seedRetiringPool inserts a pool with a registration (reward account +
+// deposit) and a retirement at retireEpoch, so GetPoolsRetiringAtEpoch will
+// return it at that epoch boundary.
+func seedRetiringPool(
+	t *testing.T,
+	gdb *gorm.DB,
+	keyHash, rewardAccount []byte,
+	deposit, regSlot, retireEpoch, retireSlot uint64,
+) {
+	t.Helper()
+	pool := &models.Pool{PoolKeyHash: keyHash, RewardAccount: rewardAccount}
+	require.NoError(t, gdb.Create(pool).Error)
+	require.NoError(t, gdb.Create(&models.PoolRegistration{
+		PoolID:        pool.ID,
+		PoolKeyHash:   keyHash,
+		RewardAccount: rewardAccount,
+		DepositAmount: types.Uint64(deposit),
+		AddedSlot:     regSlot,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.PoolRetirement{
+		PoolID:      pool.ID,
+		PoolKeyHash: keyHash,
+		Epoch:       retireEpoch,
+		AddedSlot:   retireSlot,
+	}).Error)
+}
+
+func runApplyPoolRetirements(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	newEpoch, boundarySlot uint64,
+) {
+	t.Helper()
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyPoolRetirements(txn, newEpoch, boundarySlot)
+	}))
+}
+
+// TestApplyPoolRetirements_CreditsRegisteredRewardAccount: a pool retiring at
+// the new epoch with a registered, active reward account has its deposit
+// refunded to that account; the treasury is untouched.
+func TestApplyPoolRetirements_CreditsRegisteredRewardAccount(t *testing.T) {
+	ls, db, gdb := newPoolreapTestLedger(t)
+
+	const (
+		deposit      = uint64(500)
+		newEpoch     = uint64(5)
+		boundarySlot = uint64(1_000)
+	)
+	rewardAccount := reapCred28(0x11)
+	seedRetiringPool(t, gdb, reapCred28(0xAA), rewardAccount, deposit, 100, newEpoch, 200)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: rewardAccount,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+
+	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
+
+	account, err := db.GetAccount(rewardAccount, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, deposit, uint64(account.Reward),
+		"deposit refunded to the registered reward account")
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury),
+		"treasury untouched when deposit is refunded to an account")
+	assert.Equal(t, uint64(50), state.Slot,
+		"no boundary network-state row when nothing goes to treasury")
+}
+
+// TestApplyPoolRetirements_UnregisteredAccountToTreasury: a pool retiring with
+// no reward account, and one with an inactive account, both route their
+// deposit to the treasury.
+func TestApplyPoolRetirements_UnregisteredAccountToTreasury(t *testing.T) {
+	ls, db, gdb := newPoolreapTestLedger(t)
+
+	const (
+		newEpoch     = uint64(5)
+		boundarySlot = uint64(1_000)
+	)
+	// Pool with no reward account at all.
+	seedRetiringPool(t, gdb, reapCred28(0xBB), reapCred28(0x22), 500, 100, newEpoch, 200)
+	// Pool whose reward account exists but is inactive (deregistered). The
+	// Account.Active column defaults to true, so create it then flip the
+	// column the way a deregistration would, rather than relying on the
+	// zero value (which GORM replaces with the default on insert).
+	inactive := reapCred28(0x33)
+	seedRetiringPool(t, gdb, reapCred28(0xCC), inactive, 700, 100, newEpoch, 200)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: inactive,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}))
+	require.NoError(t, gdb.Model(&models.Account{}).
+		Where("staking_key = ?", inactive).
+		Update("active", false).Error)
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+
+	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(2_200), uint64(state.Treasury),
+		"both deposits (500+700) added to treasury")
+	assert.Equal(t, uint64(5_000), uint64(state.Reserves),
+		"reserves untouched by deposit refunds")
+	assert.Equal(t, boundarySlot, state.Slot,
+		"treasury update written at the boundary slot")
+
+	// The inactive account was not credited.
+	account, err := db.GetAccount(inactive, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"inactive account is not credited")
+}
+
+// TestApplyPoolRetirements_WrongEpoch: a pool whose retirement epoch is not the
+// new epoch is left untouched.
+func TestApplyPoolRetirements_WrongEpoch(t *testing.T) {
+	ls, db, gdb := newPoolreapTestLedger(t)
+
+	rewardAccount := reapCred28(0x11)
+	// Retires at epoch 6, but we process the boundary into epoch 5.
+	seedRetiringPool(t, gdb, reapCred28(0xAA), rewardAccount, 500, 100, 6, 200)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: rewardAccount,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+
+	runApplyPoolRetirements(t, ls, db, 5, 1_000)
+
+	account, err := db.GetAccount(rewardAccount, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"pool retiring at a later epoch is not refunded yet")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury))
+}
+
+// TestApplyPoolRetirements_Rollback exercises the acceptance scenario: applying
+// the boundary refunds (one to a reward account, one to the treasury), then
+// rolling back past the boundary restores the prior reward balance and
+// treasury so re-application is deterministic.
+func TestApplyPoolRetirements_Rollback(t *testing.T) {
+	ls, db, gdb := newPoolreapTestLedger(t)
+
+	const (
+		newEpoch     = uint64(5)
+		boundarySlot = uint64(1_000)
+		preBoundary  = uint64(500)
+	)
+	registered := reapCred28(0x11)
+	seedRetiringPool(t, gdb, reapCred28(0xAA), registered, 500, 100, newEpoch, 200)
+	seedRetiringPool(t, gdb, reapCred28(0xBB), reapCred28(0x22), 300, 100, newEpoch, 200)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: registered,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+
+	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
+
+	account, err := db.GetAccount(registered, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(500), uint64(account.Reward),
+		"registered pool deposit refunded")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_300), uint64(state.Treasury),
+		"unregistered pool deposit (300) added to treasury")
+
+	// Roll back past the boundary: reward credit and treasury row are dropped.
+	require.NoError(t, db.DeleteAccountRewardsAfterSlot(preBoundary, nil))
+	require.NoError(t, db.DeleteNetworkStateAfterSlot(preBoundary, nil))
+
+	account, err = db.GetAccount(registered, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"reward credit reverted on rollback")
+	state, err = db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury),
+		"treasury restored to pre-boundary value")
+	assert.Equal(t, uint64(50), state.Slot)
+
+	// Re-applying the boundary reproduces the same effects (determinism).
+	runApplyPoolRetirements(t, ls, db, newEpoch, boundarySlot)
+	account, err = db.GetAccount(registered, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(500), uint64(account.Reward),
+		"re-applied refund is deterministic")
+	state, err = db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_300), uint64(state.Treasury))
+}


### PR DESCRIPTION
## Summary

Implements the Shelley POOLREAP transition embedded in the Conway EPOCH rule. At each epoch boundary, pools whose retirement epoch is the new epoch have their deposit refunded to the pool's registered, active reward account, or added to the treasury when that account is missing or inactive. Runs before governance enactment so treasury-bound deposits are visible to enacted withdrawals, and is rollback-safe and consistent with the treasury-donation handling from #2374.

Closes #2375.

## Changes

- **Query layer** — `GetPoolsRetiringAtEpoch` (sqlite/postgres/mysql): a CTE returning the pools retiring at a given epoch as of the boundary slot, with the reward account and deposit from their active registration. Excludes retirements cancelled by a later re-registration; same-slot disambiguation uses `block_index` then `cert_index`, matching `GetActivePoolKeyHashesAtSlot`. Adds the `Database` wrapper and the `PoolRetirementRefund` query-result model.
- **Ledger transition** — `applyPoolRetirements` runs the embedded POOLREAP before `governance.ProcessEpoch`. It reuses the governance refund helpers (now exported as `CreditRegisteredRewardAccount` / `AddUnclaimedToTreasury`) so pool-deposit returns follow the same registered-vs-unclaimed accounting as proposal-deposit returns and treasury withdrawals.
- **Active pool state** stays query-derived (`GetActivePoolKeyHashesAtSlot` already excludes pools once `retirement.epoch <= epochAtSlot`); retirement certificate rows are kept so the slot-keyed reward (`account_reward_delta`) and `network_state` writes are reverted by the normal rollback path and re-application is deterministic.
- **Ordering invariant** — `TestProcessEpochRollover_OrderingInvariant` updated to pin POOLREAP between Shelley pparam updates and governance enactment; the long-form ordering comment in `processEpochRollover` is updated to match.

## Testing

- New sqlite query test: epoch filter, re-registration cancellation, and boundary-slot filter.
- New ledger tests: deposit credited to a registered/active reward account; unregistered and inactive accounts route to the treasury; a pool retiring at a later epoch is untouched; and a full rollback across the boundary restores the reward balance and treasury with deterministic re-application.
- Full `./ledger/...` and targeted `./database/...` suites pass under `-race`; the conformance suite passes.
- **DevNet**: the epoch-boundary consensus scenario passed — Dingo and `cardano-node` converged at slot 703 / block 284 across the boundary, confirming no consensus regression on the epoch-boundary state-transition path.

## Documentation

- `DATABASE.md`: documents the `GetPoolsRetiringAtEpoch` query and the refund/treasury/rollback behavior.
- `ARCHITECTURE.md`: documents the epoch-boundary EPOCH-rule transition sequence (pparam updates → POOLREAP → governance enactment → donations) and the rollback semantics for reward/treasury writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the Shelley POOLREAP transition at epoch rollover to refund pool deposits for pools retiring in the new epoch. Refunds credit the registered, active reward account or go to the treasury, run before governance enactment, and are rollback-safe with query-derived pool state.

- **New Features**
  - Runs POOLREAP in `processEpochRollover` after pparam updates and before governance enactment; ordering test updated.
  - Adds `GetPoolsRetiringAtEpoch` for `sqlite`, `postgres`, and `mysql` to return retiring pools at the boundary slot, excluding retirements canceled by later re-registrations.
  - Applies refunds via `governance.CreditRegisteredRewardAccount` or `governance.AddUnclaimedToTreasury`; slot-keyed writes ensure deterministic rollback. Documentation updated in `ARCHITECTURE.md` and `DATABASE.md`.

- **Refactors**
  - Exported `governance.CreditRegisteredRewardAccount` and `governance.AddUnclaimedToTreasury` for shared refund and treasury handling.

<sup>Written for commit aa1b1946d51631918ddbd48f1057e30311ac15bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pool retirement deposit refund functionality at epoch boundaries. Deposits from retiring pools are now credited to their registered reward accounts or routed to the treasury if no account is registered.
  
* **Documentation**
  * Updated architecture and database documentation to describe epoch boundary state transitions and pool retirement refund processing with rollback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->