### PR TITLE
fix: disconnect wedged peer

### DIFF
--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -34,7 +34,7 @@ var errRestartLedgerPipeline = errors.New(
 )
 
 var errHaltLedgerPipeline = errors.New(
-	"halt ledger pipeline after persistent tx validation failure",
+	"persistent tx validation failure after recovery attempts",
 )
 
 // errStaleChainIterator is returned by ledgerProcessBlock when a block's
@@ -65,12 +65,11 @@ func (e *txValidationError) Unwrap() error {
 	return e.Cause
 }
 
-// maxAtTipRecoveryAttempts caps how many times the ledger will try to
-// recover from the same persistent at-tip validation failure before
-// halting. Each attempt rewinds the primary chain progressively
-// deeper to give chainselection room to pick a different fork. We
-// only halt when even a deep rewind to security-param-sized depth
-// has not let a different chain win.
+// maxAtTipRecoveryAttempts caps the depth schedule for recovering from the
+// same persistent at-tip validation failure. Each attempt rewinds the primary
+// chain progressively deeper to give chainselection room to pick a different
+// fork. After the cap, recovery keeps retrying at the deepest rewind depth and
+// relies on ChainSync peer rotation to find a valid candidate chain.
 const maxAtTipRecoveryAttempts = 3
 
 type atTipRecoveryAttempt struct {
@@ -293,8 +292,8 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		ls.lastAtTipRecovery.matches(validationErr) {
 		attempts = ls.lastAtTipRecovery.Attempts + 1
 		if attempts > maxAtTipRecoveryAttempts {
-			ls.config.Logger.Error(
-				"at-tip recovery exhausted attempts, halting to avoid infinite loop",
+			ls.config.Logger.Warn(
+				"at-tip recovery exhausted scheduled rewind attempts, retrying with deepest rewind",
 				"component", "ledger",
 				"failing_slot", validationErr.BlockPoint.Slot,
 				"failing_block_hash", hex.EncodeToString(
@@ -303,11 +302,7 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 				"tx_hash", hex.EncodeToString(validationErr.TxHash),
 				"attempts", attempts,
 			)
-			return false, fmt.Errorf(
-				"%w: %w",
-				errHaltLedgerPipeline,
-				validationErr,
-			)
+			attempts = maxAtTipRecoveryAttempts
 		}
 	}
 	ls.lastAtTipRecovery = newAtTipRecoveryAttempt(validationErr)

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -534,13 +534,19 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 		ls.lastAtTipRecovery.Attempts,
 	)
 
-	// One more attempt past the cap halts the pipeline.
+	// One more attempt past the cap keeps recovering at the deepest
+	// scheduled rewind. A persistent bad candidate chain is a peer/fork
+	// selection problem; the node should keep trying fresh ChainSync
+	// connections instead of halting the ledger pipeline.
 	recovered, err = ls.tryRecoverFromTxValidationError(validationErr)
-	require.ErrorIs(t, err, errHaltLedgerPipeline)
-	require.False(t, recovered)
-	var txErr *txValidationError
-	require.ErrorAs(t, err, &txErr)
-	assert.Equal(t, validationErr, txErr)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	require.NotNil(t, ls.lastAtTipRecovery)
+	assert.Equal(
+		t,
+		maxAtTipRecoveryAttempts,
+		ls.lastAtTipRecovery.Attempts,
+	)
 }
 
 func TestTryRecoverFromTxValidationErrorFallsBackToTxBlobOffsets(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2639,21 +2639,29 @@ func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 		if err == nil || ctx.Err() != nil {
 			return
 		}
-		if errors.Is(err, errRestartLedgerPipeline) {
+		if ls.handleLedgerProcessBlocksError(err) {
 			continue
 		}
-		if errors.Is(err, errHaltLedgerPipeline) {
-			ls.config.Logger.Error(
-				"block processing halted after persistent validation failure",
-				"error", err,
-			)
-			return
-		}
+		return
+	}
+}
+
+func (ls *LedgerState) handleLedgerProcessBlocksError(err error) bool {
+	if errors.Is(err, errRestartLedgerPipeline) {
+		return true
+	}
+	if errors.Is(err, errHaltLedgerPipeline) {
 		ls.config.Logger.Warn(
-			"block processing failed, restarting pipeline",
+			"block processing hit persistent validation failure, restarting pipeline",
 			"error", err,
 		)
+		return true
 	}
+	ls.config.Logger.Warn(
+		"block processing failed, restarting pipeline",
+		"error", err,
+	)
+	return true
 }
 
 // ProcessTrustedBlockBatches processes already-decoded trusted block batches

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2639,29 +2639,25 @@ func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 		if err == nil || ctx.Err() != nil {
 			return
 		}
-		if ls.handleLedgerProcessBlocksError(err) {
-			continue
-		}
-		return
+		ls.handleLedgerProcessBlocksError(err)
 	}
 }
 
