### PR TITLE
test(database): cover reward metadata parity

### DIFF
--- a/database/plugin/metadata/mysql/mysql_test.go
+++ b/database/plugin/metadata/mysql/mysql_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -1787,4 +1788,135 @@ func TestStartRejectsInvalidDatabaseNameFromDSN(t *testing.T) {
 	if !strings.Contains(err.Error(), "mysql config dsn") {
 		t.Fatalf("expected DSN config error, got: %v", err)
 	}
+}
+
+// TestMysqlRewardLiveStakeCreditDeltaIsExactAcrossTwoCredits proves the
+// AddAccountRewardByCredential delta-update path (a single UPDATE of
+// reward_stake/total_stake, added as an efficiency fix for the epoch-boundary
+// reward rollover which credits ~every delegator's account) computes exact
+// totals against real MySQL across two sequential credits, and leaves every
+// other reward_live_stake column untouched. reward_stake/total_stake are
+// stored as longtext/varchar decimal strings, so this also proves the
+// CAST(...AS UNSIGNED)/CAST(...AS CHAR) delta SQL round-trips correctly.
+func TestMysqlRewardLiveStakeCreditDeltaIsExactAcrossTwoCredits(t *testing.T) {
+	store := newTestMysqlStore(t)
+
+	poolA := bytes.Repeat([]byte{0x8a}, 28)
+	stakeA := bytes.Repeat([]byte{0x8b}, 28)
+	utxoHash := bytes.Repeat([]byte{0x8c}, 32)
+
+	cleanup := func() {
+		db := store.DB()
+		db.Where("credential_tag = ? AND staking_key = ?", 0, stakeA).
+			Delete(&models.RewardLiveStake{})
+		db.Where("credential_tag = ? AND staking_key = ?", 0, stakeA).
+			Delete(&models.AccountRewardDelta{})
+		db.Where("staking_key = ?", stakeA).
+			Delete(&models.Utxo{})
+		db.Where("staking_key = ?", stakeA).
+			Delete(&models.Account{})
+		db.Where("pool_key_hash = ?", poolA).
+			Delete(&models.PoolRegistration{})
+		db.Where("pool_key_hash = ?", poolA).
+			Delete(&models.Pool{})
+	}
+	cleanup()
+	t.Cleanup(func() {
+		cleanup()
+		_ = store.Close()
+	})
+
+	pool := models.Pool{PoolKeyHash: poolA}
+	require.NoError(t, store.DB().
+		Where("pool_key_hash = ?", poolA).
+		FirstOrCreate(&pool).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:      pool.ID,
+		PoolKeyHash: poolA,
+		AddedSlot:   0,
+	}).Error)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		StakingKey:    stakeA,
+		CredentialTag: 0,
+		Pool:          poolA,
+		Reward:        1_000,
+		Active:        true,
+		AddedSlot:     10,
+	}))
+	require.NoError(t, store.CreateUtxo(nil, &models.Utxo{
+		TxId:          utxoHash,
+		OutputIdx:     0,
+		StakingKey:    stakeA,
+		CredentialTag: 0,
+		Amount:        2_000_000,
+		AddedSlot:     10,
+	}))
+
+	// Sanity: the row already exists before crediting, so both credits below
+	// exercise the delta-update path rather than falling back to a full
+	// refresh (which only happens when no row exists yet).
+	var seeded models.RewardLiveStake
+	require.NoError(t, store.DB().Where(
+		"credential_tag = ? AND staking_key = ?", 0, stakeA,
+	).First(&seeded).Error)
+	require.Equal(t, types.Uint64(1_000), seeded.RewardStake)
+	require.Equal(t, types.Uint64(2_000_000), seeded.UtxoStake)
+	require.Equal(t, types.Uint64(2_001_000), seeded.TotalStake)
+
+	const credit1 = uint64(500_000_000)
+	const credit2 = uint64(123_456_789)
+	require.NoError(t, store.AddAccountRewardByCredential(
+		0, stakeA, credit1, 11, bytes.Repeat([]byte{0x01}, 32), nil,
+	))
+	require.NoError(t, store.AddAccountRewardByCredential(
+		0, stakeA, credit2, 12, bytes.Repeat([]byte{0x02}, 32), nil,
+	))
+
+	wantReward := types.Uint64(1_000 + credit1 + credit2)
+	wantTotal := types.Uint64(2_000_000 + 1_000 + credit1 + credit2)
+
+	var got models.RewardLiveStake
+	require.NoError(t, store.DB().Where(
+		"credential_tag = ? AND staking_key = ?", 0, stakeA,
+	).First(&got).Error)
+	require.Equal(
+		t, wantReward, got.RewardStake,
+		"reward_stake must equal the exact sum of both credits",
+	)
+	require.Equal(
+		t, wantTotal, got.TotalStake,
+		"total_stake must equal the exact sum of utxo_stake and both credits",
+	)
+	require.Equal(
+		t, types.Uint64(2_000_000), got.UtxoStake,
+		"utxo_stake must be untouched by the reward-credit delta",
+	)
+	require.Equal(
+		t, poolA, got.PoolKeyHash,
+		"pool delegation must be untouched by the reward-credit delta",
+	)
+	require.True(
+		t, got.Registered,
+		"registered flag must be untouched by the reward-credit delta",
+	)
+	require.Equal(
+		t, uint64(12), got.UpdatedSlot,
+		"updated_slot must reflect the latest credit's slot",
+	)
+
+	// Cross-check against ground truth: a full rebuild from source tables
+	// must land on the exact same totals the delta path produced.
+	txn, err := store.BeginTxn()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = txn.Rollback() })
+	require.NoError(t, store.RebuildRewardLiveStake(12, txn))
+	txnDB, err := store.resolveDB(txn)
+	require.NoError(t, err)
+	var rebuilt models.RewardLiveStake
+	require.NoError(t, txnDB.Where(
+		"credential_tag = ? AND staking_key = ?", 0, stakeA,
+	).First(&rebuilt).Error)
+	require.Equal(t, wantReward, rebuilt.RewardStake)
+	require.Equal(t, wantTotal, rebuilt.TotalStake)
 }

