### PR TITLE
chore: commit recent benchmark results

### DIFF
--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -1,17 +1,10 @@
 # Dingo Ledger & Database Benchmark Results
 
-Focused Mithril API-mode metadata backfill results are tracked separately in
-[`benchmark_results_api_backfill.md`](benchmark_results_api_backfill.md).
-The latest local Kubernetes rerun on May 29-30, 2026 measured current `main`
-with a local #2457 workaround at 87.1 blocks/sec for API backfill
-(13h45m16s for 4,312,604 blocks), plus 32m28s to rebuild deferred metadata
-indexes.
-
 ## Latest Results
 
 ### Test Environment
-- **Date**: November 26, 2025
-- **Go Version**: 1.24.1
+- **Date**: June 12, 2026
+- **Go Version**: 1.26.1
 - **OS**: Linux
 - **Architecture**: aarch64
 - **CPU Cores**: 128
@@ -19,7 +12,263 @@ indexes.
 
 ### Benchmark Results
 
-All benchmarks run with `-benchmem` flag showing memory allocations and operation counts.
+All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration counts; benchmark-specific throughput metrics (for example `blocks/sec`) are reported separately.
+
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
+| connmanager:Has Inbound Peer Address/10 | 1876215 | 645.4ns | - | 40B | 2 |
+| connmanager:Has Inbound Peer Address/100 | 2049895 | 653.5ns | - | 40B | 2 |
+| connmanager:Has Inbound Peer Address/1000 | 2212045 | 595.4ns | - | 40B | 2 |
+| connmanager:Has Inbound Peer Address/500 | 1976878 | 635.2ns | - | 40B | 2 |
+| connmanager:Try Reserve Inbound Slot Parallel/10 | 2844913 | 442.9ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/100 | 1329261 | 918.2ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/500 | 1305675 | 882.4ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/10 | 39124141 | 30.51ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/100 | 37243389 | 30.55ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/1000 | 38756811 | 30.31ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/500 | 40533412 | 30.28ns | - | 0B | 0 |
+| database:Batch Resolution Hot Hits | 2638 | 426745ns | - | 110KB | 254 |
+| database:Block L R U Cache Get | 21083229 | 55.46ns | - | 0B | 0 |
+| database:Block L R U Cache Put | 1930647 | 625.2ns | - | 96B | 2 |
+| database:Cached Block Extract | 62241637 | 18.20ns | - | 0B | 0 |
+| database:Cbor Offset Decode | 10259774 | 120.7ns | - | 48B | 1 |
+| database:Cbor Offset Encode | 145843496 | 7.755ns | - | 0B | 0 |
+| database:Hot Cache Get | 2163880 | 560.5ns | - | 192B | 2 |
+| database:Hot Cache Get Miss | 122696038 | 9.175ns | - | 0B | 0 |
+| database:Hot Cache Parallel Get | 10000 | 129295ns | - | 438KB | 57 |
+| database:Hot Cache Put | 10000 | 2008500ns | - | 638KB | 40 |
+| database:Make Utxo Key | 185591302 | 6.447ns | - | 0B | 0 |
+| database:Metrics Increment | 134105025 | 8.441ns | - | 0B | 0 |
+| database:Metrics Increment With Prometheus | 87684171 | 13.40ns | - | 0B | 0 |
+| database:Tiered Cache Hot Hit | 1855422 | 644.0ns | - | 191B | 1 |
+| database:Transaction Create | 69379 | 16209ns | - | 2KB | 21 |
+| database:Tx Batch Resolution Hot Hits | 2960 | 392791ns | - | 149KB | 254 |
+| event:Publish Subscribers/1 | 9006843 | 155.2ns | - | 0B | 0 |
+| event:Publish Subscribers/10 | 1379077 | 850.1ns | - | 0B | 0 |
+| event:Publish Subscribers/100 | 122960 | 9315ns | - | 0B | 0 |
+| event:Publish Subscribers/500 | 14185 | 81714ns | - | 0B | 0 |
+| integration:Storage Backends/ S3 | 51 | 23474469ns | - | 413KB | 5604 |
+| integration:Storage Backends/disk | 20888 | 60056ns | - | 36KB | 120 |
+| integration:Storage Backends/memory | 16039 | 72909ns | - | 36KB | 120 |
+| integration:Test Load/ S3 | 3 | 469521190ns | - | 8223KB | 111670 |
+| integration:Test Load/disk | 1117 | 1155046ns | - | 681KB | 2021 |
+| integration:Test Load/memory | 1447 | 1070303ns | - | 681KB | 2021 |
+| leader:Is Leader For Slot | 16403265 | 62.15ns | - | 0B | 0 |
+| ledger:Account Lookup By Stake Key No Data | 30961 | 45169ns | - | 5KB | 82 |
+| ledger:Account Lookup By Stake Key Real Data | 32756 | 40402ns | - | 5KB | 82 |
+| ledger:Block Batch Processing Throughput | 1738 | 710552ns | 70368 blocks/sec | 97KB | 2238 |
+| ledger:Block Memory Usage | 17202 | 69987ns | - | 22KB | 81 |
+| ledger:Block Nonce Lookup No Data | 31898 | 40346ns | - | 4KB | 66 |
+| ledger:Block Nonce Lookup Real Data | 38780 | 32720ns | - | 4KB | 66 |
+| ledger:Block Processing Throughput | 10000 | 113856ns | 8783 blocks/sec | 24KB | 137 |
+| ledger:Block Processing Throughput Predecoded | 24138 | 47821ns | 20911 blocks/sec | 2KB | 61 |
+| ledger:Block Retrieval By Index No Data | 290994 | 4070ns | - | 490B | 10 |
+| ledger:Block Retrieval By Index Real Data | 358546 | 3791ns | - | 490B | 10 |
+| ledger:Blockfetch Near Tip Flush Only Predecoded | 27274 | 45207ns | 22120 blocks/sec | 2KB | 59 |
+| ledger:Blockfetch Near Tip Queued Header Predecoded | 1539733 | 711.2ns | 1406054 blocks/sec | 418B | 2 |
+| ledger:Blockfetch Near Tip Throughput | 28318 | 35968ns | 27802 blocks/sec | 21KB | 74 |
+| ledger:Blockfetch Near Tip Throughput Predecoded | 24760303 | 47.30ns | 21143182 blocks/sec | 0B | 0 |
+| ledger:Blockfetch Verified Header Dispatch | 164117104 | 7.003ns | - | 0B | 0 |
+| ledger:Chain Sync From Genesis | 100 | 16226844ns | 100.0 blocks_processed | 3079KB | 20971 |
+| ledger:Concurrent Queries | 13389 | 87594ns | 11452 queries/sec | 4KB | 56 |
+| ledger:D Rep Lookup By Key Hash No Data | 29600 | 45740ns | - | 4KB | 78 |
+| ledger:D Rep Lookup By Key Hash Real Data | 33402 | 40542ns | - | 4KB | 78 |
+| ledger:Datum Lookup By Hash No Data | 42435 | 31087ns | - | 4KB | 62 |
+| ledger:Datum Lookup By Hash Real Data | 44158 | 31732ns | - | 4KB | 62 |
+| ledger:Era Transition Performance | 510968528 | 2.139ns | - | 0B | 0 |
+| ledger:Era Transition Performance Real Data | 1788 | 632574ns | - | 115KB | 604 |
+| ledger:Index Building Time | 12878 | 96172ns | - | 25KB | 147 |
+| ledger:Pool Lookup By Key Hash No Data | 30160 | 38061ns | - | 4KB | 71 |
+| ledger:Pool Lookup By Key Hash Real Data | 38528 | 35611ns | - | 4KB | 71 |
+| ledger:Pool Registration Lookups No Data | 24674 | 59497ns | - | 15KB | 116 |
+| ledger:Pool Registration Lookups Real Data | 22318 | 56090ns | - | 15KB | 116 |
+| ledger:Protocol Parameters Lookup By Epoch No Data | 15066 | 81706ns | - | 5KB | 62 |
+| ledger:Protocol Parameters Lookup By Epoch Real Data | 14772 | 78482ns | - | 5KB | 62 |
+| ledger:Raw Block Batch Processing Throughput | 1774 | 685615ns | 72927 blocks/sec | 94KB | 2138 |
+| ledger:Real Block Processing | 10000 | 113666ns | - | 25KB | 147 |
+| ledger:Real Block Reading | 19 | 60340634ns | - | 4307KB | 93886 |
+| ledger:Real Data Queries | 106478 | 16850ns | - | 5KB | 41 |
+| ledger:Stake Registration Lookups No Data | 37182 | 35447ns | - | 5KB | 60 |
+| ledger:Stake Registration Lookups Real Data | 35109 | 37608ns | - | 5KB | 60 |
+| ledger:Storage Mode Ingest Steady State/api | 3 | 455072561ns | 395.5 blocks_ingested/sec, 439.5 txs_ingested/sec | 16134KB | 196320 |
+| ledger:Storage Mode Ingest Steady State/core | 4 | 261284205ns | 688.9 blocks_ingested/sec, 765.5 txs_ingested/sec | 9934KB | 125256 |
+| ledger:Storage Mode Ingest/api | 3 | 389263279ns | 462.4 blocks_ingested/sec, 513.8 txs_ingested/sec | 16274KB | 204481 |
+| ledger:Storage Mode Ingest/core | 5 | 235316116ns | 764.9 blocks_ingested/sec, 849.9 txs_ingested/sec | 10111KB | 133483 |
+| ledger:Transaction History Queries No Data | 29394 | 39802ns | - | 5KB | 73 |
+| ledger:Transaction History Queries Real Data | 35984 | 36650ns | - | 5KB | 73 |
+| ledger:Transaction Validation | 3714817 | 306.0ns | - | 64B | 2 |
+| ledger:Utxo Lookup By Address No Data | 76494 | 17271ns | - | 2KB | 22 |
+| ledger:Utxo Lookup By Address Real Data | 73520 | 16779ns | - | 2KB | 22 |
+| ledger:Utxo Lookup By Ref No Data | 8665 | 123559ns | - | 9KB | 123 |
+| ledger:Utxo Lookup By Ref Real Data | 10000 | 142173ns | - | 9KB | 123 |
+| ledger:Verify Block Header/direct | 1074 | 1070831ns | - | 2KB | 28 |
+| ledger:Verify Block Header/ledger_state | 1075 | 1089516ns | - | 2KB | 30 |
+| ouroboros:Blockfetch Client Block Metrics | 3696294 | 284.8ns | - | 0B | 0 |
+| peergov:Reconcile/100 | 7358 | 186636ns | - | 22KB | 166 |
+| peergov:Reconcile/1000 | 488 | 2386170ns | - | 291KB | 2197 |
+| peergov:Reconcile/500 | 1044 | 1185364ns | - | 138KB | 992 |
+| sqlite:Get Utxo Address Keys Batch/address-keys | 54 | 21874618ns | - | 858KB | 11710 |
+| sqlite:Get Utxo Address Keys Batch/full-utxo | 33 | 30965584ns | - | 1388KB | 20740 |
+| sqlite:Import Utxos | 10 | 104772186ns | - | 1252KB | 11248 |
+| sqlite:Import Utxos G O R M | 10 | 119981616ns | - | 1373KB | 21278 |
+| sqlite:Insert Key Witnesses | 63 | 24106513ns | - | 406KB | 3652 |
+| sqlite:Insert Key Witnesses G O R M | 36 | 38921330ns | - | 932KB | 17394 |
+
+## Performance Changes
+
+Changes since **November 26, 2025**:
+
+### Summary
+- **Faster benchmarks**: 0
+- **Slower benchmarks**: 0
+- **New benchmarks**: 97
+- **Removed benchmarks**: 40
+
+### New Benchmarks Added
+- connmanager:Has Inbound Peer Address/10
+- connmanager:Has Inbound Peer Address/100
+- connmanager:Has Inbound Peer Address/1000
+- connmanager:Has Inbound Peer Address/500
+- connmanager:Try Reserve Inbound Slot Parallel/10
+- connmanager:Try Reserve Inbound Slot Parallel/100
+- connmanager:Try Reserve Inbound Slot Parallel/500
+- connmanager:Update Connection Metrics/10
+- connmanager:Update Connection Metrics/100
+- connmanager:Update Connection Metrics/1000
+- connmanager:Update Connection Metrics/500
+- database:Batch Resolution Hot Hits
+- database:Block L R U Cache Get
+- database:Block L R U Cache Put
+- database:Cached Block Extract
+- database:Cbor Offset Decode
+- database:Cbor Offset Encode
+- database:Hot Cache Get
+- database:Hot Cache Get Miss
+- database:Hot Cache Parallel Get
+- database:Hot Cache Put
+- database:Make Utxo Key
+- database:Metrics Increment
+- database:Metrics Increment With Prometheus
+- database:Tiered Cache Hot Hit
+- database:Transaction Create
+- database:Tx Batch Resolution Hot Hits
+- event:Publish Subscribers/1
+- event:Publish Subscribers/10
+- event:Publish Subscribers/100
+- event:Publish Subscribers/500
+- integration:Storage Backends/ S3
+- integration:Storage Backends/disk
+- integration:Storage Backends/memory
+- integration:Test Load/ S3
+- integration:Test Load/disk
+- integration:Test Load/memory
+- leader:Is Leader For Slot
+- ledger:Account Lookup By Stake Key No Data
+- ledger:Account Lookup By Stake Key Real Data
+- ledger:Block Batch Processing Throughput
+- ledger:Block Memory Usage
+- ledger:Block Nonce Lookup No Data
+- ledger:Block Nonce Lookup Real Data
+- ledger:Block Processing Throughput
+- ledger:Block Processing Throughput Predecoded
+- ledger:Block Retrieval By Index No Data
+- ledger:Block Retrieval By Index Real Data
+- ledger:Blockfetch Near Tip Flush Only Predecoded
+- ledger:Blockfetch Near Tip Queued Header Predecoded
+- ledger:Blockfetch Near Tip Throughput
+- ledger:Blockfetch Near Tip Throughput Predecoded
+- ledger:Blockfetch Verified Header Dispatch
+- ledger:Chain Sync From Genesis
+- ledger:Concurrent Queries
+- ledger:D Rep Lookup By Key Hash No Data
+- ledger:D Rep Lookup By Key Hash Real Data
+- ledger:Datum Lookup By Hash No Data
+- ledger:Datum Lookup By Hash Real Data
+- ledger:Era Transition Performance
+- ledger:Era Transition Performance Real Data
+- ledger:Index Building Time
+- ledger:Pool Lookup By Key Hash No Data
+- ledger:Pool Lookup By Key Hash Real Data
+- ledger:Pool Registration Lookups No Data
+- ledger:Pool Registration Lookups Real Data
+- ledger:Protocol Parameters Lookup By Epoch No Data
+- ledger:Protocol Parameters Lookup By Epoch Real Data
+- ledger:Raw Block Batch Processing Throughput
+- ledger:Real Block Processing
+- ledger:Real Block Reading
+- ledger:Real Data Queries
+- ledger:Stake Registration Lookups No Data
+- ledger:Stake Registration Lookups Real Data
+- ledger:Storage Mode Ingest Steady State/api
+- ledger:Storage Mode Ingest Steady State/core
+- ledger:Storage Mode Ingest/api
+- ledger:Storage Mode Ingest/core
+- ledger:Transaction History Queries No Data
+- ledger:Transaction History Queries Real Data
+- ledger:Transaction Validation
+- ledger:Utxo Lookup By Address No Data
+- ledger:Utxo Lookup By Address Real Data
+- ledger:Utxo Lookup By Ref No Data
+- ledger:Utxo Lookup By Ref Real Data
+- ledger:Verify Block Header/direct
+- ledger:Verify Block Header/ledger_state
+- ouroboros:Blockfetch Client Block Metrics
+- peergov:Reconcile/100
+- peergov:Reconcile/1000
+- peergov:Reconcile/500
+- sqlite:Get Utxo Address Keys Batch/address-keys
+- sqlite:Get Utxo Address Keys Batch/full-utxo
+- sqlite:Import Utxos
+- sqlite:Import Utxos G O R M
+- sqlite:Insert Key Witnesses
+- sqlite:Insert Key Witnesses G O R M
+
+### Benchmarks Removed
+- Account Lookup By Stake Key No Data
+- Account Lookup By Stake Key Real Data
+- Block Memory Usage
+- Block Nonce Lookup No Data
+- Block Nonce Lookup Real Data
+- Block Processing Throughput
+- Block Retrieval By Index No Data
+- Block Retrieval By Index Real Data
+- Chain Sync From Genesis
+- Concurrent Queries
+- D Rep Lookup By Key Hash No Data
+- D Rep Lookup By Key Hash Real Data
+- Datum Lookup By Hash No Data
+- Datum Lookup By Hash Real Data
+- Era Transition Performance
+- Era Transition Performance Real Data
+- Index Building Time
+- Pool Lookup By Key Hash No Data
+- Pool Lookup By Key Hash Real Data
+- Pool Registration Lookups No Data
+- Pool Registration Lookups Real Data
+- Protocol Parameters Lookup By Epoch No Data
+- Protocol Parameters Lookup By Epoch Real Data
+- Real Block Processing
+- Real Block Reading
+- Real Data Queries
+- Stake Registration Lookups No Data
+- Stake Registration Lookups Real Data
+- Storage Backends/disk
+- Storage Backends/memory
+- Test Load/disk
+- Test Load/memory
+- Transaction Create
+- Transaction History Queries No Data
+- Transaction History Queries Real Data
+- Transaction Validation
+- Utxo Lookup By Address No Data
+- Utxo Lookup By Address Real Data
+- Utxo Lookup By Ref No Data
+- Utxo Lookup By Ref Real Data
+
+
+## Historical Results
+
+### November 26, 2025
 
 | Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |
 |-----------|----------------|---------|-----------|-----------|
