### PR TITLE
fix(blockfrost): populate asset mint history and metadata fields

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1693,6 +1693,17 @@ signers, and account/delegation/registration/reward endpoints. It uses an
 adapter pattern to translate between Dingo's internal state and Blockfrost
 response types and supports Blockfrost-style pagination headers.
 
+`GET /assets/{asset}` derives its mint-history fields from the API-mode
+`asset_mint_burn` table, which the transaction indexer populates from
+`tx.AssetMint()` (recorded in `SetTransaction`, `SetTransactionBatched`, and
+`SetGapBlockTransaction`; removed on rollback). `initial_mint_tx_hash` and
+`mint_or_burn_count` come from `MetadataStore.GetAssetMintBurnInfo`. On-chain
+metadata (`onchain_metadata`/`onchain_metadata_standard`) is resolved lazily in
+the adapter by loading the initial mint transaction's stored metadata and
+parsing its CIP-25 (label 721) entry for the policy/asset; no dedicated
+metadata table is kept. Off-chain `metadata` (token registry) and CIP-68
+datum metadata are not yet sourced and return `null`.
+
 ### Mesh API (`api/mesh/`)
 
 Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -187,6 +187,7 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `transaction` | `id`, `hash`, `block_hash`, `slot`, `block_index`, `type`, `fee`, `ttl`, `valid`, `metadata` | PK `id`; unique `hash`; indexes `block_hash`, `slot` | One row per transaction. `block_hash` and `slot` point to the blob block. `metadata` is populated only in API mode. |
 | `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `credential_tag`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount`, `payment_script` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes `transaction_id`, `payment_key`, `staking_key`, spend/reference/collateral tx hashes, and `added_slot`; composites `idx_utxo_deleted_staking_amount` (`deleted_slot`, `credential_tag`, `staking_key`, `amount`), `idx_utxo_staking_deleted_amount` (`credential_tag`, `staking_key`, `deleted_slot`, `amount`), and `idx_utxo_deleted_payment_script` (`deleted_slot`, `payment_script`, `amount`) | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. `credential_tag`: 0 key hash, 1 script hash for stake-bearing outputs. The `(credential_tag, staking_key, deleted_slot, amount)` composite backs stake-credential live UTxO sums such as DRep voting-power tallying. `payment_script` is a bool set at index time from the output address type (true when the payment credential is a script hash); the `(deleted_slot, payment_script, amount)` composite backs the network script-locked supply sum (blockfrost `/network` `supply.locked`). It is derived only at write time, so a database synced before this column existed reports script-locked supply only for UTxOs created after the upgrade until it is rebuilt from chain data. |
 | `asset` | `id`, `utxo_id`, `policy_id`, `name`, `name_hex`, `fingerprint`, `amount` | PK `id`; unique `(name, policy_id, utxo_id)`; named index `idx_asset_policy_id` on `policy_id`; indexes `name_hex`, `fingerprint`, `amount` | Multi-asset quantities attached to `utxo.id`. The unique key backs ledger-state import `ON CONFLICT`; the policy-id query index can be deferred during bulk load. Use `utxo.deleted_slot = 0` for live balances. |
+| `asset_mint_burn` | `id`, `tx_hash`, `policy_id`, `name`, `fingerprint`, `slot`, `quantity`, `tx_index` | PK `id`; unique `(tx_hash, policy_id, name)` (`idx_asset_mint_burn_unique`); composite `(policy_id, name, slot)` (`idx_asset_mint_burn_lookup`); indexes `fingerprint`, `slot` | API-mode-only mint/burn history: one row per `(transaction, asset)` for every tx that mints or burns the asset. Populated from `tx.AssetMint()` during indexing; `quantity` is a signed decimal string (negative for burns). Unlike `asset` (live holdings), this preserves full history so Blockfrost `/assets/{asset}` can derive `initial_mint_tx_hash` (earliest event by `(slot, tx_index, id)`) and `mint_or_burn_count` (row count). The unique key makes re-applying a transaction after a rollback idempotent. Rows with `slot > rollback_slot` are deleted alongside `transaction` on rollback. |
 | `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key`, `(credential_tag, staking_key)`, `transaction_id`, `slot` | API-mode address-to-transaction index. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. |
 | `transaction_metadata_label` | `id`, `transaction_id`, `label`, `slot`, `cbor_value`, `json_value` | PK `id`; unique `(transaction_id, label)`; indexes `label`, `slot` | API-mode per-label metadata index. Join to `transaction.id`. |
 | `key_witness` | `id`, `transaction_id`, `type`, `vkey`, `signature`, `public_key`, `chain_code`, `attributes` | PK `id`; indexes `transaction_id`, `type` | API-mode vkey/bootstrap witnesses. Join to `transaction.id`. |
@@ -754,6 +755,32 @@ WHERE a.policy_id = decode($1, 'hex')
   AND a.name = decode($2, 'hex')
   AND u.deleted_slot = 0;
 ```
+
+`GetAssetMintBurnInfo` (Blockfrost `/assets/{asset}` `initial_mint_tx_hash` and
+`mint_or_burn_count`) reads the mint/burn history rather than live holdings:
+
+```sql
+-- mint_or_burn_count: number of mint/burn events for the asset
+SELECT COUNT(*)
+FROM asset_mint_burn
+WHERE policy_id = decode($1, 'hex')
+  AND name = decode($2, 'hex');
+
+-- initial_mint_tx_hash: earliest recorded event
+SELECT tx_hash
+FROM asset_mint_burn
+WHERE policy_id = decode($1, 'hex')
+  AND name = decode($2, 'hex')
+ORDER BY slot ASC, tx_index ASC, id ASC
+LIMIT 1;
+```
+
+On-chain metadata (`onchain_metadata`, `onchain_metadata_standard`) is not
+stored in a dedicated table: the adapter loads the initial mint transaction's
+`transaction.metadata`, extracts CIP-25 metadata label `721`, and matches the
+policy/asset entry (v1 UTF-8 or v2 hex asset-name keys). Off-chain `metadata`
+(the Cardano token registry) has no on-node source and is returned as `null`.
+CIP-68 datum-based metadata is not yet parsed.
 
 The Blockfrost-compatible `GET /api/v0/assets/{asset}/addresses` endpoint
 uses `GetUtxosByAssets` for live candidate UTxOs, decodes each UTxO CBOR value

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -776,11 +776,16 @@ LIMIT 1;
 ```
 
 On-chain metadata (`onchain_metadata`, `onchain_metadata_standard`) is not
