### PR TITLE
ci(antithesis): pin moog and wait for results

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -29,7 +29,10 @@ on:
 
 concurrency:
   group: antithesis
-  cancel-in-progress: true
+  # Once submitted, an Antithesis test continues running outside GitHub.
+  # Keep its polling workflow alive so the result is not lost and the next
+  # test waits for the active run to finish.
+  cancel-in-progress: false
 
 env:
   APPLICATION_NAME: 'dingo'
@@ -233,6 +236,20 @@ jobs:
       MOOG_TOKEN_ID: ${{ vars.MOOG_TOKEN_ID || '21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b' }} # not a secret
       DURATION: ${{ inputs.duration || '3' }}
     steps:
+      - name: Validate duration
+        id: duration
+        run: |
+          if [[ ! "$DURATION" =~ ^[0-9]+$ ]]; then
+            echo "::error::Duration must be a positive integer number of hours"
+            exit 1
+          fi
+          HOURS=$((10#$DURATION))
+          if ((HOURS < 1)); then
+            echo "::error::Duration must be at least one hour"
+            exit 1
+          fi
+          echo "hours=$HOURS" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
 
@@ -284,14 +301,14 @@ jobs:
           TRY=$(moog facts test-runs --whose "$MOOG_REQUESTER" \
             | jq --arg sha "$GITHUB_SHA" 'map(select(.key.commitId == $sha)) | length')
           TRY=$((TRY + 1))
-          echo "Submitting Antithesis test for commit ${GITHUB_SHA} (try $TRY, duration ${DURATION}h)..."
+          echo "Submitting Antithesis test for commit ${GITHUB_SHA} (try $TRY, duration ${DURATION_HOURS}h)..."
           # shellcheck disable=SC2086 # NO_FAULTS_FLAG intentionally word-splits
           RESULT=$(moog requester create-test \
             -d "internal/test/antithesis/testnets/dingo-praos" \
             -c "${GITHUB_SHA}" \
             -r "${GITHUB_REPOSITORY}" \
             --try "$TRY" \
-            -t "$DURATION" \
+            -t "$DURATION_HOURS" \
             $NO_FAULTS_FLAG)
           echo "$RESULT"
           # moog can print an error envelope (e.g. {"exception": ...}) and still
@@ -303,12 +320,15 @@ jobs:
         env:
           MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
           NO_FAULTS: ${{ inputs.no_faults || 'false' }}
+          DURATION_HOURS: ${{ steps.duration.outputs.hours }}
 
       - name: Wait for results
         run: |
-          timeout $(((DURATION + 1) * 3600)) \
+          timeout $(((DURATION_HOURS + 1) * 3600)) \
             ./internal/test/antithesis/scripts/wait-for-test.sh \
             "${{ steps.request.outputs.id }}"
+        env:
+          DURATION_HOURS: ${{ steps.duration.outputs.hours }}
 
       - name: Clean up wallet
         if: always()

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -16,9 +16,16 @@ on:
         type: boolean
         default: false
       moog_tag:
+        # The deployed MPFS at mpfs.plutimus.com runs the moog v0.5.x line, so
+        # the requester CLI must match it (same pin as the cardano-foundation
+        # cardano-node-antithesis testnet). moog v2.x (the moog-v2 MPFS cutover)
+        # is incompatible: v2.0.1 preflights GET /status, which the deployed
+        # MPFS answers with 404, then prints an error envelope and exits 0 so
+        # the submission silently never launches. Bump this only once a v2 MPFS
+        # (one that serves /status) is deployed and MOOG_MPFS_HOST points at it.
         description: 'Moog CLI release tag'
         type: string
-        default: 'v2.0.1'
+        default: 'v0.5.1.5'
 
 concurrency:
   group: antithesis
@@ -216,6 +223,15 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 600
+    # Shared Moog env for the submit + wait steps (the wait step polls
+    # MOOG_MPFS_HOST read-only, so it needs the same host/token/requester).
+    env:
+      MOOG_WALLET_FILE: wallet.json
+      MOOG_MPFS_HOST: ${{ vars.MOOG_MPFS_HOST || 'https://mpfs.plutimus.com' }}
+      MOOG_PLATFORM: github
+      MOOG_REQUESTER: ${{ vars.MOOG_REQUESTER }}
+      MOOG_TOKEN_ID: ${{ vars.MOOG_TOKEN_ID || '21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b' }} # not a secret
+      DURATION: ${{ inputs.duration || '3' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
@@ -223,7 +239,7 @@ jobs:
       - name: Resolve Moog release
         id: moog-release
         run: |
-          TAG="${MOOG_TAG_INPUT:-v2.0.1}"
+          TAG="${MOOG_TAG_INPUT:-v0.5.1.5}"
           VERSION="${TAG#v}"
           TAG="v${VERSION}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -256,28 +272,43 @@ jobs:
           MOOG_WALLET: ${{ secrets.MOOG_REQUESTER_WALLET }}
 
       - name: Submit test to Antithesis
+        id: request
         run: |
+          set -euo pipefail
           NO_FAULTS_FLAG=""
           if [ "$NO_FAULTS" = "true" ]; then
             NO_FAULTS_FLAG="--no-faults"
           fi
-          echo "Submitting Antithesis test for commit ${GITHUB_SHA}..."
-          moog requester create-test \
+          # Try index must be unique per commit, so count existing runs for this
+          # commit and increment (matches io-ouroboros-leios antithesis-leios).
+          TRY=$(moog facts test-runs --whose "$MOOG_REQUESTER" \
+            | jq --arg sha "$GITHUB_SHA" 'map(select(.key.commitId == $sha)) | length')
+          TRY=$((TRY + 1))
+          echo "Submitting Antithesis test for commit ${GITHUB_SHA} (try $TRY, duration ${DURATION}h)..."
+          # shellcheck disable=SC2086 # NO_FAULTS_FLAG intentionally word-splits
+          RESULT=$(moog requester create-test \
             -d "internal/test/antithesis/testnets/dingo-praos" \
             -c "${GITHUB_SHA}" \
             -r "${GITHUB_REPOSITORY}" \
+            --try "$TRY" \
             -t "$DURATION" \
-            -y 1 \
-            $NO_FAULTS_FLAG
+            $NO_FAULTS_FLAG)
+          echo "$RESULT"
+          # moog can print an error envelope (e.g. {"exception": ...}) and still
+          # exit 0; a submission only truly launched if it returned a testRunId.
+          # jq -e fails the step (set -e) so a bad submit can't report false green.
+          ID=$(echo "$RESULT" | jq -e .value.testRunId | jq -r .)
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "Launched Antithesis test run: $ID"
         env:
           MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
-          MOOG_WALLET_FILE: wallet.json
-          MOOG_MPFS_HOST: ${{ vars.MOOG_MPFS_HOST || 'https://mpfs.plutimus.com' }}
-          MOOG_PLATFORM: github
-          MOOG_REQUESTER: ${{ vars.MOOG_REQUESTER }}
-          MOOG_TOKEN_ID: ${{ vars.MOOG_TOKEN_ID || '21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b' }} # not a secret
-          DURATION: ${{ inputs.duration || '3' }}
           NO_FAULTS: ${{ inputs.no_faults || 'false' }}
+
+      - name: Wait for results
+        run: |
+          timeout $(((DURATION + 1) * 3600)) \
+            ./internal/test/antithesis/scripts/wait-for-test.sh \
+            "${{ steps.request.outputs.id }}"
 
       - name: Clean up wallet
         if: always()

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       duration:
-        description: 'Test duration in hours'
+        description: 'Test duration in hours (1-8)'
         type: string
         default: '1'
       no_faults:
@@ -29,6 +29,7 @@ on:
 
 concurrency:
   group: antithesis
+  queue: max
   # Once submitted, an Antithesis test continues running outside GitHub.
   # Keep its polling workflow alive so the result is not lost and the next
   # test waits for the active run to finish.
@@ -246,6 +247,13 @@ jobs:
           HOURS=$((10#$DURATION))
           if ((HOURS < 1)); then
             echo "::error::Duration must be at least one hour"
+            exit 1
+          fi
+          # The wait step allows one extra hour for Antithesis to publish the
+          # result. Leave another hour for this job's setup and cleanup within
+          # its 600-minute timeout.
+          if ((HOURS > 8)); then
+            echo "::error::Duration must be no more than 8 hours"
             exit 1
           fi
           echo "hours=$HOURS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -260,6 +260,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Resolve Moog release
         id: moog-release
@@ -334,9 +336,10 @@ jobs:
         run: |
           timeout $(((DURATION_HOURS + 1) * 3600)) \
             ./internal/test/antithesis/scripts/wait-for-test.sh \
-            "${{ steps.request.outputs.id }}"
+            "$ANTITHESIS_TEST_RUN_ID"
         env:
           DURATION_HOURS: ${{ steps.duration.outputs.hours }}
+          ANTITHESIS_TEST_RUN_ID: ${{ steps.request.outputs.id }}
 
       - name: Clean up wallet
         if: always()

--- a/internal/test/antithesis/scripts/wait-for-test.sh
+++ b/internal/test/antithesis/scripts/wait-for-test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+# Poll Moog for Antithesis test results.
+# Usage: wait-for-test.sh <testRunId>
+# Exits 0 on success, 1 on rejection/failure/unknown.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "error: expected exactly 1 argument: <testRunId>" >&2
+  echo "usage: wait-for-test.sh <testRunId>" >&2
+  exit 1
+fi
+ID="$1"
+
+# Wallet auth isn't needed for read-only queries
+unset MOOG_WALLET_FILE
+
+function query_run() { moog facts test-runs --test-run-id "$ID"; }
+
+# Phase 1: wait for acceptance (fast poll)
+echo "Waiting to be accepted..."
+CONSECUTIVE_ERRORS=0
+MAX_CONSECUTIVE_ERRORS=10
+while true; do
+  if ! RESULT=$(query_run 2>&1); then
+    CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
+    echo "query failed (attempt $CONSECUTIVE_ERRORS/$MAX_CONSECUTIVE_ERRORS): $RESULT"
+    if [ "$CONSECUTIVE_ERRORS" -ge "$MAX_CONSECUTIVE_ERRORS" ]; then
+      echo "error: too many consecutive query failures in acceptance phase" >&2
+      exit 1
+    fi
+    sleep 10
+    echo "retrying..."
+    continue
+  fi
+  echo "current status: $RESULT"
+  STATUS=$(echo "$RESULT" | jq -r '.[0].value.phase') || {
+    CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
+    echo "failed to parse status (attempt $CONSECUTIVE_ERRORS/$MAX_CONSECUTIVE_ERRORS), retrying..."
+    if [ "$CONSECUTIVE_ERRORS" -ge "$MAX_CONSECUTIVE_ERRORS" ]; then
+      echo "error: too many consecutive parse failures in acceptance phase" >&2
+      exit 1
+    fi
+    sleep 10
+    continue
+  }
+  CONSECUTIVE_ERRORS=0
+  case $STATUS in
+    accepted)
+      echo "accepted"
+      break
+      ;;
+    rejected)
+      echo "rejected"
+      exit 1
+      ;;
+    finished)
+      echo "already finished"
+      break
+      ;;
+    pending)
+      ;;
+    *)
+      echo "unknown status: $STATUS"
+      ;;
+  esac
+  sleep 10
+  echo "..."
+done
+
+# Phase 2: wait for completion (slow poll)
+echo "Waiting to finish..."
+CONSECUTIVE_ERRORS=0
+MAX_CONSECUTIVE_ERRORS=5
+while true; do
+  if ! RESULT=$(query_run 2>&1); then
+    CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
+    echo "query failed (attempt $CONSECUTIVE_ERRORS/$MAX_CONSECUTIVE_ERRORS): $RESULT"
+    if [ "$CONSECUTIVE_ERRORS" -ge "$MAX_CONSECUTIVE_ERRORS" ]; then
+      echo "error: too many consecutive query failures in completion phase" >&2
+      exit 1
+    fi
+    sleep 300
+    echo "retrying..."
+    continue
+  fi
+  echo "current status: $RESULT"
+  STATUS=$(echo "$RESULT" | jq -r '.[0].value.phase') || {
+    CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
+    echo "failed to parse status (attempt $CONSECUTIVE_ERRORS/$MAX_CONSECUTIVE_ERRORS), retrying..."
+    if [ "$CONSECUTIVE_ERRORS" -ge "$MAX_CONSECUTIVE_ERRORS" ]; then
+      echo "error: too many consecutive parse failures in completion phase" >&2
+      exit 1
+    fi
+    sleep 300
+    continue
+  }
+  CONSECUTIVE_ERRORS=0
+  case $STATUS in
+    finished)
+      echo "finished"
+      break
+      ;;
+    accepted)
+      ;;
+    *)
+      echo "unknown status: $STATUS"
+      ;;
+  esac
+  sleep 300
+  echo "..."
+done
+
+# Final outcome check (retry on transient errors)
+FINAL_RESULT_OK=false
+OUTCOME=""
+for i in 1 2 3; do
+  if ! RESULT=$(query_run 2>&1); then
+    echo "final query failed (attempt $i/3): $RESULT"
+    sleep 10
+    continue
+  fi
+  echo "final result: $RESULT"
+  OUTCOME=$(echo "$RESULT" | jq -r '.[0].value.outcome') || {
+    echo "failed to parse final outcome (attempt $i/3), retrying..."
+    sleep 10
+    continue
+  }
+  FINAL_RESULT_OK=true
+  break
+done
+
+if [ "$FINAL_RESULT_OK" != true ]; then
+  echo "error: failed to fetch a valid final outcome after 3 attempts" >&2
+  exit 1
+fi
+
+case $OUTCOME in
+  success)
+    exit 0
+    ;;
+  failure)
+    echo "failed"
+    exit 1
+    ;;
+  *)
+    echo "unknown outcome"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the `moog` CLI to `v0.5.1.5` to match the deployed MPFS and make the Antithesis workflow wait for results, failing CI on rejected, failed, or unknown runs. Also validates duration (1–8h), computes a per-commit try index, and queues runs instead of canceling them.

- **Dependencies**
  - Pin `moog` to `v0.5.1.5` (v0.5.x) to match `https://mpfs.plutimus.com`; `v2.x` is incompatible until MPFS v2 is live.

- **New Features**
  - Add `internal/test/antithesis/scripts/wait-for-test.sh` to poll until accepted and finished; exits non-zero on rejection/failure/unknown with retry logic for transient errors.
  - Require a `testRunId` on submit (fail on error envelopes), compute per-commit `--try` index, validate duration input (1–8h), and bound waiting to duration + 1h.
  - Use Actions concurrency to keep active runs and queue new ones (`cancel-in-progress: false`, `queue: max`).

<sup>Written for commit d987787c4ae697ec47665c11517668e42a558064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Antithesis test runs now automatically track attempts for each commit.
  - Added automated monitoring through test acceptance, completion, and final outcome.
  - Test duration inputs are validated between 1 and 8 hours.

- **Bug Fixes**
  - Test workflows now preserve queued and in-progress runs instead of cancelling them.
  - Runs fail clearly when results are missing, invalid, or unsuccessful.
  - Improved retry handling for temporary status-query and parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->