### PR TITLE
fix: replace unchecked type assertion in localtxsubmission handler

### DIFF
--- a/ouroboros/localtxsubmission.go
+++ b/ouroboros/localtxsubmission.go
@@ -50,10 +50,24 @@ func (o *Ouroboros) localtxsubmissionServerSubmitTx(
 	ctx olocaltxsubmission.CallbackContext,
 	tx olocaltxsubmission.MsgSubmitTxTransaction,
 ) error {
+	rawTx, ok := tx.Raw.Content.([]byte)
+	if !ok {
+		o.config.Logger.Warn(
+			fmt.Sprintf(
+				"received local-tx-submission payload with unexpected content type: %T",
+				tx.Raw.Content,
+			),
+			"component", "network",
+			"protocol", "local-tx-submission",
+			"role", "server",
+			"connection_id", ctx.ConnectionId.String(),
+		)
+		return errors.New("local-tx-submission: unexpected transaction content type")
+	}
 	// Add transaction to mempool
 	err := o.Mempool.AddTransaction(
 		uint(tx.EraId),
-		tx.Raw.Content.([]byte),
+		rawTx,
 	)
 	if err != nil {
 		o.config.Logger.Error(

--- a/ouroboros/localtxsubmission_test.go
+++ b/ouroboros/localtxsubmission_test.go
@@ -17,12 +17,43 @@ package ouroboros
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"net"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	olocaltxsubmission "github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLocalTxSubmissionServerSubmitTx_NonByteContentReturnsError(t *testing.T) {
+	o := &Ouroboros{
+		config: OuroborosConfig{
+			Logger: slog.New(slog.DiscardHandler),
+		},
+	}
+	ctx := olocaltxsubmission.CallbackContext{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}
+	tx := olocaltxsubmission.MsgSubmitTxTransaction{
+		EraId: uint16(gledger.EraIdConway),
+		Raw: cbor.Tag{
+			Number:  24,
+			Content: "not-bytes",
+		},
+	}
+
+	require.NotPanics(t, func() {
+		err := o.localtxsubmissionServerSubmitTx(ctx, tx)
+		require.Error(t, err)
+	})
+}
 
 func TestLocalTxSubmissionRejectReason_FallbackIsHardForkApplyTxErr(t *testing.T) {
 	for _, era := range []uint16{


### PR DESCRIPTION
Closes #2433

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the unchecked type assertion in the local tx submission server so invalid transaction payloads no longer panic. Now we validate `tx.Raw.Content`, log a warning, and return a clear error (fixes #2433).

- **Bug Fixes**
  - Safely assert `tx.Raw.Content` as `[]byte`; return error if not.
  - Emit a warning log with connection and protocol details for unexpected types.
  - Added a test to ensure non-byte content returns an error without panicking.

<sup>Written for commit 21508c21bc4321b32f8fff9d4d72abfec7a5192a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

