### PR TITLE
fix(chainsync): don't recycle chainsync on ledger-application backlog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1191,7 +1191,7 @@ The `chainsync.State` tracks multiple concurrent chainsync clients:
 - Stall detection with configurable timeout
 - Grace period before recycling stalled connections
 - Cooldown to prevent rapid reconnection flapping
-- Plateau detection: if the local tip stops advancing while peers are ahead, the active chainsync connection is recycled
+- Plateau detection: if the local tip stops advancing while peers are ahead, the recycler first asks ledger to reconcile any live primary-chain/ledger divergence (`ReconcileLivePrimaryChainLedgerDivergence`). When that local repair succeeds, connection-level recovery is skipped so ledger replay can resume from the repaired tip. If no divergence is found, the active chainsync connection is recycled — except when the primary (header) chain has already caught up to the peer and the gap is dominated by downloaded-but-not-yet-applied blocks (`isLedgerApplicationBacklog`, `node_chainsync_recycler.go`). That plateau is a ledger-application backlog, not a chainsync stall, so the healthy connection is left running and the condition is logged at INFO instead of recycling (recycling cannot advance the applied tip and only churns the connection)
 - Peer-governance connection-close lookup uses stable endpoint identity so reconnect and eligibility cleanup still run for equivalent connection IDs; when no active chainsync client remains, ledger clears its cached upstream tip so slot-clock epoch work does not run against a disconnected tip
 
 #### Header-Sync Strategy

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -102,6 +102,39 @@ func shouldRecycleLocalTipPlateau(
 	return true
 }
 
