### PR TITLE
fix(ledger): apply MIR certificate effects to reward and Ada pot state

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -203,7 +203,7 @@ erDiagram
 | `stake_vote_registration_delegation` | `id`, `staking_key`, `pool_key_hash`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `pool_key_hash`, `drep`, `certificate_id`, `added_slot` | Combined registration, pool delegation, and DRep delegation. |
 | `vote_delegation` | `id`, `staking_key`, `drep`, `drep_type`, `certificate_id`, `added_slot` | PK `id`; indexes `staking_key`, `drep`, `certificate_id`, `added_slot` | DRep-only vote delegation. |
 | `vote_registration_delegation` | `id`, `staking_key`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `staking_key`, `drep`, `certificate_id`, `added_slot` | Combined registration and DRep delegation. |
-| `move_instantaneous_rewards` | `id`, `pot`, `certificate_id`, `added_slot` | PK `id`; indexes `pot`, `certificate_id`, `added_slot` | MIR certificate header. |
+| `move_instantaneous_rewards` | `id`, `pot`, `certificate_id`, `added_slot`, `other_pot` | PK `id`; indexes `pot`, `certificate_id`, `added_slot` | MIR certificate header. `pot`: 0 = Reserves, 1 = Treasury. `other_pot` is non-zero for pot-to-pot transfer certs (no child rows); zero for credential distribution certs (child rows in `move_instantaneous_rewards_reward`). Applied at each epoch boundary by the Shelley INSTANT rule. |
 | `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `amount` | PK `id`; index `mir_id` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. |
 
 ### Pools
@@ -754,6 +754,20 @@ to the registered, active reward account, or added to `network_state.treasury`
 when that account is missing or inactive. Both writes are slot-keyed (the
 `account_reward_delta` journal and the boundary `network_state` row), so a
 rollback past the boundary reverts them and re-application is deterministic.
+
+### `GetMIRCertsInSlotRange`
+
+MIR certificates for the epoch range `[startSlot, endSlot)`, applied at the epoch boundary as the Shelley INSTANT rule. Distribution certs (`other_pot = 0`) credit registered reward accounts and debit the source pot in `network_state`; pot-to-pot transfer certs (`other_pot > 0`) move that amount between treasury and reserves directly.
+
+```sql
+SELECT mir.id, mir.pot, mir.other_pot, mir.added_slot,
+       mirr.credential, mirr.amount
+FROM move_instantaneous_rewards mir
+LEFT JOIN move_instantaneous_rewards_reward mirr ON mirr.mir_id = mir.id
+WHERE mir.added_slot >= $startSlot
+  AND mir.added_slot < $endSlot
+ORDER BY mir.added_slot ASC, mir.id ASC;
+```
 
 ### `GetGovernanceProposal` and `GetGovernanceVotes`
 

--- a/database/mir.go
+++ b/database/mir.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "github.com/blinklabs-io/dingo/database/models"
+
+// GetMIRCertsInSlotRange returns the processed effects of all MIR certificates
+// whose added_slot is >= startSlot and < endSlot. Used to apply the Shelley-era
+// INSTANT rule at each epoch boundary.
+func (d *Database) GetMIRCertsInSlotRange(
+	startSlot, endSlot uint64,
+	txn *Txn,
+) ([]models.MIREffect, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetMIRCertsInSlotRange(startSlot, endSlot, txn.Metadata())
+}

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -33,11 +33,11 @@ type MoveInstantaneousRewards struct {
 // or len(Rewards) > 0 (credential distribution) will be non-empty.
 type MIREffect struct {
 	// Pot is the source Ada pot: 0 = Reserves, 1 = Treasury.
-	Pot      uint
+	Pot uint
 	// OtherPot is the amount for a pot-to-pot transfer (0 when distributing).
 	OtherPot uint64
 	// Rewards lists credential→amount pairs for a distribution MIR.
-	Rewards  []MIRReward
+	Rewards []MIRReward
 }
 
 // MIRReward is a single credential→amount entry from a distribution MIR cert.

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -22,6 +22,28 @@ type MoveInstantaneousRewards struct {
 	CertificateID uint                             `gorm:"index"`
 	ID            uint                             `gorm:"primarykey"`
 	AddedSlot     uint64                           `gorm:"index"`
+	// OtherPot holds the lovelace amount for a pot-to-pot transfer (non-zero
+	// only when the cert moves coins between treasury and reserves rather than
+	// distributing to staking credentials).
+	OtherPot types.Uint64 `gorm:"default:0"`
+}
+
+// MIREffect is the processed form of a single MIR certificate used by the
+// epoch-boundary application logic. One of OtherPot > 0 (pot-to-pot transfer)
+// or len(Rewards) > 0 (credential distribution) will be non-empty.
+type MIREffect struct {
+	// Pot is the source Ada pot: 0 = Reserves, 1 = Treasury.
+	Pot      uint
+	// OtherPot is the amount for a pot-to-pot transfer (0 when distributing).
+	OtherPot uint64
+	// Rewards lists credential→amount pairs for a distribution MIR.
+	Rewards  []MIRReward
+}
+
+// MIRReward is a single credential→amount entry from a distribution MIR cert.
+type MIRReward struct {
+	Credential []byte
+	Amount     uint64
 }
 
 func (MoveInstantaneousRewards) TableName() string {

--- a/database/plugin/metadata/mysql/mir.go
+++ b/database/plugin/metadata/mysql/mir.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetMIRCertsInSlotRange returns the processed effects of all MIR certificates
+// whose added_slot is >= startSlot and < endSlot. Both distribution MIR certs
+// (credential→amount pairs) and pot-to-pot transfer MIR certs are returned.
+func (d *MetadataStoreMysql) GetMIRCertsInSlotRange(
+	startSlot, endSlot uint64,
+	txn types.Txn,
+) ([]models.MIREffect, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetMIRCertsInSlotRange: resolve db: %w", err)
+	}
+
+	var mirs []models.MoveInstantaneousRewards
+	if err := db.Preload("Rewards").
+		Where("added_slot >= ? AND added_slot < ?", startSlot, endSlot).
+		Find(&mirs).Error; err != nil {
+		return nil, fmt.Errorf("GetMIRCertsInSlotRange: query: %w", err)
+	}
+
+	effects := make([]models.MIREffect, len(mirs))
+	for i, m := range mirs {
+		effects[i].Pot = m.Pot
+		effects[i].OtherPot = uint64(m.OtherPot)
+		effects[i].Rewards = make([]models.MIRReward, len(m.Rewards))
+		for j, r := range m.Rewards {
+			effects[i].Rewards[j] = models.MIRReward{
+				Credential: r.Credential,
+				Amount:     uint64(r.Amount),
+			}
+		}
+	}
+	return effects, nil
+}

--- a/database/plugin/metadata/mysql/mir.go
+++ b/database/plugin/metadata/mysql/mir.go
@@ -36,6 +36,7 @@ func (d *MetadataStoreMysql) GetMIRCertsInSlotRange(
 	var mirs []models.MoveInstantaneousRewards
 	if err := db.Preload("Rewards").
 		Where("added_slot >= ? AND added_slot < ?", startSlot, endSlot).
+		Order("added_slot ASC, id ASC").
 		Find(&mirs).Error; err != nil {
 		return nil, fmt.Errorf("GetMIRCertsInSlotRange: query: %w", err)
 	}

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -2160,6 +2160,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 				case *lcommon.MoveInstantaneousRewardsCertificate:
 					tmpMIR := models.MoveInstantaneousRewards{
 						Pot:           c.Reward.Source,
+						OtherPot:      types.Uint64(c.Reward.OtherPot),
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -3486,6 +3487,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 				case *lcommon.MoveInstantaneousRewardsCertificate:
 					tmpMIR := models.MoveInstantaneousRewards{
 						Pot:           c.Reward.Source,
+						OtherPot:      types.Uint64(c.Reward.OtherPot),
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}

--- a/database/plugin/metadata/postgres/mir.go
+++ b/database/plugin/metadata/postgres/mir.go
@@ -36,6 +36,7 @@ func (d *MetadataStorePostgres) GetMIRCertsInSlotRange(
 	var mirs []models.MoveInstantaneousRewards
 	if err := db.Preload("Rewards").
 		Where("added_slot >= ? AND added_slot < ?", startSlot, endSlot).
+		Order("added_slot ASC, id ASC").
 		Find(&mirs).Error; err != nil {
 		return nil, fmt.Errorf("GetMIRCertsInSlotRange: query: %w", err)
 	}

--- a/database/plugin/metadata/postgres/mir.go
+++ b/database/plugin/metadata/postgres/mir.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetMIRCertsInSlotRange returns the processed effects of all MIR certificates
+// whose added_slot is >= startSlot and < endSlot. Both distribution MIR certs
+// (credential→amount pairs) and pot-to-pot transfer MIR certs are returned.
+func (d *MetadataStorePostgres) GetMIRCertsInSlotRange(
+	startSlot, endSlot uint64,
+	txn types.Txn,
+) ([]models.MIREffect, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetMIRCertsInSlotRange: resolve db: %w", err)
+	}
+
+	var mirs []models.MoveInstantaneousRewards
+	if err := db.Preload("Rewards").
+		Where("added_slot >= ? AND added_slot < ?", startSlot, endSlot).
+		Find(&mirs).Error; err != nil {
+		return nil, fmt.Errorf("GetMIRCertsInSlotRange: query: %w", err)
+	}
+
+	effects := make([]models.MIREffect, len(mirs))
+	for i, m := range mirs {
+		effects[i].Pot = m.Pot
+		effects[i].OtherPot = uint64(m.OtherPot)
+		effects[i].Rewards = make([]models.MIRReward, len(m.Rewards))
+		for j, r := range m.Rewards {
+			effects[i].Rewards[j] = models.MIRReward{
+				Credential: r.Credential,
+				Amount:     uint64(r.Amount),
+			}
+		}
+	}
+	return effects, nil
+}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -2158,6 +2158,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 				case *lcommon.MoveInstantaneousRewardsCertificate:
 					tmpMIR := models.MoveInstantaneousRewards{
 						Pot:           c.Reward.Source,
+						OtherPot:      types.Uint64(c.Reward.OtherPot),
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -3494,6 +3495,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 				case *lcommon.MoveInstantaneousRewardsCertificate:
 					tmpMIR := models.MoveInstantaneousRewards{
 						Pot:           c.Reward.Source,
+						OtherPot:      types.Uint64(c.Reward.OtherPot),
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}

--- a/database/plugin/metadata/sqlite/mir.go
+++ b/database/plugin/metadata/sqlite/mir.go
@@ -36,6 +36,7 @@ func (d *MetadataStoreSqlite) GetMIRCertsInSlotRange(
 	var mirs []models.MoveInstantaneousRewards
 	if err := db.Preload("Rewards").
 		Where("added_slot >= ? AND added_slot < ?", startSlot, endSlot).
+		Order("added_slot ASC, id ASC").
 		Find(&mirs).Error; err != nil {
 		return nil, fmt.Errorf("GetMIRCertsInSlotRange: query: %w", err)
 	}

--- a/database/plugin/metadata/sqlite/mir.go
+++ b/database/plugin/metadata/sqlite/mir.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// GetMIRCertsInSlotRange returns the processed effects of all MIR certificates
+// whose added_slot is >= startSlot and < endSlot. Both distribution MIR certs
+// (credential→amount pairs) and pot-to-pot transfer MIR certs are returned.
+func (d *MetadataStoreSqlite) GetMIRCertsInSlotRange(
+	startSlot, endSlot uint64,
+	txn types.Txn,
+) ([]models.MIREffect, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf("GetMIRCertsInSlotRange: resolve db: %w", err)
+	}
+
+	var mirs []models.MoveInstantaneousRewards
+	if err := db.Preload("Rewards").
+		Where("added_slot >= ? AND added_slot < ?", startSlot, endSlot).
+		Find(&mirs).Error; err != nil {
+		return nil, fmt.Errorf("GetMIRCertsInSlotRange: query: %w", err)
+	}
+
+	effects := make([]models.MIREffect, len(mirs))
+	for i, m := range mirs {
+		effects[i].Pot = m.Pot
+		effects[i].OtherPot = uint64(m.OtherPot)
+		effects[i].Rewards = make([]models.MIRReward, len(m.Rewards))
+		for j, r := range m.Rewards {
+			effects[i].Rewards[j] = models.MIRReward{
+				Credential: r.Credential,
+				Amount:     uint64(r.Amount),
+			}
+		}
+	}
+	return effects, nil
+}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -2333,6 +2333,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				case *lcommon.MoveInstantaneousRewardsCertificate:
 					tmpMIR := models.MoveInstantaneousRewards{
 						Pot:           c.Reward.Source,
+						OtherPot:      types.Uint64(c.Reward.OtherPot),
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}
@@ -3760,6 +3761,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				case *lcommon.MoveInstantaneousRewardsCertificate:
 					tmpMIR := models.MoveInstantaneousRewards{
 						Pot:           c.Reward.Source,
+						OtherPot:      types.Uint64(c.Reward.OtherPot),
 						AddedSlot:     point.Slot,
 						CertificateID: certIDMap[i],
 					}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -264,6 +264,14 @@ type MetadataStore interface {
 		txn types.Txn,
 	) ([]models.PoolRetirementRefund, error)
 
+	// GetMIRCertsInSlotRange returns the processed effects of all MIR
+	// certificates whose added_slot is >= startSlot and < endSlot. Used to
+	// apply the Shelley-era INSTANT rule at each epoch boundary.
+	GetMIRCertsInSlotRange(
+		startSlot, endSlot uint64,
+		txn types.Txn,
+	) ([]models.MIREffect, error)
+
 	// GetStakeByPool returns the total delegated stake and delegator count for a pool.
 	// This aggregates all accounts delegated to the pool and sums their UTxO values.
 	GetStakeByPool(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3287,12 +3287,15 @@ func (ls *LedgerState) processEpochRollover(
 	//      deposits of pools whose retirement epoch is the new epoch. Runs
 	//      before enactment so any deposit landing in the treasury is visible
 	//      to the treasury withdrawals checked in step 3.
-	//   3. governance.ProcessEpoch       — Conway-style HardForkInitiation /
+	//   3. applyMIRCerts                 — Shelley-era INSTANT rule: apply
+	//      Move Instantaneous Rewards certificates accumulated during the
+	//      ended epoch. No-op for Conway+ epochs (no MIR certs exist).
+	//   4. governance.ProcessEpoch       — Conway-style HardForkInitiation /
 	//      ParameterChange enactment; may further mutate pparams.
-	//   4. SetPParams                    — persist the enacted pparams.
-	//   5. IsHardForkTransition check    — detect inter-era boundary from
+	//   5. SetPParams                    — persist the enacted pparams.
+	//   6. IsHardForkTransition check    — detect inter-era boundary from
 	//      the now-final pparams.
-	//   6. applyIntraEraHardForkRule     — dispatch the per-major-version
+	//   7. applyIntraEraHardForkRule     — dispatch the per-major-version
 	//      HARDFORK STS rule (e.g. pv3 AVVM removal, pv10 DRep clear).
 	//
 	// Steps 5 and 6 must observe the post-enactment major version. Step 6
@@ -3326,6 +3329,17 @@ func (ls *LedgerState) processEpochRollover(
 		txn, currentEpoch.EpochId+1, epochStartSlot,
 	); err != nil {
 		return nil, fmt.Errorf("apply pool retirements: %w", err)
+	}
+
+	// Apply the Shelley-era INSTANT rule: credit MIR certificate rewards
+	// accumulated during the ended epoch to registered reward accounts, and
+	// apply pot-to-pot transfers between treasury and reserves. This is a
+	// no-op for Conway+ epochs because MIR certs are not valid there and no
+	// DB rows exist for those slots.
+	if err := ls.applyMIRCerts(
+		txn, currentEpoch.StartSlot, epochStartSlot,
+	); err != nil {
+		return nil, fmt.Errorf("apply MIR certs: %w", err)
 	}
 
 	// Run the CIP-1694 governance tick: enact proposals ratified in the

--- a/ledger/chainsync_ordering_test.go
+++ b/ledger/chainsync_ordering_test.go
@@ -47,10 +47,11 @@ func TestProcessEpochRollover_OrderingInvariant(t *testing.T) {
 	wantOrder := []string{
 		"ComputeAndApplyPParamUpdates", // (1) Shelley-style pparam updates
 		"applyPoolRetirements",         // (2) embedded POOLREAP deposit refunds
-		"ProcessEpoch",                 // (3) Conway-style governance enact
-		"SetPParams",                   // (4) persist enacted pparams
-		"isHardForkTransition",         // (5) inter-era boundary detection
-		"applyIntraEraHardForkRule",    // (6) per-major-version HARDFORK rule
+		"applyMIRCerts",                // (3) Shelley-era INSTANT rule
+		"ProcessEpoch",                 // (4) Conway-style governance enact
+		"SetPParams",                   // (5) persist enacted pparams
+		"isHardForkTransition",         // (6) inter-era boundary detection
+		"applyIntraEraHardForkRule",    // (7) per-major-version HARDFORK rule
 	}
 
 	fset := token.NewFileSet()

--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/ledger/governance"
+)
+
+const (
+	// mirPotReserves is the on-chain CBOR encoding of the reserves pot (0).
+	mirPotReserves = uint(0)
+	// mirPotTreasury is the on-chain CBOR encoding of the treasury pot (1).
+	mirPotTreasury = uint(1)
+)
+
+// applyMIRCerts applies all MIR (Move Instantaneous Rewards) certificate
+// effects accumulated during the ended epoch at the given boundary slot. This
+// implements the Shelley-era INSTANT rule, which runs at each epoch boundary
+// for Shelley through Babbage. In Conway and later, MIR certificates are not
+// valid, so no records exist in the DB and this function returns immediately.
+//
+// epochStartSlot is the first slot of the ended epoch (inclusive lower bound);
+// boundarySlot is the first slot of the new epoch (exclusive upper bound).
+// MIR certs with added_slot in [epochStartSlot, boundarySlot) are applied.
+//
+// Distribution MIR (credential→amount map):
+//   - Registered, active reward accounts are credited from the source pot.
+//   - Credentials without a registered account are silently skipped — unlike
+//     POOLREAP, there is no fallback routing to the treasury.
+//   - The source pot is debited only for amounts actually credited.
+//
+// Pot-to-pot transfer MIR (OtherPot > 0):
+//   - Source=0 (Reserves) moves OtherPot lovelace from reserves to treasury.
+//   - Source=1 (Treasury) moves OtherPot lovelace from treasury to reserves.
+func (ls *LedgerState) applyMIRCerts(
+	txn *database.Txn,
+	epochStartSlot uint64,
+	boundarySlot uint64,
+) error {
+	effects, err := ls.db.GetMIRCertsInSlotRange(
+		epochStartSlot, boundarySlot, txn,
+	)
+	if err != nil {
+		return fmt.Errorf("get MIR certs: %w", err)
+	}
+	if len(effects) == 0 {
+		return nil
+	}
+	for _, effect := range effects {
+		if effect.OtherPot > 0 {
+			if err := ls.applyMIRPotTransfer(
+				txn, effect.Pot, effect.OtherPot, boundarySlot,
+			); err != nil {
+				return err
+			}
+			continue
+		}
+		var totalDebited uint64
+		for _, reward := range effect.Rewards {
+			credited, err := governance.CreditRegisteredRewardAccount(
+				ls.db, txn, reward.Credential, reward.Amount, boundarySlot,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"apply MIR reward to %x: %w",
+					reward.Credential, err,
+				)
+			}
+			if credited {
+				totalDebited += reward.Amount
+				ls.config.Logger.Debug(
+					"applied MIR reward",
+					"credential", hex.EncodeToString(reward.Credential),
+					"amount", reward.Amount,
+					"pot", effect.Pot,
+					"component", "ledger",
+				)
+			}
+		}
+		if totalDebited > 0 {
+			if err := ls.debitMIRPot(
+				txn, effect.Pot, totalDebited, boundarySlot,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// debitMIRPot decrements the given Ada pot by amount, writing an updated
+// NetworkState at boundarySlot. Shared by distribution MIR processing; the
+// pot-to-pot path uses applyMIRPotTransfer which does a combined read-modify.
+func (ls *LedgerState) debitMIRPot(
+	txn *database.Txn,
+	pot uint,
+	amount uint64,
+	slot uint64,
+) error {
+	treasury, reserves, err := ls.readNetworkState(txn)
+	if err != nil {
+		return fmt.Errorf("debit MIR pot: %w", err)
+	}
+	switch pot {
+	case mirPotReserves:
+		if amount > reserves {
+			return fmt.Errorf(
+				"MIR would underflow reserves: pot has %d, distributing %d",
+				reserves, amount,
+			)
+		}
+		reserves -= amount
+	case mirPotTreasury:
+		if amount > treasury {
+			return fmt.Errorf(
+				"MIR would underflow treasury: pot has %d, distributing %d",
+				treasury, amount,
+			)
+		}
+		treasury -= amount
+	default:
+		return fmt.Errorf("unknown MIR pot %d", pot)
+	}
+	return ls.db.Metadata().SetNetworkState(treasury, reserves, slot, txn.Metadata())
+}
+
+// applyMIRPotTransfer moves amount lovelace between the two Ada pots at slot.
+// Source=0 (Reserves) transfers from reserves to treasury.
+// Source=1 (Treasury) transfers from treasury to reserves.
+func (ls *LedgerState) applyMIRPotTransfer(
+	txn *database.Txn,
+	sourcePot uint,
+	amount uint64,
+	slot uint64,
+) error {
+	treasury, reserves, err := ls.readNetworkState(txn)
+	if err != nil {
+		return fmt.Errorf("apply MIR pot transfer: %w", err)
+	}
+	switch sourcePot {
+	case mirPotReserves:
+		if amount > reserves {
+			return fmt.Errorf(
+				"MIR pot transfer would underflow reserves: pot has %d, moving %d",
+				reserves, amount,
+			)
+		}
+		reserves -= amount
+		treasury += amount
+	case mirPotTreasury:
+		if amount > treasury {
+			return fmt.Errorf(
+				"MIR pot transfer would underflow treasury: pot has %d, moving %d",
+				treasury, amount,
+			)
+		}
+		treasury -= amount
+		reserves += amount
+	default:
+		return fmt.Errorf("unknown MIR source pot %d", sourcePot)
+	}
+	ls.config.Logger.Debug(
+		"applied MIR pot-to-pot transfer",
+		"source_pot", sourcePot,
+		"amount", amount,
+		"component", "ledger",
+	)
+	return ls.db.Metadata().SetNetworkState(treasury, reserves, slot, txn.Metadata())
+}
+
+// readNetworkState returns the current treasury and reserves from the most
+// recent NetworkState row, returning (0, 0) if none exists yet.
+func (ls *LedgerState) readNetworkState(txn *database.Txn) (treasury, reserves uint64, err error) {
+	state, err := ls.db.Metadata().GetNetworkState(txn.Metadata())
+	if err != nil {
+		return 0, 0, fmt.Errorf("get network state: %w", err)
+	}
+	if state != nil {
+		treasury = uint64(state.Treasury)
+		reserves = uint64(state.Reserves)
+	}
+	return treasury, reserves, nil
+}

--- a/ledger/mir_test.go
+++ b/ledger/mir_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// mirCred28 builds a 28-byte stake credential filled with seed.
+func mirCred28(seed byte) []byte {
+	out := make([]byte, 28)
+	for i := range out {
+		out[i] = seed
+	}
+	return out
+}
+
+// newMIRTestLedger reuses the poolreap helper (same DB setup).
+func newMIRTestLedger(t *testing.T) (*LedgerState, *database.Database, *gorm.DB) {
+	t.Helper()
+	return newPoolreapTestLedger(t)
+}
+
+// seedMIRDistribution inserts a MoveInstantaneousRewards row with one or more
+// credential→amount reward rows, simulating a distribution MIR cert.
+func seedMIRDistribution(
+	t *testing.T,
+	gdb *gorm.DB,
+	pot uint,
+	addedSlot uint64,
+	rewards []models.MoveInstantaneousRewardsReward,
+) {
+	t.Helper()
+	mir := &models.MoveInstantaneousRewards{
+		Pot:       pot,
+		AddedSlot: addedSlot,
+	}
+	require.NoError(t, gdb.Create(mir).Error)
+	for i := range rewards {
+		rewards[i].MIRID = mir.ID
+		require.NoError(t, gdb.Create(&rewards[i]).Error)
+	}
+}
+
+// seedMIRPotTransfer inserts a MoveInstantaneousRewards row representing a
+// pot-to-pot transfer (OtherPot > 0, no credential rows).
+func seedMIRPotTransfer(
+	t *testing.T,
+	gdb *gorm.DB,
+	sourcePot uint,
+	amount uint64,
+	addedSlot uint64,
+) {
+	t.Helper()
+	mir := &models.MoveInstantaneousRewards{
+		Pot:       sourcePot,
+		OtherPot:  types.Uint64(amount),
+		AddedSlot: addedSlot,
+	}
+	require.NoError(t, gdb.Create(mir).Error)
+}
+
+func runApplyMIRCerts(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	epochStartSlot, boundarySlot uint64,
+) {
+	t.Helper()
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyMIRCerts(txn, epochStartSlot, boundarySlot)
+	}))
+}
+
+// TestApplyMIRCerts_DistributionFromReserves_RegisteredAccount verifies that a
+// MIR cert distributing from reserves credits the registered reward account and
+// debits reserves.
+func TestApplyMIRCerts_DistributionFromReserves_RegisteredAccount(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const (
+		epochStartSlot = uint64(0)
+		boundarySlot   = uint64(1_000)
+		mirAmount      = uint64(750)
+	)
+	cred := mirCred28(0x11)
+	seedMIRDistribution(t, gdb, mirPotReserves, 500, []models.MoveInstantaneousRewardsReward{
+		{Credential: cred, Amount: types.Uint64(mirAmount)},
+	})
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Reward:     0,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 10_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
+
+	account, err := db.GetAccount(cred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, mirAmount, uint64(account.Reward),
+		"registered account should receive MIR reward")
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(9_250), uint64(state.Reserves),
+		"reserves debited by MIR amount")
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury),
+		"treasury untouched for reserves distribution")
+}
+
+// TestApplyMIRCerts_DistributionFromTreasury_RegisteredAccount verifies a MIR
+// cert from the treasury credits the account and debits the treasury.
+func TestApplyMIRCerts_DistributionFromTreasury_RegisteredAccount(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const (
+		epochStartSlot = uint64(0)
+		boundarySlot   = uint64(1_000)
+		mirAmount      = uint64(200)
+	)
+	cred := mirCred28(0x22)
+	seedMIRDistribution(t, gdb, mirPotTreasury, 500, []models.MoveInstantaneousRewardsReward{
+		{Credential: cred, Amount: types.Uint64(mirAmount)},
+	})
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Reward:     0,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(5_000, 8_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
+
+	account, err := db.GetAccount(cred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, mirAmount, uint64(account.Reward),
+		"registered account should receive MIR reward from treasury")
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(4_800), uint64(state.Treasury),
+		"treasury debited by MIR amount")
+	assert.Equal(t, uint64(8_000), uint64(state.Reserves),
+		"reserves untouched for treasury distribution")
+}
+
+// TestApplyMIRCerts_DistributionUnregisteredAccount verifies that an
+// unregistered credential is silently skipped — no pot debit, no error.
+func TestApplyMIRCerts_DistributionUnregisteredAccount(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x33) // no Account row seeded
+	seedMIRDistribution(t, gdb, mirPotReserves, 500, []models.MoveInstantaneousRewardsReward{
+		{Credential: cred, Amount: types.Uint64(400)},
+	})
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(5_000), uint64(state.Reserves),
+		"unregistered credential — reserves untouched")
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury),
+		"unregistered credential — treasury untouched")
+	assert.Equal(t, uint64(50), state.Slot,
+		"no boundary state row written when nothing is distributed")
+}
+
+// TestApplyMIRCerts_PotTransferReservesToTreasury verifies that a pot-to-pot
+// MIR with sourcePot=Reserves moves coins from reserves to treasury.
+func TestApplyMIRCerts_PotTransferReservesToTreasury(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const transfer = uint64(2_000)
+	seedMIRPotTransfer(t, gdb, mirPotReserves, transfer, 500)
+	require.NoError(t, db.Metadata().SetNetworkState(3_000, 10_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(5_000), uint64(state.Treasury),
+		"treasury increased by pot transfer")
+	assert.Equal(t, uint64(8_000), uint64(state.Reserves),
+		"reserves decreased by pot transfer")
+}
+
+// TestApplyMIRCerts_PotTransferTreasuryToReserves verifies sourcePot=Treasury
+// moves coins from treasury to reserves.
+func TestApplyMIRCerts_PotTransferTreasuryToReserves(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const transfer = uint64(1_500)
+	seedMIRPotTransfer(t, gdb, mirPotTreasury, transfer, 500)
+	require.NoError(t, db.Metadata().SetNetworkState(4_000, 6_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(2_500), uint64(state.Treasury),
+		"treasury decreased by pot transfer")
+	assert.Equal(t, uint64(7_500), uint64(state.Reserves),
+		"reserves increased by pot transfer")
+}
+
+// TestApplyMIRCerts_OutsideEpochRange verifies that a MIR cert submitted
+// before epochStartSlot or at/after boundarySlot is not applied.
+func TestApplyMIRCerts_OutsideEpochRange(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x44)
+	// addedSlot=50 is before epochStartSlot=100
+	seedMIRDistribution(t, gdb, mirPotReserves, 50, []models.MoveInstantaneousRewardsReward{
+		{Credential: cred, Amount: types.Uint64(500)},
+	})
+	// addedSlot=1000 equals boundarySlot — excluded (half-open interval)
+	seedMIRDistribution(t, gdb, mirPotReserves, 1_000, []models.MoveInstantaneousRewardsReward{
+		{Credential: cred, Amount: types.Uint64(300)},
+	})
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Reward:     0,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 10, nil))
+
+	// epoch range: [100, 1000)
+	runApplyMIRCerts(t, ls, db, 100, 1_000)
+
+	account, err := db.GetAccount(cred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"certs outside epoch range should not be applied")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5_000), uint64(state.Reserves),
+		"reserves should be unchanged for out-of-range certs")
+}
+
+// TestApplyMIRCerts_Rollback verifies that reward credits and pot debits are
+// reversed by deleting AccountRewardDelta and NetworkState rows after slot,
+// and re-application produces the same outcome.
+func TestApplyMIRCerts_Rollback(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const (
+		epochStartSlot = uint64(0)
+		boundarySlot   = uint64(1_000)
+		preBoundary    = uint64(500)
+		mirAmount      = uint64(600)
+	)
+	cred := mirCred28(0x55)
+	seedMIRDistribution(t, gdb, mirPotReserves, 200, []models.MoveInstantaneousRewardsReward{
+		{Credential: cred, Amount: types.Uint64(mirAmount)},
+	})
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Reward:     0,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 8_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
+
+	account, err := db.GetAccount(cred, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, mirAmount, uint64(account.Reward), "MIR reward applied")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7_400), uint64(state.Reserves),
+		"reserves debited after apply")
+
+	// Roll back past the boundary: drop the reward credit and treasury row.
+	require.NoError(t, db.DeleteAccountRewardsAfterSlot(preBoundary, nil))
+	require.NoError(t, db.DeleteNetworkStateAfterSlot(preBoundary, nil))
+
+	account, err = db.GetAccount(cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"reward credit reverted on rollback")
+	state, err = db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(8_000), uint64(state.Reserves),
+		"reserves restored to pre-boundary value")
+
+	// Re-apply must be deterministic.
+	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
+	account, err = db.GetAccount(cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, mirAmount, uint64(account.Reward),
+		"re-applied MIR reward is deterministic")
+	state, err = db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7_400), uint64(state.Reserves))
+}
+
+// TestApplyMIRCerts_NoOp verifies that an epoch with no MIR certs leaves
+// state completely untouched.
+func TestApplyMIRCerts_NoOp(t *testing.T) {
+	ls, db, _ := newMIRTestLedger(t)
+
+	require.NoError(t, db.Metadata().SetNetworkState(2_000, 9_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(2_000), uint64(state.Treasury))
+	assert.Equal(t, uint64(9_000), uint64(state.Reserves))
+	assert.Equal(t, uint64(50), state.Slot,
+		"no boundary row written when no MIR certs exist")
+}


### PR DESCRIPTION
Closes #2376 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Shelley-era MIR effects at epoch rollover, crediting registered rewards and moving Ada between treasury and reserves. Adds slot-range MIR retrieval and runs MIR processing before governance enactment.

- **Bug Fixes**
  - Implemented `ledger.applyMIRCerts` to process distributions and pot-to-pot transfers with underflow checks, rollback safety, and deterministic ordering (by `added_slot`, then `id`).
  - Inserted MIR step into `processEpochRollover` between pool retirements and governance; updated the ordering test.

- **New Features**
  - Added `OtherPot` to `models.MoveInstantaneousRewards` and new types `MIREffect`/`MIRReward`.
  - Added `database.GetMIRCertsInSlotRange` with MySQL/Postgres/SQLite implementations (preloads rewards and returns processed effects); writers now persist `OtherPot`; updated `DATABASE.md` to document MIR schema and the slot-range query with ordering.

<sup>Written for commit 41c2d90274251d9026ea6bdef0ee4f1b7f50b095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Move Instantaneous Rewards (MIR) certificate processing at epoch boundaries
  * Implemented support for pot-to-pot transfers and reward account distributions from treasury and reserves
  * Enhanced ledger state management to handle Shelley-era instant reward operations

* **Tests**
  * Added comprehensive test suite validating MIR distributions, transfers, and rollback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->