@@ -63,75 +312,3 @@ All benchmarks run with `-benchmem` flag showing memory allocations and operatio
 | Concurrent Queries | 15408 | 68781ns | 14581queries/sec | 3943 |
 | D Rep Lookup By Key Hash Real Data | 39360 | 34907ns | 4KB | 77 |
 | Block Memory Usage | 29292 | 44369ns | 14KB | 49 |
-
-## Performance Changes
-
-Changes since **November 26, 2025**:
-
-### Summary
-- **Faster benchmarks**: 19
-- **Slower benchmarks**: 20
-- **New benchmarks**: 0
-- **Removed benchmarks**: 0
-
-### Top Improvements
-- Utxo Lookup By Address No Data (+44%)
-- Transaction Validation (+0%)
-- Test Load/memory (+19%)
-- Test Load/disk (+31%)
-- Storage Backends/memory (+3%)
-
-### Performance Regressions
-- Pool Lookup By Key Hash No Data (-0%)
-- Index Building Time (-0%)
-- Account Lookup By Stake Key No Data (-0%)
-- Transaction History Queries No Data (-1%)
-- Stake Registration Lookups No Data (-1%)
-
-
-## Historical Results
-
-### November 26, 2025
-
-| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |
-|-----------|----------------|---------|-----------|-----------|
-| Pool Lookup By Key Hash No Data | 36328 | 33556ns | 4KB | 79 |
-| Pool Registration Lookups No Data | 24898 | 51298ns | 10KB | 93 |
-| Account Lookup By Stake Key Real Data | 39936 | 33871ns | 4KB | 75 |
-| Utxo Lookup By Address No Data | 75966 | 16953ns | 2KB | 19 |
-| Storage Backends/memory | 31369 | 33394ns | 13KB | 70 |
-| Transaction Validation | 230637091 | 5.213ns | 0B | 0 |
-| Real Block Reading | 20 | 55046083ns | 2183KB | 74472 |
-| Block Retrieval By Index Real Data | 312492 | 4102ns | 472B | 11 |
-| Index Building Time | 14168 | 86378ns | 17KB | 119 |
-| Chain Sync From Genesis | 100 | 14189212ns | 100.0blocks_processed | 2247966 |
-| Block Retrieval By Index No Data | 277410 | 4025ns | 472B | 11 |
-| Transaction Create | 92761 | 16456ns | 2KB | 18 |
-| Utxo Lookup By Address Real Data | 86467 | 15705ns | 2KB | 19 |
-| Era Transition Performance | 499031763 | 2.139ns | 0B | 0 |
-| Protocol Parameters Lookup By Epoch Real Data | 44150 | 30066ns | 5KB | 62 |
-| Pool Registration Lookups Real Data | 23724 | 48201ns | 10KB | 93 |
-| Stake Registration Lookups Real Data | 40082 | 32844ns | 5KB | 69 |
-| Era Transition Performance Real Data | 3525 | 305364ns | 83KB | 490 |
-| Real Block Processing | 13509 | 87846ns | 17KB | 119 |
-| Utxo Lookup By Ref No Data | 10724 | 111792ns | 8KB | 131 |
-| Storage Backends/disk | 28960 | 37643ns | 13KB | 70 |
-| Test Load/memory | 1605 | 669272ns | 260KB | 1400 |
-| Stake Registration Lookups No Data | 34359 | 36417ns | 5KB | 69 |
-| Utxo Lookup By Ref Real Data | 10000 | 111756ns | 8KB | 131 |
-| Protocol Parameters Lookup By Epoch No Data | 37886 | 32905ns | 5KB | 62 |
-| Datum Lookup By Hash No Data | 40302 | 29076ns | 4KB | 69 |
-| Block Processing Throughput | 4632 | 287053ns | 3484blocks/sec | 22466 |
-| Real Data Queries | 62532 | 19011ns | 5KB | 43 |
-| Block Nonce Lookup Real Data | 35782 | 38514ns | 4KB | 73 |
-| Test Load/disk | 1574 | 711525ns | 260KB | 1400 |
-| Pool Lookup By Key Hash Real Data | 39812 | 33599ns | 4KB | 79 |
-| D Rep Lookup By Key Hash No Data | 35139 | 35088ns | 4KB | 77 |
-| Transaction History Queries No Data | 34530 | 36887ns | 4KB | 78 |
-| Datum Lookup By Hash Real Data | 36972 | 31369ns | 4KB | 69 |
-| Block Nonce Lookup No Data | 32977 | 36460ns | 4KB | 73 |
-| Account Lookup By Stake Key No Data | 35020 | 32890ns | 4KB | 75 |
-| Transaction History Queries Real Data | 38739 | 35904ns | 4KB | 78 |
-| D Rep Lookup By Key Hash Real Data | 38977 | 36859ns | 4KB | 77 |
-| Concurrent Queries | 19104 | 59527ns | 168280queries/sec | 3851 |
-| Block Memory Usage | 26552 | 46212ns | 14KB | 49 |

