### PR TITLE
fix: metrics listener failure should be non-fatal

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -117,6 +117,29 @@ func shutdownNodeResources(
 	return err
 }
 
+// serveAuxiliaryListener runs a non-essential observability HTTP server (the
+// prometheus metrics endpoint or the pprof debug endpoint). A bind or serve
+// failure is logged but never fatal: losing metrics or pprof must not take
+// down a node that is otherwise healthy (for example a node that has just
+// finished an expensive backfill, started while the configured port is held
+// by another process). This mirrors how `dingo mithril sync` already tolerates
+// a metrics-port conflict.
+func serveAuxiliaryListener(
+	name string,
+	srv *http.Server,
+	logger *slog.Logger,
+) {
+	if err := srv.ListenAndServe(); err != nil &&
+		!errors.Is(err, http.ErrServerClosed) {
+		logger.Error(
+			name+" listener stopped; continuing without it",
+			"component", "node",
+			"addr", srv.Addr,
+			"error", err,
+		)
+	}
+}
+
 func Run(cfg *config.Config, logger *slog.Logger) error {
 	logger.Debug(fmt.Sprintf("config: %+v", cfg), "component", "node")
 	logger.Debug(
@@ -477,29 +500,14 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	)
 	defer signalCtxStop()
 
-	// Error channel for node, metrics, and optional debug goroutines
-	errChan := make(chan error, 3)
-	go func() {
-		if err := metricsServer.ListenAndServe(); err != nil &&
-			err != http.ErrServerClosed {
-			logger.Error(
-				fmt.Sprintf("failed to start metrics listener: %s", err),
-				"component", "node",
-			)
-			errChan <- fmt.Errorf("metrics server: %w", err)
-		}
-	}()
+	// Error channel for the node goroutine. The metrics and pprof debug
+	// listeners are non-essential observability endpoints handled by
+	// serveAuxiliaryListener; their bind/serve failures are logged but never
+	// queued here, so a port conflict on them cannot take down the node.
+	errChan := make(chan error, 1)
+	go serveAuxiliaryListener("metrics", metricsServer, logger)
 	if debugServer != nil {
-		go func() {
-			if err := debugServer.ListenAndServe(); err != nil &&
-				err != http.ErrServerClosed {
-				logger.Error(
-					fmt.Sprintf("failed to start debug listener: %s", err),
-					"component", "node",
-				)
-				errChan <- fmt.Errorf("debug server: %w", err)
-			}
-		}()
+		go serveAuxiliaryListener("pprof debug", debugServer, logger)
 	}
 	go func() {
 		//nolint:contextcheck

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -15,8 +15,12 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"net"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +42,47 @@ func TestWaitForSignalOrErrorPrefersQueuedError(t *testing.T) {
 	}
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+}
+
+// A bind failure on a non-essential observability listener (metrics or pprof)
+// must be logged and non-fatal: it returns instead of blocking, and never
+// signals an error that would take down an otherwise-healthy node.
+func TestServeAuxiliaryListenerBindFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	// Occupy a port so the auxiliary listener cannot bind.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to occupy port: %s", err)
+	}
+	defer occupied.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	srv := &http.Server{
+		Addr:              occupied.Addr().String(),
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: time.Second,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		serveAuxiliaryListener("metrics", srv, logger)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal(
+			"serveAuxiliaryListener did not return on bind failure; " +
+				"a non-essential listener must not block or be fatal",
+		)
+	}
+	// Read after the goroutine finished, so no concurrent buffer access.
+	if logged := buf.String(); !strings.Contains(logged, "metrics") {
+		t.Fatalf("expected a log mentioning the metrics listener, got: %q", logged)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make metrics and `pprof` listener failures non-fatal so the node keeps running even if those ports are in use. Errors are logged and the node no longer exits on observability bind/serve failures.

- **Bug Fixes**
  - Added serveAuxiliaryListener to run observability servers and log failures without stopping the node.
  - Limited the error channel to node errors; metrics/`pprof` failures are no longer queued.
  - Added a test that verifies bind failures return quickly and log the listener name.

<sup>Written for commit 0a47bd46f9e76483eda5bb9e8664d07a54e7ea7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the app’s metrics and debug endpoints so port conflicts or startup failures there no longer stop the main service.
  * If an auxiliary listener can’t start, the app now logs the issue and continues running instead of treating it as a fatal error.
  * Shutdown behavior is more stable by ensuring only the main service determines whether the node should exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->