### PR TITLE
fix(mithril): progress log

### DIFF
--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -641,8 +641,20 @@ func downloadImmutables(
 	}
 
 	totalArchives := artifact.Beacon.ImmutableFileNumber + 1
+	// Progress denominator must be the immutable-only uncompressed size,
+	// not TotalDbSizeUncompressed. The latter covers the whole database
+	// (immutable archives plus the ancillary ledger state), but this pool
+	// downloads only the immutable archives — the ancillary archive runs
+	// concurrently and reports its own progress. Using the whole-DB size
+	// here would cap immutable progress below 100%. Fall back to the
+	// whole-DB size only when the per-file average is unavailable.
+	immutableTotalBytes := artifact.Immutables.AverageSizeUncompressed *
+		int64(totalArchives) // #nosec G115 -- archive count, non-negative
+	if immutableTotalBytes <= 0 {
+		immutableTotalBytes = artifact.TotalDbSizeUncompressed
+	}
 	onArchiveDone := newImmutableProgress(
-		cfg, totalArchives, artifact.TotalDbSizeUncompressed,
+		cfg, totalArchives, immutableTotalBytes,
 	)
 	// Per-archive extraction is too chatty for the main log at
 	// mainnet scale (tens of thousands of archives); aggregate
@@ -743,12 +755,30 @@ func newImmutableProgress(
 		defer mu.Unlock()
 		doneArchives++
 		doneBytes += bytesAdded
-		percent := float64(doneArchives) / float64(totalArchives) * 100
+		// Archive-count fraction drives the per-archive log line and its
+		// throttle below. Archives vary in size, so this does NOT equal
+		// the byte fraction reported to OnProgress.
+		archivePercent := float64(doneArchives) / float64(totalArchives) * 100
 		if cfg.OnProgress != nil {
 			var speed float64
 			if elapsed := time.Since(start).Seconds(); elapsed > 0 {
 				speed = float64(doneBytes) / elapsed
 			}
+			// Report a byte-based percent so Percent stays consistent
+			// with the BytesDownloaded/TotalBytes pair it is emitted
+			// alongside. Using the archive-count fraction here produced a
+			// percentage that disagreed with the bytes (e.g. "45.3%
+			// (8.2 GB / 14.2 GB)", where 8.2/14.2 is 57.7%). Fall back to
+			// the archive-count fraction only when the total size is
+			// unknown.
+			percent := pctOf(doneBytes, totalBytes)
+			if totalBytes <= 0 {
+				percent = archivePercent
+			}
+			// The total is estimated from the per-file average, so the
+			// accumulated bytes can marginally overshoot it on the final
+			// archive. Clamp so the reported percent never exceeds 100.
+			percent = min(percent, 100)
 			cfg.OnProgress(DownloadProgress{
 				BytesDownloaded: doneBytes,
 				TotalBytes:      totalBytes,
@@ -759,7 +789,7 @@ func newImmutableProgress(
 		now := time.Now()
 		if !lastLog.IsZero() &&
 			now.Sub(lastLog) < 10*time.Second &&
-			percent-lastLoggedPercent < 5.0 &&
+			archivePercent-lastLoggedPercent < 5.0 &&
 			doneArchives != totalArchives {
 			return
 		}
@@ -768,12 +798,12 @@ func newImmutableProgress(
 				"immutable archives: %d/%d (%.1f%%)",
 				doneArchives,
 				totalArchives,
-				percent,
+				archivePercent,
 			),
 			"component", "mithril",
 		)
 		lastLog = now
-		lastLoggedPercent = percent
+		lastLoggedPercent = archivePercent
 	}
 }
 

--- a/mithril/progress_test.go
+++ b/mithril/progress_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mithril
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewImmutableProgressByteBased verifies the percent reported to
+// OnProgress tracks bytes (consistent with the BytesDownloaded/TotalBytes
+// pair) rather than the archive count. The archive-count fraction
+// previously disagreed with the byte counts logged alongside it, producing
+// lines like "45.3% (8.2 GB / 14.2 GB)" where 8.2/14.2 is 57.7%.
+func TestNewImmutableProgressByteBased(t *testing.T) {
+	var last DownloadProgress
+	cfg := BootstrapConfig{
+		Logger:     slog.New(slog.DiscardHandler),
+		OnProgress: func(p DownloadProgress) { last = p },
+	}
+	// 4 archives of uneven size summing to 1000 bytes.
+	const totalArchives = 4
+	const totalBytes = 1000
+	onDone := newImmutableProgress(cfg, totalArchives, totalBytes)
+
+	// 1 of 4 archives carrying 100 of 1000 bytes: archive-count fraction
+	// is 25%, but the byte fraction is 10%. The reported percent must be
+	// the byte fraction so it agrees with BytesDownloaded/TotalBytes.
+	onDone(100)
+	assert.Equal(t, int64(100), last.BytesDownloaded)
+	assert.Equal(t, int64(totalBytes), last.TotalBytes)
+	assert.InDelta(t, 10.0, last.Percent, 0.001,
+		"percent must track bytes (10%%), not archive count (25%%)")
+
+	// Completing all archives reaches the denominator and 100%.
+	onDone(200)
+	onDone(300)
+	onDone(400)
+	assert.Equal(t, int64(1000), last.BytesDownloaded)
+	assert.InDelta(t, 100.0, last.Percent, 0.001)
+}
+
+// TestNewImmutableProgressClamp verifies the byte-percent is clamped to 100
+// when accumulated bytes overshoot the estimated (average-derived) total.
+func TestNewImmutableProgressClamp(t *testing.T) {
+	var last DownloadProgress
+	cfg := BootstrapConfig{
+		Logger:     slog.New(slog.DiscardHandler),
+		OnProgress: func(p DownloadProgress) { last = p },
+	}
+	onDone := newImmutableProgress(cfg, 2, 300) // estimated total 300
+	onDone(200)
+	onDone(200) // actual 400 > estimated 300
+	assert.LessOrEqual(t, last.Percent, 100.0)
+	assert.InDelta(t, 100.0, last.Percent, 0.001)
+}
+
+// TestNewImmutableProgressUnknownTotalFallback verifies that when the total
+// size is unavailable the percent falls back to the archive-count fraction.
+func TestNewImmutableProgressUnknownTotalFallback(t *testing.T) {
+	var last DownloadProgress
+	cfg := BootstrapConfig{
+		Logger:     slog.New(slog.DiscardHandler),
+		OnProgress: func(p DownloadProgress) { last = p },
+	}
+	onDone := newImmutableProgress(cfg, 4, 0) // total unknown
+	onDone(123)
+	assert.InDelta(t, 25.0, last.Percent, 0.001,
+		"with unknown total, percent falls back to archive count")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes progress reporting during `mithril` v2 bootstrap for immutable archive downloads. The percent now reflects bytes, uses the correct total size, and reaches 100% with clearer logs.

- **Bug Fixes**
  - Use immutable-only uncompressed size for the total; fallback to the whole DB size if the per-archive average is unavailable.
  - Report percent based on bytes so it matches BytesDownloaded/TotalBytes; fallback to archive count when total is unknown; clamp to 100%.
  - Keep per-archive log lines and throttling based on archive-count fraction to avoid noisy output.
  - Add tests for byte-based percent, clamping, and unknown-total fallback.

<sup>Written for commit d9aa10fd0b811595231226c2119de2031fefdc6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