--- a/benchmark_results_bp_pi.md
+++ b/benchmark_results_bp_pi.md
@@ -4,6 +4,7 @@ Assumptions:
 - `storageMode=core`
 - `runMode=serve`, `blob=badger`, `metadata=sqlite`
 - `GOMAXPROCS=4`
+- target peak RSS: `<= 1024 MB`
 - immutable fixture: `database/immutable/testdata`
 - measurements were collected on non-Pi hardware and are a sizing proxy, not Raspberry Pi device benchmarks
 - block producer peer count remains small; this is not a relay profile
@@ -12,11 +13,12 @@ Assumptions:
 
 | Profile | Elapsed | Peak RSS | Notes |
 | --- | --- | --- | --- |
-| `core-default` | `100.35s` | `568.1 MB` | Current default `serve/core` cache profile |
+| `core-default` | `99.00s` | `713.4 MB` | Current default `serve/core` cache profile |
 
 ## Recommendation
 
-For Raspberry Pi-class sizing in `storageMode=core`, the current default `serve/core` profile is already in the measured low-memory range on this four-thread non-Pi host.
+For Raspberry Pi-class sizing in `storageMode=core`, keep production defaults aligned with normal Badger behavior and use explicit memory/cache constraints only in this harness when validating low-memory targets.
+This run stayed under the configured `1024 MB` RSS limit.
 Explicit Badger cache settings still override these defaults if an operator wants to tune further.
 Treat this as a sizing baseline rather than a direct Raspberry Pi hardware measurement.
 
