### PR TITLE
fix(peergov): spread outbound dials across resolved backends

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1248,7 +1248,21 @@ upstream connection left, capped per cycle. This guarantees the node converges
 back to connected even when a close event cannot be attributed to its peer or
 a dial loop exited early. Gossip churn never demotes the peer holding the last
 eligible upstream connection, so routine churn cannot leave the node without a
-chainsync source.
+chainsync source. Each outbound dial attempt re-resolves a hostname-based
+peer's address fresh, narrows the records to the address families the local
+host can route to (detected once via `net.InterfaceAddrs` and cached, so a
+v4-only or v6-only host never dials a dead family), and picks one of the
+remaining records at random for that attempt (`resolveDialAddress`), so repeated
+attempts spread across every reachable backend behind a load-balancer hostname
+and a congested or half-dead backend is escaped on the next attempt rather than
+pinned until a process restart. If family detection is inconclusive or filters
+everything out, the full record set is used so a peer is never stranded. The
+re-resolution runs against `net.DefaultResolver` with a context bounded by a
+few seconds and tied to the governor context, so a hung or slow resolver
+cannot wedge the outbound-dial loop and a shutdown cancels an in-flight lookup
+promptly; on timeout or failure the attempt falls back to the unresolved
+address. IP-literal peers dial unchanged, and peer identity/dedup stays keyed
+on the stable `Address`/`NormalizedAddress`, not the rotating dial target.
 
 Reconnect backoff after short-lived sessions escalates exponentially. The
 reconnect goroutine consumes and zeroes the stored delay before dialing, so

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -285,9 +285,15 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			continue
 		}
 
