### PR TITLE
fix(ledger): verify slot-leader VRF eligibility against stake thresho…

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -5702,6 +5702,9 @@ func (ls *LedgerState) SlotsPerEpoch() uint64 {
 // ActiveSlotCoeff returns the active slot coefficient (f parameter).
 // This is used in the Ouroboros Praos leader election probability.
 func (ls *LedgerState) ActiveSlotCoeff() float64 {
+	if ls.config.CardanoNodeConfig == nil {
+		return 0
+	}
 	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil || shelleyGenesis.ActiveSlotsCoeff.Rat == nil {
 		return 0

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -5718,6 +5718,20 @@ func (ls *LedgerState) ActiveSlotCoeff() float64 {
 	return float64(num) / float64(denom)
 }
 
+// activeSlotCoeffRat returns the active slot coefficient as a *big.Rat,
+// preserving the full precision from the Shelley genesis without a
+// float64 roundtrip. Returns nil when the genesis is unavailable.
+func (ls *LedgerState) activeSlotCoeffRat() *big.Rat {
+	if ls.config.CardanoNodeConfig == nil {
+		return nil
+	}
+	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if shelleyGenesis == nil || shelleyGenesis.ActiveSlotsCoeff.Rat == nil {
+		return nil
+	}
+	return shelleyGenesis.ActiveSlotsCoeff.Rat
+}
+
 // Database returns the underlying database for transaction operations.
 func (ls *LedgerState) Database() *database.Database {
 	return ls.db

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -311,10 +311,12 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 	}
 
 	// Use the genesis Rat directly to avoid a float64 precision roundtrip.
+	// A zero or negative coefficient would compute a zero threshold and
+	// reject every non-Byron block; treat it as unavailable.
 	activeSlotCoeffRat := ls.activeSlotCoeffRat()
-	if activeSlotCoeffRat == nil {
+	if activeSlotCoeffRat == nil || activeSlotCoeffRat.Sign() <= 0 {
 		ls.config.Logger.Warn(
-			"skipping leader eligibility check: active slot coefficient unavailable",
+			"skipping leader eligibility check: active slot coefficient unavailable or non-positive",
 			"slot", block.SlotNumber(),
 			"component", "ledger",
 		)

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"slices"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -225,16 +224,20 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 //
 //	vrfLeaderOutput < threshold(sigma, f)
 //
-// where sigma = poolStake / totalStake (from the "mark" snapshot at epoch-2)
-// and f is the active slot coefficient from Shelley genesis.
+// where sigma = poolStake / totalStake and f is the active slot coefficient
+// from Shelley genesis.
+//
+// Snapshot epoch selection follows the Mark→Set→Go rotation:
+//   - epoch 0 and 1: genesis snapshot (stored at epoch 0, "mark")
+//   - epoch e >= 2:  mark snapshot at epoch e-2
 //
 // TPraos (Shelley/Allegra/Mary/Alonzo) and CPraos (Babbage/Conway) differ in
 // how the VRF leader value is derived from the output bytes; ConsensusModeForEpoch
 // selects the correct path for the block's era.
 //
-// Early epochs (< 2) and Byron blocks are skipped because no mark snapshot
-// exists two epochs prior. A missing total-stake or zero active-slot-coeff
-// is logged and skipped rather than rejecting, to tolerate early-chain states.
+// Byron blocks are skipped (PBFT). A missing total-stake or unavailable active
+// slot coefficient is logged and skipped rather than rejecting, to tolerate
+// early-chain bootstrap states where the genesis snapshot is not yet written.
 func (ls *LedgerState) verifyBlockLeaderEligibility(
 	block ledger.Block,
 	epochId uint64,
@@ -243,12 +246,13 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 		return nil
 	}
 
-	// The mark snapshot used for leader eligibility is taken at epoch-2.
-	// Skip the check for the first two epochs where no such snapshot exists.
-	if epochId < 2 {
-		return nil
+	// Determine which mark snapshot epoch to query.
+	// Epochs 0 and 1 use the genesis distribution stored at epoch 0.
+	// Epoch e >= 2 uses the mark snapshot captured at epoch e-2.
+	snapshotEpoch := uint64(0)
+	if epochId >= 2 {
+		snapshotEpoch = epochId - 2
 	}
-	snapshotEpoch := epochId - 2
 
 	// Derive pool key hash from the block's issuer verification key.
 	issuerVkey := block.IssuerVkey()
@@ -295,8 +299,8 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 		)
 	}
 	if totalStake == 0 {
-		// No total stake in snapshot yet — occurs during very early chain
-		// bootstrap. Skip rather than reject.
+		// Genesis snapshot not yet written (very early bootstrap).
+		// Skip rather than reject.
 		ls.config.Logger.Warn(
 			"skipping leader eligibility check: total active stake is zero",
 			"slot", block.SlotNumber(),
@@ -306,8 +310,9 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 		return nil
 	}
 
-	activeSlotCoeff := ls.ActiveSlotCoeff()
-	if activeSlotCoeff <= 0 {
+	// Use the genesis Rat directly to avoid a float64 precision roundtrip.
+	activeSlotCoeffRat := ls.activeSlotCoeffRat()
+	if activeSlotCoeffRat == nil {
 		ls.config.Logger.Warn(
 			"skipping leader eligibility check: active slot coefficient unavailable",
 			"slot", block.SlotNumber(),
@@ -315,7 +320,6 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 		)
 		return nil
 	}
-	activeSlotCoeffRat := new(big.Rat).SetFloat64(activeSlotCoeff)
 
 	// Consensus mode determines the VRF leader-value derivation path.
 	mode := ls.ConsensusModeForEpoch(epochId)

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -19,10 +19,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"slices"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -203,11 +205,164 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 		)
 	}
 
-	return verifyBlockHeaderHex(
+	if err := verifyBlockHeaderHex(
 		block,
 		ls.epochNonceHex(epoch.EpochId, epoch.Nonce),
 		slotsPerKesPeriod,
+	); err != nil {
+		return err
+	}
+
+	return ls.verifyBlockLeaderEligibility(block, epoch.EpochId)
+}
+
+// verifyBlockLeaderEligibility checks that the block's producer pool was
+// eligible to produce a block at this slot under the Praos stake-derived
+// leadership threshold. This enforces the Cardano Blueprint chain validity
+// requirement that header validation confirms slot-leader eligibility.
+//
+// The eligibility condition is:
+//
+//	vrfLeaderOutput < threshold(sigma, f)
+//
+// where sigma = poolStake / totalStake (from the "mark" snapshot at epoch-2)
+// and f is the active slot coefficient from Shelley genesis.
+//
+// TPraos (Shelley/Allegra/Mary/Alonzo) and CPraos (Babbage/Conway) differ in
+// how the VRF leader value is derived from the output bytes; ConsensusModeForEpoch
+// selects the correct path for the block's era.
+//
+// Early epochs (< 2) and Byron blocks are skipped because no mark snapshot
+// exists two epochs prior. A missing total-stake or zero active-slot-coeff
+// is logged and skipped rather than rejecting, to tolerate early-chain states.
+func (ls *LedgerState) verifyBlockLeaderEligibility(
+	block ledger.Block,
+	epochId uint64,
+) error {
+	if block.Era().Id == byron.EraIdByron {
+		return nil
+	}
+
+	// The mark snapshot used for leader eligibility is taken at epoch-2.
+	// Skip the check for the first two epochs where no such snapshot exists.
+	if epochId < 2 {
+		return nil
+	}
+	snapshotEpoch := epochId - 2
+
+	// Derive pool key hash from the block's issuer verification key.
+	issuerVkey := block.IssuerVkey()
+	poolKeyHash := lcommon.PoolKeyHash(issuerVkey.Hash())
+
+	// Look up the pool's stake in the mark snapshot.
+	snapshot, err := ls.db.Metadata().GetPoolStakeSnapshot(
+		snapshotEpoch,
+		"mark",
+		poolKeyHash[:],
+		nil,
 	)
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"lookup pool stake: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	if snapshot == nil || snapshot.TotalStake == 0 {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"producer pool %x has no stake in epoch %d snapshot",
+			block.SlotNumber(),
+			poolKeyHash[:],
+			snapshotEpoch,
+		)
+	}
+	poolStake := uint64(snapshot.TotalStake)
+
+	// Look up the total active stake for the threshold denominator.
+	totalStake, err := ls.db.Metadata().GetTotalActiveStake(
+		snapshotEpoch,
+		"mark",
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"lookup total active stake: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	if totalStake == 0 {
+		// No total stake in snapshot yet — occurs during very early chain
+		// bootstrap. Skip rather than reject.
+		ls.config.Logger.Warn(
+			"skipping leader eligibility check: total active stake is zero",
+			"slot", block.SlotNumber(),
+			"epoch", epochId,
+			"component", "ledger",
+		)
+		return nil
+	}
+
+	activeSlotCoeff := ls.ActiveSlotCoeff()
+	if activeSlotCoeff <= 0 {
+		ls.config.Logger.Warn(
+			"skipping leader eligibility check: active slot coefficient unavailable",
+			"slot", block.SlotNumber(),
+			"component", "ledger",
+		)
+		return nil
+	}
+	activeSlotCoeffRat := new(big.Rat).SetFloat64(activeSlotCoeff)
+
+	// Consensus mode determines the VRF leader-value derivation path.
+	mode := ls.ConsensusModeForEpoch(epochId)
+
+	// Extract the VRF output from the header body CBOR.
+	vrfResult, ok, err := headerVrfResultFromBodyCbor(block.Header())
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"extract VRF result: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	if !ok || len(vrfResult.Output) == 0 {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"VRF output unavailable for eligibility check",
+			block.SlotNumber(),
+		)
+	}
+
+	// Compute the Praos leadership threshold and compare.
+	threshold := consensus.CertifiedNatThresholdWithMode(
+		poolStake,
+		totalStake,
+		activeSlotCoeffRat,
+		mode,
+	)
+	if !consensus.IsVRFOutputBelowThresholdWithMode(
+		vrfResult.Output,
+		threshold,
+		mode,
+	) {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"producer pool %x VRF leader value exceeds stake-derived threshold "+
+				"(pool stake: %d, total stake: %d, epoch: %d)",
+			block.SlotNumber(),
+			poolKeyHash[:],
+			poolStake,
+			totalStake,
+			epochId,
+		)
+	}
+
+	return nil
 }
 
 func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -721,17 +721,38 @@ func TestVerifyBlockHeaderCrypto_RejectsBlockWithNoNonce(t *testing.T) {
 // when blocks span an epoch boundary, each block is verified against
 // the nonce of its own epoch, not the "current" epoch. This is the
 // epoch-aware lookup that prevents the LDG-08 bypass.
+//
+// The test also exercises the full pipeline including leader-eligibility:
+// epoch 0 blocks query the genesis snapshot (epoch 0, "mark"), so the
+// database is seeded with the pool's stake before calling verifyBlockHeaderCrypto.
 func TestVerifyBlockHeaderCrypto_EpochBoundaryUsesCorrectNonce(
 	t *testing.T,
 ) {
-	epoch0Nonce := make([]byte, 32)
+	// createTestBlock uses f=0.99 to find eligible slots; use the same
+	// coefficient in the Shelley genesis so the eligibility check matches.
+	tb := createTestBlock(t, [32]byte{10}, 0, tamperNone)
+
+	epoch0Nonce := tb.epochNonce // nonceSeed=0 → epoch0Nonce
 	epoch1Nonce := make([]byte, 32)
-	for i := range epoch0Nonce {
-		epoch0Nonce[i] = byte(i)     //nolint:gosec
+	for i := range epoch1Nonce {
 		epoch1Nonce[i] = byte(i + 1) //nolint:gosec
 	}
 
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+
+	// Seed genesis snapshot (epoch 0, "mark") for the pool so leader
+	// eligibility succeeds for blocks in epoch 0.
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 0, poolKeyHash[:], 1_000_000_000)
+
 	ls := &LedgerState{
+		db: db,
 		currentEpoch: models.Epoch{
 			EpochId:       1,
 			StartSlot:     1000,
@@ -753,16 +774,13 @@ func TestVerifyBlockHeaderCrypto_EpochBoundaryUsesCorrectNonce(
 			},
 		},
 		config: LedgerStateConfig{
-			CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+			CardanoNodeConfig: newHighFreqShelleyGenesisCfg(t),
 			Logger: slog.New(
 				slog.NewJSONHandler(io.Discard, nil),
 			),
 		},
 	}
 
-	// Create a valid block in epoch 0 (slot < 1000).
-	// The block's VRF proof was generated with epoch0Nonce.
-	tb := createTestBlock(t, [32]byte{10}, 0, tamperNone)
 	// The test block's slot is in [1, 200]. Ensure epoch 0 covers it.
 	require.Less(
 		t,
@@ -773,8 +791,7 @@ func TestVerifyBlockHeaderCrypto_EpochBoundaryUsesCorrectNonce(
 
 	// Verify: the epoch-aware lookup should find epoch 0 for this block
 	// and use epoch0Nonce (which matches the block's VRF proof).
-	// tb.epochNonce == epoch0Nonce by construction (nonceSeed=0).
-	err := ls.verifyBlockHeaderCrypto(tb.block)
+	err = ls.verifyBlockHeaderCrypto(tb.block)
 	assert.NoError(
 		t,
 		err,
@@ -928,15 +945,31 @@ func TestVerifyBlockLeaderEligibility_ByronSkipped(t *testing.T) {
 	assert.NoError(t, err, "Byron blocks must be skipped")
 }
 
-// TestVerifyBlockLeaderEligibility_EarlyEpochSkipped verifies that epochs
-// 0 and 1 are skipped because no mark snapshot exists at epoch-2.
-func TestVerifyBlockLeaderEligibility_EarlyEpochSkipped(t *testing.T) {
-	ls := &LedgerState{} // no db needed — must not reach DB
-	block := &mockBabbageBlock{slot: 100}
-	for _, epoch := range []uint64{0, 1} {
-		err := ls.verifyBlockLeaderEligibility(block, epoch)
-		assert.NoErrorf(t, err, "epoch %d should be skipped (no snapshot)", epoch)
+// TestVerifyBlockLeaderEligibility_EarlyEpochUsesGenesisSnapshot verifies that
+// epochs 0 and 1 query the genesis snapshot (epoch 0, "mark") rather than
+// skipping eligibility checks. A pool absent from that snapshot is rejected.
+func TestVerifyBlockLeaderEligibility_EarlyEpochUsesGenesisSnapshot(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{35}, 0, tamperNone)
+	// Use epoch 5 nonce for the genesis epoch cache entry; the actual nonce
+	// is not used by verifyBlockLeaderEligibility itself.
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	// Override epoch cache to place the block in epoch 1 (snapshotEpoch = 0).
+	ls.epochCache = []models.Epoch{
+		{EpochId: 1, StartSlot: 0, LengthInSlots: 1_000_000, Nonce: tb.epochNonce},
 	}
+
+	// No genesis snapshot seeded — pool has no stake at epoch 0.
+	err := ls.verifyBlockLeaderEligibility(tb.block, 1)
+	require.Error(t, err, "epoch 1 without genesis snapshot must be rejected")
+	assert.Contains(t, err.Error(), "has no stake in epoch")
+
+	// Now seed the genesis snapshot at epoch 0.
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 0, poolKeyHash[:], 1_000_000_000)
+
+	err = ls.verifyBlockLeaderEligibility(tb.block, 1)
+	assert.NoError(t, err, "epoch 1 with valid genesis snapshot should pass")
 }
 
 // TestVerifyBlockLeaderEligibility_EligiblePoolPasses verifies that a block

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -25,7 +25,9 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/kes"
@@ -840,4 +842,196 @@ func TestVerifyBlockHeaderCrypto_WrongNonceFails(t *testing.T) {
 		err,
 		"block verified against wrong epoch nonce should fail",
 	)
+}
+
+// --- verifyBlockLeaderEligibility tests ---
+
+// newHighFreqShelleyGenesisCfg returns a CardanoNodeConfig with
+// activeSlotsCoeff=0.99, matching the coefficient used in createTestBlock
+// so that VRF outputs found eligible there are also eligible here.
+func newHighFreqShelleyGenesisCfg(t testing.TB) *cardano.CardanoNodeConfig {
+	t.Helper()
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.99,
+		"securityParam": 432,
+		"slotsPerKESPeriod": 129600,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+	cfg := &cardano.CardanoNodeConfig{}
+	err := cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON))
+	require.NoError(t, err)
+	return cfg
+}
+
+// newEligibilityTestLedger builds a LedgerState backed by in-memory SQLite,
+// with an epoch cache that places any slot in [0, 1_000_000) at epoch 5
+// (so snapshotEpoch = 3). The Shelley genesis uses activeSlotsCoeff=0.99
+// to match createTestBlock's VRF eligibility threshold.
+func newEligibilityTestLedger(
+	t *testing.T,
+	epochNonce []byte,
+) (*LedgerState, *database.Database) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+
+	ls := &LedgerState{
+		db: db,
+		epochCache: []models.Epoch{
+			{
+				EpochId:       5,
+				StartSlot:     0,
+				LengthInSlots: 1_000_000,
+				Nonce:         epochNonce,
+			},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newHighFreqShelleyGenesisCfg(t),
+			Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	return ls, db
+}
+
+// seedPoolStakeSnapshot inserts a pool stake snapshot using the store interface.
+func seedPoolStakeSnapshot(
+	t *testing.T,
+	db *database.Database,
+	epoch uint64,
+	poolKeyHash []byte,
+	totalStake uint64,
+) {
+	t.Helper()
+	err := db.Metadata().SavePoolStakeSnapshot(
+		&models.PoolStakeSnapshot{
+			Epoch:        epoch,
+			SnapshotType: "mark",
+			PoolKeyHash:  poolKeyHash,
+			TotalStake:   types.Uint64(totalStake),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+// TestVerifyBlockLeaderEligibility_ByronSkipped verifies that Byron blocks
+// bypass eligibility checking entirely (Byron uses PBFT, not Praos).
+func TestVerifyBlockLeaderEligibility_ByronSkipped(t *testing.T) {
+	ls := &LedgerState{} // no db needed
+	block := &mockByronBlock{}
+	err := ls.verifyBlockLeaderEligibility(block, 5)
+	assert.NoError(t, err, "Byron blocks must be skipped")
+}
+
+// TestVerifyBlockLeaderEligibility_EarlyEpochSkipped verifies that epochs
+// 0 and 1 are skipped because no mark snapshot exists at epoch-2.
+func TestVerifyBlockLeaderEligibility_EarlyEpochSkipped(t *testing.T) {
+	ls := &LedgerState{} // no db needed — must not reach DB
+	block := &mockBabbageBlock{slot: 100}
+	for _, epoch := range []uint64{0, 1} {
+		err := ls.verifyBlockLeaderEligibility(block, epoch)
+		assert.NoErrorf(t, err, "epoch %d should be skipped (no snapshot)", epoch)
+	}
+}
+
+// TestVerifyBlockLeaderEligibility_EligiblePoolPasses verifies that a block
+// from a pool with sufficient stake and an eligible VRF output passes the check.
+func TestVerifyBlockLeaderEligibility_EligiblePoolPasses(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{30}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	// Pool owns 100% of stake — matches createTestBlock's threshold assumption.
+	const totalStake = uint64(1_000_000_000)
+	seedPoolStakeSnapshot(t, db, 3, poolKeyHash[:], totalStake)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err, "eligible pool with full stake should pass")
+}
+
+// TestVerifyBlockLeaderEligibility_PoolNotInSnapshotFails verifies that a block
+// from a pool absent from the epoch-2 mark snapshot is rejected.
+func TestVerifyBlockLeaderEligibility_PoolNotInSnapshotFails(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{31}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	// No snapshot seeded — pool is unknown.
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no stake in epoch")
+}
+
+// TestVerifyBlockLeaderEligibility_ZeroStakeFails verifies that a block
+// from a pool with a zero-stake snapshot entry is rejected.
+func TestVerifyBlockLeaderEligibility_ZeroStakeFails(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{32}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 3, poolKeyHash[:], 0)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no stake in epoch")
+}
+
+// TestVerifyBlockLeaderEligibility_VRFAboveThresholdFails verifies that a block
+// whose VRF leader value is above the stake-derived threshold is rejected.
+// The block was produced eligible at 100% stake (f=0.99 threshold ≈ 2^256*0.99),
+// but the pool only holds 1 lovelace out of 10^18 — making its threshold
+// near zero and ensuring the VRF output exceeds it.
+func TestVerifyBlockLeaderEligibility_VRFAboveThresholdFails(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{33}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	// Actual pool: tiny stake (1 lovelace).
+	seedPoolStakeSnapshot(t, db, 3, poolKeyHash[:], 1)
+	// Dummy pool: huge stake to make the total far exceed the pool's share,
+	// pushing sigma ≈ 1/10^18 and the threshold to essentially zero.
+	dummyHash := make([]byte, 28)
+	dummyHash[0] = 0xFF
+	seedPoolStakeSnapshot(t, db, 3, dummyHash, 1_000_000_000_000_000_000)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VRF leader value exceeds stake-derived threshold")
+}
+
+// TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips verifies that
+// when the active slot coefficient is unavailable (Shelley genesis not loaded),
+// the eligibility check is skipped rather than rejecting the block.
+func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{34}, 0, tamperNone)
+
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+
+	// Seed a pool stake snapshot so the check reaches the coeff lookup.
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 3, poolKeyHash[:], 1_000_000_000)
+
+	ls := &LedgerState{
+		db: db,
+		epochCache: []models.Epoch{
+			{EpochId: 5, StartSlot: 0, LengthInSlots: 1_000_000, Nonce: tb.epochNonce},
+		},
+		config: LedgerStateConfig{
+			// No CardanoNodeConfig → ActiveSlotCoeff() returns 0 → skip.
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+
+	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err, "missing active slot coeff should skip, not reject")
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1068,3 +1068,50 @@ func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips(t *testing.T) {
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	assert.NoError(t, err, "missing active slot coeff should skip, not reject")
 }
+
+// TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips_ExplicitZero
+// verifies that a genesis with activeSlotsCoeff=0 also triggers the skip path.
+// A zero coefficient produces a zero threshold and would otherwise reject every
+// non-Byron block.
+func TestVerifyBlockLeaderEligibility_ZeroCoeffSkips(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{36}, 0, tamperNone)
+
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 3, poolKeyHash[:], 1_000_000_000)
+
+	// Build a genesis config with activeSlotsCoeff explicitly set to 0.
+	// big.Rat.SetString("0") gives Sign()==0, which the guard must catch.
+	zeroCoeffJSON := `{
+		"activeSlotsCoeff": 0,
+		"securityParam": 432,
+		"slotsPerKESPeriod": 129600,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+	zeroCfg := &cardano.CardanoNodeConfig{}
+	require.NoError(
+		t,
+		zeroCfg.LoadShelleyGenesisFromReader(strings.NewReader(zeroCoeffJSON)),
+	)
+
+	ls := &LedgerState{
+		db: db,
+		epochCache: []models.Epoch{
+			{EpochId: 5, StartSlot: 0, LengthInSlots: 1_000_000, Nonce: tb.epochNonce},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: zeroCfg,
+			Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+
+	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err, "zero active slot coeff should skip, not reject all blocks")
+}


### PR DESCRIPTION
Closes #2609 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Praos slot-leader eligibility during block header verification by comparing the header’s VRF output to a stake-derived threshold. Improves `activeSlotsCoeff` handling with full-precision math and safe guards to avoid false rejections.

- **Bug Fixes**
  - Validates leader eligibility using pool/total stake, exact `activeSlotCoeffRat()`, and era-aware mode via `ConsensusModeForEpoch` and `consensus` helpers.
  - Uses mark snapshot at epoch e-2; epochs 0–1 use the genesis (epoch 0) snapshot. Rejects when the producer has no/zero stake or when the VRF exceeds the threshold.
  - Skips the check for Byron, zero total stake, or missing/non-positive `activeSlotsCoeff` (logs a warning).
  - Adds a nil-guard in `ActiveSlotCoeff()` and preserves precision with a `*big.Rat` path.
  - Tests cover: eligible pool success, missing/zero stake rejection, above-threshold VRF rejection, Byron skip, early-epoch genesis snapshot, and missing/zero coefficient skips.

<sup>Written for commit c4623ef1a7b859ba64beb523f97293a37105d1d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash when node configuration is missing by safely handling absent active-slot settings.
  * Improved block header validation to better reject invalid blocks based on leader eligibility rules, reducing acceptance of malformed or unauthorized headers.
  * Added safer fallback behavior in cases where stake data is unavailable, avoiding unnecessary block rejection while logging the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->