### PR TITLE
fix(database): committee voting query performance

### DIFF
--- a/database/plugin/metadata/mysql/governance.go
+++ b/database/plugin/metadata/mysql/governance.go
@@ -354,17 +354,24 @@ func (d *MetadataStoreMysql) GetActiveCommitteeMembers(
 	if err != nil {
 		return nil, err
 	}
-	// Use a subquery to get only the latest authorization per cold_credential,
-	// then filter out members whose latest resignation is after their latest authorization.
-	// Uses (added_slot, certificate_id) for deterministic ordering based on global certificate order.
+	// Select the latest authorization per cold_credential with a window function
+	// (rn = 1), then exclude members whose latest resignation is after that
+	// authorization. Ordering is (added_slot DESC, certificate_id DESC) for
+	// deterministic global certificate order. This replaces a correlated NOT
+	// EXISTS self-join that was O(rows * rows-per-credential): auth_committee_hot
+	// accumulates every hot-key authorization ever seen (hundreds of thousands of
+	// rows on a long-lived chain), which stalled epoch rollover for hours (#2754).
 	if result := db.Raw(`
-		SELECT a.*
-		FROM auth_committee_hot a
-		WHERE NOT EXISTS (
-			SELECT 1 FROM auth_committee_hot a2
-			WHERE a2.cold_credential = a.cold_credential
-			AND (a2.added_slot > a.added_slot OR (a2.added_slot = a.added_slot AND a2.certificate_id > a.certificate_id))
-		)
+		SELECT a.cold_credential, a.host_credential, a.id, a.certificate_id, a.added_slot
+		FROM (
+			SELECT cold_credential, host_credential, id, certificate_id, added_slot,
+				ROW_NUMBER() OVER (
+					PARTITION BY cold_credential
+					ORDER BY added_slot DESC, certificate_id DESC
+				) AS rn
+			FROM auth_committee_hot
+		) a
+		WHERE a.rn = 1
 		AND NOT EXISTS (
 			SELECT 1 FROM resign_committee_cold r
 			WHERE r.cold_credential = a.cold_credential

--- a/database/plugin/metadata/postgres/governance.go
+++ b/database/plugin/metadata/postgres/governance.go
@@ -358,17 +358,24 @@ func (d *MetadataStorePostgres) GetActiveCommitteeMembers(
 	if err != nil {
 		return nil, err
 	}
-	// Use a subquery to get only the latest authorization per cold_credential,
-	// then filter out members whose latest resignation is after their latest authorization.
-	// Uses (added_slot, certificate_id) for deterministic ordering based on global certificate order.
+	// Select the latest authorization per cold_credential with a window function
+	// (rn = 1), then exclude members whose latest resignation is after that
+	// authorization. Ordering is (added_slot DESC, certificate_id DESC) for
+	// deterministic global certificate order. This replaces a correlated NOT
+	// EXISTS self-join that was O(rows * rows-per-credential): auth_committee_hot
+	// accumulates every hot-key authorization ever seen (hundreds of thousands of
+	// rows on a long-lived chain), which stalled epoch rollover for hours (#2754).
 	if result := db.Raw(`
-		SELECT a.*
-		FROM auth_committee_hot a
-		WHERE NOT EXISTS (
-			SELECT 1 FROM auth_committee_hot a2
-			WHERE a2.cold_credential = a.cold_credential
-			AND (a2.added_slot > a.added_slot OR (a2.added_slot = a.added_slot AND a2.certificate_id > a.certificate_id))
-		)
+		SELECT a.cold_credential, a.host_credential, a.id, a.certificate_id, a.added_slot
+		FROM (
+			SELECT cold_credential, host_credential, id, certificate_id, added_slot,
+				ROW_NUMBER() OVER (
+					PARTITION BY cold_credential
+					ORDER BY added_slot DESC, certificate_id DESC
+				) AS rn
+			FROM auth_committee_hot
+		) a
+		WHERE a.rn = 1
 		AND NOT EXISTS (
 			SELECT 1 FROM resign_committee_cold r
 			WHERE r.cold_credential = a.cold_credential

--- a/database/plugin/metadata/sqlite/committee.go
+++ b/database/plugin/metadata/sqlite/committee.go
@@ -56,17 +56,24 @@ func (d *MetadataStoreSqlite) GetActiveCommitteeMembers(
 	if err != nil {
 		return nil, err
 	}
-	// Use a subquery to get only the latest authorization per cold_credential,
-	// then filter out members whose latest resignation is after their latest authorization.
-	// Uses (added_slot, certificate_id) for deterministic ordering based on global certificate order.
+	// Select the latest authorization per cold_credential with a window function
+	// (rn = 1), then exclude members whose latest resignation is after that
+	// authorization. Ordering is (added_slot DESC, certificate_id DESC) for
+	// deterministic global certificate order. This replaces a correlated NOT
+	// EXISTS self-join that was O(rows * rows-per-credential): auth_committee_hot
+	// accumulates every hot-key authorization ever seen (hundreds of thousands of
+	// rows on a long-lived chain), which stalled epoch rollover for hours (#2754).
 	if result := db.Raw(`
-		SELECT a.*
-		FROM auth_committee_hot a
-		WHERE NOT EXISTS (
-			SELECT 1 FROM auth_committee_hot a2
-			WHERE a2.cold_credential = a.cold_credential
-			AND (a2.added_slot > a.added_slot OR (a2.added_slot = a.added_slot AND a2.certificate_id > a.certificate_id))
-		)
+		SELECT a.cold_credential, a.host_credential, a.id, a.certificate_id, a.added_slot
+		FROM (
+			SELECT cold_credential, host_credential, id, certificate_id, added_slot,
+				ROW_NUMBER() OVER (
+					PARTITION BY cold_credential
+					ORDER BY added_slot DESC, certificate_id DESC
+				) AS rn
+			FROM auth_committee_hot
+		) a
+		WHERE a.rn = 1
 		AND NOT EXISTS (
 			SELECT 1 FROM resign_committee_cold r
 			WHERE r.cold_credential = a.cold_credential


### PR DESCRIPTION
Closes #2754 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up committee voting queries by selecting the latest authorization per cold credential with a window function instead of a correlated self-join. This removes the O(n²) scan that caused epoch rollover stalls on long‑lived chains and closes #2754.

- **Bug Fixes**
  - Use ROW_NUMBER() partitioned by cold_credential, ordered by added_slot DESC, certificate_id DESC, then filter by resignations.
  - Applied to MySQL, Postgres, and SQLite paths; no schema or API changes.
  - Keeps deterministic global ordering while reducing load on large `auth_committee_hot` tables.

<sup>Written for commit f6d1598bd77743597ae9ab77459c1ed35104893f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

