### PR TITLE
fix(ledger): trust accepted chain validation sentinels

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3803,6 +3803,39 @@ func (ls *LedgerState) ledgerProcessBlock(
 					)
 					err = nil
 				}
+				if err != nil &&
+					isAcceptedBlockCollateralVKeyDisagreement(err) {
+					ls.config.Logger.Warn(
+						"collateral witness validation disagrees with accepted block (trusting isValid=true)",
+						"component", "ledger",
+						"tx_hash", tx.Hash().String(),
+						"block_slot", point.Slot,
+						"error", err.Error(),
+					)
+					err = nil
+				}
+				if err != nil &&
+					isAcceptedBlockDelegationRegistrationDisagreement(err) {
+					ls.config.Logger.Warn(
+						"stake delegation validation disagrees with accepted block (trusting accepted chain)",
+						"component", "ledger",
+						"tx_hash", tx.Hash().String(),
+						"block_slot", point.Slot,
+						"error", err.Error(),
+					)
+					err = nil
+				}
+				if err != nil &&
+					isAcceptedBlockScriptDataHashDisagreement(err) {
+					ls.config.Logger.Warn(
+						"script data hash validation disagrees with accepted block (trusting accepted chain)",
+						"component", "ledger",
+						"tx_hash", tx.Hash().String(),
+						"block_slot", point.Slot,
+						"error", err.Error(),
+					)
+					err = nil
+				}
 				// Dijkstra/Leios: the block was admitted to the chain via its
 				// Leios certificate. An endorser block may be only partially
 				// resolvable (e.g. an endorser-resident input from an endorser
@@ -3931,6 +3964,31 @@ func (ls *LedgerState) ledgerProcessBlock(
 		}
 	}
 	return delta, nil
+}
+
+func isAcceptedBlockCollateralVKeyDisagreement(err error) bool {
+	var validationErr *lcommon.ValidationError
+	if !errors.As(err, &validationErr) {
+		return false
+	}
+	return validationErr.Type == lcommon.ValidationErrorTypeTransaction &&
+		validationErr.Message == "collateral input must be key-locked"
+}
+
+func isAcceptedBlockDelegationRegistrationDisagreement(err error) bool {
+	var validationErr *lcommon.ValidationError
+	if !errors.As(err, &validationErr) {
+		return false
+	}
+	return validationErr.Type == lcommon.ValidationErrorTypeTransaction &&
+		strings.HasPrefix(
+			validationErr.Message,
+			"delegation from unregistered stake credential: ",
+		)
+}
+
+func isAcceptedBlockScriptDataHashDisagreement(err error) bool {
+	return errors.Is(err, lcommon.ErrScriptDataHashMismatch)
 }
 
 func opCertSequenceNumber(block ledger.Block) (uint32, bool) {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -112,6 +112,102 @@ func TestHandleLedgerProcessBlocksErrorDoesNotReportFatalErrors(
 	require.False(t, fatalCalled)
 }
 
+func TestIsAcceptedBlockCollateralVKeyDisagreement(t *testing.T) {
+	err := lcommon.NewValidationError(
+		lcommon.ValidationErrorTypeTransaction,
+		"collateral input must be key-locked",
+		map[string]any{"input": "tx#0"},
+		nil,
+	)
+
+	require.True(t, isAcceptedBlockCollateralVKeyDisagreement(err))
+	require.False(
+		t,
+		isAcceptedBlockCollateralVKeyDisagreement(
+			errors.New("collateral input must be key-locked"),
+		),
+	)
+	require.False(
+		t,
+		isAcceptedBlockCollateralVKeyDisagreement(
+			lcommon.NewValidationError(
+				lcommon.ValidationErrorTypeTransaction,
+				"missing vkey witness for collateral input",
+				nil,
+				nil,
+			),
+		),
+	)
+}
+
+func TestIsAcceptedBlockDelegationRegistrationDisagreement(t *testing.T) {
+	err := lcommon.NewValidationError(
+		lcommon.ValidationErrorTypeTransaction,
+		"delegation from unregistered stake credential: a1c0af",
+		map[string]any{"credential": "a1c0af"},
+		nil,
+	)
+
+	require.True(t, isAcceptedBlockDelegationRegistrationDisagreement(err))
+	require.False(
+		t,
+		isAcceptedBlockDelegationRegistrationDisagreement(
+			errors.New("delegation from unregistered stake credential: a1c0af"),
+		),
+	)
+	require.False(
+		t,
+		isAcceptedBlockDelegationRegistrationDisagreement(
+			lcommon.NewValidationError(
+				lcommon.ValidationErrorTypeTransaction,
+				"stake credential not registered for withdrawal",
+				nil,
+				nil,
+			),
+		),
+	)
+}
+
+func TestIsAcceptedBlockScriptDataHashDisagreement(t *testing.T) {
+	err := lcommon.NewValidationError(
+		lcommon.ValidationErrorTypeTransaction,
+		"transaction validation failed",
+		map[string]any{"tx_hash": "d5feb126a6ae3cc3e04fe1f08a236a35c45e4113775153cfc33a5607390e0306"},
+		fmt.Errorf(
+			"conway utxo validation rule 12: %w",
+			lcommon.ScriptDataHashMismatchError{},
+		),
+	)
+
+	require.True(t, isAcceptedBlockScriptDataHashDisagreement(err))
+	require.True(
+		t,
+		isAcceptedBlockScriptDataHashDisagreement(
+			fmt.Errorf(
+				"conway utxo validation rule 12: %w",
+				lcommon.ScriptDataHashMismatchError{},
+			),
+		),
+	)
+	require.False(
+		t,
+		isAcceptedBlockScriptDataHashDisagreement(
+			errors.New("script data hash mismatch: declared a, computed b"),
+		),
+	)
+	require.False(
+		t,
+		isAcceptedBlockScriptDataHashDisagreement(
+			lcommon.NewValidationError(
+				lcommon.ValidationErrorTypeTransaction,
+				"missing redeemer for spending input",
+				nil,
+				nil,
+			),
+		),
+	)
+}
+
 // It verifies that calculating the stability window is synchronized with
 // concurrent currentEra updates from block processing.
 func TestCalculateStabilityWindowConcurrentCurrentEraAccess(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Trust the accepted chain for specific validation sentinels during `ledger` block processing, downgrading known disagreements to warnings and continuing. This prevents false failures when replaying already accepted blocks.

- **Bug Fixes**
  - In `ledgerProcessBlock`, treat these as non-fatal and log a warning: collateral input must be key-locked, delegation from unregistered stake credential, script data hash mismatch.
  - Added helpers `isAcceptedBlockCollateralVKeyDisagreement`, `isAcceptedBlockDelegationRegistrationDisagreement`, and `isAcceptedBlockScriptDataHashDisagreement` using `lcommon` errors.
  - Added unit tests for the helpers in `ledger/state_test.go`.

<sup>Written for commit 2a71ac7e584da75e0308d384072b24aeb8ce6282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction processing so certain known validation disagreements are tolerated and logged as warnings instead of causing blocks to fail.
  * Better handles a few specific cases involving collateral inputs, delegation registration, and script data hash mismatches.
  * Added coverage to ensure these validation cases are recognized consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->