@@ -25,8 +27,8 @@ Treat this as a sizing baseline rather than a direct Raspberry Pi hardware measu
 ## Latest Results
 
 ### Test Environment
-- **Date**: March 15, 2026
-- **Go Version**: 1.25.8
+- **Date**: June 12, 2026
+- **Go Version**: 1.26.1
 - **OS**: Linux
 - **Architecture**: aarch64
 - **CPU Cores**: 128
@@ -39,12 +41,51 @@ All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration 
 
 | Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
 |-----------|------------|---------|---------------|-----------|-----------|
+| ledger:Blockfetch Near Tip Flush Only Predecoded | 30390 | 40276ns | 24829 blocks/sec | 2KB | 59 |
+| ledger:Blockfetch Near Tip Queued Header Predecoded | 1870012 | 616.8ns | 1621211 blocks/sec | 418B | 2 |
+| ledger:Blockfetch Near Tip Throughput | 36349 | 35741ns | 27979 blocks/sec | 21KB | 74 |
+| ledger:Blockfetch Near Tip Throughput Predecoded | 24396732 | 48.72ns | 20524367 blocks/sec | 0B | 0 |
+| ledger:Verify Block Header/direct | 1189 | 997996ns | - | 2KB | 28 |
+| ledger:Verify Block Header/ledger_state | 1147 | 1032909ns | - | 2KB | 30 |
+
+## Performance Changes
+
+Changes since **March 15, 2026**:
+
+### Load Footprint
+
+| Metric | Previous | Current | Change |
+|--------|----------|---------|--------|
+| Profile | `core-default` | `core-default` | - |
+| Elapsed | `100.35s` | `99.00s` | `-1.35s (-1.3%)` |
+| Peak RSS | `568.1 MB` | `713.4 MB` | `+145.3 MB (+25.6%)` |
+
+### Summary
+- **Faster benchmarks**: 2
+- **Slower benchmarks**: 3
+- **New benchmarks**: 1
+- **Removed benchmarks**: 0
+
+### Top Improvements
+- ledger:Blockfetch Near Tip Throughput Predecoded (+7324%)
+- ledger:Blockfetch Near Tip Queued Header Predecoded (+1099%)
+
+### Performance Regressions
+- ledger:Verify Block Header/ledger_state (-80%)
+- ledger:Verify Block Header/direct (-80%)
+- ledger:Blockfetch Near Tip Throughput (-79%)
+
+### New Benchmarks Added
+- ledger:Blockfetch Near Tip Flush Only Predecoded
+
+## Historical Results
+
+### March 15, 2026
+
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
 | ledger:Blockfetch Near Tip Queued Header Predecoded | 155935 | 36391ns | 27479 blocks/sec | 2KB | 51 |
 | ledger:Blockfetch Near Tip Throughput | 181371 | 66974ns | 14931 blocks/sec | 25KB | 128 |
 | ledger:Blockfetch Near Tip Throughput Predecoded | 328588 | 36882ns | 27113 blocks/sec | 2KB | 50 |
 | ledger:Verify Block Header/direct | 5946 | 1005264ns | - | 2KB | 29 |
 | ledger:Verify Block Header/ledger_state | 6008 | 997998ns | - | 2KB | 29 |
