### PR TITLE
fix(ledger): mithril chain rewind for catch-up

### DIFF
--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1398,7 +1398,13 @@ func TestReconcileLivePrimaryChainLedgerDivergenceExportedWrapperRecoversSubKFor
 	)
 }
 
-func TestReconcilePrimaryChainTipWithLedgerTipRewindsPrimaryChainWhenAheadBeyondK(
+// TestReconcilePrimaryChainTipWithLedgerTipCatchesUpWhenAheadBeyondK covers the
+// old-Mithril-snapshot shape: the immutable primary chain is far ahead of the
+// ledger tip (more than k blocks), but the ledger tip is still a valid ancestor
+// on the primary chain. The primary chain must be preserved so ledgerProcessBlocks
+// can replay forward and catch up; it must NOT be rewound (which would delete the
+// very blocks needed to catch up).
+func TestReconcilePrimaryChainTipWithLedgerTipCatchesUpWhenAheadBeyondK(
 	t *testing.T,
 ) {
 	fixture := newChainsyncRollbackFixture(t)
@@ -1424,19 +1430,38 @@ func TestReconcilePrimaryChainTipWithLedgerTipRewindsPrimaryChainWhenAheadBeyond
 		prevHash = hash
 	}
 	require.NoError(t, fixture.ls.chain.AddRawBlocks(blocks))
+	aheadTip := fixture.ls.chain.Tip()
 	require.Equal(
 		t,
 		fixture.currentTip.Point.Slot+3,
-		fixture.ls.chain.Tip().Point.Slot,
+		aheadTip.Point.Slot,
 	)
 
 	require.NoError(t, fixture.ls.reconcilePrimaryChainTipWithLedgerTip())
 
+	// Ledger tip is unchanged: reconcile does not itself advance the ledger,
+	// the forward replay happens later in ledgerProcessBlocks.
 	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)
-	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
 	dbTip, err := fixture.ls.db.GetTip(nil)
 	require.NoError(t, err)
 	assert.Equal(t, fixture.currentTip, dbTip)
+
+	// Primary chain is preserved at its original ahead tip, not rewound.
+	assert.Equal(t, aheadTip, fixture.ls.chain.Tip())
+
+	// Every block ahead of the ledger tip still exists so it can be replayed.
+	for _, block := range blocks {
+		_, err := fixture.ls.chain.BlockByPoint(
+			ocommon.NewPoint(block.Slot, block.Hash),
+			nil,
+		)
+		assert.NoError(
+			t,
+			err,
+			"ahead block at slot %d should be preserved for catch-up",
+			block.Slot,
+		)
+	}
 }
 
 func TestIntersectPointsDoesNotUsePrimaryChainWhenLedgerTipMissing(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4416,29 +4416,16 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 		return fmt.Errorf("check ledger tip on primary chain: %w", err)
 	}
 	if containsLedgerTip {
-		if gap, unsafe := ls.primaryChainAheadBeyondLedgerSafetyWindow(
-			chainTip,
-			ledgerTip,
-		); unsafe {
-			ls.config.Logger.Warn(
-				"primary chain tip too far ahead of ledger tip at startup, rewinding primary chain",
-				"component", "ledger",
-				"chain_tip_slot", chainTip.Point.Slot,
-				"ledger_tip_slot", ledgerTip.Point.Slot,
-				"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
-				"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
-				"block_gap", gap,
-				"security_param", ls.SecurityParam(),
-			)
-			if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
-				ledgerTip.Point,
-			); err != nil {
-				return fmt.Errorf(
-					"rewind primary chain to ledger tip: %w",
-					err,
-				)
-			}
-			return nil
+		// The ledger tip is a valid ancestor on the primary chain, so the
+		// primary chain is simply a forward extension of the ledger. This is
+		// the normal shape when bootstrapping from a Mithril snapshot whose
+		// ledger state lags the immutable block data, and the gap can far
+		// exceed the security parameter. We must always replay forward to
+		// catch up; rewinding the primary chain here would delete the very
+		// blocks ledgerProcessBlocks needs and defeat catch-up.
+		gap := uint64(0)
+		if chainTip.BlockNumber > ledgerTip.BlockNumber {
+			gap = chainTip.BlockNumber - ledgerTip.BlockNumber
 		}
 		ls.config.Logger.Warn(
 			"primary chain tip ahead of ledger tip at startup; ledgerProcessBlocks will catch up via chainsync",
@@ -4447,6 +4434,7 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 			"ledger_tip_slot", ledgerTip.Point.Slot,
 			"chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
 			"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+			"block_gap", gap,
 		)
 		return nil
 	}
@@ -4556,24 +4544,6 @@ func (ls *LedgerState) reconcileLivePrimaryChainLedgerDivergence(
 	return true, nil
 }
 
-func (ls *LedgerState) primaryChainAheadBeyondLedgerSafetyWindow(
-	chainTip ochainsync.Tip,
-	ledgerTip ochainsync.Tip,
-) (uint64, bool) {
-	if chainTip.BlockNumber <= ledgerTip.BlockNumber {
-		return 0, false
-	}
-	gap := chainTip.BlockNumber - ledgerTip.BlockNumber
-	if ls.config.CardanoNodeConfig == nil {
-		return gap, false
-	}
-	securityParam := ls.SecurityParam()
-	if securityParam <= 0 {
-		return gap, false
-	}
-	return gap, gap > uint64(securityParam)
-}
-
 func (ls *LedgerState) primaryChainContainsPoint(point ocommon.Point) (bool, error) {
 	if point.Slot == 0 && len(point.Hash) == 0 {
 		return true, nil
@@ -4647,12 +4617,10 @@ func (ls *LedgerState) primaryChainTipAtOrAheadOfLedgerTip() bool {
 	ls.RUnlock()
 	chainTip := ls.chain.Tip()
 	if chainTip.Point.Slot > ledgerTip.Point.Slot {
-		if _, unsafe := ls.primaryChainAheadBeyondLedgerSafetyWindow(
-			chainTip,
-			ledgerTip,
-		); unsafe {
-			return false
-		}
+		// The primary chain leads the ledger tip. As long as the ledger tip
+		// is a valid ancestor on the primary chain, the chain is a forward
+		// extension we can intersect against, regardless of how far it leads
+		// (e.g. an old Mithril snapshot whose ledger lags the block data).
 		containsLedgerTip, err := ls.primaryChainContainsPoint(ledgerTip.Point)
 		if err != nil {
 			ls.config.Logger.Warn(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented unwanted primary-chain rewinds during Mithril snapshot catch-up by preserving ahead immutable blocks when the ledger tip is a valid ancestor. This keeps the chain intact so `ledgerProcessBlocks` can replay forward and catch up.

- **Bug Fixes**
  - Updated `reconcilePrimaryChainTipWithLedgerTip` to never rewind when the ledger tip is on the primary chain; removed safety-window logic, computed gap only for logging, and adjusted `primaryChainTipAtOrAheadOfLedgerTip` to intersect regardless of gap.
  - Added `TestReconcilePrimaryChainTipWithLedgerTipCatchesUpWhenAheadBeyondK` to verify the chain tip stays ahead and all ahead blocks are preserved for replay.

<sup>Written for commit 0ba247286675dd5b484c1acc7d870b1632c5d31b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

