### PR TITLE
fix(ledger): primary chain rewind loop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1731,6 +1731,28 @@ detector itself breaks a loop by skipping a rollback it can no longer cross,
 it feeds that same point-keyed tracker so the escalation and metric fire on
 the skip path too, rather than silently suppressing the rollback.
 
+A separate recovery path handles transaction-validation failures that occur
+after the node has reached the chain tip (`recoverAtTipFromTxValidationError`
+in `ledger/replay_recovery.go`). When a block fails per-tx validation at tip,
+the node rewinds the primary chain and rolls the ledger back so ChainSelection
+can re-pick a candidate chain; repeating the *same* `(block, tx)` failure
+escalates the rewind progressively deeper, up to the era stability window, to
+escape a losing fork. A descending series of *distinct* failures is treated
+differently (issue #2939): because each distinct failure resets the same-block
+escalation, without a guard the primary chain would be rewound a stability
+window deeper every cycle and the node would fall unboundedly behind the wall
+clock, recoverable only by restart. `maxAtTipRecoveryDescents` consecutive
+distinct failures that fail to advance latch recovery into a hold-at-tip mode
+that suppresses deep rewinds — rewinding only to the ledger tip so ChainSync
+re-delivers rather than descending. The latch clears when the ledger makes
+forward progress past the failing region (`resetAtTipRecoveryDescent`, called
+from the block-apply success path). Because a hold usually indicates local
+ledger validation diverging from the network (a false-positive rejection that
+no rewind can fix) rather than a peer/fork problem, it surfaces the
+`dingo_ledger_attip_recovery_nonconverging_total` metric and a throttled
+operator warning; a node in this state needs the underlying validation
+divergence resolved.
+
 Topology configuration is loaded from an explicit topology file when provided,
 otherwise from the embedded `network/topology.json` for built-in networks,
 falling back to the legacy network bootstrap-peer list only when no embedded

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -43,6 +43,13 @@ type stateMetrics struct {
 	// we cannot cross to (local chain diverged), so a stuck node surfaces
 	// as a metric instead of only a WARN loop. See issue #2728.
 	unrecoverableRollbacks prometheus.Counter
+	// Incremented when at-tip validation recovery detects a non-converging,
+	// descending series of distinct failures and holds at the ledger tip
+	// instead of rewinding the primary chain ever deeper. A rising value
+	// means local ledger validation is diverging from the network (e.g. a
+	// false-positive validation rejection), not a peer/fork problem. See
+	// issue #2939.
+	atTipRecoveryNonConverging prometheus.Counter
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -140,6 +147,12 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.CounterOpts{
 			Name: "dingo_chainsync_unrecoverable_rollback_total",
 			Help: "times a peer repeatedly requested a rollback we cannot cross to (local chain diverged, operator intervention required)",
+		},
+	)
+	m.atTipRecoveryNonConverging = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_ledger_attip_recovery_nonconverging_total",
+			Help: "times at-tip validation recovery held at the ledger tip instead of rewinding the primary chain deeper, because a descending series of distinct failures indicated local validation divergence (operator intervention required)",
 		},
 	)
 }

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -73,6 +73,19 @@ func (e *txValidationError) Unwrap() error {
 // relies on ChainSync peer rotation to find a valid candidate chain.
 const maxAtTipRecoveryAttempts = 3
 
+// maxAtTipRecoveryDescents caps how many consecutive *distinct* at-tip failures
+// may fail to advance (each at a slot at or below the previous distinct
+// failure) before at-tip recovery declares itself non-converging and stops
+// rewinding the primary chain deeper. Distinct failures each reset the
+// same-block escalation to attempt 1, so without this bound the escalate-and-cap
+// logic never engages and the primary chain is rewound a stability window
+// deeper every cycle, falling unboundedly behind the wall clock (issue #2939).
+// Once tripped, recovery holds at the ledger tip until the ledger makes forward
+// progress past the failing region, relying on ChainSync re-delivery rather
+// than a destructive descent that no rewind can fix (e.g. a local
+// false-positive validation rejection).
+const maxAtTipRecoveryDescents = 2
+
 type atTipRecoveryAttempt struct {
 	BlockPoint ocommon.Point
 	TxHash     []byte
@@ -237,6 +250,25 @@ func (ls *LedgerState) rejectReplayRecoveryAtMithrilBoundary(
 	)
 }
 
+// resetAtTipRecoveryDescent clears the non-convergence descent tracking once
+// the ledger has made forward progress past the failing region. Called from the
+// block-apply success path when the tip advances beyond the last recorded
+// at-tip failure slot, so a later, unrelated at-tip failure starts with a fresh
+// recovery budget instead of inheriting a stale hold. Runs on the ledger
+// pipeline goroutine, the same goroutine that mutates these fields during
+// recovery, so no additional locking is required.
+func (ls *LedgerState) resetAtTipRecoveryDescent(newTipSlot uint64) {
+	if ls.atTipRecoveryLastFailSlot == 0 {
+		return
+	}
+	if newTipSlot <= ls.atTipRecoveryLastFailSlot {
+		return
+	}
+	ls.atTipRecoveryLastFailSlot = 0
+	ls.atTipRecoveryDescentCount = 0
+	ls.atTipRecoveryHolding = false
+}
+
 func (ls *LedgerState) recoverAtTipFromTxValidationError(
 	validationErr *txValidationError,
 ) (bool, error) {
@@ -252,9 +284,10 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 	// Rewind progressively deeper to expose a wider candidate set, up
 	// to the era's stability window. Only halt if even the deepest
 	// rewind has been tried.
+	isSameFailure := ls.lastAtTipRecovery != nil &&
+		ls.lastAtTipRecovery.matches(validationErr)
 	attempts := 1
-	if ls.lastAtTipRecovery != nil &&
-		ls.lastAtTipRecovery.matches(validationErr) {
+	if isSameFailure {
 		attempts = ls.lastAtTipRecovery.Attempts + 1
 		if attempts > maxAtTipRecoveryAttempts {
 			ls.config.Logger.Warn(
@@ -270,6 +303,28 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 			attempts = maxAtTipRecoveryAttempts
 		}
 	}
+	// Track non-convergence across DISTINCT failures. Each distinct (block,
+	// tx) failure resets the same-block escalation above to attempt 1, so a
+	// descending series would otherwise rewind the primary chain a stability
+	// window deeper every cycle without ever hitting the escalation cap. When
+	// a distinct failure does not advance beyond the previous distinct
+	// failure's slot, count it as a descent; once enough accumulate, latch
+	// into a hold-at-tip mode that suppresses deep rewinds. The latch clears
+	// only when the ledger makes forward progress (see
+	// resetAtTipRecoveryDescent, called from the block-apply success path).
+	if !isSameFailure {
+		if ls.atTipRecoveryLastFailSlot != 0 &&
+			validationErr.BlockPoint.Slot <= ls.atTipRecoveryLastFailSlot {
+			ls.atTipRecoveryDescentCount++
+		} else {
+			ls.atTipRecoveryDescentCount = 0
+			ls.atTipRecoveryHolding = false
+		}
+		ls.atTipRecoveryLastFailSlot = validationErr.BlockPoint.Slot
+	}
+	if ls.atTipRecoveryDescentCount >= maxAtTipRecoveryDescents {
+		ls.atTipRecoveryHolding = true
+	}
 	ls.lastAtTipRecovery = newAtTipRecoveryAttempt(validationErr)
 	ls.lastAtTipRecovery.Attempts = attempts
 	ls.RLock()
@@ -278,8 +333,12 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 	chainTip := ls.chain.Tip()
 	// Compute the rewind target. Depth grows linearly with each retry,
 	// capped at the era stability window so we never undo an immutable block.
+	// While holding (non-converging descent detected), deep rewinds are
+	// suppressed entirely: we rewind only to the ledger tip so the primary
+	// chain stops descending and ChainSync can re-deliver, avoiding the
+	// unbounded staircase of issue #2939.
 	rewindPoint := ledgerTip.Point
-	if attempts > 1 {
+	if attempts > 1 && !ls.atTipRecoveryHolding {
 		stabilityWindow := ls.calculateStabilityWindow()
 		// depth grows linearly so the final attempt reaches the full
 		// stability window: (attempts-1)/(maxAttempts-1) of the window.
@@ -312,6 +371,20 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		}
 		return true, nil
 	}
+	if ls.atTipRecoveryHolding {
+		ls.metrics.atTipRecoveryNonConverging.Inc()
+		ls.config.Logger.Warn(
+			"at-tip recovery not converging across distinct validation failures, holding at ledger tip instead of rewinding primary chain deeper",
+			"component", "ledger",
+			"tx_hash", hex.EncodeToString(validationErr.TxHash),
+			"failing_block_slot", validationErr.BlockPoint.Slot,
+			"ledger_tip_slot", ledgerTip.Point.Slot,
+			"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+			"primary_chain_tip_slot", chainTip.Point.Slot,
+			"descent_count", ls.atTipRecoveryDescentCount,
+			"hint", "local ledger validation likely diverging from the network; operator intervention may be required",
+		)
+	}
 	ls.config.Logger.Warn(
 		"validation failure after reaching tip, rewinding primary chain",
 		"component", "ledger",
@@ -323,6 +396,7 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		"primary_chain_tip_hash", hex.EncodeToString(chainTip.Point.Hash),
 		"rewind_target_slot", rewindPoint.Slot,
 		"attempt", attempts,
+		"holding", ls.atTipRecoveryHolding,
 	)
 	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
 		rewindPoint,

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -702,16 +702,21 @@ func TestTryRecoverFromTxValidationErrorAtTipResetsDescentOnForwardProgress(
 ) {
 	ls, _ := newAtTipDescentLedger(t)
 
-	// Two descending distinct failures build up descent state.
-	for _, slot := range []uint64{500, 480} {
+	// Enough descending distinct failures to enter the hold state.
+	for _, slot := range []uint64{500, 480, 460} {
 		ferr := atTipDescentFailure(slot, fmt.Sprintf("%d", slot))
 		recovered, err := ls.tryRecoverFromTxValidationError(ferr)
 		require.NoError(t, err)
 		require.True(t, recovered)
 	}
-	require.Positive(t, ls.atTipRecoveryDescentCount)
+	require.Equal(
+		t,
+		maxAtTipRecoveryDescents,
+		ls.atTipRecoveryDescentCount,
+	)
+	require.True(t, ls.atTipRecoveryHolding)
 
-	// A distinct failure at a higher slot is forward progress and resets it.
+	// A distinct failure at a higher slot is forward progress and clears it.
 	recovered, err := ls.tryRecoverFromTxValidationError(
 		atTipDescentFailure(600, "ahead"),
 	)

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -38,6 +38,7 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	pdata "github.com/blinklabs-io/plutigo/data"
 	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
@@ -550,6 +551,174 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 		maxAtTipRecoveryAttempts,
 		ls.lastAtTipRecovery.Attempts,
 	)
+}
+
+// newAtTipDescentLedger builds a LedgerState sitting at a fixed tip with
+// at-tip validation enabled, for exercising the non-convergence guard in
+// recoverAtTipFromTxValidationError. The failing blocks fed in these tests are
+// synthetic and never added to the chain — recovery only ever rewinds to the
+// ledger tip, which is all the guard tests assert on.
+func newAtTipDescentLedger(t *testing.T) (*LedgerState, ochainsync.Tip) {
+	t.Helper()
+	db, err := database.New(&database.Config{
+		BlobPlugin:     "badger",
+		MetadataPlugin: "sqlite",
+		DataDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("descent-parent", 100, 1, nil)
+	ledgerTipBlock := testRawBlock(
+		"descent-ledger-tip",
+		120,
+		2,
+		parentBlock.Hash,
+	)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{parentBlock, ledgerTipBlock},
+		),
+	)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	ledgerTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			ledgerTipBlock.Slot,
+			ledgerTipBlock.Hash,
+		),
+		BlockNumber: ledgerTipBlock.BlockNumber,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+	ls.currentTip = ledgerTip
+	ls.currentTipBlockNonce = []byte("nonce-descent-tip")
+	ls.validationEnabled = true
+	ls.reachedTip.Store(true)
+	ls.publishSnapshotsLocked()
+	return ls, ledgerTip
+}
+
+func atTipDescentFailure(slot uint64, tag string) *txValidationError {
+	return &txValidationError{
+		BlockPoint: ocommon.NewPoint(
+			slot,
+			testHashBytes("descent-block-"+tag),
+		),
+		TxHash: testHashBytes("descent-tx-" + tag),
+		Cause: errors.New(
+			"conway utxo validation: withdrawal not delegated to a drep",
+		),
+	}
+}
+
+// TestTryRecoverFromTxValidationErrorAtTipStopsDescendingRewindLoop verifies
+// that a descending series of distinct at-tip validation failures trips the
+// non-convergence guard: recovery holds at the ledger tip and records the
+// condition instead of rewinding the primary chain ever deeper (issue #2939).
+func TestTryRecoverFromTxValidationErrorAtTipStopsDescendingRewindLoop(
+	t *testing.T,
+) {
+	ls, ledgerTip := newAtTipDescentLedger(t)
+
+	// Feed a descending series of DISTINCT failures. Each first appears
+	// (attempt 1: shallow rewind to ledger tip) then repeats (attempt 2:
+	// same block re-delivered), mirroring the field log in #2939.
+	for _, slot := range []uint64{500, 480, 460, 440} {
+		ferr := atTipDescentFailure(slot, fmt.Sprintf("%d", slot))
+		for range 2 {
+			recovered, err := ls.tryRecoverFromTxValidationError(ferr)
+			require.NoError(t, err)
+			require.True(t, recovered)
+		}
+	}
+
+	assert.True(
+		t,
+		ls.atTipRecoveryHolding,
+		"descending distinct failures should trip the non-convergence guard",
+	)
+	assert.GreaterOrEqual(
+		t,
+		promtestutil.ToFloat64(ls.metrics.atTipRecoveryNonConverging),
+		1.0,
+		"holding should be recorded via the non-convergence metric",
+	)
+	// The primary chain must never be rewound below the ledger tip.
+	assert.GreaterOrEqual(
+		t,
+		ls.chain.Tip().Point.Slot,
+		ledgerTip.Point.Slot,
+	)
+}
+
+// TestTryRecoverFromTxValidationErrorAtTipDoesNotHoldOnSameBlockEscalation
+// verifies the guard does not fire for the legitimate same-block escalation
+// (fork escape): repeating the identical (block, tx) failure must keep
+// escalating without ever entering the hold state.
+func TestTryRecoverFromTxValidationErrorAtTipDoesNotHoldOnSameBlockEscalation(
+	t *testing.T,
+) {
+	ls, _ := newAtTipDescentLedger(t)
+
+	ferr := atTipDescentFailure(500, "stable")
+	for i := 0; i <= maxAtTipRecoveryAttempts+2; i++ {
+		recovered, err := ls.tryRecoverFromTxValidationError(ferr)
+		require.NoError(t, err)
+		require.True(t, recovered)
+	}
+
+	assert.False(
+		t,
+		ls.atTipRecoveryHolding,
+		"same-block escalation must not trip the non-convergence guard",
+	)
+	assert.Equal(t, 0, ls.atTipRecoveryDescentCount)
+	assert.Equal(
+		t,
+		0.0,
+		promtestutil.ToFloat64(ls.metrics.atTipRecoveryNonConverging),
+	)
+}
+
+// TestTryRecoverFromTxValidationErrorAtTipResetsDescentOnForwardProgress
+// verifies that a distinct failure at a HIGHER slot (forward progress past the
+// previous failing point) resets the descent tracking, so an unrelated later
+// failure gets a fresh recovery budget rather than being treated as part of a
+// descent.
+func TestTryRecoverFromTxValidationErrorAtTipResetsDescentOnForwardProgress(
+	t *testing.T,
+) {
+	ls, _ := newAtTipDescentLedger(t)
+
+	// Two descending distinct failures build up descent state.
+	for _, slot := range []uint64{500, 480} {
+		ferr := atTipDescentFailure(slot, fmt.Sprintf("%d", slot))
+		recovered, err := ls.tryRecoverFromTxValidationError(ferr)
+		require.NoError(t, err)
+		require.True(t, recovered)
+	}
+	require.Positive(t, ls.atTipRecoveryDescentCount)
+
+	// A distinct failure at a higher slot is forward progress and resets it.
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		atTipDescentFailure(600, "ahead"),
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Equal(t, 0, ls.atTipRecoveryDescentCount)
+	assert.False(t, ls.atTipRecoveryHolding)
 }
 
 func TestTryRecoverFromTxValidationErrorAtTipRejectsRewindBelowMithrilBoundary(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -647,10 +647,20 @@ type LedgerState struct {
 	closed                        atomic.Bool
 	inRecovery                    bool // guards against recursive recovery in SubmitAsyncDBTxn
 	lastAtTipRecovery             *atTipRecoveryAttempt
-	mithrilLedgerSlot             uint64 // blocks at or below this slot are Mithril-verified; skip validation
-	mithrilLedgerHash             []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
-	lastLocalRollbackSeq          uint64
-	lastLocalRollbackPoint        ocommon.Point
+	// At-tip recovery non-convergence tracking (issue #2939). A descending
+	// series of *distinct* (block, tx) validation failures each resets the
+	// same-block escalation to attempt 1, so the escalate-and-cap logic in
+	// lastAtTipRecovery never engages and the primary chain would be rewound
+	// ever deeper, falling unboundedly behind the wall clock. These fields
+	// detect that pattern and switch recovery to a shallow, hold-at-tip mode.
+	// All three are only read/written from the ledger pipeline goroutine.
+	atTipRecoveryLastFailSlot uint64 // failing slot of the previous distinct at-tip failure
+	atTipRecoveryDescentCount int    // consecutive distinct failures that did not advance
+	atTipRecoveryHolding      bool   // sticky: deep rewinds suppressed until forward progress
+	mithrilLedgerSlot         uint64 // blocks at or below this slot are Mithril-verified; skip validation
+	mithrilLedgerHash         []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
+	lastLocalRollbackSeq      uint64
+	lastLocalRollbackPoint    ocommon.Point
 
 	// Subscription IDs for event bus unsubscribe on close
 	chainsyncSubID           event.EventSubscriberId
@@ -3890,6 +3900,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				if len(pendingNonce) > 0 {
 					ls.currentTipBlockNonce = pendingNonce
 				}
+				// Forward progress past a prior at-tip failure clears the
+				// non-convergence hold so a later, unrelated failure gets a
+				// fresh recovery budget (issue #2939).
+				ls.resetAtTipRecoveryDescent(pendingTip.Point.Slot)
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				if wantEnableValidation {
 					ls.validationEnabled = true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents an unbounded primary-chain rewind loop on at-tip transaction validation failures by holding at the ledger tip when distinct failures descend across blocks. Surfaces the state via a new metric and clears it on forward progress. Fixes #2939.

- **Bug Fixes**
  - Added a non-convergence guard in `recoverAtTipFromTxValidationError`: after `maxAtTipRecoveryDescents` distinct failures at non-increasing slots, hold at tip and suppress deep rewinds.
  - While holding, only rewind to the current ledger tip; log with a "holding" flag and increment `dingo_ledger_attip_recovery_nonconverging_total`.
  - Clear the hold and descent counters on forward progress via `resetAtTipRecoveryDescent` from the block-apply success path.
  - Updated architecture docs and expanded tests to cover descending failures, no hold on same-block escalation, reset on progress, metric emission, and ensuring the primary chain never rewinds below the ledger tip.

<sup>Written for commit a1900a866967c2425c786b5720bdf97b2a9fdb94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved recovery from transaction-validation failures at the chain tip.
  * Prevented repeated, descending recovery attempts from rewinding beyond the current ledger tip.
  * Recovery now resumes normal behavior after forward ledger progress.

* **Monitoring**
  * Added a metric and operator warning when recovery enters hold-at-tip mode.

* **Documentation**
  * Documented the updated recovery behavior, escalation rules, and monitoring signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->