### PR TITLE
feat(chainsync): expose per-peer blockfetch metrics

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -210,10 +210,11 @@ type State struct {
 	// seenHeadersGauge tracks the current number of slots retained in the
 	// deduplication cache. Never nil; unregistered when PromRegistry is nil.
 	seenHeadersGauge prometheus.Gauge
-	// blockfetchLatencyGauge exposes the per-peer blockfetch latency EWMA
-	// (seconds), labelled by remote peer address. Never nil; unregistered
-	// when PromRegistry is nil. Series are deleted on disconnect in
-	// RemoveClientConnId so cardinality stays bounded by live connections.
+	// blockfetchLatencyGauge exposes the per-connection blockfetch latency
+	// EWMA (seconds), labelled by remote peer address and full connection
+	// ID. Never nil; unregistered when PromRegistry is nil. Series are
+	// deleted on disconnect in RemoveClientConnId so cardinality stays
+	// bounded by live connections.
 	blockfetchLatencyGauge *prometheus.GaugeVec
 
 	observedHeaders      map[ouroboros.ConnectionId]*observedHeaderChain
@@ -285,9 +286,9 @@ func NewStateWithConfig(
 	s.blockfetchLatencyGauge = promauto.With(cfg.PromRegistry).NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "dingo_chainsync_blockfetch_latency_seconds",
-			Help: "exponential moving average (alpha=0.2) of blockfetch RequestRange-to-first-block latency in seconds, by peer",
+			Help: "exponential moving average (alpha=0.2) of blockfetch RequestRange-to-first-block latency in seconds, by peer connection",
 		},
-		[]string{"peer"},
+		[]string{"peer", "connection_id"},
 	)
 	return s
 }
@@ -369,7 +370,8 @@ func (s *State) RemoveClientConnId(
 		*s.activeClientConnId == connId
 	wasEligible := exists && tc != nil && !tc.ObservabilityOnly
 	delete(s.trackedClients, connId)
-	s.blockfetchLatencyGauge.DeleteLabelValues(connId.RemoteAddr.String())
+	peer, connectionID := blockfetchLatencyMetricLabels(connId)
+	s.blockfetchLatencyGauge.DeleteLabelValues(peer, connectionID)
 	s.clearObservedHeaderHistory(connId)
 	if wasPrimary {
 		s.activeClientConnId = nil
@@ -1301,8 +1303,27 @@ func (s *State) RecordBlockfetchLatency(
 				float64(tc.BlockfetchLatencyEWMA)*(1-blockfetchLatencyAlpha),
 		)
 	}
-	s.blockfetchLatencyGauge.WithLabelValues(connId.RemoteAddr.String()).
+	peer, connectionID := blockfetchLatencyMetricLabels(connId)
+	s.blockfetchLatencyGauge.WithLabelValues(peer, connectionID).
 		Set(tc.BlockfetchLatencyEWMA.Seconds())
+}
+
+func blockfetchLatencyMetricLabels(
+	connId ouroboros.ConnectionId,
+) (string, string) {
+	return netAddrLabel(connId.RemoteAddr),
+		fmt.Sprintf(
+			"%s<->%s",
+			netAddrLabel(connId.LocalAddr),
+			netAddrLabel(connId.RemoteAddr),
+		)
+}
+
+func netAddrLabel(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
 }
 
 // BlockfetchLatency returns the blockfetch EWMA for the given

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -210,6 +210,11 @@ type State struct {
 	// seenHeadersGauge tracks the current number of slots retained in the
 	// deduplication cache. Never nil; unregistered when PromRegistry is nil.
 	seenHeadersGauge prometheus.Gauge
+	// blockfetchLatencyGauge exposes the per-peer blockfetch latency EWMA
+	// (seconds), labelled by remote peer address. Never nil; unregistered
+	// when PromRegistry is nil. Series are deleted on disconnect in
+	// RemoveClientConnId so cardinality stays bounded by live connections.
+	blockfetchLatencyGauge *prometheus.GaugeVec
 
 	observedHeaders      map[ouroboros.ConnectionId]*observedHeaderChain
 	observedHeadersMutex sync.RWMutex
@@ -276,6 +281,13 @@ func NewStateWithConfig(
 			Name: "dingo_chainsync_seen_headers",
 			Help: "current number of slots retained in the chainsync header deduplication cache",
 		},
+	)
+	s.blockfetchLatencyGauge = promauto.With(cfg.PromRegistry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "dingo_chainsync_blockfetch_latency_seconds",
+			Help: "exponential moving average (alpha=0.2) of blockfetch RequestRange-to-first-block latency in seconds, by peer",
+		},
+		[]string{"peer"},
 	)
 	return s
 }
