### PR TITLE
fix: dial ledger-discovered pool relays by resolved IP, not hostname

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1454,7 +1454,15 @@ internal address (the one actually dialed), causing the node to TCP-probe
 internal addresses (a DNS-rebind attack; see issue #2435). The trade-off is
 that a multi-homed ledger relay does not get the load-spreading/backend-
 escape behavior described above; that is intentional given the untrusted
-input.
+input. Two refinements on that fallback resolution: the record locked in is
+filtered to the locally-supported address families first (same filter as the
+per-attempt path above), so a v4-only host doesn't get permanently pinned to
+an unreachable AAAA record it can never re-roll; and the write-back is
+skipped if another distinct peer entry already owns the resolved
+`NormalizedAddress`, since `peerIndexByAddress` assumes that field uniquely
+identifies a peer — colliding would misdirect that peer's connection
+bookkeeping onto this one. The peer simply re-resolves (still
+routability-checked every time) on its next attempt instead.
 
 Reconnect backoff after short-lived sessions escalates exponentially. The
 reconnect goroutine consumes and zeroes the stored delay before dialing, so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1454,10 +1454,16 @@ internal address (the one actually dialed), causing the node to TCP-probe
 internal addresses (a DNS-rebind attack; see issue #2435). The trade-off is
 that a multi-homed ledger relay does not get the load-spreading/backend-
 escape behavior described above; that is intentional given the untrusted
-input. Two refinements on that fallback resolution: the record locked in is
-filtered to the locally-supported address families first (same filter as the
-per-attempt path above), so a v4-only host doesn't get permanently pinned to
-an unreachable AAAA record it can never re-roll; and the write-back is
+input.
+
+Because the record chosen here — whether at discovery or in the fallback
+resolution — is what gets dialed for the peer's entire lifetime with no later
+attempt to self-correct, both resolution points filter to the
+locally-supported address families first (the same filter the per-attempt
+path above uses): `addLedgerPeer` calls `resolveLedgerDiscoveryAddress`
+rather than the generic `resolveAddress` used by every other peer source, so
+a v4-only host is never pinned to an unreachable AAAA record just because DNS
+answered with it first. Separately, the fallback resolution's write-back is
 skipped if another distinct peer entry already owns the resolved
 `NormalizedAddress`, since `peerIndexByAddress` assumes that field uniquely
 identifies a peer — colliding would misdirect that peer's connection

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1437,6 +1437,25 @@ timeout or failure the attempt falls back to the unresolved address. IP-literal
 peers dial unchanged, and peer identity/dedup stays keyed on the stable
 `Address`/`NormalizedAddress`, not the rotating dial target.
 
+Ledger-discovered pool relays (`PeerSourceP2PLedger`) are the one source
+exempted from that per-attempt re-resolution, because their hostname is
+attacker-supplied via on-chain stake pool registration rather than operator-
+or protocol-controlled. `resolveLedgerDialTarget` instead resolves the
+hostname exactly once and dials that same IP on every subsequent attempt: in
+the common case the IP already locked in by `addLedgerPeer`'s discovery-time
+resolution (stored in `NormalizedAddress`, the same value `isRoutableAddr`
+checked) is reused as-is; only if that earlier resolution had failed does it
+resolve once more here, re-check routability, and write the result back to
+`NormalizedAddress` so it is locked in from then on. This guarantees the IP
+that passed the routability check is always the IP that gets dialed — without
+it, a malicious or compromised authoritative DNS server could answer a first
+lookup with a public IP (passing the check) and a later lookup with an
+internal address (the one actually dialed), causing the node to TCP-probe
+internal addresses (a DNS-rebind attack; see issue #2435). The trade-off is
+that a multi-homed ledger relay does not get the load-spreading/backend-
+escape behavior described above; that is intentional given the untrusted
+input.
+
 Reconnect backoff after short-lived sessions escalates exponentially. The
 reconnect goroutine consumes and zeroes the stored delay before dialing, so
 the close handler derives the next rung from a count of consecutive

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 )
 
 func isConnectionCancellationError(err error) bool {
@@ -304,16 +305,33 @@ func (p *PeerGovernor) createOutboundConnection(peer *Peer) {
 			continue
 		}
 
-		// Re-resolve hostname-based peers on every attempt and rotate the
-		// dial target across all resolved records so load spreads across
+		// Determine the dial target for this attempt. Ledger-discovered
+		// pool relays are resolved once and locked to that IP (see
+		// resolveLedgerDialTarget): their hostname is attacker-supplied via
+		// on-chain stake pool registration, so re-resolving it at dial time
+		// would let a malicious DNS server pass the routability check with
+		// one IP and dial an internal one with another (DNS rebind). Every
+		// other source re-resolves on each attempt and rotates the dial
+		// target across all resolved records so load spreads across
 		// load-balancer backends and a stuck/unhealthy backend is escaped
-		// on the next attempt without a process restart. IP-literal peers
-		// are returned unchanged. Peer identity/dedup is keyed on
+		// without a process restart; those hostnames are operator- or
+		// protocol-controlled, not attacker-supplied. IP-literal peers are
+		// returned unchanged either way. Peer identity/dedup is keyed on
 		// peer.Address / NormalizedAddress and is unaffected.
-		conn, err := p.config.ConnManager.CreateOutboundConn(
-			p.ctx,
-			p.resolveDialAddress(p.ctx, peer.Address),
-		)
+		var dialTarget string
+		var err error
+		if peer.Source == PeerSourceP2PLedger {
+			dialTarget, err = p.resolveLedgerDialTarget(p.ctx, peer)
+		} else {
+			dialTarget = p.resolveDialAddress(p.ctx, peer.Address)
+		}
+		var conn *ouroboros.Connection
+		if err == nil {
+			conn, err = p.config.ConnManager.CreateOutboundConn(
+				p.ctx,
+				dialTarget,
+			)
+		}
 		if err == nil {
 			connId := conn.Id()
 			p.mu.Lock()

--- a/peergov/ledger_dial_security_test.go
+++ b/peergov/ledger_dial_security_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveLedgerDialTarget_LockedInIPUnaffectedByRebindAttempt is the core
+// regression test for issue #2435: once a ledger relay hostname has been
+// resolved (peer.NormalizedAddress is already an IP), resolveLedgerDialTarget
+// must return that same IP without consulting the resolver again. A
+// compromised authoritative DNS server that answers a second lookup with an
+// internal address must have no effect, because no second lookup happens.
+func TestResolveLedgerDialTarget_LockedInIPUnaffectedByRebindAttempt(t *testing.T) {
+	calls := 0
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls++
+		// If this were consulted, it would rebind to an internal address.
+		return []net.IP{net.ParseIP("10.0.0.5")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	peer := &Peer{
+		Address:           "relay.example.com:3001",
+		NormalizedAddress: "198.51.100.7:3001", // resolved at discovery time
+		Source:            PeerSourceP2PLedger,
+	}
+
+	got, err := pg.resolveLedgerDialTarget(context.Background(), peer)
+	require.NoError(t, err)
+	assert.Equal(t, "198.51.100.7:3001", got)
+	assert.Equal(t, 0, calls, "a locked-in IP must not trigger a fresh DNS lookup")
+	assert.Equal(t, "198.51.100.7:3001", peer.NormalizedAddress)
+}
+
+// TestResolveLedgerDialTarget_LocksInResolutionOnFallbackHostname verifies the
+// fallback path: if discovery-time resolution failed and NormalizedAddress is
+// still a hostname, the first dial attempt resolves once, checks routability,
+// and writes the resolved IP back so every later attempt reuses it instead of
+// resolving again.
+func TestResolveLedgerDialTarget_LocksInResolutionOnFallbackHostname(t *testing.T) {
+	calls := 0
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls++
+		return []net.IP{net.ParseIP("203.0.113.5")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	peer := &Peer{
+		Address:           "relay2.example.com:3001",
+		NormalizedAddress: "relay2.example.com:3001", // discovery resolution had failed
+		Source:            PeerSourceP2PLedger,
+	}
+	pg.peers = []*Peer{peer}
+
+	got, err := pg.resolveLedgerDialTarget(context.Background(), peer)
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.5:3001", got)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "203.0.113.5:3001", peer.NormalizedAddress)
+
+	// Change the resolver to return a different address entirely. A second
+	// call must still return the locked-in result without consulting it.
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls++
+		return []net.IP{net.ParseIP("10.9.9.9")}, nil
+	}
+	got, err = pg.resolveLedgerDialTarget(context.Background(), peer)
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.5:3001", got)
+	assert.Equal(t, 1, calls, "resolution must not happen again once locked in")
+}
+
+// TestResolveLedgerDialTarget_RejectsUnroutableResolutionAndDoesNotLockIn
+// verifies that when the fallback resolution (discovery-time lookup failed)
+// yields a non-routable IP, the dial is refused rather than silently probing
+// a private address, and the hostname is left un-locked so a later attempt
+// gets a fresh chance to resolve to something routable.
+func TestResolveLedgerDialTarget_RejectsUnroutableResolutionAndDoesNotLockIn(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.1.2.3")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	peer := &Peer{
+		Address:           "relay3.example.com:3001",
+		NormalizedAddress: "relay3.example.com:3001",
+		Source:            PeerSourceP2PLedger,
+	}
+	pg.peers = []*Peer{peer}
+
+	_, err := pg.resolveLedgerDialTarget(context.Background(), peer)
+	require.ErrorIs(t, err, ErrUnroutableAddress)
+	assert.Equal(
+		t,
+		"relay3.example.com:3001",
+		peer.NormalizedAddress,
+		"an unroutable resolution must not be locked in",
+	)
+}
+
+// TestResolveLedgerDialTarget_ResolutionFailurePropagatesError verifies a
+// resolver error on the fallback path is surfaced (so the caller applies its
+// normal dial-failure backoff) instead of falling back to dialing the raw
+// hostname, which would hand resolution back to the OS resolver unchecked.
+func TestResolveLedgerDialTarget_ResolutionFailurePropagatesError(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return nil, errors.New("lookup failed")
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	peer := &Peer{
+		Address:           "relay4.example.com:3001",
+		NormalizedAddress: "relay4.example.com:3001",
+		Source:            PeerSourceP2PLedger,
+	}
+
+	_, err := pg.resolveLedgerDialTarget(context.Background(), peer)
+	assert.Error(t, err)
+}
+
+// TestCreateOutboundConnection_LedgerPeerDialsLockedIPNotRebindTarget is an
+// end-to-end check that the outbound dial path for a ledger-sourced peer
+// actually calls resolveLedgerDialTarget (and not the generic
+// resolveDialAddress, which re-resolves on every attempt). A peer whose
+// NormalizedAddress is already locked to a dead loopback IP must have its
+// dial fail against that IP; the injected resolver — which would answer with
+// a completely different address — must never be consulted.
+func TestCreateOutboundConnection_LedgerPeerDialsLockedIPNotRebindTarget(t *testing.T) {
+	calls := 0
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls++
+		return []net.IP{net.ParseIP("203.0.113.9")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   logger,
+		EventBus: newMockEventBus(),
+		ConnManager: connmanager.NewConnectionManager(
+			connmanager.ConnectionManagerConfig{Logger: logger},
+		),
+		DenyDuration: 30 * time.Minute,
+	})
+	pg.mu.Lock()
+	pg.ctx = t.Context()
+	pg.stopCh = make(chan struct{})
+	pg.mu.Unlock()
+	t.Cleanup(pg.Stop)
+
+	target := &Peer{
+		Address:           "relay.example.com:1",
+		NormalizedAddress: deadDialAddress, // locked-in resolved IP, nothing listening
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateCold,
+	}
+	pg.mu.Lock()
+	// An eligible upstream present makes the never-connected-peer drop gate
+	// fire on the very first failed dial, so the test does not have to wait
+	// out the (much slower) excessive-failures backoff path.
+	pg.peers = []*Peer{
+		target,
+		{
+			Address:           "203.0.113.10:3001",
+			NormalizedAddress: "203.0.113.10:3001",
+			Source:            PeerSourceTopologyLocalRoot,
+			State:             PeerStateHot,
+			Connection:        &PeerConnection{IsClient: true},
+		},
+	}
+	pg.mu.Unlock()
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		pg.mu.Lock()
+		defer pg.mu.Unlock()
+		_, denied := pg.denyList[deadDialAddress]
+		return denied
+	}, 5*time.Second, 10*time.Millisecond,
+		"failed dial to the locked-in address must still drive the normal deny path")
+
+	assert.Equal(
+		t,
+		0,
+		calls,
+		"ledger peer with an already-resolved NormalizedAddress must not re-resolve at dial time",
+	)
+}

--- a/peergov/ledger_dial_security_test.go
+++ b/peergov/ledger_dial_security_test.go
@@ -15,11 +15,14 @@
 package peergov
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -219,4 +222,192 @@ func TestCreateOutboundConnection_LedgerPeerDialsLockedIPNotRebindTarget(t *test
 		calls,
 		"ledger peer with an already-resolved NormalizedAddress must not re-resolve at dial time",
 	)
+}
+
+// safeLogBuffer is a mutex-guarded io.Writer/String() pair. slog's built-in
+// handlers serialize their own writes, but that does not protect a test
+// goroutine reading the buffer concurrently with a background dial
+// goroutine's writes; bytes.Buffer itself is not safe for concurrent use.
+type safeLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestCreateOutboundConnection_LedgerPeerFallbackDialsExactRoutabilityCheckedIP
+// closes a coverage gap: TestCreateOutboundConnection_LedgerPeerDialsLockedIPNotRebindTarget
+// starts from an already-locked IP, so it never actually calls isRoutableAddr.
+// This test drives a peer through the FALLBACK path instead — discovery-time
+// DNS failed, NormalizedAddress is still a hostname — through the real
+// ConnectionManager, and asserts that the address the connection manager logs
+// immediately before its OS-level dial call is the exact IP that
+// resolveLedgerDialTarget just resolved and passed through isRoutableAddr.
+// There is no separate "checked" value and "dialed" value to drift apart:
+// they are the same string, returned once and handed straight to the dialer.
+func TestCreateOutboundConnection_LedgerPeerFallbackDialsExactRoutabilityCheckedIP(
+	t *testing.T,
+) {
+	const resolvedIP = "203.0.113.77"
+	const resolvedAddr = resolvedIP + ":3001"
+
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP(resolvedIP)}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	logBuf := &safeLogBuffer{}
+	logger := slog.New(slog.NewJSONHandler(
+		logBuf,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+
+	// A cancelable (not t.Context()) base context: the assertion below only
+	// needs the pre-dial log line, which is written synchronously before the
+	// OS dial call, so the in-flight dial (which may otherwise run for the
+	// connection manager's 10s timeout against an address nothing answers
+	// on) is aborted immediately afterward instead of being waited out.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:   logger,
+		EventBus: newMockEventBus(),
+		ConnManager: connmanager.NewConnectionManager(
+			connmanager.ConnectionManagerConfig{Logger: logger},
+		),
+		DenyDuration: 30 * time.Minute,
+	})
+	pg.mu.Lock()
+	pg.ctx = ctx
+	pg.stopCh = make(chan struct{})
+	pg.mu.Unlock()
+	t.Cleanup(pg.Stop)
+
+	target := &Peer{
+		Address:           "relay5.example.com:3001",
+		NormalizedAddress: "relay5.example.com:3001", // discovery-time DNS had failed
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateCold,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{target}
+	pg.mu.Unlock()
+
+	go pg.createOutboundConnection(target)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(
+			logBuf.String(),
+			"establishing TCP connection to: "+resolvedAddr,
+		)
+	}, 5*time.Second, 10*time.Millisecond,
+		"the connection manager must dial exactly the IP resolveLedgerDialTarget "+
+			"resolved and routability-checked, not a separately re-resolved value")
+
+	cancel()
+}
+
+// TestResolveLedgerDialTarget_FallbackPrefersLocallySupportedFamily verifies
+// that a dual-stack relay hostname whose discovery-time resolution failed
+// locks in a record the local host can actually dial. Unlike
+// resolveDialAddress, this resolution never runs again for the peer's
+// lifetime, so pinning to the first (possibly unusable) DNS answer would
+// strand a v4-only host on an IPv6 record forever.
+func TestResolveLedgerDialTarget_FallbackPrefersLocallySupportedFamily(t *testing.T) {
+	setLocalAddrFamilies(t, true, false) // v4-only host
+
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		// AAAA record ordered first, mirroring real-world DNS answers that
+		// are not sorted by local reachability.
+		return []net.IP{
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("198.51.100.9"),
+		}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	peer := &Peer{
+		Address:           "relay6.example.com:3001",
+		NormalizedAddress: "relay6.example.com:3001",
+		Source:            PeerSourceP2PLedger,
+	}
+	pg.peers = []*Peer{peer}
+
+	got, err := pg.resolveLedgerDialTarget(context.Background(), peer)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"198.51.100.9:3001",
+		got,
+		"must lock in the IPv4 record on a v4-only host, not the first (IPv6) DNS answer",
+	)
+	assert.Equal(t, "198.51.100.9:3001", peer.NormalizedAddress)
+}
+
+// TestResolveLedgerDialTarget_DoesNotStealNormalizedAddressFromExistingPeer
+// verifies a peer-identity guard: if a ledger peer's fallback resolution
+// lands on the same IP:port that a distinct, existing peer entry already
+// uses as its NormalizedAddress (e.g. the same relay already known via
+// gossip or topology), the resolution must not be written back.
+// peerIndexByAddress assumes NormalizedAddress uniquely identifies a peer;
+// silently duplicating it would let a lookup keyed on that IP return the
+// wrong peer object and misdirect this peer's connection bookkeeping onto
+// it — potentially leaving this peer stuck endlessly reconnecting.
+func TestResolveLedgerDialTarget_DoesNotStealNormalizedAddressFromExistingPeer(
+	t *testing.T,
+) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("198.51.100.42")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := newDialSpreadGovernor()
+	existing := &Peer{
+		Address:           "198.51.100.42:3001",
+		NormalizedAddress: "198.51.100.42:3001",
+		Source:            PeerSourceP2PGossip,
+	}
+	ledgerPeer := &Peer{
+		Address:           "relay7.example.com:3001",
+		NormalizedAddress: "relay7.example.com:3001", // discovery resolution had failed
+		Source:            PeerSourceP2PLedger,
+	}
+	pg.peers = []*Peer{existing, ledgerPeer}
+
+	got, err := pg.resolveLedgerDialTarget(context.Background(), ledgerPeer)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"198.51.100.42:3001",
+		got,
+		"this attempt must still dial the resolved, routability-checked IP",
+	)
+	assert.Equal(
+		t,
+		"relay7.example.com:3001",
+		ledgerPeer.NormalizedAddress,
+		"must not overwrite NormalizedAddress onto a value another peer already owns",
+	)
+	assert.Same(
+		t,
+		existing,
+		pg.peers[0],
+		"existing peer entry must be untouched",
+	)
+	assert.Equal(t, "198.51.100.42:3001", existing.NormalizedAddress)
 }

