### PR TITLE
feat: delegator inactivity (CIP-163)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2591,8 +2591,8 @@ CIP-0163 reward-account inactivity (proof-of-life) tracks each account's
 DRep activity uses a boundary one epoch later —
 `drep.ExpiryEpoch == 0 || drep.ExpiryEpoch > currentEpoch`
 (`ledger/governance/epoch.go` `drepActiveAtEpoch`) — so a stored expiry equal
-to `currentEpoch` is still active for a DRep but already expired for an
-account; the two predicates are intentionally not shared code, matching the
+to `currentEpoch` is still active for an account but already expired for a
+DRep; the two predicates are intentionally not shared code, matching the
 CIP text's separate account and DRep expiry semantics. When the
 delegator-inactivity gate
 (`LedgerStateConfig.DelegatorInactivityEnabled` / `DelegatorInactivity`) is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,6 +276,7 @@ sequenceDiagram
     LS->>ChM: chain.Rollback(point)
     ChM->>DB: delete blocks/txs after point
     ChM->>DB: restore account/pool/DRep state
+    LS->>DB: recompute CIP-0163 account expiration (epoch-owned)
     LS->>LS: reload epoch cache, repair lab nonces
     LS->>EB: publish TransactionEvent(rollback: true) per tx
 ```
@@ -2511,6 +2512,28 @@ LedgerState --> Epoch Transition --> EventBus (EpochTransitionEvent)
          PoolStakeSnapshot    EpochSummary
 ```
 
+CIP-0163 reward-account inactivity exclusion: the snapshot manager mirrors both
+`LedgerStateConfig.DelegatorInactivityEnabled` and its inactivity period (set at
+construction in `node.go`/`internal/node/load.go` via
+`Manager.SetDelegatorInactivity`). The setting becomes permanently immutable
+when `Start` succeeds or any capture path is entered; a late setter call returns
+an error, and stopping/restarting the same manager does not unlock it. When
+enabled, the manager passes the snapshot slot, epoch (as `expiryEpoch`), and the
+period into the shared historical stake-aggregation chokepoint
+(`GetStakeByPoolsAtSlot`), which reconstructs expiration at the requested slot.
+The reward-input path (`GetRewardStakeInputsForPools`) sources the gated per-pool
+reward basis from that same historical `active_delegator_stake` CTE, so its
+inputs agree with the leader-election stake by construction (identical
+membership, stake values, and slot-historical expiry); only its gate-off path
+reads the live `account.expiration_epoch` aggregate. This closes the earlier
+divergence where a fallback capture running after the boundary could read a
+post-slot renewal from the live column. Together these filters exclude expired
+credentials from leader-election Mark stake, the per-pool reward basis, and SPO
+governance vote power. The gate and period must match the ledger config that
+stamps account expirations, and both are consensus-affecting. The public
+`Calculator.CalculateStakeDistribution` query path passes zero values (gate
+off).
+
 ### Database Models
 
 | Model | Purpose |
@@ -2562,6 +2585,111 @@ Pool registration lookup reconstructs the parameters effective during the
 ended epoch for per-pool input capture. Reward calculation and application
 remain outside the snapshot manager's responsibility.
 
+CIP-0163 reward-account inactivity (proof-of-life) tracks each account's
+`expiration_epoch`. An account is active iff `expiration_epoch == 0` (unset) or
+`expiration_epoch >= currentEpoch` (`ledger.accountExpiredAtEpoch`, negated).
+DRep activity uses a boundary one epoch later —
+`drep.ExpiryEpoch == 0 || drep.ExpiryEpoch > currentEpoch`
+(`ledger/governance/epoch.go` `drepActiveAtEpoch`) — so a stored expiry equal
+to `currentEpoch` is still active for a DRep but already expired for an
+account; the two predicates are intentionally not shared code, matching the
+CIP text's separate account and DRep expiry semantics. When the
+delegator-inactivity gate
+(`LedgerStateConfig.DelegatorInactivityEnabled` / `DelegatorInactivity`) is
+enabled, block application renews it: `LedgerDelta.applyWithDonationRecording`
+(`ledger/delta.go`, the shared body of `apply` and
+`applyWithoutRecordingDonations`)
+calls `LedgerState.renewWitnessedAccountExpirations`
+(`ledger/account_expiry_renew.go`) after the block's transactions have been
+written to the metadata store, inside the same DB transaction, so the renewal
+commits or rolls back atomically with the block. `witnessedRewardCredentials`
+collects the reward-account stake credentials a phase-2-valid transaction
+witnesses — reward-withdrawal accounts plus the stake credential of stake/vote
+registration, deregistration, and delegation certificates (including the
+combined registration+delegation certs), derived exactly as
+`database/plugin/metadata/sqlite` `SetTransaction` derives them — and every
+witnessed credential's `expiration_epoch` is set to
+`currentEpoch + DelegatorInactivity` through `Database.RenewAccountExpirations`.
+Because that primitive only updates existing account rows and runs after the
+block's account writes, a stake-key registration in the same block has already
+created the row it then renews; because the current epoch's expiry is never
+earlier than a prior renewal and within-epoch re-witnessing is idempotent, the
+value only moves forward (the monotonicity is a caller contract, not a guard in
+the primitive). Phase-2-invalid transactions apply no certificates or
+withdrawals, so they witness nothing and are skipped. With the gate off the hook
+computes and writes nothing. `expiration_epoch` enforcement lives in two
+separate read paths plus one application-time guard, all gated by the same flag:
+the stake-aggregation chokepoint (`GetStakeByPoolsAtSlot`/`GetRewardStakeInputsForPools`,
+see the snapshot-manager paragraph above) for leader-election Mark stake, the
+per-pool reward basis, and SPO governance vote power; the DRep voting-power queries
+(`GetDRepVotingPower`/`GetDRepVotingPowerBatch`/`GetDRepVotingPowerByType`, see
+"Epoch Boundary State Transitions" step 5) for the DRep governance tally; and the
+reward-crediting guard in `applyStakeRewardApplication` (`ledger/reward_calculation.go`).
+The stake-aggregation chokepoint already removes an expired delegator's stake from
+the reward basis, so an expired delegator earns nothing. A pool's reward (leader)
+account, however, is credited its leader reward independent of that account's own
+stake, so an expired reward account would still be credited without this guard.
+At application time the guard reconstructs expiry for every credited credential
+from witness history through the reward snapshot's captured slot (plus the
+activation floor, with the current row retained only as an import-history
+fallback) and skips crediting any whose account is expired as of the
+reward's snapshot epoch — `stakeRewardEpochsForApplication(newEpoch).snapshot`, the
+same snapshot epoch the basis was judged against, so the two agree on which
+snapshot an account is measured at. A skipped amount is excluded from the credited
+(effective) total and from the unspendable (treasury) total by
+`deriveStakeRewardApplicationTotals`, so it falls through to undistributed and is
+refunded to reserves, and the ADA pots reconcile exactly (reserves gains the
+skipped amount, total supply conserved). The guard set is built only when the gate
+is on; with the gate off it is nil and the crediting loop and pot derivation are
+byte-identical to pre-CIP behavior.
+
+CIP-0163 activation is a one-time stamp that starts the inactivity clock for
+accounts that existed before the gate was ever turned on: without it, those
+accounts would keep `expiration_epoch = 0` (permanently exempt) since ordinary
+renewal only touches credentials witnessed by a transaction.
+`LedgerState.activateDelegatorInactivityIfNeeded`
+(`ledger/account_expiry_activate.go`) runs inside `processEpochRollover`
+(`ledger/chainsync.go`), before the inactivity-gated governance tally and mark
+snapshot, in the same rollover DB transaction. It is a no-op when the gate is
+off. With the gate on, it checks the durable `sync_state` marker
+`delegator_inactivity_activated` (`Database.GetSyncState`/`SetSyncState`); if
+already set (any non-empty value), it returns immediately. Otherwise it calls
+`Database.StampAllActiveAccountExpirations(currentEpoch + DelegatorInactivity,
+txn)` — an exact membership capture followed by an `UPDATE` over every active
+account, including accounts already renewed by a pre-activation witness — and
+then writes the activation epoch `A`
+(the entered `currentEpoch`, as a decimal string) into the marker in the same
+transaction,
+so the stamp and the marker commit or roll back together. `currentEpoch` here
+is the epoch being entered (`currentEpoch.EpochId + 1`), not the epoch that
+just ended, matching the `currentEpoch + DelegatorInactivity` convention the
+per-block renewal hook uses. The new epoch row is persisted later in the same
+transaction. The stored epoch is not just a flag: because the
+activation stamp sets `A + DelegatorInactivity` without leaving any witness,
+the rollback recompute (`recomputeAccountExpirationsAfterRollback`, read back
+via `LedgerState.delegatorInactivityActivationEpoch`) reads `A` as an
+activation floor and clamps each credential in the durable
+`account_inactivity_activation` membership set up to
+`A + DelegatorInactivity` — otherwise an account whose only post-activation
+witness was orphaned would be mis-restored to a far-past registration epoch or
+reset to 0. Explicit membership is required because a deregistered account row
+may exist at activation without being stamped. Because the marker gates the
+whole stamp, later rollovers never repeat it.
+Rolling back before epoch `A` clears expiration for the exact membership set,
+returns its credentials, deletes the membership rows, and unions those
+credentials with credentials witnessed after the rollback point. The ledger then
+reconstructs every affected expiration from surviving witness history before
+deleting the marker. This restores a pre-activation witness renewal that the
+uniform activation stamp overwrote, while an account with no surviving witness
+returns to expiration 0. The marker deletion allows activation to run again
+when the surviving chain next enters an enabled boundary.
+
+Every valid reward-withdrawal map entry is also persisted in the rollback-aware
+`account_withdrawal_witness` history, independently of balance deltas. This
+includes zero-amount withdrawals: they move no rewards but still prove account
+activity under CIP-0163. Rollback affected-set and last-witness queries include
+this history, and rollback removes its orphaned rows.
+
 Reward snapshots consume `RewardLiveStake` instead of scanning the full UTxO
 table at the epoch boundary. The snapshot manager copies the registered,
 delegated subset into `RewardStakeInput` and derives `RewardPoolInput` rows,
@@ -2583,7 +2711,25 @@ for leader-election and governance consumers. Those synthetic rows do not get
 `RewardSnapshot` or reward-input bundles unless the live aggregate represents
 the target boundary exactly; without a historical reward-input backfill, reward
 application skips the missing bundle rather than treating current stake as
-historical stake.
+historical stake. When CIP-0163 delegator inactivity is enabled, Mithril bootstrap is refused
+outright. `account.expiration_epoch` is dingo-only ledger state with no
+representation in the cardano-ledger Mithril snapshot, and it cannot be
+reconstructed after import — a long-inactive account (exactly what CIP-0163
+targets) may have last witnessed before the import point — so a
+Mithril-bootstrapped node would compute different expiry-dependent stake,
+rewards, and governance than a genesis-synced one. Two guards enforce this: the
+`mithril sync` command (and the shared `sync --mithril` path) rejects the run
+when `delegatorInactivityEnabled` is set (`errMithrilInactivityIncompatible`),
+and `dingo serve` refuses to start on a Mithril-bootstrapped database (detected
+via `mithril.WasBootstrapped`, which checks the durable `mithril_immutable_max`
+marker and falls back to the legacy `mithril_ledger_slot` trust boundary so
+databases bootstrapped before that marker existed — pre-v0.62.0, #2694 — are
+still recognized) with the gate on (`checkMithrilInactivityCompat`) — closing the
+"run `mithril sync` gate-off, then restart gate-on" path. A CIP-0163 node must
+sync from genesis.
+(Independently, the snapshot manager also does not synthesize the N-1/N-2 Mark
+rows from live `account.expiration_epoch`, which may reflect a later renewal; the
+current-epoch N row is still captured.)
 
 ### Query Interface
 
@@ -2626,10 +2772,12 @@ relies solely on the fallback capture, preserving the pre-wiring behavior.
 event-driven fallback: `LoadWithDB` builds the snapshot manager with a nil
 `EventBus` and never starts it, and the load ledger publishes no
 `EpochTransitionEvent`s. A post-hoc fallback cannot substitute either, because
-the reward inputs are copied from the live reward aggregate, which only matches
-the boundary during the in-transaction capture. So the ledger's savepoint
-deferral would otherwise turn a transient capture error into a silently missing
-mark/reward snapshot. To prevent that, `LoadWithDB` wraps the hook with a
+with the CIP-0163 gate off the reward inputs are copied from the live reward
+aggregate, which only matches the boundary during the in-transaction capture
+(with the gate on they are reconstructed at slot and would match, but the load
+path publishes no events to drive a fallback regardless). So the ledger's
+savepoint deferral would otherwise turn a transient capture error into a silently
+missing mark/reward snapshot. To prevent that, `LoadWithDB` wraps the hook with a
 `loadCaptureFailureTracker` that records any suppressed capture failure and,
 after replay completes, returns it — failing the load loudly so the operator
 knows the resulting database is incomplete and must be re-imported, rather than
@@ -2727,7 +2875,15 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    credit their rewards to registered reward accounts and apply the pot-to-pot
    transfers between treasury and reserves. It is a no-op for Conway+ epochs,
    where MIR certificates are not valid and no rows exist for those slots.
-5. Governance enactment (`governance.ProcessEpoch`): treasury withdrawals and
+5. CIP-0163 one-time activation stamp (`activateDelegatorInactivityIfNeeded`):
+   no-op unless the delegator-inactivity gate is on and the durable
+   `delegator_inactivity_activated` `sync_state` marker is unset; otherwise
+   stamps every active account to the new epoch's
+   `EpochId + DelegatorInactivity` and sets the marker atomically with this
+   transaction. It precedes governance so the first inactivity-gated DRep tally
+   observes the same full activation window as the Mark snapshot. See
+   "CIP-0163 activation" above.
+6. Governance enactment (`governance.ProcessEpoch`): treasury withdrawals and
    proposal-deposit returns, which observe the post-POOLREAP treasury. The
    proposal-independent voting denominators — DRep voting power
    (`LoadDRepVotingState`, the heavy `account`⋈`utxo` aggregation), the pool
@@ -2739,23 +2895,36 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    at an epoch boundary with many active proposals it stalled the rollover, and
    thus the whole ledger pipeline, for hours.) A `slowGovernanceTallyThreshold`
    warning surfaces an unexpectedly slow tally rather than letting it present as
-   a silent stalled rollover.
-6. Treasury donations (`applyEpochDonations`), added after withdrawals.
-7. ADA-pot capture (`saveRewardAdaPotsForEpoch`): record the new epoch's
+   a silent stalled rollover. `LoadDRepVotingState` also applies the CIP-0163
+   reward-account inactivity exclusion to the DRep voting-power denominator: it
+   passes `expiryEpoch = NewEpoch` (0 when the gate is off) to
+   `GetDRepVotingPowerBatch`/`GetDRepVotingPowerByType`, threaded in from
+   `EpochInput.DelegatorInactivityOn` (set by `processEpochRollover` from
+   `LedgerStateConfig.DelegatorInactivityEnabled`, the same gate the snapshot
+   manager and stake-aggregation chokepoint use), excluding delegated stake
+   whose reward account expired before `NewEpoch` from the DRep tally exactly
+   as the stake-aggregation chokepoint excludes it from Mark stake, the reward
+   basis, and SPO vote power. `TallyContext.DelegatorInactivityOn` mirrors the
+   same flag into the lazy (non-precomputed) `tallyDRepVotes` fallback path
+   used by standalone/test callers. The mid-epoch HardForkInitiation stability
+   check snapshots and threads this gate through `StabilityCheckInputs` as well,
+   keeping its advertised transition tally aligned with boundary ratification.
+7. Treasury donations (`applyEpochDonations`), added after withdrawals.
+8. ADA-pot capture (`saveRewardAdaPotsForEpoch`): record the new epoch's
    reserves, treasury, and fees after every boundary treasury/reserves mutation
    above (rewards, POOLREAP, MIR, withdrawals, donations, and any AVVM-removal
    reserves top-up). This `reward_ada_pots` row seeds the delayed reward
    calculation for a later epoch.
-8. New epoch row (`SetEpoch`, with the computed nonce/boundary slot).
-9. Authoritative Mark snapshot capture (`captureEpochBoundarySnapshot` →
-   `snapshot.Manager.CaptureEpochBoundarySnapshot`, when a hook is installed),
-   run last so the new epoch's nonce and boundary slot are available, inside a
-   metadata savepoint so a capture failure defers to the event-driven fallback
-   instead of aborting the rollover. See "Boundary Capture And Events" for the
-   SNAP-point placement caveat and the DevNet gate.
+9. New epoch row (`SetEpoch`, with the computed nonce/boundary slot).
+10. Authoritative Mark snapshot capture (`captureEpochBoundarySnapshot` →
+    `snapshot.Manager.CaptureEpochBoundarySnapshot`, when a hook is installed),
+    run last so the new epoch's nonce and boundary slot are available, inside a
+    metadata savepoint so a capture failure defers to the event-driven fallback
+    instead of aborting the rollover. See "Boundary Capture And Events" for the
+    SNAP-point placement caveat and the DevNet gate.
 
 POOLREAP runs before governance so any deposit that lands in the treasury is
-visible to the withdrawals checked in step 5. MIR certificate effects are applied
+visible to the withdrawals checked in step 6. MIR certificate effects are applied
 in the same pre-governance window, so their treasury/reserves movements are also
 visible to governance and to the ADA-pot capture. Stake rewards are applied first
 so their reserves/treasury movement is visible to governance and to the ADA-pot

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -173,7 +173,7 @@ erDiagram
 | `network_donation` | `id`, `slot`, `epoch`, `amount` | PK `id`; unique `slot`; index `epoch` | Per-block Conway treasury donation, tagged with its epoch. `amount` is a plain integer column (not `types.Uint64`) so `SUM` aggregates directly across backends. All donation sources applied under the same block slot, including Leios endorser-block effects recorded under a ranking block, are accumulated before this per-slot row is written. Donations accumulate during an epoch and are moved into `network_state.treasury` at the next epoch boundary; rows are kept (not deleted on apply) so a rollback drops them by slot and re-application re-derives the same total. |
 | `pparams` | `id`, `cbor`, `added_slot`, `epoch`, `era_id` | PK `id`; index `added_slot` | CBOR protocol parameters. Query by `epoch <= ?` and matching `era_id`. |
 | `pparam_update` | `id`, `genesis_hash`, `cbor`, `added_slot`, `epoch` | PK `id`; index `added_slot` | Proposed protocol-parameter updates by epoch. |
-| `sync_state` | `sync_key`, `value` | PK `sync_key` | Key/value state for sync/load work. `sync_status` (`in_progress`/`backfill`/cleared; unknown non-empty values are treated as incomplete) is ephemeral and cleared on completion. Mithril stores `mithril_ledger_slot` plus `mithril_ledger_hash` as the trusted replay/intersect boundary point. `mithril_immutable_max` persists the highest immutable file number a Mithril sync imported (written *after* the completion clear, since clearing wipes all `sync_state`) so a later `dingo mithril sync` catch-up can skip already-present immutable archives when the marker exists. `mithril_catchup_active` is ephemeral (set when a catch-up import starts mutating, wiped on completion): it routes an interrupted catch-up back through catch-up semantics (reconcile) on the next run, which a markerless catch-up otherwise leaves no trace of. `deferred_header_validation:<slot>:<hash>` is written when blockfetch defers stateful header checks to ledger apply; the value is `true` and the row is deleted after the strict apply-time check passes. |
+| `sync_state` | `sync_key`, `value` | PK `sync_key` | Key/value state for sync/load work. `sync_status` (`in_progress`/`backfill`/cleared; unknown non-empty values are treated as incomplete) is ephemeral and cleared on completion. Mithril stores `mithril_ledger_slot` plus `mithril_ledger_hash` as the trusted replay/intersect boundary point. `mithril_immutable_max` persists the highest immutable file number a Mithril sync imported (written *after* the completion clear, since clearing wipes all `sync_state`) so a later `dingo mithril sync` catch-up can skip already-present immutable archives when the marker exists. `mithril_catchup_active` is ephemeral (set when a catch-up import starts mutating, wiped on completion): it routes an interrupted catch-up back through catch-up semantics (reconcile) on the next run, which a markerless catch-up otherwise leaves no trace of. `deferred_header_validation:<slot>:<hash>` is written when blockfetch defers stateful header checks to ledger apply; the value is `true` and the row is deleted after the strict apply-time check passes. `delegator_inactivity_activated` guards the CIP-0163 one-time activation stamp (`ledger.LedgerState.activateDelegatorInactivityIfNeeded`): its value is the activation epoch `A` (the entered epoch, stored as a decimal string), and any non-empty value means activation has run, so later rollovers skip it even after a restart. It is durable but not permanent: a chain rollback to before epoch `A` clears it (`recomputeAccountExpirationsAfterRollback` calls `DeleteSyncState` alongside `ResetAccountExpirationActivation`), so a subsequent re-sync re-runs activation. The stored epoch is read back (`ledger.LedgerState.delegatorInactivityActivationEpoch`) as the activation floor the rollback recompute clamps expirations up to, since the activation stamp writes `A + DelegatorInactivity` without leaving a witness. |
 | `backfill_checkpoint` | `id`, `phase`, `last_slot`, `total_slots`, `started_at`, `updated_at`, `completed` | PK `id`; unique `phase` | Durable, resumable one-time backfill progress keyed by `phase`. `metadata` tracks API-mode historical metadata backfill. `account_created_slot` records completion of the one-time `account.created_slot` stamp (`models.BackfillAccountCreatedSlot`); gating on this marker instead of on "the column was just added" makes that backfill crash-safe (an interrupted run leaves the marker absent, so the next startup retries the `created_slot = 0` guarded scan). |
 | `import_checkpoint` | `id`, `import_key`, `phase` | PK `id`; unique `import_key` | Mithril snapshot import resume state. `import_key` is usually `{digest}:{slot}`. Catch-up imports leave `import_key` empty to force a full pass. |
 
@@ -330,8 +330,10 @@ rather than relied on).
 
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
-| `account` | `id`, `staking_key`, `credential_tag`, `pool`, `drep`, `added_slot`, `created_slot`, `certificate_id`, `reward`, `drep_type`, `active` | PK `id`; unique (`credential_tag`, `staking_key`); indexes pool/DRep/active lookup combinations, including leftmost `active` coverage for reconcile scans | Current stake account state. `credential_tag`: 0 key hash, 1 script hash. Historical changes are in certificate-specific tables. `drep_type`: 0 key hash, 1 script hash, 2 AlwaysAbstain, 3 AlwaysNoConfidence. `created_slot` is the immutable slot the row was first created (0 for Shelley-genesis delegated accounts); unlike `added_slot`, later registration and delegation changes do not bump it. New rows resolve the `AccountCreatedSlotUnset` sentinel when saved, including phantom rows created by deregistration certificates. Older certificate-created rows (`certificate_id != 0`) are backfilled once from the earliest registration certificate in bounded keyset pages; genesis rows remain at 0 even if later registration history exists. `GetAccountsActiveAtSlot` combines registration/deregistration certificate order with this immutable creation slot so pre-Babbage reward filtering can reconstruct whether each requested credential was active immediately before the RUPD cutoff. |
+| `account` | `id`, `staking_key`, `credential_tag`, `pool`, `drep`, `added_slot`, `created_slot`, `certificate_id`, `reward`, `drep_type`, `active`, `expiration_epoch` | PK `id`; unique (`credential_tag`, `staking_key`); indexes pool/DRep/active lookup combinations, including leftmost `active` coverage for reconcile scans; index on `expiration_epoch` | Current stake account state. `credential_tag`: 0 key hash, 1 script hash. Historical changes are in certificate-specific tables. `drep_type`: 0 key hash, 1 script hash, 2 AlwaysAbstain, 3 AlwaysNoConfidence. `created_slot` is the immutable slot the row was first created (0 for Shelley-genesis delegated accounts); unlike `added_slot`, later registration and delegation changes do not bump it. New rows resolve the `AccountCreatedSlotUnset` sentinel when saved, including phantom rows created by deregistration certificates. Older certificate-created rows (`certificate_id != 0`) are backfilled once from the earliest registration certificate in bounded keyset pages; genesis rows remain at 0 even if later registration history exists. `GetAccountsActiveAtSlot` combines registration/deregistration certificate order with this immutable creation slot so pre-Babbage reward filtering can reconstruct whether each requested credential was active immediately before the RUPD cutoff. `expiration_epoch` (default 0, plain AutoMigrate column mirroring `drep.expiry_epoch`) is the CIP-0163 reward-account inactivity expiry: 0 means unset/active; otherwise the account is treated as expired once the current epoch strictly exceeds it (`ledger.accountExpiredAtEpoch`). Mithril bootstrap does not import this column (it is absent from the cardano-ledger snapshot and cannot be reconstructed after import), so a node with the CIP-0163 gate enabled refuses Mithril bootstrap and must sync from genesis (see ARCHITECTURE.md). `MetadataStore.RenewAccountExpirations(refs, expirationEpoch, txn)` sets it for a batch of stake credentials with set-based `UPDATE`s — one statement per chunk of credentials over an OR-chain of `(credential_tag, staking_key)` equality predicates (the same portable pattern as `MarkUtxosDeletedAtSlot`, avoiding GORM's byte-by-byte tuple-IN unpacking), rather than one `UPDATE` per credential — so a large rollback recompute does not hold the ledger write transaction open across thousands of single-row round-trips; refs with no matching account row are silently ignored (an account must already be registered to have an expiration). The ledger calls this write primitive during block application through the CIP-0163 renewal hook (`ledger.LedgerState.renewWitnessedAccountExpirations`, invoked from `LedgerDelta.applyWithDonationRecording` — the shared body of `apply` and `applyWithoutRecordingDonations` — after the block's account writes and in the same transaction): when the delegator-inactivity gate is on, every reward-account credential witnessed by a block's phase-2-valid transactions (reward withdrawals plus stake/vote registration, deregistration, and delegation certificates) has its `expiration_epoch` set to `currentEpoch + DelegatorInactivity`; with the gate off the hook computes and writes nothing. `MetadataStore.StampAllActiveAccountExpirations(expirationEpoch, txn)` is the one-time CIP-0163 activation counterpart: it records the exact active credential set in `account_inactivity_activation`, then gives every active account the same full window from the activation epoch, overwriting any shorter expiration set by a pre-activation witness, and returns the row count. `ledger.LedgerState.activateDelegatorInactivityIfNeeded` (`ledger/account_expiry_activate.go`) calls it exactly once before inactivity-gated governance and snapshot calculations, guarded by the `delegator_inactivity_activated` `sync_state` marker (see the `sync_state` row above). On a chain rollback the ledger recomputes `expiration_epoch` for the affected reward accounts, because it is an epoch value the slot-oriented account restore (`RestoreAccountStateAtSlot`) cannot derive: `MetadataStore.AccountsWitnessedAfterSlot(slot, txn)` returns the distinct credentials with a stake-witnessing certificate or a reward withdrawal from `account_withdrawal_witness` (including zero-amount withdrawals) or legacy `account_reward_delta` withdrawal rows at `added_slot > slot` — the rolled-away witnesses, collected before the rollback deletes those rows — and `MetadataStore.AccountLastWitnessSlots(refs, maxSlot, txn)` returns, per credential, the greatest witnessing `added_slot <= maxSlot` across that same CIP-0163 witness set (the ten stake-witnessing certificate tables plus both withdrawal histories), keyed by `StakeCredentialRef.MapKey()` and absent when there is no surviving witness. `ledger.LedgerState.recomputeAccountExpirationsAfterRollback` (`ledger/account_expiry_rollback.go`, invoked from the rollback transaction in `ledger/state.go` after `RestoreAccountStateAtSlot`) stamps each affected credential's `expiration_epoch` to the surviving witness slot's epoch + `DelegatorInactivity`, or resets it to 0 when no surviving witness remains. It also honors the one-time activation floor: when activation ran at or before the rollback point (the `delegator_inactivity_activated` marker epoch `A` is `<= SlotToEpoch(rollbackSlot)`), exactly the credentials recorded in `account_inactivity_activation` are clamped up to at least `A + DelegatorInactivity`, because the activation stamp left no witness for a witness-only recompute to recover. This explicit membership avoids flooring account rows that existed but were deregistered at activation. When rollback crosses before `A`, `ResetAccountExpirationActivation` clears expiration for that exact membership, returns those credentials, and deletes the membership rows; the ledger unions the returned credentials into the affected set so a pre-activation witness expiration overwritten by activation is reconstructed rather than lost. With the gate off it does nothing. The stake-aggregation chokepoint enforces the gate for consensus: `GetStakeByPoolsAtSlot`, `GetPoolOwnerStakeAtSlot`, and `GetRewardStakeInputsForPools` all accept `slot`, `expiryEpoch`, and `inactivityPeriod` arguments (`expiryEpoch == 0` = gate off, byte-identical to pre-CIP). With the gate on they reconstruct each credential's expiration at `slot` from witness history (not the mutable live column) and exclude credentials expired before `expiryEpoch` from leader-election mark stake, the per-pool reward basis, and SPO vote power. `GetRewardStakeInputsForPools` sources the gated per-pool reward basis from the same historical `active_delegator_stake` CTE as `GetStakeByPoolsAtSlot`, so the reward-basis inputs agree with the leader-election pool totals by construction; only its gate-off path still reads the live reward aggregate. See `GetStakeByPoolsAtSlot` below. `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, and `GetDRepVotingPowerByType` accept the identical `expiryEpoch` gate for the separate DRep governance voting-power denominator, applied at the epoch-boundary tally by `ledger/governance.LoadDRepVotingState`; see `GetDRepVotingPower` below. |
+| `account_inactivity_activation` | `credential_tag`, `staking_key` | composite PK (`credential_tag`, `staking_key`); index `staking_key` | Exact active-account membership captured by the one-time CIP-0163 activation stamp. Historical expiry reconstruction and rollback use this table instead of inferring membership from account creation time, because an account row may exist while deregistered. The rows are deleted together with the activation marker when rollback crosses before activation. |
 | `account_reward_delta` | `id`, `staking_key`, `credential_tag`, `tx_hash`, `amount`, `previous_reward`, `added_slot`, `withdrawal` | PK `id`; indexes `(credential_tag, staking_key)`, `tx_hash`, `added_slot`, `withdrawal`; unique `(withdrawal, tx_hash, credential_tag, staking_key, added_slot)` | Rollback-aware reward-account change journal. `tx_hash` is non-null; credit writers use an empty blob only when no event discriminator exists. Credit rows add `amount`; withdrawal rows clear `account.reward`, store `previous_reward`, and use `tx_hash` plus the full stake credential identity as their slot-independent logical replay key. The physical unique key also includes `added_slot` so distinct per-epoch credits remain separate while same-boundary credit re-ingest is idempotent. Governance proposal credits store a 32-byte proposal-event discriminator derived from proposal `tx_hash` plus `action_index`, not the raw proposal transaction hash alone. Logical join to `account.(credential_tag, staking_key)`. |
+| `account_withdrawal_witness` | `id`, `staking_key`, `credential_tag`, `tx_hash`, `added_slot` | PK `id`; indexes `added_slot` and (`staking_key`, `credential_tag`, `added_slot`); unique (`tx_hash`, `credential_tag`, `staking_key`) | Rollback-aware CIP-0163 history for every valid withdrawal-map entry, including zero-amount withdrawals that create no reward delta. Rollback witness queries read this table (and legacy withdrawal delta rows), and rollback deletes rows after its target slot. |
 | `registration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Conway-era stake registration certificate. Join `certificate_id -> certs.id`. |
 | `deregistration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot`, `amount` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Conway-era stake deregistration certificate. |
 | `stake_registration` | `id`, `staking_key`, `credential_tag`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, staking_key)`, `certificate_id`, `added_slot` | Shelley-era stake registration certificate. |
@@ -395,11 +397,11 @@ process the same pointer unless the claim expires before a result is recorded.
 |---|---|---|---|
 | `pool_stake_snapshot` | `id`, `epoch`, `snapshot_type`, `pool_key_hash`, `total_stake`, `stake_denominator`, `delegator_count`, `captured_slot`, `reward_account_auto_vote`, `reward_account_auto_vote_resolved` | PK `id`; unique `(epoch, snapshot_type, pool_key_hash)` | Per-pool stake snapshots. `"mark"` rows store lovelace stake totals captured from slot-aware delegation and UTxO state at `captured_slot`, plus each delegator's live `account.reward` balance (issue #2813; interim source, not boundary-exact), and are used by the normal Praos epoch-2 rotation. Mithril-imported `"actv"` rows store `NewEpochState.pool-distr` stake fractions as `total_stake / stake_denominator` for the imported epoch. Mark snapshot refreshes atomically replace all rows for the same `(epoch, snapshot_type)` before inserting the freshly captured set, so disappeared pools cannot remain in the snapshot. Logical joins to `epoch.epoch_id` and `pool.pool_key_hash`. |
 | `epoch_summary` | `id`, `epoch`, `total_active_stake`, `total_pool_count`, `total_delegators`, `epoch_nonce`, `boundary_slot`, `snapshot_ready` | PK `id`; unique `epoch` | Aggregate epoch snapshot state. |
-| `reward_live_stake` | `id`, `credential_tag`, `staking_key`, `pool_key_hash`, `utxo_stake`, `reward_stake`, `total_stake`, `registered`, `pool_delegation_slot`, `pool_delegation_block_index`, `pool_delegation_cert_index`, `updated_slot` | PK `id`; unique `(credential_tag, staking_key)` | Live per-stake-credential aggregate maintained transactionally with UTxO, account, delegation, and reward-balance writes. Epoch-boundary reward capture copies positive, registered, delegated rows into `reward_stake_input`; leader-election Mark snapshots remain slot-aware and independent. Node startup checks for missing aggregate credentials and rebuilds from canonical state when necessary. The `(credential_tag, staking_key)` uniqueness protects the invariant that each stake credential contributes to exactly one reward aggregate and pool input. Capture defensively applies the same credential-only identity before deriving `reward_pool_input` totals. Before AutoMigrate creates the unique index, startup repairs duplicates left by upgraded or partially-written databases by preserving the lowest-`id` row, which is the row the pre-index incremental refresh path updates. |
+| `reward_live_stake` | `id`, `credential_tag`, `staking_key`, `pool_key_hash`, `utxo_stake`, `reward_stake`, `total_stake`, `registered`, `pool_delegation_slot`, `pool_delegation_block_index`, `pool_delegation_cert_index`, `updated_slot` | PK `id`; unique `(credential_tag, staking_key)` | Live per-stake-credential aggregate maintained transactionally with UTxO, account, delegation, and reward-balance writes. Epoch-boundary reward capture copies positive, registered, delegated rows into `reward_stake_input` when the CIP-0163 gate is off; with the gate on, the reward basis is instead reconstructed at the snapshot slot from the historical `active_delegator_stake` CTE (see `GetRewardStakeInputsForPools`) so it agrees with leader-election stake by construction. Leader-election Mark snapshots remain slot-aware and independent. Node startup checks for missing aggregate credentials and rebuilds from canonical state when necessary. The `(credential_tag, staking_key)` uniqueness protects the invariant that each stake credential contributes to exactly one reward aggregate and pool input. Capture defensively applies the same credential-only identity before deriving `reward_pool_input` totals. Before AutoMigrate creates the unique index, startup repairs duplicates left by upgraded or partially-written databases by preserving the lowest-`id` row, which is the row the pre-index incremental refresh path updates. |
 | `reward_ada_pots` | `id`, `epoch`, `treasury`, `reserves`, `fees`, `rewards`, `captured_slot` | PK `id`; unique `epoch`; index `captured_slot` | Reward ADA pots captured at an epoch boundary. |
 | `reward_snapshot` | `id`, `epoch`, `snapshot_type`, `total_active_stake`, `total_pool_count`, `total_delegators`, `captured_slot`, `boundary_slot`, `epoch_nonce`, `protocol_version`, `authoritative` | PK `id`; unique `(epoch, snapshot_type)`; indexes `captured_slot`, `boundary_slot` | Reward snapshot metadata recorded by the epoch rotation path. `authoritative` is `true` for a snapshot captured inside the ledger epoch-rollover write transaction at the SNAP point (`CaptureEpochBoundarySnapshot`) and `false` for the event-driven fallback (`captureMarkSnapshot`). The fallback claims the `(epoch, mark)` row atomically (INSERT ... ON CONFLICT DO NOTHING, then a `FOR UPDATE` recheck) and skips when an `authoritative` row already exists, so it can never overwrite the authoritative capture; the authoritative writer always overwrites a fallback row. When ended-epoch metadata is unavailable and no reward inputs can be persisted, the fallback uses `ClaimFallbackRewardSnapshotGuard` to insert-or-lock the same key, writes the leader-election Mark rows, then deletes only the temporary row it inserted before commit. The transaction retains the row/unique-key lock through commit, so serialization still closes the MySQL/Postgres capture race (SQLite is already serial) while no durable `reward_snapshot` row remains without reward inputs. Guard claim/release require the same non-nil metadata transaction. |
 | `reward_pool_input` | `id`, `epoch`, `pool_key_hash`, `reward_account`, `reward_account_credential_tag`, `pledge`, `delegated_stake`, `owner_stake`, `cost`, `margin`, `delegator_count`, `blocks_produced`, `total_blocks_in_epoch`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Per-pool metadata captured by epoch rotation. Stake totals are aggregated from the captured `reward_stake_input` credentials, independently of leader-election Mark totals; pool parameters are selected as effective during the ended epoch. Owner stake counts captured key credentials named by the effective pool registration. Block counts are stored on the row at capture time. Pools with missing or invalid registration data are excluded from reward inputs without changing `pool_stake_snapshot` or `epoch_summary`. Logical join to `pool.pool_key_hash`. |
-| `reward_stake_input` | `id`, `epoch`, `pool_key_hash`, `credential_tag`, `staking_key`, `stake`, `owner`, `registered`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash, credential_tag, staking_key)`; indexes `captured_slot`, `boundary_slot` | Per-credential stake frozen from `reward_live_stake` by either authoritative or fallback reward snapshot capture. Check the matching `reward_snapshot.authoritative` value to distinguish the source snapshot. `owner` records whether the effective pool registration names the key credential as an owner. Capture defensively deduplicates by `(credential_tag, staking_key)` before deriving `reward_pool_input.delegated_stake` and `delegator_count`, so a corrupted credential cannot contribute to multiple pools and the persisted pool totals remain equal to the sum of their stake-input rows. |
+| `reward_stake_input` | `id`, `epoch`, `pool_key_hash`, `credential_tag`, `staking_key`, `stake`, `owner`, `registered`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash, credential_tag, staking_key)`; indexes `captured_slot`, `boundary_slot` | Per-credential stake frozen by either authoritative or fallback reward snapshot capture: from the live `reward_live_stake` aggregate when the CIP-0163 gate is off, or reconstructed at the snapshot slot from the historical `active_delegator_stake` CTE when the gate is on (matching the leader-election basis). Check the matching `reward_snapshot.authoritative` value to distinguish the source snapshot. `owner` records whether the effective pool registration names the key credential as an owner. Capture defensively deduplicates by `(credential_tag, staking_key)` before deriving `reward_pool_input.delegated_stake` and `delegator_count`, so a corrupted credential cannot contribute to multiple pools and the persisted pool totals remain equal to the sum of their stake-input rows. |
 | `reward_pool_output` | `id`, `epoch`, `pool_key_hash`, `apparent_performance`, `optimal_reward`, `total_reward`, `leader_reward`, `member_reward_total`, `owner_stake`, `undistributed`, `unspendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Persisted per-pool reward-calculation results. Replacing a provisional reward snapshot invalidates rows for the same epoch. |
 | `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. |
 
@@ -914,6 +916,38 @@ across the UTxO join fan-out.
 integer type before arithmetic (`INTEGER` on sqlite, `BIGINT` on postgres,
 `UNSIGNED` on mysql), matching the DRep voting-power queries:
 
+`GetStakeByPoolsAtSlot` and `GetPoolOwnerStakeAtSlot` take both an
+`expiryEpoch uint64` and the configured inactivity period. `expiryEpoch == 0`
+disables the CIP-0163 gate and leaves the pre-CIP query path unchanged. With the
+gate enabled, a shared CTE reconstructs expiration at the requested slot from
+the latest qualifying certificate/withdrawal witness at or before that slot,
+maps the witness slot through the `epoch` table, and adds the inactivity period.
+If the one-time activation marker applies, credentials recorded in
+`account_inactivity_activation` are floored to
+`activationEpoch + inactivityPeriod`. A mutable
+`account.expiration_epoch` is used only as the import/bootstrap fallback when
+neither witness history nor the activation floor can reconstruct the value; if
+only later local witnesses exist, `account.created_slot` supplies the historical
+floor instead, so a later renewal cannot revive stake in an older snapshot.
+Credentials without an account row remain active. The final predicate keeps
+only `expiration_epoch = 0 OR expiration_epoch >= expiryEpoch`.
+
+`GetRewardStakeInputsForPools` takes the same `slot`, `expiryEpoch`, and
+`inactivityPeriod` arguments. With the gate off (`expiryEpoch == 0`) it reads the
+live reward aggregate (`reward_live_stake`), byte-identical to the pre-CIP query
+(`slot`/`inactivityPeriod` ignored). With the gate on it selects the
+per-credential rows of the same `active_delegator_stake` CTE that
+`GetStakeByPoolsAtSlot` aggregates for pool totals — identical credential
+membership, slot-accurate stake values, and the identical historical expiry
+reconstruction — so the reward-basis inputs agree with the leader-election stake
+by construction rather than reading the mutable `account.expiration_epoch`
+column (which can reflect a post-`slot` renewal when a fallback capture runs
+after the boundary). Together, these historical filters remove expired-account
+stake from the leader-election Mark snapshot, reward basis, and SPO governance
+vote power. The snapshot manager supplies the snapshot slot, epoch, and period;
+the public `Calculator.CalculateStakeDistribution` path passes zero values (gate
+off).
+
 ```sql
 -- Predicate used by sqlite/postgres/mysql implementations after resolving
 -- active_delegation(pool_key_hash, credential_tag, staking_key)
@@ -932,7 +966,15 @@ WITH active_delegator_stake AS (
   LEFT JOIN historical_reward
     ON historical_reward.credential_tag = active_delegation.credential_tag
    AND historical_reward.staking_key = active_delegation.staking_key
-  WHERE active_delegation.pool_key_hash IN (...)
+  -- CIP-0163 gate (emitted only when expiryEpoch > 0). The preceding
+  -- historical_expiration CTE derives expiration at the requested slot.
+  LEFT JOIN historical_expiration expiry_acct
+    ON expiry_acct.credential_tag = active_delegation.credential_tag
+   AND expiry_acct.staking_key = active_delegation.staking_key
+  WHERE (expiry_acct.expiration_epoch = 0
+         OR expiry_acct.expiration_epoch >= $expiryEpoch
+         OR expiry_acct.expiration_epoch IS NULL) AND
+        active_delegation.pool_key_hash IN (...)
   GROUP BY active_delegation.pool_key_hash,
            active_delegation.credential_tag,
            active_delegation.staking_key
@@ -943,6 +985,73 @@ SELECT pool_key_hash,
 FROM active_delegator_stake
 GROUP BY pool_key_hash;
 ```
+
+### `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, `GetDRepVotingPowerByType`
+
+All three DRep voting-power queries take an `expiryEpoch uint64` argument that
+drives the same CIP-0163 reward-account inactivity exclusion as
+`GetStakeByPoolsAtSlot` (see above), applied to the DRep governance
+denominator instead of the leader-election/reward/SPO one. `expiryEpoch == 0`
+disables the gate and the generated SQL and bind args are byte-identical to
+the pre-CIP query. A nonzero value adds
+`AND (<alias>.expiration_epoch = 0 OR <alias>.expiration_epoch >= expiryEpoch)`
+to both the inner subquery's `WHERE ... active = 1/true` (aliased `ax`, or an
+`EXISTS` correlation for the single-DRep and by-type variants) and the outer
+query's `WHERE ... active = 1/true` (aliased `a`), keeping an account iff it
+has never been witnessed-expired or its expiration is not yet due.
+`ledger/governance.LoadDRepVotingState` computes `expiryEpoch` as
+`currentEpoch` when `LedgerStateConfig.DelegatorInactivityEnabled` is true and
+`0` otherwise, and passes it to `GetDRepVotingPowerBatch` (regular DReps) and
+`GetDRepVotingPowerByType` (the `AlwaysAbstain`/`AlwaysNoConfidence`
+predefined options); `ledger.LedgerState.processEpochRollover` threads the
+gate flag in from config through `governance.ProcessEpoch`'s `EpochInput`.
+`GetDRepVotingPower` (the single-DRep, non-batch form used by point-in-time
+API/ledger-view queries, not the epoch-boundary tally) accepts the same
+parameter but its callers always pass `0`.
+
+The expiry clause's bind position is always textually ahead of the
+pre-existing predicate it shares a `WHERE` with (the `IN (...)` chunk for the
+batch/by-type variants, or the `drep = ?`/`drep_type = ?` equality for the
+single-DRep variant), so callers append args in
+"inner expiry, inner predicate, outer expiry, outer predicate" order,
+omitting both expiry args when the gate is off:
+
+```sql
+-- GetDRepVotingPowerBatch, sqlite dialect (postgres/mysql equivalent, CAST
+-- target and true/false spelling aside)
+SELECT a.drep AS drep, a.drep_type AS credential_tag,
+       COALESCE(SUM(
+         COALESCE(u.utxo_sum, 0) + COALESCE(CAST(a.reward AS INTEGER), 0)
+       ), 0) AS stake
+FROM account a
+LEFT JOIN (
+  SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
+         COALESCE(SUM(CAST(utxo.amount AS INTEGER)), 0) AS utxo_sum
+  FROM account ax
+  JOIN utxo ON utxo.credential_tag = ax.credential_tag
+           AND utxo.staking_key = ax.staking_key
+           AND utxo.deleted_slot = 0
+  -- CIP-0163 gate (emitted only when expiryEpoch > 0), ahead of the IN chunk:
+  WHERE ax.active = 1 AND (ax.expiration_epoch = 0 OR ax.expiration_epoch >= ?)
+    AND ax.drep IN (...)
+  GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
+) u ON u.credential_tag = a.credential_tag
+   AND u.staking_key = a.staking_key
+   AND u.drep_type = a.drep_type
+WHERE a.active = 1 AND (a.expiration_epoch = 0 OR a.expiration_epoch >= ?)
+  AND a.drep IN (...)
+GROUP BY a.drep, a.drep_type;
+```
+
+One dialect-specific wrinkle: the postgres `GetDRepVotingPower` (single-DRep)
+query is hand-written with literal `$1`/`$2` placeholders reused across the
+inner and outer clause rather than GORM's `?` auto-numbering (used by every
+other DRep voting-power/stake query in this file). GORM's raw-SQL builder
+only rewrites literal `?` bytes into dialect placeholders as it walks the SQL
+text, in textual order; it does not parse or reserve numbers already spelled
+out as `$1`/`$2` text. The expiry clause therefore reuses a third literal
+placeholder (`$3`) instead of a new `?`, to avoid the new `?` being
+substituted using the wrong (already-textually-earlier) argument.
 
 ### `GetDRepDelegators`
 

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -1184,7 +1184,9 @@ func (a *NodeAdapter) drepByCredentialTag(
 		)
 	}
 	hasScript := credentialTag == 1
-	power, err := db.GetDRepVotingPower(credentialTag, credential.Hash, nil)
+	// expiryEpoch 0: this point-in-time API query is not gated by the
+	// CIP-0163 epoch-boundary tally (see ledger/governance for that path).
+	power, err := db.GetDRepVotingPower(credentialTag, credential.Hash, 0, nil)
 	if err != nil {
 		return DRepInfo{}, fmt.Errorf(
 			"get drep voting power %x: %w",

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -359,12 +359,36 @@ func mithrilSyncRunE(
 	if cfg == nil {
 		return errors.New("no config found in context")
 	}
+	// CIP-0163: a Mithril bootstrap cannot carry reward-account expiration
+	// state (see errMithrilInactivityIncompatible), so refuse before touching
+	// the network or the database.
+	if cfg.DelegatorInactivityEnabled {
+		return errMithrilInactivityIncompatible()
+	}
 	logger := commonRun(cfg)
 	network := cfg.Network
 	if network == "" {
 		network = "preview"
 	}
 	return runMithrilSync(cmd.Context(), cfg, logger, network)
+}
+
+// errMithrilInactivityIncompatible reports why Mithril bootstrap and the
+// CIP-0163 delegator-inactivity gate cannot be combined on the same node.
+// Account.ExpirationEpoch is dingo-only ledger state with no representation in
+// the cardano-ledger Mithril snapshot dingo imports, and it cannot be
+// reconstructed from post-import witness history (a long-inactive account --
+// exactly what CIP-0163 targets -- may have last witnessed before the import
+// point). A Mithril-bootstrapped node would therefore compute different
+// expiry-dependent stake, rewards, and governance than a genesis-synced node.
+func errMithrilInactivityIncompatible() error {
+	return errors.New(
+		"cannot use Mithril bootstrap when delegatorInactivityEnabled " +
+			"(CIP-0163) is set: reward-account expiration state is absent from " +
+			"the cardano-ledger Mithril snapshot and cannot be reconstructed " +
+			"after import, so a Mithril-bootstrapped node would diverge from a " +
+			"genesis-synced one; sync from genesis instead",
+	)
 }
 
 func runMithrilSync(

--- a/cmd/dingo/mithril_inactivity_guard_test.go
+++ b/cmd/dingo/mithril_inactivity_guard_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMithrilSyncRefusedWithDelegatorInactivity covers Guard 1: the mithril
+// sync command (and the shared "sync --mithril" path) must refuse before doing
+// any work when the CIP-0163 delegator-inactivity gate is enabled, because a
+// Mithril bootstrap cannot carry reward-account expiration state.
+func TestMithrilSyncRefusedWithDelegatorInactivity(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithContext(context.Background(), &config.Config{
+		DelegatorInactivityEnabled: true,
+	}))
+
+	err := mithrilSyncRunE(cmd, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot use Mithril bootstrap")
+}
+
+// TestCheckMithrilInactivityCompat covers Guard 2: serving is refused only when
+// the gate is enabled AND the database was Mithril-bootstrapped. It is a no-op
+// with the gate off, and allowed on a fresh (genesis-synced) database.
+func TestCheckMithrilInactivityCompat(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Gate off: no-op, no database access.
+	require.NoError(t, checkMithrilInactivityCompat(
+		&config.Config{DelegatorInactivityEnabled: false},
+		logger,
+	))
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		DelegatorInactivityEnabled: true,
+		DatabasePath:               dir,
+		BlobPlugin:                 "badger",
+		MetadataPlugin:             "sqlite",
+	}
+
+	// Gate on, fresh (non-bootstrapped) database: allowed.
+	require.NoError(t, checkMithrilInactivityCompat(cfg, logger))
+
+	// Mark the database as Mithril-bootstrapped, then confirm serving is
+	// refused. The key mirrors mithril's durable immutable-import marker
+	// (mithril.WasBootstrapped / import_marker.go).
+	db, err := database.New(&database.Config{
+		DataDir:        dir,
+		Logger:         logger,
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.SetSyncState("mithril_immutable_max", "26887", nil))
+	require.NoError(t, db.Close())
+
+	err = checkMithrilInactivityCompat(cfg, logger)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot use Mithril bootstrap")
+}
+
+// TestCheckMithrilInactivityCompatLegacyMarker covers the pre-v0.62.0 (#2694)
+// bootstrap case: a database Mithril-bootstrapped before the immutable-import
+// marker existed carries only the durable mithril_ledger_slot trust boundary.
+// Serving with the gate enabled must still be refused, or such a database could
+// start with CIP-0163 enabled and diverge from a genesis-synced node.
+func TestCheckMithrilInactivityCompatLegacyMarker(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		DelegatorInactivityEnabled: true,
+		DatabasePath:               dir,
+		BlobPlugin:                 "badger",
+		MetadataPlugin:             "sqlite",
+	}
+
+	// Legacy bootstrap: only the durable mithril_ledger_slot boundary is set,
+	// with no newer mithril_immutable_max marker.
+	db, err := database.New(&database.Config{
+		DataDir:        dir,
+		Logger:         logger,
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.SetSyncState("mithril_ledger_slot", "12345678", nil))
+	require.NoError(t, db.Close())
+
+	err = checkMithrilInactivityCompat(cfg, logger)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot use Mithril bootstrap")
+}

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/node"
+	"github.com/blinklabs-io/dingo/mithril"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,16 @@ func serveRun(
 	// did not complete. The user must finish (or re-run) the sync
 	// before starting the node.
 	if err := checkSyncState(cfg, logger); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+
+	// CIP-0163: refuse to serve a Mithril-bootstrapped database with the
+	// delegator-inactivity gate enabled. This closes the "run 'mithril sync'
+	// with the gate off, then restart with it on" path that Guard 1 in the
+	// sync command cannot see; a bootstrapped node cannot reproduce a
+	// genesis-synced node's expiration state.
+	if err := checkMithrilInactivityCompat(cfg, logger); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
 	}
@@ -129,6 +140,49 @@ func checkSyncState(
 			"Mithril bootstrap) to resume before starting the node",
 		val,
 	)
+}
+
+// checkMithrilInactivityCompat refuses to start a node that has the CIP-0163
+// delegator-inactivity gate enabled on a database populated by a Mithril
+// bootstrap. Reward-account expiration state is dingo-only and absent from the
+// cardano-ledger Mithril snapshot, and cannot be reconstructed after import, so
+// serving such a database would diverge from a genesis-synced node. A no-op
+// when the gate is off or the database was not Mithril-bootstrapped.
+func checkMithrilInactivityCompat(
+	cfg *config.Config,
+	logger *slog.Logger,
+) error {
+	if !cfg.DelegatorInactivityEnabled {
+		return nil
+	}
+	db, err := database.New(&database.Config{
+		DataDir:        cfg.DatabasePath,
+		Logger:         logger,
+		BlobPlugin:     cfg.BlobPlugin,
+		RunMode:        string(cfg.RunMode),
+		MetadataPlugin: cfg.MetadataPlugin,
+		MaxConnections: 1,
+		StorageMode:    cfg.StorageMode,
+		Network:        cfg.Network,
+	})
+	if err != nil {
+		// A commit-timestamp mismatch is recovered downstream in node.Run;
+		// the marker read works on the partially-initialised handle.
+		var cte database.CommitTimestampError
+		if !errors.As(err, &cte) || db == nil {
+			return fmt.Errorf("opening database: %w", err)
+		}
+	}
+	defer db.Close()
+
+	bootstrapped, err := mithril.WasBootstrapped(db)
+	if err != nil {
+		return fmt.Errorf("checking mithril bootstrap marker: %w", err)
+	}
+	if bootstrapped {
+		return errMithrilInactivityIncompatible()
+	}
+	return nil
 }
 
 // repairDeferredIndexes rebuilds any deferred metadata indexes left

--- a/config.go
+++ b/config.go
@@ -208,6 +208,11 @@ type Config struct {
 	// of returning the residual to reserves.
 	fullPotRewardsEnabled                  bool
 	unsafeFullPotRewardsOnStandardNetworks bool
+	// CIP-0163 reward-account inactivity expiry (consensus-affecting; default
+	// off). delegatorInactivity is the inactivity window in epochs, used only
+	// when enabled.
+	delegatorInactivityEnabled bool
+	delegatorInactivity        uint64
 	// Leios voting configuration (experimental)
 	leiosVoteSigningKeyFile string
 	leiosVoterPublicKeys    map[string]string
@@ -523,6 +528,13 @@ func (n *Node) configValidate() error {
 				shelleyGenesis.NetworkMagic,
 			)
 		}
+	}
+	if n.config.delegatorInactivityEnabled &&
+		(n.config.delegatorInactivity < 1 || n.config.delegatorInactivity > 10_000) {
+		return fmt.Errorf(
+			"delegator inactivity (%d) must be in [1, 10000] when enabled",
+			n.config.delegatorInactivity,
+		)
 	}
 	return nil
 }
@@ -1088,6 +1100,17 @@ func WithForgeStaleGapThresholdSlots(slots uint64) ConfigOptionFunc {
 func WithValidateForgedBlock(enabled bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.validateForgedBlock = enabled
+	}
+}
+
+// WithDelegatorInactivity configures the CIP-0163 reward-account inactivity
+// expiry. It is consensus-affecting and disabled by default; enable it only on
+// a network where every node also enables it. epochs is the inactivity window
+// and is used only when enabled.
+func WithDelegatorInactivity(enabled bool, epochs uint64) ConfigOptionFunc {
+	return func(c *Config) {
+		c.delegatorInactivityEnabled = enabled
+		c.delegatorInactivity = epochs
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -267,6 +267,16 @@ func TestFullPotRewardsStandardNetworkValidation(t *testing.T) {
 	}
 }
 
+func TestWithDelegatorInactivity(t *testing.T) {
+	cfg := &Config{}
+	WithDelegatorInactivity(true, 90)(cfg)
+	assert.True(t, cfg.delegatorInactivityEnabled)
+	assert.Equal(t, uint64(90), cfg.delegatorInactivity)
+	WithDelegatorInactivity(false, 0)(cfg)
+	assert.False(t, cfg.delegatorInactivityEnabled)
+	assert.Zero(t, cfg.delegatorInactivity)
+}
+
 func TestExperimentalDijkstraEnabled(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/database/account.go
+++ b/database/account.go
@@ -34,6 +34,121 @@ func (d *Database) CreateAccount(txn *Txn, account *models.Account) error {
 	})
 }
 
+// RenewAccountExpirations sets the CIP-0163 expirationEpoch for the given
+// reward-account credentials. See the metadata store implementation for
+// semantics (refs with no matching account row are ignored). When txn is
+// nil a write transaction is opened, committed on success and rolled back
+// on error via Txn.Do; pass an existing write txn to participate in a
+// wider unit of work.
+func (d *Database) RenewAccountExpirations(
+	refs []models.StakeCredentialRef,
+	expirationEpoch uint64,
+	txn *Txn,
+) error {
+	if txn != nil {
+		return d.metadata.RenewAccountExpirations(refs, expirationEpoch, txn.Metadata())
+	}
+	return d.MetadataTxn(true).Do(func(t *Txn) error {
+		return d.metadata.RenewAccountExpirations(refs, expirationEpoch, t.Metadata())
+	})
+}
+
+// AccountLastWitnessSlots returns, per requested credential, the greatest
+// CIP-0163 witnessing slot <= maxSlot across the stake-witnessing certificate
+// tables and the reward-withdrawal history, keyed by
+// StakeCredentialRef.MapKey(). A credential with no witness <= maxSlot is
+// absent from the map. When txn is nil a read transaction is opened for the
+// query; pass an existing txn to read within a wider unit of work.
+func (d *Database) AccountLastWitnessSlots(
+	refs []models.StakeCredentialRef,
+	maxSlot uint64,
+	txn *Txn,
+) (map[string]uint64, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	return d.metadata.AccountLastWitnessSlots(refs, maxSlot, txn.Metadata())
+}
+
+// AccountsWitnessedAfterSlot returns the distinct reward-account credentials
+// witnessed (via a stake-witnessing certificate or a reward withdrawal) at a
+// slot greater than the given slot — the CIP-0163 rollback affected set. It
+// must be called before rolled-back certificate and reward-delta rows are
+// deleted. When txn is nil a read transaction is opened for the query; pass an
+// existing txn to read within a wider unit of work.
+func (d *Database) AccountsWitnessedAfterSlot(
+	slot uint64,
+	txn *Txn,
+) ([]models.StakeCredentialRef, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	return d.metadata.AccountsWitnessedAfterSlot(slot, txn.Metadata())
+}
+
+// StampAllActiveAccountExpirations sets the CIP-0163 expirationEpoch for every
+// active account row. Used once at activation to give every pre-existing
+// account a full inactivity window from the activation epoch, including
+// accounts witnessed before activation. Returns the number of rows stamped.
+// When txn is nil a write transaction is opened, committed on success and
+// rolled back on error via Txn.Do; pass an existing write txn to participate
+// in a wider unit of work.
+func (d *Database) StampAllActiveAccountExpirations(
+	expirationEpoch uint64,
+	txn *Txn,
+) (int64, error) {
+	if txn != nil {
+		return d.metadata.StampAllActiveAccountExpirations(expirationEpoch, txn.Metadata())
+	}
+	var rows int64
+	err := d.MetadataTxn(true).Do(func(t *Txn) error {
+		var doErr error
+		rows, doErr = d.metadata.StampAllActiveAccountExpirations(expirationEpoch, t.Metadata())
+		return doErr
+	})
+	return rows, err
+}
+
+// AccountInactivityActivationMembership returns the requested credentials that
+// were included in the one-time CIP-0163 activation stamp.
+func (d *Database) AccountInactivityActivationMembership(
+	refs []models.StakeCredentialRef,
+	txn *Txn,
+) (map[string]struct{}, error) {
+	if txn == nil {
+		txn = d.MetadataTxn(false)
+		defer txn.Release()
+	}
+	return d.metadata.AccountInactivityActivationMembership(
+		refs,
+		txn.Metadata(),
+	)
+}
+
+// ResetAccountExpirationActivation clears expiration from every account in the
+// durable activation-membership set, deletes that set, and returns the affected
+// credentials so the ledger can reconstruct any overwritten pre-activation
+// witness expiration. When txn is nil, the operation runs in its own write
+// transaction.
+func (d *Database) ResetAccountExpirationActivation(
+	txn *Txn,
+) ([]models.StakeCredentialRef, error) {
+	if txn != nil {
+		return d.metadata.ResetAccountExpirationActivation(txn.Metadata())
+	}
+	var refs []models.StakeCredentialRef
+	err := d.MetadataTxn(true).Do(func(t *Txn) error {
+		var doErr error
+		refs, doErr = d.metadata.ResetAccountExpirationActivation(
+			t.Metadata(),
+		)
+		return doErr
+	})
+	return refs, err
+}
+
 // ClearDanglingDRepDelegations applies the cardano-ledger Conway HARDFORK
 // STS rule for protocol major version 10 (Plomin, mainnet January 2025): any
 // account with a credential-backed DRep delegation (DrepType 0 or 1) whose
@@ -125,7 +240,7 @@ func (d *Database) GetAccountByCredential(
 	txn *Txn,
 ) (*models.Account, error) {
 	if txn == nil {
-		txn = d.Transaction(false)
+		txn = d.MetadataTxn(false)
 		defer txn.Release()
 	}
 	account, err := d.metadata.GetAccountByCredential(
@@ -151,7 +266,7 @@ func (d *Database) GetAccountsByCredential(
 	txn *Txn,
 ) (map[string]*models.Account, error) {
 	if txn == nil {
-		txn = d.Transaction(false)
+		txn = d.MetadataTxn(false)
 		defer txn.Release()
 	}
 	return d.metadata.GetAccountsByCredential(

--- a/database/drep.go
+++ b/database/drep.go
@@ -172,9 +172,13 @@ func (d *Database) InsertDrepIfAbsent(
 // the current stake of all delegated accounts, approximated from live
 // UTxO balance plus reward-account balance. credentialTag distinguishes
 // key (0) from script (1) DRep credentials sharing the same 28-byte hash.
+// expiryEpoch is the CIP-0163 reward-account inactivity gate: 0 = off
+// (byte-identical to the pre-CIP query), >0 = exclude accounts whose
+// expiration_epoch is nonzero and less than expiryEpoch.
 func (d *Database) GetDRepVotingPower(
 	credentialTag uint8,
 	drepCredential []byte,
+	expiryEpoch uint64,
 	txn *Txn,
 ) (uint64, error) {
 	if txn == nil {
@@ -184,6 +188,7 @@ func (d *Database) GetDRepVotingPower(
 	return d.metadata.GetDRepVotingPower(
 		credentialTag,
 		drepCredential,
+		expiryEpoch,
 		txn.Metadata(),
 	)
 }
@@ -209,9 +214,11 @@ func (d *Database) GetDRepDelegators(
 }
 
 // GetDRepVotingPowerBatch is the batch form of GetDRepVotingPower; see
-// the metadata-store interface for the contract.
+// the metadata-store interface for the contract. expiryEpoch is the
+// CIP-0163 gate; see GetDRepVotingPower.
 func (d *Database) GetDRepVotingPowerBatch(
 	drepCredentials []models.StakeCredentialRef,
+	expiryEpoch uint64,
 	txn *Txn,
 ) (map[string]uint64, error) {
 	if txn == nil {
@@ -220,6 +227,7 @@ func (d *Database) GetDRepVotingPowerBatch(
 	}
 	result, err := d.metadata.GetDRepVotingPowerBatch(
 		drepCredentials,
+		expiryEpoch,
 		txn.Metadata(),
 	)
 	if err != nil {
@@ -234,9 +242,11 @@ func (d *Database) GetDRepVotingPowerBatch(
 }
 
 // GetDRepVotingPowerByType returns voting power grouped by DRep
-// delegation type.
+// delegation type. expiryEpoch is the CIP-0163 gate; see
+// GetDRepVotingPower.
 func (d *Database) GetDRepVotingPowerByType(
 	drepTypes []uint64,
+	expiryEpoch uint64,
 	txn *Txn,
 ) (map[uint64]uint64, error) {
 	if txn == nil {
@@ -245,6 +255,7 @@ func (d *Database) GetDRepVotingPowerByType(
 	}
 	result, err := d.metadata.GetDRepVotingPowerByType(
 		drepTypes,
+		expiryEpoch,
 		txn.Metadata(),
 	)
 	if err != nil {

--- a/database/models/account.go
+++ b/database/models/account.go
@@ -122,10 +122,29 @@ type Account struct {
 	// disambiguated by whether Drep is nil.
 	DrepType uint64 `gorm:"default:0;index:idx_account_drep_type_active_staking_key,priority:1"`
 	Active   bool   `gorm:"default:true;index:idx_account_drep_active_staking_key,priority:2;index:idx_account_drep_type_active_staking_key,priority:2;index:idx_account_active_pool_staking_key,priority:1"`
+	// ExpirationEpoch is the CIP-0163 reward-account inactivity expiry: the
+	// last epoch in which the account remains active unless it
+	// witnesses again. 0 means unset (treated as active). Mirrors
+	// Drep.ExpiryEpoch. Set/bumped by RenewAccountExpirations and the one-time
+	// activation stamp; only read when the delegator-inactivity gate is on.
+	ExpirationEpoch uint64 `gorm:"index;default:0"`
 }
 
 func (a *Account) TableName() string {
 	return "account"
+}
+
+// AccountInactivityActivation records the exact reward-account credentials
+// stamped by the one-time CIP-0163 activation. Membership cannot be inferred
+// from CreatedSlot alone because an account may have existed but been inactive
+// at the activation boundary.
+type AccountInactivityActivation struct {
+	CredentialTag uint8  `gorm:"primaryKey;autoIncrement:false"`
+	StakingKey    []byte `gorm:"size:28;primaryKey;index"`
+}
+
+func (AccountInactivityActivation) TableName() string {
+	return "account_inactivity_activation"
 }
 
 // MigrateAccountCredentialTagIndex drops the legacy hash-only account
@@ -685,6 +704,19 @@ type AccountRewardDelta struct {
 	AddedSlot      uint64 `gorm:"index;not null;uniqueIndex:idx_account_reward_delta_w_tx_s_slot,priority:5"`
 	Withdrawal     bool   `gorm:"index;not null;default:false;uniqueIndex:idx_account_reward_delta_w_tx_s_slot,priority:1"`
 }
+
+// AccountWithdrawalWitness records every valid reward-withdrawal map entry,
+// including zero-amount withdrawals. It is separate from balance deltas because
+// CIP-0163 treats the credential witness as activity even when no reward moves.
+type AccountWithdrawalWitness struct {
+	StakingKey    []byte `gorm:"size:28;not null;uniqueIndex:idx_account_withdrawal_witness,priority:3;index:idx_account_withdrawal_witness_credential_slot,priority:1"`
+	CredentialTag uint8  `gorm:"not null;default:0;uniqueIndex:idx_account_withdrawal_witness,priority:2;index:idx_account_withdrawal_witness_credential_slot,priority:2"`
+	TxHash        []byte `gorm:"size:32;not null;uniqueIndex:idx_account_withdrawal_witness,priority:1"`
+	ID            uint   `gorm:"primarykey"`
+	AddedSlot     uint64 `gorm:"index;not null;index:idx_account_withdrawal_witness_credential_slot,priority:3"`
+}
+
+func (AccountWithdrawalWitness) TableName() string { return "account_withdrawal_witness" }
 
 func (AccountRewardDelta) TableName() string {
 	return "account_reward_delta"

--- a/database/models/account_test.go
+++ b/database/models/account_test.go
@@ -468,11 +468,13 @@ func TestAccountInactivityActivationCompositeIdentity(t *testing.T) {
 	}
 
 	key := bytes.Repeat([]byte{0xA5}, 28)
+	otherKey := bytes.Repeat([]byte{0x5A}, 28)
 	if err := db.Create(&[]AccountInactivityActivation{
 		{CredentialTag: 0, StakingKey: key},
 		{CredentialTag: 1, StakingKey: key},
+		{CredentialTag: 0, StakingKey: otherKey},
 	}).Error; err != nil {
-		t.Fatalf("insert tag-distinct activation members: %v", err)
+		t.Fatalf("insert composite-distinct activation members: %v", err)
 	}
 	if err := db.Create(&AccountInactivityActivation{
 		CredentialTag: 0,

--- a/database/models/account_test.go
+++ b/database/models/account_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -423,6 +424,61 @@ func TestAccount_String_Bech32Format(t *testing.T) {
 				addr,
 			)
 		}
+	}
+}
+
+func TestAccountWithdrawalWitnessCredentialSlotIndex(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&AccountWithdrawalWitness{}); err != nil {
+		t.Fatalf("migrate account withdrawal witness: %v", err)
+	}
+
+	indexes, err := db.Migrator().GetIndexes(&AccountWithdrawalWitness{})
+	if err != nil {
+		t.Fatalf("get account withdrawal witness indexes: %v", err)
+	}
+	for _, index := range indexes {
+		if index.Name() != "idx_account_withdrawal_witness_credential_slot" {
+			continue
+		}
+		columns := index.Columns()
+		want := []string{"staking_key", "credential_tag", "added_slot"}
+		if !slices.Equal(columns, want) {
+			t.Fatalf(
+				"credential-slot index columns = %v, want %v",
+				columns,
+				want,
+			)
+		}
+		return
+	}
+	t.Fatal("credential-slot index missing after AutoMigrate")
+}
+
+func TestAccountInactivityActivationCompositeIdentity(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&AccountInactivityActivation{}); err != nil {
+		t.Fatalf("migrate account inactivity activation: %v", err)
+	}
+
+	key := bytes.Repeat([]byte{0xA5}, 28)
+	if err := db.Create(&[]AccountInactivityActivation{
+		{CredentialTag: 0, StakingKey: key},
+		{CredentialTag: 1, StakingKey: key},
+	}).Error; err != nil {
+		t.Fatalf("insert tag-distinct activation members: %v", err)
+	}
+	if err := db.Create(&AccountInactivityActivation{
+		CredentialTag: 0,
+		StakingKey:    key,
+	}).Error; err == nil {
+		t.Fatal("duplicate composite activation member unexpectedly succeeded")
 	}
 }
 

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -17,7 +17,9 @@ package models
 // MigrateModels contains a list of model objects that should have DB migrations applied
 var MigrateModels = []any{
 	&Account{},
+	&AccountInactivityActivation{},
 	&AccountRewardDelta{},
+	&AccountWithdrawalWitness{},
 	&AddressTransaction{},
 	&Asset{},
 	&AssetMintBurn{},

--- a/database/plugin/metadata/internal/accountwitness/accountwitness.go
+++ b/database/plugin/metadata/internal/accountwitness/accountwitness.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accountwitness
+
+import (
+	"slices"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// RecordWithdrawal persists a rollback-aware CIP-0163 withdrawal witness.
+func RecordWithdrawal(db *gorm.DB, ref models.StakeCredentialRef, txHash []byte, slot uint64) error {
+	if txHash == nil {
+		txHash = []byte{}
+	}
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(
+		&models.AccountWithdrawalWitness{
+			StakingKey: ref.Key, CredentialTag: ref.Tag, TxHash: txHash, AddedSlot: slot,
+		},
+	).Error
+}
+
+// ActivationMembership returns the requested credentials that were included in
+// the one-time CIP-0163 activation stamp.
+func ActivationMembership(
+	db *gorm.DB,
+	refs []models.StakeCredentialRef,
+	batchSize int,
+) (map[string]struct{}, error) {
+	ret := make(map[string]struct{}, len(refs))
+	if len(refs) == 0 {
+		return ret, nil
+	}
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	stakingKeys := make([][]byte, 0, len(refs))
+	for _, ref := range refs {
+		requested[ref.MapKey()] = struct{}{}
+		hash := string(ref.Key)
+		if _, ok := seenHash[hash]; ok {
+			continue
+		}
+		seenHash[hash] = struct{}{}
+		stakingKeys = append(stakingKeys, ref.Key)
+	}
+	for keyChunk := range slices.Chunk(stakingKeys, batchSize) {
+		var rows []models.AccountInactivityActivation
+		if err := db.Where("staking_key IN ?", keyChunk).
+			Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			key := models.NewStakeCredentialRef(
+				row.CredentialTag,
+				row.StakingKey,
+			).MapKey()
+			if _, ok := requested[key]; ok {
+				ret[key] = struct{}{}
+			}
+		}
+	}
+	return ret, nil
+}
+
+// CertTableNames returns the certificate tables that witness reward accounts
+// under CIP-0163.
+func CertTableNames() []string {
+	return []string{
+		models.StakeRegistration{}.TableName(),
+		models.StakeRegistrationDelegation{}.TableName(),
+		models.StakeVoteRegistrationDelegation{}.TableName(),
+		models.VoteRegistrationDelegation{}.TableName(),
+		models.Registration{}.TableName(),
+		models.StakeDeregistration{}.TableName(),
+		models.Deregistration{}.TableName(),
+		models.StakeDelegation{}.TableName(),
+		models.StakeVoteDelegation{}.TableName(),
+		models.VoteDelegation{}.TableName(),
+	}
+}
+
+type witnessRow struct {
+	CredentialTag uint8
+	StakingKey    []byte
+	LastSlot      uint64
+}
+
+// LastSlots returns the latest surviving witness slot for each requested
+// credential. db carries the caller's resolved transaction context.
+func LastSlots(
+	db *gorm.DB,
+	refs []models.StakeCredentialRef,
+	maxSlot uint64,
+	batchSize int,
+) (map[string]uint64, error) {
+	result := make(map[string]uint64, len(refs))
+	if len(refs) == 0 {
+		return result, nil
+	}
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	stakingKeys := make([][]byte, 0, len(refs))
+	for _, ref := range refs {
+		requested[ref.MapKey()] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			stakingKeys = append(stakingKeys, ref.Key)
+		}
+	}
+	merge := func(rows []witnessRow) {
+		for _, row := range rows {
+			key := models.NewStakeCredentialRef(row.CredentialTag, row.StakingKey).MapKey()
+			if _, ok := requested[key]; !ok {
+				continue
+			}
+			if current, ok := result[key]; !ok || row.LastSlot > current {
+				result[key] = row.LastSlot
+			}
+		}
+	}
+	for keyChunk := range slices.Chunk(stakingKeys, batchSize) {
+		for _, table := range CertTableNames() {
+			var rows []witnessRow
+			if err := db.Table(table).
+				Select("credential_tag, staking_key, MAX(added_slot) AS last_slot").
+				Where("staking_key IN ? AND added_slot <= ?", keyChunk, maxSlot).
+				Group("credential_tag, staking_key").
+				Scan(&rows).Error; err != nil {
+				return nil, err
+			}
+			merge(rows)
+		}
+		var rows []witnessRow
+		if err := db.Table(models.AccountWithdrawalWitness{}.TableName()).
+			Select("credential_tag, staking_key, MAX(added_slot) AS last_slot").
+			Where("staking_key IN ? AND added_slot <= ?", keyChunk, maxSlot).
+			Group("credential_tag, staking_key").Scan(&rows).Error; err != nil {
+			return nil, err
+		}
+		merge(rows)
+		rows = nil
+		if err := db.Table(models.AccountRewardDelta{}.TableName()).
+			Select("credential_tag, staking_key, MAX(added_slot) AS last_slot").
+			Where("withdrawal = ? AND staking_key IN ? AND added_slot <= ?", true, keyChunk, maxSlot).
+			Group("credential_tag, staking_key").
+			Scan(&rows).Error; err != nil {
+			return nil, err
+		}
+		merge(rows)
+	}
+	return result, nil
+}
+
+// AfterSlot returns the distinct credentials witnessed after slot. db carries
+// the caller's resolved transaction context.
+func AfterSlot(db *gorm.DB, slot uint64) ([]models.StakeCredentialRef, error) {
+	seen := make(map[string]struct{})
+	var refs []models.StakeCredentialRef
+	collect := func(rows []witnessRow) {
+		for _, row := range rows {
+			ref := models.NewStakeCredentialRef(row.CredentialTag, row.StakingKey)
+			key := ref.MapKey()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	for _, table := range CertTableNames() {
+		var rows []witnessRow
+		if err := db.Table(table).
+			Select("credential_tag, staking_key").
+			Where("added_slot > ?", slot).
+			Group("credential_tag, staking_key").
+			Scan(&rows).Error; err != nil {
+			return nil, err
+		}
+		collect(rows)
+	}
+	var rows []witnessRow
+	if err := db.Table(models.AccountWithdrawalWitness{}.TableName()).
+		Select("credential_tag, staking_key").Where("added_slot > ?", slot).
+		Group("credential_tag, staking_key").Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	collect(rows)
+	rows = nil
+	if err := db.Table(models.AccountRewardDelta{}.TableName()).
+		Select("credential_tag, staking_key").
+		Where("withdrawal = ? AND added_slot > ?", true, slot).
+		Group("credential_tag, staking_key").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	collect(rows)
+	return refs, nil
+}

--- a/database/plugin/metadata/internal/drepquery/voting_power.go
+++ b/database/plugin/metadata/internal/drepquery/voting_power.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drepquery
+
+const sqliteUtxoStakingLiveAmountIndex = "idx_utxo_staking_deleted_amount"
+
+type dialectSQL struct {
+	castType         string
+	active           string
+	credentialParams string
+	utxoJoin         string
+}
+
+func sqlDialect(name string) dialectSQL {
+	switch name {
+	case "postgres":
+		return dialectSQL{"BIGINT", "true", "$1 AND ax.drep_type = $2", "JOIN utxo"}
+	case "mysql":
+		return dialectSQL{"UNSIGNED", "1", "? AND ax.drep_type = ?", "JOIN utxo"}
+	default:
+		return dialectSQL{
+			"INTEGER",
+			"1",
+			"? AND ax.drep_type = ?",
+			"JOIN utxo INDEXED BY " + sqliteUtxoStakingLiveAmountIndex,
+		}
+	}
+}
+
+// expiryClauses returns the paired CIP-0163 predicates. The positional form is
+// used only by PostgreSQL's single-credential query, which deliberately reuses
+// $3 in both query scopes.
+func expiryClauses(expiryEpoch uint64, positional bool) (string, string) {
+	if expiryEpoch == 0 {
+		return "", ""
+	}
+	placeholder := "?"
+	if positional {
+		placeholder = "$3"
+	}
+	return " AND (ax.expiration_epoch = 0 OR ax.expiration_epoch >= " + placeholder + ")",
+		" AND (a.expiration_epoch = 0 OR a.expiration_epoch >= " + placeholder + ")"
+}
+
+// VotingPowerSQL builds the single-credential voting-power query and its bind
+// arguments in textual order.
+func VotingPowerSQL(
+	dialectName string,
+	credentialTag uint8,
+	drepCredential []byte,
+	expiryEpoch uint64,
+) (string, []any) {
+	dialect := sqlDialect(dialectName)
+	positional := dialectName == "postgres"
+	innerExpiry, outerExpiry := expiryClauses(expiryEpoch, positional)
+	outerParams := "? AND a.drep_type = ?"
+	args := []any{drepCredential, credentialTag}
+	if positional {
+		outerParams = "$1 AND a.drep_type = $2"
+		if expiryEpoch > 0 {
+			args = append(args, expiryEpoch)
+		}
+	} else {
+		if expiryEpoch > 0 {
+			args = append(args, expiryEpoch)
+		}
+		args = append(args, drepCredential, credentialTag)
+		if expiryEpoch > 0 {
+			args = append(args, expiryEpoch)
+		}
+	}
+	return `
+		SELECT COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS ` + dialect.castType + `), 0)
+			   ), 0)
+		FROM account a
+		LEFT JOIN (
+			SELECT credential_tag, staking_key,
+				   COALESCE(SUM(CAST(amount AS ` + dialect.castType + `)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.drep = ` + dialect.credentialParams + ` AND ax.active = ` + dialect.active + innerExpiry + `
+			  )
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
+		WHERE a.drep = ` + outerParams + ` AND a.active = ` + dialect.active + outerExpiry + `
+	`, args
+}
+
+func collectionExpiry(expiryEpoch uint64) (string, string) {
+	inner, outer := expiryClauses(expiryEpoch, false)
+	if inner != "" {
+		inner = inner[1:] + " "
+		outer = outer[1:] + " "
+	}
+	return inner, outer
+}
+
+// CollectionArgs returns the bind order shared by batch and by-type queries:
+// inner expiry, inner collection, outer expiry, outer collection.
+func CollectionArgs(values any, expiryEpoch uint64) []any {
+	args := make([]any, 0, 4)
+	if expiryEpoch > 0 {
+		args = append(args, expiryEpoch)
+	}
+	args = append(args, values)
+	if expiryEpoch > 0 {
+		args = append(args, expiryEpoch)
+	}
+	return append(args, values)
+}
+
+// VotingPowerBatchSQL builds the aggregate credential voting-power query.
+func VotingPowerBatchSQL(dialectName string, expiryEpoch uint64) string {
+	dialect := sqlDialect(dialectName)
+	innerExpiry, outerExpiry := collectionExpiry(expiryEpoch)
+	return `
+	SELECT a.drep AS drep, a.drep_type AS credential_tag,
+		   COALESCE(SUM(
+			   COALESCE(u.utxo_sum, 0)
+			   + COALESCE(CAST(a.reward AS ` + dialect.castType + `), 0)
+		   ), 0) AS stake
+	FROM account a
+	LEFT JOIN (
+			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
+				   COALESCE(SUM(CAST(utxo.amount AS ` + dialect.castType + `)), 0) AS utxo_sum
+			FROM account ax
+			` + dialect.utxoJoin + `
+			         ON utxo.credential_tag = ax.credential_tag
+			         AND utxo.staking_key = ax.staking_key
+			         AND utxo.deleted_slot = 0
+		WHERE ax.active = ` + dialect.active + ` ` + innerExpiry + `AND ax.drep IN ?
+		GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
+	) u ON u.credential_tag = a.credential_tag
+		AND u.staking_key = a.staking_key
+		AND u.drep_type = a.drep_type
+	WHERE a.active = ` + dialect.active + ` ` + outerExpiry + `AND a.drep IN ?
+	GROUP BY a.drep, a.drep_type
+`
+}
+
+// VotingPowerByTypeSQL builds the predefined-DRep voting-power query.
+func VotingPowerByTypeSQL(dialectName string, expiryEpoch uint64) string {
+	dialect := sqlDialect(dialectName)
+	innerExpiry, outerExpiry := collectionExpiry(expiryEpoch)
+	return `
+		SELECT a.drep_type AS drep_type,
+			   COALESCE(SUM(
+				   COALESCE(u.utxo_sum, 0)
+				   + COALESCE(CAST(a.reward AS ` + dialect.castType + `), 0)
+			   ), 0) AS stake
+		FROM account a
+		LEFT JOIN (
+			SELECT credential_tag, staking_key,
+				   COALESCE(SUM(CAST(amount AS ` + dialect.castType + `)), 0) AS utxo_sum
+			FROM utxo
+			WHERE deleted_slot = 0
+			  AND EXISTS (
+				  SELECT 1 FROM account ax
+				  WHERE ax.credential_tag = utxo.credential_tag
+				    AND ax.staking_key = utxo.staking_key
+				    AND ax.active = ` + dialect.active + ` ` + innerExpiry + `AND ax.drep_type IN ?
+			  )
+			GROUP BY credential_tag, staking_key
+		) u ON u.credential_tag = a.credential_tag
+			AND u.staking_key = a.staking_key
+		WHERE a.active = ` + dialect.active + ` ` + outerExpiry + `AND a.drep_type IN ?
+		GROUP BY a.drep_type
+	`
+}

--- a/database/plugin/metadata/internal/drepquery/voting_power_test.go
+++ b/database/plugin/metadata/internal/drepquery/voting_power_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drepquery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVotingPowerSQLPostgresPlaceholderReuse(t *testing.T) {
+	credential := []byte("credential")
+	offSQL, offArgs := VotingPowerSQL("postgres", 1, credential, 0)
+	require.NotContains(t, offSQL, "expiration_epoch")
+	require.Equal(t, []any{credential, uint8(1)}, offArgs)
+
+	onSQL, onArgs := VotingPowerSQL("postgres", 1, credential, 5)
+	require.Equal(t, 2, strings.Count(onSQL, "expiration_epoch >= $3"))
+	require.NotContains(t, onSQL, "expiration_epoch >= ?")
+	require.Equal(t, []any{credential, uint8(1), uint64(5)}, onArgs)
+}
+
+func TestCollectionArgsExpiryOrder(t *testing.T) {
+	values := []uint64{2, 3}
+	require.Equal(t, []any{values, values}, CollectionArgs(values, 0))
+	require.Equal(
+		t,
+		[]any{uint64(5), values, uint64(5), values},
+		CollectionArgs(values, 5),
+	)
+}

--- a/database/plugin/metadata/internal/rewardstate/state.go
+++ b/database/plugin/metadata/internal/rewardstate/state.go
@@ -372,34 +372,53 @@ func DedupePoolKeyHashes(poolKeyHashes [][]byte) [][]byte {
 // live reward aggregate for the requested pools. The live aggregate is
 // maintained transactionally, so the result reflects the caller's db/txn view
 // rather than any historical slot.
+// When expiryEpoch > 0 the CIP-0163 reward-account inactivity gate is active:
+// the live aggregate is joined to account and credentials whose account expired
+// before expiryEpoch (nonzero expiration_epoch < expiryEpoch) are excluded,
+// while credentials with no account row or expiration_epoch 0 stay included.
+// When expiryEpoch == 0 the gate is off and the query and args are
+// byte-identical to the pre-CIP query.
 func StakeInputsForPools(
 	db *gorm.DB,
 	poolKeyHashes [][]byte,
 	chunkSize int,
+	expiryEpoch uint64,
 ) ([]*models.RewardStakeInput, error) {
 	if len(poolKeyHashes) == 0 {
 		return nil, nil
 	}
 	poolKeyHashes = DedupePoolKeyHashes(poolKeyHashes)
+	// The expiry gate's "?" is the last placeholder, so its bind arg is
+	// appended after the fixed IN/registered/total_stake args.
+	var expiryJoin, expiryPredicate string
+	if expiryEpoch > 0 {
+		expiryJoin = `
+			LEFT JOIN account acct
+				ON acct.credential_tag = rls.credential_tag
+				AND acct.staking_key = rls.staking_key`
+		expiryPredicate = `
+			AND (acct.expiration_epoch = 0
+				OR acct.expiration_epoch >= ?
+				OR acct.expiration_epoch IS NULL)`
+	}
 	query := fmt.Sprintf(`
 		SELECT rls.*
-		FROM reward_live_stake rls
+		FROM reward_live_stake rls%s
 		WHERE rls.pool_key_hash IN ?
 			AND rls.registered = ?
-			AND CAST(rls.total_stake AS %s) > ?
+			AND CAST(rls.total_stake AS %s) > ?%s
 		ORDER BY rls.pool_key_hash ASC, rls.credential_tag ASC, rls.staking_key ASC
-	`, integerCastType(db))
+	`, expiryJoin, integerCastType(db), expiryPredicate)
 
 	rows := make([]models.RewardLiveStake, 0)
 	for start := 0; start < len(poolKeyHashes); start += chunkSize {
 		end := min(start+chunkSize, len(poolKeyHashes))
+		args := []any{poolKeyHashes[start:end], true, 0}
+		if expiryEpoch > 0 {
+			args = append(args, expiryEpoch)
+		}
 		var chunkRows []models.RewardLiveStake
-		if err := db.Raw(
-			query,
-			poolKeyHashes[start:end],
-			true,
-			0,
-		).Scan(&chunkRows).Error; err != nil {
+		if err := db.Raw(query, args...).Scan(&chunkRows).Error; err != nil {
 			return nil, fmt.Errorf("query stake inputs: %w", err)
 		}
 		rows = append(rows, chunkRows...)

--- a/database/plugin/metadata/internal/stakequery/stakequery.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery.go
@@ -15,9 +15,14 @@
 package stakequery
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/rewardstate"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -36,8 +41,9 @@ type registrationSource struct {
 }
 
 const (
-	defaultPoolQueryChunkSize = 800
-	largePoolQueryChunkSize   = 5000
+	defaultPoolQueryChunkSize           = 800
+	largePoolQueryChunkSize             = 5000
+	delegatorInactivityActivatedSyncKey = "delegator_inactivity_activated"
 )
 
 // GetStakeByPoolsAtSlot returns delegated stake and delegator counts at a
@@ -48,6 +54,8 @@ func GetStakeByPoolsAtSlot(
 	db *gorm.DB,
 	poolKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) (map[string]uint64, map[string]uint64, error) {
 	stakeMap := make(map[string]uint64, len(poolKeyHashes))
 	delegatorMap := make(map[string]uint64, len(poolKeyHashes))
@@ -59,9 +67,13 @@ func GetStakeByPoolsAtSlot(
 		return stakeMap, delegatorMap, nil
 	}
 
-	query, args := historicalDelegatorStakeCTE(
-		db, slot, "active_delegation.pool_key_hash IN ?",
+	query, args, err := historicalDelegatorStakeCTE(
+		db, slot, expiryEpoch, inactivityPeriod,
+		"active_delegation.pool_key_hash IN ?",
 	)
+	if err != nil {
+		return nil, nil, err
+	}
 	query += `
 SELECT pool_key_hash,
 	COUNT(*) AS delegator_count,
@@ -97,13 +109,123 @@ GROUP BY pool_key_hash`
 	return stakeMap, delegatorMap, nil
 }
 
+// GetRewardStakeInputsByPoolsAtSlot returns positive per-credential delegated
+// stake for the requested pools reconstructed at slot, from the same
+// active_delegator_stake CTE that GetStakeByPoolsAtSlot aggregates for
+// leader-election pool totals. Sourcing both halves of the epoch-boundary
+// snapshot from one CTE makes the reward-basis inputs agree with the
+// leader-election stake by construction: identical credential membership,
+// identical slot-accurate stake values, and the identical CIP-0163 historical
+// expiry filter (expiration reconstructed at slot, not read from the mutable
+// live account.expiration_epoch column). It is used only when the
+// delegator-inactivity gate is active (expiryEpoch > 0); the gate-off reward
+// path stays on the live aggregate (StakeInputsForPools) to remain
+// byte-identical to the pre-CIP query.
+func GetRewardStakeInputsByPoolsAtSlot(
+	db *gorm.DB,
+	poolKeyHashes [][]byte,
+	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
+) ([]*models.RewardStakeInput, error) {
+	if len(poolKeyHashes) == 0 {
+		return nil, nil
+	}
+	poolKeyHashes = rewardstate.DedupePoolKeyHashes(poolKeyHashes)
+
+	query, args, err := historicalDelegatorStakeCTE(
+		db, slot, expiryEpoch, inactivityPeriod,
+		"active_delegation.pool_key_hash IN ?",
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Only positive stake contributes a reward input, matching the live-path
+	// filter (StakeInputsForPools drops total_stake = 0). Ordering mirrors the
+	// live path for stable output.
+	query += `
+SELECT pool_key_hash, credential_tag, staking_key, total_stake
+FROM active_delegator_stake
+WHERE total_stake > 0
+ORDER BY pool_key_hash ASC, credential_tag ASC, staking_key ASC`
+
+	type inputRow struct {
+		PoolKeyHash   []byte `gorm:"column:pool_key_hash"`
+		StakingKey    []byte `gorm:"column:staking_key"`
+		CredentialTag uint8  `gorm:"column:credential_tag"`
+		TotalStake    uint64 `gorm:"column:total_stake"`
+	}
+	var ret []*models.RewardStakeInput
+	chunkSize := poolQueryChunkSize(db)
+	for start := 0; start < len(poolKeyHashes); start += chunkSize {
+		end := min(start+chunkSize, len(poolKeyHashes))
+		queryArgs := append(append([]any(nil), args...), poolKeyHashes[start:end])
+		var rows []inputRow
+		if err := db.Raw(query, queryArgs...).Scan(&rows).Error; err != nil {
+			return nil, fmt.Errorf(
+				"query historical reward stake inputs: %w", err,
+			)
+		}
+		for _, row := range rows {
+			ret = append(ret, &models.RewardStakeInput{
+				PoolKeyHash:   append([]byte(nil), row.PoolKeyHash...),
+				StakingKey:    append([]byte(nil), row.StakingKey...),
+				CredentialTag: row.CredentialTag,
+				Stake:         types.Uint64(row.TotalStake),
+				// active_delegator_stake contains only actively-delegated
+				// credentials at slot, so every row is registered.
+				Registered: true,
+			})
+		}
+	}
+	return ret, nil
+}
+
+// historicalDelegatorStakeCTE builds the shared per-credential stake
+// aggregation. When expiryEpoch > 0 the CIP-0163 reward-account inactivity gate
+// is active: a LEFT JOIN to account plus a WHERE clause drop credentials whose
+// account expired before expiryEpoch (nonzero expiration_epoch < expiryEpoch),
+// while credentials with no account row (LEFT JOIN NULL) or expiration_epoch 0
+// stay active. When expiryEpoch == 0 the gate is off and the generated SQL and
+// args are byte-identical to the pre-CIP query (no join, no clause, no arg).
 func historicalDelegatorStakeCTE(
 	db *gorm.DB,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	predicate string,
-) (string, []any) {
+) (string, []any, error) {
 	cte, args := activeDelegationCTE(db, slot)
-	query := cte + fmt.Sprintf(`,
+	// The expiry gate is hand-written positional-arg SQL. Its "?" sits in the
+	// WHERE clause ahead of the caller-supplied predicate's `IN ?`, so the
+	// expiryEpoch bind arg is appended right after the four slot args below and
+	// before the caller appends the pool chunk. Keeping the clause ahead of the
+	// predicate preserves the "caller appends last" contract of both callers.
+	var expiryCTE, expiryJoin, expiryPredicate string
+	if expiryEpoch > 0 {
+		if inactivityPeriod == 0 {
+			return "", nil, errors.New(
+				"historical stake expiry enabled with zero inactivity period",
+			)
+		}
+		activationEpoch, err := loadActivationEpoch(db)
+		if err != nil {
+			return "", nil, err
+		}
+		var expiryArgs []any
+		expiryCTE, expiryArgs = historicalExpirationCTE(
+			slot, inactivityPeriod, activationEpoch, expiryEpoch,
+		)
+		args = append(args, expiryArgs...)
+		expiryJoin = `
+	LEFT JOIN historical_expiration expiry_acct
+		ON expiry_acct.credential_tag = active_delegation.credential_tag
+		AND expiry_acct.staking_key = active_delegation.staking_key`
+		expiryPredicate = `(expiry_acct.expiration_epoch = 0
+		OR expiry_acct.expiration_epoch >= ?
+		OR expiry_acct.expiration_epoch IS NULL) AND `
+	}
+	query := cte + expiryCTE + fmt.Sprintf(`,
 ranked_future_withdrawal AS (
 	SELECT withdrawal.credential_tag,
 		withdrawal.staking_key,
@@ -183,14 +305,17 @@ active_delegator_stake AS (
 		AND (utxo.deleted_slot = 0 OR utxo.deleted_slot > ?)
 	LEFT JOIN historical_reward
 		ON historical_reward.credential_tag = active_delegation.credential_tag
-		AND historical_reward.staking_key = active_delegation.staking_key
-	WHERE %[2]s
+		AND historical_reward.staking_key = active_delegation.staking_key%[3]s
+	WHERE %[4]s%[2]s
 	GROUP BY active_delegation.pool_key_hash,
 		active_delegation.credential_tag,
 		active_delegation.staking_key
-)`, utxoAmountCastType(db), predicate)
+)`, utxoAmountCastType(db), predicate, expiryJoin, expiryPredicate)
 	args = append(args, slot, slot, slot, slot)
-	return query, args
+	if expiryEpoch > 0 {
+		args = append(args, expiryEpoch)
+	}
+	return query, args, nil
 }
 
 // GetPoolOwnerStakeAtSlot returns stake only for the requested key-hash owner
@@ -201,16 +326,21 @@ func GetPoolOwnerStakeAtSlot(
 	db *gorm.DB,
 	ownerKeys [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64)
 	if len(ownerKeys) == 0 {
 		return out, nil
 	}
-	query, args := historicalDelegatorStakeCTE(
-		db, slot,
+	query, args, err := historicalDelegatorStakeCTE(
+		db, slot, expiryEpoch, inactivityPeriod,
 		"active_delegation.credential_tag = 0 "+
 			"AND active_delegation.staking_key IN ?",
 	)
+	if err != nil {
+		return nil, err
+	}
 	query += `
 SELECT pool_key_hash, staking_key, total_stake
 FROM active_delegator_stake`
@@ -235,6 +365,151 @@ FROM active_delegator_stake`
 		}
 	}
 	return out, nil
+}
+
+// loadActivationEpoch returns the durable one-time CIP-0163 activation epoch.
+// Reading and parsing it here keeps malformed consensus state from being
+// silently coerced by backend-specific SQL casts.
+func loadActivationEpoch(db *gorm.DB) (*uint64, error) {
+	var state models.SyncState
+	result := db.Where(
+		"sync_key = ?", delegatorInactivityActivatedSyncKey,
+	).Limit(1).Find(&state)
+	if result.Error != nil {
+		return nil, fmt.Errorf("load delegator inactivity activation: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return nil, nil
+	}
+	epoch, err := strconv.ParseUint(state.Value, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse delegator inactivity activation %q: %w", state.Value, err,
+		)
+	}
+	return &epoch, nil
+}
+
+// historicalExpirationCTE reconstructs expiration at slot from the latest
+// locally retained witness at or before that slot. The mutable account value is
+// used only for imported/bootstrap credentials with no reconstructable witness
+// or activation floor.
+func historicalExpirationCTE(
+	slot uint64,
+	inactivityPeriod uint64,
+	activationEpoch *uint64,
+	expiryEpoch uint64,
+) (string, []any) {
+	witnessParts := make([]string, 0, len(accountwitness.CertTableNames())+2)
+	args := make([]any, 0, len(accountwitness.CertTableNames())+4)
+	for _, table := range accountwitness.CertTableNames() {
+		witnessParts = append(witnessParts, fmt.Sprintf(`
+SELECT witness.credential_tag, witness.staking_key, witness.added_slot
+FROM %s witness
+INNER JOIN active_delegation
+	ON active_delegation.credential_tag = witness.credential_tag
+	AND active_delegation.staking_key = witness.staking_key`, table))
+	}
+	witnessParts = append(witnessParts, `
+SELECT witness.credential_tag, witness.staking_key, witness.added_slot
+FROM account_withdrawal_witness witness
+INNER JOIN active_delegation
+	ON active_delegation.credential_tag = witness.credential_tag
+	AND active_delegation.staking_key = witness.staking_key`)
+	witnessParts = append(witnessParts, `
+SELECT witness.credential_tag, witness.staking_key, witness.added_slot
+FROM account_reward_delta witness
+INNER JOIN active_delegation
+	ON active_delegation.credential_tag = witness.credential_tag
+	AND active_delegation.staking_key = witness.staking_key
+WHERE witness.withdrawal = TRUE`)
+	args = append(args, slot)
+
+	activationCTE := ""
+	createdEpochJoin := ""
+	expirationExpr := `CASE
+		WHEN account.id IS NULL THEN 0
+		WHEN historical_witness_epoch.epoch_id IS NOT NULL
+			THEN historical_witness_epoch.epoch_id + ?
+		WHEN witness_summary.latest_added_slot IS NOT NULL
+			THEN COALESCE(created_epoch.epoch_id, 0) + ?
+		ELSE COALESCE(account.expiration_epoch, 0)
+	END`
+	createdEpochJoin = `
+	LEFT JOIN epoch created_epoch
+		ON account.created_slot > 0
+		AND account.created_slot >= created_epoch.start_slot
+		AND account.created_slot < created_epoch.start_slot + created_epoch.length_in_slots`
+	if activationEpoch != nil && *activationEpoch <= expiryEpoch {
+		activationCTE = `,
+inactivity_activation AS (
+	SELECT ? AS epoch_id
+)`
+		args = append(args, *activationEpoch)
+		createdEpochJoin = `
+	LEFT JOIN epoch created_epoch
+		ON account.created_slot > 0
+		AND account.created_slot >= created_epoch.start_slot
+		AND account.created_slot < created_epoch.start_slot + created_epoch.length_in_slots
+	CROSS JOIN inactivity_activation
+	LEFT JOIN account_inactivity_activation activation_account
+		ON activation_account.credential_tag = active_delegation.credential_tag
+		AND activation_account.staking_key = active_delegation.staking_key`
+		expirationExpr = `CASE
+		WHEN account.id IS NULL THEN 0
+		WHEN activation_account.staking_key IS NOT NULL
+			AND (historical_witness_epoch.epoch_id IS NULL
+				OR historical_witness_epoch.epoch_id < inactivity_activation.epoch_id)
+			THEN inactivity_activation.epoch_id + ?
+		WHEN historical_witness_epoch.epoch_id IS NOT NULL
+			THEN historical_witness_epoch.epoch_id + ?
+		WHEN witness_summary.latest_added_slot IS NOT NULL
+			THEN COALESCE(created_epoch.epoch_id, 0) + ?
+		ELSE COALESCE(account.expiration_epoch, 0)
+	END`
+		args = append(args, inactivityPeriod, inactivityPeriod, inactivityPeriod)
+	} else {
+		args = append(args, inactivityPeriod, inactivityPeriod)
+	}
+
+	return fmt.Sprintf(`,
+account_witness_events AS (
+%s
+),
+witness_summary AS (
+	SELECT credential_tag,
+		staking_key,
+		MAX(CASE WHEN added_slot <= ? THEN added_slot END) AS historical_added_slot,
+		MAX(added_slot) AS latest_added_slot
+	FROM account_witness_events
+	GROUP BY credential_tag, staking_key
+),
+historical_witness_epoch AS (
+	SELECT witness_summary.credential_tag,
+		witness_summary.staking_key,
+		MAX(epoch.epoch_id) AS epoch_id
+	FROM witness_summary
+	INNER JOIN epoch
+		ON witness_summary.historical_added_slot >= epoch.start_slot
+		AND witness_summary.historical_added_slot < epoch.start_slot + epoch.length_in_slots
+	GROUP BY witness_summary.credential_tag,
+		witness_summary.staking_key
+)%s,
+historical_expiration AS (
+	SELECT active_delegation.credential_tag,
+		active_delegation.staking_key,
+		%s AS expiration_epoch
+	FROM active_delegation
+	LEFT JOIN account
+		ON account.credential_tag = active_delegation.credential_tag
+		AND account.staking_key = active_delegation.staking_key
+	LEFT JOIN historical_witness_epoch
+		ON historical_witness_epoch.credential_tag = active_delegation.credential_tag
+		AND historical_witness_epoch.staking_key = active_delegation.staking_key
+	LEFT JOIN witness_summary
+		ON witness_summary.credential_tag = active_delegation.credential_tag
+		AND witness_summary.staking_key = active_delegation.staking_key%s
+)`, strings.Join(witnessParts, "\nUNION ALL\n"), activationCTE, expirationExpr, createdEpochJoin), args
 }
 
 func poolQueryChunkSize(db *gorm.DB) int {

--- a/database/plugin/metadata/internal/stakequery/stakequery_test.go
+++ b/database/plugin/metadata/internal/stakequery/stakequery_test.go
@@ -16,6 +16,7 @@ package stakequery
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -31,6 +32,50 @@ func TestPoolQueryChunkSizeDefault(t *testing.T) {
 	_, cteArgs := activeDelegationCTE(nil, 0)
 	const stakeQueryArgs = 2
 	require.LessOrEqual(t, len(cteArgs)+stakeQueryArgs+chunkSize, 999)
+}
+
+// TestHistoricalDelegatorStakeCTEExpiryGate verifies the CIP-0163 expiry gate
+// on the shared aggregation query builder. It is hand-written positional-arg
+// SQL, so the number of "?" placeholders must always equal len(args)+1 (the
+// caller appends exactly one more arg for the predicate's `IN ?`). With the
+// gate off (expiryEpoch == 0) the generated SQL and args must be byte-identical
+// to the pre-CIP query: no account join, no expiration clause, no extra arg.
+func TestHistoricalDelegatorStakeCTEExpiryGate(t *testing.T) {
+	const predicate = "active_delegation.pool_key_hash IN ?"
+
+	offQuery, offArgs, err := historicalDelegatorStakeCTE(nil, 42, 0, 0, predicate)
+	require.NoError(t, err)
+	// Gate off: byte-identical to today. No expiry artifacts.
+	require.NotContains(t, offQuery, "expiry_acct")
+	require.NotContains(t, offQuery, "expiration_epoch")
+	// The caller fills the single predicate placeholder, so #? == len(args)+1.
+	require.Equal(
+		t,
+		strings.Count(offQuery, "?"),
+		len(offArgs)+1,
+		"gate-off placeholder/arg alignment",
+	)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SyncState{}))
+	onQuery, onArgs, err := historicalDelegatorStakeCTE(db, 42, 7, 90, predicate)
+	require.NoError(t, err)
+	require.Contains(t, onQuery, "expiry_acct")
+	require.Contains(t, onQuery, "expiration_epoch >= ?")
+	require.Contains(t, onQuery, "expiration_epoch IS NULL")
+	// Same positional invariant must hold with the gate on.
+	require.Equal(
+		t,
+		strings.Count(onQuery, "?"),
+		len(onArgs)+1,
+		"gate-on placeholder/arg alignment",
+	)
+	// The expiry epoch remains the final builder argument, immediately before
+	// the caller's pool chunk; witness-history reconstruction contributes the
+	// preceding slot/window arguments.
+	require.Greater(t, len(onArgs), len(offArgs))
+	require.Equal(t, uint64(7), onArgs[len(onArgs)-1])
 }
 
 func TestPreEpochPoolQueryChunkSizeSQLite(t *testing.T) {

--- a/database/plugin/metadata/mysql/account.go
+++ b/database/plugin/metadata/mysql/account.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -96,6 +98,175 @@ func (d *MetadataStoreMysql) GetAccountsByCredential(
 		}
 	}
 	return ret, nil
+}
+
+// RenewAccountExpirations sets expiration_epoch for every existing account
+// row matching one of refs. Rows with no match are ignored (an account must
+// be registered to have an expiration). Credentials are updated in set-based
+// batches — one UPDATE per chunk rather than one per credential — so a large
+// rollback recompute does not hold the ledger write transaction open across
+// thousands of single-row round-trips.
+func (d *MetadataStoreMysql) RenewAccountExpirations(
+	refs []models.StakeCredentialRef,
+	expirationEpoch uint64,
+	txn types.Txn,
+) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(refs); start += mysqlBatchChunkSize {
+		end := min(start+mysqlBatchChunkSize, len(refs))
+		chunk := refs[start:end]
+		// GORM's tuple-IN handling unpacks []byte arguments byte-by-byte across
+		// drivers, so build an OR chain with parallel (credential_tag,
+		// staking_key) equality predicates instead (see MarkUtxosDeletedAtSlot).
+		var clauses strings.Builder
+		args := make([]any, 0, 1+2*len(chunk))
+		args = append(args, expirationEpoch)
+		for i, ref := range chunk {
+			if i > 0 {
+				clauses.WriteString(" OR ")
+			}
+			clauses.WriteString("(credential_tag = ? AND staking_key = ?)")
+			args = append(args, ref.Tag, ref.Key)
+		}
+		if err := db.Exec(
+			"UPDATE account SET expiration_epoch = ? WHERE "+clauses.String(),
+			args...,
+		).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AccountLastWitnessSlots returns, per requested credential, the greatest
+// witnessing added_slot <= maxSlot across the stake-witnessing certificate
+// tables and the reward-withdrawal history (account_reward_delta where
+// withdrawal = TRUE). The witness set matches CIP-0163 exactly (see
+// accountwitness.CertTableNames and the ledger's witnessedRewardCredentials).
+// The result is keyed by StakeCredentialRef.MapKey(); a credential with no
+// witness <= maxSlot is absent from the map.
+//
+// The SQL IN clause filters on the staking-key hash only and the result is
+// post-filtered to the requested composite (tag, hash) keys, so credentials
+// sharing a hash but differing in tag stay isolated.
+func (d *MetadataStoreMysql) AccountLastWitnessSlots(
+	refs []models.StakeCredentialRef,
+	maxSlot uint64,
+	txn types.Txn,
+) (map[string]uint64, error) {
+	if len(refs) == 0 {
+		return map[string]uint64{}, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.LastSlots(db, refs, maxSlot, mysqlBatchChunkSize)
+}
+
+// AccountsWitnessedAfterSlot returns the distinct reward-account credentials
+// that have a stake-witnessing certificate OR a reward withdrawal at
+// added_slot > slot. It is the CIP-0163 rollback affected set: the credentials
+// whose expiration_epoch may have been renewed by a now-orphaned witness and
+// therefore must be recomputed against the surviving chain. The witness set
+// matches AccountLastWitnessSlots (cert tables + withdrawal history). Callers
+// must invoke this before deleting rolled-back certificate and reward-delta
+// rows, since those are exactly the rows this query inspects.
+func (d *MetadataStoreMysql) AccountsWitnessedAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.StakeCredentialRef, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.AfterSlot(db, slot)
+}
+
+// StampAllActiveAccountExpirations sets expiration_epoch = expirationEpoch for
+// every active account. Used once at CIP-0163 activation to give every
+// pre-existing account a full inactivity window starting at the activation
+// epoch, including accounts witnessed before activation. Returns the number of
+// rows stamped.
+func (d *MetadataStoreMysql) StampAllActiveAccountExpirations(
+	expirationEpoch uint64,
+	txn types.Txn,
+) (int64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	if err := db.Exec(`
+		INSERT INTO account_inactivity_activation (credential_tag, staking_key)
+		SELECT credential_tag, staking_key
+		FROM account
+		WHERE active = ?`,
+		true,
+	).Error; err != nil {
+		return 0, err
+	}
+	res := db.Model(&models.Account{}).
+		Where("active = ?", true).
+		Update("expiration_epoch", expirationEpoch)
+	return res.RowsAffected, res.Error
+}
+
+func (d *MetadataStoreMysql) AccountInactivityActivationMembership(
+	refs []models.StakeCredentialRef,
+	txn types.Txn,
+) (map[string]struct{}, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.ActivationMembership(
+		db,
+		refs,
+		mysqlBatchChunkSize,
+	)
+}
+
+func (d *MetadataStoreMysql) ResetAccountExpirationActivation(
+	txn types.Txn,
+) ([]models.StakeCredentialRef, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var activations []models.AccountInactivityActivation
+	if err := db.Find(&activations).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Exec(`
+		UPDATE account
+		SET expiration_epoch = 0
+		WHERE EXISTS (
+			SELECT 1
+			FROM account_inactivity_activation activation
+			WHERE activation.credential_tag = account.credential_tag
+				AND activation.staking_key = account.staking_key
+		)`,
+	).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Where("1 = 1").
+		Delete(&models.AccountInactivityActivation{}).Error; err != nil {
+		return nil, err
+	}
+	refs := make([]models.StakeCredentialRef, 0, len(activations))
+	for _, activation := range activations {
+		refs = append(refs, models.NewStakeCredentialRef(
+			activation.CredentialTag,
+			activation.StakingKey,
+		))
+	}
+	return refs, nil
 }
 
 // AddAccountRewardByCredential credits a registered reward account.
@@ -414,6 +585,10 @@ func (d *MetadataStoreMysql) DeleteAccountRewardsAfterSlot(
 			"added_slot > ?",
 			slot,
 		).Delete(&models.AccountRewardDelta{}); result.Error != nil {
+			return result.Error
+		}
+		if result := tx.Where("added_slot > ?", slot).
+			Delete(&models.AccountWithdrawalWitness{}); result.Error != nil {
 			return result.Error
 		}
 		return refreshRewardLiveStakeAggregates(tx, refs)

--- a/database/plugin/metadata/mysql/account_activation_test.go
+++ b/database/plugin/metadata/mysql/account_activation_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package mysql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStampAllActiveAccountExpirationsMysql verifies that activation gives all
+// active accounts the same full inactivity window. In particular, a witness
+// before activation may have already set expiration_epoch, but that earlier
+// value must be replaced by the activation expiration.
+func TestStampAllActiveAccountExpirationsMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	keyUnset := bytes.Repeat([]byte{0xD1}, 28)
+	keyWitnessed := bytes.Repeat([]byte{0xD2}, 28)
+	keyInactive := bytes.Repeat([]byte{0xD3}, 28)
+	keys := [][]byte{keyUnset, keyWitnessed, keyInactive}
+	cleanup := func() {
+		for _, key := range keys {
+			_ = db.Where("staking_key = ?", key).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", key).
+				Delete(&models.AccountInactivityActivation{}).Error
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	accounts := []models.Account{
+		{
+			StakingKey: keyUnset, CredentialTag: 0, Active: true,
+		},
+		{
+			StakingKey: keyWitnessed, CredentialTag: 0, Active: true,
+			ExpirationEpoch: 149,
+		},
+		{
+			StakingKey: keyInactive, CredentialTag: 0, Active: true,
+			ExpirationEpoch: 149,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	require.NoError(t, db.Model(&models.Account{}).
+		Where("staking_key = ?", keyInactive).
+		Update("active", false).Error)
+
+	rows, err := store.StampAllActiveAccountExpirations(150, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, rows)
+
+	var gotUnset models.Account
+	require.NoError(t, db.First(&gotUnset, accounts[0].ID).Error)
+	require.Equal(t, uint64(150), gotUnset.ExpirationEpoch)
+
+	var gotWitnessed models.Account
+	require.NoError(t, db.First(&gotWitnessed, accounts[1].ID).Error)
+	require.Equal(t, uint64(150), gotWitnessed.ExpirationEpoch)
+
+	var gotInactive models.Account
+	require.NoError(t, db.First(&gotInactive, accounts[2].ID).Error)
+	require.Equal(t, uint64(149), gotInactive.ExpirationEpoch)
+}

--- a/database/plugin/metadata/mysql/account_activation_test.go
+++ b/database/plugin/metadata/mysql/account_activation_test.go
@@ -30,7 +30,9 @@ import (
 // value must be replaced by the activation expiration.
 func TestStampAllActiveAccountExpirationsMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
 	db := store.DB()
 
 	keyUnset := bytes.Repeat([]byte{0xD1}, 28)
@@ -39,9 +41,10 @@ func TestStampAllActiveAccountExpirationsMysql(t *testing.T) {
 	keys := [][]byte{keyUnset, keyWitnessed, keyInactive}
 	cleanup := func() {
 		for _, key := range keys {
-			_ = db.Where("staking_key = ?", key).Delete(&models.Account{}).Error
-			_ = db.Where("staking_key = ?", key).
-				Delete(&models.AccountInactivityActivation{}).Error
+			require.NoError(t, db.Where("staking_key = ?", key).
+				Delete(&models.AccountInactivityActivation{}).Error)
+			require.NoError(t, db.Where("staking_key = ?", key).
+				Delete(&models.Account{}).Error)
 		}
 	}
 	cleanup()
@@ -70,6 +73,17 @@ func TestStampAllActiveAccountExpirationsMysql(t *testing.T) {
 	rows, err := store.StampAllActiveAccountExpirations(150, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, rows)
+
+	refs := []models.StakeCredentialRef{
+		models.NewStakeCredentialRef(0, keyUnset),
+		models.NewStakeCredentialRef(0, keyWitnessed),
+		models.NewStakeCredentialRef(0, keyInactive),
+	}
+	membership, err := store.AccountInactivityActivationMembership(refs, nil)
+	require.NoError(t, err)
+	require.Contains(t, membership, refs[0].MapKey())
+	require.Contains(t, membership, refs[1].MapKey())
+	require.NotContains(t, membership, refs[2].MapKey())
 
 	var gotUnset models.Account
 	require.NoError(t, db.First(&gotUnset, accounts[0].ID).Error)

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/drepquery"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -174,35 +175,18 @@ func (d *MetadataStoreMysql) InsertDrepIfAbsent(
 func (d *MetadataStoreMysql) GetDRepVotingPower(
 	credentialTag uint8,
 	drepCredential []byte,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (uint64, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, err
 	}
+	sql, args := drepquery.VotingPowerSQL(
+		db.Name(), credentialTag, drepCredential, expiryEpoch,
+	)
 	var totalStake uint64
-	if err := db.Raw(`
-		SELECT COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
-			   ), 0)
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.drep = ? AND ax.drep_type = ? AND ax.active = 1
-			  )
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-		WHERE a.drep = ? AND a.drep_type = ? AND a.active = 1
-	`, drepCredential, credentialTag, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 	return totalStake, nil
@@ -244,6 +228,7 @@ func (d *MetadataStoreMysql) GetDRepDelegators(
 // in a single query. See sqlite/drep.go for the documented contract.
 func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 	drepCredentials []models.StakeCredentialRef,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64, len(drepCredentials))
@@ -265,29 +250,10 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 		hashes[i] = ref.Key
 		requested[ref.MapKey()] = struct{}{}
 	}
+	sql := drepquery.VotingPowerBatchSQL(db.Name(), expiryEpoch)
+	args := drepquery.CollectionArgs(hashes, expiryEpoch)
 	var rows []row
-	if err := db.Raw(`
-		SELECT a.drep AS drep, a.drep_type AS credential_tag,
-			   COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
-			   ), 0) AS stake
-		FROM account a
-		LEFT JOIN (
-			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
-				   COALESCE(SUM(CAST(utxo.amount AS UNSIGNED)), 0) AS utxo_sum
-			FROM account ax
-			JOIN utxo ON utxo.credential_tag = ax.credential_tag
-			         AND utxo.staking_key = ax.staking_key
-			         AND utxo.deleted_slot = 0
-			WHERE ax.active = 1 AND ax.drep IN ?
-			GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-			AND u.drep_type = a.drep_type
-		WHERE a.active = 1 AND a.drep IN ?
-		GROUP BY a.drep, a.drep_type
-	`, hashes, hashes).Scan(&rows).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power batch: %w", err)
 	}
 	for _, r := range rows {
@@ -310,6 +276,7 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerBatch(
 // type. It is used for predefined DRep options, which carry no credential.
 func (d *MetadataStoreMysql) GetDRepVotingPowerByType(
 	drepTypes []uint64,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (map[uint64]uint64, error) {
 	out := make(map[uint64]uint64, len(drepTypes))
@@ -327,36 +294,15 @@ func (d *MetadataStoreMysql) GetDRepVotingPowerByType(
 		DrepType uint64
 		Stake    uint64
 	}
+	sql := drepquery.VotingPowerByTypeSQL(db.Name(), expiryEpoch)
+	args := drepquery.CollectionArgs(drepTypes, expiryEpoch)
 	var rows []row
 	// Aggregate UTxO amounts per staking_key in a subquery before
 	// adding account.reward, otherwise the LEFT JOIN would multiply
 	// the per-account reward by the number of live UTxOs and inflate
 	// the totals. Each account contributes (utxo_sum + reward) once
 	// to its drep_type bucket.
-	if err := db.Raw(`
-		SELECT a.drep_type AS drep_type,
-			   COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS UNSIGNED), 0)
-			   ), 0) AS stake
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS UNSIGNED)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.active = 1 AND ax.drep_type IN ?
-			  )
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-		WHERE a.active = 1 AND a.drep_type IN ?
-		GROUP BY a.drep_type
-	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power by type: %w", err)
 	}
 	for _, r := range rows {

--- a/database/plugin/metadata/mysql/drep_test.go
+++ b/database/plugin/metadata/mysql/drep_test.go
@@ -47,18 +47,20 @@ func TestMysqlGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 	require.NoError(t, store.SetDrep(0, rewardOnlyCred, 1000, "", nil, true, nil))
 	require.NoError(t, store.SetDrep(0, multiUtxoCred, 1000, "", nil, true, nil))
 	require.NoError(t, store.DB().Create(&models.Account{
-		StakingKey: rewardOnlyStake,
-		Drep:       rewardOnlyCred,
-		Reward:     700,
-		Active:     true,
-		AddedSlot:  1000,
+		StakingKey:      rewardOnlyStake,
+		Drep:            rewardOnlyCred,
+		Reward:          700,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: 4,
 	}).Error)
 	require.NoError(t, store.DB().Create(&models.Account{
-		StakingKey: multiUtxoStake,
-		Drep:       multiUtxoCred,
-		Reward:     500,
-		Active:     true,
-		AddedSlot:  1000,
+		StakingKey:      multiUtxoStake,
+		Drep:            multiUtxoCred,
+		Reward:          500,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: 6,
 	}).Error)
 	require.NoError(t, store.DB().Create(&models.Utxo{
 		TxId:       testHash32("tx_reward_1"),
@@ -80,17 +82,37 @@ func TestMysqlGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 			{Tag: 0, Key: rewardOnlyCred},
 			{Tag: 0, Key: multiUtxoCred},
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), powers[models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey()])
 	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
 
-	singlePower, err := store.GetDRepVotingPower(0, rewardOnlyCred, nil)
+	singlePower, err := store.GetDRepVotingPower(0, rewardOnlyCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), singlePower)
 
-	singlePower, err = store.GetDRepVotingPower(0, multiUtxoCred, nil)
+	singlePower, err = store.GetDRepVotingPower(0, multiUtxoCred, 0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), singlePower)
+
+	powers, err = store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: rewardOnlyCred},
+			{Tag: 0, Key: multiUtxoCred},
+		},
+		5,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, powers, models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey())
+	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
+
+	singlePower, err = store.GetDRepVotingPower(0, rewardOnlyCred, 5, nil)
+	require.NoError(t, err)
+	assert.Zero(t, singlePower)
+	singlePower, err = store.GetDRepVotingPower(0, multiUtxoCred, 5, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1000), singlePower)
 }
@@ -104,18 +126,20 @@ func TestMysqlGetDRepVotingPowerByTypeIncludesReward(t *testing.T) {
 	noConfidenceStake := testHash28("stake_no_conf_reward")
 
 	require.NoError(t, store.DB().Create(&models.Account{
-		StakingKey: abstainStake,
-		DrepType:   models.DrepTypeAlwaysAbstain,
-		Reward:     700,
-		Active:     true,
-		AddedSlot:  1000,
+		StakingKey:      abstainStake,
+		DrepType:        models.DrepTypeAlwaysAbstain,
+		Reward:          700,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: 4,
 	}).Error)
 	require.NoError(t, store.DB().Create(&models.Account{
-		StakingKey: noConfidenceStake,
-		DrepType:   models.DrepTypeAlwaysNoConfidence,
-		Reward:     500,
-		Active:     true,
-		AddedSlot:  1000,
+		StakingKey:      noConfidenceStake,
+		DrepType:        models.DrepTypeAlwaysNoConfidence,
+		Reward:          500,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: 6,
 	}).Error)
 	require.NoError(t, store.DB().Create(&models.Utxo{
 		TxId:       testHash32("tx_type_1"),
@@ -137,10 +161,23 @@ func TestMysqlGetDRepVotingPowerByTypeIncludesReward(t *testing.T) {
 			models.DrepTypeAlwaysAbstain,
 			models.DrepTypeAlwaysNoConfidence,
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), powers[models.DrepTypeAlwaysAbstain])
+	assert.Equal(t, uint64(1000), powers[models.DrepTypeAlwaysNoConfidence])
+
+	powers, err = store.GetDRepVotingPowerByType(
+		[]uint64{
+			models.DrepTypeAlwaysAbstain,
+			models.DrepTypeAlwaysNoConfidence,
+		},
+		5,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, powers, models.DrepTypeAlwaysAbstain)
 	assert.Equal(t, uint64(1000), powers[models.DrepTypeAlwaysNoConfidence])
 }
 
@@ -180,11 +217,11 @@ func TestMysqlGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 		AddedSlot:     1000,
 	}).Error)
 
-	keyPower, err := store.GetDRepVotingPower(0, sharedHash, nil)
+	keyPower, err := store.GetDRepVotingPower(0, sharedHash, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(100), keyPower, "key-hash DRep power should be 100")
 
-	scriptPower, err := store.GetDRepVotingPower(1, sharedHash, nil)
+	scriptPower, err := store.GetDRepVotingPower(1, sharedHash, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(200), scriptPower, "script-hash DRep power should be 200")
 
@@ -193,6 +230,7 @@ func TestMysqlGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 			{Tag: 0, Key: sharedHash},
 			{Tag: 1, Key: sharedHash},
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -1161,6 +1161,8 @@ func (d *MetadataStoreMysql) GetStakeByPools(
 func (d *MetadataStoreMysql) GetStakeByPoolsAtSlot(
 	poolKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	txn types.Txn,
 ) (map[string]uint64, map[string]uint64, error) {
 	db, err := d.resolveDB(txn)
@@ -1174,6 +1176,8 @@ func (d *MetadataStoreMysql) GetStakeByPoolsAtSlot(
 		db,
 		poolKeyHashes,
 		slot,
+		expiryEpoch,
+		inactivityPeriod,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("GetStakeByPoolsAtSlot: %w", err)
@@ -1184,6 +1188,8 @@ func (d *MetadataStoreMysql) GetStakeByPoolsAtSlot(
 func (d *MetadataStoreMysql) GetPoolOwnerStakeAtSlot(
 	ownerKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	db, err := d.resolveReadDB(txn)
@@ -1191,6 +1197,6 @@ func (d *MetadataStoreMysql) GetPoolOwnerStakeAtSlot(
 		return nil, err
 	}
 	return stakequery.GetPoolOwnerStakeAtSlot(
-		db, ownerKeyHashes, slot,
+		db, ownerKeyHashes, slot, expiryEpoch, inactivityPeriod,
 	)
 }

--- a/database/plugin/metadata/mysql/pool_atslot_test.go
+++ b/database/plugin/metadata/mysql/pool_atslot_test.go
@@ -57,7 +57,7 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
 	}
 
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
-		[][]byte{poolA, poolB, poolEmpty}, 80, nil,
+		[][]byte{poolA, poolB, poolEmpty}, 80, 0, 0, nil,
 	)
 	require.NoError(t, err)
 
@@ -110,7 +110,7 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql(t *testing.T) {
 	}
 
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
-		[][]byte{poolA, poolB}, 80, nil,
+		[][]byte{poolA, poolB}, 80, 0, 0, nil,
 	)
 	require.NoError(t, err)
 
@@ -171,4 +171,92 @@ func TestGetStakeByPoolsPreservesIntegerPrecisionMysql(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(9007199254740995), stakes[string(pool)])
 	require.Equal(t, uint64(1), delegators[string(pool)])
+}
+
+// TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql exercises the
+// CIP-0163 gated reward-input path on mysql. With the gate on it must
+// reconstruct expiration at slot from the shared historical CTE (not the live
+// account.expiration_epoch column) so the reward-basis inputs agree with
+// GetStakeByPoolsAtSlot. Mysql type-checks the full query at parse time,
+// catching backend-specific regressions the sqlite test cannot.
+func TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	pool := bytes.Repeat([]byte{0xD5}, 28)
+	active := bytes.Repeat([]byte{0x2A}, 28)
+	expired := bytes.Repeat([]byte{0x2B}, 28)
+
+	cleanup := func() {
+		for _, k := range [][]byte{active, expired} {
+			_ = db.Where("staking_key = ?", k).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", k).Delete(&models.Utxo{}).Error
+			_ = db.Where("staking_key = ?", k).
+				Delete(&models.AccountWithdrawalWitness{}).Error
+			_ = db.Where("staking_key = ?", k).
+				Delete(&models.RewardLiveStake{}).Error
+		}
+		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+	accounts := []models.Account{
+		{
+			StakingKey: active, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		},
+		{
+			StakingKey: expired, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x63}, 32), StakingKey: active, Amount: 100, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x64}, 32), StakingKey: expired, Amount: 40, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: active, AddedSlot: 250, TxHash: bytes.Repeat([]byte{0x73}, 32),
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: expired, AddedSlot: 50, TxHash: bytes.Repeat([]byte{0x74}, 32),
+	}).Error)
+	live := []models.RewardLiveStake{
+		{
+			PoolKeyHash: pool, StakingKey: active, CredentialTag: 0,
+			TotalStake: types.Uint64(100), Registered: true,
+		},
+		{
+			PoolKeyHash: pool, StakingKey: expired, CredentialTag: 0,
+			TotalStake: types.Uint64(40), Registered: true,
+		},
+	}
+	for i := range live {
+		require.NoError(t, db.Create(&live[i]).Error)
+	}
+
+	// Gate off: live aggregate returns both inputs.
+	inputs, err := store.GetRewardStakeInputsForPools([][]byte{pool}, 250, 0, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+
+	// Gate on: expiration reconstructed at slot 250 excludes the expired-at-slot
+	// credential; a live-column filter would have kept both (both live epoch 7).
+	inputs, err = store.GetRewardStakeInputsForPools([][]byte{pool}, 250, 3, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.Equal(t, active, inputs[0].StakingKey)
+	require.Equal(t, uint64(100), uint64(inputs[0].Stake))
 }

--- a/database/plugin/metadata/mysql/reward_state.go
+++ b/database/plugin/metadata/mysql/reward_state.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/rewardstate"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -158,12 +159,25 @@ func (d *MetadataStoreMysql) GetRewardPoolInputs(
 	return rewardstate.GetPoolInputs(db, epoch)
 }
 
-func (d *MetadataStoreMysql) GetRewardStakeInputsForPools(poolKeyHashes [][]byte, txn types.Txn) ([]*models.RewardStakeInput, error) {
+func (d *MetadataStoreMysql) GetRewardStakeInputsForPools(poolKeyHashes [][]byte, slot uint64, expiryEpoch uint64, inactivityPeriod uint64, txn types.Txn) ([]*models.RewardStakeInput, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf("GetRewardStakeInputsForPools: resolve db: %w", err)
 	}
-	inputs, err := rewardstate.StakeInputsForPools(db, poolKeyHashes, rewardStakeInputPoolBatchSize)
+	// CIP-0163 gate on: reconstruct reward inputs at slot from the same
+	// historical CTE the leader-election path uses so both halves of the
+	// snapshot agree by construction. Gate off: read the live aggregate,
+	// byte-identical to the pre-CIP query.
+	if expiryEpoch > 0 {
+		inputs, err := stakequery.GetRewardStakeInputsByPoolsAtSlot(
+			db, poolKeyHashes, slot, expiryEpoch, inactivityPeriod,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("GetRewardStakeInputsForPools: %w", err)
+		}
+		return inputs, nil
+	}
+	inputs, err := rewardstate.StakeInputsForPools(db, poolKeyHashes, rewardStakeInputPoolBatchSize, expiryEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("GetRewardStakeInputsForPools: %w", err)
 	}

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountsums"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/collateralfee"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
@@ -2805,7 +2806,7 @@ func (d *MetadataStoreMysql) applyTransactionRewardWithdrawals(
 	txn types.Txn,
 ) error {
 	for addr, amount := range withdrawals {
-		if addr == nil || amount == nil || amount.Sign() == 0 {
+		if addr == nil || amount == nil {
 			continue
 		}
 		if amount.Sign() < 0 || !amount.IsUint64() {
@@ -2822,6 +2823,16 @@ func (d *MetadataStoreMysql) applyTransactionRewardWithdrawals(
 		credentialTag, ok := models.StakeCredentialTagFromAddress(*addr)
 		if !ok {
 			return errors.New("derive reward withdrawal credential tag")
+		}
+		db, err := d.resolveDB(txn)
+		if err != nil {
+			return err
+		}
+		if err := accountwitness.RecordWithdrawal(db, models.NewStakeCredentialRef(credentialTag, stakeKeyHash.Bytes()), txHash, slot); err != nil {
+			return err
+		}
+		if amount.Sign() == 0 {
+			continue
 		}
 		if err := d.ApplyAccountRewardWithdrawal(
 			credentialTag,

--- a/database/plugin/metadata/postgres/account.go
+++ b/database/plugin/metadata/postgres/account.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -96,6 +98,175 @@ func (d *MetadataStorePostgres) GetAccountsByCredential(
 		}
 	}
 	return ret, nil
+}
+
+// RenewAccountExpirations sets expiration_epoch for every existing account
+// row matching one of refs. Rows with no match are ignored (an account must
+// be registered to have an expiration). Credentials are updated in set-based
+// batches — one UPDATE per chunk rather than one per credential — so a large
+// rollback recompute does not hold the ledger write transaction open across
+// thousands of single-row round-trips.
+func (d *MetadataStorePostgres) RenewAccountExpirations(
+	refs []models.StakeCredentialRef,
+	expirationEpoch uint64,
+	txn types.Txn,
+) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(refs); start += postgresBatchChunkSize {
+		end := min(start+postgresBatchChunkSize, len(refs))
+		chunk := refs[start:end]
+		// GORM's tuple-IN handling unpacks []byte arguments byte-by-byte across
+		// drivers, so build an OR chain with parallel (credential_tag,
+		// staking_key) equality predicates instead (see MarkUtxosDeletedAtSlot).
+		var clauses strings.Builder
+		args := make([]any, 0, 1+2*len(chunk))
+		args = append(args, expirationEpoch)
+		for i, ref := range chunk {
+			if i > 0 {
+				clauses.WriteString(" OR ")
+			}
+			clauses.WriteString("(credential_tag = ? AND staking_key = ?)")
+			args = append(args, ref.Tag, ref.Key)
+		}
+		if err := db.Exec(
+			"UPDATE account SET expiration_epoch = ? WHERE "+clauses.String(),
+			args...,
+		).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AccountLastWitnessSlots returns, per requested credential, the greatest
+// witnessing added_slot <= maxSlot across the stake-witnessing certificate
+// tables and the reward-withdrawal history (account_reward_delta where
+// withdrawal = TRUE). The witness set matches CIP-0163 exactly (see
+// accountwitness.CertTableNames and the ledger's witnessedRewardCredentials).
+// The result is keyed by StakeCredentialRef.MapKey(); a credential with no
+// witness <= maxSlot is absent from the map.
+//
+// The SQL IN clause filters on the staking-key hash only and the result is
+// post-filtered to the requested composite (tag, hash) keys, so credentials
+// sharing a hash but differing in tag stay isolated.
+func (d *MetadataStorePostgres) AccountLastWitnessSlots(
+	refs []models.StakeCredentialRef,
+	maxSlot uint64,
+	txn types.Txn,
+) (map[string]uint64, error) {
+	if len(refs) == 0 {
+		return map[string]uint64{}, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.LastSlots(db, refs, maxSlot, postgresBatchChunkSize)
+}
+
+// AccountsWitnessedAfterSlot returns the distinct reward-account credentials
+// that have a stake-witnessing certificate OR a reward withdrawal at
+// added_slot > slot. It is the CIP-0163 rollback affected set: the credentials
+// whose expiration_epoch may have been renewed by a now-orphaned witness and
+// therefore must be recomputed against the surviving chain. The witness set
+// matches AccountLastWitnessSlots (cert tables + withdrawal history). Callers
+// must invoke this before deleting rolled-back certificate and reward-delta
+// rows, since those are exactly the rows this query inspects.
+func (d *MetadataStorePostgres) AccountsWitnessedAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.StakeCredentialRef, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.AfterSlot(db, slot)
+}
+
+// StampAllActiveAccountExpirations sets expiration_epoch = expirationEpoch for
+// every active account. Used once at CIP-0163 activation to give every
+// pre-existing account a full inactivity window starting at the activation
+// epoch, including accounts witnessed before activation. Returns the number of
+// rows stamped.
+func (d *MetadataStorePostgres) StampAllActiveAccountExpirations(
+	expirationEpoch uint64,
+	txn types.Txn,
+) (int64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	if err := db.Exec(`
+		INSERT INTO account_inactivity_activation (credential_tag, staking_key)
+		SELECT credential_tag, staking_key
+		FROM account
+		WHERE active = ?`,
+		true,
+	).Error; err != nil {
+		return 0, err
+	}
+	res := db.Model(&models.Account{}).
+		Where("active = ?", true).
+		Update("expiration_epoch", expirationEpoch)
+	return res.RowsAffected, res.Error
+}
+
+func (d *MetadataStorePostgres) AccountInactivityActivationMembership(
+	refs []models.StakeCredentialRef,
+	txn types.Txn,
+) (map[string]struct{}, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.ActivationMembership(
+		db,
+		refs,
+		postgresBatchChunkSize,
+	)
+}
+
+func (d *MetadataStorePostgres) ResetAccountExpirationActivation(
+	txn types.Txn,
+) ([]models.StakeCredentialRef, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var activations []models.AccountInactivityActivation
+	if err := db.Find(&activations).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Exec(`
+		UPDATE account
+		SET expiration_epoch = 0
+		WHERE EXISTS (
+			SELECT 1
+			FROM account_inactivity_activation activation
+			WHERE activation.credential_tag = account.credential_tag
+				AND activation.staking_key = account.staking_key
+		)`,
+	).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Where("1 = 1").
+		Delete(&models.AccountInactivityActivation{}).Error; err != nil {
+		return nil, err
+	}
+	refs := make([]models.StakeCredentialRef, 0, len(activations))
+	for _, activation := range activations {
+		refs = append(refs, models.NewStakeCredentialRef(
+			activation.CredentialTag,
+			activation.StakingKey,
+		))
+	}
+	return refs, nil
 }
 
 // AddAccountRewardByCredential credits a registered reward account.
@@ -414,6 +585,10 @@ func (d *MetadataStorePostgres) DeleteAccountRewardsAfterSlot(
 			"added_slot > ?",
 			slot,
 		).Delete(&models.AccountRewardDelta{}); result.Error != nil {
+			return result.Error
+		}
+		if result := tx.Where("added_slot > ?", slot).
+			Delete(&models.AccountWithdrawalWitness{}); result.Error != nil {
 			return result.Error
 		}
 		return refreshRewardLiveStakeAggregates(tx, refs)

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/drepquery"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -174,35 +175,18 @@ func (d *MetadataStorePostgres) InsertDrepIfAbsent(
 func (d *MetadataStorePostgres) GetDRepVotingPower(
 	credentialTag uint8,
 	drepCredential []byte,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (uint64, error) {
 	db, err := d.resolveDB(txn)
 	if err != nil {
 		return 0, err
 	}
+	sql, args := drepquery.VotingPowerSQL(
+		db.Name(), credentialTag, drepCredential, expiryEpoch,
+	)
 	var totalStake uint64
-	if err := db.Raw(`
-		SELECT COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS BIGINT), 0)
-			   ), 0)
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.drep = $1 AND ax.drep_type = $2 AND ax.active = true
-			  )
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-		WHERE a.drep = $1 AND a.drep_type = $2 AND a.active = true
-	`, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 	return totalStake, nil
@@ -244,6 +228,7 @@ func (d *MetadataStorePostgres) GetDRepDelegators(
 // in a single query. See sqlite/drep.go for the documented contract.
 func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 	drepCredentials []models.StakeCredentialRef,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64, len(drepCredentials))
@@ -265,29 +250,10 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 		hashes[i] = ref.Key
 		requested[ref.MapKey()] = struct{}{}
 	}
+	sql := drepquery.VotingPowerBatchSQL(db.Name(), expiryEpoch)
+	args := drepquery.CollectionArgs(hashes, expiryEpoch)
 	var rows []row
-	if err := db.Raw(`
-		SELECT a.drep AS drep, a.drep_type AS credential_tag,
-			   COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS BIGINT), 0)
-			   ), 0) AS stake
-		FROM account a
-		LEFT JOIN (
-			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
-				   COALESCE(SUM(CAST(utxo.amount AS BIGINT)), 0) AS utxo_sum
-			FROM account ax
-			JOIN utxo ON utxo.credential_tag = ax.credential_tag
-			         AND utxo.staking_key = ax.staking_key
-			         AND utxo.deleted_slot = 0
-			WHERE ax.active = true AND ax.drep IN ?
-			GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-			AND u.drep_type = a.drep_type
-		WHERE a.active = true AND a.drep IN ?
-		GROUP BY a.drep, a.drep_type
-	`, hashes, hashes).Scan(&rows).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power batch: %w", err)
 	}
 	for _, r := range rows {
@@ -310,6 +276,7 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerBatch(
 // type. It is used for predefined DRep options, which carry no credential.
 func (d *MetadataStorePostgres) GetDRepVotingPowerByType(
 	drepTypes []uint64,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (map[uint64]uint64, error) {
 	out := make(map[uint64]uint64, len(drepTypes))
@@ -327,36 +294,15 @@ func (d *MetadataStorePostgres) GetDRepVotingPowerByType(
 		DrepType uint64
 		Stake    uint64
 	}
+	sql := drepquery.VotingPowerByTypeSQL(db.Name(), expiryEpoch)
+	args := drepquery.CollectionArgs(drepTypes, expiryEpoch)
 	var rows []row
 	// Aggregate UTxO amounts per staking_key in a subquery before
 	// adding account.reward, otherwise the LEFT JOIN would multiply
 	// the per-account reward by the number of live UTxOs and inflate
 	// the totals. Each account contributes (utxo_sum + reward) once
 	// to its drep_type bucket.
-	if err := db.Raw(`
-		SELECT a.drep_type AS drep_type,
-			   COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS BIGINT), 0)
-			   ), 0) AS stake
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS BIGINT)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.active = true AND ax.drep_type IN ?
-			  )
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-		WHERE a.active = true AND a.drep_type IN ?
-		GROUP BY a.drep_type
-	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power by type: %w", err)
 	}
 	for _, r := range rows {

--- a/database/plugin/metadata/postgres/drep_test.go
+++ b/database/plugin/metadata/postgres/drep_test.go
@@ -45,11 +45,12 @@ func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 
 	require.NoError(t, pgStore.SetDrep(0, rewardOnlyCred, 1000, "", nil, true, nil))
 	require.NoError(t, pgStore.DB().Create(&models.Account{
-		StakingKey: rewardOnlyStake,
-		Drep:       rewardOnlyCred,
-		Reward:     types.Uint64(700),
-		Active:     true,
-		AddedSlot:  1000,
+		StakingKey:      rewardOnlyStake,
+		Drep:            rewardOnlyCred,
+		Reward:          types.Uint64(700),
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: 4,
 	}).Error)
 
 	multiUtxoCred := []byte("drep_multi_utxo_1234567890123456789012345")
@@ -57,11 +58,12 @@ func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 
 	require.NoError(t, pgStore.SetDrep(0, multiUtxoCred, 1000, "", nil, true, nil))
 	require.NoError(t, pgStore.DB().Create(&models.Account{
-		StakingKey: multiUtxoStake,
-		Drep:       multiUtxoCred,
-		Reward:     types.Uint64(500),
-		Active:     true,
-		AddedSlot:  1000,
+		StakingKey:      multiUtxoStake,
+		Drep:            multiUtxoCred,
+		Reward:          types.Uint64(500),
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: 6,
 	}).Error)
 	require.NoError(t, pgStore.DB().Create(&models.Utxo{
 		TxId:       []byte("tx_reward_123456789012345678901234567890"),
@@ -83,17 +85,37 @@ func TestPostgresGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 			{Tag: 0, Key: rewardOnlyCred},
 			{Tag: 0, Key: multiUtxoCred},
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), powers[models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey()])
 	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
 
-	singlePower, err := pgStore.GetDRepVotingPower(0, rewardOnlyCred, nil)
+	singlePower, err := pgStore.GetDRepVotingPower(0, rewardOnlyCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(700), singlePower)
 
-	singlePower, err = pgStore.GetDRepVotingPower(0, multiUtxoCred, nil)
+	singlePower, err = pgStore.GetDRepVotingPower(0, multiUtxoCred, 0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), singlePower)
+
+	powers, err = pgStore.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{
+			{Tag: 0, Key: rewardOnlyCred},
+			{Tag: 0, Key: multiUtxoCred},
+		},
+		5,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, powers, models.StakeCredentialRef{Tag: 0, Key: rewardOnlyCred}.MapKey())
+	assert.Equal(t, uint64(1000), powers[models.StakeCredentialRef{Tag: 0, Key: multiUtxoCred}.MapKey()])
+
+	singlePower, err = pgStore.GetDRepVotingPower(0, rewardOnlyCred, 5, nil)
+	require.NoError(t, err)
+	assert.Zero(t, singlePower)
+	singlePower, err = pgStore.GetDRepVotingPower(0, multiUtxoCred, 5, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1000), singlePower)
 }
@@ -131,12 +153,13 @@ func TestPostgresGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *test
 
 	powers, err := pgStore.GetDRepVotingPowerBatch(
 		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1200), powers[models.StakeCredentialRef{Tag: 0, Key: drepCred}.MapKey()])
 
-	singlePower, err := pgStore.GetDRepVotingPower(0, drepCred, nil)
+	singlePower, err := pgStore.GetDRepVotingPower(0, drepCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1200), singlePower)
 }
@@ -177,11 +200,11 @@ func TestPostgresGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 		AddedSlot:     1000,
 	}).Error)
 
-	keyPower, err := pgStore.GetDRepVotingPower(0, sharedHash, nil)
+	keyPower, err := pgStore.GetDRepVotingPower(0, sharedHash, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(100), keyPower, "key-hash DRep power should be 100")
 
-	scriptPower, err := pgStore.GetDRepVotingPower(1, sharedHash, nil)
+	scriptPower, err := pgStore.GetDRepVotingPower(1, sharedHash, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(200), scriptPower, "script-hash DRep power should be 200")
 
@@ -190,6 +213,7 @@ func TestPostgresGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 			{Tag: 0, Key: sharedHash},
 			{Tag: 1, Key: sharedHash},
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -1212,6 +1212,8 @@ func (d *MetadataStorePostgres) GetStakeByPools(
 func (d *MetadataStorePostgres) GetStakeByPoolsAtSlot(
 	poolKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	txn types.Txn,
 ) (map[string]uint64, map[string]uint64, error) {
 	db, err := d.resolveReadDB(txn)
@@ -1225,6 +1227,8 @@ func (d *MetadataStorePostgres) GetStakeByPoolsAtSlot(
 		db,
 		poolKeyHashes,
 		slot,
+		expiryEpoch,
+		inactivityPeriod,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("GetStakeByPoolsAtSlot: %w", err)
@@ -1235,6 +1239,8 @@ func (d *MetadataStorePostgres) GetStakeByPoolsAtSlot(
 func (d *MetadataStorePostgres) GetPoolOwnerStakeAtSlot(
 	ownerKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	db, err := d.resolveReadDB(txn)
@@ -1242,6 +1248,6 @@ func (d *MetadataStorePostgres) GetPoolOwnerStakeAtSlot(
 		return nil, err
 	}
 	return stakequery.GetPoolOwnerStakeAtSlot(
-		db, ownerKeyHashes, slot,
+		db, ownerKeyHashes, slot, expiryEpoch, inactivityPeriod,
 	)
 }

--- a/database/plugin/metadata/postgres/pool_atslot_test.go
+++ b/database/plugin/metadata/postgres/pool_atslot_test.go
@@ -58,7 +58,7 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsPostgres(t *testing.T) {
 	}
 
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
-		[][]byte{poolA, poolB, poolEmpty}, 80, nil,
+		[][]byte{poolA, poolB, poolEmpty}, 80, 0, 0, nil,
 	)
 	require.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres(t *testing.T) {
 	}
 
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
-		[][]byte{poolA, poolB}, 80, nil,
+		[][]byte{poolA, poolB}, 80, 0, 0, nil,
 	)
 	require.NoError(t, err)
 
@@ -171,4 +171,92 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres(t *testing.T) {
 	require.Equal(t, uint64(2), delegators[string(poolA)])
 	require.Equal(t, uint64(40), stakes[string(poolB)])
 	require.Equal(t, uint64(1), delegators[string(poolB)])
+}
+
+// TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres exercises the
+// CIP-0163 gated reward-input path on postgres. With the gate on it must
+// reconstruct expiration at slot from the shared historical CTE (not the live
+// account.expiration_epoch column) so the reward-basis inputs agree with
+// GetStakeByPoolsAtSlot. Postgres type-checks the full query at parse time,
+// catching backend-specific regressions the sqlite test cannot.
+func TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	pool := bytes.Repeat([]byte{0xD5}, 28)
+	active := bytes.Repeat([]byte{0x2A}, 28)
+	expired := bytes.Repeat([]byte{0x2B}, 28)
+
+	cleanup := func() {
+		for _, k := range [][]byte{active, expired} {
+			_ = db.Where("staking_key = ?", k).Delete(&models.Account{}).Error
+			_ = db.Where("staking_key = ?", k).Delete(&models.Utxo{}).Error
+			_ = db.Where("staking_key = ?", k).
+				Delete(&models.AccountWithdrawalWitness{}).Error
+			_ = db.Where("staking_key = ?", k).
+				Delete(&models.RewardLiveStake{}).Error
+		}
+		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+	accounts := []models.Account{
+		{
+			StakingKey: active, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		},
+		{
+			StakingKey: expired, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x63}, 32), StakingKey: active, Amount: 100, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x64}, 32), StakingKey: expired, Amount: 40, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: active, AddedSlot: 250, TxHash: bytes.Repeat([]byte{0x73}, 32),
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: expired, AddedSlot: 50, TxHash: bytes.Repeat([]byte{0x74}, 32),
+	}).Error)
+	live := []models.RewardLiveStake{
+		{
+			PoolKeyHash: pool, StakingKey: active, CredentialTag: 0,
+			TotalStake: types.Uint64(100), Registered: true,
+		},
+		{
+			PoolKeyHash: pool, StakingKey: expired, CredentialTag: 0,
+			TotalStake: types.Uint64(40), Registered: true,
+		},
+	}
+	for i := range live {
+		require.NoError(t, db.Create(&live[i]).Error)
+	}
+
+	// Gate off: live aggregate returns both inputs.
+	inputs, err := store.GetRewardStakeInputsForPools([][]byte{pool}, 250, 0, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+
+	// Gate on: expiration reconstructed at slot 250 excludes the expired-at-slot
+	// credential; a live-column filter would have kept both (both live epoch 7).
+	inputs, err = store.GetRewardStakeInputsForPools([][]byte{pool}, 250, 3, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.Equal(t, active, inputs[0].StakingKey)
+	require.Equal(t, uint64(100), uint64(inputs[0].Stake))
 }

--- a/database/plugin/metadata/postgres/reward_state.go
+++ b/database/plugin/metadata/postgres/reward_state.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/rewardstate"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -156,12 +157,25 @@ func (d *MetadataStorePostgres) GetRewardPoolInputs(
 	return rewardstate.GetPoolInputs(db, epoch)
 }
 
-func (d *MetadataStorePostgres) GetRewardStakeInputsForPools(poolKeyHashes [][]byte, txn types.Txn) ([]*models.RewardStakeInput, error) {
+func (d *MetadataStorePostgres) GetRewardStakeInputsForPools(poolKeyHashes [][]byte, slot uint64, expiryEpoch uint64, inactivityPeriod uint64, txn types.Txn) ([]*models.RewardStakeInput, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf("GetRewardStakeInputsForPools: resolve db: %w", err)
 	}
-	inputs, err := rewardstate.StakeInputsForPools(db, poolKeyHashes, 1000)
+	// CIP-0163 gate on: reconstruct reward inputs at slot from the same
+	// historical CTE the leader-election path uses so both halves of the
+	// snapshot agree by construction. Gate off: read the live aggregate,
+	// byte-identical to the pre-CIP query.
+	if expiryEpoch > 0 {
+		inputs, err := stakequery.GetRewardStakeInputsByPoolsAtSlot(
+			db, poolKeyHashes, slot, expiryEpoch, inactivityPeriod,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("GetRewardStakeInputsForPools: %w", err)
+		}
+		return inputs, nil
+	}
+	inputs, err := rewardstate.StakeInputsForPools(db, poolKeyHashes, 1000, expiryEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("GetRewardStakeInputsForPools: %w", err)
 	}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountsums"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/collateralfee"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
@@ -2808,7 +2809,7 @@ func (d *MetadataStorePostgres) applyTransactionRewardWithdrawals(
 	txn types.Txn,
 ) error {
 	for addr, amount := range withdrawals {
-		if addr == nil || amount == nil || amount.Sign() == 0 {
+		if addr == nil || amount == nil {
 			continue
 		}
 		if amount.Sign() < 0 || !amount.IsUint64() {
@@ -2825,6 +2826,16 @@ func (d *MetadataStorePostgres) applyTransactionRewardWithdrawals(
 		credentialTag, ok := models.StakeCredentialTagFromAddress(*addr)
 		if !ok {
 			return errors.New("derive reward withdrawal credential tag")
+		}
+		db, err := d.resolveDB(txn)
+		if err != nil {
+			return err
+		}
+		if err := accountwitness.RecordWithdrawal(db, models.NewStakeCredentialRef(credentialTag, stakeKeyHash.Bytes()), txHash, slot); err != nil {
+			return err
+		}
+		if amount.Sign() == 0 {
+			continue
 		}
 		if err := d.ApplyAccountRewardWithdrawal(
 			credentialTag,

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -796,7 +796,7 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 // set-based UPDATE. Each ref contributes two bind vars (credential_tag,
 // staking_key) plus the shared SET value, so this keeps the total under the
 // self-imposed sqliteBindVarLimit (mirrors markUtxosDeletedChunkSize).
-const renewAccountExpirationsChunkSize = sqliteBindVarLimit / 2
+const renewAccountExpirationsChunkSize = (sqliteBindVarLimit - 1) / 2
 
 // RenewAccountExpirations sets expiration_epoch for every existing account
 // row matching one of refs. Rows with no match are ignored (an account must

--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -18,8 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -790,6 +792,181 @@ func (d *MetadataStoreSqlite) GetAccountsByCredential(
 	return ret, nil
 }
 
+// renewAccountExpirationsChunkSize bounds the number of credentials per
+// set-based UPDATE. Each ref contributes two bind vars (credential_tag,
+// staking_key) plus the shared SET value, so this keeps the total under the
+// self-imposed sqliteBindVarLimit (mirrors markUtxosDeletedChunkSize).
+const renewAccountExpirationsChunkSize = sqliteBindVarLimit / 2
+
+// RenewAccountExpirations sets expiration_epoch for every existing account
+// row matching one of refs. Rows with no match are ignored (an account must
+// be registered to have an expiration). Credentials are updated in set-based
+// batches — one UPDATE per chunk rather than one per credential — so a large
+// rollback recompute does not hold the ledger write transaction open across
+// thousands of single-row round-trips.
+func (d *MetadataStoreSqlite) RenewAccountExpirations(
+	refs []models.StakeCredentialRef,
+	expirationEpoch uint64,
+	txn types.Txn,
+) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(refs); start += renewAccountExpirationsChunkSize {
+		end := min(start+renewAccountExpirationsChunkSize, len(refs))
+		chunk := refs[start:end]
+		// GORM's tuple-IN handling unpacks []byte arguments byte-by-byte across
+		// drivers, so build an OR chain with parallel (credential_tag,
+		// staking_key) equality predicates instead (see MarkUtxosDeletedAtSlot).
+		var clauses strings.Builder
+		args := make([]any, 0, 1+2*len(chunk))
+		args = append(args, expirationEpoch)
+		for i, ref := range chunk {
+			if i > 0 {
+				clauses.WriteString(" OR ")
+			}
+			clauses.WriteString("(credential_tag = ? AND staking_key = ?)")
+			args = append(args, ref.Tag, ref.Key)
+		}
+		if err := db.Exec(
+			"UPDATE account SET expiration_epoch = ? WHERE "+clauses.String(),
+			args...,
+		).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AccountLastWitnessSlots returns, per requested credential, the greatest
+// witnessing added_slot <= maxSlot across the stake-witnessing certificate
+// tables and the reward-withdrawal history (account_reward_delta where
+// withdrawal = TRUE). The witness set matches CIP-0163 exactly (see
+// accountwitness.CertTableNames and the ledger's witnessedRewardCredentials).
+// The result is keyed by StakeCredentialRef.MapKey(); a credential with no
+// witness <= maxSlot is absent from the map.
+//
+// The SQL IN clause filters on the staking-key hash only (like batchFetchCerts)
+// and the result is post-filtered to the requested composite (tag, hash) keys,
+// so credentials sharing a hash but differing in tag stay isolated.
+func (d *MetadataStoreSqlite) AccountLastWitnessSlots(
+	refs []models.StakeCredentialRef,
+	maxSlot uint64,
+	txn types.Txn,
+) (map[string]uint64, error) {
+	if len(refs) == 0 {
+		return map[string]uint64{}, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.LastSlots(db, refs, maxSlot, sqliteBindVarLimit)
+}
+
+// AccountsWitnessedAfterSlot returns the distinct reward-account credentials
+// that have a stake-witnessing certificate OR a reward withdrawal at
+// added_slot > slot. It is the CIP-0163 rollback affected set: the credentials
+// whose expiration_epoch may have been renewed by a now-orphaned witness and
+// therefore must be recomputed against the surviving chain. The witness set
+// matches AccountLastWitnessSlots (cert tables + withdrawal history). Callers
+// must invoke this before deleting rolled-back certificate and reward-delta
+// rows, since those are exactly the rows this query inspects.
+func (d *MetadataStoreSqlite) AccountsWitnessedAfterSlot(
+	slot uint64,
+	txn types.Txn,
+) ([]models.StakeCredentialRef, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.AfterSlot(db, slot)
+}
+
+// StampAllActiveAccountExpirations sets expiration_epoch = expirationEpoch for
+// every active account. Used once at CIP-0163 activation to give every
+// pre-existing account a full inactivity window starting at the activation
+// epoch, including accounts witnessed before activation. Returns the number of
+// rows stamped.
+func (d *MetadataStoreSqlite) StampAllActiveAccountExpirations(
+	expirationEpoch uint64,
+	txn types.Txn,
+) (int64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	if err := db.Exec(`
+		INSERT INTO account_inactivity_activation (credential_tag, staking_key)
+		SELECT credential_tag, staking_key
+		FROM account
+		WHERE active = ?`,
+		true,
+	).Error; err != nil {
+		return 0, err
+	}
+	res := db.Model(&models.Account{}).
+		Where("active = ?", true).
+		Update("expiration_epoch", expirationEpoch)
+	return res.RowsAffected, res.Error
+}
+
+func (d *MetadataStoreSqlite) AccountInactivityActivationMembership(
+	refs []models.StakeCredentialRef,
+	txn types.Txn,
+) (map[string]struct{}, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return accountwitness.ActivationMembership(
+		db,
+		refs,
+		renewAccountExpirationsChunkSize,
+	)
+}
+
+func (d *MetadataStoreSqlite) ResetAccountExpirationActivation(
+	txn types.Txn,
+) ([]models.StakeCredentialRef, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var activations []models.AccountInactivityActivation
+	if err := db.Find(&activations).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Exec(`
+		UPDATE account
+		SET expiration_epoch = 0
+		WHERE EXISTS (
+			SELECT 1
+			FROM account_inactivity_activation activation
+			WHERE activation.credential_tag = account.credential_tag
+				AND activation.staking_key = account.staking_key
+		)`,
+	).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Where("1 = 1").
+		Delete(&models.AccountInactivityActivation{}).Error; err != nil {
+		return nil, err
+	}
+	refs := make([]models.StakeCredentialRef, 0, len(activations))
+	for _, activation := range activations {
+		refs = append(refs, models.NewStakeCredentialRef(
+			activation.CredentialTag,
+			activation.StakingKey,
+		))
+	}
+	return refs, nil
+}
+
 // AddAccountRewardByCredential credits a registered reward account.
 func (d *MetadataStoreSqlite) AddAccountRewardByCredential(
 	credentialTag uint8,
@@ -1103,6 +1280,10 @@ func (d *MetadataStoreSqlite) DeleteAccountRewardsAfterSlot(
 			"added_slot > ?",
 			slot,
 		).Delete(&models.AccountRewardDelta{}); result.Error != nil {
+			return result.Error
+		}
+		if result := tx.Where("added_slot > ?", slot).
+			Delete(&models.AccountWithdrawalWitness{}); result.Error != nil {
 			return result.Error
 		}
 		return refreshRewardLiveStakeAggregates(tx, refs)

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -15,6 +15,8 @@
 package sqlite
 
 import (
+	"bytes"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -23,6 +25,308 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestAccountExpirationEpochRoundTrip pins that Account.ExpirationEpoch (the
+// CIP-0163 delegator-inactivity column) persists through GORM's AutoMigrate
+// and survives a create/reload round trip like the other plain-column
+// account fields (e.g. DrepType).
+func TestAccountExpirationEpochRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xEE
+	}
+
+	acct := &models.Account{
+		StakingKey:      stakeKey,
+		CredentialTag:   0,
+		ExpirationEpoch: 123,
+	}
+	require.NoError(t, db.Create(acct).Error)
+
+	var got models.Account
+	require.NoError(t, db.First(&got, acct.ID).Error)
+	assert.Equal(t, uint64(123), got.ExpirationEpoch)
+}
+
+// TestRenewAccountExpirations pins the CIP-0163 write primitive that sets
+// expiration_epoch for a set of reward-account credentials: matching rows
+// are updated in place, and a ref with no matching account row is silently
+// ignored (no error, no row created), since an account must already be
+// registered to have an expiration.
+func TestRenewAccountExpirations(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	keyA := make([]byte, 28)
+	for i := range keyA {
+		keyA[i] = 0xA4
+	}
+	keyB := make([]byte, 28)
+	for i := range keyB {
+		keyB[i] = 0xB4
+	}
+	keyMissing := make([]byte, 28)
+	for i := range keyMissing {
+		keyMissing[i] = 0xC4
+	}
+
+	acctA := &models.Account{StakingKey: keyA, CredentialTag: 0}
+	require.NoError(t, db.Create(acctA).Error)
+	acctB := &models.Account{StakingKey: keyB, CredentialTag: 0}
+	require.NoError(t, db.Create(acctB).Error)
+
+	refs := []models.StakeCredentialRef{
+		models.NewStakeCredentialRef(0, keyA),
+		models.NewStakeCredentialRef(0, keyB),
+		models.NewStakeCredentialRef(0, keyMissing), // no row => ignored
+	}
+	require.NoError(t, store.RenewAccountExpirations(refs, 150, nil))
+
+	var gotA models.Account
+	require.NoError(t, db.First(&gotA, acctA.ID).Error)
+	assert.Equal(t, uint64(150), gotA.ExpirationEpoch)
+
+	var gotB models.Account
+	require.NoError(t, db.First(&gotB, acctB.ID).Error)
+	assert.Equal(t, uint64(150), gotB.ExpirationEpoch)
+
+	var count int64
+	require.NoError(
+		t,
+		db.Model(&models.Account{}).
+			Where("credential_tag = ? AND staking_key = ?", 0, keyMissing).
+			Count(&count).Error,
+	)
+	assert.Equal(t, int64(0), count, "no row should be created for a missing credential")
+}
+
+// TestRenewAccountExpirations_EmptyRefsIsNoop verifies that an empty refs
+// slice is a no-op that returns nil without touching the store.
+func TestRenewAccountExpirations_EmptyRefsIsNoop(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	require.NoError(t, store.RenewAccountExpirations(nil, 150, nil))
+}
+
+// TestRenewAccountExpirations_Chunking exercises the set-based batch UPDATE
+// across chunk boundaries: it renews more credentials than fit in a single
+// chunk (renewAccountExpirationsChunkSize) in one call, interleaving both
+// credential tags, and confirms every matching row is updated while a missing
+// credential threaded through the batch is still silently ignored.
+func TestRenewAccountExpirations_Chunking(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	// Span more than two chunks so the batching loop runs at least three times.
+	const total = renewAccountExpirationsChunkSize*2 + 5
+	mkKey := func(i int) []byte {
+		key := make([]byte, 28)
+		key[0] = byte(i >> 8)
+		key[1] = byte(i)
+		key[2] = 0xEE
+		return key
+	}
+
+	refs := make([]models.StakeCredentialRef, 0, total+1)
+	ids := make([]uint, 0, total)
+	for i := range total {
+		tag := uint8(i % 2) // interleave key- and script-credential tags
+		key := mkKey(i)
+		acct := &models.Account{StakingKey: key, CredentialTag: tag}
+		require.NoError(t, db.Create(acct).Error)
+		ids = append(ids, acct.ID)
+		refs = append(refs, models.NewStakeCredentialRef(tag, key))
+	}
+	// Thread a missing credential through the batch to confirm it is ignored.
+	missing := mkKey(total + 1)
+	refs = append(refs, models.NewStakeCredentialRef(0, missing))
+
+	require.NoError(t, store.RenewAccountExpirations(refs, 777, nil))
+
+	for _, id := range ids {
+		var got models.Account
+		require.NoError(t, db.First(&got, id).Error)
+		assert.Equal(t, uint64(777), got.ExpirationEpoch)
+	}
+	var count int64
+	require.NoError(t,
+		db.Model(&models.Account{}).
+			Where("credential_tag = ? AND staking_key = ?", 0, missing).
+			Count(&count).Error,
+	)
+	assert.Equal(t, int64(0), count, "missing credential must not be created")
+}
+
+// TestStampAllActiveAccountExpirations pins the CIP-0163 one-time activation
+// write primitive: every active account is stamped to expirationEpoch,
+// including an account whose pre-activation witness already started its
+// inactivity clock. An inactive account is never stamped regardless of its
+// expiration_epoch. Returns the count of rows actually stamped.
+func TestStampAllActiveAccountExpirations(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	keyUnsetA := make([]byte, 28)
+	for i := range keyUnsetA {
+		keyUnsetA[i] = 0xD1
+	}
+	keyUnsetB := make([]byte, 28)
+	for i := range keyUnsetB {
+		keyUnsetB[i] = 0xD2
+	}
+	keyPreset := make([]byte, 28)
+	for i := range keyPreset {
+		keyPreset[i] = 0xD3
+	}
+	keyInactive := make([]byte, 28)
+	for i := range keyInactive {
+		keyInactive[i] = 0xD4
+	}
+
+	acctUnsetA := &models.Account{
+		StakingKey:    keyUnsetA,
+		CredentialTag: 0,
+		Active:        true,
+	}
+	require.NoError(t, db.Create(acctUnsetA).Error)
+	acctUnsetB := &models.Account{
+		StakingKey:    keyUnsetB,
+		CredentialTag: 0,
+		Active:        true,
+	}
+	require.NoError(t, db.Create(acctUnsetB).Error)
+	acctPreset := &models.Account{
+		StakingKey:      keyPreset,
+		CredentialTag:   0,
+		Active:          true,
+		ExpirationEpoch: 5,
+	}
+	require.NoError(t, db.Create(acctPreset).Error)
+	acctInactive := &models.Account{
+		StakingKey:    keyInactive,
+		CredentialTag: 0,
+		Active:        true,
+	}
+	require.NoError(t, db.Create(acctInactive).Error)
+	// GORM's `default:true` on Account.Active swallows an explicit false on
+	// INSERT, so deactivate via a follow-up UPDATE (see
+	// TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse below).
+	require.NoError(t, db.Model(&models.Account{}).
+		Where("staking_key = ?", keyInactive).
+		Update("active", false).Error)
+
+	rows, err := store.StampAllActiveAccountExpirations(150, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), rows, "all three active accounts should be stamped")
+
+	var gotA models.Account
+	require.NoError(t, db.First(&gotA, acctUnsetA.ID).Error)
+	assert.Equal(t, uint64(150), gotA.ExpirationEpoch)
+
+	var gotB models.Account
+	require.NoError(t, db.First(&gotB, acctUnsetB.ID).Error)
+	assert.Equal(t, uint64(150), gotB.ExpirationEpoch)
+
+	var gotPreset models.Account
+	require.NoError(t, db.First(&gotPreset, acctPreset.ID).Error)
+	assert.Equal(
+		t,
+		uint64(150),
+		gotPreset.ExpirationEpoch,
+		"pre-activation witness expiration must be replaced",
+	)
+
+	var gotInactive models.Account
+	require.NoError(t, db.First(&gotInactive, acctInactive.ID).Error)
+	assert.Equal(
+		t,
+		uint64(0),
+		gotInactive.ExpirationEpoch,
+		"inactive account must not be stamped",
+	)
+}
+
+// TestStampAllActiveAccountExpirations_OverwritesExistingExpiration verifies
+// that activation replaces an existing expiration so every active account gets
+// the same activation window.
+func TestStampAllActiveAccountExpirations_OverwritesExistingExpiration(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	stakeKey := make([]byte, 28)
+	for i := range stakeKey {
+		stakeKey[i] = 0xD5
+	}
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey:      stakeKey,
+		CredentialTag:   0,
+		Active:          true,
+		ExpirationEpoch: 200,
+	}).Error)
+
+	rows, err := store.StampAllActiveAccountExpirations(150, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+
+	var got models.Account
+	require.NoError(t, db.Where("staking_key = ?", stakeKey).First(&got).Error)
+	assert.Equal(t, uint64(150), got.ExpirationEpoch)
+}
+
+func TestResetAccountExpirationActivationReturnsClearedCredentials(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	resetKey := bytes.Repeat([]byte{0xD6}, 28)
+	inactiveKey := bytes.Repeat([]byte{0xD7}, 28)
+	postActivationKey := bytes.Repeat([]byte{0xD8}, 28)
+	require.NoError(t, db.Create(&[]models.Account{
+		{
+			StakingKey: resetKey, CredentialTag: 1, Active: true,
+			ExpirationEpoch: 149,
+		},
+		{
+			StakingKey: inactiveKey, CredentialTag: 0, Active: true,
+			ExpirationEpoch: 149,
+		},
+	}).Error)
+	require.NoError(t, db.Model(&models.Account{}).
+		Where("staking_key = ?", inactiveKey).
+		Update("active", false).Error)
+	rows, err := store.StampAllActiveAccountExpirations(150, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+
+	// This account happens to carry the activation value but was created after
+	// activation, so it is not in the durable membership set and must not reset.
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: postActivationKey, Active: true, ExpirationEpoch: 150,
+	}).Error)
+
+	refs, err := store.ResetAccountExpirationActivation(nil)
+	require.NoError(t, err)
+	require.Equal(t, []models.StakeCredentialRef{
+		models.NewStakeCredentialRef(1, resetKey),
+	}, refs)
+
+	var reset, inactive, postActivation models.Account
+	require.NoError(t, db.Where("staking_key = ?", resetKey).First(&reset).Error)
+	require.NoError(t, db.Where("staking_key = ?", inactiveKey).First(&inactive).Error)
+	require.NoError(t, db.Where("staking_key = ?", postActivationKey).
+		First(&postActivation).Error)
+	assert.Zero(t, reset.ExpirationEpoch)
+	assert.Equal(t, uint64(149), inactive.ExpirationEpoch)
+	assert.Equal(t, uint64(150), postActivation.ExpirationEpoch)
+}
 
 // TestGetAccount_ExcludesInactiveWhenIncludeInactiveFalse pins the
 // includeInactive=false branch of GetAccountByCredential: a row with
@@ -570,4 +874,200 @@ func TestBatchFetchCerts_CrossTableTiebreakByBlockIndex(t *testing.T) {
 			"transaction; without block_index in certRecord/isMoreRecent this "+
 			"falls through to batchFetch* iteration order",
 	)
+}
+
+// witnessTestKey builds a 28-byte credential hash filled with b.
+func witnessTestKey(b byte) []byte {
+	out := make([]byte, 28)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+// TestAccountLastWitnessSlots pins the CIP-0163 rollback query surface: for each
+// requested credential it returns the greatest witnessing added_slot <= maxSlot
+// across the stake-witnessing certificate tables AND the reward-withdrawal
+// history (account_reward_delta where withdrawal = TRUE). The brief example:
+// a delegation cert at slot s1 and a reward withdrawal at s2 > s1. maxSlot=s2
+// must return s2 (the withdrawal wins); maxSlot=s1 must return s1 (the later
+// withdrawal is excluded); a maxSlot before any witness leaves the credential
+// absent from the map.
+func TestAccountLastWitnessSlots(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	key := witnessTestKey(0xA1)
+	ref := models.NewStakeCredentialRef(0, key)
+	const (
+		s1 = uint64(1000)
+		s2 = uint64(2000)
+	)
+
+	// Delegation cert (a stake-witnessing cert) at slot s1.
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		StakingKey:    key,
+		CredentialTag: 0,
+		PoolKeyHash:   witnessTestKey(0x0A),
+		AddedSlot:     s1,
+	}).Error)
+	// Reward withdrawal (also a CIP witnessing action) at slot s2 > s1.
+	require.NoError(t, db.Create(&models.AccountRewardDelta{
+		StakingKey:    key,
+		CredentialTag: 0,
+		TxHash:        make([]byte, 32),
+		Amount:        types.Uint64(1_000),
+		AddedSlot:     s2,
+		Withdrawal:    true,
+	}).Error)
+
+	refs := []models.StakeCredentialRef{ref}
+
+	// maxSlot = s2: the withdrawal at s2 is the latest witness <= s2.
+	got, err := store.AccountLastWitnessSlots(refs, s2, nil)
+	require.NoError(t, err)
+	assert.Equal(t, s2, got[ref.MapKey()])
+
+	// maxSlot = s1: the withdrawal at s2 is excluded; the cert at s1 wins.
+	got, err = store.AccountLastWitnessSlots(refs, s1, nil)
+	require.NoError(t, err)
+	assert.Equal(t, s1, got[ref.MapKey()])
+
+	// maxSlot before any witness: absent from the map.
+	got, err = store.AccountLastWitnessSlots(refs, s1-1, nil)
+	require.NoError(t, err)
+	_, present := got[ref.MapKey()]
+	assert.False(t, present, "no witness <= maxSlot means the credential is absent")
+}
+
+// TestAccountLastWitnessSlots_TagIsolation verifies that two credentials sharing
+// a 28-byte hash but differing in tag (key vs script) keep separate last-witness
+// slots, matching the composite (tag, key) identity used throughout the account
+// tables.
+func TestAccountLastWitnessSlots_TagIsolation(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	hash := witnessTestKey(0xB2)
+	keyRef := models.NewStakeCredentialRef(0, hash)
+	scriptRef := models.NewStakeCredentialRef(1, hash)
+
+	require.NoError(t, db.Create(&models.StakeRegistration{
+		StakingKey:    hash,
+		CredentialTag: 0,
+		AddedSlot:     100,
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeRegistration{
+		StakingKey:    hash,
+		CredentialTag: 1,
+		AddedSlot:     200,
+	}).Error)
+
+	got, err := store.AccountLastWitnessSlots(
+		[]models.StakeCredentialRef{keyRef, scriptRef},
+		1000,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), got[keyRef.MapKey()])
+	assert.Equal(t, uint64(200), got[scriptRef.MapKey()])
+}
+
+// TestAccountLastWitnessSlots_EmptyRefsIsNoop verifies an empty refs slice
+// returns an empty map without error.
+func TestAccountLastWitnessSlots_EmptyRefsIsNoop(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	got, err := store.AccountLastWitnessSlots(nil, 1000, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestZeroAmountWithdrawalWitnessHistory(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+	key := witnessTestKey(0xBC)
+	ref := models.NewStakeCredentialRef(0, key)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey, lcommon.AddressNetworkTestnet, nil, key,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.applyTransactionRewardWithdrawals(
+		map[*lcommon.Address]*big.Int{&addr: big.NewInt(0)},
+		2000, make([]byte, 32), nil,
+	))
+	var witnessCount int64
+	require.NoError(t, db.Model(&models.AccountWithdrawalWitness{}).Count(&witnessCount).Error)
+	require.Equal(t, int64(1), witnessCount)
+
+	last, err := store.AccountLastWitnessSlots([]models.StakeCredentialRef{ref}, 2000, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2000), last[ref.MapKey()])
+	affected, err := store.AccountsWitnessedAfterSlot(1500, nil)
+	require.NoError(t, err)
+	require.Equal(t, []models.StakeCredentialRef{ref}, affected)
+	require.NoError(t, store.DeleteAccountRewardsAfterSlot(1500, nil))
+	affected, err = store.AccountsWitnessedAfterSlot(1500, nil)
+	require.NoError(t, err)
+	require.Empty(t, affected)
+}
+
+// TestAccountsWitnessedAfterSlot pins the CIP-0163 rollback affected-set query:
+// it returns every credential with a stake-witnessing cert OR a reward
+// withdrawal at added_slot > slot. A cert-only credential, a withdrawal-only
+// credential, and a credential witnessed only at/before the slot exercise the
+// three cases.
+func TestAccountsWitnessedAfterSlot(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	db := store.DB()
+
+	certKey := witnessTestKey(0xC1) // cert at slot 2000
+	wdrKey := witnessTestKey(0xC2)  // withdrawal at slot 2500
+	oldKey := witnessTestKey(0xC3)  // cert at slot 500 only
+	certRef := models.NewStakeCredentialRef(0, certKey)
+	wdrRef := models.NewStakeCredentialRef(0, wdrKey)
+
+	require.NoError(t, db.Create(&models.StakeDelegation{
+		StakingKey:    certKey,
+		CredentialTag: 0,
+		PoolKeyHash:   witnessTestKey(0x0A),
+		AddedSlot:     2000,
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountRewardDelta{
+		StakingKey:    wdrKey,
+		CredentialTag: 0,
+		TxHash:        make([]byte, 32),
+		Amount:        types.Uint64(5),
+		AddedSlot:     2500,
+		Withdrawal:    true,
+	}).Error)
+	require.NoError(t, db.Create(&models.StakeRegistration{
+		StakingKey:    oldKey,
+		CredentialTag: 0,
+		AddedSlot:     500,
+	}).Error)
+
+	// Slot 1500: both the cert (2000) and the withdrawal (2500) are after it;
+	// the old cert (500) is not.
+	got, err := store.AccountsWitnessedAfterSlot(1500, nil)
+	require.NoError(t, err)
+	keys := make(map[string]struct{}, len(got))
+	for _, r := range got {
+		keys[r.MapKey()] = struct{}{}
+	}
+	_, hasCert := keys[certRef.MapKey()]
+	_, hasWdr := keys[wdrRef.MapKey()]
+	_, hasOld := keys[models.NewStakeCredentialRef(0, oldKey).MapKey()]
+	assert.True(t, hasCert, "cert witnessed at 2000 must be in the affected set for slot 1500")
+	assert.True(t, hasWdr, "withdrawal witnessed at 2500 must be in the affected set for slot 1500")
+	assert.False(t, hasOld, "cert witnessed at 500 must not be in the affected set for slot 1500")
+
+	// Slot 2500: nothing is strictly after it.
+	got, err = store.AccountsWitnessedAfterSlot(2500, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }

--- a/database/plugin/metadata/sqlite/account_test.go
+++ b/database/plugin/metadata/sqlite/account_test.go
@@ -123,6 +123,13 @@ func TestRenewAccountExpirations_Chunking(t *testing.T) {
 	store := setupTestStore(t)
 	db := store.DB()
 
+	require.LessOrEqual(
+		t,
+		1+2*renewAccountExpirationsChunkSize,
+		sqliteBindVarLimit,
+		"chunk bindings must include the shared expiration_epoch value",
+	)
+
 	// Span more than two chunks so the batching loop runs at least three times.
 	const total = renewAccountExpirationsChunkSize*2 + 5
 	mkKey := func(i int) []byte {

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/drepquery"
 	"github.com/blinklabs-io/dingo/database/types"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -63,30 +64,6 @@ type drepCertCache struct {
 	update    map[string]drepCertRecord
 	hasUpdate map[string]bool
 }
-
-const getDRepVotingPowerBatchSQL = `
-	SELECT a.drep AS drep, a.drep_type AS credential_tag,
-		   COALESCE(SUM(
-			   COALESCE(u.utxo_sum, 0)
-			   + COALESCE(CAST(a.reward AS INTEGER), 0)
-		   ), 0) AS stake
-	FROM account a
-	LEFT JOIN (
-			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
-				   COALESCE(SUM(CAST(utxo.amount AS INTEGER)), 0) AS utxo_sum
-			FROM account ax
-			JOIN utxo INDEXED BY ` + utxoStakingLiveAmountIndex + `
-			         ON utxo.credential_tag = ax.credential_tag
-			         AND utxo.staking_key = ax.staking_key
-			         AND utxo.deleted_slot = 0
-		WHERE ax.active = 1 AND ax.drep IN ?
-		GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
-	) u ON u.credential_tag = a.credential_tag
-		AND u.staking_key = a.staking_key
-		AND u.drep_type = a.drep_type
-	WHERE a.active = 1 AND a.drep IN ?
-	GROUP BY a.drep, a.drep_type
-`
 
 // newDrepCertCache creates an empty DRep certificate cache.
 func newDrepCertCache(capacity int) *drepCertCache {
@@ -590,6 +567,7 @@ func (d *MetadataStoreSqlite) InsertDrepIfAbsent(
 func (d *MetadataStoreSqlite) GetDRepVotingPower(
 	credentialTag uint8,
 	drepCredential []byte,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (uint64, error) {
 	db, err := d.resolveReadDB(txn)
@@ -597,29 +575,12 @@ func (d *MetadataStoreSqlite) GetDRepVotingPower(
 		return 0, err
 	}
 
+	sql, args := drepquery.VotingPowerSQL(
+		db.Name(), credentialTag, drepCredential, expiryEpoch,
+	)
+
 	var totalStake uint64
-	if err := db.Raw(`
-		SELECT COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS INTEGER), 0)
-			   ), 0)
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.drep = ? AND ax.drep_type = ? AND ax.active = 1
-			  )
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-		WHERE a.drep = ? AND a.drep_type = ? AND a.active = 1
-	`, drepCredential, credentialTag, drepCredential, credentialTag).Scan(&totalStake).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&totalStake).Error; err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}
 
@@ -668,6 +629,7 @@ func (d *MetadataStoreSqlite) GetDRepDelegators(
 // tallying governance votes across many active DReps.
 func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 	drepCredentials []models.StakeCredentialRef,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	out := make(map[string]uint64, len(drepCredentials))
@@ -693,13 +655,18 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 		hashes[i] = ref.Key
 		requested[ref.MapKey()] = struct{}{}
 	}
+	sql := drepquery.VotingPowerBatchSQL(db.Name(), expiryEpoch)
 	for start := 0; start < len(hashes); start += sqliteBindVarLimit {
 		end := min(start+sqliteBindVarLimit, len(hashes))
 		chunk := hashes[start:end]
 		var rows []row
+		// Bind order must match the text order produced by
+		// VotingPowerBatchSQL: inner expiry, inner IN, outer
+		// expiry, outer IN. expiryEpoch == 0 omits both expiry args.
+		args := drepquery.CollectionArgs(chunk, expiryEpoch)
 		// Aggregate UTxO amounts per (staking_key, drep_type) before
 		// adding account.reward to avoid fan-out from the LEFT JOIN.
-		if err := db.Raw(getDRepVotingPowerBatchSQL, chunk, chunk).Scan(&rows).Error; err != nil {
+		if err := db.Raw(sql, args...).Scan(&rows).Error; err != nil {
 			return nil, fmt.Errorf("get drep voting power batch: %w", err)
 		}
 		for _, r := range rows {
@@ -723,6 +690,7 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerBatch(
 // type. It is used for predefined DRep options, which carry no credential.
 func (d *MetadataStoreSqlite) GetDRepVotingPowerByType(
 	drepTypes []uint64,
+	expiryEpoch uint64,
 	txn types.Txn,
 ) (map[uint64]uint64, error) {
 	out := make(map[uint64]uint64, len(drepTypes))
@@ -740,36 +708,15 @@ func (d *MetadataStoreSqlite) GetDRepVotingPowerByType(
 		DrepType uint64
 		Stake    uint64
 	}
+	sql := drepquery.VotingPowerByTypeSQL(db.Name(), expiryEpoch)
+	args := drepquery.CollectionArgs(drepTypes, expiryEpoch)
 	var rows []row
 	// Aggregate UTxO amounts per staking_key in a subquery before
 	// adding account.reward, otherwise the LEFT JOIN would multiply
 	// the per-account reward by the number of live UTxOs and inflate
 	// the totals. Each account contributes (utxo_sum + reward) once
 	// to its drep_type bucket.
-	if err := db.Raw(`
-		SELECT a.drep_type AS drep_type,
-			   COALESCE(SUM(
-				   COALESCE(u.utxo_sum, 0)
-				   + COALESCE(CAST(a.reward AS INTEGER), 0)
-			   ), 0) AS stake
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-				   COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			  AND EXISTS (
-				  SELECT 1 FROM account ax
-				  WHERE ax.credential_tag = utxo.credential_tag
-				    AND ax.staking_key = utxo.staking_key
-				    AND ax.active = 1 AND ax.drep_type IN ?
-			  )
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag
-			AND u.staking_key = a.staking_key
-		WHERE a.active = 1 AND a.drep_type IN ?
-		GROUP BY a.drep_type
-	`, drepTypes, drepTypes).Scan(&rows).Error; err != nil {
+	if err := db.Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("get drep voting power by type: %w", err)
 	}
 	for _, r := range rows {

--- a/database/plugin/metadata/sqlite/drep_test.go
+++ b/database/plugin/metadata/sqlite/drep_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/drepquery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func TestSqliteGetDRepVotingPowerIncludesReward(t *testing.T) {
 		AddedSlot:  1000,
 	}).Error)
 
-	power, err := store.GetDRepVotingPower(0, drepCred, nil)
+	power, err := store.GetDRepVotingPower(0, drepCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1700), power)
 }
@@ -112,6 +113,7 @@ func TestSqliteGetDRepVotingPowerBatchIncludesReward(t *testing.T) {
 			{Tag: 0, Key: rewardOnlyCred},
 			{Tag: 0, Key: multiUtxoCred},
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -151,6 +153,7 @@ func TestSqliteGetDRepVotingPowerBatchDoesNotMultiplyRewardAcrossUTxOs(t *testin
 
 	powers, err := store.GetDRepVotingPowerBatch(
 		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -204,6 +207,7 @@ func TestSqliteGetDRepVotingPowerBatchUsesStakeCredentialUtxoIndex(t *testing.T)
 
 	powers, err := store.GetDRepVotingPowerBatch(
 		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -212,11 +216,11 @@ func TestSqliteGetDRepVotingPowerBatchUsesStakeCredentialUtxoIndex(t *testing.T)
 		uint64(1000),
 		powers[models.StakeCredentialRef{Tag: 0, Key: drepCred}.MapKey()],
 	)
-	require.Contains(t, getDRepVotingPowerBatchSQL, "INDEXED BY "+utxoStakingLiveAmountIndex)
+	require.Contains(t, drepquery.VotingPowerBatchSQL("sqlite", 0), "INDEXED BY "+utxoStakingLiveAmountIndex)
 
 	planRows, err := store.DB().
 		Raw(
-			"EXPLAIN QUERY PLAN "+getDRepVotingPowerBatchSQL,
+			"EXPLAIN QUERY PLAN "+drepquery.VotingPowerBatchSQL("sqlite", 0),
 			[][]byte{drepCred},
 			[][]byte{drepCred},
 		).Rows()
@@ -281,12 +285,13 @@ func TestSqliteGetDRepVotingPowerUsesStakeCredentialTag(t *testing.T) {
 		AddedSlot:     1000,
 	}).Error)
 
-	power, err := store.GetDRepVotingPower(0, drepCred, nil)
+	power, err := store.GetDRepVotingPower(0, drepCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(330), power)
 
 	powers, err := store.GetDRepVotingPowerBatch(
 		[]models.StakeCredentialRef{{Tag: 0, Key: drepCred}},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -336,6 +341,7 @@ func TestSqliteGetDRepVotingPowerByTypeUsesStakeCredentialTag(t *testing.T) {
 
 	powers, err := store.GetDRepVotingPowerByType(
 		[]uint64{models.DrepTypeAlwaysAbstain},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -382,12 +388,12 @@ func TestSqliteGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 	}).Error)
 
 	// GetDRepVotingPower for key-hash DRep must only see the key account (100).
-	keyPower, err := store.GetDRepVotingPower(0, sharedHash, nil)
+	keyPower, err := store.GetDRepVotingPower(0, sharedHash, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(100), keyPower, "key-hash DRep power should be 100")
 
 	// GetDRepVotingPower for script-hash DRep must only see the script account (200).
-	scriptPower, err := store.GetDRepVotingPower(1, sharedHash, nil)
+	scriptPower, err := store.GetDRepVotingPower(1, sharedHash, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(200), scriptPower, "script-hash DRep power should be 200")
 
@@ -397,6 +403,7 @@ func TestSqliteGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 			{Tag: 0, Key: sharedHash},
 			{Tag: 1, Key: sharedHash},
 		},
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -404,6 +411,200 @@ func TestSqliteGetDRepVotingPowerCrossTagIsolation(t *testing.T) {
 		"batch: key-hash DRep power should be 100")
 	assert.Equal(t, uint64(200), powers[models.StakeCredentialRef{Tag: 1, Key: sharedHash}.MapKey()],
 		"batch: script-hash DRep power should be 200")
+}
+
+// TestGetDRepVotingPowerBatchSQLGateOffByteIdentical pins that
+// VotingPowerBatchSQL("sqlite", 0) is byte-identical to the pre-CIP-0163 const
+// query (no expiration_epoch clause, no extra "?" placeholder), and that the
+// gate-on variant adds exactly the two expected placeholders — one in the
+// inner subquery's WHERE (before its "IN ?"), one in the outer WHERE (before
+// its "IN ?") — matching the "inner-expiry, inner-IN, outer-expiry, outer-IN"
+// bind order the batch method builds its args in.
+func TestGetDRepVotingPowerBatchSQLGateOffByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	want := `
+	SELECT a.drep AS drep, a.drep_type AS credential_tag,
+		   COALESCE(SUM(
+			   COALESCE(u.utxo_sum, 0)
+			   + COALESCE(CAST(a.reward AS INTEGER), 0)
+		   ), 0) AS stake
+	FROM account a
+	LEFT JOIN (
+			SELECT ax.drep_type, ax.credential_tag, ax.staking_key,
+				   COALESCE(SUM(CAST(utxo.amount AS INTEGER)), 0) AS utxo_sum
+			FROM account ax
+			JOIN utxo INDEXED BY ` + utxoStakingLiveAmountIndex + `
+			         ON utxo.credential_tag = ax.credential_tag
+			         AND utxo.staking_key = ax.staking_key
+			         AND utxo.deleted_slot = 0
+		WHERE ax.active = 1 AND ax.drep IN ?
+		GROUP BY ax.drep_type, ax.credential_tag, ax.staking_key
+	) u ON u.credential_tag = a.credential_tag
+		AND u.staking_key = a.staking_key
+		AND u.drep_type = a.drep_type
+	WHERE a.active = 1 AND a.drep IN ?
+	GROUP BY a.drep, a.drep_type
+`
+	offSQL := drepquery.VotingPowerBatchSQL("sqlite", 0)
+	assert.Equal(t, want, offSQL, "gate-off SQL must be byte-identical to the pre-CIP query")
+	assert.Equal(t, 2, strings.Count(offSQL, "?"), "gate-off must have exactly the 2 pre-CIP placeholders")
+
+	onSQL := drepquery.VotingPowerBatchSQL("sqlite", 5)
+	assert.NotEqual(t, want, onSQL)
+	assert.Equal(t, 4, strings.Count(onSQL, "?"), "gate-on must add exactly 2 placeholders")
+
+	innerClause := onSQL[strings.Index(onSQL, "WHERE ax.active = 1"):strings.Index(onSQL, "GROUP BY ax.drep_type")]
+	require.Contains(t, innerClause, "ax.expiration_epoch = 0 OR ax.expiration_epoch >= ?")
+	require.Less(
+		t,
+		strings.Index(innerClause, "ax.expiration_epoch"),
+		strings.Index(innerClause, "ax.drep IN ?"),
+		"inner expiry clause must precede the inner IN clause in text order",
+	)
+
+	outerClause := onSQL[strings.Index(onSQL, "WHERE a.active = 1"):strings.Index(onSQL, "GROUP BY a.drep,")]
+	require.Contains(t, outerClause, "a.expiration_epoch = 0 OR a.expiration_epoch >= ?")
+	require.Less(
+		t,
+		strings.Index(outerClause, "a.expiration_epoch"),
+		strings.Index(outerClause, "a.drep IN ?"),
+		"outer expiry clause must precede the outer IN clause in text order",
+	)
+}
+
+// TestSqliteGetDRepVotingPowerBatchExpiryGate is the CIP-0163 TDD case for
+// Task 9: two accounts delegated to one DRep, one active (no expiration) and
+// one with expiration_epoch in the past. With the gate off (expiryEpoch=0)
+// both accounts' stake counts; with the gate on and expiryEpoch set past the
+// expired account's expiration_epoch, only the active account's stake counts.
+func TestSqliteGetDRepVotingPowerBatchExpiryGate(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	drepCred := []byte("drep_expiry_gate_batch_1234567890123456789")
+	activeStake := []byte("stake_expiry_gate_active_batch_123456789")
+	expiredStake := []byte("stake_expiry_gate_expired_batch_12345678")
+
+	require.NoError(t, store.SetDrep(0, drepCred, 1000, "", nil, true, nil))
+
+	const pastEpoch = uint64(10)
+
+	// Active account: ExpirationEpoch 0 (never expires).
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: activeStake,
+		Drep:       drepCred,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	// Expired account: ExpirationEpoch in the past relative to pastEpoch+1.
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:      expiredStake,
+		Drep:            drepCred,
+		Reward:          300,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: pastEpoch,
+	}).Error)
+
+	ref := models.StakeCredentialRef{Tag: 0, Key: drepCred}
+
+	// Gate off: both accounts' reward counts (700 + 300).
+	offPowers, err := store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{ref}, 0, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), offPowers[ref.MapKey()])
+
+	// Gate on with expiryEpoch past the expired account's expiration_epoch:
+	// only the active account's reward (700) counts.
+	onPowers, err := store.GetDRepVotingPowerBatch(
+		[]models.StakeCredentialRef{ref}, pastEpoch+1, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), onPowers[ref.MapKey()])
+}
+
+// TestSqliteGetDRepVotingPowerExpiryGate is the same CIP-0163 exclusion case
+// as TestSqliteGetDRepVotingPowerBatchExpiryGate but exercises the single-DRep
+// GetDRepVotingPower variant, which uses a different query shape (EXISTS
+// subquery, no IN clause) and therefore a different "?" bind order.
+func TestSqliteGetDRepVotingPowerExpiryGate(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	drepCred := []byte("drep_expiry_gate_single_123456789012345678")
+	activeStake := []byte("stake_expiry_gate_active_single_12345678")
+	expiredStake := []byte("stake_expiry_gate_expired_single_1234567")
+
+	require.NoError(t, store.SetDrep(0, drepCred, 1000, "", nil, true, nil))
+
+	const pastEpoch = uint64(10)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: activeStake,
+		Drep:       drepCred,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:      expiredStake,
+		Drep:            drepCred,
+		Reward:          300,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: pastEpoch,
+	}).Error)
+
+	offPower, err := store.GetDRepVotingPower(0, drepCred, 0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), offPower)
+
+	onPower, err := store.GetDRepVotingPower(0, drepCred, pastEpoch+1, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), onPower)
+}
+
+// TestSqliteGetDRepVotingPowerByTypeExpiryGate is the same CIP-0163 exclusion
+// case for the predefined-option (AlwaysAbstain/AlwaysNoConfidence) variant.
+func TestSqliteGetDRepVotingPowerByTypeExpiryGate(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	activeStake := []byte("stake_expiry_gate_active_bytype_1234567")
+	expiredStake := []byte("stake_expiry_gate_expired_bytype_123456")
+
+	const pastEpoch = uint64(10)
+
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: activeStake,
+		DrepType:   models.DrepTypeAlwaysAbstain,
+		Reward:     700,
+		Active:     true,
+		AddedSlot:  1000,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:      expiredStake,
+		DrepType:        models.DrepTypeAlwaysAbstain,
+		Reward:          300,
+		Active:          true,
+		AddedSlot:       1000,
+		ExpirationEpoch: pastEpoch,
+	}).Error)
+
+	offPowers, err := store.GetDRepVotingPowerByType(
+		[]uint64{models.DrepTypeAlwaysAbstain}, 0, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1000), offPowers[models.DrepTypeAlwaysAbstain])
+
+	onPowers, err := store.GetDRepVotingPowerByType(
+		[]uint64{models.DrepTypeAlwaysAbstain}, pastEpoch+1, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(700), onPowers[models.DrepTypeAlwaysAbstain])
 }
 
 func TestSqliteInsertDrepIfAbsentInsertsNewRow(t *testing.T) {

--- a/database/plugin/metadata/sqlite/governance_test.go
+++ b/database/plugin/metadata/sqlite/governance_test.go
@@ -1040,7 +1040,7 @@ func TestGetDRepVotingPower(t *testing.T) {
 	require.NoError(t, err)
 
 	// No delegators = zero voting power
-	power, err := store.GetDRepVotingPower(0, drepCred, nil)
+	power, err := store.GetDRepVotingPower(0, drepCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), power)
 
@@ -1104,7 +1104,7 @@ func TestGetDRepVotingPower(t *testing.T) {
 	require.NoError(t, result.Error)
 
 	// Voting power should be 5M + 3M + 2M = 10M
-	power, err = store.GetDRepVotingPower(0, drepCred, nil)
+	power, err = store.GetDRepVotingPower(0, drepCred, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(10000000), power)
 }
@@ -1115,6 +1115,7 @@ func TestGetDRepVotingPowerByTypeRejectsCredentialTypes(t *testing.T) {
 
 	_, err := store.GetDRepVotingPowerByType(
 		[]uint64{models.DrepTypeAddrKeyHash},
+		0,
 		nil,
 	)
 	require.Error(t, err)
@@ -1122,12 +1123,13 @@ func TestGetDRepVotingPowerByTypeRejectsCredentialTypes(t *testing.T) {
 
 	_, err = store.GetDRepVotingPowerByType(
 		[]uint64{models.DrepTypeScriptHash},
+		0,
 		nil,
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "credential-backed")
 
-	_, err = store.GetDRepVotingPowerByType([]uint64{99}, nil)
+	_, err = store.GetDRepVotingPowerByType([]uint64{99}, 0, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown predefined drep type")
 }

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1273,6 +1273,8 @@ func (d *MetadataStoreSqlite) GetStakeByPools(
 func (d *MetadataStoreSqlite) GetStakeByPoolsAtSlot(
 	poolKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	txn types.Txn,
 ) (map[string]uint64, map[string]uint64, error) {
 	db, err := d.resolveReadDB(txn)
@@ -1286,6 +1288,8 @@ func (d *MetadataStoreSqlite) GetStakeByPoolsAtSlot(
 		db,
 		poolKeyHashes,
 		slot,
+		expiryEpoch,
+		inactivityPeriod,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("GetStakeByPoolsAtSlot: %w", err)
@@ -1296,6 +1300,8 @@ func (d *MetadataStoreSqlite) GetStakeByPoolsAtSlot(
 func (d *MetadataStoreSqlite) GetPoolOwnerStakeAtSlot(
 	ownerKeyHashes [][]byte,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	txn types.Txn,
 ) (map[string]uint64, error) {
 	db, err := d.resolveReadDB(txn)
@@ -1303,6 +1309,6 @@ func (d *MetadataStoreSqlite) GetPoolOwnerStakeAtSlot(
 		return nil, err
 	}
 	return stakequery.GetPoolOwnerStakeAtSlot(
-		db, ownerKeyHashes, slot,
+		db, ownerKeyHashes, slot, expiryEpoch, inactivityPeriod,
 	)
 }

--- a/database/plugin/metadata/sqlite/reward_state.go
+++ b/database/plugin/metadata/sqlite/reward_state.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/rewardstate"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -155,13 +156,30 @@ func (d *MetadataStoreSqlite) GetRewardPoolInputs(
 }
 
 func (d *MetadataStoreSqlite) GetRewardStakeInputsForPools(
-	poolKeyHashes [][]byte, txn types.Txn,
+	poolKeyHashes [][]byte,
+	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
+	txn types.Txn,
 ) ([]*models.RewardStakeInput, error) {
 	db, err := d.resolveReadDB(txn)
 	if err != nil {
 		return nil, fmt.Errorf("GetRewardStakeInputsForPools: resolve db: %w", err)
 	}
-	inputs, err := rewardstate.StakeInputsForPools(db, poolKeyHashes, sqliteBindVarLimit)
+	// CIP-0163 gate on: reconstruct reward inputs at slot from the same
+	// historical CTE the leader-election path uses so both halves of the
+	// snapshot agree by construction. Gate off: read the live aggregate,
+	// byte-identical to the pre-CIP query.
+	if expiryEpoch > 0 {
+		inputs, err := stakequery.GetRewardStakeInputsByPoolsAtSlot(
+			db, poolKeyHashes, slot, expiryEpoch, inactivityPeriod,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("GetRewardStakeInputsForPools: %w", err)
+		}
+		return inputs, nil
+	}
+	inputs, err := rewardstate.StakeInputsForPools(db, poolKeyHashes, sqliteBindVarLimit, expiryEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("GetRewardStakeInputsForPools: %w", err)
 	}

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -761,6 +761,8 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccounts(t *testing.T) {
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
 		[][]byte{poolA, poolB, poolEmpty},
 		80,
+		0,
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -771,6 +773,437 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccounts(t *testing.T) {
 	require.Equal(t, uint64(1), delegators[string(poolB)])
 	require.Equal(t, uint64(0), stakes[string(poolEmpty)])
 	require.Equal(t, uint64(0), delegators[string(poolEmpty)])
+}
+
+// TestGetStakeByPoolsAtSlotExcludesExpiredAccounts covers the CIP-0163
+// reward-account inactivity exclusion in the shared stake-aggregation
+// chokepoint. Two credentials delegate to the same pool; one has an
+// expiration_epoch in the past. With the gate on (expiryEpoch > 0) the expired
+// credential's stake is dropped from the pool total and delegator count; with
+// the gate off (expiryEpoch == 0) both are included, matching pre-CIP behavior.
+func TestGetStakeByPoolsAtSlotExcludesExpiredAccounts(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	db := store.DB()
+	pool := bytes.Repeat([]byte{0xC1}, 28)
+	active := bytes.Repeat([]byte{0x08}, 28)  // expiration_epoch 0 (never expires)
+	expired := bytes.Repeat([]byte{0x09}, 28) // expiration_epoch 5 (< currentEpoch)
+
+	accounts := []models.Account{
+		{StakingKey: active, Pool: pool, AddedSlot: 10, Active: true},
+		{
+			StakingKey: expired, Pool: pool, AddedSlot: 10, Active: true,
+			ExpirationEpoch: 5,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+
+	utxos := []models.Utxo{
+		{
+			TxId: bytes.Repeat([]byte{0x51}, 32), OutputIdx: 0,
+			StakingKey: active, Amount: 100, AddedSlot: 20,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x52}, 32), OutputIdx: 0,
+			StakingKey: expired, Amount: 40, AddedSlot: 20,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+
+	// Gate off (expiryEpoch == 0): both credentials included (baseline).
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, 80, 0, 0, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(140), stakes[string(pool)],
+		"gate off must include both delegators (100 + 40)")
+	require.Equal(t, uint64(2), delegators[string(pool)])
+
+	// Gate on with currentEpoch 10: expired (expiration 5 < 10) is excluded.
+	stakes, delegators, err = store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, 80, 10, 90, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), stakes[string(pool)],
+		"gate on must drop the expired delegator's 40")
+	require.Equal(t, uint64(1), delegators[string(pool)])
+
+	// Gate on where the boundary has not yet passed (currentEpoch 5):
+	// expiration_epoch 5 is not strictly less than 5, so it is still active.
+	stakes, _, err = store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, 80, 5, 90, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(140), stakes[string(pool)],
+		"expiration_epoch == currentEpoch is not yet expired")
+}
+
+// TestGetStakeByPoolsAtSlotUsesHistoricalExpiration proves a witness after the
+// requested slot cannot revive stake that had already expired at that slot.
+func TestGetStakeByPoolsAtSlotUsesHistoricalExpiration(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+	pool := bytes.Repeat([]byte{0xC2}, 28)
+	credential := bytes.Repeat([]byte{0x12}, 28)
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: credential, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+		Active: true, ExpirationEpoch: 7, // later witness: epoch 5 + window 2
+	}).Error)
+	require.NoError(t, db.Create(&models.Utxo{
+		TxId: bytes.Repeat([]byte{0x61}, 32), StakingKey: credential,
+		Amount: 40, AddedSlot: 20,
+	}).Error)
+	for i, witnessSlot := range []uint64{50, 550} {
+		require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+			StakingKey: credential, AddedSlot: witnessSlot,
+			TxHash: bytes.Repeat([]byte{byte(0x70 + i)}, 32),
+		}).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, 250, 3, 2, nil,
+	)
+	require.NoError(t, err)
+	require.Zero(t, stakes[string(pool)],
+		"epoch-5 renewal must not replace epoch-0 expiration at slot 250")
+	require.Zero(t, delegators[string(pool)])
+}
+
+// TestGetStakeByPoolsAtSlotAppliesHistoricalActivationFloor proves the
+// one-time activation stamp remains part of historical reconstruction even
+// after a later witness overwrites the mutable account projection.
+func TestGetStakeByPoolsAtSlotAppliesHistoricalActivationFloor(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+	require.NoError(t, db.Create(&models.SyncState{
+		Key: "delegator_inactivity_activated", Value: "2",
+	}).Error)
+	pool := bytes.Repeat([]byte{0xC3}, 28)
+	credential := bytes.Repeat([]byte{0x13}, 28)
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: credential, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+		Active: true, ExpirationEpoch: 7,
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountInactivityActivation{
+		StakingKey: credential,
+	}).Error)
+	require.NoError(t, db.Create(&models.Utxo{
+		TxId: bytes.Repeat([]byte{0x62}, 32), StakingKey: credential,
+		Amount: 40, AddedSlot: 20,
+	}).Error)
+	for i, witnessSlot := range []uint64{50, 550} {
+		require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+			StakingKey: credential, AddedSlot: witnessSlot,
+			TxHash: bytes.Repeat([]byte{byte(0x72 + i)}, 32),
+		}).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, 250, 3, 2, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(40), stakes[string(pool)],
+		"activation epoch 2 must floor historical expiration at epoch 4")
+	require.Equal(t, uint64(1), delegators[string(pool)])
+}
+
+// TestGetStakeByPoolsAtSlotDoesNotFloorUnstampedAccount proves that an account
+// row that existed but was inactive at activation does not receive the
+// activation floor. Such rows are absent from the exact activation-membership
+// table.
+func TestGetStakeByPoolsAtSlotDoesNotFloorUnstampedAccount(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+	require.NoError(t, db.Create(&models.SyncState{
+		Key: "delegator_inactivity_activated", Value: "2",
+	}).Error)
+	pool := bytes.Repeat([]byte{0xC4}, 28)
+	credential := bytes.Repeat([]byte{0x14}, 28)
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: credential, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+		Active: true, ExpirationEpoch: 7,
+	}).Error)
+	require.NoError(t, db.Create(&models.Utxo{
+		TxId: bytes.Repeat([]byte{0x63}, 32), StakingKey: credential,
+		Amount: 40, AddedSlot: 20,
+	}).Error)
+	for i, witnessSlot := range []uint64{50, 550} {
+		require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+			StakingKey: credential, AddedSlot: witnessSlot,
+			TxHash: bytes.Repeat([]byte{byte(0x74 + i)}, 32),
+		}).Error)
+	}
+
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, 250, 3, 2, nil,
+	)
+	require.NoError(t, err)
+	require.Zero(t, stakes[string(pool)],
+		"an account absent from activation membership must expire at epoch 2")
+	require.Zero(t, delegators[string(pool)])
+}
+
+// TestGetRewardStakeInputsForPoolsExcludesExpiredAccounts covers the CIP-0163
+// exclusion on the reward-basis path. With the gate off it reads the live
+// reward stake aggregate. With the gate on it reconstructs expiration at the
+// requested slot from the same historical CTE as GetStakeByPoolsAtSlot, so a
+// post-slot witness that renewed a credential's live account.expiration_epoch
+// cannot revive stake that had already expired at the boundary — matching the
+// leader-election path rather than the mutable live column.
+func TestGetRewardStakeInputsForPoolsExcludesExpiredAccounts(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	db := store.DB()
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+
+	pool := bytes.Repeat([]byte{0xD1}, 28)
+	active := bytes.Repeat([]byte{0x0A}, 28)
+	expired := bytes.Repeat([]byte{0x0B}, 28)
+
+	// Both credentials are delegated to the pool (account-row fallback) and hold
+	// UTxO stake, and both carry a high live ExpirationEpoch (7) — a live-column
+	// filter would keep both. Only the historical reconstruction at slot 250
+	// distinguishes them by their surviving witness.
+	accounts := []models.Account{
+		{
+			StakingKey: active, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		},
+		{
+			StakingKey: expired, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		},
+	}
+	for i := range accounts {
+		require.NoError(t, db.Create(&accounts[i]).Error)
+	}
+	utxos := []models.Utxo{
+		{
+			TxId: bytes.Repeat([]byte{0x61}, 32), StakingKey: active,
+			Amount: 100, AddedSlot: 20,
+		},
+		{
+			TxId: bytes.Repeat([]byte{0x62}, 32), StakingKey: expired,
+			Amount: 40, AddedSlot: 20,
+		},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+	// active: latest witness <= slot 250 is at slot 250 (epoch 2) -> 2+2=4 >= 3.
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: active, AddedSlot: 250,
+		TxHash: bytes.Repeat([]byte{0x70}, 32),
+	}).Error)
+	// expired: latest witness <= slot 250 is at slot 50 (epoch 0) -> 0+2=2 < 3;
+	// the epoch-5 witness at slot 550 is after the boundary and must not revive it.
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: expired, AddedSlot: 50,
+		TxHash: bytes.Repeat([]byte{0x71}, 32),
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: expired, AddedSlot: 550,
+		TxHash: bytes.Repeat([]byte{0x72}, 32),
+	}).Error)
+
+	// reward_live_stake rows back the gate-off (live-aggregate) path.
+	live := []models.RewardLiveStake{
+		{
+			PoolKeyHash: pool, StakingKey: active, CredentialTag: 0,
+			TotalStake: types.Uint64(100), Registered: true,
+		},
+		{
+			PoolKeyHash: pool, StakingKey: expired, CredentialTag: 0,
+			TotalStake: types.Uint64(40), Registered: true,
+		},
+	}
+	for i := range live {
+		require.NoError(t, db.Create(&live[i]).Error)
+	}
+
+	// Gate off: live aggregate returns both inputs (slot/inactivity ignored).
+	inputs, err := store.GetRewardStakeInputsForPools([][]byte{pool}, 250, 0, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+
+	// Gate on (expiryEpoch 3, window 2): expiration reconstructed at slot 250.
+	// The expired credential's surviving witness is epoch 0 -> excluded; the
+	// active credential's is epoch 2 -> included. A live-column filter would
+	// have kept both (both have live ExpirationEpoch 7).
+	inputs, err = store.GetRewardStakeInputsForPools([][]byte{pool}, 250, 3, 2, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.Equal(t, active, inputs[0].StakingKey)
+	require.Equal(t, uint64(100), uint64(inputs[0].Stake),
+		"historical reward input stake must match the leader-election basis")
+}
+
+// TestGetRewardStakeInputsForPoolsDeduplicatesPoolsAcrossChunks verifies that
+// repeated pool hashes cannot duplicate reward inputs when the historical
+// CIP-0163 query splits the requested pools across multiple SQL queries.
+func TestGetRewardStakeInputsForPoolsDeduplicatesPoolsAcrossChunks(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	for epoch := uint64(0); epoch <= 3; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+
+	pool := bytes.Repeat([]byte{0xD3}, 28)
+	credential := bytes.Repeat([]byte{0x31}, 28)
+	require.NoError(t, db.Create(&models.Account{
+		StakingKey: credential, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+		Active: true, ExpirationEpoch: 4,
+	}).Error)
+	require.NoError(t, db.Create(&models.Utxo{
+		TxId: bytes.Repeat([]byte{0x63}, 32), StakingKey: credential,
+		Amount: 100, AddedSlot: 20,
+	}).Error)
+	require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+		StakingKey: credential, AddedSlot: 250,
+		TxHash: bytes.Repeat([]byte{0x73}, 32),
+	}).Error)
+
+	// SQLite's historical query chunk size is 800. Put the same real pool in
+	// the first and second chunks, separated by unmatched duplicate hashes.
+	pools := make([][]byte, 0, 802)
+	pools = append(pools, pool)
+	for range 800 {
+		pools = append(pools, bytes.Repeat([]byte{0xEE}, 28))
+	}
+	pools = append(pools, pool)
+
+	inputs, err := store.GetRewardStakeInputsForPools(
+		pools, 250, 3, 2, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	require.Equal(t, pool, inputs[0].PoolKeyHash)
+	require.Equal(t, credential, inputs[0].StakingKey)
+	require.Equal(t, uint64(100), uint64(inputs[0].Stake))
+}
+
+// TestGetRewardStakeInputsForPoolsAgreesWithLeaderStakeAtSlot pins the Option A
+// invariant: with the CIP-0163 gate on, reward-basis inputs are sourced from
+// the same historical CTE as the leader-election pool totals, so the
+// per-credential input stakes sum to exactly the leader pool total and cover
+// the same active delegator set at the requested slot — never the mutable live
+// account state.
+func TestGetRewardStakeInputsForPoolsAgreesWithLeaderStakeAtSlot(t *testing.T) {
+	t.Parallel()
+	store := setupStakeSnapshotTestStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	for epoch := uint64(0); epoch <= 5; epoch++ {
+		require.NoError(t, db.Create(&models.Epoch{
+			EpochId: epoch, StartSlot: epoch * 100, LengthInSlots: 100,
+		}).Error)
+	}
+	pool := bytes.Repeat([]byte{0xD2}, 28)
+	one := bytes.Repeat([]byte{0x21}, 28)
+	two := bytes.Repeat([]byte{0x22}, 28)
+	expired := bytes.Repeat([]byte{0x23}, 28)
+
+	for _, cred := range [][]byte{one, two, expired} {
+		require.NoError(t, db.Create(&models.Account{
+			StakingKey: cred, Pool: pool, AddedSlot: 10, CreatedSlot: 10,
+			Active: true, ExpirationEpoch: 7,
+		}).Error)
+	}
+	utxos := []models.Utxo{
+		{TxId: bytes.Repeat([]byte{0x51}, 32), StakingKey: one, Amount: 100, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x52}, 32), StakingKey: two, Amount: 250, AddedSlot: 20},
+		{TxId: bytes.Repeat([]byte{0x53}, 32), StakingKey: expired, Amount: 40, AddedSlot: 20},
+	}
+	for i := range utxos {
+		require.NoError(t, db.Create(&utxos[i]).Error)
+	}
+	// one, two: witnessed in epoch 2 (active at slot 250). expired: witnessed in
+	// epoch 0 only (expired at slot 250).
+	for _, w := range []struct {
+		key  []byte
+		slot uint64
+		tag  byte
+	}{
+		{one, 250, 0x80},
+		{two, 250, 0x81},
+		{expired, 50, 0x82},
+	} {
+		require.NoError(t, db.Create(&models.AccountWithdrawalWitness{
+			StakingKey: w.key, AddedSlot: w.slot,
+			TxHash: bytes.Repeat([]byte{w.tag}, 32),
+		}).Error)
+	}
+
+	const (
+		slot   = uint64(250)
+		expiry = uint64(3)
+		window = uint64(2)
+	)
+	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
+		[][]byte{pool}, slot, expiry, window, nil,
+	)
+	require.NoError(t, err)
+	inputs, err := store.GetRewardStakeInputsForPools(
+		[][]byte{pool}, slot, expiry, window, nil,
+	)
+	require.NoError(t, err)
+
+	var sum uint64
+	for _, in := range inputs {
+		require.Equal(t, pool, in.PoolKeyHash)
+		require.NotEqual(t, expired, in.StakingKey,
+			"expired-at-slot credential must not appear in reward inputs")
+		sum += uint64(in.Stake)
+	}
+	require.Equal(t, stakes[string(pool)], sum,
+		"reward inputs must sum to the leader-election pool total")
+	require.Equal(t, delegators[string(pool)], uint64(len(inputs)),
+		"reward input count must match the leader-election delegator count")
+	require.Equal(t, uint64(350), sum,
+		"only the two active credentials contribute (100+250)")
 }
 
 // TestGetStakeByPoolsAtSlotIncludesRewardBalance covers issue #2813: a mark
@@ -825,6 +1258,8 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalance(t *testing.T) {
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
 		[][]byte{poolA, poolB},
 		80,
+		0,
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -890,6 +1325,8 @@ func TestGetStakeByPoolsAtSlotUsesHistoricalRewardBalance(t *testing.T) {
 	stakes, delegators, err := store.GetStakeByPoolsAtSlot(
 		[][]byte{pool},
 		80,
+		0,
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -901,6 +1338,8 @@ func TestGetStakeByPoolsAtSlotUsesHistoricalRewardBalance(t *testing.T) {
 	stakes, delegators, err = store.GetStakeByPoolsAtSlot(
 		[][]byte{pool},
 		105,
+		0,
+		0,
 		nil,
 	)
 	require.NoError(t, err)

--- a/database/plugin/metadata/sqlite/stake_snapshot_test.go
+++ b/database/plugin/metadata/sqlite/stake_snapshot_test.go
@@ -16,6 +16,7 @@ package sqlite
 
 import (
 	"bytes"
+	"encoding/binary"
 	"strings"
 	"testing"
 
@@ -1106,11 +1107,14 @@ func TestGetRewardStakeInputsForPoolsDeduplicatesPoolsAcrossChunks(t *testing.T)
 	}).Error)
 
 	// SQLite's historical query chunk size is 800. Put the same real pool in
-	// the first and second chunks, separated by unmatched duplicate hashes.
+	// the first and second chunks, separated by distinct unmatched hashes so
+	// production deduplication does not collapse the request to one chunk.
 	pools := make([][]byte, 0, 802)
 	pools = append(pools, pool)
-	for range 800 {
-		pools = append(pools, bytes.Repeat([]byte{0xEE}, 28))
+	for i := range 800 {
+		unmatched := bytes.Repeat([]byte{0xEE}, 28)
+		binary.BigEndian.PutUint32(unmatched[24:], uint32(i)) // #nosec G115
+		pools = append(pools, unmatched)
 	}
 	pools = append(pools, pool)
 

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accounthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountsums"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/collateralfee"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
@@ -2857,7 +2858,7 @@ func (d *MetadataStoreSqlite) applyTransactionRewardWithdrawals(
 	txn types.Txn,
 ) error {
 	for addr, amount := range withdrawals {
-		if addr == nil || amount == nil || amount.Sign() == 0 {
+		if addr == nil || amount == nil {
 			continue
 		}
 		if amount.Sign() < 0 || !amount.IsUint64() {
@@ -2874,6 +2875,18 @@ func (d *MetadataStoreSqlite) applyTransactionRewardWithdrawals(
 		credentialTag, ok := models.StakeCredentialTagFromAddress(*addr)
 		if !ok {
 			return errors.New("derive reward withdrawal credential tag")
+		}
+		db, err := d.resolveDB(txn)
+		if err != nil {
+			return err
+		}
+		if err := accountwitness.RecordWithdrawal(
+			db, models.NewStakeCredentialRef(credentialTag, stakeKeyHash.Bytes()), txHash, slot,
+		); err != nil {
+			return err
+		}
+		if amount.Sign() == 0 {
+			continue
 		}
 		if err := d.ApplyAccountRewardWithdrawal(
 			credentialTag,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -108,6 +108,72 @@ type MetadataStore interface {
 	// ImportAccount.
 	CreateAccount(types.Txn, *models.Account) error
 
+	// RenewAccountExpirations sets expiration_epoch for every existing
+	// account row matching one of refs (CIP-0163 delegator-inactivity
+	// mechanism). A ref with no matching account row is ignored: an
+	// account must already be registered to have an expiration. Callers
+	// handling an ordinary witness pass currentEpoch + delegatorInactivity,
+	// which moves expiration forward. Rollback recomputation may instead lower
+	// expiration or reset it to zero to restore the value at the rollback point.
+	RenewAccountExpirations(
+		refs []models.StakeCredentialRef,
+		expirationEpoch uint64,
+		txn types.Txn,
+	) error
+
+	// AccountLastWitnessSlots returns, per requested credential, the greatest
+	// witnessing added_slot <= maxSlot across the stake-witnessing certificate
+	// tables and reward-withdrawal history. Withdrawal history includes
+	// account_withdrawal_witness (which preserves zero-amount withdrawals) and
+	// legacy account_reward_delta rows where withdrawal = TRUE — together with
+	// the certificate tables, this is the CIP-0163 witness set. The result is
+	// keyed by StakeCredentialRef.MapKey(); a credential with no witness <=
+	// maxSlot is absent from the map. Used by the ledger's rollback expiration
+	// recomputation to find each affected account's surviving witness slot.
+	AccountLastWitnessSlots(
+		refs []models.StakeCredentialRef,
+		maxSlot uint64,
+		txn types.Txn,
+	) (map[string]uint64, error)
+
+	// AccountsWitnessedAfterSlot returns the distinct reward-account
+	// credentials with a stake-witnessing certificate OR a reward withdrawal
+	// at added_slot > slot — the CIP-0163 rollback affected set. Withdrawals
+	// come from account_withdrawal_witness (including zero-amount withdrawals)
+	// and legacy account_reward_delta withdrawal rows. Callers must invoke it
+	// before deleting rolled-back certificate, withdrawal-witness, and
+	// reward-delta rows, since those are exactly the rows it inspects.
+	AccountsWitnessedAfterSlot(
+		slot uint64,
+		txn types.Txn,
+	) ([]models.StakeCredentialRef, error)
+
+	// StampAllActiveAccountExpirations sets expiration_epoch = expirationEpoch
+	// for every active account. Used once at CIP-0163 activation to give every
+	// pre-existing account a full inactivity window from the activation epoch,
+	// including accounts witnessed before activation. Returns the number of
+	// rows stamped.
+	StampAllActiveAccountExpirations(
+		expirationEpoch uint64,
+		txn types.Txn,
+	) (int64, error)
+
+	// AccountInactivityActivationMembership returns the requested credentials
+	// included in the one-time activation stamp, keyed by
+	// StakeCredentialRef.MapKey().
+	AccountInactivityActivationMembership(
+		[]models.StakeCredentialRef,
+		types.Txn,
+	) (map[string]struct{}, error)
+
+	// ResetAccountExpirationActivation clears expiration for the exact durable
+	// activation-membership set, deletes that set, and returns its credentials
+	// so the ledger can reconstruct any pre-activation witness expiration. Used
+	// when rollback crosses back before the activation boundary.
+	ResetAccountExpirationActivation(
+		types.Txn,
+	) ([]models.StakeCredentialRef, error)
+
 	// CreateUtxo inserts a Utxo row directly. The normal block-
 	// application path uses AddUtxos with UtxoSlot inputs; this is
 	// the simple-insert variant for callers that already have a
@@ -414,28 +480,46 @@ type MetadataStore interface {
 	// GetStakeByPoolsAtSlot returns delegated stake for multiple pools at a
 	// historical slot. It uses certificate history plus slot-aware UTxO
 	// liveness so epoch-boundary stake snapshots do not read current live
-	// stake for an older boundary.
+	// stake for an older boundary. expiryEpoch and inactivityPeriod drive the
+	// CIP-0163 reward-account inactivity gate: 0 disables it (result
+	// byte-identical to pre-CIP); otherwise expiration is reconstructed from
+	// witness history at slot and credentials expired before expiryEpoch are
+	// excluded.
 	GetStakeByPoolsAtSlot(
 		[][]byte, // poolKeyHashes
 		uint64, // slot
+		uint64, // expiryEpoch (0 = gate off)
+		uint64, // inactivityPeriod
 		types.Txn,
 	) (map[string]uint64, map[string]uint64, error)
 
 	// GetPoolOwnerStakeAtSlot returns historical stake for the requested pool
 	// owner key hashes, keyed by pool plus credential. An owner is included only
 	// when that credential was delegated to the pool at the requested slot.
+	// expiryEpoch drives the CIP-0163 inactivity gate (0 = gate off), and
+	// inactivityPeriod reconstructs expiration from historical witnesses.
 	GetPoolOwnerStakeAtSlot(
 		[][]byte, // ownerKeyHashes
 		uint64, // slot
+		uint64, // expiryEpoch (0 = gate off)
+		uint64, // inactivityPeriod
 		types.Txn,
 	) (map[string]uint64, error)
 
 	// GetRewardStakeInputsForPools returns positive per-account delegated stake
-	// for pools from the live reward stake aggregate. The aggregate always
-	// reflects the caller's transaction view, so there is no slot argument:
-	// callers scope the result by opening the transaction at the desired point.
+	// for pools. When the CIP-0163 inactivity gate is off (expiryEpoch == 0) it
+	// reads the live reward stake aggregate, byte-identical to the pre-CIP query
+	// (slot and inactivityPeriod are ignored). When the gate is on
+	// (expiryEpoch > 0) it reconstructs per-credential stake and expiration at
+	// slot from the same historical CTE as GetStakeByPoolsAtSlot, so the
+	// reward-basis inputs agree with leader-election pool totals by construction
+	// rather than reading the mutable live account.expiration_epoch column
+	// (which can reflect a post-slot renewal on a fallback capture).
 	GetRewardStakeInputsForPools(
 		[][]byte, // poolKeyHashes
+		uint64, // slot
+		uint64, // expiryEpoch (0 = gate off)
+		uint64, // inactivityPeriod
 		types.Txn,
 	) ([]*models.RewardStakeInput, error)
 
@@ -1502,9 +1586,14 @@ type MetadataStore interface {
 	// the current stake of all delegated accounts, approximated from live
 	// UTxO balance plus reward-account balance. credentialTag distinguishes
 	// key (0) from script (1) DRep credentials that share the same hash.
+	// expiryEpoch is the CIP-0163 reward-account inactivity gate: 0 excludes
+	// no accounts (gate off, byte-identical to the pre-CIP query); >0
+	// excludes accounts whose expiration_epoch is nonzero and less than
+	// expiryEpoch.
 	GetDRepVotingPower(
 		uint8, // credentialTag
 		[]byte, // drepCredential
+		uint64, // expiryEpoch
 		types.Txn,
 	) (uint64, error)
 
@@ -1523,18 +1612,22 @@ type MetadataStore interface {
 	// Returns a StakeCredentialRef.MapKey()-to-power map; credentials with
 	// no delegated stake are omitted. Use StakeCredentialRef to carry both
 	// the tag and hash so that key-hash and script-hash DReps sharing a
-	// 28-byte hash are tallied independently.
+	// 28-byte hash are tallied independently. expiryEpoch is the CIP-0163
+	// gate; see GetDRepVotingPower.
 	GetDRepVotingPowerBatch(
 		drepCredentials []models.StakeCredentialRef,
+		expiryEpoch uint64,
 		txn types.Txn,
 	) (map[string]uint64, error)
 
 	// GetDRepVotingPowerByType returns voting power grouped by DRep
 	// delegation type. This is used for predefined DRep options such
 	// as AlwaysAbstain and AlwaysNoConfidence, which do not have a
-	// credential hash.
+	// credential hash. expiryEpoch is the CIP-0163 gate; see
+	// GetDRepVotingPower.
 	GetDRepVotingPowerByType(
 		drepTypes []uint64,
+		expiryEpoch uint64,
 		txn types.Txn,
 	) (map[uint64]uint64, error)
 

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -617,3 +617,25 @@ mithril:
 # Env: DINGO_FULL_POT_REWARDS_ENABLED / DINGO_UNSAFE_FULL_POT_REWARDS_ON_STANDARD_NETWORKS
 # fullPotRewardsEnabled: false
 # unsafeFullPotRewardsOnStandardNetworks: false
+
+# ---
+# CIP-0163 reward-account inactivity expiry (experimental, consensus-affecting)
+#
+# When enabled, a reward account that performs no witnessing action (reward
+# withdrawal, (re)delegation to a pool or DRep, stake-key (de)registration) for
+# delegatorInactivity epochs is treated as expired and ignored for pool leader
+# election, reward crediting, and governance tallying until it witnesses again.
+# This changes the ledger rules, so it MUST only be enabled on a network where
+# every node also enables it (a devnet or custom network). Enabling it
+# off-consensus, e.g. on mainnet or the public testnets, will fork this node off
+# the network. It is disabled by default.
+#
+# Mithril bootstrap ('dingo mithril sync') is NOT supported with this enabled:
+# reward-account expiration state is absent from Mithril ledger snapshots and
+# cannot be reconstructed after import, so a CIP-0163 node must sync from
+# genesis. The sync command and node startup both refuse the combination.
+#
+# CLI: --delegator-inactivity-enabled / --delegator-inactivity
+# Env: DINGO_DELEGATOR_INACTIVITY_ENABLED / DINGO_DELEGATOR_INACTIVITY
+# delegatorInactivityEnabled: false
+# delegatorInactivity: 90        # epochs; integer in [1, 10000]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -591,6 +591,11 @@ type Config struct {
 	// for running CIP-0163 full-pot rewards on predefined public networks.
 	// Leave false except for controlled off-consensus experiments.
 	UnsafeFullPotRewardsOnStandardNetworks bool `yaml:"unsafeFullPotRewardsOnStandardNetworks" envconfig:"DINGO_UNSAFE_FULL_POT_REWARDS_ON_STANDARD_NETWORKS"`
+	// CIP-0163 reward-account inactivity expiry. Consensus-affecting; defaults
+	// off. See ARCHITECTURE.md ("Stake Snapshots", CIP-0163 reward-account
+	// inactivity).
+	DelegatorInactivityEnabled bool   `yaml:"delegatorInactivityEnabled" envconfig:"DINGO_DELEGATOR_INACTIVITY_ENABLED"`
+	DelegatorInactivity        uint64 `yaml:"delegatorInactivity"        envconfig:"DINGO_DELEGATOR_INACTIVITY"`
 
 	// Leios voting configuration (experimental, leios runMode only).
 	// LeiosVoteSigningKeyFile is the path to a hex-encoded BLS12-381

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -177,6 +177,9 @@ var flagSpecs = []flagSpec{
 	// CIP-0163 full-pot reward distribution (consensus-affecting; default off)
 	boolFlag("FullPotRewardsEnabled", "full-pot-rewards-enabled", "enable CIP-0163 full-pot reward distribution (custom networks only unless explicitly unsafe)"),
 	boolFlag("UnsafeFullPotRewardsOnStandardNetworks", "unsafe-full-pot-rewards-on-standard-networks", "allow CIP-0163 full-pot rewards on predefined standard networks; consensus-breaking unless the network has adopted it"),
+	// CIP-0163 reward-account inactivity expiry (consensus-affecting; default off)
+	boolFlag("DelegatorInactivityEnabled", "delegator-inactivity-enabled", "enable CIP-0163 reward-account inactivity expiry (only where every node also enables it)"),
+	uint64Flag("DelegatorInactivity", "delegator-inactivity", "CIP-0163 inactivity window in epochs, in [1,10000] (used when delegator-inactivity-enabled)"),
 
 	// CIP-50 pledge-leverage staking rewards (consensus-affecting; default off)
 	boolFlag("PledgeLeverageEnabled", "pledge-leverage-enabled", "enable the CIP-50 pledge-leverage reward cap (only where every node also enables it)"),

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -320,6 +320,28 @@ func TestMempoolImplementationSourcePrecedence(t *testing.T) {
 	)
 }
 
+func TestDelegatorInactivityEnvBinding(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_DELEGATOR_INACTIVITY_ENABLED", "true")
+	t.Setenv("DINGO_DELEGATOR_INACTIVITY", "90")
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "dingo.yaml")
+	if err := os.WriteFile(configFile, []byte(""), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if !cfg.DelegatorInactivityEnabled {
+		t.Fatal("expected env var to enable delegator inactivity")
+	}
+	if cfg.DelegatorInactivity != 90 {
+		t.Fatalf("expected delegatorInactivity=90, got %d", cfg.DelegatorInactivity)
+	}
+}
+
 func TestRegisterFlags_MidnightAddressAndPolicyFieldsAreYAMLOnly(t *testing.T) {
 	resetGlobalConfig()
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -463,6 +463,14 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		))
 	}
 
+	if c.DelegatorInactivityEnabled &&
+		(c.DelegatorInactivity < 1 || c.DelegatorInactivity > 10000) {
+		errs = append(errs, fmt.Errorf(
+			"delegatorInactivity (%d) must be in [1, 10000] when delegatorInactivityEnabled",
+			c.DelegatorInactivity,
+		))
+	}
+
 	return errors.Join(errs...)
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -511,6 +511,49 @@ func TestValidatePledgeLeverage(t *testing.T) {
 	}
 }
 
+// TestValidateDelegatorInactivity pins the CIP-0163 range check: the
+// inactivity window is only validated when the gate is enabled, and must
+// fall in [1, 10000] when it is.
+func TestValidateDelegatorInactivity(t *testing.T) {
+	tests := []struct {
+		name       string
+		enabled    bool
+		inactivity uint64
+		wantErr    string
+	}{
+		{name: "disabled ignores out-of-range value", enabled: false, inactivity: 10_001},
+		{name: "enabled at minimum", enabled: true, inactivity: 1},
+		{name: "enabled within range", enabled: true, inactivity: 90},
+		{name: "enabled at maximum", enabled: true, inactivity: 10_000},
+		{
+			name:       "enabled below minimum",
+			enabled:    true,
+			inactivity: 0,
+			wantErr:    "delegatorInactivity",
+		},
+		{
+			name:       "enabled above maximum",
+			enabled:    true,
+			inactivity: 10_001,
+			wantErr:    "delegatorInactivity",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.DelegatorInactivityEnabled = tt.enabled
+			cfg.DelegatorInactivity = tt.inactivity
+			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 // TestValidatePrivilegedPortAllowedWhenBindable covers a process that
 // may bind any port (root, Windows, or CAP_NET_BIND_SERVICE):
 // minBindable is 0, so a sub-1024 port passes.

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -417,6 +417,14 @@ func LoadWithDB(
 		return errors.New("primary chain not available")
 	}
 	snapshotMgr := snapshot.NewManager(db, nil, logger)
+	// Mirror the CIP-0163 reward-account inactivity gate into snapshot capture
+	// so replay matches serve mode (node.go) on the same DB.
+	if err := snapshotMgr.SetDelegatorInactivity(
+		cfg.DelegatorInactivityEnabled,
+		cfg.DelegatorInactivity,
+	); err != nil {
+		return fmt.Errorf("configuring snapshot manager: %w", err)
+	}
 	// Load state
 	ls, err := newLedgerStateForLoad(
 		ledger.LedgerStateConfig{
@@ -434,6 +442,10 @@ func LoadWithDB(
 			FullPotRewardsEnabled: cfg.FullPotRewardsEnabled,
 			TrustedReplay:         true,
 			ManualBlockProcessing: true,
+			// CIP-0163 reward-account inactivity expiry: consensus-affecting,
+			// must match serve mode (node.go) on replay of the same DB.
+			DelegatorInactivityEnabled: cfg.DelegatorInactivityEnabled,
+			DelegatorInactivity:        cfg.DelegatorInactivity,
 			DatabaseWorkerPoolConfig: ledger.DatabaseWorkerPoolConfig{
 				WorkerPoolSize: cfg.DatabaseWorkers,
 				TaskQueueSize:  cfg.DatabaseQueueSize,

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -578,6 +578,34 @@ func TestLoadWithDBRejectsFullPotRewardsFromCardanoConfigNetwork(t *testing.T) {
 	}
 }
 
+// TestLoadWithDBPropagatesDelegatorInactivity verifies that load mode
+// (`dingo load`) sets LedgerStateConfig.DelegatorInactivityEnabled /
+// DelegatorInactivity from the operator config, matching serve mode, since a
+// mismatch between load and serve would diverge consensus on replay.
+func TestLoadWithDBPropagatesDelegatorInactivity(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stop := errors.New("stop after ledger config capture")
+	run := func(enabled bool, epochs uint64) ledger.LedgerStateConfig {
+		db := newTestDB(t)
+		var captured ledger.LedgerStateConfig
+		old := newLedgerStateForLoad
+		newLedgerStateForLoad = func(cfg ledger.LedgerStateConfig) (*ledger.LedgerState, error) {
+			captured = cfg
+			return nil, stop
+		}
+		t.Cleanup(func() { newLedgerStateForLoad = old })
+		err := LoadWithDB(context.Background(),
+			&config.Config{Network: "preview", DelegatorInactivityEnabled: enabled, DelegatorInactivity: epochs},
+			logger, "unused", db)
+		require.ErrorIs(t, err, stop)
+		return captured
+	}
+	on := run(true, 90)
+	require.True(t, on.DelegatorInactivityEnabled)
+	require.Equal(t, uint64(90), on.DelegatorInactivity)
+	require.False(t, run(false, 0).DelegatorInactivityEnabled)
+}
+
 // TestLoadCaptureFailureTrackerCleanReturnsNil verifies that a tracker with no
 // recorded failures reports success, so a clean load is never turned into an
 // error.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -461,6 +461,11 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				cfg.ForgeStaleGapThresholdSlots,
 			),
 			dingo.WithValidateForgedBlock(cfg.ValidateForgedBlock),
+			// CIP-0163 reward-account inactivity expiry (consensus-affecting)
+			dingo.WithDelegatorInactivity(
+				cfg.DelegatorInactivityEnabled,
+				cfg.DelegatorInactivity,
+			),
 			// Leios voting (experimental)
 			dingo.WithLeiosVoteSigningKeyFile(
 				cfg.LeiosVoteSigningKeyFile,

--- a/ledger/account_expiry.go
+++ b/ledger/account_expiry.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+// accountExpiredAtEpoch reports whether a reward account with the given stored
+// ExpirationEpoch is expired at currentEpoch, per CIP-0163: expired iff a
+// concrete expiration was set (non-zero) and it is strictly before the current
+// epoch. A zero ExpirationEpoch means "unset" and is never expired.
+func accountExpiredAtEpoch(expirationEpoch, currentEpoch uint64) bool {
+	return expirationEpoch != 0 && expirationEpoch < currentEpoch
+}

--- a/ledger/account_expiry_activate.go
+++ b/ledger/account_expiry_activate.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/blinklabs-io/dingo/database"
+)
+
+// delegatorInactivityActivatedSyncKey is the durable sync_state marker key
+// guarding the one-time CIP-0163 activation stamp. Its value is the activation
+// epoch A (the epoch entered at the boundary activation ran on), stored as a
+// decimal string; a NON-EMPTY value means activation has already run. Once set,
+// activateDelegatorInactivityIfNeeded never re-stamps, even across restarts
+// (the marker is stored in the same metadata store as the account rows and
+// committed atomically with the stamp). The stored epoch is the activation
+// floor the rollback recompute clamps to (see
+// recomputeAccountExpirationsAfterRollback): activation stamps A + W without
+// leaving a witness, so witness history alone cannot reconstruct it.
+const delegatorInactivityActivatedSyncKey = "delegator_inactivity_activated"
+
+// activateDelegatorInactivityIfNeeded performs the one-time CIP-0163
+// activation stamp: on the first epoch boundary processed with the
+// delegator-inactivity gate on, it sets every active reward account's
+// expiration_epoch to currentEpoch + DelegatorInactivity, including rows
+// already renewed by a pre-activation witness, giving every pre-existing
+// account a full inactivity window starting at this boundary. It is guarded by
+// a durable sync_state marker so it runs exactly once regardless of how many
+// epoch boundaries are processed afterward or how many times the node
+// restarts. A no-op when the gate is off (no stamp, no marker write, so turning
+// the gate on later still triggers activation on the next boundary).
+//
+// currentEpoch is the epoch being entered at this boundary
+// (processEpochRollover passes the ending epoch plus one), not the epoch that
+// just ended: pre-existing accounts get a full DelegatorInactivity-epoch window
+// measured from the boundary they are activated at, matching the monotonic
+// currentEpoch+DelegatorInactivity convention used by
+// renewWitnessedAccountExpirations for ordinary per-block renewals.
+//
+// Must run inside the same database transaction as the epoch rollover
+// (txn) so the marker commits atomically with the stamp: a crash between the
+// two would otherwise either re-run the stamp or, worse, record activation
+// without ever having stamped anything. Passing the rollover's txn rules out
+// both partial states.
+func (ls *LedgerState) activateDelegatorInactivityIfNeeded(
+	txn *database.Txn,
+	currentEpoch uint64,
+) error {
+	if !ls.config.DelegatorInactivityEnabled {
+		return nil
+	}
+	done, err := ls.db.GetSyncState(delegatorInactivityActivatedSyncKey, txn)
+	if err != nil {
+		return err
+	}
+	if done != "" {
+		return nil
+	}
+	expiration := currentEpoch + ls.config.DelegatorInactivity
+	stamped, err := ls.db.StampAllActiveAccountExpirations(expiration, txn)
+	if err != nil {
+		return err
+	}
+	// Record the activation epoch A (not a bare flag) so the rollback recompute
+	// can clamp orphaned accounts back up to the activation floor A + W.
+	if err := ls.db.SetSyncState(
+		delegatorInactivityActivatedSyncKey,
+		strconv.FormatUint(currentEpoch, 10),
+		txn,
+	); err != nil {
+		return err
+	}
+	// This one-time, consensus-affecting event starts the inactivity clock for
+	// every pre-existing active account; log it so operators can see when and
+	// how broadly CIP-0163 activation fired.
+	if ls.config.Logger != nil {
+		ls.config.Logger.Info(
+			"CIP-0163 delegator inactivity activated",
+			"component", "ledger",
+			"activation_epoch", currentEpoch,
+			"expiration_epoch", expiration,
+			"accounts_stamped", stamped,
+		)
+	}
+	return nil
+}
+
+// delegatorInactivityActivationEpoch reads the durable CIP-0163 activation
+// marker and reports the activation epoch A, whether activation has occurred,
+// and any read/parse error. An empty marker means activation has not run yet
+// (activated == false, epoch 0). It is the read-back counterpart of the marker
+// write in activateDelegatorInactivityIfNeeded and is consumed by
+// recomputeAccountExpirationsAfterRollback.
+func (ls *LedgerState) delegatorInactivityActivationEpoch(
+	txn *database.Txn,
+) (epoch uint64, activated bool, err error) {
+	marker, err := ls.db.GetSyncState(delegatorInactivityActivatedSyncKey, txn)
+	if err != nil {
+		return 0, false, err
+	}
+	if marker == "" {
+		return 0, false, nil
+	}
+	epoch, err = strconv.ParseUint(marker, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			"parse delegator-inactivity activation marker %q: %w",
+			marker,
+			err,
+		)
+	}
+	return epoch, true, nil
+}

--- a/ledger/account_expiry_activate_test.go
+++ b/ledger/account_expiry_activate_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runActivate applies activateDelegatorInactivityIfNeeded inside a real
+// write transaction, mirroring how processEpochRollover calls it (and how
+// runRenew in account_expiry_renew_test.go drives
+// renewWitnessedAccountExpirations).
+func runActivate(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	currentEpoch uint64,
+) error {
+	t.Helper()
+	txn := db.Transaction(true)
+	return txn.Do(func(txn *database.Txn) error {
+		return ls.activateDelegatorInactivityIfNeeded(txn, currentEpoch)
+	})
+}
+
+// TestActivateDelegatorInactivityIfNeeded_GateOn verifies that, with the gate
+// on, activating at epoch E stamps every pre-existing active account
+// to E + DelegatorInactivity and durably records the activation marker.
+func TestActivateDelegatorInactivityIfNeeded_GateOn(t *testing.T) {
+	const (
+		epoch      = uint64(200)
+		inactivity = uint64(90)
+	)
+	ls, db := newRenewTestLedger(t, true, inactivity)
+
+	credA := renewTestCred(0x11)
+	credB := renewTestCred(0x12)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    credA,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    credB,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	require.NoError(t, runActivate(t, ls, db, epoch))
+
+	acctA, err := db.GetAccountByCredential(0, credA, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, epoch+inactivity, acctA.ExpirationEpoch)
+
+	acctB, err := db.GetAccountByCredential(0, credB, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, epoch+inactivity, acctB.ExpirationEpoch)
+
+	marker, err := db.GetSyncState(delegatorInactivityActivatedSyncKey, nil)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		strconv.FormatUint(epoch, 10),
+		marker,
+		"durable marker must record the activation epoch",
+	)
+}
+
+// TestActivateDelegatorInactivityIfNeeded_RunsOnce verifies the durable
+// marker guards a second activation attempt (e.g. a later epoch boundary)
+// from re-stamping an account whose expiration has since moved on (either
+// through ordinary CIP-0163 renewal or a manual operator adjustment).
+func TestActivateDelegatorInactivityIfNeeded_RunsOnce(t *testing.T) {
+	const (
+		epoch      = uint64(200)
+		inactivity = uint64(90)
+	)
+	ls, db := newRenewTestLedger(t, true, inactivity)
+
+	cred := renewTestCred(0x21)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	require.NoError(t, runActivate(t, ls, db, epoch))
+
+	// Simulate the account's expiration having since moved on (a normal
+	// renewal or a manual operator set) to a value the second activation
+	// pass must not clobber.
+	const manualExpiration = uint64(9999)
+	require.NoError(t, db.RenewAccountExpirations(
+		[]models.StakeCredentialRef{models.NewStakeCredentialRef(0, cred)},
+		manualExpiration,
+		nil,
+	))
+
+	// A later epoch boundary reaching the activation step again must be a
+	// no-op: the marker is already set.
+	require.NoError(t, runActivate(t, ls, db, epoch+inactivity+5))
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		manualExpiration,
+		acct.ExpirationEpoch,
+		"second activation must not re-stamp an already-activated account",
+	)
+}
+
+// TestActivateDelegatorInactivityIfNeeded_GateOff verifies that, with the
+// gate off, activation neither stamps any account nor writes the durable
+// marker (so turning the gate on later still triggers a real activation on
+// the next boundary).
+func TestActivateDelegatorInactivityIfNeeded_GateOff(t *testing.T) {
+	const epoch = uint64(200)
+	ls, db := newRenewTestLedger(t, false, 90)
+
+	cred := renewTestCred(0x31)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	require.NoError(t, runActivate(t, ls, db, epoch))
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), acct.ExpirationEpoch, "gate off must not stamp")
+
+	marker, err := db.GetSyncState(delegatorInactivityActivatedSyncKey, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "", marker, "gate off must not write the activation marker")
+}

--- a/ledger/account_expiry_e2e_test.go
+++ b/ledger/account_expiry_e2e_test.go
@@ -1,0 +1,451 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+// This file is Task 11 of CIP-0163 Mechanism B: an end-to-end lifecycle test
+// for reward-account inactivity expiry. CIP-0163 is ahead of cardano-ledger,
+// so there is no cardano-node DevNet reference for this behavior -- this test
+// is the primary integration validation that the per-layer mechanisms (Tasks
+// 1-10) compose correctly on a single reward account as it moves through its
+// full lifecycle.
+//
+// Scope note: this is a COMPOSED lifecycle test, not a full multi-epoch block
+// replay. There is no harness in this package that drives block-by-block
+// chain application through real epoch rollovers with certificate-bearing
+// blocks (the closest candidates -- newRenewTestLedger in
+// account_expiry_renew_test.go and newRewardCalculationTestLedger in
+// reward_calculation_test.go -- both call the relevant LedgerState methods
+// directly against a seeded database rather than replaying blocks). This test
+// reuses those exact harnesses and calls the same production methods
+// (renewWitnessedAccountExpirations, GetStakeByPoolsAtSlot,
+// applyStakeRewards) that the per-layer tests already exercise individually,
+// but drives them in lifecycle order against a single account/pool so the
+// composition itself -- not just each layer in isolation -- is under test.
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// Epoch labels for the lifecycle. DelegatorInactivity is short (2 epochs) so
+// the whole lifecycle -- register, expire, and reactivate -- fits in a small
+// number of epoch labels. The reward-crediting stage's epoch offsets follow
+// stakeRewardEpochsForNewEpoch (snapshot = newEpoch-3, performance =
+// newEpoch-2, pots = newEpoch-1), chosen so its snapshot epoch lines up with
+// delegatorInactivityE2EExcludeEpoch: the same point in the timeline where
+// the stake-snapshot query (Task 8) excludes this account is also the
+// snapshot epoch the reward-crediting guard (Task 10) judges it against.
+const (
+	delegatorInactivityE2EInactivity = uint64(2)
+	// registerEpoch: the credential registers and delegates (witnesses).
+	delegatorInactivityE2ERegisterEpoch = uint64(0)
+	// includeEpoch: still active (expiration 2 >= 1); gate genuinely on
+	// (nonzero) so this is not the "gate off" sentinel.
+	delegatorInactivityE2EIncludeEpoch = uint64(1)
+	// excludeEpoch: past expiration (2 < 3): now expired.
+	delegatorInactivityE2EExcludeEpoch = uint64(3)
+	// Reward-crediting guard epochs: newEpoch 6 -> snapshot 3 (matches
+	// excludeEpoch), performance 4, pots 5.
+	delegatorInactivityE2ERewardNewEpoch   = uint64(6)
+	delegatorInactivityE2ERewardSnapshotEp = uint64(3)
+	delegatorInactivityE2EPerformanceEpoch = uint64(4)
+	delegatorInactivityE2EPotsEpoch        = uint64(5)
+	delegatorInactivityE2EBoundarySlot     = uint64(600)
+	// rewitnessEpoch: a withdrawal is witnessed once already expired.
+	delegatorInactivityE2ERewitnessEpoch = uint64(3)
+	// reincludeEpoch: active again (new expiration 5 >= 4).
+	delegatorInactivityE2EReincludeEpoch = uint64(4)
+	// querySlot is held fixed across every stake-snapshot query in this test:
+	// only the CIP-0163 epoch argument changes between stages, not the chain
+	// slot, since this is a composed test rather than a real multi-slot
+	// chain replay.
+	delegatorInactivityE2EQuerySlot = uint64(1000)
+)
+
+// delegatorInactivityLifecycleResult captures the observable state at each
+// stage of the CIP-0163 lifecycle so the gate-on and gate-off assertions can
+// be written against a single shared run.
+type delegatorInactivityLifecycleResult struct {
+	expirationAfterRegister  uint64
+	stakeAtInclude           uint64
+	delegatorsAtInclude      uint64
+	stakeAtExclude           uint64
+	delegatorsAtExclude      uint64
+	leaderRewardAfterGuard   uint64
+	memberRewardAfterGuard   uint64
+	expirationAfterRewitness uint64
+	stakeAtReinclude         uint64
+	delegatorsAtReinclude    uint64
+}
+
+// e2eExpiryArg mirrors snapshot.Manager.expiryEpoch: callers pass the epoch
+// itself as the CIP-0163 gate argument when the gate is enabled, or the
+// sentinel 0 (gate off, byte-identical to pre-CIP behavior) when it is not.
+func e2eExpiryArg(gateEnabled bool, epoch uint64) uint64 {
+	if !gateEnabled {
+		return 0
+	}
+	return epoch
+}
+
+// runDelegatorInactivityLifecycleScenario drives a single reward-account
+// credential through the full CIP-0163 lifecycle against one shared
+// LedgerState/database:
+//
+//  1. Register+delegate (witness): create the account row the same way
+//     block application would after a registration+delegation certificate,
+//     then call renewWitnessedAccountExpirations (the same hook
+//     ledger/delta.go wires into block application) as if a
+//     StakeRegistrationDelegationCertificate had witnessed it. Query the
+//     Task 8 stake-snapshot aggregation (GetStakeByPoolsAtSlot) to confirm
+//     the delegated stake is included.
+//  2. Advance with no further witness past expiration: query the same
+//     aggregation at a later epoch to confirm the now-expired credential's
+//     stake is excluded, then run the Task 10 reward-crediting guard
+//     (applyStakeRewards) against a second credential carrying the same
+//     expiration to confirm an account in this same expired state is not
+//     credited (see the leaderCred comment below for why it is a separate
+//     credential rather than a literal reuse of cred).
+//  3. Witness again (a reward withdrawal): call
+//     renewWitnessedAccountExpirations again to confirm the expiration is
+//     renewed forward, then re-query the stake snapshot to confirm the
+//     credential is included again.
+//
+// gateEnabled controls both the renewal hook and the query arguments
+// (mirroring how the snapshot manager derives its expiryEpoch argument), so
+// calling this twice with true and false produces the gate-on lifecycle and
+// the gate-off baseline from the exact same sequence of operations.
+func runDelegatorInactivityLifecycleScenario(
+	t *testing.T,
+	gateEnabled bool,
+) delegatorInactivityLifecycleResult {
+	t.Helper()
+	var res delegatorInactivityLifecycleResult
+
+	ls, db := newRewardCalculationTestLedger(t)
+	ls.config.DelegatorInactivityEnabled = gateEnabled
+	ls.config.DelegatorInactivity = delegatorInactivityE2EInactivity
+	meta := db.Metadata()
+	gormDB := rewardCalcGormDB(t, db)
+
+	poolKey := rewardCalcHash(0x91)
+	cred := renewTestCred(0x92)
+	member := rewardCalcHash(0x93)
+	var poolID lcommon.PoolKeyHash
+	copy(poolID[:], poolKey)
+
+	pool := models.Pool{PoolKeyHash: poolKey}
+	require.NoError(t, gormDB.Create(&pool).Error)
+	require.NoError(t, gormDB.Create(&models.PoolRegistration{
+		PoolID:      pool.ID,
+		PoolKeyHash: poolKey,
+		AddedSlot:   0,
+	}).Error)
+
+	// ---- Stage 1: register + delegate (witness) ----
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Pool:          poolKey,
+		Active:        true,
+	}))
+	require.NoError(t, gormDB.Create(&models.Utxo{
+		TxId:       bytes.Repeat([]byte{0x71}, 32),
+		OutputIdx:  0,
+		StakingKey: cred,
+		Amount:     1_000_000,
+		AddedSlot:  0,
+	}).Error)
+
+	regDelegCred := lcommon.Credential{
+		CredType:   0,
+		Credential: lcommon.NewBlake2b224(cred),
+	}
+	regDelegTx := mockledger.NewTransactionBuilder()
+	regDelegTx.WithValid(true)
+	regDelegTx.WithCertificates(&lcommon.StakeRegistrationDelegationCertificate{
+		StakeCredential: regDelegCred,
+		PoolKeyHash:     poolID,
+	})
+	runRenew(t, ls, db, delegatorInactivityE2ERegisterEpoch, regDelegTx)
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	res.expirationAfterRegister = acct.ExpirationEpoch
+
+	stakes, delegators, err := meta.GetStakeByPoolsAtSlot(
+		[][]byte{poolKey},
+		delegatorInactivityE2EQuerySlot,
+		e2eExpiryArg(gateEnabled, delegatorInactivityE2EIncludeEpoch),
+		delegatorInactivityE2EInactivity,
+		nil,
+	)
+	require.NoError(t, err)
+	res.stakeAtInclude = stakes[string(poolKey)]
+	res.delegatorsAtInclude = delegators[string(poolKey)]
+
+	// ---- Stage 2: advance with no further witness past expiration ----
+	stakes, delegators, err = meta.GetStakeByPoolsAtSlot(
+		[][]byte{poolKey},
+		delegatorInactivityE2EQuerySlot,
+		e2eExpiryArg(gateEnabled, delegatorInactivityE2EExcludeEpoch),
+		delegatorInactivityE2EInactivity,
+		nil,
+	)
+	require.NoError(t, err)
+	res.stakeAtExclude = stakes[string(poolKey)]
+	res.delegatorsAtExclude = delegators[string(poolKey)]
+
+	// "Not credited": a second credential (leaderCred), carrying the exact
+	// expiration res.expirationAfterRegister just observed on cred, plays the
+	// pool's own reward (leader) account for the Task 10 reward-crediting
+	// guard via applyStakeRewards, at a snapshot epoch matching excludeEpoch.
+	// It must be a separate credential rather than reusing cred: seeding a
+	// StakeRegistration certificate below (rewardCalcSeedStakeCert) gives the
+	// credential real certificate history, which would make the Task 8
+	// account-fallback CTE's "no certificate history" guard in
+	// stakequery.go's delegationFallbackBlockTables exclude cred from its own
+	// later stake-snapshot queries (stage 3's reinclusion check) -- an
+	// artifact of this test harness, not of the CIP-0163 mechanism under
+	// test. This is otherwise the same scaffolding shape as
+	// TestApplyStakeRewardsGuardsExpiredRewardAccount's
+	// applyGuardExpiredLeaderScenario helper (reused pattern, not a new
+	// mechanism): pparams, performance/pots epochs, ADA pots, the reward
+	// snapshot row, and the pool/stake reward inputs the precompute step
+	// reads.
+	leaderCred := rewardCalcHash(0x94)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      leaderCred,
+		CredentialTag:   0,
+		Pool:            poolKey,
+		Active:          true,
+		ExpirationEpoch: res.expirationAfterRegister,
+	}))
+
+	pparams := &shelley.ShelleyProtocolParameters{
+		NOpt:             10,
+		A0:               rewardCalcRat(1, 2),
+		Rho:              rewardCalcRat(1, 100),
+		Tau:              rewardCalcRat(0, 1),
+		Decentralization: rewardCalcRat(0, 1),
+		ProtocolMajor:    7,
+		ProtocolMinor:    0,
+	}
+	pparamsCbor, err := cbor.Encode(pparams)
+	require.NoError(t, err)
+	require.NoError(t, meta.SetEpoch(
+		100, delegatorInactivityE2EPerformanceEpoch,
+		nil, nil, nil, nil, eras.ShelleyEraDesc.Id, 1, 100, nil,
+	))
+	require.NoError(t, meta.SetEpoch(
+		200, delegatorInactivityE2EPotsEpoch,
+		nil, nil, nil, nil, eras.ShelleyEraDesc.Id, 1, 100, nil,
+	))
+	for i := range uint64(10) {
+		require.NoError(t, db.UpdatePoolOpCertSequence(
+			poolID, i+1, 140+i, nil,
+		))
+	}
+	require.NoError(t, db.SetPParams(
+		pparamsCbor, 100, delegatorInactivityE2EPerformanceEpoch,
+		eras.ShelleyEraDesc.Id, nil,
+	))
+	require.NoError(t, meta.SaveRewardAdaPots(&models.RewardAdaPots{
+		Epoch:        delegatorInactivityE2EPotsEpoch,
+		Reserves:     100_000_000,
+		CapturedSlot: 300,
+	}, nil))
+	require.NoError(t, meta.SaveRewardSnapshot(&models.RewardSnapshot{
+		Epoch:            delegatorInactivityE2ERewardSnapshotEp,
+		SnapshotType:     "mark",
+		TotalActiveStake: 1_000,
+		TotalPoolCount:   1,
+		TotalDelegators:  2,
+		CapturedSlot:     100,
+		BoundarySlot:     100,
+		ProtocolVersion:  7,
+	}, nil))
+	require.NoError(t, meta.SaveRewardPoolInputs([]*models.RewardPoolInput{
+		{
+			Epoch:                      delegatorInactivityE2ERewardSnapshotEp,
+			PoolKeyHash:                poolKey,
+			RewardAccount:              leaderCred,
+			RewardAccountCredentialTag: 0,
+			Margin:                     &types.Rat{Rat: big.NewRat(1, 10)},
+			Pledge:                     500,
+			Cost:                       1_000,
+			DelegatedStake:             1_000,
+			OwnerStake:                 500,
+			DelegatorCount:             2,
+			CapturedSlot:               100,
+			BoundarySlot:               100,
+		},
+	}, nil))
+	require.NoError(t, meta.SaveRewardStakeInputs([]*models.RewardStakeInput{
+		{
+			Epoch:         delegatorInactivityE2ERewardSnapshotEp,
+			PoolKeyHash:   poolKey,
+			CredentialTag: 0,
+			StakingKey:    leaderCred,
+			Stake:         500,
+			Owner:         true,
+			Registered:    true,
+			CapturedSlot:  100,
+			BoundarySlot:  100,
+		},
+		{
+			Epoch:         delegatorInactivityE2ERewardSnapshotEp,
+			PoolKeyHash:   poolKey,
+			CredentialTag: 0,
+			StakingKey:    member,
+			Stake:         500,
+			Registered:    true,
+			CapturedSlot:  100,
+			BoundarySlot:  100,
+		},
+	}, nil))
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    member,
+		CredentialTag: 0,
+		Pool:          poolKey,
+		Active:        true,
+	}))
+	rewardCalcSeedStakeCert(
+		t, db, 1, leaderCred, 0, 250, uint(lcommon.CertificateTypeStakeRegistration),
+	)
+	rewardCalcSeedStakeCert(
+		t, db, 2, member, 0, 250, uint(lcommon.CertificateTypeStakeRegistration),
+	)
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(
+			txn,
+			delegatorInactivityE2ERewardNewEpoch,
+			delegatorInactivityE2EBoundarySlot,
+		)
+	}))
+
+	rewardOwner, err := db.GetAccountByCredential(0, leaderCred, true, nil)
+	require.NoError(t, err)
+	res.leaderRewardAfterGuard = uint64(rewardOwner.Reward)
+	rewardMember, err := db.GetAccountByCredential(0, member, true, nil)
+	require.NoError(t, err)
+	res.memberRewardAfterGuard = uint64(rewardMember.Reward)
+
+	// ---- Stage 3: witness again (withdrawal) -> renewed + reactivated ----
+	rewardAddr := renewTestRewardAddress(t, 0xE1, 0x92) // same fill byte as cred
+	withdrawTx := mockledger.NewTransactionBuilder()
+	withdrawTx.WithValid(true)
+	withdrawTx.WithWithdrawals(map[*lcommon.Address]uint64{rewardAddr: 1})
+	runRenew(t, ls, db, delegatorInactivityE2ERewitnessEpoch, withdrawTx)
+
+	acct, err = db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	res.expirationAfterRewitness = acct.ExpirationEpoch
+
+	stakes, delegators, err = meta.GetStakeByPoolsAtSlot(
+		[][]byte{poolKey},
+		delegatorInactivityE2EQuerySlot,
+		e2eExpiryArg(gateEnabled, delegatorInactivityE2EReincludeEpoch),
+		delegatorInactivityE2EInactivity,
+		nil,
+	)
+	require.NoError(t, err)
+	res.stakeAtReinclude = stakes[string(poolKey)]
+	res.delegatorsAtReinclude = delegators[string(poolKey)]
+
+	return res
+}
+
+// TestDelegatorInactivityEndToEnd is the CIP-0163 Mechanism B Task 11
+// end-to-end lifecycle test. See the file doc comment for scope (composed
+// lifecycle, not full block replay).
+func TestDelegatorInactivityEndToEnd(t *testing.T) {
+	t.Run("GateOn", testDelegatorInactivityEndToEndGateOn)
+	t.Run("GateOff", testDelegatorInactivityEndToEndGateOff)
+}
+
+// testDelegatorInactivityEndToEndGateOn walks a reward-account credential
+// through register -> included -> expire -> excluded+not-credited ->
+// witness -> renewed+included with the CIP-0163 gate on.
+func testDelegatorInactivityEndToEndGateOn(t *testing.T) {
+	res := runDelegatorInactivityLifecycleScenario(t, true)
+
+	require.Equal(t,
+		delegatorInactivityE2ERegisterEpoch+delegatorInactivityE2EInactivity,
+		res.expirationAfterRegister,
+		"registration+delegation witness must set the inactivity window",
+	)
+	require.Equal(t, uint64(1_000_000), res.stakeAtInclude,
+		"newly delegated stake must be included while active")
+	require.Equal(t, uint64(1), res.delegatorsAtInclude)
+
+	require.Equal(t, uint64(0), res.stakeAtExclude,
+		"expired delegator stake must be excluded from the pool snapshot")
+	require.Equal(t, uint64(0), res.delegatorsAtExclude)
+
+	require.Equal(t, uint64(0), res.leaderRewardAfterGuard,
+		"expired reward account must not be credited")
+	require.Greater(t, res.memberRewardAfterGuard, uint64(0),
+		"active member must still be credited")
+
+	require.Equal(t,
+		delegatorInactivityE2ERewitnessEpoch+delegatorInactivityE2EInactivity,
+		res.expirationAfterRewitness,
+		"a withdrawal witness must renew the expiration forward",
+	)
+	require.Equal(t, uint64(1_000_000), res.stakeAtReinclude,
+		"reactivated account's stake must be included again")
+	require.Equal(t, uint64(1), res.delegatorsAtReinclude)
+}
+
+// testDelegatorInactivityEndToEndGateOff runs the identical sequence with the
+// CIP-0163 gate off: the expiration is never set and the credential's stake
+// stays included and credited throughout, matching pre-CIP behavior.
+func testDelegatorInactivityEndToEndGateOff(t *testing.T) {
+	res := runDelegatorInactivityLifecycleScenario(t, false)
+
+	require.Equal(t, uint64(0), res.expirationAfterRegister,
+		"gate off must never set an expiration")
+	require.Equal(t, uint64(1_000_000), res.stakeAtInclude)
+	require.Equal(t, uint64(1), res.delegatorsAtInclude)
+
+	// Baseline unchanged: the same "advance past expiration" point that
+	// excludes with the gate on must still include with the gate off.
+	require.Equal(t, uint64(1_000_000), res.stakeAtExclude,
+		"gate off must keep the delegator included at every point in the timeline")
+	require.Equal(t, uint64(1), res.delegatorsAtExclude)
+
+	require.Greater(t, res.leaderRewardAfterGuard, uint64(0),
+		"gate off must credit the reward account (pre-CIP behavior)")
+	require.Greater(t, res.memberRewardAfterGuard, uint64(0))
+
+	require.Equal(t, uint64(0), res.expirationAfterRewitness,
+		"gate off must never set an expiration, even after another witness")
+	require.Equal(t, uint64(1_000_000), res.stakeAtReinclude)
+	require.Equal(t, uint64(1), res.delegatorsAtReinclude)
+}

--- a/ledger/account_expiry_renew.go
+++ b/ledger/account_expiry_renew.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// witnessedRewardCredentials returns the reward-account stake credentials that
+// tx witnesses under CIP-0163: the stake credential of every reward-withdrawal
+// entry and of every stake registration/deregistration, stake delegation, and
+// vote/DRep delegation certificate (including the combined
+// registration+delegation certificates). Duplicates are collapsed.
+//
+// The tag/hash extraction mirrors exactly how
+// database/plugin/metadata/sqlite applies withdrawals
+// (applyTransactionRewardWithdrawals: StakeKeyHash +
+// StakeCredentialTagFromAddress) and certificates (StakeCredential.Credential /
+// CredentialTagFromUint(StakeCredential.CredType)), so the witnessed set matches
+// the credentials the ledger itself writes for the same transaction. Callers
+// are responsible for skipping phase-2-invalid transactions (see
+// renewWitnessedAccountExpirations); this helper reports what a transaction
+// would witness regardless of validity.
+func witnessedRewardCredentials(
+	tx lcommon.Transaction,
+) []models.StakeCredentialRef {
+	seen := make(map[string]struct{})
+	var refs []models.StakeCredentialRef
+	add := func(tag uint8, key []byte) {
+		ref := models.NewStakeCredentialRef(tag, key)
+		k := ref.MapKey()
+		if _, ok := seen[k]; ok {
+			return
+		}
+		seen[k] = struct{}{}
+		refs = append(refs, ref)
+	}
+	// addFromCredential derives the credential tag from a stake Credential's
+	// CredType the same way SetTransaction does. A CredType the ledger would
+	// reject never reaches this hook (SetTransaction runs first and would have
+	// failed the block), so an unmappable tag is skipped rather than surfaced as
+	// an error from a hook that must not introduce new rejection paths.
+	addFromCredential := func(cred *lcommon.Credential) {
+		if cred == nil {
+			return
+		}
+		tag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return
+		}
+		add(tag, cred.Credential[:])
+	}
+	// Reward withdrawals: each map key is a reward account whose stake
+	// credential the transaction must witness. Amount is irrelevant to
+	// witnessing (the withdrawal still requires the account's signature), so
+	// unlike reward-balance application zero-amount entries are not skipped.
+	for addr := range tx.Withdrawals() {
+		if addr == nil {
+			continue
+		}
+		tag, ok := models.StakeCredentialTagFromAddress(*addr)
+		if !ok {
+			continue
+		}
+		add(tag, addr.StakeKeyHash().Bytes())
+	}
+	for _, cert := range tx.Certificates() {
+		switch c := cert.(type) {
+		case *lcommon.StakeRegistrationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.StakeDeregistrationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.StakeDelegationCertificate:
+			addFromCredential(c.StakeCredential)
+		case *lcommon.VoteDelegationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.StakeVoteDelegationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.RegistrationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.DeregistrationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.StakeRegistrationDelegationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.StakeVoteRegistrationDelegationCertificate:
+			addFromCredential(&c.StakeCredential)
+		case *lcommon.VoteRegistrationDelegationCertificate:
+			addFromCredential(&c.StakeCredential)
+		}
+	}
+	return refs
+}
+
+// renewWitnessedAccountExpirations bumps the CIP-0163 expiration_epoch of every
+// reward account witnessed by the given block's transactions to
+// currentEpoch + DelegatorInactivity. It is a no-op when the
+// delegator-inactivity gate is disabled (compute nothing, call nothing).
+//
+// Phase-2-invalid transactions apply no certificates or reward withdrawals
+// (database/plugin/metadata/sqlite SetTransaction gates both on tx.IsValid()),
+// so they witness nothing under CIP-0163 and are skipped here to keep the
+// witnessed set identical to the credentials the ledger actually wrote.
+//
+// RenewAccountExpirations only updates existing account rows, so this must run
+// inside the same database transaction as the block's account writes and after
+// them: a stake-key registration in this block creates the row that a later
+// (or same) witnessing event in the same block then renews. Passing
+// currentEpoch (the epoch of the block being applied) makes the write
+// monotonic — a witness in the current epoch always yields an expiration >= any
+// earlier renewal, and re-witnessing within an epoch is idempotent.
+func (ls *LedgerState) renewWitnessedAccountExpirations(
+	txn *database.Txn,
+	currentEpoch uint64,
+	txs []lcommon.Transaction,
+) error {
+	if !ls.config.DelegatorInactivityEnabled {
+		return nil
+	}
+	expiration := currentEpoch + ls.config.DelegatorInactivity
+	seen := make(map[string]struct{})
+	var refs []models.StakeCredentialRef
+	for _, tx := range txs {
+		if tx == nil || !tx.IsValid() {
+			continue
+		}
+		for _, ref := range witnessedRewardCredentials(tx) {
+			k := ref.MapKey()
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return ls.db.RenewAccountExpirations(refs, expiration, txn)
+}

--- a/ledger/account_expiry_renew_test.go
+++ b/ledger/account_expiry_renew_test.go
@@ -1,0 +1,467 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// renewTestCred builds a 28-byte credential hash filled with b.
+func renewTestCred(b byte) []byte {
+	return bytes.Repeat([]byte{b}, 28)
+}
+
+// renewTestCredential builds a gouroboros stake Credential with the given tag
+// (0 = key hash, 1 = script hash) and a 28-byte hash filled with b.
+func renewTestCredential(tag uint, b byte) lcommon.Credential {
+	return lcommon.Credential{
+		CredType:   tag,
+		Credential: lcommon.NewBlake2b224(renewTestCred(b)),
+	}
+}
+
+// renewTestRewardAddress builds a reward (stake) address for the credential hash
+// filled with b. header 0xE1 => key-hash reward address; 0xF1 => script-hash.
+func renewTestRewardAddress(t *testing.T, header byte, b byte) *lcommon.Address {
+	t.Helper()
+	addr, err := lcommon.NewAddressFromBytes(
+		append([]byte{header}, renewTestCred(b)...),
+	)
+	require.NoError(t, err)
+	return &addr
+}
+
+// refKeys returns the dedup MapKeys of refs so a returned set can be compared
+// independent of ordering (withdrawal map iteration order is nondeterministic).
+func refKeys(refs []models.StakeCredentialRef) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.MapKey())
+	}
+	return out
+}
+
+func TestWitnessedRewardCredentials(t *testing.T) {
+	t.Parallel()
+
+	stakeKey := renewTestCredential(0, 0x01)
+	scriptKey := renewTestCredential(1, 0x02)
+	poolHash := lcommon.NewBlake2b224(renewTestCred(0x0A))
+
+	tests := []struct {
+		name     string
+		build    func(t *testing.T, tx *mockledger.MockTransaction)
+		wantRefs []models.StakeCredentialRef
+	}{
+		{
+			name: "withdrawal key-hash reward account",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithWithdrawals(map[*lcommon.Address]uint64{
+					renewTestRewardAddress(t, 0xE1, 0xAB): 5_000,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0xAB)),
+			},
+		},
+		{
+			name: "withdrawal script-hash reward account",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithWithdrawals(map[*lcommon.Address]uint64{
+					renewTestRewardAddress(t, 0xF1, 0xCD): 1,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(1, renewTestCred(0xCD)),
+			},
+		},
+		{
+			name: "zero-amount withdrawal still witnesses",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithWithdrawals(map[*lcommon.Address]uint64{
+					renewTestRewardAddress(t, 0xE1, 0xAB): 0,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0xAB)),
+			},
+		},
+		{
+			name: "stake registration certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.StakeRegistrationCertificate{
+					StakeCredential: stakeKey,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "stake deregistration certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.StakeDeregistrationCertificate{
+					StakeCredential: stakeKey,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "stake delegation certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.StakeDelegationCertificate{
+					StakeCredential: &stakeKey,
+					PoolKeyHash:     poolHash,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "vote delegation certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.VoteDelegationCertificate{
+					StakeCredential: stakeKey,
+					Drep:            lcommon.Drep{Type: lcommon.DrepTypeAbstain},
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "stake vote delegation certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.StakeVoteDelegationCertificate{
+					StakeCredential: stakeKey,
+					PoolKeyHash:     poolHash,
+					Drep:            lcommon.Drep{Type: lcommon.DrepTypeAbstain},
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "registration certificate (conway)",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.RegistrationCertificate{
+					StakeCredential: scriptKey,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(1, renewTestCred(0x02)),
+			},
+		},
+		{
+			name: "deregistration certificate (conway)",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.DeregistrationCertificate{
+					StakeCredential: scriptKey,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(1, renewTestCred(0x02)),
+			},
+		},
+		{
+			name: "stake registration+delegation certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.StakeRegistrationDelegationCertificate{
+					StakeCredential: stakeKey,
+					PoolKeyHash:     poolHash,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "stake vote registration+delegation certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.StakeVoteRegistrationDelegationCertificate{
+					StakeCredential: stakeKey,
+					PoolKeyHash:     poolHash,
+					Drep:            lcommon.Drep{Type: lcommon.DrepTypeAbstain},
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "vote registration+delegation certificate",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.VoteRegistrationDelegationCertificate{
+					StakeCredential: stakeKey,
+					Drep:            lcommon.Drep{Type: lcommon.DrepTypeAbstain},
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "withdrawal plus stake delegation (brief example)",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithWithdrawals(map[*lcommon.Address]uint64{
+					renewTestRewardAddress(t, 0xE1, 0xAB): 5_000,
+				})
+				tx.WithCertificates(&lcommon.StakeDelegationCertificate{
+					StakeCredential: &stakeKey,
+					PoolKeyHash:     poolHash,
+				})
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0xAB)),
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "duplicate credentials are collapsed",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(
+					&lcommon.StakeRegistrationCertificate{StakeCredential: stakeKey},
+					&lcommon.StakeDelegationCertificate{
+						StakeCredential: &stakeKey,
+						PoolKeyHash:     poolHash,
+					},
+				)
+			},
+			wantRefs: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, renewTestCred(0x01)),
+			},
+		},
+		{
+			name: "non-witnessing certificate contributes nothing",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				tx.WithCertificates(&lcommon.PoolRetirementCertificate{
+					PoolKeyHash: poolHash,
+					Epoch:       5,
+				})
+			},
+			wantRefs: nil,
+		},
+		{
+			name: "payment only (no certs or withdrawals)",
+			build: func(t *testing.T, tx *mockledger.MockTransaction) {
+				// nothing witnessed
+			},
+			wantRefs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tx := mockledger.NewTransactionBuilder()
+			tx.WithValid(true)
+			tt.build(t, tx)
+
+			got := witnessedRewardCredentials(tx)
+			require.ElementsMatch(t, refKeys(tt.wantRefs), refKeys(got))
+		})
+	}
+}
+
+// newRenewTestLedger builds a DB-backed LedgerState with the CIP-0163
+// delegator-inactivity gate configured. It uses the same sqlite/badger
+// in-memory setup as the other ledger tests. renewWitnessedAccountExpirations
+// only touches ls.config and ls.db, so no era/protocol-parameter state is
+// required.
+func newRenewTestLedger(
+	t *testing.T,
+	enabled bool,
+	inactivity uint64,
+) (*LedgerState, *database.Database) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger:                     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			DelegatorInactivityEnabled: enabled,
+			DelegatorInactivity:        inactivity,
+		},
+	}
+	return ls, db
+}
+
+// runRenew applies renewWitnessedAccountExpirations inside a real write
+// transaction, mirroring how the block-application path calls it.
+func runRenew(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	currentEpoch uint64,
+	txs ...lcommon.Transaction,
+) {
+	t.Helper()
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.renewWitnessedAccountExpirations(txn, currentEpoch, txs)
+	}))
+}
+
+// stakeDelegationTx builds a valid transaction that witnesses cred via a stake
+// delegation certificate.
+func stakeDelegationTx(cred []byte) lcommon.Transaction {
+	stakeCred := lcommon.Credential{
+		CredType:   0,
+		Credential: lcommon.NewBlake2b224(cred),
+	}
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithValid(true)
+	tx.WithCertificates(&lcommon.StakeDelegationCertificate{
+		StakeCredential: &stakeCred,
+		PoolKeyHash:     lcommon.NewBlake2b224(renewTestCred(0x0A)),
+	})
+	return tx
+}
+
+// TestRenewWitnessedAccountExpirationsGateOn verifies that, with the gate on,
+// applying a block containing a stake delegation for a registered credential in
+// epoch E sets the account's ExpirationEpoch to E + DelegatorInactivity.
+func TestRenewWitnessedAccountExpirationsGateOn(t *testing.T) {
+	const (
+		epoch      = uint64(42)
+		inactivity = uint64(90)
+	)
+	ls, db := newRenewTestLedger(t, true, inactivity)
+
+	cred := renewTestCred(0x01)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	runRenew(t, ls, db, epoch, stakeDelegationTx(cred))
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, epoch+inactivity, acct.ExpirationEpoch)
+}
+
+// TestRenewWitnessedAccountExpirationsGateOff verifies that, with the gate off,
+// witnessing the same credential leaves ExpirationEpoch at its unset value (0).
+func TestRenewWitnessedAccountExpirationsGateOff(t *testing.T) {
+	const epoch = uint64(42)
+	ls, db := newRenewTestLedger(t, false, 90)
+
+	cred := renewTestCred(0x01)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	runRenew(t, ls, db, epoch, stakeDelegationTx(cred))
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), acct.ExpirationEpoch)
+}
+
+// TestRenewWitnessedAccountExpirationsWithdrawal verifies that a reward
+// withdrawal renews the withdrawn account's expiration (gate on).
+func TestRenewWitnessedAccountExpirationsWithdrawal(t *testing.T) {
+	const (
+		epoch      = uint64(10)
+		inactivity = uint64(90)
+	)
+	ls, db := newRenewTestLedger(t, true, inactivity)
+
+	// A key-hash reward address (header 0xE1) over the 0xAB..AB credential.
+	rewardAddr := renewTestRewardAddress(t, 0xE1, 0xAB)
+	cred := renewTestCred(0xAB)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithValid(true)
+	tx.WithWithdrawals(map[*lcommon.Address]uint64{rewardAddr: 1_000})
+
+	runRenew(t, ls, db, epoch, tx)
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, epoch+inactivity, acct.ExpirationEpoch)
+}
+
+// TestRenewWitnessedAccountExpirationsMissingRowIgnored verifies that
+// witnessing a credential with no account row is a no-op: no error and no row
+// is created (RenewAccountExpirations only touches existing rows).
+func TestRenewWitnessedAccountExpirationsMissingRowIgnored(t *testing.T) {
+	ls, db := newRenewTestLedger(t, true, 90)
+
+	cred := renewTestCred(0x07)
+	runRenew(t, ls, db, 5, stakeDelegationTx(cred))
+
+	_, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.ErrorIs(t, err, models.ErrAccountNotFound)
+}
+
+// TestRenewWitnessedAccountExpirationsSkipsInvalidTx verifies that a
+// phase-2-invalid transaction witnesses nothing (its certificates and
+// withdrawals are not applied by the ledger), so it does not renew.
+func TestRenewWitnessedAccountExpirationsSkipsInvalidTx(t *testing.T) {
+	ls, db := newRenewTestLedger(t, true, 90)
+
+	cred := renewTestCred(0x01)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        true,
+	}))
+
+	stakeCred := lcommon.Credential{
+		CredType:   0,
+		Credential: lcommon.NewBlake2b224(cred),
+	}
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithValid(false) // phase-2 failed: no certs/withdrawals applied
+	tx.WithCertificates(&lcommon.StakeDelegationCertificate{
+		StakeCredential: &stakeCred,
+		PoolKeyHash:     lcommon.NewBlake2b224(renewTestCred(0x0A)),
+	})
+
+	runRenew(t, ls, db, 5, tx)
+
+	acct, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), acct.ExpirationEpoch)
+}

--- a/ledger/account_expiry_rollback.go
+++ b/ledger/account_expiry_rollback.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// recomputeAccountExpirationsAfterRollback restores the CIP-0163
+// expiration_epoch of the reward accounts affected by a chain rollback.
+//
+// expiration_epoch is an epoch quantity, but the metadata layer that restores
+// the rest of the account state on rollback only knows slots. So the ledger,
+// which owns the epoch schedule, recomputes it here: for every affected
+// credential (one whose expiration may have been renewed by a now-orphaned
+// witness, gathered by AccountsWitnessedAfterSlot before the rolled-away
+// certificate/withdrawal rows were deleted) it finds the greatest surviving
+// witnessing slot <= rollbackSlot and stamps expiration = that slot's epoch +
+// DelegatorInactivity. A credential with no surviving witness has its
+// expiration reset to 0 (unset): its only renewals were orphaned. Doing
+// nothing would leave a stale, too-high expiration and exclude the account
+// later than the surviving chain would — a consensus divergence.
+//
+// Activation floor: the one-time activation stamp
+// (activateDelegatorInactivityIfNeeded) sets expiration = A + W for every
+// account active at activation epoch A WITHOUT leaving any witness. A pure
+// witness-history recompute therefore mis-restores an account that was active
+// and stamped at activation but whose only post-activation witness is orphaned:
+// it would drop
+// to a far-past registration epoch (or reset to 0), below the activation floor
+// the surviving chain still carries. So when activation actually ran at or
+// before the rollback point (activated && A <= epoch(rollbackSlot)), the
+// recomputed expiration is clamped up to the activation floor A + W for every
+// account in the durable activation-membership set. Existence alone is not
+// enough because a deregistered account present in the table was not stamped.
+// If the rollback is to before the activation boundary there is no floor: the
+// surviving chain has no activation stamp to preserve.
+//
+// affectedRefs are deduped with any rows reset while crossing back before the
+// activation boundary, so each credential is stamped exactly once. Refs are
+// grouped by target expiration so identical epochs share a single
+// RenewAccountExpirations batch.
+//
+// It is a no-op when the delegator-inactivity gate is disabled, and must run
+// inside the rollback's write transaction, after RestoreAccountStateAtSlot has
+// restored the remaining account fields.
+func (ls *LedgerState) recomputeAccountExpirationsAfterRollback(
+	txn *database.Txn,
+	rollbackSlot uint64,
+	affectedRefs []models.StakeCredentialRef,
+) error {
+	if !ls.config.DelegatorInactivityEnabled {
+		return nil
+	}
+	rollbackEpoch, err := ls.SlotToEpoch(rollbackSlot)
+	if err != nil {
+		return fmt.Errorf("map rollback slot %d to epoch: %w", rollbackSlot, err)
+	}
+	activationEpoch, activated, err := ls.delegatorInactivityActivationEpoch(txn)
+	if err != nil {
+		return fmt.Errorf("read delegator-inactivity activation epoch: %w", err)
+	}
+	// Rolling back to before the activation boundary: undo the one-time
+	// activation stamp so a later re-sync re-runs it.
+	// ResetAccountExpirationActivation returns every reset credential. Unioning
+	// those credentials into affectedRefs is required because activation
+	// overwrites an earlier witness expiration: an account with no orphaned
+	// post-activation witness would otherwise be absent from affectedRefs and
+	// remain reset to 0 instead of being reconstructed from its surviving
+	// pre-activation witness.
+	if activated && activationEpoch > rollbackEpoch.EpochId {
+		resetRefs, resetErr := ls.db.ResetAccountExpirationActivation(
+			txn,
+		)
+		if resetErr != nil {
+			return fmt.Errorf(
+				"reset delegator-inactivity activation stamp: %w",
+				resetErr,
+			)
+		}
+		affectedRefs = mergeStakeCredentialRefs(affectedRefs, resetRefs)
+		if err := ls.db.DeleteSyncState(delegatorInactivityActivatedSyncKey, txn); err != nil {
+			return fmt.Errorf("clear delegator-inactivity activation marker: %w", err)
+		}
+		activated = false
+	}
+	if len(affectedRefs) == 0 {
+		return nil
+	}
+	lastWitness, err := ls.db.AccountLastWitnessSlots(
+		affectedRefs,
+		rollbackSlot,
+		txn,
+	)
+	if err != nil {
+		return fmt.Errorf("query last witness slots: %w", err)
+	}
+	// Resolve the activation floor. The floor applies only when activation
+	// actually ran at or before the rollback point; otherwise the surviving
+	// chain carries no activation stamp and there is nothing to clamp to.
+	clampApplies := false
+	if activated {
+		clampApplies = activationEpoch <= rollbackEpoch.EpochId
+	}
+	// Load exact activation membership only when the floor is in play. Existence
+	// at activation is insufficient: accounts that were deregistered at the
+	// boundary were not stamped and must not receive the floor.
+	var activationMembership map[string]struct{}
+	if clampApplies {
+		activationMembership, err = ls.db.AccountInactivityActivationMembership(
+			affectedRefs,
+			txn,
+		)
+		if err != nil {
+			return fmt.Errorf("load activation membership: %w", err)
+		}
+	}
+	// Group affected credentials by the expiration epoch to stamp. A credential
+	// with neither a surviving witness nor an applicable activation floor is
+	// reset to expiration 0.
+	byExpiration := make(map[uint64][]models.StakeCredentialRef)
+	for _, ref := range affectedRefs {
+		var (
+			witnessEpoch   uint64
+			witnessPresent bool
+		)
+		if slot, ok := lastWitness[ref.MapKey()]; ok {
+			epoch, epochErr := ls.SlotToEpoch(slot)
+			if epochErr != nil {
+				return fmt.Errorf(
+					"map witness slot %d to epoch: %w",
+					slot,
+					epochErr,
+				)
+			}
+			witnessEpoch = epoch.EpochId
+			witnessPresent = true
+		}
+		floorEpoch, floorPresent := rollbackActivationFloor(
+			ref,
+			clampApplies,
+			activationEpoch,
+			activationMembership,
+		)
+		var expiration uint64
+		switch {
+		case witnessPresent && floorPresent:
+			expiration = max(witnessEpoch, floorEpoch) + ls.config.DelegatorInactivity
+		case witnessPresent:
+			expiration = witnessEpoch + ls.config.DelegatorInactivity
+		case floorPresent:
+			expiration = floorEpoch + ls.config.DelegatorInactivity
+		default:
+			expiration = 0
+		}
+		byExpiration[expiration] = append(byExpiration[expiration], ref)
+	}
+	for expiration, refs := range byExpiration {
+		if err := ls.db.RenewAccountExpirations(refs, expiration, txn); err != nil {
+			return fmt.Errorf(
+				"stamp rollback expiration %d: %w",
+				expiration,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func mergeStakeCredentialRefs(
+	refs ...[]models.StakeCredentialRef,
+) []models.StakeCredentialRef {
+	total := 0
+	for _, group := range refs {
+		total += len(group)
+	}
+	ret := make([]models.StakeCredentialRef, 0, total)
+	seen := make(map[string]struct{}, total)
+	for _, group := range refs {
+		for _, ref := range group {
+			key := ref.MapKey()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			ret = append(ret, ref)
+		}
+	}
+	return ret
+}
+
+// rollbackActivationFloor reports the CIP-0163 activation-floor epoch for one
+// affected credential and whether the floor applies to it. The floor is the
+// activation epoch A, and it applies only when the clamp is active for this
+// rollback AND the account was actually stamped at activation. Durable
+// activation membership distinguishes those accounts from credentials that
+// existed but were deregistered at the activation boundary.
+func rollbackActivationFloor(
+	ref models.StakeCredentialRef,
+	clampApplies bool,
+	activationEpoch uint64,
+	activationMembership map[string]struct{},
+) (uint64, bool) {
+	if !clampApplies {
+		return 0, false
+	}
+	_, ok := activationMembership[ref.MapKey()]
+	if !ok {
+		return 0, false
+	}
+	return activationEpoch, true
+}

--- a/ledger/account_expiry_rollback_test.go
+++ b/ledger/account_expiry_rollback_test.go
@@ -1,0 +1,454 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// newExpiryRollbackTestLedger builds a DB-backed LedgerState with the CIP-0163
+// delegator-inactivity gate configured and a fixed epoch schedule so
+// SlotToEpoch resolves the seeded witness slots. Epochs are 100 slots long:
+// E0 = [0,100), E1 = [100,200), E2 = [200,300), ... Epochs after E2 are
+// projected from the current era, as SlotToEpoch documents.
+func newExpiryRollbackTestLedger(
+	t *testing.T,
+	enabled bool,
+	inactivity uint64,
+) (*LedgerState, *database.Database) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Logger:                     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			DelegatorInactivityEnabled: enabled,
+			DelegatorInactivity:        inactivity,
+		},
+		currentEra: eras.ShelleyEraDesc,
+		epochCache: []models.Epoch{
+			{EpochId: 0, StartSlot: 0, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+			{EpochId: 1, StartSlot: 100, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+			{EpochId: 2, StartSlot: 200, SlotLength: 1000, LengthInSlots: 100, EraId: 1},
+		},
+	}
+	ls.publishSnapshotsLocked()
+	return ls, db
+}
+
+// seedRollbackCertificate records a certificate through the public database
+// ingestion boundary. This keeps the ledger test independent of a concrete
+// metadata plugin and its GORM schema.
+func seedRollbackCertificate(
+	t *testing.T,
+	db *database.Database,
+	slot uint64,
+	cert lcommon.Certificate,
+) {
+	t.Helper()
+	txID := make([]byte, 32)
+	binary.BigEndian.PutUint64(txID[len(txID)-8:], slot)
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithId(txID)
+	tx.WithCertificates(cert)
+	require.NoError(t, db.SetTransactionMetadataOnly(
+		tx,
+		ocommon.NewPoint(slot, txID),
+		0,
+		map[int]uint64{0: 0},
+		nil,
+	))
+}
+
+func rollbackStakeDelegationCertificate(
+	cred []byte,
+) lcommon.Certificate {
+	return &lcommon.StakeDelegationCertificate{
+		StakeCredential: &lcommon.Credential{
+			CredType:   0,
+			Credential: lcommon.NewBlake2b224(cred),
+		},
+		PoolKeyHash: lcommon.NewBlake2b224(renewTestCred(0x0A)),
+	}
+}
+
+func rollbackStakeRegistrationCertificate(
+	cred []byte,
+) lcommon.Certificate {
+	return &lcommon.StakeRegistrationCertificate{
+		StakeCredential: lcommon.Credential{
+			CredType:   0,
+			Credential: lcommon.NewBlake2b224(cred),
+		},
+	}
+}
+
+func rollbackStakeDeregistrationCertificate(
+	cred []byte,
+) lcommon.Certificate {
+	return &lcommon.StakeDeregistrationCertificate{
+		StakeCredential: lcommon.Credential{
+			CredType:   0,
+			Credential: lcommon.NewBlake2b224(cred),
+		},
+	}
+}
+
+// runRollbackRecompute mirrors the rollback path: it gathers the affected set
+// (witnessed after rollbackSlot) before any deletes, then recomputes
+// expirations, all inside one write transaction.
+func runRollbackRecompute(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	rollbackSlot uint64,
+) {
+	t.Helper()
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		affected, err := db.AccountsWitnessedAfterSlot(rollbackSlot, txn)
+		if err != nil {
+			return err
+		}
+		return ls.recomputeAccountExpirationsAfterRollback(
+			txn,
+			rollbackSlot,
+			affected,
+		)
+	}))
+}
+
+// TestRecomputeAccountExpirationsAfterRollbackDropsOrphanedRenewal is the brief
+// scenario: a credential witnessed in E1 (slot 150) then E2 (slot 250) has its
+// expiration stamped to E2+W. Rolling back into E1 (slot 199) must drop the
+// orphaned E2 renewal and restore the surviving E1 renewal: ExpirationEpoch ==
+// E1 + DelegatorInactivity.
+func TestRecomputeAccountExpirationsAfterRollbackDropsOrphanedRenewal(t *testing.T) {
+	const inactivity = uint64(90)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+
+	cred := renewTestCred(0x01)
+	// Account currently reflects the E2 witness: expiration = 2 + 90 = 92.
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      cred,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       150,
+		ExpirationEpoch: 2 + inactivity,
+	}))
+	// Witness in E1 (slot 150) and E2 (slot 250).
+	seedRollbackCertificate(
+		t, db, 150, rollbackStakeDelegationCertificate(cred),
+	)
+	seedRollbackCertificate(
+		t, db, 250, rollbackStakeDelegationCertificate(cred),
+	)
+
+	runRollbackRecompute(t, ls, db, 199)
+
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1)+inactivity, acct.ExpirationEpoch)
+}
+
+// TestRecomputeAccountExpirationsAfterRollbackGateOff verifies the recomputation
+// is a no-op when the gate is off: the E2-derived expiration is left untouched.
+func TestRecomputeAccountExpirationsAfterRollbackGateOff(t *testing.T) {
+	const inactivity = uint64(90)
+	ls, db := newExpiryRollbackTestLedger(t, false, inactivity)
+
+	cred := renewTestCred(0x02)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      cred,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       150,
+		ExpirationEpoch: 2 + inactivity,
+	}))
+	seedRollbackCertificate(
+		t, db, 150, rollbackStakeDelegationCertificate(cred),
+	)
+	seedRollbackCertificate(
+		t, db, 250, rollbackStakeDelegationCertificate(cred),
+	)
+
+	runRollbackRecompute(t, ls, db, 199)
+
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2)+inactivity, acct.ExpirationEpoch)
+}
+
+// TestRecomputeAccountExpirationsAfterRollbackClampsToActivationFloor is the
+// review-fix scenario: the one-time CIP-0163 activation stamp gives every
+// pre-existing account expiration = A + W without leaving a witness, so a pure
+// witness-history recompute would mis-restore an account whose only
+// post-activation witness is orphaned. Here W=90, activation runs at epoch
+// A=500 for an account created in epoch 5 (registration cert at slot 550,
+// stamped to 590 by activation). A post-activation delegation at slot 50550
+// (epoch 505) renews expiration to 595, then a rollback to slot 50150 (epoch
+// 501) orphans it. The only surviving witness is the epoch-5 registration, so
+// an unclamped recompute would produce 5+90=95. The activation floor (A=500,
+// account was stamped at activation) must clamp it back up to 500+90=590 — NOT 95,
+// NOT 0.
+func TestRecomputeAccountExpirationsAfterRollbackClampsToActivationFloor(t *testing.T) {
+	const (
+		inactivity      = uint64(90)
+		activationEpoch = uint64(500)
+	)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+
+	cred := renewTestCred(0x04)
+	// Account created in epoch 5 (slot 550): pre-activation registration only.
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      cred,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       550,
+		CreatedSlot:     550,
+		ExpirationEpoch: 0,
+	}))
+	// Pre-activation registration witness at slot 550 (epoch 5).
+	seedRollbackCertificate(
+		t, db, 550, rollbackStakeRegistrationCertificate(cred),
+	)
+
+	// One-time activation at epoch A=500 stamps expiration = 500 + 90 = 590 and
+	// durably records the activation epoch in the marker.
+	require.NoError(t, runActivate(t, ls, db, activationEpoch))
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, activationEpoch+inactivity, acct.ExpirationEpoch,
+		"activation must stamp A+W")
+
+	// Post-activation delegation witness at slot 50550 (epoch 505) renews the
+	// expiration to 505 + 90 = 595 (as block application would).
+	seedRollbackCertificate(
+		t, db, 50550, rollbackStakeDelegationCertificate(cred),
+	)
+	require.NoError(t, db.RenewAccountExpirations(
+		[]models.StakeCredentialRef{models.NewStakeCredentialRef(0, cred)},
+		505+inactivity,
+		nil,
+	))
+
+	// Roll back into epoch 501 (slot 50150): the epoch-505 delegation is
+	// orphaned, leaving only the epoch-5 registration surviving.
+	runRollbackRecompute(t, ls, db, 50150)
+
+	acct, err = db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, activationEpoch+inactivity, acct.ExpirationEpoch,
+		"must clamp to activation floor A+W (590), not cert+W (95) or 0")
+}
+
+// TestRecomputeAccountExpirationsAfterRollbackResetsOrphanOnly verifies that a
+// credential whose only witness was rolled away (no surviving witness <=
+// rollbackSlot) has its expiration reset to 0.
+func TestRecomputeAccountExpirationsAfterRollbackResetsOrphanOnly(t *testing.T) {
+	const inactivity = uint64(90)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+
+	cred := renewTestCred(0x03)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      cred,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       150,
+		ExpirationEpoch: 2 + inactivity,
+	}))
+	// Only witness is at slot 250 (E2), which is rolled away by a rollback to
+	// slot 199.
+	seedRollbackCertificate(
+		t, db, 250, rollbackStakeDelegationCertificate(cred),
+	)
+
+	runRollbackRecompute(t, ls, db, 199)
+
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), acct.ExpirationEpoch)
+}
+
+// TestRecomputeAccountExpirationsAfterRollbackActivationMembership verifies
+// that every account stamped at activation is reconstructed when rollback
+// crosses before A. The account with no surviving witness resets to 0, while
+// the account with an epoch-A witness restores its earlier epoch-1 witness.
+func TestRecomputeAccountExpirationsAfterRollbackActivationMembership(t *testing.T) {
+	const (
+		inactivity      = uint64(90)
+		activationEpoch = uint64(2)
+	)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+
+	// Activation-stamped account: expiration = A+W = 92, created before
+	// activation, no witness rows.
+	stamped := renewTestCred(0x51)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      stamped,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       50,
+		CreatedSlot:     50,
+		ExpirationEpoch: activationEpoch + inactivity,
+	}))
+
+	// Coincidentally-92 account: value came from an epoch-2 witness (slot 250),
+	// with a surviving epoch-1 witness (slot 150).
+	witnessed := renewTestCred(0x52)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      witnessed,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       150,
+		CreatedSlot:     150,
+		ExpirationEpoch: activationEpoch + inactivity,
+	}))
+	seedRollbackCertificate(
+		t, db, 150, rollbackStakeDelegationCertificate(witnessed),
+	)
+	seedRollbackCertificate(
+		t, db, 250, rollbackStakeDelegationCertificate(witnessed),
+	)
+	require.NoError(t, runActivate(t, ls, db, activationEpoch))
+
+	// Roll back into epoch 1 (before activation epoch 2): the reset targets both
+	// 92-valued rows, then the affected-set recompute corrects the witnessed one.
+	runRollbackRecompute(t, ls, db, 199)
+
+	stampedAcct, err := db.GetAccountByCredential(0, stamped, true, nil)
+	require.NoError(t, err)
+	require.Zero(t, stampedAcct.ExpirationEpoch,
+		"activation-stamped account resets to 0 (its pre-activation value)")
+
+	witnessedAcct, err := db.GetAccountByCredential(0, witnessed, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1)+inactivity, witnessedAcct.ExpirationEpoch,
+		"epoch-2-witnessed account is recomputed from its surviving epoch-1 witness, not left at 0")
+}
+
+// TestRecomputeAccountExpirationsAfterRollbackRestoresPreActivationWitness
+// verifies that crossing back before activation restores the expiration that
+// activation overwrote. The credential has only an epoch-(A-1) witness, so it
+// is absent from the ordinary post-rollback affected set; the activation-reset
+// credential set must bring it into the witness-history recomputation.
+func TestRecomputeAccountExpirationsAfterRollbackRestoresPreActivationWitness(
+	t *testing.T,
+) {
+	const (
+		inactivity      = uint64(90)
+		activationEpoch = uint64(2)
+	)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+	cred := renewTestCred(0x53)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      cred,
+		CredentialTag:   0,
+		Active:          true,
+		AddedSlot:       150,
+		CreatedSlot:     150,
+		ExpirationEpoch: uint64(1) + inactivity,
+	}))
+	seedRollbackCertificate(
+		t, db, 150, rollbackStakeDelegationCertificate(cred),
+	)
+
+	require.NoError(t, runActivate(t, ls, db, activationEpoch))
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, activationEpoch+inactivity, acct.ExpirationEpoch,
+		"activation must replace the shorter pre-activation witness expiration")
+
+	runRollbackRecompute(t, ls, db, 199)
+
+	acct, err = db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1)+inactivity, acct.ExpirationEpoch,
+		"rollback before activation must restore the epoch-(A-1) witness expiration")
+}
+
+func TestRecomputeAccountExpirationsAfterRollbackDoesNotFloorAccountInactiveAtActivation(
+	t *testing.T,
+) {
+	const (
+		inactivity      = uint64(90)
+		activationEpoch = uint64(2)
+	)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+	cred := renewTestCred(0x54)
+	seedRollbackCertificate(
+		t, db, 50, rollbackStakeRegistrationCertificate(cred),
+	)
+	seedRollbackCertificate(
+		t, db, 150, rollbackStakeDeregistrationCertificate(cred),
+	)
+
+	// The account exists but is inactive at A, so activation must not record it
+	// in the durable stamped-membership set.
+	require.NoError(t, runActivate(t, ls, db, activationEpoch))
+
+	// A later registration is rolled away. The surviving deregistration is a
+	// witness in epoch 1, and must not be clamped to activation epoch 2.
+	seedRollbackCertificate(
+		t, db, 250, rollbackStakeRegistrationCertificate(cred),
+	)
+	require.NoError(t, db.RenewAccountExpirations(
+		[]models.StakeCredentialRef{models.NewStakeCredentialRef(0, cred)},
+		2+inactivity,
+		nil,
+	))
+
+	runRollbackRecompute(t, ls, db, 225)
+
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1)+inactivity, acct.ExpirationEpoch)
+}
+
+func TestRecomputeAccountExpirationsAfterRollbackBeforeActivation(t *testing.T) {
+	const inactivity = uint64(90)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+	cred := renewTestCred(0x44)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred, Active: true, ExpirationEpoch: 2 + inactivity,
+	}))
+	require.NoError(t, runActivate(t, ls, db, 2))
+
+	runRollbackRecompute(t, ls, db, 199) // epoch 1, before activation epoch 2
+
+	acct, err := db.GetAccountByCredential(0, cred, true, nil)
+	require.NoError(t, err)
+	require.Zero(t, acct.ExpirationEpoch)
+	marker, err := db.GetSyncState(delegatorInactivityActivatedSyncKey, nil)
+	require.NoError(t, err)
+	require.Empty(t, marker)
+}

--- a/ledger/account_expiry_rollback_test.go
+++ b/ledger/account_expiry_rollback_test.go
@@ -405,6 +405,13 @@ func TestRecomputeAccountExpirationsAfterRollbackDoesNotFloorAccountInactiveAtAc
 	)
 	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
 	cred := renewTestCred(0x54)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    cred,
+		CredentialTag: 0,
+		Active:        false,
+		AddedSlot:     50,
+		CreatedSlot:   50,
+	}))
 	seedRollbackCertificate(
 		t, db, 50, rollbackStakeRegistrationCertificate(cred),
 	)

--- a/ledger/account_expiry_test.go
+++ b/ledger/account_expiry_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import "testing"
+
+func TestAccountExpiredAtEpoch(t *testing.T) {
+	cases := []struct {
+		exp, cur uint64
+		expired  bool
+	}{
+		{0, 0, false},   // unset => active
+		{0, 100, false}, // unset => active regardless of epoch
+		{10, 9, false},  // exp >= cur => active
+		{10, 10, false}, // boundary: exp == cur => active (CIP: expired is < cur)
+		{10, 11, true},  // exp < cur => expired
+	}
+	for _, c := range cases {
+		if got := accountExpiredAtEpoch(c.exp, c.cur); got != c.expired {
+			t.Fatalf("accountExpiredAtEpoch(%d,%d)=%v want %v", c.exp, c.cur, got, c.expired)
+		}
+	}
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3777,14 +3777,16 @@ func (ls *LedgerState) processEpochRollover(
 	//   4. applyMIRCerts                 — Shelley-era INSTANT rule: apply
 	//      Move Instantaneous Rewards certificates accumulated during the
 	//      ended epoch. No-op for Conway+ epochs (no MIR certs exist).
-	//   5. governance.ProcessEpoch       — Conway-style HardForkInitiation /
+	//   5. activateDelegatorInactivityIfNeeded — one-time CIP-0163 activation
+	//      before any inactivity-gated boundary calculation.
+	//   6. governance.ProcessEpoch       — Conway-style HardForkInitiation /
 	//      ParameterChange enactment; may further mutate pparams.
-	//   6. SetPParams                    — persist the enacted pparams.
-	//   7. IsHardForkTransition check    — detect inter-era boundary from
+	//   7. SetPParams                    — persist the enacted pparams.
+	//   8. IsHardForkTransition check    — detect inter-era boundary from
 	//      the now-final pparams.
-	//   8. applyIntraEraHardForkRule     — dispatch the per-major-version
+	//   9. applyIntraEraHardForkRule     — dispatch the per-major-version
 	//      HARDFORK STS rule (e.g. pv3 AVVM removal, pv10 DRep clear).
-	//   9. saveRewardAdaPotsForEpoch     — capture the new epoch's ADA pots
+	//  10. saveRewardAdaPotsForEpoch     — capture the new epoch's ADA pots
 	//      (reserves/treasury/fees) after all boundary pot mutations so the
 	//      next delayed reward calculation has its pot inputs.
 	//
@@ -3840,6 +3842,17 @@ func (ls *LedgerState) processEpochRollover(
 		return nil, fmt.Errorf("apply MIR certs: %w", err)
 	}
 
+	// CIP-0163: one-time activation stamp. It must precede governance's
+	// inactivity-gated DRep voting-power calculation so every active account
+	// receives the same full window starting at the activation boundary. The
+	// new epoch row is persisted later in this transaction; the stamp and
+	// durable marker still commit or roll back atomically with it.
+	if err := ls.activateDelegatorInactivityIfNeeded(
+		txn, currentEpoch.EpochId+1,
+	); err != nil {
+		return nil, err
+	}
+
 	// Run the CIP-1694 governance tick: enact proposals ratified in the
 	// previous epoch (possibly mutating pparams), expire stale proposals,
 	// and ratify active proposals whose tallies meet threshold. Any
@@ -3850,15 +3863,16 @@ func (ls *LedgerState) processEpochRollover(
 		conwayGenesis = ls.config.CardanoNodeConfig.ConwayGenesis()
 	}
 	govOut, err := governance.ProcessEpoch(&governance.EpochInput{
-		DB:            ls.db,
-		Txn:           txn,
-		Logger:        ls.config.Logger,
-		PrevEpoch:     currentEpoch.EpochId,
-		NewEpoch:      currentEpoch.EpochId + 1,
-		BoundarySlot:  epochStartSlot,
-		PParams:       newPParams,
-		UpdateFn:      currentEra.PParamsUpdateFunc,
-		ConwayGenesis: conwayGenesis,
+		DB:                    ls.db,
+		Txn:                   txn,
+		Logger:                ls.config.Logger,
+		PrevEpoch:             currentEpoch.EpochId,
+		NewEpoch:              currentEpoch.EpochId + 1,
+		BoundarySlot:          epochStartSlot,
+		PParams:               newPParams,
+		UpdateFn:              currentEra.PParamsUpdateFunc,
+		ConwayGenesis:         conwayGenesis,
+		DelegatorInactivityOn: ls.config.DelegatorInactivityEnabled,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("process governance epoch: %w", err)

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3850,7 +3850,7 @@ func (ls *LedgerState) processEpochRollover(
 	if err := ls.activateDelegatorInactivityIfNeeded(
 		txn, currentEpoch.EpochId+1,
 	); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("activate delegator inactivity: %w", err)
 	}
 
 	// Run the CIP-1694 governance tick: enact proposals ratified in the

--- a/ledger/chainsync_ordering_test.go
+++ b/ledger/chainsync_ordering_test.go
@@ -115,13 +115,14 @@ func TestProcessEpochRollover_OrderingInvariant(t *testing.T) {
 	// Each entry is the trailing identifier of a SelectorExpr (or a bare
 	// Ident for unqualified calls).
 	wantOrder := []string{
-		"ComputeAndApplyPParamUpdates", // (1) Shelley-style pparam updates
-		"applyPoolRetirements",         // (2) embedded POOLREAP deposit refunds
-		"applyMIRCerts",                // (3) Shelley-era INSTANT rule
-		"ProcessEpoch",                 // (4) Conway-style governance enact
-		"SetPParams",                   // (5) persist enacted pparams
-		"isHardForkTransition",         // (6) inter-era boundary detection
-		"applyIntraEraHardForkRule",    // (7) per-major-version HARDFORK rule
+		"ComputeAndApplyPParamUpdates",        // (1) Shelley-style pparam updates
+		"applyPoolRetirements",                // (2) embedded POOLREAP deposit refunds
+		"applyMIRCerts",                       // (3) Shelley-era INSTANT rule
+		"activateDelegatorInactivityIfNeeded", // (4) CIP-0163 activation
+		"ProcessEpoch",                        // (5) Conway-style governance enact
+		"SetPParams",                          // (6) persist enacted pparams
+		"isHardForkTransition",                // (7) inter-era boundary detection
+		"applyIntraEraHardForkRule",           // (8) per-major-version HARDFORK rule
 	}
 
 	seen, observed := observeProcessEpochRolloverCallOrder(t, targetFunc, wantOrder)

--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -194,6 +194,36 @@ func (d *LedgerDelta) applyWithDonationRecording(
 		}
 	}
 
+	// CIP-0163: renew reward-account expirations for the credentials witnessed
+	// by this block's transactions. This runs after every transaction's effects
+	// (including stake-key registrations that create account rows) have been
+	// written to the same DB transaction above, so a credential registered by
+	// this block already has a row for RenewAccountExpirations to update, and
+	// the renewal commits or rolls back atomically with the block. It is a
+	// no-op when the delegator-inactivity gate is off. The renewal is idempotent
+	// and monotonic, so applying it per delta (once per block outside
+	// validation, once per transaction while validating, where each tx is its
+	// own delta) yields the same final expiration as applying it once per block.
+	if ls.config.DelegatorInactivityEnabled {
+		ls.RLock()
+		currentEpoch := ls.currentEpoch.EpochId
+		ls.RUnlock()
+		witnessTxs := make([]lcommon.Transaction, 0, len(d.Transactions))
+		for i, tr := range d.Transactions {
+			if !appliedTxs[i] {
+				continue
+			}
+			witnessTxs = append(witnessTxs, tr.Tx)
+		}
+		if err := ls.renewWitnessedAccountExpirations(
+			txn,
+			currentEpoch,
+			witnessTxs,
+		); err != nil {
+			return fmt.Errorf("renew witnessed account expirations: %w", err)
+		}
+	}
+
 	if recordDonations {
 		if err := d.recordNetworkDonations(ls, txn, appliedTxs); err != nil {
 			return err

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -55,6 +55,12 @@ type EpochInput struct {
 	// used until a live per-committee quorum is persisted in state.
 	// Nil falls back to the hardcoded default.
 	ConwayGenesis *conway.ConwayGenesis
+	// DelegatorInactivityOn mirrors LedgerStateConfig.DelegatorInactivityEnabled
+	// (CIP-0163): when true, the DRep voting-power denominator excludes
+	// reward accounts whose expiration_epoch is nonzero and stale relative
+	// to NewEpoch. Defaults false (gate off), keeping the tally
+	// byte-identical to the pre-CIP behavior.
+	DelegatorInactivityOn bool
 }
 
 // EpochOutput reports what happened during the tick so the
@@ -291,10 +297,11 @@ func ProcessEpoch(
 	// ratification input here without updating the mid-epoch path
 	// will silently make the two answers diverge — keep them in sync.
 	tallyCtx := &TallyContext{
-		DB:           in.DB,
-		Txn:          in.Txn,
-		StakeEpoch:   stakeEpochFor(in.NewEpoch),
-		CurrentEpoch: in.NewEpoch,
+		DB:                    in.DB,
+		Txn:                   in.Txn,
+		StakeEpoch:            stakeEpochFor(in.NewEpoch),
+		CurrentEpoch:          in.NewEpoch,
+		DelegatorInactivityOn: in.DelegatorInactivityOn,
 	}
 
 	// Active set changes as we ratify; snapshot once.
@@ -354,7 +361,9 @@ func ProcessEpoch(
 	drepState := &DRepVotingState{}
 	spoState := &SPOVotingState{}
 	if len(stillActive) > 0 {
-		drepState, err = LoadDRepVotingState(in.DB, in.Txn, in.NewEpoch)
+		drepState, err = LoadDRepVotingState(
+			in.DB, in.Txn, in.NewEpoch, in.DelegatorInactivityOn,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("load drep voting state: %w", err)
 		}

--- a/ledger/governance/stability.go
+++ b/ledger/governance/stability.go
@@ -40,6 +40,7 @@ type StabilityCheckInputs struct {
 	DB                      *database.Database
 	Txn                     *database.Txn
 	CurrentEpoch            uint64
+	DelegatorInactivityOn   bool
 	PParams                 lcommon.ProtocolParameters
 	ConwayGenesis           *conway.ConwayGenesis
 	OnProposalDecodeFailure func(proposal *models.GovernanceProposal, err error)
@@ -49,6 +50,7 @@ func NewStabilityCheckInputs(
 	db *database.Database,
 	txn *database.Txn,
 	currentEpoch uint64,
+	delegatorInactivityOn bool,
 	pparams lcommon.ProtocolParameters,
 	conwayGenesis *conway.ConwayGenesis,
 	onProposalDecodeFailure func(proposal *models.GovernanceProposal, err error),
@@ -57,6 +59,7 @@ func NewStabilityCheckInputs(
 		DB:                      db,
 		Txn:                     txn,
 		CurrentEpoch:            currentEpoch,
+		DelegatorInactivityOn:   delegatorInactivityOn,
 		PParams:                 pparams,
 		ConwayGenesis:           conwayGenesis,
 		OnProposalDecodeFailure: onProposalDecodeFailure,
@@ -125,10 +128,11 @@ func EvaluateRatifiableHardForkInitiation(
 	// boundary path performs; doing them again here is the cost of not
 	// sharing with ProcessEpoch.
 	tallyCtx := &TallyContext{
-		DB:           in.DB,
-		Txn:          in.Txn,
-		StakeEpoch:   stakeEpochFor(in.CurrentEpoch),
-		CurrentEpoch: in.CurrentEpoch,
+		DB:                    in.DB,
+		Txn:                   in.Txn,
+		StakeEpoch:            stakeEpochFor(in.CurrentEpoch),
+		CurrentEpoch:          in.CurrentEpoch,
+		DelegatorInactivityOn: in.DelegatorInactivityOn,
 	}
 
 	activeDRepCount, err := countActiveDReps(in.DB, in.Txn, in.CurrentEpoch)

--- a/ledger/governance/stability_test.go
+++ b/ledger/governance/stability_test.go
@@ -146,7 +146,7 @@ func seedDRepYesVote(
 func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T) {
 	db, _ := newTallyTestDB(t)
 	// pre-Conway: no governance state machine yet
-	in := NewStabilityCheckInputs(db, nil, stabilityTestEpoch, nil, nil, nil)
+	in := NewStabilityCheckInputs(db, nil, stabilityTestEpoch, false, nil, nil, nil)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
 	assert.Nil(t, got, "pre-Conway pparams must short-circuit to nil")
@@ -155,7 +155,7 @@ func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(t *testing.T)
 func TestEvaluateRatifiableHardForkInitiation_NoActiveProposals_ReturnsNil(t *testing.T) {
 	db, _ := newTallyTestDB(t)
 	in := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func TestEvaluateRatifiableHardForkInitiation_OnlyOtherActionType_ReturnsNil(t *
 	}, nil))
 
 	in := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(t *testin
 	seedDRepYesVote(t, db, proposal.ID, drepCred)
 
 	in := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -217,6 +217,39 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(t *testin
 		"target major must come from the proposal's encoded action")
 	assert.Equal(t, proposal.ID, got.Proposal.ID,
 		"the helper must return the proposal that ratifies")
+}
+
+func TestEvaluateRatifiableHardForkInitiation_DelegatorInactivityParity(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+
+	proposal := seedHardForkInitiationProposal(
+		t, db, stabilityTestEpoch, 11, 1, stabilityProposalTx,
+	)
+	drepCred := seedDRepWithStake(t, db, 1_000)
+	seedDRepYesVote(t, db, proposal.ID, drepCred)
+	rewardCred := models.NewStakeCredentialRef(
+		0,
+		testBytes(28, stabilityStakeCred),
+	)
+	require.NoError(t, db.RenewAccountExpirations(
+		[]models.StakeCredentialRef{rewardCred},
+		stabilityTestEpoch-1,
+		nil,
+	))
+
+	gateOff := NewStabilityCheckInputs(
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
+	)
+	got, err := EvaluateRatifiableHardForkInitiation(gateOff)
+	require.NoError(t, err)
+	require.NotNil(t, got, "gate off must preserve the expired account's vote")
+
+	gateOn := NewStabilityCheckInputs(
+		db, nil, stabilityTestEpoch, true, stabilityConwayPParams(9), nil, nil,
+	)
+	got, err = EvaluateRatifiableHardForkInitiation(gateOn)
+	require.NoError(t, err)
+	assert.Nil(t, got, "gate on must match boundary tally and exclude expired stake")
 }
 
 // TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable
@@ -228,7 +261,7 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(t *
 	seedHardForkInitiationProposal(t, db, stabilityTestEpoch, 11, 1, stabilityProposalTx)
 
 	in := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
@@ -264,7 +297,7 @@ func TestEvaluateRatifiableHardForkInitiation_MultipleRatifiable_PicksLowestAdde
 	seedDRepYesVote(t, db, late.ID, drepCred)
 
 	in := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -70,6 +70,12 @@ type TallyContext struct {
 	// proposal loop, mirroring CommitteeState.
 	DRepState *DRepVotingState
 	SPOState  *SPOVotingState
+	// DelegatorInactivityOn mirrors the CIP-0163 reward-account inactivity
+	// gate (ledger LedgerStateConfig.DelegatorInactivityEnabled) into the
+	// lazy tallyDRepVotes fallback path (used when DRepState is nil, i.e.
+	// standalone/test callers). ProcessEpoch always uses the precomputed
+	// DRepState instead, loaded via LoadDRepVotingState with this same gate.
+	DelegatorInactivityOn bool
 }
 
 // CommitteeVotingState is the ratification view of the seated CC:
@@ -224,13 +230,26 @@ type DRepVotingState struct {
 // LoadDRepVotingState computes the DRep voting denominators for the
 // given epoch. It is the single heavy query (active DReps + batched
 // voting power) hoisted out of the per-proposal tally path.
+// delegatorInactivityOn mirrors the CIP-0163 reward-account inactivity gate
+// (ledger LedgerStateConfig.DelegatorInactivityEnabled): when true, the
+// voting-power queries exclude reward accounts whose expiration_epoch is
+// nonzero and stale relative to currentEpoch; when false the queries are
+// byte-identical to the pre-CIP behavior (no account is excluded).
 func LoadDRepVotingState(
 	db *database.Database,
 	txn *database.Txn,
 	currentEpoch uint64,
+	delegatorInactivityOn bool,
 ) (*DRepVotingState, error) {
 	if db == nil {
 		return nil, errors.New("nil database")
+	}
+	// expiryEpoch encodes the CIP-0163 gate for the voting-power queries:
+	// 0 = off (byte-identical SQL/args), >0 = exclude accounts whose
+	// expiration_epoch is nonzero and less than expiryEpoch.
+	var expiryEpoch uint64
+	if delegatorInactivityOn {
+		expiryEpoch = currentEpoch
 	}
 	allDreps, err := db.GetActiveDreps(txn)
 	if err != nil {
@@ -258,7 +277,7 @@ func LoadDRepVotingState(
 		for i, drep := range dreps {
 			creds[i] = models.StakeCredentialRef{Tag: drep.CredentialTag, Key: drep.Credential}
 		}
-		powers, err = db.GetDRepVotingPowerBatch(creds, txn)
+		powers, err = db.GetDRepVotingPowerBatch(creds, expiryEpoch, txn)
 		if err != nil {
 			return nil, fmt.Errorf("batch drep voting power: %w", err)
 		}
@@ -269,6 +288,7 @@ func LoadDRepVotingState(
 			models.DrepTypeAlwaysAbstain,
 			models.DrepTypeAlwaysNoConfidence,
 		},
+		expiryEpoch,
 		txn,
 	)
 	if err != nil {
@@ -295,7 +315,9 @@ func tallyDRepVotes(
 	state := ctx.DRepState
 	if state == nil {
 		var err error
-		state, err = LoadDRepVotingState(ctx.DB, ctx.Txn, ctx.CurrentEpoch)
+		state, err = LoadDRepVotingState(
+			ctx.DB, ctx.Txn, ctx.CurrentEpoch, ctx.DelegatorInactivityOn,
+		)
 		if err != nil {
 			return err
 		}

--- a/ledger/governance/tally_dedup_test.go
+++ b/ledger/governance/tally_dedup_test.go
@@ -57,7 +57,7 @@ func TestLoadDRepVotingStateMatchesLazyTally(t *testing.T) {
 	}
 	require.NoError(t, tallyDRepVotes(&TallyContext{DB: db}, votes, lazyTally))
 
-	state, err := LoadDRepVotingState(db, nil, 0)
+	state, err := LoadDRepVotingState(db, nil, 0, false)
 	require.NoError(t, err)
 	precomputedTally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeTreasuryWithdrawal),
@@ -86,7 +86,7 @@ func TestPrecomputedDRepStateReusedAcrossProposals(t *testing.T) {
 		t, store, stakeCred, nil, models.DrepTypeAlwaysNoConfidence, 30, 3,
 	)
 
-	state, err := LoadDRepVotingState(db, nil, 0)
+	state, err := LoadDRepVotingState(db, nil, 0, false)
 	require.NoError(t, err)
 
 	noConfidence := &ProposalTally{

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -89,6 +89,16 @@ type stakeRewardApplication struct {
 	unspendable      uint64
 	precomputed      bool
 	outputsUpdated   bool
+	// guardedRewardCredentials is the CIP-0163 reward-crediting guard set,
+	// populated only at application time when the delegator-inactivity gate is
+	// on (nil otherwise, so the gate-off path is byte-identical). Its keys are
+	// StakeCredentialRef.MapKey() values for reward-account credentials that are
+	// expired as of epochs.snapshot -- the same snapshot epoch Task 8 used to
+	// build the reward basis. An output whose credential is in this set is
+	// neither credited (applyStakeRewardApplication) nor counted toward
+	// effective/unspendable (deriveStakeRewardApplicationTotals), so its amount
+	// falls through to undistributed and is refunded to reserves.
+	guardedRewardCredentials map[string]struct{}
 	// snapshotCapturedSlot and snapshotBoundarySlot record the reward_snapshot
 	// row's own captured/boundary slots as observed by
 	// calculateStakeRewardApplication. Callers that compute this application
@@ -318,12 +328,33 @@ func (ls *LedgerState) applyStakeRewardApplication(
 		}
 	}
 
+	// CIP-0163 reward-crediting guard (Mechanism B, Task 10). A pool's reward
+	// (leader) account is credited its leader reward independent of its own
+	// stake, so -- unlike an expired delegator, whose stake Task 8 already
+	// removed from the reward basis -- an expired reward account could still be
+	// credited here. Build the set of credited credentials that are expired as
+	// of the reward's snapshot epoch (the same epoch Task 8 judged the basis
+	// against) so the crediting loop and deriveStakeRewardApplicationTotals
+	// agree: a guarded amount is not credited and lands in undistributed ->
+	// reserves rather than being counted effective. Gate off leaves the set nil
+	// (no load, byte-identical to pre-CIP behavior).
+	if ls.config.DelegatorInactivityEnabled {
+		guarded, err := ls.guardedExpiredRewardCredentials(txn, app)
+		if err != nil {
+			return err
+		}
+		app.guardedRewardCredentials = guarded
+	}
+
 	for _, output := range app.accountOutputs {
 		reward, err := rewardFromAccountOutput(output)
 		if err != nil {
 			return err
 		}
 		if !reward.Spendable {
+			continue
+		}
+		if rewardOutputGuarded(app, output) {
 			continue
 		}
 		if err := ls.db.AddAccountRewardByCredential(
@@ -375,6 +406,113 @@ func (ls *LedgerState) applyStakeRewardApplication(
 		"unspendable_rewards", app.unspendable,
 	)
 	return nil
+}
+
+// guardedExpiredRewardCredentials returns the set of credited reward-account
+// credentials that are expired as of the reward snapshot, keyed by
+// StakeCredentialRef.MapKey(). Expiry is reconstructed from witness history at
+// the snapshot's captured slot, rather than read from the mutable account row:
+// a later witness may already have renewed that row by application time.
+func (ls *LedgerState) guardedExpiredRewardCredentials(
+	txn *database.Txn,
+	app *stakeRewardApplication,
+) (map[string]struct{}, error) {
+	if app == nil || len(app.accountOutputs) == 0 {
+		return nil, nil
+	}
+	refsByKey := make(map[string]models.StakeCredentialRef, len(app.accountOutputs))
+	for _, output := range app.accountOutputs {
+		if output == nil || len(output.StakingKey) != rewards.CredentialHashSize {
+			continue
+		}
+		ref := models.NewStakeCredentialRef(output.CredentialTag, output.StakingKey)
+		refsByKey[ref.MapKey()] = ref
+	}
+	if len(refsByKey) == 0 {
+		return nil, nil
+	}
+	refs := make([]models.StakeCredentialRef, 0, len(refsByKey))
+	for _, ref := range refsByKey {
+		refs = append(refs, ref)
+	}
+	accounts, err := ls.db.GetAccountsByCredential(refs, true, txn)
+	if err != nil {
+		return nil, fmt.Errorf("load reward account expirations: %w", err)
+	}
+	lastWitness, err := ls.db.AccountLastWitnessSlots(
+		refs, app.snapshotCapturedSlot, txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load reward account witness history: %w", err)
+	}
+	activationEpoch, activated, err := ls.delegatorInactivityActivationEpoch(txn)
+	if err != nil {
+		return nil, fmt.Errorf("load delegator-inactivity activation: %w", err)
+	}
+	activationApplies := activated && activationEpoch <= app.epochs.snapshot
+	var activationMembership map[string]struct{}
+	if activationApplies {
+		activationMembership, err = ls.db.AccountInactivityActivationMembership(
+			refs,
+			txn,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("load activation membership: %w", err)
+		}
+	}
+	var guarded map[string]struct{}
+	for key, account := range accounts {
+		if account == nil {
+			continue
+		}
+		// Imported/bootstrap rows may carry an expiry without locally retained
+		// witness history, so retain the projection as a fallback. When history
+		// exists it is authoritative at the snapshot cutoff.
+		expiration := account.ExpirationEpoch
+		if slot, ok := lastWitness[key]; ok {
+			epoch, epochErr := ls.SlotToEpoch(slot)
+			if epochErr != nil {
+				return nil, fmt.Errorf("map reward witness slot %d to epoch: %w", slot, epochErr)
+			}
+			expiration = epoch.EpochId + ls.config.DelegatorInactivity
+		}
+		if activationApplies {
+			floor, applies := rollbackActivationFloor(
+				models.NewStakeCredentialRef(account.CredentialTag, account.StakingKey),
+				true, activationEpoch, activationMembership,
+			)
+			if applies {
+				expiration = max(expiration, floor+ls.config.DelegatorInactivity)
+			}
+		}
+		if accountExpiredAtEpoch(expiration, app.epochs.snapshot) {
+			if guarded == nil {
+				guarded = make(map[string]struct{})
+			}
+			guarded[key] = struct{}{}
+		}
+	}
+	return guarded, nil
+}
+
+// rewardOutputGuarded reports whether an account output's reward-account
+// credential is in the CIP-0163 guard set. It returns false whenever the set is
+// empty (always the case when the gate is off), so both the crediting loop and
+// deriveStakeRewardApplicationTotals skip exactly the same outputs and remain
+// byte-identical to pre-CIP behavior when the gate is off.
+func rewardOutputGuarded(
+	app *stakeRewardApplication,
+	output *models.RewardAccountOutput,
+) bool {
+	if app == nil || len(app.guardedRewardCredentials) == 0 || output == nil {
+		return false
+	}
+	key := models.NewStakeCredentialRef(
+		output.CredentialTag,
+		output.StakingKey,
+	).MapKey()
+	_, ok := app.guardedRewardCredentials[key]
+	return ok
 }
 
 func (ls *LedgerState) precomputedStakeRewardApplication(
@@ -1918,6 +2056,15 @@ func deriveStakeRewardApplicationTotals(app *stakeRewardApplication) error {
 	app.unspendable = 0
 	for _, output := range app.accountOutputs {
 		if output == nil {
+			continue
+		}
+		// CIP-0163 guard: an output whose reward account is expired as of the
+		// snapshot epoch is neither credited nor counted here, so its amount
+		// falls through to undistributed (see undistributed below) and is
+		// refunded to reserves. This must match the crediting loop's skip in
+		// applyStakeRewardApplication exactly. The set is nil unless the gate
+		// was on at application time, keeping the gate-off path byte-identical.
+		if rewardOutputGuarded(app, output) {
 			continue
 		}
 		amount := uint64(output.Amount)

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -765,15 +765,22 @@ func (ls *LedgerState) precomputedStakeRewardApplication(
 		return nil, false, err
 	}
 	app := &stakeRewardApplication{
-		epochs:         epochs,
-		pparams:        pparams,
-		params:         params,
-		pots:           pots,
-		poolOutputs:    poolOutputs,
-		accountOutputs: accountOutputs,
-		totalRewardPot: uint64(pots.Rewards),
-		precomputed:    true,
-		outputsUpdated: outputsUpdated,
+		epochs:                   epochs,
+		pparams:                  pparams,
+		params:                   params,
+		pots:                     pots,
+		poolOutputs:              poolOutputs,
+		accountOutputs:           accountOutputs,
+		totalRewardPot:           uint64(pots.Rewards),
+		precomputed:              true,
+		outputsUpdated:           outputsUpdated,
+		snapshotCapturedSlot:     rewardSnapshot.CapturedSlot,
+		snapshotBoundarySlot:     rewardSnapshot.BoundarySlot,
+		snapshotEpochNonce:       rewardSnapshot.EpochNonce,
+		snapshotTotalActiveStake: rewardSnapshot.TotalActiveStake,
+		snapshotTotalPoolCount:   rewardSnapshot.TotalPoolCount,
+		snapshotTotalDelegators:  rewardSnapshot.TotalDelegators,
+		snapshotProtocolVersion:  rewardSnapshot.ProtocolVersion,
 	}
 	if err := deriveStakeRewardApplicationTotals(app); err != nil {
 		return nil, false, err

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -3522,7 +3522,6 @@ func TestPrecomputedStakeRewardsRejectEarlyPreBabbageOutputs(t *testing.T) {
 		seedOutputs(t, db)
 
 		txn := db.Transaction(false)
-		defer func() { _ = txn.Rollback() }()
 		app, ok, err := ls.precomputedStakeRewardApplication(
 			txn,
 			newEpoch,
@@ -3555,6 +3554,59 @@ func TestPrecomputedStakeRewardsRejectEarlyPreBabbageOutputs(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, app)
 		require.True(t, app.precomputed)
+		require.Equal(t, uint64(100), app.snapshotCapturedSlot)
+		require.Equal(t, uint64(100), app.snapshotBoundarySlot)
+		require.NoError(t, txn.Rollback())
+
+		// Exercise the application-time expiry guard with a renewal after the
+		// captured snapshot. The fixture's reward epoch is 1, but the earliest
+		// concrete expiry is also 1, so judge this isolated boundary case at
+		// epoch 2: the slot-50 witness gives expiry 1 (expired), while the
+		// slot-150 renewal projected onto the mutable account row gives expiry
+		// 2 (active at equality). The precomputed application must retain its
+		// captured-slot cutoff and therefore ignore that later renewal.
+		ls.config.DelegatorInactivityEnabled = true
+		ls.config.DelegatorInactivity = 1
+		ls.epochCache = []models.Epoch{
+			{
+				EpochId: 0, StartSlot: 0, SlotLength: 1000,
+				LengthInSlots: 100, EraId: eras.ShelleyEraDesc.Id,
+			},
+			{
+				EpochId: 1, StartSlot: 100, SlotLength: 1000,
+				LengthInSlots: 100, EraId: eras.ShelleyEraDesc.Id,
+			},
+		}
+		ls.publishSnapshotsLocked()
+		rewardAccount := rewardCalcHash(0x5a)
+		seedRollbackCertificate(
+			t, db, 50, rollbackStakeRegistrationCertificate(rewardAccount),
+		)
+		seedRollbackCertificate(
+			t, db, 150, rollbackStakeRegistrationCertificate(rewardAccount),
+		)
+		require.NoError(t, db.RenewAccountExpirations(
+			[]models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, rewardAccount),
+			},
+			2,
+			nil,
+		))
+		app.epochs.snapshot = 2
+
+		guardTxn := db.Transaction(false)
+		require.NoError(t, guardTxn.Do(func(txn *database.Txn) error {
+			guarded, err := ls.guardedExpiredRewardCredentials(txn, app)
+			if err != nil {
+				return err
+			}
+			require.Contains(
+				t,
+				guarded,
+				models.NewStakeCredentialRef(0, rewardAccount).MapKey(),
+			)
+			return nil
+		}))
 	})
 }
 

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -192,6 +192,9 @@ func TestApplyStakeRewardsUsesDelayedRewardState(t *testing.T) {
 
 	liveInputs, err := meta.GetRewardStakeInputsForPools(
 		[][]byte{poolKey},
+		boundarySlot,
+		0, // gate off: live aggregate, slot/inactivity ignored
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -243,6 +246,9 @@ func TestApplyStakeRewardsUsesDelayedRewardState(t *testing.T) {
 	require.Equal(t, uint64(37_049), uint64(rewardMember.Reward))
 	liveInputs, err = meta.GetRewardStakeInputsForPools(
 		[][]byte{poolKey},
+		boundarySlot,
+		0, // gate off: live aggregate, slot/inactivity ignored
+		0,
 		nil,
 	)
 	require.NoError(t, err)
@@ -258,6 +264,293 @@ func TestApplyStakeRewardsUsesDelayedRewardState(t *testing.T) {
 		Where("added_slot = ?", boundarySlot).
 		Count(&deltas).Error)
 	require.Equal(t, int64(2), deltas)
+}
+
+// guardExpiredLeaderResult captures the post-application state a Task 10
+// scenario run produces, so gate-on and gate-off runs can be compared.
+type guardExpiredLeaderResult struct {
+	reserves           uint64
+	treasury           uint64
+	leaderReward       uint64 // credited to the reward (leader) account
+	memberReward       uint64 // credited to the member delegator
+	leaderOutputAmount uint64 // persisted leader account output amount
+	memberOutputAmount uint64 // persisted member account output amount
+}
+
+// applyGuardExpiredLeaderScenario seeds a single-pool reward application in
+// which the pool's reward (leader) account is expired as of the reward's
+// snapshot epoch, runs the application with the delegator-inactivity gate set
+// to gateEnabled, and returns the resulting network state and reward balances.
+//
+// It is the shared harness for the Task 10 reward-crediting guard. newEpoch is
+// 5, so stakeRewardEpochsForApplication maps it to snapshot epoch 2: an
+// ExpirationEpoch of 1 is nonzero and strictly before 2 (expired), while an
+// unset (0) expiration is active. This is the same snapshot epoch Task 8 uses
+// to build the reward basis, so the guard and the basis agree on which snapshot
+// an account is judged against.
+func applyGuardExpiredLeaderScenario(
+	t *testing.T,
+	gateEnabled bool,
+) guardExpiredLeaderResult {
+	t.Helper()
+	ls, db := newRewardCalculationTestLedger(t)
+	ls.config.DelegatorInactivityEnabled = gateEnabled
+	meta := db.Metadata()
+
+	const (
+		newEpoch            = uint64(5)
+		rewardSnapshotEpoch = uint64(2)
+		performanceEpoch    = uint64(3)
+		potsEpoch           = uint64(4)
+		boundarySlot        = uint64(500)
+	)
+	poolKey := rewardCalcHash(0x11)
+	rewardAccount := rewardCalcHash(0x22)
+	member := rewardCalcHash(0x33)
+	var poolID lcommon.PoolKeyHash
+	copy(poolID[:], poolKey)
+
+	pparams := &shelley.ShelleyProtocolParameters{
+		NOpt:             10,
+		A0:               rewardCalcRat(1, 2),
+		Rho:              rewardCalcRat(1, 100),
+		Tau:              rewardCalcRat(0, 1),
+		Decentralization: rewardCalcRat(0, 1),
+		ProtocolMajor:    7,
+		ProtocolMinor:    0,
+	}
+	pparamsCbor, err := cbor.Encode(pparams)
+	require.NoError(t, err)
+
+	require.NoError(t, meta.SetEpoch(100, performanceEpoch, nil, nil, nil, nil, eras.ShelleyEraDesc.Id, 1, 100, nil))
+	require.NoError(t, meta.SetEpoch(200, potsEpoch, nil, nil, nil, nil, eras.ShelleyEraDesc.Id, 1, 100, nil))
+	for i := range uint64(10) {
+		require.NoError(t, db.UpdatePoolOpCertSequence(
+			poolID,
+			i+1,
+			140+i,
+			nil,
+		))
+	}
+	require.NoError(t, db.SetPParams(
+		pparamsCbor,
+		100,
+		performanceEpoch,
+		eras.ShelleyEraDesc.Id,
+		nil,
+	))
+	require.NoError(t, meta.SaveRewardAdaPots(&models.RewardAdaPots{
+		Epoch:        potsEpoch,
+		Reserves:     100_000_000,
+		CapturedSlot: 300,
+	}, nil))
+	require.NoError(t, meta.SaveRewardSnapshot(&models.RewardSnapshot{
+		Epoch:            rewardSnapshotEpoch,
+		SnapshotType:     "mark",
+		TotalActiveStake: 1_000,
+		TotalPoolCount:   1,
+		TotalDelegators:  2,
+		CapturedSlot:     100,
+		BoundarySlot:     100,
+		ProtocolVersion:  7,
+	}, nil))
+	require.NoError(t, meta.SaveRewardPoolInputs([]*models.RewardPoolInput{
+		{
+			Epoch:                      rewardSnapshotEpoch,
+			PoolKeyHash:                poolKey,
+			RewardAccount:              rewardAccount,
+			RewardAccountCredentialTag: 0,
+			Margin:                     &types.Rat{Rat: big.NewRat(1, 10)},
+			Pledge:                     500,
+			Cost:                       1_000,
+			DelegatedStake:             1_000,
+			OwnerStake:                 500,
+			DelegatorCount:             2,
+			CapturedSlot:               100,
+			BoundarySlot:               100,
+		},
+	}, nil))
+	require.NoError(t, meta.SaveRewardStakeInputs([]*models.RewardStakeInput{
+		{
+			Epoch:         rewardSnapshotEpoch,
+			PoolKeyHash:   poolKey,
+			CredentialTag: 0,
+			StakingKey:    rewardAccount,
+			Stake:         500,
+			Owner:         true,
+			Registered:    true,
+			CapturedSlot:  100,
+			BoundarySlot:  100,
+		},
+		{
+			Epoch:         rewardSnapshotEpoch,
+			PoolKeyHash:   poolKey,
+			CredentialTag: 0,
+			StakingKey:    member,
+			Stake:         500,
+			Registered:    true,
+			CapturedSlot:  100,
+			BoundarySlot:  100,
+		},
+	}, nil))
+	gormDB := rewardCalcGormDB(t, db)
+	pool := models.Pool{PoolKeyHash: poolKey}
+	require.NoError(t, gormDB.Create(&pool).Error)
+	require.NoError(t, gormDB.Create(&models.PoolRegistration{
+		PoolID:      pool.ID,
+		PoolKeyHash: poolKey,
+		AddedSlot:   0,
+	}).Error)
+	// The reward (leader) account is expired as of the snapshot epoch (2):
+	// ExpirationEpoch 1 is nonzero and strictly before 2.
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      rewardAccount,
+		Pool:            poolKey,
+		Active:          true,
+		ExpirationEpoch: 1,
+	}))
+	// The member delegator is active (unset expiration).
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      member,
+		Pool:            poolKey,
+		Active:          true,
+		ExpirationEpoch: 0,
+	}))
+	rewardCalcSeedStakeCert(
+		t,
+		db,
+		1,
+		rewardAccount,
+		0,
+		250,
+		uint(lcommon.CertificateTypeStakeRegistration),
+	)
+	rewardCalcSeedStakeCert(
+		t,
+		db,
+		2,
+		member,
+		0,
+		250,
+		uint(lcommon.CertificateTypeStakeRegistration),
+	)
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, newEpoch, boundarySlot)
+	}))
+
+	rewardOwner, err := db.GetAccountByCredential(0, rewardAccount, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, rewardOwner)
+	rewardMember, err := db.GetAccountByCredential(0, member, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, rewardMember)
+
+	state, err := meta.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	accountOutputs, err := meta.GetRewardAccountOutputs(rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+
+	res := guardExpiredLeaderResult{
+		reserves:     uint64(state.Reserves),
+		treasury:     uint64(state.Treasury),
+		leaderReward: uint64(rewardOwner.Reward),
+		memberReward: uint64(rewardMember.Reward),
+	}
+	for _, output := range accountOutputs {
+		switch string(output.StakingKey) {
+		case string(rewardAccount):
+			require.Equal(t, string(rewards.RewardTypeLeader), output.RewardType)
+			res.leaderOutputAmount = uint64(output.Amount)
+		case string(member):
+			require.Equal(t, string(rewards.RewardTypeMember), output.RewardType)
+			res.memberOutputAmount = uint64(output.Amount)
+		}
+	}
+	return res
+}
+
+// TestApplyStakeRewardsGuardsExpiredRewardAccount is the Task 10 reward-crediting
+// guard test: a pool reward (leader) account expired as of the reward snapshot
+// epoch must not be credited, and its reward must be routed to undistributed ->
+// reserves so the ADA pots reconcile exactly. Gate off is byte-identical to the
+// pre-CIP behavior (both accounts credited).
+func TestApplyStakeRewardsGuardsExpiredRewardAccount(t *testing.T) {
+	const initialReserves = uint64(100_000_000)
+
+	// Gate off: the expired reward account is still credited (pre-CIP
+	// behavior). Both leader and member receive their rewards, and the ADA is
+	// fully conserved (fees=0, tau=0).
+	off := applyGuardExpiredLeaderScenario(t, false)
+	require.Greater(t, off.leaderReward, uint64(0), "gate off must credit the leader")
+	require.Greater(t, off.memberReward, uint64(0), "gate off must credit the member")
+	require.Equal(t, off.leaderOutputAmount, off.leaderReward)
+	require.Equal(t, off.memberOutputAmount, off.memberReward)
+	require.Equal(t,
+		initialReserves,
+		off.reserves+off.treasury+off.leaderReward+off.memberReward,
+		"gate off ADA must be conserved",
+	)
+
+	// Gate on: the expired reward (leader) account is NOT credited; the active
+	// member is still credited its full, unchanged amount.
+	on := applyGuardExpiredLeaderScenario(t, true)
+	require.Equal(t, uint64(0), on.leaderReward,
+		"gate on must not credit the expired reward account")
+	require.Equal(t, off.memberReward, on.memberReward,
+		"gate on must still credit the active member unchanged")
+	// The guard skips crediting only; it does not rewrite the computed reward
+	// outputs, so the persisted leader output amount is unchanged.
+	require.Equal(t, off.leaderOutputAmount, on.leaderOutputAmount)
+
+	// Reconciliation: reserves gains exactly the skipped leader reward, and the
+	// treasury is unchanged (the skipped amount is routed to undistributed ->
+	// reserves, not unspendable -> treasury).
+	require.Equal(t, off.reserves+off.leaderReward, on.reserves,
+		"reserves must gain exactly the skipped leader reward")
+	require.Equal(t, off.treasury, on.treasury,
+		"treasury must be unchanged by the guard")
+	// ADA conservation with the guard on: the only credited reward is the
+	// member; the skipped leader amount stayed in reserves.
+	require.Equal(t,
+		initialReserves,
+		on.reserves+on.treasury+on.memberReward,
+		"gate on ADA must be conserved",
+	)
+}
+
+func TestGuardedExpiredRewardCredentialsUsesSnapshotWitnessHistory(t *testing.T) {
+	const inactivity = uint64(90)
+	ls, db := newExpiryRollbackTestLedger(t, true, inactivity)
+	cred := renewTestCred(0x71)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred, Active: true, ExpirationEpoch: 2 + inactivity,
+	}))
+	seedRollbackCertificate(
+		t, db, 150, rollbackStakeRegistrationCertificate(cred),
+	)
+	seedRollbackCertificate(
+		t, db, 250, rollbackStakeRegistrationCertificate(cred),
+	)
+	app := &stakeRewardApplication{
+		epochs:               stakeRewardEpochs{snapshot: 92},
+		snapshotCapturedSlot: 199,
+		accountOutputs: []*models.RewardAccountOutput{{
+			StakingKey: cred, CredentialTag: 0,
+		}},
+	}
+	txn := db.Transaction(false)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		guarded, err := ls.guardedExpiredRewardCredentials(txn, app)
+		if err != nil {
+			return err
+		}
+		require.Contains(t, guarded, models.NewStakeCredentialRef(0, cred).MapKey())
+		return nil
+	}))
 }
 
 func TestApplyStakeRewardsAggregatesSharedRewardAccountBalance(t *testing.T) {

--- a/ledger/snapshot/calculator.go
+++ b/ledger/snapshot/calculator.go
@@ -76,20 +76,35 @@ func (c *Calculator) CalculateStakeDistribution(
 	txn := c.db.Transaction(false)
 	defer func() { _ = txn.Commit() }()
 
-	return c.calculateHistoricalStakeDistributionInTxn(ctx, txn, slot)
+	// Public historical query path: the CIP-0163 inactivity gate is a
+	// consensus concern applied only by the snapshot manager, which supplies a
+	// nonzero expiryEpoch. This query keeps expiryEpoch == 0 (gate off).
+	return c.calculateHistoricalStakeDistributionInTxn(ctx, txn, slot, 0, 0)
 }
 
+// calculateStakeDistributionInTxn computes the leader-election and reward-basis
+// stake for an epoch-boundary snapshot. expiryEpoch drives the CIP-0163
+// reward-account inactivity gate: 0 disables it (byte-identical to pre-CIP), a
+// nonzero value (the epoch the snapshot is computed for) excludes credentials
+// whose account expired before that epoch. inactivityPeriod reconstructs each
+// credential's expiration from witness history at the requested slot.
 func (c *Calculator) calculateStakeDistributionInTxn(
 	ctx context.Context,
 	txn *database.Txn,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) (*StakeDistribution, error) {
-	dist, err := c.calculateHistoricalStakeDistributionInTxn(ctx, txn, slot)
+	dist, err := c.calculateHistoricalStakeDistributionInTxn(
+		ctx, txn, slot, expiryEpoch, inactivityPeriod,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	stakeInputs, err := c.rewardStakeInputsInTxn(ctx, txn, slot)
+	stakeInputs, err := c.rewardStakeInputsInTxn(
+		ctx, txn, slot, expiryEpoch, inactivityPeriod,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("calculate reward stake inputs: %w", err)
 	}
@@ -105,6 +120,8 @@ func (c *Calculator) calculateHistoricalStakeDistributionInTxn(
 	ctx context.Context,
 	txn *database.Txn,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) (*StakeDistribution, error) {
 	dist := &StakeDistribution{
 		Slot:           slot,
@@ -112,7 +129,9 @@ func (c *Calculator) calculateHistoricalStakeDistributionInTxn(
 		DelegatorCount: make(map[lcommon.PoolKeyHash]uint64),
 	}
 
-	err := c.calculateFromHistoricalStake(ctx, txn, slot, dist)
+	err := c.calculateFromHistoricalStake(
+		ctx, txn, slot, expiryEpoch, inactivityPeriod, dist,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("calculate from historical stake: %w", err)
 	}
@@ -123,13 +142,18 @@ func (c *Calculator) calculateHistoricalStakeDistributionInTxn(
 	return dist, nil
 }
 
-// rewardStakeInputsInTxn copies per-credential reward inputs from the live
-// reward aggregate. Leader-election pool totals remain on the canonical,
-// slot-aware path in calculateHistoricalStakeDistributionInTxn.
+// rewardStakeInputsInTxn returns per-credential reward inputs. With the
+// CIP-0163 gate off (expiryEpoch == 0) these come from the live reward
+// aggregate; with the gate on they are reconstructed at slot from the same
+// historical CTE as the leader-election pool totals in
+// calculateHistoricalStakeDistributionInTxn, so both halves agree by
+// construction.
 func (c *Calculator) rewardStakeInputsInTxn(
 	ctx context.Context,
 	txn *database.Txn,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) ([]StakeInput, error) {
 	meta := c.db.Metadata()
 	metaTxn := (*txn).Metadata()
@@ -152,6 +176,9 @@ func (c *Calculator) rewardStakeInputsInTxn(
 		meta,
 		metaTxn,
 		pools,
+		slot,
+		expiryEpoch,
+		inactivityPeriod,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get batch reward stake inputs: %w", err)
@@ -165,6 +192,8 @@ func (c *Calculator) calculateFromHistoricalStake(
 	ctx context.Context,
 	txn *database.Txn,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 	dist *StakeDistribution,
 ) error {
 	meta := c.db.Metadata()
@@ -184,6 +213,8 @@ func (c *Calculator) calculateFromHistoricalStake(
 		metaTxn,
 		pools,
 		slot,
+		expiryEpoch,
+		inactivityPeriod,
 	)
 	if err != nil {
 		return fmt.Errorf("get batch pools historical stake: %w", err)
@@ -235,15 +266,21 @@ func (c *Calculator) getActivePoolsAtSlot(
 	return pools, nil
 }
 
-// getBatchPoolsDelegatedStake returns stake for all pools from the live reward
-// aggregate. Metadata block application keeps that aggregate aligned with UTxO,
-// account, delegation, and reward-balance changes, so the epoch-boundary
-// snapshot avoids scanning the UTxO set.
+// getBatchPoolsDelegatedStake returns per-credential reward stake for all
+// pools. With the CIP-0163 gate off it reads the live reward aggregate, which
+// metadata block application keeps aligned with UTxO, account, delegation, and
+// reward-balance changes so the epoch-boundary snapshot avoids scanning the
+// UTxO set. With the gate on it reconstructs the inputs at slot from the same
+// historical CTE as the leader-election pool totals, trading that optimization
+// for reward inputs that agree with leader stake by construction.
 func (c *Calculator) getBatchPoolsDelegatedStake(
 	_ context.Context,
 	meta metadata.MetadataStore,
 	metaTxn types.Txn,
 	pools []lcommon.PoolKeyHash,
+	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) (*rewardStakeAggregation, error) {
 	// Initialize result maps
 	stakeMap := &rewardStakeAggregation{
@@ -264,6 +301,9 @@ func (c *Calculator) getBatchPoolsDelegatedStake(
 
 	inputs, err := meta.GetRewardStakeInputsForPools(
 		poolKeyHashBytes,
+		slot,
+		expiryEpoch,
+		inactivityPeriod,
 		metaTxn,
 	)
 	if err != nil {
@@ -322,6 +362,8 @@ func (c *Calculator) getBatchPoolsHistoricalStake(
 	metaTxn types.Txn,
 	pools []lcommon.PoolKeyHash,
 	slot uint64,
+	expiryEpoch uint64,
+	inactivityPeriod uint64,
 ) (map[lcommon.PoolKeyHash]uint64, map[lcommon.PoolKeyHash]uint64, error) {
 	stakeMap := make(map[lcommon.PoolKeyHash]uint64, len(pools))
 	delegatorMap := make(map[lcommon.PoolKeyHash]uint64, len(pools))
@@ -339,6 +381,8 @@ func (c *Calculator) getBatchPoolsHistoricalStake(
 	stakes, delegators, err := meta.GetStakeByPoolsAtSlot(
 		poolKeyHashBytes,
 		slot,
+		expiryEpoch,
+		inactivityPeriod,
 		metaTxn,
 	)
 	if err != nil {

--- a/ledger/snapshot/calculator_test.go
+++ b/ledger/snapshot/calculator_test.go
@@ -703,6 +703,8 @@ func TestCalculateStakeDistributionRejectsPoolStakeOverflow(t *testing.T) {
 		context.Background(),
 		txn,
 		1000,
+		0,
+		0,
 	)
 	require.ErrorContains(t, err, "delegated stake overflow")
 	require.Nil(t, dist)
@@ -746,6 +748,8 @@ func TestCalculateStakeDistributionRejectsTotalStakeOverflow(t *testing.T) {
 		context.Background(),
 		txn,
 		1000,
+		0,
+		0,
 	)
 	require.ErrorContains(t, err, "total active stake overflow")
 	require.Nil(t, dist)

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -40,6 +40,15 @@ type Manager struct {
 	eventBus *event.EventBus
 	logger   *slog.Logger
 
+	// delegatorInactivityEnabled is the CIP-0163 reward-account inactivity
+	// consensus gate, mirrored from LedgerStateConfig at node/load construction.
+	// When true, mark-snapshot capture excludes accounts expired before the
+	// snapshot epoch from leader-election stake, the reward basis, and SPO vote
+	// power. It is consensus-affecting, so every node on a network must agree.
+	delegatorInactivityEnabled bool
+	delegatorInactivityPeriod  uint64
+	configurationLocked        bool
+
 	mu             sync.RWMutex
 	running        bool
 	stopping       bool
@@ -63,6 +72,72 @@ func NewManager(
 		eventBus: eventBus,
 		logger:   logger,
 	}
+}
+
+// SetDelegatorInactivity mirrors the CIP-0163 reward-account inactivity gate
+// and inactivity window from LedgerStateConfig into the snapshot manager. It
+// must be called before snapshot capture begins (i.e. before
+// CaptureGenesisSnapshot/Start), matching how node.go and load.go configure the
+// ledger. Once capture can begin, the configuration is permanently locked.
+// Default (unset) is gate off, which keeps snapshot capture byte-identical to
+// the pre-CIP behavior.
+func (m *Manager) SetDelegatorInactivity(
+	enabled bool,
+	inactivityPeriod uint64,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.configurationLocked {
+		return errors.New(
+			"snapshot manager: delegator inactivity configuration is locked",
+		)
+	}
+	if enabled && (inactivityPeriod == 0 || inactivityPeriod > 10_000) {
+		return fmt.Errorf(
+			"snapshot manager: delegator inactivity period %d is outside [1, 10000]",
+			inactivityPeriod,
+		)
+	}
+	m.delegatorInactivityEnabled = enabled
+	if enabled {
+		m.delegatorInactivityPeriod = inactivityPeriod
+	} else {
+		m.delegatorInactivityPeriod = 0
+	}
+	return nil
+}
+
+// lockConfiguration freezes consensus-affecting options before snapshot
+// capture can observe them. The lock is permanent for the manager's lifetime:
+// stopping and restarting must not permit snapshots produced by one manager to
+// use different consensus rules.
+func (m *Manager) lockConfiguration() {
+	m.mu.Lock()
+	m.configurationLocked = true
+	m.mu.Unlock()
+}
+
+// expiryEpoch returns the CIP-0163 gate argument for a snapshot being computed
+// for snapshotEpoch: 0 when the gate is off (query byte-identical to pre-CIP),
+// otherwise snapshotEpoch, so the aggregation excludes accounts whose
+// expiration_epoch is nonzero and strictly less than the snapshot epoch.
+func (m *Manager) expiryEpoch(snapshotEpoch uint64) uint64 {
+	m.mu.RLock()
+	enabled := m.delegatorInactivityEnabled
+	m.mu.RUnlock()
+	if !enabled {
+		return 0
+	}
+	return snapshotEpoch
+}
+
+func (m *Manager) inactivityPeriod() uint64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.delegatorInactivityEnabled {
+		return 0
+	}
+	return m.delegatorInactivityPeriod
 }
 
 // SetPromRegistry enables snapshot manager metrics.
@@ -113,6 +188,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("snapshot manager: parent context already done: %w", err)
 	}
 
+	m.configurationLocked = true
 	childCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
 	m.running = true
@@ -346,6 +422,7 @@ func (m *Manager) CaptureEpochBoundarySnapshot(
 	txn *database.Txn,
 	evt event.EpochTransitionEvent,
 ) error {
+	m.lockConfiguration()
 	start := time.Now()
 	calculator := NewCalculator(m.db)
 
@@ -353,6 +430,8 @@ func (m *Manager) CaptureEpochBoundarySnapshot(
 		ctx,
 		txn,
 		evt.SnapshotSlot,
+		m.expiryEpoch(evt.NewEpoch),
+		m.inactivityPeriod(),
 	)
 	if err != nil {
 		if m.metrics != nil {
@@ -421,11 +500,14 @@ func (m *Manager) CaptureEpochBoundarySnapshot(
 func (m *Manager) calculateSnapshotDistribution(
 	ctx context.Context,
 	slot uint64,
+	expiryEpoch uint64,
 ) (*StakeDistribution, error) {
 	calculator := NewCalculator(m.db)
 	txn := m.db.Transaction(false)
 	defer func() { _ = txn.Commit() }()
-	return calculator.calculateStakeDistributionInTxn(ctx, txn, slot)
+	return calculator.calculateStakeDistributionInTxn(
+		ctx, txn, slot, expiryEpoch, m.inactivityPeriod(),
+	)
 }
 
 // captureMarkSnapshot captures the stake distribution as a Mark snapshot.
@@ -433,6 +515,7 @@ func (m *Manager) captureMarkSnapshot(
 	ctx context.Context,
 	evt event.EpochTransitionEvent,
 ) error {
+	m.lockConfiguration()
 	start := time.Now()
 
 	// Calculate canonical, slot-aware leader-election pool totals and attach
@@ -440,6 +523,7 @@ func (m *Manager) captureMarkSnapshot(
 	distribution, err := m.calculateSnapshotDistribution(
 		ctx,
 		evt.SnapshotSlot,
+		m.expiryEpoch(evt.NewEpoch),
 	)
 	if err != nil {
 		if m.metrics != nil {
@@ -526,6 +610,7 @@ func HandleGenesisSnapshotError(
 // the node starts at a much later epoch, so the method also seeds the recent
 // historical window (epochs N, N-1, N-2).
 func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
+	m.lockConfiguration()
 	start := time.Now()
 	if ok, epoch, pools, stake, err := m.hasExistingPostMithrilSnapshotWindow(); err != nil {
 		m.logger.Warn(
@@ -552,7 +637,9 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 	successCount := uint64(0)
 	lastSuccessfulEpoch := uint64(0)
 
-	distribution, err := m.calculateSnapshotDistribution(ctx, 0)
+	// Fresh sync seeds epoch 0, where no account can be expired, so the gate
+	// argument is 0 regardless of the enabled flag.
+	distribution, err := m.calculateSnapshotDistribution(ctx, 0, m.expiryEpoch(0))
 	if err != nil {
 		if m.metrics != nil {
 			m.metrics.captureFailureTotal.Inc()
@@ -586,7 +673,7 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 				"total_pools", distribution.TotalPools,
 			)
 			dist2, err2 := m.calculateSnapshotDistribution(
-				ctx, lastEpoch.StartSlot,
+				ctx, lastEpoch.StartSlot, m.expiryEpoch(currentEpochId),
 			)
 			if err2 != nil {
 				m.logger.Warn(
@@ -660,6 +747,19 @@ func (m *Manager) CaptureGenesisSnapshot(ctx context.Context) error {
 			seedEpoch := currentEpochId - offset
 			if seedEpoch == 0 {
 				continue // already saved above
+			}
+			// ExpirationEpoch is live account state, not historical state.
+			// Once CIP-0163 is enabled a later witness may have renewed an
+			// account that was expired at this older boundary, so the current
+			// rows cannot safely reconstruct N-1/N-2. Leave those rows absent
+			// instead of persisting a consensus-incorrect historical snapshot.
+			if offset > 0 && m.expiryEpoch(seedEpoch) > 0 {
+				m.logger.Warn(
+					"skipping post-Mithril historical snapshot with delegator inactivity enabled",
+					"component", "snapshot",
+					"epoch", seedEpoch,
+				)
+				continue
 			}
 			seedEvt := event.EpochTransitionEvent{
 				NewEpoch: seedEpoch,

--- a/ledger/snapshot/manager_test.go
+++ b/ledger/snapshot/manager_test.go
@@ -33,6 +33,60 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+func TestSetDelegatorInactivityRejectsInvalidPeriod(t *testing.T) {
+	mgr := NewManager(nil, nil, nil)
+
+	require.ErrorContains(t, mgr.SetDelegatorInactivity(true, 0), "[1, 10000]")
+	require.ErrorContains(t, mgr.SetDelegatorInactivity(true, 10_001), "[1, 10000]")
+	require.NoError(t, mgr.SetDelegatorInactivity(false, 90))
+	require.Zero(t, mgr.expiryEpoch(123))
+	require.Zero(t, mgr.inactivityPeriod())
+}
+
+func TestSetDelegatorInactivityLockedAfterStart(t *testing.T) {
+	db := setupTestDB(t)
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	require.NoError(t, mgr.SetDelegatorInactivity(true, 90))
+	require.NoError(t, mgr.Start(context.Background()))
+	t.Cleanup(func() { require.NoError(t, mgr.Stop()) })
+
+	require.ErrorContains(
+		t,
+		mgr.SetDelegatorInactivity(false, 0),
+		"configuration is locked",
+	)
+	require.Equal(t, uint64(123), mgr.expiryEpoch(123))
+	require.Equal(t, uint64(90), mgr.inactivityPeriod())
+
+	require.NoError(t, mgr.Stop())
+	require.ErrorContains(
+		t,
+		mgr.SetDelegatorInactivity(true, 91),
+		"configuration is locked",
+	)
+}
+
+func TestSetDelegatorInactivityLockedAfterGenesisCapture(t *testing.T) {
+	db := setupTestDB(t)
+	seedEpochs(t, db, []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+	})
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	require.NoError(t, mgr.CaptureGenesisSnapshot(context.Background()))
+
+	require.ErrorContains(
+		t,
+		mgr.SetDelegatorInactivity(true, 90),
+		"configuration is locked",
+	)
+}
+
+func TestSetDelegatorInactivityRemainsMutableAfterFailedStart(t *testing.T) {
+	mgr := NewManager(nil, event.NewEventBus(nil, nil), nil)
+	require.ErrorContains(t, mgr.Start(context.Background()), "nil database")
+	require.NoError(t, mgr.SetDelegatorInactivity(true, 90))
+}
+
 // TestCaptureGenesisSnapshot_PostMithril verifies that after a Mithril
 // bootstrap (where slot 0 has no pools but later epochs exist), the
 // snapshot manager seeds the recent historical window for the current epoch.
@@ -113,6 +167,52 @@ func TestCaptureGenesisSnapshot_PostMithril(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, stakeInputs,
 		"current post-Mithril seed row keeps stake reward inputs")
+}
+
+func TestCaptureGenesisSnapshot_PostMithrilSkipsUnsafeExpiryHistory(t *testing.T) {
+	db := setupTestDB(t)
+
+	seedEpochs(t, db, []models.Epoch{
+		{EpochId: 0, StartSlot: 0, LengthInSlots: 432000},
+		{EpochId: 148, StartSlot: 63936000, LengthInSlots: 432000},
+		{EpochId: 149, StartSlot: 64368000, LengthInSlots: 432000},
+		{EpochId: 150, StartSlot: 64800000, LengthInSlots: 432000},
+	})
+
+	poolHash := []byte("poolM_expiry_history_1234567")
+	activeCred := bytes.Repeat([]byte{0xa1}, 28)
+	expiredCred := bytes.Repeat([]byte{0xe1}, 28)
+	seedPoolAndDelegations(t, db, poolHash, []struct {
+		stakingKey  []byte
+		utxoAmounts []types.Uint64
+	}{
+		{stakingKey: activeCred, utxoAmounts: []types.Uint64{10_000_000}},
+		{stakingKey: expiredCred, utxoAmounts: []types.Uint64{50_000_000}},
+	}, 64800000)
+	require.NoError(t, db.RenewAccountExpirations(
+		[]models.StakeCredentialRef{
+			models.NewStakeCredentialRef(0, expiredCred),
+		},
+		149,
+		nil,
+	))
+
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	require.NoError(t, mgr.SetDelegatorInactivity(true, 90))
+	require.NoError(t, mgr.CaptureGenesisSnapshot(context.Background()))
+
+	for _, epoch := range []uint64{148, 149} {
+		snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+			epoch, "mark", poolHash, nil,
+		)
+		require.NoError(t, err)
+		require.Nil(t, snapshot,
+			"epoch %d must not be synthesized from current expiry state", epoch)
+	}
+	current, err := db.Metadata().GetPoolStakeSnapshot(150, "mark", poolHash, nil)
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	require.Equal(t, uint64(10_000_000), uint64(current.TotalStake))
 }
 
 func TestCaptureGenesisSnapshot_PostMithrilSkipsExistingWindow(t *testing.T) {
@@ -526,6 +626,7 @@ func TestFallbackWithoutRewardMarkerStillWritesMarkSnapshot(t *testing.T) {
 	distribution, err := mgr.calculateSnapshotDistribution(
 		context.Background(),
 		evt.SnapshotSlot,
+		0,
 	)
 	require.NoError(t, err)
 	saved, err := mgr.saveSnapshot(
@@ -1854,6 +1955,7 @@ func TestConcurrentFallbackAndAuthoritativeCaptureSerialization(t *testing.T) {
 		fallbackDistribution, err := mgr.calculateSnapshotDistribution(
 			context.Background(),
 			fallbackEvt.SnapshotSlot,
+			0,
 		)
 		require.NoError(t, err)
 		for poolKey := range fallbackDistribution.PoolStakes {
@@ -1961,6 +2063,7 @@ func TestConcurrentFallbackAndAuthoritativeCaptureSerialization(t *testing.T) {
 		fallbackDistribution, err := mgr.calculateSnapshotDistribution(
 			context.Background(),
 			fallbackEvt.SnapshotSlot,
+			0,
 		)
 		require.NoError(t, err)
 		fallbackTxn := db.Transaction(true)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -470,7 +470,15 @@ type LedgerStateConfig struct {
 	// enable it only on a network where every node also enables it (mainnet and
 	// the public testnets keep it off). Like the CIP-50 pledge-leverage gate it
 	// is set from operator config in node.go, not derived from the network.
-	FullPotRewardsEnabled    bool
+	FullPotRewardsEnabled bool
+	// DelegatorInactivityEnabled turns on CIP-0163 reward-account inactivity
+	// expiry. Consensus-affecting; defaults false. Set from operator config in
+	// node.go (serve mode) and internal/node/load.go (load/replay mode), not
+	// derived from the network. Must match across the network.
+	DelegatorInactivityEnabled bool
+	// DelegatorInactivity is the inactivity window in epochs, used only when
+	// DelegatorInactivityEnabled is true.
+	DelegatorInactivity      uint64
 	ValidateHistorical       bool
 	EnableDijkstra           bool
 	StartInDijkstra          bool
@@ -1961,6 +1969,25 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 	var newNonce []byte
 	// Start a transaction
 	err := ls.SubmitAsyncDBTxn(func(txn *database.Txn) error {
+		// CIP-0163: capture the reward-account credentials witnessed in the
+		// rolled-away blocks (added_slot > rollback slot) before the deletes
+		// below remove their certificate and reward-withdrawal rows. Their
+		// expiration_epoch is recomputed against the surviving chain once
+		// account state has been restored (see below). Gate off => skip.
+		var expiryAffectedRefs []models.StakeCredentialRef
+		if ls.config.DelegatorInactivityEnabled {
+			var affErr error
+			expiryAffectedRefs, affErr = ls.db.AccountsWitnessedAfterSlot(
+				point.Slot,
+				txn,
+			)
+			if affErr != nil {
+				return fmt.Errorf(
+					"collect rolled-back witnessed accounts: %w",
+					affErr,
+				)
+			}
+		}
 		// Delete certificates first (they reference transactions)
 		if err := ls.db.DeleteCertificatesAfterSlot(
 			point.Slot,
@@ -1989,6 +2016,21 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 		); err != nil {
 			return fmt.Errorf(
 				"restore account state after rollback: %w",
+				err,
+			)
+		}
+		// CIP-0163: now that the rolled-away certificate/withdrawal rows are
+		// gone and the remaining account fields are restored, recompute the
+		// expiration_epoch of the affected reward accounts against the
+		// surviving chain (ledger-owned because it requires the epoch
+		// schedule). Gate off => no-op.
+		if err := ls.recomputeAccountExpirationsAfterRollback(
+			txn,
+			point.Slot,
+			expiryAffectedRefs,
+		); err != nil {
+			return fmt.Errorf(
+				"recompute account expirations after rollback: %w",
 				err,
 			)
 		}
@@ -4715,6 +4757,7 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 	// exact contention concern.
 	snapshotEpoch := ls.currentEpoch.EpochId
 	snapshotPParams := ls.currentPParams
+	snapshotDelegatorInactivityOn := ls.config.DelegatorInactivityEnabled
 	conwayGenesis := ls.config.CardanoNodeConfig.ConwayGenesis()
 	db := ls.db
 	logger := ls.config.Logger
@@ -4734,6 +4777,7 @@ func (ls *LedgerState) evaluateHardForkInitiationStability() {
 				db,
 				nil,
 				snapshotEpoch,
+				snapshotDelegatorInactivityOn,
 				snapshotPParams,
 				conwayGenesis,
 				onDecodeFailure,

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -787,7 +787,9 @@ func (lv *LedgerView) GetDRepVotingPower(
 	credentialTag uint8,
 	drepCredential []byte,
 ) (uint64, error) {
-	power, err := lv.ls.db.GetDRepVotingPower(credentialTag, drepCredential, lv.txn)
+	// expiryEpoch 0: this point-in-time API query is not gated by the
+	// CIP-0163 epoch-boundary tally (see ledger/governance for that path).
+	power, err := lv.ls.db.GetDRepVotingPower(credentialTag, drepCredential, 0, lv.txn)
 	if err != nil {
 		return 0, fmt.Errorf("get drep voting power: %w", err)
 	}

--- a/mithril/import_marker.go
+++ b/mithril/import_marker.go
@@ -44,6 +44,36 @@ func setImmutableImportMarker(db *database.Database, num uint64) error {
 	return nil
 }
 
+// WasBootstrapped reports whether db was populated by a Mithril bootstrap. It
+// checks the durable immutable-import marker a completed Mithril sync leaves in
+// sync_state (written after the completion clear, and never removed by normal
+// serve operation), so it stays true for the life of a bootstrapped database.
+// Consensus features whose ledger state cannot be reconstructed from a Mithril
+// snapshot use it to refuse serving such a database -- notably CIP-0163
+// delegator inactivity, whose per-account expiration state is absent from the
+// cardano-ledger snapshot and cannot be recovered after import.
+//
+// Databases bootstrapped before the immutable-import marker existed (pre-v0.62.0,
+// #2694) carry only the older mithril_ledger_slot trust boundary, so we fall
+// back to it. That boundary is written solely by the Mithril import completion
+// path (updateMithrilReadyState, sync_import.go) and never by a genesis sync, so
+// keying on its presence cannot misclassify a genesis-synced database as
+// bootstrapped.
+func WasBootstrapped(db *database.Database) (bool, error) {
+	if _, ok, err := getImmutableImportMarker(db); err != nil || ok {
+		return ok, err
+	}
+	// Legacy fallback: the durable trust boundary written by every completed
+	// Mithril import before the immutable-import marker was introduced.
+	val, err := db.GetSyncState(mithrilLedgerSlotSyncKey, nil)
+	if err != nil {
+		return false, fmt.Errorf(
+			"reading mithril ledger-slot boundary: %w", err,
+		)
+	}
+	return val != "", nil
+}
+
 // getImmutableImportMarker returns the recorded highest imported immutable file
 // number. ok is false when no marker is present (a database bootstrapped before
 // this feature, or one that never completed a Mithril sync).

--- a/mithril/import_marker_test.go
+++ b/mithril/import_marker_test.go
@@ -29,3 +29,19 @@ func TestImmutableImportMarkerRoundTrip(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, uint64(26900), num)
 }
+
+// TestWasBootstrapped pins the exported detector used by the serve-time
+// CIP-0163 guard: false on a fresh database, true once the durable
+// immutable-import marker a completed Mithril sync leaves behind is present.
+func TestWasBootstrapped(t *testing.T) {
+	db := newSyncModeTestDB(t)
+
+	got, err := WasBootstrapped(db)
+	require.NoError(t, err)
+	require.False(t, got, "fresh database is not Mithril-bootstrapped")
+
+	require.NoError(t, setImmutableImportMarker(db, 12345))
+	got, err = WasBootstrapped(db)
+	require.NoError(t, err)
+	require.True(t, got, "database with the immutable-import marker is bootstrapped")
+}

--- a/node.go
+++ b/node.go
@@ -379,7 +379,10 @@ func (n *Node) Run(ctx context.Context) error {
 			// CIP-0163 full-pot reward distribution. Operator-set (not derived
 			// from the network) and off by default; enable only where every node
 			// also enables it.
-			FullPotRewardsEnabled:      n.config.fullPotRewardsEnabled,
+			FullPotRewardsEnabled: n.config.fullPotRewardsEnabled,
+			// CIP-0163 reward-account inactivity expiry (operator-set)
+			DelegatorInactivityEnabled: n.config.delegatorInactivityEnabled,
+			DelegatorInactivity:        n.config.delegatorInactivity,
 			BlockfetchRequestRangeFunc: n.ouroboros.BlockfetchClientRequestRange,
 			PeersWithBlockFunc: func(
 				origin ouroboros.ConnectionId,
@@ -600,6 +603,14 @@ func (n *Node) Run(ctx context.Context) error {
 		n.eventBus,
 		n.config.logger,
 	)
+	// Mirror the CIP-0163 reward-account inactivity gate into snapshot capture
+	// so it matches the ledger config that drives account expiry stamping.
+	if err := n.snapshotMgr.SetDelegatorInactivity(
+		n.config.delegatorInactivityEnabled,
+		n.config.delegatorInactivity,
+	); err != nil {
+		return fmt.Errorf("configuring snapshot manager: %w", err)
+	}
 	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
 	// Wire the authoritative epoch-boundary capture before block sync begins so
 	// each epoch rollover stages its mark snapshot atomically at the SNAP point.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CIP-0163 delegator inactivity: reward accounts that don’t witness for N epochs expire and are excluded from leader election, reward crediting, and DRep voting. Configurable via flags/env, off by default, consensus-affecting, and incompatible with Mithril-bootstrapped databases.

- New Features
  - Operator config: `--delegator-inactivity-enabled` and `--delegator-inactivity` (epochs [1,10000]); env `DINGO_DELEGATOR_INACTIVITY_ENABLED` / `DINGO_DELEGATOR_INACTIVITY`; validates range.
  - Database: adds `account.expiration_epoch`; persists withdrawal witnesses (`AccountWithdrawalWitness`); one-time activation membership (`AccountInactivityActivation`); APIs to renew expirations and query last-witness slots; zero-amount withdrawals count as witnesses.
  - Ledger: renews expirations per block from witnessed reward credentials; one-time activation at the first enabled epoch; rollback recomputes expirations from witness history; chainsync and load/replay mirror the gate; point-in-time queries explicitly pass `expiryEpoch=0`.
  - Rewards/governance: reward crediting skips expired accounts (undistributed returns to reserves); stake aggregation, reward inputs, and DRep power accept an `expiryEpoch` and exclude expired accounts; governance tally honors the gate; point-in-time APIs keep gate off by passing 0.
  - Snapshot: `snapshot.Manager` mirrors the gate via `SetDelegatorInactivity`, locks configuration after start, and supplies `expiryEpoch` + inactivity period to stake aggregation.
  - Mithril: `dingo mithril sync` refuses when the gate is enabled; `serve` refuses if the DB was Mithril-bootstrapped (detected via immutable import marker).

- Migration
  - Disabled by default; enable only on networks where every node enables it. Use `--delegator-inactivity-enabled` with `--delegator-inactivity` (e.g., 90).
  - Not supported with a Mithril-bootstrapped DB.
  - DB auto-migrates `expiration_epoch` and activation/witness tables; behavior is unchanged when the gate is off.
  - API changes:
    - `GetDRepVotingPower`, `GetDRepVotingPowerBatch` now take `expiryEpoch`.
    - `GetStakeByPoolsAtSlot`, `GetPoolOwnerStakeAtSlot` now take `expiryEpoch` and `inactivityPeriod`.
    - `GetRewardStakeInputsForPools` now takes `slot`, `expiryEpoch`, and `inactivityPeriod`.
    - Pass `expiryEpoch=0` for pre-CIP behavior in point-in-time queries.

<sup>Written for commit d765dd6158a5c338b5aa0fd974f5642857b69b6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reward-account inactivity expiry with CLI flags, environment variables, and validation.
  * Automatically renews account activity when eligible transactions witness reward credentials.
  * Excludes expired accounts from stake snapshots, reward calculations, and governance voting power.
  * Preserves account expiry state during rollbacks and initializes inactivity tracking once at activation.

* **Bug Fixes**
  * Prevented rewards from being credited to expired accounts while maintaining supply balance.

* **Documentation**
  * Documented configuration, database fields, expiry behavior, activation, rollback, and epoch-boundary rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->