### PR TITLE
perf(mithril): download pipeline

### DIFF
--- a/database/immutable/immutable.go
+++ b/database/immutable/immutable.go
@@ -227,6 +227,43 @@ func (i *ImmutableDb) GetTip() (*ocommon.Point, error) {
 	return ret, nil
 }
 
+// LastSlotInChunk returns the slot of the last block in the chunk at the
+// given 0-based index. The second return value is false when num is beyond
+// the chunks currently present, with no error. This bounds an incremental
+// copy to a contiguous chunk prefix while later chunks may still be
+// downloading out of order: chunks 0..num are known complete, so num maps
+// to the num-th sorted chunk name.
+func (i *ImmutableDb) LastSlotInChunk(
+	num uint64,
+) (uint64, bool, error) {
+	chunkNames, err := i.getChunkNames()
+	if err != nil {
+		return 0, false, err
+	}
+	if num >= uint64(len(chunkNames)) {
+		return 0, false, nil
+	}
+	secondary, err := i.getChunkSecondaryIndex(chunkNames[num])
+	if err != nil {
+		return 0, false, err
+	}
+	defer func() { _ = secondary.Close() }()
+	var last uint64
+	found := false
+	for {
+		next, err := secondary.Next()
+		if err != nil {
+			return 0, false, err
+		}
+		if next == nil {
+			break
+		}
+		last = next.BlockOrEbb
+		found = true
+	}
+	return last, found, nil
+}
+
 func (i *ImmutableDb) GetBlock(point ocommon.Point) (*Block, error) {
 	var err error
 	chunkNames, err := i.getChunkNamesFromPoint(point)

--- a/database/immutable/immutable_test.go
+++ b/database/immutable/immutable_test.go
@@ -58,6 +58,44 @@ func TestGetTip(t *testing.T) {
 	}
 }
 
