### PR TITLE
fix(database): Validate database names before CREATE DATABASE

### DIFF
--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -49,6 +49,12 @@ func validateDatabaseName(name string) error {
 	if name == "" {
 		return errors.New("database name must not be empty")
 	}
+	if len(name) > 64 {
+		return fmt.Errorf(
+			"invalid database name %q: must be 64 characters or fewer",
+			name,
+		)
+	}
 	if strings.ContainsRune(name, '`') {
 		return fmt.Errorf(
 			"invalid database name %q: must not contain backticks",

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,31 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 	"gorm.io/plugin/opentelemetry/tracing"
 )
+
+// validDatabaseNameRe matches the conservative identifier set allowed for MySQL
+// database names: letters, digits, underscores, and hyphens only.
+var validDatabaseNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// validateDatabaseName rejects names that would break backtick quoting in the
+// CREATE DATABASE statement or fall outside the conservative identifier set.
+func validateDatabaseName(name string) error {
+	if name == "" {
+		return fmt.Errorf("database name must not be empty")
+	}
+	if strings.ContainsRune(name, '`') {
+		return fmt.Errorf(
+			"invalid database name %q: must not contain backticks",
+			name,
+		)
+	}
+	if !validDatabaseNameRe.MatchString(name) {
+		return fmt.Errorf(
+			"invalid database name %q: must contain only letters, digits, underscores, or hyphens",
+			name,
+		)
+	}
+	return nil
+}
 
 // mysqlTxn wraps a gorm transaction and implements types.Txn
 type mysqlTxn struct {
@@ -139,6 +165,11 @@ func New(
 	logger *slog.Logger,
 	promRegistry prometheus.Registerer,
 ) (*MetadataStoreMysql, error) {
+	if database != "" {
+		if err := validateDatabaseName(database); err != nil {
+			return nil, fmt.Errorf("mysql config: %w", err)
+		}
+	}
 	return NewWithOptions(
 		WithHost(host),
 		WithPort(port),
@@ -173,6 +204,11 @@ func NewWithOptions(opts ...MysqlOptionFunc) (*MetadataStoreMysql, error) {
 	}
 	if db.database == "" {
 		db.database = "mysql"
+	}
+	if strings.TrimSpace(db.dsn) == "" {
+		if err := validateDatabaseName(db.database); err != nil {
+			return nil, fmt.Errorf("mysql config: %w", err)
+		}
 	}
 	if db.sslMode == "" {
 		db.sslMode = ""
@@ -234,6 +270,9 @@ func (d *MetadataStoreMysql) Start() error {
 	logDatabase := d.database
 
 	if dsn == "" {
+		if err := validateDatabaseName(d.database); err != nil {
+			return fmt.Errorf("mysql config: %w", err)
+		}
 		cfg := mysql.Config{
 			User:   d.user,
 			Passwd: d.password,
@@ -265,7 +304,12 @@ func (d *MetadataStoreMysql) Start() error {
 			cfg.Params["tls"] = d.sslMode
 		}
 		dsn = cfg.FormatDSN()
-	} else if parsedDB, ok := parseMysqlDatabaseFromDSN(dsn); ok {
+	} else if parsedDB, ok, err := parseMysqlDatabaseFromDSN(dsn); err != nil {
+		return err
+	} else if ok {
+		if err := validateDatabaseName(parsedDB); err != nil {
+			return fmt.Errorf("mysql config dsn: %w", err)
+		}
 		logDatabase = parsedDB
 	}
 
@@ -422,6 +466,9 @@ func (d *MetadataStoreMysql) ensureDatabaseExists(
 	if dbName == "" {
 		return false, nil
 	}
+	if err := validateDatabaseName(dbName); err != nil {
+		return false, fmt.Errorf("cannot create database: %w", err)
+	}
 	adminDsn, ok := stripDatabaseFromDSN(dsn)
 	if !ok {
 		return false, nil
@@ -448,16 +495,15 @@ func (d *MetadataStoreMysql) ensureDatabaseExists(
 	return true, nil
 }
 
-func parseMysqlDatabaseFromDSN(dsn string) (string, bool) {
-	base := dsn
-	if before, _, found := strings.Cut(base, "?"); found {
-		base = before
+func parseMysqlDatabaseFromDSN(dsn string) (string, bool, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", false, fmt.Errorf("parse mysql dsn: %w", err)
 	}
-	slash := strings.LastIndex(base, "/")
-	if slash < 0 || slash == len(base)-1 {
-		return "", false
+	if cfg.DBName == "" {
+		return "", false, nil
 	}
-	return base[slash+1:], true
+	return cfg.DBName, true, nil
 }
 
 func stripDatabaseFromDSN(dsn string) (string, bool) {

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -47,7 +47,7 @@ var validDatabaseNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // CREATE DATABASE statement or fall outside the conservative identifier set.
 func validateDatabaseName(name string) error {
 	if name == "" {
-		return fmt.Errorf("database name must not be empty")
+		return errors.New("database name must not be empty")
 	}
 	if strings.ContainsRune(name, '`') {
 		return fmt.Errorf(

--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -1498,6 +1498,7 @@ func TestValidateDatabaseName(t *testing.T) {
 		"db123",
 		"UPPER",
 		"Mixed_Case-1",
+		strings.Repeat("a", 64),
 	}
 	for _, name := range valid {
 		if err := validateDatabaseName(name); err != nil {
@@ -1518,6 +1519,7 @@ func TestValidateDatabaseName(t *testing.T) {
 		{"db/name", "slash in name"},
 		{"db\\name", "backslash in name"},
 		{"db\x00name", "null byte"},
+		{strings.Repeat("a", 65), "over MySQL identifier length limit"},
 	}
 	for _, tc := range invalid {
 		if err := validateDatabaseName(tc.name); err == nil {

--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1485,4 +1486,122 @@ func TestMysqlRestoreDrepStateAtSlot(t *testing.T) {
 			}
 		},
 	)
+}
+
+// TestValidateDatabaseName verifies the conservative MySQL identifier allowlist.
+func TestValidateDatabaseName(t *testing.T) {
+	valid := []string{
+		"mydb",
+		"dingo",
+		"my_db",
+		"my-db",
+		"db123",
+		"UPPER",
+		"Mixed_Case-1",
+	}
+	for _, name := range valid {
+		if err := validateDatabaseName(name); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", name, err)
+		}
+	}
+
+	invalid := []struct {
+		name string
+		desc string
+	}{
+		{"", "empty name"},
+		{"`injected`", "backtick injection"},
+		{"db`drop", "embedded backtick"},
+		{"db name", "space in name"},
+		{"db;DROP TABLE x", "semicolon injection"},
+		{"db.name", "dot in name"},
+		{"db/name", "slash in name"},
+		{"db\\name", "backslash in name"},
+		{"db\x00name", "null byte"},
+	}
+	for _, tc := range invalid {
+		if err := validateDatabaseName(tc.name); err == nil {
+			t.Errorf("expected %q (%s) to be invalid, but got no error", tc.name, tc.desc)
+		}
+	}
+}
+
+// TestNewWithOptionsRejectsInvalidDatabaseName verifies option-based config validation.
+func TestNewWithOptionsRejectsInvalidDatabaseName(t *testing.T) {
+	_, err := NewWithOptions(WithDatabase("`bad`"))
+	if err == nil {
+		t.Fatal("expected error for database name with backticks, got nil")
+	}
+
+	_, err = NewWithOptions(WithDatabase("bad name"))
+	if err == nil {
+		t.Fatal("expected error for database name with space, got nil")
+	}
+
+	_, err = NewWithOptions(WithDatabase("bad name"), WithDSN("   "))
+	if err == nil {
+		t.Fatal("expected error for bad database name with whitespace DSN, got nil")
+	}
+
+	_, err = NewWithOptions(WithDatabase("good_db"))
+	if err != nil {
+		t.Fatalf("expected valid database name to succeed, got: %v", err)
+	}
+}
+
+// TestNewRejectsInvalidDatabaseName verifies direct constructor config validation.
+func TestNewRejectsInvalidDatabaseName(t *testing.T) {
+	_, err := New(
+		"localhost",
+		3306,
+		"root",
+		"",
+		"`bad`",
+		"",
+		"UTC",
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for database name with backticks, got nil")
+	}
+}
+
+// TestNewAllowsEmptyDatabaseNameDefault preserves the legacy empty-name default.
+func TestNewAllowsEmptyDatabaseNameDefault(t *testing.T) {
+	store, err := New(
+		"localhost",
+		3306,
+		"root",
+		"",
+		"",
+		"",
+		"UTC",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected empty database name to use default, got: %v", err)
+	}
+	if store.database != "mysql" {
+		t.Fatalf("expected default database name mysql, got %q", store.database)
+	}
+}
+
+// TestStartRejectsInvalidDatabaseNameFromDSN verifies DSN database validation.
+func TestStartRejectsInvalidDatabaseNameFromDSN(t *testing.T) {
+	store, err := NewWithOptions(
+		WithDSN("root:secret@tcp(localhost:3306)/bad`name?parseTime=true"),
+	)
+	if err != nil {
+		t.Fatalf("expected store creation to defer DSN database validation to start, got: %v", err)
+	}
+
+	err = store.Start()
+	if err == nil {
+		t.Fatal("expected error for DSN database name with backticks, got nil")
+	}
+	if !strings.Contains(err.Error(), "mysql config dsn") {
+		t.Fatalf("expected DSN config error, got: %v", err)
+	}
 }


### PR DESCRIPTION
1. Made changes to validate mysql database identifiers before any `CREATE DATABASE` SQL is built and rejected unsafe configured or DSN-derived names and cover backtick/unusual-character cases with tests.
2. Added validation to `direct New(...) `and `NewWithOptions(...) `config paths of mysql.
3. Added validation to DSN-derived database names using `mysql.ParseDSN`.
4. Added a final guard before `CREATE DATABASE IF NOT EXISTS`.
5. Added tests for valid names, backticks, unusual characters, DSN names, and empty-name default behavior.

Closes #2271 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate MySQL database names from config and DSN before building CREATE DATABASE to block unsafe identifiers and return clearer errors. Adds tests for valid names and edge cases like backticks, length, and unusual characters.

- **Bug Fixes**
  - Added strict validator (letters, digits, `_`, `-`; max 64 chars); rejects backticks and empty names.
  - Applied checks in `New(...)`, `NewWithOptions(...)` (when no DSN), DSN names in `Start()`, and before `CREATE DATABASE IF NOT EXISTS`.
  - Parse DSNs with `mysql.ParseDSN`; surface parse errors; keep empty-name default to `mysql`.
  - Tests for valid/invalid names, DSN names, length limit, and defaults.

<sup>Written for commit 79907083e95b3a61cf7113b237d344dc8a54e06d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for MySQL database names to reject empty values and unsupported characters.
  * Improved handling of database names supplied through connection settings, including clearer errors when a database name can’t be parsed.
  * Prevented invalid database names from being used during database creation or startup flows.

* **Tests**
  * Added coverage for valid and invalid database-name inputs, including cases with special characters and malformed connection strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->