### PR TITLE
fix(blockfrost): align stake-account response schemas with OpenAPI 0.…

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -217,7 +217,7 @@ erDiagram
 | `vote_registration_delegation` | `id`, `staking_key`, `credential_tag`, `drep`, `drep_type`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `drep`, `certificate_id`, `added_slot` | Combined registration and DRep delegation. |
 
 | `move_instantaneous_rewards` | `id`, `pot`, `certificate_id`, `added_slot`, `other_pot` | PK `id`; indexes `pot`, `certificate_id`, `added_slot` | MIR certificate header. `pot`: 0 = Reserves, 1 = Treasury. `other_pot` is non-zero for pot-to-pot transfer certs (no child rows); zero for credential distribution certs (child rows in `move_instantaneous_rewards_reward`). Applied at each epoch boundary by the Shelley INSTANT rule. |
-| `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `amount` | PK `id`; index `mir_id` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. |
+| `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `credential_tag`, `amount` | PK `id`; index `mir_id`; composite index `(credential_tag, credential)` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. `credential_tag` distinguishes key (0) vs script (1) stake credentials sharing a hash; `GetAccountSumsByCredential` filters on `(credential_tag, credential)` to attribute reserves/treasury totals to an account. |
 
 ### Pools
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -643,44 +643,53 @@ AND a.active = true
 
 ### `GetAccountDelegationHistory`
 
-Dingo unions all certificate tables that can carry pool delegation and orders with slot, transaction index, and certificate index.
+Dingo unions all certificate tables that can carry pool delegation and orders with slot, transaction index, and certificate index. Each row also selects `tx.slot` (`tx_slot`) and `tx.block_hash` (`block_hash`); the Blockfrost adapter resolves `block_height` from the block store by hash (block numbers are not in the metadata SQL schema) and derives `block_time` from the slot.
 
 ```sql
 SELECT *
 FROM (
-  SELECT sd.added_slot, tx.block_index, c.cert_index, tx.hash AS tx_hash, sd.pool_key_hash
+  SELECT sd.added_slot, tx.block_index, c.cert_index, tx.hash AS tx_hash, sd.pool_key_hash,
+         tx.slot AS tx_slot, tx.block_hash AS block_hash
   FROM stake_delegation sd
   JOIN certs c ON c.id = sd.certificate_id
   JOIN "transaction" tx ON tx.id = c.transaction_id
   WHERE sd.credential_tag = $1
     AND sd.staking_key = decode($2, 'hex')
 
-  UNION ALL
-  SELECT srd.added_slot, tx.block_index, c.cert_index, tx.hash, srd.pool_key_hash
-  FROM stake_registration_delegation srd
-  JOIN certs c ON c.id = srd.certificate_id
-  JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE srd.credential_tag = $1
-    AND srd.staking_key = decode($2, 'hex')
-
-  UNION ALL
-  SELECT svd.added_slot, tx.block_index, c.cert_index, tx.hash, svd.pool_key_hash
-  FROM stake_vote_delegation svd
-  JOIN certs c ON c.id = svd.certificate_id
-  JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE svd.credential_tag = $1
-    AND svd.staking_key = decode($2, 'hex')
-
-  UNION ALL
-  SELECT svrd.added_slot, tx.block_index, c.cert_index, tx.hash, svrd.pool_key_hash
-  FROM stake_vote_registration_delegation svrd
-  JOIN certs c ON c.id = svrd.certificate_id
-  JOIN "transaction" tx ON tx.id = c.transaction_id
-  WHERE svrd.credential_tag = $1
-    AND svrd.staking_key = decode($2, 'hex')
+  UNION ALL  -- same projection from stake_registration_delegation,
+             -- stake_vote_delegation, and stake_vote_registration_delegation
+  -- ...
 ) h
 ORDER BY added_slot DESC, block_index DESC, cert_index DESC, tx_hash DESC
 LIMIT 50;
+```
+
+### `GetAccountRegistrationHistory`
+
+Unions the stake (de)registration certificate tables, tagging each row with an
+`action` (`registered` / `deregistered`). Each row additionally selects the
+deposit (`deposit_amount` for registrations, the refund `amount` for the legacy
+`deregistration` table, `0` where the certificate carries none), `tx.slot`
+(`tx_slot`), and `tx.block_hash` (`block_hash`, resolved to `block_height` by
+the adapter as above).
+
+### `GetAccountSumsByCredential`
+
+Backs the Blockfrost account `withdrawals_sum`, `reserves_sum`, and
+`treasury_sum` fields. All three totals are reconstructed from rollback-aware
+persisted rows rather than stored as running counters:
+
+```sql
+-- withdrawals_sum
+SELECT COALESCE(SUM(amount), 0)
+FROM account_reward_delta
+WHERE withdrawal = true AND credential_tag = $1 AND staking_key = decode($2, 'hex');
+
+-- reserves_sum (pot = 0) / treasury_sum (pot = 1)
+SELECT COALESCE(SUM(r.amount), 0)
+FROM move_instantaneous_rewards_reward r
+JOIN move_instantaneous_rewards mir ON mir.id = r.mir_id
+WHERE mir.pot = $pot AND r.credential_tag = $1 AND r.credential = decode($2, 'hex');
 ```
 
 ### `GetStakeRegistrationsByCredential`

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -136,6 +136,51 @@ func delegationActivationEpoch(
 	)
 }
 
