### PR TITLE
feat(ledger): add Shelley reward formulas

### DIFF
--- a/ledger/rewards/reference_test.go
+++ b/ledger/rewards/reference_test.go
@@ -1,0 +1,498 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rewards
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHaskellReferenceApparentPerformanceBranches(t *testing.T) {
+	require.Zero(
+		t,
+		apparentPerformance(big.NewRat(0, 1), 0, 100, 2, 20).Sign(),
+	)
+	require.Equal(
+		t,
+		big.NewRat(1, 2),
+		apparentPerformance(big.NewRat(0, 1), 20, 100, 2, 20),
+	)
+	require.Equal(
+		t,
+		big.NewRat(1, 1),
+		apparentPerformance(big.NewRat(4, 5), 20, 100, 0, 0),
+	)
+}
+
+func TestHaskellReferenceOperatorRewardBranches(t *testing.T) {
+	t.Run("pool reward at or below cost pays all to operator", func(t *testing.T) {
+		require.Equal(
+			t,
+			uint64(90),
+			requireLeaderReward(t, 90, 100, big.NewRat(1, 50), 100, 1_000),
+		)
+		require.Equal(
+			t,
+			uint64(0),
+			requireMemberReward(t, 90, 100, big.NewRat(1, 50), 300, 1_000),
+		)
+	})
+
+	t.Run("cost plus margin plus owner share uses exact floor", func(t *testing.T) {
+		require.Equal(
+			t,
+			uint64(417),
+			requireLeaderReward(t, 1_000, 340, big.NewRat(1, 50), 100, 1_000),
+		)
+	})
+}
+
+func TestHaskellReferenceMemberRewardBranches(t *testing.T) {
+	require.Equal(
+		t,
+		uint64(0),
+		requireMemberReward(t, 1_000, 340, big.NewRat(1, 50), 0, 1_000),
+	)
+	require.Equal(
+		t,
+		uint64(194),
+		requireMemberReward(t, 1_000, 340, big.NewRat(1, 50), 300, 1_000),
+	)
+}
+
+func TestShelleySpecOptimalPoolRewardVectors(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		poolStake uint64
+		pledge    uint64
+		want      uint64
+	}{
+		{
+			name:      "saturated with half saturation pledge",
+			poolStake: 1_000,
+			pledge:    500,
+			want:      83_333,
+		},
+		{
+			name:      "saturated with saturation pledge",
+			poolStake: 2_000,
+			pledge:    2_000,
+			want:      100_000,
+		},
+		{
+			name:      "saturated with no pledge influence bonus",
+			poolStake: 2_000,
+			pledge:    0,
+			want:      66_666,
+		},
+		{
+			name:      "unsaturated with exact pledge discount floor",
+			poolStake: 500,
+			pledge:    250,
+			want:      36_458,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				tc.want,
+				requireOptimalPoolReward(
+					t,
+					1_000_000,
+					10,
+					big.NewRat(1, 2),
+					tc.poolStake,
+					tc.pledge,
+					10_000,
+				),
+			)
+		})
+	}
+}
+
+func TestCFCalculatorPoolRewardFormulaVectors(t *testing.T) {
+	require.Equal(
+		t,
+		uint64(66_800),
+		requireOptimalPoolReward(
+			t,
+			801_600,
+			10,
+			big.NewRat(1, 2),
+			1_000,
+			500,
+			10_000,
+		),
+	)
+
+	for _, tc := range []struct {
+		name         string
+		poolReward   uint64
+		cost         uint64
+		margin       *big.Rat
+		ownerStake   uint64
+		memberStake  uint64
+		totalStake   uint64
+		wantLeader   uint64
+		wantMember   uint64
+		wantLeftover uint64
+	}{
+		{
+			name:         "medium pool README example with ledger floors",
+			poolReward:   4_000,
+			cost:         340,
+			margin:       big.NewRat(1, 50),
+			memberStake:  1_000,
+			totalStake:   1_000,
+			wantLeader:   413,
+			wantMember:   3_586,
+			wantLeftover: 1,
+		},
+		{
+			name:         "small pool README example with ledger floors",
+			poolReward:   400,
+			cost:         340,
+			margin:       big.NewRat(1, 50),
+			memberStake:  1_000,
+			totalStake:   1_000,
+			wantLeader:   341,
+			wantMember:   58,
+			wantLeftover: 1,
+		},
+		{
+			name:         "frontend pledge-return term",
+			poolReward:   4_000,
+			cost:         340,
+			margin:       big.NewRat(1, 50),
+			ownerStake:   100,
+			memberStake:  900,
+			totalStake:   1_000,
+			wantLeader:   771,
+			wantMember:   3_228,
+			wantLeftover: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			leader := requireLeaderReward(
+				t,
+				tc.poolReward,
+				tc.cost,
+				tc.margin,
+				tc.ownerStake,
+				tc.totalStake,
+			)
+			member := requireMemberReward(
+				t,
+				tc.poolReward,
+				tc.cost,
+				tc.margin,
+				tc.memberStake,
+				tc.totalStake,
+			)
+			require.Equal(t, tc.wantLeader, leader)
+			require.Equal(t, tc.wantMember, member)
+			require.Equal(t, tc.wantLeftover, tc.poolReward-leader-member)
+		})
+	}
+}
+
+func TestAmaruReferenceRewardVector(t *testing.T) {
+	vector := loadAmaruRewardVector(t)
+
+	result, err := Calculate(
+		vector.Pots.toPots(),
+		vector.Snapshot.toSnapshot(t),
+		vector.Parameters.toParameters(t),
+	)
+	require.NoError(t, err)
+
+	source := vector.Source.Repository + "@" + vector.Source.Commit +
+		":" + vector.Source.Path
+	require.Equal(t, uint64(vector.Expected.Incentives), result.Incentives, source)
+	require.Equal(t, uint64(vector.Expected.TotalRewardPot), result.TotalRewardPot, source)
+	require.Equal(t, uint64(vector.Expected.TreasuryTax), result.TreasuryTax, source)
+	require.Equal(t, uint64(vector.Expected.AvailableRewards), result.AvailableRewards, source)
+	require.Equal(t, uint64(vector.Expected.EffectiveRewards), result.EffectiveRewards, source)
+	require.Equal(t, uint64(vector.Expected.Undistributed), result.Undistributed, source)
+	require.Equal(t, vector.Expected.UpdatedPots.toPots(), result.UpdatedPots, source)
+	require.Len(t, result.PoolRewards, len(vector.Expected.PoolRewards), source)
+	for i, want := range vector.Expected.PoolRewards {
+		got := result.PoolRewards[i]
+		require.Equal(t, parsePoolID(t, want.PoolID), got.PoolID, source)
+		require.Equal(t, uint64(want.OptimalReward), got.OptimalReward, source)
+		require.Equal(t, uint64(want.PoolReward), got.PoolReward, source)
+		require.Equal(t, uint64(want.LeaderReward), got.LeaderReward, source)
+		require.Equal(t, uint64(want.MemberRewardTotal), got.MemberRewardTotal, source)
+		require.Equal(t, uint64(want.OwnerStake), got.OwnerStake, source)
+		require.Equal(t, uint64(want.Undistributed), got.Undistributed, source)
+		require.Equal(t, uint64(want.Unspendable), got.Unspendable, source)
+	}
+	require.Len(t, result.AccountRewards, len(vector.Expected.AccountRewards), source)
+	for i, want := range vector.Expected.AccountRewards {
+		got := result.AccountRewards[i]
+		require.Equal(t, want.Credential.toCredential(t), got.Credential, source)
+		require.Equal(t, parsePoolID(t, want.PoolID), got.PoolID, source)
+		require.Equal(t, RewardType(want.Type), got.Type, source)
+		require.Equal(t, uint64(want.Amount), got.Amount, source)
+		require.Equal(t, want.Spendable, got.Spendable, source)
+	}
+}
+
+type amaruRewardVector struct {
+	Name       string                 `json:"name"`
+	Source     rewardVectorSource     `json:"source"`
+	Parameters rewardVectorParameters `json:"parameters"`
+	Pots       rewardVectorPots       `json:"pots"`
+	Snapshot   rewardVectorSnapshot   `json:"snapshot"`
+	Expected   rewardVectorExpected   `json:"expected"`
+}
+
+type rewardVectorSource struct {
+	Implementation string   `json:"implementation"`
+	Repository     string   `json:"repository"`
+	Commit         string   `json:"commit"`
+	Path           string   `json:"path"`
+	Functions      []string `json:"functions"`
+}
+
+type rewardVectorParameters struct {
+	MonetaryExpansion string `json:"monetary_expansion"`
+	TreasuryExpansion string `json:"treasury_expansion"`
+	Decentralization  string `json:"decentralization"`
+	PledgeInfluence   string `json:"pledge_influence"`
+	ActiveSlotsCoeff  string `json:"active_slots_coeff"`
+	OptimalPoolCount  uint64 `json:"optimal_pool_count"`
+	EpochLength       uint64 `json:"epoch_length"`
+	MaxLovelaceSupply uint64 `json:"max_lovelace_supply"`
+	ProtocolMajorVer  uint64 `json:"protocol_major_version"`
+}
+
+type rewardVectorPots struct {
+	Reserves uint64 `json:"reserves"`
+	Treasury uint64 `json:"treasury"`
+	Fees     uint64 `json:"fees"`
+}
+
+type rewardVectorSnapshot struct {
+	TotalActiveStake uint64             `json:"total_active_stake"`
+	Pools            []rewardVectorPool `json:"pools"`
+}
+
+type rewardVectorPool struct {
+	ID                      string                   `json:"id"`
+	RewardAccount           rewardVectorCredential   `json:"reward_account"`
+	Margin                  string                   `json:"margin"`
+	Pledge                  uint64                   `json:"pledge"`
+	Cost                    uint64                   `json:"cost"`
+	DelegatedStake          uint64                   `json:"delegated_stake"`
+	OwnerStake              uint64                   `json:"owner_stake"`
+	BlocksProduced          uint64                   `json:"blocks_produced"`
+	TotalBlocks             uint64                   `json:"total_blocks"`
+	RewardAccountRegistered bool                     `json:"reward_account_registered"`
+	RewardAccountEligible   bool                     `json:"reward_account_eligible"`
+	Owners                  []rewardVectorCredential `json:"owners"`
+	Delegators              []rewardVectorDelegator  `json:"delegators"`
+}
+
+type rewardVectorDelegator struct {
+	Credential rewardVectorCredential `json:"credential"`
+	Stake      uint64                 `json:"stake"`
+	Registered bool                   `json:"registered"`
+	Eligible   bool                   `json:"eligible"`
+}
+
+type rewardVectorCredential struct {
+	Tag  uint8  `json:"tag"`
+	Hash string `json:"hash"`
+}
+
+type rewardVectorExpected struct {
+	Incentives       uint64                      `json:"incentives"`
+	TotalRewardPot   uint64                      `json:"total_reward_pot"`
+	TreasuryTax      uint64                      `json:"treasury_tax"`
+	AvailableRewards uint64                      `json:"available_rewards"`
+	EffectiveRewards uint64                      `json:"effective_rewards"`
+	Undistributed    uint64                      `json:"undistributed"`
+	UpdatedPots      rewardVectorPots            `json:"updated_pots"`
+	PoolRewards      []rewardVectorPoolReward    `json:"pool_rewards"`
+	AccountRewards   []rewardVectorAccountReward `json:"account_rewards"`
+}
+
+type rewardVectorPoolReward struct {
+	PoolID            string `json:"pool_id"`
+	OptimalReward     uint64 `json:"optimal_reward"`
+	PoolReward        uint64 `json:"pool_reward"`
+	LeaderReward      uint64 `json:"leader_reward"`
+	MemberRewardTotal uint64 `json:"member_reward_total"`
+	OwnerStake        uint64 `json:"owner_stake"`
+	Undistributed     uint64 `json:"undistributed"`
+	Unspendable       uint64 `json:"unspendable"`
+}
+
+type rewardVectorAccountReward struct {
+	Credential rewardVectorCredential `json:"credential"`
+	PoolID     string                 `json:"pool_id"`
+	Type       string                 `json:"type"`
+	Amount     uint64                 `json:"amount"`
+	Spendable  bool                   `json:"spendable"`
+}
+
+func loadAmaruRewardVector(t *testing.T) amaruRewardVector {
+	t.Helper()
+	data, err := os.ReadFile("testdata/amaru_single_pool_reward_vector.json")
+	require.NoError(t, err)
+	var vector amaruRewardVector
+	require.NoError(t, json.Unmarshal(data, &vector))
+	require.NotEmpty(t, vector.Source.Repository)
+	require.NotEmpty(t, vector.Source.Commit)
+	require.NotEmpty(t, vector.Source.Path)
+	require.NotZero(t, vector.Parameters.ProtocolMajorVer)
+	return vector
+}
+
+func (p rewardVectorParameters) toParameters(t *testing.T) Parameters {
+	t.Helper()
+	return Parameters{
+		MonetaryExpansion:    parseRat(t, p.MonetaryExpansion),
+		TreasuryExpansion:    parseRat(t, p.TreasuryExpansion),
+		Decentralization:     parseRat(t, p.Decentralization),
+		PledgeInfluence:      parseRat(t, p.PledgeInfluence),
+		ActiveSlotsCoeff:     parseRat(t, p.ActiveSlotsCoeff),
+		OptimalPoolCount:     p.OptimalPoolCount,
+		EpochLength:          p.EpochLength,
+		MaxLovelaceSupply:    p.MaxLovelaceSupply,
+		ProtocolMajorVersion: p.ProtocolMajorVer,
+	}
+}
+
+func (p rewardVectorPots) toPots() Pots {
+	return Pots{Reserves: p.Reserves, Treasury: p.Treasury, Fees: p.Fees}
+}
+
+func (s rewardVectorSnapshot) toSnapshot(t *testing.T) Snapshot {
+	t.Helper()
+	pools := make([]Pool, 0, len(s.Pools))
+	for _, item := range s.Pools {
+		owners := make(map[Credential]struct{}, len(item.Owners))
+		for _, owner := range item.Owners {
+			owners[owner.toCredential(t)] = struct{}{}
+		}
+		delegators := make([]Delegator, 0, len(item.Delegators))
+		for _, delegator := range item.Delegators {
+			delegators = append(delegators, Delegator{
+				Credential: delegator.Credential.toCredential(t),
+				Stake:      delegator.Stake,
+				Registered: delegator.Registered,
+				Eligible:   delegator.Eligible,
+			})
+		}
+		pools = append(pools, Pool{
+			ID:                      parsePoolID(t, item.ID),
+			RewardAccount:           item.RewardAccount.toCredential(t),
+			Margin:                  parseRat(t, item.Margin),
+			Pledge:                  item.Pledge,
+			Cost:                    item.Cost,
+			DelegatedStake:          item.DelegatedStake,
+			OwnerStake:              item.OwnerStake,
+			BlocksProduced:          item.BlocksProduced,
+			TotalBlocks:             item.TotalBlocks,
+			RewardAccountRegistered: item.RewardAccountRegistered,
+			RewardAccountEligible:   item.RewardAccountEligible,
+			Owners:                  owners,
+			Delegators:              delegators,
+		})
+	}
+	return Snapshot{TotalActiveStake: s.TotalActiveStake, Pools: pools}
+}
+
+func (c rewardVectorCredential) toCredential(t *testing.T) Credential {
+	t.Helper()
+	decoded, err := hex.DecodeString(c.Hash)
+	require.NoError(t, err)
+	ret, err := NewCredential(c.Tag, decoded)
+	require.NoError(t, err)
+	return ret
+}
+
+func parsePoolID(t *testing.T, value string) PoolID {
+	t.Helper()
+	decoded, err := hex.DecodeString(value)
+	require.NoError(t, err)
+	ret, err := NewPoolID(decoded)
+	require.NoError(t, err)
+	return ret
+}
+
+func parseRat(t *testing.T, value string) *big.Rat {
+	t.Helper()
+	ret, ok := new(big.Rat).SetString(value)
+	require.True(t, ok, "invalid rational %q", value)
+	return ret
+}
+
+func requireOptimalPoolReward(
+	t *testing.T,
+	availableRewards uint64,
+	optimalPoolCount uint64,
+	a0 *big.Rat,
+	poolStake uint64,
+	pledge uint64,
+	totalStake uint64,
+) uint64 {
+	t.Helper()
+	ret, err := optimalPoolRewardChecked(
+		availableRewards,
+		optimalPoolCount,
+		a0,
+		poolStake,
+		pledge,
+		totalStake,
+	)
+	require.NoError(t, err)
+	return ret
+}
+
+func requireLeaderReward(
+	t *testing.T,
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	ownerStake uint64,
+	poolStake uint64,
+) uint64 {
+	t.Helper()
+	ret, err := leaderRewardChecked(poolReward, cost, margin, ownerStake, poolStake)
+	require.NoError(t, err)
+	return ret
+}
+
+func requireMemberReward(
+	t *testing.T,
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	memberStake uint64,
+	poolStake uint64,
+) uint64 {
+	t.Helper()
+	ret, err := memberRewardChecked(poolReward, cost, margin, memberStake, poolStake)
+	require.NoError(t, err)
+	return ret
+}

