### PR TITLE
fix(leios): per-connection failure cooldown on leios-fetch backfill

### DIFF
--- a/ouroboros/leios_backfill.go
+++ b/ouroboros/leios_backfill.go
@@ -88,19 +88,20 @@ func (o *Ouroboros) FetchEndorserBlockByPoint(
 			conn.LeiosFetch().Client == nil {
 			continue
 		}
+		// fetchEndorserBlockOnConn records the cooldown outcome
+		// (markFetchFailed/markFetchOK) itself, under the connection's fetch
+		// guard, so concurrent backfill fetches on the same connection publish
+		// their cooldown state in fetch-completion order. Doing it here, after
+		// the guard is released, would let a slow failure's mark land after a
+		// newer success's mark and wrongly cool down a healthy connection.
 		if err := o.fetchEndorserBlockOnConn(
 			connId,
 			conn.LeiosFetch().Client,
 			point,
 		); err != nil {
 			lastErr = err
-			o.leiosFetchGuardFor(connId).markFetchFailed(
-				time.Now(),
-				leiosBackfillConnCooldown,
-			)
 			continue
 		}
-		o.leiosFetchGuardFor(connId).markFetchOK()
 		if data, ok := o.lookupLeiosEndorserBlock(ebHash); ok &&
 			data.completeTxCache() {
 			return nil
@@ -118,15 +119,27 @@ func (o *Ouroboros) FetchEndorserBlockByPoint(
 // fetchEndorserBlockOnConn fetches the manifest (if not already cached) and all
 // transaction bodies for point on a single connection, holding that
 // connection's fetch guard so the strict request/response leios-fetch client is
-// never used concurrently with a tip-driven fetch.
+// never used concurrently with a tip-driven fetch. It records the connection's
+// cooldown outcome (markFetchFailed on error, markFetchOK on success) while the
+// guard is still held, so concurrent backfill fetches on the same connection
+// publish their cooldown state in fetch-completion order rather than racing.
 func (o *Ouroboros) fetchEndorserBlockOnConn(
 	connId ouroboros.ConnectionId,
 	client *oleiosfetch.Client,
 	point ocommon.Point,
-) error {
+) (err error) {
 	g := o.leiosFetchGuardFor(connId)
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	// Runs before the deferred Unlock above (LIFO), so the cooldown state is
+	// published while the guard is still held and stays ordered with the fetch.
+	defer func() {
+		if err != nil {
+			g.markFetchFailed(time.Now(), leiosBackfillConnCooldown)
+		} else {
+			g.markFetchOK()
+		}
+	}()
 	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
 	if !ok {
 		resp, err := client.BlockRequest(point)

--- a/ouroboros/leios_backfill.go
+++ b/ouroboros/leios_backfill.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -28,6 +29,13 @@ import (
 // requests so concurrent fetches spread over the available relay connections
 // instead of contending on a single connection's fetch guard.
 var leiosBackfillConnCursor atomic.Uint64
+
+// leiosBackfillConnCooldown is how long the backfill connection selector skips a
+// leios-fetch connection after a failed or timed-out fetch, so it prefers
+// healthy connections instead of repeatedly retrying a stalled or flaky one. It
+// only falls back to a cooled-down connection when no healthy connection is
+// available, so every connection is still eventually tried.
+const leiosBackfillConnCooldown = 20 * time.Second
 
 // FetchEndorserBlockByPoint fetches the endorser block identified by
 // (ebSlot, ebHash) -- its manifest and all transaction bodies -- over
@@ -58,9 +66,23 @@ func (o *Ouroboros) FetchEndorserBlockByPoint(
 	point := ocommon.Point{Slot: ebSlot, Hash: ebHash}
 	//nolint:gosec // bounded by len(connIds), so it fits in int
 	start := int(leiosBackfillConnCursor.Add(1) % uint64(len(connIds)))
-	var lastErr error
+	// Try connections in round-robin order, but visit ones not cooling down
+	// from a recent failed fetch first; fall back to cooled-down connections
+	// only if no healthy connection is available, so every connection is still
+	// eventually tried while a stalled or flaky one is skipped.
+	now := time.Now()
+	healthy := make([]ouroboros.ConnectionId, 0, len(connIds))
+	cooled := make([]ouroboros.ConnectionId, 0, len(connIds))
 	for off := range connIds {
 		connId := connIds[(start+off)%len(connIds)]
+		if o.leiosFetchGuardFor(connId).inCooldown(now) {
+			cooled = append(cooled, connId)
+		} else {
+			healthy = append(healthy, connId)
+		}
+	}
+	var lastErr error
+	for _, connId := range append(healthy, cooled...) {
 		conn := o.ConnManager.GetConnectionById(connId)
 		if conn == nil || conn.LeiosFetch() == nil ||
 			conn.LeiosFetch().Client == nil {
@@ -72,8 +94,13 @@ func (o *Ouroboros) FetchEndorserBlockByPoint(
 			point,
 		); err != nil {
 			lastErr = err
+			o.leiosFetchGuardFor(connId).markFetchFailed(
+				time.Now(),
+				leiosBackfillConnCooldown,
+			)
 			continue
 		}
+		o.leiosFetchGuardFor(connId).markFetchOK()
 		if data, ok := o.lookupLeiosEndorserBlock(ebHash); ok &&
 			data.completeTxCache() {
 			return nil

--- a/ouroboros/leios_backfill_test.go
+++ b/ouroboros/leios_backfill_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLeiosFetchGuardCooldown verifies the per-connection backfill cooldown that
+// FetchEndorserBlockByPoint uses to prefer healthy leios-fetch connections over
+// ones that recently failed or timed out.
+func TestLeiosFetchGuardCooldown(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_780_000_000, 0)
+	g := &leiosFetchGuard{}
+
+	// A fresh guard is never in cooldown.
+	if g.inCooldown(now) {
+		t.Fatal("fresh guard should not be in cooldown")
+	}
+
+	// After a failed fetch, the connection cools down for the configured window.
+	g.markFetchFailed(now, leiosBackfillConnCooldown)
+	if !g.inCooldown(now) {
+		t.Fatal("guard should be in cooldown immediately after a failed fetch")
+	}
+	// Still cooling down just before the deadline.
+	if !g.inCooldown(now.Add(leiosBackfillConnCooldown - time.Nanosecond)) {
+		t.Fatal("guard should still be in cooldown before the deadline")
+	}
+	// No longer cooling down at/after the deadline.
+	if g.inCooldown(now.Add(leiosBackfillConnCooldown)) {
+		t.Fatal("guard should not be in cooldown at the deadline")
+	}
+	if g.inCooldown(now.Add(leiosBackfillConnCooldown + time.Second)) {
+		t.Fatal("guard should not be in cooldown after the deadline")
+	}
+
+	// A successful fetch clears the cooldown immediately, even mid-window.
+	g.markFetchFailed(now, leiosBackfillConnCooldown)
+	g.markFetchOK()
+	if g.inCooldown(now) {
+		t.Fatal("markFetchOK should clear the cooldown")
+	}
+}

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -569,6 +569,29 @@ const leiosFetchMaxInflightPerConn = 4
 type leiosFetchGuard struct {
 	mu       sync.Mutex
 	inflight atomic.Int32
+	// cooledUntilNano is a unix-nano deadline before which the backfill
+	// connection selector should skip this connection after a failed or
+	// timed-out fetch, so it prefers healthy connections instead of repeatedly
+	// retrying a stalled or flaky one.
+	cooledUntilNano atomic.Int64
+}
+
+// markFetchFailed puts this connection on a short cooldown after a failed or
+// timed-out backfill fetch.
+func (g *leiosFetchGuard) markFetchFailed(now time.Time, d time.Duration) {
+	g.cooledUntilNano.Store(now.Add(d).UnixNano())
+}
+
+// markFetchOK clears any cooldown after a successful fetch on this connection.
+func (g *leiosFetchGuard) markFetchOK() {
+	g.cooledUntilNano.Store(0)
+}
+
+// inCooldown reports whether this connection is still cooling down from a
+// recent failed fetch as of now.
+func (g *leiosFetchGuard) inCooldown(now time.Time) bool {
+	until := g.cooledUntilNano.Load()
+	return until > 0 && now.UnixNano() < until
 }
 
 func (o *Ouroboros) leiosFetchGuardFor(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-connection failure cooldown to `leios-fetch` backfill to avoid retrying stalled or flaky peers. Prefer healthy connections and only fall back when none are available, improving throughput and stability.

- **Bug Fixes**
  - Round-robins but tries healthy connections first; only falls back to cooled ones if needed.
  - 20s cooldown after failed/timed-out fetches; cleared immediately on a successful fetch.
  - Cooldown state is updated while holding the fetch guard to avoid races; includes a unit test for timing and recovery.

<sup>Written for commit 5bc266b0ef8a073b466676c21dcdfe9e530614f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backfill fetching to prefer recently healthy connections and temporarily avoid ones that just failed.
  * Added a short cooldown period after failed attempts, with automatic recovery after the timeout or a successful fetch.
  * Backfill errors now consistently return a generic failure message when no complete result is found.

* **Tests**
  * Added coverage for cooldown timing and recovery behavior across failure and success cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->