### PR TITLE
fix(ledger): break single-relay chainsync rollback loop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1449,6 +1449,23 @@ trust-boundary reasons) place the peer on the deny list for a cooldown in
 addition to closing the connection, so the node does not redial a peer that
 will deterministically be rejected again moments later.
 
+The per-connection rollback loop detector (`rollbackHistory` in
+`LedgerState`) records recent rollback points per connection and breaks a
+loop if the same point recurs past a threshold within a window. Two rules keep
+it from suppressing legitimate rollbacks (issue #2790). First, a rollback the
+node successfully applies is forward progress toward the peer's chain, so its
+records are cleared from `rollbackHistory` on the successful cross
+(`clearRollbackHistoryForPoint`), so a legitimately repeated but crossable
+rollback does not accumulate toward the threshold. Second, even when a point
+does reach the threshold, the detector only breaks the loop if the rollback is
+genuinely un-crossable: `rollbackIsAppliable` mirrors the pre-checks
+`rollbackChainAndState` uses (target block present and within the security
+parameter K via `chain.ValidateRollback`, and at/above the Mithril anchor),
+and a rollback that would succeed is applied even on the repeat rather than
+suppressed. Only a rollback the node cannot cross takes the skip path, which
+would otherwise wedge the node in a reconnect loop behind a legitimately
+advancing peer.
+
 When the local chain has diverged from the network, an upstream peer can
 repeatedly ask us to roll back to a canonical point we cannot cross to
 (the block is missing below our diverged tip, the rollback exceeds K, or it
@@ -1460,7 +1477,10 @@ un-crossable rollbacks; once the same point recurs past a threshold within a
 window it surfaces the stuck-divergence condition as a throttled operator
 error plus the `dingo_chainsync_unrecoverable_rollback_total` metric, since a
 node in this state cannot self-recover and needs operator intervention
-(e.g. re-bootstrapping from a Mithril snapshot).
+(e.g. re-bootstrapping from a Mithril snapshot). When the per-connection loop
+detector itself breaks a loop by skipping a rollback it can no longer cross,
+it feeds that same point-keyed tracker so the escalation and metric fire on
+the skip path too, rather than silently suppressing the rollback.
 
 Topology configuration is loaded from an explicit topology file when provided,
 otherwise from the embedded `network/topology.json` for built-in networks,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1359,7 +1359,34 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 				skipRollback = false
 			}
 		}
