### PR TITLE
fix: chainsync rollback recovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1262,6 +1262,19 @@ trust-boundary reasons) place the peer on the deny list for a cooldown in
 addition to closing the connection, so the node does not redial a peer that
 will deterministically be rejected again moments later.
 
+When the local chain has diverged from the network, an upstream peer can
+repeatedly ask us to roll back to a canonical point we cannot cross to
+(the block is missing below our diverged tip, the rollback exceeds K, or it
+sits below the Mithril trust boundary). Each attempt wipes `rollbackHistory`
+and forces a fresh connection, so the per-connection rollback loop detector
+never accumulates. A separate point-keyed tracker (`unrecoverableRollbacks`
+in `LedgerState`, deliberately not cleared by the resync reset) counts these
+un-crossable rollbacks; once the same point recurs past a threshold within a
+window it surfaces the stuck-divergence condition as a throttled operator
+error plus the `dingo_chainsync_unrecoverable_rollback_total` metric, since a
+node in this state cannot self-recover and needs operator intervention
+(e.g. re-bootstrapping from a Mithril snapshot).
+
 Topology configuration is loaded from an explicit topology file when provided,
 otherwise from the embedded `network/topology.json` for built-in networks,
 falling back to the legacy network bootstrap-peer list only when no embedded

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1325,6 +1325,16 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				"hash", hex.EncodeToString(e.Point.Hash),
 				"connection_id", e.ConnectionId.String(),
 			)
+			// The per-connection loop detector cannot catch this: the
+			// reset below wipes rollbackHistory and the resync forces a
+			// fresh connection, so its counter never accumulates. Track
+			// the point itself so a persistently un-crossable rollback
+			// surfaces as an operator error + metric (see issue #2728).
+			ls.reportUnrecoverableRollbackIfStuck(
+				e.Point,
+				event.ChainsyncResyncReasonRollbackNotFound,
+				e.ConnectionId,
+			)
 			ls.resetChainsyncResyncState()
 			ls.setChainsyncState(SyncingChainsyncState)
 			if ls.config.EventBus != nil {
@@ -1371,6 +1381,11 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				"slot", e.Point.Slot,
 				"hash", hex.EncodeToString(e.Point.Hash),
 				"connection_id", e.ConnectionId.String(),
+			)
+			ls.reportUnrecoverableRollbackIfStuck(
+				e.Point,
+				event.ChainsyncResyncReasonRollbackExceedsK,
+				e.ConnectionId,
 			)
 			// Restore state: no rollback actually occurred, so
 			// we are still syncing. Leaving RollbackChainsyncState
@@ -1435,6 +1450,11 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 					"connection_id", e.ConnectionId.String(),
 				)
 			}
+			ls.reportUnrecoverableRollbackIfStuck(
+				e.Point,
+				reason,
+				e.ConnectionId,
+			)
 			ls.resetChainsyncResyncState()
 			ls.setChainsyncState(SyncingChainsyncState)
 			if ls.config.EventBus != nil {
@@ -1453,6 +1473,10 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		}
 		return fmt.Errorf("chain rollback failed: %w", err)
 	}
+	// The rollback applied: we crossed to the peer's point, so any prior
+	// un-crossable-rollback tracking is stale. Clear it so a later,
+	// unrelated divergence starts counting from zero (see issue #2728).
+	ls.clearUnrecoverableRollbacks()
 	return nil
 }
 

