### PR TITLE
fix(mithril): retry transient TLS failures for v2 immutable archive d…

### DIFF
--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -82,6 +82,11 @@ type BootstrapConfig struct {
 	// DownloadMaxIdleRetries is the number of consecutive idle retries
 	// allowed without additional bytes. Zero uses the downloader default.
 	DownloadMaxIdleRetries int
+	// DownloadMaxTransientRetries is the maximum number of retry attempts
+	// for transient network errors (TLS handshake failures, connection
+	// resets, HTTP 429, HTTP 5xx) per download. Zero uses the downloader
+	// default. Negative disables transient retries.
+	DownloadMaxTransientRetries int
 }
 
 // VerificationMode selects the level of Mithril certificate verification.
@@ -381,14 +386,15 @@ func Bootstrap(
 		for i, loc := range snapshot.Locations {
 			archivePath, dlErr = DownloadSnapshot(
 				ctx, DownloadConfig{
-					URL:            loc,
-					DestDir:        downloadDir,
-					Filename:       archiveFilename,
-					ExpectedSize:   snapshot.Size,
-					Logger:         cfg.Logger,
-					OnProgress:     cfg.OnProgress,
-					IdleTimeout:    cfg.DownloadIdleTimeout,
-					MaxIdleRetries: cfg.DownloadMaxIdleRetries,
+					URL:                 loc,
+					DestDir:             downloadDir,
+					Filename:            archiveFilename,
+					ExpectedSize:        snapshot.Size,
+					Logger:              cfg.Logger,
+					OnProgress:          cfg.OnProgress,
+					IdleTimeout:         cfg.DownloadIdleTimeout,
+					MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
+					MaxTransientRetries: cfg.DownloadMaxTransientRetries,
 				},
 			)
 			if dlErr == nil {
@@ -567,14 +573,15 @@ func downloadAncillary(
 	for i, loc := range snapshot.AncillaryLocations {
 		ancillaryPath, err = DownloadSnapshot(
 			ctx, DownloadConfig{
-				URL:            loc,
-				DestDir:        downloadDir,
-				Filename:       ancillaryFilename,
-				ExpectedSize:   snapshot.AncillarySize,
-				Logger:         cfg.Logger,
-				OnProgress:     cfg.OnProgress,
-				IdleTimeout:    cfg.DownloadIdleTimeout,
-				MaxIdleRetries: cfg.DownloadMaxIdleRetries,
+				URL:                 loc,
+				DestDir:             downloadDir,
+				Filename:            ancillaryFilename,
+				ExpectedSize:        snapshot.AncillarySize,
+				Logger:              cfg.Logger,
+				OnProgress:          cfg.OnProgress,
+				IdleTimeout:         cfg.DownloadIdleTimeout,
+				MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
+				MaxTransientRetries: cfg.DownloadMaxTransientRetries,
 			},
 		)
 		if err == nil {

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -819,12 +819,17 @@ func fetchImmutableArchive(
 	archiveDir string,
 	extractDir string,
 ) error {
+	// Use the main logger (not the per-archive quiet logger) for download
+	// retries so that transient-error warnings include immutable_file_number
+	// and reach the operator. extractLogger (discarded) is still used for
+	// the extraction step to suppress per-file INFO noise.
+	dlLogger := cfg.Logger.With("immutable_file_number", num)
 	archivePath, err := DownloadSnapshot(
 		ctx, DownloadConfig{
 			URL:                 location.ImmutableArchiveURI(num),
 			DestDir:             archiveDir,
 			Filename:            filepath.Base(immutableArchivePath(archiveDir, num)),
-			Logger:              extractLogger,
+			Logger:              dlLogger,
 			IdleTimeout:         cfg.DownloadIdleTimeout,
 			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 			MaxTransientRetries: cfg.DownloadMaxTransientRetries,

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -550,9 +550,10 @@ func downloadDigestsArchive(
 				"digests-%s.tar.zst",
 				truncateDigest(artifact.Hash),
 			),
-			Logger:         cfg.Logger,
-			IdleTimeout:    cfg.DownloadIdleTimeout,
-			MaxIdleRetries: cfg.DownloadMaxIdleRetries,
+			Logger:              cfg.Logger,
+			IdleTimeout:         cfg.DownloadIdleTimeout,
+			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
+			MaxTransientRetries: cfg.DownloadMaxTransientRetries,
 		},
 	)
 	if err != nil {
@@ -820,12 +821,13 @@ func fetchImmutableArchive(
 ) error {
 	archivePath, err := DownloadSnapshot(
 		ctx, DownloadConfig{
-			URL:            location.ImmutableArchiveURI(num),
-			DestDir:        archiveDir,
-			Filename:       filepath.Base(immutableArchivePath(archiveDir, num)),
-			Logger:         extractLogger,
-			IdleTimeout:    cfg.DownloadIdleTimeout,
-			MaxIdleRetries: cfg.DownloadMaxIdleRetries,
+			URL:                 location.ImmutableArchiveURI(num),
+			DestDir:             archiveDir,
+			Filename:            filepath.Base(immutableArchivePath(archiveDir, num)),
+			Logger:              extractLogger,
+			IdleTimeout:         cfg.DownloadIdleTimeout,
+			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
+			MaxTransientRetries: cfg.DownloadMaxTransientRetries,
 		},
 	)
 	if err != nil {
@@ -944,13 +946,14 @@ func downloadAncillaryV2(
 		}
 		ancillaryPath, err = DownloadSnapshot(
 			ctx, DownloadConfig{
-				URL:            loc.URI,
-				DestDir:        downloadDir,
-				Filename:       ancillaryFilename,
-				Logger:         cfg.Logger,
-				OnProgress:     cfg.OnProgress,
-				IdleTimeout:    cfg.DownloadIdleTimeout,
-				MaxIdleRetries: cfg.DownloadMaxIdleRetries,
+				URL:                 loc.URI,
+				DestDir:             downloadDir,
+				Filename:            ancillaryFilename,
+				Logger:              cfg.Logger,
+				OnProgress:          cfg.OnProgress,
+				IdleTimeout:         cfg.DownloadIdleTimeout,
+				MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
+				MaxTransientRetries: cfg.DownloadMaxTransientRetries,
 			},
 		)
 		if err == nil {

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -277,7 +278,11 @@ func isTransientDownloadError(err error) bool {
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
-	return strings.Contains(err.Error(), "connection reset by peer")
+	// Connection reset by peer — check via the syscall errno so that
+	// wrapped errors (url.Error → net.OpError → os.SyscallError → errno)
+	// are still detected without relying on string matching.
+	var errno syscall.Errno
+	return errors.As(err, &errno) && errno == syscall.ECONNRESET
 }
 
 // transientRetryDelay returns the backoff duration for the given
@@ -446,13 +451,16 @@ func DownloadSnapshot(
 		currentSize := downloadFileSize(destPath)
 		madeProgress := currentSize > startSize ||
 			currentSize > lastObservedSize
+		// Progress resets both retry counters symmetrically: partial
+		// forward progress proves we are not permanently stuck, so the
+		// budget for each failure class is restored from scratch.
 		if madeProgress {
 			lastObservedSize = currentSize
+			consecutiveIdleRetries = 0
+			transientRetries = 0
 		}
 		if errors.Is(err, errDownloadIdleTimeout) {
-			if madeProgress {
-				consecutiveIdleRetries = 0
-			} else {
+			if !madeProgress {
 				consecutiveIdleRetries++
 			}
 			if consecutiveIdleRetries > maxIdleRetries {
@@ -470,7 +478,9 @@ func DownloadSnapshot(
 				"error", err,
 			)
 		} else if isTransientDownloadError(err) {
-			transientRetries++
+			if !madeProgress {
+				transientRetries++
+			}
 			if transientRetries > maxTransientRetries {
 				return "", err
 			}

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -50,9 +52,19 @@ type ProgressFunc func(DownloadProgress)
 const (
 	defaultDownloadIdleTimeout = 2 * time.Minute
 	defaultDownloadIdleRetries = 12
+
+	defaultTransientRetryMaxAttempts = 10
+	defaultTransientRetryBaseDelay   = 500 * time.Millisecond
+	defaultTransientRetryMaxDelay    = 30 * time.Second
 )
 
-var errDownloadIdleTimeout = errors.New("download idle timeout")
+var (
+	errDownloadIdleTimeout = errors.New("download idle timeout")
+	// errDownloadTransient is wrapped into errors returned by
+	// downloadSnapshotOnce for HTTP 429 and HTTP 5xx responses so that
+	// DownloadSnapshot can identify them as retryable.
+	errDownloadTransient = errors.New("transient download error")
+)
 
 type countingReader struct {
 	reader io.Reader
@@ -91,6 +103,12 @@ type DownloadConfig struct {
 	// after idle timeouts that make no additional download progress.
 	// If zero, a conservative default is used.
 	MaxIdleRetries int
+	// MaxTransientRetries is the maximum number of retry attempts for
+	// transient network errors (TLS handshake failures, connection
+	// resets, unexpected EOF, HTTP 429, HTTP 5xx). If zero, a
+	// conservative default is used. If negative, transient retries
+	// are disabled.
+	MaxTransientRetries int
 }
 
 // Validate checks DownloadConfig values before use.
@@ -230,6 +248,54 @@ func (cfg DownloadConfig) maxIdleRetries() int {
 	return defaultDownloadIdleRetries
 }
 
+func (cfg DownloadConfig) maxTransientRetries() int {
+	if cfg.MaxTransientRetries < 0 {
+		return 0 // disabled
+	}
+	if cfg.MaxTransientRetries > 0 {
+		return cfg.MaxTransientRetries
+	}
+	return defaultTransientRetryMaxAttempts
+}
+
+// isTransientDownloadError reports whether err is a transient network
+// or server error that is safe to retry: net.Error timeouts (which
+// cover TLS handshake timeouts), unexpected EOF during body read,
+// connection reset by peer, and HTTP 429/5xx (wrapped as
+// errDownloadTransient by downloadSnapshotOnce).
+func isTransientDownloadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errDownloadTransient) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	return strings.Contains(err.Error(), "connection reset by peer")
+}
+
+// transientRetryDelay returns the backoff duration for the given
+// retry attempt (0-indexed). It uses exponential backoff capped at
+// defaultTransientRetryMaxDelay with ±25% jitter.
+func transientRetryDelay(attempt int) time.Duration {
+	shift := min(attempt, 6) // 2^6 * 500ms = 32s, capped at 30s
+	d := defaultTransientRetryBaseDelay * (1 << shift)
+	if d > defaultTransientRetryMaxDelay {
+		d = defaultTransientRetryMaxDelay
+	}
+	if quarter := d / 4; quarter > 0 {
+		// Jitter in [-quarter, +quarter]
+		d += time.Duration(rand.Int63n(int64(quarter)*2+1)) - quarter //nolint:gosec
+	}
+	return d
+}
+
 func downloadIdleTimeoutCause(timeout time.Duration) error {
 	return fmt.Errorf("%w after %s without data", errDownloadIdleTimeout, timeout)
 }
@@ -363,41 +429,69 @@ func DownloadSnapshot(
 		cfg.Logger = slog.Default()
 	}
 	maxIdleRetries := cfg.maxIdleRetries()
+	maxTransientRetries := cfg.maxTransientRetries()
 	destPath := downloadDestinationPath(cfg)
 	lastObservedSize := downloadFileSize(destPath)
 	consecutiveIdleRetries := 0
+	transientRetries := 0
 	for attempt := 1; ; attempt++ {
 		startSize := downloadFileSize(destPath)
 		path, err := downloadSnapshotOnce(ctx, cfg)
 		if err == nil {
 			return path, nil
 		}
-		if !errors.Is(err, errDownloadIdleTimeout) || ctx.Err() != nil {
+		if ctx.Err() != nil {
 			return "", err
 		}
 		currentSize := downloadFileSize(destPath)
 		madeProgress := currentSize > startSize ||
 			currentSize > lastObservedSize
 		if madeProgress {
-			consecutiveIdleRetries = 0
 			lastObservedSize = currentSize
-		} else {
-			consecutiveIdleRetries++
 		}
-		if consecutiveIdleRetries > maxIdleRetries {
+		if errors.Is(err, errDownloadIdleTimeout) {
+			if madeProgress {
+				consecutiveIdleRetries = 0
+			} else {
+				consecutiveIdleRetries++
+			}
+			if consecutiveIdleRetries > maxIdleRetries {
+				return "", err
+			}
+			cfg.Logger.Warn(
+				"snapshot download stalled, retrying",
+				"component", "mithril",
+				"attempt", attempt,
+				"consecutive_idle_retries", consecutiveIdleRetries,
+				"max_idle_retries", maxIdleRetries,
+				"idle_timeout", cfg.idleTimeout(),
+				"partial_bytes", currentSize,
+				"made_progress", madeProgress,
+				"error", err,
+			)
+		} else if isTransientDownloadError(err) {
+			transientRetries++
+			if transientRetries > maxTransientRetries {
+				return "", err
+			}
+			delay := transientRetryDelay(transientRetries - 1)
+			cfg.Logger.Warn(
+				"transient download error, retrying",
+				"component", "mithril",
+				"attempt", attempt,
+				"transient_retry", transientRetries,
+				"max_transient_retries", maxTransientRetries,
+				"backoff", delay,
+				"error", err,
+			)
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(delay):
+			}
+		} else {
 			return "", err
 		}
-		cfg.Logger.Warn(
-			"snapshot download stalled, retrying",
-			"component", "mithril",
-			"attempt", attempt,
-			"consecutive_idle_retries", consecutiveIdleRetries,
-			"max_idle_retries", maxIdleRetries,
-			"idle_timeout", cfg.idleTimeout(),
-			"partial_bytes", currentSize,
-			"made_progress", madeProgress,
-			"error", err,
-		)
 	}
 }
 
@@ -669,6 +763,15 @@ func downloadSnapshotOnce(
 		bodyBytes, _ := io.ReadAll(
 			io.LimitReader(resp.Body, 1024),
 		)
+		if resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode >= http.StatusInternalServerError {
+			return "", fmt.Errorf(
+				"%w: download failed with status %d: %s",
+				errDownloadTransient,
+				resp.StatusCode,
+				string(bodyBytes),
+			)
+		}
 		return "", fmt.Errorf(
 			"download failed with status %d: %s",
 			resp.StatusCode,

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -478,9 +478,11 @@ func DownloadSnapshot(
 				"error", err,
 			)
 		} else if isTransientDownloadError(err) {
-			if !madeProgress {
-				transientRetries++
-			}
+			// Always increment: the progress-based reset above already
+			// zeroes the counter on forward progress, so transientRetries
+			// is guaranteed >= 1 here, making transientRetries-1 >= 0 and
+			// safe to pass to transientRetryDelay.
+			transientRetries++
 			if transientRetries > maxTransientRetries {
 				return "", err
 			}

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -366,11 +367,110 @@ func TestDownloadSnapshotServerError(t *testing.T) {
 
 	destDir := t.TempDir()
 	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
-		URL:     server.URL + "/snapshot.tar.zst",
-		DestDir: destDir,
+		URL:                 server.URL + "/snapshot.tar.zst",
+		DestDir:             destDir,
+		MaxTransientRetries: -1, // disable retries so the test stays fast
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "500")
+}
+
+func TestDownloadSnapshotTransientRetrySucceeds(t *testing.T) {
+	content := []byte("ok-after-transient")
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requestCount.Add(1) == 1 {
+				http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+			_, _ = w.Write(content)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	destDir := t.TempDir()
+	path, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:                 server.URL + "/snapshot.tar.zst",
+		DestDir:             destDir,
+		Filename:            "transient-retry.tar.zst",
+		MaxTransientRetries: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), requestCount.Load(), "expected one retry after transient 503")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, data)
+}
+
+func TestDownloadSnapshotTransientRetryExhausted(t *testing.T) {
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	destDir := t.TempDir()
+	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:                 server.URL + "/snapshot.tar.zst",
+		DestDir:             destDir,
+		MaxTransientRetries: 2,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "429")
+	// 1 original attempt + 2 retries = 3 total requests
+	require.Equal(t, int32(3), requestCount.Load(), "expected 1 attempt + 2 retries")
+}
+
+func TestIsTransientDownloadError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{
+			name:      "nil",
+			err:       nil,
+			transient: false,
+		},
+		{
+			name:      "errDownloadTransient sentinel",
+			err:       fmt.Errorf("wrapped: %w", errDownloadTransient),
+			transient: true,
+		},
+		{
+			name:      "unexpected EOF",
+			err:       fmt.Errorf("writing snapshot data: %w", io.ErrUnexpectedEOF),
+			transient: true,
+		},
+		{
+			name:      "connection reset",
+			err:       fmt.Errorf("downloading snapshot: connection reset by peer"),
+			transient: true,
+		},
+		{
+			name:      "non-transient error",
+			err:       fmt.Errorf("download size mismatch: got 1, want 2"),
+			transient: false,
+		},
+		{
+			name:      "idle timeout is not transient",
+			err:       fmt.Errorf("stalled: %w", errDownloadIdleTimeout),
+			transient: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.transient, isTransientDownloadError(tc.err))
+		})
+	}
 }
 
 func TestDownloadSnapshotSizeVerification(t *testing.T) {

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -452,7 +453,7 @@ func TestIsTransientDownloadError(t *testing.T) {
 		},
 		{
 			name:      "connection reset",
-			err:       fmt.Errorf("downloading snapshot: connection reset by peer"),
+			err:       fmt.Errorf("downloading snapshot: %w", syscall.ECONNRESET),
 			transient: true,
 		},
 		{


### PR DESCRIPTION
Closes #2627 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transient retry handling for `mithril` snapshot downloads (including v2 immutable archives) to reduce flaky TLS/network failures. Uses capped exponential backoff with jitter and a configurable retry limit.

- **Bug Fixes**
  - Retries on transient errors: TLS timeouts, connection reset, unexpected EOF, HTTP 429, and HTTP 5xx.
  - Default up to 10 transient retries with jittered exponential backoff (500ms base, capped at 30s).
  - Resets retry counters on partial progress and logs v2 immutable archive retries via the main logger with immutable_file_number.

- **Migration**
  - New `DownloadMaxTransientRetries` in `BootstrapConfig` and `DownloadConfig`. Zero uses the default; negative disables retries.
  - No changes required unless you want to tune or disable transient retries.

<sup>Written for commit 79f8a3d3affee41611091af7447f0129a15b0f52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limits for snapshot downloads when transient network or server errors occur.
  * Snapshot and related archive downloads now retry more reliably, with backoff between attempts.

* **Bug Fixes**
  * Improved handling of temporary failures such as connection resets, TLS handshake issues, HTTP 429, and HTTP 5xx responses.
  * Added coverage to ensure retries succeed when the service recovers and stop when errors persist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->