### PR TITLE
fix(ledgerstate): resolve SPO reward-account auto-votes for Mithril-i…

### DIFF
--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -56,12 +56,13 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 	for _, s := range snapshots {
 		// Reset to ensure callers can re-run resolution without
 		// stale values leaking through from a previous attempt.
-		// Mark the row as resolved up-front: every snapshot passed
-		// to this resolver runs against snapshot-era state by
-		// contract, so the absence of an Always{Abstain,NoConfidence}
-		// delegation is a real "none" answer, not "unknown".
+		// Resolved is intentionally left false here: it is only
+		// set true below, after we confirm the pool row exists in
+		// the database. A missing pool row means the reward-account
+		// delegation cannot be determined, so the row must not be
+		// persisted as authoritative Resolved=true, AutoVote=None.
 		s.RewardAccountAutoVote = models.PoolRewardAccountAutoVoteNone
-		s.RewardAccountAutoVoteResolved = true
+		s.RewardAccountAutoVoteResolved = false
 		key := string(s.PoolKeyHash)
 		if _, seen := snapshotsByPool[key]; !seen {
 			pkhs = append(pkhs, lcommon.PoolKeyHash(s.PoolKeyHash))
@@ -72,6 +73,19 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 	pools, err := d.GetPools(pkhs, txn)
 	if err != nil {
 		return fmt.Errorf("get pools: %w", err)
+	}
+
+	// Mark resolved for every snapshot whose pool row was found.
+	// "Resolved" means the resolver ran to completion with real pool
+	// data; AutoVote=None means the reward account is not delegated to
+	// an Always{Abstain,NoConfidence} DRep (implicit no). Snapshots
+	// whose pool is absent in the DB retain Resolved=false so the tally
+	// can distinguish "confirmed none" from "could not resolve".
+	for i := range pools {
+		poolKey := string(pools[i].PoolKeyHash)
+		for _, s := range snapshotsByPool[poolKey] {
+			s.RewardAccountAutoVoteResolved = true
+		}
 	}
 
 	rewardAcctByPool := make(map[string]models.StakeCredentialRef, len(pools))

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -30,12 +30,28 @@ import (
 //
 // Resolution proceeds in two batched lookups:
 //  1. Pool rows yield each pool's reward-account stake credential.
-//  2. Account rows yield the DRep delegation type for each credential.
+//  2. Account rows (active and inactive) yield the DRep delegation type
+//     for each credential.
 //
-// Only ACTIVE accounts are considered. A deregistered reward account
-// — even one whose row still carries an AlwaysAbstain or
-// AlwaysNoConfidence delegation flag — yields PoolRewardAccountAutoVoteNone,
-// since CIP-1694 treats unregistered reward accounts as implicit no.
+// RewardAccountAutoVoteResolved is set true only when the outcome is
+// determined from real data, at exactly three terminal conditions:
+//   - The pool row exists and carries no reward account → confirmed None.
+//   - The pool row exists, its reward-account row is present and ACTIVE →
+//     classified by DRep delegation (Abstain / NoConfidence / None).
+//   - The pool row exists, its reward-account row is present but INACTIVE
+//     (deregistered) → confirmed None, since CIP-1694 treats unregistered
+//     reward accounts as implicit no.
+//
+// Resolved is left false (so the tally falls back to implicit no without
+// freezing a value) when:
+//   - The pool row is absent from the DB (cannot determine the reward
+//     account at all), or
+//   - The pool's reward-account credential has no row in the account table
+//     at all. An absent row is ambiguous: it may mean the account was never
+//     registered, OR that account data has not yet been imported (e.g. a
+//     Mithril restore that imported pools from the snapshot fallback before
+//     cert-state accounts were loaded). Persisting Resolved=true here would
+//     conflate "account input unavailable" with "confirmed none".
 func (d *Database) ResolvePoolRewardAccountAutoVotes(
 	snapshots []*models.PoolStakeSnapshot,
 	txn *Txn,
@@ -56,11 +72,6 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 	for _, s := range snapshots {
 		// Reset to ensure callers can re-run resolution without
 		// stale values leaking through from a previous attempt.
-		// Resolved is intentionally left false here: it is only
-		// set true below, after we confirm the pool row exists in
-		// the database. A missing pool row means the reward-account
-		// delegation cannot be determined, so the row must not be
-		// persisted as authoritative Resolved=true, AutoVote=None.
 		s.RewardAccountAutoVote = models.PoolRewardAccountAutoVoteNone
 		s.RewardAccountAutoVoteResolved = false
 		key := string(s.PoolKeyHash)
@@ -75,29 +86,21 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 		return fmt.Errorf("get pools: %w", err)
 	}
 
-	// Mark resolved for every snapshot whose pool row was found.
-	// "Resolved" means the resolver ran to completion with real pool
-	// data; AutoVote=None means the reward account is not delegated to
-	// an Always{Abstain,NoConfidence} DRep (implicit no). Snapshots
-	// whose pool is absent in the DB retain Resolved=false so the tally
-	// can distinguish "confirmed none" from "could not resolve".
-	for i := range pools {
-		poolKey := string(pools[i].PoolKeyHash)
-		for _, s := range snapshotsByPool[poolKey] {
-			s.RewardAccountAutoVoteResolved = true
-		}
-	}
-
 	rewardAcctByPool := make(map[string]models.StakeCredentialRef, len(pools))
 	seenRefs := make(map[string]struct{}, len(pools))
 	rewardAccountRefs := make([]models.StakeCredentialRef, 0, len(pools))
 	for i := range pools {
-		ra := pools[i].RewardAccount
-		if len(ra) == 0 {
-			continue
-		}
 		poolKey := string(pools[i].PoolKeyHash)
 		if _, dup := rewardAcctByPool[poolKey]; dup {
+			continue
+		}
+		ra := pools[i].RewardAccount
+		if len(ra) == 0 {
+			// Pool row exists but carries no reward account: this is a
+			// confirmed None outcome — mark resolved immediately.
+			for _, s := range snapshotsByPool[poolKey] {
+				s.RewardAccountAutoVoteResolved = true
+			}
 			continue
 		}
 		ref := models.StakeCredentialRef{
@@ -115,11 +118,13 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 		return nil
 	}
 
-	// includeInactive=false so a deregistered reward account that
-	// still carries a stale predefined-DRep flag does not auto-vote.
+	// includeInactive=true so a present-but-deregistered reward account
+	// is distinguishable from an account row that is entirely absent.
+	// Deregistered accounts are a confirmed None; absent rows stay
+	// unresolved (see the doc comment).
 	accounts, err := d.GetAccountsByCredential(
 		rewardAccountRefs,
-		false,
+		true,
 		txn,
 	)
 	if err != nil {
@@ -129,18 +134,24 @@ func (d *Database) ResolvePoolRewardAccountAutoVotes(
 	for poolKey, ref := range rewardAcctByPool {
 		acct, ok := accounts[ref.MapKey()]
 		if !ok {
+			// Account row not in DB: data may not have been imported yet.
+			// Leave Resolved=false rather than persisting a false None.
 			continue
 		}
+		// Account row exists. A deregistered (inactive) account does not
+		// auto-vote per CIP-1694; an active account auto-votes only when
+		// delegated to AlwaysAbstain or AlwaysNoConfidence.
 		var autoVote uint8
-		switch acct.DrepType {
-		case models.DrepTypeAlwaysAbstain:
-			autoVote = models.PoolRewardAccountAutoVoteAbstain
-		case models.DrepTypeAlwaysNoConfidence:
-			autoVote = models.PoolRewardAccountAutoVoteNoConfidence
-		default:
-			continue
+		if acct.Active {
+			switch acct.DrepType {
+			case models.DrepTypeAlwaysAbstain:
+				autoVote = models.PoolRewardAccountAutoVoteAbstain
+			case models.DrepTypeAlwaysNoConfidence:
+				autoVote = models.PoolRewardAccountAutoVoteNoConfidence
+			}
 		}
 		for _, s := range snapshotsByPool[poolKey] {
+			s.RewardAccountAutoVoteResolved = true
 			s.RewardAccountAutoVote = autoVote
 		}
 	}

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1247,41 +1247,31 @@ func persistImportedSnapshot(
 	}
 
 	if len(poolSnapshots) > 0 {
-		// CIP-1694 reward-account auto-vote resolution strategy:
+		// CIP-1694 reward-account auto-vote resolution.
 		//
-		// Current-epoch (N): live Pool/Account rows in the DB were
-		// imported from the snapshot's own cert-state and exactly match
-		// the N-epoch boundary, so we query them directly.
+		// Current-epoch (N): live Pool/Account rows in the DB match the
+		// N-epoch boundary (imported from the snapshot's own cert-state,
+		// or from the snapshot-pool fallback which runs before this loop),
+		// so we resolve directly against them.
 		//
-		// Historical N-1/N-2: pool rows were imported with the current
-		// snapshot slot, not with their original historical registration
-		// slot. GetPoolRegistrationsAtSlot would find nothing at the
-		// historical boundary slot. Instead we use the reward-account
-		// data embedded in the snapshot bundle's PoolParams, which is
-		// historically accurate for each target epoch. Account DRep
-		// delegation is resolved against live state (best-effort; more
-		// accurate than leaving rows permanently unresolved / implicit no).
+		// Historical N-1/N-2 (stored as "mark" rows for older target
+		// epochs): faithful resolution needs the reward account's DRep
+		// delegation AS OF the historical boundary. That state is not
+		// available after a Mithril restore — cert history tables are
+		// empty for pre-snapshot epochs and #1902's persisted reward
+		// state does not capture reward-account DRep delegation. Resolving
+		// against live DRep delegation and marking the row authoritative
+		// would freeze a possibly-changed value onto a historical boundary.
+		// We therefore leave these rows RewardAccountAutoVoteResolved=false
+		// so the tally treats them as PoolRewardAccountAutoVoteNone
+		// (implicit no), matching pre-CIP-1694 behaviour, until per-boundary
+		// DRep-delegation state is persisted (follow-up to #1902).
 		if st.targetEpoch == cfg.State.Epoch {
 			if err := cfg.Database.ResolvePoolRewardAccountAutoVotes(
 				poolSnapshots, txn,
 			); err != nil {
 				return fmt.Errorf(
 					"resolving reward-account auto-votes for "+
-						"%s snapshot epoch %d: %w",
-					st.name,
-					st.targetEpoch,
-					err,
-				)
-			}
-		} else if st.snap != nil && len(st.snap.PoolParams) > 0 {
-			if err := resolveAutoVotesFromSnapshotPoolParams(
-				cfg.Database,
-				poolSnapshots,
-				st.snap.PoolParams,
-				txn,
-			); err != nil {
-				return fmt.Errorf(
-					"resolving historical reward-account auto-votes for "+
 						"%s snapshot epoch %d: %w",
 					st.name,
 					st.targetEpoch,
@@ -1440,7 +1430,15 @@ func collectPoolsFromSnapshots(
 				continue
 			}
 			hexKey := hex.EncodeToString(pool.PoolKeyHash)
-			seen[hexKey] = *pool
+			// First-seen wins: Mark is iterated first, so Mark-era pool
+			// params (including the reward account) take precedence over
+			// older Set/Go params when a pool appears in multiple
+			// snapshots. The fallback import feeds the current-epoch
+			// auto-vote resolver, which must read the current (Mark)
+			// reward account, not a historical one.
+			if _, ok := seen[hexKey]; !ok {
+				seen[hexKey] = *pool
+			}
 		}
 	}
 	ret := make([]ParsedPool, 0, len(seen))
@@ -1453,123 +1451,6 @@ func collectPoolsFromSnapshots(
 		ret = append(ret, seen[hexKey])
 	}
 	return ret
-}
-
-// resolveAutoVotesFromSnapshotPoolParams resolves reward-account
-// auto-votes for historical imported snapshot rows (N-1, N-2) using
-// the pool reward-account data that is embedded in the snapshot bundle's
-// own PoolParams map. This avoids a dependency on historically-correct
-// pool_registration.added_slot values: imported pool rows carry the
-// import-time slot, so GetPoolRegistrationsAtSlot would find nothing
-// at a historical boundary slot.
-//
-// Resolution is "best-effort": pool reward accounts are taken from the
-// snapshot data (accurate for the snapshot era), while account DRep
-// delegation is resolved against live state (since per-slot DRep history
-// is not yet tracked). The result is more accurate than leaving rows
-// permanently unresolved (implicit no), but may be wrong when a reward
-// account changed its DRep delegation after the historical boundary.
-//
-// Rows whose pool key is absent from poolParams are left Resolved=false
-// (cannot determine). Rows whose pool is present are always marked
-// Resolved=true — even when the reward account is empty or unregistered,
-// both of which produce AutoVote=None (implicit no) per CIP-1694.
-func resolveAutoVotesFromSnapshotPoolParams(
-	db *database.Database,
-	poolSnapshots []*models.PoolStakeSnapshot,
-	poolParams map[string]*ParsedPool,
-	txn *database.Txn,
-) error {
-	if len(poolSnapshots) == 0 || len(poolParams) == 0 {
-		return nil
-	}
-
-	type entry struct {
-		snapshots     []*models.PoolStakeSnapshot
-		rewardAcct    []byte
-		credentialTag uint8
-		hasPool       bool // true if pool key appeared in PoolParams
-	}
-
-	byPool := make(map[string]*entry, len(poolSnapshots))
-	for _, s := range poolSnapshots {
-		s.RewardAccountAutoVote = models.PoolRewardAccountAutoVoteNone
-		s.RewardAccountAutoVoteResolved = false
-		poolHex := hex.EncodeToString(s.PoolKeyHash)
-		e := byPool[poolHex]
-		if e == nil {
-			e = &entry{}
-			byPool[poolHex] = e
-		}
-		e.snapshots = append(e.snapshots, s)
-	}
-
-	seenRefs := make(map[string]struct{})
-	var rewardAccountRefs []models.StakeCredentialRef
-
-	for poolHex, e := range byPool {
-		pool := poolParams[poolHex]
-		if pool == nil {
-			continue
-		}
-		e.hasPool = true
-		if len(pool.RewardAccount) == 0 {
-			// Pool has no reward account → confirmed None
-			for _, s := range e.snapshots {
-				s.RewardAccountAutoVoteResolved = true
-			}
-			continue
-		}
-		e.rewardAcct = pool.RewardAccount
-		e.credentialTag = pool.RewardAccountCredentialTag
-		ref := models.StakeCredentialRef{
-			Tag: pool.RewardAccountCredentialTag,
-			Key: pool.RewardAccount,
-		}
-		mk := ref.MapKey()
-		if _, seen := seenRefs[mk]; !seen {
-			seenRefs[mk] = struct{}{}
-			rewardAccountRefs = append(rewardAccountRefs, ref)
-		}
-	}
-
-	if len(rewardAccountRefs) == 0 {
-		return nil
-	}
-
-	// includeInactive=false: deregistered reward accounts don't auto-vote.
-	accounts, err := db.GetAccountsByCredential(rewardAccountRefs, false, txn)
-	if err != nil {
-		return fmt.Errorf(
-			"get reward accounts for historical snapshot resolution: %w",
-			err,
-		)
-	}
-
-	for _, e := range byPool {
-		if !e.hasPool || e.rewardAcct == nil {
-			continue
-		}
-		ref := models.StakeCredentialRef{
-			Tag: e.credentialTag,
-			Key: e.rewardAcct,
-		}
-		var autoVote uint8
-		if acct, ok := accounts[ref.MapKey()]; ok {
-			switch acct.DrepType {
-			case models.DrepTypeAlwaysAbstain:
-				autoVote = models.PoolRewardAccountAutoVoteAbstain
-			case models.DrepTypeAlwaysNoConfidence:
-				autoVote = models.PoolRewardAccountAutoVoteNoConfidence
-			}
-		}
-		for _, s := range e.snapshots {
-			s.RewardAccountAutoVoteResolved = true
-			s.RewardAccountAutoVote = autoVote
-		}
-	}
-
-	return nil
 }
 
 // importTip sets the chain tip to the snapshot's tip and generates

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1124,6 +1124,34 @@ func importSnapShots(
 
 	epoch := cfg.State.Epoch
 
+	if allowPoolFallback {
+		// Fallback pool import path runs BEFORE snapshot processing so
+		// that pool rows exist in the DB when ResolvePoolRewardAccountAutoVotes
+		// runs for the current-epoch snapshot. Importing pools after
+		// snapshot processing would leave the current-epoch snapshot rows
+		// resolved against an empty pool table, producing false
+		// Resolved=true, AutoVote=None entries.
+		snapshotPools := collectPoolsFromSnapshots(snapshots)
+		if len(snapshotPools) > 0 {
+			if err := importPools(ctx, cfg, snapshotPools, slot); err != nil {
+				return fmt.Errorf(
+					"importing pools from snapshots: %w",
+					err,
+				)
+			}
+			progress(ImportProgress{
+				Stage:   "pools",
+				Current: len(snapshotPools),
+				Total:   len(snapshotPools),
+				Percent: 100,
+				Description: fmt.Sprintf(
+					"%d pools imported from snapshots",
+					len(snapshotPools),
+				),
+			})
+		}
+	}
+
 	// Mithril exports the current epoch's Mark/Set/Go bundle, but
 	// Dingo persists only Mark snapshots and resolves Set/Go via
 	// epoch offsets:
@@ -1191,31 +1219,6 @@ func importSnapShots(
 		})
 	}
 
-	if allowPoolFallback {
-		// Fallback pool import path:
-		// Snapshot data includes pool parameters and remains reliable when
-		// cert-state pool data is unavailable.
-		snapshotPools := collectPoolsFromSnapshots(snapshots)
-		if len(snapshotPools) > 0 {
-			if err := importPools(ctx, cfg, snapshotPools, slot); err != nil {
-				return fmt.Errorf(
-					"importing pools from snapshots: %w",
-					err,
-				)
-			}
-			progress(ImportProgress{
-				Stage:   "pools",
-				Current: len(snapshotPools),
-				Total:   len(snapshotPools),
-				Percent: 100,
-				Description: fmt.Sprintf(
-					"%d pools imported from snapshots",
-					len(snapshotPools),
-				),
-			})
-		}
-	}
-
 	return nil
 }
 
@@ -1244,26 +1247,41 @@ func persistImportedSnapshot(
 	}
 
 	if len(poolSnapshots) > 0 {
-		// CIP-1694 reward-account auto-vote can only be faithfully
-		// resolved when live Pool/Account state matches the row's
-		// target boundary. All three import targets are persisted as
-		// "mark" rows (only the target epoch differs: N, N-1, N-2),
-		// so gating on the source rotation name would be fragile —
-		// every row's SnapshotType is "mark" by the time it reaches
-		// this function. The correct semantic check is "is the
-		// target epoch equal to the current import-time epoch?"
-		// Only that one row's boundary matches the live state we'd
-		// read; the other two represent older boundaries and must be
-		// left RewardAccountAutoVoteResolved=false so the tally
-		// treats them as PoolRewardAccountAutoVoteNone (implicit no)
-		// instead of freezing today's delegation map onto an older
-		// boundary.
+		// CIP-1694 reward-account auto-vote resolution strategy:
+		//
+		// Current-epoch (N): live Pool/Account rows in the DB were
+		// imported from the snapshot's own cert-state and exactly match
+		// the N-epoch boundary, so we query them directly.
+		//
+		// Historical N-1/N-2: pool rows were imported with the current
+		// snapshot slot, not with their original historical registration
+		// slot. GetPoolRegistrationsAtSlot would find nothing at the
+		// historical boundary slot. Instead we use the reward-account
+		// data embedded in the snapshot bundle's PoolParams, which is
+		// historically accurate for each target epoch. Account DRep
+		// delegation is resolved against live state (best-effort; more
+		// accurate than leaving rows permanently unresolved / implicit no).
 		if st.targetEpoch == cfg.State.Epoch {
 			if err := cfg.Database.ResolvePoolRewardAccountAutoVotes(
 				poolSnapshots, txn,
 			); err != nil {
 				return fmt.Errorf(
 					"resolving reward-account auto-votes for "+
+						"%s snapshot epoch %d: %w",
+					st.name,
+					st.targetEpoch,
+					err,
+				)
+			}
+		} else if st.snap != nil && len(st.snap.PoolParams) > 0 {
+			if err := resolveAutoVotesFromSnapshotPoolParams(
+				cfg.Database,
+				poolSnapshots,
+				st.snap.PoolParams,
+				txn,
+			); err != nil {
+				return fmt.Errorf(
+					"resolving historical reward-account auto-votes for "+
 						"%s snapshot epoch %d: %w",
 					st.name,
 					st.targetEpoch,
@@ -1435,6 +1453,123 @@ func collectPoolsFromSnapshots(
 		ret = append(ret, seen[hexKey])
 	}
 	return ret
+}
+
+// resolveAutoVotesFromSnapshotPoolParams resolves reward-account
+// auto-votes for historical imported snapshot rows (N-1, N-2) using
+// the pool reward-account data that is embedded in the snapshot bundle's
+// own PoolParams map. This avoids a dependency on historically-correct
+// pool_registration.added_slot values: imported pool rows carry the
+// import-time slot, so GetPoolRegistrationsAtSlot would find nothing
+// at a historical boundary slot.
+//
+// Resolution is "best-effort": pool reward accounts are taken from the
+// snapshot data (accurate for the snapshot era), while account DRep
+// delegation is resolved against live state (since per-slot DRep history
+// is not yet tracked). The result is more accurate than leaving rows
+// permanently unresolved (implicit no), but may be wrong when a reward
+// account changed its DRep delegation after the historical boundary.
+//
+// Rows whose pool key is absent from poolParams are left Resolved=false
+// (cannot determine). Rows whose pool is present are always marked
+// Resolved=true — even when the reward account is empty or unregistered,
+// both of which produce AutoVote=None (implicit no) per CIP-1694.
+func resolveAutoVotesFromSnapshotPoolParams(
+	db *database.Database,
+	poolSnapshots []*models.PoolStakeSnapshot,
+	poolParams map[string]*ParsedPool,
+	txn *database.Txn,
+) error {
+	if len(poolSnapshots) == 0 || len(poolParams) == 0 {
+		return nil
+	}
+
+	type entry struct {
+		snapshots     []*models.PoolStakeSnapshot
+		rewardAcct    []byte
+		credentialTag uint8
+		hasPool       bool // true if pool key appeared in PoolParams
+	}
+
+	byPool := make(map[string]*entry, len(poolSnapshots))
+	for _, s := range poolSnapshots {
+		s.RewardAccountAutoVote = models.PoolRewardAccountAutoVoteNone
+		s.RewardAccountAutoVoteResolved = false
+		poolHex := hex.EncodeToString(s.PoolKeyHash)
+		e := byPool[poolHex]
+		if e == nil {
+			e = &entry{}
+			byPool[poolHex] = e
+		}
+		e.snapshots = append(e.snapshots, s)
+	}
+
+	seenRefs := make(map[string]struct{})
+	var rewardAccountRefs []models.StakeCredentialRef
+
+	for poolHex, e := range byPool {
+		pool := poolParams[poolHex]
+		if pool == nil {
+			continue
+		}
+		e.hasPool = true
+		if len(pool.RewardAccount) == 0 {
+			// Pool has no reward account → confirmed None
+			for _, s := range e.snapshots {
+				s.RewardAccountAutoVoteResolved = true
+			}
+			continue
+		}
+		e.rewardAcct = pool.RewardAccount
+		e.credentialTag = pool.RewardAccountCredentialTag
+		ref := models.StakeCredentialRef{
+			Tag: pool.RewardAccountCredentialTag,
+			Key: pool.RewardAccount,
+		}
+		mk := ref.MapKey()
+		if _, seen := seenRefs[mk]; !seen {
+			seenRefs[mk] = struct{}{}
+			rewardAccountRefs = append(rewardAccountRefs, ref)
+		}
+	}
+
+	if len(rewardAccountRefs) == 0 {
+		return nil
+	}
+
+	// includeInactive=false: deregistered reward accounts don't auto-vote.
+	accounts, err := db.GetAccountsByCredential(rewardAccountRefs, false, txn)
+	if err != nil {
+		return fmt.Errorf(
+			"get reward accounts for historical snapshot resolution: %w",
+			err,
+		)
+	}
+
+	for _, e := range byPool {
+		if !e.hasPool || e.rewardAcct == nil {
+			continue
+		}
+		ref := models.StakeCredentialRef{
+			Tag: e.credentialTag,
+			Key: e.rewardAcct,
+		}
+		var autoVote uint8
+		if acct, ok := accounts[ref.MapKey()]; ok {
+			switch acct.DrepType {
+			case models.DrepTypeAlwaysAbstain:
+				autoVote = models.PoolRewardAccountAutoVoteAbstain
+			case models.DrepTypeAlwaysNoConfidence:
+				autoVote = models.PoolRewardAccountAutoVoteNoConfidence
+			}
+		}
+		for _, s := range e.snapshots {
+			s.RewardAccountAutoVoteResolved = true
+			s.RewardAccountAutoVote = autoVote
+		}
+	}
+
+	return nil
 }
 
 // importTip sets the chain tip to the snapshot's tip and generates

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -470,32 +469,55 @@ func TestPersistImportedSnapshotMissingPoolsNotResolved(t *testing.T) {
 	require.Equal(t, models.PoolRewardAccountAutoVoteNone, stored[0].RewardAccountAutoVote)
 }
 
-// TestPersistImportedSnapshotHistoricalResolvesFromPoolParams verifies that
-// historical N-1/N-2 imported rows are resolved from the snapshot bundle's
-// own PoolParams when a reward account delegates to AlwaysAbstain or
-// AlwaysNoConfidence, and that rows whose pool key is absent from PoolParams
-// remain Resolved=false.
-func TestPersistImportedSnapshotHistoricalResolvesFromPoolParams(t *testing.T) {
+// TestPersistImportedSnapshotPoolPresentAccountStates exercises the
+// current-epoch resolver's three account outcomes for issue #2440:
+//   - reward account row absent entirely → Resolved=false (data may not be
+//     imported yet; must not be persisted as a false confirmed None);
+//   - reward account present but inactive (deregistered) → Resolved=true,
+//     AutoVote=None (CIP-1694 treats unregistered reward accounts as
+//     implicit no, but it is a confirmed outcome);
+//   - reward account present and active, delegated to AlwaysNoConfidence →
+//     Resolved=true, AutoVote=NoConfidence.
+func TestPersistImportedSnapshotPoolPresentAccountStates(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-	poolAbstain := bytes.Repeat([]byte{0x20}, 28)
-	poolNoConf := bytes.Repeat([]byte{0x21}, 28)
-	poolNoAccount := bytes.Repeat([]byte{0x22}, 28)
-	poolAbsent := bytes.Repeat([]byte{0x23}, 28) // not in PoolParams
-
-	rewardAbstain := bytes.Repeat([]byte{0x30}, 28)
-	rewardNoConf := bytes.Repeat([]byte{0x31}, 28)
-
 	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
 	require.True(t, ok, "test requires the sqlite metadata backend")
-	require.NoError(t, store.DB().Create(&models.Account{
-		StakingKey: rewardAbstain,
+
+	poolAbsent := bytes.Repeat([]byte{0x60}, 28)    // pool present, account absent
+	poolInactive := bytes.Repeat([]byte{0x61}, 28)  // pool present, account inactive
+	poolNoConf := bytes.Repeat([]byte{0x62}, 28)     // pool present, account active NoConf
+	rewardAbsent := bytes.Repeat([]byte{0x70}, 28)
+	rewardInactive := bytes.Repeat([]byte{0x71}, 28)
+	rewardNoConf := bytes.Repeat([]byte{0x72}, 28)
+
+	// All three pools exist in the DB. Only two of their reward accounts
+	// have account rows; poolAbsent's reward account has none.
+	for _, p := range []struct {
+		pool   []byte
+		reward []byte
+	}{
+		{poolAbsent, rewardAbsent},
+		{poolInactive, rewardInactive},
+		{poolNoConf, rewardNoConf},
+	} {
+		require.NoError(t, store.DB().Create(&models.Pool{
+			PoolKeyHash:   p.pool,
+			RewardAccount: p.reward,
+		}).Error)
+	}
+	// Inactive (deregistered) account that still carries an Always* flag.
+	inactive := models.Account{
+		StakingKey: rewardInactive,
 		DrepType:   models.DrepTypeAlwaysAbstain,
 		AddedSlot:  1,
 		Active:     true,
-	}).Error)
+	}
+	require.NoError(t, store.DB().Create(&inactive).Error)
+	require.NoError(t, store.DB().Model(&inactive).Update("active", false).Error)
+	// Active account delegated to AlwaysNoConfidence.
 	require.NoError(t, store.DB().Create(&models.Account{
 		StakingKey: rewardNoConf,
 		DrepType:   models.DrepTypeAlwaysNoConfidence,
@@ -503,46 +525,27 @@ func TestPersistImportedSnapshotHistoricalResolvesFromPoolParams(t *testing.T) {
 		Active:     true,
 	}).Error)
 
-	poolParamsMap := map[string]*ParsedPool{
-		poolHex(poolAbstain): {
-			PoolKeyHash:   poolAbstain,
-			RewardAccount: rewardAbstain,
-		},
-		poolHex(poolNoConf): {
-			PoolKeyHash:   poolNoConf,
-			RewardAccount: rewardNoConf,
-		},
-		poolHex(poolNoAccount): {
-			PoolKeyHash:   poolNoAccount,
-			RewardAccount: nil, // pool has no reward account → resolved as None
-		},
-		// poolAbsent intentionally omitted → left Resolved=false
-	}
-
 	cases := []struct {
 		name         string
 		pool         []byte
 		wantResolved bool
 		wantAutoVote uint8
 	}{
-		{"abstain", poolAbstain, true, models.PoolRewardAccountAutoVoteAbstain},
-		{"noconfidence", poolNoConf, true, models.PoolRewardAccountAutoVoteNoConfidence},
-		{"no_reward_account", poolNoAccount, true, models.PoolRewardAccountAutoVoteNone},
-		{"absent_from_params", poolAbsent, false, models.PoolRewardAccountAutoVoteNone},
+		{"account_absent", poolAbsent, false, models.PoolRewardAccountAutoVoteNone},
+		{"account_inactive", poolInactive, true, models.PoolRewardAccountAutoVoteNone},
+		{"account_active_noconfidence", poolNoConf, true, models.PoolRewardAccountAutoVoteNoConfidence},
 	}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			targetEpoch := uint64(101) // N-1
 			snaps := []*models.PoolStakeSnapshot{{
-				Epoch:          targetEpoch,
+				Epoch:          102,
 				SnapshotType:   "mark",
 				PoolKeyHash:    tc.pool,
 				TotalStake:     100,
 				DelegatorCount: 1,
 				CapturedSlot:   55,
 			}}
-			err := persistImportedSnapshot(
+			require.NoError(t, persistImportedSnapshot(
 				ImportConfig{
 					Database: db,
 					State: &RawLedgerState{
@@ -551,24 +554,12 @@ func TestPersistImportedSnapshotHistoricalResolvesFromPoolParams(t *testing.T) {
 					},
 				},
 				999,
-				snapshotImportTarget{
-					name:        "set",
-					targetEpoch: targetEpoch,
-					snap: &ParsedSnapShot{
-						PoolParams: poolParamsMap,
-					},
-				},
+				snapshotImportTarget{name: "mark", targetEpoch: 102},
 				snaps,
-			)
-			require.NoError(t, err)
+			))
 
-			stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
-				targetEpoch, "mark", nil,
-			)
+			stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(102, "mark", nil)
 			require.NoError(t, err)
-			// Each sub-test calls persistImportedSnapshot which first
-			// deletes all epoch-101 rows then inserts its own. Query the
-			// freshly-inserted row by matching the pool key hash.
 			var row *models.PoolStakeSnapshot
 			for i := range stored {
 				if bytes.Equal(stored[i].PoolKeyHash, tc.pool) {
@@ -576,13 +567,124 @@ func TestPersistImportedSnapshotHistoricalResolvesFromPoolParams(t *testing.T) {
 					break
 				}
 			}
-			require.NotNil(t, row, "snapshot row must be persisted")
+			require.NotNil(t, row)
 			require.Equal(t, tc.wantResolved, row.RewardAccountAutoVoteResolved,
 				"RewardAccountAutoVoteResolved mismatch for %s", tc.name)
 			require.Equal(t, tc.wantAutoVote, row.RewardAccountAutoVote,
 				"RewardAccountAutoVote mismatch for %s", tc.name)
 		})
 	}
+}
+
+// TestPersistImportedSnapshotHistoricalLeftUnresolved verifies that historical
+// N-1/N-2 imported rows (target epoch != import epoch) are left
+// RewardAccountAutoVoteResolved=false even when the snapshot bundle carries
+// pool params and a live reward account delegates to an Always* DRep.
+//
+// Faithful historical resolution would need the reward account's DRep
+// delegation AS OF the historical boundary, which is not recoverable after a
+// Mithril restore. Freezing live DRep state onto a historical boundary could
+// persist a value that was changed after the boundary, so the row is left
+// unresolved and the tally treats it as implicit no.
+func TestPersistImportedSnapshotHistoricalLeftUnresolved(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	poolKeyHash := bytes.Repeat([]byte{0x20}, 28)
+	rewardAccount := bytes.Repeat([]byte{0x30}, 28)
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test requires the sqlite metadata backend")
+	// Live account delegates to AlwaysAbstain. If historical resolution
+	// (incorrectly) used live state, the row would become Abstain/resolved.
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash:   poolKeyHash,
+		RewardAccount: rewardAccount,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardAccount,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+
+	targetEpoch := uint64(101) // N-1, import epoch is 102
+	snaps := []*models.PoolStakeSnapshot{{
+		Epoch:          targetEpoch,
+		SnapshotType:   "mark",
+		PoolKeyHash:    poolKeyHash,
+		TotalStake:     100,
+		DelegatorCount: 1,
+		CapturedSlot:   55,
+	}}
+	err = persistImportedSnapshot(
+		ImportConfig{
+			Database: db,
+			State: &RawLedgerState{
+				Epoch:      102,
+				EpochNonce: []byte{0x01},
+			},
+		},
+		999,
+		snapshotImportTarget{
+			name:        "set",
+			targetEpoch: targetEpoch,
+			snap: &ParsedSnapShot{
+				PoolParams: map[string]*ParsedPool{
+					string(poolKeyHash): {
+						PoolKeyHash:   poolKeyHash,
+						RewardAccount: rewardAccount,
+					},
+				},
+			},
+		},
+		snaps,
+	)
+	require.NoError(t, err)
+
+	stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+		targetEpoch, "mark", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.False(t, stored[0].RewardAccountAutoVoteResolved,
+		"historical N-1 row must remain unresolved (no historical DRep state)")
+	require.Equal(t, models.PoolRewardAccountAutoVoteNone, stored[0].RewardAccountAutoVote)
+}
+
+// TestCollectPoolsFromSnapshotsMarkWins verifies that when a pool appears in
+// more than one snapshot (Mark/Set/Go) with different reward accounts, the
+// Mark-era params win. The fallback import feeds the current-epoch auto-vote
+// resolver, which must read the current (Mark) reward account.
+func TestCollectPoolsFromSnapshotsMarkWins(t *testing.T) {
+	poolKeyHash := bytes.Repeat([]byte{0x42}, 28)
+	markReward := bytes.Repeat([]byte{0x01}, 28)
+	goReward := bytes.Repeat([]byte{0x02}, 28)
+
+	snapshots := &ParsedSnapShots{
+		Mark: ParsedSnapShot{
+			PoolParams: map[string]*ParsedPool{
+				string(poolKeyHash): {
+					PoolKeyHash:   poolKeyHash,
+					RewardAccount: markReward,
+				},
+			},
+		},
+		Go: ParsedSnapShot{
+			PoolParams: map[string]*ParsedPool{
+				string(poolKeyHash): {
+					PoolKeyHash:   poolKeyHash,
+					RewardAccount: goReward,
+				},
+			},
+		},
+	}
+
+	pools := collectPoolsFromSnapshots(snapshots)
+	require.Len(t, pools, 1)
+	require.Equal(t, markReward, pools[0].RewardAccount,
+		"Mark-era reward account must take precedence over Go-era")
 }
 
 // TestImportSnapShotsFallbackPoolsResolveCurrentEpoch verifies the end-to-end
@@ -656,11 +758,6 @@ func TestImportSnapShotsFallbackPoolsResolveCurrentEpoch(t *testing.T) {
 		"current-epoch snapshot must be resolved after pool fallback import")
 	require.Equal(t, models.PoolRewardAccountAutoVoteAbstain, stored[0].RewardAccountAutoVote,
 		"AlwaysAbstain reward account must produce Abstain auto-vote")
-}
-
-// poolHex is a test helper that hex-encodes a pool key hash.
-func poolHex(pkh []byte) string {
-	return fmt.Sprintf("%x", pkh)
 }
 
 func TestImportPParamsAnchorsAddedSlotToCurrentEpochStart(t *testing.T) {

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -416,6 +417,250 @@ func TestPersistImportedSnapshotResolvesAutoVoteOnlyForMark(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestPersistImportedSnapshotMissingPoolsNotResolved verifies that when no
+// pool rows exist in the DB (e.g. the fallback pool import has not yet run),
+// the current-epoch snapshot is NOT falsely marked Resolved=true. This is the
+// main correctness invariant from issue #2440: a missing pool row must not
+// produce an authoritative Resolved=true, AutoVote=None entry.
+func TestPersistImportedSnapshotMissingPoolsNotResolved(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	poolKeyHash := make([]byte, 28)
+	poolKeyHash[0] = 0x11
+	// Deliberately do NOT seed any Pool rows — simulating the state
+	// before fallback pool import.
+
+	snapshots := []*models.PoolStakeSnapshot{
+		{
+			Epoch:          102,
+			SnapshotType:   "mark",
+			PoolKeyHash:    poolKeyHash,
+			TotalStake:     100,
+			DelegatorCount: 1,
+			CapturedSlot:   55,
+		},
+	}
+
+	err = persistImportedSnapshot(
+		ImportConfig{
+			Database: db,
+			State: &RawLedgerState{
+				Epoch:      102,
+				EpochNonce: []byte{0x01},
+			},
+		},
+		999,
+		snapshotImportTarget{
+			name:        "mark",
+			targetEpoch: 102,
+		},
+		snapshots,
+	)
+	require.NoError(t, err)
+
+	stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(102, "mark", nil)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.False(t, stored[0].RewardAccountAutoVoteResolved,
+		"pool row absent: must NOT be falsely resolved")
+	require.Equal(t, models.PoolRewardAccountAutoVoteNone, stored[0].RewardAccountAutoVote)
+}
+
+// TestPersistImportedSnapshotHistoricalResolvesFromPoolParams verifies that
+// historical N-1/N-2 imported rows are resolved from the snapshot bundle's
+// own PoolParams when a reward account delegates to AlwaysAbstain or
+// AlwaysNoConfidence, and that rows whose pool key is absent from PoolParams
+// remain Resolved=false.
+func TestPersistImportedSnapshotHistoricalResolvesFromPoolParams(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	poolAbstain := bytes.Repeat([]byte{0x20}, 28)
+	poolNoConf := bytes.Repeat([]byte{0x21}, 28)
+	poolNoAccount := bytes.Repeat([]byte{0x22}, 28)
+	poolAbsent := bytes.Repeat([]byte{0x23}, 28) // not in PoolParams
+
+	rewardAbstain := bytes.Repeat([]byte{0x30}, 28)
+	rewardNoConf := bytes.Repeat([]byte{0x31}, 28)
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test requires the sqlite metadata backend")
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardAbstain,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardNoConf,
+		DrepType:   models.DrepTypeAlwaysNoConfidence,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+
+	poolParamsMap := map[string]*ParsedPool{
+		poolHex(poolAbstain): {
+			PoolKeyHash:   poolAbstain,
+			RewardAccount: rewardAbstain,
+		},
+		poolHex(poolNoConf): {
+			PoolKeyHash:   poolNoConf,
+			RewardAccount: rewardNoConf,
+		},
+		poolHex(poolNoAccount): {
+			PoolKeyHash:   poolNoAccount,
+			RewardAccount: nil, // pool has no reward account → resolved as None
+		},
+		// poolAbsent intentionally omitted → left Resolved=false
+	}
+
+	cases := []struct {
+		name         string
+		pool         []byte
+		wantResolved bool
+		wantAutoVote uint8
+	}{
+		{"abstain", poolAbstain, true, models.PoolRewardAccountAutoVoteAbstain},
+		{"noconfidence", poolNoConf, true, models.PoolRewardAccountAutoVoteNoConfidence},
+		{"no_reward_account", poolNoAccount, true, models.PoolRewardAccountAutoVoteNone},
+		{"absent_from_params", poolAbsent, false, models.PoolRewardAccountAutoVoteNone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			targetEpoch := uint64(101) // N-1
+			snaps := []*models.PoolStakeSnapshot{{
+				Epoch:          targetEpoch,
+				SnapshotType:   "mark",
+				PoolKeyHash:    tc.pool,
+				TotalStake:     100,
+				DelegatorCount: 1,
+				CapturedSlot:   55,
+			}}
+			err := persistImportedSnapshot(
+				ImportConfig{
+					Database: db,
+					State: &RawLedgerState{
+						Epoch:      102,
+						EpochNonce: []byte{0x01},
+					},
+				},
+				999,
+				snapshotImportTarget{
+					name:        "set",
+					targetEpoch: targetEpoch,
+					snap: &ParsedSnapShot{
+						PoolParams: poolParamsMap,
+					},
+				},
+				snaps,
+			)
+			require.NoError(t, err)
+
+			stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+				targetEpoch, "mark", nil,
+			)
+			require.NoError(t, err)
+			// Each sub-test calls persistImportedSnapshot which first
+			// deletes all epoch-101 rows then inserts its own. Query the
+			// freshly-inserted row by matching the pool key hash.
+			var row *models.PoolStakeSnapshot
+			for i := range stored {
+				if bytes.Equal(stored[i].PoolKeyHash, tc.pool) {
+					row = stored[i]
+					break
+				}
+			}
+			require.NotNil(t, row, "snapshot row must be persisted")
+			require.Equal(t, tc.wantResolved, row.RewardAccountAutoVoteResolved,
+				"RewardAccountAutoVoteResolved mismatch for %s", tc.name)
+			require.Equal(t, tc.wantAutoVote, row.RewardAccountAutoVote,
+				"RewardAccountAutoVote mismatch for %s", tc.name)
+		})
+	}
+}
+
+// TestImportSnapShotsFallbackPoolsResolveCurrentEpoch verifies the end-to-end
+// fix from issue #2440: when pools come from the snapshot-pool fallback path
+// (importPools runs before persistImportedSnapshot), the current-epoch snapshot
+// is correctly resolved rather than left with a false Resolved=true, AutoVote=None.
+func TestImportSnapShotsFallbackPoolsResolveCurrentEpoch(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	poolKeyHash := bytes.Repeat([]byte{0x42}, 28)
+	rewardAccount := bytes.Repeat([]byte{0x43}, 28)
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok, "test requires the sqlite metadata backend")
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: rewardAccount,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		AddedSlot:  1,
+		Active:     true,
+	}).Error)
+
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+	}
+	// Simulate the fallback pool import that now runs BEFORE snapshot
+	// processing in importSnapShots.
+	require.NoError(t, importPools(
+		context.Background(),
+		cfg,
+		[]ParsedPool{{
+			PoolKeyHash:   poolKeyHash,
+			RewardAccount: rewardAccount,
+			VrfKeyHash:    bytes.Repeat([]byte{0x44}, 32),
+			MarginDen:     1,
+		}},
+		999,
+	))
+
+	// Now call persistImportedSnapshot for the current epoch,
+	// which should find the pool row and correctly resolve auto-votes.
+	poolSnapshots := []*models.PoolStakeSnapshot{{
+		Epoch:          102,
+		SnapshotType:   "mark",
+		PoolKeyHash:    poolKeyHash,
+		TotalStake:     5_000_000,
+		DelegatorCount: 1,
+		CapturedSlot:   999,
+	}}
+	require.NoError(t, persistImportedSnapshot(
+		ImportConfig{
+			Database: db,
+			State: &RawLedgerState{
+				Epoch:      102,
+				EpochNonce: []byte{0x01},
+			},
+		},
+		999,
+		snapshotImportTarget{name: "mark", targetEpoch: 102},
+		poolSnapshots,
+	))
+
+	stored, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(102, "mark", nil)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.True(t, stored[0].RewardAccountAutoVoteResolved,
+		"current-epoch snapshot must be resolved after pool fallback import")
+	require.Equal(t, models.PoolRewardAccountAutoVoteAbstain, stored[0].RewardAccountAutoVote,
+		"AlwaysAbstain reward account must produce Abstain auto-vote")
+}
+
+// poolHex is a test helper that hex-encodes a pool key hash.
+func poolHex(pkh []byte) string {
+	return fmt.Sprintf("%x", pkh)
 }
 
 func TestImportPParamsAnchorsAddedSlotToCurrentEpochStart(t *testing.T) {


### PR DESCRIPTION
Closes #2440 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect SPO reward‑account auto‑vote resolution for Mithril‑imported snapshots, preventing false Resolved=true/AutoVote=None entries and correctly handling current and historical rows. Fixes #2440.

- **Bug Fixes**
  - Set `RewardAccountAutoVoteResolved=true` only when determined from real data: pool exists with no reward account (confirmed None), or reward account row exists (active → Abstain/NoConfidence; inactive → None). Missing pool or missing account row stays unresolved.
  - Run fallback pool import before snapshot processing so current‑epoch rows resolve against real pool data; when a pool appears in multiple snapshots, Mark‑era params win.
  - Leave historical N‑1/N‑2 rows unresolved (implicit None) because historical DRep delegation isn’t available after a Mithril restore.
  - Added tests for missing pools, account absent vs inactive vs active, Mark‑wins precedence, and the fallback path end‑to‑end.

<sup>Written for commit d4feecb285a13a8152808eb156a3093989c739f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of stake pool reward account auto-vote resolution by distinguishing between unresolved and resolved states.
  * Enhanced handling of edge cases when pool registrations are missing from the database.
  * More reliable historical epoch snapshot processing using embedded pool data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->