### PR TITLE
fix(blockfrost): populate block aggregate and header fields

### DIFF
--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -370,20 +370,26 @@ func (a *NodeAdapter) blockOutputAndFees(
 			err,
 		)
 	}
-	var totalOutput, totalFees uint64
+	// Accumulate in big.Int: a block's summed lovelace is bounded by the ADA
+	// supply and stays well under uint64 in practice, but big.Int keeps the
+	// response totals correct even if a chained aggregate ever exceeds uint64
+	// rather than silently wrapping.
+	totalOutput := new(big.Int)
+	totalFees := new(big.Int)
 	for _, tx := range txs {
-		totalFees += uint64(tx.Fee)
+		totalFees.Add(totalFees, new(big.Int).SetUint64(uint64(tx.Fee)))
 		outputs := tx.Outputs
 		if !tx.Valid && tx.CollateralReturn != nil {
 			outputs = []models.Utxo{*tx.CollateralReturn}
 		}
 		for _, out := range outputs {
-			totalOutput += uint64(out.Amount)
+			totalOutput.Add(
+				totalOutput,
+				new(big.Int).SetUint64(uint64(out.Amount)),
+			)
 		}
 	}
-	return strconv.FormatUint(totalOutput, 10),
-		strconv.FormatUint(totalFees, 10),
-		nil
+	return totalOutput.String(), totalFees.String(), nil
 }
 
 // nextBlockHash returns the hash of the block that directly follows the block

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/blinklabs-io/dingo/mempool"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -42,6 +43,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
 var (
@@ -304,6 +306,29 @@ func (a *NodeAdapter) blockInfoFromBlock(
 	if tip.BlockNumber >= block.Number {
 		confirmations = tip.BlockNumber - block.Number
 	}
+
+	output, fees, err := a.blockOutputAndFees(block.Hash)
+	if err != nil {
+		return BlockInfo{}, fmt.Errorf(
+			"aggregate output and fees for block %x: %w",
+			block.Hash,
+			err,
+		)
+	}
+
+	blockVRF, opCert, opCertCounter := praosHeaderFields(
+		decodedBlock.Header(),
+	)
+
+	nextBlock, err := a.nextBlockHash(block.Number, tip.BlockNumber)
+	if err != nil {
+		return BlockInfo{}, fmt.Errorf(
+			"resolve next block for block %x: %w",
+			block.Hash,
+			err,
+		)
+	}
+
 	return BlockInfo{
 		Hash:      hex.EncodeToString(block.Hash),
 		Slot:      block.Slot,
@@ -320,7 +345,143 @@ func (a *NodeAdapter) blockInfoFromBlock(
 			block.PrevHash,
 		),
 		Confirmations: confirmations,
+		Output:        output,
+		Fees:          fees,
+		BlockVRF:      blockVRF,
+		OPCert:        opCert,
+		OPCertCounter: opCertCounter,
+		NextBlock:     nextBlock,
 	}, nil
+}
+
+// blockOutputAndFees aggregates the total lovelace output and fees across all
+// transactions in a block. Fees are summed from each transaction's recorded
+// fee. For phase-2 invalid transactions, the collateral return (rather than the
+// discarded outputs) counts toward the block output, matching the
+// per-transaction endpoint.
+func (a *NodeAdapter) blockOutputAndFees(
+	blockHash []byte,
+) (output string, fees string, err error) {
+	txs, err := a.ledgerState.GetTransactionsByBlockHash(blockHash)
+	if err != nil {
+		return "", "", fmt.Errorf(
+			"get transactions for block %x: %w",
+			blockHash,
+			err,
+		)
+	}
+	var totalOutput, totalFees uint64
+	for _, tx := range txs {
+		totalFees += uint64(tx.Fee)
+		outputs := tx.Outputs
+		if !tx.Valid && tx.CollateralReturn != nil {
+			outputs = []models.Utxo{*tx.CollateralReturn}
+		}
+		for _, out := range outputs {
+			totalOutput += uint64(out.Amount)
+		}
+	}
+	return strconv.FormatUint(totalOutput, 10),
+		strconv.FormatUint(totalFees, 10),
+		nil
+}
+
+// nextBlockHash returns the hash of the block that directly follows the block
+// at the given height, or nil when the block is the chain tip (no successor).
+func (a *NodeAdapter) nextBlockHash(
+	height uint64,
+	tipHeight uint64,
+) (*string, error) {
+	if height >= tipHeight {
+		return nil, nil
+	}
+	// Dingo's blob block index is 1-based (BlockInitialIndex) while Cardano
+	// block heights are 0-based, so the successor's internal index is
+	// height + BlockInitialIndex + 1.
+	if height > math.MaxUint64-database.BlockInitialIndex-1 {
+		return nil, nil
+	}
+	next, err := a.ledgerState.Database().BlockByIndex(
+		height+database.BlockInitialIndex+1,
+		nil,
+	)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	hash := hex.EncodeToString(next.Hash)
+	return &hash, nil
+}
+
+// praosHeaderFields extracts the Blockfrost block_vrf, op_cert, and
+// op_cert_counter values from a Praos/TPraos block header. Byron and unknown
+// headers carry none of these, so all three returns are nil.
+func praosHeaderFields(
+	header gledger.BlockHeader,
+) (blockVRF *string, opCert *string, opCertCounter *string) {
+	var vrfKey, opCertHotVkey []byte
+	var counter uint64
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCertHotVkey
+		counter = uint64(h.Body.OpCertSequenceNumber)
+	case *allegra.AllegraBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCertHotVkey
+		counter = uint64(h.Body.OpCertSequenceNumber)
+	case *mary.MaryBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCertHotVkey
+		counter = uint64(h.Body.OpCertSequenceNumber)
+	case *alonzo.AlonzoBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCertHotVkey
+		counter = uint64(h.Body.OpCertSequenceNumber)
+	case *babbage.BabbageBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCert.HotVkey
+		counter = uint64(h.Body.OpCert.SequenceNumber)
+	case *conway.ConwayBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCert.HotVkey
+		counter = uint64(h.Body.OpCert.SequenceNumber)
+	case *dijkstra.DijkstraBlockHeader:
+		vrfKey = h.Body.VrfKey
+		opCertHotVkey = h.Body.OpCert.HotVkey
+		counter = uint64(h.Body.OpCert.SequenceNumber)
+	default:
+		// Byron and unknown headers have no Praos/TPraos header fields.
+		return nil, nil, nil
+	}
+	if len(vrfKey) > 0 {
+		if encoded, err := bech32EncodeData("vrf_vk", vrfKey); err == nil {
+			blockVRF = &encoded
+		}
+	}
+	if len(opCertHotVkey) > 0 {
+		hexCert := hex.EncodeToString(opCertHotVkey)
+		opCert = &hexCert
+	}
+	counterStr := strconv.FormatUint(counter, 10)
+	opCertCounter = &counterStr
+	return blockVRF, opCert, opCertCounter
+}
+
+// bech32EncodeData bech32-encodes raw 8-bit data under the given human-readable
+// prefix, converting to the 5-bit groups bech32 requires.
+func bech32EncodeData(hrp string, data []byte) (string, error) {
+	conv, err := bech32.ConvertBits(data, 8, 5, true)
+	if err != nil {
+		return "", fmt.Errorf("convert bits: %w", err)
+	}
+	encoded, err := bech32.Encode(hrp, conv)
+	if err != nil {
+		return "", fmt.Errorf("bech32 encode: %w", err)
+	}
+	return encoded, nil
 }
 
 // LatestBlockTxHashes returns transaction hashes from the