+// accountHistoryBlockInfo resolves the tx_slot, block_time (Unix seconds), and
+// block_height fields shared by the account delegation and registration
+// history endpoints. The block height comes from the block store (keyed by
+// block hash, since the metadata SQL schema does not hold block numbers);
+// blockNumbers caches lookups across the rows of a single response.
+func (a *NodeAdapter) accountHistoryBlockInfo(
+	txSlot uint64,
+	blockHash []byte,
+	blockNumbers map[string]uint64,
+) (slot, blockTime, height int64, err error) {
+	slot, err = uint64ToInt64(txSlot, "account history tx slot")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	blockHashKey := hex.EncodeToString(blockHash)
+	blockHeight, ok := blockNumbers[blockHashKey]
+	if !ok {
+		block, err := a.ledgerState.BlockByHash(blockHash)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf(
+				"get block %x for account history: %w",
+				blockHash,
+				err,
+			)
+		}
+		blockHeight = block.Number
+		blockNumbers[blockHashKey] = blockHeight
+	}
+	height, err = uint64ToInt64(blockHeight, "account history block height")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	slotTime, err := a.ledgerState.SlotToTime(txSlot)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf(
+			"get block time for slot %d: %w",
+			txSlot,
+			err,
+		)
+	}
+	return slot, slotTime.Unix(), height, nil
+}
+
 // ChainTip returns the current chain tip from the ledger
 // state.
 func (a *NodeAdapter) ChainTip() (
@@ -1046,27 +1091,71 @@ func (a *NodeAdapter) Account(
 		activeEpoch = &epochID
 	}
 
+	// Per Blockfrost OpenAPI (>=0.1.85), `active` is the delegation
+	// state (the account is registered and currently delegated to a
+	// pool), while `registered` is the registration state on its own.
+	// account.Active is Dingo's registration flag, so it backs
+	// `registered`; `active` additionally requires a pool delegation.
+	delegating := account.Active && len(account.Pool) > 0
+
 	var poolID *string
-	if account.Active && len(account.Pool) > 0 {
+	if delegating {
 		pool := lcommon.PoolId(
 			lcommon.NewBlake2b224(account.Pool),
 		).String()
 		poolID = &pool
 	}
 
+	sums, err := db.GetAccountSumsByCredential(
+		credentialTag,
+		stakeKey,
+		nil,
+	)
+	if err != nil {
+		return AccountInfo{}, fmt.Errorf(
+			"get account sums: %w",
+			err,
+		)
+	}
+
 	reward := strconv.FormatUint(uint64(account.Reward), 10)
 	return AccountInfo{
 		StakeAddress:       stakeAddress,
-		Active:             account.Active,
+		Active:             delegating,
 		ActiveEpoch:        activeEpoch,
 		ControlledAmount:   strconv.FormatUint(controlledAmount, 10),
 		RewardsSum:         reward,
-		WithdrawalsSum:     "0",
-		ReservesSum:        "0",
-		TreasurySum:        "0",
+		WithdrawalsSum:     strconv.FormatUint(sums.WithdrawalsSum, 10),
+		ReservesSum:        strconv.FormatUint(sums.ReservesSum, 10),
+		TreasurySum:        strconv.FormatUint(sums.TreasurySum, 10),
 		WithdrawableAmount: reward,
 		PoolID:             poolID,
+		DrepID:             accountDrepID(account.Drep, account.DrepType),
+		Registered:         account.Active,
 	}, nil
+}
+
+// accountDrepID renders the Bech32 DRep ID a stake account is delegated to,
+// matching the Blockfrost account_content drep_id field. It returns nil when
+// the account has no DRep delegation (no credential and the default key-hash
+// type), distinguishing that from an explicit always-abstain/no-confidence
+// delegation, which carry no credential but a non-default type.
+func accountDrepID(credential []byte, drepType uint64) *string {
+	if len(credential) == 0 && drepType == models.DrepTypeAddrKeyHash {
+		return nil
+	}
+	// DrepType is a small ledger enum (0-3); guard the narrowing
+	// conversion so gosec is satisfied and an out-of-range value
+	// degrades to "no DRep" rather than wrapping negative.
+	if drepType > uint64(math.MaxInt) {
+		return nil
+	}
+	drep := lcommon.Drep{
+		Type:       int(drepType),
+		Credential: credential,
+	}
+	id := drep.String()
+	return &id
 }
 
 // AccountAssociatedAddresses returns payment addresses
@@ -1204,6 +1293,7 @@ func (a *NodeAdapter) AccountDelegationHistory(
 		)
 	}
 
+	blockNumbers := make(map[string]uint64, len(rows))
 	ret := make([]AccountDelegationHistoryInfo, 0, len(rows))
 	for _, row := range rows {
 		activeEpoch, err := delegationActivationEpoch(
@@ -1217,6 +1307,14 @@ func (a *NodeAdapter) AccountDelegationHistory(
 				err,
 			)
 		}
+		txSlot, blockTime, blockHeight, err := a.accountHistoryBlockInfo(
+			row.TxSlot,
+			row.BlockHash,
+			blockNumbers,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
 		ret = append(ret, AccountDelegationHistoryInfo{
 			ActiveEpoch: activeEpoch,
 			TxHash:      hex.EncodeToString(row.TxHash),
@@ -1224,6 +1322,9 @@ func (a *NodeAdapter) AccountDelegationHistory(
 			PoolID: lcommon.PoolId(
 				lcommon.NewBlake2b224(row.PoolKeyHash),
 			).String(),
+			TxSlot:      txSlot,
+			BlockTime:   blockTime,
+			BlockHeight: blockHeight,
 		})
 	}
 	return ret, total, nil
@@ -1281,15 +1382,28 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 		)
 	}
 
