### PR TITLE
build(database): gate optional metadata plugins behind dingo_extra_pl…

### DIFF
--- a/database/plugin/metadata/metadata_extra.go
+++ b/database/plugin/metadata/metadata_extra.go
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package metadata
 
 import (
-	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/mysql"
+	_ "github.com/blinklabs-io/dingo/database/plugin/metadata/postgres"
 )

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/asset.go
+++ b/database/plugin/metadata/mysql/asset.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/backfill.go
+++ b/database/plugin/metadata/mysql/backfill.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/batch_accumulator.go
+++ b/database/plugin/metadata/mysql/batch_accumulator.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/block_nonce.go
+++ b/database/plugin/metadata/mysql/block_nonce.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/certs.go
+++ b/database/plugin/metadata/mysql/certs.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/commit_timestamp.go
+++ b/database/plugin/metadata/mysql/commit_timestamp.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/committee_member.go
+++ b/database/plugin/metadata/mysql/committee_member.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/create.go
+++ b/database/plugin/metadata/mysql/create.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/datum.go
+++ b/database/plugin/metadata/mysql/datum.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/drep_test.go
+++ b/database/plugin/metadata/mysql/drep_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/epoch.go
+++ b/database/plugin/metadata/mysql/epoch.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/governance.go
+++ b/database/plugin/metadata/mysql/governance.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/import.go
+++ b/database/plugin/metadata/mysql/import.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/mir.go
+++ b/database/plugin/metadata/mysql/mir.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/network_donation.go
+++ b/database/plugin/metadata/mysql/network_donation.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/network_state.go
+++ b/database/plugin/metadata/mysql/network_state.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/offchain_metadata.go
+++ b/database/plugin/metadata/mysql/offchain_metadata.go
@@ -12,6 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/options.go
+++ b/database/plugin/metadata/mysql/options.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/options_test.go
+++ b/database/plugin/metadata/mysql/options_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/plugin.go
+++ b/database/plugin/metadata/mysql/plugin.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/poolreap.go
+++ b/database/plugin/metadata/mysql/poolreap.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/pparams.go
+++ b/database/plugin/metadata/mysql/pparams.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/reward_state.go
+++ b/database/plugin/metadata/mysql/reward_state.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/script.go
+++ b/database/plugin/metadata/mysql/script.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/stake_snapshot.go
+++ b/database/plugin/metadata/mysql/stake_snapshot.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/tip.go
+++ b/database/plugin/metadata/mysql/tip.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -12,6 +12,8 @@
 // either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package mysql
 
 import (

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/asset.go
+++ b/database/plugin/metadata/postgres/asset.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/backfill.go
+++ b/database/plugin/metadata/postgres/backfill.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/batch_accumulator.go
+++ b/database/plugin/metadata/postgres/batch_accumulator.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/block_nonce.go
+++ b/database/plugin/metadata/postgres/block_nonce.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/certs.go
+++ b/database/plugin/metadata/postgres/certs.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/commit_timestamp.go
+++ b/database/plugin/metadata/postgres/commit_timestamp.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/committee_member.go
+++ b/database/plugin/metadata/postgres/committee_member.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/create.go
+++ b/database/plugin/metadata/postgres/create.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/datum.go
+++ b/database/plugin/metadata/postgres/datum.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/drep_test.go
+++ b/database/plugin/metadata/postgres/drep_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/epoch.go
+++ b/database/plugin/metadata/postgres/epoch.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/governance.go
+++ b/database/plugin/metadata/postgres/governance.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/import.go
+++ b/database/plugin/metadata/postgres/import.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/midnight.go
+++ b/database/plugin/metadata/postgres/midnight.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/mir.go
+++ b/database/plugin/metadata/postgres/mir.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/network_donation.go
+++ b/database/plugin/metadata/postgres/network_donation.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/network_state.go
+++ b/database/plugin/metadata/postgres/network_state.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/offchain_metadata.go
+++ b/database/plugin/metadata/postgres/offchain_metadata.go
@@ -12,6 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/options.go
+++ b/database/plugin/metadata/postgres/options.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/options_test.go
+++ b/database/plugin/metadata/postgres/options_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/plugin.go
+++ b/database/plugin/metadata/postgres/plugin.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/poolreap.go
+++ b/database/plugin/metadata/postgres/poolreap.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/pparams.go
+++ b/database/plugin/metadata/postgres/pparams.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/reward_state.go
+++ b/database/plugin/metadata/postgres/reward_state.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/script.go
+++ b/database/plugin/metadata/postgres/script.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/stake_snapshot.go
+++ b/database/plugin/metadata/postgres/stake_snapshot.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/stake_snapshot_test.go
+++ b/database/plugin/metadata/postgres/stake_snapshot_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/tip.go
+++ b/database/plugin/metadata/postgres/tip.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -12,6 +12,8 @@
 // either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/transaction_gap_test.go
+++ b/database/plugin/metadata/postgres/transaction_gap_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build dingo_extra_plugins
+
 package postgres
 
 import (


### PR DESCRIPTION
Closes #2586 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates MySQL and Postgres metadata plugins behind the `dingo_extra_plugins` build tag, keeping `sqlite` enabled by default. This makes optional DB backends opt-in and reduces the default build surface.

- **Migration**
  - Build or test with the extra plugins using: `go build -tags dingo_extra_plugins ./...` and `go test -tags dingo_extra_plugins ./...`
  - Without the tag, only the `sqlite` metadata plugin is included.

<sup>Written for commit 5f342b7c10a3556e79e6f7e7241e7334f3763f45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for extra database metadata plugins when a build tag is enabled.
  * Default builds now include only the SQLite metadata plugin, while MySQL and PostgreSQL plugins can be turned on separately.

* **Refactor**
  * Reorganized how database metadata plugins are included at build time, making plugin availability more explicit and configurable.

* **Tests**
  * Updated related test coverage to match the new optional plugin build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->