### PR TITLE
build: Add plumbing for optional storage plugin build tag

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -93,9 +93,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go-version }}-
       - name: go-build
+        run: go build -tags dingo_extra_plugins ./cmd/dingo
+      - name: go-build-minimal
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test -ldflags="-s -w" -race ./...
+        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race ./...
 
   # macOS and Windows jobs without Postgres service
   go-test-other:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 version: "2"
 run:
+  build-tags:
+    - dingo_extra_plugins
   issues-exit-code: 1
   tests: false
 linters:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -733,10 +733,16 @@ Dingo uses a dual-layer storage architecture with pluggable backends:
     -------------------------------------------------
     | Plugins:                    | Plugins:          |
     |  - Badger (default)         |  - SQLite (default)|
-    |  - AWS S3                   |  - PostgreSQL     |
-    |  - Google Cloud Storage     |  - MySQL          |
+    |  - AWS S3 (optional)        |  - PostgreSQL (optional)|
+    |  - Google Cloud Storage (optional)|  - MySQL (optional)|
     -------------------------------------------------
 ```
+
+Badger and SQLite are always compiled into Dingo. The non-default storage
+plugins (`s3`, `gcs`, `postgres`, and `mysql`) are compiled only when the
+`dingo_extra_plugins` build tag is enabled; project builds, CI, and release
+binaries opt into that tag, while a plain `go build ./cmd/dingo` produces a
+minimal binary.
 
 ### Storage Modes
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2,8 +2,8 @@
 
 Dingo stores chain state in two sibling stores:
 
-- The metadata store is a relational SQL database managed by the metadata plugins in `database/plugin/metadata/`. The supported plugins are `sqlite`, `postgres`, and `mysql`.
-- The blob store is a key/value object store managed by the blob plugins in `database/plugin/blob/`. The supported plugins are `badger`, `gcs`, and `s3`.
+- The metadata store is a relational SQL database managed by the metadata plugins in `database/plugin/metadata/`. The always-built plugin is `sqlite`; `postgres` and `mysql` are optional and are built only with the `dingo_extra_plugins` build tag.
+- The blob store is a key/value object store managed by the blob plugins in `database/plugin/blob/`. The always-built plugin is `badger`; `gcs` and `s3` are optional and are built only with the `dingo_extra_plugins` build tag.
 
 The SQL schema is generated from GORM models in `database/models/` plus the plugin-local singleton tables `commit_timestamp` and `node_settings`. There are no checked-in SQL migrations; startup runs `AutoMigrate` for the active metadata plugin.
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ PROTOC_SHA256=$(PROTOC_SHA256_$(PROTOC_OS)_$(PROTOC_ARCH))
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' -X '$(GOMODULE)/internal/version.CommitHash=$(COMMIT_HASH)'"
+BUILD_TAGS ?= dingo_extra_plugins
+GO_TAG_FLAGS=$(if $(strip $(BUILD_TAGS)),-tags "$(BUILD_TAGS)",)
 
 .PHONY: all build help mod-tidy clean format golines lint proto test bench test-load test-load-log test-load-profile test-devnet
 
@@ -65,8 +67,8 @@ golines: ## Enforce 80-character line limit
 
 lint: ## Run linters (golangci-lint + nilaway + modernize)
 	golangci-lint run ./...
-	nilaway ./...
-	modernize ./...
+	nilaway $(GO_TAG_FLAGS) ./...
+	modernize $(GO_TAG_FLAGS) ./...
 
 proto: $(PROTOC) ## Generate Go code from protobuf definitions
 	go build -o $(TOOLS_BIN)/protoc-gen-go google.golang.org/protobuf/cmd/protoc-gen-go
@@ -93,10 +95,10 @@ $(PROTOC):
 	unzip -q -o $(PROTOC_ZIP) -d $(PROTOC_DIR)
 
 test: mod-tidy ## Run tests with race detection
-	go test -v -race ./...
+	go test $(GO_TAG_FLAGS) -v -race ./...
 
 bench: mod-tidy ## Run benchmarks
-	go test -run=^$$ -bench=. -benchmem ./...
+	go test $(GO_TAG_FLAGS) -run=^$$ -bench=. -benchmem ./...
 
 test-load: build ## Load test data into a fresh database
 	rm -rf .dingo
@@ -119,6 +121,7 @@ test-devnet: ## Run devnet integration tests
 $(BINARIES): mod-tidy $(GO_FILES)
 	CGO_ENABLED=0 \
 	go build \
+		$(GO_TAG_FLAGS) \
 		$(GO_LDFLAGS) \
 		-o $(@)$(if $(filter windows,$(GOOS)),.exe,)  \
 		./cmd/$(@)

--- a/database/database.go
+++ b/database/database.go
@@ -237,8 +237,8 @@ func New(
 		configCopy.BlobPlugin,
 	)
 	if blobPlugin == nil {
-		return nil, fmt.Errorf(
-			"blob plugin %q not found",
+		return nil, plugin.MissingPluginError(
+			plugin.PluginTypeBlob,
 			configCopy.BlobPlugin,
 		)
 	}
@@ -272,8 +272,8 @@ func New(
 	if metadataPlugin == nil {
 		closeErr := blobDb.Close()
 		return nil, errors.Join(
-			fmt.Errorf(
-				"metadata plugin %q not found",
+			plugin.MissingPluginError(
+				plugin.PluginTypeMetadata,
 				configCopy.MetadataPlugin,
 			),
 			closeErr,

--- a/database/plugin/plugin.go
+++ b/database/plugin/plugin.go
@@ -39,16 +39,42 @@ func NewErrorPlugin(err error) Plugin {
 	return &ErrorPlugin{Err: err}
 }
 
+var knownOptionalPlugins = map[PluginType]map[string]struct{}{
+	PluginTypeBlob: {
+		"gcs": {},
+		"s3":  {},
+	},
+	PluginTypeMetadata: {
+		"mysql":    {},
+		"postgres": {},
+	},
+}
+
+// MissingPluginError returns the operator-facing error for a configured plugin
+// that is absent from the registry.
+func MissingPluginError(pluginType PluginType, pluginName string) error {
+	if optionalPlugins, ok := knownOptionalPlugins[pluginType]; ok {
+		if _, ok := optionalPlugins[pluginName]; ok {
+			return fmt.Errorf(
+				"%s plugin %q is not included in this build; rebuild with optional plugins enabled (-tags dingo_extra_plugins), or use an official release binary",
+				PluginTypeName(pluginType),
+				pluginName,
+			)
+		}
+	}
+	return fmt.Errorf(
+		"%s plugin %q not found",
+		PluginTypeName(pluginType),
+		pluginName,
+	)
+}
+
 // StartPlugin gets a plugin from the registry and starts it
 func StartPlugin(pluginType PluginType, pluginName string) (Plugin, error) {
 	// Get the plugin from the registry
 	p := GetPlugin(pluginType, pluginName)
 	if p == nil {
-		return nil, fmt.Errorf(
-			"%s plugin '%s' not found",
-			PluginTypeName(pluginType),
-			pluginName,
-		)
+		return nil, MissingPluginError(pluginType, pluginName)
 	}
 
 	// Start the plugin
@@ -232,9 +258,5 @@ func SetPluginOption(
 		// implementations (for example `data-dir` may not be relevant).
 		return nil
 	}
-	return fmt.Errorf(
-		"plugin %s of type %s not found",
-		pluginName,
-		PluginTypeName(pluginType),
-	)
+	return MissingPluginError(pluginType, pluginName)
 }

--- a/database/plugin/register_test.go
+++ b/database/plugin/register_test.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -134,5 +135,38 @@ func TestGetPlugin(t *testing.T) {
 			"Expected nil for non-existent plugin, got %v",
 			nonExistentPlugin,
 		)
+	}
+}
+
+// Known optional plugins should explain that the running binary lacks support.
+func TestMissingPluginErrorOptionalPlugin(t *testing.T) {
+	err := MissingPluginError(PluginTypeBlob, "s3")
+	if err == nil {
+		t.Fatal("expected error for missing optional plugin")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		`blob plugin "s3" is not included in this build`,
+		"rebuild with optional plugins enabled (-tags dingo_extra_plugins)",
+		"use an official release binary",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected error %q to contain %q", msg, want)
+		}
+	}
+}
+
+// Unknown plugins should keep the ordinary not-found error.
+func TestMissingPluginErrorUnknownPlugin(t *testing.T) {
+	err := MissingPluginError(PluginTypeMetadata, "oracle")
+	if err == nil {
+		t.Fatal("expected error for unknown plugin")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `metadata plugin "oracle" not found`) {
+		t.Fatalf("expected unknown-plugin error, got %q", msg)
+	}
+	if strings.Contains(msg, "not included in this build") {
+		t.Fatalf("unknown plugin should not be reported as optional: %q", msg)
 	}
 }

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -23,6 +23,8 @@ database:
   # Blob storage plugin configuration
   blob:
     # Plugin to use for blob storage (badger, gcs, s3)
+    # badger is always built; gcs and s3 require a build with
+    # -tags dingo_extra_plugins or an official release binary.
     plugin: "badger"
     # Configuration options for each plugin
     badger:
@@ -71,6 +73,8 @@ database:
   # Metadata storage plugin configuration
   metadata:
     # Plugin to use for metadata storage (sqlite, postgres, mysql)
+    # sqlite is always built; postgres and mysql require a build with
+    # -tags dingo_extra_plugins or an official release binary.
     plugin: "sqlite"
     # Configuration options for each plugin
     sqlite:


### PR DESCRIPTION
1. Added the first-stage plumbing for the dingo_extra_plugins build tag so non-default storage plugins can be moved behind the tag in follow-up PRs.
2. Added a known-optional plugin list for gcs, s3, mysql, and postgres.
3. Added a clearer missing-plugin error for optional plugins that are not compiled into the running binary.
4. Wired the new error through plugin startup, plugin option setup, and database blob/metadata startup.
5. Added unit tests for optional-plugin and unknown-plugin error paths.
6. Added BUILD_TAGS as dingo_extra_plugins to the Makefile.
7. Passed the tag to build, test, bench, nilaway, and modernize targets.
8. Configured golangci-lint to analyze with dingo_extra_plugins.
9. Updated Linux CI to build/test with the tag and keep a separate tag-free minimal build smoke check.
10. Updated DATABASE.md, ARCHITECTURE.md, and dingo.yaml.example to document always-built and optional storage plugins.


Closes #2584 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `dingo_extra_plugins` build tag to gate non-default storage plugins and enable minimal binaries, with clearer errors when optional plugins aren’t compiled in. Updates build, tests, and docs to support this flow.

- **New Features**
  - Gate optional storage plugins behind `dingo_extra_plugins`: blob `s3`, `gcs`; metadata `postgres`, `mysql`.
  - Show a clear error when an optional plugin isn’t compiled in; wired through plugin startup and option setup; tests added.
  - Makefile, `golangci-lint`, and Linux CI build/test with the tag, plus a minimal tag-free smoke check.
  - Docs and `dingo.yaml.example` updated to explain always-built vs optional plugins.

- **Migration**
  - No changes for releases or CI builds.
  - For local builds that need optional plugins, run: `go build -tags dingo_extra_plugins ./cmd/dingo` or set `BUILD_TAGS=dingo_extra_plugins`.

<sup>Written for commit c3563a933dfde03bc33b2ddb343ef7ef12fc1bbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which storage plugins (Badger, SQLite, S3, GCS, PostgreSQL, MySQL) are always included versus optionally available based on build configuration.

* **Bug Fixes**
  * Enhanced error messages to indicate when optional storage plugins are unavailable and suggest rebuilding with additional configuration.

* **Chores**
  * Updated build workflows and configuration to support both minimal and extended plugin builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->