### PR TITLE
feat(midnight): implement paginated UTxO query RPCs for MidnightState

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1759,12 +1759,22 @@ and governance state (`cNightUTxOs`, `regUTxOs`, `candidates`,
 `candidateRemovals`, `epochTransitions`, `lastAriadneDatum`, `currentEpoch`,
 `snapshotEpoch`) as they go, ahead of the write transaction's commit. To keep
 that memory from drifting ahead of the database when a later write in the
-same block fails, `processBlock` snapshots all of it
-(`snapshotMutableState`) before scanning any transactions and restores the
-snapshot (`restoreMutableState`) if it returns without committing — so a
+same block fails, `processBlock` opens a `blockMutationJournal`
+(`newBlockMutationJournal`) before scanning any transactions and undoes it
+(`undoBlockMutations`) if the block returns without committing — so a
 partially-processed, ultimately-rolled-back block leaves memory exactly as
 it was, rather than retaining mutations for rows the database never durably
-recorded.
+recorded. The journal records only each touched key's pre-block value (via
+a generic `mapJournal[K, V]`, the first time that key is touched in the
+block) rather than cloning `cNightUTxOs`/`regUTxOs`/`candidates` wholesale —
+those maps hold all actively tracked state for the whole chain, so a full
+clone would cost O(total live state) on every block instead of O(that
+block's own changes). `candidateRemovals`/`epochTransitions` are only ever
+written under the current block's own key while processing it, so the
+journal there is just that one key's pre-block value; the periodic pruning
+step that deletes older keys from both maps separately records exactly
+which entries it removes, so undo can restore them without journaling the
+maps' full contents either.
 
 **Startup and catch-up**: `node.go` calls
 `LedgerState.PrepareEpochCacheForStartup()`, then creates and starts the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -820,7 +820,10 @@ unrelated write-path/lifecycle methods) backs the five UTxO-event query RPCs
 `GetUtxoEvents` merge-sorts all four tables by
 `(block_number, tx_index, kind_order)` and returns a `next_position` cursor
 (see DATABASE.md's Midnight Indexer section for the merge algorithm,
-including how page cutoffs extend to avoid splitting a transaction's rows).
+including how page cutoffs extend to avoid splitting a transaction's rows,
+and for how write-side atomicity in the indexer and the read-side
+`ReadTransaction()` shared by `GetUtxoEvents`' four table reads together keep
+that cursor from skipping rows while the live indexer is mid-block).
 `Config.BlockNumberByHash` (set to a closure over `database.BlockByHash` in
 `node.go`) resolves `GetUtxoEvents`' `end_block_hash` to a block number
 independent of the fetched event rows, so the boundary is honored even for a
@@ -1728,15 +1731,28 @@ An optional block scanner that indexes Midnight chain events into multiple
   snapshots created by the rolled-back block before readers can observe stale
   `midnight_epoch_candidates` rows.
 
-**Epoch tracking**: The indexer subscribes to `epoch.transition`
-(`event.EpochTransitionEventType`) as well as block events. Before scanning the
-first block of a new epoch, `handleBlockEvent` calls `advanceEpochLocked` to
-snapshot any skipped epochs and update `currentEpoch`. A late or duplicate
-`epoch.transition` event is ignored when the epoch has already been snapshotted
-by the block-event path (`hasSnapshotEpoch` guard). On cold start
-(`hasCurrentEpoch = false`), the first block's epoch is recorded without
-snapshotting so no spurious empty snapshot is written before any candidates are
-observed.
+**Epoch tracking**: `processBlock` resolves and advances the epoch (via
+`advanceEpochLocked`) for every block, on both the live event path and the
+backfill path (both call `processBlock`, which is the single place this
+happens — there is no separate epoch-event subscription). `advanceEpochLocked`
+snapshots any skipped epochs before updating `currentEpoch`; a repeated call
+for an epoch already snapshotted is a no-op (`hasSnapshotEpoch` guard). On
+cold start (`hasCurrentEpoch = false`), the first block's epoch is recorded
+without snapshotting so no spurious empty snapshot is written before any
+candidates are observed.
+
+**Write atomicity**: `processBlock` opens one write transaction
+(`Metadata.Transaction()`) and threads it through every `Create*`/
+`InsertMidnightGovernanceDatum`/`UpsertMidnightAriadneParams`/
+`UpsertMidnightEpochCandidates` call it makes while scanning the block —
+including the epoch-advance snapshot above — committing once at the end and
+rolling back on any error. This closes a race that independent per-row
+autocommit writes would otherwise leave open: `(block_number, tx_index)` is
+not a unique key (one tx can write more than one row to the same table), so
+a reader paginating by that cursor could see one row for a key, advance past
+it, and permanently miss a sibling row for the same key committed moments
+later. See DATABASE.md's Midnight Indexer section for how this pairs with
+`GetUtxoEvents`' shared `ReadTransaction()` on the read side.
 
 **Startup and catch-up**: `node.go` calls
 `LedgerState.PrepareEpochCacheForStartup()`, then creates and starts the
@@ -1750,9 +1766,11 @@ same scan logic before subscribing to live events. The checkpoint (phase
 is stored in the `backfill_checkpoint` table via `SetBackfillCheckpoint` and is
 updated after each block — both during backfill and for each live event. Because
 the checkpoint write and the block's `Create*` writes are separate (not
-transactional), a crash between the two causes at most one block to be
-re-processed on the next restart: the block whose rows were written but whose
-checkpoint update did not commit. All four `Create*` methods use
+transactional — the block's writes are their own single transaction per Write
+atomicity above, but the checkpoint commits afterward in a second, separate
+one), a crash between the two causes at most one block to be re-processed on
+the next restart: the block whose rows were written but whose checkpoint
+update did not commit. All four `Create*` methods use
 `ON CONFLICT DO NOTHING` against the unique indexes on the UTxO natural keys
 (`tx_hash + output_index` / `utxo_tx_hash + utxo_index`), so re-processing an
 already-indexed block is safe and produces no duplicate rows.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -809,12 +809,19 @@ In `storageMode: api` with `midnight.port > 0`, `node.go` starts
 ConnectRPC, for byte-for-byte compatibility with the Acropolis tonic service)
 on its own `midnight.host:midnight.port` listener. It registers the
 `MidnightState` service, plus gRPC reflection and a `grpc_health_v1` health
-service reporting `SERVING`. The compatibility surface is still incomplete:
-merged work covers server lifecycle and block scanning, while the remaining RPC
-bodies are tracked by the Midnight plan and issues #2118/#2119. TLS is enabled
-when the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start` binds the
-listener synchronously (so bind/cert errors surface immediately) and serves in
-a goroutine; a context watcher performs a bounded `GracefulStop`, escalating to
+service reporting `SERVING`. `Config.Metadata` (set to `n.db.Metadata()` in
+`node.go`) backs the five UTxO-event query RPCs — `GetAssetCreates`,
+`GetAssetSpends`, `GetRegistrations`, `GetDeregistrations`, and
+`GetUtxoEvents` — implemented in `midnight/server/midnight_state.go`; the
+first four page a single `midnight_*` table forward from a
+`(start_block, start_tx_index)` cursor, and `GetUtxoEvents` merge-sorts all
+four tables by `(block_number, tx_index, kind_order)` and returns a
+`next_position` cursor (see DATABASE.md's Midnight Indexer section for the
+merge algorithm). The remaining RPC bodies are still incomplete, tracked by
+the Midnight plan and issues #2118/#2119. TLS is enabled when the shared
+`tlsCertFilePath`/`tlsKeyFilePath` are set. `Start` binds the listener
+synchronously (so bind/cert errors surface immediately) and serves in a
+goroutine; a context watcher performs a bounded `GracefulStop`, escalating to
 a hard `Stop` on timeout. Setting `midnight.port` to `0` disables the server
 without affecting indexer eligibility.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1754,6 +1754,18 @@ it, and permanently miss a sibling row for the same key committed moments
 later. See DATABASE.md's Midnight Indexer section for how this pairs with
 `GetUtxoEvents`' shared `ReadTransaction()` on the read side.
 
+`processTx`/`processOutput` also mutate the indexer's in-memory tracked-UTxO
+and governance state (`cNightUTxOs`, `regUTxOs`, `candidates`,
+`candidateRemovals`, `epochTransitions`, `lastAriadneDatum`, `currentEpoch`,
+`snapshotEpoch`) as they go, ahead of the write transaction's commit. To keep
+that memory from drifting ahead of the database when a later write in the
+same block fails, `processBlock` snapshots all of it
+(`snapshotMutableState`) before scanning any transactions and restores the
+snapshot (`restoreMutableState`) if it returns without committing — so a
+partially-processed, ultimately-rolled-back block leaves memory exactly as
+it was, rather than retaining mutations for rows the database never durably
+recorded.
+
 **Startup and catch-up**: `node.go` calls
 `LedgerState.PrepareEpochCacheForStartup()`, then creates and starts the
 indexer (via `Start()`) *before* `LedgerState.Start()`, so backfill can resolve

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -810,20 +810,33 @@ ConnectRPC, for byte-for-byte compatibility with the Acropolis tonic service)
 on its own `midnight.host:midnight.port` listener. It registers the
 `MidnightState` service, plus gRPC reflection and a `grpc_health_v1` health
 service reporting `SERVING`. `Config.Metadata` (set to `n.db.Metadata()` in
-`node.go`) backs the five UTxO-event query RPCs — `GetAssetCreates`,
-`GetAssetSpends`, `GetRegistrations`, `GetDeregistrations`, and
-`GetUtxoEvents` — implemented in `midnight/server/midnight_state.go`; the
-first four page a single `midnight_*` table forward from a
-`(start_block, start_tx_index)` cursor, and `GetUtxoEvents` merge-sorts all
-four tables by `(block_number, tx_index, kind_order)` and returns a
-`next_position` cursor (see DATABASE.md's Midnight Indexer section for the
-merge algorithm). The remaining RPC bodies are still incomplete, tracked by
-the Midnight plan and issues #2118/#2119. TLS is enabled when the shared
-`tlsCertFilePath`/`tlsKeyFilePath` are set. `Start` binds the listener
-synchronously (so bind/cert errors surface immediately) and serves in a
-goroutine; a context watcher performs a bounded `GracefulStop`, escalating to
-a hard `Stop` on timeout. Setting `midnight.port` to `0` disables the server
-without affecting indexer eligibility.
+`node.go`, typed as a package-local `eventStore` interface rather than the
+full `metadata.MetadataStore` so this gRPC-query package doesn't carry
+unrelated write-path/lifecycle methods) backs the five UTxO-event query RPCs
+— `GetAssetCreates`, `GetAssetSpends`, `GetRegistrations`,
+`GetDeregistrations`, and `GetUtxoEvents` — implemented in
+`midnight/server/midnight_state.go`; the first four page a single
+`midnight_*` table forward from a `(start_block, start_tx_index)` cursor, and
+`GetUtxoEvents` merge-sorts all four tables by
+`(block_number, tx_index, kind_order)` and returns a `next_position` cursor
+(see DATABASE.md's Midnight Indexer section for the merge algorithm,
+including how page cutoffs extend to avoid splitting a transaction's rows).
+`Config.BlockNumberByHash` (set to a closure over `database.BlockByHash` in
+`node.go`) resolves `GetUtxoEvents`' `end_block_hash` to a block number
+independent of the fetched event rows, so the boundary is honored even for a
+block with no Midnight events; `GetUtxoEvents` fails with
+`codes.FailedPrecondition` if `end_block_hash` is set but no resolver was
+configured. `utxo_capacity`/`tx_capacity` are clamped server-side
+(`effectivePageSize`) to a bounded default/max instead of being forwarded
+to the store, since the store's own pagination contract treats a
+non-positive limit as unbounded. The remaining RPC bodies are still
+incomplete, tracked by the Midnight plan and issues #2118/#2119. TLS is
+enabled when the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start`
+binds the listener synchronously (so bind/cert errors surface immediately)
+and serves in a goroutine; a context watcher performs a bounded
+`GracefulStop`, escalating to a hard `Stop` on timeout. Setting
+`midnight.port` to `0` disables the server without affecting indexer
+eligibility.
 
 ### Off-chain Metadata Fetching
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -276,6 +276,35 @@ Midnight events of its own. Both `utxo_capacity` and `tx_capacity` default to
 a bounded page size when omitted (proto3 zero value) and are clamped to a
 maximum, rather than being forwarded to the store as an unbounded scan.
 
+**Write-side atomicity.** All of one block's `midnight_*` writes — every
+`Create*`/`InsertMidnightGovernanceDatum`/`UpsertMidnightAriadneParams`/
+`UpsertMidnightEpochCandidates` call `processBlock` makes while scanning that
+block's transactions — share a single write transaction
+(`Metadata.Transaction()`), committed once at the end of `processBlock` and
+rolled back on any error. `(block_number, tx_index)` is not a unique key: one
+transaction can write more than one row to the same table (for example
+several cNIGHT outputs created in one tx, or a create and a registration in
+the same tx). Without this, a live indexer using independent autocommit
+writes could let a paginated reader observe one row for a key, advance its
+`start_block`/`start_tx_index` cursor past it, and then permanently miss a
+sibling row for that same key committed moments later — the per-table page
+and merge extensions described above only close pagination-boundary gaps
+*within* an already-fully-committed key, not gaps against a write still in
+flight.
+
+**Read-side consistency.** `GetUtxoEvents` opens one
+`Metadata.ReadTransaction()` and passes it to all four `Find*From` calls, so
+they observe a single consistent point in time instead of four independent
+reads that could each land on a different side of a live block commit (which
+would otherwise let the merged `next_position` cursor skip rows in whichever
+table hadn't yet reflected that commit at the time of its read).
+`ReadTransaction()` uses SQLite's WAL-mode snapshot semantics on that backend
+and an explicit `REPEATABLE READ` isolation level on Postgres/MySQL (the
+former's driver default, `READ COMMITTED`, would otherwise let two
+statements in the same read-only transaction observe different commits; the
+latter's session default already behaves this way, but is set explicitly
+rather than relied on).
+
 ### Stake Accounts and Certificate Tables
 
 | Table | Columns | Keys / indexes | Relationships and notes |

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -227,7 +227,7 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `DeleteMidnightAssetSpendsByBlock(txn, blockNumber)` | Deletes and returns all `midnight_asset_spends` rows for the given block. Used during chain rollback; caller restores the returned UTxOs to the in-memory set. |
 | `DeleteMidnightRegistrationsByBlock(txn, blockNumber)` | Deletes and returns all `midnight_registrations` rows for the given block. Used during chain rollback. |
 | `DeleteMidnightDeregistrationsByBlock(txn, blockNumber)` | Deletes and returns all `midnight_deregistrations` rows for the given block. Used during chain rollback; caller restores the returned reg UTxOs to the in-memory set. |
-| `FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, txn)` | Returns `midnight_asset_creates` rows with `(block_number, tx_index) > (startBlock, startTxIndex)`, ordered `block_number ASC, tx_index ASC`, capped at `limit` (`limit <= 0` means no SQL LIMIT). Backs the MidnightState `GetAssetCreates` RPC. |
+| `FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, txn)` | Returns `midnight_asset_creates` rows with `(block_number, tx_index) > (startBlock, startTxIndex)`, ordered `block_number ASC, tx_index ASC`, capped at `limit` (`limit <= 0` means no SQL LIMIT). May return more than `limit` rows: `(block_number, tx_index)` is not a unique key (one tx can write several rows to the same table), so a page that would otherwise end mid-key is extended, via `pagination.ExtendPageToFullTxGroup`, to include the rest of that key's rows — keeping the cursor gap-free instead of silently dropping the remainder on the next call. Backs the MidnightState `GetAssetCreates` RPC. |
 | `FindMidnightAssetSpendsFrom(startBlock, startTxIndex, limit, txn)` | Same cursor semantics as `FindMidnightAssetCreatesFrom`, over `midnight_asset_spends`. Backs `GetAssetSpends`. |
 | `FindMidnightRegistrationsFrom(startBlock, startTxIndex, limit, txn)` | Same cursor semantics as `FindMidnightAssetCreatesFrom`, over `midnight_registrations`. Backs `GetRegistrations`. |
 | `FindMidnightDeregistrationsFrom(startBlock, startTxIndex, limit, txn)` | Same cursor semantics as `FindMidnightAssetCreatesFrom`, over `midnight_deregistrations`. Backs `GetDeregistrations`. |
@@ -264,7 +264,17 @@ deregistration=3), applies `end_block_hash` truncation and the `tx_capacity`
 limit, and returns the last emitted row's position as `next_position`.
 Fetching each table's own top-`tx_capacity` rows is sufficient for a correct
 merge, since a row beyond that position in its own table cannot be among the
-global top `tx_capacity` results.
+global top `tx_capacity` results. Truncating to `tx_capacity` extends forward
+while the next item shares the cutoff's `(block_number, tx_index)` key, for
+the same reason the per-table `Find*From` methods extend a page: a single tx
+can write rows of more than one kind (e.g. a create and a registration), and
+cutting between them would silently drop the remainder. `end_block_hash` is
+resolved to a block number via the handler's configured block-hash resolver
+(`node.go` wires `database.BlockByHash`), not by scanning the fetched event
+rows, so the boundary is honored even when the target block carries no
+Midnight events of its own. Both `utxo_capacity` and `tx_capacity` default to
+a bounded page size when omitted (proto3 zero value) and are clamped to a
+maximum, rather than being forwarded to the store as an unbounded scan.
 
 ### Stake Accounts and Certificate Tables
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -227,6 +227,10 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `DeleteMidnightAssetSpendsByBlock(txn, blockNumber)` | Deletes and returns all `midnight_asset_spends` rows for the given block. Used during chain rollback; caller restores the returned UTxOs to the in-memory set. |
 | `DeleteMidnightRegistrationsByBlock(txn, blockNumber)` | Deletes and returns all `midnight_registrations` rows for the given block. Used during chain rollback. |
 | `DeleteMidnightDeregistrationsByBlock(txn, blockNumber)` | Deletes and returns all `midnight_deregistrations` rows for the given block. Used during chain rollback; caller restores the returned reg UTxOs to the in-memory set. |
