### PR TITLE
feat(chainselection): corroborate Genesis fast sources before selection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1278,53 +1278,84 @@ it. Dingo implements this as a **corroboration gate**
 (`chainselection/genesis_corroboration.go`), controlled by
 `genesisBootstrap.corroborationPeers` (`MinCorroboratingPeers`):
 
-- A candidate peer is **corroborated** when at least `corroborationPeers` other
-  eligible, live, non-stale peers report an identical `(slot, hash)` point in
-  their observed frontier — evidence they are following the same chain within
-  the Genesis window.
+- A candidate peer is **corroborated** when at least `corroborationPeers`
+  independent witness peers *confirm the candidate's recent chain*
+  (`confirmsRecentChain`): every block a witness observed within the candidate's
+  window slot range matches the candidate's own `(slot, hash)`, and they share at
+  least one such block. The observed frontier is populated per header during
+  chainsync (dense), so two peers on the same chain agree on every block in their
+  overlap. This is deliberately stronger than "share any common point": a fast
+  source that agrees on one old ancestor and then produces different blocks for
+  the rest of the window is **not** confirmed, because the witness observed
+  recent blocks the candidate lacks (or a conflicting hash at the same slot).
+- Witnesses are counted by distinct remote **host**, and a witness on the
+  candidate's own host is excluded, so several connections from one operator
+  cannot self-corroborate a private fork. This is a lower bound on independence,
+  not a guarantee: genuine independence (distinct operators, ASNs, and chain
+  views) depends on the operator's validated topology and peer-governance
+  diversity groups. Raising `corroborationPeers` raises the *count* required, not
+  the independence of the peers supplied — that remains an operator
+  responsibility.
 - In Genesis mode with `corroborationPeers > 0`, an **uncorroborated** candidate
-  is denied chain selection (`isPeerSelectableLocked`). A divergent fast source
-  on a private fork shares no recent block hash with any honest peer, so it is
-  never corroborated and cannot become the best peer. With no corroborated
-  peer, selection returns none and the node **stalls** rather than following an
-  untrue chain. This is the security property: a bad or divergent fast source
-  can at worst stall the node under the documented assumptions (at least one
-  honest corroborating peer, e.g. seeded from a ledger peer snapshot).
+  is denied chain selection (`isPeerSelectableLocked`). A fully divergent fast
+  source shares no recent block with any honest peer, so it is never corroborated
+  and cannot become the best peer. With no corroborated peer, selection returns
+  none and the node **stalls** rather than following an untrue chain: a bad or
+  divergent fast source can at worst stall the node under the documented
+  assumption of at least one honest, independent corroborating peer within the
+  window (e.g. seeded from a ledger peer snapshot). Corroboration fails **closed**
+  — a candidate whose window does not overlap any witness's frontier (e.g. a fast
+  source that has raced far beyond every corroborator's window) is not confirmed
+  and stalls, so operators must keep corroborators within the Genesis window of
+  the fast source.
 - The gate **denies selection but does not disconnect** the fast source. Genesis
   wants the fast source kept connected so it can serve blocks as soon as
   corroboration arrives; demoting or dropping it would defeat the accelerator.
   Peer governance may still subscribe to the failure event to react.
 - `corroborationPeers = 0` disables the gate (density-only Genesis selection,
   the historical default), preserving prior behavior for nodes that do not opt
-  into the Genesis trust model.
+  into the Genesis trust model. While the gate is disabled the per-peer hash
+  frontier is not tracked, so normal Praos operation carries no extra state.
 
 **Supported GSA-style configuration**: a trustable `localRoots` peer (the fast
-source) plus a ledger peer snapshot (`peerSnapshotFile`) that seeds independent
+source) plus a ledger peer snapshot (`peerSnapshotFile`) that seeds
 `PeerSourceP2PLedger` corroborators before outbound startup (see Peer
-Governance). Set `corroborationPeers` to the number of independent snapshot
-peers that must agree. See `GENESIS_SYNC.md` for the operator runbook. This differs from normal Praos sync (which trusts the
-longest valid chain from any peer) and from Mithril bootstrap (which trusts a
-signed snapshot at a trust boundary): Genesis trusts *density corroborated by
-independent peers* from origin.
+Governance). Set `corroborationPeers` to the number of *independent* snapshot
+peers that must agree — where independence must be established by the operator
+(distinct operators/infrastructure/chain views), since the selector can only
+enforce distinct remote hosts. See `GENESIS_SYNC.md` for the operator runbook.
+This differs from normal Praos sync (which trusts the longest valid chain from
+any peer) and from Mithril bootstrap (which trusts a signed snapshot at a trust
+boundary): Genesis trusts *density corroborated by peers the operator has reason
+to believe are independent* from origin.
 
 **Observability**: `GenesisStatus()` exposes the current mode, window, selected
 fast source, and per-peer density/corroboration. The selector emits
 `chainselection.genesis_corroboration_failed` when the densest fast source is
-denied for lack of corroboration (deduped per source) and
-`chainselection.genesis_mode_exited` with the exit reason (local slot, best
-known slot, window) when it returns to Praos.
+denied for lack of corroboration (deduped per source; the warning is also logged
+without an EventBus) and `chainselection.genesis_mode_exited` with the exit
+reason (local slot, best known slot, window) when it returns to Praos. A change
+to any tracked peer's frontier re-runs selection while corroboration is active,
+so corroboration granted or revoked takes effect immediately rather than on the
+next periodic tick.
 
-**Deferred / not implemented** (explicit scope boundary): the gate is a
-corroboration check, not the reference implementation's full Ouroboros Genesis
-density-at-intersection with **ChainSync Jumping** and devoted BlockFetch
-dynamics. It compares recent shared frontier points within the window; it does
-not, on its own, resolve a fork whose intersection is inside the window by
-counting blocks after the exact intersection, nor does it schedule block
-downloads across jumped peers. Those performance/robustness pieces (and wiring
-peer-governance demotion to the corroboration-failure event) remain future
-work; the density comparison plus the corroboration gate provide the from-origin
-*security* property that a fast source cannot steer the node without independent
-corroboration.
+**Deferred / not implemented** (explicit scope boundary — some of these are
+security limitations, not only performance): the gate is a corroboration check,
+not the reference implementation's full Ouroboros Genesis density-at-intersection
+with **ChainSync Jumping** and devoted BlockFetch dynamics. It confirms that a
+witness's chain is a prefix of the candidate's within the overlapping window; it
+does **not** resolve a fork whose intersection lies *inside* the window by
+counting blocks after the exact intersection, and it cannot testify about blocks
+a fast source produced *beyond* every witness's frontier. Consequently a fast
+source that stays consistent with honest peers up to their frontiers but forks
+only in the not-yet-witnessed suffix is corroborated until a witness advances
+past the fork — full density-at-intersection would decide such cases sooner, so
+its absence is a **security** limitation for that window, mitigated (not closed)
+by the fail-closed overlap requirement and the per-header density comparison.
+Wiring peer-governance demotion to the corroboration-failure event is likewise
+deferred. These remain future work; the density comparison plus the corroboration
+gate provide the from-origin property that a fast source cannot steer the node
+onto a chain no independent witness shares.
 
 #### Anti-flap incumbent pin
 
@@ -1622,13 +1653,17 @@ later ledger peer refreshes still query the live ledger/database provider.
 If the snapshot produces no usable peers, startup falls back to topology
 bootstrap peers.
 
-These snapshot-seeded ledger peers are the independent corroborators for the
+These snapshot-seeded ledger peers are the configured corroborators for the
 Genesis corroboration gate (see Chain Selection → Ouroboros Genesis trust
 model). In a GSA-style deployment the fast source is a trustable `localRoots`
 peer and the snapshot supplies the corroborating ledger peers; setting
-`genesisBootstrap.corroborationPeers` to the number of independent snapshot
-peers that must agree makes the node stall rather than follow the fast source
-until that many corroborators confirm its recent blocks.
+`genesisBootstrap.corroborationPeers` to the number of snapshot peers that must
+agree makes the node stall rather than follow the fast source until that many
+distinct-host corroborators confirm its recent blocks. Their *independence*
+(distinct operators, infrastructure, and chain views) is not something the
+selector can verify — it enforces only distinct remote hosts — so the operator
+is responsible for populating the snapshot with genuinely independent large
+ledger peers.
 
 Live ledger peer discovery is adapted at the node composition boundary:
 `ledger/` exposes stake pool relay data and current slot through neutral

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1338,11 +1338,22 @@ without an EventBus) and `chainselection.genesis_mode_exited` with the exit
 reason (local slot, best known *advertised* slot, window) when it returns to
 Praos — exit keys off the advertised network tip, not the observed frontier, so
 the gate stays active through from-origin sync until the local tip nears the
-real network tip. The exit horizon is the highest advertised tip among all
-live/eligible/non-stale peers, **including an uncorroborated far-ahead source**,
-so a lower corroborated peer cannot trigger a premature exit that would let the
-uncorroborated source steer the chain under Praos (the implausible-tip check
-bounds how far ahead any peer can advertise). A change
+real network tip.
+
+The exit horizon is the highest advertised tip slot among **corroborated
+(selectable)** peers. It must be corroborated, not any live peer's raw tip,
+because the advertised tip is untrusted and the implausible-tip check bounds only
+the advertised *block number*, not the *slot* (and the first peer is accepted
+with no reference): a single peer advertising a plausible block with a slot near
+`math.MaxUint64` would otherwise pin the node in Genesis mode forever — a
+liveness DoS. Requiring corroboration means `MinCorroboratingPeers` independent
+peers must have delivered matching headers, so a lone liar cannot inflate the
+horizon. The trade-off is that an uncorroborated source that is ahead in block
+number could win Praos selection once the local tip has caught up to the
+corroborated tip and the node has exited; closing that residual needs
+density-at-intersection (deferred, below). Liveness is prioritized over that
+residual because an unbounded advertised slot is a trivially exploitable
+single-peer stall. A change
 to any tracked peer's frontier re-runs selection while corroboration is active,
 so corroboration granted or revoked takes effect immediately rather than on the
 next periodic tick.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -740,6 +740,8 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `chainselection.chain_switch` | ChainSelector | Active peer changed |
 | `chainselection.selection` | ChainSelector | Chain selection made |
 | `chainselection.peer_evicted` | ChainSelector | Peer evicted |
+| `chainselection.genesis_corroboration_failed` | ChainSelector | Densest Genesis fast source lacked corroboration and was denied selection |
+| `chainselection.genesis_mode_exited` | ChainSelector | Left Genesis mode for Praos after catching up to the best known tip |
 | `chainsync.client_added` | ChainsyncState | Client tracking added |
 | `chainsync.client_removed` | ChainsyncState | Client tracking removed |
 | `chainsync.client_synced` | ChainsyncState | Client caught up |
@@ -1256,6 +1258,74 @@ as a fallback ingress source, but peer governance lowers their priority to zero.
 This lets non-bootstrap peers win same-tip transport selection without
 stranding ChainSync when the bootstrap peer is still the only usable upstream.
 
+#### Ouroboros Genesis trust model
+
+Genesis mode (`genesisBootstrap`, active only for from-origin sync with no
+`intersectTip`/`intersectPoints`) selects the chain by observed header
+*density* within a window of `3k/f` slots rather than by longest-chain length,
+so a from-origin node can prefer the denser (honest) chain before it has the
+history to run the full Praos comparison. The window is derived from Shelley
+genesis params (`GenesisWindowSlotsForParams`) or overridden by
+`genesisWindowSlots`. Each tracked peer keeps a bounded recent frontier of
+`(slot, hash)` points (`PeerChainTip.observedPoints`, in lockstep with the
+`observedSlots` used for density), trimmed to the window and on rollback.
+
+The trust problem Genesis solves for **biased fast-sync sources** — e.g. a
+local shallow peer or the Genesis Sync Accelerator (GSA), which serve blocks
+quickly but are not themselves trustworthy — is that the densest/longest source
+must not be allowed to steer the local chain unless independent peers confirm
+it. Dingo implements this as a **corroboration gate**
+(`chainselection/genesis_corroboration.go`), controlled by
+`genesisBootstrap.corroborationPeers` (`MinCorroboratingPeers`):
+
+- A candidate peer is **corroborated** when at least `corroborationPeers` other
+  eligible, live, non-stale peers report an identical `(slot, hash)` point in
+  their observed frontier — evidence they are following the same chain within
+  the Genesis window.
+- In Genesis mode with `corroborationPeers > 0`, an **uncorroborated** candidate
+  is denied chain selection (`isPeerSelectableLocked`). A divergent fast source
+  on a private fork shares no recent block hash with any honest peer, so it is
+  never corroborated and cannot become the best peer. With no corroborated
+  peer, selection returns none and the node **stalls** rather than following an
+  untrue chain. This is the security property: a bad or divergent fast source
+  can at worst stall the node under the documented assumptions (at least one
+  honest corroborating peer, e.g. seeded from a ledger peer snapshot).
+- The gate **denies selection but does not disconnect** the fast source. Genesis
+  wants the fast source kept connected so it can serve blocks as soon as
+  corroboration arrives; demoting or dropping it would defeat the accelerator.
+  Peer governance may still subscribe to the failure event to react.
+- `corroborationPeers = 0` disables the gate (density-only Genesis selection,
+  the historical default), preserving prior behavior for nodes that do not opt
+  into the Genesis trust model.
+
+**Supported GSA-style configuration**: a trustable `localRoots` peer (the fast
+source) plus a ledger peer snapshot (`peerSnapshotFile`) that seeds independent
+`PeerSourceP2PLedger` corroborators before outbound startup (see Peer
+Governance). Set `corroborationPeers` to the number of independent snapshot
+peers that must agree. See `GENESIS_SYNC.md` for the operator runbook. This differs from normal Praos sync (which trusts the
+longest valid chain from any peer) and from Mithril bootstrap (which trusts a
+signed snapshot at a trust boundary): Genesis trusts *density corroborated by
+independent peers* from origin.
+
+**Observability**: `GenesisStatus()` exposes the current mode, window, selected
+fast source, and per-peer density/corroboration. The selector emits
+`chainselection.genesis_corroboration_failed` when the densest fast source is
+denied for lack of corroboration (deduped per source) and
+`chainselection.genesis_mode_exited` with the exit reason (local slot, best
+known slot, window) when it returns to Praos.
+
+**Deferred / not implemented** (explicit scope boundary): the gate is a
+corroboration check, not the reference implementation's full Ouroboros Genesis
+density-at-intersection with **ChainSync Jumping** and devoted BlockFetch
+dynamics. It compares recent shared frontier points within the window; it does
+not, on its own, resolve a fork whose intersection is inside the window by
+counting blocks after the exact intersection, nor does it schedule block
+downloads across jumped peers. Those performance/robustness pieces (and wiring
+peer-governance demotion to the corroboration-failure event) remain future
+work; the density comparison plus the corroboration gate provide the from-origin
+*security* property that a fast source cannot steer the node without independent
+corroboration.
+
 #### Anti-flap incumbent pin
 
 The active connection (the peer that drives the chainsync+blockfetch pipeline
@@ -1551,6 +1621,14 @@ Genesis initial sync while preserving the existing `UseLedgerAfterSlot` path:
 later ledger peer refreshes still query the live ledger/database provider.
 If the snapshot produces no usable peers, startup falls back to topology
 bootstrap peers.
+
+These snapshot-seeded ledger peers are the independent corroborators for the
+Genesis corroboration gate (see Chain Selection → Ouroboros Genesis trust
+model). In a GSA-style deployment the fast source is a trustable `localRoots`
+peer and the snapshot supplies the corroborating ledger peers; setting
+`genesisBootstrap.corroborationPeers` to the number of independent snapshot
+peers that must agree makes the node stall rather than follow the fast source
+until that many corroborators confirm its recent blocks.
 
 Live ledger peer discovery is adapted at the node composition boundary:
 `ledger/` exposes stake pool relay data and current slot through neutral

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1338,7 +1338,11 @@ without an EventBus) and `chainselection.genesis_mode_exited` with the exit
 reason (local slot, best known *advertised* slot, window) when it returns to
 Praos — exit keys off the advertised network tip, not the observed frontier, so
 the gate stays active through from-origin sync until the local tip nears the
-real network tip. A change
+real network tip. The exit horizon is the highest advertised tip among all
+live/eligible/non-stale peers, **including an uncorroborated far-ahead source**,
+so a lower corroborated peer cannot trigger a premature exit that would let the
+uncorroborated source steer the chain under Praos (the implausible-tip check
+bounds how far ahead any peer can advertise). A change
 to any tracked peer's frontier re-runs selection while corroboration is active,
 so corroboration granted or revoked takes effect immediately rather than on the
 next periodic tick.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -742,6 +742,7 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `chainselection.peer_evicted` | ChainSelector | Peer evicted |
 | `chainselection.genesis_corroboration_failed` | ChainSelector | Densest Genesis fast source lacked corroboration and was denied selection |
 | `chainselection.genesis_mode_exited` | ChainSelector | Left Genesis mode for Praos after catching up to the best known tip |
+| `chainselection.selected_none` | ChainSelector | Best-peer selection transitioned to none (selection stalled) |
 | `chainsync.client_added` | ChainsyncState | Client tracking added |
 | `chainsync.client_removed` | ChainsyncState | Client tracking removed |
 | `chainsync.client_synced` | ChainsyncState | Client caught up |
@@ -1309,10 +1310,26 @@ it. Dingo implements this as a **corroboration gate**
   source that has raced far beyond every corroborator's window) is not confirmed
   and stalls, so operators must keep corroborators within the Genesis window of
   the fast source.
-- The gate **denies selection but does not disconnect** the fast source. Genesis
+- **Enforcement is at ledger application, not just peer selection.** Header
+  ingress into the ledger is gated by *peer-governance* eligibility, independent
+  of the selected best peer (any ingress-eligible peer's headers are applied and
+  blockfetched under the default primary strategy). So denying an uncorroborated
+  source the "best peer" slot — or clearing the active chainsync driver — does
+  **not** by itself stop it feeding the ledger. The real stall is enforced by
+  `ChainSelector.ShouldApplyIngress`, wired to `OuroborosConfig.ChainsyncApplyEligible`
+  (`ouroboros/chainsync.go`): while Genesis corroboration is active, only
+  corroborated peers are *apply-eligible*. An uncorroborated peer is still
+  **observed** — its `PeerTipUpdateEvent` tips feed corroboration — but its
+  `ledger.ChainsyncEvent` (and therefore blockfetch) is withheld, so it cannot
+  steer the ledger. When no peer is corroborated, nothing is applied and the
+  ledger genuinely stalls. Observation happening before the apply gate is what
+  avoids a deadlock (a peer must be observed to become corroborated).
+- The gate **denies application but does not disconnect** the fast source. Genesis
   wants the fast source kept connected so it can serve blocks as soon as
   corroboration arrives; demoting or dropping it would defeat the accelerator.
-  Peer governance may still subscribe to the failure event to react.
+  A best-peer → none transition publishes `chainselection.selected_none` for
+  observability of the stall; peer governance may also subscribe to the
+  corroboration-failure event to react.
 - `corroborationPeers = 0` disables the gate (density-only Genesis selection,
   the historical default), preserving prior behavior for nodes that do not opt
   into the Genesis trust model. While the gate is disabled the per-peer hash

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1240,7 +1240,8 @@ The `ChainSelector` (`chainselection/`) implements Ouroboros Praos rules:
 3. At equal length/slot, the reference implementation's opcert/VRF
    tie-breaker is used when the necessary select-view data is available
 4. During genesis bootstrap mode, observed density is used until the local tip
-   is close enough to the best observed peer tip to switch back to Praos
+   is close enough to the best advertised peer tip (the network tip) to switch
+   back to Praos
 
 The selector tracks tips from all connected peers, honors peer eligibility and
 priority updates from peer governance, and switches the active chainsync
@@ -1334,7 +1335,10 @@ fast source, and per-peer density/corroboration. The selector emits
 `chainselection.genesis_corroboration_failed` when the densest fast source is
 denied for lack of corroboration (deduped per source; the warning is also logged
 without an EventBus) and `chainselection.genesis_mode_exited` with the exit
-reason (local slot, best known slot, window) when it returns to Praos. A change
+reason (local slot, best known *advertised* slot, window) when it returns to
+Praos — exit keys off the advertised network tip, not the observed frontier, so
+the gate stays active through from-origin sync until the local tip nears the
+real network tip. A change
 to any tracked peer's frontier re-runs selection while corroboration is active,
 so corroboration granted or revoked takes effect immediately rather than on the
 next periodic tick.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1340,20 +1340,26 @@ Praos — exit keys off the advertised network tip, not the observed frontier, s
 the gate stays active through from-origin sync until the local tip nears the
 real network tip.
 
-The exit horizon is the highest advertised tip slot among **corroborated
-(selectable)** peers. It must be corroborated, not any live peer's raw tip,
-because the advertised tip is untrusted and the implausible-tip check bounds only
-the advertised *block number*, not the *slot* (and the first peer is accepted
-with no reference): a single peer advertising a plausible block with a slot near
-`math.MaxUint64` would otherwise pin the node in Genesis mode forever — a
-liveness DoS. Requiring corroboration means `MinCorroboratingPeers` independent
-peers must have delivered matching headers, so a lone liar cannot inflate the
-horizon. The trade-off is that an uncorroborated source that is ahead in block
-number could win Praos selection once the local tip has caught up to the
-corroborated tip and the node has exited; closing that residual needs
-density-at-intersection (deferred, below). Liveness is prioritized over that
-residual because an unbounded advertised slot is a trivially exploitable
-single-peer stall. A change
+The exit horizon (`bestKnownGenesisSlotLocked`) is the highest advertised tip
+slot among **corroborated (selectable)** peers that have **actually delivered
+headers up to within the window of that advertised tip**
+(`ObservedTip + window >= Tip`). The advertised tip is untrusted and unbounded —
+the implausible-tip check bounds the advertised *block number* but not the
+*slot*, and the first peer is accepted with no reference — and corroboration
+alone does not fix this, because it validates the *delivered* headers (the
+observed frontier), not the advertised claim: a peer that delivers one shared
+early header (passing corroboration) can still advertise a slot near
+`math.MaxUint64`. Binding the horizon to *delivered* data closes this: a liar
+cannot deliver headers up to a `MaxUint64` slot, and an honest peer early in
+from-origin sync has not yet delivered up to its far advertised tip, so neither
+raises the horizon prematurely; the advertised tip becomes the exit target only
+once a corroborated peer has served its chain up to (near) it, which is reached
+exactly when the local tip has caught up. This satisfies both bounds — no
+single-peer liveness pin (an unbounded slot never counts until delivered) and no
+premature exit at the start of sync (delivered headers only reach the far tip
+once caught up). The trade-off is that an uncorroborated source ahead in block
+number could win Praos selection after exit; closing that residual needs
+density-at-intersection (deferred, below). A change
 to any tracked peer's frontier re-runs selection while corroboration is active,
 so corroboration granted or revoked takes effect immediately rather than on the
 next periodic tick.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1323,7 +1323,14 @@ it. Dingo implements this as a **corroboration gate**
   `ledger.ChainsyncEvent` (and therefore blockfetch) is withheld, so it cannot
   steer the ledger. When no peer is corroborated, nothing is applied and the
   ledger genuinely stalls. Observation happening before the apply gate is what
