### PR TITLE
fix(ledger): delay initial reward application

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1037,6 +1037,13 @@ Key models in `database/models/`:
 
 The `LedgerState` (`ledger/state.go`) manages UTXO tracking and validation:
 
+The first reward update is applied at the boundary into epoch 2 using epoch
+0's block performance with the epoch-1 ADA pots. Cardano-ledger's Go stake
+distribution is still empty at that point, so monetary expansion and treasury
+tax are applied but no pool or account rewards are distributed; the post-tax
+amount returns to reserves. Later updates use the normal delayed E-3 snapshot,
+E-2 performance, and E-1 pots mapping.
+
 During from-genesis startup, the synthetic genesis block transaction creates
 the combined Byron and Shelley genesis UTxOs and atomically writes the slot-0
 `NetworkState`: treasury starts at zero and reserves start at
@@ -2452,7 +2459,10 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    reserves, and route unspendable rewards to the treasury before governance
    reads it. It is a no-op until the required reward inputs exist (the mark
    snapshot and the prior epoch's ADA-pot row); see "Reward Calculation And
-   Precomputation".
+   Precomputation". Epoch 2 is the bootstrap exception: it applies expansion
+   and treasury tax synchronously with an empty Go distribution and returns the
+   post-tax amount to reserves. It is not precomputed because zero output rows
+   cannot provide rollback-safe precompute provenance.
 2. Shelley-style protocol-parameter updates (`ComputeAndApplyPParamUpdates`).
 3. Embedded POOLREAP (`applyPoolRetirements`): refund the deposits of pools
    whose retirement epoch is the new epoch. Each deposit is credited to the

--- a/ledger/reward_bootstrap_test.go
+++ b/ledger/reward_bootstrap_test.go
@@ -15,15 +15,91 @@
 package ledger
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/rewards"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStakeRewardEpochsForInitialApplication(t *testing.T) {
+	for _, epoch := range []uint64{0, 1} {
+		_, ok := stakeRewardEpochsForApplication(epoch)
+		require.False(t, ok, "epoch %d must not apply stake rewards", epoch)
+	}
+
 	epochs, ok := stakeRewardEpochsForApplication(2)
 	require.True(t, ok)
-	require.Equal(t, uint64(0), epochs.snapshot)
-	require.Equal(t, uint64(0), epochs.performance)
-	require.Equal(t, uint64(1), epochs.pots)
+	require.Equal(t, stakeRewardEpochs{
+		snapshot:    0,
+		performance: 0,
+		pots:        1,
+		bootstrap:   true,
+	}, epochs)
+
+	epochs, ok = stakeRewardEpochsForApplication(3)
+	require.True(t, ok)
+	require.Equal(t, stakeRewardEpochs{
+		snapshot:    0,
+		performance: 1,
+		pots:        2,
+	}, epochs)
+}
+
+func TestSuppressBootstrapStakeRewardsReturnsAvailableRewardsToReserves(t *testing.T) {
+	result := &rewards.Result{
+		PoolRewards:      []rewards.PoolReward{{PoolReward: 600}},
+		AccountRewards:   []rewards.AccountReward{{Amount: 600}},
+		TotalRewardPot:   1_000,
+		AvailableRewards: 800,
+		EffectiveRewards: 600,
+		Unspendable:      50,
+		Undistributed:    150,
+	}
+	suppressBootstrapStakeRewards(result)
+
+	require.Empty(t, result.PoolRewards)
+	require.Empty(t, result.AccountRewards)
+	require.Zero(t, result.EffectiveRewards)
+	require.Zero(t, result.Unspendable)
+	require.Equal(t, uint64(800), result.Undistributed)
+
+	app := &stakeRewardApplication{
+		params: rewards.Parameters{
+			TreasuryExpansion: big.NewRat(1, 5),
+		},
+		pots: &models.RewardAdaPots{
+			Reserves: types.Uint64(10_000),
+			Treasury: types.Uint64(10),
+		},
+		totalRewardPot:   result.TotalRewardPot,
+		availableRewards: result.AvailableRewards,
+		undistributed:    result.Undistributed,
+	}
+	reserves, treasury, err := stakeRewardUpdatedPots(app)
+	require.NoError(t, err)
+	require.Equal(t, uint64(9_800), reserves)
+	require.Equal(t, uint64(210), treasury)
+}
+
+func TestBootstrapStakeRewardsRejectStalePrecompute(t *testing.T) {
+	ls, db := newRewardCalculationTestLedger(t)
+	require.NoError(t, db.Metadata().SaveRewardAdaPots(&models.RewardAdaPots{
+		Epoch:   1,
+		Rewards: types.Uint64(1_000),
+	}, nil))
+
+	txn := db.Transaction(false)
+	defer func() { _ = txn.Rollback() }()
+	app, ok, err := ls.precomputedStakeRewardApplication(txn, 2, 200)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, app)
+
+	app, ok, err = ls.precomputeStakeRewardsCalculate(txn, 2, 100, 200)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, app)
 }

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -260,6 +260,9 @@ func (ls *LedgerState) calculateStakeRewardApplication(
 			rewardSnapshotEpoch, err,
 		)
 	}
