### PR TITLE
test(devnet): wait for slot and block growth

### DIFF
--- a/internal/test/devnet/scenarios/chain_growth_test.go
+++ b/internal/test/devnet/scenarios/chain_growth_test.go
@@ -77,19 +77,40 @@ func TestChainGrowthRate(t *testing.T) {
 	targetSlot := startTip.SlotNumber + measureSlots
 	measureTimeout := time.Duration(measureSlots)*cfg.SlotDuration() +
 		cfg.ExpectedBlockTime()*5
-	h.WaitForNodeSlot(dingoEndpoint, targetSlot, measureTimeout)
 
-	// Record the ending point
-	endTip, err := h.GetChainTip(dingoEndpoint)
-	require.NoError(t, err, "failed to get end tip")
+	// With activeSlotsCoeff=0.4 we expect ~40 blocks in 100 slots.
+	// Require at least 8 (20% of expected) as a conservative lower bound
+	// that accounts for random variance and possible rollbacks.
+	const minBlocks = uint64(8)
+	minBlock := startTip.BlockNumber + minBlocks
+	var endTip devnet.ChainTip
+	require.Eventually(t, func() bool {
+		tip, err := h.GetChainTip(dingoEndpoint)
+		if err != nil {
+			t.Logf("growth check: error querying %s: %v",
+				dingoEndpoint.Name, err)
+			return false
+		}
+		endTip = tip
+		t.Logf(
+			"growth check: %s at slot %d, block %d",
+			dingoEndpoint.Name, tip.SlotNumber, tip.BlockNumber,
+		)
+		return tip.SlotNumber >= targetSlot &&
+			tip.BlockNumber >= minBlock
+	}, measureTimeout, 2*time.Second,
+		"%s did not reach slot %d and block %d within %s",
+		dingoEndpoint.Name, targetSlot, minBlock, measureTimeout,
+	)
 	t.Logf(
 		"end tip: slot=%d block=%d",
 		endTip.SlotNumber, endTip.BlockNumber,
 	)
 
-	require.GreaterOrEqual(t, endTip.BlockNumber, startTip.BlockNumber,
-		"end block number should not be less than start (possible rollback)",
-	)
+	// The require.Eventually above already guarantees
+	// endTip.BlockNumber >= startTip.BlockNumber + minBlocks, so the
+	// subtraction below cannot underflow and a rollback below the start tip
+	// would have failed the Eventually rather than reaching here.
 	blocksProduced := endTip.BlockNumber - startTip.BlockNumber
 	slotsElapsed := endTip.SlotNumber - startTip.SlotNumber
 	if slotsElapsed == 0 {
@@ -104,10 +125,6 @@ func TestChainGrowthRate(t *testing.T) {
 		cfg.ExpectedBlocksPerSlot()*100,
 	)
 
-	// With activeSlotsCoeff=0.4 we expect ~40 blocks in 100 slots.
-	// Require at least 8 (20% of expected) as a conservative lower bound
-	// that accounts for random variance and possible rollbacks.
-	const minBlocks = uint64(8)
 	require.GreaterOrEqual(t, blocksProduced, minBlocks,
 		"chain should produce at least %d blocks in %d slots "+
 			"(activeSlotsCoeff=%.2f)",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the devnet chain growth test to wait for both slot and block growth. This reduces flakiness from rollbacks and transient query errors.

- **Bug Fixes**
  - Replaced `WaitForNodeSlot` with `require.Eventually` polling `GetChainTip` until target slot and a minimum of 8 blocks are reached within the calculated timeout.
  - Added progress logs and a 2s poll interval; tolerate query errors during polling.
  - Ensured safe delta calculations by relying on the eventual condition before computing blocks and slots.

<sup>Written for commit 306ea30eff26a22d461f8453601cb9eb8b1ecb02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

