### PR TITLE
fix: dijkstra at-tip nonce calculation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -620,7 +620,13 @@ When `Node.Run()` is called, components are initialized in this order:
     Runs synchronously before LedgerState starts so no BlockActionApply events are
     missed. Backfill iterates stored blocks from the last checkpoint slot onward;
     inserts are idempotent (ON CONFLICT DO NOTHING) so a crash-restart replay is safe.
- 9. LedgerState start
+ 9. LedgerState start. Loading the epoch cache (`loadEpochs`) also runs
+    `healEmptyLabNonces`: it repairs any epoch record whose
+    `last_epoch_block_nonce` was persisted empty by the pre-fix
+    endorser-block/`BlockBeforeSlot` collision — re-deriving the lab from the
+    real boundary block and recomputing the affected next epoch's nonce in the
+    cache so leader-VRF verification matches the network (an empty lab would
+    otherwise collapse that epoch's nonce to the NeutralNonce identity).
 10. Snapshot manager start (captures genesis snapshot, or reuses an existing
     post-Mithril Mark snapshot window)
 11. Mempool setup and injection into LedgerState/Ouroboros

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -344,7 +344,15 @@ endorser transactions' CBOR is written as a standalone blob under a `bp` +
 `(endorser-block slot, endorser-block hash)` key via `SetGenesisCbor` — which,
 like the genesis UTxO blob, writes only the `bp` and `bp..._metadata` keys and
 deliberately omits the `bi`/`bh` index keys, so the chain iterator never treats
-it as a chain block. Each endorser transaction's `t` entry and its outputs' `u`
+it as a chain block. Its `bp..._metadata` carries `ID=0` (real ranking blocks
+created via `BlockCreate` get `ID >= 1`), which is also how the `bp`-prefix
+scanning helpers exclude it: `BlockBeforeSlotTxn` skips `ID=0` blobs so a
+synthetic endorser/genesis blob is never returned as the "previous block." This
+matters for the epoch-nonce computation — the lagged `last_epoch_block_nonce`
+(lab) is derived from the previous epoch's last block's `PrevHash`; returning an
+endorser blob there (its `PrevHash` is empty) saves an empty lab, collapsing the
+next epoch's nonce to the NeutralNonce identity and failing every leader-VRF
+check in that epoch. Each endorser transaction's `t` entry and its outputs' `u`
 entries store ordinary `DOFF` references whose `block_slot`/`block_hash` point at
 that endorser-block blob, so cold-extract resolution is identical to chain-block
 transactions. The transactions' metadata rows, however, are recorded under the

--- a/database/block.go
+++ b/database/block.go
@@ -632,7 +632,21 @@ func BlockBeforeSlotTxn(txn *Txn, slotNumber uint64) (models.Block, error) {
 		if strings.HasSuffix(string(k), types.BlockBlobMetadataKeySuffix) {
 			continue
 		}
-		return blockByKey(txn, k)
+		blk, blkErr := blockByKey(txn, k)
+		if blkErr != nil {
+			return models.Block{}, blkErr
+		}
+		// Skip synthetic blobs. Genesis CBOR and Leios endorser blocks are
+		// persisted at block-blob keys via SetGenesisCbor with ID=0 and no
+		// chain index entry; they are not ranking blocks. Returning one here
+		// would feed callers (epoch-nonce labNonce/candidate computation,
+		// chain reconciliation) a non-block whose PrevHash/Type are empty —
+		// the source of the empty-labNonce epoch-nonce corruption. Real
+		// blocks created via BlockCreate always have ID >= BlockInitialIndex.
+		if blk.ID == 0 {
+			continue
+		}
+		return blk, nil
 	}
 	if err := it.Err(); err != nil {
 		return models.Block{}, err

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -72,3 +72,61 @@ func TestBlockBySlotSkipsStaleSameSlotIndex(t *testing.T) {
 	require.Equal(t, lowerIDBlock.ID, block.ID)
 	require.Equal(t, lowerIDBlock.Hash, block.Hash)
 }
+
+// TestBlockBeforeSlotSkipsSyntheticBlobs verifies BlockBeforeSlot returns the
+// highest real ranking block before a slot and skips synthetic blobs. Genesis
+// CBOR and Leios endorser blocks are persisted at block-blob keys via
+// SetGenesisCbor with ID=0 and an empty PrevHash; returning one to the
+// epoch-nonce lab computation saves an empty lastEpochBlockNonce, which
+// collapses the next epoch's nonce to the NeutralNonce identity and fails every
+// leader-VRF check (the Dijkstra/Leios at-tip wedge).
+func TestBlockBeforeSlotSkipsSyntheticBlobs(t *testing.T) {
+	db := newTestDB(t)
+
+	realBlock := models.Block{
+		ID:       7,
+		Slot:     100,
+		Hash:     bytes.Repeat([]byte{0xaa}, 32),
+		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		Cbor:     []byte{0x80},
+		Number:   7,
+		Type:     6,
+	}
+	require.NoError(t, db.BlockCreate(realBlock, nil))
+
+	// Synthetic endorser-block blob at a HIGHER slot than the real block but
+	// still before the query slot. SetGenesisCbor stores it with ID=0 and a
+	// nil PrevHash.
+	ebHash := bytes.Repeat([]byte{0xcc}, 32)
+	require.NoError(t, db.SetGenesisCbor(110, ebHash, []byte{0x80}, nil))
+
+	got, err := BlockBeforeSlot(db, 120)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		realBlock.Slot,
+		got.Slot,
+		"BlockBeforeSlot must skip the synthetic blob at slot 110 and return "+
+			"the real ranking block at slot 100",
+	)
+	require.Equal(t, realBlock.Hash, got.Hash)
+	require.Equal(
+		t,
+		realBlock.PrevHash,
+		got.PrevHash,
+		"the real block's PrevHash must survive — it feeds the epoch-nonce lab",
+	)
+}
+
+// TestBlockBeforeSlotSyntheticOnlyNotFound verifies that when only synthetic
+// blobs precede the slot (no real ranking block), BlockBeforeSlot reports
+// ErrBlockNotFound rather than returning a synthetic blob.
+func TestBlockBeforeSlotSyntheticOnlyNotFound(t *testing.T) {
+	db := newTestDB(t)
+
+	ebHash := bytes.Repeat([]byte{0xcc}, 32)
+	require.NoError(t, db.SetGenesisCbor(110, ebHash, []byte{0x80}, nil))
+
+	_, err := BlockBeforeSlot(db, 120)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealEmptyLabNoncesRepairsAndRecomputes verifies that healEmptyLabNonces
+// restores an epoch's empty LastEpochBlockNonce from its boundary block and
+// recomputes the next epoch's nonce. A pre-fix BlockBeforeSlot endorser-block
+// collision could persist an empty lab, collapsing the next epoch's nonce to
+// the NeutralNonce identity (η == candidateNonce) and failing every leader-VRF
+// check in that epoch (the Dijkstra/Leios at-tip wedge).
+func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The last block of the epoch preceding epoch 5 (slot < 200). Its
+	// PrevHash is the lab value epoch 5 must recover to.
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     150,
+		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		PrevHash: boundaryPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	ls := &LedgerState{
+		db: db,
+		epochCache: []models.Epoch{
+			{
+				EpochId:             5,
+				StartSlot:           200,
+				LengthInSlots:       100,
+				LastEpochBlockNonce: nil, // corrupted: empty lab
+			},
+			{
+				EpochId:        6,
+				StartSlot:      300,
+				LengthInSlots:  100,
+				CandidateNonce: candidate,
+				// NeutralNonce-collapsed (wrong) nonce: η == candidateNonce.
+				Nonce: append([]byte(nil), candidate...),
+			},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.healEmptyLabNonces()
+
+	// Epoch 5's lab is recovered from the boundary block's PrevHash.
+	require.Equal(
+		t,
+		boundaryPrevHash,
+		ls.epochCache[0].LastEpochBlockNonce,
+		"empty lab must be restored from the boundary block's PrevHash",
+	)
+
+	// Epoch 6's nonce is recomputed as candidateNonce ⭒ lab, no longer the
+	// NeutralNonce-collapsed value.
+	want, err := lcommon.CalculateEpochNonce(candidate, boundaryPrevHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, want.Bytes(), ls.epochCache[1].Nonce)
+	require.NotEqual(
+		t,
+		candidate,
+		ls.epochCache[1].Nonce,
+		"epoch nonce must no longer be the NeutralNonce-collapsed candidate",
+	)
+}
+
+// TestHealEmptyLabNoncesLeavesValidRecordsUntouched verifies the recovery is a
+// no-op when no epoch has an empty lab — it must not perturb correct state.
+func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	lab := bytes.Repeat([]byte{0xcc}, 32)
+	nonce := bytes.Repeat([]byte{0xdd}, 32)
+	ls := &LedgerState{
+		db: db,
+		epochCache: []models.Epoch{
+			{
+				EpochId:             6,
+				StartSlot:           300,
+				LengthInSlots:       100,
+				LastEpochBlockNonce: lab,
+				Nonce:               nonce,
+				CandidateNonce:      bytes.Repeat([]byte{0xaa}, 32),
+			},
+		},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.healEmptyLabNonces()
+
+	require.Equal(t, lab, ls.epochCache[0].LastEpochBlockNonce)
+	require.Equal(t, nonce, ls.epochCache[0].Nonce)
+}

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,4 +129,64 @@ func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
 
 	require.Equal(t, lab, ls.epochCache[0].LastEpochBlockNonce)
 	require.Equal(t, nonce, ls.epochCache[0].Nonce)
+}
+
+func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     150,
+		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		PrevHash: boundaryPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	require.NoError(t, db.SetEpoch(
+		200,
+		5,
+		bytes.Repeat([]byte{0x55}, 32),
+		nil,
+		nil,
+		nil,
+		eras.ShelleyEraDesc.Id,
+		1,
+		100,
+		nil,
+	))
+	require.NoError(t, db.SetEpoch(
+		300,
+		6,
+		append([]byte(nil), candidate...),
+		nil,
+		candidate,
+		bytes.Repeat([]byte{0x66}, 32),
+		eras.ShelleyEraDesc.Id,
+		1,
+		100,
+		nil,
+	))
+
+	want, err := lcommon.CalculateEpochNonce(candidate, boundaryPrevHash, nil)
+	require.NoError(t, err)
+
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+	require.NoError(t, ls.loadEpochs(nil))
+
+	require.Equal(t, want.Bytes(), ls.epochCache[1].Nonce)
+	require.Equal(t, want.Bytes(), ls.currentEpoch.Nonce)
+	require.Equal(t, want.Bytes(), ls.EpochNonce(6))
+	require.NotEqual(t, candidate, ls.EpochNonce(6))
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4457,6 +4457,11 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 		ls.currentEra = *eraDesc
 		// Update metrics
 		ls.metrics.epochNum.Set(float64(ls.currentEpoch.EpochId))
+		// Recover epoch records whose LastEpochBlockNonce was persisted empty
+		// by the pre-fix BlockBeforeSlot endorser-block collision (see
+		// healEmptyLabNonces). New syncs are unaffected now that
+		// BlockBeforeSlotTxn skips synthetic blobs.
+		ls.healEmptyLabNonces()
 		return nil
 	}
 	// Populate initial epoch
@@ -4520,6 +4525,84 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 	ls.checkpointWrittenForEpoch = rolloverResult.CheckpointWrittenForEpoch
 	ls.metrics.epochNum.Set(rolloverResult.NewEpochNum)
 	return nil
+}
+
+// healEmptyLabNonces repairs epoch records whose LastEpochBlockNonce was
+// persisted empty by the pre-fix BlockBeforeSlot endorser-block collision.
+//
+// LastEpochBlockNonce is the lagged "prevHash of the last block of the previous
+// epoch" that feeds the next epoch's nonce as candidateNonce ⭒ labNonce. Before
+// BlockBeforeSlotTxn was taught to skip synthetic blobs, the labNonce lookup at
+// an epoch transition could return a Leios endorser block (persisted at a
+// block-blob key via SetGenesisCbor with an empty PrevHash) instead of the real
+// ranking block, saving an empty lab. An empty lab collapses the next epoch's
+// nonce to the NeutralNonce identity (η = candidateNonce, skipping the labNonce
+// mix), so every leader-VRF check in that epoch fails and the node wedges at
+// the first block it must verify live.
+//
+// This runs once at startup over the loaded epoch cache. For each non-genesis
+// epoch with an empty lab whose boundary block (now resolved to the real
+// ranking block) carries a valid PrevHash, it restores the lab and recomputes
+// the affected next epoch's nonce in the cache. It is a pure function of
+// already-stored chain data and is idempotent across restarts.
+func (ls *LedgerState) healEmptyLabNonces() {
+	repaired := false
+	for i := range ls.epochCache {
+		ep := &ls.epochCache[i]
+		// The genesis epoch legitimately carries no lagged block nonce.
+		if len(ep.LastEpochBlockNonce) != 0 || ep.StartSlot == 0 {
+			continue
+		}
+		boundary, err := database.BlockBeforeSlot(ls.db, ep.StartSlot)
+		if err != nil ||
+			len(boundary.PrevHash) != lcommon.Blake2b256Size {
+			continue
+		}
+		ep.LastEpochBlockNonce = boundary.PrevHash
+		repaired = true
+		ls.config.Logger.Info(
+			"recovered empty epoch lastEpochBlockNonce",
+			"epoch", ep.EpochId,
+			"boundary_slot", boundary.Slot,
+			"last_epoch_block_nonce",
+			hex.EncodeToString(ep.LastEpochBlockNonce),
+			"component", "ledger",
+		)
+		// Recompute the next epoch's nonce: it used this lab in its formula
+		// and would otherwise be the NeutralNonce-collapsed (η=candidate) value.
+		for j := range ls.epochCache {
+			nxt := &ls.epochCache[j]
+			if nxt.EpochId != ep.EpochId+1 ||
+				len(nxt.CandidateNonce) != lcommon.Blake2b256Size {
+				continue
+			}
+			res, err := lcommon.CalculateEpochNonce(
+				nxt.CandidateNonce,
+				ep.LastEpochBlockNonce,
+				nil,
+			)
+			if err != nil {
+				ls.config.Logger.Warn(
+					"failed to recompute epoch nonce during lab recovery",
+					"epoch", nxt.EpochId,
+					"error", err,
+					"component", "ledger",
+				)
+				continue
+			}
+			ls.config.Logger.Info(
+				"recomputed epoch nonce after lab recovery",
+				"epoch", nxt.EpochId,
+				"previous_nonce", hex.EncodeToString(nxt.Nonce),
+				"epoch_nonce", hex.EncodeToString(res.Bytes()),
+				"component", "ledger",
+			)
+			nxt.Nonce = res.Bytes()
+		}
+	}
+	if repaired {
+		clear(ls.epochNonceHexCache)
+	}
 }
 
 func (ls *LedgerState) loadTip() error {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4448,8 +4448,14 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 	ls.epochCache = epochs
 	clear(ls.epochNonceHexCache)
 	if len(epochs) > 0 {
-		// Set current epoch and era
-		ls.currentEpoch = epochs[len(epochs)-1]
+		// Recover epoch records whose LastEpochBlockNonce was persisted empty
+		// by the pre-fix BlockBeforeSlot endorser-block collision (see
+		// healEmptyLabNonces). New syncs are unaffected now that
+		// BlockBeforeSlotTxn skips synthetic blobs.
+		ls.healEmptyLabNonces()
+		// Set current epoch and era after healing so currentEpoch reflects
+		// any repaired nonce in epochCache.
+		ls.currentEpoch = ls.epochCache[len(ls.epochCache)-1]
 		eraDesc, _ := ls.eraById(ls.currentEpoch.EraId)
 		if eraDesc == nil {
 			return fmt.Errorf("unknown era ID %d", ls.currentEpoch.EraId)
@@ -4457,11 +4463,6 @@ func (ls *LedgerState) loadEpochs(txn *database.Txn) error {
 		ls.currentEra = *eraDesc
 		// Update metrics
 		ls.metrics.epochNum.Set(float64(ls.currentEpoch.EpochId))
-		// Recover epoch records whose LastEpochBlockNonce was persisted empty
-		// by the pre-fix BlockBeforeSlot endorser-block collision (see
-		// healEmptyLabNonces). New syncs are unaffected now that
-		// BlockBeforeSlotTxn skips synthetic blobs.
-		ls.healEmptyLabNonces()
 		return nil
 	}
 	// Populate initial epoch


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes epoch nonce calculation at tip by skipping synthetic endorser/genesis blobs when looking up the previous block and by healing empty last-epoch-block nonces before selecting the current epoch. Prevents NeutralNonce collapse that broke leader-VRF checks and wedged Dijkstra/Leios nodes at tip.

- **Bug Fixes**
  - Make `BlockBeforeSlotTxn` skip synthetic `ID=0` blobs written via `SetGenesisCbor`, returning the last real ranking block.
  - Run `healEmptyLabNonces()` in `loadEpochs` before setting `currentEpoch`; restore missing `last_epoch_block_nonce` from the boundary block, recompute the next epoch’s nonce, and clear the cached hex map.
  - Add tests for synthetic-blob skipping (including synthetic-only not-found) and epoch nonce repair/recompute, including `loadEpochs` refreshing `currentEpoch`.
  - Update docs to explain why `ID=0` blobs are excluded and how this affects epoch nonce calculation.

<sup>Written for commit ecfa563f7b9fa3011313fc59a619ab64fca75f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery for epoch nonce data, helping prevent leader-check failures caused by missing or incorrect boundary nonce values.
  * Block lookups now skip synthetic genesis/endorser entries, reducing the chance of returning the wrong previous block.
* **Documentation**
  * Clarified how block storage, chain iteration, and epoch nonce calculations behave in edge cases.
* **Tests**
  * Added coverage for synthetic block filtering and nonce repair behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->