### PR TITLE
fix(config): Fix silent plugin config type assertion failures

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,6 +154,58 @@ type databaseConfig struct {
 
 var midnightYAMLFields map[string]struct{}
 
+func databasePluginConfig(
+	pluginType string,
+	data map[string]any,
+) (string, map[string]map[string]any, error) {
+	pluginConfig := make(map[string]map[string]any)
+	var pluginName string
+	if pluginVal, exists := data["plugin"]; exists {
+		var ok bool
+		pluginName, ok = pluginVal.(string)
+		if !ok {
+			return "", nil, fmt.Errorf(
+				"%s plugin name must be a string, got %T",
+				pluginType,
+				pluginVal,
+			)
+		}
+	}
+	for k, v := range data {
+		if k == "plugin" {
+			continue
+		}
+		if val, ok := v.(map[string]any); ok {
+			pluginConfig[k] = val
+			continue
+		}
+		if val, ok := v.(map[any]any); ok {
+			stringAnyMap := make(map[string]any)
+			for vk, vv := range val {
+				keyStr, ok := vk.(string)
+				if !ok {
+					return "", nil, fmt.Errorf(
+						"%s plugin config %q key must be a string, got %T",
+						pluginType,
+						k,
+						vk,
+					)
+				}
+				stringAnyMap[keyStr] = vv
+			}
+			pluginConfig[k] = stringAnyMap
+			continue
+		}
+		return "", nil, fmt.Errorf(
+			"%s plugin config %q must be a map, got %T",
+			pluginType,
+			k,
+			v,
+		)
+	}
+	return pluginName, pluginConfig, nil
+}
+
 func collectMidnightYAMLFields(buf []byte) map[string]struct{} {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(buf, &doc); err != nil {
@@ -826,32 +878,15 @@ func LoadConfig(configFile string) (*Config, error) {
 		// Handle database section if present
 		if tempCfg.Database != nil {
 			if tempCfg.Database.Blob != nil {
-				// Extract plugin name if specified
-				if pluginVal, exists := tempCfg.Database.Blob["plugin"]; exists {
-					if pluginName, ok := pluginVal.(string); ok {
-						globalConfig.BlobPlugin = pluginName
-						// Remove plugin from config map
-						delete(tempCfg.Database.Blob, "plugin")
-					}
+				pluginName, blobConfig, err := databasePluginConfig(
+					"blob",
+					tempCfg.Database.Blob,
+				)
+				if err != nil {
+					return nil, err
 				}
-				// Build plugin config map
-				blobConfig := make(map[string]map[string]any)
-				for k, v := range tempCfg.Database.Blob {
-					if val, ok := v.(map[string]any); ok {
-						blobConfig[k] = val
-					} else if val, ok := v.(map[any]any); ok {
-						// Convert map[any]any to map[string]any
-						stringAnyMap := make(map[string]any)
-						for vk, vv := range val {
-							if keyStr, ok := vk.(string); ok {
-								stringAnyMap[keyStr] = vv
-							}
-						}
-						blobConfig[k] = stringAnyMap
-					} else {
-						// Log skipped non-map config entries
-						fmt.Fprintf(os.Stderr, "warning: skipping blob config entry %q: expected map, got %T\n", k, v)
-					}
+				if pluginName != "" {
+					globalConfig.BlobPlugin = pluginName
 				}
 				// Merge with existing blob config instead of overwriting
 				if pluginConfig["blob"] == nil {
@@ -861,32 +896,15 @@ func LoadConfig(configFile string) (*Config, error) {
 				}
 			}
 			if tempCfg.Database.Metadata != nil {
-				// Extract plugin name if specified
-				if pluginVal, exists := tempCfg.Database.Metadata["plugin"]; exists {
-					if pluginName, ok := pluginVal.(string); ok {
-						globalConfig.MetadataPlugin = pluginName
-						// Remove plugin from config map
-						delete(tempCfg.Database.Metadata, "plugin")
-					}
+				pluginName, metadataConfig, err := databasePluginConfig(
+					"metadata",
+					tempCfg.Database.Metadata,
+				)
+				if err != nil {
+					return nil, err
 				}
-				// Build plugin config map
-				metadataConfig := make(map[string]map[string]any)
-				for k, v := range tempCfg.Database.Metadata {
-					if val, ok := v.(map[string]any); ok {
-						metadataConfig[k] = val
-					} else if val, ok := v.(map[any]any); ok {
-						// Convert map[any]any to map[string]any
-						stringAnyMap := make(map[string]any)
-						for vk, vv := range val {
-							if keyStr, ok := vk.(string); ok {
-								stringAnyMap[keyStr] = vv
-							}
-						}
-						metadataConfig[k] = stringAnyMap
-					} else {
-						// Log skipped non-map config entries
-						fmt.Fprintf(os.Stderr, "warning: skipping metadata config entry %q: expected map, got %T\n", k, v)
-					}
+				if pluginName != "" {
+					globalConfig.MetadataPlugin = pluginName
 				}
 				// Merge with existing metadata config instead of overwriting
 				if pluginConfig["metadata"] == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -855,6 +855,77 @@ database:
 	}
 }
 
+// Database plugin config must fail loudly when YAML values have the wrong shape.
+// These cases guard against silently falling back to zero-value plugin config.
+func TestLoad_DatabaseSectionInvalidPluginConfigTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		errContain string
+	}{
+		{
+			name: "blob plugin selector is not string",
+			yaml: `
+database:
+  blob:
+    plugin: 123
+`,
+			errContain: "blob plugin name must be a string",
+		},
+		{
+			name: "metadata plugin selector is not string",
+			yaml: `
+database:
+  metadata:
+    plugin: true
+`,
+			errContain: "metadata plugin name must be a string",
+		},
+		{
+			name: "blob plugin config is not map",
+			yaml: `
+database:
+  blob:
+    plugin: "badger"
+    badger: "/tmp/badger"
+`,
+			errContain: `blob plugin config "badger" must be a map`,
+		},
+		{
+			name: "metadata plugin config is not map",
+			yaml: `
+database:
+  metadata:
+    plugin: "sqlite"
+    sqlite: "/tmp/test.db"
+`,
+			errContain: `metadata plugin config "sqlite" must be a map`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobalConfig()
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test-dingo.yaml")
+			if err := os.WriteFile(tmpFile, []byte(tt.yaml), 0644); err != nil {
+				t.Fatalf("failed to write config file: %v", err)
+			}
+
+			_, err := LoadConfig(tmpFile)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errContain)
+			}
+			if !strings.Contains(err.Error(), tt.errContain) {
+				t.Fatalf(
+					"error %q should contain %q",
+					err.Error(),
+					tt.errContain,
+				)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 	validTests := []struct {
 		name    string


### PR DESCRIPTION
1. Fixed silent plugin config type assertion failures so malformed database.blob and database.metadata sections now return LoadConfig errors instead of being ignored or falling back to zero-value config.
2. Added shared `databasePluginConfig` validation for database plugin config sections.
3. Validated that `plugin` selectors are strings.
4. Validated that each plugin config block is a map.
5. Validated nested plugin config keys when generic YAML maps are converted.
6. Reused the same validation path for both blob and metadata plugin config.
7. Added regression tests for invalid blob and metadata plugin config types.

Closes #1486 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1486: Make database plugin config validation strict. Wrong types in blob/metadata now cause LoadConfig to return an error instead of being silently ignored.

- **Bug Fixes**
  - Validate that the `plugin` selector is a string.
  - Require each plugin config block to be a map; nested keys must be strings.
  - Return a LoadConfig error for malformed blob/metadata config instead of warning and skipping.
  - Added regression tests covering invalid shapes for blob and metadata.

- **Refactors**
  - Extracted shared `databasePluginConfig` validator and used it for both blob and metadata paths for consistent behavior.

<sup>Written for commit 38b63c2abbf52fe7b152e2a79f0455faa66f58ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for database plugin settings during configuration loading.
  * Invalid plugin names or malformed plugin configuration blocks now return clear errors instead of being ignored.
  * Better handling of mixed configuration map formats for database sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->