### PR TITLE
feat(node): integrate epoch reward processing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2363,6 +2363,19 @@ roll back and the rollover proceeds, deferring to the event-driven fallback
 rather than wedging the epoch boundary. When no hook is installed the ledger
 relies solely on the fallback capture, preserving the pre-wiring behavior.
 
+`dingo load` (immutable-DB replay) wires the authoritative hook but has no
+event-driven fallback: `LoadWithDB` builds the snapshot manager with a nil
+`EventBus` and never starts it, and the load ledger publishes no
+`EpochTransitionEvent`s. A post-hoc fallback cannot substitute either, because
+the reward inputs are copied from the live reward aggregate, which only matches
+the boundary during the in-transaction capture. So the ledger's savepoint
+deferral would otherwise turn a transient capture error into a silently missing
+mark/reward snapshot. To prevent that, `LoadWithDB` wraps the hook with a
+`loadCaptureFailureTracker` that records any suppressed capture failure and,
+after replay completes, returns it — failing the load loudly so the operator
+knows the resulting database is incomplete and must be re-imported, rather than
+finishing "successfully".
+
 Because the capture is staged inside the still-open rollover transaction, its
 success metrics (`capture_success_total`, `last_successful_epoch`, and the
 latest-snapshot pool/stake gauges) are published through `database.Txn.AfterCommit`

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -61,6 +62,54 @@ var installEpochBoundarySnapshotHookForLoad = func(
 ) error {
 	ls.SetEpochBoundarySnapshotHook(fn)
 	return nil
+}
+
+// loadCaptureFailureTracker records authoritative epoch-boundary snapshot
+// capture failures so `dingo load` can surface them after replay.
+//
+// Load has no event-driven snapshot fallback: LoadWithDB builds the snapshot
+// manager with a nil EventBus and never starts it, and the load ledger runs
+// without an EventBus, so no EpochTransitionEvents are ever published. The
+// ledger deliberately suppresses a failed authoritative capture (rolling back
+// its savepoint and deferring to the fallback) so an epoch boundary is never
+// wedged. During normal operation the event-driven fallback re-captures the
+// snapshot; during load there is no fallback, so a suppressed capture error
+// would silently drop that epoch's mark/reward snapshot and load would still
+// report success. A post-hoc fallback cannot substitute either: the reward
+// inputs are copied from the live reward aggregate, which only matches the
+// boundary during the in-transaction capture. This tracker lets load fail
+// loudly instead, so the operator knows the resulting database is incomplete.
+type loadCaptureFailureTracker struct {
+	mu     sync.Mutex
+	first  error
+	epochs []uint64
+}
+
+// record notes a failed capture for the given epoch. The first error is kept as
+// the representative cause; every failed epoch is accumulated for reporting.
+func (t *loadCaptureFailureTracker) record(epoch uint64, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.first == nil {
+		t.first = err
+	}
+	t.epochs = append(t.epochs, epoch)
+}
+
+// err returns a wrapped error naming every epoch whose authoritative snapshot
+// capture failed, or nil if all captures succeeded.
+func (t *loadCaptureFailureTracker) err() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.first == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"epoch-boundary snapshot capture failed for epoch(s) %v during load; "+
+			"load has no event-driven snapshot fallback, so the database is "+
+			"missing mark/reward snapshots and must be re-imported: %w",
+		t.epochs, t.first,
+	)
 }
 
 func Load(ctx context.Context, cfg *config.Config, logger *slog.Logger, immutableDir string) error {
@@ -354,10 +403,21 @@ func LoadWithDB(
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
+	captureFailures := &loadCaptureFailureTracker{}
 	if err := installEpochBoundarySnapshotHookForLoad(
 		ls,
 		func(txn *database.Txn, evt event.EpochTransitionEvent) error {
-			return snapshotMgr.CaptureEpochBoundarySnapshot(ctx, txn, evt)
+			// The ledger suppresses a failed authoritative capture and defers
+			// to the event-driven fallback, which does not exist in load mode.
+			// Record the failure so LoadWithDB can surface it after replay
+			// instead of completing with a missing mark/reward snapshot.
+			if err := snapshotMgr.CaptureEpochBoundarySnapshot(
+				ctx, txn, evt,
+			); err != nil {
+				captureFailures.record(evt.NewEpoch, err)
+				return err
+			}
+			return nil
 		},
 	); err != nil {
 		return fmt.Errorf("installing epoch-boundary snapshot hook: %w", err)
@@ -413,6 +473,12 @@ func LoadWithDB(
 		"blocks_copied", blocksCopied,
 		"tip_slot", immutableTipSlot,
 	)
+	// Surface any authoritative epoch-boundary capture the ledger suppressed:
+	// load has no fallback to recapture it, so a silent success here would leave
+	// the database missing mark/reward snapshots for those epochs.
+	if err := captureFailures.err(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -28,8 +28,10 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/ledger/snapshot"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -46,6 +48,20 @@ const (
 
 	immutableUtxoOffsetsSyncStateKey = "immutable_utxo_offsets_tip"
 )
+
+// newLedgerStateForLoad is replaceable in tests so load-mode composition can
+// be verified without replaying a full ImmutableDB fixture.
+var newLedgerStateForLoad = ledger.NewLedgerState
+
+// installEpochBoundarySnapshotHookForLoad is replaceable in tests so load-mode
+// composition can verify the hook is installed without starting ledger workers.
+var installEpochBoundarySnapshotHookForLoad = func(
+	ls *ledger.LedgerState,
+	fn func(*database.Txn, event.EpochTransitionEvent) error,
+) error {
+	ls.SetEpochBoundarySnapshotHook(fn)
+	return nil
+}
 
 func Load(ctx context.Context, cfg *config.Config, logger *slog.Logger, immutableDir string) error {
 	return LoadWithDB(ctx, cfg, logger, immutableDir, nil)
@@ -92,6 +108,24 @@ func ensureDB(
 		return nil, nil, fmt.Errorf("creating database: %w", err)
 	}
 	return newDB, func() { newDB.Close() }, nil
+}
+
+// captureLoadGenesisSnapshot captures the genesis (epoch 0) mark stake
+// snapshot during a `dingo load` replay, mirroring the guard node.go applies
+// around the equivalent call (see handleGenesisSnapshotError): a block
+// producer cannot elect leaders without this snapshot, so a capture failure
+// is fatal, while a relay or replay-only load only warns and continues.
+func captureLoadGenesisSnapshot(
+	ctx context.Context,
+	snapshotMgr *snapshot.Manager,
+	cfg *config.Config,
+	logger *slog.Logger,
+) error {
+	return snapshot.HandleGenesisSnapshotError(
+		cfg.BlockProducer,
+		logger,
+		snapshotMgr.CaptureGenesisSnapshot(ctx),
+	)
 }
 
 // WithBulkLoadPragmas enables bulk-load optimizations on the metadata
@@ -299,8 +333,9 @@ func LoadWithDB(
 	if c == nil {
 		return errors.New("primary chain not available")
 	}
+	snapshotMgr := snapshot.NewManager(db, nil, logger)
 	// Load state
-	ls, err := ledger.NewLedgerState(
+	ls, err := newLedgerStateForLoad(
 		ledger.LedgerStateConfig{
 			Database:              db,
 			ChainManager:          cm,
@@ -319,10 +354,29 @@ func LoadWithDB(
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
+	if err := installEpochBoundarySnapshotHookForLoad(
+		ls,
+		func(txn *database.Txn, evt event.EpochTransitionEvent) error {
+			return snapshotMgr.CaptureEpochBoundarySnapshot(ctx, txn, evt)
+		},
+	); err != nil {
+		return fmt.Errorf("installing epoch-boundary snapshot hook: %w", err)
+	}
 	if err := ls.Start(context.WithoutCancel(ctx)); err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
 	defer ls.Close()
+
+	// Capture the genesis stake snapshot (epoch 0) now that ls.Start has
+	// applied genesis (including any Shelley-genesis staking), mirroring
+	// node.go's normal startup path. Without this, replaying a devnet chain
+	// with genesis staking through `dingo load` never creates the epoch-0
+	// mark RewardSnapshot, silently skipping the first reward round applied
+	// at the epoch-3 boundary (#1959). This must run before any epoch
+	// boundaries are processed below.
+	if err := captureLoadGenesisSnapshot(ctx, snapshotMgr, cfg, logger); err != nil {
+		return err
+	}
 
 	replayCtx, cancelReplay := context.WithCancel(ctx)
 	defer cancelReplay()

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -480,6 +481,60 @@ func TestLoadWithDBWiresEpochBoundarySnapshotHook(t *testing.T) {
 	require.NotNil(t, capturedHook)
 	require.True(t, captured.TrustedReplay)
 	require.True(t, captured.ManualBlockProcessing)
+}
+
+// TestLoadCaptureFailureTrackerCleanReturnsNil verifies that a tracker with no
+// recorded failures reports success, so a clean load is never turned into an
+// error.
+func TestLoadCaptureFailureTrackerCleanReturnsNil(t *testing.T) {
+	t.Parallel()
+	tracker := &loadCaptureFailureTracker{}
+	require.NoError(t, tracker.err())
+}
+
+// TestLoadCaptureFailureTrackerSurfacesFailures verifies that a recorded capture
+// failure surfaces as an error that preserves the first cause and names every
+// failed epoch. This is the load-mode safety net for #1959: the ledger
+// suppresses the authoritative capture error and load has no event-driven
+// fallback, so without this the missing mark/reward snapshot would be silent.
+func TestLoadCaptureFailureTrackerSurfacesFailures(t *testing.T) {
+	t.Parallel()
+	tracker := &loadCaptureFailureTracker{}
+
+	first := errors.New("capture epoch 3 failed")
+	tracker.record(3, first)
+	tracker.record(7, errors.New("capture epoch 7 failed"))
+
+	err := tracker.err()
+	require.Error(t, err)
+	// First error is kept as the representative cause.
+	require.ErrorIs(t, err, first)
+	// Every failed epoch is named for the operator.
+	require.Contains(t, err.Error(), "3")
+	require.Contains(t, err.Error(), "7")
+	require.Contains(t, err.Error(), "re-imported")
+}
+
+// TestLoadCaptureFailureTrackerConcurrentRecord exercises the tracker under the
+// race detector to confirm record/err are safe to call from the replay
+// goroutine while the load goroutine reads the result.
+func TestLoadCaptureFailureTrackerConcurrentRecord(t *testing.T) {
+	t.Parallel()
+	tracker := &loadCaptureFailureTracker{}
+
+	const n = 64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range uint64(n) {
+		go func(epoch uint64) {
+			defer wg.Done()
+			tracker.record(epoch, fmt.Errorf("capture epoch %d failed", epoch))
+		}(i)
+	}
+	wg.Wait()
+
+	err := tracker.err()
+	require.Error(t, err)
 }
 
 // TestCaptureLoadGenesisSnapshot_BlockProducerFatal verifies that

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,14 +11,20 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/ledger/snapshot"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	fxcbor "github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
@@ -431,6 +438,176 @@ func TestCopyBlocksRawWithCallback_BackfillsWhenChainTipPastImmutableTip(
 	assert.Equal(t, 0, blocksCopied)
 	assert.Equal(t, immutableTipSlot, resumedImmutableTipSlot)
 	assert.Greater(t, offsetsStored, 0)
+}
+
+func TestLoadWithDBWiresEpochBoundarySnapshotHook(t *testing.T) {
+	db := newTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	stopAfterHook := errors.New("stop after snapshot hook capture")
+	var captured ledger.LedgerStateConfig
+	var capturedHook func(*database.Txn, event.EpochTransitionEvent) error
+	oldNewLedgerStateForLoad := newLedgerStateForLoad
+	oldInstallHook := installEpochBoundarySnapshotHookForLoad
+	newLedgerStateForLoad = func(
+		cfg ledger.LedgerStateConfig,
+	) (*ledger.LedgerState, error) {
+		captured = cfg
+		return &ledger.LedgerState{}, nil
+	}
+	installEpochBoundarySnapshotHookForLoad = func(
+		_ *ledger.LedgerState,
+		fn func(*database.Txn, event.EpochTransitionEvent) error,
+	) error {
+		capturedHook = fn
+		return stopAfterHook
+	}
+	t.Cleanup(func() {
+		newLedgerStateForLoad = oldNewLedgerStateForLoad
+		installEpochBoundarySnapshotHookForLoad = oldInstallHook
+	})
+
+	err := LoadWithDB(
+		context.Background(),
+		&config.Config{Network: "preview"},
+		logger,
+		"unused",
+		db,
+	)
+	require.ErrorIs(t, err, stopAfterHook)
+	require.Same(t, db, captured.Database)
+	require.NotNil(t, captured.ChainManager)
+	require.NotNil(t, capturedHook)
+	require.True(t, captured.TrustedReplay)
+	require.True(t, captured.ManualBlockProcessing)
+}
+
+// TestCaptureLoadGenesisSnapshot_BlockProducerFatal verifies that
+// captureLoadGenesisSnapshot returns a fatal, wrapped error for a
+// block-producer load when the underlying capture fails, mirroring
+// node.go's handleGenesisSnapshotError guard for the normal Run path.
+func TestCaptureLoadGenesisSnapshot_BlockProducerFatal(t *testing.T) {
+	db := newTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mgr := snapshot.NewManager(db, nil, logger)
+
+	// Close the database so the capture call fails deterministically.
+	require.NoError(t, db.Close())
+
+	err := captureLoadGenesisSnapshot(
+		context.Background(),
+		mgr,
+		&config.Config{BlockProducer: true},
+		logger,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to capture genesis snapshot")
+}
+
+// TestCaptureLoadGenesisSnapshot_RelayWarnsAndContinues verifies that a
+// non-block-producer load only warns and continues when the capture fails,
+// matching the relay behavior of node.go's handleGenesisSnapshotError.
+func TestCaptureLoadGenesisSnapshot_RelayWarnsAndContinues(t *testing.T) {
+	db := newTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mgr := snapshot.NewManager(db, nil, logger)
+
+	require.NoError(t, db.Close())
+
+	err := captureLoadGenesisSnapshot(
+		context.Background(),
+		mgr,
+		&config.Config{BlockProducer: false},
+		logger,
+	)
+	require.NoError(t, err)
+}
+
+// TestLoadWithDBCapturesGenesisMarkSnapshotForShelleyGenesisStaking verifies
+// finding B (#1959): replaying a genesis with Shelley-genesis staking (as
+// devnets configure) through `dingo load` must seed the epoch-0 "mark"
+// RewardSnapshot the same way the normal node.Run startup path does via
+// CaptureGenesisSnapshot, or the first reward round applied at the epoch-3
+// boundary is silently skipped.
+//
+// The chain tip is advanced past the immutable testdata tip before calling
+// LoadWithDB so copyBlocksDirect takes its "chain tip already beyond
+// immutable DB tip" short-circuit (see load.go) and skips decoding the real
+// mainnet blocks in testdata, which are unrelated to the devnet genesis
+// configured here. This isolates the test to the genesis-application and
+// genesis-snapshot-capture behavior that finding B is about.
+func TestLoadWithDBCapturesGenesisMarkSnapshotForShelleyGenesisStaking(
+	t *testing.T,
+) {
+	// No t.Parallel(): newTestDB shares process-wide plugin state (see
+	// database.go:164), so concurrent test runs race on SetPluginOption and
+	// the in-memory schema migration.
+	immutableDir := filepath.Join(
+		"..",
+		"..",
+		"database",
+		"immutable",
+		"testdata",
+	)
+	imm, err := immutable.New(immutableDir)
+	require.NoError(t, err)
+	immutableTip, err := imm.GetTip()
+	require.NoError(t, err)
+	require.NotNil(t, immutableTip)
+
+	db := newTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	currentTip := cm.PrimaryChain().Tip()
+	stubSlot := immutableTip.Slot + 5
+	stubHash := bytes.Repeat([]byte{0xAB}, 32)
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        stubSlot,
+			Hash:        stubHash,
+			BlockNumber: currentTip.BlockNumber + 1,
+			Type:        0,
+			PrevHash:    currentTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point:       ocommon.NewPoint(stubSlot, stubHash),
+		BlockNumber: currentTip.BlockNumber + 1,
+	}, nil))
+
+	cfg := &config.Config{
+		Network:       "devnet",
+		CardanoConfig: "devnet/config.json",
+	}
+
+	err = LoadWithDB(context.Background(), cfg, logger, immutableDir, db)
+	require.NoError(t, err)
+
+	nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
+		cfg.CardanoConfig,
+		cfg.Network,
+		cardano.EmbeddedConfigFS,
+	)
+	require.NoError(t, err)
+	shelleyGenesis := nodeCfg.ShelleyGenesis()
+	require.NotNil(t, shelleyGenesis)
+	require.NotEmpty(
+		t,
+		shelleyGenesis.Staking.Pools,
+		"devnet genesis fixture must declare staking for this test to be meaningful",
+	)
+
+	rewardSnapshot, err := db.Metadata().GetRewardSnapshot(0, "mark", nil)
+	require.NoError(t, err)
+	require.NotNil(
+		t,
+		rewardSnapshot,
+		"expected epoch-0 mark RewardSnapshot after loading a genesis "+
+			"with Shelley staking via `dingo load`",
+	)
 }
 
 func decodeImmutableBlockHeader(

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -535,6 +535,13 @@ func ImportLedgerState(
 		}
 	}
 
+	// RebuildRewardLiveStake is a full-table rebuild in a single expensive
+	// transaction and takes no context, so it cannot observe cancellation once
+	// started. Bail out here if the import was cancelled during the preceding
+	// phases rather than beginning the rebuild on an interrupted sync.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("cancelled before rebuilding reward live stake: %w", err)
+	}
 	if err := cfg.Database.RebuildRewardLiveStake(slot, nil); err != nil {
 		return fmt.Errorf("rebuilding reward live stake: %w", err)
 	}

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -421,7 +421,6 @@ func ImportLedgerState(
 			"component", "ledgerstate",
 		)
 	}
-
 	// Import stake snapshots
 	if !models.IsPhaseCompleted(
 		completedPhase,
@@ -535,6 +534,17 @@ func ImportLedgerState(
 			return fmt.Errorf("reconciling stale ledger state: %w", err)
 		}
 	}
+
+	if err := cfg.Database.RebuildRewardLiveStake(slot, nil); err != nil {
+		return fmt.Errorf("rebuilding reward live stake: %w", err)
+	}
+	progress(ImportProgress{
+		Stage:       "reward_live_stake",
+		Current:     1,
+		Total:       1,
+		Percent:     100,
+		Description: "reward live stake rebuilt",
+	})
 
 	// Set the chain tip
 	if !models.IsPhaseCompleted(

--- a/node_forging.go
+++ b/node_forging.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	"github.com/blinklabs-io/dingo/ledger/leader"
 	"github.com/blinklabs-io/dingo/ledger/leios"
+	"github.com/blinklabs-io/dingo/ledger/snapshot"
 	"github.com/blinklabs-io/dingo/mempool"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -202,14 +203,11 @@ func (n *Node) validateBlockProducerLedgerWithView(
 // require the genesis snapshot for leader election) and logs a warning for
 // relay nodes (which do not perform leader election).
 func (n *Node) handleGenesisSnapshotError(err error) error {
-	if n.config.blockProducer {
-		return fmt.Errorf("failed to capture genesis snapshot: %w", err)
-	}
-	n.config.logger.Warn(
-		"failed to capture genesis snapshot",
-		"error", err,
+	return snapshot.HandleGenesisSnapshotError(
+		n.config.blockProducer,
+		n.config.logger,
+		err,
 	)
-	return nil
 }
 
 // initBlockForger initializes the block forger for production mode.


### PR DESCRIPTION
Refs: #1959 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates epoch reward processing by capturing genesis and epoch-boundary snapshots during `dingo load`, surfacing any capture failures, and rebuilding live stake with progress so the first reward round runs on time. Addresses #1959 by seeding the epoch-0 mark snapshot during `dingo load` to prevent skipped rewards on devnets.

- **New Features**
  - Capture genesis snapshot during `dingo load` after `ls.Start`; fatal for block producers, warn for relays via `snapshot.HandleGenesisSnapshotError`.
  - Install epoch-boundary snapshot hook in load mode using `snapshot.Manager`; record failures and fail load after replay to avoid missing mark/reward snapshots.
  - Rebuild reward live stake at the end of `ledgerstate.ImportLedgerState` with progress reporting and a cancellation pre-check.

- **Bug Fixes**
  - Create epoch-0 mark `RewardSnapshot` when replaying Shelley-genesis staking so epoch-3 rewards are applied.

<sup>Written for commit 51bf7210d1873794ed14532f51b2b48c7366e8a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic snapshot capture during ledger loading, including the initial genesis snapshot and epoch-boundary snapshots.
  * Added progress reporting for rebuilding reward live stake during reconciled ledger imports.

* **Bug Fixes**
  * Improved genesis snapshot error handling: block-producing nodes now fail clearly, while relay nodes continue with a warning.
  * Ensured loaded networks with Shelley genesis staking include the expected initial reward snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->