### PR TITLE
test(conformance): Added PostgreSQL tests via ouroboros-mock harness

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -98,11 +98,6 @@ jobs:
         run: go build ./cmd/dingo
       - name: go-test
         run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race ./...
-      - name: go-test-conformance-postgres
-        # Separate, verbose step so the PostgreSQL-backed conformance
-        # vector counts (pass/fail/total) are visible in their own CI log
-        # section instead of buried inside the go-test step's ./... output.
-        run: go test -tags dingo_extra_plugins -v -race ./internal/test/conformance/... -run Postgres
 
   # macOS and Windows jobs without Postgres service
   go-test-other:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -98,6 +98,11 @@ jobs:
         run: go build ./cmd/dingo
       - name: go-test
         run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race ./...
+      - name: go-test-conformance-postgres
+        # Separate, verbose step so the PostgreSQL-backed conformance
+        # vector counts (pass/fail/total) are visible in their own CI log
+        # section instead of buried inside the go-test step's ./... output.
+        run: go test -tags dingo_extra_plugins -v -race ./internal/test/conformance/... -run Postgres
 
   # macOS and Windows jobs without Postgres service
   go-test-other:

--- a/internal/test/conformance/README.md
+++ b/internal/test/conformance/README.md
@@ -4,8 +4,10 @@ This package runs the [Amaru ledger rules conformance vectors](https://github.co
 against Dingo's ledger implementation. The shared harness and embedded test
 data live in `github.com/blinklabs-io/ouroboros-mock/conformance`; this package
 provides `DingoStateManager`, an adapter that drives Dingo's database and
-ledger packages with an in-memory SQLite backend so every vector runs against
-a clean state.
+ledger packages so every vector runs against a clean state. `DingoStateManager`
+only ever talks to the database through `*gorm.DB`, so the same adapter runs
+against either an in-memory SQLite backend (the default, no setup required)
+or a real PostgreSQL backend (see [PostgreSQL backend](#postgresql-backend)).
 
 ## What the vectors cover
 
@@ -42,6 +44,47 @@ Run a single vector by substring match (delegated by the harness):
 go test -v ./internal/test/conformance/ -run TestRulesConformanceVectors -vector <name>
 ```
 
+## PostgreSQL backend
+
+By default the tests use an in-memory SQLite database and need no setup. A
+second, build-tag-gated variant runs the identical harness against a real
+PostgreSQL database, using the same `dingo_extra_plugins` build tag as
+`database/plugin/metadata/postgres` (the actual Postgres metadata store
+plugin) and the same `POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE/SSLMODE`
+environment variables that plugin's tests and CI's `go-test-linux` job
+already use.
+
+Bring up a local Postgres and run it:
+
+```bash
+docker compose -f internal/test/conformance/docker-compose.yml up -d
+
+POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
+POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=dingo_test \
+  go test -tags dingo_extra_plugins -v ./internal/test/conformance/... -run Postgres
+```
+
+Without a `POSTGRES_PASSWORD` or `POSTGRES_DSN` set, both Postgres tests
+skip (they never fail a plain `go test ./...`). CI's `go-test-linux` job
+already runs a `postgres:16` service with those exact env vars, so the
+Postgres variant runs there automatically as its own step — no separate CI
+job needed.
+
+**Schema isolation.** `database/plugin/metadata/postgres`'s own tests
+connect to the same `dingo_test` database. Since `go test ./...` runs
+different packages as separate, concurrent processes, sharing the default
+`public` schema would let the two suites race on the same tables.
+`NewDingoPostgresStateManager` migrates into a dedicated `conformance`
+schema instead (via `CREATE SCHEMA IF NOT EXISTS` + `SET search_path`, with
+the connection pool pinned to one connection so every statement lands on
+the session the `search_path` was set on).
+
+`TestRulesConformanceVectorsWithResultsPostgres` runs the SQLite and
+Postgres harnesses in the same test and compares vector counts instead of
+asserting a hardcoded number, so the two runs should exercise the identical
+vector count with identical pass counts, and the comparison stays correct
+even as the embedded `ouroboros-mock` vector corpus grows or shrinks.
+
 ## When to run them
 
 **Conformance tests are mandatory after every ledger-affecting change**, not
@@ -75,9 +118,12 @@ Cross-repo change cascades that must re-run this suite:
 
 | File | Purpose |
 |---|---|
-| `conformance_test.go` | Go test entry points (`TestRulesConformanceVectors`, `…WithResults`) |
+| `conformance_test.go` | Go test entry points, SQLite backend (`TestRulesConformanceVectors`, `…WithResults`) |
+| `conformance_postgres_test.go` | Go test entry points, PostgreSQL backend (`dingo_extra_plugins` build tag) |
 | `state_manager.go`    | `DingoStateManager` — implements `conformance.StateManager` against Dingo's DB/ledger |
+| `state_manager_postgres.go` | `NewDingoPostgresStateManager` — same `DingoStateManager`, Postgres connection (`dingo_extra_plugins` build tag) |
 | `state_provider.go`   | State-query adapters used by the harness |
+| `docker-compose.yml`  | Local PostgreSQL for the Postgres-backed tests |
 
 ## Updating vectors
 

--- a/internal/test/conformance/README.md
+++ b/internal/test/conformance/README.md
@@ -67,8 +67,8 @@ POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=dingo_test \
 Without a `POSTGRES_PASSWORD` or `POSTGRES_DSN` set, both Postgres tests
 skip (they never fail a plain `go test ./...`). CI's `go-test-linux` job
 already runs a `postgres:16` service with those exact env vars, so the
-Postgres variant runs there automatically as its own step — no separate CI
-job needed.
+Postgres variant runs automatically as part of the existing tagged
+`go test -race ./...` step.
 
 **Schema isolation.** `database/plugin/metadata/postgres`'s own tests
 connect to the same `dingo_test` database. Since `go test ./...` runs

--- a/internal/test/conformance/conformance_postgres_test.go
+++ b/internal/test/conformance/conformance_postgres_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"github.com/stretchr/testify/require"
+)
+
+// isPostgresConformanceConfigured checks whether postgres connection info
+// has been supplied via environment variables. Mirrors
+// database/plugin/metadata/postgres's isPostgresConfigured so both suites
+// skip/run under the same conditions in CI and locally.
+func isPostgresConformanceConfigured() bool {
+	return os.Getenv("POSTGRES_PASSWORD") != "" || os.Getenv("POSTGRES_DSN") != ""
+}
+
+// skipIfPostgresConformanceNotConfigured skips the test unless postgres
+// connection info is available, matching
+// database/plugin/metadata/postgres/postgres_test.go's convention so a
+// plain `go test ./...` with no database running still passes.
+func skipIfPostgresConformanceNotConfigured(t *testing.T) {
+	t.Helper()
+	if !isPostgresConformanceConfigured() {
+		t.Skip(
+			"Skipping postgres conformance test: postgres not configured " +
+				"(set POSTGRES_PASSWORD or POSTGRES_DSN)",
+		)
+	}
+}
+
+// postgresConformanceDSN builds a libpq-style DSN from the same
+// POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE/SSLMODE environment variables
+// database/plugin/metadata/postgres/postgres_test.go reads, so both suites
+// point at the same server/database when run together (they stay isolated
+// from each other via a dedicated Postgres schema -- see
+// state_manager_postgres.go). POSTGRES_DSN, if set, overrides everything.
+func postgresConformanceDSN() string {
+	if dsn := os.Getenv("POSTGRES_DSN"); dsn != "" {
+		return dsn
+	}
+
+	host := "localhost"
+	if v := os.Getenv("POSTGRES_HOST"); v != "" {
+		host = v
+	}
+	port := "5432"
+	if v := os.Getenv("POSTGRES_PORT"); v != "" {
+		port = v
+	}
+	user := "postgres"
+	if v := os.Getenv("POSTGRES_USER"); v != "" {
+		user = v
+	}
+	database := "dingo_test"
+	if v := os.Getenv("POSTGRES_DATABASE"); v != "" {
+		database = v
+	}
+	sslMode := "disable"
+	if v := os.Getenv("POSTGRES_SSLMODE"); v != "" {
+		sslMode = v
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
+		host, port, user, os.Getenv("POSTGRES_PASSWORD"), database, sslMode,
+	)
+}
+
+// newTestPostgresConformanceManager creates a Postgres-backed
+// DingoStateManager for testing, skipping the test if postgres isn't
+// configured.
+func newTestPostgresConformanceManager(t *testing.T) *DingoStateManager {
+	t.Helper()
+	skipIfPostgresConformanceNotConfigured(t)
+
+	sm, err := NewDingoPostgresStateManager(postgresConformanceDSN())
+	require.NoError(t, err, "failed to create postgres state manager")
+	return sm
+}
+
+// TestRulesConformanceVectorsPostgres is the strict pass/fail gate for the
+// Postgres-backed DingoStateManager: it fails immediately on the first
+// vector mismatch (via harness.RunAllVectors), mirroring
+// TestRulesConformanceVectors in conformance_test.go.
+func TestRulesConformanceVectorsPostgres(t *testing.T) {
+	skipIfPostgresConformanceNotConfigured(t)
+
+	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	sm := newTestPostgresConformanceManager(t)
+	defer sm.Close()
+
+	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
+		TestdataRoot: testdataRoot,
+		Debug:        testing.Verbose(),
+	})
+
+	harness.RunAllVectors(t)
+}
+
+// TestRulesConformanceVectorsWithResultsPostgres runs the harness against
+// both the SQLite-backed and Postgres-backed state managers in the same
+// test and compares them, rather than asserting a hardcoded vector count:
+// the two runs should exercise the identical number of vectors with
+// identical pass counts, and the comparison stays correct even as the
+// embedded ouroboros-mock vector corpus grows or shrinks.
+func TestRulesConformanceVectorsWithResultsPostgres(t *testing.T) {
+	skipIfPostgresConformanceNotConfigured(t)
+
+	sqliteRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	sqliteSm, err := NewDingoStateManager()
+	require.NoError(t, err)
+	defer sqliteSm.Close()
+
+	sqliteHarness := conformance.NewHarness(sqliteSm, conformance.HarnessConfig{
+		TestdataRoot: sqliteRoot,
+	})
+	sqliteResults, err := sqliteHarness.RunAllVectorsWithResults()
+	require.NoError(t, err, "failed to run sqlite vectors")
+
+	pgRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	pgSm := newTestPostgresConformanceManager(t)
+	defer pgSm.Close()
+
+	pgHarness := conformance.NewHarness(pgSm, conformance.HarnessConfig{
+		TestdataRoot: pgRoot,
+	})
+	pgResults, err := pgHarness.RunAllVectorsWithResults()
+	require.NoError(t, err, "failed to run postgres vectors")
+
+	var pgPassed, pgFailed int
+	for _, result := range pgResults {
+		if result.Success {
+			pgPassed++
+		} else {
+			pgFailed++
+		}
+	}
+
+	t.Logf("Conformance Test Results (PostgreSQL):")
+	t.Logf("  Total vectors: %d", len(pgResults))
+	t.Logf("  Passed: %d", pgPassed)
+	t.Logf("  Failed: %d", pgFailed)
+	if len(pgResults) > 0 {
+		t.Logf(
+			"  Pass rate: %.1f%%",
+			float64(pgPassed)/float64(len(pgResults))*100,
+		)
+	}
+	if pgFailed > 0 && testing.Verbose() {
+		t.Log("First failures:")
+		failCount := 0
+		for _, result := range pgResults {
+			if !result.Success && failCount < 5 {
+				t.Logf("  %s: %v", result.Title, result.Error)
+				failCount++
+			}
+		}
+		if pgFailed > 5 {
+			t.Logf("  ... and %d more failures", pgFailed-5)
+		}
+	}
+
+	require.Equal(
+		t,
+		len(sqliteResults),
+		len(pgResults),
+		"postgres backend exercised a different number of vectors than "+
+			"sqlite; vector discovery/extraction should be backend-invariant",
+	)
+	require.Zero(t, pgFailed, "postgres backend failed vectors sqlite passed")
+}

--- a/internal/test/conformance/docker-compose.yml
+++ b/internal/test/conformance/docker-compose.yml
@@ -1,0 +1,25 @@
+# PostgreSQL for local conformance test runs.
+#
+# Usage:
+#   docker compose -f internal/test/conformance/docker-compose.yml up -d
+#   POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
+#   POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=dingo_test \
+#     go test -tags dingo_extra_plugins -v ./internal/test/conformance/... -run Postgres
+#
+# Image/credentials match .github/workflows/go-test.yml's postgres service
+# so a passing local run and a passing CI run mean the same thing.
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: dingo_test
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 20

--- a/internal/test/conformance/state_manager_postgres.go
+++ b/internal/test/conformance/state_manager_postgres.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package conformance
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// conformanceSchema is the dedicated Postgres schema the conformance suite
+// migrates into. database/plugin/metadata/postgres's own tests connect to
+// the same dingo_test database and migrate models.MigrateModels into the
+// default "public" schema; go test runs different packages as separate,
+// concurrent binaries, so sharing "public" would let the two suites race on
+// the same tables (one DELETEing/AutoMigrating rows the other is mid-vector
+// on). A dedicated schema gives this suite its own copy of every table
+// without requiring a second CI service or database.
+const conformanceSchema = "conformance"
+
+// NewDingoPostgresStateManager creates a new DingoStateManager backed by a
+// real Postgres database instead of the default in-memory SQLite one used
+// by NewDingoStateManager. DingoStateManager's methods only ever go through
+// *gorm.DB, so no other state-manager code needs to change to support this
+// backend.
+func NewDingoPostgresStateManager(dsn string) (*DingoStateManager, error) {
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+		// models.MigrateModels lists Asset before Utxo, but Utxo.Assets
+		// declares the FK ("gorm:foreignKey:UtxoID;constraint:..."). A
+		// single batched AutoMigrate(MigrateModels...) call pre-parses
+		// every model's schema up front, so it embeds that constraint into
+		// Asset's CREATE TABLE before Utxo's table exists. SQLite (the
+		// default backend here) never validates REFERENCES targets at DDL
+		// time, so this was always latent; Postgres validates immediately
+		// and fails with "relation utxo does not exist". Disabling FK
+		// constraint creation during migration costs nothing for this
+		// harness specifically: DingoStateProvider (state_provider.go)
+		// never queries these rows back through SQL, only through
+		// DingoStateManager's in-memory maps.
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open postgres database: %w", err)
+	}
+
+	// SET search_path is a session-level setting; a connection pool would
+	// hand later queries a different pooled connection where search_path
+	// is back to the server default, silently routing AutoMigrate/writes
+	// to "public" instead of our dedicated schema. Pin to a single
+	// connection so every statement on this *gorm.DB shares the one
+	// session the search_path was set on (same fix already used by
+	// database/plugin/metadata/postgres's SetBulkLoadPragmas).
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sql.DB handle: %w", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
+	if err := db.Exec(
+		"CREATE SCHEMA IF NOT EXISTS " + conformanceSchema,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to create conformance schema: %w", err)
+	}
+	if err := db.Exec(
+		"SET search_path TO " + conformanceSchema,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to set search_path: %w", err)
+	}
+
+	// Run migrations for all models
+	if err := db.AutoMigrate(models.MigrateModels...); err != nil {
+		return nil, fmt.Errorf("failed to migrate database: %w", err)
+	}
+
+	return &DingoStateManager{
+		db:                   db,
+		govState:             conformance.NewGovernanceState(),
+		utxos:                make(map[string]common.Utxo),
+		stakeRegistrations:   make(map[common.Blake2b224]uint64),
+		poolRegistrations:    make(map[common.Blake2b224]bool),
+		drepRegistrations:    make(map[common.Blake2b224]bool),
+		committeeMembers:     make(map[common.Blake2b224]uint64),
+		hotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
+		committeeRemovals:    make(map[string]map[common.Blake2b224]struct{}),
+		committeeQuorums:     make(map[string]*big.Rat),
+	}, nil
+}


### PR DESCRIPTION
1. Added PostgreSQL-backed ledger conformance tests using the shared ouroboros-mock harness while retaining the existing SQLite suite.
2. Added a PostgreSQL-backed `DingoStateManager` using GORM’s PostgreSQL driver.
3. Added a dedicated `conformance` schema to isolate the suite from other PostgreSQL tests.
4. Added PostgreSQL conformance tests driven by `conformance.NewHarness(...)`.
5. Added strict vector pass/fail validation and detailed result reporting.
6.  Added environment-variable and DSN configuration for PostgreSQL connections.
7. Added a local PostgreSQL 16 Docker Compose setup for developer runs.
8. Integrated the PostgreSQL suite into the existing tagged Linux CI test step.
9. Updated the conformance README with setup, execution, and troubleshooting instructions.

Closes #2004 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PostgreSQL-backed conformance test suite using the shared `ouroboros-mock` harness alongside the SQLite suite. Runs locally and in CI via the existing tagged `go test` job to validate ledger behavior against a real Postgres backend. Closes #2004.

- **New Features**
  - Added Postgres-backed `DingoStateManager` via GORM; migrates into a dedicated `conformance` schema and pins a single connection to keep `search_path` stable.
  - Introduced `conformance_postgres_test.go` (gated by `dingo_extra_plugins`) to run the same vectors on Postgres with strict pass/fail and a SQLite vs Postgres result cross-check.
  - Enabled config via `POSTGRES_*` env vars or `POSTGRES_DSN`; tests auto-skip when not configured.
  - Added local Postgres 16 `docker-compose.yml` and README updates for setup and troubleshooting.
  - Removed the separate Postgres CI step; coverage now comes from the existing `go-test-linux` job’s tagged run.

<sup>Written for commit d46ae3d4c718769dfb4ef11d8765a9a35822ad71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added PostgreSQL-backed conformance testing alongside the existing SQLite tests.
  * CI now runs PostgreSQL conformance checks automatically and reports results separately.
  * Tests skip gracefully when PostgreSQL connection details are unavailable.

* **Documentation**
  * Added instructions for running PostgreSQL conformance tests locally with Docker Compose.
  * Documented required environment variables, schema isolation, and backend configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->