### PR TITLE
fix: caclulate slots using byron too

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last reviewed: 2026-06-23
+Last reviewed: 2026-07-09
 
 Dingo is a high-performance Cardano blockchain node implementation in Go. This document describes its architecture, core components, and design patterns.
 
@@ -371,7 +371,8 @@ sequenceDiagram
     Note over SC,EB: Epoch Preparation
     EB->>LE: EpochTransitionEvent(newEpoch)
     LE->>LS: GetStakeDistribution("mark" snapshot, epoch-2)
-    LE->>LE: compute VRF schedule for new epoch
+    LE->>LS: EpochSlotRange(newEpoch)
+    LE->>LE: compute VRF schedule over absolute epoch slots
 
     Note over SC,EB: Per-Slot Forging Loop
     SC->>BF: slot tick
@@ -1417,7 +1418,7 @@ When running as a stake pool operator, Dingo can produce blocks. This involves t
 
 ### Leader Election (`ledger/leader/`)
 
-`Election` subscribes to epoch transition events and pre-computes a leader schedule for each epoch. For each slot, it checks whether the pool's VRF output meets the threshold determined by the pool's relative stake as of the end of epoch E-2 (the reference node's active `set`/`nesPd` distribution). dingo captures `mark[K]` at the boundary into epoch K, holding stake as of the end of K-1, so that distribution is the Mark row for epoch E-1: `praos.StakeSnapshotEpoch(E)` returns E-1 (see "dingo storage indexing" under Stake Snapshots). Header validation uses the same Mark row except for the epoch imported from a Mithril snapshot, where it uses the imported active `pool-distr` stake fraction. Mark snapshots are captured from slot-aware delegation and UTxO state at the boundary slot; threshold failures remain hard validation rejects, and a pool absent from the epoch's Mark distribution is a hard reject mirroring the reference node's `VRFKeyUnknown`. An epoch whose Mark row is entirely empty instead signals a dingo-side storage or computation gap (corrupt DB, incomplete Mithril import, pruned history) rather than pool ineligibility, and the reject message says so. Post-Mithril historical Mark rows captured at or after the target snapshot epoch's start slot are treated as import artifacts and skip only the stake-threshold eligibility check.
+`Election` subscribes to epoch transition events and pre-computes a leader schedule for each epoch. The epoch provider supplies the era-aware absolute slot range for the epoch from `LedgerState.EpochInfo`, which is backed by the hard-fork summary; leader schedules must not derive the range as `epoch * slotsPerEpoch`, because Byron-era prefixes make that value wrong on preprod and mainnet. For each slot in the resolved range, it checks whether the pool's VRF output meets the threshold determined by the pool's relative stake as of the end of epoch E-2 (the reference node's active `set`/`nesPd` distribution). dingo captures `mark[K]` at the boundary into epoch K, holding stake as of the end of K-1, so that distribution is the Mark row for epoch E-1: `praos.StakeSnapshotEpoch(E)` returns E-1 (see "dingo storage indexing" under Stake Snapshots). Header validation uses the same Mark row except for the epoch imported from a Mithril snapshot, where it uses the imported active `pool-distr` stake fraction. Mark snapshots are captured from slot-aware delegation and UTxO state at the boundary slot; threshold failures remain hard validation rejects, and a pool absent from the epoch's Mark distribution is a hard reject mirroring the reference node's `VRFKeyUnknown`. An epoch whose Mark row is entirely empty instead signals a dingo-side storage or computation gap (corrupt DB, incomplete Mithril import, pruned history) rather than pool ineligibility, and the reject message says so. Post-Mithril historical Mark rows captured at or after the target snapshot epoch's start slot are treated as import artifacts and skip only the stake-threshold eligibility check.
 
 ### Block Forging (`ledger/forging/`)
 
@@ -1429,6 +1430,7 @@ When running as a stake pool operator, Dingo can produce blocks. This involves t
 5. Broadcasts the forged block through the chain manager
 
 The forger tracks slot battles (competing blocks at the same slot) and skips forging when the node is not sufficiently synced, controlled by `forgeSyncToleranceSlots` and `forgeStaleGapThresholdSlots`.
+KES periods are computed from the era-aware absolute slot (`currentSlot / slotsPerKESPeriod`) for both startup opcert validation and forge-time signing, so networks with Byron-era prefixes do not skew the current KES period by converting wall-clock duration directly through the Shelley slot length.
 
 #### Optional Self-Validation (`DINGO_VALIDATE_FORGED_BLOCK`)
 

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -321,7 +321,12 @@ func (f *BlockForger) Start(ctx context.Context) error {
 	if f.metrics != nil && f.slotClock != nil && f.creds != nil {
 		if slotsPerKES := f.slotClock.SlotsPerKESPeriod(); slotsPerKES > 0 {
 			if currentSlot, err := f.slotClock.CurrentSlot(); err == nil {
-				f.updateKESMetrics(currentSlot / slotsPerKES)
+				if kesPeriod, err := CurrentKESPeriod(
+					currentSlot,
+					slotsPerKES,
+				); err == nil {
+					f.updateKESMetrics(kesPeriod)
+				}
 			}
 		}
 	}
@@ -568,7 +573,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	if slotsPerKESPeriod == 0 {
 		return errors.New("slots per KES period is zero")
 	}
-	kesPeriod := currentSlot / slotsPerKESPeriod
+	kesPeriod, err := CurrentKESPeriod(currentSlot, slotsPerKESPeriod)
+	if err != nil {
+		return err
+	}
 
 	// Ensure KES key is at correct period
 	if err := f.creds.UpdateKESPeriod(kesPeriod); err != nil {

--- a/ledger/forging/kes_period.go
+++ b/ledger/forging/kes_period.go
@@ -23,18 +23,29 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
-// CurrentKESPeriod returns the KES period that wall-clock time `now` falls
-// in, given the chain's Shelley genesis. It is a pure function so callers
-// can drive it with synthetic genesis and timestamps in tests.
+// CurrentKESPeriod returns the KES period containing currentSlot.
 //
 // Semantics:
-//   - Before SystemStart, period is 0 (the chain has not begun).
-//   - SlotLength is a rational number of seconds per slot; the math is
-//     done in big.Rat to avoid losing precision on chains where slot
-//     length is a fraction (e.g. 1/20s on devnets).
-//   - Returns an error if SlotsPerKESPeriod is non-positive, SlotLength
-//     is non-positive, or the computed period overflows uint64.
-func CurrentKESPeriod(genesis *shelley.ShelleyGenesis, now time.Time) (uint64, error) {
+//   - currentSlot must be the era-aware absolute slot number from the slot
+//     clock. Reconstructing it from Shelley wall-clock slot length is wrong
+//     on networks with a Byron prefix.
+//   - Returns an error if slotsPerKESPeriod is zero.
+func CurrentKESPeriod(
+	currentSlot uint64,
+	slotsPerKESPeriod uint64,
+) (uint64, error) {
+	if slotsPerKESPeriod == 0 {
+		return 0, errors.New("slotsPerKESPeriod must be positive")
+	}
+	return currentSlot / slotsPerKESPeriod, nil
+}
+
+// CurrentKESPeriodFromGenesis returns the KES period containing currentSlot,
+// using slotsPerKESPeriod from Shelley genesis.
+func CurrentKESPeriodFromGenesis(
+	genesis *shelley.ShelleyGenesis,
+	currentSlot uint64,
+) (uint64, error) {
 	if genesis == nil {
 		return 0, errors.New("shelley genesis is nil")
 	}
@@ -44,6 +55,35 @@ func CurrentKESPeriod(genesis *shelley.ShelleyGenesis, now time.Time) (uint64, e
 			genesis.SlotsPerKESPeriod,
 		)
 	}
+	// #nosec G115 -- validated positive above, genesis protocol values fit uint64.
+	return CurrentKESPeriod(currentSlot, uint64(genesis.SlotsPerKESPeriod))
+}
+
+// WallClockKESPeriod returns the KES period implied by Shelley genesis wall
+// time. It is retained for tests and diagnostics on networks without a Byron
+// prefix. Block production startup must use CurrentKESPeriodFromGenesis with
+// an era-aware slot clock instead.
+func WallClockKESPeriod(
+	genesis *shelley.ShelleyGenesis,
+	now time.Time,
+) (uint64, error) {
+	if genesis == nil {
+		return 0, errors.New("shelley genesis is nil")
+	}
+	if now.Before(genesis.SystemStart) {
+		return 0, nil
+	}
+	slot, err := wallClockSlot(genesis, now)
+	if err != nil {
+		return 0, err
+	}
+	return CurrentKESPeriodFromGenesis(genesis, slot)
+}
+
+func wallClockSlot(
+	genesis *shelley.ShelleyGenesis,
+	now time.Time,
+) (uint64, error) {
 	if genesis.SlotLength.Rat == nil {
 		return 0, errors.New("genesis slotLength is nil")
 	}
@@ -54,11 +94,6 @@ func CurrentKESPeriod(genesis *shelley.ShelleyGenesis, now time.Time) (uint64, e
 			slotLengthSeconds.RatString(),
 		)
 	}
-	if now.Before(genesis.SystemStart) {
-		return 0, nil
-	}
-	// slot = elapsedSeconds / slotLengthSeconds, computed exactly in big.Rat.
-	// Convert through nanoseconds to keep both sides as integers.
 	elapsedNanos := now.Sub(genesis.SystemStart).Nanoseconds()
 	num := new(big.Int).Mul(
 		big.NewInt(elapsedNanos),
@@ -69,15 +104,11 @@ func CurrentKESPeriod(genesis *shelley.ShelleyGenesis, now time.Time) (uint64, e
 		big.NewInt(1_000_000_000),
 	)
 	slot := new(big.Int).Quo(num, denom)
-	period := new(big.Int).Quo(
-		slot,
-		big.NewInt(int64(genesis.SlotsPerKESPeriod)),
-	)
-	if !period.IsUint64() {
+	if !slot.IsUint64() {
 		return 0, fmt.Errorf(
-			"computed KES period %s overflows uint64",
-			period.String(),
+			"computed slot %s overflows uint64",
+			slot.String(),
 		)
 	}
-	return period.Uint64(), nil
+	return slot.Uint64(), nil
 }

--- a/ledger/forging/kes_period_test.go
+++ b/ledger/forging/kes_period_test.go
@@ -34,23 +34,9 @@ func synthGenesis(slotsPerKES, maxKES int, slotLen time.Duration, systemStart ti
 	}
 }
 
-func TestCurrentKESPeriod_BeforeSystemStart(t *testing.T) {
-	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	g := synthGenesis(100, 5, time.Second, systemStart)
-	got, err := CurrentKESPeriod(g, systemStart.Add(-time.Hour))
-	if err != nil {
-		t.Fatalf("CurrentKESPeriod: %v", err)
-	}
-	if got != 0 {
-		t.Errorf("got %d, want 0 (before SystemStart)", got)
-	}
-}
-
 func TestCurrentKESPeriod_HappyPath(t *testing.T) {
-	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	g := synthGenesis(100, 5, time.Second, systemStart)
 	// 250 slots elapsed at 1s/slot, 100 slots per period → period 2.
-	got, err := CurrentKESPeriod(g, systemStart.Add(250*time.Second))
+	got, err := CurrentKESPeriod(250, 100)
 	if err != nil {
 		t.Fatalf("CurrentKESPeriod: %v", err)
 	}
@@ -68,9 +54,9 @@ func TestCurrentKESPeriod_FractionalSlotLength(t *testing.T) {
 		SlotsPerKESPeriod: 200,
 		SlotLength:        common.GenesisRat{Rat: big.NewRat(1, 20)},
 	}
-	got, err := CurrentKESPeriod(g, systemStart.Add(50*time.Second))
+	got, err := WallClockKESPeriod(g, systemStart.Add(50*time.Second))
 	if err != nil {
-		t.Fatalf("CurrentKESPeriod: %v", err)
+		t.Fatalf("WallClockKESPeriod: %v", err)
 	}
 	if got != 5 {
 		t.Errorf("got %d, want 5", got)
@@ -80,9 +66,7 @@ func TestCurrentKESPeriod_FractionalSlotLength(t *testing.T) {
 func TestCurrentKESPeriod_PeriodBoundaryExclusive(t *testing.T) {
 	// At exactly 100 slots elapsed (the start of period 1) we should be in
 	// period 1, not 0 or 2.
-	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	g := synthGenesis(100, 5, time.Second, systemStart)
-	got, err := CurrentKESPeriod(g, systemStart.Add(100*time.Second))
+	got, err := CurrentKESPeriod(100, 100)
 	if err != nil {
 		t.Fatalf("CurrentKESPeriod: %v", err)
 	}
@@ -91,17 +75,8 @@ func TestCurrentKESPeriod_PeriodBoundaryExclusive(t *testing.T) {
 	}
 }
 
-func TestCurrentKESPeriod_NilGenesis(t *testing.T) {
-	_, err := CurrentKESPeriod(nil, time.Now())
-	if err == nil {
-		t.Fatal("expected error for nil genesis")
-	}
-}
-
 func TestCurrentKESPeriod_ZeroSlotsPerKES(t *testing.T) {
-	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	g := synthGenesis(0, 5, time.Second, systemStart)
-	_, err := CurrentKESPeriod(g, systemStart)
+	_, err := CurrentKESPeriod(0, 0)
 	if err == nil {
 		t.Fatal("expected error for zero SlotsPerKESPeriod")
 	}
@@ -117,7 +92,7 @@ func TestCurrentKESPeriod_ZeroSlotLength(t *testing.T) {
 		SlotsPerKESPeriod: 100,
 		SlotLength:        common.GenesisRat{Rat: big.NewRat(0, 1)},
 	}
-	_, err := CurrentKESPeriod(g, systemStart.Add(time.Hour))
+	_, err := WallClockKESPeriod(g, systemStart.Add(time.Hour))
 	if err == nil {
 		t.Fatal("expected error for zero SlotLength")
 	}
@@ -133,8 +108,34 @@ func TestCurrentKESPeriod_NilSlotLengthRat(t *testing.T) {
 		SlotsPerKESPeriod: 100,
 		SlotLength:        common.GenesisRat{Rat: nil},
 	}
-	_, err := CurrentKESPeriod(g, systemStart.Add(time.Hour))
+	_, err := WallClockKESPeriod(g, systemStart.Add(time.Hour))
 	if err == nil {
 		t.Fatal("expected error for nil SlotLength.Rat")
+	}
+}
+
+func TestCurrentKESPeriod_UsesAbsoluteSlot(t *testing.T) {
+	const (
+		preprodEpoch299Start = uint64(127_526_400)
+		epochSlot            = uint64(385_815)
+		slotsPerKESPeriod    = uint64(129_600)
+	)
+
+	got, err := CurrentKESPeriod(
+		preprodEpoch299Start+epochSlot,
+		slotsPerKESPeriod,
+	)
+	if err != nil {
+		t.Fatalf("CurrentKESPeriod: %v", err)
+	}
+	if got != 986 {
+		t.Errorf("got %d, want 986", got)
+	}
+}
+
+func TestCurrentKESPeriodFromGenesis_NilGenesis(t *testing.T) {
+	_, err := CurrentKESPeriodFromGenesis(nil, 0)
+	if err == nil {
+		t.Fatal("expected error for nil genesis")
 	}
 }

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/gouroboros/kes"
@@ -398,18 +397,17 @@ func (pc *PoolCredentials) PeriodsRemaining(currentPeriod uint64) uint64 {
 }
 
 // ValidateKESPeriod checks that the loaded operational certificate's KES
-// period is plausible at wall-clock time `now`, given the chain's Shelley
-// genesis. A non-nil result means the node should refuse to start: either
-// the opcert claims a period that hasn't started yet (rotated key staged
-// too early, or wrong network) or the opcert has expired and needs to be
-// rotated.
+// period is plausible at currentSlot, given the chain's Shelley genesis. A
+// non-nil result means the node should refuse to start: either the opcert
+// claims a period that hasn't started yet (rotated key staged too early, or
+// wrong network) or the opcert has expired and needs to be rotated.
 //
 // The protocol-level expiry uses MaxKESEvolutions from genesis rather
 // than the raw 2^depth ceiling, so this matches the chain's view of when
 // an opcert stops being valid.
 func (pc *PoolCredentials) ValidateKESPeriod(
 	genesis *shelley.ShelleyGenesis,
-	now time.Time,
+	currentSlot uint64,
 ) error {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
@@ -420,7 +418,7 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 	if genesis == nil {
 		return errors.New("shelley genesis is required")
 	}
-	current, err := CurrentKESPeriod(genesis, now)
+	current, err := CurrentKESPeriodFromGenesis(genesis, currentSlot)
 	if err != nil {
 		return err
 	}

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -575,8 +575,7 @@ func TestValidateKESPeriod_HappyPath(t *testing.T) {
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
 	// 250 slots elapsed → KES period 2; opcert period 1 is within
 	// [2, 1+5).
-	now := systemStart.Add(250 * time.Second)
-	if err := pc.ValidateKESPeriod(g, now); err != nil {
+	if err := pc.ValidateKESPeriod(g, 250); err != nil {
 		t.Errorf("ValidateKESPeriod: %v", err)
 	}
 }
@@ -587,8 +586,7 @@ func TestValidateKESPeriod_AtStart(t *testing.T) {
 	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	g := synthGenesis(100, 5, time.Second, systemStart)
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 2}}
-	now := systemStart.Add(250 * time.Second)
-	if err := pc.ValidateKESPeriod(g, now); err != nil {
+	if err := pc.ValidateKESPeriod(g, 250); err != nil {
 		t.Errorf("ValidateKESPeriod: %v", err)
 	}
 }
@@ -599,8 +597,7 @@ func TestValidateKESPeriod_InFuture(t *testing.T) {
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 10}}
 	// 50 slots elapsed → current period 0; opcert period 10 is in the
 	// future.
-	now := systemStart.Add(50 * time.Second)
-	err := pc.ValidateKESPeriod(g, now)
+	err := pc.ValidateKESPeriod(g, 50)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -615,8 +612,7 @@ func TestValidateKESPeriod_Expired(t *testing.T) {
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
 	// Period 1 + max evolutions 3 = expires once current >= 4. At slot
 	// 500 → current period 5, which is past expiry.
-	now := systemStart.Add(500 * time.Second)
-	err := pc.ValidateKESPeriod(g, now)
+	err := pc.ValidateKESPeriod(g, 500)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -632,18 +628,17 @@ func TestValidateKESPeriod_ExpiryBoundaryExclusive(t *testing.T) {
 	g := synthGenesis(100, 3, time.Second, systemStart)
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
 	// 400 slots → current period 4. start (1) + max (3) = 4 → expired.
-	now := systemStart.Add(400 * time.Second)
-	err := pc.ValidateKESPeriod(g, now)
+	err := pc.ValidateKESPeriod(g, 400)
 	if err == nil {
 		t.Fatal("expected expired error at exact boundary")
 	}
 }
 
-func TestValidateKESPeriod_BeforeSystemStart(t *testing.T) {
+func TestValidateKESPeriod_AtGenesisSlot(t *testing.T) {
 	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	g := synthGenesis(100, 5, time.Second, systemStart)
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 0}}
-	if err := pc.ValidateKESPeriod(g, systemStart.Add(-time.Hour)); err != nil {
+	if err := pc.ValidateKESPeriod(g, 0); err != nil {
 		t.Errorf("ValidateKESPeriod: %v", err)
 	}
 }
@@ -652,7 +647,7 @@ func TestValidateKESPeriod_NoOpCert(t *testing.T) {
 	systemStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	g := synthGenesis(100, 5, time.Second, systemStart)
 	pc := &PoolCredentials{}
-	err := pc.ValidateKESPeriod(g, systemStart)
+	err := pc.ValidateKESPeriod(g, 0)
 	if err == nil {
 		t.Fatal("expected error when opcert not loaded")
 	}
@@ -660,7 +655,7 @@ func TestValidateKESPeriod_NoOpCert(t *testing.T) {
 
 func TestValidateKESPeriod_NilGenesis(t *testing.T) {
 	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 0}}
-	err := pc.ValidateKESPeriod(nil, time.Now())
+	err := pc.ValidateKESPeriod(nil, 0)
 	if err == nil {
 		t.Fatal("expected error for nil genesis")
 	}

--- a/ledger/hardfork/summary.go
+++ b/ledger/hardfork/summary.go
@@ -185,3 +185,25 @@ func (s *Summary) SlotToEpoch(slot uint64) (EpochInfo, error) {
 		EraID:         era.EraID,
 	}, nil
 }
+
+// EpochInfo converts an absolute epoch number to its boundary information.
+func (s *Summary) EpochInfo(epoch uint64) (EpochInfo, error) {
+	for i := range s.Eras {
+		era := &s.Eras[i]
+		if epoch < era.Start.Epoch {
+			return EpochInfo{}, ErrPastHorizon
+		}
+		if era.End != nil && epoch >= era.End.Epoch {
+			continue
+		}
+		epochsIntoEra := epoch - era.Start.Epoch
+		return EpochInfo{
+			Epoch:         epoch,
+			StartSlot:     era.Start.Slot + epochsIntoEra*era.Params.EpochSize,
+			LengthInSlots: era.Params.EpochSize,
+			SlotLength:    era.Params.SlotLength,
+			EraID:         era.EraID,
+		}, nil
+	}
+	return EpochInfo{}, ErrPastHorizon
+}

--- a/ledger/hardfork/summary.go
+++ b/ledger/hardfork/summary.go
@@ -197,10 +197,27 @@ func (s *Summary) EpochInfo(epoch uint64) (EpochInfo, error) {
 			continue
 		}
 		epochsIntoEra := epoch - era.Start.Epoch
+		epochSize := era.Params.EpochSize
+		if epochsIntoEra != 0 && epochSize > ^uint64(0)/epochsIntoEra {
+			return EpochInfo{}, fmt.Errorf(
+				"hardfork: epoch start slot overflows uint64: epoch=%d era_start_epoch=%d epoch_size=%d",
+				epoch,
+				era.Start.Epoch,
+				epochSize,
+			)
+		}
+		slotOffset := epochsIntoEra * epochSize
+		if era.Start.Slot > ^uint64(0)-slotOffset {
+			return EpochInfo{}, fmt.Errorf(
+				"hardfork: epoch start slot overflows uint64: era_start_slot=%d slot_offset=%d",
+				era.Start.Slot,
+				slotOffset,
+			)
+		}
 		return EpochInfo{
 			Epoch:         epoch,
-			StartSlot:     era.Start.Slot + epochsIntoEra*era.Params.EpochSize,
-			LengthInSlots: era.Params.EpochSize,
+			StartSlot:     era.Start.Slot + slotOffset,
+			LengthInSlots: epochSize,
 			SlotLength:    era.Params.SlotLength,
 			EraID:         era.EraID,
 		}, nil

--- a/ledger/hardfork/summary_test.go
+++ b/ledger/hardfork/summary_test.go
@@ -220,6 +220,52 @@ func TestSummary_EpochInfo_ByronPrefix(t *testing.T) {
 	assert.Equal(t, uint64(299), got.Epoch)
 	assert.Equal(t, uint64(127_526_400), got.StartSlot)
 	assert.Equal(t, uint64(432_000), got.LengthInSlots)
+	assert.Equal(t, time.Second, got.SlotLength)
+	assert.Equal(t, uint(1), got.EraID)
+}
+
+func TestSummary_EpochInfo_StartSlotOverflow(t *testing.T) {
+	maxUint64 := ^uint64(0)
+	tests := []struct {
+		name    string
+		summary hardfork.Summary
+		epoch   uint64
+	}{
+		{
+			name: "epoch offset multiplication",
+			summary: hardfork.Summary{
+				Eras: []hardfork.EraSummary{{
+					Start: hardfork.Bound{Epoch: 0, Slot: 0},
+					Params: hardfork.EraParams{
+						EpochSize:  2,
+						SlotLength: time.Second,
+					},
+				}},
+			},
+			epoch: maxUint64,
+		},
+		{
+			name: "era start slot addition",
+			summary: hardfork.Summary{
+				Eras: []hardfork.EraSummary{{
+					Start: hardfork.Bound{Epoch: 0, Slot: maxUint64 - 1},
+					Params: hardfork.EraParams{
+						EpochSize:  2,
+						SlotLength: time.Second,
+					},
+				}},
+			},
+			epoch: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.summary.EpochInfo(tt.epoch)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "overflows uint64")
+		})
+	}
 }
 
 func TestSummary_SlotToEpoch_PastHorizon(t *testing.T) {

--- a/ledger/hardfork/summary_test.go
+++ b/ledger/hardfork/summary_test.go
@@ -197,6 +197,31 @@ func TestSummary_SlotToEpoch_InSecondEra(t *testing.T) {
 	assert.Equal(t, uint(6), got.EraID)
 }
 
+func TestSummary_EpochInfo_ByronPrefix(t *testing.T) {
+	byronEnd := hardfork.Bound{Slot: 86_400, Epoch: 4}
+	s := hardfork.Summary{
+		Eras: []hardfork.EraSummary{
+			{
+				EraID:  0,
+				Start:  hardfork.Bound{Slot: 0, Epoch: 0},
+				End:    &byronEnd,
+				Params: byronParams,
+			},
+			{
+				EraID:  1,
+				Start:  byronEnd,
+				Params: shelleyParams,
+			},
+		},
+	}
+
+	got, err := s.EpochInfo(299)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(299), got.Epoch)
+	assert.Equal(t, uint64(127_526_400), got.StartSlot)
+	assert.Equal(t, uint64(432_000), got.LengthInSlots)
+}
+
 func TestSummary_SlotToEpoch_PastHorizon(t *testing.T) {
 	end := boundedAt(100*20*time.Second, 100, 5)
 	s := hardfork.Summary{

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -57,8 +57,10 @@ type EpochInfoProvider interface {
 	// for the normal nonce-ready event path instead.
 	NextEpochNonceReadyEpoch() (uint64, bool)
 
-	// SlotsPerEpoch returns the number of slots in an epoch.
-	SlotsPerEpoch() uint64
+	// EpochSlotRange returns the absolute slot range for an epoch, resolved
+	// against the ledger hard-fork summary so Byron prefixes and variable
+	// epoch lengths are respected.
+	EpochSlotRange(epoch uint64) (EpochSlotRange, error)
 
 	// EpochForSlot returns the epoch containing slot, resolved against
 	// the ledger hard-fork summary so era boundaries and variable epoch
@@ -546,6 +548,27 @@ func (e *Election) validatePersistedSchedule(
 		return false, "epoch nonce changed", nil
 	}
 
+	epochRange, err := e.epochProvider.EpochSlotRange(epoch)
+	if err != nil {
+		return false, "", fmt.Errorf("get epoch slot range: %w", err)
+	}
+	if epochRange.SlotCount == 0 {
+		return false, "epoch slot count is zero", nil
+	}
+	if epochRange.StartSlot > ^uint64(0)-epochRange.SlotCount {
+		return false, "", fmt.Errorf(
+			"epoch slot range overflows uint64: start=%d count=%d",
+			epochRange.StartSlot,
+			epochRange.SlotCount,
+		)
+	}
+	epochEndSlot := epochRange.StartSlot + epochRange.SlotCount
+	for _, slot := range schedule.LeaderSlotsSnapshot() {
+		if slot < epochRange.StartSlot || slot >= epochEndSlot {
+			return false, "leader slot outside epoch range", nil
+		}
+	}
+
 	snapshotEpoch := praos.StakeSnapshotEpoch(epoch)
 	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
 	if err != nil {
@@ -675,16 +698,19 @@ func (e *Election) computeSchedule(
 		return nil, nil
 	}
 
-	calc := NewCalculator(
-		e.epochProvider.ActiveSlotCoeff(),
-		e.epochProvider.SlotsPerEpoch(),
-	)
+	epochRange, err := e.epochProvider.EpochSlotRange(currentEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("get epoch slot range: %w", err)
+	}
+
+	calc := NewCalculator(e.epochProvider.ActiveSlotCoeff())
 
 	mode := e.epochProvider.ConsensusModeForEpoch(currentEpoch)
 
 	vrfEvalStart := time.Now()
 	schedule, err := calc.CalculateSchedule(
 		currentEpoch,
+		epochRange,
 		e.poolId,
 		e.poolVrfSkey,
 		poolStake,
@@ -711,7 +737,7 @@ func (e *Election) computeSchedule(
 		"leader_slot_list", schedule.LeaderSlotsSnapshot(),
 	)
 	if e.metrics != nil {
-		slotsChecked := e.epochProvider.SlotsPerEpoch()
+		slotsChecked := epochRange.SlotCount
 		slotsWon := uint64(len(schedule.LeaderSlotsSnapshot()))
 		slotsNotWon := uint64(0)
 		if slotsWon <= slotsChecked {

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -363,7 +363,13 @@ func TestElectionUsesEpochSlotRangeForSchedule(t *testing.T) {
 	epochProvider.activeSlotCoeff = 1.0
 	epochProvider.SetEpochNonceForEpoch(epoch, electionTestNonce)
 	epochProvider.epochSlotRange = func(gotEpoch uint64) (EpochSlotRange, error) {
-		require.Equal(t, epoch, gotEpoch)
+		if gotEpoch != epoch {
+			return EpochSlotRange{}, fmt.Errorf(
+				"got epoch slot range request for epoch %d, want %d",
+				gotEpoch,
+				epoch,
+			)
+		}
 		return EpochSlotRange{
 			StartSlot: preprodEpochStart,
 			SlotCount: testEpochSlotCount,

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -101,6 +101,9 @@ type mockEpochProvider struct {
 	// division so tests can model variable epoch lengths or simulate
 	// past-horizon errors.
 	epochForSlot func(slot uint64) (uint64, error)
+	// epochSlotRange, when set, overrides EpochSlotRange's default fixed
+	// range so tests can model Byron-era offsets or variable epoch lengths.
+	epochSlotRange func(epoch uint64) (EpochSlotRange, error)
 }
 
 func newMockEpochProvider() *mockEpochProvider {
@@ -138,6 +141,21 @@ func (m *mockEpochProvider) NextEpochNonceReadyEpoch() (uint64, bool) {
 
 func (m *mockEpochProvider) SlotsPerEpoch() uint64 {
 	return m.slotsPerEpoch
+}
+
+func (m *mockEpochProvider) EpochSlotRange(
+	epoch uint64,
+) (EpochSlotRange, error) {
+	if m.epochSlotRange != nil {
+		return m.epochSlotRange(epoch)
+	}
+	if m.slotsPerEpoch == 0 {
+		return EpochSlotRange{}, errors.New("slotsPerEpoch unset")
+	}
+	return EpochSlotRange{
+		StartSlot: epoch * m.slotsPerEpoch,
+		SlotCount: m.slotsPerEpoch,
+	}, nil
 }
 
 func (m *mockEpochProvider) EpochForSlot(slot uint64) (uint64, error) {
@@ -326,6 +344,56 @@ func TestElectionScheduleEarlyEpochs(t *testing.T) {
 	// Schedule is computed asynchronously; wait for it.
 	schedule := waitForSchedule(t, election, 30*time.Second)
 	assert.Equal(t, uint64(1), schedule.Epoch)
+}
+
+func TestElectionUsesEpochSlotRangeForSchedule(t *testing.T) {
+	const (
+		epoch              = uint64(299)
+		preprodEpochStart  = uint64(127_526_400)
+		testEpochSlotCount = uint64(4)
+	)
+
+	poolId := lcommon.PoolKeyHash{}
+	stakeProvider := newMockStakeProvider()
+	stakeProvider.totalStake = 1_000_000
+	stakeProvider.poolStakes[string(poolId[:])] = 1_000_000
+
+	epochProvider := newMockEpochProvider()
+	epochProvider.currentEpoch.Store(epoch)
+	epochProvider.activeSlotCoeff = 1.0
+	epochProvider.SetEpochNonceForEpoch(epoch, electionTestNonce)
+	epochProvider.epochSlotRange = func(gotEpoch uint64) (EpochSlotRange, error) {
+		require.Equal(t, epoch, gotEpoch)
+		return EpochSlotRange{
+			StartSlot: preprodEpochStart,
+			SlotCount: testEpochSlotCount,
+		}, nil
+	}
+
+	eventBus := event.NewEventBus(nil, nil)
+	defer eventBus.Stop()
+
+	election := NewElection(
+		poolId,
+		electionTestVRFSeed,
+		stakeProvider,
+		epochProvider,
+		eventBus,
+		slog.Default(),
+	)
+
+	err := election.Start(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = election.Stop() }()
+
+	schedule := waitForSchedule(t, election, 30*time.Second)
+	require.Equal(t, epoch, schedule.Epoch)
+	slots := schedule.LeaderSlotsSnapshot()
+	require.NotEmpty(t, slots)
+	for _, slot := range slots {
+		assert.GreaterOrEqual(t, slot, preprodEpochStart)
+		assert.Less(t, slot, preprodEpochStart+testEpochSlotCount)
+	}
 }
 
 func TestElectionLoadsPersistedSchedule(t *testing.T) {

--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -33,10 +33,18 @@ import (
 // ScheduleFormatVersion identifies the in-memory and on-disk shape of a
 // computed Schedule. Bump it whenever a code change alters how schedules
 // are computed (e.g. the consensus mode threading added with the
-// per-era TPraos/CPraos split): older persisted schedules then fail
-// validatePersistedSchedule and are recomputed from scratch instead of
-// being silently reused with stale assumptions.
-const ScheduleFormatVersion = 1
+// per-era TPraos/CPraos split, or the epoch slot range becoming
+// era-aware): older persisted schedules then fail validatePersistedSchedule
+// and are recomputed from scratch instead of being silently reused with
+// stale assumptions.
+const ScheduleFormatVersion = 2
+
+// EpochSlotRange identifies the absolute slot range covered by an epoch.
+// StartSlot is inclusive and SlotCount is the number of slots to evaluate.
+type EpochSlotRange struct {
+	StartSlot uint64
+	SlotCount uint64
+}
 
 // Schedule represents the leader schedule for a stake pool in an epoch.
 // It contains the slots where the pool is eligible to produce blocks.
@@ -131,16 +139,12 @@ type Calculator struct {
 	// ActiveSlotCoeff (f) determines block production rate.
 	// For mainnet, f = 0.05 (5% of slots have blocks on average)
 	ActiveSlotCoeff float64
-
-	// SlotsPerEpoch is the number of slots in an epoch.
-	SlotsPerEpoch uint64
 }
 
 // NewCalculator creates a calculator with the given protocol parameters.
-func NewCalculator(activeSlotCoeff float64, slotsPerEpoch uint64) *Calculator {
+func NewCalculator(activeSlotCoeff float64) *Calculator {
 	return &Calculator{
 		ActiveSlotCoeff: activeSlotCoeff,
-		SlotsPerEpoch:   slotsPerEpoch,
 	}
 }
 
@@ -196,6 +200,7 @@ func (c *Calculator) activeSlotCoeffRat() (*big.Rat, error) {
 // reaching the canonical chain.
 func (c *Calculator) CalculateSchedule(
 	epoch uint64,
+	epochRange EpochSlotRange,
 	poolId lcommon.PoolKeyHash,
 	poolVrfSkey []byte,
 	poolStake uint64,
@@ -205,6 +210,16 @@ func (c *Calculator) CalculateSchedule(
 ) (*Schedule, error) {
 	if totalStake == 0 {
 		return nil, errors.New("total stake cannot be zero")
+	}
+	if epochRange.SlotCount == 0 {
+		return nil, errors.New("epoch slot count cannot be zero")
+	}
+	if epochRange.StartSlot > ^uint64(0)-epochRange.SlotCount {
+		return nil, fmt.Errorf(
+			"epoch slot range overflows uint64: start=%d count=%d",
+			epochRange.StartSlot,
+			epochRange.SlotCount,
+		)
 	}
 
 	// Create VRF signer from the pool's VRF secret key seed
@@ -216,8 +231,8 @@ func (c *Calculator) CalculateSchedule(
 	schedule := NewSchedule(epoch, poolId, poolStake, totalStake, epochNonce)
 
 	// Calculate epoch slot range
-	epochStartSlot := epoch * c.SlotsPerEpoch
-	epochEndSlot := epochStartSlot + c.SlotsPerEpoch
+	epochStartSlot := epochRange.StartSlot
+	epochEndSlot := epochStartSlot + epochRange.SlotCount
 
 	activeSlotCoeff, err := c.activeSlotCoeffRat()
 	if err != nil {

--- a/ledger/leader/schedule_consensus_mode_test.go
+++ b/ledger/leader/schedule_consensus_mode_test.go
@@ -79,11 +79,16 @@ func TestCalculateSchedule_TPraosErasMatchGouroborosTPraos(t *testing.T) {
 		epoch         uint64 = 0
 	)
 	activeSlotCoeff := big.NewRat(2, 5)
+	epochRange := leader.EpochSlotRange{
+		StartSlot: epoch * slotsPerEpoch,
+		SlotCount: slotsPerEpoch,
+	}
 
 	// dingo's calculator, called with the era-correct mode.
-	calc := leader.NewCalculator(0.4, slotsPerEpoch)
+	calc := leader.NewCalculator(0.4)
 	dingoSchedule, err := calc.CalculateSchedule(
 		epoch,
+		epochRange,
 		poolID,
 		vrfSeed,
 		poolStake,
@@ -104,7 +109,7 @@ func TestCalculateSchedule_TPraosErasMatchGouroborosTPraos(t *testing.T) {
 	tpraosLeaders := map[uint64]struct{}{}
 	signer, err := consensus.NewSimpleVRFSigner(vrfSeed)
 	require.NoError(t, err)
-	for slot := range (epoch + 1) * slotsPerEpoch {
+	for slot := epochRange.StartSlot; slot < epochRange.StartSlot+epochRange.SlotCount; slot++ {
 		res, err := consensus.IsSlotLeaderWithMode(
 			slot,
 			epochNonce,

--- a/ledger/leader/schedule_test.go
+++ b/ledger/leader/schedule_test.go
@@ -37,6 +37,13 @@ var testEpochNonce = func() []byte {
 	return nonce
 }()
 
+func testEpochSlotRange(epoch, slotsPerEpoch uint64) EpochSlotRange {
+	return EpochSlotRange{
+		StartSlot: epoch * slotsPerEpoch,
+		SlotCount: slotsPerEpoch,
+	}
+}
+
 func TestNewSchedule(t *testing.T) {
 	poolId := lcommon.PoolKeyHash{}
 	copy(poolId[:], []byte("pool1234567890123456"))
@@ -155,15 +162,14 @@ func TestScheduleStakeRatio(t *testing.T) {
 }
 
 func TestNewCalculator(t *testing.T) {
-	calc := NewCalculator(0.05, 432000)
+	calc := NewCalculator(0.05)
 
 	assert.Equal(t, 0.05, calc.ActiveSlotCoeff)
-	assert.Equal(t, uint64(432000), calc.SlotsPerEpoch)
 }
 
 func TestCalculatorThreshold(t *testing.T) {
 	// Mainnet parameters: f = 0.05
-	calc := NewCalculator(0.05, 432000)
+	calc := NewCalculator(0.05)
 
 	tests := []struct {
 		name       string
@@ -273,7 +279,7 @@ func TestCalculatorThresholdInvalidInputs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			calc := NewCalculator(tt.activeSlotCoeff, 432000)
+			calc := NewCalculator(tt.activeSlotCoeff)
 			result := calc.Threshold(tt.stakeRatio)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -297,9 +303,10 @@ func TestCalculateScheduleInvalidActiveSlotCoeff(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			calc := NewCalculator(tt.activeSlotCoeff, 20)
+			calc := NewCalculator(tt.activeSlotCoeff)
 			_, err := calc.CalculateSchedule(
-				5, poolId, testVRFSeed, 1000, 10000, testEpochNonce,
+				5, testEpochSlotRange(5, 20),
+				poolId, testVRFSeed, 1000, 10000, testEpochNonce,
 				consensus.ConsensusModeCPraos,
 			)
 			require.Error(t, err)
@@ -309,11 +316,12 @@ func TestCalculateScheduleInvalidActiveSlotCoeff(t *testing.T) {
 }
 
 func TestCalculateScheduleZeroTotalStake(t *testing.T) {
-	calc := NewCalculator(0.05, 432000)
+	calc := NewCalculator(0.05)
 	poolId := lcommon.PoolKeyHash{}
 
 	_, err := calc.CalculateSchedule(
-		10,             // epoch
+		10, // epoch
+		testEpochSlotRange(10, 432000),
 		poolId,         // pool ID
 		testVRFSeed,    // VRF key
 		1000,           // pool stake
@@ -330,12 +338,13 @@ func TestCalculateSchedulePoolWithStakeGetsSlots(t *testing.T) {
 	// Use a small epoch (20 slots) with high f=0.9 and 100% stake to ensure
 	// we reliably get leader slots. VRF Prove is expensive (~0.2s per call),
 	// so we keep the slot count small.
-	calc := NewCalculator(0.9, 20)
+	calc := NewCalculator(0.9)
 	poolId := lcommon.PoolKeyHash{}
 	copy(poolId[:], []byte("testpool1234567890123"))
 
 	schedule, err := calc.CalculateSchedule(
-		5,              // epoch
+		5, // epoch
+		testEpochSlotRange(5, 20),
 		poolId,         // pool ID
 		testVRFSeed,    // VRF key (32-byte seed)
 		1_000_000,      // pool stake = 100% of total
@@ -360,11 +369,12 @@ func TestCalculateSchedulePoolWithStakeGetsSlots(t *testing.T) {
 }
 
 func TestCalculateScheduleZeroPoolStakeGetsNoSlots(t *testing.T) {
-	calc := NewCalculator(0.9, 20)
+	calc := NewCalculator(0.9)
 	poolId := lcommon.PoolKeyHash{}
 
 	schedule, err := calc.CalculateSchedule(
-		5,              // epoch
+		5, // epoch
+		testEpochSlotRange(5, 20),
 		poolId,         // pool ID
 		testVRFSeed,    // VRF key
 		0,              // zero pool stake
@@ -385,12 +395,13 @@ func TestCalculateScheduleFullStakeApproxRate(t *testing.T) {
 	// With f=0.9 and 100% stake, a pool should be leader for ~90% of slots.
 	// Use 20 slots to keep VRF computation fast while having enough samples.
 	const slotsPerEpoch = 20
-	calc := NewCalculator(0.9, slotsPerEpoch)
+	calc := NewCalculator(0.9)
 	poolId := lcommon.PoolKeyHash{}
 	copy(poolId[:], []byte("testpool1234567890123"))
 
 	schedule, err := calc.CalculateSchedule(
-		3,              // epoch
+		3, // epoch
+		testEpochSlotRange(3, slotsPerEpoch),
 		poolId,         // pool ID
 		testVRFSeed,    // VRF key
 		10_000_000,     // pool stake = 100% of total
@@ -418,19 +429,58 @@ func TestCalculateScheduleFullStakeApproxRate(t *testing.T) {
 	)
 }
 
+func TestCalculateScheduleUsesExplicitEpochSlotRange(t *testing.T) {
+	const (
+		epoch              = uint64(299)
+		preprodEpochStart  = uint64(127_526_400)
+		naiveEpochStart    = epoch * 432_000
+		testEpochSlotCount = uint64(4)
+	)
+
+	calc := NewCalculator(1.0)
+	poolId := lcommon.PoolKeyHash{}
+	copy(poolId[:], []byte("testpool1234567890123"))
+
+	schedule, err := calc.CalculateSchedule(
+		epoch,
+		EpochSlotRange{
+			StartSlot: preprodEpochStart,
+			SlotCount: testEpochSlotCount,
+		},
+		poolId,
+		testVRFSeed,
+		1_000_000,
+		1_000_000,
+		testEpochNonce,
+		consensus.ConsensusModeCPraos,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, schedule)
+
+	slots := schedule.LeaderSlotsSnapshot()
+	require.NotEmpty(t, slots)
+	for _, slot := range slots {
+		assert.GreaterOrEqual(t, slot, preprodEpochStart)
+		assert.Less(t, slot, preprodEpochStart+testEpochSlotCount)
+		assert.Less(t, slot, naiveEpochStart)
+	}
+}
+
 func TestCalculateScheduleIsDeterministic(t *testing.T) {
-	calc := NewCalculator(0.9, 10)
+	calc := NewCalculator(0.9)
 	poolId := lcommon.PoolKeyHash{}
 	copy(poolId[:], []byte("testpool1234567890123"))
 
 	schedule1, err := calc.CalculateSchedule(
-		7, poolId, testVRFSeed, 500_000, 1_000_000, testEpochNonce,
+		7, testEpochSlotRange(7, 10),
+		poolId, testVRFSeed, 500_000, 1_000_000, testEpochNonce,
 		consensus.ConsensusModeCPraos,
 	)
 	require.NoError(t, err)
 
 	schedule2, err := calc.CalculateSchedule(
-		7, poolId, testVRFSeed, 500_000, 1_000_000, testEpochNonce,
+		7, testEpochSlotRange(7, 10),
+		poolId, testVRFSeed, 500_000, 1_000_000, testEpochNonce,
 		consensus.ConsensusModeCPraos,
 	)
 	require.NoError(t, err)
@@ -441,13 +491,14 @@ func TestCalculateScheduleIsDeterministic(t *testing.T) {
 }
 
 func TestCalculateScheduleInvalidVRFKey(t *testing.T) {
-	calc := NewCalculator(0.9, 10)
+	calc := NewCalculator(0.9)
 	poolId := lcommon.PoolKeyHash{}
 
 	t.Run("nil key", func(t *testing.T) {
 		// A nil VRF key should cause an error from the VRF signer creation
 		_, err := calc.CalculateSchedule(
-			5, poolId, nil, 1000, 10000, testEpochNonce,
+			5, testEpochSlotRange(5, 10),
+			poolId, nil, 1000, 10000, testEpochNonce,
 			consensus.ConsensusModeCPraos,
 		)
 		require.Error(t, err)
@@ -458,7 +509,8 @@ func TestCalculateScheduleInvalidVRFKey(t *testing.T) {
 		// A 16-byte key is too short (must be 32 bytes)
 		shortKey := make([]byte, 16)
 		_, err := calc.CalculateSchedule(
-			5, poolId, shortKey, 1000, 10000, testEpochNonce,
+			5, testEpochSlotRange(5, 10),
+			poolId, shortKey, 1000, 10000, testEpochNonce,
 			consensus.ConsensusModeCPraos,
 		)
 		require.Error(t, err)
@@ -507,12 +559,13 @@ func TestScheduleConcurrentAccess(t *testing.T) {
 // IsLeaderForSlot's binary search depends on: CalculateSchedule must emit
 // leader slots in ascending order.
 func TestCalculateScheduleProducesSortedSlots(t *testing.T) {
-	calc := NewCalculator(0.9, 30)
+	calc := NewCalculator(0.9)
 	poolId := lcommon.PoolKeyHash{}
 	copy(poolId[:], []byte("testpool1234567890123"))
 
 	schedule, err := calc.CalculateSchedule(
 		7,
+		testEpochSlotRange(7, 30),
 		poolId,
 		testVRFSeed,
 		1_000_000,

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -126,6 +126,39 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	}, nil
 }
 
+// EpochInfo returns boundary information for the given epoch.
+//
+// Epochs within the known epoch cache resolve to cached-era parameters;
+// epochs past the cache are projected using the current era's parameters.
+// Returns an error for an empty cache or for epochs before the first known
+// era.
+func (ls *LedgerState) EpochInfo(epoch uint64) (models.Epoch, error) {
+	sum, err := ls.HardForkSummary()
+	if err != nil {
+		return models.Epoch{}, errors.New("no epochs in cache")
+	}
+	info, err := sum.EpochInfo(epoch)
+	if err != nil {
+		if errors.Is(err, hardfork.ErrPastHorizon) {
+			return models.Epoch{}, errors.New(
+				"epoch is outside the known epoch range",
+			)
+		}
+		return models.Epoch{}, err
+	}
+	return models.Epoch{
+		EpochId:   info.Epoch,
+		StartSlot: info.StartSlot,
+		EraId:     info.EraID,
+		// info.SlotLength is a positive, protocol-bounded duration.
+		// #nosec G115
+		SlotLength: uint(info.SlotLength / time.Millisecond),
+		// info.LengthInSlots is protocol-bounded and persisted as uint.
+		// #nosec G115
+		LengthInSlots: uint(info.LengthInSlots),
+	}, nil
+}
+
 // shelleySlotLengthMs returns the Shelley genesis slot length in milliseconds,
 // or 0 if the genesis is missing or malformed. Shelley genesis stores slot
 // length as seconds per slot.

--- a/node_forging.go
+++ b/node_forging.go
@@ -32,9 +32,13 @@ import (
 	"github.com/blinklabs-io/gouroboros/consensus"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
 func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) {
+	if _, err := n.blockProducerShelleyGenesis(); err != nil {
+		return nil, err
+	}
 	if n.ledgerState == nil {
 		return nil, errors.New(
 			"block producer mode requires ledger state for current slot",
@@ -64,19 +68,9 @@ func (n *Node) validateBlockProducerStartupAtSlot(
 	if err := creds.ValidateOpCert(); err != nil {
 		return nil, fmt.Errorf("validate operational certificate: %w", err)
 	}
-	// KES-period plausibility requires a Shelley genesis. Block producer
-	// mode without one is unsafe — a node with no genesis cannot tell
-	// whether the opcert is current — so refuse to start.
-	if n.config.cardanoNodeConfig == nil {
-		return nil, errors.New(
-			"block producer mode requires Cardano node config with Shelley genesis",
-		)
-	}
-	genesis := n.config.cardanoNodeConfig.ShelleyGenesis()
-	if genesis == nil {
-		return nil, errors.New(
-			"block producer mode requires Shelley genesis information",
-		)
+	genesis, err := n.blockProducerShelleyGenesis()
+	if err != nil {
+		return nil, err
 	}
 	if err := creds.ValidateKESPeriod(genesis, currentSlot); err != nil {
 		return nil, fmt.Errorf("validate KES period: %w", err)
@@ -103,6 +97,24 @@ func (n *Node) validateBlockProducerStartupAtSlot(
 		"opcert_expiry_period", creds.OpCertExpiryPeriod(),
 	)
 	return creds, nil
+}
+
+func (n *Node) blockProducerShelleyGenesis() (*shelley.ShelleyGenesis, error) {
+	// KES-period plausibility requires a Shelley genesis. Block producer
+	// mode without one is unsafe — a node with no genesis cannot tell
+	// whether the opcert is current — so refuse to start.
+	if n.config.cardanoNodeConfig == nil {
+		return nil, errors.New(
+			"block producer mode requires Cardano node config with Shelley genesis",
+		)
+	}
+	genesis := n.config.cardanoNodeConfig.ShelleyGenesis()
+	if genesis == nil {
+		return nil, errors.New(
+			"block producer mode requires Shelley genesis information",
+		)
+	}
+	return genesis, nil
 }
 
 // blockProducerLedgerView adapts ledger.LedgerState to

--- a/node_forging.go
+++ b/node_forging.go
@@ -35,6 +35,24 @@ import (
 )
 
 func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) {
+	if n.ledgerState == nil {
+		return nil, errors.New(
+			"block producer mode requires ledger state for current slot",
+		)
+	}
+	currentSlot, err := n.ledgerState.CurrentSlot()
+	if err != nil {
+		if !errors.Is(err, ledger.ErrBeforeGenesis) {
+			return nil, fmt.Errorf("compute current slot: %w", err)
+		}
+		currentSlot = 0
+	}
+	return n.validateBlockProducerStartupAtSlot(currentSlot)
+}
+
+func (n *Node) validateBlockProducerStartupAtSlot(
+	currentSlot uint64,
+) (*forging.PoolCredentials, error) {
 	creds := forging.NewPoolCredentials()
 	if err := creds.LoadFromFiles(
 		n.config.shelleyVRFKey,
@@ -60,11 +78,13 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 			"block producer mode requires Shelley genesis information",
 		)
 	}
-	now := time.Now()
-	if err := creds.ValidateKESPeriod(genesis, now); err != nil {
+	if err := creds.ValidateKESPeriod(genesis, currentSlot); err != nil {
 		return nil, fmt.Errorf("validate KES period: %w", err)
 	}
-	currentPeriod, err := forging.CurrentKESPeriod(genesis, now)
+	currentPeriod, err := forging.CurrentKESPeriodFromGenesis(
+		genesis,
+		currentSlot,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("compute current KES period: %w", err)
 	}
@@ -76,6 +96,7 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 		"block producer credentials validated",
 		"component", "node",
 		"pool_id", creds.GetPoolID().String(),
+		"current_slot", currentSlot,
 		"current_kes_period", currentPeriod,
 		"opcert_kes_period", opCert.KESPeriod,
 		"opcert_counter", opCert.IssueNumber,
@@ -525,8 +546,17 @@ func (a *epochInfoAdapter) NextEpochNonceReadyEpoch() (uint64, bool) {
 	return a.ledgerState.NextEpochNonceReadyEpoch()
 }
 
-func (a *epochInfoAdapter) SlotsPerEpoch() uint64 {
-	return a.ledgerState.SlotsPerEpoch()
+func (a *epochInfoAdapter) EpochSlotRange(
+	epoch uint64,
+) (leader.EpochSlotRange, error) {
+	info, err := a.ledgerState.EpochInfo(epoch)
+	if err != nil {
+		return leader.EpochSlotRange{}, err
+	}
+	return leader.EpochSlotRange{
+		StartSlot: info.StartSlot,
+		SlotCount: uint64(info.LengthInSlots),
+	}, nil
 }
 
 func (a *epochInfoAdapter) EpochForSlot(slot uint64) (uint64, error) {

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -84,7 +84,7 @@ func TestValidateBlockProducerStartup_HappyPath(t *testing.T) {
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
 	creds, err := n.validateBlockProducerStartupAtSlot(0)
 	if err != nil {
-		t.Fatalf("validateBlockProducerStartup: %v", err)
+		t.Fatalf("validateBlockProducerStartupAtSlot: %v", err)
 	}
 	if !creds.IsLoaded() {
 		t.Error("expected credentials to be loaded")
@@ -94,7 +94,7 @@ func TestValidateBlockProducerStartup_HappyPath(t *testing.T) {
 func TestValidateBlockProducerStartup_NoCardanoConfig(t *testing.T) {
 	vrf, kes, opcert := devnetCredPaths()
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, nil)
-	_, err := n.validateBlockProducerStartupAtSlot(0)
+	_, err := n.validateBlockProducerStartup()
 	if err == nil {
 		t.Fatal("expected error for missing cardano node config")
 	}
@@ -182,7 +182,7 @@ func TestValidateBlockProducerLedger_NonDevnetVRFMismatchIsFatal(t *testing.T) {
 	n.config.network = "preview"
 	creds, err := n.validateBlockProducerStartupAtSlot(0)
 	if err != nil {
-		t.Fatalf("validateBlockProducerStartup: %v", err)
+		t.Fatalf("validateBlockProducerStartupAtSlot: %v", err)
 	}
 	err = n.validateBlockProducerLedgerWithView(
 		creds,
@@ -203,7 +203,7 @@ func TestValidateBlockProducerLedger_DevnetVRFMismatchWarns(t *testing.T) {
 	n.config.network = "devnet"
 	creds, err := n.validateBlockProducerStartupAtSlot(0)
 	if err != nil {
-		t.Fatalf("validateBlockProducerStartup: %v", err)
+		t.Fatalf("validateBlockProducerStartupAtSlot: %v", err)
 	}
 	err = n.validateBlockProducerLedgerWithView(
 		creds,

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -82,7 +82,7 @@ func TestValidateBlockProducerStartup_HappyPath(t *testing.T) {
 	vrf, kes, opcert := devnetCredPaths()
 	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
-	creds, err := n.validateBlockProducerStartup()
+	creds, err := n.validateBlockProducerStartupAtSlot(0)
 	if err != nil {
 		t.Fatalf("validateBlockProducerStartup: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestValidateBlockProducerStartup_HappyPath(t *testing.T) {
 func TestValidateBlockProducerStartup_NoCardanoConfig(t *testing.T) {
 	vrf, kes, opcert := devnetCredPaths()
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, nil)
-	_, err := n.validateBlockProducerStartup()
+	_, err := n.validateBlockProducerStartupAtSlot(0)
 	if err == nil {
 		t.Fatal("expected error for missing cardano node config")
 	}
@@ -122,7 +122,7 @@ func TestValidateBlockProducerStartup_ExpiredKESPeriod(t *testing.T) {
 		t.Fatalf("LoadShelleyGenesisFromReader: %v", err)
 	}
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, cfg)
-	_, err := n.validateBlockProducerStartup()
+	_, err := n.validateBlockProducerStartupAtSlot(20)
 	if err == nil {
 		t.Fatal("expected error for expired opcert KES period")
 	}
@@ -141,7 +141,7 @@ func TestValidateBlockProducerStartup_MissingFile(t *testing.T) {
 		filepath.Join(tmp, "missing-opcert.cert"),
 		cardanoCfg,
 	)
-	_, err := n.validateBlockProducerStartup()
+	_, err := n.validateBlockProducerStartupAtSlot(0)
 	if err == nil {
 		t.Fatal("expected error for missing credential files")
 	}
@@ -180,7 +180,7 @@ func TestValidateBlockProducerLedger_NonDevnetVRFMismatchIsFatal(t *testing.T) {
 	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
 	n.config.network = "preview"
-	creds, err := n.validateBlockProducerStartup()
+	creds, err := n.validateBlockProducerStartupAtSlot(0)
 	if err != nil {
 		t.Fatalf("validateBlockProducerStartup: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestValidateBlockProducerLedger_DevnetVRFMismatchWarns(t *testing.T) {
 	cardanoCfg := shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour))
 	n := newTestNodeForBP(t, true, vrf, kes, opcert, cardanoCfg)
 	n.config.network = "devnet"
-	creds, err := n.validateBlockProducerStartup()
+	creds, err := n.validateBlockProducerStartupAtSlot(0)
 	if err != nil {
 		t.Fatalf("validateBlockProducerStartup: %v", err)
 	}


### PR DESCRIPTION
Closes #2785 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leader election and KES period calculations to use era-aware absolute slots (including Byron-era prefixes), preventing wrong schedules and KES skew on preprod/mainnet. Closes #2785.

- **Bug Fixes**
  - Leader schedules are computed over `EpochSlotRange` from `ledger/hardfork.Summary` and persisted schedules are validated against this range; `ScheduleFormatVersion` bumped to 2.
  - KES period is derived from the absolute slot: `CurrentKESPeriod(currentSlot, slotsPerKESPeriod)` and `CurrentKESPeriodFromGenesis(genesis, currentSlot)`; forger uses this for metrics and forging. `WallClockKESPeriod` remains for tests.
  - Block producer startup now validates the opcert against the ledger’s current slot and requires Shelley genesis and ledger state.
  - Added `ledger/hardfork.Summary.EpochInfo` and `ledger.LedgerState.EpochInfo` to resolve epoch boundaries with Byron offsets.

- **Migration**
  - Replace `SlotsPerEpoch()` with `EpochSlotRange(epoch)` in `EpochInfoProvider`.
  - Update scheduler API: `leader.NewCalculator(activeSlotCoeff)` (no `slotsPerEpoch`), and pass `EpochSlotRange` to `CalculateSchedule`.
  - Update KES helpers: use `CurrentKESPeriod(currentSlot, slotsPerKESPeriod)` or `CurrentKESPeriodFromGenesis(genesis, currentSlot)`; `PoolCredentials.ValidateKESPeriod` now takes `currentSlot`.
  - Persisted schedules will be recomputed due to `ScheduleFormatVersion = 2`.

<sup>Written for commit 5dced091ef445f10ea461425c7704146a32420a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added epoch boundary information to help surface start slot, era, and slot length for any epoch.
  * Leader schedule generation now uses explicit epoch slot ranges for more accurate slot selection.

* **Bug Fixes**
  * Improved KES period handling to use chain slots instead of wall-clock time, reducing expiry and boundary errors.
  * Block producer startup validation now checks credentials against the current ledger slot for better accuracy.

* **Documentation**
  * Updated architecture notes to reflect the latest epoch, leader election, and forging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->