### PR TITLE
feat(database): Gate s3 and gcs blob plugins behind dingo_extra_plugins build tag

### DIFF
--- a/database/plugin/blob/aws/commit_timestamp.go
+++ b/database/plugin/blob/aws/commit_timestamp.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package aws
 
 import (

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package aws
 
 import (

--- a/database/plugin/blob/aws/logger.go
+++ b/database/plugin/blob/aws/logger.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package aws
 
 import (

--- a/database/plugin/blob/aws/options.go
+++ b/database/plugin/blob/aws/options.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package aws
 
 import (

--- a/database/plugin/blob/aws/plugin.go
+++ b/database/plugin/blob/aws/plugin.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package aws
 
 import (

--- a/database/plugin/blob/aws/plugin_test.go
+++ b/database/plugin/blob/aws/plugin_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package aws
 
 import (

--- a/database/plugin/blob/blob.go
+++ b/database/plugin/blob/blob.go
@@ -15,7 +15,5 @@
 package blob
 
 import (
-	_ "github.com/blinklabs-io/dingo/database/plugin/blob/aws"
 	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
-	_ "github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 )

--- a/database/plugin/blob/blob_extra.go
+++ b/database/plugin/blob/blob_extra.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,30 +14,9 @@
 
 //go:build dingo_extra_plugins
 
-package gcs
+package blob
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/aws"
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 )
-
-const (
-	gcsMetricNamePrefix = "database_blob_"
-)
-
-func (d *BlobStoreGCS) registerBlobMetrics() {
-	opsTotal := prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: gcsMetricNamePrefix + "ops_total",
-			Help: "Total number of GCS blob operations",
-		},
-	)
-
-	bytesTotal := prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: gcsMetricNamePrefix + "bytes_total",
-			Help: "Total bytes read/written for GCS blob operations",
-		},
-	)
-
-	d.promRegistry.MustRegister(opsTotal, bytesTotal)
-}

--- a/database/plugin/blob/gcs/commit_timestamp.go
+++ b/database/plugin/blob/gcs/commit_timestamp.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package gcs
 
 import (

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package gcs
 
 import (

--- a/database/plugin/blob/gcs/logger.go
+++ b/database/plugin/blob/gcs/logger.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package gcs
 
 import (

--- a/database/plugin/blob/gcs/options.go
+++ b/database/plugin/blob/gcs/options.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package gcs
 
 import (

--- a/database/plugin/blob/gcs/options_test.go
+++ b/database/plugin/blob/gcs/options_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package gcs
 
 import (

--- a/database/plugin/blob/gcs/plugin.go
+++ b/database/plugin/blob/gcs/plugin.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package gcs
 
 import (

--- a/internal/integration/benchmark_test.go
+++ b/internal/integration/benchmark_test.go
@@ -26,9 +26,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
-	_ "github.com/blinklabs-io/dingo/database/plugin/blob/aws"
 	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
-	_ "github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 )
 

--- a/internal/integration/cloud_stubs_test.go
+++ b/internal/integration/cloud_stubs_test.go
@@ -12,27 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build dingo_extra_plugins
+//go:build !dingo_extra_plugins
 
-package aws
+package integration
 
-import "github.com/prometheus/client_golang/prometheus"
+func additionalBlobPlugins() []string { return nil }
 
-const s3MetricNamePrefix = "database_blob_"
+func hasGCSCredentials() bool { return false }
 
-func (d *BlobStoreS3) registerBlobMetrics() {
-	opsTotal := prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: s3MetricNamePrefix + "ops_total",
-			Help: "Total number of S3 blob operations",
-		},
-	)
-	bytesTotal := prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: s3MetricNamePrefix + "bytes_total",
-			Help: "Total bytes read/written for S3 blob operations",
-		},
-	)
-
-	d.promRegistry.MustRegister(opsTotal, bytesTotal)
-}
+func hasS3Credentials() bool { return false }

--- a/internal/integration/cloud_test.go
+++ b/internal/integration/cloud_test.go
@@ -60,9 +60,6 @@ func hasS3Credentials() bool {
 			return true
 		}
 	}
-	if os.Getenv("AWS_REGION") != "" {
-		return true
-	}
 	return false
 }
 

--- a/internal/integration/cloud_test.go
+++ b/internal/integration/cloud_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob/aws"
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/aws"
+	"github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
+	_ "github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
+)
+
+func additionalBlobPlugins() []string {
+	return []string{"gcs", "s3"}
+}
+
+func hasGCSCredentials() bool {
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != "" {
+		return true
+	}
+	home := os.Getenv("HOME")
+	if home != "" {
+		adcPath := filepath.Join(
+			home,
+			".config",
+			"gcloud",
+			"application_default_credentials.json",
+		)
+		if _, err := os.Stat(adcPath); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasS3Credentials() bool {
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+		return true
+	}
+	home := os.Getenv("HOME")
+	if home != "" {
+		if _, err := os.Stat(filepath.Join(home, ".aws", "credentials")); err == nil {
+			return true
+		}
+	}
+	if os.Getenv("AWS_REGION") != "" {
+		return true
+	}
+	return false
+}
+
+func TestCloudPluginGCS(t *testing.T) {
+	if !hasGCSCredentials() {
+		t.Skip("GCS credentials not found, skipping test")
+	}
+	testBucket := os.Getenv("DINGO_TEST_GCS_BUCKET")
+	if testBucket == "" {
+		testBucket = "dingo-test-bucket"
+	}
+	gcsPlugin, err := gcs.NewWithOptions(
+		gcs.WithBucket(testBucket),
+	)
+	if err != nil {
+		t.Fatalf("failed to create GCS plugin: %v", err)
+	}
+	if err := gcsPlugin.Start(); err != nil {
+		t.Fatalf("failed to start GCS plugin: %v", err)
+	}
+	defer func() {
+		if err := gcsPlugin.Stop(); err != nil {
+			t.Errorf("failed to stop GCS plugin: %v", err)
+		}
+	}()
+}
+
+func TestCloudPluginS3(t *testing.T) {
+	if !hasS3Credentials() {
+		t.Skip("S3 credentials not found, skipping test")
+	}
+	testBucket := os.Getenv("DINGO_TEST_S3_BUCKET")
+	if testBucket == "" {
+		testBucket = "dingo-test-bucket"
+	}
+	opts := []aws.BlobStoreS3OptionFunc{
+		aws.WithBucket(testBucket),
+	}
+	if os.Getenv("AWS_ENDPOINT") != "" {
+		opts = append(opts, aws.WithEndpoint(os.Getenv("AWS_ENDPOINT")))
+	}
+	s3Plugin, err := aws.NewWithOptions(opts...)
+	if err != nil {
+		t.Fatalf("failed to create S3 plugin: %v", err)
+	}
+	if err := s3Plugin.Start(); err != nil {
+		t.Fatalf("failed to start S3 plugin: %v", err)
+	}
+	defer func() {
+		if err := s3Plugin.Stop(); err != nil {
+			t.Errorf("failed to stop S3 plugin: %v", err)
+		}
+	}()
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -29,9 +29,7 @@ import (
 
 	"github.com/blinklabs-io/dingo"
 	"github.com/blinklabs-io/dingo/database/plugin"
-	"github.com/blinklabs-io/dingo/database/plugin/blob/aws"
 	_ "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
-	"github.com/blinklabs-io/dingo/database/plugin/blob/gcs"
 	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/internal/config"
 )
@@ -194,7 +192,7 @@ func TestPluginLifecycleEndToEnd(t *testing.T) {
 	// 1. Verify plugins are registered
 	blobPlugins := plugin.GetPlugins(plugin.PluginTypeBlob)
 	// Check for expected plugins by name instead of count
-	expectedBlobs := []string{config.DefaultBlobPlugin, "gcs", "s3"}
+	expectedBlobs := append([]string{config.DefaultBlobPlugin}, additionalBlobPlugins()...)
 	for _, name := range expectedBlobs {
 		if findPluginEntry(blobPlugins, name) == nil {
 			t.Errorf("expected blob plugin %q not found", name)
@@ -344,127 +342,6 @@ func TestPluginSwitching(t *testing.T) {
 
 	// Note: We don't instantiate cloud plugins here as they require configuration
 	// This test validates that the plugin registry works correctly
-}
-
-func TestCloudPluginGCS(t *testing.T) {
-	// Test GCS plugin with real credentials if available
-	if !hasGCSCredentials() {
-		t.Skip("GCS credentials not found, skipping test")
-	}
-
-	// Set up test configuration
-	testBucket := os.Getenv("DINGO_TEST_GCS_BUCKET")
-	if testBucket == "" {
-		testBucket = "dingo-test-bucket"
-	}
-
-	// Create GCS plugin directly with test configuration
-	gcsPlugin, err := gcs.NewWithOptions(
-		gcs.WithBucket(testBucket),
-	)
-	if err != nil {
-		t.Fatalf("failed to create GCS plugin: %v", err)
-	}
-
-	// Test basic lifecycle
-	if err := gcsPlugin.Start(); err != nil {
-		t.Fatalf("failed to start GCS plugin: %v", err)
-	}
-	defer func() {
-		if err := gcsPlugin.Stop(); err != nil {
-			t.Errorf("failed to stop GCS plugin: %v", err)
-		}
-	}()
-}
-
-func TestCloudPluginS3(t *testing.T) {
-	// Test S3 plugin with real credentials if available
-	if !hasS3Credentials() {
-		t.Skip("S3 credentials not found, skipping test")
-	}
-
-	// Set up test configuration
-	testBucket := os.Getenv("DINGO_TEST_S3_BUCKET")
-	if testBucket == "" {
-		testBucket = "dingo-test-bucket"
-	}
-
-	opts := []aws.BlobStoreS3OptionFunc{
-		aws.WithBucket(testBucket),
-	}
-
-	if os.Getenv("AWS_ENDPOINT") != "" {
-		opts = append(opts, aws.WithEndpoint(os.Getenv("AWS_ENDPOINT")))
-	}
-
-	// Create S3 plugin directly with test configuration
-	s3Plugin, err := aws.NewWithOptions(opts...)
-	if err != nil {
-		t.Fatalf("failed to create S3 plugin: %v", err)
-	}
-
-	// Test basic lifecycle
-	if err := s3Plugin.Start(); err != nil {
-		t.Fatalf("failed to start S3 plugin: %v", err)
-	}
-	defer func() {
-		if err := s3Plugin.Stop(); err != nil {
-			t.Errorf("failed to stop S3 plugin: %v", err)
-		}
-	}()
-}
-
-func hasGCSCredentials() bool {
-	// Check for GCS credentials in various locations
-	credentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-	if credentials != "" {
-		return true
-	}
-
-	// Check if gcloud is configured
-	home := os.Getenv("HOME")
-	if home != "" {
-		// Check for application default credentials
-		adcPath := filepath.Join(
-			home,
-			".config",
-			"gcloud",
-			"application_default_credentials.json",
-		)
-		if _, err := os.Stat(adcPath); err == nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-func hasS3Credentials() bool {
-	// Check for AWS credentials in standard locations
-	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	if accessKey != "" && secretKey != "" {
-		return true
-	}
-
-	// Check for AWS profile or IAM role
-	// This is a basic check - AWS SDK will handle the full credential chain
-	home := os.Getenv("HOME")
-	if home != "" {
-		credentialsPath := filepath.Join(home, ".aws", "credentials")
-		if _, err := os.Stat(credentialsPath); err == nil {
-			return true
-		}
-	}
-
-	// Check for EC2 instance metadata (IAM role)
-	// This would require a network call, so we'll assume if AWS_REGION is set,
-	// there might be credentials available
-	if os.Getenv("AWS_REGION") != "" {
-		return true
-	}
-
-	return false
 }
 
 func findPluginEntry(


### PR DESCRIPTION
1. Made S3 and GCS blob plugins optional behind the dingo_extra_plugins build tag so default builds only include Badger and avoid cloud SDK linkage.
2. Added //go:build dingo_extra_plugins to all S3 plugin files under database/plugin/blob/aws.
3. Added //go:build dingo_extra_plugins to all GCS plugin files under database/plugin/blob/gcs
4. Changed database/plugin/blob/blob.go to register only the default Badger blob plugin.
5. Added database/plugin/blob/blob_extra.go to register S3 and GCS only in tagged builds.
6. Moved TestCloudPluginGCS, TestCloudPluginS3, and credential helpers into tagged internal/integration/cloud_test.go.
7. Added default-build stubs in internal/integration/cloud_stubs_test.go.
8. Made integration plugin expectations tag-aware with additionalBlobPlugins().
9. Removed s3/gcs blank imports from internal/integration/benchmark_test.go.
10. Verified default builds do not link AWS/GCS SDKs, while -tags dingo_extra_plugins builds do.
11. Verified tests, tagged blob plugin tests, and conformance pass.

Closes #2585 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate S3 and GCS blob plugins behind the `dingo_extra_plugins` build tag so default builds only include Badger and avoid linking cloud SDKs. Tagged builds restore S3/GCS registration and tests. Closes #2585.

- **New Features**
  - S3/GCS plugin code and tests are now behind `//go:build dingo_extra_plugins`.
  - `database/plugin/blob/blob.go` registers only Badger by default; `blob_extra.go` registers S3/GCS when tagged.
  - Cloud tests moved to tagged `internal/integration/cloud_test.go` with default-build stubs in `cloud_stubs_test.go`; integration assertions are tag-aware.
  - Removed cloud plugin imports from `internal/integration/benchmark_test.go`.

- **Bug Fixes**
  - S3 cloud test now requires real AWS credentials (env vars or `~/.aws/credentials`) and skips when not present.

<sup>Written for commit 09d87b3abfc4edbe9deabdefe0bf09ea1534cd50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud blob storage support is now available only in builds that enable the optional extra-plugins tag.
  * Default builds include only the core blob backend, reducing what ships by default.

* **Tests**
  * Added coverage for cloud blob plugins when optional extras are enabled.
  * Updated integration checks to match the new default-vs-optional plugin setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->