--- a/database/plugin/metadata/mysql/reward_live_stake_equivalence_test.go
+++ b/database/plugin/metadata/mysql/reward_live_stake_equivalence_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package mysql
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// normalizedLiveStakeRow is the backend-agnostic shape used to compare
+// reward_live_stake rows across sqlite, mysql, and postgres: every field
+// except the auto-increment ID, which is expected to differ across
+// backends/runs. Duplicated identically in the sqlite and postgres packages'
+// equivalence tests: each backend's test lives in a different Go package
+// (and postgres/mysql are additionally gated by the dingo_extra_plugins
+// build tag), so sharing it as a single helper would require a new
+// test-only package outside this task's scope.
+type normalizedLiveStakeRow struct {
+	CredentialTag            uint8
+	StakingKey               string
+	PoolKeyHash              string
+	UtxoStake                uint64
+	RewardStake              uint64
+	TotalStake               uint64
+	Registered               bool
+	PoolDelegationSlot       uint64
+	PoolDelegationBlockIndex uint64
+	PoolDelegationCertIndex  uint32
+	UpdatedSlot              uint64
+}
+
+func normalizeLiveStakeRows(
+	rows []models.RewardLiveStake,
+) []normalizedLiveStakeRow {
+	out := make([]normalizedLiveStakeRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, normalizedLiveStakeRow{
+			CredentialTag:            row.CredentialTag,
+			StakingKey:               string(row.StakingKey),
+			PoolKeyHash:              string(row.PoolKeyHash),
+			UtxoStake:                uint64(row.UtxoStake),
+			RewardStake:              uint64(row.RewardStake),
+			TotalStake:               uint64(row.TotalStake),
+			Registered:               row.Registered,
+			PoolDelegationSlot:       row.PoolDelegationSlot,
+			PoolDelegationBlockIndex: row.PoolDelegationBlockIndex,
+			PoolDelegationCertIndex:  row.PoolDelegationCertIndex,
+			UpdatedSlot:              row.UpdatedSlot,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CredentialTag != out[j].CredentialTag {
+			return out[i].CredentialTag < out[j].CredentialTag
+		}
+		return out[i].StakingKey < out[j].StakingKey
+	})
+	return out
+}
+
+// rewardLiveStakeEquivalenceHashes are the fixed 28-byte test vectors used
+// (by identical construction, not by cross-package import) across the
+// sqlite/mysql/postgres equivalence tests, so every backend rebuilds from
+// byte-identical input.
+type rewardLiveStakeEquivalenceHashes struct {
+	poolA, poolB           []byte
+	stakeA, stakeB, stakeC []byte
+	stakeD                 []byte
+}
+
+func newRewardLiveStakeEquivalenceHashes() rewardLiveStakeEquivalenceHashes {
+	return rewardLiveStakeEquivalenceHashes{
+		poolA:  bytes.Repeat([]byte{0xA1}, 28),
+		poolB:  bytes.Repeat([]byte{0xB1}, 28),
+		stakeA: bytes.Repeat([]byte{0x10}, 28),
+		stakeB: bytes.Repeat([]byte{0x20}, 28),
+		stakeC: bytes.Repeat([]byte{0x30}, 28),
+		stakeD: bytes.Repeat([]byte{0x40}, 28),
+	}
+}
+
+// seedRewardLiveStakeEquivalenceScenario populates the same
+// accounts/UTxOs/delegation-certificate scenario used by every backend's
+// cross-backend equivalence test:
+//
+//   - stakeA (key credential): active, delegated to poolA both via
+//     account.Pool and a stake_delegation cert recorded after the account's
+//     own AddedSlot (exercises the latest_delegation CTE overriding the
+//     account fallback), one live UTxO and one deleted (excluded) UTxO.
+//   - stakeB (script credential): active, delegated to poolB with no
+//     delegation certificate on record (exercises the account.AddedSlot
+//     fallback), and one live UTxO whose amount exceeds 2^53 (exercises the
+//     backend-native integer CAST that avoids MySQL's lossy implicit DOUBLE
+//     conversion on a text-encoded SUM).
+//   - stakeC: a deregistered (inactive) account with a nonzero reward and no
+//     UTxOs (exercises registered=false with pool_key_hash NULL and
+//     reward_stake carried through the account.reward CAST fix).
+//   - stakeD: a live UTxO with no matching account row at all (exercises the
+//     UTxO-only fallback branch of the creds UNION).
+func seedRewardLiveStakeEquivalenceScenario(
+	t *testing.T,
+	db *gorm.DB,
+	h rewardLiveStakeEquivalenceHashes,
+) {
+	t.Helper()
+
+	accounts := []models.Account{
+		{
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Pool:          h.poolA,
+			Reward:        1_000_000,
+			Active:        true,
+			AddedSlot:     10,
+		},
+		{
+			StakingKey:    h.stakeB,
+			CredentialTag: 1,
+			Pool:          h.poolB,
+			Reward:        0,
+			Active:        true,
+			AddedSlot:     20,
+		},
+		{
+			// Active starts true and is flipped to false below: GORM's
+			// Create skips zero-value fields when the model has a
+			// `default:true` tag (Account.Active does), so Active: false
+			// here would otherwise be silently stored as true.
+			StakingKey:    h.stakeC,
+			CredentialTag: 0,
+			Pool:          nil,
+			Reward:        500_000,
+			Active:        true,
+			AddedSlot:     5,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	require.NoError(
+		t,
+		db.Model(&accounts[2]).Update("active", false).Error,
+	)
+
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		StakingKey:    h.stakeA,
+		CredentialTag: 0,
+		PoolKeyHash:   h.poolA,
+		AddedSlot:     15,
+	}).Error)
+
+	utxos := []models.Utxo{
+		{
+			TxId:          bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Amount:        5_000_000,
+			AddedSlot:     11,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Amount:        2_000_000,
+			AddedSlot:     12,
+			DeletedSlot:   50,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeB,
+			CredentialTag: 1,
+			// Exceeds 2^53 (9007199254740992): exposes MySQL's lossy
+			// implicit DOUBLE conversion on a text-encoded SUM without an
+			// explicit backend-native integer CAST.
+			Amount:    9_007_199_254_740_993,
+			AddedSlot: 21,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x04}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeD,
+			CredentialTag: 0,
+			Amount:        3_000_000,
+			AddedSlot:     30,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+}
+
+// expectedRewardLiveStakeEquivalenceRows is the expected reward_live_stake
+// content after RebuildRewardLiveStake over
+// seedRewardLiveStakeEquivalenceScenario's scenario, at slot 100.
+func expectedRewardLiveStakeEquivalenceRows(
+	h rewardLiveStakeEquivalenceHashes,
+) []normalizedLiveStakeRow {
+	rows := []normalizedLiveStakeRow{
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeA),
+			PoolKeyHash:        string(h.poolA),
+			UtxoStake:          5_000_000,
+			RewardStake:        1_000_000,
+			TotalStake:         6_000_000,
+			Registered:         true,
+			PoolDelegationSlot: 15,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      1,
+			StakingKey:         string(h.stakeB),
+			PoolKeyHash:        string(h.poolB),
+			UtxoStake:          9_007_199_254_740_993,
+			RewardStake:        0,
+			TotalStake:         9_007_199_254_740_993,
+			Registered:         true,
+			PoolDelegationSlot: 20,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeC),
+			PoolKeyHash:        "",
+			UtxoStake:          0,
+			RewardStake:        500_000,
+			TotalStake:         500_000,
+			Registered:         false,
+			PoolDelegationSlot: 0,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeD),
+			PoolKeyHash:        "",
+			UtxoStake:          3_000_000,
+			RewardStake:        0,
+			TotalStake:         3_000_000,
+			Registered:         false,
+			PoolDelegationSlot: 0,
+			UpdatedSlot:        100,
+		},
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].CredentialTag != rows[j].CredentialTag {
+			return rows[i].CredentialTag < rows[j].CredentialTag
+		}
+		return rows[i].StakingKey < rows[j].StakingKey
+	})
+	return rows
+}
+
+// TestRewardLiveStakeRebuildCrossBackendEquivalenceMysql seeds the shared
+// scenario (byte-identical to the sqlite and postgres equivalence tests) on
+// mysql and asserts the rebuilt reward_live_stake rows for these specific
+// credentials match the expected values exactly.
+//
+// RebuildRewardLiveStake does a full-table DELETE + repopulate from every
+// account/UTxO row in the database, so the scenario runs in a rollback-only
+// transaction to leave the shared mysql database unchanged.
+func TestRewardLiveStakeRebuildCrossBackendEquivalenceMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+	txn, err := store.BeginTxn()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = txn.Rollback() })
+	db, err := store.resolveDB(txn)
+	require.NoError(t, err)
+	h := newRewardLiveStakeEquivalenceHashes()
+	stakingKeys := [][]byte{h.stakeA, h.stakeB, h.stakeC, h.stakeD}
+	for _, k := range stakingKeys {
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.RewardLiveStake{}).Error)
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.StakeDelegation{}).Error)
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.Utxo{}).Error)
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.Account{}).Error)
+	}
+
+	seedRewardLiveStakeEquivalenceScenario(t, db, h)
+
+	require.NoError(t, store.RebuildRewardLiveStake(100, txn))
+
+	var rows []models.RewardLiveStake
+	require.NoError(t, db.
+		Where("staking_key IN ?", stakingKeys).
+		Order("credential_tag ASC, staking_key ASC").
+		Find(&rows).Error)
+
+	require.Equal(
+		t,
+		expectedRewardLiveStakeEquivalenceRows(h),
+		normalizeLiveStakeRows(rows),
+	)
+}

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -31,6 +31,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/require"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -233,6 +234,22 @@ func (r *setTransactionSQLRecorder) countUtxoLookupSelects() int {
 		}
 	}
 	return count
