### PR TITLE
fix(ledger): correct Praos epoch nonce across Mithril and epoch boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -641,13 +641,25 @@ When `Node.Run()` is called, components are initialized in this order:
     idempotent (ON CONFLICT DO NOTHING) so a
     crash-restart replay is safe.
  9. LedgerState start. Loading the epoch cache (`loadEpochs`) also runs
-    `healEmptyLabNonces`: it repairs any epoch record whose
-    `last_epoch_block_nonce` was persisted empty or stale by pre-fix boundary
-    lookup bugs, re-deriving the lab from the active chain's boundary block and
-    recomputing the affected epoch's nonce in the cache when that epoch has a
-    stored `candidate_nonce`, so leader-VRF verification matches the network.
-    If the candidate is missing, startup leaves the epoch unchanged rather than
-    substituting Shelley genesis for a candidate that may have evolved.
+    `healEmptyLabNonces`: in ascending epoch order over the most recent eight
+    epochs plus one predecessor (or the full cache when shorter), it repairs
+    records whose `last_epoch_block_nonce` was persisted empty or stale by
+    pre-fix boundary bugs, re-deriving the lab from the active chain boundary
+    block's `PrevHash` (nil for pre-Praos epochs and for the first Praos epoch,
+    whose carried lab is NeutralNonce), and independently recomputes each
+    scanned epoch's nonce as `candidate ⭒ previous epoch's carried lab` when
+    that epoch has a stored `candidate_nonce` and the previous epoch's lab was
+    verified — the same assembly the boundary rollover uses, so leader-VRF
+    verification matches the network. The predecessor is included so the oldest
+    in-window epoch can use a verified carried lab; older epochs are left as
+    persisted because they no longer feed a runtime nonce. The lab repair itself
+    does not need a candidate. If the candidate is missing, startup leaves the
+    epoch's nonce unchanged rather than substituting Shelley genesis for a
+    candidate that may have evolved. After the
+    tip loads, `healMithrilGapBlockNonces` reconstructs the evolving-nonce fold
+    across any Mithril "gap blocks" (see Mithril Bootstrap) before header
+    verification computes an epoch nonce; only then does LedgerState subscribe
+    to chainsync/blockfetch/chain-update EventBus events.
 10. Snapshot manager start (captures genesis snapshot, or reuses an existing
     post-Mithril Mark snapshot window)
 11. Mempool setup and injection into LedgerState/Ouroboros
@@ -1488,6 +1500,48 @@ ingestion (`ensureGapConsumedUtxos`, used while closing the range between the
 snapshot and the chain tip) is unconditionally strict already, since that range
 is always expected to be fully recoverable from the snapshot import.
 
+The Mithril ledger-state snapshot slot normally lags the immutable-chunk tip, so
+`processPostLedgerStateBlocks`/`processGapBlocks` ingest the blocks in between
+(the "gap blocks") for their transaction effects, including consumed-input
+reconciliation via `ensureGapConsumedUtxos`, but without VRF folding. The trust
+boundary is then recorded at the post-gap chain tip (`mithril/sync_import.go`),
+ahead of the evolving nonce persisted at the ledger-state slot. Because live
+chainsync folds nonces only past the trust boundary, the candidate nonce carried
+into the first post-bootstrap epoch
+boundary would otherwise omit every gap block's VRF output, diverging the
+computed epoch nonce from the network and failing every leader-VRF check in that
+epoch (a node runs clean through the bootstrap epoch — whose nonce was imported,
+not computed — then wedges rejecting the first block of the next epoch).
+`LedgerState.healMithrilGapBlockNonces` closes this at startup: it re-folds the
+evolving nonce (the shared `foldBlockEtaV`, Byron-skipped) from the anchor
+block's stored `block_nonce` through every canonical-chain block up to the tip,
+persisting a corrected `block_nonce` for each and checkpointing the
+trust-boundary block. Blocks come from the primary chain index — a raw
+block-blob slot scan would also fold retained fork blobs and synthetic Leios
+endorser blobs, silently corrupting every subsequent nonce. Writes commit in
+batches, with the trust-boundary row committed last as the completion marker,
+so the heal is idempotent — once the recorded trust-boundary point carries a
+folded nonce it detects completion and no-ops — and a crash mid-heal resumes on
+the next start from the highest valid canonical row below the boundary. It
+repairs an already-bootstrapped node in place with no re-bootstrap and never
+reconstructs from an unknown seed: when no usable anchor nonce exists below the
+boundary, or no valid anchor candidate is on the primary chain, it declines
+rather than guess. If a higher valid nonce row below the boundary belongs to a
+retained fork, the heal falls back to the next lower canonical candidate instead
+of treating the fork row as the seed.
+
+The epoch nonce for the boundary into epoch N+1 is
+`candidateNonce(N) ⭒ epoch(N).LastEpochBlockNonce`, where the carried
+`LastEpochBlockNonce` is cardano-ledger's `praosStateLastEpochBlockNonce`:
+`prevHashToNonce(lastBlock.prevHash)` — the PARENT hash of the last block of the
+closing epoch (a one-block Praos lag), computed by `LedgerState.epochLabNonce`
+and stored on the new epoch record for the next boundary. Using the last block's
+own hash instead shifts the carried lab by one block and diverges the computed
+epoch nonce from the network at every self-computed boundary (only the imported
+bootstrap boundary escapes it), wedging the node at the tip of the following
+epoch. For an empty closing epoch (no blocks of its own) the previous carried
+nonce is passed through unchanged.
+
 In API storage mode, the SQLite metadata plugin can defer selected query indexes
 during bulk load. Deferred indexes are classified as critical or lazy in
 `database/plugin/metadata/deferred`: critical indexes cover startup API queries
@@ -1863,9 +1917,11 @@ On chain rollback past an epoch boundary:
 - Delete snapshots for epochs after rollback point
 - Recalculate affected snapshots on forward replay
 - Reload the remaining epoch rows into the in-memory cache and run the same
-  empty/stale `last_epoch_block_nonce` repair used at startup before publishing
-  the new cache. Epochs without a stored `candidate_nonce` are skipped because
-  their nonce cannot be safely recomputed from the lab alone.
+  bounded empty/stale `last_epoch_block_nonce` repair used at startup before
+  publishing the new cache. The scan covers the recent repair window plus one
+  predecessor; epochs without a stored `candidate_nonce` still have their lab
+  repaired when possible, but their nonce is left unchanged because it cannot be
+  safely recomputed from the lab alone.
 - Reward-account credits (`account_reward_delta` journal) and treasury/reserves
   writes (`network_state`) from governance refunds and POOLREAP deposit refunds
   are slot-keyed, so they are reverted by slot and re-derived on forward replay

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -160,8 +160,8 @@ erDiagram
 | `commit_timestamp` | `id`, `timestamp` | PK `id`; singleton row `id = 1` | Mirrored with the blob-store `metadata_commit_timestamp` key to detect partial commits. |
 | `node_settings` | `id`, `storage_mode`, `network` | PK `id`; singleton row `id = 1` | Immutable startup settings. Dingo rejects storage-mode or network changes after initialization. |
 | `tip` | `id`, `hash`, `slot`, `block_number` | PK `id` | Current metadata tip. Block CBOR is in the blob store, not SQL. |
-| `epoch` | `id`, `epoch_id`, `start_slot`, `era_id`, `slot_length`, `length_in_slots`, `nonce`, `evolving_nonce`, `candidate_nonce`, `last_epoch_block_nonce` | PK `id`; unique `epoch_id` | Epoch nonce and era boundary state. Join snapshots and rewards with `epoch.epoch_id = ... .epoch`. |
-| `block_nonce` | `id`, `hash`, `slot`, `nonce`, `is_checkpoint` | PK `id`; unique `(hash, slot)` | Per-block nonce history used by Praos nonce computation. |
+| `epoch` | `id`, `epoch_id`, `start_slot`, `era_id`, `slot_length`, `length_in_slots`, `nonce`, `evolving_nonce`, `candidate_nonce`, `last_epoch_block_nonce` | PK `id`; unique `epoch_id` | Epoch nonce and era boundary state. `last_epoch_block_nonce` is the Praos lab carried at the boundary: the previous epoch's last block `PrevHash`, or the previously carried lab when that epoch had no blocks. Join snapshots and rewards with `epoch.epoch_id = ... .epoch`. |
+| `block_nonce` | `id`, `hash`, `slot`, `nonce`, `is_checkpoint` | PK `id`; unique `(hash, slot)` | Per-block nonce history (cumulative evolving nonce through each block) used by Praos nonce computation. Must cover from the Mithril anchor through the trust boundary and beyond; when a usable anchor nonce exists below the boundary, `healMithrilGapBlockNonces` reconstructs missing gap-block rows at startup (see below). |
 | `network_state` | `id`, `treasury`, `reserves`, `slot` | PK `id`; unique `slot` | Treasury/reserves at a slot. |
 | `network_donation` | `id`, `slot`, `epoch`, `amount` | PK `id`; unique `slot`; index `epoch` | Per-block Conway treasury donation, tagged with its epoch. `amount` is a plain integer column (not `types.Uint64`) so `SUM` aggregates directly across backends. Donations accumulate during an epoch and are moved into `network_state.treasury` at the next epoch boundary; rows are kept (not deleted on apply) so a rollback drops them by slot and re-application re-derives the same total. |
 | `pparams` | `id`, `cbor`, `added_slot`, `epoch`, `era_id` | PK `id`; index `added_slot` | CBOR protocol parameters. Query by `epoch <= ?` and matching `era_id`. |
@@ -379,11 +379,29 @@ synthetic endorser/genesis blob is never returned as the "previous block." This
 matters for storage callers, but it does not make a slot-key scan a canonical
 chain query: retained fork blobs can still sort before an epoch boundary.
 Epoch nonce code derives `last_epoch_block_nonce` from the previous epoch's last
-ranking-block hash through the active chain index (`chain.BlockBeforeSlot`),
-not directly from `BlockBeforeSlotTxn`, so synthetic blobs and stored fork blobs
-cannot be mixed into the boundary nonce. Older PrevHash-based lab lookup also
-saved an empty lab here, collapsing the epoch's nonce to the NeutralNonce
-identity and failing leader-VRF checks. Each endorser transaction's `t` entry
+ranking block's `PrevHash` through `canonicalBlockBeforeSlot`: when a chain
+index is attached it uses `chain.BlockBeforeSlot`; startup helpers, tests, and
+tooling that construct a ledger without a chain fall back to
+`BlockBeforeSlotTxn`/`BlockBeforeSlot`. That fallback still excludes synthetic
+`ID=0` blobs, but it is not a canonical fork filter in databases that retain
+same-slot fork blobs, so production ledger paths attach the chain index before
+using this lookup. Older blob-scan lab lookup could also save an empty lab here,
+collapsing the epoch's nonce to the NeutralNonce
+identity and failing leader-VRF checks. A related hazard is the candidate/evolving
+nonce input: Mithril import persists the evolving nonce only at the ledger-state
+slot and ingests the "gap blocks" up to the (later) trust boundary without folding
+their VRF output into `block_nonce`, so the frozen candidate for the first
+post-bootstrap epoch boundary would omit them. `healMithrilGapBlockNonces`
+re-folds the evolving nonce from the anchor `block_nonce` through every
+canonical-chain block to the tip (walking the primary chain index, not a `bp`
+slot scan, so retained fork blobs and synthetic endorser blobs are never
+folded) and writes a corrected `block_nonce` per block at startup. Writes
+commit in batches; the recorded trust-boundary point's row is the completion
+marker and commits last, so the heal is idempotent and a crash mid-heal resumes
+from the highest valid canonical row below the boundary. Fork rows at the
+boundary or below it do not mark completion or seed the fold when the canonical
+trust-boundary hash / primary-chain anchor is available. Each endorser
+transaction's `t` entry
 and its outputs' `u` entries store ordinary `DOFF` references whose
 `block_slot`/`block_hash` point at that endorser-block blob, so cold-extract
 resolution is identical to chain-block transactions. The transactions' metadata

--- a/database/models/epoch.go
+++ b/database/models/epoch.go
@@ -28,11 +28,12 @@ type Epoch struct {
 	// candidate nonce across epochs so it can seed the next
 	// epoch's computation correctly.
 	CandidateNonce []byte
-	// LastEpochBlockNonce holds the hash of the last applied block
-	// carried by the Praos chain-dependent state at this epoch's
-	// boundary. In Ouroboros Praos, the epoch nonce formula mixes
-	// CandidateNonce with this value. This field is nil for epoch 0
-	// (equivalent to NeutralNonce / identity).
+	// LastEpochBlockNonce holds the Praos lab carried at this epoch's
+	// boundary: the parent hash (PrevHash) of the previous epoch's last
+	// block, or the previously carried lab when that epoch had no blocks.
+	// In Ouroboros Praos, the epoch nonce formula mixes CandidateNonce with
+	// this value. This field is nil for epoch 0 (equivalent to NeutralNonce /
+	// identity).
 	LastEpochBlockNonce []byte
 	ID                  uint `gorm:"primarykey"`
 	// NOTE: we would normally use this as the primary key, but GORM doesn't

--- a/ledger/candidate_nonce.go
+++ b/ledger/candidate_nonce.go
@@ -266,6 +266,61 @@ func (ls *LedgerState) computeCandidateNonceFast(
 	return candidateNonce, evolvingNonce, nil
 }
 
+// foldBlockEtaV folds one block's VRF output into the evolving nonce via the
+// block era's CalculateEtaVFunc. Byron blocks carry no Praos VRF contribution:
+// the input nonce is returned unchanged with folded=false. This is the single
+// per-block fold used by both the boundary candidate computation and the
+// startup Mithril gap-nonce reconstruction, so the two can never drift.
+func (ls *LedgerState) foldBlockEtaV(
+	evolvingNonce []byte,
+	block models.Block,
+) (newNonce []byte, folded bool, err error) {
+	if block.Type == byron.BlockTypeByronEbb ||
+		block.Type == byron.BlockTypeByronMain {
+		return evolvingNonce, false, nil
+	}
+	parsedBlock, err := block.Decode()
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"decode block at slot %d: %w",
+			block.Slot,
+			err,
+		)
+	}
+	eraId := uint(parsedBlock.Era().Id)
+	era, ok := ls.eraById(eraId)
+	if !ok || era == nil {
+		return nil, false, fmt.Errorf(
+			"fold etaV at slot %d block %x: unknown era ID %d",
+			block.Slot,
+			block.Hash,
+			eraId,
+		)
+	}
+	if era.CalculateEtaVFunc == nil {
+		return nil, false, fmt.Errorf(
+			"fold etaV at slot %d block %x: era ID %d (%s) has no etaV calculator",
+			block.Slot,
+			block.Hash,
+			eraId,
+			era.Name,
+		)
+	}
+	newNonce, err = era.CalculateEtaVFunc(
+		ls.config.CardanoNodeConfig,
+		evolvingNonce,
+		parsedBlock,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"calculate etaV at slot %d: %w",
+			block.Slot,
+			err,
+		)
+	}
+	return newNonce, true, nil
+}
+
 // computeCandidateNonceSlow re-decodes every block in the epoch from CBOR
 // and recomputes VRF nonces. This is the fallback when pre-stored nonces
 // are not available.
@@ -290,49 +345,13 @@ func (ls *LedgerState) computeCandidateNonceSlow(
 	var blockCount, preCutoffCount int
 
 	iterFn := func(block models.Block) error {
-		// Byron blocks have no VRF contribution.
-		if block.Type == byron.BlockTypeByronEbb ||
-			block.Type == byron.BlockTypeByronMain {
+		newNonce, folded, err := ls.foldBlockEtaV(evolvingNonce, block)
+		if err != nil {
+			return fmt.Errorf("recompute candidate nonce: %w", err)
+		}
+		if !folded {
+			// Byron blocks have no VRF contribution.
 			return nil
-		}
-		parsedBlock, err := block.Decode()
-		if err != nil {
-			return fmt.Errorf(
-				"decode block at slot %d: %w",
-				block.Slot,
-				err,
-			)
-		}
-		eraId := uint(parsedBlock.Era().Id)
-		era, ok := ls.eraById(eraId)
-		if !ok || era == nil {
-			return fmt.Errorf(
-				"recompute candidate nonce at slot %d block %x: unknown era ID %d",
-				block.Slot,
-				block.Hash,
-				eraId,
-			)
-		}
-		if era.CalculateEtaVFunc == nil {
-			return fmt.Errorf(
-				"recompute candidate nonce at slot %d block %x: era ID %d (%s) has no etaV calculator",
-				block.Slot,
-				block.Hash,
-				eraId,
-				era.Name,
-			)
-		}
-		newNonce, err := era.CalculateEtaVFunc(
-			ls.config.CardanoNodeConfig,
-			evolvingNonce,
-			parsedBlock,
-		)
-		if err != nil {
-			return fmt.Errorf(
-				"calculate etaV at slot %d: %w",
-				block.Slot,
-				err,
-			)
 		}
 		evolvingNonce = newNonce
 		blockCount++

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3055,11 +3055,16 @@ func (ls *LedgerState) calculateEpochNonce(
 		)
 	}
 
-	// For the initial epoch creation (no blocks yet), the epoch
-	// nonce and initial evolving nonce are both the genesis hash.
-	// This matches cardano-node where the initial state sets
-	// epochNonce, candidateNonce, and evolvingNonce all to the
-	// genesis hash. lastEpochBlockNonce is nil (NeutralNonce).
+	// For the initial epoch creation (no blocks yet), the epoch nonce and
+	// initial evolving/candidate nonces are all the genesis nonce, and the
+	// carried lastEpochBlockNonce is Neutral (nil). At genesis cardano-ledger
+	// initializes praosStateLastEpochBlockNonce to NeutralNonce, so the FIRST
+	// from-genesis epoch boundary takes the identity branch: eta = candidate ⭒
+	// NeutralNonce = candidate. Devnet confirms cardano's epoch-1 epochNonce ==
+	// its candidate (identity). Do NOT seed this with the genesis nonce — that
+	// combines instead of using identity and diverges at the first boundary
+	// (#2734). The Mithril path never takes this branch (bootstrap epoch imports
+	// a non-nil lastEpochBlockNonce).
 	if len(currentEpoch.Nonce) == 0 {
 		return genesisHashBytes, genesisHashBytes, genesisHashBytes, nil, nil
 	}
@@ -3174,12 +3179,22 @@ func (ls *LedgerState) calculateEpochNonce(
 		)
 	}
 
-	// Compute the lastEpochBlockNonce for the epoch being closed.
-	// This is the hash of the last block of current epoch N, or the
-	// carried value when the epoch has no blocks. It will be stored on
-	// the new epoch record and used immediately in this boundary's
-	// epoch-nonce formula.
-	lastEpochBlockNonce, err := ls.epochLabNonce(
+	// The epoch nonce mixes the frozen candidate with the nonce derived from
+	// the last block of the PREVIOUS epoch. In cardano-ledger this is
+	// praosStateLastEpochBlockNonce: the value CARRIED in the closing epoch's
+	// state (set at the prior epoch boundary) — i.e. the hash of the last block
+	// of the epoch *before* the one closing here — NOT the last block of the
+	// closing epoch itself. Using the closing epoch's own last block shifts the
+	// lab by one epoch and diverges eta from the network, so every leader-VRF
+	// check in the new epoch fails (#2734):
+	//   epochNonce(N+1) = candidateNonce(N) ⭒ currentEpoch(N).LastEpochBlockNonce
+	labForEta := cloneNonce(currentEpoch.LastEpochBlockNonce)
+
+	// The carried lab for the NEXT boundary is stored on the new epoch record:
+	// prevHashToNonce(lastBlock.prevHash) = the PARENT hash of the last block of
+	// the epoch being closed (a one-block Praos lag), NOT the last block's own
+	// hash. See epochLabNonce and #2734 (eta_1349 wedge).
+	labNonceToSave, err := ls.epochLabNonce(
 		txn,
 		currentEpoch.StartSlot,
 		epochEndSlot,
@@ -3188,11 +3203,10 @@ func (ls *LedgerState) calculateEpochNonce(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	labNonceToSave := lastEpochBlockNonce
 
 	// If nil/empty, it's NeutralNonce (identity): result is
 	// just candidateNonce.
-	if len(lastEpochBlockNonce) == 0 {
+	if len(labForEta) == 0 {
 		// NeutralNonce is the identity element of ⭒:
 		//   candidateNonce ⭒ NeutralNonce = candidateNonce
 		// So the epoch nonce is just the candidate nonce.
@@ -3212,20 +3226,20 @@ func (ls *LedgerState) calculateEpochNonce(
 		return candidateNonce, evolvingNonce, candidateNonce, labNonceToSave, nil
 	}
 
-	// candidateNonce ⭒ lastEpochBlockNonce
-	// = blake2b_256(candidateNonce || lastEpochBlockNonce)
+	// candidateNonce ⭒ labForEta
+	// = blake2b_256(candidateNonce || labForEta)
 	if len(candidateNonce) < 32 ||
-		len(lastEpochBlockNonce) < 32 {
+		len(labForEta) < 32 {
 		return nil, nil, nil, nil, fmt.Errorf(
 			"epoch nonce requires 32-byte inputs: "+
-				"candidateNonce=%d, lastEpochBlockNonce=%d",
+				"candidateNonce=%d, labForEta=%d",
 			len(candidateNonce),
-			len(lastEpochBlockNonce),
+			len(labForEta),
 		)
 	}
 	result, err := lcommon.CalculateEpochNonce(
 		candidateNonce,
-		lastEpochBlockNonce,
+		labForEta,
 		nil,
 	)
 	if err != nil {
@@ -3238,8 +3252,8 @@ func (ls *LedgerState) calculateEpochNonce(
 		"component", "ledger",
 		"epoch_start_slot", epochStartSlot,
 		"candidate_nonce", hex.EncodeToString(candidateNonce),
-		"last_epoch_block_nonce",
-		hex.EncodeToString(lastEpochBlockNonce),
+		"lab_for_eta",
+		hex.EncodeToString(labForEta),
 		"lab_nonce_to_save",
 		hex.EncodeToString(labNonceToSave),
 		"epoch_nonce", hex.EncodeToString(result.Bytes()),

--- a/ledger/epoch_lab_nonce.go
+++ b/ledger/epoch_lab_nonce.go
@@ -21,12 +21,30 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
-// epochLabNonce returns the Praos lastEpochBlockNonce value for an epoch
-// boundary. If the epoch has at least one block, the nonce is the hash of the
-// last block before the boundary. If the epoch has no blocks, the consensus
-// state carries the previous value forward.
+// epochLabNonce returns the Praos lastEpochBlockNonce value to store on the new
+// epoch record at a boundary (it becomes the carried lab used at the NEXT
+// boundary). In cardano-ledger this is praosStateLastEpochBlockNonce, set at the
+// epoch transition to praosStateLabNonce, which is updated per block to
+// prevHashToNonce(block.prevHash). So when the closing epoch has at least one
+// block, the value is the PARENT hash of that epoch's last block (the last
+// block's prevHash), NOT the last block's own hash — a deliberate one-block lag.
+//
+// Using the last block's own hash shifts the carried lab by one block and
+// diverges the computed epoch nonce from the network at every self-computed
+// boundary, so every leader-VRF check in the following epoch fails with "issue
+// verifying proof" (#2734, eta_1349 wedge). koios preview proof:
+//
+//	eta_1348 lab = prevHash(04f75b4e, last block of 1346) = 43edf2  (imported, correct)
+//	eta_1349 lab = prevHash(94d3083a, last block of 1347) = 08a8dd12
+//	blake2b256(candidate_1348 1aee9a8d || 08a8dd12) = 294f4731 = koios eta_1349
+//
+// If the closing epoch has no blocks of its own (or the boundary block has no
+// parent — the genesis edge), the consensus state carries the previous value
+// forward unchanged; that value is already a prevHash-shape nonce (or, at
+// genesis, NeutralNonce/nil).
 func (ls *LedgerState) epochLabNonce(
 	txn *database.Txn,
 	epochStartSlot uint64,
@@ -40,36 +58,42 @@ func (ls *LedgerState) epochLabNonce(
 		}
 		return cloneNonce(carriedLabNonce), nil
 	}
-	if lastBlock.Slot >= epochStartSlot && len(lastBlock.Hash) > 0 {
-		return cloneNonce(lastBlock.Hash), nil
-	}
-	return ls.normalizeCarriedLabNonce(txn, epochStartSlot, carriedLabNonce)
-}
-
-// normalizeCarriedLabNonce upgrades the old persisted shape that stored the
-// boundary block's PrevHash instead of its Hash. This only applies when an
-// epoch has no blocks of its own and must carry the previous boundary nonce.
-func (ls *LedgerState) normalizeCarriedLabNonce(
-	txn *database.Txn,
-	epochStartSlot uint64,
-	carriedLabNonce []byte,
-) ([]byte, error) {
-	if len(carriedLabNonce) == 0 || epochStartSlot == 0 {
+	if lastBlock.Slot < epochStartSlot {
 		return cloneNonce(carriedLabNonce), nil
 	}
-	boundary, err := ls.canonicalBlockBeforeSlot(txn, epochStartSlot)
+	// Derive the parent hash, decoding the block CBOR when the stored
+	// PrevHash is empty (legacy rows from the empty-PrevHash storage bug that
+	// caused the Dijkstra at-tip wedge). Falling back to the carried value
+	// here would silently shift the lab by one epoch, so a block whose parent
+	// cannot be determined is an error, not a carry.
+	prevHash, err := blockPrevHash(lastBlock)
 	if err != nil {
-		if !errors.Is(err, models.ErrBlockNotFound) {
-			return nil, fmt.Errorf("lookup carried boundary block: %w", err)
-		}
+		return nil, fmt.Errorf(
+			"derive boundary block parent hash at slot %d: %w",
+			lastBlock.Slot,
+			err,
+		)
+	}
+	if len(prevHash) == 0 {
+		// The boundary block has no parent: it is the chain's first block,
+		// so the carried value (NeutralNonce at genesis) is unchanged.
 		return cloneNonce(carriedLabNonce), nil
 	}
-	if len(boundary.Hash) > 0 &&
-		len(boundary.PrevHash) > 0 &&
-		bytes.Equal(carriedLabNonce, boundary.PrevHash) {
-		return cloneNonce(boundary.Hash), nil
+	if len(prevHash) != lcommon.Blake2b256Size {
+		return nil, fmt.Errorf(
+			"boundary block parent hash at slot %d has invalid length %d",
+			lastBlock.Slot,
+			len(prevHash),
+		)
 	}
-	return cloneNonce(carriedLabNonce), nil
+	// cardano-ledger's prevHashToNonce maps GenesisHash to NeutralNonce: when
+	// the closing epoch's last block is the chain's first block, the carried
+	// value is used, not the genesis hash bytes.
+	if genesisHash, gErr := GenesisBlockHash(ls.config.CardanoNodeConfig); gErr == nil &&
+		bytes.Equal(prevHash, genesisHash[:]) {
+		return cloneNonce(carriedLabNonce), nil
+	}
+	return cloneNonce(prevHash), nil
 }
 
 func (ls *LedgerState) canonicalBlockBeforeSlot(
@@ -81,6 +105,9 @@ func (ls *LedgerState) canonicalBlockBeforeSlot(
 	}
 	if ls.chain != nil {
 		return ls.chain.BlockBeforeSlot(slot)
+	}
+	if ls.db == nil && txn == nil {
+		return models.Block{}, models.ErrBlockNotFound
 	}
 	return lookupBlockBeforeSlot(ls.db, txn, slot)
 }

--- a/ledger/epoch_lab_nonce_test.go
+++ b/ledger/epoch_lab_nonce_test.go
@@ -31,7 +31,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEpochNonceUsesCurrentEpochLastBlockHash(t *testing.T) {
+// TestEpochNonceStoresClosingEpochLastBlockPrevHashAsLab verifies the
+// epoch-nonce assembly (#2734). The epoch nonce mixes the frozen candidate with
+// the CARRIED lastEpochBlockNonce (prevEpoch.LastEpochBlockNonce, == cardano-
+// ledger praosStateLastEpochBlockNonce; ouroboros-consensus Praos.hs
+// tickChainDepState uses candidateNonce ⭒ praosStateLastEpochBlockNonce). The
+// value stored on the NEW epoch record (the carried lab for the NEXT boundary)
+// is prevHashToNonce(lastBlock.prevHash) — the PARENT hash of the closing
+// epoch's last block, NOT the last block's OWN hash (a one-block Praos lag).
+// Confirmed on preview mainnet: koios eta_1348 =
+// blake2b(frozenCandidate || epoch1347.LastEpochBlockNonce); eta_1349 lab =
+// prevHash(94d3083a) = 08a8dd12.
+func TestEpochNonceStoresClosingEpochLastBlockPrevHashAsLab(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
@@ -126,7 +137,15 @@ func TestEpochNonceUsesCurrentEpochLastBlockHash(t *testing.T) {
 		return err
 	}))
 
-	expected, err := lcommon.CalculateEpochNonce(
+	// Correct assembly: eta = candidate ⭒ carried lastEpochBlockNonce.
+	wantEta, err := lcommon.CalculateEpochNonce(
+		nonceAtPreCut,
+		carriedLab,
+		nil,
+	)
+	require.NoError(t, err)
+	// Old (buggy) assembly used the closing epoch's own last block hash.
+	oldBuggyEta, err := lcommon.CalculateEpochNonce(
 		nonceAtPreCut,
 		hashAtPostCut,
 		nil,
@@ -135,25 +154,48 @@ func TestEpochNonceUsesCurrentEpochLastBlockHash(t *testing.T) {
 
 	require.Equal(t, hex.EncodeToString(nonceAtPreCut), hex.EncodeToString(rCandidate))
 	require.Equal(t, hex.EncodeToString(rCandidate), hex.EncodeToString(hvCandidate))
+	// The STORED lastEpochBlockNonce is the PARENT hash of the closing epoch's
+	// last block (prevHashToNonce(lastBlock.prevHash) == the post-cutoff block's
+	// PrevHash == hashAtPreCut), which becomes the carried lab at the NEXT
+	// boundary — a one-block Praos lag, NOT the last block's own hash.
 	require.Equal(
 		t,
-		hex.EncodeToString(hashAtPostCut),
+		hex.EncodeToString(hashAtPreCut),
 		hex.EncodeToString(rLab),
-		"lastEpochBlockNonce must be the current epoch's last block hash",
+		"stored lastEpochBlockNonce must be the closing epoch's last-block PrevHash (for the next boundary)",
 	)
 	require.Equal(t, hex.EncodeToString(rLab), hex.EncodeToString(hvLab))
 	require.NotEqual(
 		t,
-		hex.EncodeToString(hashAtPreCut),
+		hex.EncodeToString(hashAtPostCut),
 		hex.EncodeToString(rLab),
-		"lastEpochBlockNonce must not be the boundary block's PrevHash",
+		"stored lastEpochBlockNonce must NOT be the closing epoch's last block's own hash (the #2734 eta_1349 off-by-one)",
 	)
 	require.NotEqual(t, hex.EncodeToString(carriedLab), hex.EncodeToString(rLab))
-	require.Equal(t, expected.Bytes(), rNonce)
-	require.Equal(t, expected.Bytes(), hvNonce)
+	// The epoch nonce for THIS boundary uses the CARRIED lastEpochBlockNonce
+	// (#2734), not the closing epoch's own last block.
+	require.Equal(
+		t,
+		hex.EncodeToString(wantEta.Bytes()),
+		hex.EncodeToString(rNonce),
+		"epoch nonce must be candidate ⭒ carried lastEpochBlockNonce",
+	)
+	require.NotEqual(
+		t,
+		hex.EncodeToString(oldBuggyEta.Bytes()),
+		hex.EncodeToString(rNonce),
+		"epoch nonce must not use the closing epoch's own last block",
+	)
+	require.Equal(t, hex.EncodeToString(rNonce), hex.EncodeToString(hvNonce))
 }
 
-func TestEpochLabNonceNormalizesOldPrevHashCarryForEmptyEpoch(t *testing.T) {
+// TestEpochLabNonceEmptyEpochCarriesPrevNonceForward verifies that when the
+// closing epoch has NO blocks of its own, epochLabNonce carries the previous
+// boundary nonce forward UNCHANGED. Under the corrected Praos prevHash semantic
+// (#2734) the carried value is already a prevHash-shape nonce, so it must be
+// returned as-is — NOT converted to the boundary block's own hash (the old
+// "normalize PrevHash -> Hash" behavior was the eta_1349 off-by-one regression).
+func TestEpochLabNonceEmptyEpochCarriesPrevNonceForward(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
@@ -163,6 +205,8 @@ func TestEpochLabNonceNormalizesOldPrevHashCarryForEmptyEpoch(t *testing.T) {
 		epochEnd   uint64 = 300
 	)
 
+	// Only block is at slot 150, BEFORE epochStart (200): the closing epoch
+	// [200,300) has no blocks of its own, so the carried nonce is preserved.
 	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
 	boundaryPrevHash := bytes.Repeat([]byte{0x02}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
@@ -174,10 +218,14 @@ func TestEpochLabNonceNormalizesOldPrevHashCarryForEmptyEpoch(t *testing.T) {
 		Type:     conway.BlockTypeConway,
 	}, nil))
 
+	carried := bytes.Repeat([]byte{0x03}, 32)
 	ls := &LedgerState{db: db}
-	lab, err := ls.epochLabNonce(nil, epochStart, epochEnd, boundaryPrevHash)
+	lab, err := ls.epochLabNonce(nil, epochStart, epochEnd, carried)
 	require.NoError(t, err)
-	require.Equal(t, boundaryHash, lab)
+	require.Equal(t, carried, lab,
+		"empty closing epoch must carry the previous (prevHash-shape) nonce forward unchanged")
+	require.NotEqual(t, boundaryHash, lab,
+		"empty closing epoch must NOT normalize the carried nonce to the boundary block's own hash")
 }
 
 func TestEpochLabNonceUsesCanonicalChainWhenForkBlobHasHigherSlot(t *testing.T) {
@@ -198,9 +246,14 @@ func TestEpochLabNonceUsesCanonicalChainWhenForkBlobHasHigherSlot(t *testing.T) 
 	)
 	require.NoError(t, err)
 	require.Len(t, canonicalBlocks, 2)
+	// canonicalBlocks[1] is the boundary (last) block; its PrevHash is
+	// canonicalBlocks[0].Hash. Under the corrected prevHash semantic (#2734)
+	// epochLabNonce returns the boundary block's PrevHash, so the fork blob is
+	// given a DISTINCT PrevHash to keep the canonical-vs-fork distinction sharp.
 	canonicalPrevHash := canonicalBlocks[0].Hash().Bytes()
 	canonicalBoundaryHash := canonicalBlocks[1].Hash().Bytes()
 	forkHash := bytes.Repeat([]byte{0xf0}, 32)
+	forkPrevHash := bytes.Repeat([]byte{0xfa}, 32)
 
 	require.NoError(t, canonicalChain.AddBlock(canonicalBlocks[0], nil))
 	require.NoError(t, canonicalChain.AddBlock(canonicalBlocks[1], nil))
@@ -208,7 +261,7 @@ func TestEpochLabNonceUsesCanonicalChainWhenForkBlobHasHigherSlot(t *testing.T) 
 		ID:       99,
 		Slot:     30,
 		Hash:     forkHash,
-		PrevHash: canonicalPrevHash,
+		PrevHash: forkPrevHash,
 		Cbor:     []byte{0x80},
 		Number:   99,
 		Type:     conway.BlockTypeConway,
@@ -224,5 +277,46 @@ func TestEpochLabNonceUsesCanonicalChainWhenForkBlobHasHigherSlot(t *testing.T) 
 	}
 	lab, err := ls.epochLabNonce(nil, 0, 40, nil)
 	require.NoError(t, err)
-	require.Equal(t, canonicalBoundaryHash, lab)
+	// Must be the canonical boundary block's PrevHash (from the canonical chain),
+	// NOT the higher-slot fork blob's PrevHash, and NOT the boundary block's own
+	// hash.
+	require.Equal(t, canonicalPrevHash, lab)
+	require.NotEqual(t, forkPrevHash, lab)
+	require.NotEqual(t, canonicalBoundaryHash, lab)
+}
+
+// TestEpochLabNonceReturnsPrevHashNotHash pins the #2734 eta_1349 root cause:
+// for a closing epoch with blocks, epochLabNonce returns the PARENT hash (the
+// last block's PrevHash), NOT the last block's own hash. cardano-ledger's
+// praosStateLastEpochBlockNonce = prevHashToNonce(lastBlock.prevHash), a
+// one-block lag. Using the last block's own hash shifts the carried lab by one
+// block and wedges every following epoch at the tip. koios preview:
+// eta_1349 lab = prevHash(94d3083a, last block of 1347) = 08a8dd12.
+func TestEpochLabNonceReturnsPrevHashNotHash(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	const (
+		epochStart uint64 = 1000
+		epochEnd   uint64 = 2000
+	)
+	parentHash := bytes.Repeat([]byte{0xa1}, 32) // second-to-last block
+	lastHash := bytes.Repeat([]byte{0xb2}, 32)   // last block of the closing epoch
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot:     1500,
+		Hash:     lastHash,
+		PrevHash: parentHash, // last block's parent == the carried lab
+		Cbor:     []byte{0x80},
+		Number:   2,
+		Type:     conway.BlockTypeConway,
+	}, nil))
+
+	ls := &LedgerState{db: db}
+	lab, err := ls.epochLabNonce(nil, epochStart, epochEnd, nil)
+	require.NoError(t, err)
+	require.Equal(t, parentHash, lab,
+		"epochLabNonce must return the last block's PrevHash (the parent hash)")
+	require.NotEqual(t, lastHash, lab,
+		"epochLabNonce must NOT return the last block's own hash (the eta_1349 off-by-one)")
 }

--- a/ledger/epoch_nonce_carried_lab_test.go
+++ b/ledger/epoch_nonce_carried_lab_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEpochNonceUsesCarriedLastEpochBlockNonce verifies the cardano-ledger
+// epoch-nonce assembly (#2734): the epoch nonce mixes the frozen candidate with
+// the CARRIED last-block-of-previous-epoch nonce
+// (prevEpoch.LastEpochBlockNonce == cardano praosStateLastEpochBlockNonce),
+// NOT the hash of the last block of the epoch being closed. The closing epoch's
+// last block hash is stored on the new epoch record for use at the NEXT
+// boundary.
+//
+// Confirmed against preview mainnet: for the 1347->1348 boundary, koios
+// eta_1348 = blake2b(frozenCandidate || epoch1347.LastEpochBlockNonce), where
+// epoch1347.LastEpochBlockNonce is the last block of epoch 1346 (the carried
+// value), not the last block of epoch 1347.
+func TestEpochNonceUsesCarriedLastEpochBlockNonce(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cfg := newConwayBootstrapStabilityCfg(t)
+
+	const (
+		epochStart  uint64 = 1000
+		epochLength uint64 = 75
+		epochEnd    uint64 = epochStart + epochLength
+		preCutSlot  uint64 = 1014
+		postCutSlot uint64 = 1070
+	)
+
+	importedNonce := bytes.Repeat([]byte{0xaa}, 32)
+	nonceAtPreCut := bytes.Repeat([]byte{0xbb}, 32) // frozen candidate
+	nonceAtPostCut := bytes.Repeat([]byte{0xcc}, 32)
+	carriedLab := bytes.Repeat([]byte{0xfa}, 32) // = last block of the PREVIOUS epoch
+
+	hashAtPreCut := bytes.Repeat([]byte{0x14}, 32)
+	hashAtPostCut := bytes.Repeat([]byte{0x70}, 32) // last block of the CLOSING epoch
+	prevHashAtPreCut := bytes.Repeat([]byte{0x09}, 32)
+
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		if err := db.BlockCreate(models.Block{
+			Slot: preCutSlot, Hash: hashAtPreCut, PrevHash: prevHashAtPreCut,
+			Cbor: []byte{0x80}, Number: 1, Type: conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		if err := db.BlockCreate(models.Block{
+			Slot: postCutSlot, Hash: hashAtPostCut, PrevHash: hashAtPreCut,
+			Cbor: []byte{0x80}, Number: 2, Type: conway.BlockTypeConway,
+		}, txn); err != nil {
+			return err
+		}
+		if err := db.SetBlockNonce(
+			hashAtPreCut, preCutSlot, nonceAtPreCut, false, txn); err != nil {
+			return err
+		}
+		return db.SetBlockNonce(
+			hashAtPostCut, postCutSlot, nonceAtPostCut, false, txn)
+	}))
+
+	prevEpoch := models.Epoch{
+		EpochId:             100,
+		StartSlot:           epochStart,
+		LengthInSlots:       uint(epochLength),
+		SlotLength:          1000,
+		EraId:               eras.ConwayEraDesc.Id,
+		Nonce:               bytes.Repeat([]byte{0xee}, 32),
+		EvolvingNonce:       importedNonce,
+		CandidateNonce:      importedNonce,
+		LastEpochBlockNonce: carriedLab,
+	}
+
+	ls := &LedgerState{
+		db:           db,
+		currentEra:   eras.ConwayEraDesc,
+		currentEpoch: prevEpoch,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	hvNonce, _, hvCandidate, hvLab, err :=
+		ls.computeEpochNonceForSlot(epochEnd, prevEpoch)
+	require.NoError(t, err)
+
+	var rNonce, rCandidate, rLab []byte
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		n, _, c, lab, err := ls.calculateEpochNonce(
+			txn, epochEnd, eras.ConwayEraDesc, prevEpoch)
+		rNonce, rCandidate, rLab = n, c, lab
+		return err
+	}))
+
+	// Correct assembly: eta = candidate ⭒ carriedLab (prevEpoch.LastEpochBlockNonce).
+	wantEta, err := lcommon.CalculateEpochNonce(nonceAtPreCut, carriedLab, nil)
+	require.NoError(t, err)
+	// Old (buggy) assembly: eta = candidate ⭒ last block of closing epoch.
+	oldEta, err := lcommon.CalculateEpochNonce(nonceAtPreCut, hashAtPostCut, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, hex.EncodeToString(nonceAtPreCut),
+		hex.EncodeToString(rCandidate), "candidate is the frozen pre-cutoff nonce")
+	require.Equal(t, hex.EncodeToString(wantEta.Bytes()),
+		hex.EncodeToString(rNonce),
+		"epoch nonce must mix the candidate with the CARRIED lab, not the closing epoch's last block")
+	require.NotEqual(t, hex.EncodeToString(oldEta.Bytes()),
+		hex.EncodeToString(rNonce),
+		"epoch nonce must NOT use the closing epoch's own last block (the #2734 bug)")
+	// The carried lab stored for the NEXT boundary is the PARENT hash of the
+	// closing epoch's last block (prevHashToNonce(lastBlock.prevHash) ==
+	// hashAtPreCut, the post-cutoff block's PrevHash), NOT the last block's own
+	// hash — a one-block Praos lag (#2734 eta_1349 root cause).
+	require.Equal(t, hex.EncodeToString(hashAtPreCut),
+		hex.EncodeToString(rLab),
+		"stored lastEpochBlockNonce must be the closing epoch's last-block PrevHash, for the next boundary")
+	require.NotEqual(t, hex.EncodeToString(hashAtPostCut),
+		hex.EncodeToString(rLab),
+		"stored lastEpochBlockNonce must NOT be the closing epoch's last block's own hash")
+
+	// The eager header-verification path must agree with the rollover path.
+	require.Equal(t, hex.EncodeToString(rNonce), hex.EncodeToString(hvNonce),
+		"eager epoch nonce must match rollover")
+	require.Equal(t, hex.EncodeToString(rCandidate), hex.EncodeToString(hvCandidate),
+		"eager candidate must match rollover")
+	require.Equal(t, hex.EncodeToString(rLab), hex.EncodeToString(hvLab),
+		"eager lab must match rollover")
+}
+
+// TestEpochNonceGenesisEdgeUsesNeutralLab pins the from-genesis initialization
+// of the carried lastEpochBlockNonce (#2734). When the initial epoch is created
+// (no prior nonce), the epoch/evolving/candidate nonces are the genesis nonce
+// but the carried lab is Neutral (nil) — NOT the genesis nonce. cardano-ledger
+// initializes praosStateLastEpochBlockNonce to NeutralNonce at genesis
+// (Cardano.Ledger.Shelley.API.Protocol.initialChainDepState: csLabNonce =
+// NeutralNonce; Cardano.Protocol.TPraos.BHeader.prevHashToNonce GenesisHash =
+// NeutralNonce), so the FIRST from-genesis boundary uses the identity
+// (eta_1 = candidate ⭒ NeutralNonce = candidate). Devnet confirmed cardano's
+// epoch-1 epochNonce == its candidate. Seeding the lab with the genesis nonce
+// instead combines and diverges at the first boundary. The Mithril bootstrap
+// path is unaffected (bootstrap epoch imports a non-nil lastEpochBlockNonce and
+// never takes this branch).
+func TestEpochNonceGenesisEdgeUsesNeutralLab(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cfg := newConwayBootstrapStabilityCfg(t)
+	// ShelleyGenesisHash set by the helper is 32 bytes of 0x11.
+	genesisHash := bytes.Repeat([]byte{0x11}, 32)
+
+	// Initial epoch: no nonce/evolving/candidate yet (from-genesis creation).
+	initialEpoch := models.Epoch{
+		EpochId: 0,
+		EraId:   eras.ConwayEraDesc.Id,
+	}
+
+	ls := &LedgerState{
+		db:           db,
+		currentEra:   eras.ConwayEraDesc,
+		currentEpoch: initialEpoch,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	hvNonce, hvEvolving, hvCandidate, hvLab, err :=
+		ls.computeEpochNonceForSlot(500, initialEpoch)
+	require.NoError(t, err)
+
+	var rNonce, rEvolving, rCandidate, rLab []byte
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		n, ev, c, lab, err := ls.calculateEpochNonce(
+			txn, 500, eras.ConwayEraDesc, initialEpoch)
+		rNonce, rEvolving, rCandidate, rLab = n, ev, c, lab
+		return err
+	}))
+
+	// Epoch/evolving/candidate are the genesis nonce for the initial epoch.
+	require.Equal(t, hex.EncodeToString(genesisHash), hex.EncodeToString(rNonce),
+		"initial epoch nonce is the genesis nonce")
+	require.Equal(t, hex.EncodeToString(genesisHash), hex.EncodeToString(rEvolving),
+		"initial evolving nonce is the genesis nonce")
+	require.Equal(t, hex.EncodeToString(genesisHash), hex.EncodeToString(rCandidate),
+		"initial candidate nonce is the genesis nonce")
+	// The key #2734 assertion: the carried lab is Neutral (nil), NOT the genesis
+	// nonce, so the first from-genesis boundary uses the identity.
+	require.Empty(t, rLab,
+		"initial carried lastEpochBlockNonce must be Neutral (nil), not the genesis nonce")
+
+	// The eager header-verification path must agree with the rollover path.
+	require.Equal(t, hex.EncodeToString(rNonce), hex.EncodeToString(hvNonce))
+	require.Equal(t, hex.EncodeToString(rEvolving), hex.EncodeToString(hvEvolving))
+	require.Equal(t, hex.EncodeToString(rCandidate), hex.EncodeToString(hvCandidate))
+	require.Empty(t, hvLab,
+		"eager path initial carried lab must also be Neutral (nil)")
+}

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -29,18 +29,21 @@ import (
 )
 
 // TestHealEmptyLabNoncesRepairsAndRecomputes verifies that healEmptyLabNonces
-// restores an epoch's empty LastEpochBlockNonce from its boundary block and
-// recomputes that epoch's nonce. A pre-fix BlockBeforeSlot endorser-block
-// collision could persist an empty lab, collapsing the epoch's nonce to
-// the NeutralNonce identity (η == candidateNonce) and failing every leader-VRF
-// check in that epoch (the Dijkstra/Leios at-tip wedge).
+// restores an epoch's empty LastEpochBlockNonce from its boundary block's
+// PrevHash and recomputes that epoch's nonce from the PREVIOUS epoch's carried
+// lab (η(E) = candidate(E) ⭒ lab(E-1), the cardano-ledger assembly — NOT the
+// epoch's own lab, which would shift eta by one epoch). A pre-fix
+// BlockBeforeSlot endorser-block collision could persist an empty lab,
+// collapsing the next epoch's nonce to the NeutralNonce identity
+// (η == candidateNonce) and failing every leader-VRF check in that epoch (the
+// Dijkstra/Leios at-tip wedge).
 func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
 
-	// The last block of the epoch preceding epoch 5 (slot < 200). Its
-	// Hash is the lab value epoch 5 must recover to.
+	// The last block of the epoch preceding epoch 5 (slot < 200). Its PrevHash
+	// is the lab value epoch 5 must recover to.
 	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
 	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
@@ -54,9 +57,21 @@ func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 	}, nil))
 
 	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	// Epoch 4 is covered by the Mithril trust boundary: its imported carried
+	// lab is trusted verbatim and feeds epoch 5's nonce.
+	carriedLab := bytes.Repeat([]byte{0xfa}, 32)
 	ls := &LedgerState{
-		db: db,
+		db:                db,
+		mithrilLedgerSlot: 150,
 		epochCache: []models.Epoch{
+			{
+				EpochId:             4,
+				StartSlot:           100,
+				LengthInSlots:       100,
+				Nonce:               bytes.Repeat([]byte{0xee}, 32),
+				CandidateNonce:      bytes.Repeat([]byte{0xed}, 32),
+				LastEpochBlockNonce: carriedLab,
+			},
 			{
 				EpochId:        5,
 				StartSlot:      200,
@@ -74,25 +89,142 @@ func TestHealEmptyLabNoncesRepairsAndRecomputes(t *testing.T) {
 
 	ls.healEmptyLabNonces()
 
-	// Epoch 5's lab is recovered from the boundary block's Hash.
+	// Epoch 5's lab is recovered from the boundary block's PrevHash.
 	require.Equal(
 		t,
-		boundaryHash,
-		ls.epochCache[0].LastEpochBlockNonce,
-		"empty lab must be restored from the boundary block's Hash",
+		boundaryPrevHash,
+		ls.epochCache[1].LastEpochBlockNonce,
+		"empty lab must be restored from the boundary block's PrevHash",
 	)
 
-	// Epoch 5's nonce is recomputed as candidateNonce ⭒ lab, no longer the
-	// NeutralNonce-collapsed value.
-	want, err := lcommon.CalculateEpochNonce(candidate, boundaryHash, nil)
+	// Epoch 5's nonce is recomputed as candidateNonce ⭒ epoch 4's carried lab,
+	// no longer the NeutralNonce-collapsed value.
+	want, err := lcommon.CalculateEpochNonce(candidate, carriedLab, nil)
 	require.NoError(t, err)
-	require.Equal(t, want.Bytes(), ls.epochCache[0].Nonce)
+	require.Equal(t, want.Bytes(), ls.epochCache[1].Nonce)
 	require.NotEqual(
 		t,
 		candidate,
-		ls.epochCache[0].Nonce,
+		ls.epochCache[1].Nonce,
 		"epoch nonce must no longer be the NeutralNonce-collapsed candidate",
 	)
+	// The one-epoch-shifted assembly (candidate ⭒ epoch 5's OWN lab) must NOT
+	// be produced — that is the #2734 divergence.
+	shifted, err := lcommon.CalculateEpochNonce(candidate, boundaryPrevHash, nil)
+	require.NoError(t, err)
+	require.NotEqual(
+		t,
+		shifted.Bytes(),
+		ls.epochCache[1].Nonce,
+		"epoch nonce must not mix the candidate with the epoch's own lab",
+	)
+}
+
+// TestHealEmptyLabNoncesBoundsToRecentEpochs verifies the repair only touches
+// the recent window: repairing every historical epoch on each restart is one
+// block lookup per epoch and needlessly slow, and older labs never feed a
+// runtime nonce, so an epoch older than the window must be left untouched even
+// when it has a repairable (empty) lab.
+func TestHealEmptyLabNoncesBoundsToRecentEpochs(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// A single boundary block precedes every epoch's start slot, so any epoch
+	// that is actually processed repairs its empty lab to this PrevHash.
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       1,
+		Slot:     50,
+		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		PrevHash: boundaryPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   1,
+		Type:     6,
+	}, nil))
+
+	const n = healLabNonceRecentEpochs + 3
+	epochs := make([]models.Epoch, n)
+	for i := range epochs {
+		epochs[i] = models.Epoch{
+			EpochId:        uint64(i + 1),
+			StartSlot:      uint64((i + 1) * 100),
+			LengthInSlots:  100,
+			Nonce:          bytes.Repeat([]byte{0xee}, 32),
+			CandidateNonce: bytes.Repeat([]byte{0xaa}, 32),
+			// LastEpochBlockNonce left empty (repairable)
+		}
+	}
+	ls := &LedgerState{
+		db:         db,
+		epochCache: epochs,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.healEmptyLabNonces()
+
+	require.Empty(t, ls.epochCache[0].LastEpochBlockNonce,
+		"epoch older than the recent window must be left untouched, not repaired")
+	require.Equal(t, boundaryPrevHash, ls.epochCache[n-1].LastEpochBlockNonce,
+		"the most recent epoch must still be repaired")
+}
+
+// TestHealEmptyLabNoncesRepairsOldestInWindowNonce verifies the bounded scan
+// includes one predecessor epoch so the oldest in-window epoch's nonce — which
+// mixes the PREVIOUS epoch's lab — is repaired from a verified predecessor lab
+// rather than left stale. Without the predecessor the first in-window nonce
+// check has no verified previous lab and is skipped.
+func TestHealEmptyLabNoncesRepairsOldestInWindowNonce(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	prevHash := bytes.Repeat([]byte{0xbb}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       1,
+		Slot:     50,
+		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		PrevHash: prevHash,
+		Cbor:     []byte{0x80},
+		Number:   1,
+		Type:     6,
+	}, nil))
+
+	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	const n = healLabNonceRecentEpochs + 3
+	epochs := make([]models.Epoch, n)
+	for i := range epochs {
+		epochs[i] = models.Epoch{
+			EpochId:        uint64(i + 1),
+			StartSlot:      uint64((i + 1) * 100),
+			LengthInSlots:  100,
+			CandidateNonce: candidate,
+			// NeutralNonce-collapsed (wrong) nonce and empty lab, both repairable.
+			Nonce: append([]byte(nil), candidate...),
+		}
+	}
+	ls := &LedgerState{
+		db:         db,
+		epochCache: epochs,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	ls.healEmptyLabNonces()
+
+	// The oldest in-window epoch is scanned right after the predecessor whose
+	// lab the scan verifies. Its nonce must be recomputed as candidate ⭒ the
+	// predecessor's repaired lab (prevHash), not left as the collapsed candidate.
+	oldest := n - healLabNonceRecentEpochs
+	want, err := lcommon.CalculateEpochNonce(candidate, prevHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, want.Bytes(), ls.epochCache[oldest].Nonce,
+		"oldest in-window epoch nonce must be repaired from the verified predecessor lab")
+	require.NotEqual(t, candidate, ls.epochCache[oldest].Nonce,
+		"oldest in-window epoch nonce must no longer be the collapsed candidate")
 }
 
 // TestHealEmptyLabNoncesLeavesValidRecordsUntouched verifies the recovery is a
@@ -128,17 +260,68 @@ func TestHealEmptyLabNoncesLeavesValidRecordsUntouched(t *testing.T) {
 	require.Equal(t, nonce, ls.epochCache[0].Nonce)
 }
 
-func TestHealEmptyLabNoncesSkipsStaleLabWhenCandidateMissing(t *testing.T) {
+func TestHealEmptyLabNoncesLeavesParentHashLabUntouched(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
 
 	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
 		ID:       3,
 		Slot:     250,
 		Hash:     boundaryHash,
-		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		PrevHash: boundaryPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     6,
+	}, nil))
+
+	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	nonce, err := lcommon.CalculateEpochNonce(candidate, boundaryPrevHash, nil)
+	require.NoError(t, err)
+	epochs := []models.Epoch{
+		{
+			EpochId:             6,
+			StartSlot:           300,
+			LengthInSlots:       100,
+			Nonce:               nonce.Bytes(),
+			CandidateNonce:      candidate,
+			LastEpochBlockNonce: boundaryPrevHash,
+		},
+	}
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	repaired := ls.healEmptyLabNoncesInPlace(epochs)
+
+	require.False(t, repaired)
+	require.Equal(t, boundaryPrevHash, epochs[0].LastEpochBlockNonce)
+	require.NotEqual(t, boundaryHash, epochs[0].LastEpochBlockNonce)
+	require.Equal(t, nonce.Bytes(), epochs[0].Nonce)
+}
+
+// TestHealEmptyLabNoncesRepairsLabWhenCandidateMissing verifies that the lab
+// repair does not depend on a stored candidate nonce: the lab feeds the NEXT
+// boundary's eta directly, so leaving it in a stale shape just because this
+// epoch's nonce cannot be re-verified would wedge the next rollover. The
+// nonce itself must be left untouched (no candidate to recompute it from).
+func TestHealEmptyLabNoncesRepairsLabWhenCandidateMissing(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     250,
+		Hash:     boundaryHash,
+		PrevHash: boundaryPrevHash,
 		Cbor:     []byte{0x80},
 		Number:   3,
 		Type:     6,
@@ -167,23 +350,28 @@ func TestHealEmptyLabNoncesSkipsStaleLabWhenCandidateMissing(t *testing.T) {
 
 	repaired := ls.healEmptyLabNoncesInPlace(epochs)
 
-	require.False(t, repaired)
-	require.Equal(t, oldLab, epochs[0].LastEpochBlockNonce)
-	require.Equal(t, oldNonce, epochs[0].Nonce)
+	require.True(t, repaired)
+	require.Equal(t, boundaryPrevHash, epochs[0].LastEpochBlockNonce,
+		"stale lab must be repaired even without a stored candidate")
+	require.Equal(t, oldNonce, epochs[0].Nonce,
+		"nonce must be untouched when no candidate is stored")
 	require.Empty(t, epochs[0].CandidateNonce)
 }
 
-func TestHealEmptyLabNoncesSkipsWithoutCandidateFallback(t *testing.T) {
+// TestHealEmptyLabNoncesRepairsEmptyLabWithoutCandidate mirrors the test above
+// for an empty (rather than stale) lab.
+func TestHealEmptyLabNoncesRepairsEmptyLabWithoutCandidate(t *testing.T) {
 	db, err := database.New(&database.Config{DataDir: ""})
 	require.NoError(t, err)
 	defer db.Close()
 
 	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
 		ID:       3,
 		Slot:     250,
 		Hash:     boundaryHash,
-		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		PrevHash: boundaryPrevHash,
 		Cbor:     []byte{0x80},
 		Number:   3,
 		Type:     6,
@@ -209,9 +397,11 @@ func TestHealEmptyLabNoncesSkipsWithoutCandidateFallback(t *testing.T) {
 
 	repaired := ls.healEmptyLabNoncesInPlace(epochs)
 
-	require.False(t, repaired)
-	require.Empty(t, epochs[0].LastEpochBlockNonce)
-	require.Equal(t, oldNonce, epochs[0].Nonce)
+	require.True(t, repaired)
+	require.Equal(t, boundaryPrevHash, epochs[0].LastEpochBlockNonce,
+		"empty lab must be repaired even without a stored candidate")
+	require.Equal(t, oldNonce, epochs[0].Nonce,
+		"nonce must be untouched when no candidate is stored")
 }
 
 func TestHealEmptyLabNoncesSkipsMissingCandidateBeforeBoundaryLookup(
@@ -241,6 +431,65 @@ func TestHealEmptyLabNoncesSkipsMissingCandidateBeforeBoundaryLookup(
 	})
 	require.Equal(t, oldLab, epochs[0].LastEpochBlockNonce)
 	require.Equal(t, oldNonce, epochs[0].Nonce)
+}
+
+// TestHealEmptyLabNoncesLeavesFirstPraosEpochLabNeutral verifies the heal does
+// not "repair" the first Praos epoch's nil lab to the last pre-Praos (Byron)
+// block's parent hash. cardano-ledger initializes praosStateLastEpochBlockNonce
+// to NeutralNonce at the Praos start (initialChainDepState csLabNonce =
+// NeutralNonce), and the initial-epoch branch of calculateEpochNonce stores a
+// nil lab — rewriting it would diverge the next boundary's eta on any chain
+// with a Byron era (mainnet, preprod).
+func TestHealEmptyLabNoncesLeavesFirstPraosEpochLabNeutral(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Last Byron block before the Shelley start at slot 200. Without the
+	// first-Praos guard, its PrevHash would be written as the lab.
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       3,
+		Slot:     150,
+		Hash:     bytes.Repeat([]byte{0x01}, 32),
+		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		Cbor:     []byte{0x80},
+		Number:   3,
+		Type:     1, // Byron main
+	}, nil))
+
+	genesisNonce := bytes.Repeat([]byte{0x11}, 32)
+	epochs := []models.Epoch{
+		{
+			// Pre-Praos (Byron) epoch: no nonce, no candidate, no lab.
+			EpochId:       3,
+			StartSlot:     100,
+			LengthInSlots: 100,
+		},
+		{
+			// First Praos epoch: nonce/candidate are the genesis nonce, lab is
+			// Neutral (nil).
+			EpochId:        4,
+			StartSlot:      200,
+			LengthInSlots:  100,
+			Nonce:          append([]byte(nil), genesisNonce...),
+			CandidateNonce: append([]byte(nil), genesisNonce...),
+		},
+	}
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	repaired := ls.healEmptyLabNoncesInPlace(epochs)
+
+	require.False(t, repaired)
+	require.Empty(t, epochs[0].LastEpochBlockNonce)
+	require.Empty(t, epochs[1].LastEpochBlockNonce,
+		"first Praos epoch's lab must stay NeutralNonce (nil)")
+	require.Equal(t, genesisNonce, epochs[1].Nonce,
+		"first Praos epoch's nonce must stay the genesis nonce")
 }
 
 func TestHealEmptyLabNoncesTrustsMithrilCoveredEpoch(t *testing.T) {
@@ -294,18 +543,29 @@ func TestHealEmptyLabNoncesInPlaceRepairsReloadedEpochs(t *testing.T) {
 	defer db.Close()
 
 	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
+	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
 		ID:       3,
 		Slot:     250,
 		Hash:     boundaryHash,
-		PrevHash: bytes.Repeat([]byte{0xbb}, 32),
+		PrevHash: boundaryPrevHash,
 		Cbor:     []byte{0x80},
 		Number:   3,
 		Type:     6,
 	}, nil))
 
 	candidate := bytes.Repeat([]byte{0xaa}, 32)
+	// Epoch 5 is Mithril-trusted; its carried lab feeds epoch 6's nonce.
+	carriedLab := bytes.Repeat([]byte{0xfa}, 32)
 	epochs := []models.Epoch{
+		{
+			EpochId:             5,
+			StartSlot:           200,
+			LengthInSlots:       100,
+			Nonce:               bytes.Repeat([]byte{0xee}, 32),
+			CandidateNonce:      bytes.Repeat([]byte{0xed}, 32),
+			LastEpochBlockNonce: carriedLab,
+		},
 		{
 			EpochId:             6,
 			StartSlot:           300,
@@ -316,7 +576,8 @@ func TestHealEmptyLabNoncesInPlaceRepairsReloadedEpochs(t *testing.T) {
 		},
 	}
 	ls := &LedgerState{
-		db: db,
+		db:                db,
+		mithrilLedgerSlot: 250,
 		config: LedgerStateConfig{
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
@@ -324,11 +585,11 @@ func TestHealEmptyLabNoncesInPlaceRepairsReloadedEpochs(t *testing.T) {
 
 	repaired := ls.healEmptyLabNoncesInPlace(epochs)
 
-	want, err := lcommon.CalculateEpochNonce(candidate, boundaryHash, nil)
+	want, err := lcommon.CalculateEpochNonce(candidate, carriedLab, nil)
 	require.NoError(t, err)
 	require.True(t, repaired)
-	require.Equal(t, boundaryHash, epochs[0].LastEpochBlockNonce)
-	require.Equal(t, want.Bytes(), epochs[0].Nonce)
+	require.Equal(t, boundaryPrevHash, epochs[1].LastEpochBlockNonce)
+	require.Equal(t, want.Bytes(), epochs[1].Nonce)
 }
 
 func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
@@ -336,6 +597,18 @@ func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
+	// Last block of epoch 4 (before slot 200): its PrevHash is epoch 5's lab.
+	epoch5BoundaryPrevHash := bytes.Repeat([]byte{0x44}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       2,
+		Slot:     150,
+		Hash:     bytes.Repeat([]byte{0x02}, 32),
+		PrevHash: epoch5BoundaryPrevHash,
+		Cbor:     []byte{0x80},
+		Number:   2,
+		Type:     6,
+	}, nil))
+	// Last block of epoch 5 (before slot 300): its PrevHash is epoch 6's lab.
 	boundaryHash := bytes.Repeat([]byte{0x01}, 32)
 	boundaryPrevHash := bytes.Repeat([]byte{0xbb}, 32)
 	require.NoError(t, db.BlockCreate(models.Block{
@@ -374,7 +647,13 @@ func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
 		nil,
 	))
 
-	want, err := lcommon.CalculateEpochNonce(candidate, boundaryHash, nil)
+	// Epoch 6's nonce mixes its candidate with epoch 5's carried lab (repaired
+	// to the epoch-5 boundary block's PrevHash), not with epoch 6's own lab.
+	want, err := lcommon.CalculateEpochNonce(
+		candidate,
+		epoch5BoundaryPrevHash,
+		nil,
+	)
 	require.NoError(t, err)
 
 	ls := &LedgerState{

--- a/ledger/heal_mithril_gap_nonce.go
+++ b/ledger/heal_mithril_gap_nonce.go
@@ -1,0 +1,461 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	mithrilGapNonceProgressInterval = 10_000
+	mithrilGapNonceWriteBatchSize   = 2_000
+)
+
+// healMithrilGapBlockNonces reconstructs per-block evolving nonces for a
+// Mithril-bootstrapped chain whose "gap blocks" were imported without folding
+// their VRF output into the evolving nonce.
+//
+// Mithril import stores the ledger-state snapshot's evolving nonce at the
+// ledger-state slot (the anchor) and then copies the immutable/gap blocks that
+// extend the chain from the anchor up to a later tip, recording the Mithril
+// trust boundary at that later tip (see mithril/sync_import.go and
+// mithril/sync_gap.go). Those gap blocks have their transactions imported but
+// their VRF outputs are NEVER folded into the evolving nonce, and no
+// block_nonce rows are written for them. Live chainsync only folds blocks past
+// the trust boundary, so it resumes from the stale anchor nonce, dropping every
+// gap block's VRF contribution. The candidate nonce frozen for the first
+// post-bootstrap epoch boundary is therefore wrong, the computed epoch nonce
+// diverges from the network, and every leader-VRF check in that epoch fails
+// with "issue verifying proof" — the node rejects the first block of the new
+// epoch and wedges.
+//
+// This heal re-folds the evolving nonce from the anchor's stored nonce through
+// every canonical block up to the current tip (gap blocks first, then any
+// blocks live chainsync already mis-folded), persisting a corrected
+// block_nonce for each. Blocks come from the primary chain index — a raw
+// block-blob slot scan would also visit retained fork blobs and synthetic
+// Leios endorser blobs, folding non-canonical VRF output into the evolving
+// nonce. It is a pure function of already-stored chain data (block CBOR + the
+// anchor nonce) and is idempotent: the trust-boundary block's nonce row is the
+// completion marker and is committed last, so a crash mid-heal simply resumes
+// on the next start (already-committed rows below the boundary become the new
+// anchor), and once the marker exists the heal detects completion and no-ops.
+// Writes are committed in batches so an arbitrarily long post-boundary tail
+// does not accumulate into a single unbounded transaction.
+//
+// It must run at startup after the tip and trust boundary are loaded and before
+// header verification computes any epoch nonce.
+func (ls *LedgerState) healMithrilGapBlockNonces(ctx context.Context) error {
+	ls.RLock()
+	boundary := ls.mithrilLedgerSlot
+	boundaryHash := bytes.Clone(ls.mithrilLedgerHash)
+	tipPoint := ls.currentTip.Point
+	ls.RUnlock()
+
+	// Not a Mithril bootstrap: nothing to reconcile.
+	if boundary == 0 {
+		return nil
+	}
+	// The tip must be at or past the trust boundary for a gap to exist between
+	// the anchor and the boundary. A tip below the boundary is not a normal
+	// post-bootstrap state; leave it untouched.
+	if tipPoint.Slot < boundary {
+		return nil
+	}
+
+	// Completion / no-gap detection: the heal commits a valid 32-byte evolving
+	// nonce at the trust-boundary point as its completion marker (written last,
+	// see below). A valid boundary nonce therefore means either there was no
+	// gap (the anchor is the boundary block, carrying the import checkpoint) or
+	// the heal has already run — nothing to do, which is what makes the heal
+	// idempotent across restarts. When the import recorded the trust-boundary
+	// hash, require that exact point: a fork row at the same slot is not a
+	// completion marker for the canonical boundary block. A boundary row whose
+	// nonce is malformed (missing/short — e.g. a block imported without its VRF
+	// folded) is NOT a valid marker and must NOT short-circuit reconstruction,
+	// or the post-bootstrap epoch nonce would stay wrong. This mirrors the
+	// anchor selection below, which likewise ignores malformed rows.
+	boundaryRows, err := ls.db.GetBlockNoncesInSlotRange(
+		boundary,
+		boundary+1,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("query trust-boundary block nonce: %w", err)
+	}
+	for i := range boundaryRows {
+		row := boundaryRows[i]
+		if len(row.Nonce) != lcommon.Blake2b256Size {
+			continue
+		}
+		if len(boundaryHash) == 0 || bytes.Equal(row.Hash, boundaryHash) {
+			return nil
+		}
+	}
+
+	// Seed: the import anchor is the highest-slot valid stored block_nonce
+	// strictly before the trust boundary. Its value is the ledger-state
+	// snapshot's evolving nonce (eta_v at the anchor block), which correctly
+	// embeds the entire chain up to that block. Malformed rows are ignored
+	// rather than allowed to mask a usable lower-slot anchor.
+	anchorRows, err := ls.db.GetBlockNoncesInSlotRange(0, boundary, nil)
+	if err != nil {
+		return fmt.Errorf("query Mithril anchor block nonce: %w", err)
+	}
+	anchorCandidates := make([]models.BlockNonce, 0, len(anchorRows))
+	for i := range anchorRows {
+		row := anchorRows[i]
+		if len(row.Nonce) != lcommon.Blake2b256Size {
+			continue
+		}
+		anchorCandidates = append(anchorCandidates, row)
+	}
+	sort.SliceStable(anchorCandidates, func(i, j int) bool {
+		if anchorCandidates[i].Slot != anchorCandidates[j].Slot {
+			return anchorCandidates[i].Slot > anchorCandidates[j].Slot
+		}
+		return bytes.Compare(
+			anchorCandidates[i].Hash,
+			anchorCandidates[j].Hash,
+		) > 0
+	})
+	var (
+		anchorRow  *models.BlockNonce
+		anchorIter *chain.ChainIterator
+	)
+	if len(anchorCandidates) == 0 {
+		// No usable anchor nonce (e.g. a DB predating evolving-nonce storage).
+		// Reconstructing from an unknown seed would be worse than leaving the
+		// state as-is, so decline rather than guess. Never weaken nonce
+		// correctness.
+		ls.config.Logger.Warn(
+			"skipped Mithril gap block nonce reconstruction: "+
+				"no anchor evolving nonce below trust boundary",
+			"trust_boundary_slot", boundary,
+			"component", "ledger",
+		)
+		return nil
+	}
+	if ls.chain != nil {
+		for i := range anchorCandidates {
+			candidate := &anchorCandidates[i]
+			contains, err := ls.primaryChainContainsExactPoint(
+				ocommon.Point{
+					Slot: candidate.Slot,
+					Hash: candidate.Hash,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"check Mithril anchor block on primary chain: %w",
+					err,
+				)
+			}
+			if !contains {
+				continue
+			}
+			iter, err := ls.chain.FromPointContext(
+				ctx,
+				ocommon.Point{Slot: candidate.Slot, Hash: candidate.Hash},
+				false,
+			)
+			if err != nil {
+				if errors.Is(err, models.ErrBlockNotFound) {
+					continue
+				}
+				return fmt.Errorf(
+					"create primary-chain iterator from Mithril anchor: %w",
+					err,
+				)
+			}
+			anchorRow = candidate
+			anchorIter = iter
+			break
+		}
+		if anchorRow == nil {
+			ls.config.Logger.Warn(
+				"skipped Mithril gap block nonce reconstruction: "+
+					"no valid anchor nonce below trust boundary is on "+
+					"the primary chain",
+				"trust_boundary_slot", boundary,
+				"component", "ledger",
+			)
+			return nil
+		}
+	} else {
+		anchorRow = &anchorCandidates[0]
+	}
+	anchorSlot := anchorRow.Slot
+	anchorNonce := anchorRow.Nonce
+	if anchorIter != nil {
+		defer anchorIter.Cancel()
+	}
+
+	// Preserve existing checkpoint flags on rows we overwrite so pruning
+	// retention is unchanged, and ensure the trust-boundary block is
+	// checkpointed so post-boundary folding can always re-seed from it.
+	existingRows, err := ls.db.GetBlockNoncesInSlotRange(
+		anchorSlot+1,
+		tipPoint.Slot+1,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("query existing post-anchor block nonces: %w", err)
+	}
+	checkpointSlots := make(map[uint64]bool, len(existingRows)+1)
+	for _, row := range existingRows {
+		if row.IsCheckpoint {
+			checkpointSlots[row.Slot] = true
+		}
+	}
+	checkpointSlots[boundary] = true
+
+	ls.config.Logger.Warn(
+		"reconstructing Mithril gap block nonces",
+		"anchor_slot", anchorSlot,
+		"trust_boundary_slot", boundary,
+		"tip_slot", tipPoint.Slot,
+		"component", "ledger",
+	)
+
+	evolvingNonce := cloneNonce(anchorNonce)
+	var (
+		processed     int
+		folded        int
+		byronSkipped  int
+		lastFoldedSlt uint64
+	)
+
+	logProgress := func(currentSlot uint64) {
+		if processed == 0 || processed%mithrilGapNonceProgressInterval != 0 {
+			return
+		}
+		ls.config.Logger.Info(
+			"reconstructing Mithril gap block nonces progress",
+			"anchor_slot", anchorSlot,
+			"trust_boundary_slot", boundary,
+			"tip_slot", tipPoint.Slot,
+			"processed_blocks", processed,
+			"folded_blocks", folded,
+			"byron_skipped", byronSkipped,
+			"current_slot", currentSlot,
+			"last_folded_slot", lastFoldedSlt,
+			"component", "ledger",
+		)
+	}
+
+	// Reconstructed rows are committed in batches. The trust-boundary row is
+	// withheld until every other row has committed: its presence is the
+	// completion marker, so writing it last keeps a crash mid-heal resumable
+	// instead of marking a partial reconstruction as done.
+	type nonceRow struct {
+		hash  []byte
+		slot  uint64
+		nonce []byte
+	}
+	var (
+		pending          []nonceRow
+		boundaryNonceRow *nonceRow
+	)
+	writeRows := func(rows []nonceRow) error {
+		txn := ls.db.Transaction(true)
+		defer txn.Release()
+		return txn.Do(func(txn *database.Txn) error {
+			for _, row := range rows {
+				if err := ls.db.SetBlockNonce(
+					row.hash,
+					row.slot,
+					row.nonce,
+					checkpointSlots[row.slot],
+					txn,
+				); err != nil {
+					return fmt.Errorf(
+						"store reconstructed block nonce at slot %d: %w",
+						row.slot,
+						err,
+					)
+				}
+			}
+			return nil
+		})
+	}
+	flush := func() error {
+		if len(pending) == 0 {
+			return nil
+		}
+		if err := writeRows(pending); err != nil {
+			return err
+		}
+		pending = pending[:0]
+		return nil
+	}
+
+	handleBlock := func(block models.Block) error {
+		processed++
+		newNonce, didFold, err := ls.foldBlockEtaV(evolvingNonce, block)
+		if err != nil {
+			return fmt.Errorf("reconstruct gap nonce: %w", err)
+		}
+		if !didFold {
+			// Byron blocks carry no Praos VRF contribution.
+			byronSkipped++
+			logProgress(block.Slot)
+			return nil
+		}
+		evolvingNonce = newNonce
+		row := nonceRow{
+			hash:  block.Hash,
+			slot:  block.Slot,
+			nonce: cloneNonce(evolvingNonce),
+		}
+		if block.Slot == boundary {
+			boundaryNonceRow = &row
+		} else {
+			pending = append(pending, row)
+			if len(pending) >= mithrilGapNonceWriteBatchSize {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+		}
+		folded++
+		lastFoldedSlt = block.Slot
+		logProgress(block.Slot)
+		return nil
+	}
+
+	// Walk the canonical chain from the anchor to the ledger tip.
+	if ls.chain != nil {
+		iter := anchorIter
+		for {
+			res, err := iter.Next(false)
+			if err != nil {
+				if errors.Is(err, chain.ErrIteratorChainTip) {
+					break
+				}
+				return fmt.Errorf(
+					"iterate primary chain for gap nonce reconstruction: %w",
+					err,
+				)
+			}
+			if res.Rollback {
+				return fmt.Errorf(
+					"unexpected rollback at slot %d while reconstructing gap nonces",
+					res.Point.Slot,
+				)
+			}
+			if res.Block.Slot > tipPoint.Slot {
+				break
+			}
+			if err := handleBlock(res.Block); err != nil {
+				return err
+			}
+		}
+	} else {
+		// No chain index attached (tests/tooling): fall back to the slot-range
+		// blob scan.
+		if err := database.ForEachBlockInRangeDB(
+			ls.db,
+			anchorSlot+1,
+			tipPoint.Slot+1,
+			handleBlock,
+		); err != nil {
+			return fmt.Errorf(
+				"re-fold Mithril gap and post-boundary block nonces: %w",
+				err,
+			)
+		}
+	}
+	if err := flush(); err != nil {
+		return err
+	}
+	if boundaryNonceRow != nil {
+		if err := writeRows([]nonceRow{*boundaryNonceRow}); err != nil {
+			return err
+		}
+	} else {
+		// No ranking block produced a nonce at the trust-boundary slot (e.g. a
+		// Byron boundary block): without the completion marker the heal will
+		// re-run on the next start. Harmless but worth surfacing.
+		ls.config.Logger.Warn(
+			"Mithril gap block nonce reconstruction completed without a "+
+				"trust-boundary nonce row; heal will re-run on next start",
+			"trust_boundary_slot", boundary,
+			"component", "ledger",
+		)
+	}
+
+	// Refresh the in-memory tip nonce, which loadTip populated from the stale
+	// pre-heal value, and drop any epoch-nonce hex cache derived from it.
+	if len(tipPoint.Hash) > 0 {
+		tipNonce, err := ls.db.GetBlockNonce(tipPoint, nil)
+		if err != nil {
+			return fmt.Errorf("reload tip block nonce after heal: %w", err)
+		}
+		ls.Lock()
+		if ls.currentTip.Point.Slot == tipPoint.Slot &&
+			bytes.Equal(ls.currentTip.Point.Hash, tipPoint.Hash) {
+			ls.currentTipBlockNonce = tipNonce
+		}
+		clear(ls.epochNonceHexCache)
+		ls.Unlock()
+	} else {
+		ls.Lock()
+		clear(ls.epochNonceHexCache)
+		ls.Unlock()
+	}
+
+	ls.config.Logger.Warn(
+		"reconstructed Mithril gap block nonces",
+		"anchor_slot", anchorSlot,
+		"trust_boundary_slot", boundary,
+		"folded_blocks", folded,
+		"byron_skipped", byronSkipped,
+		"last_folded_slot", lastFoldedSlt,
+		"final_evolving_nonce", hex.EncodeToString(evolvingNonce),
+		"component", "ledger",
+	)
+	return nil
+}
+
+func (ls *LedgerState) primaryChainContainsExactPoint(
+	point ocommon.Point,
+) (bool, error) {
+	if point.Slot == 0 && len(point.Hash) == 0 {
+		return true, nil
+	}
+	if ls.chain == nil || point.Slot == ^uint64(0) {
+		return false, nil
+	}
+	block, err := ls.chain.BlockBeforeSlot(point.Slot + 1)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return block.Slot == point.Slot && bytes.Equal(block.Hash, point.Hash), nil
+}

--- a/ledger/heal_mithril_gap_nonce_test.go
+++ b/ledger/heal_mithril_gap_nonce_test.go
@@ -1,0 +1,663 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+	"github.com/stretchr/testify/require"
+)
+
+// newGapHealTestLedgerState builds a minimal LedgerState backed by an
+// in-memory database for exercising healMithrilGapBlockNonces guard logic.
+func newGapHealTestLedgerState(
+	t *testing.T,
+	db *database.Database,
+	boundary uint64,
+	tipSlot uint64,
+	tipHash []byte,
+) *LedgerState {
+	t.Helper()
+	return &LedgerState{
+		db:                db,
+		mithrilLedgerSlot: boundary,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.Point{Slot: tipSlot, Hash: tipHash},
+		},
+		epochNonceHexCache: map[uint64]string{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+}
+
+func countBlockNonces(t *testing.T, db *database.Database) int {
+	t.Helper()
+	// A slot range wide enough to cover every row written in these tests.
+	rows, err := db.GetBlockNoncesInSlotRange(0, 1_000_000, nil)
+	require.NoError(t, err)
+	return len(rows)
+}
+
+func TestHealMithrilGapBlockNonces_ReconstructsGapAndRefreshesTip(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	const (
+		anchorSlot uint64 = 100
+		byronSlot  uint64 = 110
+		firstSlot  uint64 = 120
+		boundary   uint64 = 130
+	)
+
+	var origin lcommon.Blake2b256
+	blocks, err := fixtures.GenerateConwayChain(1, origin, firstSlot, 10, 3)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+
+	anchorHash := bytes.Repeat([]byte{0x0a}, 32)
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	byronHash := bytes.Repeat([]byte{0xb0}, 32)
+	staleTipNonce := bytes.Repeat([]byte{0xee}, 32)
+	tipBlock := blocks[len(blocks)-1]
+	tipSlot := tipBlock.SlotNumber()
+	tipHash := tipBlock.Hash().Bytes()
+
+	require.NoError(t, db.SetBlockNonce(
+		anchorHash,
+		anchorSlot,
+		anchorNonce,
+		true,
+		nil,
+	))
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot:     byronSlot,
+		Hash:     byronHash,
+		PrevHash: anchorHash,
+		Cbor:     []byte{0x80},
+		Number:   1,
+		Type:     byron.BlockTypeByronMain,
+	}, nil))
+	for _, block := range blocks {
+		require.NoError(t, db.BlockCreate(models.Block{
+			Slot:     block.SlotNumber(),
+			Hash:     block.Hash().Bytes(),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     block.Cbor(),
+			Number:   block.BlockNumber(),
+			Type:     conway.BlockTypeConway,
+		}, nil))
+	}
+	require.NoError(t, db.SetBlockNonce(
+		tipHash,
+		tipSlot,
+		staleTipNonce,
+		true,
+		nil,
+	))
+
+	ls := newGapHealTestLedgerState(t, db, boundary, tipSlot, tipHash)
+	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
+	ls.currentTipBlockNonce = bytes.Clone(staleTipNonce)
+	ls.epochNonceHexCache[42] = "stale"
+
+	expected := bytes.Clone(anchorNonce)
+	expectedBySlot := map[uint64][]byte{}
+	for _, block := range blocks {
+		expected, err = eras.CalculateEtaVConway(
+			ls.config.CardanoNodeConfig,
+			expected,
+			block,
+		)
+		require.NoError(t, err)
+		expectedBySlot[block.SlotNumber()] = bytes.Clone(expected)
+	}
+
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	require.Equal(t, 4, countBlockNonces(t, db))
+	byronNonce, err := db.GetBlockNonce(
+		ocommon.Point{Slot: byronSlot, Hash: byronHash},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, byronNonce, "Byron blocks must not get Praos block_nonce rows")
+
+	for _, block := range blocks {
+		got, err := db.GetBlockNonce(
+			ocommon.Point{Slot: block.SlotNumber(), Hash: block.Hash().Bytes()},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedBySlot[block.SlotNumber()], got)
+	}
+	tipNonce, err := db.GetBlockNonce(
+		ocommon.Point{Slot: tipSlot, Hash: tipHash},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expected, tipNonce)
+	require.NotEqual(t, staleTipNonce, tipNonce)
+
+	rows, err := db.GetBlockNoncesInSlotRange(anchorSlot, tipSlot+1, nil)
+	require.NoError(t, err)
+	rowsBySlot := map[uint64]models.BlockNonce{}
+	for _, row := range rows {
+		rowsBySlot[row.Slot] = row
+	}
+	require.True(t, rowsBySlot[anchorSlot].IsCheckpoint)
+	require.False(t, rowsBySlot[firstSlot].IsCheckpoint)
+	require.True(t, rowsBySlot[boundary].IsCheckpoint)
+	require.True(t, rowsBySlot[tipSlot].IsCheckpoint)
+
+	require.Equal(t, expected, ls.currentTipBlockNonce)
+	require.Empty(t, ls.epochNonceHexCache)
+}
+
+// TestHealMithrilGapBlockNonces_CanonicalChainExcludesForkBlob verifies that
+// when a chain index is attached, the heal folds only canonical-chain blocks:
+// a retained fork blob inside the anchor→tip slot range must not contribute to
+// the reconstructed evolving nonce (a raw block-blob slot scan would fold it
+// and silently corrupt every subsequent nonce).
+func TestHealMithrilGapBlockNonces_CanonicalChainExcludesForkBlob(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	canonicalChain := cm.PrimaryChain()
+
+	var origin lcommon.Blake2b256
+	blocks, err := fixtures.GenerateConwayChain(1, origin, 100, 10, 3)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+	for _, block := range blocks {
+		require.NoError(t, canonicalChain.AddBlock(block, nil))
+	}
+	anchorBlock := blocks[0] // slot 100
+	boundary := blocks[1].SlotNumber()
+	tipBlock := blocks[2]
+
+	// Retained fork blob between the anchor and the boundary: present in the
+	// blob store but not on the canonical chain.
+	forkHash := bytes.Repeat([]byte{0xf0}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       99,
+		Slot:     105,
+		Hash:     forkHash,
+		PrevHash: anchorBlock.Hash().Bytes(),
+		Cbor:     blocks[1].Cbor(),
+		Number:   99,
+		Type:     conway.BlockTypeConway,
+	}, nil))
+
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	require.NoError(t, db.SetBlockNonce(
+		anchorBlock.Hash().Bytes(),
+		anchorBlock.SlotNumber(),
+		anchorNonce,
+		true,
+		nil,
+	))
+
+	ls := newGapHealTestLedgerState(
+		t, db, boundary, tipBlock.SlotNumber(), tipBlock.Hash().Bytes())
+	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
+	ls.chain = canonicalChain
+
+	// Expected fold: anchor nonce through the two canonical blocks only.
+	expected := bytes.Clone(anchorNonce)
+	expectedBySlot := map[uint64][]byte{}
+	for _, block := range blocks[1:] {
+		expected, err = eras.CalculateEtaVConway(
+			ls.config.CardanoNodeConfig,
+			expected,
+			block,
+		)
+		require.NoError(t, err)
+		expectedBySlot[block.SlotNumber()] = bytes.Clone(expected)
+	}
+
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	// Anchor + the two canonical blocks; the fork blob gets no row.
+	require.Equal(t, 3, countBlockNonces(t, db))
+	forkNonce, err := db.GetBlockNonce(
+		ocommon.Point{Slot: 105, Hash: forkHash},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, forkNonce, "fork blob must not be folded or given a row")
+	for _, block := range blocks[1:] {
+		got, err := db.GetBlockNonce(
+			ocommon.Point{
+				Slot: block.SlotNumber(),
+				Hash: block.Hash().Bytes(),
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedBySlot[block.SlotNumber()], got,
+			"canonical block nonce must be the fold of canonical blocks only")
+	}
+}
+
+// TestHealMithrilGapBlockNonces_BoundaryCompletionRequiresTrustHash verifies
+// that a nonce row at the trust-boundary slot only marks the heal complete
+// when it belongs to the recorded Mithril boundary hash. A retained fork row
+// at the same slot must not mask missing canonical nonce history.
+func TestHealMithrilGapBlockNonces_BoundaryCompletionRequiresTrustHash(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	canonicalChain := cm.PrimaryChain()
+
+	var origin lcommon.Blake2b256
+	blocks, err := fixtures.GenerateConwayChain(1, origin, 100, 10, 3)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+	for _, block := range blocks {
+		require.NoError(t, canonicalChain.AddBlock(block, nil))
+	}
+	anchorBlock := blocks[0]
+	boundaryBlock := blocks[1]
+	tipBlock := blocks[2]
+
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	forkBoundaryHash := bytes.Repeat([]byte{0xfb}, 32)
+	forkBoundaryNonce := bytes.Repeat([]byte{0xbb}, 32)
+	require.NoError(t, db.SetBlockNonce(
+		anchorBlock.Hash().Bytes(),
+		anchorBlock.SlotNumber(),
+		anchorNonce,
+		true,
+		nil,
+	))
+	require.NoError(t, db.SetBlockNonce(
+		forkBoundaryHash,
+		boundaryBlock.SlotNumber(),
+		forkBoundaryNonce,
+		true,
+		nil,
+	))
+
+	ls := newGapHealTestLedgerState(
+		t,
+		db,
+		boundaryBlock.SlotNumber(),
+		tipBlock.SlotNumber(),
+		tipBlock.Hash().Bytes(),
+	)
+	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
+	ls.chain = canonicalChain
+	ls.mithrilLedgerHash = boundaryBlock.Hash().Bytes()
+
+	expected := bytes.Clone(anchorNonce)
+	expectedBySlot := map[uint64][]byte{}
+	for _, block := range blocks[1:] {
+		expected, err = eras.CalculateEtaVConway(
+			ls.config.CardanoNodeConfig,
+			expected,
+			block,
+		)
+		require.NoError(t, err)
+		expectedBySlot[block.SlotNumber()] = bytes.Clone(expected)
+	}
+
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	gotBoundary, err := db.GetBlockNonce(
+		ocommon.Point{
+			Slot: boundaryBlock.SlotNumber(),
+			Hash: boundaryBlock.Hash().Bytes(),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expectedBySlot[boundaryBlock.SlotNumber()], gotBoundary)
+	gotTip, err := db.GetBlockNonce(
+		ocommon.Point{
+			Slot: tipBlock.SlotNumber(),
+			Hash: tipBlock.Hash().Bytes(),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expected, gotTip)
+	gotFork, err := db.GetBlockNonce(
+		ocommon.Point{
+			Slot: boundaryBlock.SlotNumber(),
+			Hash: forkBoundaryHash,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, forkBoundaryNonce, gotFork)
+}
+
+// TestHealMithrilGapBlockNonces_FallsBackFromNonCanonicalAnchor verifies that
+// a valid nonce on a retained fork below the trust boundary is not allowed to
+// make startup healing skip when a lower canonical anchor can seed the fold.
+func TestHealMithrilGapBlockNonces_FallsBackFromNonCanonicalAnchor(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	canonicalChain := cm.PrimaryChain()
+
+	var origin lcommon.Blake2b256
+	blocks, err := fixtures.GenerateConwayChain(1, origin, 100, 10, 3)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+	for _, block := range blocks {
+		require.NoError(t, canonicalChain.AddBlock(block, nil))
+	}
+	anchorBlock := blocks[0]
+	boundaryBlock := blocks[1]
+	tipBlock := blocks[2]
+
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	require.NoError(t, db.SetBlockNonce(
+		anchorBlock.Hash().Bytes(),
+		anchorBlock.SlotNumber(),
+		anchorNonce,
+		true,
+		nil,
+	))
+
+	forkHash := bytes.Repeat([]byte{0xfc}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:       99,
+		Slot:     anchorBlock.SlotNumber() + 5,
+		Hash:     forkHash,
+		PrevHash: anchorBlock.Hash().Bytes(),
+		Cbor:     boundaryBlock.Cbor(),
+		Number:   99,
+		Type:     conway.BlockTypeConway,
+	}, nil))
+	require.NoError(t, db.SetBlockNonce(
+		forkHash,
+		anchorBlock.SlotNumber()+5,
+		bytes.Repeat([]byte{0xff}, 32),
+		false,
+		nil,
+	))
+
+	ls := newGapHealTestLedgerState(
+		t,
+		db,
+		boundaryBlock.SlotNumber(),
+		tipBlock.SlotNumber(),
+		tipBlock.Hash().Bytes(),
+	)
+	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
+	ls.chain = canonicalChain
+
+	expected := bytes.Clone(anchorNonce)
+	expectedBySlot := map[uint64][]byte{}
+	for _, block := range blocks[1:] {
+		expected, err = eras.CalculateEtaVConway(
+			ls.config.CardanoNodeConfig,
+			expected,
+			block,
+		)
+		require.NoError(t, err)
+		expectedBySlot[block.SlotNumber()] = bytes.Clone(expected)
+	}
+
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	gotBoundary, err := db.GetBlockNonce(
+		ocommon.Point{
+			Slot: boundaryBlock.SlotNumber(),
+			Hash: boundaryBlock.Hash().Bytes(),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expectedBySlot[boundaryBlock.SlotNumber()], gotBoundary)
+	gotTip, err := db.GetBlockNonce(
+		ocommon.Point{
+			Slot: tipBlock.SlotNumber(),
+			Hash: tipBlock.Hash().Bytes(),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expected, gotTip)
+}
+
+// TestHealMithrilGapBlockNonces_MalformedRowDoesNotMaskAnchor verifies anchor
+// selection ignores rows with an invalid nonce length: a malformed higher-slot
+// row below the trust boundary must not displace a valid lower-slot anchor and
+// make the heal decline.
+func TestHealMithrilGapBlockNonces_MalformedRowDoesNotMaskAnchor(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	var origin lcommon.Blake2b256
+	blocks, err := fixtures.GenerateConwayChain(1, origin, 120, 10, 1)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	tipBlock := blocks[0]
+	boundary := tipBlock.SlotNumber()
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot:     tipBlock.SlotNumber(),
+		Hash:     tipBlock.Hash().Bytes(),
+		PrevHash: tipBlock.PrevHash().Bytes(),
+		Cbor:     tipBlock.Cbor(),
+		Number:   tipBlock.BlockNumber(),
+		Type:     conway.BlockTypeConway,
+	}, nil))
+
+	anchorHash := bytes.Repeat([]byte{0x0a}, 32)
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	require.NoError(t, db.SetBlockNonce(anchorHash, 100, anchorNonce, true, nil))
+	// Malformed row at a higher slot below the boundary.
+	require.NoError(t, db.SetBlockNonce(
+		bytes.Repeat([]byte{0x0b}, 32), 110, []byte{0x01, 0x02}, false, nil))
+
+	ls := newGapHealTestLedgerState(
+		t, db, boundary, tipBlock.SlotNumber(), tipBlock.Hash().Bytes())
+	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
+
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	want, err := eras.CalculateEtaVConway(
+		ls.config.CardanoNodeConfig,
+		anchorNonce,
+		tipBlock,
+	)
+	require.NoError(t, err)
+	got, err := db.GetBlockNonce(
+		ocommon.Point{
+			Slot: tipBlock.SlotNumber(),
+			Hash: tipBlock.Hash().Bytes(),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, want, got,
+		"heal must seed from the valid lower-slot anchor, not decline")
+}
+
+// TestHealMithrilGapBlockNonces_MalformedBoundaryRowDoesNotSkip verifies that a
+// boundary row whose nonce is malformed (non-32-byte) does not short-circuit
+// the heal. Only a valid 32-byte nonce is a completion marker, so a boundary
+// block imported without its VRF folded must still be reconstructed and
+// overwritten with the correct nonce rather than leaving the epoch nonce wrong.
+func TestHealMithrilGapBlockNonces_MalformedBoundaryRowDoesNotSkip(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	var origin lcommon.Blake2b256
+	blocks, err := fixtures.GenerateConwayChain(1, origin, 120, 10, 1)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	tipBlock := blocks[0]
+	boundary := tipBlock.SlotNumber()
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot:     tipBlock.SlotNumber(),
+		Hash:     tipBlock.Hash().Bytes(),
+		PrevHash: tipBlock.PrevHash().Bytes(),
+		Cbor:     tipBlock.Cbor(),
+		Number:   tipBlock.BlockNumber(),
+		Type:     conway.BlockTypeConway,
+	}, nil))
+
+	anchorHash := bytes.Repeat([]byte{0x0a}, 32)
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	require.NoError(t, db.SetBlockNonce(anchorHash, 100, anchorNonce, true, nil))
+	// Malformed nonce already stored AT the boundary slot (a block imported
+	// without folding its VRF). It must not be mistaken for a completion marker.
+	require.NoError(t, db.SetBlockNonce(
+		tipBlock.Hash().Bytes(), boundary, []byte{0x01, 0x02}, false, nil))
+
+	ls := newGapHealTestLedgerState(
+		t, db, boundary, tipBlock.SlotNumber(), tipBlock.Hash().Bytes())
+	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
+
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	want, err := eras.CalculateEtaVConway(
+		ls.config.CardanoNodeConfig,
+		anchorNonce,
+		tipBlock,
+	)
+	require.NoError(t, err)
+	got, err := db.GetBlockNonce(
+		ocommon.Point{Slot: boundary, Hash: tipBlock.Hash().Bytes()},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, want, got,
+		"malformed boundary nonce must be reconstructed, not treated as complete")
+	require.NotEqual(t, []byte{0x01, 0x02}, got,
+		"the malformed boundary nonce must have been overwritten")
+}
+
+// TestHealMithrilGapBlockNonces_NoBoundaryNoOp verifies the heal is a no-op on
+// a non-Mithril (genesis-synced) DB, where mithrilLedgerSlot is zero.
+func TestHealMithrilGapBlockNonces_NoBoundaryNoOp(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	ls := newGapHealTestLedgerState(t, db, 0, 300, bytes.Repeat([]byte{0x01}, 32))
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+	require.Equal(t, 0, countBlockNonces(t, db),
+		"heal must not write any block_nonce rows when not Mithril-bootstrapped")
+}
+
+// TestHealMithrilGapBlockNonces_AlreadyHealedNoOp verifies idempotency: when a
+// block_nonce already exists at the trust-boundary slot (either no gap existed,
+// or the heal ran previously), the heal detects completion and does nothing.
+// This is the critical invariant for a startup heal — it must not re-fold or
+// mutate an already-correct chain.
+func TestHealMithrilGapBlockNonces_AlreadyHealedNoOp(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	const boundary = 200
+	anchorNonce := bytes.Repeat([]byte{0xaa}, 32)
+	boundaryNonce := bytes.Repeat([]byte{0xbb}, 32)
+	// Anchor below the boundary and a nonce present AT the boundary slot: the
+	// completion signal.
+	boundaryHash := bytes.Repeat([]byte{0x0b}, 32)
+	require.NoError(t, db.SetBlockNonce(
+		bytes.Repeat([]byte{0x0a}, 32), 150, anchorNonce, true, nil))
+	require.NoError(t, db.SetBlockNonce(
+		boundaryHash, boundary, boundaryNonce, true, nil))
+
+	ls := newGapHealTestLedgerState(
+		t, db, boundary, 300, bytes.Repeat([]byte{0x0c}, 32))
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+
+	// Both rows must be untouched and no new rows created.
+	require.Equal(t, 2, countBlockNonces(t, db))
+	got, err := db.GetBlockNonce(
+		ocommon.Point{Slot: boundary, Hash: boundaryHash}, nil)
+	require.NoError(t, err)
+	require.Equal(t, boundaryNonce, got,
+		"boundary nonce must be left unchanged when already healed")
+}
+
+// TestHealMithrilGapBlockNonces_NoAnchorSkips verifies the heal declines to act
+// when no anchor evolving nonce exists below the trust boundary. Reconstructing
+// from an unknown seed would be worse than leaving state as-is, so the heal must
+// not write anything or error.
+func TestHealMithrilGapBlockNonces_NoAnchorSkips(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	ls := newGapHealTestLedgerState(
+		t, db, 200, 300, bytes.Repeat([]byte{0x0c}, 32))
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+	require.Equal(t, 0, countBlockNonces(t, db),
+		"heal must not write block_nonce rows without a usable anchor nonce")
+}
+
+// TestHealMithrilGapBlockNonces_TipBelowBoundaryNoOp verifies the heal does not
+// act when the tip has not reached the trust boundary (an abnormal state that
+// implies no gap has been crossed yet).
+func TestHealMithrilGapBlockNonces_TipBelowBoundaryNoOp(t *testing.T) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.SetBlockNonce(
+		bytes.Repeat([]byte{0x0a}, 32), 150,
+		bytes.Repeat([]byte{0xaa}, 32), true, nil))
+
+	ls := newGapHealTestLedgerState(
+		t, db, 200, 180, bytes.Repeat([]byte{0x0c}, 32))
+	require.NoError(t, ls.healMithrilGapBlockNonces(t.Context()))
+	require.Equal(t, 1, countBlockNonces(t, db),
+		"heal must not act when the tip is below the trust boundary")
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -757,9 +757,45 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		ls.config.Logger.Info("database worker pool disabled")
 	}
 
-	// Setup event handlers. The chainsync/blockfetch/chain-update streams
-	// can burst at bulk-sync rates (#1556 / #1914), so they opt into the
-	// large EventQueueSize buffer. Sparser streams use the default.
+	// Schedule periodic process to purge consumed UTxOs outside of the rollback window
+	ls.scheduleCleanupConsumedUtxos()
+	// Load epoch info from DB
+	err := ls.SubmitAsyncDBTxn(func(txn *database.Txn) error {
+		return ls.loadEpochs(txn)
+	}, true)
+	if err != nil {
+		return fmt.Errorf("failed to load epoch info: %w", err)
+	}
+	ls.checkpointWrittenForEpoch = false
+	// Load current protocol parameters from DB
+	if err := ls.loadPParams(); err != nil {
+		return fmt.Errorf("failed to load pparams: %w", err)
+	}
+	// Reconstruct TransitionInfo from loaded state.  After restart, the
+	// in-memory field is zero (TransitionUnknown), but if the node shut down
+	// while in the window between an epoch-boundary version bump and the first
+	// block of the new era, the pparams will report a major version that maps
+	// to a later era than currentEpoch.EraId.  Detecting this here restores
+	// the correct TransitionKnown state without persisting extra data.
+	ls.reconstructTransitionInfo()
+	// Load current tip
+	if err := ls.loadTip(); err != nil {
+		return fmt.Errorf("failed to load tip: %w", err)
+	}
+	// Reconstruct the evolving-nonce fold across Mithril "gap blocks" (blocks
+	// between the ledger-state snapshot slot and the trust boundary) that were
+	// imported without folding their VRF output. Must run after the tip and
+	// trust boundary are loaded and before any epoch nonce is computed by
+	// header verification, or the first post-bootstrap epoch boundary yields a
+	// wrong nonce and every leader-VRF check in that epoch fails.
+	if err := ls.healMithrilGapBlockNonces(ctx); err != nil {
+		return fmt.Errorf("failed to heal Mithril gap block nonces: %w", err)
+	}
+	// Setup event handlers only after startup nonce repair is complete, so a
+	// Mithril-bootstrapped node cannot process chainsync/blockfetch events with
+	// stale gap-block nonces. The chainsync/blockfetch/chain-update streams can
+	// burst at bulk-sync rates (#1556 / #1914), so they opt into the large
+	// EventQueueSize buffer. Sparser streams use the default.
 	if ls.config.EventBus != nil {
 		ls.chainsyncSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			ChainsyncEventType,
@@ -788,31 +824,6 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 			ConnectionClosedEventType,
 			ls.handleConnectionClosedEvent,
 		)
-	}
-	// Schedule periodic process to purge consumed UTxOs outside of the rollback window
-	ls.scheduleCleanupConsumedUtxos()
-	// Load epoch info from DB
-	err := ls.SubmitAsyncDBTxn(func(txn *database.Txn) error {
-		return ls.loadEpochs(txn)
-	}, true)
-	if err != nil {
-		return fmt.Errorf("failed to load epoch info: %w", err)
-	}
-	ls.checkpointWrittenForEpoch = false
-	// Load current protocol parameters from DB
-	if err := ls.loadPParams(); err != nil {
-		return fmt.Errorf("failed to load pparams: %w", err)
-	}
-	// Reconstruct TransitionInfo from loaded state.  After restart, the
-	// in-memory field is zero (TransitionUnknown), but if the node shut down
-	// while in the window between an epoch-boundary version bump and the first
-	// block of the new era, the pparams will report a major version that maps
-	// to a later era than currentEpoch.EraId.  Detecting this here restores
-	// the correct TransitionKnown state without persisting extra data.
-	ls.reconstructTransitionInfo()
-	// Load current tip
-	if err := ls.loadTip(); err != nil {
-		return fmt.Errorf("failed to load tip: %w", err)
 	}
 	// Now that both tip and epoch are loaded, check whether the safe zone
 	// already covers the epoch end (TransitionImpossible).  This handles the
@@ -4621,26 +4632,45 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 	return nil
 }
 
-// healEmptyLabNonces repairs epoch records whose LastEpochBlockNonce was
-// persisted empty by pre-fix boundary block lookup bugs.
+// healEmptyLabNonces repairs epoch records whose LastEpochBlockNonce or Nonce
+// was persisted empty or wrong by pre-fix boundary bugs.
 //
-// LastEpochBlockNonce is the hash of the last block of the previous epoch. It
-// feeds the current epoch's nonce as candidateNonce ⭒ lastEpochBlockNonce.
+// LastEpochBlockNonce is the Praos lab carried at this epoch's opening
+// boundary: the parent hash (PrevHash) of the last canonical block before the
+// boundary (cardano-ledger praosStateLastEpochBlockNonce). It feeds the NEXT
+// epoch's nonce: Nonce(E) = CandidateNonce(E) ⭒ LastEpochBlockNonce(E-1).
 // Earlier boundary lookups scanned block-blob keys, so they could return a
 // synthetic Leios endorser block or retained fork blob instead of the active
-// chain's real ranking block. Empty or wrong lab values diverge epoch nonces
-// from peers and break leader-VRF verification.
+// chain's real ranking block, and older releases stored the boundary block's
+// own hash instead of its parent hash. Empty or wrong lab values diverge epoch
+// nonces from peers and break leader-VRF verification.
 //
-// This runs once at startup over the loaded epoch cache. For each non-genesis
-// epoch whose lab is empty or differs from the boundary block resolved through
-// the canonical chain index, it restores the lab and recomputes the affected
-// epoch's nonce in the cache. It is a pure function of already-stored chain
-// data and is idempotent across restarts.
+// This runs once at startup over the loaded epoch cache, in ascending epoch
+// order. For each non-genesis epoch it independently (a) restores the lab from
+// the canonical chain index when it differs from the expected epochLabNonce
+// semantics, and (b) recomputes the epoch's nonce from its candidate and the
+// PREVIOUS epoch's (already repaired) carried lab when they disagree. The lab
+// repair needs no candidate; the nonce repair is skipped when the candidate is
+// missing/invalid or the previous epoch's lab could not be verified. It is a
+// pure function of already-stored chain data and is idempotent across restarts.
 func (ls *LedgerState) healEmptyLabNonces() {
 	if ls.healEmptyLabNoncesInPlace(ls.epochCache) {
 		clear(ls.epochNonceHexCache)
 	}
 }
+
+// healLabNonceRecentEpochs bounds the startup lab/nonce repair to the most
+// recent epochs. Epoch labs are immutable historical data, and only the
+// resume-tip epoch's lab feeds a nonce the node computes at runtime: the
+// current epoch nonce mixes the previous epoch's lab, forward boundaries
+// recompute labs fresh in calculateEpochNonce, and rollbacks are bounded by the
+// security parameter (well under one epoch on real networks). Re-deriving every
+// historical epoch's lab from the chain on every restart is one canonical-block
+// lookup per epoch, which on a large blob store costs many minutes for no
+// consensus benefit. This window comfortably covers the current epoch, the
+// bounded rollback window, and a margin; DBs with fewer epochs are fully
+// processed.
+const healLabNonceRecentEpochs = 8
 
 func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 	repaired := false
@@ -4676,16 +4706,71 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 			skippedMithrilTrusted++
 		}
 	)
-	for i := range epochs {
+	// labVerified[i] records that epochs[i].LastEpochBlockNonce is known to
+	// match the canonical lab semantics (verified against the chain, repaired,
+	// or Mithril-trusted), so it is safe to use as the eta input for
+	// epochs[i+1]'s nonce check.
+	// Verify/repair the recent window (see healLabNonceRecentEpochs), plus one
+	// predecessor epoch. The predecessor is scanned only so its lab is verified
+	// and repaired: the oldest in-window epoch's nonce check mixes the PREVIOUS
+	// epoch's LastEpochBlockNonce, so without a verified predecessor lab that
+	// first in-window nonce would be skipped and left stale. Epochs before the
+	// scan are immutable and never feed a runtime nonce, so re-deriving their
+	// labs from the chain on every restart is wasted work.
+	startIdx := 0
+	if scanEpochs := healLabNonceRecentEpochs + 1; len(epochs) > scanEpochs {
+		startIdx = len(epochs) - scanEpochs
+	}
+	labVerified := make([]bool, len(epochs))
+	for i := startIdx; i < len(epochs); i++ {
 		ep := &epochs[i]
 		// The genesis epoch legitimately carries no last block nonce.
 		if ep.StartSlot == 0 {
+			labVerified[i] = len(ep.LastEpochBlockNonce) == 0
 			continue
 		}
 		if ls.mithrilLedgerSlot > 0 &&
 			ep.StartSlot <= ls.mithrilLedgerSlot &&
 			len(ep.LastEpochBlockNonce) == lcommon.Blake2b256Size {
 			recordSkippedMithrilTrustedEpoch(ep.EpochId)
+			labVerified[i] = true
+			continue
+		}
+		boundary, err := ls.canonicalBlockBeforeSlot(nil, ep.StartSlot)
+		if err != nil {
+			// A pre-Praos epoch carries no lab by definition, so its nil lab
+			// is verified even without chain data.
+			if len(ep.Nonce) == 0 && len(ep.LastEpochBlockNonce) == 0 {
+				labVerified[i] = true
+			}
+			continue
+		}
+		expectedLab, ok := ls.expectedEpochRepairLab(epochs, i, boundary)
+		if !ok {
+			continue
+		}
+		if !bytes.Equal(ep.LastEpochBlockNonce, expectedLab) {
+			previousLab := cloneNonce(ep.LastEpochBlockNonce)
+			ep.LastEpochBlockNonce = cloneNonce(expectedLab)
+			repaired = true
+			ls.config.Logger.Info(
+				"repaired epoch lastEpochBlockNonce",
+				"epoch", ep.EpochId,
+				"boundary_slot", boundary.Slot,
+				"previous_last_epoch_block_nonce",
+				hex.EncodeToString(previousLab),
+				"last_epoch_block_nonce",
+				hex.EncodeToString(ep.LastEpochBlockNonce),
+				"component", "ledger",
+			)
+		}
+		labVerified[i] = true
+		// The nonce check needs the PREVIOUS epoch's carried lab (already
+		// verified/repaired above, since the loop runs in ascending order):
+		//   Nonce(E) = CandidateNonce(E) ⭒ LastEpochBlockNonce(E-1)
+		// Mixing with this epoch's OWN lab instead would shift eta by one
+		// epoch — the exact #2734 divergence this heal exists to repair.
+		if i == 0 || !labVerified[i-1] {
 			continue
 		}
 		candidateNonce, err := ls.epochRepairCandidateNonce(*ep)
@@ -4697,53 +4782,41 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 			}
 			continue
 		}
-		boundary, err := ls.canonicalBlockBeforeSlot(nil, ep.StartSlot)
-		if err != nil ||
-			len(boundary.Hash) != lcommon.Blake2b256Size {
-			continue
+		labForEta := epochs[i-1].LastEpochBlockNonce
+		var expectedNonce []byte
+		if len(labForEta) == 0 {
+			// NeutralNonce is the identity element of ⭒:
+			//   candidateNonce ⭒ NeutralNonce = candidateNonce
+			expectedNonce = cloneNonce(candidateNonce)
+		} else {
+			res, err := lcommon.CalculateEpochNonce(
+				candidateNonce,
+				labForEta,
+				nil,
+			)
+			if err != nil {
+				ls.config.Logger.Warn(
+					"failed to recompute epoch nonce during lab recovery",
+					"epoch", ep.EpochId,
+					"error", err,
+					"component", "ledger",
+				)
+				continue
+			}
+			expectedNonce = res.Bytes()
 		}
-		if bytes.Equal(ep.LastEpochBlockNonce, boundary.Hash) {
-			continue
-		}
-		// Recompute this epoch's nonce before mutating the record; the lab and
-		// nonce must be repaired together or not at all.
-		res, err := lcommon.CalculateEpochNonce(
-			candidateNonce,
-			boundary.Hash,
-			nil,
-		)
-		if err != nil {
-			ls.config.Logger.Warn(
-				"failed to recompute epoch nonce during lab recovery",
+		if !bytes.Equal(ep.Nonce, expectedNonce) {
+			previousNonce := cloneNonce(ep.Nonce)
+			ep.Nonce = expectedNonce
+			repaired = true
+			ls.config.Logger.Info(
+				"recomputed epoch nonce after lab recovery",
 				"epoch", ep.EpochId,
-				"error", err,
+				"previous_nonce", hex.EncodeToString(previousNonce),
+				"epoch_nonce", hex.EncodeToString(expectedNonce),
 				"component", "ledger",
 			)
-			continue
 		}
-		previousLab := cloneNonce(ep.LastEpochBlockNonce)
-		previousNonce := cloneNonce(ep.Nonce)
-		newNonce := res.Bytes()
-		ep.LastEpochBlockNonce = cloneNonce(boundary.Hash)
-		ep.Nonce = newNonce
-		repaired = true
-		ls.config.Logger.Info(
-			"repaired epoch lastEpochBlockNonce",
-			"epoch", ep.EpochId,
-			"boundary_slot", boundary.Slot,
-			"previous_last_epoch_block_nonce",
-			hex.EncodeToString(previousLab),
-			"last_epoch_block_nonce",
-			hex.EncodeToString(ep.LastEpochBlockNonce),
-			"component", "ledger",
-		)
-		ls.config.Logger.Info(
-			"recomputed epoch nonce after lab recovery",
-			"epoch", ep.EpochId,
-			"previous_nonce", hex.EncodeToString(previousNonce),
-			"epoch_nonce", hex.EncodeToString(newNonce),
-			"component", "ledger",
-		)
 	}
 	if skippedMithrilTrusted > 0 {
 		ls.config.Logger.Info(
@@ -4774,6 +4847,50 @@ func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 		)
 	}
 	return repaired
+}
+
+// expectedEpochRepairLab returns the canonical LastEpochBlockNonce for
+// epochs[idx], given the last canonical block before its start slot.
+//
+// Pre-Praos (Byron) epochs carry no lab, and the FIRST Praos epoch's carried
+// lab is NeutralNonce (nil): cardano-ledger initialChainDepState sets
+// csLabNonce = NeutralNonce, and the initial-epoch branch of
+// calculateEpochNonce stores a nil lab. "Repairing" it to the last pre-Praos
+// block's parent hash would diverge the next boundary's eta on any chain with
+// a Byron era. For every other epoch the carried lab is prevHashToNonce of the
+// boundary block — regardless of which epoch that block fell in, since an
+// empty closing epoch carries the same block's parent hash forward unchanged.
+// Consulting the stored previous-epoch lab instead could inject an unhealed
+// old-shape (own-hash) value, so the value is always derived from the chain.
+func (ls *LedgerState) expectedEpochRepairLab(
+	epochs []models.Epoch,
+	idx int,
+	boundary models.Block,
+) ([]byte, bool) {
+	if idx < 0 || idx >= len(epochs) {
+		return nil, false
+	}
+	// Pre-Praos epochs have no nonce and carry no lab.
+	if len(epochs[idx].Nonce) == 0 {
+		return nil, true
+	}
+	// The first Praos epoch (previous epoch is pre-Praos) carries NeutralNonce.
+	if idx > 0 && len(epochs[idx-1].Nonce) == 0 {
+		return nil, true
+	}
+	// Derive the boundary block's parent hash, decoding the block CBOR when
+	// the stored PrevHash is empty (legacy empty-PrevHash rows).
+	prevHash, err := blockPrevHash(boundary)
+	if err != nil || len(prevHash) != lcommon.Blake2b256Size {
+		return nil, false
+	}
+	// cardano-ledger's prevHashToNonce maps GenesisHash to NeutralNonce: a
+	// boundary block that is the chain's first block contributes no lab.
+	if genesisHash, gErr := GenesisBlockHash(ls.config.CardanoNodeConfig); gErr == nil &&
+		bytes.Equal(prevHash, genesisHash[:]) {
+		return nil, true
+	}
+	return cloneNonce(prevHash), true
 }
 
 func (ls *LedgerState) epochRepairCandidateNonce(

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -745,8 +745,14 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		)
 	}
 
-	// For the initial epoch (no nonce yet), return genesis hash
-	// for both epoch nonce and initial evolving nonce.
+	// For the initial epoch (no nonce yet), the epoch/evolving/candidate nonces
+	// are all the genesis nonce, and the carried lastEpochBlockNonce is Neutral
+	// (nil): cardano-ledger initializes praosStateLastEpochBlockNonce to
+	// NeutralNonce at genesis, so the first from-genesis boundary uses the
+	// identity (eta = candidate ⭒ NeutralNonce = candidate). Do NOT seed this
+	// with the genesis nonce (#2734). Mirrors calculateEpochNonce; the Mithril
+	// bootstrap path imports a non-nil lastEpochBlockNonce and never takes this
+	// branch.
 	if len(prevEpoch.Nonce) == 0 {
 		return genesisHash, genesisHash, genesisHash, nil, nil
 	}
@@ -841,10 +847,19 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		)
 	}
 
-	// Compute the lastEpochBlockNonce for the epoch being closed.
-	// This is the hash of the last block in prevEpoch, or the carried
-	// value when prevEpoch has no blocks.
-	lastEpochBlockNonce, err := ls.epochLabNonce(
+	// The epoch nonce mixes the frozen candidate with the CARRIED
+	// last-block-of-previous-epoch nonce (cardano-ledger
+	// praosStateLastEpochBlockNonce), i.e. prevEpoch.LastEpochBlockNonce — NOT
+	// the last block of the epoch being closed. This must match the rollover
+	// path (calculateEpochNonce); see #2734.
+	//   epochNonce(N+1) = candidateNonce(N) ⭒ prevEpoch(N).LastEpochBlockNonce
+	labForEta := cloneNonce(prevEpoch.LastEpochBlockNonce)
+
+	// The carried lab for the NEXT boundary is stored on the new epoch record:
+	// prevHashToNonce(lastBlock.prevHash) = the PARENT hash of the last block of
+	// the epoch being closed (a one-block Praos lag), NOT the last block's own
+	// hash. See epochLabNonce and #2734 (eta_1349 wedge).
+	labNonceToSave, err := ls.epochLabNonce(
 		nil,
 		prevEpoch.StartSlot,
 		prevEpochEndSlot,
@@ -853,9 +868,8 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	labNonceToSave := lastEpochBlockNonce
 
-	if len(lastEpochBlockNonce) == 0 {
+	if len(labForEta) == 0 {
 		// NeutralNonce is the identity element of ⭒:
 		//   candidateNonce ⭒ NeutralNonce = candidateNonce
 		ls.config.Logger.Debug(
@@ -874,7 +888,7 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 
 	result, err := lcommon.CalculateEpochNonce(
 		candidateNonce,
-		lastEpochBlockNonce,
+		labForEta,
 		nil,
 	)
 	if err != nil {
@@ -887,8 +901,10 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 		"computed epoch nonce for cache advance",
 		"new_epoch_start_slot", epochStartSlot,
 		"prev_epoch_id", prevEpoch.EpochId,
-		"last_epoch_block_nonce",
-		hex.EncodeToString(lastEpochBlockNonce),
+		"lab_for_eta",
+		hex.EncodeToString(labForEta),
+		"lab_nonce_to_save",
+		hex.EncodeToString(labNonceToSave),
 		"candidate_nonce", hex.EncodeToString(candidateNonce),
 		"evolving_nonce", hex.EncodeToString(evolvingNonce),
 		"epoch_nonce", hex.EncodeToString(result.Bytes()),


### PR DESCRIPTION
Closes #2734 

The Praos epoch nonce (eta) diverged from the network in three ways, each making every leader-VRF check in the affected epoch fail (#2734):

- eta mixed the frozen candidate with the CLOSING epoch's own last-block nonce instead of the value carried from the previous boundary (cardano-ledger praosStateLastEpochBlockNonce), shifting the lab by one epoch. calculateEpochNonce and computeEpochNonceForSlot now mix the candidate with the carried currentEpoch.LastEpochBlockNonce.
- The lab stored for the next boundary used the last block's own hash instead of prevHashToNonce(lastBlock.prevHash), the parent hash (a one-block Praos lag). epochLabNonce now returns the parent hash.
- Blocks imported across the Mithril bootstrap gap (between the ledger-state snapshot slot and the trust boundary) were stored without folding their VRF output into the evolving nonce, producing a wrong candidate at the first post-bootstrap boundary. healMithrilGapBlockNonces reconstructs the fold at startup, after the tip and trust boundary load and before any epoch nonce is computed.

The from-genesis initial boundary keeps the identity (eta = candidate): cardano-ledger initializes praosStateLastEpochBlockNonce to NeutralNonce at genesis, so it must not be seeded with the genesis nonce.

Validated on preview crossing epochs 1347 to 1348 to 1349 with eta byte-equal to koios (3e6047c192... and 294f473148...), past the former wedge slots with no VRF failures; ledger tests and conformance green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Praos epoch nonce assembly across epoch transitions and after Mithril bootstrap so eta matches the network and leader-VRF checks pass (#2734). Restarts are safer and faster by bounding lab-nonce repair to recent epochs and rebuilding gap nonces before header verification.

- **Bug Fixes**
  - Mix the frozen candidate with the carried `LastEpochBlockNonce` (from the previous epoch) for eta; align boundary and header paths and use one per-block VRF fold; genesis keeps lab Neutral (nil).
  - Store the next boundary’s lab as the parent hash (`PrevHash`) of the closing epoch’s last block; carry forward unchanged for empty epochs; use canonical-chain lookup/decoding when needed.
  - Startup `healEmptyLabNonces`: normalize labs to parent-hash form and recompute epoch nonces as `candidate ⭒ previous-epoch lab` when a candidate exists; keep the first Praos lab nil; bound work to recent epochs and scan one predecessor; skip Mithril-covered epochs.
  - Require a valid 32-byte boundary nonce to accept the Mithril trust boundary; prevents malformed/empty rows from skipping healing; write the corrected boundary nonce last.

- **New Features**
  - Add startup `healMithrilGapBlockNonces` to rebuild missing evolving nonces from the Mithril anchor through the gap and first post-boundary blocks; idempotent, skips Byron and non-canonical blobs, refreshes the tip nonce, and runs before header verification.

<sup>Written for commit 7c9291bc871c2b983a5e6e51d105b781607dd676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic startup recovery for Mithril gap blocks, rebuilding missing nonce history before normal node checks continue.
  * Improved epoch nonce handling so the carried boundary value now follows the correct parent-hash behavior.

* **Bug Fixes**
  * Fixed epoch nonce calculation to avoid divergence at the first post-bootstrap epoch.
  * Corrected boundary nonce storage and trust-boundary behavior to keep nonce history aligned with the network.
  * Added coverage for empty epochs, forks, and recovery no-op cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->