### PR TITLE
fix(peergov): reduce duplex-dedupe EOF to info

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -54,7 +54,13 @@ func isExpectedNetworkDialError(err error) bool {
 		strings.Contains(msg, "i/o timeout") ||
 		strings.Contains(msg, "cannot assign requested address") ||
 		strings.Contains(msg, "version data mismatch") ||
-		strings.Contains(msg, "timeout waiting on transition")
+		strings.Contains(msg, "timeout waiting on transition") ||
+		// gouroboros reports a crossing duplicate connection pruned during
+		// the handshake (duplex connection-manager dedup) as an EOF-wrapped
+		// "connection shutdown initiated". This happens routinely when a peer
+		// dials us while we dial it; the surviving duplex connection carries
+		// diffusion both ways, so it is expected rather than a dial failure.
+		strings.Contains(msg, "connection shutdown initiated")
 }
 
 // shortLivedReconnectDelay returns the exponential backoff rung for the

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -60,7 +60,8 @@ func isExpectedNetworkDialError(err error) bool {
 		// "connection shutdown initiated". This happens routinely when a peer
 		// dials us while we dial it; the surviving duplex connection carries
 		// diffusion both ways, so it is expected rather than a dial failure.
-		strings.Contains(msg, "connection shutdown initiated")
+		(errors.Is(err, io.EOF) &&
+			strings.Contains(msg, "connection shutdown initiated"))
 }
 
 // shortLivedReconnectDelay returns the exponential backoff rung for the

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -217,6 +217,11 @@ func TestIsExpectedNetworkDialError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "connection shutdown initiated without eof",
+			err:  errors.New("connection shutdown initiated: handshake failed"),
+			want: false,
+		},
+		{
 			name: "nil",
 			err:  nil,
 			want: false,

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -206,6 +206,17 @@ func TestIsExpectedNetworkDialError(t *testing.T) {
 			want: false,
 		},
 		{
+			// gouroboros closes the muxer with this error when a crossing
+			// duplicate connection is pruned during the handshake (duplex
+			// connection-manager dedup). It is benign, not a dial failure.
+			name: "connection shutdown initiated eof (duplex dedup)",
+			err: fmt.Errorf(
+				"connection shutdown initiated: %w",
+				io.EOF,
+			),
+			want: true,
+		},
+		{
 			name: "nil",
 			err:  nil,
 			want: false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Downgrade duplex-dedup EOFs from `gouroboros` (“connection shutdown initiated”) to expected dial errors so they log at info, not error. This reduces noise from crossing dials where the surviving connection is healthy.

- **Bug Fixes**
  - Treat “connection shutdown initiated” as expected only when wrapped with `io.EOF` in `isExpectedNetworkDialError`.
  - Add tests for the duplex-dedup EOF case and a non-EOF “connection shutdown initiated” to prevent false positives.

<sup>Written for commit e011dd8c3af49fe3e5278596bfe4fe5ed086e02e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

