### PR TITLE
fix(database): genesis utxo fk

### DIFF
--- a/database/inflight_provenance_test.go
+++ b/database/inflight_provenance_test.go
@@ -77,7 +77,7 @@ func TestSetTransactionBatched_SameBatchProducerSpentViaInFlight(t *testing.T) {
 		"same-batch produced output must be created at flush",
 	)
 	require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
-	require.Equal(t, candidate.consumerTx.Hash().Bytes(), utxo.SpentAtTxId)
+	require.Equal(t, candidate.consumerTx.Hash().Bytes(), []byte(utxo.SpentAtTxId))
 }
 
 // TestSetTransactionBatched_CrossBatchProducerResolvesFromDB flushes the
@@ -149,7 +149,7 @@ func TestSetTransactionBatched_CrossBatchProducerResolvesFromDB(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, post)
 	require.Equal(t, candidate.consumerPoint.Slot, post.DeletedSlot)
-	require.Equal(t, candidate.consumerTx.Hash().Bytes(), post.SpentAtTxId)
+	require.Equal(t, candidate.consumerTx.Hash().Bytes(), []byte(post.SpentAtTxId))
 }
 
 // TestSetTransactionBatched_MissingProducerNotFabricated ingests only the
@@ -281,7 +281,7 @@ func TestSetTransactionBatched_InFlightDoesNotSkipExistingRowRepair(
 	require.Equal(
 		t,
 		candidate.consumerTx.Hash().Bytes(),
-		post.SpentAtTxId,
+		[]byte(post.SpentAtTxId),
 		"spender link must be backfilled for a pre-existing same-slot row",
 	)
 }

--- a/database/mithril_gap_test.go
+++ b/database/mithril_gap_test.go
@@ -116,7 +116,7 @@ func TestSetGapBlockTransactionRestoresConsumedInputsOnRollback(
 		require.Equal(
 			t,
 			candidate.consumerTx.Hash().Bytes(),
-			utxo.SpentAtTxId,
+			[]byte(utxo.SpentAtTxId),
 		)
 	}
 
@@ -205,7 +205,7 @@ func TestSetTransactionRecoversMissingConsumedInputsFromBlob(
 		require.Equal(
 			t,
 			candidate.consumerTx.Hash().Bytes(),
-			utxo.SpentAtTxId,
+			[]byte(utxo.SpentAtTxId),
 		)
 	}
 }
