### PR TITLE
fix(governance): replay boundary side effects

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -360,7 +360,7 @@ rather than relied on).
 | `registration_drep` | `id`, `credential_tag`, `drep_credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; unique `(credential_tag, drep_credential, added_slot)`; index `certificate_id` | DRep registration certificate. `credential_tag` mirrors `drep.credential_tag` for the registered DRep. |
 | `deregistration_drep` | `id`, `credential_tag`, `drep_credential`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, drep_credential)`, `certificate_id`, `added_slot` | DRep deregistration certificate. |
 | `update_drep` | `id`, `credential_tag`, `credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, credential)`, `certificate_id`, `added_slot` | DRep update certificate. |
-| `governance_proposal` | `id`, `tx_hash`, `action_index`, `action_type`, `proposed_epoch`, `expires_epoch`, `parent_tx_hash`, `parent_action_idx`, `enacted_epoch`, `enacted_slot`, `ratified_epoch`, `ratified_slot`, `policy_hash`, `anchor_url`, `anchor_hash`, `deposit`, `return_address`, `gov_action_cbor`, `expired_epoch`, `expired_slot`, `added_slot`, `deleted_slot` | PK `id`; unique `(tx_hash, action_index)`; composite `(parent_tx_hash, parent_action_idx)` (`idx_gov_proposal_parent`); indexes action type, epochs, lifecycle slots, `added_slot`, `deleted_slot` | Governance action lifecycle. Votes join by `governance_vote.proposal_id`. `gov_action_cbor` stores the era-specific GovAction CBOR used for enactment; replay may rewrite ratified parameter-change actions at an era boundary, such as Conway to Dijkstra, so old databases should be rebuilt from chain data when this encoding changes. |
+| `governance_proposal` | `id`, `tx_hash`, `action_index`, `action_type`, `proposed_epoch`, `expires_epoch`, `parent_tx_hash`, `parent_action_idx`, `enacted_epoch`, `enacted_slot`, `ratified_epoch`, `ratified_slot`, `policy_hash`, `anchor_url`, `anchor_hash`, `deposit`, `return_address`, `gov_action_cbor`, `expired_epoch`, `expired_slot`, `added_slot`, `deleted_slot` | PK `id`; unique `(tx_hash, action_index)`; composite `(parent_tx_hash, parent_action_idx)` (`idx_gov_proposal_parent`); indexes action type, epochs, lifecycle slots, `added_slot`, `deleted_slot` | Governance action lifecycle. Votes join by `governance_vote.proposal_id`. `gov_action_cbor` stores the era-specific GovAction CBOR used for enactment; replay may rewrite ratified parameter-change actions at an era boundary, such as Conway to Dijkstra, so old databases should be rebuilt from chain data when this encoding changes. Same-boundary epoch replay reads proposals whose `enacted_epoch/enacted_slot` or `expired_epoch/expired_slot` already match the boundary to restore treasury/reward side effects after stake reward pot reset. |
 | `governance_vote` | `id`, `proposal_id`, `voter_type`, `voter_credential_tag`, `voter_credential`, `vote`, `anchor_url`, `anchor_hash`, `added_slot`, `vote_updated_slot`, `deleted_slot` | PK `id`; unique `(proposal_id, voter_type, voter_credential_tag, voter_credential)`; indexes proposal/voter/lifecycle slots | Vote on a governance proposal. `voter_type`: 0 committee, 1 DRep, 2 SPO. `voter_credential_tag`: 0 key hash, 1 script hash for committee/DRep voters; 0 for SPO key hashes. `vote`: 0 No, 1 Yes, 2 Abstain. |
 | `constitution` | `id`, `anchor_url`, `anchor_hash`, `policy_hash`, `added_slot`, `deleted_slot` | PK `id`; unique `added_slot`; index `deleted_slot` | Current or historical constitution references. |
 | `committee_member` | `id`, `cold_cred_hash`, `expires_epoch`, `added_slot`, `deleted_slot` | PK `id`; unique `cold_cred_hash`; indexes `added_slot`, `deleted_slot` | Snapshot-imported committee state. |
@@ -1193,6 +1193,31 @@ FROM governance_proposal
 WHERE expires_epoch >= $1
   AND enacted_epoch IS NULL
   AND expired_epoch IS NULL
