### PR TITLE
fix(chainsync): realign switched peer cursors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1074,7 +1074,14 @@ The `ChainSelector` (`chainselection/`) implements Ouroboros Praos rules:
 
 The selector tracks tips from all connected peers, honors peer eligibility and
 priority updates from peer governance, and switches the active chainsync
-connection when a better chain is found.
+connection when a better chain is found. A chain switch does not assume that the
+new peer's already-running ChainSync cursor is still contiguous with the local
+ledger. If the selected peer advertises a tip ahead of the primary chain and
+there are no queued headers, buffered headers, or active blockfetch work to
+bridge the gap, the ledger emits `chainsync.resync` with reason
+`chain switch cursor ahead of local tip`; Ouroboros then closes that connection
+for a fresh intersect from the current local tip instead of waiting for a cursor
+that has already moved past the missing blocks.
 
 Bootstrap topology peers remain chain-selection eligible after bootstrap exit
 as a fallback ingress source, but peer governance lowers their priority to zero.

--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -37,6 +37,7 @@ const (
 	ChainsyncResyncReasonForkResolutionExceedsK       = "fork resolution exceeds security parameter K"
 	ChainsyncResyncReasonLocalLedgerRollback          = "local ledger rollback"
 	ChainsyncResyncReasonLiveTxValidationRecovery     = "live tx validation recovery"
+	ChainsyncResyncReasonChainSwitchCursorAhead       = "chain switch cursor ahead of local tip"
 	ChainsyncResyncReasonBlockfetchTimeoutRetryFailed = "blockfetch timeout retry failed on all available connections"
 )
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -380,6 +380,8 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 		return
 	}
 	var replayConnId ouroboros.ConnectionId
+	effectiveConnId := e.NewConnectionId
+	var requestFreshCursor bool
 	ls.chainsyncMutex.Lock()
 	defer ls.chainsyncMutex.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
@@ -402,6 +404,7 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 				)
 				if retryConnId, retryErr := ls.handoffPipelineOnSwitchLocked(*activeConnId); retryErr == nil {
 					replayConnId = retryConnId
+					effectiveConnId = *activeConnId
 					err = nil
 				}
 			}
@@ -420,8 +423,29 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 			ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 		}
 	}