@@ -274,7 +274,7 @@ func TestSetTransactionBatchedSpendsPreviousBlockOutputInSameBatch(
 	require.NoError(t, err)
 	require.NotNil(t, utxo)
 	require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
-	require.Equal(t, candidate.consumerTx.Hash().Bytes(), utxo.SpentAtTxId)
+	require.Equal(t, candidate.consumerTx.Hash().Bytes(), []byte(utxo.SpentAtTxId))
 }
 
 func findGapRollbackCandidate(t *testing.T) gapRollbackCandidate {
@@ -949,7 +949,7 @@ func TestSetGapBlockTransactionSpendsLiveProducedInputs(t *testing.T) {
 		require.Equal(
 			t,
 			spenderTxHash,
-			utxo.SpentAtTxId,
+			[]byte(utxo.SpentAtTxId),
 			"input %s spent_at_tx_id not set to consumer tx hash",
 			input.String(),
 		)

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -77,25 +77,30 @@ func AppendUtxoAddressOrBranch(
 
 // Utxo represents an unspent transaction output
 type Utxo struct {
-	TransactionID           *uint        `gorm:"index"`
-	CollateralReturnForTxID *uint        `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
-	TxId                    []byte       `gorm:"uniqueIndex:tx_id_output_idx;size:32"`
-	PaymentKey              []byte       `gorm:"index;size:28"`
-	StakingKey              []byte       `gorm:"index;size:28;index:idx_utxo_deleted_staking_amount,priority:3;index:idx_utxo_staking_deleted_amount,priority:2"`
-	CredentialTag           uint8        `gorm:"not null;default:0;index:idx_utxo_deleted_staking_amount,priority:2;index:idx_utxo_staking_deleted_amount,priority:1"`
-	Assets                  []Asset      `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
-	Cbor                    []byte       `gorm:"-"`       // This is here for convenience but not represented in the metadata DB
-	DatumHash               []byte       `gorm:"size:32"` // Optional datum hash (32 bytes)
-	Datum                   []byte       `gorm:"-"`       // Inline datum CBOR, not stored in metadata DB
-	ScriptRef               []byte       `gorm:"-"`       // Reference script bytes, not stored in metadata DB
-	SpentAtTxId             []byte       `gorm:"index;size:32"`
-	ReferencedByTxId        []byte       `gorm:"index;size:32"`
-	CollateralByTxId        []byte       `gorm:"index;size:32"`
-	ID                      uint         `gorm:"primarykey"`
-	AddedSlot               uint64       `gorm:"index"`
-	DeletedSlot             uint64       `gorm:"index:idx_utxo_deleted_staking_amount,priority:1;index:idx_utxo_staking_deleted_amount,priority:3;index:idx_utxo_deleted_payment_script,priority:1"`
-	Amount                  types.Uint64 `gorm:"index:idx_utxo_deleted_staking_amount,priority:4;index:idx_utxo_staking_deleted_amount,priority:4;index:idx_utxo_deleted_payment_script,priority:3"`
-	OutputIdx               uint32       `gorm:"uniqueIndex:tx_id_output_idx"`
+	TransactionID           *uint   `gorm:"index"`
+	CollateralReturnForTxID *uint   `gorm:"uniqueIndex"` // Unique: a transaction has at most one collateral return output
+	TxId                    []byte  `gorm:"uniqueIndex:tx_id_output_idx;size:32"`
+	PaymentKey              []byte  `gorm:"index;size:28"`
+	StakingKey              []byte  `gorm:"index;size:28;index:idx_utxo_deleted_staking_amount,priority:3;index:idx_utxo_staking_deleted_amount,priority:2"`
+	CredentialTag           uint8   `gorm:"not null;default:0;index:idx_utxo_deleted_staking_amount,priority:2;index:idx_utxo_staking_deleted_amount,priority:1"`
+	Assets                  []Asset `gorm:"foreignKey:UtxoID;constraint:OnDelete:CASCADE"`
+	Cbor                    []byte  `gorm:"-"`       // This is here for convenience but not represented in the metadata DB
+	DatumHash               []byte  `gorm:"size:32"` // Optional datum hash (32 bytes)
+	Datum                   []byte  `gorm:"-"`       // Inline datum CBOR, not stored in metadata DB
+	ScriptRef               []byte  `gorm:"-"`       // Reference script bytes, not stored in metadata DB
+	// SpentAtTxId, ReferencedByTxId, and CollateralByTxId are nullable FKs to
+	// transaction(hash); they are unset until a UTxO is spent/referenced.
+	// They use types.NullableHash so an empty value serializes to SQL NULL
+	// (not an empty blob), which is required for the FK to be skipped — see
+	// the type docs for the FOREIGN KEY constraint failed (787) issue.
+	SpentAtTxId      types.NullableHash `gorm:"index;size:32"`
+	ReferencedByTxId types.NullableHash `gorm:"index;size:32"`
+	CollateralByTxId types.NullableHash `gorm:"index;size:32"`
+	ID               uint               `gorm:"primarykey"`
+	AddedSlot        uint64             `gorm:"index"`
+	DeletedSlot      uint64             `gorm:"index:idx_utxo_deleted_staking_amount,priority:1;index:idx_utxo_staking_deleted_amount,priority:3;index:idx_utxo_deleted_payment_script,priority:1"`
+	Amount           types.Uint64       `gorm:"index:idx_utxo_deleted_staking_amount,priority:4;index:idx_utxo_staking_deleted_amount,priority:4;index:idx_utxo_deleted_payment_script,priority:3"`
+	OutputIdx        uint32             `gorm:"uniqueIndex:tx_id_output_idx"`
 	// PaymentScript is true when the output's payment credential is a
 	// script hash (as opposed to a key hash). It is derived from the
 	// address type at index time and used to compute the network's

--- a/database/plugin/metadata/sqlite/batch_accumulator_test.go
+++ b/database/plugin/metadata/sqlite/batch_accumulator_test.go
@@ -297,7 +297,7 @@ func TestFlushBatch_UtxoOutputsAndSpends(t *testing.T) {
 	assert.Equal(t, uint64(0), outputs[0].DeletedSlot)
 	assert.Empty(t, outputs[0].SpentAtTxId)
 	assert.Equal(t, uint64(120), outputs[1].DeletedSlot)
-	assert.Equal(t, spentBy, outputs[1].SpentAtTxId)
+	assert.Equal(t, spentBy, []byte(outputs[1].SpentAtTxId))
 }
 
 func TestFlushBatch_MultipleSpends(t *testing.T) {
@@ -363,9 +363,9 @@ func TestFlushBatch_MultipleSpends(t *testing.T) {
 
 	// Each UTxO must carry its own slot and spentBy — wrong if args were interleaved.
 	assert.Equal(t, uint64(200), u1.DeletedSlot)
-	assert.Equal(t, spentBy1, u1.SpentAtTxId)
+	assert.Equal(t, spentBy1, []byte(u1.SpentAtTxId))
 	assert.Equal(t, uint64(201), u2.DeletedSlot)
-	assert.Equal(t, spentBy2, u2.SpentAtTxId)
+	assert.Equal(t, spentBy2, []byte(u2.SpentAtTxId))
 }
 
 func TestFlushBatch_Idempotent(t *testing.T) {

--- a/database/plugin/metadata/sqlite/bulk_sql.go
+++ b/database/plugin/metadata/sqlite/bulk_sql.go
@@ -74,6 +74,11 @@ const (
 )
 
 func appendUtxoRow(dst []any, u *models.Utxo) []any {
+	// SpentAtTxId/ReferencedByTxId/CollateralByTxId are types.NullableHash,
+	// whose driver.Valuer binds an empty value as SQL NULL (not an empty
+	// blob), so the FK to transaction(hash) is correctly skipped for unspent/
+	// unreferenced UTxOs. database/sql invokes the Valuer on these positional
+	// args, so no normalization is needed here.
 	return append(dst,
 		u.TransactionID, u.CollateralReturnForTxID, u.TxId,
 		u.PaymentKey, u.StakingKey, u.CredentialTag, u.DatumHash,

--- a/database/plugin/metadata/sqlite/bulk_sql_test.go
+++ b/database/plugin/metadata/sqlite/bulk_sql_test.go
@@ -241,7 +241,7 @@ func TestBatchSpendUtxos_GuardSkipsAlreadySpent(t *testing.T) {
 		Where("tx_id = ? AND output_idx = ?", txid, uint32(0)).
 		First(&got).Error)
 	assert.Equal(t, uint64(100), got.DeletedSlot)
-	assert.Equal(t, spender1, got.SpentAtTxId)
+	assert.Equal(t, spender1, []byte(got.SpentAtTxId))
 }
 
 func newBenchStore(b *testing.B) *MetadataStoreSqlite {

--- a/database/plugin/metadata/sqlite/genesis_transaction_test.go
+++ b/database/plugin/metadata/sqlite/genesis_transaction_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// setupFileTestStore creates a file-backed sqlite store. The file-based
+// configuration is what genesis sync uses in production: it enables
+// foreign_keys(1) and uses WAL with separate read/write pools. FK enforcement
+// is what surfaces the genesis UTxO bug.
+func setupFileTestStore(t *testing.T) *MetadataStoreSqlite {
+	t.Helper()
+	store, err := New(t.TempDir(), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, store.Start())
+	require.NoError(t, store.DB().AutoMigrate(models.MigrateModels...))
+	t.Cleanup(func() {
+		store.Close() //nolint:errcheck
+	})
+	return store
+}
+
+// genesisOutputs builds n unspent genesis UTxO models. The hash-referencing FK
+// columns (SpentAtTxId, ReferencedByTxId, CollateralByTxId) are set to
+// zero-length, non-nil slices on purpose: this is the state that would trigger
+// the FK failure if the column did not serialize empty -> SQL NULL. The
+// types.NullableHash driver.Valuer must store these as NULL so the FK to
+// transaction(hash) is skipped.
+func genesisOutputs(n int) []models.Utxo {
+	outputs := make([]models.Utxo, n)
+	for i := range outputs {
+		txid := make([]byte, 32)
+		txid[0] = byte(i + 1)
+		outputs[i] = models.Utxo{
+			TxId:             txid,
+			OutputIdx:        0,
+			AddedSlot:        0,
+			Amount:           1_000_000,
+			SpentAtTxId:      types.NullableHash{},
+			ReferencedByTxId: types.NullableHash{},
+			CollateralByTxId: types.NullableHash{},
+		}
+	}
+	return outputs
+}
+
+// TestSqliteSetGenesisTransactionWithinTxn reproduces the genesis sync FK
+// failure: the genesis transaction row and its UTxOs are written inside a
+// single explicit transaction (as ledger.createGenesisBlock does). Genesis
+// UTxOs are unspent/unreferenced, so the nullable hash FK columns must be
+// stored as NULL; an empty blob fails the FK to transaction(hash) with error
+// 787. Before the fix this INSERT failed with
+// "create genesis utxos: FOREIGN KEY constraint failed (787)".
+func TestSqliteSetGenesisTransactionWithinTxn(t *testing.T) {
+	t.Parallel()
+	store := setupFileTestStore(t)
+
+	hash := bytes.Repeat([]byte{0xaa}, 32)
+	blockHash := bytes.Repeat([]byte{0xbb}, 32)
+	outputs := genesisOutputs(3)
+
+	txn, err := store.BeginTxn()
+	require.NoError(t, err)
+
+	err = store.SetGenesisTransaction(hash, blockHash, outputs, txn)
+	require.NoError(t, err, "SetGenesisTransaction within txn")
+
+	require.NoError(t, txn.Commit())
+
+	// All outputs should reference the genesis transaction row.
+	var count int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Utxo{}).
+			Where("transaction_id IS NOT NULL").
+			Count(&count).Error,
+	)
+	require.Equal(t, int64(3), count, "all genesis UTxOs link to transaction")
+
+	// The nullable hash FK columns must be stored as NULL, not empty blobs.
+	var emptyFKCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Utxo{}).
+			Where(
+				"spent_at_tx_id IS NOT NULL OR referenced_by_tx_id IS NOT NULL OR collateral_by_tx_id IS NOT NULL",
+			).
+			Count(&emptyFKCount).Error,
+	)
+	require.Equal(
+		t,
+		int64(0),
+		emptyFKCount,
+		"genesis UTxOs must store NULL hash FKs, not empty blobs",
+	)
+}
+
+// TestSqliteSetGenesisTransactionIdempotent verifies re-running genesis init
+// does not error or duplicate rows.
+func TestSqliteSetGenesisTransactionIdempotent(t *testing.T) {
+	t.Parallel()
+	store := setupFileTestStore(t)
+
+	hash := bytes.Repeat([]byte{0xaa}, 32)
+	blockHash := bytes.Repeat([]byte{0xbb}, 32)
+
+	run := func() {
+		txn, err := store.BeginTxn()
+		require.NoError(t, err)
+		err = store.SetGenesisTransaction(
+			hash,
+			blockHash,
+			genesisOutputs(3),
+			txn,
+		)
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit())
+	}
+
+	run()
+	run() // re-run must not error or duplicate
+
+	var txCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Transaction{}).Count(&txCount).Error,
+	)
+	require.Equal(t, int64(1), txCount, "exactly one genesis transaction")
+
+	var utxoCount int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Utxo{}).Count(&utxoCount).Error,
+	)
+	require.Equal(t, int64(3), utxoCount, "no duplicate genesis UTxOs")
+}

