### PR TITLE
fix(peergov): replenish ledger peers aggressively when short on upstreams

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1258,6 +1258,18 @@ dial capacity; local-root and bootstrap peers, and any peer that has connected
 at least once, keep retrying, and the drop is suppressed while the node has no
 eligible upstream so its last leads back onto the network are never discarded.
 
+Ledger-peer discovery is demand-driven so the pool never collapses in the
+first place. While the node has fewer chain-selection-eligible upstreams than
+its hot-peer target (`MinHotPeers`), replenishment is treated as urgent: a
+dedicated emergency ticker (default 30s via
+`EmergencyDiscoveryCheckInterval`, far more frequent than the 5-minute
+reconcile) pulls fresh stake-pool relays on a short emergency interval (default
+30s via `EmergencyLedgerPeerRefreshInterval`) instead of the normal hourly
+`LedgerPeerRefreshInterval`, so a run of dead or flaky relays can never wedge
+sync while the ledger still lists plenty of registered relays. Once the node is
+at its hot-peer target the emergency path is a no-op and the normal hourly
+cadence applies.
+
 Each outbound dial attempt re-resolves a hostname-based peer's address fresh,
 narrows the records to the address families the local host can route to
 (detected once via `net.InterfaceAddrs` and cached, so a v4-only or v6-only

--- a/peergov/emergency_ledger_discovery_test.go
+++ b/peergov/emergency_ledger_discovery_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// addEligibleUpstreamPeers appends n connected, chain-selection-eligible
+// upstream peers (client connections from a topology source).
+func addEligibleUpstreamPeers(pg *PeerGovernor, n int) {
+	pg.mu.Lock()
+	for i := 0; i < n; i++ {
+		addr := "10.10.0." + strconv.Itoa(i+1) + ":3001"
+		pg.peers = append(pg.peers, &Peer{
+			Address:           addr,
+			NormalizedAddress: addr,
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateHot,
+			Connection:        &PeerConnection{IsClient: true},
+		})
+	}
+	pg.mu.Unlock()
+}
+
+func countPeersBySource(pg *PeerGovernor, src PeerSource) int {
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	n := 0
+	for _, peer := range pg.peers {
+		if peer != nil && peer.Source == src {
+			n++
+		}
+	}
+	return n
+}
+
+func fiftyLedgerRelays() []PoolRelay {
+	relays := make([]PoolRelay, 50)
+	for i := range relays {
+		ip := net.ParseIP("44.0." + strconv.Itoa(i/2) + "." + strconv.Itoa(i%2+1))
+		relays[i] = PoolRelay{IPv4: &ip, Port: 3001}
+	}
+	return relays
+}
+
+// The node is "urgent" for ledger-peer replenishment while it has fewer
+// connected upstreams than its hot-peer target, and never when discovery is
+// disabled.
+func TestLedgerPeersUrgent(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:      10,
+		LedgerPeerTarget: 20,
+	})
+	minHot := pg.config.MinHotPeers
+
+	assert.True(t, pg.ledgerPeersUrgent(),
+		"a node with no connected upstreams must be urgent")
+
+	addEligibleUpstreamPeers(pg, minHot-1)
+	assert.True(t, pg.ledgerPeersUrgent(),
+		"still urgent while below the hot-peer target")
+
+	addEligibleUpstreamPeers(pg, 1) // now at minHot
+	assert.False(t, pg.ledgerPeersUrgent(),
+		"not urgent once the hot-peer target is met")
+
+	pgDisabled := NewPeerGovernor(PeerGovernorConfig{
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		MinHotPeers:      10,
+		LedgerPeerTarget: -1, // discovery disabled
+	})
+	assert.False(t, pgDisabled.ledgerPeersUrgent(),
+		"ledger discovery disabled is never urgent")
+}
+
+// When the node is peer-starved, discovery must ignore the (hourly) refresh
+// interval and replenish immediately, so a collapsed pool never wedges the
+// node while relays are still available.
+func TestDiscoverLedgerPeers_EmergencyBypassesRefreshInterval(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		MinHotPeers:        10,
+		LedgerPeerTarget:   5,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      fiftyLedgerRelays(),
+			currentSlot: 1000,
+		},
+	})
+	// Refreshed 1 minute ago: within the hourly interval (normal gate would
+	// block) but past the 30s emergency interval.
+	pg.lastLedgerPeerRefresh.Store(time.Now().Add(-1 * time.Minute).UnixNano())
+	// No upstreams -> urgent -> emergency cadence bypasses the hourly gate.
+	pg.discoverLedgerPeers()
+
+	assert.Equal(t, 5, countPeersBySource(pg, PeerSourceP2PLedger),
+		"urgent node must replenish ledger peers despite a recent refresh")
+}
+
+// When the known ledger-peer target is already full of unusable peers, urgent
+// discovery must still add fresh candidates instead of returning early.
+func TestDiscoverLedgerPeers_EmergencyBypassesSatisfiedTarget(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		MinHotPeers:        10,
+		LedgerPeerTarget:   2,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      fiftyLedgerRelays(),
+			currentSlot: 1000,
+		},
+	})
+	pg.mu.Lock()
+	pg.peers = append(pg.peers,
+		&Peer{
+			Address:           "44.0.0.1:3001",
+			NormalizedAddress: "44.0.0.1:3001",
+			Source:            PeerSourceP2PLedger,
+			State:             PeerStateCold,
+		},
+		&Peer{
+			Address:           "44.0.0.2:3001",
+			NormalizedAddress: "44.0.0.2:3001",
+			Source:            PeerSourceP2PLedger,
+			State:             PeerStateCold,
+		},
+	)
+	pg.mu.Unlock()
+	assert.Equal(t, 0, pg.ledgerPeerDeficit(),
+		"known ledger-peer target should appear satisfied")
+	// Refreshed 1 minute ago: within the hourly interval but past the default
+	// emergency interval, so only the urgent path may proceed.
+	pg.lastLedgerPeerRefresh.Store(time.Now().Add(-1 * time.Minute).UnixNano())
+
+	pg.discoverLedgerPeers()
+
+	assert.Greater(t, countPeersBySource(pg, PeerSourceP2PLedger), 2,
+		"urgent discovery must add fresh ledger peers even when target appears satisfied")
+}
+
+func TestDiscoverLedgerPeers_EmergencyLogField(t *testing.T) {
+	var logBuf bytes.Buffer
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(&logBuf, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		MinHotPeers:        10,
+		LedgerPeerTarget:   1,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      fiftyLedgerRelays(),
+			currentSlot: 1000,
+		},
+	})
+
+	pg.discoverLedgerPeers()
+
+	assert.Contains(t, logBuf.String(), `"emergency":true`,
+		"emergency ledger discovery log should include emergency=true")
+}
+
+// A healthy node (at its hot-peer target) must NOT bypass the refresh
+// interval: a recent refresh suppresses discovery as normal.
+func TestDiscoverLedgerPeers_NoBypassWhenNotUrgent(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		MinHotPeers:        10,
+		LedgerPeerTarget:   5,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      fiftyLedgerRelays(),
+			currentSlot: 1000,
+		},
+	})
+	addEligibleUpstreamPeers(pg, pg.config.MinHotPeers) // at hot target: not urgent
+	// Refreshed 1 minute ago: inside the hourly interval, so a non-urgent node
+	// must not discover (no emergency bypass applies).
+	pg.lastLedgerPeerRefresh.Store(time.Now().Add(-1 * time.Minute).UnixNano())
+
+	pg.discoverLedgerPeers()
+
+	assert.Equal(t, 0, countPeersBySource(pg, PeerSourceP2PLedger),
+		"non-urgent node must respect the refresh interval and add no ledger peers")
+}

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -21,8 +21,12 @@ import (
 // discoverLedgerPeers discovers peers from on-chain stake pool relay registrations.
 // This method is called during reconciliation if ledger peers are enabled.
 //
-// Selection is bounded: only enough peers are added to reach LedgerPeerTarget.
-// Candidates are shuffled uniformly so no single pool dominates across refreshes.
+// Selection is bounded: normal discovery adds only enough peers to reach
+// LedgerPeerTarget. Emergency discovery may add one target-sized batch even
+// when the known ledger-peer target is already satisfied, because stale or
+// unusable peers must not block fresh relay candidates while the node is short
+// of connected upstreams. Candidates are shuffled uniformly so no single pool
+// dominates across refreshes.
 func (p *PeerGovernor) discoverLedgerPeers() {
 	// Check if ledger peer provider is configured
 	if p.config.LedgerPeerProvider == nil {
@@ -32,12 +36,6 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 		)
 		return
 	}
-	p.config.Logger.Debug(
-		"ledger peer discovery starting",
-		"component", "peergov",
-		"use_ledger_after_slot", p.config.UseLedgerAfterSlot,
-	)
-
 	// Check UseLedgerAfterSlot threshold first (before claiming refresh)
 	if p.config.UseLedgerAfterSlot < 0 {
 		// Ledger peers are disabled
@@ -58,20 +56,37 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 	}
 
 	// Count existing ledger peers to determine how many we need.
+	urgent := p.ledgerPeersUrgent()
 	needed := p.ledgerPeerDeficit()
-	if needed <= 0 {
+	p.config.Logger.Debug(
+		"ledger peer discovery starting",
+		"component", "peergov",
+		"use_ledger_after_slot", p.config.UseLedgerAfterSlot,
+		"needed", needed,
+		"emergency", urgent,
+	)
+	if needed <= 0 && !urgent {
 		p.config.Logger.Debug(
 			"ledger peer target already satisfied",
 			"target", p.config.LedgerPeerTarget,
+			"emergency", urgent,
 		)
 		return
 	}
 
 	// Atomically check and claim the refresh to prevent concurrent discoveries.
-	// Use CompareAndSwap to ensure only one goroutine proceeds.
+	// Use CompareAndSwap to ensure only one goroutine proceeds. The normal
+	// cadence is LedgerPeerRefreshInterval, but when the node is critically
+	// short of connected upstreams it replenishes on a much shorter emergency
+	// interval instead of waiting up to an hour: a node must never wedge on a
+	// collapsed peer pool while the ledger still lists plenty of relays.
+	refreshInterval := p.config.LedgerPeerRefreshInterval
+	if urgent {
+		refreshInterval = p.config.EmergencyLedgerPeerRefreshInterval
+	}
 	now := time.Now().UnixNano()
 	lastRefresh := p.lastLedgerPeerRefresh.Load()
-	if time.Duration(now-lastRefresh) < p.config.LedgerPeerRefreshInterval {
+	if time.Duration(now-lastRefresh) < refreshInterval {
 		return
 	}
 	if !p.lastLedgerPeerRefresh.CompareAndSwap(lastRefresh, now) {
@@ -85,6 +100,7 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 		p.config.Logger.Error(
 			"failed to get ledger peers",
 			"error", err,
+			"emergency", urgent,
 		)
 		// Reset timestamp to allow retry on next reconciliation cycle
 		// rather than waiting for the full refresh interval
@@ -93,7 +109,11 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 	}
 
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
-	addedCount := p.addLedgerRelays(relays)
+	extraAdds := 0
+	if urgent && needed <= 0 {
+		extraAdds = p.config.LedgerPeerTarget
+	}
+	addedCount := p.addLedgerRelays(relays, extraAdds)
 
 	if addedCount > 0 {
 		p.config.Logger.Info(
@@ -101,14 +121,33 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 			"added", addedCount,
 			"target", p.config.LedgerPeerTarget,
 			"candidates", len(candidates),
+			"emergency", urgent,
 		)
 	} else {
 		p.config.Logger.Debug(
 			"ledger peer discovery complete",
 			"candidates", len(candidates),
 			"new_peers", 0,
+			"emergency", urgent,
 		)
 	}
+}
+
+// ledgerPeersUrgent reports whether the node is critically short of connected
+// upstreams and must replenish ledger peers on the emergency cadence rather
+// than waiting for the normal refresh interval. Ledger discovery must be
+// enabled (target > 0) for this to apply. The threshold is the hot-peer
+// target: while the node has fewer eligible upstreams than it wants hot
+// peers, it keeps pulling fresh relays so it never gets stuck on a shrinking
+// pool of bad peers.
+func (p *PeerGovernor) ledgerPeersUrgent() bool {
+	if p.config.LedgerPeerTarget <= 0 {
+		return false
+	}
+	p.mu.Lock()
+	upstreams := p.countEligibleUpstreamsLocked()
+	p.mu.Unlock()
+	return upstreams < p.config.MinHotPeers
 }
 
 // ledgerPeerDeficit returns how many more ledger peers are needed to reach

--- a/peergov/ledger_discovery_test.go
+++ b/peergov/ledger_discovery_test.go
@@ -118,6 +118,7 @@ func TestDiscoverLedgerPeers_TargetAlreadySatisfied(t *testing.T) {
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:           newMockEventBus(),
 		UseLedgerAfterSlot: 0,
+		MinHotPeers:        2,
 		LedgerPeerTarget:   2,
 		LedgerPeerProvider: &mockLedgerPeerProvider{
 			relays: func() []PoolRelay {
@@ -135,6 +136,12 @@ func TestDiscoverLedgerPeers_TargetAlreadySatisfied(t *testing.T) {
 	// First discovery: adds 2 to reach target
 	pg.discoverLedgerPeers()
 	assert.Len(t, pg.peers, 2)
+	pg.mu.Lock()
+	for _, peer := range pg.peers {
+		peer.State = PeerStateHot
+		peer.Connection = &PeerConnection{IsClient: true}
+	}
+	pg.mu.Unlock()
 
 	// Reset refresh timestamp
 	pg.lastLedgerPeerRefresh.Store(

--- a/peergov/peer_snapshot.go
+++ b/peergov/peer_snapshot.go
@@ -32,7 +32,7 @@ func (p *PeerGovernor) LoadPeerSnapshot(
 		return 0
 	}
 	relays := PoolRelaysFromPeerSnapshot(snapshot)
-	added := p.addLedgerRelays(relays)
+	added := p.addLedgerRelays(relays, 0)
 	p.config.Logger.Info(
 		"loaded peer snapshot",
 		"snapshot_slot", snapshot.Point.BlockPointSlot,
@@ -85,7 +85,9 @@ func poolRelayFromSnapshotAccessPoint(
 	}, true
 }
 
-func (p *PeerGovernor) addLedgerRelays(relays []PoolRelay) int {
+// addLedgerRelays fills the configured ledger-peer target. extraAdds permits a
+// bounded emergency overfill after the target is already satisfied.
+func (p *PeerGovernor) addLedgerRelays(relays []PoolRelay, extraAdds int) int {
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
 	rand.Shuffle(len(candidates), func(i, j int) {
 		candidates[i], candidates[j] = candidates[j], candidates[i]
@@ -93,7 +95,7 @@ func (p *PeerGovernor) addLedgerRelays(relays []PoolRelay) int {
 
 	added := 0
 	for _, addr := range candidates {
-		if p.ledgerPeerDeficit() <= 0 {
+		if p.ledgerPeerDeficit() <= 0 && added >= extraAdds {
 			break
 		}
 		if p.addLedgerPeer(addr) {

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -37,6 +37,15 @@ const (
 	defaultLedgerPeerRefreshInterval    = 1 * time.Hour
 	defaultLedgerPeerTarget             = 20
 
+	// When the node is critically short of connected upstreams, ledger-peer
+	// discovery ignores the normal (hourly) refresh interval and replenishes
+	// on this much shorter emergency cadence, and a dedicated ticker checks
+	// for that condition far more often than the 5-minute reconcile. Together
+	// they ensure a collapsed peer pool recovers in seconds rather than
+	// wedging the node while the ledger still lists plenty of relays.
+	defaultEmergencyLedgerPeerRefreshInterval = 30 * time.Second
+	defaultEmergencyDiscoveryCheckInterval    = 30 * time.Second
+
 	// Default peer targets match cardano-node config.json defaults.
 	defaultTargetNumberOfKnownPeers       = 150
 	defaultTargetNumberOfEstablishedPeers = 50
@@ -160,6 +169,9 @@ type PeerGovernorConfig struct {
 	UseLedgerAfterSlot        int64              // Slot after which to enable ledger peers (-1 = disabled)
 	LedgerPeerRefreshInterval time.Duration      // How often to refresh ledger peers
 	LedgerPeerTarget          int                // Negative disables ledger discovery, 0 uses defaultLedgerPeerTarget, positive uses that target
+	// Emergency ledger-peer discovery configuration
+	EmergencyLedgerPeerRefreshInterval time.Duration // Urgent ledger refresh cadence (0 = default 30s)
+	EmergencyDiscoveryCheckInterval    time.Duration // Urgent condition check cadence (0 = default 30s)
 
 	// Peer targets (0 = use default, -1 = unlimited)
 	// These are goals the system works toward, not hard limits.
@@ -259,6 +271,12 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	}
 	if cfg.LedgerPeerRefreshInterval == 0 {
 		cfg.LedgerPeerRefreshInterval = defaultLedgerPeerRefreshInterval
+	}
+	if cfg.EmergencyLedgerPeerRefreshInterval <= 0 {
+		cfg.EmergencyLedgerPeerRefreshInterval = defaultEmergencyLedgerPeerRefreshInterval
+	}
+	if cfg.EmergencyDiscoveryCheckInterval <= 0 {
+		cfg.EmergencyDiscoveryCheckInterval = defaultEmergencyDiscoveryCheckInterval
 	}
 	// Ledger peer target mapping: negative disables discovery, 0 uses
 	// defaultLedgerPeerTarget, positive uses the explicit target.
@@ -446,6 +464,30 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 			}
 		}
 	}(publicRootChurnTicker, stopCh)
+
+	// Emergency ledger-peer discovery loop. When the node is critically short
+	// of connected upstreams, discoverLedgerPeers replenishes on the emergency
+	// cadence (see ledgerPeersUrgent). This ticker checks far more often than
+	// the 5-minute reconcile so a collapsed peer pool recovers in seconds. It
+	// is a no-op while the node has enough upstreams.
+	emergencyDiscoveryTicker := time.NewTicker(
+		p.config.EmergencyDiscoveryCheckInterval,
+	)
+	go func(t *time.Ticker, stop <-chan struct{}) {
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				if p.ledgerPeersUrgent() {
+					p.discoverLedgerPeers()
+				}
+			case <-stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}(emergencyDiscoveryTicker, stopCh)
 
 	// Start outbound connections
 	p.startOutboundConnections()

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -89,11 +89,13 @@ func TestNewPeerGovernor(t *testing.T) {
 				Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 			},
 			expected: PeerGovernorConfig{
-				ReconcileInterval:            defaultReconcileInterval,
-				MaxReconnectFailureThreshold: defaultMaxReconnectFailureThreshold,
-				MinHotPeers:                  defaultMinHotPeers,
-				InactivityTimeout:            defaultInactivityTimeout,
-				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
+				ReconcileInterval:                  defaultReconcileInterval,
+				MaxReconnectFailureThreshold:       defaultMaxReconnectFailureThreshold,
+				MinHotPeers:                        defaultMinHotPeers,
+				InactivityTimeout:                  defaultInactivityTimeout,
+				BootstrapRecoveryCooldown:          defaultBootstrapRecoveryCooldown,
+				EmergencyLedgerPeerRefreshInterval: defaultEmergencyLedgerPeerRefreshInterval,
+				EmergencyDiscoveryCheckInterval:    defaultEmergencyDiscoveryCheckInterval,
 			},
 		},
 		{
@@ -102,16 +104,20 @@ func TestNewPeerGovernor(t *testing.T) {
 				Logger: slog.New(
 					slog.NewJSONHandler(io.Discard, nil),
 				),
-				ReconcileInterval:            10 * time.Minute,
-				MaxReconnectFailureThreshold: 10,
-				MinHotPeers:                  5,
+				ReconcileInterval:                  10 * time.Minute,
+				MaxReconnectFailureThreshold:       10,
+				MinHotPeers:                        5,
+				EmergencyLedgerPeerRefreshInterval: 10 * time.Second,
+				EmergencyDiscoveryCheckInterval:    15 * time.Second,
 			},
 			expected: PeerGovernorConfig{
-				ReconcileInterval:            10 * time.Minute,
-				MaxReconnectFailureThreshold: 10,
-				MinHotPeers:                  5,
-				InactivityTimeout:            defaultInactivityTimeout,
-				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
+				ReconcileInterval:                  10 * time.Minute,
+				MaxReconnectFailureThreshold:       10,
+				MinHotPeers:                        5,
+				InactivityTimeout:                  defaultInactivityTimeout,
+				BootstrapRecoveryCooldown:          defaultBootstrapRecoveryCooldown,
+				EmergencyLedgerPeerRefreshInterval: 10 * time.Second,
+				EmergencyDiscoveryCheckInterval:    15 * time.Second,
 			},
 		},
 		{
@@ -126,11 +132,13 @@ func TestNewPeerGovernor(t *testing.T) {
 				InactivityTimeout:            -3 * time.Minute,
 			},
 			expected: PeerGovernorConfig{
-				ReconcileInterval:            defaultReconcileInterval,
-				MaxReconnectFailureThreshold: defaultMaxReconnectFailureThreshold,
-				MinHotPeers:                  defaultMinHotPeers,
-				InactivityTimeout:            defaultInactivityTimeout,
-				BootstrapRecoveryCooldown:    defaultBootstrapRecoveryCooldown,
+				ReconcileInterval:                  defaultReconcileInterval,
+				MaxReconnectFailureThreshold:       defaultMaxReconnectFailureThreshold,
+				MinHotPeers:                        defaultMinHotPeers,
+				InactivityTimeout:                  defaultInactivityTimeout,
+				BootstrapRecoveryCooldown:          defaultBootstrapRecoveryCooldown,
+				EmergencyLedgerPeerRefreshInterval: defaultEmergencyLedgerPeerRefreshInterval,
+				EmergencyDiscoveryCheckInterval:    defaultEmergencyDiscoveryCheckInterval,
 			},
 		},
 	}
@@ -160,6 +168,16 @@ func TestNewPeerGovernor(t *testing.T) {
 				t,
 				tt.expected.BootstrapRecoveryCooldown,
 				pg.config.BootstrapRecoveryCooldown,
+			)
+			assert.Equal(
+				t,
+				tt.expected.EmergencyLedgerPeerRefreshInterval,
+				pg.config.EmergencyLedgerPeerRefreshInterval,
+			)
+			assert.Equal(
+				t,
+				tt.expected.EmergencyDiscoveryCheckInterval,
+				pg.config.EmergencyDiscoveryCheckInterval,
 			)
 			assert.NotNil(t, pg.config.BootstrapPromotionEnabled)
 			assert.True(t, *pg.config.BootstrapPromotionEnabled)


### PR DESCRIPTION
Ledger-peer discovery was gated to a 1-hour refresh interval, so when the connectable pool collapsed (dead/flaky relays denied for 30m and removed after repeated failures) the node could not pull fresh stake-pool relays for up to an hour. On a network with many stale relay registrations this starved the node down to a single hot peer, stalling sync while the ledger still listed plenty of relays (observed: preprod from-genesis wedged at slot 11320459 with 1 hot peer, errscan clean).

While the node has fewer chain-selection-eligible upstreams than its hot-peer target (MinHotPeers), discovery now treats replenishment as urgent: it ignores the hourly interval and refreshes on a 30s emergency cadence, driven by a dedicated ticker that is a no-op once the node is at its hot-peer target. A collapsed pool now recovers in seconds instead of wedging on a bad peer.

Validated on preprod from-genesis: the node sustains 5-12 hot peers and syncs past the former wedge with zero VRF/decode/UTxO errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented sync stalls by aggressively replenishing ledger peers when the node is short on eligible upstreams. Discovery checks every 30s until `MinHotPeers` is met, then returns to the normal hourly cadence.

- **Bug Fixes**
  - Bypass hourly `LedgerPeerRefreshInterval` when eligible upstreams < `MinHotPeers` via `ledgerPeersUrgent()`; `discoverLedgerPeers()` uses 30s `EmergencyLedgerPeerRefreshInterval`.
  - Added a 30s `EmergencyDiscoveryCheckInterval` ticker that triggers discovery only when urgent; no-op when healthy or when `LedgerPeerTarget` <= 0.
  - In urgent mode, allow one target-sized extra batch even if the target looks satisfied to replace stale/invalid peers; tests updated and `ARCHITECTURE.md` documented.

<sup>Written for commit 482a22f4dede3d15bda395a06002221c70016b9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an emergency ledger-peer discovery path that checks more frequently when hot peer availability drops too low.
  * Peer discovery now refreshes faster in urgent situations, helping the node recover upstream peers without waiting for the normal interval.

* **Tests**
  * Added coverage for urgent discovery behavior, including bypassing the usual refresh delay and avoiding unnecessary refreshes when enough peers are already connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->