### PR TITLE
fix: clean up modernize and nilaway reports

### DIFF
--- a/api/blockfrost/blockfrost_compat_test.go
+++ b/api/blockfrost/blockfrost_compat_test.go
@@ -683,7 +683,7 @@ func TestCompatAccountRegistrationHistoryResponse(
 
 	// bfgo.AccountRegistrationHistory has no Deposit field; assert via raw
 	// JSON so a serialization regression on the "deposit" key is caught.
-	var rawItems []map[string]interface{}
+	var rawItems []map[string]any
 	require.NoError(t, json.Unmarshal(data, &rawItems))
 	require.Len(t, rawItems, 2)
 	assert.Equal(t, ours[0].Deposit, rawItems[0]["deposit"])

--- a/database/models/leios_block_test.go
+++ b/database/models/leios_block_test.go
@@ -162,9 +162,10 @@ func TestDecodeConwayBlockLeiosExtendedHeader(t *testing.T) {
 	// chain-sync header path (gdijkstra header decode) computes for the same
 	// block. Otherwise prev-hash chain linkage between the header and body
 	// paths would break.
-	var comps []cbor.RawMessage
+	comps := make([]cbor.RawMessage, 0)
 	_, err = cbor.Decode(extendedRaw, &comps)
 	require.NoError(t, err)
+	require.NotEmpty(t, comps)
 	hdr, err := gdijkstra.NewDijkstraBlockHeaderFromCbor(comps[0])
 	require.NoError(t, err)
 	assert.Equal(

--- a/database/plugin/metadata/sqlite/account_created_slot_test.go
+++ b/database/plugin/metadata/sqlite/account_created_slot_test.go
@@ -246,12 +246,10 @@ func TestSaveAccountConcurrentCopiesKeepEarliestCreatedSlot(t *testing.T) {
 	for _, slot := range slots {
 		copy := *account
 		copy.AddedSlot = slot
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			errs <- saveAccount(&copy, db)
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/database/types/types_test.go
+++ b/database/types/types_test.go
@@ -207,35 +207,35 @@ func TestNullableHashValueNonEmpty(t *testing.T) {
 
 // TestNullableHashScan round-trips NULL, []byte, and string sources.
 func TestNullableHashScan(t *testing.T) {
-	var h types.NullableHash
+	h := new(types.NullableHash)
 
 	if err := h.Scan(nil); err != nil {
 		t.Fatalf("Scan(nil) error: %v", err)
 	}
-	if h != nil {
-		t.Fatalf("Scan(nil) = %#v, want nil", h)
+	if *h != nil {
+		t.Fatalf("Scan(nil) = %#v, want nil", *h)
 	}
 
 	if err := h.Scan([]byte{}); err != nil {
 		t.Fatalf("Scan(empty []byte) error: %v", err)
 	}
-	if h != nil {
-		t.Fatalf("Scan(empty []byte) = %#v, want nil", h)
+	if *h != nil {
+		t.Fatalf("Scan(empty []byte) = %#v, want nil", *h)
 	}
 
 	want := bytes.Repeat([]byte{0x01}, 32)
 	if err := h.Scan(want); err != nil {
 		t.Fatalf("Scan([]byte) error: %v", err)
 	}
-	if !bytes.Equal(h, want) {
-		t.Fatalf("Scan([]byte) = %x, want %x", h, want)
+	if !bytes.Equal(*h, want) {
+		t.Fatalf("Scan([]byte) = %x, want %x", *h, want)
 	}
 
 	if err := h.Scan("xyz"); err != nil {
 		t.Fatalf("Scan(string) error: %v", err)
 	}
-	if string(h) != "xyz" {
-		t.Fatalf("Scan(string) = %q, want %q", string(h), "xyz")
+	if string(*h) != "xyz" {
+		t.Fatalf("Scan(string) = %q, want %q", string(*h), "xyz")
 	}
 
 	if err := h.Scan(123); err == nil {

--- a/internal/architecture/import_boundary_test.go
+++ b/internal/architecture/import_boundary_test.go
@@ -77,10 +77,7 @@ func TestImportBoundaries(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for _, rule := range importBoundaryRules {
-		rule := rule
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			ruleViolations, err := importBoundaryViolations(repoRoot, rule)
 			if err != nil {
@@ -90,7 +87,7 @@ func TestImportBoundaries(t *testing.T) {
 			for _, violation := range ruleViolations {
 				violationsCh <- violation
 			}
-		}()
+		})
 	}
 
 	go func() {
@@ -152,9 +149,7 @@ func importBoundaryViolations(
 	jobs := make(chan string)
 
 	for range runtime.GOMAXPROCS(0) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			for file := range jobs {
 				fileViolations, err := importBoundaryViolationsForFile(
@@ -170,7 +165,7 @@ func importBoundaryViolations(
 				}
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 	for _, file := range files {
 		jobs <- file

--- a/ledger/chainsync_state_race_test.go
+++ b/ledger/chainsync_state_race_test.go
@@ -29,22 +29,18 @@ func TestChainsyncValidationStateConcurrentAccess(t *testing.T) {
 	const iterations = 1000
 
 	var wg sync.WaitGroup
-	for worker := 0; worker < 2; worker++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for slot := 0; slot < iterations; slot++ {
+	for range 2 {
+		wg.Go(func() {
+			for slot := range iterations {
 				_ = ls.shouldVerifyChainsyncHeaderCrypto(uint64(slot))
 				_, _ = ls.validationStateSnapshot()
 				_ = ls.mithrilLedgerSlotSnapshot()
 			}
-		}()
+		})
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+	wg.Go(func() {
+		for i := range iterations {
 			ls.Lock()
 			ls.validationEnabled = i%2 == 0
 			ls.mithrilLedgerSlot = uint64(i % 128)
@@ -60,7 +56,7 @@ func TestChainsyncValidationStateConcurrentAccess(t *testing.T) {
 				SyncingChainsyncState,
 			)
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/ledger/delta_test.go
+++ b/ledger/delta_test.go
@@ -110,6 +110,7 @@ func TestConwayProtocolParametersDijkstra(t *testing.T) {
 
 	got := conwayProtocolParameters(pparams)
 	require.Same(t, &pparams.ConwayProtocolParameters, got)
+	require.NotNil(t, got)
 	require.Equal(t, uint64(42), got.GovActionValidityPeriod)
 	require.Equal(t, uint64(99), got.DRepInactivityPeriod)
 }

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -246,16 +246,34 @@ func protocolBlockSizeLimits(
 ) (maxBodySize, maxHeaderSize uint64, ok bool) {
 	switch pp := pparams.(type) {
 	case *shelley.ShelleyProtocolParameters:
+		if pp == nil {
+			return 0, 0, false
+		}
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	case *mary.MaryProtocolParameters:
+		if pp == nil {
+			return 0, 0, false
+		}
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	case *alonzo.AlonzoProtocolParameters:
+		if pp == nil {
+			return 0, 0, false
+		}
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	case *babbage.BabbageProtocolParameters:
+		if pp == nil {
+			return 0, 0, false
+		}
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	case *conway.ConwayProtocolParameters:
+		if pp == nil {
+			return 0, 0, false
+		}
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	case *dijkstra.DijkstraProtocolParameters:
+		if pp == nil {
+			return 0, 0, false
+		}
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	default:
 		return 0, 0, false

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -351,8 +351,8 @@ func ProcessEpoch(
 	// RATIFY loop below never calls TallyProposal, so this heavy read
 	// would be pure overhead (and a needless failure surface) on a no-op
 	// epoch boundary.
-	var drepState *DRepVotingState
-	var spoState *SPOVotingState
+	drepState := &DRepVotingState{}
+	spoState := &SPOVotingState{}
 	if len(stillActive) > 0 {
 		drepState, err = LoadDRepVotingState(in.DB, in.Txn, in.NewEpoch)
 		if err != nil {

--- a/ledger/heal_empty_lab_nonce_test.go
+++ b/ledger/heal_empty_lab_nonce_test.go
@@ -663,7 +663,11 @@ func TestLoadEpochsRefreshesCurrentEpochAfterHealing(t *testing.T) {
 		},
 	}
 	ls.metrics.init(prometheus.NewRegistry())
-	require.NoError(t, ls.loadEpochs(nil))
+	txn := db.Transaction(true)
+	defer txn.Release()
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.loadEpochs(txn)
+	}))
 
 	require.Equal(t, want.Bytes(), ls.epochCache[1].Nonce)
 	require.Equal(t, want.Bytes(), ls.currentEpoch.Nonce)

--- a/ledger/heal_mithril_gap_nonce.go
+++ b/ledger/heal_mithril_gap_nonce.go
@@ -349,6 +349,11 @@ func (ls *LedgerState) healMithrilGapBlockNonces(ctx context.Context) error {
 
 	// Walk the canonical chain from the anchor to the ledger tip.
 	if ls.chain != nil {
+		if anchorIter == nil {
+			return errors.New(
+				"missing primary-chain iterator for Mithril gap nonce reconstruction",
+			)
+		}
 		iter := anchorIter
 		for {
 			res, err := iter.Next(false)

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -107,8 +107,8 @@ func (ls *LedgerState) applyEndorserBlock(
 
 	// Decode each standalone endorser transaction, capturing its body CBOR
 	// (the first array element) for the transaction-offset entry.
-	txs := make([]lcommon.Transaction, 0, len(rawTxs))
-	bodyCbors := make([][]byte, 0, len(rawTxs))
+	txs := make([]lcommon.Transaction, len(rawTxs))
+	bodyCbors := make([][]byte, len(rawTxs))
 	for i, raw := range rawTxs {
 		// leios-fetch carries each endorser transaction CBOR-in-CBOR: the
 		// tx_list entry is a CBOR byte string wrapping the transaction's own
@@ -143,8 +143,8 @@ func (ls *LedgerState) applyEndorserBlock(
 		if err != nil {
 			return 0, 0, fmt.Errorf("decode endorser tx %d: %w", i, err)
 		}
-		txs = append(txs, tx)
-		bodyCbors = append(bodyCbors, []byte(elems[0]))
+		txs[i] = tx
+		bodyCbors[i] = []byte(elems[0])
 	}
 
 	// Reject repeated endorser transactions before recording ledger data. The
@@ -159,8 +159,8 @@ func (ls *LedgerState) applyEndorserBlock(
 		if len(keepIndexes) == 0 {
 			return 0, 0, nil
 		}
-		keptTxs := txs[:0]
-		keptBodies := bodyCbors[:0]
+		keptTxs := make([]lcommon.Transaction, 0, len(keepIndexes))
+		keptBodies := make([][]byte, 0, len(keepIndexes))
 		for _, idx := range keepIndexes {
 			keptTxs = append(keptTxs, txs[idx])
 			keptBodies = append(keptBodies, bodyCbors[idx])

--- a/ledger/leios_apply_test.go
+++ b/ledger/leios_apply_test.go
@@ -399,10 +399,14 @@ func TestClassifyEndorserBlockFetches(t *testing.T) {
 	backfill, tipWait = classifyEndorserBlockFetches(
 		infos, annByHash, 100_050, true, 100, false, neverCached,
 	)
+	backfillHashes := make([]lcommon.Blake2b256, 0, len(backfill))
+	for _, ref := range backfill {
+		backfillHashes = append(backfillHashes, ref.hash)
+	}
 	require.ElementsMatch(
 		t,
 		[]lcommon.Blake2b256{ebA, ebE},
-		[]lcommon.Blake2b256{backfill[0].hash, backfill[1].hash},
+		backfillHashes,
 	)
 	require.Len(t, tipWait, 1)
 	require.Equal(t, ebB, tipWait[0].hash)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3781,7 +3781,14 @@ func (ls *LedgerState) ledgerProcessBlock(
 	// checked at header verification.
 	opCert, hasOpCert := opCertFromHeader(block.Header())
 	var opCertPoolKeyHash lcommon.PoolKeyHash
+	var opCertIssueNumber uint64
 	if hasOpCert {
+		if opCert == nil {
+			return nil, errors.New(
+				"block header reported an operational certificate but returned nil",
+			)
+		}
+		opCertIssueNumber = opCert.IssueNumber
 		opCertPoolKeyHash = lcommon.PoolKeyHash(block.IssuerVkey().Hash())
 		// Counter monotonicity is the stateful half of inbound opcert
 		// validation: read the pool's last-seen counter before processing this
@@ -3811,7 +3818,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 			if err := validateOpCertCounter(
 				stored,
 				found,
-				opCert.IssueNumber,
+				opCertIssueNumber,
 				opCertNoGapRuleApplies(block.Era().Id),
 			); err != nil {
 				return nil, fmt.Errorf("pool %x: %w", opCertPoolKeyHash, err)
@@ -4131,7 +4138,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 	if hasOpCert {
 		if err := ls.db.UpdatePoolOpCertSequence(
 			opCertPoolKeyHash,
-			opCert.IssueNumber,
+			opCertIssueNumber,
 			point.Slot,
 			txn,
 		); err != nil {
@@ -5540,6 +5547,9 @@ func (ls *LedgerState) withMithrilTrustBoundaryIntersectPoint(
 			bytes.Equal(existing.Hash, point.Hash) {
 			return points
 		}
+	}
+	if len(points) == 0 {
+		return []ocommon.Point{point}
 	}
 
 	insertAt := len(points)

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -297,10 +297,7 @@ func isTransientDownloadError(err error) bool {
 // defaultTransientRetryMaxDelay with ±25% jitter.
 func transientRetryDelay(attempt int) time.Duration {
 	shift := min(attempt, 6) // 2^6 * 500ms = 32s, capped at 30s
-	d := defaultTransientRetryBaseDelay * (1 << shift)
-	if d > defaultTransientRetryMaxDelay {
-		d = defaultTransientRetryMaxDelay
-	}
+	d := min(defaultTransientRetryBaseDelay*(1<<shift), defaultTransientRetryMaxDelay)
 	if quarter := d / 4; quarter > 0 {
 		// Jitter in [-quarter, +quarter]
 		d += time.Duration(rand.Int63n(int64(quarter)*2+1)) - quarter //nolint:gosec

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -146,11 +146,9 @@ func (n *Node) startChainsyncStallRecycler(
 	recyclerCtx, recyclerCancel := context.WithCancel(ctx)
 	// Track the recycler as a node-owned background worker so shutdown can
 	// wait for it before closing the dependencies it reads or publishes to.
-	n.chainsyncStallRecyclerWG.Add(1)
-	go func() {
+	n.chainsyncStallRecyclerWG.Go(func() {
 		// Mark the worker complete no matter whether it exits by cancellation
 		// or after a recovered panic stops the outer loop.
-		defer n.chainsyncStallRecyclerWG.Done()
 		n.runChainsyncStallRecycler(
 			recyclerCtx,
 			chainsyncCfg,
@@ -158,7 +156,7 @@ func (n *Node) startChainsyncStallRecycler(
 			grace,
 			cooldown,
 		)
-	}()
+	})
 	return recyclerCancel
 }
 

--- a/ouroboros/leios_backfill_failover_test.go
+++ b/ouroboros/leios_backfill_failover_test.go
@@ -81,13 +81,16 @@ func TestLeiosBackfillConnOrderAffinity(t *testing.T) {
 	connIds := []ouroboros.ConnectionId{fresh, cooled, proven}
 
 	now := time.Now()
+	provenGuard := &leiosFetchGuard{}
+	freshGuard := &leiosFetchGuard{}
+	cooledGuard := &leiosFetchGuard{}
 	guards := map[ouroboros.ConnectionId]*leiosFetchGuard{
-		proven: {},
-		fresh:  {},
-		cooled: {},
+		proven: provenGuard,
+		fresh:  freshGuard,
+		cooled: cooledGuard,
 	}
-	guards[proven].markFetchOK()
-	guards[cooled].markFetchFailed(now, leiosBackfillConnCooldown)
+	provenGuard.markFetchOK()
+	cooledGuard.markFetchFailed(now, leiosBackfillConnCooldown)
 	guardFor := func(id ouroboros.ConnectionId) *leiosFetchGuard {
 		return guards[id]
 	}

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -517,21 +517,25 @@ func TestSpliceEndorserTxsIntoDijkstraBlockFillsCertRB(t *testing.T) {
 
 	// The header is preserved byte-for-byte so the served block's hash is
 	// unchanged.
-	var origTop, mergedTop []cbor.RawMessage
+	origTop := make([]cbor.RawMessage, 0)
+	mergedTop := make([]cbor.RawMessage, 0)
 	_, err = cbor.Decode(certRB, &origTop)
 	require.NoError(t, err)
 	_, err = cbor.Decode(merged, &mergedTop)
 	require.NoError(t, err)
+	require.Len(t, origTop, 2)
 	require.Len(t, mergedTop, 2)
 	require.Equal(t, []byte(origTop[0]), []byte(mergedTop[0]))
 
 	// The transaction segment now holds the endorser block's transactions; the
 	// invalid, certificate, and peras segments are preserved.
-	var origBody, mergedBody []cbor.RawMessage
+	origBody := make([]cbor.RawMessage, 0)
+	mergedBody := make([]cbor.RawMessage, 0)
 	_, err = cbor.Decode(origTop[1], &origBody)
 	require.NoError(t, err)
 	_, err = cbor.Decode(mergedTop[1], &mergedBody)
 	require.NoError(t, err)
+	require.Len(t, origBody, 4)
 	require.Len(t, mergedBody, 4)
 	require.Equal(t, []byte(origBody[0]), []byte(mergedBody[0]))
 	require.Equal(t, []byte(origBody[2]), []byte(mergedBody[2]))

--- a/ouroboros/leios_txfetch_test.go
+++ b/ouroboros/leios_txfetch_test.go
@@ -53,8 +53,10 @@ func (r *cappingBlockTxsRequester) BlockTxsRequest(
 	}
 	served := map[uint16]uint64{}
 	txs := make([]cbor.RawMessage, 0, n)
-	for k := 0; k < n; k++ {
-		idx := requested[k]
+	for k, idx := range requested {
+		if k >= n {
+			break
+		}
 		served[uint16(idx/64)] |= 1 << uint(63-(idx%64)) // MSB-first, see leiosWindowNeededMask
 		enc, err := cbor.Encode(idx)
 		if err != nil {

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -752,10 +752,7 @@ func (g *leiosFetchGuard) markFetchFailed(now time.Time, base time.Duration) {
 	n := g.consecutiveFailures.Add(1)
 	d := base
 	if n > 1 {
-		shift := n - 1
-		if shift > leiosBackfillConnCooldownMaxShift {
-			shift = leiosBackfillConnCooldownMaxShift
-		}
+		shift := min(n-1, leiosBackfillConnCooldownMaxShift)
 		d = base << uint(shift)
 	}
 	// Guard against overflow (d <= 0) and clamp to the cap.

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -620,7 +620,7 @@ func TestHandleConnectionClosedEvent_CriticalHotPeersCapsBackoff(
 
 	// Unbounded escalation would reach 1,2,4,8,16,32s; the cap holds the delay
 	// at emergencyReconnectDelay once it would exceed that, and never above it.
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		pg.mu.Lock()
 		peer.ReconnectDelay = 0
 		peer.Connection = &PeerConnection{

--- a/peergov/emergency_ledger_discovery_test.go
+++ b/peergov/emergency_ledger_discovery_test.go
@@ -30,7 +30,7 @@ import (
 // upstream peers (client connections from a topology source).
 func addEligibleUpstreamPeers(pg *PeerGovernor, n int) {
 	pg.mu.Lock()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		addr := "10.10.0." + strconv.Itoa(i+1) + ":3001"
 		pg.peers = append(pg.peers, &Peer{
 			Address:           addr,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleans up `nil`-safety issues flagged by `NilAway` and modernizes loops/concurrency for Go 1.22. Improves robustness in ledger, Mithril healing, and Ouroboros tests, and simplifies retry/backoff logic.

- **Bug Fixes**
  - Add `nil` checks in protocol parameter size retrieval and opcert handling to prevent panics.
  - Guard Mithril gap healing when the anchor iterator is missing; return a clear error.
  - Ensure epoch loading uses a transaction; refresh current epoch after healing.
  - Guarantee fallback point is returned when trust-boundary intersection yields none.
  - Preallocate and index-assign slices in Leios apply; dedupe using new slices sized to kept indexes.
  - Fix out-of-bounds risks in tx fetch tests; collect backfill hashes safely.
  - Use addressable guards in Leios backfill tests; avoid calling methods on map literals.
  - Tighten CBOR decode tests with non-empty assertions; replace `map[string]interface{}` with `map[string]any`.

- **Refactors**
  - Replace manual `WaitGroup` Add/Done with `wg.Go` in tests and recycler worker.
  - Adopt range-over-int loops (Go 1.22) in tests for simpler iteration.
  - Simplify retry/backoff math using `min` for delay and shift clamping.

<sup>Written for commit ab68b06a7c15c3fd9547297cdd802d14c02c30b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