--- a/api/blockfrost/adapter_block_db_test.go
+++ b/api/blockfrost/adapter_block_db_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newDBBackedAdapter builds a NodeAdapter over a real, in-package LedgerState
+// backed by an on-disk (temp-dir) database, plus the sqlite metadata store so
+// tests can insert transaction/block rows directly. No CardanoNodeConfig is
+// supplied because the exercised paths (blockOutputAndFees, nextBlockHash) do
+// not perform slot/epoch/time math, and NewLedgerState tolerates a nil config.
+func newDBBackedAdapter(
+	t *testing.T,
+) (*NodeAdapter, *sqliteplugin.MetadataStoreSqlite, *database.Database) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ls, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:     db,
+		ChainManager: cm,
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+
+	adapter, err := NewNodeAdapter(ls, nil)
+	require.NoError(t, err)
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+
+	return adapter, store, db
+}
+
+// fill32 returns a 32-byte slice filled with b, used for distinct hash/ID
+// values in tests.
+func fill32(b byte) []byte {
+	return bytes.Repeat([]byte{b}, 32)
+}
+
+// TestNodeAdapterBlockOutputAndFees exercises the real DB aggregation path,
+// including the phase-2 invalid transaction branch where the collateral return
+// (not the discarded outputs) counts toward block output.
+func TestNodeAdapterBlockOutputAndFees(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	blockHash := fill32(0xab)
+
+	// Valid transaction: fee 100, outputs 1000 + 2000 (both count).
+	validTx := &models.Transaction{
+		Hash:       fill32(0x01),
+		BlockHash:  blockHash,
+		BlockIndex: 0,
+		Valid:      true,
+		Fee:        types.Uint64(100),
+		Outputs: []models.Utxo{
+			{TxId: fill32(0x01), OutputIdx: 0, Amount: types.Uint64(1000)},
+			{TxId: fill32(0x01), OutputIdx: 1, Amount: types.Uint64(2000)},
+		},
+	}
+	require.NoError(t, store.DB().Create(validTx).Error)
+
+	// Invalid transaction: fee 50, its outputs (9999) are discarded and the
+	// collateral return (500) is what actually reaches the chain.
+	invalidTx := &models.Transaction{
+		Hash:       fill32(0x02),
+		BlockHash:  blockHash,
+		BlockIndex: 1,
+		Valid:      false,
+		Fee:        types.Uint64(50),
+		Outputs: []models.Utxo{
+			{TxId: fill32(0x02), OutputIdx: 0, Amount: types.Uint64(9999)},
+		},
+		CollateralReturn: &models.Utxo{
+			TxId:      fill32(0x03),
+			OutputIdx: 0,
+			Amount:    types.Uint64(500),
+		},
+	}
+	require.NoError(t, store.DB().Create(invalidTx).Error)
+
+	output, fees, err := adapter.blockOutputAndFees(blockHash)
+	require.NoError(t, err)
+	// output = 1000 + 2000 (valid) + 500 (collateral return, NOT 9999) = 3500
+	assert.Equal(t, "3500", output)
+	// fees = 100 + 50 = 150
+	assert.Equal(t, "150", fees)
+}
+
+// TestNodeAdapterBlockOutputAndFeesEmpty verifies a block with no transactions
+// aggregates to zero rather than erroring.
+func TestNodeAdapterBlockOutputAndFeesEmpty(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	output, fees, err := adapter.blockOutputAndFees(fill32(0xcd))
+	require.NoError(t, err)
+	assert.Equal(t, "0", output)
+	assert.Equal(t, "0", fees)
+}
+
+// TestNodeAdapterNextBlockHash covers the successor lookup against real block
+// index entries: a middle block resolves to its successor's hash, the tip block
+// resolves to nil (short-circuit), and a block whose successor index is absent
+// resolves to nil via ErrBlockNotFound.
+func TestNodeAdapterNextBlockHash(t *testing.T) {
+	adapter, _, db := newDBBackedAdapter(t)
+
+	// Three consecutive blocks at Cardano heights 0, 1, 2. Dingo's blob index
+	// is 1-based (BlockInitialIndex), so height H lives at index H+1.
+	hashes := map[uint64][]byte{
+		0: fill32(0x10),
+		1: fill32(0x11),
+		2: fill32(0x12),
+	}
+	for height := uint64(0); height <= 2; height++ {
+		require.NoError(t, db.BlockCreate(models.Block{
+			Hash:   hashes[height],
+			Slot:   height * 10,
+			Number: height,
+			ID:     height + database.BlockInitialIndex,
+			Type:   0,
+			Cbor:   []byte{byte(height)},
+		}, nil))
+	}
+
+	const tipHeight = uint64(2)
+
+	// Middle block (height 0) -> successor at height 1.
+	next, err := adapter.nextBlockHash(0, tipHeight)
+	require.NoError(t, err)
+	require.NotNil(t, next)
+	assert.Equal(t, hex.EncodeToString(hashes[1]), *next)
+
+	// Height 1 -> successor at height 2.
+	next, err = adapter.nextBlockHash(1, tipHeight)
+	require.NoError(t, err)
+	require.NotNil(t, next)
+	assert.Equal(t, hex.EncodeToString(hashes[2]), *next)
+
+	// Tip block (height == tipHeight) has no successor: short-circuit to nil
+	// without a DB lookup.
+	next, err = adapter.nextBlockHash(tipHeight, tipHeight)
+	require.NoError(t, err)
+	assert.Nil(t, next)
+
+	// A non-tip height whose successor index is absent (gap in storage) must
+	// resolve to nil via the ErrBlockNotFound path, not surface an error.
+	next, err = adapter.nextBlockHash(50, 100)
+	require.NoError(t, err)
+	assert.Nil(t, next)
+}

