### PR TITLE
fix(peergov): improved peer replenishment

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -71,6 +71,18 @@ func shortLivedReconnectDelay(count uint32) time.Duration {
 	return delay
 }
 
+// countHotPeersLocked returns the number of peers currently in the hot state.
+// Callers must hold p.mu.
+func (p *PeerGovernor) countHotPeersLocked() int {
+	n := 0
+	for _, peer := range p.peers {
+		if peer != nil && peer.State == PeerStateHot {
+			n++
+		}
+	}
+	return n
+}
+
 // isAddrInUseError returns true if the error is a "cannot assign
 // requested address" or EADDRINUSE, indicating a TCP 4-tuple collision.
 func isAddrInUseError(err error) bool {
@@ -827,12 +839,29 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 							peer.ReconnectDelay = maxReconnectDelay
 						}
 					}
-					p.config.Logger.Warn(
-						"short-lived connection detected, applying backoff",
-						"address", peer.Address,
-						"connection_duration", connDur,
-						"next_delay", peer.ReconnectDelay,
-					)
+					// When the hot pool is critically low, cap the backoff so we
+					// keep reconnecting to known peers instead of locking them
+					// out for minutes and collapsing to a single stalled
+					// upstream. On a network of few flaky relays every session
+					// is short-lived, so the escalating backoff would otherwise
+					// erode the pool to one. See issue #2765.
+					if peer.ReconnectDelay > emergencyReconnectDelay &&
+						p.countHotPeersLocked() <= criticalHotPeerThreshold {
+						peer.ReconnectDelay = emergencyReconnectDelay
+						p.config.Logger.Warn(
+							"hot peer pool critically low; capping reconnect backoff to replenish faster",
+							"address", peer.Address,
+							"capped_delay", peer.ReconnectDelay,
+							"component", "peergov",
+						)
+					} else {
+						p.config.Logger.Warn(
+							"short-lived connection detected, applying backoff",
+							"address", peer.Address,
+							"connection_duration", connDur,
+							"next_delay", peer.ReconnectDelay,
+						)
+					}
 				}
 			}
 			peer.ConnectedAt = time.Time{} // Reset for next connection

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -520,8 +520,17 @@ func TestHandleConnectionClosedEvent_ShortLivedBackoffEscalatesAfterDelayConsume
 		// Suppress reconnect goroutine; this test only checks close accounting.
 		Reconnecting: true,
 	}
+	// The short-lived backoff escalates only while the hot pool is healthy; the
+	// issue #2765 cap engages when hot peers <= criticalHotPeerThreshold. Add
+	// hot fillers so this test exercises the escalation path rather than the
+	// critically-low cap (which has its own test below).
 	pg.mu.Lock()
-	pg.peers = []*Peer{peer}
+	pg.peers = []*Peer{
+		peer,
+		{Address: "10.0.0.1:3001", State: PeerStateHot},
+		{Address: "10.0.0.2:3001", State: PeerStateHot},
+		{Address: "10.0.0.3:3001", State: PeerStateHot},
+	}
 	pg.mu.Unlock()
 
 	wantDelays := []time.Duration{
@@ -565,5 +574,73 @@ func TestHandleConnectionClosedEvent_ShortLivedBackoffEscalatesAfterDelayConsume
 				i+1, got, want,
 			)
 		}
