### PR TITLE
perf(database): shard block lru cache

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -817,6 +817,12 @@ Tier 1: Hot Cache (in-memory)
 Tier 2: Block LRU Cache
   - Recently accessed blocks with pre-computed indexes
   - Fast extraction without blob store access
+  - Lock-striped: blocks are routed by hash to one of N independent
+    shards, each with its own mutex and LRU list, so concurrent lookups
+    for different blocks rarely contend. Shard count is derived from the
+    configured capacity (small caches use a single shard, preserving exact
+    global-LRU behavior). Eviction is per-shard; total occupancy never
+    exceeds the configured entry limit.
        | miss
        v
 Tier 3: Cold Extraction

--- a/database/block_lru_cache.go
+++ b/database/block_lru_cache.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"container/list"
+	"encoding/binary"
 	"sync"
 )
 
@@ -74,63 +75,103 @@ type cacheEntry struct {
 	block *CachedBlock
 }
 
-// BlockLRUCache is a thread-safe LRU cache for recently accessed blocks.
-// Blocks are keyed by (slot, hash) and evicted in LRU order when the cache
-// exceeds maxEntries.
-type BlockLRUCache struct {
+// Lock-striping parameters for BlockLRUCache. See
+// https://strebkov.dev/posts/shard-your-locks/ : a single mutex around a map +
+// LRU list scales backwards under concurrent access because Get itself mutates
+// the list (MoveToFront), so even reads serialize on one lock and its cache
+// line ping-pongs between cores. Splitting the cache into independent shards,
+// each with its own lock, drops contention by roughly the shard count.
+const (
+	// blockLRUMaxShards bounds the number of lock stripes. It is sized to
+	// exceed the realistic count of concurrent accessors (API request handlers
+	// plus the validation path) while keeping each shard's LRU large enough to
+	// be useful. The blog's shard sweep shows steeply diminishing returns once
+	// the stripe count comfortably exceeds the core/goroutine count, so there
+	// is no need to chase its 256 (which targeted a million-entry cache).
+	blockLRUMaxShards = 64
+
+	// blockLRUMinEntriesPerShard is the smallest per-shard capacity we are
+	// willing to create. Sharding splits one global LRU into N independent
+	// LRUs, so too-small shards would evict useful blocks and tank the hit
+	// rate. Below this threshold we use fewer shards (down to a single shard,
+	// which preserves exact global-LRU behavior and adds no overhead).
+	blockLRUMinEntriesPerShard = 16
+)
+
+// blockLRUShardCount picks a power-of-two shard count for a cache of the given
+// total capacity. Tiny caches get a single shard (exact global LRU, zero
+// sharding overhead); capacity is sharded only once each shard can still hold
+// at least blockLRUMinEntriesPerShard blocks, up to blockLRUMaxShards.
+func blockLRUShardCount(maxEntries int) int {
+	if maxEntries < 0 {
+		maxEntries = 0
+	}
+	n := 1
+	for n < blockLRUMaxShards && maxEntries/(n*2) >= blockLRUMinEntriesPerShard {
+		n *= 2
+	}
+	return n
+}
+
+// blockLRUShardCapacities splits maxEntries across shardCount shards so the
+// per-shard capacities sum to exactly maxEntries (the cache as a whole never
+// holds more than maxEntries blocks). The remainder is spread one-per-shard
+// across the leading shards, keeping all shards within one entry of each other.
+func blockLRUShardCapacities(maxEntries, shardCount int) []int {
+	if maxEntries < 0 {
+		maxEntries = 0
+	}
+	capacities := make([]int, shardCount)
+	base := maxEntries / shardCount
+	rem := maxEntries % shardCount
+	for i := range capacities {
+		capacities[i] = base
+		if i < rem {
+			capacities[i]++
+		}
+	}
+	return capacities
+}
+
+// blockLRUShard is a single lock stripe: an independent map + LRU list guarded
+// by its own mutex. Shards are heap-allocated separately (the parent holds
+// pointers) so adjacent shards' mutexes do not share a cache line, avoiding
+// false sharing when different shards are locked concurrently.
+type blockLRUShard struct {
 	mu         sync.Mutex
 	maxEntries int
 	cache      map[blockKey]*list.Element
 	lruList    *list.List
 }
 
-// NewBlockLRUCache creates a new BlockLRUCache with the specified maximum
-// number of entries. If maxEntries is negative, it is treated as zero
-// (cache disabled).
-func NewBlockLRUCache(maxEntries int) *BlockLRUCache {
-	if maxEntries < 0 {
-		maxEntries = 0
-	}
-	return &BlockLRUCache{
-		maxEntries: maxEntries,
-		cache:      make(map[blockKey]*list.Element),
-		lruList:    list.New(),
-	}
-}
+// get retrieves a block from the shard, moving it to the front of the shard's
+// LRU list on a hit.
+func (s *blockLRUShard) get(key blockKey) (*CachedBlock, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-// Get retrieves a cached block by slot and hash.
-// Returns the block and true if found, or nil and false if not found.
-// Accessing a block moves it to the front of the LRU list.
-func (c *BlockLRUCache) Get(slot uint64, hash [32]byte) (*CachedBlock, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	key := blockKey{slot: slot, hash: hash}
-	elem, ok := c.cache[key]
+	elem, ok := s.cache[key]
 	if !ok {
 		return nil, false
 	}
 
 	// Move to front (most recently used)
-	c.lruList.MoveToFront(elem)
+	s.lruList.MoveToFront(elem)
 
 	entry := elem.Value.(*cacheEntry)
 	return entry.block, true
 }
 
-// Put adds or updates a block in the cache.
-// The block is moved to the front of the LRU list.
-// If the cache exceeds maxEntries, the least recently used block is evicted.
-func (c *BlockLRUCache) Put(slot uint64, hash [32]byte, block *CachedBlock) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	key := blockKey{slot: slot, hash: hash}
+// put adds or updates a block in the shard, evicting the least recently used
+// entry if the shard is over capacity.
+func (s *blockLRUShard) put(key blockKey, block *CachedBlock) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	// Check if entry already exists
-	if elem, ok := c.cache[key]; ok {
+	if elem, ok := s.cache[key]; ok {
 		// Update existing entry
-		c.lruList.MoveToFront(elem)
+		s.lruList.MoveToFront(elem)
 		entry := elem.Value.(*cacheEntry)
 		entry.block = block
 		return
@@ -138,24 +179,87 @@ func (c *BlockLRUCache) Put(slot uint64, hash [32]byte, block *CachedBlock) {
 
 	// Add new entry
 	entry := &cacheEntry{key: key, block: block}
-	elem := c.lruList.PushFront(entry)
-	c.cache[key] = elem
+	elem := s.lruList.PushFront(entry)
+	s.cache[key] = elem
 
 	// Evict if over capacity
-	for c.lruList.Len() > c.maxEntries {
-		c.evictOldest()
+	for s.lruList.Len() > s.maxEntries {
+		s.evictOldest()
 	}
 }
 
-// evictOldest removes the least recently used entry from the cache.
-// Must be called with the mutex held.
-func (c *BlockLRUCache) evictOldest() {
-	elem := c.lruList.Back()
+// evictOldest removes the least recently used entry from the shard.
+// Must be called with the shard mutex held.
+func (s *blockLRUShard) evictOldest() {
+	elem := s.lruList.Back()
 	if elem == nil {
 		return
 	}
 
 	entry := elem.Value.(*cacheEntry)
-	delete(c.cache, entry.key)
-	c.lruList.Remove(elem)
+	delete(s.cache, entry.key)
+	s.lruList.Remove(elem)
+}
+
+// BlockLRUCache is a thread-safe, lock-striped LRU cache for recently accessed
+// blocks. Blocks are keyed by (slot, hash) and routed to one of N independent
+// shards by the block hash, so operations on different blocks rarely contend on
+// the same lock. Each shard maintains its own LRU list and capacity; eviction
+// is therefore per-shard rather than strictly global (the standard trade-off
+// for a sharded cache). The total number of cached blocks never exceeds the
+// configured maxEntries.
+type BlockLRUCache struct {
+	shardMask uint64
+	shards    []*blockLRUShard
+}
+
+// NewBlockLRUCache creates a new BlockLRUCache with the specified maximum
+// number of entries. If maxEntries is negative, it is treated as zero
+// (cache disabled). The cache transparently shards its internal storage to
+// reduce lock contention; the shard count is derived from maxEntries (small
+// caches use a single shard, preserving exact global-LRU behavior).
+func NewBlockLRUCache(maxEntries int) *BlockLRUCache {
+	if maxEntries < 0 {
+		maxEntries = 0
+	}
+	shardCount := blockLRUShardCount(maxEntries)
+	capacities := blockLRUShardCapacities(maxEntries, shardCount)
+	shards := make([]*blockLRUShard, shardCount)
+	for i := range shards {
+		shards[i] = &blockLRUShard{
+			maxEntries: capacities[i],
+			cache:      make(map[blockKey]*list.Element),
+			lruList:    list.New(),
+		}
+	}
+	return &BlockLRUCache{
+		// shardCount is always a positive power of two (>=1), so shardCount-1
+		// is non-negative and fits in uint64.
+		shardMask: uint64(shardCount - 1), //nolint:gosec // shardCount >= 1
+		shards:    shards,
+	}
+}
+
+// shardFor selects the shard for a block hash. The hash is a uniformly
+// distributed cryptographic digest, so its low bits make a good shard index
+// with no additional hashing. shardMask is shardCount-1 (shardCount is always a
+// power of two), so this masks rather than divides.
+func (c *BlockLRUCache) shardFor(hash [32]byte) *blockLRUShard {
+	idx := binary.LittleEndian.Uint64(hash[:8]) & c.shardMask
+	return c.shards[idx]
+}
+
+// Get retrieves a cached block by slot and hash.
+// Returns the block and true if found, or nil and false if not found.
+// Accessing a block moves it to the front of its shard's LRU list.
+func (c *BlockLRUCache) Get(slot uint64, hash [32]byte) (*CachedBlock, bool) {
+	return c.shardFor(hash).get(blockKey{slot: slot, hash: hash})
+}
+
+// Put adds or updates a block in the cache.
+// The block is moved to the front of its shard's LRU list.
+// If the shard exceeds its capacity, the least recently used block in that
+// shard is evicted.
+func (c *BlockLRUCache) Put(slot uint64, hash [32]byte, block *CachedBlock) {
+	c.shardFor(hash).put(blockKey{slot: slot, hash: hash}, block)
 }

--- a/database/block_lru_cache_parallel_bench_test.go
+++ b/database/block_lru_cache_parallel_bench_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// benchBlockKeyHash builds a 32-byte block hash whose leading bytes encode the
+// given index. The leading bytes drive shard selection, so encoding the index
+// here spreads the working set uniformly across shards once the cache is
+// sharded.
+func benchBlockKeyHash(idx int) [32]byte {
+	var h [32]byte
+	binary.LittleEndian.PutUint64(h[:8], uint64(idx))
+	return h
+}
+
+// benchmarkBlockLRUParallel exercises the cache from many goroutines over a
+// working set that fits within capacity (so reads hit). It mirrors the
+// methodology of https://strebkov.dev/posts/shard-your-locks/ : a fixed key
+// space hammered concurrently, with a tunable read/write mix. Note that the
+// hot path Get also mutates the LRU ordering (MoveToFront), so even reads
+// contend on the lock — the case where a single mutex scales backwards.
+//
+// Run with -cpu=1,4,8 to see the scaling curve.
+func benchmarkBlockLRUParallel(b *testing.B, workingSet int, writeEvery int) {
+	cache := NewBlockLRUCache(workingSet)
+
+	// Pre-populate the full working set so reads are hits.
+	for i := range workingSet {
+		cache.Put(uint64(i), benchBlockKeyHash(i), &CachedBlock{
+			RawBytes: make([]byte, 256),
+		})
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Per-goroutine counter avoids shared RNG state; the stride keeps
+		// successive ops landing on different keys/shards.
+		i := 0
+		for pb.Next() {
+			idx := (i * 2654435761) % workingSet
+			if idx < 0 {
+				idx += workingSet
+			}
+			slot := uint64(idx)
+			hash := benchBlockKeyHash(idx)
+			if writeEvery > 0 && i%writeEvery == 0 {
+				cache.Put(slot, hash, &CachedBlock{RawBytes: make([]byte, 256)})
+			} else {
+				cache.Get(slot, hash)
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkBlockLRUParallelReadHeavy is ~90% Get / ~10% Put.
+func BenchmarkBlockLRUParallelReadHeavy(b *testing.B) {
+	benchmarkBlockLRUParallel(b, 500, 10)
+}
+
+// BenchmarkBlockLRUParallelBalanced is ~50% Get / ~50% Put.
+func BenchmarkBlockLRUParallelBalanced(b *testing.B) {
+	benchmarkBlockLRUParallel(b, 500, 2)
+}
+
+// BenchmarkBlockLRUParallelReadOnly is pure Get (still mutates LRU order).
+func BenchmarkBlockLRUParallelReadOnly(b *testing.B) {
+	benchmarkBlockLRUParallel(b, 500, 0)
+}

--- a/database/block_lru_cache_shard_test.go
+++ b/database/block_lru_cache_shard_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"math/bits"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockLRUShardCount(t *testing.T) {
+	tests := []struct {
+		maxEntries int
+		want       int
+	}{
+		// Small caches stay single-shard so global-LRU semantics are exact.
+		{maxEntries: -5, want: 1},
+		{maxEntries: 0, want: 1},
+		{maxEntries: 1, want: 1},
+		{maxEntries: 3, want: 1},
+		{maxEntries: blockLRUMinEntriesPerShard, want: 1},
+		// Once capacity comfortably exceeds the per-shard minimum, shard.
+		{maxEntries: 32, want: 2},
+		{maxEntries: 100, want: 4},
+		{maxEntries: 500, want: 16}, // production default
+		// Large caches saturate at the shard cap.
+		{maxEntries: 100000, want: blockLRUMaxShards},
+	}
+	for _, tt := range tests {
+		got := blockLRUShardCount(tt.maxEntries)
+		assert.Equal(
+			t,
+			tt.want,
+			got,
+			"blockLRUShardCount(%d)",
+			tt.maxEntries,
+		)
+		// Must always be a power of two and at least 1.
+		require.GreaterOrEqual(t, got, 1)
+		assert.Equal(
+			t,
+			1,
+			bits.OnesCount(uint(got)),
+			"shard count %d must be a power of two",
+			got,
+		)
+		assert.LessOrEqual(t, got, blockLRUMaxShards)
+	}
+}
+
+func TestBlockLRUShardCapacities(t *testing.T) {
+	tests := []struct {
+		maxEntries int
+		shardCount int
+	}{
+		{maxEntries: 0, shardCount: 1},
+		{maxEntries: 3, shardCount: 1},
+		{maxEntries: 500, shardCount: 16},
+		{maxEntries: 501, shardCount: 16}, // not evenly divisible
+		{maxEntries: 1000, shardCount: 64},
+	}
+	for _, tt := range tests {
+		caps := blockLRUShardCapacities(tt.maxEntries, tt.shardCount)
+
+		// One capacity per shard.
+		require.Len(t, caps, tt.shardCount)
+
+		// The per-shard capacities must sum to exactly the requested total,
+		// so the sharded cache never holds more than maxEntries blocks.
+		sum := 0
+		minCap, maxCap := caps[0], caps[0]
+		for _, c := range caps {
+			assert.GreaterOrEqual(t, c, 0)
+			sum += c
+			minCap = min(minCap, c)
+			maxCap = max(maxCap, c)
+		}
+		assert.Equal(
+			t,
+			tt.maxEntries,
+			sum,
+			"capacities must sum to maxEntries (%d across %d shards)",
+			tt.maxEntries,
+			tt.shardCount,
+		)
+
+		// Distribution must be even to within one entry per shard.
+		assert.LessOrEqual(
+			t,
+			maxCap-minCap,
+			1,
+			"capacities must be balanced within 1 entry",
+		)
+	}
+}
+
+// totalEntries counts cached blocks across all shards (white-box helper).
+func (c *BlockLRUCache) totalEntries() int {
+	n := 0
+	for _, s := range c.shards {
+		s.mu.Lock()
+		n += len(s.cache)
+		s.mu.Unlock()
+	}
+	return n
+}
+
+func TestBlockLRUCacheShardsScaleWithCapacity(t *testing.T) {
+	// Small caches stay single-shard (exact global LRU, no overhead).
+	assert.Len(t, NewBlockLRUCache(3).shards, 1)
+	// The production default capacity shards.
+	assert.Len(t, NewBlockLRUCache(500).shards, 16)
+}
+
+func TestBlockLRUCacheTotalCapacityBounded(t *testing.T) {
+	const maxEntries = 500
+	cache := NewBlockLRUCache(maxEntries)
+
+	// Flood with far more distinct keys than capacity, spread across shards.
+	for i := range maxEntries * 20 {
+		cache.Put(uint64(i), benchBlockKeyHash(i), &CachedBlock{
+			RawBytes: []byte{byte(i)},
+		})
+	}
+
+	// Sharding makes eviction per-shard, but the aggregate must never exceed
+	// the configured capacity.
+	assert.LessOrEqual(
+		t,
+		cache.totalEntries(),
+		maxEntries,
+		"total cached blocks must not exceed maxEntries",
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shard the block LRU cache by hash to reduce lock contention and improve parallel throughput. Small caches stay single-shard to preserve exact global LRU; total capacity remains bounded.

- **Refactors**
  - Implemented lock-striped, sharded `BlockLRUCache`; shard count is capacity-driven (power-of-two), capped at 64, and keeps ≥16 entries per shard; small caches remain single-shard.
  - Split `maxEntries` across shards so capacities differ by at most 1 and sum to `maxEntries`; eviction is per-shard while the aggregate never exceeds the limit.
  - Added shard/count/capacity unit tests, parallel read/write benchmarks, and `ARCHITECTURE.md` notes documenting the design.

<sup>Written for commit 5df8fce88157896d6f72ff0f7fad7cba222bc54a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

