### PR TITLE
feat: full pot distribution (CIP-163)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1054,11 +1054,18 @@ passes: pass one computes each pool's base reward `B_i` in pool-ID order, and
 (Hamilton) method — all `big.Int`, tie-broken by pool ID — so the per-pool totals
 sum to the entire available pot exactly; pass two re-derives each pool's leader
 and member split from the scaled total using the same checked helpers as the
-disabled path. Only the irreducible per-pool leader/member split rounding (a few
-lovelace network-wide) still returns to reserves. The one exception is when no
-pool earned a base reward (`W == 0`, e.g. every pool disqualified): apportionment
-is skipped and the whole available pot returns to reserves, identical to the
-disabled path. The gate is overlaid onto the
+disabled path. This removes the pre-CIP-0163 saturation, pledge, and performance
+residual, but it does not make the full pot spendable by reward accounts. Rewards
+omitted by the pre-Babbage registration prefilter still return to reserves;
+calculated rewards for accounts that fail the application-time registration or
+eligibility check still route to treasury as unspendable; and per-delegator
+member-reward flooring returns to reserves and can accumulate across many
+delegators. The "few lovelace" bound applies only to the irreducible per-pool
+leader/member split rounding that returns to reserves when all relevant rewards
+pass those eligibility checks. The one
+exception is when no pool earned a base reward (`W == 0`, e.g. every pool
+disqualified): apportionment is skipped and the whole available pot returns to
+reserves, identical to the disabled path. The gate is overlaid onto the
 on-chain-derived reward parameters at a single chokepoint,
 `rewardParameters` (`applyFullPotConfig`), which feeds both the epoch-boundary
 apply and the async precompute path, so both compute identical rewards; the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1044,6 +1044,30 @@ tax are applied but no pool or account rewards are distributed; the post-tax
 amount returns to reserves. Later updates use the normal delayed E-3 snapshot,
 E-2 performance, and E-1 pots mapping.
 
+CIP-0163 full-pot reward distribution is an operator-set, consensus-affecting
+feature gate (`FullPotRewardsEnabled`, default off; see `WithFullPotRewards` and
+`LedgerStateConfig`). When off, `rewards.Calculate` is byte-for-byte identical to
+the pre-CIP-0163 calculation and the saturation, pledge-influence, and
+performance residual returns to reserves as above. When on, `Calculate` runs two
+passes: pass one computes each pool's base reward `B_i` in pool-ID order, and
+`rewards.ApportionFullPot` scales the base rewards up with the largest-remainder
+(Hamilton) method — all `big.Int`, tie-broken by pool ID — so the per-pool totals
+sum to the entire available pot exactly; pass two re-derives each pool's leader
+and member split from the scaled total using the same checked helpers as the
+disabled path. Only the irreducible per-pool leader/member split rounding (a few
+lovelace network-wide) still returns to reserves. The one exception is when no
+pool earned a base reward (`W == 0`, e.g. every pool disqualified): apportionment
+is skipped and the whole available pot returns to reserves, identical to the
+disabled path. The gate is overlaid onto the
+on-chain-derived reward parameters at a single chokepoint,
+`rewardParameters` (`applyFullPotConfig`), which feeds both the epoch-boundary
+apply and the async precompute path, so both compute identical rewards; the
+precompute reuse verifier (`precomputedRewardPoolRewardsMatchInputs`) reproduces
+the same apportionment before validating persisted pool totals. Because it
+changes consensus, enable it only on a network where every node also enables it
+(mainnet and the public testnets keep it off); enabling it off-consensus forks
+the node off the network.
+
 During from-genesis startup, the synthetic genesis block transaction creates
 the combined Byron and Shelley genesis UTxOs and atomically writes the slot-0
 `NetworkState`: treasury starts at zero and reserves start at

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1071,8 +1071,11 @@ on-chain-derived reward parameters at a single chokepoint,
 apply and the async precompute path, so both compute identical rewards; the
 precompute reuse verifier (`precomputedRewardPoolRewardsMatchInputs`) reproduces
 the same apportionment before validating persisted pool totals. Because it
-changes consensus, enable it only on a network where every node also enables it
-(mainnet and the public testnets keep it off); enabling it off-consensus forks
+changes consensus, startup validation permits it only on devnet/custom networks
+by default. Predefined standard networks reject it unless the operator also sets
+the explicit unsafe override
+(`UnsafeFullPotRewardsOnStandardNetworks` /
+`WithUnsafeFullPotRewardsOnStandardNetworks`); enabling it off-consensus forks
 the node off the network.
 
 During from-genesis startup, the synthetic genesis block transaction creates

--- a/config.go
+++ b/config.go
@@ -203,7 +203,8 @@ type Config struct {
 	// CIP-0163 full-pot reward distribution (consensus-affecting; default
 	// off). Distributes the entire epoch reward pot to eligible pools instead
 	// of returning the residual to reserves.
-	fullPotRewardsEnabled bool
+	fullPotRewardsEnabled                  bool
+	unsafeFullPotRewardsOnStandardNetworks bool
 	// Leios voting configuration (experimental)
 	leiosVoteSigningKeyFile string
 	leiosVoterPublicKeys    map[string]string
@@ -460,6 +461,19 @@ func (n *Node) configValidate() error {
 			"pledge leverage (%d) must be in [1, 10000] when enabled",
 			n.config.pledgeLeverage,
 		)
+	}
+	if n.config.fullPotRewardsEnabled &&
+		!n.config.unsafeFullPotRewardsOnStandardNetworks {
+		if network, ok := internalconfig.FullPotRewardsStandardNetwork(
+			n.config.network,
+			n.config.networkMagic,
+		); ok {
+			return fmt.Errorf(
+				"full pot rewards are not permitted on standard network %q "+
+					"without unsafe full-pot rewards opt-in",
+				network,
+			)
+		}
 	}
 	// In core mode, ignore API ports — they are only used in API mode.
 	// This lets defaults stay non-zero without requiring core-mode users
