### PR TITLE
fix(ledger): remove and refund orphaned governance actions after enac…

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -225,7 +225,7 @@ erDiagram
 | `registration_drep` | `id`, `drep_credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; unique `(drep_credential, added_slot)`; index `certificate_id` | DRep registration certificate. |
 | `deregistration_drep` | `id`, `drep_credential`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `drep_credential`, `certificate_id`, `added_slot` | DRep deregistration certificate. |
 | `update_drep` | `id`, `credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `credential`, `certificate_id`, `added_slot` | DRep update certificate. |
-| `governance_proposal` | `id`, `tx_hash`, `action_index`, `action_type`, `proposed_epoch`, `expires_epoch`, `parent_tx_hash`, `parent_action_idx`, `enacted_epoch`, `enacted_slot`, `ratified_epoch`, `ratified_slot`, `policy_hash`, `anchor_url`, `anchor_hash`, `deposit`, `return_address`, `gov_action_cbor`, `expired_epoch`, `expired_slot`, `added_slot`, `deleted_slot` | PK `id`; unique `(tx_hash, action_index)`; indexes action type, epochs, lifecycle slots, `added_slot`, `deleted_slot` | Governance action lifecycle. Votes join by `governance_vote.proposal_id`. `gov_action_cbor` stores the era-specific GovAction CBOR used for enactment; replay may rewrite ratified parameter-change actions at an era boundary, such as Conway to Dijkstra, so old databases should be rebuilt from chain data when this encoding changes. |
+| `governance_proposal` | `id`, `tx_hash`, `action_index`, `action_type`, `proposed_epoch`, `expires_epoch`, `parent_tx_hash`, `parent_action_idx`, `enacted_epoch`, `enacted_slot`, `ratified_epoch`, `ratified_slot`, `policy_hash`, `anchor_url`, `anchor_hash`, `deposit`, `return_address`, `gov_action_cbor`, `expired_epoch`, `expired_slot`, `added_slot`, `deleted_slot` | PK `id`; unique `(tx_hash, action_index)`; composite `(parent_tx_hash, parent_action_idx)` (`idx_gov_proposal_parent`); indexes action type, epochs, lifecycle slots, `added_slot`, `deleted_slot` | Governance action lifecycle. Votes join by `governance_vote.proposal_id`. `gov_action_cbor` stores the era-specific GovAction CBOR used for enactment; replay may rewrite ratified parameter-change actions at an era boundary, such as Conway to Dijkstra, so old databases should be rebuilt from chain data when this encoding changes. |
 | `governance_vote` | `id`, `proposal_id`, `voter_type`, `voter_credential`, `vote`, `anchor_url`, `anchor_hash`, `added_slot`, `vote_updated_slot`, `deleted_slot` | PK `id`; unique `(proposal_id, voter_type, voter_credential)`; indexes proposal/voter/lifecycle slots | Vote on a governance proposal. `voter_type`: 0 committee, 1 DRep, 2 SPO. `vote`: 0 No, 1 Yes, 2 Abstain. |
 | `constitution` | `id`, `anchor_url`, `anchor_hash`, `policy_hash`, `added_slot`, `deleted_slot` | PK `id`; unique `added_slot`; index `deleted_slot` | Current or historical constitution references. |
 | `committee_member` | `id`, `cold_cred_hash`, `expires_epoch`, `added_slot`, `deleted_slot` | PK `id`; unique `cold_cred_hash`; indexes `added_slot`, `deleted_slot` | Snapshot-imported committee state. |
