### PR TITLE
feat(ledger): validate operational certificates on inbound blocks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1030,8 +1030,33 @@ When a network config supplies a `CheckpointsFile` (mainnet and preview ship one
 `ledger/verify_header.go` performs cryptographic validation of block headers:
 - VRF proof verification against the epoch nonce
 - KES signature verification with period checks
-- Operational certificate chain validation
 - Slot leader eligibility checking
+
+### Operational Certificate Validation
+
+Inbound operational-certificate (opcert) validation is split by its data
+dependency across two points in the pipeline:
+
+- **Stateless checks at header verification** (`ledger/verify_opcert.go`,
+  invoked from `verifyBlockHeaderCrypto`): the cold-key signature and the KES
+  period expiry. The cold verification key is the header's issuer vkey — a
+  registered pool's cold key is, by construction, the vkey whose Blake2b224
+  hash is its pool id. `opCertFromHeader` extracts the opcert across the
+  Shelley- and Babbage-family header layouts; `gouroboros`'
+  `ledger.VerifyOpCertSignature` and `ledger.ValidateKesPeriod`
+  (against `maxKESEvolutions` from Shelley genesis) perform the checks. Running
+  here rejects forged or expired opcerts before the block body is fetched.
+  These checks share the existing skip-during-historical-sync gating.
+- **Counter monotonicity at block apply** (`validateOpCertCounter`, invoked
+  from `ledgerProcessBlock` under `shouldValidate`): a read-before-write of the
+  pool's stored opcert counter inside the validation transaction. The counter
+  must equal the last-seen value or be exactly one greater; backward counters
+  (stale/stolen hot key) and gapped counters (skipped rotation) are rejected. A
+  pool with no recorded counter has no baseline (genuine first sighting, or a
+  Mithril-restored start) and is accepted as the baseline. Rollback safety is
+  inherited from the per-`(pool, slot)` `PoolOpCertSequence` store, which drops
+  rows past the rollback slot and recomputes the latest counter, so the counter
+  never advances for a block that is later rolled back.
 
 ### Epoch Nonce Computation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1042,9 +1042,11 @@ dependency across two points in the pipeline:
   period expiry. The cold verification key is the header's issuer vkey — a
   registered pool's cold key is, by construction, the vkey whose Blake2b224
   hash is its pool id. `opCertFromHeader` extracts the opcert across the
-  Shelley- and Babbage-family header layouts; `gouroboros`'
-  `ledger.VerifyOpCertSignature` and `ledger.ValidateKesPeriod`
-  (against `maxKESEvolutions` from Shelley genesis) perform the checks. Running
+  Shelley- and Babbage-family header layouts; `verifyOpCertColdSignature`
+  verifies the cold-key signature over the raw cardano-ledger `OCertSignable`
+  bytes (not `gouroboros`' `ledger.VerifyOpCertSignature`, which hashes a CBOR
+  array that does not match real opcerts), and `ledger.ValidateKesPeriod`
+  (against `maxKESEvolutions` from Shelley genesis) checks expiry. Running
   here rejects forged or expired opcerts before the block body is fetched.
   These checks share the existing skip-during-historical-sync gating.
 - **Counter monotonicity at block apply** (`validateOpCertCounter`, invoked

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1050,15 +1050,20 @@ dependency across two points in the pipeline:
   here rejects forged or expired opcerts before the block body is fetched.
   These checks share the existing skip-during-historical-sync gating.
 - **Counter monotonicity at block apply** (`validateOpCertCounter`, invoked
-  from `ledgerProcessBlock` under `shouldValidate`): a read-before-write of the
-  pool's stored opcert counter inside the validation transaction. The counter
-  must equal the last-seen value or be exactly one greater; backward counters
-  (stale/stolen hot key) and gapped counters (skipped rotation) are rejected. A
-  pool with no recorded counter has no baseline (genuine first sighting, or a
-  Mithril-restored start) and is accepted as the baseline. Rollback safety is
-  inherited from the per-`(pool, slot)` `PoolOpCertSequence` store, which drops
-  rows past the rollback slot and recomputes the latest counter, so the counter
-  never advances for a block that is later rolled back.
+  from `ledgerProcessBlock` under `shouldValidate`, before the block's
+  transactions are validated): a read-before-write of the pool's stored opcert
+  counter inside the validation transaction. A backward counter (below the last
+  seen — stale/stolen hot key) is rejected in every era. A gapped counter (more
+  than one past the last seen) is the Praos over-increment case and is rejected
+  only for Praos eras (Babbage onward, via `opCertNoGapRuleApplies`); TPraos
+  eras (Shelley–Alonzo) enforce only monotonicity, so the gap rule is scoped by
+  era rather than by validation mode (`shouldValidate` can be true for
+  historical or near-tip TPraos blocks). A pool with no recorded counter has no
+  baseline (genuine first sighting, or a Mithril-restored start) and is accepted
+  as the baseline. Rollback safety is inherited from the per-`(pool, slot)`
+  `PoolOpCertSequence` store, which drops rows past the rollback slot and
+  recomputes the latest counter, so the counter never advances for a block that
+  is later rolled back.
 
 ### Epoch Nonce Computation
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -281,7 +281,7 @@ to still be available.
 | `pool_registration_owner` | `id`, `pool_registration_id`, `pool_id`, `key_hash` | PK `id`; indexes `pool_registration_id`, `pool_id` | Owners for a pool registration. Join `pool_registration_id -> pool_registration.id`; `pool_id -> pool.id`. |
 | `pool_registration_relay` | `id`, `pool_registration_id`, `pool_id`, `ipv4`, `ipv6`, `hostname`, `port` | PK `id`; indexes `pool_registration_id`, `pool_id` | Relay addresses for a pool registration. |
 | `pool_retirement` | `id`, `pool_id`, `pool_key_hash`, `certificate_id`, `epoch`, `added_slot` | PK `id`; indexes `pool_id`, `pool_key_hash`, `certificate_id`, `added_slot` | Pool retirement certificate. Synthetic reconcile retirements written by a Mithril v2 catch-up have `certificate_id = 0` and join to no `certs` row (`epoch`/`added_slot` are the catch-up tip); joins on `certificate_id` must be LEFT JOINs to keep them visible. |
-| `pool_opcert_sequence` | `id`, `pool_key_hash`, `slot`, `sequence` | PK `id`; unique `(pool_key_hash, slot)`; index `slot` | Observed operational certificate sequence by slot. |
+| `pool_opcert_sequence` | `id`, `pool_key_hash`, `slot`, `sequence` | PK `id`; unique `(pool_key_hash, slot)`; index `slot` | Observed operational certificate sequence by slot. Read before write inside the block-apply transaction to enforce inbound opcert counter monotonicity; per-slot rows let rollback drop entries past the rollback slot and recompute `pool.latest_op_cert_sequence`. |
 
 ### DReps, Governance, and Committee
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -48,14 +48,10 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/ledger"
-	"github.com/blinklabs-io/gouroboros/ledger/allegra"
-	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
-	"github.com/blinklabs-io/gouroboros/ledger/mary"
-	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -3932,12 +3928,49 @@ func (ls *LedgerState) ledgerProcessBlock(
 			}
 		}
 	}
