### PR TITLE
fix(ledger): dijkstra forge pparams

### DIFF
--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -806,6 +806,28 @@ func computeBlockBodyHash(
 		totalSize += uint64(len(invalidCbor))
 	}
 
+	if era == eraDijkstra {
+		// Dijkstra blocks append two nullable certificate fields after
+		// invalid_transactions — leios_cert then peras_cert (CDDL
+		// "<cert> / nil"). A producer that forges no endorser block emits
+		// both as CBOR null, and DijkstraBlockBody.Hash hashes all six body
+		// components, so the header body hash must include both null-cert
+		// components or the forged block fails body-hash validation. The
+		// same null encoding is emitted by encodeBlockCbor.
+		nullCert, err := cbor.Encode(nil)
+		if err != nil {
+			return lcommon.Blake2b256{}, 0, fmt.Errorf(
+				"failed to encode null Dijkstra certificate: %w",
+				err,
+			)
+		}
+		nullHash := blake2b.Sum256(nullCert)
+		// leios_cert, then peras_cert.
+		bodyHashes = append(bodyHashes, nullHash[:]...)
+		bodyHashes = append(bodyHashes, nullHash[:]...)
+		totalSize += 2 * uint64(len(nullCert))
+	}
+
 	// Final hash of concatenated hashes
 	finalHash := blake2b.Sum256(bodyHashes)
 	return lcommon.NewBlake2b256(finalHash[:]), totalSize, nil
@@ -894,6 +916,21 @@ type rawBabbageEraBlock struct {
 	InvalidTransactions    []uint
 }
 
+// rawDijkstraBlock encodes a Dijkstra block: 7 elements — the
+// Babbage/Conway five plus the two trailing nullable certificate fields
+// leios_cert and peras_cert (CDDL "<cert> / nil"). The forge produces no
+// endorser block, so both certificates are CBOR null.
+type rawDijkstraBlock struct {
+	cbor.StructAsArray
+	Header                 cbor.RawMessage
+	TransactionBodies      []cbor.RawMessage
+	TransactionWitnessSets []cbor.RawMessage
+	TransactionMetadataSet lcommon.TransactionMetadataSet
+	InvalidTransactions    []uint
+	LeiosCertificate       cbor.RawMessage
+	PerasCertificate       cbor.RawMessage
+}
+
 // encodeBlockCbor selects the era-correct raw-block envelope and
 // encodes it. The forge path never produces invalid_transactions so
 // the list is always empty when present; we still emit it because
@@ -905,6 +942,28 @@ func encodeBlockCbor(
 	witnessSets []cbor.RawMessage,
 	metadataSet lcommon.TransactionMetadataSet,
 ) ([]byte, error) {
+	if era == eraDijkstra {
+		// Dijkstra appends leios_cert and peras_cert after
+		// invalid_transactions; both are CBOR null when no endorser
+		// block is forged. The same null encoding feeds the body hash
+		// in computeBlockBodyHash, so they stay consistent.
+		nullCert, err := cbor.Encode(nil)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to encode null Dijkstra certificate: %w",
+				err,
+			)
+		}
+		return cbor.Encode(rawDijkstraBlock{
+			Header:                 header,
+			TransactionBodies:      txBodies,
+			TransactionWitnessSets: witnessSets,
+			TransactionMetadataSet: metadataSet,
+			InvalidTransactions:    []uint{},
+			LeiosCertificate:       cbor.RawMessage(nullCert),
+			PerasCertificate:       cbor.RawMessage(nullCert),
+		})
+	}
 	if !era.hasInvalidTxs() {
 		return cbor.Encode(rawShelleyEraBlock{
 			Header:                 header,

--- a/ledger/forging/builder_eras_test.go
+++ b/ledger/forging/builder_eras_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -167,4 +168,76 @@ func TestBuildBlockSupportsAllEras(t *testing.T) {
 			assert.Equal(t, 0, len(block.Transactions()))
 		})
 	}
+}
+
+// TestBuildBlockSupportsDijkstraEra verifies BuildBlock forges on the
+// Dijkstra (Leios) era: a musashi block producer must build a block from
+// *dijkstra.DijkstraProtocolParameters instead of failing the forge with
+// "unsupported protocol parameter type". Dijkstra shares Conway's Praos
+// block/header layout, so the forged block round-trips through the
+// Dijkstra block constructor.
+func TestBuildBlockSupportsDijkstraEra(t *testing.T) {
+	creds := setupTestCredentials(t)
+
+	// DijkstraProtocolParameters embeds ConwayProtocolParameters, so the
+	// shared limits are set via the embedded field.
+	pparams := &dijkstra.DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			MaxTxSize:        16384,
+			MaxBlockBodySize: 90112,
+			ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+				Major: 10,
+			},
+			MaxBlockExUnits: lcommon.ExUnits{
+				Memory: 62000000,
+				Steps:  20000000000,
+			},
+		},
+	}
+
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool:         &mockMempool{transactions: []MempoolTransaction{}},
+		PParamsProvider: &mockPParamsProvider{pparams: pparams},
+		ChainTip: &mockChainTip{
+			tip: ochainsync.Tip{
+				Point: ocommon.Point{
+					Slot: 1000,
+					Hash: make([]byte, 32),
+				},
+				BlockNumber: 100,
+			},
+		},
+		EpochNonce: &mockEpochNonceProvider{
+			epoch: 1,
+			nonce: make([]byte, 32),
+		},
+		Credentials: creds,
+	})
+	require.NoError(t, err)
+
+	block, blockCbor, err := builder.BuildBlock(1001, 0)
+	require.NoError(t, err, "BuildBlock must succeed in the Dijkstra era")
+	require.NotNil(t, block)
+	require.NotEmpty(t, blockCbor)
+
+	assert.IsType(
+		t,
+		(*dijkstra.DijkstraBlock)(nil),
+		block,
+		"Dijkstra era must round-trip through the Dijkstra block constructor",
+	)
+	assert.Equal(t, uint64(1001), block.SlotNumber())
+	assert.Equal(t, uint64(101), block.BlockNumber())
+	assert.Equal(t, 0, len(block.Transactions()))
+
+	// The forged block's body hash must match the header commitment, i.e.
+	// the Dijkstra six-component body hash including the null leios_cert and
+	// peras_cert. A mismatch means the network would reject the block.
+	dblock := block.(*dijkstra.DijkstraBlock)
+	assert.Equal(
+		t,
+		dblock.BlockBodyHash(),
+		dblock.CalculatedBlockBodyHash(),
+		"forged Dijkstra block body hash must match the header commitment",
+	)
 }