--- a/database/plugin/metadata/sqlite/rollback_test.go
+++ b/database/plugin/metadata/sqlite/rollback_test.go
@@ -92,7 +92,7 @@ func TestSetUtxoDeletedAtSlotBackfillsSameSlotMissingSpender(t *testing.T) {
 		).First(&updated).Error,
 	)
 	require.Equal(t, uint64(200), updated.DeletedSlot)
-	require.Equal(t, spenderTxHash, updated.SpentAtTxId)
+	require.Equal(t, spenderTxHash, []byte(updated.SpentAtTxId))
 }
 
 func TestSetUtxoDeletedAtSlotReturnsNotFoundWhenRowMissing(

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -125,6 +125,60 @@ func (u *Uint64) Scan(val any) error {
 	}
 }
 
+// NullableHash is a byte slice that serializes to SQL NULL when empty,
+// rather than to an empty blob. It is used for nullable foreign-key columns
+// that reference transaction(hash) (e.g. utxo.spent_at_tx_id) and are unset
+// until the UTxO is spent/referenced.
+//
+// Without a custom driver.Valuer, an empty/nil []byte can be bound by some
+// GORM + SQLite driver versions as an empty blob instead of SQL NULL. SQLite
+// enforces FK constraints against an empty blob (no transaction has an empty
+// hash), so such a row fails with SQLITE_CONSTRAINT_FOREIGNKEY (787).
+// This affects every UTxO not yet spent/referenced, including all genesis
+// UTxOs. Returning a nil driver.Value guarantees SQL NULL on every driver
+// version, so the FK is correctly skipped.
+//
+//nolint:recvcheck
+type NullableHash []byte
+
+// Value implements driver.Valuer. An empty (or nil) slice serializes to SQL
+// NULL; a non-empty slice serializes to its bytes.
+func (h NullableHash) Value() (driver.Value, error) {
+	if len(h) == 0 {
+		return nil, nil
+	}
+	return []byte(h), nil
+}
+
+// Scan implements sql.Scanner.
+func (h *NullableHash) Scan(val any) error {
+	switch v := val.(type) {
+	case nil:
+		*h = nil
+		return nil
+	case []byte:
+		if len(v) == 0 {
+			*h = nil
+			return nil
+		}
+		// Copy so we do not retain the driver's buffer.
+		*h = append(NullableHash(nil), v...)
+		return nil
+	case string:
+		if v == "" {
+			*h = nil
+			return nil
+		}
+		*h = append(NullableHash(nil), v...)
+		return nil
+	default:
+		return fmt.Errorf(
+			"value was not expected type, wanted []byte/string, got %T",
+			val,
+		)
+	}
+}
+
 // Storage mode constants shared by the metadata plugins.
 const (
 	// StorageModeCore stores only consensus and chain state data.

--- a/database/types/types_test.go
+++ b/database/types/types_test.go
@@ -161,3 +161,90 @@ func TestHistoryExpiredErrorWraps(t *testing.T) {
 		t.Fatalf("extracted = %+v, want slot=42 hash=%x", extracted, hash)
 	}
 }
