### PR TITLE
fix(blockfrost): populate address and transaction UTxO datum/referenc…

### DIFF
--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -2036,21 +2036,86 @@ func (a *NodeAdapter) AddressUTXOs(
 		)
 	}
 
+	// Inline datum and reference script are not persisted in metadata rows, so
+	// resolve each paged UTxO's CBOR (hot cache -> block LRU -> cold blob) and
+	// recover them from the decoded output. Missing entries degrade to nil
+	// rather than failing the whole listing.
+	utxoCbor, err := a.addressUtxoCbor(paged)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"resolve CBOR for address UTxOs %q: %w",
+			address,
+			err,
+		)
+	}
+
 	ret := make([]AddressUTXOInfo, 0, len(paged))
 	for _, utxo := range paged {
 		txKey := hex.EncodeToString(utxo.TxId)
+		var inlineDatum, referenceScriptHash *string
+		if cborBytes := utxoCbor[utxoRef(utxo.Utxo)]; len(cborBytes) > 0 {
+			if output, decodeErr := gledger.NewTransactionOutputFromCbor(
+				cborBytes,
+			); decodeErr == nil {
+				inlineDatum, referenceScriptHash = utxoDatumAndScriptRef(output)
+			}
+		}
 		ret = append(ret, AddressUTXOInfo{
 			Address:             address,
 			TxHash:              txKey,
+			TxIndex:             utxo.OutputIdx,
 			OutputIndex:         utxo.OutputIdx,
 			Amount:              addressAmountsFromUtxo(utxo.Utxo),
 			Block:               txBlockHashes[txKey],
 			DataHash:            optionalHexString(utxo.DatumHash),
-			InlineDatum:         nil,
-			ReferenceScriptHash: nil,
+			InlineDatum:         inlineDatum,
+			ReferenceScriptHash: referenceScriptHash,
 		})
 	}
 	return ret, total, nil
