### PR TITLE
feat(chainselection): pin same-tip peer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1013,6 +1013,51 @@ as a fallback ingress source, but peer governance lowers their priority to zero.
 This lets non-bootstrap peers win same-tip transport selection without
 stranding ChainSync when the bootstrap peer is still the only usable upstream.
 
+#### Anti-flap incumbent pin
+
+The active connection (the peer that drives the chainsync+blockfetch pipeline
+via `SetClientConnId`) is selected by Praos rules, but switching it on every
+1-block head difference is harmful: with multiple upstream peers at the same
+tip, the peers micro-fork at the head (peer A one block ahead, then peer B
+leapfrogs to a sibling at the same height, then A again). Each switch hands off
+and resets the pipeline, so during deep catch-up the ledger can apply zero
+blocks (it wedges) and at the live tip it grinds. The reference-implementation
+Praos comparison still governs which chain is canonically best; the anti-flap
+pin only suppresses the active-CONNECTION handoff between peers on the same
+height or sibling head-forks.
+
+The pin (`pinIncumbentDuringCatchUpLocked` in `chainselection/selector.go`)
+engages whenever there is an established, still-selectable incumbent and a
+local tip has been applied at least once (`SetLocalTip` called, applied block
+> 0). It applies in both regimes: deep catch-up (best known peer tip more than
+`catchUpPinBlockThreshold` = 100 blocks ahead of the applied local tip) and
+at/near the live tip. When a switch would otherwise occur to a peer that is
+only a head micro-fork ahead, the pin keeps the incumbent active and does NOT
+emit a `ChainSwitchEvent`.
+
+The pin RELEASES (allows the switch) when any of these hold, which together
+guarantee the node still converges to the genuinely-longest chain and can never
+pin to a dead/minority peer:
+
+- No local tip has ever been applied (applied block == 0) — near-genesis and
+  pre-`SetLocalTip` behavior is unchanged, so the pin is inactive.
+- The incumbent is no longer selectable (disconnected, ineligible, stale, or
+  implausibly behind).
+- Longer-chain escape: the challenger is genuinely taller than the incumbent by
+  more than `catchUpPinHeadMargin` (= 2 blocks) — a real longer chain, not a
+  head micro-fork.
+- Progress-stall escape: the applied local tip has stopped advancing for at
+  least `catchUpPinStallTimeout` (= 20s wall-clock, not 20 slots). `SetLocalTip`
+  records the timestamp of the last FORWARD progress (block number advancing);
+  repeated same-or-lower tip updates (including rollbacks) do NOT reset the
+  stall clock, so a stalled incumbent cannot keep the pin alive by re-reporting
+  an unchanged tip. The clock is fed by an injectable `nowFn` (defaulting to
+  `time.Now`) for deterministic tests.
+
+The existing equal-tip incumbent preservation (when `ComparePraosTips` returns
+`ChainEqual`, and the same-block transport tiebreaker) is preserved and runs
+ahead of the pin.
+
 ## Network and Protocol Handling
 
 ### Ouroboros Protocol Stack

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -46,6 +46,28 @@ const (
 	// and CPU cost of chain selection, preventing Sybil-based resource
 	// exhaustion.
 	DefaultMaxTrackedPeers = 200
+
+	// catchUpPinBlockThreshold is the catch-up gap (in blocks, measured as
+	// bestKnownPeerBlock - appliedLocalTipBlock) at or above which the node
+	// is considered to be in deep catch-up. The anti-flap pin's behavior is
+	// identical in catch-up and at the tip; this threshold is only used for
+	// observability/diagnostics and to describe the two regimes.
+	catchUpPinBlockThreshold = 100
+
+	// catchUpPinHeadMargin is the maximum number of blocks a challenger may
+	// lead the incumbent and still be treated as a head micro-fork (a
+	// sibling at, or barely past, the same height) rather than a genuinely
+	// longer chain. A challenger ahead by more than this margin is a real
+	// longer chain and the pin releases so the node converges to it.
+	catchUpPinHeadMargin = 2
+
+	// catchUpPinStallTimeout is the progress-aware wall-clock escape window.
+	// It is deliberately time-based, not slot-based: if the applied local tip
+	// stops advancing for at least this long while the pin is engaged, the pin
+	// releases so the node can switch away from a dead/stalled incumbent. This
+	// is the key safety valve that guarantees the node can never pin to a
+	// non-progressing peer forever.
+	catchUpPinStallTimeout = 20 * time.Second
 )
 
 // safeBlockDiff computes the difference between two block numbers as int64,