--- a/peergov/ledger_dial_security_test.go
+++ b/peergov/ledger_dial_security_test.go
@@ -411,3 +411,39 @@ func TestResolveLedgerDialTarget_DoesNotStealNormalizedAddressFromExistingPeer(
 	)
 	assert.Equal(t, "198.51.100.42:3001", existing.NormalizedAddress)
 }
+
+// TestAddLedgerPeerPrefersLocallySupportedFamily verifies the common
+// discovery-time path, not just the resolveLedgerDialTarget fallback: when
+// addLedgerPeer resolves a relay hostname with mixed A/AAAA records, the
+// record it stores in NormalizedAddress must be one the local host can
+// actually dial. Without this, a v4-only host would lock onto whatever
+// record DNS happens to answer first — here an AAAA record — and
+// resolveLedgerDialTarget's fast path would then dial that unreachable
+// family for the peer's entire lifetime, since (unlike resolveDialAddress)
+// nothing ever re-resolves it.
+func TestAddLedgerPeerPrefersLocallySupportedFamily(t *testing.T) {
+	setLocalAddrFamilies(t, true, false) // v4-only host
+
+	oldLookupIP := lookupIP
+	lookupIP = func(string) ([]net.IP, error) {
+		return []net.IP{
+			net.ParseIP("2001:db8::1"), // AAAA returned first
+			net.ParseIP("198.51.100.9"),
+		}, nil
+	}
+	t.Cleanup(func() { lookupIP = oldLookupIP })
+
+	pg := newDialSpreadGovernor()
+	require.True(t, pg.addLedgerPeer("relay.example.com:3001"))
+	require.Len(t, pg.peers, 1)
+	assert.Equal(
+		t,
+		"198.51.100.9:3001",
+		pg.peers[0].NormalizedAddress,
+		"must store the IPv4 record on a v4-only host, not the first (IPv6) DNS answer",
+	)
+
+	got, err := pg.resolveLedgerDialTarget(t.Context(), pg.peers[0])
+	require.NoError(t, err)
+	assert.Equal(t, "198.51.100.9:3001", got)
+}

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -221,8 +221,11 @@ func dedupeRelayCandidates(candidates []string) []string {
 // Returns true if the peer was added, false if it already exists or is denied.
 func (p *PeerGovernor) addLedgerPeer(address string) bool {
 	// Resolve address (with DNS lookup) before acquiring lock to avoid
-	// blocking while holding the mutex
-	normalized := p.resolveAddress(address)
+	// blocking while holding the mutex. Ledger relay hostnames are
+	// attacker-supplied, and resolveLedgerDialTarget's fast path dials
+	// whatever ends up here unchanged for the peer's whole lifetime, so this
+	// (unlike resolveAddress) filters to a locally-dialable address family.
+	normalized := p.resolveLedgerDiscoveryAddress(address)
 
 	// Reject non-routable IPs (private, loopback, link-local, etc.)
 	if !isRoutableAddr(normalized) {

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -341,6 +341,69 @@ func (p *PeerGovernor) resolveDialAddress(
 	return net.JoinHostPort(ip.String(), port)
 }
 
+// resolveLedgerDialTarget returns the concrete IP:port to dial for a
+// ledger-discovered pool relay peer, locking that choice onto the peer so
+// every subsequent dial attempt reuses the same resolved IP instead of
+// asking DNS again.
+//
+// Ledger relay hostnames are supplied by pool operators via on-chain stake
+// pool registration — input outside the node's control. If the routability
+// check performed when the relay was discovered (isRoutableAddr, via
+// resolveAddress in addLedgerPeer) and the actual dial each triggered their
+// own DNS lookup, a malicious or compromised authoritative DNS server could
+// answer the discovery-time lookup with a public IP (passing the check) and
+// a later lookup with an internal address (the one actually dialed) — a DNS
+// rebind that would cause the node to TCP-probe internal addresses.
+// Resolving exactly once and always dialing that resolved IP closes the
+// gap.
+//
+// peer.NormalizedAddress already holds the IP resolved at discovery time in
+// the common case, so this returns it unchanged. If that earlier resolution
+// failed and NormalizedAddress is still a hostname, a single fresh
+// resolution is performed here, checked for routability, and — on success —
+// written back to peer.NormalizedAddress under p.mu so it is locked in for
+// this and every future reconnect attempt. It must NOT be called while
+// holding p.mu.
+func (p *PeerGovernor) resolveLedgerDialTarget(
+	ctx context.Context,
+	peer *Peer,
+) (string, error) {
+	host, port, err := net.SplitHostPort(peer.NormalizedAddress)
+	if err != nil {
+		return "", err
+	}
+	if net.ParseIP(host) != nil {
+		// Resolved and locked in at discovery time.
+		return peer.NormalizedAddress, nil
+	}
+
+	// Discovery-time resolution didn't produce an IP (e.g. it failed and
+	// fell back to the lowercased hostname). Resolve once now, bounded so a
+	// hung or slow resolver cannot wedge the dial loop.
+	lookupCtx, cancel := context.WithTimeout(ctx, dialDNSResolveTimeout)
+	defer cancel()
+	ips, err := lookupIPAddr(lookupCtx, host)
+	if err != nil {
+		return "", err
+	}
+	if len(ips) == 0 {
+		return "", errors.New("no addresses returned for ledger relay hostname")
+	}
+	resolved := net.JoinHostPort(ips[0].String(), port)
+	if !isRoutableAddr(resolved) {
+		return "", ErrUnroutableAddress
+	}
+
+	p.mu.Lock()
+	idx := p.peerIndexByAddress(peer.NormalizedAddress)
+	if idx != -1 && p.peers[idx] != nil {
+		p.peers[idx].NormalizedAddress = resolved
+	}
+	p.mu.Unlock()
+
+	return resolved, nil
+}
+
 // localAddrFamilies detects which IP families the local host can route to.
 // It is a package var so tests can inject a deterministic result independent
 // of the host's real network interfaces.

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -276,6 +276,52 @@ func (p *PeerGovernor) resolveAddress(address string) string {
 	return net.JoinHostPort(ips[0].String(), port)
 }
 
+// resolveLedgerDiscoveryAddress resolves a ledger relay hostname at initial
+// discovery time, filtering the resolved records to the locally-supported
+// address families before picking one. This function performs blocking DNS
+// lookups and must NOT be called while holding locks.
+//
+// It is ledger-specific rather than a change to resolveAddress (shared by
+// every peer source — topology, gossip, inbound, TestPeer/DenyPeer lookups)
+// because the record chosen here matters far more than it does for those
+// other sources: resolveLedgerDialTarget's fast path reuses whatever ends up
+// in NormalizedAddress unchanged and dials it for the rest of the peer's
+// lifetime, whereas every other source re-resolves (and re-filters via
+// resolveDialAddress) on every dial attempt. Without this, a v4-only host
+// could pin a ledger peer to an unreachable AAAA record forever, since
+// there is no later attempt to self-correct the family.
+//
+// Behavior otherwise matches resolveAddress: an IP literal is normalized
+// unchanged, and a resolution failure or empty result falls back to the
+// lowercased hostname so the peer is still added (with routability decided
+// downstream) rather than dropped.
+func (p *PeerGovernor) resolveLedgerDiscoveryAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return strings.ToLower(address)
+	}
+
+	ip := net.ParseIP(host)
+	if ip != nil {
+		return net.JoinHostPort(ip.String(), port)
+	}
+
+	ips, err := lookupIP(host)
+	if err != nil || len(ips) == 0 {
+		p.config.Logger.Warn(
+			"failed to resolve ledger relay hostname",
+			"address", address,
+			"host", host,
+			"error", err,
+		)
+		return net.JoinHostPort(strings.ToLower(host), port)
+	}
+
+	hasV4, hasV6 := p.supportedDialFamilies()
+	ips = filterDialFamilies(ips, hasV4, hasV6)
+	return net.JoinHostPort(ips[0].String(), port)
+}
+
 // resolveDialAddress returns the concrete transport target to dial for an
 // outbound connection attempt against the given peer address.
 //

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -360,10 +360,12 @@ func (p *PeerGovernor) resolveDialAddress(
 // peer.NormalizedAddress already holds the IP resolved at discovery time in
 // the common case, so this returns it unchanged. If that earlier resolution
 // failed and NormalizedAddress is still a hostname, a single fresh
-// resolution is performed here, checked for routability, and — on success —
-// written back to peer.NormalizedAddress under p.mu so it is locked in for
-// this and every future reconnect attempt. It must NOT be called while
-// holding p.mu.
+// resolution is performed here, filtered to the locally-supported address
+// families (so the record locked in for the rest of this peer's lifetime is
+// actually dialable, not an arbitrary first record), checked for
+// routability, and — on success — written back to peer.NormalizedAddress
+// under p.mu so it is locked in for this and every future reconnect
+// attempt. It must NOT be called while holding p.mu.
 func (p *PeerGovernor) resolveLedgerDialTarget(
 	ctx context.Context,
 	peer *Peer,
@@ -389,6 +391,13 @@ func (p *PeerGovernor) resolveLedgerDialTarget(
 	if len(ips) == 0 {
 		return "", errors.New("no addresses returned for ledger relay hostname")
 	}
+	// Filter to the address families this host can actually dial before
+	// picking the one record that gets locked in forever; an unfiltered
+	// pick could permanently pin the peer to an unreachable family (e.g. an
+	// AAAA record on a v4-only host), which resolveDialAddress's per-attempt
+	// re-resolution would otherwise self-correct on the next try.
+	hasV4, hasV6 := p.supportedDialFamilies()
+	ips = filterDialFamilies(ips, hasV4, hasV6)
 	resolved := net.JoinHostPort(ips[0].String(), port)
 	if !isRoutableAddr(resolved) {
 		return "", ErrUnroutableAddress
@@ -397,7 +406,19 @@ func (p *PeerGovernor) resolveLedgerDialTarget(
 	p.mu.Lock()
 	idx := p.peerIndexByAddress(peer.NormalizedAddress)
 	if idx != -1 && p.peers[idx] != nil {
-		p.peers[idx].NormalizedAddress = resolved
+		// Guard against colliding with a distinct peer entry that already
+		// owns this resolved address (e.g. a gossip/topology peer for the
+		// same relay, or another ledger hostname that happens to resolve
+		// here). Two peers sharing NormalizedAddress breaks
+		// peerIndexByAddress's assumption that it uniquely identifies a
+		// peer, which can misdirect this peer's connection bookkeeping onto
+		// the other entry. Skip the lock-in in that case; this peer simply
+		// re-resolves (still routability-checked before every dial) on its
+		// next attempt instead of corrupting peer identity.
+		if collidingIdx := p.peerIndexByAddress(resolved); collidingIdx == -1 ||
+			collidingIdx == idx {
+			p.peers[idx].NormalizedAddress = resolved
+		}
 	}
 	p.mu.Unlock()
 


### PR DESCRIPTION
Closes #2435 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dial ledger-discovered pool relays by a resolved IP (not hostname) to block DNS-rebind and always use the routability-checked address. Discovery now picks an IP family the host can dial to avoid pinning unreachable records; tests and docs updated.

- **Bug Fixes**
  - Lock IPs via `resolveLedgerDialTarget`: reuse `NormalizedAddress` if already an IP; else resolve once (with timeout), filter to locally supported v4/v6, verify routable, persist; error on resolver failure or unroutable result. Only applies to `PeerSourceP2PLedger`; others keep per-attempt re-resolution. `createOutboundConnection` dials exactly the checked IP.
  - Prefer supported IP family at discovery: `addLedgerPeer` uses `resolveLedgerDiscoveryAddress` to store a dialable A/AAAA result, avoiding pinning v4-only hosts to AAAA (or vice versa).
  - Prevent peer identity collisions: skip write-back if another peer already owns the resolved `NormalizedAddress`; still dial the checked IP and re-resolve on the next attempt.

<sup>Written for commit 092008b2f1294fe91337d3ffd38b3846c4bdce4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Ledger-discovered relay addresses are now resolved once and reused for subsequent connection attempts.
  * Prevented DNS rebinding from redirecting connections to internal or unroutable addresses.
  * Unroutable or failed address resolution is rejected safely.

* **Documentation**
  * Updated peer governance documentation to describe the new relay resolution behavior and its trade-offs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->