@@ -805,6 +805,23 @@ WHERE expires_epoch >= $1
   AND deleted_slot IS NULL
 ORDER BY proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC;
 ```
+
+### `GetChildGovernanceProposals`
+
+Used during the Conway epoch boundary orphan sweep (`removeOrphanedProposals`). Returns all active proposals that reference a given enacted or expired proposal as their parent. The composite index `idx_gov_proposal_parent` on `(parent_tx_hash, parent_action_idx)` makes this lookup O(children) rather than O(table).
+
+```sql
+SELECT *
+FROM governance_proposal
+WHERE parent_tx_hash = $1
+  AND parent_action_idx = $2
+  AND enacted_epoch IS NULL
+  AND expired_epoch IS NULL
+  AND deleted_slot IS NULL
+ORDER BY proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC;
+```
+
+The sweep is transitive (BFS): each orphaned proposal is itself used as a seed to find its own children, continuing until the graph is exhausted. Orphaned proposals are marked with `expired_epoch`/`expired_slot` at the boundary slot so the existing slot-based rollback path in `DeleteGovernanceProposalsAfterSlot` reverts them cleanly.
 
 ### `GetPParams`, `GetPParamUpdates`, and `GetTip`
 

--- a/database/governance.go
+++ b/database/governance.go
@@ -223,6 +223,30 @@ func (d *Database) SetGovernanceProposal(
 	return nil
 }
 
+// GetChildGovernanceProposals returns all active proposals whose parent is
+// the given proposal (parentTxHash + parentActionIdx). Only proposals not
+// yet enacted, expired, or soft-deleted are returned. Used during epoch
+// boundary orphan sweeps.
+func (d *Database) GetChildGovernanceProposals(
+	parentTxHash []byte,
+	parentActionIdx uint32,
+	txn *Txn,
+) ([]*models.GovernanceProposal, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	proposals, err := d.metadata.GetChildGovernanceProposals(
+		parentTxHash, parentActionIdx, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get child governance proposals: %w", err,
+		)
+	}
+	return proposals, nil
+}
+
 // GetGovernanceVotes returns all votes for a governance proposal
 func (d *Database) GetGovernanceVotes(
 	proposalID uint,

--- a/database/models/governance.go
+++ b/database/models/governance.go
@@ -52,14 +52,14 @@ func (Constitution) TableName() string {
 // GovernanceProposal represents a governance action submitted to the chain.
 // Proposals have a lifecycle: submitted -> (ratified) -> (enacted) or expired.
 type GovernanceProposal struct {
-	ID              uint   `gorm:"primarykey"`
-	TxHash          []byte `gorm:"uniqueIndex:idx_proposal_tx_action,priority:1;size:32;not null"`
-	ActionIndex     uint32 `gorm:"uniqueIndex:idx_proposal_tx_action,priority:2;not null"`
-	ActionType      uint8  `gorm:"index;not null"` // GovActionType enum
-	ProposedEpoch   uint64 `gorm:"index;not null"`
-	ExpiresEpoch    uint64 `gorm:"index;not null"`
-	ParentTxHash    []byte `gorm:"size:32"`
-	ParentActionIdx *uint32
+	ID              uint    `gorm:"primarykey"`
+	TxHash          []byte  `gorm:"uniqueIndex:idx_proposal_tx_action,priority:1;size:32;not null"`
+	ActionIndex     uint32  `gorm:"uniqueIndex:idx_proposal_tx_action,priority:2;not null"`
+	ActionType      uint8   `gorm:"index;not null"` // GovActionType enum
+	ProposedEpoch   uint64  `gorm:"index;not null"`
+	ExpiresEpoch    uint64  `gorm:"index;not null"`
+	ParentTxHash    []byte  `gorm:"index:idx_gov_proposal_parent,priority:1;size:32"`
+	ParentActionIdx *uint32 `gorm:"index:idx_gov_proposal_parent,priority:2"`
 	EnactedEpoch    *uint64
 	EnactedSlot     *uint64 `gorm:"index"` // Slot when enacted (for rollback safety)
 	RatifiedEpoch   *uint64

--- a/database/plugin/metadata/mysql/governance.go
+++ b/database/plugin/metadata/mysql/governance.go
@@ -156,6 +156,29 @@ func (d *MetadataStoreMysql) GetLastEnactedGovernanceProposal(
 	return &proposal, nil
 }
 
+// GetChildGovernanceProposals returns all active proposals whose parent is
+// the specified proposal (identified by parentTxHash + parentActionIdx).
+// Only proposals not yet enacted, expired, or soft-deleted are returned.
+func (d *MetadataStoreMysql) GetChildGovernanceProposals(
+	parentTxHash []byte,
+	parentActionIdx uint32,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"parent_tx_hash = ? AND parent_action_idx = ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
+		parentTxHash,
+		parentActionIdx,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
 // govProposalUpsertColumns is the list of columns whose values are
 // always replaced on upsert. Lifecycle columns (enacted_*, ratified_*,
 // expired_*, deleted_slot) and gov_action_cbor are handled separately

--- a/database/plugin/metadata/postgres/governance.go
+++ b/database/plugin/metadata/postgres/governance.go
@@ -156,6 +156,29 @@ func (d *MetadataStorePostgres) GetLastEnactedGovernanceProposal(
 	return &proposal, nil
 }
 
+// GetChildGovernanceProposals returns all active proposals whose parent is
+// the specified proposal (identified by parentTxHash + parentActionIdx).
+// Only proposals not yet enacted, expired, or soft-deleted are returned.
+func (d *MetadataStorePostgres) GetChildGovernanceProposals(
+	parentTxHash []byte,
+	parentActionIdx uint32,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"parent_tx_hash = ? AND parent_action_idx = ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
+		parentTxHash,
+		parentActionIdx,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
 // govProposalUpsertColumns is the list of columns whose values are
 // always replaced on upsert. Lifecycle columns (enacted_*, ratified_*,
 // expired_*, deleted_slot) and gov_action_cbor are handled separately

--- a/database/plugin/metadata/sqlite/governance.go
+++ b/database/plugin/metadata/sqlite/governance.go
@@ -251,6 +251,29 @@ func (d *MetadataStoreSqlite) SetGovernanceProposal(
 	return nil
 }
 
+// GetChildGovernanceProposals returns all active proposals whose parent is
+// the specified proposal (identified by parentTxHash + parentActionIdx).
+// Only proposals not yet enacted, expired, or soft-deleted are returned.
+func (d *MetadataStoreSqlite) GetChildGovernanceProposals(
+	parentTxHash []byte,
+	parentActionIdx uint32,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"parent_tx_hash = ? AND parent_action_idx = ? AND enacted_epoch IS NULL AND expired_epoch IS NULL AND deleted_slot IS NULL",
+		parentTxHash,
+		parentActionIdx,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
 // GetGovernanceVotes retrieves all votes for a governance proposal.
 func (d *MetadataStoreSqlite) GetGovernanceVotes(
 	proposalID uint,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -992,6 +992,17 @@ type MetadataStore interface {
 		types.Txn,
 	) error
 
+	// GetChildGovernanceProposals returns all active proposals whose parent
+	// is the given proposal (matched by txHash + actionIndex). Only returns
+	// proposals not yet enacted, expired, or soft-deleted. Used during
+	// epoch boundary orphan sweeps to find dependents of enacted/expired
+	// proposals and remove them transitively.
+	GetChildGovernanceProposals(
+		parentTxHash []byte,
+		parentActionIdx uint32,
+		txn types.Txn,
+	) ([]*models.GovernanceProposal, error)
+
 	// GetGovernanceVotes retrieves all votes for a governance proposal.
 	GetGovernanceVotes(
 		uint, // proposalID

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -58,6 +58,7 @@ type EpochOutput struct {
 	EnactedCount      int
 	RatifiedCount     int
 	ExpiredCount      int
+	OrphanedCount     int
 	HardForkInitiated bool
 }
 
@@ -185,6 +186,28 @@ func ProcessEpoch(
 		}
 		out.ExpiredCount++
 	}
+
+	// --- ORPHAN REMOVAL --------------------------------------------------
+	// Proposals that reference a just-enacted or just-expired proposal as
+	// their parent are "orphaned": their anchor is gone from the active
+	// pool and can never become a chain root. The spec (Conway EPOCH)
+	// calls this set `removedDueToEnactment` and requires deposits to be
+	// returned (or sent to treasury) for all of them. The sweep is
+	// transitive — orphans of orphans are also removed — so we run a BFS
+	// over the dependency graph seeded with every enacted and expired
+	// proposal from this tick.
+	orphanSeeds := make(
+		[]*models.GovernanceProposal, 0, len(ratified)+len(expired),
+	)
+	orphanSeeds = append(orphanSeeds, ratified...)
+	orphanSeeds = append(orphanSeeds, expired...)
+	orphanCount, err := removeOrphanedProposals(
+		in.DB, in.Txn, orphanSeeds, in.NewEpoch, in.BoundarySlot, in.Logger,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("remove orphaned proposals: %w", err)
+	}
+	out.OrphanedCount = orphanCount
 
 	// Active proposals still in play: not expired past the new epoch,
 	// not enacted, not marked expired, not soft-deleted.
@@ -538,6 +561,78 @@ func refundProposalDeposit(
 		}
 	}
 	return nil
+}
+
+// removeOrphanedProposals performs a BFS over the live proposal dependency
+// graph starting from seeds (enacted + expired proposals from this tick).
+// For each seed it finds active proposals that reference it as their parent.
+// Those dependents are "orphaned" — their anchor is no longer pending and can
+// never become a chain root — so their deposits are refunded and they are
+// marked expired at the boundary slot (using expired_epoch/expired_slot so
+// the existing slot-based rollback path reverts this tick cleanly). The sweep
+// is transitive: each newly-orphaned proposal is itself added to the queue so
+// its dependents are also swept.
+func removeOrphanedProposals(
+	db *database.Database,
+	txn *database.Txn,
+	seeds []*models.GovernanceProposal,
+	epoch uint64,
+	slot uint64,
+	logger *slog.Logger,
+) (int, error) {
+	queue := append(make([]*models.GovernanceProposal, 0, len(seeds)), seeds...)
+	count := 0
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		children, err := db.GetChildGovernanceProposals(
+			parent.TxHash, parent.ActionIndex, txn,
+		)
+		if err != nil {
+			return count, fmt.Errorf(
+				"get children of proposal %s#%d: %w",
+				shortHash(parent.TxHash),
+				parent.ActionIndex,
+				err,
+			)
+		}
+		for _, child := range children {
+			if err := refundProposalDeposit(db, txn, child, slot); err != nil {
+				return count, fmt.Errorf(
+					"refund orphaned proposal deposit %s#%d: %w",
+					shortHash(child.TxHash),
+					child.ActionIndex,
+					err,
+				)
+			}
+			expiredEpoch := epoch
+			expiredSlot := slot
+			child.ExpiredEpoch = &expiredEpoch
+			child.ExpiredSlot = &expiredSlot
+			if err := db.SetGovernanceProposal(child, txn); err != nil {
+				return count, fmt.Errorf(
+					"mark orphaned proposal expired %s#%d: %w",
+					shortHash(child.TxHash),
+					child.ActionIndex,
+					err,
+				)
+			}
+			if logger != nil {
+				logger.Info(
+					"removed orphaned governance proposal",
+					"component", "governance",
+					"tx_hash", shortHash(child.TxHash),
+					"action_index", child.ActionIndex,
+					"parent_tx_hash", shortHash(parent.TxHash),
+					"parent_action_index", parent.ActionIndex,
+					"epoch", epoch,
+				)
+			}
+			queue = append(queue, child)
+			count++
+		}
+	}
+	return count, nil
 }
 
 func rewardAccountStakeCredential(returnAddress []byte) ([]byte, error) {

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -409,3 +409,444 @@ func TestCommitteeNoConfidenceStateUsesEnactedCommitteeRoot(t *testing.T) {
 		ActionType: uint8(lcommon.GovActionTypeNoConfidence),
 	}))
 }
+
+// buildInfoProposal is a test helper that creates a GovernanceProposal with
+// Info action CBOR set, ready for insertion via SetGovernanceProposal.
+func buildInfoProposal(
+	t *testing.T,
+	txHash []byte,
+	actionIndex uint32,
+	expiresEpoch uint64,
+	deposit uint64,
+	returnAddress []byte,
+	addedSlot uint64,
+	parentTxHash []byte,
+	parentActionIdx *uint32,
+	ratifiedEpoch *uint64,
+	ratifiedSlot *uint64,
+) *models.GovernanceProposal {
+	t.Helper()
+	infoCbor, err := cbor.Encode(&lcommon.InfoGovAction{
+		Type: uint(lcommon.GovActionTypeInfo),
+	})
+	require.NoError(t, err)
+	return &models.GovernanceProposal{
+		TxHash:          txHash,
+		ActionIndex:     actionIndex,
+		ActionType:      uint8(lcommon.GovActionTypeInfo),
+		ProposedEpoch:   3,
+		ExpiresEpoch:    expiresEpoch,
+		AnchorURL:       "https://example.invalid/proposal",
+		AnchorHash:      testBytes(32, txHash[0]),
+		Deposit:         deposit,
+		ReturnAddress:   returnAddress,
+		GovActionCbor:   infoCbor,
+		AddedSlot:       addedSlot,
+		ParentTxHash:    parentTxHash,
+		ParentActionIdx: parentActionIdx,
+		RatifiedEpoch:   ratifiedEpoch,
+		RatifiedSlot:    ratifiedSlot,
+	}
+}
+
+// buildRewardAddr returns a reward address byte slice for the given stake
+// credential for use in proposal return-address fields.
+func buildRewardAddr(t *testing.T, stakeCred []byte) []byte {
+	t.Helper()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	b, err := addr.Bytes()
+	require.NoError(t, err)
+	return b
+}
+
+// TestProcessEpochOrphanedChildRemovedAndRefunded verifies that when a
+// ratified proposal is enacted, an active proposal that references it as
+// parent is orphaned: its deposit is returned to the registered reward
+// account and it is marked expired at the boundary slot.
+func TestProcessEpochOrphanedChildRemovedAndRefunded(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	stakeCred := testBytes(28, 50)
+	returnAddr := buildRewardAddr(t, stakeCred)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	parentHash := testBytes(32, 51)
+	childHash := testBytes(32, 52)
+	parentIdx := uint32(0)
+
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, parentHash, 0, 10, 30, returnAddr, 100,
+			nil, nil, &ratifiedEpoch, &ratifiedSlot),
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, childHash, 0, 12, 15, returnAddr, 101,
+			parentHash, &parentIdx, nil, nil),
+		nil,
+	))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(p lcommon.ProtocolParameters, _ any) (lcommon.ProtocolParameters, error) {
+			return p, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	assert.Equal(t, 1, out.EnactedCount)
+	assert.Equal(t, 1, out.OrphanedCount)
+
+	child, err := db.GetGovernanceProposal(childHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, child.ExpiredEpoch)
+	require.NotNil(t, child.ExpiredSlot)
+	assert.Equal(t, uint64(5), *child.ExpiredEpoch)
+	assert.Equal(t, uint64(500), *child.ExpiredSlot)
+
+	// Enacted parent's deposit (30) + orphaned child's deposit (15) = 45.
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(45), uint64(account.Reward))
+}
+
+// TestProcessEpochOrphanedChildMissingReturnAccountGoesToTreasury checks
+// that when an orphaned proposal's return reward account is not registered,
+// its deposit is routed to the treasury rather than credited to the account.
+func TestProcessEpochOrphanedChildMissingReturnAccountGoesToTreasury(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	parentStakeCred := testBytes(28, 53)
+	parentReturnAddr := buildRewardAddr(t, parentStakeCred)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: parentStakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	missingStakeCred := testBytes(28, 54)
+	missingReturnAddr := buildRewardAddr(t, missingStakeCred)
+
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	parentHash := testBytes(32, 55)
+	childHash := testBytes(32, 56)
+	parentIdx := uint32(0)
+
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, parentHash, 0, 10, 30, parentReturnAddr, 100,
+			nil, nil, &ratifiedEpoch, &ratifiedSlot),
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, childHash, 0, 12, 25, missingReturnAddr, 101,
+			parentHash, &parentIdx, nil, nil),
+		nil,
+	))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(p lcommon.ProtocolParameters, _ any) (lcommon.ProtocolParameters, error) {
+			return p, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	assert.Equal(t, 1, out.OrphanedCount)
+
+	child, err := db.GetGovernanceProposal(childHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, child.ExpiredEpoch)
+
+	missing, err := store.GetAccount(missingStakeCred, false, nil)
+	require.NoError(t, err)
+	assert.Nil(t, missing, "orphan refund must not create a reward account")
+
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(125), uint64(state.Treasury))
+}
+
+// TestProcessEpochTransitiveOrphanRemoval verifies that orphan sweeps
+// cascade: when the direct child of an enacted proposal is orphaned, its own
+// children are also swept and refunded in the same tick.
+func TestProcessEpochTransitiveOrphanRemoval(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	stakeCred := testBytes(28, 57)
+	returnAddr := buildRewardAddr(t, stakeCred)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	parentHash := testBytes(32, 58)
+	childHash := testBytes(32, 59)
+	grandchildHash := testBytes(32, 60)
+	parentIdx := uint32(0)
+
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, parentHash, 0, 10, 10, returnAddr, 100,
+			nil, nil, &ratifiedEpoch, &ratifiedSlot),
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, childHash, 0, 12, 20, returnAddr, 101,
+			parentHash, &parentIdx, nil, nil),
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, grandchildHash, 0, 14, 30, returnAddr, 102,
+			childHash, &parentIdx, nil, nil),
+		nil,
+	))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(p lcommon.ProtocolParameters, _ any) (lcommon.ProtocolParameters, error) {
+			return p, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	assert.Equal(t, 1, out.EnactedCount)
+	assert.Equal(t, 2, out.OrphanedCount)
+
+	for _, hash := range [][]byte{childHash, grandchildHash} {
+		p, err := db.GetGovernanceProposal(hash, 0, nil)
+		require.NoError(t, err)
+		require.NotNil(t, p.ExpiredEpoch,
+			"proposal %x should be orphaned", hash)
+		assert.Equal(t, uint64(5), *p.ExpiredEpoch)
+	}
+
+	// Enacted parent's deposit (10) + orphaned child (20) + grandchild (30) = 60.
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(60), uint64(account.Reward))
+}
+
+// TestProcessEpochOrphanExcludedFromActiveProposals verifies that after
+// orphan removal, GetActiveGovernanceProposals no longer returns orphaned
+// proposals (their expired_epoch field filters them out).
+func TestProcessEpochOrphanExcludedFromActiveProposals(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	stakeCred := testBytes(28, 61)
+	returnAddr := buildRewardAddr(t, stakeCred)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	parentHash := testBytes(32, 62)
+	childHash := testBytes(32, 63)
+	parentIdx := uint32(0)
+
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, parentHash, 0, 10, 5, returnAddr, 100,
+			nil, nil, &ratifiedEpoch, &ratifiedSlot),
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, childHash, 0, 12, 5, returnAddr, 101,
+			parentHash, &parentIdx, nil, nil),
+		nil,
+	))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	_, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(p lcommon.ProtocolParameters, _ any) (lcommon.ProtocolParameters, error) {
+			return p, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	active, err := db.GetActiveGovernanceProposals(5, nil)
+	require.NoError(t, err)
+	for _, p := range active {
+		assert.NotEqual(t, childHash, p.TxHash,
+			"orphaned proposal must not appear in active pool")
+	}
+}
+
+// TestProcessEpochOrphanedChildRestoredOnRollback verifies that rolling
+// back to a slot before the boundary slot restores orphaned proposals
+// (clears their expired_epoch/expired_slot) and reverses the reward credit.
+func TestProcessEpochOrphanedChildRestoredOnRollback(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	stakeCred := testBytes(28, 64)
+	returnAddr := buildRewardAddr(t, stakeCred)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	parentHash := testBytes(32, 65)
+	childHash := testBytes(32, 66)
+	parentIdx := uint32(0)
+
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, parentHash, 0, 10, 10, returnAddr, 100,
+			nil, nil, &ratifiedEpoch, &ratifiedSlot),
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, childHash, 0, 12, 20, returnAddr, 101,
+			parentHash, &parentIdx, nil, nil),
+		nil,
+	))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	_, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(p lcommon.ProtocolParameters, _ any) (lcommon.ProtocolParameters, error) {
+			return p, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	child, err := db.GetGovernanceProposal(childHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, child.ExpiredEpoch, "child must be orphaned before rollback")
+
+	require.NoError(t, db.DeleteGovernanceProposalsAfterSlot(499, nil))
+	require.NoError(t, db.DeleteAccountRewardsAfterSlot(499, nil))
+
+	child, err = db.GetGovernanceProposal(childHash, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(t, child.ExpiredEpoch, "orphaned status must be reversed by rollback")
+	assert.Nil(t, child.ExpiredSlot)
+
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"reward credit must be reversed by rollback")
+}
+
+// TestProcessEpochOrphanAfterExpiry verifies that a proposal whose parent
+// expires naturally at this epoch boundary is also orphaned and refunded.
+func TestProcessEpochOrphanAfterExpiry(t *testing.T) {
+	db, store := newTallyTestDB(t)
+
+	stakeCred := testBytes(28, 67)
+	returnAddr := buildRewardAddr(t, stakeCred)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+
+	parentHash := testBytes(32, 68)
+	childHash := testBytes(32, 69)
+	parentIdx := uint32(0)
+
+	// Parent expires at epoch 4 (ExpiresEpoch < NewEpoch=5).
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, parentHash, 0, 4, 10, returnAddr, 100,
+			nil, nil, nil, nil),
+		nil,
+	))
+	// Child expires at epoch 15 but references parent.
+	require.NoError(t, db.SetGovernanceProposal(
+		buildInfoProposal(t, childHash, 0, 15, 20, returnAddr, 101,
+			parentHash, &parentIdx, nil, nil),
+		nil,
+	))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    4,
+		NewEpoch:     5,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(10),
+		UpdateFn: func(p lcommon.ProtocolParameters, _ any) (lcommon.ProtocolParameters, error) {
+			return p, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	assert.Equal(t, 1, out.ExpiredCount)
+	assert.Equal(t, 1, out.OrphanedCount)
+
+	child, err := db.GetGovernanceProposal(childHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, child.ExpiredEpoch)
+	assert.Equal(t, uint64(5), *child.ExpiredEpoch)
+
+	account, err := store.GetAccount(stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(30), uint64(account.Reward))
+}


### PR DESCRIPTION
Closes #2372 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes and refunds orphaned governance proposals at epoch boundaries by sweeping dependents of newly enacted or expired proposals; deposits are returned to the reward account or sent to the treasury. Aligns with Linear #2372 and keeps the active pool consistent and rollback-safe.

- **Bug Fixes**
  - Added transitive orphan sweep in `ProcessEpoch`: BFS over dependents of enacted/expired proposals, refund deposits, and mark them expired at the boundary slot; exposes `OrphanedCount` in `EpochOutput`.
  - Introduced `GetChildGovernanceProposals` on `MetadataStore` with `mysql`, `postgres`, and `sqlite` implementations; added composite index `idx_gov_proposal_parent` for fast parent lookup and documented it in `DATABASE.md`.
  - Ensured refunds go to the proposal’s return reward account when registered, otherwise to the treasury; uses existing refund path for slot-based rollback safety.
  - Added tests for refund to account, treasury fallback, transitive removal, exclusion from the active pool, and rollback restoration.

<sup>Written for commit 2517e4be31778681ffd8074a99e98f480a115e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Governance proposals dependent on parent proposals are now automatically expired and refunded when the parent proposal expires or is ratified, including cascading cleanup of transitively dependent proposals.

* **Tests**
  * Added comprehensive test coverage for dependent proposal cleanup, refund handling, and rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->