### PR TITLE
fix(database): log blob deletion failures during rollback cleanup

### DIFF
--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1286,7 +1286,7 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 			if err := blob.DeleteTx(blobTxn, txHash); err != nil {
 				deleteErrors++
 				batchDeleteErrors++
-				d.logger.Debug(
+				d.logger.Warn(
 					"failed to delete TX blob data",
 					"txHash", hex.EncodeToString(txHash),
 					"error", err,
@@ -1311,13 +1311,19 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 			if err := batchTxn.Commit(); err != nil {
 				deleteErrors += len(batch) - batchDeleteErrors
 				_ = batchTxn.Rollback()
-				d.logger.Debug("tx blob delete batch commit failed", "error", err)
+				d.logger.Warn(
+					"TX blob delete batch commit failed",
+					"batch_start", start,
+					"batch_end", end,
+					"batch_size", len(batch),
+					"error", err,
+				)
 			}
 		}
 	}
 	if deleteErrors > 0 {
-		d.logger.Debug(
-			"tx blob deletion completed with errors",
+		d.logger.Warn(
+			"TX blob deletion completed with errors",
 			"failed",
 			deleteErrors,
 			"total",

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -235,6 +235,35 @@ func TestDeleteTxBlobsCountsFailedBatchCommit(t *testing.T) {
 	require.Contains(t, logs.String(), "\"total\":3")
 }
 
+// TestDeleteUtxoBlobsCountsFailedBatchCommit injects a UTxO batch commit failure.
+// It verifies every uncommitted deletion is included in the aggregate error count.
+func TestDeleteUtxoBlobsCountsFailedBatchCommit(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	store := &mockBlobStore{commitErrs: []error{errors.New("commit failed")}}
+	db := &Database{
+		blob: store,
+		logger: slog.New(
+			slog.NewJSONHandler(
+				&logs,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	}
+
+	utxos := []models.Utxo{
+		{TxId: []byte{0x01}, OutputIdx: 0},
+		{TxId: []byte{0x02}, OutputIdx: 1},
+		{TxId: []byte{0x03}, OutputIdx: 2},
+	}
+	require.NoError(t, deleteUtxoBlobs(db, utxos, nil))
+	require.Len(t, store.txns, 1)
+	require.Equal(t, 1, store.txns[0].commitCount)
+	require.Contains(t, logs.String(), "\"failed\":3")
+	require.Contains(t, logs.String(), "\"total\":3")
+}
+
 // TestTransactionsDeleteRolledbackLogsBlobFailureAndDeletesMetadata injects a transaction blob deletion failure.
 // It verifies the failure is logged while rollback metadata cleanup still succeeds.
 func TestTransactionsDeleteRolledbackLogsBlobFailureAndDeletesMetadata(t *testing.T) {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	metadataSqlite "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	dbtestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -33,12 +34,14 @@ import (
 )
 
 type mockBlobStore struct {
-	deleteTxErrs map[string]error
-	commitErrs   []error
-	deleteTxnIDs []int
-	iterator     types.BlobIterator
-	txns         []*mockBlobTxn
-	utxoData     map[string][]byte
+	deleteTxErrs     map[string]error
+	deleteUtxoErrs   map[string]error
+	commitErrs       []error
+	deleteTxnIDs     []int
+	deleteUtxoTxnIDs []int
+	iterator         types.BlobIterator
+	txns             []*mockBlobTxn
+	utxoData         map[string][]byte
 }
 
 type mockBlobTxn struct {
@@ -142,7 +145,15 @@ func (m *mockBlobStore) GetUtxo(txn types.Txn, txId []byte, outputIdx uint32) ([
 	return nil, types.ErrBlobKeyNotFound
 }
 
-func (m *mockBlobStore) DeleteUtxo(types.Txn, []byte, uint32) error {
+func (m *mockBlobStore) DeleteUtxo(txn types.Txn, txId []byte, outputIdx uint32) error {
+	mockTxn, ok := txn.(*mockBlobTxn)
+	if !ok {
+		return types.ErrTxnWrongType
+	}
+	m.deleteUtxoTxnIDs = append(m.deleteUtxoTxnIDs, mockTxn.id)
+	if err, ok := m.deleteUtxoErrs[fmt.Sprintf("%x:%d", txId, outputIdx)]; ok {
+		return err
+	}
 	return nil
 }
 
@@ -222,6 +233,101 @@ func TestDeleteTxBlobsCountsFailedBatchCommit(t *testing.T) {
 	require.Equal(t, 1, store.txns[0].commitCount)
 	require.Contains(t, logs.String(), "\"failed\":3")
 	require.Contains(t, logs.String(), "\"total\":3")
+}
+
+// TestTransactionsDeleteRolledbackLogsBlobFailureAndDeletesMetadata injects a transaction blob deletion failure.
+// It verifies the failure is logged while rollback metadata cleanup still succeeds.
+func TestTransactionsDeleteRolledbackLogsBlobFailureAndDeletesMetadata(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(
+			&logs,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+	txHash := bytes.Repeat([]byte{0x11}, 32)
+	sqliteStore, err := metadataSqlite.New("", logger, nil)
+	require.NoError(t, err)
+	require.NoError(t, sqliteStore.Start())
+	store := &mockBlobStore{
+		deleteTxErrs: map[string]error{
+			string(txHash): errors.New("delete tx blob failed"),
+		},
+	}
+	db := &Database{
+		blob:     store,
+		metadata: sqliteStore,
+		logger:   logger,
+		config:   &Config{Logger: logger},
+	}
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+	require.NoError(t, sqliteStore.DB().Create(&models.Transaction{
+		Hash:  txHash,
+		Slot:  200,
+		Valid: true,
+	}).Error)
+
+	require.NoError(t, db.TransactionsDeleteRolledback(100, nil))
+
+	var count int64
+	require.NoError(t, sqliteStore.DB().Model(&models.Transaction{}).
+		Where("hash = ?", txHash).
+		Count(&count).Error)
+	require.Zero(t, count)
+	require.Contains(t, logs.String(), "\"level\":\"WARN\"")
+	require.Contains(t, logs.String(), "failed to delete TX blob data")
+	require.Contains(t, logs.String(), "\"txHash\"")
+	require.Contains(t, logs.String(), "\"total\":1")
+}
+
+// TestUtxosDeleteRolledbackLogsBlobFailureAndDeletesMetadata injects a UTxO blob deletion failure.
+// It verifies the failure is logged while rollback metadata cleanup still succeeds.
+func TestUtxosDeleteRolledbackLogsBlobFailureAndDeletesMetadata(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(
+			&logs,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+	txID := bytes.Repeat([]byte{0x22}, 32)
+	sqliteStore, err := metadataSqlite.New("", logger, nil)
+	require.NoError(t, err)
+	require.NoError(t, sqliteStore.Start())
+	store := &mockBlobStore{
+		deleteUtxoErrs: map[string]error{
+			fmt.Sprintf("%x:%d", txID, 0): errors.New("delete utxo blob failed"),
+		},
+	}
+	db := &Database{
+		blob:     store,
+		metadata: sqliteStore,
+		logger:   logger,
+		config:   &Config{Logger: logger},
+	}
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+	require.NoError(t, sqliteStore.DB().Create(&models.Utxo{
+		TxId:      txID,
+		OutputIdx: 0,
+		AddedSlot: 200,
+		Amount:    1,
+	}).Error)
+
+	require.NoError(t, db.UtxosDeleteRolledback(100, nil))
+
+	var count int64
+	require.NoError(t, sqliteStore.DB().Model(&models.Utxo{}).
+		Where("tx_id = ? AND output_idx = ?", txID, 0).
+		Count(&count).Error)
+	require.Zero(t, count)
+	require.Contains(t, logs.String(), "\"level\":\"WARN\"")
+	require.Contains(t, logs.String(), "failed to delete UTxO blob data")
+	require.Contains(t, logs.String(), "\"added_slot\":200")
+	require.Contains(t, logs.String(), "\"total\":1")
 }
 
 func TestRecoverConsumedUtxoLegacyRawCborWithoutProducerBlockFails(t *testing.T) {

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -62,22 +62,30 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 		for _, utxo := range utxos[start:end] {
 			if err := blob.DeleteUtxo(batchTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {
 				deleteErrors++
-				d.logger.Debug(
+				d.logger.Warn(
 					"failed to delete UTxO blob data",
 					"txid", hex.EncodeToString(utxo.TxId),
 					"output_idx", utxo.OutputIdx,
+					"added_slot", utxo.AddedSlot,
+					"deleted_slot", utxo.DeletedSlot,
 					"error", err,
 				)
 			}
 		}
 		if err := batchTxn.Commit(); err != nil {
 			_ = batchTxn.Rollback()
-			d.logger.Debug("blob delete batch commit failed", "error", err)
+			d.logger.Warn(
+				"UTxO blob delete batch commit failed",
+				"batch_start", start,
+				"batch_end", end,
+				"batch_size", end-start,
+				"error", err,
+			)
 		}
 	}
 	if deleteErrors > 0 {
-		d.logger.Debug(
-			"blob deletion completed with errors",
+		d.logger.Warn(
+			"UTxO blob deletion completed with errors",
 			"failed",
 			deleteErrors,
 			"total",

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -59,9 +59,11 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 	for start := 0; start < len(utxos); start += batchSize {
 		end := min(start+batchSize, len(utxos))
 		batchTxn := NewBlobOnlyTxn(d, true)
+		var batchDeleteErrors int
 		for _, utxo := range utxos[start:end] {
 			if err := blob.DeleteUtxo(batchTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {
 				deleteErrors++
+				batchDeleteErrors++
 				d.logger.Warn(
 					"failed to delete UTxO blob data",
 					"txid", hex.EncodeToString(utxo.TxId),
@@ -73,6 +75,7 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 			}
 		}
 		if err := batchTxn.Commit(); err != nil {
+			deleteErrors += (end - start) - batchDeleteErrors
 			_ = batchTxn.Rollback()
 			d.logger.Warn(
 				"UTxO blob delete batch commit failed",


### PR DESCRIPTION
1. Blob deletion failures during rollback cleanup are now logged as warnings.
2. Metadata cleanup still continues even when blob deletion fails.
3. Added warning logs for transaction blob deletion failures and utxo blob deletion failures.
4. Added transaction, UTxO, slot, and batch details to the logs.
5. Added the tests that injects a transaction blob deletion failure as well as utxo blob deletion failure and verified metadata is still deleted after blob deletion fails along with the failures are visible as warning logs or not.

Closes #2260 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log TX and UTxO blob deletion failures during rollback as warnings and keep metadata cleanup running. Also count uncommitted UTxO deletions when a batch commit fails to keep summaries accurate.

- **Bug Fixes**
  - Warn on TX/UTxO delete errors and batch commit failures with context (tx hash, output idx, added/deleted slot, batch start/end/size).
  - Include UTxO batch commit failures in the failed count; emit a warn summary when any deletions fail.
  - Tests cover TX/UTxO deletion failures and UTxO batch commit failure counting; verify warnings and that metadata is still deleted.

<sup>Written for commit 087e157e793247f134409ef04425e862c4e1fb8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility for failed blob deletions during transaction and UTxO cleanup by raising warning-level logs and adding more context when batch commits fail.
  * Updated rollback handling so metadata records are still removed even if blob cleanup encounters errors.
  * Added coverage for rollback scenarios to verify warning logs and successful metadata cleanup when deletion failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->