+}
+
+// testHash32 creates a 32-byte test hash from a seed string.
+// Used for block hashes, transaction hashes, and other Blake2b256 values.
+func testHash32(seed string) []byte {
+	hash := make([]byte, 32)
+	copy(hash, []byte(seed))
+	return hash
+}
+
+// testHash28 creates a 28-byte test hash from a seed string.
+// Used for staking keys, credentials, and other Blake2b224 values.
+func testHash28(seed string) []byte {
+	hash := make([]byte, 28)
+	copy(hash, []byte(seed))
+	return hash
 }
 
 type mockTransactionInput struct {
@@ -880,7 +897,7 @@ func TestPostgresUnifiedCertificateCreation(t *testing.T) {
 	// Create a mock transaction with certificates
 	mockTx := &mockTransaction{
 		hash: lcommon.NewBlake2b256(
-			[]byte("test_hash_1234567890123456789012345678901234567890"),
+			testHash32("test_hash"),
 		),
 		isValid: true,
 		certificates: []lcommon.Certificate{
@@ -889,27 +906,27 @@ func TestPostgresUnifiedCertificateCreation(t *testing.T) {
 				StakeCredential: lcommon.Credential{
 					CredType: lcommon.CredentialTypeAddrKeyHash,
 					Credential: lcommon.CredentialHash(
-						[]byte("stake_key_hash_1234567890123456789012345678"),
+						testHash28("stake_key_hash_1"),
 					),
 				},
 			},
 			&lcommon.PoolRegistrationCertificate{
 				CertType: uint(lcommon.CertificateTypePoolRegistration),
 				Operator: lcommon.PoolKeyHash(
-					[]byte("pool_key_hash_1234567890123456789012345678"),
+					testHash28("pool_key_hash_1"),
 				),
 				VrfKeyHash: lcommon.VrfKeyHash(
-					[]byte("vrf_key_hash_12345678901234567890123456789012"),
+					testHash32("vrf_key_hash_1"),
 				),
 				Pledge: 1000000,
 				Cost:   340000000,
 				Margin: cbor.Rat{Rat: big.NewRat(1, 100)},
 				RewardAccount: lcommon.AddrKeyHash(
-					[]byte("reward_account_1234567890123456789012345678"),
+					testHash28("reward_account_1"),
 				),
 				PoolOwners: []lcommon.AddrKeyHash{
 					lcommon.AddrKeyHash(
-						[]byte("owner1_1234567890123456789012345678"),
+						testHash28("owner1"),
 					),
 				},
 			},
@@ -918,13 +935,13 @@ func TestPostgresUnifiedCertificateCreation(t *testing.T) {
 				ColdCredential: lcommon.Credential{
 					CredType: lcommon.CredentialTypeAddrKeyHash,
 					Credential: lcommon.CredentialHash(
-						[]byte("cold_cred_hash_1234567890123456789012345678"),
+						testHash28("cold_cred_hash_1"),
 					),
 				},
 				HotCredential: lcommon.Credential{
 					CredType: lcommon.CredentialTypeAddrKeyHash,
 					Credential: lcommon.CredentialHash(
-						[]byte("hot_cred_hash_1234567890123456789012345678"),
+						testHash28("hot_cred_hash_1"),
 					),
 				},
 			},
@@ -932,7 +949,7 @@ func TestPostgresUnifiedCertificateCreation(t *testing.T) {
 	}
 
 	point := ocommon.Point{
-		Hash: []byte("block_hash_12345678901234567890123456789012"),
+		Hash: testHash32("block_hash_1"),
 		Slot: 1000000,
 	}
 
@@ -1131,13 +1148,13 @@ func TestPostgresFeeConversion(t *testing.T) {
 	// Test with nil Fee
 	mockTxNilFee := &mockTransactionNilFee{
 		hash: lcommon.NewBlake2b256(
-			[]byte("nil_fee_tx_hash_12345678901234567890"),
+			testHash32("nil_fee_tx_hash"),
 		),
 		isValid: true,
 	}
 
 	point := ocommon.Point{
-		Hash: []byte("block_hash_nil_fee_test_1234567890123456"),
+		Hash: testHash32("block_hash_nil_fee"),
 		Slot: 2000000,
 	}
 
@@ -1297,21 +1314,13 @@ func (m *mockTransactionNilFee) LeiosHash() lcommon.Blake2b256 {
 
 // createTestTransactionPg is a helper to create a Transaction record for FK constraints in postgres tests
 func createTestTransactionPg(db *gorm.DB, id uint, slot uint64) error {
+	idText := strconv.FormatUint(uint64(id), 10)
+	slotText := strconv.FormatUint(slot, 10)
 	tx := models.Transaction{
-		Hash: []byte(
-			"tx_hash_" + strconv.FormatUint(
-				uint64(id),
-				10,
-			) + "_123456789012345678901234567890",
-		),
-		BlockHash: []byte(
-			"block_hash_" + strconv.FormatUint(
-				slot,
-				10,
-			) + "_12345678901234567890123456789012",
-		),
-		Slot:  slot,
-		Valid: true,
+		Hash:      testHash32("tx_hash_" + idText),
+		BlockHash: testHash32("block_hash_" + slotText),
+		Slot:      slot,
+		Valid:     true,
 	}
 	tx.ID = id
 	return db.Create(&tx).Error
@@ -1351,8 +1360,8 @@ func TestPostgresDeleteCertificatesAfterSlot(t *testing.T) {
 
 	stakeReg1 := models.StakeDelegation{
 		CertificateID: cert1.ID,
-		StakingKey:    []byte("stake_key_1_1234567890123456789012345678"),
-		PoolKeyHash:   []byte("pool_hash_1_12345678901234567890123456789012"),
+		StakingKey:    testHash28("stake_key_1"),
+		PoolKeyHash:   testHash28("pool_hash_1"),
 		AddedSlot:     1000,
 	}
 	if result := pgStore.DB().Create(&stakeReg1); result.Error != nil {
@@ -1375,8 +1384,8 @@ func TestPostgresDeleteCertificatesAfterSlot(t *testing.T) {
 
 	stakeReg2 := models.StakeDelegation{
 		CertificateID: cert2.ID,
-		StakingKey:    []byte("stake_key_2_1234567890123456789012345678"),
-		PoolKeyHash:   []byte("pool_hash_2_12345678901234567890123456789012"),
+		StakingKey:    testHash28("stake_key_2"),
+		PoolKeyHash:   testHash28("pool_hash_2"),
 		AddedSlot:     2000,
 	}
 	if result := pgStore.DB().Create(&stakeReg2); result.Error != nil {
@@ -1455,10 +1464,8 @@ func TestPostgresRestoreAccountStateAtSlot(t *testing.T) {
 
 		// Create registration certificate at slot 1000
 		regCert := models.Certificate{
-			Slot: 1000,
-			BlockHash: []byte(
-				"block_hash_1000_12345678901234567890123456789012",
-			),
+			Slot:          1000,
+			BlockHash:     testHash32("block_hash_1000"),
 			CertType:      uint(lcommon.CertificateTypeStakeRegistration),
 			TransactionID: 100,
 			CertIndex:     0,
@@ -1474,10 +1481,8 @@ func TestPostgresRestoreAccountStateAtSlot(t *testing.T) {
 
 		// Create delegation to pool1 at slot 2000
 		delCert1 := models.Certificate{
-			Slot: 2000,
-			BlockHash: []byte(
-				"block_hash_2000_12345678901234567890123456789012",
-			),
+			Slot:          2000,
+			BlockHash:     testHash32("block_hash_2000"),
 			CertType:      uint(lcommon.CertificateTypeStakeDelegation),
 			TransactionID: 101,
 			CertIndex:     0,
@@ -1494,10 +1499,8 @@ func TestPostgresRestoreAccountStateAtSlot(t *testing.T) {
 
 		// Create delegation to pool2 at slot 3000
 		delCert2 := models.Certificate{
-			Slot: 3000,
-			BlockHash: []byte(
-				"block_hash_3000_12345678901234567890123456789012",
-			),
+			Slot:          3000,
+			BlockHash:     testHash32("block_hash_3000"),
 			CertType:      uint(lcommon.CertificateTypeStakeDelegation),
 			TransactionID: 102,
 			CertIndex:     0,
@@ -1702,7 +1705,7 @@ func TestPostgresRestorePoolStateAtSlot(t *testing.T) {
 		pgStore.DB().Where("1 = 1").Delete(&models.PoolRegistration{})
 		pgStore.DB().Where("1 = 1").Delete(&models.Pool{})
 
-		poolKeyHash := []byte("pool_key_hash_12345678901234567890123456789012")
+		poolKeyHash := testHash28("pool_key_hash")
 
 		// Create pool registered at slot 2000
 		pool := models.Pool{
@@ -1745,7 +1748,7 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 		pgStore.DB().Where("1 = 1").Delete(&models.RegistrationDrep{})
 		pgStore.DB().Where("1 = 1").Delete(&models.Drep{})
 
-		drepCred := []byte("drep_credential_12345678901234567890123456789012")
+		drepCred := testHash28("drep_credential")
 
 		// Create DRep registered at slot 2000
 		drep := models.Drep{
@@ -1785,9 +1788,7 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 			pgStore.DB().Where("1 = 1").Delete(&models.Drep{})
 			pgStore.DB().Where("1 = 1").Delete(&models.Transaction{})
 
-			drepCred := []byte(
-				"drep_credential_12345678901234567890123456789012",
-			)
+			drepCred := testHash28("drep_credential")
 
 			// Create transactions
 			if err := createTestTransactionPg(pgStore.DB(), 200, 1000); err != nil {
@@ -1799,10 +1800,8 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 
 			// Create registration at slot 1000
 			regCert := models.Certificate{
-				Slot: 1000,
-				BlockHash: []byte(
-					"block_hash_1000_12345678901234567890123456789012",
-				),
+				Slot:          1000,
+				BlockHash:     testHash32("block_hash_1000"),
 				CertType:      uint(lcommon.CertificateTypeRegistrationDrep),
 				TransactionID: 200,
 				CertIndex:     0,
@@ -1813,19 +1812,15 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 				CertificateID:  regCert.ID,
 				DrepCredential: drepCred,
 				AnchorURL:      "https://example.com/drep1",
-				AnchorHash: []byte(
-					"anchor_hash_1_12345678901234567890123456789012",
-				),
-				AddedSlot: 1000,
+				AnchorHash:     testHash32("anchor_hash_1"),
+				AddedSlot:      1000,
 			}
 			pgStore.DB().Create(&drepReg)
 
 			// Create update at slot 2000 with different anchor
 			updateCert := models.Certificate{
-				Slot: 2000,
-				BlockHash: []byte(
-					"block_hash_2000_12345678901234567890123456789012",
-				),
+				Slot:          2000,
+				BlockHash:     testHash32("block_hash_2000"),
 				CertType:      uint(lcommon.CertificateTypeUpdateDrep),
 				TransactionID: 201,
 				CertIndex:     0,
@@ -1836,10 +1831,8 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 				CertificateID: updateCert.ID,
 				Credential:    drepCred,
 				AnchorURL:     "https://example.com/drep2",
-				AnchorHash: []byte(
-					"anchor_hash_2_12345678901234567890123456789012",
-				),
-				AddedSlot: 2000,
+				AnchorHash:    testHash32("anchor_hash_2"),
+				AddedSlot:     2000,
 			}
 			pgStore.DB().Create(&drepUpdate)
 
@@ -1847,11 +1840,9 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 			drep := models.Drep{
 				Credential: drepCred,
 				AnchorURL:  "https://example.com/drep2",
-				AnchorHash: []byte(
-					"anchor_hash_2_12345678901234567890123456789012",
-				),
-				AddedSlot: 2000,
-				Active:    true,
+				AnchorHash: testHash32("anchor_hash_2"),
+				AddedSlot:  2000,
+				Active:     true,
 			}
 			pgStore.DB().Create(&drep)
 
@@ -1875,4 +1866,135 @@ func TestPostgresRestoreDrepStateAtSlot(t *testing.T) {
 			}
 		},
 	)
+}
+
+// TestPostgresRewardLiveStakeCreditDeltaIsExactAcrossTwoCredits proves the
+// AddAccountRewardByCredential delta-update path (a single UPDATE of
+// reward_stake/total_stake, added as an efficiency fix for the epoch-boundary
+// reward rollover which credits ~every delegator's account) computes exact
+// totals against real Postgres across two sequential credits, and leaves
+// every other reward_live_stake column untouched. reward_stake/total_stake
+// are stored as text decimal strings, so this also proves the
+// CAST(...AS BIGINT)/CAST(...AS TEXT) delta SQL round-trips correctly.
+func TestPostgresRewardLiveStakeCreditDeltaIsExactAcrossTwoCredits(t *testing.T) {
+	store := newTestPostgresStore(t)
+
+	poolA := bytes.Repeat([]byte{0x8a}, 28)
+	stakeA := bytes.Repeat([]byte{0x8b}, 28)
+	utxoHash := bytes.Repeat([]byte{0x8c}, 32)
+
+	cleanup := func() {
+		db := store.DB()
+		db.Where("credential_tag = ? AND staking_key = ?", 0, stakeA).
+			Delete(&models.RewardLiveStake{})
+		db.Where("credential_tag = ? AND staking_key = ?", 0, stakeA).
+			Delete(&models.AccountRewardDelta{})
+		db.Where("staking_key = ?", stakeA).
+			Delete(&models.Utxo{})
+		db.Where("staking_key = ?", stakeA).
+			Delete(&models.Account{})
+		db.Where("pool_key_hash = ?", poolA).
+			Delete(&models.PoolRegistration{})
+		db.Where("pool_key_hash = ?", poolA).
+			Delete(&models.Pool{})
+	}
+	cleanup()
+	t.Cleanup(func() {
+		cleanup()
+		_ = store.Close()
+	})
+
+	pool := models.Pool{PoolKeyHash: poolA}
+	require.NoError(t, store.DB().
+		Where("pool_key_hash = ?", poolA).
+		FirstOrCreate(&pool).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:      pool.ID,
+		PoolKeyHash: poolA,
+		AddedSlot:   0,
+	}).Error)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		StakingKey:    stakeA,
+		CredentialTag: 0,
+		Pool:          poolA,
+		Reward:        1_000,
+		Active:        true,
+		AddedSlot:     10,
+	}))
+	require.NoError(t, store.CreateUtxo(nil, &models.Utxo{
+		TxId:          utxoHash,
+		OutputIdx:     0,
+		StakingKey:    stakeA,
+		CredentialTag: 0,
+		Amount:        2_000_000,
+		AddedSlot:     10,
+	}))
+
+	// Sanity: the row already exists before crediting, so both credits below
+	// exercise the delta-update path rather than falling back to a full
+	// refresh (which only happens when no row exists yet).
+	var seeded models.RewardLiveStake
+	require.NoError(t, store.DB().Where(
+		"credential_tag = ? AND staking_key = ?", 0, stakeA,
+	).First(&seeded).Error)
+	require.Equal(t, types.Uint64(1_000), seeded.RewardStake)
+	require.Equal(t, types.Uint64(2_000_000), seeded.UtxoStake)
+	require.Equal(t, types.Uint64(2_001_000), seeded.TotalStake)
+
+	const credit1 = uint64(500_000_000)
+	const credit2 = uint64(123_456_789)
+	require.NoError(t, store.AddAccountRewardByCredential(
+		0, stakeA, credit1, 11, bytes.Repeat([]byte{0x01}, 32), nil,
+	))
+	require.NoError(t, store.AddAccountRewardByCredential(
+		0, stakeA, credit2, 12, bytes.Repeat([]byte{0x02}, 32), nil,
+	))
+
+	wantReward := types.Uint64(1_000 + credit1 + credit2)
+	wantTotal := types.Uint64(2_000_000 + 1_000 + credit1 + credit2)
+
+	var got models.RewardLiveStake
+	require.NoError(t, store.DB().Where(
+		"credential_tag = ? AND staking_key = ?", 0, stakeA,
+	).First(&got).Error)
+	require.Equal(
+		t, wantReward, got.RewardStake,
+		"reward_stake must equal the exact sum of both credits",
+	)
+	require.Equal(
+		t, wantTotal, got.TotalStake,
+		"total_stake must equal the exact sum of utxo_stake and both credits",
+	)
+	require.Equal(
+		t, types.Uint64(2_000_000), got.UtxoStake,
+		"utxo_stake must be untouched by the reward-credit delta",
+	)
+	require.Equal(
+		t, poolA, got.PoolKeyHash,
+		"pool delegation must be untouched by the reward-credit delta",
+	)
+	require.True(
+		t, got.Registered,
+		"registered flag must be untouched by the reward-credit delta",
+	)
+	require.Equal(
+		t, uint64(12), got.UpdatedSlot,
+		"updated_slot must reflect the latest credit's slot",
+	)
+
+	// Cross-check against ground truth: a full rebuild from source tables
+	// must land on the exact same totals the delta path produced.
+	txn, err := store.BeginTxn()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = txn.Rollback() })
+	require.NoError(t, store.RebuildRewardLiveStake(12, txn))
+	txnDB, err := store.resolveDB(txn)
+	require.NoError(t, err)
+	var rebuilt models.RewardLiveStake
+	require.NoError(t, txnDB.Where(
+		"credential_tag = ? AND staking_key = ?", 0, stakeA,
+	).First(&rebuilt).Error)
+	require.Equal(t, wantReward, rebuilt.RewardStake)
+	require.Equal(t, wantTotal, rebuilt.TotalStake)
 }

--- a/database/plugin/metadata/postgres/reward_live_stake_equivalence_test.go
+++ b/database/plugin/metadata/postgres/reward_live_stake_equivalence_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package postgres
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// normalizedLiveStakeRow is the backend-agnostic shape used to compare
+// reward_live_stake rows across sqlite, mysql, and postgres: every field
+// except the auto-increment ID, which is expected to differ across
+// backends/runs. Duplicated identically in the sqlite and postgres packages'
+// equivalence tests: each backend's test lives in a different Go package
+// (and postgres/mysql are additionally gated by the dingo_extra_plugins
+// build tag), so sharing it as a single helper would require a new
+// test-only package outside this task's scope.
+type normalizedLiveStakeRow struct {
+	CredentialTag            uint8
+	StakingKey               string
+	PoolKeyHash              string
+	UtxoStake                uint64
+	RewardStake              uint64
+	TotalStake               uint64
+	Registered               bool
+	PoolDelegationSlot       uint64
+	PoolDelegationBlockIndex uint64
+	PoolDelegationCertIndex  uint32
+	UpdatedSlot              uint64
+}
+
+func normalizeLiveStakeRows(
+	rows []models.RewardLiveStake,
+) []normalizedLiveStakeRow {
+	out := make([]normalizedLiveStakeRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, normalizedLiveStakeRow{
+			CredentialTag:            row.CredentialTag,
+			StakingKey:               string(row.StakingKey),
+			PoolKeyHash:              string(row.PoolKeyHash),
+			UtxoStake:                uint64(row.UtxoStake),
+			RewardStake:              uint64(row.RewardStake),
+			TotalStake:               uint64(row.TotalStake),
+			Registered:               row.Registered,
+			PoolDelegationSlot:       row.PoolDelegationSlot,
+			PoolDelegationBlockIndex: row.PoolDelegationBlockIndex,
+			PoolDelegationCertIndex:  row.PoolDelegationCertIndex,
+			UpdatedSlot:              row.UpdatedSlot,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CredentialTag != out[j].CredentialTag {
+			return out[i].CredentialTag < out[j].CredentialTag
+		}
+		return out[i].StakingKey < out[j].StakingKey
+	})
+	return out
+}
+
+// rewardLiveStakeEquivalenceHashes are the fixed 28-byte test vectors used
+// (by identical construction, not by cross-package import) across the
+// sqlite/mysql/postgres equivalence tests, so every backend rebuilds from
+// byte-identical input.
+type rewardLiveStakeEquivalenceHashes struct {
+	poolA, poolB           []byte
+	stakeA, stakeB, stakeC []byte
+	stakeD                 []byte
+}
+
+func newRewardLiveStakeEquivalenceHashes() rewardLiveStakeEquivalenceHashes {
+	return rewardLiveStakeEquivalenceHashes{
+		poolA:  bytes.Repeat([]byte{0xA1}, 28),
+		poolB:  bytes.Repeat([]byte{0xB1}, 28),
+		stakeA: bytes.Repeat([]byte{0x10}, 28),
+		stakeB: bytes.Repeat([]byte{0x20}, 28),
+		stakeC: bytes.Repeat([]byte{0x30}, 28),
+		stakeD: bytes.Repeat([]byte{0x40}, 28),
+	}
+}
+
+// seedRewardLiveStakeEquivalenceScenario populates the same
+// accounts/UTxOs/delegation-certificate scenario used by every backend's
+// cross-backend equivalence test:
+//
+//   - stakeA (key credential): active, delegated to poolA both via
+//     account.Pool and a stake_delegation cert recorded after the account's
+//     own AddedSlot (exercises the latest_delegation CTE overriding the
+//     account fallback), one live UTxO and one deleted (excluded) UTxO.
+//   - stakeB (script credential): active, delegated to poolB with no
+//     delegation certificate on record (exercises the account.AddedSlot
+//     fallback), and one live UTxO whose amount exceeds 2^53 (exercises the
+//     backend-native integer CAST that avoids MySQL's lossy implicit DOUBLE
+//     conversion on a text-encoded SUM).
+//   - stakeC: a deregistered (inactive) account with a nonzero reward and no
+//     UTxOs (exercises registered=false with pool_key_hash NULL and
+//     reward_stake carried through the account.reward CAST fix).
+//   - stakeD: a live UTxO with no matching account row at all (exercises the
+//     UTxO-only fallback branch of the creds UNION).
+func seedRewardLiveStakeEquivalenceScenario(
+	t *testing.T,
+	db *gorm.DB,
+	h rewardLiveStakeEquivalenceHashes,
+) {
+	t.Helper()
+
+	accounts := []models.Account{
+		{
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Pool:          h.poolA,
+			Reward:        1_000_000,
+			Active:        true,
+			AddedSlot:     10,
+		},
+		{
+			StakingKey:    h.stakeB,
+			CredentialTag: 1,
+			Pool:          h.poolB,
+			Reward:        0,
+			Active:        true,
+			AddedSlot:     20,
+		},
+		{
+			// Active starts true and is flipped to false below: GORM's
+			// Create skips zero-value fields when the model has a
+			// `default:true` tag (Account.Active does), so Active: false
+			// here would otherwise be silently stored as true.
+			StakingKey:    h.stakeC,
+			CredentialTag: 0,
+			Pool:          nil,
+			Reward:        500_000,
+			Active:        true,
+			AddedSlot:     5,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	require.NoError(
+		t,
+		db.Model(&accounts[2]).Update("active", false).Error,
+	)
+
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		StakingKey:    h.stakeA,
+		CredentialTag: 0,
+		PoolKeyHash:   h.poolA,
+		AddedSlot:     15,
+	}).Error)
+
+	utxos := []models.Utxo{
+		{
+			TxId:          bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Amount:        5_000_000,
+			AddedSlot:     11,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Amount:        2_000_000,
+			AddedSlot:     12,
+			DeletedSlot:   50,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeB,
+			CredentialTag: 1,
+			// Exceeds 2^53 (9007199254740992): exposes MySQL's lossy
+			// implicit DOUBLE conversion on a text-encoded SUM without an
+			// explicit backend-native integer CAST.
+			Amount:    9_007_199_254_740_993,
+			AddedSlot: 21,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x04}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeD,
+			CredentialTag: 0,
+			Amount:        3_000_000,
+			AddedSlot:     30,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+}
+
+// expectedRewardLiveStakeEquivalenceRows is the expected reward_live_stake
+// content after RebuildRewardLiveStake over
+// seedRewardLiveStakeEquivalenceScenario's scenario, at slot 100.
+func expectedRewardLiveStakeEquivalenceRows(
+	h rewardLiveStakeEquivalenceHashes,
+) []normalizedLiveStakeRow {
+	rows := []normalizedLiveStakeRow{
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeA),
+			PoolKeyHash:        string(h.poolA),
+			UtxoStake:          5_000_000,
+			RewardStake:        1_000_000,
+			TotalStake:         6_000_000,
+			Registered:         true,
+			PoolDelegationSlot: 15,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      1,
+			StakingKey:         string(h.stakeB),
+			PoolKeyHash:        string(h.poolB),
+			UtxoStake:          9_007_199_254_740_993,
+			RewardStake:        0,
+			TotalStake:         9_007_199_254_740_993,
+			Registered:         true,
+			PoolDelegationSlot: 20,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeC),
+			PoolKeyHash:        "",
+			UtxoStake:          0,
+			RewardStake:        500_000,
+			TotalStake:         500_000,
+			Registered:         false,
+			PoolDelegationSlot: 0,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeD),
+			PoolKeyHash:        "",
+			UtxoStake:          3_000_000,
+			RewardStake:        0,
+			TotalStake:         3_000_000,
+			Registered:         false,
+			PoolDelegationSlot: 0,
+			UpdatedSlot:        100,
+		},
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].CredentialTag != rows[j].CredentialTag {
+			return rows[i].CredentialTag < rows[j].CredentialTag
+		}
+		return rows[i].StakingKey < rows[j].StakingKey
+	})
+	return rows
+}
+
+// TestRewardLiveStakeRebuildCrossBackendEquivalencePostgres seeds the shared
+// scenario (byte-identical to the sqlite and mysql equivalence tests) on
+// postgres and asserts the rebuilt reward_live_stake rows for these specific
+// credentials match the expected values exactly.
+//
+// RebuildRewardLiveStake does a full-table DELETE + repopulate from every
+// account/UTxO row in the database, so the scenario runs in a rollback-only
+// transaction to leave the shared postgres database unchanged.
+func TestRewardLiveStakeRebuildCrossBackendEquivalencePostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+	txn, err := store.BeginTxn()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = txn.Rollback() })
+	db, err := store.resolveDB(txn)
+	require.NoError(t, err)
+	h := newRewardLiveStakeEquivalenceHashes()
+	stakingKeys := [][]byte{h.stakeA, h.stakeB, h.stakeC, h.stakeD}
+	for _, k := range stakingKeys {
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.RewardLiveStake{}).Error)
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.StakeDelegation{}).Error)
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.Utxo{}).Error)
+		require.NoError(t, db.Where("staking_key = ?", k).
+			Delete(&models.Account{}).Error)
+	}
+
+	seedRewardLiveStakeEquivalenceScenario(t, db, h)
+
+	require.NoError(t, store.RebuildRewardLiveStake(100, txn))
+
+	var rows []models.RewardLiveStake
+	require.NoError(t, db.
+		Where("staking_key IN ?", stakingKeys).
+		Order("credential_tag ASC, staking_key ASC").
+		Find(&rows).Error)
+
+	require.Equal(
+		t,
+		expectedRewardLiveStakeEquivalenceRows(h),
+		normalizeLiveStakeRows(rows),
+	)
+}

