### PR TITLE
feat: pledge leverage (CIP-50)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2566,6 +2566,19 @@ validator is left unclamped, so when the feature is active and any pool in the
 epoch's snapshot is below the floor, reuse is conservatively bypassed for that
 whole epoch's snapshot and the fresh authoritative calculation is used.
 
+CIP-50 pledge-leverage rewards are an optional, consensus-affecting feature gate
+that defaults off. When `LedgerStateConfig.PledgeLeverageEnabled` is set (from
+operator config, not derived from the network), a pool's reward-eligible stake
+`sigma'` in `optimalPoolRewardChecked` (`ledger/rewards`) is additionally capped
+at `L` times its pledge, so `sigma' = min(sigma, z0, L*p)`; a zero-pledge pool
+then earns nothing. `L` is threaded from config onto `rewards.Parameters` at the
+single `LedgerState.rewardParameters` chokepoint (`applyPledgeLeverageConfig`),
+so the boundary-apply and precompute paths compute identical rewards. Disabled,
+the term is nil and the formula is byte-for-byte the pre-CIP-50 calculation.
+Because it changes reward amounts and therefore ADA pots and reward accounts, it
+must be enabled only on a network where every node also enables it (a devnet or
+custom network); enabling it off-consensus forks the node.
+
 After an epoch-transition event, ledger can precompute the next delayed reward
 update into `reward_pool_output` and `reward_account_output`. Calculation runs
 in a read-only transaction; a separate short write transaction re-reads the

--- a/config.go
+++ b/config.go
@@ -196,6 +196,10 @@ type Config struct {
 	// CIP-23 minimum pool margin (minimum variable fee) in basis points,
 	// [0, 10000]; consensus-affecting, 0 = off; effective only in Dijkstra+.
 	minPoolMargin uint
+	// CIP-50 pledge-leverage staking rewards (consensus-affecting; default
+	// off). pledgeLeverage is L in [1, 10000], used only when enabled.
+	pledgeLeverageEnabled bool
+	pledgeLeverage        uint
 	// Leios voting configuration (experimental)
 	leiosVoteSigningKeyFile string
 	leiosVoterPublicKeys    map[string]string
@@ -444,6 +448,13 @@ func (n *Node) configValidate() error {
 		return fmt.Errorf(
 			"min pool margin (%d) must be in [0, 10000] basis points",
 			n.config.minPoolMargin,
+		)
+	}
+	if n.config.pledgeLeverageEnabled &&
+		(n.config.pledgeLeverage < 1 || n.config.pledgeLeverage > 10_000) {
+		return fmt.Errorf(
+			"pledge leverage (%d) must be in [1, 10000] when enabled",
+			n.config.pledgeLeverage,
 		)
 	}
 	// In core mode, ignore API ports — they are only used in API mode.
@@ -905,6 +916,17 @@ func WithMinPoolMargin(basisPoints uint) ConfigOptionFunc {
 	}
 }
 
