### PR TITLE
ci(antithesis): use antithesis build tag

### DIFF
--- a/internal/test/antithesis/Dockerfile.analysis
+++ b/internal/test/antithesis/Dockerfile.analysis
@@ -9,7 +9,7 @@ WORKDIR /code
 COPY . .
 WORKDIR /code/internal/test/antithesis
 RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache \
-    go build -o /code/analysis ./cmd/analysis/
+    go build -tags antithesis -o /code/analysis ./cmd/analysis/
 
 FROM debian:bookworm-slim
 RUN apt-get update -y && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the analysis tool build configuration to include Antithesis-specific functionality.
  * Ensured the runtime image uses the correctly configured analysis binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the analysis binary with the `antithesis` build tag in `internal/test/antithesis/Dockerfile.analysis`. Ensures the runtime image includes Antithesis-specific functionality.

<sup>Written for commit 8549edad1f9c4ad6945b922aed1aec518606ed3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

