### PR TITLE
fix(database): Cast live stake UTxO amounts before summing in GetStakeByPools

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -748,6 +748,15 @@ To match `includeInactive = false`, add:
 AND a.active = true
 ```
 
+### `GetStakeByPools`
+
+Current live stake by pool joins active `account` rows to UTxOs with
+`deleted_slot = 0` and sums their lovelace amounts. Because `utxo.amount` is
+stored as text (`types.Uint64`) on postgres and mysql, implementations cast it
+before summation: `INTEGER` on sqlite, `BIGINT` on postgres, and `UNSIGNED` on
+mysql. The casts keep postgres from rejecting `SUM(text)` and prevent mysql
+from implicitly converting amounts to `DOUBLE` and losing integer precision.
+
 ### `GetStakeByPoolsAtSlot`
 
 Historical stake by pool for epoch-boundary snapshots. The query resolves the

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -1077,7 +1077,7 @@ func (d *MetadataStoreMysql) GetStakeByPools(
 
 	var stakeResults []poolStakeResult
 	if err := db.Table("account").
-		Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
+		Select("account.pool, COALESCE(SUM(CAST(utxo.amount AS UNSIGNED)), 0) as total_stake").
 		Joins("INNER JOIN utxo ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 		Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", poolKeyHashes, true).
 		Group("account.pool").

--- a/database/plugin/metadata/mysql/pool_atslot_test.go
+++ b/database/plugin/metadata/mysql/pool_atslot_test.go
@@ -67,3 +67,56 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
 	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
 	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
 }
+
+// TestGetStakeByPoolsPreservesIntegerPrecisionMysql verifies that the live
+// stake query casts the text-encoded amount before summing it. Values above
+// 2^53 expose MySQL's lossy implicit DOUBLE conversion.
+func TestGetStakeByPoolsPreservesIntegerPrecisionMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	pool := bytes.Repeat([]byte{0xC1}, 28)
+	stakeKey := bytes.Repeat([]byte{0x74}, 28)
+
+	cleanup := func() {
+		_ = db.Where("staking_key = ?", stakeKey).Delete(&models.Account{}).Error
+		_ = db.Where("staking_key = ?", stakeKey).Delete(&models.Utxo{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: stakeKey,
+		Pool:       pool,
+		AddedSlot:  10,
+		Active:     true,
+	}).Error)
+
+	utxos := []models.Utxo{
+		{
+			TxId:        bytes.Repeat([]byte{0x21}, 32),
+			OutputIdx:   0,
+			StakingKey:  stakeKey,
+			Amount:      9007199254740993,
+			AddedSlot:   20,
+			DeletedSlot: 0,
+		},
+		{
+			TxId:        bytes.Repeat([]byte{0x22}, 32),
+			OutputIdx:   0,
+			StakingKey:  stakeKey,
+			Amount:      2,
+			AddedSlot:   20,
+			DeletedSlot: 0,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPools([][]byte{pool}, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(9007199254740995), stakes[string(pool)])
+	require.Equal(t, uint64(1), delegators[string(pool)])
+}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -1128,7 +1128,7 @@ func (d *MetadataStorePostgres) GetStakeByPools(
 
 	var stakeResults []poolStakeResult
 	if err := db.Table("account").
-		Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
+		Select("account.pool, COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0) as total_stake").
 		Joins("INNER JOIN utxo ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 		Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", poolKeyHashes, true).
 		Group("account.pool").

--- a/database/plugin/metadata/postgres/pool_atslot_test.go
+++ b/database/plugin/metadata/postgres/pool_atslot_test.go
@@ -68,3 +68,55 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsPostgres(t *testing.T) {
 	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
 	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
 }
+
+// TestGetStakeByPoolsAggregatesTextAmountsPostgres verifies that the live
+// stake query casts the text-encoded amount to BIGINT before SUM.
+func TestGetStakeByPoolsAggregatesTextAmountsPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	pool := bytes.Repeat([]byte{0xC1}, 28)
+	stakeKey := bytes.Repeat([]byte{0x74}, 28)
+
+	cleanup := func() {
+		_ = db.Where("staking_key = ?", stakeKey).Delete(&models.Account{}).Error
+		_ = db.Where("staking_key = ?", stakeKey).Delete(&models.Utxo{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: stakeKey,
+		Pool:       pool,
+		AddedSlot:  10,
+		Active:     true,
+	}).Error)
+
+	utxos := []models.Utxo{
+		{
+			TxId:        bytes.Repeat([]byte{0x21}, 32),
+			OutputIdx:   0,
+			StakingKey:  stakeKey,
+			Amount:      5,
+			AddedSlot:   20,
+			DeletedSlot: 0,
+		},
+		{
+			TxId:        bytes.Repeat([]byte{0x22}, 32),
+			OutputIdx:   0,
+			StakingKey:  stakeKey,
+			Amount:      7,
+			AddedSlot:   20,
+			DeletedSlot: 0,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPools([][]byte{pool}, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(12), stakes[string(pool)])
+	require.Equal(t, uint64(1), delegators[string(pool)])
+}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1186,7 +1186,7 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 		// scan of millions of rows and stalls the epoch stake-distribution
 		// calculation for many minutes. Mirrors the DRep voting-power query.
 		if err := db.Table("account").
-			Select("account.pool, COALESCE(SUM(utxo.amount), 0) as total_stake").
+			Select("account.pool, COALESCE(SUM(CAST(utxo.amount AS INTEGER)), 0) as total_stake").
 			Joins("INNER JOIN utxo INDEXED BY "+utxoStakingLiveAmountIndex+" ON utxo.credential_tag = account.credential_tag AND utxo.staking_key = account.staking_key").
 			Where("account.pool IN ? AND account.active = ? AND utxo.deleted_slot = 0", chunk, true).
 			Group("account.pool").


### PR DESCRIPTION
1. Fixed live stake aggregation by casting text-backed utxo amounts before summing in sqlite, postgres, and mysql.
2. Updated `GetStakeByPools` in sqlite, postgres, and mysql metadata plugins to cast utxo.amount before SUM.
3. Used INTEGER for sqlite, BIGINT for postgres, and UNSIGNED for mysql.
4. Added postgres regression test for proving `GetStakeByPools` aggregates text-backed amounts without SUM(text) failure.
5. Added mysql regression test for proving `GetStakeByPools` preserves integer precision for large text-backed amounts.
6. Updated DATABASE.md to document the live stake aggregation cast behavior.

Closes #2772 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live stake aggregation in `GetStakeByPools` by casting text-backed UTxO amounts before SUM across sqlite, postgres, and mysql. Prevents postgres SUM(text) errors and avoids mysql precision loss on large values. Closes #2772.

- **Bug Fixes**
  - Cast `utxo.amount` before SUM: INTEGER (sqlite), BIGINT (postgres), UNSIGNED (mysql).
  - Added regression tests: postgres aggregates text amounts; mysql preserves precision above 2^53.
  - Documented casting behavior in `DATABASE.md`.

<sup>Written for commit b1c87d68167793881a295283026e747f9e68acbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stake totals to handle text-encoded amounts correctly across databases.
  * Preserved exact large-number precision when calculating live stake, preventing rounding issues.
  * Ensured pools with no matching live UTxOs still show a zero stake total.

* **Tests**
  * Added database-specific coverage for live stake aggregation in MySQL and Postgres.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->