-  avoids a deadlock (a peer must be observed to become corroborated).
+  avoids a deadlock (a peer must be observed to become corroborated). While the
+  gate is active the observation is made **synchronously** with the gate
+  (`OuroborosConfig.ChainsyncObservePeerTip`, wired to update chain selection in
+  the roll-forward handler, skipping the async `PeerTipUpdateEvent`), so the
+  apply decision reflects the header currently being admitted rather than a tip
+  update that has not been processed yet — an async observation could otherwise
+  let a header slip through in the window before it revoked corroboration. With
+  the gate disabled the async path is used unchanged.
 - The gate **denies application but does not disconnect** the fast source. Genesis
   wants the fast source kept connected so it can serve blocks as soon as
   corroboration arrives; demoting or dropping it would defeat the accelerator.

--- a/GENESIS_SYNC.md
+++ b/GENESIS_SYNC.md
@@ -29,14 +29,29 @@ does not enter Genesis mode — it syncs with normal Praos chain selection.
 
 The security goal for from-origin sync is that a fast source which serves blocks
 quickly but is not itself trustworthy (a shallow local peer, GSA) **cannot steer
-the node onto an untrue chain**. Dingo enforces this with a **corroboration
-gate**: the densest fast source is only followed while independent peers confirm
-its recent blocks. A divergent or uncorroborated source is **denied selection**
-and the node **stalls** rather than following it.
+the node onto a chain no independent peer shares**. Dingo enforces this with a
+**corroboration gate**: the densest fast source is only followed while other
+peers confirm its recent chain — every block a witness has seen within the
+candidate's window must match the candidate's, so agreeing on one old ancestor
+and then forking is not enough. A divergent or uncorroborated source is **denied
+selection** and the node **stalls** rather than following it.
 
-Assumption: at least `corroborationPeers` **honest** peers are reachable (e.g.
-seeded from a ledger peer snapshot). Under that assumption a bad or divergent
-fast source can at worst stall the node.
+Assumptions (the security property holds only under these):
+
+- At least `corroborationPeers` **honest, independent** peers are reachable and
+  within the Genesis window of the fast source (e.g. seeded from a ledger peer
+  snapshot). If the fast source races far beyond every corroborator's window,
+  corroboration fails closed and the node stalls until the corroborators catch
+  up — this is safe but means corroborators must not be left far behind.
+- Those peers really are independent. The node can only enforce **distinct remote
+  hosts** (several connections from one IP cannot self-corroborate); it cannot
+  tell whether two hosts are the same operator, ASN, or chain view. Establishing
+  genuine independence is the operator's responsibility (see below).
+
+Under these assumptions a bad or divergent fast source can at worst stall the
+node. A fork that diverges only in blocks no honest peer has yet observed is not
+detected until a corroborator advances past it — full Ouroboros Genesis
+density-at-intersection would resolve such cases sooner (see Limitations).
 
 ## Configuration
 
@@ -65,8 +80,17 @@ Equivalent CLI flags / environment variables:
 Put the fast source in `localRoots` (mark it `trustable` so peer governance
 keeps it as a preferred ingress source) and point `peerSnapshotFile` at a
 cardano-node ledger peer snapshot. When Genesis selection is active and the
-snapshot has relays, Dingo seeds the snapshot relays as independent ledger peers
-before outbound startup — these are the corroborators.
+snapshot has relays, Dingo seeds the snapshot relays as ledger peers before
+outbound startup — these are the corroborators.
+
+**Validate corroborator independence.** The gate only enforces that
+corroborators are on *distinct remote hosts* from each other and from the fast
+source; it cannot tell whether two hosts belong to the same operator, ASN, or
+share a chain view. The security property assumes the corroborators are
+genuinely independent, so populate the snapshot with large ledger peers run by
+distinct operators on distinct infrastructure, and avoid pointing several
+snapshot entries at relays that ultimately share an upstream. A snapshot full of
+related relays satisfies the count but not the trust assumption.
 
 `topology.json`:
 
@@ -119,10 +143,12 @@ fast source, and per-peer density/corroboration for metrics or debugging.
   behavior). Use only when every configured peer is already trusted.
 - **1** — a single independent peer must confirm the fast source. Minimal
   protection; a lone honest snapshot peer is enough to keep going.
-- **2+** — require a quorum of independent peers. More robust against a small
+- **2+** — require a quorum of distinct-host peers. More robust against a small
   set of colluding/divergent sources, but the node stalls until that many
   reachable peers agree, so size it to how many independent snapshot peers you
-  actually connect.
+  actually connect. Raising this raises the required *count*, not the
+  independence of the peers you supply — that is fixed by your snapshot contents
+  (see "Validate corroborator independence").
 
 ## Limitations (deferred)
 
@@ -132,11 +158,18 @@ Genesis. Specifically **not** implemented:
 - **ChainSync Jumping** and devoted BlockFetch dynamics (a
   performance/robustness optimization for downloading across many peers).
 - **Density-at-intersection** resolution of a fork whose intersection is *inside*
-  the window (the gate compares recent shared frontier points, not block counts
-  after an exact intersection).
+  the window. The gate confirms a witness's chain is a prefix of the candidate's
+  within their overlap; it does not count blocks after an exact intersection, and
+  it cannot testify about blocks the fast source produced *beyond* every
+  witness's frontier. A fast source that stays consistent with honest peers up to
+  their frontiers but forks in the not-yet-witnessed suffix is followed until a
+  corroborator advances past the fork. This is a **security** limitation for that
+  window (not merely performance), mitigated but not closed by the fail-closed
+  overlap requirement and the per-header density comparison.
 - **Peer-governance demotion** wired to the corroboration-failure event; today
   the source is denied selection (stall) but kept connected so it can serve
   blocks once corroboration arrives.
 
-These do not affect the from-origin **security** property above; they are
-performance and refinement work.
+The first and third are performance/refinement work; the second is a residual
+security limitation of the density-based approach, documented here so operators
+do not over-rely on the gate to resolve every in-window fork.

--- a/GENESIS_SYNC.md
+++ b/GENESIS_SYNC.md
@@ -126,9 +126,13 @@ snapshot yields no usable peers, startup falls back to topology `bootstrapPeers`
   `genesis fast source lacks corroboration; denying chain selection` and a
   `chainselection.genesis_corroboration_failed` event carrying the source
   connection, its observed density, the corroborator count, and the required
-  count. While this persists the node makes no forward progress on that source
-  (it stalls) — this is expected and safe. Investigate whether the snapshot
-  peers are reachable and on the same chain as the fast source.
+  count. While this persists the source's **blocks are withheld from the ledger**
+  (its tips are still observed so corroboration can form, but its
+  `ledger.ChainsyncEvent`/blockfetch is gated off), so the node makes no forward
+  progress on that source — this is expected and safe. A best-peer → none
+  transition also logs `chain selection stalled: no selectable peer` and emits
+  `chainselection.selected_none`. Investigate whether the snapshot peers are
+  reachable and on the same chain as the fast source.
 - **Exit to Praos**: once the local tip catches up to within the Genesis window
   of the best corroborated peer's *advertised* tip (the network tip — not the
   headers delivered so far), the node logs `exiting Genesis selection mode` and

--- a/GENESIS_SYNC.md
+++ b/GENESIS_SYNC.md
@@ -1,0 +1,142 @@
+# Ouroboros Genesis from-origin sync (operator guide)
+
+This guide covers configuring Dingo for **from-origin** (from-genesis) sync using
+Ouroboros Genesis density selection with a biased fast-sync source — for example
+a local shallow peer or the Genesis Sync Accelerator (GSA) — corroborated by
+independent ledger peers.
+
+For the internal design, see `ARCHITECTURE.md` → **Chain Selection → Ouroboros
+Genesis trust model**.
+
+## When this applies
+
+Genesis mode is used only when **all** of these hold:
+
+- `genesisBootstrap.enabled: true` (the default), and
+- the node is starting **from origin** (no `intersectTip`, no explicit
+  intersect points), i.e. an empty database syncing from slot 0.
+
+A node bootstrapped from a Mithril snapshot, or resuming an existing database,
+does not enter Genesis mode — it syncs with normal Praos chain selection.
+
+## Trust model at a glance
+
+| Mode | What it trusts |
+|------|----------------|
+| **Praos** (normal) | The longest valid chain from any peer. |
+| **Mithril bootstrap** | A signed snapshot at a trust boundary, then Praos above it. |
+| **Genesis** (from origin) | Header **density** within a `3k/f`-slot window, **corroborated by independent peers**. |
+
+The security goal for from-origin sync is that a fast source which serves blocks
+quickly but is not itself trustworthy (a shallow local peer, GSA) **cannot steer
+the node onto an untrue chain**. Dingo enforces this with a **corroboration
+gate**: the densest fast source is only followed while independent peers confirm
+its recent blocks. A divergent or uncorroborated source is **denied selection**
+and the node **stalls** rather than following it.
+
+Assumption: at least `corroborationPeers` **honest** peers are reachable (e.g.
+seeded from a ledger peer snapshot). Under that assumption a bad or divergent
+fast source can at worst stall the node.
+
+## Configuration
+
+`dingo.yaml`:
+
+```yaml
+genesisBootstrap:
+  enabled: true
+  # 0 auto-derives the density window from Shelley genesis params (3k/f).
+  windowSlots: 0
+  # Independent peers that must report the same recent blocks before a fast
+  # source may drive Genesis selection. 0 disables corroboration (density-only).
+  # Set this to the number of independent snapshot/ledger peers you expect to
+  # corroborate the fast source.
+  corroborationPeers: 2
+```
+
+Equivalent CLI flags / environment variables:
+
+- `--genesis-bootstrap-enabled` / `DINGO_GENESIS_BOOTSTRAP_ENABLED`
+- `--genesis-bootstrap-window-slots` / `DINGO_GENESIS_BOOTSTRAP_WINDOW_SLOTS`
+- `--genesis-bootstrap-corroboration-peers` / `DINGO_GENESIS_BOOTSTRAP_CORROBORATION_PEERS`
+
+## Topology: fast source + corroborating snapshot
+
+Put the fast source in `localRoots` (mark it `trustable` so peer governance
+keeps it as a preferred ingress source) and point `peerSnapshotFile` at a
+cardano-node ledger peer snapshot. When Genesis selection is active and the
+snapshot has relays, Dingo seeds the snapshot relays as independent ledger peers
+before outbound startup — these are the corroborators.
+
+`topology.json`:
+
+```json
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        { "address": "gsa.internal.example", "port": 3001 }
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 1
+    }
+  ],
+  "publicRoots": [
+    { "accessPoints": [], "advertise": false }
+  ],
+  "peerSnapshotFile": "peer-snapshot.json",
+  "useLedgerAfterSlot": 185500763
+}
+```
+
+The `peerSnapshotFile` path is resolved relative to the topology file. If the
+snapshot yields no usable peers, startup falls back to topology `bootstrapPeers`
+(so keep a bootstrap-peer list configured as a safety net).
+
+## What you should observe
+
+- **Log at startup**: `Genesis chain selection enabled` with `genesis_window_slots`,
+  `security_param`, and `min_corroborating_peers`.
+- **Uncorroborated fast source**: a throttled warning
+  `genesis fast source lacks corroboration; denying chain selection` and a
+  `chainselection.genesis_corroboration_failed` event carrying the source
+  connection, its observed density, the corroborator count, and the required
+  count. While this persists the node makes no forward progress on that source
+  (it stalls) — this is expected and safe. Investigate whether the snapshot
+  peers are reachable and on the same chain as the fast source.
+- **Exit to Praos**: once the local tip catches up to within the Genesis window
+  of the best corroborated peer, the node logs `exiting Genesis selection mode`
+  and emits `chainselection.genesis_mode_exited` (local slot, best known slot,
+  window). Normal Praos selection takes over from there.
+
+`GenesisStatus()` on the chain selector exposes the live mode, window, selected
+fast source, and per-peer density/corroboration for metrics or debugging.
+
+## Tuning `corroborationPeers`
+
+- **0** — corroboration off. The densest source wins on density alone (prior
+  behavior). Use only when every configured peer is already trusted.
+- **1** — a single independent peer must confirm the fast source. Minimal
+  protection; a lone honest snapshot peer is enough to keep going.
+- **2+** — require a quorum of independent peers. More robust against a small
+  set of colluding/divergent sources, but the node stalls until that many
+  reachable peers agree, so size it to how many independent snapshot peers you
+  actually connect.
+
+## Limitations (deferred)
+
+This is a corroboration gate, not the reference implementation's full Ouroboros
+Genesis. Specifically **not** implemented:
+
+- **ChainSync Jumping** and devoted BlockFetch dynamics (a
+  performance/robustness optimization for downloading across many peers).
+- **Density-at-intersection** resolution of a fork whose intersection is *inside*
+  the window (the gate compares recent shared frontier points, not block counts
+  after an exact intersection).
+- **Peer-governance demotion** wired to the corroboration-failure event; today
+  the source is denied selection (stall) but kept connected so it can serve
+  blocks once corroboration arrives.
+
+These do not affect the from-origin **security** property above; they are
+performance and refinement work.

--- a/GENESIS_SYNC.md
+++ b/GENESIS_SYNC.md
@@ -130,8 +130,9 @@ snapshot yields no usable peers, startup falls back to topology `bootstrapPeers`
   (it stalls) — this is expected and safe. Investigate whether the snapshot
   peers are reachable and on the same chain as the fast source.
 - **Exit to Praos**: once the local tip catches up to within the Genesis window
-  of the best corroborated peer, the node logs `exiting Genesis selection mode`
-  and emits `chainselection.genesis_mode_exited` (local slot, best known slot,
+  of the best corroborated peer's *advertised* tip (the network tip — not the
+  headers delivered so far), the node logs `exiting Genesis selection mode` and
+  emits `chainselection.genesis_mode_exited` (local slot, best known slot,
   window). Normal Praos selection takes over from there.
 
 `GenesisStatus()` on the chain selector exposes the live mode, window, selected

--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -41,6 +41,15 @@ const (
 	// local tip has caught up to within the Genesis window of the best known
 	// peer tip.
 	GenesisModeExitedEventType event.EventType = "chainselection.genesis_mode_exited"
+
+	// ChainSelectedNoneEventType is published when the selector transitions to
+	// having no selectable best peer (e.g. an uncorroborated Genesis fast source
+	// is denied). It is the explicit selected-to-none transition that the
+	// ChainSwitchEvent (which always carries a non-nil replacement) cannot
+	// express, so subscribers can observe that selection has stalled. Ledger
+	// application from uncorroborated peers is separately gated via
+	// ShouldApplyIngress; this event is for observability of the stall.
+	ChainSelectedNoneEventType event.EventType = "chainselection.selected_none"
 )
 
 // PeerTipUpdateEvent is published when a peer's chain tip is updated via
@@ -118,6 +127,20 @@ type GenesisCorroborationFailedEvent struct {
 	CorroboratingPeers int
 	RequiredPeers      int
 	GenesisWindowSlots uint64
+}
+
+// ChainSelectedNoneEvent is published when best-peer selection transitions from
+// some peer to none (selection stalled).
+//
+// Fields:
+//   - PreviousConnectionId: the peer that was selected before the stall (zero
+//     value if none was selected).
+//   - GenesisCorroboration: true when the stall is due to the Genesis
+//     corroboration gate (no corroborated peer), as opposed to simply having no
+//     eligible peers.
+type ChainSelectedNoneEvent struct {
+	PreviousConnectionId ouroboros.ConnectionId
+	GenesisCorroboration bool
 }
 
 // GenesisModeExitedEvent is published when the selector leaves Genesis mode.

--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -28,6 +28,19 @@ const (
 	ChainSwitchEventType    event.EventType = "chainselection.chain_switch"
 	ChainSelectionEventType event.EventType = "chainselection.selection"
 	PeerEvictedEventType    event.EventType = "chainselection.peer_evicted"
+
+	// GenesisCorroborationFailedEventType is published when the densest
+	// Genesis fast source cannot be corroborated by the configured minimum
+	// number of independent peers, so it is denied chain selection (stalls)
+	// rather than steering the local chain. Subscribers (peer governance,
+	// operators) can use this to demote or investigate the source.
+	GenesisCorroborationFailedEventType event.EventType = "chainselection.genesis_corroboration_failed"
+
+	// GenesisModeExitedEventType is published when the selector transitions
+	// from Genesis density-based selection back to Praos selection because the
+	// local tip has caught up to within the Genesis window of the best known
+	// peer tip.
+	GenesisModeExitedEventType event.EventType = "chainselection.genesis_mode_exited"
 )
 
 // PeerTipUpdateEvent is published when a peer's chain tip is updated via
@@ -88,4 +101,33 @@ type ChainSelectionEvent struct {
 // manager) can use this to close the evicted peer's connection.
 type PeerEvictedEvent struct {
 	ConnectionId ouroboros.ConnectionId
+}
+
+// GenesisCorroborationFailedEvent is published when the densest Genesis fast
+// source lacks the configured minimum corroboration from independent peers.
+//
+// Fields:
+//   - ConnectionId: the uncorroborated fast source that was denied selection.
+//   - ObservedDensity: its observed block density within the Genesis window.
+//   - CorroboratingPeers: how many independent peers actually corroborate it.
+//   - RequiredPeers: the configured MinCorroboratingPeers threshold.
+//   - GenesisWindowSlots: the active Genesis density window in slots.
+type GenesisCorroborationFailedEvent struct {
+	ConnectionId       ouroboros.ConnectionId
+	ObservedDensity    uint64
+	CorroboratingPeers int
+	RequiredPeers      int
+	GenesisWindowSlots uint64
+}
+
+// GenesisModeExitedEvent is published when the selector leaves Genesis mode.
+//
+// Fields:
+//   - LocalSlot: the local tip slot at the time of exit.
+//   - BestKnownSlot: the best known selectable peer tip slot.
+//   - GenesisWindowSlots: the active Genesis density window in slots.
+type GenesisModeExitedEvent struct {
+	LocalSlot          uint64
+	BestKnownSlot      uint64
+	GenesisWindowSlots uint64
 }

--- a/chainselection/genesis_corroboration.go
+++ b/chainselection/genesis_corroboration.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+)
+
+// Genesis corroboration implements the Ouroboros Genesis trust property that a
+// fast (shallow) block source is followed only while corroborated by
+// independent peers. A candidate peer is "corroborated" when at least
+// MinCorroboratingPeers other eligible, live, non-stale peers report the same
+// recent block(s) within the Genesis density window (identical slot+hash in
+// their observed frontier). An uncorroborated fast source — including a
+// divergent source on a private fork that no honest peer reports — is denied
+// chain selection so it stalls rather than steering the local chain.
+//
+// This is a corroboration gate, not full Ouroboros Genesis density-at-
+// intersection with ChainSync Jumping. See ARCHITECTURE.md ("Ouroboros Genesis
+// trust model") for the supported trust model and the explicitly deferred
+// pieces.
+
+// peerCanCorroborateLocked reports whether a peer is a valid corroboration
+// witness: live, eligible, and non-stale. It deliberately omits the
+// corroboration check itself (which would be circular) and the behind-best
+// selection filters, so honest peers that are slightly behind the fast source
+// still count as witnesses.
+func (cs *ChainSelector) peerCanCorroborateLocked(
+	connId ouroboros.ConnectionId,
+	peerTip *PeerChainTip,
+) bool {
+	if peerTip == nil {
+		return false
+	}
+	if cs.config.ConnectionLive != nil && !cs.config.ConnectionLive(connId) {
+		return false
+	}
+	if !cs.isConnectionEligible(connId) {
+		return false
+	}
+	if cs.isPeerTipStale(peerTip) {
+		return false
+	}
+	return true
+}
+
+// corroboratingPeersLocked counts the distinct other eligible, live, non-stale
+// peers whose observed frontier shares at least one identical (slot, hash)
+// point with the candidate.
+func (cs *ChainSelector) corroboratingPeersLocked(
+	candidate ouroboros.ConnectionId,
+	candidateTip *PeerChainTip,
+) int {
+	if candidateTip == nil {
+		return 0
+	}
+	count := 0
+	for connId, peerTip := range cs.peerTips {
+		if connId == candidate {
+			continue
+		}
+		if !cs.peerCanCorroborateLocked(connId, peerTip) {
+			continue
+		}
+		if candidateTip.sharesObservedPoint(peerTip) {
+			count++
+		}
+	}
+	return count
+}
+
+// isPeerCorroboratedLocked reports whether a peer may drive Genesis chain
+// selection. Corroboration only applies in Genesis mode with a positive
+// MinCorroboratingPeers; otherwise every peer passes (density-only / Praos
+// selection), preserving the historical default.
+func (cs *ChainSelector) isPeerCorroboratedLocked(
+	connId ouroboros.ConnectionId,
+	peerTip *PeerChainTip,
+) bool {
+	if cs.mode != SelectionModeGenesis ||
+		cs.config.MinCorroboratingPeers <= 0 {
+		return true
+	}
+	return cs.corroboratingPeersLocked(connId, peerTip) >=
+		cs.config.MinCorroboratingPeers
+}
+
+// rawDensityLeaderLocked returns the connection with the highest observed
+// density among live/eligible/non-stale peers, ignoring corroboration. This is
+// the fast source Genesis selection would pick on density alone; comparing it
+// against corroboration surfaces a divergent/uncorroborated leader.
+func (cs *ChainSelector) rawDensityLeaderLocked() (
+	ouroboros.ConnectionId,
+	uint64,
+	bool,
+) {
+	window := cs.genesisWindowSlotsLocked()
+	var leader ouroboros.ConnectionId
+	var bestDensity uint64
+	var bestBlock uint64
+	found := false
+	for connId, peerTip := range cs.peerTips {
+		if !cs.peerCanCorroborateLocked(connId, peerTip) {
+			continue
+		}
+		density := peerTip.observedDensity(window)
+		block := peerTip.SelectionTip().BlockNumber
+		if !found || density > bestDensity ||
+			(density == bestDensity && block > bestBlock) {
+			leader = connId
+			bestDensity = density
+			bestBlock = block
+			found = true
+		}
+	}
+	return leader, bestDensity, found
+}
+
+// genesisCorroborationFailureLocked returns a GenesisCorroborationFailedEvent
+// when the densest Genesis fast source cannot be corroborated, deduped so a
+// persistently uncorroborated leader emits once (not on every evaluation).
+// Returns nil outside Genesis corroboration, when the leader is corroborated,
+// or when the same failure was already reported.
+func (cs *ChainSelector) genesisCorroborationFailureLocked() *event.Event {
+	if cs.config.EventBus == nil ||
+		cs.mode != SelectionModeGenesis ||
+		cs.config.MinCorroboratingPeers <= 0 {
+		cs.lastCorroborationFailedConn = nil
+		return nil
+	}
+	leader, density, ok := cs.rawDensityLeaderLocked()
+	if !ok {
+		cs.lastCorroborationFailedConn = nil
+		return nil
+	}
+	corroborators := cs.corroboratingPeersLocked(leader, cs.peerTips[leader])
+	if corroborators >= cs.config.MinCorroboratingPeers {
+		cs.lastCorroborationFailedConn = nil
+		return nil
+	}
+	if cs.lastCorroborationFailedConn != nil &&
+		*cs.lastCorroborationFailedConn == leader {
+		return nil
+	}
+	leaderCopy := leader
+	cs.lastCorroborationFailedConn = &leaderCopy
+	cs.config.Logger.Warn(
+		"genesis fast source lacks corroboration; denying chain selection",
+		"connection_id", leader.String(),
+		"observed_density", density,
+		"corroborating_peers", corroborators,
+		"required_peers", cs.config.MinCorroboratingPeers,
+		"genesis_window_slots", cs.genesisWindowSlotsLocked(),
+	)
+	evt := event.NewEvent(
+		GenesisCorroborationFailedEventType,
+		GenesisCorroborationFailedEvent{
+			ConnectionId:       leader,
+			ObservedDensity:    density,
+			CorroboratingPeers: corroborators,
+			RequiredPeers:      cs.config.MinCorroboratingPeers,
+			GenesisWindowSlots: cs.genesisWindowSlotsLocked(),
+		},
+	)
+	return &evt
+}
+
+// GenesisPeerStatus is the per-peer Genesis observability snapshot.
+type GenesisPeerStatus struct {
+	ConnectionId       ouroboros.ConnectionId
+	ObservedDensity    uint64
+	CorroboratingPeers int
+	Corroborated       bool
+	Selectable         bool
+}
+
+// GenesisStatus is a point-in-time snapshot of Genesis selection state for
+// observability (metrics, logs, operator tooling).
+type GenesisStatus struct {
+	Mode                  SelectionMode
+	WindowSlots           uint64
+	MinCorroboratingPeers int
+	BestSource            *ouroboros.ConnectionId
+	Peers                 []GenesisPeerStatus
+}
+
+// GenesisStatus returns a snapshot of current selection mode, Genesis window,
+// selected fast source, and per-peer density/corroboration for observability.
+func (cs *ChainSelector) GenesisStatus() GenesisStatus {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+
+	window := cs.genesisWindowSlotsLocked()
+	status := GenesisStatus{
+		Mode:                  cs.mode,
+		WindowSlots:           window,
+		MinCorroboratingPeers: cs.config.MinCorroboratingPeers,
+		Peers:                 make([]GenesisPeerStatus, 0, len(cs.peerTips)),
+	}
+	if cs.bestPeerConn != nil {
+		best := *cs.bestPeerConn
+		status.BestSource = &best
+	}
+	for connId, peerTip := range cs.peerTips {
+		corroborators := cs.corroboratingPeersLocked(connId, peerTip)
+		status.Peers = append(status.Peers, GenesisPeerStatus{
+			ConnectionId:       connId,
+			ObservedDensity:    peerTip.observedDensity(window),
+			CorroboratingPeers: corroborators,
+			Corroborated:       cs.isPeerCorroboratedLocked(connId, peerTip),
+			Selectable:         cs.isPeerSelectableLocked(connId, peerTip, false),
+		})
+	}
+	return status
+}

