### PR TITLE
fix(ledger): preserve mithril-covered lab nonces

### DIFF
--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -214,6 +214,80 @@ func TestHealEmptyLabNoncesSkipsWithoutCandidateFallback(t *testing.T) {
 	require.Equal(t, oldNonce, epochs[0].Nonce)
 }
 
+func TestHealEmptyLabNoncesSkipsMissingCandidateBeforeBoundaryLookup(
+	t *testing.T,
+) {
+	oldLab := bytes.Repeat([]byte{0x99}, 32)
+	oldNonce := bytes.Repeat([]byte{0xaa}, 32)
+	epochs := []models.Epoch{
+		{
+			EpochId:             6,
+			StartSlot:           300,
+			LengthInSlots:       100,
+			Nonce:               oldNonce,
+			CandidateNonce:      nil,
+			LastEpochBlockNonce: oldLab,
+		},
+	}
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	require.NotPanics(t, func() {
+		repaired := ls.healEmptyLabNoncesInPlace(epochs)
+		require.False(t, repaired)
+	})
+	require.Equal(t, oldLab, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, oldNonce, epochs[0].Nonce)
+}
+
+func TestHealEmptyLabNoncesTrustsMithrilCoveredEpoch(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     250,
+		Hash:     boundaryHash,
+		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	importedLab := bytes.Repeat([]byte{0x99}, 32)
+	importedNonce := bytes.Repeat([]byte{0xdd}, 32)
+	epochs := []models.Epoch{
+		{
+			EpochId:             6,
+			StartSlot:           300,
+			LengthInSlots:       100,
+			Nonce:               importedNonce,
+			CandidateNonce:      candidate,
+			LastEpochBlockNonce: importedLab,
+		},
+	}
+	ls := &LedgerState{
+		db:                db,
+		mithrilLedgerSlot: 350,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	repaired := ls.healEmptyLabNoncesInPlace(epochs)
+
+	require.False(t, repaired)
+	require.Equal(t, importedLab, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, importedNonce, epochs[0].Nonce)
+	require.NotEqual(t, boundaryHash, epochs[0].LastEpochBlockNonce)
+}
+
 func TestHealEmptyLabNoncesInPlaceRepairsReloadedEpochs(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4634,10 +4634,57 @@ func (ls *LedgerState) healEmptyLabNonces() {
 
 func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 	repaired := false
+	var (
+		skippedMissingCandidate            int
+		firstMissingCandidateEpoch         uint64
+		lastMissingCandidateEpoch          uint64
+		skippedInvalidCandidate            int
+		firstInvalidCandidateEpoch         uint64
+		lastInvalidCandidateEpoch          uint64
+		skippedMithrilTrusted              int
+		firstMithrilTrustedEpoch           uint64
+		lastMithrilTrustedEpoch            uint64
+		recordSkippedMissingCandidateEpoch = func(epoch uint64) {
+			if skippedMissingCandidate == 0 {
+				firstMissingCandidateEpoch = epoch
+			}
+			lastMissingCandidateEpoch = epoch
+			skippedMissingCandidate++
+		}
+		recordSkippedInvalidCandidateEpoch = func(epoch uint64) {
+			if skippedInvalidCandidate == 0 {
+				firstInvalidCandidateEpoch = epoch
+			}
+			lastInvalidCandidateEpoch = epoch
+			skippedInvalidCandidate++
+		}
+		recordSkippedMithrilTrustedEpoch = func(epoch uint64) {
+			if skippedMithrilTrusted == 0 {
+				firstMithrilTrustedEpoch = epoch
+			}
+			lastMithrilTrustedEpoch = epoch
+			skippedMithrilTrusted++
+		}
+	)
 	for i := range epochs {
 		ep := &epochs[i]
 		// The genesis epoch legitimately carries no last block nonce.
 		if ep.StartSlot == 0 {
+			continue
+		}
+		if ls.mithrilLedgerSlot > 0 &&
+			ep.StartSlot <= ls.mithrilLedgerSlot &&
+			len(ep.LastEpochBlockNonce) == lcommon.Blake2b256Size {
+			recordSkippedMithrilTrustedEpoch(ep.EpochId)
+			continue
+		}
+		candidateNonce, err := ls.epochRepairCandidateNonce(*ep)
+		if err != nil {
+			if len(ep.CandidateNonce) == 0 {
+				recordSkippedMissingCandidateEpoch(ep.EpochId)
+			} else {
+				recordSkippedInvalidCandidateEpoch(ep.EpochId)
+			}
 			continue
 		}
 		boundary, err := ls.canonicalBlockBeforeSlot(nil, ep.StartSlot)
@@ -4646,16 +4693,6 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 			continue
 		}
 		if bytes.Equal(ep.LastEpochBlockNonce, boundary.Hash) {
-			continue
-		}
-		candidateNonce, err := ls.epochRepairCandidateNonce(*ep)
-		if err != nil {
-			ls.config.Logger.Warn(
-				"skipping epoch lab recovery; candidate nonce unavailable",
-				"epoch", ep.EpochId,
-				"error", err,
-				"component", "ledger",
-			)
 			continue
 		}
 		// Recompute this epoch's nonce before mutating the record; the lab and
@@ -4695,6 +4732,34 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 			"epoch", ep.EpochId,
 			"previous_nonce", hex.EncodeToString(previousNonce),
 			"epoch_nonce", hex.EncodeToString(newNonce),
+			"component", "ledger",
+		)
+	}
+	if skippedMithrilTrusted > 0 {
+		ls.config.Logger.Info(
+			"skipped epoch lab recovery for epochs covered by Mithril trust boundary",
+			"count", skippedMithrilTrusted,
+			"first_epoch", firstMithrilTrustedEpoch,
+			"last_epoch", lastMithrilTrustedEpoch,
+			"mithril_ledger_slot", ls.mithrilLedgerSlot,
+			"component", "ledger",
+		)
+	}
+	if skippedMissingCandidate > 0 {
+		ls.config.Logger.Info(
+			"skipped epoch lab recovery for epochs without stored candidate nonce",
+			"count", skippedMissingCandidate,
+			"first_epoch", firstMissingCandidateEpoch,
+			"last_epoch", lastMissingCandidateEpoch,
+			"component", "ledger",
+		)
+	}
+	if skippedInvalidCandidate > 0 {
+		ls.config.Logger.Warn(
+			"skipped epoch lab recovery for epochs with invalid candidate nonce",
+			"count", skippedInvalidCandidate,
+			"first_epoch", firstInvalidCandidateEpoch,
+			"last_epoch", lastInvalidCandidateEpoch,
 			"component", "ledger",
 		)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves LAB and epoch nonce for epochs covered by the Mithril trust boundary to avoid unintended overwrites during healing. Also improves safety and logging when candidate nonces are missing or invalid.

- **Bug Fixes**
  - Skip LAB recovery for epochs at or before `mithrilLedgerSlot` when a LAB is present.
  - Check candidate nonce before boundary lookup; if missing/invalid, skip without mutating.
  - Add summary logs for repaired and skipped epochs (Mithril-covered, missing candidate, invalid candidate).
  - Add tests for missing-candidate skip and Mithril-covered preservation.

<sup>Written for commit c5f5f3cd2c538c9cb6be35e3a2e539a1b70d59f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