@@ -357,6 +369,7 @@ func (s *State) RemoveClientConnId(
 		*s.activeClientConnId == connId
 	wasEligible := exists && tc != nil && !tc.ObservabilityOnly
 	delete(s.trackedClients, connId)
+	s.blockfetchLatencyGauge.DeleteLabelValues(connId.RemoteAddr.String())
 	s.clearObservedHeaderHistory(connId)
 	if wasPrimary {
 		s.activeClientConnId = nil
@@ -1282,12 +1295,14 @@ func (s *State) RecordBlockfetchLatency(
 	tc.blockfetchSampleCount++
 	if tc.blockfetchSampleCount == 1 {
 		tc.BlockfetchLatencyEWMA = latency
-		return
+	} else {
+		tc.BlockfetchLatencyEWMA = time.Duration(
+			float64(latency)*blockfetchLatencyAlpha +
+				float64(tc.BlockfetchLatencyEWMA)*(1-blockfetchLatencyAlpha),
+		)
 	}
-	tc.BlockfetchLatencyEWMA = time.Duration(
-		float64(latency)*blockfetchLatencyAlpha +
-			float64(tc.BlockfetchLatencyEWMA)*(1-blockfetchLatencyAlpha),
-	)
+	s.blockfetchLatencyGauge.WithLabelValues(connId.RemoteAddr.String()).
+		Set(tc.BlockfetchLatencyEWMA.Seconds())
 }
 
 // BlockfetchLatency returns the blockfetch EWMA for the given

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -30,6 +30,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1534,4 +1535,84 @@ func TestObservedHeader_RoundTrip(t *testing.T) {
 	// LookupObservedHeader must not be visible from a different connection.
 	_, _, ok = s.LookupObservedHeader(newTestConnId(99), hash)
 	require.False(t, ok)
+}
+
+// --- Blockfetch latency metric tests ---
+
+const blockfetchLatencyMetricName = "dingo_chainsync_blockfetch_latency_seconds"
+
+func TestBlockfetchLatencyMetricExposedPerPeer(t *testing.T) {
+	bus := newTestEventBus(t)
+	reg := prometheus.NewRegistry()
+	cfg := chainsync.DefaultConfig()
+	cfg.PromRegistry = reg
+	s := newTestState(t, bus, cfg)
+
+	conn := newTestConnId(42)
+	require.True(t, s.AddClientConnId(conn))
+
+	// First sample sets the EWMA directly to the observed latency.
+	s.RecordBlockfetchLatency(conn, 200*time.Millisecond)
+
+	got, ok := gaugeValueForLabel(
+		t, reg, blockfetchLatencyMetricName,
+		"peer", conn.RemoteAddr.String(),
+	)
+	require.True(t, ok, "expected a per-peer gauge series after recording")
+	require.InDelta(t, 0.2, got, 1e-9)
+}
+
+func TestBlockfetchLatencyMetricRemovedOnDisconnect(t *testing.T) {
+	bus := newTestEventBus(t)
+	reg := prometheus.NewRegistry()
+	cfg := chainsync.DefaultConfig()
+	cfg.PromRegistry = reg
+	s := newTestState(t, bus, cfg)
+
+	conn := newTestConnId(42)
+	require.True(t, s.AddClientConnId(conn))
+	s.RecordBlockfetchLatency(conn, 200*time.Millisecond)
+
+	_, ok := gaugeValueForLabel(
+		t, reg, blockfetchLatencyMetricName,
+		"peer", conn.RemoteAddr.String(),
+	)
+	require.True(t, ok, "precondition: gauge series should exist before removal")
+
+	// Removing the connection must delete the per-peer series so cardinality
+	// stays bounded by live tracked connections.
+	s.RemoveClientConnId(conn)
+
+	_, ok = gaugeValueForLabel(
+		t, reg, blockfetchLatencyMetricName,
+		"peer", conn.RemoteAddr.String(),
+	)
+	require.False(t, ok, "expected per-peer series to be removed on disconnect")
+}
+
+// gaugeValueForLabel gathers from reg and returns the gauge value for the
+// metric family `name` whose label `labelName` equals `labelValue`, plus
+// whether such a series exists.
+func gaugeValueForLabel(
+	t *testing.T,
+	reg *prometheus.Registry,
+	name, labelName, labelValue string,
+) (float64, bool) {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == labelName &&
+					lp.GetValue() == labelValue {
+					return m.GetGauge().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
 }

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1436,9 +1436,9 @@ func TestTryAddClientConnIdWithDirection_LimitEnforced(t *testing.T) {
 
 // mockChainProvider is a test double for the ChainProvider interface.
 type mockChainProvider struct {
-	iter          *chain.ChainIterator
-	iterErr       error
-	stabilityWin  uint64
+	iter         *chain.ChainIterator
+	iterErr      error
+	stabilityWin uint64
 }
 
 func (m *mockChainProvider) GetChainFromPoint(
@@ -1541,7 +1541,7 @@ func TestObservedHeader_RoundTrip(t *testing.T) {
 
 const blockfetchLatencyMetricName = "dingo_chainsync_blockfetch_latency_seconds"
 
-func TestBlockfetchLatencyMetricExposedPerPeer(t *testing.T) {
+func TestBlockfetchLatencyMetricExposedPerConnection(t *testing.T) {
 	bus := newTestEventBus(t)
 	reg := prometheus.NewRegistry()
 	cfg := chainsync.DefaultConfig()
@@ -1554,11 +1554,16 @@ func TestBlockfetchLatencyMetricExposedPerPeer(t *testing.T) {
 	// First sample sets the EWMA directly to the observed latency.
 	s.RecordBlockfetchLatency(conn, 200*time.Millisecond)
 
-	got, ok := gaugeValueForLabel(
-		t, reg, blockfetchLatencyMetricName,
-		"peer", conn.RemoteAddr.String(),
+	got, ok := gaugeValueForLabels(
+		t,
+		reg,
+		blockfetchLatencyMetricName,
+		map[string]string{
+			"peer":          conn.RemoteAddr.String(),
+			"connection_id": conn.String(),
+		},
 	)
-	require.True(t, ok, "expected a per-peer gauge series after recording")
+	require.True(t, ok, "expected a per-connection gauge series after recording")
 	require.InDelta(t, 0.2, got, 1e-9)
 }
 
@@ -1573,30 +1578,92 @@ func TestBlockfetchLatencyMetricRemovedOnDisconnect(t *testing.T) {
 	require.True(t, s.AddClientConnId(conn))
 	s.RecordBlockfetchLatency(conn, 200*time.Millisecond)
 
-	_, ok := gaugeValueForLabel(
-		t, reg, blockfetchLatencyMetricName,
-		"peer", conn.RemoteAddr.String(),
+	labels := map[string]string{
+		"peer":          conn.RemoteAddr.String(),
+		"connection_id": conn.String(),
+	}
+	_, ok := gaugeValueForLabels(
+		t, reg, blockfetchLatencyMetricName, labels,
 	)
 	require.True(t, ok, "precondition: gauge series should exist before removal")
 
-	// Removing the connection must delete the per-peer series so cardinality
-	// stays bounded by live tracked connections.
+	// Removing the connection must delete the per-connection series so
+	// cardinality stays bounded by live tracked connections.
 	s.RemoveClientConnId(conn)
 
-	_, ok = gaugeValueForLabel(
-		t, reg, blockfetchLatencyMetricName,
-		"peer", conn.RemoteAddr.String(),
+	_, ok = gaugeValueForLabels(
+		t, reg, blockfetchLatencyMetricName, labels,
 	)
-	require.False(t, ok, "expected per-peer series to be removed on disconnect")
+	require.False(t, ok, "expected per-connection series to be removed on disconnect")
 }
 
-// gaugeValueForLabel gathers from reg and returns the gauge value for the
-// metric family `name` whose label `labelName` equals `labelValue`, plus
+func TestBlockfetchLatencyMetricDisconnectPreservesSamePeerConnection(
+	t *testing.T,
+) {
+	bus := newTestEventBus(t)
+	reg := prometheus.NewRegistry()
+	cfg := chainsync.DefaultConfig()
+	cfg.PromRegistry = reg
+	s := newTestState(t, bus, cfg)
+
+	remoteA := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001}
+	remoteB := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001}
+	connA := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 4001},
+		RemoteAddr: remoteA,
+	}
+	connB := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 4002},
+		RemoteAddr: remoteB,
+	}
+	require.Equal(t, connA.RemoteAddr.String(), connB.RemoteAddr.String())
+	require.NotEqual(t, connA.String(), connB.String())
+	require.True(t, s.AddClientConnId(connA))
+	require.True(t, s.AddClientConnId(connB))
+
+	s.RecordBlockfetchLatency(connA, 200*time.Millisecond)
+	s.RecordBlockfetchLatency(connB, 500*time.Millisecond)
+
+	labelsA := map[string]string{
+		"peer":          connA.RemoteAddr.String(),
+		"connection_id": connA.String(),
+	}
+	labelsB := map[string]string{
+		"peer":          connB.RemoteAddr.String(),
+		"connection_id": connB.String(),
+	}
+	gotA, ok := gaugeValueForLabels(
+		t, reg, blockfetchLatencyMetricName, labelsA,
+	)
+	require.True(t, ok, "precondition: first connection series should exist")
+	require.InDelta(t, 0.2, gotA, 1e-9)
+	gotB, ok := gaugeValueForLabels(
+		t, reg, blockfetchLatencyMetricName, labelsB,
+	)
+	require.True(t, ok, "precondition: second connection series should exist")
+	require.InDelta(t, 0.5, gotB, 1e-9)
+
+	s.RemoveClientConnId(connA)
+
+	_, ok = gaugeValueForLabels(
+		t, reg, blockfetchLatencyMetricName, labelsA,
+	)
+	require.False(t, ok, "removed connection series should be deleted")
+	gotB, ok = gaugeValueForLabels(
+		t, reg, blockfetchLatencyMetricName, labelsB,
+	)
+	require.True(t, ok, "same-peer live connection series should remain")
+	require.InDelta(t, 0.5, gotB, 1e-9)
+}
+
+// gaugeValueForLabels gathers from reg and returns the gauge value for the
+// metric family `name` whose labels include all entries in `labels`, plus
 // whether such a series exists.
-func gaugeValueForLabel(
+func gaugeValueForLabels(
 	t *testing.T,
 	reg *prometheus.Registry,
-	name, labelName, labelValue string,
+	name string,
+	labels map[string]string,
 ) (float64, bool) {
 	t.Helper()
 	families, err := reg.Gather()
@@ -1606,11 +1673,15 @@ func gaugeValueForLabel(
 			continue
 		}
 		for _, m := range mf.GetMetric() {
+			matchedLabels := 0
 			for _, lp := range m.GetLabel() {
-				if lp.GetName() == labelName &&
-					lp.GetValue() == labelValue {
-					return m.GetGauge().GetValue(), true
+				if expectedValue, ok := labels[lp.GetName()]; ok &&
+					expectedValue == lp.GetValue() {
+					matchedLabels++
 				}
+			}
+			if matchedLabels == len(labels) {
+				return m.GetGauge().GetValue(), true
 			}
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose per-connection blockfetch latency in `chainsync` via a Prometheus gauge (EWMA seconds) labeled by peer and connection ID. The metric updates on each sample and removes only the matching series on disconnect to keep cardinality bounded without affecting other connections.

- **New Features**
  - Added `dingo_chainsync_blockfetch_latency_seconds` (`prometheus` `GaugeVec`): EWMA (alpha=0.2) of RequestRange-to-first-block latency, labeled `peer` and `connection_id`. Gauge is set in `RecordBlockfetchLatency`.

- **Bug Fixes**
  - On disconnect, delete only the exact `peer`/`connection_id` series to avoid removing metrics for other connections; tests cover per-connection exposure and safe removal.

<sup>Written for commit a69c82f7d63e691ba02b05611affdfba7726ecf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

