### PR TITLE
fix(mempool): make shutdown terminal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1596,6 +1596,12 @@ The `Mempool` (`mempool/mempool.go`) manages pending transactions:
     -------------------------------------------------
 ```
 
+Mempool shutdown is terminal. `Stop` atomically marks the pool stopped before
+clearing transaction and consumer state; later transaction admission returns
+`mempool.ErrMempoolStopped`, and later consumer registration is rejected. This
+prevents in-flight protocol callbacks from repopulating a pool whose background
+expiry and chain-update workers have already been stopped.
+
 ## Block Production
 
 When running as a stake pool operator, Dingo can produce blocks. This involves three subsystems under `ledger/`:

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -104,6 +104,7 @@ type Mempool struct {
 	cleanupInterval    time.Duration
 	evictionWatermark  float64
 	rejectionWatermark float64
+	stopped            bool
 	sync.RWMutex
 	doneOnce       sync.Once
 	consumersMutex sync.Mutex
@@ -313,6 +314,9 @@ func (o *utxoOverlay) simulateRemoveBatch(
 // crash the node.
 var ErrNilValidator = errors.New("mempool: validator is nil")
 
+// ErrMempoolStopped is returned when admission is attempted after shutdown.
+var ErrMempoolStopped = errors.New("mempool: stopped")
+
 type MempoolFullError struct {
 	CurrentSize int
 	TxSize      int
@@ -418,6 +422,11 @@ func NewMempool(config MempoolConfig) (*Mempool, error) {
 }
 
 func (m *Mempool) AddConsumer(connId ouroboros.ConnectionId) *MempoolConsumer {
+	m.RLock()
+	defer m.RUnlock()
+	if m.stopped {
+		return nil
+	}
 	m.consumersMutex.Lock()
 	defer m.consumersMutex.Unlock()
 	if consumer := m.consumers[connId]; consumer != nil {
@@ -438,10 +447,17 @@ func (m *Mempool) Stop(ctx context.Context) error {
 	// Context is accepted for API consistency but not used since cleanup is synchronous and fast
 	m.logger.Debug("stopping mempool")
 
-	// Signal the processChainEvents goroutine to stop (safe to call multiple times)
+	// Establish a terminal state before clearing data. AddTransaction and
+	// AddConsumer check this state while holding the same pool lock, so neither
+	// can repopulate the mempool once shutdown begins.
+	m.Lock()
+	if m.stopped {
+		m.Unlock()
+		return nil
+	}
+	m.stopped = true
 	m.doneOnce.Do(func() { close(m.done) })
 
-	// Stop all consumers
 	m.consumersMutex.Lock()
 	for _, consumer := range m.consumers {
 		if consumer != nil {
@@ -451,8 +467,6 @@ func (m *Mempool) Stop(ctx context.Context) error {
 	m.consumers = make(map[ouroboros.ConnectionId]*MempoolConsumer)
 	m.consumersMutex.Unlock()
 
-	// Clear transactions
-	m.Lock()
 	m.transactions = []*MempoolTransaction{}
 	m.txByHash = make(map[string]*MempoolTransaction)
 	m.currentSizeBytes = 0
@@ -728,6 +742,11 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 	var evictedEvents []event.Event
 	func() {
 		m.Lock()
+		if m.stopped {
+			err = ErrMempoolStopped
+			m.Unlock()
+			return
+		}
 		m.consumersMutex.Lock()
 		defer func() {
 			m.consumersMutex.Unlock()

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1172,6 +1172,21 @@ func TestMempool_ConsumerAfterStop(t *testing.T) {
 	m.RUnlock()
 }
 
+func TestMempool_RejectsOperationsAfterStop(t *testing.T) {
+	m := newTestMempool(t)
+	connId := newTestConnectionId(0)
+
+	require.NoError(t, m.Stop(context.Background()))
+
+	err := m.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t))
+	require.ErrorIs(t, err, ErrMempoolStopped)
+	assert.Empty(t, m.Transactions())
+	assert.Nil(t, m.AddConsumer(connId))
+	assert.Nil(t, m.Consumer(connId))
+
+	require.NoError(t, m.Stop(context.Background()))
+}
+
 func TestMempool_BlockingNextTx_WithEmptyMempool(t *testing.T) {
 	m := newTestMempool(t)
 	defer m.Stop(context.Background())

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -140,7 +140,9 @@ func (o *Ouroboros) txsubmissionClientStart(
 	}
 	// Register only after all required connection state has been verified. This
 	// avoids leaving a stale consumer behind when startup cannot proceed.
-	o.Mempool.AddConsumer(connId)
+	if consumer := o.Mempool.AddConsumer(connId); consumer == nil {
+		return mempool.ErrMempoolStopped
+	}
 	tx.Client.Init()
 	return nil
 }


### PR DESCRIPTION
Closes #2907.

Makes mempool shutdown terminal so later admission and consumer registration cannot repopulate stopped state.

Tests: `go test -race ./mempool ./ouroboros`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make mempool shutdown terminal so the pool cannot be repopulated after it stops. After `Stop`, new transactions are rejected and consumer registration is rejected to avoid zombie activity.

- **Bug Fixes**
  - Added terminal `stopped` flag; `Stop` now sets it under lock before clearing state and is idempotent.
  - Post-stop: `AddTransaction` returns `mempool.ErrMempoolStopped`; `AddConsumer` returns `nil`; `ouroboros/txsubmission` returns the stop error during client start.
  - Tests cover rejection after stop; docs updated to describe terminal shutdown.

<sup>Written for commit 2d8d5b82acb9d418049ecd2a2de3bf9387ff3964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

