### PR TITLE
fix(database): consume update statement cache

### DIFF
--- a/database/plugin/metadata/internal/utxocond/utxocond.go
+++ b/database/plugin/metadata/internal/utxocond/utxocond.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utxocond builds fixed-shape "(tx_id = ? AND output_idx = ?)" OR-list
+// conditions for the UTxO block-apply UPDATEs (consume, collateral, reference
+// inputs) shared by the sqlite, postgres, and mysql metadata plugins.
+//
+// The block-apply path builds one such UPDATE per transaction, matching that
+// transaction's consumed/collateral/reference inputs. Building the WHERE clause
+// as a variable-length list of OR-ed placeholder pairs made the SQL text vary
+// with the input count, so GORM's prepared-statement cache (keyed on SQL text)
+// could not reuse statements and thrashed on parse/prepare under dense sync
+// (issue #2943).
+//
+// Chunks pads each chunk's term count up to the next power of two by repeating
+// the chunk's last ref. Because these UPDATEs match rows by an OR of composite
+// keys, repeating a ref is idempotent: it does not change which rows match or
+// how many rows are affected. Padding to powers of two bounds the number of
+// distinct SQL shapes to about log2(maxTerms)+1 regardless of input count, so
+// the prepared-statement cache can reuse them.
+package utxocond
+
+import "strings"
+
+// Ref is a (tx_id, output_idx) UTxO reference.
+type Ref struct {
+	TxID []byte
+	Idx  uint32
+}
+
+// Chunk is one fixed-shape OR-list condition and its bound arguments.
+type Chunk struct {
+	// Condition is the parenthesized OR-list, e.g.
+	// "(tx_id = ? AND output_idx = ?) OR (tx_id = ? AND output_idx = ?)".
+	// Its placeholder count is padded to a power of two, so only a handful
+	// of distinct Condition strings are ever produced.
+	Condition string
+	// Args holds TxID, Idx pairs for every term including padding, in order:
+	// len(Args) == 2 * (padded term count).
+	Args []any
+	// Real is the number of leading terms that correspond to distinct input
+	// refs (the remainder are idempotent padding). Callers that verify an
+	// affected-row count should sum Real across chunks.
+	Real int
+}
+
+// DefaultMaxTerms bounds the OR-terms per statement. Each term binds two
+// parameters, so 256 terms is 512 parameters, comfortably under driver
+// parameter limits (SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999, newer
+// builds 32766; postgres/mysql are far higher). It is a power of two so a full
+// chunk reuses the single largest SQL shape.
+const DefaultMaxTerms = 256
+
+const term = "(tx_id = ? AND output_idx = ?)"
+
+// Chunks splits refs into chunks of at most maxTerms terms and pads each chunk's
+// term count up to the next power of two (repeating the chunk's last ref). It
+// returns nil for an empty input. maxTerms values below 1 fall back to
+// DefaultMaxTerms; a maxTerms that is not a power of two is used as-is for the
+// split boundary, but padded chunk lengths are still powers of two capped at
+// maxTerms.
+func Chunks(refs []Ref, maxTerms int) []Chunk {
+	if len(refs) == 0 {
+		return nil
+	}
+	if maxTerms < 1 {
+		maxTerms = DefaultMaxTerms
+	}
+	var chunks []Chunk
+	for start := 0; start < len(refs); start += maxTerms {
+		end := min(start+maxTerms, len(refs))
+		group := refs[start:end]
+		padded := nextPow2Capped(len(group), maxTerms)
+		args := make([]any, 0, padded*2)
+		for _, r := range group {
+			args = append(args, r.TxID, r.Idx)
+		}
+		last := group[len(group)-1]
+		for i := len(group); i < padded; i++ {
+			args = append(args, last.TxID, last.Idx)
+		}
+		chunks = append(chunks, Chunk{
+			Condition: condition(padded),
+			Args:      args,
+			Real:      len(group),
+		})
+	}
+	return chunks
+}
+
+// condition returns n OR-ed terms.
+func condition(n int) string {
+	if n <= 1 {
+		return term
+	}
+	var b strings.Builder
+	b.Grow(len(term)*n + 4*(n-1))
+	for i := range n {
+		if i > 0 {
+			b.WriteString(" OR ")
+		}
+		b.WriteString(term)
+	}
+	return b.String()
+}
+
+// nextPow2Capped returns the smallest power of two >= n, capped at limit. n is
+// assumed to be in [1, limit].
+func nextPow2Capped(n, limit int) int {
+	p := 1
+	for p < n {
+		p <<= 1
+	}
+	if p > limit {
+		return limit
+	}
+	return p
+}

