### PR TITLE
fix(consensus): validate header VRF key against pool registration and block number continuity

### DIFF
--- a/chain/block_number_validation_test.go
+++ b/chain/block_number_validation_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// TestBlockNumberContiguous covers the block-number continuity rule that binds a
+// header's self-reported block number to its parent, preventing a forged
+// (inflated) number from entering the chain and winning chain selection.
+func TestBlockNumberContiguous(t *testing.T) {
+	const parent = uint64(100)
+	tests := []struct {
+		name    string
+		eraId   uint8
+		number  uint64
+		wantOK  bool
+	}{
+		{"shelley parent+1 ok", shelley.EraIdShelley, parent + 1, true},
+		{"shelley same as parent rejected", shelley.EraIdShelley, parent, false},
+		{"shelley inflated rejected", shelley.EraIdShelley, parent + 1_000_000, false},
+		{"shelley below parent rejected", shelley.EraIdShelley, parent - 1, false},
+		{"shelley zero rejected", shelley.EraIdShelley, 0, false},
+		{"byron parent+1 ok (normal block)", byron.EraIdByron, parent + 1, true},
+		{"byron same as parent ok (EBB)", byron.EraIdByron, parent, true},
+		{"byron inflated rejected", byron.EraIdByron, parent + 1_000_000, false},
+		{"byron below parent rejected", byron.EraIdByron, parent - 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blockNumberContiguous(tt.eraId, tt.number, parent)
+			if got != tt.wantOK {
+				t.Fatalf(
+					"blockNumberContiguous(era=%d, number=%d, parent=%d) = %v, want %v",
+					tt.eraId, tt.number, parent, got, tt.wantOK,
+				)
+			}
+		})
+	}
+}

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -83,6 +84,21 @@ func (c *Chain) HeaderTip() ochainsync.Tip {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	return c.headerTip()
+}
+
+// blockNumberContiguous reports whether a block number legitimately follows its
+// parent's. Shelley-era and later increment by exactly one per block. Byron
+// epoch-boundary blocks reuse the parent's block number (they do not increment),
+// so in the Byron era both parentNumber and parentNumber+1 are valid. Any other
+// value (notably an inflated one) is non-contiguous and rejected.
+func blockNumberContiguous(eraId uint8, blockNumber, parentNumber uint64) bool {
+	if blockNumber == parentNumber+1 {
+		return true
+	}
+	if eraId == byron.EraIdByron && blockNumber == parentNumber {
+		return true
+	}
+	return false
 }
 
 func (c *Chain) headerTip() ochainsync.Tip {
@@ -146,6 +162,24 @@ func (c *Chain) AddBlockHeader(header ledger.BlockHeader) error {
 				headerHash.String(),
 				headerPrevHash.String(),
 				hex.EncodeToString(headerTip.Point.Hash),
+			)
+		}
+		// Bind the header's self-reported block number to the parent's. The
+		// header chains onto the tip (prev hash matched above), so its block
+		// number must be contiguous: exactly parent+1 for Shelley-era and
+		// later. Byron epoch-boundary blocks reuse the parent's number, so in
+		// the Byron era both parent and parent+1 are accepted. Rejecting a
+		// non-contiguous number stops a forged (inflated) block number from
+		// entering the chain and winning chain selection's longest-chain rule.
+		if !blockNumberContiguous(
+			header.Era().Id,
+			queued.blockNumber,
+			headerTip.BlockNumber,
+		) {
+			return NewBlockNumberNotContiguousError(
+				headerHash.String(),
+				queued.blockNumber,
+				headerTip.BlockNumber,
 			)
 		}
 	}
@@ -261,6 +295,20 @@ func (c *Chain) addBlockLocked(
 				hex.EncodeToString(blockHashBytes),
 				hex.EncodeToString(blockPrevHashBytes),
 				hex.EncodeToString(c.currentTip.Point.Hash),
+			)
+		}
+		// Bind the block number to the parent's (defense in depth alongside the
+		// header-ingestion check): a block that fits on the tip must carry a
+		// contiguous number so a forged number cannot enter the chain.
+		if !blockNumberContiguous(
+			block.Era().Id,
+			blockNumber,
+			c.currentTip.BlockNumber,
+		) {
+			return event.Event{}, NewBlockNumberNotContiguousError(
+				hex.EncodeToString(blockHashBytes),
+				blockNumber,
+				c.currentTip.BlockNumber,
 			)
 		}
 	}

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -93,6 +93,45 @@ func (e BlockNotFitChainTipError) Error() string {
 	)
 }
 