+	blockNumbers := make(map[string]uint64, len(rows))
 	ret := make(
 		[]AccountRegistrationHistoryInfo,
 		0,
 		len(rows),
 	)
 	for _, row := range rows {
+		txSlot, blockTime, blockHeight, err := a.accountHistoryBlockInfo(
+			row.TxSlot,
+			row.BlockHash,
+			blockNumbers,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
 		ret = append(ret, AccountRegistrationHistoryInfo{
-			TxHash: hex.EncodeToString(row.TxHash),
-			Action: row.Action,
+			TxHash:      hex.EncodeToString(row.TxHash),
+			Action:      row.Action,
+			Deposit:     strconv.FormatUint(row.Deposit, 10),
+			TxSlot:      txSlot,
+			BlockTime:   blockTime,
+			BlockHeight: blockHeight,
 		})
 	}
 	return ret, total, nil

--- a/api/blockfrost/blockfrost_compat_test.go
+++ b/api/blockfrost/blockfrost_compat_test.go
@@ -680,6 +680,14 @@ func TestCompatAccountRegistrationHistoryResponse(
 	assert.Equal(t, int(ours[1].TxSlot), theirs[1].TxSlot)
 	assert.Equal(t, int(ours[1].BlockTime), theirs[1].BlockTime)
 	assert.Equal(t, int(ours[1].BlockHeight), theirs[1].BlockHeight)
+
+	// bfgo.AccountRegistrationHistory has no Deposit field; assert via raw
+	// JSON so a serialization regression on the "deposit" key is caught.
+	var rawItems []map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &rawItems))
+	require.Len(t, rawItems, 2)
+	assert.Equal(t, ours[0].Deposit, rawItems[0]["deposit"])
+	assert.Equal(t, ours[1].Deposit, rawItems[1]["deposit"])
 }
 
 // TestCompatAccountRewardHistoryResponse verifies that

--- a/api/blockfrost/blockfrost_compat_test.go
+++ b/api/blockfrost/blockfrost_compat_test.go
@@ -677,6 +677,9 @@ func TestCompatAccountRegistrationHistoryResponse(
 	assert.Equal(t, int(ours[0].BlockHeight), theirs[0].BlockHeight)
 	assert.Equal(t, ours[1].TxHash, theirs[1].TXHash)
 	assert.Equal(t, ours[1].Action, theirs[1].Action)
+	assert.Equal(t, int(ours[1].TxSlot), theirs[1].TxSlot)
+	assert.Equal(t, int(ours[1].BlockTime), theirs[1].BlockTime)
+	assert.Equal(t, int(ours[1].BlockHeight), theirs[1].BlockHeight)
 }
 
 // TestCompatAccountRewardHistoryResponse verifies that

