### PR TITLE
fix(database): Make validation that consumed UTxO exists configurable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1424,6 +1424,18 @@ still demands a rollback below it is rejected as genuinely divergent. Both
 classifications close the connection for a fresh intersect and deny the peer for
 a cooldown via peer governance.
 
+The same `mithril_ledger_slot` boundary gates how the database layer reacts to a
+consumed UTxO it cannot find or reconstruct from the blob store. By default
+(`StrictUtxoValidation: false`) `ensureTransactionConsumedUtxos` silently skips an
+unrecoverable input, which is expected when bootstrapping from a non-genesis
+chainsync intersect point without a Mithril snapshot import (pre-intersect UTxOs
+are never imported). With `StrictUtxoValidation: true`, a miss for a block past
+the recorded boundary — where the node should hold complete producer history —
+is treated as corruption or a bug and fails the ingest instead. Gap-block
+ingestion (`ensureGapConsumedUtxos`, used while closing the range between the
+snapshot and the chain tip) is unconditionally strict already, since that range
+is always expected to be fully recoverable from the snapshot import.
+
 In API storage mode, the SQLite metadata plugin can defer selected query indexes
 during bulk load. Deferred indexes are classified as critical or lazy in
 `database/plugin/metadata/deferred`: critical indexes cover startup API queries

