### PR TITLE
fix(leios): escalate per-connection backfill cooldown on repeated failures

### DIFF
--- a/ouroboros/leios_backfill.go
+++ b/ouroboros/leios_backfill.go
@@ -37,6 +37,18 @@ var leiosBackfillConnCursor atomic.Uint64
 // available, so every connection is still eventually tried.
 const leiosBackfillConnCooldown = 20 * time.Second
 
+// leiosBackfillConnCooldownMax caps the escalated per-connection backfill
+// cooldown so a persistently-failing connection is deprioritized aggressively
+// but its cooldown never grows without bound (it is still eventually retried
+// when no healthy connection is available).
+const leiosBackfillConnCooldownMax = 5 * time.Minute
+
+// leiosBackfillConnCooldownMaxShift bounds the exponential cooldown escalation
+// (base << shift) so the shift can never overflow the duration; the cap above
+// is reached well before this bound (20s << 4 = 320s > 5m), so this is only a
+// safety ceiling on the shift amount.
+const leiosBackfillConnCooldownMaxShift = 5
+
 // FetchEndorserBlockByPoint fetches the endorser block identified by
 // (ebSlot, ebHash) -- its manifest and all transaction bodies -- over
 // leios-fetch and caches it, so EndorserBlockTxsByHash subsequently returns it.

--- a/ouroboros/leios_fetch_resilience_test.go
+++ b/ouroboros/leios_fetch_resilience_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// assertCooldownWindow asserts the guard is in cooldown right up to, but not at,
+// now+want.
+func assertCooldownWindow(
+	t *testing.T,
+	g *leiosFetchGuard,
+	now time.Time,
+	want time.Duration,
+) {
+	t.Helper()
+	require.Truef(
+		t,
+		g.inCooldown(now.Add(want-time.Nanosecond)),
+		"expected in cooldown just before %s", want,
+	)
+	require.Falsef(
+		t,
+		g.inCooldown(now.Add(want)),
+		"expected not in cooldown at %s", want,
+	)
+}
+
+// TestLeiosFetchGuardCooldownEscalates verifies that consecutive backfill
+// failures on the same connection escalate the cooldown exponentially from the
+// base, so a connection that repeatedly returns wrong (hash-mismatching) or
+// unservable/stalling responses is deprioritized for progressively longer.
+func TestLeiosFetchGuardCooldownEscalates(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_780_000_000, 0)
+	base := leiosBackfillConnCooldown
+	g := &leiosFetchGuard{}
+
+	// 1st failure = base, then doubling on each consecutive failure.
+	g.markFetchFailed(now, base)
+	assertCooldownWindow(t, g, now, base)
+
+	g.markFetchFailed(now, base)
+	assertCooldownWindow(t, g, now, 2*base)
+
+	g.markFetchFailed(now, base)
+	assertCooldownWindow(t, g, now, 4*base)
+
+	g.markFetchFailed(now, base)
+	assertCooldownWindow(t, g, now, 8*base)
+}
+
+// TestLeiosFetchGuardCooldownCaps verifies the escalating cooldown never exceeds
+// leiosBackfillConnCooldownMax no matter how many consecutive failures occur.
+func TestLeiosFetchGuardCooldownCaps(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_780_000_000, 0)
+	base := leiosBackfillConnCooldown
+	g := &leiosFetchGuard{}
+
+	for range 50 {
+		g.markFetchFailed(now, base)
+	}
+	// At the cap: still cooling just before the max deadline, clear at/after it.
+	assertCooldownWindow(t, g, now, leiosBackfillConnCooldownMax)
+}
+
+// TestLeiosFetchGuardCooldownResetsOnSuccess verifies a successful fetch clears
+// the cooldown AND resets the escalation, so the next failure starts again at
+// the base cooldown rather than the escalated one.
+func TestLeiosFetchGuardCooldownResetsOnSuccess(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_780_000_000, 0)
+	base := leiosBackfillConnCooldown
+	g := &leiosFetchGuard{}
+
+	// Escalate a few times.
+	g.markFetchFailed(now, base)
+	g.markFetchFailed(now, base)
+	g.markFetchFailed(now, base)
+	assertCooldownWindow(t, g, now, 4*base)
+
+	// A success clears the cooldown immediately and resets escalation.
+	g.markFetchOK()
+	require.False(t, g.inCooldown(now), "success should clear the cooldown")
+
+	// The next failure starts again at the base window, not the escalated one.
+	g.markFetchFailed(now, base)
+	assertCooldownWindow(t, g, now, base)
+}

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -574,16 +574,44 @@ type leiosFetchGuard struct {
 	// timed-out fetch, so it prefers healthy connections instead of repeatedly
 	// retrying a stalled or flaky one.
 	cooledUntilNano atomic.Int64
+	// consecutiveFailures counts back-to-back failed/timed-out backfill
+	// fetches on this connection with no intervening success. It escalates the
+	// cooldown (see markFetchFailed) so a connection that repeatedly returns
+	// wrong (hash-mismatching) or unservable/stalling responses is
+	// deprioritized for progressively longer; markFetchOK resets it.
+	consecutiveFailures atomic.Int32
 }
 
