### PR TITLE
ci(antithesis): fix image build context

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -129,7 +129,7 @@ jobs:
         id: txpump-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 https://github.com/docker/build-push-action/releases/tag/v7.3.0
         with:
-          context: internal/test/antithesis
+          context: .
           file: internal/test/antithesis/Dockerfile.txpump
           outputs: "type=registry,push=true"
           platforms: linux/amd64
@@ -158,7 +158,7 @@ jobs:
         id: analysis-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 https://github.com/docker/build-push-action/releases/tag/v7.3.0
         with:
-          context: internal/test/antithesis
+          context: .
           file: internal/test/antithesis/Dockerfile.analysis
           outputs: "type=registry,push=true"
           platforms: linux/amd64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Antithesis Docker image builds by changing the build context to the repo root in CI so Dockerfiles can include required files and push successfully.

- **Bug Fixes**
  - Set `context: .` for `Dockerfile.txpump`.
  - Set `context: .` for `Dockerfile.analysis`.

<sup>Written for commit 70e1e55ea239a1b804247f3de219335c1fbc0fea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the txpump and analysis container images.
  * Improved the set of project files included during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->