### PR TITLE
fix(database): mithril deferred index for live stake

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2313,8 +2313,13 @@ UTxO-only credentials as unregistered and undelegated so a later registration
 can activate their existing stake without losing it. `RewardLiveStakeNeedsBackfill`
 distinguishes an upgraded database with accounts but no aggregate rows from a
 legitimately fresh empty database. Node startup performs the check and rebuild
-after database recovery and before ledger processing. Mithril import does not
-currently invoke this rebuild directly; the next normal node startup does.
+after database recovery and before ledger processing. Mithril ledger-state
+import also invokes the rebuild directly, at the end of import once accounts and
+UTxOs are populated. That import runs with the deferred-index manifest dropped
+for bulk load, so the SQLite backend applies its `INDEXED BY
+idx_utxo_staking_deleted_amount` query-planner hint only when the index is
+present; while the index is deferred the rebuild falls back to a planner-chosen
+plan rather than aborting with `no such index`.
 
 Pool registration lookup reconstructs the parameters effective during the
 ended epoch for per-pool input capture. Reward calculation and application

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -197,7 +197,9 @@ var Manifest = []Index{
 	},
 	{
 		Model: &models.Utxo{}, Name: "idx_utxo_staking_deleted_amount", Table: "utxo",
-		Notes:    "DRep voting-power live UTxO SUM; live query path",
+		Notes: "DRep voting-power live UTxO SUM; live query path. RebuildRewardLiveStake " +
+			"runs during ledger-state import and hints this index, but the sqlite backend " +
+			"applies the INDEXED BY hint only when the index exists, so it stays deferrable.",
 		Critical: true,
 	},
 	{

--- a/database/plugin/metadata/sqlite/reward_live_stake.go
+++ b/database/plugin/metadata/sqlite/reward_live_stake.go
@@ -286,12 +286,38 @@ func (d *MetadataStoreSqlite) RebuildRewardLiveStake(
 	if err != nil {
 		return fmt.Errorf("rebuild reward live stake: resolve db: %w", err)
 	}
-	rebuild := func(tx *gorm.DB) error {
-		return rewardstate.RebuildLiveStake(
-			tx,
-			slot,
-			"INDEXED BY "+utxoStakingLiveAmountIndex,
+	// The INDEXED BY hint forces the covering index for the per-credential
+	// UTxO SUM, but idx_utxo_staking_deleted_amount is a deferred-manifest
+	// entry (see database/plugin/metadata/deferred) that Mithril bulk load
+	// drops for the duration of ledger-state import. SQLite treats INDEXED BY
+	// as a hard directive and aborts with "no such index" when the hinted
+	// index is absent, and this full rebuild runs at the end of that import
+	// before the index is rebuilt. Only apply the hint when the index is
+	// present (live operation, startup rebuild); otherwise fall back to a
+	// planner-chosen plan, which for a full-table aggregate is a scan and hash
+	// group anyway.
+	//
+	// The presence check MUST run on the resolved db (the caller's transaction
+	// connection when txn != nil), not d.DB(): Mithril import calls this inside
+	// a write transaction (database.RebuildRewardLiveStake -> Txn.Do), and the
+	// write pool is capped at a single connection, so probing d.DB() here would
+	// request a second handle and deadlock against the very transaction waiting
+	// on this call. Query sqlite_master directly, mirroring LiveStakeNeedsBackfill.
+	var indexPresent bool
+	if err := db.Raw(
+		"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?)",
+		utxoStakingLiveAmountIndex,
+	).Scan(&indexPresent).Error; err != nil {
+		return fmt.Errorf(
+			"rebuild reward live stake: check staking index: %w", err,
 		)
+	}
+	utxoJoinHint := ""
+	if indexPresent {
+		utxoJoinHint = "INDEXED BY " + utxoStakingLiveAmountIndex
+	}
+	rebuild := func(tx *gorm.DB) error {
+		return rewardstate.RebuildLiveStake(tx, slot, utxoJoinHint)
 	}
 	if txn != nil {
 		return rebuild(db)

--- a/database/plugin/metadata/sqlite/reward_live_stake_test.go
+++ b/database/plugin/metadata/sqlite/reward_live_stake_test.go
@@ -9,8 +9,10 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,6 +32,124 @@ func TestRewardLiveStakeNeedsBackfillAcceptsReadTransaction(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, needed)
+}
+
+// TestRebuildRewardLiveStakeToleratesDroppedStakingIndex reproduces the
+// Mithril sync crash where the ledger-state import runs RebuildRewardLiveStake
+// while idx_utxo_staking_deleted_amount is dropped by the deferred-index
+// bulk-load optimization. SQLite treats INDEXED BY as a hard directive and
+// aborts with "no such index" when the hinted index is absent, so the rebuild
+// must fall back to a planner-chosen plan and still produce the correct
+// aggregate.
+func TestRebuildRewardLiveStakeToleratesDroppedStakingIndex(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	stakingKey := bytes.Repeat([]byte{0xA1}, 28)
+	pool := bytes.Repeat([]byte{0xC2}, 28)
+	require.NoError(t, store.DB().Create(&models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Pool:          pool,
+		Reward:        types.Uint64(500),
+		Active:        true,
+		AddedSlot:     10,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:          bytes.Repeat([]byte{0x01}, 32),
+		OutputIdx:     0,
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Amount:        types.Uint64(1_000),
+		DeletedSlot:   0,
+		AddedSlot:     10,
+	}).Error)
+
+	// Simulate the deferred-index bulk-load window: the composite staking
+	// index the rebuild hints is dropped during Mithril ledger-state import.
+	migrator := store.DB().Migrator()
+	require.NoError(
+		t,
+		migrator.DropIndex(&models.Utxo{}, utxoStakingLiveAmountIndex),
+	)
+	require.False(
+		t,
+		migrator.HasIndex(&models.Utxo{}, utxoStakingLiveAmountIndex),
+		"precondition: staking index must be absent",
+	)
+
+	require.NoError(t, store.RebuildRewardLiveStake(20, nil))
+
+	var row models.RewardLiveStake
+	require.NoError(t, store.DB().Where(
+		"credential_tag = ? AND staking_key = ?",
+		0,
+		stakingKey,
+	).First(&row).Error)
+	require.Equal(t, uint64(1_000), uint64(row.UtxoStake))
+	require.Equal(t, uint64(500), uint64(row.RewardStake))
+	require.Equal(t, uint64(1_500), uint64(row.TotalStake))
+}
+
+// TestRebuildRewardLiveStakeWithinWriteTxnToleratesDroppedIndex reproduces the
+// Mithril import deadlock: the ledger-state import calls RebuildRewardLiveStake
+// inside a write transaction (database.RebuildRewardLiveStake -> Txn.Do) while
+// idx_utxo_staking_deleted_amount is dropped for bulk load. The file-based write
+// pool is capped at a single connection, so probing index presence on d.DB()
+// (rather than the transaction's own connection) requests a second handle and
+// deadlocks against the transaction waiting on the rebuild. A file-based store
+// is required — the in-memory store uses a multi-connection pool and cannot
+// reproduce the single-writer contention.
+func TestRebuildRewardLiveStakeWithinWriteTxnToleratesDroppedIndex(t *testing.T) {
+	t.Parallel()
+	store, err := New(t.TempDir(), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, store.Start())
+	t.Cleanup(func() { store.Close() }) //nolint:errcheck
+
+	stakingKey := bytes.Repeat([]byte{0xA2}, 28)
+	require.NoError(t, store.DB().Create(&models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Reward:        types.Uint64(700),
+		Active:        true,
+		AddedSlot:     5,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:          bytes.Repeat([]byte{0x02}, 32),
+		OutputIdx:     0,
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Amount:        types.Uint64(2_000),
+		DeletedSlot:   0,
+		AddedSlot:     5,
+	}).Error)
+
+	require.NoError(
+		t,
+		store.DB().Migrator().DropIndex(&models.Utxo{}, utxoStakingLiveAmountIndex),
+	)
+
+	txn := store.Transaction()
+	done := make(chan error, 1)
+	go func() { done <- store.RebuildRewardLiveStake(30, txn) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("RebuildRewardLiveStake deadlocked inside a write transaction")
+	}
+	require.NoError(t, txn.Commit())
+
+	var row models.RewardLiveStake
+	require.NoError(t, store.DB().Where(
+		"credential_tag = ? AND staking_key = ?",
+		0,
+		stakingKey,
+	).First(&row).Error)
+	require.Equal(t, uint64(2_000), uint64(row.UtxoStake))
+	require.Equal(t, uint64(700), uint64(row.RewardStake))
+	require.Equal(t, uint64(2_700), uint64(row.TotalStake))
 }
 
 func TestRebuildRewardLiveStakeRejectsNullAccountCredential(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash and potential deadlock during Mithril ledger-state import when rebuilding live stake with the deferred `idx_utxo_staking_deleted_amount` index. The rebuild now detects the index and only uses the `INDEXED BY` hint when the index exists; otherwise it falls back to the planner.

- Bug Fixes
  - Build the join hint dynamically by probing `sqlite_master`; use `INDEXED BY idx_utxo_staking_deleted_amount` only if present.
  - Perform the presence check on the caller’s transaction connection to avoid single-writer deadlocks.
  - Keep the staking index in the `deferred` manifest; the SQLite backend applies the hint only when the index exists.

<sup>Written for commit 00e45fe4e01849eca3d767102e1c3676b9e4382e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