-	if seqNum, ok := opCertSequenceNumber(block); ok {
+	if opCert, ok := opCertFromHeader(block.Header()); ok {
 		issuerVkey := block.IssuerVkey()
 		poolKeyHash := lcommon.PoolKeyHash(issuerVkey.Hash())
+		// Counter monotonicity is the stateful half of inbound opcert
+		// validation: read the pool's last-seen counter before writing this
+		// block's, inside the same validation transaction. The opcert counter
+		// must equal the last-seen counter or be exactly one greater. A
+		// backward counter signals a stale or stolen hot key; a gapped counter
+		// signals a skipped rotation. Both must be rejected. Only enforced
+		// under shouldValidate (live, current-era blocks): historical blocks
+		// were already network-validated, and the over-increment rule postdates
+		// the early eras replayed during sync. Rollback safety is inherited
+		// from the per-(pool,slot) PoolOpCertSequence store, which drops rows
+		// past the rollback slot and recomputes the latest counter.
+		if shouldValidate {
+			stored, found, err := ls.db.LatestPoolOpCertSequence(
+				poolKeyHash,
+				txn,
+			)
+			if err != nil {
+				if delta != nil {
+					delta.Release()
+				}
+				return nil, fmt.Errorf(
+					"read opcert counter for pool %x: %w",
+					poolKeyHash,
+					err,
+				)
+			}
+			if err := validateOpCertCounter(
+				stored,
+				found,
+				opCert.IssueNumber,
+			); err != nil {
+				if delta != nil {
+					delta.Release()
+				}
+				return nil, fmt.Errorf("pool %x: %w", poolKeyHash, err)
+			}
+		}
 		if err := ls.db.UpdatePoolOpCertSequence(
 			poolKeyHash,
-			uint64(seqNum),
+			opCert.IssueNumber,
 			point.Slot,
 			txn,
 		); err != nil {
@@ -3948,31 +3981,6 @@ func (ls *LedgerState) ledgerProcessBlock(
 		}
 	}
 	return delta, nil
-}
-
-func opCertSequenceNumber(block ledger.Block) (uint32, bool) {
-	switch header := block.Header().(type) {
-	case *dijkstra.DijkstraBlockHeader:
-		// Distinct concrete type embedding BabbageBlockHeader; a type
-		// switch won't fall through to the Babbage case, so it needs an
-		// explicit entry or per-pool OpCert sequence tracking is skipped
-		// for Dijkstra-era blocks.
-		return header.Body.OpCert.SequenceNumber, true
-	case *shelley.ShelleyBlockHeader:
-		return header.Body.OpCertSequenceNumber, true
-	case *allegra.AllegraBlockHeader:
-		return header.Body.OpCertSequenceNumber, true
-	case *mary.MaryBlockHeader:
-		return header.Body.OpCertSequenceNumber, true
-	case *alonzo.AlonzoBlockHeader:
-		return header.Body.OpCertSequenceNumber, true
-	case *babbage.BabbageBlockHeader:
-		return header.Body.OpCert.SequenceNumber, true
-	case *conway.ConwayBlockHeader:
-		return header.Body.OpCert.SequenceNumber, true
-	default:
-		return 0, false
-	}
 }
 
 // updateTipMetrics updates gauges from in-memory state. Call under ls.Lock().

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3668,16 +3668,17 @@ func (ls *LedgerState) ledgerProcessBlock(
 		opCertPoolKeyHash = lcommon.PoolKeyHash(block.IssuerVkey().Hash())
 		// Counter monotonicity is the stateful half of inbound opcert
 		// validation: read the pool's last-seen counter before processing this
-		// block, inside the same validation transaction. The opcert counter
-		// must equal the last-seen counter or be exactly one greater. A
-		// backward counter signals a stale or stolen hot key; a gapped counter
-		// signals a skipped rotation. Both must be rejected. Only enforced
-		// under shouldValidate (live, current-era blocks): historical blocks
-		// were already network-validated, and the over-increment rule postdates
-		// the early eras replayed during sync. The counter is recorded once the
-		// block's transactions are processed (below); rollback safety is
-		// inherited from the per-(pool,slot) PoolOpCertSequence store, which
-		// drops rows past the rollback slot and recomputes the latest counter.
+		// block, inside the same validation transaction. A backward counter
+		// (below the last seen) signals a stale or stolen hot key and is
+		// rejected in every era. A gapped counter (more than one past the last
+		// seen) is the Praos over-increment case and is rejected only for Praos
+		// eras (Babbage onward); TPraos eras (Shelley–Alonzo) enforce only
+		// monotonicity, so the gap rule is scoped by era rather than by
+		// validation mode (shouldValidate can be true for historical or
+		// near-tip TPraos blocks). The counter is recorded once the block's
+		// transactions are processed (below); rollback safety is inherited from
+		// the per-(pool,slot) PoolOpCertSequence store, which drops rows past
+		// the rollback slot and recomputes the latest counter.
 		if shouldValidate {
 			stored, found, err := ls.db.LatestPoolOpCertSequence(
 				opCertPoolKeyHash,
@@ -3694,6 +3695,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 				stored,
 				found,
 				opCert.IssueNumber,
+				opCertNoGapRuleApplies(block.Era().Id),
 			); err != nil {
 				return nil, fmt.Errorf("pool %x: %w", opCertPoolKeyHash, err)
 			}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3657,6 +3657,48 @@ func (ls *LedgerState) ledgerProcessBlock(
 			return nil, err
 		}
 	}
+	// Validate the operational certificate counter before processing the
+	// block's transactions, so a stale or gapped opcert is rejected by this
+	// cheap stateful check rather than after full transaction and Plutus
+	// validation. The cold-key signature and KES-period expiry were already
+	// checked at header verification.
+	opCert, hasOpCert := opCertFromHeader(block.Header())
+	var opCertPoolKeyHash lcommon.PoolKeyHash
+	if hasOpCert {
+		opCertPoolKeyHash = lcommon.PoolKeyHash(block.IssuerVkey().Hash())
+		// Counter monotonicity is the stateful half of inbound opcert
+		// validation: read the pool's last-seen counter before processing this
+		// block, inside the same validation transaction. The opcert counter
+		// must equal the last-seen counter or be exactly one greater. A
+		// backward counter signals a stale or stolen hot key; a gapped counter
+		// signals a skipped rotation. Both must be rejected. Only enforced
+		// under shouldValidate (live, current-era blocks): historical blocks
+		// were already network-validated, and the over-increment rule postdates
+		// the early eras replayed during sync. The counter is recorded once the
+		// block's transactions are processed (below); rollback safety is
+		// inherited from the per-(pool,slot) PoolOpCertSequence store, which
+		// drops rows past the rollback slot and recomputes the latest counter.
+		if shouldValidate {
+			stored, found, err := ls.db.LatestPoolOpCertSequence(
+				opCertPoolKeyHash,
+				txn,
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"read opcert counter for pool %x: %w",
+					opCertPoolKeyHash,
+					err,
+				)
+			}
+			if err := validateOpCertCounter(
+				stored,
+				found,
+				opCert.IssueNumber,
+			); err != nil {
+				return nil, fmt.Errorf("pool %x: %w", opCertPoolKeyHash, err)
+			}
+		}
+	}
 	// Apply the referenced Leios endorser block's transactions before the
 	// ranking block's own, so the endorser-resident outputs the ranking block
 	// spends are present in the UTxO set. The endorser block is identified by
@@ -3928,48 +3970,13 @@ func (ls *LedgerState) ledgerProcessBlock(
 			}
 		}
 	}
