### PR TITLE
perf(ledger): Add lock-free copy-on-write state snapshots

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2097,12 +2097,29 @@ Database operations and event delivery use worker pools for controlled concurren
 | Pattern | Usage |
 |---------|-------|
 | Goroutine Management | Tracked WaitGroups for clean shutdown |
-| Mutex Protection | RWMutex for read-heavy operations |
-| Atomic Operations | Atomic types for metrics counters |
+| Mutex Protection | Ledger writer serialization and mutable operational state |
+| Atomic Operations | Immutable ledger read snapshots and metrics counters |
 | Channel Communication | EventBus async delivery |
 | Context Cancellation | Graceful shutdown signals |
 | Worker Pools | Database operations and event delivery |
 | sync.Once | Ensure single shutdown execution |
+
+`LedgerState` publishes its read-mostly state through two immutable
+copy-on-write snapshots. The consensus snapshot groups the current epoch, era,
+current and previous-era protocol parameters, epoch cache, and hard-fork
+transition information. The tip snapshot groups the applied chain tip with the
+Praos block nonce belonging to that tip. Hot query paths load these snapshots
+through `atomic.Pointer` without acquiring the state's `RWMutex`; `reachedTip`
+is an `atomic.Bool`.
+
+Ledger writers remain serialized by the existing mutex. They compute changes
+privately, update the writer-owned state, and publish a complete replacement
+snapshot before unlocking. Slice-backed epoch nonces, tip hashes, and block
+nonces are copied at publication boundaries and published snapshots must never
+be mutated. Each snapshot is internally consistent, but a caller loading both
+snapshot pointers may observe adjacent publication generations; code requiring
+one exact cross-snapshot commit must remain under the ledger lock or explicitly
+retry.
 
 ## Configuration
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2134,10 +2134,13 @@ Each snapshot is internally consistent, but a caller loading both snapshot
 pointers could otherwise observe adjacent publication generations. Each
 production publication therefore stamps both snapshots with one generation,
 and code requiring fields from both uses a paired-load helper that retries until
-the generations match. A nil-snapshot fallback exists only for zero-value
-white-box test fixtures; it builds snapshots independently and does not provide
-the cross-snapshot generation guarantee. Production states initialize both
-snapshots in `NewLedgerState` before becoming visible.
+the generations match. The load helpers dereference `consensus.Load()` /
+`tip.Load()` directly and do not nil-check: `NewLedgerState` always calls
+`publishSnapshotsLocked()` before the state becomes visible, so production
+snapshots are never nil. White-box test fixtures that construct `LedgerState{}`
+directly must call `publishSnapshotsLocked()` (or `NewLedgerState` /
+`SetTipForTesting`) themselves before exercising any snapshot-reading path, or
+the read will nil-dereference.
 
 ## Configuration
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2117,9 +2117,10 @@ privately, update the writer-owned state, and publish a complete replacement
 snapshot before unlocking. Slice-backed epoch nonces, tip hashes, and block
 nonces are copied at publication boundaries and published snapshots must never
 be mutated. Each snapshot is internally consistent, but a caller loading both
-snapshot pointers may observe adjacent publication generations; code requiring
-one exact cross-snapshot commit must remain under the ledger lock or explicitly
-retry.
+snapshot pointers could otherwise observe adjacent publication generations.
+Each publication therefore stamps both snapshots with one generation, and code
+requiring fields from both uses a paired-load helper that retries until the
+generations match.
 
 ## Configuration
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2104,19 +2104,24 @@ Database operations and event delivery use worker pools for controlled concurren
 | Worker Pools | Database operations and event delivery |
 | sync.Once | Ensure single shutdown execution |
 
-`LedgerState` publishes its read-mostly state through two immutable
-copy-on-write snapshots. The consensus snapshot groups the current epoch, era,
-current and previous-era protocol parameters, epoch cache, and hard-fork
-transition information. The tip snapshot groups the applied chain tip with the
-Praos block nonce belonging to that tip. Hot query paths load these snapshots
-through `atomic.Pointer` without acquiring the state's `RWMutex`; `reachedTip`
-is an `atomic.Bool`.
+`LedgerState` publishes its read-mostly state through two copy-on-write
+snapshots. The consensus snapshot groups the current epoch, era, current and
+previous-era protocol parameters, epoch cache, and hard-fork transition
+information. The tip snapshot groups the applied chain tip with the Praos block
+nonce belonging to that tip. Hot query paths load these snapshots through
+`atomic.Pointer` without acquiring the state's `RWMutex`; `reachedTip` is an
+`atomic.Bool`. Snapshot containers and their owned byte slices are immutable;
+protocol-parameter values are shared and consumers must treat them as read-only.
 
 Ledger writers remain serialized by the existing mutex. They compute changes
 privately, update the writer-owned state, and publish a complete replacement
-snapshot before unlocking. Slice-backed epoch nonces, tip hashes, and block
-nonces are copied at publication boundaries and published snapshots must never
-be mutated. Each snapshot is internally consistent, but a caller loading both
+snapshot before unlocking. Tip hashes, block nonces, and the current epoch's
+nonce fields are copied at publication. The full historical epoch cache is
+instead shared by reference to avoid an allocation whose cost grows with chain
+age on every block: writers must replace the cache and nested nonce slices
+before modifying them. Publication caps the cache capacity so even an accidental
+append allocates a new backing array. Each snapshot is internally consistent,
+but a caller loading both
 snapshot pointers could otherwise observe adjacent publication generations.
 Each publication therefore stamps both snapshots with one generation, and code
 requiring fields from both uses a paired-load helper that retries until the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2112,6 +2112,12 @@ nonce belonging to that tip. Hot query paths load these snapshots through
 `atomic.Pointer` without acquiring the state's `RWMutex`; `reachedTip` is an
 `atomic.Bool`. Snapshot containers and their owned byte slices are immutable;
 protocol-parameter values are shared and consumers must treat them as read-only.
+Era-specific parameter-update functions mutate their concrete parameter
+pointer in place, so `processEpochRollover` clones the current protocol
+parameters (`cloneProtocolParametersForEra`) into a transaction-owned value
+before running them; without that clone, an epoch boundary applying an
+on-chain pparam update would mutate the pointee that a published snapshot's
+`currentPParams`/`prevEraPParams` still reference.
 
 Runtime ledger writers remain serialized by the existing mutex. They compute
 changes privately, update the writer-owned state, and publish a complete

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2113,19 +2113,25 @@ nonce belonging to that tip. Hot query paths load these snapshots through
 `atomic.Bool`. Snapshot containers and their owned byte slices are immutable;
 protocol-parameter values are shared and consumers must treat them as read-only.
 
-Ledger writers remain serialized by the existing mutex. They compute changes
-privately, update the writer-owned state, and publish a complete replacement
-snapshot before unlocking. Tip hashes, block nonces, and the current epoch's
-nonce fields are copied at publication. The full historical epoch cache is
-instead shared by reference to avoid an allocation whose cost grows with chain
-age on every block: writers must replace the cache and nested nonce slices
+Runtime ledger writers remain serialized by the existing mutex. They compute
+changes privately, update the writer-owned state, and publish a complete
+replacement snapshot before unlocking. Construction and single-threaded
+startup may also publish without the mutex, but only before the `LedgerState`
+is visible to concurrent readers. Tip hashes, block nonces, and the current
+epoch's nonce fields are copied at publication. The full historical epoch cache
+is instead shared by reference to avoid an allocation whose cost grows with
+chain age on every block: writers must replace the cache and nested nonce slices
 before modifying them. Publication caps the cache capacity so even an accidental
-append allocates a new backing array. Each snapshot is internally consistent,
-but a caller loading both
-snapshot pointers could otherwise observe adjacent publication generations.
-Each publication therefore stamps both snapshots with one generation, and code
-requiring fields from both uses a paired-load helper that retries until the
-generations match.
+append allocates a new backing array.
+
+Each snapshot is internally consistent, but a caller loading both snapshot
+pointers could otherwise observe adjacent publication generations. Each
+production publication therefore stamps both snapshots with one generation,
+and code requiring fields from both uses a paired-load helper that retries until
+the generations match. A nil-snapshot fallback exists only for zero-value
+white-box test fixtures; it builds snapshots independently and does not provide
+the cross-snapshot generation guarantee. Production states initialize both
+snapshots in `NewLedgerState` before becoming visible.
 
 ## Configuration
 