+	if err == nil {
+		requestFreshCursor = ls.chainSwitchNeedsFreshCursorLocked(
+			e,
+			effectiveConnId,
+		)
+	}
 	ls.chainsyncBlockfetchMutex.Unlock()
 	if err != nil {
+		return
+	}
+	if requestFreshCursor {
+		ls.config.Logger.Info(
+			"chain switch selected peer is ahead without queued headers, requesting fresh chainsync cursor",
+			"component", "ledger",
+			"connection_id", effectiveConnId.String(),
+			"switch_connection_id", e.NewConnectionId.String(),
+			"local_tip_slot", ls.PrimaryChainTip().Point.Slot,
+			"peer_tip_slot", e.NewTip.Point.Slot,
+		)
+		ls.requestChainsyncResync(
+			effectiveConnId,
+			event.ChainsyncResyncReasonChainSwitchCursorAhead,
+		)
 		return
 	}
 	if connIdKey(replayConnId) != "" {
@@ -678,6 +702,31 @@ func (ls *LedgerState) handoffPipelineOnSwitchLocked(
 	}
 
 	return ouroboros.ConnectionId{}, nil
+}
+
+func (ls *LedgerState) chainSwitchNeedsFreshCursorLocked(
+	e chainselection.ChainSwitchEvent,
+	connId ouroboros.ConnectionId,
+) bool {
+	if connIdKey(e.PreviousConnectionId) == "" ||
+		connIdKey(connId) == "" {
+		return false
+	}
+	if ls.chainsyncBlockfetchReadyChan != nil {
+		return false
+	}
+	if ls.chain != nil && ls.chain.HeaderCount() > 0 {
+		return false
+	}
+	if len(ls.bufferedHeaderEvents[connIdKey(connId)]) > 0 {
+		return false
+	}
+	localTip := ls.PrimaryChainTip()
+	if e.NewTip.BlockNumber > localTip.BlockNumber {
+		return true
+	}
+	return e.NewTip.BlockNumber == localTip.BlockNumber &&
+		e.NewTip.Point.Slot > localTip.Point.Slot
 }
 
 func (ls *LedgerState) bufferHeaderEvent(e ChainsyncEvent) {

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -543,6 +544,240 @@ func TestHandleChainSwitchEventUpdatesSelectedBlockfetchConnId(t *testing.T) {
 	assert.Equal(t, connId, nextConnId)
 }
 
+func TestHandleChainSwitchEventRequestsFreshCursorWhenPeerAheadWithoutHeaders(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.handleChainSwitchEvent(event.NewEvent(
+		chainselection.ChainSwitchEventType,
+		chainselection.ChainSwitchEvent{
+			PreviousConnectionId: connId1,
+			NewConnectionId:      connId2,
+			NewTip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(200, []byte("peer-tip")),
+				BlockNumber: 10,
+			},
+		},
+	))
+
+	evt := testutil.RequireReceive(
+		t,
+		resyncCh,
+		2*time.Second,
+		"expected chain-switch cursor resync event",
+	)
+	resync, ok := evt.Data.(event.ChainsyncResyncEvent)
+	require.True(t, ok)
+	assert.Equal(t, connId2, resync.ConnectionId)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonChainSwitchCursorAhead,
+		resync.Reason,
+	)
+}
+
+type chainSwitchFallbackFixture struct {
+	ls             *LedgerState
+	resyncCh       <-chan event.Event
+	previousConnId ouroboros.ConnectionId
+	targetConnId   ouroboros.ConnectionId
+	activeConnId   ouroboros.ConnectionId
+}
+
+func newChainSwitchFallbackFixture(
+	t *testing.T,
+) chainSwitchFallbackFixture {
+	t.Helper()
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+
+	connId1 := testChainsyncConnId(6000, 3001)
+	connId2 := testChainsyncConnId(6000, 3002)
+	connId3 := testChainsyncConnId(6000, 3003)
+	currentConn := connId3
+	testChain := &chain.Chain{}
+	err := testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("stale-hdr")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	})
+	require.NoError(t, err)
+
+	ls := &LedgerState{
+		chain: testChain,
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &currentConn
+			},
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				start ocommon.Point,
+				end ocommon.Point,
+			) error {
+				_ = start
+				_ = end
+				if sameConnectionId(connId, connId2) {
+					testChain.ClearHeaders()
+					return errors.New("connection closed")
+				}
+				return nil
+			},
+		},
+	}
+
+	return chainSwitchFallbackFixture{
+		ls:             ls,
+		resyncCh:       resyncCh,
+		previousConnId: connId1,
+		targetConnId:   connId2,
+		activeConnId:   connId3,
+	}
+}
+
+func (f chainSwitchFallbackFixture) handleChainSwitchEvent() {
+	f.ls.handleChainSwitchEvent(event.NewEvent(
+		chainselection.ChainSwitchEventType,
+		chainselection.ChainSwitchEvent{
+			PreviousConnectionId: f.previousConnId,
+			NewConnectionId:      f.targetConnId,
+			NewTip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(200, []byte("peer-tip")),
+				BlockNumber: 10,
+			},
+		},
+	))
+}
+
+func TestHandleChainSwitchEventFallbackResyncUsesActiveConnection(
+	t *testing.T,
+) {
+	fixture := newChainSwitchFallbackFixture(t)
+	fixture.handleChainSwitchEvent()
+
+	evt := testutil.RequireReceive(
+		t,
+		fixture.resyncCh,
+		2*time.Second,
+		"expected fallback chain-switch cursor resync event",
+	)
+	resync, ok := evt.Data.(event.ChainsyncResyncEvent)
+	require.True(t, ok)
+	assert.Equal(t, fixture.activeConnId, resync.ConnectionId)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonChainSwitchCursorAhead,
+		resync.Reason,
+	)
+	assert.Equal(t, fixture.activeConnId, fixture.ls.selectedBlockfetchConnId)
+}
+
+func TestHandleChainSwitchEventFallbackReplaysBufferedActiveHeaders(
+	t *testing.T,
+) {
+	bufferedHeaderHash := lcommon.NewBlake2b256([]byte("active-hdr"))
+	fixture := newChainSwitchFallbackFixture(t)
+
+	fixture.ls.bufferedHeaderEvents = map[string][]ChainsyncEvent{
+		connIdKey(fixture.activeConnId): {{
+			ConnectionId: fixture.activeConnId,
+			BlockHeader: mockHeader{
+				hash:        bufferedHeaderHash,
+				prevHash:    lcommon.NewBlake2b256(nil),
+				blockNumber: 1,
+				slot:        1,
+			},
+			Point: ocommon.NewPoint(1, bufferedHeaderHash.Bytes()),
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(10, []byte("tip")),
+				BlockNumber: 10,
+			},
+		}},
+	}
+
+	fixture.handleChainSwitchEvent()
+
+	testutil.WaitForCondition(
+		t,
+		func() bool {
+			fixture.ls.chainsyncMutex.Lock()
+			defer fixture.ls.chainsyncMutex.Unlock()
+			return sameConnectionId(
+				fixture.ls.headerPipelineConnId,
+				fixture.activeConnId,
+			) &&
+				fixture.ls.chain.HeaderCount() == 1 &&
+				len(fixture.ls.bufferedHeaderEvents[connIdKey(fixture.activeConnId)]) == 0
+		},
+		2*time.Second,
+		"expected buffered active headers to replay after fallback handoff",
+	)
+	testutil.RequireNoReceive(
+		t,
+		fixture.resyncCh,
+		200*time.Millisecond,
+		"active buffered headers should not trigger fresh cursor resync",
+	)
+}
+
+func TestHandleChainSwitchEventDoesNotResyncInitialPeerSelection(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.handleChainSwitchEvent(event.NewEvent(
+		chainselection.ChainSwitchEventType,
+		chainselection.ChainSwitchEvent{
+			NewConnectionId: connId,
+			NewTip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(200, []byte("peer-tip")),
+				BlockNumber: 10,
+			},
+		},
+	))
+
+	testutil.RequireNoReceive(
+		t,
+		resyncCh,
+		200*time.Millisecond,
+		"initial peer selection should not trigger resync",
+	)
+}
+
 func TestShouldBufferHeaderEventDoesNotPreserveIdleSelectedConnection(
 	t *testing.T,
 ) {
@@ -635,7 +870,7 @@ func TestHandleChainSwitchEventReplaysBufferedHeadersForSelectedConnection(
 		return sameConnectionId(ls.headerPipelineConnId, connId2) &&
 			ls.chain.HeaderCount() == 1 &&
 			len(ls.bufferedHeaderEvents[connIdKey(connId2)]) == 0
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestHandleEventChainsyncBlockHeaderAcceptsCompatibleNonOwnerConnection(
@@ -1035,7 +1270,7 @@ func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
 		return sameConnectionId(ls.headerPipelineConnId, connId2) &&
 			len(ls.bufferedHeaderEvents[connIdKey(connId2)]) == 0 &&
 			ls.chain.HeaderCount() == 1
-	}, time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 10*time.Millisecond)
 	assert.True(t, sameConnectionId(ls.headerPipelineConnId, connId2))
 	assert.Equal(t, 1, ls.chain.HeaderCount())
 }

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -139,6 +139,7 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 		event.ChainsyncResyncReasonRollbackNotFound,
 		event.ChainsyncResyncReasonPersistentFork,
 		event.ChainsyncResyncReasonLiveTxValidationRecovery,