--- a/api/blockfrost/blockfrost_compat_test.go
+++ b/api/blockfrost/blockfrost_compat_test.go
@@ -534,6 +534,7 @@ func TestCompatNetworkResponse(t *testing.T) {
 func TestCompatAccountResponse(t *testing.T) {
 	activeEpoch := int64(42)
 	poolID := "pool1xyz"
+	drepID := "drep1y2v8nygzdll2krgvw5dzqpkncvj3y"
 	ours := AccountResponse{
 		StakeAddress:       "stake_test1upugeuz3jdy0a7hncusutadavzcetdzylgxcldz39hp9n0s0xy0n5",
 		Active:             true,
@@ -545,6 +546,8 @@ func TestCompatAccountResponse(t *testing.T) {
 		TreasurySum:        "7",
 		WithdrawableAmount: "89",
 		PoolID:             &poolID,
+		DrepID:             &drepID,
+		Registered:         true,
 	}
 
 	data, err := json.Marshal(ours)
@@ -572,6 +575,9 @@ func TestCompatAccountResponse(t *testing.T) {
 	)
 	require.NotNil(t, theirs.PoolID)
 	assert.Equal(t, poolID, *theirs.PoolID)
+	require.NotNil(t, theirs.DrepID)
+	assert.Equal(t, drepID, *theirs.DrepID)
+	assert.Equal(t, ours.Registered, theirs.Registered)
 }
 
 // TestCompatAccountAssociatedAddressesResponse verifies
@@ -605,6 +611,9 @@ func TestCompatAccountDelegationHistoryResponse(t *testing.T) {
 			TxHash:      "abc123",
 			Amount:      "1000000",
 			PoolID:      "pool1xyz",
+			TxSlot:      123456,
+			BlockTime:   1700000000,
+			BlockHeight: 9876,
 		},
 	}
 
@@ -622,6 +631,9 @@ func TestCompatAccountDelegationHistoryResponse(t *testing.T) {
 	assert.Equal(t, ours[0].TxHash, theirs[0].TXHash)
 	assert.Equal(t, ours[0].Amount, theirs[0].Amount)
 	assert.Equal(t, ours[0].PoolID, theirs[0].PoolID)
+	assert.Equal(t, int(ours[0].TxSlot), theirs[0].TxSlot)
+	assert.Equal(t, int(ours[0].BlockTime), theirs[0].BlockTime)
+	assert.Equal(t, int(ours[0].BlockHeight), theirs[0].BlockHeight)
 }
 
 // TestCompatAccountRegistrationHistoryResponse verifies
@@ -633,12 +645,20 @@ func TestCompatAccountRegistrationHistoryResponse(
 ) {
 	ours := []AccountRegistrationHistoryResponse{
 		{
-			TxHash: "abc123",
-			Action: "registered",
+			TxHash:      "abc123",
+			Action:      "registered",
+			Deposit:     "2000000",
+			TxSlot:      123456,
+			BlockTime:   1700000000,
+			BlockHeight: 9876,
 		},
 		{
-			TxHash: "def456",
-			Action: "deregistered",
+			TxHash:      "def456",
+			Action:      "deregistered",
+			Deposit:     "2000000",
+			TxSlot:      223456,
+			BlockTime:   1700000100,
+			BlockHeight: 9999,
 		},
 	}
 
@@ -652,6 +672,9 @@ func TestCompatAccountRegistrationHistoryResponse(
 	require.Len(t, theirs, 2)
 	assert.Equal(t, ours[0].TxHash, theirs[0].TXHash)
 	assert.Equal(t, ours[0].Action, theirs[0].Action)
+	assert.Equal(t, int(ours[0].TxSlot), theirs[0].TxSlot)
+	assert.Equal(t, int(ours[0].BlockTime), theirs[0].BlockTime)
+	assert.Equal(t, int(ours[0].BlockHeight), theirs[0].BlockHeight)
 	assert.Equal(t, ours[1].TxHash, theirs[1].TXHash)
 	assert.Equal(t, ours[1].Action, theirs[1].Action)
 }

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -1869,16 +1869,19 @@ func TestHandleEpochParamsNotFound(t *testing.T) {
 }
 
 func TestHandleAccount(t *testing.T) {
+	drepID := "drep1xyz"
 	mock := &mockNode{
 		account: AccountInfo{
 			StakeAddress:       "stake_test1",
 			Active:             true,
 			ControlledAmount:   "123",
 			RewardsSum:         "10",
-			WithdrawalsSum:     "0",
-			ReservesSum:        "0",
-			TreasurySum:        "0",
+			WithdrawalsSum:     "45",
+			ReservesSum:        "6",
+			TreasurySum:        "7",
 			WithdrawableAmount: "10",
+			DrepID:             &drepID,
+			Registered:         true,
 		},
 	}
 	b := newTestBlockfrost(mock)
@@ -1901,7 +1904,46 @@ func TestHandleAccount(t *testing.T) {
 	assert.True(t, resp.Active)
 	assert.Equal(t, "123", resp.ControlledAmount)
 	assert.Equal(t, "10", resp.RewardsSum)
+	assert.Equal(t, "45", resp.WithdrawalsSum)
+	assert.Equal(t, "6", resp.ReservesSum)
+	assert.Equal(t, "7", resp.TreasurySum)
 	assert.Equal(t, "10", resp.WithdrawableAmount)
+	require.NotNil(t, resp.DrepID)
+	assert.Equal(t, "drep1xyz", *resp.DrepID)
+	assert.True(t, resp.Registered)
+
+	// The OpenAPI 0.1.88 account_content schema requires these field
+	// names; assert the marshaled key set exposes them.
+	assertJSONKeys(t, resp, []string{
+		"stake_address",
+		"active",
+		"active_epoch",
+		"controlled_amount",
+		"rewards_sum",
+		"withdrawals_sum",
+		"reserves_sum",
+		"treasury_sum",
+		"withdrawable_amount",
+		"pool_id",
+		"drep_id",
+		"registered",
+	})
+}
+
+// assertJSONKeys marshals v and asserts that the resulting JSON object's keys
+// exactly match want. It is used to pin Blockfrost response structs to the
+// field set defined by the Blockfrost OpenAPI schema.
+func assertJSONKeys(t *testing.T, v any, want []string) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	var obj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &obj))
+	got := make([]string, 0, len(obj))
+	for k := range obj {
+		got = append(got, k)
+	}
+	assert.ElementsMatch(t, want, got)
 }
 
 func TestHandleAccountInvalidStakeAddress(t *testing.T) {
@@ -1983,12 +2025,18 @@ func TestHandleAccountDelegationHistory(t *testing.T) {
 				TxHash:      "tx1",
 				Amount:      "0",
 				PoolID:      "pool1",
+				TxSlot:      100,
+				BlockTime:   1000,
+				BlockHeight: 10,
 			},
 			{
 				ActiveEpoch: 2,
 				TxHash:      "tx2",
 				Amount:      "0",
 				PoolID:      "pool2",
+				TxSlot:      200,
+				BlockTime:   2000,
+				BlockHeight: 20,
 			},
 		},
 	}