-
-## Performance Changes
-
-No previous results found. This is the first benchmark run.

--- a/benchmark_results_targeted.md
+++ b/benchmark_results_targeted.md
@@ -3,8 +3,8 @@
 ## Latest Results
 
 ### Test Environment
-- **Date**: March 15, 2026
-- **Go Version**: 1.25.8
+- **Date**: June 12, 2026
+- **Go Version**: 1.26.1
 - **OS**: Linux
 - **Architecture**: aarch64
 - **CPU Cores**: 128
@@ -14,6 +14,78 @@
 ### Benchmark Results
 
 All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration counts; benchmark-specific throughput metrics (for example `blocks/sec`) are reported separately.
+
+| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
+|-----------|------------|---------|---------------|-----------|-----------|
+| connmanager:Has Inbound Peer Address/10 | 1806908 | 592.3ns | - | 40B | 2 |
+| connmanager:Has Inbound Peer Address/100 | 1805614 | 665.6ns | - | 40B | 2 |
+| connmanager:Has Inbound Peer Address/1000 | 1757652 | 647.8ns | - | 40B | 2 |
+| connmanager:Has Inbound Peer Address/500 | 1759791 | 656.7ns | - | 40B | 2 |
+| connmanager:Try Reserve Inbound Slot Parallel/10 | 1321866 | 787.9ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/100 | 1488516 | 869.2ns | - | 0B | 0 |
+| connmanager:Try Reserve Inbound Slot Parallel/500 | 1299157 | 796.1ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/10 | 40943979 | 30.85ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/100 | 40637336 | 28.86ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/1000 | 33163863 | 30.67ns | - | 0B | 0 |
+| connmanager:Update Connection Metrics/500 | 37643042 | 30.34ns | - | 0B | 0 |
+| event:Publish Subscribers/1 | 5566287 | 206.5ns | - | 0B | 0 |
+| event:Publish Subscribers/10 | 1576297 | 794.1ns | - | 0B | 0 |
+| event:Publish Subscribers/100 | 125047 | 8942ns | - | 0B | 0 |
+| event:Publish Subscribers/500 | 15193 | 79365ns | - | 0B | 0 |
+| ledger:Block Processing Throughput | 10000 | 113423ns | 8817 blocks/sec | 24KB | 136 |
+| ledger:Block Processing Throughput Predecoded | 25467 | 42734ns | 23401 blocks/sec | 2KB | 61 |
+| ledger:Blockfetch Near Tip Flush Only Predecoded | 32299 | 39575ns | 25269 blocks/sec | 2KB | 59 |
+| ledger:Blockfetch Near Tip Queued Header Predecoded | 1883409 | 599.9ns | 1666820 blocks/sec | 418B | 2 |
+| ledger:Blockfetch Near Tip Throughput | 32918 | 31718ns | 31528 blocks/sec | 21KB | 74 |
+| ledger:Blockfetch Near Tip Throughput Predecoded | 22904923 | 48.08ns | 20799215 blocks/sec | 0B | 0 |
+| ledger:Blockfetch Verified Header Dispatch | 178266688 | 6.724ns | - | 0B | 0 |
+| ledger:Verify Block Header/direct | 1147 | 1032274ns | - | 2KB | 28 |
+| ledger:Verify Block Header/ledger_state | 1149 | 1031635ns | - | 2KB | 30 |
+| peergov:Reconcile/100 | 9492 | 136118ns | - | 21KB | 166 |
+| peergov:Reconcile/1000 | 526 | 2275401ns | - | 281KB | 2199 |
+| peergov:Reconcile/500 | 1232 | 975706ns | - | 132KB | 991 |
+
+## Performance Changes
+
+Changes since **March 15, 2026**:
+
+### Summary
+- **Faster benchmarks**: 5
+- **Slower benchmarks**: 17
+- **New benchmarks**: 5
+- **Removed benchmarks**: 4
+
+### Top Improvements
+- ledger:Blockfetch Verified Header Dispatch (+82.48%)
+- ledger:Blockfetch Near Tip Throughput Predecoded (+75,665.75%)
+- event:Publish Subscribers/500 (+17%)
+- event:Publish Subscribers/100 (+104%)
+- event:Publish Subscribers/10 (+111%)
+
+### Performance Regressions
+- event:Publish Subscribers/1 (-30%)
+- connmanager:Try Reserve Inbound Slot Parallel/100 (-78%)
+- connmanager:Update Connection Metrics/10 (-79%)
+- ledger:Verify Block Header/ledger_state (-80%)
+- ledger:Verify Block Header/direct (-80%)
+
+### New Benchmarks Added
+- connmanager:Has Inbound Peer Address/10
+- connmanager:Has Inbound Peer Address/100
+- connmanager:Has Inbound Peer Address/1000
+- connmanager:Has Inbound Peer Address/500
+- ledger:Blockfetch Near Tip Queued Header Predecoded
+
+### Benchmarks Removed
+- connmanager:Has Inbound From Host/10
+- connmanager:Has Inbound From Host/100
+- connmanager:Has Inbound From Host/1000
+- connmanager:Has Inbound From Host/500
+
+
+## Historical Results
+
+### March 15, 2026
 
 | Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
 |-----------|------------|---------|---------------|-----------|-----------|
@@ -34,8 +106,8 @@ All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration 
 | event:Publish Subscribers/500 | 12976 | 489401ns | - | 0B | 0 |
 | ledger:Block Processing Throughput | 54142 | 95123ns | 10513 blocks/sec | 25KB | 133 |
 | ledger:Block Processing Throughput Predecoded | 144867 | 40441ns | 24728 blocks/sec | 2KB | 51 |
