### PR TITLE
feat(forging): optionally validate a forged block through chain selection before diffusion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1180,9 +1180,14 @@ When running as a stake pool operator, Dingo can produce blocks. This involves t
 1. Waits for the next slot boundary using the wall-clock slot timer
 2. Checks leader eligibility via the `Election`
 3. Assembles a block from a neutral pending-transaction provider using `DefaultBlockBuilder`
-4. Broadcasts the forged block through the chain manager
+4. Optionally self-validates the forged block before adoption (see below)
+5. Broadcasts the forged block through the chain manager
 
 The forger tracks slot battles (competing blocks at the same slot) and skips forging when the node is not sufficiently synced, controlled by `forgeSyncToleranceSlots` and `forgeStaleGapThresholdSlots`.
+
+#### Optional Self-Validation (`DINGO_VALIDATE_FORGED_BLOCK`)
+
+When `validateForgedBlock` is enabled in config, the forger invokes `LedgerState.ValidateForgedBlock` between step 3 and step 5. This runs three checks: (a) VRF proof and KES signature verification of the block header, (b) body-hash non-zero guard, and (c) per-transaction ledger rule validation against the current UTxO state with an intra-block overlay so outputs created by earlier transactions in the same block are visible to later ones. A failing block is logged, counted in `dingo_forge_validation_failed_total`, and dropped without being adopted or diffused. Validation wall-clock time is recorded in the `dingo_forge_validation_duration_seconds` histogram. Disabled by default; intended for block producers who want defence-in-depth against builder bugs at the cost of additional forge-to-diffusion latency.
 
 ### Pool Credentials (`ledger/forging/keys.go`, `keystore/`)
 

