### PR TITLE
fix: Mark snapshots to use historical stake state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1382,7 +1382,7 @@ When running as a stake pool operator, Dingo can produce blocks. This involves t
 
 ### Leader Election (`ledger/leader/`)
 
-`Election` subscribes to epoch transition events and pre-computes a leader schedule for each epoch. For each slot, it checks whether the pool's VRF output meets the threshold determined by the pool's relative stake from the Mark snapshot two epochs back. Header validation uses the same epoch-2 Mark source except for the epoch imported from a Mithril snapshot, where it uses the imported active `pool-distr` stake fraction. If a post-Mithril historical Mark row was captured at or after the target snapshot epoch's start slot, header validation treats that row as an import artifact and skips only the stake-threshold eligibility check rather than rejecting a canonical block.
+`Election` subscribes to epoch transition events and pre-computes a leader schedule for each epoch. For each slot, it checks whether the pool's VRF output meets the threshold determined by the pool's relative stake from the Mark snapshot two epochs back. Header validation uses the same epoch-2 Mark source except for the epoch imported from a Mithril snapshot, where it uses the imported active `pool-distr` stake fraction. Mark snapshots are captured from slot-aware delegation and UTxO state at the boundary slot; threshold failures remain hard validation rejects. Post-Mithril historical Mark rows captured at or after the target snapshot epoch's start slot are treated as import artifacts and skip only the stake-threshold eligibility check.
 
 ### Block Forging (`ledger/forging/`)
 
@@ -1814,7 +1814,7 @@ Key configuration areas:
 
 ## Stake Snapshots
 
-Stake snapshots capture the stake distribution at epoch boundaries for use in Ouroboros Praos leader election. The block producer must know the Mark distribution from two epochs ago to determine if it is the slot leader. When bootstrapping from Mithril, the imported epoch also needs the active `pool-distr` fraction from the certified ledger state for header validation.
+Stake snapshots capture the stake distribution at epoch boundaries for use in Ouroboros Praos leader election. The block producer must know the Mark distribution from two epochs ago to determine if it is the slot leader. Mark captures use slot-aware delegation and UTxO liveness at the boundary slot instead of the current live UTxO set. When bootstrapping from Mithril, the imported epoch also needs the active `pool-distr` fraction from the certified ledger state for header validation.
 
 ### Ouroboros Praos Snapshot Model
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -308,7 +308,7 @@ process the same pointer unless the claim expires before a result is recorded.
 
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
-| `pool_stake_snapshot` | `id`, `epoch`, `snapshot_type`, `pool_key_hash`, `total_stake`, `stake_denominator`, `delegator_count`, `captured_slot`, `reward_account_auto_vote`, `reward_account_auto_vote_resolved` | PK `id`; unique `(epoch, snapshot_type, pool_key_hash)` | Per-pool stake snapshots. `"mark"` rows store lovelace stake totals and are used by the normal Praos epoch-2 rotation. Mithril-imported `"actv"` rows store `NewEpochState.pool-distr` stake fractions as `total_stake / stake_denominator` for the imported epoch. Logical joins to `epoch.epoch_id` and `pool.pool_key_hash`. |
+| `pool_stake_snapshot` | `id`, `epoch`, `snapshot_type`, `pool_key_hash`, `total_stake`, `stake_denominator`, `delegator_count`, `captured_slot`, `reward_account_auto_vote`, `reward_account_auto_vote_resolved` | PK `id`; unique `(epoch, snapshot_type, pool_key_hash)` | Per-pool stake snapshots. `"mark"` rows store lovelace stake totals captured from slot-aware delegation and UTxO state at `captured_slot` and are used by the normal Praos epoch-2 rotation. Mithril-imported `"actv"` rows store `NewEpochState.pool-distr` stake fractions as `total_stake / stake_denominator` for the imported epoch. Logical joins to `epoch.epoch_id` and `pool.pool_key_hash`. |
 | `epoch_summary` | `id`, `epoch`, `total_active_stake`, `total_pool_count`, `total_delegators`, `epoch_nonce`, `boundary_slot`, `snapshot_ready` | PK `id`; unique `epoch` | Aggregate epoch snapshot state. |
 | `reward_ada_pots` | `id`, `epoch`, `treasury`, `reserves`, `fees`, `rewards`, `captured_slot` | PK `id`; unique `epoch`; index `captured_slot` | Reward ADA pots at an epoch boundary. |
 | `reward_snapshot` | `id`, `epoch`, `snapshot_type`, `total_active_stake`, `total_pool_count`, `total_delegators`, `captured_slot`, `boundary_slot`, `epoch_nonce`, `protocol_version` | PK `id`; unique `(epoch, snapshot_type)`; indexes `captured_slot`, `boundary_slot` | Reward-calculation snapshot metadata. |
@@ -735,6 +735,45 @@ To match `includeInactive = false`, add:
 
 ```sql
 AND a.active = true
+```
+
+### `GetStakeByPoolsAtSlot`
+
+Historical stake by pool for epoch-boundary snapshots. The query resolves the
+latest registration/deregistration and pool-delegation certificate for each
+stake credential at or before the requested slot, treats current `account` rows
+as synthetic state only when no relevant certificate history exists for
+imported/bootstrap data, and sums only UTxOs live at that slot:
+
+`utxo.amount` is stored as text (`types.Uint64`) on postgres and mysql, so it is
+cast to the backend's native integer type before summation (`INTEGER` on sqlite,
+`BIGINT` on postgres, `UNSIGNED` on mysql), matching the DRep voting-power
+queries:
+
+```sql
+-- Predicate used by sqlite/postgres/mysql implementations after resolving
+-- active_delegation(pool_key_hash, credential_tag, staking_key)
+WITH active_delegator_stake AS (
+  SELECT active_delegation.pool_key_hash,
+         active_delegation.credential_tag,
+         active_delegation.staking_key,
+         COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0) AS total_stake
+  FROM active_delegation
+  LEFT JOIN utxo
+    ON utxo.credential_tag = active_delegation.credential_tag
+   AND utxo.staking_key = active_delegation.staking_key
+   AND utxo.added_slot <= $1
+   AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > $1)
+  WHERE active_delegation.pool_key_hash IN (...)
+  GROUP BY active_delegation.pool_key_hash,
+           active_delegation.credential_tag,
+           active_delegation.staking_key
+)
+SELECT pool_key_hash,
+       COUNT(*) AS delegator_count,
+       COALESCE(SUM(total_stake), 0) AS total_stake
+FROM active_delegator_stake
+GROUP BY pool_key_hash;
 ```
 
 ### `GetDRepDelegators`