@@ -939,6 +953,16 @@ func WithPledgeLeverage(enabled bool, leverage uint) ConfigOptionFunc {
 func WithFullPotRewards(enabled bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.fullPotRewardsEnabled = enabled
+	}
+}
+
+// WithUnsafeFullPotRewardsOnStandardNetworks allows CIP-0163 full-pot reward
+// distribution on predefined standard networks. This is consensus-breaking
+// unless the network has explicitly adopted the rule; leave disabled for
+// normal operation.
+func WithUnsafeFullPotRewardsOnStandardNetworks(enabled bool) ConfigOptionFunc {
+	return func(c *Config) {
+		c.unsafeFullPotRewardsOnStandardNetworks = enabled
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -200,6 +200,10 @@ type Config struct {
 	// off). pledgeLeverage is L in [1, 10000], used only when enabled.
 	pledgeLeverageEnabled bool
 	pledgeLeverage        uint
+	// CIP-0163 full-pot reward distribution (consensus-affecting; default
+	// off). Distributes the entire epoch reward pot to eligible pools instead
+	// of returning the residual to reserves.
+	fullPotRewardsEnabled bool
 	// Leios voting configuration (experimental)
 	leiosVoteSigningKeyFile string
 	leiosVoterPublicKeys    map[string]string
@@ -924,6 +928,17 @@ func WithPledgeLeverage(enabled bool, leverage uint) ConfigOptionFunc {
 	return func(c *Config) {
 		c.pledgeLeverageEnabled = enabled
 		c.pledgeLeverage = leverage
+	}
+}
+
+// WithFullPotRewards configures CIP-0163 full-pot reward distribution. It is
+// consensus-affecting and disabled by default; enable it only on a network
+// where every node also enables it. When enabled, the entire epoch reward pot
+// is distributed to eligible pools and delegators instead of returning the
+// residual to reserves.
+func WithFullPotRewards(enabled bool) ConfigOptionFunc {
+	return func(c *Config) {
+		c.fullPotRewardsEnabled = enabled
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -162,6 +162,14 @@ func TestConfigValidatePledgeLeverage(t *testing.T) {
 	}
 }
 
+func TestWithFullPotRewards(t *testing.T) {
+	cfg := &Config{}
+	WithFullPotRewards(true)(cfg)
+	assert.True(t, cfg.fullPotRewardsEnabled)
+	WithFullPotRewards(false)(cfg)
+	assert.False(t, cfg.fullPotRewardsEnabled)
+}
+
 func TestExperimentalDijkstraEnabled(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/config_test.go
+++ b/config_test.go
@@ -170,6 +170,70 @@ func TestWithFullPotRewards(t *testing.T) {
 	assert.False(t, cfg.fullPotRewardsEnabled)
 }
 
+func TestFullPotRewardsStandardNetworkValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ConfigOptionFunc
+		wantErr string
+	}{
+		{
+			name: "rejects standard network by name",
+			opts: []ConfigOptionFunc{
+				WithNetwork("preview"),
+			},
+			wantErr: "full pot rewards are not permitted on standard network \"preview\"",
+		},
+		{
+			name: "rejects standard network by magic",
+			opts: []ConfigOptionFunc{
+				WithNetwork("private-preview-mirror"),
+				WithNetworkMagic(2),
+			},
+			wantErr: "full pot rewards are not permitted on standard network \"preview\"",
+		},
+		{
+			name: "allows standard network with unsafe opt-in",
+			opts: []ConfigOptionFunc{
+				WithNetwork("preview"),
+				WithUnsafeFullPotRewardsOnStandardNetworks(true),
+			},
+		},
+		{
+			name: "allows custom network",
+			opts: []ConfigOptionFunc{
+				WithNetwork("private-net"),
+				WithNetworkMagic(9_999),
+			},
+		},
+		{
+			name: "allows devnet",
+			opts: []ConfigOptionFunc{
+				WithNetwork("devnet"),
+				WithNetworkMagic(42),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []ConfigOptionFunc{
+				WithPrometheusRegistry(prometheus.NewRegistry()),
+				WithListeners(ListenerConfig{
+					ListenNetwork: "tcp",
+					ListenAddress: "127.0.0.1:0",
+				}),
+				WithFullPotRewards(true),
+			}
+			opts = append(opts, tt.opts...)
+			_, err := New(NewConfig(opts...))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestExperimentalDijkstraEnabled(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -593,11 +593,13 @@ mithril:
 # the treasury tax is still taken first, and account eligibility plus per-pool
 # leader/member handling can still route some or all of a pool's allocation to
 # treasury or reserves, so not every lovelace necessarily reaches a delegator.
-# This changes the ledger reward calculation, so it MUST only be enabled on a
-# network where every node also enables it (a devnet or custom network).
+# This changes the ledger reward calculation, so it can only be enabled by
+# default on a devnet or custom network where every node also enables it.
 # Enabling it off-consensus, e.g. on mainnet or the public testnets, will fork
-# this node off the network. It is disabled by default.
+# this node off the network. Standard networks require the explicit unsafe
+# override below. It is disabled by default.
 #
-# CLI: --full-pot-rewards-enabled
-# Env: DINGO_FULL_POT_REWARDS_ENABLED
+# CLI: --full-pot-rewards-enabled / --unsafe-full-pot-rewards-on-standard-networks
+# Env: DINGO_FULL_POT_REWARDS_ENABLED / DINGO_UNSAFE_FULL_POT_REWARDS_ON_STANDARD_NETWORKS
 # fullPotRewardsEnabled: false
+# unsafeFullPotRewardsOnStandardNetworks: false

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -582,3 +582,22 @@ mithril:
 # Env: DINGO_PLEDGE_LEVERAGE_ENABLED / DINGO_PLEDGE_LEVERAGE
 # pledgeLeverageEnabled: false
 # pledgeLeverage: 100        # L; integer in [1, 10000]
+
+# ---
+# CIP-0163 full-pot reward distribution (experimental, consensus-affecting)
+#
+# Distributes the available reward pot (after the treasury tax) across pool
+# totals instead of returning the saturation, pledge-influence, and performance
+# residual to reserves. The per-pool base rewards are scaled up with the
+# largest-remainder method so the pool totals sum to the available pot exactly;
+# the treasury tax is still taken first, and account eligibility plus per-pool
+# leader/member handling can still route some or all of a pool's allocation to
+# treasury or reserves, so not every lovelace necessarily reaches a delegator.
+# This changes the ledger reward calculation, so it MUST only be enabled on a
+# network where every node also enables it (a devnet or custom network).
+# Enabling it off-consensus, e.g. on mainnet or the public testnets, will fork
+# this node off the network. It is disabled by default.
+#
+# CLI: --full-pot-rewards-enabled
+# Env: DINGO_FULL_POT_REWARDS_ENABLED
+# fullPotRewardsEnabled: false

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -593,8 +593,8 @@ mithril:
 # the treasury tax is still taken first, and account eligibility plus per-pool
 # leader/member handling can still route some or all of a pool's allocation to
 # treasury or reserves, so not every lovelace necessarily reaches a delegator.
-# This changes the ledger reward calculation, so it can only be enabled by
-# default on a devnet or custom network where every node also enables it.
+# This changes the ledger reward calculation, so it can only be enabled without
+# the unsafe override on a devnet or custom network where every node enables it.
 # Enabling it off-consensus, e.g. on mainnet or the public testnets, will fork
 # this node off the network. Standard networks require the explicit unsafe
 # override below. It is disabled by default.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -572,6 +572,12 @@ type Config struct {
 	// docs/plans/2026-07-19-cip50-pledge-leverage-design.md.
 	PledgeLeverageEnabled bool `yaml:"pledgeLeverageEnabled" envconfig:"DINGO_PLEDGE_LEVERAGE_ENABLED"`
 	PledgeLeverage        uint `yaml:"pledgeLeverage"        envconfig:"DINGO_PLEDGE_LEVERAGE"`
+	// CIP-0163 full-pot reward distribution. Consensus-affecting; defaults
+	// off. When enabled the entire epoch reward pot is distributed to eligible
+	// pools and delegators instead of returning the residual to reserves.
+	// Enable only on a network where every node also enables it. See
+	// docs/plans/2026-07-19-cip163-full-pot-distribution-design.md.
+	FullPotRewardsEnabled bool `yaml:"fullPotRewardsEnabled" envconfig:"DINGO_FULL_POT_REWARDS_ENABLED"`
 
 	// Leios voting configuration (experimental, leios runMode only).
 	// LeiosVoteSigningKeyFile is the path to a hex-encoded BLS12-381

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -578,6 +578,10 @@ type Config struct {
 	// Enable only on a network where every node also enables it. See
 	// docs/plans/2026-07-19-cip163-full-pot-distribution-design.md.
 	FullPotRewardsEnabled bool `yaml:"fullPotRewardsEnabled" envconfig:"DINGO_FULL_POT_REWARDS_ENABLED"`
+	// UnsafeFullPotRewardsOnStandardNetworks is an explicit unsafe override
+	// for running CIP-0163 full-pot rewards on predefined public networks.
+	// Leave false except for controlled off-consensus experiments.
+	UnsafeFullPotRewardsOnStandardNetworks bool `yaml:"unsafeFullPotRewardsOnStandardNetworks" envconfig:"DINGO_UNSAFE_FULL_POT_REWARDS_ON_STANDARD_NETWORKS"`
 
 	// Leios voting configuration (experimental, leios runMode only).
 	// LeiosVoteSigningKeyFile is the path to a hex-encoded BLS12-381

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -173,7 +173,8 @@ var flagSpecs = []flagSpec{
 	// CIP-23 minimum pool margin / minimum variable fee (consensus-affecting; default 0 = off)
 	uintFlag("MinPoolMargin", "min-pool-margin", "CIP-23 minimum pool margin in basis points [0,10000] (150 = 1.5%); 0 disables (enable only where every node also enables it)"),
 	// CIP-0163 full-pot reward distribution (consensus-affecting; default off)
-	boolFlag("FullPotRewardsEnabled", "full-pot-rewards-enabled", "enable CIP-0163 full-pot reward distribution (only where every node also enables it)"),
+	boolFlag("FullPotRewardsEnabled", "full-pot-rewards-enabled", "enable CIP-0163 full-pot reward distribution (custom networks only unless explicitly unsafe)"),
+	boolFlag("UnsafeFullPotRewardsOnStandardNetworks", "unsafe-full-pot-rewards-on-standard-networks", "allow CIP-0163 full-pot rewards on predefined standard networks; consensus-breaking unless the network has adopted it"),
 
 	// CIP-50 pledge-leverage staking rewards (consensus-affecting; default off)
 	boolFlag("PledgeLeverageEnabled", "pledge-leverage-enabled", "enable the CIP-50 pledge-leverage reward cap (only where every node also enables it)"),

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -172,6 +172,8 @@ var flagSpecs = []flagSpec{
 
 	// CIP-23 minimum pool margin / minimum variable fee (consensus-affecting; default 0 = off)
 	uintFlag("MinPoolMargin", "min-pool-margin", "CIP-23 minimum pool margin in basis points [0,10000] (150 = 1.5%); 0 disables (enable only where every node also enables it)"),
+	// CIP-0163 full-pot reward distribution (consensus-affecting; default off)
+	boolFlag("FullPotRewardsEnabled", "full-pot-rewards-enabled", "enable CIP-0163 full-pot reward distribution (only where every node also enables it)"),
 
 	// CIP-50 pledge-leverage staking rewards (consensus-affecting; default off)
 	boolFlag("PledgeLeverageEnabled", "pledge-leverage-enabled", "enable the CIP-50 pledge-leverage reward cap (only where every node also enables it)"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -111,6 +111,26 @@ func TestPledgeLeverageEnvBinding(t *testing.T) {
 	}
 }
 
+func TestFullPotRewardsEnvBinding(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_FULL_POT_REWARDS_ENABLED", "true")
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(configFile, []byte(""), 0o600); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if !cfg.FullPotRewardsEnabled {
+		t.Fatal("expected env var to enable full-pot rewards")
+	}
+}
+
 func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 	resetGlobalConfig()
 	t.Setenv("HOME", t.TempDir())

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -115,6 +115,7 @@ func TestFullPotRewardsEnvBinding(t *testing.T) {
 	resetGlobalConfig()
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DINGO_FULL_POT_REWARDS_ENABLED", "true")
+	t.Setenv("DINGO_UNSAFE_FULL_POT_REWARDS_ON_STANDARD_NETWORKS", "true")
 
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "dingo.yaml")
@@ -128,6 +129,9 @@ func TestFullPotRewardsEnvBinding(t *testing.T) {
 	}
 	if !cfg.FullPotRewardsEnabled {
 		t.Fatal("expected env var to enable full-pot rewards")
+	}
+	if !cfg.UnsafeFullPotRewardsOnStandardNetworks {
+		t.Fatal("expected env var to enable unsafe full-pot rewards override")
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
 )
 
 const (
@@ -47,6 +49,29 @@ var AcceptedChainsyncStrategies = []string{
 // resolveMithrilBackend. Kept in sync by the same parity test in
 // cmd/dingo as AcceptedChainsyncStrategies.
 var AcceptedMithrilBackends = []string{"", "v1", "v2"}
+
+// FullPotRewardsStandardNetwork reports whether network/networkMagic identifies
+// a predefined non-devnet network where CIP-0163 full-pot rewards must not be
+// enabled accidentally. Network magic is checked too, so a custom name cannot
+// opt in while still pointing at a public network magic.
+func FullPotRewardsStandardNetwork(
+	network string,
+	networkMagic uint32,
+) (string, bool) {
+	if network != "" {
+		if known, ok := ouroboros.NetworkByName(network); ok &&
+			known.Name != ouroboros.NetworkDevnet.Name {
+			return known.Name, true
+		}
+	}
+	if networkMagic != 0 {
+		if known, ok := ouroboros.NetworkByNetworkMagic(networkMagic); ok &&
+			known.Name != ouroboros.NetworkDevnet.Name {
+			return known.Name, true
+		}
+	}
+	return "", false
+}
 
 // Validate checks the fully merged configuration (defaults, YAML,
 // environment, CLI flags) for invalid values and nonsensical
@@ -326,6 +351,19 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 			"pledgeLeverage (%d) must be in [1, 10000] when pledgeLeverageEnabled",
 			c.PledgeLeverage,
 		))
+	}
+
+	if c.FullPotRewardsEnabled && !c.UnsafeFullPotRewardsOnStandardNetworks {
+		if network, ok := FullPotRewardsStandardNetwork(
+			c.Network,
+			c.NetworkMagic,
+		); ok {
+			errs = append(errs, fmt.Errorf(
+				"fullPotRewardsEnabled is not permitted on standard network %q "+
+					"without unsafeFullPotRewardsOnStandardNetworks",
+				network,
+			))
+		}
 	}
 
 	// Network identity

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -335,6 +335,45 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "full pot rewards reject standard network by name",
+			modify: func(c *Config) {
+				c.FullPotRewardsEnabled = true
+			},
+			wantErr: "fullPotRewardsEnabled is not permitted on standard network \"preview\"",
+		},
+		{
+			name: "full pot rewards reject standard network by magic",
+			modify: func(c *Config) {
+				c.Network = "private-preview-mirror"
+				c.NetworkMagic = 2
+				c.FullPotRewardsEnabled = true
+			},
+			wantErr: "fullPotRewardsEnabled is not permitted on standard network \"preview\"",
+		},
+		{
+			name: "full pot rewards allow standard network with unsafe opt-in",
+			modify: func(c *Config) {
+				c.FullPotRewardsEnabled = true
+				c.UnsafeFullPotRewardsOnStandardNetworks = true
+			},
+		},
+		{
+			name: "full pot rewards allow custom network",
+			modify: func(c *Config) {
+				c.Network = "private-net"
+				c.NetworkMagic = 9_999
+				c.FullPotRewardsEnabled = true
+			},
+		},
+		{
+			name: "full pot rewards allow devnet",
+			modify: func(c *Config) {
+				c.Network = "devnet"
+				c.NetworkMagic = 42
+				c.FullPotRewardsEnabled = true
+			},
+		},
+		{
 			name:    "network name with traversal characters",
 			modify:  func(c *Config) { c.Network = "../mainnet" },
 			wantErr: "invalid network name",

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -345,6 +345,19 @@ func LoadWithDB(
 		}
 		cardanoConfigPath = network + "/config.json"
 	}
+	if cfg.FullPotRewardsEnabled &&
+		!cfg.UnsafeFullPotRewardsOnStandardNetworks {
+		if networkName, ok := config.FullPotRewardsStandardNetwork(
+			network,
+			cfg.NetworkMagic,
+		); ok {
+			return fmt.Errorf(
+				"fullPotRewardsEnabled is not permitted on standard network %q "+
+					"without unsafeFullPotRewardsOnStandardNetworks",
+				networkName,
+			)
+		}
+	}
 
 	nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
 		cardanoConfigPath,

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -345,8 +345,27 @@ func LoadWithDB(
 		}
 		cardanoConfigPath = network + "/config.json"
 	}
+	nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
+		cardanoConfigPath,
+		network,
+		cardano.EmbeddedConfigFS,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"loading cardano node config: %w", err,
+		)
+	}
 	if cfg.FullPotRewardsEnabled &&
 		!cfg.UnsafeFullPotRewardsOnStandardNetworks {
+		var genesisNetworkMagic uint32
+		if shelleyGenesis := nodeCfg.ShelleyGenesis(); shelleyGenesis != nil {
+			genesisNetworkMagic = shelleyGenesis.NetworkMagic
+		}
+		if network == "" && cfg.NetworkMagic == 0 && genesisNetworkMagic == 0 {
+			return errors.New(
+				"fullPotRewardsEnabled requires a resolvable network identity",
+			)
+		}
 		if networkName, ok := config.FullPotRewardsStandardNetwork(
 			network,
 			cfg.NetworkMagic,
@@ -357,17 +376,19 @@ func LoadWithDB(
 				networkName,
 			)
 		}
-	}
-
-	nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
-		cardanoConfigPath,
-		network,
-		cardano.EmbeddedConfigFS,
-	)
-	if err != nil {
-		return fmt.Errorf(
-			"loading cardano node config: %w", err,
-		)
+		// The Shelley genesis drives ledger state during load, so validate its
+		// identity independently. Otherwise a custom configured name or magic
+		// could disguise a standard-network Cardano config and bypass the gate.
+		if networkName, ok := config.FullPotRewardsStandardNetwork(
+			"",
+			genesisNetworkMagic,
+		); ok {
+			return fmt.Errorf(
+				"fullPotRewardsEnabled is not permitted on standard network %q "+
+					"without unsafeFullPotRewardsOnStandardNetworks",
+				networkName,
+			)
+		}
 	}
 	logger.Debug(
 		"cardano network config",

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -386,11 +386,18 @@ func LoadWithDB(
 	// Load state
 	ls, err := newLedgerStateForLoad(
 		ledger.LedgerStateConfig{
-			Database:              db,
-			ChainManager:          cm,
-			Logger:                logger,
-			CardanoNodeConfig:     nodeCfg,
-			ValidateHistorical:    cfg.ValidateHistorical,
+			Database:           db,
+			ChainManager:       cm,
+			Logger:             logger,
+			CardanoNodeConfig:  nodeCfg,
+			ValidateHistorical: cfg.ValidateHistorical,
+			// CIP-0163 full-pot reward distribution is consensus-affecting and
+			// deterministically changes the reward state written during replay,
+			// so load must honor the same operator flag as serve mode; otherwise
+			// an import with the feature enabled would persist legacy
+			// residual-to-reserves reward state that disagrees with an enabled
+			// serve node.
+			FullPotRewardsEnabled: cfg.FullPotRewardsEnabled,
 			TrustedReplay:         true,
 			ManualBlockProcessing: true,
 			DatabaseWorkerPoolConfig: ledger.DatabaseWorkerPoolConfig{

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -507,8 +507,9 @@ func TestLoadWithDBPropagatesFullPotRewards(t *testing.T) {
 		err := LoadWithDB(
 			context.Background(),
 			&config.Config{
-				Network:               "preview",
-				FullPotRewardsEnabled: enabled,
+				Network:                                "preview",
+				FullPotRewardsEnabled:                  enabled,
+				UnsafeFullPotRewardsOnStandardNetworks: enabled,
 			},
 			logger,
 			"unused",
@@ -520,6 +521,25 @@ func TestLoadWithDBPropagatesFullPotRewards(t *testing.T) {
 
 	require.True(t, run(true).FullPotRewardsEnabled)
 	require.False(t, run(false).FullPotRewardsEnabled)
+}
+
+func TestLoadWithDBRejectsFullPotRewardsOnStandardNetwork(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	err := LoadWithDB(
+		context.Background(),
+		&config.Config{
+			Network:               "preview",
+			FullPotRewardsEnabled: true,
+		},
+		logger,
+		"unused",
+		nil,
+	)
+	require.ErrorContains(
+		t,
+		err,
+		"fullPotRewardsEnabled is not permitted on standard network \"preview\"",
+	)
 }
 
 // TestLoadCaptureFailureTrackerCleanReturnsNil verifies that a tracker with no

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -542,6 +542,42 @@ func TestLoadWithDBRejectsFullPotRewardsOnStandardNetwork(t *testing.T) {
 	)
 }
 
+func TestLoadWithDBRejectsFullPotRewardsFromCardanoConfigNetwork(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, test := range []struct {
+		name         string
+		network      string
+		networkMagic uint32
+	}{
+		{name: "configured identity unset"},
+		{
+			name:         "configured identity claims custom network",
+			network:      "devnet",
+			networkMagic: 42,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := LoadWithDB(
+				context.Background(),
+				&config.Config{
+					Network:               test.network,
+					NetworkMagic:          test.networkMagic,
+					CardanoConfig:         "preview/config.json",
+					FullPotRewardsEnabled: true,
+				},
+				logger,
+				"unused",
+				nil,
+			)
+			require.ErrorContains(
+				t,
+				err,
+				"fullPotRewardsEnabled is not permitted on standard network \"preview\"",
+			)
+		})
+	}
+}
+
 // TestLoadCaptureFailureTrackerCleanReturnsNil verifies that a tracker with no
 // recorded failures reports success, so a clean load is never turned into an
 // error.

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -483,6 +483,45 @@ func TestLoadWithDBWiresEpochBoundarySnapshotHook(t *testing.T) {
 	require.True(t, captured.ManualBlockProcessing)
 }
 
+// TestLoadWithDBPropagatesFullPotRewards verifies that the CIP-0163 full-pot
+// feature gate flows from the loaded config into the load-mode ledger config,
+// so `dingo load` computes the same reward state as an enabled serve node
+// instead of the legacy residual-to-reserves behavior.
+func TestLoadWithDBPropagatesFullPotRewards(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stopAfterCapture := errors.New("stop after ledger config capture")
+
+	run := func(enabled bool) ledger.LedgerStateConfig {
+		db := newTestDB(t)
+		var captured ledger.LedgerStateConfig
+		oldNewLedgerStateForLoad := newLedgerStateForLoad
+		newLedgerStateForLoad = func(
+			cfg ledger.LedgerStateConfig,
+		) (*ledger.LedgerState, error) {
+			captured = cfg
+			return nil, stopAfterCapture
+		}
+		t.Cleanup(func() {
+			newLedgerStateForLoad = oldNewLedgerStateForLoad
+		})
+		err := LoadWithDB(
+			context.Background(),
+			&config.Config{
+				Network:               "preview",
+				FullPotRewardsEnabled: enabled,
+			},
+			logger,
+			"unused",
+			db,
+		)
+		require.ErrorIs(t, err, stopAfterCapture)
+		return captured
+	}
+
+	require.True(t, run(true).FullPotRewardsEnabled)
+	require.False(t, run(false).FullPotRewardsEnabled)
+}
+
 // TestLoadCaptureFailureTrackerCleanReturnsNil verifies that a tracker with no
 // recorded failures reports success, so a clean load is never turned into an
 // error.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -437,6 +437,9 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			),
 			// CIP-0163 full-pot reward distribution (consensus-affecting)
 			dingo.WithFullPotRewards(cfg.FullPotRewardsEnabled),
+			dingo.WithUnsafeFullPotRewardsOnStandardNetworks(
+				cfg.UnsafeFullPotRewardsOnStandardNetworks,
+			),
 			// Block production (SPO mode)
 			dingo.WithBlockProducer(cfg.BlockProducer),
 			dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -435,6 +435,8 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				cfg.PledgeLeverageEnabled,
 				cfg.PledgeLeverage,
 			),
+			// CIP-0163 full-pot reward distribution (consensus-affecting)
+			dingo.WithFullPotRewards(cfg.FullPotRewardsEnabled),
 			// Block production (SPO mode)
 			dingo.WithBlockProducer(cfg.BlockProducer),
 			dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -712,6 +712,17 @@ func precomputedRewardPoolRewardsMatchInputs(
 		}
 		poolOutputByKey[string(output.PoolKeyHash)] = output
 	}
+	// Re-derive each pool's base reward B_i and pair it with its persisted
+	// output. The pool ID is not needed to compute the reward: it only labels
+	// the result and the pool keys were already validated upstream by
+	// validateRewardCalculatorInputs.
+	type verifyPool struct {
+		key    string
+		output *models.RewardPoolOutput
+		pool   rewards.Pool
+		base   uint64
+	}
+	verifyPools := make([]verifyPool, 0, len(poolInputs))
 	for _, input := range poolInputs {
 		if input == nil {
 			return false, nil
@@ -721,18 +732,17 @@ func precomputedRewardPoolRewardsMatchInputs(
 		if !ok {
 			return false, nil
 		}
-		// The pool ID is not needed here: it only labels the result and the pool
-		// keys were already validated upstream by validateRewardCalculatorInputs.
+		pool := rewards.Pool{
+			Margin:         ratOrZero(input.Margin),
+			Pledge:         uint64(input.Pledge),
+			Cost:           uint64(input.Cost),
+			DelegatedStake: uint64(input.DelegatedStake),
+			OwnerStake:     uint64(input.OwnerStake),
+			BlocksProduced: blockCounts[key],
+			TotalBlocks:    totalBlocks,
+		}
 		reward, err := rewards.CalculatePoolReward(
-			rewards.Pool{
-				Margin:         ratOrZero(input.Margin),
-				Pledge:         uint64(input.Pledge),
-				Cost:           uint64(input.Cost),
-				DelegatedStake: uint64(input.DelegatedStake),
-				OwnerStake:     uint64(input.OwnerStake),
-				BlocksProduced: blockCounts[key],
-				TotalBlocks:    totalBlocks,
-			},
+			pool,
 			availableRewards,
 			totalActiveStake,
 			totalCirculation,
@@ -742,8 +752,49 @@ func precomputedRewardPoolRewardsMatchInputs(
 		if err != nil {
 			return false, err
 		}
-		if uint64(output.TotalReward) != reward.PoolReward ||
-			uint64(output.LeaderReward) != reward.LeaderReward {
+		verifyPools = append(verifyPools, verifyPool{
+			key:    key,
+			output: output,
+			pool:   pool,
+			base:   reward.PoolReward,
+		})
+	}
+	// CIP-0163 full pot: the persisted TotalReward is the base reward scaled up
+	// so the per-pool totals sum to the entire available pot. Reproduce that
+	// apportionment in the same canonical order Calculate uses (ascending pool
+	// key hash, which equals ascending pool ID string), then re-derive the
+	// leader split from the scaled total. When the gate is off the scaled total
+	// is the base total, so this reduces to verifying against
+	// CalculatePoolReward's base pool and leader rewards.
+	scaled := make([]uint64, len(verifyPools))
+	for i := range verifyPools {
+		scaled[i] = verifyPools[i].base
+	}
+	if params.FullPotRewardsEnabled {
+		sort.Slice(verifyPools, func(i, j int) bool {
+			return verifyPools[i].key < verifyPools[j].key
+		})
+		baseTotals := make([]uint64, len(verifyPools))
+		for i := range verifyPools {
+			baseTotals[i] = verifyPools[i].base
+		}
+		scaled = rewards.ApportionFullPot(baseTotals, availableRewards)
+	}
+	for i := range verifyPools {
+		vp := verifyPools[i]
+		leader, err := rewards.LeaderRewardWithParameters(
+			scaled[i],
+			vp.pool.Cost,
+			vp.pool.Margin,
+			vp.pool.OwnerStake,
+			vp.pool.DelegatedStake,
+			params,
+		)
+		if err != nil {
+			return false, err
+		}
+		if uint64(vp.output.TotalReward) != scaled[i] ||
+			uint64(vp.output.LeaderReward) != leader {
 			return false, nil
 		}
 	}
@@ -2195,6 +2246,10 @@ func (ls *LedgerState) rewardParameters(
 	// the on-chain-derived parameters. This is the single chokepoint feeding
 	// both the boundary apply and the async precompute path, so both agree.
 	applyPledgeLeverageConfig(&params, ls.config)
+	// CIP-0163: overlay the operator-configured full-pot feature gate onto the
+	// on-chain-derived parameters. This is the single chokepoint feeding both
+	// the boundary apply and the async precompute path, so both agree.
+	applyFullPotConfig(&params, ls.config)
 	if params.MaxLovelaceSupply < uint64(pots.Reserves) {
 		return nil, rewards.Parameters{}, nil, fmt.Errorf(
 			"invalid reward pots: reserves %d exceed max supply %d",
@@ -2203,6 +2258,14 @@ func (ls *LedgerState) rewardParameters(
 		)
 	}
 	return pparams, params, performanceDecentralization, nil
+}
+
+// applyFullPotConfig copies the CIP-0163 full-pot feature gate from the ledger
+// config onto the reward parameters. When disabled the parameters are left with
+// FullPotRewardsEnabled false, preserving the pre-CIP-0163 residual-to-reserves
+// behavior.
+func applyFullPotConfig(params *rewards.Parameters, cfg LedgerStateConfig) {
+	params.FullPotRewardsEnabled = cfg.FullPotRewardsEnabled
 }
 
 func (ls *LedgerState) rewardBlockCounts(

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -4775,3 +4775,174 @@ func TestLedgerStateMinPoolMargin(t *testing.T) {
 	ls.config.MinPoolMargin = 150
 	require.Zero(t, big.NewRat(150, 10_000).Cmp(ls.MinPoolMargin()))
 }
+
+// --- CIP-0163 full-pot reward distribution -------------------------------
+
+func TestApplyFullPotConfigEnabled(t *testing.T) {
+	params := rewards.Parameters{}
+	applyFullPotConfig(&params, LedgerStateConfig{FullPotRewardsEnabled: true})
+	require.True(t, params.FullPotRewardsEnabled)
+}
+
+func TestApplyFullPotConfigDisabled(t *testing.T) {
+	params := rewards.Parameters{FullPotRewardsEnabled: true}
+	applyFullPotConfig(&params, LedgerStateConfig{FullPotRewardsEnabled: false})
+	require.False(t, params.FullPotRewardsEnabled)
+}
+
+// TestPrecomputedRewardPoolRewardsMatchInputsFullPot verifies that under
+// CIP-0163 full pot the reuse verifier reproduces the pot-filling apportionment:
+// it accepts persisted totals equal to the apportioned pool rewards (with the
+// leader split re-derived from the scaled total), and rejects both the
+// unscaled base totals and any perturbed total or leader reward. With the gate
+// off the same apportioned totals are rejected because the disabled path
+// expects each pool's base reward.
+func TestPrecomputedRewardPoolRewardsMatchInputsFullPot(t *testing.T) {
+	keyA := rewardCalcHash(0x51)
+	keyB := rewardCalcHash(0x52)
+
+	params := rewards.Parameters{
+		Decentralization:      new(big.Rat),
+		OptimalPoolCount:      10,
+		PledgeInfluence:       big.NewRat(1, 2),
+		FullPotRewardsEnabled: true,
+	}
+	const (
+		availableRewards = uint64(1_000_000)
+		totalActiveStake = uint64(1_000)
+		totalCirculation = uint64(10_000)
+		totalBlocks      = uint64(10)
+	)
+	blockCounts := map[string]uint64{
+		string(keyA): 6,
+		string(keyB): 4,
+	}
+	poolInputs := []*models.RewardPoolInput{
+		{
+			PoolKeyHash:    keyA,
+			Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+			Pledge:         100,
+			Cost:           1_000,
+			DelegatedStake: 600,
+			OwnerStake:     100,
+		},
+		{
+			PoolKeyHash:    keyB,
+			Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+			Pledge:         50,
+			Cost:           1_000,
+			DelegatedStake: 400,
+			OwnerStake:     50,
+		},
+	}
+
+	baseFor := func(in *models.RewardPoolInput) uint64 {
+		pr, err := rewards.CalculatePoolReward(
+			rewards.Pool{
+				Margin:         big.NewRat(1, 10),
+				Pledge:         uint64(in.Pledge),
+				Cost:           uint64(in.Cost),
+				DelegatedStake: uint64(in.DelegatedStake),
+				OwnerStake:     uint64(in.OwnerStake),
+				BlocksProduced: blockCounts[string(in.PoolKeyHash)],
+				TotalBlocks:    totalBlocks,
+			},
+			availableRewards,
+			totalActiveStake,
+			totalCirculation,
+			totalBlocks,
+			params,
+		)
+		require.NoError(t, err)
+		return pr.PoolReward
+	}
+	baseA := baseFor(poolInputs[0])
+	baseB := baseFor(poolInputs[1])
+	scaled := rewards.ApportionFullPot([]uint64{baseA, baseB}, availableRewards)
+	require.Equal(t, availableRewards, scaled[0]+scaled[1])
+	require.Greater(t, scaled[0], baseA)
+	require.Greater(t, scaled[1], baseB)
+
+	leaderA, err := rewards.LeaderReward(
+		scaled[0], 1_000, big.NewRat(1, 10), 100, 600,
+	)
+	require.NoError(t, err)
+	leaderB, err := rewards.LeaderReward(
+		scaled[1], 1_000, big.NewRat(1, 10), 50, 400,
+	)
+	require.NoError(t, err)
+
+	check := func(p rewards.Parameters, outs []*models.RewardPoolOutput) bool {
+		ok, err := precomputedRewardPoolRewardsMatchInputs(
+			poolInputs,
+			outs,
+			blockCounts,
+			availableRewards,
+			totalActiveStake,
+			totalCirculation,
+			totalBlocks,
+			p,
+		)
+		require.NoError(t, err)
+		return ok
+	}
+
+	apportioned := []*models.RewardPoolOutput{
+		{
+			PoolKeyHash:  keyA,
+			TotalReward:  types.Uint64(scaled[0]),
+			LeaderReward: types.Uint64(leaderA),
+		},
+		{
+			PoolKeyHash:  keyB,
+			TotalReward:  types.Uint64(scaled[1]),
+			LeaderReward: types.Uint64(leaderB),
+		},
+	}
+	base := []*models.RewardPoolOutput{
+		{PoolKeyHash: keyA, TotalReward: types.Uint64(baseA)},
+		{PoolKeyHash: keyB, TotalReward: types.Uint64(baseB)},
+	}
+
+	// Gate on: the apportioned totals with re-derived leader rewards are
+	// accepted.
+	require.True(t, check(params, apportioned))
+
+	// Gate on: the unscaled base totals are rejected.
+	require.False(t, check(params, base))
+
+	// Gate on: a total that is not the apportioned value is rejected.
+	require.False(t, check(params, []*models.RewardPoolOutput{
+		{
+			PoolKeyHash:  keyA,
+			TotalReward:  types.Uint64(scaled[0] + 1),
+			LeaderReward: types.Uint64(leaderA),
+		},
+		{
+			PoolKeyHash:  keyB,
+			TotalReward:  types.Uint64(scaled[1]),
+			LeaderReward: types.Uint64(leaderB),
+		},
+	}))
+
+	// Gate on: a leader reward not re-derivable from the scaled total is
+	// rejected.
+	require.False(t, check(params, []*models.RewardPoolOutput{
+		{
+			PoolKeyHash:  keyA,
+			TotalReward:  types.Uint64(scaled[0]),
+			LeaderReward: types.Uint64(leaderA + 1),
+		},
+		{
+			PoolKeyHash:  keyB,
+			TotalReward:  types.Uint64(scaled[1]),
+			LeaderReward: types.Uint64(leaderB),
+		},
+	}))
+
+	// Gate off: the apportioned totals are rejected because the disabled path
+	// expects each pool's base reward.
+	paramsOff := params
+	paramsOff.FullPotRewardsEnabled = false
+	require.False(t, check(paramsOff, apportioned))
+}

--- a/ledger/rewards/rewards.go
+++ b/ledger/rewards/rewards.go
@@ -129,6 +129,14 @@ type Parameters struct {
 	// pool's reward-eligible stake plateaus. It is used only when
 	// PledgeLeverageEnabled is true and must be in the range [1, 10000].
 	PledgeLeverage *big.Rat
+	// FullPotRewardsEnabled turns on CIP-0163 full-pot reward distribution: the
+	// entire available reward pot is apportioned across pools that earned a base
+	// reward (largest-remainder scaling of each pool's base reward), instead of
+	// returning the saturation/pledge/performance residual to reserves. It is a
+	// consensus-affecting feature gate that defaults off; enable it only on a
+	// network where every node also enables it. When off, Calculate is
+	// byte-for-byte identical to the pre-CIP-0163 calculation.
+	FullPotRewardsEnabled bool
 }
 
 // pledgeLeverageCap returns L for the CIP-50 pledge-leverage cap when the
@@ -309,7 +317,12 @@ func Calculate(pots Pots, snapshot Snapshot, params Parameters) (*Result, error)
 		return pools[i].ID.String() < pools[j].ID.String()
 	})
 
-	for _, pool := range pools {
+	// Pass 1: compute each pool's base reward B_i (the pre-CIP-0163 pool
+	// reward) in canonical pool-ID order, accumulating the base totals used by
+	// the CIP-0163 full-pot apportionment below.
+	poolRewards := make([]PoolReward, len(pools))
+	baseTotals := make([]uint64, len(pools))
+	for i, pool := range pools {
 		poolReward, err := calculatePoolRewards(
 			pool,
 			availableRewards,
@@ -325,6 +338,47 @@ func Calculate(pots Pots, snapshot Snapshot, params Parameters) (*Result, error)
 				err,
 			)
 		}
+		poolRewards[i] = poolReward
+		baseTotals[i] = poolReward.PoolReward
+	}
+
+	// CIP-0163: when full-pot distribution is enabled, scale the base rewards
+	// up with the largest-remainder method so the per-pool totals sum to the
+	// entire available pot R, then re-derive each pool's leader reward from its
+	// scaled total. When no pool earned a base reward (W == 0) ApportionFullPot
+	// returns the base totals unchanged, so the whole pot falls through to
+	// reserves via the reconciliation below, matching the disabled path. The
+	// leader/member split reuses the same checked helpers as the disabled path,
+	// so the two paths cannot drift.
+	if params.FullPotRewardsEnabled {
+		scaled := ApportionFullPot(baseTotals, availableRewards)
+		for i := range poolRewards {
+			if scaled[i] == poolRewards[i].PoolReward {
+				continue
+			}
+			poolRewards[i].PoolReward = scaled[i]
+			leader, err := leaderRewardChecked(
+				scaled[i],
+				pools[i].Cost,
+				params.effectiveMargin(pools[i].Margin),
+				pools[i].OwnerStake,
+				pools[i].DelegatedStake,
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"calculate leader reward for pool %s: %w",
+					pools[i].ID.String(),
+					err,
+				)
+			}
+			poolRewards[i].LeaderReward = leader
+		}
+	}
+
+	// Pass 2: credit each pool's leader and member rewards from its (possibly
+	// scaled) pool total, in the same order as the disabled path.
+	for i, pool := range pools {
+		poolReward := poolRewards[i]
 		result.PoolRewards = append(result.PoolRewards, poolReward)
 		result.poolAccounted = append(result.poolAccounted, 0)
 
@@ -1006,13 +1060,24 @@ func calculatePoolRewards(
 	return ret, nil
 }
 
-// CalculatePoolReward re-derives a single pool's reward fields (OptimalReward,
-// PoolReward, LeaderReward, ApparentPerformance) from frozen snapshot inputs
-// using the same arithmetic Calculate applies per pool. It lets callers
-// validate persisted pool reward outputs against the inputs instead of trusting
-// the stored values. Member distribution (MemberRewardTotal, Undistributed) is
-// not derived here because it depends on per-delegator eligibility, not the
-// pool-level reward that leader and member payouts are computed from.
+// CalculatePoolReward re-derives a single pool's BASE reward fields
+// (OptimalReward, PoolReward, LeaderReward, ApparentPerformance) from frozen
+// snapshot inputs using the same arithmetic Calculate applies per pool. It lets
+// callers validate persisted pool reward outputs against the inputs instead of
+// trusting the stored values. Member distribution (MemberRewardTotal,
+// Undistributed) is not derived here because it depends on per-delegator
+// eligibility, not the pool-level reward that leader and member payouts are
+// computed from.
+//
+// The returned PoolReward is always the base (pre-CIP-0163) reward: it is a
+// single-pool computation and has no visibility into the pool set, so it cannot
+// know the full-pot apportionment. When Parameters.FullPotRewardsEnabled is set,
+// Calculate scales these base rewards across the whole pot, so its persisted
+// PoolReward/LeaderReward differ from this function's output. A caller
+// validating full-pot outputs must first collect every pool's base PoolReward
+// from this function, apply ApportionFullPot to obtain each pool's scaled total,
+// and then re-derive the leader split from that scaled total with LeaderReward
+// (this is exactly what precomputedRewardPoolRewardsMatchInputs does).
 //
 // It validates the pool-reward parameters it dereferences (Decentralization and
 // PledgeInfluence) before computing, so malformed snapshot/config data yields an
@@ -1036,6 +1101,72 @@ func CalculatePoolReward(
 		totalBlocks,
 		params,
 	)
+}
+
+// ApportionFullPot implements the CIP-0163 full-pot distribution: it scales each
+// pool's base reward B_i up so the per-pool totals sum to the entire available
+// reward pot R exactly, using the largest-remainder (Hamilton) method on
+// integer lovelace. baseRewards holds each pool's B_i in the caller's canonical
+// pool ordering (Calculate sorts pools by ID ascending; the precompute verifier
+// sorts by key hash ascending, which is the same order). availableRewards is R.
+//
+// f_pool_exact(i) = B_i * R / W, where W = sum(B_i). Each pool receives
+// floor(B_i * R / W); the D = R - sum(floor) leftover lovelace go to the D pools
+// with the largest remainders (B_i * R) mod W, ties broken by ascending index
+// (i.e. ascending pool ID, matching the caller's sort). All arithmetic is
+// big.Int, so there is no floating point and no intermediate overflow; the
+// result sums to exactly R.
+//
+// If W == 0 (no pool earned a base reward) it returns a copy of baseRewards
+// unchanged and leaves the residual for the caller to return to reserves; the
+// caller is expected to guard this case explicitly.
+func ApportionFullPot(baseRewards []uint64, availableRewards uint64) []uint64 {
+	scaled := make([]uint64, len(baseRewards))
+	w := new(big.Int)
+	for _, b := range baseRewards {
+		w.Add(w, new(big.Int).SetUint64(b))
+	}
+	if w.Sign() == 0 {
+		copy(scaled, baseRewards)
+		return scaled
+	}
+	r := new(big.Int).SetUint64(availableRewards)
+	remainders := make([]*big.Int, len(baseRewards))
+	allocated := new(big.Int)
+	for i, b := range baseRewards {
+		// prod = B_i * R; q = floor(prod / W); rem = prod mod W.
+		prod := new(big.Int).Mul(new(big.Int).SetUint64(b), r)
+		q := new(big.Int)
+		rem := new(big.Int)
+		q.QuoRem(prod, w, rem)
+		// q <= B_i*R/W <= R (B_i <= W), so it fits uint64.
+		scaled[i] = q.Uint64()
+		remainders[i] = rem
+		allocated.Add(allocated, q)
+	}
+	// D = R - sum(floor); 0 <= D <= number of pools with B_i > 0.
+	d := new(big.Int).Sub(r, allocated)
+	if d.Sign() <= 0 {
+		return scaled
+	}
+	order := make([]int, len(baseRewards))
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(a, b int) bool {
+		ia, ib := order[a], order[b]
+		if cmp := remainders[ia].Cmp(remainders[ib]); cmp != 0 {
+			// Larger remainder first.
+			return cmp > 0
+		}
+		// Tie-break by ascending index (ascending pool ID).
+		return ia < ib
+	})
+	extra := int(d.Int64())
+	for k := 0; k < extra && k < len(order); k++ {
+		scaled[order[k]]++
+	}
+	return scaled
 }
 
 func expectedBlocks(params Parameters) *big.Rat {
@@ -1259,6 +1390,53 @@ func MemberRewardWithParameters(
 		cost,
 		params.effectiveMargin(margin),
 		memberStake,
+		poolStake,
+	)
+}
+
+// LeaderReward computes a pool operator's leader reward from the pool's total
+// reward, fixed cost, margin, the owner (pledge) stake, and the pool's total
+// delegated stake, using the plainly normalized margin (no CIP-23 floor). It is
+// the leader-side sibling of MemberReward. Callers that must match Calculate's
+// authoritative split when the CIP-23 minimum pool margin may be active should
+// use LeaderRewardWithParameters instead.
+func LeaderReward(
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	ownerStake uint64,
+	poolStake uint64,
+) (uint64, error) {
+	return leaderRewardChecked(
+		poolReward,
+		cost,
+		normalizedMargin(margin),
+		ownerStake,
+		poolStake,
+	)
+}
+
+// LeaderRewardWithParameters computes a leader reward using the same effective
+// pool margin as Calculate, applying the CIP-23 minimum pool margin from params
+// when one is enabled. It is the leader-side sibling of MemberRewardWithParameters.
+// Under CIP-0163 full-pot distribution the pool total is the apportioned reward
+// rather than the base reward, so the precompute-reuse validator computes the
+// leader split from the scaled total via this form; using it (rather than the
+// unfloored LeaderReward) keeps the validator consistent with Calculate when both
+// CIP-23 and full-pot are active.
+func LeaderRewardWithParameters(
+	poolReward uint64,
+	cost uint64,
+	margin *big.Rat,
+	ownerStake uint64,
+	poolStake uint64,
+	params Parameters,
+) (uint64, error) {
+	return leaderRewardChecked(
+		poolReward,
+		cost,
+		params.effectiveMargin(margin),
+		ownerStake,
 		poolStake,
 	)
 }

--- a/ledger/rewards/rewards_test.go
+++ b/ledger/rewards/rewards_test.go
@@ -2175,3 +2175,233 @@ func TestCalculateAllowsPledgeLeverageAtBounds(t *testing.T) {
 	_, err = leverageCalc(100, 100, true, big.NewRat(10_000, 1))
 	require.NoError(t, err)
 }
+
+// --- CIP-0163 full-pot reward distribution -------------------------------
+
+// TestApportionFullPotSumsToTotal exercises the largest-remainder core: three
+// equal base rewards over a pot that does not divide evenly. floor(10*1/3)=3
+// for each (sum 9), leaving D=1 lovelace; the remainders are all equal, so the
+// tie breaks to the lowest index.
+func TestApportionFullPotSumsToTotal(t *testing.T) {
+	require.Equal(t, []uint64{4, 3, 3}, ApportionFullPot([]uint64{1, 1, 1}, 10))
+}
+
+// TestApportionFullPotLargestRemainderWins: base [2,1,1] over R=10, W=4 gives
+// floors [5,2,2] (sum 9, D=1). Remainders are [0,2,2]; the +1 lovelace lands on
+// the largest remainder, and the tie between indices 1 and 2 breaks to 1.
+func TestApportionFullPotLargestRemainderWins(t *testing.T) {
+	require.Equal(t, []uint64{5, 3, 2}, ApportionFullPot([]uint64{2, 1, 1}, 10))
+}
+
+// TestApportionFullPotNoRemainder: when R divides exactly by W there is no
+// leftover lovelace to allocate.
+func TestApportionFullPotNoRemainder(t *testing.T) {
+	require.Equal(t, []uint64{10}, ApportionFullPot([]uint64{3}, 10))
+	require.Equal(t, []uint64{4, 6}, ApportionFullPot([]uint64{2, 3}, 10))
+}
+
+// TestApportionFullPotZeroWeightUnchanged: W==0 returns the base rewards
+// unchanged (all zero); the caller returns the pot to reserves.
+func TestApportionFullPotZeroWeightUnchanged(t *testing.T) {
+	require.Equal(t, []uint64{0, 0}, ApportionFullPot([]uint64{0, 0}, 10))
+}
+
+// TestApportionFullPotBigProductNoOverflow: B_i*R overflows uint64 (~1.8e19);
+// the big.Int arithmetic keeps it exact.
+func TestApportionFullPotBigProductNoOverflow(t *testing.T) {
+	const b = uint64(10_000_000_000_000_000) // 1e16
+	require.Equal(
+		t,
+		[]uint64{b, b},
+		ApportionFullPot([]uint64{b, b}, 20_000_000_000_000_000),
+	)
+}
+
+func fullPotTwoPoolSnapshot() Snapshot {
+	ownerA := testCredential(0, 0x11)
+	memberA := testCredential(0, 0x12)
+	ownerB := testCredential(0, 0x21)
+	memberB := testCredential(0, 0x22)
+	return Snapshot{
+		TotalActiveStake: 1_000,
+		Pools: []Pool{
+			{
+				ID:                      testPoolID(0x01),
+				RewardAccount:           testCredential(0, 0x13),
+				Margin:                  big.NewRat(1, 10),
+				Pledge:                  100,
+				Cost:                    1_000,
+				DelegatedStake:          600,
+				OwnerStake:              100,
+				BlocksProduced:          6,
+				TotalBlocks:             10,
+				RewardAccountRegistered: true,
+				RewardAccountEligible:   true,
+				Owners:                  map[Credential]struct{}{ownerA: {}},
+				Delegators: []Delegator{
+					{Credential: ownerA, Stake: 100, Registered: true, Eligible: true},
+					{Credential: memberA, Stake: 500, Registered: true, Eligible: true},
+				},
+			},
+			{
+				ID:                      testPoolID(0x02),
+				RewardAccount:           testCredential(0, 0x23),
+				Margin:                  big.NewRat(1, 10),
+				Pledge:                  50,
+				Cost:                    1_000,
+				DelegatedStake:          400,
+				OwnerStake:              50,
+				BlocksProduced:          4,
+				TotalBlocks:             10,
+				RewardAccountRegistered: true,
+				RewardAccountEligible:   true,
+				Owners:                  map[Credential]struct{}{ownerB: {}},
+				Delegators: []Delegator{
+					{Credential: ownerB, Stake: 50, Registered: true, Eligible: true},
+					{Credential: memberB, Stake: 350, Registered: true, Eligible: true},
+				},
+			},
+		},
+	}
+}
+
+func fullPotCalc(t *testing.T, enabled bool) *Result {
+	t.Helper()
+	params := testParams()
+	params.FullPotRewardsEnabled = enabled
+	result, err := Calculate(
+		Pots{Reserves: 100_000_000},
+		fullPotTwoPoolSnapshot(),
+		params,
+	)
+	require.NoError(t, err)
+	return result
+}
+
+// TestCalculateFullPotDisabledMatchesBaseTotals anchors the shared two-pool
+// scenario: with the gate off each pool earns its pre-CIP-0163 base reward.
+func TestCalculateFullPotDisabledMatchesBaseTotals(t *testing.T) {
+	off := fullPotCalc(t, false)
+	require.Equal(t, uint64(41_866), off.PoolRewards[0].PoolReward)
+	require.Equal(t, uint64(27_283), off.PoolRewards[1].PoolReward)
+}
+
+// TestCalculateFullPotDistributesEntirePot checks that the gate-on pool totals
+// are exactly the Hamilton apportionment of the whole pot by base reward, never
+// reduce a pool below its base, and sum to the entire available pot, whereas the
+// disabled path leaves a large pot-scaling residual.
+func TestCalculateFullPotDistributesEntirePot(t *testing.T) {
+	off := fullPotCalc(t, false)
+	on := fullPotCalc(t, true)
+	require.Equal(t, off.AvailableRewards, on.AvailableRewards)
+
+	baseTotals := make([]uint64, len(off.PoolRewards))
+	for i, pr := range off.PoolRewards {
+		baseTotals[i] = pr.PoolReward
+	}
+	expected := ApportionFullPot(baseTotals, off.AvailableRewards)
+
+	var onTotal, offTotal uint64
+	for i := range on.PoolRewards {
+		require.Equal(t, expected[i], on.PoolRewards[i].PoolReward,
+			"pool %d scaled total", i)
+		require.GreaterOrEqual(t, on.PoolRewards[i].PoolReward, baseTotals[i],
+			"full pot must never reduce a pool reward")
+		onTotal += on.PoolRewards[i].PoolReward
+		offTotal += off.PoolRewards[i].PoolReward
+	}
+	require.Equal(t, on.AvailableRewards, onTotal,
+		"gate on: pool totals sum to the entire pot")
+	require.Less(t, offTotal, off.AvailableRewards,
+		"gate off: a pot-scaling residual remains")
+}
+
+// TestCalculateFullPotResidualIsOnlySplitRounding checks that the only reserves
+// inflow left under full pot is the per-pool leader/member split rounding, far
+// below the disabled path's pot-scaling residual.
+func TestCalculateFullPotResidualIsOnlySplitRounding(t *testing.T) {
+	off := fullPotCalc(t, false)
+	on := fullPotCalc(t, true)
+	accounted := on.EffectiveRewards + on.Unspendable
+	require.Equal(t, on.AvailableRewards-accounted, on.Undistributed)
+	require.Less(t, on.Undistributed, off.Undistributed)
+	require.Less(t, on.UpdatedPots.Reserves, off.UpdatedPots.Reserves)
+}
+
+// TestCalculateFullPotNoBaseRewardFallsBackToReserves: with no pool earning a
+// base reward (pledge exceeds owner stake => disqualified, W==0), the gate-on
+// result is identical to the disabled path — the whole pot returns to reserves.
+func TestCalculateFullPotNoBaseRewardFallsBackToReserves(t *testing.T) {
+	owner := testCredential(0, 0x11)
+	snap := Snapshot{
+		TotalActiveStake: 600,
+		Pools: []Pool{
+			{
+				ID:             testPoolID(0x01),
+				RewardAccount:  testCredential(0, 0x13),
+				Margin:         big.NewRat(1, 10),
+				Pledge:         200, // exceeds OwnerStake => disqualified
+				Cost:           1_000,
+				DelegatedStake: 600,
+				OwnerStake:     100,
+				BlocksProduced: 10,
+				TotalBlocks:    10,
+				Owners:         map[Credential]struct{}{owner: {}},
+				Delegators: []Delegator{
+					{Credential: owner, Stake: 100, Registered: true, Eligible: true},
+				},
+			},
+		},
+	}
+	run := func(enabled bool) *Result {
+		params := testParams()
+		params.FullPotRewardsEnabled = enabled
+		r, err := Calculate(Pots{Reserves: 100_000_000}, snap, params)
+		require.NoError(t, err)
+		return r
+	}
+	on := run(true)
+	off := run(false)
+	require.Empty(t, on.AccountRewards)
+	require.Equal(t, on.AvailableRewards, on.Undistributed)
+	require.Equal(t, off.Undistributed, on.Undistributed)
+	require.Equal(t, off.UpdatedPots, on.UpdatedPots)
+}
+
+// TestCalculateFullPotComposesWithMinPoolMargin verifies that when BOTH CIP-0163
+// full-pot distribution and the CIP-23 minimum pool margin are enabled, each
+// pool's full-pot-scaled leader reward is computed with the CIP-23 effective
+// (floored) margin, not the pool's unfloored registered margin. This guards the
+// composition of the two independent reward features (a below-floor pool must
+// have its scaled leader split shifted toward the operator by the floor).
+func TestCalculateFullPotComposesWithMinPoolMargin(t *testing.T) {
+	snap := fullPotTwoPoolSnapshot() // pools register margin 1/10, IDs 0x01 < 0x02
+	params := testParams()
+	params.FullPotRewardsEnabled = true
+	params.MinPoolMargin = big.NewRat(1, 5) // 20% floor, above the pools' 10% margin
+
+	result, err := Calculate(Pots{Reserves: 100_000_000}, snap, params)
+	require.NoError(t, err)
+	require.Len(t, result.PoolRewards, len(snap.Pools))
+
+	for i := range result.PoolRewards {
+		pr := result.PoolRewards[i]
+		pool := snap.Pools[i] // Calculate sorts by pool ID; snapshot is already in that order
+		floored, err := LeaderRewardWithParameters(
+			pr.PoolReward, pool.Cost, pool.Margin,
+			pool.OwnerStake, pool.DelegatedStake, params,
+		)
+		require.NoError(t, err)
+		unfloored, err := LeaderReward(
+			pr.PoolReward, pool.Cost, pool.Margin,
+			pool.OwnerStake, pool.DelegatedStake,
+		)
+		require.NoError(t, err)
+		// The credited leader reward uses the floored (effective) margin.
+		require.Equal(t, floored, pr.LeaderReward,
+			"pool %d scaled leader must use the CIP-23 effective margin", i)
+		// And the floor actually shifts the split (leader gets more than at 1/10).
+		require.Greater(t, floored, unfloored,
+			"pool %d floor must raise the leader share above the registered margin", i)
+	}
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -462,7 +462,15 @@ type LedgerStateConfig struct {
 	// PledgeLeverage is L, the CIP-50 maximum ratio of total stake to pledge,
 	// in the range [1, 10000]. It is used only when PledgeLeverageEnabled is
 	// true.
-	PledgeLeverage           uint
+	PledgeLeverage uint
+	// FullPotRewardsEnabled turns on CIP-0163 full-pot reward distribution: the
+	// entire epoch reward pot is apportioned across pools that earned a base
+	// reward instead of returning the saturation/pledge/performance residual to
+	// reserves. It is a consensus-affecting feature gate that defaults false;
+	// enable it only on a network where every node also enables it (mainnet and
+	// the public testnets keep it off). Like the CIP-50 pledge-leverage gate it
+	// is set from operator config in node.go, not derived from the network.
+	FullPotRewardsEnabled    bool
 	ValidateHistorical       bool
 	EnableDijkstra           bool
 	StartInDijkstra          bool

--- a/node.go
+++ b/node.go
@@ -366,8 +366,12 @@ func (n *Node) Run(ctx context.Context) error {
 			// CIP-50 pledge-leverage reward cap. Operator-set (not derived from
 			// the network) and off by default; enable only where every node
 			// also enables it.
-			PledgeLeverageEnabled:      n.config.pledgeLeverageEnabled,
-			PledgeLeverage:             n.config.pledgeLeverage,
+			PledgeLeverageEnabled: n.config.pledgeLeverageEnabled,
+			PledgeLeverage:        n.config.pledgeLeverage,
+			// CIP-0163 full-pot reward distribution. Operator-set (not derived
+			// from the network) and off by default; enable only where every node
+			// also enables it.
+			FullPotRewardsEnabled:      n.config.fullPotRewardsEnabled,
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
 			PeersWithBlockFunc: func(
 				origin ouroboros.ConnectionId,


### PR DESCRIPTION
This is the first half of CIP-163 implementation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CIP-163 full-pot reward distribution behind an operator gate with strict safety checks. When enabled, the entire epoch pot is apportioned to eligible pools using largest-remainder scaling; `dingo load` enforces the same gate so replay matches serve mode, and standard networks reject it unless the explicit unsafe override is set.

- **New Features**
  - Adds `FullPotRewardsEnabled` and unsafe override `UnsafeFullPotRewardsOnStandardNetworks`; CLI `--full-pot-rewards-enabled` / `--unsafe-full-pot-rewards-on-standard-networks`, env `DINGO_FULL_POT_REWARDS_ENABLED` / `DINGO_UNSAFE_FULL_POT_REWARDS_ON_STANDARD_NETWORKS`, YAML; wired via `WithFullPotRewards` and `WithUnsafeFullPotRewardsOnStandardNetworks`, validated in config and `LoadWithDB`, propagated to load-mode ledger config.
  - Standard-network protection checks network name or magic; load-mode also validates the Cardano config’s genesis network magic and requires a resolvable network identity.
  - Implements `ledger/rewards.ApportionFullPot` (largest-remainder/Hamilton; `big.Int`; tie-break by pool ID) and updates `ledger/rewards.Calculate` to two passes: compute base totals, apportion when enabled, then re-derive leader/member splits; only split-rounding returns to reserves; if no pool earns a base reward (`W == 0`), the pot returns to reserves.
  - Adds `ledger/rewards.LeaderReward` and `ledger/rewards.LeaderRewardWithParameters`; the precompute reuse verifier reproduces apportionment and re-derives leader splits before validating persisted totals. Docs expanded; tests cover env/flag bindings, gate validation across run/load paths, apportionment math/overflow, and CIP-23 composition.

- **Migration**
  - Off by default. Consensus-affecting; enable only where every node also enables it.
  - Standard networks reject it unless `unsafeFullPotRewardsOnStandardNetworks: true` is also set.
  - Enable via YAML `fullPotRewardsEnabled: true`, CLI `--full-pot-rewards-enabled`, or env `DINGO_FULL_POT_REWARDS_ENABLED=true`.

<sup>Written for commit 5edd3455c6b4467690ab6f786c48966ed9395475. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CIP-0163 full-pot reward distribution.
  * When enabled, available rewards are distributed across pools using proportional allocation, reducing undistributed residuals to rounding effects.
  * Added configuration support through CLI, environment variables, and YAML.
  * The feature remains disabled by default and must be enabled consistently across network nodes.

* **Documentation**
  * Documented reward behavior, configuration, and network compatibility requirements.

* **Tests**
  * Added coverage for allocation accuracy, rounding, overflow handling, configuration, and reward verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->