-stored in a dedicated table: the adapter loads the initial mint transaction's
-`transaction.metadata`, extracts CIP-25 metadata label `721`, and matches the
-policy/asset entry (v1 UTF-8 or v2 hex asset-name keys). Off-chain `metadata`
-(the Cardano token registry) has no on-node source and is returned as `null`.
-CIP-68 datum-based metadata is not yet parsed.
+stored in a dedicated table: the adapter loads only the initial mint
+transaction's `transaction.metadata` column (via
+`GetTransactionMetadataByHash`, which selects the blob without preloading
+inputs/outputs/witnesses), extracts CIP-25 metadata label `721`, and matches
+the policy/asset entry. The asset-name key format is chosen from the detected
+standard — UTF-8 for v1, hex for v2 — rather than trying both, so an asset
+whose UTF-8 name collides with another asset's hex name is not mismatched.
+Off-chain `metadata` (the Cardano token registry) has no on-node source and,
+like CIP-68 (`onchain_metadata_extra`) datum-based metadata, is returned as
+`null` to match the Blockfrost response shape.
 
 The Blockfrost-compatible `GET /api/v0/assets/{asset}/addresses` endpoint
 uses `GetUtxosByAssets` for live candidate UTxOs, decodes each UTxO CBOR value

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -940,17 +940,82 @@ func (a *NodeAdapter) Asset(
 		)
 	}
 
