### PR TITLE
fix(bark): validate Bark archive block URLs and cap downloads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -858,8 +858,11 @@ fallback:
 - A node with `barkBaseUrl` is wired by `node.go` with a `bark.BlobStoreBark`
   wrapper. Normal block writes still go to the local blob plugin. Reads first
   check local storage; expired or missing historical blocks fall back to the
-  remote Bark archive and download the signed URL response. This wrapper can be
-  used with or without local History Expiry.
+  remote Bark archive and download the signed URL response. Block download URLs
+  are accepted only when they are HTTPS, credential-free, and hosted by the
+  expected archive hostname or a configured `barkBlockDownloadHosts` allowlist
+  entry; redirects are disabled and response bodies are capped before buffering.
+  This wrapper can be used with or without local History Expiry.
 
 ### Tiered CBOR Cache
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -434,7 +434,11 @@ older than the ledger stability window:
   SQL metadata rows also remain. Blob readers return `types.ErrHistoryExpired`
   with the slot/hash. Without an archive wrapper this is the final read error;
   with `barkBaseUrl` configured, Bark fetches the CBOR from the archive while
-  preserving local block indexes and iteration semantics.
+  preserving local block indexes and iteration semantics. Bark validates archive
+  download URLs before fetching: they must be HTTPS, must not contain embedded
+  credentials, and must resolve to the `barkBaseUrl` hostname or a configured
+  `barkBlockDownloadHosts` entry; downloads are also size-limited to the archive
+  block response cap.
 
 ### Block Hash Index Contract
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ The following environment variables modify Dingo's behavior:
 - `DINGO_BARK_BASE_URL`
   - Base URL of a remote Bark archive node used for archive fallback
     (default: empty, disabled)
+- `DINGO_BARK_BLOCK_DOWNLOAD_HOSTS`
+  - Comma-separated HTTPS hostnames allowed for Bark-supplied block download
+    URLs. Defaults to the `DINGO_BARK_BASE_URL` hostname.
 - `DINGO_HISTORY_EXPIRY_ENABLED`
   - Enable local expiry of immutable block CBOR older than the ledger stability
     window (default: `false`)
@@ -257,7 +260,13 @@ archive:
 
 ```yaml
 barkBaseUrl: "http://archive.example.internal:9091"
+barkBlockDownloadHosts:
+  - "dingo-archive.s3.us-east-1.amazonaws.com"
 ```
+
+Bark archive RPC may use the configured `barkBaseUrl`, but the block download
+URLs returned by that service must be HTTPS, must not contain credentials, and
+must match either the `barkBaseUrl` hostname or `barkBlockDownloadHosts`.
 
 The runnable demonstration in `internal/test/archive-demo/` brings up an S3
 compatible Minio archive node, a local Badger history-expiry node, and an end-to-end

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ The following environment variables modify Dingo's behavior:
   - Base URL of a remote Bark archive node used for archive fallback
     (default: empty, disabled)
 - `DINGO_BARK_BLOCK_DOWNLOAD_HOSTS`
