### PR TITLE
fix(ouroboros): report configured mempool capacity

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -877,6 +877,11 @@ func cloneMempoolTransaction(tx *MempoolTransaction) *MempoolTransaction {
 	return &ret
 }
 
+// CapacityBytes returns the configured maximum mempool size in bytes.
+func (m *Mempool) CapacityBytes() int64 {
+	return m.config.MempoolCapacity
+}
+
 func (m *Mempool) getTransaction(txHash string) *MempoolTransaction {
 	return m.txByHash[txHash]
 }

--- a/ouroboros/localtxmonitor.go
+++ b/ouroboros/localtxmonitor.go
@@ -15,13 +15,11 @@
 package ouroboros
 
 import (
+	"fmt"
+	"math"
 	"time"
 
 	olocaltxmonitor "github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
-)
-
-const (
-	localtxmonitorMempoolCapacity = 10 * 1024 * 1024 // TODO: replace with configurable value (#400)
 )
 
 func (o *Ouroboros) localtxmonitorServerConnOpts() []olocaltxmonitor.LocalTxMonitorOptionFunc {
@@ -47,6 +45,13 @@ func (o *Ouroboros) localtxmonitorServerGetMempool(
 	ctx olocaltxmonitor.CallbackContext,
 ) (uint64, uint32, []olocaltxmonitor.TxAndEraId, error) {
 	tip := o.LedgerState.Tip()
+	capacity := o.Mempool.CapacityBytes()
+	if capacity < 0 || capacity > math.MaxUint32 {
+		return 0, 0, nil, fmt.Errorf(
+			"mempool capacity %d cannot be represented by LocalTxMonitor",
+			capacity,
+		)
+	}
 	mempoolTxs := o.Mempool.Transactions()
 	retTxs := make([]olocaltxmonitor.TxAndEraId, len(mempoolTxs))
 	for i := range mempoolTxs {
@@ -55,5 +60,5 @@ func (o *Ouroboros) localtxmonitorServerGetMempool(
 			Tx:    mempoolTxs[i].Cbor,
 		}
 	}
-	return tip.Point.Slot, localtxmonitorMempoolCapacity, retTxs, nil
+	return tip.Point.Slot, uint32(capacity), retTxs, nil // #nosec G115 -- range checked above
 }

--- a/ouroboros/localtxmonitor_test.go
+++ b/ouroboros/localtxmonitor_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/mempool"
+	olocaltxmonitor "github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocaltxmonitorServerGetMempoolReportsConfiguredCapacity(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int64
+	}{
+		{name: "praos default", capacity: 1024 * 1024},
+		{name: "leios default", capacity: 25 * 1024 * 1024},
+		{name: "custom", capacity: 7 * 1024 * 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, _ := newTxSubmissionTestOuroboros(t, func(cfg *mempool.MempoolConfig) {
+				cfg.MempoolCapacity = tt.capacity
+			})
+			o.LedgerState = newTestLedgerState(t)
+
+			_, capacity, _, err := o.localtxmonitorServerGetMempool(
+				olocaltxmonitor.CallbackContext{},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, uint32(tt.capacity), capacity) // #nosec G115 -- test values fit
+		})
+	}
+}
+
+func TestLocaltxmonitorServerGetMempoolRejectsUnrepresentableCapacity(t *testing.T) {
+	o, _ := newTxSubmissionTestOuroboros(t, func(cfg *mempool.MempoolConfig) {
+		cfg.MempoolCapacity = int64(math.MaxUint32) + 1
+	})
+	o.LedgerState = newTestLedgerState(t)
+
+	_, _, _, err := o.localtxmonitorServerGetMempool(
+		olocaltxmonitor.CallbackContext{},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be represented")
+}


### PR DESCRIPTION
Closes #2904.

Reports the configured mempool capacity through LocalTxMonitor and rejects values the protocol cannot represent.

Tests: `go test -race ./mempool ./ouroboros`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report the configured mempool capacity via `LocalTxMonitor` and error on unrepresentable values to avoid incorrect reporting and failures.

- **Bug Fixes**
  - Use the configured mempool capacity in `LocalTxMonitor` instead of a hardcoded value; add `Mempool.CapacityBytes()` to expose it.
  - Validate capacity is non-negative and fits `uint32`; return an error if out of range. Tests cover reporting and rejection.

<sup>Written for commit 96db244c4de3111857997c6be7ae95b1005774e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