-	return AssetInfo{
-		Asset:             policyID + hex.EncodeToString(assetName),
-		PolicyID:          policyID,
-		AssetName:         hex.EncodeToString(assetName),
-		AssetNameASCII:    assetNameASCII(assetName),
-		Fingerprint:       string(asset.Fingerprint),
-		Quantity:          strconv.FormatUint(quantity, 10),
-		InitialMintTxHash: "",
-		MintOrBurnCount:   0,
-		OnchainMetadata:   nil,
-	}, nil
+	initialMintTxHash, mintOrBurnCount, err := a.ledgerState.Database().
+		Metadata().
+		GetAssetMintBurnInfo(policyHash, assetName, nil)
+	if err != nil {
+		return AssetInfo{}, fmt.Errorf(
+			"get asset mint/burn info by policy %s and name %x: %w",
+			policyID,
+			assetName,
+			err,
+		)
+	}
+
+	info := AssetInfo{
+		Asset:           policyID + hex.EncodeToString(assetName),
+		PolicyID:        policyID,
+		AssetName:       hex.EncodeToString(assetName),
+		AssetNameASCII:  assetNameASCII(assetName),
+		Fingerprint:     string(asset.Fingerprint),
+		Quantity:        strconv.FormatUint(quantity, 10),
+		MintOrBurnCount: mintOrBurnCount,
+	}
+	if len(initialMintTxHash) > 0 {
+		info.InitialMintTxHash = hex.EncodeToString(initialMintTxHash)
+		if err := a.populateAssetOnchainMetadata(
+			&info,
+			initialMintTxHash,
+			policyID,
+			assetName,
+		); err != nil {
+			return AssetInfo{}, err
+		}
+	}
+	return info, nil
+}
+
+// populateAssetOnchainMetadata resolves the CIP-25 on-chain metadata for an
+// asset from its initial mint transaction and fills the metadata fields on
+// info. A mint transaction without (matching) metadata is not an error; the
+// fields are simply left unset.
+func (a *NodeAdapter) populateAssetOnchainMetadata(
+	info *AssetInfo,
+	initialMintTxHash []byte,
+	policyID string,
+	assetName []byte,
+) error {
+	tx, err := a.ledgerState.Database().
+		GetTransactionByHash(initialMintTxHash, nil)
+	if err != nil {
+		return fmt.Errorf(
+			"get initial mint tx %x for asset %s%x: %w",
+			initialMintTxHash,
+			policyID,
+			assetName,
+			err,
+		)
+	}
+	if tx == nil || len(tx.Metadata) == 0 {
+		return nil
+	}
+	// A mint transaction without a CIP-25 (label 721) entry is normal; treat a
+	// missing label as "no on-chain metadata" rather than an error.
+	jsonValue, _, err := labelcodec.RawValues(tx.Metadata, metadataLabelCIP25)
+	if err != nil {
+		return nil //nolint:nilerr // missing metadata label is not an error
+	}
+	metadata, standard, ok := parseCIP25Metadata(
+		string(jsonValue),
+		policyID,
+		assetName,
+	)
+	if !ok {
+		return nil
+	}
+	info.OnchainMetadata = &metadata
+	info.OnchainMetadataStandard = &standard
+	return nil
 }
 
 // AssetAddresses returns paginated addresses currently holding the given asset.

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -985,23 +985,23 @@ func (a *NodeAdapter) populateAssetOnchainMetadata(
 	policyID string,
 	assetName []byte,
 ) error {
-	tx, err := a.ledgerState.Database().
-		GetTransactionByHash(initialMintTxHash, nil)
+	metadataCbor, err := a.ledgerState.Database().
+		GetTransactionMetadataByHash(initialMintTxHash, nil)
 	if err != nil {
 		return fmt.Errorf(
-			"get initial mint tx %x for asset %s%x: %w",
+			"get initial mint tx %x metadata for asset %s%x: %w",
 			initialMintTxHash,
 			policyID,
 			assetName,
 			err,
 		)
 	}
-	if tx == nil || len(tx.Metadata) == 0 {
+	if len(metadataCbor) == 0 {
 		return nil
 	}
 	// A mint transaction without a CIP-25 (label 721) entry is normal; treat a
 	// missing label as "no on-chain metadata" rather than an error.
-	jsonValue, _, err := labelcodec.RawValues(tx.Metadata, metadataLabelCIP25)
+	jsonValue, _, err := labelcodec.RawValues(metadataCbor, metadataLabelCIP25)
 	if err != nil {
 		return nil //nolint:nilerr // missing metadata label is not an error
 	}

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -661,16 +661,20 @@ func TestHandleBlockNotFound(t *testing.T) {
 }
 
 func TestHandleAsset(t *testing.T) {
+	onchain := any(map[string]any{"name": "Test Token", "decimals": float64(6)})
+	standard := "CIP25v2"
 	mock := &mockNode{
 		asset: AssetInfo{
-			Asset:             "00112233445566778899aabbccddeeff00112233445566778899aabb746f6b656e",
-			PolicyID:          "00112233445566778899aabbccddeeff00112233445566778899aabb",
-			AssetName:         "746f6b656e",
-			AssetNameASCII:    "token",
-			Fingerprint:       "asset1test",
-			Quantity:          "42",
-			InitialMintTxHash: "",
-			MintOrBurnCount:   0,
+			Asset:                   "00112233445566778899aabbccddeeff00112233445566778899aabb746f6b656e",
+			PolicyID:                "00112233445566778899aabbccddeeff00112233445566778899aabb",
+			AssetName:               "746f6b656e",
+			AssetNameASCII:          "token",
+			Fingerprint:             "asset1test",
+			Quantity:                "42",
+			InitialMintTxHash:       "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+			MintOrBurnCount:         3,
+			OnchainMetadata:         &onchain,
+			OnchainMetadataStandard: &standard,
 		},
 	}
 	b := newTestBlockfrost(mock)
@@ -700,7 +704,11 @@ func TestHandleAsset(t *testing.T) {
 	assert.Equal(t, mock.asset.Quantity, resp.Quantity)
 	assert.Equal(t, mock.asset.InitialMintTxHash, resp.InitialMintTxHash)
 	assert.Equal(t, mock.asset.MintOrBurnCount, resp.MintOrBurnCount)
-	assert.Nil(t, resp.OnchainMetadata)
+	require.NotNil(t, resp.OnchainMetadata)
+	assert.Equal(t, onchain, *resp.OnchainMetadata)
+	require.NotNil(t, resp.OnchainMetadataStandard)
+	assert.Equal(t, "CIP25v2", *resp.OnchainMetadataStandard)
+	assert.Nil(t, resp.Metadata)
 }
 
 func TestHandleAssetInvalidIdentifier(t *testing.T) {

--- a/api/blockfrost/cip25.go
+++ b/api/blockfrost/cip25.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+	"encoding/json"
+)
+
+const (
+	// metadataLabelCIP25 is the transaction metadata label reserved for NFT
+	// (and general native token) mint metadata by CIP-25.
+	metadataLabelCIP25 = 721
+
+	onchainMetadataStandardCIP25v1 = "CIP25v1"
+	onchainMetadataStandardCIP25v2 = "CIP25v2"
+)
+
+// parseCIP25Metadata extracts the on-chain metadata object for a single asset
+// from the JSON form of a transaction's CIP-25 (label 721) metadata.
+//
+// The label 721 structure is:
+//
+//	{ "<policy_id>": { "<asset_name>": { ...metadata... } }, "version": 1|2 }
+//
+// Dingo's metadata codec renders byte-string map keys as hex, so the policy id
+// key is always the hex policy id for both v1 (text hex) and v2 (bytes) forms.
+// The asset name key is the UTF-8 name in v1 and the hex name in v2, so both
+// candidates are tried.
+//
+// It returns the metadata object, the detected standard ("CIP25v1" or
+// "CIP25v2"), and whether a matching asset entry was found.
+func parseCIP25Metadata(
+	label721JSON string,
+	policyIDHex string,
+	assetName []byte,
+) (any, string, bool) {
+	if label721JSON == "" {
+		return nil, "", false
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(label721JSON), &top); err != nil {
+		return nil, "", false
+	}
+
+	standard := onchainMetadataStandardCIP25v1
+	if raw, ok := top["version"]; ok && isCIP25Version2(raw) {
+		standard = onchainMetadataStandardCIP25v2
+	}
+
+	policyRaw, ok := top[policyIDHex]
+	if !ok {
+		return nil, "", false
+	}
+	var byAsset map[string]json.RawMessage
+	if err := json.Unmarshal(policyRaw, &byAsset); err != nil {
+		return nil, "", false
+	}
+
+	candidates := []string{hex.EncodeToString(assetName), string(assetName)}
+	for _, key := range candidates {
+		raw, ok := byAsset[key]
+		if !ok {
+			continue
+		}
+		var metadata any
+		if err := json.Unmarshal(raw, &metadata); err != nil {
+			return nil, "", false
+		}
+		return metadata, standard, true
+	}
+	return nil, "", false
+}
+
+// isCIP25Version2 reports whether a CIP-25 "version" value denotes version 2.
+// The value may be encoded as a JSON number (2) or a JSON string ("2").
+func isCIP25Version2(raw json.RawMessage) bool {
+	var num json.Number
+	if err := json.Unmarshal(raw, &num); err == nil {
+		return num.String() == "2"
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		return str == "2"
+	}
+	return false
+}

--- a/api/blockfrost/cip25.go
+++ b/api/blockfrost/cip25.go
@@ -37,8 +37,10 @@ const (
 //
 // Dingo's metadata codec renders byte-string map keys as hex, so the policy id
 // key is always the hex policy id for both v1 (text hex) and v2 (bytes) forms.
-// The asset name key is the UTF-8 name in v1 and the hex name in v2, so both
-// candidates are tried.
+// The asset name key is the UTF-8 name in v1 and the hex name in v2. The key
+// format is chosen from the detected standard rather than trying both, so an
+// asset whose UTF-8 name happens to collide with another asset's hex name under
+// the same policy is not matched to the wrong entry.
 //
 // It returns the metadata object, the detected standard ("CIP25v1" or
 // "CIP25v2"), and whether a matching asset entry was found.
@@ -69,19 +71,21 @@ func parseCIP25Metadata(
 		return nil, "", false
 	}
 
-	candidates := []string{hex.EncodeToString(assetName), string(assetName)}
-	for _, key := range candidates {
-		raw, ok := byAsset[key]
-		if !ok {
-			continue
-		}
-		var metadata any
-		if err := json.Unmarshal(raw, &metadata); err != nil {
-			return nil, "", false
-		}
-		return metadata, standard, true
+	// v2 asset-name keys are byte strings (rendered as hex); v1 keys are the
+	// UTF-8 asset name.
+	key := string(assetName)
+	if standard == onchainMetadataStandardCIP25v2 {
+		key = hex.EncodeToString(assetName)
 	}
-	return nil, "", false
+	raw, ok := byAsset[key]
+	if !ok {
+		return nil, "", false
+	}
+	var metadata any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return nil, "", false
+	}
+	return metadata, standard, true
 }
 
 // isCIP25Version2 reports whether a CIP-25 "version" value denotes version 2.

--- a/api/blockfrost/cip25_test.go
+++ b/api/blockfrost/cip25_test.go
@@ -54,6 +54,23 @@ func TestParseCIP25Metadata(t *testing.T) {
 			wantName:     "Str Ver",
 		},
 		{
+			// v1 metadata must not match the hex form of the asset name: here
+			// the entry keyed by another asset's UTF-8 name equals our asset's
+			// hex name ("746f6b656e"). A hex lookup would return the wrong
+			// asset's metadata.
+			name: "v1 does not fall back to hex key",
+			json: `{"` + policyID +
+				`":{"746f6b656e":{"name":"Collision"}}}`,
+			wantOK: false,
+		},
+		{
+			// v2 metadata is keyed by hex; a UTF-8 key must not be matched.
+			name: "v2 does not fall back to utf8 key",
+			json: `{"` + policyID +
+				`":{"token":{"name":"Collision"}},"version":2}`,
+			wantOK: false,
+		},
+		{
 			name:   "policy not present",
 			json:   `{"deadbeef":{"token":{"name":"nope"}}}`,
 			wantOK: false,

--- a/api/blockfrost/cip25_test.go
+++ b/api/blockfrost/cip25_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCIP25Metadata(t *testing.T) {
+	const policyID = "00112233445566778899aabbccddeeff00112233445566778899aabb"
+	assetName := []byte("token") // ascii "token" -> hex 746f6b656e
+
+	tests := []struct {
+		name         string
+		json         string
+		wantStandard string
+		wantOK       bool
+		wantName     string
+	}{
+		{
+			name:         "v1 utf8 asset key, no version",
+			json:         `{"` + policyID + `":{"token":{"name":"My Token","image":"ipfs://x"}}}`,
+			wantStandard: onchainMetadataStandardCIP25v1,
+			wantOK:       true,
+			wantName:     "My Token",
+		},
+		{
+			name:         "v2 hex asset key, numeric version",
+			json:         `{"` + policyID + `":{"746f6b656e":{"name":"Hex Token"}},"version":2}`,
+			wantStandard: onchainMetadataStandardCIP25v2,
+			wantOK:       true,
+			wantName:     "Hex Token",
+		},
+		{
+			name:         "v2 string version",
+			json:         `{"` + policyID + `":{"746f6b656e":{"name":"Str Ver"}},"version":"2"}`,
+			wantStandard: onchainMetadataStandardCIP25v2,
+			wantOK:       true,
+			wantName:     "Str Ver",
+		},
+		{
+			name:   "policy not present",
+			json:   `{"deadbeef":{"token":{"name":"nope"}}}`,
+			wantOK: false,
+		},
+		{
+			name:   "asset not present under policy",
+			json:   `{"` + policyID + `":{"other":{"name":"nope"}}}`,
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			json:   "",
+			wantOK: false,
+		},
+		{
+			name:   "invalid json",
+			json:   "{not json",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta, standard, ok := parseCIP25Metadata(tc.json, policyID, assetName)
+			assert.Equal(t, tc.wantOK, ok)
+			if !tc.wantOK {
+				return
+			}
+			assert.Equal(t, tc.wantStandard, standard)
+			m, isMap := meta.(map[string]any)
+			require.True(t, isMap)
+			assert.Equal(t, tc.wantName, m["name"])
+		})
+	}
+}

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -454,15 +454,18 @@ func (b *Blockfrost) handleAsset(
 	}
 
 	writeJSON(w, http.StatusOK, AssetResponse{
-		Asset:             asset.Asset,
-		PolicyID:          asset.PolicyID,
-		AssetName:         asset.AssetName,
-		AssetNameASCII:    asset.AssetNameASCII,
-		Fingerprint:       asset.Fingerprint,
-		Quantity:          asset.Quantity,
-		InitialMintTxHash: asset.InitialMintTxHash,
-		MintOrBurnCount:   asset.MintOrBurnCount,
-		OnchainMetadata:   asset.OnchainMetadata,
+		Asset:                   asset.Asset,
+		PolicyID:                asset.PolicyID,
+		AssetName:               asset.AssetName,
+		AssetNameASCII:          asset.AssetNameASCII,
+		Fingerprint:             asset.Fingerprint,
+		Quantity:                asset.Quantity,
+		InitialMintTxHash:       asset.InitialMintTxHash,
+		MintOrBurnCount:         asset.MintOrBurnCount,
+		OnchainMetadata:         asset.OnchainMetadata,
+		OnchainMetadataStandard: asset.OnchainMetadataStandard,
+		OnchainMetadataExtra:    asset.OnchainMetadataExtra,
+		Metadata:                asset.Metadata,
 	})
 }
 

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -573,15 +573,18 @@ type TransactionRequiredSignerInfo struct {
 
 // AssetInfo holds native asset data needed by the API.
 type AssetInfo struct {
-	Asset             string
-	PolicyID          string
-	AssetName         string
-	AssetNameASCII    string
-	Fingerprint       string
-	Quantity          string
-	InitialMintTxHash string
-	MintOrBurnCount   int
-	OnchainMetadata   *any
+	OnchainMetadata         *any
+	OnchainMetadataStandard *string
+	OnchainMetadataExtra    *string
+	Metadata                *any
+	Asset                   string
+	PolicyID                string
+	AssetName               string
+	AssetNameASCII          string
+	Fingerprint             string
+	Quantity                string
+	InitialMintTxHash       string
+	MintOrBurnCount         int
 }
 
 // AssetHolderInfo holds address and quantity data for a single asset holder.

--- a/database/models/asset.go
+++ b/database/models/asset.go
@@ -35,6 +35,67 @@ func (Asset) TableName() string {
 	return "asset"
 }
 
+// AssetMintBurn records a single asset mint or burn event: one row per
+// (transaction, asset) pair for every transaction that mints or burns the
+// asset. Quantity is a signed decimal string (positive for a mint, negative
+// for a burn). Only populated in API storage mode.
+//
+// Unlike Asset (which tracks live UTxO holdings), this table preserves the
+// full mint/burn history so the Blockfrost API can derive an asset's
+// initial_mint_tx_hash (earliest event) and mint_or_burn_count (row count).
+type AssetMintBurn struct {
+	ID          uint   `gorm:"primaryKey"`
+	TxHash      []byte `gorm:"size:32;uniqueIndex:idx_asset_mint_burn_unique,priority:1"`
+	PolicyId    []byte `gorm:"size:28;uniqueIndex:idx_asset_mint_burn_unique,priority:2;index:idx_asset_mint_burn_lookup,priority:1"`
+	Name        []byte `gorm:"size:32;uniqueIndex:idx_asset_mint_burn_unique,priority:3;index:idx_asset_mint_burn_lookup,priority:2"`
+	Fingerprint []byte `gorm:"index;size:48"`
+	Slot        uint64 `gorm:"index;index:idx_asset_mint_burn_lookup,priority:3"`
+	Quantity    string `gorm:"size:40"`
+	TxIndex     uint32
+}
+
+func (AssetMintBurn) TableName() string {
+	return "asset_mint_burn"
+}
+
+// ConvertMintToAssetMintBurnModels converts a transaction's mint field into a
+// slice of AssetMintBurn models, one per (policy, asset name) pair with a
+// non-zero net quantity. Returns nil when there is nothing minted or burned.
+func ConvertMintToAssetMintBurnModels(
+	mint *lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
+	txHash []byte,
+	slot uint64,
+	txIndex uint32,
+) []AssetMintBurn {
+	if mint == nil {
+		return nil
+	}
+	var rows []AssetMintBurn
+	for _, policyId := range mint.Policies() {
+		policyIdBytes := policyId.Bytes()
+		for _, assetNameBytes := range mint.Assets(policyId) {
+			amount := mint.Asset(policyId, assetNameBytes)
+			if amount == nil || amount.Sign() == 0 {
+				continue
+			}
+			fingerprint := lcommon.NewAssetFingerprint(
+				policyIdBytes,
+				assetNameBytes,
+			)
+			rows = append(rows, AssetMintBurn{
+				TxHash:      append([]byte(nil), txHash...),
+				PolicyId:    policyIdBytes,
+				Name:        append([]byte(nil), assetNameBytes...),
+				Fingerprint: []byte(fingerprint.String()),
+				Slot:        slot,
+				Quantity:    amount.String(),
+				TxIndex:     txIndex,
+			})
+		}
+	}
+	return rows
+}
+
 // ConvertMultiAssetToModels converts a MultiAsset structure into a slice of Asset models.
 // Each asset is populated with its name, hex-encoded name, policy ID, fingerprint, and amount.
 // Returns an empty slice if multiAsset is nil or contains no assets.

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -20,6 +20,7 @@ var MigrateModels = []any{
 	&AccountRewardDelta{},
 	&AddressTransaction{},
 	&Asset{},
+	&AssetMintBurn{},
 	&AuthCommitteeHot{},
 	&BackfillCheckpoint{},
 	&BlockNonce{},

--- a/database/plugin/metadata/mysql/asset.go
+++ b/database/plugin/metadata/mysql/asset.go
@@ -114,9 +114,10 @@ func (d *MetadataStoreMysql) GetAssetMintBurnInfo(
 }
 
 // recordAssetMintBurn persists the mint/burn events for a transaction. It is a
-// no-op outside API storage mode or when the transaction mints/burns nothing.
-// Re-applying the same transaction (e.g. after a rollback) is idempotent via
-// the unique (tx_hash, policy_id, name) index.
+// no-op outside API storage mode, for phase-2-invalid transactions (whose mint
+// field is never applied on-chain), or when the transaction mints/burns
+// nothing. Re-applying the same transaction (e.g. after a rollback) is
+// idempotent via the unique (tx_hash, policy_id, name) index.
 func (d *MetadataStoreMysql) recordAssetMintBurn(
 	tx lcommon.Transaction,
 	txHash []byte,
@@ -125,6 +126,11 @@ func (d *MetadataStoreMysql) recordAssetMintBurn(
 	txn types.Txn,
 ) error {
 	if d.storageMode != types.StorageModeAPI {
+		return nil
+	}
+	// A phase-2 script-validation failure includes the transaction in the block
+	// but does not apply its mint/burn, so it must not enter asset history.
+	if !tx.IsValid() {
 		return nil
 	}
 	rows := models.ConvertMintToAssetMintBurnModels(

--- a/database/plugin/metadata/mysql/asset.go
+++ b/database/plugin/metadata/mysql/asset.go
@@ -18,11 +18,13 @@ package mysql
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GetAssetByPolicyAndName returns an asset by policy ID and asset name
@@ -77,6 +79,82 @@ func (d *MetadataStoreMysql) GetAssetQuantityByPolicyAndName(
 		return 0, result.Error
 	}
 	return total, nil
+}
+
+// GetAssetMintBurnInfo returns the initial mint transaction hash and the total
+// mint/burn event count for the given asset.
+func (d *MetadataStoreMysql) GetAssetMintBurnInfo(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) ([]byte, int, error) {
+	query, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var count int64
+	if result := query.Model(&models.AssetMintBurn{}).
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Count(&count); result.Error != nil {
+		return nil, 0, result.Error
+	}
+	if count == 0 {
+		return nil, 0, nil
+	}
+
+	var first models.AssetMintBurn
+	if result := query.
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Order("slot ASC, tx_index ASC, id ASC").
+		First(&first); result.Error != nil {
+		return nil, 0, result.Error
+	}
+	return first.TxHash, int(count), nil
+}
+
+// recordAssetMintBurn persists the mint/burn events for a transaction. It is a
+// no-op outside API storage mode or when the transaction mints/burns nothing.
+// Re-applying the same transaction (e.g. after a rollback) is idempotent via
+// the unique (tx_hash, policy_id, name) index.
+func (d *MetadataStoreMysql) recordAssetMintBurn(
+	tx lcommon.Transaction,
+	txHash []byte,
+	slot uint64,
+	txIndex uint32,
+	txn types.Txn,
+) error {
+	if d.storageMode != types.StorageModeAPI {
+		return nil
+	}
+	rows := models.ConvertMintToAssetMintBurnModels(
+		tx.AssetMint(),
+		txHash,
+		slot,
+		txIndex,
+	)
+	if len(rows) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tx_hash"},
+			{Name: "policy_id"},
+			{Name: "name"},
+		},
+		DoNothing: true,
+	}).Create(&rows); result.Error != nil {
+		return fmt.Errorf(
+			"record asset mint/burn for tx %x: %w",
+			txHash,
+			result.Error,
+		)
+	}
+	return nil
 }
 
 // GetAssetsByPolicy returns all assets for a given policy ID

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -873,6 +873,9 @@ func (d *MetadataStoreMysql) SetGapBlockTransaction(
 			)
 		}
 	}
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1008,6 +1011,10 @@ func (d *MetadataStoreMysql) SetTransaction(
 				result.Error,
 			)
 		}
