### PR TITLE
fix(mithril): primary ledger drain

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1299,6 +1299,56 @@ func (c *Chain) blockByIndex(
 	return tmpBlock, nil
 }
 
+func chainIteratorPreviousPoint(iter *ChainIterator) ocommon.Point {
+	if iter.lastPoint.Slot > 0 || len(iter.lastPoint.Hash) > 0 {
+		return iter.lastPoint
+	}
+	return iter.startPoint
+}
+
+func blockFollowsPoint(block models.Block, point ocommon.Point) bool {
+	if point.Slot == 0 && len(point.Hash) == 0 {
+		return len(block.PrevHash) == 0
+	}
+	return bytes.Equal(block.PrevHash, point.Hash)
+}
+
+func (c *Chain) nextPersistentBlockAfterSparseIndex(
+	iter *ChainIterator,
+) (models.Block, bool, error) {
+	if !c.persistent || iter.reverse ||
+		iter.nextBlockIndex > c.tipBlockIndex {
+		return models.Block{}, false, nil
+	}
+	previousPoint := chainIteratorPreviousPoint(iter)
+	for idx := iter.nextBlockIndex + 1; idx <= c.tipBlockIndex; idx++ {
+		block, err := c.blockByIndex(idx)
+		if errors.Is(err, models.ErrBlockNotFound) {
+			continue
+		}
+		if err != nil {
+			return models.Block{}, false, err
+		}
+		if blockFollowsPoint(block, previousPoint) {
+			return block, true, nil
+		}
+		return models.Block{}, false, fmt.Errorf(
+			"persistent chain index gap after index %d: block %d/%s at index %d has prev hash %s, expected %s",
+			iter.nextBlockIndex,
+			block.Slot,
+			hex.EncodeToString(block.Hash),
+			block.ID,
+			hex.EncodeToString(block.PrevHash),
+			hex.EncodeToString(previousPoint.Hash),
+		)
+	}
+	return models.Block{}, false, fmt.Errorf(
+		"persistent chain tip index %d is ahead of missing iterator index %d, but no later indexed block was found",
+		c.tipBlockIndex,
+		iter.nextBlockIndex,
+	)
+}
+
 func (c *Chain) iterNext(
 	iter *ChainIterator,
 	blocking bool,
@@ -1354,6 +1404,18 @@ func (c *Chain) iterNext(
 		ret := &ChainIteratorResult{}
 		// Lookup next block in metadata DB
 		tmpBlock, err := c.blockByIndex(iter.nextBlockIndex)
+		if errors.Is(err, models.ErrBlockNotFound) && !iter.reverse {
+			recoveredBlock, recovered, recoverErr := c.nextPersistentBlockAfterSparseIndex(
+				iter,
+			)
+			if recoverErr != nil {
+				err = recoverErr
+			} else if recovered {
+				tmpBlock = recoveredBlock
+				iter.nextBlockIndex = tmpBlock.ID
+				err = nil
+			}
+		}
 		// Return immedidately if a block is found
 		if err == nil {
 			ret.Point = ocommon.NewPoint(tmpBlock.Slot, tmpBlock.Hash)

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1321,31 +1321,31 @@ func (c *Chain) nextPersistentBlockAfterSparseIndex(
 		return models.Block{}, false, nil
 	}
 	previousPoint := chainIteratorPreviousPoint(iter)
-	for idx := iter.nextBlockIndex + 1; idx <= c.tipBlockIndex; idx++ {
-		block, err := c.blockByIndex(idx)
-		if errors.Is(err, models.ErrBlockNotFound) {
-			continue
-		}
-		if err != nil {
-			return models.Block{}, false, err
-		}
-		if blockFollowsPoint(block, previousPoint) {
-			return block, true, nil
-		}
+	block, err := c.manager.blockAtOrAfterIndex(
+		iter.nextBlockIndex+1,
+		nil,
+	)
+	if errors.Is(err, models.ErrBlockNotFound) {
 		return models.Block{}, false, fmt.Errorf(
-			"persistent chain index gap after index %d: block %d/%s at index %d has prev hash %s, expected %s",
+			"persistent chain tip index %d is ahead of missing iterator index %d, but no later indexed block was found",
+			c.tipBlockIndex,
 			iter.nextBlockIndex,
-			block.Slot,
-			hex.EncodeToString(block.Hash),
-			block.ID,
-			hex.EncodeToString(block.PrevHash),
-			hex.EncodeToString(previousPoint.Hash),
 		)
 	}
+	if err != nil {
+		return models.Block{}, false, err
+	}
+	if blockFollowsPoint(block, previousPoint) {
+		return block, true, nil
+	}
 	return models.Block{}, false, fmt.Errorf(
-		"persistent chain tip index %d is ahead of missing iterator index %d, but no later indexed block was found",
-		c.tipBlockIndex,
+		"persistent chain index gap after index %d: block %d/%s at index %d has prev hash %s, expected %s",
 		iter.nextBlockIndex,
+		block.Slot,
+		hex.EncodeToString(block.Hash),
+		block.ID,
+		hex.EncodeToString(block.PrevHash),
+		hex.EncodeToString(previousPoint.Hash),
 	)
 }
 

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -62,7 +62,7 @@ func TestPersistentIteratorDrainsAlreadyAheadPrimaryChainAcrossSparseIndex(
 			Cbor:     []byte{0x80},
 		},
 		{
-			ID:       initialBlockIndex + 3,
+			ID:       initialBlockIndex + 1_000_000,
 			Slot:     30,
 			Hash:     bytes.Repeat([]byte{0x03}, 32),
 			PrevHash: bytes.Repeat([]byte{0x02}, 32),
@@ -71,7 +71,7 @@ func TestPersistentIteratorDrainsAlreadyAheadPrimaryChainAcrossSparseIndex(
 			Cbor:     []byte{0x80},
 		},
 		{
-			ID:       initialBlockIndex + 4,
+			ID:       initialBlockIndex + 1_000_001,
 			Slot:     40,
 			Hash:     bytes.Repeat([]byte{0x04}, 32),
 			PrevHash: bytes.Repeat([]byte{0x03}, 32),

--- a/chain/iter_test.go
+++ b/chain/iter_test.go
@@ -15,11 +15,14 @@
 package chain
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	mockfixtures "github.com/blinklabs-io/ouroboros-mock/fixtures"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +31,143 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
+
+func TestPersistentIteratorDrainsAlreadyAheadPrimaryChainAcrossSparseIndex(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		DataDir:        t.TempDir(),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	blocks := []models.Block{
+		{
+			ID:     initialBlockIndex,
+			Slot:   10,
+			Hash:   bytes.Repeat([]byte{0x01}, 32),
+			Number: 1,
+			Type:   1,
+			Cbor:   []byte{0x80},
+		},
+		{
+			ID:       initialBlockIndex + 1,
+			Slot:     20,
+			Hash:     bytes.Repeat([]byte{0x02}, 32),
+			PrevHash: bytes.Repeat([]byte{0x01}, 32),
+			Number:   2,
+			Type:     1,
+			Cbor:     []byte{0x80},
+		},
+		{
+			ID:       initialBlockIndex + 3,
+			Slot:     30,
+			Hash:     bytes.Repeat([]byte{0x03}, 32),
+			PrevHash: bytes.Repeat([]byte{0x02}, 32),
+			Number:   3,
+			Type:     1,
+			Cbor:     []byte{0x80},
+		},
+		{
+			ID:       initialBlockIndex + 4,
+			Slot:     40,
+			Hash:     bytes.Repeat([]byte{0x04}, 32),
+			PrevHash: bytes.Repeat([]byte{0x03}, 32),
+			Number:   4,
+			Type:     1,
+			Cbor:     []byte{0x80},
+		},
+	}
+	for _, block := range blocks {
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	cm, err := NewManager(db, nil)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+	require.Equal(t, blocks[len(blocks)-1].Slot, c.Tip().Point.Slot)
+
+	iter, err := c.FromPoint(
+		ocommon.NewPoint(blocks[1].Slot, blocks[1].Hash),
+		false,
+	)
+	require.NoError(t, err)
+	defer iter.Cancel()
+
+	next, err := iter.Next(false)
+	require.NoError(t, err)
+	require.Equal(t, blocks[2].Slot, next.Point.Slot)
+	require.Equal(t, blocks[2].Hash, next.Point.Hash)
+
+	next, err = iter.Next(false)
+	require.NoError(t, err)
+	require.Equal(t, blocks[3].Slot, next.Point.Slot)
+	require.Equal(t, blocks[3].Hash, next.Point.Hash)
+
+	next, err = iter.Next(false)
+	require.Nil(t, next)
+	require.ErrorIs(t, err, ErrIteratorChainTip)
+}
+
+func TestPersistentIteratorRejectsSparseIndexWithHashDiscontinuity(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{
+		DataDir:        t.TempDir(),
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ledgerTipHash := bytes.Repeat([]byte{0x02}, 32)
+	blocks := []models.Block{
+		{
+			ID:     initialBlockIndex,
+			Slot:   10,
+			Hash:   bytes.Repeat([]byte{0x01}, 32),
+			Number: 1,
+			Type:   1,
+			Cbor:   []byte{0x80},
+		},
+		{
+			ID:       initialBlockIndex + 1,
+			Slot:     20,
+			Hash:     ledgerTipHash,
+			PrevHash: bytes.Repeat([]byte{0x01}, 32),
+			Number:   2,
+			Type:     1,
+			Cbor:     []byte{0x80},
+		},
+		{
+			ID:       initialBlockIndex + 3,
+			Slot:     30,
+			Hash:     bytes.Repeat([]byte{0x03}, 32),
+			PrevHash: bytes.Repeat([]byte{0xff}, 32),
+			Number:   3,
+			Type:     1,
+			Cbor:     []byte{0x80},
+		},
+	}
+	for _, block := range blocks {
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	cm, err := NewManager(db, nil)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+
+	iter, err := c.FromPoint(ocommon.NewPoint(blocks[1].Slot, ledgerTipHash), false)
+	require.NoError(t, err)
+	defer iter.Cancel()
+
+	next, err := iter.Next(false)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrIteratorChainTip)
+	require.False(t, next != nil && next.Point.Slot == blocks[2].Slot)
+}
 
 func TestIteratorCancelRemovesFromChain(t *testing.T) {
 	// Create a chain manager without a database (in-memory only)

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -327,6 +327,20 @@ func (cm *ChainManager) blockByIndex(
 	return models.Block{}, models.ErrBlockNotFound
 }
 
+func (cm *ChainManager) blockAtOrAfterIndex(
+	blockIndex uint64,
+	txn *database.Txn,
+) (models.Block, error) {
+	if cm.db == nil {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	block, err := cm.db.BlockAtOrAfterIndex(blockIndex, txn)
+	if errors.Is(err, models.ErrBlockNotFound) {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	return block, err
+}
+
 func (cm *ChainManager) loadPrimaryChain() error {
 	persistent := (cm.db != nil)
 	chain := &Chain{

--- a/database/block.go
+++ b/database/block.go
@@ -542,11 +542,32 @@ func (d *Database) BlockAtOrAfterIndex(
 			it.Next()
 			continue
 		}
+		indexKey := item.Key()
+		if indexKey == nil {
+			it.Next()
+			continue
+		}
 		blockKey, err := item.ValueCopy(nil)
 		if err != nil {
 			return models.Block{}, err
 		}
-		return blockByKey(txn, blockKey)
+		block, err := blockByKey(txn, blockKey)
+		if err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				it.Next()
+				continue
+			}
+			return models.Block{}, err
+		}
+		// The index value is an indirection to the block blob. A stale
+		// mapping may still resolve successfully but point at a block from
+		// an older index. Only accept the block when its metadata ID matches
+		// the ordered index key currently being visited.
+		if !bytes.Equal(indexKey, types.BlockBlobIndexKey(block.ID)) {
+			it.Next()
+			continue
+		}
+		return block, nil
 	}
 	if err := it.Err(); err != nil {
 		return models.Block{}, err

--- a/database/block.go
+++ b/database/block.go
@@ -507,6 +507,53 @@ func (d *Database) BlockByIndex(
 	return blockByKey(txn, val)
 }
 
+// BlockAtOrAfterIndex returns the first block whose chain index is greater
+// than or equal to blockIndex. It seeks the ordered block-index keys so sparse
+// imported chains do not require one lookup and transaction per missing index.
+func (d *Database) BlockAtOrAfterIndex(
+	blockIndex uint64,
+	txn *Txn,
+) (models.Block, error) {
+	if txn == nil {
+		txn = d.BlobTxn(false)
+		defer txn.Rollback() //nolint:errcheck
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return models.Block{}, types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return models.Block{}, types.ErrBlobStoreUnavailable
+	}
+	prefix := []byte(types.BlockBlobIndexKeyPrefix)
+	it := blob.NewIterator(
+		blobTxn,
+		types.BlobIteratorOptions{Prefix: prefix},
+	)
+	if it == nil {
+		return models.Block{}, errors.New("blob iterator is nil")
+	}
+	defer it.Close()
+	it.Seek(types.BlockBlobIndexKey(blockIndex))
+	for it.ValidForPrefix(prefix) {
+		item := it.Item()
+		if item == nil {
+			it.Next()
+			continue
+		}
+		blockKey, err := item.ValueCopy(nil)
+		if err != nil {
+			return models.Block{}, err
+		}
+		return blockByKey(txn, blockKey)
+	}
+	if err := it.Err(); err != nil {
+		return models.Block{}, err
+	}
+	return models.Block{}, models.ErrBlockNotFound
+}
+
 func BlocksRecent(db *Database, count int) ([]models.Block, error) {
 	var ret []models.Block
 	txn := db.Transaction(false)

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -73,6 +73,25 @@ func TestBlockBySlotSkipsStaleSameSlotIndex(t *testing.T) {
 	require.Equal(t, lowerIDBlock.Hash, block.Hash)
 }
 
+func TestBlockAtOrAfterIndexSkipsSparseIndexes(t *testing.T) {
+	db := newTestDB(t)
+	blocks := []models.Block{
+		testIndexedBlock(10, 1, 0x01),
+		testIndexedBlock(20, 1_000_000, 0x02),
+	}
+	for _, block := range blocks {
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	block, err := db.BlockAtOrAfterIndex(2, nil)
+	require.NoError(t, err)
+	require.Equal(t, blocks[1].ID, block.ID)
+	require.Equal(t, blocks[1].Hash, block.Hash)
+
+	_, err = db.BlockAtOrAfterIndex(blocks[1].ID+1, nil)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}
+
 // TestBlockBeforeSlotSkipsSyntheticBlobs verifies BlockBeforeSlot returns the
 // highest real ranking block before a slot and skips synthetic blobs. Genesis
 // CBOR and Leios endorser blocks are persisted at block-blob keys via

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -92,6 +92,37 @@ func TestBlockAtOrAfterIndexSkipsSparseIndexes(t *testing.T) {
 	require.ErrorIs(t, err, models.ErrBlockNotFound)
 }
 
+func TestBlockAtOrAfterIndexSkipsInvalidIndexMappings(t *testing.T) {
+	db := newTestDB(t)
+	olderBlock := testIndexedBlock(10, 1, 0x01)
+	nextBlock := testIndexedBlock(30, 300, 0x03)
+	require.NoError(t, db.BlockCreate(olderBlock, nil))
+	require.NoError(t, db.BlockCreate(nextBlock, nil))
+
+	txn := db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		// This index resolves, but its target belongs to an older index.
+		if err := db.Blob().Set(
+			txn.Blob(),
+			types.BlockBlobIndexKey(100),
+			types.BlockBlobKey(olderBlock.Slot, olderBlock.Hash),
+		); err != nil {
+			return err
+		}
+		// This index points at a block that is no longer present.
+		return db.Blob().Set(
+			txn.Blob(),
+			types.BlockBlobIndexKey(200),
+			types.BlockBlobKey(20, bytes.Repeat([]byte{0x02}, 32)),
+		)
+	}))
+
+	block, err := db.BlockAtOrAfterIndex(2, nil)
+	require.NoError(t, err)
+	require.Equal(t, nextBlock.ID, block.ID)
+	require.Equal(t, nextBlock.Hash, block.Hash)
+}
+
 // TestBlockBeforeSlotSkipsSyntheticBlobs verifies BlockBeforeSlot returns the
 // highest real ranking block before a slot and skips synthetic blobs. Genesis
 // CBOR and Leios endorser blocks are persisted at block-blob keys via


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes draining of the persistent primary ledger iterator when the metadata index is sparse. The iterator now seeks the next valid block after a gap and fails fast on prev-hash discontinuities.

- **Bug Fixes**
  - Seek the first indexed block at/after the gap that follows the iterator’s previous point (persistent, forward iterators only).
  - Validate prev-hash continuity; return a clear error on mismatch.
  - Add a DB helper to scan for the first block at/after an index (reduces lookups on sparse chains), skipping stale/invalid index mappings; add tests for sparse indexes and discontinuities.

<sup>Written for commit 91d5df266bed4c87a1ca38c9bbd5b507709ea385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

