### PR TITLE
fix(ledger): import previous governance action ids

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2003,6 +2003,14 @@ Ledger-state import decodes treasury and reserves from the certified
 tip. It does not derive a genesis baseline, because the imported account state
 already includes every pot transition through that tip.
 
+For Conway governance, ledger-state import persists active proposals, the
+per-purpose previous governance action IDs, and the ratified action IDs from
+`ConwayGovState.cgsDRepPulsingState`'s completed `RatifyState.rsEnacted` list.
+Imported proposals whose `(tx_hash, action_index)` appears in that list are
+stored with `ratified_epoch`/`ratified_slot` at the snapshot epoch anchor, so the
+next epoch boundary enacts the same already-ratified actions as the certified
+ledger state instead of re-ratifying them one epoch late.
+
 Ledger-state import also persists `NewEpochState.pool-distr` as
 `pool_stake_snapshot` rows with snapshot type `"actv"` for the imported epoch.
 Those rows store the consensus stake fraction as `total_stake /

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1550,11 +1550,12 @@ type ParsedPrevGovActionIds struct {
 
 // ParsedGovState holds all decoded governance state components.
 type ParsedGovState struct {
-	Constitution     *ParsedConstitution
-	Committee        []ParsedCommitteeMember
-	CommitteeQuorum  *cbor.Rat
-	Proposals        []ParsedGovProposal
-	PrevGovActionIds *ParsedPrevGovActionIds
+	Constitution         *ParsedConstitution
+	Committee            []ParsedCommitteeMember
+	CommitteeQuorum      *cbor.Rat
+	Proposals            []ParsedGovProposal
+	PrevGovActionIds     *ParsedPrevGovActionIds
+	RatifiedGovActionIds []ParsedGovActionId
 }
 
 // ParseGovState decodes governance state from raw CBOR.
@@ -1630,6 +1631,18 @@ func ParseGovState(
 	}
 	result.Proposals = proposals
 	result.PrevGovActionIds = prevIds
+
+	if len(fields) >= 7 {
+		ratifiedIds, err := parseDRepPulsingStateRatifiedIds(
+			fields[6],
+		)
+		if err != nil {
+			warnings = append(warnings, fmt.Errorf(
+				"parsing drep pulsing state: %w", err,
+			))
+		}
+		result.RatifiedGovActionIds = ratifiedIds
+	}
 
 	return result, errors.Join(warnings...)
 }
@@ -1898,6 +1911,82 @@ func parseProposals(data []byte) (
 	}
 
 	return proposals, prevIds, errors.Join(propErrs...)
+}
+
+// parseDRepPulsingStateRatifiedIds decodes
+// ConwayGovState.cgsDRepPulsingState enough to recover the
+// GovActionIds in DRComplete's RatifyState.rsEnacted field.
+//
+// DRepPulsingState is persisted as DRComplete, even when the node was
+// still pulsing in memory:
+//
+//	[pulsingSnapshot, ratifyState]
+//
+// RatifyState then encodes as:
+//
+//	[enactState, enacted, expired, delayed]
+//
+// The enacted field is a sequence of GovActionState values in the same
+// representation used by cgsProposals, so parseGovActionState can
+// recover the exact action IDs without decoding the full enact state.
+func parseDRepPulsingStateRatifiedIds(
+	data []byte,
+) ([]ParsedGovActionId, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	fields, err := decodeRawArray(data)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding DRepPulsingState: %w", err,
+		)
+	}
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	if len(fields) < 2 {
+		return nil, fmt.Errorf(
+			"DRepPulsingState has %d elements, expected 2",
+			len(fields),
+		)
+	}
+
+	ratifyState, err := decodeRawArray(fields[1])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding RatifyState: %w", err,
+		)
+	}
+	if len(ratifyState) < 2 {
+		return nil, fmt.Errorf(
+			"RatifyState has %d elements, expected 4",
+			len(ratifyState),
+		)
+	}
+
+	enacted, err := decodeRawArray(ratifyState[1])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decoding RatifyState enacted proposals: %w", err,
+		)
+	}
+	ratifiedIds := make([]ParsedGovActionId, 0, len(enacted))
+	var errs []error
+	for _, item := range enacted {
+		prop, err := parseGovActionState(item)
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"decoding enacted proposal: %w", err,
+			))
+			continue
+		}
+		ratifiedIds = append(ratifiedIds, ParsedGovActionId{
+			TxHash:      append([]byte(nil), prop.TxHash...),
+			ActionIndex: prop.ActionIndex,
+		})
+	}
+
+	return ratifiedIds, errors.Join(errs...)
 }
 
 // parseProposalsRoots decodes the GovRelation StrictMaybe at the

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -2293,25 +2293,25 @@ func importGovState(
 
 	// Import governance proposals
 	if len(govState.Proposals) > 0 {
-		// Snapshot bootstrap close-the-1-epoch-lag heuristic. Canon
-		// nodes mark a HFI ratified at boundary N-1 -> N and enact at
-		// boundary N -> N+1. The snapshot at epoch N reflects the
-		// ratification (in cgsDRepPulsingState's DRComplete result)
-		// but we don't parse that field, so without intervention our
-		// local node would re-ratify at boundary N -> N+1 and only
-		// enact at N+1 -> N+2 — putting us one epoch behind canon
-		// for the protocol-version bump. As a block producer that is
-		// the difference between forging vN+ blocks alongside canon
-		// and forging vN- blocks that risk rejection on TX-validation
-		// rule mismatches gated by the new version.
-		//
-		// Heuristic: when there is exactly one active HFI whose
-		// parent equals the snapshot's per-purpose HardFork root,
-		// mark it ratified at the snapshot's epoch so ENACT picks
-		// it up at the next boundary tick. Skips silently when the
-		// match is ambiguous (0 or >1 candidates) — the lag returns
-		// in those cases but correctness is preserved.
-		ratifiedHFI := findRatifiedHFICandidate(govState)
+		ratifiedIds := ratifiedGovActionIdSet(
+			govState.RatifiedGovActionIds,
+		)
+		var ratifiedHFI *ParsedGovProposal
+		if govState.RatifiedGovActionIds == nil {
+			// Snapshot bootstrap close-the-1-epoch-lag fallback for
+			// older or partial GovState payloads that don't expose
+			// cgsDRepPulsingState's DRComplete result. Exact
+			// RatifyState.rsEnacted IDs above are preferred.
+			ratifiedHFI = findRatifiedHFICandidate(govState)
+		}
+		if len(ratifiedIds) > 0 {
+			cfg.Logger.Info(
+				"marking ratified governance proposals from snapshot DRep pulsing state",
+				"component", "ledgerstate",
+				"count", len(ratifiedIds),
+				"ratified_epoch", cfg.State.Epoch,
+			)
+		}
 		if ratifiedHFI != nil {
 			cfg.Logger.Info(
 				"marking active HFI as ratified at snapshot epoch (close 1-epoch lag)",
@@ -2340,9 +2340,16 @@ func importGovState(
 				)
 				var ratifiedEpoch *uint64
 				var ratifiedSlot *uint64
-				if ratifiedHFI != nil &&
+				_, ratified := ratifiedIds[govActionIdKey(
+					prop.TxHash,
+					prop.ActionIndex,
+				)]
+				if !ratified && ratifiedHFI != nil &&
 					bytes.Equal(prop.TxHash, ratifiedHFI.TxHash) &&
 					prop.ActionIndex == ratifiedHFI.ActionIndex {
+					ratified = true
+				}
+				if ratified {
 					re := cfg.State.Epoch
 					rs := currentEpochSlot
 					ratifiedEpoch = &re
@@ -2429,6 +2436,23 @@ func importGovState(
 	})
 
 	return nil
+}
+
+func ratifiedGovActionIdSet(
+	ids []ParsedGovActionId,
+) map[string]struct{} {
+	if ids == nil {
+		return nil
+	}
+	result := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		result[govActionIdKey(id.TxHash, id.ActionIndex)] = struct{}{}
+	}
+	return result
+}
+
+func govActionIdKey(txHash []byte, actionIdx uint32) string {
+	return fmt.Sprintf("%s#%d", hex.EncodeToString(txHash), actionIdx)
 }
 
 // seedPrevGovActionIds writes synthetic enacted GovernanceProposal

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -41,10 +41,22 @@ func govStateWithRoots(
 	roots [4]*ParsedGovActionId,
 	committeePresent bool,
 ) []byte {
+	return govStateWithRootsAndProposals(
+		t, roots, committeePresent, nil, nil,
+	)
+}
+
+func govStateWithRootsAndProposals(
+	t *testing.T,
+	roots [4]*ParsedGovActionId,
+	committeePresent bool,
+	proposals []any,
+	drepPulsingState any,
+) []byte {
 	t.Helper()
 
 	rootsAny := encodeRootsAsAny(t, roots)
-	proposalsContainer := []any{rootsAny, []any{}}
+	proposalsContainer := []any{rootsAny, proposals}
 
 	var committee any
 	if committeePresent {
@@ -76,9 +88,75 @@ func govStateWithRoots(
 			nil,
 		},
 	}
+	if drepPulsingState != nil {
+		govState = append(
+			govState,
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+			drepPulsingState,
+		)
+	}
 	data, err := cbor.Encode(govState)
 	require.NoError(t, err)
 	return data
+}
+
+func govActionStateForTest(
+	txHash []byte,
+	actionIdx uint64,
+	actionType uint8,
+	parent *ParsedGovActionId,
+	proposedEpoch uint64,
+) []any {
+	var parentAny any = []any{}
+	if parent != nil {
+		parentAny = []any{
+			[]any{parent.TxHash, uint64(parent.ActionIndex)},
+		}
+	}
+	govAction := []any{
+		actionType,
+		parentAny,
+		map[uint64]uint64{},
+		nil,
+	}
+	return []any{
+		[]any{txHash, actionIdx},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		[]any{
+			uint64(100_000_000),
+			bytes.Repeat([]byte{0xa1}, 29),
+			govAction,
+			[]any{
+				"https://example.com/proposal",
+				bytes.Repeat([]byte{0xb2}, 32),
+			},
+		},
+		proposedEpoch,
+		proposedEpoch + 5,
+	}
+}
+
+func drepPulsingStateWithRatified(
+	proposals ...any,
+) any {
+	return []any{
+		[]any{
+			[]any{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+		},
+		[]any{
+			[]any{},
+			proposals,
+			[]any{},
+			false,
+		},
+	}
 }
 
 func TestImportGovStateSeedsPrevGovActionIds(t *testing.T) {
@@ -207,6 +285,65 @@ func TestImportGovStateSeedsPrevGovActionIds(t *testing.T) {
 			assert.Equal(t, c.actionIdx, root.ActionIndex)
 		})
 	}
+}
+
+func TestImportGovStateMarksRatifiedParameterChangeFromDRepPulsingState(
+	t *testing.T,
+) {
+	db, err := database.New(&database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	ppRoot := &ParsedGovActionId{
+		TxHash:      bytes.Repeat([]byte{0x11}, 32),
+		ActionIndex: 0,
+	}
+	txHash := bytes.Repeat([]byte{0x22}, 32)
+	proposal := govActionStateForTest(
+		txHash,
+		0,
+		govActionTypeParameterChange,
+		ppRoot,
+		499,
+	)
+	govStateData := govStateWithRootsAndProposals(
+		t,
+		[4]*ParsedGovActionId{ppRoot, nil, nil, nil},
+		false,
+		[]any{proposal},
+		drepPulsingStateWithRatified(proposal),
+	)
+
+	cfg := ImportConfig{
+		Database: db,
+		Logger: slog.New(
+			slog.NewTextHandler(io.Discard, nil),
+		),
+		State: &RawLedgerState{
+			GovStateData:  govStateData,
+			Epoch:         500,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 100,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
+	}
+
+	require.NoError(t, importGovState(
+		context.Background(),
+		cfg,
+		func(ImportProgress) {},
+	))
+
+	row, err := db.Metadata().GetGovernanceProposal(txHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.NotNil(t, row.RatifiedEpoch)
+	require.Equal(t, uint64(500), *row.RatifiedEpoch)
+	require.NotNil(t, row.RatifiedSlot)
+	require.Equal(t, uint64(50_000), *row.RatifiedSlot)
 }
 
 func TestImportGovStateSeedsCommitteeUpdateWhenCommitteePresent(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Import Conway governance previous action IDs and ratified proposals during `ledger-state` import so local governance matches the certified state and avoids a 1-epoch enactment lag (e.g., HFIs and parameter changes).

- **Bug Fixes**
  - Parse ratified action IDs from `ConwayGovState.cgsDRepPulsingState` (DRComplete `RatifyState.rsEnacted`) and mark matching proposals with `ratified_epoch`/`ratified_slot` at the snapshot anchor.
  - Keep the HFI fallback heuristic for older snapshots that lack ratified IDs.
  - Persist per-purpose `PrevGovActionIds` from the snapshot.
  - Update `ARCHITECTURE.md` and add tests covering ratified import via DRep pulsing state.

<sup>Written for commit a484f13f4c55f8c984f2f3e5efe3441b7b08d021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

