### PR TITLE
fix(mempool): return immutable transaction snapshots

### DIFF
--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -44,8 +44,12 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 
 		// Check if we have a transaction available
 		if m.nextTxIdx < len(m.mempool.transactions) {
-			nextTx := m.mempool.transactions[m.nextTxIdx]
-			if nextTx != nil {
+			poolTx := m.mempool.transactions[m.nextTxIdx]
+			if poolTx != nil {
+				// Clone while holding the pool read lock so neither the caller
+				// nor the consumer cache shares mutable CBOR with pool storage.
+				nextTx := cloneMempoolTransaction(poolTx)
+				cachedTx := cloneMempoolTransaction(poolTx)
 				// Increment next TX index atomically with reading it
 				m.nextTxIdx++
 				m.nextTxIdxMu.Unlock()
@@ -53,7 +57,7 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 
 				// Add transaction to cache (outside of locks)
 				m.cacheMutex.Lock()
-				m.cache[nextTx.Hash] = nextTx
+				m.cache[cachedTx.Hash] = cachedTx
 				m.cacheMutex.Unlock()
 
 				return nextTx
@@ -103,7 +107,7 @@ func (m *MempoolConsumer) GetTxFromCache(hash string) *MempoolTransaction {
 	if m != nil {
 		m.cacheMutex.Lock()
 		defer m.cacheMutex.Unlock()
-		return m.cache[hash]
+		return cloneMempoolTransaction(m.cache[hash])
 	}
 	var ret *MempoolTransaction
 	return ret

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -853,7 +853,7 @@ func (m *Mempool) GetTransaction(txHash string) (MempoolTransaction, bool) {
 	if ret == nil {
 		return MempoolTransaction{}, false
 	}
-	return *ret, true
+	return *cloneMempoolTransaction(ret), true
 }
 
 func (m *Mempool) Transactions() []MempoolTransaction {
@@ -861,9 +861,20 @@ func (m *Mempool) Transactions() []MempoolTransaction {
 	defer m.RUnlock()
 	ret := make([]MempoolTransaction, len(m.transactions))
 	for i := range m.transactions {
-		ret[i] = *m.transactions[i]
+		ret[i] = *cloneMempoolTransaction(m.transactions[i])
 	}
 	return ret
+}
+
+// cloneMempoolTransaction returns a deep copy that does not share mutable CBOR
+// storage with the source transaction.
+func cloneMempoolTransaction(tx *MempoolTransaction) *MempoolTransaction {
+	if tx == nil {
+		return nil
+	}
+	ret := *tx
+	ret.Cbor = slices.Clone(tx.Cbor)
+	return &ret
 }
 
 func (m *Mempool) getTransaction(txHash string) *MempoolTransaction {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1264,6 +1264,7 @@ func TestMempool_Transactions_ReturnsCopies(t *testing.T) {
 	// Modify returned transaction
 	originalHash := txs[0].Hash
 	txs[0].Hash = "modified-hash"
+	txs[0].Cbor[0] = 'X'
 
 	// Verify mempool transaction is unchanged
 	mempoolTxs := m.Transactions()
@@ -1273,6 +1274,7 @@ func TestMempool_Transactions_ReturnsCopies(t *testing.T) {
 		mempoolTxs[0].Hash,
 		"mempool should return copies",
 	)
+	assert.NotEqual(t, byte('X'), mempoolTxs[0].Cbor[0], "CBOR should be copied")
 }
 
 func TestMempool_GetTransaction_ReturnsCopy(t *testing.T) {
@@ -1288,11 +1290,39 @@ func TestMempool_GetTransaction_ReturnsCopy(t *testing.T) {
 
 	// Modify returned transaction
 	tx.Hash = "modified"
+	tx.Cbor[0] = 'X'
 
 	// Verify mempool transaction is unchanged
 	tx2, exists := m.GetTransaction("tx-hash-0")
 	require.True(t, exists)
 	assert.Equal(t, "tx-hash-0", tx2.Hash, "mempool should return copy")
+	assert.NotEqual(t, byte('X'), tx2.Cbor[0], "CBOR should be copied")
+}
+
+func TestMempoolConsumer_ReturnsImmutableCopies(t *testing.T) {
+	m := newTestMempool(t)
+	defer m.Stop(context.Background())
+
+	txs := addMockTransactions(t, m, 1)
+	consumer := m.AddConsumer(newTestConnectionId(0))
+
+	nextTx := consumer.NextTx(false)
+	require.NotNil(t, nextTx)
+	nextTx.Cbor[0] = 'X'
+
+	cachedTx := consumer.GetTxFromCache(txs[0].Hash)
+	require.NotNil(t, cachedTx)
+	assert.NotEqual(t, byte('X'), cachedTx.Cbor[0], "cache should not alias NextTx")
+	cachedTx.Cbor[0] = 'Y'
+
+	cachedTxAgain := consumer.GetTxFromCache(txs[0].Hash)
+	require.NotNil(t, cachedTxAgain)
+	assert.NotEqual(t, byte('Y'), cachedTxAgain.Cbor[0], "cache reads should be copied")
+
+	poolTx, ok := m.GetTransaction(txs[0].Hash)
+	require.True(t, ok)
+	assert.NotEqual(t, byte('X'), poolTx.Cbor[0], "pool should not alias NextTx")
+	assert.NotEqual(t, byte('Y'), poolTx.Cbor[0], "pool should not alias cache")
 }
 
 func TestMempool_AddTransaction_DuplicateUpdatesLastSeen(t *testing.T) {


### PR DESCRIPTION
Closes #2908.

Deep-copies transaction CBOR at mempool snapshot and consumer-cache boundaries so callers cannot mutate validated pool state.

Tests: `go test -race ./mempool ./ouroboros`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return immutable transaction snapshots from the `mempool` and consumer cache. We deep-copy CBOR so callers cannot mutate validated pool state. Addresses #2908.

- **Bug Fixes**
  - Deep-copy transactions (including CBOR) from `Mempool.GetTransaction`/`Transactions` and in `MempoolConsumer.NextTx`/`GetTxFromCache`; introduced `cloneMempoolTransaction`.
  - Added tests verifying no aliasing between pool, `NextTx`, and cache CBOR.

<sup>Written for commit feb461367b7beb765a8dc6370b00ccc561ad899c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction data isolation in the mempool.
  * Retrieving transactions or transaction lists now returns independent copies, preventing caller changes from modifying stored data.
  * Consumer and cached transactions are also protected from unintended data changes.

* **Tests**
  * Added coverage verifying transaction data remains unchanged after returned values are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->