### PR TITLE
feat(config): add Validate() method for startup validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1803,7 +1803,12 @@ defaults are derived from other settings (an empty `runMode` selects `serve`;
 `mempoolCapacity` defaults by run mode — Leios raises it — and the watermarks,
 forge slot thresholds, and history-expiry frequency take their standard
 values), and then `Config.Validate()` checks the resulting configuration
-before any services start: mode enums, listener port ranges (privileged/out-of-range/duplicate),
+before any services start. Topology resolution
+(`config.LoadTopologyConfig`) runs last, only after the merged
+configuration is defaulted and valid, because it derives from the
+`network` and `topology` settings — resolving it earlier could reject a
+YAML or environment value that a CLI flag has since repaired. Validate
+checks: mode enums, listener port ranges (privileged/out-of-range/duplicate),
 load-mode `immutableDbPath` requirement, path-traversal guards, TLS cert/key
 pairing, mempool watermarks, block-producer credential paths, and
 duration/strategy strings that are otherwise only parsed at their point of use.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1796,15 +1796,21 @@ Configuration priority (highest to lowest):
 
 After all sources are merged (including CLI flags), `Config.Validate()`
 (`internal/config`) checks the resulting configuration before any services
-start: mode enums, port ranges (privileged/out-of-range/duplicate), load-mode
-`immutableDbPath` requirement, path-traversal guards, TLS cert/key pairing,
-mempool watermarks, block-producer credential paths, and duration/strategy
-strings that are otherwise only parsed at their point of use. The relay,
-private, and metrics listener ports are required only for the serving modes;
-the one-shot subcommands (`load`, `sync`, `mithril`) start none of them. Because
-those subcommands run a fixed operation regardless of the configured `runMode`
-(which defaults to `serve`), `cmd/dingo` passes `Validate()` an *effective* run
-mode derived from the invoked command, so listener and ImmutableDB-source
+start: mode enums, listener port ranges (privileged/out-of-range/duplicate),
+load-mode `immutableDbPath` requirement, path-traversal guards, TLS cert/key
+pairing, mempool watermarks, block-producer credential paths, and
+duration/strategy strings that are otherwise only parsed at their point of use.
+Port checks apply only to the listeners a given invocation actually starts,
+derived from the *effective* run mode plus the storage mode: the serving modes
+start the relay, private, metrics, debug, and bark listeners (and, under `api`
+storage, the UTxORPC/Blockfrost/Mesh/Midnight listeners); the `sync` and
+`mithril` utilities start only the metrics and debug listeners; `load` starts
+none. A port configured for an inactive listener cannot bind, so it is neither
+range-checked nor counted toward a collision; the relay, private, and metrics
+ports must additionally be set in the serving modes. Because the one-shot
+subcommands run a fixed operation regardless of the configured `runMode` (which
+defaults to `serve`), `cmd/dingo` passes `Validate()` the effective run mode
+derived from the invoked command, so listener and ImmutableDB-source
 requirements match what the command actually does. All violations are reported
 together in a single startup error. The informational `version` and `list`
 subcommands are exempt so they still run against an otherwise-invalid config.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1808,15 +1808,19 @@ UTxORPC/Blockfrost/Mesh/Midnight listeners); the Mithril snapshot
 sync (`dingo sync --mithril` or `dingo mithril sync`) starts only the metrics
 and debug listeners; the read-only `mithril list`/`show` and `load` start none.
 A port configured for an inactive listener cannot bind, so it is neither
-range-checked nor counted toward a collision; the relay, private, and metrics
+range-checked nor counted toward a collision; two active listeners are only
+reported as colliding when their bind addresses overlap (equal, or either
+side a wildcard) — listeners on distinct specific addresses may share a
+port. The relay, private, and metrics
 ports must additionally be set in the serving modes. Because the one-shot
 subcommands run a fixed operation regardless of the configured `runMode` (which
 defaults to `serve`), `cmd/dingo` passes `Validate()` the effective run mode
 derived from the invoked command, so listener and ImmutableDB-source
 requirements match what the command actually does. All violations are reported
 together in a single startup error. The informational `version` and `list`
-subcommands — and cobra's built-in `help` and `completion` — are exempt so
-they still run against an otherwise-invalid config. The privileged-port check compares each active port against what the
+subcommands — and cobra's built-in `help` and `completion` — skip config
+loading and validation entirely, so they run even when the config file is
+missing or invalid. The privileged-port check compares each active port against what the
 process may actually bind: root, Windows, and Linux `CAP_NET_BIND_SERVICE`
 allow any port, and otherwise Linux uses the kernel's
 `net.ipv4.ip_unprivileged_port_start` cutoff (1024 by default; container

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1794,9 +1794,16 @@ Configuration priority (highest to lowest):
 3. YAML config file (`dingo.yaml`)
 4. Hardcoded defaults
 
-After all sources are merged (including CLI flags), `Config.Validate()`
-(`internal/config`) checks the resulting configuration before any services
-start: mode enums, listener port ranges (privileged/out-of-range/duplicate),
+`LoadConfig` (`internal/config`) only parses and merges the YAML and
+environment sources; it makes no semantic judgments about the merged values,
+because CLI flags are a higher-precedence source merged afterwards by
+`ApplyFlags` and may still replace an invalid or unset value. Once every
+source is merged, `Config.ApplyDefaults()` fills in unset values whose
+defaults are derived from other settings (an empty `runMode` selects `serve`;
+`mempoolCapacity` defaults by run mode — Leios raises it — and the watermarks,
+forge slot thresholds, and history-expiry frequency take their standard
+values), and then `Config.Validate()` checks the resulting configuration
+before any services start: mode enums, listener port ranges (privileged/out-of-range/duplicate),
 load-mode `immutableDbPath` requirement, path-traversal guards, TLS cert/key
 pairing, mempool watermarks, block-producer credential paths, and
 duration/strategy strings that are otherwise only parsed at their point of use.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1796,11 +1796,15 @@ Configuration priority (highest to lowest):
 
 After all sources are merged (including CLI flags), `Config.Validate()`
 (`internal/config`) checks the resulting configuration before any services
-start: mode enums, port ranges (privileged/out-of-range), load-mode
+start: mode enums, port ranges (privileged/out-of-range/duplicate), load-mode
 `immutableDbPath` requirement, path-traversal guards, TLS cert/key pairing,
 mempool watermarks, block-producer credential paths, and duration/strategy
-strings that are otherwise only parsed at their point of use. All violations
-are reported together in a single startup error.
+strings that are otherwise only parsed at their point of use. The relay,
+private, and metrics listener ports are required for the serving modes but not
+for `load`, which starts none of them. All violations are reported together in
+a single startup error. Validation runs for every service-starting command;
+the informational `version` and `list` subcommands are exempt so they still
+run against an otherwise-invalid config.
 
 Key configuration areas:
 - Network selection (preview, preprod, mainnet)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1803,7 +1803,8 @@ duration/strategy strings that are otherwise only parsed at their point of use.
 Port checks apply only to the listeners a given invocation actually starts,
 derived from the *effective* run mode plus the storage mode: the serving modes
 start the relay, private, metrics, debug, and bark listeners (and, under `api`
-storage, the UTxORPC/Blockfrost/Mesh/Midnight listeners); the Mithril snapshot
+storage or a configured `dev` run mode — which forces `api` storage — the
+UTxORPC/Blockfrost/Mesh/Midnight listeners); the Mithril snapshot
 sync (`dingo sync --mithril` or `dingo mithril sync`) starts only the metrics
 and debug listeners; the read-only `mithril list`/`show` and `load` start none.
 A port configured for an inactive listener cannot bind, so it is neither
@@ -1814,7 +1815,11 @@ defaults to `serve`), `cmd/dingo` passes `Validate()` the effective run mode
 derived from the invoked command, so listener and ImmutableDB-source
 requirements match what the command actually does. All violations are reported
 together in a single startup error. The informational `version` and `list`
-subcommands are exempt so they still run against an otherwise-invalid config.
+subcommands — and cobra's built-in `help` and `completion` — are exempt so
+they still run against an otherwise-invalid config. The privileged-port
+check (below 1024) recognizes root, Windows, Linux `CAP_NET_BIND_SERVICE`,
+and a zeroed `net.ipv4.ip_unprivileged_port_start` (as container runtimes
+set) as allowed to bind.
 
 Key configuration areas:
 - Network selection (preview, preprod, mainnet)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1816,10 +1816,11 @@ derived from the invoked command, so listener and ImmutableDB-source
 requirements match what the command actually does. All violations are reported
 together in a single startup error. The informational `version` and `list`
 subcommands — and cobra's built-in `help` and `completion` — are exempt so
-they still run against an otherwise-invalid config. The privileged-port
-check (below 1024) recognizes root, Windows, Linux `CAP_NET_BIND_SERVICE`,
-and a zeroed `net.ipv4.ip_unprivileged_port_start` (as container runtimes
-set) as allowed to bind.
+they still run against an otherwise-invalid config. The privileged-port check compares each active port against what the
+process may actually bind: root, Windows, and Linux `CAP_NET_BIND_SERVICE`
+allow any port, and otherwise Linux uses the kernel's
+`net.ipv4.ip_unprivileged_port_start` cutoff (1024 by default; container
+runtimes commonly set 0).
 
 Key configuration areas:
 - Network selection (preview, preprod, mainnet)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1800,11 +1800,14 @@ start: mode enums, port ranges (privileged/out-of-range/duplicate), load-mode
 `immutableDbPath` requirement, path-traversal guards, TLS cert/key pairing,
 mempool watermarks, block-producer credential paths, and duration/strategy
 strings that are otherwise only parsed at their point of use. The relay,
-private, and metrics listener ports are required for the serving modes but not
-for `load`, which starts none of them. All violations are reported together in
-a single startup error. Validation runs for every service-starting command;
-the informational `version` and `list` subcommands are exempt so they still
-run against an otherwise-invalid config.
+private, and metrics listener ports are required only for the serving modes;
+the one-shot subcommands (`load`, `sync`, `mithril`) start none of them. Because
+those subcommands run a fixed operation regardless of the configured `runMode`
+(which defaults to `serve`), `cmd/dingo` passes `Validate()` an *effective* run
+mode derived from the invoked command, so listener and ImmutableDB-source
+requirements match what the command actually does. All violations are reported
+together in a single startup error. The informational `version` and `list`
+subcommands are exempt so they still run against an otherwise-invalid config.
 
 Key configuration areas:
 - Network selection (preview, preprod, mainnet)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1794,6 +1794,14 @@ Configuration priority (highest to lowest):
 3. YAML config file (`dingo.yaml`)
 4. Hardcoded defaults
 
+After all sources are merged (including CLI flags), `Config.Validate()`
+(`internal/config`) checks the resulting configuration before any services
+start: mode enums, port ranges (privileged/out-of-range), load-mode
+`immutableDbPath` requirement, path-traversal guards, TLS cert/key pairing,
+mempool watermarks, block-producer credential paths, and duration/strategy
+strings that are otherwise only parsed at their point of use. All violations
+are reported together in a single startup error.
+
 Key configuration areas:
 - Network selection (preview, preprod, mainnet)
 - Storage mode (`core` or `api`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1803,9 +1803,10 @@ duration/strategy strings that are otherwise only parsed at their point of use.
 Port checks apply only to the listeners a given invocation actually starts,
 derived from the *effective* run mode plus the storage mode: the serving modes
 start the relay, private, metrics, debug, and bark listeners (and, under `api`
-storage, the UTxORPC/Blockfrost/Mesh/Midnight listeners); the `sync` and
-`mithril` utilities start only the metrics and debug listeners; `load` starts
-none. A port configured for an inactive listener cannot bind, so it is neither
+storage, the UTxORPC/Blockfrost/Mesh/Midnight listeners); the Mithril snapshot
+sync (`dingo sync --mithril` or `dingo mithril sync`) starts only the metrics
+and debug listeners; the read-only `mithril list`/`show` and `load` start none.
+A port configured for an inactive listener cannot bind, so it is neither
 range-checked nor counted toward a collision; the relay, private, and metrics
 ports must additionally be set in the serving modes. Because the one-shot
 subcommands run a fixed operation regardless of the configured `runMode` (which

--- a/chainsync/strategy.go
+++ b/chainsync/strategy.go
@@ -16,6 +16,7 @@ package chainsync
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -62,24 +63,42 @@ func (h HeaderSyncStrategy) String() string {
 	}
 }
 
+// headerSyncStrategyNames maps every accepted strategy name (in
+// normalized form: lower-case, no surrounding whitespace) to its
+// strategy. It is the single source of truth for both
+// ParseHeaderSyncStrategy and AcceptedHeaderSyncStrategyNames, so the
+// two cannot drift apart.
+var headerSyncStrategyNames = map[string]HeaderSyncStrategy{
+	"":            HeaderSyncStrategyPrimary,
+	"primary":     HeaderSyncStrategyPrimary,
+	"parallel":    HeaderSyncStrategyParallel,
+	"round-robin": HeaderSyncStrategyRoundRobin,
+	"roundrobin":  HeaderSyncStrategyRoundRobin,
+	"round_robin": HeaderSyncStrategyRoundRobin,
+}
+
+// AcceptedHeaderSyncStrategyNames returns every strategy name accepted
+// by ParseHeaderSyncStrategy in normalized form, including the empty
+// string (which selects the default). Callers that must duplicate the
+// accepted set — internal/config's validation whitelist cannot import
+// this package — verify parity against this list.
+func AcceptedHeaderSyncStrategyNames() []string {
+	return slices.Sorted(maps.Keys(headerSyncStrategyNames))
+}
+
 // ParseHeaderSyncStrategy parses a header-sync strategy name. An empty string
 // returns the default (primary). Names are case-insensitive and ignore
 // surrounding whitespace; "round-robin", "roundrobin", and "round_robin" are
 // all accepted.
 func ParseHeaderSyncStrategy(s string) (HeaderSyncStrategy, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "primary":
-		return HeaderSyncStrategyPrimary, nil
-	case "parallel":
-		return HeaderSyncStrategyParallel, nil
-	case "round-robin", "roundrobin", "round_robin":
-		return HeaderSyncStrategyRoundRobin, nil
-	default:
+	strategy, ok := headerSyncStrategyNames[strings.ToLower(strings.TrimSpace(s))]
+	if !ok {
 		return HeaderSyncStrategyPrimary, fmt.Errorf(
 			"invalid header sync strategy %q (want primary, parallel, or round-robin)",
 			s,
 		)
 	}
+	return strategy, nil
 }
 
 // HeaderSyncStrategy returns the configured header-sync strategy.

