### PR TITLE
fix: skip imported mithril mark eligibility check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1382,7 +1382,7 @@ When running as a stake pool operator, Dingo can produce blocks. This involves t
 
 ### Leader Election (`ledger/leader/`)
 
-`Election` subscribes to epoch transition events and pre-computes a leader schedule for each epoch. For each slot, it checks whether the pool's VRF output meets the threshold determined by the pool's relative stake from the Mark snapshot two epochs back. Header validation uses the same epoch-2 Mark source except for the epoch imported from a Mithril snapshot, where it uses the imported active `pool-distr` stake fraction.
+`Election` subscribes to epoch transition events and pre-computes a leader schedule for each epoch. For each slot, it checks whether the pool's VRF output meets the threshold determined by the pool's relative stake from the Mark snapshot two epochs back. Header validation uses the same epoch-2 Mark source except for the epoch imported from a Mithril snapshot, where it uses the imported active `pool-distr` stake fraction. If a post-Mithril historical Mark row was captured at or after the target snapshot epoch's start slot, header validation treats that row as an import artifact and skips only the stake-threshold eligibility check rather than rejecting a canonical block.
 
 ### Block Forging (`ledger/forging/`)
 
@@ -1484,7 +1484,11 @@ Those rows store the consensus stake fraction as `total_stake /
 stake_denominator` and are required for block-header leader eligibility checks
 until the node leaves the imported epoch. The regular Mark snapshot window is
 kept for epoch-offset consumers, but it does not substitute for `"actv"` rows in
-the imported epoch.
+the imported epoch. Historical Mark rows imported from the same ledger-state
+bundle can have a `captured_slot` after their target epoch's boundary; inbound
+header validation recognizes that shape as unsuitable for hard stake-threshold
+rejection and skips that portion of validation until live boundary-captured Mark
+rows are available.
 
 The Mithril snapshot also acts as the local trust anchor during live
 chainsync. The ledger refuses any rollback below the imported ledger slot

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -259,9 +259,12 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 	issuerVkey := block.IssuerVkey()
 	poolKeyHash := lcommon.PoolKeyHash(issuerVkey.Hash())
 