+		event.ChainsyncResyncReasonChainSwitchCursorAhead,
 		event.ChainsyncResyncReasonRollbackExceedsK,
 		event.ChainsyncResyncReasonRollbackExceedsMithril,
 		event.ChainsyncResyncReasonPeerTipBehindMithril,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1782,6 +1782,11 @@ func TestChainsyncResyncMithrilReasonsDenyPeerAndRequireFreshConnection(
 			wantFresh:      true,
 			wantDeniesPeer: false,
 		},
+		{
+			reason:         event.ChainsyncResyncReasonChainSwitchCursorAhead,
+			wantFresh:      true,
+			wantDeniesPeer: false,
+		},
 	}
 	for _, tt := range tests {
 		if got := chainsyncResyncRequiresFreshConnection(tt.reason); got != tt.wantFresh {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Realigns ChainSync after a chain switch by requesting a fresh cursor when the selected peer is ahead and there’s no queued/buffered headers or active blockfetch. Prevents stalls by re-intersecting from the current local tip.

- **Bug Fixes**
  - In `ledger/chainsync.go`, detect this case and emit `chainsync.resync` with reason "chain switch cursor ahead of local tip"; resync on the active connection if the pipeline was handed off, otherwise on the switched peer; skip resync on initial peer selection or when headers are queued/buffered.
  - Add `ChainsyncResyncReasonChainSwitchCursorAhead` and require a fresh connection for this reason in `ouroboros/chainsync.go`.
  - Add tests for fresh-cursor request, active-connection fallback with buffered header replay, and no-resync on initial selection; update `ARCHITECTURE.md` to document the behavior.

<sup>Written for commit 0bfd7ed8c9f0650d16a2189065443de26b5a366f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified chain-switch behavior so the app now explains when a fresh sync is triggered after moving to a newer peer.

* **Bug Fixes**
  * Improved chain switching when the selected peer is ahead but no buffered sync work is available.
  * Added a specific resync path to restart syncing from the current local tip instead of waiting on stale progress.
  * Ensured the sync client treats this case as requiring a fresh connection.

* **Tests**
  * Added coverage for fresh-cursor resync, fallback behavior, buffered header replay, and initial peer selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->