-  - Comma-separated HTTPS hostnames allowed for Bark-supplied block download
-    URLs. Defaults to the `DINGO_BARK_BASE_URL` hostname.
+  - Comma-separated HTTPS hostnames additionally allowed for Bark-supplied
+    block download URLs. The allowlist always includes the
+    `DINGO_BARK_BASE_URL` hostname.
 - `DINGO_HISTORY_EXPIRY_ENABLED`
   - Enable local expiry of immutable block CBOR older than the ledger stability
     window (default: `false`)

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -36,16 +39,89 @@ import (
 // per-item expired-history resolution.
 const archiveFetchTimeout = 20 * time.Second
 
+// maxArchiveBlockSize caps archive download responses to guard against
+// memory exhaustion from a malicious or misconfigured archive service.
+// 128 KiB covers the current Cardano max block body size (~90 KiB) plus
+// header/CBOR overhead while keeping malicious archive responses small.
+const maxArchiveBlockSize = 128 * 1024
+
+// validateArchiveURL rejects download URLs that could enable SSRF, credential
+// leakage, or TLS-downgrade attacks.
+func validateArchiveURL(rawURL string, allowedHosts map[string]struct{}) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.User != nil {
+		return errors.New("URL must not contain embedded credentials")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("URL must use HTTPS, got scheme %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("URL must include a host")
+	}
+	normalizedHost := strings.ToLower(host)
+	if _, ok := allowedHosts[normalizedHost]; !ok {
+		return fmt.Errorf("URL host %q is not allowed", host)
+	}
+	return nil
+}
+
+func archiveDownloadHosts(baseURL string, allowlist []string) map[string]struct{} {
+	hosts := map[string]struct{}{}
+	if u, err := url.Parse(baseURL); err == nil {
+		addArchiveDownloadHost(hosts, u.Hostname())
+	}
+	for _, host := range allowlist {
+		addArchiveDownloadHost(hosts, host)
+	}
+	return hosts
+}
+
+func addArchiveDownloadHost(hosts map[string]struct{}, host string) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return
+	}
+	if u, err := url.Parse(host); err == nil && u.Hostname() != "" {
+		host = u.Hostname()
+	} else if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	host = strings.Trim(host, "[]")
+	host = strings.ToLower(host)
+	if host != "" {
+		hosts[host] = struct{}{}
+	}
+}
+
+func archiveHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{
+			Timeout: 30 * time.Second,
+		}
+	}
+	secured := *client
+	secured.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return errors.New("bark: redirects are not permitted for archive downloads")
+	}
+	return &secured
+}
+
 type BlobStoreBarkConfig struct {
-	BaseUrl    string
-	HTTPClient *http.Client
+	BaseUrl                   string
+	HTTPClient                *http.Client
+	BlockDownloadAllowedHosts []string
 }
 
 type BlobStoreBark struct {
-	config        BlobStoreBarkConfig
-	archiveClient archiveconnect.ArchiveServiceClient
-	httpClient    *http.Client
-	upstream      blob.BlobStore
+	config                    BlobStoreBarkConfig
+	archiveClient             archiveconnect.ArchiveServiceClient
+	httpClient                *http.Client
+	blockDownloadAllowedHosts map[string]struct{}
+	upstream                  blob.BlobStore
 }
 
 func NewBarkBlobStore(
@@ -56,12 +132,7 @@ func NewBarkBlobStore(
 		return nil, errors.New("bark: upstream blob store is required")
 	}
 
-	httpClient := config.HTTPClient
-	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: 30 * time.Second,
-		}
-	}
+	httpClient := archiveHTTPClient(config.HTTPClient)
 
 	return &BlobStoreBark{
 		config: config,
@@ -69,8 +140,9 @@ func NewBarkBlobStore(
 			httpClient,
 			config.BaseUrl,
 		),
-		httpClient: httpClient,
-		upstream:   upstream,
+		httpClient:                httpClient,
+		blockDownloadAllowedHosts: archiveDownloadHosts(config.BaseUrl, config.BlockDownloadAllowedHosts),
+		upstream:                  upstream,
 	}, nil
 }
 
@@ -274,6 +346,11 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 
 	block := blocks[0]
 
+	if err := validateArchiveURL(block.GetUrl(), b.blockDownloadAllowedHosts); err != nil {
+		return nil, types.BlockMetadata{},
+			fmt.Errorf("bark: archive returned unsafe download URL: %w", err)
+	}
+
 	blockReq, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
@@ -301,10 +378,15 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 				blockResp.StatusCode)
 	}
 
-	blockBody, err := io.ReadAll(blockResp.Body)
+	lr := io.LimitReader(blockResp.Body, maxArchiveBlockSize+1)
+	blockBody, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("failed reading block body: %w", err)
+	}
+	if int64(len(blockBody)) > maxArchiveBlockSize {
+		return nil, types.BlockMetadata{},
+			fmt.Errorf("bark: archive response exceeds %d-byte limit", maxArchiveBlockSize)
 	}
 
 	prevHash, err := hex.DecodeString(block.GetMeta().GetPrevHash())

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -42,6 +42,8 @@ type fakeArchive struct {
 	prevHash    []byte
 	height      uint64
 	blockType   archive.BlockType
+	redirectURL string
+	oversize    bool
 
 	fetchCalls int
 }