-	if opCert, ok := opCertFromHeader(block.Header()); ok {
-		issuerVkey := block.IssuerVkey()
-		poolKeyHash := lcommon.PoolKeyHash(issuerVkey.Hash())
-		// Counter monotonicity is the stateful half of inbound opcert
-		// validation: read the pool's last-seen counter before writing this
-		// block's, inside the same validation transaction. The opcert counter
-		// must equal the last-seen counter or be exactly one greater. A
-		// backward counter signals a stale or stolen hot key; a gapped counter
-		// signals a skipped rotation. Both must be rejected. Only enforced
-		// under shouldValidate (live, current-era blocks): historical blocks
-		// were already network-validated, and the over-increment rule postdates
-		// the early eras replayed during sync. Rollback safety is inherited
-		// from the per-(pool,slot) PoolOpCertSequence store, which drops rows
-		// past the rollback slot and recomputes the latest counter.
-		if shouldValidate {
-			stored, found, err := ls.db.LatestPoolOpCertSequence(
-				poolKeyHash,
-				txn,
-			)
-			if err != nil {
-				if delta != nil {
-					delta.Release()
-				}
-				return nil, fmt.Errorf(
-					"read opcert counter for pool %x: %w",
-					poolKeyHash,
-					err,
-				)
-			}
-			if err := validateOpCertCounter(
-				stored,
-				found,
-				opCert.IssueNumber,
-			); err != nil {
-				if delta != nil {
-					delta.Release()
-				}
-				return nil, fmt.Errorf("pool %x: %w", poolKeyHash, err)
-			}
-		}
+	// Record the opcert counter now that the block's transactions are
+	// processed. The monotonicity check ran before transaction validation
+	// (above); this write is what advances the stored counter, and it is
+	// rolled back with the transaction if the block is rejected.
+	if hasOpCert {
 		if err := ls.db.UpdatePoolOpCertSequence(
-			poolKeyHash,
+			opCertPoolKeyHash,
 			opCert.IssueNumber,
 			point.Slot,
 			txn,

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -212,6 +212,22 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 		return err
 	}
 
+	// Validate the operational certificate's cold-key signature and KES
+	// period expiry. This is the stateless half of inbound opcert validation;
+	// the counter-monotonicity check lives in the block-apply transaction.
+	if err := verifyOpCertHeaderCrypto(
+		block.Header(),
+		blockSlot,
+		slotsPerKesPeriod,
+		ls.maxKESEvolutions(),
+	); err != nil {
+		return fmt.Errorf(
+			"block header verification failed at slot %d: %w",
+			blockSlot,
+			err,
+		)
+	}
+
 	// Bind the header's VRF key to the pool's on-chain registered VRF key.
 	// The crypto path above verifies the VRF proof only against the key carried
 	// in the header (SkipStakePoolValidation skips gouroboros' registered-key
@@ -580,6 +596,21 @@ func registeredPoolVrfKeyHash(
 	}
 	copy(vrfHash[:], pool.VrfKeyHash)
 	return vrfHash, true
+}
+
+// maxKESEvolutions returns the maximum number of KES evolutions allowed before
+// an operational certificate expires, from Shelley genesis. Returns 0 when the
+// genesis is unavailable, in which case opcert KES-period expiry is left to the
+// lighter future-cert guard inside VerifyBlock.
+func (ls *LedgerState) maxKESEvolutions() uint64 {
+	if ls.config.CardanoNodeConfig == nil {
+		return 0
+	}
+	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if shelleyGenesis == nil || shelleyGenesis.MaxKESEvolutions <= 0 {
+		return 0
+	}
+	return uint64(shelleyGenesis.MaxKESEvolutions) // #nosec G115 -- guarded > 0
 }
 
 func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"log/slog"
@@ -112,13 +113,18 @@ func createTestBlock(
 		epochNonce[i] = nonceSeed + byte(i) //nolint:gosec
 	}
 
-	// Create OpCert: cold key signs [hot_vkey, seq_number, kes_period]
+	// Create OpCert: the cold key signs the cardano-ledger OCertSignable
+	// representation — KES vkey (32) || issue number (8 BE) || KES period
+	// (8 BE), the raw concatenation real cardano-cli opcerts use, NOT a CBOR
+	// array. See ledger/forging/keys.go ValidateOpCert and
+	// verifyOpCertColdSignature.
 	opCertSeqNum := uint32(0)
 	opCertKesPeriod := uint32(0)
-	opCertBody := []any{kesPk, opCertSeqNum, opCertKesPeriod}
-	opCertBodyBytes, err := cbor.Encode(opCertBody)
-	require.NoError(t, err, "CBOR encode OpCert body should succeed")
-	opCertSig := ed25519.Sign(coldPrivKey, opCertBodyBytes)
+	var opCertBody [48]byte
+	copy(opCertBody[:32], kesPk)
+	binary.BigEndian.PutUint64(opCertBody[32:40], uint64(opCertSeqNum))
+	binary.BigEndian.PutUint64(opCertBody[40:48], uint64(opCertKesPeriod))
+	opCertSig := ed25519.Sign(coldPrivKey, opCertBody[:])
 
 	if tamper == tamperOpCertSig {
 		opCertSig[0] ^= 0xFF
@@ -346,23 +352,22 @@ func TestVerifyBlockHeader_TamperedVRFProof(t *testing.T) {
 	)
 }
 
-// TestVerifyBlockHeader_TamperedOpCertSignature verifies the current
-// behavior for blocks with tampered OpCert signatures. Because
-// verifyBlockHeader uses SkipStakePoolValidation (OpCert cold-key
-// signature verification requires pool registration data from ledger
-// state), the tampered signature is not caught at this layer. Full
-// OpCert validation happens during stake pool verification in the
-// ledger processing pipeline.
+// TestVerifyBlockHeader_TamperedOpCertSignature verifies that the
+// VerifyBlock-based crypto path (verifyBlockHeaderHex) does not, by itself,
+// validate the OpCert cold-key signature: it runs with SkipStakePoolValidation.
+// Inbound OpCert validation lives in the sibling verifyOpCertHeaderCrypto
+// (exercised by verify_opcert_test.go), which verifyBlockHeaderCrypto invokes
+// alongside this path. This test pins the boundary so the two layers stay
+// distinct.
 func TestVerifyBlockHeader_TamperedOpCertSignature(t *testing.T) {
 	tb := createTestBlock(t, [32]byte{4}, 77, tamperOpCertSig)
 	err := verifyBlockHeader(tb.block, tb.epochNonce, tb.slotsPerKesPeriod)
-	// OpCert signature is NOT verified at this layer (requires ledger
-	// state for pool registration lookup), so tampering does not cause
-	// an error here.
+	// The hex/VerifyBlock layer does not verify the OpCert signature, so
+	// tampering does not cause an error here; verifyOpCertHeaderCrypto does.
 	assert.NoError(
 		t,
 		err,
-		"OpCert signature not validated at header-only layer",
+		"OpCert signature not validated by the VerifyBlock crypto layer",
 	)
 }
 

--- a/ledger/verify_opcert.go
+++ b/ledger/verify_opcert.go
@@ -102,11 +102,24 @@ func babbageOpCert(oc babbage.BabbageOpCert) *ledger.OpCert {
 	}
 }
 
