### PR TITLE
fix(database): utxo cleanup order sort

### DIFF
--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -231,6 +231,13 @@ func (d *MetadataStoreMysql) GetUtxosBySlot(
 }
 
 // GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
+//
+// No ORDER BY is applied. Cleanup (UtxosDeleteConsumed) physically deletes every
+// row this returns and loops until none remain, so the order the batch is
+// returned in has no effect on correctness. Omitting the ordering lets the engine
+// satisfy the deleted_slot range and LIMIT directly from the deleted_slot-leading
+// composite index (idx_utxo_deleted_staking_amount) instead of sorting the entire
+// matching set on every batch, mirroring the SQLite plugin.
 func (d *MetadataStoreMysql) GetUtxosDeletedBeforeSlot(
 	slot uint64,
 	limit int,
@@ -241,8 +248,7 @@ func (d *MetadataStoreMysql) GetUtxosDeletedBeforeSlot(
 	if err != nil {
 		return nil, err
 	}
-	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot).
-		Order("id DESC")
+	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot)
 	if limit > 0 {
 		db = db.Limit(limit)
 	}

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -287,6 +287,13 @@ func (d *MetadataStorePostgres) GetUtxosBySlot(
 }
 
 // GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
+//
+// No ORDER BY is applied. Cleanup (UtxosDeleteConsumed) physically deletes every
+// row this returns and loops until none remain, so the order the batch is
+// returned in has no effect on correctness. Omitting the ordering lets the engine
+// satisfy the deleted_slot range and LIMIT directly from the deleted_slot-leading
+// composite index (idx_utxo_deleted_staking_amount) instead of sorting the entire
+// matching set on every batch, mirroring the SQLite plugin.
 func (d *MetadataStorePostgres) GetUtxosDeletedBeforeSlot(
 	slot uint64,
 	limit int,
@@ -297,8 +304,7 @@ func (d *MetadataStorePostgres) GetUtxosDeletedBeforeSlot(
 	if err != nil {
 		return nil, err
 	}
-	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot).
-		Order("id DESC")
+	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot)
 	if limit > 0 {
 		db = db.Limit(limit)
 	}

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -300,6 +300,15 @@ func (d *MetadataStoreSqlite) GetUtxosBySlot(
 }
 
 // GetUtxosDeletedBeforeSlot returns a list of Utxos marked as deleted before a given slot