@@ -80,7 +82,7 @@ func (a *fakeArchive) FetchBlock(
 func startFakeArchive(
 	t *testing.T,
 	blocks map[string][]byte,
-) (string, *fakeArchive) {
+) (string, *fakeArchive, *http.Client) {
 	t.Helper()
 	mux := http.NewServeMux()
 	a := &fakeArchive{
@@ -93,6 +95,15 @@ func startFakeArchive(
 	mux.HandleFunc(
 		"/download",
 		func(w http.ResponseWriter, r *http.Request) {
+			if a.redirectURL != "" {
+				http.Redirect(w, r, a.redirectURL, http.StatusFound)
+				return
+			}
+			if a.oversize {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(bytes.Repeat([]byte{0xFF}, maxArchiveBlockSize+1))
+				return
+			}
 			hashHex := r.URL.Query().Get("hash")
 			cbor, ok := a.blocks[hashHex]
 			if !ok {
@@ -108,12 +119,12 @@ func startFakeArchive(
 	mux.Handle(archivePath, archiveHandler)
 
 	srv := httptest.NewUnstartedServer(mux)
-	srv.Config.Protocols = unencryptedHTTP2Protocols()
-	srv.Start()
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
 	t.Cleanup(srv.Close)
 
 	a.downloadURL = srv.URL + "/download"
-	return srv.URL, a
+	return srv.URL, a, srv.Client()
 }
 
 // newTestDB builds an in-memory dingo database for use as the upstream
@@ -134,16 +145,154 @@ func newTestDB(t *testing.T) *database.Database {
 // and pointed at baseURL. Direct struct construction lets the tests inject
 // a fake archive client while focusing on the iterator path.
 func newBarkBlobStoreForTest(
-	db *database.Database, baseURL string,
+	t *testing.T, db *database.Database, baseURL string, httpClient *http.Client,
 ) *BlobStoreBark {
-	httpClient := http.DefaultClient
-	return &BlobStoreBark{
-		archiveClient: archiveconnect.NewArchiveServiceClient(
-			httpClient, baseURL,
-		),
-		httpClient: httpClient,
-		upstream:   db.Blob(),
+	t.Helper()
+	store, err := NewBarkBlobStore(BlobStoreBarkConfig{
+		BaseUrl:    baseURL,
+		HTTPClient: httpClient,
+	}, db.Blob())
+	require.NoError(t, err)
+	return store
+}
+
+// TestValidateArchiveURL covers the URL security rules enforced before any
+// download is attempted: HTTPS-only, no credentials, and allowed host only.
+func TestValidateArchiveURL(t *testing.T) {
+	allowedHosts := archiveDownloadHosts(
+		"https://archive.example.com:9091",
+		[]string{"https://s3.example.com/block"},
+	)
+	cases := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{name: "valid expected host", url: "https://archive.example.com/block?sig=abc"},
+		{name: "valid HTTPS", url: "https://s3.example.com/block?sig=abc"},
+		{name: "non-HTTPS external", url: "http://s3.example.com/block", wantErr: "HTTPS"},
+		{name: "FTP scheme", url: "ftp://s3.example.com/block", wantErr: "HTTPS"},
+		{name: "embedded credentials", url: "https://user:pass@s3.example.com/block", wantErr: "credential"},
+		{name: "missing host", url: "https:///block", wantErr: "host"},
+		{name: "disallowed host", url: "https://evil.example.com/block", wantErr: "not allowed"},
 	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateArchiveURL(c.url, allowedHosts)
+			if c.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestGetBlock_RejectsNonHTTPS verifies that a non-HTTPS download URL returned
+// by the archive is rejected before any outbound dial is attempted.
+func TestGetBlock_RejectsNonHTTPS(t *testing.T) {
+	db := newTestDB(t)
+	const slot uint64 = 500
+	hash := bytes.Repeat([]byte{0x11}, 32)
+
+	baseURL, fakeArch, httpClient := startFakeArchive(t, map[string][]byte{
+		hex.EncodeToString(hash): []byte("cbor"),
+	})
+	// Override to a non-HTTPS URL — validation fires before any dial.
+	fakeArch.downloadURL = "http://evil.example.com/block"
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err := store.GetBlock(rTxn, slot, hash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTPS")
+}
+
+// TestGetBlock_RejectsEmbeddedCredentials verifies that an archive-supplied
+// URL containing user:password is rejected even when the scheme is HTTPS.
+func TestGetBlock_RejectsEmbeddedCredentials(t *testing.T) {
+	db := newTestDB(t)
+	const slot uint64 = 501
+	hash := bytes.Repeat([]byte{0x22}, 32)
+
+	baseURL, fakeArch, httpClient := startFakeArchive(t, map[string][]byte{
+		hex.EncodeToString(hash): []byte("cbor"),
+	})
+	fakeArch.downloadURL = "https://user:pass@s3.example.com/block"
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err := store.GetBlock(rTxn, slot, hash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential")
+}
+
+// TestGetBlock_RejectsUnconfiguredHost verifies that an HTTPS URL is still
+// rejected when it points at a host outside the expected/allowlisted set.
+func TestGetBlock_RejectsUnconfiguredHost(t *testing.T) {
+	db := newTestDB(t)
+	const slot uint64 = 504
+	hash := bytes.Repeat([]byte{0x55}, 32)
+
+	baseURL, fakeArch, httpClient := startFakeArchive(t, map[string][]byte{
+		hex.EncodeToString(hash): []byte("cbor"),
+	})
+	fakeArch.downloadURL = "https://evil.example.com/block"
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err := store.GetBlock(rTxn, slot, hash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+// TestGetBlock_RejectsRedirect verifies that the HTTP client does not follow
+// redirects returned by the download server.
+func TestGetBlock_RejectsRedirect(t *testing.T) {
+	db := newTestDB(t)
+	const slot uint64 = 502
+	hash := bytes.Repeat([]byte{0x33}, 32)
+
+	baseURL, fakeArch, httpClient := startFakeArchive(t, map[string][]byte{
+		hex.EncodeToString(hash): []byte("cbor"),
+	})
+	fakeArch.redirectURL = "http://evil.example.com/block"
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err := store.GetBlock(rTxn, slot, hash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "redirect")
+}
+
+// TestGetBlock_CapsResponseSize verifies that a download response larger than
+// maxArchiveBlockSize is rejected rather than fully buffered into memory.
+func TestGetBlock_CapsResponseSize(t *testing.T) {
+	db := newTestDB(t)
+	const slot uint64 = 503
+	hash := bytes.Repeat([]byte{0x44}, 32)
+
+	baseURL, fakeArch, httpClient := startFakeArchive(t, map[string][]byte{
+		hex.EncodeToString(hash): []byte("placeholder"),
+	})
+	fakeArch.oversize = true
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err := store.GetBlock(rTxn, slot, hash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit")
 }
 
 // TestBarkIterator_ResolvesExpiredHistoryViaArchive seeds the database with a
@@ -168,10 +317,10 @@ func TestBarkIterator_ResolvesExpiredHistoryViaArchive(t *testing.T) {
 		return db.Blob().TombstoneBlock(txn.Blob(), slot, hash)
 	}))
 
-	baseURL, archiveSrv := startFakeArchive(t, map[string][]byte{
+	baseURL, archiveSrv, httpClient := startFakeArchive(t, map[string][]byte{
 		hex.EncodeToString(hash): cbor,
 	})
-	store := newBarkBlobStoreForTest(db, baseURL)
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
 
 	rTxn := store.NewTransaction(false)
 	t.Cleanup(func() { _ = rTxn.Rollback() })
@@ -293,8 +442,8 @@ func TestBarkIterator_PassesThroughLiveValues(t *testing.T) {
 	}, nil))
 
 	// Empty block map — any archive call would fatal in the fake handler.
-	baseURL, archiveSrv := startFakeArchive(t, map[string][]byte{})
-	store := newBarkBlobStoreForTest(db, baseURL)
+	baseURL, archiveSrv, httpClient := startFakeArchive(t, map[string][]byte{})
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
 
 	rTxn := store.NewTransaction(false)
 	t.Cleanup(func() { _ = rTxn.Rollback() })

--- a/config.go
+++ b/config.go
@@ -138,6 +138,7 @@ type Config struct {
 	outboundSourcePort       uint
 	utxorpcPort              uint
 	barkBaseUrl              string
+	barkBlockDownloadHosts   []string
 	barkPort                 uint
 	historyExpiry            HistoryExpiryConfig
 	corsAllowedOrigins       []string
@@ -980,6 +981,12 @@ func WithBlockfrostPort(port uint) ConfigOptionFunc {
 func WithBarkBaseUrl(baseUrl string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.barkBaseUrl = baseUrl
+	}
+}
+
+func WithBarkBlockDownloadHosts(hosts []string) ConfigOptionFunc {
+	return func(c *Config) {
+		c.barkBlockDownloadHosts = slices.Clone(hosts)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -407,33 +407,34 @@ func DefaultMidnightConfig() MidnightConfig {
 }
 
 type Config struct {
-	MetadataPlugin       string   `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
-	TlsKeyFilePath       string   `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
-	Topology             string   `yaml:"topology"`
-	CardanoConfig        string   `yaml:"cardanoConfig"      envconfig:"config"`
-	DatabasePath         string   `yaml:"databasePath"                                                     split_words:"true"`
-	SocketPath           string   `yaml:"socketPath"                                                       split_words:"true"`
-	TlsCertFilePath      string   `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr             string   `yaml:"bindAddr"                                                         split_words:"true"`
-	BlobPlugin           string   `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
-	PrivateBindAddr      string   `yaml:"privateBindAddr"                                                  split_words:"true"`
-	ShutdownTimeout      string   `yaml:"shutdownTimeout"                                                  split_words:"true"`
-	LedgerCatchupTimeout string   `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
-	Network              string   `yaml:"network"`
-	NetworkMagic         uint32   `yaml:"networkMagic"                                                     split_words:"true"`
-	MempoolCapacity      int64    `yaml:"mempoolCapacity"                                                  split_words:"true"`
-	EvictionWatermark    float64  `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
-	RejectionWatermark   float64  `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
-	PrivatePort          uint     `yaml:"privatePort"                                                      split_words:"true"`
-	RelayPort            uint     `yaml:"relayPort"          envconfig:"port"`
-	BarkBaseUrl          string   `yaml:"barkBaseUrl"        envconfig:"DINGO_BARK_BASE_URL"`
-	BarkPort             uint     `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
-	UtxorpcPort          uint     `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
-	CORSAllowedOrigins   []string `yaml:"corsAllowedOrigins" envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
-	MetricsPort          uint     `yaml:"metricsPort"                                                      split_words:"true"`
-	DebugPort            uint     `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
-	IntersectTip         bool     `yaml:"intersectTip"                                                     split_words:"true"`
-	ValidateHistorical   bool     `yaml:"validateHistorical"                                               split_words:"true"`
+	MetadataPlugin         string   `yaml:"metadataPlugin"     envconfig:"DINGO_DATABASE_METADATA_PLUGIN"`
+	TlsKeyFilePath         string   `yaml:"tlsKeyFilePath"     envconfig:"TLS_KEY_FILE_PATH"`
+	Topology               string   `yaml:"topology"`
+	CardanoConfig          string   `yaml:"cardanoConfig"      envconfig:"config"`
+	DatabasePath           string   `yaml:"databasePath"                                                     split_words:"true"`
+	SocketPath             string   `yaml:"socketPath"                                                       split_words:"true"`
+	TlsCertFilePath        string   `yaml:"tlsCertFilePath"    envconfig:"TLS_CERT_FILE_PATH"`
+	BindAddr               string   `yaml:"bindAddr"                                                         split_words:"true"`
+	BlobPlugin             string   `yaml:"blobPlugin"         envconfig:"DINGO_DATABASE_BLOB_PLUGIN"`
+	PrivateBindAddr        string   `yaml:"privateBindAddr"                                                  split_words:"true"`
+	ShutdownTimeout        string   `yaml:"shutdownTimeout"                                                  split_words:"true"`
+	LedgerCatchupTimeout   string   `yaml:"ledgerCatchupTimeout"  envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
+	Network                string   `yaml:"network"`
+	NetworkMagic           uint32   `yaml:"networkMagic"                                                     split_words:"true"`
+	MempoolCapacity        int64    `yaml:"mempoolCapacity"                                                  split_words:"true"`
+	EvictionWatermark      float64  `yaml:"evictionWatermark"  envconfig:"DINGO_MEMPOOL_EVICTION_WATERMARK"`
+	RejectionWatermark     float64  `yaml:"rejectionWatermark" envconfig:"DINGO_MEMPOOL_REJECTION_WATERMARK"`
+	PrivatePort            uint     `yaml:"privatePort"                                                      split_words:"true"`
+	RelayPort              uint     `yaml:"relayPort"          envconfig:"port"`
+	BarkBaseUrl            string   `yaml:"barkBaseUrl"        envconfig:"DINGO_BARK_BASE_URL"`
+	BarkBlockDownloadHosts []string `yaml:"barkBlockDownloadHosts" envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
+	BarkPort               uint     `yaml:"barkPort"           envconfig:"DINGO_BARK_PORT"`
+	UtxorpcPort            uint     `yaml:"utxorpcPort"        envconfig:"DINGO_UTXORPC_PORT"`
+	CORSAllowedOrigins     []string `yaml:"corsAllowedOrigins" envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
+	MetricsPort            uint     `yaml:"metricsPort"                                                      split_words:"true"`
+	DebugPort              uint     `yaml:"debugPort"          envconfig:"DINGO_DEBUG_PORT"`
+	IntersectTip           bool     `yaml:"intersectTip"                                                     split_words:"true"`
+	ValidateHistorical     bool     `yaml:"validateHistorical"                                               split_words:"true"`
 	// StrictUtxoValidation errors out (instead of silently skipping) when a
 	// consumed UTxO cannot be found or recovered for a block past the
 	// recorded Mithril sync boundary. Leave disabled when bootstrapping from

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -92,6 +92,7 @@ var flagSpecs = []flagSpec{
 
 	// Bark
 	stringFlag("BarkBaseUrl", "bark-url", "", "Bark archive fallback base URL"),
+	stringSliceFlag("BarkBlockDownloadHosts", "bark-block-download-hosts", "allowed HTTPS hostnames for Bark block downloads"),
 	uintFlag("BarkPort", "bark-port", "Bark RPC port"),
 
 	// History expiry

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -329,6 +329,7 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithUtxorpcTlsCertFilePath(cfg.TlsCertFilePath),
 			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
 			dingo.WithBarkBaseUrl(cfg.BarkBaseUrl),
+			dingo.WithBarkBlockDownloadHosts(cfg.BarkBlockDownloadHosts),
 			dingo.WithBarkPort(cfg.BarkPort),
 			dingo.WithHistoryExpiry(dingo.HistoryExpiryConfig{
 				Enabled:   cfg.HistoryExpiry.Enabled,

--- a/node.go
+++ b/node.go
@@ -425,7 +425,8 @@ func (n *Node) Run(ctx context.Context) error {
 
 	if n.config.barkBaseUrl != "" {
 		barkBlobStore, err := bark.NewBarkBlobStore(bark.BlobStoreBarkConfig{
-			BaseUrl: n.config.barkBaseUrl,
+			BaseUrl:                   n.config.barkBaseUrl,
+			BlockDownloadAllowedHosts: n.config.barkBlockDownloadHosts,
 			HTTPClient: &http.Client{
 				Timeout: 30 * time.Second,
 			},


### PR DESCRIPTION
1. Made changes to secure bark archive fallback by validating archive-supplied block download URLs, disabling redirects, and capping response sizes.
2. Added validation before fetching Bark block URLs to require https.
3. Added rejection for URLs containing embedded username/password credentials.
4. Added host allowlist enforcement using `barkBaseUrl` plus `barkBlockDownloadHosts`.
5. Made changes to disable HTTP redirects for Bark archive downloads, including custom clients.
6. Added a `128 KiB` response body cap for archived block downloads.
7. Replaced unbounded block response reads with io.LimitReader.
8. Added tests for non-HTTPS URLs & credentialed URLs, disallowed hosts & redirect attempts and oversized archive block responses.
9. Updated README, DATABASE, and ARCHITECTURE docs for the new behavior.

Closes #2037 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `bark` archive fallback by validating archive-provided block URLs, disallowing redirects, and capping response bodies to 128 KiB. Adds a host allowlist config, tests, and docs updates.

- **Bug Fixes**
  - Validate archive URLs: HTTPS-only, no embedded credentials, and host must match `barkBaseUrl` or `barkBlockDownloadHosts`.
  - Block downloads: disable HTTP redirects; cap body to 128 KiB via `io.LimitReader`.
  - Config: new `barkBlockDownloadHosts` (env `DINGO_BARK_BLOCK_DOWNLOAD_HOSTS`, CLI `--bark-block-download-hosts`); defaults to the `barkBaseUrl` hostname.
  - Tests added for non-HTTPS, credentialed URLs, disallowed hosts, redirects, and oversized responses. Docs updated in README, DATABASE, and ARCHITECTURE.

<sup>Written for commit 2b1f37b92135fbf615c9353a337fa8400a8811c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to configure allowed hostnames for Bark block downloads via environment variable, CLI flag, and config.
* **Bug Fixes**
  * Tightened archive download handling by requiring secure, credential-free URLs, restricting allowed hosts, blocking redirects, and limiting response sizes.
* **Documentation**
  * Updated architecture, database, and README docs with the new archive download rules and configuration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->