### PR TITLE
feat(ledger): min pool margin (CIP-23)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2539,6 +2539,23 @@ Rewards omitted by the filter return to reserves. Calculated rewards that fail
 the application-time account-registration check are unspendable and go to
 treasury. Spendable rewards are credited through `account_reward_delta`.
 
+CIP-23 minimum pool margin is an optional, consensus-affecting operator setting
+that defaults off (0) and takes effect only in Dijkstra and later. When
+`LedgerStateConfig.MinPoolMargin` (basis points) is nonzero, `rewardParameters`
+sets `rewards.Parameters.MinPoolMargin` via `applyMinPoolMarginConfig` only for
+protocol major version >= 12, and the reward split uses
+`params.effectiveMargin(pool.Margin) = max(pool.Margin, MinPoolMargin)` for both
+the operator (leader) and delegator (member) shares. In the same era,
+`ValidateTxDijkstra` rejects pool registration certificates whose margin is below
+the floor via `checkPoolMarginFloor`. Disabled or pre-Dijkstra, the field is nil,
+the split is byte-for-byte the pre-CIP-23 calculation, and no certificate is
+rejected. Because it changes reward amounts (and therefore ADA pots and reward
+accounts) and certificate acceptance, enable a nonzero value only on a network
+where every node also enables the same value; the precompute-reuse member
+validator is left unclamped, so when the feature is active and any pool in the
+epoch's snapshot is below the floor, reuse is conservatively bypassed for that
+whole epoch's snapshot and the fresh authoritative calculation is used.
+
 After an epoch-transition event, ledger can precompute the next delayed reward
 update into `reward_pool_output` and `reward_account_output`. Calculation runs
 in a read-only transaction; a separate short write transaction re-reads the

--- a/config.go
+++ b/config.go
@@ -193,6 +193,9 @@ type Config struct {
 	// (VRF/KES header crypto, body-hash, per-tx ledger rules) before the
 	// block is adopted onto the chain and diffused to peers.
 	validateForgedBlock bool
+	// CIP-23 minimum pool margin (minimum variable fee) in basis points,
+	// [0, 10000]; consensus-affecting, 0 = off; effective only in Dijkstra+.
+	minPoolMargin uint
 	// Leios voting configuration (experimental)
 	leiosVoteSigningKeyFile string
 	leiosVoterPublicKeys    map[string]string
@@ -432,6 +435,15 @@ func (n *Node) configValidate() error {
 			"invalid start era %q: must be empty or %q",
 			n.config.startEra,
 			internalconfig.StartEraDijkstra,
+		)
+	}
+	// CIP-23 minimum pool margin is expressed in basis points. Validate the
+	// exported WithMinPoolMargin option at the root node boundary so an invalid
+	// value cannot reach ledger reward or certificate validation.
+	if n.config.minPoolMargin > 10_000 {
+		return fmt.Errorf(
+			"min pool margin (%d) must be in [0, 10000] basis points",
+			n.config.minPoolMargin,
 		)
 	}
 	// In core mode, ignore API ports — they are only used in API mode.
