### PR TITLE
fix: peergov plateau

### DIFF
--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -231,52 +231,57 @@ func (n *Node) processChainsyncRecyclerTick(
 					}
 					if !reconciledByLedger {
 						// The local reconcile found nothing to repair (or
-						// failed). Recycling the upstream peer only helps
-						// when there is a spare eligible peer to fail over
-						// to: closing the only upstream forces a reconnect
-						// to the same remote on a fresh source port, which
-						// cannot recover a locally-pinned tip and amplifies
-						// disruption when the remote RSTs the reconnect.
-						// Mirrors the stalled-recycle guard below.
-						if eligibleCount <= 1 {
-							n.config.logger.Warn(
-								"local tip plateau detected but no spare eligible peer, skipping peer recycle",
-								"connection_id", connKey,
-								"local_tip_slot", localTipSlot,
-								"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
-								"plateau_duration", now.Sub(*lastProgressAt),
-								"eligible_peer_count", eligibleCount,
-							)
-							// Throttle the warning to plateau cadence
-							// instead of every tick.
-							*lastProgressAt = now
-						} else {
-							n.config.logger.Warn(
-								"local tip plateau detected, resyncing chainsync client",
-								"connection_id", connKey,
-								"local_tip_slot", localTipSlot,
-								"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
-								"plateau_duration", now.Sub(*lastProgressAt),
-							)
-							n.eventBus.Publish(
+						// failed), so the stall is in the upstream chainsync
+						// stream itself: the active peer's server-side cursor
+						// has stopped advancing (a flaky/stalled relay) while
+						// chain selection still tracks it AT a higher tip.
+						//
+						// A plateau resync is NOT a peer recycle. Recycling
+						// (the stalled path below) drops the peer and fails
+						// over to a SPARE, so it genuinely needs a spare and
+						// is suppressed at eligibleCount <= 1. A plateau
+						// resync instead closes the connection so peer
+						// governance reconnects to the SAME remote and
+						// re-enters FindIntersect with fresh intersect points
+						// anchored at the current local tip (see
+						// chainsyncResyncRequiresFreshConnection). That is
+						// exactly the recovery a single-peer plateau needs:
+						// it restarts header delivery from local-tip+1 on the
+						// only upstream we have. The plateau predicate
+						// (peer ahead AND no local progress for the full
+						// plateau threshold) plus the recycle cooldown gate
+						// this so a healthy single peer is never churned.
+						n.config.logger.Warn(
+							"local tip plateau detected, resyncing chainsync client",
+							"connection_id", connKey,
+							"local_tip_slot", localTipSlot,
+							"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+							"plateau_duration", now.Sub(*lastProgressAt),
+							"eligible_peer_count", eligibleCount,
+						)
+						n.eventBus.Publish(
+							event.ChainsyncResyncEventType,
+							event.NewEvent(
 								event.ChainsyncResyncEventType,
-								event.NewEvent(
-									event.ChainsyncResyncEventType,
-									event.ChainsyncResyncEvent{
-										ConnectionId: *targetConn,
-										Reason:       event.ChainsyncResyncReasonLocalTipPlateau,
-									},
-								),
-							)
+								event.ChainsyncResyncEvent{
+									ConnectionId: *targetConn,
+									Reason:       event.ChainsyncResyncReasonLocalTipPlateau,
+								},
+							),
+						)
+						// Realign only matters when there are spare peers
+						// whose cursors raced ahead while the active peer was
+						// stuck; with a single eligible peer it is a no-op.
+						if eligibleCount > 1 {
 							n.realignOtherPeersAfterPlateau(
 								*targetConn,
 								trackedClients,
 								localTipSlot,
 							)
-							delete(recycleAt, connKey)
-							lastRecycled[connKey] = now
-							*lastProgressAt = now
 						}
+						delete(recycleAt, connKey)
+						lastRecycled[connKey] = now
+						*lastProgressAt = now
 					}
 				}
 			}

--- a/node_test.go
+++ b/node_test.go
@@ -424,7 +424,15 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 	}
 }
 
