### PR TITLE
fix(koios): Koios-backed reward parity checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -566,6 +566,7 @@ dingo/
 │   ├── test/            # Test utilities
 │   │   ├── conformance/ # Amaru conformance tests
 │   │   ├── devnet/      # DevNet end-to-end tests
+│   │   ├── koios/       # Koios reward parity checker (preview/preprod)
 │   │   └── testutil/    # Shared test helpers
 │   └── version/         # Version information
 ├── node.go              # Node struct definition, Run(), shutdown

--- a/internal/test/koios/client.go
+++ b/internal/test/koios/client.go
@@ -164,15 +164,17 @@ func (c *Client) post(ctx context.Context, path string, body any, out any) error
 	return c.do(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(buf), out)
 }
 
-// do performs the HTTP request with up to 3 retries on 429 Too Many Requests.
+// do performs the HTTP request with up to 3 retries (4 total attempts) on
+// 429 Too Many Requests. No wait is inserted after the final attempt.
 func (c *Client) do(
 	ctx context.Context,
 	method, rawURL string,
 	body io.ReadSeeker,
 	out any,
 ) error {
-	const maxRetries = 3
-	for attempt := range maxRetries {
+	// maxAttempts = 1 initial + 3 retries.
+	const maxAttempts = 4
+	for attempt := range maxAttempts {
 		if attempt > 0 && body != nil {
 			if _, err := body.Seek(0, io.SeekStart); err != nil {
 				return fmt.Errorf("rewind request body: %w", err)
@@ -198,6 +200,10 @@ func (c *Client) do(
 
 		if resp.StatusCode == http.StatusTooManyRequests {
 			_ = resp.Body.Close()
+			// Don't wait after the last attempt; fall through to the error.
+			if attempt == maxAttempts-1 {
+				break
+			}
 			wait := time.Duration(attempt+1) * 2 * time.Second
 			if ra := resp.Header.Get("Retry-After"); ra != "" {
 				if secs, parseErr := strconv.Atoi(ra); parseErr == nil {
@@ -225,7 +231,7 @@ func (c *Client) do(
 		}
 		return json.Unmarshal(data, out)
 	}
-	return fmt.Errorf("koios %s %s: exceeded %d retries", method, rawURL, maxRetries)
+	return fmt.Errorf("koios %s %s: exceeded %d attempts", method, rawURL, maxAttempts)
 }
 
 func truncate(b []byte, n int) string {

--- a/internal/test/koios/client.go
+++ b/internal/test/koios/client.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package koios provides a lightweight Koios REST API client and reward
+// parity checker for comparing Dingo's closed-epoch reward state against the
+// Koios public API on preview and preprod networks.
+package koios
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	NetworkPreview = "preview"
+	NetworkPreprod = "preprod"
+)
+
+var baseURLs = map[string]string{
+	NetworkPreview: "https://preview.koios.rest/api/v1",
+	NetworkPreprod: "https://preprod.koios.rest/api/v1",
+}
+
+// Client is a minimal Koios REST API client that supports the endpoints
+// needed for epoch-level reward parity checks.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	network    string
+	apiKey     string // optional Bearer token for higher rate limits
+}
+
+// NewClient constructs a Client for the named network (preview|preprod).
+// Pass an empty apiKey to use anonymous, rate-limited access.
+func NewClient(network, apiKey string) (*Client, error) {
+	base, ok := baseURLs[network]
+	if !ok {
+		return nil, fmt.Errorf(
+			"unknown network %q: want %q or %q",
+			network, NetworkPreview, NetworkPreprod,
+		)
+	}
+	return &Client{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    base,
+		network:    network,
+		apiKey:     apiKey,
+	}, nil
+}
+
+// EpochInfo is a single record from the Koios /epoch_info endpoint.
+// Fields that are null before an epoch's snapshot is ready are pointers.
+type EpochInfo struct {
+	EpochNo      uint64  `json:"epoch_no"`
+	Fees         string  `json:"fees"`
+	ActiveStake  *string `json:"active_stake"`
+	TotalRewards *string `json:"total_rewards"`
+	PoolCnt      *int64  `json:"pool_cnt"`
+	DelegatorCnt *int64  `json:"delegator_cnt"`
+}
+
+// PoolHistoryEntry is a single record from the Koios /pool_history endpoint.
+type PoolHistoryEntry struct {
+	EpochNo     uint64  `json:"epoch_no"`
+	ActiveStake string  `json:"active_stake"`
+	BlockCnt    *uint64 `json:"block_cnt"`
+	Delegators  *uint64 `json:"delegators"`
+}
+
+// AccountInfo is a single record from the Koios /account_info endpoint.
+type AccountInfo struct {
+	StakeAddress     string `json:"stake_address"`
+	Status           string `json:"status"`
+	RewardsAvailable string `json:"rewards_available"`
+}
+
+// GetEpochInfo fetches epoch aggregate data for the given epoch number.
+// Returns nil, nil when Koios has no data for the epoch yet.
+func (c *Client) GetEpochInfo(ctx context.Context, epoch uint64) (*EpochInfo, error) {
+	params := url.Values{
+		"_epoch_no":           {strconv.FormatUint(epoch, 10)},
+		"_include_next_epoch": {"false"},
+	}
+	var results []EpochInfo
+	if err := c.get(ctx, "/epoch_info", params, &results); err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return &results[0], nil
+}
+
+// GetPoolHistory fetches per-epoch pool performance data.
+// Returns nil, nil when Koios has no entry for that pool/epoch combination.
+func (c *Client) GetPoolHistory(
+	ctx context.Context,
+	poolBech32 string,
+	epoch uint64,
+) (*PoolHistoryEntry, error) {
+	params := url.Values{
+		"_pool_bech32": {poolBech32},
+		"_epoch_no":    {strconv.FormatUint(epoch, 10)},
+	}
+	var results []PoolHistoryEntry
+	if err := c.get(ctx, "/pool_history", params, &results); err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return &results[0], nil
+}
+
+// GetAccountInfo fetches current account balances for up to 50 stake addresses
+// in a single request. Callers must batch larger sets themselves.
+func (c *Client) GetAccountInfo(
+	ctx context.Context,
+	stakeAddresses []string,
+) ([]AccountInfo, error) {
+	body := map[string]any{"_stake_addresses": stakeAddresses}
+	var results []AccountInfo
+	if err := c.post(ctx, "/account_info", body, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// get issues a GET request with query parameters and decodes the JSON response.
+func (c *Client) get(
+	ctx context.Context,
+	path string,
+	params url.Values,
+	out any,
+) error {
+	rawURL := c.baseURL + path + "?" + params.Encode()
+	return c.do(ctx, http.MethodGet, rawURL, nil, out)
+}
+
+// post issues a POST request with a JSON body and decodes the JSON response.
+func (c *Client) post(ctx context.Context, path string, body any, out any) error {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+	return c.do(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(buf), out)
+}
+
+// do performs the HTTP request with up to 3 retries on 429 Too Many Requests.
+func (c *Client) do(
+	ctx context.Context,
+	method, rawURL string,
+	body io.ReadSeeker,
+	out any,
+) error {
+	const maxRetries = 3
+	for attempt := range maxRetries {
+		if attempt > 0 && body != nil {
+			if _, err := body.Seek(0, io.SeekStart); err != nil {
+				return fmt.Errorf("rewind request body: %w", err)
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
+		if err != nil {
+			return fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if c.apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("koios %s %s: %w", method, rawURL, err)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close()
+			wait := time.Duration(attempt+1) * 2 * time.Second
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, parseErr := strconv.Atoi(ra); parseErr == nil {
+					wait = time.Duration(secs) * time.Second
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		data, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return fmt.Errorf("read response body: %w", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf(
+				"koios %s %s: HTTP %d: %s",
+				method, rawURL, resp.StatusCode, truncate(data, 200),
+			)
+		}
+		return json.Unmarshal(data, out)
+	}
+	return fmt.Errorf("koios %s %s: exceeded %d retries", method, rawURL, maxRetries)
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/internal/test/koios/parity.go
+++ b/internal/test/koios/parity.go
@@ -1,0 +1,412 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koios
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/btcsuite/btcd/btcutil/bech32"
+	"gorm.io/gorm"
+)
+
+// Mismatch records a single field discrepancy between Dingo and Koios.
+type Mismatch struct {
+	// Epoch is always set.
+	Epoch uint64
+	// Pool is set for pool-level mismatches (bech32 pool ID).
+	Pool string
+	// Account is set for account-level mismatches (bech32 stake address).
+	Account string
+	// Field is the name of the mismatched attribute.
+	Field string
+	// Dingo is the value held in the local Dingo database.
+	Dingo string
+	// Koios is the value returned by the Koios API.
+	Koios string
+}
+
+func (m Mismatch) String() string {
+	who := fmt.Sprintf("epoch=%d", m.Epoch)
+	if m.Pool != "" {
+		who += " pool=" + m.Pool
+	}
+	if m.Account != "" {
+		who += " account=" + m.Account
+	}
+	return fmt.Sprintf("%s field=%s dingo=%s koios=%s", who, m.Field, m.Dingo, m.Koios)
+}
+
+// Report is the result of a full parity run.
+type Report struct {
+	EpochsChecked   int
+	PoolsChecked    int
+	AccountsChecked int
+	Mismatches      []Mismatch
+}
+
+// Checker compares Dingo's closed-epoch reward state against Koios.
+// Open the Dingo SQLite database with gorm before creating a Checker:
+//
+//	db, _ := gorm.Open(sqlite.Open(path+"?mode=ro"), &gorm.Config{...})
+//	checker, _ := koios.NewChecker(db, koios.NetworkPreview, "")
+type Checker struct {
+	db      *gorm.DB
+	koios   *Client
+	network string
+}
+
+// NewChecker constructs a Checker using an open GORM connection and the named
+// Koios network (preview|preprod). Pass apiKey="" for anonymous (rate-limited)
+// access.
+func NewChecker(db *gorm.DB, network, apiKey string) (*Checker, error) {
+	client, err := NewClient(network, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &Checker{db: db, koios: client, network: network}, nil
+}
+
+// Run checks all closed epochs in the Dingo database against Koios.
+//
+// Only epochs with EpochSummary.SnapshotReady = true are examined (closed
+// epochs). The current (live) epoch is never included even if it happens to
+// appear in the table.
+//
+// maxPoolsPerEpoch limits how many RewardPoolInputs are sampled per epoch (0
+// disables pool-level checks). maxAccounts limits the sampled stake addresses
+// for balance checks (0 disables account-level checks). A courtesy delay is
+// inserted between Koios requests to stay within public rate limits.
+func (c *Checker) Run(
+	ctx context.Context,
+	maxPoolsPerEpoch int,
+	maxAccounts int,
+) (*Report, error) {
+	report := &Report{}
+
+	// Fetch all closed epoch summaries from Dingo.
+	var summaries []models.EpochSummary
+	if err := c.db.
+		Where("snapshot_ready = ?", true).
+		Order("epoch asc").
+		Find(&summaries).Error; err != nil {
+		return nil, fmt.Errorf("query epoch summaries: %w", err)
+	}
+
+	// Sample account addresses once; reuse across the full check.
+	var sampleAccounts []models.Account
+	if maxAccounts > 0 {
+		if err := c.db.
+			Where("active = ?", true).
+			Order("staking_key asc").
+			Limit(maxAccounts).
+			Find(&sampleAccounts).Error; err != nil {
+			return nil, fmt.Errorf("query sample accounts: %w", err)
+		}
+	}
+
+	// Run epoch-level and pool-level checks for every closed epoch.
+	for _, summary := range summaries {
+		ms, poolsChecked, err := c.checkEpoch(ctx, summary, maxPoolsPerEpoch)
+		if err != nil {
+			return nil, fmt.Errorf("epoch %d: %w", summary.Epoch, err)
+		}
+		report.EpochsChecked++
+		report.PoolsChecked += poolsChecked
+		report.Mismatches = append(report.Mismatches, ms...)
+	}
+
+	// Run account-level checks (current withdrawable balance only; per-epoch
+	// reward history requires #1875 before it can be compared).
+	if len(sampleAccounts) > 0 {
+		ms, err := c.checkAccounts(ctx, sampleAccounts)
+		if err != nil {
+			return nil, fmt.Errorf("check accounts: %w", err)
+		}
+		report.AccountsChecked = len(sampleAccounts)
+		report.Mismatches = append(report.Mismatches, ms...)
+	}
+
+	return report, nil
+}
+
+// checkEpoch compares EpochSummary aggregate fields and a sample of
+// RewardPoolInputs against Koios for a single closed epoch.
+func (c *Checker) checkEpoch(
+	ctx context.Context,
+	summary models.EpochSummary,
+	maxPools int,
+) (mismatches []Mismatch, poolsChecked int, _ error) {
+	epoch := summary.Epoch
+
+	// Courtesy delay between epochs.
+	time.Sleep(300 * time.Millisecond)
+
+	info, err := c.koios.GetEpochInfo(ctx, epoch)
+	if err != nil {
+		return nil, 0, fmt.Errorf("GetEpochInfo: %w", err)
+	}
+	if info == nil {
+		// Koios does not have data for this epoch yet; skip silently.
+		return nil, 0, nil
+	}
+
+	// active_stake
+	if info.ActiveStake != nil {
+		kStake := *info.ActiveStake
+		dStake := strconv.FormatUint(uint64(summary.TotalActiveStake), 10)
+		if kStake != dStake {
+			mismatches = append(mismatches, Mismatch{
+				Epoch: epoch,
+				Field: "total_active_stake",
+				Dingo: dStake,
+				Koios: kStake,
+			})
+		}
+	}
+
+	// pool_cnt
+	if info.PoolCnt != nil {
+		kCnt := strconv.FormatInt(*info.PoolCnt, 10)
+		dCnt := strconv.FormatUint(summary.TotalPoolCount, 10)
+		if kCnt != dCnt {
+			mismatches = append(mismatches, Mismatch{
+				Epoch: epoch,
+				Field: "pool_count",
+				Dingo: dCnt,
+				Koios: kCnt,
+			})
+		}
+	}
+
+	// delegator_cnt
+	if info.DelegatorCnt != nil {
+		kCnt := strconv.FormatInt(*info.DelegatorCnt, 10)
+		dCnt := strconv.FormatUint(summary.TotalDelegators, 10)
+		if kCnt != dCnt {
+			mismatches = append(mismatches, Mismatch{
+				Epoch: epoch,
+				Field: "delegator_count",
+				Dingo: dCnt,
+				Koios: kCnt,
+			})
+		}
+	}
+
+	// Pool-level checks.
+	poolMs, poolsChecked, err := c.checkEpochPools(ctx, epoch, maxPools)
+	if err != nil {
+		return nil, 0, err
+	}
+	mismatches = append(mismatches, poolMs...)
+
+	return mismatches, poolsChecked, nil
+}
+
+// checkEpochPools compares up to maxPools RewardPoolInputs for epoch against
+// Koios /pool_history.
+func (c *Checker) checkEpochPools(
+	ctx context.Context,
+	epoch uint64,
+	maxPools int,
+) ([]Mismatch, int, error) {
+	if maxPools <= 0 {
+		return nil, 0, nil
+	}
+
+	var inputs []models.RewardPoolInput
+	if err := c.db.
+		Where("epoch = ?", epoch).
+		Order("pool_key_hash asc").
+		Limit(maxPools).
+		Find(&inputs).Error; err != nil {
+		return nil, 0, fmt.Errorf("query reward pool inputs: %w", err)
+	}
+
+	var mismatches []Mismatch
+	for _, input := range inputs {
+		poolID := lcommon.PoolId(lcommon.NewBlake2b224(input.PoolKeyHash)).String()
+
+		// Courtesy delay per pool request.
+		time.Sleep(150 * time.Millisecond)
+
+		entry, err := c.koios.GetPoolHistory(ctx, poolID, epoch)
+		if err != nil {
+			return nil, 0, fmt.Errorf("GetPoolHistory %s epoch %d: %w", poolID, epoch, err)
+		}
+		if entry == nil {
+			continue // pool not present in Koios for this epoch
+		}
+
+		// delegated_stake / active_stake (lovelace)
+		dStake := strconv.FormatUint(uint64(input.DelegatedStake), 10)
+		if entry.ActiveStake != dStake {
+			mismatches = append(mismatches, Mismatch{
+				Epoch: epoch,
+				Pool:  poolID,
+				Field: "delegated_stake",
+				Dingo: dStake,
+				Koios: entry.ActiveStake,
+			})
+		}
+
+		// delegator_count
+		if entry.Delegators != nil {
+			kDel := strconv.FormatUint(*entry.Delegators, 10)
+			dDel := strconv.FormatUint(input.DelegatorCount, 10)
+			if kDel != dDel {
+				mismatches = append(mismatches, Mismatch{
+					Epoch: epoch,
+					Pool:  poolID,
+					Field: "delegator_count",
+					Dingo: dDel,
+					Koios: kDel,
+				})
+			}
+		}
+
+		// blocks_produced
+		if input.BlocksProduced != nil && entry.BlockCnt != nil {
+			kBlk := strconv.FormatUint(*entry.BlockCnt, 10)
+			dBlk := strconv.FormatUint(*input.BlocksProduced, 10)
+			if kBlk != dBlk {
+				mismatches = append(mismatches, Mismatch{
+					Epoch: epoch,
+					Pool:  poolID,
+					Field: "blocks_produced",
+					Dingo: dBlk,
+					Koios: kBlk,
+				})
+			}
+		}
+	}
+
+	return mismatches, len(inputs), nil
+}
+
+// checkAccounts compares the current withdrawable reward balance (Account.Reward)
+// for each sampled account against Koios /account_info.
+//
+// Per-epoch reward history is not yet persisted by Dingo (#1875) and therefore
+// cannot be compared here. Only the aggregate withdrawable balance is checked.
+func (c *Checker) checkAccounts(
+	ctx context.Context,
+	accounts []models.Account,
+) ([]Mismatch, error) {
+	// Build stake address strings; skip accounts whose keys cannot be encoded.
+	type entry struct {
+		addr  string
+		model models.Account
+	}
+	entries := make([]entry, 0, len(accounts))
+	for _, acc := range accounts {
+		addr, err := stakeAddressBech32(c.network, acc.CredentialTag, acc.StakingKey)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry{addr: addr, model: acc})
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Koios /account_info accepts up to 50 addresses per request.
+	const batchSize = 50
+	var mismatches []Mismatch
+
+	for i := 0; i < len(entries); i += batchSize {
+		batch := entries[i:min(i+batchSize, len(entries))]
+
+		addrs := make([]string, len(batch))
+		for j, e := range batch {
+			addrs[j] = e.addr
+		}
+
+		// Courtesy delay between batch requests.
+		time.Sleep(300 * time.Millisecond)
+
+		infos, err := c.koios.GetAccountInfo(ctx, addrs)
+		if err != nil {
+			return nil, fmt.Errorf("GetAccountInfo batch %d: %w", i/batchSize, err)
+		}
+
+		byAddr := make(map[string]AccountInfo, len(infos))
+		for _, info := range infos {
+			byAddr[info.StakeAddress] = info
+		}
+
+		for _, e := range batch {
+			info, ok := byAddr[e.addr]
+			if !ok || info.Status != "registered" {
+				// Account unknown to Koios or already deregistered; skip.
+				continue
+			}
+
+			dReward := strconv.FormatUint(uint64(e.model.Reward), 10)
+			if info.RewardsAvailable != dReward {
+				mismatches = append(mismatches, Mismatch{
+					Account: e.addr,
+					Field:   "reward_balance",
+					Dingo:   dReward,
+					Koios:   info.RewardsAvailable,
+				})
+			}
+		}
+	}
+
+	return mismatches, nil
+}
+
+// stakeAddressBech32 encodes a staking key as a bech32 reward address.
+//
+// credentialTag 0 = key hash, 1 = script hash. The header byte and HRP are
+// chosen per the Cardano address spec:
+//
+//	key:    mainnet 0xe0 / testnet 0xe1, HRP "stake" / "stake_test"
+//	script: mainnet 0xf0 / testnet 0xf1, HRP "stake"  / "stake_test"
+func stakeAddressBech32(network string, credentialTag uint8, stakingKey []byte) (string, error) {
+	if len(stakingKey) != 28 {
+		return "", fmt.Errorf("staking key must be 28 bytes, got %d", len(stakingKey))
+	}
+
+	isMainnet := network == "mainnet"
+
+	var header byte
+	var hrp string
+	switch {
+	case isMainnet && credentialTag == 0:
+		header, hrp = 0xe0, "stake"
+	case isMainnet && credentialTag == 1:
+		header, hrp = 0xf0, "stake"
+	case !isMainnet && credentialTag == 0:
+		header, hrp = 0xe1, "stake_test"
+	default: // !isMainnet && credentialTag == 1
+		header, hrp = 0xf1, "stake_test"
+	}
+
+	addrBytes := make([]byte, 29)
+	addrBytes[0] = header
+	copy(addrBytes[1:], stakingKey)
+
+	conv, err := bech32.ConvertBits(addrBytes, 8, 5, true)
+	if err != nil {
+		return "", fmt.Errorf("bech32 convert bits: %w", err)
+	}
+	return bech32.Encode(hrp, conv)
+}

--- a/internal/test/koios/parity.go
+++ b/internal/test/koios/parity.go
@@ -43,7 +43,12 @@ type Mismatch struct {
 }
 
 func (m Mismatch) String() string {
-	who := fmt.Sprintf("epoch=%d", m.Epoch)
+	var who string
+	// Epoch 0 is the genesis epoch, which is never checked; a zero value here
+	// means this mismatch is account-scoped rather than epoch-scoped.
+	if m.Epoch > 0 {
+		who = fmt.Sprintf("epoch=%d", m.Epoch)
+	}
 	if m.Pool != "" {
 		who += " pool=" + m.Pool
 	}

--- a/internal/test/koios/parity_test.go
+++ b/internal/test/koios/parity_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koios_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/koios"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestKoiosParityCheck compares Dingo's closed-epoch reward state against the
+// Koios public API for the configured network.
+//
+// This test is intentionally skipped in CI. Run it manually when validating
+// reward state on a live preview or preprod node:
+//
+//	KOIOS_PARITY_TEST=1 \
+//	DINGO_DATA_DIR=/path/to/dingo/data \
+//	KOIOS_NETWORK=preview \
+//	go test ./internal/test/koios/ -v -run TestKoiosParityCheck -timeout 60m
+//
+// Environment variables:
+//
+//	KOIOS_PARITY_TEST  required; any non-empty value enables the test
+//	DINGO_DATA_DIR     path to the Dingo data directory (contains metadata.sqlite)
+//	KOIOS_NETWORK      preview (default) or preprod
+//	KOIOS_API_KEY      optional Koios Bearer token for higher rate limits
+//	KOIOS_MAX_POOLS    max pool inputs sampled per epoch (default 10)
+//	KOIOS_MAX_ACCOUNTS max stake accounts sampled for balance checks (default 50)
+func TestKoiosParityCheck(t *testing.T) {
+	if os.Getenv("KOIOS_PARITY_TEST") == "" {
+		t.Skip(
+			"set KOIOS_PARITY_TEST=1 to enable; " +
+				"requires a running or recently synced Dingo node",
+		)
+	}
+
+	dataDir := os.Getenv("DINGO_DATA_DIR")
+	if dataDir == "" {
+		t.Fatal("DINGO_DATA_DIR must point to the Dingo data directory")
+	}
+
+	network := os.Getenv("KOIOS_NETWORK")
+	if network == "" {
+		network = koios.NetworkPreview
+	}
+	if network != koios.NetworkPreview && network != koios.NetworkPreprod {
+		t.Fatalf(
+			"KOIOS_NETWORK must be %q or %q, got %q",
+			koios.NetworkPreview, koios.NetworkPreprod, network,
+		)
+	}
+
+	apiKey := os.Getenv("KOIOS_API_KEY") // optional
+
+	maxPoolsPerEpoch := 10
+	maxAccounts := 50
+	if v := os.Getenv("KOIOS_MAX_POOLS"); v != "" {
+		if n, err := fmt.Sscanf(v, "%d", &maxPoolsPerEpoch); n != 1 || err != nil {
+			t.Fatalf("invalid KOIOS_MAX_POOLS %q", v)
+		}
+	}
+	if v := os.Getenv("KOIOS_MAX_ACCOUNTS"); v != "" {
+		if n, err := fmt.Sscanf(v, "%d", &maxAccounts); n != 1 || err != nil {
+			t.Fatalf("invalid KOIOS_MAX_ACCOUNTS %q", v)
+		}
+	}
+
+	dbPath := filepath.Join(dataDir, "metadata.sqlite")
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("cannot access Dingo database at %s: %v", dbPath, err)
+	}
+
+	// Open read-only so the parity test cannot mutate production state.
+	db, err := gorm.Open(
+		sqlite.Open("file:"+dbPath+"?mode=ro&_journal=WAL"),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)},
+	)
+	if err != nil {
+		t.Fatalf("open Dingo database: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	checker, err := koios.NewChecker(db, network, apiKey)
+	if err != nil {
+		t.Fatalf("create parity checker: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	defer cancel()
+
+	t.Logf("running Koios parity check: network=%s db=%s", network, dbPath)
+	t.Logf("sampling: max_pools_per_epoch=%d max_accounts=%d", maxPoolsPerEpoch, maxAccounts)
+
+	report, err := checker.Run(ctx, maxPoolsPerEpoch, maxAccounts)
+	if err != nil {
+		t.Fatalf("parity check error: %v", err)
+	}
+
+	t.Logf("epochs checked:   %d", report.EpochsChecked)
+	t.Logf("pools checked:    %d", report.PoolsChecked)
+	t.Logf("accounts checked: %d", report.AccountsChecked)
+	t.Logf("total mismatches: %d", len(report.Mismatches))
+
+	// Print all mismatches regardless of pass/fail so the caller can triage.
+	for i, m := range report.Mismatches {
+		t.Logf("mismatch[%d]: %s", i, m)
+	}
+
+	if len(report.Mismatches) > 0 {
+		t.Errorf(
+			"found %d reward-state mismatch(es) between Dingo and Koios — "+
+				"see mismatch lines above for details",
+			len(report.Mismatches),
+		)
+	}
+}

--- a/internal/test/koios/parity_test.go
+++ b/internal/test/koios/parity_test.go
@@ -77,12 +77,18 @@ func TestKoiosParityCheck(t *testing.T) {
 	maxAccounts := 50
 	if v := os.Getenv("KOIOS_MAX_POOLS"); v != "" {
 		if n, err := fmt.Sscanf(v, "%d", &maxPoolsPerEpoch); n != 1 || err != nil {
-			t.Fatalf("invalid KOIOS_MAX_POOLS %q", v)
+			t.Fatalf("invalid KOIOS_MAX_POOLS %q: %v", v, err)
+		}
+		if maxPoolsPerEpoch < 0 {
+			t.Fatalf("KOIOS_MAX_POOLS must be >= 0, got %d", maxPoolsPerEpoch)
 		}
 	}
 	if v := os.Getenv("KOIOS_MAX_ACCOUNTS"); v != "" {
 		if n, err := fmt.Sscanf(v, "%d", &maxAccounts); n != 1 || err != nil {
-			t.Fatalf("invalid KOIOS_MAX_ACCOUNTS %q", v)
+			t.Fatalf("invalid KOIOS_MAX_ACCOUNTS %q: %v", v, err)
+		}
+		if maxAccounts < 0 {
+			t.Fatalf("KOIOS_MAX_ACCOUNTS must be >= 0, got %d", maxAccounts)
 		}
 	}
 


### PR DESCRIPTION
Refs #1903 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Koios-backed reward parity checks to validate Dingo’s closed-epoch reward state on preview/preprod. Ships a lightweight `internal/test/koios` client, a DB-backed checker, and a manual test harness.

- **New Features**
  - Minimal Koios REST client for `/epoch_info`, `/pool_history`, and `/account_info` with 429 retries (honors `Retry-After`) and optional Bearer token.
  - Parity checker reads closed epochs via GORM and compares epoch aggregates (active stake, pool/delegator counts), per-pool metrics (delegated stake, delegator count, blocks), and current account reward balances; samples pools/accounts with courteous delays; batches `/account_info` (50 per call).
  - Manual test `internal/test/koios/parity_test.go` (skipped in CI). Run with: `KOIOS_PARITY_TEST=1`, `DINGO_DATA_DIR`, `KOIOS_NETWORK` (`preview`/`preprod`), optional `KOIOS_API_KEY`; sampling via `KOIOS_MAX_POOLS`, `KOIOS_MAX_ACCOUNTS`.
  - Docs: `ARCHITECTURE.md` notes the new `test/koios` tool.

<sup>Written for commit 152b400f916673d90efd008ef8b38e6a768e690d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new parity check for preview and preprod environments to compare reward-related data against external network data.
  * Introduced support for checking epoch, pool, and account reward information with reporting for any mismatches.

* **Tests**
  * Added an integration-style parity test, disabled by default, that can be enabled with environment variables and logs detailed mismatch results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->