### PR TITLE
fix: improved mithril intersect offers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1378,13 +1378,18 @@ The Mithril snapshot also acts as the local trust anchor during live
 chainsync. The ledger refuses any rollback below the imported ledger slot
 (`mithrilLedgerSlot`), since blocks at or below that boundary were certified
 as a single ledger state and intermediate UTxO states for a replacement fork
-cannot be reconstructed. The boundary block is always offered as an intersect
-point, so the peer's reported tip classifies the refusal: a peer whose own
-tip is below the boundary is treated as stale (it is simply behind and
-matched an old rung of the intersect ladder), while a peer claiming a tip at
-or above the boundary that still demands a rollback below it is rejected as
-genuinely divergent. Both classifications close the connection for a fresh
-intersect and deny the peer for a cooldown via peer governance.
+cannot be reconstructed. Mithril sync persists the full boundary point in
+`sync_state` (`mithril_ledger_slot` and `mithril_ledger_hash`) so outbound
+chainsync can always offer that point during `FindIntersect`, even if recent
+ledger-tip point generation is temporarily empty or stale. Slot-only older
+databases fall back to reconstructing the boundary point from canonical local
+chain data. The boundary block is always offered as an intersect point, so the
+peer's reported tip classifies the refusal: a peer whose own tip is below the
+boundary is treated as stale (it is simply behind and matched an old rung of the
+intersect ladder), while a peer claiming a tip at or above the boundary that
+still demands a rollback below it is rejected as genuinely divergent. Both
+classifications close the connection for a fresh intersect and deny the peer for
+a cooldown via peer governance.
 
 In API storage mode, the SQLite metadata plugin can defer selected query indexes
 during bulk load. Deferred indexes are classified as critical or lazy in

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -166,7 +166,7 @@ erDiagram
 | `network_donation` | `id`, `slot`, `epoch`, `amount` | PK `id`; unique `slot`; index `epoch` | Per-block Conway treasury donation, tagged with its epoch. `amount` is a plain integer column (not `types.Uint64`) so `SUM` aggregates directly across backends. Donations accumulate during an epoch and are moved into `network_state.treasury` at the next epoch boundary; rows are kept (not deleted on apply) so a rollback drops them by slot and re-application re-derives the same total. |
 | `pparams` | `id`, `cbor`, `added_slot`, `epoch`, `era_id` | PK `id`; index `added_slot` | CBOR protocol parameters. Query by `epoch <= ?` and matching `era_id`. |
 | `pparam_update` | `id`, `genesis_hash`, `cbor`, `added_slot`, `epoch` | PK `id`; index `added_slot` | Proposed protocol-parameter updates by epoch. |
