### PR TITLE
chore(mithril): Update default verification key URLs to IntersectMBO

### DIFF
--- a/mithril/client.go
+++ b/mithril/client.go
@@ -573,18 +573,18 @@ var ErrNoSnapshotsAvailable = errors.New(
 var defaultNetworkConfigs = map[string]NetworkConfig{
 	"mainnet": {
 		AggregatorURL:               "https://aggregator.release-mainnet.api.mithril.network/aggregator",
-		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/data/network-config/mainnet/genesis.vkey",
-		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/data/network-config/mainnet/genesis-ancillary.vkey",
+		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/mainnet/genesis.vkey",
+		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/mainnet/genesis-ancillary.vkey",
 	},
 	"preprod": {
 		AggregatorURL:               "https://aggregator.release-preprod.api.mithril.network/aggregator",
-		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/data/network-config/preprod/genesis.vkey",
-		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/data/network-config/preprod/genesis-ancillary.vkey",
+		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preprod/genesis.vkey",
+		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preprod/genesis-ancillary.vkey",
 	},
 	"preview": {
 		AggregatorURL:               "https://aggregator.pre-release-preview.api.mithril.network/aggregator",
-		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/data/network-config/preview/genesis.vkey",
-		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/data/network-config/preview/genesis-ancillary.vkey",
+		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preview/genesis.vkey",
+		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preview/genesis-ancillary.vkey",
 	},
 }
 

--- a/mithril/client.go
+++ b/mithril/client.go
@@ -573,18 +573,18 @@ var ErrNoSnapshotsAvailable = errors.New(
 var defaultNetworkConfigs = map[string]NetworkConfig{
 	"mainnet": {
 		AggregatorURL:               "https://aggregator.release-mainnet.api.mithril.network/aggregator",
-		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/mainnet/genesis.vkey",
-		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/mainnet/genesis-ancillary.vkey",
+		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey",
+		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/release-mainnet/ancillary.vkey",
 	},
 	"preprod": {
 		AggregatorURL:               "https://aggregator.release-preprod.api.mithril.network/aggregator",
-		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preprod/genesis.vkey",
-		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preprod/genesis-ancillary.vkey",
+		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey",
+		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/release-preprod/ancillary.vkey",
 	},
 	"preview": {
 		AggregatorURL:               "https://aggregator.pre-release-preview.api.mithril.network/aggregator",
-		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preview/genesis.vkey",
-		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/data/network-config/preview/genesis-ancillary.vkey",
+		GenesisVerificationKeyURL:   "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey",
+		AncillaryVerificationKeyURL: "https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/pre-release-preview/ancillary.vkey",
 	},
 }
 

--- a/mithril/client_test.go
+++ b/mithril/client_test.go
@@ -669,31 +669,64 @@ func TestSignedEntityTypeCardanoTransactionsFeedHash(t *testing.T) {
 }
 
 func TestNetworkConfigForNetwork(t *testing.T) {
-	cfg, err := NetworkConfigForNetwork("preview")
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		"https://aggregator.pre-release-preview.api.mithril.network/aggregator",
-		cfg.AggregatorURL,
-	)
-	require.Contains(t, cfg.GenesisVerificationKeyURL, "/preview/genesis.vkey")
-	require.Contains(
-		t,
-		cfg.AncillaryVerificationKeyURL,
-		"/preview/genesis-ancillary.vkey",
-	)
+	const keyURLBase = "https://raw.githubusercontent.com/" +
+		"IntersectMBO/mithril/main/mithril-infra/configuration/"
+	testCases := map[string]NetworkConfig{
+		"mainnet": {
+			AggregatorURL: "https://aggregator.release-mainnet.api." +
+				"mithril.network/aggregator",
+			GenesisVerificationKeyURL: keyURLBase +
+				"release-mainnet/genesis.vkey",
+			AncillaryVerificationKeyURL: keyURLBase +
+				"release-mainnet/ancillary.vkey",
+		},
+		"preprod": {
+			AggregatorURL: "https://aggregator.release-preprod.api." +
+				"mithril.network/aggregator",
+			GenesisVerificationKeyURL: keyURLBase +
+				"release-preprod/genesis.vkey",
+			AncillaryVerificationKeyURL: keyURLBase +
+				"release-preprod/ancillary.vkey",
+		},
+		"preview": {
+			AggregatorURL: "https://aggregator.pre-release-preview.api." +
+				"mithril.network/aggregator",
+			GenesisVerificationKeyURL: keyURLBase +
+				"pre-release-preview/genesis.vkey",
+			AncillaryVerificationKeyURL: keyURLBase +
+				"pre-release-preview/ancillary.vkey",
+		},
+	}
+
+	for network, expected := range testCases {
+		t.Run(network, func(t *testing.T) {
+			cfg, err := NetworkConfigForNetwork(network)
+			require.NoError(t, err)
+			require.Equal(t, expected, cfg)
+		})
+	}
 }
 
 func TestGenesisVerificationKeyURLForNetwork(t *testing.T) {
 	url, err := GenesisVerificationKeyURLForNetwork("mainnet")
 	require.NoError(t, err)
-	require.Contains(t, url, "/mainnet/genesis.vkey")
+	require.Equal(
+		t,
+		"https://raw.githubusercontent.com/IntersectMBO/mithril/main/"+
+			"mithril-infra/configuration/release-mainnet/genesis.vkey",
+		url,
+	)
 }
 
 func TestAncillaryVerificationKeyURLForNetwork(t *testing.T) {
 	url, err := AncillaryVerificationKeyURLForNetwork("preprod")
 	require.NoError(t, err)
-	require.Contains(t, url, "/preprod/genesis-ancillary.vkey")
+	require.Equal(
+		t,
+		"https://raw.githubusercontent.com/IntersectMBO/mithril/main/"+
+			"mithril-infra/configuration/release-preprod/ancillary.vkey",
+		url,
+	)
 }
 
 func TestCertificateAggregateVerificationKeyBytes(t *testing.T) {


### PR DESCRIPTION
This PR adapts the default Mithril config to the move to `IntersectMBO`:
- Repoints the six default genesis/ancillary verification-key URL constants in `mithril/client.go` to `raw.githubusercontent.com/IntersectMBO/mithril`.
- Corrects the URL paths, which pointed at a non-existent `configuration/data/network-config/<network>/` directory with a `genesis-ancillary.vkey` filename.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed the default genesis and ancillary verification key URLs to `IntersectMBO/mithril` and fixed the paths/filenames for mainnet, preprod, and preview. Fixes 404s; aggregator URLs are unchanged and tests now assert the new URLs.

<sup>Written for commit a8ca0a66ad777dc3d9094b0704084014821d9598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default network configuration links for genesis and ancillary verification keys across mainnet, preprod, and preview environments.
  * Existing aggregator URLs and other network settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->