### PR TITLE
fix(config): genesis config start time consistency check

### DIFF
--- a/config/cardano/genesis_consistency.go
+++ b/config/cardano/genesis_consistency.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"fmt"
+	"time"
+)
+
+// validateGenesisConsistency cross-checks invariants that must hold
+// between genesis files but are not captured by any single file's hash.
+//
+// Currently it asserts that, when both a Byron and a Shelley genesis are
+// present, the Byron startTime (Unix seconds) equals the Shelley
+// systemStart. On every real Cardano network these are the same instant:
+// the Shelley systemStart is the chain start time inherited from Byron.
+// All slot-to-time and time-to-slot conversion (ledger/hardfork_summary.go,
+// ledger/slot.go) is anchored on the Shelley systemStart, so a config
+// whose two genesis files disagree would compute wrong wall-clock times
+// for Byron-era slots. Failing closed at load time surfaces such a
+// misconfiguration immediately rather than as silent time drift later.
+func (c *CardanoNodeConfig) validateGenesisConsistency() error {
+	if c.byronGenesis == nil || c.shelleyGenesis == nil {
+		return nil
+	}
+	byronStart := int64(c.byronGenesis.StartTime)
+	shelleyStart := c.shelleyGenesis.SystemStart.Unix()
+	if byronStart != shelleyStart {
+		return fmt.Errorf(
+			"genesis system start mismatch: Byron startTime %d does not match Shelley systemStart %d (%s); slot-to-time conversion is anchored on the Shelley systemStart and would be wrong for Byron-era slots",
+			byronStart,
+			shelleyStart,
+			c.shelleyGenesis.SystemStart.UTC().Format(time.RFC3339),
+		)
+	}
+	return nil
+}

--- a/config/cardano/genesis_consistency_test.go
+++ b/config/cardano/genesis_consistency_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateGenesisConsistencyNoGenesis(t *testing.T) {
+	// With neither (or only one) genesis loaded there is nothing to
+	// cross-check, so the consistency check must pass.
+	require.NoError(t, (&CardanoNodeConfig{}).validateGenesisConsistency())
+
+	onlyByron := &CardanoNodeConfig{
+		byronGenesis: &byron.ByronGenesis{StartTime: 1000},
+	}
+	require.NoError(t, onlyByron.validateGenesisConsistency())
+}
+
+func TestValidateGenesisConsistencyMatch(t *testing.T) {
+	c := &CardanoNodeConfig{
+		byronGenesis:   &byron.ByronGenesis{StartTime: 1666656000},
+		shelleyGenesis: &shelley.ShelleyGenesis{SystemStart: time.Unix(1666656000, 0).UTC()},
+	}
+	require.NoError(t, c.validateGenesisConsistency())
+}
+
+func TestValidateGenesisConsistencyMismatch(t *testing.T) {
+	c := &CardanoNodeConfig{
+		byronGenesis:   &byron.ByronGenesis{StartTime: 1506203091},
+		shelleyGenesis: &shelley.ShelleyGenesis{SystemStart: time.Unix(1666656000, 0).UTC()},
+	}
+	require.Error(t, c.validateGenesisConsistency())
+}

--- a/config/cardano/node.go
+++ b/config/cardano/node.go
@@ -296,6 +296,9 @@ func (c *CardanoNodeConfig) loadGenesisConfigs() error {
 	if err := c.loadMithrilVerificationKeysFromDisk(); err != nil {
 		return err
 	}
+	if err := c.validateGenesisConsistency(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -607,6 +610,9 @@ func (c *CardanoNodeConfig) loadGenesisConfigsFromEmbed() error {
 			return err
 		}
 		c.MithrilGenesisAncillaryVerificationKey = string(keyBytes)
+	}
+	if err := c.validateGenesisConsistency(); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a consistency check that fails fast if Byron `startTime` and Shelley `systemStart` differ when both genesis files are present. This prevents wrong time/slot conversions for Byron-era slots.

- **Bug Fixes**
  - Validate start times during genesis load (both disk and embedded).
  - Skip check if only one genesis is present; return a clear error on mismatch.
  - Added tests for no-genesis, match, and mismatch cases.

- **Migration**
  - No action for standard networks.
  - For custom networks, ensure Byron `startTime` equals Shelley `systemStart`.

<sup>Written for commit 9d39637824364628cca9be0ac2f121551c34fb90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