--- a/chainselection/genesis_corroboration.go
+++ b/chainselection/genesis_corroboration.go
@@ -44,6 +44,16 @@ func (cs *ChainSelector) genesisCorroborationActiveLocked() bool {
 		cs.config.MinCorroboratingPeers > 0
 }
 
+// GenesisCorroborationActive reports whether the Genesis corroboration gate is
+// currently in effect. Callers use it to decide whether tip observation must be
+// ordered synchronously with the apply-eligibility gate (see ShouldApplyIngress):
+// the gate is only non-trivial while corroboration is active.
+func (cs *ChainSelector) GenesisCorroborationActive() bool {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return cs.genesisCorroborationActiveLocked()
+}
+
 // peerLiveEligibleNonStaleLocked reports whether a peer passes the shared
 // live/eligible/non-stale prerequisite used by both Genesis corroboration
 // witness eligibility and normal selection eligibility. It is the single

--- a/chainselection/genesis_corroboration.go
+++ b/chainselection/genesis_corroboration.go
@@ -138,6 +138,35 @@ func (cs *ChainSelector) isPeerCorroboratedLocked(
 		cs.config.MinCorroboratingPeers
 }
 
+// ShouldApplyIngress reports whether headers/blocks from connId may be applied
+// to the ledger. It returns false only while Genesis corroboration is active
+// (Genesis mode with a positive threshold) and the peer is not corroborated, so
+// an uncorroborated or divergent fast source is OBSERVED — its tips still feed
+// corroboration via PeerTipUpdateEvent — but its blocks are not applied and it
+// cannot steer the ledger. Enforcing the stall here (ledger application) rather
+// than only at peer selection is required because ingress is gated on peer-
+// governance eligibility, independent of the selected best peer: clearing the
+// active chainsync driver alone would not stop an eligible uncorroborated peer's
+// headers from being applied.
+//
+// An unknown peer (no tips observed yet) is treated as uncorroborated and denied
+// while the gate is active — fail closed until corroboration forms. Outside
+// Genesis corroboration it always returns true (no behavior change).
+func (cs *ChainSelector) ShouldApplyIngress(
+	connId ouroboros.ConnectionId,
+) bool {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	if !cs.genesisCorroborationActiveLocked() {
+		return true
+	}
+	peerTip := cs.peerTips[connId]
+	if peerTip == nil {
+		return false
+	}
+	return cs.isPeerCorroboratedLocked(connId, peerTip)
+}
+
 // rawDensityLeaderLocked returns the connection with the highest observed
 // density among live/eligible/non-stale peers, ignoring corroboration. This is
 // the fast source Genesis selection would pick on density alone; comparing it

--- a/chainselection/genesis_corroboration.go
+++ b/chainselection/genesis_corroboration.go
@@ -15,6 +15,8 @@
 package chainselection
 
 import (
+	"net"
+
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 )
@@ -33,12 +35,20 @@ import (
 // trust model") for the supported trust model and the explicitly deferred
 // pieces.
 
-// peerCanCorroborateLocked reports whether a peer is a valid corroboration
-// witness: live, eligible, and non-stale. It deliberately omits the
-// corroboration check itself (which would be circular) and the behind-best
-// selection filters, so honest peers that are slightly behind the fast source
-// still count as witnesses.
-func (cs *ChainSelector) peerCanCorroborateLocked(
+// genesisCorroborationActiveLocked reports whether the Genesis corroboration
+// gate is in effect (Genesis mode with a positive threshold). When false the
+// selector behaves as before (density-only / Praos) and does not track the
+// per-peer hash frontier used for corroboration.
+func (cs *ChainSelector) genesisCorroborationActiveLocked() bool {
+	return cs.mode == SelectionModeGenesis &&
+		cs.config.MinCorroboratingPeers > 0
+}
+
+// peerLiveEligibleNonStaleLocked reports whether a peer passes the shared
+// live/eligible/non-stale prerequisite used by both Genesis corroboration
+// witness eligibility and normal selection eligibility. It is the single
+// source of truth for those three checks.
+func (cs *ChainSelector) peerLiveEligibleNonStaleLocked(
 	connId ouroboros.ConnectionId,
 	peerTip *PeerChainTip,
 ) bool {
@@ -51,15 +61,43 @@ func (cs *ChainSelector) peerCanCorroborateLocked(
 	if !cs.isConnectionEligible(connId) {
 		return false
 	}
-	if cs.isPeerTipStale(peerTip) {
-		return false
-	}
-	return true
+	return !cs.isPeerTipStale(peerTip)
 }
 
-// corroboratingPeersLocked counts the distinct other eligible, live, non-stale
-// peers whose observed frontier shares at least one identical (slot, hash)
-// point with the candidate.
+// peerCanCorroborateLocked reports whether a peer is a valid corroboration
+// witness: live, eligible, and non-stale. It deliberately omits the
+// corroboration check itself (which would be circular) and the behind-best
+// selection filters, so honest peers that are slightly behind the fast source
+// still count as witnesses.
+func (cs *ChainSelector) peerCanCorroborateLocked(
+	connId ouroboros.ConnectionId,
+	peerTip *PeerChainTip,
+) bool {
+	return cs.peerLiveEligibleNonStaleLocked(connId, peerTip)
+}
+
+// corroboratorIdentity returns a coarse peer identity (remote host, without
+// port) used to de-duplicate corroboration witnesses. Counting raw connection
+// IDs would let several connections from one operator corroborate each other, so
+// witnesses are grouped by remote host. This is a lower bound on independence,
+// not a guarantee: true independence (distinct operators, ASNs, chain views)
+// depends on the operator's topology and diversity groups in peer governance.
+func corroboratorIdentity(connId ouroboros.ConnectionId) string {
+	if connId.RemoteAddr == nil {
+		return connId.String()
+	}
+	addr := connId.RemoteAddr.String()
+	if host, _, err := net.SplitHostPort(addr); err == nil && host != "" {
+		return host
+	}
+	return addr
+}
+
+// corroboratingPeersLocked counts the distinct witness identities whose chain
+// confirms the candidate's recent chain within the Genesis window. Witnesses are
+// de-duplicated by remote host, and any witness sharing the candidate's own host
+// is excluded, so a Sybil fast source opening several connections cannot
+// self-corroborate.
 func (cs *ChainSelector) corroboratingPeersLocked(
 	candidate ouroboros.ConnectionId,
 	candidateTip *PeerChainTip,
@@ -67,7 +105,7 @@ func (cs *ChainSelector) corroboratingPeersLocked(
 	if candidateTip == nil {
 		return 0
 	}
-	count := 0
+	witnesses := make(map[string]struct{})
 	for connId, peerTip := range cs.peerTips {
 		if connId == candidate {
 			continue
@@ -75,11 +113,14 @@ func (cs *ChainSelector) corroboratingPeersLocked(
 		if !cs.peerCanCorroborateLocked(connId, peerTip) {
 			continue
 		}
-		if candidateTip.sharesObservedPoint(peerTip) {
-			count++
+		if candidateTip.confirmsRecentChain(peerTip) {
+			witnesses[corroboratorIdentity(connId)] = struct{}{}
 		}
 	}
-	return count
+	// A witness on the candidate's own host is the same operator; it cannot
+	// count as independent corroboration.
+	delete(witnesses, corroboratorIdentity(candidate))
+	return len(witnesses)
 }
 
 // isPeerCorroboratedLocked reports whether a peer may drive Genesis chain
@@ -90,8 +131,7 @@ func (cs *ChainSelector) isPeerCorroboratedLocked(
 	connId ouroboros.ConnectionId,
 	peerTip *PeerChainTip,
 ) bool {
-	if cs.mode != SelectionModeGenesis ||
-		cs.config.MinCorroboratingPeers <= 0 {
+	if !cs.genesisCorroborationActiveLocked() {
 		return true
 	}
 	return cs.corroboratingPeersLocked(connId, peerTip) >=
@@ -129,15 +169,15 @@ func (cs *ChainSelector) rawDensityLeaderLocked() (
 	return leader, bestDensity, found
 }
 
-// genesisCorroborationFailureLocked returns a GenesisCorroborationFailedEvent
-// when the densest Genesis fast source cannot be corroborated, deduped so a
-// persistently uncorroborated leader emits once (not on every evaluation).
-// Returns nil outside Genesis corroboration, when the leader is corroborated,
-// or when the same failure was already reported.
+// genesisCorroborationFailureLocked warns (deduped) and returns a
+// GenesisCorroborationFailedEvent when the densest Genesis fast source cannot be
+// corroborated. The warning log and dedup run whether or not an EventBus is
+// configured, so an enabled gate that is stalling bootstrap is always visible;
+// only event publishing needs the bus. Returns nil outside Genesis
+// corroboration, when the leader is corroborated, when the same failure was
+// already reported, or when no EventBus is configured to publish to.
 func (cs *ChainSelector) genesisCorroborationFailureLocked() *event.Event {
-	if cs.config.EventBus == nil ||
-		cs.mode != SelectionModeGenesis ||
-		cs.config.MinCorroboratingPeers <= 0 {
+	if !cs.genesisCorroborationActiveLocked() {
 		cs.lastCorroborationFailedConn = nil
 		return nil
 	}
@@ -165,6 +205,9 @@ func (cs *ChainSelector) genesisCorroborationFailureLocked() *event.Event {
 		"required_peers", cs.config.MinCorroboratingPeers,
 		"genesis_window_slots", cs.genesisWindowSlotsLocked(),
 	)
+	if cs.config.EventBus == nil {
+		return nil
+	}
 	evt := event.NewEvent(
 		GenesisCorroborationFailedEventType,
 		GenesisCorroborationFailedEvent{

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -371,6 +371,10 @@ func TestGenesisCorroborationRevokedOnWitnessRemoval(t *testing.T) {
 	require.Equal(t, fast, *cs.GetBestPeer())
 
 	// The witness disconnects; the fast source loses its only corroboration.
+	// RemovePeer itself must re-evaluate here (the removed peer is a witness,
+	// not the best), so GetBestPeer reflects the drop with no extra
+	// EvaluateAndSwitch call — that internal re-evaluation is exactly the
+	// behavior under test.
 	cs.RemovePeer(witness)
 	assert.Nil(
 		t,

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -361,39 +361,102 @@ func TestGenesisDoesNotExitOnEarlyObservedHeaders(t *testing.T) {
 
 	peerA := corrConn(1)
 	peerB := corrConn(2)
-	// Both peers advertise slot 100000 but have only delivered the slot-1
-	// header so far (separate advertised Tip and observed ObservedTip).
+	// Both peers advertise slot 100000 throughout; only their DELIVERED
+	// (observed) frontier advances as sync progresses.
 	advertised := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 100000, Hash: []byte("net-tip")},
 		BlockNumber: 100000,
 	}
-	observed := ochainsync.Tip{
-		Point:       ocommon.Point{Slot: 1, Hash: []byte("h1")},
-		BlockNumber: 1,
+	deliver := func(slot uint64) {
+		obs := ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: slot,
+				Hash: []byte(fmt.Sprintf("h%d", slot)),
+			},
+			BlockNumber: slot,
+		}
+		require.True(t, cs.updatePeerTipObserved(peerA, advertised, obs, nil))
+		require.True(t, cs.updatePeerTipObserved(peerB, advertised, obs, nil))
 	}
-	require.True(t, cs.updatePeerTipObserved(peerA, advertised, observed, nil))
-	require.True(t, cs.updatePeerTipObserved(peerB, advertised, observed, nil))
 
-	// Two peers now corroborate the early header, but the advertised tip is far
-	// beyond the window, so the node must remain in Genesis mode.
+	// Both peers advertise slot 100000 but have only delivered the slot-1
+	// header. The far advertised tip has not been delivered, so the node must
+	// stay in Genesis (no premature exit on early observed headers).
+	deliver(1)
 	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode(),
 		"must not exit Genesis on early observed headers")
 
-	// Advancing the local tip while still far behind the advertised tip keeps
-	// the node in Genesis mode.
+	// Sync progresses: headers are delivered up to slot 50000 and the local tip
+	// follows. Still far below the advertised tip, so stay in Genesis.
+	deliver(50000)
 	cs.SetLocalTip(ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 50000, Hash: []byte("local-50000")},
 		BlockNumber: 50000,
 	})
 	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode())
 
-	// Only once the local tip catches up to within the window (30) of the
-	// advertised tip does the node exit to Praos.
+	// Only once the peers have DELIVERED headers up to within the window (30) of
+	// their advertised tip — and the local tip has caught up — does the node
+	// exit to Praos.
+	deliver(99990)
 	cs.SetLocalTip(ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 99990, Hash: []byte("local-99990")},
 		BlockNumber: 99990,
 	})
 	assert.Equal(t, SelectionModePraos, cs.SelectionMode())
+}
+
+// A corroborated peer can still lie about its advertised tip: it delivers a
+// shared early header (passing corroboration) but advertises a slot near
+// MaxUint64 it has not delivered. That undelivered advertised slot must not pin
+// Genesis mode — the exit horizon is bound to delivered headers, so the node
+// still exits once the local tip catches up to the delivered/corroborated tip.
+func TestGenesisExitNotPinnedByCorroboratedLiarAdvertisingFarTip(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         10, // window = 30
+		MinCorroboratingPeers: 1,
+	})
+
+	honest := corrConn(1)
+	liar := corrConn(2)
+	// Both deliver the same header at slot 100, so they corroborate each other.
+	sharedObs := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("h100")},
+		BlockNumber: 100,
+	}
+	// Honest advertises what it has delivered.
+	require.True(t, cs.updatePeerTipObserved(
+		honest,
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 100, Hash: []byte("honest-tip")},
+			BlockNumber: 100,
+		},
+		sharedObs,
+		nil,
+	))
+	// Liar is corroborated on the shared slot-100 header but advertises an
+	// extreme tip it has NOT delivered.
+	const extremeSlot = uint64(1) << 62
+	require.True(t, cs.updatePeerTipObserved(
+		liar,
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: extremeSlot, Hash: []byte("liar-tip")},
+			BlockNumber: 100,
+		},
+		sharedObs,
+		nil,
+	))
+
+	// Local catches up to the delivered/corroborated tip (slot 100).
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("local-100")},
+		BlockNumber: 100,
+	})
+
+	// The liar's undelivered extreme advertised slot must not pin Genesis mode.
+	assert.Equal(t, SelectionModePraos, cs.SelectionMode(),
+		"a corroborated peer's undelivered advertised slot must not pin Genesis")
 }
 
 // The Genesis exit horizon must be bounded so a single uncorroborated peer

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -15,6 +15,8 @@
 package chainselection
 
 import (
+	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -26,6 +28,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// corrConn builds a connection id with a distinct remote HOST per n, so peers
+// count as independent corroboration witnesses (which dedup by remote host).
+func corrConn(n int) ouroboros.ConnectionId {
+	return corrConnAddr(fmt.Sprintf("10.0.0.%d", n), 3001)
+}
+
+// corrConnAddr builds a connection id for an explicit remote host and port,
+// used to model several connections sharing one host (a Sybil source).
+func corrConnAddr(host string, port int) ouroboros.ConnectionId {
+	localAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:3001")
+	remoteAddr, _ := net.ResolveTCPAddr(
+		"tcp",
+		fmt.Sprintf("%s:%d", host, port),
+	)
+	return ouroboros.ConnectionId{
+		LocalAddr:  localAddr,
+		RemoteAddr: remoteAddr,
+	}
+}
 
 // genesisTip builds a chainsync tip at the given slot with a named hash.
 func genesisTip(slot uint64, hash string, block uint64) ochainsync.Tip {
@@ -47,18 +69,24 @@ func feedFrontier(
 	}
 }
 
+// feedPoints records a sequence of points into a bare PeerChainTip with hash
+// tracking enabled.
+func feedPoints(pt *PeerChainTip, window uint64, points ...ocommon.Point) {
+	for _, p := range points {
+		pt.recordObservedPoint(p, window, true)
+	}
+}
+
 // recordObservedPoint keeps the slot frontier and the point (slot+hash)
 // frontier in lockstep, storing the current hash at each slot.
 func TestRecordObservedPointTracksHashFrontier(t *testing.T) {
 	pt := &PeerChainTip{}
 	window := uint64(100)
-	for _, p := range []ocommon.Point{
-		{Slot: 10, Hash: []byte("h10")},
-		{Slot: 20, Hash: []byte("h20")},
-		{Slot: 30, Hash: []byte("h30")},
-	} {
-		pt.recordObservedPoint(p, window)
-	}
+	feedPoints(pt, window,
+		ocommon.Point{Slot: 10, Hash: []byte("h10")},
+		ocommon.Point{Slot: 20, Hash: []byte("h20")},
+		ocommon.Point{Slot: 30, Hash: []byte("h30")},
+	)
 
 	require.Equal(t, []uint64{10, 20, 30}, pt.observedSlots)
 	require.Len(t, pt.observedPoints, 3)
@@ -72,10 +100,36 @@ func TestRecordObservedPointTracksHashFrontier(t *testing.T) {
 	}
 
 	// Re-reporting the same slot with a new hash updates the frontier in place.
-	pt.recordObservedPoint(ocommon.Point{Slot: 30, Hash: []byte("h30b")}, window)
+	pt.recordObservedPoint(
+		ocommon.Point{Slot: 30, Hash: []byte("h30b")},
+		window,
+		true,
+	)
 	require.Equal(t, []uint64{10, 20, 30}, pt.observedSlots)
 	require.Len(t, pt.observedPoints, 3)
 	assert.Equal(t, []byte("h30b"), pt.observedPoints[2].Hash)
+}
+
+// With hash tracking disabled (corroboration inactive) only the slot frontier
+// is kept; the hash frontier is not retained.
+func TestRecordObservedPointSkipsHashesWhenInactive(t *testing.T) {
+	pt := &PeerChainTip{}
+	window := uint64(100)
+	for _, p := range []ocommon.Point{
+		{Slot: 10, Hash: []byte("h10")},
+		{Slot: 20, Hash: []byte("h20")},
+	} {
+		pt.recordObservedPoint(p, window, false)
+	}
+	assert.Equal(t, []uint64{10, 20}, pt.observedSlots)
+	assert.Empty(t, pt.observedPoints)
+
+	// Enabling tracking starts populating the hash frontier again; disabling
+	// clears it.
+	pt.recordObservedPoint(ocommon.Point{Slot: 30, Hash: []byte("h30")}, window, true)
+	assert.Len(t, pt.observedPoints, 1)
+	pt.recordObservedPoint(ocommon.Point{Slot: 40, Hash: []byte("h40")}, window, false)
+	assert.Empty(t, pt.observedPoints)
 }
 
 // ApplyRollback trims the slot and point frontiers together so they stay
@@ -83,13 +137,11 @@ func TestRecordObservedPointTracksHashFrontier(t *testing.T) {
 func TestApplyRollbackTrimsPointFrontier(t *testing.T) {
 	pt := &PeerChainTip{}
 	window := uint64(100)
-	for _, p := range []ocommon.Point{
-		{Slot: 10, Hash: []byte("h10")},
-		{Slot: 20, Hash: []byte("h20")},
-		{Slot: 30, Hash: []byte("h30")},
-	} {
-		pt.recordObservedPoint(p, window)
-	}
+	feedPoints(pt, window,
+		ocommon.Point{Slot: 10, Hash: []byte("h10")},
+		ocommon.Point{Slot: 20, Hash: []byte("h20")},
+		ocommon.Point{Slot: 30, Hash: []byte("h30")},
+	)
 
 	pt.ApplyRollback(
 		ocommon.Point{Slot: 20, Hash: []byte("h20")},
@@ -105,36 +157,78 @@ func TestApplyRollbackTrimsPointFrontier(t *testing.T) {
 	assert.Equal(t, []byte("h20"), pt.observedPoints[1].Hash)
 
 	// A subsequent point extends both frontiers consistently.
-	pt.recordObservedPoint(ocommon.Point{Slot: 40, Hash: []byte("h40")}, window)
+	pt.recordObservedPoint(ocommon.Point{Slot: 40, Hash: []byte("h40")}, window, true)
 	require.Equal(t, []uint64{10, 20, 40}, pt.observedSlots)
 	require.Len(t, pt.observedPoints, 3)
 	assert.Equal(t, []byte("h40"), pt.observedPoints[2].Hash)
 }
 
-// sharesObservedPoint requires an identical slot AND hash; a peer on a divergent
-// fork (same slots, different hashes) does not corroborate.
-func TestSharesObservedPointHashSensitive(t *testing.T) {
+// confirmsRecentChain requires the witness's chain, as far as it reaches into
+// the candidate's window, to match the candidate: same-chain peers confirm each
+// other; a peer on a divergent fork does not.
+func TestConfirmsRecentChainHashSensitive(t *testing.T) {
 	window := uint64(100)
 	honestA := &PeerChainTip{}
 	honestB := &PeerChainTip{}
 	divergent := &PeerChainTip{}
-	for _, p := range []ocommon.Point{
-		{Slot: 10, Hash: []byte("h10")},
-		{Slot: 20, Hash: []byte("h20")},
-	} {
-		honestA.recordObservedPoint(p, window)
-		honestB.recordObservedPoint(p, window)
-	}
-	for _, p := range []ocommon.Point{
-		{Slot: 10, Hash: []byte("x10")},
-		{Slot: 20, Hash: []byte("x20")},
-	} {
-		divergent.recordObservedPoint(p, window)
-	}
+	feedPoints(honestA, window,
+		ocommon.Point{Slot: 10, Hash: []byte("h10")},
+		ocommon.Point{Slot: 20, Hash: []byte("h20")},
+	)
+	feedPoints(honestB, window,
+		ocommon.Point{Slot: 10, Hash: []byte("h10")},
+		ocommon.Point{Slot: 20, Hash: []byte("h20")},
+	)
+	feedPoints(divergent, window,
+		ocommon.Point{Slot: 10, Hash: []byte("x10")},
+		ocommon.Point{Slot: 20, Hash: []byte("x20")},
+	)
 
-	assert.True(t, honestA.sharesObservedPoint(honestB))
-	assert.False(t, honestA.sharesObservedPoint(divergent))
-	assert.False(t, divergent.sharesObservedPoint(honestB))
+	assert.True(t, honestA.confirmsRecentChain(honestB))
+	assert.False(t, honestA.confirmsRecentChain(divergent))
+	assert.False(t, divergent.confirmsRecentChain(honestB))
+}
+
+// Regression for the "shared ancestor then diverge" bypass: a fast source that
+// agrees on one old block but then produces different blocks for the rest of the
+// window is NOT confirmed by an honest witness, because the witness observed
+// recent blocks the candidate does not have.
+func TestConfirmsRecentChainRejectsSharedAncestorThenDiverge(t *testing.T) {
+	window := uint64(100)
+	fast := &PeerChainTip{}
+	honest := &PeerChainTip{}
+	// Both agree on slot 100, then the fast source forks (x...) while the
+	// honest witness continues on the real chain (h...).
+	feedPoints(fast, window,
+		ocommon.Point{Slot: 100, Hash: []byte("shared-100")},
+		ocommon.Point{Slot: 105, Hash: []byte("x105")},
+		ocommon.Point{Slot: 110, Hash: []byte("x110")},
+	)
+	feedPoints(honest, window,
+		ocommon.Point{Slot: 100, Hash: []byte("shared-100")},
+		ocommon.Point{Slot: 106, Hash: []byte("h106")},
+		ocommon.Point{Slot: 111, Hash: []byte("h111")},
+	)
+
+	assert.False(t, fast.confirmsRecentChain(honest),
+		"a witness that diverges after the shared ancestor must not confirm")
+}
+
+// A witness whose frontier does not overlap the candidate's window cannot
+// confirm it (fail-closed).
+func TestConfirmsRecentChainRequiresOverlap(t *testing.T) {
+	window := uint64(20)
+	ahead := &PeerChainTip{}
+	behind := &PeerChainTip{}
+	feedPoints(ahead, window,
+		ocommon.Point{Slot: 200, Hash: []byte("h200")},
+		ocommon.Point{Slot: 210, Hash: []byte("h210")},
+	)
+	feedPoints(behind, window,
+		ocommon.Point{Slot: 100, Hash: []byte("h100")},
+		ocommon.Point{Slot: 105, Hash: []byte("h105")},
+	)
+	assert.False(t, ahead.confirmsRecentChain(behind))
 }
 
 // A dense fast source whose recent blocks are also reported by other eligible
@@ -147,9 +241,9 @@ func TestGenesisHonestFastSourceIsCorroborated(t *testing.T) {
 		MinCorroboratingPeers: 1,
 	})
 
-	fast := newTestConnectionId(1)
-	corroboratorA := newTestConnectionId(2)
-	corroboratorB := newTestConnectionId(3)
+	fast := corrConn(1)
+	corroboratorA := corrConn(2)
+	corroboratorB := corrConn(3)
 
 	// Fast source: three blocks in the window (densest).
 	feedFrontier(cs, fast,
@@ -204,9 +298,9 @@ func TestGenesisDivergentFastSourceNotSelected(t *testing.T) {
 		EventBus:              bus,
 	})
 
-	divergent := newTestConnectionId(1)
-	honestA := newTestConnectionId(2)
-	honestB := newTestConnectionId(3)
+	divergent := corrConn(1)
+	honestA := corrConn(2)
+	honestB := corrConn(3)
 
 	// Divergent source: densest/longest, but on a private fork — its block
 	// hashes ("x...") are seen by nobody else.
@@ -251,6 +345,40 @@ func TestGenesisDivergentFastSourceNotSelected(t *testing.T) {
 		"expected corroboration-failure event for divergent source")
 }
 
+// Removing the only witness revokes the incumbent fast source's corroboration
+// and forces a re-evaluation that drops it, even though the removed peer was not
+// itself the selected best.
+func TestGenesisCorroborationRevokedOnWitnessRemoval(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	fast := corrConn(1)
+	witness := corrConn(2)
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	feedFrontier(cs, witness,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, fast, *cs.GetBestPeer())
+
+	// The witness disconnects; the fast source loses its only corroboration.
+	cs.RemovePeer(witness)
+	assert.Nil(
+		t,
+		cs.GetBestPeer(),
+		"incumbent must be dropped once it loses corroboration",
+	)
+}
+
 // With no corroborating peers available, a fast source stalls: the selector
 // refuses to select it, returning no best peer, rather than following an
 // uncorroborated chain.
@@ -261,7 +389,7 @@ func TestGenesisInsufficientCorroborationStalls(t *testing.T) {
 		MinCorroboratingPeers: 1,
 	})
 
-	fast := newTestConnectionId(1)
+	fast := corrConn(1)
 	feedFrontier(cs, fast,
 		genesisTip(100, "h100", 100),
 		genesisTip(105, "h105", 105),
@@ -285,8 +413,8 @@ func TestGenesisCorroborationQuorumNotMet(t *testing.T) {
 		MinCorroboratingPeers: 2,
 	})
 
-	fast := newTestConnectionId(1)
-	corroborator := newTestConnectionId(2)
+	fast := corrConn(1)
+	corroborator := corrConn(2)
 
 	feedFrontier(cs, fast,
 		genesisTip(100, "h100", 100),
@@ -304,6 +432,48 @@ func TestGenesisCorroborationQuorumNotMet(t *testing.T) {
 		cs.GetBestPeer(),
 		"quorum of 2 not met with a single corroborator; must stall",
 	)
+}
+
+// Several connections from the SAME remote host cannot corroborate each other:
+// witnesses are de-duplicated by host, so a Sybil fast source opening multiple
+// connections still lacks independent corroboration and stalls.
+func TestGenesisCorroborationDedupsBySybilHost(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	// Fast source and two "corroborators" that are really the same operator
+	// host (10.9.9.9), just different ports.
+	fast := corrConnAddr("10.9.9.9", 3001)
+	sybilA := corrConnAddr("10.9.9.9", 3002)
+	sybilB := corrConnAddr("10.9.9.9", 3003)
+	for _, conn := range []ouroboros.ConnectionId{fast, sybilA, sybilB} {
+		feedFrontier(cs, conn,
+			genesisTip(100, "h100", 100),
+			genesisTip(105, "h105", 105),
+			genesisTip(110, "h110", 110),
+		)
+	}
+
+	cs.EvaluateAndSwitch()
+	assert.Nil(
+		t,
+		cs.GetBestPeer(),
+		"same-host connections must not self-corroborate a Sybil fast source",
+	)
+
+	// Add a genuinely independent host on the same chain; now corroboration
+	// succeeds.
+	independent := corrConnAddr("10.0.0.42", 3001)
+	feedFrontier(cs, independent,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer(),
+		"an independent-host corroborator should satisfy the gate")
 }
 
 // Corroboration is opt-in. With MinCorroboratingPeers == 0 (the default), a
@@ -337,8 +507,8 @@ func TestGenesisStatusObservability(t *testing.T) {
 		MinCorroboratingPeers: 1,
 	})
 
-	fast := newTestConnectionId(1)
-	corroborator := newTestConnectionId(2)
+	fast := corrConn(1)
+	corroborator := corrConn(2)
 	feedFrontier(cs, fast,
 		genesisTip(100, "h100", 100),
 		genesisTip(105, "h105", 105),

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -231,6 +231,50 @@ func TestConfirmsRecentChainRequiresOverlap(t *testing.T) {
 	assert.False(t, ahead.confirmsRecentChain(behind))
 }
 
+// Removing the selected best peer with no replacement also publishes a
+// ChainSelectedNoneEvent (the event represents every selected-to-none
+// transition, not only the evaluate-loop path).
+func TestChainSelectedNoneEventOnBestPeerRemoval(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var mu sync.Mutex
+	var events []ChainSelectedNoneEvent
+	bus.SubscribeFunc(
+		ChainSelectedNoneEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(ChainSelectedNoneEvent)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			events = append(events, e)
+			mu.Unlock()
+		},
+	)
+
+	cs := NewChainSelector(ChainSelectorConfig{EventBus: bus})
+	conn := corrConn(1)
+	cs.UpdatePeerTip(conn, genesisTip(100, "h100", 100), nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+
+	cs.RemovePeer(conn)
+	require.Nil(t, cs.GetBestPeer())
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, e := range events {
+			if e.PreviousConnectionId == conn {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected ChainSelectedNoneEvent when the selected best peer is removed")
+}
+
 // ShouldApplyIngress is the real enforcement of the corroboration stall: an
 // uncorroborated peer is observed (tips feed corroboration) but its blocks must
 // not be applied. It gates apply on corroboration while active, denying unknown

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -231,6 +231,122 @@ func TestConfirmsRecentChainRequiresOverlap(t *testing.T) {
 	assert.False(t, ahead.confirmsRecentChain(behind))
 }
 
+// ShouldApplyIngress is the real enforcement of the corroboration stall: an
+// uncorroborated peer is observed (tips feed corroboration) but its blocks must
+// not be applied. It gates apply on corroboration while active, denying unknown
+// and uncorroborated peers, and re-denies when corroboration is revoked.
+func TestGenesisShouldApplyIngressGatesUncorroborated(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	fast := corrConn(1)
+	witness := corrConn(2)
+
+	// Unknown peer: fail closed (deny apply) while the gate is active.
+	assert.False(t, cs.ShouldApplyIngress(fast))
+
+	// Lone uncorroborated fast source: observed but denied application.
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	assert.False(t, cs.ShouldApplyIngress(fast),
+		"uncorroborated fast source must not be apply-eligible")
+
+	// A corroborator arrives: both become apply-eligible.
+	feedFrontier(cs, witness,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	assert.True(t, cs.ShouldApplyIngress(fast))
+	assert.True(t, cs.ShouldApplyIngress(witness))
+
+	// The witness disconnects: corroboration is revoked, so the fast source is
+	// denied application again (no post-revocation ingress).
+	cs.RemovePeer(witness)
+	assert.False(t, cs.ShouldApplyIngress(fast),
+		"apply must be denied again once corroboration is revoked")
+}
+
+// Outside Genesis corroboration (Praos, or Genesis with the gate disabled) every
+// peer is apply-eligible — no behavior change.
+func TestShouldApplyIngressAllowsWhenCorroborationInactive(t *testing.T) {
+	conn := corrConn(1)
+
+	praos := NewChainSelector(ChainSelectorConfig{})
+	assert.True(t, praos.ShouldApplyIngress(conn))
+
+	genesisNoGate := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 20,
+	})
+	assert.True(t, genesisNoGate.ShouldApplyIngress(conn))
+}
+
+// A best-peer → none transition publishes an explicit ChainSelectedNoneEvent so
+// subscribers can observe that selection has stalled.
+func TestChainSelectedNoneEventOnCorroborationRevocation(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var mu sync.Mutex
+	var events []ChainSelectedNoneEvent
+	bus.SubscribeFunc(
+		ChainSelectedNoneEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(ChainSelectedNoneEvent)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			events = append(events, e)
+			mu.Unlock()
+		},
+	)
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+		EventBus:              bus,
+	})
+
+	fast := corrConn(1)
+	witness := corrConn(2)
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	feedFrontier(cs, witness,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, fast, *cs.GetBestPeer())
+
+	// Revoke corroboration by removing the witness.
+	cs.RemovePeer(witness)
+	require.Nil(t, cs.GetBestPeer())
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, e := range events {
+			if e.PreviousConnectionId == fast && e.GenesisCorroboration {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected ChainSelectedNoneEvent for the stalled incumbent")
+}
+
 // A dense fast source whose recent blocks are also reported by other eligible
 // peers (shared block hashes at shared slots) is corroborated, so it is
 // selected as the best chain in Genesis mode.
@@ -650,6 +766,39 @@ func TestGenesisCorroborationDedupsBySybilHost(t *testing.T) {
 	cs.EvaluateAndSwitch()
 	require.NotNil(t, cs.GetBestPeer(),
 		"an independent-host corroborator should satisfy the gate")
+}
+
+// A negative corroboration threshold (reachable via the public programmatic API,
+// e.g. NewConfig(WithGenesisCorroborationPeers(-1))) must fail closed: the gate
+// stays active rather than being silently disabled. Only 0 disables it.
+func TestGenesisNegativeCorroborationFailsClosed(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: -1,
+	})
+
+	// The gate is active (clamped to 1), not disabled: a lone fast source with
+	// no corroborators is denied selection and stalls.
+	fast := corrConn(1)
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	cs.EvaluateAndSwitch()
+	assert.Nil(t, cs.GetBestPeer(),
+		"negative threshold must fail closed (gate active), not disable the gate")
+
+	// Adding one independent corroborator satisfies the clamped threshold of 1.
+	witness := corrConn(2)
+	feedFrontier(cs, witness,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Equal(t, fast, *cs.GetBestPeer())
 }
 
 // Corroboration is opt-in. With MinCorroboratingPeers == 0 (the default), a

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -345,6 +345,57 @@ func TestGenesisDivergentFastSourceNotSelected(t *testing.T) {
 		"expected corroboration-failure event for divergent source")
 }
 
