### PR TITLE
feat(leios): serve forged EB bodies

### DIFF
--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -137,9 +137,16 @@ type LeiosProduceChecker interface {
 }
 
 // EndorserBlockBroadcaster stores a locally-forged endorser block and
-// notifies connected peers via the LeiosNotify protocol.
+// notifies connected peers via the LeiosNotify protocol. txBodies are the
+// referenced transactions' raw CBOR, in manifest order, so the endorser block
+// can also be served over leios-fetch.
 type EndorserBlockBroadcaster interface {
-	BroadcastEndorserBlock(slot uint64, hash []byte, cbor []byte) error
+	BroadcastEndorserBlock(
+		slot uint64,
+		hash []byte,
+		cbor []byte,
+		txBodies [][]byte,
+	) error
 }
 
 // SlotClockProvider provides current slot information from the slot clock.
@@ -734,7 +741,7 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 		return nil
 	}
 
-	ebCbor, ebHash, txRefCount, err := buildLeiosEB(txs)
+	ebCbor, ebHash, bodies, err := buildLeiosEB(txs)
 	if err != nil {
 		if errors.Is(err, errNoValidTxRefs) {
 			f.logger.Debug("leios EB skipped: no valid tx refs", "slot", slot)
@@ -746,7 +753,15 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 		return fmt.Errorf("build leios EB: %w", err)
 	}
 
-	if err := f.leiosEBCaster.BroadcastEndorserBlock(slot, ebHash, ebCbor); err != nil {
+	// Pass the transaction bodies alongside the manifest so the endorser
+	// block can be served to peers over leios-fetch (they request the bodies
+	// after fetching the manifest).
+	if err := f.leiosEBCaster.BroadcastEndorserBlock(
+		slot,
+		ebHash,
+		ebCbor,
+		bodies,
+	); err != nil {
 		return fmt.Errorf("broadcast leios EB: %w", err)
 	}
 
@@ -754,7 +769,7 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 		"leios endorser block produced",
 		"slot", slot,
 		"hash", hex.EncodeToString(ebHash),
-		"tx_refs", txRefCount,
+		"tx_refs", len(bodies),
 	)
 	if f.metrics != nil {
 		f.metrics.leiosEbForged.Inc()
@@ -768,8 +783,13 @@ func (f *BlockForger) checkAndForgeLeiosEB(slot uint64) error {
 // when no valid references remain after filtering.
 func buildLeiosEB(
 	txs []MempoolTransaction,
-) (cbor []byte, hash []byte, txRefCount int, err error) {
+) (cbor []byte, hash []byte, bodies [][]byte, err error) {
 	refs := make([]lcommon.LeiosTransactionReference, 0, len(txs))
+	// bodies holds each referenced transaction's raw CBOR, in the same order
+	// as refs, so the endorser block can serve them over leios-fetch. A
+	// transaction dropped from refs (bad hash or size) is dropped here too,
+	// keeping body i aligned with reference i.
+	bodies = make([][]byte, 0, len(txs))
 	for _, tx := range txs {
 		raw, hexErr := hex.DecodeString(tx.Hash)
 		if hexErr != nil || len(raw) != 32 {
@@ -783,17 +803,18 @@ func buildLeiosEB(
 			TransactionHash: lcommon.NewBlake2b256(raw),
 			TransactionSize: uint16(sz), // #nosec G115 -- bounded above
 		})
+		bodies = append(bodies, tx.Cbor)
 	}
 	if len(refs) == 0 {
-		return nil, nil, 0, errNoValidTxRefs
+		return nil, nil, nil, errNoValidTxRefs
 	}
 	eb := lcommon.LeiosEndorserBlock{TransactionReferences: refs}
 	ebCbor, marshalErr := eb.MarshalCBOR()
 	if marshalErr != nil {
-		return nil, nil, 0, fmt.Errorf("marshal leios EB: %w", marshalErr)
+		return nil, nil, nil, fmt.Errorf("marshal leios EB: %w", marshalErr)
 	}
 	h := lcommon.Blake2b256Hash(ebCbor)
-	return ebCbor, h.Bytes(), len(refs), nil
+	return ebCbor, h.Bytes(), bodies, nil
 }
 
 // modeString returns a string representation of the forging mode.

--- a/ledger/forging/leios_eb_build_test.go
+++ b/ledger/forging/leios_eb_build_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"strings"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildLeiosEBBodiesAlignWithRefs verifies that buildLeiosEB returns the
+// transaction bodies in the same order as the manifest references, and that a
+// transaction dropped from the manifest (invalid hash or size) is dropped from
+// the bodies too, so body i stays aligned with reference i.
+func TestBuildLeiosEBBodiesAlignWithRefs(t *testing.T) {
+	txs := []MempoolTransaction{
+		{Hash: strings.Repeat("11", 32), Cbor: []byte{0x01}},
+		{Hash: "not-hex", Cbor: []byte{0x02}},            // dropped: bad hash
+		{Hash: strings.Repeat("22", 32), Cbor: []byte{}}, // dropped: zero size
+		{Hash: strings.Repeat("33", 32), Cbor: []byte{0x03, 0x04}},
+	}
+
+	ebCbor, ebHash, bodies, err := buildLeiosEB(txs)
+	require.NoError(t, err)
+	require.NotEmpty(t, ebHash)
+
+	// Only the two valid transactions survive, in input order.
+	require.Len(t, bodies, 2)
+	require.Equal(t, []byte{0x01}, bodies[0])
+	require.Equal(t, []byte{0x03, 0x04}, bodies[1])
+
+	// The manifest references match the surviving bodies in order and size.
+	eb, err := lcommon.NewLeiosEndorserBlockFromCbor(ebCbor)
+	require.NoError(t, err)
+	require.Len(t, eb.TransactionReferences, len(bodies))
+	for i, ref := range eb.TransactionReferences {
+		require.Equalf(
+			t,
+			len(bodies[i]),
+			int(ref.TransactionSize),
+			"reference %d size matches body length",
+			i,
+		)
+	}
+}
+
+// TestBuildLeiosEBNoValidRefs verifies buildLeiosEB returns errNoValidTxRefs
+// when no transaction yields a valid reference.
+func TestBuildLeiosEBNoValidRefs(t *testing.T) {
+	_, _, bodies, err := buildLeiosEB([]MempoolTransaction{
+		{Hash: "not-hex", Cbor: []byte{0x01}},
+	})
+	require.ErrorIs(t, err, errNoValidTxRefs)
+	require.Nil(t, bodies)
+}

--- a/ouroboros/leios_forge_serve_test.go
+++ b/ouroboros/leios_forge_serve_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServeForgedEndorserBlockTxs verifies that a locally-forged endorser
+// block's transaction bodies are stored alongside its manifest so the
+// leios-fetch server can serve them, in manifest order, honoring the requested
+// bitmap. Each served transaction is the on-the-wire byte-string wrap of the
+// forged body, so it decodes back to the original body on the requesting side.
+func TestServeForgedEndorserBlockTxs(t *testing.T) {
+	o := &Ouroboros{leiosEBLog: newLeiosForgedEBLog()}
+
+	// Three forged transaction bodies (arbitrary raw CBOR is fine; they are
+	// only stored and served, not decoded as transactions here).
+	bodies := [][]byte{
+		{0x83, 0x01, 0x02, 0x03},
+		{0x84, 0x0a, 0x0b, 0x0c, 0x0d},
+		{0x82, 0xf6},
+	}
+	// Build the manifest in the same order as the bodies.
+	refs := make([]lcommon.LeiosTransactionReference, len(bodies))
+	for i, b := range bodies {
+		var h [32]byte
+		h[0] = byte(i + 1)
+		refs[i] = lcommon.LeiosTransactionReference{
+			TransactionHash: lcommon.NewBlake2b256(h[:]),
+			TransactionSize: uint16(len(b)), //nolint:gosec // small test bodies
+		}
+	}
+	ebCbor, err := lcommon.LeiosEndorserBlock{
+		TransactionReferences: refs,
+	}.MarshalCBOR()
+	require.NoError(t, err)
+	ebHash := lcommon.Blake2b256Hash(ebCbor).Bytes()
+	const slot = uint64(42)
+
+	// Forge + broadcast: this stores the EB with its transaction bodies.
+	require.NoError(t, o.BroadcastEndorserBlock(slot, ebHash, ebCbor, bodies))
+	point := ocommon.Point{Slot: slot, Hash: ebHash}
+
+	// Full request: all three transactions (window 0, bits 0..2).
+	resp, err := o.leiosfetchServerBlockTxsRequest(
+		oleiosfetch.CallbackContext{},
+		point,
+		map[uint16]uint64{0: 0b111},
+	)
+	require.NoError(t, err)
+	msg, ok := resp.(*oleiosfetch.MsgBlockTxs)
+	require.True(t, ok)
+	require.Len(t, msg.TxsRaw, len(bodies))
+	for i, raw := range msg.TxsRaw {
+		var inner []byte
+		_, derr := cbor.Decode(raw, &inner)
+		require.NoErrorf(t, derr, "served tx %d should be a CBOR byte string", i)
+		require.Equalf(
+			t,
+			bodies[i],
+			inner,
+			"served tx %d should round-trip to the forged body",
+			i,
+		)
+	}
+
+	// Partial request: only transaction index 1 (window 0, bit 1).
+	resp2, err := o.leiosfetchServerBlockTxsRequest(
+		oleiosfetch.CallbackContext{},
+		point,
+		map[uint16]uint64{0: 0b010},
+	)
+	require.NoError(t, err)
+	msg2, ok := resp2.(*oleiosfetch.MsgBlockTxs)
+	require.True(t, ok)
+	require.Len(t, msg2.TxsRaw, 1)
+	var inner1 []byte
+	_, err = cbor.Decode(msg2.TxsRaw[0], &inner1)
+	require.NoError(t, err)
+	require.Equal(t, bodies[1], inner1)
+}

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -169,15 +169,33 @@ func (l *leiosForgedEBLog) pruneLocked() {
 }
 
 // BroadcastEndorserBlock stores a locally-forged EB and notifies waiting
-// LeiosNotify server goroutines so they can announce it to peers.
-// It satisfies forging.EndorserBlockBroadcaster.
+// LeiosNotify server goroutines so they can announce it to peers. txBodies are
+// the referenced transactions' raw CBOR in manifest order; they are stored in
+// the endorser block's tx cache so the EB can be served to peers over
+// leios-fetch (completeTxCache() then holds and leiosfetchServerBlockTxsRequest
+// can answer). It satisfies forging.EndorserBlockBroadcaster.
 func (o *Ouroboros) BroadcastEndorserBlock(
 	slot uint64,
 	hash []byte,
 	data []byte,
+	txBodies [][]byte,
 ) error {
 	point := ocommon.Point{Slot: slot, Hash: hash}
-	if err := o.storeLeiosEndorserBlock(point, data, nil); err != nil {
+	// Match the on-the-wire form fetched EB transactions are stored in: each
+	// transaction is a CBOR byte string wrapping its CBOR (LeiosTx =
+	// encodeBytes(txCbor)), so served forged-EB bodies decode identically.
+	var txsRaw []cbor.RawMessage
+	if len(txBodies) > 0 {
+		txsRaw = make([]cbor.RawMessage, 0, len(txBodies))
+		for i, body := range txBodies {
+			wrapped, err := cbor.Encode(body)
+			if err != nil {
+				return fmt.Errorf("encode forged EB tx %d: %w", i, err)
+			}
+			txsRaw = append(txsRaw, cbor.RawMessage(wrapped))
+		}
+	}
+	if err := o.storeLeiosEndorserBlock(point, data, txsRaw); err != nil {
 		return fmt.Errorf("store forged endorser block: %w", err)
 	}
 	o.leiosEBLog.append(leiosForgedEBEntry{point: point})


### PR DESCRIPTION
Closes #2624 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve locally forged Leios endorser blocks with their transaction bodies so peers can fetch them via `leios-fetch` right after announce. This stores bodies aligned with the manifest and updates broadcasting to include wrapped CBOR bodies. Closes #2624.

- New Features
  - `buildLeiosEB` now returns `bodies` aligned with manifest refs; the forger passes them to `BroadcastEndorserBlock(slot, hash, cbor, bodies)`.
  - `leiosnotify` stores bodies as CBOR byte strings so the `leios-fetch` server can serve them by bitmap and order.
  - Added tests for body/ref alignment and serving forged EB txs.

<sup>Written for commit 5b80b9499d45f392dcd505e7b335930b1347583f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forged endorser blocks now include the original transaction bodies, allowing peers to retrieve the full transaction data after broadcast.
* **Bug Fixes**
  * Improved handling of invalid or unsupported transactions so only valid references and matching bodies are kept.
  * Transaction counts shown in logs now reflect the actual number of included bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->