-// validateOpCertCounter enforces operational-certificate counter monotonicity:
-// the candidate counter must equal the pool's last-seen counter or be exactly
-// one greater. A counter below the last-seen value signals a stale or stolen
-// hot key; a counter that skips ahead signals a gapped rotation. Both are
-// rejected.
+// opCertNoGapRuleApplies reports whether the operational-certificate
+// over-increment (no-gap) counter rule applies to a block in the given era.
+// That rule — reject a counter that skips ahead of the last seen by more than
+// one — is part of the Praos protocol (Babbage onward). TPraos eras
+// (Shelley–Alonzo) enforce only counter monotonicity, so a valid TPraos block
+// may advance its opcert counter by more than one.
+func opCertNoGapRuleApplies(eraId uint8) bool {
+	return eraId >= babbage.EraIdBabbage
+}
+
+// validateOpCertCounter enforces operational-certificate counter rules for the
+// pool's issuer. A counter below the last-seen value (candidate < stored)
+// signals a stale or stolen hot key and is rejected in every era. A counter
+// that skips ahead (candidate > stored+1) is the Praos over-increment case and
+// is rejected only when enforceNoGap is set — the rule is Praos-only (Babbage
+// onward); TPraos eras (Shelley–Alonzo) accept any candidate >= stored, so the
+// gap check must be scoped by era rather than by validation mode. See
+// opCertNoGapRuleApplies.
 //
 // When the pool has no recorded counter (found is false) there is no baseline
 // to compare against — a genuine first sighting, or a pool that last forged
