### PR TITLE
fix(ledger): reword mithril warn log

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -945,7 +945,7 @@ func (ls *LedgerState) leaderEligibilityStake(
 	if ls.isMithrilImportedMarkSnapshot(snapshot, snapshotEpoch) {
 		if ls.config.Logger != nil {
 			ls.config.Logger.Warn(
-				"skipping leader eligibility check: mark snapshot captured after target epoch start",
+				"skipping leader eligibility check: Mithril-imported mark snapshot captured mid-epoch, not at the epoch boundary",
 				"slot", block.SlotNumber(),
 				"epoch", epochId,
 				"snapshot_epoch", snapshotEpoch,

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1768,7 +1768,7 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	assert.NoError(t, err)
-	assert.Contains(t, logBuf.String(), "mark snapshot captured after target epoch start")
+	assert.Contains(t, logBuf.String(), "Mithril-imported mark snapshot captured mid-epoch, not at the epoch boundary")
 	assert.NotContains(t, logBuf.String(), "total active stake is zero")
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the warn log when skipping leader eligibility due to a Mithril-imported mark snapshot captured mid-epoch (not at the epoch boundary), and updated the test to match the new wording.

<sup>Written for commit b2fc18f21a6f80ccfbfb32f9227af20a2c64b504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

