### PR TITLE
test(ouroboros): Add server-side ChainSync protocol tests

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -59,6 +59,8 @@ const (
 	chainsyncDivergentPeerCooldown = 2 * time.Minute
 )
 
+var chainsyncRestartAfter = time.After
+
 func effectiveChainsyncBlockTimeout(timeout time.Duration) time.Duration {
 	if timeout < ochainsync.MustReplyTimeoutMax {
 		return ochainsync.MustReplyTimeoutMax
@@ -1064,7 +1066,7 @@ func (o *Ouroboros) restartChainsyncClientAsync(
 			)
 			closeConn()
 			<-done
-		case <-time.After(chainsyncRestartTimeout):
+		case <-chainsyncRestartAfter(chainsyncRestartTimeout):
 			o.config.Logger.Warn(
 				"chainsync restart timed out, closing connection",
 				"connection_id", connId.String(),

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -17,15 +17,18 @@ package ouroboros
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"maps"
 	"net"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
@@ -211,6 +214,32 @@ func newTestLedgerState(t *testing.T) *ledger.LedgerState {
 	})
 	require.NoError(t, err)
 	return ls
+}
+
+func setTestLedgerTip(
+	t *testing.T,
+	ls *ledger.LedgerState,
+	tip ochainsync.Tip,
+) {
+	t.Helper()
+	field := reflect.ValueOf(ls).Elem().FieldByName("currentTip")
+	require.True(t, field.IsValid())
+	reflect.NewAt(
+		field.Type(),
+		unsafe.Pointer(field.UnsafeAddr()),
+	).Elem().Set(reflect.ValueOf(tip))
+}
+
+func testLedgerDB(t *testing.T, ls *ledger.LedgerState) *database.Database {
+	t.Helper()
+	field := reflect.ValueOf(ls).Elem().FieldByName("db")
+	require.True(t, field.IsValid())
+	db, ok := reflect.NewAt(
+		field.Type(),
+		unsafe.Pointer(field.UnsafeAddr()),
+	).Elem().Interface().(*database.Database)
+	require.True(t, ok)
+	return db
 }
 
 func snapshotChainsyncNtNTimeouts() map[string]struct {
@@ -486,6 +515,482 @@ func TestChainsyncServerRequestNext_AsyncRollBackwardErrorClosesConnection(
 		h,
 		"async RollBackward send failure should close the connection",
 	)
+}
+
+// TestChainsyncServerFindIntersect_MatchingPointRegistersClient verifies a
+// common point returns the server tip and registers downstream client state.
+func TestChainsyncServerFindIntersect_MatchingPointRegistersClient(
+	t *testing.T,
+) {
+	o := newFindIntersectTestOuroboros(t)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  1,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, o.LedgerState.Chain().AddBlock(block, nil))
+	point := ocommon.NewPoint(block.SlotNumber(), block.Hash().Bytes())
+	setTestLedgerTip(t, o.LedgerState, ochainsync.Tip{
+		Point:       point,
+		BlockNumber: block.BlockNumber(),
+	})
+
+	gotPoint, tip, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		[]ocommon.Point{point},
+	)
+	require.NoError(t, err)
+	require.Equal(t, point, gotPoint)
+	require.Equal(t, point, tip.Point)
+	require.Equal(t, block.BlockNumber(), tip.BlockNumber)
+
+	clientState, err := o.ChainsyncState.AddClient(connId, point)
+	require.NoError(t, err)
+	require.Equal(t, point, clientState.Cursor)
+	require.True(t, clientState.NeedsInitialRollback)
+}
+
+// TestChainsyncServerFindIntersect_MissingIntersection verifies that an
+// in-range but unknown point returns the protocol IntersectNotFound error.
+func TestChainsyncServerFindIntersect_MissingIntersection(
+	t *testing.T,
+) {
+	o := newFindIntersectTestOuroboros(t)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  10,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, o.LedgerState.Chain().AddBlock(block, nil))
+	setTestLedgerTip(t, o.LedgerState, ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			block.SlotNumber(),
+			block.Hash().Bytes(),
+		),
+		BlockNumber: block.BlockNumber(),
+	})
+
+	_, _, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		[]ocommon.Point{ocommon.NewPoint(10, gledger.Blake2b256{0xff}.Bytes())},
+	)
+	require.ErrorIs(t, err, ochainsync.ErrIntersectNotFound)
+}
+
+// TestChainsyncServerFindIntersect_LedgerErrorPropagates verifies ledger
+// lookup failures are wrapped and returned to the protocol layer.
+func TestChainsyncServerFindIntersect_LedgerErrorPropagates(
+	t *testing.T,
+) {
+	o := newFindIntersectTestOuroboros(t)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  10,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, o.LedgerState.Chain().AddBlock(block, nil))
+	setTestLedgerTip(t, o.LedgerState, ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			block.SlotNumber(),
+			block.Hash().Bytes(),
+		),
+		BlockNumber: block.BlockNumber(),
+	})
+
+	_, _, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		[]ocommon.Point{ocommon.NewPoint(10, []byte{0xff})},
+	)
+	require.ErrorContains(t, err, "get intersect point")
+	require.ErrorContains(t, err, "parsing block key")
+}
+
+// TestChainsyncServerFindIntersect_ClientRegistrationFailure verifies
+// successful intersections still fail when server client state cannot register.
+func TestChainsyncServerFindIntersect_ClientRegistrationFailure(
+	t *testing.T,
+) {
+	o := newFindIntersectTestOuroboros(t)
+	o.ChainsyncState = dchainsync.NewState(o.EventBus, nil)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+
+	_, _, err := o.chainsyncServerFindIntersect(
+		ochainsync.CallbackContext{ConnectionId: connId},
+		[]ocommon.Point{ocommon.NewPointOrigin()},
+	)
+	require.ErrorContains(t, err, "add chainsync client")
+	require.ErrorContains(t, err, "no chain provider available")
+}
+
+// TestChainsyncServerRequestNext_AddClientFailure verifies RequestNext returns
+// registration errors before attempting any protocol response.
+func TestChainsyncServerRequestNext_AddClientFailure(
+	t *testing.T,
+) {
+	o := newFindIntersectTestOuroboros(t)
+	o.ChainsyncState = dchainsync.NewState(o.EventBus, nil)
+	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+
+	err := o.chainsyncServerRequestNext(
+		ochainsync.CallbackContext{ConnectionId: connId},
+	)
+	require.ErrorContains(t, err, "add chainsync client")
+	require.ErrorContains(t, err, "no chain provider available")
+}
+
+// TestChainsyncServerRequestNext_InitialRollbackClearsFlag verifies the first
+// RequestNext sends the initial rollback and clears the one-shot flag.
+func TestChainsyncServerRequestNext_InitialRollbackClearsFlag(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	ctx := ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	}
+
+	require.NoError(t, h.o.chainsyncServerRequestNext(ctx))
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	require.False(t, clientState.NeedsInitialRollback)
+}
+
+// TestChainsyncServerRequestNext_ImmediateForwardBlock verifies an available
+// iterator block is sent immediately instead of parking in AwaitReply.
+func TestChainsyncServerRequestNext_ImmediateForwardBlock(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  1,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, h.ledgerState.Chain().AddBlock(block, nil))
+
+	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	})
+	require.NoError(t, err)
+	_, err = clientState.ChainIter.Next(false)
+	require.ErrorIs(t, err, chain.ErrIteratorChainTip)
+}
+
+// TestChainsyncServerRequestNext_ImmediateRollbackEvent verifies a pending
+// iterator rollback is sent immediately on the synchronous RequestNext path.
+func TestChainsyncServerRequestNext_ImmediateRollbackEvent(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+	block := &testBlock{
+		testBlockHeader: &testBlockHeader{
+			hash:        gledger.Blake2b256{0x01},
+			blockNumber: 1,
+			slotNumber:  1,
+		},
+		blockType: 1,
+		cbor:      []byte{0x80},
+	}
+	require.NoError(t, h.ledgerState.Chain().AddBlock(block, nil))
+	next, err := clientState.ChainIter.Next(false)
+	require.NoError(t, err)
+	require.False(t, next.Rollback)
+	require.NoError(t, h.ledgerState.Chain().Rollback(ocommon.NewPointOrigin()))
+
+	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	})
+	require.NoError(t, err)
+	_, err = clientState.ChainIter.Next(false)
+	require.ErrorIs(t, err, chain.ErrIteratorChainTip)
+}
+
+// TestChainsyncServerRequestNext_AwaitReplyAtIteratorTip verifies the server
+// sends AwaitReply when the iterator has reached the current chain tip.
+func TestChainsyncServerRequestNext_AwaitReplyAtIteratorTip(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+
+	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	})
+	require.NoError(t, err)
+}
+
+// TestChainsyncServerRequestNext_SyncIteratorErrorPropagates verifies real
+// iterator failures are returned instead of being treated as chain tip.
+func TestChainsyncServerRequestNext_SyncIteratorErrorPropagates(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+	require.NoError(t, testLedgerDB(t, h.ledgerState).Close())
+
+	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, chain.ErrIteratorChainTip)
+}
+
+// TestChainsyncServerRequestNext_AwaitReplyErrorPropagates verifies
+// AwaitReply send failures are returned from the callback.
+func TestChainsyncServerRequestNext_AwaitReplyErrorPropagates(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+	h.server.Stop()
+
+	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	})
+	require.Error(t, err)
+}
+
+// TestChainsyncServerRequestNext_MissingConnectionAfterAwaitReply verifies
+// the async wait path fails when the connection was already recycled.
+func TestChainsyncServerRequestNext_MissingConnectionAfterAwaitReply(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+	require.True(t, h.o.ConnManager.RemoveConnection(h.conn.Id(), h.conn))
+
+	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	})
+	require.ErrorContains(t, err, "not found")
+}
+
+// TestChainsyncServerRequestNext_AsyncIteratorCancelDoesNotCloseConnection
+// verifies expected iterator cancellation does not recycle the connection.
+func TestChainsyncServerRequestNext_AsyncIteratorCancelDoesNotCloseConnection(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	clientState, err := h.o.ChainsyncState.AddClient(
+		h.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
+	clientState.NeedsInitialRollback = false
+
+	require.NoError(t, h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
+		ConnectionId: h.conn.Id(),
+		Server:       h.server,
+	}))
+	clientState.ChainIter.Cancel()
+	testutil.RequireNoReceive(
+		t,
+		h.closedCh,
+		100*time.Millisecond,
+		"iterator cancellation should not close connection",
+	)
+}
+
+// TestRestartChainsyncClientAsync_TimeoutClosesConnection verifies a hung
+// restart is bounded by chainsyncRestartTimeout and recycles the connection.
+func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	timeoutCh := make(chan time.Time)
+	oldRestartAfter := chainsyncRestartAfter
+	chainsyncRestartAfter = func(timeout time.Duration) <-chan time.Time {
+		require.Equal(t, chainsyncRestartTimeout, timeout)
+		return timeoutCh
+	}
+	t.Cleanup(func() { chainsyncRestartAfter = oldRestartAfter })
+	restartStarted := make(chan struct{})
+	releaseRestart := make(chan struct{})
+
+	h.o.restartChainsyncClientAsync(
+		context.Background(),
+		h.conn.Id(),
+		"test-timeout",
+		func() error {
+			close(restartStarted)
+			<-releaseRestart
+			return nil
+		},
+	)
+	testutil.RequireReceive(
+		t,
+		restartStarted,
+		5*time.Second,
+		"restart function should start",
+	)
+	timeoutCh <- time.Now()
+	evt := testutil.RequireReceive(
+		t,
+		h.closedCh,
+		5*time.Second,
+		"restart timeout should close the connection",
+	)
+	closed, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+	require.True(t, ok)
+	require.Equal(t, h.conn.Id(), closed.ConnectionId)
+	close(releaseRestart)
+}
+
+// TestRestartChainsyncClientAsync_ContextCancelClosesConnection verifies node
+// shutdown cancellation aborts restart and closes the connection.
+func TestRestartChainsyncClientAsync_ContextCancelClosesConnection(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	restartStarted := make(chan struct{})
+	releaseRestart := make(chan struct{})
+
+	h.o.restartChainsyncClientAsync(
+		ctx,
+		h.conn.Id(),
+		"test-context-cancel",
+		func() error {
+			close(restartStarted)
+			<-releaseRestart
+			return nil
+		},
+	)
+	testutil.RequireReceive(
+		t,
+		restartStarted,
+		5*time.Second,
+		"restart function should start",
+	)
+	cancel()
+	evt := testutil.RequireReceive(
+		t,
+		h.closedCh,
+		5*time.Second,
+		"context cancellation should close the connection",
+	)
+	closed, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+	require.True(t, ok)
+	require.Equal(t, h.conn.Id(), closed.ConnectionId)
+	close(releaseRestart)
+}
+
+// TestRestartChainsyncClientAsync_SuccessLeavesConnectionOpen verifies a
+// completed restart does not emit connection-close lifecycle events.
+func TestRestartChainsyncClientAsync_SuccessLeavesConnectionOpen(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	restartDone := make(chan struct{})
+
+	h.o.restartChainsyncClientAsync(
+		context.Background(),
+		h.conn.Id(),
+		"test-success",
+		func() error {
+			close(restartDone)
+			return nil
+		},
+	)
+	testutil.RequireReceive(
+		t,
+		restartDone,
+		5*time.Second,
+		"restart function should complete",
+	)
+	testutil.RequireNoReceive(
+		t,
+		h.closedCh,
+		100*time.Millisecond,
+		"successful restart should leave connection open",
+	)
+}
+
+// TestRestartChainsyncClientAsync_RestartFailureClosesConnection verifies
+// restart function errors recycle the affected connection.
+func TestRestartChainsyncClientAsync_RestartFailureClosesConnection(
+	t *testing.T,
+) {
+	h := newChainsyncAsyncSendFailureHarness(t)
+	expectedErr := errors.New("restart failed")
+
+	h.o.restartChainsyncClientAsync(
+		context.Background(),
+		h.conn.Id(),
+		"test-failure",
+		func() error {
+			return expectedErr
+		},
+	)
+	evt := testutil.RequireReceive(
+		t,
+		h.closedCh,
+		5*time.Second,
+		"restart failure should close the connection",
+	)
+	closed, ok := evt.Data.(connmanager.ConnectionClosedEvent)
+	require.True(t, ok)
+	require.Equal(t, h.conn.Id(), closed.ConnectionId)
 }
 
 func TestNormalizeIntersectPoints(t *testing.T) {

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -230,18 +230,6 @@ func setTestLedgerTip(
 	).Elem().Set(reflect.ValueOf(tip))
 }
 
