### PR TITLE
test(midnight): cover indexer rollback with no recorded events

### DIFF
--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -558,6 +558,59 @@ func TestDeregistration_Rollback(t *testing.T) {
 	assert.NotEmpty(t, reg.FullDatum)
 }
 
+// TestRollback_NoRecordedEvents verifies that rolling back a block that
+// recorded no Midnight-relevant rows is a clean no-op: it returns without
+// error, leaves the in-memory tracked sets unchanged, and does not touch rows
+// belonging to other blocks. Deleting by a block number that matched nothing
+// must not disturb earlier, non-rolled-back state.
+func TestRollback_NoRecordedEvents(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	idx := setupIndexer(t, store)
+
+	// Block 1: a real cNIGHT create that must survive the rollback below.
+	keepTxHash := pad32("a1000001")
+	block1 := testBlock(1, 100, 0x01)
+	require.NoError(t, idx.processBlock(block1,
+		[]lcommon.Transaction{buildTx(t, keepTxHash,
+			[]lcommon.TransactionInput{buildInput(t, pad32("a1000000"), 0)},
+			[]lcommon.TransactionOutput{buildCNightOutput(t, testPolicyID, testAssetNameHex, 500)})},
+		1_000))
+
+	// Block 2: only a non-relevant plain transfer, so nothing is recorded.
+	plainTx := buildTx(t, pad32("b2000001"),
+		[]lcommon.TransactionInput{buildInput(t, pad32("b2000000"), 0)},
+		[]lcommon.TransactionOutput{anyOutput(t)})
+	block2 := testBlock(2, 200, 0x02)
+	require.NoError(t, idx.processBlock(block2, []lcommon.Transaction{plainTx}, 2_000))
+
+	// Precondition: block 2 wrote no rows; only block 1's create exists.
+	var creates []models.MidnightAssetCreate
+	require.NoError(t, store.DB().Find(&creates).Error)
+	require.Len(t, creates, 1, "only block 1 should have recorded a create")
+
+	idx.mu.RLock()
+	utxoCountBefore := len(idx.cNightUTxOs)
+	idx.mu.RUnlock()
+
+	// Roll back block 2, which recorded no events. Must be a clean no-op.
+	idx.rollbackBlock(block2)
+
+	// Block 1's create row must be untouched by the rollback of an empty block.
+	require.NoError(t, store.DB().Find(&creates).Error)
+	assert.Len(t, creates, 1,
+		"rolling back a block with no recorded events must not delete other blocks' rows")
+
+	idx.mu.RLock()
+	_, kept := idx.cNightUTxOs[utxoKey{TxHash: keepTxHash, Index: 0}]
+	utxoCountAfter := len(idx.cNightUTxOs)
+	idx.mu.RUnlock()
+	assert.True(t, kept,
+		"block 1's tracked UTxO must remain after rolling back an unrelated empty block")
+	assert.Equal(t, utxoCountBefore, utxoCountAfter,
+		"tracked UTxO set must be unchanged by a no-op rollback")
+}
+
 // TestNew_PolicyIDLengthValidation verifies that New rejects policy IDs that
 // are not exactly 28 bytes (56 hex characters).
 func TestNew_PolicyIDLengthValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a test asserting that rolling back a block which recorded no Midnight-relevant rows is a clean no-op: `rollbackBlock` returns without error, leaves the in-memory tracked UTxO set unchanged, and does not delete rows belonging to other, non-rolled-back blocks.

## Context

While reviewing the Midnight indexer rollback handling described in #2116, I found the functional requirements are already implemented and tested on `main` (landed via #2604 and #2606). The indexer reacts to `ChainRollbackEvent`, which `ledger/block_event.go` fans out into per-block `BlockActionUndo` events; `rollbackBlock` then undoes each block incrementally — deleting `midnight_asset_creates/spends`, `midnight_registrations/deregistrations`, `midnight_governance_datums`, `midnight_epoch_candidates`, and `midnight_ariadne_params` rows for that block and restoring the in-memory tracked/candidate sets. This is the codebase-wide rollback convention and is more precise than a bulk `block_number > point` delete (it correctly handles a UTxO created and spent within the same block).

Mapping #2116's three required test scenarios against existing coverage:
- **Rollback within current epoch** — covered (`TestCNightCreate_Rollback`, `TestCNightSpend_Rollback`, `TestRegistration_Rollback`, `TestDeregistration_Rollback`).
- **Rollback crossing epoch boundaries requiring candidate-set rebuild** — covered (`TestAriadneRollbackRestoresPriorEpochState`, `TestCandidateRollbackDeletesPersistedSnapshots`, `TestEpochTransitionIdempotent`).
- **Rollback to points with no recorded events** — was **not** asserted. This PR adds `TestRollback_NoRecordedEvents` to close that gap.

With this test in place, #2116 is fully satisfied; **recommend closing #2116** once this merges.

## Testing

- `go test ./midnight/indexer/ -race` — pass
- `golangci-lint run ./midnight/indexer/...` — 0 issues; `modernize` / `gofmt` clean

`DATABASE.md` / `ARCHITECTURE.md`: checked, not affected (test-only change; no models, storage, EventBus, or component-boundary changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TestRollback_NoRecordedEvents` to verify that rolling back a block with no Midnight-relevant rows is a clean no-op. Confirms `rollbackBlock` returns without error, keeps the in-memory UTxO set unchanged, and does not delete rows from other blocks, completing the “no events” rollback scenario in #2116.

<sup>Written for commit 4d199c9e5139ac4d1b5513c4a95d6064bc86e461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for rollback behavior when a block contains no relevant events, helping ensure existing indexed data and tracked balances remain unchanged in this case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->