### PR TITLE
fix(chain): binary search block index on heal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1043,7 +1043,12 @@ When a network config supplies a `CheckpointsFile` (mainnet and preview ship one
 The previous epoch's last-block hash is resolved through the active chain index
 (`chain.BlockBeforeSlot`), not a raw blob-store slot scan. Blob storage can
 retain synthetic endorser/genesis blobs and fork blobs that are useful for other
-storage paths but are not part of the selected chain.
+storage paths but are not part of the selected chain. Because block slots are
+strictly increasing with block index on the canonical chain, `BlockBeforeSlot`
+binary-searches the chain index for the boundary (O(log n) block reads) rather
+than walking backward from the tip; the walk previously scanned the entire
+header-ahead gap during catch-up and made the startup epoch-lab-nonce heal wedge
+large-DB startup for minutes (#2771).
 
 ### Ledger View
 

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1208,19 +1208,41 @@ func (c *Chain) BlockBeforeSlot(slotNumber uint64) (models.Block, error) {
 	if c.tipBlockIndex < initialBlockIndex {
 		return models.Block{}, models.ErrBlockNotFound
 	}
-	for blockIndex := c.tipBlockIndex; blockIndex >= initialBlockIndex; blockIndex-- {
-		block, err := c.blockByIndex(blockIndex)
+	// Block slots are strictly increasing with block index on the canonical
+	// chain, so binary-search for the highest index whose slot is below
+	// slotNumber rather than walking backward from the tip. The old linear walk
+	// cost O(tip - boundary) block reads; during catch-up the header chain runs
+	// far ahead of the ledger tip, so a boundary near the ledger tip made every
+	// lookup scan the entire header-ahead gap (the epoch-lab-nonce heal ran this
+	// per recent epoch, wedging large-DB startup for minutes — #2771). The
+	// search still resolves each candidate via blockByIndex (the active chain),
+	// so retained fork or synthetic blobs are never returned.
+	lo, hi := initialBlockIndex, c.tipBlockIndex
+	var (
+		result models.Block
+		found  bool
+	)
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		block, err := c.blockByIndex(mid)
 		if err != nil {
 			return models.Block{}, err
 		}
 		if block.Slot < slotNumber {
-			return block, nil
-		}
-		if blockIndex == initialBlockIndex {
-			break
+			result = block
+			found = true
+			lo = mid + 1
+		} else {
+			if mid == initialBlockIndex {
+				break
+			}
+			hi = mid - 1
 		}
 	}
-	return models.Block{}, models.ErrBlockNotFound
+	if !found {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	return result, nil
 }
 
 func (c *Chain) blockByIndex(

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -275,6 +275,67 @@ func TestChainBlockBeforeSlotUsesCanonicalChainIndex(t *testing.T) {
 	}
 }
 
+// TestChainBlockBeforeSlotBinarySearchBoundaries exercises the binary-search
+// boundary logic across a multi-block chain (testBlocks have slots 0, 20, 40,
+// 60, 80, 100): below all, at a block slot, between blocks, and above the tip.
+// It guards the #2771 change from the linear backward walk to a binary search.
+func TestChainBlockBeforeSlotBinarySearchBoundaries(t *testing.T) {
+	db, err := database.New(dbConfig)
+	if err != nil {
+		t.Fatalf("unexpected error creating database: %s", err)
+	}
+	defer db.Close()
+
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for i, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block %d: %s", i, err)
+		}
+	}
+
+	testCases := []struct {
+		name      string
+		slot      uint64
+		wantFound bool
+		wantSlot  uint64
+	}{
+		{name: "below all blocks", slot: 0, wantFound: false},
+		{name: "just above genesis", slot: 1, wantFound: true, wantSlot: 0},
+		{name: "at a block slot returns the prior block", slot: 20, wantFound: true, wantSlot: 0},
+		{name: "just above a block slot", slot: 21, wantFound: true, wantSlot: 20},
+		{name: "between blocks", slot: 55, wantFound: true, wantSlot: 40},
+		{name: "just above the tip", slot: 101, wantFound: true, wantSlot: 100},
+		{name: "far above the tip", slot: 100_000, wantFound: true, wantSlot: 100},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			block, err := c.BlockBeforeSlot(tc.slot)
+			if !tc.wantFound {
+				if !errors.Is(err, models.ErrBlockNotFound) {
+					t.Fatalf(
+						"slot %d: expected ErrBlockNotFound, got slot=%d err=%v",
+						tc.slot, block.Slot, err,
+					)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("slot %d: unexpected error: %s", tc.slot, err)
+			}
+			if block.Slot != tc.wantSlot {
+				t.Fatalf(
+					"slot %d: got block slot %d, want %d",
+					tc.slot, block.Slot, tc.wantSlot,
+				)
+			}
+		})
+	}
+}
+
 func TestChainIteratorReverseFromTipInclusive(t *testing.T) {
 	cm, err := chain.NewManager(nil, nil)
 	if err != nil {


### PR DESCRIPTION
Closes #2771 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix startup heal stalls by switching `BlockBeforeSlot` to a binary search over the canonical chain index, reducing lookups from O(n) to O(log n). This prevents large-DB startup wedges and addresses #2771.

- **Bug Fixes**
  - Replace linear walk with binary search in `chain.BlockBeforeSlot`, still resolving via `blockByIndex` to stay on the active chain.
  - Add boundary tests in `chain_test.go` for below/all, at-slot, between blocks, and above tip cases.
  - Update `ARCHITECTURE.md` to document the binary search approach and its performance rationale.

<sup>Written for commit ebc3cac90daaab2ddf7a92db3860df3143cc211d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

