### PR TITLE
fix(database): chunk extra large leios batches

### DIFF
--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -80,6 +80,28 @@ func (d *MetadataStoreMysql) resolveReadDB(
 	return d.resolveDB(txn)
 }
 
+// ExistingTransactionHashes returns transaction hashes already recorded.
+func (d *MetadataStoreMysql) ExistingTransactionHashes(
+	hashes [][]byte,
+	txn types.Txn,
+) ([][]byte, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var existing [][]byte
+	result := db.Model(&models.Transaction{}).
+		Where("hash IN ?", hashes).
+		Pluck("hash", &existing)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return existing, nil
+}
+
 // GetTransactionByHash returns a transaction by its hash
 func (d *MetadataStoreMysql) GetTransactionByHash(
 	hash []byte,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -80,6 +80,28 @@ func (d *MetadataStorePostgres) resolveReadDB(
 	return d.resolveDB(txn)
 }
 
+// ExistingTransactionHashes returns transaction hashes already recorded.
+func (d *MetadataStorePostgres) ExistingTransactionHashes(
+	hashes [][]byte,
+	txn types.Txn,
+) ([][]byte, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var existing [][]byte
+	result := db.Model(&models.Transaction{}).
+		Where("hash IN ?", hashes).
+		Pluck("hash", &existing)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return existing, nil
+}
+
 // GetTransactionByHash returns a transaction by its hash
 func (d *MetadataStorePostgres) GetTransactionByHash(
 	hash []byte,

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -104,6 +104,28 @@ func (d *MetadataStoreSqlite) resolveReadDB(
 	return db, nil
 }
 
+// ExistingTransactionHashes returns transaction hashes already recorded.
+func (d *MetadataStoreSqlite) ExistingTransactionHashes(
+	hashes [][]byte,
+	txn types.Txn,
+) ([][]byte, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var existing [][]byte
+	result := db.Model(&models.Transaction{}).
+		Where("hash IN ?", hashes).
+		Pluck("hash", &existing)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return existing, nil
+}
+
 // GetTransactionByHash returns a transaction by its hash
 func (d *MetadataStoreSqlite) GetTransactionByHash(
 	hash []byte,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -501,6 +501,17 @@ type MetadataStore interface {
 		types.Txn,
 	) (uint, bool, error)
 
+	// ExistingTransactionHashes returns the subset of the given hashes that
+	// are already recorded. Lightweight (selects the hash column only, no
+	// associations); used to skip re-applying transactions that an earlier
+	// endorser block already applied, since the Leios prototype re-includes
+	// unconfirmed mempool transactions in successive endorser blocks
+	// (issue #2699).
+	ExistingTransactionHashes(
+		[][]byte, // hashes
+		types.Txn,
+	) ([][]byte, error)
+
 	// GetTransactionsByHashes retrieves transactions by their hashes.
 	GetTransactionsByHashes(
 		[][]byte, // hashes

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -825,6 +825,37 @@ func (d *Database) GetTransactionByHash(
 	return d.metadata.GetTransactionByHash(hash, txn.Metadata())
 }
 
+// GetExistingTransactionHashes returns the subset of the provided hashes that
+// are already recorded in the ledger. It is lightweight (hash column only) and
+// chunked to keep the IN clause within backend parameter limits. Used to skip
+// re-applying transactions an earlier endorser block already applied
+// (issue #2699).
+func (d *Database) GetExistingTransactionHashes(
+	hashes [][]byte,
+	txn *Txn,
+) ([][]byte, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	const chunk = 900
+	var existing [][]byte
+	for i := 0; i < len(hashes); i += chunk {
+		end := min(i+chunk, len(hashes))
+		part, err := d.metadata.ExistingTransactionHashes(
+			hashes[i:end], txn.Metadata(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("get existing tx hashes: %w", err)
+		}
+		existing = append(existing, part...)
+	}
+	return existing, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *Database) GetTransactionsByHashes(
 	hashes [][]byte,

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -122,14 +122,14 @@ func (ls *LedgerState) applyEndorserBlock(
 		bodyCbors = append(bodyCbors, []byte(elems[0]))
 	}
 
-	// Deduplicate against the ledger. The Leios prototype re-includes
-	// unconfirmed mempool transactions in successive endorser blocks, so a
-	// transaction here may already have been applied by an earlier endorser
-	// block in this batch (visible through the open txn's read-your-writes) or
-	// by a committed block. Re-applying it would double-spend its inputs and
+	// Deduplicate against the ledger and within this endorser block. The
+	// Leios prototype re-includes unconfirmed mempool transactions in
+	// successive endorser blocks, so a transaction here may already have been
+	// applied by an earlier endorser block in this batch (visible through the
+	// open txn's read-your-writes), by a committed block, or repeated in this
+	// raw transaction list. Re-applying it would double-spend its inputs and
 	// wedge the ledger in a permanent "UTxO already spent" retry loop
-	// (issue #2699), so drop any transaction already recorded before building
-	// the blob and delta.
+	// (issue #2699), so drop duplicates before building the blob and delta.
 	if len(txs) > 0 {
 		hashes := make([][]byte, len(txs))
 		for i, tx := range txs {
@@ -139,23 +139,27 @@ func (ls *LedgerState) applyEndorserBlock(
 		if err != nil {
 			return 0, fmt.Errorf("dedup endorser transactions: %w", err)
 		}
-		if len(existing) > 0 {
-			skip := make(map[string]struct{}, len(existing))
-			for _, h := range existing {
-				skip[string(h)] = struct{}{}
-			}
-			keptTxs := txs[:0]
-			keptBodies := bodyCbors[:0]
-			for i, tx := range txs {
-				if _, dup := skip[string(tx.Hash().Bytes())]; dup {
-					continue
-				}
-				keptTxs = append(keptTxs, tx)
-				keptBodies = append(keptBodies, bodyCbors[i])
-			}
-			txs = keptTxs
-			bodyCbors = keptBodies
+		skip := make(map[string]struct{}, len(existing))
+		for _, h := range existing {
+			skip[string(h)] = struct{}{}
 		}
+		seen := make(map[string]struct{}, len(txs))
+		keptTxs := txs[:0]
+		keptBodies := bodyCbors[:0]
+		for i, tx := range txs {
+			hashKey := string(tx.Hash().Bytes())
+			if _, dup := skip[hashKey]; dup {
+				continue
+			}
+			if _, dup := seen[hashKey]; dup {
+				continue
+			}
+			seen[hashKey] = struct{}{}
+			keptTxs = append(keptTxs, tx)
+			keptBodies = append(keptBodies, bodyCbors[i])
+		}
+		txs = keptTxs
+		bodyCbors = keptBodies
 	}
 	if len(txs) == 0 {
 		// Every transaction was already applied by an earlier endorser block

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -122,6 +122,47 @@ func (ls *LedgerState) applyEndorserBlock(
 		bodyCbors = append(bodyCbors, []byte(elems[0]))
 	}
 
+	// Deduplicate against the ledger. The Leios prototype re-includes
+	// unconfirmed mempool transactions in successive endorser blocks, so a
+	// transaction here may already have been applied by an earlier endorser
+	// block in this batch (visible through the open txn's read-your-writes) or
+	// by a committed block. Re-applying it would double-spend its inputs and
+	// wedge the ledger in a permanent "UTxO already spent" retry loop
+	// (issue #2699), so drop any transaction already recorded before building
+	// the blob and delta.
+	if len(txs) > 0 {
+		hashes := make([][]byte, len(txs))
+		for i, tx := range txs {
+			hashes[i] = tx.Hash().Bytes()
+		}
+		existing, err := ls.db.GetExistingTransactionHashes(hashes, txn)
+		if err != nil {
+			return 0, fmt.Errorf("dedup endorser transactions: %w", err)
+		}
+		if len(existing) > 0 {
+			skip := make(map[string]struct{}, len(existing))
+			for _, h := range existing {
+				skip[string(h)] = struct{}{}
+			}
+			keptTxs := txs[:0]
+			keptBodies := bodyCbors[:0]
+			for i, tx := range txs {
+				if _, dup := skip[string(tx.Hash().Bytes())]; dup {
+					continue
+				}
+				keptTxs = append(keptTxs, tx)
+				keptBodies = append(keptBodies, bodyCbors[i])
+			}
+			txs = keptTxs
+			bodyCbors = keptBodies
+		}
+	}
+	if len(txs) == 0 {
+		// Every transaction was already applied by an earlier endorser block
+		// (or a committed block); nothing new to store or apply.
+		return 0, nil
+	}
+
 	// Build the endorser-block blob and its offsets, then persist the blob
 	// under (ebSlot, ebHash) so cold-extract can resolve the DOFF refs.
 	blob, offsets, err := buildEndorserBlockBlob(txs, bodyCbors, ebSlot, ebHash)

--- a/ledger/leios_apply_test.go
+++ b/ledger/leios_apply_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newLeiosApplyTestLedger(
+	t *testing.T,
+) (*LedgerState, *database.Database, *gorm.DB) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	store, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok, "expected sqlite metadata store")
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	return ls, db, store.DB()
+}
+
+func leiosApplyTestTx(
+	t *testing.T,
+	seed byte,
+) (cbor.RawMessage, []byte, lcommon.Transaction) {
+	t.Helper()
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		2: 200_000 + uint64(seed),
+	})
+	require.NoError(t, err)
+	txCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(bodyCbor),
+		map[uint]any{},
+		true,
+		nil,
+	})
+	require.NoError(t, err)
+	tx, err := gledger.NewTransactionFromCbor(
+		gledger.TxTypeDijkstra,
+		txCbor,
+	)
+	require.NoError(t, err)
+	return cbor.RawMessage(txCbor), bodyCbor, tx
+}
+
+func leiosApplyTestEbHash(seed byte) []byte {
+	return bytes.Repeat([]byte{seed}, lcommon.Blake2b256Size)
+}
+
+func leiosApplyTestRankingPoint(seed byte) ocommon.Point {
+	return ocommon.Point{
+		Slot: 10_000 + uint64(seed),
+		Hash: bytes.Repeat([]byte{seed}, lcommon.Blake2b256Size),
+	}
+}
+
+func requireLeiosApplyTestTxCount(
+	t *testing.T,
+	gdb *gorm.DB,
+	want int64,
+) {
+	t.Helper()
+	var got int64
+	require.NoError(t, gdb.Model(&models.Transaction{}).Count(&got).Error)
+	require.Equal(t, want, got)
+}
+
+func requireLeiosApplyTestNoEndorserBlob(
+	t *testing.T,
+	db *database.Database,
+	slot uint64,
+	hash []byte,
+) {
+	t.Helper()
+	require.False(t, db.HasGenesisCbor(slot, hash))
+}
+
+func requireLeiosApplyTestEndorserBlob(
+	t *testing.T,
+	db *database.Database,
+	slot uint64,
+	hash []byte,
+	want []byte,
+) {
+	t.Helper()
+	txn := db.BlobTxn(false)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		got, _, err := db.Blob().GetBlock(txn.Blob(), slot, hash)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, want, got)
+		return nil
+	}))
+}
+
+func TestApplyEndorserBlockDedupSkipsCommittedTransaction(t *testing.T) {
+	ls, db, gdb := newLeiosApplyTestLedger(t)
+	rawTx, _, tx := leiosApplyTestTx(t, 0x01)
+	require.NoError(t, gdb.Create(&models.Transaction{
+		Hash:  tx.Hash().Bytes(),
+		Type:  tx.Type(),
+		Slot:  99,
+		Valid: true,
+	}).Error)
+
+	const ebSlot = uint64(200)
+	ebHash := leiosApplyTestEbHash(0x22)
+	applied := -1
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		var err error
+		applied, err = ls.applyEndorserBlock(
+			txn,
+			leiosApplyTestRankingPoint(0x33),
+			1,
+			ebSlot,
+			ebHash,
+			[]cbor.RawMessage{rawTx},
+		)
+		return err
+	}))
+
+	require.Equal(t, 0, applied)
+	requireLeiosApplyTestTxCount(t, gdb, 1)
+	requireLeiosApplyTestNoEndorserBlob(t, db, ebSlot, ebHash)
+}
+
+func TestApplyEndorserBlockDedupSeesEarlierEndorserBlockInBatch(t *testing.T) {
+	ls, db, gdb := newLeiosApplyTestLedger(t)
+	rawTx, bodyCbor, _ := leiosApplyTestTx(t, 0x02)
+	firstEbHash := leiosApplyTestEbHash(0x44)
+	secondEbHash := leiosApplyTestEbHash(0x55)
+	firstApplied := -1
+	secondApplied := -1
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		var err error
+		firstApplied, err = ls.applyEndorserBlock(
+			txn,
+			leiosApplyTestRankingPoint(0x66),
+			1,
+			300,
+			firstEbHash,
+			[]cbor.RawMessage{rawTx},
+		)
+		if err != nil {
+			return err
+		}
+		secondApplied, err = ls.applyEndorserBlock(
+			txn,
+			leiosApplyTestRankingPoint(0x77),
+			2,
+			301,
+			secondEbHash,
+			[]cbor.RawMessage{rawTx},
+		)
+		return err
+	}))
+
+	require.Equal(t, 1, firstApplied)
+	require.Equal(t, 0, secondApplied)
+	requireLeiosApplyTestTxCount(t, gdb, 1)
+	requireLeiosApplyTestEndorserBlob(t, db, 300, firstEbHash, bodyCbor)
+	requireLeiosApplyTestNoEndorserBlob(t, db, 301, secondEbHash)
+}
+
+func TestApplyEndorserBlockDedupSkipsRepeatedTransactionInSameEndorserBlock(
+	t *testing.T,
+) {
+	ls, db, gdb := newLeiosApplyTestLedger(t)
+	rawTx, bodyCbor, _ := leiosApplyTestTx(t, 0x03)
+	ebHash := leiosApplyTestEbHash(0x88)
+	applied := -1
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		var err error
+		applied, err = ls.applyEndorserBlock(
+			txn,
+			leiosApplyTestRankingPoint(0x99),
+			1,
+			400,
+			ebHash,
+			[]cbor.RawMessage{rawTx, rawTx},
+		)
+		return err
+	}))
+
+	require.Equal(t, 1, applied)
+	requireLeiosApplyTestTxCount(t, gdb, 1)
+	requireLeiosApplyTestEndorserBlob(t, db, 400, ebHash, bodyCbor)
+}


### PR DESCRIPTION
Closes #2699 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates transactions in Leios endorser blocks (against the ledger and within the same block) and chunks large hash lookups to avoid DB parameter limits. Fixes the wedge/loop in issue #2699.

- **Bug Fixes**
  - Added `ExistingTransactionHashes` to `mysql`, `postgres`, and `sqlite` to return only already-recorded hashes.
  - Added `GetExistingTransactionHashes` in `database` with 900-size chunked `IN` queries for very large batches.
  - Updated `ledger/leios_apply` to skip transactions already in the ledger and to ignore repeats within the same block via an in-memory seen filter; if all are duplicates, exit without persisting a blob or changing state.

<sup>Written for commit 75a792df71c9864b59e4608d0be03ff9255f15c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endorser transactions are now deduplicated before being applied, helping prevent duplicate entries from being processed again.
  * Added transaction-hash lookup support across supported databases to identify records that already exist.

* **Bug Fixes**
  * Improved handling for duplicate endorser blocks by skipping transactions that are already stored.
  * If all transactions in a block are duplicates, the system now exits cleanly without changing ledger state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->