### PR TITLE
test(chain): use shared ouroboros-mock Conway chain fixture

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -24,13 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
-	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
-	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
-	"golang.org/x/crypto/blake2b"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
@@ -1348,16 +1345,10 @@ func newTestDB(t *testing.T) *database.Database {
 	return db
 }
 
-// generateTestChain builds `count` Conway blocks that chain together via
-// PrevHash and survive a CBOR round-trip — that is, after re-decoding
-// each block's stored Cbor() via ledger.NewBlockFromCbor (the path used
-// by models.Block.Decode in chain.reconcile), the decoded block's
-// Hash() and PrevHash() match what the generator originally produced.
-//
-// The first block's PrevHash is set to prevHash. Each block's slot is
-// startSlot + i*slotIncrement; block numbers run startBlockNumber..+count-1.
-// All blocks have empty transactions/witnesses/auxiliary/invalid sets,
-// so they share the same block body hash.
+// generateTestChain builds count Conway blocks that chain together via
+// PrevHash with CBOR-stable encodings, delegating to the shared ouroboros-mock
+// fixture generator. It fails the test on error so call sites keep their
+// existing positional form.
 func generateTestChain(
 	t testing.TB,
 	startBlockNumber uint64,
@@ -1366,135 +1357,13 @@ func generateTestChain(
 	count int,
 ) []ledger.Block {
 	t.Helper()
-	if count <= 0 {
-		return []ledger.Block{}
-	}
-	// All generated blocks have identical empty bodies, so the four
-	// component CBORs and the resulting block body hash are constant.
-	emptyTxsCbor, err := cbor.Encode([]ledger.ConwayTransactionBody{})
-	if err != nil {
-		t.Fatalf("encode empty tx bodies: %s", err)
-	}
-	emptyWitsCbor, err := cbor.Encode([]ledger.ConwayTransactionWitnessSet{})
-	if err != nil {
-		t.Fatalf("encode empty witnesses: %s", err)
-	}
-	emptyAuxCbor, err := cbor.Encode(common.TransactionMetadataSet{})
-	if err != nil {
-		t.Fatalf("encode empty metadata set: %s", err)
-	}
-	emptyInvalidCbor, err := cbor.Encode([]uint{})
-	if err != nil {
-		t.Fatalf("encode empty invalid txs: %s", err)
-	}
-	bodyHash := computeBlockBodyHash(
-		emptyTxsCbor, emptyWitsCbor, emptyAuxCbor, emptyInvalidCbor,
+	blocks, err := fixtures.GenerateConwayChain(
+		startBlockNumber, prevHash, startSlot, slotIncrement, count,
 	)
-	blocks := make([]ledger.Block, 0, count)
-	currentPrev := prevHash
-	for i := range count {
-		body := babbage.BabbageBlockHeaderBody{
-			BlockNumber: startBlockNumber + uint64(i),
-			Slot:        startSlot + uint64(i)*slotIncrement,
-			PrevHash:    currentPrev,
-			IssuerVkey:  common.IssuerVkey{},
-			VrfKey:      make([]byte, 32),
-			VrfResult: common.VrfResult{
-				Output: make([]byte, 64),
-				Proof:  make([]byte, 80),
-			},
-			BlockBodySize: 0,
-			BlockBodyHash: bodyHash,
-			OpCert: babbage.BabbageOpCert{
-				HotVkey:   make([]byte, 32),
-				Signature: make([]byte, 64),
-			},
-			ProtoVersion: babbage.BabbageProtoVersion{Major: 9, Minor: 0},
-		}
-		block := &ledger.ConwayBlock{
-			BlockHeader: &ledger.ConwayBlockHeader{
-				BabbageBlockHeader: ledger.BabbageBlockHeader{
-					Body:      body,
-					Signature: make([]byte, 64),
-				},
-			},
-		}
-		blockCbor, err := cbor.Encode(block)
-		if err != nil {
-			t.Fatalf("encode block %d: %s", i, err)
-		}
-		// Re-decode so the returned block carries the canonical Cbor()
-		// the reconcile path will observe, and so Hash() reads from the
-		// post-round-trip header bytes.
-		decoded, err := conway.NewConwayBlockFromCbor(blockCbor)
-		if err != nil {
-			t.Fatalf("decode generated block %d: %s", i, err)
-		}
-		if !bytes.Equal(decoded.Cbor(), blockCbor) {
-			t.Fatalf("block %d Cbor mismatch after round-trip", i)
-		}
-		blocks = append(blocks, decoded)
-		currentPrev = decoded.Hash()
+	if err != nil {
+		t.Fatalf("generate test chain: %s", err)
 	}
 	return blocks
-}
-
-// computeBlockBodyHash returns blake2b256(blake2b256(p[0]) || ...) which
-// matches common.ValidateBlockBodyHash's expected derivation.
-func computeBlockBodyHash(parts ...[]byte) common.Blake2b256 {
-	var combined []byte
-	for _, p := range parts {
-		h := blake2b.Sum256(p)
-		combined = append(combined, h[:]...)
-	}
-	h := blake2b.Sum256(combined)
-	return common.NewBlake2b256(h[:])
-}
-
-func TestGenerateTestChainRoundTrip(t *testing.T) {
-	var origin common.Blake2b256
-	gen := generateTestChain(t, 1, origin, 0, 20, 5)
-	if len(gen) != 5 {
-		t.Fatalf("expected 5 blocks, got %d", len(gen))
-	}
-	for i, b := range gen {
-		decoded, err := ledger.NewBlockFromCbor(uint(b.Type()), b.Cbor())
-		if err != nil {
-			t.Fatalf("block %d decode failed: %s", i, err)
-		}
-		if decoded.Hash() != b.Hash() {
-			t.Fatalf(
-				"block %d hash changed after round-trip: %s -> %s",
-				i, b.Hash(), decoded.Hash(),
-			)
-		}
-		if decoded.PrevHash() != b.PrevHash() {
-			t.Fatalf(
-				"block %d prev hash changed after round-trip: %s -> %s",
-				i, b.PrevHash(), decoded.PrevHash(),
-			)
-		}
-		if decoded.BlockNumber() != uint64(i+1) {
-			t.Fatalf(
-				"block %d unexpected block number %d",
-				i, decoded.BlockNumber(),
-			)
-		}
-		if decoded.SlotNumber() != uint64(i)*20 {
-			t.Fatalf(
-				"block %d unexpected slot %d",
-				i, decoded.SlotNumber(),
-			)
-		}
-	}
-	for i := 1; i < len(gen); i++ {
-		if gen[i].PrevHash() != gen[i-1].Hash() {
-			t.Fatalf(
-				"chain link mismatch at index %d: prev=%s, want=%s",
-				i, gen[i].PrevHash(), gen[i-1].Hash(),
-			)
-		}
-	}
 }
 
 func TestChainRollbackExceedsSecurityParam(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
 	github.com/blinklabs-io/gouroboros v0.185.0
-	github.com/blinklabs-io/ouroboros-mock v0.13.0
+	github.com/blinklabs-io/ouroboros-mock v0.14.0
 	github.com/blinklabs-io/plutigo v0.1.15
 	github.com/blockfrost/blockfrost-go v0.4.0
 	github.com/btcsuite/btcd/btcutil v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -133,12 +133,10 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.184.0 h1:t+WjKX5zS+cDZbOAdLez4uMGagRKtT4V0+JkCrNDmuU=
-github.com/blinklabs-io/gouroboros v0.184.0/go.mod h1:8xBiVJLVon6El0oJ+UwMuPVmbwIyu5xubTnrZmpRBi0=
 github.com/blinklabs-io/gouroboros v0.185.0 h1:QQKKDSZa2xz5485xvK8tTZz4TnChwtk7kG4yPy6DmsY=
 github.com/blinklabs-io/gouroboros v0.185.0/go.mod h1:8xBiVJLVon6El0oJ+UwMuPVmbwIyu5xubTnrZmpRBi0=
-github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
-github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
+github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
+github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=


### PR DESCRIPTION
Closes #2233

Moves the in-tree `generateTestChain` / `computeBlockBodyHash` CBOR block-fixture helpers out of `chain/chain_test.go` and into the shared `ouroboros-mock` library, per the policy that ledger/consensus/network mocks live there rather than in dingo (`CLAUDE.md`/`AGENTS.md`).

This is the dingo half of the cross-repo move; the generator landed in **blinklabs-io/ouroboros-mock#217** and is released as **v0.14.0**.

## Changes
- Bump `github.com/blinklabs-io/ouroboros-mock` to `v0.14.0`.
- Delete the in-tree `generateTestChain`, `computeBlockBodyHash`, and the dedicated `TestGenerateTestChainRoundTrip` (the round-trip test moved to ouroboros-mock alongside the generator), plus the four now-unused imports (`babbage`, `conway`, `cbor`, `blake2b`).
- `generateTestChain` is now a thin `testing.TB` adapter that delegates to `fixtures.GenerateConwayChain` and fails the test on error — so the 7 reconcile/rollback call sites are unchanged and their coverage is intact. Net **−140 lines** of fixture logic.

## Verification
- `go test -race ./chain/` — passes (reconcile + rollback suites green against the released v0.14.0).
- `golangci-lint run ./chain/` — 0 issues.

## Docs
`ARCHITECTURE.md` / `DATABASE.md` checked — not affected (test-fixture refactor, no component/DB/API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Conway test chain generation to the shared `github.com/blinklabs-io/ouroboros-mock` fixture to reduce duplicate test code and keep test call sites unchanged.

- **Refactors**
  - Replace in-tree `generateTestChain`/`computeBlockBodyHash` with a thin adapter to `fixtures.GenerateConwayChain`.
  - Remove the round-trip test and unused imports; net −140 LOC in `chain_test.go`.
  - Test-only changes; no runtime behavior updates.

- **Dependencies**
  - Bump `github.com/blinklabs-io/ouroboros-mock` to `v0.14.0`.

<sup>Written for commit 6674fd269492340d9613b08820310e0999c6ec58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified test chain generation by using a shared fixture-based approach instead of custom block-building logic.
  * Removed several now-unused low-level helpers and dependencies.

* **Chores**
  * Updated a project dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->