### PR TITLE
fix(ledger): chainsync state change race

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -172,7 +172,7 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 				// can negotiate a fresh intersection rather than
 				// continuing to send the same rollback point.
 				ls.resetChainsyncResyncState()
-				ls.chainsyncState = SyncingChainsyncState
+				ls.setChainsyncState(SyncingChainsyncState)
 				if ls.config.EventBus != nil {
 					ls.config.EventBus.Publish(
 						event.ChainsyncResyncEventType,
@@ -246,6 +246,41 @@ func (ls *LedgerState) isConnectionLive(
 		return true
 	}
 	return ls.config.ConnectionLiveFunc(connId)
+}
+
+func (ls *LedgerState) setChainsyncState(
+	state ChainsyncState,
+) ChainsyncState {
+	ls.Lock()
+	previous := ls.chainsyncState
+	ls.chainsyncState = state
+	ls.Unlock()
+	return previous
+}
+
+func (ls *LedgerState) setChainsyncStateIf(
+	current ChainsyncState,
+	next ChainsyncState,
+) bool {
+	ls.Lock()
+	defer ls.Unlock()
+	if ls.chainsyncState != current {
+		return false
+	}
+	ls.chainsyncState = next
+	return true
+}
+
+func (ls *LedgerState) validationStateSnapshot() (bool, uint64) {
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.validationEnabled, ls.mithrilLedgerSlot
+}
+
+func (ls *LedgerState) mithrilLedgerSlotSnapshot() uint64 {
+	ls.RLock()
+	defer ls.RUnlock()
+	return ls.mithrilLedgerSlot
 }
 
 func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
@@ -1197,7 +1232,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			"connection_id", e.ConnectionId.String(),
 		)
 		ls.resetChainsyncResyncState()