@@ -2012,13 +2060,41 @@ func TestHandleAccountDelegationHistory(t *testing.T) {
 	assert.Equal(t, int32(2), resp[0].ActiveEpoch)
 	assert.Equal(t, "tx2", resp[0].TxHash)
 	assert.Equal(t, "pool2", resp[0].PoolID)
+	assert.Equal(t, int64(200), resp[0].TxSlot)
+	assert.Equal(t, int64(2000), resp[0].BlockTime)
+	assert.Equal(t, int64(20), resp[0].BlockHeight)
+
+	// OpenAPI 0.1.88 account_delegation_content required field names.
+	assertJSONKeys(t, resp[0], []string{
+		"active_epoch",
+		"tx_hash",
+		"amount",
+		"pool_id",
+		"tx_slot",
+		"block_time",
+		"block_height",
+	})
 }
 
 func TestHandleAccountRegistrationHistory(t *testing.T) {
 	mock := &mockNode{
 		regs: []AccountRegistrationHistoryInfo{
-			{TxHash: "tx1", Action: "registered"},
-			{TxHash: "tx2", Action: "deregistered"},
+			{
+				TxHash:      "tx1",
+				Action:      "registered",
+				Deposit:     "2000000",
+				TxSlot:      100,
+				BlockTime:   1000,
+				BlockHeight: 10,
+			},
+			{
+				TxHash:      "tx2",
+				Action:      "deregistered",
+				Deposit:     "2000000",
+				TxSlot:      200,
+				BlockTime:   2000,
+				BlockHeight: 20,
+			},
 		},
 	}
 	b := newTestBlockfrost(mock)
@@ -2040,6 +2116,20 @@ func TestHandleAccountRegistrationHistory(t *testing.T) {
 	require.Len(t, resp, 2)
 	assert.Equal(t, "registered", resp[0].Action)
 	assert.Equal(t, "deregistered", resp[1].Action)
+	assert.Equal(t, "2000000", resp[0].Deposit)
+	assert.Equal(t, int64(100), resp[0].TxSlot)
+	assert.Equal(t, int64(1000), resp[0].BlockTime)
+	assert.Equal(t, int64(10), resp[0].BlockHeight)
+
+	// OpenAPI 0.1.88 account_registration_content required field names.
+	assertJSONKeys(t, resp[0], []string{
+		"tx_hash",
+		"action",
+		"deposit",
+		"tx_slot",
+		"block_time",
+		"block_height",
+	})
 }
 
 func TestHandleAccountRewardHistory(t *testing.T) {

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -593,6 +593,8 @@ type AccountInfo struct {
 	TreasurySum        string
 	WithdrawableAmount string
 	PoolID             *string
+	DrepID             *string
+	Registered         bool
 }
 
 // AccountAssociatedAddressInfo holds a payment address
@@ -608,13 +610,20 @@ type AccountDelegationHistoryInfo struct {
 	TxHash      string
 	Amount      string
 	PoolID      string
+	TxSlot      int64
+	BlockTime   int64
+	BlockHeight int64
 }
 
 // AccountRegistrationHistoryInfo holds a stake-account
 // registration history row.
 type AccountRegistrationHistoryInfo struct {
-	TxHash string
-	Action string
+	TxHash      string
+	Action      string
+	Deposit     string
+	TxSlot      int64
+	BlockTime   int64
+	BlockHeight int64
 }
 
 // AccountRewardHistoryInfo holds a stake-account reward

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -471,6 +471,8 @@ type AccountResponse struct {
 	TreasurySum        string  `json:"treasury_sum"`
 	WithdrawableAmount string  `json:"withdrawable_amount"`
 	PoolID             *string `json:"pool_id"`
+	DrepID             *string `json:"drep_id"`
+	Registered         bool    `json:"registered"`
 }
 
 // AccountAssociatedAddressResponse represents a stake
@@ -486,13 +488,20 @@ type AccountDelegationHistoryResponse struct {
 	TxHash      string `json:"tx_hash"`
 	Amount      string `json:"amount"`
 	PoolID      string `json:"pool_id"`
+	TxSlot      int64  `json:"tx_slot"`
+	BlockTime   int64  `json:"block_time"`
+	BlockHeight int64  `json:"block_height"`
 }
 
 // AccountRegistrationHistoryResponse represents a
 // stake-account registration history row.
 type AccountRegistrationHistoryResponse struct {
-	TxHash string `json:"tx_hash"`
-	Action string `json:"action"`
+	TxHash      string `json:"tx_hash"`
+	Action      string `json:"action"`
+	Deposit     string `json:"deposit"`
+	TxSlot      int64  `json:"tx_slot"`
+	BlockTime   int64  `json:"block_time"`
+	BlockHeight int64  `json:"block_height"`
 }
 
 // AccountRewardHistoryResponse represents a stake-account

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -131,3 +131,28 @@ func (d *Database) CountAccountRegistrationHistoryByCredential(
 	}
 	return count, nil
 }
+
+// GetAccountSumsByCredential returns the aggregated withdrawal, reserves, and
+// treasury lovelace totals for a stake credential.
+func (d *Database) GetAccountSumsByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	txn *Txn,
+) (models.AccountSums, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	sums, err := d.metadata.GetAccountSumsByCredential(
+		credentialTag,
+		stakeKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"get account sums: %w",
+			err,
+		)
+	}
+	return sums, nil
+}

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -22,6 +22,14 @@ type AccountDelegationHistoryRow struct {
 	CertIndex   uint32
 	TxHash      []byte
 	PoolKeyHash []byte
+	// TxSlot is the slot of the transaction containing the
+	// delegation certificate.
+	TxSlot uint64
+	// BlockHash is the hash of the block containing the
+	// delegation certificate's transaction. The block height is
+	// resolved from the block store, which is not part of the
+	// metadata SQL schema.
+	BlockHash []byte
 }
 
 // AccountRegistrationHistoryRow holds registration
@@ -32,4 +40,30 @@ type AccountRegistrationHistoryRow struct {
 	CertIndex  uint32
 	TxHash     []byte
 	Action     string
+	// Deposit is the registration deposit (or refund, for
+	// deregistrations) in lovelace. Zero for certificate types
+	// that do not record an explicit deposit.
+	Deposit uint64
+	// TxSlot is the slot of the transaction containing the
+	// (de)registration certificate.
+	TxSlot uint64
+	// BlockHash is the hash of the block containing the
+	// (de)registration certificate's transaction. The block
+	// height is resolved from the block store, which is not part
+	// of the metadata SQL schema.
+	BlockHash []byte
+}
+
+// AccountSums holds aggregated lovelace totals for a stake
+// account, summed from persisted withdrawal and MIR state.
+type AccountSums struct {
+	// WithdrawalsSum is the total of all reward withdrawals
+	// made by the account.
+	WithdrawalsSum uint64
+	// ReservesSum is the total of all MIR transfers to the
+	// account sourced from the reserves pot.
+	ReservesSum uint64
+	// TreasurySum is the total of all MIR transfers to the
+	// account sourced from the treasury pot.
+	TreasurySum uint64
 }