+// In a realistic from-origin ChainSync flow a peer advertises a far-ahead tip
+// (slot 100000) but has only delivered early headers (slot 1). Genesis-mode exit
+// must key off the advertised network tip, not the observed frontier: otherwise
+// the node leaves Genesis mode — and disables the corroboration gate — as soon
+// as two peers corroborate an early header, long before the local tip is near
+// the network tip.
+func TestGenesisDoesNotExitOnEarlyObservedHeaders(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         10, // window = 30
+		MinCorroboratingPeers: 1,
+	})
+	require.Equal(t, uint64(30), cs.GenesisWindowSlots())
+
+	peerA := corrConn(1)
+	peerB := corrConn(2)
+	// Both peers advertise slot 100000 but have only delivered the slot-1
+	// header so far (separate advertised Tip and observed ObservedTip).
+	advertised := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100000, Hash: []byte("net-tip")},
+		BlockNumber: 100000,
+	}
+	observed := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 1, Hash: []byte("h1")},
+		BlockNumber: 1,
+	}
+	require.True(t, cs.updatePeerTipObserved(peerA, advertised, observed, nil))
+	require.True(t, cs.updatePeerTipObserved(peerB, advertised, observed, nil))
+
+	// Two peers now corroborate the early header, but the advertised tip is far
+	// beyond the window, so the node must remain in Genesis mode.
+	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode(),
+		"must not exit Genesis on early observed headers")
+
+	// Advancing the local tip while still far behind the advertised tip keeps
+	// the node in Genesis mode.
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 50000, Hash: []byte("local-50000")},
+		BlockNumber: 50000,
+	})
+	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	// Only once the local tip catches up to within the window (30) of the
+	// advertised tip does the node exit to Praos.
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 99990, Hash: []byte("local-99990")},
+		BlockNumber: 99990,
+	})
+	assert.Equal(t, SelectionModePraos, cs.SelectionMode())
+}
+
 // Removing the only witness revokes the incumbent fast source's corroboration
 // and forces a re-evaluation that drops it, even though the removed peer was not
 // itself the selected best.

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -396,6 +396,67 @@ func TestGenesisDoesNotExitOnEarlyObservedHeaders(t *testing.T) {
 	assert.Equal(t, SelectionModePraos, cs.SelectionMode())
 }
 
+// The Genesis exit horizon must include an uncorroborated far-ahead source, not
+// only selectable (corroborated) peers. Otherwise a lower corroborated peer can
+// trigger a premature exit to Praos, which disables the corroboration gate and
+// lets the uncorroborated source steer the chain. The source here has a high
+// slot but a block number close to the honest peers (a low-density divergent
+// chain), so the block-based behind-best filter does not exclude it.
+func TestGenesisExitHorizonIncludesUncorroboratedSource(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         10, // window = 30
+		MinCorroboratingPeers: 1,
+	})
+
+	fast := corrConn(1)
+	honestA := corrConn(2)
+	honestB := corrConn(3)
+
+	// Uncorroborated far source: advertises slot 100000 but block only 205 (a
+	// sparse/divergent chain), so it is within K blocks of the honest peers and
+	// is not behind-best-filtered, yet nobody corroborates its chain.
+	require.True(t, cs.updatePeerTipObserved(
+		fast,
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 100000, Hash: []byte("fast-tip")},
+			BlockNumber: 205,
+		},
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 100000, Hash: []byte("fast-hdr")},
+			BlockNumber: 205,
+		},
+		nil,
+	))
+
+	// Honest peers on the real chain at slot 200 / block 200, corroborating each
+	// other.
+	honestAdv := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("real-tip")},
+		BlockNumber: 200,
+	}
+	honestObs := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("real-hdr")},
+		BlockNumber: 200,
+	}
+	require.True(t, cs.updatePeerTipObserved(honestA, honestAdv, honestObs, nil))
+	require.True(t, cs.updatePeerTipObserved(honestB, honestAdv, honestObs, nil))
+
+	// Local tip has caught up to the honest corroborated tip (slot 200).
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 200, Hash: []byte("local-200")},
+		BlockNumber: 200,
+	})
+
+	// The uncorroborated far source's advertised slot (100000) must keep the
+	// exit horizon high, so the node stays in Genesis and the gate stays active.
+	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode(),
+		"an uncorroborated far source must keep Genesis mode active")
+	// The honest corroborated peers are what actually drive selection.
+	require.NotNil(t, cs.GetBestPeer())
+	assert.Contains(t, []ouroboros.ConnectionId{honestA, honestB}, *cs.GetBestPeer())
+}
+
 // Removing the only witness revokes the incumbent fast source's corroboration
 // and forces a re-evaluation that drops it, even though the removed peer was not
 // itself the selected best.

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -396,38 +396,22 @@ func TestGenesisDoesNotExitOnEarlyObservedHeaders(t *testing.T) {
 	assert.Equal(t, SelectionModePraos, cs.SelectionMode())
 }
 
-// The Genesis exit horizon must include an uncorroborated far-ahead source, not
-// only selectable (corroborated) peers. Otherwise a lower corroborated peer can
-// trigger a premature exit to Praos, which disables the corroboration gate and
-// lets the uncorroborated source steer the chain. The source here has a high
-// slot but a block number close to the honest peers (a low-density divergent
-// chain), so the block-based behind-best filter does not exclude it.
-func TestGenesisExitHorizonIncludesUncorroboratedSource(t *testing.T) {
+// The Genesis exit horizon must be bounded so a single uncorroborated peer
+// cannot pin Genesis mode indefinitely. The advertised slot is untrusted and the
+// implausible-tip check bounds only the advertised block number, so a peer can
+// advertise a plausible block with a near-MaxUint64 slot. Because the horizon is
+// built from corroborated peers only, that extreme slot is ignored and the node
+// still exits once the local tip catches up to the corroborated network tip.
+func TestGenesisExitNotPinnedByUncorroboratedExtremeSlot(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
 		GenesisMode:           true,
 		SecurityParam:         10, // window = 30
 		MinCorroboratingPeers: 1,
 	})
 
-	fast := corrConn(1)
-	honestA := corrConn(2)
-	honestB := corrConn(3)
-
-	// Uncorroborated far source: advertises slot 100000 but block only 205 (a
-	// sparse/divergent chain), so it is within K blocks of the honest peers and
-	// is not behind-best-filtered, yet nobody corroborates its chain.
-	require.True(t, cs.updatePeerTipObserved(
-		fast,
-		ochainsync.Tip{
-			Point:       ocommon.Point{Slot: 100000, Hash: []byte("fast-tip")},
-			BlockNumber: 205,
-		},
-		ochainsync.Tip{
-			Point:       ocommon.Point{Slot: 100000, Hash: []byte("fast-hdr")},
-			BlockNumber: 205,
-		},
-		nil,
-	))
+	honestA := corrConn(1)
+	honestB := corrConn(2)
+	liar := corrConn(3)
 
 	// Honest peers on the real chain at slot 200 / block 200, corroborating each
 	// other.
@@ -442,19 +426,32 @@ func TestGenesisExitHorizonIncludesUncorroboratedSource(t *testing.T) {
 	require.True(t, cs.updatePeerTipObserved(honestA, honestAdv, honestObs, nil))
 	require.True(t, cs.updatePeerTipObserved(honestB, honestAdv, honestObs, nil))
 
-	// Local tip has caught up to the honest corroborated tip (slot 200).
+	// Uncorroborated liar: a plausible block number (200, within K of the honest
+	// peers) but an extreme advertised slot that nothing corroborates.
+	const extremeSlot = uint64(1) << 62
+	require.True(t, cs.updatePeerTipObserved(
+		liar,
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: extremeSlot, Hash: []byte("liar-tip")},
+			BlockNumber: 200,
+		},
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: extremeSlot, Hash: []byte("liar-hdr")},
+			BlockNumber: 200,
+		},
+		nil,
+	))
+
+	// Local tip catches up to the corroborated honest tip (slot 200).
 	cs.SetLocalTip(ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 200, Hash: []byte("local-200")},
 		BlockNumber: 200,
 	})
 
-	// The uncorroborated far source's advertised slot (100000) must keep the
-	// exit horizon high, so the node stays in Genesis and the gate stays active.
-	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode(),
-		"an uncorroborated far source must keep Genesis mode active")
-	// The honest corroborated peers are what actually drive selection.
-	require.NotNil(t, cs.GetBestPeer())
-	assert.Contains(t, []ouroboros.ConnectionId{honestA, honestB}, *cs.GetBestPeer())
+	// The liar's extreme advertised slot must NOT pin Genesis mode: the horizon
+	// is the corroborated tip (200), so the node exits to Praos.
+	assert.Equal(t, SelectionModePraos, cs.SelectionMode(),
+		"an uncorroborated extreme advertised slot must not pin Genesis mode")
 }
 
 // Removing the only witness revokes the incumbent fast source's corroboration