-	poolStake, totalStake, snapshotEpoch, snapshotType, err := ls.leaderEligibilityStake(block, epochId, poolKeyHash)
+	poolStake, totalStake, snapshotEpoch, snapshotType, skipEligibility, err := ls.leaderEligibilityStake(block, epochId, poolKeyHash)
 	if err != nil {
 		return err
+	}
+	if skipEligibility {
+		return nil
 	}
 	if totalStake == 0 {
 		// Genesis snapshot not yet written (very early bootstrap).
@@ -344,13 +347,13 @@ func (ls *LedgerState) leaderEligibilityStake(
 	block ledger.Block,
 	epochId uint64,
 	poolKeyHash lcommon.PoolKeyHash,
-) (uint64, uint64, uint64, string, error) {
+) (uint64, uint64, uint64, string, bool, error) {
 	useImportedActive, err := ls.shouldUseImportedActivePoolDistribution(
 		block,
 		epochId,
 	)
 	if err != nil {
-		return 0, 0, epochId, models.PoolStakeSnapshotTypeActive, err
+		return 0, 0, epochId, models.PoolStakeSnapshotTypeActive, false, err
 	}
 	if useImportedActive {
 		snapshot, err := ls.db.Metadata().GetPoolStakeSnapshot(
@@ -360,7 +363,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 			nil,
 		)
 		if err != nil {
-			return 0, 0, epochId, models.PoolStakeSnapshotTypeActive,
+			return 0, 0, epochId, models.PoolStakeSnapshotTypeActive, false,
 				fmt.Errorf(
 					"block header verification rejected at slot %d: "+
 						"lookup active pool distribution: %w",
@@ -371,7 +374,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 		if snapshot == nil ||
 			snapshot.TotalStake == 0 ||
 			snapshot.StakeDenominator == 0 {
-			return 0, 0, epochId, models.PoolStakeSnapshotTypeActive,
+			return 0, 0, epochId, models.PoolStakeSnapshotTypeActive, false,
 				fmt.Errorf(
 					"block header verification rejected at slot %d: "+
 						"producer pool %x missing from active pool distribution for epoch %d",
@@ -384,6 +387,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 			uint64(snapshot.StakeDenominator),
 			epochId,
 			models.PoolStakeSnapshotTypeActive,
+			false,
 			nil
 	}
 
@@ -396,7 +400,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 		nil,
 	)
 	if err != nil {
-		return 0, 0, snapshotEpoch, snapshotType,
+		return 0, 0, snapshotEpoch, snapshotType, false,
 			fmt.Errorf(
 				"block header verification rejected at slot %d: "+
 					"lookup pool stake: %w",
@@ -405,7 +409,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 			)
 	}
 	if snapshot == nil || snapshot.TotalStake == 0 {
-		return 0, 0, snapshotEpoch, snapshotType,
+		return 0, 0, snapshotEpoch, snapshotType, false,
 			fmt.Errorf(
 				"block header verification rejected at slot %d: "+
 					"producer pool %x has no stake in epoch %d snapshot",
@@ -426,7 +430,8 @@ func (ls *LedgerState) leaderEligibilityStake(
 				"component", "ledger",
 			)
 		}
-		return uint64(snapshot.TotalStake), 0, snapshotEpoch, snapshotType, nil
+		return uint64(snapshot.TotalStake), 0, snapshotEpoch, snapshotType,
+			true, nil
 	}
 	totalStake, err := ls.db.Metadata().GetTotalActiveStake(
 		snapshotEpoch,
@@ -434,7 +439,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 		nil,
 	)
 	if err != nil {
-		return 0, 0, snapshotEpoch, snapshotType,
+		return 0, 0, snapshotEpoch, snapshotType, false,
 			fmt.Errorf(
 				"block header verification rejected at slot %d: "+
 					"lookup total active stake: %w",
@@ -442,7 +447,8 @@ func (ls *LedgerState) leaderEligibilityStake(
 				err,
 			)
 	}
-	return uint64(snapshot.TotalStake), totalStake, snapshotEpoch, snapshotType, nil
+	return uint64(snapshot.TotalStake), totalStake, snapshotEpoch, snapshotType,
+		false, nil
 }
 
 func (ls *LedgerState) isMithrilImportedMarkSnapshot(

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -414,6 +414,20 @@ func (ls *LedgerState) leaderEligibilityStake(
 				snapshotEpoch,
 			)
 	}
+	if ls.isMithrilImportedMarkSnapshot(snapshot, snapshotEpoch) {
+		if ls.config.Logger != nil {
+			ls.config.Logger.Warn(
+				"skipping leader eligibility check: mark snapshot captured after target epoch start",
+				"slot", block.SlotNumber(),
+				"epoch", epochId,
+				"snapshot_epoch", snapshotEpoch,
+				"snapshot_type", snapshotType,
+				"captured_slot", snapshot.CapturedSlot,
+				"component", "ledger",
+			)
+		}
+		return uint64(snapshot.TotalStake), 0, snapshotEpoch, snapshotType, nil
+	}
 	totalStake, err := ls.db.Metadata().GetTotalActiveStake(
 		snapshotEpoch,
 		snapshotType,
@@ -429,6 +443,31 @@ func (ls *LedgerState) leaderEligibilityStake(
 			)
 	}
 	return uint64(snapshot.TotalStake), totalStake, snapshotEpoch, snapshotType, nil
+}
+
+func (ls *LedgerState) isMithrilImportedMarkSnapshot(
+	snapshot *models.PoolStakeSnapshot,
+	snapshotEpoch uint64,
+) bool {
+	if snapshot == nil ||
+		snapshot.SnapshotType != models.PoolStakeSnapshotTypeMark ||
+		snapshot.CapturedSlot == 0 {
+		return false
+	}
+
+	ls.RLock()
+	defer ls.RUnlock()
+
+	if ls.mithrilLedgerSlot == 0 {
+		return false
+	}
+	for _, ep := range ls.epochCache {
+		if ep.EpochId != snapshotEpoch || ep.LengthInSlots == 0 {
+			continue
+		}
+		return snapshot.CapturedSlot >= ep.StartSlot
+	}
+	return false
 }
 
 func (ls *LedgerState) shouldUseImportedActivePoolDistribution(

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"io"
@@ -23,11 +24,15 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	ledgersnapshot "github.com/blinklabs-io/dingo/ledger/snapshot"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/kes"
@@ -1001,6 +1006,130 @@ func seedPoolStakeSnapshotOfTypeAtSlot(
 	require.NoError(t, err)
 }
 
+func seedEligibilityEpochs(
+	t *testing.T,
+	db *database.Database,
+	epochs []models.Epoch,
+) {
+	t.Helper()
+	for _, epoch := range epochs {
+		require.NoError(t, db.SetEpoch(
+			epoch.StartSlot,
+			epoch.EpochId,
+			epoch.Nonce,
+			epoch.EvolvingNonce,
+			epoch.CandidateNonce,
+			epoch.LastEpochBlockNonce,
+			epoch.EraId,
+			epoch.SlotLength,
+			epoch.LengthInSlots,
+			nil,
+		))
+	}
+}
+
+func seedLiveDelegatedPoolStake(
+	t *testing.T,
+	db *database.Database,
+	poolKeyHash []byte,
+	totalStake uint64,
+	slot uint64,
+	discriminator byte,
+) {
+	t.Helper()
+	margin := &types.Rat{Rat: big.NewRat(1, 100)}
+	err := db.Metadata().ImportPool(
+		&models.Pool{
+			PoolKeyHash:   poolKeyHash,
+			VrfKeyHash:    make([]byte, 32),
+			Pledge:        types.Uint64(1_000_000),
+			Cost:          types.Uint64(340_000_000),
+			Margin:        margin,
+			RewardAccount: make([]byte, 28),
+		},
+		&models.PoolRegistration{
+			PoolKeyHash:   poolKeyHash,
+			VrfKeyHash:    make([]byte, 32),
+			AddedSlot:     slot,
+			Pledge:        types.Uint64(1_000_000),
+			Cost:          types.Uint64(340_000_000),
+			Margin:        &types.Rat{Rat: big.NewRat(1, 100)},
+			RewardAccount: make([]byte, 28),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	stakingKey := make([]byte, 28)
+	copy(stakingKey, poolKeyHash)
+	stakingKey[27] ^= discriminator
+	err = db.Metadata().CreateAccount(nil, &models.Account{
+		StakingKey: stakingKey,
+		Pool:       poolKeyHash,
+		AddedSlot:  slot,
+		Active:     true,
+	})
+	require.NoError(t, err)
+
+	txId := make([]byte, 32)
+	copy(txId, poolKeyHash)
+	txId[28] = discriminator
+	txId[31] = discriminator + 1
+	err = db.Metadata().CreateUtxo(nil, &models.Utxo{
+		TxId:       txId,
+		OutputIdx:  uint32(discriminator),
+		StakingKey: stakingKey,
+		Amount:     types.Uint64(totalStake),
+		AddedSlot:  slot,
+	})
+	require.NoError(t, err)
+}
+
+func captureLiveMarkSnapshot(
+	t *testing.T,
+	db *database.Database,
+	newEpoch uint64,
+	boundarySlot uint64,
+	snapshotSlot uint64,
+	poolKeyHash []byte,
+) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	eventBus := event.NewEventBus(nil, logger)
+	t.Cleanup(eventBus.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr := ledgersnapshot.NewManager(db, eventBus, logger)
+	require.NoError(t, mgr.Start(ctx))
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, mgr.Stop())
+	})
+
+	epochEvent := event.EpochTransitionEvent{
+		PreviousEpoch: newEpoch - 1,
+		NewEpoch:      newEpoch,
+		BoundarySlot:  boundarySlot,
+		SnapshotSlot:  snapshotSlot,
+	}
+	eventBus.Publish(
+		event.EpochTransitionEventType,
+		event.NewEvent(event.EpochTransitionEventType, epochEvent),
+	)
+
+	testutil.WaitForCondition(t, func() bool {
+		snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+			newEpoch,
+			models.PoolStakeSnapshotTypeMark,
+			poolKeyHash,
+			nil,
+		)
+		return err == nil &&
+			snapshot != nil &&
+			snapshot.CapturedSlot == snapshotSlot
+	}, 2*time.Second, "live mark snapshot should be captured")
+}
+
 // seedPoolRegistration registers a pool so that db.GetPool(poolKeyHash)
 // returns a *models.Pool whose VrfKeyHash equals vrfKeyHash. It mirrors
 // seedPoolStakeSnapshot by persisting through the metadata store interface:
@@ -1177,13 +1306,16 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 ) {
 	tb := createTestBlock(t, [32]byte{38}, 0, tamperNone)
 	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	var logBuf bytes.Buffer
+	ls.config.Logger = slog.New(slog.NewTextHandler(&logBuf, nil))
 	ls.epochCache = []models.Epoch{
 		{EpochId: 3, StartSlot: 300, LengthInSlots: 100, Nonce: tb.epochNonce},
 		{EpochId: 4, StartSlot: 400, LengthInSlots: 100, Nonce: tb.epochNonce},
 		{EpochId: 5, StartSlot: 500, LengthInSlots: 100, Nonce: tb.epochNonce},
 	}
-	ls.mithrilLedgerSlot = 450
-	tb.block.slot = 550
+	importedCaptureSlot := ls.epochCache[1].StartSlot + 50
+	ls.mithrilLedgerSlot = importedCaptureSlot
+	tb.block.slot = ls.epochCache[2].StartSlot + 50
 
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	seedPoolStakeSnapshotOfTypeAtSlot(
@@ -1194,7 +1326,7 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 		poolKeyHash[:],
 		1,
 		0,
-		450,
+		importedCaptureSlot,
 	)
 	dummyHash := make([]byte, 28)
 	dummyHash[0] = 0xFF
@@ -1206,14 +1338,24 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 		dummyHash,
 		1_000_000_000_000_000_000,
 		0,
-		450,
+		importedCaptureSlot,
 	)
+	snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+		3,
+		models.PoolStakeSnapshotTypeMark,
+		poolKeyHash[:],
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, ls.isMithrilImportedMarkSnapshot(snapshot, 3))
 
-	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	assert.NoError(t, err)
+	assert.Contains(t, logBuf.String(), "mark snapshot captured after target epoch start")
+	assert.NotContains(t, logBuf.String(), "total active stake is zero")
 }
 
