### PR TITLE
fix(blockfrost): return 404 for unmatched Blockfrost API routes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1840,7 +1840,10 @@ DRep lookup, address UTxOs and transactions, metadata label JSON/CBOR,
 transaction content/CBOR/metadata/UTxOs/certificates/redeemers/required
 signers, and account/delegation/registration/reward endpoints. It uses an
 adapter pattern to translate between Dingo's internal state and Blockfrost
-response types and supports Blockfrost-style pagination headers.
+response types and supports Blockfrost-style pagination headers. The root
+document is served only at the literal `/` path (`GET /{$}`); any other
+unregistered path falls through to a catch-all `404` handler instead of the
+root document, matching real Blockfrost's behavior for unimplemented routes.
 
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -59,18 +59,14 @@ func New(
 	}
 }
 
-// Start starts the HTTP server in a background goroutine.
-func (b *Blockfrost) Start(
-	ctx context.Context,
-) error {
-	b.mu.Lock()
-	if b.httpServer != nil {
-		b.mu.Unlock()
-		return errors.New("server already started")
-	}
-
+// handler builds the HTTP handler for the Blockfrost API,
+// including route registration and middleware.
+func (b *Blockfrost) handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /", b.handleRoot)
+	// "GET /{$}" matches only the literal root path. Without
+	// "{$}" the pattern would act as a subtree match and
+	// silently catch every unimplemented route.
+	mux.HandleFunc("GET /{$}", b.handleRoot)
 	mux.HandleFunc("GET /health", b.handleHealth)
 	mux.HandleFunc(
 		"GET /api/v0/blocks/latest",
@@ -217,19 +213,36 @@ func (b *Blockfrost) Start(
 		b.handleAccountRewardHistory,
 	)
 
+	// Catch-all for any path not matched above. Registered
+	// last so more specific patterns still take precedence;
+	// ServeMux resolves by pattern specificity, not
+	// registration order.
+	mux.HandleFunc("/", b.handleNotFound)
+
 	// Wrap handler with a request body size limit (1 MB)
 	// as defense-in-depth against oversized payloads.
 	const maxRequestBodyBytes int64 = 1 << 20 // 1 MB
-	handler := httpcors.Handler(
+	return httpcors.Handler(
 		http.MaxBytesHandler(mux, maxRequestBodyBytes),
 		httpcors.Config{
 			AllowedOrigins: b.config.CORSAllowedOrigins,
 		},
 	)
+}
+
+// Start starts the HTTP server in a background goroutine.
+func (b *Blockfrost) Start(
+	ctx context.Context,
+) error {
+	b.mu.Lock()
+	if b.httpServer != nil {
+		b.mu.Unlock()
+		return errors.New("server already started")
+	}
 
 	server := &http.Server{
 		Addr:              b.config.ListenAddress,
-		Handler:           handler,
+		Handler:           b.handler(),
 		ReadHeaderTimeout: 60 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -513,6 +513,61 @@ func TestHandleRoot(t *testing.T) {
 	assert.Equal(t, "0.1.0", resp.Version)
 }
 
+func TestRouterRootServesRootDocument(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+	handler := b.handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp RootResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "https://blockfrost.io/", resp.URL)
+}
+
+func TestRouterUnimplementedRouteReturns404(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+	handler := b.handler()
+
+	paths := []string{
+		"/api/v0/",
+		"/api/v0/scripts",
+		"/api/v0/pools",
+		"/does-not-exist",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			var resp ErrorResponse
+			err := json.NewDecoder(w.Body).Decode(&resp)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+			assert.Equal(t, "Not Found", resp.Error)
+		})
+	}
+}
+
+func TestRouterImplementedRouteStillWorks(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+	handler := b.handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestHandleHealth(t *testing.T) {
 	mock := &mockNode{}
 	b := newTestBlockfrost(mock)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -527,6 +527,7 @@ func TestRouterRootServesRootDocument(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 	assert.Equal(t, "https://blockfrost.io/", resp.URL)
+	assert.Equal(t, "0.1.0", resp.Version)
 }
 
 func TestRouterUnimplementedRouteReturns404(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -95,6 +95,20 @@ func (b *Blockfrost) handleRoot(
 	})
 }
 
+// handleNotFound handles any request that doesn't match a
+// registered route, including unimplemented endpoints.
+func (b *Blockfrost) handleNotFound(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	writeError(
+		w,
+		http.StatusNotFound,
+		"Not Found",
+		"The requested component has not been found.",
+	)
+}
+
 // handleHealth handles GET /health and returns node health
 // status.
 func (b *Blockfrost) handleHealth(


### PR DESCRIPTION
Closes #2858 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 for any unmatched Blockfrost API routes and serve the root document only at `/`. This aligns `api/blockfrost` with real Blockfrost behavior and avoids the root response on unimplemented paths.

- **Bug Fixes**
  - Route root with `GET /{$}` so only `/` serves the root document.
  - Add `handleNotFound` and a catch-all `/` to return a JSON 404 for unimplemented paths.
  - Introduce `handler()` and have `Start` use it; wraps the mux with `http.MaxBytesHandler` and `httpcors` for consistent middleware.
  - Tests cover root-only behavior, 404s for unknown routes, and a known route sanity check.
  - Updated `ARCHITECTURE.md` to document the new routing behavior.

<sup>Written for commit 598fe6f760b3d7d268afeae3f6194d65165fdb6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to unimplemented or unknown Blockfrost API paths now return a consistent `404 Not Found` response.
  * The root document is served only from the exact `/` path.
  * Existing health and root endpoints continue to work as expected.

* **Tests**
  * Added coverage for root routing, unknown routes, and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->