### PR TITLE
fix: pool-stake snapshot index

### DIFF
--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -64,8 +64,6 @@ type drepCertCache struct {
 	hasUpdate map[string]bool
 }
 
-const utxoStakingLiveAmountIndex = "idx_utxo_staking_deleted_amount"
-
 const getDRepVotingPowerBatchSQL = `
 	SELECT a.drep AS drep, a.drep_type AS credential_tag,
 		   COALESCE(SUM(

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1167,9 +1167,16 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 		chunk := poolKeyHashes[start:end]
 
 		var chunkResults []poolStakeResult
+		// INDEXED BY idx_utxo_staking_deleted_amount forces the account-driven
+		// join: probe the live-UTxO index per delegating account rather than
+		// scanning the entire live UTxO set (deleted_slot=0) and joining back
+		// to account. Without the hint SQLite's planner drives from the utxo
+		// side, which turns this snapshot-time aggregation into a full-table
+		// scan of millions of rows and stalls the epoch stake-distribution
+		// calculation for many minutes. Mirrors the DRep voting-power query.
 		if err := db.Table("account").
 			Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
-			Joins("INNER JOIN utxo ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
+			Joins("INNER JOIN utxo INDEXED BY idx_utxo_staking_deleted_amount ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 			Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", chunk, true).
 			Group("account.pool").
 			Scan(&chunkResults).Error; err != nil {

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1167,7 +1167,7 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 		chunk := poolKeyHashes[start:end]
 
 		var chunkResults []poolStakeResult
-		// INDEXED BY idx_utxo_staking_deleted_amount forces the account-driven
+		// The utxoStakingLiveAmountIndex hint forces the account-driven
 		// join: probe the live-UTxO index per delegating account rather than
 		// scanning the entire live UTxO set (deleted_slot=0) and joining back
 		// to account. Without the hint SQLite's planner drives from the utxo
@@ -1176,7 +1176,7 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 		// calculation for many minutes. Mirrors the DRep voting-power query.
 		if err := db.Table("account").
 			Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
-			Joins("INNER JOIN utxo INDEXED BY idx_utxo_staking_deleted_amount ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
+			Joins("INNER JOIN utxo INDEXED BY "+utxoStakingLiveAmountIndex+" ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 			Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", chunk, true).
 			Group("account.pool").
 			Scan(&chunkResults).Error; err != nil {

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm"
 )
 
 func setupStakeSnapshotTestStore(t *testing.T) *MetadataStoreSqlite {
@@ -708,6 +710,53 @@ func TestGetStakeByPoolsAggregatesUtxos(t *testing.T) {
 		"pool A should have 2 delegators")
 	require.Equal(t, uint64(1), delegators[string(poolB)],
 		"pool B should have 1 delegator")
+}
+
+func TestGetStakeByPoolsUsesStakeCredentialUtxoIndex(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	poolA := []byte("pool_index_plan_123456789012")
+
+	var capturedSQL string
+	var capturedVars []any
+	callbackName := "test:capture_get_stake_by_pools_sql"
+	require.NoError(t, store.ReadDB().Callback().Row().
+		After("gorm:row").
+		Register(callbackName, func(tx *gorm.DB) {
+			sql := tx.Statement.SQL.String()
+			if capturedSQL != "" ||
+				!strings.Contains(sql, "INDEXED BY "+utxoStakingLiveAmountIndex) {
+				return
+			}
+			capturedSQL = sql
+			capturedVars = append([]any(nil), tx.Statement.Vars...)
+		}))
+
+	_, _, err := store.GetStakeByPools([][]byte{poolA}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedSQL)
+
+	planRows, err := store.DB().
+		Raw(
+			"EXPLAIN QUERY PLAN "+capturedSQL,
+			capturedVars...,
+		).Rows()
+	require.NoError(t, err)
+	defer planRows.Close()
+
+	var details []string
+	for planRows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, planRows.Err())
+	plan := strings.Join(details, "\n")
+	assert.Contains(t, plan, utxoStakingLiveAmountIndex)
+	assert.NotContains(t, plan, "idx_utxo_deleted_staking_amount")
 }
 
 // TestGetStakeByPoolsExcludesInactiveAccounts tests that inactive accounts

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -88,12 +88,15 @@ func (d *MetadataStoreSqlite) GetUtxoIncludingSpent(
 	return ret, nil
 }
 
-// batchChunkSize is the maximum number of UTXO refs to query in a single SQL statement.
-// Each ref uses 2 bind parameters (tx_id and output_idx), so this must be <= 499 to stay
-// under SQLite's default SQLITE_MAX_VARIABLE_NUMBER limit of 999 bind parameters.
-const batchChunkSize = 499
+const (
+	// batchChunkSize is the maximum number of UTXO refs to query in a single SQL statement.
+	// Each ref uses 2 bind parameters (tx_id and output_idx), so this must be <= 499 to stay
+	// under SQLite's default SQLITE_MAX_VARIABLE_NUMBER limit of 999 bind parameters.
+	batchChunkSize = 499
 
-const utxoRefLookupIndex = "tx_id_output_idx"
+	utxoRefLookupIndex         = "tx_id_output_idx"
+	utxoStakingLiveAmountIndex = "idx_utxo_staking_deleted_amount"
+)
 
 func utxoRefIndexedTable() string {
 	return (&models.Utxo{}).TableName() + " INDEXED BY " + utxoRefLookupIndex


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force the stake-by-pool snapshot to use the `idx_utxo_staking_deleted_amount` index by adding `INDEXED BY` on the `utxo` join (via the shared `utxoStakingLiveAmountIndex` const). Add a test that asserts the query plan uses this index, preventing live UTxO scans and speeding up epoch stake distribution.

<sup>Written for commit d4df386a3463e67521aa1b5dc8ebf5684d9fc651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

