### PR TITLE
test(ledger): cover typed-nil Dijkstra deltas

### DIFF
--- a/ledger/delta_test.go
+++ b/ledger/delta_test.go
@@ -100,10 +100,69 @@ func TestProcessGovernanceAcceptsDijkstraProtocolParameters(t *testing.T) {
 	require.Equal(t, uint64(32), got.ExpiresEpoch)
 }
 
+func TestConwayProtocolParametersDijkstra(t *testing.T) {
+	pparams := &dijkstra.DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			GovActionValidityPeriod: 42,
+			DRepInactivityPeriod:    99,
+		},
+	}
+
+	got := conwayProtocolParameters(pparams)
+	require.Same(t, &pparams.ConwayProtocolParameters, got)
+	require.Equal(t, uint64(42), got.GovActionValidityPeriod)
+	require.Equal(t, uint64(99), got.DRepInactivityPeriod)
+}
+
 func TestConwayProtocolParametersNilDijkstra(t *testing.T) {
 	var pparams *dijkstra.DijkstraProtocolParameters
 
 	require.Nil(t, conwayProtocolParameters(pparams))
+}
+
+func TestConwayProtocolParametersTypedNil(t *testing.T) {
+	var conwayPParams *conway.ConwayProtocolParameters
+	var dijkstraPParams *dijkstra.DijkstraProtocolParameters
+
+	require.Nil(t, conwayProtocolParameters(conwayPParams))
+	require.Nil(t, conwayProtocolParameters(dijkstraPParams))
+}
+
+func TestProcessGovernanceTypedNilPParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		pparams lcommon.ProtocolParameters
+	}{
+		{
+			name:    "conway",
+			pparams: (*conway.ConwayProtocolParameters)(nil),
+		},
+		{
+			name:    "dijkstra",
+			pparams: (*dijkstra.DijkstraProtocolParameters)(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := &LedgerState{
+				currentPParams: tt.pparams,
+			}
+			tx := mockledger.NewTransactionBuilder().
+				WithProposalProcedures(nil)
+
+			var err error
+			require.NotPanics(t, func() {
+				err = (&LedgerDelta{}).processGovernance(ls, tx, nil)
+			})
+			require.Error(t, err)
+			require.Contains(
+				t,
+				err.Error(),
+				"governance requires Conway protocol parameters",
+			)
+		})
+	}
 }
 
 func TestApplyTransactionMetadataOnlyRecordsNetworkDonations(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests to cover typed-nil handling for `dijkstra`/`conway` protocol parameters in ledger delta logic. Verify `conwayProtocolParameters` returns the embedded `conway` params from `dijkstra` inputs, treats typed-nil pointers as nil, and that `processGovernance` does not panic and returns an error ("governance requires Conway protocol parameters") when protocol params are typed-nil.

<sup>Written for commit 676390f95b9af53b7a70121f5ebc5c1d350de211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

