### PR TITLE
docs(examples): gov lens account created

### DIFF
--- a/examples/dingo-gov-lens/README.md
+++ b/examples/dingo-gov-lens/README.md
@@ -16,7 +16,8 @@ dependencies live in this directory's `go.mod`.
 - Active DReps from `drep`
 - DRep vote, update, registration, and delegation views
 - Stake credential lookup from `account`, either pasted manually or derived
-  locally from a CIP-30 wallet reward address
+  locally from a CIP-30 wallet reward address, including the immutable slot at
+  which Dingo first observed the account
 - Links out to Preview GovTool for proposal and voting workflows
 
 ## Bootstrap Dingo Quickly

--- a/examples/dingo-gov-lens/k8s/dingo-values.yaml
+++ b/examples/dingo-gov-lens/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.49.0"
+  tag: "0.64.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-gov-lens/main.go
+++ b/examples/dingo-gov-lens/main.go
@@ -163,6 +163,7 @@ type drepVote struct {
 type accountSummary struct {
 	StakingKey    string `json:"stakingKey"`
 	CredentialTag uint8  `json:"credentialTag"`
+	CreatedSlot   uint64 `json:"createdSlot"`
 	Reward        string `json:"reward"`
 	Active        bool   `json:"active"`
 }
@@ -179,6 +180,7 @@ type drepHistoryItem struct {
 type stakeLookup struct {
 	StakingKey    string `json:"stakingKey"`
 	CredentialTag uint8  `json:"credentialTag"`
+	CreatedSlot   uint64 `json:"createdSlot"`
 	Pool          string `json:"pool,omitempty"`
 	DRep          string `json:"drep,omitempty"`
 	DRepType      int64  `json:"drepType"`
@@ -745,6 +747,7 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 		SELECT
 			encode(staking_key, 'hex'),
 			credential_tag,
+			created_slot,
 			COALESCE(encode(pool, 'hex'), ''),
 			COALESCE(encode(drep, 'hex'), ''),
 			drep_type,
@@ -756,6 +759,7 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 	`, credential, credentialTag).Scan(
 		&ret.StakingKey,
 		&ret.CredentialTag,
+		&ret.CreatedSlot,
 		&ret.Pool,
 		&ret.DRep,
 		&ret.DRepType,
@@ -870,7 +874,7 @@ func (a *app) drepDelegations(
 	credentialTag uint8,
 ) ([]accountSummary, error) {
 	rows, err := a.db.QueryContext(ctx, `
-		SELECT encode(staking_key, 'hex'), credential_tag, reward::text, active
+		SELECT encode(staking_key, 'hex'), credential_tag, created_slot, reward::text, active
 		FROM account
 		WHERE drep = decode($1, 'hex')
 			AND drep_type = $2
@@ -888,6 +892,7 @@ func (a *app) drepDelegations(
 		if err := rows.Scan(
 			&item.StakingKey,
 			&item.CredentialTag,
+			&item.CreatedSlot,
 			&item.Reward,
 			&item.Active,
 		); err != nil {

--- a/examples/dingo-gov-lens/static/app.js
+++ b/examples/dingo-gov-lens/static/app.js
@@ -50,6 +50,7 @@ $("#stake-form").addEventListener("submit", async (event) => {
       <div class="detail-grid">
         ${metric("Stake", shortHex(data.stakingKey))}
         ${metric("Type", credentialTypeName(data.credentialTag))}
+        ${metric("Created slot", number(data.createdSlot))}
         ${metric("Active", data.active ? "yes" : "no")}
         ${metric("Reward", lovelace(data.reward))}
         ${metric("DRep type", data.drepType)}
@@ -243,15 +244,16 @@ async function showDrep(credential, credentialTag) {
       <h3>Recent delegators</h3>
       <div class="table-wrap">
         <table>
-          <thead><tr><th>Stake credential</th><th>Reward</th><th>Active</th></tr></thead>
+          <thead><tr><th>Stake credential</th><th>Created slot</th><th>Reward</th><th>Active</th></tr></thead>
           <tbody>
             ${data.delegations.length ? data.delegations.map((account) => `
               <tr>
                 <td><span class="mono">${shortHex(account.stakingKey)}</span><br /><span class="muted">${credentialTypeName(account.credentialTag)}</span></td>
+                <td>${number(account.createdSlot)}</td>
                 <td>${lovelace(account.reward)}</td>
                 <td>${account.active ? "yes" : "no"}</td>
               </tr>
-            `).join("") : emptyRow(3, "No active delegators returned.")}
+            `).join("") : emptyRow(4, "No active delegators returned.")}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose and display the immutable account created slot in the Gov Lens example to improve account history visibility. Also bump the `dingo` image to 0.64.0.

- **New Features**
  - Add `created_slot` to stake lookup and DRep delegations API responses.
  - Show “Created slot” in stake details and in the delegators table; update column count.
  - Update README to mention the immutable created slot.

- **Dependencies**
  - Update `ghcr.io/blinklabs-io/dingo` image tag from 0.49.0 to 0.64.0.

<sup>Written for commit 4c7675c093e752529b48a80c622407ef322b296c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