-| `sync_state` | `sync_key`, `value` | PK `sync_key` | Ephemeral key/value state for one-time sync/load work. |
+| `sync_state` | `sync_key`, `value` | PK `sync_key` | Ephemeral key/value state for one-time sync/load work. Mithril stores `mithril_ledger_slot` plus `mithril_ledger_hash` as the trusted replay/intersect boundary point. |
 | `backfill_checkpoint` | `id`, `phase`, `last_slot`, `total_slots`, `started_at`, `updated_at`, `completed` | PK `id`; unique `phase` | API-mode historical metadata backfill progress. |
 | `import_checkpoint` | `id`, `import_key`, `phase` | PK `id`; unique `import_key` | Mithril snapshot import resume state. `import_key` is usually `{digest}:{slot}`. |
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -67,6 +67,8 @@ const (
 	ledgerIntersectDenseCount    = 32
 	ledgerAncestorSearchWindow   = 10_000
 	firstBlockIndex              = 1
+	mithrilLedgerSlotSyncKey     = "mithril_ledger_slot"
+	mithrilLedgerHashSyncKey     = "mithril_ledger_hash"
 )
 
 type metadataDbReader interface {
@@ -542,6 +544,7 @@ type LedgerState struct {
 	inRecovery                    bool // guards against recursive recovery in SubmitAsyncDBTxn
 	lastAtTipRecovery             *atTipRecoveryAttempt
 	mithrilLedgerSlot             uint64 // blocks at or below this slot are Mithril-verified; skip validation
+	mithrilLedgerHash             []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
 	lastLocalRollbackSeq          uint64
 	lastLocalRollbackPoint        ocommon.Point
 
@@ -713,37 +716,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		ls.metrics.epochLengthSlots.Set(float64(ls.currentEpoch.LengthInSlots))
 	}
 
-	// Read Mithril ledger state slot if present. Blocks at or below
-	// this slot were verified by the Mithril certificate chain during
-	// import and must not be re-validated during chainsync replay.
-	if mithrilSlotStr, err := ls.db.GetSyncState(
-		"mithril_ledger_slot", nil,
-	); err != nil {
-		ls.config.Logger.Warn(
-			"failed to read Mithril trust boundary from database",
-			"component", "ledger",
-			"error", err,
-		)
-	} else if mithrilSlotStr != "" {
-		mls, parseErr := strconv.ParseUint(
-			mithrilSlotStr, 10, 64,
-		)
-		if parseErr != nil {
-			ls.config.Logger.Warn(
-				"malformed mithril_ledger_slot value, ignoring",
-				"component", "ledger",
-				"value", mithrilSlotStr,
-				"error", parseErr,
-			)
-		} else {
-			ls.mithrilLedgerSlot = mls
-			ls.config.Logger.Info(
-				"loaded Mithril trust boundary",
-				"component", "ledger",
-				"mithril_ledger_slot", mls,
-			)
-		}
-	}
+	ls.loadMithrilTrustBoundary()
 
 	// Initialize database worker pool for async operations
 	if !ls.config.DatabaseWorkerPoolConfig.Disabled {
@@ -851,6 +824,76 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		go ls.ledgerProcessBlocks(ctx)
 	}
 	return nil
+}
+
+func (ls *LedgerState) loadMithrilTrustBoundary() {
+	// Read Mithril ledger state point if present. Blocks at or below
+	// this point were verified by the Mithril certificate chain during
+	// import and must not be re-validated during chainsync replay.
+	mithrilSlotStr, err := ls.db.GetSyncState(
+		mithrilLedgerSlotSyncKey,
+		nil,
+	)
+	if err != nil {
+		ls.config.Logger.Warn(
+			"failed to read Mithril trust boundary from database",
+			"component", "ledger",
+			"error", err,
+		)
+		return
+	}
+	if mithrilSlotStr == "" {
+		return
+	}
+	mls, parseErr := strconv.ParseUint(mithrilSlotStr, 10, 64)
+	if parseErr != nil {
+		ls.config.Logger.Warn(
+			"malformed mithril_ledger_slot value, ignoring",
+			"component", "ledger",
+			"value", mithrilSlotStr,
+			"error", parseErr,
+		)
+		return
+	}
+
+	ls.mithrilLedgerSlot = mls
+	hashStr, err := ls.db.GetSyncState(mithrilLedgerHashSyncKey, nil)
+	if err != nil {
+		ls.config.Logger.Warn(
+			"failed to read Mithril trust boundary hash from database",
+			"component", "ledger",
+			"mithril_ledger_slot", mls,
+			"error", err,
+		)
+		return
+	}
+	if hashStr != "" {
+		hash, decodeErr := hex.DecodeString(hashStr)
+		if decodeErr != nil || len(hash) != lcommon.Blake2b256Size {
+			ls.config.Logger.Warn(
+				"malformed mithril_ledger_hash value, ignoring hash",
+				"component", "ledger",
+				"mithril_ledger_slot", mls,
+				"value", hashStr,
+				"error", decodeErr,
+			)
+		} else {
+			ls.mithrilLedgerHash = hash
+		}
+	}
+
+	attrs := []any{
+		"component", "ledger",
+		"mithril_ledger_slot", mls,
+	}
+	if len(ls.mithrilLedgerHash) > 0 {
+		attrs = append(
+			attrs,
+			"mithril_ledger_hash",
+			hex.EncodeToString(ls.mithrilLedgerHash),
+		)
+	}
+	ls.config.Logger.Info("loaded Mithril trust boundary", attrs...)
 }
 
 func (ls *LedgerState) RecoverCommitTimestampConflict() error {
@@ -5076,7 +5119,7 @@ func (ls *LedgerState) withMithrilTrustBoundaryIntersectPoint(
 	points []ocommon.Point,
 	count int,
 ) []ocommon.Point {
-	if count <= 0 || len(points) == 0 {
+	if count <= 0 {
 		return points
 	}
 	point, ok := ls.mithrilTrustBoundaryPoint()
@@ -5116,10 +5159,17 @@ func (ls *LedgerState) mithrilTrustBoundaryPoint() (ocommon.Point, bool) {
 	}
 	ls.RLock()
 	boundarySlot := ls.mithrilLedgerSlot
+	boundaryHash := append([]byte(nil), ls.mithrilLedgerHash...)
 	currentTip := ls.currentTip
 	ls.RUnlock()
 	if boundarySlot == 0 || boundarySlot == ^uint64(0) {
 		return ocommon.Point{}, false
+	}
+	if len(boundaryHash) > 0 {
+		if len(boundaryHash) != lcommon.Blake2b256Size {
+			return ocommon.Point{}, false
+		}
+		return ocommon.NewPoint(boundarySlot, boundaryHash), true
 	}
 	if currentTip.Point.Slot == 0 && len(currentTip.Point.Hash) == 0 {
 		return ocommon.Point{}, false

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2605,6 +2605,50 @@ func TestIntersectPointsReturnsNoPointsWhenLedgerTipIsEmpty(
 	assert.Nil(t, points)
 }
 
+func TestLoadMithrilTrustBoundaryLoadsPersistedHash(t *testing.T) {
+	db := newTestDB(t)
+	boundaryHash := bytes.Repeat([]byte{0x42}, 32)
+	require.NoError(t, db.SetSyncState(
+		mithrilLedgerSlotSyncKey,
+		"42",
+		nil,
+	))
+	require.NoError(t, db.SetSyncState(
+		mithrilLedgerHashSyncKey,
+		fmt.Sprintf("%x", boundaryHash),
+		nil,
+	))
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.loadMithrilTrustBoundary()
+
+	require.Equal(t, uint64(42), ls.mithrilLedgerSlot)
+	require.Equal(t, boundaryHash, ls.mithrilLedgerHash)
+}
+
+func TestIntersectPointsIncludesPersistedMithrilBoundaryWhenRecentPointsEmpty(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+	boundaryHash := bytes.Repeat([]byte{0x24}, 32)
+	ls := &LedgerState{
+		db:                db,
+		mithrilLedgerSlot: 42,
+		mithrilLedgerHash: boundaryHash,
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.Equal(t, uint64(42), points[0].Slot)
+	assert.Equal(t, boundaryHash, points[0].Hash)
+}
+
 func TestIntersectPointsUsesPrimaryChainWhenPrimaryChainIsAhead(t *testing.T) {
 	db, err := database.New(&database.Config{
 		BlobPlugin:     "badger",

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -734,7 +734,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 
 	if isAPIMode(cfg.StorageMode) {
 		if err := updateMithrilReadyState(
-			db, logger, loadResult, ledgerStateSlot,
+			db, logger, loadResult, ledgerStateSlot, ledgerStateHash,
 			syncStatusBackfill, false,
 		); err != nil {
 			return SyncResult{}, err
@@ -799,7 +799,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 	)
 
 	if err := updateMithrilReadyState(
-		db, logger, loadResult, ledgerStateSlot,
+		db, logger, loadResult, ledgerStateSlot, ledgerStateHash,
 		"", true,
 	); err != nil {
 		return SyncResult{}, err

--- a/mithril/sync_import.go
+++ b/mithril/sync_import.go
@@ -33,6 +33,11 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
+const (
+	mithrilLedgerSlotSyncKey = "mithril_ledger_slot"
+	mithrilLedgerHashSyncKey = "mithril_ledger_hash"
+)
+
 // epochLengthFromConfig returns an EpochLengthFunc that resolves
 // era parameters from the Cardano node config.
 func epochLengthFromConfig(
@@ -89,6 +94,7 @@ func updateMithrilReadyState(
 	logger *slog.Logger,
 	loadResult *node.LoadBlobsResult,
 	ledgerStateSlot uint64,
+	ledgerStateHash []byte,
 	syncStatus string,
 	clearSyncState bool,
 ) error {
@@ -128,8 +134,10 @@ func updateMithrilReadyState(
 	// (no UTxO tracking), so chainsync replay must skip them too.
 	// Fall back to the snapshot slot when no gap blocks were fetched.
 	trustBoundarySlot := ledgerStateSlot
+	trustBoundaryHash := ledgerStateHash
 	if len(recentBlocks) > 0 {
 		trustBoundarySlot = recentBlocks[0].Slot
+		trustBoundaryHash = recentBlocks[0].Hash
 	}
 
 	txn := db.MetadataTxn(true)
@@ -148,12 +156,32 @@ func updateMithrilReadyState(
 			}
 		}
 		if err := db.SetSyncState(
-			"mithril_ledger_slot",
+			mithrilLedgerSlotSyncKey,
 			strconv.FormatUint(trustBoundarySlot, 10),
 			txn,
 		); err != nil {
 			return fmt.Errorf(
 				"recording mithril ledger slot: %w", err,
+			)
+		}
+		if len(trustBoundaryHash) > 0 {
+			if err := db.SetSyncState(
+				mithrilLedgerHashSyncKey,
+				hex.EncodeToString(trustBoundaryHash),
+				txn,
+			); err != nil {
+				return fmt.Errorf(
+					"recording mithril ledger hash: %w",
+					err,
+				)
+			}
+		} else if err := db.DeleteSyncState(
+			mithrilLedgerHashSyncKey,
+			txn,
+		); err != nil {
+			return fmt.Errorf(
+				"clearing mithril ledger hash: %w",
+				err,
 			)
 		}
 		return nil

--- a/mithril/sync_import_test.go
+++ b/mithril/sync_import_test.go
@@ -15,6 +15,8 @@
 package mithril
 
 import (
+	"bytes"
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"testing"
@@ -111,4 +113,89 @@ func TestEnsureMithrilBackfillCheckpointReopensCompleted(t *testing.T) {
 	require.False(t, cp.Completed)
 	require.Equal(t, startedAt.UnixNano(), cp.StartedAt.UnixNano())
 	require.True(t, cp.UpdatedAt.After(startedAt))
+}
+
+func TestUpdateMithrilReadyStateStoresTrustBoundaryFromRecentTip(
+	t *testing.T,
+) {
+	db := newMithrilTestDB(t)
+	tipHash := bytes.Repeat([]byte{0x11}, 32)
+	ledgerStateHash := bytes.Repeat([]byte{0x22}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:     1,
+		Slot:   42,
+		Hash:   tipHash,
+		Number: 1,
+		Type:   1,
+		Cbor:   []byte{0x80},
+	}, nil))
+
+	require.NoError(t, updateMithrilReadyState(
+		db,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+		30,
+		ledgerStateHash,
+		"",
+		true,
+	))
+
+	slot, err := db.GetSyncState(mithrilLedgerSlotSyncKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, "42", slot)
+	hash, err := db.GetSyncState(mithrilLedgerHashSyncKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(tipHash), hash)
+}
+
+func TestUpdateMithrilReadyStateStoresTrustBoundaryFromLedgerState(
+	t *testing.T,
+) {
+	db := newMithrilTestDB(t)
+	ledgerStateHash := bytes.Repeat([]byte{0x33}, 32)
+
+	require.NoError(t, updateMithrilReadyState(
+		db,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+		30,
+		ledgerStateHash,
+		"",
+		true,
+	))
+
+	slot, err := db.GetSyncState(mithrilLedgerSlotSyncKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, "30", slot)
+	hash, err := db.GetSyncState(mithrilLedgerHashSyncKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(ledgerStateHash), hash)
+}
+
+func TestUpdateMithrilReadyStateClearsStaleTrustBoundaryHash(
+	t *testing.T,
+) {
+	db := newMithrilTestDB(t)
+	require.NoError(t, db.SetSyncState(
+		mithrilLedgerHashSyncKey,
+		hex.EncodeToString(bytes.Repeat([]byte{0x44}, 32)),
+		nil,
+	))
+
+	require.NoError(t, updateMithrilReadyState(
+		db,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+		30,
+		nil,
+		"",
+		true,
+	))
+
+	slot, err := db.GetSyncState(mithrilLedgerSlotSyncKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, "30", slot)
+	hash, err := db.GetSyncState(mithrilLedgerHashSyncKey, nil)
+	require.NoError(t, err)
+	require.Empty(t, hash)
 }


### PR DESCRIPTION
Closes #2703 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always offer the Mithril trust boundary (slot + hash) during chainsync intersect. This fixes empty or stale intersect offers and prevents rollbacks below the certified boundary.

- **Bug Fixes**
  - Persist `mithril_ledger_slot` and `mithril_ledger_hash` in `sync_state`; docs updated.
  - Load the boundary at startup and include it in `FindIntersect`, even when recent points are empty; fall back for slot-only DBs using local canonical data.
  - During import, store the boundary hash from recent blocks or the ledger state; clear stale hashes when absent.
  - Added tests covering boundary storage, loading, and intersect behavior.

<sup>Written for commit fec5917f57ec6bc8ebc04b4d8315bf1907202325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Mithril sync handling so the trusted boundary is remembered more completely, including both slot and hash when available.
  * Better peer classification during chain sync helps distinguish stale peers from genuinely divergent ones.

* **Bug Fixes**
  * Fixed edge cases where the trusted boundary could be missed during intersection checks, especially when no recent points are available.
  * Ensures outdated boundary data is cleared or refreshed correctly during sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->