-func testLedgerDB(t *testing.T, ls *ledger.LedgerState) *database.Database {
-	t.Helper()
-	field := reflect.ValueOf(ls).Elem().FieldByName("db")
-	require.True(t, field.IsValid())
-	db, ok := reflect.NewAt(
-		field.Type(),
-		unsafe.Pointer(field.UnsafeAddr()),
-	).Elem().Interface().(*database.Database)
-	require.True(t, ok)
-	return db
-}
-
 func snapshotChainsyncNtNTimeouts() map[string]struct {
 	timeout        time.Duration
 	hasTimeoutFunc bool
@@ -825,7 +813,7 @@ func TestChainsyncServerRequestNext_SyncIteratorErrorPropagates(
 	)
 	require.NoError(t, err)
 	clientState.NeedsInitialRollback = false
-	require.NoError(t, testLedgerDB(t, h.ledgerState).Close())
+	require.NoError(t, h.ledgerState.Database().Close())
 
 	// Request the next item from the now-broken iterator.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -522,6 +522,8 @@ func TestChainsyncServerRequestNext_AsyncRollBackwardErrorClosesConnection(
 func TestChainsyncServerFindIntersect_MatchingPointRegistersClient(
 	t *testing.T,
 ) {
+	// Create a local chain with one known point and expose it as the ledger
+	// tip so FindIntersect takes the normal non-origin path.
 	o := newFindIntersectTestOuroboros(t)
 	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
 	block := &testBlock{
@@ -540,10 +542,14 @@ func TestChainsyncServerFindIntersect_MatchingPointRegistersClient(
 		BlockNumber: block.BlockNumber(),
 	})
 
+	// Ask the server to intersect at the point we know exists.
 	gotPoint, tip, err := o.chainsyncServerFindIntersect(
 		ochainsync.CallbackContext{ConnectionId: connId},
 		[]ocommon.Point{point},
 	)
+
+	// The callback returns the match, reports the tip, and leaves downstream
+	// client state registered at the intersect point.
 	require.NoError(t, err)
 	require.Equal(t, point, gotPoint)
 	require.Equal(t, point, tip.Point)
@@ -560,6 +566,8 @@ func TestChainsyncServerFindIntersect_MatchingPointRegistersClient(
 func TestChainsyncServerFindIntersect_MissingIntersection(
 	t *testing.T,
 ) {
+	// Create a chain tip, then prepare an in-range point with a different
+	// hash so the lookup is valid but does not intersect.
 	o := newFindIntersectTestOuroboros(t)
 	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
 	block := &testBlock{
@@ -580,10 +588,14 @@ func TestChainsyncServerFindIntersect_MissingIntersection(
 		BlockNumber: block.BlockNumber(),
 	})
 
+	// Submit the nonmatching point list to the server callback.
 	_, _, err := o.chainsyncServerFindIntersect(
 		ochainsync.CallbackContext{ConnectionId: connId},
 		[]ocommon.Point{ocommon.NewPoint(10, gledger.Blake2b256{0xff}.Bytes())},
 	)
+
+	// The callback maps the missing intersection to the protocol
+	// ErrIntersectNotFound response.
 	require.ErrorIs(t, err, ochainsync.ErrIntersectNotFound)
 }
 
@@ -592,6 +604,8 @@ func TestChainsyncServerFindIntersect_MissingIntersection(
 func TestChainsyncServerFindIntersect_LedgerErrorPropagates(
 	t *testing.T,
 ) {
+	// Move the ledger past origin so malformed point data reaches the
+	// database-backed intersection lookup.
 	o := newFindIntersectTestOuroboros(t)
 	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
 	block := &testBlock{
@@ -612,10 +626,15 @@ func TestChainsyncServerFindIntersect_LedgerErrorPropagates(
 		BlockNumber: block.BlockNumber(),
 	})
 
+	// Submit a malformed point hash that causes the ledger lookup to fail
+	// while resolving the candidate block.
 	_, _, err := o.chainsyncServerFindIntersect(
 		ochainsync.CallbackContext{ConnectionId: connId},
 		[]ocommon.Point{ocommon.NewPoint(10, []byte{0xff})},
 	)
+
+	// The server wraps and returns the ledger error to the protocol layer
+	// instead of hiding it as an ordinary miss.
 	require.ErrorContains(t, err, "get intersect point")
 	require.ErrorContains(t, err, "parsing block key")
 }
@@ -625,14 +644,20 @@ func TestChainsyncServerFindIntersect_LedgerErrorPropagates(
 func TestChainsyncServerFindIntersect_ClientRegistrationFailure(
 	t *testing.T,
 ) {
+	// Use a ledger that can intersect at origin, but a ChainsyncState without
+	// a chain provider so client registration must fail.
 	o := newFindIntersectTestOuroboros(t)
 	o.ChainsyncState = dchainsync.NewState(o.EventBus, nil)
 	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
 
+	// Perform FindIntersect with origin so registration is the first failing
+	// operation after a successful intersection.
 	_, _, err := o.chainsyncServerFindIntersect(
 		ochainsync.CallbackContext{ConnectionId: connId},
 		[]ocommon.Point{ocommon.NewPointOrigin()},
 	)
+
+	// The registration error is surfaced to the caller.
 	require.ErrorContains(t, err, "add chainsync client")
 	require.ErrorContains(t, err, "no chain provider available")
 }
@@ -642,13 +667,18 @@ func TestChainsyncServerFindIntersect_ClientRegistrationFailure(
 func TestChainsyncServerRequestNext_AddClientFailure(
 	t *testing.T,
 ) {
+	// Configure RequestNext with ChainsyncState that cannot build a
+	// server-side iterator for the downstream client.
 	o := newFindIntersectTestOuroboros(t)
 	o.ChainsyncState = dchainsync.NewState(o.EventBus, nil)
 	connId := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
 
+	// Enter RequestNext before any protocol response can be sent.
 	err := o.chainsyncServerRequestNext(
 		ochainsync.CallbackContext{ConnectionId: connId},
 	)
+
+	// AddClient failure is returned directly from the callback.
 	require.ErrorContains(t, err, "add chainsync client")
 	require.ErrorContains(t, err, "no chain provider available")
 }
@@ -658,13 +688,18 @@ func TestChainsyncServerRequestNext_AddClientFailure(
 func TestChainsyncServerRequestNext_InitialRollbackClearsFlag(
 	t *testing.T,
 ) {
+	// Start a real server protocol with a fresh downstream client that still
+	// needs its initial rollback response.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	ctx := ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	}
 
+	// Handle the first RequestNext for this connection.
 	require.NoError(t, h.o.chainsyncServerRequestNext(ctx))
+
+	// The one-shot initial rollback state has been consumed.
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
 		ocommon.NewPointOrigin(),
@@ -678,6 +713,8 @@ func TestChainsyncServerRequestNext_InitialRollbackClearsFlag(
 func TestChainsyncServerRequestNext_ImmediateForwardBlock(
 	t *testing.T,
 ) {
+	// Register the downstream client and append a block that the iterator can
+	// return without entering AwaitReply.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -696,10 +733,13 @@ func TestChainsyncServerRequestNext_ImmediateForwardBlock(
 	}
 	require.NoError(t, h.ledgerState.Chain().AddBlock(block, nil))
 
+	// Request the next item from the server-side ChainSync callback.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	})
+
+	// The immediate block was consumed by the RollForward path.
 	require.NoError(t, err)
 	_, err = clientState.ChainIter.Next(false)
 	require.ErrorIs(t, err, chain.ErrIteratorChainTip)
@@ -710,6 +750,8 @@ func TestChainsyncServerRequestNext_ImmediateForwardBlock(
 func TestChainsyncServerRequestNext_ImmediateRollbackEvent(
 	t *testing.T,
 ) {
+	// Move the iterator past a block, then roll the chain back so the next
+	// synchronous iterator result is a rollback event.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -732,10 +774,13 @@ func TestChainsyncServerRequestNext_ImmediateRollbackEvent(
 	require.False(t, next.Rollback)
 	require.NoError(t, h.ledgerState.Chain().Rollback(ocommon.NewPointOrigin()))
 
+	// Request the next item from the server-side ChainSync callback.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	})
+
+	// The rollback was consumed by the RollBackward path.
 	require.NoError(t, err)
 	_, err = clientState.ChainIter.Next(false)
 	require.ErrorIs(t, err, chain.ErrIteratorChainTip)
@@ -746,6 +791,8 @@ func TestChainsyncServerRequestNext_ImmediateRollbackEvent(
 func TestChainsyncServerRequestNext_AwaitReplyAtIteratorTip(
 	t *testing.T,
 ) {
+	// Register a downstream client at origin with no block or rollback
+	// immediately available from the iterator.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -754,10 +801,13 @@ func TestChainsyncServerRequestNext_AwaitReplyAtIteratorTip(
 	require.NoError(t, err)
 	clientState.NeedsInitialRollback = false
 
+	// Request the next item while the iterator is at chain tip.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	})
+
+	// AwaitReply is sent successfully and async waiting is armed.
 	require.NoError(t, err)
 }
 
@@ -766,6 +816,8 @@ func TestChainsyncServerRequestNext_AwaitReplyAtIteratorTip(
 func TestChainsyncServerRequestNext_SyncIteratorErrorPropagates(
 	t *testing.T,
 ) {
+	// Register a client, skip initial rollback, and close the backing DB so
+	// the synchronous iterator returns a real lookup error.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -775,10 +827,14 @@ func TestChainsyncServerRequestNext_SyncIteratorErrorPropagates(
 	clientState.NeedsInitialRollback = false
 	require.NoError(t, testLedgerDB(t, h.ledgerState).Close())
 
+	// Request the next item from the now-broken iterator.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	})
+
+	// The real iterator error propagates instead of being treated as the
+	// normal chain-tip sentinel.
 	require.Error(t, err)
 	require.NotErrorIs(t, err, chain.ErrIteratorChainTip)
 }
@@ -788,6 +844,8 @@ func TestChainsyncServerRequestNext_SyncIteratorErrorPropagates(
 func TestChainsyncServerRequestNext_AwaitReplyErrorPropagates(
 	t *testing.T,
 ) {
+	// Stop the protocol before RequestNext reaches the AwaitReply send path,
+	// causing the send to fail.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -797,10 +855,13 @@ func TestChainsyncServerRequestNext_AwaitReplyErrorPropagates(
 	clientState.NeedsInitialRollback = false
 	h.server.Stop()
 
+	// Request next while the iterator is at tip.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	})
+
+	// The AwaitReply send failure is returned to the caller.
 	require.Error(t, err)
 }
 
@@ -809,6 +870,8 @@ func TestChainsyncServerRequestNext_AwaitReplyErrorPropagates(
 func TestChainsyncServerRequestNext_MissingConnectionAfterAwaitReply(
 	t *testing.T,
 ) {
+	// Register a client, then remove its connection before the callback
+	// reaches the post-AwaitReply connection lookup.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -818,10 +881,13 @@ func TestChainsyncServerRequestNext_MissingConnectionAfterAwaitReply(
 	clientState.NeedsInitialRollback = false
 	require.True(t, h.o.ConnManager.RemoveConnection(h.conn.Id(), h.conn))
 
+	// Request next while the iterator is at tip.
 	err = h.o.chainsyncServerRequestNext(ochainsync.CallbackContext{
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	})
+
+	// The missing connection guard returns an explicit error.
 	require.ErrorContains(t, err, "not found")
 }
 
@@ -830,6 +896,8 @@ func TestChainsyncServerRequestNext_MissingConnectionAfterAwaitReply(
 func TestChainsyncServerRequestNext_AsyncIteratorCancelDoesNotCloseConnection(
 	t *testing.T,
 ) {
+	// Park the server in AwaitReply so the async goroutine blocks in
+	// ChainIter.Next(true), then cancel that iterator.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	clientState, err := h.o.ChainsyncState.AddClient(
 		h.conn.Id(),
@@ -842,7 +910,12 @@ func TestChainsyncServerRequestNext_AsyncIteratorCancelDoesNotCloseConnection(
 		ConnectionId: h.conn.Id(),
 		Server:       h.server,
 	}))
+
+	// Cancel the iterator to simulate normal connection/iterator cleanup.
 	clientState.ChainIter.Cancel()
+
+	// Expected iterator cancellation is ignored and does not emit a
+	// connection-close lifecycle event.
 	testutil.RequireNoReceive(
 		t,
 		h.closedCh,
@@ -856,6 +929,8 @@ func TestChainsyncServerRequestNext_AsyncIteratorCancelDoesNotCloseConnection(
 func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
 	t *testing.T,
 ) {
+	// Replace the restart timer with a test channel and block the restart
+	// function so the timeout branch is deterministic.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	timeoutCh := make(chan time.Time)
 	oldRestartAfter := chainsyncRestartAfter
@@ -867,6 +942,7 @@ func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
 	restartStarted := make(chan struct{})
 	releaseRestart := make(chan struct{})
 
+	// Start restart, wait until it is running, then trigger timeout.
 	h.o.restartChainsyncClientAsync(
 		context.Background(),
 		h.conn.Id(),
@@ -884,6 +960,8 @@ func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
 		"restart function should start",
 	)
 	timeoutCh <- time.Now()
+
+	// The timeout branch closes/recycles the connection.
 	evt := testutil.RequireReceive(
 		t,
 		h.closedCh,
@@ -901,11 +979,14 @@ func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
 func TestRestartChainsyncClientAsync_ContextCancelClosesConnection(
 	t *testing.T,
 ) {
+	// Start a restart under a cancellable context and block the restart
+	// function so ctx.Done can win the select.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	restartStarted := make(chan struct{})
 	releaseRestart := make(chan struct{})
 
+	// Start restart, wait until it is running, then cancel the context.
 	h.o.restartChainsyncClientAsync(
 		ctx,
 		h.conn.Id(),
@@ -923,6 +1004,8 @@ func TestRestartChainsyncClientAsync_ContextCancelClosesConnection(
 		"restart function should start",
 	)
 	cancel()
+
+	// Cancellation closes/recycles the connection.
 	evt := testutil.RequireReceive(
 		t,
 		h.closedCh,
@@ -940,9 +1023,12 @@ func TestRestartChainsyncClientAsync_ContextCancelClosesConnection(
 func TestRestartChainsyncClientAsync_SuccessLeavesConnectionOpen(
 	t *testing.T,
 ) {
+	// Prepare a restart function that completes normally and signals when the
+	// goroutine has run.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	restartDone := make(chan struct{})
 
+	// Run the restart path without returning an error.
 	h.o.restartChainsyncClientAsync(
 		context.Background(),
 		h.conn.Id(),
@@ -958,6 +1044,8 @@ func TestRestartChainsyncClientAsync_SuccessLeavesConnectionOpen(
 		5*time.Second,
 		"restart function should complete",
 	)
+
+	// A successful restart does not close the connection.
 	testutil.RequireNoReceive(
 		t,
 		h.closedCh,
@@ -971,9 +1059,11 @@ func TestRestartChainsyncClientAsync_SuccessLeavesConnectionOpen(
 func TestRestartChainsyncClientAsync_RestartFailureClosesConnection(
 	t *testing.T,
 ) {
+	// Prepare a restart function that fails immediately.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	expectedErr := errors.New("restart failed")
 
+	// Run the async restart path with a failing function.
 	h.o.restartChainsyncClientAsync(
 		context.Background(),
 		h.conn.Id(),
@@ -988,6 +1078,8 @@ func TestRestartChainsyncClientAsync_RestartFailureClosesConnection(
 		5*time.Second,
 		"restart failure should close the connection",
 	)
+
+	// Restart failure closes/recycles the affected connection.
 	closed, ok := evt.Data.(connmanager.ConnectionClosedEvent)
 	require.True(t, ok)
 	require.Equal(t, h.conn.Id(), closed.ConnectionId)

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -933,9 +933,10 @@ func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
 	// function so the timeout branch is deterministic.
 	h := newChainsyncAsyncSendFailureHarness(t)
 	timeoutCh := make(chan time.Time)
+	timeoutArgCh := make(chan time.Duration, 1)
 	oldRestartAfter := chainsyncRestartAfter
 	chainsyncRestartAfter = func(timeout time.Duration) <-chan time.Time {
-		require.Equal(t, chainsyncRestartTimeout, timeout)
+		timeoutArgCh <- timeout
 		return timeoutCh
 	}
 	t.Cleanup(func() { chainsyncRestartAfter = oldRestartAfter })
@@ -958,6 +959,16 @@ func TestRestartChainsyncClientAsync_TimeoutClosesConnection(
 		restartStarted,
 		5*time.Second,
 		"restart function should start",
+	)
+	require.Equal(
+		t,
+		chainsyncRestartTimeout,
+		testutil.RequireReceive(
+			t,
+			timeoutArgCh,
+			5*time.Second,
+			"restart timeout duration should be requested",
+		),
 	)
 	timeoutCh <- time.Now()
 


### PR DESCRIPTION
1. Added focused server-side ChainSync tests for `FindIntersect`, `RequestNext`, `async iterator/send behavior`, and restart lifecycle handling.
2. Added `TestChainsyncServerFindIntersect_MatchingPointRegistersClient` to verify the server returns the matched intersection/tip and creates downstream client cursor state.
3. Added `TestChainsyncServerFindIntersect_MissingIntersection` to verify the server returns `ErrIntersectNotFound` when no supplied point exists on the local chain.
4. Added `TestChainsyncServerFindIntersect_LedgerErrorPropagates` to verify malformed/failed ledger intersection lookups are returned as protocol callback errors.
5. Added `TestChainsyncServerFindIntersect_ClientRegistrationFailure` to verify intersection success still fails if `ChainsyncState` cannot register the client.
6. Added `TestChainsyncServerRequestNext_AddClientFailure` to verify `RequestNext` stops early and returns client-state registration errors.
7. Added `TestChainsyncServerRequestNext_InitialRollbackClearsFlag` to verify the first [RequestNext](url) sends the initial rollback and clears `NeedsInitialRollback`.
8. Added `TestChainsyncServerRequestNext_ImmediateForwardBlock` to verify an available iterator block is sent immediately through `RollForward`.
9. Added `TestChainsyncServerRequestNext_ImmediateRollbackEvent` to verify a pending iterator rollback is sent immediately through `RollBackward`.
10. Added `TestChainsyncServerRequestNext_AwaitReplyAtIteratorTip` to verify the server sends `AwaitReply` when no block/rollback is immediately available.
11. Added `TestChainsyncServerRequestNext_SyncIteratorErrorPropagates` to verify real iterator/DB errors from Next(false) are returned, not treated as normal chain tip.
12. Added `TestChainsyncServerRequestNext_AwaitReplyErrorPropagates` to verify `AwaitReply` send failures propagate out of the callback.
13. Added `TestChainsyncServerRequestNext_MissingConnectionAfterAwaitReply` to verify the async wait path returns an error if the connection has already been recycled.
14. Added TestChainsyncServerRequestNext_AsyncIteratorCancelDoesNotCloseConnection to verify expected iterator cancellation after `AwaitReply` does not close the peer connection.
15. Added `TestRestartChainsyncClientAsync_TimeoutClosesConnection` to verify a hung restart is bounded by `chainsyncRestartTimeout` and closes/recycles the connection.
16. Added `TestRestartChainsyncClientAsync_ContextCancelClosesConnection` to verify node shutdown cancellation aborts restart and closes/recycles the connection.
17. Added `TestRestartChainsyncClientAsync_SuccessLeavesConnectionOpen` to verify a completed restart does not emit connection-close lifecycle events.
18. Added `TestRestartChainsyncClientAsync_RestartFailureClosesConnection` to verify restart function errors close/recycle the affected connection.
19. Verified with `go test ./ouroboros -run 'TestChainsyncServer|TestRestartChainsyncClientAsync'` , `go test ./ouroboros` and `go test -count=1 -race ./ouroboros`.

Closes #2255 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved ChainSync connection handling during restarts, cancellations, timeouts, and restart failures.
  * Improved synchronization behavior when locating chain intersections and requesting the next update.
  * Preserved active connections during successful operations and appropriate cancellation scenarios.

* **Tests**
  * Expanded coverage for ChainSync synchronization, rollback, error handling, connection lifecycle, and restart outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->