### PR TITLE
docs(examples): update dingo in swap

### DIFF
--- a/examples/dingo-sundae-preview/README.md
+++ b/examples/dingo-sundae-preview/README.md
@@ -26,7 +26,8 @@ cd examples/dingo-sundae-preview
 ./scripts/port-forward-dingo.sh
 ```
 
-The chart uses a `LoadBalancer` service and enables only `DINGO_UTXORPC_PORT`.
+The example values pin Dingo `0.64.0`. The chart uses a `LoadBalancer` service
+and enables only `DINGO_UTXORPC_PORT`.
 If the load balancer is not reachable from the dev host, keep the port-forward
 open while running the frontend.
 

--- a/examples/dingo-sundae-preview/k8s/dingo-values.yaml
+++ b/examples/dingo-sundae-preview/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.46.2"
+  tag: "0.64.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin `ghcr.io/blinklabs-io/dingo` image to 0.64.0 in the Sundae preview example and update the README to note the pin. Confirms the chart uses a LoadBalancer and exposes only `DINGO_UTXORPC_PORT`.

<sup>Written for commit 480ff67ccb7c3021e7706e69036a09f4bb9da8c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

