### PR TITLE
fix: epoch lab nonce

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,6 +276,7 @@ sequenceDiagram
     LS->>ChM: chain.Rollback(point)
     ChM->>DB: delete blocks/txs after point
     ChM->>DB: restore account/pool/DRep state
+    LS->>LS: reload epoch cache, repair empty lab nonces
     LS->>EB: publish TransactionEvent(rollback: true) per tx
 ```
 
@@ -633,7 +634,7 @@ When `Node.Run()` is called, components are initialized in this order:
     `healEmptyLabNonces`: it repairs any epoch record whose
     `last_epoch_block_nonce` was persisted empty by the pre-fix
     endorser-block/`BlockBeforeSlot` collision — re-deriving the lab from the
-    real boundary block and recomputing the affected next epoch's nonce in the
+    real boundary block and recomputing the affected epoch's nonce in the
     cache so leader-VRF verification matches the network (an empty lab would
     otherwise collapse that epoch's nonce to the NeutralNonce identity).
 10. Snapshot manager start (captures genesis snapshot, or reuses an existing
@@ -1743,6 +1744,9 @@ visible to the withdrawals checked in step 3. The ordering is locked in by
 On chain rollback past an epoch boundary:
 - Delete snapshots for epochs after rollback point
 - Recalculate affected snapshots on forward replay
+- Reload the remaining epoch rows into the in-memory cache and run the same
+  empty `last_epoch_block_nonce` repair used at startup before publishing the
+  new cache.
 - Reward-account credits (`account_reward_delta` journal) and treasury/reserves
   writes (`network_state`) from governance refunds and POOLREAP deposit refunds
   are slot-keyed, so they are reverted by slot and re-derived on forward replay

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -634,8 +634,10 @@ When `Node.Run()` is called, components are initialized in this order:
     `healEmptyLabNonces`: it repairs any epoch record whose
     `last_epoch_block_nonce` was persisted empty or stale by pre-fix boundary
     lookup bugs, re-deriving the lab from the active chain's boundary block and
-    recomputing the affected epoch's nonce in the cache so leader-VRF
-    verification matches the network.
+    recomputing the affected epoch's nonce in the cache when that epoch has a
+    stored `candidate_nonce`, so leader-VRF verification matches the network.
+    If the candidate is missing, startup leaves the epoch unchanged rather than
+    substituting Shelley genesis for a candidate that may have evolved.
 10. Snapshot manager start (captures genesis snapshot, or reuses an existing
     post-Mithril Mark snapshot window)
 11. Mempool setup and injection into LedgerState/Ouroboros
@@ -1750,7 +1752,8 @@ On chain rollback past an epoch boundary:
 - Recalculate affected snapshots on forward replay
 - Reload the remaining epoch rows into the in-memory cache and run the same
   empty/stale `last_epoch_block_nonce` repair used at startup before publishing
-  the new cache.
+  the new cache. Epochs without a stored `candidate_nonce` are skipped because
+  their nonce cannot be safely recomputed from the lab alone.
 - Reward-account credits (`account_reward_delta` journal) and treasury/reserves
   writes (`network_state`) from governance refunds and POOLREAP deposit refunds
   are slot-keyed, so they are reverted by slot and re-derived on forward replay

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -632,11 +632,11 @@ When `Node.Run()` is called, components are initialized in this order:
     crash-restart replay is safe.
  9. LedgerState start. Loading the epoch cache (`loadEpochs`) also runs
     `healEmptyLabNonces`: it repairs any epoch record whose
-    `last_epoch_block_nonce` was persisted empty by the pre-fix
-    endorser-block/`BlockBeforeSlot` collision — re-deriving the lab from the
-    real boundary block and recomputing the affected epoch's nonce in the
-    cache so leader-VRF verification matches the network (an empty lab would
-    otherwise collapse that epoch's nonce to the NeutralNonce identity).
+    `last_epoch_block_nonce` was persisted empty by pre-fix boundary lookup
+    bugs, re-deriving the lab from the active chain's boundary block and
+    recomputing the affected epoch's nonce in the cache so leader-VRF
+    verification matches the network (an empty lab would otherwise collapse
+    that epoch's nonce to the NeutralNonce identity).
 10. Snapshot manager start (captures genesis snapshot, or reuses an existing
     post-Mithril Mark snapshot window)
 11. Mempool setup and injection into LedgerState/Ouroboros
@@ -976,10 +976,15 @@ When a network config supplies a `CheckpointsFile` (mainnet and preview ship one
 
 ### Epoch Nonce Computation
 
-`ledger/chainsync.go` and `ledger/candidate_nonce.go` implement the Ouroboros Praos nonce evolution:
+`ledger/chainsync.go`, `ledger/candidate_nonce.go`, and `ledger/epoch_lab_nonce.go` implement the Ouroboros Praos nonce evolution:
 - Evolving nonce: accumulated from each block's VRF output
 - Candidate nonce: frozen at the stability window cutoff
 - Epoch nonce: derived from candidate nonce and previous epoch's last block hash
+
+The previous epoch's last-block hash is resolved through the active chain index
+(`chain.BlockBeforeSlot`), not a raw blob-store slot scan. Blob storage can
+retain synthetic endorser/genesis blobs and fork blobs that are useful for other
+storage paths but are not part of the selected chain.
 
 ### Ledger View
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,7 +276,7 @@ sequenceDiagram
     LS->>ChM: chain.Rollback(point)
     ChM->>DB: delete blocks/txs after point
     ChM->>DB: restore account/pool/DRep state
-    LS->>LS: reload epoch cache, repair empty lab nonces
+    LS->>LS: reload epoch cache, repair lab nonces
     LS->>EB: publish TransactionEvent(rollback: true) per tx
 ```
 
@@ -632,11 +632,10 @@ When `Node.Run()` is called, components are initialized in this order:
     crash-restart replay is safe.
  9. LedgerState start. Loading the epoch cache (`loadEpochs`) also runs
     `healEmptyLabNonces`: it repairs any epoch record whose
-    `last_epoch_block_nonce` was persisted empty by pre-fix boundary lookup
-    bugs, re-deriving the lab from the active chain's boundary block and
+    `last_epoch_block_nonce` was persisted empty or stale by pre-fix boundary
+    lookup bugs, re-deriving the lab from the active chain's boundary block and
     recomputing the affected epoch's nonce in the cache so leader-VRF