+// WithPledgeLeverage configures the CIP-50 pledge-leverage staking reward cap.
+// It is consensus-affecting and disabled by default; enable it only on a
+// network where every node also enables it. leverage is L, the maximum ratio
+// of total stake to pledge, and is used only when enabled.
+func WithPledgeLeverage(enabled bool, leverage uint) ConfigOptionFunc {
+	return func(c *Config) {
+		c.pledgeLeverageEnabled = enabled
+		c.pledgeLeverage = leverage
+	}
+}
+
 // WithShelleyVRFKey specifies the path to the VRF signing key file (CARDANO_SHELLEY_VRF_KEY).
 // Required for block production.
 func WithShelleyVRFKey(path string) ConfigOptionFunc {
@@ -1103,7 +1125,10 @@ func WithStorageMode(mode StorageMode) ConfigOptionFunc {
 
 // WithCacheConfig sets the CBOR cache sizes for block LRU,
 // hot UTxO, and hot TX caches.
-func WithCacheConfig(blockLRU, hotUtxo, hotTx int, hotTxMaxBytes int64) ConfigOptionFunc {
+func WithCacheConfig(
+	blockLRU, hotUtxo, hotTx int,
+	hotTxMaxBytes int64,
+) ConfigOptionFunc {
 	return func(c *Config) {
 		c.cacheBlockLRUEntries = blockLRU
 		c.cacheHotUtxoEntries = hotUtxo

--- a/config_test.go
+++ b/config_test.go
@@ -117,6 +117,51 @@ func TestWithMidnightConfig(t *testing.T) {
 	assert.Equal(t, midnightCfg, cfg.midnight)
 }
 
+func TestConfigValidatePledgeLeverage(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		leverage uint
+		wantErr  bool
+	}{
+		{name: "disabled ignores zero", leverage: 0},
+		{
+			name:     "enabled rejects zero",
+			enabled:  true,
+			leverage: 0,
+			wantErr:  true,
+		},
+		{name: "enabled accepts minimum", enabled: true, leverage: 1},
+		{name: "enabled accepts typical value", enabled: true, leverage: 100},
+		{name: "enabled accepts maximum", enabled: true, leverage: 10_000},
+		{
+			name:     "enabled rejects above maximum",
+			enabled:  true,
+			leverage: 10_001,
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig(
+				WithNetworkMagic(1),
+				WithPrometheusRegistry(prometheus.NewRegistry()),
+				WithListeners(ListenerConfig{
+					ListenNetwork: "tcp",
+					ListenAddress: "127.0.0.1:0",
+				}),
+				WithPledgeLeverage(tt.enabled, tt.leverage),
+			)
+			_, err := New(cfg)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "pledge leverage")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestExperimentalDijkstraEnabled(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -186,7 +231,12 @@ func TestExperimentalLeiosNetworkingEnabled(t *testing.T) {
 		expectNetworking  bool
 		expectDijkstraEra bool
 	}{
-		{name: "default", cfg: Config{}, expectNetworking: false, expectDijkstraEra: false},
+		{
+			name:              "default",
+			cfg:               Config{},
+			expectNetworking:  false,
+			expectDijkstraEra: false,
+		},
 		{
 			name:              "leios run mode enables both",
 			cfg:               Config{runMode: runModeLeios},
@@ -194,8 +244,10 @@ func TestExperimentalLeiosNetworkingEnabled(t *testing.T) {
 			expectDijkstraEra: true,
 		},
 		{
-			name:              "dijkstra start era enables both",
-			cfg:               Config{startEra: internalconfig.StartEraDijkstra},
+			name: "dijkstra start era enables both",
+			cfg: Config{
+				startEra: internalconfig.StartEraDijkstra,
+			},
 			expectNetworking:  true,
 			expectDijkstraEra: true,
 		},
@@ -310,7 +362,11 @@ func TestRunRTSMetricsUpdater_Lifecycle(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	n := &Node{config: Config{promRegistry: reg}}
 	n.registerRTSMetrics()
-	require.NotNil(t, n.rtsMetrics, "registerRTSMetrics must populate n.rtsMetrics")
+	require.NotNil(
+		t,
+		n.rtsMetrics,
+		"registerRTSMetrics must populate n.rtsMetrics",
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -566,3 +566,19 @@ mithril:
 # CLI: --min-pool-margin
 # Env: DINGO_MIN_POOL_MARGIN
 # minPoolMargin: 0        # basis points, 0..10000 (150 = 1.5%); 0 disables
+
+# ---
+# CIP-50 pledge-leverage staking rewards (experimental, consensus-affecting)
+#
+# Adds the CIP-50 leverage cap to the staking-reward formula: a pool's
+# reward-eligible stake is capped at L times its pledge, so a zero-pledge pool
+# earns nothing and an over-leveraged pool plateaus. This changes the ledger
+# reward calculation, so it MUST only be enabled on a network where every node
+# also enables it (a devnet or custom network). Enabling it off-consensus, e.g.
+# on mainnet or the public testnets, will fork this node off the network. It is
+# disabled by default.
+#
+# CLI: --pledge-leverage-enabled / --pledge-leverage
+# Env: DINGO_PLEDGE_LEVERAGE_ENABLED / DINGO_PLEDGE_LEVERAGE
+# pledgeLeverageEnabled: false
+# pledgeLeverage: 100        # L; integer in [1, 10000]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -565,6 +565,13 @@ type Config struct {
 	// value only where every node also enables the same value. See
 	// ARCHITECTURE.md ("Reward Calculation And Precomputation").
 	MinPoolMargin uint `yaml:"minPoolMargin" envconfig:"DINGO_MIN_POOL_MARGIN"`
+	// CIP-50 pledge-leverage staking rewards. Consensus-affecting; defaults
+	// off. PledgeLeverageEnabled turns on the L*pledge reward cap and
+	// PledgeLeverage is L in [1, 10000]. Enable only on a network where every
+	// node also enables it. See
+	// docs/plans/2026-07-19-cip50-pledge-leverage-design.md.
+	PledgeLeverageEnabled bool `yaml:"pledgeLeverageEnabled" envconfig:"DINGO_PLEDGE_LEVERAGE_ENABLED"`
+	PledgeLeverage        uint `yaml:"pledgeLeverage"        envconfig:"DINGO_PLEDGE_LEVERAGE"`
 
 	// Leios voting configuration (experimental, leios runMode only).
 	// LeiosVoteSigningKeyFile is the path to a hex-encoded BLS12-381
@@ -844,6 +851,8 @@ var globalConfig = &Config{
 	DatabaseWorkers:   5,
 	DatabaseQueueSize: 50,
 	BackfillBatchSize: 100,
+	// CIP-50 default L (feature disabled by default via PledgeLeverageEnabled)
+	PledgeLeverage: 100,
 	// Cache configuration defaults
 	Cache: DefaultCacheConfig(),
 	// Chainsync configuration defaults

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -173,6 +173,10 @@ var flagSpecs = []flagSpec{
 	// CIP-23 minimum pool margin / minimum variable fee (consensus-affecting; default 0 = off)
 	uintFlag("MinPoolMargin", "min-pool-margin", "CIP-23 minimum pool margin in basis points [0,10000] (150 = 1.5%); 0 disables (enable only where every node also enables it)"),
 
+	// CIP-50 pledge-leverage staking rewards (consensus-affecting; default off)
+	boolFlag("PledgeLeverageEnabled", "pledge-leverage-enabled", "enable the CIP-50 pledge-leverage reward cap (only where every node also enables it)"),
+	uintFlag("PledgeLeverage", "pledge-leverage", "CIP-50 max pledge leverage L in [1,10000] (used when pledge-leverage-enabled)"),
+
 	// Leios voting (experimental)
 	stringFlag("LeiosVoteSigningKeyFile", "leios-vote-signing-key-file", "", "path to hex-encoded BLS12-381 Leios vote signing key"),
 	stringToStringFlag("LeiosVoterPublicKeys", "leios-voter-public-keys", "Leios voter public key registry: pool key hash hex=public key hex"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -84,6 +84,33 @@ func TestRegisterFlags_CoversAllExportedConfigFields(t *testing.T) {
 	}
 }
 
+func TestPledgeLeverageEnvBinding(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_PLEDGE_LEVERAGE_ENABLED", "true")
+	t.Setenv("DINGO_PLEDGE_LEVERAGE", "42")
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(configFile, []byte(""), 0o600); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if !cfg.PledgeLeverageEnabled {
+		t.Fatal("expected env var to enable pledge leverage")
+	}
+	if cfg.PledgeLeverage != 42 {
+		t.Fatalf(
+			"expected env var to set pledgeLeverage=42, got %d",
+			cfg.PledgeLeverage,
+		)
+	}
+}
+
 func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 	resetGlobalConfig()
 	t.Setenv("HOME", t.TempDir())

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -319,6 +319,15 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		))
 	}
 
+	// CIP-50 pledge leverage L must be within [1, 10000] when enabled.
+	if c.PledgeLeverageEnabled &&
+		(c.PledgeLeverage < 1 || c.PledgeLeverage > 10000) {
+		errs = append(errs, fmt.Errorf(
+			"pledgeLeverage (%d) must be in [1, 10000] when pledgeLeverageEnabled",
+			c.PledgeLeverage,
+		))
+	}
+
 	// Network identity
 	if c.Network == "" {
 		if c.NetworkMagic == 0 {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -411,6 +411,46 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidatePledgeLeverage(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		l       uint
+		wantErr string
+	}{
+		{name: "disabled ignores out-of-range value", enabled: false, l: 0},
+		{name: "enabled at minimum", enabled: true, l: 1},
+		{name: "enabled within range", enabled: true, l: 100},
+		{name: "enabled at maximum", enabled: true, l: 10_000},
+		{
+			name:    "enabled below minimum",
+			enabled: true,
+			l:       0,
+			wantErr: "pledgeLeverage",
+		},
+		{
+			name:    "enabled above maximum",
+			enabled: true,
+			l:       10_001,
+			wantErr: "pledgeLeverage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.PledgeLeverageEnabled = tt.enabled
+			cfg.PledgeLeverage = tt.l
+			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 // TestValidatePrivilegedPortAllowedWhenBindable covers a process that
 // may bind any port (root, Windows, or CAP_NET_BIND_SERVICE):
 // minBindable is 0, so a sub-1024 port passes.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -430,6 +430,11 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithStorageMode(storageMode),
 			// CIP-23 minimum pool margin (consensus-affecting)
 			dingo.WithMinPoolMargin(cfg.MinPoolMargin),
+			// CIP-50 pledge-leverage staking rewards (consensus-affecting)
+			dingo.WithPledgeLeverage(
+				cfg.PledgeLeverageEnabled,
+				cfg.PledgeLeverage,
+			),
 			// Block production (SPO mode)
 			dingo.WithBlockProducer(cfg.BlockProducer),
 			dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -2191,6 +2191,10 @@ func (ls *LedgerState) rewardParameters(
 	// Dijkstra and later. Single chokepoint feeding both the boundary apply and
 	// the async precompute, so both agree.
 	applyMinPoolMarginConfig(&params, ls.config)
+	// CIP-50: overlay the operator-configured pledge-leverage feature gate onto
+	// the on-chain-derived parameters. This is the single chokepoint feeding
+	// both the boundary apply and the async precompute path, so both agree.
+	applyPledgeLeverageConfig(&params, ls.config)
 	if params.MaxLovelaceSupply < uint64(pots.Reserves) {
 		return nil, rewards.Parameters{}, nil, fmt.Errorf(
 			"invalid reward pots: reserves %d exceed max supply %d",
@@ -2958,6 +2962,20 @@ func rewardFromAccountOutput(
 		Type:       rewards.RewardType(output.RewardType),
 		Spendable:  output.Spendable,
 	}, nil
+}
+
+// applyPledgeLeverageConfig copies the CIP-50 pledge-leverage feature gate from
+// the ledger config onto the reward parameters, converting the integer L to the
+// rational the rewards package expects. When the feature is disabled the
+// pledge-leverage value is cleared (PledgeLeverage stays nil), preserving the
+// pre-CIP-50 formula.
+func applyPledgeLeverageConfig(params *rewards.Parameters, cfg LedgerStateConfig) {
+	params.PledgeLeverageEnabled = cfg.PledgeLeverageEnabled
+	if cfg.PledgeLeverageEnabled {
+		params.PledgeLeverage = new(big.Rat).SetUint64(uint64(cfg.PledgeLeverage))
+	} else {
+		params.PledgeLeverage = nil
+	}
 }
 
 func rewardParametersFromPParams(

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -3879,6 +3879,29 @@ func TestRewardParametersRejectIncompletePParams(t *testing.T) {
 	require.ErrorContains(t, err, "missing treasury expansion")
 }
 
+func TestApplyPledgeLeverageConfigEnabledSetsRationalL(t *testing.T) {
+	params := rewards.Parameters{}
+	applyPledgeLeverageConfig(&params, LedgerStateConfig{
+		PledgeLeverageEnabled: true,
+		PledgeLeverage:        100,
+	})
+	require.True(t, params.PledgeLeverageEnabled)
+	require.Equal(t, big.NewRat(100, 1), params.PledgeLeverage)
+}
+
+func TestApplyPledgeLeverageConfigDisabledClearsL(t *testing.T) {
+	params := rewards.Parameters{
+		PledgeLeverageEnabled: true,
+		PledgeLeverage:        big.NewRat(50, 1),
+	}
+	applyPledgeLeverageConfig(&params, LedgerStateConfig{
+		PledgeLeverageEnabled: false,
+		PledgeLeverage:        100,
+	})
+	require.False(t, params.PledgeLeverageEnabled)
+	require.Nil(t, params.PledgeLeverage)
+}
+
 func TestRewardBlockCountsTotalIncludesPoolsOutsideSnapshot(t *testing.T) {
 	ls, db := newRewardCalculationTestLedger(t)
 	meta := db.Metadata()

--- a/ledger/rewards/reference_test.go
+++ b/ledger/rewards/reference_test.go
@@ -464,6 +464,7 @@ func requireOptimalPoolReward(
 		poolStake,
 		pledge,
 		totalStake,
+		nil,
 	)
 	require.NoError(t, err)
 	return ret

--- a/ledger/rewards/rewards.go
+++ b/ledger/rewards/rewards.go
@@ -121,6 +121,23 @@ type Parameters struct {
 	// nil reproduces the pre-CIP-23 split byte-for-byte. Must be in [0, 1] when
 	// set.
 	MinPoolMargin *big.Rat
+	// PledgeLeverageEnabled turns on the CIP-50 pledge-leverage cap. It is a
+	// consensus-affecting feature gate that defaults off; enable it only on a
+	// network where every node also enables it.
+	PledgeLeverageEnabled bool
+	// PledgeLeverage is L, the maximum ratio of total stake to pledge before a
+	// pool's reward-eligible stake plateaus. It is used only when
+	// PledgeLeverageEnabled is true and must be in the range [1, 10000].
+	PledgeLeverage *big.Rat
+}
+
+// pledgeLeverageCap returns L for the CIP-50 pledge-leverage cap when the
+// feature is enabled, or nil when it is disabled (the pre-CIP-50 formula).
+func (p Parameters) pledgeLeverageCap() *big.Rat {
+	if !p.PledgeLeverageEnabled {
+		return nil
+	}
+	return p.PledgeLeverage
 }
 
 // Pots captures the pot values available at the start of reward calculation.
@@ -650,7 +667,37 @@ func validateParameters(params Parameters) error {
 	if params.EpochLength == 0 {
 		return fmt.Errorf("%w: epoch length is zero", ErrInvalidParameters)
 	}
-	return validateMinPoolMargin(params)
+	if err := validateMinPoolMargin(params); err != nil {
+		return err
+	}
+	return validatePledgeLeverage(params)
+}
+
+// validatePledgeLeverage enforces the CIP-50 constraint that, when the
+// pledge-leverage feature is enabled, L is supplied and lies in [1, 10000]. It
+// is a no-op when the feature is disabled. Both Calculate (via
+// validateParameters) and CalculatePoolReward (via validatePoolRewardParameters)
+// run it, since a nil L reaching optimalPoolRewardChecked while enabled would
+// otherwise be silently ignored.
+func validatePledgeLeverage(params Parameters) error {
+	if !params.PledgeLeverageEnabled {
+		return nil
+	}
+	if params.PledgeLeverage == nil {
+		return fmt.Errorf(
+			"%w: pledge leverage enabled without a value",
+			ErrInvalidParameters,
+		)
+	}
+	if params.PledgeLeverage.Cmp(oneRat()) < 0 ||
+		params.PledgeLeverage.Cmp(big.NewRat(10_000, 1)) > 0 {
+		return fmt.Errorf(
+			"%w: pledge leverage %s outside [1, 10000]",
+			ErrInvalidParameters,
+			params.PledgeLeverage.RatString(),
+		)
+	}
+	return nil
 }
 
 // validatePoolRewardParameters checks the subset of parameters that
@@ -665,6 +712,9 @@ func validatePoolRewardParameters(params Parameters) error {
 		true,
 		false,
 	); err != nil {
+		return err
+	}
+	if err := validatePledgeLeverage(params); err != nil {
 		return err
 	}
 	if err := validateRatParameter(
@@ -928,6 +978,7 @@ func calculatePoolRewards(
 		pool.DelegatedStake,
 		pool.Pledge,
 		totalCirculation,
+		params.pledgeLeverageCap(),
 	)
 	if err != nil {
 		return PoolReward{}, err
@@ -1085,6 +1136,7 @@ func optimalPoolRewardChecked(
 	poolStake uint64,
 	pledge uint64,
 	totalStake uint64,
+	pledgeLeverage *big.Rat,
 ) (uint64, error) {
 	if totalStake == 0 || optimalPoolCount == 0 {
 		return 0, nil
@@ -1102,6 +1154,16 @@ func optimalPoolRewardChecked(
 		new(big.Int).SetUint64(totalStake),
 	)
 	s := minRat(sigma, z0)
+	// CIP-50: when pledgeLeverage (L) is set, a pool's reward-eligible stake is
+	// additionally capped at L*p (the pledge fraction times L), so sigma' =
+	// min(sigma, z0, L*p). A zero-pledge pool then has sigma' = 0 and earns no
+	// rewards. Because L >= 1 and poolStake always includes pledge, the capped
+	// sigma' still satisfies sigma' >= p', so the pledge-influence term below
+	// stays non-negative.
+	if pledgeLeverage != nil {
+		leverageCap := new(big.Rat).Mul(pledgeLeverage, pledgeRatio)
+		s = minRat(s, leverageCap)
+	}
 	p := minRat(pledgeRatio, z0)
 
 	left := new(big.Rat).Quo(

--- a/ledger/rewards/rewards_test.go
+++ b/ledger/rewards/rewards_test.go
@@ -2041,3 +2041,137 @@ func TestCalculateMinPoolMarginRange(t *testing.T) {
 	_, err = minMarginCalc(big.NewRat(1, 50), big.NewRat(1, 1))
 	require.NoError(t, err)
 }
+
+// --- CIP-50 pledge leverage ---
+
+// leveragePoolResult runs Calculate for a single pool sized to exercise the
+// CIP-50 pledge-leverage cap. It reuses the shared testParams() economics
+// (rho=1/100, a0=1/2, k=10) with Reserves=100_000_000 and
+// MaxLovelaceSupply=100_010_000, giving totalCirculation=10_000 and
+// AvailableRewards=1_000_000. BlocksProduced==TotalBlocks and
+// DelegatedStake==TotalActiveStake make apparentPerformance==1, so
+// PoolReward==OptimalReward. enabled toggles the leverage cap; l is L and is
+// ignored when disabled.
+func leveragePoolResult(
+	t *testing.T,
+	pledge, ownerStake uint64,
+	enabled bool,
+	l *big.Rat,
+) *Result {
+	t.Helper()
+	result, err := leverageCalc(pledge, ownerStake, enabled, l)
+	require.NoError(t, err)
+	return result
+}
+
+func leverageCalc(
+	pledge, ownerStake uint64,
+	enabled bool,
+	l *big.Rat,
+) (*Result, error) {
+	owner := testCredential(0, 2)
+	member := testCredential(0, 3)
+
+	params := testParams()
+	params.PledgeLeverageEnabled = enabled
+	params.PledgeLeverage = l
+
+	return Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      testPoolID(1),
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  big.NewRat(1, 10),
+					Pledge:                  pledge,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              ownerStake,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{owner: {}},
+					Delegators: []Delegator{
+						{
+							Credential: owner,
+							Stake:      ownerStake,
+							Registered: true,
+							Eligible:   true,
+						},
+						{
+							Credential: member,
+							Stake:      1_000 - ownerStake,
+							Registered: true,
+							Eligible:   true,
+						},
+					},
+				},
+			},
+		},
+		params,
+	)
+}
+
+// With pledge fraction p = 100/10_000 = 1/100 and L=5, the leverage cap
+// L*p = 1/20 is below min(sigma, z0) = 1/10, so eligible stake sigma' is
+// capped at 1/20 (halved), reducing the optimal reward from 70_000 to 34_833.
+func TestCalculatePledgeLeverageCapsEligibleStake(t *testing.T) {
+	result := leveragePoolResult(t, 100, 100, true, big.NewRat(5, 1))
+	require.Equal(t, uint64(34_833), result.PoolRewards[0].OptimalReward)
+	require.Equal(t, uint64(34_833), result.PoolRewards[0].PoolReward)
+}
+
+// Disabled is the regression guard: the eligible stake and reward match the
+// current (pre-CIP-50) formula exactly.
+func TestCalculatePledgeLeverageDisabledMatchesBaseline(t *testing.T) {
+	result := leveragePoolResult(t, 100, 100, false, nil)
+	require.Equal(t, uint64(70_000), result.PoolRewards[0].OptimalReward)
+	require.Equal(t, uint64(70_000), result.PoolRewards[0].PoolReward)
+}
+
+// A well-pledged pool (here L=100 => L*p = 1, far above z0=1/10) is unaffected
+// by the cap and earns the same reward as with the feature disabled.
+func TestCalculatePledgeLeverageWellPledgedUnaffected(t *testing.T) {
+	result := leveragePoolResult(t, 100, 100, true, big.NewRat(100, 1))
+	require.Equal(t, uint64(70_000), result.PoolRewards[0].OptimalReward)
+	require.Equal(t, uint64(70_000), result.PoolRewards[0].PoolReward)
+}
+
+// A zero-pledge pool earns zero rewards under CIP-50 (L*p = 0 => sigma' = 0),
+// a break from the current formula where it would earn 66_666.
+func TestCalculatePledgeLeverageZeroPledgeZerosPoolReward(t *testing.T) {
+	result := leveragePoolResult(t, 0, 0, true, big.NewRat(5, 1))
+	require.Equal(t, uint64(0), result.PoolRewards[0].OptimalReward)
+	require.Equal(t, uint64(0), result.PoolRewards[0].PoolReward)
+	require.Empty(t, result.AccountRewards)
+}
+
+// L below the minimum of 1 is rejected when the feature is enabled.
+func TestCalculateRejectsPledgeLeverageBelowMinimum(t *testing.T) {
+	_, err := leverageCalc(100, 100, true, big.NewRat(1, 2))
+	require.ErrorIs(t, err, ErrInvalidParameters)
+}
+
+// L above the maximum of 10000 is rejected when the feature is enabled.
+func TestCalculateRejectsPledgeLeverageAboveMaximum(t *testing.T) {
+	_, err := leverageCalc(100, 100, true, big.NewRat(10_001, 1))
+	require.ErrorIs(t, err, ErrInvalidParameters)
+}
+
+// Enabling the feature without supplying L is rejected rather than silently
+// treated as disabled.
+func TestCalculateRejectsPledgeLeverageEnabledWithoutValue(t *testing.T) {
+	_, err := leverageCalc(100, 100, true, nil)
+	require.ErrorIs(t, err, ErrInvalidParameters)
+}
+
+// The inclusive bounds L=1 and L=10000 are accepted.
+func TestCalculateAllowsPledgeLeverageAtBounds(t *testing.T) {
+	_, err := leverageCalc(100, 100, true, big.NewRat(1, 1))
+	require.NoError(t, err)
+	_, err = leverageCalc(100, 100, true, big.NewRat(10_000, 1))
+	require.NoError(t, err)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -452,7 +452,17 @@ type LedgerStateConfig struct {
 	// affecting operator setting (not derived from the network) that takes
 	// effect only in Dijkstra and later. Enable a nonzero value only on a
 	// network where every node also enables the same value.
-	MinPoolMargin            uint
+	MinPoolMargin uint
+	// PledgeLeverageEnabled turns on the CIP-50 pledge-leverage reward cap. It
+	// is a consensus-affecting feature gate that defaults false; enable it only
+	// on a network where every node also enables it (mainnet and the public
+	// testnets keep it off). Unlike the Musashi-derived toggles above it is set
+	// from operator config in node.go, not derived from the network.
+	PledgeLeverageEnabled bool
+	// PledgeLeverage is L, the CIP-50 maximum ratio of total stake to pledge,
+	// in the range [1, 10000]. It is used only when PledgeLeverageEnabled is
+	// true.
+	PledgeLeverage           uint
 	ValidateHistorical       bool
 	EnableDijkstra           bool
 	StartInDijkstra          bool

--- a/node.go
+++ b/node.go
@@ -362,7 +362,12 @@ func (n *Node) Run(ctx context.Context) error {
 			SkipDijkstraTxValidation: n.config.isMusashiNetwork(),
 			// CIP-23 minimum pool margin (minimum variable fee). Operator-set,
 			// off by default (0), effective only in Dijkstra and later.
-			MinPoolMargin:              n.config.minPoolMargin,
+			MinPoolMargin: n.config.minPoolMargin,
+			// CIP-50 pledge-leverage reward cap. Operator-set (not derived from
+			// the network) and off by default; enable only where every node
+			// also enables it.
+			PledgeLeverageEnabled:      n.config.pledgeLeverageEnabled,
+			PledgeLeverage:             n.config.pledgeLeverage,
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
 			PeersWithBlockFunc: func(
 				origin ouroboros.ConnectionId,


### PR DESCRIPTION
Initial implementation of CIP-50

cc: @cerkoryn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional CIP-50 pledge‑leverage cap to staking rewards. Disabled by default; when enabled, a pool’s reward‑eligible stake is capped at L×pledge (min with sigma and z0), so zero‑pledge pools earn no rewards and ADA pots change.

- New Features
  - Reward calc: in `ledger/rewards`, eligible stake is min(sigma, z0, L×pledge). Validation requires L in [1, 10000] when enabled; enforced in both `Calculate` and `CalculatePoolReward`. Disabled path stays byte‑for‑byte unchanged.
  - Parameters & wiring: `rewards.Parameters` adds `PledgeLeverageEnabled` and rational `PledgeLeverage`. `applyPledgeLeverageConfig` sets these at `LedgerState.rewardParameters` so boundary‑apply and precompute agree.
  - Config: `internal/config` adds `pledgeLeverageEnabled` / `pledgeLeverage` (default L=100). CLI `--pledge-leverage-enabled`, `--pledge-leverage`; env `DINGO_PLEDGE_LEVERAGE_ENABLED`, `DINGO_PLEDGE_LEVERAGE`. Node threads via `dingo.WithPledgeLeverage` into `LedgerStateConfig`. Config and node validation enforce the L range.
  - Docs & tests: `ARCHITECTURE.md` updated. Tests cover env/flag binding, config validation, threading, reward behavior (caps, bounds, zero‑pledge), and disabled‑mode parity.

- Migration
  - Enable only on a devnet or custom network where all nodes also enable it; do not enable on mainnet or public testnets.
  - Set `pledgeLeverageEnabled: true` and choose `pledgeLeverage` in [1, 10000] via config, `--pledge-leverage-enabled` / `--pledge-leverage`, or `DINGO_PLEDGE_LEVERAGE_ENABLED` / `DINGO_PLEDGE_LEVERAGE`.
  - Restart nodes and verify consistent settings across the network to avoid forks.

<sup>Written for commit 4e2c426abb49245c7dfbd39b521a1bba0063649b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional CIP-50 pledge-leverage controls for staking rewards.
  - Eligible stake and rewards can now be capped according to the configured leverage value.
  - Added CLI, environment, and configuration-file options for enabling the feature and setting its cap.
  - The feature is disabled by default; enabling it requires consistent network-wide configuration.

- **Bug Fixes**
  - Added validation for leverage values and zero-pledge pool behavior.

- **Documentation**
  - Documented configuration, reward behavior, compatibility, and network considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->