### PR TITLE
fix(nilaway): Resolve or suppress current nil-safety findings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,6 +30,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
       - name: nilaway
+        timeout-minutes: 10
         run: |
-          go install go.uber.org/nilaway/cmd/nilaway@latest
+          go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260617183540-d3e528f335e3
           nilaway ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,3 +29,7 @@ jobs:
             ${{ runner.os }}-go-1.26.x-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
+      - name: nilaway
+        run: |
+          go install go.uber.org/nilaway/cmd/nilaway@latest
+          nilaway ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,8 +29,3 @@ jobs:
             ${{ runner.os }}-go-1.26.x-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
-      - name: nilaway
-        timeout-minutes: 10
-        run: |
-          go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260617183540-d3e528f335e3
-          nilaway ./...

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,9 @@ format: mod-tidy ## Format code and tidy go.mod
 golines: ## Enforce 80-character line limit
 	golines -w --ignore-generated --chain-split-dots --max-len=80 --reformat-tags .
 
-lint: ## Run linters (golangci-lint + modernize)
+lint: ## Run linters (golangci-lint + nilaway + modernize)
 	golangci-lint run ./...
+	nilaway ./...
 	modernize ./...
 
 proto: $(PROTOC) ## Generate Go code from protobuf definitions

--- a/api/utxorpc/watch.go
+++ b/api/utxorpc/watch.go
@@ -82,7 +82,7 @@ func watchTxBuildForwardMessages(
 				},
 			},
 		}
-		return nil, []*watch.WatchTxResponse{idle}, nil
+		return applied, []*watch.WatchTxResponse{idle}, nil
 	}
 	return applied, applies, nil
 }

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -169,7 +169,7 @@ func UtxoLedgerToModel(
 		ret.StakingKey = skh.Bytes()
 	}
 	if dh := utxo.Output.DatumHash(); dh != nil {
-		ret.DatumHash = dh.Bytes()
+		ret.DatumHash = append([]byte(nil), dh[:]...)
 	}
 	if multiAsset := utxo.Output.Assets(); multiAsset != nil {
 		ret.Assets = ConvertMultiAssetToModels(multiAsset)

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -87,6 +87,10 @@ func delegationHistoryUnionQuery(
 	parts := make([]string, 0, len(tables))
 	args := make([]any, 0, len(tables)*2)
 	for _, table := range tables {
+		certType, ok := DelegationTableCertType(table)
+		if !ok {
+			continue
+		}
 		parts = append(parts, fmt.Sprintf(
 			`SELECT %[1]s.added_slot AS added_slot,
 				tx.block_index AS block_index,
@@ -104,7 +108,7 @@ func delegationHistoryUnionQuery(
 		))
 		args = append(
 			args,
-			DelegationTableCertTypes(table)[0],
+			certType,
 			stakingKey,
 		)
 	}
@@ -155,27 +159,27 @@ func transactionJoinClause(db *gorm.DB) string {
 	}
 }
 
-func DelegationTableCertTypes(table string) []uint {
+func DelegationTableCertType(table string) (uint, bool) {
 	switch table {
 	case "stake_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeDelegation),
-		}
+		return uint(lcommon.CertificateTypeStakeDelegation), true
 	case "stake_registration_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeRegistrationDelegation),
-		}
+		return uint(lcommon.CertificateTypeStakeRegistrationDelegation), true
 	case "stake_vote_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeVoteDelegation),
-		}
+		return uint(lcommon.CertificateTypeStakeVoteDelegation), true
 	case "stake_vote_registration_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
-		}
+		return uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation), true
 	default:
+		return 0, false
+	}
+}
+
+func DelegationTableCertTypes(table string) []uint {
+	certType, ok := DelegationTableCertType(table)
+	if !ok {
 		return []uint{}
 	}
+	return []uint{certType}
 }
 
 func CountRegistrationHistory(
@@ -209,6 +213,10 @@ func registrationHistoryUnionQuery(
 	parts := make([]string, 0, len(sources))
 	args := make([]any, 0, len(sources)*3)
 	for _, source := range sources {
+		certType, ok := RegistrationTableCertType(source.table)
+		if !ok {
+			continue
+		}
 		parts = append(parts, fmt.Sprintf(
 			`SELECT %[1]s.added_slot AS added_slot,
 				tx.block_index AS block_index,
@@ -227,7 +235,7 @@ func registrationHistoryUnionQuery(
 		args = append(
 			args,
 			source.action,
-			RegistrationTableCertTypes(source.table)[0],
+			certType,
 			stakingKey,
 		)
 	}
@@ -246,41 +254,35 @@ func registrationHistorySources() []registrationHistorySource {
 	}
 }
 
+func RegistrationTableCertType(table string) (uint, bool) {
+	switch table {
+	case "stake_registration":
+		return uint(lcommon.CertificateTypeStakeRegistration), true
+	case "stake_registration_delegation":
+		return uint(lcommon.CertificateTypeStakeRegistrationDelegation), true
+	case "stake_vote_registration_delegation":
+		return uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation), true
+	case "vote_registration_delegation":
+		return uint(lcommon.CertificateTypeVoteRegistrationDelegation), true
+	case "registration":
+		return uint(lcommon.CertificateTypeRegistration), true
+	case "stake_deregistration":
+		return uint(lcommon.CertificateTypeStakeDeregistration), true
+	case "deregistration":
+		return uint(lcommon.CertificateTypeDeregistration), true
+	default:
+		return 0, false
+	}
+}
+
 func RegistrationTableCertTypes(
 	table string,
 ) []uint {
-	switch table {
-	case "stake_registration":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeRegistration),
-		}
-	case "stake_registration_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeRegistrationDelegation),
-		}
-	case "stake_vote_registration_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
-		}
-	case "vote_registration_delegation":
-		return []uint{
-			uint(lcommon.CertificateTypeVoteRegistrationDelegation),
-		}
-	case "registration":
-		return []uint{
-			uint(lcommon.CertificateTypeRegistration),
-		}
-	case "stake_deregistration":
-		return []uint{
-			uint(lcommon.CertificateTypeStakeDeregistration),
-		}
-	case "deregistration":
-		return []uint{
-			uint(lcommon.CertificateTypeDeregistration),
-		}
-	default:
+	certType, ok := RegistrationTableCertType(table)
+	if !ok {
 		return []uint{}
 	}
+	return []uint{certType}
 }
 
 func CompareDelegationRows(

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -174,14 +174,6 @@ func DelegationTableCertType(table string) (uint, bool) {
 	}
 }
 