-| ledger:Blockfetch Near Tip Throughput | 172838 | 69818ns | 14323 blocks/sec | 25KB | 129 |
 | ledger:Blockfetch Near Tip Flush Only Predecoded | 342222 | 37234ns | 26857 blocks/sec | 2KB | 50 |
+| ledger:Blockfetch Near Tip Throughput | 172838 | 69818ns | 14323 blocks/sec | 25KB | 129 |
 | ledger:Blockfetch Near Tip Throughput Predecoded | 340428 | 36428ns | 27452 blocks/sec | 2KB | 50 |
 | ledger:Blockfetch Verified Header Dispatch | 156298824 | 38.37ns | - | 0B | 0 |
 | ledger:Verify Block Header/direct | 5907 | 1008310ns | - | 2KB | 29 |
@@ -43,60 +115,3 @@ All benchmarks run with `-benchmem` flag. Iterations are Go benchmark iteration 
 | peergov:Reconcile/100 | 64309 | 93859ns | - | 19KB | 124 |
 | peergov:Reconcile/1000 | 3626 | 1632793ns | - | 250KB | 1597 |
 | peergov:Reconcile/500 | 7881 | 733098ns | - | 124KB | 697 |
-
-## Performance Changes
-
-Changes relative to the earlier **March 15, 2026** baseline below:
-
-### Summary
-- Focused timed reruns were used for the connmanager and peergov rows in this update.
-- `Update Connection Metrics` now uses incremental cached counts instead of rescanning all connections.
-- The default `serve/core` Badger profile now uses the previously measured Pi-tight cache sizing.
-- `peergov.reconcile` still benefits heavily from keeping per-peer churn logs below `Info`.
-- `peergov.reconcile` now reuses one reconcile timestamp and caches under-valency for warm-promotion candidates.
-- `peergov.enforceStateLimit` now sorts only removable peers and rebuilds the slice once instead of repeatedly deleting from it.
-- `peergov.reconcile` now skips valency-status scans entirely unless debug logging is enabled.
-
-### Top Improvements
-- connmanager:Update Connection Metrics/1000: `291625ns -> 30.09ns`
-- connmanager:Update Connection Metrics/500: `138551ns -> 29.69ns`
-- connmanager:Update Connection Metrics/100: `24518ns -> 29.82ns`
-- connmanager:Update Connection Metrics/10: `3123ns -> 29.24ns`
-- ledger:Blockfetch Near Tip Throughput: `86320ns -> 69818ns`
-- ledger:Blockfetch Near Tip Throughput Predecoded: `40031ns -> 36428ns`
-- peergov:Reconcile/1000: `2587803ns -> 1632793ns`
-- peergov:Reconcile/500: `1072577ns -> 733098ns`
-- peergov:Reconcile/100: `130667ns -> 93859ns`
-
-
-## Historical Results
-
-### Earlier March 15, 2026 Baseline
-
-| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |
-|-----------|------------|---------|---------------|-----------|-----------|
-| connmanager:Has Inbound From Host/10 | 102497121 | 63.18ns | - | 0B | 0 |
-| connmanager:Has Inbound From Host/100 | 93197125 | 57.95ns | - | 0B | 0 |
-| connmanager:Has Inbound From Host/1000 | 99058254 | 60.09ns | - | 0B | 0 |
-| connmanager:Has Inbound From Host/500 | 91016371 | 65.75ns | - | 0B | 0 |
-| connmanager:Try Reserve Inbound Slot Parallel/10 | 15616777 | 403.8ns | - | 0B | 0 |
-| connmanager:Try Reserve Inbound Slot Parallel/100 | 7449546 | 779.0ns | - | 0B | 0 |
-| connmanager:Try Reserve Inbound Slot Parallel/500 | 7706102 | 772.6ns | - | 0B | 0 |
-| connmanager:Update Connection Metrics/10 | 1876092 | 3123ns | - | 456B | 3 |
-| connmanager:Update Connection Metrics/100 | 239965 | 24518ns | - | 3KB | 3 |
-| connmanager:Update Connection Metrics/1000 | 20446 | 291625ns | - | 54KB | 5 |
-| connmanager:Update Connection Metrics/500 | 43100 | 138551ns | - | 27KB | 3 |
-| event:Publish Subscribers/1 | 7974799 | 650.6ns | - | 0B | 0 |
-| event:Publish Subscribers/10 | 746738 | 7520ns | - | 0B | 0 |
-| event:Publish Subscribers/100 | 61120 | 94657ns | - | 0B | 0 |
-| event:Publish Subscribers/500 | 12976 | 489401ns | - | 0B | 0 |
-| ledger:Block Processing Throughput | 54142 | 95123ns | 10513 blocks/sec | 25KB | 133 |
-| ledger:Block Processing Throughput Predecoded | 144867 | 40441ns | 24728 blocks/sec | 2KB | 51 |
-| ledger:Blockfetch Near Tip Throughput | 76536 | 86320ns | 11585 blocks/sec | 25KB | 128 |
-| ledger:Blockfetch Near Tip Throughput Predecoded | 160242 | 40031ns | 24981 blocks/sec | 2KB | 50 |
-| ledger:Blockfetch Verified Header Dispatch | 156298824 | 38.37ns | - | 0B | 0 |
-| ledger:Verify Block Header/direct | 5907 | 1008310ns | - | 2KB | 29 |
-| ledger:Verify Block Header/ledger_state | 5935 | 1006660ns | - | 2KB | 29 |
-| peergov:Reconcile/100 | 45027 | 130667ns | - | 16KB | 185 |
-| peergov:Reconcile/1000 | 2343 | 2587803ns | - | 202KB | 1662 |
-| peergov:Reconcile/500 | 5739 | 1072577ns | - | 100KB | 760 |

--- a/generate_benchmarks.sh
+++ b/generate_benchmarks.sh
@@ -265,6 +265,7 @@ done
 PREVIOUS_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/dingo_bench_XXXXXX")
 trap 'rm -f "$CURRENT_RESULTS_FILE" "$PREVIOUS_RESULTS_FILE"' EXIT
 previous_date=""
+previous_results_format=""
 MAJOR_CHANGES=false
 
 if [[ -f "$OUTPUT_FILE" && "$WRITE_TO_FILE" == "true" ]]; then
@@ -280,8 +281,13 @@ if [[ -f "$OUTPUT_FILE" && "$WRITE_TO_FILE" == "true" ]]; then
         if [[ "$line" == "## Performance Changes" || "$line" == "## Historical Results" ]]; then
             break
         fi
