### PR TITLE
fix(ledger): guard MIR arithmetic overflow

### DIFF
--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -97,6 +97,13 @@ func (ls *LedgerState) applyMIRCerts(
 				)
 			}
 			if credited {
+				if reward.Amount > ^uint64(0)-totalDebited {
+					return fmt.Errorf(
+						"MIR distribution total overflow: current=%d adding=%d",
+						totalDebited,
+						reward.Amount,
+					)
+				}
 				totalDebited += reward.Amount
 				ls.config.Logger.Debug(
 					"applied MIR reward",
@@ -185,6 +192,12 @@ func (ls *LedgerState) applyMIRPotTransfer(
 				reserves, amount,
 			)
 		}
+		if amount > ^uint64(0)-treasury {
+			return fmt.Errorf(
+				"MIR pot transfer would overflow treasury: pot has %d, moving %d",
+				treasury, amount,
+			)
+		}
 		reserves -= amount
 		treasury += amount
 	case mirPotTreasury:
@@ -192,6 +205,12 @@ func (ls *LedgerState) applyMIRPotTransfer(
 			return fmt.Errorf(
 				"MIR pot transfer would underflow treasury: pot has %d, moving %d",
 				treasury, amount,
+			)
+		}
+		if amount > ^uint64(0)-reserves {
+			return fmt.Errorf(
+				"MIR pot transfer would overflow reserves: pot has %d, moving %d",
+				reserves, amount,
 			)
 		}
 		treasury -= amount

--- a/ledger/mir_test.go
+++ b/ledger/mir_test.go
@@ -92,6 +92,17 @@ func runApplyMIRCerts(
 	}))
 }
 
+func applyMIRCertsErr(
+	ls *LedgerState,
+	db *database.Database,
+	epochStartSlot, boundarySlot uint64,
+) error {
+	txn := db.Transaction(true)
+	return txn.Do(func(txn *database.Txn) error {
+		return ls.applyMIRCerts(txn, epochStartSlot, boundarySlot)
+	})
+}
+
 // TestApplyMIRCerts_DistributionFromReserves_RegisteredAccount verifies that a
 // MIR cert distributing from reserves credits the registered reward account and
 // debits reserves.
@@ -178,6 +189,41 @@ func TestApplyMIRCerts_MultipleDistributionsSameAccount(t *testing.T) {
 	).Order("id ASC").Find(&deltas).Error)
 	require.Len(t, deltas, 2)
 	assert.NotEqual(t, string(deltas[0].TxHash), string(deltas[1].TxHash))
+}
+
+func TestApplyMIRCerts_DistributionTotalOverflowRollsBack(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	maxUint := ^uint64(0)
+	credA := mirCred28(0x13)
+	credB := mirCred28(0x14)
+	seedMIRDistribution(t, gdb, mirPotReserves, 200, []models.MoveInstantaneousRewardsReward{
+		{Credential: credA, Amount: types.Uint64(maxUint)},
+		{Credential: credB, Amount: types.Uint64(1)},
+	})
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: credA,
+		Active:     true,
+	}))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: credB,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, maxUint, 50, nil))
+
+	err := applyMIRCertsErr(ls, db, 0, 1_000)
+	require.ErrorContains(t, err, "MIR distribution total overflow")
+
+	accountA, err := db.GetAccountByCredential(0, credA, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), uint64(accountA.Reward))
+	accountB, err := db.GetAccountByCredential(0, credB, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), uint64(accountB.Reward))
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.Equal(t, maxUint, uint64(state.Reserves))
+	require.Equal(t, uint64(50), state.Slot)
 }
 
 // TestApplyMIRCerts_DistributionFromTreasury_RegisteredAccount verifies a MIR
@@ -280,6 +326,38 @@ func TestApplyMIRCerts_PotTransferTreasuryToReserves(t *testing.T) {
 		"treasury decreased by pot transfer")
 	assert.Equal(t, uint64(7_500), uint64(state.Reserves),
 		"reserves increased by pot transfer")
+}
+
+func TestApplyMIRCerts_PotTransferOverflow(t *testing.T) {
+	maxUint := ^uint64(0)
+
+	t.Run("reserves to treasury", func(t *testing.T) {
+		ls, db, gdb := newMIRTestLedger(t)
+		seedMIRPotTransfer(t, gdb, mirPotReserves, 1, 500)
+		require.NoError(t, db.Metadata().SetNetworkState(maxUint, 1, 50, nil))
+
+		err := applyMIRCertsErr(ls, db, 0, 1_000)
+		require.ErrorContains(t, err, "overflow treasury")
+		state, stateErr := db.Metadata().GetNetworkState(nil)
+		require.NoError(t, stateErr)
+		require.Equal(t, maxUint, uint64(state.Treasury))
+		require.Equal(t, uint64(1), uint64(state.Reserves))
+		require.Equal(t, uint64(50), state.Slot)
+	})
+
+	t.Run("treasury to reserves", func(t *testing.T) {
+		ls, db, gdb := newMIRTestLedger(t)
+		seedMIRPotTransfer(t, gdb, mirPotTreasury, 1, 500)
+		require.NoError(t, db.Metadata().SetNetworkState(1, maxUint, 50, nil))
+
+		err := applyMIRCertsErr(ls, db, 0, 1_000)
+		require.ErrorContains(t, err, "overflow reserves")
+		state, stateErr := db.Metadata().GetNetworkState(nil)
+		require.NoError(t, stateErr)
+		require.Equal(t, uint64(1), uint64(state.Treasury))
+		require.Equal(t, maxUint, uint64(state.Reserves))
+		require.Equal(t, uint64(50), state.Slot)
+	})
 }
 
 // TestApplyMIRCerts_OutsideEpochRange verifies that a MIR cert submitted


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent uint64 overflows when applying MIR distributions and pot transfers. On overflow, return an error and revert changes to keep ledger state consistent.

- **Bug Fixes**
  - `applyMIRCerts`: guard `totalDebited + reward.Amount` against overflow to avoid corrupting rewards.
  - `applyMIRPotTransfer`: guard destination pot overflow for reserves↔treasury moves.
  - Added tests to confirm errors are raised and no account or network state is mutated on overflow.

<sup>Written for commit 5dcb1818485e974a153c3984de27ffd9a7a5ab79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

