### PR TITLE
fix(database): Reduce MySQL/Postgres SetTransaction UTxO lookups

### DIFF
--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -508,6 +508,32 @@ func TestMysqlSetTransactionBatchesMultiInputUtxoLookups(t *testing.T) {
 
 	// Build a transaction containing multiple items in every input class.
 	txHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x91}, 32))
+	defer func() {
+		cleanupDB := store.DB()
+		for i := 0; i < 7; i++ {
+			seedTxID := makeTxID(byte(0x60 + i))
+			if result := cleanupDB.Model(&models.Utxo{}).
+				Where("tx_id = ?", seedTxID).
+				Updates(map[string]any{
+					"collateral_by_tx_id": nil,
+					"referenced_by_tx_id": nil,
+					"spent_at_tx_id":      nil,
+					"deleted_slot":        0,
+				}); result.Error != nil {
+				t.Errorf("cleanup utxo refs: %v", result.Error)
+			}
+			if result := cleanupDB.
+				Where("tx_id = ?", seedTxID).
+				Delete(&models.Utxo{}); result.Error != nil {
+				t.Errorf("cleanup utxo: %v", result.Error)
+			}
+		}
+		if result := cleanupDB.
+			Where("hash = ?", txHash.Bytes()).
+			Delete(&models.Transaction{}); result.Error != nil {
+			t.Errorf("cleanup transaction: %v", result.Error)
+		}
+	}()
 	tx := &mockTransaction{
 		hash:    txHash,
 		isValid: true,

--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -18,10 +18,12 @@ package mysql
 
 import (
 	"bytes"
+	"context"
 	"math/big"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,10 +32,12 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // TestTable is a simple table for testing concurrent transactions
@@ -45,6 +49,10 @@ type mockTransaction struct {
 	hash         lcommon.Blake2b256
 	certificates []lcommon.Certificate
 	isValid      bool
+	inputs       []lcommon.TransactionInput
+	collateral   []lcommon.TransactionInput
+	refInputs    []lcommon.TransactionInput
+	consumed     []lcommon.TransactionInput
 	withdrawals  map[*lcommon.Address]*big.Int
 }
 
@@ -97,11 +105,11 @@ func (m *mockTransaction) Outputs() []lcommon.TransactionOutput {
 }
 
 func (m *mockTransaction) Inputs() []lcommon.TransactionInput {
-	return nil
+	return m.inputs
 }
 
 func (m *mockTransaction) Collateral() []lcommon.TransactionInput {
-	return nil
+	return m.collateral
 }
 
 func (m *mockTransaction) Certificates() []lcommon.Certificate {
@@ -125,7 +133,7 @@ func (m *mockTransaction) Cbor() []byte {
 }
 
 func (m *mockTransaction) Consumed() []lcommon.TransactionInput {
-	return nil
+	return m.consumed
 }
 
 func (m *mockTransaction) Witnesses() lcommon.TransactionWitnessSet {
@@ -137,7 +145,7 @@ func (m *mockTransaction) ValidityIntervalStart() uint64 {
 }
 
 func (m *mockTransaction) ReferenceInputs() []lcommon.TransactionInput {
-	return nil
+	return m.refInputs
 }
 
 func (m *mockTransaction) TotalCollateral() *big.Int {
@@ -178,6 +186,49 @@ func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
 
 func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
 	return lcommon.Blake2b256{}
+}
+
+type setTransactionSQLRecorder struct {
+	mu         sync.Mutex
+	statements []string
+}
+
+func (r *setTransactionSQLRecorder) LogMode(
+	gormlogger.LogLevel,
+) gormlogger.Interface {
+	return r
+}
+
+func (*setTransactionSQLRecorder) Info(context.Context, string, ...any) {}
+
+func (*setTransactionSQLRecorder) Warn(context.Context, string, ...any) {}
+
+func (*setTransactionSQLRecorder) Error(context.Context, string, ...any) {}
+
+func (r *setTransactionSQLRecorder) Trace(
+	_ context.Context,
+	_ time.Time,
+	fc func() (string, int64),
+	_ error,
+) {
+	sql, _ := fc()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statements = append(r.statements, sql)
+}
+
+func (r *setTransactionSQLRecorder) countUtxoSelects() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, stmt := range r.statements {
+		normalized := strings.ToUpper(stmt)
+		if strings.Contains(normalized, "SELECT") &&
+			strings.Contains(normalized, "FROM `UTXO`") {
+			count++
+		}
+	}
+	return count
 }
 
 // testHash32 creates a 32-byte test hash from a seed string.
@@ -418,6 +469,110 @@ func TestMysqlMultipleTransaction(t *testing.T) {
 	}
 	if err := <-errCh; err != nil {
 		t.Fatalf("goroutine error: %s", err)
+	}
+}
+
+// TestMysqlSetTransactionBatchesMultiInputUtxoLookups verifies multi-input,
+// collateral, and reference-input processing uses bounded UTxO SELECTs.
+func TestMysqlSetTransactionBatchesMultiInputUtxoLookups(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	store.storageMode = types.StorageModeAPI
+
+	makeTxID := func(seed byte) []byte {
+		return bytes.Repeat([]byte{seed}, 32)
+	}
+	makeInput := func(seed byte, idx uint32) lcommon.TransactionInput {
+		return dbtestutil.NewMockInput(makeTxID(seed), idx)
+	}
+
+	// Seed UTxOs for regular inputs, collateral, and reference inputs.
+	utxos := make([]models.Utxo, 0, 7)
+	for i := 0; i < 7; i++ {
+		utxos = append(utxos, models.Utxo{
+			TxId:       makeTxID(byte(0x60 + i)),
+			OutputIdx:  uint32(i),
+			AddedSlot:  100,
+			PaymentKey: bytes.Repeat([]byte{byte(0x10 + i)}, 28),
+			StakingKey: bytes.Repeat([]byte{byte(0x20 + i)}, 28),
+			Amount:     types.Uint64(1_000_000 + i),
+		})
+	}
+	if result := store.DB().Create(&utxos); result.Error != nil {
+		t.Fatalf("create utxos: %v", result.Error)
+	}
+
+	// Record SQL executed by SetTransaction so UTxO SELECTs can be counted.
+	recorder := &setTransactionSQLRecorder{}
+	store.db = store.DB().Session(&gorm.Session{Logger: recorder})
+
+	// Build a transaction containing multiple items in every input class.
+	txHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x91}, 32))
+	tx := &mockTransaction{
+		hash:    txHash,
+		isValid: true,
+		inputs: []lcommon.TransactionInput{
+			makeInput(0x60, 0),
+			makeInput(0x61, 1),
+			makeInput(0x62, 2),
+		},
+		collateral: []lcommon.TransactionInput{
+			makeInput(0x63, 3),
+			makeInput(0x64, 4),
+		},
+		refInputs: []lcommon.TransactionInput{
+			makeInput(0x65, 5),
+			makeInput(0x66, 6),
+		},
+		consumed: []lcommon.TransactionInput{
+			makeInput(0x60, 0),
+			makeInput(0x61, 1),
+			makeInput(0x62, 2),
+		},
+	}
+	point := ocommon.NewPoint(200, bytes.Repeat([]byte{0x92}, 32))
+
+	// Process the transaction through the regular SetTransaction path.
+	if err := store.SetTransaction(tx, point, 0, nil, nil); err != nil {
+		t.Fatalf("set transaction: %v", err)
+	}
+
+	// Verify exactly one batch SELECT was used per input class.
+	if got := recorder.countUtxoSelects(); got != 3 {
+		t.Fatalf("expected 3 batched UTxO SELECTs, got %d", got)
+	}
+
+	// Verify all regular inputs were marked as spent.
+	var spent int64
+	if result := store.DB().Model(&models.Utxo{}).
+		Where("spent_at_tx_id = ?", txHash.Bytes()).
+		Count(&spent); result.Error != nil {
+		t.Fatalf("count spent utxos: %v", result.Error)
+	}
+	if spent != 3 {
+		t.Fatalf("expected 3 spent UTxOs, got %d", spent)
+	}
+
+	// Verify all collateral inputs were linked to the transaction.
+	var collateral int64
+	if result := store.DB().Model(&models.Utxo{}).
+		Where("collateral_by_tx_id = ?", txHash.Bytes()).
+		Count(&collateral); result.Error != nil {
+		t.Fatalf("count collateral utxos: %v", result.Error)
+	}
+	if collateral != 2 {
+		t.Fatalf("expected 2 collateral UTxOs, got %d", collateral)
+	}
+
+	// Verify all reference inputs were linked to the transaction.
+	var referenced int64
+	if result := store.DB().Model(&models.Utxo{}).
+		Where("referenced_by_tx_id = ?", txHash.Bytes()).
+		Count(&referenced); result.Error != nil {
+		t.Fatalf("count reference input utxos: %v", result.Error)
+	}
+	if referenced != 2 {
+		t.Fatalf("expected 2 reference input UTxOs, got %d", referenced)
 	}
 }
 

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -17,6 +17,7 @@
 package mysql
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1031,32 +1032,35 @@ func (d *MetadataStoreMysql) SetTransaction(
 		}
 	}
 	// Add Inputs to Transaction