+//
+// No ORDER BY is applied. Cleanup (UtxosDeleteConsumed) physically deletes every
+// row this returns and loops until none remain, so the order the batch is
+// returned in has no effect on correctness. Omitting the ordering lets SQLite
+// satisfy the deleted_slot range and LIMIT directly from the deleted_slot-leading
+// composite index (idx_utxo_deleted_staking_amount) instead of materializing and
+// sorting the entire matching set (millions of consumed UTxOs on a from-genesis
+// sync) on every batch. An "ORDER BY id DESC" here forced exactly that temp-btree
+// sort because the primary-key id is not aligned with the deleted_slot index.
 func (d *MetadataStoreSqlite) GetUtxosDeletedBeforeSlot(
 	slot uint64,
 	limit int,
@@ -310,8 +319,7 @@ func (d *MetadataStoreSqlite) GetUtxosDeletedBeforeSlot(
 	if err != nil {
 		return nil, err
 	}
-	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot).
-		Order("id DESC")
+	db = db.Where("deleted_slot > 0 AND deleted_slot <= ?", slot)
 	if limit > 0 {
 		db = db.Limit(limit)
 	}

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -394,6 +394,216 @@ func TestGetUtxosBySlotIncludesSpent(t *testing.T) {
 	assert.Equal(t, live.TxId, gotLive[0].Hash)
 }
 
+// utxoTestTxID builds a distinct 32-byte tx id for the given ordinal so
+// seeded rows satisfy the (tx_id, output_idx) unique index.
+func utxoTestTxID(n int) []byte {
+	id := make([]byte, 32)
+	id[0] = byte(n >> 8)
+	id[1] = byte(n)
+	return id
+}
+
+// TestGetUtxosDeletedBeforeSlotCleanupLoop exercises the consumed-UTxO cleanup
+// path (GetUtxosDeletedBeforeSlot + DeleteUtxos) the way UtxosDeleteConsumed
+// drives it: repeatedly fetch a bounded batch and physically delete it until
+// none remain. It proves the fix that removed "ORDER BY id DESC" preserves
+// correctness — exactly the consumed rows at or before the boundary are
+// deleted, while live rows and rows consumed after the boundary survive — and
+// that the multi-batch loop (batch smaller than the consumed set) terminates
+// and deletes every eligible row regardless of return order.
+func TestGetUtxosDeletedBeforeSlotCleanupLoop(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	const boundary = 1000
+	n := 0
+
+	// Consumed at or before the boundary: must all be deleted. Seed more than
+	// one batch worth (25 rows vs. a batch limit of 10) so the cleanup loop
+	// runs several iterations. Spread across several deleted slots, including
+	// the boundary slot itself (<= boundary is inclusive).
+	consumedBeforeSlots := []uint64{100, 100, 500, 999, 1000}
+	consumedBefore := make([]models.UtxoId, 0, 25)
+	for range 5 { // 5 * 5 = 25 rows
+		for _, ds := range consumedBeforeSlots {
+			n++
+			txID := utxoTestTxID(n)
+			require.NoError(t, store.DB().Create(&models.Utxo{
+				TxId:        txID,
+				OutputIdx:   0,
+				AddedSlot:   ds - 50,
+				DeletedSlot: ds,
+				Amount:      types.Uint64(1_000_000),
+			}).Error)
+			consumedBefore = append(
+				consumedBefore,
+				models.UtxoId{Hash: txID, Idx: 0},
+			)
+		}
+	}
+
+	// Consumed strictly after the boundary: must survive cleanup.
+	consumedAfterSlots := []uint64{1001, 2000, 5000}
+	consumedAfter := make([]models.UtxoId, 0, len(consumedAfterSlots))
+	for _, ds := range consumedAfterSlots {
+		n++
+		txID := utxoTestTxID(n)
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TxId:        txID,
+			OutputIdx:   0,
+			AddedSlot:   500,
+			DeletedSlot: ds,
+			Amount:      types.Uint64(2_000_000),
+		}).Error)
+		consumedAfter = append(
+			consumedAfter,
+			models.UtxoId{Hash: txID, Idx: 0},
+		)
+	}
+
+	// Live rows (deleted_slot = 0): must survive cleanup.
+	liveAddedSlots := []uint64{50, 700, 1500}
+	live := make([]models.UtxoId, 0, len(liveAddedSlots))
+	for _, as := range liveAddedSlots {
+		n++
+		txID := utxoTestTxID(n)
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TxId:      txID,
+			OutputIdx: 0,
+			AddedSlot: as,
+			Amount:    types.Uint64(3_000_000),
+		}).Error)
+		live = append(live, models.UtxoId{Hash: txID, Idx: 0})
+	}
+
+	// Drive the cleanup loop exactly like UtxosDeleteConsumed: fetch a bounded
+	// batch, delete it, repeat until the query returns nothing.
+	const batchLimit = 10
+	iterations := 0
+	deleted := 0
+	for {
+		batch, err := store.GetUtxosDeletedBeforeSlot(boundary, batchLimit, nil)
+		require.NoError(t, err)
+		if len(batch) == 0 {
+			break
+		}
+		// Every returned row must be eligible: consumed at or before boundary.
+		for i := range batch {
+			require.Positive(t, batch[i].DeletedSlot)
+			require.LessOrEqual(t, batch[i].DeletedSlot, uint64(boundary))
+		}
+		require.LessOrEqual(t, len(batch), batchLimit)
+		ids := make([]models.UtxoId, len(batch))
+		for i := range batch {
+			ids[i] = models.UtxoId{Hash: batch[i].TxId, Idx: batch[i].OutputIdx}
+		}
+		require.NoError(t, store.DeleteUtxos(ids, nil))
+		deleted += len(batch)
+		iterations++
+		require.Less(t, iterations, 100, "cleanup loop failed to terminate")
+	}
+
+	// All consumed-before rows were deleted, across multiple batches.
+	assert.Equal(t, len(consumedBefore), deleted)
+	assert.GreaterOrEqual(
+		t,
+		iterations,
+		3,
+		"expected the multi-batch loop to run several times",
+	)
+
+	// Nothing eligible remains.
+	remaining, err := store.GetUtxosDeletedBeforeSlot(boundary, 0, nil)
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+
+	// Every consumed-before row is physically gone.
+	for _, id := range consumedBefore {
+		got, err := store.GetUtxoIncludingSpent(id.Hash, id.Idx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, got, "consumed-before UTxO should be deleted")
+	}
+
+	// Rows consumed after the boundary survive (still soft-spent).
+	for _, id := range consumedAfter {
+		got, err := store.GetUtxoIncludingSpent(id.Hash, id.Idx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, got, "consumed-after UTxO must survive cleanup")
+		assert.Positive(t, got.DeletedSlot)
+	}
+
+	// Live rows survive and remain live.
+	for _, id := range live {
+		got, err := store.GetUtxo(id.Hash, id.Idx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, got, "live UTxO must survive cleanup")
+		assert.Zero(t, got.DeletedSlot)
+	}
+
+	// Row-count cross-check: only the surviving rows are left.
+	var total int64
+	require.NoError(
+		t,
+		store.DB().Model(&models.Utxo{}).Count(&total).Error,
+	)
+	assert.Equal(t, int64(len(consumedAfter)+len(live)), total)
+}
+
+// TestGetUtxosDeletedBeforeSlotNoOrderBySort proves the query no longer forces a
+// sort: with "ORDER BY id DESC" removed, the plan contains no temp-b-tree
+// ordering step (the hot spot that wedged from-genesis sync), so the
+// deleted_slot range + LIMIT can be served directly from the index.
+func TestGetUtxosDeletedBeforeSlotNoOrderBySort(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	for i := range 40 {
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TxId:        utxoTestTxID(i + 1),
+			OutputIdx:   0,
+			AddedSlot:   uint64(i + 1), //nolint:gosec
+			DeletedSlot: uint64(i + 1), //nolint:gosec
+			Amount:      types.Uint64(1_000_000),
+		}).Error)
+	}
+
+	var capturedSQL string
+	var capturedVars []any
+	callbackName := "test:capture_get_utxos_deleted_before_slot_sql"
+	require.NoError(t, store.ReadDB().Callback().Query().
+		After("gorm:query").
+		Register(callbackName, func(tx *gorm.DB) {
+			if capturedSQL != "" {
+				return
+			}
+			capturedSQL = tx.Statement.SQL.String()
+			capturedVars = append([]any(nil), tx.Statement.Vars...)
+		}))
+
+	got, err := store.GetUtxosDeletedBeforeSlot(1000, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 10)
+	require.NotEmpty(t, capturedSQL)
+	assert.NotContains(t, capturedSQL, "ORDER BY")
+
+	planRows, err := store.DB().
+		Raw("EXPLAIN QUERY PLAN "+capturedSQL, capturedVars...).
+		Rows()
+	require.NoError(t, err)
+	defer planRows.Close()
+
+	var details []string
+	for planRows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, planRows.Err())
+	plan := strings.Join(details, "\n")
+	assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY")
+}
+
 func sortUtxoIds(ids []models.UtxoId) {
 	sort.Slice(ids, func(i, j int) bool {
 		if c := bytes.Compare(ids[i].Hash, ids[j].Hash); c != 0 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed ORDER BY from the UTxO cleanup query so the DB can use the deleted_slot index and LIMIT directly, avoiding expensive sorts and fixing from-genesis sync stalls. Added tests to prove multi-batch correctness and verify no unintended sort.

- **Bug Fixes**
  - Omitted ORDER BY in `GetUtxosDeletedBeforeSlot` for `mysql`, `postgres`, and `sqlite` to leverage the deleted_slot–leading index and speed up deletes.
  - Added SQLite tests to validate cleanup loop behavior and confirm no ORDER BY/temp b-tree in the query plan.

<sup>Written for commit f2e23063628d420fb025a1a8b28fb0cb2bcf9173. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