--- a/api/blockfrost/adapter_block_db_test.go
+++ b/api/blockfrost/adapter_block_db_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/hex"
 	"io"
 	"log/slog"
+	"math"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -131,6 +133,44 @@ func TestNodeAdapterBlockOutputAndFeesEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "0", output)
 	assert.Equal(t, "0", fees)
+}
+
+// TestNodeAdapterBlockOutputAndFeesNoOverflow guards the big.Int accumulation:
+// summing amounts/fees whose total exceeds uint64 must produce the true total
+// rather than silently wrapping.
+func TestNodeAdapterBlockOutputAndFeesNoOverflow(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	blockHash := fill32(0xef)
+
+	maxU64 := uint64(math.MaxUint64)
+
+	// Two transactions, each with the maximum fee and a maximum-value output.
+	// The per-field values are valid uint64, but their sums are not.
+	for i, b := range []byte{0x21, 0x22} {
+		tx := &models.Transaction{
+			Hash:       fill32(b),
+			BlockHash:  blockHash,
+			BlockIndex: uint32(i),
+			Valid:      true,
+			Fee:        types.Uint64(maxU64),
+			Outputs: []models.Utxo{
+				{TxId: fill32(b), OutputIdx: 0, Amount: types.Uint64(maxU64)},
+			},
+		}
+		require.NoError(t, store.DB().Create(tx).Error)
+	}
+
+	// Expected total = 2 * MaxUint64 for both output and fees.
+	want := new(big.Int).Mul(
+		new(big.Int).SetUint64(maxU64),
+		big.NewInt(2),
+	).String()
+
+	output, fees, err := adapter.blockOutputAndFees(blockHash)
+	require.NoError(t, err)
+	assert.Equal(t, want, output)
+	assert.Equal(t, want, fees)
 }
 
 // TestNodeAdapterNextBlockHash covers the successor lookup against real block