--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -107,7 +107,9 @@ func delegationHistoryUnionQuery(
 				tx.block_index AS block_index,
 				certs.cert_index AS cert_index,
 				tx.hash AS tx_hash,
-				%[1]s.pool_key_hash AS pool_key_hash
+				%[1]s.pool_key_hash AS pool_key_hash,
+				tx.slot AS tx_slot,
+				tx.block_hash AS block_hash
 			FROM %[1]s
 			INNER JOIN certs
 				ON certs.id = %[1]s.certificate_id
@@ -218,6 +220,11 @@ func CountRegistrationHistoryByCredential(
 type registrationHistorySource struct {
 	table  string
 	action string
+	// depositColumn is the column on the source table holding the
+	// deposit (registrations) or deposit refund (deregistrations) in
+	// lovelace. Empty when the certificate type records no explicit
+	// deposit, in which case the query reports 0.
+	depositColumn string
 }
 
 func registrationHistoryUnionQuery(
@@ -233,12 +240,25 @@ func registrationHistoryUnionQuery(
 		if !ok {
 			continue
 		}
+		// depositColumn is drawn from the hardcoded source list below,
+		// never from caller input, so it is safe to interpolate.
+		depositExpr := "0"
+		if source.depositColumn != "" {
+			depositExpr = fmt.Sprintf(
+				"%s.%s",
+				source.table,
+				source.depositColumn,
+			)
+		}
 		parts = append(parts, fmt.Sprintf(
 			`SELECT %[1]s.added_slot AS added_slot,
 				tx.block_index AS block_index,
 				certs.cert_index AS cert_index,
 				tx.hash AS tx_hash,
-				? AS action
+				? AS action,
+				COALESCE(%[3]s, 0) AS deposit,
+				tx.slot AS tx_slot,
+				tx.block_hash AS block_hash
 			FROM %[1]s
 			INNER JOIN certs
 				ON certs.id = %[1]s.certificate_id
@@ -248,6 +268,7 @@ func registrationHistoryUnionQuery(
 					AND %[1]s.staking_key = ?`,
 			source.table,
 			transactionJoinClause(db),
+			depositExpr,
 		))
 		args = append(
 			args,
@@ -262,13 +283,13 @@ func registrationHistoryUnionQuery(
 
 func registrationHistorySources() []registrationHistorySource {
 	return []registrationHistorySource{
-		{table: "deregistration", action: "deregistered"},
-		{table: "registration", action: "registered"},
+		{table: "deregistration", action: "deregistered", depositColumn: "amount"},
+		{table: "registration", action: "registered", depositColumn: "deposit_amount"},
 		{table: "stake_deregistration", action: "deregistered"},
-		{table: "stake_registration", action: "registered"},
-		{table: "stake_registration_delegation", action: "registered"},
-		{table: "stake_vote_registration_delegation", action: "registered"},
-		{table: "vote_registration_delegation", action: "registered"},
+		{table: "stake_registration", action: "registered", depositColumn: "deposit_amount"},
+		{table: "stake_registration_delegation", action: "registered", depositColumn: "deposit_amount"},
+		{table: "stake_vote_registration_delegation", action: "registered", depositColumn: "deposit_amount"},
+		{table: "vote_registration_delegation", action: "registered", depositColumn: "deposit_amount"},
 	}
 }
 

--- a/database/plugin/metadata/internal/accountsums/accountsums.go
+++ b/database/plugin/metadata/internal/accountsums/accountsums.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accountsums
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"gorm.io/gorm"
+)
+
+// MIR source pot codes, matching models.MoveInstantaneousRewards.Pot.
+const (
+	mirPotReserves uint = 0
+	mirPotTreasury uint = 1
+)
+
+// QueryAccountSums aggregates the lovelace totals Blockfrost reports on the
+// account endpoint that are not derivable from the live account row:
+//   - withdrawals_sum: every reward withdrawal recorded for the credential
+//   - reserves_sum / treasury_sum: every MIR distribution to the credential,
+//     split by the source pot
+//
+// All totals are reconstructed from persisted state, so they remain correct
+// across rollbacks (the underlying rows are themselves rollback-aware).
+func QueryAccountSums(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (models.AccountSums, error) {
+	ret := models.AccountSums{}
+	if len(stakingKey) == 0 {
+		return ret, nil
+	}
+
+	withdrawals, err := sumWithdrawals(db, credentialTag, stakingKey)
+	if err != nil {
+		return models.AccountSums{}, err
+	}
+	ret.WithdrawalsSum = withdrawals
+
+	reserves, err := sumMIRByPot(db, mirPotReserves, credentialTag, stakingKey)
+	if err != nil {
+		return models.AccountSums{}, err
+	}
+	ret.ReservesSum = reserves
+
+	treasury, err := sumMIRByPot(db, mirPotTreasury, credentialTag, stakingKey)
+	if err != nil {
+		return models.AccountSums{}, err
+	}
+	ret.TreasurySum = treasury
+
+	return ret, nil
+}
+
+func sumWithdrawals(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (uint64, error) {
+	var total uint64
+	if err := db.Model(&models.AccountRewardDelta{}).
+		Where(
+			"withdrawal = ? AND credential_tag = ? AND staking_key = ?",
+			true,
+			credentialTag,
+			stakingKey,
+		).
+		Select("COALESCE(SUM(amount), 0)").
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf("sum account withdrawals: %w", err)
+	}
+	return total, nil
+}
+
+func sumMIRByPot(
+	db *gorm.DB,
+	pot uint,
+	credentialTag uint8,
+	stakingKey []byte,
+) (uint64, error) {
+	var total uint64
+	if err := db.Model(&models.MoveInstantaneousRewardsReward{}).
+		Joins(
+			"INNER JOIN move_instantaneous_rewards mir"+
+				" ON mir.id = move_instantaneous_rewards_reward.mir_id",
+		).
+		Where(
+			"mir.pot = ?"+
+				" AND move_instantaneous_rewards_reward.credential_tag = ?"+
+				" AND move_instantaneous_rewards_reward.credential = ?",
+			pot,
+			credentialTag,
+			stakingKey,
+		).
+		Select(
+			"COALESCE(SUM(move_instantaneous_rewards_reward.amount), 0)",
+		).
+		Scan(&total).Error; err != nil {
+		return 0, fmt.Errorf("sum account MIR for pot %d: %w", pot, err)
+	}
+	return total, nil
+}

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountsums"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -556,6 +557,28 @@ func (d *MetadataStoreMysql) CountAccountRegistrationHistoryByCredential(
 		)
 	}
 	return count, nil
+}
+
+func (d *MetadataStoreMysql) GetAccountSumsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (models.AccountSums, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"resolve DB for account sums: %w",
+			err,
+		)
+	}
+	sums, err := accountsums.QueryAccountSums(db, credentialTag, stakingKey)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"query account sums: %w",
+			err,
+		)
+	}
+	return sums, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountsums"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -556,6 +557,28 @@ func (d *MetadataStorePostgres) CountAccountRegistrationHistoryByCredential(
 		)
 	}
 	return count, nil
