### PR TITLE
fix(ledger): vrf result proof

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -103,8 +103,18 @@ func verifyBlockHeaderHex(
 		SkipStakePoolValidation:   true,
 	}
 
+	header, err := normalizeHeaderVrfResultFromBodyCbor(block.Header())
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification failed at slot %d: "+
+				"normalize VRF result from header body CBOR: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+
 	isValid, _, _, _, err := ledger.VerifyBlock(
-		block,
+		headerOnlyBlock{header: header},
 		epochNonceHex,
 		slotsPerKesPeriod,
 		config,

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
 	"io"
@@ -271,6 +272,41 @@ func TestVerifyBlockHeader_ValidBlock(t *testing.T) {
 	tb := createTestBlock(t, [32]byte{1}, 0, tamperNone)
 	err := verifyBlockHeader(tb.block, tb.epochNonce, tb.slotsPerKesPeriod)
 	assert.NoError(t, err, "valid block should pass verification")
+}
+
+// TestVerifyBlockHeader_UsesBodyCBORVRFResult verifies that header crypto
+// verification is driven by the original header-body CBOR, not by stale typed
+// VrfResult fields on the decoded header object.
+func TestVerifyBlockHeader_UsesBodyCBORVRFResult(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{5}, 11, tamperNone)
+	header := tb.block.header
+	require.NotEmpty(t, header.Body.Cbor())
+
+	originalOutput := cloneBytes(header.Body.VrfResult.Output)
+	originalProof := cloneBytes(header.Body.VrfResult.Proof)
+	staleOutput := bytes.Repeat([]byte{0x44}, len(originalOutput))
+	staleProof := bytes.Repeat([]byte{0x55}, len(originalProof))
+	require.False(t, bytes.Equal(originalOutput, staleOutput))
+	require.False(t, bytes.Equal(originalProof, staleProof))
+
+	header.Body.VrfResult.Output = staleOutput
+	header.Body.VrfResult.Proof = staleProof
+
+	normalized, err := normalizeHeaderVrfResultFromBodyCbor(header)
+	require.NoError(t, err)
+	normalizedHeader, ok := normalized.(*babbage.BabbageBlockHeader)
+	require.True(t, ok)
+	assert.Equal(t, originalOutput, normalizedHeader.Body.VrfResult.Output)
+	assert.Equal(t, originalProof, normalizedHeader.Body.VrfResult.Proof)
+
+	err = verifyBlockHeader(tb.block, tb.epochNonce, tb.slotsPerKesPeriod)
+	assert.NoError(
+		t,
+		err,
+		"valid header should pass even when decoded VrfResult is stale",
+	)
+	assert.Equal(t, staleOutput, header.Body.VrfResult.Output)
+	assert.Equal(t, staleProof, header.Body.VrfResult.Proof)
 }
 
 // TestVerifyBlockHeader_TamperedKESSignature tests that a block with a

