### PR TITLE
fix(internal): Make tracing configurable

### DIFF
--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -161,6 +161,19 @@ metricsPort: 12798
 # CLI: --debug-port  Env: DINGO_DEBUG_PORT
 debugPort: 0
 
+# Enable OpenTelemetry tracing. Disabled by default: with no collector
+# listening, the OTLP exporter logs noisy connection errors. When enabled,
+# spans are sent via OTLP HTTP; configure the destination with the standard
+# OTEL_EXPORTER_OTLP_* env vars documented for
+# go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp.
+# CLI: --tracing  Env: DINGO_TRACING_ENABLED
+tracing: false
+
+# Export traces to stdout instead of OTLP. Requires tracing to also be
+# enabled. Mostly useful for local debugging.
+# CLI: --tracing-stdout  Env: DINGO_TRACING_STDOUT
+tracingStdout: false
+
 # Internal/private address to bind for listening for Ouroboros NtC
 privateBindAddr: "127.0.0.1"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,9 +382,17 @@ type Config struct {
 	DebugPort            uint     `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
 	IntersectTip         bool     `yaml:"intersectTip"                                                     split_words:"true"`
 	ValidateHistorical   bool     `yaml:"validateHistorical"                                               split_words:"true"`
-	RunMode              RunMode  `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
-	StartEra             StartEra `yaml:"startEra"           envconfig:"DINGO_START_ERA"`
-	ImmutableDbPath      string   `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
+	// Tracing enables OpenTelemetry tracing. Disabled by default: with no
+	// collector listening, the OTLP exporter logs noisy connection errors.
+	// Spans are sent via OTLP HTTP; configure the destination with the
+	// standard OTEL_EXPORTER_OTLP_* env vars.
+	Tracing bool `yaml:"tracing" envconfig:"DINGO_TRACING_ENABLED"`
+	// TracingStdout redirects spans to stdout instead of OTLP. Requires
+	// Tracing to also be enabled. Mostly useful for local debugging.
+	TracingStdout   bool     `yaml:"tracingStdout" envconfig:"DINGO_TRACING_STDOUT"`
+	RunMode         RunMode  `yaml:"runMode"            envconfig:"DINGO_RUN_MODE"`
+	StartEra        StartEra `yaml:"startEra"           envconfig:"DINGO_START_ERA"`
+	ImmutableDbPath string   `yaml:"immutableDbPath"    envconfig:"DINGO_IMMUTABLE_DB_PATH"`
 	// Database worker pool tuning (worker count and task queue size)
 	DatabaseWorkers   int `yaml:"databaseWorkers"    envconfig:"DINGO_DATABASE_WORKERS"`
 	DatabaseQueueSize int `yaml:"databaseQueueSize"  envconfig:"DINGO_DATABASE_QUEUE_SIZE"`
@@ -704,6 +712,8 @@ var globalConfig = &Config{
 	SocketPath:           "dingo.socket",
 	IntersectTip:         false,
 	ValidateHistorical:   false,
+	Tracing:              false,
+	TracingStdout:        false,
 	Network:              "preview",
 	NetworkMagic:         0,
 	MetricsPort:          12798,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -61,6 +61,8 @@ var flagSpecs = []flagSpec{
 	stringFlag("ImmutableDbPath", "immutable-db-path", "", "path to ImmutableDB for load mode"),
 	boolFlag("IntersectTip", "intersect-tip", "start from current tip"),
 	boolFlag("ValidateHistorical", "validate-historical", "validate historical blocks"),
+	boolFlag("Tracing", "tracing", "enable OpenTelemetry tracing (configure destination with OTEL_EXPORTER_OTLP_* env vars)"),
+	boolFlag("TracingStdout", "tracing-stdout", "export traces to stdout instead of OTLP (requires --tracing; for debugging)"),
 
 	// Networking
 	validatedStringFlag("Network", "network", "n", "Cardano network name (e.g. preview, preprod, mainnet)", ValidateNetworkName),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -370,8 +370,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithShutdownTimeout(shutdownTimeout),
 			// Enable metrics with default prometheus registry
 			dingo.WithPrometheusRegistry(prometheus.DefaultRegisterer),
-			// TODO: make this configurable (#387)
-			// dingo.WithTracing(true),
+			dingo.WithTracing(cfg.Tracing),
+			dingo.WithTracingStdout(cfg.TracingStdout),
 			dingo.WithTopologyConfig(config.GetTopologyConfig()),
 			dingo.WithDatabaseWorkerPoolConfig(ledger.DatabaseWorkerPoolConfig{
 				WorkerPoolSize: cfg.DatabaseWorkers,


### PR DESCRIPTION
Closes #387 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OpenTelemetry tracing configurable via config, flags, and env vars. Disabled by default to avoid noisy OTLP connection errors; supports OTLP HTTP or stdout for local debugging.

- **New Features**
  - Added `tracing` and `tracingStdout` to `dingo.yaml` with env vars `DINGO_TRACING_ENABLED` and `DINGO_TRACING_STDOUT`, plus CLI flags `--tracing` and `--tracing-stdout`.
  - Node now respects these via `dingo.WithTracing(cfg.Tracing)` and `dingo.WithTracingStdout(cfg.TracingStdout)`.
  - OTLP destination is configured with standard OTEL_EXPORTER_OTLP_* env vars.

<sup>Written for commit 4009207a00ba4935281c1f3ccdff968f4aea2fb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenTelemetry tracing options to the app’s settings and command-line flags.
  * Traces can now be exported over OTLP, with an optional mode to also send traces to stdout.
  * Updated the sample configuration to include clear documentation for the new tracing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->