-        if [[ "$line" == "| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |" ||
-              "$line" == "| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |" ]]; then
+        if [[ "$line" == "| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |" ]]; then
+            previous_results_format="legacy_ops"
+            in_table=true
+            continue
+        fi
+        if [[ "$line" == "| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |" ]]; then
+            previous_results_format="current"
             in_table=true
             continue
         fi
@@ -559,8 +565,13 @@ EOF
             echo "" >> "$OUTPUT_FILE.tmp"
             echo "### $previous_date" >> "$OUTPUT_FILE.tmp"
             echo "" >> "$OUTPUT_FILE.tmp"
-            echo "| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |" >> "$OUTPUT_FILE.tmp"
-            echo "|-----------|------------|---------|---------------|-----------|-----------|" >> "$OUTPUT_FILE.tmp"
+            if [[ "$previous_results_format" == "legacy_ops" ]]; then
+                echo "| Benchmark | Operations/sec | Time/op | Memory/op | Allocs/op |" >> "$OUTPUT_FILE.tmp"
+                echo "|-----------|----------------|---------|-----------|-----------|" >> "$OUTPUT_FILE.tmp"
+            else
+                echo "| Benchmark | Iterations | Time/op | Extra Metrics | Memory/op | Allocs/op |" >> "$OUTPUT_FILE.tmp"
+                echo "|-----------|------------|---------|---------------|-----------|-----------|" >> "$OUTPUT_FILE.tmp"
+            fi
 
             # Add previous results
             while IFS= read -r benchmark; do
@@ -570,7 +581,12 @@ EOF
                 extra_metrics=$(echo "$data" | cut -d'|' -f3)
                 mem_op=$(echo "$data" | cut -d'|' -f4)
                 allocs_op=$(echo "$data" | cut -d'|' -f5)
-                echo "| $benchmark | $iterations | $time_op | $extra_metrics | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
+                if [[ "$previous_results_format" == "legacy_ops" ]]; then
+                    operations_sec="$extra_metrics"
+                    echo "| $benchmark | $operations_sec | $time_op | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
+                else
+                    echo "| $benchmark | $iterations | $time_op | $extra_metrics | $mem_op | $allocs_op |" >> "$OUTPUT_FILE.tmp"
+                fi
             done < <(list_previous_benchmarks)
         fi
 

--- a/generate_bp_pi_report.sh
+++ b/generate_bp_pi_report.sh
@@ -17,16 +17,19 @@ DEFAULT_DB_DIR="${DEFAULT_DB_DIR:-}"
 DEFAULT_LOG_FILE="${DEFAULT_LOG_FILE:-}"
 DB_DIR_BASE="${DB_DIR_BASE:-/tmp}"
 TMP_BENCH_FILE="$(mktemp)"
+TMP_BENCH_WITH_LOAD_FILE="$(mktemp)"
+TMP_LOAD_CHANGE_FILE="$(mktemp)"
 TIME_FORMAT_STYLE=""
 TIME_CMD=()
 AUTO_DEFAULT_DB_DIR=0
 AUTO_DEFAULT_LOG_FILE=0
 DINGO_CACHE_ARGS=()
+BENCHMARK_REPORT_TITLE="Four-Thread Block Producer Sizing Benchmark Results (Non-Pi Host)"
 
 cleanup() {
   local exit_status=$?
 
-  rm -f "$TMP_BENCH_FILE"
+  rm -f "$TMP_BENCH_FILE" "$TMP_BENCH_WITH_LOAD_FILE" "$TMP_LOAD_CHANGE_FILE"
   if [[ "$exit_status" -ne 0 ]]; then
     if [[ "$AUTO_DEFAULT_LOG_FILE" -eq 1 ]]; then
       printf 'preserving profile log for debugging: %s\n' \
@@ -242,6 +245,128 @@ parse_metric() {
   }'
 }
 
+extract_load_footprint() {
+  local report_file="$1"
+
+  awk -F'|' '
+    function trim(v) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+      return v
+    }
+    $0 == "## Load Footprint" {
+      in_load = 1
+      next
+    }
+    in_load && /^## / {
+      exit
+    }
+    in_load && /^\| `[^`]+` \|/ {
+      profile = trim($2)
+      elapsed = trim($3)
+      rss_mb = trim($4)
+      gsub(/`/, "", profile)
+      gsub(/`/, "", elapsed)
+      gsub(/`/, "", rss_mb)
+      sub(/s$/, "", elapsed)
+      sub(/[[:space:]]*MB$/, "", rss_mb)
+      printf "%s|%s|%s\n", profile, elapsed, rss_mb
+      exit
+    }
+  ' "$report_file"
+}
+
+prepare_previous_benchmark_report() {
+  local report_file="$1"
+
+  if [[ ! -f "$report_file" ]]; then
+    return 0
+  fi
+
+  awk -v title="# ${BENCHMARK_REPORT_TITLE}" '
+    found || $0 == title {
+      found = 1
+      print
+    }
+  ' "$report_file" > "$TMP_BENCH_FILE"
+}
+
+format_delta() {
+  local current="$1"
+  local previous="$2"
+  local unit="$3"
+
+  awk -v current="$current" -v previous="$previous" -v unit="$unit" '
+    BEGIN {
+      delta = current - previous
+      pct = previous == 0 ? 0 : (delta / previous) * 100
+      sign = delta > 0 ? "+" : ""
+      if (unit == "s") {
+        printf "%s%.2f%s (%s%.1f%%)", sign, delta, unit, sign, pct
+      } else {
+        printf "%s%.1f%s (%s%.1f%%)", sign, delta, unit, sign, pct
+      }
+    }
+  '
+}
+
+write_load_change_section() {
+  local previous_profile="$1"
+  local previous_elapsed="$2"
+  local previous_rss_mb="$3"
+  local current_profile="$4"
+  local current_elapsed="$5"
+  local current_rss_mb="$6"
+  local elapsed_delta
+  local rss_delta
+
+  elapsed_delta="$(format_delta "$current_elapsed" "$previous_elapsed" "s")"
+  rss_delta="$(format_delta "$current_rss_mb" "$previous_rss_mb" " MB")"
+
+  {
+    echo "### Load Footprint"
+    echo
+    echo "| Metric | Previous | Current | Change |"
+    echo "|--------|----------|---------|--------|"
+    printf -- "| Profile | \`%s\` | \`%s\` | - |\n" "$previous_profile" "$current_profile"
+    printf -- "| Elapsed | \`%ss\` | \`%ss\` | \`%s\` |\n" "$previous_elapsed" "$current_elapsed" "$elapsed_delta"
+    printf -- "| Peak RSS | \`%s MB\` | \`%s MB\` | \`%s\` |\n" "$previous_rss_mb" "$current_rss_mb" "$rss_delta"
+  } > "$TMP_LOAD_CHANGE_FILE"
+}
+
+insert_load_change_section() {
+  local previous_date="$1"
+
+  if [[ ! -s "$TMP_LOAD_CHANGE_FILE" ]]; then
+    return 0
+  fi
+
+  awk -v section_file="$TMP_LOAD_CHANGE_FILE" -v previous_date="$previous_date" '
+    function print_section(line) {
+      while ((getline line < section_file) > 0) {
+        print line
+      }
+      close(section_file)
+    }
+    /^Changes since \*\*/ && !inserted {
+      print
+      print ""
+      print_section()
+      inserted = 1
+      next
+    }
+    $0 == "No previous results found. This is the first benchmark run." && previous_date != "" && !inserted {
+      printf "Changes since **%s**:\n\n", previous_date
+      print_section()
+      inserted = 1
+      next
+    }
+    {
+      print
+    }
+  ' "$TMP_BENCH_FILE" > "$TMP_BENCH_WITH_LOAD_FILE"
+  mv "$TMP_BENCH_WITH_LOAD_FILE" "$TMP_BENCH_FILE"
+}
+
 configure_time_cmd
 
 if [[ -n "$BLOCK_CACHE_SIZE_VALUE" ]]; then