--- a/chainselection/genesis_corroboration_test.go
+++ b/chainselection/genesis_corroboration_test.go
@@ -1,0 +1,418 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// genesisTip builds a chainsync tip at the given slot with a named hash.
+func genesisTip(slot uint64, hash string, block uint64) ochainsync.Tip {
+	return ochainsync.Tip{
+		Point:       ocommon.Point{Slot: slot, Hash: []byte(hash)},
+		BlockNumber: block,
+	}
+}
+
+// feedFrontier applies a sequence of tips to a peer so it accumulates an
+// observed slot/point frontier for Genesis density and corroboration.
+func feedFrontier(
+	cs *ChainSelector,
+	connId ouroboros.ConnectionId,
+	tips ...ochainsync.Tip,
+) {
+	for _, tip := range tips {
+		cs.UpdatePeerTip(connId, tip, nil)
+	}
+}
+
+// recordObservedPoint keeps the slot frontier and the point (slot+hash)
+// frontier in lockstep, storing the current hash at each slot.
+func TestRecordObservedPointTracksHashFrontier(t *testing.T) {
+	pt := &PeerChainTip{}
+	window := uint64(100)
+	for _, p := range []ocommon.Point{
+		{Slot: 10, Hash: []byte("h10")},
+		{Slot: 20, Hash: []byte("h20")},
+		{Slot: 30, Hash: []byte("h30")},
+	} {
+		pt.recordObservedPoint(p, window)
+	}
+
+	require.Equal(t, []uint64{10, 20, 30}, pt.observedSlots)
+	require.Len(t, pt.observedPoints, 3)
+	for i, want := range []ocommon.Point{
+		{Slot: 10, Hash: []byte("h10")},
+		{Slot: 20, Hash: []byte("h20")},
+		{Slot: 30, Hash: []byte("h30")},
+	} {
+		assert.Equal(t, want.Slot, pt.observedPoints[i].Slot)
+		assert.Equal(t, want.Hash, pt.observedPoints[i].Hash)
+	}
+
+	// Re-reporting the same slot with a new hash updates the frontier in place.
+	pt.recordObservedPoint(ocommon.Point{Slot: 30, Hash: []byte("h30b")}, window)
+	require.Equal(t, []uint64{10, 20, 30}, pt.observedSlots)
+	require.Len(t, pt.observedPoints, 3)
+	assert.Equal(t, []byte("h30b"), pt.observedPoints[2].Hash)
+}
+
+// ApplyRollback trims the slot and point frontiers together so they stay
+// aligned after a rollback.
+func TestApplyRollbackTrimsPointFrontier(t *testing.T) {
+	pt := &PeerChainTip{}
+	window := uint64(100)
+	for _, p := range []ocommon.Point{
+		{Slot: 10, Hash: []byte("h10")},
+		{Slot: 20, Hash: []byte("h20")},
+		{Slot: 30, Hash: []byte("h30")},
+	} {
+		pt.recordObservedPoint(p, window)
+	}
+
+	pt.ApplyRollback(
+		ocommon.Point{Slot: 20, Hash: []byte("h20")},
+		ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 25, Hash: []byte("h25")},
+			BlockNumber: 4,
+		},
+	)
+
+	require.Equal(t, []uint64{10, 20}, pt.observedSlots)
+	require.Len(t, pt.observedPoints, 2)
+	assert.Equal(t, uint64(20), pt.observedPoints[1].Slot)
+	assert.Equal(t, []byte("h20"), pt.observedPoints[1].Hash)
+
+	// A subsequent point extends both frontiers consistently.
+	pt.recordObservedPoint(ocommon.Point{Slot: 40, Hash: []byte("h40")}, window)
+	require.Equal(t, []uint64{10, 20, 40}, pt.observedSlots)
+	require.Len(t, pt.observedPoints, 3)
+	assert.Equal(t, []byte("h40"), pt.observedPoints[2].Hash)
+}
+
+// sharesObservedPoint requires an identical slot AND hash; a peer on a divergent
+// fork (same slots, different hashes) does not corroborate.
+func TestSharesObservedPointHashSensitive(t *testing.T) {
+	window := uint64(100)
+	honestA := &PeerChainTip{}
+	honestB := &PeerChainTip{}
+	divergent := &PeerChainTip{}
+	for _, p := range []ocommon.Point{
+		{Slot: 10, Hash: []byte("h10")},
+		{Slot: 20, Hash: []byte("h20")},
+	} {
+		honestA.recordObservedPoint(p, window)
+		honestB.recordObservedPoint(p, window)
+	}
+	for _, p := range []ocommon.Point{
+		{Slot: 10, Hash: []byte("x10")},
+		{Slot: 20, Hash: []byte("x20")},
+	} {
+		divergent.recordObservedPoint(p, window)
+	}
+
+	assert.True(t, honestA.sharesObservedPoint(honestB))
+	assert.False(t, honestA.sharesObservedPoint(divergent))
+	assert.False(t, divergent.sharesObservedPoint(honestB))
+}
+
+// A dense fast source whose recent blocks are also reported by other eligible
+// peers (shared block hashes at shared slots) is corroborated, so it is
+// selected as the best chain in Genesis mode.
+func TestGenesisHonestFastSourceIsCorroborated(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	fast := newTestConnectionId(1)
+	corroboratorA := newTestConnectionId(2)
+	corroboratorB := newTestConnectionId(3)
+
+	// Fast source: three blocks in the window (densest).
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	// Corroborators are on the same chain: they report the SAME hashes at the
+	// slots they have both seen, just fewer blocks (they are slower sources).
+	feedFrontier(cs, corroboratorA,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	feedFrontier(cs, corroboratorB,
+		genesisTip(100, "h100", 100),
+	)
+
+	cs.EvaluateAndSwitch()
+
+	best := cs.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(t, fast, *best, "corroborated dense fast source must be selected")
+}
+
+// A dense but divergent fast source — one on a chain no other eligible peer
+// reports — is NOT corroborated and must not be selected, even though it is
+// the densest/longest. The node follows the corroborated honest peers instead
+// and publishes a corroboration-failure event for the divergent source.
+func TestGenesisDivergentFastSourceNotSelected(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var mu sync.Mutex
+	var failures []GenesisCorroborationFailedEvent
+	bus.SubscribeFunc(
+		GenesisCorroborationFailedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(GenesisCorroborationFailedEvent)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			failures = append(failures, e)
+			mu.Unlock()
+		},
+	)
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+		EventBus:              bus,
+	})
+
+	divergent := newTestConnectionId(1)
+	honestA := newTestConnectionId(2)
+	honestB := newTestConnectionId(3)
+
+	// Divergent source: densest/longest, but on a private fork — its block
+	// hashes ("x...") are seen by nobody else.
+	feedFrontier(cs, divergent,
+		genesisTip(100, "x100", 100),
+		genesisTip(105, "x105", 105),
+		genesisTip(110, "x110", 110),
+	)
+	// Honest peers agree with each other on the real chain ("h..."), corroborating
+	// one another but never the divergent source.
+	feedFrontier(cs, honestA,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+	feedFrontier(cs, honestB,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+
+	cs.EvaluateAndSwitch()
+
+	best := cs.GetBestPeer()
+	require.NotNil(t, best, "an honest corroborated peer should be selectable")
+	assert.NotEqual(
+		t,
+		divergent,
+		*best,
+		"uncorroborated divergent fast source must not steer selection",
+	)
+	assert.Contains(t, []ouroboros.ConnectionId{honestA, honestB}, *best)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, f := range failures {
+			if f.ConnectionId == divergent {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected corroboration-failure event for divergent source")
+}
+
+// With no corroborating peers available, a fast source stalls: the selector
+// refuses to select it, returning no best peer, rather than following an
+// uncorroborated chain.
+func TestGenesisInsufficientCorroborationStalls(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	fast := newTestConnectionId(1)
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+
+	cs.EvaluateAndSwitch()
+	assert.Nil(
+		t,
+		cs.GetBestPeer(),
+		"a lone uncorroborated fast source must stall, not be selected",
+	)
+}
+
+// Corroboration requires a quorum: when the configured minimum is 2 but only
+// one other peer agrees, the fast source is still uncorroborated and stalls.
+func TestGenesisCorroborationQuorumNotMet(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 2,
+	})
+
+	fast := newTestConnectionId(1)
+	corroborator := newTestConnectionId(2)
+
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	feedFrontier(cs, corroborator,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+	)
+
+	cs.EvaluateAndSwitch()
+	assert.Nil(
+		t,
+		cs.GetBestPeer(),
+		"quorum of 2 not met with a single corroborator; must stall",
+	)
+}
+
+// Corroboration is opt-in. With MinCorroboratingPeers == 0 (the default), a
+// lone dense source is selected exactly as before, preserving backward
+// compatibility for nodes that do not enable the Genesis trust model.
+func TestGenesisCorroborationDisabledByDefault(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 20,
+	})
+
+	fast := newTestConnectionId(1)
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+
+	cs.EvaluateAndSwitch()
+	best := cs.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(t, fast, *best)
+}
+
+// GenesisStatus exposes selection mode, window, the selected fast source, and
+// per-peer density/corroboration for observability.
+func TestGenesisStatusObservability(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         10, // window = 30
+		MinCorroboratingPeers: 1,
+	})
+
+	fast := newTestConnectionId(1)
+	corroborator := newTestConnectionId(2)
+	feedFrontier(cs, fast,
+		genesisTip(100, "h100", 100),
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	feedFrontier(cs, corroborator,
+		genesisTip(105, "h105", 105),
+		genesisTip(110, "h110", 110),
+	)
+	cs.EvaluateAndSwitch()
+
+	status := cs.GenesisStatus()
+	assert.Equal(t, SelectionModeGenesis, status.Mode)
+	assert.Equal(t, uint64(30), status.WindowSlots)
+	assert.Equal(t, 1, status.MinCorroboratingPeers)
+	require.NotNil(t, status.BestSource)
+	assert.Equal(t, fast, *status.BestSource)
+
+	byConn := make(map[ouroboros.ConnectionId]GenesisPeerStatus, len(status.Peers))
+	for _, ps := range status.Peers {
+		byConn[ps.ConnectionId] = ps
+	}
+	fastStatus, ok := byConn[fast]
+	require.True(t, ok)
+	assert.Equal(t, uint64(3), fastStatus.ObservedDensity)
+	assert.GreaterOrEqual(t, fastStatus.CorroboratingPeers, 1)
+	assert.True(t, fastStatus.Corroborated)
+}
+
+// When the local tip catches up into the Genesis window of the best known
+// peer, the selector exits Genesis mode and publishes an exit event carrying
+// the reason (local/best slots and window).
+func TestGenesisModeExitEmitsEvent(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var mu sync.Mutex
+	var exits []GenesisModeExitedEvent
+	bus.SubscribeFunc(
+		GenesisModeExitedEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(GenesisModeExitedEvent)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			exits = append(exits, e)
+			mu.Unlock()
+		},
+	)
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 10, // window = 30
+		EventBus:      bus,
+	})
+
+	connId := newTestConnectionId(1)
+	cs.UpdatePeerTip(connId, genesisTip(100, "peer", 100), nil)
+	require.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	// Local tip within window (100 - 30 = 70) triggers exit.
+	cs.SetLocalTip(genesisTip(75, "local-75", 75))
+	require.Equal(t, SelectionModePraos, cs.SelectionMode())
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(exits) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, uint64(75), exits[0].LocalSlot)
+	assert.Equal(t, uint64(100), exits[0].BestKnownSlot)
+	assert.Equal(t, uint64(30), exits[0].GenesisWindowSlots)
+}

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -149,11 +149,23 @@ func (p *PeerChainTip) trimObservedPointsTo(keepUntil int) {
 }
 
 // recordObservedPoint records a (slot, hash) point into the observed frontier
-// used for Genesis density and corroboration, keeping observedSlots and
-// observedPoints in lockstep and bounded to the density window.
-func (p *PeerChainTip) recordObservedPoint(point ocommon.Point, window uint64) {
+// used for Genesis density (observedSlots, always maintained in Genesis) and
+// corroboration (observedPoints, the block hashes), keeping the two in lockstep
+// and bounded to the density window.
+//
+// trackHashes gates the hash frontier: it is stored only while Genesis
+// corroboration is active. When false the hash frontier is dropped, so normal
+// Praos operation does not retain per-peer window-length hash history.
+func (p *PeerChainTip) recordObservedPoint(
+	point ocommon.Point,
+	window uint64,
+	trackHashes bool,
+) {
 	if p == nil {
 		return
+	}
+	if !trackHashes {
+		p.observedPoints = nil
 	}
 	slot := point.Slot
 	if slot == 0 {
@@ -168,14 +180,18 @@ func (p *PeerChainTip) recordObservedPoint(point ocommon.Point, window uint64) {
 	for len(p.observedSlots) > 0 &&
 		p.observedSlots[len(p.observedSlots)-1] > slot {
 		p.observedSlots = p.observedSlots[:len(p.observedSlots)-1]
-		p.trimObservedPointsTo(len(p.observedSlots))
+		if trackHashes {
+			p.trimObservedPointsTo(len(p.observedSlots))
+		}
 	}
 	switch {
 	case len(p.observedSlots) == 0 ||
 		p.observedSlots[len(p.observedSlots)-1] < slot:
 		p.observedSlots = append(p.observedSlots, slot)
-		p.observedPoints = append(p.observedPoints, clonePoint(point))
-	case len(p.observedPoints) == len(p.observedSlots):
+		if trackHashes {
+			p.observedPoints = append(p.observedPoints, clonePoint(point))
+		}
+	case trackHashes && len(p.observedPoints) == len(p.observedSlots):
 		// Same slot re-reported: keep the latest hash so corroboration
 		// compares against the current frontier block.
 		p.observedPoints[len(p.observedPoints)-1] = clonePoint(point)
@@ -236,32 +252,56 @@ func cloneObservedPoints(points []ocommon.Point) []ocommon.Point {
 	return out
 }
 
-// sharesObservedPoint reports whether this peer and other have at least one
-// identical observed (slot, hash) point — evidence they are following the same
-// chain within the Genesis window. Points with an empty hash are ignored so an
-// unhashed frontier slot cannot spuriously corroborate. Both frontiers are
-// kept in strictly-ascending slot order, so this is a two-pointer merge.
-func (p *PeerChainTip) sharesObservedPoint(other *PeerChainTip) bool {
-	if p == nil || other == nil {
+// confirmsRecentChain reports whether witness confirms this peer's (candidate's)
+// chain across the window range they overlap. It is true when, for every block
+// the witness observed within the candidate's frontier slot range, the candidate
+// observed the identical (slot, hash) block, AND they share at least one such
+// block. In other words the witness's chain, as far as it reaches into the
+// candidate's window, is a prefix/subset of the candidate's chain.
+//
+// This is deliberately stronger than "share any common point": a fast source
+// that shares only an old ancestor and then diverges for every later block is
+// NOT confirmed, because the witness observed recent blocks the candidate did
+// not (or a conflicting hash at the same slot). A witness whose frontier does
+// not overlap the candidate's window at all cannot confirm it (returns false),
+// so corroboration fails closed — the candidate then stalls rather than being
+// followed uncorroborated.
+//
+// Both frontiers are kept in strictly-ascending slot order; this is a
+// two-pointer scan. It relies on the observed frontier being populated per
+// header (dense) during chainsync, so two peers on the same chain share every
+// block in their overlap.
+func (p *PeerChainTip) confirmsRecentChain(witness *PeerChainTip) bool {
+	if p == nil || witness == nil ||
+		len(p.observedPoints) == 0 || len(witness.observedPoints) == 0 {
 		return false
 	}
-	a, b := p.observedPoints, other.observedPoints
-	i, j := 0, 0
-	for i < len(a) && j < len(b) {
-		switch {
-		case a[i].Slot < b[j].Slot:
-			i++
-		case a[i].Slot > b[j].Slot:
-			j++
-		default:
-			if len(a[i].Hash) > 0 && bytes.Equal(a[i].Hash, b[j].Hash) {
-				return true
-			}
-			i++
-			j++
+	candidate := p.observedPoints
+	lo := candidate[0].Slot
+	hi := candidate[len(candidate)-1].Slot
+	i := 0
+	hadMatch := false
+	for _, w := range witness.observedPoints {
+		if w.Slot < lo {
+			continue
 		}
+		if w.Slot > hi {
+			break
+		}
+		for i < len(candidate) && candidate[i].Slot < w.Slot {
+			i++
+		}
+		if i < len(candidate) && candidate[i].Slot == w.Slot &&
+			len(w.Hash) > 0 && bytes.Equal(candidate[i].Hash, w.Hash) {
+			hadMatch = true
+			continue
+		}
+		// The witness observed a block within the candidate's range that the
+		// candidate does not have (or a conflicting hash at the same slot):
+		// they are on different chains, so this witness does not confirm.
+		return false
 	}
-	return false
+	return hadMatch
 }
 
 func (p *PeerChainTip) observedDensity(window uint64) uint64 {

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -15,6 +15,7 @@
 package chainselection
 
 import (
+	"bytes"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -24,13 +25,19 @@ import (
 
 // PeerChainTip tracks the chain tip reported by a specific peer.
 type PeerChainTip struct {
-	ConnectionId  ouroboros.ConnectionId
-	Tip           ochainsync.Tip
-	ObservedTip   ochainsync.Tip
-	VRFOutput     []byte // VRF output from tip block for tie-breaking
-	PraosView     PraosTiebreakerView
-	LastUpdated   time.Time
-	observedSlots []uint64
+	ConnectionId ouroboros.ConnectionId
+	Tip          ochainsync.Tip
+	ObservedTip  ochainsync.Tip
+	VRFOutput    []byte // VRF output from tip block for tie-breaking
+	PraosView    PraosTiebreakerView
+	LastUpdated  time.Time
+	// observedSlots is the recent observed slot frontier used for Genesis
+	// density. observedPoints is the same frontier with block hashes, used
+	// for Genesis corroboration (detecting whether other peers report the
+	// same blocks). The two slices are maintained in lockstep: index i of
+	// observedPoints is the (slot, hash) for observedSlots[i].
+	observedSlots  []uint64
+	observedPoints []ocommon.Point
 }
 
 // NewPeerChainTip creates a new PeerChainTip with the given connection ID,
@@ -113,6 +120,7 @@ func (p *PeerChainTip) ApplyRollback(
 	p.LastUpdated = time.Now()
 	if point.Slot == 0 || len(p.observedSlots) == 0 {
 		p.observedSlots = nil
+		p.observedPoints = nil
 		return
 	}
 
@@ -123,17 +131,34 @@ func (p *PeerChainTip) ApplyRollback(
 	}
 	if keepUntil == 0 {
 		p.observedSlots = nil
+		p.observedPoints = nil
 		return
 	}
 	p.observedSlots = p.observedSlots[:keepUntil]
+	p.trimObservedPointsTo(keepUntil)
 }
 
-func (p *PeerChainTip) recordObservedSlot(slot, window uint64) {
+// trimObservedPointsTo keeps observedPoints aligned with observedSlots after a
+// slot-frontier trim. observedPoints may be shorter than observedSlots for
+// peers whose frontier predates hash tracking; only trim when it is at least
+// as long.
+func (p *PeerChainTip) trimObservedPointsTo(keepUntil int) {
+	if keepUntil <= len(p.observedPoints) {
+		p.observedPoints = p.observedPoints[:keepUntil]
+	}
+}
+
+// recordObservedPoint records a (slot, hash) point into the observed frontier
+// used for Genesis density and corroboration, keeping observedSlots and
+// observedPoints in lockstep and bounded to the density window.
+func (p *PeerChainTip) recordObservedPoint(point ocommon.Point, window uint64) {
 	if p == nil {
 		return
 	}
+	slot := point.Slot
 	if slot == 0 {
 		p.observedSlots = nil
+		p.observedPoints = nil
 		return
 	}
 
@@ -143,15 +168,25 @@ func (p *PeerChainTip) recordObservedSlot(slot, window uint64) {
 	for len(p.observedSlots) > 0 &&
 		p.observedSlots[len(p.observedSlots)-1] > slot {
 		p.observedSlots = p.observedSlots[:len(p.observedSlots)-1]
+		p.trimObservedPointsTo(len(p.observedSlots))
 	}
-	if len(p.observedSlots) == 0 ||
-		p.observedSlots[len(p.observedSlots)-1] < slot {
+	switch {
+	case len(p.observedSlots) == 0 ||
+		p.observedSlots[len(p.observedSlots)-1] < slot:
 		p.observedSlots = append(p.observedSlots, slot)
+		p.observedPoints = append(p.observedPoints, clonePoint(point))
+	case len(p.observedPoints) == len(p.observedSlots):
+		// Same slot re-reported: keep the latest hash so corroboration
+		// compares against the current frontier block.
+		p.observedPoints[len(p.observedPoints)-1] = clonePoint(point)
 	}
 
 	if window == 0 {
 		if len(p.observedSlots) > 1 {
 			p.observedSlots = p.observedSlots[len(p.observedSlots)-1:]
+		}
+		if len(p.observedPoints) > 1 {
+			p.observedPoints = p.observedPoints[len(p.observedPoints)-1:]
 		}
 		return
 	}
@@ -169,7 +204,64 @@ func (p *PeerChainTip) recordObservedSlot(slot, window uint64) {
 	}
 	if pruneIdx > 0 {
 		p.observedSlots = p.observedSlots[pruneIdx:]
+		if pruneIdx <= len(p.observedPoints) {
+			p.observedPoints = p.observedPoints[pruneIdx:]
+		} else {
+			p.observedPoints = nil
+		}
 	}
+}
+
+// clonePoint returns a copy of point with its own hash backing array so the
+// stored frontier does not alias the caller's chainsync buffers.
+func clonePoint(point ocommon.Point) ocommon.Point {
+	if len(point.Hash) == 0 {
+		return ocommon.Point{Slot: point.Slot}
+	}
+	hash := make([]byte, len(point.Hash))
+	copy(hash, point.Hash)
+	return ocommon.Point{Slot: point.Slot, Hash: hash}
+}
+
+// cloneObservedPoints deep-copies an observed-point frontier, including each
+// point's hash backing array, for use by the selector's deep-copy getters.
+func cloneObservedPoints(points []ocommon.Point) []ocommon.Point {
+	if len(points) == 0 {
+		return nil
+	}
+	out := make([]ocommon.Point, len(points))
+	for i, pt := range points {
+		out[i] = clonePoint(pt)
+	}
+	return out
+}
+
+// sharesObservedPoint reports whether this peer and other have at least one
+// identical observed (slot, hash) point — evidence they are following the same
+// chain within the Genesis window. Points with an empty hash are ignored so an
+// unhashed frontier slot cannot spuriously corroborate. Both frontiers are
+// kept in strictly-ascending slot order, so this is a two-pointer merge.
+func (p *PeerChainTip) sharesObservedPoint(other *PeerChainTip) bool {
+	if p == nil || other == nil {
+		return false
+	}
+	a, b := p.observedPoints, other.observedPoints
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i].Slot < b[j].Slot:
+			i++
+		case a[i].Slot > b[j].Slot:
+			j++
+		default:
+			if len(a[i].Hash) > 0 && bytes.Equal(a[i].Hash, b[j].Hash) {
+				return true
+			}
+			i++
+			j++
+		}
+	}
+	return false
 }
 
 func (p *PeerChainTip) observedDensity(window uint64) uint64 {

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -718,6 +718,10 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 					)
 					switchEvent = &evt
 				}
+			} else {
+				// No replacement selected: this is a selected-to-none transition,
+				// so stage the explicit event like the main evaluation path.
+				cs.stageSelectedNoneLocked(previousBest)
 			}
 		}
 	}()
@@ -728,6 +732,7 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
 	}
 	cs.publishPendingGenesisExitEvent()
+	cs.publishPendingSelectedNoneEvent()
 	if reevaluate {
 		cs.EvaluateAndSwitch()
 	}
@@ -1205,6 +1210,22 @@ func (cs *ChainSelector) publishPendingGenesisExitEvent() {
 	}
 }
 
+// stageSelectedNoneLocked stages a ChainSelectedNoneEvent for a best-peer →
+// none transition (a peer was previously selected, now none is). Must be called
+// with cs.mutex held; the event is published later by
+// publishPendingSelectedNoneEvent outside the lock.
+func (cs *ChainSelector) stageSelectedNoneLocked(
+	previousBest ouroboros.ConnectionId,
+) {
+	if cs.config.EventBus == nil {
+		return
+	}
+	cs.pendingSelectedNone = &ChainSelectedNoneEvent{
+		PreviousConnectionId: previousBest,
+		GenesisCorroboration: cs.genesisCorroborationActiveLocked(),
+	}
+}
+
 // publishPendingSelectedNoneEvent drains and publishes a staged
 // ChainSelectedNoneEvent outside the selector mutex.
 func (cs *ChainSelector) publishPendingSelectedNoneEvent() {
@@ -1339,12 +1360,8 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 		// stall (ChainSwitchEvent cannot express "none"). Enforcement that the
 		// stalled source stops feeding the ledger is handled separately by
 		// ShouldApplyIngress.
-		previousBest := cs.bestPeerConn
-		if previousBest != nil && cs.config.EventBus != nil {
-			cs.pendingSelectedNone = &ChainSelectedNoneEvent{
-				PreviousConnectionId: *previousBest,
-				GenesisCorroboration: cs.genesisCorroborationActiveLocked(),
-			}
+		if previousBest := cs.bestPeerConn; previousBest != nil {
+			cs.stageSelectedNoneLocked(*previousBest)
 		}
 		// Clear stale reference to avoid returning a disconnected peer
 		cs.bestPeerConn = nil
@@ -1664,6 +1681,10 @@ func (cs *ChainSelector) cleanupStalePeers() {
 					)
 					switchEvent = &evt
 				}
+			} else {
+				// No replacement selected after stale cleanup: this is a
+				// selected-to-none transition.
+				cs.stageSelectedNoneLocked(*previousBest)
 			}
 		}
 	}()
@@ -1674,4 +1695,5 @@ func (cs *ChainSelector) cleanupStalePeers() {
 		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
 	}
 	cs.publishPendingGenesisExitEvent()
+	cs.publishPendingSelectedNoneEvent()
 }

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -165,6 +165,11 @@ type ChainSelector struct {
 	// held (on the Genesis→Praos transition) for publishing outside the lock.
 	// Guarded by mutex.
 	pendingGenesisExit *GenesisModeExitedEvent
+
+	// pendingSelectedNone stages a ChainSelectedNoneEvent set while the mutex is
+	// held (on a best-peer → none transition) for publishing outside the lock.
+	// Guarded by mutex.
+	pendingSelectedNone *ChainSelectedNoneEvent
 }
 
 // NewChainSelector creates a new ChainSelector with the given configuration.
@@ -182,6 +187,18 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 	maxPeers := cfg.MaxTrackedPeers
 	if maxPeers <= 0 {
 		maxPeers = DefaultMaxTrackedPeers
+	}
+	// Fail closed on a negative corroboration threshold. Only 0 disables the
+	// Genesis corroboration security gate; a negative value (reachable via the
+	// public programmatic API, e.g. WithGenesisCorroborationPeers(-1)) must not
+	// silently disable it. Clamp to the minimum meaningful gate (require one
+	// corroborator) and warn, rather than treating it as disabled.
+	if cfg.MinCorroboratingPeers < 0 {
+		cfg.Logger.Warn(
+			"negative genesis corroboration threshold; failing closed to 1",
+			"configured", cfg.MinCorroboratingPeers,
+		)
+		cfg.MinCorroboratingPeers = 1
 	}
 	cs := &ChainSelector{
 		config:            cfg,
@@ -1167,6 +1184,7 @@ func (cs *ChainSelector) publishSelectionEvents(
 		)
 	}
 	cs.publishPendingGenesisExitEvent()
+	cs.publishPendingSelectedNoneEvent()
 }
 
 // publishPendingGenesisExitEvent drains and publishes a staged
@@ -1183,6 +1201,24 @@ func (cs *ChainSelector) publishPendingGenesisExitEvent() {
 		cs.config.EventBus.Publish(
 			GenesisModeExitedEventType,
 			event.NewEvent(GenesisModeExitedEventType, *pending),
+		)
+	}
+}
+
+// publishPendingSelectedNoneEvent drains and publishes a staged
+// ChainSelectedNoneEvent outside the selector mutex.
+func (cs *ChainSelector) publishPendingSelectedNoneEvent() {
+	if cs.config.EventBus == nil {
+		return
+	}
+	cs.mutex.Lock()
+	pending := cs.pendingSelectedNone
+	cs.pendingSelectedNone = nil
+	cs.mutex.Unlock()
+	if pending != nil {
+		cs.config.EventBus.Publish(
+			ChainSelectedNoneEventType,
+			event.NewEvent(ChainSelectedNoneEventType, *pending),
 		)
 	}
 }
@@ -1298,6 +1334,18 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 
 	newBest := cs.selectBestChainLocked()
 	if newBest == nil {
+		// Selection stalled. Stage an explicit selected-to-none transition when
+		// we were previously following a peer, so subscribers can observe the
+		// stall (ChainSwitchEvent cannot express "none"). Enforcement that the
+		// stalled source stops feeding the ledger is handled separately by
+		// ShouldApplyIngress.
+		previousBest := cs.bestPeerConn
+		if previousBest != nil && cs.config.EventBus != nil {
+			cs.pendingSelectedNone = &ChainSelectedNoneEvent{
+				PreviousConnectionId: *previousBest,
+				GenesisCorroboration: cs.genesisCorroborationActiveLocked(),
+			}
+		}
 		// Clear stale reference to avoid returning a disconnected peer
 		cs.bestPeerConn = nil
 		return false, nil, nil, corroborationEvent

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -104,10 +104,17 @@ type ChainSelectorConfig struct {
 	SecurityParam      uint64
 	GenesisMode        bool
 	GenesisWindowSlots uint64
-	ConnectionLive     func(ouroboros.ConnectionId) bool
-	ConnectionEligible func(ouroboros.ConnectionId) bool
-	ConnectionPriority func(ouroboros.ConnectionId) int
-	MaxTrackedPeers    int // 0 means use DefaultMaxTrackedPeers
+	// MinCorroboratingPeers is the number of distinct other eligible peers
+	// that must report the same recent blocks as a candidate before that
+	// candidate can drive chain selection in Genesis mode. It implements the
+	// Ouroboros Genesis trust property that a fast (shallow) block source is
+	// followed only while corroborated by independent peers. 0 disables
+	// corroboration (density-only Genesis selection, the historical default).
+	MinCorroboratingPeers int
+	ConnectionLive        func(ouroboros.ConnectionId) bool
+	ConnectionEligible    func(ouroboros.ConnectionId) bool
+	ConnectionPriority    func(ouroboros.ConnectionId) int
+	MaxTrackedPeers       int // 0 means use DefaultMaxTrackedPeers
 	// DisableEventSubscriptions leaves EventBus configured for publishing
 	// selector events but skips automatic input subscriptions. This is useful
 	// for deterministic replay harnesses that feed input events synchronously.
@@ -147,6 +154,17 @@ type ChainSelector struct {
 	localTipProgressAt    time.Time
 	// nowFn is injectable for deterministic tests; defaults to time.Now.
 	nowFn func() time.Time
+
+	// lastCorroborationFailedConn dedups GenesisCorroborationFailedEvent so a
+	// persistently uncorroborated fast source does not emit an event on every
+	// evaluation. Reset when the leading density source becomes corroborated
+	// or changes. Guarded by mutex.
+	lastCorroborationFailedConn *ouroboros.ConnectionId
+
+	// pendingGenesisExit stages a GenesisModeExitedEvent set while the mutex is
+	// held (on the Genesis→Praos transition) for publishing outside the lock.
+	// Guarded by mutex.
+	pendingGenesisExit *GenesisModeExitedEvent
 }
 
 // NewChainSelector creates a new ChainSelector with the given configuration.
@@ -248,13 +266,25 @@ func (cs *ChainSelector) advanceSelectionModeLocked() bool {
 	if !cs.shouldExitGenesisModeLocked() {
 		return false
 	}
+	// Capture exit context while still in Genesis mode so the best-known slot
+	// reflects the Genesis-mode selectable set.
+	localSlot := cs.localTip.Point.Slot
+	bestSlot := cs.bestKnownGenesisSlotLocked()
+	window := cs.genesisWindowSlotsLocked()
 	cs.mode = SelectionModePraos
 	cs.config.Logger.Info(
 		"exiting Genesis selection mode",
-		"local_slot", cs.localTip.Point.Slot,
-		"best_known_slot", cs.bestKnownGenesisSlotLocked(),
-		"genesis_window_slots", cs.genesisWindowSlotsLocked(),
+		"local_slot", localSlot,
+		"best_known_slot", bestSlot,
+		"genesis_window_slots", window,
 	)
+	if cs.config.EventBus != nil {
+		cs.pendingGenesisExit = &GenesisModeExitedEvent{
+			LocalSlot:          localSlot,
+			BestKnownSlot:      bestSlot,
+			GenesisWindowSlots: window,
+		}
+	}
 	return true
 }
 
@@ -390,8 +420,8 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 				vrfOutput,
 				praosView,
 			)
-			peerTip.recordObservedSlot(
-				observedTip.Point.Slot,
+			peerTip.recordObservedPoint(
+				observedTip.Point,
 				cs.genesisWindowSlotsLocked(),
 			)
 		} else {
@@ -417,8 +447,8 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 				PraosView:    praosView,
 				LastUpdated:  time.Now(),
 			}
-			peerTip.recordObservedSlot(
-				observedTip.Point.Slot,
+			peerTip.recordObservedPoint(
+				observedTip.Point,
 				cs.genesisWindowSlotsLocked(),
 			)
 			cs.peerTips[connId] = peerTip
@@ -482,6 +512,7 @@ func (cs *ChainSelector) TouchPeerActivity(connId ouroboros.ConnectionId) {
 	}
 	var switchEvent *event.Event
 	var selectionEvent *event.Event
+	var corroborationEvent *event.Event
 
 	func() {
 		cs.mutex.Lock()
@@ -492,10 +523,10 @@ func (cs *ChainSelector) TouchPeerActivity(connId ouroboros.ConnectionId) {
 			return
 		}
 		peerTip.Touch()
-		_, switchEvent, selectionEvent = cs.evaluateBestPeerLocked()
+		_, switchEvent, selectionEvent, corroborationEvent = cs.evaluateBestPeerLocked()
 	}()
 
-	cs.publishSelectionEvents(switchEvent, selectionEvent)
+	cs.publishSelectionEvents(switchEvent, selectionEvent, corroborationEvent)
 }
 
 // evictLeastRecentPeerLocked removes the peer with the oldest LastUpdated
@@ -717,6 +748,7 @@ func (cs *ChainSelector) GetPeerTip(
 		tipCopy.observedSlots = make([]uint64, len(pt.observedSlots))
 		copy(tipCopy.observedSlots, pt.observedSlots)
 	}
+	tipCopy.observedPoints = cloneObservedPoints(pt.observedPoints)
 	return &tipCopy
 }
 
@@ -739,6 +771,7 @@ func (cs *ChainSelector) GetAllPeerTips() map[ouroboros.ConnectionId]*PeerChainT
 			tipCopy.observedSlots = make([]uint64, len(v.observedSlots))
 			copy(tipCopy.observedSlots, v.observedSlots)
 		}
