### PR TITLE
fix(ledger): plutus restrictive validation over-rejects accepted txs …

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 
@@ -303,44 +304,22 @@ func ValidateTxAlonzo(
 				return fmt.Errorf("build evaluation context: %w", err)
 			}
 			evalContext.SkipFinalSlippageFlush = true
-			_, err = s.Evaluate(
+			usedBudget, err := s.Evaluate(
 				datum,
 				redeemer.Data,
 				sc.ToPlutusData(),
-				redeemer.ExUnits,
+				lcommon.ExUnits{Steps: math.MaxInt64 / 2, Memory: math.MaxInt64 / 2},
 				evalContext,
 			)
 			if err != nil {
-				/*
-					fmt.Printf("TX ID: %s\n", tx.Hash().String())
-					fmt.Printf("purpose = %#v, redeemer = %#v\n", purpose, redeemer)
-					scriptHash := s.Hash()
-					fmt.Printf("scriptHash = %s\n", scriptHash.String())
-					fmt.Printf("tx = %x\n", tx.Cbor())
-					// Build inputs/outputs strings that can be plugged into Aiken script_context tests for comparison
-					var tmpInputs []lcommon.TransactionInput
-					var tmpOutputs []lcommon.TransactionOutput
-					for _, input := range slices.Concat(resolvedInputs, resolvedRefInputs) {
-						tmpInputs = append(tmpInputs, input.Id)
-						tmpOutputs = append(tmpOutputs, input.Output)
-					}
-					tmpInputsCbor, err2 := cbor.Encode(tmpInputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpInputs = %x\n", tmpInputsCbor)
-					tmpOutputsCbor, err2 := cbor.Encode(tmpOutputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpOutputs = %x\n", tmpOutputsCbor)
-					scCbor, err2 := data.Encode(sc.ToPlutusData())
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("scCbor = %x\n", scCbor)
-				*/
 				return err
+			}
+			if usedBudget.Steps > redeemer.ExUnits.Steps || usedBudget.Memory > redeemer.ExUnits.Memory {
+				return fmt.Errorf(
+					"script exceeded declared budget: used (%d cpu, %d mem), declared (%d cpu, %d mem)",
+					usedBudget.Steps, usedBudget.Memory,
+					redeemer.ExUnits.Steps, redeemer.ExUnits.Memory,
+				)
 			}
 		default:
 			return fmt.Errorf("unimplemented script type: %T", tmpScript)

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 
@@ -328,44 +329,22 @@ func ValidateTxBabbage(
 				return fmt.Errorf("build evaluation context: %w", err)
 			}
 			evalContext.SkipFinalSlippageFlush = true
-			_, err = s.Evaluate(
+			usedBudgetV1, err := s.Evaluate(
 				datum,
 				redeemer.Data,
 				sc.ToPlutusData(),
-				redeemer.ExUnits,
+				lcommon.ExUnits{Steps: math.MaxInt64 / 2, Memory: math.MaxInt64 / 2},
 				evalContext,
 			)
 			if err != nil {
-				/*
-					fmt.Printf("TX ID: %s\n", tx.Hash().String())
-					fmt.Printf("purpose = %#v, redeemer = %#v\n", purpose, redeemer)
-					scriptHash := s.Hash()
-					fmt.Printf("scriptHash = %s\n", scriptHash.String())
-					fmt.Printf("tx = %x\n", tx.Cbor())
-					// Build inputs/outputs strings that can be plugged into Aiken script_context tests for comparison
-					var tmpInputs []lcommon.TransactionInput
-					var tmpOutputs []lcommon.TransactionOutput
-					for _, input := range slices.Concat(resolvedInputs, resolvedRefInputs) {
-						tmpInputs = append(tmpInputs, input.Id)
-						tmpOutputs = append(tmpOutputs, input.Output)
-					}
-					tmpInputsCbor, err2 := cbor.Encode(tmpInputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpInputs = %x\n", tmpInputsCbor)
-					tmpOutputsCbor, err2 := cbor.Encode(tmpOutputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpOutputs = %x\n", tmpOutputsCbor)
-					scCbor, err2 := data.Encode(sc.ToPlutusData())
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("scCbor = %x\n", scCbor)
-				*/
 				return err
+			}
+			if usedBudgetV1.Steps > redeemer.ExUnits.Steps || usedBudgetV1.Memory > redeemer.ExUnits.Memory {
+				return fmt.Errorf(
+					"script exceeded declared budget: used (%d cpu, %d mem), declared (%d cpu, %d mem)",
+					usedBudgetV1.Steps, usedBudgetV1.Memory,
+					redeemer.ExUnits.Steps, redeemer.ExUnits.Memory,
+				)
 			}
 		case lcommon.PlutusV2Script:
 			txInfoV2, err := script.NewTxInfoV2FromTransaction(
@@ -394,44 +373,22 @@ func ValidateTxBabbage(
 				return fmt.Errorf("build evaluation context: %w", err)
 			}
 			evalContext.SkipFinalSlippageFlush = true
-			_, err = s.Evaluate(
+			usedBudgetV2, err := s.Evaluate(
 				datum,
 				redeemer.Data,
 				sc.ToPlutusData(),
-				redeemer.ExUnits,
+				lcommon.ExUnits{Steps: math.MaxInt64 / 2, Memory: math.MaxInt64 / 2},
 				evalContext,
 			)
 			if err != nil {
-				/*
-					fmt.Printf("TX ID: %s\n", tx.Hash().String())
-					fmt.Printf("purpose = %#v, redeemer = %#v\n", purpose, redeemer)
-					scriptHash := s.Hash()
-					fmt.Printf("scriptHash = %s\n", scriptHash.String())
-					fmt.Printf("tx = %x\n", tx.Cbor())
-					// Build inputs/outputs strings that can be plugged into Aiken script_context tests for comparison
-					var tmpInputs []lcommon.TransactionInput
-					var tmpOutputs []lcommon.TransactionOutput
-					for _, input := range slices.Concat(resolvedInputs, resolvedRefInputs) {
-						tmpInputs = append(tmpInputs, input.Id)
-						tmpOutputs = append(tmpOutputs, input.Output)
-					}
-					tmpInputsCbor, err2 := cbor.Encode(tmpInputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpInputs = %x\n", tmpInputsCbor)
-					tmpOutputsCbor, err2 := cbor.Encode(tmpOutputs)
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("tmpOutputs = %x\n", tmpOutputsCbor)
-					scCbor, err2 := data.Encode(sc.ToPlutusData())
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("scCbor = %x\n", scCbor)
-				*/
 				return err
+			}
+			if usedBudgetV2.Steps > redeemer.ExUnits.Steps || usedBudgetV2.Memory > redeemer.ExUnits.Memory {
+				return fmt.Errorf(
+					"script exceeded declared budget: used (%d cpu, %d mem), declared (%d cpu, %d mem)",
+					usedBudgetV2.Steps, usedBudgetV2.Memory,
+					redeemer.ExUnits.Steps, redeemer.ExUnits.Memory,
+				)
 			}
 		default:
 			return fmt.Errorf("unimplemented script type: %T", tmpScript)

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 	"strings"
@@ -936,6 +937,19 @@ func (c *conwayTxInfoCache) v3() (script.TxInfoV3, error) {
 	return c.txInfoV3, nil
 }
 
+// restrictiveEnormousBudget is used when evaluating Plutus scripts in
+// restrictive (phase-2 ledger validation) mode. Instead of limiting the CEK
+// machine to the declared redeemer budget during execution — which causes
+// intermediate slippage-batch flush failures — we run with a virtually
+// unlimited budget and compare the consumed amount against the declared budget
+// after execution. This mirrors cardano-node's restrictingEnormous semantics:
+// the machine runs unconstrained; at the end, usedBudget (which excludes the
+// final unbudgeted step batch, per SkipFinalSlippageFlush) must fit within the
+// declared redeemer budget.
+//
+// math.MaxInt64/2 avoids overflow in ExBudget arithmetic (consumed = enormous - remaining).
+const restrictiveEnormousBudget = int64(math.MaxInt64 / 2)
+
 func evaluateConwayPlutusScript(
 	plutusScript lcommon.Script,
 	purpose script.ScriptPurpose,
@@ -946,6 +960,20 @@ func evaluateConwayPlutusScript(
 	txInfos *conwayTxInfoCache,
 	skipFinalSlippageFlush bool,
 ) (lcommon.ExUnits, error, error) {
+	// In restrictive mode (skipFinalSlippageFlush=true), pass an enormous
+	// budget to gouroboros/plutigo so intermediate slippage-batch flushes
+	// never exhaust the budget mid-execution. After execution we compare the
+	// consumed amount (final batch already excluded by SkipFinalSlippageFlush)
+	// against the declared redeemer budget. This matches cardano-node's
+	// restrictingEnormous mode. In exact mode the declared budget is used as
+	// the machine limit (unchanged behavior).
+	evalBudget := budget
+	if skipFinalSlippageFlush {
+		evalBudget = lcommon.ExUnits{
+			Steps:  restrictiveEnormousBudget,
+			Memory: restrictiveEnormousBudget,
+		}
+	}
 	switch s := plutusScript.(type) {
 	case lcommon.PlutusV3Script:
 		txInfoV3, err := txInfos.v3()
@@ -967,11 +995,17 @@ func evaluateConwayPlutusScript(
 		evalContext.SkipFinalSlippageFlush = skipFinalSlippageFlush
 		usedBudget, err := s.Evaluate(
 			ctx.ToPlutusData(),
-			budget,
+			evalBudget,
 			evalContext,
 		)
 		if err != nil {
 			return lcommon.ExUnits{}, err, nil
+		}
+		if skipFinalSlippageFlush && (usedBudget.Steps > budget.Steps || usedBudget.Memory > budget.Memory) {
+			return usedBudget, fmt.Errorf(
+				"script exceeded declared budget: used (%d cpu, %d mem), declared (%d cpu, %d mem)",
+				usedBudget.Steps, usedBudget.Memory, budget.Steps, budget.Memory,
+			), nil
 		}
 		return usedBudget, nil, nil
 	case lcommon.PlutusV2Script:
@@ -996,11 +1030,17 @@ func evaluateConwayPlutusScript(
 			datum,
 			redeemer.Data,
 			ctx.ToPlutusData(),
-			budget,
+			evalBudget,
 			evalContext,
 		)
 		if err != nil {
 			return lcommon.ExUnits{}, err, nil
+		}
+		if skipFinalSlippageFlush && (usedBudget.Steps > budget.Steps || usedBudget.Memory > budget.Memory) {
+			return usedBudget, fmt.Errorf(
+				"script exceeded declared budget: used (%d cpu, %d mem), declared (%d cpu, %d mem)",
+				usedBudget.Steps, usedBudget.Memory, budget.Steps, budget.Memory,
+			), nil
 		}
 		return usedBudget, nil, nil
 	case lcommon.PlutusV1Script:
@@ -1025,11 +1065,17 @@ func evaluateConwayPlutusScript(
 			datum,
 			redeemer.Data,
 			ctx.ToPlutusData(),
-			budget,
+			evalBudget,
 			evalContext,
 		)
 		if err != nil {
 			return lcommon.ExUnits{}, err, nil
+		}
+		if skipFinalSlippageFlush && (usedBudget.Steps > budget.Steps || usedBudget.Memory > budget.Memory) {
+			return usedBudget, fmt.Errorf(
+				"script exceeded declared budget: used (%d cpu, %d mem), declared (%d cpu, %d mem)",
+				usedBudget.Steps, usedBudget.Memory, budget.Steps, budget.Memory,
+			), nil
 		}
 		return usedBudget, nil, nil
 	default:


### PR DESCRIPTION
Closes #2644 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix restrictive Plutus validation to stop over-rejecting valid transactions by aligning CEK slippage accounting with cardano-node: run with a virtually unlimited budget and enforce the redeemer budget after execution. Applies across Alonzo, Babbage, and Conway eras.

- **Bug Fixes**
  - In restrictive mode (`SkipFinalSlippageFlush`), evaluate with an “enormous” budget (`math.MaxInt64/2`), then compare `usedBudget` to `redeemer.ExUnits`; raise a clear “exceeded declared budget” error if needed.
  - Implemented for Plutus V1/V2 (Alonzo, Babbage) and V1/V2/V3 (Conway) via `evaluateConwayPlutusScript` and `restrictiveEnormousBudget`; exact mode behavior is unchanged.
  - Removed commented debug code and added explicit budget overrun reporting.

<sup>Written for commit d75495ca42a087b843a6cc96318f9d0d6f70282e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plutus script budget enforcement across Alonzo, Babbage, and Conway eras.
  * Scripts are now checked against their declared execution limits after evaluation, helping catch cases where actual usage exceeds the allowed budget.
  * Conway evaluation now handles restrictive “enormous budget” behavior more consistently when final slippage flush is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->