--- a/database/plugin/metadata/internal/stakequery/stakequery.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery.go
@@ -1,0 +1,417 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stakequery
+
+import (
+	"fmt"
+	"strings"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+)
+
+type delegationSource struct {
+	table    string
+	certType uint
+}
+
+type registrationSource struct {
+	table      string
+	certType   uint
+	registered int
+}
+
+const (
+	defaultPoolQueryChunkSize = 800
+	largePoolQueryChunkSize   = 5000
+)
+
+// GetStakeByPoolsAtSlot returns delegated stake and delegator counts at a
+// historical slot. It uses certificate history to find each credential's latest
+// stake delegation and registration state, and account rows as synthetic state
+// for imported/bootstrap data where the certificate history is unavailable.
+func GetStakeByPoolsAtSlot(
+	db *gorm.DB,
+	poolKeyHashes [][]byte,
+	slot uint64,
+) (map[string]uint64, map[string]uint64, error) {
+	stakeMap := make(map[string]uint64, len(poolKeyHashes))
+	delegatorMap := make(map[string]uint64, len(poolKeyHashes))
+	for _, hash := range poolKeyHashes {
+		stakeMap[string(hash)] = 0
+		delegatorMap[string(hash)] = 0
+	}
+	if len(poolKeyHashes) == 0 {
+		return stakeMap, delegatorMap, nil
+	}
+
+	cte, args := activeDelegationCTE(db, slot)
+
+	// utxo.amount is stored as text by types.Uint64 on postgres and mysql, so
+	// SUM() over the raw column fails there ("function sum(text) does not
+	// exist" / "UNION types text and integer cannot be matched"). Cast to the
+	// backend's native integer type first, mirroring the DRep voting-power
+	// queries. sqlite is loosely typed but the cast keeps the backends
+	// consistent.
+	query := cte + fmt.Sprintf(`,
+active_delegator_stake AS (
+	SELECT active_delegation.pool_key_hash,
+		active_delegation.credential_tag,
+		active_delegation.staking_key,
+		COALESCE(SUM(CAST(utxo.amount AS %s)), 0) AS total_stake
+	FROM active_delegation
+	LEFT JOIN utxo
+		ON utxo.credential_tag = active_delegation.credential_tag
+		AND utxo.staking_key = active_delegation.staking_key
+		AND utxo.added_slot <= ?
+		AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > ?)
+	WHERE active_delegation.pool_key_hash IN ?
+	GROUP BY active_delegation.pool_key_hash,
+		active_delegation.credential_tag,
+		active_delegation.staking_key
+)
+SELECT pool_key_hash,
+	COUNT(*) AS delegator_count,
+	COALESCE(SUM(total_stake), 0) AS total_stake
+FROM active_delegator_stake
+GROUP BY pool_key_hash`, utxoAmountCastType(db))
+
+	type stakeResult struct {
+		PoolKeyHash    []byte `gorm:"column:pool_key_hash"`
+		DelegatorCount uint64 `gorm:"column:delegator_count"`
+		TotalStake     uint64 `gorm:"column:total_stake"`
+	}
+	var results []stakeResult
+	chunkSize := poolQueryChunkSize(db)
+	for start := 0; start < len(poolKeyHashes); start += chunkSize {
+		end := min(start+chunkSize, len(poolKeyHashes))
+		chunk := poolKeyHashes[start:end]
+		queryArgs := append(append([]any(nil), args...), slot, slot, chunk)
+		var chunkResults []stakeResult
+		if err := db.Raw(query, queryArgs...).Scan(&chunkResults).Error; err != nil {
+			return nil, nil, fmt.Errorf(
+				"query historical stake: %w",
+				err,
+			)
+		}
+		results = append(results, chunkResults...)
+	}
+	for _, row := range results {
+		delegatorMap[string(row.PoolKeyHash)] = row.DelegatorCount
+		stakeMap[string(row.PoolKeyHash)] = row.TotalStake
+	}
+
+	return stakeMap, delegatorMap, nil
+}
+
+func poolQueryChunkSize(db *gorm.DB) int {
+	if db != nil {
+		name := db.Name()
+		if strings.EqualFold(name, "postgres") ||
+			strings.EqualFold(name, "mysql") {
+			return largePoolQueryChunkSize
+		}
+	}
+	return defaultPoolQueryChunkSize
+}
+
+func activeDelegationCTE(db *gorm.DB, slot uint64) (string, []any) {
+	txTable := transactionTableName(db)
+	args := make([]any, 0, 32)
+	delegationSrcs := delegationSources()
+	registrationSrcs := registrationSources()
+
+	delegationParts := make([]string, 0, len(delegationSrcs)+1)
+	for _, source := range delegationSrcs {
+		delegationParts = append(delegationParts, fmt.Sprintf(`
+SELECT %[1]s.credential_tag,
+	%[1]s.staking_key,
+	%[1]s.pool_key_hash,
+	%[1]s.added_slot,
+	tx.block_index,
+	certs.cert_index
+FROM %[1]s
+INNER JOIN certs
+	ON certs.id = %[1]s.certificate_id
+	AND certs.cert_type = ?
+INNER JOIN %[2]s tx
+	ON tx.id = certs.transaction_id
+WHERE %[1]s.added_slot <= ?`, source.table, txTable))
+		args = append(args, source.certType, slot)
+	}
+	delegationFallbackTables := delegationFallbackBlockTables(
+		delegationSrcs,
+		registrationSrcs,
+	)
+	delegationParts = append(delegationParts, `
+SELECT account.credential_tag,
+	account.staking_key,
+	account.pool AS pool_key_hash,
+	account.added_slot,
+	0 AS block_index,
+	0 AS cert_index
+FROM account
+WHERE account.added_slot <= ?
+	AND account.active = TRUE
+	AND account.pool IS NOT NULL
+	AND length(account.pool) > 0
+`+noCredentialHistoryPredicate("account", delegationFallbackTables))
+	args = append(args, slot)
+	for range delegationFallbackTables {
+		args = append(args, slot)
+	}
+
+	registrationParts := make([]string, 0, len(registrationSrcs)+1)
+	for _, source := range registrationSrcs {
+		// registered is a trusted compile-time constant (0/1). Inline it as a
+		// literal rather than a bound parameter: a parameter placed directly in
+		// a UNION output column is inferred as text by postgres at parse time,
+		// which then fails to unify with the integer account-fallback branch
+		// ("UNION types text and integer cannot be matched").
+		registrationParts = append(registrationParts, fmt.Sprintf(`
+SELECT %[1]s.credential_tag,
+	%[1]s.staking_key,
+	%[3]d AS registered,
+	%[1]s.added_slot,
+	tx.block_index,
+	certs.cert_index
+FROM %[1]s
+INNER JOIN certs
+	ON certs.id = %[1]s.certificate_id
+	AND certs.cert_type = ?
+INNER JOIN %[2]s tx
+	ON tx.id = certs.transaction_id
+WHERE %[1]s.added_slot <= ?`, source.table, txTable, source.registered))
+		args = append(args, source.certType, slot)
+	}
+	registrationFallbackTables := registrationFallbackBlockTables(registrationSrcs)
+	registrationParts = append(registrationParts, `
+SELECT account.credential_tag,
+	account.staking_key,
+	CASE WHEN account.active THEN 1 ELSE 0 END AS registered,
+	account.added_slot,
+	0 AS block_index,
+0 AS cert_index
+FROM account
+WHERE account.added_slot <= ?
+`+noCredentialHistoryPredicate("account", registrationFallbackTables))
+	args = append(args, slot)
+	for range registrationFallbackTables {
+		args = append(args, slot)
+	}
+
+	return fmt.Sprintf(`
+WITH delegation_events AS (
+%s
+),
+ranked_delegation AS (
+	SELECT credential_tag,
+		staking_key,
+		pool_key_hash,
+		added_slot,
+		block_index,
+		cert_index,
+		ROW_NUMBER() OVER (
+			PARTITION BY credential_tag, staking_key
+			ORDER BY added_slot DESC, block_index DESC, cert_index DESC
+		) AS rn
+	FROM delegation_events
+),
+latest_delegation AS (
+	SELECT credential_tag,
+		staking_key,
+		pool_key_hash,
+		added_slot,
+		block_index,
+		cert_index
+	FROM ranked_delegation
+	WHERE rn = 1
+),
+registration_events AS (
+%s
+),
+ranked_registration AS (
+	SELECT credential_tag,
+		staking_key,
+		registered,
+		added_slot,
+		block_index,
+		cert_index,
+		ROW_NUMBER() OVER (
+			PARTITION BY credential_tag, staking_key
+			ORDER BY added_slot DESC, block_index DESC, cert_index DESC
+		) AS rn
+	FROM registration_events
+),
+latest_registration AS (
+	SELECT credential_tag,
+		staking_key,
+		registered,
+		added_slot,
+		block_index,
+		cert_index
+	FROM ranked_registration
+	WHERE rn = 1
+),
+active_delegation AS (
+	SELECT latest_delegation.pool_key_hash,
+		latest_delegation.credential_tag,
+		latest_delegation.staking_key
+	FROM latest_delegation
+	INNER JOIN latest_registration
+		ON latest_registration.credential_tag = latest_delegation.credential_tag
+		AND latest_registration.staking_key = latest_delegation.staking_key
+	WHERE latest_registration.registered = 1
+		AND (
+			latest_delegation.added_slot > latest_registration.added_slot
+			OR (
+				latest_delegation.added_slot = latest_registration.added_slot
+				AND latest_delegation.block_index > latest_registration.block_index
+			)
+			OR (
+				latest_delegation.added_slot = latest_registration.added_slot
+				AND latest_delegation.block_index = latest_registration.block_index
+				AND latest_delegation.cert_index >= latest_registration.cert_index
+			)
+		)
+)`, strings.Join(delegationParts, "\nUNION ALL\n"), strings.Join(registrationParts, "\nUNION ALL\n")), args
+}
+
+func transactionTableName(db *gorm.DB) string {
+	if db == nil {
+		return `"transaction"`
+	}
+	if strings.EqualFold(db.Name(), "mysql") {
+		return "`transaction`"
+	}
+	return `"transaction"`
+}
+
+// utxoAmountCastType returns the backend-native integer type used to cast the
+// text-encoded utxo.amount column before summation. Matches the casts used by
+// the DRep voting-power queries in each plugin.
+func utxoAmountCastType(db *gorm.DB) string {
+	if db != nil {
+		switch {
+		case strings.EqualFold(db.Name(), "postgres"):
+			return "BIGINT"
+		case strings.EqualFold(db.Name(), "mysql"):
+			return "UNSIGNED"
+		}
+	}
+	return "INTEGER"
+}
+
+func delegationFallbackBlockTables(
+	delegationSrcs []delegationSource,
+	registrationSrcs []registrationSource,
+) []string {
+	tables := make(
+		[]string,
+		0,
+		len(delegationSrcs)+len(registrationSrcs),
+	)
+	for _, source := range delegationSrcs {
+		tables = append(tables, source.table)
+	}
+	for _, source := range registrationSrcs {
+		tables = append(tables, source.table)
+	}
+	return tables
+}
+
+func registrationFallbackBlockTables(registrationSrcs []registrationSource) []string {
+	tables := make([]string, 0, len(registrationSrcs))
+	for _, source := range registrationSrcs {
+		tables = append(tables, source.table)
+	}
+	return tables
+}
+
+func noCredentialHistoryPredicate(accountAlias string, tableNames []string) string {
+	var out strings.Builder
+	for _, tableName := range tableNames {
+		fmt.Fprintf(&out, `
+	AND NOT EXISTS (
+		SELECT 1
+		FROM %s history
+		WHERE history.credential_tag = %s.credential_tag
+			AND history.staking_key = %s.staking_key
+			AND history.added_slot <= ?
+	)`, tableName, accountAlias, accountAlias)
+	}
+	return out.String()
+}
+
+func delegationSources() []delegationSource {
+	return []delegationSource{
+		{
+			table:    "stake_delegation",
+			certType: uint(lcommon.CertificateTypeStakeDelegation),
+		},
+		{
+			table:    "stake_registration_delegation",
+			certType: uint(lcommon.CertificateTypeStakeRegistrationDelegation),
+		},
+		{
+			table:    "stake_vote_delegation",
+			certType: uint(lcommon.CertificateTypeStakeVoteDelegation),
+		},
+		{
+			table:    "stake_vote_registration_delegation",
+			certType: uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
+		},
+	}
+}
+
+func registrationSources() []registrationSource {
+	return []registrationSource{
+		{
+			table:      "registration",
+			certType:   uint(lcommon.CertificateTypeRegistration),
+			registered: 1,
+		},
+		{
+			table:      "stake_registration",
+			certType:   uint(lcommon.CertificateTypeStakeRegistration),
+			registered: 1,
+		},
+		{
+			table:      "stake_registration_delegation",
+			certType:   uint(lcommon.CertificateTypeStakeRegistrationDelegation),
+			registered: 1,
+		},
+		{
+			table:      "stake_vote_registration_delegation",
+			certType:   uint(lcommon.CertificateTypeStakeVoteRegistrationDelegation),
+			registered: 1,
+		},
+		{
+			table:      "vote_registration_delegation",
+			certType:   uint(lcommon.CertificateTypeVoteRegistrationDelegation),
+			registered: 1,
+		},
+		{
+			table:      "deregistration",
+			certType:   uint(lcommon.CertificateTypeDeregistration),
+			registered: 0,
+		},
+		{
+			table:      "stake_deregistration",
+			certType:   uint(lcommon.CertificateTypeStakeDeregistration),
+			registered: 0,
+		},
+	}
+}

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
@@ -1059,4 +1060,29 @@ func (d *MetadataStoreMysql) GetStakeByPools(
 	}
 
 	return stakeMap, delegatorMap, nil