--- a/database/plugin/metadata/postgres/stake_snapshot_test.go
+++ b/database/plugin/metadata/postgres/stake_snapshot_test.go
@@ -26,13 +26,13 @@ import (
 
 func TestSaveEpochSummaryUpsertSnapshotReadyPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
 
 	const epoch = uint64(424242)
-	require.NoError(t, store.DB().Where("epoch = ?", epoch).Delete(&models.EpochSummary{}).Error)
 	t.Cleanup(func() {
 		_ = store.DB().Where("epoch = ?", epoch).Delete(&models.EpochSummary{}).Error
+		_ = store.Close()
 	})
+	require.NoError(t, store.DB().Where("epoch = ?", epoch).Delete(&models.EpochSummary{}).Error)
 
 	initial := &models.EpochSummary{
 		Epoch:            epoch,

--- a/database/plugin/metadata/postgres/transaction_gap_test.go
+++ b/database/plugin/metadata/postgres/transaction_gap_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestSetGapBlockTransactionHydratesSnapshotUtxoPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
 
 	txHash := lcommon.NewBlake2b256(
 		[]byte("pg-gap-hydrate-snapshot-utxo-1"),
@@ -62,7 +61,10 @@ func TestSetGapBlockTransactionHydratesSnapshotUtxoPostgres(t *testing.T) {
 			Delete(&models.Transaction{}).Error
 	}
 	cleanup()
-	t.Cleanup(cleanup)
+	t.Cleanup(func() {
+		cleanup()
+		_ = store.Close()
+	})
 
 	require.NoError(t, store.DB().Create(&models.Utxo{
 		TxId:      txHash.Bytes(),

--- a/database/plugin/metadata/sqlite/poolreap_test.go
+++ b/database/plugin/metadata/sqlite/poolreap_test.go
@@ -95,3 +95,116 @@ func TestGetPoolsRetiringAtEpoch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, none, "retirement cert added at slot 200 is excluded before slot 150")
 }
+
+func TestGetPoolsRetiringAtEpochTieBreaksSameAddedSlot(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	const (
+		retireEpoch = uint64(5)
+		certSlot    = uint64(300)
+		querySlot   = uint64(301)
+	)
+
+	tx := &models.Transaction{
+		Hash:       []byte("poolreap_same_slot_tx_hash_0001"),
+		Slot:       certSlot,
+		BlockIndex: 0,
+		Valid:      true,
+	}
+	require.NoError(t, store.DB().Create(tx).Error)
+	cert0 := &models.Certificate{
+		TransactionID: tx.ID,
+		Slot:          certSlot,
+		CertIndex:     0,
+	}
+	cert1 := &models.Certificate{
+		TransactionID: tx.ID,
+		Slot:          certSlot,
+		CertIndex:     1,
+	}
+	require.NoError(t, store.DB().Create(cert0).Error)
+	require.NoError(t, store.DB().Create(cert1).Error)
+
+	laterTx := &models.Transaction{
+		Hash:       []byte("poolreap_same_slot_tx_hash_0002"),
+		Slot:       certSlot,
+		BlockIndex: 1,
+		Valid:      true,
+	}
+	require.NoError(t, store.DB().Create(laterTx).Error)
+	cert2 := &models.Certificate{
+		TransactionID: laterTx.ID,
+		Slot:          certSlot,
+		CertIndex:     0,
+	}
+	require.NoError(t, store.DB().Create(cert2).Error)
+
+	// Pool A: the retirement appears first and a same-slot registration
+	// appears later in the transaction. The registration cancels the
+	// retirement, so no POOLREAP refund should be emitted.
+	poolA := seedRetiringPool(t, store, poolreapBytes(0xAA), poolreapBytes(0x11), 500, 100)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID:        poolA.ID,
+		PoolKeyHash:   poolA.PoolKeyHash,
+		Epoch:         retireEpoch,
+		AddedSlot:     certSlot,
+		CertificateID: cert0.ID,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:        poolA.ID,
+		PoolKeyHash:   poolA.PoolKeyHash,
+		RewardAccount: poolreapBytes(0x22),
+		DepositAmount: types.Uint64(700),
+		AddedSlot:     certSlot,
+		CertificateID: cert1.ID,
+	}).Error)
+
+	// Pool B: the same-slot retirement appears after the registration and is
+	// therefore effective. The refund uses that latest registration.
+	poolB := &models.Pool{PoolKeyHash: poolreapBytes(0xBB)}
+	require.NoError(t, store.DB().Create(poolB).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:        poolB.ID,
+		PoolKeyHash:   poolB.PoolKeyHash,
+		RewardAccount: poolreapBytes(0x33),
+		DepositAmount: types.Uint64(900),
+		AddedSlot:     certSlot,
+		CertificateID: cert0.ID,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID:        poolB.ID,
+		PoolKeyHash:   poolB.PoolKeyHash,
+		Epoch:         retireEpoch,
+		AddedSlot:     certSlot,
+		CertificateID: cert1.ID,
+	}).Error)
+
+	// Pool C: the earlier transaction's retirement has a higher CertIndex,
+	// but the later transaction's registration wins because BlockIndex is
+	// compared before CertIndex.
+	poolC := &models.Pool{PoolKeyHash: poolreapBytes(0xCC)}
+	require.NoError(t, store.DB().Create(poolC).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID:        poolC.ID,
+		PoolKeyHash:   poolC.PoolKeyHash,
+		Epoch:         retireEpoch,
+		AddedSlot:     certSlot,
+		CertificateID: cert1.ID,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:        poolC.ID,
+		PoolKeyHash:   poolC.PoolKeyHash,
+		RewardAccount: poolreapBytes(0x44),
+		DepositAmount: types.Uint64(1100),
+		AddedSlot:     certSlot,
+		CertificateID: cert2.ID,
+	}).Error)
+
+	refunds, err := store.GetPoolsRetiringAtEpoch(retireEpoch, querySlot, nil)
+	require.NoError(t, err)
+	require.Len(t, refunds, 1, "later BlockIndex must precede CertIndex")
+	assert.Equal(t, poolB.PoolKeyHash, refunds[0].PoolKeyHash)
+	assert.Equal(t, poolreapBytes(0x33), refunds[0].RewardAccount)
+	assert.Equal(t, uint64(900), uint64(refunds[0].DepositAmount))
+}