--- a/api/blockfrost/block_header_test.go
+++ b/api/blockfrost/block_header_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/btcsuite/btcd/btcutil/bech32"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vrfKey and hotVkey are arbitrary 32-byte values used to exercise the header
+// field extraction. The exact bytes don't matter, only that they round-trip.
+var (
+	testVRFKey  = mustHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+	testHotVkey = mustHex("ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100")
+)
+
+func mustHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// expectedVRFBech32 encodes the test VRF key exactly as praosHeaderFields
+// should, giving the tests a reference value.
+func expectedVRFBech32(t *testing.T) string {
+	t.Helper()
+	conv, err := bech32.ConvertBits(testVRFKey, 8, 5, true)
+	require.NoError(t, err)
+	encoded, err := bech32.Encode("vrf_vk", conv)
+	require.NoError(t, err)
+	return encoded
+}
+
+func TestPraosHeaderFieldsShelley(t *testing.T) {
+	var h shelley.ShelleyBlockHeader
+	h.Body.VrfKey = testVRFKey
+	h.Body.OpCertHotVkey = testHotVkey
+	h.Body.OpCertSequenceNumber = 7
+
+	vrf, opCert, counter := praosHeaderFields(&h)
+
+	require.NotNil(t, vrf)
+	assert.Equal(t, expectedVRFBech32(t), *vrf)
+	assert.True(t, strings.HasPrefix(*vrf, "vrf_vk1"))
+	require.NotNil(t, opCert)
+	assert.Equal(t, hex.EncodeToString(testHotVkey), *opCert)
+	require.NotNil(t, counter)
+	assert.Equal(t, "7", *counter)
+}
+
+func TestPraosHeaderFieldsAllegraTPraos(t *testing.T) {
+	// Allegra embeds the Shelley header body (TPraos era).
+	var h allegra.AllegraBlockHeader
+	h.Body.VrfKey = testVRFKey
+	h.Body.OpCertHotVkey = testHotVkey
+	h.Body.OpCertSequenceNumber = 0
+
+	vrf, opCert, counter := praosHeaderFields(&h)
+
+	require.NotNil(t, vrf)
+	assert.Equal(t, expectedVRFBech32(t), *vrf)
+	require.NotNil(t, opCert)
+	assert.Equal(t, hex.EncodeToString(testHotVkey), *opCert)
+	require.NotNil(t, counter)
+	assert.Equal(t, "0", *counter)
+}
+
+func TestPraosHeaderFieldsBabbage(t *testing.T) {
+	var h babbage.BabbageBlockHeader
+	h.Body.VrfKey = testVRFKey
+	h.Body.OpCert.HotVkey = testHotVkey
+	h.Body.OpCert.SequenceNumber = 42
+
+	vrf, opCert, counter := praosHeaderFields(&h)
+
+	require.NotNil(t, vrf)
+	assert.Equal(t, expectedVRFBech32(t), *vrf)
+	require.NotNil(t, opCert)
+	assert.Equal(t, hex.EncodeToString(testHotVkey), *opCert)
+	require.NotNil(t, counter)
+	assert.Equal(t, "42", *counter)
+}
+
+func TestPraosHeaderFieldsConway(t *testing.T) {
+	var h conway.ConwayBlockHeader
+	h.Body.VrfKey = testVRFKey
+	h.Body.OpCert.HotVkey = testHotVkey
+	h.Body.OpCert.SequenceNumber = 123
+
+	vrf, opCert, counter := praosHeaderFields(&h)
+
+	require.NotNil(t, vrf)
+	assert.Equal(t, expectedVRFBech32(t), *vrf)
+	require.NotNil(t, opCert)
+	assert.Equal(t, hex.EncodeToString(testHotVkey), *opCert)
+	require.NotNil(t, counter)
+	assert.Equal(t, "123", *counter)
+}
+
+// TestPraosHeaderFieldsByron covers the genesis/pre-Shelley edge case: Byron
+// headers carry no VRF or operational certificate, so all three fields are nil.
+func TestPraosHeaderFieldsByron(t *testing.T) {
+	var h byron.ByronMainBlockHeader
+	// Sanity check that the Byron header satisfies the header interface used
+	// by praosHeaderFields.
+	var _ gledger.BlockHeader = &h
+
+	vrf, opCert, counter := praosHeaderFields(&h)
+
+	assert.Nil(t, vrf)
+	assert.Nil(t, opCert)
+	assert.Nil(t, counter)
+}
+
+// TestPraosHeaderFieldsEmptyVRFAndOpCert verifies that empty header byte slices
+// (which can occur for malformed or partially populated headers) do not produce
+// empty-string values; block_vrf/op_cert stay nil while the counter is always
+// reported.
+func TestPraosHeaderFieldsEmptyVRFAndOpCert(t *testing.T) {
+	var h conway.ConwayBlockHeader
+	h.Body.OpCert.SequenceNumber = 5
+
+	vrf, opCert, counter := praosHeaderFields(&h)
+
+	assert.Nil(t, vrf)
+	assert.Nil(t, opCert)
+	require.NotNil(t, counter)
+	assert.Equal(t, "5", *counter)
+}
+
+func TestBech32EncodeDataVRF(t *testing.T) {
+	encoded, err := bech32EncodeData("vrf_vk", testVRFKey)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(encoded, "vrf_vk1"))
+
+	// Round-trip: decoding must recover the original bytes.
+	hrp, data, err := bech32.Decode(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, "vrf_vk", hrp)
+	decoded, err := bech32.ConvertBits(data, 5, 8, false)
+	require.NoError(t, err)
+	assert.Equal(t, testVRFKey, decoded)
+}

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -532,6 +532,9 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleLatestBlock(t *testing.T) {
+	blockVRF := "vrf_vk1abc"
+	opCert := "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+	opCertCounter := "7"
 	mock := &mockNode{
 		block: BlockInfo{
 			Hash:          "abc123",
@@ -545,6 +548,13 @@ func TestHandleLatestBlock(t *testing.T) {
 			SlotLeader:    "pool1xyz",
 			PreviousBlock: "prev123",
 			Confirmations: 10,
+			Output:        "123456789",
+			Fees:          "4321",
+			BlockVRF:      &blockVRF,
+			OPCert:        &opCert,
+			OPCertCounter: &opCertCounter,
+			// Latest block is the tip, so it has no successor.
+			NextBlock: nil,
 		},
 	}
 	b := newTestBlockfrost(mock)
@@ -573,9 +583,21 @@ func TestHandleLatestBlock(t *testing.T) {
 	assert.Equal(t, "pool1xyz", resp.SlotLeader)
 	assert.Equal(t, "prev123", resp.PreviousBlock)
 	assert.Equal(t, uint64(10), resp.Confirmations)
+	require.NotNil(t, resp.Output)
+	assert.Equal(t, "123456789", *resp.Output)
+	require.NotNil(t, resp.Fees)
+	assert.Equal(t, "4321", *resp.Fees)
+	require.NotNil(t, resp.BlockVRF)
+	assert.Equal(t, "vrf_vk1abc", *resp.BlockVRF)
+	require.NotNil(t, resp.OPCert)
+	assert.Equal(t, opCert, *resp.OPCert)
+	require.NotNil(t, resp.OPCertCounter)
+	assert.Equal(t, "7", *resp.OPCertCounter)
+	assert.Nil(t, resp.NextBlock)
 }
 
 func TestHandleBlockByHashOrNumber(t *testing.T) {
+	nextBlock := "nexthash"
 	mock := &mockNode{
 		blockByID: BlockInfo{
 			Hash:          "abc123",
@@ -589,6 +611,10 @@ func TestHandleBlockByHashOrNumber(t *testing.T) {
 			SlotLeader:    "pool1...",
 			PreviousBlock: "prevhash",
 			Confirmations: 7,
+			Output:        "999",
+			Fees:          "10",
+			// Historical (non-tip) block: it has a known successor.
+			NextBlock: &nextBlock,
 		},
 	}
 	b := newTestBlockfrost(mock)
@@ -610,6 +636,12 @@ func TestHandleBlockByHashOrNumber(t *testing.T) {
 	assert.Equal(t, "abc123", resp.Hash)
 	assert.Equal(t, uint64(1000), resp.Height)
 	assert.Equal(t, uint64(7), resp.Confirmations)
+	require.NotNil(t, resp.Output)
+	assert.Equal(t, "999", *resp.Output)
+	require.NotNil(t, resp.Fees)
+	assert.Equal(t, "10", *resp.Fees)
+	require.NotNil(t, resp.NextBlock)
+	assert.Equal(t, "nexthash", *resp.NextBlock)
 }
 
 func TestHandleBlockNotFound(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -1731,8 +1731,8 @@ func assetNameASCII(
 }
 
 func blockResponse(info BlockInfo) BlockResponse {
-	output := "0"
-	fees := "0"
+	output := info.Output
+	fees := info.Fees
 	return BlockResponse{
 		Hash:          info.Hash,
 		Slot:          info.Slot,
@@ -1747,8 +1747,10 @@ func blockResponse(info BlockInfo) BlockResponse {
 		Confirmations: info.Confirmations,
 		Output:        &output,
 		Fees:          &fees,
-		BlockVRF:      nil,
-		NextBlock:     nil,
+		BlockVRF:      info.BlockVRF,
+		OPCert:        info.OPCert,
+		OPCertCounter: info.OPCertCounter,
+		NextBlock:     info.NextBlock,
 	}
 }
 

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -205,6 +205,22 @@ type BlockInfo struct {
 	SlotLeader    string
 	PreviousBlock string
 	Confirmations uint64
+	// Output is the total lovelace output of the block's transactions.
+	Output string
+	// Fees is the total lovelace fees of the block's transactions.
+	Fees string
+	// BlockVRF is the bech32-encoded (vrf_vk) VRF verification key from the
+	// Praos/TPraos header, or nil for Byron/unknown headers.
+	BlockVRF *string
+	// OPCert is the hex-encoded operational certificate hot vkey, or nil for
+	// Byron/unknown headers.
+	OPCert *string
+	// OPCertCounter is the operational certificate issue counter as a decimal
+	// string, or nil for Byron/unknown headers.
+	OPCertCounter *string
+	// NextBlock is the hash of the block that builds on this one, or nil when
+	// this block is the chain tip.
+	NextBlock *string
 }
 
 // EpochInfo holds epoch data needed by the API.


### PR DESCRIPTION
Closes #2486 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate missing block aggregate and header fields in Blockfrost block endpoints. Responses now include total output, fees, VRF/op-cert data, and the next block hash to match Blockfrost behavior; aggregation now uses big integers to avoid overflow.

- **Bug Fixes**
  - Compute block `output` and `fees` across transactions; for invalid phase-2 transactions, count `collateral_return`.
  - Use big integers for totals to prevent overflow on large sums.
  - Extract `block_vrf` (bech32 `vrf_vk`), `op_cert`, and `op_cert_counter` from Praos/TPraos headers; Byron returns nil.
  - Populate `next_block` for non-tip blocks.
  - Update responses to surface these fields and add tests for aggregation, header parsing, successor lookup, and overflow safety.

<sup>Written for commit 21c8887d1484c7e361653a0dbf0ea64da22d1c44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block details now include total output, fees, successor block hash, and additional header metadata when available.
  * More block information is shown consistently across supported eras.

* **Bug Fixes**
  * Fixed block output and fee values so they reflect actual chain data instead of defaulting to zero.
  * Improved handling of tip blocks and missing successor lookups.

* **Tests**
  * Added coverage for block totals, successor lookup behavior, and header metadata extraction across multiple eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->