-func (ls *LedgerState) handleLedgerProcessBlocksError(err error) bool {
+func (ls *LedgerState) handleLedgerProcessBlocksError(err error) {
 	if errors.Is(err, errRestartLedgerPipeline) {
-		return true
+		return
 	}
 	if errors.Is(err, errHaltLedgerPipeline) {
 		ls.config.Logger.Warn(
 			"block processing hit persistent validation failure, restarting pipeline",
 			"error", err,
 		)
-		return true
+		return
 	}
 	ls.config.Logger.Warn(
 		"block processing failed, restarting pipeline",
 		"error", err,
 	)
-	return true
 }
 
 // ProcessTrustedBlockBatches processes already-decoded trusted block batches

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -71,6 +72,51 @@ func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
 		readChainResultCh,
 	)
 	require.NoError(t, err)
+}
+
+func TestHandleLedgerProcessBlocksErrorRestartsOnPersistentValidationFailure(
+	t *testing.T,
+) {
+	haltErr := fmt.Errorf("process block batch: %w", errHaltLedgerPipeline)
+	fatalCalled := false
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			FatalErrorFunc: func(error) {
+				fatalCalled = true
+			},
+		},
+	}
+
+	restart := ls.handleLedgerProcessBlocksError(haltErr)
+	require.True(t, restart)
+	require.False(t, fatalCalled)
+}
+
+func TestHandleLedgerProcessBlocksErrorRestartsOnRecoverableErrors(
+	t *testing.T,
+) {
+	fatalCalled := false
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			FatalErrorFunc: func(error) {
+				fatalCalled = true
+			},
+		},
+	}
+
+	require.True(
+		t,
+		ls.handleLedgerProcessBlocksError(errRestartLedgerPipeline),
+	)
+	require.False(t, fatalCalled)
+
+	require.True(
+		t,
+		ls.handleLedgerProcessBlocksError(errors.New("transient")),
+	)
+	require.False(t, fatalCalled)
 }
 
 // It verifies that calculating the stability window is synchronized with

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -74,7 +74,7 @@ func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
 	require.NoError(t, err)
 }
 
-func TestHandleLedgerProcessBlocksErrorRestartsOnPersistentValidationFailure(
+func TestHandleLedgerProcessBlocksErrorLogsPersistentValidationFailure(
 	t *testing.T,
 ) {
 	haltErr := fmt.Errorf("process block batch: %w", errHaltLedgerPipeline)
@@ -88,12 +88,11 @@ func TestHandleLedgerProcessBlocksErrorRestartsOnPersistentValidationFailure(
 		},
 	}
 
-	restart := ls.handleLedgerProcessBlocksError(haltErr)
-	require.True(t, restart)
+	ls.handleLedgerProcessBlocksError(haltErr)
 	require.False(t, fatalCalled)
 }
 
-func TestHandleLedgerProcessBlocksErrorRestartsOnRecoverableErrors(
+func TestHandleLedgerProcessBlocksErrorDoesNotReportFatalErrors(
 	t *testing.T,
 ) {
 	fatalCalled := false
@@ -106,16 +105,10 @@ func TestHandleLedgerProcessBlocksErrorRestartsOnRecoverableErrors(
 		},
 	}
 
-	require.True(
-		t,
-		ls.handleLedgerProcessBlocksError(errRestartLedgerPipeline),
-	)
+	ls.handleLedgerProcessBlocksError(errRestartLedgerPipeline)
 	require.False(t, fatalCalled)
 
-	require.True(
-		t,
-		ls.handleLedgerProcessBlocksError(errors.New("transient")),
-	)
+	ls.handleLedgerProcessBlocksError(errors.New("transient"))
 	require.False(t, fatalCalled)
 }
 

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -138,6 +138,7 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 		event.ChainsyncResyncReasonPostPlateauRealign,
 		event.ChainsyncResyncReasonRollbackNotFound,
 		event.ChainsyncResyncReasonPersistentFork,
+		event.ChainsyncResyncReasonLiveTxValidationRecovery,
 		event.ChainsyncResyncReasonRollbackExceedsK,
 		event.ChainsyncResyncReasonRollbackExceedsMithril,
 		event.ChainsyncResyncReasonPeerTipBehindMithril,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1777,6 +1777,11 @@ func TestChainsyncResyncMithrilReasonsDenyPeerAndRequireFreshConnection(
 			wantFresh:      true,
 			wantDeniesPeer: false,
 		},
+		{
+			reason:         event.ChainsyncResyncReasonLiveTxValidationRecovery,
+			wantFresh:      true,
+			wantDeniesPeer: false,
+		},
 	}
 	for _, tt := range tests {
 		if got := chainsyncResyncRequiresFreshConnection(tt.reason); got != tt.wantFresh {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep the ledger running when at-tip tx validation keeps failing by retrying at the deepest rewind and forcing `chainsync` to reconnect to a fresh peer. This avoids halting on a bad candidate chain and disconnects wedged peers.

- **Bug Fixes**
  - Recovery keeps retrying at the deepest rewind after the capped schedule instead of halting; logs downgraded to warn.
  - Centralized error handling so persistent validation failures restart the pipeline, not stop it (`handleLedgerProcessBlocksError`); no fatal reporting.
  - `chainsync` treats `LiveTxValidationRecovery` as a fresh-connection resync reason to rotate peers.
  - Updated tests for deepest-retry behavior, pipeline restarts without fatal errors, and fresh-connection requirement.

<sup>Written for commit 8509907d634afbc12e3bdd01377f9f48ea8deac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