+}
+
+// addressUtxoCbor resolves the raw output CBOR for the given UTxOs in a single
+// batch, keyed by UtxoRef. It is used to recover the inline datum and reference
+// script, which are not stored in metadata rows.
+func (a *NodeAdapter) addressUtxoCbor(
+	utxos []models.UtxoWithOrdering,
+) (map[database.UtxoRef][]byte, error) {
+	if len(utxos) == 0 {
+		return map[database.UtxoRef][]byte{}, nil
+	}
+	seen := make(map[database.UtxoRef]struct{}, len(utxos))
+	refs := make([]database.UtxoRef, 0, len(utxos))
+	for _, utxo := range utxos {
+		ref := utxoRef(utxo.Utxo)
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return a.ledgerState.Database().CborCache().ResolveUtxoCborBatch(refs)
+}
+
+// utxoDatumAndScriptRef derives the Blockfrost inline_datum and
+// reference_script_hash fields from a decoded transaction output. It returns nil
+// for either field the output does not carry: a datum-hash-only output has no
+// inline datum, and most outputs have no reference script.
+func utxoDatumAndScriptRef(
+	output lcommon.TransactionOutput,
+) (inlineDatum *string, referenceScriptHash *string) {
+	if datum := output.Datum(); datum != nil {
+		if raw := datum.Cbor(); len(raw) > 0 {
+			encoded := hex.EncodeToString(raw)
+			inlineDatum = &encoded
+		}
+	}
+	if scriptRef := output.ScriptRef(); scriptRef != nil {
+		hash := scriptRef.Hash()
+		encoded := hex.EncodeToString(hash.Bytes())
+		referenceScriptHash = &encoded
+	}
+	return inlineDatum, referenceScriptHash
 }
 
 // AddressTransactions returns paginated transaction
@@ -2422,18 +2487,31 @@ func (a *NodeAdapter) TransactionUTXOs(
 	})
 	outputs := make([]TransactionOutputInfo, 0, len(txOutputs))
 	for _, output := range txOutputs {
+		// Resolve the decoded output so inline datum and reference script hash
+		// can be recovered from the transaction CBOR (they are not persisted in
+		// metadata rows). A phase-2 invalid transaction's collateral return is
+		// held separately from the discarded regular outputs.
+		var decodedOutput lcommon.TransactionOutput
+		if isCollateralReturn {
+			decodedOutput = decodedTx.CollateralReturn()
+		} else if outputIndex := int(output.OutputIdx); outputIndex < len(decodedOutputs) {
+			decodedOutput = decodedOutputs[outputIndex]
+		}
 		address := ""
-		outputIndex := int(output.OutputIdx)
-		if outputIndex < len(decodedOutputs) {
-			address = decodedOutputs[outputIndex].Address().String()
+		var inlineDatum, referenceScriptHash *string
+		if decodedOutput != nil {
+			address = decodedOutput.Address().String()
+			inlineDatum, referenceScriptHash = utxoDatumAndScriptRef(
+				decodedOutput,
+			)
 		}
 		outputs = append(outputs, TransactionOutputInfo{
 			Address:             address,
 			Amount:              addressAmountsFromUtxo(output),
 			OutputIndex:         output.OutputIdx,
 			DataHash:            optionalHexString(output.DatumHash),
-			InlineDatum:         optionalHexString(output.Datum),
-			ReferenceScriptHash: nil,
+			InlineDatum:         inlineDatum,
+			ReferenceScriptHash: referenceScriptHash,
 			Collateral:          isCollateralReturn,
 		})
 	}
@@ -3281,6 +3359,16 @@ func (a *NodeAdapter) transactionInputInfoFromUtxo(
 	if err != nil {
 		return TransactionInputInfo{}, err
 	}
+	// Inputs reference outputs produced by earlier transactions; their inline
+	// datum and reference script are recovered from the resolved output CBOR
+	// (populated by transactionInputCbor) since neither is persisted in
+	// metadata rows. Missing CBOR degrades both fields to nil.
+	var inlineDatum, referenceScriptHash *string
+	if len(utxo.Cbor) > 0 {
+		if output, decodeErr := utxo.Decode(); decodeErr == nil {
+			inlineDatum, referenceScriptHash = utxoDatumAndScriptRef(output)
+		}
+	}
 	return TransactionInputInfo{
 		Address:             addr,
 		Amount:              addressAmountsFromUtxo(utxo),
@@ -3288,8 +3376,8 @@ func (a *NodeAdapter) transactionInputInfoFromUtxo(
 		OutputIndex:         utxo.OutputIdx,
 		DataHash:            optionalHexString(utxo.DatumHash),
 		Collateral:          collateral,
-		InlineDatum:         optionalHexString(utxo.Datum),
-		ReferenceScriptHash: nil,
+		InlineDatum:         inlineDatum,
+		ReferenceScriptHash: referenceScriptHash,
 		Reference:           reference,
 	}, nil
 }

--- a/api/blockfrost/adapter_utxo_datum_test.go
+++ b/api/blockfrost/adapter_utxo_datum_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDatumAddr = "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
+
+// decodeBabbageOutput builds a Babbage (map-form) transaction output CBOR with
+// the optional datum option and reference script, then decodes it through the
+// same path the adapter uses (NewTransactionOutputFromCbor). This mirrors both
+// live sync and API-mode historical backfill, where inline datum and reference
+// script are recovered from output CBOR rather than persisted metadata columns.
+func decodeBabbageOutput(
+	t *testing.T,
+	datumOption any,
+	scriptRef *lcommon.ScriptRef,
+) lcommon.TransactionOutput {
+	t.Helper()
+	addr, err := lcommon.NewAddress(testDatumAddr)
+	require.NoError(t, err)
+	addrBytes, err := addr.Bytes()
+	require.NoError(t, err)
+
+	outputMap := map[int]any{
+		0: addrBytes,
+		1: uint64(1_000_000),
+	}
+	if datumOption != nil {
+		outputMap[2] = datumOption
+	}
+	if scriptRef != nil {
+		outputMap[3] = scriptRef
+	}
+	cborBytes, err := cbor.Encode(outputMap)
+	require.NoError(t, err)
+	decoded, err := gledger.NewTransactionOutputFromCbor(cborBytes)
+	require.NoError(t, err)
+	return decoded
+}
+
+func TestUtxoDatumAndScriptRefInlineAndScript(t *testing.T) {
+	// Inline datum option is [1, 24(<datum cbor>)] per CIP-0032.
+	datum := lcommon.Datum{Data: data.NewInteger(big.NewInt(42))}
+	datumCbor, err := cbor.Encode(&datum)
+	require.NoError(t, err)
+	datumOption := []any{
+		1,
+		cbor.Tag{Number: 24, Content: datumCbor},
+	}
+
+	script := lcommon.PlutusV2Script([]byte{0x01, 0x02, 0x03, 0x04})
+	scriptRef := &lcommon.ScriptRef{
+		Type:   lcommon.ScriptRefTypePlutusV2,
+		Script: script,
+	}
+
+	output := decodeBabbageOutput(t, datumOption, scriptRef)
+
+	inlineDatum, referenceScriptHash := utxoDatumAndScriptRef(output)
+	require.NotNil(t, inlineDatum)
+	assert.Equal(t, hex.EncodeToString(datumCbor), *inlineDatum)
+	require.NotNil(t, referenceScriptHash)
+	assert.Equal(
+		t,
+		hex.EncodeToString(script.Hash().Bytes()),
+		*referenceScriptHash,
+	)
+}
+
+func TestUtxoDatumAndScriptRefDatumHashOnly(t *testing.T) {
+	// A datum-hash-only output (option [0, <hash>]) carries no inline datum and
+	// no reference script, so both Blockfrost fields must be nil (data_hash is
+	// populated elsewhere from the persisted column).
+	datumHash := lcommon.NewBlake2b256(make([]byte, 32))
+	datumOption := []any{0, datumHash}
+
+	output := decodeBabbageOutput(t, datumOption, nil)
+
+	inlineDatum, referenceScriptHash := utxoDatumAndScriptRef(output)
+	assert.Nil(t, inlineDatum)
+	assert.Nil(t, referenceScriptHash)
+}
+
+func TestUtxoDatumAndScriptRefNone(t *testing.T) {
+	output := decodeBabbageOutput(t, nil, nil)
+	inlineDatum, referenceScriptHash := utxoDatumAndScriptRef(output)
+	assert.Nil(t, inlineDatum)
+	assert.Nil(t, referenceScriptHash)
+}

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -700,6 +700,7 @@ func (b *Blockfrost) handleAddressUTXOs(
 		resp = append(resp, AddressUTXOResponse{
 			Address:             utxo.Address,
 			TxHash:              utxo.TxHash,
+			TxIndex:             int(utxo.TxIndex),
 			OutputIndex:         int(utxo.OutputIndex),
 			Amount:              convertAddressAmounts(utxo.Amount),
 			Block:               utxo.Block,

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -383,8 +383,11 @@ type AddressAmountInfo struct {
 // AddressUTXOInfo holds address UTxO data needed by the
 // API.
 type AddressUTXOInfo struct {
-	Address             string
-	TxHash              string
+	Address string
+	TxHash  string
+	// TxIndex is the deprecated Blockfrost alias for OutputIndex (the UTxO's
+	// index within its producing transaction); it carries the same value.
+	TxIndex             uint32
 	OutputIndex         uint32
 	Amount              []AddressAmountInfo
 	Block               string

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -201,8 +201,11 @@ type AddressAmountResponse struct {
 // AddressUTXOResponse represents a Blockfrost address
 // UTxO object.
 type AddressUTXOResponse struct {
-	Address             string                  `json:"address"`
-	TxHash              string                  `json:"tx_hash"`
+	Address string `json:"address"`
+	TxHash  string `json:"tx_hash"`
+	// TxIndex is a deprecated Blockfrost alias for OutputIndex ("UTXO index
+	// in the transaction"), kept for schema compatibility.
+	TxIndex             int                     `json:"tx_index"`
 	OutputIndex         int                     `json:"output_index"`
 	Amount              []AddressAmountResponse `json:"amount"`
 	Block               string                  `json:"block"`


### PR DESCRIPTION
Closes #2484 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates inline datum and reference script hash for address and transaction UTxOs in the `blockfrost` API by decoding output CBOR. Also adds the deprecated `tx_index` alias on address UTxOs for Blockfrost schema parity.

- **Bug Fixes**
  - AddressUTXOs: derive inline datum and reference script hash from output CBOR; missing data returns nil.
  - TransactionUTXOs and inputs: same derivation, including collateral return outputs.
  - Batch CBOR resolution for address UTxOs to reduce lookups.
  - Added unit tests for datum and script-ref extraction.

<sup>Written for commit 15d1e2a16f48de2cee1982f7eea586bbcde3f5c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Address and transaction UTxO responses now include inline datum data and reference script hashes when available.
  * Added the deprecated `tx_index` field as an alias for `output_index` for compatibility with Blockfrost-style responses.
* **Bug Fixes**
  * UTxO listings now correctly derive metadata from transaction outputs instead of returning missing values.
  * Missing output data is handled gracefully without failing requests.
* **Tests**
  * Added coverage for inline datums, datum hashes, reference scripts, and outputs without optional metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->