### PR TITLE
perf(ledger): cache per-epoch proposal tallys

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1548,7 +1548,18 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    (`GetActivePoolKeyHashesAtSlot`), so no separate pool-state delete is needed;
    the retirement certificate rows remain for rollback safety.
 3. Governance enactment (`governance.ProcessEpoch`): treasury withdrawals and
-   proposal-deposit returns, which observe the post-POOLREAP treasury.
+   proposal-deposit returns, which observe the post-POOLREAP treasury. The
+   proposal-independent voting denominators — DRep voting power
+   (`LoadDRepVotingState`, the heavy `account`⋈`utxo` aggregation), the pool
+   stake snapshot (`LoadSPOVotingState`), and committee state
+   (`LoadCommitteeVotingState`) — are computed once per epoch tick and reused
+   across every proposal's `TallyProposal`, since they do not change while the
+   RATIFY loop runs. (Recomputing DRep voting power per proposal ran the heavy
+   query once for every active proposal; on a freshly Mithril-restored database
+   at an epoch boundary with many active proposals it stalled the rollover, and
+   thus the whole ledger pipeline, for hours.) A `slowGovernanceTallyThreshold`
+   warning surfaces an unexpectedly slow tally rather than letting it present as
+   a silent stalled rollover.
 4. Treasury donations (`applyEpochDonations`), added after withdrawals.
 
 POOLREAP runs before governance so any deposit that lands in the treasury is

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -21,12 +21,19 @@ import (
 	"log/slog"
 	"math/big"
 	"sort"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
+
+// slowGovernanceTallyThreshold bounds how long the per-epoch governance
+// tally is expected to take. Beyond it, ProcessEpoch logs a warning so
+// an unexpectedly slow (or pathological) tally surfaces in operator logs
+// instead of presenting as a silent stalled epoch rollover.
+const slowGovernanceTallyThreshold = 30 * time.Second
 
 // EpochInput collects the inputs needed at an epoch boundary
 // to drive the governance state machine.
@@ -276,6 +283,35 @@ func ProcessEpoch(
 		rootsByPurpose[purposeCommittee],
 	)
 
+	// Precompute the proposal-independent DRep and SPO voting
+	// denominators once per epoch tick and reuse them across every
+	// proposal's tally. DRep voting power and the pool stake snapshot do
+	// not change while the RATIFY loop runs, so loading them per proposal
+	// (as the lazy path inside the tally functions does) just repeats the
+	// heavy account/utxo voting-power query for every active proposal.
+	// On a freshly Mithril-restored database at an epoch boundary with
+	// many active proposals, that repetition stalled the epoch rollover —
+	// and the entire ledger pipeline behind it — for hours.
+	//
+	// Skip the loads entirely when there are no active proposals: the
+	// RATIFY loop below never calls TallyProposal, so this heavy read
+	// would be pure overhead (and a needless failure surface) on a no-op
+	// epoch boundary.
+	var drepState *DRepVotingState
+	var spoState *SPOVotingState
+	if len(stillActive) > 0 {
+		drepState, err = LoadDRepVotingState(in.DB, in.Txn, in.NewEpoch)
+		if err != nil {
+			return nil, fmt.Errorf("load drep voting state: %w", err)
+		}
+		tallyCtx.DRepState = drepState
+		spoState, err = LoadSPOVotingState(in.DB, in.Txn, tallyCtx.StakeEpoch)
+		if err != nil {
+			return nil, fmt.Errorf("load spo voting state: %w", err)
+		}
+		tallyCtx.SPOState = spoState
+	}
+
 	// Per the Conway spec, RATIFY operates on post-ENACT state. If the
 	// enactment loop mutated pparams (e.g., ParameterChange or
 	// HardForkInitiation), refresh the Conway pparams view so major
@@ -305,6 +341,22 @@ func ProcessEpoch(
 		return govActionPriority(stillActive[i]) <
 			govActionPriority(stillActive[j])
 	})
