### PR TITLE
docs: update based on most recent changes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -434,8 +434,8 @@ dingo/
 │       │   └── gcs/     # Google Cloud Storage
 │       └── metadata/    # Metadata plugins
 │           ├── sqlite/  # SQLite (default)
-│           ├── postgres/# PostgreSQL
-│           └── mysql/   # MySQL
+│           ├── postgres/# PostgreSQL (non-default, planned tag-gating #2586)
+│           └── mysql/   # MySQL (non-default, planned tag-gating #2586)
 ├── event/               # Event bus for decoupled communication
 │   ├── event.go         # EventBus, async delivery
 │   ├── epoch.go         # Epoch transition events
@@ -543,7 +543,7 @@ dingo/
 ├── midnight/            # Midnight MidnightState gRPC compatibility surface
 │   ├── midnight_state*.pb.go # Generated google.golang.org/grpc service stubs
 │   └── server/          # Native gRPC server lifecycle (reflection, health, TLS)
-│       └── server.go    # Serves a stub MidnightState (Unimplemented) scaffold
+│       └── server.go    # Serves the MidnightState gRPC compatibility surface
 ├── mithril/             # Mithril snapshot bootstrap
 │   ├── bootstrap.go     # Bootstrap orchestration
 │   ├── client.go        # Mithril aggregator client
@@ -750,16 +750,17 @@ Dingo uses a dual-layer storage architecture with pluggable backends:
     -------------------------------------------------
     | Plugins:                    | Plugins:          |
     |  - Badger (default)         |  - SQLite (default)|
-    |  - AWS S3 (optional)        |  - PostgreSQL (optional)|
-    |  - Google Cloud Storage (optional)|  - MySQL (optional)|
+    |  - AWS S3 (tag-gated)       |  - PostgreSQL (non-default)|
+    |  - Google Cloud Storage (tag-gated)|  - MySQL (non-default)|
     -------------------------------------------------
 ```
 
-Badger and SQLite are always compiled into Dingo. The non-default storage
-plugins (`s3`, `gcs`, `postgres`, and `mysql`) are compiled only when the
-`dingo_extra_plugins` build tag is enabled; project builds, CI, and release
-binaries opt into that tag, while a plain `go build ./cmd/dingo` produces a
-minimal binary.
+Badger and SQLite are always compiled into Dingo. The non-default blob plugins
+(`s3` and `gcs`) are compiled only when the `dingo_extra_plugins` build tag is
+enabled; project builds, CI, and release binaries opt into that tag, while a
+plain `go build ./cmd/dingo` omits the cloud blob SDKs. The non-default
+metadata plugins (`postgres` and `mysql`) are still compiled into plain builds
+on current `main`; issue #2586 tracks moving them behind the same tag.
 
 ### Storage Modes
 
@@ -773,10 +774,12 @@ Dingo supports two storage modes, configured via `storageMode`:
 In `storageMode: api` with `midnight.port > 0`, `node.go` starts
 `midnight/server.Server`, a native `google.golang.org/grpc` server (not
 ConnectRPC, for byte-for-byte compatibility with the Acropolis tonic service)
-on its own `midnight.host:midnight.port` listener. It registers a stub
-`MidnightState` service whose RPCs return `Unimplemented`, plus gRPC reflection
-and a `grpc_health_v1` health service reporting `SERVING`. TLS is enabled when
-the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start` binds the
+on its own `midnight.host:midnight.port` listener. It registers the
+`MidnightState` service, plus gRPC reflection and a `grpc_health_v1` health
+service reporting `SERVING`. The compatibility surface is still incomplete:
+merged work covers server lifecycle and block scanning, while the remaining RPC
+bodies are tracked by the Midnight plan and issues #2118/#2119. TLS is enabled
+when the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start` binds the
 listener synchronously (so bind/cert errors surface immediately) and serves in
 a goroutine; a context watcher performs a bounded `GracefulStop`, escalating to
 a hard `Stop` on timeout. Setting `midnight.port` to `0` disables the server

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2,7 +2,7 @@
 
 Dingo stores chain state in two sibling stores:
 
-- The metadata store is a relational SQL database managed by the metadata plugins in `database/plugin/metadata/`. The always-built plugin is `sqlite`; `postgres` and `mysql` are optional and are built only with the `dingo_extra_plugins` build tag.
+- The metadata store is a relational SQL database managed by the metadata plugins in `database/plugin/metadata/`. `sqlite` is the default plugin; `postgres` and `mysql` are non-default plugins that are still compiled into plain builds on current `main`. Issue #2586 tracks moving them behind the `dingo_extra_plugins` build tag.
 - The blob store is a key/value object store managed by the blob plugins in `database/plugin/blob/`. The always-built plugin is `badger`; `gcs` and `s3` are optional and are built only with the `dingo_extra_plugins` build tag.
 
 The SQL schema is generated from GORM models in `database/models/` plus the plugin-local singleton tables `commit_timestamp` and `node_settings`. There are no checked-in SQL migrations; startup runs `AutoMigrate` for the active metadata plugin.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ returning a signed object-storage URL plus block metadata. Badger is valid for a
 normal local blob store, but it does not provide signed URLs and should not be
 used as the Bark archive backend.
 
+For local source builds, the `s3` and `gcs` blob plugins require
+`-tags dingo_extra_plugins` or `make build`. Official release binaries include
+the extra plugin tag.
+
 ```yaml
 storageMode: "core"
 database:
@@ -363,6 +367,11 @@ These are approximate values that grow over time. The snapshot can be deleted af
 Dingo supports pluggable storage backends for both blob storage (blocks, transactions) and metadata storage. This allows you to choose the best storage solution for your use case.
 
 ### Available Plugins
+
+For local source builds, `badger` is always available. The `gcs` and `s3` blob
+plugins require `-tags dingo_extra_plugins` or `make build`. `postgres` and
+`mysql` are still compiled into plain builds on current `main`; issue #2586
+tracks moving them behind the same tag.
 
 Blob Storage Plugins:
 - `badger` - BadgerDB local key-value store (default)

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -73,8 +73,9 @@ database:
   # Metadata storage plugin configuration
   metadata:
     # Plugin to use for metadata storage (sqlite, postgres, mysql)
-    # sqlite is always built; postgres and mysql require a build with
-    # -tags dingo_extra_plugins or an official release binary.
+    # sqlite is the default. postgres and mysql are still included in plain
+    # source builds on current main; issue #2586 tracks moving them behind
+    # -tags dingo_extra_plugins.
     plugin: "sqlite"
     # Configuration options for each plugin
     sqlite:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update docs to reflect current plugin build-tag behavior and the Midnight gRPC server status. Notes that `s3`/`gcs` require the `dingo_extra_plugins` tag for local builds, `postgres`/`mysql` are non-default but still compiled on `main` (planned tag-gating in #2586), and that the server now exposes the `MidnightState` compatibility surface; aligns `README.md`, `ARCHITECTURE.md`, `DATABASE.md`, and `dingo.yaml.example`.

<sup>Written for commit 0182c874758e1650fc9d950196d60ce0b80ac50d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