+
+// TestNullableHashValueEmptyIsNull verifies that an empty (nil or zero-length)
+// NullableHash serializes to SQL NULL, not an empty blob. This is the property
+// that keeps nullable hash FK columns (e.g. utxo.spent_at_tx_id) from failing
+// their FK to transaction(hash) for unspent/unreferenced UTxOs.
+func TestNullableHashValueEmptyIsNull(t *testing.T) {
+	cases := []struct {
+		name string
+		in   types.NullableHash
+	}{
+		{"nil", nil},
+		{"empty", types.NullableHash{}},
+		{"zero-len", types.NullableHash([]byte(""))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := tc.in.Value()
+			if err != nil {
+				t.Fatalf("Value() error: %v", err)
+			}
+			if v != nil {
+				t.Fatalf("Value() = %#v, want nil (SQL NULL)", v)
+			}
+		})
+	}
+}
+
+// TestNullableHashValueNonEmpty verifies a non-empty NullableHash serializes to
+// its bytes.
+func TestNullableHashValueNonEmpty(t *testing.T) {
+	in := types.NullableHash(bytes.Repeat([]byte{0xAB}, 32))
+	v, err := in.Value()
+	if err != nil {
+		t.Fatalf("Value() error: %v", err)
+	}
+	b, ok := v.([]byte)
+	if !ok {
+		t.Fatalf("Value() type = %T, want []byte", v)
+	}
+	if !bytes.Equal(b, in) {
+		t.Fatalf("Value() = %x, want %x", b, in)
+	}
+}
+
+// TestNullableHashScan round-trips NULL, []byte, and string sources.
+func TestNullableHashScan(t *testing.T) {
+	var h types.NullableHash
+
+	if err := h.Scan(nil); err != nil {
+		t.Fatalf("Scan(nil) error: %v", err)
+	}
+	if h != nil {
+		t.Fatalf("Scan(nil) = %#v, want nil", h)
+	}
+
+	if err := h.Scan([]byte{}); err != nil {
+		t.Fatalf("Scan(empty []byte) error: %v", err)
+	}
+	if h != nil {
+		t.Fatalf("Scan(empty []byte) = %#v, want nil", h)
+	}
+
+	want := bytes.Repeat([]byte{0x01}, 32)
+	if err := h.Scan(want); err != nil {
+		t.Fatalf("Scan([]byte) error: %v", err)
+	}
+	if !bytes.Equal(h, want) {
+		t.Fatalf("Scan([]byte) = %x, want %x", h, want)
+	}
+
+	if err := h.Scan("xyz"); err != nil {
+		t.Fatalf("Scan(string) error: %v", err)
+	}
+	if string(h) != "xyz" {
+		t.Fatalf("Scan(string) = %q, want %q", string(h), "xyz")
+	}
+
+	if err := h.Scan(123); err == nil {
+		t.Fatal("Scan(int) should error")
+	}
+}
+
+// Ensure NullableHash implements the driver interfaces.
+var (
+	_ driver.Valuer = types.NullableHash(nil)
+	_ sql.Scanner   = (*types.NullableHash)(nil)
+)