--- a/database/plugin/metadata/internal/utxocond/utxocond_test.go
+++ b/database/plugin/metadata/internal/utxocond/utxocond_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxocond
+
+import (
+	"strings"
+	"testing"
+)
+
+func mkRefs(n int) []Ref {
+	refs := make([]Ref, n)
+	for i := range refs {
+		refs[i] = Ref{TxID: []byte{byte(i), byte(i >> 8)}, Idx: uint32(i)}
+	}
+	return refs
+}
+
+// TestChunksBoundsDistinctShapes is the core property for issue #2943: across
+// every input count in a wide range, only a small, bounded set of distinct SQL
+// shapes (Condition strings) is produced, so the prepared-statement cache can
+// reuse them. Without padding this set would grow with the input count.
+func TestChunksBoundsDistinctShapes(t *testing.T) {
+	shapes := make(map[string]struct{})
+	for n := 1; n <= 1000; n++ {
+		for _, c := range Chunks(mkRefs(n), DefaultMaxTerms) {
+			shapes[c.Condition] = struct{}{}
+		}
+	}
+	// Padded lengths are powers of two in [1, 256]: 1,2,4,8,16,32,64,128,256.
+	if len(shapes) > 9 {
+		t.Fatalf("expected at most 9 distinct shapes, got %d", len(shapes))
+	}
+	// Every shape's term count must be a power of two.
+	for s := range shapes {
+		terms := strings.Count(s, "output_idx")
+		if terms&(terms-1) != 0 {
+			t.Fatalf("shape has non-power-of-two term count %d: %q", terms, s)
+		}
+	}
+}
+
+// TestChunksPreservesRealRefsInOrder verifies that padding never drops or
+// reorders real refs: the first Real*2 args of each chunk are exactly the input
+// refs, and padding repeats the chunk's last ref.
+func TestChunksPreservesRealRefsInOrder(t *testing.T) {
+	refs := mkRefs(5) // pads to 8
+	chunks := Chunks(refs, DefaultMaxTerms)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	c := chunks[0]
+	if c.Real != 5 {
+		t.Fatalf("expected Real=5, got %d", c.Real)
+	}
+	wantTerms := 8 // next power of two >= 5
+	if got := strings.Count(c.Condition, "output_idx"); got != wantTerms {
+		t.Fatalf("expected %d terms, got %d", wantTerms, got)
+	}
+	if len(c.Args) != wantTerms*2 {
+		t.Fatalf("expected %d args, got %d", wantTerms*2, len(c.Args))
+	}
+	// First 5 arg-pairs are the real refs in order.
+	for i := range refs {
+		idx, ok := c.Args[i*2+1].(uint32)
+		if !ok || idx != refs[i].Idx {
+			t.Fatalf("arg %d: expected idx %d, got %v", i, refs[i].Idx, c.Args[i*2+1])
+		}
+	}
+	// Padding (indices 5..7) repeats the last real ref (idx 4).
+	for i := 5; i < wantTerms; i++ {
+		if idx, ok := c.Args[i*2+1].(uint32); !ok || idx != refs[4].Idx {
+			t.Fatalf("padding arg %d: expected repeated idx %d, got %v", i, refs[4].Idx, c.Args[i*2+1])
+		}
+	}
+}
+
+// TestChunksSplitsOverMaxTerms verifies large inputs are chunked at maxTerms and
+// each chunk is independently padded to a power of two.
+func TestChunksSplitsOverMaxTerms(t *testing.T) {
+	chunks := Chunks(mkRefs(300), 256)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks for 300 refs at max 256, got %d", len(chunks))
+	}
+	if chunks[0].Real != 256 || strings.Count(chunks[0].Condition, "output_idx") != 256 {
+		t.Fatalf("chunk 0: expected 256 real/terms, got Real=%d terms=%d",
+			chunks[0].Real, strings.Count(chunks[0].Condition, "output_idx"))
+	}
+	// Second chunk: 44 real refs, padded to 64.
+	if chunks[1].Real != 44 || strings.Count(chunks[1].Condition, "output_idx") != 64 {
+		t.Fatalf("chunk 1: expected Real=44 terms=64, got Real=%d terms=%d",
+			chunks[1].Real, strings.Count(chunks[1].Condition, "output_idx"))
+	}
+	// Sum of Real across chunks equals input count.
+	total := 0
+	for _, c := range chunks {
+		total += c.Real
+	}
+	if total != 300 {
+		t.Fatalf("expected sum(Real)=300, got %d", total)
+	}
+}
+
+func TestChunksEmpty(t *testing.T) {
+	if Chunks(nil, DefaultMaxTerms) != nil {
+		t.Fatal("expected nil for empty input")
+	}
+	if Chunks([]Ref{}, DefaultMaxTerms) != nil {
+		t.Fatal("expected nil for empty slice")
+	}
+}
+
+func TestChunksSingle(t *testing.T) {
+	chunks := Chunks(mkRefs(1), DefaultMaxTerms)
+	if len(chunks) != 1 || chunks[0].Condition != term {
+		t.Fatalf("expected single-term condition %q, got %+v", term, chunks)
+	}
+	if len(chunks[0].Args) != 2 || chunks[0].Real != 1 {
+		t.Fatalf("expected 2 args and Real=1, got args=%d Real=%d",
+			len(chunks[0].Args), chunks[0].Real)
+	}
+}

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/collateralfee"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/utxocond"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1334,10 +1335,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 	}
 	// Add Collateral to Transaction
 	if len(tx.Collateral()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 
 		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
 		for _, input := range tx.Collateral() {
@@ -1365,33 +1363,29 @@ func (d *MetadataStoreMysql) SetTransaction(
 				)
 				continue
 			}
-			// Found the Utxo, add it to the SQL UPDATE list
-			// First, add it to the CASE statement so it's selected
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			// Also add it to the WHERE clause in the SQL UPDATE
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			// Add it to the Transaction
 			tmpTx.Collateral = append(
 				tmpTx.Collateral,
 				*utxo,
 			)
 		}