+// isLedgerApplicationBacklog reports whether a local-tip plateau is caused by
+// the ledger pipeline replaying a backlog of already-fetched blocks rather than
+// by a stalled chainsync stream.
+//
+// A plateau only means the APPLIED ledger tip stopped advancing while a peer is
+// ahead. That is a chainsync problem only when headers are actually missing. On
+// Leios (and any deep catch-up) the header/primary chain routinely runs far
+// ahead of the applied ledger tip while the ledger pipeline replays a large
+// backlog of blocks it has already fetched. When the primary chain has covered
+// the bulk of the distance to the best peer and the remaining gap is dominated
+// by downloaded-but-not-yet-applied blocks, the chainsync stream is healthy and
+// caught up: recycling it cannot advance the applied tip and only churns the
+// connection. Requiring the apply backlog to be at least as large as the
+// residual header gap keeps a genuinely lagging header chain (headers missing,
+// nothing applied) on the recycle path.
+func isLedgerApplicationBacklog(
+	appliedTipSlot uint64,
+	primaryChainTipSlot uint64,
+	bestPeerTipSlot uint64,
+) bool {
+	if primaryChainTipSlot <= appliedTipSlot {
+		// Header chain is not ahead of the applied tip, so there is no
+		// backlog to drain: any plateau here is an upstream/header stall.
+		return false
+	}
+	var headerGap uint64
+	if bestPeerTipSlot > primaryChainTipSlot {
+		headerGap = bestPeerTipSlot - primaryChainTipSlot
+	}
+	applyBacklog := primaryChainTipSlot - appliedTipSlot
+	return applyBacklog >= headerGap
+}
+
 func (n *Node) processChainsyncRecyclerTick(
 	now time.Time,
 	localTipSlot uint64,
@@ -201,12 +234,14 @@ func (n *Node) processChainsyncRecyclerTick(
 					// upstream (e.g. a one-relay devnet/leios topology),
 					// which would otherwise wedge here permanently.
 					reconciledByLedger := false
+					reconcileFailed := false
 					if n.ledgerState != nil {
 						reconciled, err := n.ledgerState.ReconcileLivePrimaryChainLedgerDivergence(
 							"local tip plateau",
 							*targetConn,
 						)
 						if err != nil {
+							reconcileFailed = true
 							n.config.logger.Warn(
 								"plateau reconcile failed",
 								"connection_id", connKey,
@@ -229,7 +264,53 @@ func (n *Node) processChainsyncRecyclerTick(
 							reconciledByLedger = true
 						}
 					}
-					if !reconciledByLedger {
+					// A local-tip plateau on Leios is usually the ledger
+					// pipeline replaying a backlog of already-fetched blocks,
+					// not a stalled header stream. When the primary chain is
+					// already caught up to the peer, recycling the (healthy)
+					// chainsync connection cannot advance the applied tip and
+					// only churns the connection -- dropped pipelines,
+					// MustReply timeouts from ingress backpressure, and
+					// TIME_WAIT/goroutine growth. Only trust this heuristic
+					// after the local reconcile had a chance to repair, or at
+					// least rule out, a primary-chain / ledger divergence.
+					var primaryChainTipSlot uint64
+					if n.ledgerState != nil {
+						primaryChainTipSlot = n.ledgerState.PrimaryChainTipSlot()
+					}
+					isBacklog := isLedgerApplicationBacklog(
+						localTipSlot,
+						primaryChainTipSlot,
+						bestPeerTip.Tip.Point.Slot,
+					)
+					if reconciledByLedger {
+						// Reconciliation already reset the plateau clock and
+						// recorded cooldown. Give ledger replay a chance to
+						// resume from the repaired tip before trying any
+						// connection-level recovery.
+					} else if isBacklog && !reconcileFailed {
+						// The header chain is already caught up to the peer;
+						// the plateau is the ledger pipeline draining a
+						// backlog of already-fetched blocks. Recycling the
+						// chainsync stream cannot help and only churns the
+						// connection, so leave it running and let the pipeline
+						// advance. Surfacing this at INFO also stops a wedged
+						// ledger pipeline from being masked as a chainsync
+						// stall.
+						n.config.logger.Info(
+							"local tip plateau is a ledger-application backlog; header chain already caught up, not recycling chainsync",
+							"connection_id", connKey,
+							"applied_tip_slot", localTipSlot,
+							"primary_chain_tip_slot", primaryChainTipSlot,
+							"best_peer_tip_slot", bestPeerTip.Tip.Point.Slot,
+							"plateau_duration", now.Sub(*lastProgressAt),
+						)
+						// Reset the plateau clock so we re-evaluate only after
+						// another full plateau window instead of every tick
+						// while the ledger pipeline drains.
+						*lastProgressAt = now
+						delete(recycleAt, connKey)
+					} else {
 						// The local reconcile found nothing to repair (or
 						// failed), so the stall is in the upstream chainsync
 						// stream itself: the active peer's server-side cursor

--- a/node_test.go
+++ b/node_test.go
@@ -16,6 +16,7 @@ package dingo
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"io"
 	"log/slog"
@@ -24,11 +25,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -48,6 +53,138 @@ func newNodeTestConnId(id uint) ouroboros.ConnectionId {
 			Port: int(id),
 		},
 	}
+}
+
+type nodeTestSecurityParamLedger struct {
+	securityParam int
+}
+
+func (m nodeTestSecurityParamLedger) SecurityParam() int {
+	return m.securityParam
+}
+
+func nodeTestHashBytes(seed string) []byte {
+	sum := sha256.Sum256([]byte(seed))
+	return append([]byte(nil), sum[:]...)
+}
+
+func newNodeTestCardanoNodeCfg(t testing.TB) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg, err := cardano.LoadCardanoNodeConfigWithFallback(
+		"preview/config.json",
+		"preview",
+		cardano.EmbeddedConfigFS,
+	)
+	require.NoError(t, err)
+	return cfg
+}
+
+func newNodeTestDivergedLedger(
+	t *testing.T,
+) (*ledger.LedgerState, ochainsync.Tip, ochainsync.Tip, ochainsync.Tip) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(nodeTestSecurityParamLedger{securityParam: 432}))
+
+	ancestorHash := nodeTestHashBytes("node-recycler-ancestor")
+	currentHash := nodeTestHashBytes("node-recycler-current")
+	ancestorBlock := chain.RawBlock{
+		Slot:        10,
+		Hash:        ancestorHash,
+		BlockNumber: 1,
+		Type:        1,
+		Cbor:        []byte{0x80},
+	}
+	currentBlock := chain.RawBlock{
+		Slot:        20,
+		Hash:        currentHash,
+		BlockNumber: 2,
+		Type:        1,
+		PrevHash:    ancestorHash,
+		Cbor:        []byte{0x80},
+	}
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
+		ancestorBlock,
+		currentBlock,
+	}))
+
+	ancestorTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(ancestorBlock.Slot, ancestorBlock.Hash),
+		BlockNumber: ancestorBlock.BlockNumber,
+	}
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(currentBlock.Slot, currentBlock.Hash),
+		BlockNumber: currentBlock.BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			ancestorTip.Point.Hash,
+			ancestorTip.Point.Slot,
+			[]byte("nonce-ancestor"),
+			true,
+			nil,
+		),
+	)
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			currentTip.Point.Hash,
+			currentTip.Point.Slot,
+			[]byte("nonce-current"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(currentTip, nil))
+
+	ledgerState, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:              db,
+		ChainManager:          cm,
+		CardanoNodeConfig:     newNodeTestCardanoNodeCfg(t),
+		Logger:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ManualBlockProcessing: true,
+		DatabaseWorkerPoolConfig: ledger.DatabaseWorkerPoolConfig{
+			WorkerPoolSize: 1,
+			TaskQueueSize:  1,
+			Disabled:       true,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ledgerState.Start(context.Background()))
+	t.Cleanup(func() {
+		if ledgerState.Scheduler != nil {
+			ledgerState.Scheduler.Stop()
+		}
+		require.NoError(t, ledgerState.Close())
+	})
+
+	forkBlock := chain.RawBlock{
+		Slot:        50,
+		Hash:        nodeTestHashBytes("node-recycler-fork"),
+		BlockNumber: currentBlock.BlockNumber + 1,
+		Type:        1,
+		PrevHash:    ancestorHash,
+		Cbor:        []byte{0x80},
+	}
+	require.NoError(t, ledgerState.Chain().Rollback(ancestorTip.Point))
+	require.NoError(t, ledgerState.Chain().AddRawBlocks([]chain.RawBlock{forkBlock}))
+	forkTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(forkBlock.Slot, forkBlock.Hash),
+		BlockNumber: forkBlock.BlockNumber,
+	}
+	require.Equal(t, currentTip, ledgerState.Tip())
+	require.Equal(t, forkTip, ledgerState.PrimaryChainTip())
+	return ledgerState, ancestorTip, currentTip, forkTip
 }
 
 func TestHandleChainSwitchEventUpdatesActiveConnection(t *testing.T) {
@@ -179,6 +316,26 @@ func TestShouldRecycleLocalTipPlateau(t *testing.T) {
 		cooldown,
 		threshold,
 	))