+func TestLastSlotInChunk(t *testing.T) {
+	imm, err := immutable.New(testDataDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// testdata has 300 chunks (0..299); chunk 299's last block is the DB tip.
+	last, ok, err := imm.LastSlotInChunk(299)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("expected chunk 299 to be present")
+	}
+	if last != 1295990 {
+		t.Fatalf("chunk 299 last slot: expected 1295990, got %d", last)
+	}
+	// Per-chunk last slots must increase with chunk number.
+	s0, ok0, err0 := imm.LastSlotInChunk(0)
+	s1, ok1, err1 := imm.LastSlotInChunk(1)
+	if err0 != nil || err1 != nil {
+		t.Fatalf("unexpected error: %v %v", err0, err1)
+	}
+	if !ok0 || !ok1 {
+		t.Fatalf("expected chunks 0 and 1 present")
+	}
+	if !(s0 < s1) {
+		t.Fatalf("expected chunk 0 last slot < chunk 1, got %d >= %d", s0, s1)
+	}
+	// An out-of-range chunk number returns ok=false, no error.
+	_, ok, err = imm.LastSlotInChunk(300)
+	if err != nil {
+		t.Fatalf("unexpected error for out-of-range chunk: %s", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false for out-of-range chunk 300")
+	}
+}
+
 func TestGetSpecificBlock(t *testing.T) {
 	imm, err := immutable.New(testDataDir)
 	if err != nil {

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -658,17 +658,19 @@ func CopyImmutableBlobsBounded(
 				bytes.Equal(next.Hash, startPoint.Hash) {
 				continue
 			}
+			// Stop at the contiguous bound BEFORE decoding the block. next.Slot
+			// comes from the secondary index, so this defers a higher
+			// out-of-order chunk's block without decoding it (decoding could
+			// otherwise fail or waste work on a block meant for a later call).
+			if maxSlot > 0 && next.Slot > maxSlot {
+				done = true
+				break
+			}
 			rawBlock, err := rawBlockFromImmutableBlock(next)
 			if err != nil {
 				return blocksCopied, lastSlot, fmt.Errorf(
 					"building raw block: %w", err,
 				)
-			}
-			if maxSlot > 0 && rawBlock.Slot > maxSlot {
-				// Reached the contiguous bound; this block belongs to a
-				// later call. Discard it (re-read when the bound advances).
-				done = true
-				break
 			}
 			blockBatch = append(blockBatch, rawBlock)
 			if len(blockBatch) == cap(blockBatch) {
@@ -914,6 +916,19 @@ func ImmutableUtxoOffsetsTipSlot(
 		)
 	}
 	return slot, true, nil
+}
+
+// MarkImmutableUtxoOffsetsComplete records that produced-UTxO offset references
+// are stored for every immutable block up to immutableTipSlot, so a later API
+// backfill can skip re-writing them. It is idempotent. Callers that split the
+// immutable copy (for example the pipelined download/copy) must call this after
+// the copy completes, because the per-block copy stores the offsets but does
+// not advance this marker on its own.
+func MarkImmutableUtxoOffsetsComplete(
+	db *database.Database,
+	immutableTipSlot uint64,
+) error {
+	return markImmutableUtxoOffsetsComplete(db, immutableTipSlot)
 }
 
 func markImmutableUtxoOffsetsComplete(

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -583,6 +583,122 @@ func copyBlocksDirect(
 	return blocksCopied, immutableTip.Slot, nil
 }
 
+// CopyImmutableBlobsBounded copies immutable blocks into the blob store from
+// the current chain tip up to and including maxSlot, storing produced-UTxO
+// offsets per block. maxSlot of 0 copies to the immutable tip. It reuses a
+// caller-opened ImmutableDb and Chain so it can be invoked repeatedly during a
+// download to overlap the copy with fetching (parallel fetch, sequenced
+// processing). Returns the number of blocks copied and the highest slot copied.
+//
+// Safe against chunks that arrive out of order: bounding by maxSlot (the last
+// slot of a known-contiguous chunk prefix) stops the copy before it can reach a
+// higher out-of-order chunk past a gap. Blocks above maxSlot are left for a
+// later call with a higher bound.
+func CopyImmutableBlobsBounded(
+	ctx context.Context,
+	logger *slog.Logger,
+	imm *immutable.ImmutableDb,
+	c *chain.Chain,
+	maxSlot uint64,
+	onProgress func(LoadBlobsProgress),
+) (int, uint64, error) {
+	callback := func(rb chain.RawBlock, txn *database.Txn) error {
+		_, err := storeRawBlockUtxoOffsets(txn, rb)
+		return err
+	}
+
+	startPoint := c.Tip().Point
+	if maxSlot > 0 && startPoint.Slot >= maxSlot {
+		return 0, startPoint.Slot, nil
+	}
+
+	// Progress denominator: the bound when set, else the immutable tip.
+	tipSlot := maxSlot
+	if tipSlot == 0 {
+		immutableTip, err := imm.GetTip()
+		if err != nil {
+			return 0, startPoint.Slot, fmt.Errorf(
+				"reading immutable DB tip: %w", err,
+			)
+		}
+		if immutableTip != nil {
+			tipSlot = immutableTip.Slot
+		}
+	}
+
+	iter, err := imm.BlocksFromPoint(startPoint)
+	if err != nil {
+		return 0, startPoint.Slot, fmt.Errorf(
+			"failed to get immutable DB iterator: %w", err,
+		)
+	}
+	defer iter.Close()
+
+	blockBatch := make([]chain.RawBlock, 0, loadBlockBatchSize)
+	blocksCopied := 0
+	lastSlot := startPoint.Slot
+	startTime := time.Now()
+	lastProgressLog := time.Time{}
+	done := false
+	for !done {
+		for {
+			next, err := iter.Next()
+			if err != nil {
+				return blocksCopied, lastSlot, fmt.Errorf(
+					"reading next block: %w", err,
+				)
+			}
+			if next == nil {
+				done = true
+				break
+			}
+			// Skip the resume anchor block (already in the chain).
+			if blocksCopied == 0 && len(blockBatch) == 0 &&
+				next.Slot == startPoint.Slot &&
+				bytes.Equal(next.Hash, startPoint.Hash) {
+				continue
+			}
+			rawBlock, err := rawBlockFromImmutableBlock(next)
+			if err != nil {
+				return blocksCopied, lastSlot, fmt.Errorf(
+					"building raw block: %w", err,
+				)
+			}
+			if maxSlot > 0 && rawBlock.Slot > maxSlot {
+				// Reached the contiguous bound; this block belongs to a
+				// later call. Discard it (re-read when the bound advances).
+				done = true
+				break
+			}
+			blockBatch = append(blockBatch, rawBlock)
+			if len(blockBatch) == cap(blockBatch) {
+				break
+			}
+		}
+		if len(blockBatch) > 0 {
+			if err := c.AddRawBlocksWithCallback(blockBatch, callback); err != nil {
+				return blocksCopied, lastSlot, fmt.Errorf(
+					"failed to import block: %w", err,
+				)
+			}
+			blocksCopied += len(blockBatch)
+			lastSlot = blockBatch[len(blockBatch)-1].Slot
+			blockBatch = blockBatch[:0]
+			reportLoadBlobsProgress(
+				onProgress, blocksCopied, lastSlot, tipSlot, startTime,
+			)
+			maybeLogBlockCopyProgress(
+				logger, "copying blocks from immutable DB (pipelined)",
+				blocksCopied, lastSlot, tipSlot, startTime, &lastProgressLog,
+			)
+		}
+		if err := ctx.Err(); err != nil {
+			return blocksCopied, lastSlot, fmt.Errorf("loading blocks: %w", err)
+		}
+	}
+	return blocksCopied, lastSlot, nil
+}
+
 // copyBlocksRawWithCallback is a lightweight variant of copyBlocks that
 // decodes only block headers instead of full blocks. This is significantly
 // faster for bulk loading since it skips decoding transaction bodies and

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -94,6 +94,17 @@ type BootstrapConfig struct {
 	// internally by downloadImmutables on a by-value copy of the config;
 	// callers do not populate it.
 	httpClient *http.Client
+	// OnChunkContiguous, when set, enables download<->processing
+	// pipelining: chunks are fetched in parallel (out of order) but this
+	// callback is invoked for each immutable file number in strict
+	// contiguous order (0,1,2,...) as soon as that prefix is fully
+	// downloaded. immutableDir is the directory the chunks are extracted
+	// into. It lets the caller copy blocks into the blob store while later
+	// chunks are still downloading. When nil, downloads run to completion
+	// before any processing (legacy behaviour). The callback runs on a
+	// single consumer goroutine and serializes processing, so it needs no
+	// internal locking.
+	OnChunkContiguous func(immutableDir string, num uint64) error
 }
 
 // VerificationMode selects the level of Mithril certificate verification.

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -681,6 +681,21 @@ func downloadImmutables(
 		CheckRedirect: httpsOnlyRedirect,
 	}
 
+	// Optional download<->processing pipeline: chunks are fetched in
+	// parallel (out of order) but seq invokes OnChunkContiguous in strict
+	// 0,1,2,... order as each prefix completes, so the caller can copy
+	// blocks while later chunks still download. nil hook => no sequencer,
+	// legacy "download everything, then process" behaviour.
+	var seq *inOrderSequencer
+	if cfg.OnChunkContiguous != nil {
+		seq = newInOrderSequencer(
+			totalArchives,
+			func(num uint64) error {
+				return cfg.OnChunkContiguous(immutableDir, num)
+			},
+		)
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(immutableDownloadWorkers)
 	for num := range totalArchives {
@@ -692,6 +707,9 @@ func downloadImmutables(
 				immutableDir, num, digests,
 			); err == nil {
 				onArchiveDone(bytes)
+				if seq != nil {
+					seq.Complete(num)
+				}
 				return nil
 			}
 			var bytes int64
@@ -751,10 +769,26 @@ func downloadImmutables(
 				)
 			}
 			onArchiveDone(bytes)
+			if seq != nil {
+				seq.Complete(num)
+			}
 			return nil
 		})
 	}
-	return g.Wait()
+	err := g.Wait()
+	if seq != nil {
+		// A fetch failure means the contiguous prefix can never advance
+		// past the gap; cancel so the consumer's Wait unblocks. On
+		// success, Wait drains any processing still trailing the last
+		// downloads.
+		if err != nil {
+			seq.Cancel(err)
+		}
+		if procErr := seq.Wait(); procErr != nil && err == nil {
+			err = procErr
+		}
+	}
+	return err
 }
 
 // newImmutableProgress returns a callback that aggregates per-archive

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -686,17 +686,36 @@ func downloadImmutables(
 	// 0,1,2,... order as each prefix completes, so the caller can copy
 	// blocks while later chunks still download. nil hook => no sequencer,
 	// legacy "download everything, then process" behaviour.
+	// errgroup only cancels its context when a download worker (a g.Go) returns
+	// an error. The pipelined copy runs in the sequencer's own goroutine, so a
+	// copy failure would otherwise let the remaining archives finish
+	// downloading before the error surfaced. Cancel the download context
+	// explicitly when the sequencer's processing fails so downloads stop at
+	// once.
+	dlCtx := ctx
 	var seq *inOrderSequencer
+	// copyErr captures a pipelined-copy failure as the root cause. It is
+	// written in the sequencer's single consumer goroutine and read only after
+	// seq.Wait() returns, so the mutex inside the sequencer orders the access.
+	var copyErr error
 	if cfg.OnChunkContiguous != nil {
+		var cancelDownloads context.CancelCauseFunc
+		dlCtx, cancelDownloads = context.WithCancelCause(ctx)
+		defer cancelDownloads(nil)
 		seq = newInOrderSequencer(
 			totalArchives,
 			func(num uint64) error {
-				return cfg.OnChunkContiguous(immutableDir, num)
+				if err := cfg.OnChunkContiguous(immutableDir, num); err != nil {
+					copyErr = err
+					cancelDownloads(err)
+					return err
+				}
+				return nil
 			},
 		)
 	}
 
-	g, gctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(dlCtx)
 	g.SetLimit(immutableDownloadWorkers)
 	for num := range totalArchives {
 		g.Go(func() error {
@@ -777,15 +796,18 @@ func downloadImmutables(
 	}
 	err := g.Wait()
 	if seq != nil {
-		// A fetch failure means the contiguous prefix can never advance
-		// past the gap; cancel so the consumer's Wait unblocks. On
-		// success, Wait drains any processing still trailing the last
-		// downloads.
+		// A download failure (or the copy-triggered cancel above) means the
+		// contiguous prefix can never advance, so unblock the consumer's Wait.
 		if err != nil {
 			seq.Cancel(err)
 		}
-		if procErr := seq.Wait(); procErr != nil && err == nil {
-			err = procErr
+		// Block until the consumer drains; its error is redundant here (copyErr
+		// holds a processing failure and err holds a download failure).
+		_ = seq.Wait()
+		// A pipelined-copy failure is the root cause; surface it instead of the
+		// context cancellation it triggered in the download workers.
+		if copyErr != nil {
+			return copyErr
 		}
 	}
 	return err

--- a/mithril/sequencer.go
+++ b/mithril/sequencer.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mithril
+
+import "sync"
+
+// inOrderSequencer turns out-of-order completions into in-order
+// processing. Parallel producers call Complete(num) as items finish in
+// any order; a single background consumer invokes process(num) in strict
+// contiguous order 0,1,2,...,total-1, each exactly once. This is the
+// reorder buffer that lets the immutable download fetch chunks in
+// parallel while the blob-store copy processes them sequentially.
+type inOrderSequencer struct {
+	total   uint64
+	process func(num uint64) error
+
+	mu       sync.Mutex
+	cond     *sync.Cond
+	done     map[uint64]bool
+	next     uint64
+	err      error
+	finished bool
+}
+
+// newInOrderSequencer starts a consumer goroutine that processes the
+// contiguous prefix of completed items in order. process is invoked
+// outside the lock so producers may keep calling Complete concurrently.
+func newInOrderSequencer(
+	total uint64,
+	process func(num uint64) error,
+) *inOrderSequencer {
+	s := &inOrderSequencer{
+		total:   total,
+		process: process,
+		done:    make(map[uint64]bool),
+	}
+	s.cond = sync.NewCond(&s.mu)
+	go s.run()
+	return s
+}
+
+// Complete marks item num as ready. Safe to call concurrently and in any
+// order. Indices beyond total or already-completed are tolerated.
+func (s *inOrderSequencer) Complete(num uint64) {
+	s.mu.Lock()
+	s.done[num] = true
+	s.cond.Broadcast()
+	s.mu.Unlock()
+}
+
+// Cancel stops the sequencer with err, unblocking Wait even if the
+// contiguous prefix can never advance (e.g. a producer failed). The
+// first cancel/process error wins.
+func (s *inOrderSequencer) Cancel(err error) {
+	s.mu.Lock()
+	if s.err == nil {
+		s.err = err
+	}
+	s.cond.Broadcast()
+	s.mu.Unlock()
+}
+
+func (s *inOrderSequencer) run() {
+	s.mu.Lock()
+	for s.next < s.total && s.err == nil {
+		for !s.done[s.next] && s.err == nil {
+			s.cond.Wait()
+		}
+		if s.err != nil {
+			break
+		}
+		num := s.next
+		s.mu.Unlock()
+		err := s.process(num)
+		s.mu.Lock()
+		if err != nil {
+			if s.err == nil {
+				s.err = err
+			}
+			break
+		}
+		s.next++
+	}
+	s.finished = true
+	s.cond.Broadcast()
+	s.mu.Unlock()
+}
+
+// Wait blocks until every item has been processed in order or the
+// sequencer stops early via a process error or Cancel. It returns the
+// first error, or nil on full completion.
+func (s *inOrderSequencer) Wait() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for !s.finished {
+		s.cond.Wait()
+	}
+	return s.err
+}

--- a/mithril/sequencer_test.go
+++ b/mithril/sequencer_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mithril
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Items completed out of order must be processed in strict contiguous
+// index order starting at 0, exactly once each.
+func TestSequencerProcessesInContiguousOrder(t *testing.T) {
+	var mu sync.Mutex
+	var order []uint64
+	seq := newInOrderSequencer(5, func(num uint64) error {
+		mu.Lock()
+		order = append(order, num)
+		mu.Unlock()
+		return nil
+	})
+	for _, n := range []uint64{3, 1, 0, 4, 2} {
+		seq.Complete(n)
+	}
+	require.NoError(t, seq.Wait())
+	assert.Equal(t, []uint64{0, 1, 2, 3, 4}, order)
+}
+
+// Concurrent completions from many goroutines must still process in
+// strict 0..N-1 order.
+func TestSequencerConcurrentCompletions(t *testing.T) {
+	const n = uint64(200)
+	var mu sync.Mutex
+	var order []uint64
+	seq := newInOrderSequencer(n, func(num uint64) error {
+		mu.Lock()
+		order = append(order, num)
+		mu.Unlock()
+		return nil
+	})
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(num uint64) {
+			defer wg.Done()
+			seq.Complete(num)
+		}(i)
+	}
+	wg.Wait()
+	require.NoError(t, seq.Wait())
+	want := make([]uint64, n)
+	for i := range want {
+		want[i] = uint64(i)
+	}
+	assert.Equal(t, want, order)
+}
+
+// A processing error stops the sequencer and is returned from Wait;
+// later indices are not processed.
+func TestSequencerStopsOnProcessError(t *testing.T) {
+	boom := errors.New("boom")
+	var mu sync.Mutex
+	var processed []uint64
+	seq := newInOrderSequencer(5, func(num uint64) error {
+		mu.Lock()
+		processed = append(processed, num)
+		mu.Unlock()
+		if num == 2 {
+			return boom
+		}
+		return nil
+	})
+	for _, n := range []uint64{0, 1, 2, 3, 4} {
+		seq.Complete(n)
+	}
+	require.ErrorIs(t, seq.Wait(), boom)
+	assert.Equal(t, []uint64{0, 1, 2}, processed)
+}
+
+// Cancel unblocks Wait even when not all indices have completed (e.g. a
+// fetch worker failed and the contiguous prefix can never advance).
+func TestSequencerCancelUnblocksWait(t *testing.T) {
+	cancelled := errors.New("cancelled")
+	seq := newInOrderSequencer(5, func(uint64) error { return nil })
+	seq.Complete(0)
+	seq.Complete(1)
+	// index 2 never completes; cancel should release Wait.
+	seq.Cancel(cancelled)
+	require.ErrorIs(t, seq.Wait(), cancelled)
+}

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -24,8 +24,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/blinklabs-io/dingo/ledgerstate"
@@ -191,10 +193,107 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 		)
 	}
 
+	// Open the database before bootstrap so the immutable copy can overlap the
+	// download: chunks are copied into the blob store in contiguous order as
+	// they finish downloading, instead of waiting for the whole download.
+	db, err := database.New(&database.Config{
+		DataDir:        cfg.DataDir,
+		Logger:         logger,
+		BlobPlugin:     cfg.BlobPlugin,
+		RunMode:        cfg.RunMode,
+		MetadataPlugin: cfg.MetadataPlugin,
+		MaxConnections: cfg.DatabaseWorkers,
+		StorageMode:    cfg.StorageMode,
+		Network:        cfg.Network,
+	})
+	if err != nil {
+		// Tolerate a recoverable commit-timestamp mismatch from a previously
+		// interrupted run; mithril import heals it on forward progress.
+		var cte database.CommitTimestampError
+		if errors.As(err, &cte) && db != nil {
+			logger.Warn(
+				"opened database with commit timestamp mismatch; "+
+					"continuing mithril sync — import will heal it",
+				"component", "mithril",
+				"metadata_timestamp", cte.MetadataTimestamp,
+				"blob_timestamp", cte.BlobTimestamp,
+			)
+		} else {
+			return SyncResult{}, fmt.Errorf("opening database: %w", err)
+		}
+	}
+	defer db.Close()
+
+	// Mark sync in-progress so `dingo serve` refuses to start on an incomplete
+	// sync, and pre-seed the API backfill checkpoint before any blob writes.
+	if err := db.SetSyncState("sync_status", syncStatusInProgress, nil); err != nil {
+		return SyncResult{}, fmt.Errorf("marking sync in-progress: %w", err)
+	}
+	if isAPIMode(cfg.StorageMode) {
+		if err := ensureMithrilBackfillCheckpoint(db); err != nil {
+			return SyncResult{}, fmt.Errorf(
+				"marking backfill in-progress: %w", err,
+			)
+		}
+	}
+
+	// Pipelined copy consumer. Bootstrap invokes onChunkContiguous for each
+	// immutable file number in contiguous order as it finishes downloading; we
+	// copy that contiguous prefix into the blob store while later chunks are
+	// still downloading. The sequencer drives this from a single in-order
+	// consumer goroutine, so the closure needs no locking.
+	copyCm, err := chain.NewManager(db, nil)
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("loading chain manager: %w", err)
+	}
+	copyChain := copyCm.PrimaryChain()
+	if copyChain == nil {
+		return SyncResult{}, errors.New("primary chain not available")
+	}
+	var pipeImm *immutable.ImmutableDb
+	var pipeLastChunk uint64
+	pipeCopied := false
+	const pipelineCopyChunkStride = 64
+	onChunkContiguous := func(immutableDir string, num uint64) error {
+		if pipeImm == nil {
+			var nerr error
+			if pipeImm, nerr = immutable.New(immutableDir); nerr != nil {
+				return fmt.Errorf(
+					"opening immutable DB for pipelined copy: %w", nerr,
+				)
+			}
+		}
+		// Throttle: copy every N contiguous chunks rather than on each one;
+		// the post-bootstrap copy finishes whatever remainder is left.
+		if pipeCopied && num < pipeLastChunk+pipelineCopyChunkStride {
+			return nil
+		}
+		maxSlot, ok, serr := pipeImm.LastSlotInChunk(num)
+		if serr != nil {
+			return fmt.Errorf(
+				"pipelined copy bound for chunk %d: %w", num, serr,
+			)
+		}
+		if !ok {
+			return nil
+		}
+		if _, _, cerr := node.CopyImmutableBlobsBounded(
+			ctx, logger, pipeImm, copyChain, maxSlot, nil,
+		); cerr != nil {
+			return fmt.Errorf(
+				"pipelined copy to slot %d: %w", maxSlot, cerr,
+			)
+		}
+		pipeLastChunk = num
+		pipeCopied = true
+		return nil
+	}
+
 	cfg.emit(SyncProgress{Phase: PhaseBootstrap, Active: true})
 	result, err := Bootstrap(
 		ctx,
 		BootstrapConfig{
+			OnChunkContiguous:      onChunkContiguous,
 			Network:                network,
 			Backend:                cfg.Backend,
 			AggregatorURL:          aggregatorURL,
@@ -254,57 +353,6 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 		return SyncResult{}, fmt.Errorf("mithril bootstrap failed: %w", err)
 	}
 
-	// Open database once and reuse for both import and ImmutableDB load
-	db, err := database.New(&database.Config{
-		DataDir:        cfg.DataDir,
-		Logger:         logger,
-		BlobPlugin:     cfg.BlobPlugin,
-		RunMode:        cfg.RunMode,
-		MetadataPlugin: cfg.MetadataPlugin,
-		MaxConnections: cfg.DatabaseWorkers,
-		StorageMode:    cfg.StorageMode,
-		Network:        cfg.Network,
-	})
-	if err != nil {
-		// Tolerate a recoverable commit-timestamp mismatch carried
-		// over from a previously interrupted run. The mithril import
-		// writes blocks and ledger state through full transactions
-		// that update both stores' timestamps in lockstep, so the
-		// mismatch heals as soon as we make forward progress.
-		var cte database.CommitTimestampError
-		if errors.As(err, &cte) && db != nil {
-			logger.Warn(
-				"opened database with commit timestamp mismatch; "+
-					"continuing mithril sync — import will heal it",
-				"component", "mithril",
-				"metadata_timestamp", cte.MetadataTimestamp,
-				"blob_timestamp", cte.BlobTimestamp,
-			)
-		} else {
-			return SyncResult{}, fmt.Errorf("opening database: %w", err)
-		}
-	}
-	defer db.Close()
-
-	// Mark sync as in-progress so `dingo serve` can detect an
-	// incomplete sync and refuse to start.
-	if err := db.SetSyncState("sync_status", syncStatusInProgress, nil); err != nil {
-		return SyncResult{}, fmt.Errorf("marking sync in-progress: %w", err)
-	}
-
-	// For API mode, mark an incomplete backfill checkpoint BEFORE any
-	// blob writes. If the process dies between writing blocks and
-	// node.Backfill.Run() creating its own initial checkpoint, the next
-	// startup would see blocks but no checkpoint and skip the backfill.
-	// Pre-seeding the checkpoint here ensures NeedsBackfill() returns
-	// the correct answer at any interruption point.
-	if isAPIMode(cfg.StorageMode) {
-		if err := ensureMithrilBackfillCheckpoint(db); err != nil {
-			return SyncResult{}, fmt.Errorf(
-				"marking backfill in-progress: %w", err,
-			)
-		}
-	}
 	// On error, log a message guiding the user to re-run.
 	syncComplete := false
 	defer func() {

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -126,6 +126,25 @@ func pctOf(cur, total int64) float64 {
 	return float64(cur) / float64(total) * 100
 }
 
+// markSyncInProgress marks the database as an incomplete sync (so `dingo serve`
+// refuses to start) and, for API mode, pre-seeds the backfill checkpoint. It is
+// called at the first actual write rather than before bootstrap, so a bootstrap
+// that fails before writing anything leaves an existing healthy database
+// untouched. Idempotent: safe to call more than once per sync.
+func markSyncInProgress(db *database.Database, storageMode string) error {
+	if err := db.SetSyncState(
+		"sync_status", syncStatusInProgress, nil,
+	); err != nil {
+		return fmt.Errorf("marking sync in-progress: %w", err)
+	}
+	if isAPIMode(storageMode) {
+		if err := ensureMithrilBackfillCheckpoint(db); err != nil {
+			return fmt.Errorf("marking backfill in-progress: %w", err)
+		}
+	}
+	return nil
+}
+
 // Sync performs a full Mithril bootstrap of the database at cfg.DataDir:
 // download + verify + extract a snapshot, import ledger state and immutable
 // blocks, close the volatile gap, backfill metadata, and mark the sync
@@ -224,18 +243,12 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 	}
 	defer db.Close()
 
-	// Mark sync in-progress so `dingo serve` refuses to start on an incomplete
-	// sync, and pre-seed the API backfill checkpoint before any blob writes.
-	if err := db.SetSyncState("sync_status", syncStatusInProgress, nil); err != nil {
-		return SyncResult{}, fmt.Errorf("marking sync in-progress: %w", err)
-	}
-	if isAPIMode(cfg.StorageMode) {
-		if err := ensureMithrilBackfillCheckpoint(db); err != nil {
-			return SyncResult{}, fmt.Errorf(
-				"marking backfill in-progress: %w", err,
-			)
-		}
-	}
+	// The sync-in-progress marker and the API backfill checkpoint are NOT set
+	// here: setting them before bootstrap would leave an existing healthy
+	// database permanently marked incomplete (blocking `dingo serve`) if the
+	// bootstrap fails before anything is written. They are set by
+	// markSyncInProgress at the first actual write instead (the pipelined copy
+	// below, and again before the post-bootstrap import as a backstop).
 
 	// Pipelined copy consumer. Bootstrap invokes onChunkContiguous for each
 	// immutable file number in contiguous order as it finishes downloading; we
@@ -276,6 +289,14 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 		}
 		if !ok {
 			return nil
+		}
+		// First blob write: mark the sync in-progress now (not before
+		// bootstrap), so a bootstrap that fails before any write leaves an
+		// existing healthy database untouched.
+		if !pipeCopied {
+			if merr := markSyncInProgress(db, cfg.StorageMode); merr != nil {
+				return merr
+			}
 		}
 		if _, _, cerr := node.CopyImmutableBlobsBounded(
 			ctx, logger, pipeImm, copyChain, maxSlot, nil,
@@ -351,6 +372,14 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 	cfg.emit(SyncProgress{Phase: PhaseBootstrap, Active: false})
 	if err != nil {
 		return SyncResult{}, fmt.Errorf("mithril bootstrap failed: %w", err)
+	}
+
+	// Backstop the in-progress marker for paths that did not pipeline a copy
+	// (for example the v1 backend, which has no per-chunk hook). Idempotent
+	// when the pipelined copy already set it. Set after a successful bootstrap
+	// and before any post-bootstrap write or deferred-index drop.
+	if err := markSyncInProgress(db, cfg.StorageMode); err != nil {
+		return SyncResult{}, err
 	}
 
 	// On error, log a message guiding the user to re-run.
@@ -455,6 +484,22 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 
 	if err := g.Wait(); err != nil {
 		return SyncResult{}, err
+	}
+
+	// The pipelined copy stores produced-UTxO offsets per block but does not
+	// advance the offsets-complete marker, and the post-bootstrap copy only
+	// marks it when it copied at least one block (so it is skipped when the
+	// pipeline already copied the entire immutable DB). Record it explicitly
+	// for the full immutable tip so a later API backfill or resume does not
+	// redo offset work the copy already performed. Idempotent.
+	if loadResult != nil {
+		if err := node.MarkImmutableUtxoOffsetsComplete(
+			db, loadResult.ImmutableTipSlot,
+		); err != nil {
+			return SyncResult{}, fmt.Errorf(
+				"recording immutable UTxO offsets complete: %w", err,
+			)
+		}
 	}
 
 	// Fetch volatile blocks between the ImmutableDB tip and the


### PR DESCRIPTION
This came out of #1802 testing and benchmarking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `mithril` bootstrap by pipelining immutable chunk downloads with blob-store import. Adds a bounded copy path and an in-order sequencer so processing stays correct when chunks finish out of order.

- New Features
  - Added `OnChunkContiguous` to `BootstrapConfig` to start processing as soon as a contiguous chunk prefix (0..N) is downloaded; no change when unset.
  - Introduced an in-order sequencer to invoke per-chunk processing strictly in 0..N order and to cancel downloads immediately on processing errors.
  - Implemented `CopyImmutableBlobsBounded(...)` in `internal/node` to import blocks up to a given slot and store UTxO offsets; avoids decoding out-of-bound blocks and is safe with out-of-order arrivals.
  - Added `LastSlotInChunk(num)` to `database/immutable` to bound copies using the last slot of each chunk.
  - Integrated the pipeline in `mithril/sync`: open DB before bootstrap, copy every 64 contiguous chunks while downloads continue, cancel downloads on copy failures, mark sync-in-progress and API backfill at the first write (not before bootstrap), and record immutable UTxO offsets complete after copy; tolerate recoverable commit-timestamp mismatches.
  - Added tests for the sequencer and immutable chunk bounds.

<sup>Written for commit 5144679a21faba39569f16c79f4733cb9f0155b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bootstrap and sync flow to process downloaded data incrementally as it becomes available, instead of waiting for all downloads to finish.
  * Added support for resuming large syncs with better progress tracking and bounded copying of immutable data.

* **Bug Fixes**
  * Made sync behavior more reliable when downloads complete out of order.
  * Improved handling of partial or out-of-range data so sync can continue cleanly on later runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->