-func TestVerifyBlockLeaderEligibility_MithrilBoundaryMarkStillChecks(
+func TestVerifyBlockLeaderEligibility_LiveComputedHistoricalMarkStillChecks(
 	t *testing.T,
 ) {
 	tb := createTestBlock(t, [32]byte{39}, 0, tamperNone)
@@ -1223,34 +1365,37 @@ func TestVerifyBlockLeaderEligibility_MithrilBoundaryMarkStillChecks(
 		{EpochId: 4, StartSlot: 400, LengthInSlots: 100, Nonce: tb.epochNonce},
 		{EpochId: 5, StartSlot: 500, LengthInSlots: 100, Nonce: tb.epochNonce},
 	}
-	ls.mithrilLedgerSlot = 450
-	tb.block.slot = 550
+	ls.mithrilLedgerSlot = ls.epochCache[1].StartSlot + 50
+	tb.block.slot = ls.epochCache[2].StartSlot + 50
+	seedEligibilityEpochs(t, db, append([]models.Epoch{
+		{EpochId: 2, StartSlot: 200, LengthInSlots: 100},
+	}, ls.epochCache...))
 
 	poolKeyHash := tb.block.IssuerVkey().Hash()
-	seedPoolStakeSnapshotOfTypeAtSlot(
-		t,
-		db,
-		3,
-		models.PoolStakeSnapshotTypeMark,
-		poolKeyHash[:],
-		1,
-		0,
-		299,
-	)
 	dummyHash := make([]byte, 28)
 	dummyHash[0] = 0xFF
-	seedPoolStakeSnapshotOfTypeAtSlot(
-		t,
-		db,
-		3,
-		models.PoolStakeSnapshotTypeMark,
-		dummyHash,
-		1_000_000_000_000_000_000,
-		0,
-		299,
+	snapshotEpoch := uint64(3)
+	boundarySlot := ls.epochCache[0].StartSlot
+	snapshotSlot := boundarySlot - 1
+	seedLiveDelegatedPoolStake(
+		t, db, poolKeyHash[:], 1, snapshotSlot, 1,
 	)
+	seedLiveDelegatedPoolStake(
+		t, db, dummyHash, 1_000_000_000_000_000_000, snapshotSlot, 2,
+	)
+	captureLiveMarkSnapshot(
+		t, db, snapshotEpoch, boundarySlot, snapshotSlot, poolKeyHash[:],
+	)
+	snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+		snapshotEpoch,
+		models.PoolStakeSnapshotTypeMark,
+		poolKeyHash[:],
+		nil,
+	)
+	require.NoError(t, err)
+	require.False(t, ls.isMithrilImportedMarkSnapshot(snapshot, snapshotEpoch))
 
-	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "VRF leader value exceeds stake-derived threshold")
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -964,6 +964,29 @@ func seedPoolStakeSnapshotOfType(
 	stakeDenominator uint64,
 ) {
 	t.Helper()
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		epoch,
+		snapshotType,
+		poolKeyHash,
+		totalStake,
+		stakeDenominator,
+		0,
+	)
+}
+
+func seedPoolStakeSnapshotOfTypeAtSlot(
+	t *testing.T,
+	db *database.Database,
+	epoch uint64,
+	snapshotType string,
+	poolKeyHash []byte,
+	totalStake uint64,
+	stakeDenominator uint64,
+	capturedSlot uint64,
+) {
+	t.Helper()
 	err := db.Metadata().SavePoolStakeSnapshot(
 		&models.PoolStakeSnapshot{
 			Epoch:            epoch,
@@ -971,6 +994,7 @@ func seedPoolStakeSnapshotOfType(
 			PoolKeyHash:      poolKeyHash,
 			TotalStake:       types.Uint64(totalStake),
 			StakeDenominator: types.Uint64(stakeDenominator),
+			CapturedSlot:     capturedSlot,
 		},
 		nil,
 	)
@@ -1142,6 +1166,89 @@ func TestVerifyBlockLeaderEligibility_VRFAboveThresholdFails(t *testing.T) {
 	dummyHash := make([]byte, 28)
 	dummyHash[0] = 0xFF
 	seedPoolStakeSnapshot(t, db, 3, dummyHash, 1_000_000_000_000_000_000)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VRF leader value exceeds stake-derived threshold")
+}
+
+func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{38}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.epochCache = []models.Epoch{
+		{EpochId: 3, StartSlot: 300, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 4, StartSlot: 400, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 5, StartSlot: 500, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.mithrilLedgerSlot = 450
+	tb.block.slot = 550
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		3,
+		models.PoolStakeSnapshotTypeMark,
+		poolKeyHash[:],
+		1,
+		0,
+		450,
+	)
+	dummyHash := make([]byte, 28)
+	dummyHash[0] = 0xFF
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		3,
+		models.PoolStakeSnapshotTypeMark,
+		dummyHash,
+		1_000_000_000_000_000_000,
+		0,
+		450,
+	)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err)
+}
+
+func TestVerifyBlockLeaderEligibility_MithrilBoundaryMarkStillChecks(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{39}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.epochCache = []models.Epoch{
+		{EpochId: 3, StartSlot: 300, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 4, StartSlot: 400, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 5, StartSlot: 500, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.mithrilLedgerSlot = 450
+	tb.block.slot = 550
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		3,
+		models.PoolStakeSnapshotTypeMark,
+		poolKeyHash[:],
+		1,
+		0,
+		299,
+	)
+	dummyHash := make([]byte, 28)
+	dummyHash[0] = 0xFF
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		3,
+		models.PoolStakeSnapshotTypeMark,
+		dummyHash,
+		1_000_000_000_000_000_000,
+		0,
+		299,
+	)
 
 	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
 	require.Error(t, err)


### PR DESCRIPTION
## Summary

Fresh Mithril bootstraps can seed historical Mark snapshots using the imported ledger-state slot rather than the historical epoch boundary. When inbound Praos header validation later uses one of those imported Mark rows as the epoch-2 stake source, the pool stake denominator can be wrong enough to reject canonical blocks with `VRF leader value exceeds stake-derived threshold`.

This keeps the existing active `pool-distr` path for the imported Mithril epoch. For later epochs, if a Mark snapshot row was captured at or after the target snapshot epoch start and the node has a Mithril trust boundary, header validation treats that historical Mark row as a Mithril import artifact and skips only the hard stake-threshold eligibility check for that header.

## Production evidence

- Fresh preview Mithril sync completed from scratch into a new data dir.
- Unpatched `v0.61.2` catchup repeatedly failed at preview slot `116727469`, hash `83505aeddee81d39a2c1cc4c002e7204a67b7ef566ee4b55e007431ed0ccc901`.
- The failing imported row was `1349 mark` for pool `9be540401e16b38000921e268bc8995a901721892e3d3c6d2fa7c103`, captured at slot `116708482`, after the target epoch start.
- A patched non-producing `v0.61.2` binary mounted into the release container passed slot `116727469` and caught up to live tip on the same fresh Mithril data.

## Tests

- `go test ./ledger`
- `go test -race ./ledger -run 'TestVerifyBlockLeaderEligibility'`
- `go test -count=1 ./internal/test/conformance/`
- DevNet passed on this change before a final lock-scope cleanup in the helper; the post-cleanup checks above passed afterward.

## Docs

- Updated `ARCHITECTURE.md`.
- `DATABASE.md` checked; no schema/API/storage layout change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the VRF leader eligibility threshold when a Mithril-imported Mark snapshot was captured after the target epoch start to avoid rejecting valid blocks during catch-up. The imported epoch still uses active `pool-distr`; later epochs treat such Mark rows as import artifacts.

- **Bug Fixes**
  - Detect post-boundary Mark snapshots (by `captured_slot >= epoch.start`) when Mithril trust is present and skip only the stake-threshold check in `ledger` header validation, with a warning log.
  - Keep normal checks for boundary-captured Mark rows and for nodes without Mithril trust.
  - Added tests for both skip and non-skip paths and updated `ARCHITECTURE.md`; no schema changes.

<sup>Written for commit dc94c22ab1edb907987627d38f8ce81b5bd12dc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header validation for imported historical stake data so Mithril-imported mark snapshots captured after an epoch boundary no longer trigger incorrect leader-eligibility failures.
  * Kept normal stake-threshold checks in place for boundary-era data, preserving validation where it still applies.

* **Documentation**
  * Clarified the expected behavior of leader election and Mithril-imported stake handling in the architecture notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->