### PR TITLE
fix(ledger): report protocol major in epoch events

### DIFF
--- a/event/epoch.go
+++ b/event/epoch.go
@@ -19,10 +19,11 @@ const EpochTransitionEventType = EventType("epoch.transition")
 
 // EpochTransitionEvent is emitted when the chain crosses an epoch boundary
 type EpochTransitionEvent struct {
-	PreviousEpoch   uint64
-	NewEpoch        uint64
-	BoundarySlot    uint64
-	EpochNonce      []byte
+	PreviousEpoch uint64
+	NewEpoch      uint64
+	BoundarySlot  uint64
+	EpochNonce    []byte
+	// ProtocolVersion is the protocol major version active for the boundary.
 	ProtocolVersion uint
 	// SnapshotSlot is the slot at which snapshot should be taken (typically boundary - 1)
 	SnapshotSlot uint64

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1427,6 +1427,7 @@ func (ls *LedgerState) handleSlotTicks() {
 		ls.RLock()
 		currentEpoch := ls.currentEpoch
 		currentEra := ls.currentEra
+		currentPParams := ls.currentPParams
 		tipSlot := ls.currentTip.Point.Slot
 		ls.RUnlock()
 
@@ -1510,7 +1511,7 @@ func (ls *LedgerState) handleSlotTicks() {
 				NewEpoch:        tick.Epoch,
 				BoundarySlot:    tick.Slot,
 				EpochNonce:      nil,
-				ProtocolVersion: currentEra.Id,
+				ProtocolVersion: ls.protocolMajorForEvent(currentPParams, currentEra),
 				SnapshotSlot:    snapshotSlot,
 			}
 			ls.config.EventBus.Publish(
@@ -1588,6 +1589,26 @@ func (ls *LedgerState) emitNextEpochNonceReady(
 
 func (ls *LedgerState) resetNextEpochNonceReady() {
 	ls.nextNonceReadyEpoch.Store(0)
+}
+
+func (ls *LedgerState) protocolMajorForEvent(
+	pparams lcommon.ProtocolParameters,
+	era eras.EraDesc,
+) uint {
+	pv, err := GetProtocolVersion(pparams)
+	if err == nil {
+		return pv.Major
+	}
+	if ls.config.Logger != nil {
+		ls.config.Logger.Warn(
+			"could not extract protocol version for epoch event",
+			"error", err,
+			"pparams_type", fmt.Sprintf("%T", pparams),
+			"fallback_era_id", era.Id,
+			"component", "ledger",
+		)
+	}
+	return era.Id
 }
 
 // isNearTip returns true when the given slot is inside the current era's
@@ -3029,12 +3050,15 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 						snapshotSlot--
 					}
 					epochTransitionEvent := event.EpochTransitionEvent{
-						PreviousEpoch:   snapshotEpoch.EpochId,
-						NewEpoch:        newEpochId,
-						BoundarySlot:    rolloverResult.NewCurrentEpoch.StartSlot,
-						EpochNonce:      rolloverResult.NewCurrentEpoch.Nonce,
-						ProtocolVersion: rolloverResult.NewCurrentEra.Id,
-						SnapshotSlot:    snapshotSlot,
+						PreviousEpoch: snapshotEpoch.EpochId,
+						NewEpoch:      newEpochId,
+						BoundarySlot:  rolloverResult.NewCurrentEpoch.StartSlot,
+						EpochNonce:    rolloverResult.NewCurrentEpoch.Nonce,
+						ProtocolVersion: ls.protocolMajorForEvent(
+							rolloverResult.NewCurrentPParams,
+							rolloverResult.NewCurrentEra,
+						),
+						SnapshotSlot: snapshotSlot,
 					}
 					ls.config.EventBus.Publish(
 						event.EpochTransitionEventType,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Epoch transition events now report the active protocol major version instead of the era ID. This makes the event accurate for consumers that depend on the protocol version.

- Bug Fixes
  - Derive ProtocolVersion from current protocol parameters in both slot-tick and block-rollover paths; fallback to era ID with a warning if parsing fails.
  - Added a small helper to centralize version extraction and updated the event field comment for clarity.

<sup>Written for commit eabdfb55edca521222e46aa91ff37fef6c04bd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