+// BlockNumberNotContiguousError is returned when a block/header's self-reported
+// block number does not follow its parent's. The block number is a redundant
+// header field that chain selection uses to pick the longer chain, so it must
+// be bound to the actual chain length: a header that chains onto the tip
+// (matching prev hash) but claims a non-contiguous block number is rejected so
+// a forged (e.g. inflated) number cannot win chain selection.
+type BlockNumberNotContiguousError struct {
+	blockHash    string
+	blockNumber  uint64
+	parentNumber uint64
+}
+
+func NewBlockNumberNotContiguousError(
+	blockHash string,
+	blockNumber uint64,
+	parentNumber uint64,
+) BlockNumberNotContiguousError {
+	return BlockNumberNotContiguousError{
+		blockHash:    blockHash,
+		blockNumber:  blockNumber,
+		parentNumber: parentNumber,
+	}
+}
+
+func (e BlockNumberNotContiguousError) BlockHash() string   { return e.blockHash }
+func (e BlockNumberNotContiguousError) BlockNumber() uint64 { return e.blockNumber }
+func (e BlockNumberNotContiguousError) ParentNumber() uint64 {
+	return e.parentNumber
+}
+
+func (e BlockNumberNotContiguousError) Error() string {
+	return fmt.Sprintf(
+		"block %s claims block number %d that is not contiguous with parent %d",
+		e.blockHash,
+		e.blockNumber,
+		e.parentNumber,
+	)
+}
+
 type BlockNotMatchHeaderError struct {
 	blockHash  string
 	headerHash string

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -355,7 +355,7 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	header := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash),
 		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
-		blockNumber: fixture.currentTip.BlockNumber + 1,
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
 		slot:        fixture.currentTip.Point.Slot + 10,
 	}
 	err := fixture.ls.chain.AddBlockHeader(header)
@@ -370,12 +370,16 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 				header.Hash().Bytes(),
 			),
 			BlockHeader: header,
+			// The delivered header is the first block after the fork point and
+			// is contiguous with the common ancestor. The peer advertises a tip
+			// further ahead, so its chain is genuinely longer than ours and the
+			// fork is worth resolving.
 			Tip: ochainsync.Tip{
 				Point: ocommon.NewPoint(
-					header.SlotNumber(),
-					header.Hash().Bytes(),
+					header.SlotNumber()+10,
+					testHashBytes("fork-block-peer-tip-ahead"),
 				),
-				BlockNumber: header.BlockNumber(),
+				BlockNumber: header.BlockNumber() + 1,
 			},
 		},
 		notFitErr,
@@ -585,7 +589,7 @@ func TestTryResolveForkDoesNotAdvanceLaggingLedgerTip(t *testing.T) {
 	header := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash),
 		prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
-		blockNumber: fixture.currentTip.BlockNumber + 2,
+		blockNumber: fixture.currentTip.BlockNumber + 1,
 		slot:        fixture.currentTip.Point.Slot + 20,
 	}
 	err := fixture.ls.chain.AddBlockHeader(header)
@@ -600,12 +604,15 @@ func TestTryResolveForkDoesNotAdvanceLaggingLedgerTip(t *testing.T) {
 				header.Hash().Bytes(),
 			),
 			BlockHeader: header,
+			// The delivered header forks off the current block and is contiguous
+			// with it. The peer advertises a tip further ahead, so its chain is
+			// longer than the local raw chain tip and the fork resolves.
 			Tip: ochainsync.Tip{
 				Point: ocommon.NewPoint(
-					header.SlotNumber(),
-					header.Hash().Bytes(),
+					header.SlotNumber()+10,
+					testHashBytes("ahead-raw-chain-fork-peer-tip-ahead"),
 				),
-				BlockNumber: header.BlockNumber(),
+				BlockNumber: header.BlockNumber() + 1,
 			},
 		},
 		notFitErr,