-func TestProcessChainsyncRecyclerTickSkipsPlateauOnlyPeer(
+// TestProcessChainsyncRecyclerTickResyncsPlateauOnlyPeer verifies the
+// single-eligible-peer plateau recovery. A flaky/stalled relay that has
+// stopped advancing the local tip (while chain selection still tracks it at
+// a higher tip) must not wedge the node permanently. With no spare peer, a
+// peer RECYCLE (drop + failover) is impossible, but a plateau RESYNC -- which
+// closes the connection so peer governance reconnects to the same remote with
+// fresh intersect points -- is still the right recovery and must be attempted,
+// not skipped.
+func TestProcessChainsyncRecyclerTickResyncsPlateauOnlyPeer(
 	t *testing.T,
 ) {
 	bus := event.NewEventBus(nil, nil)
@@ -485,23 +493,122 @@ func TestProcessChainsyncRecyclerTickSkipsPlateauOnlyPeer(
 		2*time.Minute,
 	)
 
-	// No plateau resync event should be emitted when the only
-	// eligible peer would be the disconnect target. Disconnecting
-	// a single-relay BP's only upstream over a plateau cannot
-	// recover a locally-pinned tip and amplifies disruption.
+	// A plateau resync targeting the only eligible peer must be emitted
+	// so the stalled connection is closed and re-established from the
+	// current local tip. This is the only recovery path when no spare
+	// eligible peer exists, and is what unwedges a single-relay node.
+	select {
+	case evt := <-resyncCh:
+		resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
+		require.True(t, ok)
+		assert.Equal(t, connId, resyncEvt.ConnectionId)
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonLocalTipPlateau,
+			resyncEvt.Reason,
+		)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal(
+			"expected plateau resync event for the only eligible peer",
+		)
+	}
+
+	// The plateau clock and recycle cooldown must be updated so the resync
+	// is gated to the cooldown cadence and a healthy single peer is never
+	// churned every tick.
+	assert.True(
+		t,
+		lastProgressAt.After(originalProgress),
+		"lastProgressAt should be reset after plateau resync",
+	)
+	_, recorded := lastRecycled[connId.String()]
+	assert.True(
+		t,
+		recorded,
+		"plateau resync should record a cooldown timestamp",
+	)
+}
+
+// TestProcessChainsyncRecyclerTickPlateauOnlyPeerRespectsCooldown verifies that
+// after a single-peer plateau resync fires, a second tick within the recycle
+// cooldown does NOT fire another resync. This keeps a flaky single peer being
+// retried at the cooldown cadence (forward progress without churn) rather than
+// reconnecting on every stall-check tick.
+func TestProcessChainsyncRecyclerTickPlateauOnlyPeerRespectsCooldown(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(
+		event.ChainsyncResyncEventType,
+	)
+
+	connId := newNodeTestConnId(7)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Hour,
+		},
+	)
+	require.True(t, state.AddClientConnId(connId))
+	state.SetClientConnId(connId)
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 120, Hash: []byte("best")},
+		BlockNumber: 60,
+	}, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+	}
+
+	cfg := chainsync.Config{
+		MaxClients:   1,
+		StallTimeout: time.Hour,
+	}
+	lastProgressSlot := uint64(100)
+	recycleAt := make(map[string]time.Time)
+	lastRecycled := make(map[string]time.Time)
+
+	// First tick: plateau detected, resync fires and records cooldown.
+	now := time.Now()
+	lastProgressAt := now.Add(-5 * time.Minute)
+	n.processChainsyncRecyclerTick(
+		now, 100, cfg, recycleAt, lastRecycled,
+		&lastProgressSlot, &lastProgressAt,
+		4*time.Minute, time.Second, 2*time.Minute,
+	)
+	select {
+	case <-resyncCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected first plateau resync event")
+	}
+
+	// Second tick still within cooldown: even though the plateau clock is
+	// pushed back to look stalled again, the cooldown must suppress a new
+	// resync.
+	now2 := now.Add(30 * time.Second)
+	lastProgressAt = now2.Add(-5 * time.Minute)
+	n.processChainsyncRecyclerTick(
+		now2, 100, cfg, recycleAt, lastRecycled,
+		&lastProgressSlot, &lastProgressAt,
+		4*time.Minute, time.Second, 2*time.Minute,
+	)
 	testutil.RequireNoReceive(
 		t,
 		resyncCh,
 		50*time.Millisecond,
-		"plateau action should be suppressed for only eligible peer",
-	)
-
-	// lastProgressAt should be reset so the suppression warning
-	// is throttled to plateau cadence rather than every tick.
-	assert.True(
-		t,
-		lastProgressAt.After(originalProgress),
-		"lastProgressAt should be reset after suppressed plateau",
+		"plateau resync should be suppressed within recycle cooldown",
 	)
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -497,21 +497,20 @@ func TestProcessChainsyncRecyclerTickResyncsPlateauOnlyPeer(
 	// so the stalled connection is closed and re-established from the
 	// current local tip. This is the only recovery path when no spare
 	// eligible peer exists, and is what unwedges a single-relay node.
-	select {
-	case evt := <-resyncCh:
-		resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
-		require.True(t, ok)
-		assert.Equal(t, connId, resyncEvt.ConnectionId)
-		assert.Equal(
-			t,
-			event.ChainsyncResyncReasonLocalTipPlateau,
-			resyncEvt.Reason,
-		)
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal(
-			"expected plateau resync event for the only eligible peer",
-		)
-	}
+	evt := testutil.RequireReceive(
+		t,
+		resyncCh,
+		200*time.Millisecond,
+		"plateau resync event for the only eligible peer",
+	)
+	resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
+	require.True(t, ok)
+	assert.Equal(t, connId, resyncEvt.ConnectionId)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonLocalTipPlateau,
+		resyncEvt.Reason,
+	)
 
 	// The plateau clock and recycle cooldown must be updated so the resync
 	// is gated to the cooldown cadence and a healthy single peer is never
