### PR TITLE
ci(examples): automatic dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/examples/dingo-gov-lens"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/examples/dingo-blockfrost-explorer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/examples/dingo-sundae-preview"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable automatic Dependabot updates for example apps so Go and npm dependencies stay current. Adds coverage for three example directories.

- **Dependencies**
  - Add `gomod` updates for `/examples/dingo-gov-lens`
  - Add `npm` updates for `/examples/dingo-blockfrost-explorer`
  - Add `npm` updates for `/examples/dingo-sundae-preview`

<sup>Written for commit 03a25223fdc7c3ab674b7063034c5e56c3144186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