@@ -108,6 +130,18 @@ type ChainSelector struct {
 	mutex             sync.RWMutex
 	ctx               context.Context
 	cancel            context.CancelFunc
+
+	// Anti-flap incumbent pin state (guarded by mutex).
+	//
+	// localTipProgressBlock / localTipProgressAt record when the APPLIED
+	// local tip last advanced (moved forward in block number). The stall
+	// clock (catchUpPinStallTimeout) is measured from localTipProgressAt and
+	// is only reset on genuine forward progress, so repeated same-or-lower
+	// SetLocalTip calls never reset it.
+	localTipProgressBlock uint64
+	localTipProgressAt    time.Time
+	// nowFn is injectable for deterministic tests; defaults to time.Now.
+	nowFn func() time.Time
 }
 
 // NewChainSelector creates a new ChainSelector with the given configuration.
@@ -135,6 +169,7 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 		eligible:          make(map[ouroboros.ConnectionId]bool),
 		priority:          make(map[ouroboros.ConnectionId]int),
 		evaluationTrigger: make(chan struct{}, 1),
+		nowFn:             time.Now,
 	}
 	if cfg.GenesisMode {
 		cs.mode = SelectionModeGenesis
@@ -586,15 +621,36 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 }
 
 // SetLocalTip updates the local chain tip for comparison.
+//
+// It also records the last time the APPLIED local tip moved FORWARD (its
+// block number advanced). The anti-flap incumbent pin uses this timestamp as
+// a progress-aware escape: if the applied tip stops advancing while the pin
+// is engaged, the pin releases. Same-or-lower tip updates (including
+// rollbacks) deliberately do NOT reset the stall clock, so a stalled
+// incumbent cannot keep the pin alive by re-reporting an unchanged tip.
 func (cs *ChainSelector) SetLocalTip(tip ochainsync.Tip) {
 	shouldEvaluate := false
 	cs.mutex.Lock()
+	if tip.BlockNumber > cs.localTipProgressBlock {
+		cs.localTipProgressBlock = tip.BlockNumber
+		cs.localTipProgressAt = cs.now()
+	}
 	cs.localTip = tip
 	shouldEvaluate = cs.advanceSelectionModeLocked()
 	cs.mutex.Unlock()
 	if shouldEvaluate {
 		cs.EvaluateAndSwitch()
 	}
+}
+
+// now returns the current time via the injectable clock. Must be called with
+// the mutex held (it reads cs.nowFn). Defaults to time.Now when nowFn is unset
+// (e.g. for selectors constructed without NewChainSelector in tests).
+func (cs *ChainSelector) now() time.Time {
+	if cs.nowFn != nil {
+		return cs.nowFn()
+	}
+	return time.Now()
 }
 
 // SetSecurityParam updates the security parameter (k) dynamically.
@@ -1009,6 +1065,101 @@ func (cs *ChainSelector) publishSelectionEvents(
 	}
 }
 
