### PR TITLE
feat(midnight): add MidnightState gRPC server lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -627,11 +627,12 @@ When `Node.Run()` is called, components are initialized in this order:
 16. Stalled client recycler (background goroutine)
 17. UTxO RPC server (if API storage mode and port configured)
 18. Bark C2/archive server (if port configured)
-19. Blockfrost API (if API storage mode and port configured)
-20. Mesh API (if API storage mode and port configured)
-21. Off-chain metadata fetcher (if API storage mode)
-22. Block forger + leader election (if block producer mode)
-23. Wait for shutdown signal
+19. Midnight gRPC server (if API storage mode and midnight port configured)
+20. Blockfrost API (if API storage mode and port configured)
+21. Mesh API (if API storage mode and port configured)
+22. Off-chain metadata fetcher (if API storage mode)
+23. Block forger + leader election (if block producer mode)
+24. Wait for shutdown signal
 ```
 
 ### Shutdown Flow
@@ -642,8 +643,8 @@ Graceful shutdown proceeds in phases:
 Phase 1: Stop accepting new work
   Block forger, leader election, chain selector,
   peer governor, snapshot manager, UTxO RPC,
-  Bark C2/archive server, Blockfrost API, Mesh API,
-  off-chain metadata fetcher
+  Bark C2/archive server, Midnight gRPC server,
+  Blockfrost API, Mesh API, off-chain metadata fetcher
 
 Phase 2: Drain and close connections
   Mempool, ConnectionManager

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -540,6 +540,10 @@ dingo/
 │   ├── bark.go          # Bark server lifecycle and transport setup
 │   ├── archive.go       # Archive service interface
 │   └── blob.go          # Remote archive blob adapter
+├── midnight/            # Midnight MidnightState gRPC compatibility surface
+│   ├── midnight_state*.pb.go # Generated google.golang.org/grpc service stubs
+│   └── server/          # Native gRPC server lifecycle (reflection, health, TLS)
+│       └── server.go    # Serves a stub MidnightState (Unimplemented) scaffold
 ├── mithril/             # Mithril snapshot bootstrap
 │   ├── bootstrap.go     # Bootstrap orchestration
 │   ├── client.go        # Mithril aggregator client
@@ -590,6 +594,7 @@ type Node struct {
     historyExpiry  *historyexpiry.Pruner          // Local block history expiry
     blockfrostAPI  *blockfrost.Blockfrost         // Blockfrost REST API
     meshAPI        *mesh.Server                   // Mesh (Rosetta) API
+    midnightServer *midnightserver.Server         // Midnight MidnightState gRPC server
     offchainMetadataFetcher *offchainmetadata.Fetcher // Off-chain metadata
     ouroboros      *ouroboros.Ouroboros            // Protocol handlers
     blockForger    *forging.BlockForger           // Block production
@@ -749,6 +754,20 @@ Dingo supports two storage modes, configured via `storageMode`:
 
 - `core` (default): Minimal storage for chain following and block production.
 - `api`: Extended storage with transaction indexes, address lookups, and asset tracking. Required when any client-facing API server (Blockfrost, Mesh, UTxO RPC) is enabled. Bark is a separate Dingo-to-Dingo protocol and is not part of that API surface.
+
+### Midnight gRPC Server
+
+In `storageMode: api` with `midnight.port > 0`, `node.go` starts
+`midnight/server.Server`, a native `google.golang.org/grpc` server (not
+ConnectRPC, for byte-for-byte compatibility with the Acropolis tonic service)
+on its own `midnight.host:midnight.port` listener. It registers a stub
+`MidnightState` service whose RPCs return `Unimplemented`, plus gRPC reflection
+and a `grpc_health_v1` health service reporting `SERVING`. TLS is enabled when
+the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start` binds the
+listener synchronously (so bind/cert errors surface immediately) and serves in
+a goroutine; a context watcher performs a bounded `GracefulStop`, escalating to
+a hard `Stop` on timeout. Setting `midnight.port` to `0` disables the server
+without affecting indexer eligibility.
 
 ### Off-chain Metadata Fetching
 

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -193,8 +193,13 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) Stop(ctx context.Context) error {
 	timeout := s.config.ShutdownTimeout
 	if deadline, ok := ctx.Deadline(); ok {
+		// An already-elapsed deadline means the node's shutdown budget is
+		// spent, so escalate straight to a hard stop rather than waiting out
+		// the default grace window.
 		if remaining := time.Until(deadline); remaining > 0 {
 			timeout = remaining
+		} else {
+			timeout = 0
 		}
 	}
 	s.gracefulStop(timeout)

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package server runs the MidnightState gRPC service. It is a native
+// google.golang.org/grpc server (not ConnectRPC) so that clients written
+// against the Acropolis tonic service are byte-for-byte compatible. This
+// package is the server scaffold: it registers a stub MidnightState service
+// whose RPCs all return Unimplemented; the real handlers are added separately.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/dingo/midnight"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+const (
+	defaultHost            = "0.0.0.0"
+	defaultPort            = 50051
+	defaultShutdownTimeout = 30 * time.Second
+)
+
+// Config holds the configuration for the Midnight gRPC server.
+type Config struct {
+	Logger *slog.Logger
+	// Host and Port are the gRPC listen address. Defaults to 0.0.0.0:50051.
+	Host string
+	Port uint
+	// TLSCertFilePath and TLSKeyFilePath enable TLS when both are set. When
+	// both are empty the server listens without TLS. Setting only one is an
+	// error.
+	TLSCertFilePath string
+	TLSKeyFilePath  string
+	// ShutdownTimeout bounds GracefulStop before escalating to a hard Stop.
+	// Defaults to 30s.
+	ShutdownTimeout time.Duration
+}
+
+// Server runs the MidnightState gRPC service over its own listener.
+type Server struct {
+	mu         sync.Mutex // protects grpcServer and health
+	config     Config
+	grpcServer *grpc.Server
+	health     *health.Server
+}
+
+// New validates cfg and returns a Server. It does not bind or serve; call
+// Start for that.
+func New(cfg Config) (*Server, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	cfg.Logger = cfg.Logger.With("component", "midnight-grpc")
+	if cfg.Host == "" {
+		cfg.Host = defaultHost
+	}
+	if cfg.Port == 0 {
+		cfg.Port = defaultPort
+	}
+	if cfg.ShutdownTimeout <= 0 {
+		cfg.ShutdownTimeout = defaultShutdownTimeout
+	}
+	if (cfg.TLSCertFilePath != "") != (cfg.TLSKeyFilePath != "") {
+		return nil, errors.New(
+			"midnight grpc: both tls cert and key must be specified",
+		)
+	}
+	return &Server{config: cfg}, nil
+}
+
+// Start binds the listener and serves the gRPC server in a background
+// goroutine. Binding and any TLS keypair load happen synchronously so that
+// address-in-use and certificate errors surface before Start returns. A
+// goroutine watches ctx and performs a bounded graceful shutdown when it is
+// cancelled.
+func (s *Server) Start(ctx context.Context) error {
+	useTLS := s.config.TLSCertFilePath != "" && s.config.TLSKeyFilePath != ""
+
+	var opts []grpc.ServerOption
+	serverType := "non-TLS"
+	if useTLS {
+		serverType = "TLS"
+		creds, err := credentials.NewServerTLSFromFile(
+			s.config.TLSCertFilePath,
+			s.config.TLSKeyFilePath,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"midnight grpc: load TLS keypair: %w",
+				err,
+			)
+		}
+		opts = append(opts, grpc.Creds(creds))
+	}
+
+	addr := net.JoinHostPort(
+		s.config.Host,
+		strconv.FormatUint(uint64(s.config.Port), 10),
+	)
+
+	s.mu.Lock()
+	if s.grpcServer != nil {
+		s.mu.Unlock()
+		return errors.New("midnight grpc: server already started")
+	}
+
+	grpcServer := grpc.NewServer(opts...)
+	// Stub MidnightState service: every RPC returns Unimplemented until the
+	// real handlers land.
+	midnight.RegisterMidnightStateServer(grpcServer, &stubService{})
+
+	// Health service reporting SERVING for the overall server ("") and the
+	// MidnightState service by name.
+	healthSrv := health.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, healthSrv)
+	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthSrv.SetServingStatus(
+		midnight.MidnightState_ServiceDesc.ServiceName,
+		healthpb.HealthCheckResponse_SERVING,
+	)
+
+	// Reflection so grpcurl and similar tooling work out of the box.
+	reflection.Register(grpcServer)
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		s.mu.Unlock()
+		grpcServer.Stop()
+		return fmt.Errorf("midnight grpc: listen on %s: %w", addr, err)
+	}
+
+	s.grpcServer = grpcServer
+	s.health = healthSrv
+	s.mu.Unlock()
+
+	s.config.Logger.Info(
+		fmt.Sprintf(
+			"starting midnight gRPC %s listener on %s",
+			serverType,
+			addr,
+		),
+	)
+
+	go func() {
+		if serveErr := grpcServer.Serve(ln); serveErr != nil &&
+			!errors.Is(serveErr, grpc.ErrServerStopped) {
+			s.config.Logger.Error(
+				"midnight gRPC server error",
+				"error",
+				serveErr,
+			)
+		}
+	}()
+
+	go func() { //nolint:gosec // goroutine intentionally outlives ctx to perform graceful shutdown
+		<-ctx.Done()
+		s.config.Logger.Debug(
+			"context cancelled, shutting down midnight gRPC server",
+		)
+		s.gracefulStop(s.config.ShutdownTimeout)
+	}()
+
+	return nil
+}
+
+// Stop gracefully shuts the server down, bounded by ctx's deadline when set
+// and otherwise by the configured shutdown timeout. It is safe to call
+// repeatedly and concurrently with the context-cancellation path.
+func (s *Server) Stop(ctx context.Context) error {
+	timeout := s.config.ShutdownTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 {
+			timeout = remaining
+		}
+	}
+	s.gracefulStop(timeout)
+	return nil
+}
+
+// gracefulStop attempts GracefulStop, escalating to a hard Stop if it does not
+// complete within timeout. The first caller to claim the server wins; later
+// calls observe a nil server and return immediately, making this idempotent.
+func (s *Server) gracefulStop(timeout time.Duration) {
+	s.mu.Lock()
+	grpcServer := s.grpcServer
+	healthSrv := s.health
+	s.grpcServer = nil
+	s.health = nil
+	s.mu.Unlock()
+
+	if grpcServer == nil {
+		return
+	}
+
+	// Fail readiness checks and in-flight health watches before draining.
+	if healthSrv != nil {
+		healthSrv.Shutdown()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		s.config.Logger.Warn(
+			"midnight gRPC graceful shutdown timed out; forcing stop",
+			"timeout",
+			timeout,
+		)
+		grpcServer.Stop()
+		<-done
+	}
+}
+
+// stubService is the placeholder MidnightState implementation. Embedding
+// UnimplementedMidnightStateServer makes every RPC return codes.Unimplemented
+// until the real handlers are added in follow-up work.
+type stubService struct {
+	midnight.UnimplementedMidnightStateServer
+}

