### PR TITLE
fix(ouroboros): avoid leaking txsubmission consumers

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -418,9 +418,11 @@ func NewMempool(config MempoolConfig) (*Mempool, error) {
 }
 
 func (m *Mempool) AddConsumer(connId ouroboros.ConnectionId) *MempoolConsumer {
-	// Create consumer
 	m.consumersMutex.Lock()
 	defer m.consumersMutex.Unlock()
+	if consumer := m.consumers[connId]; consumer != nil {
+		return consumer
+	}
 	consumer := newConsumer(m)
 	m.consumers[connId] = consumer
 	return consumer

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -330,6 +330,18 @@ func TestMempool_AddRemoveConsumer(t *testing.T) {
 	m.consumersMutex.Unlock()
 }
 
+func TestMempool_AddConsumerIsIdempotent(t *testing.T) {
+	m := newTestMempool(t)
+	defer m.Stop(context.Background())
+	connId := newTestConnectionId(0)
+
+	first := m.AddConsumer(connId)
+	second := m.AddConsumer(connId)
+
+	require.Same(t, first, second)
+	assert.Len(t, m.consumers, 1)
+}
+
 func TestMempoolConsumer_NextTx_NonBlocking(t *testing.T) {
 	m := newTestMempool(t)
 	defer m.Stop(context.Background())

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -127,9 +127,6 @@ func (o *Ouroboros) instrumentTxsubmissionRequestTxs(
 func (o *Ouroboros) txsubmissionClientStart(
 	connId ouroboros.ConnectionId,
 ) error {
-	// Register mempool consumer
-	o.Mempool.AddConsumer(connId)
-	// Start TxSubmission loop
 	conn := o.ConnManager.GetConnectionById(connId)
 	if conn == nil {
 		return fmt.Errorf("failed to lookup connection ID: %s", connId.String())
@@ -141,6 +138,9 @@ func (o *Ouroboros) txsubmissionClientStart(
 			connId.String(),
 		)
 	}
+	// Register only after all required connection state has been verified. This
+	// avoids leaving a stale consumer behind when startup cannot proceed.
+	o.Mempool.AddConsumer(connId)
 	tx.Client.Init()
 	return nil
 }

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -286,6 +286,29 @@ func TestTxSubmissionServerInitMissingConnectionReturnsCleanly(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestTxSubmissionClientStartMissingConnectionDoesNotAddConsumer(t *testing.T) {
+	o, connId := newTxSubmissionTestOuroboros(t)
+
+	err := o.txsubmissionClientStart(connId)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to lookup connection ID")
+	require.Nil(t, o.Mempool.Consumer(connId))
+}
+
+func TestTxSubmissionClientStartIsIdempotent(t *testing.T) {
+	h := newTxSubmissionRelayHarness(t)
+	defer h.close(t)
+	connId := h.connB.Id()
+
+	require.NoError(t, h.nodeB.txsubmissionClientStart(connId))
+	first := h.mB.Consumer(connId)
+	require.NotNil(t, first)
+
+	require.NoError(t, h.nodeB.txsubmissionClientStart(connId))
+	require.Same(t, first, h.mB.Consumer(connId))
+}
+
 // TestTxSubmissionConnectionClosedCleanup verifies connection close handling
 // removes txsubmission consumer and rate-limiter state for that peer.
 func TestTxSubmissionConnectionClosedCleanup(t *testing.T) {


### PR DESCRIPTION
Closes #2906.

Registers TxSubmission consumers only after connection validation and makes repeated registration preserve the existing consumer.

Tests: `go test -race ./mempool ./ouroboros`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking or duplicating TxSubmission consumers by registering them only after a valid connection is confirmed and making registration idempotent. Improves stability when startup fails or is invoked multiple times.

- **Bug Fixes**
  - In `ouroboros/txsubmission`, register the mempool consumer only after connection validation.
  - Make `mempool.Mempool.AddConsumer` idempotent; return the existing consumer if already present.
  - Added tests for missing-connection behavior and idempotent startup in `ouroboros`, plus an idempotency test in `mempool`.

<sup>Written for commit e42b411992dac2609481094c05ad91ea2b8eeb0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

