### PR TITLE
test(conformance): Added MySQL tests via ouroboros-mock harness

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -68,6 +68,7 @@ jobs:
       MYSQL_USER: mysql
       MYSQL_PASSWORD: mysql
       MYSQL_DATABASE: dingo_test
+      MYSQL_ROOT_PASSWORD: mysql
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_ENDPOINT: "http://127.0.0.1:9000/"

--- a/internal/test/conformance/README.md
+++ b/internal/test/conformance/README.md
@@ -6,8 +6,9 @@ data live in `github.com/blinklabs-io/ouroboros-mock/conformance`; this package
 provides `DingoStateManager`, an adapter that drives Dingo's database and
 ledger packages so every vector runs against a clean state. `DingoStateManager`
 only ever talks to the database through `*gorm.DB`, so the same adapter runs
-against either an in-memory SQLite backend (the default, no setup required)
-or a real PostgreSQL backend (see [PostgreSQL backend](#postgresql-backend)).
+against an in-memory SQLite backend (the default, no setup required), a real
+PostgreSQL backend (see [PostgreSQL backend](#postgresql-backend)), or a real
+MySQL backend (see [MySQL backend](#mysql-backend)).
 
 ## What the vectors cover
 
@@ -85,6 +86,42 @@ asserting a hardcoded number, so the two runs should exercise the identical
 vector count with identical pass counts, and the comparison stays correct
 even as the embedded `ouroboros-mock` vector corpus grows or shrinks.
 
+## MySQL backend
+
+Same idea as the PostgreSQL backend above, using the same `dingo_extra_plugins`
+build tag as `database/plugin/metadata/mysql` and the same
+`MYSQL_HOST/PORT` environment variables that plugin's tests and CI's
+`go-test-linux` job already use.
+
+Bring up a local MySQL and run it:
+
+```bash
+docker compose -f internal/test/conformance/docker-compose.yml up -d mysql
+
+MYSQL_HOST=localhost MYSQL_PORT=3306 MYSQL_ROOT_PASSWORD=mysql \
+  go test -tags dingo_extra_plugins -v ./internal/test/conformance/... -run Mysql
+```
+
+Without a `MYSQL_ROOT_PASSWORD` or `MYSQL_DSN` set, both MySQL tests skip.
+CI's `go-test-linux` job already runs a `mysql:8` service and sets
+`MYSQL_ROOT_PASSWORD`, so the MySQL variant runs automatically as part of
+the existing tagged `go test -race ./...` step.
+
+**Database isolation.** MySQL has no schema/database distinction the way
+Postgres does — a MySQL "schema" *is* a database. `database/plugin/metadata/mysql`'s
+own tests connect to the shared `dingo_test` database with a user the
+official `mysql` image's bootstrap grants access to *only* that database, so
+this suite can't reuse that user to carve out an isolated namespace the way
+the Postgres one does with `CREATE SCHEMA`. Instead,
+`NewDingoMysqlStateManager` authenticates as `root` (the one account
+guaranteed to have `CREATE DATABASE` privileges) and migrates into its own
+dedicated `dingo_conformance_test` database. This is why the MySQL tests key
+off `MYSQL_ROOT_PASSWORD` specifically rather than the `MYSQL_PASSWORD` the
+plugin's own tests use.
+
+`TestRulesConformanceVectorsWithResultsMysql` follows the same
+count-comparison approach as the Postgres variant, for the same reason.
+
 ## When to run them
 
 **Conformance tests are mandatory after every ledger-affecting change**, not
@@ -120,10 +157,12 @@ Cross-repo change cascades that must re-run this suite:
 |---|---|
 | `conformance_test.go` | Go test entry points, SQLite backend (`TestRulesConformanceVectors`, `…WithResults`) |
 | `conformance_postgres_test.go` | Go test entry points, PostgreSQL backend (`dingo_extra_plugins` build tag) |
+| `conformance_mysql_test.go` | Go test entry points, MySQL backend (`dingo_extra_plugins` build tag) |
 | `state_manager.go`    | `DingoStateManager` — implements `conformance.StateManager` against Dingo's DB/ledger |
 | `state_manager_postgres.go` | `NewDingoPostgresStateManager` — same `DingoStateManager`, Postgres connection (`dingo_extra_plugins` build tag) |
+| `state_manager_mysql.go` | `NewDingoMysqlStateManager` — same `DingoStateManager`, MySQL connection (`dingo_extra_plugins` build tag) |
 | `state_provider.go`   | State-query adapters used by the harness |
-| `docker-compose.yml`  | Local PostgreSQL for the Postgres-backed tests |
+| `docker-compose.yml`  | Local PostgreSQL and MySQL for the SQL-backed tests |
 
 ## Updating vectors
 

--- a/internal/test/conformance/conformance_mysql_test.go
+++ b/internal/test/conformance/conformance_mysql_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package conformance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// isMysqlConformanceConfigured checks whether a MySQL root DSN has been
+// supplied via environment variables. Unlike
+// database/plugin/metadata/mysql's isMysqlConfigured (which only needs
+// MYSQL_PASSWORD, since its test user is pre-granted access to dingo_test),
+// this suite needs privileges to create its own database (see
+// state_manager_mysql.go), so it specifically requires MYSQL_ROOT_PASSWORD
+// or a full MYSQL_DSN override.
+func isMysqlConformanceConfigured() bool {
+	return os.Getenv("MYSQL_ROOT_PASSWORD") != "" || os.Getenv("MYSQL_DSN") != ""
+}
+
+// skipIfMysqlConformanceNotConfigured skips the test unless a MySQL root
+// DSN is available, so a plain `go test ./...` with no database running
+// still passes.
+func skipIfMysqlConformanceNotConfigured(t *testing.T) {
+	t.Helper()
+	if !isMysqlConformanceConfigured() {
+		t.Skip(
+			"Skipping mysql conformance test: mysql not configured " +
+				"(set MYSQL_ROOT_PASSWORD or MYSQL_DSN)",
+		)
+	}
+}
+
+// mysqlConformanceRootDSN builds a root DSN from MYSQL_HOST/PORT/ROOT_PASSWORD
+// environment variables -- the same host/port convention
+// database/plugin/metadata/mysql/mysql_test.go reads, but authenticated as
+// root since this suite needs CREATE DATABASE privileges that suite's
+// regular test user doesn't have. MYSQL_DSN, if set, overrides everything.
+func mysqlConformanceRootDSN() string {
+	if dsn := os.Getenv("MYSQL_DSN"); dsn != "" {
+		return dsn
+	}
+
+	host := "localhost"
+	if v := os.Getenv("MYSQL_HOST"); v != "" {
+		host = v
+	}
+	port := "3306"
+	if v := os.Getenv("MYSQL_PORT"); v != "" {
+		port = v
+	}
+
+	cfg := mysqldriver.Config{
+		User:                 "root",
+		Passwd:               os.Getenv("MYSQL_ROOT_PASSWORD"),
+		Net:                  "tcp",
+		Addr:                 host + ":" + port,
+		ParseTime:            true,
+		AllowNativePasswords: true,
+	}
+	return cfg.FormatDSN()
+}
+
+// newTestMysqlConformanceManager creates a MySQL-backed DingoStateManager
+// for testing, skipping the test if mysql isn't configured.
+func newTestMysqlConformanceManager(t *testing.T) *DingoStateManager {
+	t.Helper()
+	skipIfMysqlConformanceNotConfigured(t)
+
+	sm, err := NewDingoMysqlStateManager(mysqlConformanceRootDSN())
+	require.NoError(t, err, "failed to create mysql state manager")
+	return sm
+}
+
+// TestRulesConformanceVectorsMysql is the strict pass/fail gate for the
+// MySQL-backed DingoStateManager: it fails immediately on the first vector
+// mismatch (via harness.RunAllVectors), mirroring TestRulesConformanceVectors
+// in conformance_test.go.
+func TestRulesConformanceVectorsMysql(t *testing.T) {
+	skipIfMysqlConformanceNotConfigured(t)
+
+	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	sm := newTestMysqlConformanceManager(t)
+	defer sm.Close()
+
+	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
+		TestdataRoot: testdataRoot,
+		Debug:        testing.Verbose(),
+	})
+
+	harness.RunAllVectors(t)
+}
+
+// TestRulesConformanceVectorsWithResultsMysql runs the harness against both
+// the SQLite-backed and MySQL-backed state managers in the same test and
+// compares them, rather than asserting a hardcoded vector count: the two
+// runs should exercise the identical number of vectors with identical pass
+// counts, and the comparison stays correct even as the embedded
+// ouroboros-mock vector corpus grows or shrinks.
+func TestRulesConformanceVectorsWithResultsMysql(t *testing.T) {
+	skipIfMysqlConformanceNotConfigured(t)
+
+	sqliteRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	sqliteSm, err := NewDingoStateManager()
+	require.NoError(t, err)
+	defer sqliteSm.Close()
+
+	sqliteHarness := conformance.NewHarness(sqliteSm, conformance.HarnessConfig{
+		TestdataRoot: sqliteRoot,
+	})
+	sqliteResults, err := sqliteHarness.RunAllVectorsWithResults()
+	require.NoError(t, err, "failed to run sqlite vectors")
+
+	mysqlRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
+	require.NoError(t, err, "failed to extract embedded testdata")
+
+	mysqlSm := newTestMysqlConformanceManager(t)
+	defer mysqlSm.Close()
+
+	mysqlHarness := conformance.NewHarness(mysqlSm, conformance.HarnessConfig{
+		TestdataRoot: mysqlRoot,
+	})
+	mysqlResults, err := mysqlHarness.RunAllVectorsWithResults()
+	require.NoError(t, err, "failed to run mysql vectors")
+
+	var mysqlPassed, mysqlFailed int
+	for _, result := range mysqlResults {
+		if result.Success {
+			mysqlPassed++
+		} else {
+			mysqlFailed++
+		}
+	}
+
+	t.Logf("Conformance Test Results (MySQL):")
+	t.Logf("  Total vectors: %d", len(mysqlResults))
+	t.Logf("  Passed: %d", mysqlPassed)
+	t.Logf("  Failed: %d", mysqlFailed)
+	if len(mysqlResults) > 0 {
+		t.Logf(
+			"  Pass rate: %.1f%%",
+			float64(mysqlPassed)/float64(len(mysqlResults))*100,
+		)
+	}
+	if mysqlFailed > 0 && testing.Verbose() {
+		t.Log("First failures:")
+		failCount := 0
+		for _, result := range mysqlResults {
+			if !result.Success && failCount < 5 {
+				t.Logf("  %s: %v", result.Title, result.Error)
+				failCount++
+			}
+		}
+		if mysqlFailed > 5 {
+			t.Logf("  ... and %d more failures", mysqlFailed-5)
+		}
+	}
+
+	require.Equal(
+		t,
+		len(sqliteResults),
+		len(mysqlResults),
+		"mysql backend exercised a different number of vectors than "+
+			"sqlite; vector discovery/extraction should be backend-invariant",
+	)
+	require.Zero(t, mysqlFailed, "mysql backend failed vectors sqlite passed")
+}

--- a/internal/test/conformance/docker-compose.yml
+++ b/internal/test/conformance/docker-compose.yml
@@ -1,13 +1,20 @@
-# PostgreSQL for local conformance test runs.
+# PostgreSQL and MySQL for local conformance test runs.
 #
 # Usage:
 #   docker compose -f internal/test/conformance/docker-compose.yml up -d
+#
 #   POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
 #   POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=dingo_test \
 #     go test -tags dingo_extra_plugins -v ./internal/test/conformance/... -run Postgres
 #
-# Image/credentials match .github/workflows/go-test.yml's postgres service
-# so a passing local run and a passing CI run mean the same thing.
+#   MYSQL_HOST=localhost MYSQL_PORT=3306 MYSQL_ROOT_PASSWORD=mysql \
+#     go test -tags dingo_extra_plugins -v ./internal/test/conformance/... -run Mysql
+#
+# Images/credentials match .github/workflows/go-test.yml's services so a
+# passing local run and a passing CI run mean the same thing. The mysql
+# conformance tests authenticate as root (not the mysql/mysql user) because
+# they need CREATE DATABASE privileges to isolate themselves from
+# database/plugin/metadata/mysql's own tests -- see state_manager_mysql.go.
 services:
   postgres:
     image: postgres:16
@@ -20,6 +27,22 @@ services:
       - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mysql:
+    image: mysql:8
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_DATABASE: dingo_test
+    ports:
+      - "127.0.0.1:3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u root -pmysql"]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/internal/test/conformance/state_manager_mysql.go
+++ b/internal/test/conformance/state_manager_mysql.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package conformance
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	mysqldriver "github.com/go-sql-driver/mysql"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// conformanceMysqlDatabase is the dedicated MySQL database the conformance
+// suite migrates into. MySQL has no schema/database distinction the way
+// Postgres does, so a dedicated database is the direct equivalent of
+// state_manager_postgres.go's dedicated "conformance" schema:
+// database/plugin/metadata/mysql's own tests connect to the shared
+// dingo_test database, and go test runs different packages as separate,
+// concurrent binaries, so sharing it would let the two suites race on the
+// same tables.
+const conformanceMysqlDatabase = "dingo_conformance_test"
+
+// NewDingoMysqlStateManager creates a new DingoStateManager backed by a
+// real MySQL database instead of the default in-memory SQLite one used by
+// NewDingoStateManager. rootDSN must authenticate as a user allowed to
+// create databases -- database/plugin/metadata/mysql's own test user is
+// deliberately granted access only to dingo_test by the official mysql
+// image's bootstrap, so it cannot be reused here; a root DSN is required
+// to create conformanceMysqlDatabase.
+func NewDingoMysqlStateManager(rootDSN string) (*DingoStateManager, error) {
+	adminDB, err := gorm.Open(gormmysql.Open(rootDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mysql admin connection: %w", err)
+	}
+	if err := adminDB.Exec(
+		"CREATE DATABASE IF NOT EXISTS " + conformanceMysqlDatabase,
+	).Error; err != nil {
+		return nil, fmt.Errorf("failed to create conformance database: %w", err)
+	}
+	if adminSQLDB, err := adminDB.DB(); err == nil {
+		adminSQLDB.Close()
+	}
+
+	dsn, err := dsnWithDatabase(rootDSN, conformanceMysqlDatabase)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to build conformance database dsn: %w",
+			err,
+		)
+	}
+
+	db, err := gorm.Open(gormmysql.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+		// models.MigrateModels lists Asset before Utxo, but Utxo.Assets
+		// declares the FK ("gorm:foreignKey:UtxoID;constraint:..."). A
+		// single batched AutoMigrate(MigrateModels...) call pre-parses
+		// every model's schema up front, so it embeds that constraint into
+		// Asset's CREATE TABLE before Utxo's table exists. SQLite (the
+		// default backend here) never validates REFERENCES targets at DDL
+		// time, so this was always latent; MySQL/InnoDB validates
+		// immediately, same as Postgres (see
+		// state_manager_postgres.go). Disabling FK constraint creation
+		// during migration costs nothing for this harness specifically:
+		// DingoStateProvider (state_provider.go) never queries these rows
+		// back through SQL, only through DingoStateManager's in-memory
+		// maps.
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mysql database: %w", err)
+	}
+
+	// Run migrations for all models
+	if err := db.AutoMigrate(models.MigrateModels...); err != nil {
+		return nil, fmt.Errorf("failed to migrate database: %w", err)
+	}
+
+	return &DingoStateManager{
+		db:                   db,
+		govState:             conformance.NewGovernanceState(),
+		utxos:                make(map[string]common.Utxo),
+		stakeRegistrations:   make(map[common.Blake2b224]uint64),
+		poolRegistrations:    make(map[common.Blake2b224]bool),
+		drepRegistrations:    make(map[common.Blake2b224]bool),
+		committeeMembers:     make(map[common.Blake2b224]uint64),
+		hotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
+		committeeRemovals:    make(map[string]map[common.Blake2b224]struct{}),
+		committeeQuorums:     make(map[string]*big.Rat),
+	}, nil
+}
+
+// dsnWithDatabase rewrites a go-sql-driver/mysql DSN to point at a
+// different database name, keeping every other connection parameter
+// (user, password, host, port, params) unchanged.
+func dsnWithDatabase(dsn, database string) (string, error) {
+	cfg, err := mysqldriver.ParseDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	cfg.DBName = database
+	return cfg.FormatDSN(), nil
+}


### PR DESCRIPTION
1. Added MySQL-backed ledger conformance tests using the shared ouroboros-mock harness while retaining the existing SQLite and PostgreSQL suites.
2. Added a MySQL-backed `DingoStateManager` using GORM’s MySQL driver.
3. Added a dedicated `dingo_conformance_test` database to isolate the suite from other MySQL tests.
4. Added MySQL conformance tests driven by `conformance.NewHarness(...)`.
5. Added strict vector pass/fail validation and detailed result reporting.
6. Added environment-variable and DSN configuration for MySQL connections.
7. Added a local MySQL 8 Docker Compose service for developer runs.
8. Integrated the MySQL suite into the existing tagged Linux CI test step.
9. Updated the conformance README with setup, execution, isolation, and CI instructions.


Closes #2005 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MySQL-backed conformance tests using the shared `ouroboros-mock` harness to verify ledger behavior parity with SQLite and PostgreSQL. Includes local Docker/CI integration and docs to make runs easy. Addresses Linear #2005.

- New Features
  - Added MySQL `DingoStateManager` via `gorm` (uses `dingo_conformance_test` DB; FK creation disabled during migration to match existing harness behavior).
  - New `conformance_mysql_test.go` with strict vector validation and a results-parity check vs SQLite.
  - MySQL config via `MYSQL_ROOT_PASSWORD` or `MYSQL_DSN` (respects `MYSQL_HOST`/`MYSQL_PORT`); tests skip if not set.
  - Added `mysql:8` service to `docker-compose.yml` and wired into Linux CI; set `MYSQL_ROOT_PASSWORD` in workflow.
  - Updated conformance README with setup, isolation details, and CI notes.

<sup>Written for commit 3c729e0ab1b5af24127bf96de323bf523266c056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MySQL-backed conformance testing alongside SQLite and PostgreSQL.
  * Added local Docker support for running MySQL conformance tests.
  * Tests now create and use a dedicated conformance database automatically.

* **Documentation**
  * Added setup instructions, environment configuration, run commands, and database isolation guidance for MySQL testing.

* **CI Improvements**
  * Configured Linux test runs with the required MySQL credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->