@@ -643,19 +650,19 @@ func TestTryResolveForkQueuesKnownPeerForkSegment(t *testing.T) {
 	header1 := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash1),
 		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
-		blockNumber: fixture.currentTip.BlockNumber + 1,
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
 		slot:        fixture.currentTip.Point.Slot + 1,
 	}
 	header2 := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash2),
 		prevHash:    lcommon.NewBlake2b256(forkHash1),
-		blockNumber: fixture.currentTip.BlockNumber + 2,
+		blockNumber: fixture.ancestorTip.BlockNumber + 2,
 		slot:        fixture.currentTip.Point.Slot + 2,
 	}
 	header3 := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash3),
 		prevHash:    lcommon.NewBlake2b256(forkHash2),
-		blockNumber: fixture.currentTip.BlockNumber + 3,
+		blockNumber: fixture.ancestorTip.BlockNumber + 3,
 		slot:        fixture.currentTip.Point.Slot + 3,
 	}
 
@@ -709,19 +716,19 @@ func TestTryResolveForkUsesObservedPeerHistoryFallback(t *testing.T) {
 	header1 := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash1),
 		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
-		blockNumber: fixture.currentTip.BlockNumber + 1,
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
 		slot:        fixture.currentTip.Point.Slot + 1,
 	}
 	header2 := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash2),
 		prevHash:    lcommon.NewBlake2b256(forkHash1),
-		blockNumber: fixture.currentTip.BlockNumber + 2,
+		blockNumber: fixture.ancestorTip.BlockNumber + 2,
 		slot:        fixture.currentTip.Point.Slot + 2,
 	}
 	header3 := mockHeader{
 		hash:        lcommon.NewBlake2b256(forkHash3),
 		prevHash:    lcommon.NewBlake2b256(forkHash2),
-		blockNumber: fixture.currentTip.BlockNumber + 3,
+		blockNumber: fixture.ancestorTip.BlockNumber + 3,
 		slot:        fixture.currentTip.Point.Slot + 3,
 	}
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1121,15 +1121,11 @@ func (ls *LedgerState) PoolRegistrationVRFKeyHash(
 	if pool == nil {
 		return [32]byte{}, false, nil
 	}
-	if len(pool.Registration) > 0 &&
-		len(pool.Registration[0].VrfKeyHash) == 32 {
-		copy(vrfHash[:], pool.Registration[0].VrfKeyHash)
-		return vrfHash, true, nil
-	}
-	if len(pool.VrfKeyHash) != 32 {
+	registeredVrfHash, ok := registeredPoolVrfKeyHash(pool)
+	if !ok {
 		return [32]byte{}, false, nil
 	}
-	copy(vrfHash[:], pool.VrfKeyHash)
+	copy(vrfHash[:], registeredVrfHash[:])
 	return vrfHash, true, nil
 }
 

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -212,6 +212,14 @@ func (ls *LedgerState) verifyBlockHeaderCrypto(
 		return err
 	}
 
+	// Bind the header's VRF key to the pool's on-chain registered VRF key.
+	// The crypto path above verifies the VRF proof only against the key carried
+	// in the header (SkipStakePoolValidation skips gouroboros' registered-key
+	// check), so without this an attacker can grind VRF keys to win slots.
+	if err := ls.verifyRegisteredVrfKey(block); err != nil {
+		return err
+	}
+
 	return ls.verifyBlockLeaderEligibility(block, epoch.EpochId)
 }
 
@@ -440,6 +448,93 @@ func (ls *LedgerState) shouldUseImportedActivePoolDistribution(
 		)
 	}
 	return epochId == mithrilEpoch.EpochId, nil
