### PR TITLE
fix(node): Wait for chainsync stall recycler during node shutdown

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -689,6 +689,9 @@ Graceful shutdown proceeds in phases:
 
 ```
 Phase 1: Stop accepting new work
+  Chainsync stall recycler (WaitGroup-tracked; shutdown blocks until
+  the recycler goroutine exits, so it cannot still be running once
+  ledger/database teardown begins),
   Midnight indexer (unsubscribes from BlockEventType),
   Block forger, leader election, chain selector,
   peer governor, snapshot manager, UTxO RPC,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -672,7 +672,7 @@ When `Node.Run()` is called, components are initialized in this order:
 14. ConnectionManager creation and event wiring
 15. PeerGovernor creation/start (topology + churn + ledger peers)
 16. ConnectionManager listener start
-17. Stalled client recycler (background goroutine)
+17. Chainsync stall recycler (background goroutine)
 18. UTxO RPC server (if API storage mode and port configured)
 19. Bark C2/archive server (if port configured)
 20. Midnight gRPC server (if API storage mode and midnight port configured)

--- a/node.go
+++ b/node.go
@@ -87,6 +87,7 @@ type Node struct {
 	cancel                           context.CancelFunc
 	shutdownOnce                     sync.Once
 	shutdownErr                      error
+	chainsyncStallRecyclerWG         sync.WaitGroup
 	chainsyncIngressEligibilityMu    sync.RWMutex
 	chainsyncIngressEligibilityCache map[ouroboros.ConnectionId]bool
 }
@@ -995,63 +996,19 @@ func (n *Node) Run(ctx context.Context) error {
 	stallRecoveryGrace := max(chainsyncCfg.StallTimeout, 30*time.Second)
 	stallRecycleCooldown := max(2*chainsyncCfg.StallTimeout, 2*time.Minute)
 	//nolint:gosec // G118: cancel func stored in started slice.
-	recyclerCtx, recyclerCancel := context.WithCancel(n.ctx)
-	started = append(started, recyclerCancel)
-	go func(interval, grace, cooldown time.Duration) {
-		for {
-			if recyclerCtx.Err() != nil {
-				return
-			}
-			if !n.runStallCheckerLoop(func() {
-				ticker := time.NewTicker(interval)
-				defer ticker.Stop()
-				recycleAt := make(map[string]time.Time)
-				lastRecycled := make(map[string]time.Time)
-				lastProgressSlot := n.ledgerState.Tip().Point.Slot
-				lastProgressAt := time.Now()
-				plateauRecoveryThreshold := plateauThreshold(
-					chainsyncCfg.StallTimeout,
-				)
-				for {
-					select {
-					case <-recyclerCtx.Done():
-						return
-					case <-ticker.C:
-						n.runStallCheckerTick(func() {
-							now := time.Now()
-							localTip := n.ledgerState.Tip()
-							localTipSlot := localTip.Point.Slot
-							if n.chainSelector != nil {
-								n.chainSelector.SetLocalTip(localTip)
-								if k := n.ledgerState.SecurityParam(); k > 0 {
-									n.chainSelector.SetSecurityParam(uint64(k)) //nolint:gosec
-								}
-							}
-							n.processChainsyncRecyclerTick(
-								now,
-								localTipSlot,
-								chainsyncCfg,
-								recycleAt,
-								lastRecycled,
-								&lastProgressSlot,
-								&lastProgressAt,
-								plateauRecoveryThreshold,
-								grace,
-								cooldown,
-							)
-						})
-					}
-				}
-			}) {
-				return
-			}
-			select {
-			case <-recyclerCtx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-		}
-	}(stallCheckInterval, stallRecoveryGrace, stallRecycleCooldown)
+	recyclerCancel := n.startChainsyncStallRecycler(
+		n.ctx,
+		chainsyncCfg,
+		stallCheckInterval,
+		stallRecoveryGrace,
+		stallRecycleCooldown,
+	)
+	// On startup failure or panic, cancel the recycler and wait for it before
+	// unwinding later components that the recycler can still touch.
+	started = append(started, func() {
+		recyclerCancel()
+		n.chainsyncStallRecyclerWG.Wait()
+	})
 	// Configure UTxO RPC (only in API mode with a non-zero port)
 	if n.config.storageMode.IsAPI() && n.config.utxorpcPort > 0 {
 		n.utxorpc = utxorpc.NewUtxorpc(

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -15,6 +15,7 @@
 package dingo
 
 import (
+	"context"
 	"runtime/debug"
 	"time"
 
@@ -133,6 +134,112 @@ func isLedgerApplicationBacklog(
 	}
 	applyBacklog := primaryChainTipSlot - appliedTipSlot
 	return applyBacklog >= headerGap
+}
+
+func (n *Node) startChainsyncStallRecycler(
+	ctx context.Context,
+	chainsyncCfg chainsync.Config,
+	interval time.Duration,
+	grace time.Duration,
+	cooldown time.Duration,
+) context.CancelFunc {
+	recyclerCtx, recyclerCancel := context.WithCancel(ctx)
+	// Track the recycler as a node-owned background worker so shutdown can
+	// wait for it before closing the dependencies it reads or publishes to.
+	n.chainsyncStallRecyclerWG.Add(1)
+	go func() {
+		// Mark the worker complete no matter whether it exits by cancellation
+		// or after a recovered panic stops the outer loop.
+		defer n.chainsyncStallRecyclerWG.Done()
+		n.runChainsyncStallRecycler(
+			recyclerCtx,
+			chainsyncCfg,
+			interval,
+			grace,
+			cooldown,
+		)
+	}()
+	return recyclerCancel
+}
+
+func (n *Node) runChainsyncStallRecycler(
+	ctx context.Context,
+	chainsyncCfg chainsync.Config,
+	interval time.Duration,
+	grace time.Duration,
+	cooldown time.Duration,
+) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		// Keep the existing panic-recovery behavior: a panic in the loop is
+		// logged and the recycler restarts unless shutdown was requested.
+		if !n.runStallCheckerLoop(func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			recycleAt := make(map[string]time.Time)
+			lastRecycled := make(map[string]time.Time)
+			lastProgressSlot := n.ledgerState.Tip().Point.Slot
+			lastProgressAt := time.Now()
+			plateauRecoveryThreshold := plateauThreshold(
+				chainsyncCfg.StallTimeout,
+			)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					n.runStallCheckerTick(func() {
+						now := time.Now()
+						localTip := n.ledgerState.Tip()
+						localTipSlot := localTip.Point.Slot
+						if n.chainSelector != nil {
+							n.chainSelector.SetLocalTip(localTip)
+							if k := n.ledgerState.SecurityParam(); k > 0 {
+								n.chainSelector.SetSecurityParam(uint64(k)) //nolint:gosec
+							}
+						}
+						n.processChainsyncRecyclerTick(
+							now,
+							localTipSlot,
+							chainsyncCfg,
+							recycleAt,
+							lastRecycled,
+							&lastProgressSlot,
+							&lastProgressAt,
+							plateauRecoveryThreshold,
+							grace,
+							cooldown,
+						)
+					})
+				}
+			}
+		}) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (n *Node) waitChainsyncStallRecycler(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n.chainsyncStallRecyclerWG.Wait()
+	}()
+	// WaitGroup.Wait cannot be selected on directly, so bridge completion to a
+	// channel and still honor the node's bounded shutdown context.
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (n *Node) processChainsyncRecyclerTick(

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -226,20 +226,10 @@ func (n *Node) runChainsyncStallRecycler(
 	}
 }
 
-func (n *Node) waitChainsyncStallRecycler(ctx context.Context) error {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		n.chainsyncStallRecyclerWG.Wait()
-	}()
-	// WaitGroup.Wait cannot be selected on directly, so bridge completion to a
-	// channel and still honor the node's bounded shutdown context.
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+func (n *Node) waitChainsyncStallRecycler() {
+	// This wait is intentionally not bounded by the shutdown timeout: advancing
+	// while the recycler is still active can race dependency teardown.
+	n.chainsyncStallRecyclerWG.Wait()
 }
 
 func (n *Node) processChainsyncRecyclerTick(

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -101,12 +101,7 @@ func (n *Node) shutdown() error {
 
 	// n.cancel() above asks the stall recycler to stop; wait here so it cannot
 	// race later shutdown phases that close connection, ledger, or DB state.
-	if waitErr := n.waitChainsyncStallRecycler(ctx); waitErr != nil {
-		err = errors.Join(
-			err,
-			fmt.Errorf("chainsync stall recycler shutdown: %w", waitErr),
-		)
-	}
+	n.waitChainsyncStallRecycler()
 
 	// Stop block forger first to prevent new blocks
 	if n.blockForger != nil {

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -99,6 +99,15 @@ func (n *Node) shutdown() error {
 	// Phase 1: Stop accepting new work
 	n.config.logger.Info("shutdown phase 1: stopping new work")
 
+	// n.cancel() above asks the stall recycler to stop; wait here so it cannot
+	// race later shutdown phases that close connection, ledger, or DB state.
+	if waitErr := n.waitChainsyncStallRecycler(ctx); waitErr != nil {
+		err = errors.Join(
+			err,
+			fmt.Errorf("chainsync stall recycler shutdown: %w", waitErr),
+		)
+	}
+
 	// Stop block forger first to prevent new blocks
 	if n.blockForger != nil {
 		n.blockForger.Stop()

--- a/node_test.go
+++ b/node_test.go
@@ -63,6 +63,36 @@ func (m nodeTestSecurityParamLedger) SecurityParam() int {
 	return m.securityParam
 }
 
+type nodeTestLogSignalHandler struct {
+	message string
+	seen    chan struct{}
+}
+
+func (h nodeTestLogSignalHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h nodeTestLogSignalHandler) Handle(
+	_ context.Context,
+	record slog.Record,
+) error {
+	if record.Message == h.message {
+		select {
+		case h.seen <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (h nodeTestLogSignalHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h nodeTestLogSignalHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
 func nodeTestHashBytes(seed string) []byte {
 	sum := sha256.Sum256([]byte(seed))
 	return append([]byte(nil), sum[:]...)
@@ -1007,6 +1037,95 @@ func TestRunStallCheckerLoopRecoversAndSupportsRestart(t *testing.T) {
 	})
 
 	assert.Equal(t, int32(2), attempts.Load())
+}
+
+// TestChainsyncStallRecyclerExitsOnCancel verifies that the recycler goroutine
+// observes cancellation and releases the node lifecycle wait group.
+func TestChainsyncStallRecyclerExitsOnCancel(t *testing.T) {
+	// Build the minimal ledger-backed node state needed for recycler startup.
+	// Use a long tick interval so the test only exercises cancellation.
+	ledgerState, _, _, _ := newNodeTestDivergedLedger(t)
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		ledgerState: ledgerState,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	recyclerCancel := n.startChainsyncStallRecycler(
+		ctx,
+		chainsync.Config{StallTimeout: time.Second},
+		time.Hour,
+		time.Second,
+		time.Second,
+	)
+
+	// Cancel both the recycler child context and parent context; either path
+	// should cause the recycler loop to return.
+	recyclerCancel()
+	cancel()
+
+	// Convert the wait group completion into a channel so the assertion can
+	// use the test timeout helper instead of sleeping.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n.chainsyncStallRecyclerWG.Wait()
+	}()
+	testutil.RequireReceive(
+		t,
+		done,
+		time.Second,
+		"chainsync stall recycler exit",
+	)
+}
+
+// TestStopWaitsForChainsyncStallRecycler verifies shutdown blocks while the
+// recycler is still tracked as running and continues once it exits.
+func TestStopWaitsForChainsyncStallRecycler(t *testing.T) {
+	// Signal when shutdown reaches phase 1 so the test can assert ordering
+	// without relying on a sleep.
+	phaseStarted := make(chan struct{}, 1)
+	n := &Node{
+		config: Config{
+			logger: slog.New(nodeTestLogSignalHandler{
+				message: "shutdown phase 1: stopping new work",
+				seen:    phaseStarted,
+			}),
+			shutdownTimeout: time.Second,
+		},
+	}
+	// Simulate an in-flight recycler goroutine by incrementing its lifecycle
+	// wait group without starting the actual recycler loop.
+	n.chainsyncStallRecyclerWG.Add(1)
+
+	// Start shutdown in the background; it should block on the recycler wait
+	// group before any later dependency teardown can complete.
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- n.Stop()
+	}()
+
+	// Once phase 1 starts, Stop must still be waiting because the recycler
+	// wait group has not been released yet.
+	testutil.RequireReceive(
+		t,
+		phaseStarted,
+		time.Second,
+		"shutdown phase 1 start",
+	)
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned before recycler exited: %v", err)
+	default:
+	}
+
+	// Release the simulated recycler and verify shutdown can now finish.
+	n.chainsyncStallRecyclerWG.Done()
+	require.NoError(
+		t,
+		testutil.RequireReceive(t, stopDone, time.Second, "node Stop"),
+	)
 }
 
 func TestStopReturnsSameShutdownErrorAfterFirstCall(t *testing.T) {


### PR DESCRIPTION
1. Added lifecycle tracking for the chainsync stall recycler so node shutdown waits for the goroutine to exit before closing shared dependencies.
2. Added `chainsyncStallRecyclerWG` to `Node` to track the recycler goroutine lifecycle.
3. Added `startChainsyncStallRecycler` to start the recycler with wait group tracking.
4. Added `runChainsyncStallRecycler` to hold the existing recycler loop outside `node.go`.
5. Added `waitChainsyncStallRecycler` so shutdown can wait with timeout/cancellation support.
6. Updated `Run()` startup cleanup to cancel and wait for the recycler on startup failure or panic.
7. Added `TestChainsyncStallRecyclerExitsOnCancel` to prove cancellation exits the recycler.
8. Added `TestStopWaitsForChainsyncStallRecycler` to prove node shutdown waits for recycler completion.
9. Verified the change with g`o test -run 'Test(ChainsyncStallRecyclerExitsOnCancel|StopWaitsForChainsyncStallRecycler|RunStallChecker)' .`

**Note:**
Before making this change, shutdown canceled the stall recycler but immediately continued closing shared dependencies, so the recycler could theoretically still be running during teardown. After making the changes, shutdown cancels the recycler and waits for its wait group to finish before closing connection, ledger, database, and related node resources.

Closes #2272 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make node shutdown wait for the chainsync stall recycler to exit to prevent races with connection, ledger, and DB teardown (fixes #2272).

- **Bug Fixes**
  - Track the recycler with a WaitGroup and block shutdown until it exits after cancellation.
  - On startup failure or panic, cancel and wait for the recycler before unwinding later components.

- **Refactors**
  - Moved the recycler loop to `node_chainsync_recycler.go` with `startChainsyncStallRecycler`, `runChainsyncStallRecycler`, and `waitChainsyncStallRecycler`.
  - Updated shutdown ordering in `ARCHITECTURE.md` and added tests for recycler cancellation and shutdown ordering.

<sup>Written for commit ee3ae0dfeeec05bfc8eecc61d9e4830530989025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability by ensuring background chain synchronization monitoring stops before ledger and database teardown begins.
  * Prevented shutdown races involving shared connections and storage.
  * Ensured cancellation consistently stops background monitoring during node startup failures and normal shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->