@@ -880,6 +892,16 @@ func WithGenesisWindowSlots(slots uint64) ConfigOptionFunc {
 func WithBlockProducer(enabled bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.blockProducer = enabled
+	}
+}
+
+// WithMinPoolMargin configures the CIP-23 minimum pool margin (minimum variable
+// fee) in basis points, [0, 10000] (150 = 1.5%). It is consensus-affecting and
+// off by default (0), taking effect only in Dijkstra and later. Enable a nonzero
+// value only on a network where every node also enables the same value.
+func WithMinPoolMargin(basisPoints uint) ConfigOptionFunc {
+	return func(c *Config) {
+		c.minPoolMargin = basisPoints
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -64,6 +64,37 @@ func TestWithStorageMode(t *testing.T) {
 	assert.Equal(t, StorageModeCore, cfg.storageMode)
 }
 
+func TestNewValidatesMinPoolMargin(t *testing.T) {
+	tests := []struct {
+		name    string
+		margin  uint
+		wantErr bool
+	}{
+		{name: "disabled", margin: 0},
+		{name: "maximum", margin: 10_000},
+		{name: "above maximum", margin: 10_001, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig(
+				WithMinPoolMargin(tt.margin),
+				WithNetworkMagic(1),
+				WithListeners(ListenerConfig{
+					ListenNetwork: "tcp",
+					ListenAddress: "127.0.0.1:0",
+				}),
+				WithPrometheusRegistry(prometheus.NewRegistry()),
+			)
+			_, err := New(cfg)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "min pool margin")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestWithMidnightConfig(t *testing.T) {
 	cfg := &Config{}
 	midnightCfg := MidnightConfig{

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -546,3 +546,23 @@ mithril:
   # Verify the Mithril certificate chain from snapshot back to genesis
   # Default: true
   verifyCertificates: true
+
+# ---
+# CIP-23 minimum pool margin / minimum variable fee (experimental, consensus-affecting)
+#
+# Sets a floor on the pool margin (variable fee): a pool's effective margin in
+# the staking-reward split becomes max(pool.margin, minPoolMargin), and pool
+# registration certificates below the floor are rejected. Reward-account
+# registration and eligibility still apply: some or all of a pool allocation
+# can return to reserves when omitted by the reward prefilter, or go to treasury
+# when calculated for an account that cannot receive it. Expressed in basis
+# points (150 = 1.5%), range 0..10000. This changes the ledger reward calculation
+# and certificate validation, so it MUST only be enabled (nonzero) on a network
+# where every node also enables the same value (a devnet or custom network).
+# Enabling it off-consensus, e.g. on mainnet or the public testnets, will fork
+# this node. It takes effect only in the Dijkstra era and later. Disabled by
+# default.
+#
+# CLI: --min-pool-margin
+# Env: DINGO_MIN_POOL_MARGIN
+# minPoolMargin: 0        # basis points, 0..10000 (150 = 1.5%); 0 disables

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -559,6 +559,13 @@ type Config struct {
 	ForgeStaleGapThresholdSlots   uint64 `yaml:"forgeStaleGapThresholdSlots"   envconfig:"DINGO_FORGE_STALE_GAP_THRESHOLD_SLOTS"`
 	ValidateForgedBlock           bool   `yaml:"validateForgedBlock"           envconfig:"DINGO_VALIDATE_FORGED_BLOCK"`
 
+	// MinPoolMargin is the CIP-23 minimum pool margin (minimum variable fee) in
+	// basis points, [0, 10000] (150 = 1.5%); 0 disables it. Consensus-affecting
+	// and off by default; effective only in Dijkstra and later. Enable a nonzero
+	// value only where every node also enables the same value. See
+	// ARCHITECTURE.md ("Reward Calculation And Precomputation").
+	MinPoolMargin uint `yaml:"minPoolMargin" envconfig:"DINGO_MIN_POOL_MARGIN"`
+
 	// Leios voting configuration (experimental, leios runMode only).
 	// LeiosVoteSigningKeyFile is the path to a hex-encoded BLS12-381
 	// vote signing key. When set on a block producer whose pool is a

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -170,6 +170,9 @@ var flagSpecs = []flagSpec{
 	uint64Flag("ForgeStaleGapThresholdSlots", "forge-stale-gap-threshold-slots", "slot gap threshold for stale slot clock alerts"),
 	boolFlag("ValidateForgedBlock", "validate-forged-block", "validate forged blocks before adoption and diffusion (header crypto, body hash, per-tx ledger rules)"),
 
+	// CIP-23 minimum pool margin / minimum variable fee (consensus-affecting; default 0 = off)
+	uintFlag("MinPoolMargin", "min-pool-margin", "CIP-23 minimum pool margin in basis points [0,10000] (150 = 1.5%); 0 disables (enable only where every node also enables it)"),
+
 	// Leios voting (experimental)
 	stringFlag("LeiosVoteSigningKeyFile", "leios-vote-signing-key-file", "", "path to hex-encoded BLS12-381 Leios vote signing key"),
 	stringToStringFlag("LeiosVoterPublicKeys", "leios-voter-public-keys", "Leios voter public key registry: pool key hash hex=public key hex"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -675,3 +675,22 @@ func collectExportedLeafFields(
 		out[path] = struct{}{}
 	}
 }
+
+func TestMinPoolMarginEnvBinding(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_MIN_POOL_MARGIN", "150")
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(configFile, []byte(""), 0o600); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.MinPoolMargin != 150 {
+		t.Fatalf("expected env var to set minPoolMargin=150, got %d", cfg.MinPoolMargin)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -311,6 +311,14 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		}
 	}
 
+	// CIP-23 minimum pool margin is basis points; must be within [0, 10000].
+	if c.MinPoolMargin > 10_000 {
+		errs = append(errs, fmt.Errorf(
+			"minPoolMargin (%d) must be in [0, 10000] basis points",
+			c.MinPoolMargin,
+		))
+	}
+
 	// Network identity
 	if c.Network == "" {
 		if c.NetworkMagic == 0 {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -544,3 +544,29 @@ func TestValidateAggregatesAllErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid evictionWatermark")
 	assert.Contains(t, err.Error(), "invalid chainsync.strategy")
 }
+
+func TestValidateMinPoolMargin(t *testing.T) {
+	tests := []struct {
+		name    string
+		v       uint
+		wantErr string
+	}{
+		{name: "zero disabled", v: 0},
+		{name: "within range", v: 150},
+		{name: "at maximum", v: 10_000},
+		{name: "above maximum", v: 10_001, wantErr: "minPoolMargin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.MinPoolMargin = tt.v
+			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -428,6 +428,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			dingo.WithBlockfrostPort(cfg.BlockfrostPort),
 			dingo.WithMeshPort(cfg.MeshPort),
 			dingo.WithStorageMode(storageMode),
+			// CIP-23 minimum pool margin (consensus-affecting)
+			dingo.WithMinPoolMargin(cfg.MinPoolMargin),
 			// Block production (SPO mode)
 			dingo.WithBlockProducer(cfg.BlockProducer),
 			dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),

--- a/ledger/dijkstra_pool_margin_floor_e2e_test.go
+++ b/ledger/dijkstra_pool_margin_floor_e2e_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/stretchr/testify/require"
+)
+
+// dijkstraPoolCertTx builds a real *gdijkstra.DijkstraTransaction carrying a
+// single pool registration certificate with the given margin, for exercising
+// the CIP-23 pool-margin-floor certificate rule end to end.
+func dijkstraPoolCertTx(marginNum, marginDen int64) *gdijkstra.DijkstraTransaction {
+	cert := &lcommon.PoolRegistrationCertificate{
+		CertType: uint(lcommon.CertificateTypePoolRegistration),
+		Margin:   lcommon.GenesisRat{Rat: big.NewRat(marginNum, marginDen)},
+	}
+	return &gdijkstra.DijkstraTransaction{
+		TxIsValid: true,
+		Body: gdijkstra.DijkstraTransactionBody{
+			TxFee: 200_000,
+			TxCertificates: []lcommon.CertificateWrapper{
+				{
+					Type:        uint(lcommon.CertificateTypePoolRegistration),
+					Certificate: cert,
+				},
+			},
+		},
+	}
+}
+
+func dijkstraTestProtocolParameters() *gdijkstra.DijkstraProtocolParameters {
+	return &gdijkstra.DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+				Major: gdijkstra.MinProtocolVersionDijkstra,
+			},
+			MaxTxSize:            16_384,
+			MaxValueSize:         5_000,
+			CollateralPercentage: 150,
+			MaxCollateralInputs:  3,
+		},
+	}
+}
+
+// TestValidateTxDijkstraRejectsBelowFloorPoolMarginThroughLedgerView is the
+// end-to-end regression test for the CIP-23 pool-margin-floor certificate
+// rule through the exact link used at runtime: a real *ledger.LedgerView
+// (built from a *LedgerState whose config.MinPoolMargin is nonzero) passed to
+// eras.ValidateTxDijkstra as the lcommon.LedgerState argument. This is the
+// path that depends on *LedgerView satisfying eras.MinPoolMarginProvider —
+// fix #1's compile-time assertion guards the interface signature, but only
+// this test proves the value actually reaches checkPoolMarginFloor at
+// runtime. Other Dijkstra UTxO validation rules may also error on this
+// deliberately minimal transaction; that's fine, since ValidateTxDijkstra
+// joins all rule errors and this test only asserts on the CIP-23 substring.
+func TestValidateTxDijkstraRejectsBelowFloorPoolMarginThroughLedgerView(t *testing.T) {
+	ls, _ := newRewardCalculationTestLedger(t)
+	ls.config.MinPoolMargin = 150 // 1.5%
+	lv := &LedgerView{ls: ls}
+
+	tx := dijkstraPoolCertTx(1, 1000) // 0.1%, below the 1.5% floor
+	err := eras.ValidateTxDijkstra(tx, 0, lv, dijkstraTestProtocolParameters())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "below minimum pool margin")
+}
+
+// TestValidateTxDijkstraAcceptsAtOrAboveFloorPoolMarginThroughLedgerView is
+// the companion negative assertion: a certificate at (or above, or under a
+// disabled floor) the configured minimum must never trip the CIP-23 rule
+// through the same real *LedgerView path.
+func TestValidateTxDijkstraAcceptsAtOrAboveFloorPoolMarginThroughLedgerView(
+	t *testing.T,
+) {
+	t.Run("at floor", func(t *testing.T) {
+		ls, _ := newRewardCalculationTestLedger(t)
+		ls.config.MinPoolMargin = 150 // 1.5%
+		lv := &LedgerView{ls: ls}
+
+		tx := dijkstraPoolCertTx(150, 10_000) // exactly 1.5%
+		err := eras.ValidateTxDijkstra(tx, 0, lv, dijkstraTestProtocolParameters())
+		if err != nil {
+			require.NotContains(t, err.Error(), "below minimum pool margin")
+		}
+	})
+
+	t.Run("above floor", func(t *testing.T) {
+		ls, _ := newRewardCalculationTestLedger(t)
+		ls.config.MinPoolMargin = 150 // 1.5%
+		lv := &LedgerView{ls: ls}
+
+		tx := dijkstraPoolCertTx(5, 100) // 5%
+		err := eras.ValidateTxDijkstra(tx, 0, lv, dijkstraTestProtocolParameters())
+		if err != nil {
+			require.NotContains(t, err.Error(), "below minimum pool margin")
+		}
+	})
+
+	t.Run("floor disabled", func(t *testing.T) {
+		ls, _ := newRewardCalculationTestLedger(t)
+		ls.config.MinPoolMargin = 0
+		lv := &LedgerView{ls: ls}
+
+		// Even a zero margin cert must not trip the rule when the floor is
+		// disabled (config.MinPoolMargin == 0 -> MinPoolMargin() returns nil).
+		tx := dijkstraPoolCertTx(0, 1)
+		err := eras.ValidateTxDijkstra(tx, 0, lv, dijkstraTestProtocolParameters())
+		if err != nil {
+			require.NotContains(t, err.Error(), "below minimum pool margin")
+		}
+	})
+}

--- a/ledger/eras/dijkstra.go
+++ b/ledger/eras/dijkstra.go
@@ -246,6 +246,15 @@ func ValidateTxDijkstra(
 			)
 		}
 	}
+	// CIP-23: reject pool registration certificates whose margin is below the
+	// operator-configured minimum pool margin. No-op when disabled (nil floor).
+	// Wired only here, so Conway and earlier eras are unaffected.
+	if err := checkPoolMarginFloor(
+		tx.Certificates(),
+		minPoolMarginFromLedgerState(ls),
+	); err != nil {
+		errs = append(errs, err)
+	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -37,6 +37,57 @@ type phase2ValidationSkipper interface {
 	SkipPhase2Validation() bool
 }
 
+// MinPoolMarginProvider is satisfied by the dingo ledger state to expose the
+// CIP-23 minimum pool margin to era validation, mirroring phase2ValidationSkipper.
+// Exported so implementers (e.g. *ledger.LedgerView) can assert conformance at
+// compile time; a signature drift here would otherwise silently disable the
+// CIP-23 pool-margin-floor certificate rule at runtime.
+type MinPoolMarginProvider interface {
+	MinPoolMargin() *big.Rat
+}
+
+// minPoolMarginFromLedgerState returns the CIP-23 minimum pool margin the ledger
+// state enforces, or nil when the state does not provide one (feature disabled).
+func minPoolMarginFromLedgerState(ls lcommon.LedgerState) *big.Rat {
+	provider, ok := ls.(MinPoolMarginProvider)
+	if !ok {
+		return nil
+	}
+	return provider.MinPoolMargin()
+}
+
+// checkPoolMarginFloor enforces the CIP-23 rule that each pool registration
+// certificate's margin (variable fee) is at least minMargin. It is a no-op when
+// minMargin is nil (feature disabled). A nil certificate margin is treated as 0.
+// Non-pool-registration certificates are ignored.
+func checkPoolMarginFloor(certs []lcommon.Certificate, minMargin *big.Rat) error {
+	if minMargin == nil {
+		return nil
+	}
+	for _, cert := range certs {
+		reg, ok := cert.(*lcommon.PoolRegistrationCertificate)
+		if !ok {
+			continue
+		}
+		if reg == nil {
+			continue
+		}
+		margin := reg.Margin.Rat
+		if margin == nil {
+			margin = new(big.Rat)
+		}
+		if margin.Cmp(minMargin) < 0 {
+			return fmt.Errorf(
+				"pool %x margin %s below minimum pool margin %s",
+				reg.Operator,
+				margin.RatString(),
+				minMargin.RatString(),
+			)
+		}
+	}
+	return nil
+}
+
 type indexedUtxoValidationRule struct {
 	index          int
 	validationFunc lcommon.UtxoValidationRuleFunc

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -2609,3 +2609,58 @@ func TestCalculateMinFee_OverflowSaturates(t *testing.T) {
 		"overflow should saturate at MaxUint64",
 	)
 }
+
+// --- CIP-23 pool-margin-floor certificate rule ---
+
+func cip23PoolCert(num, den int64) *lcommon.PoolRegistrationCertificate {
+	return &lcommon.PoolRegistrationCertificate{
+		Margin: lcommon.GenesisRat{Rat: big.NewRat(num, den)},
+	}
+}
+
+func TestCheckPoolMarginFloor(t *testing.T) {
+	floor := big.NewRat(150, 10_000) // 1.5%
+
+	// nil floor: no-op even for a zero-margin cert.
+	require.NoError(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{cip23PoolCert(0, 1)}, nil))
+
+	// below floor: rejected.
+	require.Error(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{cip23PoolCert(1, 1000)}, floor)) // 0.1%
+
+	// at floor: accepted.
+	require.NoError(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{cip23PoolCert(150, 10_000)}, floor))
+
+	// above floor: accepted.
+	require.NoError(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{cip23PoolCert(5, 100)}, floor)) // 5%
+
+	// nil cert margin treated as 0: rejected under a nonzero floor.
+	require.Error(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{&lcommon.PoolRegistrationCertificate{}}, floor))
+
+	// non-pool-registration cert ignored.
+	require.NoError(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{&lcommon.StakeRegistrationCertificate{}}, floor))
+
+	// multiple certs: one below floor rejects the whole set.
+	require.Error(t, checkPoolMarginFloor(
+		[]lcommon.Certificate{cip23PoolCert(5, 100), cip23PoolCert(1, 1000)}, floor))
+
+	// empty cert set: accepted.
+	require.NoError(t, checkPoolMarginFloor(nil, floor))
+
+	// typed-nil *PoolRegistrationCertificate element: must not panic, treated
+	// as ignorable (no error) under any floor, including nil.
+	var nilReg *lcommon.PoolRegistrationCertificate
+	require.NotPanics(t, func() {
+		require.NoError(t, checkPoolMarginFloor(
+			[]lcommon.Certificate{nilReg}, floor))
+	})
+	require.NotPanics(t, func() {
+		require.NoError(t, checkPoolMarginFloor(
+			[]lcommon.Certificate{nilReg}, nil))
+	})
+}

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -487,11 +487,21 @@ func (ls *LedgerState) precomputedStakeRewardApplication(
 	) {
 		return nil, false, nil
 	}
