### PR TITLE
fix(ledger): reject recovery below mithril boundary

### DIFF
--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
@@ -182,7 +183,7 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		"rollback_slot", candidate.RollbackPoint.Slot,
 		"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
 	)
-	if ls.replayRecoveryRollbackExceedsMithrilBoundary(candidate.RollbackPoint) {
+	if ls.recoveryRollbackExceedsMithrilBoundary(candidate.RollbackPoint) {
 		if err := ls.rejectReplayRecoveryAtMithrilBoundary(
 			validationErr,
 			candidate,
@@ -201,7 +202,7 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 	return true, nil
 }
 
-func (ls *LedgerState) replayRecoveryRollbackExceedsMithrilBoundary(
+func (ls *LedgerState) recoveryRollbackExceedsMithrilBoundary(
 	point ocommon.Point,
 ) bool {
 	ls.RLock()
@@ -214,62 +215,26 @@ func (ls *LedgerState) rejectReplayRecoveryAtMithrilBoundary(
 	candidate *replayRecoveryCandidate,
 	producerTxHash string,
 ) error {
-	ls.RLock()
-	mithrilLedgerSlot := ls.mithrilLedgerSlot
-	rewindPoint := ls.currentTip.Point
-	ls.RUnlock()
-	if ls.config.ChainManager == nil {
-		return fmt.Errorf(
-			"replay recovery rollback exceeds Mithril trust boundary: %w",
-			ErrRollbackExceedsMithrilBoundary,
-		)
-	}
-	ls.config.Logger.Warn(
-		"detected replay recovery below Mithril trust boundary, rejecting peer chain",
-		"component", "ledger",
-		"recovery_strategy", candidate.Strategy,
-		"tx_hash", hex.EncodeToString(validationErr.TxHash),
-		"failing_block_slot", validationErr.BlockPoint.Slot,
-		"missing_input", candidate.Input.String(),
-		"producer_tx_hash", producerTxHash,
-		"producer_block_slot", candidate.ProducerBlock.Slot,
-		"rollback_slot", candidate.RollbackPoint.Slot,
-		"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
-		"mithril_ledger_slot", mithrilLedgerSlot,
-		"rewind_target_slot", rewindPoint.Slot,
-		"rewind_target_hash", hex.EncodeToString(rewindPoint.Hash),
+	return ls.rejectRecoveryAtMithrilBoundary(
+		"replay recovery rollback exceeds Mithril trust boundary",
+		func(mithrilLedgerSlot uint64, rewindPoint ocommon.Point) {
+			ls.config.Logger.Warn(
+				"detected replay recovery below Mithril trust boundary, rejecting peer chain",
+				"component", "ledger",
+				"recovery_strategy", candidate.Strategy,
+				"tx_hash", hex.EncodeToString(validationErr.TxHash),
+				"failing_block_slot", validationErr.BlockPoint.Slot,
+				"missing_input", candidate.Input.String(),
+				"producer_tx_hash", producerTxHash,
+				"producer_block_slot", candidate.ProducerBlock.Slot,
+				"rollback_slot", candidate.RollbackPoint.Slot,
+				"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
+				"mithril_ledger_slot", mithrilLedgerSlot,
+				"rewind_target_slot", rewindPoint.Slot,
+				"rewind_target_hash", hex.EncodeToString(rewindPoint.Hash),
+			)
+		},
 	)
-	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(rewindPoint); err != nil {
-		return fmt.Errorf(
-			"rewind primary chain to Mithril trust boundary: %w",
-			err,
-		)
-	}
-	ls.chainsyncMutex.Lock()
-	ls.resetChainsyncResyncState()
-	ls.setChainsyncState(SyncingChainsyncState)
-	ls.chainsyncMutex.Unlock()
-	if ls.config.EventBus != nil {
-		var activeConnId ouroboros.ConnectionId
-		if ls.config.GetActiveConnectionFunc != nil {
-			if connId := ls.config.GetActiveConnectionFunc(); connId != nil {
-				activeConnId = *connId
-			}
-		}
-		ls.config.EventBus.Publish(
-			event.ChainsyncResyncEventType,
-			event.NewEvent(
-				event.ChainsyncResyncEventType,
-				event.ChainsyncResyncEvent{
-					ConnectionId: activeConnId,
-					Reason: event.
-						ChainsyncResyncReasonRollbackExceedsMithril,
-					Point: rewindPoint,
-				},
-			),
-		)
-	}
-	return nil
 }
 
 func (ls *LedgerState) recoverAtTipFromTxValidationError(
@@ -335,6 +300,18 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 			}
 		}
 	}
+	if ls.recoveryRollbackExceedsMithrilBoundary(rewindPoint) {
+		if err := ls.rejectAtTipRecoveryAtMithrilBoundary(
+			validationErr,
+			ledgerTip,
+			chainTip,
+			rewindPoint,
+			attempts,
+		); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	ls.config.Logger.Warn(
 		"validation failure after reaching tip, rewinding primary chain",
 		"component", "ledger",
@@ -384,6 +361,86 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		)
 	}
 	return true, nil
+}
+
+func (ls *LedgerState) rejectAtTipRecoveryAtMithrilBoundary(
+	validationErr *txValidationError,
+	ledgerTip ochainsync.Tip,
+	chainTip ochainsync.Tip,
+	requestedRewindPoint ocommon.Point,
+	attempts int,
+) error {
+	return ls.rejectRecoveryAtMithrilBoundary(
+		"at-tip recovery rollback exceeds Mithril trust boundary",
+		func(mithrilLedgerSlot uint64, rewindPoint ocommon.Point) {
+			ls.config.Logger.Warn(
+				"at-tip validation recovery would cross Mithril trust boundary, rejecting peer chain",
+				"component", "ledger",
+				"tx_hash", hex.EncodeToString(validationErr.TxHash),
+				"failing_block_slot", validationErr.BlockPoint.Slot,
+				"failing_block_hash", hex.EncodeToString(validationErr.BlockPoint.Hash),
+				"ledger_tip_slot", ledgerTip.Point.Slot,
+				"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+				"primary_chain_tip_slot", chainTip.Point.Slot,
+				"primary_chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
+				"requested_rewind_slot", requestedRewindPoint.Slot,
+				"requested_rewind_hash", hex.EncodeToString(requestedRewindPoint.Hash),
+				"mithril_ledger_slot", mithrilLedgerSlot,
+				"rewind_target_slot", rewindPoint.Slot,
+				"rewind_target_hash", hex.EncodeToString(rewindPoint.Hash),
+				"attempt", attempts,
+			)
+		},
+	)
+}
+
+func (ls *LedgerState) rejectRecoveryAtMithrilBoundary(
+	errContext string,
+	logRejection func(mithrilLedgerSlot uint64, rewindPoint ocommon.Point),
+) error {
+	ls.RLock()
+	mithrilLedgerSlot := ls.mithrilLedgerSlot
+	rewindPoint := ls.currentTip.Point
+	ls.RUnlock()
+	if ls.config.ChainManager == nil {
+		return fmt.Errorf(
+			"%s: %w",
+			errContext,
+			ErrRollbackExceedsMithrilBoundary,
+		)
+	}
+	logRejection(mithrilLedgerSlot, rewindPoint)
+	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(rewindPoint); err != nil {
+		return fmt.Errorf(
+			"rewind primary chain to Mithril trust boundary: %w",
+			err,
+		)
+	}
+	ls.chainsyncMutex.Lock()
+	ls.resetChainsyncResyncState()
+	ls.setChainsyncState(SyncingChainsyncState)
+	ls.chainsyncMutex.Unlock()
+	if ls.config.EventBus != nil {
+		var activeConnId ouroboros.ConnectionId
+		if ls.config.GetActiveConnectionFunc != nil {
+			if connId := ls.config.GetActiveConnectionFunc(); connId != nil {
+				activeConnId = *connId
+			}
+		}
+		ls.config.EventBus.Publish(
+			event.ChainsyncResyncEventType,
+			event.NewEvent(
+				event.ChainsyncResyncEventType,
+				event.ChainsyncResyncEvent{
+					ConnectionId: activeConnId,
+					Reason: event.
+						ChainsyncResyncReasonRollbackExceedsMithril,
+					Point: rewindPoint,
+				},
+			),
+		)
+	}
+	return nil
 }
 
 // findRewindPoint returns the highest committed chain point at or

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -549,6 +549,147 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 	)
 }
 
