### PR TITLE
fix(mithril): isolate pooled archive download connections

### DIFF
--- a/mithril/download.go
+++ b/mithril/download.go
@@ -17,6 +17,7 @@ package mithril
 import (
 	"archive/tar"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -364,6 +365,22 @@ func newPooledDownloadTransport(maxConns int) *http.Transport {
 	transport.MaxIdleConnsPerHost = maxConns
 	transport.MaxConnsPerHost = maxConns
 	transport.IdleConnTimeout = 90 * time.Second
+	// The immutable archive pool intentionally uses one HTTP/1.1
+	// connection per worker. HTTP/2 multiplexes every worker through the
+	// same TLS connection for Google Cloud Storage; after an idle stream
+	// timeout, retries can be routed back onto that poisoned connection and
+	// stall in lock-step. Keeping pooled downloads on separate HTTP/1.1
+	// connections preserves keep-alive without sharing stream fate.
+	transport.ForceAttemptHTTP2 = false
+	transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+	if transport.TLSClientConfig != nil {
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	} else {
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+	transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
 	return transport
 }
 

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -82,6 +82,20 @@ func TestDownloadSnapshot(t *testing.T) {
 	require.Equal(t, content, data)
 }
 
+func TestNewPooledDownloadTransportUsesHTTP1Connections(t *testing.T) {
+	transport := newPooledDownloadTransport(4)
+
+	require.False(t, transport.DisableKeepAlives)
+	require.False(t, transport.ForceAttemptHTTP2)
+	require.NotNil(t, transport.TLSNextProto)
+	require.Empty(t, transport.TLSNextProto)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.Equal(t, []string{"http/1.1"}, transport.TLSClientConfig.NextProtos)
+	require.Equal(t, 8, transport.MaxIdleConns)
+	require.Equal(t, 4, transport.MaxIdleConnsPerHost)
+	require.Equal(t, 4, transport.MaxConnsPerHost)
+}
+
 func TestDownloadSnapshotResume(t *testing.T) {
 	// Full content: "AAABBB"
 	fullContent := []byte("AAABBB")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Isolates pooled archive downloads in `mithril` by forcing per-worker HTTP/1.1 connections to avoid HTTP/2 multiplexing stalls with Google Cloud Storage. Adds a test to lock in the transport behavior.

- **Bug Fixes**
  - Enforce dedicated HTTP/1.1 connections for pooled downloads (`ForceAttemptHTTP2=false`, empty `TLSNextProto`, `TLSClientConfig.NextProtos=["http/1.1"]`, min TLS 1.2); keep keep-alive and connection limits.
  - Add test to verify HTTP/1.1 usage and transport limits.

<sup>Written for commit 7b4751b773c7159c324c3631c72176e2807a6f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

