### PR TITLE
test(database): cover import pool transaction validation

### DIFF
--- a/database/pool_test.go
+++ b/database/pool_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportPoolRejectsTransactionWithoutMetadataWriteHandle(t *testing.T) {
+	db, err := New(&Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	newPool := func() (*models.Pool, *models.PoolRegistration) {
+		poolKeyHash := bytes.Repeat([]byte{0x42}, 28)
+		return &models.Pool{PoolKeyHash: poolKeyHash},
+			&models.PoolRegistration{
+				PoolKeyHash: poolKeyHash,
+				AddedSlot:   1,
+			}
+	}
+
+	t.Run("blob-only transaction", func(t *testing.T) {
+		txn := db.BlobTxn(true)
+		t.Cleanup(func() {
+			require.NoError(t, txn.Rollback())
+		})
+		pool, reg := newPool()
+
+		err := db.ImportPool(txn, pool, reg)
+
+		require.ErrorIs(t, err, types.ErrNilTxn)
+	})
+
+	t.Run("read-only metadata transaction", func(t *testing.T) {
+		txn := db.MetadataTxn(false)
+		t.Cleanup(func() {
+			require.NoError(t, txn.Rollback())
+		})
+		pool, reg := newPool()
+
+		err := db.ImportPool(txn, pool, reg)
+
+		require.ErrorIs(t, err, types.ErrTxnWrongType)
+	})
+}


### PR DESCRIPTION
## Summary

- cover blob-only transactions passed to `Database.ImportPool`
- cover read-only metadata transactions passed to `Database.ImportPool`
- verify both invalid transaction shapes return the reviewed typed errors

Follow-up to #2833. Part of #1959.

## Tests

- `go test -race ./database -run TestImportPoolRejectsTransactionWithoutMetadataWriteHandle`
- `go test ./internal/test/conformance/`

## Documentation

- `DATABASE.md` and `ARCHITECTURE.md` checked; test-only change, no updates required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `Database.ImportPool` to ensure invalid transactions are rejected. Blob-only transactions return `types.ErrNilTxn`, and read-only metadata transactions return `types.ErrTxnWrongType`.

<sup>Written for commit 43871f917ff3432c85d65f903e7a2af5ea3a5c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation coverage for importing invalid transaction types.
  * Confirmed clear errors are returned for blob-only and read-only metadata transactions.
  * Added cleanup verification for transactions and database resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->