-func DelegationTableCertTypes(table string) []uint {
-	certType, ok := DelegationTableCertType(table)
-	if !ok {
-		return []uint{}
-	}
-	return []uint{certType}
-}
-
 func CountRegistrationHistory(
 	db *gorm.DB,
 	stakingKey []byte,
@@ -273,16 +265,6 @@ func RegistrationTableCertType(table string) (uint, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func RegistrationTableCertTypes(
-	table string,
-) []uint {
-	certType, ok := RegistrationTableCertType(table)
-	if !ok {
-		return []uint{}
-	}
-	return []uint{certType}
 }
 
 func CompareDelegationRows(

--- a/internal/offchainmetadata/fetcher.go
+++ b/internal/offchainmetadata/fetcher.go
@@ -292,6 +292,10 @@ func (f *Fetcher) fetchOne(
 		f.markFailure(doc, 0, err)
 		return nil
 	}
+	if resp == nil {
+		f.markFailure(doc, 0, errors.New("metadata fetch returned nil response"))
+		return nil
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		f.markFailure(


### PR DESCRIPTION
1. Made changes to account history cert-type lookup helpers to avoid indexing potentially empty slices.
2. Made changes to WatchTx forward-message helpers to return a non-nil empty applied transaction slice for idle blocks.
3. Copied optional datum hashes directly after nil checks in UTxO model conversion.
4. Added a nil HTTP response guard in off-chain metadata fetching.
5. Verified manual for the nilaway failure checks and after making changes - It did not return any errors.

Nilaway CI status:

I attempted to add `nilaway ./...` to the existing `golangci-lint` workflow, as requested if runtime was acceptable. However, the CI job repeatedly failed before Nilaway analysis started. The failure happened during `go install go.uber.org/nilaway/cmd/nilaway...`, with exit `143` / “operation was canceled”. Because the analyzer did not reach `nilaway ./...` and the install step was killed in CI, Nilaway is not currently a good fit for the existing `golangci-lint` workflow. I removed the CI wiring and kept the code fixes verified locally.

Closes #2280 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved Nilaway-reported nil-safety issues across account history, UTxO conversion, tx watching, and metadata fetching, and added `nilaway` to local linting. Removed the CI `nilaway` step. Closes #2280.

- **Bug Fixes**
  - Account history: guard cert-type lookup; skip unknown tables to avoid empty-slice indexing.
  - WatchTx: return non-nil empty `applied` slice for idle blocks.
  - UTxO: copy datum hash bytes after nil check to avoid aliasing.
  - Off-chain metadata: handle nil HTTP responses.

- **Dependencies**
  - Add `nilaway ./...` to `make lint`.
  - Remove `nilaway` from the GitHub lint workflow.

<sup>Written for commit e40262c6b0ebf3f8bcf19e34695e5cc937760271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for failed metadata fetch operations, including better handling of nil HTTP responses
* Enhanced robustness of account history query construction with improved handling of unknown data sources

## Chores
* Integrated nilaway static analysis linting tool into the development pipeline to improve code quality and catch potential nil pointer issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->