+	}
+
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
 	}
 	// Add Inputs to Transaction
 	if len(tx.Inputs()) > 0 {
@@ -2679,6 +2686,10 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 		}
 	}
 
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
+	}
+
 	// ------------------------------------------------------------------ //
 	// 2. Accumulate UTxO outputs                                          //
 	// ------------------------------------------------------------------ //
@@ -4062,6 +4073,15 @@ func (d *MetadataStoreMysql) DeleteTransactionsAfterSlot(
 		Delete(&models.TransactionMetadataLabel{}); result.Error != nil {
 		return fmt.Errorf(
 			"delete transaction metadata labels after slot %d: %w",
+			slot,
+			result.Error,
+		)
+	}
+
+	if result := db.Where("slot > ?", slot).
+		Delete(&models.AssetMintBurn{}); result.Error != nil {
+		return fmt.Errorf(
+			"delete asset mint/burn events after slot %d: %w",
 			slot,
 			result.Error,
 		)

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -159,6 +159,31 @@ func (d *MetadataStoreMysql) GetTransactionIDByHash(
 	return row.ID, true, nil
 }
 
+// GetTransactionMetadataByHash returns only the stored metadata blob for the
+// transaction with the given hash without preloading any related rows. Returns
+// (nil, nil) when no such transaction exists or it carries no metadata.
+func (d *MetadataStoreMysql) GetTransactionMetadataByHash(
+	hash []byte,
+	txn types.Txn,
+) ([]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var row struct{ Metadata []byte }
+	result := db.Model(&models.Transaction{}).
+		Select("metadata").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return row.Metadata, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *MetadataStoreMysql) GetTransactionsByHashes(
 	hashes [][]byte,

--- a/database/plugin/metadata/postgres/asset.go
+++ b/database/plugin/metadata/postgres/asset.go
@@ -114,9 +114,10 @@ func (d *MetadataStorePostgres) GetAssetMintBurnInfo(
 }
 
 // recordAssetMintBurn persists the mint/burn events for a transaction. It is a
-// no-op outside API storage mode or when the transaction mints/burns nothing.
-// Re-applying the same transaction (e.g. after a rollback) is idempotent via
-// the unique (tx_hash, policy_id, name) index.
+// no-op outside API storage mode, for phase-2-invalid transactions (whose mint
+// field is never applied on-chain), or when the transaction mints/burns
+// nothing. Re-applying the same transaction (e.g. after a rollback) is
+// idempotent via the unique (tx_hash, policy_id, name) index.
 func (d *MetadataStorePostgres) recordAssetMintBurn(
 	tx lcommon.Transaction,
 	txHash []byte,
@@ -125,6 +126,11 @@ func (d *MetadataStorePostgres) recordAssetMintBurn(
 	txn types.Txn,
 ) error {
 	if d.storageMode != types.StorageModeAPI {
+		return nil
+	}
+	// A phase-2 script-validation failure includes the transaction in the block
+	// but does not apply its mint/burn, so it must not enter asset history.
+	if !tx.IsValid() {
 		return nil
 	}
 	rows := models.ConvertMintToAssetMintBurnModels(

--- a/database/plugin/metadata/postgres/asset.go
+++ b/database/plugin/metadata/postgres/asset.go
@@ -18,11 +18,13 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GetAssetByPolicyAndName returns an asset by policy ID and asset name
@@ -77,6 +79,82 @@ func (d *MetadataStorePostgres) GetAssetQuantityByPolicyAndName(
 		return 0, result.Error
 	}
 	return total, nil
+}
+
+// GetAssetMintBurnInfo returns the initial mint transaction hash and the total
+// mint/burn event count for the given asset.
+func (d *MetadataStorePostgres) GetAssetMintBurnInfo(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) ([]byte, int, error) {
+	query, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var count int64
+	if result := query.Model(&models.AssetMintBurn{}).
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Count(&count); result.Error != nil {
+		return nil, 0, result.Error
+	}
+	if count == 0 {
+		return nil, 0, nil
+	}
+
+	var first models.AssetMintBurn
+	if result := query.
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Order("slot ASC, tx_index ASC, id ASC").
+		First(&first); result.Error != nil {
+		return nil, 0, result.Error
+	}
+	return first.TxHash, int(count), nil
+}
+
+// recordAssetMintBurn persists the mint/burn events for a transaction. It is a
+// no-op outside API storage mode or when the transaction mints/burns nothing.
+// Re-applying the same transaction (e.g. after a rollback) is idempotent via
+// the unique (tx_hash, policy_id, name) index.
+func (d *MetadataStorePostgres) recordAssetMintBurn(
+	tx lcommon.Transaction,
+	txHash []byte,
+	slot uint64,
+	txIndex uint32,
+	txn types.Txn,
+) error {
+	if d.storageMode != types.StorageModeAPI {
+		return nil
+	}
+	rows := models.ConvertMintToAssetMintBurnModels(
+		tx.AssetMint(),
+		txHash,
+		slot,
+		txIndex,
+	)
+	if len(rows) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tx_hash"},
+			{Name: "policy_id"},
+			{Name: "name"},
+		},
+		DoNothing: true,
+	}).Create(&rows); result.Error != nil {
+		return fmt.Errorf(
+			"record asset mint/burn for tx %x: %w",
+			txHash,
+			result.Error,
+		)
+	}
+	return nil
 }
 
 // GetAssetsByPolicy returns all assets for a given policy ID

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -875,6 +875,9 @@ func (d *MetadataStorePostgres) SetGapBlockTransaction(
 			)
 		}
 	}
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1010,6 +1013,10 @@ func (d *MetadataStorePostgres) SetTransaction(
 				result.Error,
 			)
 		}
