### PR TITLE
feat: chain validation using checkpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -912,6 +912,10 @@ The experimental N2N Leios protocols (`Config.experimentalLeiosNetworkingEnabled
 
 During accepted block replay, Alonzo-and-newer validation runs the UTXO/Phase 1 rule set and keeps declared ExUnit limit checks. Plutus Phase 2 execution is skipped only for blocks at or before the immutable tip (`tipBlockNo - securityParam`), where the block producer's `isValid` flag is treated as authoritative until the local Plutus VM is consensus-equivalent. Volatile block replay, local transaction validation for mempool submission, and forging continue to run Plutus execution.
 
+### Checkpoint Enforcement
+
+When a network config supplies a `CheckpointsFile` (mainnet and preview ship one), `config/cardano` verifies its `CheckpointsFileHash` and loads it into a block-number to block-hash map, exposed via `CardanoNodeConfig.Checkpoints()`. `LedgerState` caches the map at construction, and `ledgerProcessBlock` (`ledger/state.go`) rejects any inbound block whose height matches a checkpoint but whose hash differs, in every validation mode, before header or transaction validation runs. This is an envelope-validity guard against following a chain that diverges from the known-good chain at a checkpointed height; honest chains always agree with the shipped checkpoints, so the rule never rejects a canonical block. Byron epoch boundary blocks share the preceding block's number and are skipped to avoid a false mismatch.
+
 ### Block Header Validation
 
 `ledger/verify_header.go` performs cryptographic validation of block headers:

--- a/config/cardano/checkpoints.go
+++ b/config/cardano/checkpoints.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// checkpointEntry is a single block-number -> block-hash checkpoint as
+// stored in the CheckpointsFile JSON.
+type checkpointEntry struct {
+	BlockNo uint64 `json:"blockNo"`
+	Hash    string `json:"hash"`
+}
+
+// checkpointsFile mirrors the on-disk layout of the checkpoints JSON:
+// {"checkpoints": [{"blockNo": N, "hash": "..."}]}
+type checkpointsFile struct {
+	Checkpoints []checkpointEntry `json:"checkpoints"`
+}
+
+// blake2b256Hex returns the lower-case hex blake2b-256 hash of data,
+// matching the encoding used for CheckpointsFileHash and block hashes.
+func blake2b256Hex(data []byte) string {
+	return lcommon.Blake2b256Hash(data).String()
+}
+
+func isHexString(value string) bool {
+	for _, r := range value {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// parseCheckpoints decodes a checkpoints file into a map keyed by block
+// number with lower-case hex block hashes as values. When expectedHash
+// is non-empty, the blake2b-256 hash of data is verified against it
+// first, failing closed on mismatch. Conflicting duplicate entries for
+// the same block number are rejected.
+func parseCheckpoints(
+	data []byte,
+	expectedHash string,
+) (map[uint64]string, error) {
+	if expectedHash != "" {
+		actual := blake2b256Hex(data)
+		if !strings.EqualFold(actual, expectedHash) {
+			return nil, fmt.Errorf(
+				"checkpoints file hash mismatch: expected %s, computed %s",
+				expectedHash,
+				actual,
+			)
+		}
+	}
+	var parsed checkpointsFile
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("parse checkpoints: %w", err)
+	}
+	out := make(map[uint64]string, len(parsed.Checkpoints))
+	for _, entry := range parsed.Checkpoints {
+		hash := strings.ToLower(strings.TrimSpace(entry.Hash))
+		if hash == "" {
+			return nil, fmt.Errorf(
+				"checkpoint for block %d has empty hash",
+				entry.BlockNo,
+			)
+		}
+		if !isHexString(hash) {
+			return nil, fmt.Errorf(
+				"checkpoint for block %d has non-hex hash %q",
+				entry.BlockNo,
+				entry.Hash,
+			)
+		}
+		if existing, ok := out[entry.BlockNo]; ok && existing != hash {
+			return nil, fmt.Errorf(
+				"conflicting checkpoint for block %d: %s vs %s",
+				entry.BlockNo,
+				existing,
+				hash,
+			)
+		}
+		out[entry.BlockNo] = hash
+	}
+	return out, nil
+}
+
+// Checkpoints returns the parsed chain checkpoints keyed by block number
+// (height). It is nil when no CheckpointsFile is configured.
+func (c *CardanoNodeConfig) Checkpoints() map[uint64]string {
+	return c.checkpoints
+}
+
+// loadCheckpoints loads and validates the CheckpointsFile from the
+// regular filesystem, relative to the config directory when not absolute.
+func (c *CardanoNodeConfig) loadCheckpoints() error {
+	if c.CheckpointsFile == "" {
+		return nil
+	}
+	data, err := c.loadOptionalConfigFile(c.CheckpointsFile)
+	if err != nil {
+		return err
+	}
+	cps, err := parseCheckpoints(
+		replaceGenesisLineEndings(data),
+		c.CheckpointsFileHash,
+	)
+	if err != nil {
+		return err
+	}
+	c.checkpoints = cps
+	return nil
+}
+
+// loadCheckpointsFromEmbed loads and validates the CheckpointsFile from
+// the embedded filesystem.
+func (c *CardanoNodeConfig) loadCheckpointsFromEmbed() error {
+	if c.CheckpointsFile == "" {
+		return nil
+	}
+	data, err := c.loadOptionalConfigFileFromEmbedFS(c.CheckpointsFile)
+	if err != nil {
+		return err
+	}
+	cps, err := parseCheckpoints(
+		replaceGenesisLineEndings(data),
+		c.CheckpointsFileHash,
+	)
+	if err != nil {
+		return err
+	}
+	c.checkpoints = cps
+	return nil
+}

--- a/config/cardano/checkpoints_test.go
+++ b/config/cardano/checkpoints_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCardanoNodeConfigLoadsCheckpoints(t *testing.T) {
+	cfg, err := NewCardanoNodeConfigFromFile(
+		filepath.Join(testDataDir, "config.json"),
+	)
+	require.NoError(t, err)
+	cps := cfg.Checkpoints()
+	require.NotNil(t, cps)
+	require.Len(t, cps, 401)
+	// First entry from testdata/checkpoints.json.
+	require.Equal(
+		t,
+		"3e065fa887f09f5d1275f7d2c42b3a92d74e53535244aff5dd500f8968e3ee5e",
+		cps[3788847],
+	)
+}
+
+func TestParseCheckpointsNormalizesHashCase(t *testing.T) {
+	data := []byte(
+		`{"checkpoints":[{"blockNo":1,"hash":"AABB"},{"blockNo":2,"hash":"ccdd"}]}`,
+	)
+	cps, err := parseCheckpoints(data, "")
+	require.NoError(t, err)
+	require.Equal(t, "aabb", cps[1])
+	require.Equal(t, "ccdd", cps[2])
+}
+
+func TestParseCheckpointsRejectsInvalidHash(t *testing.T) {
+	tests := []struct {
+		name        string
+		hash        string
+		errContains string
+	}{
+		{
+			name:        "empty",
+			hash:        " ",
+			errContains: "empty hash",
+		},
+		{
+			name:        "non-hex",
+			hash:        "00xz",
+			errContains: "non-hex hash",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(
+				`{"checkpoints":[{"blockNo":1,"hash":"` + tt.hash + `"}]}`,
+			)
+			_, err := parseCheckpoints(data, "")
+			require.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+func TestParseCheckpointsRejectsWrongHash(t *testing.T) {
+	data := []byte(`{"checkpoints":[{"blockNo":1,"hash":"aa"}]}`)
+	_, err := parseCheckpoints(data, "deadbeef")
+	require.EqualError(
+		t,
+		err,
+		"checkpoints file hash mismatch: expected deadbeef, computed "+blake2b256Hex(data),
+	)
+}
+
+func TestParseCheckpointsAcceptsCorrectHash(t *testing.T) {
+	data := []byte(`{"checkpoints":[{"blockNo":1,"hash":"aa"}]}`)
+	// blake2b256 of the exact bytes above.
+	correct := blake2b256Hex(data)
+	cps, err := parseCheckpoints(data, correct)
+	require.NoError(t, err)
+	require.Equal(t, "aa", cps[1])
+}
+
+func TestParseCheckpointsRejectsConflictingDuplicate(t *testing.T) {
+	data := []byte(
+		`{"checkpoints":[{"blockNo":1,"hash":"aa"},{"blockNo":1,"hash":"bb"}]}`,
+	)
+	_, err := parseCheckpoints(data, "")
+	require.Error(t, err)
+}

--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -42,6 +42,7 @@ type CardanoNodeConfig struct {
 	conwayGenesis                              *conway.ConwayGenesis
 	dijkstraGenesis                            *dijkstra.DijkstraGenesis
 	shelleyGenesis                             *shelley.ShelleyGenesis
+	checkpoints                                map[uint64]string
 	path                                       string
 	AlonzoGenesisFile                          string `yaml:"AlonzoGenesisFile"`
 	AlonzoGenesisHash                          string `yaml:"AlonzoGenesisHash"`
@@ -57,6 +58,8 @@ type CardanoNodeConfig struct {
 	MithrilGenesisAncillaryVerificationKeyFile string `yaml:"MithrilGenesisAncillaryVerificationKeyFile"`
 	ShelleyGenesisFile                         string `yaml:"ShelleyGenesisFile"`
 	ShelleyGenesisHash                         string `yaml:"ShelleyGenesisHash"`
+	CheckpointsFile                            string `yaml:"CheckpointsFile"`
+	CheckpointsFileHash                        string `yaml:"CheckpointsFileHash"`
 
 	// Hard fork epoch configuration. Pointer types distinguish
 	// "not set" (nil) from "set to 0" (*0), which is critical
@@ -297,6 +300,9 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 		return err
 	}
 	if err := c.validateGenesisConsistency(); err != nil {
+		return err
+	}
+	if err := c.loadCheckpoints(); err != nil {
 		return err
 	}
 	return nil
@@ -612,6 +618,9 @@ func (c *CardanoNodeConfig) loadGenesisConfigsFromEmbed() error {
 		c.MithrilGenesisAncillaryVerificationKey = string(keyBytes)
 	}
 	if err := c.validateGenesisConsistency(); err != nil {
+		return err
+	}
+	if err := c.loadCheckpointsFromEmbed(); err != nil {
 		return err
 	}
 

--- a/config/cardano/node_test.go
+++ b/config/cardano/node_test.go
@@ -50,6 +50,8 @@ var expectedCardanoNodeConfig = &CardanoNodeConfig{
 	MithrilGenesisAncillaryVerificationKeyFile: "ancillary.vkey",
 	ShelleyGenesisFile:                         "shelley-genesis.json",
 	ShelleyGenesisHash:                         "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d",
+	CheckpointsFile:                            "checkpoints.json",
+	CheckpointsFileHash:                        "bb5056ff1ced9d68dd99720695789664f6bf6f0cb02a4010df09b813e225ac51",
 	ExperimentalHardForksEnabled:               new(false),
 	TestShelleyHardForkAtEpoch:                 ptrUint64(0),
 	TestAllegraHardForkAtEpoch:                 ptrUint64(0),
@@ -72,6 +74,7 @@ func TestCardanoNodeConfig(t *testing.T) {
 	tmpCfg.shelleyGenesis = nil
 	tmpCfg.alonzoGenesis = nil
 	tmpCfg.conwayGenesis = nil
+	tmpCfg.checkpoints = nil
 	if !reflect.DeepEqual(&tmpCfg, expectedCardanoNodeConfig) {
 		t.Fatalf(
 			"did not get expected object\n     got: %#v\n  wanted: %#v\n",

--- a/ledger/checkpoints.go
+++ b/ledger/checkpoints.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+)
+
+// CheckpointMismatchError is returned when a block at a configured
+// checkpoint height has a hash that differs from the expected one. This
+// is an envelope-validity failure: the block sits on a chain that
+// diverges from the known-good chain at a checkpointed height, so it
+// must be rejected regardless of any other validity it might have.
+type CheckpointMismatchError struct {
+	BlockNo  uint64
+	Expected string
+	Actual   string
+}
+
+func (e *CheckpointMismatchError) Error() string {
+	return fmt.Sprintf(
+		"block %d hash %s does not match configured checkpoint %s",
+		e.BlockNo, e.Actual, e.Expected,
+	)
+}
+
+// ValidateCheckpoint enforces a set of configured chain checkpoints
+// against a single block. The checkpoints map is keyed by block number
+// (height) with the expected block hash as a hex string.
+//
+// It returns nil when no checkpoints are configured, when there is no
+// checkpoint at the given height, or when the block hash matches the
+// configured checkpoint (case-insensitively). It returns a
+// *CheckpointMismatchError when the height is checkpointed but the hash
+// differs.
+//
+// Honest chains always agree with the shipped checkpoints, so this rule
+// can only reject a block on a divergent chain; it never rejects a block
+// on the canonical chain.
+func ValidateCheckpoint(
+	checkpoints map[uint64]string,
+	blockNo uint64,
+	hash string,
+) error {
+	if len(checkpoints) == 0 {
+		return nil
+	}
+	expected, ok := checkpoints[blockNo]
+	if !ok {
+		return nil
+	}
+	if !strings.EqualFold(expected, hash) {
+		return &CheckpointMismatchError{
+			BlockNo:  blockNo,
+			Expected: expected,
+			Actual:   hash,
+		}
+	}
+	return nil
+}
+
+// validateBlockCheckpoint applies the configured checkpoints to an
+// inbound block. Byron epoch boundary blocks (EBBs) share the preceding
+// block's number rather than incrementing it, so an EBB can collide with
+// a checkpointed height that refers to the regular block at that height.
+// EBBs are skipped to avoid a false mismatch; the regular block at the
+// checkpointed height is still validated when it is processed.
+//
+// The block hash is only computed when a checkpoint actually exists at
+// the block's height, keeping the common (non-checkpointed) case cheap.
+func (ls *LedgerState) validateBlockCheckpoint(block ledger.Block) error {
+	if len(ls.checkpoints) == 0 {
+		return nil
+	}
+	if _, isEbb := block.(*byron.ByronEpochBoundaryBlock); isEbb {
+		return nil
+	}
+	blockNo := block.BlockNumber()
+	if _, ok := ls.checkpoints[blockNo]; !ok {
+		return nil
+	}
+	return ValidateCheckpoint(ls.checkpoints, blockNo, block.Hash().String())
+}

--- a/ledger/checkpoints_block_test.go
+++ b/ledger/checkpoints_block_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
+)
+
+// loadFirstImmutableBlock returns the first non-EBB block from the
+// immutable testdata. It lets the checkpoint tests assert against a real
+// block hash in the exact format produced by block.Hash().String(),
+// which is what the checkpoint comparison relies on.
+func loadFirstImmutableBlock(t *testing.T) ledger.Block {
+	t.Helper()
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0})
+	require.NoError(t, err)
+	defer iter.Close()
+	for {
+		immBlock, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+		if immBlock == nil {
+			break
+		}
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		if _, isEbb := block.(*byron.ByronEpochBoundaryBlock); !isEbb {
+			return block
+		}
+	}
+	t.Fatal("no non-EBB block found in immutable testdata")
+	return nil
+}
+
+func TestValidateBlockCheckpointRealBlockMatch(t *testing.T) {
+	block := loadFirstImmutableBlock(t)
+	ls := &LedgerState{
+		checkpoints: map[uint64]string{
+			block.BlockNumber(): block.Hash().String(),
+		},
+	}
+	require.NoError(t, ls.validateBlockCheckpoint(block))
+}
+
+func TestValidateBlockCheckpointRealBlockMismatch(t *testing.T) {
+	block := loadFirstImmutableBlock(t)
+	ls := &LedgerState{
+		checkpoints: map[uint64]string{
+			block.BlockNumber(): "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+	err := ls.validateBlockCheckpoint(block)
+	require.Error(t, err)
+	var cpErr *CheckpointMismatchError
+	require.True(t, errors.As(err, &cpErr))
+	require.Equal(t, block.BlockNumber(), cpErr.BlockNo)
+}
+
+func TestValidateBlockCheckpointNoCheckpointsConfiguredForBlock(t *testing.T) {
+	block := loadFirstImmutableBlock(t)
+	ls := &LedgerState{} // nil checkpoints map
+	require.NoError(t, ls.validateBlockCheckpoint(block))
+}
+
+func TestValidateBlockCheckpointSkipsByronEbb(t *testing.T) {
+	// A Byron EBB shares the preceding block's number. Even if that number
+	// is checkpointed with a different hash, the EBB itself must be skipped
+	// so it cannot be falsely rejected. The skip happens before any block
+	// method is called, so a zero-value EBB is sufficient here.
+	ls := &LedgerState{
+		checkpoints: map[uint64]string{0: "deadbeef"},
+	}
+	require.NoError(
+		t,
+		ls.validateBlockCheckpoint(&byron.ByronEpochBoundaryBlock{}),
+	)
+}

--- a/ledger/checkpoints_test.go
+++ b/ledger/checkpoints_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCheckpointNoCheckpointsConfigured(t *testing.T) {
+	require.NoError(t, ValidateCheckpoint(nil, 100, "abc"))
+	require.NoError(t, ValidateCheckpoint(map[uint64]string{}, 100, "abc"))
+}
+
+func TestValidateCheckpointNoCheckpointAtHeight(t *testing.T) {
+	cps := map[uint64]string{2000: "aabb"}
+	// A block at a height with no configured checkpoint is always accepted,
+	// regardless of its hash.
+	require.NoError(t, ValidateCheckpoint(cps, 100, "ffff"))
+}
+
+func TestValidateCheckpointMatch(t *testing.T) {
+	cps := map[uint64]string{2000: "aabbcc"}
+	require.NoError(t, ValidateCheckpoint(cps, 2000, "aabbcc"))
+}
+
+func TestValidateCheckpointMatchIsCaseInsensitive(t *testing.T) {
+	cps := map[uint64]string{2000: "AABBCC"}
+	require.NoError(t, ValidateCheckpoint(cps, 2000, "aabbcc"))
+}
+
+func TestValidateCheckpointMismatch(t *testing.T) {
+	cps := map[uint64]string{2000: "aabbcc"}
+	err := ValidateCheckpoint(cps, 2000, "ddeeff")
+	require.Error(t, err)
+	var cpErr *CheckpointMismatchError
+	require.True(t, errors.As(err, &cpErr))
+	require.Equal(t, uint64(2000), cpErr.BlockNo)
+	require.Equal(t, "aabbcc", cpErr.Expected)
+	require.Equal(t, "ddeeff", cpErr.Actual)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -478,6 +478,7 @@ type LedgerState struct {
 	currentTipBlockNonce               []byte
 	epochCache                         []models.Epoch
 	epochNonceHexCache                 map[uint64]string
+	checkpoints                        map[uint64]string // configured chain checkpoints keyed by block number (height)
 	slotsPerKESPeriod                  atomic.Uint64
 	forgedBlockChecker                 atomic.Pointer[forgedBlockCheckerHolder]
 	slotBattleRecorder                 atomic.Pointer[slotBattleRecorderHolder]
@@ -614,6 +615,12 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 		chain:              cfg.ChainManager.PrimaryChain(),
 		epochNonceHexCache: make(map[uint64]string),
 		validationEnabled:  cfg.ValidateHistorical,
+	}
+	// Cache configured chain checkpoints (keyed by block height) so the
+	// hot block-processing path does an O(1) lookup. Nil when the network
+	// config supplies no CheckpointsFile.
+	if cfg.CardanoNodeConfig != nil {
+		ls.checkpoints = cfg.CardanoNodeConfig.Checkpoints()
 	}
 	// Initialize metrics here so any constructed LedgerState is safe to
 	// use without requiring Start() to have been called. Benchmarks and
@@ -3509,6 +3516,13 @@ func (ls *LedgerState) ledgerProcessBlock(
 				expectedPrevHash,
 			)
 		}
+	}
+	// Enforce configured chain checkpoints regardless of validation mode.
+	// A block at a checkpointed height whose hash differs sits on a chain
+	// that diverges from the known-good chain, so reject it before doing
+	// any further work. Honest chains always agree with the checkpoints.
+	if err := ls.validateBlockCheckpoint(block); err != nil {
+		return nil, err
 	}
 	// Reject blocks whose header protocol major version runs more than
 	// one ahead of current pparams. Skipped on testnets pre-Dijkstra


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds early chain validation using checkpoints to reject blocks that don’t match known hashes at specific heights. Checkpoints load from a JSON `CheckpointsFile` (blake2b-256 verified via `CheckpointsFileHash`) and are cached in `LedgerState` for fast checks before any header/transaction validation.

- **New Features**
  - `config/cardano`: add `CheckpointsFile`/`CheckpointsFileHash`; load from disk or embed; verify file hash; normalize hex; reject empty/non-hex; detect conflicts; expose `CardanoNodeConfig.Checkpoints()`.
  - `ledger`: add `ValidateCheckpoint` and enforce at the start of `ledgerProcessBlock`; case-insensitive hash match; skip Byron EBBs; applies in all validation modes. Docs and tests included.

- **Migration**
  - To enable, set `CheckpointsFile` and `CheckpointsFileHash` in the network config. If unset, behavior is unchanged. Mainnet and preview include checkpoint files.

<sup>Written for commit 678c88de79f5dabc7f8d4462a3da392375d37277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Network checkpoint configuration now supported via configurable files with optional integrity verification
- Blocks automatically validated against configured checkpoints, with mismatched hashes rejected early in the validation pipeline
- Byron epoch boundary blocks handled specially to prevent false checkpoint mismatches

## Tests
- Added comprehensive test coverage for checkpoint configuration and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->