### PR TITLE
perf(mithril): download keepalive

### DIFF
--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -87,6 +88,12 @@ type BootstrapConfig struct {
 	// resets, HTTP 429, HTTP 5xx) per download. Zero uses the downloader
 	// default. Negative disables transient retries.
 	DownloadMaxTransientRetries int
+	// httpClient, when set, is the shared keep-alive client the v2
+	// immutable-download pool reuses across all archive fetches so
+	// connections are pooled instead of re-handshaked per file. It is set
+	// internally by downloadImmutables on a by-value copy of the config;
+	// callers do not populate it.
+	httpClient *http.Client
 }
 
 // VerificationMode selects the level of Mithril certificate verification.

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -36,8 +37,13 @@ import (
 )
 
 // immutableDownloadWorkers is the number of concurrent immutable
-// archive downloads during a v2 bootstrap.
-const immutableDownloadWorkers = 4
+// archive downloads during a v2 bootstrap. Paired with a shared
+// keep-alive client (see downloadImmutables) so each worker holds a
+// warm pooled connection; the connection pool in
+// newPooledDownloadTransport is sized to this value. 16 is a safe
+// default across constrained pods; bandwidth/CPU-rich hosts can go
+// higher with diminishing returns past ~32.
+const immutableDownloadWorkers = 16
 
 // ancillaryManifestFilename is the signed manifest file inside a v2
 // ancillary archive.
@@ -662,6 +668,19 @@ func downloadImmutables(
 	// progress is reported by onArchiveDone instead.
 	quietLogger := slog.New(slog.DiscardHandler)
 
+	// One shared keep-alive client for the whole pool so workers reuse
+	// pooled connections instead of paying a TCP+TLS handshake per
+	// archive. Sized to the worker count; idle connections are closed
+	// when the pool finishes. Carried on the (by-value) cfg so each
+	// fetchImmutableArchive call reuses it without a signature change.
+	dlTransport := newPooledDownloadTransport(immutableDownloadWorkers)
+	defer dlTransport.CloseIdleConnections()
+	cfg.httpClient = &http.Client{
+		Timeout:       0,
+		Transport:     dlTransport,
+		CheckRedirect: httpsOnlyRedirect,
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(immutableDownloadWorkers)
 	for num := range totalArchives {
@@ -830,6 +849,7 @@ func fetchImmutableArchive(
 			DestDir:             archiveDir,
 			Filename:            filepath.Base(immutableArchivePath(archiveDir, num)),
 			Logger:              dlLogger,
+			HTTPClient:          cfg.httpClient,
 			IdleTimeout:         cfg.DownloadIdleTimeout,
 			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 			MaxTransientRetries: cfg.DownloadMaxTransientRetries,

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -110,6 +110,12 @@ type DownloadConfig struct {
 	// conservative default is used. If negative, transient retries
 	// are disabled.
 	MaxTransientRetries int
+	// HTTPClient, when non-nil, is reused for the download instead of
+	// constructing a fresh client per call. Callers that fetch many
+	// files (the v2 immutable pool) pass one shared keep-alive client so
+	// connections are pooled across files. When nil, a per-call client
+	// with keep-alives disabled is used (single-archive downloads).
+	HTTPClient *http.Client
 }
 
 // Validate checks DownloadConfig values before use.
@@ -331,6 +337,34 @@ func newDownloadTransport() *http.Transport {
 		Proxy:             http.ProxyFromEnvironment,
 		DisableKeepAlives: true,
 	}
+}
+
+// newPooledDownloadTransport returns a transport that keeps connections
+// alive and pools them across many sequential downloads sharing one
+// http.Client. This amortizes the TCP+TLS handshake over the whole batch
+// instead of paying it per file, which matters for the v2 immutable
+// download where tens of thousands of small archives are fetched.
+//
+// maxConns must be >= the number of concurrent download workers; the
+// default http.Transport caps idle connections per host at 2, so without
+// raising MaxIdleConnsPerHost most workers would close and re-handshake
+// their connection after every file and keep-alive would buy nothing.
+func newPooledDownloadTransport(maxConns int) *http.Transport {
+	if maxConns < 1 {
+		maxConns = 1
+	}
+	var transport *http.Transport
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = base.Clone()
+	} else {
+		transport = &http.Transport{Proxy: http.ProxyFromEnvironment}
+	}
+	transport.DisableKeepAlives = false
+	transport.MaxIdleConns = maxConns * 2
+	transport.MaxIdleConnsPerHost = maxConns
+	transport.MaxConnsPerHost = maxConns
+	transport.IdleConnTimeout = 90 * time.Second
+	return transport
 }
 
 // progressWriter wraps an io.Writer to track bytes written and
@@ -555,12 +589,18 @@ func downloadSnapshotOnce(
 		)
 	}
 
-	transport := newDownloadTransport()
-	defer transport.CloseIdleConnections()
-	client := &http.Client{
-		Timeout:       0, // No timeout for large downloads
-		Transport:     transport,
-		CheckRedirect: httpsOnlyRedirect,
+	// Reuse a shared keep-alive client when the caller provides one (the
+	// v2 immutable pool); otherwise build a per-call client with
+	// keep-alives disabled for single-archive downloads.
+	client := cfg.HTTPClient
+	if client == nil {
+		transport := newDownloadTransport()
+		defer transport.CloseIdleConnections()
+		client = &http.Client{
+			Timeout:       0, // No timeout for large downloads
+			Transport:     transport,
+			CheckRedirect: httpsOnlyRedirect,
+		}
 	}
 	var headerTimer *idleTimer
 	if idleTimeout > 0 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speed up Mithril v2 bootstrap by reusing keep-alive HTTP connections for immutable archive downloads and increasing concurrency to 16. This removes per-file TCP/TLS handshakes, improving throughput and reducing CPU.

- **Refactors**
  - Use one shared keep-alive `http.Client` across the immutable download pool; sized to worker count and closed when done.
  - Add `HTTPClient` to `DownloadConfig` and internal `httpClient` to `BootstrapConfig` for reuse in batch downloads.
  - Add `newPooledDownloadTransport` with tuned connection pooling (keep-alives on; MaxConns/IdleConns set).
  - Keep fallback for single-archive downloads: build a per-call client with keep-alives disabled.
  - Increase `immutableDownloadWorkers` from 4 to 16.

<sup>Written for commit c733f216ca60b61e83fce09cc1e984867e3ac6c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

