### PR TITLE
build(deps): gouroboros 0.189.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.27.4
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.189.1
+	github.com/blinklabs-io/gouroboros v0.189.2
 	github.com/blinklabs-io/ouroboros-mock v0.15.0
 	github.com/blinklabs-io/plutigo v0.1.17
 	github.com/blockfrost/blockfrost-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.189.1 h1:JIPi37b45LQL3e0Kvit5s/OSWjcB/V7WEI9bZ/T27Tc=
-github.com/blinklabs-io/gouroboros v0.189.1/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
+github.com/blinklabs-io/gouroboros v0.189.2 h1:3TSIlW2KxnNNGvRHGZDPC6+8dDz0K+/0vtWt12+PHRQ=
+github.com/blinklabs-io/gouroboros v0.189.2/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
 github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=


### PR DESCRIPTION
Closes #2939 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `github.com/blinklabs-io/gouroboros` from v0.189.1 to v0.189.2 to pull in upstream fixes. This targets the DRep withdrawal false-negative tracked in #2939.

<sup>Written for commit b2176448d78e3a0b12b2533c1396513d502bc792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying component to its latest maintenance release, improving compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->