--- a/config.go
+++ b/config.go
@@ -145,6 +145,7 @@ type Config struct {
 	intersectTip             bool
 	peerSharing              bool
 	validateHistorical       bool
+	strictUtxoValidation     bool
 	tracing                  bool
 	tracingStdout            bool
 	runMode                  string
@@ -705,6 +706,15 @@ func WithStartEra(startEra string) ConfigOptionFunc {
 func WithValidateHistorical(validate bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.validateHistorical = validate
+	}
+}
+
+// WithStrictUtxoValidation specifies whether an unrecoverable consumed UTxO
+// past the recorded Mithril sync boundary is a hard error rather than a
+// silently skipped condition. See database.Config.StrictUtxoValidation.
+func WithStrictUtxoValidation(strict bool) ConfigOptionFunc {
+	return func(c *Config) {
+		c.strictUtxoValidation = strict
 	}
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -47,6 +47,16 @@ type Config struct {
 	StorageMode    string // "core" or "api"
 	Network        string // Cardano network name (e.g. "preview", "mainnet")
 	CacheConfig    CborCacheConfig
+	// StrictUtxoValidation, when true, turns an unrecoverable consumed UTxO
+	// (not present in the metadata store and not reconstructable from the
+	// blob store) into a hard error for blocks past the recorded Mithril
+	// trust boundary (the "mithril_ledger_slot" sync state key), instead of
+	// silently skipping it. Past that boundary the node should have complete
+	// producer history, so a miss indicates real corruption or a bug rather
+	// than an expected gap. Leave disabled (the default) when bootstrapping
+	// from a non-genesis chainsync intersect point without a Mithril
+	// snapshot import, where pre-intersect UTxOs are legitimately absent.
+	StrictUtxoValidation bool
 }
 
 // Database represents our data storage services

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -38,14 +38,32 @@ const mithrilLedgerSlotSyncKey = "mithril_ledger_slot"
 
 // mithrilTrustBoundarySlot returns the recorded Mithril trust boundary slot,
 // or 0 if none is recorded (genesis sync, or a non-genesis chainsync
-// intersect point with no snapshot import).
+// intersect point with no snapshot import). A failure to read the sync
+// state is logged and also treated as 0 (the caller cannot distinguish it
+// from "no boundary recorded" by return value alone), but the log lets an
+// operator tell a transient storage problem apart from a genuinely
+// unrecoverable UTxO when StrictUtxoValidation turns the latter into an
+// ingest error.
 func (d *Database) mithrilTrustBoundarySlot(txn *Txn) uint64 {
 	val, err := d.GetSyncState(mithrilLedgerSlotSyncKey, txn)
-	if err != nil || val == "" {
+	if err != nil {
+		d.logger.Warn(
+			"failed to read Mithril trust boundary from sync state; "+
+				"treating consumed-utxo recovery failures as past the boundary",
+			"error", err,
+		)
+		return 0
+	}
+	if val == "" {
 		return 0
 	}
 	slot, err := strconv.ParseUint(val, 10, 64)
 	if err != nil {
+		d.logger.Warn(
+			"malformed mithril_ledger_slot sync state value, ignoring",
+			"value", val,
+			"error", err,
+		)
 		return 0
 	}
 	return slot

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -27,6 +28,28 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
+
+// mithrilLedgerSlotSyncKey mirrors the sync-state key written by the ledger
+// and mithril packages when a Mithril snapshot is imported: blocks at or
+// below this slot are Mithril-verified, so the node is not expected to have
+// complete pre-boundary UTxO history. Duplicated here (rather than imported)
+// because the database package cannot depend on ledger, which depends on it.
+const mithrilLedgerSlotSyncKey = "mithril_ledger_slot"
+
+// mithrilTrustBoundarySlot returns the recorded Mithril trust boundary slot,
+// or 0 if none is recorded (genesis sync, or a non-genesis chainsync
+// intersect point with no snapshot import).
+func (d *Database) mithrilTrustBoundarySlot(txn *Txn) uint64 {
+	val, err := d.GetSyncState(mithrilLedgerSlotSyncKey, txn)
+	if err != nil || val == "" {
+		return 0
+	}
+	slot, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return slot
+}
 
 func ledgerHashBytes(hash lcommon.Blake2b256) []byte {
 	return hash[:]
@@ -370,6 +393,21 @@ func (d *Database) ensureTransactionConsumedUtxos(
 			txn,
 		)
 		if err != nil {
+			// Past the Mithril trust boundary the node should have complete
+			// producer history for every input it is asked to spend, so an
+			// unrecoverable UTxO there indicates real corruption or a bug
+			// rather than an expected gap. Below the boundary (or when none
+			// is recorded and we did not sync from genesis) the UTxO may
+			// legitimately predate the data we imported.
+			if d.config.StrictUtxoValidation &&
+				point.Slot > d.mithrilTrustBoundarySlot(txn) {
+				return fmt.Errorf(
+					"consumed utxo %s not found at slot %d and could not be recovered: %w",
+					input.String(),
+					point.Slot,
+					err,
+				)
+			}
 			d.logger.Debug(
 				"skipping unrecoverable transaction input utxo repair",
 				"input",

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -452,3 +452,75 @@ func TestSetTransactionRecoveryPopulatesProducerFK(t *testing.T) {
 		)
 	}
 }
+
+// TestEnsureTransactionConsumedUtxosStrictValidation covers issue #396:
+// when a consumed UTxO cannot be recovered from either the metadata store
+// or the blob store, StrictUtxoValidation controls whether that is a hard
+// error or a silently skipped condition, gated by the recorded Mithril
+// trust boundary (blocks past the boundary should have complete producer
+// history; blocks at or below it legitimately may not).
+func TestEnsureTransactionConsumedUtxosStrictValidation(t *testing.T) {
+	// Intentionally not t.Parallel(): database.New() writes to plugin
+	// option destination pointers via SetPluginOption, which the race
+	// detector flags when two tests build a Database concurrently.
+	candidate := findGapConsumeCandidateWithoutCertificates(t)
+
+	newTestDB := func(t *testing.T, strict bool) *Database {
+		t.Helper()
+		db, err := New(&Config{
+			DataDir:              t.TempDir(),
+			Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+			BlobPlugin:           "badger",
+			MetadataPlugin:       "sqlite",
+			StrictUtxoValidation: strict,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+		// Intentionally do NOT persist candidate.producers, so the
+		// consumer's inputs exist in neither the metadata store nor the
+		// blob store and recovery is guaranteed to fail.
+		storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+		return db
+	}
+
+	setTransaction := func(t *testing.T, db *Database) error {
+		t.Helper()
+		return db.SetTransaction(
+			candidate.consumerTx,
+			candidate.consumerPoint,
+			0,
+			0,
+			nil,
+			nil,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			nil,
+		)
+	}
+
+	t.Run("disabled preserves silent skip", func(t *testing.T) {
+		db := newTestDB(t, false)
+		require.NoError(t, setTransaction(t, db))
+	})
+
+	t.Run("enabled errors past an unset boundary", func(t *testing.T) {
+		db := newTestDB(t, true)
+		// No mithril_ledger_slot recorded (0): every slot above it is
+		// past the boundary, so the missing input must be a hard error.
+		err := setTransaction(t, db)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUtxoNotFound)
+	})
+
+	t.Run("enabled skips at or below the recorded boundary", func(t *testing.T) {
+		db := newTestDB(t, true)
+		require.NoError(
+			t,
+			db.SetSyncState(
+				mithrilLedgerSlotSyncKey,
+				fmt.Sprintf("%d", candidate.consumerPoint.Slot),
+				nil,
+			),
+		)
+		require.NoError(t, setTransaction(t, db))
+	})
+}

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -360,6 +360,16 @@ immutableDbPath: ""
 # Validate historical blocks during ledger processing (default: false)
 validateHistorical: false
 
+# Error out (instead of silently skipping) when a consumed UTxO cannot be
+# found or recovered for a block past the recorded Mithril sync boundary.
+# Leave disabled when bootstrapping from a non-genesis chainsync intersect
+# point without a Mithril snapshot import, where pre-intersect UTxOs are
+# legitimately absent. (default: false)
+#
+# Can be overridden with the DINGO_STRICT_UTXO_VALIDATION environment variable
+# CLI: --strict-utxo-validation
+strictUtxoValidation: false
+
 # Peer targets - target number of peers in each state
 # These are goals the system works toward, not hard limits.
 # Use 0 for default values, -1 for unlimited

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -366,7 +366,7 @@ validateHistorical: false
 # point without a Mithril snapshot import, where pre-intersect UTxOs are
 # legitimately absent. (default: false)
 #
-# Can be overridden with the DINGO_STRICT_UTXO_VALIDATION environment variable
+# Can be overridden with the CARDANO_STRICT_UTXO_VALIDATION environment variable
 # CLI: --strict-utxo-validation
 strictUtxoValidation: false
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,6 +382,11 @@ type Config struct {
 	DebugPort            uint     `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
 	IntersectTip         bool     `yaml:"intersectTip"                                                     split_words:"true"`
 	ValidateHistorical   bool     `yaml:"validateHistorical"                                               split_words:"true"`
+	// StrictUtxoValidation errors out (instead of silently skipping) when a
+	// consumed UTxO cannot be found or recovered for a block past the
+	// recorded Mithril sync boundary. Leave disabled when bootstrapping from
+	// a non-genesis chainsync intersect point without a Mithril snapshot.
+	StrictUtxoValidation bool `yaml:"strictUtxoValidation" split_words:"true"`
 	// Tracing enables OpenTelemetry tracing. Disabled by default: with no
 	// collector listening, the OTLP exporter logs noisy connection errors.
 	// Spans are sent via OTLP HTTP; configure the destination with the
@@ -712,6 +717,7 @@ var globalConfig = &Config{
 	SocketPath:           "dingo.socket",
 	IntersectTip:         false,
 	ValidateHistorical:   false,
+	StrictUtxoValidation: false,
 	Tracing:              false,
 	TracingStdout:        false,
 	Network:              "preview",

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -61,6 +61,7 @@ var flagSpecs = []flagSpec{
 	stringFlag("ImmutableDbPath", "immutable-db-path", "", "path to ImmutableDB for load mode"),
 	boolFlag("IntersectTip", "intersect-tip", "start from current tip"),
 	boolFlag("ValidateHistorical", "validate-historical", "validate historical blocks"),
+	boolFlag("StrictUtxoValidation", "strict-utxo-validation", "error instead of skipping when a consumed UTxO past the Mithril sync boundary cannot be found or recovered"),
 	boolFlag("Tracing", "tracing", "enable OpenTelemetry tracing (configure destination with OTEL_EXPORTER_OTLP_* env vars)"),
 	boolFlag("TracingStdout", "tracing-stdout", "export traces to stdout instead of OTLP (requires --tracing; for debugging)"),
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -365,6 +365,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				PermissionedCandidatePolicy: cfg.Midnight.PermissionedCandidatePolicy,
 			}),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
+			dingo.WithStrictUtxoValidation(cfg.StrictUtxoValidation),
 			dingo.WithRunMode(string(cfg.RunMode)),
 			dingo.WithStartEra(string(cfg.StartEra)),
 			dingo.WithShutdownTimeout(shutdownTimeout),

--- a/node.go
+++ b/node.go
@@ -157,15 +157,16 @@ func (n *Node) Run(ctx context.Context) error {
 	// Load database
 	dbNeedsRecovery := false
 	dbConfig := &database.Config{
-		DataDir:        n.config.dataDir,
-		Logger:         n.config.logger,
-		PromRegistry:   n.config.promRegistry,
-		BlobPlugin:     n.config.blobPlugin,
-		RunMode:        n.config.runMode,
-		MetadataPlugin: n.config.metadataPlugin,
-		MaxConnections: n.config.DatabaseWorkerPoolConfig.WorkerPoolSize,
-		StorageMode:    string(n.config.storageMode),
-		Network:        n.config.network,
+		DataDir:              n.config.dataDir,
+		Logger:               n.config.logger,
+		PromRegistry:         n.config.promRegistry,
+		BlobPlugin:           n.config.blobPlugin,
+		RunMode:              n.config.runMode,
+		MetadataPlugin:       n.config.metadataPlugin,
+		MaxConnections:       n.config.DatabaseWorkerPoolConfig.WorkerPoolSize,
+		StorageMode:          string(n.config.storageMode),
+		Network:              n.config.network,
+		StrictUtxoValidation: n.config.strictUtxoValidation,
 		CacheConfig: database.CborCacheConfig{
 			BlockLRUEntries: n.config.cacheBlockLRUEntries,
 			HotUtxoEntries:  n.config.cacheHotUtxoEntries,


### PR DESCRIPTION
Closes #396 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable strict validation for consumed UTxOs. When enabled, ingestion errors if a consumed UTxO past the Mithril trust boundary cannot be found or reconstructed; if no boundary is recorded, strict mode treats it as 0 and errors for post-genesis slots. Default stays non‑strict for safe bootstrap.

- **New Features**
  - Adds `StrictUtxoValidation` to database and app config; set via `strictUtxoValidation` in YAML, `CARDANO_STRICT_UTXO_VALIDATION`, `--strict-utxo-validation`, or `dingo.WithStrictUtxoValidation`.
  - `ensureTransactionConsumedUtxos` now errors on unrecoverable inputs past the `mithril_ledger_slot` boundary when strict mode is on; missing/invalid boundary is treated as 0. Docs clarify gap-block ingestion is already strict.
  - Tests updated to cover strict vs non-strict behavior and boundary handling.

- **Migration**
  - No change by default. Enable strict mode after a Mithril snapshot import or when syncing from genesis; keep it off during non-genesis bootstrap.

<sup>Written for commit 17c99aa9cd033e0293f4a01b07ad0f4afcb9d730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new strict UTXO validation setting to control whether unrecoverable consumed inputs should fail ingestion or be skipped.
  * Exposed the setting through configuration, environment variables, and a CLI flag.

* **Bug Fixes**
  * Improved handling of missing consumed UTXOs around the Mithril sync boundary.
  * Made gap-block processing consistently strict when recovery is expected.

* **Tests**
  * Added coverage for strict vs. non-strict validation behavior under different sync-state conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->