### PR TITLE
fix(mempool): release pool locks during validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1602,6 +1602,13 @@ clearing transaction and consumer state; later transaction admission returns
 prevents in-flight protocol callbacks from repopulating a pool whose background
 expiry and chain-update workers have already been stopped.
 
+Mempool mutations are serialized by a dedicated mutation gate so admission and
+chain-update revalidation use a stable UTxO-overlay view. CBOR decoding and
+ledger validation run without the primary pool RW lock or consumer lock;
+transaction snapshots, lookups, and relay reads therefore remain available
+during slow script validation. Revalidation commits its rebuilt overlay and any
+invalid removals atomically before releasing the mutation gate.
+
 ## Block Production
 
 When running as a stake pool operator, Dingo can produce blocks. This involves three subsystems under `ledger/`:

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -107,6 +107,7 @@ type Mempool struct {
 	stopped            bool
 	sync.RWMutex
 	doneOnce       sync.Once
+	mutationMutex  sync.Mutex
 	consumersMutex sync.Mutex
 	overlay        *utxoOverlay
 }
@@ -446,6 +447,8 @@ func (m *Mempool) RemoveConsumer(connId ouroboros.ConnectionId) {
 func (m *Mempool) Stop(ctx context.Context) error {
 	// Context is accepted for API consistency but not used since cleanup is synchronous and fast
 	m.logger.Debug("stopping mempool")
+	m.mutationMutex.Lock()
+	defer m.mutationMutex.Unlock()
 
 	// Establish a terminal state before clearing data. AddTransaction and
 	// AddConsumer check this state while holding the same pool lock, so neither
@@ -531,10 +534,8 @@ func (m *Mempool) processChainEvents() {
 
 // rebuildOverlay re-validates all pending TXs sequentially, rebuilding the
 // UTxO overlay from scratch. TXs that fail re-validation are removed.
-// Runs under the write lock for the entire duration to prevent races with
-// AddTransaction (which also holds the write lock when updating the overlay).
-// This is safe because mempool TX submission rate is low at tip and
-// cardano-node also serializes mempool additions.
+// Mutations are serialized for the duration, but decoding and ledger validation
+// run without the primary pool lock so snapshot readers remain available.
 //
 // Returns ErrNilValidator if called on a Mempool whose validator is nil —
 // a programmer error the chain-update loop logs rather than crashes on.
@@ -542,78 +543,83 @@ func (m *Mempool) rebuildOverlay() error {
 	if m.validator == nil {
 		return ErrNilValidator
 	}
-	m.Lock()
-	prevApplied := make([]appliedTx, len(m.overlay.applied))
-	copy(prevApplied, m.overlay.applied)
-
-	if len(prevApplied) == 0 {
-		m.Unlock()
-		return nil
-	}
-
-	// Re-validate each TX in order against a fresh overlay.
-	// Build new overlay incrementally — each valid TX extends it.
-	newOverlay := newUtxoOverlay()
-	var invalidHashes []string
-
-	for _, at := range prevApplied {
-		tmpTx, err := gledger.NewTransactionFromCbor(at.txType, at.cbor)
-		if err != nil {
-			invalidHashes = append(invalidHashes, at.hash)
-			m.logger.Error(
-				"transaction failed decode during re-validation",
-				"component", "mempool",
-				"tx_hash", at.hash,
-				"error", err,
-			)
-			continue
-		}
-		if err := m.validator.ValidateTxWithOverlay(
-			tmpTx,
-			newOverlay.consumed,
-			newOverlay.created,
-		); err != nil {
-			invalidHashes = append(invalidHashes, at.hash)
-			m.logger.Debug(
-				"transaction failed re-validation",
-				"component", "mempool",
-				"tx_hash", at.hash,
-				"error", err,
-			)
-			continue
-		}
-		// TX still valid — add its effects to the new overlay
-		newOverlay.applyTx(at.hash, at.txType, at.cbor, tmpTx)
-	}
-
-	// Swap overlay AND remove invalid TXs atomically so readers
-	// never see TXs in m.transactions that aren't in the overlay.
-	m.overlay = newOverlay
 	var events []event.Event
-	if len(invalidHashes) > 0 {
-		hashSet := make(map[string]struct{}, len(invalidHashes))
-		for _, h := range invalidHashes {
-			hashSet[h] = struct{}{}
+	err := func() error {
+		m.mutationMutex.Lock()
+		defer m.mutationMutex.Unlock()
+
+		m.RLock()
+		prevApplied := make([]appliedTx, len(m.overlay.applied))
+		for i, at := range m.overlay.applied {
+			prevApplied[i] = at
+			prevApplied[i].cbor = slices.Clone(at.cbor)
 		}
-		m.consumersMutex.Lock()
-		for i, v := range slices.Backward(m.transactions) {
-			h := v.Hash
-			if _, found := hashSet[h]; found {
-				evt := m.removeTransactionByIndexLocked(i)
-				if evt != nil {
-					events = append(events, *evt)
-				}
-				delete(hashSet, h)
-				if len(hashSet) == 0 {
-					break
+		m.RUnlock()
+		if len(prevApplied) == 0 {
+			return nil
+		}
+
+		newOverlay := newUtxoOverlay()
+		var invalidHashes []string
+		for _, at := range prevApplied {
+			tmpTx, decodeErr := gledger.NewTransactionFromCbor(at.txType, at.cbor)
+			if decodeErr != nil {
+				invalidHashes = append(invalidHashes, at.hash)
+				m.logger.Error(
+					"transaction failed decode during re-validation",
+					"component", "mempool",
+					"tx_hash", at.hash,
+					"error", decodeErr,
+				)
+				continue
+			}
+			if validateErr := m.validator.ValidateTxWithOverlay(
+				tmpTx,
+				newOverlay.consumed,
+				newOverlay.created,
+			); validateErr != nil {
+				invalidHashes = append(invalidHashes, at.hash)
+				m.logger.Debug(
+					"transaction failed re-validation",
+					"component", "mempool",
+					"tx_hash", at.hash,
+					"error", validateErr,
+				)
+				continue
+			}
+			newOverlay.applyTx(at.hash, at.txType, at.cbor, tmpTx)
+		}
+
+		m.Lock()
+		defer m.Unlock()
+		m.overlay = newOverlay
+		if len(invalidHashes) > 0 {
+			hashSet := make(map[string]struct{}, len(invalidHashes))
+			for _, h := range invalidHashes {
+				hashSet[h] = struct{}{}
+			}
+			m.consumersMutex.Lock()
+			defer m.consumersMutex.Unlock()
+			for i, v := range slices.Backward(m.transactions) {
+				h := v.Hash
+				if _, found := hashSet[h]; found {
+					evt := m.removeTransactionByIndexLocked(i)
+					if evt != nil {
+						events = append(events, *evt)
+					}
+					delete(hashSet, h)
+					if len(hashSet) == 0 {
+						break
+					}
 				}
 			}
 		}
-		m.consumersMutex.Unlock()
+		return nil
+	}()
+	if err != nil {
+		return err
 	}
-	m.Unlock()
 
-	// MEM-03: Publish events outside locks
 	if m.eventBus != nil {
 		for _, evt := range events {
 			m.eventBus.Publish(RemoveTransactionEventType, evt)
@@ -650,6 +656,7 @@ func (m *Mempool) removeExpiredTransactions() {
 	now := time.Now()
 	var events []event.Event
 	var removedCount int
+	m.mutationMutex.Lock()
 	m.Lock()
 	m.consumersMutex.Lock()
 	// Collect expired transaction hashes
@@ -693,6 +700,7 @@ func (m *Mempool) removeExpiredTransactions() {
 	}
 	m.consumersMutex.Unlock()
 	m.Unlock()
+	m.mutationMutex.Unlock()
 	// MEM-03: Publish events outside locks
 	if m.eventBus != nil {
 		for _, evt := range events {
@@ -737,50 +745,45 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		}
 	}
 	txHash := tmpTx.Hash().String()
-	// Collect events to publish outside locks (MEM-03 fix)
 	var addEvent *event.Event
 	var evictedEvents []event.Event
-	func() {
+	err = func() error {
+		// Serialize mutations without blocking snapshot readers during ledger
+		// validation. This gate also guarantees the overlay used for validation
+		// remains current until the transaction is committed.
+		m.mutationMutex.Lock()
+		defer m.mutationMutex.Unlock()
+
 		m.Lock()
 		if m.stopped {
-			err = ErrMempoolStopped
 			m.Unlock()
-			return
+			return ErrMempoolStopped
 		}
-		m.consumersMutex.Lock()
-		defer func() {
-			m.consumersMutex.Unlock()
-			m.Unlock()
-		}()
-		// Update last seen for existing TX
 		existingTx := m.getTransaction(txHash)
 		if existingTx != nil {
 			existingTx.LastSeen = time.Now()
+			m.Unlock()
 			m.logger.Debug(
 				"updated last seen for transaction",
 				"component", "mempool",
 				"tx_hash", txHash,
 			)
-			return
+			return nil
 		}
-		// Enforce mempool capacity using watermarks before validation
-		// so we don't waste time validating TXs that will be rejected.
 		txSize := int64(len(txBytes))
 		newSize := m.currentSizeBytes + txSize
 		rejectionThreshold := int64(
 			float64(m.config.MempoolCapacity) * m.rejectionWatermark,
 		)
 		if newSize > rejectionThreshold {
-			err = &MempoolFullError{
+			retErr := &MempoolFullError{
 				CurrentSize: int(m.currentSizeBytes),
 				TxSize:      int(txSize),
 				Capacity:    m.config.MempoolCapacity,
 			}
-			return
+			m.Unlock()
+			return retErr
 		}
-		// Determine if eviction is needed and simulate the
-		// post-eviction overlay to validate against. This avoids
-		// mutating state before we know the TX is valid.
 		validConsumed := m.overlay.consumed
 		validCreated := m.overlay.created
 		var needsEviction bool
@@ -801,27 +804,30 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 			}
 			validConsumed, validCreated = m.overlay.simulateRemoveBatch(evictedHashes)
 		}
-		// Validate against the (possibly simulated) post-eviction
-		// overlay so we don't accept a TX whose inputs were created
-		// by an evicted parent, and don't evict live TXs if
-		// validation fails.
-		if err = m.validator.ValidateTxWithOverlay(
+		m.Unlock()
+
+		// The mutation gate keeps this overlay snapshot stable while the
+		// potentially expensive ledger validation runs without the pool locks.
+		if validateErr := m.validator.ValidateTxWithOverlay(
 			tmpTx,
 			validConsumed,
 			validCreated,
-		); err != nil {
-			err = fmt.Errorf("validate transaction: %w", err)
-			return
+		); validateErr != nil {
+			return fmt.Errorf("validate transaction: %w", validateErr)
 		}
-		// Validation passed: commit the eviction
+
+		m.Lock()
+		m.consumersMutex.Lock()
+		defer func() {
+			m.consumersMutex.Unlock()
+			m.Unlock()
+		}()
 		if needsEviction {
 			evictedEvents = m.evictOldestLocked(targetBytes)
 		}
 		overlayCbor := slices.Clone(txBytes)
 		txCbor := slices.Clone(txBytes)
-		// Update UTxO overlay with this TX's effects
 		m.overlay.applyTx(txHash, txType, overlayCbor, tmpTx)
-		// Add transaction record
 		tx := &MempoolTransaction{
 			Hash:     txHash,
 			Type:     txType,
@@ -839,7 +845,6 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		m.metrics.txsProcessedNum.Inc()
 		m.metrics.txsInMempool.Inc()
 		m.metrics.mempoolBytes.Add(float64(txSize))
-		// Prepare event for publishing outside the lock
 		if m.eventBus != nil {
 			evt := event.NewEvent(
 				AddTransactionEventType,
@@ -851,6 +856,7 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 			)
 			addEvent = &evt
 		}
+		return nil
 	}()
 	if err != nil {
 		return err
@@ -909,6 +915,7 @@ func (m *Mempool) getTransaction(txHash string) *MempoolTransaction {
 
 func (m *Mempool) RemoveTransaction(txHash string) {
 	var events []event.Event
+	m.mutationMutex.Lock()
 	m.Lock()
 	m.consumersMutex.Lock()
 	// Remove from overlay with descendant pruning
@@ -945,6 +952,7 @@ func (m *Mempool) RemoveTransaction(txHash string) {
 	}
 	m.consumersMutex.Unlock()
 	m.Unlock()
+	m.mutationMutex.Unlock()
 	// MEM-03: Publish events outside the lock
 	if m.eventBus != nil {
 		for _, evt := range events {
@@ -966,6 +974,7 @@ func (m *Mempool) RemoveTxsByHash(hashes []string) {
 		hashSet[h] = struct{}{}
 	}
 	var events []event.Event
+	m.mutationMutex.Lock()
 	m.Lock()
 	m.consumersMutex.Lock()
 	m.overlay.removeByHashes(hashSet)
@@ -979,6 +988,7 @@ func (m *Mempool) RemoveTxsByHash(hashes []string) {
 	}
 	m.consumersMutex.Unlock()
 	m.Unlock()
+	m.mutationMutex.Unlock()
 	if m.eventBus != nil {
 		for _, evt := range events {
 			m.eventBus.Publish(RemoveTransactionEventType, evt)

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
+	dingotestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // =============================================================================
@@ -55,6 +55,36 @@ func newMockValidator() *mockValidator {
 	return &mockValidator{
 		failHashes: make(map[string]bool),
 	}
+}
+
+type blockingOverlayValidator struct {
+	started     chan struct{}
+	release     chan struct{}
+	startOnce   sync.Once
+	shouldBlock atomic.Bool
+}
+
+func newBlockingOverlayValidator() *blockingOverlayValidator {
+	return &blockingOverlayValidator{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (v *blockingOverlayValidator) ValidateTx(gledger.Transaction) error {
+	return nil
+}
+
+func (v *blockingOverlayValidator) ValidateTxWithOverlay(
+	gledger.Transaction,
+	map[string]struct{},
+	map[string]lcommon.Utxo,
+) error {
+	if v.shouldBlock.Load() {
+		v.startOnce.Do(func() { close(v.started) })
+		<-v.release
+	}
+	return nil
 }
 
 func (v *mockValidator) ValidateTx(tx gledger.Transaction) error {
@@ -2773,95 +2803,90 @@ func TestMempool_MEM03_SubscriberAccessesMempoolDuringRemove(
 	)
 }
 
-// TestMempool_MEM04_ConcurrentAccessDuringRevalidation verifies that
-// other goroutines can read/write the mempool while processChainEvents
-// is re-validating transactions. Before the MEM-04 fix, the write lock
-// was held during the entire re-validation loop.
-func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(
-	t *testing.T,
-) {
-	validator := newMockValidator()
+// TestMempool_MEM04_ConcurrentAccessDuringRevalidation synchronizes directly
+// with a paused validator to prove snapshot readers remain available while
+// mutations wait for the rebuild's stable overlay view.
+func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(t *testing.T) {
+	validator := newBlockingOverlayValidator()
 	m := newTestMempoolWithValidator(t, validator)
 	defer m.Stop(context.Background())
 
-	// Add transactions
-	addMockTransactions(t, m, 10)
+	txBytes := getTestTxBytes(t)
+	require.NoError(t, m.AddTransaction(uint(conway.EraIdConway), txBytes))
+	txs := m.Transactions()
+	require.Len(t, txs, 1)
+	consumer := m.AddConsumer(newTestConnectionId(0))
+	validator.shouldBlock.Store(true)
 
-	// Start concurrent readers/writers
-	var wg sync.WaitGroup
-	done := make(chan struct{})
-	var readsCompleted atomic.Int32
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- m.rebuildOverlay() }()
+	dingotestutil.RequireReceive(t, validator.started, time.Second, "revalidation start")
 
-	// Reader goroutine: continuously reads mempool
-	wg.Go(func() {
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				txs := m.Transactions()
-				_ = txs
-				readsCompleted.Add(1)
-			}
-		}
-	})
+	snapshotDone := make(chan []MempoolTransaction, 1)
+	go func() { snapshotDone <- m.Transactions() }()
+	assert.Len(
+		t,
+		dingotestutil.RequireReceive(t, snapshotDone, time.Second, "mempool snapshot"),
+		1,
+	)
 
-	// Writer goroutine: continuously adds/removes
-	wg.Go(func() {
-		for i := 0; ; i++ {
-			select {
-			case <-done:
-				return
-			default:
-				m.Lock()
-				tx := &MempoolTransaction{
-					Hash:     fmt.Sprintf("revalidation-tx-%d", i),
-					Cbor:     fmt.Appendf(nil, "cbor-%d", i),
-					Type:     uint(conway.EraIdConway),
-					LastSeen: time.Now(),
-				}
-				m.transactions = append(m.transactions, tx)
-				m.txByHash[tx.Hash] = tx
-				m.Unlock()
-				time.Sleep(time.Millisecond)
-			}
-		}
-	})
-
-	// Trigger chain update events to cause re-validation
-	for range 5 {
-		m.eventBus.Publish(
-			chain.ChainUpdateEventType,
-			event.NewEvent(chain.ChainUpdateEventType, nil),
-		)
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	// Let things run concurrently
-	time.Sleep(100 * time.Millisecond)
-	close(done)
-
-	waitCh := make(chan struct{})
+	lookupDone := make(chan bool, 1)
 	go func() {
-		wg.Wait()
-		close(waitCh)
+		_, ok := m.GetTransaction(txs[0].Hash)
+		lookupDone <- ok
 	}()
+	assert.True(t, dingotestutil.RequireReceive(t, lookupDone, time.Second, "transaction lookup"))
 
-	select {
-	case <-waitCh:
-		t.Logf(
-			"Reads completed during re-validation: %d",
-			readsCompleted.Load(),
-		)
-		// Under the old code with write lock held during validation,
-		// reads would be blocked. With the fix, reads should proceed.
-		assert.Greater(
-			t, readsCompleted.Load(), int32(0),
-			"reads should complete during re-validation",
-		)
-	case <-time.After(5 * time.Second):
-		t.Fatal("deadlock: concurrent access blocked during re-validation")
-	}
+	consumerDone := make(chan *MempoolTransaction, 1)
+	go func() { consumerDone <- consumer.NextTx(false) }()
+	assert.NotNil(
+		t,
+		dingotestutil.RequireReceive(t, consumerDone, time.Second, "consumer read"),
+	)
+
+	removeDone := make(chan struct{}, 1)
+	go func() {
+		m.RemoveTransaction(txs[0].Hash)
+		removeDone <- struct{}{}
+	}()
+	dingotestutil.RequireNoReceive(t, removeDone, 50*time.Millisecond, "mutation during rebuild")
+
+	close(validator.release)
+	require.NoError(t, dingotestutil.RequireReceive(t, rebuildDone, time.Second, "rebuild completion"))
+	dingotestutil.RequireReceive(t, removeDone, time.Second, "queued removal")
+	assert.Empty(t, m.Transactions())
+}
+
+func TestMempool_ReadsAndConsumerRegistrationProceedDuringAdmissionValidation(t *testing.T) {
+	validator := newBlockingOverlayValidator()
+	validator.shouldBlock.Store(true)
+	m := newTestMempoolWithValidator(t, validator)
+	defer m.Stop(context.Background())
+	txBytes := getTestTxBytes(t)
+
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- m.AddTransaction(uint(conway.EraIdConway), txBytes)
+	}()
+	dingotestutil.RequireReceive(t, validator.started, time.Second, "admission validation start")
+
+	snapshotDone := make(chan []MempoolTransaction, 1)
+	go func() { snapshotDone <- m.Transactions() }()
+	assert.Empty(
+		t,
+		dingotestutil.RequireReceive(t, snapshotDone, time.Second, "admission snapshot"),
+	)
+
+	consumerDone := make(chan *MempoolConsumer, 1)
+	go func() { consumerDone <- m.AddConsumer(newTestConnectionId(0)) }()
+	assert.NotNil(
+		t,
+		dingotestutil.RequireReceive(t, consumerDone, time.Second, "consumer registration"),
+	)
+
+	close(validator.release)
+	require.NoError(t, dingotestutil.RequireReceive(t, addDone, time.Second, "admission completion"))
+	assert.Len(t, m.Transactions(), 1)
 }
 
 // TestMempool_MEM03_NoDeadlockOnConcurrentPublish exercises the scenario


### PR DESCRIPTION
Closes #2903.

Serializes mempool mutations with a dedicated gate while releasing pool and consumer locks during ledger validation. Replaces the sleep-based concurrency test with deterministic validator coordination.

Tests: race suites, conformance, DevNet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize mempool mutations with a new gate and run admission and chain revalidation without the main pool locks. This keeps snapshots and consumer reads available while ensuring a stable overlay view and atomic commits.

- **Bug Fixes**
  - Validation now runs without the `Mempool` `RWMutex` or consumer lock; snapshot reads, lookups, and consumer reads proceed while mutations wait at the gate.
  - Revalidation and admissions commit overlay updates and invalid removals atomically behind the gate; `Stop`, expirations, and removals also acquire the gate to avoid races.

- **Refactors**
  - Added `mutationMutex` to `Mempool`; revalidation clones CBOR and publishes events outside locks.
  - Replaced sleep-based concurrency tests with a blocking overlay validator and deterministic coordination; added coverage for reads and consumer registration during admission.

<sup>Written for commit 5fd467b86b149b8190dce15b14529ae24ef8b53d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved mempool concurrency so transaction validation and chain revalidation no longer block snapshot reads, transaction lookups, or consumer registration.
  * Serialized mempool updates to prevent conflicting changes during admission, removal, expiry, shutdown, and revalidation.
  * Ensured validated transaction updates and invalid transaction removals are applied atomically.
* **Documentation**
  * Clarified mempool mutation and revalidation behavior in the architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->