+}
+
+// GetStakeByPoolsAtSlot returns delegated stake for multiple pools at a
+// historical slot.
+func (d *MetadataStoreMysql) GetStakeByPoolsAtSlot(
+	poolKeyHashes [][]byte,
+	slot uint64,
+	txn types.Txn,
+) (map[string]uint64, map[string]uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetStakeByPoolsAtSlot: resolve db: %w",
+			err,
+		)
+	}
+	stakes, delegators, err := stakequery.GetStakeByPoolsAtSlot(
+		db,
+		poolKeyHashes,
+		slot,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetStakeByPoolsAtSlot: %w", err)
+	}
+	return stakes, delegators, nil
 }

--- a/database/plugin/metadata/mysql/pool_atslot_test.go
+++ b/database/plugin/metadata/mysql/pool_atslot_test.go
@@ -1,0 +1,69 @@
+//go:build dingo_extra_plugins
+
+package mysql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql exercises the
+// historical stake query on mysql. The query text includes every
+// delegation/registration UNION branch and the SUM(CAST(utxo.amount AS
+// UNSIGNED)) aggregate over the text-encoded amount column, so this catches
+// backend-specific regressions that the sqlite tests cannot.
+func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	poolA := bytes.Repeat([]byte{0xA1}, 28)
+	poolB := bytes.Repeat([]byte{0xB1}, 28)
+	poolEmpty := bytes.Repeat([]byte{0xE1}, 28)
+	stakeA1 := bytes.Repeat([]byte{0x71}, 28)
+	stakeA2 := bytes.Repeat([]byte{0x72}, 28)
+	stakeB1 := bytes.Repeat([]byte{0x73}, 28)
+
+	cleanup := func() {
+		for _, k := range [][]byte{stakeA1, stakeA2, stakeB1} {
+			_ = db.Where("staking_key = ?", k).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", k).Delete(&models.Utxo{}).Error
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	accounts := []models.Account{
+		{StakingKey: stakeA1, Pool: poolA, AddedSlot: 10, Active: true},
+		{StakingKey: stakeA2, Pool: poolA, AddedSlot: 10, Active: true},
+		{StakingKey: stakeB1, Pool: poolB, AddedSlot: 10, Active: true},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x11}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 5, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x12}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 7, AddedSlot: 30, DeletedSlot: 90},
+		{TxId: bytes.Repeat([]byte{0x13}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 11, AddedSlot: 90},
+		{TxId: bytes.Repeat([]byte{0x14}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 13, AddedSlot: 5, DeletedSlot: 70},
+		{TxId: bytes.Repeat([]byte{0x15}, 32), OutputIdx: 0, StakingKey: stakeB1, Amount: 17, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{poolA, poolB, poolEmpty}, 80, nil,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(12), stakes[string(poolA)])
+	require.Equal(t, uint64(2), delegators[string(poolA)])
+	require.Equal(t, uint64(17), stakes[string(poolB)])
+	require.Equal(t, uint64(1), delegators[string(poolB)])
+	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
+	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
+}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
@@ -1133,4 +1134,29 @@ func (d *MetadataStorePostgres) GetStakeByPools(
 	}
 
 	return stakeMap, delegatorMap, nil
+}
+
+// GetStakeByPoolsAtSlot returns delegated stake for multiple pools at a
+// historical slot.
+func (d *MetadataStorePostgres) GetStakeByPoolsAtSlot(
+	poolKeyHashes [][]byte,
+	slot uint64,
+	txn types.Txn,
+) (map[string]uint64, map[string]uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetStakeByPoolsAtSlot: resolve db: %w",
+			err,
+		)
+	}
+	stakes, delegators, err := stakequery.GetStakeByPoolsAtSlot(
+		db,
+		poolKeyHashes,
+		slot,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetStakeByPoolsAtSlot: %w", err)
+	}
+	return stakes, delegators, nil
 }