--- a/ledger/chainsync_unrecoverable_rollback.go
+++ b/ledger/chainsync_unrecoverable_rollback.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	// unrecoverableRollbackThreshold is how many times the same rollback
+	// point must fail to apply locally (within the detection window)
+	// before we treat the node as stuck on a diverged local chain. It is
+	// higher than rollbackLoopThreshold because this counter, unlike the
+	// per-connection loop detector, survives reset+reconnect and so must
+	// tolerate a couple of legitimate transient re-intersects.
+	unrecoverableRollbackThreshold = 3
+
+	// unrecoverableRollbackWindow bounds how far back failed rollback
+	// points are remembered. A point that has not recurred within the
+	// window ages out, so a node that recovers naturally stops reporting.
+	unrecoverableRollbackWindow = 10 * time.Minute
+
+	// unrecoverableRollbackLogInterval throttles the operator-facing error
+	// so a stuck node emits an actionable message roughly once a minute
+	// instead of joining the ~2/sec WARN loop.
+	unrecoverableRollbackLogInterval = 60 * time.Second
+)
+
+// unrecoverableRollbackRecord counts how often a single rollback point has
+// failed to apply locally within the detection window.
+type unrecoverableRollbackRecord struct {
+	count     int
+	firstSeen time.Time
+	lastSeen  time.Time
+}
+
+func unrecoverableRollbackKey(point ocommon.Point) string {
+	return fmt.Sprintf("%d:%x", point.Slot, point.Hash)
+}
+
+// noteUnrecoverableRollback records that we could not apply a rollback to
+// point (block missing locally, rollback exceeds K, or point below the
+// Mithril boundary) and reports the running count plus whether that count
+// has crossed unrecoverableRollbackThreshold within the window.
+//
+// Unlike the rollbackHistory loop detector this tracker is keyed on the
+// point alone and is NOT wiped by resetChainsyncResyncState/
+// requestChainsyncResync, so it accumulates across the reset+reconnect
+// cycle that a diverged node would otherwise loop through forever
+// (see issue #2728).
+//
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) noteUnrecoverableRollback(
+	point ocommon.Point,
+) (int, bool) {
+	now := time.Now()
+	if ls.unrecoverableRollbacks == nil {
+		ls.unrecoverableRollbacks = make(
+			map[string]unrecoverableRollbackRecord,
+		)
+	}
+	// Prune points that have not recurred within the window.
+	cutoff := now.Add(-unrecoverableRollbackWindow)
+	for key, rec := range ls.unrecoverableRollbacks {
+		if rec.lastSeen.Before(cutoff) {
+			delete(ls.unrecoverableRollbacks, key)
+		}
+	}
+	key := unrecoverableRollbackKey(point)
+	rec := ls.unrecoverableRollbacks[key]
+	if rec.count == 0 {
+		rec.firstSeen = now
+	}
+	rec.count++
+	rec.lastSeen = now
+	ls.unrecoverableRollbacks[key] = rec
+	return rec.count, rec.count >= unrecoverableRollbackThreshold
+}
+
+// clearUnrecoverableRollbacks resets the tracker after the node makes
+// forward progress (a rollback applied successfully), so a later,
+// unrelated divergence starts counting from zero.
+//
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) clearUnrecoverableRollbacks() {
+	ls.unrecoverableRollbacks = nil
+}
+
+// reportUnrecoverableRollbackIfStuck records a failed rollback point and,
+// once the same point has failed enough times across reset+reconnect
+// cycles, surfaces the stuck-divergence condition as a throttled
+// operator-facing error plus a metric, rather than only the per-attempt
+// WARN that otherwise repeats indefinitely with zero forward progress.
+//
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) reportUnrecoverableRollbackIfStuck(
+	point ocommon.Point,
+	reason string,
+	connId ouroboros.ConnectionId,
+) {
+	count, stuck := ls.noteUnrecoverableRollback(point)
+	if !stuck {
+		return
+	}
+	if ls.metrics.unrecoverableRollbacks != nil {
+		ls.metrics.unrecoverableRollbacks.Inc()
+	}
+	now := time.Now()
+	if now.Sub(ls.lastUnrecoverableRollbackLog) < unrecoverableRollbackLogInterval {
+		return
+	}
+	ls.lastUnrecoverableRollbackLog = now
+	if ls.config.Logger != nil {
+		ls.config.Logger.Error(
+			"chainsync stuck: repeatedly cannot cross to peer rollback point; "+
+				"local chain has diverged from the network and cannot self-recover. "+
+				"Operator intervention required (e.g. re-bootstrap from a Mithril snapshot).",
+			"component", "ledger",
+			"slot", point.Slot,
+			"hash", hex.EncodeToString(point.Hash),
+			"reason", reason,
+			"failed_attempts", count,
+			"window", unrecoverableRollbackWindow,
+			"connection_id", connId.String(),
+		)
+	}
+}