--- a/cmd/dingo/command_mode_test.go
+++ b/cmd/dingo/command_mode_test.go
@@ -80,22 +80,22 @@ func TestEffectiveRunMode(t *testing.T) {
 			config.RunModeLoad,
 		},
 		{
-			"sync is a utility",
+			"sync uses the sync utility mode",
 			[]string{"sync"},
 			config.RunModeServe,
-			config.RunModeUtility,
+			config.RunModeSync,
 		},
 		{
-			"mithril list is a utility",
+			"mithril list uses the mithril utility mode",
 			[]string{"mithril", "list"},
 			config.RunModeServe,
-			config.RunModeUtility,
+			config.RunModeMithril,
 		},
 		{
-			"mithril sync is a utility",
+			"mithril sync uses the mithril utility mode",
 			[]string{"mithril", "sync"},
 			config.RunModeServe,
-			config.RunModeUtility,
+			config.RunModeMithril,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/dingo/command_mode_test.go
+++ b/cmd/dingo/command_mode_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/internal/config"
+)
+
+// newTestRootCmd wires the real subcommands under a root command,
+// mirroring main() so the command-classification helpers see the same
+// tree.
+func newTestRootCmd() *cobra.Command {
+	root := &cobra.Command{Use: "dingo"}
+	root.AddCommand(
+		serveCommand(),
+		loadCommand(),
+		listCommand(),
+		versionCommand(),
+		mithrilCommand(),
+		syncCommand(),
+	)
+	return root
+}
+
+func findCmd(t *testing.T, root *cobra.Command, path ...string) *cobra.Command {
+	t.Helper()
+	if len(path) == 0 {
+		return root
+	}
+	cmd, _, err := root.Find(path)
+	require.NoError(t, err)
+	require.Equal(t, path[len(path)-1], cmd.Name())
+	return cmd
+}
+
+func TestEffectiveRunMode(t *testing.T) {
+	root := newTestRootCmd()
+	tests := []struct {
+		name    string
+		path    []string
+		runMode config.RunMode
+		want    config.RunMode
+	}{
+		{"bare serve", nil, config.RunModeServe, config.RunModeServe},
+		{"bare load", nil, config.RunModeLoad, config.RunModeLoad},
+		{"bare dev", nil, config.RunModeDev, config.RunModeDev},
+		{"bare empty defaults to serve", nil, "", config.RunModeServe},
+		// Subcommands run a fixed operation regardless of configured runMode.
+		{
+			"serve subcommand ignores load config",
+			[]string{"serve"},
+			config.RunModeLoad,
+			config.RunModeServe,
+		},
+		{
+			"load subcommand",
+			[]string{"load"},
+			config.RunModeServe,
+			config.RunModeLoad,
+		},
+		{
+			"sync is a utility",
+			[]string{"sync"},
+			config.RunModeServe,
+			config.RunModeUtility,
+		},
+		{
+			"mithril list is a utility",
+			[]string{"mithril", "list"},
+			config.RunModeServe,
+			config.RunModeUtility,
+		},
+		{
+			"mithril sync is a utility",
+			[]string{"mithril", "sync"},
+			config.RunModeServe,
+			config.RunModeUtility,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := findCmd(t, root, tt.path...)
+			top := topLevelCommand(cmd)
+			got := effectiveRunMode(top, &config.Config{RunMode: tt.runMode})
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsInformationalCommand(t *testing.T) {
+	root := newTestRootCmd()
+	tests := []struct {
+		name string
+		path []string
+		want bool
+	}{
+		{"bare root", nil, false},
+		{"version", []string{"version"}, true},
+		{"list", []string{"list"}, true},
+		{"serve", []string{"serve"}, false},
+		{"sync", []string{"sync"}, false},
+		// Nested `mithril list` must not be mistaken for top-level `list`.
+		{"mithril list", []string{"mithril", "list"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := findCmd(t, root, tt.path...)
+			require.Equal(
+				t,
+				tt.want,
+				isInformationalCommand(topLevelCommand(cmd)),
+			)
+		})
+	}
+}

--- a/cmd/dingo/command_mode_test.go
+++ b/cmd/dingo/command_mode_test.go
@@ -62,6 +62,10 @@ func TestEffectiveRunMode(t *testing.T) {
 		{"bare load", nil, config.RunModeLoad, config.RunModeLoad},
 		{"bare dev", nil, config.RunModeDev, config.RunModeDev},
 		{"bare empty defaults to serve", nil, "", config.RunModeServe},
+		// An invalid configured runMode falls through to serve (matching
+		// rootCmd's dispatch default) so serving-listener checks still
+		// apply; the invalid mode is reported separately by Validate.
+		{"bare invalid falls back to serve", nil, "batch", config.RunModeServe},
 		// Subcommands run a fixed operation regardless of configured runMode.
 		{
 			"serve subcommand ignores load config",

--- a/cmd/dingo/command_mode_test.go
+++ b/cmd/dingo/command_mode_test.go
@@ -25,7 +25,9 @@ import (
 
 // newTestRootCmd wires the real subcommands under a root command,
 // mirroring main() so the command-classification helpers see the same
-// tree.
+// tree. The built-in help and completion commands, which cobra normally
+// adds during Execute, are initialized explicitly so the tree includes
+// them too.
 func newTestRootCmd() *cobra.Command {
 	root := &cobra.Command{Use: "dingo"}
 	root.AddCommand(
@@ -36,6 +38,8 @@ func newTestRootCmd() *cobra.Command {
 		mithrilCommand(),
 		syncCommand(),
 	)
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd()
 	return root
 }
 
@@ -131,6 +135,11 @@ func TestIsInformationalCommand(t *testing.T) {
 		{"bare root", nil, false},
 		{"version", []string{"version"}, true},
 		{"list", []string{"list"}, true},
+		// cobra runs the root PersistentPreRunE for its built-in help and
+		// completion commands, so they must be exempt from validation.
+		{"help", []string{"help"}, true},
+		{"completion", []string{"completion"}, true},
+		{"completion zsh", []string{"completion", "zsh"}, true},
 		{"serve", []string{"serve"}, false},
 		{"sync", []string{"sync"}, false},
 		// Nested `mithril list` must not be mistaken for top-level `list`.

--- a/cmd/dingo/command_mode_test.go
+++ b/cmd/dingo/command_mode_test.go
@@ -80,20 +80,34 @@ func TestEffectiveRunMode(t *testing.T) {
 			config.RunModeLoad,
 		},
 		{
-			"sync uses the sync utility mode",
+			"sync uses the sync operation mode",
 			[]string{"sync"},
 			config.RunModeServe,
 			config.RunModeSync,
 		},
+		// `mithril sync` starts the metrics/debug listeners, so it uses the
+		// sync operation mode; the read-only mithril subcommands do not.
 		{
-			"mithril list uses the mithril utility mode",
+			"mithril sync uses the sync operation mode",
+			[]string{"mithril", "sync"},
+			config.RunModeServe,
+			config.RunModeSync,
+		},
+		{
+			"mithril list is a read-only mithril utility",
 			[]string{"mithril", "list"},
 			config.RunModeServe,
 			config.RunModeMithril,
 		},
 		{
-			"mithril sync uses the mithril utility mode",
-			[]string{"mithril", "sync"},
+			"mithril show is a read-only mithril utility",
+			[]string{"mithril", "show"},
+			config.RunModeServe,
+			config.RunModeMithril,
+		},
+		{
+			"bare mithril is a read-only mithril utility",
+			[]string{"mithril"},
 			config.RunModeServe,
 			config.RunModeMithril,
 		},
@@ -101,8 +115,7 @@ func TestEffectiveRunMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := findCmd(t, root, tt.path...)
-			top := topLevelCommand(cmd)
-			got := effectiveRunMode(top, &config.Config{RunMode: tt.runMode})
+			got := effectiveRunMode(cmd, &config.Config{RunMode: tt.runMode})
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/cmd/dingo/config_parity_test.go
+++ b/cmd/dingo/config_parity_test.go
@@ -28,7 +28,12 @@ import (
 // it validates against (config.AcceptedChainsyncStrategies and
 // config.AcceptedMithrilBackends) are duplicated from those downstream
 // parsers. These parity tests live in cmd/dingo, which can import all
-// three, and guard against drift in both directions:
+// three. The canonical sets are not hand-maintained: they come from
+// the parser packages' exported accepted-value lists
+// (chainsync.AcceptedHeaderSyncStrategyNames, mithril.AcceptedBackends),
+// which the parsers themselves derive from, so a value added to a
+// parser fails these tests until config's duplicated list is updated.
+// The tests guard drift in both directions:
 //
 //   - forward: every value config accepts must be accepted by the real
 //     parser, so a config never passes Validate() only to fail at
@@ -40,19 +45,11 @@ import (
 // TestChainsyncStrategyWhitelistParity checks config.AcceptedChainsyncStrategies
 // against chainsync.ParseHeaderSyncStrategy.
 func TestChainsyncStrategyWhitelistParity(t *testing.T) {
-	// canonical is the contract of chainsync.ParseHeaderSyncStrategy;
-	// it mirrors that function's switch. The set-equality check below
-	// ties config's list to it, and the parse check ties it to the real
-	// parser, so a change to the parser's switch fails this test until
-	// both this list and config's list are updated.
-	canonical := []string{
-		"", "primary", "parallel", "round-robin", "roundrobin", "round_robin",
-	}
 	assertWhitelistParity(
 		t,
 		"chainsync.strategy",
 		config.AcceptedChainsyncStrategies,
-		canonical,
+		chainsync.AcceptedHeaderSyncStrategyNames(),
 		func(v string) error {
 			_, err := chainsync.ParseHeaderSyncStrategy(v)
 			return err
@@ -63,10 +60,9 @@ func TestChainsyncStrategyWhitelistParity(t *testing.T) {
 // TestMithrilBackendWhitelistParity checks config.AcceptedMithrilBackends
 // against resolveMithrilBackend.
 func TestMithrilBackendWhitelistParity(t *testing.T) {
-	// canonical is the contract of resolveMithrilBackend: the empty
-	// string (which selects v2) plus the two backend constants it
-	// switches on.
-	canonical := []string{"", mithril.BackendV1, mithril.BackendV2}
+	// resolveMithrilBackend accepts mithril.AcceptedBackends plus the
+	// empty string, which selects the default (v2).
+	canonical := append([]string{""}, mithril.AcceptedBackends()...)
 	assertWhitelistParity(
 		t,
 		"mithril.backend",
@@ -100,13 +96,14 @@ func assertWhitelistParity(
 		}
 	}
 	// Reverse: every value in the parser's contract must actually parse
-	// (anchoring the contract to the real parser) and config's set must
-	// match the contract exactly.
+	// (anchoring the exported accepted list to the real parser) and
+	// config's set must match the contract exactly.
 	for _, v := range canonical {
 		if err := accepts(v); err != nil {
 			t.Errorf(
 				"%s: canonical value %q is rejected by the parser; "+
-					"update the canonical set: %v",
+					"the parser package's exported accepted list "+
+					"disagrees with its parser: %v",
 				name, v, err,
 			)
 		}

--- a/cmd/dingo/config_parity_test.go
+++ b/cmd/dingo/config_parity_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/internal/config"
+)
+
+// TestChainsyncStrategyWhitelistParity guards against drift between the
+// chainsync.strategy values internal/config.Validate accepts and those
+// chainsync.ParseHeaderSyncStrategy actually accepts. internal/config
+// cannot import chainsync without pulling node subsystems into the
+// config package, so this parity check lives in cmd/dingo, which can
+// import both.
+func TestChainsyncStrategyWhitelistParity(t *testing.T) {
+	for _, strategy := range config.AcceptedChainsyncStrategies {
+		if _, err := chainsync.ParseHeaderSyncStrategy(strategy); err != nil {
+			t.Errorf(
+				"config accepts chainsync.strategy %q but "+
+					"ParseHeaderSyncStrategy rejects it: %v",
+				strategy, err,
+			)
+		}
+	}
+}
+
+// TestMithrilBackendWhitelistParity guards against drift between the
+// mithril.backend values internal/config.Validate accepts and those
+// resolveMithrilBackend actually accepts.
+func TestMithrilBackendWhitelistParity(t *testing.T) {
+	for _, backend := range config.AcceptedMithrilBackends {
+		if _, err := resolveMithrilBackend(backend); err != nil {
+			t.Errorf(
+				"config accepts mithril.backend %q but "+
+					"resolveMithrilBackend rejects it: %v",
+				backend, err,
+			)
+		}
+	}
+}

--- a/cmd/dingo/config_parity_test.go
+++ b/cmd/dingo/config_parity_test.go
@@ -15,41 +15,117 @@
 package main
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/mithril"
 )
 
-// TestChainsyncStrategyWhitelistParity guards against drift between the
-// chainsync.strategy values internal/config.Validate accepts and those
-// chainsync.ParseHeaderSyncStrategy actually accepts. internal/config
-// cannot import chainsync without pulling node subsystems into the
-// config package, so this parity check lives in cmd/dingo, which can
-// import both.
+// internal/config cannot import chainsync or mithril without pulling
+// node subsystems into the config package, so the accepted-value sets
+// it validates against (config.AcceptedChainsyncStrategies and
+// config.AcceptedMithrilBackends) are duplicated from those downstream
+// parsers. These parity tests live in cmd/dingo, which can import all
+// three, and guard against drift in both directions:
+//
+//   - forward: every value config accepts must be accepted by the real
+//     parser, so a config never passes Validate() only to fail at
+//     startup;
+//   - reverse: config's accepted set must match the parser's contract
+//     exactly, so a value added to the parser without updating config
+//     (which would spuriously reject a valid config) is caught too.
+
+// TestChainsyncStrategyWhitelistParity checks config.AcceptedChainsyncStrategies
+// against chainsync.ParseHeaderSyncStrategy.
 func TestChainsyncStrategyWhitelistParity(t *testing.T) {
-	for _, strategy := range config.AcceptedChainsyncStrategies {
-		if _, err := chainsync.ParseHeaderSyncStrategy(strategy); err != nil {
+	// canonical is the contract of chainsync.ParseHeaderSyncStrategy;
+	// it mirrors that function's switch. The set-equality check below
+	// ties config's list to it, and the parse check ties it to the real
+	// parser, so a change to the parser's switch fails this test until
+	// both this list and config's list are updated.
+	canonical := []string{
+		"", "primary", "parallel", "round-robin", "roundrobin", "round_robin",
+	}
+	assertWhitelistParity(
+		t,
+		"chainsync.strategy",
+		config.AcceptedChainsyncStrategies,
+		canonical,
+		func(v string) error {
+			_, err := chainsync.ParseHeaderSyncStrategy(v)
+			return err
+		},
+	)
+}
+
+// TestMithrilBackendWhitelistParity checks config.AcceptedMithrilBackends
+// against resolveMithrilBackend.
+func TestMithrilBackendWhitelistParity(t *testing.T) {
+	// canonical is the contract of resolveMithrilBackend: the empty
+	// string (which selects v2) plus the two backend constants it
+	// switches on.
+	canonical := []string{"", mithril.BackendV1, mithril.BackendV2}
+	assertWhitelistParity(
+		t,
+		"mithril.backend",
+		config.AcceptedMithrilBackends,
+		canonical,
+		func(v string) error {
+			_, err := resolveMithrilBackend(v)
+			return err
+		},
+	)
+}
+
+// assertWhitelistParity verifies that configList (the values
+// internal/config accepts) and canonical (the downstream parser's
+// contract) describe the same set, and that both are actually accepted
+// by the real parser via accepts.
+func assertWhitelistParity(
+	t *testing.T,
+	name string,
+	configList, canonical []string,
+	accepts func(string) error,
+) {
+	t.Helper()
+	// Forward: everything config accepts must parse.
+	for _, v := range configList {
+		if err := accepts(v); err != nil {
 			t.Errorf(
-				"config accepts chainsync.strategy %q but "+
-					"ParseHeaderSyncStrategy rejects it: %v",
-				strategy, err,
+				"%s: config accepts %q but the parser rejects it: %v",
+				name, v, err,
 			)
 		}
+	}
+	// Reverse: every value in the parser's contract must actually parse
+	// (anchoring the contract to the real parser) and config's set must
+	// match the contract exactly.
+	for _, v := range canonical {
+		if err := accepts(v); err != nil {
+			t.Errorf(
+				"%s: canonical value %q is rejected by the parser; "+
+					"update the canonical set: %v",
+				name, v, err,
+			)
+		}
+	}
+	if got, want := toStringSet(configList), toStringSet(canonical); !maps.Equal(
+		got,
+		want,
+	) {
+		t.Errorf(
+			"%s: config accepted set %v does not match parser contract %v",
+			name, configList, canonical,
+		)
 	}
 }
 
-// TestMithrilBackendWhitelistParity guards against drift between the
-// mithril.backend values internal/config.Validate accepts and those
-// resolveMithrilBackend actually accepts.
-func TestMithrilBackendWhitelistParity(t *testing.T) {
-	for _, backend := range config.AcceptedMithrilBackends {
-		if _, err := resolveMithrilBackend(backend); err != nil {
-			t.Errorf(
-				"config accepts mithril.backend %q but "+
-					"resolveMithrilBackend rejects it: %v",
-				backend, err,
-			)
-		}
+func toStringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		set[v] = struct{}{}
 	}
+	return set
 }

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -210,12 +210,15 @@ func topLevelCommand(cmd *cobra.Command) *cobra.Command {
 // requirements come from the command rather than cfg.RunMode.
 func effectiveRunMode(top *cobra.Command, cfg *config.Config) config.RunMode {
 	if top == nil {
-		// Bare root command: dispatches on the configured run mode,
-		// defaulting to serve.
-		if cfg.RunMode == "" {
-			return config.RunModeServe
+		// Bare root command dispatches on the configured run mode,
+		// falling through to serve for an empty or unrecognized mode
+		// (matching rootCmd's dispatch default). Serving-listener checks
+		// therefore still apply to an invalid runMode; the invalid mode
+		// itself is reported separately by Validate.
+		if cfg.RunMode.Valid() && cfg.RunMode != "" {
+			return cfg.RunMode
 		}
-		return cfg.RunMode
+		return config.RunModeServe
 	}
 	switch top.Name() {
 	case "serve":

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -450,6 +450,12 @@ DSN Override:
 			cfg.ImmutableDbPath = args[0]
 		}
 
+		// Every configuration source is merged at this point (defaults,
+		// YAML, environment, CLI flags, and the load positional
+		// argument), so defaults derived from other settings can now be
+		// filled in and the final configuration validated.
+		cfg.ApplyDefaults()
+
 		if err := cfg.Validate(effectiveRunMode(cmd, cfg)); err != nil {
 			return fmt.Errorf("invalid configuration: %w", err)
 		}

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -206,9 +206,10 @@ func topLevelCommand(cmd *cobra.Command) *cobra.Command {
 // effectiveRunMode reports the run mode a command invocation will
 // actually execute, which governs the config it requires. Only the bare
 // `dingo` process honors the configured runMode; each explicit
-// subcommand runs a fixed operation, so its listener/source
-// requirements come from the command rather than cfg.RunMode.
-func effectiveRunMode(top *cobra.Command, cfg *config.Config) config.RunMode {
+// subcommand runs a fixed operation, so its listener/source requirements
+// come from the command (cmd, the leaf being run) rather than cfg.RunMode.
+func effectiveRunMode(cmd *cobra.Command, cfg *config.Config) config.RunMode {
+	top := topLevelCommand(cmd)
 	if top == nil {
 		// Bare root command dispatches on the configured run mode,
 		// falling through to serve for an empty or unrecognized mode
@@ -226,10 +227,16 @@ func effectiveRunMode(top *cobra.Command, cfg *config.Config) config.RunMode {
 	case "load":
 		return config.RunModeLoad
 	case "sync":
+		// `dingo sync [--mithril]` runs the Mithril snapshot sync, which
+		// starts a metrics listener and an optional pprof debug listener.
 		return config.RunModeSync
 	case "mithril":
-		// mithril and its subcommands (sync, list, show): one-shot
-		// utilities that start no serving/API listeners.
+		// Only `mithril sync` binds the metrics/debug listeners; the
+		// read-only `mithril list` / `mithril show` (and bare `mithril`)
+		// query the aggregator and start nothing.
+		if cmd.Name() == "sync" {
+			return config.RunModeSync
+		}
 		return config.RunModeMithril
 	default:
 		// No other non-informational top-level command exists today;
@@ -434,7 +441,7 @@ DSN Override:
 		// version and list are informational and start no services, so
 		// they must still run even when the merged config is invalid.
 		if !isInformationalCommand(top) {
-			if err := cfg.Validate(effectiveRunMode(top, cfg)); err != nil {
+			if err := cfg.Validate(effectiveRunMode(cmd, cfg)); err != nil {
 				return fmt.Errorf("invalid configuration: %w", err)
 			}
 		}

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -361,8 +361,14 @@ DSN Override:
 			cfg.ImmutableDbPath = args[0]
 		}
 
-		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("invalid configuration: %w", err)
+		// version and list are informational and start no services, so
+		// they must still run even when the merged config is invalid.
+		switch cmd.Name() {
+		case "version", "list":
+		default:
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("invalid configuration: %w", err)
+			}
 		}
 
 		cmd.SetContext(config.WithContext(cmd.Context(), cfg))

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -225,10 +225,17 @@ func effectiveRunMode(top *cobra.Command, cfg *config.Config) config.RunMode {
 		return config.RunModeServe
 	case "load":
 		return config.RunModeLoad
+	case "sync":
+		return config.RunModeSync
+	case "mithril":
+		// mithril and its subcommands (sync, list, show): one-shot
+		// utilities that start no serving/API listeners.
+		return config.RunModeMithril
 	default:
-		// sync, mithril (and its subcommands): one-shot utilities that
-		// start no listeners and need no ImmutableDB source.
-		return config.RunModeUtility
+		// No other non-informational top-level command exists today;
+		// fall back to full serving validation so a future command's
+		// misconfiguration is caught rather than silently skipped.
+		return config.RunModeServe
 	}
 }
 
@@ -364,9 +371,9 @@ DSN Override:
 
 			// When no subcommand given, check RunMode from config.
 			// cfg.RunMode is a configured mode (validated by
-			// RunMode.Valid); the effective-only RunModeUtility never
-			// reaches here.
-			switch cfg.RunMode { //nolint:exhaustive // RunModeUtility is effective-only, never configured
+			// RunMode.Valid); the effective-only sync/mithril modes never
+			// reach here.
+			switch cfg.RunMode { //nolint:exhaustive // sync/mithril are effective-only, never configured
 			case config.RunModeLoad:
 				// Validate() has already enforced that ImmutableDbPath
 				// is set for load mode

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -189,6 +189,61 @@ func listAllPlugins() string {
 	return buf.String()
 }
 
+// topLevelCommand returns the top-level subcommand under root for cmd
+// (walking up past any nested subcommands such as `mithril list`), or
+// nil when cmd is the bare root command itself.
+func topLevelCommand(cmd *cobra.Command) *cobra.Command {
+	if !cmd.HasParent() {
+		return nil
+	}
+	top := cmd
+	for top.Parent().HasParent() {
+		top = top.Parent()
+	}
+	return top
+}
+
+// effectiveRunMode reports the run mode a command invocation will
+// actually execute, which governs the config it requires. Only the bare
+// `dingo` process honors the configured runMode; each explicit
+// subcommand runs a fixed operation, so its listener/source
+// requirements come from the command rather than cfg.RunMode.
+func effectiveRunMode(top *cobra.Command, cfg *config.Config) config.RunMode {
+	if top == nil {
+		// Bare root command: dispatches on the configured run mode,
+		// defaulting to serve.
+		if cfg.RunMode == "" {
+			return config.RunModeServe
+		}
+		return cfg.RunMode
+	}
+	switch top.Name() {
+	case "serve":
+		return config.RunModeServe
+	case "load":
+		return config.RunModeLoad
+	default:
+		// sync, mithril (and its subcommands): one-shot utilities that
+		// start no listeners and need no ImmutableDB source.
+		return config.RunModeUtility
+	}
+}
+
+// isInformationalCommand reports whether a top-level command only prints
+// static information (version, list) and therefore needs no valid
+// runtime configuration.
+func isInformationalCommand(top *cobra.Command) bool {
+	if top == nil {
+		return false
+	}
+	switch top.Name() {
+	case "version", "list":
+		return true
+	default:
+		return false
+	}
+}
+
 func listCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -304,8 +359,11 @@ DSN Override:
 				os.Exit(1)
 			}
 
-			// When no subcommand given, check RunMode from config
-			switch cfg.RunMode {
+			// When no subcommand given, check RunMode from config.
+			// cfg.RunMode is a configured mode (validated by
+			// RunMode.Valid); the effective-only RunModeUtility never
+			// reaches here.
+			switch cfg.RunMode { //nolint:exhaustive // RunModeUtility is effective-only, never configured
 			case config.RunModeLoad:
 				// Validate() has already enforced that ImmutableDbPath
 				// is set for load mode
@@ -353,20 +411,20 @@ DSN Override:
 			return fmt.Errorf("applying CLI flags: %w", err)
 		}
 
+		top := topLevelCommand(cmd)
+
 		// `dingo load <path>`: the positional argument is the
 		// highest-precedence source for ImmutableDbPath; merge it before
 		// validation so a config with runMode "load" and no
 		// immutableDbPath doesn't fail spuriously.
-		if cmd.Name() == "load" && len(args) > 0 {
+		if top != nil && top.Name() == "load" && len(args) > 0 {
 			cfg.ImmutableDbPath = args[0]
 		}
 
 		// version and list are informational and start no services, so
 		// they must still run even when the merged config is invalid.
-		switch cmd.Name() {
-		case "version", "list":
-		default:
-			if err := cfg.Validate(); err != nil {
+		if !isInformationalCommand(top) {
+			if err := cfg.Validate(effectiveRunMode(top, cfg)); err != nil {
 				return fmt.Errorf("invalid configuration: %w", err)
 			}
 		}

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -307,12 +307,8 @@ DSN Override:
 			// When no subcommand given, check RunMode from config
 			switch cfg.RunMode {
 			case config.RunModeLoad:
-				if cfg.ImmutableDbPath == "" {
-					slog.Error(
-						"immutableDbPath must be set when runMode is 'load'",
-					)
-					os.Exit(1)
-				}
+				// Validate() has already enforced that ImmutableDbPath
+				// is set for load mode
 				loadRun(cmd.Context(), []string{cfg.ImmutableDbPath}, cfg)
 			case config.RunModeServe, config.RunModeDev, config.RunModeLeios:
 				// serve, dev, and leios modes all run the server
@@ -355,6 +351,18 @@ DSN Override:
 
 		if err := config.ApplyFlags(cmd, cfg); err != nil {
 			return fmt.Errorf("applying CLI flags: %w", err)
+		}
+
+		// `dingo load <path>`: the positional argument is the
+		// highest-precedence source for ImmutableDbPath; merge it before
+		// validation so a config with runMode "load" and no
+		// immutableDbPath doesn't fail spuriously.
+		if cmd.Name() == "load" && len(args) > 0 {
+			cfg.ImmutableDbPath = args[0]
+		}
+
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("invalid configuration: %w", err)
 		}
 
 		cmd.SetContext(config.WithContext(cmd.Context(), cfg))

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -248,10 +248,11 @@ func effectiveRunMode(cmd *cobra.Command, cfg *config.Config) config.RunMode {
 
 // isInformationalCommand reports whether a top-level command only prints
 // static information — version, list, and cobra's built-in help and
-// completion commands — and therefore needs no valid runtime
-// configuration. (cobra runs the root PersistentPreRunE for help and
-// completion too, so without the exemption an invalid config would
-// block `dingo help` and shell-completion generation.)
+// completion commands — and therefore needs no runtime configuration at
+// all: config loading and validation are skipped for them. (cobra runs
+// the root PersistentPreRunE for help and completion too, so without
+// the exemption a missing or invalid config would block `dingo help`
+// and shell-completion generation.)
 func isInformationalCommand(top *cobra.Command) bool {
 	if top == nil {
 		return false
@@ -422,6 +423,16 @@ DSN Override:
 			os.Exit(0)
 		}
 
+		top := topLevelCommand(cmd)
+
+		// The informational commands (version, list, help, completion)
+		// print static output and read no configuration, so they skip
+		// config loading and validation entirely: they must work even
+		// when the config file is missing or invalid.
+		if isInformationalCommand(top) {
+			return nil
+		}
+
 		cfg, err := config.LoadConfig(configFile)
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
@@ -431,8 +442,6 @@ DSN Override:
 			return fmt.Errorf("applying CLI flags: %w", err)
 		}
 
-		top := topLevelCommand(cmd)
-
 		// `dingo load <path>`: the positional argument is the
 		// highest-precedence source for ImmutableDbPath; merge it before
 		// validation so a config with runMode "load" and no
@@ -441,12 +450,8 @@ DSN Override:
 			cfg.ImmutableDbPath = args[0]
 		}
 
-		// version and list are informational and start no services, so
-		// they must still run even when the merged config is invalid.
-		if !isInformationalCommand(top) {
-			if err := cfg.Validate(effectiveRunMode(cmd, cfg)); err != nil {
-				return fmt.Errorf("invalid configuration: %w", err)
-			}
+		if err := cfg.Validate(effectiveRunMode(cmd, cfg)); err != nil {
+			return fmt.Errorf("invalid configuration: %w", err)
 		}
 
 		cmd.SetContext(config.WithContext(cmd.Context(), cfg))

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -460,6 +460,14 @@ DSN Override:
 			return fmt.Errorf("invalid configuration: %w", err)
 		}
 
+		// Topology derives from the network and topology settings, so it
+		// is resolved only now that the merged configuration is final and
+		// valid — resolving it earlier could reject a YAML/env value a
+		// CLI flag has since repaired.
+		if _, err := config.LoadTopologyConfig(); err != nil {
+			return fmt.Errorf("loading topology: %w", err)
+		}
+
 		cmd.SetContext(config.WithContext(cmd.Context(), cfg))
 		return nil
 	}

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -247,14 +247,17 @@ func effectiveRunMode(cmd *cobra.Command, cfg *config.Config) config.RunMode {
 }
 
 // isInformationalCommand reports whether a top-level command only prints
-// static information (version, list) and therefore needs no valid
-// runtime configuration.
+// static information — version, list, and cobra's built-in help and
+// completion commands — and therefore needs no valid runtime
+// configuration. (cobra runs the root PersistentPreRunE for help and
+// completion too, so without the exemption an invalid config would
+// block `dingo help` and shell-completion generation.)
 func isInformationalCommand(top *cobra.Command) bool {
 	if top == nil {
 		return false
 	}
 	switch top.Name() {
-	case "version", "list":
+	case "version", "list", "help", "completion":
 		return true
 	default:
 		return false

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/blinklabs-io/dingo/internal/config"
@@ -67,21 +68,21 @@ func resolveAggregatorURL(
 }
 
 // resolveMithrilBackend normalizes the configured Mithril artifact
-// backend, applying the node default (v2) when unset.
+// backend, applying the node default (v2) when unset. The accepted set
+// comes from mithril.AcceptedBackends so a backend added there is
+// recognized here without a manual update.
 func resolveMithrilBackend(backend string) (string, error) {
-	switch backend {
-	case "":
+	if backend == "" {
 		return mithril.BackendV2, nil
-	case mithril.BackendV1, mithril.BackendV2:
-		return backend, nil
-	default:
-		return "", fmt.Errorf(
-			"unsupported Mithril backend %q (expected %q or %q)",
-			backend,
-			mithril.BackendV1,
-			mithril.BackendV2,
-		)
 	}
+	if slices.Contains(mithril.AcceptedBackends(), backend) {
+		return backend, nil
+	}
+	return "", fmt.Errorf(
+		"unsupported Mithril backend %q (expected one of %q)",
+		backend,
+		mithril.AcceptedBackends(),
+	)
 }
 
 func mithrilListCommand() *cobra.Command {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1009,12 +1009,11 @@ func LoadConfig(configFile string) (*Config, error) {
 	// NOTE: Do not set a default CardanoConfig here. The network flag
 	// can be overridden after LoadConfig returns (see main.go
 	// PersistentPreRunE). Each consumer resolves the cardano config
-	// path using cfg.Network at call time instead.
+	// path using cfg.Network at call time instead. Topology is likewise
+	// not resolved here: it derives from Network and Topology, both of
+	// which a CLI flag may still change, so cmd/dingo loads it once
+	// after the merged configuration has been defaulted and validated.
 
-	_, err = LoadTopologyConfig()
-	if err != nil {
-		return nil, fmt.Errorf("error loading topology: %+w", err)
-	}
 	return globalConfig, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,14 +101,20 @@ const (
 	RunModeLoad  RunMode = "load"  // Batch import from ImmutableDB
 	RunModeDev   RunMode = "dev"   // Development mode (isolated, no outbound)
 	RunModeLeios RunMode = "leios" // Full node with experimental Leios capabilities
-)
 
-// RunModeUtility is an effective run mode used only for validation, not
-// a configurable runMode (RunMode.Valid rejects it). The one-shot
-// utility subcommands (sync, mithril) start no listeners and need no
-// ImmutableDB source regardless of the configured runMode; cmd/dingo
-// passes this mode to Config.Validate for them.
-const RunModeUtility RunMode = "utility"
+	// RunModeSync and RunModeMithril are effective run modes used only for
+	// validation, not configurable runMode values (RunMode.Valid rejects
+	// them). The one-shot sync and mithril subcommands run a fixed
+	// operation regardless of the configured runMode; cmd/dingo passes the
+	// mode matching the invoked command to Config.Validate. They start
+	// neither the relay/private serving listeners nor the API listeners,
+	// but they do start a Prometheus metrics listener and an optional pprof
+	// debug listener, so they are kept distinct from load (which starts
+	// none) and from each other rather than collapsed into one catch-all
+	// utility mode.
+	RunModeSync    RunMode = "sync"
+	RunModeMithril RunMode = "mithril"
+)
 
 // StartEra controls experimental direct startup in a later ledger era.
 type StartEra string
@@ -123,8 +129,8 @@ func (m RunMode) Valid() bool {
 	switch m {
 	case RunModeServe, RunModeLoad, RunModeDev, RunModeLeios, "":
 		return true
-	case RunModeUtility:
-		// Effective-only mode used for validation; never a configurable runMode.
+	case RunModeSync, RunModeMithril:
+		// Effective-only modes used for validation; never configurable runModes.
 		return false
 	default:
 		return false
@@ -137,15 +143,17 @@ func (m RunMode) IsDevMode() bool {
 	return m == RunModeDev
 }
 
-// RequiresListeners reports whether an (effective) run mode starts the
-// relay, private, and metrics listeners. The serving modes (serve, dev,
-// leios, and the empty default) do; the load and utility one-shot modes
-// do not.
+// RequiresListeners reports whether an (effective) run mode runs as a
+// serving node, starting the relay and private (NtN/NtC) listeners. The
+// serving modes (serve, dev, leios, and the empty default) do; the load
+// and one-shot sync/mithril utilities do not. (The metrics and debug
+// listeners are not gated here: serving modes and the sync/mithril
+// utilities all start them, so Validate handles those ports separately.)
 func (m RunMode) RequiresListeners() bool {
 	switch m {
 	case RunModeServe, RunModeDev, RunModeLeios, "":
 		return true
-	case RunModeLoad, RunModeUtility:
+	case RunModeLoad, RunModeSync, RunModeMithril:
 		return false
 	default:
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1081,9 +1081,14 @@ func LoadConfig(configFile string) (*Config, error) {
 		globalConfig.HistoryExpiry.Frequency = time.Hour
 	}
 
-	// Validate network name to prevent path traversal (INT-03).
-	if err := ValidateNetworkName(globalConfig.Network); err != nil {
-		return nil, err
+	// Validate network name to prevent path traversal (INT-03). An
+	// empty network is allowed here so a networkMagic-only
+	// configuration can load; Validate() enforces that network or
+	// networkMagic is set.
+	if globalConfig.Network != "" {
+		if err := ValidateNetworkName(globalConfig.Network); err != nil {
+			return nil, err
+		}
 	}
 	applyMidnightNetworkDefaults(globalConfig)
 
@@ -1122,6 +1127,14 @@ func LoadTopologyConfigFor(cfg *Config) (*topology.TopologyConfig, error) {
 		return &topology.TopologyConfig{}, nil
 	}
 	if cfg.Topology == "" {
+		if cfg.Network == "" {
+			// A networkMagic-only configuration has no network name to
+			// resolve an embedded topology or bootstrap peers from;
+			// peers must come from an explicit topology file. Return an
+			// empty topology (as dev mode does) rather than failing
+			// config load.
+			return &topology.TopologyConfig{}, nil
+		}
 		embeddedTopologyPath := path.Join(cfg.Network, "topology.json")
 		tc, err := topology.NewTopologyConfigFromFS(
 			cardano.EmbeddedConfigFS,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -992,104 +992,18 @@ func LoadConfig(configFile string) (*Config, error) {
 		)
 	}
 
-	// Validate and default RunMode
-	if !globalConfig.RunMode.Valid() {
-		return nil, fmt.Errorf(
-			"invalid runMode: %q (must be 'serve', 'load', 'dev', or 'leios')",
-			globalConfig.RunMode,
-		)
-	}
-	if globalConfig.RunMode == "" {
-		globalConfig.RunMode = RunModeServe
-	}
-	if !globalConfig.StartEra.Valid() {
-		return nil, fmt.Errorf(
-			"invalid startEra: %q (must be empty or 'dijkstra')",
-			globalConfig.StartEra,
-		)
-	}
-
-	// Default unset MempoolCapacity based on RunMode. CLI/env/YAML have
-	// already been merged at this point; an explicit non-zero setting
-	// from any of those layers wins per existing config priority.
-	if globalConfig.MempoolCapacity == 0 {
-		if globalConfig.RunMode == RunModeLeios {
-			globalConfig.MempoolCapacity = DefaultMempoolCapacityLeios
-		} else {
-			globalConfig.MempoolCapacity = DefaultMempoolCapacityPraos
-		}
-	}
-
-	// Validate block producer configuration
-	if globalConfig.BlockProducer {
-		var missing []string
-		if globalConfig.ShelleyVRFKey == "" {
-			missing = append(missing, "shelleyVrfKey")
-		}
-		if globalConfig.ShelleyKESKey == "" {
-			missing = append(missing, "shelleyKesKey")
-		}
-		if globalConfig.ShelleyOperationalCertificate == "" {
-			missing = append(missing, "shelleyOperationalCertificate")
-		}
-		if len(missing) > 0 {
-			return nil, fmt.Errorf(
-				"blockProducer enabled but missing required key paths: %v",
-				missing,
-			)
-		}
-	}
-
-	// Default unset watermarks. In Go, unset float64 fields are 0,
-	// which is indistinguishable from an explicit 0. We default 0 to
-	// the standard value; the subsequent validation rejects any value
-	// that ends up <= 0 after defaulting.
-	if globalConfig.EvictionWatermark == 0 {
-		globalConfig.EvictionWatermark = DefaultEvictionWatermark
-	}
-	if globalConfig.RejectionWatermark == 0 {
-		globalConfig.RejectionWatermark = DefaultRejectionWatermark
-	}
-	if globalConfig.EvictionWatermark <= 0 ||
-		globalConfig.EvictionWatermark >= 1.0 {
-		return nil, fmt.Errorf(
-			"invalid evictionWatermark: %f (must be in range (0, 1))",
-			globalConfig.EvictionWatermark,
-		)
-	}
-	if globalConfig.RejectionWatermark <= 0 ||
-		globalConfig.RejectionWatermark > 1.0 {
-		return nil, fmt.Errorf(
-			"invalid rejectionWatermark: %f (must be in range (0, 1])",
-			globalConfig.RejectionWatermark,
-		)
-	}
-	if globalConfig.EvictionWatermark >= globalConfig.RejectionWatermark {
-		return nil, fmt.Errorf(
-			"evictionWatermark (%f) must be less than rejectionWatermark (%f)",
-			globalConfig.EvictionWatermark,
-			globalConfig.RejectionWatermark,
-		)
-	}
-	if globalConfig.ForgeSyncToleranceSlots == 0 {
-		globalConfig.ForgeSyncToleranceSlots = DefaultForgeSyncToleranceSlots
-	}
-	if globalConfig.ForgeStaleGapThresholdSlots == 0 {
-		globalConfig.ForgeStaleGapThresholdSlots = DefaultForgeStaleGapThresholdSlots
-	}
-	if globalConfig.HistoryExpiry.Frequency <= 0 {
-		globalConfig.HistoryExpiry.Frequency = time.Hour
-	}
-
-	// Validate network name to prevent path traversal (INT-03). An
-	// empty network is allowed here so a networkMagic-only
-	// configuration can load; Validate() enforces that network or
-	// networkMagic is set.
-	if globalConfig.Network != "" {
-		if err := ValidateNetworkName(globalConfig.Network); err != nil {
-			return nil, err
-		}
-	}
+	// LoadConfig only parses and merges configuration sources; it makes
+	// no semantic judgments about the merged values. CLI flags are a
+	// higher-precedence source merged afterwards by ApplyFlags, so any
+	// defaulting or validation here would act on values a flag may
+	// still override — defaults derived from the final configuration
+	// are applied by ApplyDefaults, and semantic checks run in
+	// Validate, both called after ApplyFlags.
+	//
+	// The Midnight network defaults applied here are the exception:
+	// they let a config loaded without CLI flags resolve its per-network
+	// values, and ApplyFlags compensates for a network change by
+	// clearing the previous network's defaults and reapplying.
 	applyMidnightNetworkDefaults(globalConfig)
 
 	// NOTE: Do not set a default CardanoConfig here. The network flag
@@ -1102,6 +1016,46 @@ func LoadConfig(configFile string) (*Config, error) {
 		return nil, fmt.Errorf("error loading topology: %+w", err)
 	}
 	return globalConfig, nil
+}
+
+// ApplyDefaults fills in unset values whose defaults depend on other
+// settings in the fully merged configuration — most notably
+// MempoolCapacity, whose default is chosen by RunMode. It must run
+// after every configuration source has been merged (defaults, YAML,
+// environment, and CLI flags via ApplyFlags): defaulting earlier would
+// derive values from settings a higher-precedence source is still
+// allowed to change. Call it before Validate; Validate rejects any
+// value that is still invalid after defaulting.
+func (c *Config) ApplyDefaults() {
+	// An empty runMode selects the standard serving mode
+	if c.RunMode == "" {
+		c.RunMode = RunModeServe
+	}
+	// Unset MempoolCapacity defaults based on RunMode
+	if c.MempoolCapacity == 0 {
+		if c.RunMode == RunModeLeios {
+			c.MempoolCapacity = DefaultMempoolCapacityLeios
+		} else {
+			c.MempoolCapacity = DefaultMempoolCapacityPraos
+		}
+	}
+	// Unset float64 fields are 0, which is indistinguishable from an
+	// explicit 0; both select the standard watermark
+	if c.EvictionWatermark == 0 {
+		c.EvictionWatermark = DefaultEvictionWatermark
+	}
+	if c.RejectionWatermark == 0 {
+		c.RejectionWatermark = DefaultRejectionWatermark
+	}
+	if c.ForgeSyncToleranceSlots == 0 {
+		c.ForgeSyncToleranceSlots = DefaultForgeSyncToleranceSlots
+	}
+	if c.ForgeStaleGapThresholdSlots == 0 {
+		c.ForgeStaleGapThresholdSlots = DefaultForgeStaleGapThresholdSlots
+	}
+	if c.HistoryExpiry.Frequency <= 0 {
+		c.HistoryExpiry.Frequency = time.Hour
+	}
 }
 
 func GetConfig() *Config {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,13 @@ const (
 	RunModeLeios RunMode = "leios" // Full node with experimental Leios capabilities
 )
 
+// RunModeUtility is an effective run mode used only for validation, not
+// a configurable runMode (RunMode.Valid rejects it). The one-shot
+// utility subcommands (sync, mithril) start no listeners and need no
+// ImmutableDB source regardless of the configured runMode; cmd/dingo
+// passes this mode to Config.Validate for them.
+const RunModeUtility RunMode = "utility"
+
 // StartEra controls experimental direct startup in a later ledger era.
 type StartEra string
 
@@ -116,6 +123,9 @@ func (m RunMode) Valid() bool {
 	switch m {
 	case RunModeServe, RunModeLoad, RunModeDev, RunModeLeios, "":
 		return true
+	case RunModeUtility:
+		// Effective-only mode used for validation; never a configurable runMode.
+		return false
 	default:
 		return false
 	}
@@ -125,6 +135,21 @@ func (m RunMode) Valid() bool {
 // (forge blocks, disable outbound, skip topology)
 func (m RunMode) IsDevMode() bool {
 	return m == RunModeDev
+}
+
+// RequiresListeners reports whether an (effective) run mode starts the
+// relay, private, and metrics listeners. The serving modes (serve, dev,
+// leios, and the empty default) do; the load and utility one-shot modes
+// do not.
+func (m RunMode) RequiresListeners() bool {
+	switch m {
+	case RunModeServe, RunModeDev, RunModeLeios, "":
+		return true
+	case RunModeLoad, RunModeUtility:
+		return false
+	default:
+		return false
+	}
 }
 
 func (e StartEra) Valid() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1053,7 +1053,10 @@ func (c *Config) ApplyDefaults() {
 	if c.ForgeStaleGapThresholdSlots == 0 {
 		c.ForgeStaleGapThresholdSlots = DefaultForgeStaleGapThresholdSlots
 	}
-	if c.HistoryExpiry.Frequency <= 0 {
+	// Only an unset (zero) frequency takes the default; an explicitly
+	// negative value is preserved so Validate can reject it instead of
+	// the node silently starting the expiry worker on the default cadence
+	if c.HistoryExpiry.Frequency == 0 {
 		c.HistoryExpiry.Frequency = time.Hour
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,14 +104,16 @@ const (
 
 	// RunModeSync and RunModeMithril are effective run modes used only for
 	// validation, not configurable runMode values (RunMode.Valid rejects
-	// them). The one-shot sync and mithril subcommands run a fixed
-	// operation regardless of the configured runMode; cmd/dingo passes the
-	// mode matching the invoked command to Config.Validate. They start
-	// neither the relay/private serving listeners nor the API listeners,
-	// but they do start a Prometheus metrics listener and an optional pprof
-	// debug listener, so they are kept distinct from load (which starts
-	// none) and from each other rather than collapsed into one catch-all
-	// utility mode.
+	// them); cmd/dingo passes the one matching the invoked command to
+	// Config.Validate. Neither starts the relay/private serving listeners
+	// or the API listeners. They differ in their auxiliary-listener
+	// surface: RunModeSync is the Mithril snapshot sync operation (via
+	// `dingo sync --mithril` or `dingo mithril sync`), which starts a
+	// Prometheus metrics listener and an optional pprof debug listener;
+	// RunModeMithril is the read-only Mithril query subcommands (`list`,
+	// `show`, and bare `mithril`), which start no listeners at all.
+	// Keeping them distinct lets Validate check exactly the ports each
+	// invocation binds.
 	RunModeSync    RunMode = "sync"
 	RunModeMithril RunMode = "mithril"
 )
@@ -147,8 +149,9 @@ func (m RunMode) IsDevMode() bool {
 // serving node, starting the relay and private (NtN/NtC) listeners. The
 // serving modes (serve, dev, leios, and the empty default) do; the load
 // and one-shot sync/mithril utilities do not. (The metrics and debug
-// listeners are not gated here: serving modes and the sync/mithril
-// utilities all start them, so Validate handles those ports separately.)
+// listeners are gated separately by Validate: serving modes and the
+// Mithril sync operation start them, the read-only Mithril subcommands do
+// not.)
 func (m RunMode) RequiresListeners() bool {
 	switch m {
 	case RunModeServe, RunModeDev, RunModeLeios, "":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -951,6 +951,13 @@ func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 			name:    "underscore name",
 			network: "test_net",
 		},
+		{
+			// An empty network must load: Validate() enforces that
+			// network or networkMagic is set, so a networkMagic-only
+			// configuration is legal at the LoadConfig layer.
+			name:    "empty network for magic-only configs",
+			network: "",
+		},
 	}
 
 	for _, tt := range validTests {
@@ -1015,10 +1022,6 @@ func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 			network: ".hidden",
 		},
 		{
-			name:    "empty string",
-			network: "",
-		},
-		{
 			name:    "hyphen prefix",
 			network: "-bad",
 		},
@@ -1049,6 +1052,34 @@ func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// TestLoadConfig_NetworkMagicOnly is a regression test for the
+// networkMagic-without-network contract: a YAML config with an empty
+// network and a custom networkMagic must survive both LoadConfig and
+// validation, since Validate() accepts either network or networkMagic.
+func TestLoadConfig_NetworkMagicOnly(t *testing.T) {
+	resetGlobalConfig()
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-dingo.yaml")
+	yamlContent := "network: \"\"\nnetworkMagic: 42\n"
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Network != "" {
+		t.Errorf("Network = %q, want empty", cfg.Network)
+	}
+	if cfg.NetworkMagic != 42 {
+		t.Errorf("NetworkMagic = %d, want 42", cfg.NetworkMagic)
+	}
+	if err := cfg.validate(cfg.RunMode, minUnprivilegedPort); err != nil {
+		t.Errorf("validation rejected magic-only config: %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -606,6 +606,11 @@ func TestLoadConfig_EmbeddedDefaults(t *testing.T) {
 		t.Errorf("expected RelayPort to be 3001, got %d", cfg.RelayPort)
 	}
 
+	// Topology is resolved separately from LoadConfig, once the merged
+	// configuration is final (see cmd/dingo)
+	if _, err := LoadTopologyConfig(); err != nil {
+		t.Fatalf("failed to load topology: %v", err)
+	}
 	topologyConfig := GetTopologyConfig()
 	if topologyConfig.PeerSnapshotFile != "peer-snapshot.json" {
 		t.Fatalf(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,8 +28,8 @@ import (
 func resetGlobalConfig() {
 	midnightYAMLFields = nil
 	globalConfig = &Config{
-		// MempoolCapacity left as the zero sentinel; LoadConfig fills
-		// it in from RunMode after CLI/env/YAML processing.
+		// MempoolCapacity left as the zero sentinel; ApplyDefaults
+		// fills it in from RunMode after all sources are merged.
 		MempoolCapacity:             0,
 		EvictionWatermark:           0.90,
 		RejectionWatermark:          0.95,
@@ -225,6 +225,9 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
+	// LoadConfig only parses and merges; derived defaults (runMode,
+	// mempool capacity, watermarks) are filled in afterwards
+	cfg.ApplyDefaults()
 
 	// Expected is the updated default values from globalConfig
 	expected := &Config{
@@ -688,7 +691,12 @@ func TestLoadConfig_UnsupportedNetworkWithUserConfig(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_WatermarkValidation(t *testing.T) {
+// TestWatermarkDefaultingAndValidation covers the post-merge pipeline
+// for the mempool watermarks: ApplyDefaults fills unset (zero) values
+// and validate rejects out-of-range ones. LoadConfig itself no longer
+// judges watermark values, so a CLI flag can still override a bad YAML
+// value before validation.
+func TestWatermarkDefaultingAndValidation(t *testing.T) {
 	tests := []struct {
 		name       string
 		eviction   float64
@@ -784,7 +792,12 @@ func TestLoadConfig_WatermarkValidation(t *testing.T) {
 			globalConfig.RejectionWatermark = tt.rejection
 			globalConfig.RunMode = RunModeDev
 
-			_, err := LoadConfig("")
+			cfg, err := LoadConfig("")
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			cfg.ApplyDefaults()
+			err = cfg.validate(cfg.RunMode, minUnprivilegedPort)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf(
@@ -926,7 +939,7 @@ database:
 	}
 }
 
-func TestLoadConfig_NetworkNameValidation(t *testing.T) {
+func TestNetworkNameValidation(t *testing.T) {
 	validTests := []struct {
 		name    string
 		network string
@@ -1037,7 +1050,14 @@ func TestLoadConfig_NetworkNameValidation(t *testing.T) {
 			globalConfig.Network = tt.network
 			globalConfig.RunMode = RunModeDev
 
-			_, err := LoadConfig("")
+			// LoadConfig only parses and merges; a CLI flag may still
+			// replace the network name, so the traversal guard runs in
+			// validate on the final value.
+			cfg, err := LoadConfig("")
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			err = cfg.validate(cfg.RunMode, minUnprivilegedPort)
 			if err == nil {
 				t.Fatal(
 					"expected error for invalid network name, got nil",
@@ -1472,6 +1492,7 @@ func TestLoad_MempoolCapacityMode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("LoadConfig: %v", err)
 			}
+			cfg.ApplyDefaults()
 			if cfg.MempoolCapacity != tc.expected {
 				t.Errorf(
 					"MempoolCapacity: got %d, want %d",

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -66,7 +66,15 @@ var flagSpecs = []flagSpec{
 	boolFlag("TracingStdout", "tracing-stdout", "export traces to stdout instead of OTLP (requires --tracing; for debugging)"),
 
 	// Networking
-	validatedStringFlag("Network", "network", "n", "Cardano network name (e.g. preview, preprod, mainnet)", ValidateNetworkName),
+	// An explicitly empty --network is allowed: Validate() enforces
+	// that network or networkMagic is set, so a magic-only invocation
+	// can clear a configured network name.
+	validatedStringFlag("Network", "network", "n", "Cardano network name (e.g. preview, preprod, mainnet)", func(v string) error {
+		if v == "" {
+			return nil
+		}
+		return ValidateNetworkName(v)
+	}),
 	uint32Flag("NetworkMagic", "network-magic", "network magic override"),
 	uintFlag("RelayPort", "port", "relay/NtN port"),
 	stringFlag("PrivateBindAddr", "private-bind-addr", "", "private bind address"),

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -209,9 +209,10 @@ func ApplyFlags(cmd *cobra.Command, cfg *Config) error {
 	}
 	applyMidnightNetworkDefaults(cfg)
 	globalConfig = cfg
-	if _, err := LoadTopologyConfig(); err != nil {
-		return fmt.Errorf("loading topology after flags: %w", err)
-	}
+	// Topology is not resolved here: Network and Topology are final at
+	// this point, but the merged configuration has not been validated
+	// yet, so cmd/dingo loads topology once after ApplyDefaults and
+	// Validate.
 	return nil
 }
 

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -368,7 +368,11 @@ func TestApplyFlags_NetworkMagicRejectsOverflow(t *testing.T) {
 	}
 }
 
-func TestApplyFlags_ReloadsTopologyForNetworkFlag(t *testing.T) {
+// TestTopologyResolvesFromNetworkFlag pins topology resolution to the
+// final merged configuration: LoadTopologyConfig runs only after
+// ApplyFlags (see cmd/dingo), so a --network override determines which
+// network's topology is loaded.
+func TestTopologyResolvesFromNetworkFlag(t *testing.T) {
 	resetGlobalConfig()
 
 	cfg, err := LoadConfig("")
@@ -392,9 +396,12 @@ func TestApplyFlags_ReloadsTopologyForNetworkFlag(t *testing.T) {
 	if cfg.Network != "preprod" {
 		t.Fatalf("expected network preprod, got %q", cfg.Network)
 	}
+	if _, err := LoadTopologyConfig(); err != nil {
+		t.Fatalf("failed to load topology: %v", err)
+	}
 	topologyConfig := GetTopologyConfig()
 	if topologyConfig.PeerSnapshot == nil {
-		t.Fatal("expected topology reload to load preprod peer snapshot")
+		t.Fatal("expected topology load to use the preprod peer snapshot")
 	}
 	if topologyConfig.PeerSnapshot.NetworkMagic != 1 {
 		t.Fatalf(
@@ -405,9 +412,10 @@ func TestApplyFlags_ReloadsTopologyForNetworkFlag(t *testing.T) {
 }
 
 // loadConfigThroughPipeline runs the full cmd/dingo configuration
-// pipeline — LoadConfig, ApplyFlags, ApplyDefaults — on the given YAML
-// and CLI arguments and returns the merged config alongside the
-// validation result, mirroring PersistentPreRunE in cmd/dingo.
+// pipeline — LoadConfig, ApplyFlags, ApplyDefaults, validate, and
+// topology resolution — on the given YAML and CLI arguments and returns
+// the merged config alongside the validation/topology result, mirroring
+// PersistentPreRunE in cmd/dingo.
 func loadConfigThroughPipeline(
 	t *testing.T,
 	yaml string,
@@ -433,7 +441,13 @@ func loadConfigThroughPipeline(
 		t.Fatalf("ApplyFlags: %v", err)
 	}
 	cfg.ApplyDefaults()
-	return cfg, cfg.validate(cfg.RunMode, minUnprivilegedPort)
+	if err := cfg.validate(cfg.RunMode, minUnprivilegedPort); err != nil {
+		return cfg, err
+	}
+	if _, err := LoadTopologyConfig(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
 }
 
 // TestPipeline_FlagOverridesInvalidYAMLRunMode is a precedence
@@ -504,6 +518,61 @@ func TestPipeline_MempoolCapacityDefaultsFromFlagRunMode(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// TestPipeline_NetworkFlagRepairsInvalidYAMLNetwork is a precedence
+// regression test for topology ordering: a traversal-shaped YAML
+// network must not abort config loading or topology resolution before
+// a --network flag replaces it. Without the override the same value
+// must still be rejected — by Validate, not LoadConfig.
+func TestPipeline_NetworkFlagRepairsInvalidYAMLNetwork(t *testing.T) {
+	yaml := "network: \"../bad\"\n"
+
+	cfg, err := loadConfigThroughPipeline(
+		t, yaml, []string{"--network=preview"},
+	)
+	if err != nil {
+		t.Fatalf("expected valid config after flag override, got: %v", err)
+	}
+	if cfg.Network != "preview" {
+		t.Errorf("Network = %q, want %q", cfg.Network, "preview")
+	}
+
+	_, err = loadConfigThroughPipeline(t, yaml, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid network name") {
+		t.Fatalf("expected invalid network name error, got: %v", err)
+	}
+}
+
+// TestPipeline_TopologyFlagRepairsMissingYAMLTopology pins the same
+// ordering for the topology file itself: a missing YAML topology path
+// must not abort before a --topology flag replaces it, and must still
+// fail topology resolution without the override.
+func TestPipeline_TopologyFlagRepairsMissingYAMLTopology(t *testing.T) {
+	yaml := "topology: \"/nonexistent/topology.json\"\n"
+	validTopology := filepath.Join(t.TempDir(), "topology.json")
+	if err := os.WriteFile(
+		validTopology,
+		[]byte(`{"localRoots": [], "publicRoots": []}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("failed to write topology file: %v", err)
+	}
+
+	cfg, err := loadConfigThroughPipeline(
+		t, yaml, []string{"--topology=" + validTopology},
+	)
+	if err != nil {
+		t.Fatalf("expected valid config after flag override, got: %v", err)
+	}
+	if cfg.Topology != validTopology {
+		t.Errorf("Topology = %q, want %q", cfg.Topology, validTopology)
+	}
+
+	_, err = loadConfigThroughPipeline(t, yaml, nil)
+	if err == nil || !strings.Contains(err.Error(), "topology") {
+		t.Fatalf("expected topology load error, got: %v", err)
 	}
 }
 

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -399,6 +400,133 @@ func TestApplyFlags_ReloadsTopologyForNetworkFlag(t *testing.T) {
 			"expected preprod peer snapshot network magic 1, got %d",
 			topologyConfig.PeerSnapshot.NetworkMagic,
 		)
+	}
+}
+
+// loadConfigThroughPipeline runs the full cmd/dingo configuration
+// pipeline — LoadConfig, ApplyFlags, ApplyDefaults — on the given YAML
+// and CLI arguments and returns the merged config alongside the
+// validation result, mirroring PersistentPreRunE in cmd/dingo.
+func loadConfigThroughPipeline(
+	t *testing.T,
+	yaml string,
+	args []string,
+) (*Config, error) {
+	t.Helper()
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	if err := os.WriteFile(configFile, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := ApplyFlags(cmd, cfg); err != nil {
+		t.Fatalf("ApplyFlags: %v", err)
+	}
+	cfg.ApplyDefaults()
+	return cfg, cfg.validate(cfg.RunMode, minUnprivilegedPort)
+}
+
+// TestPipeline_FlagOverridesInvalidYAMLRunMode is a precedence
+// regression test: a higher-precedence CLI flag must be able to replace
+// an invalid YAML runMode, so LoadConfig cannot reject the value before
+// flags are merged.
+func TestPipeline_FlagOverridesInvalidYAMLRunMode(t *testing.T) {
+	cfg, err := loadConfigThroughPipeline(
+		t,
+		"runMode: \"bogus\"\n",
+		[]string{"--run-mode=serve"},
+	)
+	if err != nil {
+		t.Fatalf("expected valid config after flag override, got: %v", err)
+	}
+	if cfg.RunMode != RunModeServe {
+		t.Errorf("RunMode = %q, want %q", cfg.RunMode, RunModeServe)
+	}
+}
+
+// TestPipeline_InvalidYAMLRunModeRejectedWithoutOverride pins the other
+// side of the precedence fix: with no flag override, the invalid YAML
+// value must still be rejected — by Validate on the merged config, not
+// by LoadConfig.
+func TestPipeline_InvalidYAMLRunModeRejectedWithoutOverride(t *testing.T) {
+	_, err := loadConfigThroughPipeline(t, "runMode: \"bogus\"\n", nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid runMode") {
+		t.Fatalf("expected invalid runMode error, got: %v", err)
+	}
+}
+
+// TestPipeline_MempoolCapacityDefaultsFromFlagRunMode is a defaulting
+// regression test: the run-mode-derived MempoolCapacity default must be
+// chosen from the final merged mode, including one set only by a CLI
+// flag.
+func TestPipeline_MempoolCapacityDefaultsFromFlagRunMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected int64
+	}{
+		{
+			name:     "leios via flag",
+			args:     []string{"--run-mode=leios"},
+			expected: DefaultMempoolCapacityLeios,
+		},
+		{
+			name:     "serve via flag",
+			args:     []string{"--run-mode=serve"},
+			expected: DefaultMempoolCapacityPraos,
+		},
+		{
+			name:     "no mode configured anywhere",
+			args:     nil,
+			expected: DefaultMempoolCapacityPraos,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := loadConfigThroughPipeline(t, "", tc.args)
+			if err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+			if cfg.MempoolCapacity != tc.expected {
+				t.Errorf(
+					"MempoolCapacity = %d, want %d",
+					cfg.MempoolCapacity, tc.expected,
+				)
+			}
+		})
+	}
+}
+
+// TestPipeline_AggregatesErrorsAcrossSettings pins error aggregation on
+// the merged config: LoadConfig no longer fails on the first bad value,
+// so every problem must surface together in the single Validate pass.
+func TestPipeline_AggregatesErrorsAcrossSettings(t *testing.T) {
+	yaml := "runMode: \"bogus\"\n" +
+		"evictionWatermark: 2.0\n" +
+		"blockProducer: true\n" +
+		"chainsync:\n  strategy: \"fastest\"\n"
+	_, err := loadConfigThroughPipeline(t, yaml, nil)
+	if err == nil {
+		t.Fatal("expected validation errors, got nil")
+	}
+	for _, want := range []string{
+		"invalid runMode",
+		"invalid evictionWatermark",
+		"blockProducer enabled but missing required key paths",
+		"invalid chainsync.strategy",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should contain %q, got: %v", want, err)
+		}
 	}
 }
 

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -500,6 +501,61 @@ func TestPipeline_MempoolCapacityDefaultsFromFlagRunMode(t *testing.T) {
 				t.Errorf(
 					"MempoolCapacity = %d, want %d",
 					cfg.MempoolCapacity, tc.expected,
+				)
+			}
+		})
+	}
+}
+
+// TestPipeline_NegativeHistoryExpiryFrequencyRejected pins the
+// explicit-negative-frequency contract for every configuration source:
+// ApplyDefaults only fills in an unset (zero) historyExpiry.frequency,
+// so a configured negative value must survive defaulting and fail
+// validation instead of silently starting the expiry worker on the
+// one-hour default cadence.
+func TestPipeline_NegativeHistoryExpiryFrequencyRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		env  map[string]string
+		args []string
+	}{
+		{
+			name: "yaml",
+			yaml: "historyExpiry:\n  enabled: true\n  frequency: -1s\n",
+		},
+		{
+			name: "environment",
+			env: map[string]string{
+				"DINGO_HISTORY_EXPIRY_ENABLED":   "true",
+				"DINGO_HISTORY_EXPIRY_FREQUENCY": "-1s",
+			},
+		},
+		{
+			name: "flag",
+			args: []string{
+				"--history-expiry-enabled=true",
+				"--history-expiry-frequency=-1s",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			cfg, err := loadConfigThroughPipeline(t, tc.yaml, tc.args)
+			if err == nil ||
+				!strings.Contains(err.Error(), "invalid historyExpiry.frequency") {
+				t.Fatalf(
+					"expected invalid historyExpiry.frequency error, got: %v",
+					err,
+				)
+			}
+			if cfg.HistoryExpiry.Frequency != -time.Second {
+				t.Errorf(
+					"Frequency = %s, want -1s preserved through defaulting",
+					cfg.HistoryExpiry.Frequency,
 				)
 			}
 		})

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -17,6 +17,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -182,25 +183,37 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 	apiListeners := serving &&
 		(effectiveMode == RunModeDev || c.RunMode.IsDevMode() ||
 			c.StorageMode == storageModeAPI)
+	// Each entry's host is the bind address the listener actually uses
+	// at runtime: bindAddr for most, privateBindAddr for the private
+	// listener, midnight.host for Midnight, and all interfaces for bark
+	// (which is started without a host).
 	ports := []struct {
 		setting  string
+		host     string
 		port     uint
 		active   bool
 		required bool
 	}{
-		{"port (relay/NtN)", c.RelayPort, serving, serving},
-		{"privatePort", c.PrivatePort, serving, serving},
-		{"metricsPort", c.MetricsPort, auxListeners, serving},
-		{"debugPort", c.DebugPort, auxListeners, false},
-		{"barkPort", c.BarkPort, serving, false},
-		{"utxorpcPort", c.UtxorpcPort, apiListeners, false},
-		{"blockfrostPort", c.BlockfrostPort, apiListeners, false},
-		{"meshPort", c.MeshPort, apiListeners, false},
-		{"midnight.port", c.Midnight.Port, apiListeners, false},
+		{"port (relay/NtN)", c.BindAddr, c.RelayPort, serving, serving},
+		{"privatePort", c.PrivateBindAddr, c.PrivatePort, serving, serving},
+		{"metricsPort", c.BindAddr, c.MetricsPort, auxListeners, serving},
+		{"debugPort", c.BindAddr, c.DebugPort, auxListeners, false},
+		{"barkPort", "", c.BarkPort, serving, false},
+		{"utxorpcPort", c.BindAddr, c.UtxorpcPort, apiListeners, false},
+		{"blockfrostPort", c.BindAddr, c.BlockfrostPort, apiListeners, false},
+		{"meshPort", c.BindAddr, c.MeshPort, apiListeners, false},
+		{"midnight.port", c.Midnight.Host, c.Midnight.Port, apiListeners, false},
 	}
-	// Two active listeners sharing a port only fails at bind time; catch it
-	// here. Zero ports are disabled or OS-assigned, so they don't clash.
-	seenPorts := make(map[uint]string, len(ports))
+	// Two active listeners contending for a port only fails at bind
+	// time; catch it here. Zero ports are disabled or OS-assigned, so
+	// they don't clash, and a port is only a conflict when the bind
+	// addresses overlap: listeners on distinct specific addresses (e.g.
+	// 127.0.0.1 and 127.0.0.2) may legally share a port.
+	type boundListener struct {
+		setting string
+		host    string
+	}
+	seenPorts := make(map[uint][]boundListener, len(ports))
 	for _, p := range ports {
 		if !p.active {
 			continue
@@ -211,14 +224,21 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		if p.port == 0 {
 			continue
 		}
-		if other, dup := seenPorts[p.port]; dup {
+		for _, other := range seenPorts[p.port] {
+			if !bindAddrsOverlap(other.host, p.host) {
+				continue
+			}
 			errs = append(errs, fmt.Errorf(
-				"port %d is assigned to both %s and %s",
-				p.port, other, p.setting,
+				"port %d is assigned to both %s and %s "+
+					"on overlapping bind addresses",
+				p.port, other.setting, p.setting,
 			))
-			continue
+			break
 		}
-		seenPorts[p.port] = p.setting
+		seenPorts[p.port] = append(
+			seenPorts[p.port],
+			boundListener{setting: p.setting, host: p.host},
+		)
 	}
 
 	// Path traversal guard on the Cardano node config path, matching
@@ -243,13 +263,18 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 			c.MempoolCapacity,
 		))
 	}
-	if c.EvictionWatermark <= 0 || c.EvictionWatermark >= 1.0 {
+	// NaN is checked explicitly: every ordered comparison with NaN is
+	// false, so a NaN watermark would slip through the range checks
+	// alone and reach mempool threshold arithmetic.
+	if math.IsNaN(c.EvictionWatermark) ||
+		c.EvictionWatermark <= 0 || c.EvictionWatermark >= 1.0 {
 		errs = append(errs, fmt.Errorf(
 			"invalid evictionWatermark: %f (must be in range (0, 1))",
 			c.EvictionWatermark,
 		))
 	}
-	if c.RejectionWatermark <= 0 || c.RejectionWatermark > 1.0 {
+	if math.IsNaN(c.RejectionWatermark) ||
+		c.RejectionWatermark <= 0 || c.RejectionWatermark > 1.0 {
 		errs = append(errs, fmt.Errorf(
 			"invalid rejectionWatermark: %f (must be in range (0, 1])",
 			c.RejectionWatermark,
@@ -390,16 +415,41 @@ func validatePort(
 	return nil
 }
 
+// bindAddrsOverlap reports whether two listener bind addresses can
+// contend for the same port: equal addresses always do, and a wildcard
+// address overlaps every other address. Hostname aliases for the same
+// interface (e.g. "localhost" vs "127.0.0.1") are not resolved; such
+// conflicts surface at bind time instead.
+func bindAddrsOverlap(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return isWildcardAddr(a) || isWildcardAddr(b)
+}
+
+// isWildcardAddr reports whether a bind address selects all interfaces.
+func isWildcardAddr(addr string) bool {
+	switch addr {
+	case "", "0.0.0.0", "::", "[::]":
+		return true
+	default:
+		return false
+	}
+}
+
 // validatePathNoTraversal rejects paths containing a ".." component.
 // Values can arrive via YAML or environment, where a traversal-shaped
 // path is more likely an injection than an intent; absolute paths
-// express any legitimate target without "..".
+// express any legitimate target without "..". The original path is
+// inspected component-by-component, deliberately without cleaning it
+// first: cleaning would erase an inner ".." (e.g.
+// "configs/../secret.json"), and the contract is that no ".."
+// component appears at all.
 func validatePathNoTraversal(setting, path string) error {
 	if path == "" {
 		return nil
 	}
-	cleaned := filepath.Clean(path)
-	for part := range strings.SplitSeq(filepath.ToSlash(cleaned), "/") {
+	for part := range strings.SplitSeq(filepath.ToSlash(path), "/") {
 		if part == ".." {
 			return fmt.Errorf(
 				"invalid %s %q: path must not contain \"..\" "+

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"time"
 )
@@ -28,6 +30,20 @@ const (
 	maxPort             = 65535
 )
 
+// AcceptedChainsyncStrategies mirrors the values accepted by
+// chainsync.ParseHeaderSyncStrategy. internal/config cannot import
+// chainsync without pulling node subsystems into the config package, so
+// the two lists are kept in sync by a parity test in cmd/dingo (which
+// can import both).
+var AcceptedChainsyncStrategies = []string{
+	"", "primary", "parallel", "round-robin", "roundrobin", "round_robin",
+}
+
+// AcceptedMithrilBackends mirrors the values accepted by cmd/dingo's
+// resolveMithrilBackend (empty selects v2). Kept in sync by the same
+// parity test in cmd/dingo as AcceptedChainsyncStrategies.
+var AcceptedMithrilBackends = []string{"", "v1", "v2"}
+
 // Validate checks the fully merged configuration (defaults, YAML,
 // environment, CLI flags) for invalid values and nonsensical
 // combinations. Every problem found is returned, joined into a single
@@ -35,7 +51,11 @@ const (
 // from cmd/dingo after CLI flags have been applied, before any
 // services start; LoadConfig alone does not see CLI flag values.
 func (c *Config) Validate() error {
-	return c.validate(os.Geteuid() == 0)
+	// The privileged-port restriction is Unix-specific. os.Geteuid
+	// returns -1 on Windows, which would otherwise misclassify every
+	// Windows process as unprivileged and reject sub-1024 ports there.
+	privileged := runtime.GOOS == "windows" || os.Geteuid() == 0
+	return c.validate(privileged)
 }
 
 // validate is the deterministic core of Validate. privileged reports
@@ -75,15 +95,18 @@ func (c *Config) validate(privileged bool) error {
 		))
 	}
 
-	// Ports
+	// Ports. The relay, private, and metrics listeners are required for
+	// the serving modes but not started by "load", so they may be unset
+	// (0) in a load-only config.
+	listenersRequired := c.RunMode != RunModeLoad
 	ports := []struct {
 		setting  string
 		port     uint
 		required bool
 	}{
-		{"port (relay/NtN)", c.RelayPort, true},
-		{"privatePort", c.PrivatePort, true},
-		{"metricsPort", c.MetricsPort, true},
+		{"port (relay/NtN)", c.RelayPort, listenersRequired},
+		{"privatePort", c.PrivatePort, listenersRequired},
+		{"metricsPort", c.MetricsPort, listenersRequired},
 		{"debugPort", c.DebugPort, false},
 		{"utxorpcPort", c.UtxorpcPort, false},
 		{"blockfrostPort", c.BlockfrostPort, false},
@@ -91,10 +114,24 @@ func (c *Config) validate(privileged bool) error {
 		{"barkPort", c.BarkPort, false},
 		{"midnight.port", c.Midnight.Port, false},
 	}
+	// Two services sharing a port only fails at bind time; catch it
+	// here. Zero ports are disabled or OS-assigned, so they don't clash.
+	seenPorts := make(map[uint]string, len(ports))
 	for _, p := range ports {
 		if err := validatePort(p.setting, p.port, p.required, privileged); err != nil {
 			errs = append(errs, err)
 		}
+		if p.port == 0 {
+			continue
+		}
+		if other, dup := seenPorts[p.port]; dup {
+			errs = append(errs, fmt.Errorf(
+				"port %d is assigned to both %s and %s",
+				p.port, other, p.setting,
+			))
+			continue
+		}
+		seenPorts[p.port] = p.setting
 	}
 
 	// Path traversal guard on the Cardano node config path, matching
@@ -200,12 +237,11 @@ func (c *Config) validate(privileged bool) error {
 		}
 	}
 
-	// Chainsync; accepted strategy names must match
-	// chainsync.ParseHeaderSyncStrategy (not imported here to keep
-	// internal/config free of node subsystem dependencies)
-	switch strings.ToLower(strings.TrimSpace(c.Chainsync.Strategy)) {
-	case "", "primary", "parallel", "round-robin", "roundrobin", "round_robin":
-	default:
+	// Chainsync; accepted strategy names come from
+	// AcceptedChainsyncStrategies, kept in sync with
+	// chainsync.ParseHeaderSyncStrategy by a parity test in cmd/dingo.
+	strategy := strings.ToLower(strings.TrimSpace(c.Chainsync.Strategy))
+	if !slices.Contains(AcceptedChainsyncStrategies, strategy) {
 		errs = append(errs, fmt.Errorf(
 			"invalid chainsync.strategy %q (want primary, parallel, or round-robin)",
 			c.Chainsync.Strategy,
@@ -218,11 +254,11 @@ func (c *Config) validate(privileged bool) error {
 		))
 	}
 
-	// Mithril backend; accepted values must match
-	// cmd/dingo resolveMithrilBackend (empty selects v2)
-	switch c.Mithril.Backend {
-	case "", "v1", "v2":
-	default:
+	// Mithril backend; accepted values come from
+	// AcceptedMithrilBackends, kept in sync with cmd/dingo's
+	// resolveMithrilBackend by a parity test in cmd/dingo (empty
+	// selects v2).
+	if !slices.Contains(AcceptedMithrilBackends, c.Mithril.Backend) {
 		errs = append(errs, fmt.Errorf(
 			"invalid mithril.backend %q: must be \"v1\" or \"v2\"",
 			c.Mithril.Backend,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -352,6 +352,17 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		}
 	}
 
+	// History expiry cadence. ApplyDefaults only fills in an unset
+	// (zero) frequency, so a non-positive value here was configured
+	// explicitly — reject it rather than let the expiry worker start
+	// on a cadence the operator did not choose.
+	if c.HistoryExpiry.Frequency <= 0 {
+		errs = append(errs, fmt.Errorf(
+			"invalid historyExpiry.frequency: %s (must be positive)",
+			c.HistoryExpiry.Frequency,
+		))
+	}
+
 	// Chainsync; accepted strategy names come from
 	// AcceptedChainsyncStrategies, kept in sync with
 	// chainsync.ParseHeaderSyncStrategy by a parity test in cmd/dingo.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -32,18 +32,20 @@ const (
 	maxPort             = 65535
 )
 
-// AcceptedChainsyncStrategies mirrors the values accepted by
-// chainsync.ParseHeaderSyncStrategy. internal/config cannot import
-// chainsync without pulling node subsystems into the config package, so
-// the two lists are kept in sync by a parity test in cmd/dingo (which
-// can import both).
+// AcceptedChainsyncStrategies mirrors
+// chainsync.AcceptedHeaderSyncStrategyNames (the accepted-name list
+// chainsync.ParseHeaderSyncStrategy is derived from). internal/config
+// cannot import chainsync without pulling node subsystems into the
+// config package, so the two lists are kept in sync by a parity test in
+// cmd/dingo (which can import both).
 var AcceptedChainsyncStrategies = []string{
 	"", "primary", "parallel", "round-robin", "roundrobin", "round_robin",
 }
 
-// AcceptedMithrilBackends mirrors the values accepted by cmd/dingo's
-// resolveMithrilBackend (empty selects v2). Kept in sync by the same
-// parity test in cmd/dingo as AcceptedChainsyncStrategies.
+// AcceptedMithrilBackends mirrors mithril.AcceptedBackends plus the
+// empty string (which selects the default v2), matching cmd/dingo's
+// resolveMithrilBackend. Kept in sync by the same parity test in
+// cmd/dingo as AcceptedChainsyncStrategies.
 var AcceptedMithrilBackends = []string{"", "v1", "v2"}
 
 // Validate checks the fully merged configuration (defaults, YAML,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	minUnprivilegedPort = 1024
+	maxPort             = 65535
+)
+
+// Validate checks the fully merged configuration (defaults, YAML,
+// environment, CLI flags) for invalid values and nonsensical
+// combinations. Every problem found is returned, joined into a single
+// error, so the operator can fix them all in one pass. It is called
+// from cmd/dingo after CLI flags have been applied, before any
+// services start; LoadConfig alone does not see CLI flag values.
+func (c *Config) Validate() error {
+	return c.validate(os.Geteuid() == 0)
+}
+
+// validate is the deterministic core of Validate. privileged reports
+// whether the process may bind ports below 1024 (i.e. running as
+// root); it is a parameter so tests do not depend on the effective
+// UID of the test runner.
+func (c *Config) validate(privileged bool) error {
+	var errs []error
+
+	// Mode enums
+	if !c.RunMode.Valid() {
+		errs = append(errs, fmt.Errorf(
+			"invalid runMode: %q (must be 'serve', 'load', 'dev', or 'leios')",
+			c.RunMode,
+		))
+	}
+	if !c.StartEra.Valid() {
+		errs = append(errs, fmt.Errorf(
+			"invalid startEra: %q (must be empty or 'dijkstra')",
+			c.StartEra,
+		))
+	}
+	switch c.StorageMode {
+	case "", storageModeCore, storageModeAPI:
+	default:
+		errs = append(errs, fmt.Errorf(
+			"invalid storageMode %q: must be %q or %q",
+			c.StorageMode, storageModeCore, storageModeAPI,
+		))
+	}
+
+	// Load mode requires a source ImmutableDB
+	if c.RunMode == RunModeLoad && c.ImmutableDbPath == "" {
+		errs = append(errs, errors.New(
+			"runMode \"load\" requires immutableDbPath to be set "+
+				"(config, DINGO_IMMUTABLE_DB_PATH, or --immutable-db-path)",
+		))
+	}
+
+	// Ports
+	ports := []struct {
+		setting  string
+		port     uint
+		required bool
+	}{
+		{"port (relay/NtN)", c.RelayPort, true},
+		{"privatePort", c.PrivatePort, true},
+		{"metricsPort", c.MetricsPort, true},
+		{"debugPort", c.DebugPort, false},
+		{"utxorpcPort", c.UtxorpcPort, false},
+		{"blockfrostPort", c.BlockfrostPort, false},
+		{"meshPort", c.MeshPort, false},
+		{"barkPort", c.BarkPort, false},
+		{"midnight.port", c.Midnight.Port, false},
+	}
+	for _, p := range ports {
+		if err := validatePort(p.setting, p.port, p.required, privileged); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// Path traversal guard on the Cardano node config path, matching
+	// the network-name guard (INT-03). The path may arrive via env or
+	// YAML, so a ".." component could escape an expected config root.
+	if err := validatePathNoTraversal("cardanoConfig", c.CardanoConfig); err != nil {
+		errs = append(errs, err)
+	}
+
+	// TLS cert and key only work as a pair
+	if (c.TlsCertFilePath == "") != (c.TlsKeyFilePath == "") {
+		errs = append(errs, errors.New(
+			"tlsCertFilePath and tlsKeyFilePath must both be set to enable TLS "+
+				"(only one is set)",
+		))
+	}
+
+	// Mempool
+	if c.MempoolCapacity < 0 {
+		errs = append(errs, fmt.Errorf(
+			"invalid mempoolCapacity: %d (must not be negative)",
+			c.MempoolCapacity,
+		))
+	}
+	if c.EvictionWatermark <= 0 || c.EvictionWatermark >= 1.0 {
+		errs = append(errs, fmt.Errorf(
+			"invalid evictionWatermark: %f (must be in range (0, 1))",
+			c.EvictionWatermark,
+		))
+	}
+	if c.RejectionWatermark <= 0 || c.RejectionWatermark > 1.0 {
+		errs = append(errs, fmt.Errorf(
+			"invalid rejectionWatermark: %f (must be in range (0, 1])",
+			c.RejectionWatermark,
+		))
+	}
+	if c.EvictionWatermark >= c.RejectionWatermark {
+		errs = append(errs, fmt.Errorf(
+			"evictionWatermark (%f) must be less than rejectionWatermark (%f)",
+			c.EvictionWatermark,
+			c.RejectionWatermark,
+		))
+	}
+
+	// Block production needs all three credential paths
+	if c.BlockProducer {
+		var missing []string
+		if c.ShelleyVRFKey == "" {
+			missing = append(missing, "shelleyVrfKey")
+		}
+		if c.ShelleyKESKey == "" {
+			missing = append(missing, "shelleyKesKey")
+		}
+		if c.ShelleyOperationalCertificate == "" {
+			missing = append(missing, "shelleyOperationalCertificate")
+		}
+		if len(missing) > 0 {
+			errs = append(errs, fmt.Errorf(
+				"blockProducer enabled but missing required key paths: %v",
+				missing,
+			))
+		}
+	}
+
+	// Network identity
+	if c.Network == "" {
+		if c.NetworkMagic == 0 {
+			errs = append(errs, errors.New(
+				"network or networkMagic must be set",
+			))
+		}
+	} else if err := ValidateNetworkName(c.Network); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Duration strings, parsed downstream at use; fail at startup
+	// instead with the setting named
+	for _, d := range []struct {
+		setting      string
+		value        string
+		mustPositive bool
+	}{
+		{"shutdownTimeout", c.ShutdownTimeout, true},
+		{"ledgerCatchupTimeout", c.LedgerCatchupTimeout, true},
+		{"chainsync.stallTimeout", c.Chainsync.StallTimeout, true},
+		// Negative disables Mithril download idle detection
+		{"mithril.downloadIdleTimeout", c.Mithril.DownloadIdleTimeout, false},
+	} {
+		if d.value == "" {
+			continue
+		}
+		parsed, err := time.ParseDuration(d.value)
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"invalid %s %q: %w", d.setting, d.value, err,
+			))
+			continue
+		}
+		if d.mustPositive && parsed <= 0 {
+			errs = append(errs, fmt.Errorf(
+				"invalid %s %q: must be positive", d.setting, d.value,
+			))
+		}
+	}
+
+	// Chainsync; accepted strategy names must match
+	// chainsync.ParseHeaderSyncStrategy (not imported here to keep
+	// internal/config free of node subsystem dependencies)
+	switch strings.ToLower(strings.TrimSpace(c.Chainsync.Strategy)) {
+	case "", "primary", "parallel", "round-robin", "roundrobin", "round_robin":
+	default:
+		errs = append(errs, fmt.Errorf(
+			"invalid chainsync.strategy %q (want primary, parallel, or round-robin)",
+			c.Chainsync.Strategy,
+		))
+	}
+	if c.Chainsync.MaxClients < 0 {
+		errs = append(errs, fmt.Errorf(
+			"invalid chainsync.maxClients: %d (must not be negative)",
+			c.Chainsync.MaxClients,
+		))
+	}
+
+	// Mithril backend; accepted values must match
+	// cmd/dingo resolveMithrilBackend (empty selects v2)
+	switch c.Mithril.Backend {
+	case "", "v1", "v2":
+	default:
+		errs = append(errs, fmt.Errorf(
+			"invalid mithril.backend %q: must be \"v1\" or \"v2\"",
+			c.Mithril.Backend,
+		))
+	}
+
+	return errors.Join(errs...)
+}
+
+// validatePort checks a configured TCP port. Ports are uints, so
+// values above 65535 are representable but unbindable; ports below
+// 1024 need elevated privileges; and 0 either disables the component
+// (required=false) or is nonsense for a mandatory listener
+// (required=true, binding port 0 picks a random port).
+func validatePort(setting string, port uint, required, privileged bool) error {
+	if port == 0 {
+		if required {
+			return fmt.Errorf("%s must be set (port 0 is not valid)", setting)
+		}
+		return nil
+	}
+	if port > maxPort {
+		return fmt.Errorf(
+			"invalid %s: %d (must be at most %d)",
+			setting, port, maxPort,
+		)
+	}
+	if port < minUnprivilegedPort && !privileged {
+		return fmt.Errorf(
+			"invalid %s: %d is a privileged port and the process is not "+
+				"running as root (use %d-%d)",
+			setting, port, minUnprivilegedPort, maxPort,
+		)
+	}
+	return nil
+}
+
+// validatePathNoTraversal rejects paths containing a ".." component.
+// Values can arrive via YAML or environment, where a traversal-shaped
+// path is more likely an injection than an intent; absolute paths
+// express any legitimate target without "..".
+func validatePathNoTraversal(setting, path string) error {
+	if path == "" {
+		return nil
+	}
+	cleaned := filepath.Clean(path)
+	for part := range strings.SplitSeq(filepath.ToSlash(cleaned), "/") {
+		if part == ".." {
+			return fmt.Errorf(
+				"invalid %s %q: path must not contain \"..\" "+
+					"(use an absolute path instead)",
+				setting, path,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -101,30 +101,48 @@ func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
 		))
 	}
 
-	// Ports. The relay, private, and metrics listeners are required only
-	// for the serving modes; the load and one-shot utility (sync,
-	// mithril) invocations start none of them, so those ports may be
-	// unset (0).
-	listenersRequired := effectiveMode.RequiresListeners()
+	// Ports. Only listeners this invocation actually starts are
+	// range-checked, privilege-checked, and checked against each other for
+	// collisions: a port configured for a listener that stays inactive
+	// cannot bind and so cannot conflict. The active set is derived from
+	// the effective run mode plus the storage mode, mirroring the gating in
+	// (*dingo.Node).Start and cmd/dingo's node.Run/mithril paths:
+	//   - relay, private: serving modes only (required there);
+	//   - metrics, debug: serving modes and the sync/mithril utilities;
+	//   - bark: serving modes only (not storage-gated);
+	//   - UTxORPC, Blockfrost, Mesh, Midnight: serving modes under API
+	//     storage (dev mode forces API storage on at startup).
+	// The load and one-shot utility invocations start no relay/private or
+	// API listeners, so those ports may be unset (0) for them.
+	serving := effectiveMode.RequiresListeners()
+	auxListeners := serving ||
+		effectiveMode == RunModeSync ||
+		effectiveMode == RunModeMithril
+	apiListeners := serving &&
+		(effectiveMode == RunModeDev || c.StorageMode == storageModeAPI)
 	ports := []struct {
 		setting  string
 		port     uint
+		active   bool
 		required bool
 	}{
-		{"port (relay/NtN)", c.RelayPort, listenersRequired},
-		{"privatePort", c.PrivatePort, listenersRequired},
-		{"metricsPort", c.MetricsPort, listenersRequired},
-		{"debugPort", c.DebugPort, false},
-		{"utxorpcPort", c.UtxorpcPort, false},
-		{"blockfrostPort", c.BlockfrostPort, false},
-		{"meshPort", c.MeshPort, false},
-		{"barkPort", c.BarkPort, false},
-		{"midnight.port", c.Midnight.Port, false},
+		{"port (relay/NtN)", c.RelayPort, serving, serving},
+		{"privatePort", c.PrivatePort, serving, serving},
+		{"metricsPort", c.MetricsPort, auxListeners, serving},
+		{"debugPort", c.DebugPort, auxListeners, false},
+		{"barkPort", c.BarkPort, serving, false},
+		{"utxorpcPort", c.UtxorpcPort, apiListeners, false},
+		{"blockfrostPort", c.BlockfrostPort, apiListeners, false},
+		{"meshPort", c.MeshPort, apiListeners, false},
+		{"midnight.port", c.Midnight.Port, apiListeners, false},
 	}
-	// Two services sharing a port only fails at bind time; catch it
+	// Two active listeners sharing a port only fails at bind time; catch it
 	// here. Zero ports are disabled or OS-assigned, so they don't clash.
 	seenPorts := make(map[uint]string, len(ports))
 	for _, p := range ports {
+		if !p.active {
+			continue
+		}
 		if err := validatePort(p.setting, p.port, p.required, privileged); err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -108,16 +108,15 @@ func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
 	// the effective run mode plus the storage mode, mirroring the gating in
 	// (*dingo.Node).Start and cmd/dingo's node.Run/mithril paths:
 	//   - relay, private: serving modes only (required there);
-	//   - metrics, debug: serving modes and the sync/mithril utilities;
+	//   - metrics, debug: serving modes and the Mithril sync operation
+	//     (RunModeSync); the read-only Mithril subcommands start neither;
 	//   - bark: serving modes only (not storage-gated);
 	//   - UTxORPC, Blockfrost, Mesh, Midnight: serving modes under API
 	//     storage (dev mode forces API storage on at startup).
-	// The load and one-shot utility invocations start no relay/private or
-	// API listeners, so those ports may be unset (0) for them.
+	// The load and read-only Mithril invocations start no listeners, so
+	// their ports may be unset (0) and are not checked.
 	serving := effectiveMode.RequiresListeners()
-	auxListeners := serving ||
-		effectiveMode == RunModeSync ||
-		effectiveMode == RunModeMithril
+	auxListeners := serving || effectiveMode == RunModeSync
 	apiListeners := serving &&
 		(effectiveMode == RunModeDev || c.StorageMode == storageModeAPI)
 	ports := []struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -50,19 +50,25 @@ var AcceptedMithrilBackends = []string{"", "v1", "v2"}
 // error, so the operator can fix them all in one pass. It is called
 // from cmd/dingo after CLI flags have been applied, before any
 // services start; LoadConfig alone does not see CLI flag values.
-func (c *Config) Validate() error {
+//
+// effectiveMode is the run mode the invocation will actually execute.
+// For the bare `dingo` process it is c.RunMode, but the one-shot
+// subcommands (load, sync, mithril) run a fixed operation regardless of
+// the configured runMode, so cmd/dingo passes the mode reflecting what
+// the command does. It governs which listeners and sources are required.
+func (c *Config) Validate(effectiveMode RunMode) error {
 	// The privileged-port restriction is Unix-specific. os.Geteuid
 	// returns -1 on Windows, which would otherwise misclassify every
 	// Windows process as unprivileged and reject sub-1024 ports there.
 	privileged := runtime.GOOS == "windows" || os.Geteuid() == 0
-	return c.validate(privileged)
+	return c.validate(effectiveMode, privileged)
 }
 
 // validate is the deterministic core of Validate. privileged reports
 // whether the process may bind ports below 1024 (i.e. running as
 // root); it is a parameter so tests do not depend on the effective
 // UID of the test runner.
-func (c *Config) validate(privileged bool) error {
+func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
 	var errs []error
 
 	// Mode enums
@@ -88,17 +94,18 @@ func (c *Config) validate(privileged bool) error {
 	}
 
 	// Load mode requires a source ImmutableDB
-	if c.RunMode == RunModeLoad && c.ImmutableDbPath == "" {
+	if effectiveMode == RunModeLoad && c.ImmutableDbPath == "" {
 		errs = append(errs, errors.New(
 			"runMode \"load\" requires immutableDbPath to be set "+
 				"(config, DINGO_IMMUTABLE_DB_PATH, or --immutable-db-path)",
 		))
 	}
 
-	// Ports. The relay, private, and metrics listeners are required for
-	// the serving modes but not started by "load", so they may be unset
-	// (0) in a load-only config.
-	listenersRequired := c.RunMode != RunModeLoad
+	// Ports. The relay, private, and metrics listeners are required only
+	// for the serving modes; the load and one-shot utility (sync,
+	// mithril) invocations start none of them, so those ports may be
+	// unset (0).
+	listenersRequired := effectiveMode.RequiresListeners()
 	ports := []struct {
 		setting  string
 		port     uint

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -52,8 +52,9 @@ var AcceptedMithrilBackends = []string{"", "v1", "v2"}
 // environment, CLI flags) for invalid values and nonsensical
 // combinations. Every problem found is returned, joined into a single
 // error, so the operator can fix them all in one pass. It is called
-// from cmd/dingo after CLI flags have been applied, before any
-// services start; LoadConfig alone does not see CLI flag values.
+// from cmd/dingo after CLI flags have been applied and ApplyDefaults
+// has filled in derived defaults, before any services start;
+// LoadConfig alone does not see CLI flag values.
 //
 // effectiveMode is the run mode the invocation will actually execute.
 // For the bare `dingo` process it is c.RunMode, but the one-shot

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -57,11 +58,64 @@ var AcceptedMithrilBackends = []string{"", "v1", "v2"}
 // the configured runMode, so cmd/dingo passes the mode reflecting what
 // the command does. It governs which listeners and sources are required.
 func (c *Config) Validate(effectiveMode RunMode) error {
-	// The privileged-port restriction is Unix-specific. os.Geteuid
-	// returns -1 on Windows, which would otherwise misclassify every
-	// Windows process as unprivileged and reject sub-1024 ports there.
-	privileged := runtime.GOOS == "windows" || os.Geteuid() == 0
-	return c.validate(effectiveMode, privileged)
+	return c.validate(effectiveMode, canBindPrivilegedPorts())
+}
+
+// canBindPrivilegedPorts reports whether the process may bind TCP ports
+// below 1024. Root (euid 0) always can, and Windows has no
+// privileged-port restriction (os.Geteuid also returns -1 there, which
+// would otherwise misclassify every Windows process as unprivileged).
+// On Linux a non-root process may still bind low ports when it holds
+// CAP_NET_BIND_SERVICE (setcap, systemd AmbientCapabilities) or when
+// net.ipv4.ip_unprivileged_port_start has been lowered to 0 (container
+// runtimes such as Docker do this by default), so those are honored
+// before rejecting.
+func canBindPrivilegedPorts() bool {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		return true
+	}
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if start, err := readProcUint(
+		"/proc/sys/net/ipv4/ip_unprivileged_port_start",
+	); err == nil && start == 0 {
+		return true
+	}
+	return hasCapNetBindService()
+}
+
+// readProcUint reads a procfs file containing a single unsigned
+// decimal value.
+func readProcUint(path string) (uint64, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // fixed procfs paths
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+}
+
+// hasCapNetBindService reports whether the process's effective
+// capability set includes CAP_NET_BIND_SERVICE (bit 10), read from the
+// CapEff line of /proc/self/status.
+func hasCapNetBindService() bool {
+	const capNetBindService = 10
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return false
+	}
+	for line := range strings.Lines(string(data)) {
+		rest, ok := strings.CutPrefix(line, "CapEff:")
+		if !ok {
+			continue
+		}
+		mask, err := strconv.ParseUint(strings.TrimSpace(rest), 16, 64)
+		if err != nil {
+			return false
+		}
+		return mask&(1<<capNetBindService) != 0
+	}
+	return false
 }
 
 // validate is the deterministic core of Validate. privileged reports
@@ -112,13 +166,17 @@ func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
 	//     (RunModeSync); the read-only Mithril subcommands start neither;
 	//   - bark: serving modes only (not storage-gated);
 	//   - UTxORPC, Blockfrost, Mesh, Midnight: serving modes under API
-	//     storage (dev mode forces API storage on at startup).
+	//     storage. Dev mode forces API storage on at startup, and node.Run
+	//     keys that off the *configured* runMode — `dingo serve` with
+	//     runMode "dev" still runs dev — so the configured mode is
+	//     consulted alongside the effective one.
 	// The load and read-only Mithril invocations start no listeners, so
 	// their ports may be unset (0) and are not checked.
 	serving := effectiveMode.RequiresListeners()
 	auxListeners := serving || effectiveMode == RunModeSync
 	apiListeners := serving &&
-		(effectiveMode == RunModeDev || c.StorageMode == storageModeAPI)
+		(effectiveMode == RunModeDev || c.RunMode.IsDevMode() ||
+			c.StorageMode == storageModeAPI)
 	ports := []struct {
 		setting  string
 		port     uint

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -58,31 +58,36 @@ var AcceptedMithrilBackends = []string{"", "v1", "v2"}
 // the configured runMode, so cmd/dingo passes the mode reflecting what
 // the command does. It governs which listeners and sources are required.
 func (c *Config) Validate(effectiveMode RunMode) error {
-	return c.validate(effectiveMode, canBindPrivilegedPorts())
+	return c.validate(effectiveMode, minBindablePort())
 }
 
-// canBindPrivilegedPorts reports whether the process may bind TCP ports
-// below 1024. Root (euid 0) always can, and Windows has no
-// privileged-port restriction (os.Geteuid also returns -1 there, which
-// would otherwise misclassify every Windows process as unprivileged).
-// On Linux a non-root process may still bind low ports when it holds
-// CAP_NET_BIND_SERVICE (setcap, systemd AmbientCapabilities) or when
-// net.ipv4.ip_unprivileged_port_start has been lowered to 0 (container
-// runtimes such as Docker do this by default), so those are honored
-// before rejecting.
-func canBindPrivilegedPorts() bool {
+// minBindablePort returns the lowest TCP port this process may bind;
+// configured ports below it are privileged and rejected. Root (euid 0)
+// may bind any port, and Windows has no privileged-port restriction
+// (os.Geteuid also returns -1 there, which would otherwise misclassify
+// every Windows process as unprivileged). On Linux the restriction is
+// lifted entirely by CAP_NET_BIND_SERVICE (setcap, systemd
+// AmbientCapabilities), and the cutoff is otherwise the kernel's
+// net.ipv4.ip_unprivileged_port_start — 1024 by default, 0 inside
+// containers under runtimes such as Docker, and possibly any other
+// value an operator has set — so the actual sysctl value is used. On
+// other Unixes the traditional 1024 cutoff applies.
+func minBindablePort() uint {
 	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
-		return true
+		return 0
 	}
 	if runtime.GOOS != "linux" {
-		return false
+		return minUnprivilegedPort
+	}
+	if hasCapNetBindService() {
+		return 0
 	}
 	if start, err := readProcUint(
 		"/proc/sys/net/ipv4/ip_unprivileged_port_start",
-	); err == nil && start == 0 {
-		return true
+	); err == nil && start <= maxPort {
+		return uint(start)
 	}
-	return hasCapNetBindService()
+	return minUnprivilegedPort
 }
 
 // readProcUint reads a procfs file containing a single unsigned
@@ -118,11 +123,11 @@ func hasCapNetBindService() bool {
 	return false
 }
 
-// validate is the deterministic core of Validate. privileged reports
-// whether the process may bind ports below 1024 (i.e. running as
-// root); it is a parameter so tests do not depend on the effective
-// UID of the test runner.
-func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
+// validate is the deterministic core of Validate. minBindable is the
+// lowest port the process may bind (0 for a privileged process, 1024
+// for a typical unprivileged one); it is a parameter so tests do not
+// depend on the effective UID or kernel settings of the test runner.
+func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 	var errs []error
 
 	// Mode enums
@@ -200,7 +205,7 @@ func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
 		if !p.active {
 			continue
 		}
-		if err := validatePort(p.setting, p.port, p.required, privileged); err != nil {
+		if err := validatePort(p.setting, p.port, p.required, minBindable); err != nil {
 			errs = append(errs, err)
 		}
 		if p.port == 0 {
@@ -352,10 +357,16 @@ func (c *Config) validate(effectiveMode RunMode, privileged bool) error {
 
 // validatePort checks a configured TCP port. Ports are uints, so
 // values above 65535 are representable but unbindable; ports below
-// 1024 need elevated privileges; and 0 either disables the component
-// (required=false) or is nonsense for a mandatory listener
-// (required=true, binding port 0 picks a random port).
-func validatePort(setting string, port uint, required, privileged bool) error {
+// minBindable are privileged ports the process may not bind; and 0
+// either disables the component (required=false) or is nonsense for a
+// mandatory listener (required=true, binding port 0 picks a random
+// port).
+func validatePort(
+	setting string,
+	port uint,
+	required bool,
+	minBindable uint,
+) error {
 	if port == 0 {
 		if required {
 			return fmt.Errorf("%s must be set (port 0 is not valid)", setting)
@@ -368,11 +379,12 @@ func validatePort(setting string, port uint, required, privileged bool) error {
 			setting, port, maxPort,
 		)
 	}
-	if port < minUnprivilegedPort && !privileged {
+	if port < minBindable {
 		return fmt.Errorf(
-			"invalid %s: %d is a privileged port and the process is not "+
-				"running as root (use %d-%d)",
-			setting, port, minUnprivilegedPort, maxPort,
+			"invalid %s: %d is a privileged port this process may not "+
+				"bind (use %d-%d, or grant the privilege, e.g. root or "+
+				"CAP_NET_BIND_SERVICE)",
+			setting, port, minBindable, maxPort,
 		)
 	}
 	return nil

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -406,6 +406,20 @@ func TestValidateMithrilReadOnlyModeSkipsAuxPorts(t *testing.T) {
 	assert.NoError(t, cfg.validate(RunModeMithril, false))
 }
 
+// TestValidateDevConfigViaServeChecksApiPorts covers `dingo serve` with
+// a configured runMode of "dev": the effective mode is serve, but
+// node.Run keys dev behavior off the configured mode and forces API
+// storage, so the API listener ports bind and must still be validated.
+func TestValidateDevConfigViaServeChecksApiPorts(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.RunMode = RunModeDev
+	cfg.StorageMode = storageModeCore
+	cfg.UtxorpcPort = 99999999
+	err := cfg.validate(RunModeServe, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid utxorpcPort")
+}
+
 // TestValidateLoadModeSkipsAllListenerPorts verifies that load, which
 // starts no listeners, does not reject otherwise out-of-range listener
 // ports: they never bind during an import.

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validTestConfig returns a minimal configuration that passes
+// validation, mirroring the production defaults.
+func validTestConfig() *Config {
+	return &Config{
+		Network:              "preview",
+		RunMode:              RunModeServe,
+		StorageMode:          storageModeCore,
+		EvictionWatermark:    DefaultEvictionWatermark,
+		RejectionWatermark:   DefaultRejectionWatermark,
+		MempoolCapacity:      DefaultMempoolCapacityPraos,
+		RelayPort:            3001,
+		PrivatePort:          3002,
+		MetricsPort:          12798,
+		UtxorpcPort:          9090,
+		BlockfrostPort:       3000,
+		MeshPort:             8080,
+		ShutdownTimeout:      DefaultShutdownTimeout,
+		LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
+		Cache:                DefaultCacheConfig(),
+		Chainsync:            DefaultChainsyncConfig(),
+		Midnight:             DefaultMidnightConfig(),
+		Mithril: MithrilConfig{
+			Enabled: true,
+			Backend: "v2",
+		},
+	}
+}
+
+func TestValidateDefaultsPass(t *testing.T) {
+	assert.NoError(t, validTestConfig().validate(false))
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*Config)
+		wantErr string
+	}{
+		{
+			name:    "invalid run mode",
+			modify:  func(c *Config) { c.RunMode = "batch" },
+			wantErr: "invalid runMode",
+		},
+		{
+			name:    "invalid start era",
+			modify:  func(c *Config) { c.StartEra = "byron" },
+			wantErr: "invalid startEra",
+		},
+		{
+			name:    "invalid storage mode",
+			modify:  func(c *Config) { c.StorageMode = "full" },
+			wantErr: "invalid storageMode",
+		},
+		{
+			name:    "load mode without immutable db path",
+			modify:  func(c *Config) { c.RunMode = RunModeLoad },
+			wantErr: "requires immutableDbPath",
+		},
+		{
+			name: "load mode with immutable db path",
+			modify: func(c *Config) {
+				c.RunMode = RunModeLoad
+				c.ImmutableDbPath = "/data/immutable"
+			},
+		},
+		{
+			name:    "port above maximum",
+			modify:  func(c *Config) { c.UtxorpcPort = 99999999 },
+			wantErr: "invalid utxorpcPort: 99999999 (must be at most 65535)",
+		},
+		{
+			name:    "privileged port without privileges",
+			modify:  func(c *Config) { c.BlockfrostPort = 443 },
+			wantErr: "privileged port",
+		},
+		{
+			name:    "required port set to zero",
+			modify:  func(c *Config) { c.RelayPort = 0 },
+			wantErr: "port (relay/NtN) must be set",
+		},
+		{
+			name:    "metrics port set to zero",
+			modify:  func(c *Config) { c.MetricsPort = 0 },
+			wantErr: "metricsPort must be set",
+		},
+		{
+			name:   "optional port disabled with zero",
+			modify: func(c *Config) { c.UtxorpcPort = 0 },
+		},
+		{
+			name: "cardano config path traversal",
+			modify: func(c *Config) {
+				c.CardanoConfig = "configs/../../etc/passwd"
+			},
+			wantErr: "must not contain \"..\"",
+		},
+		{
+			name:    "cardano config bare parent reference",
+			modify:  func(c *Config) { c.CardanoConfig = ".." },
+			wantErr: "must not contain \"..\"",
+		},
+		{
+			name: "cardano config inner dotdot cleans away",
+			modify: func(c *Config) {
+				c.CardanoConfig = "/etc/dingo/../dingo/config.json"
+			},
+		},
+		{
+			name:   "cardano config absolute path",
+			modify: func(c *Config) { c.CardanoConfig = "/etc/dingo/config.json" },
+		},
+		{
+			name:    "tls cert without key",
+			modify:  func(c *Config) { c.TlsCertFilePath = "/certs/tls.crt" },
+			wantErr: "must both be set",
+		},
+		{
+			name:    "tls key without cert",
+			modify:  func(c *Config) { c.TlsKeyFilePath = "/certs/tls.key" },
+			wantErr: "must both be set",
+		},
+		{
+			name: "tls cert and key together",
+			modify: func(c *Config) {
+				c.TlsCertFilePath = "/certs/tls.crt"
+				c.TlsKeyFilePath = "/certs/tls.key"
+			},
+		},
+		{
+			name:    "negative mempool capacity",
+			modify:  func(c *Config) { c.MempoolCapacity = -1 },
+			wantErr: "invalid mempoolCapacity",
+		},
+		{
+			name:    "eviction watermark out of range",
+			modify:  func(c *Config) { c.EvictionWatermark = 1.5 },
+			wantErr: "invalid evictionWatermark",
+		},
+		{
+			name:    "rejection watermark out of range",
+			modify:  func(c *Config) { c.RejectionWatermark = 1.5 },
+			wantErr: "invalid rejectionWatermark",
+		},
+		{
+			name: "eviction above rejection",
+			modify: func(c *Config) {
+				c.EvictionWatermark = 0.95
+				c.RejectionWatermark = 0.90
+			},
+			wantErr: "must be less than rejectionWatermark",
+		},
+		{
+			name:    "block producer missing key paths",
+			modify:  func(c *Config) { c.BlockProducer = true },
+			wantErr: "missing required key paths",
+		},
+		{
+			name: "block producer with all key paths",
+			modify: func(c *Config) {
+				c.BlockProducer = true
+				c.ShelleyVRFKey = "/keys/vrf.skey"
+				c.ShelleyKESKey = "/keys/kes.skey"
+				c.ShelleyOperationalCertificate = "/keys/node.cert"
+			},
+		},
+		{
+			name: "no network and no magic",
+			modify: func(c *Config) {
+				c.Network = ""
+				c.NetworkMagic = 0
+			},
+			wantErr: "network or networkMagic must be set",
+		},
+		{
+			name: "network magic without network name",
+			modify: func(c *Config) {
+				c.Network = ""
+				c.NetworkMagic = 2
+			},
+		},
+		{
+			name:    "network name with traversal characters",
+			modify:  func(c *Config) { c.Network = "../mainnet" },
+			wantErr: "invalid network name",
+		},
+		{
+			name:    "unparseable shutdown timeout",
+			modify:  func(c *Config) { c.ShutdownTimeout = "thirty" },
+			wantErr: "invalid shutdownTimeout",
+		},
+		{
+			name:    "negative shutdown timeout",
+			modify:  func(c *Config) { c.ShutdownTimeout = "-5s" },
+			wantErr: "invalid shutdownTimeout \"-5s\": must be positive",
+		},
+		{
+			name:    "unparseable ledger catchup timeout",
+			modify:  func(c *Config) { c.LedgerCatchupTimeout = "1 hour" },
+			wantErr: "invalid ledgerCatchupTimeout",
+		},
+		{
+			name:    "unparseable chainsync stall timeout",
+			modify:  func(c *Config) { c.Chainsync.StallTimeout = "soon" },
+			wantErr: "invalid chainsync.stallTimeout",
+		},
+		{
+			name: "negative mithril idle timeout allowed",
+			modify: func(c *Config) {
+				c.Mithril.DownloadIdleTimeout = "-1s"
+			},
+		},
+		{
+			name: "unparseable mithril idle timeout",
+			modify: func(c *Config) {
+				c.Mithril.DownloadIdleTimeout = "later"
+			},
+			wantErr: "invalid mithril.downloadIdleTimeout",
+		},
+		{
+			name:    "invalid chainsync strategy",
+			modify:  func(c *Config) { c.Chainsync.Strategy = "fastest" },
+			wantErr: "invalid chainsync.strategy",
+		},
+		{
+			name:   "chainsync strategy round_robin alias",
+			modify: func(c *Config) { c.Chainsync.Strategy = "round_robin" },
+		},
+		{
+			name:    "negative chainsync max clients",
+			modify:  func(c *Config) { c.Chainsync.MaxClients = -1 },
+			wantErr: "invalid chainsync.maxClients",
+		},
+		{
+			name:    "invalid mithril backend",
+			modify:  func(c *Config) { c.Mithril.Backend = "v3" },
+			wantErr: "invalid mithril.backend",
+		},
+		{
+			name:   "empty mithril backend",
+			modify: func(c *Config) { c.Mithril.Backend = "" },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tt.modify(cfg)
+			err := cfg.validate(false)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidatePrivilegedPortAllowedAsRoot(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.BlockfrostPort = 443
+	assert.NoError(t, cfg.validate(true))
+}
+
+func TestValidateAggregatesAllErrors(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.RunMode = RunModeLoad
+	cfg.UtxorpcPort = 70000
+	cfg.EvictionWatermark = 2.0
+	err := cfg.validate(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires immutableDbPath")
+	assert.Contains(t, err.Error(), "invalid utxorpcPort")
+	assert.Contains(t, err.Error(), "invalid evictionWatermark")
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -384,19 +384,26 @@ func TestValidateSyncModeIgnoresInactiveListenerCollision(t *testing.T) {
 	assert.NoError(t, cfg.validate(RunModeSync, false))
 }
 
-// TestValidateUtilityModesValidateMetricsPort verifies that the sync and
-// mithril utilities still validate the metrics port they do start, even
-// though they skip the serving and API listener ports.
-func TestValidateUtilityModesValidateMetricsPort(t *testing.T) {
-	for _, mode := range []RunMode{RunModeSync, RunModeMithril} {
-		t.Run(string(mode), func(t *testing.T) {
-			cfg := validTestConfig()
-			cfg.MetricsPort = 99999999
-			err := cfg.validate(mode, false)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid metricsPort")
-		})
-	}
+// TestValidateSyncModeValidatesMetricsPort verifies that the Mithril sync
+// operation still validates the metrics port it starts, even though it
+// skips the serving and API listener ports.
+func TestValidateSyncModeValidatesMetricsPort(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.MetricsPort = 99999999
+	err := cfg.validate(RunModeSync, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid metricsPort")
+}
+
+// TestValidateMithrilReadOnlyModeSkipsAuxPorts is a regression test for
+// the read-only Mithril subcommands (`mithril list`, `mithril show`),
+// which query the aggregator and start no listeners: a bad metrics or
+// debug port must not block them.
+func TestValidateMithrilReadOnlyModeSkipsAuxPorts(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.MetricsPort = 99999999
+	cfg.DebugPort = 99999999
+	assert.NoError(t, cfg.validate(RunModeMithril, false))
 }
 
 // TestValidateLoadModeSkipsAllListenerPorts verifies that load, which

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -50,7 +50,8 @@ func validTestConfig() *Config {
 }
 
 func TestValidateDefaultsPass(t *testing.T) {
-	assert.NoError(t, validTestConfig().validate(false))
+	cfg := validTestConfig()
+	assert.NoError(t, cfg.validate(cfg.RunMode, false))
 }
 
 func TestValidate(t *testing.T) {
@@ -294,7 +295,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validTestConfig()
 			tt.modify(cfg)
-			err := cfg.validate(false)
+			err := cfg.validate(cfg.RunMode, false)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
 				return
@@ -308,7 +309,20 @@ func TestValidate(t *testing.T) {
 func TestValidatePrivilegedPortAllowedAsRoot(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.BlockfrostPort = 443
-	assert.NoError(t, cfg.validate(true))
+	assert.NoError(t, cfg.validate(cfg.RunMode, true))
+}
+
+// TestValidateUtilityModeRelaxesListenerAndSource verifies that a
+// one-shot utility invocation (sync, mithril) neither requires the
+// serving listener ports nor an ImmutableDB source, even though the
+// configured runMode is the default serve.
+func TestValidateUtilityModeRelaxesListenerAndSource(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.RelayPort = 0
+	cfg.PrivatePort = 0
+	cfg.MetricsPort = 0
+	cfg.ImmutableDbPath = ""
+	assert.NoError(t, cfg.validate(RunModeUtility, false))
 }
 
 func TestValidateAggregatesAllErrors(t *testing.T) {
@@ -316,7 +330,7 @@ func TestValidateAggregatesAllErrors(t *testing.T) {
 	cfg.RunMode = RunModeLoad
 	cfg.UtxorpcPort = 70000
 	cfg.EvictionWatermark = 2.0
-	err := cfg.validate(false)
+	err := cfg.validate(cfg.RunMode, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires immutableDbPath")
 	assert.Contains(t, err.Error(), "invalid utxorpcPort")

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -178,6 +179,31 @@ func TestValidate(t *testing.T) {
 			wantErr: "is assigned to both",
 		},
 		{
+			// Listeners bound to distinct specific addresses can legally
+			// share a port; only overlapping bind addresses collide.
+			name: "distinct bind addresses may share a port",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.BindAddr = "127.0.0.1"
+				c.PrivateBindAddr = "127.0.0.1"
+				c.DebugPort = 13000
+				c.Midnight.Host = "127.0.0.2"
+				c.Midnight.Port = 13000
+			},
+		},
+		{
+			// A wildcard bind address contends with every specific one.
+			name: "wildcard bind address collides with specific",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.BindAddr = "0.0.0.0"
+				c.DebugPort = 13000
+				c.Midnight.Host = "127.0.0.2"
+				c.Midnight.Port = 13000
+			},
+			wantErr: "is assigned to both",
+		},
+		{
 			name: "cardano config path traversal",
 			modify: func(c *Config) {
 				c.CardanoConfig = "configs/../../etc/passwd"
@@ -190,10 +216,21 @@ func TestValidate(t *testing.T) {
 			wantErr: "must not contain \"..\"",
 		},
 		{
-			name: "cardano config inner dotdot cleans away",
+			// An inner ".." would clean away, but the contract is that
+			// no ".." component appears at all: cleaning first would
+			// let "configs/../secret.json" through.
+			name: "cardano config inner dotdot rejected",
 			modify: func(c *Config) {
 				c.CardanoConfig = "/etc/dingo/../dingo/config.json"
 			},
+			wantErr: "must not contain \"..\"",
+		},
+		{
+			name: "cardano config inner dotdot that cleans inside the tree",
+			modify: func(c *Config) {
+				c.CardanoConfig = "configs/../secret.json"
+			},
+			wantErr: "must not contain \"..\"",
 		},
 		{
 			name:   "cardano config absolute path",
@@ -229,6 +266,19 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "rejection watermark out of range",
 			modify:  func(c *Config) { c.RejectionWatermark = 1.5 },
+			wantErr: "invalid rejectionWatermark",
+		},
+		{
+			// Every ordered comparison with NaN is false, so a plain
+			// out-of-range check would let NaN through (e.g. from
+			// --eviction-watermark NaN, which strconv parses).
+			name:    "NaN eviction watermark",
+			modify:  func(c *Config) { c.EvictionWatermark = math.NaN() },
+			wantErr: "invalid evictionWatermark",
+		},
+		{
+			name:    "NaN rejection watermark",
+			modify:  func(c *Config) { c.RejectionWatermark = math.NaN() },
 			wantErr: "invalid rejectionWatermark",
 		},
 		{

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -51,7 +51,7 @@ func validTestConfig() *Config {
 
 func TestValidateDefaultsPass(t *testing.T) {
 	cfg := validTestConfig()
-	assert.NoError(t, cfg.validate(cfg.RunMode, false))
+	assert.NoError(t, cfg.validate(cfg.RunMode, minUnprivilegedPort))
 }
 
 func TestValidate(t *testing.T) {
@@ -334,7 +334,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := validTestConfig()
 			tt.modify(cfg)
-			err := cfg.validate(cfg.RunMode, false)
+			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
 				return
@@ -345,11 +345,29 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidatePrivilegedPortAllowedAsRoot(t *testing.T) {
+// TestValidatePrivilegedPortAllowedWhenBindable covers a process that
+// may bind any port (root, Windows, or CAP_NET_BIND_SERVICE):
+// minBindable is 0, so a sub-1024 port passes.
+func TestValidatePrivilegedPortAllowedWhenBindable(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.StorageMode = storageModeAPI
 	cfg.BlockfrostPort = 443
-	assert.NoError(t, cfg.validate(cfg.RunMode, true))
+	assert.NoError(t, cfg.validate(cfg.RunMode, 0))
+}
+
+// TestValidateLoweredPrivilegedPortCutoff covers a Linux deployment
+// with net.ipv4.ip_unprivileged_port_start lowered to a nonzero value:
+// ports at or above the cutoff must pass while ports below it are
+// still rejected.
+func TestValidateLoweredPrivilegedPortCutoff(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.StorageMode = storageModeAPI
+	cfg.BlockfrostPort = 80
+	assert.NoError(t, cfg.validate(cfg.RunMode, 80))
+	cfg.BlockfrostPort = 79
+	err := cfg.validate(cfg.RunMode, 80)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "privileged port")
 }
 
 // TestValidateUtilityModesRelaxListenerAndSource verifies that the
@@ -366,7 +384,7 @@ func TestValidateUtilityModesRelaxListenerAndSource(t *testing.T) {
 			cfg.MetricsPort = 0
 			cfg.DebugPort = 0
 			cfg.ImmutableDbPath = ""
-			assert.NoError(t, cfg.validate(mode, false))
+			assert.NoError(t, cfg.validate(mode, minUnprivilegedPort))
 		})
 	}
 }
@@ -381,7 +399,7 @@ func TestValidateSyncModeIgnoresInactiveListenerCollision(t *testing.T) {
 	cfg.RelayPort = 0
 	cfg.PrivatePort = 0
 	cfg.ImmutableDbPath = ""
-	assert.NoError(t, cfg.validate(RunModeSync, false))
+	assert.NoError(t, cfg.validate(RunModeSync, minUnprivilegedPort))
 }
 
 // TestValidateSyncModeValidatesMetricsPort verifies that the Mithril sync
@@ -390,7 +408,7 @@ func TestValidateSyncModeIgnoresInactiveListenerCollision(t *testing.T) {
 func TestValidateSyncModeValidatesMetricsPort(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.MetricsPort = 99999999
-	err := cfg.validate(RunModeSync, false)
+	err := cfg.validate(RunModeSync, minUnprivilegedPort)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid metricsPort")
 }
@@ -403,7 +421,7 @@ func TestValidateMithrilReadOnlyModeSkipsAuxPorts(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.MetricsPort = 99999999
 	cfg.DebugPort = 99999999
-	assert.NoError(t, cfg.validate(RunModeMithril, false))
+	assert.NoError(t, cfg.validate(RunModeMithril, minUnprivilegedPort))
 }
 
 // TestValidateDevConfigViaServeChecksApiPorts covers `dingo serve` with
@@ -415,7 +433,7 @@ func TestValidateDevConfigViaServeChecksApiPorts(t *testing.T) {
 	cfg.RunMode = RunModeDev
 	cfg.StorageMode = storageModeCore
 	cfg.UtxorpcPort = 99999999
-	err := cfg.validate(RunModeServe, false)
+	err := cfg.validate(RunModeServe, minUnprivilegedPort)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid utxorpcPort")
 }
@@ -429,7 +447,7 @@ func TestValidateLoadModeSkipsAllListenerPorts(t *testing.T) {
 	cfg.ImmutableDbPath = "/data/immutable"
 	cfg.MetricsPort = 99999999
 	cfg.UtxorpcPort = 99999999
-	assert.NoError(t, cfg.validate(RunModeLoad, false))
+	assert.NoError(t, cfg.validate(RunModeLoad, minUnprivilegedPort))
 }
 
 // TestValidateInvalidModeStillReportsListeners verifies that when the
@@ -442,7 +460,7 @@ func TestValidateInvalidModeStillReportsListeners(t *testing.T) {
 	cfg.RelayPort = 0
 	// cmd/dingo passes RunModeServe as the effective mode for an invalid
 	// configured runMode at the bare root.
-	err := cfg.validate(RunModeServe, false)
+	err := cfg.validate(RunModeServe, minUnprivilegedPort)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid runMode")
 	assert.Contains(t, err.Error(), "port (relay/NtN) must be set")
@@ -454,7 +472,7 @@ func TestValidateAggregatesAllErrors(t *testing.T) {
 	cfg.ImmutableDbPath = ""
 	cfg.EvictionWatermark = 2.0
 	cfg.Chainsync.Strategy = "fastest"
-	err := cfg.validate(cfg.RunMode, false)
+	err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires immutableDbPath")
 	assert.Contains(t, err.Error(), "invalid evictionWatermark")

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -325,6 +325,22 @@ func TestValidateUtilityModeRelaxesListenerAndSource(t *testing.T) {
 	assert.NoError(t, cfg.validate(RunModeUtility, false))
 }
 
+// TestValidateInvalidModeStillReportsListeners verifies that when the
+// bare root falls back to an effective serve mode for an invalid
+// configured runMode, the listener-port violations are reported
+// alongside the invalid-runMode error rather than being suppressed.
+func TestValidateInvalidModeStillReportsListeners(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.RunMode = "batch"
+	cfg.RelayPort = 0
+	// cmd/dingo passes RunModeServe as the effective mode for an invalid
+	// configured runMode at the bare root.
+	err := cfg.validate(RunModeServe, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid runMode")
+	assert.Contains(t, err.Error(), "port (relay/NtN) must be set")
+}
+
 func TestValidateAggregatesAllErrors(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.RunMode = RunModeLoad

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -87,6 +87,21 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "load mode allows unset listener ports",
+			modify: func(c *Config) {
+				c.RunMode = RunModeLoad
+				c.ImmutableDbPath = "/data/immutable"
+				c.RelayPort = 0
+				c.PrivatePort = 0
+				c.MetricsPort = 0
+			},
+		},
+		{
+			name:    "serve mode still requires listener ports",
+			modify:  func(c *Config) { c.RelayPort = 0 },
+			wantErr: "port (relay/NtN) must be set",
+		},
+		{
 			name:    "port above maximum",
 			modify:  func(c *Config) { c.UtxorpcPort = 99999999 },
 			wantErr: "invalid utxorpcPort: 99999999 (must be at most 65535)",
@@ -109,6 +124,18 @@ func TestValidate(t *testing.T) {
 		{
 			name:   "optional port disabled with zero",
 			modify: func(c *Config) { c.UtxorpcPort = 0 },
+		},
+		{
+			name:    "duplicate port assignment",
+			modify:  func(c *Config) { c.PrivatePort = c.RelayPort },
+			wantErr: "is assigned to both",
+		},
+		{
+			name: "duplicate zero ports do not collide",
+			modify: func(c *Config) {
+				c.DebugPort = 0
+				c.BarkPort = 0
+			},
 		},
 		{
 			name: "cardano config path traversal",

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -103,13 +103,19 @@ func TestValidate(t *testing.T) {
 			wantErr: "port (relay/NtN) must be set",
 		},
 		{
-			name:    "port above maximum",
-			modify:  func(c *Config) { c.UtxorpcPort = 99999999 },
+			name: "port above maximum",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.UtxorpcPort = 99999999
+			},
 			wantErr: "invalid utxorpcPort: 99999999 (must be at most 65535)",
 		},
 		{
-			name:    "privileged port without privileges",
-			modify:  func(c *Config) { c.BlockfrostPort = 443 },
+			name: "privileged port without privileges",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.BlockfrostPort = 443
+			},
 			wantErr: "privileged port",
 		},
 		{
@@ -123,8 +129,11 @@ func TestValidate(t *testing.T) {
 			wantErr: "metricsPort must be set",
 		},
 		{
-			name:   "optional port disabled with zero",
-			modify: func(c *Config) { c.UtxorpcPort = 0 },
+			name: "optional port disabled with zero",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.UtxorpcPort = 0
+			},
 		},
 		{
 			name:    "duplicate port assignment",
@@ -137,6 +146,36 @@ func TestValidate(t *testing.T) {
 				c.DebugPort = 0
 				c.BarkPort = 0
 			},
+		},
+		{
+			// UTxORPC/Blockfrost/Mesh/Midnight bind only under API storage
+			// mode; in core mode their ports never bind, so even an
+			// out-of-range or privileged value must not be rejected.
+			name: "core mode skips inactive API port validation",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeCore
+				c.UtxorpcPort = 99999999
+				c.BlockfrostPort = 443
+			},
+		},
+		{
+			// An API port colliding with an active serving port is not a
+			// real clash in core mode because the API listener is inactive.
+			name: "core mode ignores API/serving port collision",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeCore
+				c.MetricsPort = c.MeshPort
+			},
+		},
+		{
+			// Under API storage the same collision is real: both listeners
+			// bind, so it must be reported.
+			name: "api mode rejects API/serving port collision",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.MetricsPort = c.MeshPort
+			},
+			wantErr: "is assigned to both",
 		},
 		{
 			name: "cardano config path traversal",
@@ -308,21 +347,68 @@ func TestValidate(t *testing.T) {
 
 func TestValidatePrivilegedPortAllowedAsRoot(t *testing.T) {
 	cfg := validTestConfig()
+	cfg.StorageMode = storageModeAPI
 	cfg.BlockfrostPort = 443
 	assert.NoError(t, cfg.validate(cfg.RunMode, true))
 }
 
-// TestValidateUtilityModeRelaxesListenerAndSource verifies that a
-// one-shot utility invocation (sync, mithril) neither requires the
-// serving listener ports nor an ImmutableDB source, even though the
-// configured runMode is the default serve.
-func TestValidateUtilityModeRelaxesListenerAndSource(t *testing.T) {
+// TestValidateUtilityModesRelaxListenerAndSource verifies that the
+// one-shot sync and mithril invocations neither require the serving
+// listener ports nor an ImmutableDB source, even though the configured
+// runMode is the default serve. Their metrics/debug listeners accept an
+// unset port, which the runtime binds ephemerally.
+func TestValidateUtilityModesRelaxListenerAndSource(t *testing.T) {
+	for _, mode := range []RunMode{RunModeSync, RunModeMithril} {
+		t.Run(string(mode), func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.RelayPort = 0
+			cfg.PrivatePort = 0
+			cfg.MetricsPort = 0
+			cfg.DebugPort = 0
+			cfg.ImmutableDbPath = ""
+			assert.NoError(t, cfg.validate(mode, false))
+		})
+	}
+}
+
+// TestValidateSyncModeIgnoresInactiveListenerCollision reproduces
+// `dingo --metrics-port 8080 sync`: the metrics port matches the default
+// mesh port, but sync starts no Mesh listener, so there is no real
+// collision and validation must pass.
+func TestValidateSyncModeIgnoresInactiveListenerCollision(t *testing.T) {
 	cfg := validTestConfig()
+	cfg.MetricsPort = cfg.MeshPort // 8080, the default mesh port
 	cfg.RelayPort = 0
 	cfg.PrivatePort = 0
-	cfg.MetricsPort = 0
 	cfg.ImmutableDbPath = ""
-	assert.NoError(t, cfg.validate(RunModeUtility, false))
+	assert.NoError(t, cfg.validate(RunModeSync, false))
+}
+
+// TestValidateUtilityModesValidateMetricsPort verifies that the sync and
+// mithril utilities still validate the metrics port they do start, even
+// though they skip the serving and API listener ports.
+func TestValidateUtilityModesValidateMetricsPort(t *testing.T) {
+	for _, mode := range []RunMode{RunModeSync, RunModeMithril} {
+		t.Run(string(mode), func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.MetricsPort = 99999999
+			err := cfg.validate(mode, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid metricsPort")
+		})
+	}
+}
+
+// TestValidateLoadModeSkipsAllListenerPorts verifies that load, which
+// starts no listeners, does not reject otherwise out-of-range listener
+// ports: they never bind during an import.
+func TestValidateLoadModeSkipsAllListenerPorts(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.RunMode = RunModeLoad
+	cfg.ImmutableDbPath = "/data/immutable"
+	cfg.MetricsPort = 99999999
+	cfg.UtxorpcPort = 99999999
+	assert.NoError(t, cfg.validate(RunModeLoad, false))
 }
 
 // TestValidateInvalidModeStillReportsListeners verifies that when the
@@ -344,11 +430,12 @@ func TestValidateInvalidModeStillReportsListeners(t *testing.T) {
 func TestValidateAggregatesAllErrors(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.RunMode = RunModeLoad
-	cfg.UtxorpcPort = 70000
+	cfg.ImmutableDbPath = ""
 	cfg.EvictionWatermark = 2.0
+	cfg.Chainsync.Strategy = "fastest"
 	err := cfg.validate(cfg.RunMode, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires immutableDbPath")
-	assert.Contains(t, err.Error(), "invalid utxorpcPort")
 	assert.Contains(t, err.Error(), "invalid evictionWatermark")
+	assert.Contains(t, err.Error(), "invalid chainsync.strategy")
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,7 @@ func validTestConfig() *Config {
 		LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
 		Cache:                DefaultCacheConfig(),
 		Chainsync:            DefaultChainsyncConfig(),
+		HistoryExpiry:        DefaultHistoryExpiryConfig(),
 		Midnight:             DefaultMidnightConfig(),
 		Mithril: MithrilConfig{
 			Enabled: true,
@@ -75,6 +77,20 @@ func TestValidate(t *testing.T) {
 			name:    "invalid storage mode",
 			modify:  func(c *Config) { c.StorageMode = "full" },
 			wantErr: "invalid storageMode",
+		},
+		{
+			name: "negative history expiry frequency",
+			modify: func(c *Config) {
+				c.HistoryExpiry.Frequency = -time.Second
+			},
+			wantErr: "invalid historyExpiry.frequency",
+		},
+		{
+			name: "zero history expiry frequency",
+			modify: func(c *Config) {
+				c.HistoryExpiry.Frequency = 0
+			},
+			wantErr: "invalid historyExpiry.frequency",
 		},
 		{
 			name:    "load mode without immutable db path",

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -39,6 +39,15 @@ const (
 	BackendV2 = "v2"
 )
 
+// AcceptedBackends returns the recognized Mithril artifact backends.
+// It is the single source for backend-name validation: cmd/dingo's
+// resolveMithrilBackend derives from it, and internal/config's
+// validation whitelist (which cannot import this package) verifies
+// parity against it.
+func AcceptedBackends() []string {
+	return []string{BackendV1, BackendV2}
+}
+
 // BootstrapConfig holds configuration for the Mithril bootstrap
 // process.
 type BootstrapConfig struct {


### PR DESCRIPTION
Closes #1485

Adds `Config.Validate()` to `internal/config`, checking the fully merged configuration (defaults, YAML, env, CLI flags) before any services start. All violations are aggregated into a single startup error naming each bad setting, so operators can fix everything in one pass.

## Checks

- Mode enums: `runMode`, `startEra`, `storageMode`
- `runMode: load` requires `immutableDbPath`
- Ports: required listeners (`port`, `privatePort`, `metricsPort`) must be non-zero; optional API ports accept 0 as disabled; all must be ≤ 65535; ports below 1024 are rejected unless the process runs as root
- Path-traversal guard on `cardanoConfig` (no `..` components), matching the existing network-name guard
- TLS cert/key must be set as a pair
- Mempool watermark ranges and eviction < rejection ordering
- Block producer requires all three credential paths
- Network name validity; `network` or `networkMagic` must be set
- Duration strings (`shutdownTimeout`, `ledgerCatchupTimeout`, `chainsync.stallTimeout`, `mithril.downloadIdleTimeout`) parse at startup instead of failing at point of use
- `chainsync.strategy` and `mithril.backend` accepted-value sets

## Wire-up

Validation runs in `PersistentPreRunE` after `ApplyFlags`. This also closes a gap where CLI flag values bypassed `LoadConfig`'s inline checks entirely (flags are applied after `LoadConfig` returns, so e.g. `--eviction-watermark 1.5` was never validated). The `dingo load <path>` positional argument is merged into `ImmutableDbPath` before validation so a config with `runMode: load` plus a path argument does not fail spuriously.

Deliberately out of scope: file/dir existence checks (embedded-FS fallbacks and later-created paths make stat-at-validate wrong for several fields), and the closed issues referenced by the ticket (#276, #387, #390, #393).

## Testing

- New table-driven tests covering every rule plus error aggregation; the privileged-port check is parameterized on privilege so tests don't depend on the runner's UID
- Full `make test` (`-race`, includes conformance) passes; golangci-lint, modernize, and import-boundaries clean
- Manual smoke tests: bad port, missing load path, and `--cardano-config ../../etc/passwd` each fail with a clear named-setting error; multiple violations report together

ARCHITECTURE.md Configuration section updated; DATABASE.md not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Config.Validate()` for startup validation keyed to the command’s effective run mode, and defers defaulting/validation until all sources (YAML, env, flags, args) are merged. Also rejects a negative `historyExpiry.frequency` instead of silently defaulting.

- New Features
  - Validate the merged config via `internal/config.Config.Validate()` before any services start, using the effective mode (serve, load, sync, mithril).
  - Scope listener checks to active listeners: serving requires relay/private/metrics; `sync` validates metrics/debug; read‑only `mithril list/show` and `load` start none; API ports validate only under `api` storage or when configured `runMode` is `dev`.
  - Add `internal/config.Config.ApplyDefaults()` to fill derived defaults after `ApplyFlags` (runMode, mempoolCapacity, watermarks, forge thresholds, history‑expiry frequency) and then validate; `LoadConfig` now only parses/merges sources.
  - Export accepted‑value lists from parsers and derive from them: `chainsync.AcceptedHeaderSyncStrategyNames` and `mithril.AcceptedBackends`. `internal/config` duplicates are guarded by bidirectional parity tests in `cmd/dingo`.

- Bug Fixes
  - Port validation: detect duplicate non‑zero ports only when bind addresses overlap (wildcard vs specific); privileged‑port checks use the actual cutoff (root/Windows/CAP_NET_BIND_SERVICE or Linux sysctl).
  - Exempt `version`, `list`, `help`, and `completion` from config loading and validation.
  - `dingo load <path>` merges the positional path before validation; load mode enforces `immutableDbPath`.
  - Harden `cardanoConfig` path guard to reject any `..`; validate CLI flags, parse duration strings at startup, and validate mempool watermarks (including NaN) and block‑producer credentials.
  - Support networkMagic‑only configs: allow an empty `network` at load/flag time; validation still requires either `network` or `networkMagic`.
  - Fix precedence gaps: CLI flags can override invalid YAML values and influence derived defaults (e.g., `--run-mode leios` sets the leios mempool capacity).
  - History expiry: preserve an explicitly negative `historyExpiry.frequency` from any source and fail validation; only zero defaults to 1h.

<sup>Written for commit b61c234057770730d2171dbfc4872ffc3b3887f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now runs deterministically before services start, aggregating multiple configuration issues at once.
  * CLI determines an “effective” run mode for validation; informational commands skip config loading/validation.
  * `dingo load <path>` can supply `immutableDbPath` even when omitted from YAML.
* **Bug Fixes**
  * Stricter listener port checks (including privileged-port rules, overlap collisions, and mode-specific validation).
  * Improved TLS, mempool watermark, chainsync, Mithril, block-producer credentials, path traversal, and duration/strategy validation.
  * Network parsing is relaxed for networkMagic-only setups and `--network ""`.
* **Tests**
  * Added expanded and parity-focused validation coverage for accepted strategy/back-end values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->