+  AND deleted_slot IS NULL
+ORDER BY proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC;
+```
+
+Epoch-boundary replay uses exact epoch/slot lifecycle lookups:
+
+```sql
+-- GetEnactedGovernanceProposalsAt(epoch, slot)
+SELECT *
+FROM governance_proposal
+WHERE ratified_epoch IS NOT NULL
+  AND enacted_epoch = $1
+  AND enacted_slot = $2
+  AND deleted_slot IS NULL
+ORDER BY ratified_epoch ASC, ratified_slot ASC,
+  proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC;
+```
+
+```sql
+-- GetExpiredGovernanceProposalsAt(epoch, slot)
+SELECT *
+FROM governance_proposal
+WHERE expired_epoch = $1
+  AND expired_slot = $2
+  AND enacted_epoch IS NULL
   AND deleted_slot IS NULL
 ORDER BY proposed_epoch ASC, added_slot ASC, tx_hash ASC, action_index ASC;
 ```

--- a/database/governance.go
+++ b/database/governance.go
@@ -156,6 +156,29 @@ func (d *Database) GetExpiringGovernanceProposals(
 	return proposals, nil
 }
 
+// GetExpiredGovernanceProposalsAt returns proposals expired at the exact
+// epoch-boundary slot. Used by epoch replay to restore deposit-return effects.
+func (d *Database) GetExpiredGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn *Txn,
+) ([]*models.GovernanceProposal, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	proposals, err := d.metadata.GetExpiredGovernanceProposalsAt(
+		epoch, slot, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get boundary-expired governance proposals: %w",
+			err,
+		)
+	}
+	return proposals, nil
+}
+
 // GetRatifiedGovernanceProposals returns proposals ratified but not yet
 // enacted, ordered by (ratified_epoch, ratified_slot, id). Used at epoch
 // start for enactment.
@@ -170,6 +193,29 @@ func (d *Database) GetRatifiedGovernanceProposals(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get ratified governance proposals: %w", err,
+		)
+	}
+	return proposals, nil
+}
+
+// GetEnactedGovernanceProposalsAt returns proposals enacted at the exact
+// epoch-boundary slot. Used by epoch replay to restore enactment effects.
+func (d *Database) GetEnactedGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn *Txn,
+) ([]*models.GovernanceProposal, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	proposals, err := d.metadata.GetEnactedGovernanceProposalsAt(
+		epoch, slot, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get boundary-enacted governance proposals: %w",
+			err,
 		)
 	}
 	return proposals, nil

--- a/database/plugin/metadata/mysql/governance.go
+++ b/database/plugin/metadata/mysql/governance.go
@@ -92,6 +92,29 @@ func (d *MetadataStoreMysql) GetExpiringGovernanceProposals(
 	return proposals, nil
 }
 
+// GetExpiredGovernanceProposalsAt returns proposals that were expired at the
+// given epoch-boundary slot. Used at epoch replay to reapply deposit returns
+// after stake reward pot reset is replayed.
+func (d *MetadataStoreMysql) GetExpiredGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"expired_epoch = ? AND expired_slot = ? AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+		epoch,
+		slot,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
 // governanceProposalOrder is the stable row order used when iterating
 // active/expiring proposals at epoch boundaries. Consensus-critical:
 // the epoch tick enforces at-most-one ratification per purpose, so
@@ -119,6 +142,29 @@ func (d *MetadataStoreMysql) GetRatifiedGovernanceProposals(
 	}
 	if result := db.Where(
 		"ratified_epoch IS NOT NULL AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// GetEnactedGovernanceProposalsAt returns proposals that were enacted at the
+// given epoch-boundary slot. Used at epoch replay to reapply enactment side
+// effects after stake reward pot reset is replayed.
+func (d *MetadataStoreMysql) GetEnactedGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"ratified_epoch IS NOT NULL AND enacted_epoch = ? AND enacted_slot = ? AND deleted_slot IS NULL",
+		epoch,
+		slot,
 	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
 		return nil, result.Error
 	}

--- a/database/plugin/metadata/postgres/governance.go
+++ b/database/plugin/metadata/postgres/governance.go
@@ -92,6 +92,29 @@ func (d *MetadataStorePostgres) GetExpiringGovernanceProposals(
 	return proposals, nil
 }
 
+// GetExpiredGovernanceProposalsAt returns proposals that were expired at the
+// given epoch-boundary slot. Used at epoch replay to reapply deposit returns
+// after stake reward pot reset is replayed.
+func (d *MetadataStorePostgres) GetExpiredGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"expired_epoch = ? AND expired_slot = ? AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+		epoch,
+		slot,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
 // governanceProposalOrder is the stable row order used when iterating
 // active/expiring proposals at epoch boundaries. Consensus-critical:
 // the epoch tick enforces at-most-one ratification per purpose, so
@@ -119,6 +142,29 @@ func (d *MetadataStorePostgres) GetRatifiedGovernanceProposals(
 	}
 	if result := db.Where(
 		"ratified_epoch IS NOT NULL AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// GetEnactedGovernanceProposalsAt returns proposals that were enacted at the
+// given epoch-boundary slot. Used at epoch replay to reapply enactment side
+// effects after stake reward pot reset is replayed.
+func (d *MetadataStorePostgres) GetEnactedGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"ratified_epoch IS NOT NULL AND enacted_epoch = ? AND enacted_slot = ? AND deleted_slot IS NULL",
+		epoch,
+		slot,
 	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
 		return nil, result.Error
 	}

--- a/database/plugin/metadata/sqlite/governance.go
+++ b/database/plugin/metadata/sqlite/governance.go
@@ -153,6 +153,29 @@ func (d *MetadataStoreSqlite) GetExpiringGovernanceProposals(
 	return proposals, nil
 }
 
+// GetExpiredGovernanceProposalsAt returns proposals that were expired at the
+// given epoch-boundary slot. Used at epoch replay to reapply deposit returns
+// after stake reward pot reset is replayed.
+func (d *MetadataStoreSqlite) GetExpiredGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"expired_epoch = ? AND expired_slot = ? AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+		epoch,
+		slot,
+	).Order(governanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
 // governanceProposalOrder is the stable row order used when iterating
 // active/expiring proposals at epoch boundaries. Consensus-critical:
 // the epoch tick enforces at-most-one ratification per purpose, so
@@ -173,6 +196,29 @@ func (d *MetadataStoreSqlite) GetRatifiedGovernanceProposals(
 	}
 	if result := db.Where(
 		"ratified_epoch IS NOT NULL AND enacted_epoch IS NULL AND deleted_slot IS NULL",
+	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
+		return nil, result.Error
+	}
+	return proposals, nil
+}
+
+// GetEnactedGovernanceProposalsAt returns proposals that were enacted at the
+// given epoch-boundary slot. Used at epoch replay to reapply enactment side
+// effects after stake reward pot reset is replayed.
+func (d *MetadataStoreSqlite) GetEnactedGovernanceProposalsAt(
+	epoch uint64,
+	slot uint64,
+	txn types.Txn,
+) ([]*models.GovernanceProposal, error) {
+	var proposals []*models.GovernanceProposal
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	if result := db.Where(
+		"ratified_epoch IS NOT NULL AND enacted_epoch = ? AND enacted_slot = ? AND deleted_slot IS NULL",
+		epoch,
+		slot,
 	).Order(ratifiedGovernanceProposalOrder).Find(&proposals); result.Error != nil {
 		return nil, result.Error
 	}

--- a/database/plugin/metadata/sqlite/governance_test.go
+++ b/database/plugin/metadata/sqlite/governance_test.go
@@ -561,6 +561,77 @@ func TestGetActiveGovernanceProposals_DeterministicOrder(t *testing.T) {
 	assert.Equal(t, "https://c.example.com", got[2].AnchorURL)
 }
 
+func TestGetExpiredGovernanceProposalsAt(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	targetEpoch := uint64(110)
+	targetSlot := uint64(5000)
+	uint64Ptr := func(value uint64) *uint64 { return &value }
+	newProposal := func(
+		name string,
+		proposedEpoch uint64,
+		addedSlot uint64,
+		actionIndex uint32,
+	) models.GovernanceProposal {
+		return models.GovernanceProposal{
+			TxHash:        []byte(name),
+			ActionIndex:   actionIndex,
+			ActionType:    uint8(6),
+			ProposedEpoch: proposedEpoch,
+			ExpiresEpoch:  targetEpoch - 1,
+			ExpiredEpoch:  &targetEpoch,
+			ExpiredSlot:   &targetSlot,
+			AnchorURL:     name,
+			AnchorHash:    []byte("anchor_hash_1234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_1234567890123456789"),
+			AddedSlot:     addedSlot,
+		}
+	}
+
+	// Insert the matching rows in reverse order. The expected result exercises
+	// every tie-break in governanceProposalOrder.
+	matching := []models.GovernanceProposal{
+		newProposal("match-c", 101, 3000, 0),
+		newProposal("match-b", 100, 2000, 0),
+		newProposal("match-a", 100, 1000, 1),
+		newProposal("match-a", 100, 1000, 0),
+	}
+	for i := range matching {
+		require.NoError(t, store.SetGovernanceProposal(&matching[i], nil))
+	}
+
+	wrongEpoch := newProposal("wrong-expired-epoch", 90, 900, 0)
+	wrongEpoch.ExpiredEpoch = uint64Ptr(targetEpoch - 1)
+	wrongSlot := newProposal("wrong-expired-slot", 90, 800, 0)
+	wrongSlot.ExpiredSlot = uint64Ptr(targetSlot - 1)
+	enacted := newProposal("already-enacted", 90, 700, 0)
+	enacted.EnactedEpoch = uint64Ptr(targetEpoch)
+	deleted := newProposal("soft-deleted", 90, 600, 0)
+	deleted.DeletedSlot = uint64Ptr(targetSlot)
+	for _, proposal := range []*models.GovernanceProposal{
+		&wrongEpoch,
+		&wrongSlot,
+		&enacted,
+		&deleted,
+	} {
+		require.NoError(t, store.SetGovernanceProposal(proposal, nil))
+	}
+
+	got, err := store.GetExpiredGovernanceProposalsAt(
+		targetEpoch,
+		targetSlot,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+	assert.Equal(t, uint32(0), got[0].ActionIndex)
+	assert.Equal(t, uint32(1), got[1].ActionIndex)
+	assert.Equal(t, "match-b", got[2].AnchorURL)
+	assert.Equal(t, "match-c", got[3].AnchorURL)
+}
+
 func TestGetRatifiedGovernanceProposals(t *testing.T) {
 	t.Parallel()
 	store := setupTestStore(t)
@@ -630,6 +701,73 @@ func TestGetRatifiedGovernanceProposals(t *testing.T) {
 		"https://ratifiedA.example.com",
 		ratified[0].AnchorURL,
 	)
+}
+
+func TestGetEnactedGovernanceProposalsAt(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	targetEpoch := uint64(110)
+	targetSlot := uint64(5000)
+	uint64Ptr := func(value uint64) *uint64 { return &value }
+	newProposal := func(
+		name string,
+		ratifiedEpoch uint64,
+		ratifiedSlot uint64,
+	) models.GovernanceProposal {
+		return models.GovernanceProposal{
+			TxHash:        []byte(name),
+			ActionType:    uint8(6),
+			ProposedEpoch: 100,
+			ExpiresEpoch:  120,
+			RatifiedEpoch: &ratifiedEpoch,
+			RatifiedSlot:  &ratifiedSlot,
+			EnactedEpoch:  &targetEpoch,
+			EnactedSlot:   &targetSlot,
+			AnchorURL:     name,
+			AnchorHash:    []byte("anchor_hash_1234567890123456789012"),
+			Deposit:       500,
+			ReturnAddress: []byte("return_addr_1234567890123456789"),
+			AddedSlot:     1000,
+		}
+	}
+
+	// Ratification time is the leading replay-order key, independent of
+	// insertion order.
+	matching := []models.GovernanceProposal{
+		newProposal("ratified-later", 102, 4000),
+		newProposal("ratified-earlier", 101, 3000),
+	}
+	for i := range matching {
+		require.NoError(t, store.SetGovernanceProposal(&matching[i], nil))
+	}
+
+	wrongEpoch := newProposal("wrong-enacted-epoch", 100, 2000)
+	wrongEpoch.EnactedEpoch = uint64Ptr(targetEpoch - 1)
+	wrongSlot := newProposal("wrong-enacted-slot", 100, 1900)
+	wrongSlot.EnactedSlot = uint64Ptr(targetSlot - 1)
+	unratified := newProposal("unratified", 100, 1800)
+	unratified.RatifiedEpoch = nil
+	deleted := newProposal("soft-deleted", 100, 1700)
+	deleted.DeletedSlot = uint64Ptr(targetSlot)
+	for _, proposal := range []*models.GovernanceProposal{
+		&wrongEpoch,
+		&wrongSlot,
+		&unratified,
+		&deleted,
+	} {
+		require.NoError(t, store.SetGovernanceProposal(proposal, nil))
+	}
+
+	got, err := store.GetEnactedGovernanceProposalsAt(
+		targetEpoch,
+		targetSlot,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "ratified-earlier", got[0].AnchorURL)
+	assert.Equal(t, "ratified-later", got[1].AnchorURL)
 }
 
 func TestGetLastEnactedGovernanceProposal(t *testing.T) {

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1184,12 +1184,30 @@ type MetadataStore interface {
 		types.Txn,
 	) ([]*models.GovernanceProposal, error)
 
+	// GetEnactedGovernanceProposalsAt returns proposals that were enacted at
+	// the given epoch-boundary slot. Used to replay enactment side effects when
+	// stake reward pot reset is reapplied after a boundary commit crash.
+	GetEnactedGovernanceProposalsAt(
+		epoch uint64,
+		slot uint64,
+		txn types.Txn,
+	) ([]*models.GovernanceProposal, error)
+
 	// GetExpiringGovernanceProposals returns proposals whose
 	// `expires_epoch` is strictly less than the given epoch and that
 	// have not yet been enacted, expired, or soft-deleted. Used at
 	// epoch boundaries to mark expired proposals and return deposits.
 	GetExpiringGovernanceProposals(
 		epoch uint64,
+		txn types.Txn,
+	) ([]*models.GovernanceProposal, error)
+
+	// GetExpiredGovernanceProposalsAt returns proposals that were expired at
+	// the given epoch-boundary slot. Used to replay deposit-return side effects
+	// when stake reward pot reset is reapplied after a boundary commit crash.
+	GetExpiredGovernanceProposalsAt(
+		epoch uint64,
+		slot uint64,
 		txn types.Txn,
 	) ([]*models.GovernanceProposal, error)
 

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -127,11 +127,23 @@ func ProcessEpoch(
 		TreasuryWithdrawalRemaining:    treasuryWithdrawalRemaining,
 		TreasuryWithdrawalRemainingSet: true,
 	}
+	// A boundary transaction can commit before the separate tip advance. If
+	// restart replays that boundary, stake-reward application first rewrites
+	// the absolute network-state pot row, so proposals already marked enacted
+	// at this exact boundary must replay their treasury side effects.
+	replayedEnacted, err := in.DB.GetEnactedGovernanceProposalsAt(
+		in.NewEpoch,
+		in.BoundarySlot,
+		in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get boundary-enacted proposals: %w", err)
+	}
 	ratified, err := in.DB.GetRatifiedGovernanceProposals(in.Txn)
 	if err != nil {
 		return nil, fmt.Errorf("get ratified proposals: %w", err)
 	}
-	for _, proposal := range ratified {
+	enactProposal := func(proposal *models.GovernanceProposal, replay bool) error {
 		enactCtx.PParams = out.UpdatedPParams
 		res, err := EnactProposal(enactCtx, proposal)
 		if err != nil {
@@ -140,14 +152,16 @@ func ProcessEpoch(
 			// continuing would leave the proposal unmarked-enacted,
 			// so the next tick would re-apply it. Returning the
 			// error lets the surrounding DB transaction roll back.
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"enact proposal %s#%d: %w",
 				shortHash(proposal.TxHash),
 				proposal.ActionIndex,
 				err,
 			)
 		}
-		out.EnactedCount++
+		if !replay {
+			out.EnactedCount++
+		}
 		if res.PParamsChanged {
 			out.UpdatedPParams = res.UpdatedPParams
 			out.PParamsChanged = true
@@ -155,6 +169,17 @@ func ProcessEpoch(
 				lcommon.GovActionTypeHardForkInitiation {
 				out.HardForkInitiated = true
 			}
+		}
+		return nil
+	}
+	for _, proposal := range replayedEnacted {
+		if err := enactProposal(proposal, true); err != nil {
+			return nil, err
+		}
+	}
+	for _, proposal := range ratified {
+		if err := enactProposal(proposal, false); err != nil {
+			return nil, err
 		}
 	}
 
@@ -170,28 +195,52 @@ func ProcessEpoch(
 	if err != nil {
 		return nil, fmt.Errorf("get expiring proposals: %w", err)
 	}
-	for _, p := range expired {
+	// Same replay window as enacted proposals: expired deposits that were
+	// routed to treasury must be restored after the reward pot reset.
+	replayedExpired, err := in.DB.GetExpiredGovernanceProposalsAt(
+		in.NewEpoch,
+		in.BoundarySlot,
+		in.Txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get boundary-expired proposals: %w", err)
+	}
+	expireProposal := func(p *models.GovernanceProposal, replay bool) error {
 		if err := refundProposalDeposit(
 			in.DB,
 			in.Txn,
 			p,
 			in.BoundarySlot,
 		); err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"refund expired proposal deposit %s#%d: %w",
 				shortHash(p.TxHash),
 				p.ActionIndex,
 				err,
 			)
 		}
+		if replay {
+			return nil
+		}
 		expiredEpoch := in.NewEpoch
 		expiredSlot := in.BoundarySlot
 		p.ExpiredEpoch = &expiredEpoch
 		p.ExpiredSlot = &expiredSlot
 		if err := in.DB.SetGovernanceProposal(p, in.Txn); err != nil {
-			return nil, fmt.Errorf("mark expired: %w", err)
+			return fmt.Errorf("mark expired: %w", err)
 		}
 		out.ExpiredCount++
+		return nil
+	}
+	for _, p := range replayedExpired {
+		if err := expireProposal(p, true); err != nil {
+			return nil, err
+		}
+	}
+	for _, p := range expired {
+		if err := expireProposal(p, false); err != nil {
+			return nil, err
+		}
 	}
 
 	// --- ORPHAN REMOVAL --------------------------------------------------
@@ -204,9 +253,14 @@ func ProcessEpoch(
 	// over the dependency graph seeded with every enacted and expired
 	// proposal from this tick.
 	orphanSeeds := make(
-		[]*models.GovernanceProposal, 0, len(ratified)+len(expired),
+		[]*models.GovernanceProposal,
+		0,
+		len(replayedEnacted)+len(ratified)+
+			len(replayedExpired)+len(expired),
 	)
+	orphanSeeds = append(orphanSeeds, replayedEnacted...)
 	orphanSeeds = append(orphanSeeds, ratified...)
+	orphanSeeds = append(orphanSeeds, replayedExpired...)
 	orphanSeeds = append(orphanSeeds, expired...)
 	orphanCount, err := removeOrphanedProposals(
 		in.DB, in.Txn, orphanSeeds, in.NewEpoch, in.BoundarySlot, in.Logger,

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -167,6 +167,70 @@ func TestProcessEpochExpiresProposalAndRefundsDeposit(t *testing.T) {
 	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
 }
 
+func TestProcessEpochReplaysBoundaryExpiredProposalAfterStakeRewardReset(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 0x20)
+	rewardAddrBytes := buildRewardAddr(t, stakeCred)
+	txHash := testBytes(32, 0x21)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeInfo),
+		ProposedEpoch: 1,
+		ExpiresEpoch:  4,
+		AnchorURL:     "https://example.invalid/replay-expired",
+		AnchorHash:    testBytes(32, 0x22),
+		Deposit:       25,
+		ReturnAddress: rewardAddrBytes,
+		AddedSlot:     100,
+	}, nil))
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	runEpoch := func() *EpochOutput {
+		t.Helper()
+		txn := db.MetadataTxn(true)
+		defer txn.Release()
+		out, err := ProcessEpoch(&EpochInput{
+			DB:           db,
+			Txn:          txn,
+			PrevEpoch:    4,
+			NewEpoch:     5,
+			BoundarySlot: 500,
+			PParams:      conwayPParamsFixture(10),
+			UpdateFn: func(
+				pparams lcommon.ProtocolParameters,
+				_ any,
+			) (lcommon.ProtocolParameters, error) {
+				return pparams, nil
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit())
+		return out
+	}
+
+	out := runEpoch()
+	assert.Equal(t, 1, out.ExpiredCount)
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(125), uint64(state.Treasury))
+
+	// Crash replay re-applies stake rewards first, which resets the same
+	// boundary NetworkState row before governance is run again.
+	require.NoError(t, store.SetNetworkState(100, 20, 500, nil))
+
+	out = runEpoch()
+	assert.Equal(t, 0, out.ExpiredCount)
+	state, err = store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(125), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
+}
+
 func TestProcessEpochReturnsMissingRewardAccountRefundToTreasury(
 	t *testing.T,
 ) {
@@ -234,6 +298,101 @@ func TestProcessEpochReturnsMissingRewardAccountRefundToTreasury(
 	require.NotNil(t, proposal.ExpiredSlot)
 	assert.Equal(t, uint64(5), *proposal.ExpiredEpoch)
 	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
+}
+
+func TestProcessEpochReplaysBoundaryTreasuryWithdrawalAfterStakeRewardReset(
+	t *testing.T,
+) {
+	db, store := newTallyTestDB(t)
+	stakeCred := testBytes(28, 0x30)
+	rewardAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCred,
+	)
+	require.NoError(t, err)
+	rewardAddrBytes, err := rewardAddr.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: stakeCred,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}).Error)
+	withdrawalCbor, err := cbor.Encode(
+		&lcommon.TreasuryWithdrawalGovAction{
+			Type:        2,
+			Withdrawals: map[*lcommon.Address]uint64{&rewardAddr: 7},
+		},
+	)
+	require.NoError(t, err)
+	ratifiedEpoch := uint64(4)
+	ratifiedSlot := uint64(400)
+	txHash := testBytes(32, 0x31)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		ProposedEpoch: 3,
+		ExpiresEpoch:  10,
+		RatifiedEpoch: &ratifiedEpoch,
+		RatifiedSlot:  &ratifiedSlot,
+		AnchorURL:     "https://example.invalid/replay-withdrawal",
+		AnchorHash:    testBytes(32, 0x32),
+		Deposit:       0,
+		ReturnAddress: rewardAddrBytes,
+		GovActionCbor: withdrawalCbor,
+		AddedSlot:     100,
+	}, nil))
+	require.NoError(t, store.SetNetworkState(100, 20, 1, nil))
+
+	runEpoch := func() *EpochOutput {
+		t.Helper()
+		txn := db.MetadataTxn(true)
+		defer txn.Release()
+		out, err := ProcessEpoch(&EpochInput{
+			DB:           db,
+			Txn:          txn,
+			PrevEpoch:    4,
+			NewEpoch:     5,
+			BoundarySlot: 500,
+			PParams:      conwayPParamsFixture(10),
+			UpdateFn: func(
+				pparams lcommon.ProtocolParameters,
+				_ any,
+			) (lcommon.ProtocolParameters, error) {
+				return pparams, nil
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit())
+		return out
+	}
+
+	out := runEpoch()
+	assert.Equal(t, 1, out.EnactedCount)
+	account, err := store.GetAccountByCredential(0, stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(7), uint64(account.Reward))
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(93), uint64(state.Treasury))
+
+	require.NoError(t, store.SetNetworkState(100, 20, 500, nil))
+
+	out = runEpoch()
+	assert.Equal(t, 0, out.EnactedCount)
+	account, err = store.GetAccountByCredential(0, stakeCred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(7), uint64(account.Reward))
+	state, err = store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(93), uint64(state.Treasury))
+	assert.Equal(t, uint64(20), uint64(state.Reserves))
 }
 
 func TestProcessEpochUnclaimedDepositDoesNotIncreaseWithdrawalCapacity(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes epoch-boundary replay so treasury withdrawals and expired deposit refunds are re-applied after a restart that replays the boundary and stake-reward pot reset. Adds exact epoch/slot queries and deterministic replay to avoid double counting. Aligns with Linear issue 1959 (governance replay).

- **Bug Fixes**
  - Added `GetEnactedGovernanceProposalsAt` and `GetExpiredGovernanceProposalsAt` to `database` with MySQL/Postgres/SQLite implementations; exact epoch/slot filters and stable ordering.
  - Exposed these methods on the `MetadataStore` interface.
  - Updated `ledger/governance` `ProcessEpoch` to replay boundary-enacted withdrawals and boundary-expired deposit refunds before normal processing; counters don’t increment on replay; replayed proposals seed orphan cleanup.
  - Added tests for boundary-enacted withdrawals, boundary-expired refunds, and ordering; updated `DATABASE.md` with SQL examples and lifecycle notes.

<sup>Written for commit 753713cdd5b16d2adc46d82075be3388d24c180b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

