### PR TITLE
feat(database): add pool import wrapper

### DIFF
--- a/database/pool.go
+++ b/database/pool.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -78,15 +79,22 @@ func (d *Database) GetPool(
 	return ret, nil
 }
 
-// ImportPool upserts a pool and creates a registration record. When txn is nil
-// a write transaction is opened, committed on success and rolled back on error
-// via Txn.Do.
+// ImportPool upserts a pool and creates a registration record. A supplied txn
+// must be writable and include a metadata handle. When txn is nil a write
+// transaction is opened, committed on success and rolled back on error via
+// Txn.Do.
 func (d *Database) ImportPool(
 	txn *Txn,
 	pool *models.Pool,
 	reg *models.PoolRegistration,
 ) error {
 	if txn != nil {
+		if txn.Metadata() == nil {
+			return fmt.Errorf("import pool: %w", types.ErrNilTxn)
+		}
+		if !txn.IsReadWrite() {
+			return fmt.Errorf("import pool: %w", types.ErrTxnWrongType)
+		}
 		return d.metadata.ImportPool(pool, reg, txn.Metadata())
 	}
 	return d.MetadataTxn(true).Do(func(t *Txn) error {

--- a/database/pool.go
+++ b/database/pool.go
@@ -78,6 +78,22 @@ func (d *Database) GetPool(
 	return ret, nil
 }
 
+// ImportPool upserts a pool and creates a registration record. When txn is nil
+// a write transaction is opened, committed on success and rolled back on error
+// via Txn.Do.
+func (d *Database) ImportPool(
+	txn *Txn,
+	pool *models.Pool,
+	reg *models.PoolRegistration,
+) error {
+	if txn != nil {
+		return d.metadata.ImportPool(pool, reg, txn.Metadata())
+	}
+	return d.MetadataTxn(true).Do(func(t *Txn) error {
+		return d.metadata.ImportPool(pool, reg, t.Metadata())
+	})
+}
+
 // UpdatePoolOpCertSequence records an observed op-cert sequence for a pool
 // and updates the pool's denormalized maximum.
 func (d *Database) UpdatePoolOpCertSequence(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add ImportPool wrapper to upsert a pool and create a registration record, using a provided read-write transaction or auto-opening one. Validates transaction metadata and type, returning `types.ErrNilTxn`/`types.ErrTxnWrongType`, and ensures consistent commit/rollback.

<sup>Written for commit 5408130e0bcd7290e8df17f72332a6979ee10fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing a pool and creating its registration record.
  * Imports can run automatically with a writable metadata transaction when one isn’t provided.
  * Added validation to reject missing or read-only transaction metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->