### PR TITLE
fix(ouroboros): order rollback observation before the roll-backward apply gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1363,8 +1363,13 @@ it. Dingo implements this as a **corroboration gate**
   the roll-forward handler, skipping the async `PeerTipUpdateEvent`), so the
   apply decision reflects the header currently being admitted rather than a tip
   update that has not been processed yet — an async observation could otherwise
-  let a header slip through in the window before it revoked corroboration. With
-  the gate disabled the async path is used unchanged.
+  let a header slip through in the window before it revoked corroboration. The
+  roll-**backward** path does the same via `OuroborosConfig.ChainsyncObserveRollback`
+  (wired to apply the rollback into chain selection, skipping the async
+  `PeerRollbackEvent`): a rollback trims the peer's observed frontier and can
+  change its corroboration status, so the rollback apply decision must reflect
+  the post-rollback state rather than pre-trim corroboration. With the gate
+  disabled both paths use the async path unchanged.
 - The gate **denies application but does not disconnect** the fast source. Genesis
   wants the fast source kept connected so it can serve blocks as soon as
   corroboration arrives; demoting or dropping it would defeat the accelerator.

--- a/node.go
+++ b/node.go
@@ -290,11 +290,12 @@ func (n *Node) Run(ctx context.Context) error {
 		// connection, so the fetch is gated on the txs offer, not the block
 		// offer. Best-effort: a fetch failure never tears down the shared
 		// connection.
-		EnableLeiosTxFetch:       enableLeiosNetworking,
-		LeiosTxFetchTailBudget:   leiosTxFetchTailBudget,
-		ChainsyncIngressEligible: n.isChainsyncIngressEligible,
-		ChainsyncApplyEligible:   n.chainsyncApplyEligible,
-		ChainsyncObservePeerTip:  n.chainsyncObservePeerTip,
+		EnableLeiosTxFetch:           enableLeiosNetworking,
+		LeiosTxFetchTailBudget:       leiosTxFetchTailBudget,
+		ChainsyncIngressEligible:     n.isChainsyncIngressEligible,
+		ChainsyncApplyEligible:       n.chainsyncApplyEligible,
+		ChainsyncObservePeerTip:      n.chainsyncObservePeerTip,
+		ChainsyncObservePeerRollback: n.chainsyncObservePeerRollback,
 		// On the Musashi prototype network every mini-protocol shares one muxer
 		// to a single relay; block/EB traffic can delay the relay's keep-alive
 		// pong past the tight 10s gouroboros default, making dingo drop the

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -58,6 +58,33 @@ func (n *Node) chainsyncObservePeerTip(
 	return true
 }
 
+// chainsyncObservePeerRollback synchronously applies a peer rollback into chain
+// selection when the Genesis corroboration gate is active, so the
+// ChainsyncApplyEligible check that immediately follows in the roll-backward
+// handler reflects the post-rollback corroboration state. A rollback trims the
+// peer's observed frontier (ApplyRollback), which can change its corroboration
+// status; delivering that observation asynchronously would let the apply gate
+// read pre-trim state and forward a rollback for a peer that the rollback has
+// just made uncorroborated (issue #2928). It returns true when handled
+// synchronously, so the ouroboros layer skips the async PeerRollbackEvent
+// publish to avoid a double update. Unlike chainsyncObservePeerTip there is no
+// peergov touch: only the chain selector subscribes to PeerRollbackEvent.
+//
+// When corroboration is inactive the async path is used unchanged (returns
+// false).
+func (n *Node) chainsyncObservePeerRollback(
+	e chainselection.PeerRollbackEvent,
+) bool {
+	if n.chainSelector == nil ||
+		!n.chainSelector.GenesisCorroborationActive() {
+		return false
+	}
+	n.chainSelector.HandlePeerRollbackEvent(
+		event.NewEvent(chainselection.PeerRollbackEventType, e),
+	)
+	return true
+}
+
 // chainsyncApplyEligible gates whether a peer's headers/rollbacks are APPLIED to
 // the ledger, on top of ingress eligibility. It defers to the chain selector's
 // corroboration decision so an uncorroborated Genesis fast source is observed

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -683,22 +683,33 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	) {
 		return nil
 	}