-	for _, input := range tx.Inputs() {
-		inTxId := input.Id().Bytes()
-		inIdx := input.Index()
-		utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+	if len(tx.Inputs()) > 0 {
+		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
+		for _, input := range tx.Inputs() {
+			inputRefs = append(inputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
 		if err != nil {
-			return fmt.Errorf(
-				"failed to fetch input %x#%d: %w",
-				inTxId,
-				inIdx,
-				err,
-			)
+			return fmt.Errorf("failed to batch fetch input UTXOs: %w", err)
 		}
-		if utxo == nil {
-			d.logger.Warn(
-				"Skipping missing input UTxO",
-				"hash",
-				input.Id().String(),
-				"index",
-				inIdx,
-			)
-			continue
+		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			utxo := inputUtxos[key]
+			if utxo == nil {
+				d.logger.Warn(
+					"Skipping missing input UTxO",
+					"hash",
+					input.Id().String(),
+					"index",
+					inIdx,
+				)
+				continue
+			}
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
 		}
-		tmpTx.Inputs = append(
-			tmpTx.Inputs,
-			*utxo,
-		)
 	}
 	// Add Collateral to Transaction
 	if len(tx.Collateral()) > 0 {
@@ -1065,18 +1069,22 @@ func (d *MetadataStoreMysql) SetTransaction(
 		var caseArgs []any
 		var whereArgs []any
 
+		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
+		for _, input := range tx.Collateral() {
+			collateralRefs = append(collateralRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
+		if err != nil {
+			return fmt.Errorf("failed to batch fetch collateral UTXOs: %w", err)
+		}
 		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
-			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-			if err != nil {
-				return fmt.Errorf(
-					"failed to fetch input %x#%d: %w",
-					inTxId,
-					inIdx,
-					err,
-				)
-			}
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			utxo := collateralUtxos[key]
 			if utxo == nil {
 				d.logger.Warn(
 					"Skipping missing collateral UTxO",
@@ -1127,18 +1135,25 @@ func (d *MetadataStoreMysql) SetTransaction(
 		var caseArgs []any
 		var whereArgs []any
 
+		refInputRefs := make([]UtxoRef, 0, len(tx.ReferenceInputs()))
+		for _, input := range tx.ReferenceInputs() {
+			refInputRefs = append(refInputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to batch fetch reference input UTXOs: %w",
+				err,
+			)
+		}
 		for _, input := range tx.ReferenceInputs() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
-			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-			if err != nil {
-				return fmt.Errorf(
-					"failed to fetch input %x#%d: %w",
-					inTxId,
-					inIdx,
-					err,
-				)
-			}
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			utxo := refInputUtxos[key]
 			if utxo == nil {
 				d.logger.Warn(
 					"Skipping missing reference input UTxO",
@@ -1187,51 +1202,116 @@ func (d *MetadataStoreMysql) SetTransaction(
 	}
 
 	// Consume UTxOs
-	for _, input := range tx.Consumed() {
-		inTxId := input.Id().Bytes()
-		inIdx := input.Index()
-		utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to fetch input %x#%d: %w",
-				inTxId,
-				inIdx,
-				err,
-			)
+	if len(tx.Consumed()) > 0 {
+		type consumedUtxoRef struct {
+			txID []byte
+			idx  uint32
+			hash string
 		}
-		if utxo == nil {
-			d.logger.Warn(
-				"input UTxO not found",
-				"hash",
-				input.Id().String(),
-				"index",
-				inIdx,
-			)
-			continue
-		}
-		// Update existing UTxOs
-		result = db.Model(&models.Utxo{}).
-			Where("tx_id = ? AND output_idx = ?", inTxId, inIdx).
-			Where("spent_at_tx_id IS NULL OR spent_at_tx_id = ?", txHash).
-			Updates(map[string]any{
-				"deleted_slot":   point.Slot,
-				"spent_at_tx_id": txHash,
+		consumedRefs := make([]consumedUtxoRef, 0, len(tx.Consumed()))
+		for _, input := range tx.Consumed() {
+			inTxID := input.Id().Bytes()
+			inIdx := input.Index()
+			duplicate := false
+			for i := range consumedRefs {
+				if consumedRefs[i].idx == inIdx &&
+					bytes.Equal(consumedRefs[i].txID, inTxID) {
+					duplicate = true
+					break
+				}
+			}
+			if duplicate {
+				continue
+			}
+			consumedRefs = append(consumedRefs, consumedUtxoRef{
+				txID: inTxID,
+				idx:  inIdx,
+				hash: input.Id().String(),
 			})
-		if result.Error != nil {
-			return result.Error
+		}
+		if len(consumedRefs) > 0 {
+			whereConditions := make([]string, 0, len(consumedRefs))
+			updateArgs := make([]any, 0, 2+(len(consumedRefs)*2))
+			updateArgs = append(updateArgs, point.Slot, txHash)
+			for _, ref := range consumedRefs {
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				updateArgs = append(updateArgs, ref.txID, ref.idx)
+			}
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
+				strings.Join(whereConditions, " OR "),
+			)
+			result = db.Exec(sql, updateArgs...)
+			if result.Error != nil {
+				return fmt.Errorf("batch consume utxos: %w", result.Error)
+			}
+			if result.RowsAffected != int64(len(consumedRefs)) {
+				for _, ref := range consumedRefs {
+					var existingUtxo models.Utxo
+					checkResult := db.Where(
+						"tx_id = ? AND output_idx = ?",
+						ref.txID,
+						ref.idx,
+					).First(&existingUtxo)
+					if checkResult.Error != nil {
+						if errors.Is(checkResult.Error, gorm.ErrRecordNotFound) {
+							d.logger.Warn(
+								"input UTxO not found",
+								"hash",
+								ref.hash,
+								"index",
+								ref.idx,
+							)
+							continue
+						}
+						return fmt.Errorf(
+							"failed to check UTXO %x#%d: %w",
+							ref.txID,
+							ref.idx,
+							checkResult.Error,
+						)
+					}
+					if existingUtxo.SpentAtTxId != nil &&
+						bytes.Equal(existingUtxo.SpentAtTxId, txHash) {
+						continue
+					}
+					if existingUtxo.DeletedSlot == 0 &&
+						existingUtxo.SpentAtTxId == nil {
+						return fmt.Errorf(
+							"batch consume did not update UTXO %x#%d",
+							ref.txID,
+							ref.idx,
+						)
+					}
+					return fmt.Errorf(
+						"%w: %x:%d",
+						types.ErrUtxoConflict,
+						ref.txID,
+						ref.idx,
+					)
+				}
+			}
 		}
 	}
 	// Address indexing, witnesses, scripts, redeemers, and plutus data only stored in API mode
 	if d.storageMode == types.StorageModeAPI {
 		// Index unique addresses participating in this transaction.
-		// Includes inputs, collateral inputs, outputs, and collateral return.
+		// Includes inputs, collateral inputs, reference inputs, outputs, and collateral return.
 		addressUtxos := make(
 			[]models.Utxo,
 			0,
-			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(tmpTx.Outputs)+1,
+			len(tmpTx.Inputs)+
+				len(tmpTx.Collateral)+
+				len(tmpTx.ReferenceInputs)+
+				len(tmpTx.Outputs)+1,
 		)
 		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
 		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
+		addressUtxos = append(addressUtxos, tmpTx.ReferenceInputs...)
 		addressUtxos = append(addressUtxos, tmpTx.Outputs...)
 		if tmpTx.CollateralReturn != nil {
 			addressUtxos = append(addressUtxos, *tmpTx.CollateralReturn)

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -33,6 +33,12 @@ import (
 // MySQL doesn't have SQLite's bind variable limits, so we can use larger batches.
 const mysqlBatchChunkSize = 1000
 
+// UtxoRef represents a reference to a UTXO by transaction ID and output index.
+type UtxoRef struct {
+	TxId      []byte
+	OutputIdx uint32
+}
+
 // GetUtxo returns a Utxo by reference
 func (d *MetadataStoreMysql) GetUtxo(
 	txId []byte,
@@ -54,6 +60,50 @@ func (d *MetadataStoreMysql) GetUtxo(
 		return nil, fmt.Errorf("get utxo %x#%d: %w", txId, idx, result.Error)
 	}
 	return ret, nil
+}
+
+// GetUtxosBatch retrieves multiple UTXOs by their references in batched queries.
+// Returns a map keyed by "txid:outputidx" for easy lookup.
+func (d *MetadataStoreMysql) GetUtxosBatch(
+	refs []UtxoRef,
+	txn types.Txn,
+) (map[string]*models.Utxo, error) {
+	if len(refs) == 0 {
+		return make(map[string]*models.Utxo), nil
+	}
+
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*models.Utxo, len(refs))
+	for i := 0; i < len(refs); i += mysqlBatchChunkSize {
+		end := min(i+mysqlBatchChunkSize, len(refs))
+		chunk := refs[i:end]
+
+		conditions := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for _, ref := range chunk {
+			conditions = append(conditions, "(tx_id = ? AND output_idx = ?)")
+			args = append(args, ref.TxId, ref.OutputIdx)
+		}
+
+		var utxos []models.Utxo
+		queryResult := db.
+			Where("deleted_slot = 0").
+			Where("("+strings.Join(conditions, " OR ")+")", args...).
+			Find(&utxos)
+		if queryResult.Error != nil {
+			return nil, queryResult.Error
+		}
+		for j := range utxos {
+			key := fmt.Sprintf("%x:%d", utxos[j].TxId, utxos[j].OutputIdx)
+			result[key] = &utxos[j]
+		}
+	}
+
+	return result, nil
 }
 
 // GetUtxoIncludingSpent returns a Utxo by reference, including spent UTxOs

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -18,9 +18,12 @@ package postgres
 
 import (
 	"bytes"
+	"context"
 	"math/big"
 	"os"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,10 +33,12 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // TestTable is a simple table for testing concurrent transactions
@@ -47,6 +52,10 @@ type mockTransaction struct {
 	isValid      bool
 	produced     []lcommon.Utxo
 	collReturn   lcommon.TransactionOutput
+	inputs       []lcommon.TransactionInput
+	collateral   []lcommon.TransactionInput
+	refInputs    []lcommon.TransactionInput
+	consumed     []lcommon.TransactionInput
 	withdrawals  map[*lcommon.Address]*big.Int
 }
 
@@ -99,11 +108,11 @@ func (m *mockTransaction) Outputs() []lcommon.TransactionOutput {
 }
 
 func (m *mockTransaction) Inputs() []lcommon.TransactionInput {
-	return nil
+	return m.inputs
 }
 
 func (m *mockTransaction) Collateral() []lcommon.TransactionInput {
-	return nil
+	return m.collateral
 }
 
 func (m *mockTransaction) Certificates() []lcommon.Certificate {
@@ -127,7 +136,7 @@ func (m *mockTransaction) Cbor() []byte {
 }
 
 func (m *mockTransaction) Consumed() []lcommon.TransactionInput {
-	return nil
+	return m.consumed
 }
 
 func (m *mockTransaction) Witnesses() lcommon.TransactionWitnessSet {
@@ -139,7 +148,7 @@ func (m *mockTransaction) ValidityIntervalStart() uint64 {
 }
 
 func (m *mockTransaction) ReferenceInputs() []lcommon.TransactionInput {
-	return nil
+	return m.refInputs
 }
 
 func (m *mockTransaction) TotalCollateral() *big.Int {
@@ -180,6 +189,49 @@ func (m *mockTransaction) Utxorpc() (*cardano.Tx, error) {
 
 func (m *mockTransaction) LeiosHash() lcommon.Blake2b256 {
 	return lcommon.Blake2b256{}
+}
+
+type setTransactionSQLRecorder struct {
+	mu         sync.Mutex
+	statements []string
+}
+
+func (r *setTransactionSQLRecorder) LogMode(
+	gormlogger.LogLevel,
+) gormlogger.Interface {
+	return r
+}
+
+func (*setTransactionSQLRecorder) Info(context.Context, string, ...any) {}
+
+func (*setTransactionSQLRecorder) Warn(context.Context, string, ...any) {}
+
+func (*setTransactionSQLRecorder) Error(context.Context, string, ...any) {}
+
+func (r *setTransactionSQLRecorder) Trace(
+	_ context.Context,
+	_ time.Time,
+	fc func() (string, int64),
+	_ error,
+) {
+	sql, _ := fc()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statements = append(r.statements, sql)
+}
+
+func (r *setTransactionSQLRecorder) countUtxoSelects() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, stmt := range r.statements {
+		normalized := strings.ToUpper(stmt)
+		if strings.Contains(normalized, "SELECT") &&
+			strings.Contains(normalized, "FROM \"UTXO\"") {
+			count++
+		}
+	}
+	return count
 }
 
 type mockTransactionInput struct {
@@ -474,6 +526,110 @@ func TestPostgresMultipleTransaction(t *testing.T) {
 	}
 	if err := <-errCh; err != nil {
 		t.Fatalf("goroutine error: %s", err)
+	}
+}
+
+// TestPostgresSetTransactionBatchesMultiInputUtxoLookups verifies multi-input,
+// collateral, and reference-input processing uses bounded UTxO SELECTs.
+func TestPostgresSetTransactionBatchesMultiInputUtxoLookups(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	store.storageMode = types.StorageModeAPI
+
+	makeTxID := func(seed byte) []byte {
+		return bytes.Repeat([]byte{seed}, 32)
+	}
+	makeInput := func(seed byte, idx uint32) lcommon.TransactionInput {
+		return dbtestutil.NewMockInput(makeTxID(seed), idx)
+	}
+
+	// Seed UTxOs for regular inputs, collateral, and reference inputs.
+	utxos := make([]models.Utxo, 0, 7)
+	for i := 0; i < 7; i++ {
+		utxos = append(utxos, models.Utxo{
+			TxId:       makeTxID(byte(0x60 + i)),
+			OutputIdx:  uint32(i),
+			AddedSlot:  100,
+			PaymentKey: bytes.Repeat([]byte{byte(0x10 + i)}, 28),
+			StakingKey: bytes.Repeat([]byte{byte(0x20 + i)}, 28),
+			Amount:     types.Uint64(1_000_000 + i),
+		})
+	}
+	if result := store.DB().Create(&utxos); result.Error != nil {
+		t.Fatalf("create utxos: %v", result.Error)
+	}
+
+	// Record SQL executed by SetTransaction so UTxO SELECTs can be counted.
+	recorder := &setTransactionSQLRecorder{}
+	store.db = store.DB().Session(&gorm.Session{Logger: recorder})
+
+	// Build a transaction containing multiple items in every input class.
+	txHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x91}, 32))
+	tx := &mockTransaction{
+		hash:    txHash,
+		isValid: true,
+		inputs: []lcommon.TransactionInput{
+			makeInput(0x60, 0),
+			makeInput(0x61, 1),
+			makeInput(0x62, 2),
+		},
+		collateral: []lcommon.TransactionInput{
+			makeInput(0x63, 3),
+			makeInput(0x64, 4),
+		},
+		refInputs: []lcommon.TransactionInput{
+			makeInput(0x65, 5),
+			makeInput(0x66, 6),
+		},
+		consumed: []lcommon.TransactionInput{
+			makeInput(0x60, 0),
+			makeInput(0x61, 1),
+			makeInput(0x62, 2),
+		},
+	}
+	point := ocommon.NewPoint(200, bytes.Repeat([]byte{0x92}, 32))
+
+	// Process the transaction through the regular SetTransaction path.
+	if err := store.SetTransaction(tx, point, 0, nil, nil); err != nil {
+		t.Fatalf("set transaction: %v", err)
+	}
+
+	// Verify exactly one batch SELECT was used per input class.
+	if got := recorder.countUtxoSelects(); got != 3 {
+		t.Fatalf("expected 3 batched UTxO SELECTs, got %d", got)
+	}
+
+	// Verify all regular inputs were marked as spent.
+	var spent int64
+	if result := store.DB().Model(&models.Utxo{}).
+		Where("spent_at_tx_id = ?", txHash.Bytes()).
+		Count(&spent); result.Error != nil {
+		t.Fatalf("count spent utxos: %v", result.Error)
+	}
+	if spent != 3 {
+		t.Fatalf("expected 3 spent UTxOs, got %d", spent)
+	}
+
+	// Verify all collateral inputs were linked to the transaction.
+	var collateral int64
+	if result := store.DB().Model(&models.Utxo{}).
+		Where("collateral_by_tx_id = ?", txHash.Bytes()).
+		Count(&collateral); result.Error != nil {
+		t.Fatalf("count collateral utxos: %v", result.Error)
+	}
+	if collateral != 2 {
+		t.Fatalf("expected 2 collateral UTxOs, got %d", collateral)
+	}
+
+	// Verify all reference inputs were linked to the transaction.
+	var referenced int64
+	if result := store.DB().Model(&models.Utxo{}).
+		Where("referenced_by_tx_id = ?", txHash.Bytes()).
+		Count(&referenced); result.Error != nil {
+		t.Fatalf("count reference input utxos: %v", result.Error)
+	}
+	if referenced != 2 {
+		t.Fatalf("expected 2 reference input UTxOs, got %d", referenced)
 	}
 }
 

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -565,6 +565,32 @@ func TestPostgresSetTransactionBatchesMultiInputUtxoLookups(t *testing.T) {
 
 	// Build a transaction containing multiple items in every input class.
 	txHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x91}, 32))
+	defer func() {
+		cleanupDB := store.DB()
+		for i := 0; i < 7; i++ {
+			seedTxID := makeTxID(byte(0x60 + i))
+			if result := cleanupDB.Model(&models.Utxo{}).
+				Where("tx_id = ?", seedTxID).
+				Updates(map[string]any{
+					"collateral_by_tx_id": nil,
+					"referenced_by_tx_id": nil,
+					"spent_at_tx_id":      nil,
+					"deleted_slot":        0,
+				}); result.Error != nil {
+				t.Errorf("cleanup utxo refs: %v", result.Error)
+			}
+			if result := cleanupDB.
+				Where("tx_id = ?", seedTxID).
+				Delete(&models.Utxo{}); result.Error != nil {
+				t.Errorf("cleanup utxo: %v", result.Error)
+			}
+		}
+		if result := cleanupDB.
+			Where("hash = ?", txHash.Bytes()).
+			Delete(&models.Transaction{}); result.Error != nil {
+			t.Errorf("cleanup transaction: %v", result.Error)
+		}
+	}()
 	tx := &mockTransaction{
 		hash:    txHash,
 		isValid: true,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -17,6 +17,7 @@
 package postgres
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1033,32 +1034,35 @@ func (d *MetadataStorePostgres) SetTransaction(
 		}
 	}
 	// Add Inputs to Transaction
-	for _, input := range tx.Inputs() {
-		inTxId := input.Id().Bytes()
-		inIdx := input.Index()
-		utxo, err := d.GetUtxo(inTxId, inIdx, txn)
+	if len(tx.Inputs()) > 0 {
+		inputRefs := make([]UtxoRef, 0, len(tx.Inputs()))
+		for _, input := range tx.Inputs() {
+			inputRefs = append(inputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		inputUtxos, err := d.GetUtxosBatch(inputRefs, txn)
 		if err != nil {
-			return fmt.Errorf(
-				"failed to fetch input %x#%d: %w",
-				inTxId,
-				inIdx,
-				err,
-			)
+			return fmt.Errorf("failed to batch fetch input UTXOs: %w", err)
 		}
-		if utxo == nil {
-			d.logger.Warn(
-				"Skipping missing input UTxO",
-				"hash",
-				input.Id().String(),
-				"index",
-				inIdx,
-			)
-			continue
+		for _, input := range tx.Inputs() {
+			inTxId := input.Id().Bytes()
+			inIdx := input.Index()
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			utxo := inputUtxos[key]
+			if utxo == nil {
+				d.logger.Warn(
+					"Skipping missing input UTxO",
+					"hash",
+					input.Id().String(),
+					"index",
+					inIdx,
+				)
+				continue
+			}
+			tmpTx.Inputs = append(tmpTx.Inputs, *utxo)
 		}
-		tmpTx.Inputs = append(
-			tmpTx.Inputs,
-			*utxo,
-		)
 	}
 	// Add Collateral to Transaction
 	if len(tx.Collateral()) > 0 {
@@ -1067,18 +1071,22 @@ func (d *MetadataStorePostgres) SetTransaction(
 		var caseArgs []any
 		var whereArgs []any
 
+		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
+		for _, input := range tx.Collateral() {
+			collateralRefs = append(collateralRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		collateralUtxos, err := d.GetUtxosBatch(collateralRefs, txn)
+		if err != nil {
+			return fmt.Errorf("failed to batch fetch collateral UTXOs: %w", err)
+		}
 		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
-			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-			if err != nil {
-				return fmt.Errorf(
-					"failed to fetch input %x#%d: %w",
-					inTxId,
-					inIdx,
-					err,
-				)
-			}
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			utxo := collateralUtxos[key]
 			if utxo == nil {
 				d.logger.Warn(
 					"Skipping missing collateral UTxO",
@@ -1129,18 +1137,25 @@ func (d *MetadataStorePostgres) SetTransaction(
 		var caseArgs []any
 		var whereArgs []any
 
+		refInputRefs := make([]UtxoRef, 0, len(tx.ReferenceInputs()))
+		for _, input := range tx.ReferenceInputs() {
+			refInputRefs = append(refInputRefs, UtxoRef{
+				TxId:      input.Id().Bytes(),
+				OutputIdx: input.Index(),
+			})
+		}
+		refInputUtxos, err := d.GetUtxosBatch(refInputRefs, txn)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to batch fetch reference input UTXOs: %w",
+				err,
+			)
+		}
 		for _, input := range tx.ReferenceInputs() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
-			utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-			if err != nil {
-				return fmt.Errorf(
-					"failed to fetch input %x#%d: %w",
-					inTxId,
-					inIdx,
-					err,
-				)
-			}
+			key := fmt.Sprintf("%x:%d", inTxId, inIdx)
+			utxo := refInputUtxos[key]
 			if utxo == nil {
 				d.logger.Warn(
 					"Skipping missing reference input UTxO",
@@ -1189,51 +1204,116 @@ func (d *MetadataStorePostgres) SetTransaction(
 	}
 
 	// Consume UTxOs
-	for _, input := range tx.Consumed() {
-		inTxId := input.Id().Bytes()
-		inIdx := input.Index()
-		utxo, err := d.GetUtxo(inTxId, inIdx, txn)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to fetch input %x#%d: %w",
-				inTxId,
-				inIdx,
-				err,
-			)
+	if len(tx.Consumed()) > 0 {
+		type consumedUtxoRef struct {
+			txID []byte
+			idx  uint32
+			hash string
 		}
-		if utxo == nil {
-			d.logger.Warn(
-				"input UTxO not found",
-				"hash",
-				input.Id().String(),
-				"index",
-				inIdx,
-			)
-			continue
-		}
-		// Update existing UTxOs
-		result = db.Model(&models.Utxo{}).
-			Where("tx_id = ? AND output_idx = ?", inTxId, inIdx).
-			Where("spent_at_tx_id IS NULL OR spent_at_tx_id = ?", txHash).
-			Updates(map[string]any{
-				"deleted_slot":   point.Slot,
-				"spent_at_tx_id": txHash,
+		consumedRefs := make([]consumedUtxoRef, 0, len(tx.Consumed()))
+		for _, input := range tx.Consumed() {
+			inTxID := input.Id().Bytes()
+			inIdx := input.Index()
+			duplicate := false
+			for i := range consumedRefs {
+				if consumedRefs[i].idx == inIdx &&
+					bytes.Equal(consumedRefs[i].txID, inTxID) {
+					duplicate = true
+					break
+				}
+			}
+			if duplicate {
+				continue
+			}
+			consumedRefs = append(consumedRefs, consumedUtxoRef{
+				txID: inTxID,
+				idx:  inIdx,
+				hash: input.Id().String(),
 			})
-		if result.Error != nil {
-			return result.Error
+		}
+		if len(consumedRefs) > 0 {
+			whereConditions := make([]string, 0, len(consumedRefs))
+			updateArgs := make([]any, 0, 2+(len(consumedRefs)*2))
+			updateArgs = append(updateArgs, point.Slot, txHash)
+			for _, ref := range consumedRefs {
+				whereConditions = append(
+					whereConditions,
+					"(tx_id = ? AND output_idx = ?)",
+				)
+				updateArgs = append(updateArgs, ref.txID, ref.idx)
+			}
+			sql := fmt.Sprintf(
+				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
+				strings.Join(whereConditions, " OR "),
+			)
+			result = db.Exec(sql, updateArgs...)
+			if result.Error != nil {
+				return fmt.Errorf("batch consume utxos: %w", result.Error)
+			}
+			if result.RowsAffected != int64(len(consumedRefs)) {
+				for _, ref := range consumedRefs {
+					var existingUtxo models.Utxo
+					checkResult := db.Where(
+						"tx_id = ? AND output_idx = ?",
+						ref.txID,
+						ref.idx,
+					).First(&existingUtxo)
+					if checkResult.Error != nil {
+						if errors.Is(checkResult.Error, gorm.ErrRecordNotFound) {
+							d.logger.Warn(
+								"input UTxO not found",
+								"hash",
+								ref.hash,
+								"index",
+								ref.idx,
+							)
+							continue
+						}
+						return fmt.Errorf(
+							"failed to check UTXO %x#%d: %w",
+							ref.txID,
+							ref.idx,
+							checkResult.Error,
+						)
+					}
+					if existingUtxo.SpentAtTxId != nil &&
+						bytes.Equal(existingUtxo.SpentAtTxId, txHash) {
+						continue
+					}
+					if existingUtxo.DeletedSlot == 0 &&
+						existingUtxo.SpentAtTxId == nil {
+						return fmt.Errorf(
+							"batch consume did not update UTXO %x#%d",
+							ref.txID,
+							ref.idx,
+						)
+					}
+					return fmt.Errorf(
+						"%w: %x:%d",
+						types.ErrUtxoConflict,
+						ref.txID,
+						ref.idx,
+					)
+				}
+			}
 		}
 	}
 	// Address indexing, witnesses, scripts, redeemers, and plutus data only stored in API mode
 	if d.storageMode == types.StorageModeAPI {
 		// Index unique addresses participating in this transaction.
-		// Includes inputs, collateral inputs, outputs, and collateral return.
+		// Includes inputs, collateral inputs, reference inputs, outputs, and collateral return.
 		addressUtxos := make(
 			[]models.Utxo,
 			0,
-			len(tmpTx.Inputs)+len(tmpTx.Collateral)+len(tmpTx.Outputs)+1,
+			len(tmpTx.Inputs)+
+				len(tmpTx.Collateral)+
+				len(tmpTx.ReferenceInputs)+
+				len(tmpTx.Outputs)+1,
 		)
 		addressUtxos = append(addressUtxos, tmpTx.Inputs...)
 		addressUtxos = append(addressUtxos, tmpTx.Collateral...)
+		addressUtxos = append(addressUtxos, tmpTx.ReferenceInputs...)
 		addressUtxos = append(addressUtxos, tmpTx.Outputs...)
 		if tmpTx.CollateralReturn != nil {
 			addressUtxos = append(addressUtxos, *tmpTx.CollateralReturn)

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -33,6 +33,12 @@ import (
 // Postgres can handle large batches efficiently.
 const postgresBatchChunkSize = 1000
 
+// UtxoRef represents a reference to a UTXO by transaction ID and output index.
+type UtxoRef struct {
+	TxId      []byte
+	OutputIdx uint32
+}
+
 // GetUtxo returns a Utxo by reference
 func (d *MetadataStorePostgres) GetUtxo(
 	txId []byte,
@@ -54,6 +60,50 @@ func (d *MetadataStorePostgres) GetUtxo(
 		return nil, fmt.Errorf("get utxo %x#%d: %w", txId, idx, result.Error)
 	}
 	return ret, nil
+}
+
+// GetUtxosBatch retrieves multiple UTXOs by their references in batched queries.
+// Returns a map keyed by "txid:outputidx" for easy lookup.
+func (d *MetadataStorePostgres) GetUtxosBatch(
+	refs []UtxoRef,
+	txn types.Txn,
+) (map[string]*models.Utxo, error) {
+	if len(refs) == 0 {
+		return make(map[string]*models.Utxo), nil
+	}
+
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*models.Utxo, len(refs))
+	for i := 0; i < len(refs); i += postgresBatchChunkSize {
+		end := min(i+postgresBatchChunkSize, len(refs))
+		chunk := refs[i:end]
+
+		conditions := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for _, ref := range chunk {
+			conditions = append(conditions, "(tx_id = ? AND output_idx = ?)")
+			args = append(args, ref.TxId, ref.OutputIdx)
+		}
+
+		var utxos []models.Utxo
+		queryResult := db.
+			Where("deleted_slot = 0").
+			Where("("+strings.Join(conditions, " OR ")+")", args...).
+			Find(&utxos)
+		if queryResult.Error != nil {
+			return nil, queryResult.Error
+		}
+		for j := range utxos {
+			key := fmt.Sprintf("%x:%d", utxos[j].TxId, utxos[j].OutputIdx)
+			result[key] = &utxos[j]
+		}
+	}
+
+	return result, nil
 }
 
 // GetUtxoIncludingSpent returns a Utxo by reference, including spent UTxOs


### PR DESCRIPTION
1. Added batched utxo lookup support for mysql and postgres, matching the sqlite lookup pattern.
2. Replaced per-input `GetUtxo()` calls in mysql and postgres `SetTransaction()` with batched UTxO lookup maps, matching the sqlite approach. It avoids N+1 SELECT patterns for regular inputs, collateral inputs, and reference inputs during transaction indexing.
3. Batched consumed UTxO updates where possible while preserving existing missing-input warnings and idempotent update behavior.
4. Added mysql and postgres tests for transactions with multiple inputs, collateral inputs, and reference inputs.
5. Add backend-specific MySQL and Postgres tests that build transactions with multiple inputs, collateral inputs.
6. Added SQL statement counting in tests to verify only 3 batched UTxO SELECTs are used: one for inputs, one for collateral, and one for reference inputs.

Closes #2264 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch UTxO lookups for MySQL and Postgres in SetTransaction to remove N+1 queries for inputs, collateral, and reference inputs. This cuts DB calls down to three batched SELECTs and improves indexing performance while preserving existing behavior.

- **Bug Fixes**
  - Added batched UTxO reads and replaced per-input lookups in MySQL/Postgres SetTransaction.
  - Batched consumed-UTxO updates with a single UPDATE while keeping idempotency and missing-input warnings.
  - Included reference inputs in address indexing in API mode.
  - Added backend-specific tests that build multi-input transactions and assert exactly 3 UTxO SELECTs.
  - Fixed test cleanup to clear UTxO reference fields and delete seeded rows to avoid FK constraint failures in later tests.

<sup>Written for commit f2cee171937232311e1c3e4d187e224a46739feb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction processing now handles multiple input types more efficiently, including regular inputs, collateral, and reference inputs.
  * UTxO lookups are batched, reducing repeated database work and improving performance.

* **Bug Fixes**
  * Improved transaction spending updates to better detect missing or conflicting UTxOs.
  * Address indexing now includes reference inputs, helping ensure transaction records are more complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->