--- a/database/plugin/metadata/sqlite/reward_live_stake_equivalence_test.go
+++ b/database/plugin/metadata/sqlite/reward_live_stake_equivalence_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// normalizedLiveStakeRow is the backend-agnostic shape used to compare
+// reward_live_stake rows across sqlite, mysql, and postgres: every field
+// except the auto-increment ID, which is expected to differ across
+// backends/runs.
+type normalizedLiveStakeRow struct {
+	CredentialTag            uint8
+	StakingKey               string
+	PoolKeyHash              string
+	UtxoStake                uint64
+	RewardStake              uint64
+	TotalStake               uint64
+	Registered               bool
+	PoolDelegationSlot       uint64
+	PoolDelegationBlockIndex uint64
+	PoolDelegationCertIndex  uint32
+	UpdatedSlot              uint64
+}
+
+func normalizeLiveStakeRows(
+	rows []models.RewardLiveStake,
+) []normalizedLiveStakeRow {
+	out := make([]normalizedLiveStakeRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, normalizedLiveStakeRow{
+			CredentialTag:            row.CredentialTag,
+			StakingKey:               string(row.StakingKey),
+			PoolKeyHash:              string(row.PoolKeyHash),
+			UtxoStake:                uint64(row.UtxoStake),
+			RewardStake:              uint64(row.RewardStake),
+			TotalStake:               uint64(row.TotalStake),
+			Registered:               row.Registered,
+			PoolDelegationSlot:       row.PoolDelegationSlot,
+			PoolDelegationBlockIndex: row.PoolDelegationBlockIndex,
+			PoolDelegationCertIndex:  row.PoolDelegationCertIndex,
+			UpdatedSlot:              row.UpdatedSlot,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CredentialTag != out[j].CredentialTag {
+			return out[i].CredentialTag < out[j].CredentialTag
+		}
+		return out[i].StakingKey < out[j].StakingKey
+	})
+	return out
+}
+
+// rewardLiveStakeEquivalenceHashes are the fixed 28-byte test vectors used
+// (by identical construction, not by cross-package import) across the
+// sqlite/mysql/postgres equivalence tests, so every backend rebuilds from
+// byte-identical input.
+type rewardLiveStakeEquivalenceHashes struct {
+	poolA, poolB           []byte
+	stakeA, stakeB, stakeC []byte
+	stakeD                 []byte
+}
+
+func newRewardLiveStakeEquivalenceHashes() rewardLiveStakeEquivalenceHashes {
+	return rewardLiveStakeEquivalenceHashes{
+		poolA:  bytes.Repeat([]byte{0xA1}, 28),
+		poolB:  bytes.Repeat([]byte{0xB1}, 28),
+		stakeA: bytes.Repeat([]byte{0x10}, 28),
+		stakeB: bytes.Repeat([]byte{0x20}, 28),
+		stakeC: bytes.Repeat([]byte{0x30}, 28),
+		stakeD: bytes.Repeat([]byte{0x40}, 28),
+	}
+}
+
+// seedRewardLiveStakeEquivalenceScenario populates the same
+// accounts/UTxOs/delegation-certificate scenario used by every backend's
+// cross-backend equivalence test:
+//
+//   - stakeA (key credential): active, delegated to poolA both via
+//     account.Pool and a stake_delegation cert recorded after the account's
+//     own AddedSlot (exercises the latest_delegation CTE overriding the
+//     account fallback), one live UTxO and one deleted (excluded) UTxO.
+//   - stakeB (script credential): active, delegated to poolB with no
+//     delegation certificate on record (exercises the account.AddedSlot
+//     fallback), and one live UTxO whose amount exceeds 2^53 (exercises the
+//     backend-native integer CAST that avoids MySQL's lossy implicit DOUBLE
+//     conversion on a text-encoded SUM).
+//   - stakeC: a deregistered (inactive) account with a nonzero reward and no
+//     UTxOs (exercises registered=false with pool_key_hash NULL and
+//     reward_stake carried through the account.reward CAST fix).
+//   - stakeD: a live UTxO with no matching account row at all (exercises the
+//     UTxO-only fallback branch of the creds UNION).
+func seedRewardLiveStakeEquivalenceScenario(
+	t *testing.T,
+	db *gorm.DB,
+	h rewardLiveStakeEquivalenceHashes,
+) {
+	t.Helper()
+
+	accounts := []models.Account{
+		{
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Pool:          h.poolA,
+			Reward:        1_000_000,
+			Active:        true,
+			AddedSlot:     10,
+		},
+		{
+			StakingKey:    h.stakeB,
+			CredentialTag: 1,
+			Pool:          h.poolB,
+			Reward:        0,
+			Active:        true,
+			AddedSlot:     20,
+		},
+		{
+			// Active starts true and is flipped to false below: GORM's
+			// Create skips zero-value fields when the model has a
+			// `default:true` tag (Account.Active does), so Active: false
+			// here would otherwise be silently stored as true.
+			StakingKey:    h.stakeC,
+			CredentialTag: 0,
+			Pool:          nil,
+			Reward:        500_000,
+			Active:        true,
+			AddedSlot:     5,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	require.NoError(
+		t,
+		db.Model(&accounts[2]).Update("active", false).Error,
+	)
+
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		StakingKey:    h.stakeA,
+		CredentialTag: 0,
+		PoolKeyHash:   h.poolA,
+		AddedSlot:     15,
+	}).Error)
+
+	utxos := []models.Utxo{
+		{
+			TxId:          bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Amount:        5_000_000,
+			AddedSlot:     11,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeA,
+			CredentialTag: 0,
+			Amount:        2_000_000,
+			AddedSlot:     12,
+			DeletedSlot:   50,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeB,
+			CredentialTag: 1,
+			// Exceeds 2^53 (9007199254740992): exposes MySQL's lossy
+			// implicit DOUBLE conversion on a text-encoded SUM without an
+			// explicit backend-native integer CAST.
+			Amount:    9_007_199_254_740_993,
+			AddedSlot: 21,
+		},
+		{
+			TxId:          bytes.Repeat([]byte{0x04}, 32),
+			OutputIdx:     0,
+			StakingKey:    h.stakeD,
+			CredentialTag: 0,
+			Amount:        3_000_000,
+			AddedSlot:     30,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+}
+
+// expectedRewardLiveStakeEquivalenceRows is the expected reward_live_stake
+// content after RebuildRewardLiveStake over
+// seedRewardLiveStakeEquivalenceScenario's scenario, at slot 100.
+func expectedRewardLiveStakeEquivalenceRows(
+	h rewardLiveStakeEquivalenceHashes,
+) []normalizedLiveStakeRow {
+	rows := []normalizedLiveStakeRow{
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeA),
+			PoolKeyHash:        string(h.poolA),
+			UtxoStake:          5_000_000,
+			RewardStake:        1_000_000,
+			TotalStake:         6_000_000,
+			Registered:         true,
+			PoolDelegationSlot: 15,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      1,
+			StakingKey:         string(h.stakeB),
+			PoolKeyHash:        string(h.poolB),
+			UtxoStake:          9_007_199_254_740_993,
+			RewardStake:        0,
+			TotalStake:         9_007_199_254_740_993,
+			Registered:         true,
+			PoolDelegationSlot: 20,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeC),
+			PoolKeyHash:        "",
+			UtxoStake:          0,
+			RewardStake:        500_000,
+			TotalStake:         500_000,
+			Registered:         false,
+			PoolDelegationSlot: 0,
+			UpdatedSlot:        100,
+		},
+		{
+			CredentialTag:      0,
+			StakingKey:         string(h.stakeD),
+			PoolKeyHash:        "",
+			UtxoStake:          3_000_000,
+			RewardStake:        0,
+			TotalStake:         3_000_000,
+			Registered:         false,
+			PoolDelegationSlot: 0,
+			UpdatedSlot:        100,
+		},
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].CredentialTag != rows[j].CredentialTag {
+			return rows[i].CredentialTag < rows[j].CredentialTag
+		}
+		return rows[i].StakingKey < rows[j].StakingKey
+	})
+	return rows
+}
+
+// TestRewardLiveStakeRebuildCrossBackendEquivalenceSqlite seeds the shared
+// scenario on sqlite and asserts the rebuilt reward_live_stake rows match
+// the expected values exactly. mysql/postgres run the identical scenario
+// under the dingo_extra_plugins build tag
+// (reward_live_stake_equivalence_test.go in each of those packages); all
+// three are expected to produce byte-identical normalized rows from the same
+// input, which is the cross-backend payoff of consolidating the three
+// RebuildRewardLiveStake SQL copies into one.
+func TestRewardLiveStakeRebuildCrossBackendEquivalenceSqlite(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+	h := newRewardLiveStakeEquivalenceHashes()
+	seedRewardLiveStakeEquivalenceScenario(t, store.DB(), h)
+
+	require.NoError(t, store.RebuildRewardLiveStake(100, nil))
+
+	var rows []models.RewardLiveStake
+	require.NoError(t, store.DB().Order(
+		"credential_tag ASC, staking_key ASC",
+	).Find(&rows).Error)
+
+	require.Equal(
+		t,
+		expectedRewardLiveStakeEquivalenceRows(h),
+		normalizeLiveStakeRows(rows),
+	)
+}