+}
+
+func TestIsLedgerApplicationBacklog(t *testing.T) {
+	// Leios deep catch-up: header/primary chain caught up to the peer while
+	// the applied ledger tip lags far behind -> backlog (do not recycle).
+	assert.True(t, isLedgerApplicationBacklog(1_488_398, 3_082_751, 3_082_751))
+	// Primary chain slightly behind the peer but the residual header gap is
+	// tiny next to the apply backlog -> still a backlog.
+	assert.True(t, isLedgerApplicationBacklog(1_488_398, 3_082_700, 3_082_751))
+	// Genuine chainsync/header stall: nothing fetched beyond the applied tip
+	// while the peer is far ahead -> not a backlog (recycle path applies).
+	assert.False(t, isLedgerApplicationBacklog(1_488_398, 1_488_398, 3_082_751))
+	// Header chain lags: residual header gap dominates the apply backlog ->
+	// not a backlog (headers are actually missing).
+	assert.False(t, isLedgerApplicationBacklog(1_000, 1_100, 3_000))
+	// No primary-chain data (e.g. nil ledger state -> 0) -> not a backlog, so
+	// existing recycle behavior is preserved.
+	assert.False(t, isLedgerApplicationBacklog(100, 0, 120))
+	// Apply backlog exactly equals residual header gap -> treat as backlog.
+	assert.True(t, isLedgerApplicationBacklog(100, 150, 200))
 }
 
 func TestProcessChainsyncRecyclerTickKeepsStalledRecyclerRunning(
@@ -422,6 +579,84 @@ func TestProcessChainsyncRecyclerTickRecyclesLocalTipPlateau(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected plateau resync event")
 	}
+}
+
+func TestProcessChainsyncRecyclerTickReconcilesBeforeBacklogSuppression(
+	t *testing.T,
+) {
+	ledgerState, ancestorTip, currentTip, forkTip := newNodeTestDivergedLedger(t)
+	require.True(
+		t,
+		isLedgerApplicationBacklog(
+			currentTip.Point.Slot,
+			forkTip.Point.Slot,
+			forkTip.Point.Slot,
+		),
+		"fixture must look like a ledger application backlog",
+	)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	_, resyncCh := bus.Subscribe(
+		event.ChainsyncResyncEventType,
+	)
+
+	connId := newNodeTestConnId(8)
+	state := chainsync.NewStateWithConfig(
+		bus,
+		nil,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Hour,
+		},
+	)
+	require.True(t, state.AddClientConnId(connId))
+	state.SetClientConnId(connId)
+
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{},
+	)
+	selector.UpdatePeerTip(connId, forkTip, nil)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		chainsyncState: state,
+		chainSelector:  selector,
+		eventBus:       bus,
+		ledgerState:    ledgerState,
+	}
+
+	now := time.Now()
+	lastProgressSlot := currentTip.Point.Slot
+	lastProgressAt := now.Add(-25 * time.Minute)
+	recycleAt := make(map[string]time.Time)
+	lastRecycled := make(map[string]time.Time)
+
+	n.processChainsyncRecyclerTick(
+		now,
+		currentTip.Point.Slot,
+		chainsync.Config{
+			MaxClients:   1,
+			StallTimeout: time.Hour,
+		},
+		recycleAt,
+		lastRecycled,
+		&lastProgressSlot,
+		&lastProgressAt,
+		4*time.Minute,
+		time.Second,
+		2*time.Minute,
+	)
+
+	assert.Equal(t, ancestorTip, ledgerState.Tip())
+	testutil.RequireNoReceive(
+		t,
+		resyncCh,
+		50*time.Millisecond,
+		"chainsync resync should not fire when ledger reconcile repairs the plateau",
+	)
 }
 
 // TestProcessChainsyncRecyclerTickResyncsPlateauOnlyPeer verifies the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop recycling chainsync when a local-tip plateau is actually a ledger-application backlog. We now reconcile first and only suppress recycling when headers are caught up, which reduces churn and timeouts during deep catch-up (e.g., Leios).

- **Bug Fixes**
  - Added `isLedgerApplicationBacklog` using applied-tip, primary-chain tip, and best-peer tip; treat as backlog when apply backlog >= residual header gap.
  - Plateau flow: attempt `ReconcileLivePrimaryChainLedgerDivergence` first; if repaired, skip resync; otherwise, when backlog is detected and reconcile didn’t fail, log at INFO, reset the plateau timer, and don’t recycle.
  - Updated `ARCHITECTURE.md` to document reconcile-first and the backlog exception.
  - Added tests for backlog detection, reconcile-before-backlog suppression, and edge cases.

<sup>Written for commit 555b7c687492d44c0bfcdb6099f46fdb05358b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

