### PR TITLE
fix(database): mark reward stake

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -877,19 +877,20 @@ The reward term (issue #2813) is required for parity with Mithril-imported mark
 rows: summing live UTxOs alone omits reward balances and understates per-pool
 mark stake by ~10% (worse for pools whose delegators hold most stake as
 rewards), which understates sigma so canonical blocks fail the leader-threshold
-VRF check and wedge networks that enforce it. It is added at the credential
-level exactly once via `MAX(account.reward)` — `idx_account_credential` is
-unique per `(credential_tag, staking_key)`, so `MAX` picks the single reward
-without multiplying it across the UTxO join fan-out that `SUM` would. This is an
-interim source: `account.reward` is the live balance, which drifts from the
-reward balance at the boundary slot, so the total is not consensus-exact; the
-boundary-accurate source is the reward engine sampling the reward at the
-snapshot slot.
+VRF check and wedge networks that enforce it. The query reconstructs each
+credential's reward balance at the requested slot from `account.reward` and
+`account_reward_delta`: without a later withdrawal it subtracts all later
+credits from the live balance; with a later withdrawal it starts from the first
+withdrawal's `previous_reward` and subtracts credits between the requested slot
+and that withdrawal. Events after the first withdrawal cannot affect its
+recorded pre-withdrawal balance. The resulting historical reward is added once
+per credential via `MAX(historical_reward.reward)`, avoiding multiplication
+across the UTxO join fan-out.
 
-`utxo.amount` and `account.reward` are both stored as text (`types.Uint64`) on
-postgres and mysql, so each is cast to the backend's native integer type before
-arithmetic (`INTEGER` on sqlite, `BIGINT` on postgres, `UNSIGNED` on mysql),
-matching the DRep voting-power queries:
+`utxo.amount`, `account.reward`, and the reward-delta amounts are stored as text
+(`types.Uint64`) on postgres and mysql, so each is cast to the backend's native
+integer type before arithmetic (`INTEGER` on sqlite, `BIGINT` on postgres,
+`UNSIGNED` on mysql), matching the DRep voting-power queries:
 
 ```sql
 -- Predicate used by sqlite/postgres/mysql implementations after resolving
@@ -899,16 +900,16 @@ WITH active_delegator_stake AS (
          active_delegation.credential_tag,
          active_delegation.staking_key,
          COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0)
-           + COALESCE(MAX(CAST(account.reward AS BIGINT)), 0) AS total_stake
+           + COALESCE(MAX(historical_reward.reward), 0) AS total_stake
   FROM active_delegation
   LEFT JOIN utxo
     ON utxo.credential_tag = active_delegation.credential_tag
    AND utxo.staking_key = active_delegation.staking_key
    AND utxo.added_slot <= $1
    AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > $1)
-  LEFT JOIN account
-    ON account.credential_tag = active_delegation.credential_tag
-   AND account.staking_key = active_delegation.staking_key
+  LEFT JOIN historical_reward
+    ON historical_reward.credential_tag = active_delegation.credential_tag
+   AND historical_reward.staking_key = active_delegation.staking_key
   WHERE active_delegation.pool_key_hash IN (...)
   GROUP BY active_delegation.pool_key_hash,
            active_delegation.credential_tag,

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -387,7 +387,7 @@ process the same pointer unless the claim expires before a result is recorded.
 
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
-| `pool_stake_snapshot` | `id`, `epoch`, `snapshot_type`, `pool_key_hash`, `total_stake`, `stake_denominator`, `delegator_count`, `captured_slot`, `reward_account_auto_vote`, `reward_account_auto_vote_resolved` | PK `id`; unique `(epoch, snapshot_type, pool_key_hash)` | Per-pool stake snapshots. `"mark"` rows store lovelace stake totals captured from slot-aware delegation and UTxO state at `captured_slot` and are used by the normal Praos epoch-2 rotation. Mithril-imported `"actv"` rows store `NewEpochState.pool-distr` stake fractions as `total_stake / stake_denominator` for the imported epoch. Logical joins to `epoch.epoch_id` and `pool.pool_key_hash`. |
+| `pool_stake_snapshot` | `id`, `epoch`, `snapshot_type`, `pool_key_hash`, `total_stake`, `stake_denominator`, `delegator_count`, `captured_slot`, `reward_account_auto_vote`, `reward_account_auto_vote_resolved` | PK `id`; unique `(epoch, snapshot_type, pool_key_hash)` | Per-pool stake snapshots. `"mark"` rows store lovelace stake totals captured from slot-aware delegation and UTxO state at `captured_slot`, plus each delegator's live `account.reward` balance (issue #2813; interim source, not boundary-exact), and are used by the normal Praos epoch-2 rotation. Mithril-imported `"actv"` rows store `NewEpochState.pool-distr` stake fractions as `total_stake / stake_denominator` for the imported epoch. Logical joins to `epoch.epoch_id` and `pool.pool_key_hash`. |
 | `epoch_summary` | `id`, `epoch`, `total_active_stake`, `total_pool_count`, `total_delegators`, `epoch_nonce`, `boundary_slot`, `snapshot_ready` | PK `id`; unique `epoch` | Aggregate epoch snapshot state. |
 | `reward_ada_pots` | `id`, `epoch`, `treasury`, `reserves`, `fees`, `rewards`, `captured_slot` | PK `id`; unique `epoch`; index `captured_slot` | Reward ADA pots at an epoch boundary. |
 | `reward_snapshot` | `id`, `epoch`, `snapshot_type`, `total_active_stake`, `total_pool_count`, `total_delegators`, `captured_slot`, `boundary_slot`, `epoch_nonce`, `protocol_version` | PK `id`; unique `(epoch, snapshot_type)`; indexes `captured_slot`, `boundary_slot` | Reward-calculation snapshot metadata. |
@@ -870,12 +870,26 @@ Historical stake by pool for epoch-boundary snapshots. The query resolves the
 latest registration/deregistration and pool-delegation certificate for each
 stake credential at or before the requested slot, treats current `account` rows
 as synthetic state only when no relevant certificate history exists for
-imported/bootstrap data, and sums only UTxOs live at that slot:
+imported/bootstrap data, and computes each delegator's stake as UTxOs live at
+that slot plus the delegator's reward-account balance.
 
-`utxo.amount` is stored as text (`types.Uint64`) on postgres and mysql, so it is
-cast to the backend's native integer type before summation (`INTEGER` on sqlite,
-`BIGINT` on postgres, `UNSIGNED` on mysql), matching the DRep voting-power
-queries:
+The reward term (issue #2813) is required for parity with Mithril-imported mark
+rows: summing live UTxOs alone omits reward balances and understates per-pool
+mark stake by ~10% (worse for pools whose delegators hold most stake as
+rewards), which understates sigma so canonical blocks fail the leader-threshold
+VRF check and wedge networks that enforce it. It is added at the credential
+level exactly once via `MAX(account.reward)` — `idx_account_credential` is
+unique per `(credential_tag, staking_key)`, so `MAX` picks the single reward
+without multiplying it across the UTxO join fan-out that `SUM` would. This is an
+interim source: `account.reward` is the live balance, which drifts from the
+reward balance at the boundary slot, so the total is not consensus-exact; the
+boundary-accurate source is the reward engine sampling the reward at the
+snapshot slot.
+
+`utxo.amount` and `account.reward` are both stored as text (`types.Uint64`) on
+postgres and mysql, so each is cast to the backend's native integer type before
+arithmetic (`INTEGER` on sqlite, `BIGINT` on postgres, `UNSIGNED` on mysql),
+matching the DRep voting-power queries:
 
 ```sql
 -- Predicate used by sqlite/postgres/mysql implementations after resolving
@@ -884,13 +898,17 @@ WITH active_delegator_stake AS (
   SELECT active_delegation.pool_key_hash,
          active_delegation.credential_tag,
          active_delegation.staking_key,
-         COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0) AS total_stake
+         COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0)
+           + COALESCE(MAX(CAST(account.reward AS BIGINT)), 0) AS total_stake
   FROM active_delegation
   LEFT JOIN utxo
     ON utxo.credential_tag = active_delegation.credential_tag
    AND utxo.staking_key = active_delegation.staking_key
    AND utxo.added_slot <= $1
    AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > $1)