--- a/database/plugin/metadata/postgres/pool_atslot_test.go
+++ b/database/plugin/metadata/postgres/pool_atslot_test.go
@@ -1,0 +1,70 @@
+//go:build dingo_extra_plugins
+
+package postgres
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsPostgres exercises the
+// historical stake query on postgres. The query text includes every
+// delegation/registration UNION branch and the SUM(CAST(utxo.amount ...))
+// aggregate, all of which postgres type-checks at parse time, so this catches
+// backend-specific regressions (text/integer UNION mismatch, sum over the
+// text-encoded amount column) that the sqlite tests cannot.
+func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	poolA := bytes.Repeat([]byte{0xA1}, 28)
+	poolB := bytes.Repeat([]byte{0xB1}, 28)
+	poolEmpty := bytes.Repeat([]byte{0xE1}, 28)
+	stakeA1 := bytes.Repeat([]byte{0x71}, 28)
+	stakeA2 := bytes.Repeat([]byte{0x72}, 28)
+	stakeB1 := bytes.Repeat([]byte{0x73}, 28)
+
+	cleanup := func() {
+		for _, k := range [][]byte{stakeA1, stakeA2, stakeB1} {
+			_ = db.Where("staking_key = ?", k).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", k).Delete(&models.Utxo{}).Error
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	accounts := []models.Account{
+		{StakingKey: stakeA1, Pool: poolA, AddedSlot: 10, Active: true},
+		{StakingKey: stakeA2, Pool: poolA, AddedSlot: 10, Active: true},
+		{StakingKey: stakeB1, Pool: poolB, AddedSlot: 10, Active: true},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x11}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 5, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x12}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 7, AddedSlot: 30, DeletedSlot: 90},
+		{TxId: bytes.Repeat([]byte{0x13}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 11, AddedSlot: 90},
+		{TxId: bytes.Repeat([]byte{0x14}, 32), OutputIdx: 0, StakingKey: stakeA1, Amount: 13, AddedSlot: 5, DeletedSlot: 70},
+		{TxId: bytes.Repeat([]byte{0x15}, 32), OutputIdx: 0, StakingKey: stakeB1, Amount: 17, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{poolA, poolB, poolEmpty}, 80, nil,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(12), stakes[string(poolA)])
+	require.Equal(t, uint64(2), delegators[string(poolA)])
+	require.Equal(t, uint64(17), stakes[string(poolB)])
+	require.Equal(t, uint64(1), delegators[string(poolB)])
+	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
+	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
+}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -20,6 +20,7 @@ import (
 	"math"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
@@ -1193,4 +1194,29 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 	}
 
 	return stakeMap, delegatorMap, nil