-		// Update reference where this Utxo was used as collateral in a Transaction
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Every matched row is set to the same txHash, so the CASE the
+		// old code built was redundant. A fixed-shape, power-of-two-padded
+		// OR-list keeps the statement text stable across input counts so
+		// the prepared-statement cache can reuse it (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET collateral_by_tx_id = ? WHERE " + chunk.Condition
 			result = db.Exec(sql, args...)
 			if result.Error != nil {
 				return fmt.Errorf("batch update collateral: %w", result.Error)
@@ -1400,10 +1394,7 @@ func (d *MetadataStoreMysql) SetTransaction(
 	}
 	// Add ReferenceInputs to Transaction
 	if len(tx.ReferenceInputs()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 
 		refInputRefs := make([]UtxoRef, 0, len(tx.ReferenceInputs()))
 		for _, input := range tx.ReferenceInputs() {
@@ -1434,33 +1425,27 @@ func (d *MetadataStoreMysql) SetTransaction(
 				)
 				continue
 			}
-			// Found the Utxo, add it to the SQL UPDATE list
-			// First, add it to the CASE statement so it's selected
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			// Also add it to the WHERE clause in the SQL UPDATE
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			// Add it to the Transaction
 			tmpTx.ReferenceInputs = append(
 				tmpTx.ReferenceInputs,
 				*utxo,
 			)
 		}
-		// Update reference where this Utxo was used as a reference input in a Transaction
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// See the collateral update above: the per-row CASE was redundant
+		// (all rows set to txHash); use a fixed-shape padded OR-list (#2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET referenced_by_tx_id = ? WHERE " + chunk.Condition
 			result = db.Exec(sql, args...)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -1501,26 +1486,32 @@ func (d *MetadataStoreMysql) SetTransaction(
 			})
 		}
 		if len(consumedRefs) > 0 {
-			whereConditions := make([]string, 0, len(consumedRefs))
-			updateArgs := make([]any, 0, 2+(len(consumedRefs)*2))
-			updateArgs = append(updateArgs, point.Slot, txHash)
-			for _, ref := range consumedRefs {
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				updateArgs = append(updateArgs, ref.txID, ref.idx)
+			// Fixed-shape, power-of-two-padded OR-list so the
+			// prepared-statement cache can reuse statements across
+			// varying input counts (issue #2943).
+			refs := make([]utxocond.Ref, len(consumedRefs))
+			for i, ref := range consumedRefs {
+				refs[i] = utxocond.Ref{TxID: ref.txID, Idx: ref.idx}
 			}
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
-					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
-				strings.Join(whereConditions, " OR "),
-			)
-			result = db.Exec(sql, updateArgs...)
-			if result.Error != nil {
-				return fmt.Errorf("batch consume utxos: %w", result.Error)
+			var totalAffected int64
+			for _, chunk := range utxocond.Chunks(
+				refs,
+				utxocond.DefaultMaxTerms,
+			) {
+				updateArgs := make([]any, 0, 2+len(chunk.Args))
+				updateArgs = append(updateArgs, point.Slot, txHash)
+				updateArgs = append(updateArgs, chunk.Args...)
+				sql := "UPDATE utxo" +
+					" SET deleted_slot = ?, spent_at_tx_id = ? " +
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (" +
+					chunk.Condition + ")"
+				result = db.Exec(sql, updateArgs...)
+				if result.Error != nil {
+					return fmt.Errorf("batch consume utxos: %w", result.Error)
+				}
+				totalAffected += result.RowsAffected
 			}
-			if result.RowsAffected != int64(len(consumedRefs)) {
+			if totalAffected != int64(len(consumedRefs)) {
 				for _, ref := range consumedRefs {
 					var existingUtxo models.Utxo
 					checkResult := db.Where(
@@ -3064,10 +3055,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	//    These update UTxOs that already exist from prior blocks.        //
 	// ------------------------------------------------------------------ //
 	if len(tx.Collateral()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
@@ -3081,25 +3069,22 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 			if utxo == nil {
 				continue
 			}
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
 		}
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Redundant CASE removed; fixed-shape padded OR-list (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET collateral_by_tx_id = ? WHERE " + chunk.Condition
 			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
 					"batch update collateral (batched): %w",
@@ -3110,10 +3095,7 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 	}
 
 	if len(tx.ReferenceInputs()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 		for _, input := range tx.ReferenceInputs() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
@@ -3127,28 +3109,25 @@ func (d *MetadataStoreMysql) SetTransactionBatched(
 			if utxo == nil {
 				continue
 			}
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			tmpTx.ReferenceInputs = append(
 				tmpTx.ReferenceInputs,
 				*utxo,
 			)
 		}
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Redundant CASE removed; fixed-shape padded OR-list (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET referenced_by_tx_id = ? WHERE " + chunk.Condition
 			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
 					"batch update reference inputs (batched): %w",

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/collateralfee"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/utxocond"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1335,10 +1336,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 	}
 	// Add Collateral to Transaction
 	if len(tx.Collateral()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 
 		collateralRefs := make([]UtxoRef, 0, len(tx.Collateral()))
 		for _, input := range tx.Collateral() {
@@ -1366,33 +1364,29 @@ func (d *MetadataStorePostgres) SetTransaction(
 				)
 				continue
 			}
-			// Found the Utxo, add it to the SQL UPDATE list
-			// First, add it to the CASE statement so it's selected
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			// Also add it to the WHERE clause in the SQL UPDATE
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			// Add it to the Transaction
 			tmpTx.Collateral = append(
 				tmpTx.Collateral,
 				*utxo,
 			)
 		}
-		// Update reference where this Utxo was used as collateral in a Transaction
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Every matched row is set to the same txHash, so the CASE the
+		// old code built was redundant. A fixed-shape, power-of-two-padded
+		// OR-list keeps the statement text stable across input counts so
+		// the prepared-statement cache can reuse it (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET collateral_by_tx_id = ? WHERE " + chunk.Condition
 			result = db.Exec(sql, args...)
 			if result.Error != nil {
 				return fmt.Errorf("batch update collateral: %w", result.Error)
@@ -1401,10 +1395,7 @@ func (d *MetadataStorePostgres) SetTransaction(
 	}
 	// Add ReferenceInputs to Transaction
 	if len(tx.ReferenceInputs()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 
 		refInputRefs := make([]UtxoRef, 0, len(tx.ReferenceInputs()))
 		for _, input := range tx.ReferenceInputs() {
@@ -1435,33 +1426,27 @@ func (d *MetadataStorePostgres) SetTransaction(
 				)
 				continue
 			}
-			// Found the Utxo, add it to the SQL UPDATE list
-			// First, add it to the CASE statement so it's selected
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			// Also add it to the WHERE clause in the SQL UPDATE
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			// Add it to the Transaction
 			tmpTx.ReferenceInputs = append(
 				tmpTx.ReferenceInputs,
 				*utxo,
 			)
 		}
-		// Update reference where this Utxo was used as a reference input in a Transaction
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// See the collateral update above: the per-row CASE was redundant
+		// (all rows set to txHash); use a fixed-shape padded OR-list (#2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET referenced_by_tx_id = ? WHERE " + chunk.Condition
 			result = db.Exec(sql, args...)
 			if result.Error != nil {
 				return fmt.Errorf(
@@ -1502,26 +1487,32 @@ func (d *MetadataStorePostgres) SetTransaction(
 			})
 		}
 		if len(consumedRefs) > 0 {
-			whereConditions := make([]string, 0, len(consumedRefs))
-			updateArgs := make([]any, 0, 2+(len(consumedRefs)*2))
-			updateArgs = append(updateArgs, point.Slot, txHash)
-			for _, ref := range consumedRefs {
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				updateArgs = append(updateArgs, ref.txID, ref.idx)
+			// Fixed-shape, power-of-two-padded OR-list so the
+			// prepared-statement cache can reuse statements across
+			// varying input counts (issue #2943).
+			refs := make([]utxocond.Ref, len(consumedRefs))
+			for i, ref := range consumedRefs {
+				refs[i] = utxocond.Ref{TxID: ref.txID, Idx: ref.idx}
 			}
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET deleted_slot = ?, spent_at_tx_id = ? "+
-					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
-				strings.Join(whereConditions, " OR "),
-			)
-			result = db.Exec(sql, updateArgs...)
-			if result.Error != nil {
-				return fmt.Errorf("batch consume utxos: %w", result.Error)
+			var totalAffected int64
+			for _, chunk := range utxocond.Chunks(
+				refs,
+				utxocond.DefaultMaxTerms,
+			) {
+				updateArgs := make([]any, 0, 2+len(chunk.Args))
+				updateArgs = append(updateArgs, point.Slot, txHash)
+				updateArgs = append(updateArgs, chunk.Args...)
+				sql := "UPDATE utxo" +
+					" SET deleted_slot = ?, spent_at_tx_id = ? " +
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (" +
+					chunk.Condition + ")"
+				result = db.Exec(sql, updateArgs...)
+				if result.Error != nil {
+					return fmt.Errorf("batch consume utxos: %w", result.Error)
+				}
+				totalAffected += result.RowsAffected
 			}
-			if result.RowsAffected != int64(len(consumedRefs)) {
+			if totalAffected != int64(len(consumedRefs)) {
 				for _, ref := range consumedRefs {
 					var existingUtxo models.Utxo
 					checkResult := db.Where(
@@ -3074,10 +3065,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	//    These update UTxOs that already exist from prior blocks.        //
 	// ------------------------------------------------------------------ //
 	if len(tx.Collateral()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
@@ -3091,25 +3079,22 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 			if utxo == nil {
 				continue
 			}
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
 		}
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET collateral_by_tx_id = CASE %s ELSE collateral_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Redundant CASE removed; fixed-shape padded OR-list (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET collateral_by_tx_id = ? WHERE " + chunk.Condition
 			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
 					"batch update collateral (batched): %w",
@@ -3120,10 +3105,7 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 	}
 
 	if len(tx.ReferenceInputs()) > 0 {
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 		for _, input := range tx.ReferenceInputs() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
@@ -3137,28 +3119,25 @@ func (d *MetadataStorePostgres) SetTransactionBatched(
 			if utxo == nil {
 				continue
 			}
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 			tmpTx.ReferenceInputs = append(
 				tmpTx.ReferenceInputs,
 				*utxo,
 			)
 		}
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE utxo SET referenced_by_tx_id = CASE %s ELSE referenced_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Redundant CASE removed; fixed-shape padded OR-list (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE utxo" +
+				" SET referenced_by_tx_id = ? WHERE " + chunk.Condition
 			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
 					"batch update reference inputs (batched): %w",

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/accountwitness"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/certutil"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/collateralfee"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/utxocond"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1436,10 +1437,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			if err != nil {
 				return fmt.Errorf("failed to batch fetch collateral UTXOs: %w", err)
 			}
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
+			var updateRefs []utxocond.Ref
 			for _, input := range tx.Collateral() {
 				inTxId := input.Id().Bytes()
 				inIdx := input.Index()
@@ -1457,27 +1455,25 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					)
 					continue
 				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				updateRefs = append(
+					updateRefs,
+					utxocond.Ref{TxID: inTxId, Idx: inIdx},
 				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
 				tmpTx.Collateral = append(tmpTx.Collateral, *utxo)
 			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE "+utxoRefIndexedTable()+
-						" SET collateral_by_tx_id = CASE %s "+
-						"ELSE collateral_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
-				)
+			// Every matched row is set to the same txHash, so the CASE the
+			// old code built was redundant. A fixed-shape, power-of-two-padded
+			// OR-list keeps the statement text stable across input counts so
+			// the prepared-statement cache can reuse it (issue #2943).
+			for _, chunk := range utxocond.Chunks(
+				updateRefs,
+				utxocond.DefaultMaxTerms,
+			) {
+				args := make([]any, 0, 1+len(chunk.Args))
+				args = append(args, txHash)
+				args = append(args, chunk.Args...)
+				sql := "UPDATE " + utxoRefIndexedTable() +
+					" SET collateral_by_tx_id = ? WHERE " + chunk.Condition
 				result = db.Exec(sql, args...)
 				if result.Error != nil {
 					return fmt.Errorf("batch update collateral: %w", result.Error)
@@ -1499,10 +1495,7 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					err,
 				)
 			}
-			var caseClauses []string
-			var whereConditions []string
-			var caseArgs []any
-			var whereArgs []any
+			var updateRefs []utxocond.Ref
 			for _, input := range tx.ReferenceInputs() {
 				inTxId := input.Id().Bytes()
 				inIdx := input.Index()
@@ -1520,27 +1513,23 @@ func (d *MetadataStoreSqlite) SetTransaction(
 					)
 					continue
 				}
-				caseClauses = append(
-					caseClauses,
-					"WHEN tx_id = ? AND output_idx = ? THEN ?",
+				updateRefs = append(
+					updateRefs,
+					utxocond.Ref{TxID: inTxId, Idx: inIdx},
 				)
-				caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				whereArgs = append(whereArgs, inTxId, inIdx)
 				tmpTx.ReferenceInputs = append(tmpTx.ReferenceInputs, *utxo)
 			}
-			if len(caseClauses) > 0 {
-				args := append(caseArgs, whereArgs...)
-				sql := fmt.Sprintf(
-					"UPDATE "+utxoRefIndexedTable()+
-						" SET referenced_by_tx_id = CASE %s "+
-						"ELSE referenced_by_tx_id END WHERE %s",
-					strings.Join(caseClauses, " "),
-					strings.Join(whereConditions, " OR "),
-				)
+			// See the collateral update above: the per-row CASE was redundant
+			// (all rows set to txHash); use a fixed-shape padded OR-list (#2943).
+			for _, chunk := range utxocond.Chunks(
+				updateRefs,
+				utxocond.DefaultMaxTerms,
+			) {
+				args := make([]any, 0, 1+len(chunk.Args))
+				args = append(args, txHash)
+				args = append(args, chunk.Args...)
+				sql := "UPDATE " + utxoRefIndexedTable() +
+					" SET referenced_by_tx_id = ? WHERE " + chunk.Condition
 				result = db.Exec(sql, args...)
 				if result.Error != nil {
 					return fmt.Errorf("batch update reference inputs: %w", result.Error)
@@ -1579,27 +1568,32 @@ func (d *MetadataStoreSqlite) SetTransaction(
 			})
 		}
 		if len(consumedRefs) > 0 {
-			whereConditions := make([]string, 0, len(consumedRefs))
-			updateArgs := make([]any, 0, 2+(len(consumedRefs)*2))
-			updateArgs = append(updateArgs, point.Slot, txHash)
-			for _, ref := range consumedRefs {
-				whereConditions = append(
-					whereConditions,
-					"(tx_id = ? AND output_idx = ?)",
-				)
-				updateArgs = append(updateArgs, ref.txID, ref.idx)
+			// Fixed-shape, power-of-two-padded OR-list so the
+			// prepared-statement cache can reuse statements across
+			// varying input counts (issue #2943).
+			refs := make([]utxocond.Ref, len(consumedRefs))
+			for i, ref := range consumedRefs {
+				refs[i] = utxocond.Ref{TxID: ref.txID, Idx: ref.idx}
 			}
-			sql := fmt.Sprintf(
-				"UPDATE "+utxoRefIndexedTable()+
-					" SET deleted_slot = ?, spent_at_tx_id = ? "+
-					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (%s)",
-				strings.Join(whereConditions, " OR "),
-			)
-			result = db.Exec(sql, updateArgs...)
-			if result.Error != nil {
-				return fmt.Errorf("batch consume utxos: %w", result.Error)
+			var totalAffected int64
+			for _, chunk := range utxocond.Chunks(
+				refs,
+				utxocond.DefaultMaxTerms,
+			) {
+				updateArgs := make([]any, 0, 2+len(chunk.Args))
+				updateArgs = append(updateArgs, point.Slot, txHash)
+				updateArgs = append(updateArgs, chunk.Args...)
+				sql := "UPDATE " + utxoRefIndexedTable() +
+					" SET deleted_slot = ?, spent_at_tx_id = ? " +
+					"WHERE deleted_slot = 0 AND spent_at_tx_id IS NULL AND (" +
+					chunk.Condition + ")"
+				result = db.Exec(sql, updateArgs...)
+				if result.Error != nil {
+					return fmt.Errorf("batch consume utxos: %w", result.Error)
+				}
+				totalAffected += result.RowsAffected
 			}
-			if result.RowsAffected != int64(len(consumedRefs)) {
+			if totalAffected != int64(len(consumedRefs)) {
 				for _, ref := range consumedRefs {
 					var existingUtxo models.Utxo
 					checkResult := db.Where(
@@ -3174,10 +3168,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				err,
 			)
 		}
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 		for _, input := range tx.Collateral() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
@@ -3185,26 +3176,21 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			if _, ok := collateralAddressKeys[key]; !ok {
 				continue
 			}
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 		}
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE "+utxoRefIndexedTable()+
-					" SET collateral_by_tx_id = CASE %s "+
-					"ELSE collateral_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Redundant CASE removed; fixed-shape padded OR-list (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE " + utxoRefIndexedTable() +
+				" SET collateral_by_tx_id = ? WHERE " + chunk.Condition
 			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
 					"batch update collateral (batched): %w",
@@ -3238,10 +3224,7 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 				err,
 			)
 		}
-		var caseClauses []string
-		var whereConditions []string
-		var caseArgs []any
-		var whereArgs []any
+		var updateRefs []utxocond.Ref
 		for _, input := range tx.ReferenceInputs() {
 			inTxId := input.Id().Bytes()
 			inIdx := input.Index()
@@ -3249,26 +3232,21 @@ func (d *MetadataStoreSqlite) SetTransactionBatched(
 			if _, ok := refInputAddressKeys[key]; !ok {
 				continue
 			}
-			caseClauses = append(
-				caseClauses,
-				"WHEN tx_id = ? AND output_idx = ? THEN ?",
+			updateRefs = append(
+				updateRefs,
+				utxocond.Ref{TxID: inTxId, Idx: inIdx},
 			)
-			caseArgs = append(caseArgs, inTxId, inIdx, txHash)
-			whereConditions = append(
-				whereConditions,
-				"(tx_id = ? AND output_idx = ?)",
-			)
-			whereArgs = append(whereArgs, inTxId, inIdx)
 		}
-		if len(caseClauses) > 0 {
-			args := append(caseArgs, whereArgs...)
-			sql := fmt.Sprintf(
-				"UPDATE "+utxoRefIndexedTable()+
-					" SET referenced_by_tx_id = CASE %s "+
-					"ELSE referenced_by_tx_id END WHERE %s",
-				strings.Join(caseClauses, " "),
-				strings.Join(whereConditions, " OR "),
-			)
+		// Redundant CASE removed; fixed-shape padded OR-list (issue #2943).
+		for _, chunk := range utxocond.Chunks(
+			updateRefs,
+			utxocond.DefaultMaxTerms,
+		) {
+			args := make([]any, 0, 1+len(chunk.Args))
+			args = append(args, txHash)
+			args = append(args, chunk.Args...)
+			sql := "UPDATE " + utxoRefIndexedTable() +
+				" SET referenced_by_tx_id = ? WHERE " + chunk.Condition
 			if r := db.Exec(sql, args...); r.Error != nil {
 				return fmt.Errorf(
 					"batch update reference inputs (batched): %w",


### PR DESCRIPTION
Closes #2943 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prepared-statement cache thrashing in UTxO UPDATE paths by using fixed-shape, power-of-two–padded OR conditions with chunked execution across SQLite, Postgres, and MySQL. This reduces parse/prepare churn and speeds up dense sync (addresses #2943).

- **Bug Fixes**
  - Collateral, reference input, and consume UPDATEs now use fixed-shape OR-lists padded to powers of two, enabling statement reuse across input counts.
  - Removed redundant per-row CASE assignments; all matched rows set to a single tx hash.
  - Chunk large inputs with `DefaultMaxTerms` = 256 and sum affected rows across chunks to keep row-count checks correct.

- **Refactors**
  - Added `database/plugin/metadata/internal/utxocond` to build padded OR-list conditions and args.
  - Included unit tests to bound distinct SQL shapes and verify ordering/padding.
  - Integrated `utxocond` across `sqlite`, `postgres`, and `mysql` transaction handlers.

<sup>Written for commit 9b5cb07a36345614b33a87efa709300ea258bc11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability when processing transactions with many UTxO references.
  * Enhanced database updates for collateral, reference inputs, and spent UTxOs.
  * Preserved accurate tracking of affected UTxOs across batched operations.

* **Tests**
  * Added coverage for empty, single-reference, padded, and multi-batch scenarios.
  * Verified reference ordering and consistent query handling across varying input sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->