--- a/ledger/forging/eras.go
+++ b/ledger/forging/eras.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
@@ -42,6 +43,7 @@ const (
 	eraAlonzo
 	eraBabbage
 	eraConway
+	eraDijkstra
 )
 
 // isTPraos reports whether the era runs on TPraos (Shelley→Alonzo).
@@ -86,6 +88,17 @@ func extractPParamsLimits(p lcommon.ProtocolParameters) (pparamsLimits, error) {
 		return pparamsLimits{}, errors.New("protocol parameters are nil")
 	}
 	switch pp := p.(type) {
+	case *dijkstra.DijkstraProtocolParameters:
+		// Dijkstra shares Conway's Praos block/header layout; the
+		// Leios header extension lives in the header, not these limits.
+		return pparamsLimits{
+			era:          eraDijkstra,
+			maxTxSize:    uint64(pp.MaxTxSize),
+			maxBlockSize: uint64(pp.MaxBlockBodySize),
+			maxExUnits:   pp.MaxBlockExUnits,
+			protoMajor:   uint64(pp.ProtocolVersion.Major),
+			protoMinor:   uint64(pp.ProtocolVersion.Minor),
+		}, nil
 	case *conway.ConwayProtocolParameters:
 		return pparamsLimits{
 			era:          eraConway,
@@ -184,6 +197,8 @@ func splitTxCbor(txCbor []byte) (body, witnesses cbor.RawMessage, err error) {
 // block, so we round-trip through the matching era's decoder.
 func decodeBlockFromCbor(era eraKind, blockCbor []byte) (ledger.Block, error) {
 	switch era {
+	case eraDijkstra:
+		return dijkstra.NewDijkstraBlockFromCbor(blockCbor)
 	case eraConway:
 		return conway.NewConwayBlockFromCbor(blockCbor)
 	case eraBabbage:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes forging for the Dijkstra (Leios) era by accepting `dijkstra.DijkstraProtocolParameters` and producing valid Dijkstra blocks. Ensures the body hash matches the header by including null `leios_cert` and `peras_cert` in hashing and CBOR encoding.

- **Bug Fixes**
  - Accept `dijkstra.DijkstraProtocolParameters` in `extractPParamsLimits` and add `eraDijkstra`.
  - Append two CBOR-null certs (`leios_cert`, `peras_cert`) in `computeBlockBodyHash` and `encodeBlockCbor`.
  - Decode forged blocks via `dijkstra.NewDijkstraBlockFromCbor`.
  - Add tests that forge a Dijkstra block and verify header/body-hash consistency and round-trip.

<sup>Written for commit a4d37dbe73e428a18f91621149663f2e8810cd77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