+}
+
+// GetStakeByPoolsAtSlot returns delegated stake for multiple pools at a
+// historical slot.
+func (d *MetadataStoreSqlite) GetStakeByPoolsAtSlot(
+	poolKeyHashes [][]byte,
+	slot uint64,
+	txn types.Txn,
+) (map[string]uint64, map[string]uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetStakeByPoolsAtSlot: resolve db: %w",
+			err,
+		)
+	}
+	stakes, delegators, err := stakequery.GetStakeByPoolsAtSlot(
+		db,
+		poolKeyHashes,
+		slot,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetStakeByPoolsAtSlot: %w", err)
+	}
+	return stakes, delegators, nil
 }

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -705,6 +706,71 @@ func TestGetStakeByPoolsAggregatesUtxos(t *testing.T) {
 		"pool A should have 2 delegators")
 	require.Equal(t, uint64(1), delegators[string(poolB)],
 		"pool B should have 1 delegator")
+}
+
+func TestGetStakeByPoolsAtSlotAggregatesFallbackAccounts(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	db := store.DB()
+	poolA := bytes.Repeat([]byte{0xA1}, 28)
+	poolB := bytes.Repeat([]byte{0xB1}, 28)
+	poolEmpty := bytes.Repeat([]byte{0xE1}, 28)
+	stakeA1 := bytes.Repeat([]byte{0x01}, 28)
+	stakeA2 := bytes.Repeat([]byte{0x02}, 28)
+	stakeB1 := bytes.Repeat([]byte{0x03}, 28)
+
+	accounts := []models.Account{
+		{StakingKey: stakeA1, Pool: poolA, AddedSlot: 10, Active: true},
+		{StakingKey: stakeA2, Pool: poolA, AddedSlot: 10, Active: true},
+		{StakingKey: stakeB1, Pool: poolB, AddedSlot: 10, Active: true},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+
+	utxos := []models.Utxo{
+		{
+			TxId: bytes.Repeat([]byte{0x11}, 32), OutputIdx: 0,
+			StakingKey: stakeA1, Amount: 5, AddedSlot: 20,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x12}, 32), OutputIdx: 0,
+			StakingKey: stakeA1, Amount: 7, AddedSlot: 30,
+			DeletedSlot: 90,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x13}, 32), OutputIdx: 0,
+			StakingKey: stakeA1, Amount: 11, AddedSlot: 90,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x14}, 32), OutputIdx: 0,
+			StakingKey: stakeA1, Amount: 13, AddedSlot: 5,
+			DeletedSlot: 70,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x15}, 32), OutputIdx: 0,
+			StakingKey: stakeB1, Amount: 17, AddedSlot: 20,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{poolA, poolB, poolEmpty},
+		80,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(12), stakes[string(poolA)])
+	require.Equal(t, uint64(2), delegators[string(poolA)])
+	require.Equal(t, uint64(17), stakes[string(poolB)])
+	require.Equal(t, uint64(1), delegators[string(poolB)])
+	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
+	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
 }
 
 func TestGetStakeByPoolsUsesStakeCredentialUtxoIndex(t *testing.T) {

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -328,6 +328,16 @@ type MetadataStore interface {
 		types.Txn,
 	) (map[string]uint64, map[string]uint64, error)
 
+	// GetStakeByPoolsAtSlot returns delegated stake for multiple pools at a
+	// historical slot. It uses certificate history plus slot-aware UTxO
+	// liveness so epoch-boundary stake snapshots do not read current live
+	// stake for an older boundary.
+	GetStakeByPoolsAtSlot(
+		[][]byte, // poolKeyHashes
+		uint64, // slot
+		types.Txn,
+	) (map[string]uint64, map[string]uint64, error)
+
 	// GetStakeRegistrationsByCredential retrieves stake registration certificates
 	// using the full credential identity: credential tag plus 28-byte hash.
 	GetStakeRegistrationsByCredential(

--- a/ledger/snapshot/calculator.go
+++ b/ledger/snapshot/calculator.go
@@ -112,6 +112,7 @@ func (c *Calculator) calculateFromAccounts(
 		meta,
 		metaTxn,
 		pools,
+		slot,
 	)
 	if err != nil {
 		return fmt.Errorf("get batch pools delegated stake: %w", err)
@@ -164,18 +165,14 @@ func (c *Calculator) getActivePoolsAtSlot(
 
 // getBatchPoolsDelegatedStake returns stake for all pools in a single batch
 // query. Returns maps of pool hash -> total stake and pool hash -> delegator
-// count. Stake is computed by joining active accounts with their live UTxOs
-// (deleted_slot = 0) and summing the amounts per pool.
-//
-// NOTE: This currently uses the live UTxO set rather than a historical
-// snapshot. A future slot-aware GetStakeByPoolsAtSlot method could filter
-// by created_slot <= slot AND (deleted_slot = 0 OR deleted_slot > slot)
-// for full consensus-grade accuracy at historical points.
+// count. Stake is computed at the requested snapshot slot using historical
+// registration/delegation certificate state and slot-aware UTxO liveness.
 func (c *Calculator) getBatchPoolsDelegatedStake(
 	_ context.Context,
 	meta metadata.MetadataStore,
 	metaTxn types.Txn,
 	pools []lcommon.PoolKeyHash,
+	slot uint64,
 ) (map[lcommon.PoolKeyHash]uint64, map[lcommon.PoolKeyHash]uint64, error) {
 	// Initialize result maps
 	stakeMap := make(map[lcommon.PoolKeyHash]uint64, len(pools))
@@ -194,7 +191,11 @@ func (c *Calculator) getBatchPoolsDelegatedStake(
 	}
 
 	// Batch query delegator counts for all pools
-	stakes, delegators, err := meta.GetStakeByPools(poolKeyHashBytes, metaTxn)
+	stakes, delegators, err := meta.GetStakeByPoolsAtSlot(
+		poolKeyHashBytes,
+		slot,
+		metaTxn,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get stake by pools: %w", err)
 	}

--- a/ledger/snapshot/calculator_test.go
+++ b/ledger/snapshot/calculator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
 )
 
 // setupTestDB creates a database.Database backed by in-memory SQLite for
@@ -119,6 +120,37 @@ func seedPoolAndDelegations(
 	}
 }
 
+func seedCertificate(
+	t *testing.T,
+	gormDB *gorm.DB,
+	slot uint64,
+	blockIndex uint32,
+	certIndex uint,
+	certType lcommon.CertificateType,
+) uint {
+	t.Helper()
+	txHash := make([]byte, 32)
+	txHash[0] = byte(slot)
+	txHash[1] = byte(slot >> 8)
+	txHash[2] = byte(blockIndex)
+	txHash[3] = byte(certIndex)
+	txHash[4] = byte(certType)
+	tx := models.Transaction{
+		Hash:       txHash,
+		Slot:       slot,
+		BlockIndex: blockIndex,
+	}
+	require.NoError(t, gormDB.Create(&tx).Error, "create tx for cert")
+	cert := models.Certificate{
+		TransactionID: tx.ID,
+		Slot:          slot,
+		CertIndex:     certIndex,
+		CertType:      uint(certType),
+	}
+	require.NoError(t, gormDB.Create(&cert).Error, "create cert")
+	return cert.ID
+}
+
 // TestCalculateStakeDistribution_NonZeroStake verifies that the calculator
 // returns non-zero stake values when delegation data and live UTxOs exist.
 // This is a regression test for the critical bug where GetStakeByPools
@@ -208,9 +240,177 @@ func TestCalculateStakeDistribution_NonZeroStake(t *testing.T) {
 		"pool B should have 1 delegator")
 }
 
-// TestCalculateStakeDistribution_SpentUtxosExcluded verifies that spent
-// UTxOs (deleted_slot != 0) are not counted in the stake distribution.
-func TestCalculateStakeDistribution_SpentUtxosExcluded(t *testing.T) {
+func TestCalculateStakeDistribution_UsesHistoricalDelegationAndRegistration(
+	t *testing.T,
+) {
+	db, sqliteStore := setupTestDB(t)
+	gormDB := sqliteStore.DB()
+
+	require.NoError(t, gormDB.Create(&models.Epoch{
+		EpochId:       10,
+		StartSlot:     0,
+		LengthInSlots: 432000,
+	}).Error, "create epoch")
+
+	poolAHash := []byte("poolA_hist_12345678901234567")
+	poolBHash := []byte("poolB_hist_12345678901234567")
+	stakeKey := []byte("hist__staking_key_1234567890")
+
+	for _, poolHash := range [][]byte{poolAHash, poolBHash} {
+		pool := models.Pool{PoolKeyHash: poolHash}
+		require.NoError(t, gormDB.Create(&pool).Error, "create pool")
+		require.NoError(t, gormDB.Create(&models.PoolRegistration{
+			PoolID:        pool.ID,
+			PoolKeyHash:   poolHash,
+			AddedSlot:     50,
+			Pledge:        1000000,
+			Cost:          340000000,
+			Margin:        &types.Rat{Rat: big.NewRat(1, 100)},
+			VrfKeyHash:    make([]byte, 32),
+			RewardAccount: make([]byte, 28),
+		}).Error, "create pool registration")
+	}
+
+	regCertID := seedCertificate(
+		t,
+		gormDB,
+		100,
+		0,
+		0,
+		lcommon.CertificateTypeStakeRegistration,
+	)
+	require.NoError(t, gormDB.Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		AddedSlot:     100,
+		CertificateID: regCertID,
+	}).Error, "create stake registration")
+
+	delegationACertID := seedCertificate(
+		t,
+		gormDB,
+		100,
+		0,
+		1,
+		lcommon.CertificateTypeStakeDelegation,
+	)
+	require.NoError(t, gormDB.Create(&models.StakeDelegation{
+		StakingKey:    stakeKey,
+		PoolKeyHash:   poolAHash,
+		AddedSlot:     100,
+		CertificateID: delegationACertID,
+	}).Error, "create pool A delegation")
+
+	delegationBCertID := seedCertificate(
+		t,
+		gormDB,
+		300,
+		0,
+		0,
+		lcommon.CertificateTypeStakeDelegation,
+	)
+	require.NoError(t, gormDB.Create(&models.StakeDelegation{
+		StakingKey:    stakeKey,
+		PoolKeyHash:   poolBHash,
+		AddedSlot:     300,
+		CertificateID: delegationBCertID,
+	}).Error, "create pool B delegation")
+
+	deregCertID := seedCertificate(
+		t,
+		gormDB,
+		500,
+		0,
+		0,
+		lcommon.CertificateTypeStakeDeregistration,
+	)
+	require.NoError(t, gormDB.Create(&models.StakeDeregistration{
+		StakingKey:    stakeKey,
+		AddedSlot:     500,
+		CertificateID: deregCertID,
+	}).Error, "create deregistration")
+
+	reregCertID := seedCertificate(
+		t,
+		gormDB,
+		600,
+		0,
+		0,
+		lcommon.CertificateTypeStakeRegistration,
+	)
+	require.NoError(t, gormDB.Create(&models.StakeRegistration{
+		StakingKey:    stakeKey,
+		AddedSlot:     600,
+		CertificateID: reregCertID,
+	}).Error, "create plain re-registration")
+
+	require.NoError(t, gormDB.Create(&models.Utxo{
+		TxId:       []byte("tx_hist_123456789012345678901234"),
+		OutputIdx:  0,
+		StakingKey: stakeKey,
+		Amount:     10000000,
+		AddedSlot:  100,
+	}).Error, "create delegated utxo")
+	require.NoError(t, gormDB.Create(&models.Account{
+		StakingKey: stakeKey,
+		Pool:       poolBHash,
+		AddedSlot:  600,
+		Active:     true,
+	}).Error, "create current account row")
+
+	bootstrapKey := []byte("hist_bootstrap_key_123456789")
+	bootstrapRegCertID := seedCertificate(
+		t,
+		gormDB,
+		610,
+		0,
+		0,
+		lcommon.CertificateTypeStakeRegistration,
+	)
+	require.NoError(t, gormDB.Create(&models.StakeRegistration{
+		StakingKey:    bootstrapKey,
+		AddedSlot:     610,
+		CertificateID: bootstrapRegCertID,
+	}).Error, "create bootstrap plain registration")
+	require.NoError(t, gormDB.Create(&models.Account{
+		StakingKey: bootstrapKey,
+		Pool:       poolBHash,
+		AddedSlot:  610,
+		Active:     true,
+	}).Error, "create bootstrap current account row")
+	require.NoError(t, gormDB.Create(&models.Utxo{
+		TxId:       []byte("tx_boot_123456789012345678901234"),
+		OutputIdx:  0,
+		StakingKey: bootstrapKey,
+		Amount:     20000000,
+		AddedSlot:  100,
+	}).Error, "create bootstrap utxo")
+
+	calc := NewCalculator(db)
+
+	dist, err := calc.CalculateStakeDistribution(context.Background(), 200)
+	require.NoError(t, err)
+	var poolAKey lcommon.PoolKeyHash
+	copy(poolAKey[:], poolAHash)
+	require.Equal(t, uint64(10000000), dist.PoolStakes[poolAKey])
+	require.Equal(t, uint64(10000000), dist.TotalStake)
+
+	dist, err = calc.CalculateStakeDistribution(context.Background(), 400)
+	require.NoError(t, err)
+	var poolBKey lcommon.PoolKeyHash
+	copy(poolBKey[:], poolBHash)
+	require.Equal(t, uint64(10000000), dist.PoolStakes[poolBKey])
+	require.Equal(t, uint64(10000000), dist.TotalStake)
+
+	dist, err = calc.CalculateStakeDistribution(context.Background(), 650)
+	require.NoError(t, err)
+	require.Zero(t, dist.TotalStake)
+	require.Empty(t, dist.PoolStakes)
+}
+
+// TestCalculateStakeDistribution_HistoricalUtxoLiveness verifies that stake
+// distribution uses UTxO liveness at the snapshot slot rather than today's live
+// UTxO set.
+func TestCalculateStakeDistribution_HistoricalUtxoLiveness(t *testing.T) {
 	db, sqliteStore := setupTestDB(t)
 	gormDB := sqliteStore.DB()
 
@@ -250,7 +450,8 @@ func TestCalculateStakeDistribution_SpentUtxosExcluded(t *testing.T) {
 	}
 	require.NoError(t, gormDB.Create(&account).Error)
 
-	// Create one live UTxO (5 ADA) and one spent UTxO (10 ADA)
+	// Create one live UTxO (5 ADA), one UTxO spent after the earlier
+	// snapshot slot (10 ADA), and one UTxO created after that slot (20 ADA).
 	liveUtxo := models.Utxo{
 		TxId:        []byte("tx_live_34567890123456789012345678901234"),
 		OutputIdx:   0,
@@ -271,19 +472,38 @@ func TestCalculateStakeDistribution_SpentUtxosExcluded(t *testing.T) {
 	}
 	require.NoError(t, gormDB.Create(&spentUtxo).Error)
 
-	// Calculate stake distribution
-	calc := NewCalculator(db)
-	dist, err := calc.CalculateStakeDistribution(context.Background(), 1000)
-	require.NoError(t, err)
+	lateUtxo := models.Utxo{
+		TxId:        []byte("tx_late_4567890123456789012345678901234"),
+		OutputIdx:   0,
+		StakingKey:  stakeKey,
+		Amount:      20000000,
+		AddedSlot:   700,
+		DeletedSlot: 0,
+	}
+	require.NoError(t, gormDB.Create(&lateUtxo).Error)
 
+	calc := NewCalculator(db)
 	var poolKey lcommon.PoolKeyHash
 	copy(poolKey[:], poolHash)
 
-	// Only the live UTxO (5 ADA) should be counted
-	require.Equal(t, uint64(5000000), dist.PoolStakes[poolKey],
-		"only live UTxOs should contribute to stake")
-	require.Equal(t, uint64(5000000), dist.TotalStake,
-		"total stake should exclude spent UTxOs")
+	dist, err := calc.CalculateStakeDistribution(context.Background(), 400)
+	require.NoError(t, err)
+
+	// At slot 400 the spent-at-500 UTxO is still live, while the
+	// added-at-700 UTxO does not exist yet.
+	require.Equal(t, uint64(15000000), dist.PoolStakes[poolKey],
+		"snapshot before spend should include UTxOs live at that slot only")
+	require.Equal(t, uint64(15000000), dist.TotalStake,
+		"total stake should use snapshot-slot UTxO liveness")
+
+	dist, err = calc.CalculateStakeDistribution(context.Background(), 1000)
+	require.NoError(t, err)
+
+	// At slot 1000 the spent UTxO is gone and the late UTxO is live.
+	require.Equal(t, uint64(25000000), dist.PoolStakes[poolKey],
+		"later snapshot should exclude spent UTxOs and include later outputs")
+	require.Equal(t, uint64(25000000), dist.TotalStake,
+		"total stake should reflect the later slot")
 }
 
 // TestCalculateStakeDistribution_InactiveAccountsExcluded verifies that

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1252,6 +1252,38 @@ func TestVerifyBlockLeaderEligibility_MithrilEpochRequiresActiveDistribution(
 	assert.NoError(t, err)
 }
 
+func TestVerifyBlockLeaderEligibility_ActiveDistributionVRFAboveThresholdFails(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{40}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	if tb.block.slot <= 1 {
+		tb.block.slot = 2
+	}
+	ls.currentEpoch = models.Epoch{
+		EpochId:       5,
+		StartSlot:     0,
+		LengthInSlots: 1_000_000,
+		Nonce:         tb.epochNonce,
+	}
+	ls.mithrilLedgerSlot = tb.block.slot - 1
+
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshotOfType(
+		t,
+		db,
+		5,
+		models.PoolStakeSnapshotTypeActive,
+		poolKeyHash[:],
+		1,
+		1_000_000_000_000_000_000,
+	)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VRF leader value exceeds stake-derived threshold")
+}
+
 // TestVerifyBlockLeaderEligibility_PoolNotInSnapshotFails verifies that a block
 // from a pool absent from the epoch-2 mark snapshot is rejected.
 func TestVerifyBlockLeaderEligibility_PoolNotInSnapshotFails(t *testing.T) {


### PR DESCRIPTION
## Summary
- compute Mark stake snapshots from historical delegation/registration state and UTxO liveness at the snapshot slot
- share the historical stake query across sqlite, mysql, and postgres metadata backends
- add regression coverage for historical delegation, registration, UTxO liveness, and active pool-distribution hard rejects
- update DATABASE.md and ARCHITECTURE.md for the snapshot data source

## Tests
- go test -count=1 ./ledger/snapshot
- go test -count=1 ./database/plugin/metadata/sqlite
- go test -count=1 ./ledger -run 'TestVerifyBlockLeaderEligibility'
- go test -count=1 ./internal/test/conformance/
- go test -count=1 -tags dingo_extra_plugins -run '^$' ./database/plugin/metadata/mysql ./database/plugin/metadata/postgres
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mark stake snapshots to use historical delegation/registration and snapshot-slot UTxO liveness so leader election and header validation are correct at epoch boundaries. Adds a shared, slot-aware stake query used by `sqlite`, `mysql`, and `postgres`.

- **Bug Fixes**
  - Mark snapshots now read stake via `GetStakeByPoolsAtSlot(slot)` using certificate history and slot-aware UTxO liveness, falling back to `account` state only when no history exists for imported/bootstrap data.
  - Introduced `database/plugin/metadata/internal/stakequery` with backend-specific casts of `utxo.amount` and chunking for large pool lists; wired into `sqlite`, `mysql`, and `postgres`.
  - Updated snapshot calculator to pass the snapshot slot and consume historical results; docs updated in `ARCHITECTURE.md` and `DATABASE.md` with query details and Mark data source. Leader-election docs clarify threshold failures are hard rejects; post-Mithril rows at/after the target epoch start skip only the stake-threshold check.
  - Added regression tests for historical delegation/registration ordering, snapshot-slot UTxO liveness, backend casting and account-fallback on `mysql`/`postgres`, and active-distribution VRF threshold rejects.

- **Migration**
  - `MetadataStore` interface adds `GetStakeByPoolsAtSlot`. Third-party metadata plugins must implement it. No data or config changes.

<sup>Written for commit 6883d986bc571eb6aaf20a1531d953c267839f80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical stake snapshots now reflect stake and delegator counts at a specific slot, improving accuracy for past epochs and pool history.
  * Pool stake queries are now available through all supported database backends.

* **Bug Fixes**
  * Snapshot calculations now use slot-aware delegation and UTxO liveness, so earlier snapshots exclude stake that was not live yet.
  * Leader eligibility checks better handle historical snapshot data during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->