+func TestTryRecoverFromTxValidationErrorAtTipRejectsRewindBelowMithrilBoundary(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("at-tip-mithril-parent", 100, 1, nil)
+	ledgerTipBlock := testRawBlock(
+		"at-tip-mithril-ledger-tip",
+		60000,
+		2,
+		parentBlock.Hash,
+	)
+	failingBlock := testRawBlock(
+		"at-tip-mithril-failing",
+		60020,
+		3,
+		ledgerTipBlock.Hash,
+	)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{
+				parentBlock,
+				ledgerTipBlock,
+				failingBlock,
+			},
+		),
+	)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+	activeConnId := ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 3000,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.ParseIP("192.0.2.12"),
+			Port: 3001,
+		},
+	}
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		EventBus:          bus,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+			return &activeConnId
+		},
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	ledgerTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(ledgerTipBlock.Slot, ledgerTipBlock.Hash),
+		BlockNumber: ledgerTipBlock.BlockNumber,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+	ls.currentTip = ledgerTip
+	ls.currentTipBlockNonce = []byte("nonce-ledger-tip")
+	ls.mithrilLedgerSlot = ledgerTip.Point.Slot
+	ls.reachedTip = true
+
+	validationErr := &txValidationError{
+		BlockPoint: ocommon.NewPoint(
+			failingBlock.Slot,
+			failingBlock.Hash,
+		),
+		TxHash: testHashBytes("failing-live-mithril-tx"),
+		Inputs: []lcommon.TransactionInput{
+			&replayRecoveryInput{
+				txId:  testHashBytes("producer-live-mithril-tx"),
+				index: 0,
+			},
+		},
+		Cause: errors.New("bad input"),
+	}
+	ls.lastAtTipRecovery = newAtTipRecoveryAttempt(validationErr)
+	ls.lastAtTipRecovery.Attempts = 1
+
+	recovered, err := ls.tryRecoverFromTxValidationError(validationErr)
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	assert.Equal(t, ledgerTip, ls.currentTip)
+	assert.Equal(t, ledgerTip, ls.chain.Tip())
+	dbTip, err := ls.db.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, ledgerTip, dbTip)
+	_, err = database.BlockByPoint(
+		db,
+		ocommon.NewPoint(failingBlock.Slot, failingBlock.Hash),
+	)
+	assert.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	resync := testutil.RequireReceive(
+		t,
+		resyncCh,
+		time.Second,
+		"expected Mithril boundary resync after at-tip recovery rejection",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonRollbackExceedsMithril,
+		resync.Reason,
+	)
+	assert.Equal(t, activeConnId.String(), resync.ConnectionId.String())
+	assert.Equal(t, ledgerTip.Point, resync.Point)
+	require.NotNil(t, ls.lastAtTipRecovery)
+	assert.Equal(t, 2, ls.lastAtTipRecovery.Attempts)
+}
+
 func TestTryRecoverFromTxValidationErrorFallsBackToTxBlobOffsets(
 	t *testing.T,
 ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reject at-tip replay recovery if it would roll back past the Mithril trust boundary. When this happens, keep the ledger at the current tip and trigger a ChainSync resync instead of rewinding.

- **Bug Fixes**
  - Added a boundary check during at-tip tx validation recovery; if `rewindPoint` is below `mithrilLedgerSlot`, reject recovery, rewind the primary chain to the current tip via `RewindPrimaryChainToPoint`, reset ChainSync to Syncing, and publish `ChainsyncResync` with reason `RollbackExceedsMithril`.
  - Added test `TestTryRecoverFromTxValidationErrorAtTipRejectsRewindBelowMithrilBoundary`.

<sup>Written for commit 731b4b924e02ab913c3146882cf9737687d3b36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