-	// Observe the rollback for chain selection first (trims the peer's observed
-	// history) so corroboration tracking stays correct even for a peer whose
-	// blocks we are withholding via the apply gate below.
-	o.EventBus.Publish(
-		chainselection.PeerRollbackEventType,
-		event.NewEvent(
+	// Observe the rollback for chain selection FIRST — it trims the peer's
+	// observed frontier (ApplyRollback), which can change its corroboration
+	// status, so the apply gate below must reflect it. If the hook handles it
+	// synchronously (Genesis corroboration active), skip the async publish to
+	// avoid a double update; otherwise publish for the async subscriber. This
+	// mirrors the roll-forward ChainsyncObservePeerTip ordering.
+	rollbackEvent := chainselection.PeerRollbackEvent{
+		ConnectionId: ctx.ConnectionId,
+		Point:        point,
+		Tip:          tip,
+	}
+	observedSync := false
+	if o.config.ChainsyncObservePeerRollback != nil {
+		observedSync = o.config.ChainsyncObservePeerRollback(rollbackEvent)
+	}
+	if !observedSync {
+		o.EventBus.Publish(
 			chainselection.PeerRollbackEventType,
-			chainselection.PeerRollbackEvent{
-				ConnectionId: ctx.ConnectionId,
-				Point:        point,
-				Tip:          tip,
-			},
-		),
-	)
+			event.NewEvent(
+				chainselection.PeerRollbackEventType,
+				rollbackEvent,
+			),
+		)
+	}
 	// Apply gate: withhold an uncorroborated peer's rollback from the ledger,
