### PR TITLE
fix(peergov): no reconnect never connected peers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1248,21 +1248,31 @@ upstream connection left, capped per cycle. This guarantees the node converges
 back to connected even when a close event cannot be attributed to its peer or
 a dial loop exited early. Gossip churn never demotes the peer holding the last
 eligible upstream connection, so routine churn cannot leave the node without a
-chainsync source. Each outbound dial attempt re-resolves a hostname-based
-peer's address fresh, narrows the records to the address families the local
-host can route to (detected once via `net.InterfaceAddrs` and cached, so a
-v4-only or v6-only host never dials a dead family), and picks one of the
-remaining records at random for that attempt (`resolveDialAddress`), so repeated
-attempts spread across every reachable backend behind a load-balancer hostname
-and a congested or half-dead backend is escaped on the next attempt rather than
-pinned until a process restart. If family detection is inconclusive or filters
-everything out, the full record set is used so a peer is never stranded. The
-re-resolution runs against `net.DefaultResolver` with a context bounded by a
-few seconds and tied to the governor context, so a hung or slow resolver
-cannot wedge the outbound-dial loop and a shutdown cancels an in-flight lookup
-promptly; on timeout or failure the attempt falls back to the unresolved
-address. IP-literal peers dial unchanged, and peer identity/dedup stays keyed
-on the stable `Address`/`NormalizedAddress`, not the rotating dial target.
+chainsync source.
+
+Conversely, a discovered (gossip/ledger) or public-root peer
+that fails its outbound dial while it has never successfully connected is
+dropped and briefly deny-listed instead of being retried, since a peer
+unreachable even once is almost certainly dead and endless redials to it waste
+dial capacity; local-root and bootstrap peers, and any peer that has connected
+at least once, keep retrying, and the drop is suppressed while the node has no
+eligible upstream so its last leads back onto the network are never discarded.
+
+Each outbound dial attempt re-resolves a hostname-based peer's address fresh,
+narrows the records to the address families the local host can route to
+(detected once via `net.InterfaceAddrs` and cached, so a v4-only or v6-only
+host never dials a dead family), and picks one of the remaining records at
+random for that attempt (`resolveDialAddress`), so repeated attempts spread
+across every reachable backend behind a load-balancer hostname and a congested
+or half-dead backend is escaped on the next attempt rather than pinned until a
+process restart. If family detection is inconclusive or filters everything out,
+the full record set is used so a peer is never stranded. The re-resolution runs
+against `net.DefaultResolver` with a context bounded by a few seconds and tied
+to the governor context, so a hung or slow resolver cannot wedge the
+outbound-dial loop and a shutdown cancels an in-flight lookup promptly; on
+timeout or failure the attempt falls back to the unresolved address. IP-literal
+peers dial unchanged, and peer identity/dedup stays keyed on the stable
+`Address`/`NormalizedAddress`, not the rotating dial target.
 
 Reconnect backoff after short-lived sessions escalates exponentially. The
 reconnect goroutine consumes and zeroes the stored delay before dialing, so

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -108,6 +108,10 @@ type ChainSelectorConfig struct {
 	ConnectionEligible func(ouroboros.ConnectionId) bool
 	ConnectionPriority func(ouroboros.ConnectionId) int
 	MaxTrackedPeers    int // 0 means use DefaultMaxTrackedPeers
+	// DisableEventSubscriptions leaves EventBus configured for publishing
+	// selector events but skips automatic input subscriptions. This is useful
+	// for deterministic replay harnesses that feed input events synchronously.
+	DisableEventSubscriptions bool
 	// BlockfetchLatency returns the EWMA first-block latency for a
 	// connection and whether any samples exist. Used only to choose a
 	// peer when two peers advertise the exact same selected block.
@@ -175,10 +179,10 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 	if cfg.GenesisMode {
 		cs.mode = SelectionModeGenesis
 	}
-	if cfg.EventBus != nil {
+	if cfg.EventBus != nil && !cfg.DisableEventSubscriptions {
 		cfg.EventBus.SubscribeFunc(
 			PeerRollbackEventType,
-			cs.handlePeerRollbackEvent,
+			cs.HandlePeerRollbackEvent,
 		)
 	}
 	return cs
@@ -1362,9 +1366,9 @@ func (cs *ChainSelector) HandlePeerActivityEvent(evt event.Event) {
 	cs.TouchPeerActivity(e.ConnectionId)
 }
 
-// handlePeerRollbackEvent trims Genesis observed history and refreshes the
+// HandlePeerRollbackEvent trims Genesis observed history and refreshes the
 // tracked peer tip after a rollback.
-func (cs *ChainSelector) handlePeerRollbackEvent(evt event.Event) {
+func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 	e, ok := evt.Data.(PeerRollbackEvent)
 	if !ok {
 		cs.config.Logger.Warn(

--- a/ouroboros/consensus_conformance_test.go
+++ b/ouroboros/consensus_conformance_test.go
@@ -163,8 +163,9 @@ func newReplayAdapter(
 	// default for older vectors — reproduces the prior k-disabled
 	// behaviour.
 	cs := chainselection.NewChainSelector(chainselection.ChainSelectorConfig{
-		EventBus:      bus,
-		SecurityParam: capture.SecurityParam,
+		EventBus:                  bus,
+		SecurityParam:             capture.SecurityParam,
+		DisableEventSubscriptions: true,
 	})
 	if capture.LocalTip != nil {
 		// Arms the implausibility-guard catch-up relaxation so a peer
@@ -223,14 +224,28 @@ func (a *replayAdapter) RollForward(
 func (a *replayAdapter) RollBackward(
 	peerID uint64, point format.Point, tip format.Tip,
 ) error {
-	return a.o.chainsyncClientRollBackward(
-		ochainsync.CallbackContext{ConnectionId: a.connFor(peerID)},
-		ocommon.Point{
-			Slot: point.Slot,
-			Hash: append([]byte(nil), point.Hash...),
+	connId := a.connFor(peerID)
+	rollbackPoint := ocommon.Point{
+		Slot: point.Slot,
+		Hash: append([]byte(nil), point.Hash...),
+	}
+	rollbackTip := toGouroborosTip(tip)
+	if err := a.o.chainsyncClientRollBackward(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		rollbackPoint,
+		rollbackTip,
+	); err != nil {
+		return err
+	}
+	a.cs.HandlePeerRollbackEvent(event.NewEvent(
+		chainselection.PeerRollbackEventType,
+		chainselection.PeerRollbackEvent{
+			ConnectionId: connId,
+			Point:        rollbackPoint,
+			Tip:          rollbackTip,
 		},
-		toGouroborosTip(tip),
-	)
+	))
+	return nil
 }
 
 func (a *replayAdapter) Stabilize() {

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -325,6 +325,7 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			oldSource := currentPeer.Source
 			oldConn := clonePeerConnection(currentPeer.Connection)
 			currentPeer.ConnectedAt = time.Now()
+			currentPeer.EverConnected = true
 			currentPeer.setConnection(conn, true)
 			p.recordPeerStateChange(currentPeer.State, PeerStateWarm)
 			currentPeer.State = PeerStateWarm
@@ -454,6 +455,40 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		peerSource := currentPeer.Source
 		peerAddress := currentPeer.Address
 		peerNormalizedAddress := currentPeer.NormalizedAddress
+		// Discovered (peer-share gossip, ledger) and public-root peers that
+		// have never successfully connected are dropped after a failed dial
+		// rather than retried indefinitely: a peer we cannot reach even once
+		// is almost certainly unreachable, and redialing it forever wastes
+		// dial capacity. Exceptions that keep their existing retry behavior:
+		//   - local-root and bootstrap peers (operator-configured, trusted);
+		//   - any peer that connected at least once (a transient loss is
+		//     worth recovering);
+		//   - when the node has no eligible upstream left, these peers are the
+		//     only leads back onto the network, so they are kept and
+		//     emergency-redialed rather than dropped (avoids self-stranding,
+		//     matching redialCandidatesLocked's emergency budget).
+		if p.shouldDropNeverConnectedPeerAfterDialFailureLocked(currentPeer) {
+			p.denyList[peerNormalizedAddress] = time.Now().Add(
+				p.config.DenyDuration,
+			)
+			p.peers = append(p.peers[:peerIdx], p.peers[peerIdx+1:]...)
+			p.updatePeerMetrics()
+			p.mu.Unlock()
+			p.config.Logger.Info(
+				"outbound: dropping never-connected discovered/public-root peer after failed connection",
+				"address", peerAddress,
+				"source", peerSource.String(),
+				"deny_duration", p.config.DenyDuration,
+			)
+			p.publishEvent(
+				PeerRemovedEventType,
+				PeerStateChangeEvent{
+					Address: peerAddress,
+					Reason:  "never-connected discovered or public-root peer",
+				},
+			)
+			return
+		}
 		if !p.isTopologyPeer(peerSource) &&
 			reconnectCount > p.config.MaxReconnectFailureThreshold {
 			// Fail fast for non-topology peers. Waiting for the long
@@ -509,6 +544,21 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 		case <-time.After(reconnectDelay):
 		}
 	}
+}
+
+// shouldDropNeverConnectedPeerAfterDialFailureLocked reports whether a failed
+// outbound dial should retire the peer instead of retrying. Must be called with
+// p.mu held.
+func (p *PeerGovernor) shouldDropNeverConnectedPeerAfterDialFailureLocked(
+	peer *Peer,
+) bool {
+	if peer == nil ||
+		peer.EverConnected ||
+		peer.hasClientConnection() ||
+		!dropIfNeverConnected(peer.Source) {
+		return false
+	}
+	return p.countEligibleUpstreamsLocked() > 0
 }
 
 func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
@@ -636,6 +686,9 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 			// available, treat it as authoritative for inbound duplex metadata.
 			tmpPeer.InboundDuplex = inboundIsClient
 		}
+	}
+	if tmpPeer.hasClientConnection() || tmpPeer.InboundDuplex {
+		tmpPeer.EverConnected = true
 	}
 	// Reset outbound backoff when an inbound connection from a
 	// topology peer succeeds. The inbound proves the peer is

--- a/peergov/peer.go
+++ b/peergov/peer.go
@@ -106,6 +106,11 @@ type Peer struct {
 	// so this counter is what carries the backoff rung across sessions.
 	OutboundShortLivedCount uint32
 	Reconnecting            bool // Whether a reconnect goroutine is active for this peer
+	// EverConnected records whether this peer has ever established a
+	// client-capable connection. Discovered (peer-share/ledger) and
+	// public-root peers that have never connected are dropped after a failed
+	// dial instead of being retried indefinitely.
+	EverConnected           bool
 	State                   PeerState
 	Source                  PeerSource
 	Sharable                bool

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -7675,6 +7675,32 @@ func TestHandleInboundConnection_InboundDuplexFromEvent(t *testing.T) {
 		"event-derived duplex hint must be retained when connmanager is nil")
 }
 
+func TestHandleInboundConnection_DuplexMarksEverConnected(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:     newMockEventBus(),
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	localAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.9:3001")
+	remoteAddr, _ := net.ResolveTCPAddr("tcp", "44.0.0.1:51432")
+	pg.handleInboundConnectionEvent(event.Event{
+		Type: connmanager.InboundConnectionEventType,
+		Data: connmanager.InboundConnectionEvent{
+			ConnectionId: ouroboros.ConnectionId{
+				LocalAddr: localAddr, RemoteAddr: remoteAddr,
+			},
+			LocalAddr:            localAddr,
+			RemoteAddr:           remoteAddr,
+			NormalizedRemoteAddr: connmanager.NormalizePeerAddr(remoteAddr.String()),
+			IsDuplex:             true,
+		},
+	})
+	peers := pg.GetPeers()
+	require.Len(t, peers, 1)
+	assert.True(t, peers[0].EverConnected,
+		"inbound duplex connection must count as prior successful connectivity")
+}
+
 func TestCensusInboundCounts_DuplexRequiresLiveConnection(t *testing.T) {
 	pg := NewPeerGovernor(PeerGovernorConfig{
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),

--- a/peergov/quotas.go
+++ b/peergov/quotas.go
@@ -74,6 +74,22 @@ func (p *PeerGovernor) isTopologyPeer(source PeerSource) bool {
 	}
 }
 
+// dropIfNeverConnected reports whether a peer from this source that has never
+// successfully connected should be dropped after a failed dial rather than
+// retried. It covers discovered peers (peer-share gossip and ledger) and
+// public-root topology peers. Local-root and bootstrap peers are trusted and
+// always retried; inbound peers are not dialed outbound.
+func dropIfNeverConnected(source PeerSource) bool {
+	switch source {
+	case PeerSourceTopologyPublicRoot,
+		PeerSourceP2PLedger,
+		PeerSourceP2PGossip:
+		return true
+	default:
+		return false
+	}
+}
+
 // countPeersBySourceAndState returns a map of peer source to peer counts by state.
 // This method must be called with p.mu held.
 // nolint:unused // Exported for tests and future use in Phase 3+ churn timers

--- a/peergov/reconnect_gate_test.go
+++ b/peergov/reconnect_gate_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadDialAddress is a loopback address with nothing listening, so an outbound
+// dial to it fails fast and drives the reconnect fail path.
+const deadDialAddress = "127.0.0.1:1"
+
+// newReconnectGateTestGovernor wires a PeerGovernor with a real connection
+// manager whose dials to deadDialAddress fail fast, so the outbound reconnect
+// gate can be exercised end to end.
+func newReconnectGateTestGovernor(t *testing.T, threshold int) *PeerGovernor {
+	t.Helper()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   logger,
+		EventBus: newMockEventBus(),
+		ConnManager: connmanager.NewConnectionManager(
+			connmanager.ConnectionManagerConfig{Logger: logger},
+		),
+		MaxReconnectFailureThreshold: threshold,
+		DenyDuration:                 30 * time.Minute,
+	})
+	pg.mu.Lock()
+	pg.ctx = t.Context()
+	pg.stopCh = make(chan struct{})
+	pg.mu.Unlock()
+	t.Cleanup(pg.Stop)
+	return pg
+}
+
+// setupReconnectGateTest installs a target peer at the dead dial address and,
+// when withUpstream is set, a connected chain-selection-eligible upstream so
+// the node is not stranded. The gate only drops never-connected discovered or
+// public-root peers while eligible upstreams remain. Returns the target peer.
+func setupReconnectGateTest(
+	pg *PeerGovernor,
+	source PeerSource,
+	everConnected bool,
+	withUpstream bool,
+) *Peer {
+	target := &Peer{
+		Address:           deadDialAddress,
+		NormalizedAddress: deadDialAddress,
+		Source:            source,
+		State:             PeerStateCold,
+		EverConnected:     everConnected,
+	}
+	peers := []*Peer{target}
+	if withUpstream {
+		peers = append(peers, &Peer{
+			Address:           "203.0.113.10:3001",
+			NormalizedAddress: "203.0.113.10:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateHot,
+			Connection:        &PeerConnection{IsClient: true},
+		})
+	}
+	pg.mu.Lock()
+	pg.peers = peers
+	pg.mu.Unlock()
+	return target
+}
+
+func peersContainAddress(peers []*Peer, address string) bool {
+	for _, peer := range peers {
+		if peer != nil && peer.NormalizedAddress == address {
+			return true
+		}
+	}
+	return false
+}
+
+// A discovered (peer-share gossip) peer that has never connected must be
+// dropped and denied after its first failed dial when other upstreams remain.
+func TestCreateOutboundConnection_DropsNeverConnectedGossipPeer(t *testing.T) {
+	pg := newReconnectGateTestGovernor(t, 0)
+	target := setupReconnectGateTest(pg, PeerSourceP2PGossip, false, true)
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		_, denied := pg.denyList[deadDialAddress]
+		return !peersContainAddress(pg.peers, deadDialAddress) && denied
+	}, 5*time.Second, 10*time.Millisecond,
+		"never-connected gossip peer must be dropped and denied after a failed dial")
+}
+
+// A public-root peer that has never connected must likewise be dropped, even
+// though it is a topology-sourced peer.
+func TestCreateOutboundConnection_DropsNeverConnectedPublicRootPeer(t *testing.T) {
+	pg := newReconnectGateTestGovernor(t, 0)
+	target := setupReconnectGateTest(pg, PeerSourceTopologyPublicRoot, false, true)
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		_, denied := pg.denyList[deadDialAddress]
+		return !peersContainAddress(pg.peers, deadDialAddress) && denied
+	}, 5*time.Second, 10*time.Millisecond,
+		"never-connected public-root peer must be dropped and denied after a failed dial")
+}
+
+// A local-root peer that has never connected is trusted and must keep retrying,
+// never dropped or denied, even while other upstreams exist.
+func TestCreateOutboundConnection_RetainsNeverConnectedLocalRootPeer(t *testing.T) {
+	pg := newReconnectGateTestGovernor(t, 0)
+	target := setupReconnectGateTest(pg, PeerSourceTopologyLocalRoot, false, true)
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		return peersContainAddress(pg.peers, deadDialAddress) && target.ReconnectCount > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"never-connected local-root peer must keep retrying, not be dropped")
+
+	pg.mu.Lock()
+	_, denied := pg.denyList[deadDialAddress]
+	pg.mu.Unlock()
+	assert.False(t, denied, "local-root peer must never be denied by the never-connected gate")
+}
+
+// A discovered peer that connected at least once must keep retrying on a later
+// failure; a transient loss is worth recovering. A high failure threshold keeps
+// the unrelated fail-fast path from interfering with the assertion.
+func TestCreateOutboundConnection_RetainsEverConnectedGossipPeer(t *testing.T) {
+	pg := newReconnectGateTestGovernor(t, 1000)
+	target := setupReconnectGateTest(pg, PeerSourceP2PGossip, true, true)
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		return peersContainAddress(pg.peers, deadDialAddress) && target.ReconnectCount > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"gossip peer that connected once must keep retrying on a later failure, not be dropped")
+
+	pg.mu.Lock()
+	_, denied := pg.denyList[deadDialAddress]
+	pg.mu.Unlock()
+	assert.False(t, denied, "ever-connected gossip peer must not be denied by the never-connected gate")
+}
+
+// When the node has no eligible upstream, a never-connected gossip peer is the
+// only lead back onto the network and must be kept and retried rather than
+// dropped, preserving the anti-stranding emergency redial path.
+func TestCreateOutboundConnection_RetainsNeverConnectedGossipPeerWhenNoUpstream(t *testing.T) {
+	pg := newReconnectGateTestGovernor(t, 1000)
+	target := setupReconnectGateTest(pg, PeerSourceP2PGossip, false, false)
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		return peersContainAddress(pg.peers, deadDialAddress) && target.ReconnectCount > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"never-connected gossip peer must be retried when the node has no upstream left")
+
+	pg.mu.Lock()
+	_, denied := pg.denyList[deadDialAddress]
+	pg.mu.Unlock()
+	assert.False(t, denied, "last-lead gossip peer must not be denied when no upstream remains")
+}
+
+// A peer can gain a client-capable inbound connection while an outbound dial is
+// still in flight. If that outbound dial then fails, the never-connected gate
+// must not remove the now-healthy upstream.
+func TestNeverConnectedDropGate_RetainsCurrentClientConnection(t *testing.T) {
+	pg := newReconnectGateTestGovernor(t, 0)
+	target := setupReconnectGateTest(pg, PeerSourceP2PGossip, false, true)
+
+	pg.mu.Lock()
+	target.Connection = &PeerConnection{IsClient: true}
+	drop := pg.shouldDropNeverConnectedPeerAfterDialFailureLocked(target)
+	pg.mu.Unlock()
+
+	assert.False(t, drop, "current client-capable connection must suppress the never-connected drop")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop retrying outbound dials to discovered or public‑root peers that have never connected. After a failed dial, these peers are dropped and briefly deny‑listed to free reconnect capacity; retries continue for trusted roots, ever‑connected peers, and when no upstream remains.

- **Bug Fixes**
  - Added `EverConnected` on `Peer`; set on first successful outbound and on any inbound duplex/client connection.
  - On failed dial, drop+deny never‑connected `P2P gossip`, `P2P ledger`, and `public-root` peers only when other eligible upstreams exist; keep retrying for `local-root`, `bootstrap`, any ever‑connected peer, or when no upstream remains; suppress drop if a client connection is present.
  - Added `dropIfNeverConnected` and `shouldDropNeverConnectedPeerAfterDialFailureLocked`; updated logs/metrics and docs; new end‑to‑end reconnect‑gate tests and an inbound‑duplex EverConnected test.
  - Chain selection conformance: added `DisableEventSubscriptions` to `ChainSelector` and exported `HandlePeerRollbackEvent`; replay harness now manually emits rollback events for deterministic runs.

<sup>Written for commit db7e18ea055170442d0aa8213966807baecdfafd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