--- a/database/pparams.go
+++ b/database/pparams.go
@@ -182,9 +182,10 @@ func (d *Database) ApplyPParamUpdates(
 // The quorum parameter specifies the minimum number of unique genesis key
 // delegates that must have submitted update proposals for the update to be
 // applied (from shelley-genesis.json updateQuorum).
-// This function takes currentPParams as a value and returns the updated parameters
-// without mutating the input. This allows callers to capture the result in a
-// transaction and apply it to in-memory state after the transaction commits.
+// Although the interface is passed by value, era-specific update functions may
+// mutate its underlying concrete protocol-parameter pointer in place. Callers
+// that need the original value preserved must pass an independently owned copy;
+// the returned value is the authoritative updated parameter set.
 func (d *Database) ComputeAndApplyPParamUpdates(
 	slot, epoch uint64,
 	era uint,

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2413,6 +2413,7 @@ func BenchmarkBlockfetchVerifiedHeaderDispatch(b *testing.B) {
 	}
 	ledgerState.currentEpoch = epoch
 	ledgerState.epochCache = []models.Epoch{epoch}
+	ledgerState.publishSnapshotsLocked()
 
 	if err := ledgerState.chain.AddBlockHeader(testBlock.block.Header()); err != nil {
 		b.Fatalf("seed header queue: %v", err)

--- a/ledger/calculate_epoch_nonce_mithril_test.go
+++ b/ledger/calculate_epoch_nonce_mithril_test.go
@@ -567,6 +567,7 @@ func TestComputeEpochNonceForSlot_PostMithrilBootstrapMatchesRollover(t *testing
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	// Header verification path.
 	hvNonce, hvEvolving, hvCandidate, hvLab, err :=

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3638,8 +3638,31 @@ func (ls *LedgerState) applyEpochDonations(
 	return nil
 }
 
-// Returns EpochRolloverResult with all computed state, or an error.
-// The caller is responsible for:
+// cloneProtocolParametersForEra returns an independently owned protocol-
+// parameter value using the active era's CBOR decoder.
+func cloneProtocolParametersForEra(
+	era eras.EraDesc,
+	pparams lcommon.ProtocolParameters,
+) (lcommon.ProtocolParameters, error) {
+	if pparams == nil {
+		return nil, nil
+	}
+	if era.DecodePParamsFunc == nil {
+		return nil, fmt.Errorf("era %d has no protocol parameter decoder", era.Id)
+	}
+	data, err := cbor.Encode(pparams)
+	if err != nil {
+		return nil, fmt.Errorf("encode protocol parameters: %w", err)
+	}
+	ret, err := era.DecodePParamsFunc(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode protocol parameters: %w", err)
+	}
+	return ret, nil
+}
+
+// processEpochRollover returns all computed state without applying it. The
+// caller is responsible for:
 //   - Applying the result to in-memory state after successful commit
 //   - Starting background cleanup goroutines
 //   - Calling Scheduler.ChangeInterval if SchedulerIntervalMs > 0
@@ -3652,10 +3675,20 @@ func (ls *LedgerState) processEpochRollover(
 	epochStartSlot := currentEpoch.StartSlot + uint64(
 		currentEpoch.LengthInSlots,
 	)
+	// Era update functions mutate their concrete protocol-parameter pointer.
+	// Give the transaction an independently owned value so a failed or
+	// in-flight rollover cannot modify parameters retained by an older snapshot.
+	ownedPParams, err := cloneProtocolParametersForEra(
+		currentEra,
+		currentPParams,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("clone current protocol parameters: %w", err)
+	}
 	result := &EpochRolloverResult{
 		CheckpointWrittenForEpoch: false,
 		NewCurrentEra:             currentEra,
-		NewCurrentPParams:         currentPParams,
+		NewCurrentPParams:         ownedPParams,
 	}
 
 	// Create initial epoch
@@ -3759,7 +3792,7 @@ func (ls *LedgerState) processEpochRollover(
 		currentEpoch.EpochId+1, // Target epoch for updates
 		currentEra.Id,
 		updateQuorum,
-		currentPParams,
+		ownedPParams,
 		currentEra.DecodePParamsUpdateFunc,
 		currentEra.PParamsUpdateFunc,
 		txn,

--- a/ledger/chainsync_recycle_test.go
+++ b/ledger/chainsync_recycle_test.go
@@ -72,6 +72,7 @@ func TestChainsyncHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) {
 			EventBus: bus,
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	err := ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
 		ConnectionId: connId,
@@ -121,6 +122,7 @@ func TestChainsyncHeaderVerificationMissingEpochDefersToBlockfetch(
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	t.Cleanup(func() {
 		if ls.chainsyncBlockfetchTimeoutTimer != nil {
 			ls.chainsyncBlockfetchTimeoutTimer.Stop()
@@ -191,6 +193,7 @@ func TestChainsyncHeaderVerificationEmptyEpochNonceDefersToBlockfetch(
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	t.Cleanup(func() {
 		if ls.chainsyncBlockfetchTimeoutTimer != nil {
 			ls.chainsyncBlockfetchTimeoutTimer.Stop()
@@ -252,6 +255,7 @@ func TestBlockfetchHeaderVerificationFailurePublishesRecycleEvent(t *testing.T) 
 			EventBus: bus,
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	ls.handleEventBlockfetch(event.NewEvent(
 		BlockfetchEventType,

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1675,6 +1675,7 @@ func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = append([]byte(nil), currentNonce...)
 	ls.chainsyncState = SyncingChainsyncState
+	ls.publishSnapshotsLocked()
 
 	connId := ouroboros.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},

--- a/ledger/chainsync_state_race_test.go
+++ b/ledger/chainsync_state_race_test.go
@@ -25,6 +25,7 @@ func TestChainsyncValidationStateConcurrentAccess(t *testing.T) {
 		validationEnabled: true,
 		mithrilLedgerSlot: 10,
 	}
+	ls.publishSnapshotsLocked()
 
 	const iterations = 1000
 

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -455,6 +455,7 @@ func TestHandleEventBlockfetchBatchDoneUsesSelectedConnectionAfterSwitch(
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	ls.handleChainSwitchEvent(event.NewEvent(
 		chainselection.ChainSwitchEventType,
 		chainselection.ChainSwitchEvent{
@@ -511,6 +512,7 @@ func TestHandleEventBlockfetchBatchDoneFallsBackToCurrentConnection(
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId,
@@ -1717,6 +1719,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchRetriesAlternateConnection(
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId1,

--- a/ledger/epoch_lab_nonce_test.go
+++ b/ledger/epoch_lab_nonce_test.go
@@ -118,6 +118,7 @@ func TestEpochNonceStoresClosingEpochLastBlockPrevHashAsLab(t *testing.T) {
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	hvNonce, _, hvCandidate, hvLab, err :=
 		ls.computeEpochNonceForSlot(epochEnd, prevEpoch)

--- a/ledger/epoch_nonce_carried_lab_test.go
+++ b/ledger/epoch_nonce_carried_lab_test.go
@@ -107,6 +107,7 @@ func TestEpochNonceUsesCarriedLastEpochBlockNonce(t *testing.T) {
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	hvNonce, _, hvCandidate, hvLab, err :=
 		ls.computeEpochNonceForSlot(epochEnd, prevEpoch)
@@ -192,6 +193,7 @@ func TestEpochNonceGenesisEdgeUsesNeutralLab(t *testing.T) {
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	hvNonce, hvEvolving, hvCandidate, hvLab, err :=
 		ls.computeEpochNonceForSlot(500, initialEpoch)

--- a/ledger/epoch_nonce_past_cutoff_test.go
+++ b/ledger/epoch_nonce_past_cutoff_test.go
@@ -142,6 +142,7 @@ func TestEpochNonce_SnapshotTipPastCutoff(t *testing.T) {
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	// Header-verification (eager) path.
 	hvNonce, hvEvolving, hvCandidate, hvLab, err :=

--- a/ledger/era_summary.go
+++ b/ledger/era_summary.go
@@ -34,14 +34,11 @@ func (ls *LedgerState) SystemStart() (time.Time, error) {
 
 // It returns all epochs stored in the database.
 func (ls *LedgerState) GetEpochs() ([]models.Epoch, error) {
-	ls.RLock()
-	defer ls.RUnlock()
-	if len(ls.epochCache) == 0 {
+	cache := ls.loadConsensusSnapshot().epochCache
+	if len(cache) == 0 {
 		return nil, nil
 	}
-	epochs := make([]models.Epoch, len(ls.epochCache))
-	copy(epochs, ls.epochCache)
-	return epochs, nil
+	return cloneEpochs(cache), nil
 }
 
 // It returns protocol parameters for the specific epoch.

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -128,6 +128,7 @@ func HardForkBabbage(
 		)
 	}
 	ret := babbage.UpgradePParams(*alonzoPParams)
+	ret.CostModels = cloneCostModels(ret.CostModels)
 	// Add PlutusV2 cost model if not already present
 	// This is needed because the Babbage hard fork happens before the on-chain
 	// protocol parameter update that contains PlutusV2 cost models arrives.

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -102,6 +102,7 @@ func HardForkConway(
 		)
 	}
 	ret := conway.UpgradePParams(*babbagePParams)
+	ret.CostModels = cloneCostModels(ret.CostModels)
 	conwayGenesis := nodeConfig.ConwayGenesis()
 	if err := ret.UpdateFromGenesis(conwayGenesis); err != nil {
 		return nil, err

--- a/ledger/eras/cost_models.go
+++ b/ledger/eras/cost_models.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+// cloneCostModels gives hard-fork parameter conversion ownership of both the
+// map and its slice values. The upstream UpgradePParams helpers copy structs,
+// so without this step a conversion can mutate the previous era's parameters.
+func cloneCostModels(values map[uint][]int64) map[uint][]int64 {
+	if values == nil {
+		return nil
+	}
+	ret := make(map[uint][]int64, len(values))
+	for language, model := range values {
+		ret[language] = append([]int64(nil), model...)
+	}
+	return ret
+}

--- a/ledger/eras/dijkstra.go
+++ b/ledger/eras/dijkstra.go
@@ -97,6 +97,7 @@ func HardForkDijkstra(
 	ret := gdijkstra.DijkstraProtocolParameters{
 		ConwayProtocolParameters: *conwayPParams,
 	}
+	ret.CostModels = cloneCostModels(ret.CostModels)
 	if nodeConfig != nil {
 		dijkstraGenesis := nodeConfig.DijkstraGenesis()
 		if !isEmptyDijkstraGenesis(dijkstraGenesis) {

--- a/ledger/eras/dijkstra_test.go
+++ b/ledger/eras/dijkstra_test.go
@@ -39,6 +39,7 @@ func TestHardForkDijkstraSkipsEmptyGenesis(t *testing.T) {
 			Major: 10,
 			Minor: 0,
 		},
+		CostModels: map[uint][]int64{0: {1, 2, 3}},
 	}
 
 	got, err := eras.HardForkDijkstra(cfg, prev)
@@ -54,4 +55,6 @@ func TestHardForkDijkstraSkipsEmptyGenesis(t *testing.T) {
 		uint(dijkstra.MinProtocolVersionDijkstra),
 		dijkstraPParams.ProtocolVersion.Major,
 	)
+	dijkstraPParams.CostModels[0][0] = 9
+	require.Equal(t, []int64{1, 2, 3}, prev.CostModels[0])
 }

--- a/ledger/eras/hardfork_test.go
+++ b/ledger/eras/hardfork_test.go
@@ -17,9 +17,11 @@ package eras_test
 import (
 	"testing"
 
+	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
@@ -37,10 +39,10 @@ import (
 // pparams as belonging to the prior era. The chain then never
 // advances.
 //
-// The tests below cover the era transitions whose HardForkFunc takes
-// no genesis configuration. Shelley, Alonzo, and Conway are excluded
-// because they require ShelleyGenesis / AlonzoGenesis / ConwayGenesis
-// respectively to produce a valid result; their version-bump
+// The version-bump tests below cover the era transitions whose HardForkFunc
+// takes no genesis configuration. Shelley, Alonzo, and Conway are excluded
+// from those because they require ShelleyGenesis / AlonzoGenesis /
+// ConwayGenesis respectively to produce a valid result; their version-bump
 // postcondition is identical and is verified end-to-end by the eras
 // integration test.
 
@@ -95,4 +97,46 @@ func TestHardForkBabbageBumpsProtocolMajor(t *testing.T) {
 		"HardForkBabbage must bump ProtocolMajor to BabbageEraDesc.MinMajorVersion (%d), got %d",
 		eras.BabbageEraDesc.MinMajorVersion, pp.ProtocolMajor,
 	)
+}
+
+// TestHardForkBabbageDoesNotMutatePreviousCostModels verifies that the
+// Babbage upgrade does not modify CostModels owned by the previous era.
+func TestHardForkBabbageDoesNotMutatePreviousCostModels(t *testing.T) {
+	prev := &alonzo.AlonzoProtocolParameters{
+		ProtocolMajor: 6,
+		CostModels: map[uint][]int64{
+			0: {1, 2, 3},
+		},
+	}
+
+	got, err := eras.HardForkBabbage(nil, prev)
+	require.NoError(t, err)
+	pp := got.(*babbage.BabbageProtocolParameters)
+	pp.CostModels[0][0] = 9
+	pp.CostModels[2] = []int64{4}
+
+	require.Equal(t, []int64{1, 2, 3}, prev.CostModels[0])
+	require.NotContains(t, prev.CostModels, uint(1))
+	require.NotContains(t, prev.CostModels, uint(2))
+}
+
+// TestHardForkConwayDoesNotMutatePreviousCostModels verifies that the
+// Conway upgrade does not modify CostModels owned by the previous era.
+func TestHardForkConwayDoesNotMutatePreviousCostModels(t *testing.T) {
+	prev := &babbage.BabbageProtocolParameters{
+		ProtocolMajor: 8,
+		CostModels: map[uint][]int64{
+			0: {1, 2, 3},
+		},
+	}
+
+	got, err := eras.HardForkConway(&cardano.CardanoNodeConfig{}, prev)
+	require.NoError(t, err)
+	pp := got.(*conway.ConwayProtocolParameters)
+	pp.CostModels[0][0] = 9
+	pp.CostModels[2] = []int64{4}
+
+	require.Equal(t, []int64{1, 2, 3}, prev.CostModels[0])
+	require.NotContains(t, prev.CostModels, uint(1))
+	require.NotContains(t, prev.CostModels, uint(2))
 }

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 )
 
@@ -44,11 +43,9 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		}
 	}
 
-	ls.RLock()
-	cache := make([]models.Epoch, len(ls.epochCache))
-	copy(cache, ls.epochCache)
-	transitionInfo := ls.transitionInfo
-	ls.RUnlock()
+	snapshot := ls.loadConsensusSnapshot()
+	cache := snapshot.epochCache
+	transitionInfo := snapshot.transitionInfo
 
 	if len(cache) == 0 {
 		return nil, errors.New("ledger: no epochs in cache")

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -55,6 +55,7 @@ func TestHardForkSummary_SingleEra(t *testing.T) {
 			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
@@ -89,6 +90,7 @@ func TestHardForkSummary_TwoEras(t *testing.T) {
 			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
@@ -127,6 +129,7 @@ func TestHardForkSummary_EmptyCache(t *testing.T) {
 			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
 		},
 	}
+	ls.publishSnapshotsLocked()
 	_, err := ls.HardForkSummary()
 	assert.Error(t, err)
 }
@@ -143,6 +146,7 @@ func TestHardForkSummary_MissingShelleyGenesis(t *testing.T) {
 		},
 		config: LedgerStateConfig{CardanoNodeConfig: &cardano.CardanoNodeConfig{}},
 	}
+	ls.publishSnapshotsLocked()
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
 	assert.True(t, sum.SystemStart.IsZero(),
@@ -164,6 +168,7 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
 		},
 	}
+	ls.publishSnapshotsLocked()
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
 	assert.Equal(t, hardfork.NewTransitionKnown(7), sum.Transition)

--- a/ledger/heal_mithril_gap_nonce.go
+++ b/ledger/heal_mithril_gap_nonce.go
@@ -421,6 +421,7 @@ func (ls *LedgerState) healMithrilGapBlockNonces(ctx context.Context) error {
 			ls.currentTipBlockNonce = tipNonce
 		}
 		clear(ls.epochNonceHexCache)
+		ls.publishSnapshotsLocked()
 		ls.Unlock()
 	} else {
 		ls.Lock()

--- a/ledger/peer_provider_test.go
+++ b/ledger/peer_provider_test.go
@@ -354,6 +354,7 @@ func TestPoolRelayProviderCacheMissFetchesFromDB(t *testing.T) {
 func TestPoolRelayProviderCurrentSlot(t *testing.T) {
 	db := newTestDB(t)
 	ls := &LedgerState{db: db}
+	ls.publishSnapshotsLocked()
 
 	adapter, err := NewPoolRelayProvider(ls, db, nil)
 	require.NoError(t, err)

--- a/ledger/protocol_params_for_slot_boundary_test.go
+++ b/ledger/protocol_params_for_slot_boundary_test.go
@@ -82,6 +82,7 @@ func TestProtocolParamsForSlot_ForecastsBumpAtBoundarySlot(t *testing.T) {
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	// Slot 74: last slot of epoch 0. Still Shelley by every measure —
 	// the schedule's trigger fires AT epoch 1, not before.

--- a/ledger/protocol_params_for_slot_boundary_test.go
+++ b/ledger/protocol_params_for_slot_boundary_test.go
@@ -18,11 +18,14 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
 )
@@ -145,5 +148,88 @@ func newAllegraAtEpoch1Cfg(t *testing.T) *cardano.CardanoNodeConfig {
 	allegraEpoch := uint64(1)
 	cfg.ExperimentalHardForksEnabled = &enabled
 	cfg.TestAllegraHardForkAtEpoch = &allegraEpoch
+	return cfg
+}
+
+// TestProtocolParamsForSlot_ConcurrentPostForkCallsDoNotRaceOnCostModels
+// guards against a concurrent map write crash, not just a -race warning.
+// ProtocolParamsForSlot forecasts across a scheduled fork by calling
+// HardForkFunc directly on the published snapshot's currentPParams; if a
+// HardForkFunc wrapper shares its input's CostModels map instead of cloning
+// it (the shape gouroboros's UpgradePParams produces — it copies the
+// pparams struct but not the map), concurrent forecasts for the same
+// post-fork slot become concurrent writes into that one shared map, which
+// Go's runtime terminates the process for rather than reporting as a
+// data race. HardForkBabbage (and Conway/Dijkstra) must clone CostModels
+// before writing to it for this to be safe.
+func TestProtocolParamsForSlot_ConcurrentPostForkCallsDoNotRaceOnCostModels(
+	t *testing.T,
+) {
+	cfg := newAlonzoBabbageAtEpoch1Cfg(t)
+
+	pparams := &alonzo.AlonzoProtocolParameters{
+		ProtocolMajor: eras.AlonzoEraDesc.MaxMajorVersion,
+		CostModels: map[uint][]int64{
+			0: {1, 2, 3},
+		},
+	}
+
+	ls := &LedgerState{
+		currentEra: eras.AlonzoEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId:       0,
+			StartSlot:     0,
+			LengthInSlots: 75,
+			SlotLength:    1000,
+			EraId:         eras.AlonzoEraDesc.Id,
+		},
+		currentPParams: pparams,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got := ls.ProtocolParamsForSlot(75)
+			babbagePParams, ok := got.(*babbage.BabbageProtocolParameters)
+			require.True(t, ok)
+			require.NotEmpty(t, babbagePParams.CostModels)
+		}()
+	}
+	wg.Wait()
+}
+
+// newAlonzoBabbageAtEpoch1Cfg schedules Babbage at epoch 1 (slot 75 with
+// epochLength=75), mirroring newAllegraAtEpoch1Cfg's shape but for the
+// CostModels-bearing Alonzo->Babbage transition.
+func newAlonzoBabbageAtEpoch1Cfg(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: strings.Repeat("11", 32),
+	}
+	require.NoError(t, cfg.LoadByronGenesisFromReader(strings.NewReader(`{
+		"protocolConsts": {
+			"k": 6,
+			"protocolMagic": 42
+		}
+	}`)))
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"systemStart": "2026-01-01T00:00:00Z",
+		"securityParam": 6,
+		"activeSlotsCoeff": 0.4,
+		"epochLength": 75,
+		"slotLength": 1
+	}`)))
+	enabled := true
+	babbageEpoch := uint64(1)
+	cfg.ExperimentalHardForksEnabled = &enabled
+	cfg.TestBabbageHardForkAtEpoch = &babbageEpoch
 	return cfg
 }

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -85,22 +85,16 @@ func (ls *LedgerState) querySystemStart() (any, error) {
 }
 
 func (ls *LedgerState) queryChainBlockNo() (any, error) {
-	ls.RLock()
-	point := ls.currentTip.Point
-	blockNumber := ls.currentTip.BlockNumber
-	ls.RUnlock()
+	tip := ls.loadTipSnapshot().currentTip
 	// WithOrigin BlockNo: [0] at genesis, [1, blockNo] once a block exists.
-	if len(point.Hash) == 0 {
+	if len(tip.Point.Hash) == 0 {
 		return []any{0}, nil
 	}
-	return []any{1, blockNumber}, nil
+	return []any{1, tip.BlockNumber}, nil
 }
 
 func (ls *LedgerState) queryChainPoint() (any, error) {
-	ls.RLock()
-	point := ls.currentTip.Point
-	ls.RUnlock()
-	return point, nil
+	return ls.loadTipSnapshot().currentTip.Point, nil
 }
 
 func (ls *LedgerState) queryHardFork(
@@ -108,10 +102,7 @@ func (ls *LedgerState) queryHardFork(
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.HardForkCurrentEraQuery:
-		ls.RLock()
-		eraId := ls.currentEra.Id
-		ls.RUnlock()
-		return eraId, nil
+		return ls.loadConsensusSnapshot().currentEra.Id, nil
 	case *olocalstatequery.HardForkEraHistoryQuery:
 		return ls.queryHardForkEraHistory()
 	default:
@@ -162,14 +153,13 @@ type eraBoundData struct {
 }
 
 func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
-	// Snapshot the tip, current era, and transition info under the read lock
-	// so we can use them without holding the lock during the (potentially
-	// slow) DB queries below.
-	ls.RLock()
-	tipSlot := ls.currentTip.Point.Slot
-	currentEraId := ls.currentEra.Id
-	transitionInfo := ls.transitionInfo
-	ls.RUnlock()
+	// Read the tip, current era, and transition info from the lock-free
+	// snapshots so this (potentially slow) DB-querying path never contends
+	// with the ledger write lock.
+	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	consensusState := ls.loadConsensusSnapshot()
+	currentEraId := consensusState.currentEra.Id
+	transitionInfo := consensusState.transitionInfo
 
 	shape := ls.eraShape()
 	if len(shape.Eras) == 0 {
@@ -429,15 +419,9 @@ func (ls *LedgerState) queryShelley(
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.ShelleyEpochNoQuery:
-		ls.RLock()
-		epochId := ls.currentEpoch.EpochId
-		ls.RUnlock()
-		return []any{epochId}, nil
+		return []any{ls.loadConsensusSnapshot().currentEpoch.EpochId}, nil
 	case *olocalstatequery.ShelleyCurrentProtocolParamsQuery:
-		ls.RLock()
-		pparams := ls.currentPParams
-		ls.RUnlock()
-		return []any{pparams}, nil
+		return []any{ls.loadConsensusSnapshot().currentPParams}, nil
 	case *olocalstatequery.ShelleyGenesisConfigQuery:
 		return ls.queryShelleyGenesisConfig()
 	case *olocalstatequery.ShelleyUtxoByAddressQuery:
@@ -589,9 +573,8 @@ func (ls *LedgerState) queryShelleyAccountState() (any, error) {
 // drepDeposit returns the current dRepDeposit protocol parameter, which is the
 // deposit every DRep locks at registration. Returns 0 outside Conway.
 func (ls *LedgerState) drepDeposit() uint64 {
-	ls.RLock()
-	defer ls.RUnlock()
-	if cpp, ok := ls.currentPParams.(*conway.ConwayProtocolParameters); ok &&
+	pparams := ls.loadConsensusSnapshot().currentPParams
+	if cpp, ok := pparams.(*conway.ConwayProtocolParameters); ok &&
 		cpp != nil {
 		return cpp.DRepDeposit
 	}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -94,7 +94,7 @@ func (ls *LedgerState) queryChainBlockNo() (any, error) {
 }
 
 func (ls *LedgerState) queryChainPoint() (any, error) {
-	return ls.loadTipSnapshot().currentTip.Point, nil
+	return cloneTip(ls.loadTipSnapshot().currentTip).Point, nil
 }
 
 func (ls *LedgerState) queryHardFork(
@@ -156,8 +156,8 @@ func (ls *LedgerState) queryHardForkEraHistory() (any, error) {
 	// Read the tip, current era, and transition info from the lock-free
 	// snapshots so this (potentially slow) DB-querying path never contends
 	// with the ledger write lock.
-	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
-	consensusState := ls.loadConsensusSnapshot()
+	consensusState, tipState := ls.loadStateSnapshots()
+	tipSlot := tipState.currentTip.Point.Slot
 	currentEraId := consensusState.currentEra.Id
 	transitionInfo := consensusState.transitionInfo
 

--- a/ledger/queries_hfc_test.go
+++ b/ledger/queries_hfc_test.go
@@ -65,6 +65,7 @@ func TestQueryHardForkEraHistory_EmitsAllKnownEras(t *testing.T) {
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 	list, ok := result.(cbor.IndefLengthList)
@@ -133,6 +134,7 @@ func TestQueryHardForkEraHistory_TransitionUnknown_TipNearEpochEnd(t *testing.T)
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 	eraList := result.(cbor.IndefLengthList)
@@ -209,6 +211,7 @@ func TestQueryHardForkEraHistory_AtEpochOverride_SurfacesKnownEnd(t *testing.T) 
 	require.Equal(t, hardfork.TransitionKnown, ls.transitionInfo.State)
 	require.Equal(t, override, ls.transitionInfo.KnownEpoch)
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 	list, ok := result.(cbor.IndefLengthList)
@@ -269,6 +272,7 @@ func TestQueryHardForkEraHistory_AdjacentErasContiguous(t *testing.T) {
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 	list, ok := result.(cbor.IndefLengthList)

--- a/ledger/queries_impossible_multiepoch_test.go
+++ b/ledger/queries_impossible_multiepoch_test.go
@@ -90,6 +90,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_MultiEpochEra(t *testing.T
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -116,6 +116,7 @@ func TestQueryHardForkEraHistory_OpenEraEndBoundedBySafeZone(t *testing.T) {
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -255,6 +256,7 @@ func TestStakePoolsResult_Empty(t *testing.T) {
 func TestQueryShelleyDRepState_EmptyDB(t *testing.T) {
 	db := newTestDB(t)
 	ls := &LedgerState{db: db}
+	ls.publishSnapshotsLocked()
 
 	result, err := ls.queryShelleyDRepState(nil)
 	require.NoError(t, err)
@@ -300,6 +302,7 @@ func TestQueryShelleyDRepState_Populated(t *testing.T) {
 		AddedSlot:     100,
 	}))
 	ls := &LedgerState{db: db}
+	ls.publishSnapshotsLocked()
 
 	result, err := ls.queryShelleyDRepState(nil)
 	require.NoError(t, err)
@@ -790,6 +793,7 @@ func TestQueryHardForkEraHistory_TransitionKnown(t *testing.T) {
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -860,6 +864,7 @@ func TestQueryHardForkEraHistory_TransitionKnown_MissingEpochFallsBackToSafeZone
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -922,6 +927,7 @@ func TestQueryHardForkEraHistory_TransitionUnknown_FallsBackToSafeZone(t *testin
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -988,6 +994,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_ServesEpochEnd(t *testing.
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -1039,6 +1046,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_EpochNumberIsNextEpoch(t *
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -1079,7 +1087,7 @@ func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *t
 			eras.ConwayEraDesc.Id, slotLenMs, epochLen,
 			nil,
 		))
-		return &LedgerState{
+		ls := &LedgerState{
 			db:             db,
 			currentEra:     eras.ConwayEraDesc,
 			currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
@@ -1089,6 +1097,8 @@ func TestQueryHardForkEraHistory_TransitionImpossible_vs_Unknown_Comparison(t *t
 				Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 			},
 		}
+		ls.publishSnapshotsLocked()
+		return ls
 	}
 
 	eraEndSlot := func(ls *LedgerState) uint64 {
@@ -1333,6 +1343,7 @@ func TestQueryHardForkEraHistory_PastEra_NormalEpochEnd(t *testing.T) {
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -1431,6 +1442,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch(t *testing.T) {
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -1556,6 +1568,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch_Contiguity(t *testing.T
 		},
 	}
 
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryHardForkEraHistory()
 	require.NoError(t, err)
 
@@ -1624,6 +1637,7 @@ func TestQueryHardForkEraHistory_PastEra_TransitionEpoch_Contiguity(t *testing.T
 // TestQueryChainBlockNoAtGenesis verifies origin is encoded as WithOrigin [0].
 func TestQueryChainBlockNoAtGenesis(t *testing.T) {
 	ls := &LedgerState{}
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryChainBlockNo()
 	assert.NoError(t, err)
 	// WithOrigin at genesis: [0]
@@ -1639,6 +1653,7 @@ func TestQueryChainBlockNoAtBlock(t *testing.T) {
 		},
 		BlockNumber: 12345,
 	}
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryChainBlockNo()
 	assert.NoError(t, err)
 	// WithOrigin at block: [1, blockNo]
@@ -1654,6 +1669,7 @@ func TestQueryChainBlockNoAtFirstBlock(t *testing.T) {
 		},
 		BlockNumber: 0,
 	}
+	ls.publishSnapshotsLocked()
 	result, err := ls.queryChainBlockNo()
 	assert.NoError(t, err)
 	// Cardano block numbers are 0-indexed, so block 0 is not origin.

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -161,6 +161,7 @@ func TestTryRecoverFromTxValidationErrorRollsBackToEarliestProducerParent(
 
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
+	ls.publishSnapshotsLocked()
 
 	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
 	require.True(t, ok)
@@ -322,6 +323,7 @@ func TestTryRecoverFromTxValidationErrorRejectsReplayBelowMithrilBoundary(
 	ls.currentTip = boundaryTip
 	ls.currentTipBlockNonce = []byte("nonce-boundary")
 	ls.mithrilLedgerSlot = boundaryTip.Point.Slot
+	ls.publishSnapshotsLocked()
 	timer := time.NewTimer(time.Hour)
 	t.Cleanup(func() { timer.Stop() })
 	ls.activeBlockfetchConnId = activeConnId
@@ -465,7 +467,8 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 	ls.currentTip = ledgerTip
 	ls.currentTipBlockNonce = []byte("nonce-ledger-tip")
 	ls.validationEnabled = true
-	ls.reachedTip = true
+	ls.reachedTip.Store(true)
+	ls.publishSnapshotsLocked()
 
 	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
 	require.True(t, ok)
@@ -639,7 +642,8 @@ func TestTryRecoverFromTxValidationErrorAtTipRejectsRewindBelowMithrilBoundary(
 	ls.currentTip = ledgerTip
 	ls.currentTipBlockNonce = []byte("nonce-ledger-tip")
 	ls.mithrilLedgerSlot = ledgerTip.Point.Slot
-	ls.reachedTip = true
+	ls.reachedTip.Store(true)
+	ls.publishSnapshotsLocked()
 
 	validationErr := &txValidationError{
 		BlockPoint: ocommon.NewPoint(
@@ -781,6 +785,7 @@ func TestTryRecoverFromTxValidationErrorFallsBackToTxBlobOffsets(
 
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
+	ls.publishSnapshotsLocked()
 
 	recovered, err := ls.tryRecoverFromTxValidationError(
 		&txValidationError{
@@ -914,6 +919,7 @@ func TestTryRecoverFromTxValidationErrorFallsBackToChainScan(t *testing.T) {
 	ls.metrics.init(prometheus.NewRegistry())
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
+	ls.publishSnapshotsLocked()
 
 	producerTxs := producerBlock.block.Transactions()
 	require.NotEmpty(t, producerTxs)
@@ -1064,6 +1070,7 @@ func TestTryRecoverFromTxValidationErrorRecoversDependencyClosure(
 	ls.metrics.init(prometheus.NewRegistry())
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
+	ls.publishSnapshotsLocked()
 
 	recovered, err := ls.tryRecoverFromTxValidationError(
 		&txValidationError{
@@ -1138,6 +1145,7 @@ func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
 	require.NoError(t, db.SetTip(currentTip, nil))
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
+	ls.publishSnapshotsLocked()
 
 	recovered, err := ls.tryRecoverFromTxValidationError(
 		&txValidationError{

--- a/ledger/slot_bugs_test.go
+++ b/ledger/slot_bugs_test.go
@@ -66,6 +66,7 @@ func TestTimeToSlot_FutureTimeWithEmptyCacheReturnsError(t *testing.T) {
 		// epochCache empty — HardForkSummary will error.
 		config: LedgerStateConfig{CardanoNodeConfig: cfg},
 	}
+	ls.publishSnapshotsLocked()
 
 	// Far-future time; well past any "near now" tolerance.
 	future := time.Now().Add(24 * time.Hour)

--- a/ledger/slot_crossera_test.go
+++ b/ledger/slot_crossera_test.go
@@ -30,7 +30,7 @@ import (
 // Total Byron time = 2 × 100 × 20s = 4000s.
 func crossEraLedger(t *testing.T) *LedgerState {
 	t.Helper()
-	return &LedgerState{
+	ls := &LedgerState{
 		epochCache: []models.Epoch{
 			{EpochId: 0, StartSlot: 0, SlotLength: 20_000, LengthInSlots: 100, EraId: 0},
 			{EpochId: 1, StartSlot: 100, SlotLength: 20_000, LengthInSlots: 100, EraId: 0},
@@ -41,6 +41,8 @@ func crossEraLedger(t *testing.T) *LedgerState {
 			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
 		},
 	}
+	ls.publishSnapshotsLocked()
+	return ls
 }
 
 // TestSlotToTime_CrossEra covers multi-era chains where per-era slot length

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -67,6 +67,7 @@ func TestSlotCalc(t *testing.T) {
 			CardanoNodeConfig: &cardano.CardanoNodeConfig{},
 		},
 	}
+	testLedgerState.publishSnapshotsLocked()
 	testShelleyGenesis := `{"systemStart": "2022-10-25T00:00:00Z"}`
 	if err := testLedgerState.config.CardanoNodeConfig.LoadShelleyGenesisFromReader(strings.NewReader(testShelleyGenesis)); err != nil {
 		t.Fatalf("unexpected error loading cardano node config: %s", err)
@@ -173,6 +174,7 @@ func TestSlotToEpochProjection(t *testing.T) {
 			},
 		},
 	}
+	testLedgerState.publishSnapshotsLocked()
 
 	testCases := []struct {
 		name          string
@@ -262,6 +264,7 @@ func TestSlotToEpochEmptyCache(t *testing.T) {
 	testLedgerState := &LedgerState{
 		epochCache: []models.Epoch{},
 	}
+	testLedgerState.publishSnapshotsLocked()
 
 	_, err := testLedgerState.SlotToEpoch(100)
 	if err == nil {
@@ -292,6 +295,7 @@ func TestSlotToEpochBeforeFirstEpoch(t *testing.T) {
 			},
 		},
 	}
+	testLedgerState.publishSnapshotsLocked()
 
 	// Slot before first known epoch should error
 	_, err := testLedgerState.SlotToEpoch(100)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4891,6 +4891,10 @@ func (ls *LedgerState) PrepareEpochCacheForStartup() error {
 
 func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) error {
 	ls.epochCache = epochs
+	// Publish every mutation made by this startup writer, including partial
+	// state on error returns, so snapshot readers can never retain a stale view
+	// if this helper is reused outside fatal startup handling in the future.
+	defer ls.publishSnapshotsLocked()
 	clear(ls.epochNonceHexCache)
 	if len(epochs) > 0 {
 		// Recover epoch records whose LastEpochBlockNonce was persisted empty
@@ -4906,7 +4910,6 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 		ls.currentEra = *eraDesc
 		// Update metrics
 		ls.metrics.epochNum.Set(float64(ls.currentEpoch.EpochId))
-		ls.publishSnapshotsLocked()
 		return nil
 	}
 	// Populate initial epoch
@@ -4969,7 +4972,6 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	ls.checkpointWrittenForEpoch = rolloverResult.CheckpointWrittenForEpoch
 	ls.metrics.epochNum.Set(rolloverResult.NewEpochNum)
-	ls.publishSnapshotsLocked()
 	return nil
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -531,19 +531,43 @@ type slotBattleRecorderHolder struct {
 	recorder SlotBattleRecorder
 }
 
+// consensusSnapshot contains ledger state that is read frequently and updated
+// as one logical unit at epoch/era boundaries and during rollback. Published
+// snapshots are immutable.
+type consensusSnapshot struct {
+	currentEpoch   models.Epoch
+	currentEra     eras.EraDesc
+	currentPParams lcommon.ProtocolParameters
+	prevEraPParams lcommon.ProtocolParameters
+	epochCache     []models.Epoch
+	transitionInfo hardfork.TransitionInfo
+}
+
+// tipSnapshot contains the applied tip and the Praos block nonce belonging to
+// that tip. Published snapshots are immutable.
+type tipSnapshot struct {
+	currentTip           ochainsync.Tip
+	currentTipBlockNonce []byte
+}
+
 type LedgerState struct {
-	metrics                            stateMetrics
+	metrics   stateMetrics
+	consensus atomic.Pointer[consensusSnapshot]
+	tip       atomic.Pointer[tipSnapshot]
+	// The fields below are writer-owned working state. Lock-free readers use
+	// consensus and tip snapshots; writers update these fields under Lock and
+	// publish a fresh immutable snapshot before unlocking.
 	currentEra                         eras.EraDesc
 	activeEras                         []eras.EraDesc
 	config                             LedgerStateConfig
 	chainsyncBlockfetchTimeoutTimer    *time.Timer // timeout timer for blockfetch operations
 	chainsyncBlockfetchTimerGeneration uint64      // generation counter to detect stale timer callbacks
 	currentPParams                     lcommon.ProtocolParameters
-	prevEraPParams                     lcommon.ProtocolParameters // pparams from the immediately previous era (for era-1 TX validation)
-	transitionInfo                     hardfork.TransitionInfo    // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
-	hfiEvalDoneEpoch                   uint64                     // currentEpoch.EpochId for which the HFI tally has been kicked off (held under ls.RWMutex)
-	hfiEvalGeneration                  atomic.Uint64              // bumped on rollback to invalidate any in-flight HFI tally
-	hfiStabilityEvalInFlight           atomic.Bool                // guard against overlapping async HFI tallies
+	prevEraPParams                     lcommon.ProtocolParameters
+	transitionInfo                     hardfork.TransitionInfo
+	hfiEvalDoneEpoch                   uint64        // currentEpoch.EpochId for which the HFI tally has been kicked off (held under ls.RWMutex)
+	hfiEvalGeneration                  atomic.Uint64 // bumped on rollback to invalidate any in-flight HFI tally
+	hfiStabilityEvalInFlight           atomic.Bool   // guard against overlapping async HFI tallies
 	mempool                            MempoolProvider
 	timerCleanupConsumedUtxos          *time.Timer
 	Scheduler                          *Scheduler
@@ -559,7 +583,7 @@ type LedgerState struct {
 	slotBattleRecorder                 atomic.Pointer[slotBattleRecorderHolder]
 	cachedShape                        atomic.Pointer[hardfork.Shape]                  // lazy-built from CardanoNodeConfig; immutable for the LedgerState's lifetime
 	epochSnapshotHook                  atomic.Pointer[epochBoundarySnapshotHookHolder] // optional authoritative epoch-boundary snapshot capture (nil = event-driven fallback only)
-	reachedTip                         bool
+	reachedTip                         atomic.Bool
 	currentTip                         ochainsync.Tip
 	currentEpoch                       models.Epoch
 	dbWorkerPool                       *DatabaseWorkerPool
@@ -711,6 +735,7 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 		epochNonceHexCache: make(map[uint64]string),
 		validationEnabled:  cfg.ValidateHistorical,
 	}
+	ls.publishSnapshotsLocked()
 	// Cache configured chain checkpoints (keyed by block height) so the
 	// hot block-processing path does an O(1) lookup. Nil when the network
 	// config supplies no CheckpointsFile.
@@ -728,6 +753,75 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 	ls.storeSlotBattleRecorder(cfg.SlotBattleRecorder)
 	ls.leiosBackfill = newLeiosBackfiller(cfg)
 	return ls, nil
+}
+
+func cloneSnapshotBytes(value []byte) []byte {
+	return append([]byte(nil), value...)
+}
+
+func cloneTip(value ochainsync.Tip) ochainsync.Tip {
+	value.Point.Hash = cloneSnapshotBytes(value.Point.Hash)
+	return value
+}
+
+func cloneEpoch(value models.Epoch) models.Epoch {
+	value.Nonce = cloneSnapshotBytes(value.Nonce)
+	value.EvolvingNonce = cloneSnapshotBytes(value.EvolvingNonce)
+	value.CandidateNonce = cloneSnapshotBytes(value.CandidateNonce)
+	value.LastEpochBlockNonce = cloneSnapshotBytes(value.LastEpochBlockNonce)
+	return value
+}
+
+func cloneEpochs(values []models.Epoch) []models.Epoch {
+	ret := make([]models.Epoch, len(values))
+	for i := range values {
+		ret[i] = cloneEpoch(values[i])
+	}
+	return ret
+}
+
+// publishSnapshotsLocked publishes a consistent, immutable view of the
+// writer-owned fields. Callers must hold ls.Lock, except during construction
+// and single-threaded startup before the LedgerState is made visible.
+func (ls *LedgerState) publishSnapshotsLocked() {
+	ls.consensus.Store(&consensusSnapshot{
+		currentEpoch:   cloneEpoch(ls.currentEpoch),
+		currentEra:     ls.currentEra,
+		currentPParams: ls.currentPParams,
+		prevEraPParams: ls.prevEraPParams,
+		epochCache:     cloneEpochs(ls.epochCache),
+		transitionInfo: ls.transitionInfo,
+	})
+	ls.tip.Store(&tipSnapshot{
+		currentTip:           cloneTip(ls.currentTip),
+		currentTipBlockNonce: cloneSnapshotBytes(ls.currentTipBlockNonce),
+	})
+}
+
+func (ls *LedgerState) loadConsensusSnapshot() *consensusSnapshot {
+	if snapshot := ls.consensus.Load(); snapshot != nil {
+		return snapshot
+	}
+	// Support zero-value LedgerState fixtures. Production states initialize
+	// snapshots in NewLedgerState before they become concurrently visible.
+	return &consensusSnapshot{
+		currentEpoch:   cloneEpoch(ls.currentEpoch),
+		currentEra:     ls.currentEra,
+		currentPParams: ls.currentPParams,
+		prevEraPParams: ls.prevEraPParams,
+		epochCache:     cloneEpochs(ls.epochCache),
+		transitionInfo: ls.transitionInfo,
+	}
+}
+
+func (ls *LedgerState) loadTipSnapshot() *tipSnapshot {
+	if snapshot := ls.tip.Load(); snapshot != nil {
+		return snapshot
+	}
+	return &tipSnapshot{
+		currentTip:           cloneTip(ls.currentTip),
+		currentTipBlockNonce: cloneSnapshotBytes(ls.currentTipBlockNonce),
+	}
 }
 
 func (ls *LedgerState) eraList() []eras.EraDesc {
@@ -870,6 +964,13 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	ls.evaluateTriggerAtEpoch()
 	ls.evaluateTransitionImpossible()
 	ls.evaluateHardForkInitiationStability()
+	// Publish the transitionInfo changes made above (single-threaded startup,
+	// no lock required) before any snapshot-reading goroutine becomes
+	// runnable. Without this, a restart that reconstructs TransitionKnown /
+	// TransitionImpossible here would leave every snapshot-based reader
+	// (CurrentTransitionInfo, ConsensusModeForEpoch, ...) on the stale
+	// pre-loadTip() value until the next unrelated write path republishes.
+	ls.publishSnapshotsLocked()
 	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
 		return fmt.Errorf("failed to reconcile primary chain tip: %w", err)
 	}
@@ -1425,12 +1526,11 @@ func (ls *LedgerState) handleSlotTicks() {
 
 	for tick := range ls.slotTickChan {
 		// Get current state snapshot
-		ls.RLock()
-		currentEpoch := ls.currentEpoch
-		currentEra := ls.currentEra
-		currentPParams := ls.currentPParams
-		tipSlot := ls.currentTip.Point.Slot
-		ls.RUnlock()
+		consensusState := ls.loadConsensusSnapshot()
+		currentEpoch := consensusState.currentEpoch
+		currentEra := consensusState.currentEra
+		currentPParams := consensusState.currentPParams
+		tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
 
 		// Update wall-clock-based metrics every tick
 		// (must run even when chain is stalled or catching up)
@@ -2173,6 +2273,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	// the cutoff on a different fork after rollback.
 	ls.resetNextEpochNonceReady()
 	ls.updateTipMetrics(newTipDensity)
+	ls.publishSnapshotsLocked()
 	ls.Unlock()
 	if ls.config.EventBus != nil {
 		ls.config.EventBus.Publish(
@@ -2353,9 +2454,7 @@ func (ls *LedgerState) applyEraTransition(result *EraTransitionResult) {
 // validationEnabled (which starts true when ValidateHistorical is set),
 // reachedTip only flips when the node actually reaches the stability window.
 func (ls *LedgerState) IsAtTip() bool {
-	ls.RLock()
-	defer ls.RUnlock()
-	return ls.reachedTip
+	return ls.reachedTip.Load()
 }
 
 // calculateStabilityWindow returns the stability window based on the current era.
@@ -2467,10 +2566,7 @@ func (ls *LedgerState) calculateStabilityWindowForEra(eraId uint) uint64 {
 // CurrentTransitionInfo returns a snapshot of the current TransitionInfo
 // under a read lock.  Callers must not hold ls.RLock() when calling this.
 func (ls *LedgerState) CurrentTransitionInfo() hardfork.TransitionInfo {
-	ls.RLock()
-	ti := ls.transitionInfo
-	ls.RUnlock()
-	return ti
+	return ls.loadConsensusSnapshot().transitionInfo
 }
 
 func (ls *LedgerState) securityParamForEra(eraId uint) (uint64, bool) {
@@ -2865,7 +2961,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 	var bulkOptimizer metadata.BulkLoadOptimizer
 	bulkLoadActive := false
 	ls.RLock()
-	bulkLoadAllowed := !ls.validationEnabled && !ls.reachedTip
+	bulkLoadAllowed := !ls.validationEnabled && !ls.reachedTip.Load()
 	ls.RUnlock()
 	if bulkLoadAllowed {
 		if opt, ok := ls.db.Metadata().(metadata.BulkLoadOptimizer); ok {
@@ -3044,6 +3140,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// advanced ls.currentEra to a new era whose own successor may
 			// carry its own AtEpoch override.
 			ls.evaluateTriggerAtEpoch()
+			ls.publishSnapshotsLocked()
 			ls.Unlock()
 
 			// Update scheduler (thread-safe, no lock needed)
@@ -3658,7 +3755,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				if wantEnableValidation {
 					ls.validationEnabled = true
-					ls.reachedTip = true
+					ls.reachedTip.Store(true)
 				}
 				ls.updateTipMetrics(tipDensity)
 				// After advancing the tip, first honor any TestXHardForkAtEpoch
@@ -3674,6 +3771,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// Capture tip for logging while holding the lock
 				tipForLog = ls.currentTip
 				checker = ls.config.ForgedBlockChecker
+				ls.publishSnapshotsLocked()
 				ls.Unlock()
 				// Restore normal DB options outside the lock after validation is enabled
 				if wantEnableValidation && bulkLoadActive && bulkOptimizer != nil {
@@ -4274,6 +4372,7 @@ func (ls *LedgerState) loadPParams() error {
 	}
 	ls.currentPParams = pp
 	ls.prevEraPParams = prevPP
+	ls.publishSnapshotsLocked()
 	return nil
 }
 
@@ -4577,7 +4676,10 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 			return
 		}
 		ls.Lock()
-		defer ls.Unlock()
+		defer func() {
+			ls.publishSnapshotsLocked()
+			ls.Unlock()
+		}()
 		// Generation guard: a rollback that landed while the tally
 		// was running invalidated our snapshot. Drop the result
 		// rather than commit stale data — rollback's own call to
@@ -4774,6 +4876,7 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 		ls.currentEra = *eraDesc
 		// Update metrics
 		ls.metrics.epochNum.Set(float64(ls.currentEpoch.EpochId))
+		ls.publishSnapshotsLocked()
 		return nil
 	}
 	// Populate initial epoch
@@ -4836,6 +4939,7 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 	ls.currentPParams = rolloverResult.NewCurrentPParams
 	ls.checkpointWrittenForEpoch = rolloverResult.CheckpointWrittenForEpoch
 	ls.metrics.epochNum.Set(rolloverResult.NewEpochNum)
+	ls.publishSnapshotsLocked()
 	return nil
 }
 
@@ -5146,6 +5250,7 @@ func (ls *LedgerState) loadTip() error {
 		ls.currentTipBlockNonce = tipNonce
 	}
 	ls.updateTipMetrics(tipDensity)
+	ls.publishSnapshotsLocked()
 	ls.Unlock()
 	return nil
 }
@@ -5672,9 +5777,7 @@ func blockPrevHash(block models.Block) ([]byte, error) {
 func (ls *LedgerState) GetIntersectPoint(
 	points []ocommon.Point,
 ) (*ocommon.Point, error) {
-	ls.RLock()
-	tip := ls.currentTip
-	ls.RUnlock()
+	tip := ls.loadTipSnapshot().currentTip
 	// When the chain is empty (tip at origin), origin is the only
 	// valid intersect regardless of what points the peer sends.
 	// This allows peers to start chainsync before we have blocks.
@@ -5766,9 +5869,7 @@ func (ls *LedgerState) GetChainFromPointReverseContext(
 
 // Tip returns the current chain tip
 func (ls *LedgerState) Tip() ochainsync.Tip {
-	ls.RLock()
-	defer ls.RUnlock()
-	return ls.currentTip
+	return cloneTip(ls.loadTipSnapshot().currentTip)
 }
 
 // SlotsBehindHead reports how many slots the applied ledger tip is behind the
@@ -5791,9 +5892,7 @@ func (ls *LedgerState) SlotsBehindHead() uint64 {
 
 // ChainTipSlot returns the slot number of the current chain tip.
 func (ls *LedgerState) ChainTipSlot() uint64 {
-	ls.RLock()
-	defer ls.RUnlock()
-	return ls.currentTip.Point.Slot
+	return ls.loadTipSnapshot().currentTip.Point.Slot
 }
 
 // PrimaryChainTip returns the tip of the primary chain. This can be ahead of
@@ -5824,9 +5923,7 @@ func (ls *LedgerState) UpstreamTipSlot() uint64 {
 
 // GetCurrentPParams returns the currentPParams value
 func (ls *LedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
-	ls.RLock()
-	defer ls.RUnlock()
-	return ls.currentPParams
+	return ls.loadConsensusSnapshot().currentPParams
 }
 
 // ProtocolParamsForSlot returns the protocol parameters that should
@@ -5849,11 +5946,10 @@ func (ls *LedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
 func (ls *LedgerState) ProtocolParamsForSlot(
 	slot uint64,
 ) lcommon.ProtocolParameters {
-	ls.RLock()
-	currentEpoch := ls.currentEpoch
-	currentEra := ls.currentEra
-	currentPParams := ls.currentPParams
-	ls.RUnlock()
+	snapshot := ls.loadConsensusSnapshot()
+	currentEpoch := snapshot.currentEpoch
+	currentEra := snapshot.currentEra
+	currentPParams := snapshot.currentPParams
 
 	if currentPParams == nil || currentEpoch.LengthInSlots == 0 {
 		return currentPParams
@@ -5915,9 +6011,7 @@ func (ls *LedgerState) ProtocolParamsForSlot(
 
 // CurrentEpoch returns the current epoch number.
 func (ls *LedgerState) CurrentEpoch() uint64 {
-	ls.RLock()
-	defer ls.RUnlock()
-	return ls.currentEpoch.EpochId
+	return ls.loadConsensusSnapshot().currentEpoch.EpochId
 }
 
 // ConsensusModeForEpoch returns the Praos consensus variant that
@@ -5942,12 +6036,11 @@ func (ls *LedgerState) CurrentEpoch() uint64 {
 //     boundary at-or-before the target epoch.
 //  4. Fall back to the current era if nothing applies.
 func (ls *LedgerState) ConsensusModeForEpoch(epoch uint64) consensus.ConsensusMode {
-	ls.RLock()
-	cache := ls.epochCache
-	currentEra := ls.currentEra
-	currentEpoch := ls.currentEpoch
-	transitionInfo := ls.transitionInfo
-	ls.RUnlock()
+	snapshot := ls.loadConsensusSnapshot()
+	cache := snapshot.epochCache
+	currentEra := snapshot.currentEra
+	currentEpoch := snapshot.currentEpoch
+	transitionInfo := snapshot.transitionInfo
 
 	for _, e := range cache {
 		if e.EpochId == epoch {
@@ -6013,11 +6106,10 @@ func consensusModeForEraID(eraID uint) consensus.ConsensusMode {
 // epoch has already crossed the nonce stability cutoff and the next leader
 // schedule can be precomputed immediately.
 func (ls *LedgerState) NextEpochNonceReadyEpoch() (uint64, bool) {
-	ls.RLock()
-	currentEpoch := ls.currentEpoch
-	currentEra := ls.currentEra
-	tipSlot := ls.currentTip.Point.Slot
-	ls.RUnlock()
+	consensusState := ls.loadConsensusSnapshot()
+	currentEpoch := consensusState.currentEpoch
+	currentEra := consensusState.currentEra
+	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
 
 	if currentEra.Id == 0 {
 		return 0, false
@@ -6060,18 +6152,14 @@ func (ls *LedgerState) NextEpochNonceReadyEpoch() (uint64, bool) {
 // the forging gap at epoch boundaries where the leader schedule would
 // otherwise be unavailable until a peer's block triggers epoch rollover.
 func (ls *LedgerState) EpochNonce(epoch uint64) []byte {
-	ls.RLock()
-	// Check current epoch under read lock; copy nonce if it matches
-	if epoch == ls.currentEpoch.EpochId {
-		if len(ls.currentEpoch.Nonce) > 0 {
-			nonce := make([]byte, len(ls.currentEpoch.Nonce))
-			copy(nonce, ls.currentEpoch.Nonce)
-			ls.RUnlock()
-			return nonce
+	snapshot := ls.loadConsensusSnapshot()
+	currentEpoch := snapshot.currentEpoch
+	if epoch == currentEpoch.EpochId {
+		if len(currentEpoch.Nonce) > 0 {
+			return cloneSnapshotBytes(currentEpoch.Nonce)
 		}
 		// In-memory nonce empty (e.g. after Mithril import) —
 		// fall through to DB lookup
-		ls.RUnlock()
 		ep, err := ls.db.GetEpoch(epoch, nil)
 		if err != nil {
 			ls.config.Logger.Error(
@@ -6084,26 +6172,22 @@ func (ls *LedgerState) EpochNonce(epoch uint64) []byte {
 		if ep == nil || len(ep.Nonce) == 0 {
 			return nil
 		}
-		nonce := make([]byte, len(ep.Nonce))
-		copy(nonce, ep.Nonce)
-		return nonce
+		return cloneSnapshotBytes(ep.Nonce)
 	}
 	// If the requested epoch is ahead of the ledger state (slot clock
 	// fired an epoch transition before block processing caught up),
 	// try to compute the nonce speculatively for the immediate next
 	// epoch. The nonce depends only on data from the current (ending)
 	// epoch, so it is computable before block processing catches up.
-	if epoch > ls.currentEpoch.EpochId {
-		if epoch == ls.currentEpoch.EpochId+1 {
-			currentEpoch := ls.currentEpoch
-			currentEra := ls.currentEra
-			ls.RUnlock()
-			return ls.computeNextEpochNonce(currentEpoch, currentEra)
+	if epoch > currentEpoch.EpochId {
+		if epoch == currentEpoch.EpochId+1 {
+			return ls.computeNextEpochNonce(
+				currentEpoch,
+				snapshot.currentEra,
+			)
 		}
-		ls.RUnlock()
 		return nil
 	}
-	ls.RUnlock()
 
 	// For historical epochs, look up in database without holding the lock
 	ep, err := ls.db.GetEpoch(epoch, nil)
@@ -6119,9 +6203,7 @@ func (ls *LedgerState) EpochNonce(epoch uint64) []byte {
 		return nil
 	}
 	// Return a defensive copy so callers cannot mutate internal state
-	nonce := make([]byte, len(ep.Nonce))
-	copy(nonce, ep.Nonce)
-	return nonce
+	return cloneSnapshotBytes(ep.Nonce)
 }
 
 // nextEpochNonceReadyCutoffSlot returns the slot at which the current epoch's
@@ -6183,9 +6265,7 @@ func (ls *LedgerState) computeNextEpochNonce(
 
 // SlotsPerEpoch returns the number of slots in an epoch for the current era.
 func (ls *LedgerState) SlotsPerEpoch() uint64 {
-	ls.RLock()
-	currentEra := ls.currentEra
-	ls.RUnlock()
+	currentEra := ls.loadConsensusSnapshot().currentEra
 
 	if currentEra.EpochLengthFunc == nil {
 		return 0
@@ -6596,12 +6676,11 @@ func (ls *LedgerState) validateTxCore(
 	tx lcommon.Transaction,
 	buildLV func(txn *database.Txn) *LedgerView,
 ) error {
-	ls.RLock()
-	snapshotEra := ls.currentEra
-	snapshotTipSlot := ls.currentTip.Point.Slot
-	snapshotPParams := ls.currentPParams
-	snapshotPrevEraPParams := ls.prevEraPParams
-	ls.RUnlock()
+	consensusState := ls.loadConsensusSnapshot()
+	snapshotEra := consensusState.currentEra
+	snapshotTipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	snapshotPParams := consensusState.currentPParams
+	snapshotPrevEraPParams := consensusState.prevEraPParams
 	currentSlot, currentSlotErr := ls.CurrentSlot()
 	if currentSlotErr != nil {
 		ls.config.Logger.Debug(
@@ -6684,12 +6763,11 @@ func (ls *LedgerState) ValidateTxWithOverlay(
 func (ls *LedgerState) EvaluateTx(
 	tx lcommon.Transaction,
 ) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error) {
-	// Snapshot mutable state under read lock to avoid data races
-	ls.RLock()
-	snapshotEra := ls.currentEra
-	snapshotPParams := ls.currentPParams
-	snapshotPrevEraPParams := ls.prevEraPParams
-	ls.RUnlock()
+	// Snapshot mutable state from the lock-free consensus snapshot
+	consensusState := ls.loadConsensusSnapshot()
+	snapshotEra := consensusState.currentEra
+	snapshotPParams := consensusState.currentPParams
+	snapshotPrevEraPParams := consensusState.prevEraPParams
 
 	validationEra, err := resolveValidationEra(
 		tx,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -826,11 +826,6 @@ func (ls *LedgerState) loadStateSnapshots() (
 	for {
 		consensusState := ls.consensus.Load()
 		tipState := ls.tip.Load()
-		if consensusState == nil || tipState == nil {
-			// Support zero-value white-box fixtures. Production states publish
-			// both snapshots in NewLedgerState before becoming visible.
-			return ls.loadConsensusSnapshot(), ls.loadTipSnapshot()
-		}
 		if consensusState.generation == tipState.generation {
 			return consensusState, tipState
 		}
@@ -838,31 +833,21 @@ func (ls *LedgerState) loadStateSnapshots() (
 }
 
 func (ls *LedgerState) loadConsensusSnapshot() *consensusSnapshot {
-	if snapshot := ls.consensus.Load(); snapshot != nil {
-		return snapshot
-	}
-	// Support zero-value LedgerState fixtures. Production states initialize
-	// snapshots in NewLedgerState before they become concurrently visible.
-	return &consensusSnapshot{
-		generation:     ls.snapshotGeneration,
-		currentEpoch:   cloneEpoch(ls.currentEpoch),
-		currentEra:     ls.currentEra,
-		currentPParams: ls.currentPParams,
-		prevEraPParams: ls.prevEraPParams,
-		epochCache:     cloneEpochs(ls.epochCache),
-		transitionInfo: ls.transitionInfo,
-	}
+	return ls.consensus.Load()
 }
 
 func (ls *LedgerState) loadTipSnapshot() *tipSnapshot {
-	if snapshot := ls.tip.Load(); snapshot != nil {
-		return snapshot
-	}
-	return &tipSnapshot{
-		generation:           ls.snapshotGeneration,
-		currentTip:           cloneTip(ls.currentTip),
-		currentTipBlockNonce: cloneSnapshotBytes(ls.currentTipBlockNonce),
-	}
+	return ls.tip.Load()
+}
+
+// SetTipForTesting replaces the in-memory tip and publishes a matching
+// snapshot generation. It exists for black-box tests that cannot use the
+// ledger package's white-box snapshot helpers.
+func (ls *LedgerState) SetTipForTesting(tip ochainsync.Tip) {
+	ls.Lock()
+	defer ls.Unlock()
+	ls.currentTip = cloneTip(tip)
+	ls.publishSnapshotsLocked()
 }
 
 func (ls *LedgerState) eraList() []eras.EraDesc {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -797,7 +797,10 @@ func (ls *LedgerState) publishSnapshotsLocked() {
 		currentEra:     ls.currentEra,
 		currentPParams: ls.currentPParams,
 		prevEraPParams: ls.prevEraPParams,
-		epochCache:     cloneEpochs(ls.epochCache),
+		// epochCache is immutable after publication. Writers replace it with a
+		// fresh slice, so tip-only publications can safely reuse the existing
+		// cache instead of copying the full epoch history for every block.
+		epochCache:     ls.epochCache,
 		transitionInfo: ls.transitionInfo,
 	})
 	ls.tip.Store(&tipSnapshot{
@@ -996,13 +999,17 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	ls.evaluateTriggerAtEpoch()
 	ls.evaluateTransitionImpossible()
 	ls.evaluateHardForkInitiationStability()
-	// Publish the transitionInfo changes made above (single-threaded startup,
-	// no lock required) before any snapshot-reading goroutine becomes
-	// runnable. Without this, a restart that reconstructs TransitionKnown /
+	// Publish the transitionInfo changes made above before any snapshot-reading
+	// goroutine becomes runnable. The HFI stability evaluation above may launch
+	// an asynchronous tally, so serialize this publication with its completion
+	// path and every other snapshot writer. Without this, a restart that
+	// reconstructs TransitionKnown /
 	// TransitionImpossible here would leave every snapshot-based reader
 	// (CurrentTransitionInfo, ConsensusModeForEpoch, ...) on the stale
 	// pre-loadTip() value until the next unrelated write path republishes.
+	ls.Lock()
 	ls.publishSnapshotsLocked()
+	ls.Unlock()
 	if err := ls.reconcilePrimaryChainTipWithLedgerTip(); err != nil {
 		return fmt.Errorf("failed to reconcile primary chain tip: %w", err)
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -535,6 +535,7 @@ type slotBattleRecorderHolder struct {
 // as one logical unit at epoch/era boundaries and during rollback. Published
 // snapshots are immutable.
 type consensusSnapshot struct {
+	generation     uint64
 	currentEpoch   models.Epoch
 	currentEra     eras.EraDesc
 	currentPParams lcommon.ProtocolParameters
@@ -546,6 +547,7 @@ type consensusSnapshot struct {
 // tipSnapshot contains the applied tip and the Praos block nonce belonging to
 // that tip. Published snapshots are immutable.
 type tipSnapshot struct {
+	generation           uint64
 	currentTip           ochainsync.Tip
 	currentTipBlockNonce []byte
 }
@@ -554,6 +556,9 @@ type LedgerState struct {
 	metrics   stateMetrics
 	consensus atomic.Pointer[consensusSnapshot]
 	tip       atomic.Pointer[tipSnapshot]
+	// snapshotGeneration is incremented while writers are serialized by Lock.
+	// It lets readers that need both snapshots reject adjacent publications.
+	snapshotGeneration uint64
 	// The fields below are writer-owned working state. Lock-free readers use
 	// consensus and tip snapshots; writers update these fields under Lock and
 	// publish a fresh immutable snapshot before unlocking.
@@ -784,7 +789,10 @@ func cloneEpochs(values []models.Epoch) []models.Epoch {
 // writer-owned fields. Callers must hold ls.Lock, except during construction
 // and single-threaded startup before the LedgerState is made visible.
 func (ls *LedgerState) publishSnapshotsLocked() {
+	ls.snapshotGeneration++
+	generation := ls.snapshotGeneration
 	ls.consensus.Store(&consensusSnapshot{
+		generation:     generation,
 		currentEpoch:   cloneEpoch(ls.currentEpoch),
 		currentEra:     ls.currentEra,
 		currentPParams: ls.currentPParams,
@@ -793,9 +801,31 @@ func (ls *LedgerState) publishSnapshotsLocked() {
 		transitionInfo: ls.transitionInfo,
 	})
 	ls.tip.Store(&tipSnapshot{
+		generation:           generation,
 		currentTip:           cloneTip(ls.currentTip),
 		currentTipBlockNonce: cloneSnapshotBytes(ls.currentTipBlockNonce),
 	})
+}
+
+// loadStateSnapshots returns consensus and tip state from the same publication
+// generation. A writer stores the two pointers sequentially, so readers that
+// need both retry during the small interval between those stores.
+func (ls *LedgerState) loadStateSnapshots() (
+	*consensusSnapshot,
+	*tipSnapshot,
+) {
+	for {
+		consensusState := ls.consensus.Load()
+		tipState := ls.tip.Load()
+		if consensusState == nil || tipState == nil {
+			// Support zero-value white-box fixtures. Production states publish
+			// both snapshots in NewLedgerState before becoming visible.
+			return ls.loadConsensusSnapshot(), ls.loadTipSnapshot()
+		}
+		if consensusState.generation == tipState.generation {
+			return consensusState, tipState
+		}
+	}
 }
 
 func (ls *LedgerState) loadConsensusSnapshot() *consensusSnapshot {
@@ -805,6 +835,7 @@ func (ls *LedgerState) loadConsensusSnapshot() *consensusSnapshot {
 	// Support zero-value LedgerState fixtures. Production states initialize
 	// snapshots in NewLedgerState before they become concurrently visible.
 	return &consensusSnapshot{
+		generation:     ls.snapshotGeneration,
 		currentEpoch:   cloneEpoch(ls.currentEpoch),
 		currentEra:     ls.currentEra,
 		currentPParams: ls.currentPParams,
@@ -819,6 +850,7 @@ func (ls *LedgerState) loadTipSnapshot() *tipSnapshot {
 		return snapshot
 	}
 	return &tipSnapshot{
+		generation:           ls.snapshotGeneration,
 		currentTip:           cloneTip(ls.currentTip),
 		currentTipBlockNonce: cloneSnapshotBytes(ls.currentTipBlockNonce),
 	}
@@ -1526,11 +1558,11 @@ func (ls *LedgerState) handleSlotTicks() {
 
 	for tick := range ls.slotTickChan {
 		// Get current state snapshot
-		consensusState := ls.loadConsensusSnapshot()
+		consensusState, tipState := ls.loadStateSnapshots()
 		currentEpoch := consensusState.currentEpoch
 		currentEra := consensusState.currentEra
 		currentPParams := consensusState.currentPParams
-		tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+		tipSlot := tipState.currentTip.Point.Slot
 
 		// Update wall-clock-based metrics every tick
 		// (must run even when chain is stalled or catching up)
@@ -2563,8 +2595,8 @@ func (ls *LedgerState) calculateStabilityWindowForEra(eraId uint) uint64 {
 	return window.Uint64()
 }
 
-// CurrentTransitionInfo returns a snapshot of the current TransitionInfo
-// under a read lock.  Callers must not hold ls.RLock() when calling this.
+// CurrentTransitionInfo returns the current TransitionInfo from the lock-free
+// consensus snapshot.
 func (ls *LedgerState) CurrentTransitionInfo() hardfork.TransitionInfo {
 	return ls.loadConsensusSnapshot().transitionInfo
 }
@@ -6106,10 +6138,10 @@ func consensusModeForEraID(eraID uint) consensus.ConsensusMode {
 // epoch has already crossed the nonce stability cutoff and the next leader
 // schedule can be precomputed immediately.
 func (ls *LedgerState) NextEpochNonceReadyEpoch() (uint64, bool) {
-	consensusState := ls.loadConsensusSnapshot()
+	consensusState, tipState := ls.loadStateSnapshots()
 	currentEpoch := consensusState.currentEpoch
 	currentEra := consensusState.currentEra
-	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	tipSlot := tipState.currentTip.Point.Slot
 
 	if currentEra.Id == 0 {
 		return 0, false
@@ -6676,9 +6708,9 @@ func (ls *LedgerState) validateTxCore(
 	tx lcommon.Transaction,
 	buildLV func(txn *database.Txn) *LedgerView,
 ) error {
-	consensusState := ls.loadConsensusSnapshot()
+	consensusState, tipState := ls.loadStateSnapshots()
 	snapshotEra := consensusState.currentEra
-	snapshotTipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	snapshotTipSlot := tipState.currentTip.Point.Slot
 	snapshotPParams := consensusState.currentPParams
 	snapshotPrevEraPParams := consensusState.prevEraPParams
 	currentSlot, currentSlotErr := ls.CurrentSlot()

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -5009,6 +5009,8 @@ func (ls *LedgerState) setEpochCache(txn *database.Txn, epochs []models.Epoch) e
 // repair needs no candidate; the nonce repair is skipped when the candidate is
 // missing/invalid or the previous epoch's lab could not be verified. It is a
 // pure function of already-stored chain data and is idempotent across restarts.
+// The writer-owned epoch cache must have been replaced with a fresh DB-loaded
+// slice and must not have been published before this in-place repair runs.
 func (ls *LedgerState) healEmptyLabNonces() {
 	if ls.healEmptyLabNoncesInPlace(ls.epochCache) {
 		clear(ls.epochNonceHexCache)
@@ -5028,6 +5030,9 @@ func (ls *LedgerState) healEmptyLabNonces() {
 // processed.
 const healLabNonceRecentEpochs = 8
 
+// healEmptyLabNoncesInPlace mutates epoch entries and their nonce slices.
+// Callers must pass a freshly owned, unpublished slice; passing an epoch cache
+// already exposed through consensusSnapshot would corrupt concurrent readers.
 func (ls *LedgerState) healEmptyLabNoncesInPlace(epochs []models.Epoch) bool {
 	repaired := false
 	var (

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -990,11 +990,11 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	ls.evaluateTriggerAtEpoch()
 	ls.evaluateTransitionImpossible()
 	ls.evaluateHardForkInitiationStability()
-	// Publish the transitionInfo changes made above before any snapshot-reading
-	// goroutine becomes runnable. The HFI stability evaluation above may launch
-	// an asynchronous tally, so serialize this publication with its completion
-	// path and every other snapshot writer. Without this, a restart that
-	// reconstructs TransitionKnown /
+	// Publish the transitionInfo changes made above so snapshot readers observe
+	// the reconstructed startup state. The HFI stability evaluation above may
+	// launch an asynchronous tally, so serialize this publication with its
+	// completion path and every other snapshot writer. Without this, a restart
+	// that reconstructs TransitionKnown /
 	// TransitionImpossible here would leave every snapshot-based reader
 	// (CurrentTransitionInfo, ConsensusModeForEpoch, ...) on the stale
 	// pre-loadTip() value until the next unrelated write path republishes.
@@ -4706,8 +4706,11 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 			return
 		}
 		ls.Lock()
+		shouldPublish := false
 		defer func() {
-			ls.publishSnapshotsLocked()
+			if shouldPublish {
+				ls.publishSnapshotsLocked()
+			}
 			ls.Unlock()
 		}()
 		// Generation guard: a rollback that landed while the tally
@@ -4730,6 +4733,7 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 		ls.transitionInfo = hardfork.NewTransitionKnown(
 			ls.currentEpoch.EpochId + 1,
 		)
+		shouldPublish = true
 	}()
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -533,7 +533,8 @@ type slotBattleRecorderHolder struct {
 
 // consensusSnapshot contains ledger state that is read frequently and updated
 // as one logical unit at epoch/era boundaries and during rollback. Published
-// snapshots are immutable.
+// snapshot containers and their owned slices are immutable. Protocol parameter
+// values are shared with writer state and must be treated as read-only.
 type consensusSnapshot struct {
 	generation     uint64
 	currentEpoch   models.Epoch
@@ -791,15 +792,20 @@ func cloneEpochs(values []models.Epoch) []models.Epoch {
 func (ls *LedgerState) publishSnapshotsLocked() {
 	ls.snapshotGeneration++
 	generation := ls.snapshotGeneration
+	// Prevent a later append to the writer-owned slice from reusing storage
+	// visible to an already-published snapshot. Element updates still require
+	// replacing the cache and its slice-backed Epoch fields.
+	ls.epochCache = ls.epochCache[:len(ls.epochCache):len(ls.epochCache)]
 	ls.consensus.Store(&consensusSnapshot{
 		generation:     generation,
 		currentEpoch:   cloneEpoch(ls.currentEpoch),
 		currentEra:     ls.currentEra,
 		currentPParams: ls.currentPParams,
 		prevEraPParams: ls.prevEraPParams,
-		// epochCache is immutable after publication. Writers replace it with a
-		// fresh slice, so tip-only publications can safely reuse the existing
-		// cache instead of copying the full epoch history for every block.
+		// epochCache is immutable after publication. Writers replace it for
+		// element updates; its capped capacity also forces accidental appends to
+		// allocate. Tip-only publications can therefore safely reuse it instead
+		// of copying the full epoch history for every block.
 		epochCache:     ls.epochCache,
 		transitionInfo: ls.transitionInfo,
 	})

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -2,9 +2,13 @@ package ledger
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
@@ -68,6 +72,47 @@ func TestLedgerStatePublishedEpochCacheRejectsInPlaceAppend(t *testing.T) {
 	ls.epochCache = append(ls.epochCache, models.Epoch{EpochId: 8})
 	ls.epochCache[0].EpochId = 9
 
+	require.Len(t, oldConsensus.epochCache, 1)
+	require.Equal(t, uint64(7), oldConsensus.epochCache[0].EpochId)
+}
+
+// TestAdvanceEpochCachePreservesPublishedSnapshot exercises the production
+// writer and verifies that extending the cache cannot alter a retained view.
+func TestAdvanceEpochCachePreservesPublishedSnapshot(t *testing.T) {
+	// An empty nonce selects the deterministic initial-epoch path, allowing the
+	// production writer to run without seeding block-nonce database records.
+	initialEpoch := models.Epoch{
+		EpochId:       7,
+		StartSlot:     70,
+		LengthInSlots: 10,
+		SlotLength:    1_000,
+		EraId:         eras.ConwayEraDesc.Id,
+	}
+	ls := &LedgerState{
+		currentEpoch: initialEpoch,
+		currentEra:   eras.ConwayEraDesc,
+		epochCache:   []models.Epoch{initialEpoch},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: &cardano.CardanoNodeConfig{
+				ShelleyGenesisHash: strings.Repeat("01", 32),
+			},
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	// Keep the exact snapshot pointer that a concurrent reader may retain while
+	// advanceEpochCache publishes the next generation.
+	ls.publishSnapshotsLocked()
+	oldConsensus := ls.consensus.Load()
+
+	// Exercise the real header-verification writer rather than reproducing its
+	// copy-on-write logic inside this test.
+	require.NoError(t, ls.advanceEpochCache())
+
+	// The current view must advance, while the retained view must remain on the
+	// original cache and epoch values.
+	newConsensus := ls.consensus.Load()
+	require.Len(t, newConsensus.epochCache, 2)
+	require.Equal(t, uint64(8), newConsensus.epochCache[1].EpochId)
 	require.Len(t, oldConsensus.epochCache, 1)
 	require.Equal(t, uint64(7), oldConsensus.epochCache[0].EpochId)
 }

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -53,6 +53,25 @@ func TestLedgerStateSnapshotPublicationIsImmutable(t *testing.T) {
 	require.Equal(t, byte(17), oldTip.currentTipBlockNonce[0])
 }
 
+// TestLedgerStatePublishedEpochCacheRejectsInPlaceAppend verifies that
+// publication removes spare capacity from the writer's cache view. An
+// accidental append must allocate instead of extending storage shared with a
+// snapshot retained by a concurrent reader.
+func TestLedgerStatePublishedEpochCacheRejectsInPlaceAppend(t *testing.T) {
+	cache := make([]models.Epoch, 1, 2)
+	cache[0] = models.Epoch{EpochId: 7}
+	ls := &LedgerState{epochCache: cache}
+	ls.publishSnapshotsLocked()
+
+	oldConsensus := ls.consensus.Load()
+	require.Equal(t, len(ls.epochCache), cap(ls.epochCache))
+	ls.epochCache = append(ls.epochCache, models.Epoch{EpochId: 8})
+	ls.epochCache[0].EpochId = 9
+
+	require.Len(t, oldConsensus.epochCache, 1)
+	require.Equal(t, uint64(7), oldConsensus.epochCache[0].EpochId)
+}
+
 // TestLedgerStateTipGetterReturnsDefensiveHashCopy verifies that callers cannot
 // mutate the published tip hash through the value returned by Tip.
 func TestLedgerStateTipGetterReturnsDefensiveHashCopy(t *testing.T) {

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -137,3 +137,58 @@ func TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders(
 	default:
 	}
 }
+
+// TestLedgerStatePairedSnapshotsUseOneGeneration verifies that callers which
+// combine consensus and tip fields never observe adjacent publications while a
+// writer is between the two atomic stores.
+func TestLedgerStatePairedSnapshotsUseOneGeneration(t *testing.T) {
+	ls := &LedgerState{}
+	ls.publishSnapshotsLocked()
+
+	const generations = 1_000
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				consensusState, tipState := ls.loadStateSnapshots()
+				if consensusState.generation != tipState.generation ||
+					consensusState.currentEpoch.EpochId !=
+						tipState.currentTip.Point.Slot {
+					select {
+					case errCh <- fmt.Errorf(
+						"cross-snapshot generation was torn",
+					):
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	for generation := 1; generation <= generations; generation++ {
+		ls.Lock()
+		ls.currentEpoch.EpochId = uint64(generation)
+		ls.currentTip.Point.Slot = uint64(generation)
+		ls.publishSnapshotsLocked()
+		ls.Unlock()
+	}
+	close(done)
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -319,10 +319,11 @@ func TestLedgerStateTipGetterReturnsDefensiveHashCopy(t *testing.T) {
 	require.Equal(t, byte(1), ls.Tip().Point.Hash[0])
 }
 
-// TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders verifies that
-// readers never observe fields from different generations within either the
-// consensus snapshot or the tip snapshot while a writer repeatedly publishes.
-func TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders(
+// TestLedgerStateSnapshotLoadersDoNotRaceWithWriters guards the loader path
+// against regressing from atomic snapshot loads to reads of live writer-owned
+// fields. Intra-snapshot consistency itself is guaranteed by atomic.Pointer;
+// this test's primary value is its execution under the race detector.
+func TestLedgerStateSnapshotLoadersDoNotRaceWithWriters(
 	t *testing.T,
 ) {
 	ls := &LedgerState{}
@@ -333,8 +334,9 @@ func TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders(
 	errCh := make(chan error, 1)
 	done := make(chan struct{})
 
-	// Readers continuously validate generation markers encoded in the paired
-	// fields. Any mismatched marker would indicate a torn snapshot read.
+	// Readers continuously exercise both atomic loaders. Matching markers make
+	// an accidental return to independently-read live fields fail logically as
+	// well as through the race detector.
 	for range 8 {
 		wg.Add(1)
 		go func() {
@@ -349,7 +351,7 @@ func TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders(
 				if consensusState.currentEpoch.EpochId !=
 					uint64(consensusState.currentEra.Id) {
 					select {
-					case errCh <- fmt.Errorf("torn consensus snapshot"):
+					case errCh <- fmt.Errorf("inconsistent consensus read"):
 					default:
 					}
 					return
@@ -359,7 +361,7 @@ func TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders(
 					tipState.currentTip.Point.Slot !=
 						uint64(tipState.currentTipBlockNonce[0]) {
 					select {
-					case errCh <- fmt.Errorf("torn tip snapshot"):
+					case errCh <- fmt.Errorf("inconsistent tip read"):
 					default:
 					}
 					return

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -4,14 +4,18 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/big"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
@@ -115,6 +119,165 @@ func TestAdvanceEpochCachePreservesPublishedSnapshot(t *testing.T) {
 	require.Equal(t, uint64(8), newConsensus.epochCache[1].EpochId)
 	require.Len(t, oldConsensus.epochCache, 1)
 	require.Equal(t, uint64(7), oldConsensus.epochCache[0].EpochId)
+}
+
+// TestEpochRolloverPParamsClonePreservesPublishedSnapshot verifies that epoch
+// updates mutate a transaction-owned parameter value, not a retained snapshot.
+func TestEpochRolloverPParamsClonePreservesPublishedSnapshot(t *testing.T) {
+	rat := func() *cbor.Rat { return &cbor.Rat{Rat: big.NewRat(1, 2)} }
+	original := &shelley.ShelleyProtocolParameters{
+		MinFeeA:          44,
+		A0:               rat(),
+		Rho:              rat(),
+		Tau:              rat(),
+		Decentralization: rat(),
+	}
+	ls := &LedgerState{
+		currentEra:     eras.ShelleyEraDesc,
+		currentPParams: original,
+	}
+	ls.publishSnapshotsLocked()
+	oldConsensus := ls.consensus.Load()
+
+	// Use the same ownership boundary as processEpochRollover, then exercise
+	// the real era update function, which mutates its concrete pointer in place.
+	owned, err := cloneProtocolParametersForEra(
+		eras.ShelleyEraDesc,
+		oldConsensus.currentPParams,
+	)
+	require.NoError(t, err)
+	newMinFeeA := uint(99)
+	updated, err := eras.PParamsUpdateShelley(
+		owned,
+		shelley.ShelleyProtocolParameterUpdate{MinFeeA: &newMinFeeA},
+	)
+	require.NoError(t, err)
+	updatedShelley := updated.(*shelley.ShelleyProtocolParameters)
+
+	// The in-place scalar update must stay isolated from the protocol parameters
+	// held by the previously published snapshot.
+	oldShelley := oldConsensus.currentPParams.(*shelley.ShelleyProtocolParameters)
+	require.Equal(t, uint(44), oldShelley.MinFeeA)
+	require.Equal(t, uint(99), updatedShelley.MinFeeA)
+}
+
+// TestProcessEpochRolloverAppliesUpdateToOwnedCopy drives the real
+// processEpochRollover writer end-to-end with a pending on-chain pparam
+// update, so the era's update function runs and mutates its concrete
+// parameter pointer in place. A previously published snapshot's pparams must
+// stay untouched; only cloneProtocolParametersForEra's copy may change.
+func TestProcessEpochRolloverAppliesUpdateToOwnedCopy(t *testing.T) {
+	shelleyGenesisJSON := `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 432,
+		"epochLength": 432000,
+		"slotLength": 1,
+		"protocolParams": {
+			"protocolVersion": {"major": 2, "minor": 0},
+			"decentralisationParam": 1,
+			"maxBlockBodySize": 65536,
+			"maxBlockHeaderSize": 1100,
+			"maxTxSize": 16384,
+			"minFeeA": 44,
+			"minFeeB": 155381,
+			"minUTxOValue": 1000000,
+			"keyDeposit": 2000000,
+			"poolDeposit": 500000000,
+			"eMax": 18,
+			"nOpt": 150,
+			"a0": 0.3,
+			"rho": 0.003,
+			"tau": 0.2,
+			"minPoolCost": 340000000
+		},
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d",
+	}
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	currentEpoch := models.Epoch{
+		EpochId:       5,
+		StartSlot:     500,
+		SlotLength:    1000,
+		LengthInSlots: 100,
+		EraId:         eras.ShelleyEraDesc.Id,
+	}
+	require.NoError(t, db.SetEpoch(
+		currentEpoch.StartSlot, currentEpoch.EpochId,
+		nil, nil, nil, nil,
+		currentEpoch.EraId, currentEpoch.SlotLength, currentEpoch.LengthInSlots,
+		nil,
+	))
+
+	// A pending update targeting the rollover's next epoch. Quorum defaults
+	// to 0 (no UpdateQuorum in the genesis JSON above), so a single proposal
+	// is enough for ComputeAndApplyPParamUpdates to apply it.
+	newMinFeeA := uint(99)
+	updateCbor, err := cbor.Encode(&shelley.ShelleyProtocolParameterUpdate{
+		MinFeeA: &newMinFeeA,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.SetPParamUpdate(
+		[]byte{0x01, 0x02, 0x03},
+		updateCbor,
+		currentEpoch.StartSlot+1,
+		currentEpoch.EpochId+1,
+		nil,
+	))
+
+	rat := func() *cbor.Rat { return &cbor.Rat{Rat: big.NewRat(1, 2)} }
+	original := &shelley.ShelleyProtocolParameters{
+		MinFeeA:          44,
+		A0:               rat(),
+		Rho:              rat(),
+		Tau:              rat(),
+		Decentralization: rat(),
+	}
+	ls := &LedgerState{
+		db:             db,
+		currentEra:     eras.ShelleyEraDesc,
+		currentEpoch:   currentEpoch,
+		currentPParams: original,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+	oldConsensus := ls.consensus.Load()
+
+	var result *EpochRolloverResult
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		var rolloverErr error
+		result, rolloverErr = ls.processEpochRollover(
+			txn,
+			ls.currentEpoch,
+			ls.currentEra,
+			ls.currentPParams,
+		)
+		return rolloverErr
+	}))
+
+	updatedShelley, ok := result.NewCurrentPParams.(*shelley.ShelleyProtocolParameters)
+	require.True(t, ok)
+	require.Equal(t, uint(99), updatedShelley.MinFeeA)
+
+	oldShelley := oldConsensus.currentPParams.(*shelley.ShelleyProtocolParameters)
+	require.Equal(t, uint(44), oldShelley.MinFeeA)
 }
 
 // TestLedgerStateTipGetterReturnsDefensiveHashCopy verifies that callers cannot

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -1,0 +1,139 @@
+package ledger
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerStateSnapshotPublicationIsImmutable verifies that publishing a
+// replacement snapshot does not mutate snapshots retained by existing readers.
+func TestLedgerStateSnapshotPublicationIsImmutable(t *testing.T) {
+	ls := &LedgerState{
+		currentEpoch: models.Epoch{
+			EpochId: 7,
+			Nonce:   []byte{7},
+		},
+		epochCache: []models.Epoch{{EpochId: 7, Nonce: []byte{7}}},
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.Point{Slot: 70, Hash: []byte{7}},
+		},
+		currentTipBlockNonce: []byte{17},
+		transitionInfo:       hardfork.NewTransitionUnknown(),
+	}
+	// Publish the initial writer-owned state and retain the exact pointers a
+	// reader could still be using when a later update is published.
+	ls.publishSnapshotsLocked()
+
+	oldConsensus := ls.consensus.Load()
+	oldTip := ls.tip.Load()
+	// Mutate both the scalar and slice-backed writer state, then publish a new
+	// generation. The retained snapshots must continue to expose generation 7.
+	ls.currentEpoch.EpochId = 8
+	ls.currentEpoch.Nonce[0] = 8
+	ls.epochCache[0].Nonce[0] = 8
+	ls.currentTip.Point.Hash[0] = 8
+	ls.currentTipBlockNonce[0] = 18
+	ls.publishSnapshotsLocked()
+
+	require.Equal(t, uint64(7), oldConsensus.currentEpoch.EpochId)
+	require.Equal(t, byte(7), oldConsensus.currentEpoch.Nonce[0])
+	require.Equal(t, byte(7), oldConsensus.epochCache[0].Nonce[0])
+	require.Equal(t, byte(7), oldTip.currentTip.Point.Hash[0])
+	require.Equal(t, byte(17), oldTip.currentTipBlockNonce[0])
+}
+
+// TestLedgerStateTipGetterReturnsDefensiveHashCopy verifies that callers cannot
+// mutate the published tip hash through the value returned by Tip.
+func TestLedgerStateTipGetterReturnsDefensiveHashCopy(t *testing.T) {
+	ls := &LedgerState{currentTip: ochainsync.Tip{
+		Point: ocommon.Point{Slot: 1, Hash: []byte{1, 2, 3}},
+	}}
+	ls.publishSnapshotsLocked()
+
+	// Mutate only the caller-owned return value. A subsequent read must still
+	// return the hash stored in the immutable tip snapshot.
+	tip := ls.Tip()
+	tip.Point.Hash[0] = 9
+	require.Equal(t, byte(1), ls.Tip().Point.Hash[0])
+}
+
+// TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders verifies that
+// readers never observe fields from different generations within either the
+// consensus snapshot or the tip snapshot while a writer repeatedly publishes.
+func TestLedgerStateSnapshotsStayConsistentWithConcurrentReaders(
+	t *testing.T,
+) {
+	ls := &LedgerState{}
+	ls.publishSnapshotsLocked()
+
+	const generations = 500
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+
+	// Readers continuously validate generation markers encoded in the paired
+	// fields. Any mismatched marker would indicate a torn snapshot read.
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				consensusState := ls.loadConsensusSnapshot()
+				if consensusState.currentEpoch.EpochId !=
+					uint64(consensusState.currentEra.Id) {
+					select {
+					case errCh <- fmt.Errorf("torn consensus snapshot"):
+					default:
+					}
+					return
+				}
+				tipState := ls.loadTipSnapshot()
+				if len(tipState.currentTipBlockNonce) > 0 &&
+					tipState.currentTip.Point.Slot !=
+						uint64(tipState.currentTipBlockNonce[0]) {
+					select {
+					case errCh <- fmt.Errorf("torn tip snapshot"):
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	// Publish many generations while all readers are active. The existing
+	// LedgerState lock continues to serialize writers; readers use only atomics.
+	for generation := 1; generation <= generations; generation++ {
+		marker := byte(generation % 256)
+		ls.Lock()
+		ls.currentEpoch.EpochId = uint64(marker)
+		ls.currentEra.Id = uint(marker)
+		ls.currentTip.Point.Slot = uint64(marker)
+		ls.currentTipBlockNonce = []byte{marker}
+		ls.publishSnapshotsLocked()
+		ls.Unlock()
+	}
+	close(done)
+	wg.Wait()
+	// Report the first consistency failure, if any. The channel is buffered so
+	// a reader can record an error without blocking other goroutines.
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -35,10 +35,12 @@ func TestLedgerStateSnapshotPublicationIsImmutable(t *testing.T) {
 
 	oldConsensus := ls.consensus.Load()
 	oldTip := ls.tip.Load()
-	// Mutate both the scalar and slice-backed writer state, then publish a new
-	// generation. The retained snapshots must continue to expose generation 7.
+	// Replace slice-backed epoch-cache state before mutation, matching the
+	// production copy-on-write invariant, then publish a new generation. The
+	// retained snapshots must continue to expose generation 7.
 	ls.currentEpoch.EpochId = 8
 	ls.currentEpoch.Nonce[0] = 8
+	ls.epochCache = cloneEpochs(ls.epochCache)
 	ls.epochCache[0].Nonce[0] = 8
 	ls.currentTip.Point.Hash[0] = 8
 	ls.currentTipBlockNonce[0] = 18

--- a/ledger/state_snapshot_test.go
+++ b/ledger/state_snapshot_test.go
@@ -80,6 +80,30 @@ func TestLedgerStatePublishedEpochCacheRejectsInPlaceAppend(t *testing.T) {
 	require.Equal(t, uint64(7), oldConsensus.epochCache[0].EpochId)
 }
 
+// TestSetEpochCachePublishesPartialStateOnError verifies that startup cache
+// mutations are published even when validation returns an error afterward.
+func TestSetEpochCachePublishesPartialStateOnError(t *testing.T) {
+	ls := &LedgerState{}
+	ls.publishSnapshotsLocked()
+	previousGeneration := ls.consensus.Load().generation
+	invalidEpoch := models.Epoch{
+		EpochId:   7,
+		StartSlot: 0,
+		EraId:     ^uint(0),
+	}
+
+	err := ls.setEpochCache(nil, []models.Epoch{invalidEpoch})
+	require.ErrorContains(t, err, "unknown era ID")
+
+	// The deferred publication must expose the mutation through the atomic
+	// reader path despite setEpochCache returning before normal completion.
+	snapshot := ls.consensus.Load()
+	require.Equal(t, previousGeneration+1, snapshot.generation)
+	require.Equal(t, invalidEpoch.EpochId, snapshot.currentEpoch.EpochId)
+	require.Equal(t, invalidEpoch.EraId, snapshot.currentEpoch.EraId)
+	require.Len(t, snapshot.epochCache, 1)
+}
+
 // TestAdvanceEpochCachePreservesPublishedSnapshot exercises the production
 // writer and verifies that extending the cache cannot alter a retained view.
 func TestAdvanceEpochCachePreservesPublishedSnapshot(t *testing.T) {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -968,7 +968,7 @@ func newNonceReadyTestLedgerState(
 ) *LedgerState {
 	t.Helper()
 
-	return &LedgerState{
+	ls := &LedgerState{
 		currentEra: eras.ShelleyEraDesc,
 		currentEpoch: models.Epoch{
 			EpochId:             10,
@@ -991,6 +991,8 @@ func newNonceReadyTestLedgerState(
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
+	return ls
 }
 
 func TestLedgerStateIsNearTipUsesStabilityWindow(t *testing.T) {
@@ -1111,6 +1113,7 @@ func TestNextEpochNonceReadyEpoch(t *testing.T) {
 		},
 	}
 	ls.syncUpstreamTipSlot.Store(1100)
+	ls.publishSnapshotsLocked()
 
 	readyEpoch, ok := ls.NextEpochNonceReadyEpoch()
 	require.True(t, ok)
@@ -1158,6 +1161,7 @@ func TestComputeNextEpochNonceUsesImportedTipAnchor(t *testing.T) {
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	got := ls.computeNextEpochNonce(ls.currentEpoch, ls.currentEra)
 	require.Equal(t, candidateNonce, got)
@@ -1224,6 +1228,7 @@ func TestNextEpochNonceReadyEpochNotReadyBeforeCutoff(t *testing.T) {
 		},
 	}
 	ls.syncUpstreamTipSlot.Store(1100)
+	ls.publishSnapshotsLocked()
 
 	readyEpoch, ok := ls.NextEpochNonceReadyEpoch()
 	require.False(t, ok)

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -683,9 +683,7 @@ func decentralizationParamRat(
 }
 
 func (ls *LedgerState) ledgerTipBehindSlot(slot uint64) bool {
-	ls.RLock()
-	defer ls.RUnlock()
-	return ls.currentTip.Point.Slot < slot
+	return ls.loadTipSnapshot().currentTip.Point.Slot < slot
 }
 
 // verifyBlockLeaderEligibility checks that the block's producer pool was
@@ -1138,22 +1136,20 @@ func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {
 	return nonceHex
 }
 
-// epochForSlot searches the epoch cache for the epoch containing the
-// given slot. It takes a snapshot of the epoch cache under RLock to
-// avoid racing with concurrent epoch rollover updates.
+// epochForSlot searches an immutable epoch-cache snapshot for the epoch
+// containing the given slot.
 //
 // Returns the matching epoch or an error if no epoch covers the slot.
 func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
-	ls.RLock()
-	defer ls.RUnlock()
+	cache := ls.loadConsensusSnapshot().epochCache
 
-	if len(ls.epochCache) == 0 {
+	if len(cache) == 0 {
 		return models.Epoch{}, errors.New("epoch cache is empty")
 	}
 
 	// Search newest-to-oldest so that if cache entries overlap
 	// (e.g., after rollback/rebuild), we use the most recent epoch data.
-	for _, ep := range slices.Backward(ls.epochCache) {
+	for _, ep := range slices.Backward(cache) {
 		if ep.LengthInSlots == 0 {
 			continue
 		}
@@ -1167,7 +1163,7 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 	// meaningful error message.
 	var lastValidEnd uint64
 	var hasValidEpoch bool
-	for _, v := range slices.Backward(ls.epochCache) {
+	for _, v := range slices.Backward(cache) {
 		if v.LengthInSlots > 0 {
 			lastValidEnd = v.StartSlot +
 				uint64(v.LengthInSlots)
@@ -1179,13 +1175,13 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 		return models.Epoch{}, fmt.Errorf(
 			"slot %d not covered by any known epoch (cache has %d epochs, all with zero length)",
 			slot,
-			len(ls.epochCache),
+			len(cache),
 		)
 	}
 	return models.Epoch{}, fmt.Errorf(
 		"slot %d not covered by any known epoch (cache has %d epochs, last ends at slot %d)",
 		slot,
-		len(ls.epochCache),
+		len(cache),
 		lastValidEnd,
 	)
 }
@@ -1227,14 +1223,12 @@ func (ls *LedgerState) ensureEpochForSlot(
 // The full rollover will run later in ledgerProcessBlocks and replace
 // the cache with the authoritative DB-backed version.
 func (ls *LedgerState) advanceEpochCache() error {
-	// Read last epoch under read lock
-	ls.RLock()
-	if len(ls.epochCache) == 0 {
-		ls.RUnlock()
+	// Read last epoch from the lock-free consensus snapshot
+	cache := ls.loadConsensusSnapshot().epochCache
+	if len(cache) == 0 {
 		return errors.New("epoch cache is empty")
 	}
-	lastEpoch := ls.epochCache[len(ls.epochCache)-1]
-	ls.RUnlock()
+	lastEpoch := cache[len(cache)-1]
 
 	if lastEpoch.LengthInSlots == 0 {
 		return errors.New("last epoch has zero length")
@@ -1287,7 +1281,10 @@ func (ls *LedgerState) advanceEpochCache() error {
 		ls.Unlock()
 		return nil
 	}
-	ls.epochCache = append(ls.epochCache, newEpoch)
+	newCache := make([]models.Epoch, len(ls.epochCache), len(ls.epochCache)+1)
+	copy(newCache, ls.epochCache)
+	ls.epochCache = append(newCache, newEpoch)
+	ls.publishSnapshotsLocked()
 	ls.Unlock()
 
 	ls.config.Logger.Debug(
@@ -1361,13 +1358,9 @@ func (ls *LedgerState) computeEpochNonceForSlot(
 	// When resuming from a snapshot, prevEpoch can carry nonce state
 	// already advanced to the imported tip slot. Continue from the next
 	// slot in that case instead of replaying from epoch start.
-	ls.RLock()
-	currentTipSlot := ls.currentTip.Point.Slot
-	currentTipBlockNonce := append(
-		[]byte(nil),
-		ls.currentTipBlockNonce...,
-	)
-	ls.RUnlock()
+	tipState := ls.loadTipSnapshot()
+	currentTipSlot := tipState.currentTip.Point.Slot
+	currentTipBlockNonce := tipState.currentTipBlockNonce
 	if currentTipSlot >= prevEpoch.StartSlot &&
 		currentTipSlot < prevEpochEndSlot &&
 		len(prevEpoch.CandidateNonce) == 32 &&

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -499,6 +499,7 @@ func TestEpochForSlot_EmptyCache(t *testing.T) {
 	ls := &LedgerState{
 		epochCache: nil,
 	}
+	ls.publishSnapshotsLocked()
 	_, err := ls.epochForSlot(100)
 	assert.Error(t, err, "should fail with empty epoch cache")
 	assert.Contains(t, err.Error(), "epoch cache is empty")
@@ -517,6 +518,7 @@ func TestEpochForSlot_SlotInFirstEpoch(t *testing.T) {
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	ep, err := ls.epochForSlot(1000)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), ep.EpochId)
@@ -543,6 +545,7 @@ func TestEpochForSlot_SlotInSecondEpoch(t *testing.T) {
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	// Slot at the very start of epoch 1
 	ep, err := ls.epochForSlot(432000)
 	require.NoError(t, err)
@@ -570,6 +573,7 @@ func TestEpochForSlot_SlotBeyondKnownEpochs(t *testing.T) {
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	_, err := ls.epochForSlot(432001)
 	assert.Error(t, err, "should fail for slot beyond known epochs")
 	assert.Contains(t, err.Error(), "not covered by any known epoch")
@@ -596,6 +600,7 @@ func TestEpochForSlot_SlotAtEpochBoundary(t *testing.T) {
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	// Last slot of epoch 0
 	ep, err := ls.epochForSlot(999)
 	require.NoError(t, err)
@@ -628,6 +633,7 @@ func TestEpochForSlot_SkipsZeroLengthEpochs(t *testing.T) {
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	ep, err := ls.epochForSlot(500)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), ep.EpochId)
@@ -699,6 +705,7 @@ func TestVerifyBlockHeaderCrypto_RejectsBlockOutsideKnownEpochs(
 			),
 		},
 	}
+	ls.publishSnapshotsLocked()
 	// Block at slot 2000, which is beyond epoch 0 (ends at slot 1000)
 	block := &mockBabbageBlock{slot: 2000}
 	err := ls.verifyBlockHeaderCrypto(block)
@@ -730,6 +737,7 @@ func TestVerifyBlockHeaderCrypto_RejectsBlockWithNoNonce(t *testing.T) {
 			),
 		},
 	}
+	ls.publishSnapshotsLocked()
 	block := &mockBabbageBlock{slot: 500}
 	err := ls.verifyBlockHeaderCrypto(block)
 	assert.Error(t, err, "block with missing nonce must be rejected")
@@ -812,6 +820,7 @@ func TestVerifyBlockHeaderCrypto_EpochBoundaryUsesCorrectNonce(
 			),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	// The test block's slot is in [1, 200]. Ensure epoch 0 covers it.
 	require.Less(
@@ -850,6 +859,7 @@ func TestVerifyBlockHeaderCryptoBeforeApplyDefersMissingPoolState(
 	tb := createTestBlock(t, [32]byte{44}, 0, tamperNone)
 	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
 	ls.currentTip.Point.Slot = tb.block.SlotNumber() - 1
+	ls.publishSnapshotsLocked()
 
 	err := ls.verifyBlockHeaderCryptoBeforeApply(tb.block)
 	require.Error(t, err)
@@ -866,6 +876,7 @@ func TestVerifyBlockHeaderCryptoBeforeApplyDefersEmptyMarkSnapshot(
 	tb := createTestBlock(t, [32]byte{45}, 0, tamperNone)
 	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
 	ls.currentTip.Point.Slot = tb.block.SlotNumber() - 1
+	ls.publishSnapshotsLocked()
 	seedBlockPoolRegistration(t, db, tb.block)
 
 	err := ls.verifyBlockHeaderCryptoBeforeApply(tb.block)
@@ -937,6 +948,7 @@ func TestVerifyBlockHeaderCrypto_RejectsEmptyEpochCache(t *testing.T) {
 			),
 		},
 	}
+	ls.publishSnapshotsLocked()
 	block := &mockBabbageBlock{slot: 100}
 	err := ls.verifyBlockHeaderCrypto(block)
 	assert.Error(t, err, "should reject with empty epoch cache")
@@ -977,6 +989,7 @@ func TestVerifyBlockHeaderCrypto_WrongNonceFails(t *testing.T) {
 			),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	err := ls.verifyBlockHeaderCrypto(tb.block)
 	assert.Error(
@@ -1090,6 +1103,7 @@ func newEligibilityTestLedger(
 			Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 	return ls, db
 }
 
@@ -1111,6 +1125,7 @@ func TestVerifyBlockHeaderState_GenesisDelegateSkipsPoolChecks(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.NoError(t, err)
@@ -1130,6 +1145,7 @@ func TestVerifyBlockHeaderState_GenesisDelegateVRFMismatchFails(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
 	}
+	ls.publishSnapshotsLocked()
 
 	err := ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.Error(t, err)
@@ -1155,6 +1171,7 @@ func TestVerifyBlockHeaderState_GenesisDelegateInactiveAtDZero(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(0, 1)},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.Error(t, err)
@@ -1180,6 +1197,7 @@ func TestVerifyBlockHeaderState_GenesisDelegateInactiveOverlaySlotFails(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.Error(t, err)
@@ -1205,6 +1223,7 @@ func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotFallsThrough(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1000)},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.Error(t, err)
@@ -1229,6 +1248,7 @@ func TestVerifyBlockHeaderState_GenesisDelegateUsesActiveDelegation(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
 	}
+	ls.publishSnapshotsLocked()
 	seedGenesisDelegation(t, db, models.GenesisDelegation{
 		GenesisHash:         bytes.Repeat([]byte{0x11}, lcommon.Blake2b224Size),
 		GenesisDelegateHash: delegateHash.Bytes(),
@@ -1503,6 +1523,7 @@ func TestVerifyBlockLeaderEligibility_EarlyEpochUsesGenesisSnapshot(t *testing.T
 	ls.epochCache = []models.Epoch{
 		{EpochId: 1, StartSlot: 0, LengthInSlots: 1_000_000, Nonce: tb.epochNonce},
 	}
+	ls.publishSnapshotsLocked()
 
 	// No genesis snapshot seeded — pool has no stake at epoch 0.
 	err := ls.verifyBlockLeaderEligibility(tb.block, 1)
@@ -1550,6 +1571,7 @@ func TestVerifyBlockLeaderEligibility_MithrilEpochRequiresActiveDistribution(
 		Nonce:         tb.epochNonce,
 	}
 	ls.mithrilLedgerSlot = tb.block.slot - 1
+	ls.publishSnapshotsLocked()
 
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	// Seed the normal rotated mark snapshot with full stake. In the imported
@@ -1588,6 +1610,7 @@ func TestVerifyBlockLeaderEligibility_ActiveDistributionVRFAboveThresholdFails(
 		Nonce:         tb.epochNonce,
 	}
 	ls.mithrilLedgerSlot = tb.block.slot - 1
+	ls.publishSnapshotsLocked()
 
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	seedPoolStakeSnapshotOfType(
@@ -1662,6 +1685,7 @@ func TestVerifyBlockLeaderEligibility_DecentralizationActiveSkipsThreshold(
 	ls.currentPParams = &shelley.ShelleyProtocolParameters{
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
 	}
+	ls.publishSnapshotsLocked()
 
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1)
@@ -1765,6 +1789,7 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 	)
 	require.NoError(t, err)
 	require.True(t, ls.isMithrilImportedMarkSnapshot(snapshot, 4))
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	assert.NoError(t, err)
@@ -1815,6 +1840,7 @@ func TestVerifyBlockLeaderEligibility_LiveComputedHistoricalMarkStillChecks(
 	)
 	require.NoError(t, err)
 	require.False(t, ls.isMithrilImportedMarkSnapshot(snapshot, snapshotEpoch))
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	require.Error(t, err)
@@ -1849,6 +1875,7 @@ func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips(t *testing.T) {
 			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	assert.NoError(t, err, "missing active slot coeff should skip, not reject")
@@ -1896,6 +1923,7 @@ func TestVerifyBlockLeaderEligibility_ZeroCoeffSkips(t *testing.T) {
 			Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		},
 	}
+	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
 	assert.NoError(t, err, "zero active slot coeff should skip, not reject all blocks")

--- a/ledger/view_test.go
+++ b/ledger/view_test.go
@@ -152,6 +152,7 @@ func TestCostModels_WithCurrentPParams(t *testing.T) {
 			},
 		},
 	}
+	ls.publishSnapshotsLocked()
 	lv := &LedgerView{ls: ls}
 	result := lv.CostModels()
 	require.Len(t, result, 3)
@@ -161,6 +162,7 @@ func TestCostModels_NilPParams(t *testing.T) {
 	ls := &LedgerState{
 		currentPParams: nil,
 	}
+	ls.publishSnapshotsLocked()
 	lv := &LedgerView{ls: ls}
 	result := lv.CostModels()
 	require.NotNil(t, result,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -23,12 +23,10 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
@@ -218,28 +216,11 @@ func newTestLedgerState(t *testing.T) *ledger.LedgerState {
 
 func setTestLedgerTip(
 	t *testing.T,
-	ls *ledger.LedgerState,
+	o *Ouroboros,
 	tip ochainsync.Tip,
 ) {
 	t.Helper()
-	field := reflect.ValueOf(ls).Elem().FieldByName("currentTip")
-	require.True(t, field.IsValid())
-	reflect.NewAt(
-		field.Type(),
-		unsafe.Pointer(field.UnsafeAddr()),
-	).Elem().Set(reflect.ValueOf(tip))
-
-	// NewLedgerState publishes an origin tip snapshot during construction.
-	// These white-box tests replace currentTip directly, so clear that initial
-	// snapshot and let the ledger's test-fixture fallback rebuild its reader
-	// view from the value above. Otherwise GetIntersectPoint keeps observing
-	// origin even though the fixture's writer-owned tip has advanced.
-	snapshotField := reflect.ValueOf(ls).Elem().FieldByName("tip")
-	require.True(t, snapshotField.IsValid())
-	reflect.NewAt(
-		snapshotField.Type(),
-		unsafe.Pointer(snapshotField.UnsafeAddr()),
-	).Elem().Set(reflect.Zero(snapshotField.Type()))
+	o.LedgerState.SetTipForTesting(tip)
 }
 
 func snapshotChainsyncNtNTimeouts() map[string]struct {
@@ -537,7 +518,7 @@ func TestChainsyncServerFindIntersect_MatchingPointRegistersClient(
 	}
 	require.NoError(t, o.LedgerState.Chain().AddBlock(block, nil))
 	point := ocommon.NewPoint(block.SlotNumber(), block.Hash().Bytes())
-	setTestLedgerTip(t, o.LedgerState, ochainsync.Tip{
+	setTestLedgerTip(t, o, ochainsync.Tip{
 		Point:       point,
 		BlockNumber: block.BlockNumber(),
 	})
@@ -580,7 +561,7 @@ func TestChainsyncServerFindIntersect_MissingIntersection(
 		cbor:      []byte{0x80},
 	}
 	require.NoError(t, o.LedgerState.Chain().AddBlock(block, nil))
-	setTestLedgerTip(t, o.LedgerState, ochainsync.Tip{
+	setTestLedgerTip(t, o, ochainsync.Tip{
 		Point: ocommon.NewPoint(
 			block.SlotNumber(),
 			block.Hash().Bytes(),
@@ -618,7 +599,7 @@ func TestChainsyncServerFindIntersect_LedgerErrorPropagates(
 		cbor:      []byte{0x80},
 	}
 	require.NoError(t, o.LedgerState.Chain().AddBlock(block, nil))
-	setTestLedgerTip(t, o.LedgerState, ochainsync.Tip{
+	setTestLedgerTip(t, o, ochainsync.Tip{
 		Point: ocommon.NewPoint(
 			block.SlotNumber(),
 			block.Hash().Bytes(),

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -228,6 +228,18 @@ func setTestLedgerTip(
 		field.Type(),
 		unsafe.Pointer(field.UnsafeAddr()),
 	).Elem().Set(reflect.ValueOf(tip))
+
+	// NewLedgerState publishes an origin tip snapshot during construction.
+	// These white-box tests replace currentTip directly, so clear that initial
+	// snapshot and let the ledger's test-fixture fallback rebuild its reader
+	// view from the value above. Otherwise GetIntersectPoint keeps observing
+	// origin even though the fixture's writer-owned tip has advanced.
+	snapshotField := reflect.ValueOf(ls).Elem().FieldByName("tip")
+	require.True(t, snapshotField.IsValid())
+	reflect.NewAt(
+		snapshotField.Type(),
+		unsafe.Pointer(snapshotField.UnsafeAddr()),
+	).Elem().Set(reflect.Zero(snapshotField.Type()))
 }
 
 func snapshotChainsyncNtNTimeouts() map[string]struct {


### PR DESCRIPTION
1. Adds immutable atomic snapshots for frequently read ledger consensus and tip state, removing RWMutex contention from hot read paths.
2. Added `consensusSnapshot` to group epoch, era, protocol parameters, epoch cache, and hard-fork transition state, ensuring related values are read consistently without locks.
3. Added `tipSnapshot` to group the applied chain tip with its block nonce, preventing readers from observing mismatched tip and nonce values.
4. Added atomic snapshot pointers to `LedgerState`, allowing hot readers to load immutable state without acquiring `RWMutex`.
5. Changed `reachedTip` to `atomic.Bool`, removing the read lock from `IsAtTip()`.
6. Added cloning helpers for hashes and nonce slices. The epoch cache is published by reference for performance, while writers must replace it using copy-on-write before mutation.
7. Added `publishSnapshotsLocked()` with shared generations, allowing readers to retry until consensus and tip snapshots come from the same publication.
8. Removed unsafe nil snapshot fallbacks so all readers use initialized atomic snapshots.
9. Modified hot getters such as `Tip(), ChainTipSlot(), CurrentEpoch(), GetCurrentPParams()`, and `CurrentTransitionInfo()` to use lock-free snapshot reads.
10. Modified epoch, era, nonce, protocol-parameter, transaction-validation, header-verification, and node-to-client queries to read from snapshots, reducing contention across API, chain-sync, forging, and validation paths.
11. Added protocol-parameter cloning before epoch updates and deep-cloned hard-fork CostModels to prevent published snapshot data from being mutated.
12. Modified startup loading to publish snapshots after restoring epochs, protocol parameters, tips, and hard-fork transition information, preventing stale state after restart.
13. Modified block processing, rollback, epoch rollover, hard-fork evaluation, and Mithril nonce healing to publish updated snapshots before releasing the write lock.
14. Modified speculative epoch-cache advancement to allocate a new slice before publication, preserving older immutable snapshots.
15. Modified `Tip()` and epoch/nonce return paths to provide defensive copies, preventing callers from changing internal snapshot data.
16. Added snapshot immutability tests to verify old readers retain unchanged state after a newer snapshot is published.
17. Added race-regression tests for snapshot readers and a paired-generation test verifying consensus and tip cannot come from different publications.
18. Modified replay recovery, chain-sync rollback, and benchmark fixtures to publish directly initialized state before snapshot-based code reads it.
19. Updated `ARCHITECTURE.md `to document lock-free ledger readers, serialized writers, snapshot consistency groups, and slice immutability rules.
20. Ran the full devnet test suite and all DevNet tests got passed with these changes.


Closes #2601 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lock‑free, copy‑on‑write snapshots for consensus and tip state to remove `RWMutex` contention and keep era/epoch and tip/nonce reads consistent. Clarifies snapshot guarantees and prevents protocol‑parameter and hard‑fork `CostModels` mutations across eras (addresses #2601).

- **Refactors**
  - Publish consensus and tip snapshots together under one generation; paired‑load helper retries until generations match.
  - Serialize startup publication in `Start()` after reconstructing transition state; publish tip‑only changes without copying the epoch history.
  - Share the epoch cache by reference and cap capacity; `advanceEpochCache` now copies before append and republishes to preserve old snapshots.
  - Clone protocol parameters during epoch rollover and clone hard‑fork `CostModels` (Babbage/Conway/Dijkstra); add `cloneProtocolParametersForEra` and `eras/cloneCostModels`. Switch hot getters/queries to snapshot reads and return defensive copies; use `atomic.Bool` for `reachedTip`.

- **Bug Fixes**
  - Defer publication in `setEpochCache` so readers observe startup mutations even if later validation fails; remove unsafe nil snapshot fallbacks and add `SetTipForTesting`.
  - Fix races in post‑fork `ProtocolParamsForSlot` by cloning `CostModels`; add tests for immutability, epoch advancement preserving old snapshots, paired snapshot generations, and concurrent snapshot loads.
  - Publish after rollback, protocol‑parameter load, and HFI transition changes so snapshot readers see current state; update `ARCHITECTURE.md` to document snapshot rules and guarantees.

<sup>Written for commit 01cb644845b558e71bf4e091acd1ff55a265c6cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved ledger-state consistency during concurrent reads and updates.
  * Enabled faster access to frequently queried chain, epoch, protocol, and tip information.
  * Improved protection against inconsistent or partially updated state during processing and recovery.
  * Preserved safe copies of returned tip data to prevent unintended modifications.

* **Documentation**
  * Clarified ledger threading and concurrency behavior.

* **Tests**
  * Added coverage for snapshot immutability and concurrent reader consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->