### PR TITLE
fix(ledger): Enforce inbound block envelope validation

### DIFF
--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -59,6 +60,9 @@ func validateInboundBlockEnvelope(
 	if err := validateByronEbbPlacement(block); err != nil {
 		return err
 	}
+	if isNilBlockHeader(block.Header()) {
+		return errors.New("validate inbound block envelope: nil block header")
+	}
 	if err := validateBlockOrder(block, parent); err != nil {
 		return err
 	}
@@ -66,6 +70,20 @@ func validateInboundBlockEnvelope(
 		return nil
 	}
 	return validateBlockSizes(block, pparams)
+}
+
+func isNilBlockHeader(header lcommon.BlockHeader) bool {
+	if header == nil {
+		return true
+	}
+	value := reflect.ValueOf(header)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface,
+		reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // validateBlockOrder checks that a block follows its parent by block number

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -34,6 +34,16 @@ type envelopeParent struct {
 	slot        uint64
 	blockNumber uint64
 	origin      bool
+	byronEbb    bool
+}
+
+func envelopeParentFromBlock(block gledger.Block) envelopeParent {
+	_, isEbb := block.(*byron.ByronEpochBoundaryBlock)
+	return envelopeParent{
+		slot:        block.SlotNumber(),
+		blockNumber: block.BlockNumber(),
+		byronEbb:    isEbb,
+	}
 }
 
 // validateInboundBlockEnvelope runs the consensus envelope checks that must
@@ -88,6 +98,10 @@ func validateBlockOrder(block gledger.Block, parent envelopeParent) error {
 			block.BlockNumber(),
 			parent.blockNumber,
 		)
+	}
+	if block.SlotNumber() == parent.slot &&
+		(parent.byronEbb && block.Era().Id == byron.EraIdByron) {
+		return nil
 	}
 	if block.SlotNumber() <= parent.slot {
 		return fmt.Errorf(

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -43,7 +44,7 @@ func validateInboundBlockEnvelope(
 	parent envelopeParent,
 ) error {
 	if block == nil {
-		return fmt.Errorf("validate inbound block envelope: nil block")
+		return errors.New("validate inbound block envelope: nil block")
 	}
 	if err := validateByronEbbPlacement(block); err != nil {
 		return err
@@ -67,14 +68,14 @@ func validateBlockOrder(block gledger.Block, parent envelopeParent) error {
 	if isEbb {
 		if block.BlockNumber() != parent.blockNumber {
 			return fmt.Errorf(
-				"Byron EBB block number %d does not match parent block number %d",
+				"byron EBB block number %d does not match parent block number %d",
 				block.BlockNumber(),
 				parent.blockNumber,
 			)
 		}
 		if block.SlotNumber() < parent.slot {
 			return fmt.Errorf(
-				"Byron EBB slot %d precedes parent slot %d",
+				"byron EBB slot %d precedes parent slot %d",
 				block.SlotNumber(),
 				parent.slot,
 			)
@@ -106,19 +107,19 @@ func validateByronEbbPlacement(block gledger.Block) error {
 		return nil
 	}
 	if ebb.BlockHeader == nil {
-		return fmt.Errorf("Byron EBB has nil header")
+		return errors.New("byron EBB has nil header")
 	}
 	slot := ebb.SlotNumber()
 	if slot%byron.ByronSlotsPerEpoch != 0 {
 		return fmt.Errorf(
-			"Byron EBB slot %d is not an epoch boundary slot",
+			"byron EBB slot %d is not an epoch boundary slot",
 			slot,
 		)
 	}
 	expectedSlot := ebb.BlockHeader.ConsensusData.Epoch * byron.ByronSlotsPerEpoch
 	if slot != expectedSlot {
 		return fmt.Errorf(
-			"Byron EBB slot %d does not match epoch %d boundary slot %d",
+			"byron EBB slot %d does not match epoch %d boundary slot %d",
 			slot,
 			ebb.BlockHeader.ConsensusData.Epoch,
 			expectedSlot,

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+type envelopeParent struct {
+	slot        uint64
+	blockNumber uint64
+	origin      bool
+}
+
+// validateInboundBlockEnvelope runs the consensus envelope checks that must
+// pass before header crypto and body validation accept an inbound block.
+func validateInboundBlockEnvelope(
+	block gledger.Block,
+	pparams lcommon.ProtocolParameters,
+	parent envelopeParent,
+) error {
+	if block == nil {
+		return fmt.Errorf("validate inbound block envelope: nil block")
+	}
+	if err := validateByronEbbPlacement(block); err != nil {
+		return err
+	}
+	if err := validateBlockOrder(block, parent); err != nil {
+		return err
+	}
+	if block.Era().Id == byron.EraIdByron {
+		return nil
+	}
+	return validateBlockSizes(block, pparams)
+}
+
+// validateBlockOrder checks that a block follows its parent by block number
+// and slot, including the Byron EBB exception for shared number/slot.
+func validateBlockOrder(block gledger.Block, parent envelopeParent) error {
+	if parent.origin {
+		return nil
+	}
+	_, isEbb := block.(*byron.ByronEpochBoundaryBlock)
+	if isEbb {
+		if block.BlockNumber() != parent.blockNumber {
+			return fmt.Errorf(
+				"Byron EBB block number %d does not match parent block number %d",
+				block.BlockNumber(),
+				parent.blockNumber,
+			)
+		}
+		if block.SlotNumber() < parent.slot {
+			return fmt.Errorf(
+				"Byron EBB slot %d precedes parent slot %d",
+				block.SlotNumber(),
+				parent.slot,
+			)
+		}
+		return nil
+	}
+	if block.BlockNumber() != parent.blockNumber+1 {
+		return fmt.Errorf(
+			"block number %d does not follow parent block number %d",
+			block.BlockNumber(),
+			parent.blockNumber,
+		)
+	}
+	if block.SlotNumber() <= parent.slot {
+		return fmt.Errorf(
+			"block slot %d does not follow parent slot %d",
+			block.SlotNumber(),
+			parent.slot,
+		)
+	}
+	return nil
+}
+
+// validateByronEbbPlacement rejects Byron epoch boundary blocks outside their
+// declared epoch boundary slot, while ignoring non-EBB blocks.
+func validateByronEbbPlacement(block gledger.Block) error {
+	ebb, isEbb := block.(*byron.ByronEpochBoundaryBlock)
+	if !isEbb {
+		return nil
+	}
+	if ebb.BlockHeader == nil {
+		return fmt.Errorf("Byron EBB has nil header")
+	}
+	slot := ebb.SlotNumber()
+	if slot%byron.ByronSlotsPerEpoch != 0 {
+		return fmt.Errorf(
+			"Byron EBB slot %d is not an epoch boundary slot",
+			slot,
+		)
+	}
+	expectedSlot := ebb.BlockHeader.ConsensusData.Epoch * byron.ByronSlotsPerEpoch
+	if slot != expectedSlot {
+		return fmt.Errorf(
+			"Byron EBB slot %d does not match epoch %d boundary slot %d",
+			slot,
+			ebb.BlockHeader.ConsensusData.Epoch,
+			expectedSlot,
+		)
+	}
+	return nil
+}
+
+// validateBlockSizes enforces maxBlockHeaderSize and maxBlockBodySize for
+// Shelley-and-later inbound blocks using protocol parameter limits.
+func validateBlockSizes(
+	block gledger.Block,
+	pparams lcommon.ProtocolParameters,
+) error {
+	maxBodySize, maxHeaderSize, ok := protocolBlockSizeLimits(pparams)
+	if !ok {
+		return fmt.Errorf(
+			"block size validation unsupported for protocol parameters %T",
+			pparams,
+		)
+	}
+	headerCbor := block.Header().Cbor()
+	if uint64(len(headerCbor)) > maxHeaderSize {
+		return fmt.Errorf(
+			"block header size %d exceeds maxBlockHeaderSize %d",
+			len(headerCbor),
+			maxHeaderSize,
+		)
+	}
+	actualBodySize, err := serializedBlockBodySize(block)
+	if err != nil {
+		return err
+	}
+	declaredBodySize := block.BlockBodySize()
+	if declaredBodySize != actualBodySize {
+		return fmt.Errorf(
+			"block body size mismatch: header declares %d, actual size is %d",
+			declaredBodySize,
+			actualBodySize,
+		)
+	}
+	if actualBodySize > maxBodySize {
+		return fmt.Errorf(
+			"block body size %d exceeds maxBlockBodySize %d",
+			actualBodySize,
+			maxBodySize,
+		)
+	}
+	return nil
+}
+
+// serializedBlockBodySize measures the serialized body portion of block CBOR
+// using the same era-specific field layout that the header declaration covers.
+func serializedBlockBodySize(block gledger.Block) (uint64, error) {
+	blockCbor := block.Cbor()
+	if len(blockCbor) == 0 {
+		return 0, fmt.Errorf(
+			"block at slot %d has no CBOR for body size validation",
+			block.SlotNumber(),
+		)
+	}
+	var fields []cbor.RawMessage
+	if _, err := cbor.Decode(blockCbor, &fields); err != nil {
+		return 0, fmt.Errorf(
+			"decode block CBOR for body size validation: %w",
+			err,
+		)
+	}
+	if len(fields) < 2 {
+		return 0, fmt.Errorf(
+			"block CBOR has %d fields, expected at least header and body",
+			len(fields),
+		)
+	}
+	if block.Era().Id == dijkstra.EraIdDijkstra {
+		return uint64(len(fields[1])), nil
+	}
+	var size uint64
+	for _, field := range fields[1:] {
+		size += uint64(len(field))
+	}
+	return size, nil
+}
+
+// protocolBlockSizeLimits extracts max block body/header size protocol
+// parameters from eras whose inbound block sizes can be validated here.
+func protocolBlockSizeLimits(
+	pparams lcommon.ProtocolParameters,
+) (maxBodySize, maxHeaderSize uint64, ok bool) {
+	switch pp := pparams.(type) {
+	case *shelley.ShelleyProtocolParameters:
+		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+	case *mary.MaryProtocolParameters:
+		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+	case *alonzo.AlonzoProtocolParameters:
+		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+	case *babbage.BabbageProtocolParameters:
+		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+	case *conway.ConwayProtocolParameters:
+		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+	case *dijkstra.DijkstraProtocolParameters:
+		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+	default:
+		return 0, 0, false
+	}
+}

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -77,13 +77,16 @@ func isNilBlockHeader(header lcommon.BlockHeader) bool {
 		return true
 	}
 	value := reflect.ValueOf(header)
-	switch value.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface,
-		reflect.Map, reflect.Pointer, reflect.Slice:
+	kind := value.Kind()
+	if kind == reflect.Chan ||
+		kind == reflect.Func ||
+		kind == reflect.Interface ||
+		kind == reflect.Map ||
+		kind == reflect.Pointer ||
+		kind == reflect.Slice {
 		return value.IsNil()
-	default:
-		return false
 	}
+	return false
 }
 
 // validateBlockOrder checks that a block follows its parent by block number

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+type envelopeTestHeader struct {
+	cbor     []byte
+	bodySize uint64
+	slot     uint64
+	number   uint64
+	era      lcommon.Era
+}
+
+func (h *envelopeTestHeader) Hash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func (h *envelopeTestHeader) PrevHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+func (h *envelopeTestHeader) BlockNumber() uint64 { return h.number }
+func (h *envelopeTestHeader) SlotNumber() uint64  { return h.slot }
+func (h *envelopeTestHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+func (h *envelopeTestHeader) BlockBodySize() uint64 { return h.bodySize }
+func (h *envelopeTestHeader) Era() lcommon.Era      { return h.era }
+func (h *envelopeTestHeader) Cbor() []byte          { return h.cbor }
+func (h *envelopeTestHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+type envelopeTestBlock struct {
+	header *envelopeTestHeader
+	cbor   []byte
+}
+
+func (b *envelopeTestBlock) Header() lcommon.BlockHeader { return b.header }
+func (b *envelopeTestBlock) Hash() lcommon.Blake2b256    { return b.header.Hash() }
+func (b *envelopeTestBlock) PrevHash() lcommon.Blake2b256 {
+	return b.header.PrevHash()
+}
+func (b *envelopeTestBlock) BlockNumber() uint64 { return b.header.BlockNumber() }
+func (b *envelopeTestBlock) SlotNumber() uint64  { return b.header.SlotNumber() }
+func (b *envelopeTestBlock) IssuerVkey() lcommon.IssuerVkey {
+	return b.header.IssuerVkey()
+}
+func (b *envelopeTestBlock) BlockBodySize() uint64 { return b.header.BlockBodySize() }
+func (b *envelopeTestBlock) Era() lcommon.Era      { return b.header.Era() }
+func (b *envelopeTestBlock) Cbor() []byte          { return b.cbor }
+func (b *envelopeTestBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return b.header.BlockBodyHash()
+}
+func (b *envelopeTestBlock) Type() int { return 0 }
+func (b *envelopeTestBlock) Transactions() []lcommon.Transaction {
+	return nil
+}
+func (b *envelopeTestBlock) Utxorpc() (*utxorpc.Block, error) {
+	return nil, nil
+}
+
+// TestValidateInboundBlockEnvelopeSizes covers header/body size limits and
+// the requirement that the declared body size matches serialized block CBOR.
+func TestValidateInboundBlockEnvelopeSizes(t *testing.T) {
+	parent := envelopeParent{slot: 9, blockNumber: 41}
+	pparams := &shelley.ShelleyProtocolParameters{
+		MaxBlockBodySize:   3,
+		MaxBlockHeaderSize: 4,
+	}
+	validHeader := mustEnvelopeCbor(t, "hdr")
+	validBlockCbor := mustEnvelopeBlockCbor(t, validHeader,
+		cbor.RawMessage{0x80},
+		cbor.RawMessage{0x80},
+		cbor.RawMessage{0xa0},
+	)
+
+	tests := []struct {
+		name       string
+		headerCbor []byte
+		blockCbor  []byte
+		bodySize   uint64
+		pparams    *shelley.ShelleyProtocolParameters
+		wantErr    string
+	}{
+		{
+			name:       "valid exact limits",
+			headerCbor: validHeader,
+			blockCbor:  validBlockCbor,
+			bodySize:   3,
+			pparams:    pparams,
+		},
+		{
+			name:       "header over limit",
+			headerCbor: mustEnvelopeCbor(t, "long-header"),
+			blockCbor:  validBlockCbor,
+			bodySize:   3,
+			pparams:    pparams,
+			wantErr:    "exceeds maxBlockHeaderSize",
+		},
+		{
+			name:       "declared body size mismatch",
+			headerCbor: validHeader,
+			blockCbor:  validBlockCbor,
+			bodySize:   2,
+			pparams:    pparams,
+			wantErr:    "block body size mismatch",
+		},
+		{
+			name:       "body over limit",
+			headerCbor: validHeader,
+			blockCbor:  validBlockCbor,
+			bodySize:   3,
+			pparams: &shelley.ShelleyProtocolParameters{
+				MaxBlockBodySize:   2,
+				MaxBlockHeaderSize: 4,
+			},
+			wantErr: "exceeds maxBlockBodySize",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := &envelopeTestBlock{
+				header: &envelopeTestHeader{
+					cbor:     tt.headerCbor,
+					bodySize: tt.bodySize,
+					slot:     10,
+					number:   42,
+					era:      shelley.EraShelley,
+				},
+				cbor: tt.blockCbor,
+			}
+			err := validateInboundBlockEnvelope(block, tt.pparams, parent)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestValidateInboundBlockEnvelopeOrdering checks normal block number and
+// slot ordering failures, including Byron main blocks reusing parent numbers.
+func TestValidateInboundBlockEnvelopeOrdering(t *testing.T) {
+	parent := envelopeParent{slot: 10, blockNumber: 5}
+	pparams := &shelley.ShelleyProtocolParameters{
+		MaxBlockBodySize:   3,
+		MaxBlockHeaderSize: 4,
+	}
+	headerCbor := mustEnvelopeCbor(t, "hdr")
+	blockCbor := mustEnvelopeBlockCbor(t, headerCbor,
+		cbor.RawMessage{0x80},
+		cbor.RawMessage{0x80},
+		cbor.RawMessage{0xa0},
+	)
+
+	tests := []struct {
+		name    string
+		slot    uint64
+		number  uint64
+		era     lcommon.Era
+		wantErr string
+	}{
+		{
+			name:    "normal block equal slot rejected",
+			slot:    10,
+			number:  6,
+			era:     shelley.EraShelley,
+			wantErr: "does not follow parent slot",
+		},
+		{
+			name:    "normal block non-successor number rejected",
+			slot:    11,
+			number:  7,
+			era:     shelley.EraShelley,
+			wantErr: "does not follow parent block number",
+		},
+		{
+			name:    "Byron main block cannot reuse parent number",
+			slot:    11,
+			number:  5,
+			era:     byron.EraByron,
+			wantErr: "does not follow parent block number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := &envelopeTestBlock{
+				header: &envelopeTestHeader{
+					cbor:     headerCbor,
+					bodySize: 3,
+					slot:     tt.slot,
+					number:   tt.number,
+					era:      tt.era,
+				},
+				cbor: blockCbor,
+			}
+			err := validateInboundBlockEnvelope(block, pparams, parent)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestValidateBlockOrderAllowsOriginParent verifies the first block is not
+// compared against a synthetic parent when the chain tip is origin.
+func TestValidateBlockOrderAllowsOriginParent(t *testing.T) {
+	block := &envelopeTestBlock{
+		header: &envelopeTestHeader{
+			slot:   0,
+			number: 0,
+			era:    shelley.EraShelley,
+		},
+	}
+
+	require.NoError(t, validateBlockOrder(block, envelopeParent{origin: true}))
+}
+
+// TestValidateInboundBlockEnvelopeByronEbbOrdering covers the Byron EBB rule
+// that an EBB shares its parent's block number instead of incrementing it.
+func TestValidateInboundBlockEnvelopeByronEbbOrdering(t *testing.T) {
+	parent := envelopeParent{
+		slot:        byron.ByronSlotsPerEpoch,
+		blockNumber: 7,
+	}
+	ebb := &byron.ByronEpochBoundaryBlock{
+		BlockHeader: &byron.ByronEpochBoundaryBlockHeader{},
+	}
+	ebb.BlockHeader.ConsensusData.Epoch = 1
+	ebb.BlockHeader.ConsensusData.Difficulty.Value = parent.blockNumber
+	require.NoError(t, validateInboundBlockEnvelope(ebb, nil, parent))
+
+	ebb.BlockHeader.ConsensusData.Difficulty.Value = parent.blockNumber + 1
+	err := validateInboundBlockEnvelope(ebb, nil, parent)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match parent block number")
+}
+
+// TestValidateByronEbbPlacementRejectsNilHeader ensures malformed Byron EBBs
+// fail before placement or ordering logic reads header consensus data.
+func TestValidateByronEbbPlacementRejectsNilHeader(t *testing.T) {
+	err := validateByronEbbPlacement(&byron.ByronEpochBoundaryBlock{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil header")
+
+	err = validateInboundBlockEnvelope(
+		&byron.ByronEpochBoundaryBlock{},
+		nil,
+		envelopeParent{},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil header")
+}
+
+func mustEnvelopeCbor(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := cbor.Encode(value)
+	require.NoError(t, err)
+	return data
+}
+
+func mustEnvelopeBlockCbor(
+	t *testing.T,
+	header []byte,
+	bodyFields ...cbor.RawMessage,
+) []byte {
+	t.Helper()
+	fields := make([]cbor.RawMessage, 0, 1+len(bodyFields))
+	fields = append(fields, cbor.RawMessage(header))
+	fields = append(fields, bodyFields...)
+	data, err := cbor.Encode(fields)
+	require.NoError(t, err)
+	return data
+}

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -295,6 +295,18 @@ func TestValidateByronEbbPlacementRejectsNilHeader(t *testing.T) {
 	require.Contains(t, err.Error(), "nil header")
 }
 
+// TestValidateInboundBlockEnvelopeRejectsNilHeader ensures malformed non-Byron
+// blocks fail before ordering or size validation can dereference the header.
+func TestValidateInboundBlockEnvelopeRejectsNilHeader(t *testing.T) {
+	err := validateInboundBlockEnvelope(
+		&envelopeTestBlock{},
+		&shelley.ShelleyProtocolParameters{},
+		envelopeParent{},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil block header")
+}
+
 func mustEnvelopeCbor(t *testing.T, value any) []byte {
 	t.Helper()
 	data, err := cbor.Encode(value)

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -240,6 +240,25 @@ func TestValidateBlockOrderAllowsOriginParent(t *testing.T) {
 	require.NoError(t, validateBlockOrder(block, envelopeParent{origin: true}))
 }
 
+// TestValidateBlockOrderAllowsByronMainBlockAfterEbb verifies that the main
+// block at a Byron epoch boundary may share the EBB parent's slot.
+func TestValidateBlockOrderAllowsByronMainBlockAfterEbb(t *testing.T) {
+	block := &envelopeTestBlock{
+		header: &envelopeTestHeader{
+			slot:   10,
+			number: 6,
+			era:    byron.EraByron,
+		},
+	}
+	parent := envelopeParent{
+		slot:        10,
+		blockNumber: 5,
+		byronEbb:    true,
+	}
+
+	require.NoError(t, validateBlockOrder(block, parent))
+}
+
 // TestValidateInboundBlockEnvelopeByronEbbOrdering covers the Byron EBB rule
 // that an EBB shares its parent's block number instead of incrementing it.
 func TestValidateInboundBlockEnvelopeByronEbbOrdering(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3257,6 +3257,8 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 		// Process batch in groups of batchSize to stay under DB txn limits
 		var tipForLog ochainsync.Tip
 		var checker ForgedBlockChecker
+		var parentEnvelope envelopeParent
+		var parentEnvelopeSet bool
 		for i = 0; i < len(nextBatch); i += batchSize {
 			end = min(
 				len(nextBatch),
@@ -3311,10 +3313,13 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			runningNonce := snapshotNonce
 			// Track expected previous hash for batch processing - updated after each block
 			expectedPrevHash := snapshotTipHash
-			parentEnvelope := envelopeParent{
-				slot:        snapshotTip.Point.Slot,
-				blockNumber: snapshotTip.BlockNumber,
-				origin:      len(snapshotTip.Point.Hash) == 0,
+			if !parentEnvelopeSet {
+				parentEnvelope = envelopeParent{
+					slot:        snapshotTip.Point.Slot,
+					blockNumber: snapshotTip.BlockNumber,
+					origin:      len(snapshotTip.Point.Hash) == 0,
+				}
+				parentEnvelopeSet = true
 			}
 			// Flag to enable validation after transaction commits (set inside callback,
 			// applied after commit to avoid mutating in-memory state on txn failure)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3440,10 +3440,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 							BlockNumber: next.BlockNumber(),
 						}
 						expectedPrevHash = tmpPoint.Hash
-						parentEnvelope = envelopeParent{
-							slot:        next.SlotNumber(),
-							blockNumber: next.BlockNumber(),
-						}
+						parentEnvelope = envelopeParentFromBlock(next)
 						blocksProcessed++
 						continue
 					}
@@ -3475,10 +3472,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					}
 					// Update expected prev hash for next block in batch
 					expectedPrevHash = tmpPoint.Hash
-					parentEnvelope = envelopeParent{
-						slot:        next.SlotNumber(),
-						blockNumber: next.BlockNumber(),
-					}
+					parentEnvelope = envelopeParentFromBlock(next)
 					// Track pending tip (will be committed after txn succeeds)
 					pendingTip = ochainsync.Tip{
 						Point:       tmpPoint,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3278,6 +3278,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			snapshotEra := ls.currentEra
 			snapshotPParams := ls.currentPParams
 			snapshotPrevEraPParams := ls.prevEraPParams
+			snapshotTip := ls.currentTip
 			snapshotTipHash := ls.currentTip.Point.Hash
 			snapshotNonce := ls.currentTipBlockNonce
 			localCheckpointWritten := ls.checkpointWrittenForEpoch
@@ -3310,6 +3311,11 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			runningNonce := snapshotNonce
 			// Track expected previous hash for batch processing - updated after each block
 			expectedPrevHash := snapshotTipHash
+			parentEnvelope := envelopeParent{
+				slot:        snapshotTip.Point.Slot,
+				blockNumber: snapshotTip.BlockNumber,
+				origin:      len(snapshotTip.Point.Hash) == 0,
+			}
 			// Flag to enable validation after transaction commits (set inside callback,
 			// applied after commit to avoid mutating in-memory state on txn failure)
 			var wantEnableValidation bool
@@ -3434,6 +3440,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 							BlockNumber: next.BlockNumber(),
 						}
 						expectedPrevHash = tmpPoint.Hash
+						parentEnvelope = envelopeParent{
+							slot:        next.SlotNumber(),
+							blockNumber: next.BlockNumber(),
+						}
 						blocksProcessed++
 						continue
 					}
@@ -3450,6 +3460,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 						shouldValidateBlock,
 						skipPhase2Validation,
 						expectedPrevHash,
+						parentEnvelope,
 						blockOffsets,
 						snapshotEra,
 						snapshotPParams,
@@ -3464,6 +3475,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					}
 					// Update expected prev hash for next block in batch
 					expectedPrevHash = tmpPoint.Hash
+					parentEnvelope = envelopeParent{
+						slot:        next.SlotNumber(),
+						blockNumber: next.BlockNumber(),
+					}
 					// Track pending tip (will be committed after txn succeeds)
 					pendingTip = ochainsync.Tip{
 						Point:       tmpPoint,
@@ -3652,6 +3667,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 	shouldValidate bool,
 	skipPhase2Validation bool,
 	expectedPrevHash []byte,
+	parent envelopeParent,
 	offsets *database.BlockIngestionResult,
 	currentEra eras.EraDesc,
 	pparams lcommon.ProtocolParameters,
@@ -3684,6 +3700,13 @@ func (ls *LedgerState) ledgerProcessBlock(
 	// one ahead of current pparams. Skipped on testnets pre-Dijkstra
 	// per cardano-ledger PR 5785.
 	if shouldValidate {
+		if err := validateInboundBlockEnvelope(
+			block,
+			pparams,
+			parent,
+		); err != nil {
+			return nil, err
+		}
 		if err := ls.validateBlockHeaderProtocolVersion(
 			block.Header(), pparams,
 		); err != nil {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4049,6 +4049,7 @@ func TestLedgerProcessBlockTracksOpCertSequenceByIssuerVkeyHash(t *testing.T) {
 			false,
 			false,
 			nil,
+			envelopeParent{},
 			nil,
 			eras.BabbageEraDesc,
 			nil,


### PR DESCRIPTION
1. Added the remaining inbound envelope validation checks for validated blocks before header protocol/body processing. This enforces block size limits, block body size declaration consistency, block number/slot ordering, and Byron EBB placement rules through the existing shouldValidate gate.
2. Added `ledger/envelope_validation.go` for inbound envelope checks.
3. Added `validateInboundBlockEnvelope` as the single entry point for envelope validation.
4. Added max block body size validation using protocol parameter `MaxBlockBodySize`.
5. Added max block header size validation using `Header().Cbor().`
6. Added declared body size vs actual serialized body size validation.
7. Added block number successor validation and slot ordering validation.
8. Added Byron EBB special handling for shared parent block number / slot.
9. Added Byron EBB epoch-boundary slot validation.
10. Added origin-parent handling to avoid rejecting the first block from genesis/origin.
11. Updated `ledger/state.go` to track parent slot/block number during batch processing.
12. Updated `ledger/state.go` to pass parent envelope context into `ledgerProcessBlock`.
13. Gated the new envelope checks behind existing `shouldValidate`.
14. Added focused unit coverage for size limits, declared body size mismatches, normal block ordering failures, origin-parent handling, Byron EBB ordering and malformed Byron EBB headers.

Closes #2607 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inbound block envelope validation before header/body processing to reject malformed or out-of-order blocks. Handles Byron EBB placement and allows a same-slot Byron main block after an EBB, with parent context tracked across batch ingest.

- **Bug Fixes**
  - Run `validateInboundBlockEnvelope` before protocol/body validation (behind `shouldValidate`).
  - Enforce header/body size limits and declared vs actual body size from protocol params.
  - Enforce ordering: successor block number and slot; Byron EBB shared-number and epoch-boundary slot rules; allow Byron main block right after an EBB in the same slot.
  - Track parent slot/block number, origin, and EBB flag across batches; add tests for size limits, ordering (including EBB→main same‑slot), origin handling, and malformed Byron EBBs.

- **Refactors**
  - Fixed lints and updated tests to pass the new `envelopeParent` argument.

<sup>Written for commit e08c15efcdd3fccf6b29b39e14fc314f51213f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for inbound block envelopes, including block ordering, Byron EBB placement, and origin-chain handling.
  * Added protocol-aware header and body size checks for supported eras.
  * Enforced consistency between declared and serialized block body sizes.

* **Bug Fixes**
  * Rejects malformed or incorrectly ordered blocks before processing.
  * Prevents Byron blocks and EBBs from violating consensus ordering rules.

* **Tests**
  * Added coverage for envelope size validation, block ordering, origin handling, and malformed Byron EBB input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->