### PR TITLE
fix(ledger): skip waiting for old Leios EBs

### DIFF
--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -268,6 +268,12 @@ func (ls *LedgerState) ensureReferencedEndorserBlocks(
 	if poll < time.Millisecond {
 		poll = time.Millisecond
 	}
+	// Only wait for blocks near the live head. IsAtTip turns true once chainsync
+	// reaches the head, but the ledger may still be replaying a backlog of older
+	// blocks; their referenced endorser blocks are historical and the relay does
+	// not diffuse them, so waiting per block would stall catch-up at the gate
+	// timeout. wallSlot is the current wall-clock slot (the live head).
+	wallSlot, wallErr := ls.CurrentSlot()
 	for _, blk := range blocks {
 		ref, ok := blk.Header().(leiosEndorserBlockReferencer)
 		if !ok {
@@ -280,6 +286,14 @@ func (ls *LedgerState) ensureReferencedEndorserBlocks(
 		if _, _, cached := ls.config.EndorserBlockProvider(
 			ebHash.Bytes(),
 		); cached {
+			continue
+		}
+		// Skip the wait for catch-up backlog blocks (well below the head): the
+		// referenced endorser block is historical and undiffused, so waiting
+		// only stalls catch-up. Gate only blocks within the wait window of the
+		// head, where the endorser block may still be diffusing.
+		if wallErr == nil && wallSlot > blk.SlotNumber() &&
+			wallSlot-blk.SlotNumber() > ls.config.EndorserBlockWaitSlots {
 			continue
 		}
 		ls.waitForEndorserBlock(ctx, blk.SlotNumber(), ebHash, timeout, poll)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip waiting for old Leios endorser blocks during catch-up to prevent stalls and speed up sync. We now only wait near the live head within the configured window.

- **Bug Fixes**
  - Gate `ensureReferencedEndorserBlocks` only when `CurrentSlot()` is within `config.EndorserBlockWaitSlots` of `blk.SlotNumber()`.
  - Avoids gate timeouts on historical blocks that are not diffused by the relay.

<sup>Written for commit 39452f44162f690ff899fdaeef399a8767607a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of block synchronization to prevent the system from stalling during historical catch-up processing. The system now intelligently skips unnecessary waiting on older blocks when they fall sufficiently behind the current time, enabling faster and more efficient backlog processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->