### PR TITLE
fix(mithril): disable badger gc during snapshot load

### DIFF
--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -537,7 +537,7 @@ func runMithrilSync(
 		CleanupAfterLoad:       cfg.Mithril.CleanupAfterLoad,
 		BlobPlugin:             cfg.BlobPlugin,
 		MetadataPlugin:         cfg.MetadataPlugin,
-		RunMode:                string(cfg.RunMode),
+		RunMode:                string(config.RunModeLoad),
 		BackfillBatchSize:      cfg.BackfillBatchSize,
 		DatabaseWorkers:        cfg.DatabaseWorkers,
 		Logger:                 logger,

--- a/database/plugin/blob/badger/options_test.go
+++ b/database/plugin/blob/badger/options_test.go
@@ -222,6 +222,74 @@ func TestUseCompactBlockMetadata(t *testing.T) {
 	}
 }
 
+func TestNewFromCmdlineOptionsDisablesGCInLoadModeByDefault(t *testing.T) {
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		"badger",
+		"run-mode",
+		"load",
+	); err != nil {
+		t.Fatalf("set run-mode: %v", err)
+	}
+
+	p := NewFromCmdlineOptions()
+	b, ok := p.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if b.gcEnabled {
+		t.Fatal("expected load mode to disable online GC by default")
+	}
+}
+
+func TestNewFromCmdlineOptionsPreservesExplicitGCInLoadMode(t *testing.T) {
+	cmdlineOptionsMutex.Lock()
+	saved := cmdlineOptions
+	cmdlineOptionsMutex.Unlock()
+	t.Cleanup(func() {
+		cmdlineOptionsMutex.Lock()
+		cmdlineOptions = saved
+		cmdlineOptionsMutex.Unlock()
+	})
+	initCmdlineOptions()
+
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		"badger",
+		"run-mode",
+		"load",
+	); err != nil {
+		t.Fatalf("set run-mode: %v", err)
+	}
+	if err := plugin.SetPluginOption(
+		plugin.PluginTypeBlob,
+		"badger",
+		"gc",
+		true,
+	); err != nil {
+		t.Fatalf("set gc: %v", err)
+	}
+
+	p := NewFromCmdlineOptions()
+	b, ok := p.(*BlobStoreBadger)
+	if !ok {
+		t.Fatal("expected *BlobStoreBadger from NewFromCmdlineOptions")
+	}
+	if !b.gcEnabled {
+		t.Fatal("expected explicit GC setting to be preserved")
+	}
+}
+
 func TestApplyStorageModeDefaultsPreservesExplicitOverrides(t *testing.T) {
 	blockCache := uint64(DefaultBlockCacheSize)
 	indexCache := uint64(DefaultIndexCacheSize)

--- a/database/plugin/blob/badger/plugin.go
+++ b/database/plugin/blob/badger/plugin.go
@@ -64,6 +64,7 @@ var (
 		compressionLevel      uint64
 		blockCacheSizeSet     bool
 		indexCacheSizeSet     bool
+		gcEnabledSet          bool
 		compressionEnabledSet bool
 	}
 	cmdlineOptionsMutex sync.RWMutex
@@ -102,6 +103,19 @@ func applyStorageModeDefaults(
 	}
 }
 
+func applyRunModeDefaults(
+	runMode string,
+	gcEnabled *bool,
+	gcEnabledSet bool,
+) {
+	if gcEnabledSet {
+		return
+	}
+	if runMode == "load" {
+		*gcEnabled = false
+	}
+}
+
 func useCompactBlockMetadata(runMode, storageMode string) bool {
 	return (runMode == "serve" || runMode == "leios") &&
 		storageMode == "core"
@@ -123,6 +137,7 @@ func initCmdlineOptions() {
 	cmdlineOptions.compressionLevel = DefaultCompressionLevel
 	cmdlineOptions.blockCacheSizeSet = false
 	cmdlineOptions.indexCacheSizeSet = false
+	cmdlineOptions.gcEnabledSet = false
 	cmdlineOptions.compressionEnabledSet = false
 	cmdlineOptions.dataDir = ".dingo"
 }
@@ -180,6 +195,7 @@ func init() {
 					Description:  "Enable garbage collection",
 					DefaultValue: true,
 					Dest:         &(cmdlineOptions.gcEnabled),
+					SetIndicator: &(cmdlineOptions.gcEnabledSet),
 				},
 				{
 					Name:         "value-log-file-size",
@@ -227,6 +243,7 @@ func NewFromCmdlineOptions() plugin.Plugin {
 	blockCacheSize := cmdlineOptions.blockCacheSize
 	indexCacheSize := cmdlineOptions.indexCacheSize
 	memTableSize := cmdlineOptions.memTableSize
+	gcEnabled := cmdlineOptions.gcEnabled
 	compressionEnabled := cmdlineOptions.compressionEnabled
 	applyStorageModeDefaults(
 		cmdlineOptions.storageMode,
@@ -236,6 +253,11 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		cmdlineOptions.blockCacheSizeSet,
 		cmdlineOptions.indexCacheSizeSet,
 		cmdlineOptions.compressionEnabledSet,
+	)
+	applyRunModeDefaults(
+		cmdlineOptions.runMode,
+		&gcEnabled,
+		cmdlineOptions.gcEnabledSet,
 	)
 	// Safe conversion from uint64 to int64 with bounds checking
 	valueLogFileSize := min(
@@ -268,7 +290,7 @@ func NewFromCmdlineOptions() plugin.Plugin {
 			),
 		),
 		WithValueThreshold(int64(valueThreshold)),
-		WithGc(cmdlineOptions.gcEnabled),
+		WithGc(gcEnabled),
 		WithCompressionEnabled(compressionEnabled),
 		WithCompressionLevel(int(compressionLevel)),
 		WithDeferOpen(),


### PR DESCRIPTION
Relates to #2701 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `badger` online GC during snapshot load and force Mithril sync to run in `load` mode so snapshot imports are stable and faster.

- **Bug Fixes**
  - In `load` run mode, default `badger` GC to off; preserves an explicit `--gc` flag if provided.
  - Mithril now passes `RunModeLoad` during snapshot apply so the `load` defaults reliably take effect.

<sup>Written for commit 1b99cbf5c90420f79be20cecd2b447ae8b946638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