@@ -115,26 +128,30 @@ func babbageOpCert(oc babbage.BabbageOpCert) *ledger.OpCert {
 // zero here would falsely reject a valid high-counter block and stall the
 // chain; the honest chain we follow already enforced monotonicity at that
 // pool's real baseline.
-func validateOpCertCounter(stored uint64, found bool, candidate uint64) error {
+func validateOpCertCounter(
+	stored uint64,
+	found bool,
+	candidate uint64,
+	enforceNoGap bool,
+) error {
 	if !found {
 		return nil
 	}
-	switch {
-	case candidate < stored:
+	if candidate < stored {
 		return fmt.Errorf(
 			"opcert counter %d is below last seen %d (stale or stolen hot key)",
 			candidate,
 			stored,
 		)
-	case candidate > stored+1:
+	}
+	if enforceNoGap && candidate > stored+1 {
 		return fmt.Errorf(
 			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
 			candidate,
 			stored,
 		)
-	default:
-		return nil
 	}
+	return nil
 }
 
 const (

--- a/ledger/verify_opcert.go
+++ b/ledger/verify_opcert.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"crypto/ed25519"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// opCertFromHeader extracts the operational certificate from a Praos/TPraos
+// block header. The Shelley-family headers carry the opcert fields flat on the
+// header body; the Babbage-family headers (Babbage/Conway/Dijkstra) nest them
+// under a BabbageOpCert. Byron and unknown headers have no opcert, so ok is
+// false.
+func opCertFromHeader(header ledger.BlockHeader) (*ledger.OpCert, bool) {
+	switch h := header.(type) {
+	case *dijkstra.DijkstraBlockHeader:
+		// Distinct concrete type embedding BabbageBlockHeader; a type
+		// switch won't fall through to the Babbage case, so it needs an
+		// explicit entry or opcert validation is skipped for Dijkstra blocks.
+		return babbageOpCert(h.Body.OpCert), true
+	case *shelley.ShelleyBlockHeader:
+		return shelleyOpCert(
+			h.Body.OpCertHotVkey,
+			h.Body.OpCertSequenceNumber,
+			h.Body.OpCertKesPeriod,
+			h.Body.OpCertSignature,
+		), true
+	case *allegra.AllegraBlockHeader:
+		return shelleyOpCert(
+			h.Body.OpCertHotVkey,
+			h.Body.OpCertSequenceNumber,
+			h.Body.OpCertKesPeriod,
+			h.Body.OpCertSignature,
+		), true
+	case *mary.MaryBlockHeader:
+		return shelleyOpCert(
+			h.Body.OpCertHotVkey,
+			h.Body.OpCertSequenceNumber,
+			h.Body.OpCertKesPeriod,
+			h.Body.OpCertSignature,
+		), true
+	case *alonzo.AlonzoBlockHeader:
+		return shelleyOpCert(
+			h.Body.OpCertHotVkey,
+			h.Body.OpCertSequenceNumber,
+			h.Body.OpCertKesPeriod,
+			h.Body.OpCertSignature,
+		), true
+	case *babbage.BabbageBlockHeader:
+		return babbageOpCert(h.Body.OpCert), true
+	case *conway.ConwayBlockHeader:
+		return babbageOpCert(h.Body.OpCert), true
+	default:
+		return nil, false
+	}
+}
+
+func shelleyOpCert(
+	hotVkey []byte,
+	sequenceNumber uint32,
+	kesPeriod uint32,
+	signature []byte,
+) *ledger.OpCert {
+	return &ledger.OpCert{
+		KesVkey:       hotVkey,
+		IssueNumber:   uint64(sequenceNumber),
+		KesPeriod:     uint64(kesPeriod),
+		ColdSignature: signature,
+	}
+}
+
+func babbageOpCert(oc babbage.BabbageOpCert) *ledger.OpCert {
+	return &ledger.OpCert{
+		KesVkey:       oc.HotVkey,
+		IssueNumber:   uint64(oc.SequenceNumber),
+		KesPeriod:     uint64(oc.KesPeriod),
+		ColdSignature: oc.Signature,
+	}
+}
+
+// validateOpCertCounter enforces operational-certificate counter monotonicity:
+// the candidate counter must equal the pool's last-seen counter or be exactly
+// one greater. A counter below the last-seen value signals a stale or stolen
+// hot key; a counter that skips ahead signals a gapped rotation. Both are
+// rejected.
+//
+// When the pool has no recorded counter (found is false) there is no baseline
+// to compare against — a genuine first sighting, or a pool that last forged
+// before this node's local history begins (e.g. a Mithril-restored start) — so
+// the candidate is accepted and becomes the baseline. Enforcing a baseline of
+// zero here would falsely reject a valid high-counter block and stall the
+// chain; the honest chain we follow already enforced monotonicity at that
+// pool's real baseline.
+func validateOpCertCounter(stored uint64, found bool, candidate uint64) error {
+	if !found {
+		return nil
+	}
+	switch {
+	case candidate < stored:
+		return fmt.Errorf(
+			"opcert counter %d is below last seen %d (stale or stolen hot key)",
+			candidate,
+			stored,
+		)
+	case candidate > stored+1:
+		return fmt.Errorf(
+			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
+			candidate,
+			stored,
+		)
+	default:
+		return nil
+	}
+}
+
+const (
+	// opCertKesVkeySize is the length of the KES (hot) verification key carried
+	// in an operational certificate.
+	opCertKesVkeySize = 32
+	// opCertSignableSize is the length of the cardano-ledger OCertSignable
+	// representation: KES vkey || counter (uint64 BE) || KES period (uint64 BE).
+	opCertSignableSize = opCertKesVkeySize + 8 + 8
+)
+
+// verifyOpCertColdSignature verifies the pool cold-key signature over the
+// operational certificate.
+//
+// The signed message is the cardano-ledger OCertSignable representation: the
+// raw concatenation of the KES (hot) verification key, the issue counter as a
+// big-endian uint64, and the KES period as a big-endian uint64 — NOT a CBOR
+// encoding. This matches what cardano-node signs (verified byte-for-byte
+// against a real cardano-cli NodeOperationalCertificate) and the forging-side
+// check in ledger/forging/keys.go ValidateOpCert.
+//
+// gouroboros' ledger.VerifyOpCertSignature is intentionally NOT used here: it
+// hashes a CBOR array ([kes_vkey, issue_number, kes_period]) instead of this
+// raw representation, which does not match real opcerts and would reject every
+// inbound block.
+func verifyOpCertColdSignature(opCert *ledger.OpCert, coldVkey []byte) error {
+	if len(coldVkey) != ed25519.PublicKeySize {
+		return fmt.Errorf(
+			"cold vkey must be %d bytes, got %d",
+			ed25519.PublicKeySize,
+			len(coldVkey),
+		)
+	}
+	if len(opCert.KesVkey) != opCertKesVkeySize {
+		return fmt.Errorf(
+			"KES vkey must be %d bytes, got %d",
+			opCertKesVkeySize,
+			len(opCert.KesVkey),
+		)
+	}
+	if len(opCert.ColdSignature) != ed25519.SignatureSize {
+		return fmt.Errorf(
+			"cold signature must be %d bytes, got %d",
+			ed25519.SignatureSize,
+			len(opCert.ColdSignature),
+		)
+	}
+	var signable [opCertSignableSize]byte
+	copy(signable[:opCertKesVkeySize], opCert.KesVkey)
+	binary.BigEndian.PutUint64(
+		signable[opCertKesVkeySize:opCertKesVkeySize+8],
+		opCert.IssueNumber,
+	)
+	binary.BigEndian.PutUint64(
+		signable[opCertKesVkeySize+8:],
+		opCert.KesPeriod,
+	)
+	if !ed25519.Verify(coldVkey, signable[:], opCert.ColdSignature) {
+		return errors.New("signature verification failed")
+	}
+	return nil
+}
+
+// verifyOpCertHeaderCrypto performs the stateless inbound operational
+// certificate checks for a block header: the cold-key signature and the KES
+// period expiry. The cold verification key is the header's issuer vkey — a
+// registered pool's cold key is, by construction, the vkey whose Blake2b224
+// hash is its pool id, so verifying against header.IssuerVkey() is verifying
+// against the registered cold key.
+//
+// The counter-monotonicity check is intentionally NOT done here: it depends on
+// per-pool ledger state and must be a read-before-write inside the block-apply
+// transaction (see ledgerProcessBlock), where ordering and rollback are
+// correct.
+//
+// Byron and unknown headers carry no opcert and return nil.
+func verifyOpCertHeaderCrypto(
+	header ledger.BlockHeader,
+	slot uint64,
+	slotsPerKesPeriod uint64,
+	maxKesEvolutions uint64,
+) error {
+	opCert, ok := opCertFromHeader(header)
+	if !ok {
+		return nil
+	}
+	coldVkey := header.IssuerVkey()
+	if err := verifyOpCertColdSignature(opCert, coldVkey[:]); err != nil {
+		return fmt.Errorf("opcert cold-key signature invalid: %w", err)
+	}
+	// KES expiry needs both genesis parameters. ValidateKesPeriod errors when
+	// either is zero, so when they're unavailable we fall back to the lighter
+	// future-cert KES guard that VerifyKesComponents already performed inside
+	// VerifyBlock rather than failing the block.
+	if slotsPerKesPeriod > 0 && maxKesEvolutions > 0 {
+		if _, err := ledger.ValidateKesPeriod(
+			opCert.KesPeriod,
+			slot,
+			slotsPerKesPeriod,
+			maxKesEvolutions,
+		); err != nil {
+			return fmt.Errorf("opcert KES period invalid: %w", err)
+		}
+	}
+	return nil
+}

--- a/ledger/verify_opcert_test.go
+++ b/ledger/verify_opcert_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -149,51 +151,80 @@ func TestVerifyOpCertHeaderCrypto_MaxKESEvolutionsZeroSkipsExpiry(t *testing.T) 
 	require.NoError(t, err)
 }
 
-// TestValidateOpCertCounter exercises the counter-monotonicity rule applied at
-// block-apply time.
+// TestValidateOpCertCounter exercises the counter rules applied at block-apply
+// time. The backward (stale) rule applies to every era; the no-gap
+// (over-increment) rule is Praos-only, so the gapped cases are split by
+// enforceNoGap: a TPraos block (enforceNoGap=false) accepts a jump, a Praos
+// block (enforceNoGap=true) rejects it.
 func TestValidateOpCertCounter(t *testing.T) {
 	tests := []struct {
-		name      string
-		stored    uint64
-		found     bool
-		candidate uint64
-		wantErr   string
+		name         string
+		stored       uint64
+		found        bool
+		candidate    uint64
+		enforceNoGap bool
+		wantErr      string
 	}{
 		{
-			name:      "first sighting accepts any counter",
-			found:     false,
-			candidate: 7,
+			name:         "first sighting accepts any counter",
+			found:        false,
+			candidate:    7,
+			enforceNoGap: true,
 		},
 		{
-			name:      "equal to last seen",
-			stored:    5,
-			found:     true,
-			candidate: 5,
+			name:         "equal to last seen",
+			stored:       5,
+			found:        true,
+			candidate:    5,
+			enforceNoGap: true,
 		},
 		{
-			name:      "exactly one greater",
-			stored:    5,
-			found:     true,
-			candidate: 6,
+			name:         "exactly one greater",
+			stored:       5,
+			found:        true,
+			candidate:    6,
+			enforceNoGap: true,
 		},
 		{
-			name:      "backward counter rejected",
-			stored:    5,
-			found:     true,
-			candidate: 4,
-			wantErr:   "below last seen",
+			name:         "backward counter rejected (praos)",
+			stored:       5,
+			found:        true,
+			candidate:    4,
+			enforceNoGap: true,
+			wantErr:      "below last seen",
 		},
 		{
-			name:      "gapped counter rejected",
-			stored:    5,
-			found:     true,
-			candidate: 7,
-			wantErr:   "skips ahead",
+			name:         "backward counter rejected (tpraos)",
+			stored:       5,
+			found:        true,
+			candidate:    4,
+			enforceNoGap: false,
+			wantErr:      "below last seen",
+		},
+		{
+			name:         "gapped counter rejected under praos",
+			stored:       5,
+			found:        true,
+			candidate:    7,
+			enforceNoGap: true,
+			wantErr:      "skips ahead",
+		},
+		{
+			name:         "gapped counter accepted under tpraos",
+			stored:       5,
+			found:        true,
+			candidate:    7,
+			enforceNoGap: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOpCertCounter(tt.stored, tt.found, tt.candidate)
+			err := validateOpCertCounter(
+				tt.stored,
+				tt.found,
+				tt.candidate,
+				tt.enforceNoGap,
+			)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return
@@ -202,4 +233,19 @@ func TestValidateOpCertCounter(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+// TestOpCertNoGapRuleApplies pins the TPraos→Praos boundary: the opcert no-gap
+// rule is off through Alonzo (TPraos) and on from Babbage onward (Praos).
+func TestOpCertNoGapRuleApplies(t *testing.T) {
+	assert.False(
+		t,
+		opCertNoGapRuleApplies(alonzo.EraIdAlonzo),
+		"Alonzo runs TPraos; the no-gap rule must be off",
+	)
+	assert.True(
+		t,
+		opCertNoGapRuleApplies(babbage.EraIdBabbage),
+		"Babbage runs Praos; the no-gap rule must be on",
+	)
 }

--- a/ledger/verify_opcert_test.go
+++ b/ledger/verify_opcert_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"testing"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpCertFromHeader_Babbage verifies the per-era extractor pulls the opcert
+// fields off a Babbage-family header body.
+func TestOpCertFromHeader_Babbage(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{10}, 9, tamperNone)
+	opCert, ok := opCertFromHeader(tb.block.Header())
+	require.True(t, ok)
+	require.NotNil(t, opCert)
+
+	body := tb.block.header.Body
+	assert.Equal(t, body.OpCert.HotVkey, opCert.KesVkey)
+	assert.Equal(t, uint64(body.OpCert.SequenceNumber), opCert.IssueNumber)
+	assert.Equal(t, uint64(body.OpCert.KesPeriod), opCert.KesPeriod)
+	assert.Equal(t, body.OpCert.Signature, opCert.ColdSignature)
+}
+
+// TestOpCertFromHeader_NonPraosReturnsFalse verifies headers without an opcert
+// (Byron) report ok=false so they are skipped by opcert validation.
+func TestOpCertFromHeader_NonPraosReturnsFalse(t *testing.T) {
+	opCert, ok := opCertFromHeader(&byron.ByronMainBlockHeader{})
+	assert.False(t, ok)
+	assert.Nil(t, opCert)
+}
+
+// TestVerifyOpCertColdSignature_RealCardanoCliCert is a known-answer test that
+// pins the opcert signable representation to real cardano output. The values
+// are taken from a real cardano-cli NodeOperationalCertificate
+// (config/cardano/devnet/keys/opcert.cert). The signature verifies only under
+// the raw 48-byte OCertSignable representation (KES vkey || counter || period);
+// gouroboros' CBOR-based VerifyOpCertSignature rejects it, which is exactly why
+// verifyOpCertColdSignature does not call that function. If this test ever
+// fails, the inbound check has drifted from real cardano and would stall the
+// chain by rejecting valid blocks.
+func TestVerifyOpCertColdSignature_RealCardanoCliCert(t *testing.T) {
+	mustHex := func(s string) []byte {
+		b, err := hex.DecodeString(s)
+		require.NoError(t, err)
+		return b
+	}
+	opCert := &gledger.OpCert{
+		KesVkey:     mustHex("4cd49bb05e9885142fe7af1481107995298771fd1a24e72b506a4d600ee2b312"),
+		IssueNumber: 0,
+		KesPeriod:   0,
+		ColdSignature: mustHex(
+			"89fc9e9f551b2ea873bf31643659d049152d5c8e8de86be4056370bccc5fa62d" +
+				"d12e3f152f1664e614763e46eaa7a17ed366b5cef19958773d1ab96941442e0b",
+		),
+	}
+	coldVkey := mustHex(
+		"5a3d778e76741a009e29d23093cfe046131808d34d7c864967b515e98dfc3583",
+	)
+
+	require.NoError(
+		t,
+		verifyOpCertColdSignature(opCert, coldVkey),
+		"real cardano-cli opcert must verify under the raw OCertSignable representation",
+	)
+
+	// A flipped signature must be rejected.
+	bad := *opCert
+	bad.ColdSignature = append([]byte(nil), opCert.ColdSignature...)
+	bad.ColdSignature[0] ^= 0xFF
+	require.Error(t, verifyOpCertColdSignature(&bad, coldVkey))
+}
+
+// TestVerifyOpCertHeaderCrypto_Valid verifies a well-formed opcert passes the
+// inbound cold-signature and KES-period checks.
+func TestVerifyOpCertHeaderCrypto_Valid(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{11}, 13, tamperNone)
+	err := verifyOpCertHeaderCrypto(
+		tb.block.Header(),
+		tb.block.SlotNumber(),
+		tb.slotsPerKesPeriod,
+		62,
+	)
+	require.NoError(t, err)
+}
+
+// TestVerifyOpCertHeaderCrypto_TamperedColdSignature verifies a flipped
+// cold-key signature is now rejected at header verification — this is the
+// behavior gap issue #2608 closes.
+func TestVerifyOpCertHeaderCrypto_TamperedColdSignature(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{12}, 14, tamperOpCertSig)
+	err := verifyOpCertHeaderCrypto(
+		tb.block.Header(),
+		tb.block.SlotNumber(),
+		tb.slotsPerKesPeriod,
+		62,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cold-key signature")
+}
+
+// TestVerifyOpCertHeaderCrypto_ExpiredKESPeriod verifies an opcert evaluated
+// beyond maxKesEvolutions is rejected. The generated opcert starts at KES
+// period 0, so evaluating it five KES periods later with a max of three
+// evolutions is expired.
+func TestVerifyOpCertHeaderCrypto_ExpiredKESPeriod(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{13}, 15, tamperNone)
+	const slotsPerKesPeriod = uint64(100)
+	err := verifyOpCertHeaderCrypto(
+		tb.block.Header(),
+		5*slotsPerKesPeriod,
+		slotsPerKesPeriod,
+		3,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KES period")
+}
+
+// TestVerifyOpCertHeaderCrypto_MaxKESEvolutionsZeroSkipsExpiry verifies the
+// expiry check degrades gracefully when the genesis parameter is unavailable:
+// the same far-future slot that expired above passes when maxKesEvolutions is
+// zero, leaving the lighter future-cert guard inside VerifyBlock in charge.
+func TestVerifyOpCertHeaderCrypto_MaxKESEvolutionsZeroSkipsExpiry(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{14}, 16, tamperNone)
+	const slotsPerKesPeriod = uint64(100)
+	err := verifyOpCertHeaderCrypto(
+		tb.block.Header(),
+		5*slotsPerKesPeriod,
+		slotsPerKesPeriod,
+		0,
+	)
+	require.NoError(t, err)
+}
+
+// TestValidateOpCertCounter exercises the counter-monotonicity rule applied at
+// block-apply time.
+func TestValidateOpCertCounter(t *testing.T) {
+	tests := []struct {
+		name      string
+		stored    uint64
+		found     bool
+		candidate uint64
+		wantErr   string
+	}{
+		{
+			name:      "first sighting accepts any counter",
+			found:     false,
+			candidate: 7,
+		},
+		{
+			name:      "equal to last seen",
+			stored:    5,
+			found:     true,
+			candidate: 5,
+		},
+		{
+			name:      "exactly one greater",
+			stored:    5,
+			found:     true,
+			candidate: 6,
+		},
+		{
+			name:      "backward counter rejected",
+			stored:    5,
+			found:     true,
+			candidate: 4,
+			wantErr:   "below last seen",
+		},
+		{
+			name:      "gapped counter rejected",
+			stored:    5,
+			found:     true,
+			candidate: 7,
+			wantErr:   "skips ahead",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOpCertCounter(tt.stored, tt.found, tt.candidate)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Closes #2608

## Problem

Inbound blocks had VRF and KES signatures verified, but the operational certificate was never validated — `VerifyBlock` ran with `SkipStakePoolValidation`, and the opcert sequence number was only recorded, not enforced. A peer could present a header for a pool whose hot key had been rotated.

## Change

Adds the three opcert checks, split by data dependency:

- **Cold-key signature + KES-period expiry — at header verification** (`ledger/verify_opcert.go`, called from `verifyBlockHeaderCrypto`). Stateless checks over the header and Shelley-genesis params, so forged/expired opcerts are rejected before the block body is fetched. `opCertFromHeader` extracts the opcert across the Shelley- and Babbage-family header layouts.
- **Counter monotonicity — at block apply** (`validateOpCertCounter`, in `ledgerProcessBlock` under `shouldValidate`). Read-before-write of the stored per-pool counter inside the validation transaction: the counter must equal the last-seen value or be exactly one greater; backward (stale/stolen hot key) and gapped (skipped rotation) counters are rejected. A pool with no recorded counter has no baseline and is accepted. Rollback safety is inherited from the existing per-`(pool, slot)` `pool_opcert_sequence` store — **no storage/schema change**.

### Note on the cold-key signature representation

The cold signature is verified over the raw cardano-ledger `OCertSignable` representation (`kesVkey || counter || period`), **not** gouroboros' `ledger.VerifyOpCertSignature`, which hashes a CBOR array that does not match real blocks (it would reject every block). This was confirmed against a real cardano-cli opcert and is pinned by a known-answer test. The upstream gouroboros bug is fixed separately in blinklabs-io/gouroboros#1843; this PR does not depend on it (the local check is self-contained, defense-in-depth).

## Validation

- Unit tests (`ledger/verify_opcert_test.go`): extractor, valid/tampered cold-sig, expired/`maxKES=0` KES, counter table (first-sight/equal/+1/backward/gap), Byron skip, and a **known-answer test against a real cardano-cli opcert**.
- Full `ledger` suite passes with `-race`; conformance suite passes.
- **DevNet harness**: `dingo-producer` reaches chain consensus with the official `cardano-node` producer (real opcerts) — confirms the inbound check accepts real opcerts end-to-end.
- `golangci-lint run ./...`: 0 issues; `modernize` clean; `make import-boundaries` passes.

## Docs

- **ARCHITECTURE.md**: new "Operational Certificate Validation" section (both checkpoints + rollback semantics).
- **DATABASE.md**: `pool_opcert_sequence` description updated to note its read-before-write role in inbound validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates operational certificates on inbound blocks to reject forged or expired headers early and enforce counter rules with a Praos‑only no‑gap check. The counter check runs before tx validation; no schema changes.

- **New Features**
  - Header: verify cold-key signature against issuer vkey and KES expiry using Shelley genesis `maxKESEvolutions`; skip expiry if params are missing; `opCertFromHeader` supports Shelley→Dijkstra.
  - Block apply: enforce counter monotonicity in all eras; reject gaps (>+1) only in Praos (Babbage+) via `opCertNoGapRuleApplies`; first sighting accepted; read-before-write before endorser/tx/Plutus; record after txs; rollback-safe via `pool_opcert_sequence`.
  - Crypto/Tests/Docs: verify over raw OCertSignable bytes (KES vkey || counter || period), not `gouroboros`’ CBOR hash; pinned by a known-answer test with a real `cardano-cli` opcert. Unit tests cover extractor, tampered sig, KES expiry, and era-scoped gap rules; conformance and DevNet pass. Docs name `verifyOpCertColdSignature` and note the counter read-before-write.

<sup>Written for commit 7bf6cc5a0ef22cf246b4f0a81b56a96e6f73a0e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating operational certificates during block processing.
  * Improved handling of certificate signature checks and expiration rules.

* **Bug Fixes**
  * Strengthened rejection of stale or skipped certificate sequence updates.
  * Improved rollback-safe handling so certificate state stays consistent after chain reorgs.

* **Documentation**
  * Clarified how certificate validation works in architecture and database docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->