### PR TITLE
refactor(database): share SQL dialect helpers

### DIFF
--- a/database/plugin/metadata/internal/accounthistory/accounthistory.go
+++ b/database/plugin/metadata/internal/accounthistory/accounthistory.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
 )
@@ -168,15 +169,8 @@ func QueryRegistrationHistoryByCredential(
 }
 
 func transactionJoinClause(db *gorm.DB) string {
-	if db == nil {
-		return `INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`
-	}
-	switch strings.ToLower(db.Name()) {
-	case "mysql":
-		return "INNER JOIN `transaction` tx ON tx.id = certs.transaction_id"
-	default:
-		return `INNER JOIN "transaction" tx ON tx.id = certs.transaction_id`
-	}
+	return "INNER JOIN " + sqldialect.TransactionTableName(db) +
+		" tx ON tx.id = certs.transaction_id"
 }
 
 func DelegationTableCertType(table string) (uint, bool) {

--- a/database/plugin/metadata/internal/sqldialect/sqldialect.go
+++ b/database/plugin/metadata/internal/sqldialect/sqldialect.go
@@ -48,10 +48,10 @@ func TransactionTableName(db *gorm.DB) string {
 
 // IntegerCastType returns the backend-native integer type used to CAST the
 // text-encoded (types.Uint64) columns before arithmetic or numeric
-// comparison. utxo.amount, account.reward, and reward_live_stake's
-// utxo_stake/reward_stake/total_stake columns are all stored as
-// decimal-string TEXT (see types.Uint64.Value) regardless of backend, so any
-// SUM, arithmetic, or ordering comparison touching them must cast first:
+// comparison. The utxo.amount and account.reward columns used by the metadata
+// stake and voting-power queries are stored as decimal-string TEXT (see
+// types.Uint64.Value) regardless of backend, so any SUM, arithmetic, or
+// ordering comparison touching them must cast first:
 // sqlite is loosely typed and tolerates INTEGER; mysql needs UNSIGNED to
 // preserve values above math.MaxInt64 exactly (a signed cast would
 // overflow); postgres needs BIGINT and, unlike sqlite/mysql, never

--- a/database/plugin/metadata/internal/sqldialect/sqldialect.go
+++ b/database/plugin/metadata/internal/sqldialect/sqldialect.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sqldialect centralizes SQL-dialect literals shared by metadata query
+// packages. Keeping one implementation prevents a corrected or newly added
+// backend from silently leaving account-history queries inconsistent with
+// stake queries. Every helper is pure and treats a nil db the same as sqlite.
+package sqldialect
+
+import (
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// Name returns the lower-cased dialect name for db, or "" for a nil db
+// (treated the same as sqlite by every helper below).
+func Name(db *gorm.DB) string {
+	if db == nil {
+		return ""
+	}
+	return strings.ToLower(db.Name())
+}
+
+// TransactionTableName returns the quoted reference to the "transaction"
+// table for the backend dialect of db. mysql does not require quoting here
+// (TRANSACTION is not a reserved word), but backtick-quoting it is always
+// valid there; postgres and sqlite both require double quotes because
+// "transaction" collides with the SQL TRANSACTION keyword in unquoted
+// position.
+func TransactionTableName(db *gorm.DB) string {
+	if Name(db) == "mysql" {
+		return "`transaction`"
+	}
+	return `"transaction"`
+}
+
+// IntegerCastType returns the backend-native integer type used to CAST the
+// text-encoded (types.Uint64) columns before arithmetic or numeric
+// comparison. utxo.amount, account.reward, and reward_live_stake's
+// utxo_stake/reward_stake/total_stake columns are all stored as
+// decimal-string TEXT (see types.Uint64.Value) regardless of backend, so any
+// SUM, arithmetic, or ordering comparison touching them must cast first:
+// sqlite is loosely typed and tolerates INTEGER; mysql needs UNSIGNED to
+// preserve values above math.MaxInt64 exactly (a signed cast would
+// overflow); postgres needs BIGINT and, unlike sqlite/mysql, never
+// implicitly coerces TEXT to a numeric type, so postgres queries fail
+// outright without the cast.
+func IntegerCastType(db *gorm.DB) string {
+	switch Name(db) {
+	case "postgres":
+		return "BIGINT"
+	case "mysql":
+		return "UNSIGNED"
+	default:
+		return "INTEGER"
+	}
+}

--- a/database/plugin/metadata/internal/stakequery/stakequery.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"gorm.io/gorm"
 )
@@ -290,28 +291,14 @@ active_delegation AS (
 }
 
 func transactionTableName(db *gorm.DB) string {
-	if db == nil {
-		return `"transaction"`
-	}
-	if strings.EqualFold(db.Name(), "mysql") {
-		return "`transaction`"
-	}
-	return `"transaction"`
+	return sqldialect.TransactionTableName(db)
 }
 
 // utxoAmountCastType returns the backend-native integer type used to cast the
 // text-encoded utxo.amount column before summation. Matches the casts used by
-// the DRep voting-power queries in each plugin.
+// the DRep voting-power queries in each plugin. See sqldialect.IntegerCastType.
 func utxoAmountCastType(db *gorm.DB) string {
-	if db != nil {
-		switch {
-		case strings.EqualFold(db.Name(), "postgres"):
-			return "BIGINT"
-		case strings.EqualFold(db.Name(), "mysql"):
-			return "UNSIGNED"
-		}
-	}
-	return "INTEGER"
+	return sqldialect.IntegerCastType(db)
 }
 
 func delegationFallbackBlockTables(

--- a/database/plugin/metadata/internal/stakequery/stakequery_test.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stakequery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolQueryChunkSizeDefault(t *testing.T) {
+	chunkSize := poolQueryChunkSize(nil)
+	require.Equal(t, 800, chunkSize)
+
+	_, cteArgs := activeDelegationCTE(nil, 0)
+	const stakeQueryArgs = 2
+	require.LessOrEqual(t, len(cteArgs)+stakeQueryArgs+chunkSize, 999)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralizes SQL dialect helpers in `database/plugin/metadata/internal/sqldialect` for consistent quoting and integer casting across SQLite, Postgres, and MySQL, and updates `accounthistory` and `stakequery` to use them. Aligns with Linear issue 1959.

- **Refactors**
  - Added `sqldialect` helpers: `TransactionTableName`, `IntegerCastType` (nil `db` treated as SQLite).
  - Replaced duplicated dialect logic in `accounthistory` and `stakequery`.
  - Added a `stakequery` test to keep the default pool chunk size (800) within the 999-parameter limit.

<sup>Written for commit 116aea2df373a157f0360364c99776caa35bc120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

