### PR TITLE
fix(peergov): skip log is edge triggered

### DIFF
--- a/peergov/churn.go
+++ b/peergov/churn.go
@@ -33,6 +33,10 @@ func (p *PeerGovernor) gossipChurn() {
 			(peer.Source == PeerSourceP2PGossip || peer.Source == PeerSourceP2PLedger)
 	})
 	if len(hotNonRoot) == 0 {
+		// No non-root hot peers means the single-upstream skip below
+		// cannot fire this cycle; clear the edge-trigger so a later
+		// entry into the degraded state logs again.
+		p.lastEligibleUpstreamSkipLogged = false
 		p.mu.Unlock()
 		return
 	}
@@ -64,6 +68,8 @@ func (p *PeerGovernor) gossipChurn() {
 	// Demote the lowest-scoring peers
 	demoted := 0
 	eligibleUpstreams := p.countEligibleUpstreamsLocked()
+	skippedLastEligibleUpstream := false
+	skippedUpstreamAddress := ""
 	for i := 0; i < len(hotNonRoot) && demoted < churnCount; i++ {
 		peer := hotNonRoot[i]
 		targetState, canDemote := p.demotionTarget(peer.Source)
@@ -78,12 +84,13 @@ func (p *PeerGovernor) gossipChurn() {
 			).eligible
 		// Never close the node's last eligible upstream connection.
 		// Demoting it to cold would leave the node with no chainsync
-		// source until the reconcile redial path recovers it.
+		// source until the reconcile redial path recovers it. This
+		// condition persists for as long as the node has a single
+		// eligible upstream, so the operator-facing log is emitted only
+		// on entry (rising edge) after the loop, not on every cycle.
 		if demotionRemovesEligibleUpstream && eligibleUpstreams <= 1 {
-			p.config.Logger.Info(
-				"gossip churn: skipping demotion of last eligible upstream peer",
-				"address", peer.Address,
-			)
+			skippedLastEligibleUpstream = true
+			skippedUpstreamAddress = peer.Address
 			continue
 		}
 		oldSource := peer.Source
@@ -150,6 +157,22 @@ func (p *PeerGovernor) gossipChurn() {
 				Reason:   "gossip churn",
 			},
 		})
+	}
+
+	// Edge-triggered logging for the single-upstream skip: emit the INFO
+	// line only when entering the degraded state, then stay quiet until it
+	// clears. Without this, the message repeats every GossipChurnInterval
+	// for as long as the node has a single eligible upstream.
+	if skippedLastEligibleUpstream {
+		if !p.lastEligibleUpstreamSkipLogged {
+			p.config.Logger.Info(
+				"gossip churn: skipping demotion of last eligible upstream peer",
+				"address", skippedUpstreamAddress,
+			)
+			p.lastEligibleUpstreamSkipLogged = true
+		}
+	} else {
+		p.lastEligibleUpstreamSkipLogged = false
 	}
 
 	// Now promote warm peers to fill slots

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -114,7 +114,13 @@ type PeerGovernor struct {
 	bootstrapExited       bool                // Whether bootstrap peers have been exited
 	lastBootstrapExit     time.Time           // Timestamp of most recent bootstrap exit
 	inboundPruned         int                 // cumulative inbound prunes since start
-	mu                    sync.Mutex
+	// lastEligibleUpstreamSkipLogged edge-triggers the gossip-churn log
+	// that fires when the node is down to its last eligible upstream. The
+	// condition persists across churn intervals, so the INFO line is
+	// emitted only on entry (rising edge) to avoid indefinite log spam.
+	// Guarded by mu.
+	lastEligibleUpstreamSkipLogged bool
+	mu                             sync.Mutex
 }
 
 type PeerGovernorConfig struct {

--- a/peergov/recovery_test.go
+++ b/peergov/recovery_test.go
@@ -15,8 +15,10 @@
 package peergov
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +61,47 @@ func TestPeerGovernor_GossipChurn_SkipsLastEligibleUpstream(t *testing.T) {
 		pg.peers[0].Connection,
 		"last eligible upstream connection must stay open",
 	)
+}
+
+// When the node is reduced to a single eligible upstream, gossip churn
+// skips demoting it on every interval. The skip itself is correct, but the
+// condition persists, so the INFO line must be emitted only on entry into
+// that state, not on every churn cycle, otherwise it spams the log
+// indefinitely (observed once every GossipChurnInterval).
+func TestPeerGovernor_GossipChurn_LastEligibleUpstreamSkipLogThrottled(
+	t *testing.T,
+) {
+	var logBuf bytes.Buffer
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(&logBuf, nil)),
+		EventBus:           newMockEventBus(),
+		GossipChurnPercent: 1.0,
+		MinScoreThreshold:  0.3,
+	})
+	pg.peers = []*Peer{
+		{
+			Address:          "gossip1:3001",
+			Source:           PeerSourceP2PGossip,
+			State:            PeerStateHot,
+			PerformanceScore: 0.5,
+			Connection:       &PeerConnection{IsClient: true},
+		},
+	}
+
+	const skipMsg = "skipping demotion of last eligible upstream peer"
+	for range 5 {
+		pg.gossipChurn()
+	}
+
+	if got := strings.Count(logBuf.String(), skipMsg); got != 1 {
+		t.Fatalf(
+			"skip log emitted %d times across 5 churn cycles, want 1 (on entry only)",
+			got,
+		)
+	}
+	// Behavior must be unchanged: the last upstream is still protected.
+	assert.Equal(t, PeerStateHot, pg.peers[0].State)
+	assert.NotNil(t, pg.peers[0].Connection)
 }
 
 func TestPeerGovernor_GossipChurn_KeepsOneUpstreamWhenChurningAll(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the “last eligible upstream” skip log in `peergov` edge‑triggered so it logs once on entry, not every churn interval. This removes log spam without changing churn behavior.

- **Bug Fixes**
  - Log the skip once when entering the single-eligible-upstream state; suppress repeats until the state clears.
  - Added `lastEligibleUpstreamSkipLogged` (guarded by `mu`) to track the edge; reset when the condition clears or when there are no hot non-root peers.
  - Emitted the log after the churn loop using a local flag to detect a skip.
  - Added a test to assert the log appears once across multiple churn cycles and that the last upstream remains protected.

<sup>Written for commit 83551f3854d0108b8b87043d26ee7ac8da758600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