-		ls.chainsyncState = SyncingChainsyncState
+		ls.setChainsyncState(SyncingChainsyncState)
 		if ls.config.EventBus != nil {
 			ls.config.EventBus.Publish(
 				event.ChainsyncResyncEventType,
@@ -1213,7 +1248,10 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		return nil
 	}
 
-	if ls.chainsyncState == SyncingChainsyncState {
+	if ls.setChainsyncStateIf(
+		SyncingChainsyncState,
+		RollbackChainsyncState,
+	) {
 		ls.config.Logger.Info(
 			fmt.Sprintf(
 				"ledger: rolling back to %d.%s",
@@ -1221,7 +1259,6 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				hex.EncodeToString(e.Point.Hash),
 			),
 		)
-		ls.chainsyncState = RollbackChainsyncState
 	}
 	if err := ls.rollbackChainAndState(e.Point); err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
@@ -1235,7 +1272,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				"connection_id", e.ConnectionId.String(),
 			)
 			ls.resetChainsyncResyncState()
-			ls.chainsyncState = SyncingChainsyncState
+			ls.setChainsyncState(SyncingChainsyncState)
 			if ls.config.EventBus != nil {
 				ls.config.EventBus.Publish(
 					event.ChainsyncResyncEventType,
@@ -1263,7 +1300,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			}
 			if reconciled {
 				ls.resetChainsyncResyncState()
-				ls.chainsyncState = SyncingChainsyncState
+				ls.setChainsyncState(SyncingChainsyncState)
 				return nil
 			}
 			// The peer's chain has diverged beyond K blocks from
@@ -1285,7 +1322,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			// we are still syncing. Leaving RollbackChainsyncState
 			// would cause a spurious "switched to fork" log and
 			// fork metric increment on the next block header.
-			ls.chainsyncState = SyncingChainsyncState
+			ls.setChainsyncState(SyncingChainsyncState)
 			if ls.config.EventBus != nil {
 				ls.config.EventBus.Publish(
 					event.ChainsyncResyncEventType,
@@ -1319,9 +1356,10 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			//     the trust anchor.
 			// A zero tip means the peer's tip is unknown; treat it as
 			// divergent to fail safe.
+			mithrilLedgerSlot := ls.mithrilLedgerSlotSnapshot()
 			reason := event.ChainsyncResyncReasonRollbackExceedsMithril
 			peerTipSlot := e.Tip.Point.Slot
-			if peerTipSlot > 0 && peerTipSlot < ls.mithrilLedgerSlot {
+			if peerTipSlot > 0 && peerTipSlot < mithrilLedgerSlot {
 				reason = event.ChainsyncResyncReasonPeerTipBehindMithril
 				ls.config.Logger.Warn(
 					"chainsync peer tip behind Mithril trust boundary, treating peer chain as stale",
@@ -1329,7 +1367,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 					"slot", e.Point.Slot,
 					"hash", hex.EncodeToString(e.Point.Hash),
 					"peer_tip_slot", peerTipSlot,
-					"mithril_ledger_slot", ls.mithrilLedgerSlot,
+					"mithril_ledger_slot", mithrilLedgerSlot,
 					"connection_id", e.ConnectionId.String(),
 				)
 			} else {
@@ -1339,12 +1377,12 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 					"slot", e.Point.Slot,
 					"hash", hex.EncodeToString(e.Point.Hash),
 					"peer_tip_slot", peerTipSlot,
-					"mithril_ledger_slot", ls.mithrilLedgerSlot,
+					"mithril_ledger_slot", mithrilLedgerSlot,
 					"connection_id", e.ConnectionId.String(),
 				)
 			}
 			ls.resetChainsyncResyncState()
-			ls.chainsyncState = SyncingChainsyncState
+			ls.setChainsyncState(SyncingChainsyncState)
 			if ls.config.EventBus != nil {
 				ls.config.EventBus.Publish(
 					event.ChainsyncResyncEventType,
@@ -1717,7 +1755,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		}
 	}
 
-	if ls.chainsyncState == RollbackChainsyncState {
+	if ls.setChainsyncState(SyncingChainsyncState) == RollbackChainsyncState {
 		ls.config.Logger.Info(
 			fmt.Sprintf(
 				"ledger: switched to fork at %d.%s",
@@ -1727,7 +1765,6 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		)
 		ls.metrics.forks.Add(1)
 	}
-	ls.chainsyncState = SyncingChainsyncState
 	ls.recordPeerHeaderHistory(e)
 	if ls.shouldBufferHeaderEvent(e) {
 		return nil
@@ -1956,10 +1993,11 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 }
 
 func (ls *LedgerState) shouldVerifyChainsyncHeaderCrypto(slot uint64) bool {
-	if !ls.validationEnabled {
+	validationEnabled, mithrilLedgerSlot := ls.validationStateSnapshot()
+	if !validationEnabled {
 		return false
 	}
-	return ls.mithrilLedgerSlot == 0 || slot > ls.mithrilLedgerSlot
+	return mithrilLedgerSlot == 0 || slot > mithrilLedgerSlot
 }
 
 // tryResolveFork attempts to resolve a chain fork when an incoming header
@@ -2108,7 +2146,7 @@ func (ls *LedgerState) tryResolveFork(
 			}
 			if reconciled {
 				ls.resetChainsyncResyncState()
-				ls.chainsyncState = SyncingChainsyncState
+				ls.setChainsyncState(SyncingChainsyncState)
 				return true, nil
 			}
 			// Fork exceeds security parameter K. We must not
@@ -2159,7 +2197,7 @@ func (ls *LedgerState) tryResolveFork(
 
 	// Mark state as rollback so the next block header event logs
 	// "switched to fork" and increments the fork metric.
-	ls.chainsyncState = RollbackChainsyncState
+	ls.setChainsyncState(RollbackChainsyncState)
 
 	// Rollback succeeded — re-add the known peer fork segment from the
 	// common ancestor forward. Re-adding only the latest mismatching header
@@ -2235,7 +2273,8 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	// Verify block header cryptographic proofs (VRF, KES).
 	// Skip during historical sync (validationEnabled=false) because
 	// historical blocks were already validated by the network.
-	if ls.validationEnabled {
+	validationEnabled, _ := ls.validationStateSnapshot()
+	if validationEnabled {
 		// Chainsync already verified the queued header before blockfetch started.
 		// When the fetched block matches that first queued header by point, a
 		// second VRF/KES verification is redundant. Chain insertion still checks

--- a/ledger/chainsync_state_race_test.go
+++ b/ledger/chainsync_state_race_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestChainsyncValidationStateConcurrentAccess(t *testing.T) {
+	ls := &LedgerState{
+		chainsyncState:    SyncingChainsyncState,
+		validationEnabled: true,
+		mithrilLedgerSlot: 10,
+	}
+
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 2; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for slot := 0; slot < iterations; slot++ {
+				_ = ls.shouldVerifyChainsyncHeaderCrypto(uint64(slot))
+				_, _ = ls.validationStateSnapshot()
+				_ = ls.mithrilLedgerSlotSnapshot()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ls.Lock()
+			ls.validationEnabled = i%2 == 0
+			ls.mithrilLedgerSlot = uint64(i % 128)
+			ls.Unlock()
+
+			if i%3 == 0 {
+				ls.setChainsyncState(RollbackChainsyncState)
+			} else {
+				ls.setChainsyncState(SyncingChainsyncState)
+			}
+			ls.setChainsyncStateIf(
+				RollbackChainsyncState,
+				SyncingChainsyncState,
+			)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/ledger/epoch_nonce_past_cutoff_test.go
+++ b/ledger/epoch_nonce_past_cutoff_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEpochNonce_SnapshotTipPastCutoff covers the one Mithril-bootstrap
+// shape the existing #2128 suite does not: a snapshot whose tip slot lies
+// PAST the candidate-freeze cutoff of its epoch. In that shape the imported
+// epoch row carries CandidateNonce != EvolvingNonce — psCandidateNonce
+// froze at the cutoff (before the tip) while psEvolvingNonce kept rolling
+// to the tip. The existing tests always set the two equal (snapshot taken
+// before the cutoff), so this exercises the distinct-values path.
+//
+// Expected: the bootstrap epoch's rollover must return candidate equal to
+// the imported (frozen) CandidateNonce — NOT the imported EvolvingNonce,
+// and NOT a value re-derived from a pre-cutoff block (there are none with
+// stored nonces; pre-cutoff blocks were imported as immutable). Both the
+// rollover path (calculateEpochNonce) and the header-verification path
+// (computeEpochNonceForSlot) must agree, because the first header of the
+// new epoch is verified against the eagerly-cached value.
+func TestEpochNonce_SnapshotTipPastCutoff(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cfg := newConwayBootstrapStabilityCfg(t)
+
+	// k=6, f=0.4 -> 4k/f = 60. Epoch [1000,1075), cutoff = 1075-60 = 1015.
+	const (
+		epochStart  uint64 = 1000
+		epochLength uint64 = 75
+		epochEnd    uint64 = epochStart + epochLength
+		cutoffSlot  uint64 = 1015
+		preImpSlot  uint64 = 1010 // pre-cutoff, imported immutable (no nonce row)
+		snapTipSlot uint64 = 1040 // snapshot tip: PAST the cutoff
+		postCutSlot uint64 = 1070 // last block of epoch (post-import)
+	)
+
+	// Imported tip-time evolving nonce (psEvolvingNonce at slot 1040).
+	importedEvolving := bytes.Repeat([]byte{0xaa}, 32)
+	// Imported frozen candidate (psCandidateNonce, frozen at the cutoff
+	// well before the tip). Distinct from evolving on purpose.
+	importedCandidate := bytes.Repeat([]byte{0xdd}, 32)
+	// Per-block evolving nonce stored by post-import processing.
+	nonceAtPostCut := bytes.Repeat([]byte{0xcc}, 32)
+
+	hashPreImp := bytes.Repeat([]byte{0x10}, 32)
+	hashAtSnap := bytes.Repeat([]byte{0x40}, 32)
+	hashAtPostCut := bytes.Repeat([]byte{0x70}, 32)
+	prevHashPreImp := bytes.Repeat([]byte{0x09}, 32)
+
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		// Pre-cutoff block imported as immutable: present in the blob
+		// store, but with NO block_nonce row (importTip only checkpoints
+		// the tip).
+		if err := db.BlockCreate(models.Block{
+			Slot:     preImpSlot,
+			Hash:     hashPreImp,
+			PrevHash: prevHashPreImp,
+			Cbor:     []byte{0x80},
+			Number:   1,
+			Type:     conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		// Snapshot tip block (past the cutoff).
+		if err := db.BlockCreate(models.Block{
+			Slot:     snapTipSlot,
+			Hash:     hashAtSnap,
+			PrevHash: hashPreImp,
+			Cbor:     []byte{0x80},
+			Number:   2,
+			Type:     conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		// Post-import block.
+		if err := db.BlockCreate(models.Block{
+			Slot:     postCutSlot,
+			Hash:     hashAtPostCut,
+			PrevHash: hashAtSnap,
+			Cbor:     []byte{0x80},
+			Number:   3,
+			Type:     conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		// importTip checkpoint at the snapshot tip = imported evolving.
+		if err := db.SetBlockNonce(
+			hashAtSnap, snapTipSlot, importedEvolving, true, txn,
+		); err != nil {
+			return err
+		}
+		return db.SetBlockNonce(
+			hashAtPostCut, postCutSlot, nonceAtPostCut, false, txn,
+		)
+	}))
+
+	prevEpoch := models.Epoch{
+		EpochId:             100,
+		StartSlot:           epochStart,
+		LengthInSlots:       uint(epochLength),
+		SlotLength:          1000,
+		EraId:               eras.ConwayEraDesc.Id,
+		Nonce:               bytes.Repeat([]byte{0xee}, 32),
+		EvolvingNonce:       importedEvolving,
+		CandidateNonce:      importedCandidate,
+		LastEpochBlockNonce: bytes.Repeat([]byte{0xfa}, 32),
+	}
+
+	ls := &LedgerState{
+		db:           db,
+		currentEra:   eras.ConwayEraDesc,
+		currentEpoch: prevEpoch,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	// Header-verification (eager) path.
+	hvNonce, hvEvolving, hvCandidate, hvLab, err :=
+		ls.computeEpochNonceForSlot(epochEnd, prevEpoch)
+	require.NoError(t, err)
+
+	// Rollover (authoritative) path.
+	var rNonce, rEvolving, rCandidate, rLab []byte
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		n, ev, c, lab, err := ls.calculateEpochNonce(
+			txn, epochEnd, eras.ConwayEraDesc, prevEpoch,
+		)
+		rNonce, rEvolving, rCandidate, rLab = n, ev, c, lab
+		return err
+	}))
+
+	require.Equalf(
+		t,
+		hex.EncodeToString(importedCandidate),
+		hex.EncodeToString(rCandidate),
+		"with the snapshot tip past the cutoff (tip=%d, cutoff=%d), the "+
+			"frozen candidate is the imported psCandidateNonce. Got %x. "+
+			"If this equals importedEvolving (0xaa...) the computation "+
+			"confused evolving for candidate.",
+		snapTipSlot, cutoffSlot, rCandidate,
+	)
+	require.Equalf(
+		t,
+		hex.EncodeToString(nonceAtPostCut),
+		hex.EncodeToString(rEvolving),
+		"evolving must equal the last block's stored nonce (slot %d). Got %x.",
+		postCutSlot, rEvolving,
+	)
+	require.NotEqual(
+		t,
+		hex.EncodeToString(rCandidate),
+		hex.EncodeToString(rEvolving),
+		"candidate (frozen pre-tip) and evolving (at tip) must differ",
+	)
+
+	// Eager path must match rollover, or the first new-epoch header is
+	// verified against a nonce the rollover later disagrees with -> VRF
+	// failure at turnover.
+	require.Equal(t,
+		hex.EncodeToString(rCandidate), hex.EncodeToString(hvCandidate),
+		"eager candidate must match rollover candidate")
+	require.Equal(t,
+		hex.EncodeToString(rEvolving), hex.EncodeToString(hvEvolving),
+		"eager evolving must match rollover evolving")
+	require.Equalf(t,
+		hex.EncodeToString(rNonce), hex.EncodeToString(hvNonce),
+		"eager epoch nonce must match rollover epoch nonce. hv=%x rollover=%x",
+		hvNonce, rNonce)
+	require.Equal(t,
+		hex.EncodeToString(rLab), hex.EncodeToString(hvLab),
+		"eager labNonce must match rollover labNonce")
+}

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -248,7 +248,7 @@ func (ls *LedgerState) rejectReplayRecoveryAtMithrilBoundary(
 	}
 	ls.chainsyncMutex.Lock()
 	ls.resetChainsyncResyncState()
-	ls.chainsyncState = SyncingChainsyncState
+	ls.setChainsyncState(SyncingChainsyncState)
 	ls.chainsyncMutex.Unlock()
 	if ls.config.EventBus != nil {
 		var activeConnId ouroboros.ConnectionId

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1735,7 +1735,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 		// the trust anchor — we never rewind below it — so the
 		// authoritative deletion slot is the rollback target or the
 		// Mithril boundary, whichever is later.
-		deleteSlot := max(ls.mithrilLedgerSlot, point.Slot)
+		deleteSlot := max(mithrilLedgerSlot, point.Slot)
 		err := ls.db.UtxosDeleteRolledback(deleteSlot, txn)
 		if err != nil {
 			return fmt.Errorf("remove rolled-back UTxOs: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a chainsync state race by making state transitions atomic and reads lock-safe, preventing spurious fork logs and inconsistent header verification. Adds tests for concurrent access and a Mithril snapshot past-cutoff epoch-nonce case to guard against VRF issues at epoch turnover.

- **Bug Fixes**
  - Atomized chainsync transitions via `setChainsyncState` and `setChainsyncStateIf`; avoids races that could mislabel rollbacks as forks and fixes incorrect metric bumps.
  - Reads validation/Mithril trust-boundary via `validationStateSnapshot` and `mithrilLedgerSlotSnapshot` in header verification, rollback, and resync paths.
  - Replaced direct state writes in chainsync and replay-recovery handlers with the new helpers for consistent resync behavior.
  - Added `TestChainsyncValidationStateConcurrentAccess` and `TestEpochNonce_SnapshotTipPastCutoff` to prevent regressions, including coverage for snapshot tips past the cutoff (VRF turnover safety).

<sup>Written for commit 12514d658956c47fc9efb8836e3eb19ded777401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

