### PR TITLE
fix(ouroboros): blockfetch backpressure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -279,6 +279,16 @@ sequenceDiagram
     LS->>EB: publish TransactionEvent(rollback: true) per tx
 ```
 
+The BlockFetch server path mirrors the retrieval flow for downstream peers:
+when a peer requests a range, `ouroboros/blockfetch.go` validates the bounds,
+opens a chain iterator at the requested start point, sends `StartBatch`, then
+streams `Block` messages until the requested end or local tip before
+`BatchDone`. The range sender is asynchronous so the mini-protocol callback can
+return promptly, but it applies backpressure between messages by waiting for
+the underlying gouroboros protocol send queue to drain. This keeps large Leios
+catch-up ranges from filling the mux pending-message queue and turning a slow
+consumer into a connection-level protocol violation.
+
 ### Peer-to-Peer Networking
 
 Connection lifecycle, protocol multiplexing, and peer governance.

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -43,6 +43,10 @@ const MaxBlockFetchRange = 129600
 // responses for the same (connId, start) tuple before closing the connection.
 const blockfetchMaxConsecutiveNoBlocks = 5
 
+// blockfetchServerSendDrainTimeout is the maximum time the range server waits
+// for the underlying protocol send queue to drain between blockfetch messages.
+const blockfetchServerSendDrainTimeout = 60 * time.Second
+
 // blockfetchNoBlocksPoint identifies the start point used by the last
 // NoBlocks response tracked for a connection.
 type blockfetchNoBlocksPoint struct {
@@ -64,6 +68,10 @@ type blockfetchBatchServer interface {
 	StartBatch() error
 	Block(uint, []byte) error
 	BatchDone() error
+}
+
+type blockfetchSendDrainWaiter interface {
+	WaitSendQueueDrained(time.Duration) bool
 }
 
 type blockfetchConnection interface {
@@ -207,6 +215,16 @@ func (o *Ouroboros) blockfetchServerSendBatch(
 		)
 		return fmt.Errorf("blockfetch StartBatch failed: %w", err)
 	}
+	if err := o.blockfetchServerWaitForSendDrain(
+		connectionID,
+		start,
+		end,
+		server,
+		conn,
+		"StartBatch",
+	); err != nil {
+		return err
+	}
 Loop:
 	for {
 		select {
@@ -264,6 +282,16 @@ Loop:
 			if o.blockfetchMetrics != nil {
 				o.blockfetchMetrics.servedBlockCount.Inc()
 			}
+			if err := o.blockfetchServerWaitForSendDrain(
+				connectionID,
+				start,
+				end,
+				server,
+				conn,
+				"Block",
+			); err != nil {
+				return err
+			}
 			// Make sure we don't hang waiting for the next block if we've already hit the end
 			if next.Block.Slot == end.Slot {
 				break Loop
@@ -287,6 +315,46 @@ Loop:
 		return fmt.Errorf("blockfetch BatchDone failed: %w", err)
 	}
 	return nil
+}
+
+func (o *Ouroboros) blockfetchServerWaitForSendDrain(
+	connectionID string,
+	start ocommon.Point,
+	end ocommon.Point,
+	server blockfetchBatchServer,
+	conn blockfetchConnection,
+	phase string,
+) error {
+	drainWaiter, ok := server.(blockfetchSendDrainWaiter)
+	if !ok {
+		return nil
+	}
+	if drainWaiter.WaitSendQueueDrained(blockfetchServerSendDrainTimeout) {
+		return nil
+	}
+	select {
+	case <-conn.ErrorChan():
+		return nil
+	default:
+	}
+	o.config.Logger.Error(
+		"blockfetch: send queue did not drain",
+		"connection_id", connectionID,
+		"start_slot", start.Slot,
+		"end_slot", end.Slot,
+		"phase", phase,
+		"timeout", blockfetchServerSendDrainTimeout,
+	)
+	o.closeBlockfetchConnection(
+		conn,
+		connectionID,
+		"blockfetch send queue did not drain",
+	)
+	return fmt.Errorf(
+		"blockfetch send queue did not drain after %s within %s",
+		phase,
+		blockfetchServerSendDrainTimeout,
+	)
 }
 
 func (o *Ouroboros) reportBlockfetchServerAsyncError(

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 )
 
@@ -65,6 +66,26 @@ func (s *stubBlockfetchBatchServer) Block(_ uint, _ []byte) error {
 func (s *stubBlockfetchBatchServer) BatchDone() error {
 	s.batchDoneCalls++
 	return s.batchDoneErr
+}
+
+type stubBlockfetchDrainBatchServer struct {
+	stubBlockfetchBatchServer
+	drainCalls    int
+	drainResults  []bool
+	drainTimeouts []time.Duration
+}
+
+func (s *stubBlockfetchDrainBatchServer) WaitSendQueueDrained(
+	timeout time.Duration,
+) bool {
+	s.drainCalls++
+	s.drainTimeouts = append(s.drainTimeouts, timeout)
+	if len(s.drainResults) == 0 {
+		return true
+	}
+	result := s.drainResults[0]
+	s.drainResults = s.drainResults[1:]
+	return result
 }
 
 type blockfetchIteratorStep struct {
@@ -104,6 +125,17 @@ func (c *stubBlockfetchConnection) ErrorChan() chan error {
 func (c *stubBlockfetchConnection) Close() error {
 	c.closeCalls++
 	return c.closeErr
+}
+
+func testBlockfetchIteratorBlock(slot uint64) *chain.ChainIteratorResult {
+	return &chain.ChainIteratorResult{
+		Point: ocommon.NewPoint(slot, []byte{byte(slot)}),
+		Block: models.Block{
+			Slot: slot,
+			Type: 1,
+			Cbor: []byte{byte(slot), byte(slot + 1)},
+		},
+	}
 }
 
 func TestBlockfetchServerRequestRange_StartAfterEnd(t *testing.T) {
@@ -330,6 +362,90 @@ func TestBlockfetchServerSendBatch_BatchDoneAtChainTip(t *testing.T) {
 	assert.Equal(t, 1, server.batchDoneCalls)
 	assert.Equal(t, 0, conn.closeCalls)
 	assert.Equal(t, 1, iter.cancelCalls)
+}
+
+func TestBlockfetchServerSendBatch_WaitsForSendDrainBetweenMessages(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	iter := &stubBlockfetchIterator{
+		steps: []blockfetchIteratorStep{
+			{result: testBlockfetchIteratorBlock(100)},
+			{result: testBlockfetchIteratorBlock(101)},
+		},
+	}
+	server := &stubBlockfetchDrainBatchServer{}
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error),
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(101, []byte{0x02})
+
+	err := o.blockfetchServerSendBatch(
+		testConnId().String(),
+		start,
+		end,
+		iter,
+		server,
+		conn,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, server.startBatchCalls)
+	assert.Equal(t, 2, server.blockCalls)
+	assert.Equal(t, 1, server.batchDoneCalls)
+	assert.Equal(t, 0, conn.closeCalls)
+	assert.Equal(t, 1, iter.cancelCalls)
+	assert.Equal(t, 3, server.drainCalls)
+	for _, timeout := range server.drainTimeouts {
+		assert.Equal(t, blockfetchServerSendDrainTimeout, timeout)
+	}
+}
+
+func TestBlockfetchServerSendBatch_ClosesConnectionWhenSendDrainStalls(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	iter := &stubBlockfetchIterator{
+		steps: []blockfetchIteratorStep{
+			{result: testBlockfetchIteratorBlock(100)},
+			{result: testBlockfetchIteratorBlock(101)},
+		},
+	}
+	server := &stubBlockfetchDrainBatchServer{
+		drainResults: []bool{true, false},
+	}
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error),
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(101, []byte{0x02})
+
+	err := o.blockfetchServerSendBatch(
+		testConnId().String(),
+		start,
+		end,
+		iter,
+		server,
+		conn,
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "send queue did not drain after Block")
+	assert.Equal(t, 1, server.startBatchCalls)
+	assert.Equal(t, 1, server.blockCalls)
+	assert.Equal(t, 0, server.batchDoneCalls)
+	assert.Equal(t, 1, conn.closeCalls)
+	assert.Equal(t, 1, iter.cancelCalls)
+	assert.Equal(t, 2, server.drainCalls)
 }
 
 func TestReportBlockfetchServerAsyncError_ForwardsToConnectionErrorChan(


### PR DESCRIPTION
Closes #2663 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backpressure to the BlockFetch server by waiting for the protocol send queue to drain between messages. Prevents mux queue buildup and connection-level violations during large catch-up ranges.

- **Bug Fixes**
  - Waits for the send queue to drain after `StartBatch` and each `Block` via `WaitSendQueueDrained` (60s timeout, if supported).
  - Closes the connection and returns an error if draining stalls to avoid slow-consumer lockups.
  - Documents the server flow and backpressure behavior in `ARCHITECTURE.md`.
  - Adds tests for normal drain and stalled drain cases.

<sup>Written for commit 645da90cd290386589637073d8396b26236d96b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