+	pparams, params, performanceDecentralization, err := ls.rewardParameters(
+		txn,
+		epochs.performance,
+		epochs.pots,
+		pots,
+	)
+	if err != nil {
+		return nil, false, err
+	}
 	if !precomputedRewardAccountAmountsMatchInputs(
 		poolInputs,
 		poolOutputs,
 		stakeInputs,
 		accountOutputs,
+		params,
 	) {
 		return nil, false, nil
 	}
@@ -501,15 +511,6 @@ func (ls *LedgerState) precomputedStakeRewardApplication(
 		boundarySlot,
 	) {
 		return nil, false, nil
-	}
-	pparams, params, performanceDecentralization, err := ls.rewardParameters(
-		txn,
-		epochs.performance,
-		epochs.pots,
-		pots,
-	)
-	if err != nil {
-		return nil, false, err
 	}
 	outputsComplete, err := precomputedRewardOutputsComplete(
 		poolOutputs,
@@ -774,6 +775,7 @@ func precomputedRewardAccountAmountsMatchInputs(
 	poolOutputs []*models.RewardPoolOutput,
 	stakeInputs []*models.RewardStakeInput,
 	accountOutputs []*models.RewardAccountOutput,
+	params rewards.Parameters,
 ) bool {
 	poolInputByKey := make(map[string]*models.RewardPoolInput, len(poolInputs))
 	for _, input := range poolInputs {
@@ -845,12 +847,13 @@ func precomputedRewardAccountAmountsMatchInputs(
 			if !ok {
 				return false
 			}
-			expected, err := rewards.MemberReward(
+			expected, err := rewards.MemberRewardWithParameters(
 				uint64(poolOutput.TotalReward),
 				uint64(poolInput.Cost),
 				ratOrZero(poolInput.Margin),
 				stake,
 				uint64(poolInput.DelegatedStake),
+				params,
 			)
 			if err != nil || reward.Amount != expected {
 				return false
@@ -2037,6 +2040,47 @@ func (ls *LedgerState) saveRewardAdaPotsForEpoch(
 	return nil
 }
 
+// minPoolMarginRat converts a CIP-23 minPoolMargin basis-points value to a
+// rational in [0, 1], returning nil when the value is 0 (feature disabled).
+// 150 bp => 150/10000. Uses SetUint64 (not int64(basisPoints)) to avoid a
+// gosec G115 uint->int64 conversion finding.
+func minPoolMarginRat(basisPoints uint) *big.Rat {
+	if basisPoints == 0 {
+		return nil
+	}
+	return new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(uint64(basisPoints)),
+		big.NewInt(10_000),
+	)
+}
+
+// applyMinPoolMarginConfig overlays the CIP-23 minimum pool margin operator
+// setting onto the reward parameters. It sets params.MinPoolMargin only when the
+// configured value is nonzero AND the calculation is for Dijkstra or later
+// (protocol major version >= dijkstra.MinProtocolVersionDijkstra); otherwise it
+// leaves the field nil so pre-Dijkstra reward calculation is byte-for-byte
+// unchanged. This is the reward-path half of the whole-feature Dijkstra+ gate;
+// the certificate half is that checkPoolMarginFloor is wired only into
+// ValidateTxDijkstra.
+func applyMinPoolMarginConfig(params *rewards.Parameters, cfg LedgerStateConfig) {
+	if cfg.MinPoolMargin == 0 {
+		return
+	}
+	if params.ProtocolMajorVersion < dijkstra.MinProtocolVersionDijkstra {
+		return
+	}
+	params.MinPoolMargin = minPoolMarginRat(cfg.MinPoolMargin)
+}
+
+// MinPoolMargin returns the CIP-23 minimum pool margin as a rational in [0, 1],
+// or nil when disabled (config value 0). It satisfies the eras package
+// MinPoolMarginProvider interface used by the Dijkstra pool-margin-floor
+// certificate rule; the Dijkstra-only era gate is inherent because only
+// ValidateTxDijkstra consults it.
+func (ls *LedgerState) MinPoolMargin() *big.Rat {
+	return minPoolMarginRat(ls.config.MinPoolMargin)
+}
+
 func (ls *LedgerState) rewardParameters(
 	txn *database.Txn,
 	performanceEpoch uint64,
@@ -2143,6 +2187,10 @@ func (ls *LedgerState) rewardParameters(
 	if err != nil {
 		return nil, rewards.Parameters{}, nil, err
 	}
+	// CIP-23: overlay the operator-configured minimum pool margin, gated to
+	// Dijkstra and later. Single chokepoint feeding both the boundary apply and
+	// the async precompute, so both agree.
+	applyMinPoolMarginConfig(&params, ls.config)
 	if params.MaxLovelaceSupply < uint64(pots.Reserves) {
 		return nil, rewards.Parameters{}, nil, fmt.Errorf(
 			"invalid reward pots: reserves %d exceed max supply %d",

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -2252,7 +2252,7 @@ func TestPrecomputedRewardAccountAmountsMatchInputs(t *testing.T) {
 
 	check := func(outs []*models.RewardAccountOutput) bool {
 		return precomputedRewardAccountAmountsMatchInputs(
-			poolInputs, poolOutputs, stakeInputs, outs,
+			poolInputs, poolOutputs, stakeInputs, outs, rewards.Parameters{},
 		)
 	}
 
@@ -2282,6 +2282,39 @@ func TestPrecomputedRewardAccountAmountsMatchInputs(t *testing.T) {
 	require.False(t, check([]*models.RewardAccountOutput{
 		memberOut(memberA, wantA), memberOut(rewardCalcHash(0x44), 1),
 	}))
+
+	// Dijkstra precompute uses the effective CIP-23 margin. A pool registered
+	// below the floor must therefore validate against the floor-derived member
+	// amounts, not amounts derived from its raw registration margin.
+	poolInputs[0].Margin = &types.Rat{Rat: big.NewRat(1, 100)}
+	minPoolMargin := big.NewRat(1, 20)
+	wantFloorA, err := rewards.MemberReward(
+		poolReward, cost, minPoolMargin, stakeA, delegated,
+	)
+	require.NoError(t, err)
+	wantFloorB, err := rewards.MemberReward(
+		poolReward, cost, minPoolMargin, stakeB, delegated,
+	)
+	require.NoError(t, err)
+	floorOutputs := []*models.RewardAccountOutput{
+		leaderOut(leaderReward),
+		memberOut(memberA, wantFloorA),
+		memberOut(memberB, wantFloorB),
+	}
+	require.True(t, precomputedRewardAccountAmountsMatchInputs(
+		poolInputs,
+		poolOutputs,
+		stakeInputs,
+		floorOutputs,
+		rewards.Parameters{MinPoolMargin: minPoolMargin},
+	))
+	require.False(t, precomputedRewardAccountAmountsMatchInputs(
+		poolInputs,
+		poolOutputs,
+		stakeInputs,
+		floorOutputs,
+		rewards.Parameters{},
+	))
 
 	// Guard the invariant this fix relies on: the pre-existing membership check
 	// accepts the redistributed set, so the amount check is the only gate that
@@ -2481,7 +2514,7 @@ func TestPrecomputedStakeRewardsRejectPoolRewardMismatch(t *testing.T) {
 	stakeInputs, err := meta.GetRewardStakeInputs(rewardSnapshotEpoch, nil)
 	require.NoError(t, err)
 	require.True(t, precomputedRewardAccountAmountsMatchInputs(
-		poolInputs, poolOutputs, stakeInputs, accountOutputs,
+		poolInputs, poolOutputs, stakeInputs, accountOutputs, rewards.Parameters{},
 	))
 	complete, err := precomputedRewardOutputsComplete(poolOutputs, accountOutputs, false)
 	require.NoError(t, err)
@@ -4675,4 +4708,47 @@ func rewardCalcSeedStakeCert(
 	default:
 		t.Fatalf("unsupported cert type %d", certType)
 	}
+}
+
+// --- CIP-23 minimum pool margin wiring ---
+
+func TestMinPoolMarginRat(t *testing.T) {
+	require.Nil(t, minPoolMarginRat(0))
+	require.Zero(t, big.NewRat(150, 10_000).Cmp(minPoolMarginRat(150)))
+	require.Zero(t, big.NewRat(1, 1).Cmp(minPoolMarginRat(10_000)))
+}
+
+// applyMinPoolMarginConfig sets the floor only when the value is nonzero AND the
+// calculation is for Dijkstra (major >= 12); otherwise it leaves the field nil.
+func TestApplyMinPoolMarginConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		bp      uint
+		major   uint64
+		wantRat *big.Rat // nil => expect nil
+	}{
+		{name: "disabled zero at dijkstra", bp: 0, major: 12},
+		{name: "pre-dijkstra ignored", bp: 150, major: 11},
+		{name: "dijkstra sets rat", bp: 150, major: 12, wantRat: big.NewRat(150, 10_000)},
+		{name: "post-dijkstra sets rat", bp: 500, major: 13, wantRat: big.NewRat(500, 10_000)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := rewards.Parameters{ProtocolMajorVersion: tt.major}
+			applyMinPoolMarginConfig(&params, LedgerStateConfig{MinPoolMargin: tt.bp})
+			if tt.wantRat == nil {
+				require.Nil(t, params.MinPoolMargin)
+				return
+			}
+			require.NotNil(t, params.MinPoolMargin)
+			require.Zero(t, tt.wantRat.Cmp(params.MinPoolMargin))
+		})
+	}
+}
+
+func TestLedgerStateMinPoolMargin(t *testing.T) {
+	ls, _ := newRewardCalculationTestLedger(t)
+	require.Nil(t, ls.MinPoolMargin())
+	ls.config.MinPoolMargin = 150
+	require.Zero(t, big.NewRat(150, 10_000).Cmp(ls.MinPoolMargin()))
 }

--- a/ledger/rewards/rewards.go
+++ b/ledger/rewards/rewards.go
@@ -113,6 +113,14 @@ type Parameters struct {
 	// reward prefilter; final unregistered rewards are still routed away from
 	// spendable accounts at application time.
 	ProtocolMajorVersion uint64
+	// MinPoolMargin is the CIP-23 minimum pool margin (minimum variable fee).
+	// When non-nil, a pool's effective margin in the reward split is
+	// max(pool.Margin, MinPoolMargin), so a pool registered below the floor is
+	// paid out as if it registered at the floor. It is nil unless the operator
+	// sets a nonzero minPoolMargin AND the calculation is for Dijkstra or later;
+	// nil reproduces the pre-CIP-23 split byte-for-byte. Must be in [0, 1] when
+	// set.
+	MinPoolMargin *big.Rat
 }
 
 // Pots captures the pot values available at the start of reward calculation.
@@ -329,7 +337,7 @@ func Calculate(pots Pots, snapshot Snapshot, params Parameters) (*Result, error)
 			amount, err := memberRewardChecked(
 				poolReward.PoolReward,
 				pool.Cost,
-				normalizedMargin(pool.Margin),
+				params.effectiveMargin(pool.Margin),
 				delegator.Stake,
 				pool.DelegatedStake,
 			)
@@ -591,6 +599,24 @@ func validateRatParameter(name string, rat *big.Rat, unit, positive bool) error 
 	return nil
 }
 
+// validateMinPoolMargin enforces that a set CIP-23 MinPoolMargin lies in [0, 1].
+// It is a no-op when MinPoolMargin is nil, so parameters built with the zero
+// value are unaffected.
+func validateMinPoolMargin(params Parameters) error {
+	if params.MinPoolMargin == nil {
+		return nil
+	}
+	if params.MinPoolMargin.Sign() < 0 ||
+		params.MinPoolMargin.Cmp(oneRat()) > 0 {
+		return fmt.Errorf(
+			"%w: min pool margin %s outside [0,1]",
+			ErrInvalidParameters,
+			params.MinPoolMargin.RatString(),
+		)
+	}
+	return nil
+}
+
 func validateParameters(params Parameters) error {
 	for _, field := range []struct {
 		name     string
@@ -624,7 +650,7 @@ func validateParameters(params Parameters) error {
 	if params.EpochLength == 0 {
 		return fmt.Errorf("%w: epoch length is zero", ErrInvalidParameters)
 	}
-	return nil
+	return validateMinPoolMargin(params)
 }
 
 // validatePoolRewardParameters checks the subset of parameters that
@@ -641,12 +667,15 @@ func validatePoolRewardParameters(params Parameters) error {
 	); err != nil {
 		return err
 	}
-	return validateRatParameter(
+	if err := validateRatParameter(
 		"pledge influence",
 		params.PledgeInfluence,
 		false,
 		false,
-	)
+	); err != nil {
+		return err
+	}
+	return validateMinPoolMargin(params)
 }
 
 func validateSnapshot(snapshot Snapshot) error {
@@ -915,7 +944,7 @@ func calculatePoolRewards(
 	leader, err := leaderRewardChecked(
 		ret.PoolReward,
 		pool.Cost,
-		normalizedMargin(pool.Margin),
+		params.effectiveMargin(pool.Margin),
 		pool.OwnerStake,
 		pool.DelegatedStake,
 	)
@@ -1150,6 +1179,28 @@ func MemberReward(
 	)
 }
 
+// MemberRewardWithParameters computes a member reward using the same effective
+// pool margin as Calculate. In particular, it applies the CIP-23 minimum pool
+// margin from params when one is enabled. Callers that validate rewards produced
+// by Calculate must use this form so their arithmetic cannot drift from the
+// authoritative reward split.
+func MemberRewardWithParameters(
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	memberStake uint64,
+	poolStake uint64,
+	params Parameters,
+) (uint64, error) {
+	return memberRewardChecked(
+		poolReward,
+		cost,
+		params.effectiveMargin(margin),
+		memberStake,
+		poolStake,
+	)
+}
+
 func memberRewardChecked(
 	poolReward uint64,
 	cost uint64,
@@ -1207,6 +1258,26 @@ func minRat(a, b *big.Rat) *big.Rat {
 		return new(big.Rat).Set(a)
 	}
 	return new(big.Rat).Set(b)
+}
+
+func maxRat(a, b *big.Rat) *big.Rat {
+	if a.Cmp(b) >= 0 {
+		return new(big.Rat).Set(a)
+	}
+	return new(big.Rat).Set(b)
+}
+
+// effectiveMargin returns the pool margin used in the reward split, applying the
+// CIP-23 minimum pool margin floor when set: max(normalizedMargin(margin),
+// MinPoolMargin). When MinPoolMargin is nil (feature off or pre-Dijkstra) it
+// returns normalizedMargin(margin) unchanged, so the split is byte-for-byte the
+// pre-CIP-23 calculation. A nil pool margin is treated as 0.
+func (p Parameters) effectiveMargin(margin *big.Rat) *big.Rat {
+	m := normalizedMargin(margin)
+	if p.MinPoolMargin == nil {
+		return m
+	}
+	return maxRat(m, p.MinPoolMargin)
 }
 
 func uintRat(v uint64) *big.Rat {

--- a/ledger/rewards/rewards_test.go
+++ b/ledger/rewards/rewards_test.go
@@ -1911,3 +1911,133 @@ func testPoolID(fill byte) PoolID {
 	}
 	return hash
 }
+
+// --- CIP-23 minimum pool margin ---
+
+// minMarginCalc runs Calculate for a single pool sized to exercise both the
+// leader and member margin split. Pledge/owner stake are 100 of 1000 total, so
+// the owner fraction (0.1) makes the leader margin term matter; cost 1000 with a
+// ~70000 pool reward leaves a large variable reward to split. margin is the
+// pool's registered margin; minPoolMargin is the CIP-23 floor (nil = off).
+func minMarginCalc(margin, minPoolMargin *big.Rat) (*Result, error) {
+	owner := testCredential(0, 2)
+	member := testCredential(0, 3)
+	params := testParams()
+	params.MinPoolMargin = minPoolMargin
+	return Calculate(
+		Pots{Reserves: 100_000_000},
+		Snapshot{
+			TotalActiveStake: 1_000,
+			Pools: []Pool{
+				{
+					ID:                      testPoolID(1),
+					RewardAccount:           testCredential(0, 4),
+					Margin:                  margin,
+					Pledge:                  100,
+					Cost:                    1_000,
+					DelegatedStake:          1_000,
+					OwnerStake:              100,
+					BlocksProduced:          10,
+					TotalBlocks:             10,
+					RewardAccountRegistered: true,
+					RewardAccountEligible:   true,
+					Owners:                  map[Credential]struct{}{owner: {}},
+					Delegators: []Delegator{
+						{Credential: owner, Stake: 100, Registered: true, Eligible: true},
+						{Credential: member, Stake: 900, Registered: true, Eligible: true},
+					},
+				},
+			},
+		},
+		params,
+	)
+}
+
+func minMarginMemberReward(t *testing.T, result *Result, cred Credential) uint64 {
+	t.Helper()
+	for _, r := range result.AccountRewards {
+		if r.Credential == cred && r.Type == RewardTypeMember {
+			return r.Amount
+		}
+	}
+	return 0
+}
+
+// effectiveMargin: max(margin, floor); margin when floor nil; nil margin == 0.
+func TestEffectiveMargin(t *testing.T) {
+	margin := big.NewRat(1, 50) // 2%
+	floor := big.NewRat(1, 10)  // 10%
+	require.Zero(t, margin.Cmp(Parameters{}.effectiveMargin(margin)))
+	require.Zero(t, margin.Cmp(
+		Parameters{MinPoolMargin: big.NewRat(1, 100)}.effectiveMargin(margin)))
+	require.Zero(t, floor.Cmp(
+		Parameters{MinPoolMargin: floor}.effectiveMargin(margin)))
+	require.Zero(t, floor.Cmp(Parameters{MinPoolMargin: floor}.effectiveMargin(nil)))
+	require.Zero(t, new(big.Rat).Cmp(Parameters{}.effectiveMargin(nil)))
+}
+
+// A below-floor pool with the feature on splits exactly like an at-floor pool
+// with the feature off: the clamp makes it behave as if registered at the floor.
+func TestCalculateMinPoolMarginBelowFloorEqualsAtFloor(t *testing.T) {
+	floor := big.NewRat(1, 10)
+	below := big.NewRat(1, 50)
+	member := testCredential(0, 3)
+
+	on, err := minMarginCalc(below, floor)
+	require.NoError(t, err)
+	atFloor, err := minMarginCalc(floor, nil)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		atFloor.PoolRewards[0].LeaderReward, on.PoolRewards[0].LeaderReward)
+	require.Equal(t,
+		minMarginMemberReward(t, atFloor, member),
+		minMarginMemberReward(t, on, member))
+}
+
+// The clamp shifts the split toward the operator: same total pool reward, higher
+// leader share, lower member share than the unfloored baseline.
+func TestCalculateMinPoolMarginShiftsSplitTowardOperator(t *testing.T) {
+	floor := big.NewRat(1, 10)
+	below := big.NewRat(1, 50)
+	member := testCredential(0, 3)
+
+	base, err := minMarginCalc(below, nil)
+	require.NoError(t, err)
+	on, err := minMarginCalc(below, floor)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		base.PoolRewards[0].PoolReward, on.PoolRewards[0].PoolReward)
+	require.Greater(t,
+		on.PoolRewards[0].LeaderReward, base.PoolRewards[0].LeaderReward)
+	require.Less(t,
+		minMarginMemberReward(t, on, member),
+		minMarginMemberReward(t, base, member))
+}
+
+// A floor at or below the pool's registered margin is a parity no-op.
+func TestCalculateMinPoolMarginBelowMarginIsParity(t *testing.T) {
+	member := testCredential(0, 3)
+	base, err := minMarginCalc(big.NewRat(1, 10), nil)
+	require.NoError(t, err)
+	on, err := minMarginCalc(big.NewRat(1, 10), big.NewRat(1, 50))
+	require.NoError(t, err)
+	require.Equal(t,
+		base.PoolRewards[0].LeaderReward, on.PoolRewards[0].LeaderReward)
+	require.Equal(t,
+		minMarginMemberReward(t, base, member),
+		minMarginMemberReward(t, on, member))
+}
+
+// A MinPoolMargin outside [0,1] is rejected; the inclusive bounds are accepted.
+func TestCalculateMinPoolMarginRange(t *testing.T) {
+	_, err := minMarginCalc(big.NewRat(1, 50), big.NewRat(3, 2))
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	_, err = minMarginCalc(big.NewRat(1, 50), big.NewRat(-1, 2))
+	require.ErrorIs(t, err, ErrInvalidParameters)
+	_, err = minMarginCalc(big.NewRat(1, 50), new(big.Rat))
+	require.NoError(t, err)
+	_, err = minMarginCalc(big.NewRat(1, 50), big.NewRat(1, 1))
+	require.NoError(t, err)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -447,6 +447,12 @@ type LedgerStateConfig struct {
 	// on Musashi in node.go. Interim until the Leios certificate / endorser-
 	// availability surface is complete (#2587).
 	SkipDijkstraTxValidation bool
+	// MinPoolMargin is the CIP-23 minimum pool margin (minimum variable fee) in
+	// basis points, [0, 10000] (150 = 1.5%); 0 disables it. It is a consensus-
+	// affecting operator setting (not derived from the network) that takes
+	// effect only in Dijkstra and later. Enable a nonzero value only on a
+	// network where every node also enables the same value.
+	MinPoolMargin            uint
 	ValidateHistorical       bool
 	EnableDijkstra           bool
 	StartInDijkstra          bool

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -56,6 +57,19 @@ type LedgerView struct {
 func (lv *LedgerView) SkipPhase2Validation() bool {
 	return lv.skipPhase2Validation
 }
+
+// MinPoolMargin forwards the CIP-23 minimum pool margin from the underlying
+// ledger state so that a *LedgerView (the value passed to ValidateTx*) satisfies
+// the eras.MinPoolMarginProvider interface. Without this, the Dijkstra
+// pool-margin-floor certificate rule would never see the configured floor.
+func (lv *LedgerView) MinPoolMargin() *big.Rat {
+	return lv.ls.MinPoolMargin()
+}
+
+// var _ eras.MinPoolMarginProvider = (*LedgerView)(nil) makes any future drift
+// in the MinPoolMarginProvider method signature a compile error instead of a
+// silent runtime no-op for the CIP-23 pool-margin-floor certificate rule.
+var _ eras.MinPoolMarginProvider = (*LedgerView)(nil)
 
 func (lv *LedgerView) NetworkId() uint {
 	genesis := lv.ls.config.CardanoNodeConfig.ShelleyGenesis()

--- a/ledger/view_test.go
+++ b/ledger/view_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -65,6 +66,21 @@ func TestLedgerViewSkipPhase2Validation(t *testing.T) {
 
 	lv.skipPhase2Validation = true
 	require.True(t, lv.SkipPhase2Validation())
+}
+
+// TestLedgerViewMinPoolMargin guards the CIP-23 bridge: MinPoolMargin() must
+// forward from the LedgerState embedded via the named ls field, since Go does
+// not promote methods across a named (non-embedded) field. Without this
+// forwarding method, ls.(eras.MinPoolMarginProvider) in ledger/eras always fails
+// for the *LedgerView actually passed to ValidateTx*, silently disabling the
+// pool-margin-floor certificate rule.
+func TestLedgerViewMinPoolMargin(t *testing.T) {
+	ls := &LedgerState{}
+	lv := &LedgerView{ls: ls}
+	require.Nil(t, lv.MinPoolMargin())
+
+	ls.config.MinPoolMargin = 150
+	require.Zero(t, big.NewRat(150, 10_000).Cmp(lv.MinPoolMargin()))
 }
 
 func TestExtractCostModelsFromPParams_Nil(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -359,7 +359,10 @@ func (n *Node) Run(ctx context.Context) error {
 			// On Musashi, certified endorser txs and Dijkstra ranking-block txs are
 			// trusted by the prototype; skip dingo's per-tx validation to match it
 			// and keep block application at the production rate.
-			SkipDijkstraTxValidation:   n.config.isMusashiNetwork(),
+			SkipDijkstraTxValidation: n.config.isMusashiNetwork(),
+			// CIP-23 minimum pool margin (minimum variable fee). Operator-set,
+			// off by default (0), effective only in Dijkstra and later.
+			MinPoolMargin:              n.config.minPoolMargin,
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
 			PeersWithBlockFunc: func(
 				origin ouroboros.ConnectionId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implements CIP-23 minimum pool margin (minimum variable fee) as an optional, consensus-affecting setting. In Dijkstra+, rewards clamp to max(pool margin, floor) and pool registration certificates below the floor are rejected; disabled by default.

- **New Features**
  - Config: YAML `minPoolMargin`, env `DINGO_MIN_POOL_MARGIN`, CLI `--min-pool-margin`, and `WithMinPoolMargin`; 0–10000 bps (150 = 1.5%); validation added.
  - Rewards: Dijkstra+ only; split uses the floor for leader and members; `rewards.Parameters.MinPoolMargin` with [0,1] validation; precompute checks use the effective margin to match the authoritative calc.
  - Tx Validation: `ValidateTxDijkstra` rejects pool registration certs below the floor; `LedgerView` implements `eras.MinPoolMarginProvider`; end-to-end and unit tests added.
  - Wiring/Docs: Node plumbs config to ledger; `ARCHITECTURE.md` and `dingo.yaml.example` updated.

- **Migration**
  - Default is off (0). To enable, set `minPoolMargin` (e.g., 150 = 1.5%) via YAML/env/CLI.
  - Enable only on networks where every node sets the same value; effective only in Dijkstra and later.

<sup>Written for commit 98c7009a587e539698cf061d51df29778d20cbdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional minimum pool margin setting for Dijkstra-era networks and later.
  * Minimum margins can be configured through YAML, command-line, or environment settings.
  * Rewards now use the configured margin floor for operator and delegator shares.
  * Pool registrations below the configured floor are rejected when the feature is enabled.
  * Added configuration guidance and validation for values from 0 to 10,000 basis points.

* **Tests**
  * Added coverage for configuration, reward calculations, transaction validation, and environment-variable support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->