--- a/ledger/rewards/rewards.go
+++ b/ledger/rewards/rewards.go
@@ -621,6 +621,7 @@ func validateParameters(params Parameters) error {
 func validateSnapshot(snapshot Snapshot) error {
 	seenPools := make(map[PoolID]struct{}, len(snapshot.Pools))
 	seenDelegators := make(map[string]PoolID)
+	credentialEligibility := make(map[string]bool)
 	var totalDelegated uint64
 	for _, pool := range snapshot.Pools {
 		if _, ok := seenPools[pool.ID]; ok {
@@ -634,6 +635,13 @@ func validateSnapshot(snapshot Snapshot) error {
 		if err := validateCredential(
 			pool.RewardAccount,
 			fmt.Sprintf("pool %s reward account", pool.ID.String()),
+		); err != nil {
+			return err
+		}
+		if err := validateCredentialEligibility(
+			credentialEligibility,
+			pool.RewardAccount,
+			pool.RewardAccountEligible,
 		); err != nil {
 			return err
 		}
@@ -658,6 +666,7 @@ func validateSnapshot(snapshot Snapshot) error {
 		if err := validatePoolDelegators(pool); err != nil {
 			return err
 		}
+		var computedOwnerStake uint64
 		for owner := range pool.Owners {
 			if owner.Tag != 0 {
 				return fmt.Errorf(
@@ -668,8 +677,45 @@ func validateSnapshot(snapshot Snapshot) error {
 					owner.Tag,
 				)
 			}
+			ownerStake, found := poolDelegatorStake(pool.Delegators, owner)
+			if !found {
+				return fmt.Errorf(
+					"%w: pool %s owner %x is not a delegator",
+					ErrInvalidParameters,
+					pool.ID.String(),
+					owner.Hash,
+				)
+			}
+			var overflow bool
+			computedOwnerStake, overflow = addUint64(
+				computedOwnerStake,
+				ownerStake,
+			)
+			if overflow {
+				return fmt.Errorf(
+					"%w: pool %s owner stake overflow",
+					ErrInvalidParameters,
+					pool.ID.String(),
+				)
+			}
+		}
+		if computedOwnerStake != pool.OwnerStake {
+			return fmt.Errorf(
+				"%w: pool %s computed owner stake %d does not match owner stake %d",
+				ErrInvalidParameters,
+				pool.ID.String(),
+				computedOwnerStake,
+				pool.OwnerStake,
+			)
 		}
 		for _, delegator := range pool.Delegators {
+			if err := validateCredentialEligibility(
+				credentialEligibility,
+				delegator.Credential,
+				delegator.Eligible,
+			); err != nil {
+				return err
+			}
 			key := delegator.Credential.Key()
 			if existingPool, ok := seenDelegators[key]; ok {
 				return fmt.Errorf(
@@ -703,6 +749,32 @@ func validateSnapshot(snapshot Snapshot) error {
 		)
 	}
 	return nil
+}
+
+func validateCredentialEligibility(
+	eligibility map[string]bool,
+	credential Credential,
+	eligible bool,
+) error {
+	key := credential.Key()
+	if existing, ok := eligibility[key]; ok && existing != eligible {
+		return fmt.Errorf(
+			"%w: credential %x has conflicting reward eligibility",
+			ErrInvalidParameters,
+			credential.Hash,
+		)
+	}
+	eligibility[key] = eligible
+	return nil
+}
+
+func poolDelegatorStake(delegators []Delegator, credential Credential) (uint64, bool) {
+	for _, delegator := range delegators {
+		if delegator.Credential == credential {
+			return delegator.Stake, true
+		}
+	}
+	return 0, false
 }
 
 func validateCredential(credential Credential, label string) error {
@@ -777,8 +849,7 @@ func calculatePoolRewards(
 		PoolID:     pool.ID,
 		OwnerStake: pool.OwnerStake,
 	}
-	if pool.BlocksProduced == 0 ||
-		pool.DelegatedStake == 0 ||
+	if pool.DelegatedStake == 0 ||
 		pool.Pledge > pool.OwnerStake {
 		return ret, nil
 	}

--- a/ledger/rewards/rewards.go
+++ b/ledger/rewards/rewards.go
@@ -1,0 +1,1068 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rewards implements the Shelley stake-pool reward calculation.
+//
+// The formulas mirror cardano-ledger's Cardano.Ledger.Shelley.Rewards module,
+// Amaru's summary rewards implementation, and the Cardano Foundation calculator
+// rewards calculator. Keep all arithmetic rational until the exact floor points
+// used by the ledger specification.
+package rewards
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"sort"
+)
+
+const CredentialHashSize = 28
+
+var (
+	ErrInvalidCredentialHash = errors.New("invalid credential hash")
+	ErrInvalidPoolHash       = errors.New("invalid pool hash")
+	ErrInvalidParameters     = errors.New("invalid reward parameters")
+	ErrRewardAmountOverflow  = errors.New("reward amount overflow")
+)
+
+// Credential identifies a stake credential. Tag 0 is a key hash and tag 1 is a
+// script hash, matching Dingo's metadata schema.
+type Credential struct {
+	Hash [CredentialHashSize]byte
+	Tag  uint8
+}
+
+func NewCredential(tag uint8, hash []byte) (Credential, error) {
+	if len(hash) != CredentialHashSize {
+		return Credential{}, fmt.Errorf(
+			"%w: got %d bytes, want %d",
+			ErrInvalidCredentialHash,
+			len(hash),
+			CredentialHashSize,
+		)
+	}
+	if tag > 1 {
+		return Credential{}, fmt.Errorf("invalid credential tag %d", tag)
+	}
+	var ret Credential
+	ret.Tag = tag
+	copy(ret.Hash[:], hash)
+	return ret, nil
+}
+
+func (c Credential) Key() string {
+	return string([]byte{c.Tag}) + string(c.Hash[:])
+}
+
+// PoolID identifies a stake pool by key hash.
+type PoolID [CredentialHashSize]byte
+
+func NewPoolID(hash []byte) (PoolID, error) {
+	if len(hash) != CredentialHashSize {
+		return PoolID{}, fmt.Errorf(
+			"%w: got %d bytes, want %d",
+			ErrInvalidPoolHash,
+			len(hash),
+			CredentialHashSize,
+		)
+	}
+	var ret PoolID
+	copy(ret[:], hash)
+	return ret, nil
+}
+
+func (p PoolID) String() string {
+	return hex.EncodeToString(p[:])
+}
+
+// Parameters contains the protocol and network parameters used for one reward
+// calculation.
+type Parameters struct {
+	// MonetaryExpansion is rho.
+	MonetaryExpansion *big.Rat
+	// TreasuryExpansion is tau.
+	TreasuryExpansion *big.Rat
+	// Decentralization is d.
+	Decentralization *big.Rat
+	// PledgeInfluence is a0.
+	PledgeInfluence *big.Rat
+	// ActiveSlotsCoeff is f.
+	ActiveSlotsCoeff *big.Rat
+	// OptimalPoolCount is nOpt/k.
+	OptimalPoolCount uint64
+	// EpochLength is the network epoch length in slots.
+	EpochLength uint64
+	// MaxLovelaceSupply is maxLL. It is used with reserves to compute total
+	// circulating stake, matching cardano-ledger and Amaru.
+	MaxLovelaceSupply uint64
+	// ProtocolMajorVersion gates ledger reward behavior that changed across
+	// hard forks. In particular, Babbage/Vasil (major > 6) forgoes the early
+	// reward prefilter; final unregistered rewards are still routed away from
+	// spendable accounts at application time.
+	ProtocolMajorVersion uint64
+}
+
+// Pots captures the pot values available at the start of reward calculation.
+type Pots struct {
+	Reserves uint64
+	Treasury uint64
+	Fees     uint64
+}
+
+type Snapshot struct {
+	Pools            []Pool
+	TotalActiveStake uint64
+}
+
+type Pool struct {
+	ID                      PoolID
+	RewardAccount           Credential
+	Margin                  *big.Rat
+	Pledge                  uint64
+	Cost                    uint64
+	DelegatedStake          uint64
+	OwnerStake              uint64
+	BlocksProduced          uint64
+	TotalBlocks             uint64
+	RewardAccountRegistered bool
+	RewardAccountEligible   bool
+	Delegators              []Delegator
+	Owners                  map[Credential]struct{}
+}
+
+type Delegator struct {
+	Credential Credential
+	Stake      uint64
+	Registered bool
+	Eligible   bool
+}
+
+type Result struct {
+	UpdatedPots      Pots
+	PoolRewards      []PoolReward
+	AccountRewards   []AccountReward
+	Efficiency       *big.Rat
+	Incentives       uint64
+	TotalRewardPot   uint64
+	TreasuryTax      uint64
+	AvailableRewards uint64
+	EffectiveRewards uint64
+	Undistributed    uint64
+	Unspendable      uint64
+	TotalCirculation uint64
+	TotalBlocks      uint64
+	ExpectedBlocks   *big.Rat
+	pendingRewards   []pendingReward
+	poolAccounted    []uint64
+}
+
+type PoolReward struct {
+	PoolID              PoolID
+	ApparentPerformance *big.Rat
+	OptimalReward       uint64
+	PoolReward          uint64
+	LeaderReward        uint64
+	MemberRewardTotal   uint64
+	OwnerStake          uint64
+	Undistributed       uint64
+	Unspendable         uint64
+}
+
+type AccountReward struct {
+	Credential Credential
+	PoolID     PoolID
+	Amount     uint64
+	Type       RewardType
+	Spendable  bool
+}
+
+type RewardType string
+
+const (
+	RewardTypeLeader RewardType = "leader"
+	RewardTypeMember RewardType = "member"
+)
+
+// Calculate computes rewards for a completed epoch. The returned UpdatedPots
+// reflects the reward calculation alone: reserves lose incentives and regain
+// rewards not paid or sent to treasury, treasury receives the tax and
+// unspendable rewards, and fees are cleared.
+func Calculate(pots Pots, snapshot Snapshot, params Parameters) (*Result, error) {
+	if err := validateParameters(params); err != nil {
+		return nil, err
+	}
+	if err := validateSnapshot(snapshot); err != nil {
+		return nil, err
+	}
+	if pots.Reserves > params.MaxLovelaceSupply {
+		return nil, fmt.Errorf(
+			"%w: reserves %d exceed max supply %d",
+			ErrInvalidParameters,
+			pots.Reserves,
+			params.MaxLovelaceSupply,
+		)
+	}
+
+	totalBlocks, err := totalBlocks(snapshot.Pools)
+	if err != nil {
+		return nil, err
+	}
+	expectedBlocks := expectedBlocks(params)
+	if expectedBlocks.Sign() == 0 &&
+		params.Decentralization.Cmp(new(big.Rat).SetFrac64(4, 5)) < 0 {
+		return nil, fmt.Errorf(
+			"%w: expected blocks is zero",
+			ErrInvalidParameters,
+		)
+	}
+	efficiency := rewardEfficiency(totalBlocks, expectedBlocks, params.Decentralization)
+	incentives, err := floorMulChecked(
+		minRat(oneRat(), efficiency),
+		params.MonetaryExpansion,
+		uintRat(pots.Reserves),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("calculate incentives: %w", err)
+	}
+	totalRewardPot, overflow := addUint64(incentives, pots.Fees)
+	if overflow {
+		return nil, fmt.Errorf("%w: reward pot overflow", ErrInvalidParameters)
+	}
+	treasuryTax, err := floorMulChecked(params.TreasuryExpansion, uintRat(totalRewardPot))
+	if err != nil {
+		return nil, fmt.Errorf("calculate treasury tax: %w", err)
+	}
+	availableRewards := totalRewardPot - treasuryTax
+	treasuryAfterTax, overflow := addUint64(pots.Treasury, treasuryTax)
+	if overflow {
+		return nil, fmt.Errorf("%w: treasury tax overflow", ErrInvalidParameters)
+	}
+
+	totalCirculation := params.MaxLovelaceSupply - pots.Reserves
+
+	result := &Result{
+		UpdatedPots: Pots{
+			Reserves: pots.Reserves - incentives,
+			Treasury: treasuryAfterTax,
+			Fees:     0,
+		},
+		Incentives:       incentives,
+		TotalRewardPot:   totalRewardPot,
+		TreasuryTax:      treasuryTax,
+		AvailableRewards: availableRewards,
+		Efficiency:       efficiency,
+		TotalCirculation: totalCirculation,
+		TotalBlocks:      totalBlocks,
+		ExpectedBlocks:   expectedBlocks,
+	}
+
+	if availableRewards == 0 ||
+		snapshot.TotalActiveStake == 0 ||
+		totalCirculation == 0 {
+		result.Undistributed = availableRewards
+		if err := result.addUndistributedToReserves(); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	pools := append([]Pool(nil), snapshot.Pools...)
+	sort.Slice(pools, func(i, j int) bool {
+		return pools[i].ID.String() < pools[j].ID.String()
+	})
+
+	for _, pool := range pools {
+		poolReward, err := calculatePoolRewards(
+			pool,
+			availableRewards,
+			snapshot.TotalActiveStake,
+			totalCirculation,
+			totalBlocks,
+			params,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"calculate reward for pool %s: %w",
+				pool.ID.String(),
+				err,
+			)
+		}
+		result.PoolRewards = append(result.PoolRewards, poolReward)
+		result.poolAccounted = append(result.poolAccounted, 0)
+
+		if poolReward.LeaderReward > 0 &&
+			params.rewardPassesPrefilter(pool.RewardAccountRegistered) {
+			reward := AccountReward{
+				Credential: pool.RewardAccount,
+				PoolID:     pool.ID,
+				Amount:     poolReward.LeaderReward,
+				Type:       RewardTypeLeader,
+				Spendable:  pool.RewardAccountEligible,
+			}
+			if err := result.addReward(params, reward); err != nil {
+				return nil, err
+			}
+		}
+
+		delegators := append([]Delegator(nil), pool.Delegators...)
+		sort.Slice(delegators, func(i, j int) bool {
+			return delegators[i].Credential.Key() <
+				delegators[j].Credential.Key()
+		})
+		for _, delegator := range delegators {
+			if _, owner := pool.Owners[delegator.Credential]; owner {
+				continue
+			}
+			amount, err := memberRewardChecked(
+				poolReward.PoolReward,
+				pool.Cost,
+				normalizedMargin(pool.Margin),
+				delegator.Stake,
+				pool.DelegatedStake,
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"calculate member reward for pool %s: %w",
+					pool.ID.String(),
+					err,
+				)
+			}
+			if amount == 0 {
+				continue
+			}
+			if params.rewardPassesPrefilter(delegator.Registered) {
+				reward := AccountReward{
+					Credential: delegator.Credential,
+					PoolID:     pool.ID,
+					Amount:     amount,
+					Type:       RewardTypeMember,
+					Spendable:  delegator.Eligible,
+				}
+				if err := result.addReward(params, reward); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	if err := result.finalizeRewards(params); err != nil {
+		return nil, err
+	}
+
+	for i := range result.PoolRewards {
+		poolReward := result.PoolRewards[i]
+		accounted := result.poolAccounted[i]
+		if accounted < poolReward.PoolReward {
+			poolReward.Undistributed = poolReward.PoolReward - accounted
+		}
+		result.PoolRewards[i] = poolReward
+	}
+
+	accounted, overflow := addUint64(result.EffectiveRewards, result.Unspendable)
+	if overflow || accounted > result.AvailableRewards {
+		return nil, fmt.Errorf(
+			"%w: rewards exceed available pot",
+			ErrInvalidParameters,
+		)
+	}
+	if accounted < result.AvailableRewards {
+		result.Undistributed = result.AvailableRewards - accounted
+	}
+	if err := result.addUndistributedToReserves(); err != nil {
+		return nil, err
+	}
+	if err := result.addUnspendableToTreasury(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type pendingReward struct {
+	reward    AccountReward
+	poolIndex int
+}
+
+func (r *Result) addReward(params Parameters, reward AccountReward) error {
+	poolIndex := len(r.PoolRewards) - 1
+	if params.aggregateRewards() {
+		return r.applyReward(reward, poolIndex)
+	}
+	r.pendingRewards = append(r.pendingRewards, pendingReward{
+		reward:    reward,
+		poolIndex: poolIndex,
+	})
+	return nil
+}
+
+func (r *Result) finalizeRewards(params Parameters) error {
+	if params.aggregateRewards() {
+		return nil
+	}
+	if len(r.pendingRewards) == 0 {
+		return nil
+	}
+	selected := make(map[string]pendingReward, len(r.pendingRewards))
+	for _, pending := range r.pendingRewards {
+		key := pending.reward.Credential.Key()
+		if current, ok := selected[key]; !ok ||
+			rewardComesBefore(pending.reward, current.reward) {
+			selected[key] = pending
+		}
+	}
+	delivered := make([]pendingReward, 0, len(selected))
+	for _, pending := range selected {
+		delivered = append(delivered, pending)
+	}
+	sort.Slice(delivered, func(i, j int) bool {
+		return pendingRewardComesBefore(delivered[i], delivered[j])
+	})
+	for _, pending := range delivered {
+		if err := r.applyReward(pending.reward, pending.poolIndex); err != nil {
+			return err
+		}
+	}
+	r.pendingRewards = nil
+	return nil
+}
+
+func (r *Result) applyReward(reward AccountReward, poolIndex int) error {
+	r.AccountRewards = append(r.AccountRewards, reward)
+	if poolIndex >= 0 && poolIndex < len(r.poolAccounted) {
+		accounted, overflow := addUint64(
+			r.poolAccounted[poolIndex],
+			reward.Amount,
+		)
+		if overflow {
+			return fmt.Errorf(
+				"%w: pool accounted reward overflow",
+				ErrInvalidParameters,
+			)
+		}
+		r.poolAccounted[poolIndex] = accounted
+		if reward.Type == RewardTypeMember {
+			memberTotal, overflow := addUint64(
+				r.PoolRewards[poolIndex].MemberRewardTotal,
+				reward.Amount,
+			)
+			if overflow {
+				return fmt.Errorf(
+					"%w: pool member reward overflow",
+					ErrInvalidParameters,
+				)
+			}
+			r.PoolRewards[poolIndex].MemberRewardTotal = memberTotal
+		}
+	}
+	if reward.Spendable {
+		effective, overflow := addUint64(r.EffectiveRewards, reward.Amount)
+		if overflow {
+			return fmt.Errorf(
+				"%w: effective reward overflow",
+				ErrInvalidParameters,
+			)
+		}
+		r.EffectiveRewards = effective
+		return nil
+	}
+	unspendable, overflow := addUint64(r.Unspendable, reward.Amount)
+	if overflow {
+		return fmt.Errorf(
+			"%w: unspendable reward overflow",
+			ErrInvalidParameters,
+		)
+	}
+	r.Unspendable = unspendable
+	if poolIndex >= 0 && poolIndex < len(r.PoolRewards) {
+		poolUnspendable, overflow := addUint64(
+			r.PoolRewards[poolIndex].Unspendable,
+			reward.Amount,
+		)
+		if overflow {
+			return fmt.Errorf(
+				"%w: pool unspendable reward overflow",
+				ErrInvalidParameters,
+			)
+		}
+		r.PoolRewards[poolIndex].Unspendable = poolUnspendable
+	}
+	return nil
+}
+
+func (r *Result) addUndistributedToReserves() error {
+	reserves, overflow := addUint64(r.UpdatedPots.Reserves, r.Undistributed)
+	if overflow {
+		return fmt.Errorf("%w: reserve refund overflow", ErrInvalidParameters)
+	}
+	r.UpdatedPots.Reserves = reserves
+	return nil
+}
+
+func (r *Result) addUnspendableToTreasury() error {
+	treasury, overflow := addUint64(r.UpdatedPots.Treasury, r.Unspendable)
+	if overflow {
+		return fmt.Errorf("%w: unspendable treasury overflow", ErrInvalidParameters)
+	}
+	r.UpdatedPots.Treasury = treasury
+	return nil
+}
+
+func pendingRewardComesBefore(a, b pendingReward) bool {
+	if rewardComesBefore(a.reward, b.reward) {
+		return true
+	}
+	if rewardComesBefore(b.reward, a.reward) {
+		return false
+	}
+	return a.reward.Credential.Key() < b.reward.Credential.Key()
+}
+
+func rewardComesBefore(a, b AccountReward) bool {
+	if a.Type != b.Type {
+		return rewardTypeOrder(a.Type) < rewardTypeOrder(b.Type)
+	}
+	return string(a.PoolID[:]) < string(b.PoolID[:])
+}
+
+func rewardTypeOrder(t RewardType) int {
+	switch t {
+	case RewardTypeLeader:
+		return 0
+	case RewardTypeMember:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func (params Parameters) forgoRewardPrefilter() bool {
+	return params.ProtocolMajorVersion > 6
+}
+
+// RequiresRewardPrefilter reports whether this protocol version still uses the
+// pre-Babbage reward calculation prefilter.
+func (params Parameters) RequiresRewardPrefilter() bool {
+	return !params.forgoRewardPrefilter()
+}
+
+func (params Parameters) rewardPassesPrefilter(registered bool) bool {
+	return params.forgoRewardPrefilter() || registered
+}
+
+func (params Parameters) aggregateRewards() bool {
+	return params.ProtocolMajorVersion >= 3
+}
+
+// Validate checks that the reward parameters are structurally usable before
+// they are applied to a reward update.
+func (params Parameters) Validate() error {
+	return validateParameters(params)
+}
+
+func validateParameters(params Parameters) error {
+	for _, field := range []struct {
+		name     string
+		rat      *big.Rat
+		unit     bool
+		positive bool
+	}{
+		{name: "monetary expansion", rat: params.MonetaryExpansion, unit: true},
+		{name: "treasury expansion", rat: params.TreasuryExpansion, unit: true},
+		{name: "decentralization", rat: params.Decentralization, unit: true},
+		{name: "pledge influence", rat: params.PledgeInfluence},
+		{
+			name:     "active slot coeff",
+			rat:      params.ActiveSlotsCoeff,
+			unit:     true,
+			positive: true,
+		},
+	} {
+		if field.rat == nil {
+			return fmt.Errorf("%w: missing %s", ErrInvalidParameters, field.name)
+		}
+		if field.rat.Sign() < 0 {
+			return fmt.Errorf("%w: negative %s", ErrInvalidParameters, field.name)
+		}
+		if field.positive && field.rat.Sign() == 0 {
+			return fmt.Errorf(
+				"%w: active slot coeff is zero",
+				ErrInvalidParameters,
+			)
+		}
+		if field.unit && field.rat.Cmp(oneRat()) > 0 {
+			return fmt.Errorf(
+				"%w: %s greater than one",
+				ErrInvalidParameters,
+				field.name,
+			)
+		}
+	}
+	if params.OptimalPoolCount == 0 {
+		return fmt.Errorf("%w: optimal pool count is zero", ErrInvalidParameters)
+	}
+	if params.EpochLength == 0 {
+		return fmt.Errorf("%w: epoch length is zero", ErrInvalidParameters)
+	}
+	return nil
+}
+
+func validateSnapshot(snapshot Snapshot) error {
+	seenPools := make(map[PoolID]struct{}, len(snapshot.Pools))
+	seenDelegators := make(map[string]PoolID)
+	var totalDelegated uint64
+	for _, pool := range snapshot.Pools {
+		if _, ok := seenPools[pool.ID]; ok {
+			return fmt.Errorf(
+				"%w: duplicate pool %s in reward snapshot",
+				ErrInvalidParameters,
+				pool.ID.String(),
+			)
+		}
+		seenPools[pool.ID] = struct{}{}
+		if err := validateCredential(
+			pool.RewardAccount,
+			fmt.Sprintf("pool %s reward account", pool.ID.String()),
+		); err != nil {
+			return err
+		}
+		if pool.Margin != nil {
+			if pool.Margin.Sign() < 0 || pool.Margin.Cmp(oneRat()) > 0 {
+				return fmt.Errorf(
+					"%w: pool %s margin outside [0,1]",
+					ErrInvalidParameters,
+					pool.ID.String(),
+				)
+			}
+		}
+		if pool.OwnerStake > pool.DelegatedStake {
+			return fmt.Errorf(
+				"%w: pool %s owner stake %d exceeds delegated stake %d",
+				ErrInvalidParameters,
+				pool.ID.String(),
+				pool.OwnerStake,
+				pool.DelegatedStake,
+			)
+		}
+		if err := validatePoolDelegators(pool); err != nil {
+			return err
+		}
+		for owner := range pool.Owners {
+			if owner.Tag != 0 {
+				return fmt.Errorf(
+					"%w: pool %s owner %x has non-key credential tag %d",
+					ErrInvalidParameters,
+					pool.ID.String(),
+					owner.Hash,
+					owner.Tag,
+				)
+			}
+		}
+		for _, delegator := range pool.Delegators {
+			key := delegator.Credential.Key()
+			if existingPool, ok := seenDelegators[key]; ok {
+				return fmt.Errorf(
+					"%w: duplicate delegator %x in pools %s and %s",
+					ErrInvalidParameters,
+					delegator.Credential.Hash,
+					existingPool.String(),
+					pool.ID.String(),
+				)
+			}
+			seenDelegators[key] = pool.ID
+		}
+		var overflow bool
+		totalDelegated, overflow = addUint64(
+			totalDelegated,
+			pool.DelegatedStake,
+		)
+		if overflow {
+			return fmt.Errorf(
+				"%w: total delegated stake overflow",
+				ErrInvalidParameters,
+			)
+		}
+	}
+	if totalDelegated != snapshot.TotalActiveStake {
+		return fmt.Errorf(
+			"%w: total delegated stake %d does not match active stake %d",
+			ErrInvalidParameters,
+			totalDelegated,
+			snapshot.TotalActiveStake,
+		)
+	}
+	return nil
+}
+
+func validateCredential(credential Credential, label string) error {
+	if credential.Tag > 1 {
+		return fmt.Errorf(
+			"%w: %s has invalid credential tag %d",
+			ErrInvalidParameters,
+			label,
+			credential.Tag,
+		)
+	}
+	return nil
+}
+
+func validatePoolDelegators(pool Pool) error {
+	if len(pool.Delegators) == 0 {
+		return nil
+	}
+	seenDelegators := make(map[string]struct{}, len(pool.Delegators))
+	var totalDelegatorStake uint64
+	for _, delegator := range pool.Delegators {
+		if err := validateCredential(
+			delegator.Credential,
+			fmt.Sprintf("pool %s delegator", pool.ID.String()),
+		); err != nil {
+			return err
+		}
+		key := delegator.Credential.Key()
+		if _, ok := seenDelegators[key]; ok {
+			return fmt.Errorf(
+				"%w: duplicate delegator %x in pool %s",
+				ErrInvalidParameters,
+				delegator.Credential.Hash,
+				pool.ID.String(),
+			)
+		}
+		seenDelegators[key] = struct{}{}
+		var overflow bool
+		totalDelegatorStake, overflow = addUint64(
+			totalDelegatorStake,
+			delegator.Stake,
+		)
+		if overflow {
+			return fmt.Errorf(
+				"%w: pool %s delegated stake overflow",
+				ErrInvalidParameters,
+				pool.ID.String(),
+			)
+		}
+	}
+	if totalDelegatorStake > pool.DelegatedStake {
+		return fmt.Errorf(
+			"%w: pool %s delegator stake %d exceeds delegated stake %d",
+			ErrInvalidParameters,
+			pool.ID.String(),
+			totalDelegatorStake,
+			pool.DelegatedStake,
+		)
+	}
+	return nil
+}
+
+func calculatePoolRewards(
+	pool Pool,
+	availableRewards uint64,
+	totalActiveStake uint64,
+	totalCirculation uint64,
+	totalBlocks uint64,
+	params Parameters,
+) (PoolReward, error) {
+	ret := PoolReward{
+		PoolID:     pool.ID,
+		OwnerStake: pool.OwnerStake,
+	}
+	if pool.BlocksProduced == 0 ||
+		pool.DelegatedStake == 0 ||
+		pool.Pledge > pool.OwnerStake {
+		return ret, nil
+	}
+
+	ret.ApparentPerformance = apparentPerformance(
+		params.Decentralization,
+		pool.DelegatedStake,
+		totalActiveStake,
+		pool.BlocksProduced,
+		totalBlocks,
+	)
+	optimalReward, err := optimalPoolRewardChecked(
+		availableRewards,
+		params.OptimalPoolCount,
+		params.PledgeInfluence,
+		pool.DelegatedStake,
+		pool.Pledge,
+		totalCirculation,
+	)
+	if err != nil {
+		return PoolReward{}, err
+	}
+	ret.OptimalReward = optimalReward
+	poolReward, err := floorMulChecked(
+		ret.ApparentPerformance,
+		uintRat(ret.OptimalReward),
+	)
+	if err != nil {
+		return PoolReward{}, err
+	}
+	ret.PoolReward = poolReward
+	leader, err := leaderRewardChecked(
+		ret.PoolReward,
+		pool.Cost,
+		normalizedMargin(pool.Margin),
+		pool.OwnerStake,
+		pool.DelegatedStake,
+	)
+	if err != nil {
+		return PoolReward{}, err
+	}
+	ret.LeaderReward = leader
+	return ret, nil
+}
+
+func expectedBlocks(params Parameters) *big.Rat {
+	nonObftSlots := new(big.Rat).Sub(oneRat(), params.Decentralization)
+	return new(big.Rat).Mul(
+		new(big.Rat).Mul(nonObftSlots, params.ActiveSlotsCoeff),
+		uintRat(params.EpochLength),
+	)
+}
+
+func rewardEfficiency(
+	totalBlocks uint64,
+	expectedBlocks *big.Rat,
+	decentralization *big.Rat,
+) *big.Rat {
+	if decentralization.Cmp(new(big.Rat).SetFrac64(4, 5)) >= 0 {
+		return oneRat()
+	}
+	if expectedBlocks == nil || expectedBlocks.Sign() == 0 {
+		return oneRat()
+	}
+	return new(big.Rat).Quo(
+		uintRat(totalBlocks),
+		expectedBlocks,
+	)
+}
+
+func totalBlocks(pools []Pool) (uint64, error) {
+	var ret uint64
+	explicit := false
+	for _, pool := range pools {
+		if pool.TotalBlocks == 0 {
+			continue
+		}
+		if explicit && pool.TotalBlocks != ret {
+			return 0, fmt.Errorf(
+				"%w: inconsistent total blocks %d and %d",
+				ErrInvalidParameters,
+				ret,
+				pool.TotalBlocks,
+			)
+		}
+		explicit = true
+		if pool.TotalBlocks > ret {
+			ret = pool.TotalBlocks
+		}
+	}
+	if explicit {
+		return ret, nil
+	}
+	for _, pool := range pools {
+		var overflow bool
+		ret, overflow = addUint64(ret, pool.BlocksProduced)
+		if overflow {
+			return 0, fmt.Errorf(
+				"%w: total blocks overflow",
+				ErrInvalidParameters,
+			)
+		}
+	}
+	return ret, nil
+}
+
+// apparentPerformance implements mkApparentPerformance from cardano-ledger.
+func apparentPerformance(
+	d *big.Rat,
+	poolStake uint64,
+	activeStake uint64,
+	blocksProduced uint64,
+	totalBlocks uint64,
+) *big.Rat {
+	if poolStake == 0 || activeStake == 0 {
+		return new(big.Rat)
+	}
+	if d.Cmp(new(big.Rat).SetFrac64(4, 5)) >= 0 {
+		return oneRat()
+	}
+	blocksDenom := totalBlocks
+	if blocksDenom == 0 {
+		blocksDenom = 1
+	}
+	beta := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(blocksProduced),
+		new(big.Int).SetUint64(blocksDenom),
+	)
+	sigma := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(poolStake),
+		new(big.Int).SetUint64(activeStake),
+	)
+	return new(big.Rat).Quo(beta, sigma)
+}
+
+// optimalPoolRewardChecked implements maxPool' from the Shelley ledger.
+func optimalPoolRewardChecked(
+	availableRewards uint64,
+	optimalPoolCount uint64,
+	a0 *big.Rat,
+	poolStake uint64,
+	pledge uint64,
+	totalStake uint64,
+) (uint64, error) {
+	if totalStake == 0 || optimalPoolCount == 0 {
+		return 0, nil
+	}
+	z0 := new(big.Rat).SetFrac(
+		big.NewInt(1),
+		new(big.Int).SetUint64(optimalPoolCount),
+	)
+	sigma := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(poolStake),
+		new(big.Int).SetUint64(totalStake),
+	)
+	pledgeRatio := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(pledge),
+		new(big.Int).SetUint64(totalStake),
+	)
+	s := minRat(sigma, z0)
+	p := minRat(pledgeRatio, z0)
+
+	left := new(big.Rat).Quo(
+		uintRat(availableRewards),
+		new(big.Rat).Add(oneRat(), a0),
+	)
+	z0MinusS := new(big.Rat).Sub(z0, s)
+	pledgeDiscount := new(big.Rat).Quo(
+		new(big.Rat).Mul(p, z0MinusS),
+		z0,
+	)
+	inner := new(big.Rat).Sub(s, pledgeDiscount)
+	z0Factor := new(big.Rat).Quo(inner, z0)
+	right := new(big.Rat).Add(
+		s,
+		new(big.Rat).Mul(new(big.Rat).Mul(p, a0), z0Factor),
+	)
+	return floorRatChecked(new(big.Rat).Mul(left, right))
+}
+
+func leaderRewardChecked(
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	ownerStake uint64,
+	poolStake uint64,
+) (uint64, error) {
+	if poolReward <= cost {
+		return poolReward, nil
+	}
+	if poolStake == 0 {
+		return poolReward, nil
+	}
+	ownerStakeRatio := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(ownerStake),
+		new(big.Int).SetUint64(poolStake),
+	)
+	oneMinusMargin := new(big.Rat).Sub(oneRat(), margin)
+	factor := new(big.Rat).Add(
+		margin,
+		new(big.Rat).Mul(oneMinusMargin, ownerStakeRatio),
+	)
+	variableReward := poolReward - cost
+	marginReward, err := floorMulChecked(factor, uintRat(variableReward))
+	if err != nil {
+		return 0, err
+	}
+	ret, overflow := addUint64(cost, marginReward)
+	if overflow {
+		return 0, fmt.Errorf("%w: leader reward overflow", ErrRewardAmountOverflow)
+	}
+	return ret, nil
+}
+
+func memberRewardChecked(
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	memberStake uint64,
+	poolStake uint64,
+) (uint64, error) {
+	if poolReward <= cost || poolStake == 0 || memberStake == 0 {
+		return 0, nil
+	}
+	memberStakeRatio := new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(memberStake),
+		new(big.Int).SetUint64(poolStake),
+	)
+	return floorMulChecked(
+		new(big.Rat).Sub(oneRat(), margin),
+		uintRat(poolReward-cost),
+		memberStakeRatio,
+	)
+}
+
+func normalizedMargin(margin *big.Rat) *big.Rat {
+	if margin == nil {
+		return new(big.Rat)
+	}
+	return new(big.Rat).Set(margin)
+}
+
+func floorMulChecked(values ...*big.Rat) (uint64, error) {
+	acc := oneRat()
+	for _, value := range values {
+		if value == nil || value.Sign() <= 0 {
+			return 0, nil
+		}
+		acc.Mul(acc, value)
+	}
+	return floorRatChecked(acc)
+}
+
+func floorRatChecked(value *big.Rat) (uint64, error) {
+	if value == nil || value.Sign() <= 0 {
+		return 0, nil
+	}
+	num := new(big.Int).Set(value.Num())
+	den := value.Denom()
+	q := new(big.Int).Quo(num, den)
+	if !q.IsUint64() {
+		return 0, fmt.Errorf("%w: floor %s", ErrRewardAmountOverflow, q.String())
+	}
+	return q.Uint64(), nil
+}
+
+func minRat(a, b *big.Rat) *big.Rat {
+	if a.Cmp(b) <= 0 {
+		return new(big.Rat).Set(a)
+	}
+	return new(big.Rat).Set(b)
+}
+
+func uintRat(v uint64) *big.Rat {
+	return new(big.Rat).SetInt(new(big.Int).SetUint64(v))
+}
+
+func oneRat() *big.Rat {
+	return new(big.Rat).SetInt64(1)
+}
+
+func addUint64(a, b uint64) (uint64, bool) {
+	if a > math.MaxUint64-b {
+		return 0, true
+	}
+	return a + b, false
+}

--- a/ledger/rewards/rewards_test.go
+++ b/ledger/rewards/rewards_test.go
@@ -117,6 +117,7 @@ func TestCalculateScriptCredentialWithOwnerHashStillEarnsMemberReward(t *testing
 						ownerKey: {},
 					},
 					Delegators: []Delegator{
+						{Credential: ownerKey, Stake: 0, Registered: true, Eligible: true},
 						{
 							Credential: scriptWithOwnerHash,
 							Stake:      1_000,
@@ -141,6 +142,7 @@ func TestCalculateScriptCredentialWithOwnerHashStillEarnsMemberReward(t *testing
 
 func TestCalculatePledgeFailureZerosPoolReward(t *testing.T) {
 	poolID := testPoolID(1)
+	owner := testCredential(0, 2)
 
 	result, err := Calculate(
 		Pots{Reserves: 100_000_000},
@@ -159,7 +161,12 @@ func TestCalculatePledgeFailureZerosPoolReward(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
+					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -248,6 +255,7 @@ func TestCalculateNoActiveStakeReturnsAvailableRewardsToReserves(t *testing.T) {
 
 func TestCalculateTreasuryTaxUsesIncentivesAndFees(t *testing.T) {
 	poolID := testPoolID(1)
+	owner := testCredential(0, 2)
 	params := testParams()
 	params.TreasuryExpansion = big.NewRat(1, 5)
 
@@ -272,7 +280,12 @@ func TestCalculateTreasuryTaxUsesIncentivesAndFees(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
+					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -289,6 +302,7 @@ func TestCalculateTreasuryTaxUsesIncentivesAndFees(t *testing.T) {
 
 func TestCalculateNetworkEfficiencyIncludesDecentralization(t *testing.T) {
 	poolID := testPoolID(1)
+	owner := testCredential(0, 2)
 	params := testParams()
 	params.Decentralization = big.NewRat(1, 2)
 
@@ -309,7 +323,12 @@ func TestCalculateNetworkEfficiencyIncludesDecentralization(t *testing.T) {
 					TotalBlocks:             5,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
+					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -324,6 +343,7 @@ func TestCalculateNetworkEfficiencyIncludesDecentralization(t *testing.T) {
 
 func TestCalculateNetworkEfficiencyHonorsDecentralizationThreshold(t *testing.T) {
 	poolID := testPoolID(1)
+	owner := testCredential(0, 2)
 	params := testParams()
 	params.Decentralization = big.NewRat(4, 5)
 	snapshot := Snapshot{
@@ -339,7 +359,12 @@ func TestCalculateNetworkEfficiencyHonorsDecentralizationThreshold(t *testing.T)
 				OwnerStake:              500,
 				RewardAccountRegistered: true,
 				RewardAccountEligible:   true,
-				Owners:                  map[Credential]struct{}{},
+				Owners: map[Credential]struct{}{
+					owner: {},
+				},
+				Delegators: []Delegator{
+					{Credential: owner, Stake: 500, Registered: true, Eligible: true},
+				},
 			},
 		},
 	}
@@ -354,8 +379,9 @@ func TestCalculateNetworkEfficiencyHonorsDecentralizationThreshold(t *testing.T)
 	require.Equal(t, big.NewRat(2, 1), result.ExpectedBlocks)
 	require.Equal(t, big.NewRat(1, 1), result.Efficiency)
 	require.Equal(t, uint64(1_000_000), result.Incentives)
-	require.Equal(t, uint64(1_000_000), result.Undistributed)
-	require.Equal(t, uint64(100_000_000), result.UpdatedPots.Reserves)
+	require.Equal(t, uint64(46_283), result.EffectiveRewards)
+	require.Equal(t, uint64(953_717), result.Undistributed)
+	require.Equal(t, uint64(99_953_717), result.UpdatedPots.Reserves)
 
 	params.Decentralization = big.NewRat(1, 1)
 	result, err = Calculate(Pots{Reserves: 100_000_000}, snapshot, params)
@@ -363,10 +389,12 @@ func TestCalculateNetworkEfficiencyHonorsDecentralizationThreshold(t *testing.T)
 	require.Equal(t, big.NewRat(0, 1), result.ExpectedBlocks)
 	require.Equal(t, big.NewRat(1, 1), result.Efficiency)
 	require.Equal(t, uint64(1_000_000), result.Incentives)
-	require.Equal(t, uint64(1_000_000), result.Undistributed)
+	require.Equal(t, uint64(46_283), result.EffectiveRewards)
+	require.Equal(t, uint64(953_717), result.Undistributed)
 }
 
 func TestCalculateRoutesUnspendableRewardsToTreasury(t *testing.T) {
+	owner := testCredential(0, 2)
 	member := testCredential(0, 3)
 	poolID := testPoolID(1)
 
@@ -390,8 +418,11 @@ func TestCalculateRoutesUnspendableRewardsToTreasury(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: false,
 					RewardAccountEligible:   false,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: false, Eligible: false},
 						{Credential: member, Stake: 500, Registered: false, Eligible: false},
 					},
 				},
@@ -416,6 +447,7 @@ func TestCalculateRoutesUnspendableRewardsToTreasury(t *testing.T) {
 }
 
 func TestCalculatePotDeltasMatchReferenceSemantics(t *testing.T) {
+	owner := testCredential(0, 2)
 	member := testCredential(0, 3)
 	poolID := testPoolID(1)
 	params := babbageParams()
@@ -443,8 +475,11 @@ func TestCalculatePotDeltasMatchReferenceSemantics(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: false,
 					RewardAccountEligible:   false,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
 						{Credential: member, Stake: 500, Registered: true, Eligible: true},
 					},
 				},
@@ -476,6 +511,8 @@ func TestCalculateRejectsRewardsAboveAvailablePot(t *testing.T) {
 	params.MaxLovelaceSupply = 1_000
 	params.OptimalPoolCount = 1
 
+	// The inconsistent block counts intentionally drive apparent performance
+	// above one so the calculated rewards exceed the available pot.
 	_, err := Calculate(
 		Pots{
 			Fees: 1_000_000,
@@ -506,6 +543,7 @@ func TestCalculateRejectsRewardsAboveAvailablePot(t *testing.T) {
 }
 
 func TestCalculatePreBabbageFilteredRewardsReturnToReserves(t *testing.T) {
+	owner := testCredential(0, 2)
 	member := testCredential(0, 3)
 	poolID := testPoolID(1)
 
@@ -529,8 +567,11 @@ func TestCalculatePreBabbageFilteredRewardsReturnToReserves(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: false,
 					RewardAccountEligible:   false,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: false, Eligible: false},
 						{Credential: member, Stake: 500, Registered: false, Eligible: false},
 					},
 				},
@@ -549,6 +590,7 @@ func TestCalculatePreBabbageFilteredRewardsReturnToReserves(t *testing.T) {
 }
 
 func TestCalculatePreBabbageFinalUnregisteredRewardsGoToTreasury(t *testing.T) {
+	owner := testCredential(0, 2)
 	member := testCredential(0, 3)
 	poolID := testPoolID(1)
 
@@ -572,8 +614,11 @@ func TestCalculatePreBabbageFinalUnregisteredRewardsGoToTreasury(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   false,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: false},
 						{Credential: member, Stake: 500, Registered: true, Eligible: false},
 					},
 				},
@@ -593,6 +638,7 @@ func TestCalculatePreBabbageFinalUnregisteredRewardsGoToTreasury(t *testing.T) {
 }
 
 func TestCalculatePreBabbagePrefilteredRewardsIgnoreCurrentRegistration(t *testing.T) {
+	owner := testCredential(0, 2)
 	member := testCredential(0, 3)
 	poolID := testPoolID(1)
 
@@ -616,8 +662,11 @@ func TestCalculatePreBabbagePrefilteredRewardsIgnoreCurrentRegistration(t *testi
 					TotalBlocks:             10,
 					RewardAccountRegistered: false,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: false, Eligible: true},
 						{Credential: member, Stake: 500, Registered: false, Eligible: true},
 					},
 				},
@@ -636,6 +685,7 @@ func TestCalculatePreBabbagePrefilteredRewardsIgnoreCurrentRegistration(t *testi
 }
 
 func TestCalculateShelleyFiltersMultipleRewardsForSameCredential(t *testing.T) {
+	owner := testCredential(0, 2)
 	shared := testCredential(0, 3)
 	poolID := testPoolID(1)
 
@@ -658,8 +708,11 @@ func TestCalculateShelleyFiltersMultipleRewardsForSameCredential(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
 						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
 					},
 				},
@@ -681,6 +734,8 @@ func TestCalculateShelleyFiltersMultipleRewardsForSameCredential(t *testing.T) {
 
 func TestCalculateShelleyFiltersLeaderRewardsByPoolOrder(t *testing.T) {
 	shared := testCredential(0, 3)
+	ownerA := testCredential(0, 1)
+	ownerB := testCredential(0, 2)
 	poolA := testPoolID(1)
 	poolB := testPoolID(2)
 
@@ -703,7 +758,12 @@ func TestCalculateShelleyFiltersLeaderRewardsByPoolOrder(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerB: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerB, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 				{
 					ID:                      poolA,
@@ -717,7 +777,12 @@ func TestCalculateShelleyFiltersLeaderRewardsByPoolOrder(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerA: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerA, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -740,6 +805,8 @@ func TestCalculateShelleyFiltersLeaderRewardsByPoolOrder(t *testing.T) {
 
 func TestCalculateShelleyFiltersLeaderBeforeLowerPoolMemberReward(t *testing.T) {
 	shared := testCredential(0, 3)
+	ownerA := testCredential(0, 1)
+	ownerB := testCredential(0, 2)
 	poolA := testPoolID(1)
 	poolB := testPoolID(2)
 
@@ -762,8 +829,11 @@ func TestCalculateShelleyFiltersLeaderBeforeLowerPoolMemberReward(t *testing.T) 
 					TotalBlocks:             10,
 					RewardAccountRegistered: false,
 					RewardAccountEligible:   false,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerA: {},
+					},
 					Delegators: []Delegator{
+						{Credential: ownerA, Stake: 500, Registered: false, Eligible: false},
 						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
 					},
 				},
@@ -779,7 +849,12 @@ func TestCalculateShelleyFiltersLeaderBeforeLowerPoolMemberReward(t *testing.T) 
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerB: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerB, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -801,6 +876,8 @@ func TestCalculateShelleyFiltersLeaderBeforeLowerPoolMemberReward(t *testing.T) 
 
 func TestCalculateShelleyDropsMemberRewardsForSharedRewardCredentialAcrossPools(t *testing.T) {
 	shared := testCredential(0, 3)
+	ownerA := testCredential(0, 1)
+	ownerB := testCredential(0, 2)
 	poolA := testPoolID(1)
 	poolB := testPoolID(2)
 
@@ -823,8 +900,11 @@ func TestCalculateShelleyDropsMemberRewardsForSharedRewardCredentialAcrossPools(
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerB: {},
+					},
 					Delegators: []Delegator{
+						{Credential: ownerB, Stake: 500, Registered: true, Eligible: true},
 						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
 					},
 				},
@@ -840,7 +920,12 @@ func TestCalculateShelleyDropsMemberRewardsForSharedRewardCredentialAcrossPools(
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerA: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerA, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -860,6 +945,7 @@ func TestCalculateShelleyDropsMemberRewardsForSharedRewardCredentialAcrossPools(
 }
 
 func TestCalculateAllegraAggregatesMultipleRewardsForSameCredential(t *testing.T) {
+	owner := testCredential(0, 2)
 	shared := testCredential(0, 3)
 	poolID := testPoolID(1)
 
@@ -882,8 +968,11 @@ func TestCalculateAllegraAggregatesMultipleRewardsForSameCredential(t *testing.T
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
 						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
 					},
 				},
@@ -906,6 +995,8 @@ func TestCalculateAllegraAggregatesMultipleRewardsForSameCredential(t *testing.T
 
 func TestCalculateAllegraKeepsSameCredentialRewardsAcrossPools(t *testing.T) {
 	shared := testCredential(0, 3)
+	ownerA := testCredential(0, 1)
+	ownerB := testCredential(0, 2)
 	poolA := testPoolID(1)
 	poolB := testPoolID(2)
 
@@ -928,7 +1019,12 @@ func TestCalculateAllegraKeepsSameCredentialRewardsAcrossPools(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerB: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerB, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 				{
 					ID:                      poolA,
@@ -942,7 +1038,12 @@ func TestCalculateAllegraKeepsSameCredentialRewardsAcrossPools(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerA: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerA, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -964,6 +1065,8 @@ func TestCalculateAllegraKeepsSameCredentialRewardsAcrossPools(t *testing.T) {
 
 func TestCalculateUsesGlobalBlockTotalWhenPoolTotalsAbsent(t *testing.T) {
 	shared := testCredential(0, 3)
+	ownerA := testCredential(0, 1)
+	ownerB := testCredential(0, 2)
 	poolA := testPoolID(1)
 	poolB := testPoolID(2)
 
@@ -985,7 +1088,12 @@ func TestCalculateUsesGlobalBlockTotalWhenPoolTotalsAbsent(t *testing.T) {
 					BlocksProduced:          5,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerB: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerB, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 				{
 					ID:                      poolA,
@@ -998,7 +1106,12 @@ func TestCalculateUsesGlobalBlockTotalWhenPoolTotalsAbsent(t *testing.T) {
 					BlocksProduced:          5,
 					RewardAccountRegistered: true,
 					RewardAccountEligible:   true,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						ownerA: {},
+					},
+					Delegators: []Delegator{
+						{Credential: ownerA, Stake: 500, Registered: true, Eligible: true},
+					},
 				},
 			},
 		},
@@ -1169,6 +1282,7 @@ func TestCalculateRewardPotMatchesCFCalculatorEtaBoundaryVectors(t *testing.T) {
 			}
 
 			testSnapshot := snapshot
+			testSnapshot.Pools = append([]Pool(nil), snapshot.Pools...)
 			testSnapshot.Pools[0].BlocksProduced = tc.totalBlocks
 			testSnapshot.Pools[0].TotalBlocks = tc.totalBlocks
 
@@ -1297,6 +1411,80 @@ func TestCalculateRejectsOwnerStakeAboveDelegatedStake(t *testing.T) {
 	)
 	require.ErrorIs(t, err, ErrInvalidParameters)
 	require.ErrorContains(t, err, "owner stake 10 exceeds delegated stake 9")
+}
+
+func TestCalculateRejectsOwnerMissingFromDelegators(t *testing.T) {
+	owner := testCredential(0, 2)
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 1,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 1,
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "owner")
+	require.ErrorContains(t, err, "is not a delegator")
+}
+
+func TestCalculateRejectsIncorrectOwnerStake(t *testing.T) {
+	owner := testCredential(0, 2)
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 5,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 5,
+					OwnerStake:     5,
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
+					Delegators: []Delegator{
+						{Credential: owner, Stake: 4},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "computed owner stake 4")
+	require.ErrorContains(t, err, "does not match owner stake 5")
+}
+
+func TestCalculateRejectsConflictingCredentialEligibility(t *testing.T) {
+	shared := testCredential(0, 3)
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 1,
+			Pools: []Pool{
+				{
+					ID:                    testPoolID(1),
+					RewardAccount:         shared,
+					RewardAccountEligible: true,
+					DelegatedStake:        1,
+					Delegators: []Delegator{
+						{Credential: shared, Stake: 1, Eligible: false},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "conflicting reward eligibility")
 }
 
 func TestCalculateRejectsScriptPoolOwner(t *testing.T) {
@@ -1573,6 +1761,7 @@ func TestCalculateRejectsReserveRefundOverflow(t *testing.T) {
 }
 
 func TestCalculateRejectsUnspendableTreasuryOverflow(t *testing.T) {
+	owner := testCredential(0, 2)
 	member := testCredential(0, 3)
 	poolID := testPoolID(1)
 	params := babbageParams()
@@ -1597,8 +1786,11 @@ func TestCalculateRejectsUnspendableTreasuryOverflow(t *testing.T) {
 					TotalBlocks:             10,
 					RewardAccountRegistered: false,
 					RewardAccountEligible:   false,
-					Owners:                  map[Credential]struct{}{},
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
 					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: false, Eligible: false},
 						{Credential: member, Stake: 500, Registered: false, Eligible: false},
 					},
 				},

--- a/ledger/rewards/rewards_test.go
+++ b/ledger/rewards/rewards_test.go
@@ -1,0 +1,1658 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rewards
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateMatchesShelleyPoolRewardFormula(t *testing.T) {
+	poolID := testPoolID(1)
+	owner := testCredential(0, 2)
+	member := testCredential(0, 3)
+	rewardAccount := testCredential(0, 4)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           rewardAccount,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners: map[Credential]struct{}{
+						owner: {},
+					},
+					Delegators: []Delegator{
+						{Credential: owner, Stake: 500, Registered: true, Eligible: true},
+						{Credential: member, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+			},
+		},
+		Parameters{
+			MonetaryExpansion: big.NewRat(1, 100),
+			TreasuryExpansion: big.NewRat(0, 1),
+			Decentralization:  big.NewRat(0, 1),
+			PledgeInfluence:   big.NewRat(1, 2),
+			ActiveSlotsCoeff:  big.NewRat(1, 10),
+			OptimalPoolCount:  10,
+			EpochLength:       100,
+			MaxLovelaceSupply: 100_010_000,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(1_000_000), result.Incentives)
+	require.Equal(t, uint64(1_000_000), result.AvailableRewards)
+	require.Equal(t, uint64(83333), result.PoolRewards[0].OptimalReward)
+	require.Equal(t, uint64(83333), result.PoolRewards[0].PoolReward)
+	require.Equal(t, uint64(46283), result.PoolRewards[0].LeaderReward)
+	require.Equal(t, uint64(37049), result.PoolRewards[0].MemberRewardTotal)
+	require.Equal(t, uint64(1), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(916_668), result.Undistributed)
+	require.Equal(t, uint64(99_916_668), result.UpdatedPots.Reserves)
+
+	require.Len(t, result.AccountRewards, 2)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, rewardAccount, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(46283), result.AccountRewards[0].Amount)
+	require.Equal(t, RewardTypeMember, result.AccountRewards[1].Type)
+	require.Equal(t, member, result.AccountRewards[1].Credential)
+	require.Equal(t, uint64(37049), result.AccountRewards[1].Amount)
+}
+
+func TestCalculateScriptCredentialWithOwnerHashStillEarnsMemberReward(t *testing.T) {
+	poolID := testPoolID(1)
+	ownerKey := testCredential(0, 2)
+	scriptWithOwnerHash := testCredential(1, 2)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(0, 1),
+					Pledge:                  0,
+					Cost:                    0,
+					DelegatedStake:          1_000,
+					OwnerStake:              0,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners: map[Credential]struct{}{
+						ownerKey: {},
+					},
+					Delegators: []Delegator{
+						{
+							Credential: scriptWithOwnerHash,
+							Stake:      1_000,
+							Registered: true,
+							Eligible:   true,
+						},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 1)
+	require.Equal(t, RewardTypeMember, result.AccountRewards[0].Type)
+	require.Equal(t, scriptWithOwnerHash, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(66_666), result.AccountRewards[0].Amount)
+	require.Equal(t, uint64(66_666), result.PoolRewards[0].MemberRewardTotal)
+	require.Equal(t, uint64(0), result.PoolRewards[0].LeaderReward)
+}
+
+func TestCalculatePledgeFailureZerosPoolReward(t *testing.T) {
+	poolID := testPoolID(1)
+
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  501,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), result.PoolRewards[0].PoolReward)
+	require.Empty(t, result.AccountRewards)
+	require.Equal(t, uint64(1_000_000), result.Undistributed)
+	require.Equal(t, uint64(100_000_000), result.UpdatedPots.Reserves)
+}
+
+func TestCalculatePoolRewardAtOrBelowCostPaysOnlyLeader(t *testing.T) {
+	poolID := testPoolID(1)
+	leader := testCredential(0, 2)
+	member := testCredential(0, 3)
+
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           leader,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    100_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners: map[Credential]struct{}{
+						leader: {},
+					},
+					Delegators: []Delegator{
+						{Credential: leader, Stake: 500, Registered: true, Eligible: true},
+						{Credential: member, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(83_333), result.PoolRewards[0].PoolReward)
+	require.Equal(t, uint64(83_333), result.PoolRewards[0].LeaderReward)
+	require.Equal(t, uint64(0), result.PoolRewards[0].MemberRewardTotal)
+	require.Equal(t, uint64(0), result.PoolRewards[0].Undistributed)
+	require.Len(t, result.AccountRewards, 1)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, leader, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(83_333), result.AccountRewards[0].Amount)
+	require.Equal(t, uint64(83_333), result.EffectiveRewards)
+	require.Equal(t, uint64(916_667), result.Undistributed)
+	require.Equal(t, uint64(99_916_667), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateNoActiveStakeReturnsAvailableRewardsToReserves(t *testing.T) {
+	params := testParams()
+	params.TreasuryExpansion = big.NewRat(1, 5)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: 10,
+			Fees:     2_000,
+		},
+		Snapshot{},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(2_000), result.TotalRewardPot)
+	require.Equal(t, uint64(400), result.TreasuryTax)
+	require.Equal(t, uint64(1_600), result.AvailableRewards)
+	require.Equal(t, uint64(1_600), result.Undistributed)
+	require.Equal(t, uint64(100_001_600), result.UpdatedPots.Reserves)
+	require.Equal(t, uint64(410), result.UpdatedPots.Treasury)
+	require.Empty(t, result.PoolRewards)
+	require.Empty(t, result.AccountRewards)
+}
+
+func TestCalculateTreasuryTaxUsesIncentivesAndFees(t *testing.T) {
+	poolID := testPoolID(1)
+	params := testParams()
+	params.TreasuryExpansion = big.NewRat(1, 5)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: 10,
+			Fees:     2_000,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(0, 1),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(1_000_000), result.Incentives)
+	require.Equal(t, uint64(1_002_000), result.TotalRewardPot)
+	require.Equal(t, uint64(200_400), result.TreasuryTax)
+	require.Equal(t, uint64(801_600), result.AvailableRewards)
+	require.Equal(t, uint64(200_410), result.UpdatedPots.Treasury)
+}
+
+func TestCalculateNetworkEfficiencyIncludesDecentralization(t *testing.T) {
+	poolID := testPoolID(1)
+	params := testParams()
+	params.Decentralization = big.NewRat(1, 2)
+
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             5,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, big.NewRat(5, 1), result.ExpectedBlocks)
+	require.Equal(t, big.NewRat(1, 1), result.Efficiency)
+	require.Equal(t, uint64(1_000_000), result.Incentives)
+}
+
+func TestCalculateNetworkEfficiencyHonorsDecentralizationThreshold(t *testing.T) {
+	poolID := testPoolID(1)
+	params := testParams()
+	params.Decentralization = big.NewRat(4, 5)
+	snapshot := Snapshot{
+		TotalActiveStake: 1_000,
+		Pools: []Pool{
+			{
+				ID:                      poolID,
+				RewardAccount:           testCredential(0, 4),
+				Margin:                  big.NewRat(1, 10),
+				Pledge:                  500,
+				Cost:                    1_000,
+				DelegatedStake:          1_000,
+				OwnerStake:              500,
+				RewardAccountRegistered: true,
+				RewardAccountEligible:   true,
+				Owners:                  map[Credential]struct{}{},
+			},
+		},
+	}
+
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		snapshot,
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, big.NewRat(2, 1), result.ExpectedBlocks)
+	require.Equal(t, big.NewRat(1, 1), result.Efficiency)
+	require.Equal(t, uint64(1_000_000), result.Incentives)
+	require.Equal(t, uint64(1_000_000), result.Undistributed)
+	require.Equal(t, uint64(100_000_000), result.UpdatedPots.Reserves)
+
+	params.Decentralization = big.NewRat(1, 1)
+	result, err = Calculate(Pots{Reserves: 100_000_000}, snapshot, params)
+	require.NoError(t, err)
+	require.Equal(t, big.NewRat(0, 1), result.ExpectedBlocks)
+	require.Equal(t, big.NewRat(1, 1), result.Efficiency)
+	require.Equal(t, uint64(1_000_000), result.Incentives)
+	require.Equal(t, uint64(1_000_000), result.Undistributed)
+}
+
+func TestCalculateRoutesUnspendableRewardsToTreasury(t *testing.T) {
+	member := testCredential(0, 3)
+	poolID := testPoolID(1)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: 10,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: false,
+					RewardAccountEligible:   false,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: member, Stake: 500, Registered: false, Eligible: false},
+					},
+				},
+			},
+		},
+		babbageParams(),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 2)
+	require.False(t, result.AccountRewards[0].Spendable)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, uint64(46283), result.AccountRewards[0].Amount)
+	require.False(t, result.AccountRewards[1].Spendable)
+	require.Equal(t, RewardTypeMember, result.AccountRewards[1].Type)
+	require.Equal(t, uint64(37049), result.AccountRewards[1].Amount)
+	require.Equal(t, uint64(83332), result.Unspendable)
+	require.Equal(t, uint64(1), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(916_668), result.Undistributed)
+	require.Equal(t, uint64(99_916_668), result.UpdatedPots.Reserves)
+	require.Equal(t, uint64(83_342), result.UpdatedPots.Treasury)
+}
+
+func TestCalculatePotDeltasMatchReferenceSemantics(t *testing.T) {
+	member := testCredential(0, 3)
+	poolID := testPoolID(1)
+	params := babbageParams()
+	params.TreasuryExpansion = big.NewRat(1, 5)
+	pots := Pots{
+		Reserves: 100_000_000,
+		Treasury: 10,
+		Fees:     2_000,
+	}
+
+	result, err := Calculate(
+		pots,
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: false,
+					RewardAccountEligible:   false,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: member, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+	require.Greater(t, result.TreasuryTax, uint64(0))
+	require.Greater(t, result.Unspendable, uint64(0))
+	require.Greater(t, result.EffectiveRewards, uint64(0))
+
+	// This is the same pot movement expressed by cardano-ledger's
+	// oldr <-> sumRewards, Amaru's delta_reserves, and the CF calculator's
+	// reserve/treasury adjustment after unspendable rewards are known.
+	computedAccountRewards := result.EffectiveRewards + result.Unspendable
+	reserveDelta := result.Incentives + computedAccountRewards - result.AvailableRewards
+	require.Equal(t, pots.Reserves-reserveDelta, result.UpdatedPots.Reserves)
+	require.Equal(
+		t,
+		pots.Treasury+result.TreasuryTax+result.Unspendable,
+		result.UpdatedPots.Treasury,
+	)
+}
+
+func TestCalculateRejectsRewardsAboveAvailablePot(t *testing.T) {
+	poolID := testPoolID(1)
+	params := babbageParams()
+	params.MaxLovelaceSupply = 1_000
+	params.OptimalPoolCount = 1
+
+	_, err := Calculate(
+		Pots{
+			Fees: 1_000_000,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 1),
+					Pledge:                  0,
+					Cost:                    0,
+					DelegatedStake:          1_000,
+					OwnerStake:              0,
+					BlocksProduced:          20,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "rewards exceed available pot")
+}
+
+func TestCalculatePreBabbageFilteredRewardsReturnToReserves(t *testing.T) {
+	member := testCredential(0, 3)
+	poolID := testPoolID(1)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: 10,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: false,
+					RewardAccountEligible:   false,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: member, Stake: 500, Registered: false, Eligible: false},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.NoError(t, err)
+
+	require.Empty(t, result.AccountRewards)
+	require.Equal(t, uint64(0), result.Unspendable)
+	require.Equal(t, uint64(83333), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(1_000_000), result.Undistributed)
+	require.Equal(t, uint64(100_000_000), result.UpdatedPots.Reserves)
+	require.Equal(t, uint64(10), result.UpdatedPots.Treasury)
+}
+
+func TestCalculatePreBabbageFinalUnregisteredRewardsGoToTreasury(t *testing.T) {
+	member := testCredential(0, 3)
+	poolID := testPoolID(1)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: 10,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   false,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: member, Stake: 500, Registered: true, Eligible: false},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 2)
+	require.False(t, result.AccountRewards[0].Spendable)
+	require.False(t, result.AccountRewards[1].Spendable)
+	require.Equal(t, uint64(83_332), result.Unspendable)
+	require.Equal(t, uint64(916_668), result.Undistributed)
+	require.Equal(t, uint64(99_916_668), result.UpdatedPots.Reserves)
+	require.Equal(t, uint64(83_342), result.UpdatedPots.Treasury)
+}
+
+func TestCalculatePreBabbagePrefilteredRewardsIgnoreCurrentRegistration(t *testing.T) {
+	member := testCredential(0, 3)
+	poolID := testPoolID(1)
+
+	result, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: 10,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: false,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: member, Stake: 500, Registered: false, Eligible: true},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.NoError(t, err)
+
+	require.Empty(t, result.AccountRewards)
+	require.Equal(t, uint64(0), result.Unspendable)
+	require.Equal(t, uint64(83333), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(1_000_000), result.Undistributed)
+	require.Equal(t, uint64(100_000_000), result.UpdatedPots.Reserves)
+	require.Equal(t, uint64(10), result.UpdatedPots.Treasury)
+}
+
+func TestCalculateShelleyFiltersMultipleRewardsForSameCredential(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolID := testPoolID(1)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 2
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 1)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, shared, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, uint64(0), result.PoolRewards[0].MemberRewardTotal)
+	require.Equal(t, uint64(37_050), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(953_717), result.Undistributed)
+	require.Equal(t, uint64(99_953_717), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateShelleyFiltersLeaderRewardsByPoolOrder(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolA := testPoolID(1)
+	poolB := testPoolID(2)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 2
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 2_000,
+			Pools: []Pool{
+				{
+					ID:                      poolB,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+				{
+					ID:                      poolA,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 1)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, poolA, result.AccountRewards[0].PoolID)
+	require.Equal(t, shared, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, poolA, result.PoolRewards[0].PoolID)
+	require.Equal(t, uint64(37_050), result.PoolRewards[0].Undistributed)
+	require.Equal(t, poolB, result.PoolRewards[1].PoolID)
+	require.Equal(t, uint64(83_333), result.PoolRewards[1].Undistributed)
+	require.Equal(t, uint64(953_717), result.Undistributed)
+	require.Equal(t, uint64(99_953_717), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateShelleyFiltersLeaderBeforeLowerPoolMemberReward(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolA := testPoolID(1)
+	poolB := testPoolID(2)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 2
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 2_000,
+			Pools: []Pool{
+				{
+					ID:                      poolA,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: false,
+					RewardAccountEligible:   false,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+				{
+					ID:                      poolB,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 1)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, poolB, result.AccountRewards[0].PoolID)
+	require.Equal(t, shared, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, uint64(0), result.PoolRewards[0].MemberRewardTotal)
+	require.Equal(t, uint64(83_333), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(37_050), result.PoolRewards[1].Undistributed)
+	require.Equal(t, uint64(953_717), result.Undistributed)
+	require.Equal(t, uint64(99_953_717), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateShelleyDropsMemberRewardsForSharedRewardCredentialAcrossPools(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolA := testPoolID(1)
+	poolB := testPoolID(2)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 2
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 2_000,
+			Pools: []Pool{
+				{
+					ID:                      poolB,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+				{
+					ID:                      poolA,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 1)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, poolA, result.AccountRewards[0].PoolID)
+	require.Equal(t, shared, result.AccountRewards[0].Credential)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, uint64(0), result.PoolRewards[1].MemberRewardTotal)
+	require.Equal(t, uint64(83_333), result.PoolRewards[1].Undistributed)
+	require.Equal(t, uint64(953_717), result.Undistributed)
+	require.Equal(t, uint64(99_953_717), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateAllegraAggregatesMultipleRewardsForSameCredential(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolID := testPoolID(1)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 3
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: shared, Stake: 500, Registered: true, Eligible: true},
+					},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 2)
+	require.Equal(t, RewardTypeLeader, result.AccountRewards[0].Type)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, RewardTypeMember, result.AccountRewards[1].Type)
+	require.Equal(t, uint64(37_049), result.AccountRewards[1].Amount)
+	require.Equal(t, uint64(37_049), result.PoolRewards[0].MemberRewardTotal)
+	require.Equal(t, uint64(1), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(916_668), result.Undistributed)
+	require.Equal(t, uint64(99_916_668), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateAllegraKeepsSameCredentialRewardsAcrossPools(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolA := testPoolID(1)
+	poolB := testPoolID(2)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 3
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 2_000,
+			Pools: []Pool{
+				{
+					ID:                      poolB,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+				{
+					ID:                      poolA,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result.AccountRewards, 2)
+	require.Equal(t, poolA, result.AccountRewards[0].PoolID)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, poolB, result.AccountRewards[1].PoolID)
+	require.Equal(t, uint64(46_283), result.AccountRewards[1].Amount)
+	require.Equal(t, uint64(92_566), result.EffectiveRewards)
+	require.Equal(t, uint64(37_050), result.PoolRewards[0].Undistributed)
+	require.Equal(t, uint64(37_050), result.PoolRewards[1].Undistributed)
+	require.Equal(t, uint64(907_434), result.Undistributed)
+	require.Equal(t, uint64(99_907_434), result.UpdatedPots.Reserves)
+}
+
+func TestCalculateUsesGlobalBlockTotalWhenPoolTotalsAbsent(t *testing.T) {
+	shared := testCredential(0, 3)
+	poolA := testPoolID(1)
+	poolB := testPoolID(2)
+
+	params := testParams()
+	params.ProtocolMajorVersion = 3
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 2_000,
+			Pools: []Pool{
+				{
+					ID:                      poolB,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+				{
+					ID:                      poolA,
+					RewardAccount:           shared,
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          5,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{},
+				},
+			},
+		},
+		params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(10), result.TotalBlocks)
+	require.Len(t, result.AccountRewards, 2)
+	require.Equal(t, poolA, result.AccountRewards[0].PoolID)
+	require.Equal(t, uint64(46_283), result.AccountRewards[0].Amount)
+	require.Equal(t, poolB, result.AccountRewards[1].PoolID)
+	require.Equal(t, uint64(46_283), result.AccountRewards[1].Amount)
+	require.Equal(t, uint64(907_434), result.Undistributed)
+	require.Equal(t, uint64(99_907_434), result.UpdatedPots.Reserves)
+}
+
+func TestApparentPerformanceHonorsDecentralizationThreshold(t *testing.T) {
+	require.Equal(
+		t,
+		big.NewRat(1, 1),
+		apparentPerformance(big.NewRat(4, 5), 1, 100, 0, 10),
+	)
+	require.Equal(
+		t,
+		big.NewRat(1, 1),
+		apparentPerformance(big.NewRat(1, 1), 1, 100, 0, 10),
+	)
+	require.Equal(
+		t,
+		big.NewRat(2, 1),
+		apparentPerformance(big.NewRat(0, 1), 10, 100, 2, 10),
+	)
+}
+
+func TestRewardEfficiencyHonorsDecentralizationThreshold(t *testing.T) {
+	// Mirrors cardano-ledger's eta shortcut in PulsingReward.startStep:
+	// when d >= 0.8, the reward pot is not reduced by observed block count.
+	require.Equal(
+		t,
+		big.NewRat(1, 1),
+		rewardEfficiency(0, big.NewRat(10, 1), big.NewRat(4, 5)),
+	)
+	require.Equal(
+		t,
+		big.NewRat(1, 1),
+		rewardEfficiency(0, big.NewRat(10, 1), big.NewRat(1, 1)),
+	)
+	require.Equal(
+		t,
+		big.NewRat(1, 5),
+		rewardEfficiency(2, big.NewRat(10, 1), big.NewRat(0, 1)),
+	)
+}
+
+func TestCalculateRewardPotMatchesCFCalculatorEtaFloorVectors(t *testing.T) {
+	params := testParams()
+	params.MonetaryExpansion = big.NewRat(3, 1000)
+	params.TreasuryExpansion = big.NewRat(0, 1)
+	params.Decentralization = big.NewRat(0, 1)
+	params.ActiveSlotsCoeff = big.NewRat(1, 1)
+	params.EpochLength = 60
+	params.MaxLovelaceSupply = 45_000_000_000_000_000
+
+	snapshot := Snapshot{
+		TotalActiveStake: 0,
+		Pools: []Pool{
+			{
+				ID:             testPoolID(1),
+				RewardAccount:  testCredential(0, 4),
+				Margin:         big.NewRat(0, 1),
+				BlocksProduced: 59,
+				TotalBlocks:    59,
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		pots   Pots
+		reward uint64
+	}{
+		{
+			name: "exact rational floor",
+			pots: Pots{
+				Reserves: 35_989_500_000_000_000,
+			},
+			reward: 106_169_025_000_000,
+		},
+		{
+			name: "fractional result floors before adding fees",
+			pots: Pots{
+				Reserves: 1_000,
+				Fees:     7,
+			},
+			reward: 9,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Calculate(tc.pots, snapshot, params)
+			require.NoError(t, err)
+			require.Equal(t, big.NewRat(59, 60), result.Efficiency)
+			require.Equal(t, tc.reward, result.TotalRewardPot)
+		})
+	}
+}
+
+func TestCalculateRewardPotMatchesCFCalculatorEtaBoundaryVectors(t *testing.T) {
+	snapshot := Snapshot{
+		TotalActiveStake: 0,
+		Pools: []Pool{
+			{
+				ID:             testPoolID(1),
+				RewardAccount:  testCredential(0, 4),
+				Margin:         big.NewRat(0, 1),
+				BlocksProduced: 0,
+				TotalBlocks:    0,
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name           string
+		totalBlocks    uint64
+		decentralized  *big.Rat
+		reward         uint64
+		treasuryTax    uint64
+		available      uint64
+		wantEfficiency *big.Rat
+	}{
+		{
+			name:           "eta one at decentralization threshold",
+			decentralized:  big.NewRat(4, 5),
+			reward:         3,
+			wantEfficiency: big.NewRat(1, 1),
+		},
+		{
+			name:           "eta capped at one when blocks meet expectation",
+			totalBlocks:    60,
+			decentralized:  big.NewRat(0, 1),
+			reward:         3,
+			wantEfficiency: big.NewRat(1, 1),
+		},
+		{
+			name:           "treasury cut uses exact ratio floor",
+			totalBlocks:    59,
+			decentralized:  big.NewRat(0, 1),
+			reward:         106_169_025_000_000,
+			treasuryTax:    21_233_805_000_000,
+			available:      84_935_220_000_000,
+			wantEfficiency: big.NewRat(59, 60),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := testParams()
+			params.MonetaryExpansion = big.NewRat(3, 1000)
+			params.TreasuryExpansion = big.NewRat(0, 1)
+			params.Decentralization = tc.decentralized
+			params.ActiveSlotsCoeff = big.NewRat(1, 1)
+			params.EpochLength = 60
+			params.MaxLovelaceSupply = 45_000_000_000_000_000
+			pots := Pots{
+				Reserves: 1_000,
+			}
+			if tc.treasuryTax != 0 {
+				params.TreasuryExpansion = big.NewRat(1, 5)
+				pots.Reserves = 35_989_500_000_000_000
+			}
+
+			testSnapshot := snapshot
+			testSnapshot.Pools[0].BlocksProduced = tc.totalBlocks
+			testSnapshot.Pools[0].TotalBlocks = tc.totalBlocks
+
+			result, err := Calculate(pots, testSnapshot, params)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantEfficiency, result.Efficiency)
+			require.Equal(t, tc.reward, result.TotalRewardPot)
+			require.Equal(t, tc.treasuryTax, result.TreasuryTax)
+			if tc.available != 0 {
+				require.Equal(t, tc.available, result.AvailableRewards)
+			}
+		})
+	}
+}
+
+func TestCalculateKeepsFractionalExpectedBlocksExact(t *testing.T) {
+	params := testParams()
+	params.EpochLength = 10
+	params.ActiveSlotsCoeff = big.NewRat(1, 3)
+	params.Decentralization = big.NewRat(0, 1)
+	params.MonetaryExpansion = big.NewRat(1, 1)
+
+	result, err := Calculate(Pots{Reserves: 100}, Snapshot{
+		Pools: []Pool{{
+			ID:             testPoolID(1),
+			RewardAccount:  testCredential(0, 2),
+			BlocksProduced: 1,
+			TotalBlocks:    1,
+		}},
+	}, params)
+	require.NoError(t, err)
+	require.Equal(t, big.NewRat(10, 3), result.ExpectedBlocks)
+	require.Equal(t, big.NewRat(3, 10), result.Efficiency)
+	require.Equal(t, uint64(30), result.Incentives)
+}
+
+func TestCalculateRejectsInvalidUnitIntervals(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Parameters)
+	}{
+		{
+			name: "monetary expansion",
+			mutate: func(params *Parameters) {
+				params.MonetaryExpansion = big.NewRat(2, 1)
+			},
+		},
+		{
+			name: "treasury expansion",
+			mutate: func(params *Parameters) {
+				params.TreasuryExpansion = big.NewRat(2, 1)
+			},
+		},
+		{
+			name: "decentralization",
+			mutate: func(params *Parameters) {
+				params.Decentralization = big.NewRat(2, 1)
+			},
+		},
+		{
+			name: "active slot coeff",
+			mutate: func(params *Parameters) {
+				params.ActiveSlotsCoeff = big.NewRat(2, 1)
+			},
+		},
+		{
+			name: "active slot coeff is zero",
+			mutate: func(params *Parameters) {
+				params.ActiveSlotsCoeff = big.NewRat(0, 1)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := testParams()
+			tc.mutate(&params)
+			_, err := Calculate(Pots{}, Snapshot{}, params)
+			require.ErrorIs(t, err, ErrInvalidParameters)
+			require.ErrorContains(t, err, tc.name)
+		})
+	}
+}
+
+func TestCalculateRejectsInvalidPoolMargins(t *testing.T) {
+	cases := []struct {
+		name   string
+		margin *big.Rat
+	}{
+		{name: "negative", margin: big.NewRat(-1, 10)},
+		{name: "above one", margin: big.NewRat(11, 10)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Calculate(
+				Pots{},
+				Snapshot{
+					Pools: []Pool{
+						{
+							ID:     testPoolID(1),
+							Margin: tc.margin,
+						},
+					},
+				},
+				testParams(),
+			)
+			require.ErrorIs(t, err, ErrInvalidParameters)
+			require.ErrorContains(t, err, "margin outside [0,1]")
+		})
+	}
+}
+
+func TestCalculateRejectsOwnerStakeAboveDelegatedStake(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 9,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 9,
+					OwnerStake:     10,
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "owner stake 10 exceeds delegated stake 9")
+}
+
+func TestCalculateRejectsScriptPoolOwner(t *testing.T) {
+	scriptOwner := testCredential(1, 2)
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			Pools: []Pool{
+				{
+					ID: testPoolID(1),
+					Owners: map[Credential]struct{}{
+						scriptOwner: {},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "non-key credential tag")
+}
+
+func TestCalculateRejectsInvalidRewardAccountCredentialTag(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			Pools: []Pool{
+				{
+					ID:            testPoolID(1),
+					RewardAccount: testCredential(2, 3),
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "reward account")
+	require.ErrorContains(t, err, "invalid credential tag")
+}
+
+func TestCalculateRejectsInvalidDelegatorCredentialTag(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 1,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					RewardAccount:  testCredential(0, 3),
+					DelegatedStake: 1,
+					Delegators: []Delegator{
+						{Credential: testCredential(2, 4), Stake: 1},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "delegator")
+	require.ErrorContains(t, err, "invalid credential tag")
+}
+
+func TestCalculateRejectsDuplicatePoolSnapshotRows(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			Pools: []Pool{
+				{ID: testPoolID(1)},
+				{ID: testPoolID(1)},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "duplicate pool")
+}
+
+func TestCalculateRejectsActiveStakeMismatch(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 2,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 1,
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(
+		t,
+		err,
+		"total delegated stake 1 does not match active stake 2",
+	)
+}
+
+func TestCalculateRejectsTotalBlocksOverflow(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: math.MaxUint64,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: math.MaxUint64 - 1,
+					BlocksProduced: math.MaxUint64,
+				},
+				{
+					ID:             testPoolID(2),
+					DelegatedStake: 1,
+					BlocksProduced: 1,
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "total blocks overflow")
+}
+
+func TestCalculateRejectsInconsistentExplicitTotalBlocks(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 2,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 1,
+					TotalBlocks:    10,
+				},
+				{
+					ID:             testPoolID(2),
+					DelegatedStake: 1,
+					TotalBlocks:    11,
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "inconsistent total blocks")
+}
+
+func TestCalculateRejectsDuplicatePoolDelegators(t *testing.T) {
+	credential := testCredential(0, 2)
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 2,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 2,
+					Delegators: []Delegator{
+						{Credential: credential, Stake: 1},
+						{Credential: credential, Stake: 1},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "duplicate delegator")
+}
+
+func TestCalculateRejectsDelegatorInMultiplePools(t *testing.T) {
+	credential := testCredential(0, 2)
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 2,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 1,
+					Delegators: []Delegator{
+						{Credential: credential, Stake: 1},
+					},
+				},
+				{
+					ID:             testPoolID(2),
+					DelegatedStake: 1,
+					Delegators: []Delegator{
+						{Credential: credential, Stake: 1},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "duplicate delegator")
+	require.ErrorContains(t, err, "in pools")
+}
+
+func TestCalculateRejectsDelegatorStakeAbovePoolStake(t *testing.T) {
+	_, err := Calculate(
+		Pots{},
+		Snapshot{
+			TotalActiveStake: 2,
+			Pools: []Pool{
+				{
+					ID:             testPoolID(1),
+					DelegatedStake: 2,
+					Delegators: []Delegator{
+						{Credential: testCredential(0, 2), Stake: 3},
+					},
+				},
+			},
+		},
+		testParams(),
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(
+		t,
+		err,
+		"delegator stake 3 exceeds delegated stake 2",
+	)
+}
+
+func TestCalculateRejectsReservesAboveMaxSupply(t *testing.T) {
+	params := testParams()
+	params.MaxLovelaceSupply = 1_000
+
+	_, err := Calculate(
+		Pots{
+			Reserves: 1_001,
+		},
+		Snapshot{},
+		params,
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "reserves 1001 exceed max supply 1000")
+}
+
+func TestCalculateRejectsTreasuryTaxOverflow(t *testing.T) {
+	params := testParams()
+	params.MonetaryExpansion = big.NewRat(0, 1)
+	params.TreasuryExpansion = big.NewRat(1, 1)
+
+	_, err := Calculate(
+		Pots{
+			Treasury: math.MaxUint64,
+			Fees:     1,
+		},
+		Snapshot{},
+		params,
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "treasury tax overflow")
+}
+
+func TestCalculateRejectsReserveRefundOverflow(t *testing.T) {
+	params := testParams()
+	params.MonetaryExpansion = big.NewRat(0, 1)
+	params.MaxLovelaceSupply = math.MaxUint64
+
+	_, err := Calculate(
+		Pots{
+			Reserves: math.MaxUint64,
+			Fees:     1,
+		},
+		Snapshot{},
+		params,
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "reserve refund overflow")
+}
+
+func TestCalculateRejectsUnspendableTreasuryOverflow(t *testing.T) {
+	member := testCredential(0, 3)
+	poolID := testPoolID(1)
+	params := babbageParams()
+
+	_, err := Calculate(
+		Pots{
+			Reserves: 100_000_000,
+			Treasury: math.MaxUint64,
+		},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      poolID,
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  500,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              500,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: false,
+					RewardAccountEligible:   false,
+					Owners:                  map[Credential]struct{}{},
+					Delegators: []Delegator{
+						{Credential: member, Stake: 500, Registered: false, Eligible: false},
+					},
+				},
+			},
+		},
+		params,
+	)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	require.ErrorContains(t, err, "unspendable treasury overflow")
+}
+
+func TestFloorRatCheckedRejectsUint64Overflow(t *testing.T) {
+	tooLarge := new(big.Rat).SetInt(
+		new(big.Int).Add(
+			new(big.Int).SetUint64(math.MaxUint64),
+			big.NewInt(1),
+		),
+	)
+
+	_, err := floorRatChecked(tooLarge)
+	require.ErrorIs(t, err, ErrRewardAmountOverflow)
+}
+
+func testParams() Parameters {
+	return Parameters{
+		MonetaryExpansion: big.NewRat(1, 100),
+		TreasuryExpansion: big.NewRat(0, 1),
+		Decentralization:  big.NewRat(0, 1),
+		PledgeInfluence:   big.NewRat(1, 2),
+		ActiveSlotsCoeff:  big.NewRat(1, 10),
+		OptimalPoolCount:  10,
+		EpochLength:       100,
+		MaxLovelaceSupply: 100_010_000,
+	}
+}
+
+func babbageParams() Parameters {
+	params := testParams()
+	params.ProtocolMajorVersion = 7
+	return params
+}
+
+func testCredential(tag uint8, fill byte) Credential {
+	var hash [CredentialHashSize]byte
+	for i := range hash {
+		hash[i] = fill
+	}
+	return Credential{Tag: tag, Hash: hash}
+}
+
+func testPoolID(fill byte) PoolID {
+	var hash PoolID
+	for i := range hash {
+		hash[i] = fill
+	}
+	return hash
+}

--- a/ledger/rewards/testdata/amaru_single_pool_reward_vector.json
+++ b/ledger/rewards/testdata/amaru_single_pool_reward_vector.json
@@ -47,7 +47,22 @@
         "total_blocks": 10,
         "reward_account_registered": true,
         "reward_account_eligible": true,
+        "owners": [
+          {
+            "tag": 0,
+            "hash": "02020202020202020202020202020202020202020202020202020202"
+          }
+        ],
         "delegators": [
+          {
+            "credential": {
+              "tag": 0,
+              "hash": "02020202020202020202020202020202020202020202020202020202"
+            },
+            "stake": 500,
+            "registered": true,
+            "eligible": true
+          },
           {
             "credential": {
               "tag": 0,

--- a/ledger/rewards/testdata/amaru_single_pool_reward_vector.json
+++ b/ledger/rewards/testdata/amaru_single_pool_reward_vector.json
@@ -1,0 +1,111 @@
+{
+  "name": "amaru-single-pool-reward-vector",
+  "source": {
+    "implementation": "PRAGMA Amaru",
+    "repository": "https://github.com/pragma-org/amaru",
+    "commit": "18b79961df0abbb83231850457242ebf6d3d5364",
+    "path": "crates/amaru-ledger/src/summary/rewards.rs",
+    "functions": [
+      "RewardsSummary::new",
+      "PoolState::optimal_rewards",
+      "PoolState::pool_rewards",
+      "PoolState::leader_rewards",
+      "PoolState::member_rewards"
+    ]
+  },
+  "parameters": {
+    "monetary_expansion": "1/100",
+    "treasury_expansion": "1/5",
+    "decentralization": "0/1",
+    "pledge_influence": "1/2",
+    "active_slots_coeff": "1/10",
+    "optimal_pool_count": 10,
+    "epoch_length": 100,
+    "max_lovelace_supply": 100010000,
+    "protocol_major_version": 9
+  },
+  "pots": {
+    "reserves": 100000000,
+    "treasury": 10,
+    "fees": 2000
+  },
+  "snapshot": {
+    "total_active_stake": 1000,
+    "pools": [
+      {
+        "id": "01010101010101010101010101010101010101010101010101010101",
+        "reward_account": {
+          "tag": 0,
+          "hash": "02020202020202020202020202020202020202020202020202020202"
+        },
+        "margin": "1/10",
+        "pledge": 500,
+        "cost": 1000,
+        "delegated_stake": 1000,
+        "owner_stake": 500,
+        "blocks_produced": 10,
+        "total_blocks": 10,
+        "reward_account_registered": true,
+        "reward_account_eligible": true,
+        "delegators": [
+          {
+            "credential": {
+              "tag": 0,
+              "hash": "03030303030303030303030303030303030303030303030303030303"
+            },
+            "stake": 500,
+            "registered": true,
+            "eligible": true
+          }
+        ]
+      }
+    ]
+  },
+  "expected": {
+    "incentives": 1000000,
+    "total_reward_pot": 1002000,
+    "treasury_tax": 200400,
+    "available_rewards": 801600,
+    "effective_rewards": 66800,
+    "undistributed": 734800,
+    "updated_pots": {
+      "reserves": 99734800,
+      "treasury": 200410,
+      "fees": 0
+    },
+    "pool_rewards": [
+      {
+        "pool_id": "01010101010101010101010101010101010101010101010101010101",
+        "optimal_reward": 66800,
+        "pool_reward": 66800,
+        "leader_reward": 37190,
+        "member_reward_total": 29610,
+        "owner_stake": 500,
+        "undistributed": 0,
+        "unspendable": 0
+      }
+    ],
+    "account_rewards": [
+      {
+        "credential": {
+          "tag": 0,
+          "hash": "02020202020202020202020202020202020202020202020202020202"
+        },
+        "pool_id": "01010101010101010101010101010101010101010101010101010101",
+        "type": "leader",
+        "amount": 37190,
+        "spendable": true
+      },
+      {
+        "credential": {
+          "tag": 0,
+          "hash": "03030303030303030303030303030303030303030303030303030303"
+        },
+        "pool_id": "01010101010101010101010101010101010101010101010101010101",
+        "type": "member",
+        "amount": 29610,
+        "spendable": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Ref: #1959 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Shelley stake-pool reward formulas in a new `ledger/rewards` package with exact floor semantics. Computes per-pool leader/member rewards and pot updates consistent with cardano-ledger, Amaru, and the CF calculator (meets #1959).

- **New Features**
  - `Calculate` computes incentives, treasury tax, available rewards, per-pool apparent performance, optimal pool reward, and leader/member distribution.
  - Rational math throughout with floors only at spec points; matches Amaru/CF vectors.
  - Protocol gating: pre-Babbage reward prefilter, Allegra aggregation, and Babbage/Vasil unspendable-to-treasury routing.
  - Strict validation (params, margins, ownership, delegators, totals) and overflow checks.
  - Tests for edge cases and reference coverage, including Haskell-branch checks for apparent performance and an Amaru vector (`ledger/rewards/testdata/amaru_single_pool_reward_vector.json`).
  - Addressed review feedback with minor cleanups and clearer errors; no functional changes to formulas.

<sup>Written for commit c90f3a5b0cd2a2e0664b52f73dbe6ba87eb22400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shelley stake-pool reward calculation support, including leader and member rewards, treasury and reserve updates, eligibility handling, and protocol-version-specific behavior.
  * Added validation for reward inputs, stake distributions, pool configuration, credentials, and arithmetic limits.

* **Tests**
  * Added comprehensive unit and reference-vector coverage for reward calculations, edge cases, overflow handling, and protocol compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->