+		// A rollback the node can actually apply (target block present,
+		// within the security parameter K, at/above the Mithril anchor)
+		// must be crossed even when the same point repeats. Suppressing a
+		// crossable rollback wedges the node behind a legitimately advancing
+		// peer and turns a transient fork into an unrecoverable reconnect
+		// loop (issue #2790). Only a rollback the node genuinely cannot
+		// cross is a true loop to break; those fall through to the skip +
+		// #2728 escalation below.
+		if skipRollback && ls.rollbackIsAppliable(e.Point) {
+			ls.config.Logger.Info(
+				"allowing repeated crossable rollback to converge to peer",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"count", slotCount,
+			)
+			skipRollback = false
+		}
 		if skipRollback {
+			// Surface the stuck condition through the point-keyed tracker
+			// that survives the resync reset+reconnect cycle. Without this
+			// the skip silently breaks the loop and the #2728 escalation
+			// (operator error + metric) never fires, hiding a node that
+			// cannot self-recover (issue #2790 bullet 6).
+			ls.reportUnrecoverableRollbackIfStuck(
+				e.Point,
+				event.ChainsyncResyncReasonRollbackLoop,
+				e.ConnectionId,
+			)
 			ls.config.Logger.Warn(
 				"rollback loop detected, skipping rollback to break loop",
 				"component", "ledger",
@@ -1591,7 +1618,60 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 	// un-crossable-rollback tracking is stale. Clear it so a later,
 	// unrelated divergence starts counting from zero (see issue #2728).
 	ls.clearUnrecoverableRollbacks()
+	// Crossing to the point is forward progress toward the peer's chain, so
+	// drop this point's per-connection loop-detector records too. A rollback
+	// we actually applied must not count toward the repeat-loop threshold on
+	// a later, legitimate rollback to the same fork point; leaving the
+	// records accumulates crossable rollbacks until the loop detector
+	// suppresses one, wedging the node in a reconnect loop behind a
+	// legitimately advancing peer (issue #2790).
+	ls.clearRollbackHistoryForPoint(e.Point)
 	return nil
+}
+
+// rollbackIsAppliable reports whether rollbackChainAndState(point) would
+// succeed right now, without mutating any state. It mirrors the pre-checks
+// rollbackChainAndState relies on for its block-not-found / exceeds-K /
+// exceeds-Mithril failures: the point must sit at or above the Mithril trust
+// anchor, and the chain must be able to roll back to it (target block present
+// and within the security parameter K, verified via chain.ValidateRollback).
+//
+// The loop detector uses this to decide whether a repeated rollback is a
+// crossable point that must be applied (issue #2790) rather than a genuinely
+// un-crossable loop to break.
+//
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) rollbackIsAppliable(point ocommon.Point) bool {
+	if ls.chain == nil {
+		return false
+	}
+	mithrilLedgerSlot := ls.mithrilLedgerSlotSnapshot()
+	if mithrilLedgerSlot > 0 && point.Slot < mithrilLedgerSlot {
+		return false
+	}
+	return ls.chain.ValidateRollback(point) == nil
+}
+
+// clearRollbackHistoryForPoint removes per-connection loop-detector records
+// for a rollback point the node has successfully applied. A crossable rollback
+// we actually crossed made forward progress toward the peer's chain, so it
+// must not count toward the repeat-loop threshold that breaks pathological
+// loops. Rollbacks the node genuinely cannot cross never reach this path and
+// are tracked separately by the survives-reset unrecoverableRollbacks map.
+//
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) clearRollbackHistoryForPoint(point ocommon.Point) {
+	if len(ls.rollbackHistory) == 0 {
+		return
+	}
+	filtered := ls.rollbackHistory[:0]
+	for _, r := range ls.rollbackHistory {
+		if pointMatches(r.point, point) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	ls.rollbackHistory = filtered
 }
 
 // resetChainsyncResyncState clears chainsync-local recovery state before a

--- a/ledger/chainsync_rollback_loop_test.go
+++ b/ledger/chainsync_rollback_loop_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A crossable rollback the node actually applies must not leave its point in
+// the per-connection loop detector. Otherwise a later, legitimate rollback to
+// the same fork point counts the crossing we already made and is suppressed as
+// a false loop, which is the reconnect-churn wedge in issue #2790.
+func TestHandleEventChainsyncRollbackClearsLoopHistoryForCrossedPoint(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        fixture.ancestorTip.Point,
+	})
+	require.NoError(t, err)
+	require.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+
+	for _, r := range fixture.ls.rollbackHistory {
+		assert.Falsef(
+			t,
+			pointMatches(r.point, fixture.ancestorTip.Point),
+			"a successfully applied rollback must clear its loop-detector record",
+		)
+	}
+}
+
+// The #2790 loop shape: after crossing a fork point the node advances forward
+// on the peer's chain, then the peer rolls it back to the same fork point
+// again. Because the successful first cross reset the loop counter, the second
+// crossable rollback must be applied, not suppressed as a false loop.
+func TestHandleEventChainsyncRollbackAppliesRepeatedCrossableRollback(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	require.NoError(t, fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        fixture.ancestorTip.Point,
+	}))
+	require.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+
+	// Re-extend the chain past the fork point so a second rollback to it is
+	// once more a real sub-K rollback.
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        fixture.currentTip.Point.Slot,
+			Hash:        fixture.currentTip.Point.Hash,
+			BlockNumber: fixture.currentTip.BlockNumber,
+			Type:        1,
+			PrevHash:    fixture.ancestorTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+	require.Equal(
+		t,
+		fixture.currentTip.Point.Slot,
+		fixture.ls.chain.Tip().Point.Slot,
+	)
+
+	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        fixture.ancestorTip.Point,
+	})
+	require.NoError(t, err)
+	require.NotErrorIs(t, err, ErrRollbackLoopDetected)
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+}
+
+// When the loop detector breaks a loop for a genuinely un-crossable rollback,
+// the skip path must surface the stuck condition through the point-keyed #2728
+// unrecoverable-rollback tracker so the escalation and metric can fire,
+// instead of silently skipping and hiding a persistently un-recoverable
+// divergence (issue #2790 bullet 6).
+func TestHandleEventChainsyncRollbackSkipReportsUnrecoverableRollback(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	// A rollback point the node cannot cross to (a fork block below our tip
+	// that is not present in our chain), so the loop detector genuinely skips
+	// it rather than applying it.
+	uncrossablePoint := ocommon.Point{
+		Slot: fixture.currentTip.Point.Slot - 3,
+		Hash: testHashBytes("uncrossable-report-fork-block"),
+	}
+
+	// Pre-seed one prior rollback so this call reaches the loop threshold
+	// and takes the skip path.
+	fixture.ls.rollbackHistory = []rollbackRecord{
+		{
+			point: ocommon.Point{
+				Slot: uncrossablePoint.Slot,
+				Hash: append([]byte(nil), uncrossablePoint.Hash...),
+			},
+			connKey:   connIdKey(fixture.connId),
+			timestamp: time.Now(),
+		},
+	}
+
+	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        uncrossablePoint,
+	})
+	require.ErrorIs(t, err, ErrRollbackLoopDetected)
+
+	_, ok := fixture.ls.unrecoverableRollbacks[unrecoverableRollbackKey(
+		uncrossablePoint,
+	)]
+	assert.True(
+		t,
+		ok,
+		"skip path must record the point in the unrecoverable-rollback tracker",
+	)
+}
+
+// A crossable rollback that reaches the per-connection loop threshold must
+// still be APPLIED, not suppressed as a false loop: the loop detector only
+// breaks loops for rollbacks the node cannot cross (issue #2790, requirement
+// 1). This exercises the appliability guard directly by pre-seeding history to
+// the threshold, unlike the reset-on-success path which never reaches it.
+func TestHandleEventChainsyncRollbackAppliesCrossableRollbackAtLoopThreshold(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+
+	// Seed a prior rollback to the (crossable) shared ancestor so this call
+	// hits the loop threshold.
+	fixture.ls.rollbackHistory = []rollbackRecord{
+		{
+			point: ocommon.Point{
+				Slot: fixture.ancestorTip.Point.Slot,
+				Hash: append([]byte(nil), fixture.ancestorTip.Point.Hash...),
+			},
+			connKey:   connIdKey(fixture.connId),
+			timestamp: time.Now(),
+		},
+	}
+
+	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        fixture.ancestorTip.Point,
+	})
+	require.NoError(t, err)
+	require.NotErrorIs(t, err, ErrRollbackLoopDetected)
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.currentTip)
+}

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -289,11 +289,23 @@ func TestHandleEventChainsyncRollbackSkipsSamePeerLoop(
 ) {
 	fixture := newChainsyncRollbackFixture(t)
 
+	// A genuinely un-crossable rollback point: a fork block below our tip
+	// that is not present in our chain. The loop detector must break the loop
+	// only for points the node cannot apply. A crossable point is instead
+	// applied even when it repeats (see
+	// TestHandleEventChainsyncRollbackAppliesRepeatedCrossableRollback and
+	// TestHandleEventChainsyncRollbackAppliesCrossableRollbackAtLoopThreshold),
+	// which is the issue #2790 fix.
+	uncrossablePoint := ocommon.Point{
+		Slot: fixture.currentTip.Point.Slot - 3,
+		Hash: testHashBytes("uncrossable-missing-fork-block"),
+	}
+
 	fixture.ls.rollbackHistory = []rollbackRecord{
 		{
 			point: ocommon.Point{
-				Slot: fixture.ancestorTip.Point.Slot,
-				Hash: append([]byte(nil), fixture.ancestorTip.Point.Hash...),
+				Slot: uncrossablePoint.Slot,
+				Hash: append([]byte(nil), uncrossablePoint.Hash...),
 			},
 			connKey:   connIdKey(fixture.connId),
 			timestamp: time.Now(),
@@ -303,7 +315,7 @@ func TestHandleEventChainsyncRollbackSkipsSamePeerLoop(
 	err := fixture.ls.handleEventChainsyncRollback(
 		ChainsyncEvent{
 			ConnectionId: fixture.connId,
-			Point:        fixture.ancestorTip.Point,
+			Point:        uncrossablePoint,
 		},
 	)
 	require.ErrorIs(t, err, ErrRollbackLoopDetected)


### PR DESCRIPTION
Closes #2790 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a chainsync rollback loop on single-relay connections by applying repeated rollbacks that are still crossable and clearing loop-detector history after successful crossings. This prevents reconnect churn and lets the node converge to an advancing peer (addresses #2790).

- **Bug Fixes**
  - Only break loops when the repeated rollback is not crossable: `rollbackIsAppliable` checks target block present, within K via `chain.ValidateRollback`, and above the Mithril anchor; crossable repeats are applied even at the loop threshold.
  - After applying a rollback, remove that point from per-connection history with `clearRollbackHistoryForPoint` to avoid false loop suppression later.
  - When skipping an un-crossable rollback, record it in the unrecoverable-rollback tracker so the operator alert and `dingo_chainsync_unrecoverable_rollback_total` metric fire on the skip path.
  - Updated ARCHITECTURE docs; added tests for history clearing, crossable repeats (including at threshold), and skip reporting.

<sup>Written for commit 8378e74962a579ccf443236800bffe805c68867c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rollback-loop handling to distinguish legitimate repeated rollbacks from genuinely unresolvable loops.
  - Repeated rollbacks that can still be applied are no longer incorrectly skipped.
  - Successfully applied rollbacks no longer trigger premature loop detection later.
  - Unresolvable rollback loops now consistently trigger operator alerts and monitoring metrics.

- **Documentation**
  - Updated rollback-loop handling documentation, including applicability checks and escalation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->