@@ -588,11 +587,20 @@ func TestProcessChainsyncRecyclerTickPlateauOnlyPeerRespectsCooldown(
 		&lastProgressSlot, &lastProgressAt,
 		4*time.Minute, time.Second, 2*time.Minute,
 	)
-	select {
-	case <-resyncCh:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("expected first plateau resync event")
-	}
+	evt := testutil.RequireReceive(
+		t,
+		resyncCh,
+		200*time.Millisecond,
+		"first plateau resync event",
+	)
+	resyncEvt, ok := evt.Data.(event.ChainsyncResyncEvent)
+	require.True(t, ok)
+	assert.Equal(t, connId, resyncEvt.ConnectionId)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonLocalTipPlateau,
+		resyncEvt.Reason,
+	)
 
 	// Second tick still within cooldown: even though the plateau clock is
 	// pushed back to look stalled again, the cooldown must suppress a new


### PR DESCRIPTION
Closes #2619 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix plateau handling in chainsync peer governance. We now resync the active peer on a local-tip stall even when it's the only eligible peer, unwedging single-peer nodes while honoring cooldowns.

- **Bug Fixes**
  - Emit `event.ChainsyncResyncEventType` with `event.ChainsyncResyncReasonLocalTipPlateau` even when `eligibleCount <= 1`; reconnects to the same remote and restarts from the current local tip.
  - Respect recycle cooldown and reset the plateau clock to avoid churn; update `lastRecycled`, `lastProgressAt`, and clear `recycleAt`.
  - Only call `realignOtherPeersAfterPlateau` when there are spare peers (`eligibleCount > 1`).
  - Added tests to assert single-peer plateau resync and cooldown suppression, using `testutil` helpers.

<sup>Written for commit 4f4d62425c9747f7e2c6761633b6d9c50ab3f12b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when the local tip stalls, ensuring a resync is triggered instead of being skipped in single-peer scenarios.
  * Kept plateau recovery on cooldown so repeated recovery attempts don’t fire too quickly.
  * Updated peer handling so recovery still runs consistently, while additional peer realignment only happens when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->