+	}
+
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
 	}
 	// Add Inputs to Transaction
 	if len(tx.Inputs()) > 0 {
@@ -2690,6 +2697,10 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 		}
 	}
 
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
+	}
+
 	// ------------------------------------------------------------------ //
 	// 2. Accumulate UTxO outputs                                          //
 	// ------------------------------------------------------------------ //
@@ -4073,6 +4084,15 @@ func (d *MetadataStorePostgres) DeleteTransactionsAfterSlot(
 		Delete(&models.TransactionMetadataLabel{}); result.Error != nil {
 		return fmt.Errorf(
 			"delete transaction metadata labels after slot %d: %w",
+			slot,
+			result.Error,
+		)
+	}
+
+	if result := db.Where("slot > ?", slot).
+		Delete(&models.AssetMintBurn{}); result.Error != nil {
+		return fmt.Errorf(
+			"delete asset mint/burn events after slot %d: %w",
 			slot,
 			result.Error,
 		)

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -159,6 +159,31 @@ func (d *MetadataStorePostgres) GetTransactionIDByHash(
 	return row.ID, true, nil
 }
 
+// GetTransactionMetadataByHash returns only the stored metadata blob for the
+// transaction with the given hash without preloading any related rows. Returns
+// (nil, nil) when no such transaction exists or it carries no metadata.
+func (d *MetadataStorePostgres) GetTransactionMetadataByHash(
+	hash []byte,
+	txn types.Txn,
+) ([]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var row struct{ Metadata []byte }
+	result := db.Model(&models.Transaction{}).
+		Select("metadata").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return row.Metadata, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *MetadataStorePostgres) GetTransactionsByHashes(
 	hashes [][]byte,

--- a/database/plugin/metadata/sqlite/asset.go
+++ b/database/plugin/metadata/sqlite/asset.go
@@ -112,9 +112,10 @@ func (d *MetadataStoreSqlite) GetAssetMintBurnInfo(
 }
 
 // recordAssetMintBurn persists the mint/burn events for a transaction. It is a
-// no-op outside API storage mode or when the transaction mints/burns nothing.
-// Re-applying the same transaction (e.g. after a rollback) is idempotent via
-// the unique (tx_hash, policy_id, name) index.
+// no-op outside API storage mode, for phase-2-invalid transactions (whose mint
+// field is never applied on-chain), or when the transaction mints/burns
+// nothing. Re-applying the same transaction (e.g. after a rollback) is
+// idempotent via the unique (tx_hash, policy_id, name) index.
 func (d *MetadataStoreSqlite) recordAssetMintBurn(
 	tx lcommon.Transaction,
 	txHash []byte,
@@ -123,6 +124,11 @@ func (d *MetadataStoreSqlite) recordAssetMintBurn(
 	txn types.Txn,
 ) error {
 	if d.storageMode != types.StorageModeAPI {
+		return nil
+	}
+	// A phase-2 script-validation failure includes the transaction in the block
+	// but does not apply its mint/burn, so it must not enter asset history.
+	if !tx.IsValid() {
 		return nil
 	}
 	rows := models.ConvertMintToAssetMintBurnModels(

--- a/database/plugin/metadata/sqlite/asset.go
+++ b/database/plugin/metadata/sqlite/asset.go
@@ -16,11 +16,13 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GetAssetByPolicyAndName returns an asset by policy ID and asset name
@@ -75,6 +77,82 @@ func (d *MetadataStoreSqlite) GetAssetQuantityByPolicyAndName(
 		return 0, result.Error
 	}
 	return total, nil
+}
+
+// GetAssetMintBurnInfo returns the initial mint transaction hash and the total
+// mint/burn event count for the given asset.
+func (d *MetadataStoreSqlite) GetAssetMintBurnInfo(
+	policyId lcommon.Blake2b224,
+	assetName []byte,
+	txn types.Txn,
+) ([]byte, int, error) {
+	query, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var count int64
+	if result := query.Model(&models.AssetMintBurn{}).
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Count(&count); result.Error != nil {
+		return nil, 0, result.Error
+	}
+	if count == 0 {
+		return nil, 0, nil
+	}
+
+	var first models.AssetMintBurn
+	if result := query.
+		Where("policy_id = ? AND name = ?", policyId[:], assetName).
+		Order("slot ASC, tx_index ASC, id ASC").
+		First(&first); result.Error != nil {
+		return nil, 0, result.Error
+	}
+	return first.TxHash, int(count), nil
+}
+
+// recordAssetMintBurn persists the mint/burn events for a transaction. It is a
+// no-op outside API storage mode or when the transaction mints/burns nothing.
+// Re-applying the same transaction (e.g. after a rollback) is idempotent via
+// the unique (tx_hash, policy_id, name) index.
+func (d *MetadataStoreSqlite) recordAssetMintBurn(
+	tx lcommon.Transaction,
+	txHash []byte,
+	slot uint64,
+	txIndex uint32,
+	txn types.Txn,
+) error {
+	if d.storageMode != types.StorageModeAPI {
+		return nil
+	}
+	rows := models.ConvertMintToAssetMintBurnModels(
+		tx.AssetMint(),
+		txHash,
+		slot,
+		txIndex,
+	)
+	if len(rows) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	if result := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tx_hash"},
+			{Name: "policy_id"},
+			{Name: "name"},
+		},
+		DoNothing: true,
+	}).Create(&rows); result.Error != nil {
+		return fmt.Errorf(
+			"record asset mint/burn for tx %x: %w",
+			txHash,
+			result.Error,
+		)
+	}
+	return nil
 }
 
 // GetAssetsByPolicy returns all assets for a given policy ID

--- a/database/plugin/metadata/sqlite/asset_mint_burn_test.go
+++ b/database/plugin/metadata/sqlite/asset_mint_burn_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+var testMintPolicy = lcommon.NewBlake2b224(
+	[]byte("0123456789012345678901234567"), // 28 bytes
+)
+
+func mintOf(name []byte, amount int64) *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	ma := lcommon.NewMultiAsset(
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeMint{
+			testMintPolicy: {
+				cbor.NewByteString(name): big.NewInt(amount),
+			},
+		},
+	)
+	return &ma
+}
+
+func TestAssetMintBurnTrackingAndRollback(t *testing.T) {
+	t.Parallel()
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+	name := []byte("token")
+
+	setTx := func(hash string, slot uint64, amount int64) {
+		tx := &mockTransaction{
+			hash:    lcommon.NewBlake2b256([]byte(hash)),
+			isValid: true,
+			mint:    mintOf(name, amount),
+		}
+		require.NoError(t, store.SetTransaction(
+			tx,
+			ocommon.Point{Hash: []byte(hash + "_block"), Slot: slot},
+			0,
+			nil,
+			nil,
+		))
+	}
+
+	// Initial mint, a later mint, then a burn.
+	setTx("mint_tx_1", 100, 1000)
+	setTx("mint_tx_2", 200, 500)
+	setTx("burn_tx_3", 300, -200)
+
+	initialHash, count, err := store.GetAssetMintBurnInfo(
+		testMintPolicy,
+		name,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+	assert.Equal(
+		t,
+		lcommon.NewBlake2b256([]byte("mint_tx_1")).Bytes(),
+		initialHash,
+	)
+
+	// Re-applying the initial mint must be idempotent (no duplicate rows).
+	setTx("mint_tx_1", 100, 1000)
+	_, count, err = store.GetAssetMintBurnInfo(testMintPolicy, name, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Rollback past slot 150 removes the later mint and the burn.
+	require.NoError(t, store.DeleteTransactionsAfterSlot(150, nil))
+	initialHash, count, err = store.GetAssetMintBurnInfo(
+		testMintPolicy,
+		name,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(
+		t,
+		lcommon.NewBlake2b256([]byte("mint_tx_1")).Bytes(),
+		initialHash,
+	)
+}
+
+func TestAssetMintBurnInfoNoHistory(t *testing.T) {
+	t.Parallel()
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+
+	initialHash, count, err := store.GetAssetMintBurnInfo(
+		testMintPolicy,
+		[]byte("missing"),
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, initialHash)
+	assert.Equal(t, 0, count)
+}
+
+func TestAssetMintBurnNotRecordedInCoreMode(t *testing.T) {
+	t.Parallel()
+	store := setupTestDBWithMode(t, types.StorageModeCore)
+	name := []byte("token")
+
+	tx := &mockTransaction{
+		hash:    lcommon.NewBlake2b256([]byte("core_mint")),
+		isValid: true,
+		mint:    mintOf(name, 1000),
+	}
+	require.NoError(t, store.SetTransaction(
+		tx,
+		ocommon.Point{Hash: []byte("core_block"), Slot: 100},
+		0,
+		nil,
+		nil,
+	))
+
+	_, count, err := store.GetAssetMintBurnInfo(testMintPolicy, name, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/database/plugin/metadata/sqlite/asset_mint_burn_test.go
+++ b/database/plugin/metadata/sqlite/asset_mint_burn_test.go
@@ -116,6 +116,36 @@ func TestAssetMintBurnInfoNoHistory(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
+func TestAssetMintBurnNotRecordedForInvalidTx(t *testing.T) {
+	t.Parallel()
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+	name := []byte("token")
+
+	// A phase-2-invalid transaction includes a mint field but never applies it
+	// on-chain, so it must not be recorded as mint/burn history.
+	tx := &mockTransaction{
+		hash:    lcommon.NewBlake2b256([]byte("invalid_mint")),
+		isValid: false,
+		mint:    mintOf(name, 1000),
+	}
+	require.NoError(t, store.SetTransaction(
+		tx,
+		ocommon.Point{Hash: []byte("invalid_block"), Slot: 100},
+		0,
+		nil,
+		nil,
+	))
+
+	initialHash, count, err := store.GetAssetMintBurnInfo(
+		testMintPolicy,
+		name,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, initialHash)
+	assert.Equal(t, 0, count)
+}
+
 func TestAssetMintBurnNotRecordedInCoreMode(t *testing.T) {
 	t.Parallel()
 	store := setupTestDBWithMode(t, types.StorageModeCore)

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -67,6 +67,7 @@ type mockTransaction struct {
 	outputs      []lcommon.TransactionOutput
 	collReturn   lcommon.TransactionOutput
 	withdrawals  map[*lcommon.Address]*big.Int
+	mint         *lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
 }
 
 func (m *mockTransaction) Hash() lcommon.Blake2b256 {
@@ -134,7 +135,7 @@ func (m *mockTransaction) ProtocolParameterUpdates() (uint64, map[lcommon.Blake2
 }
 
 func (m *mockTransaction) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
-	return nil
+	return m.mint
 }
 
 func (m *mockTransaction) AuxDataHash() *lcommon.Blake2b256 {

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -961,6 +961,9 @@ func (d *MetadataStoreSqlite) SetGapBlockTransaction(
 			)
 		}
 	}
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1106,6 +1109,10 @@ func (d *MetadataStoreSqlite) SetTransaction(
 				result.Error,
 			)
 		}
+	}
+
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
 	}
 
 	// Create UTxO records for outputs in a single statement per transaction.
@@ -2804,6 +2811,10 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				result.Error,
 			)
 		}
+	}
+
+	if err := d.recordAssetMintBurn(tx, txHash, point.Slot, idx, txn); err != nil {
+		return err
 	}
 
 	// ------------------------------------------------------------------ //
@@ -4698,6 +4709,15 @@ func (d *MetadataStoreSqlite) DeleteTransactionsAfterSlot(
 		Delete(&models.TransactionMetadataLabel{}); result.Error != nil {
 		return fmt.Errorf(
 			"delete transaction metadata labels after slot %d: %w",
+			slot,
+			result.Error,
+		)
+	}
+
+	if result := db.Where("slot > ?", slot).
+		Delete(&models.AssetMintBurn{}); result.Error != nil {
+		return fmt.Errorf(
+			"delete asset mint/burn events after slot %d: %w",
 			slot,
 			result.Error,
 		)

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -180,6 +180,31 @@ func (d *MetadataStoreSqlite) GetTransactionIDByHash(
 	return row.ID, true, nil
 }
 
+// GetTransactionMetadataByHash returns only the stored metadata blob for the
+// transaction with the given hash without preloading any related rows. Returns
+// (nil, nil) when no such transaction exists or it carries no metadata.
+func (d *MetadataStoreSqlite) GetTransactionMetadataByHash(
+	hash []byte,
+	txn types.Txn,
+) ([]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var row struct{ Metadata []byte }
+	result := db.Model(&models.Transaction{}).
+		Select("metadata").
+		Where("hash = ?", hash).
+		Take(&row)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return row.Metadata, nil
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *MetadataStoreSqlite) GetTransactionsByHashes(
 	hashes [][]byte,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -723,6 +723,16 @@ type MetadataStore interface {
 		types.Txn,
 	) (uint64, error)
 
+	// GetAssetMintBurnInfo returns the hash of the earliest transaction that
+	// minted the asset (its initial mint) and the total number of recorded
+	// mint/burn events for the asset. Returns (nil, 0, nil) when the asset has
+	// no recorded mint/burn history (e.g. running in core storage mode).
+	GetAssetMintBurnInfo(
+		lcommon.Blake2b224,
+		[]byte, // assetName
+		types.Txn,
+	) (initialMintTxHash []byte, mintOrBurnCount int, err error)
+
 	// GetScript retrieves a script by its hash.
 	GetScript(
 		lcommon.ScriptHash,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -592,6 +592,17 @@ type MetadataStore interface {
 		types.Txn,
 	) (uint, bool, error)
 
+	// GetTransactionMetadataByHash returns only the stored (API-mode)
+	// CBOR metadata blob for the transaction with the given hash,
+	// without loading any associations. Returns (nil, nil) when no such
+	// transaction exists or when it has no metadata. Used by the asset
+	// endpoint to resolve CIP-25 on-chain metadata without paying for
+	// full transaction preloads.
+	GetTransactionMetadataByHash(
+		[]byte, // hash
+		types.Txn,
+	) ([]byte, error)
+
 	// GetTransactionsByHashes retrieves transactions by their hashes.
 	GetTransactionsByHashes(
 		[][]byte, // hashes

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -881,6 +881,23 @@ func (d *Database) GetTransactionByHash(
 	return d.metadata.GetTransactionByHash(hash, txn.Metadata())
 }
 
+// GetTransactionMetadataByHash returns only the stored metadata blob for the
+// transaction with the given hash, without loading any associations. Returns
+// (nil, nil) when no such transaction exists or it carries no metadata.
+func (d *Database) GetTransactionMetadataByHash(
+	hash []byte,
+	txn *Txn,
+) ([]byte, error) {
+	if len(hash) == 0 {
+		return nil, nil
+	}
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetTransactionMetadataByHash(hash, txn.Metadata())
+}
+
 // GetTransactionsByHashes returns transactions for the provided hashes.
 func (d *Database) GetTransactionsByHashes(
 	hashes [][]byte,


### PR DESCRIPTION
Closes #2485 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates Blockfrost `/assets/{asset}` with correct mint history and on-chain metadata. Adds an API-mode table for mint/burn events and parses CIP‑25 from the initial mint transaction.

- **New Features**
  - Added `asset_mint_burn` table (API mode) with a unique `(tx_hash, policy_id, name)` and lookup indexes.
  - Indexer records events from `tx.AssetMint()` across all transaction paths, skips phase‑2 invalid txs, deletes rows on rollback, and is idempotent via the unique key.
  - Adapter derives `initial_mint_tx_hash` and `mint_or_burn_count` via `MetadataStore.GetAssetMintBurnInfo`.
  - Implemented CIP‑25 parsing (v1/v2) from the initial mint tx’s metadata; key format is chosen by detected version to avoid mismatches.
  - Loads only the tx metadata blob via `GetTransactionMetadataByHash` to resolve on‑chain metadata without full preloads.
  - Updated `AssetInfo`/handler to return `onchain_metadata`, `onchain_metadata_standard`, `onchain_metadata_extra`, and `metadata` (off‑chain registry and CIP‑68 remain `null`). Added tests and docs.

- **Migration**
  - Run DB migrations to create `asset_mint_burn`.
  - Works in API storage mode only; core mode returns `null`/zero for these fields.
  - History is recorded for transactions processed after upgrade; resync if you need full past history.

<sup>Written for commit eda2af599d227de5b239f610537910f55319dcb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset responses now include mint/burn event counts and the initial mint transaction hash.
  * On-chain CIP-25 metadata is now surfaced, including the detected metadata standard.
  * Mint/burn history is tracked across supported database backends, with rollback consistency and duplicate protection.

* **Documentation**
  * Updated architecture and database documentation with asset mint/burn tracking and metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->