+
+	// Log the tally scale before the loop so an unexpectedly slow or
+	// stalled tally is visible in operator logs (a hang shows a
+	// "starting" line with no matching completion) rather than
+	// presenting as a silent stalled epoch rollover.
+	tallyStart := time.Now()
+	if in.Logger != nil && len(stillActive) > 0 {
+		in.Logger.Info(
+			"governance epoch tally starting",
+			"component", "governance",
+			"epoch", in.NewEpoch,
+			"active_proposals", len(stillActive),
+			"active_dreps", len(drepState.Dreps),
+			"pool_snapshot_rows", len(spoState.Dist),
+		)
+	}
 
 	for _, proposal := range stillActive {
 		actionType := lcommon.GovActionType(proposal.ActionType)
@@ -429,6 +481,28 @@ func ProcessEpoch(
 		out.RatifiedCount++
 		if isDelayingActionPurpose(purpose) {
 			break
+		}
+	}
+
+	if in.Logger != nil && len(stillActive) > 0 {
+		elapsed := time.Since(tallyStart)
+		if elapsed >= slowGovernanceTallyThreshold {
+			in.Logger.Warn(
+				"governance epoch tally slow",
+				"component", "governance",
+				"epoch", in.NewEpoch,
+				"active_proposals", len(stillActive),
+				"active_dreps", len(drepState.Dreps),
+				"duration", elapsed.String(),
+			)
+		} else {
+			in.Logger.Debug(
+				"governance epoch tally complete",
+				"component", "governance",
+				"epoch", in.NewEpoch,
+				"active_proposals", len(stillActive),
+				"duration", elapsed.String(),
+			)
 		}
 	}
 

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -62,6 +62,14 @@ type TallyContext struct {
 	StakeEpoch     uint64
 	CurrentEpoch   uint64
 	CommitteeState *CommitteeVotingState
+	// DRepState and SPOState carry the proposal-independent voting
+	// denominators (DRep voting power, pool stake snapshot) so they are
+	// computed once per epoch tick and reused across every proposal's
+	// tally. When nil, the tally functions lazily load them, preserving
+	// standalone behavior. ProcessEpoch precomputes both before the
+	// proposal loop, mirroring CommitteeState.
+	DRepState *DRepVotingState
+	SPOState  *SPOVotingState
 }
 
 // CommitteeVotingState is the ratification view of the seated CC:
@@ -190,17 +198,43 @@ func TallyProposal(
 	return tally, nil
 }
 
-// tallyDRepVotes sums voting power for regular DReps and the predefined
-// AlwaysAbstain / AlwaysNoConfidence DRep options. Non-voting regular
-// DReps are not counted toward any bucket.
-func tallyDRepVotes(
-	ctx *TallyContext,
-	votes []*models.GovernanceVote,
-	tally *ProposalTally,
-) error {
-	allDreps, err := ctx.DB.GetActiveDreps(ctx.Txn)
+// DRepVotingState is the proposal-independent DRep voting view for an
+// epoch tick: the active DReps, their stake-weighted voting power, and
+// the predefined AlwaysAbstain / AlwaysNoConfidence powers. DRep voting
+// power is a function of the stake snapshot, not of any individual
+// proposal, so this is computed once per epoch and reused across every
+// proposal's tally. Recomputing it per proposal ran the heavy
+// account/utxo voting-power aggregation once for every active proposal;
+// on a freshly Mithril-restored database at an epoch boundary with many
+// active proposals that stalled the epoch rollover (and therefore the
+// whole ledger) for hours.
+type DRepVotingState struct {
+	// Dreps are the active-at-epoch regular DReps (active flag set and
+	// not expired by inactivity).
+	Dreps []*models.Drep
+	// Powers maps StakeCredentialRef.MapKey() to stake-weighted voting
+	// power for every entry in Dreps.
+	Powers map[string]uint64
+	// AbstainPower / NoConfidencePower are the predefined DRep option
+	// powers (AlwaysAbstain / AlwaysNoConfidence).
+	AbstainPower      uint64
+	NoConfidencePower uint64
+}
+
+// LoadDRepVotingState computes the DRep voting denominators for the
+// given epoch. It is the single heavy query (active DReps + batched
+// voting power) hoisted out of the per-proposal tally path.
+func LoadDRepVotingState(
+	db *database.Database,
+	txn *database.Txn,
+	currentEpoch uint64,
+) (*DRepVotingState, error) {
+	if db == nil {
+		return nil, errors.New("nil database")
+	}
+	allDreps, err := db.GetActiveDreps(txn)
 	if err != nil {
-		return fmt.Errorf("get active dreps: %w", err)
+		return nil, fmt.Errorf("get active dreps: %w", err)
 	}
 
 	// GetActiveDreps filters by the `active` flag (cleared only on
@@ -210,12 +244,13 @@ func tallyDRepVotes(
 	// never had activity recorded and is treated as unexpired.
 	dreps := make([]*models.Drep, 0, len(allDreps))
 	for _, drep := range allDreps {
-		if !drepActiveAtEpoch(drep, ctx.CurrentEpoch) {
+		if !drepActiveAtEpoch(drep, currentEpoch) {
 			continue
 		}
 		dreps = append(dreps, drep)
 	}
 
+	powers := make(map[string]uint64)
 	if len(dreps) > 0 {
 		// Batch-fetch voting power for all active DReps in one query to
 		// avoid the N+1 round-trip that the per-DRep lookup produced.
@@ -223,11 +258,50 @@ func tallyDRepVotes(
 		for i, drep := range dreps {
 			creds[i] = models.StakeCredentialRef{Tag: drep.CredentialTag, Key: drep.Credential}
 		}
-		powers, err := ctx.DB.GetDRepVotingPowerBatch(creds, ctx.Txn)
+		powers, err = db.GetDRepVotingPowerBatch(creds, txn)
 		if err != nil {
-			return fmt.Errorf("batch drep voting power: %w", err)
+			return nil, fmt.Errorf("batch drep voting power: %w", err)
 		}
+	}
 
+	virtualPowers, err := db.GetDRepVotingPowerByType(
+		[]uint64{
+			models.DrepTypeAlwaysAbstain,
+			models.DrepTypeAlwaysNoConfidence,
+		},
+		txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("predefined drep voting power: %w", err)
+	}
+	return &DRepVotingState{
+		Dreps:             dreps,
+		Powers:            powers,
+		AbstainPower:      virtualPowers[models.DrepTypeAlwaysAbstain],
+		NoConfidencePower: virtualPowers[models.DrepTypeAlwaysNoConfidence],
+	}, nil
+}
+
+// tallyDRepVotes sums voting power for regular DReps and the predefined
+// AlwaysAbstain / AlwaysNoConfidence DRep options. Non-voting regular
+// DReps are not counted toward any bucket. The proposal-independent
+// voting power is taken from ctx.DRepState when present (precomputed
+// once per epoch by ProcessEpoch); otherwise it is loaded lazily.
+func tallyDRepVotes(
+	ctx *TallyContext,
+	votes []*models.GovernanceVote,
+	tally *ProposalTally,
+) error {
+	state := ctx.DRepState
+	if state == nil {
+		var err error
+		state, err = LoadDRepVotingState(ctx.DB, ctx.Txn, ctx.CurrentEpoch)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(state.Dreps) > 0 {
 		// Index votes by full DRep credential identity for O(1) lookup.
 		voteByCred := make(map[string]uint8, len(votes))
 		for _, v := range votes {
@@ -238,9 +312,9 @@ func tallyDRepVotes(
 			voteByCred[ref.MapKey()] = v.Vote
 		}
 
-		for _, drep := range dreps {
+		for _, drep := range state.Dreps {
 			ref := models.StakeCredentialRef{Tag: drep.CredentialTag, Key: drep.Credential}
-			power := powers[ref.MapKey()]
+			power := state.Powers[ref.MapKey()]
 			tally.DRepTotalStake += power
 
 			vote, voted := voteByCred[ref.MapKey()]
@@ -258,18 +332,8 @@ func tallyDRepVotes(
 		}
 	}
 
-	virtualPowers, err := ctx.DB.GetDRepVotingPowerByType(
-		[]uint64{
-			models.DrepTypeAlwaysAbstain,
-			models.DrepTypeAlwaysNoConfidence,
-		},
-		ctx.Txn,
-	)
-	if err != nil {
-		return fmt.Errorf("predefined drep voting power: %w", err)
-	}
-	abstainPower := virtualPowers[models.DrepTypeAlwaysAbstain]
-	noConfidencePower := virtualPowers[models.DrepTypeAlwaysNoConfidence]
+	abstainPower := state.AbstainPower
+	noConfidencePower := state.NoConfidencePower
 	tally.DRepTotalStake += abstainPower + noConfidencePower
 	tally.DRepAbstainStake += abstainPower
 	if noConfidencePower > 0 {
@@ -306,29 +370,63 @@ func tallyDRepVotes(
 // changes its reward account between StakeEpoch and the ratification
 // epoch does not retroactively shift the tally, matching
 // cardano-ledger's ssDelegations/ssDReps semantics.
+// SPOVotingState is the proposal-independent SPO voting view for an
+// epoch tick: the pool stake distribution snapshot ("mark" at
+// StakeEpoch) and its total stake. Like DRepVotingState it is computed
+// once per epoch and reused across every proposal's tally.
+type SPOVotingState struct {
+	// Dist is the pool stake snapshot rows, each carrying the pool's
+	// stake and its pre-resolved reward-account auto-vote.
+	Dist []*models.PoolStakeSnapshot
+	// TotalStake is the sum of every snapshot row's stake.
+	TotalStake uint64
+}
+
+// LoadSPOVotingState reads the "mark" pool stake snapshot for stakeEpoch
+// and sums its total stake.
+func LoadSPOVotingState(
+	db *database.Database,
+	txn *database.Txn,
+	stakeEpoch uint64,
+) (*SPOVotingState, error) {
+	if db == nil {
+		return nil, errors.New("nil database")
+	}
+	var metaTxn types.Txn
+	if txn != nil {
+		metaTxn = txn.Metadata()
+	}
+	dist, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+		stakeEpoch,
+		"mark",
+		metaTxn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get pool stake snapshot: %w", err)
+	}
+	var total uint64
+	for _, s := range dist {
+		total += uint64(s.TotalStake)
+	}
+	return &SPOVotingState{Dist: dist, TotalStake: total}, nil
+}
+
 func tallySPOVotes(
 	ctx *TallyContext,
 	votes []*models.GovernanceVote,
 	tally *ProposalTally,
 ) error {
-	var metaTxn types.Txn
-	if ctx.Txn != nil {
-		metaTxn = ctx.Txn.Metadata()
-	}
-	dist, err := ctx.DB.Metadata().GetPoolStakeSnapshotsByEpoch(
-		ctx.StakeEpoch,
-		"mark",
-		metaTxn,
-	)
-	if err != nil {
-		return fmt.Errorf("get pool stake snapshot: %w", err)
+	state := ctx.SPOState
+	if state == nil {
+		var err error
+		state, err = LoadSPOVotingState(ctx.DB, ctx.Txn, ctx.StakeEpoch)
+		if err != nil {
+			return err
+		}
 	}
 
-	var total uint64
-	for _, s := range dist {
-		total += uint64(s.TotalStake)
-	}
-	tally.SPOTotalStake = total
+	dist := state.Dist
+	tally.SPOTotalStake = state.TotalStake
 	if len(dist) == 0 {
 		return nil
 	}

--- a/ledger/governance/tally_dedup_test.go
+++ b/ledger/governance/tally_dedup_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadDRepVotingStateMatchesLazyTally asserts that tallying a
+// proposal against a precomputed DRepVotingState produces results
+// identical to the lazy path that loads the state inside
+// tallyDRepVotes. The precomputed path is what ProcessEpoch uses to
+// avoid recomputing the heavy account/utxo voting-power query once per
+// proposal; it must be consensus-identical to the per-call path.
+func TestLoadDRepVotingStateMatchesLazyTally(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	drepCred := testBytes(28, 1)
+	stakeCred := testBytes(28, 2)
+	abstainStakeCred := testBytes(28, 3)
+
+	require.NoError(t, store.DB().Create(&models.Drep{
+		Credential: drepCred,
+		Active:     true,
+	}).Error)
+	seedDRepStake(
+		t, store, stakeCred, drepCred, models.DrepTypeAddrKeyHash, 60, 1,
+	)
+	seedDRepStake(
+		t, store, abstainStakeCred, nil, models.DrepTypeAlwaysAbstain, 40, 2,
+	)
+
+	votes := []*models.GovernanceVote{{
+		VoterType:       models.VoterTypeDRep,
+		VoterCredential: drepCred,
+		Vote:            models.VoteYes,
+	}}
+
+	lazyTally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	require.NoError(t, tallyDRepVotes(&TallyContext{DB: db}, votes, lazyTally))
+
+	state, err := LoadDRepVotingState(db, nil, 0)
+	require.NoError(t, err)
+	precomputedTally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	require.NoError(t, tallyDRepVotes(
+		&TallyContext{DB: db, DRepState: state},
+		votes,
+		precomputedTally,
+	))
+
+	assert.Equal(t, *lazyTally, *precomputedTally)
+	assert.Equal(t, uint64(100), precomputedTally.DRepTotalStake)
+	assert.Equal(t, uint64(60), precomputedTally.DRepYesStake)
+	assert.Equal(t, uint64(40), precomputedTally.DRepAbstainStake)
+}
+
+// TestPrecomputedDRepStateReusedAcrossProposals asserts that a single
+// DRepVotingState can be reused to tally multiple proposals with
+// different action types and still apply the action-type-dependent
+// AlwaysNoConfidence bucketing correctly. This is the reuse pattern
+// ProcessEpoch relies on: load once, tally every proposal.
+func TestPrecomputedDRepStateReusedAcrossProposals(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 4)
+	seedDRepStake(
+		t, store, stakeCred, nil, models.DrepTypeAlwaysNoConfidence, 30, 3,
+	)
+
+	state, err := LoadDRepVotingState(db, nil, 0)
+	require.NoError(t, err)
+
+	noConfidence := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeNoConfidence),
+	}
+	require.NoError(t, tallyDRepVotes(
+		&TallyContext{DB: db, DRepState: state}, nil, noConfidence,
+	))
+	assert.Equal(t, uint64(30), noConfidence.DRepTotalStake)
+	assert.Equal(t, uint64(30), noConfidence.DRepYesStake)
+	assert.Equal(t, uint64(0), noConfidence.DRepNoStake)
+
+	updateCommittee := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeUpdateCommittee),
+	}
+	require.NoError(t, tallyDRepVotes(
+		&TallyContext{DB: db, DRepState: state}, nil, updateCommittee,
+	))
+	assert.Equal(t, uint64(30), updateCommittee.DRepTotalStake)
+	assert.Equal(t, uint64(0), updateCommittee.DRepYesStake)
+	assert.Equal(t, uint64(30), updateCommittee.DRepNoStake)
+}
+
+// TestLoadSPOVotingStateMatchesLazyTally asserts the SPO voting-power
+// snapshot precompute is consensus-identical to the lazy per-call path.
+func TestLoadSPOVotingStateMatchesLazyTally(t *testing.T) {
+	db, store := newTallyTestDB(t)
+	poolKeyHash := testBytes(28, 50)
+	rewardAccount := testBytes(28, 51)
+
+	seedPoolWithStake(t, store, poolKeyHash, rewardAccount, 100, 5)
+	seedRewardAccountDelegation(
+		t, store, rewardAccount, nil, models.DrepTypeAlwaysNoConfidence,
+	)
+	resolveSnapshotAutoVotes(t, db, 5)
+
+	votes := []*models.GovernanceVote{{
+		VoterType:       models.VoterTypeSPO,
+		VoterCredential: poolKeyHash,
+		Vote:            models.VoteYes,
+	}}
+
+	lazyTally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	require.NoError(t, tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 5}, votes, lazyTally,
+	))
+
+	state, err := LoadSPOVotingState(db, nil, 5)
+	require.NoError(t, err)
+	precomputedTally := &ProposalTally{
+		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+	}
+	require.NoError(t, tallySPOVotes(
+		&TallyContext{DB: db, StakeEpoch: 5, SPOState: state},
+		votes,
+		precomputedTally,
+	))
+
+	assert.Equal(t, *lazyTally, *precomputedTally)
+	assert.Equal(t, uint64(100), precomputedTally.SPOTotalStake)
+	assert.Equal(t, uint64(100), precomputedTally.SPOYesStake)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Precompute and cache per-epoch DRep and SPO voting denominators for proposal tallies to eliminate repeated heavy queries and prevent epoch rollover stalls. Adds visibility into tally duration with start/complete logs and slow-tally warnings.

- **Performance**
  - Precompute `DRepVotingState` and `SPOVotingState` once per epoch in `ProcessEpoch`; reuse across all proposal tallies; skip loads when no active proposals.
  - Add `LoadDRepVotingState` and `LoadSPOVotingState`; keep lazy-load fallback in `tally.go` for standalone calls.
  - Log tally start with scale metrics and warn if over `slowGovernanceTallyThreshold` (30s); debug on completion.
  - Add tests confirming precomputed vs lazy paths match for DRep and SPO and that the precomputed DRep state is reusable across proposals.
  - Update `ARCHITECTURE.md` to document per-epoch reuse and operator visibility.

<sup>Written for commit cf3756fd7a84000f1213616500a15dd17801979e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Governance tallying now reuses precomputed voting state across proposals within an epoch, improving consistency and responsiveness during busy epoch boundaries.
  * Added a warning when governance tallying takes unusually long, making stalled rollovers easier to detect.

* **Bug Fixes**
  * Reduced the chance of epoch rollover delays caused by repeated vote-power recalculation.
  * Preserved tally results while avoiding redundant work for committee, DRep, and stake pool voting counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->