### PR TITLE
fix(ouroboros): end blockfetch batch on rollback sentinel

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -296,6 +296,17 @@ Loop:
 			if next == nil {
 				break Loop
 			}
+			if next.Rollback {
+				// A rollback raced this in-flight batch: the iterator
+				// surfaced a rollback sentinel with a zero-value Block.
+				// Serving it would stream a [0, null] block that a fetching
+				// peer decodes as a nil-header Byron EBB and crashes
+				// dereferencing it in SlotNumber(). Blockfetch has no
+				// rollback message, so end the batch cleanly; the client
+				// re-requests against its updated chain. Mirrors the
+				// next.Rollback handling in chainsync.
+				break Loop
+			}
 			if next.Block.Slot > end.Slot {
 				break Loop
 			}

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -364,6 +364,55 @@ func TestBlockfetchServerSendBatch_BatchDoneAtChainTip(t *testing.T) {
 	assert.Equal(t, 1, iter.cancelCalls)
 }
 
+func TestBlockfetchServerSendBatch_RollbackEndsBatchWithoutServingBlock(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := NewOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	// The chain iterator surfaces a rollback as a sentinel result with
+	// Rollback=true and a zero-value Block. Serving that zero block streams a
+	// [0, null] block that a fetching peer decodes as a nil-header Byron EBB
+	// and crashes dereferencing it in SlotNumber(). The server must end the
+	// batch instead of serving the sentinel.
+	iter := &stubBlockfetchIterator{
+		steps: []blockfetchIteratorStep{
+			{result: &chain.ChainIteratorResult{
+				Point:    ocommon.NewPoint(150, []byte{0x03}),
+				Rollback: true,
+			}},
+		},
+	}
+	server := &stubBlockfetchBatchServer{}
+	conn := &stubBlockfetchConnection{
+		errChan: make(chan error),
+	}
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(200, []byte{0x02})
+
+	err := o.blockfetchServerSendBatch(
+		testConnId().String(),
+		start,
+		end,
+		iter,
+		server,
+		conn,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, server.startBatchCalls)
+	// The rollback sentinel must NOT be streamed as a block.
+	assert.Equal(t, 0, server.blockCalls,
+		"rollback sentinel must not be streamed as a block")
+	// The batch ends cleanly so the client re-requests against its updated
+	// chain (blockfetch has no rollback message).
+	assert.Equal(t, 1, server.batchDoneCalls)
+	assert.Equal(t, 0, conn.closeCalls)
+	assert.Equal(t, 1, iter.cancelCalls)
+}
+
 func TestBlockfetchServerSendBatch_WaitsForSendDrainBetweenMessages(
 	t *testing.T,
 ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop streaming a zero-value block when a rollback sentinel is encountered in blockfetch. End the batch cleanly so peers don’t crash on a nil-header Byron EBB and can re-request on the updated chain.

- **Bug Fixes**
  - End batch on `next.Rollback`; do not send the sentinel block.
  - Added test `TestBlockfetchServerSendBatch_RollbackEndsBatchWithoutServingBlock`.

<sup>Written for commit a3d179891d860b2d814415ff19acd7cea619b415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block synchronization during chain rollbacks.
  * Prevented invalid block data from being sent to clients, avoiding potential connection crashes.
  * Clients can now safely re-request blocks using the updated chain state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->