@@ -268,6 +393,15 @@ fi
 
 pushd "$ROOT_DIR" >/dev/null
 
+previous_load_line=""
+previous_load_date=""
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  previous_load_line="$(extract_load_footprint "$OUTPUT_FILE")"
+  previous_load_date="$(grep "\*\*Date\*\*:" "$OUTPUT_FILE" | head -1 | sed 's/.*\*\*Date\*\*: //' || echo "")"
+  prepare_previous_benchmark_report "$OUTPUT_FILE"
+fi
+
 env \
   GOCACHE="$CACHE_DIR" \
   GOMAXPROCS="$GOMAXPROCS_VALUE" \
@@ -277,7 +411,7 @@ env \
   --packages ./ledger \
   --bench 'Benchmark(BlockfetchNearTipThroughput|BlockfetchNearTipThroughputPredecoded|BlockfetchNearTipQueuedHeaderPredecoded|BlockfetchNearTipFlushOnlyPredecoded|VerifyBlockHeader)$' \
   --benchtime "$BENCH_TIME" \
-  --title "Four-Thread Block Producer Sizing Benchmark Results (Non-Pi Host)" \
+  --title "$BENCHMARK_REPORT_TITLE" \
   --scope "Four-thread block producer path (GOMAXPROCS=${GOMAXPROCS_VALUE}) in core mode on a non-Pi host" \
   --data-source "database/immutable/testdata plus local immutable load runs"
 
@@ -303,10 +437,25 @@ fi
 
 default_rss_mb="$(awk "BEGIN { printf \"%.1f\", ${default_rss_kb} / 1024 }")"
 rss_limit_kb=$((RSS_LIMIT_MB * 1024))
+load_profile="core-default"
+load_notes="Current default \`serve/core\` cache profile"
+
+if [[ -n "$BLOCK_CACHE_SIZE_VALUE" || -n "$INDEX_CACHE_SIZE_VALUE" || -n "$MEMTABLE_SIZE_VALUE" || -n "$GOMEMLIMIT_VALUE" ]]; then
+  load_profile="core-constrained"
+  load_notes="Explicit test-only memory/cache overrides"
+fi
 
 if (( default_rss_kb > rss_limit_kb )); then
   echo "error: peak RSS ${default_rss_mb} MB exceeds limit ${RSS_LIMIT_MB} MB" >&2
   exit 1
+fi
+
+if [[ -n "$previous_load_line" ]]; then
+  previous_profile="$(echo "$previous_load_line" | cut -d'|' -f1)"
+  previous_elapsed="$(echo "$previous_load_line" | cut -d'|' -f2)"
+  previous_rss_mb="$(echo "$previous_load_line" | cut -d'|' -f3)"
+  write_load_change_section "$previous_profile" "$previous_elapsed" "$previous_rss_mb" "$load_profile" "$default_elapsed" "$default_rss_mb"
+  insert_load_change_section "$previous_load_date"
 fi
 
 {
@@ -340,11 +489,7 @@ fi
   echo
   echo "| Profile | Elapsed | Peak RSS | Notes |"
   echo "| --- | --- | --- | --- |"
-  if [[ -n "$BLOCK_CACHE_SIZE_VALUE" || -n "$INDEX_CACHE_SIZE_VALUE" || -n "$MEMTABLE_SIZE_VALUE" || -n "$GOMEMLIMIT_VALUE" ]]; then
-    printf -- "| \`core-constrained\` | \`%ss\` | \`%s MB\` | Explicit test-only memory/cache overrides |\n" "$default_elapsed" "$default_rss_mb"
-  else
-    printf -- "| \`core-default\` | \`%ss\` | \`%s MB\` | Current default \`serve/core\` cache profile |\n" "$default_elapsed" "$default_rss_mb"
-  fi
+  printf -- "| \`%s\` | \`%ss\` | \`%s MB\` | %s |\n" "$load_profile" "$default_elapsed" "$default_rss_mb" "$load_notes"
   echo
   echo "## Recommendation"
   echo


### PR DESCRIPTION
Relates to #1802 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update benchmark docs with the June 12, 2026 runs on Go 1.26.1 and improve the report generators with a new “Load Footprint” delta section and legacy table-format support. Covers `connmanager` (new inbound peer address checks), `event`, database caches (LRU/tiered), ledger blockfetch/ingest/verify, integration backends (S3/disk/memory), and `sqlite` import; connects to Linear #1802 by refreshing baselines and enforcing a ≤1 GB RSS goal (current `core-default` at 713.4 MB).

- **New Features**
  - `generate_bp_pi_report.sh`: adds a “Load Footprint” table comparing elapsed and peak RSS to the previous run, detects `core-default` vs `core-constrained`, and validates a 1024 MB cap.
  - `generate_benchmarks.sh`: preserves historical formatting by detecting legacy ops/sec tables vs current iteration tables.
  - Bench docs: include new `connmanager` “Has Inbound Peer Address/*” and blockfetch queued-header predecoded benches; keep integration (S3/disk/memory) and `sqlite` import results up to date.

<sup>Written for commit 7df44d1570a5143f6420f050657ca1df5f9645bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance benchmark reports with latest test results from June 12, 2026 (Go 1.26.1).
  * Refined benchmark result formatting and metrics tracking across multiple test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->