### PR TITLE
fix(ledger): normalize vrf key from header cbor

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -103,11 +103,11 @@ func verifyBlockHeaderHex(
 		SkipStakePoolValidation:   true,
 	}
 
-	header, err := normalizeHeaderVrfResultFromBodyCbor(block.Header())
+	header, err := normalizeHeaderVrfFieldsFromBodyCbor(block.Header())
 	if err != nil {
 		return fmt.Errorf(
 			"block header verification failed at slot %d: "+
-				"normalize VRF result from header body CBOR: %w",
+				"normalize VRF fields from header body CBOR: %w",
 			block.SlotNumber(),
 			err,
 		)

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -276,28 +276,33 @@ func TestVerifyBlockHeader_ValidBlock(t *testing.T) {
 	assert.NoError(t, err, "valid block should pass verification")
 }
 
-// TestVerifyBlockHeader_UsesBodyCBORVRFResult verifies that header crypto
+// TestVerifyBlockHeader_UsesBodyCBORVRFFields verifies that header crypto
 // verification is driven by the original header-body CBOR, not by stale typed
-// VrfResult fields on the decoded header object.
-func TestVerifyBlockHeader_UsesBodyCBORVRFResult(t *testing.T) {
+// VRF fields on the decoded header object.
+func TestVerifyBlockHeader_UsesBodyCBORVRFFields(t *testing.T) {
 	tb := createTestBlock(t, [32]byte{5}, 11, tamperNone)
 	header := tb.block.header
 	require.NotEmpty(t, header.Body.Cbor())
 
+	originalKey := cloneBytes(header.Body.VrfKey)
 	originalOutput := cloneBytes(header.Body.VrfResult.Output)
 	originalProof := cloneBytes(header.Body.VrfResult.Proof)
+	staleKey := bytes.Repeat([]byte{0x33}, len(originalKey))
 	staleOutput := bytes.Repeat([]byte{0x44}, len(originalOutput))
 	staleProof := bytes.Repeat([]byte{0x55}, len(originalProof))
+	require.False(t, bytes.Equal(originalKey, staleKey))
 	require.False(t, bytes.Equal(originalOutput, staleOutput))
 	require.False(t, bytes.Equal(originalProof, staleProof))
 
+	header.Body.VrfKey = staleKey
 	header.Body.VrfResult.Output = staleOutput
 	header.Body.VrfResult.Proof = staleProof
 
-	normalized, err := normalizeHeaderVrfResultFromBodyCbor(header)
+	normalized, err := normalizeHeaderVrfFieldsFromBodyCbor(header)
 	require.NoError(t, err)
 	normalizedHeader, ok := normalized.(*babbage.BabbageBlockHeader)
 	require.True(t, ok)
+	assert.Equal(t, originalKey, normalizedHeader.Body.VrfKey)
 	assert.Equal(t, originalOutput, normalizedHeader.Body.VrfResult.Output)
 	assert.Equal(t, originalProof, normalizedHeader.Body.VrfResult.Proof)
 
@@ -305,8 +310,9 @@ func TestVerifyBlockHeader_UsesBodyCBORVRFResult(t *testing.T) {
 	assert.NoError(
 		t,
 		err,
-		"valid header should pass even when decoded VrfResult is stale",
+		"valid header should pass even when decoded VRF fields are stale",
 	)
+	assert.Equal(t, staleKey, header.Body.VrfKey)
 	assert.Equal(t, staleOutput, header.Body.VrfResult.Output)
 	assert.Equal(t, staleProof, header.Body.VrfResult.Proof)
 }

--- a/ledger/verify_header_vrf.go
+++ b/ledger/verify_header_vrf.go
@@ -30,24 +30,43 @@ import (
 )
 
 const (
+	vrfKeyBodyIndex          = 4
 	praosVrfResultBodyIndex  = 5
 	tpraosLeaderVrfBodyIndex = 6
 	vrfResultFieldCount      = 2
 )
 
-// normalizeHeaderVrfResultFromBodyCbor returns a shallow header copy whose
-// typed VRF result is derived from the original header-body CBOR. Chainsync
-// and block decoders keep those original bytes for KES verification; using the
-// same source for VRF avoids rejecting canonical headers when a decoded
-// VrfResult field is stale or otherwise inconsistent with the wire bytes.
-func normalizeHeaderVrfResultFromBodyCbor(
+// normalizeHeaderVrfFieldsFromBodyCbor returns a shallow header copy whose
+// typed VRF key and result are derived from the original header-body CBOR.
+// Chainsync and block decoders keep those original bytes for KES verification;
+// using the same source for VRF avoids rejecting canonical headers when a
+// decoded VRF field is stale or otherwise inconsistent with the wire bytes.
+func normalizeHeaderVrfFieldsFromBodyCbor(
 	header ledger.BlockHeader,
 ) (ledger.BlockHeader, error) {
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(header)
+	if err != nil || !ok {
+		return header, err
+	}
 	vrfResult, ok, err := headerVrfResultFromBodyCbor(header)
 	if err != nil || !ok {
 		return header, err
 	}
-	return headerWithVrfResult(header, vrfResult), nil
+	return headerWithVrfKeyAndResult(header, vrfKey, vrfResult), nil
+}
+
+func headerVrfKeyFromBodyCbor(
+	header ledger.BlockHeader,
+) ([]byte, bool, error) {
+	bodyCbor, ok := headerBodyCbor(header)
+	if !ok || len(bodyCbor) == 0 {
+		return nil, false, nil
+	}
+	vrfKey, err := decodeBytesFromHeaderBodyCbor(bodyCbor, vrfKeyBodyIndex)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode VRF key: %w", err)
+	}
+	return vrfKey, true, nil
 }
 
 func headerVrfResultFromBodyCbor(
@@ -90,6 +109,59 @@ func headerVrfResultFromBodyCbor(
 		return lcommon.VrfResult{}, false, err
 	}
 	return vrfResult, true, nil
+}
+
+func headerBodyCbor(header ledger.BlockHeader) ([]byte, bool) {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return h.Body.Cbor(), true
+	case *allegra.AllegraBlockHeader:
+		return h.Body.Cbor(), true
+	case *mary.MaryBlockHeader:
+		return h.Body.Cbor(), true
+	case *alonzo.AlonzoBlockHeader:
+		return h.Body.Cbor(), true
+	case *babbage.BabbageBlockHeader:
+		return h.Body.Cbor(), true
+	case *conway.ConwayBlockHeader:
+		return h.Body.Cbor(), true
+	case *dijkstra.DijkstraBlockHeader:
+		return h.Body.Cbor(), true
+	default:
+		return nil, false
+	}
+}
+
+func decodeBytesFromHeaderBodyCbor(
+	bodyCbor []byte,
+	index int,
+) ([]byte, error) {
+	decoder, err := cbor.NewStreamDecoder(bodyCbor)
+	if err != nil {
+		return nil, err
+	}
+	fieldCount, _, _, err := decoder.DecodeArrayHeader()
+	if err != nil {
+		return nil, err
+	}
+	if index >= fieldCount {
+		return nil, fmt.Errorf(
+			"header body has %d fields, cannot read bytes at index %d",
+			fieldCount,
+			index,
+		)
+	}
+	if _, _, err := decoder.SkipN(index); err != nil {
+		return nil, fmt.Errorf(
+			"skip header body fields before bytes: %w",
+			err,
+		)
+	}
+	var ret []byte
+	if _, _, err := decoder.Decode(&ret); err != nil {
+		return nil, err
+	}
+	return cloneBytes(ret), nil
 }
 
 func decodeVrfResultFromHeaderBodyCbor(
@@ -151,37 +223,45 @@ func decodeVrfResultFromHeaderBodyCbor(
 	}, nil
 }
 
-func headerWithVrfResult(
+func headerWithVrfKeyAndResult(
 	header ledger.BlockHeader,
+	vrfKey []byte,
 	vrfResult lcommon.VrfResult,
 ) ledger.BlockHeader {
 	switch h := header.(type) {
 	case *shelley.ShelleyBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
 		return &clone
 	case *allegra.AllegraBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
 		return &clone
 	case *mary.MaryBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
 		return &clone
 	case *alonzo.AlonzoBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.LeaderVrf = cloneVrfResult(vrfResult)
 		return &clone
 	case *babbage.BabbageBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.VrfResult = cloneVrfResult(vrfResult)
 		return &clone
 	case *conway.ConwayBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.VrfResult = cloneVrfResult(vrfResult)
 		return &clone
 	case *dijkstra.DijkstraBlockHeader:
 		clone := *h
+		clone.Body.VrfKey = cloneBytes(vrfKey)
 		clone.Body.VrfResult = cloneVrfResult(vrfResult)
 		return &clone
 	default:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize VRF key and result from the header-body CBOR during block header verification to prevent false rejections caused by stale decoded fields. Renames the normalization function and extends it to include the VRF key.

- **Bug Fixes**
  - Derive VRF key (index 4) and VRF result from body CBOR across all eras; verification now uses canonical wire bytes.
  - Replace normalizeHeaderVrfResultFromBodyCbor with normalizeHeaderVrfFieldsFromBodyCbor; update call site and error text.
  - Add CBOR decode helpers and create a shallow header copy with cloned VRF fields to avoid mutating the original; update tests to confirm behavior.

<sup>Written for commit 979fb65d7c44b66f9ddc604370c762db51a181c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