+// appliedLocalTipBlockLocked returns the block number of the last applied
+// local tip. Zero means SetLocalTip has never been called (near-genesis /
+// no-local-tip), in which case the anti-flap pin is inactive.
+func (cs *ChainSelector) appliedLocalTipBlockLocked() uint64 {
+	return cs.localTip.BlockNumber
+}
+
+// catchingUpLocked reports whether the node is in deep catch-up: the best
+// known peer tip is more than catchUpPinBlockThreshold blocks ahead of the
+// applied local tip. The pin engages in both regimes; this is used only for
+// diagnostics/logging to distinguish catch-up from tip-hold.
+func (cs *ChainSelector) catchingUpLocked() bool {
+	local := cs.appliedLocalTipBlockLocked()
+	if local == 0 {
+		return false
+	}
+	best := cs.bestKnownBlockNumber()
+	if best <= local {
+		return false
+	}
+	return best-local > catchUpPinBlockThreshold
+}
+
+// localTipStalledLocked reports whether the applied local tip has stopped
+// advancing for at least catchUpPinStallTimeout. This is the progress-aware
+// escape: when true, the pin releases so the node can switch away from a
+// dead/stalled incumbent. Returns false until forward progress has been
+// recorded at least once (localTipProgressAt is zero), so a freshly started
+// node never reports a stall before it has had a chance to apply a block.
+func (cs *ChainSelector) localTipStalledLocked() bool {
+	if cs.localTipProgressAt.IsZero() {
+		return false
+	}
+	return cs.now().Sub(cs.localTipProgressAt) >= catchUpPinStallTimeout
+}
+
+// pinIncumbentDuringCatchUpLocked decides whether to KEEP the incumbent active
+// connection (previousBest) instead of switching to challenger (newBest).
+//
+// This is the unified anti-flap incumbent pin. It applies whenever there is an
+// established, still-selectable incumbent and SetLocalTip has been called
+// (applied local tip > 0). It generalizes the "don't flap on a 1-block head
+// micro-fork" behavior to both regimes: deep catch-up and at/near the live
+// tip. The reference-implementation Praos comparison (longer chain, then lower
+// slot, then VRF/opcert) still governs which chain is canonically best; this
+// pin only suppresses the active-CONNECTION handoff between peers that are on
+// the same height / sibling head-forks, which would otherwise reset the
+// chainsync+blockfetch pipeline on nearly every tip update.
+//
+// The pin RELEASES (returns false, allow the switch) when:
+//   - SetLocalTip has never been called (applied local tip == 0) — keeps
+//     near-genesis behavior and existing tests unchanged.
+//   - the incumbent is no longer selectable (gone/disconnected/ineligible/
+//     stale/implausible).
+//   - the applied local tip has stalled past catchUpPinStallTimeout
+//     (progress-aware escape — cannot pin to a dead peer forever).
+//   - the challenger is genuinely ahead of the incumbent by more than
+//     catchUpPinHeadMargin blocks (a real longer chain, not a head micro-fork).
+//
+// Otherwise it PINS (returns true, keep the incumbent).
+//
+// Must be called with cs.mutex held.
+func (cs *ChainSelector) pinIncumbentDuringCatchUpLocked(
+	previousBest ouroboros.ConnectionId,
+	incumbentTip *PeerChainTip,
+	challengerTip *PeerChainTip,
+) bool {
+	// Inactive near genesis / before any local tip has been applied.
+	if cs.appliedLocalTipBlockLocked() == 0 {
+		return false
+	}
+	if incumbentTip == nil || challengerTip == nil {
+		return false
+	}
+	// Release if the incumbent is no longer a viable selection target.
+	if !cs.isPeerSelectableLocked(previousBest, incumbentTip, false) {
+		return false
+	}
+	// Progress-aware escape: never pin to a stalled incumbent forever.
+	if cs.localTipStalledLocked() {
+		return false
+	}
+	// Longer-chain escape: a challenger genuinely taller than the incumbent
+	// by more than the head margin is a real longer chain, not a sibling
+	// head-fork — release so the node converges to it promptly.
+	incumbentBlock := incumbentTip.SelectionTip().BlockNumber
+	challengerBlock := challengerTip.SelectionTip().BlockNumber
+	if challengerBlock > safeAddUint64(incumbentBlock, catchUpPinHeadMargin) {
+		return false
+	}
+	// Otherwise this is a head micro-fork / same-height sibling: pin the
+	// incumbent and do not hand off the pipeline.
+	return true
+}
+
 func (cs *ChainSelector) evaluateBestPeerLocked() (
 	bool,
 	*event.Event,
@@ -1043,17 +1194,40 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 				// or the reference implementation's equal-length Praos
 				// tiebreaker is not armed, keep following the incumbent.
 				newBest = previousBest
-			} else {
+			} else if cs.comparePeerTips(
+				*previousBest,
+				previousPeerTip,
+				*newBest,
+				newPeerTip,
+			) == ChainABetter {
 				// Preserve the incumbent only when it still wins the same
 				// full comparison used during normal best-peer selection.
-				if cs.comparePeerTips(
-					*previousBest,
-					previousPeerTip,
-					*newBest,
-					newPeerTip,
-				) == ChainABetter {
-					newBest = previousBest
-				}
+				newBest = previousBest
+			} else if cs.pinIncumbentDuringCatchUpLocked(
+				*previousBest,
+				previousPeerTip,
+				newPeerTip,
+			) {
+				// Anti-flap incumbent pin: the challenger is canonically
+				// "better" by the Praos rules, but only via a head micro-fork
+				// / same-height sibling (within catchUpPinHeadMargin). Keep the
+				// active connection on the incumbent rather than handing off
+				// the chainsync+blockfetch pipeline on a 1-block head fork.
+				// The longer-chain escape and the progress-stall escape inside
+				// the pin guarantee convergence to a genuinely longer chain and
+				// prevent pinning to a dead/stalled peer.
+				cs.config.Logger.Debug(
+					"pinning incumbent active connection (anti-flap)",
+					"incumbent", previousBest.String(),
+					"challenger", newBest.String(),
+					"incumbent_block",
+					previousPeerTip.SelectionTip().BlockNumber,
+					"challenger_block",
+					newPeerTip.SelectionTip().BlockNumber,
+					"applied_local_block", cs.appliedLocalTipBlockLocked(),
+					"catching_up", cs.catchingUpLocked(),
+				)
+				newBest = previousBest
 			}
 		}
 	}

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -133,11 +133,12 @@ type ChainSelector struct {
 
 	// Anti-flap incumbent pin state (guarded by mutex).
 	//
-	// localTipProgressBlock / localTipProgressAt record when the APPLIED
-	// local tip last advanced (moved forward in block number). The stall
-	// clock (catchUpPinStallTimeout) is measured from localTipProgressAt and
-	// is only reset on genuine forward progress, so repeated same-or-lower
-	// SetLocalTip calls never reset it.
+	// localTipProgressBlock records the previously observed APPLIED local tip
+	// block number. localTipProgressAt records when the applied tip last moved
+	// forward relative to that previous tip. The stall clock
+	// (catchUpPinStallTimeout) is measured from localTipProgressAt and is only
+	// reset on genuine forward progress, so repeated same-tip updates and
+	// rollbacks never reset it, while post-rollback advancement does.
 	localTipProgressBlock uint64
 	localTipProgressAt    time.Time
 	// nowFn is injectable for deterministic tests; defaults to time.Now.
@@ -625,16 +626,18 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 // It also records the last time the APPLIED local tip moved FORWARD (its
 // block number advanced). The anti-flap incumbent pin uses this timestamp as
 // a progress-aware escape: if the applied tip stops advancing while the pin
-// is engaged, the pin releases. Same-or-lower tip updates (including
-// rollbacks) deliberately do NOT reset the stall clock, so a stalled
-// incumbent cannot keep the pin alive by re-reporting an unchanged tip.
+// is engaged, the pin releases. Same-tip updates and rollbacks deliberately do
+// NOT reset the stall clock, so a stalled incumbent cannot keep the pin alive
+// by re-reporting an unchanged tip. Forward progress after a rollback does
+// reset the clock because the comparison is against the previous applied tip,
+// not an all-time high-water mark.
 func (cs *ChainSelector) SetLocalTip(tip ochainsync.Tip) {
 	shouldEvaluate := false
 	cs.mutex.Lock()
 	if tip.BlockNumber > cs.localTipProgressBlock {
-		cs.localTipProgressBlock = tip.BlockNumber
 		cs.localTipProgressAt = cs.now()
 	}
+	cs.localTipProgressBlock = tip.BlockNumber
 	cs.localTip = tip
 	shouldEvaluate = cs.advanceSelectionModeLocked()
 	cs.mutex.Unlock()

--- a/chainselection/tip_hold_test.go
+++ b/chainselection/tip_hold_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"testing"
+	"time"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock is a deterministic, mutable clock for exercising the progress-aware
+// stall escape without sleeping.
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) Advance(d time.Duration) { c.now = c.now.Add(d) }
+
+// installFakeClock swaps the selector's nowFn for a deterministic clock and
+// seeds the initial time. Must be called before any SetLocalTip that should
+// record progress at a known instant.
+func installFakeClock(cs *ChainSelector, c *fakeClock) {
+	cs.mutex.Lock()
+	cs.nowFn = c.Now
+	cs.mutex.Unlock()
+}
+
+// tip is a small helper to build a chainsync tip.
+func tip(block, slot uint64, hash string) ochainsync.Tip {
+	return ochainsync.Tip{
+		Point:       ocommon.Point{Slot: slot, Hash: []byte(hash)},
+		BlockNumber: block,
+	}
+}
+
+// TestPinNoSwitchOnMicroForkDuringCatchUp asserts that while the node is in
+// deep catch-up (gap > catchUpPinBlockThreshold), the active connection does
+// NOT flap across micro-forking equal-tip / 1-block-ahead peers.
+func TestPinNoSwitchOnMicroForkDuringCatchUp(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	// Local tip far behind both peers: catch-up regime.
+	cs.SetLocalTip(tip(1000, 1000, "local"))
+
+	// Incumbent established at block 1200 (gap 200 > threshold 100).
+	cs.UpdatePeerTip(incumbent, tip(1200, 1200, "inc-1200"), nil)
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Challenger leapfrogs to a sibling at the same height, then one block
+	// ahead, repeatedly. These are head micro-forks; the active connection
+	// must remain pinned to the incumbent.
+	cs.UpdatePeerTip(challenger, tip(1200, 1201, "chal-1200"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"must not switch on same-height sibling during catch-up")
+
+	cs.UpdatePeerTip(challenger, tip(1201, 1202, "chal-1201"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"must not switch on 1-block micro-fork during catch-up")
+
+	// Incumbent leapfrogs back ahead; still pinned to incumbent.
+	cs.UpdatePeerTip(incumbent, tip(1202, 1203, "inc-1202"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Confirm the pin is in the catch-up regime.
+	cs.mutex.RLock()
+	catchingUp := cs.catchingUpLocked()
+	cs.mutex.RUnlock()
+	assert.True(t, catchingUp, "expected catch-up regime for this scenario")
+}
+
+// TestPinNoSwitchOnSiblingHeadForkAtTip asserts that at/near the live tip
+// (gap < catchUpPinBlockThreshold), the active connection still does NOT flap
+// across same-height sibling head-forks. This is the Part 2 tip-hold case.
+func TestPinNoSwitchOnSiblingHeadForkAtTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	// Local tip at the head: gap is tiny, NOT catch-up.
+	cs.SetLocalTip(tip(5000, 5000, "local"))
+
+	cs.UpdatePeerTip(incumbent, tip(5001, 5001, "inc-5001"), nil)
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Sibling head-fork at the same height (different hash/slot). With no VRF
+	// data the Praos comparison is ChainEqual, so this is held by the existing
+	// equal-tip preservation — the active connection must not flap.
+	cs.UpdatePeerTip(challenger, tip(5001, 5002, "chal-5001"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"must not switch on same-height sibling at the tip")
+
+	// Challenger one block ahead (head micro-fork): selectBestChain prefers the
+	// taller challenger, and the anti-flap pin holds the incumbent.
+	cs.UpdatePeerTip(challenger, tip(5002, 5003, "chal-5002"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"must not switch on 1-block head micro-fork at the tip")
+	cs.UpdatePeerTip(challenger, tip(5003, 5004, "chal-5003"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Confirm we are NOT in the catch-up regime (tip-hold path exercised).
+	cs.mutex.RLock()
+	catchingUp := cs.catchingUpLocked()
+	cs.mutex.RUnlock()
+	assert.False(t, catchingUp, "expected tip-hold (non-catch-up) regime")
+}
+
+// TestPinSwitchesToGenuinelyLongerChainCatchUp asserts the longer-chain escape
+// fires during catch-up: a challenger beyond catchUpPinHeadMargin is a real
+// longer chain and the active connection switches to it.
+func TestPinSwitchesToGenuinelyLongerChainCatchUp(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(tip(1000, 1000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(1200, 1200, "inc-1200"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Challenger genuinely longer: ahead by more than catchUpPinHeadMargin.
+	cs.UpdatePeerTip(
+		challenger,
+		tip(1200+catchUpPinHeadMargin+1, 1300, "chal-long"),
+		nil,
+	)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challenger, *cs.GetBestPeer(),
+		"must converge to a genuinely longer chain during catch-up")
+}
+
+// TestPinSwitchesToGenuinelyLongerChainAtTip asserts the longer-chain escape
+// also fires at the tip.
+func TestPinSwitchesToGenuinelyLongerChainAtTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(tip(5000, 5000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(5001, 5001, "inc-5001"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	cs.UpdatePeerTip(
+		challenger,
+		tip(5001+catchUpPinHeadMargin+1, 5100, "chal-long"),
+		nil,
+	)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challenger, *cs.GetBestPeer(),
+		"must converge to a genuinely longer chain at the tip")
+}
+
+// TestPinAtMarginBoundary verifies the exact margin boundary: a challenger
+// exactly catchUpPinHeadMargin ahead stays pinned, one block more releases.
+func TestPinAtMarginBoundary(t *testing.T) {
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	// Exactly at the margin: pinned.
+	cs := NewChainSelector(ChainSelectorConfig{})
+	cs.SetLocalTip(tip(5000, 5000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(5001, 5001, "inc"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+	cs.UpdatePeerTip(
+		challenger,
+		tip(5001+catchUpPinHeadMargin, 5050, "chal-at"),
+		nil,
+	)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"challenger exactly at the margin must stay pinned")
+
+	// One block past the margin: released.
+	cs2 := NewChainSelector(ChainSelectorConfig{})
+	cs2.SetLocalTip(tip(5000, 5000, "local"))
+	cs2.UpdatePeerTip(incumbent, tip(5001, 5001, "inc"), nil)
+	require.Equal(t, incumbent, *cs2.GetBestPeer())
+	cs2.UpdatePeerTip(
+		challenger,
+		tip(5001+catchUpPinHeadMargin+1, 5050, "chal-past"),
+		nil,
+	)
+	assert.Equal(t, challenger, *cs2.GetBestPeer(),
+		"challenger one block past the margin must release the pin")
+}
+
+// TestPinProgressStallEscape asserts the progress-aware escape: when the
+// applied local tip stops advancing for catchUpPinStallTimeout, the pin
+// releases and the active connection switches to the challenger sibling.
+func TestPinProgressStallEscape(t *testing.T) {
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	cs := NewChainSelector(ChainSelectorConfig{})
+	installFakeClock(cs, clk)
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	// Record forward progress at t0. The challenger runs one block ahead of
+	// the incumbent (a head micro-fork within catchUpPinHeadMargin), so it is
+	// the canonically Praos-better chain (higher block number). Only the
+	// anti-flap pin keeps the incumbent active; once the pin releases the
+	// taller challenger is selected.
+	cs.SetLocalTip(tip(5000, 5000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(5001, 5001, "inc-5001"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Challenger one block ahead (head micro-fork): pinned (no progress yet,
+	// but not yet stalled).
+	cs.UpdatePeerTip(challenger, tip(5002, 5002, "chal-5002"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Repeated same-or-lower local tip updates must NOT reset the stall clock.
+	cs.SetLocalTip(tip(5000, 5000, "local-again"))
+	cs.mutex.RLock()
+	progressAt := cs.localTipProgressAt
+	cs.mutex.RUnlock()
+	assert.Equal(t, clk.now, progressAt,
+		"same-tip SetLocalTip must not reset the stall clock")
+
+	// Just under the timeout: still pinned.
+	clk.Advance(catchUpPinStallTimeout - time.Second)
+	cs.UpdatePeerTip(challenger, tip(5002, 5003, "chal-5002b"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"must stay pinned before the stall timeout elapses")
+
+	// Past the timeout: the applied tip has stalled, the pin releases and the
+	// taller challenger is selected.
+	clk.Advance(2 * time.Second)
+	cs.UpdatePeerTip(challenger, tip(5003, 5004, "chal-5003"), nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challenger, *cs.GetBestPeer(),
+		"stall escape must release the pin after the timeout")
+}
+
+// TestPinStallClockResetsOnForwardProgress asserts that forward progress
+// re-arms the stall clock, so a healthy, advancing incumbent stays pinned
+// indefinitely across sibling head-forks.
+func TestPinStallClockResetsOnForwardProgress(t *testing.T) {
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	cs := NewChainSelector(ChainSelectorConfig{})
+	installFakeClock(cs, clk)
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(tip(5000, 5000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(5001, 5001, "inc"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+	// Challenger one block ahead (head micro-fork) so the pin is what holds
+	// the incumbent (selectBestChain prefers the taller challenger).
+	cs.UpdatePeerTip(challenger, tip(5002, 5002, "chal"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Advance almost to the timeout, then apply a new block (forward progress).
+	clk.Advance(catchUpPinStallTimeout - time.Second)
+	cs.SetLocalTip(tip(5001, 5005, "local-advance"))
+
+	// Advance another near-timeout window. Because progress re-armed the
+	// clock, the incumbent is still pinned.
+	clk.Advance(catchUpPinStallTimeout - time.Second)
+	cs.UpdatePeerTip(challenger, tip(5002, 5006, "chal-b"), nil)
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"forward progress must re-arm the stall clock and keep the pin")
+}
+
+// TestPinReleasesWhenIncumbentNoLongerSelectable asserts that an ineligible
+// incumbent releases the pin even on a head micro-fork.
+func TestPinReleasesWhenIncumbentNoLongerSelectable(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(tip(5000, 5000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(5001, 5001, "inc"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+	// Challenger one block ahead (head micro-fork): the pin holds the
+	// incumbent while it is selectable.
+	cs.UpdatePeerTip(challenger, tip(5002, 5002, "chal"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// Incumbent becomes ineligible: pin must release.
+	cs.SetConnectionEligible(incumbent, false)
+	switched := cs.EvaluateAndSwitch()
+	assert.True(t, switched)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challenger, *cs.GetBestPeer(),
+		"ineligible incumbent must release the pin")
+}
+
+// TestPinInactiveWithoutLocalTip asserts near-genesis behavior is unchanged:
+// when SetLocalTip has never been called, the pin is inactive and a 1-block
+// lead switches the active connection (matching the legacy behavior asserted
+// by TestIncumbentAdvantageSwitchesOnOneBlockLead).
+func TestPinInactiveWithoutLocalTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	// No SetLocalTip: localTip.BlockNumber == 0, pin inactive.
+	cs.UpdatePeerTip(incumbent, tip(50, 100, "inc"), nil)
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	// 1-block lead: must switch because the pin is inactive near genesis.
+	cs.UpdatePeerTip(challenger, tip(51, 101, "chal"), nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, challenger, *cs.GetBestPeer(),
+		"pin must be inactive without a local tip (near-genesis)")
+
+	// Confirm catchingUpLocked is false with no local tip.
+	cs.mutex.RLock()
+	catchingUp := cs.catchingUpLocked()
+	stalled := cs.localTipStalledLocked()
+	cs.mutex.RUnlock()
+	assert.False(t, catchingUp)
+	assert.False(t, stalled,
+		"stall must be false before any forward progress is recorded")
+}

--- a/chainselection/tip_hold_test.go
+++ b/chainselection/tip_hold_test.go
@@ -286,6 +286,46 @@ func TestPinStallClockResetsOnForwardProgress(t *testing.T) {
 		"forward progress must re-arm the stall clock and keep the pin")
 }
 
+// TestPinStallClockResetsOnPostRollbackProgress asserts that progress tracking
+// compares against the previous applied local tip, not the all-time high-water
+// mark. After 1000 -> 990 rollback, 991 is forward progress and must re-arm the
+// stall clock.
+func TestPinStallClockResetsOnPostRollbackProgress(t *testing.T) {
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	cs := NewChainSelector(ChainSelectorConfig{})
+	installFakeClock(cs, clk)
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(tip(1000, 1000, "local"))
+	cs.UpdatePeerTip(incumbent, tip(1001, 1001, "inc"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+	cs.UpdatePeerTip(challenger, tip(1002, 1002, "chal"), nil)
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	clk.Advance(catchUpPinStallTimeout - time.Second)
+	cs.SetLocalTip(tip(990, 1003, "local-rollback"))
+	cs.mutex.RLock()
+	rollbackProgressAt := cs.localTipProgressAt
+	cs.mutex.RUnlock()
+	assert.Equal(t, time.Unix(1_700_000_000, 0), rollbackProgressAt,
+		"rollback must not reset the stall clock")
+
+	cs.SetLocalTip(tip(991, 1004, "local-reapply"))
+	cs.mutex.RLock()
+	reapplyProgressAt := cs.localTipProgressAt
+	cs.mutex.RUnlock()
+	assert.Equal(t, clk.now, reapplyProgressAt,
+		"post-rollback forward progress must reset the stall clock")
+
+	clk.Advance(2 * time.Second)
+	cs.UpdatePeerTip(challenger, tip(1002, 1005, "chal-b"), nil)
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, incumbent, *cs.GetBestPeer(),
+		"post-rollback forward progress must keep the pin while moving again")
+}
+
 // TestPinReleasesWhenIncumbentNoLongerSelectable asserts that an ineligible
 // incumbent releases the pin even on a head micro-fork.
 func TestPinReleasesWhenIncumbentNoLongerSelectable(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the active peer when others are at the same tip or within a tiny head micro-fork to stop flapping and keep ChainSync/BlockFetch stable during catch-up and at the live tip. Still converges to the real longest chain via clear release conditions.

- **New Features**
  - Added an anti-flap pin in `chainselection/selector.go` that keeps the incumbent active when the challenger is at the same height or within `catchUpPinHeadMargin` (2 blocks), once a local tip exists.
  - Releases the pin when: no local tip yet; incumbent becomes unselectable; challenger is >2 blocks ahead; or the applied local tip has stalled for `catchUpPinStallTimeout` (20s, wall-clock).
  - Preserves Praos comparison; added `chainselection/tip_hold_test.go` and updated `ARCHITECTURE.md`; `SetLocalTip` uses an injectable `nowFn` for deterministic timing.

- **Bug Fixes**
  - Rollbacks and same-tip updates no longer count as forward progress; the stall clock only resets on true advancement (and after post-rollback progress).

<sup>Written for commit b7eb5c677359b261c08d2fe27e60718344469127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter chain selection behavior to reduce rapid peer switching during small reorganizations and catch-up.
  * Improved stability by keeping the current peer in place when changes are only minor head forks, while still allowing a switch to a clearly better chain.

* **Bug Fixes**
  * Prevents unnecessary pipeline resets that could slow or stall ledger progress during deep catch-up.
  * Ensures the selector still converges when progress stops, a stronger chain appears, or the current peer is no longer suitable.

* **Tests**
  * Added coverage for micro-forks, margin boundaries, stall recovery, and peer release conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->