### PR TITLE
fix(ledger): Improve support for chain block number query

### DIFF
--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -86,13 +86,14 @@ func (ls *LedgerState) querySystemStart() (any, error) {
 
 func (ls *LedgerState) queryChainBlockNo() (any, error) {
 	ls.RLock()
+	point := ls.currentTip.Point
 	blockNumber := ls.currentTip.BlockNumber
 	ls.RUnlock()
-	ret := []any{
-		1, // TODO: figure out what this value is (#393)
-		blockNumber,
+	// WithOrigin BlockNo: [0] at genesis, [1, blockNo] once a block exists.
+	if len(point.Hash) == 0 {
+		return []any{0}, nil
 	}
-	return ret, nil
+	return []any{1, blockNumber}, nil
 }
 
 func (ls *LedgerState) queryChainPoint() (any, error) {

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -1620,3 +1620,42 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch_Contiguity(t *testing.T
 		babbageEndTime.String(), conwayStartTime.String(),
 	)
 }
+
+// TestQueryChainBlockNoAtGenesis verifies origin is encoded as WithOrigin [0].
+func TestQueryChainBlockNoAtGenesis(t *testing.T) {
+	ls := &LedgerState{}
+	result, err := ls.queryChainBlockNo()
+	assert.NoError(t, err)
+	// WithOrigin at genesis: [0]
+	assert.Equal(t, []any{0}, result)
+}
+
+// TestQueryChainBlockNoAtBlock verifies a non-origin tip is encoded as [1, blockNo].
+func TestQueryChainBlockNoAtBlock(t *testing.T) {
+	ls := &LedgerState{}
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.Point{
+			Hash: []byte("tip-hash"),
+		},
+		BlockNumber: 12345,
+	}
+	result, err := ls.queryChainBlockNo()
+	assert.NoError(t, err)
+	// WithOrigin at block: [1, blockNo]
+	assert.Equal(t, []any{1, uint64(12345)}, result)
+}
+
+// TestQueryChainBlockNoAtFirstBlock verifies BlockNo 0 is not treated as origin.
+func TestQueryChainBlockNoAtFirstBlock(t *testing.T) {
+	ls := &LedgerState{}
+	ls.currentTip = ochainsync.Tip{
+		Point: ocommon.Point{
+			Hash: []byte("first-block-hash"),
+		},
+		BlockNumber: 0,
+	}
+	result, err := ls.queryChainBlockNo()
+	assert.NoError(t, err)
+	// Cardano block numbers are 0-indexed, so block 0 is not origin.
+	assert.Equal(t, []any{1, uint64(0)}, result)
+}


### PR DESCRIPTION
1. Fixed `queryChainBlockNo` to encode WithOrigin BlockNo correctly: `[0]` at origin and `[1, blockNo]` for real chain tips.
2. Made changes to detect origin from the tip point hash instead of `BlockNumber == 0`, since Cardano’s first real block is block 0.
3. Added tests for origin, normal block tips, and the first-block `BlockNumber == 0` edge case.

Closes #393 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly encodes `WithOrigin` for chain block numbers: `[0]` at genesis and `[1, blockNo]` for real tips. Origin is now detected by an empty tip hash (not `BlockNumber == 0`). Closes #393.

- **Bug Fixes**
  - Update `queryChainBlockNo` to return `[0]` at genesis and `[1, blockNo]` otherwise.
  - Determine origin from an empty tip hash to avoid misclassifying block 0.
  - Add tests for genesis, non-origin tips, and the block 0 edge case.

<sup>Written for commit a46ceed34e703523124cd87e8ee45522c4728eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly encodes chain tip information for both genesis and later blocks, ensuring the first block is no longer mistaken for the chain origin.
  * Returns the expected origin format for empty-chain and non-empty-chain states.

* **Tests**
  * Added coverage for genesis, regular block heights, and block zero to verify the encoded output stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->