-	// mirroring the roll-forward apply gate.
+	// mirroring the roll-forward apply gate. The observation above ran first, so
+	// this reflects the post-rollback corroboration state.
 	if !o.shouldApplyChainsyncToLedger(ctx.ConnectionId) {
 		o.config.Logger.Debug(
 			"chainsync: rollback withheld (not apply eligible)",

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -1340,6 +1340,88 @@ func TestChainsyncClientRollForward_WithheldHeaderNotPermanentlyDeduped(
 // the tip is folded into chain selection before the apply gate runs, so a
 // header that establishes corroboration is applied in the same roll-forward
 // rather than withheld until an asynchronous tip update is processed.
+// The roll-backward apply gate must reflect the rollback currently being
+// admitted: a rollback trims the peer's observed frontier (via ApplyRollback),
+// which can change its corroboration status, so the observation must be applied
+// to chain selection synchronously before the apply-eligibility check. Here a
+// peer corroborated on its pre-rollback frontier rolls back below that frontier
+// (trimming its observed points to empty), which makes it uncorroborated; the
+// rollback must therefore be withheld from the ledger — decided in the same
+// roll-backward call, with no async lag.
+func TestChainsyncClientRollBackwardSyncObservationOrdersApplyGate(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+
+	cs := chainselection.NewChainSelector(chainselection.ChainSelectorConfig{
+		GenesisMode:           true,
+		SecurityParam:         20,
+		MinCorroboratingPeers: 1,
+	})
+
+	state := dchainsync.NewState(bus, nil)
+	// Distinct remote hosts so the two peers count as independent corroborators.
+	connP := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	connW := newTestConnId("127.0.0.1:6000", "10.0.0.2:3001")
+	require.True(t, state.AddClientConnId(connP))
+	require.True(t, state.AddClientConnId(connW))
+
+	mkTip := func(slot uint64, hash string, block uint64) ochainsync.Tip {
+		return ochainsync.Tip{
+			Point:       ocommon.Point{Slot: slot, Hash: []byte(hash)},
+			BlockNumber: block,
+		}
+	}
+	// P and W corroborate each other on slots 100 and 105.
+	for _, c := range []ouroboros.ConnectionId{connP, connW} {
+		cs.UpdatePeerTip(c, mkTip(100, "h100", 100), nil)
+		cs.UpdatePeerTip(c, mkTip(105, "h105", 105), nil)
+	}
+	require.True(t, cs.ShouldApplyIngress(connP),
+		"P must be apply-eligible (corroborated) before the rollback")
+
+	o := NewOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		// Synchronous observation, exactly like node.chainsyncObservePeerRollback.
+		ChainsyncObservePeerRollback: func(
+			e chainselection.PeerRollbackEvent,
+		) bool {
+			cs.HandlePeerRollbackEvent(
+				event.NewEvent(chainselection.PeerRollbackEventType, e),
+			)
+			return true
+		},
+		ChainsyncApplyEligible: cs.ShouldApplyIngress,
+	})
+	o.ChainsyncState = state
+	o.EventBus = bus
+
+	// P rolls back to slot 99, below its entire corroborated frontier, trimming
+	// its observed points to empty. Its synchronous observation makes P
+	// uncorroborated before the apply gate, so the rollback is withheld.
+	rollbackPoint := ocommon.NewPoint(99, []byte("rb99"))
+	require.NoError(t, o.chainsyncClientRollBackward(
+		ochainsync.CallbackContext{ConnectionId: connP},
+		rollbackPoint,
+		mkTip(99, "rb99", 99),
+	))
+	testutil.RequireNoReceive(
+		t,
+		ledgerCh,
+		200*time.Millisecond,
+		"rollback must be withheld: the apply gate must reflect the "+
+			"post-rollback (trimmed) corroboration state",
+	)
+	require.False(t, cs.ShouldApplyIngress(connP),
+		"P must be uncorroborated after the rollback trims its frontier")
+}
+
 func TestChainsyncClientRollForwardSyncObservationOrdersApplyGate(
 	t *testing.T,
 ) {

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -189,6 +189,16 @@ type OuroborosConfig struct {
 	// revokes corroboration is not yet processed). Returning false (or nil hook)
 	// falls back to the async PeerTipUpdateEvent path.
 	ChainsyncObservePeerTip func(chainselection.PeerTipUpdateEvent) bool
+	// ChainsyncObservePeerRollback observes a peer rollback. It returns true if it
+	// handled the observation synchronously, in which case the caller MUST NOT
+	// also publish the async PeerRollbackEvent (avoids a double update). It
+	// mirrors ChainsyncObservePeerTip for the roll-backward path: a rollback
+	// trims the peer's observed frontier (ApplyRollback) and can therefore
+	// change its corroboration status, so the node applies it to chain selection
+	// synchronously before the ChainsyncApplyEligible gate runs, so the rollback
+	// apply decision reflects the post-rollback state. Returning false (or nil
+	// hook) falls back to the async PeerRollbackEvent path.
+	ChainsyncObservePeerRollback func(chainselection.PeerRollbackEvent) bool
 	// Enable experimental Leios protocol support
 	EnableLeios bool
 	// LeiosClosureWaitTimeout optionally overrides how long the NtC chainsync


### PR DESCRIPTION
## Summary

Fixes #2928 (follow-up to #2896, now merged).

The roll-**backward** apply gate had the same async-observation race that #2896 closed on the roll-forward path. `chainsyncClientRollBackward` published `PeerRollbackEvent` **asynchronously**, so `ApplyRollback` — which trims the peer's `observedSlots`/`observedPoints` and can therefore change its corroboration status — ran later on another goroutine, while `shouldApplyChainsyncToLedger` was checked synchronously right after. A peer corroborated on its pre-rollback frontier could thus have a rollback forwarded to the ledger using stale (pre-trim) corroboration state.

This is limited to when the corroboration gate is active (`genesisBootstrap` with `corroborationPeers > 0`, from-origin Genesis mode), which is default-off — but it's a gap in the same security property the roll-forward path enforces.

## Change

- Add `OuroborosConfig.ChainsyncObserveRollback`, mirroring `ChainsyncObservePeerTip`. When Genesis corroboration is active, the node applies the rollback into chain selection **synchronously** (`HandlePeerRollbackEvent`) before the apply gate, and the async `PeerRollbackEvent` publish is skipped to avoid a double update. Unlike the tip hook there is no peergov touch — only the chain selector subscribes to `PeerRollbackEvent`.
- Reorder `chainsyncClientRollBackward` to observe before the apply gate.
- When corroboration is inactive the async path is used unchanged, so this is a **no-op for normal sync**.

## Tests

`TestChainsyncClientRollBackwardSyncObservationOrdersApplyGate` (analogous to the roll-forward `...RollForwardSyncObservationOrdersApplyGate`): a peer corroborated pre-rollback rolls back below its frontier (trimming it to empty), becoming uncorroborated, so the rollback is withheld — decided in the same roll-backward call. Verified it **fails** against an async observation (the rollback leaks with stale corroboration state) and passes with the sync hook.

`-race` (chainselection, ouroboros, chainsync, root) + conformance + lint (0 issues) + modernize all pass. `ARCHITECTURE.md` updated.

Not run: DevNet — this change is inert with corroboration disabled (DevNet's config: `chainsyncObserveRollback` returns false, so the async path is unchanged), and the async-rollback path is covered by existing tests. Happy to run it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the roll-backward apply gate by observing peer rollbacks synchronously before the gate, so corroboration reflects post-rollback state. Adds `OuroborosConfig.ChainsyncObservePeerRollback`; no-op when corroboration is disabled.

- **Bug Fixes**
  - Added `ChainsyncObservePeerRollback` hook (mirrors `ChainsyncObservePeerTip`). When active, applies rollback via `HandlePeerRollbackEvent` and skips async `PeerRollbackEvent`.
  - Reordered `ouroboros.chainsyncClientRollBackward` to observe before the apply gate, ensuring the gate sees post-rollback corroboration.
  - Wired `node.chainsyncObservePeerRollback`; async path unchanged when corroboration is inactive. Updated `ARCHITECTURE.md`.

- **Tests**
  - Added `TestChainsyncClientRollBackwardSyncObservationOrdersApplyGate`.

<sup>Written for commit c03f0cfb1b14ca1a43738e7d1dba45d68cfdc980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback handling during chain synchronization.
  * Corroboration decisions now reflect the latest peer state immediately after rollback updates.
  * Prevented headers from being accepted after corroboration is revoked.
  * Avoided duplicate rollback processing while preserving existing asynchronous behavior when needed.

* **Documentation**
  * Clarified synchronous observation and rollback admission behavior in the architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->