--- a/ledger/genesis_block_fk_test.go
+++ b/ledger/genesis_block_fk_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+)
+
+// TestCreateGenesisBlockFileBackedNoFKError drives the real genesis sync path
+// (createGenesisBlock -> database.SetGenesisTransaction -> UtxoLedgerToModel ->
+// metadata SetGenesisTransaction) on a file-backed SQLite store, where
+// foreign_keys=ON is enforced.
+//
+// Genesis UTxOs are unspent/unreferenced, so the utxo columns spent_at_tx_id /
+// referenced_by_tx_id / collateral_by_tx_id (FKs to transaction(hash)) must be
+// stored as SQL NULL. If they are bound as an empty blob, the FK fails with
+// "FOREIGN KEY constraint failed (787)". This is the failure reported for
+// BURSA_SYNC=genesis on preview/devnet.
+//
+// It also re-runs createGenesisBlock to confirm idempotency.
+func TestCreateGenesisBlockFileBackedNoFKError(t *testing.T) {
+	networks := []struct {
+		name       string
+		configPath string
+	}{
+		{name: "preview", configPath: "preview/config.json"},
+		{name: "devnet", configPath: "devnet/config.json"},
+	}
+
+	for _, nw := range networks {
+		t.Run(nw.name, func(t *testing.T) {
+			// File-backed store: enables foreign_keys(1) + WAL, the
+			// production configuration that matches the reported failure.
+			db, err := database.New(&database.Config{
+				BlobPlugin:     "badger",
+				MetadataPlugin: "sqlite",
+				DataDir:        t.TempDir(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { db.Close() }) //nolint:errcheck
+
+			nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
+				nw.configPath,
+				nw.name,
+				cardano.EmbeddedConfigFS,
+			)
+			require.NoError(t, err)
+
+			ls := &LedgerState{
+				db: db,
+				config: LedgerStateConfig{
+					Database:          db,
+					CardanoNodeConfig: nodeCfg,
+					Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+				},
+			}
+
+			// First run: must not hit the FK 787 error.
+			require.NoError(
+				t,
+				ls.createGenesisBlock(),
+				"createGenesisBlock should not fail with FK constraint",
+			)
+
+			store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+			require.True(t, ok, "metadata store should be sqlite")
+
+			// At least one genesis UTxO should have been created so the
+			// assertions below are meaningful.
+			var utxoCount int64
+			require.NoError(
+				t,
+				store.DB().Model(&models.Utxo{}).Count(&utxoCount).Error,
+			)
+			require.Greater(t, utxoCount, int64(0), "genesis UTxOs created")
+
+			// The hash FK columns must be stored as NULL, never empty blobs.
+			var nonNull int64
+			require.NoError(
+				t,
+				store.DB().Model(&models.Utxo{}).
+					Where("spent_at_tx_id IS NOT NULL OR referenced_by_tx_id IS NOT NULL OR collateral_by_tx_id IS NOT NULL").
+					Count(&nonNull).Error,
+			)
+			require.Equal(
+				t,
+				int64(0),
+				nonNull,
+				"genesis UTxOs must store NULL hash FKs, not empty blobs",
+			)
+
+			// Second run: idempotent, still no error.
+			require.NoError(
+				t,
+				ls.createGenesisBlock(),
+				"re-running createGenesisBlock must remain idempotent",
+			)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a SQLite foreign key failure during genesis sync by storing empty UTxO hash FKs as SQL NULL instead of empty blobs. This unblocks file-backed SQLite initialization and keeps genesis writes idempotent.

- **Bug Fixes**
  - Added `types.NullableHash` to serialize empty values as SQL NULL and scan safely.
  - Updated `models.Utxo` to use `types.NullableHash` for `SpentAtTxId`, `ReferencedByTxId`, and `CollateralByTxId`.
  - Documented bulk insert behavior where `driver.Valuer` ensures NULL binding.
  - Adjusted tests for the new type and added file-backed SQLite tests that reproduce and verify the FK fix and idempotency (`database/plugin/metadata/sqlite/genesis_transaction_test.go`, `ledger/genesis_block_fk_test.go`).

<sup>Written for commit 96d04ad8ba190996bfff7e268ae8260e914686df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