+}
+
+func (d *MetadataStorePostgres) GetAccountSumsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (models.AccountSums, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"resolve DB for account sums: %w",
+			err,
+		)
+	}
+	sums, err := accountsums.QueryAccountSums(db, credentialTag, stakingKey)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"query account sums: %w",
+			err,
+		)
+	}
+	return sums, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -208,6 +208,138 @@ func TestAccountHistoryQueriesAreCredentialTagAware(t *testing.T) {
 	assert.Equal(t, 1, scriptRegistrationCount)
 }
 
+// TestAccountHistoryExposesTxSlotBlockHashAndDeposit pins the
+// OpenAPI-0.1.88 enrichment of the delegation and registration history
+// queries: each row must carry the transaction slot, the containing block's
+// hash (the adapter resolves the height from the block store), and (for
+// registrations) the deposit recorded on the certificate.
+func TestAccountHistoryExposesTxSlotBlockHashAndDeposit(t *testing.T) {
+	store := setupTestStore(t)
+	db := store.DB()
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xA2
+	}
+	pool := make([]byte, 28)
+	for i := range pool {
+		pool[i] = 0xB2
+	}
+	blockHash := []byte("block_hash_for_account_history12")
+
+	require.NoError(t, db.Create(&models.Transaction{
+		ID:         100,
+		Hash:       []byte("tx_enriched_history_hash_1234567"),
+		BlockHash:  blockHash,
+		Slot:       10,
+		BlockIndex: 0,
+	}).Error)
+	require.NoError(t, db.Create(&models.Certificate{
+		ID:            1000,
+		TransactionID: 100,
+		CertIndex:     0,
+		Slot:          10,
+		CertType:      11, // StakeRegistrationDelegation
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeRegistrationDelegation{
+		ID:            1000,
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		PoolKeyHash:   pool,
+		CertificateID: 1000,
+		AddedSlot:     10,
+		DepositAmount: 2_000_000,
+	}).Error)
+
+	delegations, err := store.GetAccountDelegationHistoryByCredential(
+		0, stakeKey, 10, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, delegations, 1)
+	assert.Equal(t, uint64(10), delegations[0].TxSlot)
+	assert.Equal(t, blockHash, delegations[0].BlockHash)
+
+	registrations, err := store.GetAccountRegistrationHistoryByCredential(
+		0, stakeKey, 10, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, registrations, 1)
+	assert.Equal(t, "registered", registrations[0].Action)
+	assert.Equal(t, uint64(2_000_000), registrations[0].Deposit)
+	assert.Equal(t, uint64(10), registrations[0].TxSlot)
+	assert.Equal(t, blockHash, registrations[0].BlockHash)
+}
+
+// TestGetAccountSumsByCredential verifies the account-sum aggregation that
+// backs the Blockfrost account withdrawals_sum/reserves_sum/treasury_sum
+// fields: withdrawals come from rollback-aware reward deltas, while the
+// reserves and treasury totals come from MIR distributions split by source
+// pot. Credits (non-withdrawal deltas) and the other credential tag must be
+// excluded.
+func TestGetAccountSumsByCredential(t *testing.T) {
+	store := setupTestStore(t)
+	db := store.DB()
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xA3
+	}
+	otherKey := make([]byte, 28)
+	for i := range otherKey {
+		otherKey[i] = 0xF3
+	}
+
+	// Two withdrawals (summed) plus a credit (ignored) for the credential.
+	require.NoError(t, db.Create(&models.AccountRewardDelta{
+		StakingKey: stakeKey, CredentialTag: 0,
+		TxHash: []byte("withdrawal_tx_hash_aaaaaaaaaaaa1"),
+		Amount: 30, Withdrawal: true, AddedSlot: 10,
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountRewardDelta{
+		StakingKey: stakeKey, CredentialTag: 0,
+		TxHash: []byte("withdrawal_tx_hash_aaaaaaaaaaaa2"),
+		Amount: 15, Withdrawal: true, AddedSlot: 20,
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountRewardDelta{
+		StakingKey: stakeKey, CredentialTag: 0,
+		TxHash: []byte("credit_tx_hash_bbbbbbbbbbbbbbbb1"),
+		Amount: 99, Withdrawal: false, AddedSlot: 30,
+	}).Error)
+	// A withdrawal for a different credential must not leak in.
+	require.NoError(t, db.Create(&models.AccountRewardDelta{
+		StakingKey: otherKey, CredentialTag: 0,
+		TxHash: []byte("withdrawal_tx_hash_ccccccccccc01"),
+		Amount: 100, Withdrawal: true, AddedSlot: 40,
+	}).Error)
+
+	// MIR distributions: pot 0 = reserves, pot 1 = treasury.
+	reservesMIR := &models.MoveInstantaneousRewards{ID: 1, Pot: 0, AddedSlot: 10}
+	require.NoError(t, db.Create(reservesMIR).Error)
+	treasuryMIR := &models.MoveInstantaneousRewards{ID: 2, Pot: 1, AddedSlot: 10}
+	require.NoError(t, db.Create(treasuryMIR).Error)
+	require.NoError(t, db.Create(&models.MoveInstantaneousRewardsReward{
+		MIRID: 1, Credential: stakeKey, CredentialTag: 0, Amount: 6,
+	}).Error)
+	require.NoError(t, db.Create(&models.MoveInstantaneousRewardsReward{
+		MIRID: 2, Credential: stakeKey, CredentialTag: 0, Amount: 7,
+	}).Error)
+	// Treasury MIR for a different credential must not leak in.
+	require.NoError(t, db.Create(&models.MoveInstantaneousRewardsReward{
+		MIRID: 2, Credential: otherKey, CredentialTag: 0, Amount: 50,
+	}).Error)
+
+	sums, err := store.GetAccountSumsByCredential(0, stakeKey, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(45), sums.WithdrawalsSum)
+	assert.Equal(t, uint64(6), sums.ReservesSum)
+	assert.Equal(t, uint64(7), sums.TreasurySum)
+
+	// An unknown credential returns zeroed sums, not an error.
+	empty, err := store.GetAccountSumsByCredential(1, stakeKey, nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.AccountSums{}, empty)
+}
+
 // TestGetStakeRegistrationsByCredentialIsTagAware verifies that certificate
 // reconstruction keeps key and script stake registrations with the same hash
 // separate and restores the correct on-chain credential type.

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountsums"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -610,6 +611,28 @@ func (d *MetadataStoreSqlite) CountAccountRegistrationHistoryByCredential(
 		)
 	}
 	return count, nil