+		// Re-resolve hostname-based peers on every attempt and rotate the
+		// dial target across all resolved records so load spreads across
+		// load-balancer backends and a stuck/unhealthy backend is escaped
+		// on the next attempt without a process restart. IP-literal peers
+		// are returned unchanged. Peer identity/dedup is keyed on
+		// peer.Address / NormalizedAddress and is unaffected.
 		conn, err := p.config.ConnManager.CreateOutboundConn(
 			p.ctx,
-			peer.Address,
+			p.resolveDialAddress(p.ctx, peer.Address),
 		)
 		if err == nil {
 			connId := conn.Id()

--- a/peergov/dial_spread_test.go
+++ b/peergov/dial_spread_test.go
@@ -1,0 +1,403 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDialSpreadGovernor() *PeerGovernor {
+	return NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+}
+
+// TestResolveDialAddress_IPv4LiteralUnchanged verifies that an IPv4 literal
+// peer is dialed exactly as before: no DNS resolution, no rotation. The
+// injected resolver would return a different address if it were consulted,
+// so an unchanged result proves the resolver was not used.
+func TestResolveDialAddress_IPv4LiteralUnchanged(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.99")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	const addr = "195.191.47.210:3001"
+	assert.Equal(t, addr, pg.resolveDialAddress(context.Background(), addr))
+}
+
+// TestResolveDialAddress_IPv6LiteralUnchanged verifies IPv6 literals are
+// returned unchanged (bracketed host:port preserved).
+func TestResolveDialAddress_IPv6LiteralUnchanged(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("2001:db8::1")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	const addr = "[2001:db8::dead:beef]:3001"
+	assert.Equal(t, addr, pg.resolveDialAddress(context.Background(), addr))
+}
+
+// TestResolveDialAddress_MalformedAddressUnchanged verifies that an address
+// without a host:port split (no resolvable form) is returned unchanged so
+// the dialer can report the error as before.
+func TestResolveDialAddress_MalformedAddressUnchanged(t *testing.T) {
+	pg := newDialSpreadGovernor()
+	const addr = "not-a-host-port"
+	assert.Equal(t, addr, pg.resolveDialAddress(context.Background(), addr))
+}
+
+// TestResolveDialAddress_ResolutionFailureFallsBack verifies that when DNS
+// resolution fails, the original hostname:port is returned so the dialer
+// can attempt its own resolution — identical to the pre-spread behavior.
+func TestResolveDialAddress_ResolutionFailureFallsBack(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return nil, errors.New("lookup failed")
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	const addr = "relay.example.com:3001"
+	assert.Equal(t, addr, pg.resolveDialAddress(context.Background(), addr))
+}
+
+// TestResolveDialAddress_EmptyResolutionFallsBack verifies that an empty
+// (but non-error) resolution result falls back to the original address.
+func TestResolveDialAddress_EmptyResolutionFallsBack(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	const addr = "relay.example.com:3001"
+	assert.Equal(t, addr, pg.resolveDialAddress(context.Background(), addr))
+}
+
+// TestResolveDialAddress_SingleIPHostname verifies that a hostname resolving
+// to exactly one record always yields that record's IP:port.
+func TestResolveDialAddress_SingleIPHostname(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("198.51.100.7")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	for range 20 {
+		assert.Equal(
+			t,
+			"198.51.100.7:3001",
+			pg.resolveDialAddress(context.Background(), "relay.example.com:3001"),
+		)
+	}
+}
+
+// TestResolveDialAddress_MultiIPRotates verifies the core fix: a hostname
+// that resolves to many records (mixed IPv4/IPv6, mirroring the observed
+// load-balancer relay with 5 IPv4 + 11 IPv6) spreads the dial target across
+// more than one backend across repeated attempts, and every returned target
+// is a valid member of the resolved set with the original port preserved.
+func TestResolveDialAddress_MultiIPRotates(t *testing.T) {
+	resolved := []net.IP{
+		net.ParseIP("192.0.2.1"),
+		net.ParseIP("192.0.2.2"),
+		net.ParseIP("192.0.2.3"),
+		net.ParseIP("192.0.2.4"),
+		net.ParseIP("192.0.2.5"),
+		net.ParseIP("2001:db8::1"),
+		net.ParseIP("2001:db8::2"),
+		net.ParseIP("2001:db8::3"),
+	}
+	valid := make(map[string]struct{}, len(resolved))
+	for _, ip := range resolved {
+		valid[net.JoinHostPort(ip.String(), "3001")] = struct{}{}
+	}
+
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		// Return a fresh copy so callers cannot mutate the fixture.
+		out := make([]net.IP, len(resolved))
+		copy(out, resolved)
+		return out, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	seen := make(map[string]struct{})
+	for range 200 {
+		got := pg.resolveDialAddress(context.Background(), "leios-node.play.dev.cardano.org:3001")
+		_, ok := valid[got]
+		require.Truef(
+			t,
+			ok,
+			"dial target %q is not one of the resolved records",
+			got,
+		)
+		seen[got] = struct{}{}
+	}
+	// The whole point of the fix: repeated attempts must not pin to a
+	// single backend. With 8 records over 200 draws, seeing fewer than 2
+	// distinct targets is statistically impossible (~5*(1/8)^200).
+	assert.Greaterf(
+		t,
+		len(seen),
+		1,
+		"expected dial target to spread across multiple backends, saw only %v",
+		seen,
+	)
+}
+
+// setLocalAddrFamilies injects a deterministic local-family detection result
+// for the duration of a test so filtering does not depend on the real host's
+// interfaces, and restores the previous detector on cleanup.
+func setLocalAddrFamilies(t *testing.T, hasV4, hasV6 bool) {
+	t.Helper()
+	old := localAddrFamilies
+	localAddrFamilies = func() (bool, bool) { return hasV4, hasV6 }
+	t.Cleanup(func() { localAddrFamilies = old })
+}
+
+func TestSupportedDialFamilies_UsesCachedResultWithinTTL(t *testing.T) {
+	old := localAddrFamilies
+	calls := 0
+	localAddrFamilies = func() (bool, bool) {
+		calls++
+		if calls == 1 {
+			return true, false
+		}
+		return false, true
+	}
+	t.Cleanup(func() { localAddrFamilies = old })
+
+	pg := newDialSpreadGovernor()
+	hasV4, hasV6 := pg.supportedDialFamilies()
+	assert.True(t, hasV4)
+	assert.False(t, hasV6)
+
+	hasV4, hasV6 = pg.supportedDialFamilies()
+	assert.True(t, hasV4)
+	assert.False(t, hasV6)
+	assert.Equal(t, 1, calls)
+}
+
+func TestSupportedDialFamilies_RefreshesAfterTTL(t *testing.T) {
+	old := localAddrFamilies
+	calls := 0
+	localAddrFamilies = func() (bool, bool) {
+		calls++
+		if calls == 1 {
+			return true, false
+		}
+		return false, true
+	}
+	t.Cleanup(func() { localAddrFamilies = old })
+
+	pg := newDialSpreadGovernor()
+	hasV4, hasV6 := pg.supportedDialFamilies()
+	require.True(t, hasV4)
+	require.False(t, hasV6)
+
+	pg.dialFamilyMu.Lock()
+	pg.dialFamilyCheckedAt = time.Now().Add(-dialFamilyCacheTTL - time.Second)
+	pg.dialFamilyMu.Unlock()
+
+	hasV4, hasV6 = pg.supportedDialFamilies()
+	assert.False(t, hasV4)
+	assert.True(t, hasV6)
+	assert.Equal(t, 2, calls)
+}
+
+// mixedFamilyResolver installs a lookupIPAddr returning the given IPs (fresh
+// copy each call) and restores the previous resolver on cleanup.
+func mixedFamilyResolver(t *testing.T, ips []net.IP) {
+	t.Helper()
+	old := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		out := make([]net.IP, len(ips))
+		copy(out, ips)
+		return out, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = old })
+}
+
+// dialTargetIsV4 parses a resolveDialAddress result and reports whether the
+// selected host is an IPv4 address.
+func dialTargetIsV4(t *testing.T, target string) bool {
+	t.Helper()
+	host, _, err := net.SplitHostPort(target)
+	require.NoError(t, err)
+	ip := net.ParseIP(host)
+	require.NotNilf(t, ip, "dial target host %q is not an IP", host)
+	return ip.To4() != nil
+}
+
+var mixedV4V6Records = []net.IP{
+	net.ParseIP("192.0.2.1"),
+	net.ParseIP("192.0.2.2"),
+	net.ParseIP("192.0.2.3"),
+	net.ParseIP("2001:db8::1"),
+	net.ParseIP("2001:db8::2"),
+}
+
+// TestResolveDialAddress_V4OnlyHostFiltersV6 verifies that on a v4-only host
+// the IPv6 records are filtered out so no dial is wasted on an unreachable
+// family; every selected target is IPv4.
+func TestResolveDialAddress_V4OnlyHostFiltersV6(t *testing.T) {
+	mixedFamilyResolver(t, mixedV4V6Records)
+	setLocalAddrFamilies(t, true, false)
+
+	pg := newDialSpreadGovernor()
+	for range 100 {
+		got := pg.resolveDialAddress(context.Background(), "relay.example.com:3001")
+		assert.Truef(t, dialTargetIsV4(t, got), "expected IPv4 target, got %q", got)
+	}
+}
+
+// TestResolveDialAddress_V6OnlyHostFiltersV4 verifies the symmetric case: on a
+// v6-only host every selected target is IPv6.
+func TestResolveDialAddress_V6OnlyHostFiltersV4(t *testing.T) {
+	mixedFamilyResolver(t, mixedV4V6Records)
+	setLocalAddrFamilies(t, false, true)
+
+	pg := newDialSpreadGovernor()
+	for range 100 {
+		got := pg.resolveDialAddress(context.Background(), "relay.example.com:3001")
+		assert.Falsef(t, dialTargetIsV4(t, got), "expected IPv6 target, got %q", got)
+	}
+}
+
+// TestResolveDialAddress_DualStackKeepsBoth verifies that on a dual-stack host
+// no family is filtered: both IPv4 and IPv6 targets are reachable across
+// repeated attempts.
+func TestResolveDialAddress_DualStackKeepsBoth(t *testing.T) {
+	mixedFamilyResolver(t, mixedV4V6Records)
+	setLocalAddrFamilies(t, true, true)
+
+	pg := newDialSpreadGovernor()
+	sawV4, sawV6 := false, false
+	for range 300 {
+		got := pg.resolveDialAddress(context.Background(), "relay.example.com:3001")
+		if dialTargetIsV4(t, got) {
+			sawV4 = true
+		} else {
+			sawV6 = true
+		}
+	}
+	assert.True(t, sawV4, "expected at least one IPv4 target on dual-stack host")
+	assert.True(t, sawV6, "expected at least one IPv6 target on dual-stack host")
+}
+
+// TestResolveDialAddress_EmptyAfterFilterFallsBackToAll verifies the safety
+// fallback: when no resolved record matches a supported family (here a v6-only
+// host but v4-only records), the peer is not stranded — the full record set is
+// used so a target is still selected.
+func TestResolveDialAddress_EmptyAfterFilterFallsBackToAll(t *testing.T) {
+	v4Only := []net.IP{
+		net.ParseIP("192.0.2.10"),
+		net.ParseIP("192.0.2.11"),
+	}
+	mixedFamilyResolver(t, v4Only)
+	setLocalAddrFamilies(t, false, true) // host claims v6-only
+
+	valid := map[string]struct{}{
+		"192.0.2.10:3001": {},
+		"192.0.2.11:3001": {},
+	}
+	pg := newDialSpreadGovernor()
+	for range 50 {
+		got := pg.resolveDialAddress(context.Background(), "relay.example.com:3001")
+		_, ok := valid[got]
+		assert.Truef(t, ok, "expected fallback to full v4 set, got %q", got)
+	}
+}
+
+// TestResolveDialAddress_DetectionInconclusiveFallsBackToAll verifies that when
+// family detection is inconclusive (neither family detected) no filtering is
+// applied: both families remain reachable across repeated attempts.
+func TestResolveDialAddress_DetectionInconclusiveFallsBackToAll(t *testing.T) {
+	mixedFamilyResolver(t, mixedV4V6Records)
+	setLocalAddrFamilies(t, false, false) // inconclusive
+
+	pg := newDialSpreadGovernor()
+	sawV4, sawV6 := false, false
+	for range 300 {
+		got := pg.resolveDialAddress(context.Background(), "relay.example.com:3001")
+		if dialTargetIsV4(t, got) {
+			sawV4 = true
+		} else {
+			sawV6 = true
+		}
+	}
+	assert.True(t, sawV4, "inconclusive detection must not filter out IPv4")
+	assert.True(t, sawV6, "inconclusive detection must not filter out IPv6")
+}
+
+// TestResolveDialAddress_CanceledContextFallsBack verifies that when the
+// passed context is already done (e.g. governor shutdown), a context-honoring
+// resolver returns the context error and resolveDialAddress falls back to the
+// original hostname:port instead of stranding the peer.
+func TestResolveDialAddress_CanceledContextFallsBack(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(ctx context.Context, _ string) ([]net.IP, error) {
+		// Mirror net.Resolver: honor the context and surface its error.
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	pg := newDialSpreadGovernor()
+	const addr = "relay.example.com:3001"
+	assert.Equal(t, addr, pg.resolveDialAddress(ctx, addr))
+}
+
+// TestResolveDialAddress_BoundsLookupWithDeadline verifies the core review
+// fix: the resolver is always invoked with a deadline-bounded context so a
+// hung or slow resolver cannot block the outbound-dial loop.
+func TestResolveDialAddress_BoundsLookupWithDeadline(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	var sawDeadline bool
+	lookupIPAddr = func(ctx context.Context, _ string) ([]net.IP, error) {
+		_, sawDeadline = ctx.Deadline()
+		return []net.IP{net.ParseIP("198.51.100.7")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	got := pg.resolveDialAddress(context.Background(), "relay.example.com:3001")
+	assert.Equal(t, "198.51.100.7:3001", got)
+	assert.True(
+		t,
+		sawDeadline,
+		"resolver must receive a deadline-bounded context",
+	)
+}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -87,6 +87,16 @@ const (
 	reconnectBackoffFactor      = 2
 	inboundCheckDelay           = 30 * time.Second
 	minStableConnectionDuration = 30 * time.Second
+	// dialDNSResolveTimeout bounds the fresh per-attempt DNS resolution in
+	// resolveDialAddress. It is intentionally shorter than connmanager's 10s
+	// dial timeout so a hung or slow resolver cannot wedge the outbound-dial
+	// loop; on timeout the attempt falls back to the unresolved address and
+	// the dialer resolves it itself.
+	dialDNSResolveTimeout = 5 * time.Second
+	// dialFamilyCacheTTL limits how long local address-family detection can
+	// remain stale after interface or routing changes while avoiding a
+	// per-dial interface scan.
+	dialFamilyCacheTTL = 1 * time.Minute
 )
 
 // Peer source priority values for removal decisions.
@@ -120,7 +130,14 @@ type PeerGovernor struct {
 	// emitted only on entry (rising edge) to avoid indefinite log spam.
 	// Guarded by mu.
 	lastEligibleUpstreamSkipLogged bool
-	mu                             sync.Mutex
+	// Local address-family capability, detected periodically and consulted by
+	// resolveDialAddress to avoid dialing an unreachable family (e.g. an IPv6
+	// record on a v4-only host).
+	dialFamilyMu        sync.RWMutex
+	dialFamilyHasV4     bool
+	dialFamilyHasV6     bool
+	dialFamilyCheckedAt time.Time
+	mu                  sync.Mutex
 }
 
 type PeerGovernorConfig struct {

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -15,7 +15,9 @@
 package peergov
 
 import (
+	"context"
 	"errors"
+	"math/rand/v2"
 	"net"
 	"strings"
 	"time"
@@ -33,6 +35,24 @@ const defaultMinPeerListCap = 200
 var ErrPeerListFull = errors.New("peer list at capacity")
 
 var lookupIP = net.LookupIP
+
+// lookupIPAddr resolves a hostname to its IP records while honoring the
+// provided context, so a hung or slow resolver cannot block the caller past
+// the context deadline or a governor shutdown. Unlike the bare net.LookupIP
+// used by resolveAddress, this path runs on the hot outbound-dial loop and
+// must never wedge the peer governor. It is a package var so tests can inject
+// a deterministic, host-independent resolver.
+var lookupIPAddr = func(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, len(addrs))
+	for i := range addrs {
+		ips[i] = addrs[i].IP
+	}
+	return ips, nil
+}
 
 // maxPeerListSize returns the hard cap for the total number of peers.
 // This prevents unbounded growth between reconciliation cycles.
@@ -254,6 +274,161 @@ func (p *PeerGovernor) resolveAddress(address string) string {
 
 	// Use first resolved IP for normalization
 	return net.JoinHostPort(ips[0].String(), port)
+}
+
+// resolveDialAddress returns the concrete transport target to dial for an
+// outbound connection attempt against the given peer address.
+//
+// For IP-literal addresses it returns the address unchanged: there is
+// nothing to resolve and behavior is identical to callers that dial the
+// address directly.
+//
+// For hostname-based addresses it performs a FRESH DNS resolution on every
+// call and returns a single, randomly-selected resolved IP:port. This
+// spreads repeated (re)connect attempts across every record the hostname
+// currently resolves to — e.g. all backends behind a load-balancer
+// hostname — instead of pinning to whichever address the dialer happens to
+// try first. A stuck or unhealthy backend is therefore escaped on the next
+// attempt without a process restart.
+//
+// Peer identity and deduplication are intentionally unaffected: callers
+// keep using the stable peer.Address / peer.NormalizedAddress for all
+// bookkeeping (dedup, deny lists, reconnect lookup, peer sharing). Only the
+// transport dial target rotates per attempt.
+//
+// On resolution failure (or a malformed address) it falls back to the
+// original address so the dialer can resolve the hostname itself,
+// preserving prior behavior.
+//
+// The DNS lookup is bounded by dialDNSResolveTimeout and tied to the passed
+// context, so a hung or slow resolver cannot block the outbound-dial loop and
+// a governor shutdown cancels an in-flight resolution promptly. It performs a
+// blocking DNS lookup for hostnames and must NOT be called while holding p.mu.
+func (p *PeerGovernor) resolveDialAddress(
+	ctx context.Context,
+	address string,
+) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	// IP literals dial exactly as before: no re-resolution, no rotation.
+	if net.ParseIP(host) != nil {
+		return address
+	}
+	// Bound the fresh resolution so a hung or slow resolver cannot wedge the
+	// dial loop, and cancel it if the governor is shutting down.
+	lookupCtx, cancel := context.WithTimeout(ctx, dialDNSResolveTimeout)
+	defer cancel()
+	ips, err := lookupIPAddr(lookupCtx, host)
+	if err != nil || len(ips) == 0 {
+		// Can't resolve (or timed out); let the dialer resolve the hostname
+		// itself so behavior matches the pre-spread code path.
+		return address
+	}
+	// Filter the resolved records to the address families the local host can
+	// actually route to, so a single-stack host never wastes a dial (and a
+	// backoff cycle) on an unreachable family — e.g. an IPv6 record on a
+	// v4-only host. The primary goal remains spreading across load-balancer
+	// backends; this just keeps that spread inside the reachable families.
+	hasV4, hasV6 := p.supportedDialFamilies()
+	ips = filterDialFamilies(ips, hasV4, hasV6)
+	// Spread the dial across all currently-returned (reachable) records.
+	// Random selection is stateless and, unlike a shared round-robin counter,
+	// does not synchronize the fleet onto a single backend; a congested or
+	// half-dead backend is escaped on the next attempt.
+	ip := ips[rand.IntN(len(ips))] //nolint:gosec // load-balancing spread, not security-sensitive
+	return net.JoinHostPort(ip.String(), port)
+}
+
+// localAddrFamilies detects which IP families the local host can route to.
+// It is a package var so tests can inject a deterministic result independent
+// of the host's real network interfaces.
+var localAddrFamilies = detectLocalAddrFamilies
+
+// detectLocalAddrFamilies reports whether the local host has at least one
+// non-loopback, non-link-local global-unicast IPv4 and/or IPv6 address, i.e.
+// which families it can plausibly originate traffic on. On any error it
+// reports (false, false), which the callers treat as "inconclusive" and fall
+// back to the full record set rather than filtering.
+func detectLocalAddrFamilies() (hasV4, hasV6 bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, false
+	}
+	for _, a := range addrs {
+		var ip net.IP
+		switch v := a.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		default:
+			continue
+		}
+		// Skip loopback/link-local and anything that is not a usable global
+		// unicast address; those do not indicate real routability. (Private
+		// RFC1918 / RFC4193 addresses are global-unicast and count, since a
+		// host on such a network can route that family.)
+		if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+			!ip.IsGlobalUnicast() {
+			continue
+		}
+		if ip.To4() != nil {
+			hasV4 = true
+		} else {
+			hasV6 = true
+		}
+	}
+	return hasV4, hasV6
+}
+
+// supportedDialFamilies returns the local host's routable IP families,
+// cached briefly to avoid a per-dial interface-scan syscall storm while still
+// picking up later interface or routing changes.
+func (p *PeerGovernor) supportedDialFamilies() (hasV4, hasV6 bool) {
+	now := time.Now()
+	p.dialFamilyMu.RLock()
+	if !p.dialFamilyCheckedAt.IsZero() &&
+		now.Sub(p.dialFamilyCheckedAt) < dialFamilyCacheTTL {
+		hasV4, hasV6 = p.dialFamilyHasV4, p.dialFamilyHasV6
+		p.dialFamilyMu.RUnlock()
+		return hasV4, hasV6
+	}
+	p.dialFamilyMu.RUnlock()
+
+	p.dialFamilyMu.Lock()
+	defer p.dialFamilyMu.Unlock()
+	now = time.Now()
+	if !p.dialFamilyCheckedAt.IsZero() &&
+		now.Sub(p.dialFamilyCheckedAt) < dialFamilyCacheTTL {
+		return p.dialFamilyHasV4, p.dialFamilyHasV6
+	}
+	p.dialFamilyHasV4, p.dialFamilyHasV6 = localAddrFamilies()
+	p.dialFamilyCheckedAt = now
+	return p.dialFamilyHasV4, p.dialFamilyHasV6
+}
+
+// filterDialFamilies returns the subset of ips whose address family the host
+// supports. SAFETY FALLBACK: if detection was inconclusive (neither family
+// supported) or nothing matches a supported family, it returns the original
+// ips unchanged so a peer is never stranded by over-filtering.
+func filterDialFamilies(ips []net.IP, hasV4, hasV6 bool) []net.IP {
+	if !hasV4 && !hasV6 {
+		// Detection inconclusive — do not filter.
+		return ips
+	}
+	filtered := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if (ip.To4() != nil && hasV4) || (ip.To4() == nil && hasV6) {
+			filtered = append(filtered, ip)
+		}
+	}
+	if len(filtered) == 0 {
+		// No record matches a supported family; never strand the peer.
+		return ips
+	}
+	return filtered
 }
 
 func (p *PeerGovernor) publishEvent(eventType event.EventType, data any) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-resolves hostname peers on each outbound dial and randomly selects a reachable IP to spread load across backends, escaping unhealthy targets without restart. DNS lookups are deadline-bound with safe fallbacks; peer identity and IP-literal addresses are unchanged.

- **Bug Fixes**
  - Bound per-dial DNS resolution with a 5s context deadline; on timeout/cancel/error or empty results, fall back to the original hostname.
  - Filter resolved records to locally routable families (IPv4/IPv6) using detection cached for 1 minute; if inconclusive or filtering removes all, use the full set.
  - Added tests for rotation, family filtering, deadline/cancel behavior, and TTL refresh; updated ARCHITECTURE docs.

<sup>Written for commit 66100596b648a4a560b9e0e4d4f81f3d85a6ecbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound peer connections by retrying against fresh resolved addresses, helping avoid repeated failures on the same network path.
  * Added safer fallback behavior so connections continue using the original address when resolution fails, times out, or is inconclusive.
  * Better matches dialing to the network families available on the local machine.

* **Documentation**
  * Updated architecture docs to describe the new peer dialing behavior.

* **Tests**
  * Added coverage for hostname resolution, IP handling, family filtering, fallback paths, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->