+| `FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, txn)` | Returns `midnight_asset_creates` rows with `(block_number, tx_index) > (startBlock, startTxIndex)`, ordered `block_number ASC, tx_index ASC`, capped at `limit` (`limit <= 0` means no SQL LIMIT). Backs the MidnightState `GetAssetCreates` RPC. |
+| `FindMidnightAssetSpendsFrom(startBlock, startTxIndex, limit, txn)` | Same cursor semantics as `FindMidnightAssetCreatesFrom`, over `midnight_asset_spends`. Backs `GetAssetSpends`. |
+| `FindMidnightRegistrationsFrom(startBlock, startTxIndex, limit, txn)` | Same cursor semantics as `FindMidnightAssetCreatesFrom`, over `midnight_registrations`. Backs `GetRegistrations`. |
+| `FindMidnightDeregistrationsFrom(startBlock, startTxIndex, limit, txn)` | Same cursor semantics as `FindMidnightAssetCreatesFrom`, over `midnight_deregistrations`. Backs `GetDeregistrations`. |
 | `InsertMidnightGovernanceDatum(txn, *MidnightGovernanceDatum)` | Insert a governance datum row. Idempotent: silently ignores replay conflicts on `(datum_type, tx_hash, output_index)`; latest is found via `ORDER BY block_number DESC`. |
 | `DeleteMidnightGovernanceDatumsByBlock(txn, blockNumber)` | Deletes governance datum rows written by a rolled-back block. |
 | `GetLatestMidnightGovernanceDatum(datumType, blockNumber, txn)` | Returns the newest datum of `datumType` at or before `blockNumber`, or nil when none exist. |
@@ -251,6 +255,16 @@ and output index so identical sets produce identical CBOR.
 On startup, committee-candidate restoration reads live `utxo` rows and joins
 `utxo.datum_hash` to `datum.raw_datum`; it does not require block CBOR blobs
 to still be available.
+
+The MidnightState `GetUtxoEvents` RPC has no dedicated store method: the
+`midnight/server` handler calls the four `Find*From` methods above with the
+same cursor window, then merge-sorts the results in Go by
+`(block_number, tx_index, kind_order)` (create=0, spend=1, registration=2,
+deregistration=3), applies `end_block_hash` truncation and the `tx_capacity`
+limit, and returns the last emitted row's position as `next_position`.
+Fetching each table's own top-`tx_capacity` rows is sufficient for a correct
+merge, since a row beyond that position in its own table cannot be among the
+global top `tx_capacity` results.
 
 ### Stake Accounts and Certificate Tables
 

--- a/database/models/midnight.go
+++ b/database/models/midnight.go
@@ -36,6 +36,11 @@ func (MidnightAssetCreate) TableName() string {
 	return "midnight_asset_creates"
 }
 