+		tipCopy.observedPoints = cloneObservedPoints(v.observedPoints)
 		result[k] = &tipCopy
 	}
 	return result
@@ -828,6 +861,19 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 				"skipping stale peer",
 				"connection_id", connId.String(),
 				"last_updated", peerTip.LastUpdated,
+			)
+		}
+		return false
+	}
+	// Genesis corroboration gate: a fast source must be corroborated by the
+	// configured minimum number of independent peers before it can steer
+	// selection. No-op outside Genesis mode / with corroboration disabled.
+	if !cs.isPeerCorroboratedLocked(connId, peerTip) {
+		if logSkip {
+			cs.config.Logger.Debug(
+				"skipping uncorroborated genesis fast source",
+				"connection_id", connId.String(),
+				"min_corroborating_peers", cs.config.MinCorroboratingPeers,
 			)
 		}
 		return false
@@ -1060,6 +1106,7 @@ func (cs *ChainSelector) triggerEvaluation() {
 func (cs *ChainSelector) publishSelectionEvents(
 	switchEvent *event.Event,
 	selectionEvent *event.Event,
+	corroborationEvent *event.Event,
 ) {
 	if cs.config.EventBus == nil {
 		return
@@ -1069,6 +1116,31 @@ func (cs *ChainSelector) publishSelectionEvents(
 	}
 	if selectionEvent != nil {
 		cs.config.EventBus.Publish(ChainSelectionEventType, *selectionEvent)
+	}
+	if corroborationEvent != nil {
+		cs.config.EventBus.Publish(
+			GenesisCorroborationFailedEventType,
+			*corroborationEvent,
+		)
+	}
+	cs.publishPendingGenesisExitEvent()
+}
+
+// publishPendingGenesisExitEvent drains and publishes a staged
+// GenesisModeExitedEvent outside the selector mutex.
+func (cs *ChainSelector) publishPendingGenesisExitEvent() {
+	if cs.config.EventBus == nil {
+		return
+	}
+	cs.mutex.Lock()
+	pending := cs.pendingGenesisExit
+	cs.pendingGenesisExit = nil
+	cs.mutex.Unlock()
+	if pending != nil {
+		cs.config.EventBus.Publish(
+			GenesisModeExitedEventType,
+			event.NewEvent(GenesisModeExitedEventType, *pending),
+		)
 	}
 }
 
@@ -1171,16 +1243,21 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 	bool,
 	*event.Event,
 	*event.Event,
+	*event.Event,
 ) {
 	var switchEvent *event.Event
 	var selectionEvent *event.Event
 	switchOccurred := false
+	// Compute Genesis corroboration status once per evaluation, independent of
+	// which peer (if any) is ultimately selected, so a stalled selection still
+	// reports why the densest fast source was denied.
+	corroborationEvent := cs.genesisCorroborationFailureLocked()
 
 	newBest := cs.selectBestChainLocked()
 	if newBest == nil {
 		// Clear stale reference to avoid returning a disconnected peer
 		cs.bestPeerConn = nil
-		return false, nil, nil
+		return false, nil, nil, corroborationEvent
 	}
 
 	previousBest := cs.bestPeerConn
@@ -1189,7 +1266,7 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 		if ok && cs.isPeerSelectableLocked(*previousBest, previousPeerTip, false) {
 			newPeerTip, ok := cs.peerTips[*newBest]
 			if !ok {
-				return false, nil, nil
+				return false, nil, nil, corroborationEvent
 			}
 			if ComparePraosTips(
 				newPeerTip.SelectionTip(),
@@ -1242,7 +1319,7 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 	if previousBest == nil || *previousBest != *newBest {
 		newPeerTip, ok := cs.peerTips[*newBest]
 		if !ok {
-			return false, nil, nil
+			return false, nil, nil, corroborationEvent
 		}
 		newTip := newPeerTip.Tip
 		cs.bestPeerConn = newBest
@@ -1298,7 +1375,7 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 	if cs.config.EventBus != nil && cs.bestPeerConn != nil {
 		bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]
 		if !ok {
-			return false, nil, nil
+			return false, nil, nil, corroborationEvent
 		}
 		bestTip := bestPeerTip.Tip
 		evt := event.NewEvent(
@@ -1313,7 +1390,7 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 		selectionEvent = &evt
 	}
 
-	return switchOccurred, switchEvent, selectionEvent
+	return switchOccurred, switchEvent, selectionEvent, corroborationEvent
 }
 
 // EvaluateAndSwitch evaluates all peer tips and switches to the best chain if
@@ -1321,15 +1398,16 @@ func (cs *ChainSelector) evaluateBestPeerLocked() (
 func (cs *ChainSelector) EvaluateAndSwitch() bool {
 	var switchEvent *event.Event
 	var selectionEvent *event.Event
+	var corroborationEvent *event.Event
 	switchOccurred := false
 
 	func() {
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
-		switchOccurred, switchEvent, selectionEvent = cs.evaluateBestPeerLocked()
+		switchOccurred, switchEvent, selectionEvent, corroborationEvent = cs.evaluateBestPeerLocked()
 	}()
 
-	cs.publishSelectionEvents(switchEvent, selectionEvent)
+	cs.publishSelectionEvents(switchEvent, selectionEvent, corroborationEvent)
 	return switchOccurred
 }
 

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -234,43 +234,49 @@ func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
 	return defaultGenesisWindowSlots
 }
 
-// bestKnownGenesisSlotLocked returns the exit horizon: the highest advertised
-// tip slot among CORROBORATED (selectable) peers, used to decide when the local
-// tip has caught up enough to leave Genesis mode.
+// bestKnownGenesisSlotLocked returns the exit horizon: the network tip slot the
+// local tip must catch up to (within the window) before leaving Genesis mode.
 //
-// Two properties matter:
+// The advertised tip (pt.Tip) is untrusted and unbounded — the implausible-tip
+// check bounds the advertised BLOCK number but NOT the advertised slot, and the
+// first peer is accepted with no reference — so a peer can advertise a plausible
+// block with a slot near math.MaxUint64. Corroboration alone does not fix this:
+// it validates the DELIVERED headers (the observed frontier), not the advertised
+// claim, so a peer that delivers one shared early header (passing corroboration)
+// can still advertise an arbitrary tip. Using that raw advertised slot as the
+// horizon lets a single peer pin the node in Genesis mode indefinitely — a
+// liveness DoS.
 //
-//   - It uses the advertised tip (pt.Tip), not the observed frontier
-//     (SelectionTip, which prefers ObservedTip): a from-origin ChainSync delivers
-//     early headers (slot 1) long before the local tip nears the network tip, so
-//     keying exit off the observed frontier would leave Genesis mode — and
-//     disable the corroboration gate — almost immediately (reproduced with two
-//     peers advertising a far tip while delivering the same slot-1 header).
-//   - It considers only selectable (corroborated) peers. The advertised tip is
-//     untrusted, and the implausible-tip check bounds the advertised BLOCK number
-//     but NOT the advertised slot — a peer can advertise a plausible block with a
-//     slot near math.MaxUint64 (and the first peer is accepted with no reference
-//     at all). If uncorroborated peers counted toward the horizon, a single such
-//     peer could pin the node in Genesis mode indefinitely (a liveness DoS).
-//     Requiring corroboration means MinCorroboratingPeers independent peers must
-//     have delivered matching headers, so a lone liar cannot inflate the horizon.
+// The horizon is therefore bound to DELIVERED data: a peer's advertised tip
+// counts only when the peer is corroborated (selectable) AND it has actually
+// delivered headers up to within the window of that advertised tip
+// (ObservedTip + window >= Tip). A liar cannot deliver up to a MaxUint64 slot,
+// and an honest peer early in from-origin sync has not yet delivered up to its
+// far advertised tip, so neither raises the horizon prematurely. Once a
+// corroborated peer has served its chain up to (near) its advertised tip, that
+// tip is trustworthy and becomes the exit target — reached exactly when the
+// local tip has caught up.
 //
-// Trade-off: keying exit off corroborated peers means an uncorroborated source
-// that is ahead in block number can, in principle, win Praos selection once the
-// local tip has caught up to the corroborated tip and the node has exited. That
-// residual is a limitation of the density heuristic (a divergent chain dense
-// enough to be plausible but uncorroborated); resolving it fully needs
-// density-at-intersection, which is deferred (see ARCHITECTURE.md). Liveness is
-// prioritized over that residual here because an unbounded advertised slot is a
-// trivially exploitable single-peer stall.
+// Residual (documented, deferred): an uncorroborated source ahead in block
+// number could win Praos selection after exit; closing that needs
+// density-at-intersection (see ARCHITECTURE.md).
 func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
+	window := cs.genesisWindowSlotsLocked()
 	var best uint64
 	for connId, pt := range cs.peerTips {
 		if !cs.isPeerSelectableLocked(connId, pt, false) {
 			continue
 		}
-		if pt.Tip.Point.Slot > best {
-			best = pt.Tip.Point.Slot
+		advertised := pt.Tip.Point.Slot
+		delivered := pt.ObservedTip.Point.Slot
+		// Ignore an advertised tip the peer has not delivered headers up to:
+		// it is either a lie or a not-yet-synced far tip, and must not raise
+		// the exit horizon.
+		if safeAddUint64(delivered, window) < advertised {
+			continue
+		}
+		if advertised > best {
+			best = advertised
 		}
 	}
 	return best

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -272,6 +272,12 @@ func (cs *ChainSelector) advanceSelectionModeLocked() bool {
 	bestSlot := cs.bestKnownGenesisSlotLocked()
 	window := cs.genesisWindowSlotsLocked()
 	cs.mode = SelectionModePraos
+	// Corroboration no longer applies in Praos; drop the per-peer hash
+	// frontier so it does not linger for the full window on every tracked peer.
+	for _, peerTip := range cs.peerTips {
+		peerTip.observedPoints = nil
+	}
+	cs.lastCorroborationFailedConn = nil
 	cs.config.Logger.Info(
 		"exiting Genesis selection mode",
 		"local_slot", localSlot,
@@ -413,6 +419,7 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 			}
 		}
 
+		trackHashes := cs.genesisCorroborationActiveLocked()
 		if peerTip, exists := cs.peerTips[connId]; exists {
 			peerTip.UpdateTipWithObservedPraosView(
 				tip,
@@ -423,6 +430,7 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 			peerTip.recordObservedPoint(
 				observedTip.Point,
 				cs.genesisWindowSlotsLocked(),
+				trackHashes,
 			)
 		} else {
 			// Evict the least-recently-updated peer if at capacity
@@ -450,6 +458,7 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 			peerTip.recordObservedPoint(
 				observedTip.Point,
 				cs.genesisWindowSlotsLocked(),
+				trackHashes,
 			)
 			cs.peerTips[connId] = peerTip
 		}
@@ -464,9 +473,15 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 		)
 
 		// Check if this peer's tip is better than the current best peer's tip
-		if modeChanged {
+		switch {
+		case modeChanged:
 			shouldEvaluate = true
-		} else if cs.bestPeerConn != nil {
+		case trackHashes:
+			// Under Genesis corroboration any peer's frontier change can grant
+			// or revoke corroboration of the incumbent/leader, so always
+			// re-evaluate rather than only when this peer beats the best.
+			shouldEvaluate = true
+		case cs.bestPeerConn != nil:
 			if bestPeerTip, ok := cs.peerTips[*cs.bestPeerConn]; ok {
 				shouldEvaluate = cs.comparePeerTips(
 					connId,
@@ -475,7 +490,7 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 					bestPeerTip,
 				) == ChainABetter
 			}
-		} else {
+		default:
 			// No best peer yet, trigger evaluation
 			shouldEvaluate = true
 		}
@@ -605,12 +620,19 @@ func (cs *ChainSelector) deletePeerLocked(connId ouroboros.ConnectionId) {
 // RemovePeer removes a peer from tracking.
 func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 	var switchEvent *event.Event
+	var reevaluate bool
 
 	func() {
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
 
 		cs.deletePeerLocked(connId)
+
+		// Removing a witness can revoke the incumbent's corroboration even
+		// when the removed peer was not itself the best; force a re-evaluation
+		// so an incumbent that just lost corroboration is dropped.
+		reevaluate = cs.genesisCorroborationActiveLocked() &&
+			(cs.bestPeerConn == nil || *cs.bestPeerConn != connId)
 
 		if cs.bestPeerConn != nil && *cs.bestPeerConn == connId {
 			previousBest := *cs.bestPeerConn
@@ -653,6 +675,10 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 	// call back into ChainSelector
 	if switchEvent != nil {
 		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+	}
+	cs.publishPendingGenesisExitEvent()
+	if reevaluate {
+		cs.EvaluateAndSwitch()
 	}
 }
 
@@ -788,8 +814,12 @@ func (cs *ChainSelector) PeerCount() int {
 // the peer with the best chain.
 func (cs *ChainSelector) SelectBestChain() *ouroboros.ConnectionId {
 	cs.mutex.Lock()
-	defer cs.mutex.Unlock()
-	return cs.selectBestChainLocked()
+	best := cs.selectBestChainLocked()
+	cs.mutex.Unlock()
+	// selectBestChainLocked may have exited Genesis mode; publish the staged
+	// exit event outside the lock.
+	cs.publishPendingGenesisExitEvent()
+	return best
 }
 
 func (cs *ChainSelector) isPeerSelectableLocked(
@@ -797,23 +827,12 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 	peerTip *PeerChainTip,
 	logSkip bool,
 ) bool {
-	if peerTip == nil {
-		return false
-	}
-	if cs.config.ConnectionLive != nil &&
-		!cs.config.ConnectionLive(connId) {
+	// Shared live/eligible/non-stale prerequisite (single source of truth,
+	// also used by the Genesis corroboration witness check).
+	if !cs.peerLiveEligibleNonStaleLocked(connId, peerTip) {
 		if logSkip {
 			cs.config.Logger.Debug(
-				"skipping closed peer",
-				"connection_id", connId.String(),
-			)
-		}
-		return false
-	}
-	if !cs.isConnectionEligible(connId) {
-		if logSkip {
-			cs.config.Logger.Debug(
-				"skipping ineligible peer",
+				"skipping closed, ineligible, or stale peer",
 				"connection_id", connId.String(),
 			)
 		}
@@ -854,16 +873,6 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 			}
 			return false
 		}
-	}
-	if cs.isPeerTipStale(peerTip) {
-		if logSkip {
-			cs.config.Logger.Debug(
-				"skipping stale peer",
-				"connection_id", connId.String(),
-				"last_updated", peerTip.LastUpdated,
-			)
-		}
-		return false
 	}
 	// Genesis corroboration gate: a fast source must be corroborated by the
 	// configured minimum number of independent peers before it can steer
@@ -1582,4 +1591,5 @@ func (cs *ChainSelector) cleanupStalePeers() {
 	if switchEvent != nil {
 		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
 	}
+	cs.publishPendingGenesisExitEvent()
 }

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -234,11 +234,11 @@ func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
 	return defaultGenesisWindowSlots
 }
 
-// bestKnownGenesisSlotLocked returns the highest ADVERTISED peer tip slot — the
-// network tip — used to decide when the local tip has caught up enough to leave
-// Genesis mode.
+// bestKnownGenesisSlotLocked returns the exit horizon: the highest advertised
+// tip slot among CORROBORATED (selectable) peers, used to decide when the local
+// tip has caught up enough to leave Genesis mode.
 //
-// Two properties matter for the exit horizon:
+// Two properties matter:
 //
 //   - It uses the advertised tip (pt.Tip), not the observed frontier
 //     (SelectionTip, which prefers ObservedTip): a from-origin ChainSync delivers
@@ -246,18 +246,27 @@ func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
 //     keying exit off the observed frontier would leave Genesis mode — and
 //     disable the corroboration gate — almost immediately (reproduced with two
 //     peers advertising a far tip while delivering the same slot-1 header).
-//   - It considers every live/eligible/non-stale peer, NOT only selectable ones.
-//     An uncorroborated (or behind-best) far-ahead source must still raise the
-//     horizon: otherwise a lower corroborated peer could trigger a premature
-//     exit, and once in Praos the now-disabled gate would let that uncorroborated
-//     source steer the chain via longest-chain. Including it keeps Genesis mode
-//     active until the local tip actually catches up. The implausible-tip check
-//     bounds how far ahead any peer can advertise, so a liar cannot pin the node
-//     in Genesis mode beyond the real network tip plus K (well within the window).
+//   - It considers only selectable (corroborated) peers. The advertised tip is
+//     untrusted, and the implausible-tip check bounds the advertised BLOCK number
+//     but NOT the advertised slot — a peer can advertise a plausible block with a
+//     slot near math.MaxUint64 (and the first peer is accepted with no reference
+//     at all). If uncorroborated peers counted toward the horizon, a single such
+//     peer could pin the node in Genesis mode indefinitely (a liveness DoS).
+//     Requiring corroboration means MinCorroboratingPeers independent peers must
+//     have delivered matching headers, so a lone liar cannot inflate the horizon.
+//
+// Trade-off: keying exit off corroborated peers means an uncorroborated source
+// that is ahead in block number can, in principle, win Praos selection once the
+// local tip has caught up to the corroborated tip and the node has exited. That
+// residual is a limitation of the density heuristic (a divergent chain dense
+// enough to be plausible but uncorroborated); resolving it fully needs
+// density-at-intersection, which is deferred (see ARCHITECTURE.md). Liveness is
+// prioritized over that residual here because an unbounded advertised slot is a
+// trivially exploitable single-peer stall.
 func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
 	var best uint64
 	for connId, pt := range cs.peerTips {
-		if !cs.peerLiveEligibleNonStaleLocked(connId, pt) {
+		if !cs.isPeerSelectableLocked(connId, pt, false) {
 			continue
 		}
 		if pt.Tip.Point.Slot > best {

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -234,20 +234,30 @@ func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
 	return defaultGenesisWindowSlots
 }
 
-// bestKnownGenesisSlotLocked returns the highest ADVERTISED peer tip slot among
-// selectable peers — the network tip, used to decide when the local tip has
-// caught up enough to leave Genesis mode.
+// bestKnownGenesisSlotLocked returns the highest ADVERTISED peer tip slot — the
+// network tip — used to decide when the local tip has caught up enough to leave
+// Genesis mode.
 //
-// It must use the advertised tip (pt.Tip), not the observed frontier
-// (SelectionTip, which prefers ObservedTip): a from-origin ChainSync delivers
-// early headers (slot 1) long before the local tip nears the network tip, so
-// keying exit off the observed frontier would leave Genesis mode — and disable
-// the corroboration gate — almost immediately (issue reproduced with two peers
-// advertising a far tip while delivering the same slot-1 header).
+// Two properties matter for the exit horizon:
+//
+//   - It uses the advertised tip (pt.Tip), not the observed frontier
+//     (SelectionTip, which prefers ObservedTip): a from-origin ChainSync delivers
+//     early headers (slot 1) long before the local tip nears the network tip, so
+//     keying exit off the observed frontier would leave Genesis mode — and
+//     disable the corroboration gate — almost immediately (reproduced with two
+//     peers advertising a far tip while delivering the same slot-1 header).
+//   - It considers every live/eligible/non-stale peer, NOT only selectable ones.
+//     An uncorroborated (or behind-best) far-ahead source must still raise the
+//     horizon: otherwise a lower corroborated peer could trigger a premature
+//     exit, and once in Praos the now-disabled gate would let that uncorroborated
+//     source steer the chain via longest-chain. Including it keeps Genesis mode
+//     active until the local tip actually catches up. The implausible-tip check
+//     bounds how far ahead any peer can advertise, so a liar cannot pin the node
+//     in Genesis mode beyond the real network tip plus K (well within the window).
 func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
 	var best uint64
 	for connId, pt := range cs.peerTips {
-		if !cs.isPeerSelectableLocked(connId, pt, false) {
+		if !cs.peerLiveEligibleNonStaleLocked(connId, pt) {
 			continue
 		}
 		if pt.Tip.Point.Slot > best {

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -234,15 +234,24 @@ func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
 	return defaultGenesisWindowSlots
 }
 
+// bestKnownGenesisSlotLocked returns the highest ADVERTISED peer tip slot among
+// selectable peers — the network tip, used to decide when the local tip has
+// caught up enough to leave Genesis mode.
+//
+// It must use the advertised tip (pt.Tip), not the observed frontier
+// (SelectionTip, which prefers ObservedTip): a from-origin ChainSync delivers
+// early headers (slot 1) long before the local tip nears the network tip, so
+// keying exit off the observed frontier would leave Genesis mode — and disable
+// the corroboration gate — almost immediately (issue reproduced with two peers
+// advertising a far tip while delivering the same slot-1 header).
 func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
 	var best uint64
 	for connId, pt := range cs.peerTips {
 		if !cs.isPeerSelectableLocked(connId, pt, false) {
 			continue
 		}
-		tip := pt.SelectionTip()
-		if tip.Point.Slot > best {
-			best = tip.Point.Slot
+		if pt.Tip.Point.Slot > best {
+			best = pt.Tip.Point.Slot
 		}
 	}
 	return best

--- a/config.go
+++ b/config.go
@@ -881,8 +881,12 @@ func WithGenesisWindowSlots(slots uint64) ConfigOptionFunc {
 // Genesis-mode chain selection. This is the Ouroboros Genesis trust control for
 // biased fast-sync sources (e.g. the Genesis Sync Accelerator): an
 // uncorroborated or divergent fast source is denied selection and stalls rather
-// than steering the local chain. A zero value disables corroboration
-// (density-only Genesis selection).
+// than steering the local chain.
+//
+// Only a zero value disables corroboration (density-only Genesis selection). A
+// negative value is invalid and fails closed: the chain selector clamps it to 1
+// (require one corroborator) rather than treating it as disabled, so a
+// misconfiguration cannot silently switch off the security gate.
 func WithGenesisCorroborationPeers(peers int) ConfigOptionFunc {
 	return func(c *Config) {
 		c.genesisCorroborationPeers = peers

--- a/config.go
+++ b/config.go
@@ -180,6 +180,7 @@ type Config struct {
 	maxInboundConns                      int
 	genesisBootstrap                     bool
 	genesisWindowSlots                   uint64
+	genesisCorroborationPeers            int
 	// Block production configuration (SPO mode)
 	// Field names match cardano-node environment variable naming convention
 	blockProducer                 bool
@@ -872,6 +873,19 @@ func WithGenesisBootstrap(enabled bool) ConfigOptionFunc {
 func WithGenesisWindowSlots(slots uint64) ConfigOptionFunc {
 	return func(c *Config) {
 		c.genesisWindowSlots = slots
+	}
+}
+
+// WithGenesisCorroborationPeers sets the number of independent peers that must
+// report the same recent blocks before a fast (shallow) block source may drive
+// Genesis-mode chain selection. This is the Ouroboros Genesis trust control for
+// biased fast-sync sources (e.g. the Genesis Sync Accelerator): an
+// uncorroborated or divergent fast source is denied selection and stalls rather
+// than steering the local chain. A zero value disables corroboration
+// (density-only Genesis selection).
+func WithGenesisCorroborationPeers(peers int) ConfigOptionFunc {
+	return func(c *Config) {
+		c.genesisCorroborationPeers = peers
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -234,6 +234,24 @@ func TestPeerGovernorOptionsApplyPositiveValues(t *testing.T) {
 	assert.Equal(t, 25, cfg.maxInboundConns)
 }
 
+// TestWithGenesisCorroborationPeers covers the public programmatic API path for
+// the Genesis corroboration threshold. A negative value is stored as-is on the
+// Config; the chain selector fails closed on it (clamps to 1) rather than
+// disabling the security gate — see chainselection.NewChainSelector and
+// TestGenesisNegativeCorroborationFailsClosed. node.go passes this field to
+// ChainSelectorConfig.MinCorroboratingPeers.
+func TestWithGenesisCorroborationPeers(t *testing.T) {
+	cfg := &Config{}
+	WithGenesisCorroborationPeers(3)(cfg)
+	assert.Equal(t, 3, cfg.genesisCorroborationPeers)
+
+	WithGenesisCorroborationPeers(0)(cfg)
+	assert.Zero(t, cfg.genesisCorroborationPeers)
+
+	WithGenesisCorroborationPeers(-1)(cfg)
+	assert.Equal(t, -1, cfg.genesisCorroborationPeers)
+}
+
 // TestUpdateRTSMetrics verifies the pure-function mapping from
 // runtime.MemStats fields to the four cardano_node_metrics_RTS_* gauges.
 // Specifically exercises the NumGC - NumForcedGC subtraction so a future

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -436,6 +436,14 @@ genesisBootstrap:
   # Minimum diversity groups to prefer while promoting peers during bootstrap.
   # 0 uses the peer-governor default.
   promotionMinDiversityGroups: 0
+  # Independent peers that must report the same recent blocks before a fast
+  # (shallow) block source may drive Genesis-mode chain selection. This is the
+  # Ouroboros Genesis trust control for biased fast-sync sources such as the
+  # Genesis Sync Accelerator: an uncorroborated or divergent fast source is
+  # denied selection and stalls rather than steering the local chain. Pair it
+  # with a trustable localRoots peer plus a ledger peer snapshot in the topology
+  # file. 0 disables corroboration (density-only Genesis selection).
+  corroborationPeers: 0
 
 # Midnight indexer configuration
 # Indexing is active only in API storage mode. Setting port to 0 disables

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,6 +309,13 @@ type GenesisBootstrapConfig struct {
 	// PromotionMinDiversityGroups sets the minimum number of diversity groups
 	// to prefer while promoting peers during bootstrap.
 	PromotionMinDiversityGroups int `yaml:"promotionMinDiversityGroups" envconfig:"DINGO_GENESIS_BOOTSTRAP_PROMOTION_MIN_DIVERSITY_GROUPS"`
+	// CorroborationPeers sets the number of independent peers that must report
+	// the same recent blocks before a fast (shallow) block source may drive
+	// Genesis-mode chain selection. This is the Ouroboros Genesis trust control
+	// for biased fast-sync sources: an uncorroborated or divergent fast source
+	// is denied selection and stalls rather than steering the local chain. A
+	// zero value disables corroboration (density-only Genesis selection).
+	CorroborationPeers int `yaml:"corroborationPeers" envconfig:"DINGO_GENESIS_BOOTSTRAP_CORROBORATION_PEERS"`
 }
 
 // HistoryExpiryConfig controls local expiry of immutable block history.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -328,6 +328,7 @@ func TestLoad_GenesisBootstrapEnvVars(t *testing.T) {
 		"DINGO_GENESIS_BOOTSTRAP_PROMOTION_MIN_DIVERSITY_GROUPS",
 		"6",
 	)
+	t.Setenv("DINGO_GENESIS_BOOTSTRAP_CORROBORATION_PEERS", "3")
 
 	cfg, err := LoadConfig("")
 	if err != nil {
@@ -347,6 +348,12 @@ func TestLoad_GenesisBootstrapEnvVars(t *testing.T) {
 		t.Fatalf(
 			"expected GenesisBootstrap.PromotionMinDiversityGroups to be 6, got %d",
 			cfg.GenesisBootstrap.PromotionMinDiversityGroups,
+		)
+	}
+	if cfg.GenesisBootstrap.CorroborationPeers != 3 {
+		t.Fatalf(
+			"expected GenesisBootstrap.CorroborationPeers to be 3, got %d",
+			cfg.GenesisBootstrap.CorroborationPeers,
 		)
 	}
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -149,6 +149,7 @@ var flagSpecs = []flagSpec{
 	boolFlag("GenesisBootstrap.Enabled", "genesis-bootstrap-enabled", "enable Genesis bootstrap mode when starting from origin"),
 	uint64Flag("GenesisBootstrap.WindowSlots", "genesis-bootstrap-window-slots", "Genesis density comparison window in slots (0 derives from Shelley genesis 3k/f)"),
 	intFlag("GenesisBootstrap.PromotionMinDiversityGroups", "genesis-bootstrap-promotion-min-diversity-groups", "minimum diversity groups preferred during Genesis bootstrap peer promotion"),
+	intFlag("GenesisBootstrap.CorroborationPeers", "genesis-bootstrap-corroboration-peers", "independent peers that must corroborate a fast source before it drives Genesis selection (0 disables)"),
 
 	// Logging
 	transformStringFlag("Logging.Format", "logging-format", "log output format: text (default) or json", normalizeLoggingValue),

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -380,6 +380,16 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		))
 	}
 
+	// Genesis corroboration is a security gate: a negative value must fail
+	// closed rather than silently disabling it (only 0 disables it).
+	if c.GenesisBootstrap.CorroborationPeers < 0 {
+		errs = append(errs, fmt.Errorf(
+			"invalid genesisBootstrap.corroborationPeers: %d "+
+				"(must not be negative; 0 disables corroboration)",
+			c.GenesisBootstrap.CorroborationPeers,
+		))
+	}
+
 	// Mithril backend; accepted values come from
 	// AcceptedMithrilBackends, kept in sync with cmd/dingo's
 	// resolveMithrilBackend by a parity test in cmd/dingo (empty

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -387,6 +387,19 @@ func TestValidate(t *testing.T) {
 			wantErr: "invalid chainsync.maxClients",
 		},
 		{
+			name: "negative genesis corroboration peers",
+			modify: func(c *Config) {
+				c.GenesisBootstrap.CorroborationPeers = -1
+			},
+			wantErr: "invalid genesisBootstrap.corroborationPeers",
+		},
+		{
+			name: "zero genesis corroboration peers allowed",
+			modify: func(c *Config) {
+				c.GenesisBootstrap.CorroborationPeers = 0
+			},
+		},
+		{
 			name:    "invalid mithril backend",
 			modify:  func(c *Config) { c.Mithril.Backend = "v3" },
 			wantErr: "invalid mithril.backend",

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -387,6 +387,9 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			),
 			dingo.WithGenesisBootstrap(cfg.GenesisBootstrap.Enabled),
 			dingo.WithGenesisWindowSlots(cfg.GenesisBootstrap.WindowSlots),
+			dingo.WithGenesisCorroborationPeers(
+				cfg.GenesisBootstrap.CorroborationPeers,
+			),
 			dingo.WithBootstrapPromotionMinDiversityGroups(
 				cfg.GenesisBootstrap.PromotionMinDiversityGroups,
 			),

--- a/node.go
+++ b/node.go
@@ -287,6 +287,7 @@ func (n *Node) Run(ctx context.Context) error {
 		EnableLeiosTxFetch:       enableLeiosNetworking,
 		LeiosTxFetchTailBudget:   leiosTxFetchTailBudget,
 		ChainsyncIngressEligible: n.isChainsyncIngressEligible,
+		ChainsyncApplyEligible:   n.chainsyncApplyEligible,
 		// On the Musashi prototype network every mini-protocol shares one muxer
 		// to a single relay; block/EB traffic can delay the relay's keep-alive
 		// pong past the tight 10s gouroboros default, making dingo drop the
@@ -757,6 +758,14 @@ func (n *Node) Run(ctx context.Context) error {
 	n.eventBus.SubscribeFunc(
 		chainselection.ChainSwitchEventType,
 		n.handleChainSwitchEvent,
+	)
+	// Subscribe to selected-to-none transitions (selection stalled, e.g. an
+	// uncorroborated Genesis fast source). Enforcement that the stalled source
+	// stops feeding the ledger is handled by the ChainsyncApplyEligible gate;
+	// this handler surfaces the stall for observability.
+	n.eventBus.SubscribeFunc(
+		chainselection.ChainSelectedNoneEventType,
+		n.handleChainSelectedNoneEvent,
 	)
 	// Subscribe to chain fork events for monitoring
 	n.eventBus.SubscribeFunc(

--- a/node.go
+++ b/node.go
@@ -699,11 +699,12 @@ func (n *Node) Run(ctx context.Context) error {
 		len(n.config.intersectPoints) == 0
 	n.chainSelector = chainselection.NewChainSelector(
 		chainselection.ChainSelectorConfig{
-			Logger:             n.config.logger,
-			EventBus:           n.eventBus,
-			SecurityParam:      chainSelectorSecurityParam,
-			GenesisMode:        genesisSelectionMode,
-			GenesisWindowSlots: genesisWindowSlots,
+			Logger:                n.config.logger,
+			EventBus:              n.eventBus,
+			SecurityParam:         chainSelectorSecurityParam,
+			GenesisMode:           genesisSelectionMode,
+			GenesisWindowSlots:    genesisWindowSlots,
+			MinCorroboratingPeers: n.config.genesisCorroborationPeers,
 			ConnectionLive: func(connId ouroboros.ConnectionId) bool {
 				return n.connManager != nil &&
 					n.connManager.GetConnectionById(connId) != nil
@@ -721,6 +722,7 @@ func (n *Node) Run(ctx context.Context) error {
 			"Genesis chain selection enabled",
 			"genesis_window_slots", genesisWindowSlots,
 			"security_param", chainSelectorSecurityParam,
+			"min_corroborating_peers", n.config.genesisCorroborationPeers,
 		)
 	}
 	// Subscribe chain selector to peer tip update events

--- a/node.go
+++ b/node.go
@@ -288,6 +288,7 @@ func (n *Node) Run(ctx context.Context) error {
 		LeiosTxFetchTailBudget:   leiosTxFetchTailBudget,
 		ChainsyncIngressEligible: n.isChainsyncIngressEligible,
 		ChainsyncApplyEligible:   n.chainsyncApplyEligible,
+		ChainsyncObservePeerTip:  n.chainsyncObservePeerTip,
 		// On the Musashi prototype network every mini-protocol shares one muxer
 		// to a single relay; block/EB traffic can delay the relay's keep-alive
 		// pong past the tight 10s gouroboros default, making dingo drop the

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -31,6 +31,33 @@ func plateauThreshold(stallTimeout time.Duration) time.Duration {
 	return max(2*stallTimeout, 4*time.Minute)
 }
 
+// chainsyncObservePeerTip synchronously feeds a peer tip update into chain
+// selection (and peergov) when the Genesis corroboration gate is active, so the
+// ChainsyncApplyEligible check that immediately follows in the roll-forward
+// handler reflects the header currently being admitted. This closes the race
+// where the apply gate would otherwise read corroboration state that predates
+// this header (the tip update is normally delivered asynchronously). It returns
+// true when it handled the observation synchronously, so the ouroboros layer
+// skips the async PeerTipUpdateEvent publish to avoid a double update.
+//
+// When corroboration is inactive the async path is used unchanged (returns
+// false), so normal high-throughput sync keeps its parallelism.
+func (n *Node) chainsyncObservePeerTip(
+	e chainselection.PeerTipUpdateEvent,
+) bool {
+	if n.chainSelector == nil ||
+		!n.chainSelector.GenesisCorroborationActive() {
+		return false
+	}
+	n.chainSelector.HandlePeerTipUpdateEvent(
+		event.NewEvent(chainselection.PeerTipUpdateEventType, e),
+	)
+	if n.peerGov != nil {
+		n.peerGov.TouchPeerByConnId(e.ConnectionId)
+	}
+	return true
+}
+
 // chainsyncApplyEligible gates whether a peer's headers/rollbacks are APPLIED to
 // the ledger, on top of ingress eligibility. It defers to the chain selector's
 // corroboration decision so an uncorroborated Genesis fast source is observed

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -31,6 +31,22 @@ func plateauThreshold(stallTimeout time.Duration) time.Duration {
 	return max(2*stallTimeout, 4*time.Minute)
 }
 
+// chainsyncApplyEligible gates whether a peer's headers/rollbacks are APPLIED to
+// the ledger, on top of ingress eligibility. It defers to the chain selector's
+// corroboration decision so an uncorroborated Genesis fast source is observed
+// (its tips still feed corroboration) but its blocks are withheld — the real
+// enforcement of the corroboration stall, since ingress is otherwise independent
+// of the selected best peer. Returns true (apply) when no chain selector is
+// wired yet or outside Genesis corroboration.
+func (n *Node) chainsyncApplyEligible(
+	connId ouroboros.ConnectionId,
+) bool {
+	if n.chainSelector == nil {
+		return true
+	}
+	return n.chainSelector.ShouldApplyIngress(connId)
+}
+
 func (n *Node) isChainsyncIngressEligible(
 	connId ouroboros.ConnectionId,
 ) bool {
@@ -646,6 +662,27 @@ func (n *Node) handleChainSwitchEvent(evt event.Event) {
 	// the ledger. Restarting chainsync here re-enters FindIntersect and can
 	// race the protocol state machine under load.
 	n.chainsyncState.SetClientConnId(e.NewConnectionId)
+}
+
+// handleChainSelectedNoneEvent logs a selected-to-none transition. Chain
+// selection has stalled with no eligible/corroborated peer; under Genesis
+// corroboration the stalled source's blocks are already withheld from the ledger
+// by the ChainsyncApplyEligible gate, so this is observability only.
+func (n *Node) handleChainSelectedNoneEvent(evt event.Event) {
+	e, ok := evt.Data.(chainselection.ChainSelectedNoneEvent)
+	if !ok {
+		return
+	}
+	prevConn := "(none)"
+	if e.PreviousConnectionId.LocalAddr != nil &&
+		e.PreviousConnectionId.RemoteAddr != nil {
+		prevConn = e.PreviousConnectionId.String()
+	}
+	n.config.logger.Info(
+		"chain selection stalled: no selectable peer",
+		"previous_connection", prevConn,
+		"genesis_corroboration", e.GenesisCorroboration,
+	)
 }
 
 func (n *Node) runStallCheckerTick(fn func()) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -711,30 +711,10 @@ func (o *Ouroboros) chainsyncClientRollForward(
 			"connection_id", ctx.ConnectionId.String(),
 			"ingress_eligible", ingressEligible,
 		)
-		// Update tracked client state and deduplicate headers.
-		// If this header has already been reported by another
-		// eligible client, skip publishing it into the ledger.
-		isNew := true
-		if o.ChainsyncState != nil {
-			if ingressEligible {
-				isNew = o.ChainsyncState.UpdateClientTip(
-					ctx.ConnectionId,
-					point,
-					tip,
-				)
-			} else {
-				o.ChainsyncState.UpdateClientTipWithoutDedup(
-					ctx.ConnectionId,
-					point,
-					tip,
-				)
-			}
-		}
-		// Publish peer tip update for chain selection only for
-		// ingress-eligible peers. Random inbound peers reporting
-		// ephemeral tips would cause spurious chain switches; peergov
-		// filters them via chainSelectionEligible so they fail the
-		// reconcile above and get skipped here.
+		// Observe the tip for chain selection FIRST, so the apply-eligibility
+		// decision below reflects this header. Only ingress-eligible peers are
+		// observed; random inbound peers reporting ephemeral tips are filtered
+		// by peergov and skipped here.
 		if ingressEligible {
 			observedTip := ochainsync.Tip{
 				Point:       point,
@@ -747,11 +727,10 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				VRFOutput:    vrfOutput,
 				PraosView:    praosView,
 			}
-			// Observe the tip. If the hook handles it synchronously (Genesis
-			// corroboration active, so the apply gate below must reflect this
-			// header), skip the async publish to avoid a double update;
-			// otherwise publish for the async chain-selection and peergov
-			// subscribers.
+			// If the hook handles it synchronously (Genesis corroboration
+			// active, so the apply gate below must reflect this header), skip
+			// the async publish to avoid a double update; otherwise publish for
+			// the async chain-selection and peergov subscribers.
 			observedSync := false
 			if o.config.ChainsyncObservePeerTip != nil {
 				observedSync = o.config.ChainsyncObservePeerTip(peerTipUpdate)
@@ -763,6 +742,33 @@ func (o *Ouroboros) chainsyncClientRollForward(
 						chainselection.PeerTipUpdateEventType,
 						peerTipUpdate,
 					),
+				)
+			}
+		}
+		// Apply-eligibility, evaluated after observation so it reflects this
+		// header. A peer can be ingress-eligible yet not apply-eligible (an
+		// uncorroborated Genesis fast source): its tips are observed but its
+		// blocks are withheld from the ledger.
+		applyEligible := ingressEligible &&
+			o.shouldApplyChainsyncToLedger(ctx.ConnectionId)
+		// Update tracked client cursor/tip and deduplicate headers. Record the
+		// cross-peer dedup entry ONLY for headers we will actually apply, so a
+		// header withheld from an uncorroborated peer is not permanently
+		// deduplicated — a later corroborated, apply-eligible peer can still
+		// publish the point into the ledger.
+		isNew := true
+		if o.ChainsyncState != nil {
+			if applyEligible {
+				isNew = o.ChainsyncState.UpdateClientTip(
+					ctx.ConnectionId,
+					point,
+					tip,
+				)
+			} else {
+				o.ChainsyncState.UpdateClientTipWithoutDedup(
+					ctx.ConnectionId,
+					point,
+					tip,
 				)
 			}
 		}
@@ -817,10 +823,12 @@ func (o *Ouroboros) chainsyncClientRollForward(
 		}
 		// Apply gate: a peer's tips have already been observed for chain
 		// selection above, but its headers are applied to the ledger only when
-		// apply-eligible. This withholds blocks from an uncorroborated Genesis
-		// fast source (it is observed but cannot steer the ledger) while letting
-		// corroboration still form from the observed tips.
-		if !o.shouldApplyChainsyncToLedger(ctx.ConnectionId) {
+		// apply-eligible (computed above, after observation). This withholds
+		// blocks from an uncorroborated Genesis fast source (it is observed but
+		// cannot steer the ledger) while letting corroboration still form from
+		// the observed tips. The header was recorded WITHOUT dedup above, so a
+		// later corroborated peer can still publish this point.
+		if !applyEligible {
 			o.config.Logger.Debug(
 				"chainsync: header withheld (not apply eligible)",
 				"component", "ouroboros",

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -740,19 +740,31 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				Point:       point,
 				BlockNumber: v.BlockNumber(),
 			}
-			o.EventBus.Publish(
-				chainselection.PeerTipUpdateEventType,
-				event.NewEvent(
+			peerTipUpdate := chainselection.PeerTipUpdateEvent{
+				ConnectionId: ctx.ConnectionId,
+				Tip:          tip,
+				ObservedTip:  observedTip,
+				VRFOutput:    vrfOutput,
+				PraosView:    praosView,
+			}
+			// Observe the tip. If the hook handles it synchronously (Genesis
+			// corroboration active, so the apply gate below must reflect this
+			// header), skip the async publish to avoid a double update;
+			// otherwise publish for the async chain-selection and peergov
+			// subscribers.
+			observedSync := false
+			if o.config.ChainsyncObservePeerTip != nil {
+				observedSync = o.config.ChainsyncObservePeerTip(peerTipUpdate)
+			}
+			if !observedSync {
+				o.EventBus.Publish(
 					chainselection.PeerTipUpdateEventType,
-					chainselection.PeerTipUpdateEvent{
-						ConnectionId: ctx.ConnectionId,
-						Tip:          tip,
-						ObservedTip:  observedTip,
-						VRFOutput:    vrfOutput,
-						PraosView:    praosView,
-					},
-				),
-			)
+					event.NewEvent(
+						chainselection.PeerTipUpdateEventType,
+						peerTipUpdate,
+					),
+				)
+			}
 		}
 		if ingressEligible && o.ChainsyncState != nil {
 			o.ChainsyncState.RecordObservedHeader(

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -631,6 +631,31 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	) {
 		return nil
 	}
+	// Observe the rollback for chain selection first (trims the peer's observed
+	// history) so corroboration tracking stays correct even for a peer whose
+	// blocks we are withholding via the apply gate below.
+	o.EventBus.Publish(
+		chainselection.PeerRollbackEventType,
+		event.NewEvent(
+			chainselection.PeerRollbackEventType,
+			chainselection.PeerRollbackEvent{
+				ConnectionId: ctx.ConnectionId,
+				Point:        point,
+				Tip:          tip,
+			},
+		),
+	)
+	// Apply gate: withhold an uncorroborated peer's rollback from the ledger,
+	// mirroring the roll-forward apply gate.
+	if !o.shouldApplyChainsyncToLedger(ctx.ConnectionId) {
+		o.config.Logger.Debug(
+			"chainsync: rollback withheld (not apply eligible)",
+			"component", "ouroboros",
+			"slot", point.Slot,
+			"connection_id", ctx.ConnectionId.String(),
+		)
+		return nil
+	}
 	// Generate event. This stream is ordering-critical: dropping a
 	// rollback/header event can strand the ledger pipeline, so use blocking
 	// delivery to apply backpressure instead of lossy buffer overflow.
@@ -648,17 +673,6 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	); err != nil {
 		return err
 	}
-	o.EventBus.Publish(
-		chainselection.PeerRollbackEventType,
-		event.NewEvent(
-			chainselection.PeerRollbackEventType,
-			chainselection.PeerRollbackEvent{
-				ConnectionId: ctx.ConnectionId,
-				Point:        point,
-				Tip:          tip,
-			},
-		),
-	)
 	return nil
 }
 
@@ -789,6 +803,21 @@ func (o *Ouroboros) chainsyncClientRollForward(
 			o.updateChainsyncMetrics(ctx.ConnectionId, tip)
 			return nil
 		}
+		// Apply gate: a peer's tips have already been observed for chain
+		// selection above, but its headers are applied to the ledger only when
+		// apply-eligible. This withholds blocks from an uncorroborated Genesis
+		// fast source (it is observed but cannot steer the ledger) while letting
+		// corroboration still form from the observed tips.
+		if !o.shouldApplyChainsyncToLedger(ctx.ConnectionId) {
+			o.config.Logger.Debug(
+				"chainsync: header withheld (not apply eligible)",
+				"component", "ouroboros",
+				"slot", blockSlot,
+				"connection_id", ctx.ConnectionId.String(),
+			)
+			o.updateChainsyncMetrics(ctx.ConnectionId, tip)
+			return nil
+		}
 		if err := o.EventBus.PublishBlocking(
 			ledger.ChainsyncEventType,
 			event.NewEvent(
@@ -848,6 +877,21 @@ func (o *Ouroboros) shouldPublishChainsyncToLedger(
 	}
 	outbound, exists := o.ChainsyncState.ClientStartedAsOutbound(connId)
 	return exists && outbound
+}
+
+// shouldApplyChainsyncToLedger reports whether an ingress-eligible peer's
+// headers/rollbacks may be APPLIED to the ledger. It is the second, stricter
+// gate (see ChainsyncApplyEligible): it runs after the peer's tips have already
+// been observed for chain selection, so an uncorroborated Genesis fast source is
+// observed but its blocks are withheld. When no policy is wired, every ingress-
+// eligible peer is apply-eligible.
+func (o *Ouroboros) shouldApplyChainsyncToLedger(
+	connId ouroboros.ConnectionId,
+) bool {
+	if o.config.ChainsyncApplyEligible == nil {
+		return true
+	}
+	return o.config.ChainsyncApplyEligible(connId)
 }
 
 // isInboundChainsyncClient returns true if the chainsync client for

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1099,6 +1099,85 @@ func TestNormalizeIntersectPoints(t *testing.T) {
 	)
 }
 
+// The apply gate (ChainsyncApplyEligible) withholds a peer's headers from the
+// ledger while still observing its tips for chain selection: an uncorroborated
+// Genesis fast source is seen but cannot steer the ledger (no post-denial
+// ingress). This is the ouroboros-layer enforcement of the corroboration stall.
+func TestChainsyncClientRollForwardApplyGateWithholdsLedgerButObservesTip(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+	state := dchainsync.NewState(bus, nil)
+	conn := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	require.True(t, state.AddClientConnId(conn))
+
+	applyEligible := false
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		ChainsyncApplyEligible: func(ouroboros.ConnectionId) bool {
+			return applyEligible
+		},
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	// Apply denied: the tip is observed for chain selection, but the header is
+	// NOT applied to the ledger.
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: conn},
+		0,
+		header,
+		tip,
+	))
+	select {
+	case evt := <-tipCh:
+		_, ok := evt.Data.(chainselection.PeerTipUpdateEvent)
+		require.True(t, ok, "tip must be observed even when apply is denied")
+	case <-time.After(time.Second):
+		t.Fatal("expected PeerTipUpdateEvent (observation) while apply denied")
+	}
+	select {
+	case <-ledgerCh:
+		t.Fatal("ledger ingress must be withheld while apply is denied")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Apply now allowed (peer corroborated): the same header is applied.
+	applyEligible = true
+	header2 := newTestBlockHeader(101, 2, 0xbb)
+	tip2 := ochainsync.Tip{
+		Point:       ocommon.NewPoint(101, header2.Hash().Bytes()),
+		BlockNumber: 2,
+	}
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: conn},
+		0,
+		header2,
+		tip2,
+	))
+	select {
+	case evt := <-ledgerCh:
+		data, ok := evt.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, conn, data.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal("expected ledger ingress once apply is allowed")
+	}
+}
+
 func TestChainsyncClientRollForwardReplaysDuplicateFromSelectedPeerSeenElsewhere(
 	t *testing.T,
 ) {

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1178,6 +1178,95 @@ func TestChainsyncClientRollForwardApplyGateWithholdsLedgerButObservesTip(
 	}
 }
 
+// With the synchronous observe hook wired (as the node does when Genesis
+// corroboration is active), a header's apply decision reflects that header:
+// the tip is folded into chain selection before the apply gate runs, so a
+// header that establishes corroboration is applied in the same roll-forward
+// rather than withheld until an asynchronous tip update is processed.
+func TestChainsyncClientRollForwardSyncObservationOrdersApplyGate(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+
+	cs := chainselection.NewChainSelector(chainselection.ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	state := dchainsync.NewState(bus, nil)
+	// Distinct remote hosts so the two peers count as independent corroborators.
+	connA := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "10.0.0.2:3001")
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connB))
+	// connA drives, so it may replay a duplicate header first seen from connB.
+	state.SetClientConnId(connA)
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		// Synchronous observation, exactly like node.chainsyncObservePeerTip.
+		ChainsyncObservePeerTip: func(
+			e chainselection.PeerTipUpdateEvent,
+		) bool {
+			cs.HandlePeerTipUpdateEvent(
+				event.NewEvent(chainselection.PeerTipUpdateEventType, e),
+			)
+			return true
+		},
+		ChainsyncApplyEligible: cs.ShouldApplyIngress,
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	// connB delivers the header first. It is observed but uncorroborated (no
+	// witness yet), so it is withheld from the ledger.
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connB},
+		0,
+		header,
+		tip,
+	))
+	select {
+	case <-ledgerCh:
+		t.Fatal("connB header must be withheld while uncorroborated")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// connA (the driver) delivers the same header. Its synchronous observation
+	// makes connA and connB corroborate each other, so by the time the apply
+	// gate runs connA is corroborated and the header is applied — in the same
+	// roll-forward, with no async lag.
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connA},
+		0,
+		header,
+		tip,
+	))
+	select {
+	case evt := <-ledgerCh:
+		data, ok := evt.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connA, data.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal(
+			"corroborating header must be applied in the same roll-forward",
+		)
+	}
+}
+
 func TestChainsyncClientRollForwardReplaysDuplicateFromSelectedPeerSeenElsewhere(
 	t *testing.T,
 ) {

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1178,6 +1178,95 @@ func TestChainsyncClientRollForwardApplyGateWithholdsLedgerButObservesTip(
 	}
 }
 
+// A header first seen from an uncorroborated (apply-denied) peer is withheld but
+// must NOT be permanently deduplicated: the point is recorded without a dedup
+// entry, so when a corroborated apply-eligible peer later delivers it the header
+// is still published — even under the parallel strategy, which never replays
+// duplicates.
+func TestChainsyncClientRollForward_WithheldHeaderNotPermanentlyDeduped(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+
+	cs := chainselection.NewChainSelector(chainselection.ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	cfg := dchainsync.DefaultConfig()
+	cfg.HeaderSyncStrategy = dchainsync.HeaderSyncStrategyParallel
+	state := dchainsync.NewStateWithConfig(bus, nil, cfg)
+	// Distinct remote hosts so the two peers count as independent corroborators.
+	connA := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "10.0.0.2:3001")
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connB))
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		ChainsyncObservePeerTip: func(
+			e chainselection.PeerTipUpdateEvent,
+		) bool {
+			cs.HandlePeerTipUpdateEvent(
+				event.NewEvent(chainselection.PeerTipUpdateEventType, e),
+			)
+			return true
+		},
+		ChainsyncApplyEligible: cs.ShouldApplyIngress,
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	// connA delivers the header while uncorroborated: withheld, and NOT recorded
+	// in the cross-peer dedup cache.
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connA},
+		0,
+		header,
+		tip,
+	))
+	select {
+	case <-ledgerCh:
+		t.Fatal("connA header must be withheld while uncorroborated")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// connB delivers the same header. connA and connB now corroborate each
+	// other, so connB is apply-eligible. Because connA's delivery was not
+	// deduplicated, the header is still "new" and the parallel strategy
+	// publishes it — the point is not lost.
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connB},
+		0,
+		header,
+		tip,
+	))
+	select {
+	case evt := <-ledgerCh:
+		data, ok := evt.Data.(ledger.ChainsyncEvent)
+		require.True(t, ok)
+		require.Equal(t, connB, data.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal(
+			"corroborated peer must be able to publish a point first seen " +
+				"from an uncorroborated (withheld) peer",
+		)
+	}
+}
+
 // With the synchronous observe hook wired (as the node does when Genesis
 // corroboration is active), a header's apply decision reflects that header:
 // the tip is folded into chain selection before the apply gate runs, so a

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -153,6 +153,15 @@ type OuroborosConfig struct {
 	// keep inbound/public noise out of ledger ingress while still
 	// tracking peer tips separately for selection and observability.
 	ChainsyncIngressEligible func(ouroboros.ConnectionId) bool
+	// ChainsyncApplyEligible reports whether a peer's chainsync headers
+	// and rollbacks may be APPLIED to the ledger. It is a second gate,
+	// stricter than ChainsyncIngressEligible: a peer can be ingress-
+	// eligible (so its tips are observed for chain selection) yet not
+	// apply-eligible, so its blocks are not applied. This enforces the
+	// Ouroboros Genesis corroboration stall — an uncorroborated fast source
+	// is observed but cannot steer the ledger. When nil, every ingress-
+	// eligible peer is apply-eligible (no behavior change).
+	ChainsyncApplyEligible func(ouroboros.ConnectionId) bool
 	// Enable experimental Leios protocol support
 	EnableLeios bool
 	// EnableLeiosVotes initiates the standalone leios-votes mini-protocol

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/chainsync"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
@@ -162,6 +163,15 @@ type OuroborosConfig struct {
 	// is observed but cannot steer the ledger. When nil, every ingress-
 	// eligible peer is apply-eligible (no behavior change).
 	ChainsyncApplyEligible func(ouroboros.ConnectionId) bool
+	// ChainsyncObservePeerTip observes a peer tip update. It returns true if it
+	// handled the observation synchronously, in which case the caller MUST NOT
+	// also publish the async PeerTipUpdateEvent (avoids a double update). This
+	// lets the node update chain-selection state synchronously before the
+	// ChainsyncApplyEligible gate runs, so an apply decision reflects the header
+	// currently being admitted (closing the race where an async tip update that
+	// revokes corroboration is not yet processed). Returning false (or nil hook)
+	// falls back to the async PeerTipUpdateEvent path.
+	ChainsyncObservePeerTip func(chainselection.PeerTipUpdateEvent) bool
 	// Enable experimental Leios protocol support
 	EnableLeios bool
 	// EnableLeiosVotes initiates the standalone leios-votes mini-protocol


### PR DESCRIPTION
## Summary

Addresses #2709. Implements the security-critical core of Ouroboros Genesis support for biased fast-sync sources: a **corroboration gate** so a fast (shallow) block source — e.g. a local shallow peer or the Genesis Sync Accelerator — is followed only while independent peers confirm its recent blocks.

Previously Genesis mode selected the densest peer with no corroboration, so a bad or divergent fast source could silently steer the local chain. Now an uncorroborated or divergent source is **denied selection** and the node **stalls** rather than following an untrue chain.

## What changed

**Corroboration gate (`chainselection/`)**
- Track a bounded recent `(slot, hash)` frontier per peer (`observedPoints`), maintained in lockstep with the existing `observedSlots`, for block-identity comparison (two-pointer merge on the sorted frontiers).
- A candidate is *corroborated* only when ≥ `MinCorroboratingPeers` other eligible/live/non-stale peers report an identical `(slot, hash)` point. In Genesis mode an uncorroborated candidate is denied selection (`isPeerSelectableLocked`); a divergent private-fork source shares no recent hash with honest peers, so it can never win. `0` disables the gate (density-only, historical default — existing Genesis tests unchanged).
- The gate denies selection but **keeps the fast source connected** so it can serve blocks once corroboration arrives.

**Observability**
- `GenesisStatus()` getter (mode, window, selected fast source, per-peer density/corroboration).
- New events `chainselection.genesis_corroboration_failed` and `chainselection.genesis_mode_exited` (with exit reason).

**Wiring**
- `WithGenesisCorroborationPeers` → `ChainSelectorConfig.MinCorroboratingPeers`.
- `genesisBootstrap.corroborationPeers` in config (yaml / `DINGO_GENESIS_BOOTSTRAP_CORROBORATION_PEERS` / `--genesis-bootstrap-corroboration-peers`), plus `dingo.yaml.example`.

## Docs

- `ARCHITECTURE.md`: new "Ouroboros Genesis trust model" subsection (corroboration, GSA `localRoots` + peer-snapshot config, trust-model comparison vs Praos/Mithril, observability, explicit deferred scope), the two new event-table rows, and a Peer-Governance cross-reference.
- `GENESIS_SYNC.md`: new operator runbook.
- `DATABASE.md`: checked, not affected.

## Tests

Added `chainselection/genesis_corroboration_test.go` covering honest fast source (corroborated → selected), divergent fast source (denied + failure event), insufficient corroboration / quorum-not-met (stall), disabled-by-default, `GenesisStatus` observability, mode-exit event, and frontier invariants (lockstep, rollback trim, hash-sensitive sharing). Extended the config env-var test.

`chainselection`, `peergov`, `internal/config`, root, and conformance suites pass with `-race`; `golangci-lint` and `modernize` clean.

## Explicitly deferred (per issue scope)

Documented, not silently dropped: full density-at-intersection, ChainSync Jumping / devoted BlockFetch dynamics, wiring peer-governance demotion to the corroboration-failure event, and a live DevNet/GSA integration run. These are performance/refinement; this PR delivers the from-origin **security** property that a fast source cannot steer the node without independent corroboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Genesis corroboration gate so a fast (shallow) source only drives chain selection when independent peers confirm its recent blocks; enforcement happens at ledger apply so uncorroborated sources are observed but withheld. Tightens Genesis exit and `ouroboros` chainsync handling to prevent premature exit, stalls, or lost headers; default remains off.

- New Features
  - Corroboration gate: requires ≥ `MinCorroboratingPeers` distinct-host witnesses of recent `(slot, hash)`; uncorroborated sources are denied but stay connected. `0` disables; negative programmatic values clamp to `1` (fail-closed); negatives in config are rejected.
  - Per-peer recent `(slot, hash)` frontier tracked only while corroboration is active and cleared on Genesis exit; trimmed on rollback.
  - Ledger apply gate: withholds headers/rollbacks from uncorroborated peers via `chainselection.ShouldApplyIngress` and `ouroboros` `ChainsyncApplyEligible`; tips are observed first via `ChainsyncObservePeerTip` to avoid races.
  - Observability: `GenesisStatus()` snapshot and events `chainselection.genesis_corroboration_failed`, `chainselection.genesis_mode_exited`, and `chainselection.selected_none`.

- Bug Fixes
  - Genesis exit uses the advertised tip and only counts corroborated peers that have delivered headers up to within the window (`ObservedTip + window >= Tip`), preventing premature exit and horizon pinning by extreme slots.
  - Order fixes: observe tips before the apply decision; rollbacks are apply-gated; emit `chainselection.selected_none` on all best-peer → none transitions.
  - `ouroboros`: do not dedup headers withheld by the apply gate; record cross-peer dedup only for apply-eligible headers so a later corroborated peer can still publish the point.

<sup>Written for commit eeadbb695264fc218d646506eb16e512458e79b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable corroboration for Genesis-mode chain selection.
  * Fast-sync sources must be independently confirmed before being selected; otherwise, selection pauses to avoid divergent chains.
  * Added Genesis status visibility, including source density, corroboration counts, and selection readiness.
  * Added events for corroboration failures and exiting Genesis mode.
  * Added configuration support through YAML, environment variables, CLI flags, and programmatic options.

* **Documentation**
  * Added operator guidance for configuring, monitoring, and tuning Genesis synchronization and corroboration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->