--- a/ledger/verify_header_vrf.go
+++ b/ledger/verify_header_vrf.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+const (
+	praosVrfResultBodyIndex  = 5
+	tpraosLeaderVrfBodyIndex = 6
+	vrfResultFieldCount      = 2
+)
+
+// normalizeHeaderVrfResultFromBodyCbor returns a shallow header copy whose
+// typed VRF result is derived from the original header-body CBOR. Chainsync
+// and block decoders keep those original bytes for KES verification; using the
+// same source for VRF avoids rejecting canonical headers when a decoded
+// VrfResult field is stale or otherwise inconsistent with the wire bytes.
+func normalizeHeaderVrfResultFromBodyCbor(
+	header ledger.BlockHeader,
+) (ledger.BlockHeader, error) {
+	vrfResult, ok, err := headerVrfResultFromBodyCbor(header)
+	if err != nil || !ok {
+		return header, err
+	}
+	return headerWithVrfResult(header, vrfResult), nil
+}
+
+func headerVrfResultFromBodyCbor(
+	header ledger.BlockHeader,
+) (lcommon.VrfResult, bool, error) {
+	var (
+		bodyCbor []byte
+		index    int
+	)
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = tpraosLeaderVrfBodyIndex
+	case *allegra.AllegraBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = tpraosLeaderVrfBodyIndex
+	case *mary.MaryBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = tpraosLeaderVrfBodyIndex
+	case *alonzo.AlonzoBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = tpraosLeaderVrfBodyIndex
+	case *babbage.BabbageBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = praosVrfResultBodyIndex
+	case *conway.ConwayBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = praosVrfResultBodyIndex
+	case *dijkstra.DijkstraBlockHeader:
+		bodyCbor = h.Body.Cbor()
+		index = praosVrfResultBodyIndex
+	default:
+		return lcommon.VrfResult{}, false, nil
+	}
+	if len(bodyCbor) == 0 {
+		return lcommon.VrfResult{}, false, nil
+	}
+	vrfResult, err := decodeVrfResultFromHeaderBodyCbor(bodyCbor, index)
+	if err != nil {
+		return lcommon.VrfResult{}, false, err
+	}
+	return vrfResult, true, nil
+}
+
+func decodeVrfResultFromHeaderBodyCbor(
+	bodyCbor []byte,
+	index int,
+) (lcommon.VrfResult, error) {
+	decoder, err := cbor.NewStreamDecoder(bodyCbor)
+	if err != nil {
+		return lcommon.VrfResult{}, err
+	}
+	fieldCount, _, _, err := decoder.DecodeArrayHeader()
+	if err != nil {
+		return lcommon.VrfResult{}, err
+	}
+	if index >= fieldCount {
+		return lcommon.VrfResult{}, fmt.Errorf(
+			"header body has %d fields, cannot read VRF result at index %d",
+			fieldCount,
+			index,
+		)
+	}
+	if _, _, err := decoder.SkipN(index); err != nil {
+		return lcommon.VrfResult{}, fmt.Errorf(
+			"skip header body fields before VRF result: %w",
+			err,
+		)
+	}
+	var fields []cbor.RawMessage
+	if _, _, err := decoder.Decode(&fields); err != nil {
+		return lcommon.VrfResult{}, fmt.Errorf(
+			"decode raw VRF result: %w",
+			err,
+		)
+	}
+	if len(fields) != vrfResultFieldCount {
+		return lcommon.VrfResult{}, fmt.Errorf(
+			"VRF result has %d fields, expected %d",
+			len(fields),
+			vrfResultFieldCount,
+		)
+	}
+	var output []byte
+	if _, err := cbor.Decode(fields[0], &output); err != nil {
+		return lcommon.VrfResult{}, fmt.Errorf(
+			"decode VRF output bytes: %w",
+			err,
+		)
+	}
+	var proof []byte
+	if _, err := cbor.Decode(fields[1], &proof); err != nil {
+		return lcommon.VrfResult{}, fmt.Errorf(
+			"decode VRF proof bytes: %w",
+			err,
+		)
+	}
+	return lcommon.VrfResult{
+		Output: cloneBytes(output),
+		Proof:  cloneBytes(proof),
+	}, nil
+}
+
+func headerWithVrfResult(
+	header ledger.BlockHeader,
+	vrfResult lcommon.VrfResult,
+) ledger.BlockHeader {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		clone := *h
+		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
+		return &clone
+	case *allegra.AllegraBlockHeader:
+		clone := *h
+		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
+		return &clone
+	case *mary.MaryBlockHeader:
+		clone := *h
+		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
+		return &clone
+	case *alonzo.AlonzoBlockHeader:
+		clone := *h
+		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
+		return &clone
+	case *babbage.BabbageBlockHeader:
+		clone := *h
+		clone.Body.VrfResult = cloneVrfResult(vrfResult)
+		return &clone
+	case *conway.ConwayBlockHeader:
+		clone := *h
+		clone.Body.VrfResult = cloneVrfResult(vrfResult)
+		return &clone
+	case *dijkstra.DijkstraBlockHeader:
+		clone := *h
+		clone.Body.VrfResult = cloneVrfResult(vrfResult)
+		return &clone
+	default:
+		return header
+	}
+}
+
+func cloneVrfResult(vrfResult lcommon.VrfResult) lcommon.VrfResult {
+	return lcommon.VrfResult{
+		Output: cloneBytes(vrfResult.Output),
+		Proof:  cloneBytes(vrfResult.Proof),
+	}
+}
+
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes block header verification by deriving VRF output and proof from the header-body CBOR before validation. This prevents rejecting valid headers when decoded `VrfResult` fields are stale.

- **Bug Fixes**
  - Added `normalizeHeaderVrfResultFromBodyCbor` to read canonical VRF bytes from header-body CBOR (era-aware: index 6 for Shelley/Allegra/Mary/Alonzo, index 5 for Babbage/Conway/Dijkstra).
  - Use the normalized header in `verifyBlockHeader` via `headerOnlyBlock` to ensure crypto checks use wire bytes.
  - Added a test that tampers decoded VRF fields and confirms verification still passes using the CBOR-derived values.

<sup>Written for commit caf60117a027b9a671bf1ca3ae07d4435f866e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