+	if epochs.bootstrap {
+		suppressBootstrapStakeRewards(result)
+	}
 
 	poolOutputs := rewardPoolOutputs(
 		rewardSnapshotEpoch,
@@ -395,6 +398,12 @@ func (ls *LedgerState) precomputedStakeRewardApplication(
 		)
 	}
 	if pots == nil || pots.Rewards == 0 {
+		return nil, false, nil
+	}
+	// The bootstrap calculation has no durable output rows with which to
+	// validate the precompute against rollbacks. Always recalculate it at the
+	// epoch-2 boundary rather than treating pots.Rewards alone as provenance.
+	if epochs.bootstrap {
 		return nil, false, nil
 	}
 
@@ -1701,6 +1710,13 @@ func (ls *LedgerState) precomputeStakeRewardsCalculate(
 	capturedSlot uint64,
 	boundarySlot uint64,
 ) (*stakeRewardApplication, bool, error) {
+	if epochs, ok := stakeRewardEpochsForApplication(newEpoch); ok &&
+		epochs.bootstrap {
+		// Epoch 2 is deliberately synchronous: its empty Go distribution leaves
+		// no output rows that can safely prove an async precompute survived a
+		// rollback on the same epoch-1 pots row.
+		return nil, false, nil
+	}
 	if _, ok, err := ls.precomputedStakeRewardApplication(
 		txn,
 		newEpoch,
@@ -1783,6 +1799,9 @@ func (ls *LedgerState) precomputeStakeRewards(
 	)
 	if err != nil || !ok {
 		return err
+	}
+	if app == nil {
+		return errors.New("missing stake reward application")
 	}
 	meta := ls.db.Metadata()
 	metaTxn := txn.Metadata()
@@ -1937,20 +1956,20 @@ type stakeRewardEpochs struct {
 	snapshot    uint64
 	performance uint64
 	pots        uint64
+	bootstrap   bool
 }
 
 func stakeRewardEpochsForApplication(newEpoch uint64) (stakeRewardEpochs, bool) {
-	// The first reward update is the bootstrap exception to the normal
-	// delayed-reward mapping. At the boundary into epoch 2, epoch 0's Mark
-	// snapshot and block performance are both available, while the epoch 1
-	// ADA pots contain the reserves, treasury, and epoch 0 fees that seed the
-	// calculation. Without this application, every later pot remains one
-	// reward update behind cardano-ledger.
+	// The first RUPD calculation is made during epoch 1 from epoch 0's block
+	// performance and the epoch 1 ADA pots. The Go stake distribution is
+	// still empty, so the epoch 2 NEWEPOCH rule applies monetary expansion
+	// and treasury tax but distributes no pool or account rewards.
 	if newEpoch == 2 {
 		return stakeRewardEpochs{
 			snapshot:    0,
 			performance: 0,
 			pots:        1,
+			bootstrap:   true,
 		}, true
 	}
 	return stakeRewardEpochsForNewEpoch(newEpoch)
@@ -1972,6 +1991,17 @@ func stakeRewardEpochsForNewEpoch(newEpoch uint64) (stakeRewardEpochs, bool) {
 		performance: newEpoch - 2,
 		pots:        newEpoch - 1,
 	}, true
+}
+
+func suppressBootstrapStakeRewards(result *rewards.Result) {
+	if result == nil {
+		return
+	}
+	result.PoolRewards = nil
+	result.AccountRewards = nil
+	result.EffectiveRewards = 0
+	result.Unspendable = 0
+	result.Undistributed = result.AvailableRewards
 }
 
 func (ls *LedgerState) saveRewardAdaPotsForEpoch(


### PR DESCRIPTION
Refs: #1959 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delays the first stake reward application to the epoch 2 boundary and treats it as a bootstrap: only apply monetary expansion and treasury tax; do not distribute pool or account rewards, and return post-tax to reserves. Addresses #1959 and aligns timing with `cardano-ledger`.

- **Bug Fixes**
  - Mark epoch 2 as bootstrap (E0 snapshot/perf, E1 pots); suppress pool/account rewards and keep undistributed = available.
  - Apply only expansion + treasury tax; update reserves/treasury accordingly.
  - Disable precompute for the bootstrap update and reject stale precompute; error on missing application when expected.
  - Update docs to explain epoch 2 bootstrap behavior and sequencing; add tests for epoch mapping, suppression, and precompute.

<sup>Written for commit 5d4f829aac1968a55a821b9470f1c15fbb99c2b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