+// BlockTxPosition implements pagination.BlockTxPositioned.
+func (r MidnightAssetCreate) BlockTxPosition() (blockNumber uint64, txIndex uint32) {
+	return r.BlockNumber, r.TxIndex
+}
+
 // MidnightAssetSpend stores cNIGHT UTxO spends for the Midnight indexer.
 type MidnightAssetSpend struct {
 	ID               uint   `gorm:"primarykey"`
@@ -54,6 +59,11 @@ func (MidnightAssetSpend) TableName() string {
 	return "midnight_asset_spends"
 }
 
+// BlockTxPosition implements pagination.BlockTxPositioned.
+func (r MidnightAssetSpend) BlockTxPosition() (blockNumber uint64, txIndex uint32) {
+	return r.BlockNumber, r.TxIndex
+}
+
 // MidnightRegistration stores mapping validator registration events.
 type MidnightRegistration struct {
 	ID               uint   `gorm:"primarykey"`
@@ -68,6 +78,11 @@ type MidnightRegistration struct {
 
 func (MidnightRegistration) TableName() string {
 	return "midnight_registrations"
+}
+
+// BlockTxPosition implements pagination.BlockTxPositioned.
+func (r MidnightRegistration) BlockTxPosition() (blockNumber uint64, txIndex uint32) {
+	return r.BlockNumber, r.TxIndex
 }
 
 // MidnightDeregistration stores mapping validator deregistration events.
@@ -85,6 +100,11 @@ type MidnightDeregistration struct {
 
 func (MidnightDeregistration) TableName() string {
 	return "midnight_deregistrations"
+}
+
+// BlockTxPosition implements pagination.BlockTxPositioned.
+func (r MidnightDeregistration) BlockTxPosition() (blockNumber uint64, txIndex uint32) {
+	return r.BlockNumber, r.TxIndex
 }
 
 // MidnightGovernanceDatum stores latest Technical Committee and Council datums.

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -591,9 +591,13 @@ func (d *MetadataStoreMysql) Transaction() types.Txn {
 	return newMysqlTxn(db)
 }
 
-// ReadTransaction creates a read-only transaction.
+// ReadTransaction creates a read-only transaction with repeatable-read
+// isolation, so every statement run through it observes one consistent
+// snapshot for its whole lifetime. InnoDB's session default is already
+// REPEATABLE READ, but setting it explicitly here does not depend on that
+// ambient session configuration.
 func (d *MetadataStoreMysql) ReadTransaction() types.Txn {
-	db := d.DB().Begin(&sql.TxOptions{ReadOnly: true})
+	db := d.DB().Begin(&sql.TxOptions{ReadOnly: true, Isolation: sql.LevelRepeatableRead})
 	if db.Error != nil {
 		d.logger.Error(
 			"failed to begin read transaction",

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -227,7 +227,7 @@ func (d *MetadataStoreMysql) FindMidnightAssetCreatesFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -257,7 +257,7 @@ func (d *MetadataStoreMysql) FindMidnightAssetSpendsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -287,7 +287,7 @@ func (d *MetadataStoreMysql) FindMidnightRegistrationsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -317,7 +317,7 @@ func (d *MetadataStoreMysql) FindMidnightDeregistrationsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/pagination"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"gorm.io/gorm"
@@ -207,6 +208,12 @@ func (d *MetadataStoreMysql) DeleteMidnightDeregistrationsByBlock(
 // FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// A page may return more than limit rows: (block_number, tx_index) is not a
+// unique key (a single tx can write multiple rows), so a page that would
+// otherwise cut a shared key in half is extended to include the rest of
+// that key's rows. This keeps the (start_block, start_tx_index) cursor
+// gap-free across pages.
 func (d *MetadataStoreMysql) FindMidnightAssetCreatesFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -228,12 +235,15 @@ func (d *MetadataStoreMysql) FindMidnightAssetCreatesFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStoreMysql) FindMidnightAssetSpendsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -255,12 +265,15 @@ func (d *MetadataStoreMysql) FindMidnightAssetSpendsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightRegistrationsFrom returns registration rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStoreMysql) FindMidnightRegistrationsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -282,12 +295,15 @@ func (d *MetadataStoreMysql) FindMidnightRegistrationsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightDeregistrationsFrom returns deregistration rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStoreMysql) FindMidnightDeregistrationsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -309,7 +325,7 @@ func (d *MetadataStoreMysql) FindMidnightDeregistrationsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 func (d *MetadataStoreMysql) GetMidnightCandidates(

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -204,6 +204,114 @@ func (d *MetadataStoreMysql) DeleteMidnightDeregistrationsByBlock(
 	return rows, nil
 }
 
+// FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreMysql) FindMidnightAssetCreatesFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetCreate, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightAssetCreate
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreMysql) FindMidnightAssetSpendsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetSpend, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightAssetSpend
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightRegistrationsFrom returns registration rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreMysql) FindMidnightRegistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightRegistration, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightRegistration
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightDeregistrationsFrom returns deregistration rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreMysql) FindMidnightDeregistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightDeregistration, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightDeregistration
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
 func (d *MetadataStoreMysql) GetMidnightCandidates(
 	addr ledger.Address,
 	txn types.Txn,

--- a/database/plugin/metadata/pagination/pagination.go
+++ b/database/plugin/metadata/pagination/pagination.go
@@ -46,6 +46,10 @@ type BlockTxPositioned interface {
 // WHERE/ORDER conditions from the caller's own query — GORM chain calls
 // clone rather than mutate, so reusing the handle that ran that query is
 // safe.
+//
+// The replacement group is ordered by id ASC, so repeated calls for the
+// same page return the tied rows in the same order — every current caller's
+// row model has an auto-increment "id" primary key column.
 func ExtendPageToFullTxGroup[T BlockTxPositioned](
 	db *gorm.DB,
 	rows []T,
@@ -66,6 +70,7 @@ func ExtendPageToFullTxGroup[T BlockTxPositioned](
 	}
 	var group []T
 	if err := db.Where("block_number = ? AND tx_index = ?", lastBlock, lastTx).
+		Order("id ASC").
 		Find(&group).Error; err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/pagination/pagination.go
+++ b/database/plugin/metadata/pagination/pagination.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pagination holds cursor-pagination helpers shared by the
+// metadata plugin backends (sqlite, postgres, mysql). It lives outside the
+// metadata package itself because that package blank-imports the backends
+// for plugin registration; a backend importing metadata back would cycle.
+package pagination
+
+import "gorm.io/gorm"
+
+// BlockTxPositioned is implemented by row models that carry a
+// (block_number, tx_index) cursor position, e.g. the midnight_* UTxO-event
+// tables.
+type BlockTxPositioned interface {
+	BlockTxPosition() (blockNumber uint64, txIndex uint32)
+}
+
+// ExtendPageToFullTxGroup re-queries db for every row sharing the last row's
+// (block_number, tx_index) key and appends any rows from that group not
+// already present in rows.
+//
+// (block_number, tx_index) is not a unique key in the midnight_* tables: a
+// single transaction can write more than one row to the same table (for
+// example several cNIGHT outputs created in one tx). If a page's SQL LIMIT
+// lands in the middle of such a group, a cursor that resumes strictly after
+// (block_number, tx_index) would silently skip the remaining rows in that
+// group forever. Extending the page to the end of the group closes that
+// gap, at the cost of an occasional page slightly larger than the
+// requested limit.
+//
+// rows must already be ordered ascending by (block_number, tx_index) and
+// contain exactly limit rows (the function is a no-op otherwise, since a
+// short page cannot have been cut mid-group). db must carry no lingering
+// WHERE/ORDER conditions from the caller's own query — GORM chain calls
+// clone rather than mutate, so reusing the handle that ran that query is
+// safe.
+func ExtendPageToFullTxGroup[T BlockTxPositioned](
+	db *gorm.DB,
+	rows []T,
+	limit int,
+) ([]T, error) {
+	if limit <= 0 || len(rows) != limit {
+		return rows, nil
+	}
+	n := len(rows)
+	lastBlock, lastTx := rows[n-1].BlockTxPosition()
+	tail := 1
+	for tail < n {
+		b, tx := rows[n-1-tail].BlockTxPosition()
+		if b != lastBlock || tx != lastTx {
+			break
+		}
+		tail++
+	}
+	var group []T
+	if err := db.Where("block_number = ? AND tx_index = ?", lastBlock, lastTx).
+		Find(&group).Error; err != nil {
+		return nil, err
+	}
+	if len(group) <= tail {
+		return rows, nil
+	}
+	extended := make([]T, 0, n-tail+len(group))
+	extended = append(extended, rows[:n-tail]...)
+	extended = append(extended, group...)
+	return extended, nil
+}

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -435,9 +435,15 @@ func (d *MetadataStorePostgres) Transaction() types.Txn {
 	return newPostgresTxn(db)
 }
 
-// ReadTransaction creates a read-only transaction.
+// ReadTransaction creates a read-only transaction with repeatable-read
+// isolation, so every statement run through it observes one consistent
+// snapshot for its whole lifetime instead of the server default (READ
+// COMMITTED), under which two statements in the same read-only transaction
+// can otherwise observe different commits. Read-only REPEATABLE READ
+// transactions cannot hit serialization failures (there is nothing for them
+// to conflict with), so this raises consistency at no retry cost.
 func (d *MetadataStorePostgres) ReadTransaction() types.Txn {
-	db := d.DB().Begin(&sql.TxOptions{ReadOnly: true})
+	db := d.DB().Begin(&sql.TxOptions{ReadOnly: true, Isolation: sql.LevelRepeatableRead})
 	if db.Error != nil {
 		d.logger.Error(
 			"failed to begin read transaction",

--- a/database/plugin/metadata/postgres/midnight.go
+++ b/database/plugin/metadata/postgres/midnight.go
@@ -227,7 +227,7 @@ func (d *MetadataStorePostgres) FindMidnightAssetCreatesFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -257,7 +257,7 @@ func (d *MetadataStorePostgres) FindMidnightAssetSpendsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -287,7 +287,7 @@ func (d *MetadataStorePostgres) FindMidnightRegistrationsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -317,7 +317,7 @@ func (d *MetadataStorePostgres) FindMidnightDeregistrationsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}

--- a/database/plugin/metadata/postgres/midnight.go
+++ b/database/plugin/metadata/postgres/midnight.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/pagination"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"gorm.io/gorm"
@@ -207,6 +208,12 @@ func (d *MetadataStorePostgres) DeleteMidnightDeregistrationsByBlock(
 // FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// A page may return more than limit rows: (block_number, tx_index) is not a
+// unique key (a single tx can write multiple rows), so a page that would
+// otherwise cut a shared key in half is extended to include the rest of
+// that key's rows. This keeps the (start_block, start_tx_index) cursor
+// gap-free across pages.
 func (d *MetadataStorePostgres) FindMidnightAssetCreatesFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -228,12 +235,15 @@ func (d *MetadataStorePostgres) FindMidnightAssetCreatesFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStorePostgres) FindMidnightAssetSpendsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -255,12 +265,15 @@ func (d *MetadataStorePostgres) FindMidnightAssetSpendsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightRegistrationsFrom returns registration rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStorePostgres) FindMidnightRegistrationsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -282,12 +295,15 @@ func (d *MetadataStorePostgres) FindMidnightRegistrationsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightDeregistrationsFrom returns deregistration rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStorePostgres) FindMidnightDeregistrationsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -309,7 +325,7 @@ func (d *MetadataStorePostgres) FindMidnightDeregistrationsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 func (d *MetadataStorePostgres) GetMidnightCandidates(

--- a/database/plugin/metadata/postgres/midnight.go
+++ b/database/plugin/metadata/postgres/midnight.go
@@ -204,6 +204,114 @@ func (d *MetadataStorePostgres) DeleteMidnightDeregistrationsByBlock(
 	return rows, nil
 }
 
+// FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStorePostgres) FindMidnightAssetCreatesFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetCreate, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightAssetCreate
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStorePostgres) FindMidnightAssetSpendsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetSpend, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightAssetSpend
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightRegistrationsFrom returns registration rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStorePostgres) FindMidnightRegistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightRegistration, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightRegistration
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightDeregistrationsFrom returns deregistration rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStorePostgres) FindMidnightDeregistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightDeregistration, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightDeregistration
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
 func (d *MetadataStorePostgres) GetMidnightCandidates(
 	addr ledger.Address,
 	txn types.Txn,

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -707,7 +707,11 @@ func (d *MetadataStoreSqlite) Transaction() types.Txn {
 // ReadTransaction creates a read-only transaction using the read
 // connection pool. For file-based databases this avoids contending
 // with the write connection; for in-memory databases it falls back
-// to the write connection.
+// to the write connection. No explicit isolation level is needed here
+// (unlike the postgres/mysql implementations): SQLite's WAL journal mode
+// (enabled for every file-based database this store opens) gives a
+// transaction a consistent snapshot for its whole lifetime as soon as its
+// first statement runs, regardless of concurrent writers.
 func (d *MetadataStoreSqlite) ReadTransaction() types.Txn {
 	db := d.ReadDB().Begin()
 	if db.Error != nil {

--- a/database/plugin/metadata/sqlite/midnight.go
+++ b/database/plugin/metadata/sqlite/midnight.go
@@ -202,6 +202,114 @@ func (d *MetadataStoreSqlite) DeleteMidnightDeregistrationsByBlock(
 	return rows, nil
 }
 
+// FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreSqlite) FindMidnightAssetCreatesFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetCreate, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightAssetCreate
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreSqlite) FindMidnightAssetSpendsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetSpend, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightAssetSpend
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightRegistrationsFrom returns registration rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreSqlite) FindMidnightRegistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightRegistration, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightRegistration
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// FindMidnightDeregistrationsFrom returns deregistration rows ordered by
+// (block_number, tx_index) ascending, starting strictly after
+// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+func (d *MetadataStoreSqlite) FindMidnightDeregistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightDeregistration, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	query := db.Where(
+		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
+		startBlock, startBlock, startTxIndex,
+	).Order("block_number ASC, tx_index ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var rows []models.MidnightDeregistration
+	if err := query.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
 func (d *MetadataStoreSqlite) GetMidnightCandidates(
 	addr ledger.Address,
 	txn types.Txn,

--- a/database/plugin/metadata/sqlite/midnight.go
+++ b/database/plugin/metadata/sqlite/midnight.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/pagination"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"gorm.io/gorm"
@@ -205,6 +206,12 @@ func (d *MetadataStoreSqlite) DeleteMidnightDeregistrationsByBlock(
 // FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// A page may return more than limit rows: (block_number, tx_index) is not a
+// unique key (a single tx can write multiple rows), so a page that would
+// otherwise cut a shared key in half is extended to include the rest of
+// that key's rows. This keeps the (start_block, start_tx_index) cursor
+// gap-free across pages.
 func (d *MetadataStoreSqlite) FindMidnightAssetCreatesFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -226,12 +233,15 @@ func (d *MetadataStoreSqlite) FindMidnightAssetCreatesFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStoreSqlite) FindMidnightAssetSpendsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -253,12 +263,15 @@ func (d *MetadataStoreSqlite) FindMidnightAssetSpendsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightRegistrationsFrom returns registration rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStoreSqlite) FindMidnightRegistrationsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -280,12 +293,15 @@ func (d *MetadataStoreSqlite) FindMidnightRegistrationsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 // FindMidnightDeregistrationsFrom returns deregistration rows ordered by
 // (block_number, tx_index) ascending, starting strictly after
 // (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+//
+// See FindMidnightAssetCreatesFrom for why a page may return more than
+// limit rows.
 func (d *MetadataStoreSqlite) FindMidnightDeregistrationsFrom(
 	startBlock uint64,
 	startTxIndex uint32,
@@ -307,7 +323,7 @@ func (d *MetadataStoreSqlite) FindMidnightDeregistrationsFrom(
 	if err := query.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	return rows, nil
+	return pagination.ExtendPageToFullTxGroup(db, rows, limit)
 }
 
 func (d *MetadataStoreSqlite) GetMidnightCandidates(

--- a/database/plugin/metadata/sqlite/midnight.go
+++ b/database/plugin/metadata/sqlite/midnight.go
@@ -225,7 +225,7 @@ func (d *MetadataStoreSqlite) FindMidnightAssetCreatesFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -255,7 +255,7 @@ func (d *MetadataStoreSqlite) FindMidnightAssetSpendsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -285,7 +285,7 @@ func (d *MetadataStoreSqlite) FindMidnightRegistrationsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
@@ -315,7 +315,7 @@ func (d *MetadataStoreSqlite) FindMidnightDeregistrationsFrom(
 	query := db.Where(
 		"(block_number > ?) OR (block_number = ? AND tx_index > ?)",
 		startBlock, startBlock, startTxIndex,
-	).Order("block_number ASC, tx_index ASC")
+	).Order("block_number ASC, tx_index ASC, id ASC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}

--- a/database/plugin/metadata/sqlite/midnight_pagination_test.go
+++ b/database/plugin/metadata/sqlite/midnight_pagination_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// hashFor returns a deterministic 32-byte hash so unique-index columns
+// (tx_hash, utxo_tx_hash) never collide across fixture rows.
+func hashFor(b byte) []byte {
+	h := make([]byte, 32)
+	h[31] = b
+	return h
+}
+
+func TestFindMidnightPaginated_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	creates, err := store.FindMidnightAssetCreatesFrom(0, 0, 10, nil)
+	require.NoError(t, err)
+	require.Empty(t, creates)
+
+	spends, err := store.FindMidnightAssetSpendsFrom(0, 0, 10, nil)
+	require.NoError(t, err)
+	require.Empty(t, spends)
+
+	registrations, err := store.FindMidnightRegistrationsFrom(0, 0, 10, nil)
+	require.NoError(t, err)
+	require.Empty(t, registrations)
+
+	deregistrations, err := store.FindMidnightDeregistrationsFrom(0, 0, 10, nil)
+	require.NoError(t, err)
+	require.Empty(t, deregistrations)
+}
+
+// TestFindMidnightAssetCreatesFrom_CursorPagination inserts rows spanning
+// several (block_number, tx_index) pairs, including multiple rows in the
+// same block, and pages through them with a small page size. It asserts the
+// pages cover every row exactly once, in (block_number, tx_index) order,
+// with no duplicates and no gaps.
+func TestFindMidnightAssetCreatesFrom_CursorPagination(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	type pos struct {
+		block uint64
+		tx    uint32
+	}
+	fixture := []pos{{1, 0}, {1, 1}, {2, 0}, {2, 1}, {3, 0}}
+	for i, p := range fixture {
+		require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+			Address:     []byte{0x01},
+			Quantity:    uint64(i + 1),
+			TxHash:      hashFor(byte(i + 1)),
+			OutputIndex: 0,
+			BlockNumber: p.block,
+			BlockHash:   hashFor(byte(p.block)),
+			TxIndex:     p.tx,
+		}))
+	}
+
+	const pageSize = 2
+	var startBlock uint64
+	var startTxIndex uint32
+	var got []pos
+	for range len(fixture) + 1 { // +1 guards against an infinite loop on a bug
+		page, err := store.FindMidnightAssetCreatesFrom(startBlock, startTxIndex, pageSize, nil)
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+		require.LessOrEqual(t, len(page), pageSize)
+		for _, row := range page {
+			got = append(got, pos{row.BlockNumber, row.TxIndex})
+		}
+		last := page[len(page)-1]
+		startBlock, startTxIndex = last.BlockNumber, last.TxIndex
+	}
+
+	require.Equal(t, fixture, got, "pages must cover every row exactly once, in order, with no gaps")
+}
+
+func TestFindMidnightAssetSpendsFrom_CursorPagination(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	for i, p := range []struct {
+		block uint64
+		tx    uint32
+	}{{1, 0}, {2, 0}, {2, 1}} {
+		require.NoError(t, store.CreateMidnightAssetSpend(nil, &models.MidnightAssetSpend{
+			Address:        []byte{0x01},
+			Quantity:       uint64(i + 1),
+			SpendingTxHash: hashFor(byte(i + 1)),
+			UtxoTxHash:     hashFor(byte(i + 10)),
+			UtxoIndex:      0,
+			BlockNumber:    p.block,
+			BlockHash:      hashFor(byte(p.block)),
+			TxIndex:        p.tx,
+		}))
+	}
+
+	page1, err := store.FindMidnightAssetSpendsFrom(0, 0, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+	require.Equal(t, uint64(1), page1[0].BlockNumber)
+	require.Equal(t, uint64(2), page1[1].BlockNumber)
+	require.Equal(t, uint32(0), page1[1].TxIndex)
+
+	last := page1[len(page1)-1]
+	page2, err := store.FindMidnightAssetSpendsFrom(last.BlockNumber, last.TxIndex, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page2, 1)
+	require.Equal(t, uint64(2), page2[0].BlockNumber)
+	require.Equal(t, uint32(1), page2[0].TxIndex)
+
+	page3, err := store.FindMidnightAssetSpendsFrom(
+		page2[0].BlockNumber,
+		page2[0].TxIndex,
+		2,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, page3)
+}
+
+func TestFindMidnightRegistrationsFrom_CursorPagination(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	for i, p := range []struct {
+		block uint64
+		tx    uint32
+	}{{1, 0}, {2, 0}, {2, 1}} {
+		require.NoError(t, store.CreateMidnightRegistration(nil, &models.MidnightRegistration{
+			FullDatum:   []byte{byte(i + 1)},
+			TxHash:      hashFor(byte(i + 1)),
+			OutputIndex: 0,
+			BlockNumber: p.block,
+			BlockHash:   hashFor(byte(p.block)),
+			TxIndex:     p.tx,
+		}))
+	}
+
+	page1, err := store.FindMidnightRegistrationsFrom(0, 0, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+
+	last := page1[len(page1)-1]
+	page2, err := store.FindMidnightRegistrationsFrom(last.BlockNumber, last.TxIndex, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page2, 1)
+	require.Equal(t, uint64(2), page2[0].BlockNumber)
+	require.Equal(t, uint32(1), page2[0].TxIndex)
+}
+
+func TestFindMidnightDeregistrationsFrom_CursorPagination(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	for i, p := range []struct {
+		block uint64
+		tx    uint32
+	}{{1, 0}, {2, 0}, {2, 1}} {
+		require.NoError(t, store.CreateMidnightDeregistration(nil, &models.MidnightDeregistration{
+			FullDatum:   []byte{byte(i + 1)},
+			TxHash:      hashFor(byte(i + 1)),
+			UtxoTxHash:  hashFor(byte(i + 10)),
+			UtxoIndex:   0,
+			BlockNumber: p.block,
+			BlockHash:   hashFor(byte(p.block)),
+			TxIndex:     p.tx,
+		}))
+	}
+
+	page1, err := store.FindMidnightDeregistrationsFrom(0, 0, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+
+	last := page1[len(page1)-1]
+	page2, err := store.FindMidnightDeregistrationsFrom(last.BlockNumber, last.TxIndex, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page2, 1)
+	require.Equal(t, uint64(2), page2[0].BlockNumber)
+	require.Equal(t, uint32(1), page2[0].TxIndex)
+}
+
+// TestFindMidnightAssetCreatesFrom_NoLimit verifies limit <= 0 returns every
+// matching row without a SQL LIMIT applied.
+func TestFindMidnightAssetCreatesFrom_NoLimit(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	for i := range 5 {
+		require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+			Address:     []byte{0x01},
+			Quantity:    1,
+			TxHash:      hashFor(byte(i + 1)),
+			OutputIndex: 0,
+			BlockNumber: uint64(i + 1),
+			BlockHash:   hashFor(byte(i + 1)),
+			TxIndex:     0,
+		}))
+	}
+
+	rows, err := store.FindMidnightAssetCreatesFrom(0, 0, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, rows, 5)
+}

--- a/database/plugin/metadata/sqlite/midnight_pagination_test.go
+++ b/database/plugin/metadata/sqlite/midnight_pagination_test.go
@@ -248,6 +248,38 @@ func TestFindMidnightAssetCreatesFrom_ExtendsPastLimitWithinSameTx(t *testing.T)
 	require.Equal(t, uint64(2), next[0].BlockNumber)
 }
 
+// TestFindMidnightAssetCreatesFrom_ExtendedGroupOrderIsDeterministic
+// verifies that repeated calls returning the same extended tx group return
+// its rows in the same order (id ASC), not whatever order the database
+// happens to produce for an unordered scan.
+func TestFindMidnightAssetCreatesFrom_ExtendedGroupOrderIsDeterministic(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	const groupSize = 8
+	for i := range groupSize {
+		require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+			Address:     []byte{0x01},
+			Quantity:    uint64(i + 1),
+			TxHash:      hashFor(1),
+			OutputIndex: uint32(i),
+			BlockNumber: 1,
+			BlockHash:   hashFor(1),
+			TxIndex:     0,
+		}))
+	}
+
+	first, err := store.FindMidnightAssetCreatesFrom(0, 0, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, first, groupSize)
+
+	for range 5 {
+		again, err := store.FindMidnightAssetCreatesFrom(0, 0, 2, nil)
+		require.NoError(t, err)
+		require.Equal(t, first, again, "repeated calls must return the extended group in the same order")
+	}
+}
+
 // TestFindMidnightAssetCreatesFrom_NoLimit verifies limit <= 0 returns every
 // matching row without a SQL LIMIT applied.
 func TestFindMidnightAssetCreatesFrom_NoLimit(t *testing.T) {

--- a/database/plugin/metadata/sqlite/midnight_pagination_test.go
+++ b/database/plugin/metadata/sqlite/midnight_pagination_test.go
@@ -202,6 +202,52 @@ func TestFindMidnightDeregistrationsFrom_CursorPagination(t *testing.T) {
 	require.Equal(t, uint32(1), page2[0].TxIndex)
 }
 
+// TestFindMidnightAssetCreatesFrom_ExtendsPastLimitWithinSameTx verifies
+// that when a page's LIMIT would otherwise land in the middle of a single
+// transaction's rows (one tx can create several cNIGHT outputs), the page
+// is extended to include the rest of that transaction's rows rather than
+// silently dropping them on the next call.
+func TestFindMidnightAssetCreatesFrom_ExtendsPastLimitWithinSameTx(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	// tx (1,0) has 3 outputs; tx (2,0) has 1.
+	for i := range 3 {
+		require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+			Address:     []byte{0x01},
+			Quantity:    uint64(i + 1),
+			TxHash:      hashFor(1),
+			OutputIndex: uint32(i),
+			BlockNumber: 1,
+			BlockHash:   hashFor(1),
+			TxIndex:     0,
+		}))
+	}
+	require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+		Address:     []byte{0x01},
+		Quantity:    99,
+		TxHash:      hashFor(2),
+		OutputIndex: 0,
+		BlockNumber: 2,
+		BlockHash:   hashFor(2),
+		TxIndex:     0,
+	}))
+
+	page, err := store.FindMidnightAssetCreatesFrom(0, 0, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, page, 3, "page must extend past limit=2 to include the full (1,0) tx group")
+	for _, row := range page {
+		require.Equal(t, uint64(1), row.BlockNumber)
+		require.Equal(t, uint32(0), row.TxIndex)
+	}
+
+	last := page[len(page)-1]
+	next, err := store.FindMidnightAssetCreatesFrom(last.BlockNumber, last.TxIndex, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, next, 1, "resuming after the extended page must not repeat any row and must find tx (2,0)")
+	require.Equal(t, uint64(2), next[0].BlockNumber)
+}
+
 // TestFindMidnightAssetCreatesFrom_NoLimit verifies limit <= 0 returns every
 // matching row without a SQL LIMIT applied.
 func TestFindMidnightAssetCreatesFrom_NoLimit(t *testing.T) {

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -159,6 +159,10 @@ type MetadataStore interface {
 	// FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
 	// (block_number, tx_index) ascending, starting strictly after
 	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+	// The result may hold more than limit rows: (block_number, tx_index) is
+	// not a unique key (one tx can write several rows to the same table),
+	// so implementations extend a page that would otherwise end mid-key to
+	// include the rest of that key's rows, keeping the cursor gap-free.
 	// Used to serve the MidnightState GetAssetCreates RPC.
 	FindMidnightAssetCreatesFrom(
 		startBlock uint64,
@@ -170,7 +174,8 @@ type MetadataStore interface {
 	// FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
 	// (block_number, tx_index) ascending, starting strictly after
 	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
-	// Used to serve the MidnightState GetAssetSpends RPC.
+	// See FindMidnightAssetCreatesFrom for why the result may hold more
+	// than limit rows. Used to serve the MidnightState GetAssetSpends RPC.
 	FindMidnightAssetSpendsFrom(
 		startBlock uint64,
 		startTxIndex uint32,
@@ -181,7 +186,8 @@ type MetadataStore interface {
 	// FindMidnightRegistrationsFrom returns registration rows ordered by
 	// (block_number, tx_index) ascending, starting strictly after
 	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
-	// Used to serve the MidnightState GetRegistrations RPC.
+	// See FindMidnightAssetCreatesFrom for why the result may hold more
+	// than limit rows. Used to serve the MidnightState GetRegistrations RPC.
 	FindMidnightRegistrationsFrom(
 		startBlock uint64,
 		startTxIndex uint32,
@@ -192,7 +198,9 @@ type MetadataStore interface {
 	// FindMidnightDeregistrationsFrom returns deregistration rows ordered by
 	// (block_number, tx_index) ascending, starting strictly after
 	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
-	// Used to serve the MidnightState GetDeregistrations RPC.
+	// See FindMidnightAssetCreatesFrom for why the result may hold more
+	// than limit rows. Used to serve the MidnightState GetDeregistrations
+	// RPC.
 	FindMidnightDeregistrationsFrom(
 		startBlock uint64,
 		startTxIndex uint32,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -156,6 +156,50 @@ type MetadataStore interface {
 	// the in-memory tracked-UTxO set. Used during chain rollback.
 	DeleteMidnightDeregistrationsByBlock(types.Txn, uint64) ([]models.MidnightDeregistration, error)
 
+	// FindMidnightAssetCreatesFrom returns cNIGHT create rows ordered by
+	// (block_number, tx_index) ascending, starting strictly after
+	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+	// Used to serve the MidnightState GetAssetCreates RPC.
+	FindMidnightAssetCreatesFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightAssetCreate, error)
+
+	// FindMidnightAssetSpendsFrom returns cNIGHT spend rows ordered by
+	// (block_number, tx_index) ascending, starting strictly after
+	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+	// Used to serve the MidnightState GetAssetSpends RPC.
+	FindMidnightAssetSpendsFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightAssetSpend, error)
+
+	// FindMidnightRegistrationsFrom returns registration rows ordered by
+	// (block_number, tx_index) ascending, starting strictly after
+	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+	// Used to serve the MidnightState GetRegistrations RPC.
+	FindMidnightRegistrationsFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightRegistration, error)
+
+	// FindMidnightDeregistrationsFrom returns deregistration rows ordered by
+	// (block_number, tx_index) ascending, starting strictly after
+	// (startBlock, startTxIndex). limit <= 0 means no SQL LIMIT is applied.
+	// Used to serve the MidnightState GetDeregistrations RPC.
+	FindMidnightDeregistrationsFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightDeregistration, error)
+
 	// GetImportCheckpoint retrieves the checkpoint for a given
 	// import key (e.g., "{digest}:{slot}"). Returns nil if no
 	// checkpoint exists.

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -498,23 +499,11 @@ func (idx *Indexer) handleBlockEvent(evt event.Event) {
 				timestampMs = uint64(t.UnixMilli()) //nolint:gosec
 			}
 		}
-		// Advance epoch context before scanning this block.
-		if idx.config.SlotToEpoch != nil {
-			epoch, err := idx.config.SlotToEpoch(block.Slot)
-			if err != nil {
-				if idx.config.Logger != nil {
-					idx.config.Logger.Error(
-						"midnight indexer: resolve block epoch",
-						"slot", block.Slot,
-						"error", err,
-					)
-				}
-			} else {
-				idx.mu.Lock()
-				idx.advanceEpochLocked(epoch, block.Number)
-				idx.mu.Unlock()
-			}
-		}
+		// Epoch resolution and advance happen inside processBlock (it must
+		// also handle the backfill path, which calls processBlock directly),
+		// so that the epoch-snapshot write it can trigger is covered by the
+		// same block-scoped write transaction as every other row this block
+		// produces, instead of committing separately beforehand.
 		if err := idx.processBlock(block, decoded.Transactions(), timestampMs); err != nil {
 			idx.fatal(fmt.Errorf(
 				"midnight indexer: process block slot=%d block=%d: %w",
@@ -787,10 +776,17 @@ func (idx *Indexer) processBlock(
 	txs []lcommon.Transaction,
 	timestampMs uint64,
 ) error {
+	// All of this block's midnight_* writes share one transaction, so a
+	// reader can never observe some but not all rows for a given
+	// (block_number, tx_index) key: rows become visible all at once, on
+	// commit, or not at all. Without this, a paginated reader that saw one
+	// row for a key and advanced its cursor past it would permanently miss
+	// a sibling row for that same key committed moments later.
+	txn := idx.config.Metadata.Transaction()
+	defer txn.Rollback() //nolint:errcheck
+
 	// Resolve the epoch for this block so Ariadne rows are keyed correctly
-	// during both backfill and live processing. The live path (handleBlockEvent)
-	// calls advanceEpochLocked before processBlock, but the backfill path calls
-	// processBlock directly, so we must resolve and advance here as well.
+	// during both backfill and live processing.
 	var govEpoch uint64
 	if idx.config.SlotToEpoch != nil {
 		epoch, err := idx.config.SlotToEpoch(block.Slot)
@@ -811,7 +807,7 @@ func (idx *Indexer) processBlock(
 			idx.mu.RUnlock()
 		} else {
 			idx.mu.Lock()
-			idx.advanceEpochLocked(epoch, block.Number)
+			idx.advanceEpochLocked(epoch, block.Number, txn)
 			govEpoch = idx.currentEpoch
 			idx.mu.Unlock()
 		}
@@ -822,7 +818,7 @@ func (idx *Indexer) processBlock(
 	}
 
 	for i, tx := range txs {
-		if err := idx.processTx(block, tx, uint32(i), timestampMs, govEpoch); err != nil { //nolint:gosec
+		if err := idx.processTx(block, tx, uint32(i), timestampMs, govEpoch, txn); err != nil { //nolint:gosec
 			return err
 		}
 	}
@@ -845,27 +841,36 @@ func (idx *Indexer) processBlock(
 		}
 		idx.mu.Unlock()
 		if len(idx.permCandidatePolicyBytes) > 0 {
-			if err := idx.config.Metadata.DeleteMidnightAriadneRollbacksBeforeBlock(nil, pruneBelow); err != nil &&
-				idx.config.Logger != nil {
-				idx.config.Logger.Error(
-					"midnight indexer: prune ariadne rollback journal",
-					"error", err,
-					"block", block.Number,
-					"prune_below", pruneBelow,
+			// Propagate the error (rather than log-and-continue) instead of
+			// risking a Commit below on a backend where a failed statement
+			// poisons the rest of the transaction (e.g. Postgres implicitly
+			// rolls back a COMMIT issued after an aborted statement) — that
+			// would silently discard this block's other, successful writes.
+			if err := idx.config.Metadata.DeleteMidnightAriadneRollbacksBeforeBlock(txn, pruneBelow); err != nil {
+				return fmt.Errorf(
+					"midnight indexer: prune ariadne rollback journal block=%d prune_below=%d: %w",
+					block.Number, pruneBelow, err,
 				)
 			}
 		}
 	}
+	if err := txn.Commit(); err != nil {
+		return fmt.Errorf("midnight indexer: commit block=%d: %w", block.Number, err)
+	}
 	return nil
 }
 
-// processTx scans a single transaction's inputs and outputs.
+// processTx scans a single transaction's inputs and outputs. txn is the
+// block-scoped write transaction opened by processBlock; every row this
+// function (and processOutput) writes uses it, so the block's rows become
+// visible to readers atomically on processBlock's Commit.
 func (idx *Indexer) processTx(
 	block models.Block,
 	tx lcommon.Transaction,
 	txIdx uint32,
 	timestampMs uint64,
 	govEpoch uint64,
+	txn types.Txn,
 ) error {
 	txHashBytes := tx.Id().Bytes()
 
@@ -896,7 +901,7 @@ func (idx *Indexer) processTx(
 				TxIndex:          txIdx,
 				BlockTimestampMs: timestampMs,
 			}
-			if err := idx.config.Metadata.CreateMidnightAssetSpend(nil, row); err != nil {
+			if err := idx.config.Metadata.CreateMidnightAssetSpend(txn, row); err != nil {
 				return fmt.Errorf(
 					"write asset spend tx=%s input=%s#%d: %w",
 					hex.EncodeToString(txHashBytes), inpHashHex, inpIdx, err,
@@ -918,7 +923,7 @@ func (idx *Indexer) processTx(
 				TxIndex:          txIdx,
 				BlockTimestampMs: timestampMs,
 			}
-			if err := idx.config.Metadata.CreateMidnightDeregistration(nil, row); err != nil {
+			if err := idx.config.Metadata.CreateMidnightDeregistration(txn, row); err != nil {
 				return fmt.Errorf(
 					"write deregistration tx=%s input=%s#%d: %w",
 					hex.EncodeToString(txHashBytes), inpHashHex, inpIdx, err,
@@ -949,6 +954,7 @@ func (idx *Indexer) processTx(
 			timestampMs,
 			govEpoch,
 			out,
+			txn,
 		); err != nil {
 			return err
 		}
@@ -957,7 +963,8 @@ func (idx *Indexer) processTx(
 }
 
 // processOutput checks a single transaction output for cNIGHT tokens,
-// registration auth tokens, and governance/Ariadne/candidate data.
+// registration auth tokens, and governance/Ariadne/candidate data. txn is
+// processBlock's block-scoped write transaction; see processTx.
 func (idx *Indexer) processOutput(
 	block models.Block,
 	txHashBytes []byte,
@@ -966,6 +973,7 @@ func (idx *Indexer) processOutput(
 	timestampMs uint64,
 	govEpoch uint64,
 	out lcommon.TransactionOutput,
+	txn types.Txn,
 ) error {
 	txHashHex := hex.EncodeToString(txHashBytes)
 	key := utxoKey{TxHash: txHashHex, Index: outIdx}
@@ -987,7 +995,7 @@ func (idx *Indexer) processOutput(
 					TxIndex:          txIdx,
 					BlockTimestampMs: timestampMs,
 				}
-				if err := idx.config.Metadata.CreateMidnightAssetCreate(nil, row); err != nil {
+				if err := idx.config.Metadata.CreateMidnightAssetCreate(txn, row); err != nil {
 					return fmt.Errorf(
 						"write asset create tx=%s output=%d: %w",
 						txHashHex, outIdx, err,
@@ -1021,7 +1029,7 @@ func (idx *Indexer) processOutput(
 						TxIndex:          txIdx,
 						BlockTimestampMs: timestampMs,
 					}
-					if err := idx.config.Metadata.CreateMidnightRegistration(nil, row); err != nil {
+					if err := idx.config.Metadata.CreateMidnightRegistration(txn, row); err != nil {
 						return fmt.Errorf(
 							"write registration tx=%s output=%d: %w",
 							txHashHex, outIdx, err,
@@ -1060,7 +1068,7 @@ func (idx *Indexer) processOutput(
 		idx.outputHasPolicy(out, idx.techCommitteePolicyBytes) &&
 		datumCbor != nil {
 		if err := idx.config.Metadata.InsertMidnightGovernanceDatum(
-			nil,
+			txn,
 			&models.MidnightGovernanceDatum{
 				DatumType:   models.MidnightGovernanceDatumTypeTechnicalCommittee,
 				TxHash:      txHashBytes,
@@ -1082,7 +1090,7 @@ func (idx *Indexer) processOutput(
 		idx.outputHasPolicy(out, idx.councilPolicyBytes) &&
 		datumCbor != nil {
 		if err := idx.config.Metadata.InsertMidnightGovernanceDatum(
-			nil,
+			txn,
 			&models.MidnightGovernanceDatum{
 				DatumType:   models.MidnightGovernanceDatumTypeCouncil,
 				TxHash:      txHashBytes,
@@ -1106,14 +1114,14 @@ func (idx *Indexer) processOutput(
 		isDup := bytes.Equal(datumCbor, idx.lastAriadneDatum)
 		idx.mu.RUnlock()
 		if !isDup {
-			if err := idx.recordAriadneRollback(block.Number, govEpoch); err != nil {
+			if err := idx.recordAriadneRollback(block.Number, govEpoch, txn); err != nil {
 				return fmt.Errorf(
 					"record ariadne rollback tx=%s output=%d epoch=%d: %w",
 					txHashHex, outIdx, govEpoch, err,
 				)
 			}
 			if err := idx.config.Metadata.UpsertMidnightAriadneParams(
-				nil,
+				txn,
 				&models.MidnightAriadneParams{
 					Epoch: govEpoch,
 					Datum: datumCbor,
@@ -1145,8 +1153,8 @@ func (idx *Indexer) processOutput(
 	return nil
 }
 
-func (idx *Indexer) recordAriadneRollback(blockNumber, epoch uint64) error {
-	existing, err := idx.config.Metadata.GetMidnightAriadneParamsByEpoch(epoch, nil)
+func (idx *Indexer) recordAriadneRollback(blockNumber, epoch uint64, txn types.Txn) error {
+	existing, err := idx.config.Metadata.GetMidnightAriadneParamsByEpoch(epoch, txn)
 	if err != nil {
 		return err
 	}
@@ -1159,7 +1167,7 @@ func (idx *Indexer) recordAriadneRollback(blockNumber, epoch uint64) error {
 		entry.PreviousExists = true
 		entry.PreviousDatum = bytes.Clone(existing.Datum)
 	}
-	return idx.config.Metadata.CreateMidnightAriadneRollback(nil, entry)
+	return idx.config.Metadata.CreateMidnightAriadneRollback(txn, entry)
 }
 
 // hasAuthToken returns true if the output assets contain at least one unit of
@@ -1194,7 +1202,7 @@ func (idx *Indexer) hasAuthToken(out lcommon.TransactionOutput) bool {
 // epoch and the new epoch, then sets currentEpoch = epoch.
 // If hasCurrentEpoch is false (cold start), it skips snapshotting and just
 // sets the current epoch. idx.mu must be held.
-func (idx *Indexer) advanceEpochLocked(epoch uint64, blockNumber uint64) {
+func (idx *Indexer) advanceEpochLocked(epoch uint64, blockNumber uint64, txn types.Txn) {
 	if !idx.hasCurrentEpoch {
 		idx.currentEpoch = epoch
 		idx.hasCurrentEpoch = true
@@ -1206,14 +1214,14 @@ func (idx *Indexer) advanceEpochLocked(epoch uint64, blockNumber uint64) {
 	// Journal the pre-advance value so rollbackBlock can restore it.
 	idx.epochTransitions[blockNumber] = idx.currentEpoch
 	for e := idx.currentEpoch; e < epoch; e++ {
-		idx.snapshotEpochLocked(e, blockNumber)
+		idx.snapshotEpochLocked(e, blockNumber, txn)
 	}
 	idx.currentEpoch = epoch
 }
 
 // snapshotEpochLocked writes the current candidate set as the epoch snapshot.
 // Skips if this epoch has already been snapshotted. idx.mu must be held.
-func (idx *Indexer) snapshotEpochLocked(epoch uint64, blockNumber uint64) {
+func (idx *Indexer) snapshotEpochLocked(epoch uint64, blockNumber uint64, txn types.Txn) {
 	if idx.hasSnapshotEpoch && epoch <= idx.snapshotEpoch {
 		return
 	}
@@ -1246,7 +1254,7 @@ func (idx *Indexer) snapshotEpochLocked(epoch uint64, blockNumber uint64) {
 		return
 	}
 	if err := idx.config.Metadata.UpsertMidnightEpochCandidates(
-		nil,
+		txn,
 		&models.MidnightEpochCandidates{
 			Epoch:          epoch,
 			BlockNumber:    blockNumber,

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -770,64 +770,142 @@ func (idx *Indexer) rollbackCandidateCreates(txs []lcommon.Transaction) {
 	}
 }
 
-// mutableStateSnapshot captures every in-memory field processTx/processOutput
-// (and the epoch-advance/candidate-snapshot helpers they call) mutate while
-// scanning a block, so a failed block's partial mutations can be undone.
-// Without this, a later write failing within the same block's transaction
-// would roll back the DB while leaving these already-applied — the two
-// views would disagree about whether the block's earlier rows exist.
-type mutableStateSnapshot struct {
-	cNightUTxOs       map[utxoKey]cNightUTxO
-	regUTxOs          map[utxoKey]registrationUTxO
-	candidates        map[candidateKey][]byte
-	candidateRemovals map[uint64]map[candidateKey][]byte
-	epochTransitions  map[uint64]uint64
-	lastAriadneDatum  []byte
-	currentEpoch      uint64
-	hasCurrentEpoch   bool
-	snapshotEpoch     uint64
-	hasSnapshotEpoch  bool
+// mapJournal records, for a single map, the pre-block value of every key
+// that gets touched while processing a block — the first time each key is
+// touched, not on every touch, so undo restores exactly the value the key
+// had before this block started. Cost is proportional to the number of
+// distinct keys this block mutates, not to the size of the live map.
+type mapJournal[K comparable, V any] struct {
+	before  map[K]V
+	existed map[K]bool
 }
 
-// snapshotMutableState clones the mutable fields processBlock's write path
-// may touch. idx.mu must not be held by the caller.
-func (idx *Indexer) snapshotMutableState() mutableStateSnapshot {
+func newMapJournal[K comparable, V any]() *mapJournal[K, V] {
+	return &mapJournal[K, V]{before: make(map[K]V), existed: make(map[K]bool)}
+}
+
+// record captures m[key]'s current value and presence, if key has not
+// already been recorded this block. Call before mutating m[key].
+func (j *mapJournal[K, V]) record(m map[K]V, key K) {
+	if _, seen := j.existed[key]; seen {
+		return
+	}
+	v, ok := m[key]
+	j.before[key] = v
+	j.existed[key] = ok
+}
+
+// undo restores every key this journal recorded to its pre-block value, or
+// deletes it if it did not exist before this block.
+func (j *mapJournal[K, V]) undo(m map[K]V) {
+	for key, existed := range j.existed {
+		if existed {
+			m[key] = j.before[key]
+		} else {
+			delete(m, key)
+		}
+	}
+}
+
+// blockMutationJournal records exactly the in-memory mutations
+// processTx/processOutput (and the epoch-advance/candidate-snapshot/pruning
+// steps around them) make while scanning one block, so a failed block's
+// partial mutations can be undone in proportion to what this block changed
+// rather than by cloning the indexer's entire live state on every block —
+// cNightUTxOs, regUTxOs, and candidates hold all actively tracked UTxOs
+// across the whole chain, so a full clone would cost O(total live state)
+// per block instead of O(this block's changes).
+//
+// Without undoing these, a later write failing within the same block's
+// transaction would roll back the DB while these mutations stood — memory
+// and the database would disagree about whether the block's earlier rows
+// exist.
+type blockMutationJournal struct {
+	cNightUTxOs *mapJournal[utxoKey, cNightUTxO]
+	regUTxOs    *mapJournal[utxoKey, registrationUTxO]
+	candidates  *mapJournal[candidateKey, []byte]
+
+	// candidateRemovals and epochTransitions are only ever written under
+	// this block's own key (block.Number) while processing it, so their
+	// journal is just that one key's pre-block value — not a per-key
+	// mapJournal, since every write this block makes to either map shares
+	// the same key.
+	candidateRemovalsExisted bool
+	candidateRemovalsBefore  map[candidateKey][]byte
+	epochTransitionExisted   bool
+	epochTransitionBefore    uint64
+
+	// Pruning deletes stale entries (keyed by *older* blocks) in the same
+	// pass; record exactly what it removes so undo can put them back.
+	prunedCandidateRemovals map[uint64]map[candidateKey][]byte
+	prunedEpochTransitions  map[uint64]uint64
+
+	// Scalars mutated at most a handful of times per block; recording the
+	// single pre-block value is already O(1).
+	lastAriadneDatumBefore []byte
+	currentEpochBefore     uint64
+	hasCurrentEpochBefore  bool
+	snapshotEpochBefore    uint64
+	hasSnapshotEpochBefore bool
+}
+
+// newBlockMutationJournal starts a journal for the block about to be
+// processed, capturing the pre-block value of every field that is only
+// ever touched under this block's own key (so no per-key journal is
+// needed for it) plus the scalar fields. idx.mu must not be held by the
+// caller.
+func (idx *Indexer) newBlockMutationJournal(blockNumber uint64) *blockMutationJournal {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	candidateRemovals := make(map[uint64]map[candidateKey][]byte, len(idx.candidateRemovals))
-	for blockNumber, removals := range idx.candidateRemovals {
-		candidateRemovals[blockNumber] = maps.Clone(removals)
+	j := &blockMutationJournal{
+		cNightUTxOs:            newMapJournal[utxoKey, cNightUTxO](),
+		regUTxOs:               newMapJournal[utxoKey, registrationUTxO](),
+		candidates:             newMapJournal[candidateKey, []byte](),
+		lastAriadneDatumBefore: idx.lastAriadneDatum,
+		currentEpochBefore:     idx.currentEpoch,
+		hasCurrentEpochBefore:  idx.hasCurrentEpoch,
+		snapshotEpochBefore:    idx.snapshotEpoch,
+		hasSnapshotEpochBefore: idx.hasSnapshotEpoch,
 	}
-	return mutableStateSnapshot{
-		cNightUTxOs:       maps.Clone(idx.cNightUTxOs),
-		regUTxOs:          maps.Clone(idx.regUTxOs),
-		candidates:        maps.Clone(idx.candidates),
-		candidateRemovals: candidateRemovals,
-		epochTransitions:  maps.Clone(idx.epochTransitions),
-		lastAriadneDatum:  idx.lastAriadneDatum,
-		currentEpoch:      idx.currentEpoch,
-		hasCurrentEpoch:   idx.hasCurrentEpoch,
-		snapshotEpoch:     idx.snapshotEpoch,
-		hasSnapshotEpoch:  idx.hasSnapshotEpoch,
+	if removals, ok := idx.candidateRemovals[blockNumber]; ok {
+		j.candidateRemovalsExisted = true
+		j.candidateRemovalsBefore = maps.Clone(removals)
 	}
+	if prevEpoch, ok := idx.epochTransitions[blockNumber]; ok {
+		j.epochTransitionExisted = true
+		j.epochTransitionBefore = prevEpoch
+	}
+	return j
 }
 
-// restoreMutableState overwrites the mutable fields with a prior snapshot,
-// undoing any in-memory mutations a failed processBlock call made. idx.mu
+// undo reverts every mutation this journal recorded, restoring idx's
+// in-memory state to exactly what it was before the block started. idx.mu
 // must not be held by the caller.
-func (idx *Indexer) restoreMutableState(snap mutableStateSnapshot) {
+func (idx *Indexer) undoBlockMutations(j *blockMutationJournal, blockNumber uint64) {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	idx.cNightUTxOs = snap.cNightUTxOs
-	idx.regUTxOs = snap.regUTxOs
-	idx.candidates = snap.candidates
-	idx.candidateRemovals = snap.candidateRemovals
-	idx.epochTransitions = snap.epochTransitions
-	idx.lastAriadneDatum = snap.lastAriadneDatum
-	idx.currentEpoch = snap.currentEpoch
-	idx.hasCurrentEpoch = snap.hasCurrentEpoch
-	idx.snapshotEpoch = snap.snapshotEpoch
-	idx.hasSnapshotEpoch = snap.hasSnapshotEpoch
+	j.cNightUTxOs.undo(idx.cNightUTxOs)
+	j.regUTxOs.undo(idx.regUTxOs)
+	j.candidates.undo(idx.candidates)
+
+	if j.candidateRemovalsExisted {
+		idx.candidateRemovals[blockNumber] = j.candidateRemovalsBefore
+	} else {
+		delete(idx.candidateRemovals, blockNumber)
+	}
+	if j.epochTransitionExisted {
+		idx.epochTransitions[blockNumber] = j.epochTransitionBefore
+	} else {
+		delete(idx.epochTransitions, blockNumber)
+	}
+	maps.Copy(idx.candidateRemovals, j.prunedCandidateRemovals)
+	maps.Copy(idx.epochTransitions, j.prunedEpochTransitions)
+
+	idx.lastAriadneDatum = j.lastAriadneDatumBefore
+	idx.currentEpoch = j.currentEpochBefore
+	idx.hasCurrentEpoch = j.hasCurrentEpochBefore
+	idx.snapshotEpoch = j.snapshotEpochBefore
+	idx.hasSnapshotEpoch = j.hasSnapshotEpochBefore
 }
 
 // processBlock iterates the transactions in a block and calls processTx for
@@ -849,14 +927,15 @@ func (idx *Indexer) processBlock(
 	// processTx/processOutput (and the epoch-advance/pruning steps below)
 	// mutate idx's in-memory tracked-UTxO and governance state as they go,
 	// ahead of txn's commit. If a later write in this same block fails, txn
-	// rolls back but those earlier mutations would otherwise stand,
-	// leaving memory ahead of the database. Snapshot before mutating so a
-	// failure can restore exactly the pre-block state.
-	snap := idx.snapshotMutableState()
+	// rolls back but those earlier mutations would otherwise stand, leaving
+	// memory ahead of the database. Journal each mutation's pre-block value
+	// so a failure can undo exactly this block's changes, without cloning
+	// the whole (chain-sized) live state on every block.
+	journal := idx.newBlockMutationJournal(block.Number)
 	committed := false
 	defer func() {
 		if !committed {
-			idx.restoreMutableState(snap)
+			idx.undoBlockMutations(journal, block.Number)
 		}
 	}()
 
@@ -893,7 +972,7 @@ func (idx *Indexer) processBlock(
 	}
 
 	for i, tx := range txs {
-		if err := idx.processTx(block, tx, uint32(i), timestampMs, govEpoch, txn); err != nil { //nolint:gosec
+		if err := idx.processTx(block, tx, uint32(i), timestampMs, govEpoch, txn, journal); err != nil { //nolint:gosec
 			return err
 		}
 	}
@@ -901,16 +980,27 @@ func (idx *Indexer) processBlock(
 	// Prune rollback journals that are beyond the rollback window.
 	// Ouroboros cannot roll back more than candidateRollbackDepth blocks, so
 	// journal entries older than that depth will never be needed for rollback.
+	// Record exactly what gets pruned (never this block's own key — its
+	// block number is always >= pruneBelow) so a failure can put it back,
+	// without journaling the whole map.
 	if block.Number > candidateRollbackDepth {
 		pruneBelow := block.Number - candidateRollbackDepth
 		idx.mu.Lock()
-		for bn := range idx.candidateRemovals {
+		for bn, removals := range idx.candidateRemovals {
 			if bn < pruneBelow {
+				if journal.prunedCandidateRemovals == nil {
+					journal.prunedCandidateRemovals = make(map[uint64]map[candidateKey][]byte)
+				}
+				journal.prunedCandidateRemovals[bn] = removals
 				delete(idx.candidateRemovals, bn)
 			}
 		}
-		for bn := range idx.epochTransitions {
+		for bn, prevEpoch := range idx.epochTransitions {
 			if bn < pruneBelow {
+				if journal.prunedEpochTransitions == nil {
+					journal.prunedEpochTransitions = make(map[uint64]uint64)
+				}
+				journal.prunedEpochTransitions[bn] = prevEpoch
 				delete(idx.epochTransitions, bn)
 			}
 		}
@@ -939,7 +1029,9 @@ func (idx *Indexer) processBlock(
 // processTx scans a single transaction's inputs and outputs. txn is the
 // block-scoped write transaction opened by processBlock; every row this
 // function (and processOutput) writes uses it, so the block's rows become
-// visible to readers atomically on processBlock's Commit.
+// visible to readers atomically on processBlock's Commit. journal records
+// this block's in-memory mutations so processBlock can undo them if a
+// later write in the same block fails.
 func (idx *Indexer) processTx(
 	block models.Block,
 	tx lcommon.Transaction,
@@ -947,6 +1039,7 @@ func (idx *Indexer) processTx(
 	timestampMs uint64,
 	govEpoch uint64,
 	txn types.Txn,
+	journal *blockMutationJournal,
 ) error {
 	txHashBytes := tx.Id().Bytes()
 
@@ -984,6 +1077,7 @@ func (idx *Indexer) processTx(
 				)
 			}
 			idx.mu.Lock()
+			journal.cNightUTxOs.record(idx.cNightUTxOs, key)
 			delete(idx.cNightUTxOs, key)
 			idx.mu.Unlock()
 		}
@@ -1006,6 +1100,7 @@ func (idx *Indexer) processTx(
 				)
 			}
 			idx.mu.Lock()
+			journal.regUTxOs.record(idx.regUTxOs, key)
 			delete(idx.regUTxOs, key)
 			idx.mu.Unlock()
 		}
@@ -1013,7 +1108,7 @@ func (idx *Indexer) processTx(
 		// Always attempt to remove from candidate set (no-op if not tracked).
 		if len(idx.candidateAddrBytes) > 0 {
 			idx.mu.Lock()
-			if candidateKey, datum, removed := idx.removeCandidate(inpHashBytes, inpIdx); removed {
+			if candidateKey, datum, removed := idx.removeCandidate(journal, inpHashBytes, inpIdx); removed {
 				idx.recordCandidateRemovalLocked(block.Number, candidateKey, datum)
 			}
 			idx.mu.Unlock()
@@ -1031,6 +1126,7 @@ func (idx *Indexer) processTx(
 			govEpoch,
 			out,
 			txn,
+			journal,
 		); err != nil {
 			return err
 		}
@@ -1040,7 +1136,8 @@ func (idx *Indexer) processTx(
 
 // processOutput checks a single transaction output for cNIGHT tokens,
 // registration auth tokens, and governance/Ariadne/candidate data. txn is
-// processBlock's block-scoped write transaction; see processTx.
+// processBlock's block-scoped write transaction; journal records this
+// block's in-memory mutations; see processTx.
 func (idx *Indexer) processOutput(
 	block models.Block,
 	txHashBytes []byte,
@@ -1050,6 +1147,7 @@ func (idx *Indexer) processOutput(
 	govEpoch uint64,
 	out lcommon.TransactionOutput,
 	txn types.Txn,
+	journal *blockMutationJournal,
 ) error {
 	txHashHex := hex.EncodeToString(txHashBytes)
 	key := utxoKey{TxHash: txHashHex, Index: outIdx}
@@ -1078,6 +1176,7 @@ func (idx *Indexer) processOutput(
 					)
 				}
 				idx.mu.Lock()
+				journal.cNightUTxOs.record(idx.cNightUTxOs, key)
 				idx.cNightUTxOs[key] = cNightUTxO{
 					Address:  addrBytes,
 					Quantity: quantity,
@@ -1112,6 +1211,7 @@ func (idx *Indexer) processOutput(
 						)
 					}
 					idx.mu.Lock()
+					journal.regUTxOs.record(idx.regUTxOs, key)
 					idx.regUTxOs[key] = registrationUTxO{FullDatum: datumCbor}
 					idx.mu.Unlock()
 				}
@@ -1222,6 +1322,7 @@ func (idx *Indexer) processOutput(
 		copy(ckey.TxHash[:], txHashBytes)
 		ckey.OutputIndex = outIdx
 		idx.mu.Lock()
+		journal.candidates.record(idx.candidates, ckey)
 		idx.candidates[ckey] = bytes.Clone(datumCbor)
 		idx.mu.Unlock()
 	}
@@ -1353,7 +1454,11 @@ func (idx *Indexer) snapshotEpochLocked(epoch uint64, blockNumber uint64, txn ty
 // removeCandidate removes a UTxO from the in-memory candidate set when it is
 // consumed by a transaction. This is a no-op if the key is not in the set.
 // idx.mu must be held by the caller.
-func (idx *Indexer) removeCandidate(txHashBytes []byte, outputIndex uint32) (candidateKey, []byte, bool) {
+func (idx *Indexer) removeCandidate(
+	journal *blockMutationJournal,
+	txHashBytes []byte,
+	outputIndex uint32,
+) (candidateKey, []byte, bool) {
 	var key candidateKey
 	copy(key.TxHash[:], txHashBytes)
 	key.OutputIndex = outputIndex
@@ -1361,6 +1466,7 @@ func (idx *Indexer) removeCandidate(txHashBytes []byte, outputIndex uint32) (can
 	if !ok {
 		return key, nil, false
 	}
+	journal.candidates.record(idx.candidates, key)
 	delete(idx.candidates, key)
 	return key, bytes.Clone(datum), true
 }

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math"
 	"math/big"
 	"sort"
@@ -769,6 +770,66 @@ func (idx *Indexer) rollbackCandidateCreates(txs []lcommon.Transaction) {
 	}
 }
 
+// mutableStateSnapshot captures every in-memory field processTx/processOutput
+// (and the epoch-advance/candidate-snapshot helpers they call) mutate while
+// scanning a block, so a failed block's partial mutations can be undone.
+// Without this, a later write failing within the same block's transaction
+// would roll back the DB while leaving these already-applied — the two
+// views would disagree about whether the block's earlier rows exist.
+type mutableStateSnapshot struct {
+	cNightUTxOs       map[utxoKey]cNightUTxO
+	regUTxOs          map[utxoKey]registrationUTxO
+	candidates        map[candidateKey][]byte
+	candidateRemovals map[uint64]map[candidateKey][]byte
+	epochTransitions  map[uint64]uint64
+	lastAriadneDatum  []byte
+	currentEpoch      uint64
+	hasCurrentEpoch   bool
+	snapshotEpoch     uint64
+	hasSnapshotEpoch  bool
+}
+
+// snapshotMutableState clones the mutable fields processBlock's write path
+// may touch. idx.mu must not be held by the caller.
+func (idx *Indexer) snapshotMutableState() mutableStateSnapshot {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	candidateRemovals := make(map[uint64]map[candidateKey][]byte, len(idx.candidateRemovals))
+	for blockNumber, removals := range idx.candidateRemovals {
+		candidateRemovals[blockNumber] = maps.Clone(removals)
+	}
+	return mutableStateSnapshot{
+		cNightUTxOs:       maps.Clone(idx.cNightUTxOs),
+		regUTxOs:          maps.Clone(idx.regUTxOs),
+		candidates:        maps.Clone(idx.candidates),
+		candidateRemovals: candidateRemovals,
+		epochTransitions:  maps.Clone(idx.epochTransitions),
+		lastAriadneDatum:  idx.lastAriadneDatum,
+		currentEpoch:      idx.currentEpoch,
+		hasCurrentEpoch:   idx.hasCurrentEpoch,
+		snapshotEpoch:     idx.snapshotEpoch,
+		hasSnapshotEpoch:  idx.hasSnapshotEpoch,
+	}
+}
+
+// restoreMutableState overwrites the mutable fields with a prior snapshot,
+// undoing any in-memory mutations a failed processBlock call made. idx.mu
+// must not be held by the caller.
+func (idx *Indexer) restoreMutableState(snap mutableStateSnapshot) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.cNightUTxOs = snap.cNightUTxOs
+	idx.regUTxOs = snap.regUTxOs
+	idx.candidates = snap.candidates
+	idx.candidateRemovals = snap.candidateRemovals
+	idx.epochTransitions = snap.epochTransitions
+	idx.lastAriadneDatum = snap.lastAriadneDatum
+	idx.currentEpoch = snap.currentEpoch
+	idx.hasCurrentEpoch = snap.hasCurrentEpoch
+	idx.snapshotEpoch = snap.snapshotEpoch
+	idx.hasSnapshotEpoch = snap.hasSnapshotEpoch
+}
+
 // processBlock iterates the transactions in a block and calls processTx for
 // each one. Exposed for direct use in tests.
 func (idx *Indexer) processBlock(
@@ -784,6 +845,20 @@ func (idx *Indexer) processBlock(
 	// a sibling row for that same key committed moments later.
 	txn := idx.config.Metadata.Transaction()
 	defer txn.Rollback() //nolint:errcheck
+
+	// processTx/processOutput (and the epoch-advance/pruning steps below)
+	// mutate idx's in-memory tracked-UTxO and governance state as they go,
+	// ahead of txn's commit. If a later write in this same block fails, txn
+	// rolls back but those earlier mutations would otherwise stand,
+	// leaving memory ahead of the database. Snapshot before mutating so a
+	// failure can restore exactly the pre-block state.
+	snap := idx.snapshotMutableState()
+	committed := false
+	defer func() {
+		if !committed {
+			idx.restoreMutableState(snap)
+		}
+	}()
 
 	// Resolve the epoch for this block so Ariadne rows are keyed correctly
 	// during both backfill and live processing.
@@ -857,6 +932,7 @@ func (idx *Indexer) processBlock(
 	if err := txn.Commit(); err != nil {
 		return fmt.Errorf("midnight indexer: commit block=%d: %w", block.Number, err)
 	}
+	committed = true
 	return nil
 }
 

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -1204,7 +1204,11 @@ func (s *failingAfterNCreatesStore) CreateMidnightAssetCreate(
 // too, rather than left durably committed on its own. All of a block's
 // midnight_* rows share one write transaction specifically so that readers
 // paginating by (block_number, tx_index) never observe part of a block's
-// rows without the rest.
+// rows without the rest. It also verifies the in-memory tracked-UTxO set is
+// restored to its pre-block state, not left ahead of the rolled-back DB —
+// the first tx's create adds a UTxO to idx.cNightUTxOs before the second
+// tx's create fails, so without a restore that entry would linger in memory
+// even though the DB never durably recorded it.
 func TestProcessBlock_PartialFailureRollsBackWholeBlock(t *testing.T) {
 	t.Parallel()
 	store := setupTestStore(t)
@@ -1234,5 +1238,13 @@ func TestProcessBlock_PartialFailureRollsBackWholeBlock(t *testing.T) {
 		t,
 		rows,
 		"the first tx's successful write must be rolled back along with the second tx's failure",
+	)
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	require.Empty(
+		t,
+		idx.cNightUTxOs,
+		"the first tx's in-memory UTxO must be undone along with its rolled-back DB row",
 	)
 }

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -1248,3 +1248,52 @@ func TestProcessBlock_PartialFailureRollsBackWholeBlock(t *testing.T) {
 		"the first tx's in-memory UTxO must be undone along with its rolled-back DB row",
 	)
 }
+
+// TestProcessBlock_PartialFailureLeavesUnrelatedStateIntact verifies that
+// undoing a failed block's mutations touches only the keys that block
+// itself wrote, not the whole tracked-UTxO map. A prior, already-committed
+// block's entry must survive a later block's rollback untouched — the
+// journal records per-key pre-block values instead of cloning and
+// restoring the entire live map, so this also demonstrates the undo cost
+// scales with what the failed block changed, not with total tracked state.
+func TestProcessBlock_PartialFailureLeavesUnrelatedStateIntact(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	wrapped := &failingAfterNCreatesStore{MetadataStoreSqlite: store, remaining: 2}
+	idx, err := New(Config{
+		Metadata:        wrapped,
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		CNightPolicyID:  testPolicyID,
+		CNightAssetName: testAssetNameHex,
+	})
+	require.NoError(t, err)
+
+	// Block 1 succeeds outright and leaves a durably tracked UTxO.
+	seedTx := buildTx(t, pad32("11000001"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("11000000"), 0)},
+		[]lcommon.TransactionOutput{buildCNightOutput(t, testPolicyID, testAssetNameHex, 50)})
+	require.NoError(t, idx.processBlock(testBlock(1, 100, 0x11), []lcommon.Transaction{seedTx}, 1_000))
+
+	idx.mu.RLock()
+	require.Len(t, idx.cNightUTxOs, 1, "block 1's create must be tracked")
+	idx.mu.RUnlock()
+
+	// Block 2's first tx succeeds, its second fails, aborting the block.
+	tx1 := buildTx(t, pad32("aa000001"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("aa000000"), 0)},
+		[]lcommon.TransactionOutput{buildCNightOutput(t, testPolicyID, testAssetNameHex, 100)})
+	tx2 := buildTx(t, pad32("bb000001"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("bb000000"), 0)},
+		[]lcommon.TransactionOutput{buildCNightOutput(t, testPolicyID, testAssetNameHex, 200)})
+	err = idx.processBlock(testBlock(2, 200, 0x22), []lcommon.Transaction{tx1, tx2}, 2_000)
+	require.Error(t, err, "block 2's second tx must fail and abort the block")
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	require.Len(
+		t,
+		idx.cNightUTxOs,
+		1,
+		"block 1's unrelated, already-committed UTxO must survive block 2's rollback untouched",
+	)
+}

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
@@ -1014,7 +1015,7 @@ func TestCandidateAddRemove(t *testing.T) {
 
 	// Epoch transition: snapshot must contain the one remaining candidate.
 	idx.mu.Lock()
-	idx.advanceEpochLocked(2, 2)
+	idx.advanceEpochLocked(2, 2, nil)
 	idx.mu.Unlock()
 
 	var snapshots []models.MidnightEpochCandidates
@@ -1150,8 +1151,8 @@ func TestCandidateEmptySnapshot(t *testing.T) {
 	idx := setupGovIndexer(t, store)
 
 	idx.mu.Lock()
-	idx.advanceEpochLocked(0, 0) // cold-start init: sets currentEpoch=0, hasCurrentEpoch=true
-	idx.advanceEpochLocked(1, 1) // advance to epoch 1, snapshots epoch 0
+	idx.advanceEpochLocked(0, 0, nil) // cold-start init: sets currentEpoch=0, hasCurrentEpoch=true
+	idx.advanceEpochLocked(1, 1, nil) // advance to epoch 1, snapshots epoch 0
 	idx.mu.Unlock()
 
 	var snapshots []models.MidnightEpochCandidates
@@ -1168,12 +1169,70 @@ func TestEpochTransitionIdempotent(t *testing.T) {
 	idx := setupGovIndexer(t, store)
 
 	idx.mu.Lock()
-	idx.advanceEpochLocked(3, 0)  // cold-start init: sets currentEpoch=3, hasCurrentEpoch=true
-	idx.advanceEpochLocked(4, 42) // advance to epoch 4, snapshots epoch 3
-	idx.advanceEpochLocked(4, 42) // no-op: same epoch, guard prevents a second snapshot
+	idx.advanceEpochLocked(3, 0, nil)  // cold-start init: sets currentEpoch=3, hasCurrentEpoch=true
+	idx.advanceEpochLocked(4, 42, nil) // advance to epoch 4, snapshots epoch 3
+	idx.advanceEpochLocked(4, 42, nil) // no-op: same epoch, guard prevents a second snapshot
 	idx.mu.Unlock()
 
 	var snapshots []models.MidnightEpochCandidates
 	require.NoError(t, store.DB().Find(&snapshots).Error)
 	require.Len(t, snapshots, 1, "advancing to the same epoch twice must not write a second snapshot row")
+}
+
+// failingAfterNCreatesStore wraps a real store and fails the (n+1)th call to
+// CreateMidnightAssetCreate, so a test can force processBlock to fail
+// partway through a block that would otherwise write more than one row.
+type failingAfterNCreatesStore struct {
+	*sqlite.MetadataStoreSqlite
+	remaining int
+}
+
+func (s *failingAfterNCreatesStore) CreateMidnightAssetCreate(
+	txn types.Txn,
+	row *models.MidnightAssetCreate,
+) error {
+	if s.remaining <= 0 {
+		return errors.New("injected failure")
+	}
+	s.remaining--
+	return s.MetadataStoreSqlite.CreateMidnightAssetCreate(txn, row)
+}
+
+// TestProcessBlock_PartialFailureRollsBackWholeBlock verifies that when one
+// transaction's write fails partway through a block, an earlier
+// transaction's already-successful write in the SAME block is rolled back
+// too, rather than left durably committed on its own. All of a block's
+// midnight_* rows share one write transaction specifically so that readers
+// paginating by (block_number, tx_index) never observe part of a block's
+// rows without the rest.
+func TestProcessBlock_PartialFailureRollsBackWholeBlock(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	wrapped := &failingAfterNCreatesStore{MetadataStoreSqlite: store, remaining: 1}
+	idx, err := New(Config{
+		Metadata:        wrapped,
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		CNightPolicyID:  testPolicyID,
+		CNightAssetName: testAssetNameHex,
+	})
+	require.NoError(t, err)
+
+	tx1 := buildTx(t, pad32("aa000001"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("aa000000"), 0)},
+		[]lcommon.TransactionOutput{buildCNightOutput(t, testPolicyID, testAssetNameHex, 100)})
+	tx2 := buildTx(t, pad32("bb000001"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("bb000000"), 0)},
+		[]lcommon.TransactionOutput{buildCNightOutput(t, testPolicyID, testAssetNameHex, 200)})
+
+	block := testBlock(1, 100, 0xAA)
+	err = idx.processBlock(block, []lcommon.Transaction{tx1, tx2}, 1_000_000)
+	require.Error(t, err, "the second tx's create must fail and abort the whole block")
+
+	var rows []models.MidnightAssetCreate
+	require.NoError(t, store.DB().Find(&rows).Error)
+	require.Empty(
+		t,
+		rows,
+		"the first tx's successful write must be rolled back along with the second tx's failure",
+	)
 }

--- a/midnight/server/midnight_state.go
+++ b/midnight/server/midnight_state.go
@@ -65,7 +65,7 @@ func effectivePageSize(requested uint32) int {
 // UTxO-event query RPCs. It is declared locally, rather than depending on
 // the full metadata.MetadataStore interface, so this gRPC-query package
 // does not carry unrelated write-path and lifecycle methods; any store
-// (e.g. *sqlite.MetadataStoreSqlite) that implements these four methods
+// (e.g. *sqlite.MetadataStoreSqlite) that implements these methods
 // satisfies it structurally, with no explicit declaration required.
 type eventStore interface {
 	FindMidnightAssetCreatesFrom(
@@ -92,6 +92,13 @@ type eventStore interface {
 		limit int,
 		txn types.Txn,
 	) ([]models.MidnightDeregistration, error)
+	// ReadTransaction opens a read-only, repeatable-read transaction.
+	// GetUtxoEvents shares one across its four Find*From calls so they
+	// observe a single consistent point in time — without it, the four
+	// independent reads could straddle the live indexer committing a new
+	// block between them, each table then reflecting a different "as of"
+	// point and corrupting the merged next_position cursor.
+	ReadTransaction() types.Txn
 }
 
 // GetAssetCreates returns cNIGHT UTxO creations starting strictly after
@@ -234,19 +241,26 @@ func (s *service) GetUtxoEvents(
 	}
 	limit := effectivePageSize(req.GetTxCapacity())
 
-	creates, err := s.metadata.FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, nil)
+	// One shared read transaction for all four tables: without it, each
+	// Find*From call would independently see whatever the live indexer had
+	// most recently committed, so the four reads could straddle a block
+	// commit and disagree on "as of" which block/tx they cover.
+	txn := s.metadata.ReadTransaction()
+	defer txn.Rollback() //nolint:errcheck
+
+	creates, err := s.metadata.FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, txn)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "query asset creates: %v", err)
 	}
-	spends, err := s.metadata.FindMidnightAssetSpendsFrom(startBlock, startTxIndex, limit, nil)
+	spends, err := s.metadata.FindMidnightAssetSpendsFrom(startBlock, startTxIndex, limit, txn)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "query asset spends: %v", err)
 	}
-	registrations, err := s.metadata.FindMidnightRegistrationsFrom(startBlock, startTxIndex, limit, nil)
+	registrations, err := s.metadata.FindMidnightRegistrationsFrom(startBlock, startTxIndex, limit, txn)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "query registrations: %v", err)
 	}
-	deregistrations, err := s.metadata.FindMidnightDeregistrationsFrom(startBlock, startTxIndex, limit, nil)
+	deregistrations, err := s.metadata.FindMidnightDeregistrationsFrom(startBlock, startTxIndex, limit, txn)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "query deregistrations: %v", err)
 	}

--- a/midnight/server/midnight_state.go
+++ b/midnight/server/midnight_state.go
@@ -15,11 +15,11 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"sort"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/midnight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -35,6 +35,65 @@ const (
 	utxoEventKindDeregistration
 )
 
+const (
+	// defaultEventPageSize is used when a request's capacity field is the
+	// proto3 zero value (unset), so a page always has a bounded size
+	// instead of triggering an unbounded store scan and response.
+	defaultEventPageSize = 1000
+	// maxEventPageSize caps a client-requested capacity so a single page
+	// can't force an unbounded scan/response.
+	maxEventPageSize = 10000
+)
+
+// effectivePageSize clamps a client-requested capacity to
+// [1, maxEventPageSize], substituting defaultEventPageSize when the request
+// omitted it (proto3 zero value). The store's own Find*From contract treats
+// limit <= 0 as "no SQL LIMIT", so RPC handlers must never forward a
+// non-positive capacity as-is.
+func effectivePageSize(requested uint32) int {
+	switch {
+	case requested == 0:
+		return defaultEventPageSize
+	case requested > maxEventPageSize:
+		return maxEventPageSize
+	default:
+		return int(requested)
+	}
+}
+
+// eventStore is the narrow slice of metadata.MetadataStore used by the
+// UTxO-event query RPCs. It is declared locally, rather than depending on
+// the full metadata.MetadataStore interface, so this gRPC-query package
+// does not carry unrelated write-path and lifecycle methods; any store
+// (e.g. *sqlite.MetadataStoreSqlite) that implements these four methods
+// satisfies it structurally, with no explicit declaration required.
+type eventStore interface {
+	FindMidnightAssetCreatesFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightAssetCreate, error)
+	FindMidnightAssetSpendsFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightAssetSpend, error)
+	FindMidnightRegistrationsFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightRegistration, error)
+	FindMidnightDeregistrationsFrom(
+		startBlock uint64,
+		startTxIndex uint32,
+		limit int,
+		txn types.Txn,
+	) ([]models.MidnightDeregistration, error)
+}
+
 // GetAssetCreates returns cNIGHT UTxO creations starting strictly after
 // (start_block, start_tx_index), ordered by (block_number, tx_index)
 // ascending and capped at utxo_capacity rows.
@@ -48,7 +107,7 @@ func (s *service) GetAssetCreates(
 	rows, err := s.metadata.FindMidnightAssetCreatesFrom(
 		uint64(req.GetStartBlock()),
 		req.GetStartTxIndex(),
-		int(req.GetUtxoCapacity()),
+		effectivePageSize(req.GetUtxoCapacity()),
 		nil,
 	)
 	if err != nil {
@@ -74,7 +133,7 @@ func (s *service) GetAssetSpends(
 	rows, err := s.metadata.FindMidnightAssetSpendsFrom(
 		uint64(req.GetStartBlock()),
 		req.GetStartTxIndex(),
-		int(req.GetUtxoCapacity()),
+		effectivePageSize(req.GetUtxoCapacity()),
 		nil,
 	)
 	if err != nil {
@@ -100,7 +159,7 @@ func (s *service) GetRegistrations(
 	rows, err := s.metadata.FindMidnightRegistrationsFrom(
 		uint64(req.GetStartBlock()),
 		req.GetStartTxIndex(),
-		int(req.GetUtxoCapacity()),
+		effectivePageSize(req.GetUtxoCapacity()),
 		nil,
 	)
 	if err != nil {
@@ -126,7 +185,7 @@ func (s *service) GetDeregistrations(
 	rows, err := s.metadata.FindMidnightDeregistrationsFrom(
 		uint64(req.GetStartBlock()),
 		req.GetStartTxIndex(),
-		int(req.GetUtxoCapacity()),
+		effectivePageSize(req.GetUtxoCapacity()),
 		nil,
 	)
 	if err != nil {
@@ -173,7 +232,7 @@ func (s *service) GetUtxoEvents(
 		startBlock = uint64(pos.GetBlockNumber())
 		startTxIndex = pos.GetTxIndex()
 	}
-	limit := int(req.GetTxCapacity())
+	limit := effectivePageSize(req.GetTxCapacity())
 
 	creates, err := s.metadata.FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, nil)
 	if err != nil {
@@ -261,12 +320,18 @@ func (s *service) GetUtxoEvents(
 	})
 
 	if endHash := req.GetEndBlockHash(); len(endHash) > 0 {
-		boundary, found := uint64(0), false
-		for _, item := range items {
-			if bytes.Equal(item.blockHash, endHash) {
-				boundary, found = item.blockNumber, true
-				break
-			}
+		if s.blockNumberByHash == nil {
+			return nil, status.Error(
+				codes.FailedPrecondition,
+				"end_block_hash requires a configured block resolver",
+			)
+		}
+		// Resolved independently of the fetched event rows: a block with no
+		// Midnight events of its own would never be found by scanning
+		// items, silently letting the response run past the boundary.
+		boundary, found, err := s.blockNumberByHash(endHash)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "resolve end_block_hash: %v", err)
 		}
 		if found {
 			cut := len(items)
@@ -281,7 +346,17 @@ func (s *service) GetUtxoEvents(
 	}
 
 	if limit > 0 && len(items) > limit {
-		items = items[:limit]
+		// Extend forward while the next item shares the cutoff's
+		// (block_number, tx_index) key, so a page never splits a single
+		// transaction's events across kinds (e.g. a create and a
+		// registration written by the same tx).
+		cut := limit
+		for cut < len(items) &&
+			items[cut].blockNumber == items[cut-1].blockNumber &&
+			items[cut].txIndex == items[cut-1].txIndex {
+			cut++
+		}
+		items = items[:cut]
 	}
 
 	events := make([]*midnight.UtxoEvent, len(items))

--- a/midnight/server/midnight_state.go
+++ b/midnight/server/midnight_state.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"sort"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/midnight"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// kind_order tie-break used when merging the four UTxO-event tables in
+// GetUtxoEvents: events at the same (block_number, tx_index) sort
+// create < spend < registration < deregistration.
+const (
+	utxoEventKindAssetCreate = iota
+	utxoEventKindAssetSpend
+	utxoEventKindRegistration
+	utxoEventKindDeregistration
+)
+
+// GetAssetCreates returns cNIGHT UTxO creations starting strictly after
+// (start_block, start_tx_index), ordered by (block_number, tx_index)
+// ascending and capped at utxo_capacity rows.
+func (s *service) GetAssetCreates(
+	_ context.Context,
+	req *midnight.AssetCreatesRequest,
+) (*midnight.AssetCreatesResponse, error) {
+	if s.metadata == nil {
+		return nil, status.Error(codes.Unimplemented, "method GetAssetCreates not implemented")
+	}
+	rows, err := s.metadata.FindMidnightAssetCreatesFrom(
+		uint64(req.GetStartBlock()),
+		req.GetStartTxIndex(),
+		int(req.GetUtxoCapacity()),
+		nil,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query asset creates: %v", err)
+	}
+	creates := make([]*midnight.AssetCreate, len(rows))
+	for i := range rows {
+		creates[i] = assetCreateToProto(&rows[i])
+	}
+	return &midnight.AssetCreatesResponse{Creates: creates}, nil
+}
+
+// GetAssetSpends returns cNIGHT UTxO spends starting strictly after
+// (start_block, start_tx_index), ordered by (block_number, tx_index)
+// ascending and capped at utxo_capacity rows.
+func (s *service) GetAssetSpends(
+	_ context.Context,
+	req *midnight.AssetSpendsRequest,
+) (*midnight.AssetSpendsResponse, error) {
+	if s.metadata == nil {
+		return nil, status.Error(codes.Unimplemented, "method GetAssetSpends not implemented")
+	}
+	rows, err := s.metadata.FindMidnightAssetSpendsFrom(
+		uint64(req.GetStartBlock()),
+		req.GetStartTxIndex(),
+		int(req.GetUtxoCapacity()),
+		nil,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query asset spends: %v", err)
+	}
+	spends := make([]*midnight.AssetSpend, len(rows))
+	for i := range rows {
+		spends[i] = assetSpendToProto(&rows[i])
+	}
+	return &midnight.AssetSpendsResponse{Spends: spends}, nil
+}
+
+// GetRegistrations returns mapping-validator registrations starting strictly
+// after (start_block, start_tx_index), ordered by (block_number, tx_index)
+// ascending and capped at utxo_capacity rows.
+func (s *service) GetRegistrations(
+	_ context.Context,
+	req *midnight.RegistrationsRequest,
+) (*midnight.RegistrationsResponse, error) {
+	if s.metadata == nil {
+		return nil, status.Error(codes.Unimplemented, "method GetRegistrations not implemented")
+	}
+	rows, err := s.metadata.FindMidnightRegistrationsFrom(
+		uint64(req.GetStartBlock()),
+		req.GetStartTxIndex(),
+		int(req.GetUtxoCapacity()),
+		nil,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query registrations: %v", err)
+	}
+	registrations := make([]*midnight.Registration, len(rows))
+	for i := range rows {
+		registrations[i] = registrationToProto(&rows[i])
+	}
+	return &midnight.RegistrationsResponse{Registrations: registrations}, nil
+}
+
+// GetDeregistrations returns mapping-validator deregistrations starting
+// strictly after (start_block, start_tx_index), ordered by (block_number,
+// tx_index) ascending and capped at utxo_capacity rows.
+func (s *service) GetDeregistrations(
+	_ context.Context,
+	req *midnight.DeregistrationsRequest,
+) (*midnight.DeregistrationsResponse, error) {
+	if s.metadata == nil {
+		return nil, status.Error(codes.Unimplemented, "method GetDeregistrations not implemented")
+	}
+	rows, err := s.metadata.FindMidnightDeregistrationsFrom(
+		uint64(req.GetStartBlock()),
+		req.GetStartTxIndex(),
+		int(req.GetUtxoCapacity()),
+		nil,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query deregistrations: %v", err)
+	}
+	deregistrations := make([]*midnight.Deregistration, len(rows))
+	for i := range rows {
+		deregistrations[i] = deregistrationToProto(&rows[i])
+	}
+	return &midnight.DeregistrationsResponse{Deregistrations: deregistrations}, nil
+}
+
+// utxoEventMergeItem is one row from any of the four UTxO-event tables,
+// carrying the fields needed to merge-sort across tables and to build the
+// next_position cursor.
+type utxoEventMergeItem struct {
+	blockNumber uint64
+	txIndex     uint32
+	kindOrder   int
+	blockHash   []byte
+	timestampMs uint64
+	event       *midnight.UtxoEvent
+}
+
+// GetUtxoEvents returns a merged, kind_order-tie-broken stream of all four
+// UTxO-event tables starting strictly after start_position, capped at
+// tx_capacity events and optionally stopped at end_block_hash.
+//
+// Fetching each table's own top tx_capacity rows (ordered ascending) is
+// sufficient to compute the correct global top-tx_capacity merge: any row
+// beyond position tx_capacity within its own table already has tx_capacity
+// smaller-or-equal rows ahead of it in that single table, so it cannot be
+// among the smallest tx_capacity rows overall.
+func (s *service) GetUtxoEvents(
+	_ context.Context,
+	req *midnight.UtxoEventsRequest,
+) (*midnight.UtxoEventsResponse, error) {
+	if s.metadata == nil {
+		return nil, status.Error(codes.Unimplemented, "method GetUtxoEvents not implemented")
+	}
+	var startBlock uint64
+	var startTxIndex uint32
+	if pos := req.GetStartPosition(); pos != nil {
+		startBlock = uint64(pos.GetBlockNumber())
+		startTxIndex = pos.GetTxIndex()
+	}
+	limit := int(req.GetTxCapacity())
+
+	creates, err := s.metadata.FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query asset creates: %v", err)
+	}
+	spends, err := s.metadata.FindMidnightAssetSpendsFrom(startBlock, startTxIndex, limit, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query asset spends: %v", err)
+	}
+	registrations, err := s.metadata.FindMidnightRegistrationsFrom(startBlock, startTxIndex, limit, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query registrations: %v", err)
+	}
+	deregistrations, err := s.metadata.FindMidnightDeregistrationsFrom(startBlock, startTxIndex, limit, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "query deregistrations: %v", err)
+	}
+
+	items := make(
+		[]utxoEventMergeItem,
+		0,
+		len(creates)+len(spends)+len(registrations)+len(deregistrations),
+	)
+	for i := range creates {
+		row := &creates[i]
+		items = append(items, utxoEventMergeItem{
+			blockNumber: row.BlockNumber,
+			txIndex:     row.TxIndex,
+			kindOrder:   utxoEventKindAssetCreate,
+			blockHash:   row.BlockHash,
+			timestampMs: row.BlockTimestampMs,
+			event: &midnight.UtxoEvent{
+				Kind: &midnight.UtxoEvent_AssetCreate{AssetCreate: assetCreateToProto(row)},
+			},
+		})
+	}
+	for i := range spends {
+		row := &spends[i]
+		items = append(items, utxoEventMergeItem{
+			blockNumber: row.BlockNumber,
+			txIndex:     row.TxIndex,
+			kindOrder:   utxoEventKindAssetSpend,
+			blockHash:   row.BlockHash,
+			timestampMs: row.BlockTimestampMs,
+			event: &midnight.UtxoEvent{
+				Kind: &midnight.UtxoEvent_AssetSpend{AssetSpend: assetSpendToProto(row)},
+			},
+		})
+	}
+	for i := range registrations {
+		row := &registrations[i]
+		items = append(items, utxoEventMergeItem{
+			blockNumber: row.BlockNumber,
+			txIndex:     row.TxIndex,
+			kindOrder:   utxoEventKindRegistration,
+			blockHash:   row.BlockHash,
+			timestampMs: row.BlockTimestampMs,
+			event: &midnight.UtxoEvent{
+				Kind: &midnight.UtxoEvent_Registration{Registration: registrationToProto(row)},
+			},
+		})
+	}
+	for i := range deregistrations {
+		row := &deregistrations[i]
+		items = append(items, utxoEventMergeItem{
+			blockNumber: row.BlockNumber,
+			txIndex:     row.TxIndex,
+			kindOrder:   utxoEventKindDeregistration,
+			blockHash:   row.BlockHash,
+			timestampMs: row.BlockTimestampMs,
+			event: &midnight.UtxoEvent{
+				Kind: &midnight.UtxoEvent_Deregistration{Deregistration: deregistrationToProto(row)},
+			},
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].blockNumber != items[j].blockNumber {
+			return items[i].blockNumber < items[j].blockNumber
+		}
+		if items[i].txIndex != items[j].txIndex {
+			return items[i].txIndex < items[j].txIndex
+		}
+		return items[i].kindOrder < items[j].kindOrder
+	})
+
+	if endHash := req.GetEndBlockHash(); len(endHash) > 0 {
+		boundary, found := uint64(0), false
+		for _, item := range items {
+			if bytes.Equal(item.blockHash, endHash) {
+				boundary, found = item.blockNumber, true
+				break
+			}
+		}
+		if found {
+			cut := len(items)
+			for i, item := range items {
+				if item.blockNumber > boundary {
+					cut = i
+					break
+				}
+			}
+			items = items[:cut]
+		}
+	}
+
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+
+	events := make([]*midnight.UtxoEvent, len(items))
+	for i, item := range items {
+		events[i] = item.event
+	}
+	resp := &midnight.UtxoEventsResponse{Events: events}
+	if len(items) > 0 {
+		last := items[len(items)-1]
+		resp.NextPosition = &midnight.CardanoPosition{
+			BlockHash:                last.blockHash,
+			BlockNumber:              uint32(last.blockNumber), //nolint:gosec // wire format is uint32
+			TxIndex:                  last.txIndex,
+			BlockTimestampUnixMillis: int64(last.timestampMs), //nolint:gosec // wire format is int64
+		}
+	}
+	return resp, nil
+}
+
+func assetCreateToProto(row *models.MidnightAssetCreate) *midnight.AssetCreate {
+	return &midnight.AssetCreate{
+		Address:                  row.Address,
+		Quantity:                 row.Quantity,
+		TxHash:                   row.TxHash,
+		OutputIndex:              row.OutputIndex,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		BlockTimestampUnixMillis: int64(row.BlockTimestampMs), //nolint:gosec // wire format is int64
+	}
+}
+
+func assetSpendToProto(row *models.MidnightAssetSpend) *midnight.AssetSpend {
+	return &midnight.AssetSpend{
+		Address:                  row.Address,
+		Quantity:                 row.Quantity,
+		SpendingTxHash:           row.SpendingTxHash,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		UtxoTxHash:               row.UtxoTxHash,
+		UtxoIndex:                row.UtxoIndex,
+		BlockTimestampUnixMillis: int64(row.BlockTimestampMs), //nolint:gosec // wire format is int64
+	}
+}
+
+func registrationToProto(row *models.MidnightRegistration) *midnight.Registration {
+	return &midnight.Registration{
+		FullDatum:                row.FullDatum,
+		TxHash:                   row.TxHash,
+		OutputIndex:              row.OutputIndex,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		BlockTimestampUnixMillis: int64(row.BlockTimestampMs), //nolint:gosec // wire format is int64
+	}
+}
+
+func deregistrationToProto(row *models.MidnightDeregistration) *midnight.Deregistration {
+	return &midnight.Deregistration{
+		FullDatum:                row.FullDatum,
+		TxHash:                   row.TxHash,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		UtxoTxHash:               row.UtxoTxHash,
+		UtxoIndex:                row.UtxoIndex,
+		BlockTimestampUnixMillis: int64(row.BlockTimestampMs), //nolint:gosec // wire format is int64
+	}
+}

--- a/midnight/server/midnight_state_internal_test.go
+++ b/midnight/server/midnight_state_internal_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEffectivePageSize verifies zero/omitted capacity requests fall back
+// to a bounded default instead of being forwarded to the store as an
+// unbounded scan (limit <= 0 means "no SQL LIMIT" in the store contract),
+// and that oversized requests are clamped rather than honored as-is.
+func TestEffectivePageSize(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, defaultEventPageSize, effectivePageSize(0))
+	require.Equal(t, 1, effectivePageSize(1))
+	require.Equal(t, maxEventPageSize, effectivePageSize(maxEventPageSize))
+	require.Equal(t, maxEventPageSize, effectivePageSize(maxEventPageSize+1))
+}

--- a/midnight/server/midnight_state_test.go
+++ b/midnight/server/midnight_state_test.go
@@ -17,9 +17,7 @@ package server_test
 import (
 	"context"
 	"log/slog"
-	"net"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -28,6 +26,8 @@ import (
 	"github.com/blinklabs-io/dingo/midnight"
 	"github.com/blinklabs-io/dingo/midnight/server"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // setupTestStore creates an in-memory sqlite metadata store with the schema
@@ -44,28 +44,12 @@ func setupTestStore(t *testing.T) *sqlite.MetadataStoreSqlite {
 	return store
 }
 
-// startTestServerWithMetadata starts a server backed by md and returns its
-// dial address. The server is stopped on test cleanup.
+// startTestServerWithMetadata starts a server backed by md (with no block
+// resolver configured) and returns its dial address. The server is stopped
+// on test cleanup.
 func startTestServerWithMetadata(t *testing.T, md *sqlite.MetadataStoreSqlite) string {
 	t.Helper()
-	port := freePort(t)
-	srv, err := server.New(server.Config{
-		Host:     "127.0.0.1",
-		Port:     port,
-		Metadata: md,
-	})
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	require.NoError(t, srv.Start(ctx))
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer stopCancel()
-		require.NoError(t, srv.Stop(stopCtx))
-	})
-
-	return net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
+	return startTestServerConfig(t, server.Config{Metadata: md})
 }
 
 func hashForByte(b byte) []byte {
@@ -312,4 +296,141 @@ func TestGetUtxoEvents_CursorPagination(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, page3.GetEvents())
+}
+
+// TestGetUtxoEvents_TxCapacityDoesNotSplitTxGroup verifies that when
+// tx_capacity would otherwise cut through events sharing the same
+// (block_number, tx_index) but different kinds (e.g. a cNIGHT create and a
+// mapping-validator registration written by the same tx), the page is
+// extended to include the whole group rather than dropping the remainder.
+func TestGetUtxoEvents_TxCapacityDoesNotSplitTxGroup(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+		Address:     []byte{0x01},
+		Quantity:    1,
+		TxHash:      hashForByte(1),
+		OutputIndex: 0,
+		BlockNumber: 1,
+		BlockHash:   hashForByte(1),
+		TxIndex:     0,
+	}))
+	require.NoError(t, store.CreateMidnightRegistration(nil, &models.MidnightRegistration{
+		FullDatum:   []byte{0xd1},
+		TxHash:      hashForByte(2),
+		OutputIndex: 0,
+		BlockNumber: 1,
+		BlockHash:   hashForByte(1),
+		TxIndex:     0,
+	}))
+	require.NoError(t, store.CreateMidnightAssetSpend(nil, &models.MidnightAssetSpend{
+		Address:        []byte{0x01},
+		Quantity:       1,
+		SpendingTxHash: hashForByte(3),
+		UtxoTxHash:     hashForByte(4),
+		UtxoIndex:      0,
+		BlockNumber:    2,
+		BlockHash:      hashForByte(2),
+		TxIndex:        0,
+	}))
+
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// tx_capacity=1 would naturally cut after just the create, splitting
+	// the (1,0) group; the handler must extend to include the registration
+	// too, without pulling in the unrelated spend at (2,0).
+	resp, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{TxCapacity: 1})
+	require.NoError(t, err)
+	require.Len(t, resp.GetEvents(), 2, "must extend past tx_capacity to include the full (1,0) group")
+	require.NotNil(t, resp.GetEvents()[0].GetAssetCreate())
+	require.NotNil(t, resp.GetEvents()[1].GetRegistration())
+
+	next := resp.GetNextPosition()
+	require.NotNil(t, next)
+	require.Equal(t, uint32(1), next.GetBlockNumber())
+	require.Equal(t, uint32(0), next.GetTxIndex())
+
+	page2, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{
+		TxCapacity:    1,
+		StartPosition: next,
+	})
+	require.NoError(t, err)
+	require.Len(t, page2.GetEvents(), 1, "resuming must find exactly the spend, with no duplicates")
+	require.NotNil(t, page2.GetEvents()[0].GetAssetSpend())
+}
+
+// TestGetUtxoEvents_EndBlockHashRequiresResolver verifies end_block_hash
+// fails clearly when no block resolver is configured, instead of silently
+// ignoring the boundary.
+func TestGetUtxoEvents_EndBlockHashRequiresResolver(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{
+		TxCapacity:   10,
+		EndBlockHash: hashForByte(1),
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestGetUtxoEvents_EndBlockHashStopsAtBlockWithNoEvents verifies the
+// end_block_hash boundary is honored even when the target block itself
+// carries no Midnight events — resolved via the configured block resolver,
+// not by scanning the fetched event rows (which would never find a hash
+// belonging to an event-less block).
+func TestGetUtxoEvents_EndBlockHashStopsAtBlockWithNoEvents(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+		Address:     []byte{0x01},
+		Quantity:    1,
+		TxHash:      hashForByte(1),
+		OutputIndex: 0,
+		BlockNumber: 1,
+		BlockHash:   hashForByte(1),
+		TxIndex:     0,
+	}))
+	require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+		Address:     []byte{0x01},
+		Quantity:    1,
+		TxHash:      hashForByte(2),
+		OutputIndex: 0,
+		BlockNumber: 3,
+		BlockHash:   hashForByte(3),
+		TxIndex:     0,
+	}))
+
+	// Block 2 is resolvable on-chain but has zero Midnight events of its
+	// own.
+	blockNumbers := map[string]uint64{
+		string(hashForByte(1)): 1,
+		string(hashForByte(2)): 2,
+		string(hashForByte(3)): 3,
+	}
+	addr := startTestServerConfig(t, server.Config{
+		Metadata: store,
+		BlockNumberByHash: func(hash []byte) (uint64, bool, error) {
+			n, ok := blockNumbers[string(hash)]
+			return n, ok, nil
+		},
+	})
+	client := midnight.NewMidnightStateClient(dial(t, addr))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{
+		TxCapacity:   10,
+		EndBlockHash: hashForByte(2),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetEvents(), 1, "must include block 1's create but exclude block 3's, even though the boundary block 2 has no events of its own")
+	require.Equal(t, uint64(1), resp.GetEvents()[0].GetAssetCreate().GetBlockNumber())
 }

--- a/midnight/server/midnight_state_test.go
+++ b/midnight/server/midnight_state_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/midnight"
+	"github.com/blinklabs-io/dingo/midnight/server"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestStore creates an in-memory sqlite metadata store with the schema
+// migrated, so tests can seed midnight_* tables directly.
+func setupTestStore(t *testing.T) *sqlite.MetadataStoreSqlite {
+	t.Helper()
+	store, err := sqlite.New("", slog.New(slog.NewTextHandler(os.Stderr, nil)), nil)
+	require.NoError(t, err)
+	require.NoError(t, store.Start())
+	require.NoError(t, store.DB().AutoMigrate(models.MigrateModels...))
+	t.Cleanup(func() {
+		store.Close() //nolint:errcheck
+	})
+	return store
+}
+
+// startTestServerWithMetadata starts a server backed by md and returns its
+// dial address. The server is stopped on test cleanup.
+func startTestServerWithMetadata(t *testing.T, md *sqlite.MetadataStoreSqlite) string {
+	t.Helper()
+	port := freePort(t)
+	srv, err := server.New(server.Config{
+		Host:     "127.0.0.1",
+		Port:     port,
+		Metadata: md,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+
+	return net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
+}
+
+func hashForByte(b byte) []byte {
+	h := make([]byte, 32)
+	h[31] = b
+	return h
+}
+
+func TestGetAssetCreates_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetAssetCreates(ctx, &midnight.AssetCreatesRequest{UtxoCapacity: 10})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetCreates())
+}
+
+// TestGetAssetCreates_CursorPagination seeds rows across three blocks and
+// pages through them with a page size smaller than the total row count,
+// asserting every row is returned exactly once, in order, with no gaps.
+func TestGetAssetCreates_CursorPagination(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	for i, p := range []struct {
+		block uint64
+		tx    uint32
+	}{{1, 0}, {1, 1}, {2, 0}, {3, 0}} {
+		require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+			Address:     []byte{0x01},
+			Quantity:    uint64(i + 1),
+			TxHash:      hashForByte(byte(i + 1)),
+			OutputIndex: 0,
+			BlockNumber: p.block,
+			BlockHash:   hashForByte(byte(p.block)),
+			TxIndex:     p.tx,
+		}))
+	}
+
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var startBlock, startTxIndex uint32
+	type pos struct {
+		block uint64
+		tx    uint32
+	}
+	var got []pos
+	for range 5 {
+		resp, err := client.GetAssetCreates(ctx, &midnight.AssetCreatesRequest{
+			StartBlock:   startBlock,
+			StartTxIndex: startTxIndex,
+			UtxoCapacity: 2,
+		})
+		require.NoError(t, err)
+		if len(resp.GetCreates()) == 0 {
+			break
+		}
+		require.LessOrEqual(t, len(resp.GetCreates()), 2)
+		for _, c := range resp.GetCreates() {
+			got = append(got, pos{c.GetBlockNumber(), c.GetTxIndex()})
+		}
+		last := resp.GetCreates()[len(resp.GetCreates())-1]
+		startBlock, startTxIndex = uint32(last.GetBlockNumber()), last.GetTxIndex()
+	}
+
+	require.Equal(t, []pos{{1, 0}, {1, 1}, {2, 0}, {3, 0}}, got)
+}
+
+func TestGetAssetSpends_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetAssetSpends(ctx, &midnight.AssetSpendsRequest{UtxoCapacity: 10})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetSpends())
+}
+
+func TestGetRegistrations_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetRegistrations(ctx, &midnight.RegistrationsRequest{UtxoCapacity: 10})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetRegistrations())
+}
+
+func TestGetDeregistrations_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetDeregistrations(ctx, &midnight.DeregistrationsRequest{UtxoCapacity: 10})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetDeregistrations())
+}
+
+func TestGetUtxoEvents_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{TxCapacity: 10})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetEvents())
+	require.Nil(t, resp.GetNextPosition())
+}
+
+// TestGetUtxoEvents_KindOrderTieBreak seeds one row of each of the four
+// event types at the same (block_number, tx_index) and asserts GetUtxoEvents
+// merges them in kind_order: create, spend, registration, deregistration.
+func TestGetUtxoEvents_KindOrderTieBreak(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	const block, tx = uint64(5), uint32(2)
+	require.NoError(t, store.CreateMidnightDeregistration(nil, &models.MidnightDeregistration{
+		FullDatum:   []byte{0xd0},
+		TxHash:      hashForByte(1),
+		UtxoTxHash:  hashForByte(2),
+		UtxoIndex:   0,
+		BlockNumber: block,
+		BlockHash:   hashForByte(byte(block)),
+		TxIndex:     tx,
+	}))
+	require.NoError(t, store.CreateMidnightRegistration(nil, &models.MidnightRegistration{
+		FullDatum:   []byte{0xd1},
+		TxHash:      hashForByte(3),
+		OutputIndex: 0,
+		BlockNumber: block,
+		BlockHash:   hashForByte(byte(block)),
+		TxIndex:     tx,
+	}))
+	require.NoError(t, store.CreateMidnightAssetSpend(nil, &models.MidnightAssetSpend{
+		Address:        []byte{0x01},
+		Quantity:       1,
+		SpendingTxHash: hashForByte(4),
+		UtxoTxHash:     hashForByte(5),
+		UtxoIndex:      0,
+		BlockNumber:    block,
+		BlockHash:      hashForByte(byte(block)),
+		TxIndex:        tx,
+	}))
+	require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+		Address:     []byte{0x01},
+		Quantity:    1,
+		TxHash:      hashForByte(6),
+		OutputIndex: 0,
+		BlockNumber: block,
+		BlockHash:   hashForByte(byte(block)),
+		TxIndex:     tx,
+	}))
+
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{TxCapacity: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.GetEvents(), 4)
+
+	require.NotNil(t, resp.GetEvents()[0].GetAssetCreate())
+	require.NotNil(t, resp.GetEvents()[1].GetAssetSpend())
+	require.NotNil(t, resp.GetEvents()[2].GetRegistration())
+	require.NotNil(t, resp.GetEvents()[3].GetDeregistration())
+
+	next := resp.GetNextPosition()
+	require.NotNil(t, next)
+	require.Equal(t, uint32(block), next.GetBlockNumber())
+	require.Equal(t, tx, next.GetTxIndex())
+}
+
+// TestGetUtxoEvents_CursorPagination verifies the next_position cursor
+// returned from one page correctly resumes the merged stream on the next
+// call, with no duplicates and no gaps across event kinds.
+func TestGetUtxoEvents_CursorPagination(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	require.NoError(t, store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+		Address:     []byte{0x01},
+		Quantity:    1,
+		TxHash:      hashForByte(1),
+		OutputIndex: 0,
+		BlockNumber: 1,
+		BlockHash:   hashForByte(1),
+		TxIndex:     0,
+	}))
+	require.NoError(t, store.CreateMidnightRegistration(nil, &models.MidnightRegistration{
+		FullDatum:   []byte{0xd1},
+		TxHash:      hashForByte(2),
+		OutputIndex: 0,
+		BlockNumber: 1,
+		BlockHash:   hashForByte(1),
+		TxIndex:     1,
+	}))
+	require.NoError(t, store.CreateMidnightAssetSpend(nil, &models.MidnightAssetSpend{
+		Address:        []byte{0x01},
+		Quantity:       1,
+		SpendingTxHash: hashForByte(3),
+		UtxoTxHash:     hashForByte(4),
+		UtxoIndex:      0,
+		BlockNumber:    2,
+		BlockHash:      hashForByte(2),
+		TxIndex:        0,
+	}))
+
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerWithMetadata(t, store)))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	page1, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{TxCapacity: 2})
+	require.NoError(t, err)
+	require.Len(t, page1.GetEvents(), 2)
+	require.NotNil(t, page1.GetEvents()[0].GetAssetCreate())
+	require.NotNil(t, page1.GetEvents()[1].GetRegistration())
+	require.NotNil(t, page1.GetNextPosition())
+
+	page2, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{
+		TxCapacity:    2,
+		StartPosition: page1.GetNextPosition(),
+	})
+	require.NoError(t, err)
+	require.Len(t, page2.GetEvents(), 1)
+	require.NotNil(t, page2.GetEvents()[0].GetAssetSpend())
+
+	page3, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{
+		TxCapacity:    2,
+		StartPosition: page2.GetNextPosition(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, page3.GetEvents())
+}

--- a/midnight/server/midnight_state_test.go
+++ b/midnight/server/midnight_state_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/midnight"
 	"github.com/blinklabs-io/dingo/midnight/server"
 	"github.com/stretchr/testify/require"
@@ -433,4 +434,84 @@ func TestGetUtxoEvents_EndBlockHashStopsAtBlockWithNoEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.GetEvents(), 1, "must include block 1's create but exclude block 3's, even though the boundary block 2 has no events of its own")
 	require.Equal(t, uint64(1), resp.GetEvents()[0].GetAssetCreate().GetBlockNumber())
+}
+
+// spyEventStore wraps a real store and records the txn passed to
+// ReadTransaction and to each Find*From call, so a test can assert
+// GetUtxoEvents shares exactly one read transaction across all four tables
+// instead of passing nil (a separate, independently-timed read) to each.
+type spyEventStore struct {
+	*sqlite.MetadataStoreSqlite
+	readTxnCalls int
+	seenTxns     []types.Txn
+}
+
+func (s *spyEventStore) ReadTransaction() types.Txn {
+	s.readTxnCalls++
+	return s.MetadataStoreSqlite.ReadTransaction()
+}
+
+func (s *spyEventStore) FindMidnightAssetCreatesFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetCreate, error) {
+	s.seenTxns = append(s.seenTxns, txn)
+	return s.MetadataStoreSqlite.FindMidnightAssetCreatesFrom(startBlock, startTxIndex, limit, txn)
+}
+
+func (s *spyEventStore) FindMidnightAssetSpendsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightAssetSpend, error) {
+	s.seenTxns = append(s.seenTxns, txn)
+	return s.MetadataStoreSqlite.FindMidnightAssetSpendsFrom(startBlock, startTxIndex, limit, txn)
+}
+
+func (s *spyEventStore) FindMidnightRegistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightRegistration, error) {
+	s.seenTxns = append(s.seenTxns, txn)
+	return s.MetadataStoreSqlite.FindMidnightRegistrationsFrom(startBlock, startTxIndex, limit, txn)
+}
+
+func (s *spyEventStore) FindMidnightDeregistrationsFrom(
+	startBlock uint64,
+	startTxIndex uint32,
+	limit int,
+	txn types.Txn,
+) ([]models.MidnightDeregistration, error) {
+	s.seenTxns = append(s.seenTxns, txn)
+	return s.MetadataStoreSqlite.FindMidnightDeregistrationsFrom(startBlock, startTxIndex, limit, txn)
+}
+
+// TestGetUtxoEvents_SharesOneReadTransactionAcrossTables verifies GetUtxoEvents
+// opens exactly one read transaction and passes that SAME transaction to all
+// four Find*From calls, rather than four independent (nil-txn) reads that
+// could each observe a different point in time while the live indexer is
+// mid-block.
+func TestGetUtxoEvents_SharesOneReadTransactionAcrossTables(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	spy := &spyEventStore{MetadataStoreSqlite: store}
+
+	client := midnight.NewMidnightStateClient(dial(t, startTestServerConfig(t, server.Config{Metadata: spy})))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.GetUtxoEvents(ctx, &midnight.UtxoEventsRequest{TxCapacity: 10})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, spy.readTxnCalls, "GetUtxoEvents must open exactly one read transaction")
+	require.Len(t, spy.seenTxns, 4, "all four Find*From calls must have run")
+	for i, txn := range spy.seenTxns {
+		require.NotNil(t, txn, "call %d must receive the shared transaction, not nil", i)
+		require.True(t, txn == spy.seenTxns[0], "call %d must receive the SAME transaction object as the others", i)
+	}
 }

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/midnight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -53,8 +52,15 @@ type Config struct {
 	// Metadata is the store backing the MidnightState query RPCs
 	// (GetAssetCreates, GetAssetSpends, GetRegistrations,
 	// GetDeregistrations, GetUtxoEvents). Nil leaves those RPCs
-	// unimplemented.
-	Metadata metadata.MetadataStore
+	// unimplemented. Any metadata.MetadataStore implementation satisfies
+	// this narrower interface structurally.
+	Metadata eventStore
+	// BlockNumberByHash resolves a Cardano block hash to its block number.
+	// It backs GetUtxoEvents' end_block_hash boundary so that boundary is
+	// honored even when the target block has no Midnight events of its
+	// own (found=false for an unknown hash, not an error). Nil causes
+	// GetUtxoEvents to fail requests that set end_block_hash.
+	BlockNumberByHash func(hash []byte) (blockNumber uint64, found bool, err error)
 	// Host and Port are the gRPC listen address. Defaults to 0.0.0.0:50051.
 	Host string
 	Port uint
@@ -140,7 +146,10 @@ func (s *Server) Start(ctx context.Context) error {
 	// MidnightState service: the UTxO-event query RPCs are implemented
 	// against s.config.Metadata; every other RPC returns Unimplemented until
 	// its handler lands.
-	midnight.RegisterMidnightStateServer(grpcServer, &service{metadata: s.config.Metadata})
+	midnight.RegisterMidnightStateServer(grpcServer, &service{
+		metadata:          s.config.Metadata,
+		blockNumberByHash: s.config.BlockNumberByHash,
+	})
 
 	// Health service reporting SERVING for the overall server ("") and the
 	// MidnightState service by name.
@@ -259,5 +268,6 @@ func (s *Server) gracefulStop(timeout time.Duration) {
 // return codes.Unimplemented until its handler is added in follow-up work.
 type service struct {
 	midnight.UnimplementedMidnightStateServer
-	metadata metadata.MetadataStore
+	metadata          eventStore
+	blockNumberByHash func(hash []byte) (blockNumber uint64, found bool, err error)
 }

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -14,9 +14,11 @@
 
 // Package server runs the MidnightState gRPC service. It is a native
 // google.golang.org/grpc server (not ConnectRPC) so that clients written
-// against the Acropolis tonic service are byte-for-byte compatible. This
-// package is the server scaffold: it registers a stub MidnightState service
-// whose RPCs all return Unimplemented; the real handlers are added separately.
+// against the Acropolis tonic service are byte-for-byte compatible. The
+// UTxO-event query RPCs (GetAssetCreates, GetAssetSpends, GetRegistrations,
+// GetDeregistrations, GetUtxoEvents) are backed by Config.Metadata; the
+// remaining RPCs fall back to UnimplementedMidnightStateServer until their
+// handlers are added separately.
 package server
 
 import (
@@ -30,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/midnight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -47,6 +50,11 @@ const (
 // Config holds the configuration for the Midnight gRPC server.
 type Config struct {
 	Logger *slog.Logger
+	// Metadata is the store backing the MidnightState query RPCs
+	// (GetAssetCreates, GetAssetSpends, GetRegistrations,
+	// GetDeregistrations, GetUtxoEvents). Nil leaves those RPCs
+	// unimplemented.
+	Metadata metadata.MetadataStore
 	// Host and Port are the gRPC listen address. Defaults to 0.0.0.0:50051.
 	Host string
 	Port uint
@@ -129,9 +137,10 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	grpcServer := grpc.NewServer(opts...)
-	// Stub MidnightState service: every RPC returns Unimplemented until the
-	// real handlers land.
-	midnight.RegisterMidnightStateServer(grpcServer, &stubService{})
+	// MidnightState service: the UTxO-event query RPCs are implemented
+	// against s.config.Metadata; every other RPC returns Unimplemented until
+	// its handler lands.
+	midnight.RegisterMidnightStateServer(grpcServer, &service{metadata: s.config.Metadata})
 
 	// Health service reporting SERVING for the overall server ("") and the
 	// MidnightState service by name.
@@ -245,9 +254,10 @@ func (s *Server) gracefulStop(timeout time.Duration) {
 	}
 }
 
-// stubService is the placeholder MidnightState implementation. Embedding
-// UnimplementedMidnightStateServer makes every RPC return codes.Unimplemented
-// until the real handlers are added in follow-up work.
-type stubService struct {
+// service is the MidnightState implementation. Embedding
+// UnimplementedMidnightStateServer makes every RPC not overridden below
+// return codes.Unimplemented until its handler is added in follow-up work.
+type service struct {
 	midnight.UnimplementedMidnightStateServer
+	metadata metadata.MetadataStore
 }

--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -43,15 +43,17 @@ func freePort(t *testing.T) uint {
 	return uint(port) //nolint:gosec // port is always in range
 }
 
-// startTestServer starts a server on a free loopback port and returns its
-// dial address. The server is stopped on test cleanup.
-func startTestServer(t *testing.T) string {
+// startTestServerConfig starts a server with cfg (Host/Port populated from a
+// free loopback port, overriding whatever cfg set) and returns its dial
+// address. The server is stopped on test cleanup. Shared by every test
+// helper that needs a running server so the start/stop boilerplate and its
+// cleanup ordering live in exactly one place.
+func startTestServerConfig(t *testing.T, cfg server.Config) string {
 	t.Helper()
 	port := freePort(t)
-	srv, err := server.New(server.Config{
-		Host: "127.0.0.1",
-		Port: port,
-	})
+	cfg.Host = "127.0.0.1"
+	cfg.Port = port
+	srv, err := server.New(cfg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -67,6 +69,13 @@ func startTestServer(t *testing.T) string {
 	})
 
 	return net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(port), 10))
+}
+
+// startTestServer starts a server on a free loopback port and returns its
+// dial address. The server is stopped on test cleanup.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	return startTestServerConfig(t, server.Config{})
 }
 
 func dial(t *testing.T, addr string) *grpc.ClientConn {

--- a/node.go
+++ b/node.go
@@ -1099,6 +1099,7 @@ func (n *Node) Run(ctx context.Context) error {
 		n.midnightServer, err = midnightserver.New(
 			midnightserver.Config{
 				Logger:          n.config.logger,
+				Metadata:        n.db.Metadata(),
 				Host:            n.config.midnight.Host,
 				Port:            n.config.midnight.Port,
 				TLSCertFilePath: n.config.tlsCertFilePath,

--- a/node.go
+++ b/node.go
@@ -1098,8 +1098,18 @@ func (n *Node) Run(ctx context.Context) error {
 		var err error
 		n.midnightServer, err = midnightserver.New(
 			midnightserver.Config{
-				Logger:          n.config.logger,
-				Metadata:        n.db.Metadata(),
+				Logger:   n.config.logger,
+				Metadata: n.db.Metadata(),
+				BlockNumberByHash: func(hash []byte) (uint64, bool, error) {
+					block, err := database.BlockByHash(n.db, hash)
+					if err != nil {
+						if errors.Is(err, models.ErrBlockNotFound) {
+							return 0, false, nil
+						}
+						return 0, false, err
+					}
+					return block.Number, true, nil
+				},
 				Host:            n.config.midnight.Host,
 				Port:            n.config.midnight.Port,
 				TLSCertFilePath: n.config.tlsCertFilePath,


### PR DESCRIPTION
Closes #2118

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cursor‑paginated UTxO event query RPCs for MidnightState with stable ordering, consistent snapshot reads, and atomic indexer writes. Pages are bounded, extend to full transaction groups, and enforce `end_block_hash` via a block‑hash resolver.

- **New Features**
  - gRPC handlers in `midnight/server` for `GetAssetCreates`, `GetAssetSpends`, `GetRegistrations`, `GetDeregistrations`, and merge‑sorted `GetUtxoEvents` (create < spend < registration < deregistration) with `next_position`.
  - Forward pagination from `(start_block, start_tx_index)`; server defaults/clamps `utxo_capacity`/`tx_capacity`; deterministic ordering (`ORDER BY id`); `limit <= 0` skips SQL LIMIT. Shared pagination helpers and model `BlockTxPosition` methods unify backend behavior.
  - `GetUtxoEvents` enforces `end_block_hash` via `BlockNumberByHash` (returns `FailedPrecondition` if unset). Server uses `Config.Metadata`; `node.go` wires `n.db.Metadata()` and the resolver.

- **Bug Fixes**
  - Read consistency: read-only transactions use repeatable‑read on MySQL/Postgres; SQLite uses WAL snapshots.
  - Prevented in‑memory/DB divergence: epoch resolution/advance moved inside block processing so writes, snapshots, and indexer state update atomically.

<sup>Written for commit 150f2e63b5ede1934dad88b1ab8a50c7f71e5b06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Midnight gRPC query support for asset creates, asset spends, registrations, deregistrations, and combined UTxO events.
  * UTxO event responses now support stable cursor-based pagination and resume tokens for continued fetching.

* **Bug Fixes**
  * Improved ordering and paging consistency across Midnight event queries, including tie-breaking when multiple events share the same block and transaction position.
  * Added handling for empty results and no-limit requests to return complete data when appropriate.

* **Documentation**
  * Updated architecture and database docs to reflect the new Midnight metadata-backed query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->