+  LEFT JOIN account
+    ON account.credential_tag = active_delegation.credential_tag
+   AND account.staking_key = active_delegation.staking_key
   WHERE active_delegation.pool_key_hash IN (...)
   GROUP BY active_delegation.pool_key_hash,
            active_delegation.credential_tag,

--- a/database/plugin/metadata/internal/stakequery/stakequery.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery.go
@@ -60,7 +60,8 @@ func GetStakeByPoolsAtSlot(
 
 	cte, args := activeDelegationCTE(db, slot)
 
-	// utxo.amount and account.reward are stored as text by types.Uint64 on
+	// utxo.amount, account.reward, and account_reward_delta amounts are stored as
+	// text by types.Uint64 on
 	// postgres and mysql, so SUM()/arithmetic over the raw columns fails there
 	// ("function sum(text) does not exist" / "UNION types text and integer
 	// cannot be matched"). Cast to the backend's native integer type first,
@@ -73,34 +74,92 @@ func GetStakeByPoolsAtSlot(
 	// most of their stake as rewards), understating sigma so that canonical
 	// blocks fail the "VRF leader value exceeds stake-derived threshold"
 	// check and wedge networks that enforce it (preview/preprod/mainnet).
-	// The reward term is added at the credential level exactly once via
-	// MAX(account.reward): idx_account_credential is unique per
-	// (credential_tag, staking_key), so MAX picks the single reward value
-	// without multiplying it across the UTxO join fan-out (SUM would).
-	//
-	// CAVEAT (interim fix): account.reward is the LIVE balance, which drifts
-	// from the reward balance at the boundary slot. This greatly reduces the
-	// gross undercount and unblocks pools whose delegators' entire stake sits
-	// in rewards, but it is NOT consensus-exact. The boundary-accurate source
-	// is the #1959 reward engine sampling the reward at the snapshot slot,
-	// which is not wired into snapshots yet. Do NOT enable
-	// SkipLeaderStakeThresholdCheck on non-musashi networks as a workaround.
+	// Reward balances are reconstructed at slot from the rollback journal. If
+	// there is no later withdrawal, subtract all later credits from the live
+	// balance. If there is one, its PreviousReward is the balance immediately
+	// before that withdrawal; subtract only credits between slot and that first
+	// withdrawal. Later events cannot affect that recorded balance.
 	query := cte + fmt.Sprintf(`,
+ranked_future_withdrawal AS (
+	SELECT withdrawal.credential_tag,
+		withdrawal.staking_key,
+		withdrawal.id,
+		withdrawal.added_slot,
+		CAST(withdrawal.previous_reward AS %[1]s) AS previous_reward,
+		ROW_NUMBER() OVER (
+			PARTITION BY withdrawal.credential_tag, withdrawal.staking_key
+			ORDER BY withdrawal.added_slot, withdrawal.id
+		) AS event_order
+	FROM account_reward_delta withdrawal
+	WHERE withdrawal.withdrawal = TRUE
+		AND withdrawal.added_slot > ?
+),
+first_future_withdrawal AS (
+	SELECT credential_tag,
+		staking_key,
+		id,
+		added_slot,
+		previous_reward
+	FROM ranked_future_withdrawal
+	WHERE event_order = 1
+),
+future_credit AS (
+	SELECT credit.credential_tag,
+		credit.staking_key,
+		COALESCE(SUM(CAST(credit.amount AS %[1]s)), 0) AS total,
+		COALESCE(SUM(CASE
+			WHEN first_future_withdrawal.id IS NOT NULL
+				AND (credit.added_slot < first_future_withdrawal.added_slot
+					OR (credit.added_slot = first_future_withdrawal.added_slot
+						AND credit.id < first_future_withdrawal.id))
+			THEN CAST(credit.amount AS %[1]s)
+			ELSE 0
+		END), 0) AS before_first_withdrawal
+	FROM account_reward_delta credit
+	LEFT JOIN first_future_withdrawal
+		ON first_future_withdrawal.credential_tag = credit.credential_tag
+		AND first_future_withdrawal.staking_key = credit.staking_key
+	WHERE credit.withdrawal = FALSE
+		AND credit.added_slot > ?
+	GROUP BY credit.credential_tag,
+		credit.staking_key
+),
+historical_reward AS (
+	SELECT active_delegation.credential_tag,
+		active_delegation.staking_key,
+		CASE
+			WHEN first_future_withdrawal.id IS NOT NULL THEN
+				first_future_withdrawal.previous_reward
+					- COALESCE(future_credit.before_first_withdrawal, 0)
+			ELSE COALESCE(CAST(account.reward AS %[1]s), 0)
+				- COALESCE(future_credit.total, 0)
+		END AS reward
+	FROM active_delegation
+	LEFT JOIN account
+		ON account.credential_tag = active_delegation.credential_tag
+		AND account.staking_key = active_delegation.staking_key
+	LEFT JOIN first_future_withdrawal
+		ON first_future_withdrawal.credential_tag = active_delegation.credential_tag
+		AND first_future_withdrawal.staking_key = active_delegation.staking_key
+	LEFT JOIN future_credit
+		ON future_credit.credential_tag = active_delegation.credential_tag
+		AND future_credit.staking_key = active_delegation.staking_key
+),
 active_delegator_stake AS (
 	SELECT active_delegation.pool_key_hash,
 		active_delegation.credential_tag,
 		active_delegation.staking_key,
 		COALESCE(SUM(CAST(utxo.amount AS %[1]s)), 0)
-			+ COALESCE(MAX(CAST(account.reward AS %[1]s)), 0) AS total_stake
+			+ COALESCE(MAX(historical_reward.reward), 0) AS total_stake
 	FROM active_delegation
 	LEFT JOIN utxo
 		ON utxo.credential_tag = active_delegation.credential_tag
 		AND utxo.staking_key = active_delegation.staking_key
 		AND utxo.added_slot <= ?
 		AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > ?)
-	LEFT JOIN account
-		ON account.credential_tag = active_delegation.credential_tag
-		AND account.staking_key = active_delegation.staking_key
+	LEFT JOIN historical_reward
+		ON historical_reward.credential_tag = active_delegation.credential_tag
+		AND historical_reward.staking_key = active_delegation.staking_key
 	WHERE active_delegation.pool_key_hash IN ?
 	GROUP BY active_delegation.pool_key_hash,
 		active_delegation.credential_tag,
@@ -122,7 +181,10 @@ GROUP BY pool_key_hash`, utxoAmountCastType(db))
 	for start := 0; start < len(poolKeyHashes); start += chunkSize {
 		end := min(start+chunkSize, len(poolKeyHashes))
 		chunk := poolKeyHashes[start:end]
-		queryArgs := append(append([]any(nil), args...), slot, slot, chunk)
+		queryArgs := append(
+			append([]any(nil), args...),
+			slot, slot, slot, slot, chunk,
+		)
 		var chunkResults []stakeResult
 		if err := db.Raw(query, queryArgs...).Scan(&chunkResults).Error; err != nil {
 			return nil, nil, fmt.Errorf(

--- a/database/plugin/metadata/internal/stakequery/stakequery.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery.go
@@ -60,24 +60,47 @@ func GetStakeByPoolsAtSlot(
 
 	cte, args := activeDelegationCTE(db, slot)
 
-	// utxo.amount is stored as text by types.Uint64 on postgres and mysql, so
-	// SUM() over the raw column fails there ("function sum(text) does not
-	// exist" / "UNION types text and integer cannot be matched"). Cast to the
-	// backend's native integer type first, mirroring the DRep voting-power
-	// queries. sqlite is loosely typed but the cast keeps the backends
-	// consistent.
+	// utxo.amount and account.reward are stored as text by types.Uint64 on
+	// postgres and mysql, so SUM()/arithmetic over the raw columns fails there
+	// ("function sum(text) does not exist" / "UNION types text and integer
+	// cannot be matched"). Cast to the backend's native integer type first,
+	// mirroring the DRep voting-power queries. sqlite is loosely typed but the
+	// cast keeps the backends consistent.
+	//
+	// Per-credential stake is live UTxO lovelace PLUS the delegator's
+	// reward-account balance (issue #2813): summing UTxOs alone undercounts
+	// each pool's mark stake by ~10% (worse for pools whose delegators hold
+	// most of their stake as rewards), understating sigma so that canonical
+	// blocks fail the "VRF leader value exceeds stake-derived threshold"
+	// check and wedge networks that enforce it (preview/preprod/mainnet).
+	// The reward term is added at the credential level exactly once via
+	// MAX(account.reward): idx_account_credential is unique per
+	// (credential_tag, staking_key), so MAX picks the single reward value
+	// without multiplying it across the UTxO join fan-out (SUM would).
+	//
+	// CAVEAT (interim fix): account.reward is the LIVE balance, which drifts
+	// from the reward balance at the boundary slot. This greatly reduces the
+	// gross undercount and unblocks pools whose delegators' entire stake sits
+	// in rewards, but it is NOT consensus-exact. The boundary-accurate source
+	// is the #1959 reward engine sampling the reward at the snapshot slot,
+	// which is not wired into snapshots yet. Do NOT enable
+	// SkipLeaderStakeThresholdCheck on non-musashi networks as a workaround.
 	query := cte + fmt.Sprintf(`,
 active_delegator_stake AS (
 	SELECT active_delegation.pool_key_hash,
 		active_delegation.credential_tag,
 		active_delegation.staking_key,
-		COALESCE(SUM(CAST(utxo.amount AS %s)), 0) AS total_stake
+		COALESCE(SUM(CAST(utxo.amount AS %[1]s)), 0)
+			+ COALESCE(MAX(CAST(account.reward AS %[1]s)), 0) AS total_stake
 	FROM active_delegation
 	LEFT JOIN utxo
 		ON utxo.credential_tag = active_delegation.credential_tag
 		AND utxo.staking_key = active_delegation.staking_key
 		AND utxo.added_slot <= ?
 		AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > ?)
+	LEFT JOIN account
+		ON account.credential_tag = active_delegation.credential_tag
+		AND account.staking_key = active_delegation.staking_key
 	WHERE active_delegation.pool_key_hash IN ?
 	GROUP BY active_delegation.pool_key_hash,
 		active_delegation.credential_tag,

--- a/database/plugin/metadata/mysql/pool_atslot_test.go
+++ b/database/plugin/metadata/mysql/pool_atslot_test.go
@@ -70,9 +70,9 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
 }
 
 // TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql covers issue #2813 on
-// mysql: the reward-account balance is cast to UNSIGNED and added to live UTxO
-// lovelace via MAX(CAST(account.reward AS UNSIGNED)), and a reward-only
-// credential with no live UTxO yields non-zero stake.
+// mysql: the reconstructed reward-account balance is cast to UNSIGNED and
+// added to live UTxO lovelace, and a reward-only credential with no live UTxO
+// yields non-zero stake.
 func TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
 	defer store.Close() //nolint:errcheck

--- a/database/plugin/metadata/mysql/pool_atslot_test.go
+++ b/database/plugin/metadata/mysql/pool_atslot_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,6 +67,57 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
 	require.Equal(t, uint64(1), delegators[string(poolB)])
 	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
 	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
+}
+
+// TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql covers issue #2813 on
+// mysql: the reward-account balance is cast to UNSIGNED and added to live UTxO
+// lovelace via MAX(CAST(account.reward AS UNSIGNED)), and a reward-only
+// credential with no live UTxO yields non-zero stake.
+func TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	poolA := bytes.Repeat([]byte{0xA2}, 28)
+	poolB := bytes.Repeat([]byte{0xB2}, 28)
+	stakeUtxoReward := bytes.Repeat([]byte{0x75}, 28)
+	stakeRewardOnly := bytes.Repeat([]byte{0x76}, 28)
+	stakeUtxoNoReward := bytes.Repeat([]byte{0x77}, 28)
+
+	cleanup := func() {
+		for _, k := range [][]byte{stakeUtxoReward, stakeRewardOnly, stakeUtxoNoReward} {
+			_ = db.Where("staking_key = ?", k).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", k).Delete(&models.Utxo{}).Error
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	accounts := []models.Account{
+		{StakingKey: stakeUtxoReward, Pool: poolA, AddedSlot: 10, Active: true, Reward: types.Uint64(50)},
+		{StakingKey: stakeRewardOnly, Pool: poolA, AddedSlot: 10, Active: true, Reward: types.Uint64(30)},
+		{StakingKey: stakeUtxoNoReward, Pool: poolB, AddedSlot: 10, Active: true},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x41}, 32), OutputIdx: 0, StakingKey: stakeUtxoReward, Amount: 100, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x42}, 32), OutputIdx: 0, StakingKey: stakeUtxoNoReward, Amount: 40, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{poolA, poolB}, 80, nil,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(180), stakes[string(poolA)])
+	require.Equal(t, uint64(2), delegators[string(poolA)])
+	require.Equal(t, uint64(40), stakes[string(poolB)])
+	require.Equal(t, uint64(1), delegators[string(poolB)])
 }
 
 // TestGetStakeByPoolsPreservesIntegerPrecisionMysql verifies that the live

--- a/database/plugin/metadata/postgres/pool_atslot_test.go
+++ b/database/plugin/metadata/postgres/pool_atslot_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,4 +120,55 @@ func TestGetStakeByPoolsAggregatesTextAmountsPostgres(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(12), stakes[string(pool)])
 	require.Equal(t, uint64(1), delegators[string(pool)])
+}
+
+// TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres covers issue #2813 on
+// postgres: the reward-account balance is cast to BIGINT and added to live UTxO
+// lovelace via MAX(CAST(account.reward AS BIGINT)), and a reward-only credential
+// with no live UTxO yields non-zero stake.
+func TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	poolA := bytes.Repeat([]byte{0xA2}, 28)
+	poolB := bytes.Repeat([]byte{0xB2}, 28)
+	stakeUtxoReward := bytes.Repeat([]byte{0x75}, 28)
+	stakeRewardOnly := bytes.Repeat([]byte{0x76}, 28)
+	stakeUtxoNoReward := bytes.Repeat([]byte{0x77}, 28)
+
+	cleanup := func() {
+		for _, k := range [][]byte{stakeUtxoReward, stakeRewardOnly, stakeUtxoNoReward} {
+			_ = db.Where("staking_key = ?", k).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", k).Delete(&models.Utxo{}).Error
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	accounts := []models.Account{
+		{StakingKey: stakeUtxoReward, Pool: poolA, AddedSlot: 10, Active: true, Reward: types.Uint64(50)},
+		{StakingKey: stakeRewardOnly, Pool: poolA, AddedSlot: 10, Active: true, Reward: types.Uint64(30)},
+		{StakingKey: stakeUtxoNoReward, Pool: poolB, AddedSlot: 10, Active: true},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x41}, 32), OutputIdx: 0, StakingKey: stakeUtxoReward, Amount: 100, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x42}, 32), OutputIdx: 0, StakingKey: stakeUtxoNoReward, Amount: 40, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{poolA, poolB}, 80, nil,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(180), stakes[string(poolA)])
+	require.Equal(t, uint64(2), delegators[string(poolA)])
+	require.Equal(t, uint64(40), stakes[string(poolB)])
+	require.Equal(t, uint64(1), delegators[string(poolB)])
 }

--- a/database/plugin/metadata/postgres/pool_atslot_test.go
+++ b/database/plugin/metadata/postgres/pool_atslot_test.go
@@ -123,9 +123,9 @@ func TestGetStakeByPoolsAggregatesTextAmountsPostgres(t *testing.T) {
 }
 
 // TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres covers issue #2813 on
-// postgres: the reward-account balance is cast to BIGINT and added to live UTxO
-// lovelace via MAX(CAST(account.reward AS BIGINT)), and a reward-only credential
-// with no live UTxO yields non-zero stake.
+// postgres: the reconstructed reward-account balance is cast to BIGINT and
+// added to live UTxO lovelace, and a reward-only credential with no live UTxO
+// yields non-zero stake.
 func TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
 	defer store.Close() //nolint:errcheck

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -773,6 +773,73 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccounts(t *testing.T) {
 	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
 }
 
+// TestGetStakeByPoolsAtSlotIncludesRewardBalance covers issue #2813: the live
+// mark snapshot must add each delegator's reward-account balance to their live
+// UTxO lovelace. A credential with both a live UTxO and a reward balance sums
+// both, and a credential whose entire stake sits in its reward balance (no live
+// UTxO) now yields non-zero stake instead of collapsing to zero.
+func TestGetStakeByPoolsAtSlotIncludesRewardBalance(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	db := store.DB()
+	poolA := bytes.Repeat([]byte{0xA2}, 28)
+	poolB := bytes.Repeat([]byte{0xB2}, 28)
+	stakeUtxoReward := bytes.Repeat([]byte{0x04}, 28) // live UTxO + reward
+	stakeRewardOnly := bytes.Repeat([]byte{0x05}, 28) // reward only, no UTxO
+	stakeUtxoNoReward := bytes.Repeat([]byte{0x06}, 28)
+
+	accounts := []models.Account{
+		{
+			StakingKey: stakeUtxoReward, Pool: poolA, AddedSlot: 10,
+			Active: true, Reward: types.Uint64(50),
+		},
+		{
+			StakingKey: stakeRewardOnly, Pool: poolA, AddedSlot: 10,
+			Active: true, Reward: types.Uint64(30),
+		},
+		{
+			StakingKey: stakeUtxoNoReward, Pool: poolB, AddedSlot: 10,
+			Active: true,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+
+	utxos := []models.Utxo{
+		{
+			TxId: bytes.Repeat([]byte{0x31}, 32), OutputIdx: 0,
+			StakingKey: stakeUtxoReward, Amount: 100, AddedSlot: 20,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x32}, 32), OutputIdx: 0,
+			StakingKey: stakeUtxoNoReward, Amount: 40, AddedSlot: 20,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{poolA, poolB},
+		80,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Pool A: (100 UTxO + 50 reward) + (0 UTxO + 30 reward) = 180
+	require.Equal(t, uint64(180), stakes[string(poolA)],
+		"pool A stake should add reward balances to live UTxO lovelace")
+	require.Equal(t, uint64(2), delegators[string(poolA)])
+	// Reward-only credential still counts and contributes its reward.
+	// Pool B: 40 UTxO + 0 reward = 40 (baseline, reward absent)
+	require.Equal(t, uint64(40), stakes[string(poolB)],
+		"pool B stake unchanged when reward balance is zero")
+	require.Equal(t, uint64(1), delegators[string(poolB)])
+}
+
 func TestGetStakeByPoolsUsesStakeCredentialUtxoIndex(t *testing.T) {
 	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -773,11 +773,11 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccounts(t *testing.T) {
 	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
 }
 
-// TestGetStakeByPoolsAtSlotIncludesRewardBalance covers issue #2813: the live
-// mark snapshot must add each delegator's reward-account balance to their live
-// UTxO lovelace. A credential with both a live UTxO and a reward balance sums
-// both, and a credential whose entire stake sits in its reward balance (no live
-// UTxO) now yields non-zero stake instead of collapsing to zero.
+// TestGetStakeByPoolsAtSlotIncludesRewardBalance covers issue #2813: a mark
+// snapshot must add each delegator's reward-account balance to their live UTxO
+// lovelace. A credential with both a live UTxO and a reward balance sums both,
+// and a credential whose entire stake sits in its reward balance (no live UTxO)
+// yields non-zero stake instead of collapsing to zero.
 func TestGetStakeByPoolsAtSlotIncludesRewardBalance(t *testing.T) {
 	t.Parallel()
 	store := setupStakeSnapshotTestStore(t)
@@ -838,6 +838,74 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalance(t *testing.T) {
 	require.Equal(t, uint64(40), stakes[string(poolB)],
 		"pool B stake unchanged when reward balance is zero")
 	require.Equal(t, uint64(1), delegators[string(poolB)])
+}
+
+// TestGetStakeByPoolsAtSlotUsesHistoricalRewardBalance proves that credits and
+// withdrawals after a snapshot boundary cannot change that snapshot's stake.
+func TestGetStakeByPoolsAtSlotUsesHistoricalRewardBalance(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	db := store.DB()
+	pool := bytes.Repeat([]byte{0xA3}, 28)
+	stakeKey := bytes.Repeat([]byte{0x07}, 28)
+	account := models.Account{
+		StakingKey: stakeKey,
+		Pool:       pool,
+		AddedSlot:  10,
+		Active:     true,
+		Reward:     types.Uint64(50),
+	}
+	require.NoError(t, db.Create(&account).Error)
+
+	// The boundary balance is 50. A later credit raises it to 70, a
+	// withdrawal clears it, and another later credit leaves the live balance
+	// at 25. Neither the live 25 nor the intermediate 70 belongs at slot 80.
+	require.NoError(t, store.AddAccountRewardByCredential(
+		0,
+		stakeKey,
+		20,
+		90,
+		bytes.Repeat([]byte{0x41}, 32),
+		nil,
+	))
+	require.NoError(t, store.ApplyAccountRewardWithdrawal(
+		0,
+		stakeKey,
+		70,
+		100,
+		bytes.Repeat([]byte{0x42}, 32),
+		nil,
+	))
+	require.NoError(t, store.AddAccountRewardByCredential(
+		0,
+		stakeKey,
+		25,
+		110,
+		bytes.Repeat([]byte{0x43}, 32),
+		nil,
+	))
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{pool},
+		80,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), stakes[string(pool)])
+	require.Equal(t, uint64(1), delegators[string(pool)])
+
+	// After the withdrawal, reversing the sole later credit must recover the
+	// cleared balance rather than use the current 25.
+	stakes, delegators, err = store.GetStakeByPoolsAtSlot(
+		[][]byte{pool},
+		105,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), stakes[string(pool)])
+	require.Equal(t, uint64(1), delegators[string(pool)])
 }
 
 func TestGetStakeByPoolsUsesStakeCredentialUtxoIndex(t *testing.T) {


### PR DESCRIPTION
Closes #2813 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes undercounted pool “mark” stake by adding each delegator’s reward-account balance at the snapshot slot to their live UTxO stake, preventing VRF leader-threshold failures. Addresses Linear #2813 and aligns mark snapshots with stake used for epoch-2 rotation.

- **Bug Fixes**
  - Compute per-credential stake as SUM(UTxO) + historical reward at slot, reconstructed from `account` and `account_reward_delta` (first future withdrawal + later credits) and added via MAX(...) to avoid UTxO join fan-out; cast text amounts (`utxo.amount`, `account.reward`, deltas) to native integers on sqlite/postgres/mysql.
  - Add tests (sqlite/postgres/mysql) for reward-only and mixed UTxO+reward cases, and for stability across post-snapshot credits/withdrawals; update DATABASE.md to document the historical reward reconstruction.

<sup>Written for commit f799ce02aec4c044367ea120c770aa12fe1f83ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stake calculations at a specific slot by including delegator reward-account balances alongside live UTxO balances.
  * Corrected stake totals for delegators with rewards but no live UTxOs.
  * Ensured accurate pool stake and delegator counts across supported database backends.

* **Documentation**
  * Updated stake-query guidance and examples to reflect reward balances in stake calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->