--- a/database/plugin/metadata/sqlite/sqlite_test.go
+++ b/database/plugin/metadata/sqlite/sqlite_test.go
@@ -1420,7 +1420,7 @@ func TestRestoreAccountStateAtSlot(t *testing.T) {
 			}
 		}
 
-		stakingKey := bytes.Repeat([]byte{0x91}, 28)
+		stakingKey := bytes.Repeat([]byte{0x31}, 28)
 		poolHash1 := []byte("pool_hash_1_12345678901234567890123456789012")
 		poolHash2 := []byte("pool_hash_2_12345678901234567890123456789012")
 
@@ -1549,7 +1549,7 @@ func TestRestoreAccountStateAtSlot(t *testing.T) {
 				}
 			}
 
-			stakingKey := bytes.Repeat([]byte{0x92}, 28)
+			stakingKey := bytes.Repeat([]byte{0x32}, 28)
 
 			// Create an account that is currently inactive (deregistered at slot 2000)
 			account := models.Account{
@@ -1649,7 +1649,7 @@ func TestRestoreAccountStateAtSlot(t *testing.T) {
 				}
 			}
 
-			stakingKey := bytes.Repeat([]byte{0x93}, 28)
+			stakingKey := bytes.Repeat([]byte{0x33}, 28)
 
 			// Create an account that was re-registered at slot 2000 (currently active)
 			account := models.Account{
@@ -1768,7 +1768,7 @@ func TestRestoreAccountStateAtSlot(t *testing.T) {
 			t.Fatalf("failed to create transaction: %v", err)
 		}
 
-		stakingKey := bytes.Repeat([]byte{0x94}, 28)
+		stakingKey := bytes.Repeat([]byte{0x34}, 28)
 
 		// Create an account registered at slot 2000 (after rollback point)
 		account := models.Account{
@@ -3012,16 +3012,18 @@ func TestGetActivePoolKeyHashesAtSlot(t *testing.T) {
 				PoolID:        pool.ID,
 				PoolKeyHash:   poolHash,
 				AddedSlot:     1000,
-				CertificateID: 200,
+				CertificateID: regCert.ID,
 			}
 			if result := sqliteStore.DB().Create(&poolReg); result.Error != nil {
 				t.Fatalf("failed to create pool registration: %v", result.Error)
 			}
+
 			poolRet := models.PoolRetirement{
-				PoolID:      pool.ID,
-				PoolKeyHash: poolHash,
-				AddedSlot:   1000,
-				Epoch:       10,
+				PoolID:        pool.ID,
+				PoolKeyHash:   poolHash,
+				AddedSlot:     1000,
+				Epoch:         10,
+				CertificateID: 0,
 			}
 			if result := sqliteStore.DB().Create(&poolRet); result.Error != nil {
 				t.Fatalf("failed to create pool retirement: %v", result.Error)

--- a/database/types/keys_test.go
+++ b/database/types/keys_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+func TestPoolCredentialStakeKey(t *testing.T) {
+	poolKeyHash := []byte{0x01, 0x02}
+	stakingKey := []byte{0x03, 0x04}
+
+	got := types.PoolCredentialStakeKey(poolKeyHash, 0x05, stakingKey)
+	want := string([]byte{0x01, 0x02, 0x05, 0x03, 0x04})
+	if got != want {
+		t.Fatalf("PoolCredentialStakeKey() = %x, want %x", got, want)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds cross-backend tests to ensure `reward_live_stake` parity and proves reward-credit delta updates are exact. Also adds a same-slot POOLREAP tie-break and test cleanup. Addresses Linear issue 1959.

- **New Features**
  - Cross-backend `reward_live_stake` equivalence tests on `sqlite`, `mysql`, and `postgres` using normalized row comparison, including large-UTxO precision.
  - Verifies `AddAccountRewardByCredential` delta-path exactness across two sequential credits on `mysql` and `postgres`, with rebuild cross-checks.
  - Adds `sqlite` POOLREAP same-slot tie-break (BlockIndex before CertIndex).
  - Test hygiene: deterministic hash helpers in `postgres`, consistent `t.Cleanup` DB closing, fixture fixes, and a unit test for `types.PoolCredentialStakeKey`.

<sup>Written for commit 77a1d5560157d61626fb650593420838483b4065. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