+}
+
+func (d *MetadataStoreSqlite) GetAccountSumsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (models.AccountSums, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"resolve read DB for account sums: %w",
+			err,
+		)
+	}
+	sums, err := accountsums.QueryAccountSums(db, credentialTag, stakingKey)
+	if err != nil {
+		return models.AccountSums{}, fmt.Errorf(
+			"query account sums: %w",
+			err,
+		)
+	}
+	return sums, nil
 }
 
 // GetTransactionsByMetadataLabel returns transactions containing a metadata

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -538,6 +538,14 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
+	// GetAccountSumsByCredential retrieves the aggregated withdrawal, reserves,
+	// and treasury lovelace totals for a stake credential tag/hash pair.
+	GetAccountSumsByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		types.Txn,
+	) (models.AccountSums, error)
+
 	// GetTransactionsByMetadataLabel retrieves transactions that include
 	// metadata for the given label.
 	GetTransactionsByMetadataLabel(


### PR DESCRIPTION
Closes #2483 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Blockfrost stake-account endpoints with OpenAPI 0.1.88. Fixes active vs registered semantics, adds DRep info, enriches history with slot/time/height and deposits, and computes sums from rollback-safe data.

- **Bug Fixes**
  - Account: active now reflects current delegation; added registered and drep_id. Populates withdrawals_sum, reserves_sum, and treasury_sum via `GetAccountSumsByCredential` from persisted withdrawals and MIR.
  - History: delegation and registration rows include tx_slot, block_time, and block_height (height via block store; time from slot). Registration rows include deposit/refund.
  - Database: added `GetAccountSumsByCredential`; history queries now select tx_slot and block_hash. MIR rewards are attributed by (credential_tag, credential). Implemented for SQLite, Postgres, and MySQL.
  - Tests/Docs: compatibility tests pin OpenAPI 0.1.88 field sets; expanded DATABASE.md; SQLite tests cover tx_slot/block_hash/deposit and account sums.

<sup>Written for commit c2fc7198270ecc4267464cde651aa550c1e7987f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer account details, including governance registration status and DRep information.
  * Account history now includes slot, block hash, block time, and registration deposit/refund amounts.
  * Added account balance summaries for withdrawals, reserves, and treasury totals.

* **Bug Fixes**
  * Improved account “active” status handling to better reflect delegation state.
  * History and account responses now align more closely with expected API schemas and returned fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->