-    verification matches the network (an empty lab would otherwise collapse
-    that epoch's nonce to the NeutralNonce identity).
+    verification matches the network.
 10. Snapshot manager start (captures genesis snapshot, or reuses an existing
     post-Mithril Mark snapshot window)
 11. Mempool setup and injection into LedgerState/Ouroboros
@@ -1750,8 +1749,8 @@ On chain rollback past an epoch boundary:
 - Delete snapshots for epochs after rollback point
 - Recalculate affected snapshots on forward replay
 - Reload the remaining epoch rows into the in-memory cache and run the same
-  empty `last_epoch_block_nonce` repair used at startup before publishing the
-  new cache.
+  empty/stale `last_epoch_block_nonce` repair used at startup before publishing
+  the new cache.
 - Reward-account credits (`account_reward_delta` journal) and treasury/reserves
   writes (`network_state`) from governance refunds and POOLREAP deposit refunds
   are slot-keyed, so they are reverted by slot and re-derived on forward replay

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -373,15 +373,19 @@ it as a chain block. Its `bp..._metadata` carries `ID=0` (real ranking blocks
 created via `BlockCreate` get `ID >= 1`), which is also how the `bp`-prefix
 scanning helpers exclude it: `BlockBeforeSlotTxn` skips `ID=0` blobs so a
 synthetic endorser/genesis blob is never returned as the "previous block." This
-matters for the epoch-nonce computation — `last_epoch_block_nonce` is derived
-from the previous epoch's last ranking-block hash; returning an endorser blob
-there would save a non-chain hash. Older PrevHash-based lab lookup also saved an
-empty lab here, collapsing the epoch's nonce to the NeutralNonce identity and
-failing leader-VRF checks. Each endorser transaction's `t` entry and its outputs'
-`u` entries store ordinary `DOFF` references whose `block_slot`/`block_hash`
-point at that endorser-block blob, so cold-extract resolution is identical to
-chain-block transactions. The transactions' metadata rows, however, are recorded
-under the referencing ranking block's point, so a rollback of the ranking block
+matters for storage callers, but it does not make a slot-key scan a canonical
+chain query: retained fork blobs can still sort before an epoch boundary.
+Epoch nonce code derives `last_epoch_block_nonce` from the previous epoch's last
+ranking-block hash through the active chain index (`chain.BlockBeforeSlot`),
+not directly from `BlockBeforeSlotTxn`, so synthetic blobs and stored fork blobs
+cannot be mixed into the boundary nonce. Older PrevHash-based lab lookup also
+saved an empty lab here, collapsing the epoch's nonce to the NeutralNonce
+identity and failing leader-VRF checks. Each endorser transaction's `t` entry
+and its outputs' `u` entries store ordinary `DOFF` references whose
+`block_slot`/`block_hash` point at that endorser-block blob, so cold-extract
+resolution is identical to chain-block transactions. The transactions' metadata
+rows, however, are recorded under the referencing ranking block's point, so a
+rollback of the ranking block
 removes them (the orphaned endorser-block blob is harmless and re-created on
 reprocess).
 Decode/build failures are ignored before storage is touched; once the blob or

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -373,16 +373,17 @@ it as a chain block. Its `bp..._metadata` carries `ID=0` (real ranking blocks
 created via `BlockCreate` get `ID >= 1`), which is also how the `bp`-prefix
 scanning helpers exclude it: `BlockBeforeSlotTxn` skips `ID=0` blobs so a
 synthetic endorser/genesis blob is never returned as the "previous block." This
-matters for the epoch-nonce computation — the lagged `last_epoch_block_nonce`
-(lab) is derived from the previous epoch's last block's `PrevHash`; returning an
-endorser blob there (its `PrevHash` is empty) saves an empty lab, collapsing the
-next epoch's nonce to the NeutralNonce identity and failing every leader-VRF
-check in that epoch. Each endorser transaction's `t` entry and its outputs' `u`
-entries store ordinary `DOFF` references whose `block_slot`/`block_hash` point at
-that endorser-block blob, so cold-extract resolution is identical to chain-block
-transactions. The transactions' metadata rows, however, are recorded under the
-referencing ranking block's point, so a rollback of the ranking block removes
-them (the orphaned endorser-block blob is harmless and re-created on reprocess).
+matters for the epoch-nonce computation — `last_epoch_block_nonce` is derived
+from the previous epoch's last ranking-block hash; returning an endorser blob
+there would save a non-chain hash. Older PrevHash-based lab lookup also saved an
+empty lab here, collapsing the epoch's nonce to the NeutralNonce identity and
+failing leader-VRF checks. Each endorser transaction's `t` entry and its outputs'
+`u` entries store ordinary `DOFF` references whose `block_slot`/`block_hash`
+point at that endorser-block blob, so cold-extract resolution is identical to
+chain-block transactions. The transactions' metadata rows, however, are recorded
+under the referencing ranking block's point, so a rollback of the ranking block
+removes them (the orphaned endorser-block blob is harmless and re-created on
+reprocess).
 Decode/build failures are ignored before storage is touched; once the blob or
 transaction rows start writing, the caller aborts the enclosing block
 transaction rather than committing a partial endorser-block application.

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1143,6 +1143,38 @@ func (c *Chain) BlockByPoint(
 	return c.manager.BlockByPoint(point, txn)
 }
 
+// BlockBeforeSlot returns the highest-slot block before slotNumber on this
+// chain. It walks the chain index instead of scanning blob keys so retained
+// fork or synthetic blobs cannot be returned as canonical blocks.
+func (c *Chain) BlockBeforeSlot(slotNumber uint64) (models.Block, error) {
+	if c == nil {
+		return models.Block{}, errors.New("chain is nil")
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.manager.mutex.RLock()
+	defer c.manager.mutex.RUnlock()
+	if err := c.reconcile(); err != nil {
+		return models.Block{}, err
+	}
+	if c.tipBlockIndex < initialBlockIndex {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	for blockIndex := c.tipBlockIndex; blockIndex >= initialBlockIndex; blockIndex-- {
+		block, err := c.blockByIndex(blockIndex)
+		if err != nil {
+			return models.Block{}, err
+		}
+		if block.Slot < slotNumber {
+			return block, nil
+		}
+		if blockIndex == initialBlockIndex {
+			break
+		}
+	}
+	return models.Block{}, models.ErrBlockNotFound
+}
+
 func (c *Chain) blockByIndex(
 	blockIndex uint64,
 ) (models.Block, error) {

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -224,6 +224,57 @@ func TestChainBasic(t *testing.T) {
 	}
 }
 
+func TestChainBlockBeforeSlotUsesCanonicalChainIndex(t *testing.T) {
+	db, err := database.New(dbConfig)
+	if err != nil {
+		t.Fatalf("unexpected error creating database: %s", err)
+	}
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	if err := c.AddBlock(testBlocks[0], nil); err != nil {
+		t.Fatalf("unexpected error adding block 0: %s", err)
+	}
+	if err := c.AddBlock(testBlocks[1], nil); err != nil {
+		t.Fatalf("unexpected error adding block 1: %s", err)
+	}
+
+	forkHash := decodeHex(testHashPrefix + "00ff")
+	if err := db.BlockCreate(models.Block{
+		ID:       99,
+		Slot:     30,
+		Hash:     forkHash,
+		PrevHash: decodeHex(testBlocks[0].MockHash),
+		Cbor:     []byte{0x80},
+		Number:   99,
+		Type:     uint(testBlocks[1].Type()), //nolint:gosec
+	}, nil); err != nil {
+		t.Fatalf("unexpected error adding fork block blob: %s", err)
+	}
+	rawBlock, err := database.BlockBeforeSlot(db, 40)
+	if err != nil {
+		t.Fatalf("unexpected error looking up raw block before slot: %s", err)
+	}
+	if !bytes.Equal(rawBlock.Hash, forkHash) {
+		t.Fatalf("raw lookup did not expose fork block: got %x", rawBlock.Hash)
+	}
+
+	block, err := c.BlockBeforeSlot(40)
+	if err != nil {
+		t.Fatalf("unexpected error looking up canonical block before slot: %s", err)
+	}
+	if got, want := block.Slot, testBlocks[1].MockSlot; got != want {
+		t.Fatalf("unexpected canonical block slot: got %d, want %d", got, want)
+	}
+	if got, want := hex.EncodeToString(block.Hash), testBlocks[1].MockHash; got != want {
+		t.Fatalf("unexpected canonical block hash: got %s, want %s", got, want)
+	}
+}
+
 func TestChainIteratorReverseFromTipInclusive(t *testing.T) {
 	cm, err := chain.NewManager(nil, nil)
 	if err != nil {

--- a/database/block.go
+++ b/database/block.go
@@ -640,9 +640,10 @@ func BlockBeforeSlotTxn(txn *Txn, slotNumber uint64) (models.Block, error) {
 		// persisted at block-blob keys via SetGenesisCbor with ID=0 and no
 		// chain index entry; they are not ranking blocks. Returning one here
 		// would feed callers (epoch-nonce labNonce/candidate computation,
-		// chain reconciliation) a non-block whose PrevHash/Type are empty —
-		// the source of the empty-labNonce epoch-nonce corruption. Real
-		// blocks created via BlockCreate always have ID >= BlockInitialIndex.
+		// chain reconciliation) a non-ranking blob whose hash is not on the
+		// chain. Older PrevHash-based lab lookup also collapsed this case to
+		// an empty lab. Real blocks created via BlockCreate always have ID >=
+		// BlockInitialIndex.
 		if blk.ID == 0 {
 			continue
 		}

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -76,10 +76,10 @@ func TestBlockBySlotSkipsStaleSameSlotIndex(t *testing.T) {
 // TestBlockBeforeSlotSkipsSyntheticBlobs verifies BlockBeforeSlot returns the
 // highest real ranking block before a slot and skips synthetic blobs. Genesis
 // CBOR and Leios endorser blocks are persisted at block-blob keys via
-// SetGenesisCbor with ID=0 and an empty PrevHash; returning one to the
-// epoch-nonce lab computation saves an empty lastEpochBlockNonce, which
-// collapses the next epoch's nonce to the NeutralNonce identity and fails every
-// leader-VRF check (the Dijkstra/Leios at-tip wedge).
+// SetGenesisCbor with ID=0 and no chain index; returning one to the
+// epoch-nonce lab computation saves a non-chain hash. Older PrevHash-based lab
+// lookup also saved an empty lastEpochBlockNonce here, collapsing the new
+// epoch's nonce to the NeutralNonce identity and failing leader-VRF checks.
 func TestBlockBeforeSlotSkipsSyntheticBlobs(t *testing.T) {
 	db := newTestDB(t)
 
@@ -114,7 +114,7 @@ func TestBlockBeforeSlotSkipsSyntheticBlobs(t *testing.T) {
 		t,
 		realBlock.PrevHash,
 		got.PrevHash,
-		"the real block's PrevHash must survive — it feeds the epoch-nonce lab",
+		"the real block's PrevHash must survive for chain continuity",
 	)
 }
 

--- a/database/models/epoch.go
+++ b/database/models/epoch.go
@@ -28,12 +28,11 @@ type Epoch struct {
 	// candidate nonce across epochs so it can seed the next
 	// epoch's computation correctly.
 	CandidateNonce []byte
-	// LastEpochBlockNonce holds the prevHash of the last applied
-	// block from the PREVIOUS epoch transition (praosStateLabNonce
-	// in Haskell). In Ouroboros Praos, the epoch nonce formula uses
-	// a lagged lab nonce: at the N→N+1 transition, the nonce saved
-	// at N-1→N is used. This field is nil for epoch 0 (equivalent
-	// to NeutralNonce / identity).
+	// LastEpochBlockNonce holds the hash of the last applied block
+	// carried by the Praos chain-dependent state at this epoch's
+	// boundary. In Ouroboros Praos, the epoch nonce formula mixes
+	// CandidateNonce with this value. This field is nil for epoch 0
+	// (equivalent to NeutralNonce / identity).
 	LastEpochBlockNonce []byte
 	ID                  uint `gorm:"primarykey"`
 	// NOTE: we would normally use this as the primary key, but GORM doesn't

--- a/ledger/candidate_nonce.go
+++ b/ledger/candidate_nonce.go
@@ -69,7 +69,7 @@ var errNoncesMissing = errors.New("block nonce rows missing for epoch")
 // window cutoff (slot + stabilityWindow >= firstSlotNextEpoch), then
 // freezes. The frozen value is used in the epoch nonce formula:
 //
-//	epochNonce(N+1) = blake2b_256(candidateNonce(N) || labNonce(N))
+//	epochNonce(N+1) = blake2b_256(candidateNonce(N) || lastEpochBlockNonce(N))
 //
 // The evolving nonce continues to be updated past the cutoff with
 // all remaining blocks. Its end-of-epoch value becomes the starting

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2933,16 +2933,16 @@ func writeCborMajorType(buf *bytes.Buffer, majorType, n int) {
 }
 
 // calculateEpochNonce computes the epoch nonce for epoch N+1, the
-// end-of-epoch evolving nonce, and the labNonce to save for epoch
-// N+2's computation.
+// end-of-epoch evolving nonce, and the lastEpochBlockNonce to carry
+// into epoch N+1.
 //
 // The Ouroboros Praos formula is:
 //
 //	epochNonce(N+1) = candidateNonce(N) ⭒ lastEpochBlockNonce(N)
 //
-// where lastEpochBlockNonce(N) was saved at the N-1→N transition
-// (it's the prevHash of the last block of epoch N-1). This value
-// is stored in currentEpoch.LastEpochBlockNonce.
+// where lastEpochBlockNonce(N) is the hash of the last block in epoch N.
+// If epoch N has no blocks, the consensus state carries the previous
+// lastEpochBlockNonce forward.
 //
 // The ⭒ operator has NeutralNonce as identity:
 //
@@ -2953,8 +2953,8 @@ func writeCborMajorType(buf *bytes.Buffer, majorType, n int) {
 //
 // Returns (epochNonce, evolvingNonce, candidateNonce, labNonce, error).
 // The caller must store candidateNonce as the new epoch's CandidateNonce
-// and labNonce as the new epoch's LastEpochBlockNonce so the next
-// transition can use them.
+// and labNonce as the new epoch's LastEpochBlockNonce so an empty next
+// epoch can carry it forward.
 func (ls *LedgerState) calculateEpochNonce(
 	txn *database.Txn,
 	epochStartSlot uint64,
@@ -3101,31 +3101,24 @@ func (ls *LedgerState) calculateEpochNonce(
 		)
 	}
 
-	// Compute the labNonce to SAVE for epoch N+2's computation.
-	// This is prevHashToNonce(prevHash of last block of current
-	// epoch N). It will be stored as LastEpochBlockNonce on the
-	// new epoch record.
-	var labNonceToSave []byte
-	blockLastCurrentEpoch, err := database.BlockBeforeSlotTxn(
+	// Compute the lastEpochBlockNonce for the epoch being closed.
+	// This is the hash of the last block of current epoch N, or the
+	// carried value when the epoch has no blocks. It will be stored on
+	// the new epoch record and used immediately in this boundary's
+	// epoch-nonce formula.
+	lastEpochBlockNonce, err := ls.epochLabNonce(
 		txn,
+		currentEpoch.StartSlot,
 		epochEndSlot,
+		currentEpoch.LastEpochBlockNonce,
 	)
 	if err != nil {
-		if !errors.Is(err, models.ErrBlockNotFound) {
-			return nil, nil, nil, nil, fmt.Errorf(
-				"lookup block before slot: %w", err,
-			)
-		}
-		// No block — labNonceToSave stays nil (NeutralNonce)
-	} else if len(blockLastCurrentEpoch.PrevHash) > 0 {
-		labNonceToSave = blockLastCurrentEpoch.PrevHash
+		return nil, nil, nil, nil, err
 	}
+	labNonceToSave := lastEpochBlockNonce
 
-	// Use the LAGGED lastEpochBlockNonce from the current epoch
-	// record (set at the PREVIOUS transition) in the formula.
 	// If nil/empty, it's NeutralNonce (identity): result is
 	// just candidateNonce.
-	lastEpochBlockNonce := currentEpoch.LastEpochBlockNonce
 	if len(lastEpochBlockNonce) == 0 {
 		// NeutralNonce is the identity element of ⭒:
 		//   candidateNonce ⭒ NeutralNonce = candidateNonce

--- a/ledger/epoch_lab_nonce.go
+++ b/ledger/epoch_lab_nonce.go
@@ -33,7 +33,7 @@ func (ls *LedgerState) epochLabNonce(
 	epochEndSlot uint64,
 	carriedLabNonce []byte,
 ) ([]byte, error) {
-	lastBlock, err := lookupBlockBeforeSlot(ls.db, txn, epochEndSlot)
+	lastBlock, err := ls.canonicalBlockBeforeSlot(txn, epochEndSlot)
 	if err != nil {
 		if !errors.Is(err, models.ErrBlockNotFound) {
 			return nil, fmt.Errorf("lookup boundary block: %w", err)
@@ -57,7 +57,7 @@ func (ls *LedgerState) normalizeCarriedLabNonce(
 	if len(carriedLabNonce) == 0 || epochStartSlot == 0 {
 		return cloneNonce(carriedLabNonce), nil
 	}
-	boundary, err := lookupBlockBeforeSlot(ls.db, txn, epochStartSlot)
+	boundary, err := ls.canonicalBlockBeforeSlot(txn, epochStartSlot)
 	if err != nil {
 		if !errors.Is(err, models.ErrBlockNotFound) {
 			return nil, fmt.Errorf("lookup carried boundary block: %w", err)
@@ -70,6 +70,19 @@ func (ls *LedgerState) normalizeCarriedLabNonce(
 		return cloneNonce(boundary.Hash), nil
 	}
 	return cloneNonce(carriedLabNonce), nil
+}
+
+func (ls *LedgerState) canonicalBlockBeforeSlot(
+	txn *database.Txn,
+	slot uint64,
+) (models.Block, error) {
+	if ls == nil {
+		return models.Block{}, errors.New("ledger state is nil")
+	}
+	if ls.chain != nil {
+		return ls.chain.BlockBeforeSlot(slot)
+	}
+	return lookupBlockBeforeSlot(ls.db, txn, slot)
 }
 
 func cloneNonce(nonce []byte) []byte {

--- a/ledger/epoch_lab_nonce.go
+++ b/ledger/epoch_lab_nonce.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// epochLabNonce returns the Praos lastEpochBlockNonce value for an epoch
+// boundary. If the epoch has at least one block, the nonce is the hash of the
+// last block before the boundary. If the epoch has no blocks, the consensus
+// state carries the previous value forward.
+func (ls *LedgerState) epochLabNonce(
+	txn *database.Txn,
+	epochStartSlot uint64,
+	epochEndSlot uint64,
+	carriedLabNonce []byte,
+) ([]byte, error) {
+	lastBlock, err := lookupBlockBeforeSlot(ls.db, txn, epochEndSlot)
+	if err != nil {
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			return nil, fmt.Errorf("lookup boundary block: %w", err)
+		}
+		return cloneNonce(carriedLabNonce), nil
+	}
+	if lastBlock.Slot >= epochStartSlot && len(lastBlock.Hash) > 0 {
+		return cloneNonce(lastBlock.Hash), nil
+	}
+	return ls.normalizeCarriedLabNonce(txn, epochStartSlot, carriedLabNonce)
+}
+
+// normalizeCarriedLabNonce upgrades the old persisted shape that stored the
+// boundary block's PrevHash instead of its Hash. This only applies when an
+// epoch has no blocks of its own and must carry the previous boundary nonce.
+func (ls *LedgerState) normalizeCarriedLabNonce(
+	txn *database.Txn,
+	epochStartSlot uint64,
+	carriedLabNonce []byte,
+) ([]byte, error) {
+	if len(carriedLabNonce) == 0 || epochStartSlot == 0 {
+		return cloneNonce(carriedLabNonce), nil
+	}
+	boundary, err := lookupBlockBeforeSlot(ls.db, txn, epochStartSlot)
+	if err != nil {
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			return nil, fmt.Errorf("lookup carried boundary block: %w", err)
+		}
+		return cloneNonce(carriedLabNonce), nil
+	}
+	if len(boundary.Hash) > 0 &&
+		len(boundary.PrevHash) > 0 &&
+		bytes.Equal(carriedLabNonce, boundary.PrevHash) {
+		return cloneNonce(boundary.Hash), nil
+	}
+	return cloneNonce(carriedLabNonce), nil
+}
+
+func cloneNonce(nonce []byte) []byte {
+	return append([]byte(nil), nonce...)
+}

--- a/ledger/epoch_lab_nonce_test.go
+++ b/ledger/epoch_lab_nonce_test.go
@@ -21,13 +21,74 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/require"
+	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
+
+type epochLabNonceTestBlock struct {
+	slot     uint64
+	number   uint64
+	hash     []byte
+	prevHash []byte
+}
+
+func (b epochLabNonceTestBlock) Era() lcommon.Era {
+	return conway.EraConway
+}
+
+func (b epochLabNonceTestBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+func (b epochLabNonceTestBlock) Hash() lcommon.Blake2b256 {
+	return lcommon.NewBlake2b256(b.hash)
+}
+
+func (b epochLabNonceTestBlock) PrevHash() lcommon.Blake2b256 {
+	return lcommon.NewBlake2b256(b.prevHash)
+}
+
+func (b epochLabNonceTestBlock) BlockNumber() uint64 {
+	return b.number
+}
+
+func (b epochLabNonceTestBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+func (b epochLabNonceTestBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+func (b epochLabNonceTestBlock) Cbor() []byte {
+	return []byte{0x80}
+}
+
+func (b epochLabNonceTestBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func (b epochLabNonceTestBlock) Header() lcommon.BlockHeader {
+	return b
+}
+
+func (b epochLabNonceTestBlock) Type() int {
+	return conway.BlockTypeConway
+}
+
+func (b epochLabNonceTestBlock) Transactions() []lcommon.Transaction {
+	return nil
+}
+
+func (b epochLabNonceTestBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
+	return nil, nil
+}
 
 func TestEpochNonceUsesCurrentEpochLastBlockHash(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
@@ -176,4 +237,51 @@ func TestEpochLabNonceNormalizesOldPrevHashCarryForEmptyEpoch(t *testing.T) {
 	lab, err := ls.epochLabNonce(nil, epochStart, epochEnd, boundaryPrevHash)
 	require.NoError(t, err)
 	require.Equal(t, boundaryHash, lab)
+}
+
+func TestEpochLabNonceUsesCanonicalChainWhenForkBlobHasHigherSlot(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	canonicalChain := cm.PrimaryChain()
+
+	canonicalPrevHash := bytes.Repeat([]byte{0x01}, 32)
+	canonicalBoundaryHash := bytes.Repeat([]byte{0x02}, 32)
+	forkHash := bytes.Repeat([]byte{0xf0}, 32)
+
+	require.NoError(t, canonicalChain.AddBlock(epochLabNonceTestBlock{
+		slot:   10,
+		number: 1,
+		hash:   canonicalPrevHash,
+	}, nil))
+	require.NoError(t, canonicalChain.AddBlock(epochLabNonceTestBlock{
+		slot:     20,
+		number:   2,
+		hash:     canonicalBoundaryHash,
+		prevHash: canonicalPrevHash,
+	}, nil))
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       99,
+		Slot:     30,
+		Hash:     forkHash,
+		PrevHash: canonicalPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   99,
+		Type:     conway.BlockTypeConway,
+	}, nil))
+
+	rawBlock, err := database.BlockBeforeSlot(db, 40)
+	require.NoError(t, err)
+	require.Equal(t, forkHash, rawBlock.Hash)
+
+	ls := &LedgerState{
+		db:    db,
+		chain: canonicalChain,
+	}
+	lab, err := ls.epochLabNonce(nil, 0, 40, nil)
+	require.NoError(t, err)
+	require.Equal(t, canonicalBoundaryHash, lab)
 }

--- a/ledger/epoch_lab_nonce_test.go
+++ b/ledger/epoch_lab_nonce_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEpochNonceUsesCurrentEpochLastBlockHash(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cfg := newConwayBootstrapStabilityCfg(t)
+
+	const (
+		epochStart  uint64 = 1000
+		epochLength uint64 = 75
+		epochEnd    uint64 = epochStart + epochLength
+		preCutSlot  uint64 = 1014
+		postCutSlot uint64 = 1070
+	)
+
+	importedNonce := bytes.Repeat([]byte{0xaa}, 32)
+	nonceAtPreCut := bytes.Repeat([]byte{0xbb}, 32)
+	nonceAtPostCut := bytes.Repeat([]byte{0xcc}, 32)
+	carriedLab := bytes.Repeat([]byte{0xfa}, 32)
+
+	hashAtPreCut := bytes.Repeat([]byte{0x14}, 32)
+	hashAtPostCut := bytes.Repeat([]byte{0x70}, 32)
+	prevHashAtPreCut := bytes.Repeat([]byte{0x09}, 32)
+
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		if err := db.BlockCreate(models.Block{
+			Slot:     preCutSlot,
+			Hash:     hashAtPreCut,
+			PrevHash: prevHashAtPreCut,
+			Cbor:     []byte{0x80},
+			Number:   1,
+			Type:     conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		if err := db.BlockCreate(models.Block{
+			Slot:     postCutSlot,
+			Hash:     hashAtPostCut,
+			PrevHash: hashAtPreCut,
+			Cbor:     []byte{0x80},
+			Number:   2,
+			Type:     conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		if err := db.SetBlockNonce(
+			hashAtPreCut, preCutSlot, nonceAtPreCut, false, txn,
+		); err != nil {
+			return err
+		}
+		return db.SetBlockNonce(
+			hashAtPostCut, postCutSlot, nonceAtPostCut, false, txn,
+		)
+	}))
+
+	prevEpoch := models.Epoch{
+		EpochId:             100,
+		StartSlot:           epochStart,
+		LengthInSlots:       uint(epochLength),
+		SlotLength:          1000,
+		EraId:               eras.ConwayEraDesc.Id,
+		Nonce:               bytes.Repeat([]byte{0xee}, 32),
+		EvolvingNonce:       importedNonce,
+		CandidateNonce:      importedNonce,
+		LastEpochBlockNonce: carriedLab,
+	}
+
+	ls := &LedgerState{
+		db:           db,
+		currentEra:   eras.ConwayEraDesc,
+		currentEpoch: prevEpoch,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	hvNonce, _, hvCandidate, hvLab, err :=
+		ls.computeEpochNonceForSlot(epochEnd, prevEpoch)
+	require.NoError(t, err)
+
+	var rNonce, rCandidate, rLab []byte
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		n, _, c, lab, err := ls.calculateEpochNonce(
+			txn,
+			epochEnd,
+			eras.ConwayEraDesc,
+			prevEpoch,
+		)
+		rNonce = n
+		rCandidate = c
+		rLab = lab
+		return err
+	}))
+
+	expected, err := lcommon.CalculateEpochNonce(
+		nonceAtPreCut,
+		hashAtPostCut,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, hex.EncodeToString(nonceAtPreCut), hex.EncodeToString(rCandidate))
+	require.Equal(t, hex.EncodeToString(rCandidate), hex.EncodeToString(hvCandidate))
+	require.Equal(
+		t,
+		hex.EncodeToString(hashAtPostCut),
+		hex.EncodeToString(rLab),
+		"lastEpochBlockNonce must be the current epoch's last block hash",
+	)
+	require.Equal(t, hex.EncodeToString(rLab), hex.EncodeToString(hvLab))
+	require.NotEqual(
+		t,
+		hex.EncodeToString(hashAtPreCut),
+		hex.EncodeToString(rLab),
+		"lastEpochBlockNonce must not be the boundary block's PrevHash",
+	)
+	require.NotEqual(t, hex.EncodeToString(carriedLab), hex.EncodeToString(rLab))
+	require.Equal(t, expected.Bytes(), rNonce)
+	require.Equal(t, expected.Bytes(), hvNonce)
+}
+
+func TestEpochLabNonceNormalizesOldPrevHashCarryForEmptyEpoch(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	const (
+		epochStart uint64 = 200
+		epochEnd   uint64 = 300
+	)
+
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	boundaryPrevHash := bytes.Repeat([]byte{0x02}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot:     150,
+		Hash:     boundaryHash,
+		PrevHash: boundaryPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   1,
+		Type:     conway.BlockTypeConway,
+	}, nil))
+
+	ls := &LedgerState{db: db}
+	lab, err := ls.epochLabNonce(nil, epochStart, epochEnd, boundaryPrevHash)
+	require.NoError(t, err)
+	require.Equal(t, boundaryHash, lab)
+}

--- a/ledger/epoch_lab_nonce_test.go
+++ b/ledger/epoch_lab_nonce_test.go
@@ -27,68 +27,9 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
 	"github.com/stretchr/testify/require"
-	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
-
-type epochLabNonceTestBlock struct {
-	slot     uint64
-	number   uint64
-	hash     []byte
-	prevHash []byte
-}
-
-func (b epochLabNonceTestBlock) Era() lcommon.Era {
-	return conway.EraConway
-}
-
-func (b epochLabNonceTestBlock) SlotNumber() uint64 {
-	return b.slot
-}
-
-func (b epochLabNonceTestBlock) Hash() lcommon.Blake2b256 {
-	return lcommon.NewBlake2b256(b.hash)
-}
-
-func (b epochLabNonceTestBlock) PrevHash() lcommon.Blake2b256 {
-	return lcommon.NewBlake2b256(b.prevHash)
-}
-
-func (b epochLabNonceTestBlock) BlockNumber() uint64 {
-	return b.number
-}
-
-func (b epochLabNonceTestBlock) IssuerVkey() lcommon.IssuerVkey {
-	return lcommon.IssuerVkey{}
-}
-
-func (b epochLabNonceTestBlock) BlockBodySize() uint64 {
-	return 0
-}
-
-func (b epochLabNonceTestBlock) Cbor() []byte {
-	return []byte{0x80}
-}
-
-func (b epochLabNonceTestBlock) BlockBodyHash() lcommon.Blake2b256 {
-	return lcommon.Blake2b256{}
-}
-
-func (b epochLabNonceTestBlock) Header() lcommon.BlockHeader {
-	return b
-}
-
-func (b epochLabNonceTestBlock) Type() int {
-	return conway.BlockTypeConway
-}
-
-func (b epochLabNonceTestBlock) Transactions() []lcommon.Transaction {
-	return nil
-}
-
-func (b epochLabNonceTestBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
-	return nil, nil
-}
 
 func TestEpochNonceUsesCurrentEpochLastBlockHash(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
@@ -248,21 +189,21 @@ func TestEpochLabNonceUsesCanonicalChainWhenForkBlobHasHigherSlot(t *testing.T) 
 	require.NoError(t, err)
 	canonicalChain := cm.PrimaryChain()
 
-	canonicalPrevHash := bytes.Repeat([]byte{0x01}, 32)
-	canonicalBoundaryHash := bytes.Repeat([]byte{0x02}, 32)
+	canonicalBlocks, err := fixtures.GenerateConwayChain(
+		1,
+		lcommon.Blake2b256{},
+		10,
+		10,
+		2,
+	)
+	require.NoError(t, err)
+	require.Len(t, canonicalBlocks, 2)
+	canonicalPrevHash := canonicalBlocks[0].Hash().Bytes()
+	canonicalBoundaryHash := canonicalBlocks[1].Hash().Bytes()
 	forkHash := bytes.Repeat([]byte{0xf0}, 32)
 
-	require.NoError(t, canonicalChain.AddBlock(epochLabNonceTestBlock{
-		slot:   10,
-		number: 1,
-		hash:   canonicalPrevHash,
-	}, nil))
-	require.NoError(t, canonicalChain.AddBlock(epochLabNonceTestBlock{
-		slot:     20,
-		number:   2,
-		hash:     canonicalBoundaryHash,
-		prevHash: canonicalPrevHash,
-	}, nil))
+	require.NoError(t, canonicalChain.AddBlock(canonicalBlocks[0], nil))
+	require.NoError(t, canonicalChain.AddBlock(canonicalBlocks[1], nil))
 	require.NoError(t, db.BlockCreate(models.Block{
 		ID:       99,
 		Slot:     30,

--- a/ledger/epoch_nonce_test.go
+++ b/ledger/epoch_nonce_test.go
@@ -35,7 +35,7 @@ func TestEpochNonceFormula(t *testing.T) {
 		t,
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	)
-	// Synthetic 32-byte lastEpochBlockNonce (prevHash of last block)
+	// Synthetic 32-byte lastEpochBlockNonce (hash of last block)
 	lastEpochBlockNonce := mustDecodeHex(
 		t,
 		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -30,8 +30,8 @@ import (
 
 // TestHealEmptyLabNoncesRepairsAndRecomputes verifies that healEmptyLabNonces
 // restores an epoch's empty LastEpochBlockNonce from its boundary block and
-// recomputes the next epoch's nonce. A pre-fix BlockBeforeSlot endorser-block
-// collision could persist an empty lab, collapsing the next epoch's nonce to
+// recomputes that epoch's nonce. A pre-fix BlockBeforeSlot endorser-block
+// collision could persist an empty lab, collapsing the epoch's nonce to
 // the NeutralNonce identity (η == candidateNonce) and failing every leader-VRF
 // check in that epoch (the Dijkstra/Leios at-tip wedge).
 func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
@@ -40,12 +40,13 @@ func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 	defer db.Close()
 
 	// The last block of the epoch preceding epoch 5 (slot < 200). Its
-	// PrevHash is the lab value epoch 5 must recover to.
+	// Hash is the lab value epoch 5 must recover to.
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
 	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
 		ID:       3,
 		Slot:     150,
-		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		Hash:     boundaryHash,
 		PrevHash: boundaryPrevHash,
 		Cbor:     []byte{0x80},
 		Number:   3,
@@ -57,18 +58,13 @@ func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 		db: db,
 		epochCache: []models.Epoch{
 			{
-				EpochId:             5,
-				StartSlot:           200,
-				LengthInSlots:       100,
-				LastEpochBlockNonce: nil, // corrupted: empty lab
-			},
-			{
-				EpochId:        6,
-				StartSlot:      300,
+				EpochId:        5,
+				StartSlot:      200,
 				LengthInSlots:  100,
 				CandidateNonce: candidate,
 				// NeutralNonce-collapsed (wrong) nonce: η == candidateNonce.
-				Nonce: append([]byte(nil), candidate...),
+				Nonce:               append([]byte(nil), candidate...),
+				LastEpochBlockNonce: nil, // corrupted: empty lab
 			},
 		},
 		config: LedgerStateConfig{
@@ -78,23 +74,23 @@ func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 
 	ls.healEmptyLabNonces()
 
-	// Epoch 5's lab is recovered from the boundary block's PrevHash.
+	// Epoch 5's lab is recovered from the boundary block's Hash.
 	require.Equal(
 		t,
-		boundaryPrevHash,
+		boundaryHash,
 		ls.epochCache[0].LastEpochBlockNonce,
-		"empty lab must be restored from the boundary block's PrevHash",
+		"empty lab must be restored from the boundary block's Hash",
 	)
 
-	// Epoch 6's nonce is recomputed as candidateNonce ⭒ lab, no longer the
+	// Epoch 5's nonce is recomputed as candidateNonce ⭒ lab, no longer the
 	// NeutralNonce-collapsed value.
-	want, err := lcommon.CalculateEpochNonce(candidate, boundaryPrevHash, nil)
+	want, err := lcommon.CalculateEpochNonce(candidate, boundaryHash, nil)
 	require.NoError(t, err)
-	require.Equal(t, want.Bytes(), ls.epochCache[1].Nonce)
+	require.Equal(t, want.Bytes(), ls.epochCache[0].Nonce)
 	require.NotEqual(
 		t,
 		candidate,
-		ls.epochCache[1].Nonce,
+		ls.epochCache[0].Nonce,
 		"epoch nonce must no longer be the NeutralNonce-collapsed candidate",
 	)
 }
@@ -131,16 +127,60 @@ func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
 	require.Equal(t, nonce, ls.epochCache[0].Nonce)
 }
 
+func TestHealEmptyLabNoncesInPlaceRepairsReloadedEpochs(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     250,
+		Hash:     boundaryHash,
+		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	epochs := []models.Epoch{
+		{
+			EpochId:             6,
+			StartSlot:           300,
+			LengthInSlots:       100,
+			Nonce:               append([]byte(nil), candidate...),
+			CandidateNonce:      candidate,
+			LastEpochBlockNonce: nil,
+		},
+	}
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	repaired := ls.healEmptyLabNoncesInPlace(epochs)
+
+	want, err := lcommon.CalculateEpochNonce(candidate, boundaryHash, nil)
+	require.NoError(t, err)
+	require.True(t, repaired)
+	require.Equal(t, boundaryHash, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, want.Bytes(), epochs[0].Nonce)
+}
+
 func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
 
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
 	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
 		ID:       3,
-		Slot:     150,
-		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		Slot:     250,
+		Hash:     boundaryHash,
 		PrevHash: boundaryPrevHash,
 		Cbor:     []byte{0x80},
 		Number:   3,
@@ -166,14 +206,14 @@ func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
 		append([]byte(nil), candidate...),
 		nil,
 		candidate,
-		bytes.Repeat([]byte{0x66}, 32),
+		nil,
 		eras.ShelleyEraDesc.Id,
 		1,
 		100,
 		nil,
 	))
 
-	want, err := lcommon.CalculateEpochNonce(candidate, boundaryPrevHash, nil)
+	want, err := lcommon.CalculateEpochNonce(candidate, boundaryHash, nil)
 	require.NoError(t, err)
 
 	ls := &LedgerState{

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -96,7 +96,8 @@ func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 }
 
 // TestHealEmptyLabNoncesLeavesValidRecordsUntouched verifies the recovery is a
-// no-op when no epoch has an empty lab — it must not perturb correct state.
+// no-op when no epoch has a repairable lab mismatch — it must not perturb
+// correct state.
 func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
@@ -125,6 +126,99 @@ func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
 
 	require.Equal(t, lab, ls.epochCache[0].LastEpochBlockNonce)
 	require.Equal(t, nonce, ls.epochCache[0].Nonce)
+}
+
+func TestHealEmptyLabNoncesRepairsStaleLabWithGenesisCandidateFallback(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     250,
+		Hash:     boundaryHash,
+		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	cfg := newConwayBootstrapStabilityCfg(t)
+	genesisCandidate := bytes.Repeat([]byte{0x11}, 32)
+	oldLab := bytes.Repeat([]byte{0x99}, 32)
+	oldNonce := bytes.Repeat([]byte{0xaa}, 32)
+	epochs := []models.Epoch{
+		{
+			EpochId:             6,
+			StartSlot:           300,
+			LengthInSlots:       100,
+			Nonce:               oldNonce,
+			CandidateNonce:      nil,
+			LastEpochBlockNonce: oldLab,
+		},
+	}
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	repaired := ls.healEmptyLabNoncesInPlace(epochs)
+
+	want, err := lcommon.CalculateEpochNonce(
+		genesisCandidate,
+		boundaryHash,
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, repaired)
+	require.Equal(t, boundaryHash, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, want.Bytes(), epochs[0].Nonce)
+	require.Empty(t, epochs[0].CandidateNonce)
+}
+
+func TestHealEmptyLabNoncesSkipsWithoutCandidateFallback(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     250,
+		Hash:     boundaryHash,
+		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	oldNonce := bytes.Repeat([]byte{0xaa}, 32)
+	epochs := []models.Epoch{
+		{
+			EpochId:             6,
+			StartSlot:           300,
+			LengthInSlots:       100,
+			Nonce:               oldNonce,
+			CandidateNonce:      nil,
+			LastEpochBlockNonce: nil,
+		},
+	}
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	repaired := ls.healEmptyLabNoncesInPlace(epochs)
+
+	require.False(t, repaired)
+	require.Empty(t, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, oldNonce, epochs[0].Nonce)
 }
 
 func TestHealEmptyLabNoncesInPlaceRepairsReloadedEpochs(t *testing.T) {

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -128,7 +128,7 @@ func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
 	require.Equal(t, nonce, ls.epochCache[0].Nonce)
 }
 
-func TestHealEmptyLabNoncesRepairsStaleLabWithGenesisCandidateFallback(t *testing.T) {
+func TestHealEmptyLabNoncesSkipsStaleLabWhenCandidateMissing(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
@@ -145,7 +145,6 @@ func TestHealEmptyLabNoncesRepairsStaleLabWithGenesisCandidateFallback(t *testin
 	}, nil))
 
 	cfg := newConwayBootstrapStabilityCfg(t)
-	genesisCandidate := bytes.Repeat([]byte{0x11}, 32)
 	oldLab := bytes.Repeat([]byte{0x99}, 32)
 	oldNonce := bytes.Repeat([]byte{0xaa}, 32)
 	epochs := []models.Epoch{
@@ -168,15 +167,9 @@ func TestHealEmptyLabNoncesRepairsStaleLabWithGenesisCandidateFallback(t *testin
 
 	repaired := ls.healEmptyLabNoncesInPlace(epochs)
 
-	want, err := lcommon.CalculateEpochNonce(
-		genesisCandidate,
-		boundaryHash,
-		nil,
-	)
-	require.NoError(t, err)
-	require.True(t, repaired)
-	require.Equal(t, boundaryHash, epochs[0].LastEpochBlockNonce)
-	require.Equal(t, want.Bytes(), epochs[0].Nonce)
+	require.False(t, repaired)
+	require.Equal(t, oldLab, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, oldNonce, epochs[0].Nonce)
 	require.Empty(t, epochs[0].CandidateNonce)
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4474,9 +4474,7 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 	clear(ls.epochNonceHexCache)
 	if len(epochs) > 0 {
 		// Recover epoch records whose LastEpochBlockNonce was persisted empty
-		// by the pre-fix BlockBeforeSlot endorser-block collision (see
-		// healEmptyLabNonces). New syncs are unaffected now that
-		// BlockBeforeSlotTxn skips synthetic blobs.
+		// or stale by pre-fix boundary lookup bugs (see healEmptyLabNonces).
 		ls.healEmptyLabNonces()
 		// Set current epoch and era after healing so currentEpoch reflects
 		// any repaired nonce in epochCache.
@@ -4564,10 +4562,10 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 // from peers and break leader-VRF verification.
 //
 // This runs once at startup over the loaded epoch cache. For each non-genesis
-// epoch with an empty lab whose boundary block (resolved through the canonical
-// chain index) carries a valid Hash, it restores the lab and recomputes
-// the affected epoch's nonce in the cache. It is a pure function of
-// already-stored chain data and is idempotent across restarts.
+// epoch whose lab is empty or differs from the boundary block resolved through
+// the canonical chain index, it restores the lab and recomputes the affected
+// epoch's nonce in the cache. It is a pure function of already-stored chain
+// data and is idempotent across restarts.
 func (ls *LedgerState) healEmptyLabNonces() {
 	if ls.healEmptyLabNoncesInPlace(ls.epochCache) {
 		clear(ls.epochNonceHexCache)
@@ -4579,7 +4577,7 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 	for i := range epochs {
 		ep := &epochs[i]
 		// The genesis epoch legitimately carries no last block nonce.
-		if len(ep.LastEpochBlockNonce) != 0 || ep.StartSlot == 0 {
+		if ep.StartSlot == 0 {
 			continue
 		}
 		boundary, err := ls.canonicalBlockBeforeSlot(nil, ep.StartSlot)
@@ -4587,24 +4585,24 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 			len(boundary.Hash) != lcommon.Blake2b256Size {
 			continue
 		}
-		ep.LastEpochBlockNonce = cloneNonce(boundary.Hash)
-		repaired = true
-		ls.config.Logger.Info(
-			"recovered empty epoch lastEpochBlockNonce",
-			"epoch", ep.EpochId,
-			"boundary_slot", boundary.Slot,
-			"last_epoch_block_nonce",
-			hex.EncodeToString(ep.LastEpochBlockNonce),
-			"component", "ledger",
-		)
-		// Recompute this epoch's nonce: it used this lab in its formula
-		// and would otherwise be the NeutralNonce-collapsed (η=candidate) value.
-		if len(ep.CandidateNonce) != lcommon.Blake2b256Size {
+		if bytes.Equal(ep.LastEpochBlockNonce, boundary.Hash) {
 			continue
 		}
+		candidateNonce, err := ls.epochRepairCandidateNonce(*ep)
+		if err != nil {
+			ls.config.Logger.Warn(
+				"skipping epoch lab recovery; candidate nonce unavailable",
+				"epoch", ep.EpochId,
+				"error", err,
+				"component", "ledger",
+			)
+			continue
+		}
+		// Recompute this epoch's nonce before mutating the record; the lab and
+		// nonce must be repaired together or not at all.
 		res, err := lcommon.CalculateEpochNonce(
-			ep.CandidateNonce,
-			ep.LastEpochBlockNonce,
+			candidateNonce,
+			boundary.Hash,
 			nil,
 		)
 		if err != nil {
@@ -4616,16 +4614,63 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 			)
 			continue
 		}
+		previousLab := cloneNonce(ep.LastEpochBlockNonce)
+		previousNonce := cloneNonce(ep.Nonce)
+		newNonce := res.Bytes()
+		ep.LastEpochBlockNonce = cloneNonce(boundary.Hash)
+		ep.Nonce = newNonce
+		repaired = true
+		ls.config.Logger.Info(
+			"repaired epoch lastEpochBlockNonce",
+			"epoch", ep.EpochId,
+			"boundary_slot", boundary.Slot,
+			"previous_last_epoch_block_nonce",
+			hex.EncodeToString(previousLab),
+			"last_epoch_block_nonce",
+			hex.EncodeToString(ep.LastEpochBlockNonce),
+			"component", "ledger",
+		)
 		ls.config.Logger.Info(
 			"recomputed epoch nonce after lab recovery",
 			"epoch", ep.EpochId,
-			"previous_nonce", hex.EncodeToString(ep.Nonce),
-			"epoch_nonce", hex.EncodeToString(res.Bytes()),
+			"previous_nonce", hex.EncodeToString(previousNonce),
+			"epoch_nonce", hex.EncodeToString(newNonce),
 			"component", "ledger",
 		)
-		ep.Nonce = res.Bytes()
 	}
 	return repaired
+}
+
+func (ls *LedgerState) epochRepairCandidateNonce(
+	ep models.Epoch,
+) ([]byte, error) {
+	switch len(ep.CandidateNonce) {
+	case lcommon.Blake2b256Size:
+		return cloneNonce(ep.CandidateNonce), nil
+	case 0:
+		if ls.config.CardanoNodeConfig == nil ||
+			ls.config.CardanoNodeConfig.ShelleyGenesisHash == "" {
+			return nil, errors.New("shelley genesis hash not available")
+		}
+		genesisHash, err := hex.DecodeString(
+			ls.config.CardanoNodeConfig.ShelleyGenesisHash,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("decode genesis hash: %w", err)
+		}
+		if len(genesisHash) != lcommon.Blake2b256Size {
+			return nil, fmt.Errorf(
+				"invalid genesis hash length %d",
+				len(genesisHash),
+			)
+		}
+		return genesisHash, nil
+	default:
+		return nil, fmt.Errorf(
+			"invalid candidate nonce length %d",
+			len(ep.CandidateNonce),
+		)
+	}
 }
 
 func (ls *LedgerState) loadTip() error {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4648,23 +4648,7 @@ func (ls *LedgerState) epochRepairCandidateNonce(
 	case lcommon.Blake2b256Size:
 		return cloneNonce(ep.CandidateNonce), nil
 	case 0:
-		if ls.config.CardanoNodeConfig == nil ||
-			ls.config.CardanoNodeConfig.ShelleyGenesisHash == "" {
-			return nil, errors.New("shelley genesis hash not available")
-		}
-		genesisHash, err := hex.DecodeString(
-			ls.config.CardanoNodeConfig.ShelleyGenesisHash,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("decode genesis hash: %w", err)
-		}
-		if len(genesisHash) != lcommon.Blake2b256Size {
-			return nil, fmt.Errorf(
-				"invalid genesis hash length %d",
-				len(genesisHash),
-			)
-		}
-		return genesisHash, nil
+		return nil, errors.New("candidate nonce not stored")
 	default:
 		return nil, fmt.Errorf(
 			"invalid candidate nonce length %d",

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4554,21 +4554,18 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 }
 
 // healEmptyLabNonces repairs epoch records whose LastEpochBlockNonce was
-// persisted empty by the pre-fix BlockBeforeSlot endorser-block collision.
+// persisted empty by pre-fix boundary block lookup bugs.
 //
 // LastEpochBlockNonce is the hash of the last block of the previous epoch. It
-// feeds the current epoch's nonce as candidateNonce ⭒ lastEpochBlockNonce. Before
-// BlockBeforeSlotTxn was taught to skip synthetic blobs, the labNonce lookup at
-// an epoch transition could return a Leios endorser block (persisted at a
-// block-blob key via SetGenesisCbor with an empty PrevHash) instead of the real
-// ranking block, saving an empty lab. An empty lab collapses the current epoch's
-// nonce to the NeutralNonce identity (η = candidateNonce, skipping the labNonce
-// mix), so every leader-VRF check in that epoch fails and the node wedges at
-// the first block it must verify live.
+// feeds the current epoch's nonce as candidateNonce ⭒ lastEpochBlockNonce.
+// Earlier boundary lookups scanned block-blob keys, so they could return a
+// synthetic Leios endorser block or retained fork blob instead of the active
+// chain's real ranking block. Empty or wrong lab values diverge epoch nonces
+// from peers and break leader-VRF verification.
 //
 // This runs once at startup over the loaded epoch cache. For each non-genesis
-// epoch with an empty lab whose boundary block (now resolved to the real
-// ranking block) carries a valid Hash, it restores the lab and recomputes
+// epoch with an empty lab whose boundary block (resolved through the canonical
+// chain index) carries a valid Hash, it restores the lab and recomputes
 // the affected epoch's nonce in the cache. It is a pure function of
 // already-stored chain data and is idempotent across restarts.
 func (ls *LedgerState) healEmptyLabNonces() {
@@ -4585,7 +4582,7 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 		if len(ep.LastEpochBlockNonce) != 0 || ep.StartSlot == 0 {
 			continue
 		}
-		boundary, err := database.BlockBeforeSlot(ls.db, ep.StartSlot)
+		boundary, err := ls.canonicalBlockBeforeSlot(nil, ep.StartSlot)
 		if err != nil ||
 			len(boundary.Hash) != lcommon.Blake2b256Size {
 			continue

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1849,12 +1849,13 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	// then applied atomically under a single Lock to avoid data
 	// races with concurrent readers.
 	var (
-		newEpochs       []models.Epoch
-		newCurrentEpoch models.Epoch
-		newCurrentEra   eras.EraDesc
-		newPParams      lcommon.ProtocolParameters
-		newPrevPParams  lcommon.ProtocolParameters
-		eraResolved     bool
+		newEpochs         []models.Epoch
+		newEpochsRepaired bool
+		newCurrentEpoch   models.Epoch
+		newCurrentEra     eras.EraDesc
+		newPParams        lcommon.ProtocolParameters
+		newPrevPParams    lcommon.ProtocolParameters
+		eraResolved       bool
 	)
 	// Snapshot current era under read lock for fallback
 	ls.RLock()
@@ -1872,6 +1873,9 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	}
 	if epochs != nil {
 		newEpochs = epochs
+		// Keep rollback reloads consistent with startup reloads: a
+		// persisted empty lab must not re-enter the in-memory cache.
+		newEpochsRepaired = ls.healEmptyLabNoncesInPlace(newEpochs)
 		// Reset currentEpoch to the last remaining epoch so
 		// that ledgerProcessBlocks correctly detects the next
 		// epoch boundary and EpochNonce() returns the right
@@ -1933,6 +1937,9 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	ls.Lock()
 	if newEpochs != nil {
 		ls.epochCache = newEpochs
+		if newEpochsRepaired {
+			clear(ls.epochNonceHexCache)
+		}
 
 		if len(newEpochs) > 0 {
 			ls.currentEpoch = newCurrentEpoch
@@ -4549,35 +4556,41 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 // healEmptyLabNonces repairs epoch records whose LastEpochBlockNonce was
 // persisted empty by the pre-fix BlockBeforeSlot endorser-block collision.
 //
-// LastEpochBlockNonce is the lagged "prevHash of the last block of the previous
-// epoch" that feeds the next epoch's nonce as candidateNonce ⭒ labNonce. Before
+// LastEpochBlockNonce is the hash of the last block of the previous epoch. It
+// feeds the current epoch's nonce as candidateNonce ⭒ lastEpochBlockNonce. Before
 // BlockBeforeSlotTxn was taught to skip synthetic blobs, the labNonce lookup at
 // an epoch transition could return a Leios endorser block (persisted at a
 // block-blob key via SetGenesisCbor with an empty PrevHash) instead of the real
-// ranking block, saving an empty lab. An empty lab collapses the next epoch's
+// ranking block, saving an empty lab. An empty lab collapses the current epoch's
 // nonce to the NeutralNonce identity (η = candidateNonce, skipping the labNonce
 // mix), so every leader-VRF check in that epoch fails and the node wedges at
 // the first block it must verify live.
 //
 // This runs once at startup over the loaded epoch cache. For each non-genesis
 // epoch with an empty lab whose boundary block (now resolved to the real
-// ranking block) carries a valid PrevHash, it restores the lab and recomputes
-// the affected next epoch's nonce in the cache. It is a pure function of
+// ranking block) carries a valid Hash, it restores the lab and recomputes
+// the affected epoch's nonce in the cache. It is a pure function of
 // already-stored chain data and is idempotent across restarts.
 func (ls *LedgerState) healEmptyLabNonces() {
+	if ls.healEmptyLabNoncesInPlace(ls.epochCache) {
+		clear(ls.epochNonceHexCache)
+	}
+}
+
+func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 	repaired := false
-	for i := range ls.epochCache {
-		ep := &ls.epochCache[i]
-		// The genesis epoch legitimately carries no lagged block nonce.
+	for i := range epochs {
+		ep := &epochs[i]
+		// The genesis epoch legitimately carries no last block nonce.
 		if len(ep.LastEpochBlockNonce) != 0 || ep.StartSlot == 0 {
 			continue
 		}
 		boundary, err := database.BlockBeforeSlot(ls.db, ep.StartSlot)
 		if err != nil ||
-			len(boundary.PrevHash) != lcommon.Blake2b256Size {
+			len(boundary.Hash) != lcommon.Blake2b256Size {
 			continue
 		}
-		ep.LastEpochBlockNonce = boundary.PrevHash
+		ep.LastEpochBlockNonce = cloneNonce(boundary.Hash)
 		repaired = true
 		ls.config.Logger.Info(
 			"recovered empty epoch lastEpochBlockNonce",
@@ -4587,41 +4600,35 @@ func (ls *LedgerState) healEmptyLabNonces() {
 			hex.EncodeToString(ep.LastEpochBlockNonce),
 			"component", "ledger",
 		)
-		// Recompute the next epoch's nonce: it used this lab in its formula
+		// Recompute this epoch's nonce: it used this lab in its formula
 		// and would otherwise be the NeutralNonce-collapsed (η=candidate) value.
-		for j := range ls.epochCache {
-			nxt := &ls.epochCache[j]
-			if nxt.EpochId != ep.EpochId+1 ||
-				len(nxt.CandidateNonce) != lcommon.Blake2b256Size {
-				continue
-			}
-			res, err := lcommon.CalculateEpochNonce(
-				nxt.CandidateNonce,
-				ep.LastEpochBlockNonce,
-				nil,
-			)
-			if err != nil {
-				ls.config.Logger.Warn(
-					"failed to recompute epoch nonce during lab recovery",
-					"epoch", nxt.EpochId,
-					"error", err,
-					"component", "ledger",
-				)
-				continue
-			}
-			ls.config.Logger.Info(
-				"recomputed epoch nonce after lab recovery",
-				"epoch", nxt.EpochId,
-				"previous_nonce", hex.EncodeToString(nxt.Nonce),
-				"epoch_nonce", hex.EncodeToString(res.Bytes()),
+		if len(ep.CandidateNonce) != lcommon.Blake2b256Size {
+			continue
+		}
+		res, err := lcommon.CalculateEpochNonce(
+			ep.CandidateNonce,
+			ep.LastEpochBlockNonce,
+			nil,
+		)
+		if err != nil {
+			ls.config.Logger.Warn(
+				"failed to recompute epoch nonce during lab recovery",
+				"epoch", ep.EpochId,
+				"error", err,
 				"component", "ledger",
 			)
-			nxt.Nonce = res.Bytes()
+			continue
 		}
+		ls.config.Logger.Info(
+			"recomputed epoch nonce after lab recovery",
+			"epoch", ep.EpochId,
+			"previous_nonce", hex.EncodeToString(ep.Nonce),
+			"epoch_nonce", hex.EncodeToString(res.Bytes()),
+			"component", "ledger",
+		)
+		ep.Nonce = res.Bytes()
 	}
-	if repaired {
-		clear(ls.epochNonceHexCache)
-	}
+	return repaired
 }
 
 func (ls *LedgerState) loadTip() error {
@@ -5644,7 +5651,8 @@ func (ls *LedgerState) nextEpochNonceReadyCutoffSlot(
 
 // computeNextEpochNonce speculatively computes the epoch nonce for the
 // next epoch (currentEpoch.EpochId + 1) using data from the current epoch.
-// Uses the lagged lastEpochBlockNonce from the current epoch record.
+// Uses the current epoch's last block hash, carrying the stored
+// lastEpochBlockNonce only when the epoch has no blocks.
 //
 // Returns nil if the nonce cannot be computed (e.g., missing block data,
 // Byron era, or missing genesis config).

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -393,7 +392,7 @@ func (ls *LedgerState) advanceEpochCache() error {
 }
 
 // computeEpochNonceForSlot computes the epoch nonce, evolving nonce,
-// and labNonce for a new epoch starting at epochStartSlot. This
+// and lastEpochBlockNonce for a new epoch starting at epochStartSlot. This
 // mirrors calculateEpochNonce but uses non-transactional DB lookups
 // since we're not inside the ledger processing pipeline.
 //
@@ -514,24 +513,20 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		)
 	}
 
-	// Compute the labNonce to SAVE for the next epoch's formula.
-	var labNonceToSave []byte
-	boundaryBlock, err := database.BlockBeforeSlot(
-		ls.db,
+	// Compute the lastEpochBlockNonce for the epoch being closed.
+	// This is the hash of the last block in prevEpoch, or the carried
+	// value when prevEpoch has no blocks.
+	lastEpochBlockNonce, err := ls.epochLabNonce(
+		nil,
+		prevEpoch.StartSlot,
 		prevEpochEndSlot,
+		prevEpoch.LastEpochBlockNonce,
 	)
 	if err != nil {
-		if !errors.Is(err, models.ErrBlockNotFound) {
-			return nil, nil, nil, nil, fmt.Errorf(
-				"lookup boundary block: %w", err,
-			)
-		}
-	} else if len(boundaryBlock.PrevHash) > 0 {
-		labNonceToSave = boundaryBlock.PrevHash
+		return nil, nil, nil, nil, err
 	}
+	labNonceToSave := lastEpochBlockNonce
 
-	// Use the LAGGED lastEpochBlockNonce in the formula.
-	lastEpochBlockNonce := prevEpoch.LastEpochBlockNonce
 	if len(lastEpochBlockNonce) == 0 {
 		// NeutralNonce is the identity element of ⭒:
 		//   candidateNonce ⭒ NeutralNonce = candidateNonce

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -91,8 +91,8 @@ type RawLedgerState struct {
 	// tip. This is required to correctly continue nonce accumulation
 	// from snapshot tip to epoch boundary.
 	CandidateNonce []byte
-	// LastEpochBlockNonce is the lagged lab nonce from consensus
-	// state (used in epoch nonce calculation).
+	// LastEpochBlockNonce is the Praos last applied block hash from
+	// consensus state (used in epoch nonce calculation).
 	LastEpochBlockNonce []byte
 	// EraBoundsWarning holds a non-fatal error from era bounds
 	// extraction. When set, epoch generation falls back to

--- a/ledgerstate/snapshot.go
+++ b/ledgerstate/snapshot.go
@@ -723,8 +723,8 @@ type praosNonces struct {
 	// CandidateNonce is the current Praos candidate nonce (eta_c)
 	// at the imported tip.
 	CandidateNonce []byte
-	// LastEpochBlockNonce is the lagged lab nonce used in epoch
-	// nonce calculation.
+	// LastEpochBlockNonce is the Praos last applied block hash used
+	// in epoch nonce calculation.
 	LastEpochBlockNonce []byte
 }
 


### PR DESCRIPTION
Closes #2688 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes epoch nonce computation by deriving the lab from the active chain’s boundary block hash and carrying it across empty epochs, then repairing persisted empty/stale labs on startup and rollback to restore correct leader-VRF checks.

- **Bug Fixes**
  - Resolve boundary blocks via `chain.BlockBeforeSlot` (canonical chain index), not blob scans, so synthetic and fork blobs are excluded.
  - Save the current epoch’s last block Hash as `LastEpochBlockNonce`; carry forward when the epoch has no blocks; normalize older PrevHash carries to the boundary block Hash.
  - Repair empty/stale labs at startup and on rollback, recomputing that epoch’s `Nonce` only when a stored `CandidateNonce` exists; skip epochs without one; clear epoch-nonce caches and update header verification/chain sync to use the corrected lab.

- **Refactors**
  - Added `ledger/epoch_lab_nonce.go` to centralize canonical lookup, carry-forward, and normalization (with `LedgerState` DB fallback when no chain is attached).
  - Added `Chain.BlockBeforeSlot` to walk the canonical chain index.
  - Updated docs and tests to reflect canonical boundary lookup and the new lab nonce shape.

<sup>Written for commit 3d6136f6e529f64656b539f6d2f2cee7f170107a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved epoch nonce recovery during startup and rollback so affected epochs are repaired consistently, preventing incorrect leader-VRF checks and nonce fallback issues.
  * Fixed chain selection during nonce calculation to use the canonical chain, reducing the chance of fork or synthetic data affecting results.

* **Documentation**
  * Clarified the handling of epoch boundary hashes and nonce repair behavior across architecture and database documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->