--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -160,7 +160,9 @@ func TestShutdownOnContextCancel(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 	addr := net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
 
 	// While running, the stub answers Unimplemented.

--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/midnight"
+	"github.com/blinklabs-io/dingo/midnight/server"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	"google.golang.org/grpc/status"
+)
+
+// freePort returns a currently-free TCP port on the loopback interface.
+func freePort(t *testing.T) uint {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return uint(port) //nolint:gosec // port is always in range
+}
+
+// startTestServer starts a server on a free loopback port and returns its
+// dial address. The server is stopped on test cleanup.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	port := freePort(t)
+	srv, err := server.New(server.Config{
+		Host: "127.0.0.1",
+		Port: port,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+
+	return net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
+}
+
+func dial(t *testing.T, addr string) *grpc.ClientConn {
+	t.Helper()
+	conn, err := grpc.NewClient(
+		addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// The stub service must answer every RPC with codes.Unimplemented.
+func TestStubServiceReturnsUnimplemented(t *testing.T) {
+	addr := startTestServer(t)
+	client := midnight.NewMidnightStateClient(dial(t, addr))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := client.GetLatestBlock(ctx, &midnight.LatestBlockRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+// The health service must report SERVING for both the overall server and the
+// MidnightState service by name.
+func TestHealthCheckServing(t *testing.T) {
+	addr := startTestServer(t)
+	hc := healthpb.NewHealthClient(dial(t, addr))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, svc := range []string{"", midnight.MidnightState_ServiceDesc.ServiceName} {
+		resp, err := hc.Check(
+			ctx,
+			&healthpb.HealthCheckRequest{Service: svc},
+		)
+		require.NoError(t, err, "service %q", svc)
+		require.Equal(
+			t,
+			healthpb.HealthCheckResponse_SERVING,
+			resp.GetStatus(),
+			"service %q",
+			svc,
+		)
+	}
+}
+
+// Reflection must be enabled and advertise the MidnightState service.
+func TestReflectionListsService(t *testing.T) {
+	addr := startTestServer(t)
+	client := reflectionpb.NewServerReflectionClient(dial(t, addr))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.ServerReflectionInfo(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&reflectionpb.ServerReflectionRequest{
+		MessageRequest: &reflectionpb.ServerReflectionRequest_ListServices{
+			ListServices: "*",
+		},
+	}))
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+
+	var names []string
+	for _, svc := range resp.GetListServicesResponse().GetService() {
+		names = append(names, svc.GetName())
+	}
+	require.Contains(t, names, midnight.MidnightState_ServiceDesc.ServiceName)
+}
+
+// New rejects a half-configured TLS pair (cert without key, or key without
+// cert).
+func TestNewRequiresBothTLSPaths(t *testing.T) {
+	_, err := server.New(server.Config{TLSCertFilePath: "cert.pem"})
+	require.Error(t, err)
+	_, err = server.New(server.Config{TLSKeyFilePath: "key.pem"})
+	require.Error(t, err)
+}
+
+// Cancelling the context passed to Start must shut the server down.
+func TestShutdownOnContextCancel(t *testing.T) {
+	port := freePort(t)
+	srv, err := server.New(server.Config{
+		Host: "127.0.0.1",
+		Port: port,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, srv.Start(ctx))
+	addr := net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
+
+	// While running, the stub answers Unimplemented.
+	client := midnight.NewMidnightStateClient(dial(t, addr))
+	callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer callCancel()
+	_, err = client.GetLatestBlock(callCtx, &midnight.LatestBlockRequest{})
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	// Cancellation triggers graceful shutdown; once stopped a fresh call no
+	// longer reaches the handler (transport error, not Unimplemented).
+	cancel()
+	testutil.WaitForCondition(t, func() bool {
+		conn, dialErr := grpc.NewClient(
+			addr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if dialErr != nil {
+			return true
+		}
+		defer conn.Close()
+		c := midnight.NewMidnightStateClient(conn)
+		probeCtx, probeCancel := context.WithTimeout(
+			context.Background(),
+			200*time.Millisecond,
+		)
+		defer probeCancel()
+		_, probeErr := c.GetLatestBlock(probeCtx, &midnight.LatestBlockRequest{})
+		return status.Code(probeErr) != codes.Unimplemented
+	}, 5*time.Second, "server did not shut down after context cancel")
+}
+
+// Stop is idempotent and safe to call when the server was never started or
+// already stopped.
+func TestStopIdempotent(t *testing.T) {
+	srv, err := server.New(server.Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, srv.Stop(ctx))
+	require.NoError(t, srv.Stop(ctx))
+}

--- a/node.go
+++ b/node.go
@@ -45,6 +45,7 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/leios"
 	"github.com/blinklabs-io/dingo/ledger/snapshot"
 	"github.com/blinklabs-io/dingo/mempool"
+	midnightserver "github.com/blinklabs-io/dingo/midnight/server"
 	ouroborosPkg "github.com/blinklabs-io/dingo/ouroboros"
 	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -69,6 +70,7 @@ type Node struct {
 	historyExpiry                    *historyexpiry.Pruner
 	blockfrostAPI                    *blockfrost.Blockfrost
 	meshAPI                          *mesh.Server
+	midnightServer                   *midnightserver.Server
 	offchainMetadataFetcher          *offchainmetadata.Fetcher
 	ouroboros                        *ouroborosPkg.Ouroboros
 	blockForger                      *forging.BlockForger
@@ -980,6 +982,38 @@ func (n *Node) Run(ctx context.Context) error {
 		started = append(started, func() { //nolint:contextcheck
 			if err := n.bark.Stop(context.Background()); err != nil {
 				n.config.logger.Error("failed to stop bark during cleanup", "error", err)
+			}
+		})
+	}
+
+	// Configure the Midnight gRPC server (only in API mode with a non-zero
+	// port). Port 0 disables the server while leaving the indexer eligible to
+	// run.
+	if n.config.storageMode.IsAPI() && n.config.midnight.Port > 0 {
+		var err error
+		n.midnightServer, err = midnightserver.New(
+			midnightserver.Config{
+				Logger:          n.config.logger,
+				Host:            n.config.midnight.Host,
+				Port:            n.config.midnight.Port,
+				TLSCertFilePath: n.config.tlsCertFilePath,
+				TLSKeyFilePath:  n.config.tlsKeyFilePath,
+				ShutdownTimeout: n.config.shutdownTimeout,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create midnight gRPC server: %w", err)
+		}
+		if err := n.midnightServer.Start(n.ctx); err != nil { //nolint:contextcheck
+			return fmt.Errorf("starting midnight gRPC server: %w", err)
+		}
+		started = append(started, func() { //nolint:contextcheck
+			if err := n.midnightServer.Stop(context.Background()); err != nil {
+				n.config.logger.Error(
+					"failed to stop midnight gRPC server during cleanup",
+					"error",
+					err,
+				)
 			}
 		})
 	}

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -143,6 +143,15 @@ func (n *Node) shutdown() error {
 		}
 	}
 
+	if n.midnightServer != nil {
+		if stopErr := n.midnightServer.Stop(ctx); stopErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("midnight gRPC server shutdown: %w", stopErr),
+			)
+		}
+	}
+
 	if n.historyExpiry != nil {
 		if stopErr := n.historyExpiry.Stop(ctx); stopErr != nil {
 			err = errors.Join(


### PR DESCRIPTION
Closes #2117

Stands up a native `google.golang.org/grpc` server for the MidnightState service — the server scaffold; real RPC handlers come in follow-up issues.

## What this does
- **New `midnight/server` package** (`New`/`Start`/`Stop`) mirroring the `bark` / `api/utxorpc` lifecycle idiom: synchronous listener bind (so address-in-use and cert errors surface before `Start` returns), then serve in a background goroutine; mutex-guarded start/stop.
- **Native gRPC, not ConnectRPC** — for byte-for-byte client compatibility with the Acropolis tonic service.
- **Stub `MidnightState` service** embedding the generated `UnimplementedMidnightStateServer`, so every RPC returns `Unimplemented`.
- **gRPC reflection** enabled (`reflection.Register`) so `grpcurl` and friends work out of the box.
- **Health** via `google.golang.org/grpc/health` (`grpc_health_v1`), reporting `SERVING` for both the overall server (`""`) and `midnight_state.MidnightState`.
- **Optional TLS**, gated on the shared `tlsCertFilePath`/`tlsKeyFilePath` (both-or-neither validation, same paths as utxorpc/bark).
- **Graceful shutdown tied to the node context**: a context watcher runs `GracefulStop` bounded by a timeout, escalating to a hard `Stop` on overrun.
- **Node wiring** (`node.go`, `node_shutdown.go`): constructed/started in API storage mode when `midnight.port > 0`, registered in the startup cleanup slice and shutdown Phase 1. **Port 0 disables the server** while leaving the indexer eligible to run. Host/port come from the `midnight` config section (default `0.0.0.0:50051`).

No config changes were needed — the `midnight.host`/`midnight.port` plumbing and the port-0-disables-server semantics already exist (#2113), and `dingo.yaml.example` already documents them.

## Tests
`go test -race ./midnight/server/` — 6 tests, no `time.Sleep` (uses `internal/test/testutil`):
- stub RPC returns `Unimplemented`
- health reports `SERVING` for `""` and the named service
- reflection lists `midnight_state.MidnightState`
- `New` rejects a half-configured TLS pair
- graceful shutdown on context cancellation
- `Stop` is idempotent

## Checks
- `go build ./...`, `go vet` — clean
- `golangci-lint run` — 0 issues; `modernize` — clean; `make import-boundaries` — passes

## Docs
- **ARCHITECTURE.md** — new "Midnight gRPC Server" subsection, `midnightServer` Node field, and `midnight/` directory entry.
- **DATABASE.md** — checked, not affected (no DB/model/query changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native `google.golang.org/grpc` MidnightState server with a clean start/stop lifecycle and node wiring. Uses the Acropolis-compatible gRPC surface; RPCs are stubbed for now.

- **New Features**
  - `midnight/server` with `New`/`Start`/`Stop`; sync listener bind, serve in a goroutine.
  - Stub `MidnightState` (returns Unimplemented).
  - gRPC reflection and `grpc_health_v1` health reporting SERVING for "" and `midnight_state.MidnightState`.
  - Optional TLS via `tlsCertFilePath`/`tlsKeyFilePath` (both-or-neither).
  - Graceful shutdown on node context; bounded `GracefulStop`, then hard `Stop` on timeout.
  - Node wiring: starts in API storage mode when `midnight.port > 0`; port 0 disables; host/port from `midnight` config.

- **Bug Fixes**
  - `Stop` now hard-stops immediately when the caller’s context deadline is already elapsed, preventing shutdown overruns.

<sup>Written for commit 8a47942354a8f7dd09e2911549712b67b8926362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Midnight gRPC server available in API storage mode
  * Configurable via `midnight.port` setting (set to 0 to disable)
  * Includes gRPC health checks and service reflection capabilities
  * TLS support with configurable certificate/key configuration
  * Graceful shutdown handling with timeout escalation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->