--- a/config.go
+++ b/config.go
@@ -186,6 +186,10 @@ type Config struct {
 	// Forging tolerances (0 = use defaults)
 	forgeSyncToleranceSlots     uint64
 	forgeStaleGapThresholdSlots uint64
+	// validateForgedBlock enables self-validation of locally-forged blocks
+	// (VRF/KES header crypto, body-hash, per-tx ledger rules) before the
+	// block is adopted onto the chain and diffused to peers.
+	validateForgedBlock bool
 	// Leios voting configuration (experimental)
 	leiosVoteSigningKeyFile string
 	leiosVoterPublicKeys    map[string]string
@@ -938,6 +942,17 @@ func WithForgeSyncToleranceSlots(slots uint64) ConfigOptionFunc {
 func WithForgeStaleGapThresholdSlots(slots uint64) ConfigOptionFunc {
 	return func(c *Config) {
 		c.forgeStaleGapThresholdSlots = slots
+	}
+}
+
+// WithValidateForgedBlock enables self-validation of locally-forged blocks
+// before they are adopted onto the chain and diffused to peers. When enabled,
+// the forger runs VRF/KES header crypto, body-hash consistency, and per-tx
+// ledger validation on each forged block. A failing block is dropped without
+// being adopted or diffused. Disabled by default.
+func WithValidateForgedBlock(enabled bool) ConfigOptionFunc {
+	return func(c *Config) {
+		c.validateForgedBlock = enabled
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -454,6 +454,7 @@ type Config struct {
 	ShelleyOperationalCertificate string `yaml:"shelleyOperationalCertificate" envconfig:"SHELLEY_OPERATIONAL_CERTIFICATE"`
 	ForgeSyncToleranceSlots       uint64 `yaml:"forgeSyncToleranceSlots"       envconfig:"DINGO_FORGE_SYNC_TOLERANCE_SLOTS"`
 	ForgeStaleGapThresholdSlots   uint64 `yaml:"forgeStaleGapThresholdSlots"   envconfig:"DINGO_FORGE_STALE_GAP_THRESHOLD_SLOTS"`
+	ValidateForgedBlock           bool   `yaml:"validateForgedBlock"           envconfig:"DINGO_VALIDATE_FORGED_BLOCK"`
 
 	// Leios voting configuration (experimental, leios runMode only).
 	// LeiosVoteSigningKeyFile is the path to a hex-encoded BLS12-381

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -156,6 +156,7 @@ var flagSpecs = []flagSpec{
 	uint64Flag("MaxKESEvolutions", "max-kes-evolutions", "maximum KES evolutions before certificate rotation"),
 	uint64Flag("ForgeSyncToleranceSlots", "forge-sync-tolerance-slots", "max slots behind tip before skipping block forging"),
 	uint64Flag("ForgeStaleGapThresholdSlots", "forge-stale-gap-threshold-slots", "slot gap threshold for stale slot clock alerts"),
+	boolFlag("ValidateForgedBlock", "validate-forged-block", "validate forged blocks before adoption and diffusion (header crypto, body hash, per-tx ledger rules)"),
 
 	// Leios voting (experimental)
 	stringFlag("LeiosVoteSigningKeyFile", "leios-vote-signing-key-file", "", "path to hex-encoded BLS12-381 Leios vote signing key"),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -415,6 +415,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithForgeStaleGapThresholdSlots(
 				cfg.ForgeStaleGapThresholdSlots,
 			),
+			dingo.WithValidateForgedBlock(cfg.ValidateForgedBlock),
 			// Leios voting (experimental)
 			dingo.WithLeiosVoteSigningKeyFile(
 				cfg.LeiosVoteSigningKeyFile,

--- a/internal/test/antithesis/Dockerfile.txpump
+++ b/internal/test/antithesis/Dockerfile.txpump
@@ -16,7 +16,6 @@ FROM debian:bookworm-slim
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-RUN useradd -m txpump
+RUN mkdir -p /logs
 COPY --from=build /code/txpump /bin/txpump
-USER txpump
 ENTRYPOINT ["/bin/txpump"]

--- a/internal/test/devnet/configurator.sh
+++ b/internal/test/devnet/configurator.sh
@@ -144,9 +144,8 @@ uv run python3 genesis-cli.py testnet.yaml -o /tmp/testnet -c generate
 # # Remove dynamic topology.json
 find /tmp/testnet -type f -name 'topology.json' -exec rm -f '{}' ';'
 
-mkdir -p /configs
+mkdir -p /configs /configs/utxo-keys
 cp -r /tmp/testnet/pools/* /configs
-cp -r /tmp/testnet/utxos/* /configs
 
 echo "removing /configs/keys"; rm -rf /configs/keys
 
@@ -169,6 +168,10 @@ for pool in $pools; do
   set_start_time "$pool"
   config_config_json "$pool"
 done
+
+# Expose the Shelley genesis (updated system start) to txpump so it can
+# discover the initial UTxOs from initialFunds and know the genesis start time.
+cp /configs/1/configs/shelley-genesis.json /configs/utxo-keys/
 
 # Test-only credentials: make config + genesis files world-readable so any
 # consuming container's user can read them.

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -126,8 +126,8 @@ services:
 
   txpump:
     build:
-      context: ../antithesis
-      dockerfile: Dockerfile.txpump
+      context: ../../..
+      dockerfile: internal/test/antithesis/Dockerfile.txpump
     container_name: devnet-txpump
     depends_on:
       dingo-producer:

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       CARDANO_SHELLEY_VRF_KEY: /configs/keys/vrf.skey
       CARDANO_SHELLEY_KES_KEY: /configs/keys/kes.skey
       CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE: /configs/keys/opcert.cert
+      DINGO_VALIDATE_FORGED_BLOCK: "true"
     volumes:
       - p1-configs:/configs:ro
       - ./topology/dingo-producer.json:/topology/topology.json:ro
@@ -129,6 +130,10 @@ services:
       context: ../../..
       dockerfile: internal/test/antithesis/Dockerfile.txpump
     container_name: devnet-txpump
+    init: true
+    # Named Docker volumes are root-owned on first mount; txpump writes
+    # /logs/txpump.log so the runtime user must be root.
+    user: "0:0"
     depends_on:
       dingo-producer:
         condition: service_healthy

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -87,8 +87,8 @@ fi
 # Start DevNet
 # --------------------------------------------------------------------------- #
 
-log "Building Dingo Docker image..."
-docker compose -f "${COMPOSE_FILE}" build configurator dingo-producer
+log "Building DevNet Docker images..."
+docker compose -f "${COMPOSE_FILE}" build configurator dingo-producer txpump
 
 log "Starting DevNet containers..."
 docker compose -f "${COMPOSE_FILE}" up -d
@@ -126,6 +126,21 @@ if [[ ${ELAPSED} -ge ${MAX_WAIT} ]]; then
   docker compose -f "${COMPOSE_FILE}" logs --tail=100
   die "Node health check timeout"
 fi
+
+# --------------------------------------------------------------------------- #
+# Verify txpump is running
+# --------------------------------------------------------------------------- #
+
+log "Checking txpump is running..."
+TXPUMP_RUNNING=$(docker compose -f "${COMPOSE_FILE}" ps --status running --quiet txpump 2>/dev/null || true)
+if [[ -z "${TXPUMP_RUNNING}" ]]; then
+  log "txpump container status:"
+  docker compose -f "${COMPOSE_FILE}" ps txpump
+  log "txpump logs:"
+  docker compose -f "${COMPOSE_FILE}" logs txpump
+  die "txpump is not running — mempool traffic will be absent; aborting"
+fi
+log "txpump is running"
 
 # --------------------------------------------------------------------------- #
 # Run tests

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -92,6 +92,9 @@ type BlockForger struct {
 	forgeSyncToleranceSlots     uint64
 	forgeStaleGapThresholdSlots uint64
 
+	// Optional self-validation before adoption (nil = disabled)
+	blockValidator BlockValidator
+
 	// State
 	mu      sync.RWMutex
 	running bool
@@ -127,6 +130,14 @@ type BlockForgedObserver func(
 	cbor []byte,
 	latency time.Duration,
 )
+
+// BlockValidator validates a locally-forged block before it is adopted
+// onto the local chain and diffused to peers. If ValidateForgedBlock
+// returns a non-nil error the block is dropped and neither adopted nor
+// diffused.
+type BlockValidator interface {
+	ValidateForgedBlock(block ledger.Block, blockCbor []byte) error
+}
 
 // LeiosProduceChecker is the forge-loop seam into the Leios pipeline.
 // It reports whether the slot leader may produce an endorser block for
@@ -187,6 +198,12 @@ type ForgerConfig struct {
 	// chain tip is far ahead of the slot clock. Zero uses the default.
 	ForgeStaleGapThresholdSlots uint64
 
+	// BlockValidator, when non-nil, validates the forged block (VRF/KES
+	// header crypto, body-hash consistency, per-tx ledger rules) before
+	// AddBlock is called. A validation failure drops the block without
+	// adopting or diffusing it. Nil disables self-validation (default).
+	BlockValidator BlockValidator
+
 	// Prometheus metrics registry (optional)
 	PromRegistry prometheus.Registerer
 }
@@ -215,6 +232,7 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		leiosChecker:     cfg.LeiosProduceChecker,
 		leiosEBCaster:    cfg.LeiosEBBroadcaster,
 		leiosMempool:     cfg.LeiosMempool,
+		blockValidator:   cfg.BlockValidator,
 	}
 	if cfg.ForgeSyncToleranceSlots == 0 {
 		cfg.ForgeSyncToleranceSlots = forgeSyncToleranceSlots
@@ -586,6 +604,40 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			}()
 			f.blockForged(block, blockCbor, time.Since(forgeStartTime))
 		}()
+	}
+
+	// Optionally self-validate before adoption and diffusion.
+	// This runs VRF/KES header crypto, body-hash consistency, and
+	// per-tx ledger rules against the current chain state. A failure
+	// means the locally-built block is invalid; drop it without
+	// adopting or diffusing so we never serve a bad block to peers.
+	if f.blockValidator != nil {
+		validateStart := time.Now()
+		if err := f.blockValidator.ValidateForgedBlock(block, blockCbor); err != nil {
+			f.incCouldNotForge()
+			if f.metrics != nil {
+				f.metrics.forgeValidationFailed.Inc()
+			}
+			f.logger.Error(
+				"forged block failed self-validation, dropping block",
+				"slot", currentSlot,
+				"hash", hex.EncodeToString(block.Hash().Bytes()),
+				"error", err,
+			)
+			return fmt.Errorf("forged block self-validation failed: %w", err)
+		}
+		validationDuration := time.Since(validateStart)
+		if f.metrics != nil {
+			f.metrics.forgeValidationDuration.Observe(
+				validationDuration.Seconds(),
+			)
+		}
+		f.logger.Info(
+			"forged block passed self-validation",
+			"slot", currentSlot,
+			"hash", hex.EncodeToString(block.Hash().Bytes()),
+			"validation_duration", validationDuration,
+		)
 	}
 
 	// Add block to chain and broadcast

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -587,19 +587,19 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// that is ultimately dropped.
 	if f.blockValidator != nil {
 		validateStart := time.Now()
+		blockHashStr := ""
+		if block != nil {
+			blockHashStr = hex.EncodeToString(block.Hash().Bytes())
+		}
 		if err := f.blockValidator.ValidateForgedBlock(block, blockCbor); err != nil {
 			f.incCouldNotForge()
 			if f.metrics != nil {
 				f.metrics.forgeValidationFailed.Inc()
 			}
-			hashStr := ""
-			if block != nil {
-				hashStr = hex.EncodeToString(block.Hash().Bytes())
-			}
 			f.logger.Error(
 				"forged block failed self-validation, dropping block",
 				"slot", currentSlot,
-				"hash", hashStr,
+				"hash", blockHashStr,
 				"error", err,
 			)
 			return fmt.Errorf("forged block self-validation failed: %w", err)
@@ -613,7 +613,7 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		f.logger.Info(
 			"forged block passed self-validation",
 			"slot", currentSlot,
-			"hash", hex.EncodeToString(block.Hash().Bytes()),
+			"hash", blockHashStr,
 			"validation_duration", validationDuration,
 		)
 	}

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -591,7 +591,12 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		if block != nil {
 			blockHashStr = hex.EncodeToString(block.Hash().Bytes())
 		}
-		if err := f.blockValidator.ValidateForgedBlock(block, blockCbor); err != nil {
+		validationErr := f.blockValidator.ValidateForgedBlock(block, blockCbor)
+		validationDuration := time.Since(validateStart)
+		if f.metrics != nil {
+			f.metrics.forgeValidationDuration.Observe(validationDuration.Seconds())
+		}
+		if validationErr != nil {
 			f.incCouldNotForge()
 			if f.metrics != nil {
 				f.metrics.forgeValidationFailed.Inc()
@@ -600,15 +605,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 				"forged block failed self-validation, dropping block",
 				"slot", currentSlot,
 				"hash", blockHashStr,
-				"error", err,
+				"validation_duration", validationDuration,
+				"error", validationErr,
 			)
-			return fmt.Errorf("forged block self-validation failed: %w", err)
-		}
-		validationDuration := time.Since(validateStart)
-		if f.metrics != nil {
-			f.metrics.forgeValidationDuration.Observe(
-				validationDuration.Seconds(),
-			)
+			return fmt.Errorf("forged block self-validation failed: %w", validationErr)
 		}
 		f.logger.Info(
 			"forged block passed self-validation",

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -592,10 +592,14 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			if f.metrics != nil {
 				f.metrics.forgeValidationFailed.Inc()
 			}
+			hashStr := ""
+			if block != nil {
+				hashStr = hex.EncodeToString(block.Hash().Bytes())
+			}
 			f.logger.Error(
 				"forged block failed self-validation, dropping block",
 				"slot", currentSlot,
-				"hash", hex.EncodeToString(block.Hash().Bytes()),
+				"hash", hashStr,
 				"error", err,
 			)
 			return fmt.Errorf("forged block self-validation failed: %w", err)

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -581,36 +581,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return fmt.Errorf("failed to build block: %w", err)
 	}
 
-	// Block forged successfully
-	if f.metrics != nil {
-		f.metrics.forgeForged.Inc()
-		f.metrics.blockSizeBytes.Observe(
-			float64(len(blockCbor)),
-		)
-		f.metrics.blockTxCount.Observe(
-			float64(len(block.Transactions())),
-		)
-	}
-	if f.blockForged != nil {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					f.logger.Error(
-						"blockForged observer panic",
-						"panic", r,
-						"stack", string(debug.Stack()),
-					)
-				}
-			}()
-			f.blockForged(block, blockCbor, time.Since(forgeStartTime))
-		}()
-	}
-
 	// Optionally self-validate before adoption and diffusion.
-	// This runs VRF/KES header crypto, body-hash consistency, and
-	// per-tx ledger rules against the current chain state. A failure
-	// means the locally-built block is invalid; drop it without
-	// adopting or diffusing so we never serve a bad block to peers.
+	// Runs here — before success metrics and the blockForged observer — so
+	// that forgeForged and RecordForgedBlock are never triggered for a block
+	// that is ultimately dropped.
 	if f.blockValidator != nil {
 		validateStart := time.Now()
 		if err := f.blockValidator.ValidateForgedBlock(block, blockCbor); err != nil {
@@ -638,6 +612,31 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			"hash", hex.EncodeToString(block.Hash().Bytes()),
 			"validation_duration", validationDuration,
 		)
+	}
+
+	// Block forged successfully
+	if f.metrics != nil {
+		f.metrics.forgeForged.Inc()
+		f.metrics.blockSizeBytes.Observe(
+			float64(len(blockCbor)),
+		)
+		f.metrics.blockTxCount.Observe(
+			float64(len(block.Transactions())),
+		)
+	}
+	if f.blockForged != nil {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					f.logger.Error(
+						"blockForged observer panic",
+						"panic", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}()
+			f.blockForged(block, blockCbor, time.Since(forgeStartTime))
+		}()
 	}
 
 	// Add block to chain and broadcast

--- a/ledger/forging/forger_validator_test.go
+++ b/ledger/forging/forger_validator_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// forgerTestValidator is a controllable BlockValidator stub.
+type forgerTestValidator struct {
+	err   error
+	calls int
+}
+
+func (v *forgerTestValidator) ValidateForgedBlock(ledger.Block, []byte) error {
+	v.calls++
+	return v.err
+}
+
+func newForgerWithValidator(
+	t *testing.T,
+	block ledger.Block,
+	blockCbor []byte,
+	broadcaster *forgerTestBroadcaster,
+	validator *forgerTestValidator,
+) *BlockForger {
+	t.Helper()
+	creds := setupTestCredentials(t)
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{block: block, cbor: blockCbor},
+		BlockBroadcaster: broadcaster,
+		BlockValidator:   validator,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      9,
+			slotsPerKESPeriod: 100,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	return forger
+}
+
+// TestBlockValidatorPassesAllowsAdoption verifies that a passing validator
+// does not prevent adoption: broadcaster is called and forgeAdopted increments.
+func TestBlockValidatorPassesAllowsAdoption(t *testing.T) {
+	block := newForgerTestBlock(10, 2)
+	broadcaster := &forgerTestBroadcaster{}
+	validator := &forgerTestValidator{err: nil}
+
+	forger := newForgerWithValidator(t, block, nil, broadcaster, validator)
+	err := forger.checkAndForgeProduction(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, validator.calls, "validator must be called once")
+	assert.Equal(t, 1, broadcaster.calls, "block must be adopted after passing validation")
+	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeAdopted))
+	assert.Equal(t, float64(0), testutil.ToFloat64(forger.metrics.forgeCouldNot))
+}
+
+// TestBlockValidatorFailureDropsBlock verifies that a failing validator
+// prevents adoption: broadcaster is NOT called, couldNotForge increments.
+func TestBlockValidatorFailureDropsBlock(t *testing.T) {
+	block := newForgerTestBlock(10, 2)
+	broadcaster := &forgerTestBroadcaster{}
+	validator := &forgerTestValidator{
+		err: errors.New("header crypto: invalid KES signature"),
+	}
+
+	forger := newForgerWithValidator(t, block, nil, broadcaster, validator)
+	err := forger.checkAndForgeProduction(context.Background())
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "self-validation failed")
+	assert.Equal(t, 1, validator.calls, "validator must be called once")
+	assert.Equal(t, 0, broadcaster.calls, "block must NOT be adopted after failed validation")
+	assert.Equal(t, float64(0), testutil.ToFloat64(forger.metrics.forgeAdopted))
+	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeCouldNot))
+	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeValidationFailed))
+}
+
+// TestNilBlockValidatorSkipsValidation confirms that the default nil validator
+// does not affect normal forging: block is adopted without any validation call.
+func TestNilBlockValidatorSkipsValidation(t *testing.T) {
+	block := newForgerTestBlock(10, 2)
+	broadcaster := &forgerTestBroadcaster{}
+
+	creds := setupTestCredentials(t)
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{block: block},
+		BlockBroadcaster: broadcaster,
+		// BlockValidator intentionally omitted (nil = disabled)
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      9,
+			slotsPerKESPeriod: 100,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	err = forger.checkAndForgeProduction(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, broadcaster.calls, "block must be adopted when validator is nil")
+}
+
+// TestBlockValidatorCalledBeforeBroadcaster verifies ordering: the validator
+// runs before AddBlock. If the validator fails, AddBlock must never be called.
+func TestBlockValidatorCalledBeforeBroadcaster(t *testing.T) {
+	block := newForgerTestBlock(10, 2)
+
+	var callOrder []string
+	broadcaster := &forgerTestBroadcaster{}
+	// Override the underlying AddBlock via a tracking broadcaster
+	trackingBroadcaster := &trackingBroadcaster{
+		inner: broadcaster,
+		onAdd: func() { callOrder = append(callOrder, "broadcast") },
+	}
+	trackingValidator := &trackingBlockValidator{
+		onValidate: func() error {
+			callOrder = append(callOrder, "validate")
+			return errors.New("intentional failure")
+		},
+	}
+
+	creds := setupTestCredentials(t)
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{block: block},
+		BlockBroadcaster: trackingBroadcaster,
+		BlockValidator:   trackingValidator,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      9,
+			slotsPerKESPeriod: 100,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	_ = forger.checkAndForgeProduction(context.Background())
+
+	require.Equal(t, []string{"validate"}, callOrder,
+		"validator must run before broadcaster; broadcaster must not run on failure")
+}
+
+// trackingBroadcaster wraps a broadcaster and calls a hook on AddBlock.
+type trackingBroadcaster struct {
+	inner BlockBroadcaster
+	onAdd func()
+}
+
+func (b *trackingBroadcaster) AddBlock(block ledger.Block, cbor []byte) error {
+	b.onAdd()
+	return b.inner.AddBlock(block, cbor)
+}
+
+// trackingBlockValidator calls a hook on ValidateForgedBlock.
+type trackingBlockValidator struct {
+	onValidate func() error
+}
+
+func (v *trackingBlockValidator) ValidateForgedBlock(ledger.Block, []byte) error {
+	return v.onValidate()
+}

--- a/ledger/forging/metrics.go
+++ b/ledger/forging/metrics.go
@@ -46,6 +46,10 @@ type forgingMetrics struct {
 	slotClockErrors  prometheus.Counter
 	tipGapSlots      prometheus.Gauge
 
+	// Self-validation before adoption (optional, nil when disabled)
+	forgeValidationDuration prometheus.Histogram
+	forgeValidationFailed   prometheus.Counter
+
 	// Leios EB forging outcomes
 	leiosEbForged  prometheus.Counter
 	leiosEbSkipped *prometheus.CounterVec
@@ -165,6 +169,21 @@ func initForgingMetrics(
 		prometheus.GaugeOpts{
 			Name: "dingo_forge_tip_gap_slots",
 			Help: "latest observed tip gap in slots",
+		},
+	)
+	m.forgeValidationDuration = factory.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "dingo_forge_validation_duration_seconds",
+			Help: "wall-clock time spent in forged-block self-validation (header crypto, body hash, per-tx); only recorded when validation is enabled",
+			Buckets: prometheus.ExponentialBuckets(
+				0.001, 2, 12,
+			), // 1ms to ~4s
+		},
+	)
+	m.forgeValidationFailed = factory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_forge_validation_failed_total",
+			Help: "forged blocks dropped because self-validation failed",
 		},
 	)
 	m.leiosEbForged = factory.NewCounter(

--- a/ledger/validate_forged.go
+++ b/ledger/validate_forged.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ValidateForgedBlock validates a locally-forged block before it is adopted
+// onto the chain and diffused to peers. It runs three checks in order:
+//
+//  1. Header crypto — VRF proof and KES signature verification (skipped for
+//     Byron-era blocks which use PBFT consensus and have no VRF/KES fields).
+//  2. Body-hash consistency — verifies that the body hash in the header is
+//     non-zero, catching any builder bug that would embed an all-zero hash.
+//  3. Per-transaction ledger rules — each transaction in the block is
+//     validated against the current UTxO state. An intra-block overlay
+//     is maintained so that transactions spending outputs created earlier
+//     in the same block are correctly resolved.
+//
+// A non-nil error means the block is invalid and must not be adopted or
+// diffused. This function satisfies the forging.BlockValidator interface.
+func (ls *LedgerState) ValidateForgedBlock(
+	block ledger.Block,
+	_ []byte,
+) error {
+	if block == nil {
+		return errors.New("nil block")
+	}
+
+	// 1. Header crypto: VRF proof + KES signature.
+	// Byron blocks use PBFT and have no VRF/KES fields; skip them.
+	if block.Era().Id != byron.EraIdByron {
+		if err := ls.verifyBlockHeaderCrypto(block); err != nil {
+			return fmt.Errorf("header crypto: %w", err)
+		}
+	}
+
+	// 2. Body-hash consistency: a non-Byron block with an all-zero body
+	// hash is always invalid — the builder must have committed a real hash.
+	if err := ls.validateForgedBodyHash(block); err != nil {
+		return err
+	}
+
+	// 3. Per-transaction ledger validation with intra-block UTxO overlay.
+	if err := ls.validateForgedTxs(block); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateForgedBodyHash checks that the body hash embedded in the header is
+// non-zero for non-Byron blocks. gouroboros era parsers validate hash
+// agreement during CBOR decode, but we re-check here as defence-in-depth.
+func (ls *LedgerState) validateForgedBodyHash(block ledger.Block) error {
+	if block.Era().Id == byron.EraIdByron {
+		return nil
+	}
+	bodyHash := block.Header().BlockBodyHash()
+	bh := bodyHash.Bytes()
+	if len(bh) == 0 {
+		return fmt.Errorf(
+			"block at slot %d has empty body hash bytes",
+			block.SlotNumber(),
+		)
+	}
+	allZero := true
+	for _, b := range bh {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return fmt.Errorf(
+			"block at slot %d has all-zero body hash",
+			block.SlotNumber(),
+		)
+	}
+	return nil
+}
+
+// validateForgedTxs validates each transaction in the block against the
+// current ledger state using an intra-block UTxO overlay. The overlay
+// accumulates outputs produced by earlier transactions so that later
+// transactions in the same block can spend them correctly.
+func (ls *LedgerState) validateForgedTxs(block ledger.Block) error {
+	txs := block.Transactions()
+	if len(txs) == 0 {
+		return nil
+	}
+
+	// consumedUtxos: inputs spent within this block (prevents intra-block
+	// double-spend); key: "<txId>:<outputIndex>".
+	// createdUtxos: outputs produced within this block and not yet in the
+	// persistent UTxO set; key: same format.
+	consumedUtxos := make(map[string]struct{}, len(txs)*2)
+	createdUtxos := make(map[string]lcommon.Utxo, len(txs)*4)
+
+	for _, tx := range txs {
+		if err := ls.ValidateTxWithOverlay(tx, consumedUtxos, createdUtxos); err != nil {
+			return fmt.Errorf(
+				"tx %s in forged block at slot %d: %w",
+				tx.Hash(),
+				block.SlotNumber(),
+				err,
+			)
+		}
+
+		// Advance the overlay with this transaction's effects.
+		// Use Produced() instead of Outputs() to handle failed TXs correctly:
+		// for an invalid TX the collateral return is at index len(Outputs())
+		// and is the only output that should be visible to later TXs.
+		for _, utxo := range tx.Produced() {
+			key := fmt.Sprintf(
+				"%s:%d",
+				utxo.Id.Id().String(),
+				utxo.Id.Index(),
+			)
+			createdUtxos[key] = utxo
+		}
+		for _, input := range tx.Inputs() {
+			key := fmt.Sprintf(
+				"%s:%d",
+				input.Id().String(),
+				input.Index(),
+			)
+			consumedUtxos[key] = struct{}{}
+		}
+	}
+
+	return nil
+}

--- a/ledger/validate_forged.go
+++ b/ledger/validate_forged.go
@@ -126,9 +126,6 @@ func (ls *LedgerState) validateForgedTxs(block ledger.Block) error {
 		}
 
 		// Advance the overlay with this transaction's effects.
-		// Use Produced() instead of Outputs() to handle failed TXs correctly:
-		// for an invalid TX the collateral return is at index len(Outputs())
-		// and is the only output that should be visible to later TXs.
 		for _, utxo := range tx.Produced() {
 			key := fmt.Sprintf(
 				"%s:%d",
@@ -137,7 +134,11 @@ func (ls *LedgerState) validateForgedTxs(block ledger.Block) error {
 			)
 			createdUtxos[key] = utxo
 		}
-		for _, input := range tx.Inputs() {
+		// Use Consumed() instead of Inputs(): for a phase-2 failed Plutus tx
+		// the regular inputs are NOT spent; only the collateral inputs are.
+		// Inputs() would falsely mark regular inputs as consumed and reject
+		// a later tx in the same block that spends those still-valid UTxOs.
+		for _, input := range tx.Consumed() {
 			key := fmt.Sprintf(
 				"%s:%d",
 				input.Id().String(),

--- a/ledger/validate_forged_test.go
+++ b/ledger/validate_forged_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// validateForgedBodyHashTest exercises validateForgedBodyHash in isolation
+// using the stub block type from block_event_test.go (same package).
+
+func TestValidateForgedBlockNilBlockReturnsError(t *testing.T) {
+	ls := &LedgerState{}
+	err := ls.ValidateForgedBlock(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil block")
+}
+
+func TestValidateForgedBodyHashZeroHashReturnsError(t *testing.T) {
+	ls := &LedgerState{}
+	// Use a stub block with a non-Byron era and an all-zero body hash.
+	block := &stubValidateBlock{
+		slot:     100,
+		bodyHash: lcommon.Blake2b256{},
+	}
+	err := ls.validateForgedBodyHash(block)
+	require.Error(t, err)
+	// Either "empty body hash bytes" or "all-zero body hash"
+	assert.Contains(t, err.Error(), "body hash")
+}
+
+func TestValidateForgedBodyHashNonZeroHashPasses(t *testing.T) {
+	ls := &LedgerState{}
+	var h lcommon.Blake2b256
+	raw := make([]byte, 32)
+	raw[0] = 0x01
+	h = lcommon.NewBlake2b256(raw)
+	block := &stubValidateBlock{
+		slot:     100,
+		bodyHash: h,
+	}
+	err := ls.validateForgedBodyHash(block)
+	require.NoError(t, err)
+}
+
+func TestValidateForgedTxsEmptyBlockPasses(t *testing.T) {
+	ls := &LedgerState{}
+	block := &stubValidateBlock{slot: 100}
+	err := ls.validateForgedTxs(block)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Stub block for body-hash and empty-tx tests.
+// ---------------------------------------------------------------------------
+
+// stubValidateBlock satisfies ledger.Block for validate_forged_test tests.
+// It uses a Babbage-like era so Byron checks are skipped.
+type stubValidateBlock struct {
+	slot     uint64
+	bodyHash lcommon.Blake2b256
+}
+
+func (b *stubValidateBlock) Header() lcommon.BlockHeader      { return b }
+func (b *stubValidateBlock) Type() int                        { return 0 }
+func (b *stubValidateBlock) Transactions() []lcommon.Transaction { return nil }
+func (b *stubValidateBlock) Utxorpc() (*utxorpc_cardano.Block, error) { return nil, nil }
+func (b *stubValidateBlock) Hash() lcommon.Blake2b256         { return lcommon.Blake2b256{} }
+func (b *stubValidateBlock) PrevHash() lcommon.Blake2b256     { return lcommon.Blake2b256{} }
+func (b *stubValidateBlock) BlockNumber() uint64              { return 0 }
+func (b *stubValidateBlock) SlotNumber() uint64               { return b.slot }
+func (b *stubValidateBlock) IssuerVkey() lcommon.IssuerVkey   { return lcommon.IssuerVkey{} }
+func (b *stubValidateBlock) BlockBodySize() uint64            { return 0 }
+func (b *stubValidateBlock) Era() lcommon.Era {
+	// Return a non-Byron era so body-hash checks are applied.
+	return lcommon.Era{Id: 5, Name: "Babbage"}
+}
+func (b *stubValidateBlock) Cbor() []byte                      { return nil }
+func (b *stubValidateBlock) BlockBodyHash() lcommon.Blake2b256 { return b.bodyHash }

--- a/node_forging.go
+++ b/node_forging.go
@@ -260,6 +260,15 @@ func (n *Node) initBlockForger(
 		leiosMempool = mempoolAdapter
 	}
 
+	// Wire self-validation when the operator opts in. The validator runs
+	// header crypto, body-hash, and per-tx ledger checks before AddBlock.
+	var blockValidator forging.BlockValidator
+	if n.config.validateForgedBlock {
+		blockValidator = &forgedBlockValidatorAdapter{
+			ledgerState: n.ledgerState,
+		}
+	}
+
 	// Create the block forger with the real leader election
 	forger, err := forging.NewBlockForger(forging.ForgerConfig{
 		Mode:                        forging.ModeProduction,
@@ -272,6 +281,7 @@ func (n *Node) initBlockForger(
 		SlotClock:                   slotClock,
 		ForgeSyncToleranceSlots:     n.config.forgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots: n.config.forgeStaleGapThresholdSlots,
+		BlockValidator:              blockValidator,
 		PromRegistry:                n.config.promRegistry,
 		LeiosProduceChecker:         leiosChecker,
 		LeiosEBBroadcaster:          leiosEBCaster,
@@ -570,6 +580,20 @@ func (a *leiosPipelineAdapter) MayProduceEndorserBlock(
 		return false, "", err
 	}
 	return dec.Allowed, dec.Reason, nil
+}
+
+// forgedBlockValidatorAdapter adapts ledger.LedgerState to
+// forging.BlockValidator so the forger can self-validate blocks before
+// adoption without importing the ledger package from within forging.
+type forgedBlockValidatorAdapter struct {
+	ledgerState *ledger.LedgerState
+}
+
+func (a *forgedBlockValidatorAdapter) ValidateForgedBlock(
+	block gledger.Block,
+	blockCbor []byte,
+) error {
+	return a.ledgerState.ValidateForgedBlock(block, blockCbor)
 }
 
 // epochNonceAdapter adapts ledger.LedgerState to forging.EpochNonceProvider.


### PR DESCRIPTION
**Summary**

Added an optional self-validation step for forged blocks that runs before the block is adopted into the chain and diffused to peers. When --validate-forged-block is set, each forged block is checked for:

```
Header crypto — VRF/KES signature verification (non-Byron eras).
Body hash guard — rejects non-Byron blocks with an all-zero body hash.
Per-tx ledger rules — validates each transaction with an intra-block UTxO overlay so tx N+1 can spend outputs created by tx N in the same block.
```
The validator runs between BuildBlock and AddBlock. On failure, the block is dropped and logged and the dingo_forge_validation_failed_total counter increments. On success, dingo_forge_validation_duration_seconds is recorded. 
The feature is off by default — no behavior change unless the flag is set.

**Changes**

1. `ledger/validate_forged.go`: Added `ValidateForgedBlock` on `LedgerState`, giving the forger a full self-validation path for newly assembled blocks. It checks header crypto, rejects invalid body-hash state, and validates transactions using an intra-block UTxO overlay.
2. `ledger/forging/forger.go`: Added a `BlockValidator` interface and calls it after `BuildBlock` but before `AddBlock`, so a bad forged block is rejected before it becomes the local chain tip or is broadcast.
3. `ledger/forging/metrics.go`: Added observability for the new path with `dingo_forge_validation_duration_seconds` and `dingo_forge_validation_failed_total`.
4. `node_forging.go`: wires the ledger validator into the forger through forgedBlockValidatorAdapter.
5. `config.go, internal/config/config.go, internal/config/flags.go, internal/node/node.go`: plumbs the new opt-in `--validate-forged-block flag `and `DINGO_VALIDATE_FORGED_BLOCK` env var through config and node startup.
6. `ARCHITECTURE.md`: documents the optional forged-block self-validation step in the block forging flow.


**Tests**

1. `ledger/forging/forger_validator_test.go`: verifies that a passing validator allows adoption, a failing validator drops the block, a nil validator skips validation, and validation happens before broadcast.
2. `ledger/validate_forged_test.go`: covers the validator’s basic behavior: nil block errors, all-zero body hash errors, non-zero body hash passes, and an empty transaction block passes.

Closes #2612 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional self-validation of forged blocks right after `BuildBlock` and before adoption/diffusion; invalid blocks are dropped, and forge latency now includes validation time. Closes #2612.

- **New Features**
  - Added `BlockValidator` to run after `BuildBlock` and before `AddBlock`, so dropped blocks never emit success events.
  - Implemented `LedgerState.ValidateForgedBlock`: VRF/KES header checks (non-Byron), non-zero body hash guard, and per-tx ledger rules with an intra-block UTxO overlay.
  - Metrics: `dingo_forge_validation_duration_seconds`, `dingo_forge_validation_failed_total`.
  - Config: `validateForgedBlock`, CLI `--validate-forged-block`, env `DINGO_VALIDATE_FORGED_BLOCK`.
  - Dev/test: wired `txpump` into DevNet compose build, run as root with `/logs`, added a post-start check in `run-tests.sh`; exposed `shelley-genesis.json` for genesis UTxO discovery; switched `txpump` Dockerfile path.

- **Bug Fixes**
  - Guarded `block.Hash()` logging on both success and failure paths when `BuildBlock` returns nil to avoid a panic.

<sup>Written for commit 718d962bfcc7f0ad6f72212eee0973a93cfa8fe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to validate locally forged blocks before they are accepted and shared.
  * Added a new command-line flag and configuration option to enable this behavior.

* **Bug Fixes**
  * Blocks that fail validation are now dropped instead of being adopted or broadcast.
  * Validation checks include block headers, body hash integrity, and transaction rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->