+	}
+}
+
+// TestHandleConnectionClosedEvent_CriticalHotPeersCapsBackoff verifies the
+// issue #2765 fix: when the hot pool is at or below criticalHotPeerThreshold,
+// the short-lived reconnect backoff is capped at emergencyReconnectDelay rather
+// than escalating toward maxReconnectDelay, so the node keeps reconnecting to
+// its known peers instead of collapsing to a single stalled upstream on a
+// network of few, flaky relays.
+func TestHandleConnectionClosedEvent_CriticalHotPeersCapsBackoff(
+	t *testing.T,
+) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	connId := outboundTestConnId()
+	peer := &Peer{
+		Address:           "192.168.12.101:3003",
+		NormalizedAddress: "192.168.12.101:3003",
+		Source:            PeerSourceTopologyLocalRoot,
+		// Suppress reconnect goroutine; this test only checks close accounting.
+		Reconnecting: true,
+	}
+	// No hot peers: the pool is critically low, so the cap must engage.
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	// Unbounded escalation would reach 1,2,4,8,16,32s; the cap holds the delay
+	// at emergencyReconnectDelay once it would exceed that, and never above it.
+	for i := 0; i < 6; i++ {
+		pg.mu.Lock()
+		peer.ReconnectDelay = 0
+		peer.Connection = &PeerConnection{
+			Id:       connId,
+			IsClient: true,
+		}
+		peer.State = PeerStateWarm
+		peer.ConnectedAt = time.Now().Add(-600 * time.Millisecond)
+		pg.mu.Unlock()
+
+		pg.handleConnectionClosedEvent(event.NewEvent(
+			connmanager.ConnectionClosedEventType,
+			connmanager.ConnectionClosedEvent{
+				ConnectionId: connId,
+			},
+		))
+
+		pg.mu.Lock()
+		got := peer.ReconnectDelay
+		pg.mu.Unlock()
+		if got > emergencyReconnectDelay {
+			t.Fatalf(
+				"close %d: ReconnectDelay = %s, want <= %s (critically-low cap)",
+				i+1, got, emergencyReconnectDelay,
+			)
+		}
+	}
+	// After enough short-lived closes to exceed the cap, the delay must sit at
+	// the emergency cap, not the escalated value it would otherwise reach.
+	pg.mu.Lock()
+	got := peer.ReconnectDelay
+	pg.mu.Unlock()
+	if got != emergencyReconnectDelay {
+		t.Fatalf(
+			"final ReconnectDelay = %s, want %s (emergency cap)",
+			got, emergencyReconnectDelay,
+		)
 	}
 }

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -96,6 +96,22 @@ const (
 	reconnectBackoffFactor      = 2
 	inboundCheckDelay           = 30 * time.Second
 	minStableConnectionDuration = 30 * time.Second
+	// criticalHotPeerThreshold is the hot-peer low-water mark below which the
+	// short-lived-connection reconnect backoff is capped at
+	// emergencyReconnectDelay instead of escalating toward maxReconnectDelay.
+	// The escalating backoff exists to avoid ephemeral-port exhaustion from
+	// rapid reconnect cycles to an unstable peer, but when the hot pool is this
+	// small the greater risk is losing the last upstreams entirely: on a network
+	// of few, flaky relays (e.g. the Leios prototype) every connection is
+	// short-lived, so escalating backoff locks every known peer out for minutes
+	// and the pool collapses to one stalled upstream. Below this threshold we
+	// prioritize replenishment over port conservation. See issue #2765.
+	criticalHotPeerThreshold = 2
+	// emergencyReconnectDelay is the capped reconnect delay used when hot peers
+	// are at or below criticalHotPeerThreshold: frequent enough to replenish the
+	// pool within seconds, slow enough (a handful of reconnects per minute per
+	// peer) to avoid port exhaustion.
+	emergencyReconnectDelay = 5 * time.Second
 	// dialDNSResolveTimeout bounds the fresh per-attempt DNS resolution in
 	// resolveDialAddress. It is intentionally shorter than connmanager's 10s
 	// dial timeout so a hung or slow resolver cannot wedge the outbound-dial


### PR DESCRIPTION
Closes #2765 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap short-lived reconnect backoff when the hot peer pool is low to quickly replenish connections and avoid collapsing to a single upstream. Fixes #2765.

- **Bug Fixes**
  - Introduced `criticalHotPeerThreshold` (2) and `emergencyReconnectDelay` (5s); cap backoff when hot peers ≤ threshold.
  - Added `countHotPeersLocked()` and updated `handleConnectionClosedEvent` to apply the cap with clear logging in `peergov`.
  - Extended tests: added critical-pool cap test and adjusted escalation test to run with a healthy hot pool.

<sup>Written for commit 9a8e00a56396fc9504229b19a0a9b747d4471456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