--- a/ledger/chainsync_unrecoverable_rollback_test.go
+++ b/ledger/chainsync_unrecoverable_rollback_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// freshUnrecoverableConnId returns a distinct connection ID for each call,
+// mimicking the new bearer that peer governance opens after every forced
+// reconnect during the issue #2728 rollback loop.
+func freshUnrecoverableConnId(port int) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
+	}
+}
+
+// TestUnrecoverableRollbackTrackerSurvivesResyncReset reproduces the core
+// gap behind issue #2728: a diverged node is asked to roll back to the same
+// canonical point it cannot cross to, and on every attempt it wipes
+// rollbackHistory (the resync reset) and reconnects with a fresh connection.
+// The per-connection rollback loop detector therefore never accumulates.
+// The point-keyed unrecoverableRollbacks tracker must accumulate instead, so
+// the stuck condition is eventually recognised.
+func TestUnrecoverableRollbackTrackerSurvivesResyncReset(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	point := ocommon.NewPoint(
+		116385054,
+		[]byte{0x46, 0xc5, 0xd0, 0x72, 0x6c, 0xcf, 0xc5, 0xde},
+	)
+
+	var lastCount int
+	var everStuck bool
+	for cycle := range unrecoverableRollbackThreshold {
+		// A fresh connection each cycle, exactly as after a forced
+		// reconnect. Record it the way the per-connection loop detector
+		// does so we can show that detector never reaches its threshold.
+		connKey := connIdKey(freshUnrecoverableConnId(3001 + cycle))
+		ls.rollbackHistory = append(ls.rollbackHistory, rollbackRecord{
+			point:     point,
+			connKey:   connKey,
+			timestamp: time.Now(),
+		})
+		var perConnCount int
+		for _, r := range ls.rollbackHistory {
+			if r.connKey == connKey && pointMatches(r.point, point) {
+				perConnCount++
+			}
+		}
+		require.Equal(
+			t,
+			1,
+			perConnCount,
+			"per-connection loop detector must see only one hit per fresh connection",
+		)
+
+		// resetChainsyncResyncState / requestChainsyncResync wipe
+		// rollbackHistory on every un-crossable rollback.
+		ls.rollbackHistory = nil
+
+		count, stuck := ls.noteUnrecoverableRollback(point)
+		lastCount = count
+		if stuck {
+			everStuck = true
+		}
+	}
+
+	require.Equal(
+		t,
+		unrecoverableRollbackThreshold,
+		lastCount,
+		"point-keyed tracker must accumulate across reset+reconnect cycles",
+	)
+	require.True(
+		t,
+		everStuck,
+		"tracker must report stuck once the threshold is reached",
+	)
+	require.Nil(
+		t,
+		ls.rollbackHistory,
+		"per-connection loop detector state is wiped each cycle, so it never trips",
+	)
+}
+
+// TestReportUnrecoverableRollbackSurfacesOperatorSignal verifies that once
+// the same un-crossable rollback point recurs past the threshold, the stuck
+// condition is surfaced via the dedicated metric instead of only the
+// per-attempt WARN that otherwise loops forever.
+func TestReportUnrecoverableRollbackSurfacesOperatorSignal(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+	point := ocommon.NewPoint(
+		116385054,
+		[]byte{0x46, 0xc5, 0xd0, 0x72, 0x6c, 0xcf, 0xc5, 0xde},
+	)
+
+	// Below threshold: no metric increment.
+	for cycle := range unrecoverableRollbackThreshold - 1 {
+		ls.reportUnrecoverableRollbackIfStuck(
+			point,
+			event.ChainsyncResyncReasonRollbackNotFound,
+			freshUnrecoverableConnId(3001+cycle),
+		)
+	}
+	require.Equal(
+		t,
+		float64(0),
+		promtestutil.ToFloat64(ls.metrics.unrecoverableRollbacks),
+		"metric must stay zero until the threshold is crossed",
+	)
+
+	// Crossing the threshold trips the metric.
+	ls.reportUnrecoverableRollbackIfStuck(
+		point,
+		event.ChainsyncResyncReasonRollbackNotFound,
+		freshUnrecoverableConnId(4000),
+	)
+	require.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(ls.metrics.unrecoverableRollbacks),
+		"metric must increment once the node is recognised as stuck",
+	)
+
+	// Every further stuck attempt keeps incrementing the counter.
+	ls.reportUnrecoverableRollbackIfStuck(
+		point,
+		event.ChainsyncResyncReasonRollbackNotFound,
+		freshUnrecoverableConnId(4001),
+	)
+	require.Equal(
+		t,
+		float64(2),
+		promtestutil.ToFloat64(ls.metrics.unrecoverableRollbacks),
+	)
+
+	// Forward progress clears the tracker, so an unrelated later
+	// divergence starts counting from zero.
+	ls.clearUnrecoverableRollbacks()
+	count, stuck := ls.noteUnrecoverableRollback(point)
+	require.Equal(t, 1, count)
+	require.False(t, stuck)
+}

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -39,6 +39,10 @@ type stateMetrics struct {
 	// decode during the mid-epoch ratifiability check, so the failures
 	// surface as a metric instead of just log volume.
 	governanceProposalDecodeFailures prometheus.Counter
+	// Incremented when a peer repeatedly asks us to roll back to a point
+	// we cannot cross to (local chain diverged), so a stuck node surfaces
+	// as a metric instead of only a WARN loop. See issue #2728.
+	unrecoverableRollbacks prometheus.Counter
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -130,6 +134,12 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.CounterOpts{
 			Name: "dingo_governance_proposal_decode_failures_total",
 			Help: "stored governance proposals whose CBOR failed to decode during ratifiability checks",
+		},
+	)
+	m.unrecoverableRollbacks = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_chainsync_unrecoverable_rollback_total",
+			Help: "times a peer repeatedly requested a rollback we cannot cross to (local chain diverged, operator intervention required)",
 		},
 	)
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -592,6 +592,20 @@ type LedgerState struct {
 
 	rollbackHistory []rollbackRecord // recent rollback slot+time pairs for loop detection
 
+	// unrecoverableRollbacks tracks rollback points a peer repeatedly asks
+	// us to cross to but that we cannot apply locally (block missing below
+	// our diverged tip, rollback exceeds K, or the point is below the
+	// Mithril trust boundary). Unlike rollbackHistory it is keyed on the
+	// rollback point alone (not the connection) and is deliberately NOT
+	// cleared by the resync reset, so it survives the reset+reconnect
+	// cycle. That cycle otherwise defeats the rollbackHistory-based loop
+	// detector: each un-crossable rollback calls resetChainsyncResyncState
+	// (which wipes rollbackHistory) and forces a fresh connection, and the
+	// detector keys on connection ID, so the per-connection counter never
+	// reaches its threshold across reconnects. See issue #2728.
+	unrecoverableRollbacks       map[string]unrecoverableRollbackRecord
+	lastUnrecoverableRollbackLog time.Time // throttles the stuck-divergence operator error
+
 	lastActiveConnId *ouroboros.ConnectionId // tracks active connection for switch detection
 
 	// Header mismatch tracking for fork detection and re-sync


### PR DESCRIPTION
Closes #2728 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Detects and reports unrecoverable ChainSync rollbacks that cause infinite resync loops. Repeated failed rollbacks are tracked across reconnects, surfaced via a throttled operator error, and exposed as `dingo_chainsync_unrecoverable_rollback_total`.

- **Bug Fixes**
  - Added point-keyed tracker `unrecoverableRollbacks` that survives resync resets; threshold=3 within a 10m window.
  - Emits a throttled error when stuck and increments Prometheus counter `dingo_chainsync_unrecoverable_rollback_total`.
  - Clears the tracker on successful rollback to avoid false positives.
  - Hooked into `handleEventChainsyncRollback` for not-found, exceeds-K, and below-Mithril-boundary cases.
  - Added unit tests and updated architecture docs.

<sup>Written for commit 97a7247938c7f2e53bdf505fd2007c0a4e038d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