-// markFetchFailed puts this connection on a short cooldown after a failed or
-// timed-out backfill fetch.
-func (g *leiosFetchGuard) markFetchFailed(now time.Time, d time.Duration) {
+// markFetchFailed puts this connection on a cooldown after a failed or
+// timed-out backfill fetch. Consecutive failures on the same connection
+// escalate the cooldown exponentially from base, capped at
+// leiosBackfillConnCooldownMax, so a connection that repeatedly returns wrong
+// (hash-mismatching) or unservable/stalling responses is deprioritized for
+// progressively longer and the backfill prefers other connections/backends.
+// The cooldown only reorders connection preference -- FetchEndorserBlockByPoint
+// still falls back to cooled connections when none are healthy -- so a
+// persistently-bad connection is deprioritized but never permanently starved.
+func (g *leiosFetchGuard) markFetchFailed(now time.Time, base time.Duration) {
+	n := g.consecutiveFailures.Add(1)
+	d := base
+	if n > 1 {
+		shift := n - 1
+		if shift > leiosBackfillConnCooldownMaxShift {
+			shift = leiosBackfillConnCooldownMaxShift
+		}
+		d = base << uint(shift)
+	}
+	// Guard against overflow (d <= 0) and clamp to the cap.
+	if d <= 0 || d > leiosBackfillConnCooldownMax {
+		d = leiosBackfillConnCooldownMax
+	}
 	g.cooledUntilNano.Store(now.Add(d).UnixNano())
 }
 
-// markFetchOK clears any cooldown after a successful fetch on this connection.
+// markFetchOK clears any cooldown and resets the failure escalation after a
+// successful fetch on this connection.
 func (g *leiosFetchGuard) markFetchOK() {
+	g.consecutiveFailures.Store(0)
 	g.cooledUntilNano.Store(0)
 }
 


### PR DESCRIPTION
Escalate the per-connection Leios backfill cooldown geometrically (20s → 40s → 80s → 160s, capped 5m, reset on success) so a connection that repeatedly returns hash-mismatching manifests (now diagnosed by #2733) or repeatedly stalls is deprioritized, steering backfill toward healthier backends. Peer selection is otherwise unchanged: no starvation, no new wedge, no extra relay flooding; the manifest hash check remains authoritative.

Addresses the ~1–2 blocks/min crawl in #2729 and the long relay-fetch stalls on the musashi validation node. Pairs with outbound DNS backend-spread (#2731), which makes alternate backends reachable.

Build, `go test -race ./ouroboros/`, and conformance pass; new tests cover the escalation/reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaChbD7R59hJp5Hqq9MYo2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escalates the per-connection Leios backfill cooldown on consecutive failures (20s → 40s → 80s → 160s, capped at 5m) and resets on success to deprioritize flaky connections and steer backfill to healthy backends. Mitigates the ~1–2 blocks/min crawl and long relay-fetch stalls with no peer starvation.

- **Bug Fixes**
  - Track consecutive failures and apply exponential cooldown; clamp with `leiosBackfillConnCooldownMax` and a safety shift bound.
  - Reset cooldown and escalation on any success; cooled peers are still retried if no healthy peers exist.
  - Add tests covering escalation, cap, and reset behavior.

<sup>Written for commit e6025ee998fa44da31c3f2f2c259cfc5f3665c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backfill fetch resilience by making cooldowns increase after repeated failures, helping reduce rapid retry loops.
  * Added a safety cap so cooldowns won’t grow beyond a reasonable maximum.
  * Successful fetches now immediately clear the cooldown and reset retry behavior.

* **Tests**
  * Added coverage for cooldown escalation, maximum cap behavior, and reset-on-success handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->