### PR TITLE
feat(midnight): Implement governance, parameters, block, epoch, and s…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -553,8 +553,10 @@ dingo/
 │   └── blob.go          # Remote archive blob adapter
 ├── midnight/            # Midnight MidnightState gRPC compatibility surface
 │   ├── midnight_state*.pb.go # Generated google.golang.org/grpc service stubs
+│   ├── indexer/         # Block scanner indexing midnight_* metadata tables
 │   └── server/          # Native gRPC server lifecycle (reflection, health, TLS)
-│       └── server.go    # Serves the MidnightState gRPC compatibility surface
+│       ├── server.go    # Serves the MidnightState gRPC compatibility surface
+│       └── service.go   # Governance/parameters/block/epoch/stability RPC handlers
 ├── mithril/             # Mithril snapshot bootstrap
 │   ├── bootstrap.go     # Bootstrap orchestration
 │   ├── client.go        # Mithril aggregator client
@@ -809,14 +811,16 @@ In `storageMode: api` with `midnight.port > 0`, `node.go` starts
 ConnectRPC, for byte-for-byte compatibility with the Acropolis tonic service)
 on its own `midnight.host:midnight.port` listener. It registers the
 `MidnightState` service, plus gRPC reflection and a `grpc_health_v1` health
-service reporting `SERVING`. `Config.Metadata` (set to `n.db.Metadata()` in
-`node.go`, typed as a package-local `eventStore` interface rather than the
-full `metadata.MetadataStore` so this gRPC-query package doesn't carry
-unrelated write-path/lifecycle methods) backs the five UTxO-event query RPCs
-— `GetAssetCreates`, `GetAssetSpends`, `GetRegistrations`,
-`GetDeregistrations`, and `GetUtxoEvents` — implemented in
-`midnight/server/midnight_state.go`; the first four page a single
-`midnight_*` table forward from a `(start_block, start_tx_index)` cursor, and
+service reporting `SERVING`. The `MidnightState` service is backed by two
+groups of injected dependencies, both wired in `node.go`.
+
+`Config.Metadata` (set to `n.db.Metadata()`, typed as a package-local
+`eventStore` interface rather than the full `metadata.MetadataStore` so this
+gRPC-query package doesn't carry unrelated write-path/lifecycle methods) backs
+the five UTxO-event query RPCs — `GetAssetCreates`, `GetAssetSpends`,
+`GetRegistrations`, `GetDeregistrations`, and `GetUtxoEvents` — implemented in
+`midnight/server/midnight_state.go`; the first four page a single `midnight_*`
+table forward from a `(start_block, start_tx_index)` cursor, and
 `GetUtxoEvents` merge-sorts all four tables by
 `(block_number, tx_index, kind_order)` and returns a `next_position` cursor
 (see DATABASE.md's Midnight Indexer section for the merge algorithm,
@@ -824,16 +828,46 @@ including how page cutoffs extend to avoid splitting a transaction's rows,
 and for how write-side atomicity in the indexer and the read-side
 `ReadTransaction()` shared by `GetUtxoEvents`' four table reads together keep
 that cursor from skipping rows while the live indexer is mid-block).
-`Config.BlockNumberByHash` (set to a closure over `database.BlockByHash` in
-`node.go`) resolves `GetUtxoEvents`' `end_block_hash` to a block number
-independent of the fetched event rows, so the boundary is honored even for a
-block with no Midnight events; `GetUtxoEvents` fails with
-`codes.FailedPrecondition` if `end_block_hash` is set but no resolver was
-configured. `utxo_capacity`/`tx_capacity` are clamped server-side
-(`effectivePageSize`) to a bounded default/max instead of being forwarded
-to the store, since the store's own pagination contract treats a
-non-positive limit as unbounded. The remaining RPC bodies are still
-incomplete, tracked by the Midnight plan and issues #2118/#2119. TLS is
+`Config.BlockNumberByHash` (set to a closure over `database.BlockByHash`)
+resolves `GetUtxoEvents`' `end_block_hash` to a block number independent of
+the fetched event rows, so the boundary is honored even for a block with no
+Midnight events; `GetUtxoEvents` fails with `codes.FailedPrecondition` if
+`end_block_hash` is set but no resolver was configured.
+`utxo_capacity`/`tx_capacity` are clamped server-side (`effectivePageSize`)
+to a bounded default/max instead of being forwarded to the store, since the
+store's own pagination contract treats a non-positive limit as unbounded.
+
+`Config.Database` (set to `midnightserver.NewDatabase(n.db)`, a narrow
+`MidnightDatabase` interface so this package doesn't depend on the concrete
+`*database.Database`) and `Config.SlotTimer` (set to `n.ledgerState`,
+satisfying `SlotToTime`/`TimeToSlot`) back the
+governance/parameters/block/epoch/stability RPCs implemented in
+`midnight/server/service.go`:
+
+- `GetTechnicalCommitteeDatum` / `GetCouncilDatum` — latest
+  `MidnightGovernanceDatum` at or before a block number.
+- `GetAriadneParameters` — latest `MidnightAriadneParams` at or before an
+  epoch.
+- `GetBlockByHash` / `GetLatestBlock` — block metadata via
+  `database.BlockByHash`/`BlocksRecent`, with epoch number resolved from the
+  stored epoch cache (`Database.GetEpochBySlot`) and timestamp from
+  `SlotTimer.SlotToTime`.
+- `GetEpochNonce` — reads `Epoch.Nonce` via `Database.GetEpoch`.
+- `GetEpochCandidates` — decodes `MidnightEpochCandidates.CandidatesCbor` via
+  `midnight/indexer.DecodeEpochCandidatesCbor` and joins it with the `"mark"`
+  `pool_stake_snapshot` rows for the epoch to build the stake distribution.
+- `GetStableBlock` / `GetLatestStableBlock` — compare
+  `chain_tip_block_number - block_number` against the requested stability
+  offset; when `as_of_timestamp_unix_millis` is set, the "tip" is resolved to
+  the latest block at or before that wall-clock time
+  (`SlotTimer.TimeToSlot` + `database.BlockBeforeSlot`) instead of the live
+  tip. `GetLatestStableBlock` looks the target block number up via
+  `Database.BlockByIndex`, translating 0-based block number to the blob
+  store's 1-based index the same way `api/blockfrost` does.
+
+With both groups wired, every `MidnightState` RPC is implemented. A handler
+whose backend is nil (e.g. a server started for lifecycle/health only)
+returns a clean `codes.FailedPrecondition` rather than nil-panicking. TLS is
 enabled when the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start`
 binds the listener synchronously (so bind/cert errors surface immediately)
 and serves in a goroutine; a context watcher performs a bounded

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -862,8 +862,16 @@ implemented in `midnight/server/service.go`:
   `SlotTimer.SlotToTime`.
 - `GetEpochNonce` — reads `Epoch.Nonce` via `Database.GetEpoch`.
 - `GetEpochCandidates` — decodes `MidnightEpochCandidates.CandidatesCbor` via
-  `midnight/indexer.DecodeEpochCandidatesCbor` and joins it with the `"mark"`
-  `pool_stake_snapshot` rows for the epoch to build the stake distribution.
+  `midnight/indexer.DecodeEpochCandidatesCbor` for `(tx_hash, output_index,
+  datum)` membership, batch-fetches
+  `midnight_committee_candidate_registrations` rows for those tx hashes
+  (`Database.GetMidnightCommitteeCandidateRegistrationsByTxHashes`, one query
+  regardless of candidate count) to fill in each candidate's
+  `block_number`/`slot_number`/`tx_index`/`tx_inputs` (the latter decoded via
+  `midnight/indexer.DecodeCandidateInputsCbor`), and joins the `"mark"`
+  `pool_stake_snapshot` rows for the epoch to build the stake distribution. A
+  candidate with no matching registration row keeps those fields at their
+  zero values rather than failing the response.
 - `GetStableBlock` / `GetLatestStableBlock` — compare
   `chain_tip_block_number - block_number` against the requested stability
   offset; when `as_of_timestamp_unix_millis` is set, the "tip" is resolved to
@@ -1802,6 +1810,19 @@ An optional block scanner that indexes Midnight chain events into multiple
   candidate snapshots record the block that created them, so rollback deletes
   snapshots created by the rolled-back block before readers can observe stale
   `midnight_epoch_candidates` rows.
+  `midnight_epoch_candidates.CandidatesCbor` records only `(tx_hash,
+  output_index, datum)` membership — it has no room for the creating
+  transaction's block/slot/tx-index or the inputs it consumed, and the
+  in-memory set is rebuilt on restart from the generic UTXO index
+  (`GetMidnightCandidates`, which also carries only tx_hash/output_index/
+  datum), so that provenance can't be recovered after a restart if it isn't
+  persisted separately. `processOutput` therefore also writes a
+  `midnight_committee_candidate_registrations` row (`block_number`,
+  `slot_number`, `tx_index`, and `tx_inputs_cbor` — the creating tx's inputs,
+  via `EncodeCandidateInputsCbor`) the first time each candidate UTxO is
+  observed, write-before-track same as the in-memory update. `rollbackBlock`
+  deletes registration rows for the rolled-back block alongside the epoch
+  snapshot cleanup.
 
 **Epoch tracking**: `processBlock` resolves and advances the epoch (via
 `advanceEpochLocked`) for every block, on both the live event path and the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -556,7 +556,8 @@ dingo/
 │   ├── indexer/         # Block scanner indexing midnight_* metadata tables
 │   └── server/          # Native gRPC server lifecycle (reflection, health, TLS)
 │       ├── server.go    # Serves the MidnightState gRPC compatibility surface
-│       └── service.go   # Governance/parameters/block/epoch/stability RPC handlers
+│       ├── service.go   # Governance/parameters/block/epoch/stability RPC handlers
+│       └── adapter.go   # *database.Database -> MidnightDatabase interface adapter
 ├── mithril/             # Mithril snapshot bootstrap
 │   ├── bootstrap.go     # Bootstrap orchestration
 │   ├── client.go        # Mithril aggregator client
@@ -812,7 +813,12 @@ ConnectRPC, for byte-for-byte compatibility with the Acropolis tonic service)
 on its own `midnight.host:midnight.port` listener. It registers the
 `MidnightState` service, plus gRPC reflection and a `grpc_health_v1` health
 service reporting `SERVING`. The `MidnightState` service is backed by two
-groups of injected dependencies, both wired in `node.go`.
+groups of injected dependencies, both wired in `node.go`. Per the
+composition-boundary principle (domain packages depend on narrow,
+constructor-injected interfaces, not concrete node/database types),
+`midnight/server` declares its own narrow interfaces — `eventStore`,
+`MidnightDatabase`, and `SlotTimer` — rather than importing the concrete
+`*database.Database`/`*ledger.LedgerState`.
 
 `Config.Metadata` (set to `n.db.Metadata()`, typed as a package-local
 `eventStore` interface rather than the full `metadata.MetadataStore` so this
@@ -837,12 +843,14 @@ Midnight events; `GetUtxoEvents` fails with `codes.FailedPrecondition` if
 to a bounded default/max instead of being forwarded to the store, since the
 store's own pagination contract treats a non-positive limit as unbounded.
 
-`Config.Database` (set to `midnightserver.NewDatabase(n.db)`, a narrow
-`MidnightDatabase` interface so this package doesn't depend on the concrete
-`*database.Database`) and `Config.SlotTimer` (set to `n.ledgerState`,
-satisfying `SlotToTime`/`TimeToSlot`) back the
-governance/parameters/block/epoch/stability RPCs implemented in
-`midnight/server/service.go`:
+`Config.Database` (set to `midnightserver.NewDatabase(n.db)` — `adapter.go`'s
+`databaseAdapter`, which bridges the package-level
+`database.BlockByHash`/`BlocksRecent`/`BlockBeforeSlot` functions and the
+0-based/1-based block-number translation into `MidnightDatabase` interface
+methods, mirroring `api/mesh`'s `meshDatabaseAdapter`/`MeshDatabase`) and
+`Config.SlotTimer` (set to `n.ledgerState`, satisfying `SlotToTime`/
+`TimeToSlot`) back the governance/parameters/block/epoch/stability RPCs
+implemented in `midnight/server/service.go`:
 
 - `GetTechnicalCommitteeDatum` / `GetCouncilDatum` — latest
   `MidnightGovernanceDatum` at or before a block number.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -235,6 +235,7 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `GetLatestMidnightGovernanceDatum(datumType, blockNumber, txn)` | Returns the newest datum of `datumType` at or before `blockNumber`, or nil when none exist. |
 | `GetLatestMidnightAriadneParams(txn)` | Returns the most recently stored Ariadne parameters row (ordered by `epoch DESC`), or nil. |
 | `GetMidnightAriadneParamsByEpoch(epoch, txn)` | Returns the Ariadne params row for one epoch, or nil when none exists. Used to journal rollback state before an upsert. |
+| `GetMidnightAriadneParamsAtOrBeforeEpoch(epoch, txn)` | Returns the newest Ariadne params row at or before `epoch` (`ORDER BY epoch DESC`), or nil when none exist. Backs `MidnightState.GetAriadneParameters`. |
 | `UpsertMidnightAriadneParams(txn, *MidnightAriadneParams)` | Insert or update the Ariadne params row for the given epoch. |
 | `DeleteMidnightAriadneParamsByEpoch(txn, epoch)` | Deletes the Ariadne params row for one epoch. Used when rolling back a block that created the row. |
 | `CreateMidnightAriadneRollback(txn, *MidnightAriadneRollback)` | Insert an Ariadne rollback journal row, ignoring duplicate `(block_number, epoch)` rows for idempotent replay. |
@@ -243,6 +244,7 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `DeleteMidnightAriadneRollbacksBeforeBlock(txn, blockNumber)` | Prunes Ariadne rollback journal rows older than the rollback window. |
 | `UpsertMidnightEpochCandidates(txn, *MidnightEpochCandidates)` | Insert or replace the committee-candidate snapshot for the given epoch, including the block number that created it. |
 | `DeleteMidnightEpochCandidatesByBlock(txn, blockNumber)` | Deletes candidate snapshots created while applying `blockNumber`. Used during candidate rollback so persisted snapshots cannot retain stale candidate sets. |
+| `GetMidnightEpochCandidatesByEpoch(epoch, txn)` | Returns the candidate snapshot row for one epoch, or nil when none exists. Backs `MidnightState.GetEpochCandidates`; `CandidatesCbor` is decoded via `midnight/indexer.DecodeEpochCandidatesCbor`. |
 
 Governance datum reads filter by `datum_type` and
 `block_number <= requested_block`, then order by `block_number DESC, id DESC`.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -208,7 +208,8 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `midnight_governance_datums` | `id`, `datum_type`, `tx_hash`, `output_index`, `datum`, `block_number` | PK `id`; composite index `(datum_type, block_number DESC)`; **unique** composite index `(datum_type, tx_hash, output_index)` (`idx_midnight_governance_datums_output`) | Latest Technical Committee and Council datum snapshots. `datum_type` values are `technical_committee` and `council`; use the composite index for latest-at-or-before queries. The unique output key keeps restart/backfill replay idempotent while preserving distinct governance outputs as separate history rows. |
 | `midnight_ariadne_params` | `id`, `epoch`, `datum` | PK `id`; unique `epoch` | Ariadne parameters per epoch when changed. |
 | `midnight_ariadne_rollbacks` | `id`, `block_number`, `epoch`, `previous_exists`, `previous_datum` | PK `id`; unique `(block_number, epoch)` | Durable rollback journal for Ariadne upserts. Before changing an epoch row, the indexer records the previous row (or absence) so an undo after restart can restore/delete the row. |
-| `midnight_epoch_candidates` | `id`, `epoch`, `block_number`, `candidates_cbor` | PK `id`; unique `epoch`; index `block_number` | Candidate snapshots captured at epoch boundaries. `block_number` records the block application that wrote the snapshot, so rollback deletes only snapshots created by the rolled-back block. |
+| `midnight_epoch_candidates` | `id`, `epoch`, `block_number`, `candidates_cbor` | PK `id`; unique `epoch`; index `block_number` | Candidate snapshots captured at epoch boundaries. `block_number` records the block application that wrote the snapshot, so rollback deletes only snapshots created by the rolled-back block. `candidates_cbor` records only `(tx_hash, output_index, datum)` membership per candidate — see `midnight_committee_candidate_registrations` for per-candidate provenance. |
+| `midnight_committee_candidate_registrations` | `id`, `tx_hash`, `output_index`, `block_number`, `slot_number`, `tx_index`, `tx_inputs_cbor` | PK `id`; **unique** composite index `(tx_hash, output_index)` (`idx_midnight_committee_candidate_reg_utxo`); index `block_number` | Durable provenance for a committee-candidate UTxO, written once when it's first observed as a transaction output. `tx_inputs_cbor` is the creating transaction's inputs, CBOR-encoded as a list of `(tx_hash, index)` pairs. Exists because the in-memory candidate set is rebuilt on restart from the generic UTXO index (`GetMidnightCandidates`), which carries only `tx_hash`/`output_index`/`datum` — this table is the only durable source for `tx_inputs`/`slot_number`/`tx_index`/`block_number`, which `MidnightState.GetEpochCandidates` joins in by `tx_hash`. |
 
 #### Midnight MetadataStore API
 
@@ -245,6 +246,9 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `UpsertMidnightEpochCandidates(txn, *MidnightEpochCandidates)` | Insert or replace the committee-candidate snapshot for the given epoch, including the block number that created it. |
 | `DeleteMidnightEpochCandidatesByBlock(txn, blockNumber)` | Deletes candidate snapshots created while applying `blockNumber`. Used during candidate rollback so persisted snapshots cannot retain stale candidate sets. |
 | `GetMidnightEpochCandidatesByEpoch(epoch, txn)` | Returns the candidate snapshot row for one epoch, or nil when none exists. Backs `MidnightState.GetEpochCandidates`; `CandidatesCbor` is decoded via `midnight/indexer.DecodeEpochCandidatesCbor`. |
+| `InsertMidnightCommitteeCandidateRegistration(txn, *MidnightCommitteeCandidateRegistration)` | Insert a candidate UTxO provenance row. Idempotent: silently ignores conflicts on `(tx_hash, output_index)`. `TxInputsCbor` is encoded via `midnight/indexer.EncodeCandidateInputsCbor`. |
+| `DeleteMidnightCommitteeCandidateRegistrationsByBlock(txn, blockNumber)` | Deletes candidate registration rows written while applying `blockNumber`. Used during candidate rollback. |
+| `GetMidnightCommitteeCandidateRegistrationsByTxHashes(txHashes, txn)` | Returns every registration row whose `tx_hash` is in `txHashes` (single `IN` query). Backs `MidnightState.GetEpochCandidates`'s join from decoded snapshot entries to their `tx_inputs`/`slot_number`/`tx_index`/`block_number`; `TxInputsCbor` is decoded via `midnight/indexer.DecodeCandidateInputsCbor`. |
 
 Governance datum reads filter by `datum_type` and
 `block_number <= requested_block`, then order by `block_number DESC, id DESC`.
@@ -255,7 +259,15 @@ epoch's row. Candidate snapshots encode entries ordered by transaction hash
 and output index so identical sets produce identical CBOR.
 On startup, committee-candidate restoration reads live `utxo` rows and joins
 `utxo.datum_hash` to `datum.raw_datum`; it does not require block CBOR blobs
-to still be available.
+to still be available. This restoration path rebuilds only the in-memory
+`(tx_hash, output_index) -> datum` membership set used to write the next
+epoch snapshot — it does not touch `midnight_committee_candidate_registrations`,
+which is written once per candidate UTxO at creation time and never needs
+rebuilding. `MidnightState.GetEpochCandidates` treats a missing registration
+row for a decoded snapshot entry as a legitimate (if unexpected) partial
+result: it returns that candidate's `full_datum`/`utxo_tx_hash`/`utxo_index`
+with `block_number`/`slot_number`/`tx_index`/`tx_inputs` left at their zero
+values, rather than failing the whole response.
 
 The MidnightState `GetUtxoEvents` RPC has no dedicated store method: the
 `midnight/server` handler calls the four `Find*From` methods above with the

--- a/database/midnight.go
+++ b/database/midnight.go
@@ -90,6 +90,17 @@ func (d *Database) GetMidnightEpochCandidatesByEpoch(
 	return d.metadata.GetMidnightEpochCandidatesByEpoch(epoch, nil)
 }
 
+// GetMidnightCommitteeCandidateRegistrationsByTxHashes returns every
+// candidate-registration provenance row whose tx_hash is in txHashes.
+func (d *Database) GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+	txHashes [][]byte,
+) ([]models.MidnightCommitteeCandidateRegistration, error) {
+	return d.metadata.GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+		txHashes,
+		nil,
+	)
+}
+
 // UpsertMidnightEpochCandidates inserts or replaces the committee-candidate
 // snapshot for the given epoch.
 func (d *Database) UpsertMidnightEpochCandidates(

--- a/database/midnight.go
+++ b/database/midnight.go
@@ -74,6 +74,22 @@ func (d *Database) UpsertMidnightAriadneParams(
 	return txn.Commit()
 }
 
+// GetMidnightAriadneParamsAtOrBeforeEpoch returns the newest Ariadne params
+// row at or before epoch, or nil when none exists.
+func (d *Database) GetMidnightAriadneParamsAtOrBeforeEpoch(
+	epoch uint64,
+) (*models.MidnightAriadneParams, error) {
+	return d.metadata.GetMidnightAriadneParamsAtOrBeforeEpoch(epoch, nil)
+}
+
+// GetMidnightEpochCandidatesByEpoch returns the committee-candidate snapshot
+// for one epoch, or nil when none exists.
+func (d *Database) GetMidnightEpochCandidatesByEpoch(
+	epoch uint64,
+) (*models.MidnightEpochCandidates, error) {
+	return d.metadata.GetMidnightEpochCandidatesByEpoch(epoch, nil)
+}
+
 // UpsertMidnightEpochCandidates inserts or replaces the committee-candidate
 // snapshot for the given epoch.
 func (d *Database) UpsertMidnightEpochCandidates(

--- a/database/models/midnight.go
+++ b/database/models/midnight.go
@@ -157,3 +157,26 @@ type MidnightEpochCandidates struct {
 func (MidnightEpochCandidates) TableName() string {
 	return "midnight_epoch_candidates"
 }
+
+// MidnightCommitteeCandidateRegistration stores full on-chain provenance for
+// a committee-candidate UTxO the first time it is observed as a transaction
+// output: which block/slot/transaction created it and which UTxOs its
+// creating transaction consumed. MidnightEpochCandidates.CandidatesCbor
+// records only (tx_hash, output_index, datum) membership at each epoch
+// boundary — this table is the durable side-store GetEpochCandidates joins
+// against to fill in tx_inputs/slot_number/tx_index/block_number, since the
+// in-memory candidate set is rebuilt on restart from the generic UTXO index
+// (GetMidnightCandidates), which carries only tx_hash/output_index/datum.
+type MidnightCommitteeCandidateRegistration struct {
+	ID           uint   `gorm:"primarykey"`
+	TxHash       []byte `gorm:"uniqueIndex:idx_midnight_committee_candidate_reg_utxo,priority:1;size:32;not null"`
+	OutputIndex  uint32 `gorm:"uniqueIndex:idx_midnight_committee_candidate_reg_utxo,priority:2;not null"`
+	BlockNumber  uint64 `gorm:"index;not null"`
+	SlotNumber   uint64 `gorm:"not null"`
+	TxIndex      uint32 `gorm:"not null"`
+	TxInputsCbor []byte `gorm:"not null"`
+}
+
+func (MidnightCommitteeCandidateRegistration) TableName() string {
+	return "midnight_committee_candidate_registrations"
+}

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -43,6 +43,7 @@ var MigrateModels = []any{
 	&MidnightAriadneRollback{},
 	&MidnightAssetCreate{},
 	&MidnightAssetSpend{},
+	&MidnightCommitteeCandidateRegistration{},
 	&MidnightDeregistration{},
 	&MidnightEpochCandidates{},
 	&MidnightGovernanceDatum{},

--- a/database/models/stake_snapshot.go
+++ b/database/models/stake_snapshot.go
@@ -51,12 +51,35 @@ const (
 	// PoolStakeSnapshotTypeMark is the epoch-boundary mark snapshot used by
 	// governance and by the normal Praos epoch-offset rotation.
 	PoolStakeSnapshotTypeMark = "mark"
+	// PoolStakeSnapshotTypeSet is the mark snapshot rotated forward one
+	// epoch, per the Shelley set/go/mark rotation.
+	PoolStakeSnapshotTypeSet = "set"
+	// PoolStakeSnapshotTypeGo is the set snapshot rotated forward one more
+	// epoch; this is the row consulted for live leader-election stake.
+	PoolStakeSnapshotTypeGo = "go"
 	// PoolStakeSnapshotTypeActive is the active consensus pool distribution
 	// imported from a Mithril NewEpochState.pool-distr field. TotalStake
 	// stores the fraction numerator and StakeDenominator stores the
 	// denominator for the same row.
 	PoolStakeSnapshotTypeActive = "actv"
 )
+
+// ValidPoolStakeSnapshotType reports whether snapshotType is one of the
+// known pool_stake_snapshot.snapshot_type values. Callers that accept a
+// snapshotType from outside the package should validate with this before
+// querying, so a typo or stale value fails fast instead of silently
+// returning zero rows.
+func ValidPoolStakeSnapshotType(snapshotType string) bool {
+	switch snapshotType {
+	case PoolStakeSnapshotTypeMark,
+		PoolStakeSnapshotTypeSet,
+		PoolStakeSnapshotTypeGo,
+		PoolStakeSnapshotTypeActive:
+		return true
+	default:
+		return false
+	}
+}
 
 // PoolStakeSnapshot captures pool stake for an epoch snapshot. Mark rows store
 // lovelace totals at an epoch boundary. Active rows imported from Mithril store

--- a/database/models/stake_snapshot_test.go
+++ b/database/models/stake_snapshot_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidPoolStakeSnapshotType(t *testing.T) {
+	for _, valid := range []string{
+		models.PoolStakeSnapshotTypeMark,
+		models.PoolStakeSnapshotTypeSet,
+		models.PoolStakeSnapshotTypeGo,
+		models.PoolStakeSnapshotTypeActive,
+	} {
+		require.True(t, models.ValidPoolStakeSnapshotType(valid), "%q must be valid", valid)
+	}
+	for _, invalid := range []string{"", "Mark", "MARK", "active", "unknown"} {
+		require.False(t, models.ValidPoolStakeSnapshotType(invalid), "%q must be invalid", invalid)
+	}
+}

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -593,3 +593,54 @@ func (d *MetadataStoreMysql) GetMidnightEpochCandidatesByEpoch(
 	}
 	return &ec, nil
 }
+
+// InsertMidnightCommitteeCandidateRegistration inserts a candidate UTxO
+// provenance row. Uses INSERT IGNORE so that backfill replays are
+// idempotent.
+func (d *MetadataStoreMysql) InsertMidnightCommitteeCandidateRegistration(
+	txn types.Txn,
+	row *models.MidnightCommitteeCandidateRegistration,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error
+}
+
+// DeleteMidnightCommitteeCandidateRegistrationsByBlock deletes candidate
+// registration rows written while applying blockNumber. Used during
+// rollback so a re-applied block at the same height starts clean.
+func (d *MetadataStoreMysql) DeleteMidnightCommitteeCandidateRegistrationsByBlock(
+	txn types.Txn,
+	blockNumber uint64,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Where("block_number = ?", blockNumber).
+		Delete(&models.MidnightCommitteeCandidateRegistration{}).Error
+}
+
+// GetMidnightCommitteeCandidateRegistrationsByTxHashes returns every
+// registration row whose tx_hash is in txHashes, for the caller to match
+// against (tx_hash, output_index) pairs. A single IN query regardless of how
+// many candidates are being enriched avoids one round trip per candidate.
+func (d *MetadataStoreMysql) GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+	txHashes [][]byte,
+	txn types.Txn,
+) ([]models.MidnightCommitteeCandidateRegistration, error) {
+	if len(txHashes) == 0 {
+		return nil, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var rows []models.MidnightCommitteeCandidateRegistration
+	if err := db.Where("tx_hash IN ?", txHashes).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -447,6 +447,28 @@ func (d *MetadataStoreMysql) GetMidnightAriadneParamsByEpoch(
 	return &params, nil
 }
 
+// GetMidnightAriadneParamsAtOrBeforeEpoch returns the newest Ariadne params
+// row at or before epoch, or nil when none exists.
+func (d *MetadataStoreMysql) GetMidnightAriadneParamsAtOrBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (*models.MidnightAriadneParams, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var params models.MidnightAriadneParams
+	result := db.Where("epoch <= ?", epoch).
+		Order("epoch DESC").First(&params)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &params, nil
+}
+
 func (d *MetadataStoreMysql) UpsertMidnightAriadneParams(
 	txn types.Txn,
 	params *models.MidnightAriadneParams,
@@ -549,4 +571,25 @@ func (d *MetadataStoreMysql) DeleteMidnightEpochCandidatesByBlock(
 	}
 	return db.Where("block_number = ?", blockNumber).
 		Delete(&models.MidnightEpochCandidates{}).Error
+}
+
+// GetMidnightEpochCandidatesByEpoch returns the candidate snapshot for one
+// epoch, or nil when none exists.
+func (d *MetadataStoreMysql) GetMidnightEpochCandidatesByEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (*models.MidnightEpochCandidates, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var ec models.MidnightEpochCandidates
+	result := db.Where("epoch = ?", epoch).First(&ec)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &ec, nil
 }

--- a/database/plugin/metadata/mysql/midnight.go
+++ b/database/plugin/metadata/mysql/midnight.go
@@ -28,7 +28,8 @@ import (
 )
 
 // CreateMidnightAssetCreate inserts a cNIGHT UTxO creation row.
-// Uses INSERT IGNORE so that backfill replays are idempotent.
+// Idempotent on replay: GORM's DoNothing conflict clause renders on MySQL as
+// a no-op ON DUPLICATE KEY UPDATE (not INSERT IGNORE).
 func (d *MetadataStoreMysql) CreateMidnightAssetCreate(
 	txn types.Txn,
 	row *models.MidnightAssetCreate,
@@ -41,7 +42,8 @@ func (d *MetadataStoreMysql) CreateMidnightAssetCreate(
 }
 
 // CreateMidnightAssetSpend inserts a cNIGHT UTxO spend row.
-// Uses INSERT IGNORE so that backfill replays are idempotent.
+// Idempotent on replay: GORM's DoNothing conflict clause renders on MySQL as
+// a no-op ON DUPLICATE KEY UPDATE (not INSERT IGNORE).
 func (d *MetadataStoreMysql) CreateMidnightAssetSpend(
 	txn types.Txn,
 	row *models.MidnightAssetSpend,
@@ -54,7 +56,8 @@ func (d *MetadataStoreMysql) CreateMidnightAssetSpend(
 }
 
 // CreateMidnightRegistration inserts a mapping-validator registration row.
-// Uses INSERT IGNORE so that backfill replays are idempotent.
+// Idempotent on replay: GORM's DoNothing conflict clause renders on MySQL as
+// a no-op ON DUPLICATE KEY UPDATE (not INSERT IGNORE).
 func (d *MetadataStoreMysql) CreateMidnightRegistration(
 	txn types.Txn,
 	row *models.MidnightRegistration,
@@ -67,7 +70,8 @@ func (d *MetadataStoreMysql) CreateMidnightRegistration(
 }
 
 // CreateMidnightDeregistration inserts a mapping-validator deregistration row.
-// Uses INSERT IGNORE so that backfill replays are idempotent.
+// Idempotent on replay: GORM's DoNothing conflict clause renders on MySQL as
+// a no-op ON DUPLICATE KEY UPDATE (not INSERT IGNORE).
 func (d *MetadataStoreMysql) CreateMidnightDeregistration(
 	txn types.Txn,
 	row *models.MidnightDeregistration,
@@ -595,8 +599,8 @@ func (d *MetadataStoreMysql) GetMidnightEpochCandidatesByEpoch(
 }
 
 // InsertMidnightCommitteeCandidateRegistration inserts a candidate UTxO
-// provenance row. Uses INSERT IGNORE so that backfill replays are
-// idempotent.
+// provenance row. Idempotent on replay: GORM's DoNothing conflict clause
+// renders on MySQL as a no-op ON DUPLICATE KEY UPDATE (not INSERT IGNORE).
 func (d *MetadataStoreMysql) InsertMidnightCommitteeCandidateRegistration(
 	txn types.Txn,
 	row *models.MidnightCommitteeCandidateRegistration,

--- a/database/plugin/metadata/postgres/midnight.go
+++ b/database/plugin/metadata/postgres/midnight.go
@@ -447,6 +447,28 @@ func (d *MetadataStorePostgres) GetMidnightAriadneParamsByEpoch(
 	return &params, nil
 }
 
+// GetMidnightAriadneParamsAtOrBeforeEpoch returns the newest Ariadne params
+// row at or before epoch, or nil when none exists.
+func (d *MetadataStorePostgres) GetMidnightAriadneParamsAtOrBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (*models.MidnightAriadneParams, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var params models.MidnightAriadneParams
+	result := db.Where("epoch <= ?", epoch).
+		Order("epoch DESC").First(&params)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &params, nil
+}
+
 func (d *MetadataStorePostgres) UpsertMidnightAriadneParams(
 	txn types.Txn,
 	params *models.MidnightAriadneParams,
@@ -549,4 +571,25 @@ func (d *MetadataStorePostgres) DeleteMidnightEpochCandidatesByBlock(
 	}
 	return db.Where("block_number = ?", blockNumber).
 		Delete(&models.MidnightEpochCandidates{}).Error
+}
+
+// GetMidnightEpochCandidatesByEpoch returns the candidate snapshot for one
+// epoch, or nil when none exists.
+func (d *MetadataStorePostgres) GetMidnightEpochCandidatesByEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (*models.MidnightEpochCandidates, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var ec models.MidnightEpochCandidates
+	result := db.Where("epoch = ?", epoch).First(&ec)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &ec, nil
 }

--- a/database/plugin/metadata/postgres/midnight.go
+++ b/database/plugin/metadata/postgres/midnight.go
@@ -593,3 +593,54 @@ func (d *MetadataStorePostgres) GetMidnightEpochCandidatesByEpoch(
 	}
 	return &ec, nil
 }
+
+// InsertMidnightCommitteeCandidateRegistration inserts a candidate UTxO
+// provenance row. Uses ON CONFLICT DO NOTHING so that backfill replays are
+// idempotent.
+func (d *MetadataStorePostgres) InsertMidnightCommitteeCandidateRegistration(
+	txn types.Txn,
+	row *models.MidnightCommitteeCandidateRegistration,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error
+}
+
+// DeleteMidnightCommitteeCandidateRegistrationsByBlock deletes candidate
+// registration rows written while applying blockNumber. Used during
+// rollback so a re-applied block at the same height starts clean.
+func (d *MetadataStorePostgres) DeleteMidnightCommitteeCandidateRegistrationsByBlock(
+	txn types.Txn,
+	blockNumber uint64,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Where("block_number = ?", blockNumber).
+		Delete(&models.MidnightCommitteeCandidateRegistration{}).Error
+}
+
+// GetMidnightCommitteeCandidateRegistrationsByTxHashes returns every
+// registration row whose tx_hash is in txHashes, for the caller to match
+// against (tx_hash, output_index) pairs. A single IN query regardless of how
+// many candidates are being enriched avoids one round trip per candidate.
+func (d *MetadataStorePostgres) GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+	txHashes [][]byte,
+	txn types.Txn,
+) ([]models.MidnightCommitteeCandidateRegistration, error) {
+	if len(txHashes) == 0 {
+		return nil, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var rows []models.MidnightCommitteeCandidateRegistration
+	if err := db.Where("tx_hash IN ?", txHashes).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/database/plugin/metadata/sqlite/midnight.go
+++ b/database/plugin/metadata/sqlite/midnight.go
@@ -445,6 +445,28 @@ func (d *MetadataStoreSqlite) GetMidnightAriadneParamsByEpoch(
 	return &params, nil
 }
 
+// GetMidnightAriadneParamsAtOrBeforeEpoch returns the newest Ariadne params
+// row at or before epoch, or nil when none exists.
+func (d *MetadataStoreSqlite) GetMidnightAriadneParamsAtOrBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (*models.MidnightAriadneParams, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var params models.MidnightAriadneParams
+	result := db.Where("epoch <= ?", epoch).
+		Order("epoch DESC").First(&params)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &params, nil
+}
+
 func (d *MetadataStoreSqlite) UpsertMidnightAriadneParams(
 	txn types.Txn,
 	params *models.MidnightAriadneParams,
@@ -547,4 +569,25 @@ func (d *MetadataStoreSqlite) DeleteMidnightEpochCandidatesByBlock(
 	}
 	return db.Where("block_number = ?", blockNumber).
 		Delete(&models.MidnightEpochCandidates{}).Error
+}
+
+// GetMidnightEpochCandidatesByEpoch returns the candidate snapshot for one
+// epoch, or nil when none exists.
+func (d *MetadataStoreSqlite) GetMidnightEpochCandidatesByEpoch(
+	epoch uint64,
+	txn types.Txn,
+) (*models.MidnightEpochCandidates, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var ec models.MidnightEpochCandidates
+	result := db.Where("epoch = ?", epoch).First(&ec)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &ec, nil
 }

--- a/database/plugin/metadata/sqlite/midnight.go
+++ b/database/plugin/metadata/sqlite/midnight.go
@@ -591,3 +591,53 @@ func (d *MetadataStoreSqlite) GetMidnightEpochCandidatesByEpoch(
 	}
 	return &ec, nil
 }
+
+// InsertMidnightCommitteeCandidateRegistration inserts a candidate UTxO
+// provenance row. Uses OR IGNORE so that backfill replays are idempotent.
+func (d *MetadataStoreSqlite) InsertMidnightCommitteeCandidateRegistration(
+	txn types.Txn,
+	row *models.MidnightCommitteeCandidateRegistration,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error
+}
+
+// DeleteMidnightCommitteeCandidateRegistrationsByBlock deletes candidate
+// registration rows written while applying blockNumber. Used during
+// rollback so a re-applied block at the same height starts clean.
+func (d *MetadataStoreSqlite) DeleteMidnightCommitteeCandidateRegistrationsByBlock(
+	txn types.Txn,
+	blockNumber uint64,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	return db.Where("block_number = ?", blockNumber).
+		Delete(&models.MidnightCommitteeCandidateRegistration{}).Error
+}
+
+// GetMidnightCommitteeCandidateRegistrationsByTxHashes returns every
+// registration row whose tx_hash is in txHashes, for the caller to match
+// against (tx_hash, output_index) pairs. A single IN query regardless of how
+// many candidates are being enriched avoids one round trip per candidate.
+func (d *MetadataStoreSqlite) GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+	txHashes [][]byte,
+	txn types.Txn,
+) ([]models.MidnightCommitteeCandidateRegistration, error) {
+	if len(txHashes) == 0 {
+		return nil, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var rows []models.MidnightCommitteeCandidateRegistration
+	if err := db.Where("tx_hash IN ?", txHashes).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1525,6 +1525,12 @@ type MetadataStore interface {
 	UpsertMidnightEpochCandidates(types.Txn, *models.MidnightEpochCandidates) error
 	DeleteMidnightEpochCandidatesByBlock(types.Txn, uint64) error
 	GetMidnightEpochCandidatesByEpoch(uint64, types.Txn) (*models.MidnightEpochCandidates, error)
+	InsertMidnightCommitteeCandidateRegistration(types.Txn, *models.MidnightCommitteeCandidateRegistration) error
+	DeleteMidnightCommitteeCandidateRegistrationsByBlock(types.Txn, uint64) error
+	GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+		[][]byte,
+		types.Txn,
+	) ([]models.MidnightCommitteeCandidateRegistration, error)
 }
 
 // BulkLoadOptimizer is an optional interface that metadata stores can

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1515,6 +1515,7 @@ type MetadataStore interface {
 	GetLatestMidnightGovernanceDatum(string, uint64, types.Txn) (*models.MidnightGovernanceDatum, error)
 	GetLatestMidnightAriadneParams(types.Txn) (*models.MidnightAriadneParams, error)
 	GetMidnightAriadneParamsByEpoch(uint64, types.Txn) (*models.MidnightAriadneParams, error)
+	GetMidnightAriadneParamsAtOrBeforeEpoch(uint64, types.Txn) (*models.MidnightAriadneParams, error)
 	UpsertMidnightAriadneParams(types.Txn, *models.MidnightAriadneParams) error
 	DeleteMidnightAriadneParamsByEpoch(types.Txn, uint64) error
 	CreateMidnightAriadneRollback(types.Txn, *models.MidnightAriadneRollback) error
@@ -1523,6 +1524,7 @@ type MetadataStore interface {
 	DeleteMidnightAriadneRollbacksBeforeBlock(types.Txn, uint64) error
 	UpsertMidnightEpochCandidates(types.Txn, *models.MidnightEpochCandidates) error
 	DeleteMidnightEpochCandidatesByBlock(types.Txn, uint64) error
+	GetMidnightEpochCandidatesByEpoch(uint64, types.Txn) (*models.MidnightEpochCandidates, error)
 }
 
 // BulkLoadOptimizer is an optional interface that metadata stores can

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -28,6 +28,12 @@ func (d *Database) GetPoolStakeSnapshotsByEpoch(
 	snapshotType string,
 	txn *Txn,
 ) ([]*models.PoolStakeSnapshot, error) {
+	if !models.ValidPoolStakeSnapshotType(snapshotType) {
+		return nil, fmt.Errorf(
+			"get pool stake snapshots by epoch: invalid snapshot type %q",
+			snapshotType,
+		)
+	}
 	if txn == nil {
 		return d.metadata.GetPoolStakeSnapshotsByEpoch(epoch, snapshotType, nil)
 	}

--- a/database/stake_snapshot.go
+++ b/database/stake_snapshot.go
@@ -21,6 +21,23 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// GetPoolStakeSnapshotsByEpoch returns all pool stake snapshots of
+// snapshotType for the given epoch.
+func (d *Database) GetPoolStakeSnapshotsByEpoch(
+	epoch uint64,
+	snapshotType string,
+	txn *Txn,
+) ([]*models.PoolStakeSnapshot, error) {
+	if txn == nil {
+		return d.metadata.GetPoolStakeSnapshotsByEpoch(epoch, snapshotType, nil)
+	}
+	return d.metadata.GetPoolStakeSnapshotsByEpoch(
+		epoch,
+		snapshotType,
+		txn.Metadata(),
+	)
+}
+
 // ResolvePoolRewardAccountAutoVotes classifies each PoolStakeSnapshot
 // with the CIP-1694 reward-account DRep-delegation outcome and writes
 // the result onto snapshot.RewardAccountAutoVote in place. Callers

--- a/database/stake_snapshot_test.go
+++ b/database/stake_snapshot_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetPoolStakeSnapshotsByEpoch_RejectsInvalidSnapshotType verifies a
+// typo'd or stale snapshot type fails fast with an error instead of
+// silently querying and returning zero rows.
+func TestGetPoolStakeSnapshotsByEpoch_RejectsInvalidSnapshotType(t *testing.T) {
+	db := newTestDB(t)
+	_, err := db.GetPoolStakeSnapshotsByEpoch(1, "marc", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid snapshot type")
+}
+
+// TestGetPoolStakeSnapshotsByEpoch_AcceptsKnownTypes verifies every known
+// snapshot type passes validation and reaches the query layer (returning an
+// empty, not an error, result for an epoch with no rows).
+func TestGetPoolStakeSnapshotsByEpoch_AcceptsKnownTypes(t *testing.T) {
+	db := newTestDB(t)
+	for _, snapshotType := range []string{"mark", "set", "go", "actv"} {
+		rows, err := db.GetPoolStakeSnapshotsByEpoch(1, snapshotType, nil)
+		require.NoError(t, err, "snapshot type %q must be accepted", snapshotType)
+		require.Empty(t, rows)
+	}
+}

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -109,11 +109,24 @@ type candidateKey struct {
 	OutputIndex uint32
 }
 
-// candidateEntry is one element of the epoch-candidate snapshot.
-type candidateEntry struct {
+// CandidateEntry is one element of the epoch-candidate snapshot stored in
+// MidnightEpochCandidates.CandidatesCbor. Exported so that MidnightState
+// gRPC handlers (midnight/server) can decode the snapshot back into
+// individual candidates.
+type CandidateEntry struct {
 	TxHash      []byte `cbor:"1,keyasint"`
 	OutputIndex uint32 `cbor:"2,keyasint"`
 	Datum       []byte `cbor:"3,keyasint"`
+}
+
+// DecodeEpochCandidatesCbor decodes a MidnightEpochCandidates.CandidatesCbor
+// blob back into its candidate entries.
+func DecodeEpochCandidatesCbor(data []byte) ([]CandidateEntry, error) {
+	var entries []CandidateEntry
+	if err := fxcbor.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("decode epoch candidates cbor: %w", err)
+	}
+	return entries, nil
 }
 
 // Indexer scans blocks for Midnight-relevant transactions and writes rows
@@ -1403,11 +1416,11 @@ func (idx *Indexer) snapshotEpochLocked(epoch uint64, blockNumber uint64, txn ty
 		return
 	}
 
-	entries := make([]candidateEntry, 0, len(idx.candidates))
+	entries := make([]CandidateEntry, 0, len(idx.candidates))
 	for k, datum := range idx.candidates {
 		hashCopy := make([]byte, 32)
 		copy(hashCopy, k.TxHash[:])
-		entries = append(entries, candidateEntry{
+		entries = append(entries, CandidateEntry{
 			TxHash:      hashCopy,
 			OutputIndex: k.OutputIndex,
 			Datum:       datum,

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -669,24 +669,21 @@ func (idx *Indexer) rollbackBlock(block models.Block) {
 	}
 
 	if len(idx.candidateAddrBytes) > 0 {
-		// Snapshot cleanup, registration-provenance cleanup, and spend-
-		// journal restore only need block.Number; do all three before
-		// decoding so a decode error leaves neither stale DB rows nor
-		// unrestored in-memory candidates.
+		// Snapshot cleanup and spend-journal restore only need block.Number;
+		// do both before decoding so a decode error leaves neither stale DB
+		// rows nor unrestored in-memory candidates.
 		idx.rollbackCandidateSnapshots(block)
-		if err := idx.config.Metadata.DeleteMidnightCommitteeCandidateRegistrationsByBlock(
-			nil,
-			block.Number,
-		); err != nil && idx.config.Logger != nil {
-			idx.config.Logger.Error(
-				"midnight indexer: rollback committee candidate registrations",
-				"error", err,
-				"block", block.Number,
-			)
-		}
 		idx.rollbackCandidateSpends(block.Number)
 		decoded, err := block.Decode()
 		if err != nil {
+			// Decode failure means we cannot remove the in-memory candidate
+			// outputs this block created. Their
+			// MidnightCommitteeCandidateRegistration provenance rows must
+			// therefore be RETAINED, not deleted: a later epoch snapshot may
+			// still serialize those candidates, and GetEpochCandidates needs
+			// the provenance to fill in tx_inputs/slot_number/tx_index/
+			// block_number. Deleting the rows here would leave the in-memory
+			// candidate set and the persisted provenance inconsistent.
 			if idx.config.Logger != nil {
 				idx.config.Logger.Error(
 					"midnight indexer: rollback candidate decode block",
@@ -696,6 +693,20 @@ func (idx *Indexer) rollbackBlock(block models.Block) {
 			}
 		} else {
 			idx.rollbackCandidateCreates(decoded.Transactions())
+			// The created candidates are now gone from the in-memory set, so
+			// their provenance rows can be deleted in lockstep. Doing this
+			// only on the decode-success path preserves the invariant that
+			// every in-memory candidate has a registration row.
+			if err := idx.config.Metadata.DeleteMidnightCommitteeCandidateRegistrationsByBlock(
+				nil,
+				block.Number,
+			); err != nil && idx.config.Logger != nil {
+				idx.config.Logger.Error(
+					"midnight indexer: rollback committee candidate registrations",
+					"error", err,
+					"block", block.Number,
+				)
+			}
 		}
 	}
 

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -129,6 +129,44 @@ func DecodeEpochCandidatesCbor(data []byte) ([]CandidateEntry, error) {
 	return entries, nil
 }
 
+// CandidateInputRef identifies one UTxO consumed by the transaction that
+// created a committee-candidate UTxO. Encoded into
+// MidnightCommitteeCandidateRegistration.TxInputsCbor; exported so
+// midnight/server can decode it back into the EpochCandidate.tx_inputs
+// proto field.
+type CandidateInputRef struct {
+	TxHash []byte `cbor:"1,keyasint"`
+	Index  uint32 `cbor:"2,keyasint"`
+}
+
+// EncodeCandidateInputsCbor encodes a transaction's inputs as the
+// TxInputsCbor payload for MidnightCommitteeCandidateRegistration.
+func EncodeCandidateInputsCbor(inputs []lcommon.TransactionInput) ([]byte, error) {
+	refs := make([]CandidateInputRef, len(inputs))
+	for i, inp := range inputs {
+		refs[i] = CandidateInputRef{
+			TxHash: inp.Id().Bytes(),
+			Index:  inp.Index(),
+		}
+	}
+	data, err := fxcbor.Marshal(refs)
+	if err != nil {
+		return nil, fmt.Errorf("encode candidate tx inputs cbor: %w", err)
+	}
+	return data, nil
+}
+
+// DecodeCandidateInputsCbor decodes a
+// MidnightCommitteeCandidateRegistration.TxInputsCbor blob back into its
+// input references.
+func DecodeCandidateInputsCbor(data []byte) ([]CandidateInputRef, error) {
+	var refs []CandidateInputRef
+	if err := fxcbor.Unmarshal(data, &refs); err != nil {
+		return nil, fmt.Errorf("decode candidate tx inputs cbor: %w", err)
+	}
+	return refs, nil
+}
+
 // Indexer scans blocks for Midnight-relevant transactions and writes rows
 // to the midnight_* tables.
 type Indexer struct {
@@ -631,10 +669,21 @@ func (idx *Indexer) rollbackBlock(block models.Block) {
 	}
 
 	if len(idx.candidateAddrBytes) > 0 {
-		// Snapshot cleanup and spend-journal restore only need block.Number;
-		// do both before decoding so a decode error leaves neither stale DB
-		// rows nor unrestored in-memory candidates.
+		// Snapshot cleanup, registration-provenance cleanup, and spend-
+		// journal restore only need block.Number; do all three before
+		// decoding so a decode error leaves neither stale DB rows nor
+		// unrestored in-memory candidates.
 		idx.rollbackCandidateSnapshots(block)
+		if err := idx.config.Metadata.DeleteMidnightCommitteeCandidateRegistrationsByBlock(
+			nil,
+			block.Number,
+		); err != nil && idx.config.Logger != nil {
+			idx.config.Logger.Error(
+				"midnight indexer: rollback committee candidate registrations",
+				"error", err,
+				"block", block.Number,
+			)
+		}
 		idx.rollbackCandidateSpends(block.Number)
 		decoded, err := block.Decode()
 		if err != nil {
@@ -1128,6 +1177,29 @@ func (idx *Indexer) processTx(
 		}
 	}
 
+	// txInputsCborOnce lazily encodes the creating transaction's input
+	// references the first time a candidate output actually needs them, and
+	// caches the result so a tx with multiple candidate outputs doesn't
+	// re-encode. Most transactions in a block never touch the candidate
+	// address, so encoding eagerly for every transaction would waste work.
+	var txInputsCbor []byte
+	var txInputsCborComputed bool
+	txInputsCborOnce := func() ([]byte, error) {
+		if txInputsCborComputed {
+			return txInputsCbor, nil
+		}
+		var err error
+		txInputsCbor, err = EncodeCandidateInputsCbor(tx.Inputs())
+		if err != nil {
+			return nil, fmt.Errorf(
+				"encode candidate tx inputs tx=%s: %w",
+				hex.EncodeToString(txHashBytes), err,
+			)
+		}
+		txInputsCborComputed = true
+		return txInputsCbor, nil
+	}
+
 	// Scan outputs for cNIGHT creates, registration outputs, and governance.
 	for outIdx, out := range tx.Outputs() {
 		if err := idx.processOutput(
@@ -1140,6 +1212,7 @@ func (idx *Indexer) processTx(
 			out,
 			txn,
 			journal,
+			txInputsCborOnce,
 		); err != nil {
 			return err
 		}
@@ -1161,6 +1234,7 @@ func (idx *Indexer) processOutput(
 	out lcommon.TransactionOutput,
 	txn types.Txn,
 	journal *blockMutationJournal,
+	txInputsCborOnce func() ([]byte, error),
 ) error {
 	txHashHex := hex.EncodeToString(txHashBytes)
 	key := utxoKey{TxHash: txHashHex, Index: outIdx}
@@ -1331,6 +1405,26 @@ func (idx *Indexer) processOutput(
 	// Committee-candidate tracking.
 	if len(idx.candidateAddrBytes) > 0 &&
 		bytes.Equal(addrBytes, idx.candidateAddrBytes) {
+		txInputsCbor, err := txInputsCborOnce()
+		if err != nil {
+			return err
+		}
+		if err := idx.config.Metadata.InsertMidnightCommitteeCandidateRegistration(
+			txn,
+			&models.MidnightCommitteeCandidateRegistration{
+				TxHash:       txHashBytes,
+				OutputIndex:  outIdx,
+				BlockNumber:  block.Number,
+				SlotNumber:   block.Slot,
+				TxIndex:      txIdx,
+				TxInputsCbor: txInputsCbor,
+			},
+		); err != nil {
+			return fmt.Errorf(
+				"write committee candidate registration tx=%s output=%d block=%d: %w",
+				txHashHex, outIdx, block.Number, err,
+			)
+		}
 		var ckey candidateKey
 		copy(ckey.TxHash[:], txHashBytes)
 		ckey.OutputIndex = outIdx

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -21,11 +21,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	fxcbor "github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
@@ -1087,10 +1090,31 @@ func TestCandidateRegistrationProvenance_PersistedAndDecodable(t *testing.T) {
 	assert.Equal(t, uint32(3), refs[1].Index)
 }
 
-// TestCandidateRegistrationProvenance_RollbackDeletes verifies that rolling
-// back a block deletes the committee-candidate registration rows it wrote,
-// so a re-applied block at the same height doesn't see stale provenance.
-func TestCandidateRegistrationProvenance_RollbackDeletes(t *testing.T) {
+// decodableBlockCbor returns the CBOR and block type of a real, decodable
+// block from the shared immutable test fixtures. Used where a rollback test
+// needs block.Decode() to succeed (testBlock produces CBOR-less blocks that
+// fail to decode).
+func decodableBlockCbor(t *testing.T) ([]byte, uint) {
+	t.Helper()
+	imm, err := immutable.New("../../database/immutable/testdata")
+	require.NoError(t, err)
+	it, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer it.Close()
+	b, err := it.Next()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	// Sanity: the fixture block must actually decode.
+	_, err = ledger.NewBlockFromCbor(b.Type, b.Cbor)
+	require.NoError(t, err)
+	return b.Cbor, b.Type
+}
+
+// TestCandidateRegistrationProvenance_RollbackDeletesOnDecodeSuccess verifies
+// that rolling back a decodable block deletes the committee-candidate
+// registration rows it wrote, so a re-applied block at the same height
+// doesn't see stale provenance.
+func TestCandidateRegistrationProvenance_RollbackDeletesOnDecodeSuccess(t *testing.T) {
 	t.Parallel()
 	store := setupTestStore(t)
 	idx := setupGovIndexer(t, store)
@@ -1103,7 +1127,15 @@ func TestCandidateRegistrationProvenance_RollbackDeletes(t *testing.T) {
 		[]lcommon.TransactionInput{buildInput(t, pad32("cafe1000"), 0)},
 		[]lcommon.TransactionOutput{buildGovOutput(t, testMappingAddr, datum)},
 	)
+	// Process the candidate under a block whose CBOR/type make block.Decode()
+	// succeed, so rollbackBlock takes the create-removal + provenance-delete
+	// path. The fixture block's own transactions are unrelated to our
+	// candidate; the registration delete is keyed by block number, and the
+	// in-memory create removal simply finds nothing matching to remove.
+	cborData, blockType := decodableBlockCbor(t)
 	block := testBlock(1, 100, 0xC7)
+	block.Cbor = cborData
+	block.Type = blockType
 	require.NoError(t, idx.processBlock(block, []lcommon.Transaction{createTx}, 1_000))
 
 	var before []models.MidnightCommitteeCandidateRegistration
@@ -1114,7 +1146,50 @@ func TestCandidateRegistrationProvenance_RollbackDeletes(t *testing.T) {
 
 	var after []models.MidnightCommitteeCandidateRegistration
 	require.NoError(t, store.DB().Find(&after).Error)
-	assert.Empty(t, after, "registration row must be deleted after rollback")
+	assert.Empty(t, after, "registration row must be deleted after a decode-success rollback")
+}
+
+// TestCandidateRegistrationProvenance_RollbackRetainsOnDecodeFailure guards
+// the fix for the decode-failure inconsistency: when a rolled-back block
+// cannot be decoded, its created candidates cannot be removed from the
+// in-memory set, so their registration provenance rows must be RETAINED.
+// Deleting them would let a later epoch snapshot emit those candidates with
+// missing tx_inputs/slot_number/tx_index/block_number.
+func TestCandidateRegistrationProvenance_RollbackRetainsOnDecodeFailure(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	idx := setupGovIndexer(t, store)
+
+	datum := simpleDatumCbor(t)
+	txHash := pad32("cafe2001")
+	createTx := buildTx(
+		t,
+		txHash,
+		[]lcommon.TransactionInput{buildInput(t, pad32("cafe2000"), 0)},
+		[]lcommon.TransactionOutput{buildGovOutput(t, testMappingAddr, datum)},
+	)
+	// testBlock carries no CBOR, so block.Decode() fails inside rollbackBlock.
+	block := testBlock(1, 100, 0xC8)
+	require.NoError(t, idx.processBlock(block, []lcommon.Transaction{createTx}, 1_000))
+
+	key := candidateTestKey(t, txHash, 0)
+	idx.mu.RLock()
+	_, trackedBefore := idx.candidates[key]
+	idx.mu.RUnlock()
+	require.True(t, trackedBefore, "candidate must be in memory before rollback")
+
+	idx.rollbackBlock(block)
+
+	// The in-memory candidate remains (decode failure can't remove it)...
+	idx.mu.RLock()
+	_, trackedAfter := idx.candidates[key]
+	idx.mu.RUnlock()
+	assert.True(t, trackedAfter, "decode failure leaves the created candidate in memory")
+
+	// ...so its provenance row must remain too, keeping the two consistent.
+	var after []models.MidnightCommitteeCandidateRegistration
+	require.NoError(t, store.DB().Find(&after).Error)
+	require.Len(t, after, 1, "registration row must be retained when the candidate can't be removed from memory")
 }
 
 // TestCandidateRollbackRestoresSpentAndRemovesCreated verifies candidate

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -1023,7 +1023,7 @@ func TestCandidateAddRemove(t *testing.T) {
 	require.Len(t, snapshots, 1, "epoch transition must write a candidate snapshot")
 	assert.Equal(t, uint64(1), snapshots[0].Epoch)
 
-	var entries []candidateEntry
+	var entries []CandidateEntry
 	require.NoError(t, fxcbor.Unmarshal(snapshots[0].CandidatesCbor, &entries))
 	require.Len(t, entries, 1)
 }

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -1028,6 +1028,95 @@ func TestCandidateAddRemove(t *testing.T) {
 	require.Len(t, entries, 1)
 }
 
+// TestCandidateRegistrationProvenance_PersistedAndDecodable verifies that
+// creating a candidate UTxO durably records its block/slot/tx-index and the
+// creating transaction's inputs, and that the CBOR round-trips through
+// DecodeCandidateInputsCbor exactly as written.
+func TestCandidateRegistrationProvenance_PersistedAndDecodable(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	idx := setupGovIndexer(t, store)
+
+	datum := simpleDatumCbor(t)
+	txHash := pad32("cafe0001")
+	in1Hash := pad32("cafe0000")
+	in2Hash := pad32("cafe0002")
+	createTx := buildTx(
+		t,
+		txHash,
+		[]lcommon.TransactionInput{
+			buildInput(t, in1Hash, 0),
+			buildInput(t, in2Hash, 3),
+		},
+		[]lcommon.TransactionOutput{buildGovOutput(t, testMappingAddr, datum)},
+	)
+	// A leading, unrelated tx so the candidate-creating tx lands at index 1,
+	// proving TxIndex is the tx's position and not just hardcoded to 0.
+	otherTx := buildTx(
+		t,
+		pad32("cafe0003"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("cafe0004"), 0)},
+		[]lcommon.TransactionOutput{anyOutput(t)},
+	)
+	block := testBlock(7, 777, 0xF7)
+	require.NoError(t, idx.processBlock(block, []lcommon.Transaction{otherTx, createTx}, 1_000))
+
+	txHashBytes, err := hex.DecodeString(txHash)
+	require.NoError(t, err)
+
+	var rows []models.MidnightCommitteeCandidateRegistration
+	require.NoError(t, store.DB().Find(&rows).Error)
+	require.Len(t, rows, 1)
+	row := rows[0]
+	assert.Equal(t, txHashBytes, row.TxHash)
+	assert.Equal(t, uint32(0), row.OutputIndex)
+	assert.Equal(t, block.Number, row.BlockNumber)
+	assert.Equal(t, block.Slot, row.SlotNumber)
+	assert.Equal(t, uint32(1), row.TxIndex, "candidate tx is the second tx in the block")
+
+	refs, err := DecodeCandidateInputsCbor(row.TxInputsCbor)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	in1HashBytes, err := hex.DecodeString(in1Hash)
+	require.NoError(t, err)
+	in2HashBytes, err := hex.DecodeString(in2Hash)
+	require.NoError(t, err)
+	assert.Equal(t, in1HashBytes, refs[0].TxHash)
+	assert.Equal(t, uint32(0), refs[0].Index)
+	assert.Equal(t, in2HashBytes, refs[1].TxHash)
+	assert.Equal(t, uint32(3), refs[1].Index)
+}
+
+// TestCandidateRegistrationProvenance_RollbackDeletes verifies that rolling
+// back a block deletes the committee-candidate registration rows it wrote,
+// so a re-applied block at the same height doesn't see stale provenance.
+func TestCandidateRegistrationProvenance_RollbackDeletes(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	idx := setupGovIndexer(t, store)
+
+	datum := simpleDatumCbor(t)
+	txHash := pad32("cafe1001")
+	createTx := buildTx(
+		t,
+		txHash,
+		[]lcommon.TransactionInput{buildInput(t, pad32("cafe1000"), 0)},
+		[]lcommon.TransactionOutput{buildGovOutput(t, testMappingAddr, datum)},
+	)
+	block := testBlock(1, 100, 0xC7)
+	require.NoError(t, idx.processBlock(block, []lcommon.Transaction{createTx}, 1_000))
+
+	var before []models.MidnightCommitteeCandidateRegistration
+	require.NoError(t, store.DB().Find(&before).Error)
+	require.Len(t, before, 1, "registration row must exist before rollback")
+
+	idx.rollbackBlock(block)
+
+	var after []models.MidnightCommitteeCandidateRegistration
+	require.NoError(t, store.DB().Find(&after).Error)
+	assert.Empty(t, after, "registration row must be deleted after rollback")
+}
+
 // TestCandidateRollbackRestoresSpentAndRemovesCreated verifies candidate
 // rollback safety: undoing a block restores candidates it spent and removes
 // candidate outputs created by the rolled-back block.

--- a/midnight/server/adapter.go
+++ b/midnight/server/adapter.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// databaseAdapter adapts *database.Database to MidnightDatabase.
+// BlockByHash, BlocksRecent, and BlockBeforeSlot are package-level functions
+// in the database package rather than methods, so this adapter bridges the
+// gap while keeping the rest of this package free of a direct
+// *database.Database dependency (mirrors api/mesh's meshDatabaseAdapter).
+type databaseAdapter struct {
+	db *database.Database
+}
+
+// NewDatabase wraps a *database.Database as a MidnightDatabase for use in
+// the Midnight gRPC server config.
+func NewDatabase(db *database.Database) MidnightDatabase {
+	return &databaseAdapter{db: db}
+}
+
+func (a *databaseAdapter) GetLatestMidnightGovernanceDatum(
+	datumType string,
+	blockNumber uint64,
+) (*models.MidnightGovernanceDatum, error) {
+	return a.db.GetLatestMidnightGovernanceDatum(datumType, blockNumber)
+}
+
+func (a *databaseAdapter) GetMidnightAriadneParamsAtOrBeforeEpoch(
+	epoch uint64,
+) (*models.MidnightAriadneParams, error) {
+	return a.db.GetMidnightAriadneParamsAtOrBeforeEpoch(epoch)
+}
+
+func (a *databaseAdapter) GetMidnightEpochCandidatesByEpoch(
+	epoch uint64,
+) (*models.MidnightEpochCandidates, error) {
+	return a.db.GetMidnightEpochCandidatesByEpoch(epoch)
+}
+
+func (a *databaseAdapter) GetPoolStakeSnapshotsByEpoch(
+	epoch uint64,
+	snapshotType string,
+) ([]*models.PoolStakeSnapshot, error) {
+	return a.db.GetPoolStakeSnapshotsByEpoch(epoch, snapshotType, nil)
+}
+
+func (a *databaseAdapter) GetEpoch(epochId uint64) (*models.Epoch, error) {
+	return a.db.GetEpoch(epochId, nil)
+}
+
+func (a *databaseAdapter) GetEpochBySlot(slot uint64) (*models.Epoch, error) {
+	return a.db.GetEpochBySlot(slot, nil)
+}
+
+func (a *databaseAdapter) BlockByHash(hash []byte) (models.Block, error) {
+	return database.BlockByHash(a.db, hash)
+}
+
+func (a *databaseAdapter) BlockByNumber(number uint64) (models.Block, error) {
+	// Cardano block numbers are 0-based; the blob store's internal index is
+	// 1-based (database.BlockInitialIndex). Translate here, the same way
+	// api/blockfrost's block-by-height lookup does, so callers deal only in
+	// consensus block numbers.
+	return a.db.BlockByIndex(number+database.BlockInitialIndex, nil)
+}
+
+func (a *databaseAdapter) BlocksRecent(count int) ([]models.Block, error) {
+	return database.BlocksRecent(a.db, count)
+}
+
+func (a *databaseAdapter) BlockBeforeSlot(slot uint64) (models.Block, error) {
+	return database.BlockBeforeSlot(a.db, slot)
+}

--- a/midnight/server/adapter.go
+++ b/midnight/server/adapter.go
@@ -15,6 +15,9 @@
 package server
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 )
@@ -76,7 +79,16 @@ func (a *databaseAdapter) BlockByNumber(number uint64) (models.Block, error) {
 	// Cardano block numbers are 0-based; the blob store's internal index is
 	// 1-based (database.BlockInitialIndex). Translate here, the same way
 	// api/blockfrost's block-by-height lookup does, so callers deal only in
-	// consensus block numbers.
+	// consensus block numbers. Guard the addition first: no real chain gets
+	// anywhere near math.MaxUint64, but without the check that value would
+	// wrap to internal index 0 instead of failing.
+	if number > math.MaxUint64-database.BlockInitialIndex {
+		return models.Block{}, fmt.Errorf(
+			"block number %d overflows internal index: %w",
+			number,
+			models.ErrBlockNotFound,
+		)
+	}
 	return a.db.BlockByIndex(number+database.BlockInitialIndex, nil)
 }
 

--- a/midnight/server/adapter.go
+++ b/midnight/server/adapter.go
@@ -56,6 +56,12 @@ func (a *databaseAdapter) GetMidnightEpochCandidatesByEpoch(
 	return a.db.GetMidnightEpochCandidatesByEpoch(epoch)
 }
 
+func (a *databaseAdapter) GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+	txHashes [][]byte,
+) ([]models.MidnightCommitteeCandidateRegistration, error) {
+	return a.db.GetMidnightCommitteeCandidateRegistrationsByTxHashes(txHashes)
+}
+
 func (a *databaseAdapter) GetPoolStakeSnapshotsByEpoch(
 	epoch uint64,
 	snapshotType string,

--- a/midnight/server/adapter_test.go
+++ b/midnight/server/adapter_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/midnight/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockByNumber_OverflowIsRejected verifies that a block number so large
+// it would wrap the blob store's 1-based internal index back to 0 is
+// rejected up front rather than silently looking up the wrong block.
+func TestBlockByNumber_OverflowIsRejected(t *testing.T) {
+	db := newTestDatabase(t)
+	adapted := server.NewDatabase(db)
+
+	_, err := adapted.BlockByNumber(math.MaxUint64)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}
+
+// TestBlockByNumber_ResolvesInsertedBlock is the non-overflow control case:
+// a normal block number round-trips through the 0-based/1-based translation.
+func TestBlockByNumber_ResolvesInsertedBlock(t *testing.T) {
+	db := newTestDatabase(t)
+	blk := insertPlaceholderBlock(t, db, 5, 5, 0x05)
+	adapted := server.NewDatabase(db)
+
+	got, err := adapted.BlockByNumber(5)
+	require.NoError(t, err)
+	require.Equal(t, blk.Hash, got.Hash)
+}

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -75,6 +75,14 @@ type MidnightDatabase interface {
 	GetMidnightEpochCandidatesByEpoch(
 		epoch uint64,
 	) (*models.MidnightEpochCandidates, error)
+	// GetMidnightCommitteeCandidateRegistrationsByTxHashes returns the
+	// on-chain provenance (block/slot/tx-index/tx-inputs) for candidate
+	// UTxOs whose creating tx hash is in txHashes, for GetEpochCandidates to
+	// join against the (tx_hash, output_index, datum) membership decoded
+	// from a MidnightEpochCandidates snapshot.
+	GetMidnightCommitteeCandidateRegistrationsByTxHashes(
+		txHashes [][]byte,
+	) ([]models.MidnightCommitteeCandidateRegistration, error)
 	GetPoolStakeSnapshotsByEpoch(
 		epoch uint64,
 		snapshotType string,

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/midnight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -54,6 +54,39 @@ const (
 type SlotTimer interface {
 	SlotToTime(slot uint64) (time.Time, error)
 	TimeToSlot(t time.Time) (uint64, error)
+}
+
+// MidnightDatabase is the subset of *database.Database needed by the
+// governance/parameters/block/epoch/stability RPCs. Keeping this package
+// dependent on a narrow interface (rather than *database.Database directly)
+// matches the composition boundary documented in ARCHITECTURE.md: domain
+// packages depend on constructor-injected narrow interfaces, and only the
+// composition layer (here, adapter.go's NewDatabase) wires the concrete
+// type. All methods implicitly use a nil transaction (auto-transaction per
+// call), mirroring api/mesh's MeshDatabase.
+type MidnightDatabase interface {
+	GetLatestMidnightGovernanceDatum(
+		datumType string,
+		blockNumber uint64,
+	) (*models.MidnightGovernanceDatum, error)
+	GetMidnightAriadneParamsAtOrBeforeEpoch(
+		epoch uint64,
+	) (*models.MidnightAriadneParams, error)
+	GetMidnightEpochCandidatesByEpoch(
+		epoch uint64,
+	) (*models.MidnightEpochCandidates, error)
+	GetPoolStakeSnapshotsByEpoch(
+		epoch uint64,
+		snapshotType string,
+	) ([]*models.PoolStakeSnapshot, error)
+	GetEpoch(epochId uint64) (*models.Epoch, error)
+	GetEpochBySlot(slot uint64) (*models.Epoch, error)
+	BlockByHash(hash []byte) (models.Block, error)
+	// BlockByNumber returns the block at the given 0-based consensus block
+	// number, translating to the blob store's internal 1-based index.
+	BlockByNumber(number uint64) (models.Block, error)
+	BlocksRecent(count int) ([]models.Block, error)
+	BlockBeforeSlot(slot uint64) (models.Block, error)
 }
 
 // Config holds the configuration for the Midnight gRPC server.
@@ -83,9 +116,9 @@ type Config struct {
 	// Defaults to 30s.
 	ShutdownTimeout time.Duration
 	// Database backs the governance/parameters/block/epoch/stability RPCs.
-	// Required for those RPCs to work; RPCs that only need Database are
-	// unaffected by a nil SlotTimer.
-	Database *database.Database
+	// Wrap a *database.Database with NewDatabase. Required for those RPCs to
+	// work; RPCs that only need Database are unaffected by a nil SlotTimer.
+	Database MidnightDatabase
 	// SlotTimer resolves block timestamps and, for the as-of-timestamp
 	// variants of the stability RPCs, converts a wall-clock time back to a
 	// slot. Required by GetBlockByHash, GetLatestBlock, GetStableBlock, and
@@ -295,6 +328,6 @@ type service struct {
 	midnight.UnimplementedMidnightStateServer
 	metadata          eventStore
 	blockNumberByHash func(hash []byte) (blockNumber uint64, found bool, err error)
-	db                *database.Database
+	db                MidnightDatabase
 	slotTimer         SlotTimer
 }

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -16,9 +16,10 @@
 // google.golang.org/grpc server (not ConnectRPC) so that clients written
 // against the Acropolis tonic service are byte-for-byte compatible. The
 // UTxO-event query RPCs (GetAssetCreates, GetAssetSpends, GetRegistrations,
-// GetDeregistrations, GetUtxoEvents) are backed by Config.Metadata; the
-// remaining RPCs fall back to UnimplementedMidnightStateServer until their
-// handlers are added separately.
+// GetDeregistrations, GetUtxoEvents) are backed by Config.Metadata
+// (see midnight_state.go). The governance/parameters/block/epoch/stability
+// RPCs are backed by Config.Database and Config.SlotTimer (see service.go).
+// Any remaining RPC falls back to UnimplementedMidnightStateServer.
 package server
 
 import (
@@ -32,6 +33,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/midnight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -45,6 +47,14 @@ const (
 	defaultPort            = 50051
 	defaultShutdownTimeout = 30 * time.Second
 )
+
+// SlotTimer converts between slot numbers and wall-clock time. Satisfied by
+// *ledger.LedgerState; kept as a narrow local interface so this package does
+// not need to import the full ledger package.
+type SlotTimer interface {
+	SlotToTime(slot uint64) (time.Time, error)
+	TimeToSlot(t time.Time) (uint64, error)
+}
 
 // Config holds the configuration for the Midnight gRPC server.
 type Config struct {
@@ -72,6 +82,15 @@ type Config struct {
 	// ShutdownTimeout bounds GracefulStop before escalating to a hard Stop.
 	// Defaults to 30s.
 	ShutdownTimeout time.Duration
+	// Database backs the governance/parameters/block/epoch/stability RPCs.
+	// Required for those RPCs to work; RPCs that only need Database are
+	// unaffected by a nil SlotTimer.
+	Database *database.Database
+	// SlotTimer resolves block timestamps and, for the as-of-timestamp
+	// variants of the stability RPCs, converts a wall-clock time back to a
+	// slot. Required by GetBlockByHash, GetLatestBlock, GetStableBlock, and
+	// GetLatestStableBlock.
+	SlotTimer SlotTimer
 }
 
 // Server runs the MidnightState gRPC service over its own listener.
@@ -143,12 +162,15 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	grpcServer := grpc.NewServer(opts...)
-	// MidnightState service: the UTxO-event query RPCs are implemented
-	// against s.config.Metadata; every other RPC returns Unimplemented until
-	// its handler lands.
+	// MidnightState service: the UTxO-event query RPCs are backed by
+	// s.config.Metadata; the governance/parameters/block/epoch/stability RPCs
+	// by s.config.Database and s.config.SlotTimer. Any RPC whose backend is
+	// nil returns Unimplemented (embedded) or a clean FailedPrecondition.
 	midnight.RegisterMidnightStateServer(grpcServer, &service{
 		metadata:          s.config.Metadata,
 		blockNumberByHash: s.config.BlockNumberByHash,
+		db:                s.config.Database,
+		slotTimer:         s.config.SlotTimer,
 	})
 
 	// Health service reporting SERVING for the overall server ("") and the
@@ -266,8 +288,13 @@ func (s *Server) gracefulStop(timeout time.Duration) {
 // service is the MidnightState implementation. Embedding
 // UnimplementedMidnightStateServer makes every RPC not overridden below
 // return codes.Unimplemented until its handler is added in follow-up work.
+// The UTxO-event query RPCs use metadata/blockNumberByHash (midnight_state.go);
+// the governance/parameters/block/epoch/stability RPCs use db/slotTimer
+// (service.go).
 type service struct {
 	midnight.UnimplementedMidnightStateServer
 	metadata          eventStore
 	blockNumberByHash func(hash []byte) (blockNumber uint64, found bool, err error)
+	db                *database.Database
+	slotTimer         SlotTimer
 }

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -332,6 +332,13 @@ func (s *Server) gracefulStop(timeout time.Duration) {
 // The UTxO-event query RPCs use metadata/blockNumberByHash (midnight_state.go);
 // the governance/parameters/block/epoch/stability RPCs use db/slotTimer
 // (service.go).
+//
+// Any backend field may be nil: the server can be started for health,
+// reflection, and lifecycle purposes without them. Handlers guard on their
+// required backend (checkDatabase / checkBlockBackends in service.go, and
+// the metadata/blockNumberByHash checks in midnight_state.go) so a missing
+// dependency yields a clean status error rather than a nil-pointer panic. In
+// production (node.go) all backends are wired.
 type service struct {
 	midnight.UnimplementedMidnightStateServer
 	metadata          eventStore

--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -50,6 +50,14 @@ func freePort(t *testing.T) uint {
 // cleanup ordering live in exactly one place.
 func startTestServerConfig(t *testing.T, cfg server.Config) string {
 	t.Helper()
+	return startTestServerWithConfig(t, server.Config{})
+}
+
+// startTestServerWithConfig is like startTestServer but lets the caller
+// supply Database/SlotTimer (and any other Config field); Host and Port are
+// always overridden to a free loopback address.
+func startTestServerWithConfig(t *testing.T, cfg server.Config) string {
+	t.Helper()
 	port := freePort(t)
 	cfg.Host = "127.0.0.1"
 	cfg.Port = port
@@ -96,7 +104,7 @@ func TestStubServiceReturnsUnimplemented(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err := client.GetLatestBlock(ctx, &midnight.LatestBlockRequest{})
+	_, err := client.GetAssetCreates(ctx, &midnight.AssetCreatesRequest{})
 	require.Error(t, err)
 	require.Equal(t, codes.Unimplemented, status.Code(err))
 }
@@ -178,7 +186,7 @@ func TestShutdownOnContextCancel(t *testing.T) {
 	client := midnight.NewMidnightStateClient(dial(t, addr))
 	callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer callCancel()
-	_, err = client.GetLatestBlock(callCtx, &midnight.LatestBlockRequest{})
+	_, err = client.GetAssetCreates(callCtx, &midnight.AssetCreatesRequest{})
 	require.Equal(t, codes.Unimplemented, status.Code(err))
 
 	// Cancellation triggers graceful shutdown; once stopped a fresh call no
@@ -199,7 +207,7 @@ func TestShutdownOnContextCancel(t *testing.T) {
 			200*time.Millisecond,
 		)
 		defer probeCancel()
-		_, probeErr := c.GetLatestBlock(probeCtx, &midnight.LatestBlockRequest{})
+		_, probeErr := c.GetAssetCreates(probeCtx, &midnight.AssetCreatesRequest{})
 		return status.Code(probeErr) != codes.Unimplemented
 	}, 5*time.Second, "server did not shut down after context cancel")
 }

--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -50,7 +50,7 @@ func freePort(t *testing.T) uint {
 // cleanup ordering live in exactly one place.
 func startTestServerConfig(t *testing.T, cfg server.Config) string {
 	t.Helper()
-	return startTestServerWithConfig(t, server.Config{})
+	return startTestServerWithConfig(t, cfg)
 }
 
 // startTestServerWithConfig is like startTestServer but lets the caller

--- a/midnight/server/service.go
+++ b/midnight/server/service.go
@@ -163,6 +163,14 @@ func (s *service) GetEpochCandidates(
 			err,
 		)
 	}
+	registrations, err := s.candidateRegistrationsFor(entries)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"get committee candidate registrations: %v",
+			err,
+		)
+	}
 	candidates := make([]*midnight.EpochCandidate, len(entries))
 	for i, entry := range entries {
 		candidates[i] = &midnight.EpochCandidate{
@@ -170,8 +178,35 @@ func (s *service) GetEpochCandidates(
 			UtxoTxHash:  entry.TxHash,
 			UtxoIndex:   entry.OutputIndex,
 			EpochNumber: epoch,
-			BlockNumber: snapshot.BlockNumber,
 		}
+		reg, ok := registrations[candidateRegistrationKey{
+			txHash:      string(entry.TxHash),
+			outputIndex: entry.OutputIndex,
+		}]
+		if !ok {
+			// Every candidate tracked in a snapshot was written via
+			// processOutput's write-before-track path, which always inserts
+			// a registration row first; a miss here means the row was lost
+			// (e.g. a pre-migration snapshot). Report what we know rather
+			// than failing the whole response.
+			continue
+		}
+		candidates[i].BlockNumber = reg.BlockNumber
+		candidates[i].SlotNumber = reg.SlotNumber
+		candidates[i].TxIndex = reg.TxIndex
+		inputs, err := midnightindexer.DecodeCandidateInputsCbor(reg.TxInputsCbor)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"decode candidate tx inputs: %v",
+				err,
+			)
+		}
+		txInputs := make([]*midnight.UtxoId, len(inputs))
+		for j, ref := range inputs {
+			txInputs[j] = &midnight.UtxoId{TxHash: ref.TxHash, Index: ref.Index}
+		}
+		candidates[i].TxInputs = txInputs
 	}
 
 	stakeSnapshots, err := s.db.GetPoolStakeSnapshotsByEpoch(
@@ -203,6 +238,48 @@ func (s *service) GetEpochCandidates(
 		Candidates:        candidates,
 		StakeDistribution: stakeDistribution,
 	}, nil
+}
+
+// candidateRegistrationKey identifies a committee-candidate UTxO by its
+// creating (tx_hash, output_index), matching how
+// MidnightCommitteeCandidateRegistration rows are keyed.
+type candidateRegistrationKey struct {
+	txHash      string // string(txHash bytes), not hex — cheaper and just as hashable
+	outputIndex uint32
+}
+
+// candidateRegistrationsFor batch-fetches the on-chain provenance for every
+// entry's creating transaction and returns it keyed by (tx_hash,
+// output_index) for O(1) lookup per candidate. A single query regardless of
+// candidate count avoids one round trip per candidate.
+func (s *service) candidateRegistrationsFor(
+	entries []midnightindexer.CandidateEntry,
+) (map[candidateRegistrationKey]models.MidnightCommitteeCandidateRegistration, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(entries))
+	txHashes := make([][]byte, 0, len(entries))
+	for _, entry := range entries {
+		key := string(entry.TxHash)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		txHashes = append(txHashes, entry.TxHash)
+	}
+	rows, err := s.db.GetMidnightCommitteeCandidateRegistrationsByTxHashes(txHashes)
+	if err != nil {
+		return nil, err
+	}
+	byKey := make(map[candidateRegistrationKey]models.MidnightCommitteeCandidateRegistration, len(rows))
+	for _, row := range rows {
+		byKey[candidateRegistrationKey{
+			txHash:      string(row.TxHash),
+			outputIndex: row.OutputIndex,
+		}] = row
+	}
+	return byKey, nil
 }
 
 // GetBlockByHash returns metadata for the block with the requested hash.

--- a/midnight/server/service.go
+++ b/midnight/server/service.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/midnight"
 	midnightindexer "github.com/blinklabs-io/dingo/midnight/indexer"
@@ -122,7 +121,7 @@ func (s *service) GetEpochNonce(
 	_ context.Context,
 	req *midnight.EpochNonceRequest,
 ) (*midnight.EpochNonceResponse, error) {
-	epoch, err := s.db.GetEpoch(req.GetEpoch(), nil)
+	epoch, err := s.db.GetEpoch(req.GetEpoch())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get epoch: %v", err)
 	}
@@ -178,7 +177,6 @@ func (s *service) GetEpochCandidates(
 	stakeSnapshots, err := s.db.GetPoolStakeSnapshotsByEpoch(
 		epoch,
 		models.PoolStakeSnapshotTypeMark,
-		nil,
 	)
 	if err != nil {
 		return nil, status.Errorf(
@@ -212,7 +210,7 @@ func (s *service) GetBlockByHash(
 	_ context.Context,
 	req *midnight.BlockByHashRequest,
 ) (*midnight.BlockByHashResponse, error) {
-	blk, err := database.BlockByHash(s.db, req.GetBlockHash())
+	blk, err := s.db.BlockByHash(req.GetBlockHash())
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return nil, status.Error(codes.NotFound, "block not found")
@@ -249,7 +247,7 @@ func (s *service) GetLatestBlock(
 	_ context.Context,
 	_ *midnight.LatestBlockRequest,
 ) (*midnight.LatestBlockResponse, error) {
-	blocks, err := database.BlocksRecent(s.db, 1)
+	blocks, err := s.db.BlocksRecent(1)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get latest block: %v", err)
 	}
@@ -270,7 +268,7 @@ func (s *service) GetStableBlock(
 	_ context.Context,
 	req *midnight.StableBlockRequest,
 ) (*midnight.StableBlockResponse, error) {
-	blk, err := database.BlockByHash(s.db, req.GetBlockHash())
+	blk, err := s.db.BlockByHash(req.GetBlockHash())
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return nil, status.Error(codes.NotFound, "block not found")
@@ -314,14 +312,7 @@ func (s *service) GetLatestStableBlock(
 	if tip.Number < offset {
 		return &midnight.LatestStableBlockResponse{}, nil
 	}
-	// BlockByIndex looks up by the blob store's internal sequential index,
-	// which is 1-based (database.BlockInitialIndex) while Cardano block
-	// numbers are 0-based; translate as api/blockfrost's block-by-height
-	// lookup does.
-	blk, err := s.db.BlockByIndex(
-		tip.Number-offset+database.BlockInitialIndex,
-		nil,
-	)
+	blk, err := s.db.BlockByNumber(tip.Number - offset)
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return &midnight.LatestStableBlockResponse{}, nil
@@ -343,7 +334,7 @@ func (s *service) GetLatestStableBlock(
 // non-zero, the latest block at or before that wall-clock time.
 func (s *service) resolveTipBlock(asOfMillis uint64) (models.Block, error) {
 	if asOfMillis == 0 {
-		blocks, err := database.BlocksRecent(s.db, 1)
+		blocks, err := s.db.BlocksRecent(1)
 		if err != nil {
 			return models.Block{}, err
 		}
@@ -361,7 +352,7 @@ func (s *service) resolveTipBlock(asOfMillis uint64) (models.Block, error) {
 			err,
 		)
 	}
-	return database.BlockBeforeSlot(s.db, slot+1)
+	return s.db.BlockBeforeSlot(slot + 1)
 }
 
 // buildBlock converts a stored block into the shared MidnightState Block
@@ -391,7 +382,7 @@ func (s *service) buildBlock(blk models.Block) (*midnight.Block, error) {
 // epochForSlot resolves the epoch containing slot from the stored epoch
 // cache.
 func (s *service) epochForSlot(slot uint64) (*models.Epoch, error) {
-	epoch, err := s.db.GetEpochBySlot(slot, nil)
+	epoch, err := s.db.GetEpochBySlot(slot)
 	if err != nil {
 		return nil, fmt.Errorf("resolve epoch for slot %d: %w", slot, err)
 	}

--- a/midnight/server/service.go
+++ b/midnight/server/service.go
@@ -31,6 +31,41 @@ import (
 // The service struct is declared in server.go, where its db/slotTimer fields
 // (used by the handlers below) sit alongside the metadata/blockNumberByHash
 // fields used by the UTxO-event query handlers in midnight_state.go.
+//
+// db and slotTimer may be nil: the server can be started for health,
+// reflection, and lifecycle purposes without them (see server.New). The
+// implemented handlers guard on their required backends with checkDatabase /
+// checkBlockBackends so a missing dependency yields a clean
+// FailedPrecondition status rather than a nil-pointer panic. In production
+// (node.go) both are always wired.
+
+// checkDatabase returns a FailedPrecondition status when the service was
+// constructed without a Database backend, which every implemented RPC needs.
+func (s *service) checkDatabase() error {
+	if s.db == nil {
+		return status.Error(
+			codes.FailedPrecondition,
+			"midnight: database backend not configured",
+		)
+	}
+	return nil
+}
+
+// checkBlockBackends returns a FailedPrecondition status when the service is
+// missing either the Database or the SlotTimer that the block/stability RPCs
+// require (they resolve epoch numbers and wall-clock timestamps).
+func (s *service) checkBlockBackends() error {
+	if err := s.checkDatabase(); err != nil {
+		return err
+	}
+	if s.slotTimer == nil {
+		return status.Error(
+			codes.FailedPrecondition,
+			"midnight: slot timer not configured",
+		)
+	}
+	return nil
+}
 
 // GetTechnicalCommitteeDatum returns the newest Technical Committee datum at
 // or before the requested block number.
@@ -38,6 +73,9 @@ func (s *service) GetTechnicalCommitteeDatum(
 	_ context.Context,
 	req *midnight.TechnicalCommitteeDatumRequest,
 ) (*midnight.TechnicalCommitteeDatumResponse, error) {
+	if err := s.checkDatabase(); err != nil {
+		return nil, err
+	}
 	datum, err := s.db.GetLatestMidnightGovernanceDatum(
 		models.MidnightGovernanceDatumTypeTechnicalCommittee,
 		req.GetBlockNumber(),
@@ -67,6 +105,9 @@ func (s *service) GetCouncilDatum(
 	_ context.Context,
 	req *midnight.CouncilDatumRequest,
 ) (*midnight.CouncilDatumResponse, error) {
+	if err := s.checkDatabase(); err != nil {
+		return nil, err
+	}
 	datum, err := s.db.GetLatestMidnightGovernanceDatum(
 		models.MidnightGovernanceDatumTypeCouncil,
 		req.GetBlockNumber(),
@@ -96,6 +137,9 @@ func (s *service) GetAriadneParameters(
 	_ context.Context,
 	req *midnight.AriadneParametersRequest,
 ) (*midnight.AriadneParametersResponse, error) {
+	if err := s.checkDatabase(); err != nil {
+		return nil, err
+	}
 	params, err := s.db.GetMidnightAriadneParamsAtOrBeforeEpoch(req.GetEpoch())
 	if err != nil {
 		return nil, status.Errorf(
@@ -121,6 +165,9 @@ func (s *service) GetEpochNonce(
 	_ context.Context,
 	req *midnight.EpochNonceRequest,
 ) (*midnight.EpochNonceResponse, error) {
+	if err := s.checkDatabase(); err != nil {
+		return nil, err
+	}
 	epoch, err := s.db.GetEpoch(req.GetEpoch())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get epoch: %v", err)
@@ -138,6 +185,9 @@ func (s *service) GetEpochCandidates(
 	_ context.Context,
 	req *midnight.EpochCandidatesRequest,
 ) (*midnight.EpochCandidatesResponse, error) {
+	if err := s.checkDatabase(); err != nil {
+		return nil, err
+	}
 	epoch := req.GetEpoch()
 	snapshot, err := s.db.GetMidnightEpochCandidatesByEpoch(epoch)
 	if err != nil {
@@ -287,6 +337,9 @@ func (s *service) GetBlockByHash(
 	_ context.Context,
 	req *midnight.BlockByHashRequest,
 ) (*midnight.BlockByHashResponse, error) {
+	if err := s.checkBlockBackends(); err != nil {
+		return nil, err
+	}
 	blk, err := s.db.BlockByHash(req.GetBlockHash())
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
@@ -324,6 +377,9 @@ func (s *service) GetLatestBlock(
 	_ context.Context,
 	_ *midnight.LatestBlockRequest,
 ) (*midnight.LatestBlockResponse, error) {
+	if err := s.checkBlockBackends(); err != nil {
+		return nil, err
+	}
 	blocks, err := s.db.BlocksRecent(1)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get latest block: %v", err)
@@ -345,6 +401,9 @@ func (s *service) GetStableBlock(
 	_ context.Context,
 	req *midnight.StableBlockRequest,
 ) (*midnight.StableBlockResponse, error) {
+	if err := s.checkBlockBackends(); err != nil {
+		return nil, err
+	}
 	blk, err := s.db.BlockByHash(req.GetBlockHash())
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
@@ -378,6 +437,9 @@ func (s *service) GetLatestStableBlock(
 	_ context.Context,
 	req *midnight.LatestStableBlockRequest,
 ) (*midnight.LatestStableBlockResponse, error) {
+	if err := s.checkBlockBackends(); err != nil {
+		return nil, err
+	}
 	tip, err := s.resolveTipBlock(req.GetAsOfTimestampUnixMillis())
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {

--- a/midnight/server/service.go
+++ b/midnight/server/service.go
@@ -1,0 +1,414 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/midnight"
+	midnightindexer "github.com/blinklabs-io/dingo/midnight/indexer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The service struct is declared in server.go, where its db/slotTimer fields
+// (used by the handlers below) sit alongside the metadata/blockNumberByHash
+// fields used by the UTxO-event query handlers in midnight_state.go.
+
+// GetTechnicalCommitteeDatum returns the newest Technical Committee datum at
+// or before the requested block number.
+func (s *service) GetTechnicalCommitteeDatum(
+	_ context.Context,
+	req *midnight.TechnicalCommitteeDatumRequest,
+) (*midnight.TechnicalCommitteeDatumResponse, error) {
+	datum, err := s.db.GetLatestMidnightGovernanceDatum(
+		models.MidnightGovernanceDatumTypeTechnicalCommittee,
+		req.GetBlockNumber(),
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"get technical committee datum: %v",
+			err,
+		)
+	}
+	if datum == nil {
+		return nil, status.Error(
+			codes.NotFound,
+			"no technical committee datum at or before the requested block",
+		)
+	}
+	return &midnight.TechnicalCommitteeDatumResponse{
+		SourceBlockNumber: datum.BlockNumber,
+		Datum:             datum.Datum,
+	}, nil
+}
+
+// GetCouncilDatum returns the newest Council datum at or before the
+// requested block number.
+func (s *service) GetCouncilDatum(
+	_ context.Context,
+	req *midnight.CouncilDatumRequest,
+) (*midnight.CouncilDatumResponse, error) {
+	datum, err := s.db.GetLatestMidnightGovernanceDatum(
+		models.MidnightGovernanceDatumTypeCouncil,
+		req.GetBlockNumber(),
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"get council datum: %v",
+			err,
+		)
+	}
+	if datum == nil {
+		return nil, status.Error(
+			codes.NotFound,
+			"no council datum at or before the requested block",
+		)
+	}
+	return &midnight.CouncilDatumResponse{
+		SourceBlockNumber: datum.BlockNumber,
+		Datum:             datum.Datum,
+	}, nil
+}
+
+// GetAriadneParameters returns the newest Ariadne parameters at or before
+// the requested epoch.
+func (s *service) GetAriadneParameters(
+	_ context.Context,
+	req *midnight.AriadneParametersRequest,
+) (*midnight.AriadneParametersResponse, error) {
+	params, err := s.db.GetMidnightAriadneParamsAtOrBeforeEpoch(req.GetEpoch())
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"get ariadne parameters: %v",
+			err,
+		)
+	}
+	if params == nil {
+		return nil, status.Error(
+			codes.NotFound,
+			"no ariadne parameters at or before the requested epoch",
+		)
+	}
+	return &midnight.AriadneParametersResponse{
+		SourceEpoch: params.Epoch,
+		Datum:       params.Datum,
+	}, nil
+}
+
+// GetEpochNonce returns the stored epoch nonce for the requested epoch.
+func (s *service) GetEpochNonce(
+	_ context.Context,
+	req *midnight.EpochNonceRequest,
+) (*midnight.EpochNonceResponse, error) {
+	epoch, err := s.db.GetEpoch(req.GetEpoch(), nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get epoch: %v", err)
+	}
+	if epoch == nil {
+		return nil, status.Error(codes.NotFound, "epoch not found")
+	}
+	return &midnight.EpochNonceResponse{Nonce: epoch.Nonce}, nil
+}
+
+// GetEpochCandidates returns the committee-candidate snapshot for the
+// requested epoch along with the pool stake distribution captured at the
+// same epoch boundary.
+func (s *service) GetEpochCandidates(
+	_ context.Context,
+	req *midnight.EpochCandidatesRequest,
+) (*midnight.EpochCandidatesResponse, error) {
+	epoch := req.GetEpoch()
+	snapshot, err := s.db.GetMidnightEpochCandidatesByEpoch(epoch)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"get epoch candidates: %v",
+			err,
+		)
+	}
+	if snapshot == nil {
+		return nil, status.Error(
+			codes.NotFound,
+			"no candidate snapshot for the requested epoch",
+		)
+	}
+	entries, err := midnightindexer.DecodeEpochCandidatesCbor(
+		snapshot.CandidatesCbor,
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"decode candidate snapshot: %v",
+			err,
+		)
+	}
+	candidates := make([]*midnight.EpochCandidate, len(entries))
+	for i, entry := range entries {
+		candidates[i] = &midnight.EpochCandidate{
+			FullDatum:   entry.Datum,
+			UtxoTxHash:  entry.TxHash,
+			UtxoIndex:   entry.OutputIndex,
+			EpochNumber: epoch,
+			BlockNumber: snapshot.BlockNumber,
+		}
+	}
+
+	stakeSnapshots, err := s.db.GetPoolStakeSnapshotsByEpoch(
+		epoch,
+		models.PoolStakeSnapshotTypeMark,
+		nil,
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"get pool stake snapshots: %v",
+			err,
+		)
+	}
+	// GetPoolStakeSnapshotsByEpoch does not guarantee row order; sort by pool
+	// key hash so the response is deterministic across calls and backends.
+	sort.Slice(stakeSnapshots, func(i, j int) bool {
+		return string(stakeSnapshots[i].PoolKeyHash) <
+			string(stakeSnapshots[j].PoolKeyHash)
+	})
+	stakeDistribution := make([]*midnight.StakePoolEntry, len(stakeSnapshots))
+	for i, snap := range stakeSnapshots {
+		stakeDistribution[i] = &midnight.StakePoolEntry{
+			PoolHash: snap.PoolKeyHash,
+			Stake:    uint64(snap.TotalStake),
+		}
+	}
+
+	return &midnight.EpochCandidatesResponse{
+		Candidates:        candidates,
+		StakeDistribution: stakeDistribution,
+	}, nil
+}
+
+// GetBlockByHash returns metadata for the block with the requested hash.
+func (s *service) GetBlockByHash(
+	_ context.Context,
+	req *midnight.BlockByHashRequest,
+) (*midnight.BlockByHashResponse, error) {
+	blk, err := database.BlockByHash(s.db, req.GetBlockHash())
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return nil, status.Error(codes.NotFound, "block not found")
+		}
+		return nil, status.Errorf(codes.Internal, "get block by hash: %v", err)
+	}
+	decoded, err := blk.Decode()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "decode block: %v", err)
+	}
+	epoch, err := s.epochForSlot(blk.Slot)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	ts, err := s.slotTimer.SlotToTime(blk.Slot)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"resolve block timestamp: %v",
+			err,
+		)
+	}
+	return &midnight.BlockByHashResponse{
+		BlockNumber:        checkedUint32(blk.Number),
+		TxCount:            checkedUint32(uint64(len(decoded.Transactions()))),
+		BlockTimestampUnix: ts.Unix(),
+		EpochNumber:        checkedUint32(epoch.EpochId),
+		SlotNumber:         blk.Slot,
+	}, nil
+}
+
+// GetLatestBlock returns the current chain tip.
+func (s *service) GetLatestBlock(
+	_ context.Context,
+	_ *midnight.LatestBlockRequest,
+) (*midnight.LatestBlockResponse, error) {
+	blocks, err := database.BlocksRecent(s.db, 1)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get latest block: %v", err)
+	}
+	if len(blocks) == 0 {
+		return nil, status.Error(codes.NotFound, "no blocks in chain yet")
+	}
+	pb, err := s.buildBlock(blocks[0])
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &midnight.LatestBlockResponse{Block: pb}, nil
+}
+
+// GetStableBlock returns the requested block, or an empty response when the
+// block is not yet at or beyond the requested stability offset behind the
+// chain tip (or the tip as of AsOfTimestampUnixMillis, when set).
+func (s *service) GetStableBlock(
+	_ context.Context,
+	req *midnight.StableBlockRequest,
+) (*midnight.StableBlockResponse, error) {
+	blk, err := database.BlockByHash(s.db, req.GetBlockHash())
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return nil, status.Error(codes.NotFound, "block not found")
+		}
+		return nil, status.Errorf(codes.Internal, "get block by hash: %v", err)
+	}
+	tip, err := s.resolveTipBlock(req.GetAsOfTimestampUnixMillis())
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return &midnight.StableBlockResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "resolve chain tip: %v", err)
+	}
+	if tip.Number < blk.Number ||
+		tip.Number-blk.Number < uint64(req.GetStabilityOffset()) {
+		return &midnight.StableBlockResponse{}, nil
+	}
+	pb, err := s.buildBlock(blk)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &midnight.StableBlockResponse{Block: pb}, nil
+}
+
+// GetLatestStableBlock returns the newest block that is at least
+// StabilityOffset blocks behind the chain tip (or the tip as of
+// AsOfTimestampUnixMillis, when set), or an empty response when no block is
+// stable yet.
+func (s *service) GetLatestStableBlock(
+	_ context.Context,
+	req *midnight.LatestStableBlockRequest,
+) (*midnight.LatestStableBlockResponse, error) {
+	tip, err := s.resolveTipBlock(req.GetAsOfTimestampUnixMillis())
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return &midnight.LatestStableBlockResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "resolve chain tip: %v", err)
+	}
+	offset := uint64(req.GetStabilityOffset())
+	if tip.Number < offset {
+		return &midnight.LatestStableBlockResponse{}, nil
+	}
+	// BlockByIndex looks up by the blob store's internal sequential index,
+	// which is 1-based (database.BlockInitialIndex) while Cardano block
+	// numbers are 0-based; translate as api/blockfrost's block-by-height
+	// lookup does.
+	blk, err := s.db.BlockByIndex(
+		tip.Number-offset+database.BlockInitialIndex,
+		nil,
+	)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return &midnight.LatestStableBlockResponse{}, nil
+		}
+		return nil, status.Errorf(
+			codes.Internal,
+			"get block by number: %v",
+			err,
+		)
+	}
+	pb, err := s.buildBlock(blk)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &midnight.LatestStableBlockResponse{Block: pb}, nil
+}
+
+// resolveTipBlock returns the current chain tip, or, when asOfMillis is
+// non-zero, the latest block at or before that wall-clock time.
+func (s *service) resolveTipBlock(asOfMillis uint64) (models.Block, error) {
+	if asOfMillis == 0 {
+		blocks, err := database.BlocksRecent(s.db, 1)
+		if err != nil {
+			return models.Block{}, err
+		}
+		if len(blocks) == 0 {
+			return models.Block{}, models.ErrBlockNotFound
+		}
+		return blocks[0], nil
+	}
+	// #nosec G115 -- millisecond unix timestamps fit in int64 until year 292277026596
+	asOf := time.UnixMilli(int64(asOfMillis))
+	slot, err := s.slotTimer.TimeToSlot(asOf)
+	if err != nil {
+		return models.Block{}, fmt.Errorf(
+			"resolve slot for as-of timestamp: %w",
+			err,
+		)
+	}
+	return database.BlockBeforeSlot(s.db, slot+1)
+}
+
+// buildBlock converts a stored block into the shared MidnightState Block
+// message, resolving its epoch number and wall-clock timestamp.
+func (s *service) buildBlock(blk models.Block) (*midnight.Block, error) {
+	epoch, err := s.epochForSlot(blk.Slot)
+	if err != nil {
+		return nil, err
+	}
+	ts, err := s.slotTimer.SlotToTime(blk.Slot)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve timestamp for slot %d: %w",
+			blk.Slot,
+			err,
+		)
+	}
+	return &midnight.Block{
+		BlockNumber:        checkedUint32(blk.Number),
+		BlockHash:          blk.Hash,
+		EpochNumber:        checkedUint32(epoch.EpochId),
+		SlotNumber:         blk.Slot,
+		BlockTimestampUnix: checkedUint64(ts.Unix()),
+	}, nil
+}
+
+// epochForSlot resolves the epoch containing slot from the stored epoch
+// cache.
+func (s *service) epochForSlot(slot uint64) (*models.Epoch, error) {
+	epoch, err := s.db.GetEpochBySlot(slot, nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolve epoch for slot %d: %w", slot, err)
+	}
+	if epoch == nil {
+		return nil, fmt.Errorf("no epoch known for slot %d", slot)
+	}
+	return epoch, nil
+}
+
+// checkedUint32 truncates a uint64 to uint32. Block, epoch, and transaction
+// counts stay well under 2^32 for any real Cardano chain.
+func checkedUint32(v uint64) uint32 {
+	return uint32(v) // #nosec G115
+}
+
+// checkedUint64 converts a unix-seconds timestamp (always non-negative for
+// any post-genesis block) to uint64.
+func checkedUint64(v int64) uint64 {
+	return uint64(v) // #nosec G115
+}

--- a/midnight/server/service_test.go
+++ b/midnight/server/service_test.go
@@ -238,6 +238,14 @@ type candidateEntryCbor struct {
 	Datum       []byte `cbor:"3,keyasint"`
 }
 
+// candidateInputRefCbor mirrors midnight/indexer.CandidateInputRef's CBOR
+// shape so this test can seed registration rows without importing the
+// indexer package.
+type candidateInputRefCbor struct {
+	TxHash []byte `cbor:"1,keyasint"`
+	Index  uint32 `cbor:"2,keyasint"`
+}
+
 func TestGetEpochCandidates_CandidatesAndStakeDistribution(t *testing.T) {
 	db := newTestDatabase(t)
 	entries := []candidateEntryCbor{
@@ -251,6 +259,29 @@ func TestGetEpochCandidates_CandidatesAndStakeDistribution(t *testing.T) {
 		BlockNumber:    700,
 		CandidatesCbor: blob,
 	}))
+
+	// Registration provenance is looked up separately from the snapshot, by
+	// (tx_hash, output_index); seed one row per candidate with distinct
+	// block/slot/tx-index/inputs so the assertions below can't pass by
+	// accident (e.g. by reading the same field twice).
+	inputsA, err := cbor.Marshal([]candidateInputRefCbor{{TxHash: []byte{0x11}, Index: 2}})
+	require.NoError(t, err)
+	inputsB, err := cbor.Marshal([]candidateInputRefCbor{
+		{TxHash: []byte{0x22}, Index: 0},
+		{TxHash: []byte{0x33}, Index: 5},
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Metadata().InsertMidnightCommitteeCandidateRegistration(nil, &models.MidnightCommitteeCandidateRegistration{
+		TxHash: []byte{0xAA}, OutputIndex: 0,
+		BlockNumber: 701, SlotNumber: 7010, TxIndex: 3,
+		TxInputsCbor: inputsA,
+	}))
+	require.NoError(t, db.Metadata().InsertMidnightCommitteeCandidateRegistration(nil, &models.MidnightCommitteeCandidateRegistration{
+		TxHash: []byte{0xBB}, OutputIndex: 1,
+		BlockNumber: 702, SlotNumber: 7020, TxIndex: 4,
+		TxInputsCbor: inputsB,
+	}))
+
 	require.NoError(t, db.Metadata().SavePoolStakeSnapshots([]*models.PoolStakeSnapshot{
 		{Epoch: 7, SnapshotType: models.PoolStakeSnapshotTypeMark, PoolKeyHash: []byte{0x02}, TotalStake: 200, DelegatorCount: 1, CapturedSlot: 1},
 		{Epoch: 7, SnapshotType: models.PoolStakeSnapshotTypeMark, PoolKeyHash: []byte{0x01}, TotalStake: 100, DelegatorCount: 1, CapturedSlot: 1},
@@ -262,9 +293,27 @@ func TestGetEpochCandidates_CandidatesAndStakeDistribution(t *testing.T) {
 	resp, err := client.GetEpochCandidates(callCtx(t), &midnight.EpochCandidatesRequest{Epoch: 7})
 	require.NoError(t, err)
 	require.Len(t, resp.GetCandidates(), 2)
-	require.Equal(t, []byte("candidate-a"), resp.GetCandidates()[0].GetFullDatum())
-	require.Equal(t, uint64(700), resp.GetCandidates()[0].GetBlockNumber())
-	require.Equal(t, uint64(7), resp.GetCandidates()[0].GetEpochNumber())
+
+	c0 := resp.GetCandidates()[0]
+	require.Equal(t, []byte("candidate-a"), c0.GetFullDatum())
+	require.Equal(t, uint64(7), c0.GetEpochNumber())
+	require.Equal(t, uint64(701), c0.GetBlockNumber())
+	require.Equal(t, uint64(7010), c0.GetSlotNumber())
+	require.Equal(t, uint32(3), c0.GetTxIndex())
+	require.Len(t, c0.GetTxInputs(), 1)
+	require.Equal(t, []byte{0x11}, c0.GetTxInputs()[0].GetTxHash())
+	require.Equal(t, uint32(2), c0.GetTxInputs()[0].GetIndex())
+
+	c1 := resp.GetCandidates()[1]
+	require.Equal(t, []byte("candidate-b"), c1.GetFullDatum())
+	require.Equal(t, uint64(702), c1.GetBlockNumber())
+	require.Equal(t, uint64(7020), c1.GetSlotNumber())
+	require.Equal(t, uint32(4), c1.GetTxIndex())
+	require.Len(t, c1.GetTxInputs(), 2)
+	require.Equal(t, []byte{0x22}, c1.GetTxInputs()[0].GetTxHash())
+	require.Equal(t, uint32(0), c1.GetTxInputs()[0].GetIndex())
+	require.Equal(t, []byte{0x33}, c1.GetTxInputs()[1].GetTxHash())
+	require.Equal(t, uint32(5), c1.GetTxInputs()[1].GetIndex())
 
 	require.Len(t, resp.GetStakeDistribution(), 2)
 	// Sorted by pool key hash ascending: 0x01 before 0x02.
@@ -274,6 +323,41 @@ func TestGetEpochCandidates_CandidatesAndStakeDistribution(t *testing.T) {
 
 	_, err = client.GetEpochCandidates(callCtx(t), &midnight.EpochCandidatesRequest{Epoch: 999})
 	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestGetEpochCandidates_MissingRegistrationLeavesProvenanceZero documents
+// the graceful-degradation path: a candidate present in the snapshot but
+// with no matching registration row (which should not happen given the
+// indexer's write-before-track invariant, but could for a pre-migration
+// snapshot) still returns successfully with its datum/UTxO identity intact,
+// just without block/slot/tx-index/inputs.
+func TestGetEpochCandidates_MissingRegistrationLeavesProvenanceZero(t *testing.T) {
+	db := newTestDatabase(t)
+	entries := []candidateEntryCbor{
+		{TxHash: []byte{0xCC}, OutputIndex: 0, Datum: []byte("candidate-c")},
+	}
+	blob, err := cbor.Marshal(entries)
+	require.NoError(t, err)
+	require.NoError(t, db.UpsertMidnightEpochCandidates(&models.MidnightEpochCandidates{
+		Epoch:          9,
+		BlockNumber:    900,
+		CandidatesCbor: blob,
+	}))
+	// Deliberately no InsertMidnightCommitteeCandidateRegistration call.
+
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	resp, err := client.GetEpochCandidates(callCtx(t), &midnight.EpochCandidatesRequest{Epoch: 9})
+	require.NoError(t, err)
+	require.Len(t, resp.GetCandidates(), 1)
+	c := resp.GetCandidates()[0]
+	require.Equal(t, []byte("candidate-c"), c.GetFullDatum())
+	require.Equal(t, uint64(9), c.GetEpochNumber())
+	require.Equal(t, uint64(0), c.GetBlockNumber())
+	require.Equal(t, uint64(0), c.GetSlotNumber())
+	require.Equal(t, uint32(0), c.GetTxIndex())
+	require.Empty(t, c.GetTxInputs())
 }
 
 func TestGetLatestBlock(t *testing.T) {

--- a/midnight/server/service_test.go
+++ b/midnight/server/service_test.go
@@ -360,6 +360,65 @@ func TestGetEpochCandidates_MissingRegistrationLeavesProvenanceZero(t *testing.T
 	require.Empty(t, c.GetTxInputs())
 }
 
+// TestEmptyConfigImplementedRPCsReturnFailedPrecondition verifies that a
+// server started without a Database/SlotTimer (server.New(server.Config{}),
+// as the health/reflection/lifecycle tests do) answers every implemented RPC
+// with a clean FailedPrecondition status instead of nil-panicking on a
+// missing backend. An unimplemented RPC must still return Unimplemented.
+func TestEmptyConfigImplementedRPCsReturnFailedPrecondition(t *testing.T) {
+	addr := startTestServerWithConfig(t, server.Config{})
+	client := dialClient(t, addr)
+
+	implemented := map[string]func(context.Context) error{
+		"GetTechnicalCommitteeDatum": func(ctx context.Context) error {
+			_, err := client.GetTechnicalCommitteeDatum(ctx, &midnight.TechnicalCommitteeDatumRequest{})
+			return err
+		},
+		"GetCouncilDatum": func(ctx context.Context) error {
+			_, err := client.GetCouncilDatum(ctx, &midnight.CouncilDatumRequest{})
+			return err
+		},
+		"GetAriadneParameters": func(ctx context.Context) error {
+			_, err := client.GetAriadneParameters(ctx, &midnight.AriadneParametersRequest{})
+			return err
+		},
+		"GetEpochNonce": func(ctx context.Context) error {
+			_, err := client.GetEpochNonce(ctx, &midnight.EpochNonceRequest{})
+			return err
+		},
+		"GetEpochCandidates": func(ctx context.Context) error {
+			_, err := client.GetEpochCandidates(ctx, &midnight.EpochCandidatesRequest{})
+			return err
+		},
+		"GetBlockByHash": func(ctx context.Context) error {
+			_, err := client.GetBlockByHash(ctx, &midnight.BlockByHashRequest{})
+			return err
+		},
+		"GetLatestBlock": func(ctx context.Context) error {
+			_, err := client.GetLatestBlock(ctx, &midnight.LatestBlockRequest{})
+			return err
+		},
+		"GetStableBlock": func(ctx context.Context) error {
+			_, err := client.GetStableBlock(ctx, &midnight.StableBlockRequest{})
+			return err
+		},
+		"GetLatestStableBlock": func(ctx context.Context) error {
+			_, err := client.GetLatestStableBlock(ctx, &midnight.LatestStableBlockRequest{})
+			return err
+		},
+	}
+	for name, call := range implemented {
+		err := call(callCtx(t))
+		require.Error(t, err, "%s must error on empty config", name)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err),
+			"%s must return FailedPrecondition, not panic/other", name)
+	}
+
+	// Unimplemented RPCs are unaffected by the missing backend.
+	_, err := client.GetAssetCreates(callCtx(t), &midnight.AssetCreatesRequest{})
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
 func TestGetLatestBlock(t *testing.T) {
 	db := newTestDatabase(t)
 	insertPlaceholderBlock(t, db, 1, 1, 0x01)

--- a/midnight/server/service_test.go
+++ b/midnight/server/service_test.go
@@ -1,0 +1,402 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/midnight"
+	"github.com/blinklabs-io/dingo/midnight/server"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeSlotTimer is a linear slot/time mapping used so tests don't depend on
+// real Cardano genesis configuration. Slot 0 maps to fakeGenesis; each slot
+// is one second.
+type fakeSlotTimer struct{}
+
+const fakeGenesisUnix = int64(1_600_000_000)
+
+func (fakeSlotTimer) SlotToTime(slot uint64) (time.Time, error) {
+	return time.Unix(fakeGenesisUnix, 0).Add(time.Duration(slot) * time.Second), nil
+}
+
+func (fakeSlotTimer) TimeToSlot(t time.Time) (uint64, error) {
+	delta := max(t.Unix()-fakeGenesisUnix, 0)
+	return uint64(delta), nil
+}
+
+// newTestDatabase returns an in-memory Database with a wide-open epoch row
+// (epoch 0 covers every slot used by these tests) plus fakeSlotTimer as the
+// server's SlotTimer.
+func newTestDatabase(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.SetEpoch(
+		0, 0,
+		[]byte("epoch-0-nonce"), nil, nil, nil,
+		0, 1000, math.MaxInt32,
+		nil,
+	))
+	return db
+}
+
+// insertPlaceholderBlock inserts a block whose CBOR is never decoded by the
+// handler under test (GetLatestBlock/GetStableBlock/GetLatestStableBlock
+// only read Number/Hash/Slot). ID is set explicitly to Number +
+// database.BlockInitialIndex, the same invariant a real contiguously-synced
+// chain maintains, so BlockByIndex-based lookups (GetLatestStableBlock) work
+// without inserting every intermediate block number.
+func insertPlaceholderBlock(
+	t *testing.T,
+	db *database.Database,
+	number, slot uint64,
+	hashByte byte,
+) models.Block {
+	t.Helper()
+	hash := make([]byte, 32)
+	hash[0] = hashByte
+	blk := models.Block{
+		ID:     number + database.BlockInitialIndex,
+		Number: number,
+		Slot:   slot,
+		Hash:   hash,
+		Cbor:   []byte{0x01},
+		Type:   1,
+	}
+	require.NoError(t, db.BlockCreate(blk, nil))
+	return blk
+}
+
+// loadRealTestBlock loads one decodable block from the shared conformance
+// fixtures, for the one test (GetBlockByHash) that needs a real TxCount.
+func loadRealTestBlock(t *testing.T) models.Block {
+	t.Helper()
+	imm, err := immutable.New("../../database/immutable/testdata")
+	require.NoError(t, err)
+	it, err := imm.BlocksFromPoint(ocommon.Point{})
+	require.NoError(t, err)
+	defer it.Close()
+	b, err := it.Next()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	lb, err := ledger.NewBlockFromCbor(b.Type, b.Cbor)
+	require.NoError(t, err)
+	return models.Block{
+		Hash:     lb.Hash().Bytes(),
+		PrevHash: lb.PrevHash().Bytes(),
+		Cbor:     b.Cbor,
+		Slot:     lb.SlotNumber(),
+		Number:   lb.BlockNumber(),
+		Type:     uint(lb.Type()),
+	}
+}
+
+func dialClient(t *testing.T, addr string) midnight.MidnightStateClient {
+	t.Helper()
+	return midnight.NewMidnightStateClient(dial(t, addr))
+}
+
+func callCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestGetTechnicalCommitteeDatum_AtOrBefore seeds three historical rows and
+// verifies the "latest at or before the requested block" query picks the
+// correct row, including the not-found case before the first row.
+func TestGetTechnicalCommitteeDatum_AtOrBefore(t *testing.T) {
+	db := newTestDatabase(t)
+	for i, blockNumber := range []uint64{10, 20, 30} {
+		require.NoError(t, db.InsertMidnightGovernanceDatum(&models.MidnightGovernanceDatum{
+			DatumType:   models.MidnightGovernanceDatumTypeTechnicalCommittee,
+			TxHash:      []byte{byte(i), 1, 2, 3},
+			OutputIndex: 0,
+			Datum:       []byte{byte('a' + i)},
+			BlockNumber: blockNumber,
+		}))
+	}
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	_, err := client.GetTechnicalCommitteeDatum(callCtx(t), &midnight.TechnicalCommitteeDatumRequest{BlockNumber: 5})
+	require.Equal(t, codes.NotFound, status.Code(err), "before the first row must be NotFound")
+
+	resp, err := client.GetTechnicalCommitteeDatum(callCtx(t), &midnight.TechnicalCommitteeDatumRequest{BlockNumber: 25})
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), resp.GetSourceBlockNumber())
+	require.Equal(t, []byte{'b'}, resp.GetDatum())
+
+	resp, err = client.GetTechnicalCommitteeDatum(callCtx(t), &midnight.TechnicalCommitteeDatumRequest{BlockNumber: 1000})
+	require.NoError(t, err)
+	require.Equal(t, uint64(30), resp.GetSourceBlockNumber())
+	require.Equal(t, []byte{'c'}, resp.GetDatum())
+}
+
+// TestGetCouncilDatum_DistinctFromTechnicalCommittee verifies the two
+// governance datum RPCs are scoped by datum_type and don't cross-contaminate.
+func TestGetCouncilDatum_DistinctFromTechnicalCommittee(t *testing.T) {
+	db := newTestDatabase(t)
+	require.NoError(t, db.InsertMidnightGovernanceDatum(&models.MidnightGovernanceDatum{
+		DatumType:   models.MidnightGovernanceDatumTypeTechnicalCommittee,
+		TxHash:      []byte{1, 2, 3, 4},
+		OutputIndex: 0,
+		Datum:       []byte("tc"),
+		BlockNumber: 10,
+	}))
+	require.NoError(t, db.InsertMidnightGovernanceDatum(&models.MidnightGovernanceDatum{
+		DatumType:   models.MidnightGovernanceDatumTypeCouncil,
+		TxHash:      []byte{5, 6, 7, 8},
+		OutputIndex: 0,
+		Datum:       []byte("council"),
+		BlockNumber: 10,
+	}))
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	resp, err := client.GetCouncilDatum(callCtx(t), &midnight.CouncilDatumRequest{BlockNumber: 100})
+	require.NoError(t, err)
+	require.Equal(t, []byte("council"), resp.GetDatum())
+}
+
+// TestGetAriadneParameters_AtOrBefore mirrors the governance-datum at-or-
+// before semantics but against midnight_ariadne_params, keyed by epoch.
+func TestGetAriadneParameters_AtOrBefore(t *testing.T) {
+	db := newTestDatabase(t)
+	for i, epoch := range []uint64{1, 2, 3} {
+		require.NoError(t, db.UpsertMidnightAriadneParams(&models.MidnightAriadneParams{
+			Epoch: epoch,
+			Datum: []byte{byte('a' + i)},
+		}))
+	}
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	_, err := client.GetAriadneParameters(callCtx(t), &midnight.AriadneParametersRequest{Epoch: 0})
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	resp, err := client.GetAriadneParameters(callCtx(t), &midnight.AriadneParametersRequest{Epoch: 2})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), resp.GetSourceEpoch())
+	require.Equal(t, []byte{'b'}, resp.GetDatum())
+
+	resp, err = client.GetAriadneParameters(callCtx(t), &midnight.AriadneParametersRequest{Epoch: 50})
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), resp.GetSourceEpoch())
+}
+
+func TestGetEpochNonce(t *testing.T) {
+	db := newTestDatabase(t)
+	require.NoError(t, db.SetEpoch(100, 1, []byte("epoch-1-nonce"), nil, nil, nil, 0, 1000, 100, nil))
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	resp, err := client.GetEpochNonce(callCtx(t), &midnight.EpochNonceRequest{Epoch: 1})
+	require.NoError(t, err)
+	require.Equal(t, []byte("epoch-1-nonce"), resp.GetNonce())
+
+	_, err = client.GetEpochNonce(callCtx(t), &midnight.EpochNonceRequest{Epoch: 999})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// candidateEntryCbor mirrors midnight/indexer.CandidateEntry's CBOR shape so
+// this test can seed a snapshot without importing the indexer package.
+type candidateEntryCbor struct {
+	TxHash      []byte `cbor:"1,keyasint"`
+	OutputIndex uint32 `cbor:"2,keyasint"`
+	Datum       []byte `cbor:"3,keyasint"`
+}
+
+func TestGetEpochCandidates_CandidatesAndStakeDistribution(t *testing.T) {
+	db := newTestDatabase(t)
+	entries := []candidateEntryCbor{
+		{TxHash: []byte{0xAA}, OutputIndex: 0, Datum: []byte("candidate-a")},
+		{TxHash: []byte{0xBB}, OutputIndex: 1, Datum: []byte("candidate-b")},
+	}
+	blob, err := cbor.Marshal(entries)
+	require.NoError(t, err)
+	require.NoError(t, db.UpsertMidnightEpochCandidates(&models.MidnightEpochCandidates{
+		Epoch:          7,
+		BlockNumber:    700,
+		CandidatesCbor: blob,
+	}))
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshots([]*models.PoolStakeSnapshot{
+		{Epoch: 7, SnapshotType: models.PoolStakeSnapshotTypeMark, PoolKeyHash: []byte{0x02}, TotalStake: 200, DelegatorCount: 1, CapturedSlot: 1},
+		{Epoch: 7, SnapshotType: models.PoolStakeSnapshotTypeMark, PoolKeyHash: []byte{0x01}, TotalStake: 100, DelegatorCount: 1, CapturedSlot: 1},
+	}, nil))
+
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	resp, err := client.GetEpochCandidates(callCtx(t), &midnight.EpochCandidatesRequest{Epoch: 7})
+	require.NoError(t, err)
+	require.Len(t, resp.GetCandidates(), 2)
+	require.Equal(t, []byte("candidate-a"), resp.GetCandidates()[0].GetFullDatum())
+	require.Equal(t, uint64(700), resp.GetCandidates()[0].GetBlockNumber())
+	require.Equal(t, uint64(7), resp.GetCandidates()[0].GetEpochNumber())
+
+	require.Len(t, resp.GetStakeDistribution(), 2)
+	// Sorted by pool key hash ascending: 0x01 before 0x02.
+	require.Equal(t, []byte{0x01}, resp.GetStakeDistribution()[0].GetPoolHash())
+	require.Equal(t, uint64(100), resp.GetStakeDistribution()[0].GetStake())
+	require.Equal(t, []byte{0x02}, resp.GetStakeDistribution()[1].GetPoolHash())
+
+	_, err = client.GetEpochCandidates(callCtx(t), &midnight.EpochCandidatesRequest{Epoch: 999})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestGetLatestBlock(t *testing.T) {
+	db := newTestDatabase(t)
+	insertPlaceholderBlock(t, db, 1, 1, 0x01)
+	tip := insertPlaceholderBlock(t, db, 2, 2, 0x02)
+
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	resp, err := client.GetLatestBlock(callCtx(t), &midnight.LatestBlockRequest{})
+	require.NoError(t, err)
+	require.Equal(t, uint32(tip.Number), resp.GetBlock().GetBlockNumber())
+	require.Equal(t, tip.Hash, resp.GetBlock().GetBlockHash())
+	require.Equal(t, tip.Slot, resp.GetBlock().GetSlotNumber())
+}
+
+func TestGetBlockByHash(t *testing.T) {
+	db := newTestDatabase(t)
+	blk := loadRealTestBlock(t)
+	require.NoError(t, db.BlockCreate(blk, nil))
+	decoded, err := blk.Decode()
+	require.NoError(t, err)
+	wantTxCount := len(decoded.Transactions())
+
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	resp, err := client.GetBlockByHash(callCtx(t), &midnight.BlockByHashRequest{BlockHash: blk.Hash})
+	require.NoError(t, err)
+	require.Equal(t, uint32(blk.Number), resp.GetBlockNumber())
+	require.Equal(t, blk.Slot, resp.GetSlotNumber())
+	require.Equal(t, uint32(wantTxCount), resp.GetTxCount())
+	require.Equal(t, fakeGenesisUnix+int64(blk.Slot), resp.GetBlockTimestampUnix())
+	require.Equal(t, uint32(0), resp.GetEpochNumber())
+
+	_, err = client.GetBlockByHash(callCtx(t), &midnight.BlockByHashRequest{BlockHash: []byte("unknown-hash-000000000000000000")})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// praosStabilityOffset returns ceil(3k/f), the Ouroboros Praos randomness/
+// settlement stability window, for a given security parameter k and active
+// slot coefficient f.
+func praosStabilityOffset(k uint64, f float64) uint64 {
+	return uint64(math.Ceil(3 * float64(k) / f))
+}
+
+// TestStability_MatchesConfiguredKAndF verifies GetStableBlock's boundary
+// behaviour (tip - block >= offset) against offsets derived from the 3k/f
+// Praos stability-window formula for both a small DevNet-style profile and
+// preview testnet's real k/f.
+func TestStability_MatchesConfiguredKAndF(t *testing.T) {
+	cases := []struct {
+		name string
+		k    uint64
+		f    float64
+	}{
+		{name: "devnet", k: 10, f: 0.5},
+		{name: "preview", k: 432, f: 0.05},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			offset := praosStabilityOffset(tc.k, tc.f)
+			db := newTestDatabase(t)
+			target := insertPlaceholderBlock(t, db, 1000, 1000, 0xAA)
+			tip := insertPlaceholderBlock(t, db, 1000+offset, 1000+offset, 0xBB)
+
+			addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+			client := dialClient(t, addr)
+
+			// Exactly at the offset: stable.
+			resp, err := client.GetStableBlock(callCtx(t), &midnight.StableBlockRequest{
+				BlockHash:       target.Hash,
+				StabilityOffset: uint32(offset), //nolint:gosec // test-only, small values
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp.GetBlock(), "block exactly %d behind tip must be stable", offset)
+			require.Equal(t, uint32(target.Number), resp.GetBlock().GetBlockNumber())
+
+			// One more than the offset: not yet stable.
+			resp, err = client.GetStableBlock(callCtx(t), &midnight.StableBlockRequest{
+				BlockHash:       target.Hash,
+				StabilityOffset: uint32(offset + 1), //nolint:gosec // test-only, small values
+			})
+			require.NoError(t, err)
+			require.Nil(t, resp.GetBlock(), "block one short of the offset must not be stable")
+
+			// GetLatestStableBlock at the same offset must resolve back to target.
+			latestResp, err := client.GetLatestStableBlock(callCtx(t), &midnight.LatestStableBlockRequest{
+				StabilityOffset: uint32(offset), //nolint:gosec // test-only, small values
+			})
+			require.NoError(t, err)
+			require.NotNil(t, latestResp.GetBlock())
+			require.Equal(t, uint32(target.Number), latestResp.GetBlock().GetBlockNumber())
+
+			// No block is stable yet when the offset exceeds the whole chain height.
+			latestResp, err = client.GetLatestStableBlock(callCtx(t), &midnight.LatestStableBlockRequest{
+				StabilityOffset: uint32(tip.Number + 1), //nolint:gosec // test-only, small values
+			})
+			require.NoError(t, err)
+			require.Nil(t, latestResp.GetBlock())
+		})
+	}
+}
+
+// TestGetStableBlock_AsOfTimestamp verifies that AsOfTimestampUnixMillis, when
+// set, resolves the "chain tip" to the latest block at or before that
+// wall-clock time rather than the live tip.
+func TestGetStableBlock_AsOfTimestamp(t *testing.T) {
+	db := newTestDatabase(t)
+	older := insertPlaceholderBlock(t, db, 10, 10, 0x01)
+	insertPlaceholderBlock(t, db, 20, 20, 0x02) // newer than the as-of time
+
+	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	client := dialClient(t, addr)
+
+	asOfMillis := uint64(time.Unix(fakeGenesisUnix+15, 0).UnixMilli())
+	resp, err := client.GetStableBlock(callCtx(t), &midnight.StableBlockRequest{
+		BlockHash:               older.Hash,
+		StabilityOffset:         0,
+		AsOfTimestampUnixMillis: asOfMillis,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetBlock(), "older block must be stable relative to the as-of tip")
+	require.Equal(t, uint32(older.Number), resp.GetBlock().GetBlockNumber())
+}

--- a/midnight/server/service_test.go
+++ b/midnight/server/service_test.go
@@ -147,7 +147,7 @@ func TestGetTechnicalCommitteeDatum_AtOrBefore(t *testing.T) {
 			BlockNumber: blockNumber,
 		}))
 	}
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	_, err := client.GetTechnicalCommitteeDatum(callCtx(t), &midnight.TechnicalCommitteeDatumRequest{BlockNumber: 5})
@@ -182,7 +182,7 @@ func TestGetCouncilDatum_DistinctFromTechnicalCommittee(t *testing.T) {
 		Datum:       []byte("council"),
 		BlockNumber: 10,
 	}))
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	resp, err := client.GetCouncilDatum(callCtx(t), &midnight.CouncilDatumRequest{BlockNumber: 100})
@@ -200,7 +200,7 @@ func TestGetAriadneParameters_AtOrBefore(t *testing.T) {
 			Datum: []byte{byte('a' + i)},
 		}))
 	}
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	_, err := client.GetAriadneParameters(callCtx(t), &midnight.AriadneParametersRequest{Epoch: 0})
@@ -219,7 +219,7 @@ func TestGetAriadneParameters_AtOrBefore(t *testing.T) {
 func TestGetEpochNonce(t *testing.T) {
 	db := newTestDatabase(t)
 	require.NoError(t, db.SetEpoch(100, 1, []byte("epoch-1-nonce"), nil, nil, nil, 0, 1000, 100, nil))
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	resp, err := client.GetEpochNonce(callCtx(t), &midnight.EpochNonceRequest{Epoch: 1})
@@ -256,7 +256,7 @@ func TestGetEpochCandidates_CandidatesAndStakeDistribution(t *testing.T) {
 		{Epoch: 7, SnapshotType: models.PoolStakeSnapshotTypeMark, PoolKeyHash: []byte{0x01}, TotalStake: 100, DelegatorCount: 1, CapturedSlot: 1},
 	}, nil))
 
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	resp, err := client.GetEpochCandidates(callCtx(t), &midnight.EpochCandidatesRequest{Epoch: 7})
@@ -281,7 +281,7 @@ func TestGetLatestBlock(t *testing.T) {
 	insertPlaceholderBlock(t, db, 1, 1, 0x01)
 	tip := insertPlaceholderBlock(t, db, 2, 2, 0x02)
 
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	resp, err := client.GetLatestBlock(callCtx(t), &midnight.LatestBlockRequest{})
@@ -299,7 +299,7 @@ func TestGetBlockByHash(t *testing.T) {
 	require.NoError(t, err)
 	wantTxCount := len(decoded.Transactions())
 
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	resp, err := client.GetBlockByHash(callCtx(t), &midnight.BlockByHashRequest{BlockHash: blk.Hash})
@@ -341,7 +341,7 @@ func TestStability_MatchesConfiguredKAndF(t *testing.T) {
 			target := insertPlaceholderBlock(t, db, 1000, 1000, 0xAA)
 			tip := insertPlaceholderBlock(t, db, 1000+offset, 1000+offset, 0xBB)
 
-			addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+			addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 			client := dialClient(t, addr)
 
 			// Exactly at the offset: stable.
@@ -387,7 +387,7 @@ func TestGetStableBlock_AsOfTimestamp(t *testing.T) {
 	older := insertPlaceholderBlock(t, db, 10, 10, 0x01)
 	insertPlaceholderBlock(t, db, 20, 20, 0x02) // newer than the as-of time
 
-	addr := startTestServerWithConfig(t, server.Config{Database: db, SlotTimer: fakeSlotTimer{}})
+	addr := startTestServerWithConfig(t, server.Config{Database: server.NewDatabase(db), SlotTimer: fakeSlotTimer{}})
 	client := dialClient(t, addr)
 
 	asOfMillis := uint64(time.Unix(fakeGenesisUnix+15, 0).UnixMilli())

--- a/node.go
+++ b/node.go
@@ -1128,6 +1128,8 @@ func (n *Node) Run(ctx context.Context) error {
 				TLSCertFilePath: n.config.tlsCertFilePath,
 				TLSKeyFilePath:  n.config.tlsKeyFilePath,
 				ShutdownTimeout: n.config.shutdownTimeout,
+				Database:        n.db,
+				SlotTimer:       n.ledgerState,
 			},
 		)
 		if err != nil {

--- a/node.go
+++ b/node.go
@@ -1128,7 +1128,7 @@ func (n *Node) Run(ctx context.Context) error {
 				TLSCertFilePath: n.config.tlsCertFilePath,
 				TLSKeyFilePath:  n.config.tlsKeyFilePath,
 				ShutdownTimeout: n.config.shutdownTimeout,
-				Database:        n.db,
+				Database:        midnightserver.NewDatabase(n.db),
 				SlotTimer:       n.ledgerState,
 			},
 		)


### PR DESCRIPTION
Closes #2119

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements governance, parameters, block, epoch, and stability RPCs for the `MidnightState` gRPC service, wired to the node `Database` via a narrow adapter and `SlotTimer` for epoch/time resolution. Delivers the API for #2119; asset create/spend, registrations, deregistrations, and UTXO-event RPCs remain unimplemented.

- New Features
  - Governance/parameters: `GetTechnicalCommitteeDatum`, `GetCouncilDatum` (at-or-before block), `GetAriadneParameters` (at-or-before epoch via `GetMidnightAriadneParamsAtOrBeforeEpoch`).
  - Blocks/epoch: `GetBlockByHash`, `GetBlockByNumber`, `GetLatestBlock` (timestamp via `SlotTimer.SlotToTime`; epoch via `GetEpochBySlot`), `GetEpochNonce`, `GetEpochCandidates` (decode via `midnight/indexer.DecodeEpochCandidatesCbor`; enrich from `midnight_committee_candidate_registrations` in one batched lookup; decode inputs via `midnight/indexer.DecodeCandidateInputsCbor`; join `"mark"` `pool_stake_snapshot`; deterministic ordering; zero fields when provenance is missing).
  - Stability: `GetStableBlock`, `GetLatestStableBlock` (offset behind tip; support `as_of_timestamp_unix_millis` via `SlotTimer.TimeToSlot`; 0→1 block-number translation in adapter).
  - Server/wiring: real handlers in `midnight/server/service.go`; add `midnight/server/adapter.go` (`NewDatabase` bridging package-level DB functions); `node.go` passes `midnightserver.NewDatabase(n.db)` and `SlotTimer`.
  - Database/indexer: new table/model `midnight_committee_candidate_registrations`; metadata APIs for Ariadne-at-or-before, epoch candidates by epoch, and candidate provenance lookups; `GetPoolStakeSnapshotsByEpoch` with snapshot-type validation and `set`/`go` support; indexer persists candidate-registration provenance and rolls it back on decode; exports CBOR encode/decode helpers.

- Bug Fixes
  - Guard against block-number overflow in adapter `BlockByNumber`.
  - Persist all candidate-registration fields and clean up on rollback.
  - Reject invalid pool snapshot types early when querying.

<sup>Written for commit 7b8015fc734e7efac9f9392e196680e3ac1986cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader Midnight gRPC support for governance, parameters, epoch, block, and stability queries.
  * Introduced support for additional pool stake snapshot types and lookup by epoch.
  * Improved epoch-candidate and Ariadne parameter retrieval for Midnight metadata queries.

* **Bug Fixes**
  * Fixed handling of missing records so “not found” results now return cleanly.
  * Added validation to reject invalid snapshot type values.

* **Documentation**
  * Expanded architecture and database docs to better describe Midnight server behavior and supported queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->