+}
+
+// verifyRegisteredVrfKey rejects a block whose VRF verification key (carried in
+// the header body) is not the VRF key the producing pool registered on-chain.
+// The block's VRF proof is validated only against this embedded key, and the
+// leader-eligibility threshold uses its output, so binding it to the pool's
+// registered VRF key is what prevents an attacker from grinding VRF keys to
+// win slots. Mirrors gouroboros VerifyBlock's stake-pool VRF-key check, which
+// dingo's crypto path skips via SkipStakePoolValidation.
+func (ls *LedgerState) verifyRegisteredVrfKey(
+	block ledger.Block,
+) error {
+	// Byron (PBFT) blocks have no pool-registered VRF key.
+	if block.Era().Id == byron.EraIdByron {
+		return nil
+	}
+	issuerVkey := block.IssuerVkey()
+	poolKeyHash := lcommon.PoolKeyHash(issuerVkey.Hash())
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(block.Header())
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"extract VRF key: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	if !ok || len(vrfKey) == 0 {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"VRF key unavailable for registration check",
+			block.SlotNumber(),
+		)
+	}
+	pool, err := ls.db.GetPool(poolKeyHash, true, nil)
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"producer pool %x registration lookup failed: %w",
+			block.SlotNumber(),
+			poolKeyHash[:],
+			err,
+		)
+	}
+	registeredVrfKeyHash, ok := registeredPoolVrfKeyHash(pool)
+	if !ok {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"producer pool %x registered VRF key hash unavailable",
+			block.SlotNumber(),
+			poolKeyHash[:],
+		)
+	}
+	headerVrfKeyHash := lcommon.Blake2b256Hash(vrfKey)
+	if !bytes.Equal(registeredVrfKeyHash.Bytes(), headerVrfKeyHash.Bytes()) {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"producer pool %x VRF key does not match registered VRF key "+
+				"(header %x, registered %x)",
+			block.SlotNumber(),
+			poolKeyHash[:],
+			headerVrfKeyHash.Bytes(),
+			registeredVrfKeyHash.Bytes(),
+		)
+	}
+	return nil
+}
+
+func registeredPoolVrfKeyHash(
+	pool *models.Pool,
+) (lcommon.Blake2b256, bool) {
+	var vrfHash lcommon.Blake2b256
+	if pool == nil {
+		return vrfHash, false
+	}
+	if len(pool.Registration) == 0 {
+		return vrfHash, false
+	}
+	if len(pool.Registration[0].VrfKeyHash) == len(vrfHash) {
+		copy(vrfHash[:], pool.Registration[0].VrfKeyHash)
+		return vrfHash, true
+	}
+	if len(pool.VrfKeyHash) != len(vrfHash) {
+		return vrfHash, false
+	}
+	copy(vrfHash[:], pool.VrfKeyHash)
+	return vrfHash, true
 }
 
 func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -757,6 +757,19 @@ func TestVerifyBlockHeaderCrypto_EpochBoundaryUsesCorrectNonce(
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	seedPoolStakeSnapshot(t, db, 0, poolKeyHash[:], 1_000_000_000)
 
+	// Register the pool with the block's actual VRF key hash so the
+	// registered-VRF-key binding check accepts the block. Without this the
+	// block is rejected before the nonce-selection logic under test runs.
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(tb.block.Header())
+	require.NoError(t, err)
+	require.True(t, ok)
+	seedPoolRegistration(
+		t,
+		db,
+		poolKeyHash[:],
+		lcommon.Blake2b256Hash(vrfKey).Bytes(),
+	)
+
 	ls := &LedgerState{
 		db: db,
 		currentEpoch: models.Epoch{
@@ -958,6 +971,36 @@ func seedPoolStakeSnapshotOfType(
 			PoolKeyHash:      poolKeyHash,
 			TotalStake:       types.Uint64(totalStake),
 			StakeDenominator: types.Uint64(stakeDenominator),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+// seedPoolRegistration registers a pool so that db.GetPool(poolKeyHash)
+// returns a *models.Pool whose VrfKeyHash equals vrfKeyHash. It mirrors
+// seedPoolStakeSnapshot by persisting through the metadata store interface:
+// ImportPool upserts the Pool row (whose denormalized VrfKeyHash is what
+// verifyRegisteredVrfKey compares against) and creates a linked
+// PoolRegistration record, which GetPool requires before it treats the pool
+// as active. vrfKeyHash must be the 32-byte Blake2b256 of the block header's
+// VRF key bytes for verifyRegisteredVrfKey to accept the block.
+func seedPoolRegistration(
+	t *testing.T,
+	db *database.Database,
+	poolKeyHash []byte,
+	vrfKeyHash []byte,
+) {
+	t.Helper()
+	err := db.Metadata().ImportPool(
+		&models.Pool{
+			PoolKeyHash: poolKeyHash,
+			VrfKeyHash:  vrfKeyHash,
+		},
+		&models.PoolRegistration{
+			PoolKeyHash: poolKeyHash,
+			VrfKeyHash:  vrfKeyHash,
+			AddedSlot:   1,
 		},
 		nil,
 	)

--- a/ledger/verify_registered_vrf_key_test.go
+++ b/ledger/verify_registered_vrf_key_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyRegisteredVrfKey_RejectsUnregisteredOrMismatchedKey verifies the
+// consensus-critical binding of a block's VRF verification key to the producing
+// pool's on-chain registered VRF key. The VRF proof is validated only against
+// the key carried in the header, so a block whose VRF key is not the one the
+// pool registered must be rejected — otherwise an attacker can grind VRF keys
+// offline and win slots regardless of stake. With no pool registration present
+// for the block's issuer, the block's VRF key cannot match any registered key,
+// so verification must fail (it must never pass by default).
+func TestVerifyRegisteredVrfKey_RejectsUnregisteredOrMismatchedKey(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{71}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	// No pool registration seeded for this block's issuer, so the header's VRF
+	// key is not bound to any registered VRF key.
+	err := ls.verifyRegisteredVrfKey(tb.block)
+	require.Error(
+		t,
+		err,
+		"a block whose VRF key is not the issuer pool's registered VRF key must be rejected",
+	)
+	// The rejection is specifically about the VRF key / pool registration, not
+	// some unrelated failure.
+	msg := err.Error()
+	assert.True(
+		t,
+		containsAny(msg, "VRF key", "registered VRF key", "registration lookup"),
+		"rejection should cite the VRF-key registration binding, got: %s",
+		msg,
+	)
+
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(tb.block.Header())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEmpty(t, vrfKey)
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	store, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok, "expected sqlite metadata store")
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash: poolKeyHash[:],
+		VrfKeyHash:  lcommon.Blake2b256Hash(vrfKey).Bytes(),
+	}).Error)
+
+	err = ls.verifyRegisteredVrfKey(tb.block)
+	require.Error(
+		t,
+		err,
+		"a denormalized pool row without a registration must not bind "+
+			"the header VRF key",
+	)
+	assert.Contains(t, err.Error(), "registered VRF key hash unavailable")
+}
+
+// TestVerifyRegisteredVrfKey_AcceptsMatchingKeyRejectsMismatch is the
+// positive-and-mismatch counterpart to the unregistered-pool case: it proves
+// the binding accepts a block whose header VRF key hashes to the pool's
+// registered VRF key hash, and rejects one whose does not. The VRF proof is
+// only ever validated against the header-carried key, so this equality is the
+// sole barrier preventing an attacker from registering with one VRF key and
+// producing blocks with a different, offline-ground key.
+func TestVerifyRegisteredVrfKey_AcceptsMatchingKeyRejectsMismatch(
+	t *testing.T,
+) {
+	// --- Matching registered VRF key is accepted ---
+	tbMatch := createTestBlock(t, [32]byte{72}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tbMatch.epochNonce)
+
+	matchVrfKey, ok, err := headerVrfKeyFromBodyCbor(tbMatch.block.Header())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEmpty(t, matchVrfKey)
+
+	matchPoolKeyHash := tbMatch.block.IssuerVkey().Hash()
+	seedPoolRegistration(
+		t,
+		db,
+		matchPoolKeyHash[:],
+		lcommon.Blake2b256Hash(matchVrfKey).Bytes(),
+	)
+
+	require.NoError(
+		t,
+		ls.verifyRegisteredVrfKey(tbMatch.block),
+		"block whose header VRF key hashes to the pool's registered "+
+			"VRF key hash must be accepted",
+	)
+
+	// --- Mismatched registered VRF key is rejected ---
+	tbMismatch := createTestBlock(t, [32]byte{73}, 0, tamperNone)
+	mismatchVrfKey, ok, err := headerVrfKeyFromBodyCbor(
+		tbMismatch.block.Header(),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	wrongVrfKeyHash := make([]byte, len(lcommon.Blake2b256{}))
+	for i := range wrongVrfKeyHash {
+		wrongVrfKeyHash[i] = 0xAB
+	}
+	// Guard against an accidental collision with the block's real VRF key hash.
+	require.NotEqual(
+		t,
+		lcommon.Blake2b256Hash(mismatchVrfKey).Bytes(),
+		wrongVrfKeyHash,
+	)
+
+	mismatchPoolKeyHash := tbMismatch.block.IssuerVkey().Hash()
+	seedPoolRegistration(t, db, mismatchPoolKeyHash[:], wrongVrfKeyHash)
+
+	err = ls.verifyRegisteredVrfKey(tbMismatch.block)
+	require.Error(
+		t,
+		err,
+		"block whose header VRF key does not match the registered "+
+			"VRF key must be rejected",
+	)
+	assert.Contains(t, err.Error(), "VRF key does not match")
+}
+
+func TestVerifyRegisteredVrfKey_AcceptsRetiredPoolRegistration(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{74}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(tb.block.Header())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEmpty(t, vrfKey)
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolRegistration(
+		t,
+		db,
+		poolKeyHash[:],
+		lcommon.Blake2b256Hash(vrfKey).Bytes(),
+	)
+
+	require.NoError(t, db.SetEpoch(
+		0,
+		0,
+		nil,
+		nil,
+		nil,
+		nil,
+		0,
+		1,
+		1_000,
+		nil,
+	))
+	require.NoError(t, db.SetEpoch(
+		2_000,
+		2,
+		nil,
+		nil,
+		nil,
+		nil,
+		0,
+		1,
+		1_000,
+		nil,
+	))
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: 2_000,
+			Hash: make([]byte, 32),
+		},
+		BlockNumber: 2,
+	}, nil))
+
+	store, ok := db.Metadata().(*sqlite.MetadataStoreSqlite)
+	require.True(t, ok, "expected sqlite metadata store")
+	var pool models.Pool
+	require.NoError(t, store.DB().
+		Where("pool_key_hash = ?", poolKeyHash[:]).
+		First(&pool).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID:      pool.ID,
+		PoolKeyHash: poolKeyHash[:],
+		Epoch:       2,
+		AddedSlot:   2,
+	}).Error)
+
+	require.NoError(
+		t,
+		ls.verifyRegisteredVrfKey(tb.block),
+		"registered VRF-key binding must not depend on current-tip "+
+			"active pool filtering",
+	)
+}
+
+func TestVerifyRegisteredVrfKey_UsesLatestRegistrationBeforePoolRowHash(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{75}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(tb.block.Header())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEmpty(t, vrfKey)
+	registeredVrfHash := lcommon.Blake2b256Hash(vrfKey).Bytes()
+
+	staleVrfHash := make([]byte, len(lcommon.Blake2b256{}))
+	for i := range staleVrfHash {
+		staleVrfHash[i] = 0xCD
+	}
+	require.NotEqual(t, registeredVrfHash, staleVrfHash)
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	err = db.Metadata().ImportPool(
+		&models.Pool{
+			PoolKeyHash: poolKeyHash[:],
+			VrfKeyHash:  staleVrfHash,
+		},
+		&models.PoolRegistration{
+			PoolKeyHash: poolKeyHash[:],
+			VrfKeyHash:  registeredVrfHash,
+			AddedSlot:   1,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		ls.verifyRegisteredVrfKey(tb.block),
+		"latest registration VRF hash should take precedence over stale "+
+			"denormalized pool VRF hash",
+	)
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if len(sub) > 0 && len(s) >= len(sub) {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds consensus checks to bind a header’s VRF key to the pool’s registered VRF key and to require contiguous block numbers at header and block ingestion, preventing VRF-key grinding and inflated block numbers from biasing chain selection.

- **Bug Fixes**
  - Verify the header VRF key matches the producing pool’s on-chain registered VRF key for Shelley and later; accept retired pools, prefer the latest registration over the denormalized pool hash, and reject unregistered or mismatched keys. Added focused tests and seeding helpers.
  - Enforce block-number continuity for headers and blocks; allow parent or parent+1 only in Byron (EBB). Emit BlockNumberNotContiguousError. Added targeted tests and updated fork-resolution tests to use contiguous numbers.

<sup>Written for commit 8037b5ebe0e7a428ff7aa57919a28b5b20ca6789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

