### PR TITLE
fix(ledger): support stake-address-info queries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1260,6 +1260,17 @@ The `LedgerView` interface provides query access to ledger state:
 - Stake distribution queries
 - Account registration checks
 
+### Local State Query
+
+The node-to-client LocalStateQuery server in `ouroboros/localstatequery.go`
+delegates decoded ledger queries to `LedgerState.Query`. Stake-address
+inspection combines several independently encoded queries: filtered pool
+delegations and rewards, the registration deposits locked by the requested
+stake credentials, current DRep vote delegatees, and active governance
+proposals. The handlers read current account state and registration history
+from the database; proposal results reconstruct the on-wire proposal procedure
+from the persisted action CBOR, return address, deposit, anchor, and votes.
+
 ## Chain Management
 
 The `ChainManager` (`chain/manager.go`) manages multiple chains:

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.27.4
 	github.com/blinklabs-io/bark v0.0.2
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.189.2
+	github.com/blinklabs-io/gouroboros v0.189.4
 	github.com/blinklabs-io/ouroboros-mock v0.15.0
 	github.com/blinklabs-io/plutigo v0.1.17
 	github.com/blockfrost/blockfrost-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.189.2 h1:3TSIlW2KxnNNGvRHGZDPC6+8dDz0K+/0vtWt12+PHRQ=
-github.com/blinklabs-io/gouroboros v0.189.2/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
+github.com/blinklabs-io/gouroboros v0.189.4 h1:9zW9iu+7c/Xou9jH9VoC71CZ9IdvcHvbf4u58u6tnzU=
+github.com/blinklabs-io/gouroboros v0.189.4/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
 github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=

--- a/internal/test/devnet/lsq.go
+++ b/internal/test/devnet/lsq.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	olsq "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
@@ -107,4 +108,59 @@ func RewardAccountsByNtcForCreds(
 		}
 	}
 	return out, nil
+}
+
+// QueryStakeAddressInfoByNtc runs the same LocalStateQuery sequence used by
+// cardano-cli query stake-address-info. The credential need not be registered;
+// empty maps are valid and still exercise every request/response wire shape.
+func QueryStakeAddressInfoByNtc(
+	addr string,
+	magic uint32,
+	cred olsq.StakeCredential,
+) error {
+	conn, err := ouroboros.New(
+		ouroboros.WithNetworkMagic(magic),
+		ouroboros.WithNodeToNode(false),
+	)
+	if err != nil {
+		return fmt.Errorf("ouroboros.New: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	if err := conn.DialTimeout("tcp", addr, 10*time.Second); err != nil {
+		return fmt.Errorf("dial tcp %s: %w", addr, err)
+	}
+	lsq := conn.LocalStateQuery()
+	if lsq == nil || lsq.Client == nil {
+		return fmt.Errorf("LocalStateQuery client unavailable on %s", addr)
+	}
+	client := lsq.Client
+	if err := client.AcquireVolatileTip(); err != nil {
+		return fmt.Errorf("acquire tip on %s: %w", addr, err)
+	}
+	defer client.Release() //nolint:errcheck
+
+	if _, err := client.GetFilteredDelegationsAndRewardAccounts(
+		[]olsq.StakeCredential{cred},
+	); err != nil {
+		return fmt.Errorf("delegations and rewards on %s: %w", addr, err)
+	}
+	if _, err := client.GetStakeDelegDeposits(
+		[]olsq.StakeCredential{cred},
+	); err != nil {
+		return fmt.Errorf("stake delegation deposits on %s: %w", addr, err)
+	}
+	commonCred := lcommon.Credential{
+		CredType:   uint(cred.Tag),
+		Credential: cred.Bytes,
+	}
+	if _, err := client.GetFilteredVoteDelegatees(
+		[]lcommon.Credential{commonCred},
+	); err != nil {
+		return fmt.Errorf("vote delegatees on %s: %w", addr, err)
+	}
+	if _, err := client.GetProposals(); err != nil {
+		return fmt.Errorf("governance proposals on %s: %w", addr, err)
+	}
+	return nil
 }

--- a/internal/test/devnet/scenarios/stake_address_info_test.go
+++ b/internal/test/devnet/scenarios/stake_address_info_test.go
@@ -1,0 +1,42 @@
+//go:build devnet && !devnet_conformance
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/test/devnet"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	olsq "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStakeAddressInfoQueries(t *testing.T) {
+	cred := olsq.StakeCredential{
+		Tag:   0,
+		Bytes: lcommon.NewBlake2b224([]byte("stake-address-info")),
+	}
+	for name, addr := range devnet.DingoNtcAddrs() {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, devnet.QueryStakeAddressInfoByNtc(
+				addr,
+				devnet.DefaultNetworkMagic,
+				cred,
+			))
+		})
+	}
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -443,6 +443,8 @@ func (ls *LedgerState) queryShelleyLeaf(query any) (any, error) {
 		return ls.queryShelleyFilteredDelegationAndRewardAccounts(
 			q.Creds.Items(),
 		)
+	case *olocalstatequery.ShelleyStakeDelegDepositsQuery:
+		return ls.queryShelleyStakeDelegDeposits(q.Creds.Items())
 	case *olocalstatequery.ShelleyGetLedgerPeerSnapshotQuery:
 		return ls.queryLedgerPeerSnapshot(q.PeerKind)
 	case *olocalstatequery.ShelleyStakePoolsQuery:
@@ -453,6 +455,10 @@ func (ls *LedgerState) queryShelleyLeaf(query any) (any, error) {
 		return ls.queryShelleyAccountState()
 	case *olocalstatequery.ShelleyStakeSnapshotsQuery:
 		return ls.queryShelleyStakeSnapshots(q)
+	case *olocalstatequery.ShelleyFilteredVoteDelegateesQuery:
+		return ls.queryShelleyFilteredVoteDelegatees(q.Credentials.Items())
+	case *olocalstatequery.ShelleyGetProposalsQuery:
+		return ls.queryShelleyGetProposals(q.ActionIds.Items())
 	// TODO (#394)
 	/*
 		case *olocalstatequery.ShelleyLedgerTipQuery:
@@ -988,6 +994,204 @@ func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 		}
 	}
 	return []any{[]any{delegations, rewards}}, nil
+}
+
+// queryShelleyStakeDelegDeposits answers GetStakeDelegDeposits with the
+// registration deposit currently locked by each requested active stake
+// credential. The latest registration event carries the historical deposit
+// actually paid, which may differ from the current protocol parameter.
+func (ls *LedgerState) queryShelleyStakeDelegDeposits(
+	creds []olocalstatequery.StakeCredential,
+) (any, error) {
+	ret := make(olocalstatequery.StakeDelegDepositsResult)
+	for _, cred := range creds {
+		credentialTag, err := models.CredentialTagFromUint64(cred.Tag)
+		if err != nil {
+			return nil, err
+		}
+		history, err := ls.db.GetAccountRegistrationHistoryByCredential(
+			credentialTag,
+			cred.Bytes[:],
+			1,
+			0,
+			"desc",
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(history) == 0 || history[0].Action != "registered" {
+			continue
+		}
+		ret[cred] = history[0].Deposit
+	}
+	return []any{ret}, nil
+}
+
+// queryShelleyFilteredVoteDelegatees returns the current DRep delegation for
+// each requested active stake credential. Credentials without a vote
+// delegation are omitted.
+func (ls *LedgerState) queryShelleyFilteredVoteDelegatees(
+	creds []lcommon.Credential,
+) (any, error) {
+	ret := make(olocalstatequery.FilteredVoteDelegateesResult)
+	for _, cred := range creds {
+		credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+		if err != nil {
+			return nil, err
+		}
+		account, err := ls.db.GetAccountByCredential(
+			credentialTag,
+			cred.Credential[:],
+			false,
+			nil,
+		)
+		if err != nil {
+			if errors.Is(err, models.ErrAccountNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		if account == nil ||
+			(len(account.Drep) == 0 &&
+				account.DrepType == models.DrepTypeAddrKeyHash) {
+			continue
+		}
+		var drepType int
+		switch account.DrepType {
+		case models.DrepTypeAddrKeyHash:
+			drepType = lcommon.DrepTypeAddrKeyHash
+		case models.DrepTypeScriptHash:
+			drepType = lcommon.DrepTypeScriptHash
+		case models.DrepTypeAlwaysAbstain:
+			drepType = lcommon.DrepTypeAbstain
+		case models.DrepTypeAlwaysNoConfidence:
+			drepType = lcommon.DrepTypeNoConfidence
+		default:
+			return nil, fmt.Errorf(
+				"unsupported DRep delegation type: %d",
+				account.DrepType,
+			)
+		}
+		key := olocalstatequery.StakeCredential{
+			Tag:   uint64(credentialTag),
+			Bytes: ledger.NewBlake2b224(cred.Credential[:]),
+		}
+		ret[key] = lcommon.Drep{
+			Type:       drepType,
+			Credential: slices.Clone(account.Drep),
+		}
+	}
+	return []any{ret}, nil
+}
+
+// queryShelleyGetProposals returns the active Conway governance proposals,
+// optionally filtered by action ID.
+func (ls *LedgerState) queryShelleyGetProposals(
+	actionIds []lcommon.GovActionId,
+) (any, error) {
+	epoch := ls.loadConsensusSnapshot().currentEpoch.EpochId
+	proposals, err := ls.db.GetActiveGovernanceProposals(epoch, nil)
+	if err != nil {
+		return nil, err
+	}
+	filter := make(map[lcommon.GovActionId]struct{}, len(actionIds))
+	for _, id := range actionIds {
+		filter[id] = struct{}{}
+	}
+	ret := make(olocalstatequery.ProposalsResult, 0, len(proposals))
+	for _, proposal := range proposals {
+		if proposal == nil {
+			continue
+		}
+		id, err := lcommon.NewGovActionId(
+			proposal.TxHash,
+			proposal.ActionIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(filter) > 0 {
+			if _, ok := filter[id]; !ok {
+				continue
+			}
+		}
+		state, err := ls.governanceProposalState(proposal, id)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, state)
+	}
+	return []any{ret}, nil
+}
+
+func (ls *LedgerState) governanceProposalState(
+	proposal *models.GovernanceProposal,
+	id lcommon.GovActionId,
+) (olocalstatequery.GovActionState, error) {
+	rewardAccount, err := lcommon.NewAddressFromBytes(proposal.ReturnAddress)
+	if err != nil {
+		return olocalstatequery.GovActionState{}, fmt.Errorf(
+			"decode governance proposal return address: %w",
+			err,
+		)
+	}
+	anchor := lcommon.GovAnchor{Url: proposal.AnchorURL}
+	copy(anchor.DataHash[:], proposal.AnchorHash)
+	procedure, err := cbor.Encode([]any{
+		proposal.Deposit,
+		rewardAccount,
+		cbor.RawMessage(proposal.GovActionCbor),
+		anchor,
+	})
+	if err != nil {
+		return olocalstatequery.GovActionState{}, fmt.Errorf(
+			"encode governance proposal procedure: %w",
+			err,
+		)
+	}
+	state := olocalstatequery.GovActionState{
+		Id:                id,
+		CommitteeVotes:    make(map[olocalstatequery.StakeCredential]lcommon.Vote),
+		DRepVotes:         make(map[olocalstatequery.StakeCredential]lcommon.Vote),
+		SPOVotes:          make(map[ledger.Blake2b224]lcommon.Vote),
+		ProposalProcedure: cbor.RawMessage(procedure),
+		ProposedIn:        proposal.ProposedEpoch,
+		ExpiresAfter:      proposal.ExpiresEpoch,
+	}
+	votes, err := ls.db.GetGovernanceVotes(proposal.ID, nil)
+	if err != nil {
+		return olocalstatequery.GovActionState{}, err
+	}
+	for _, vote := range votes {
+		if vote == nil {
+			continue
+		}
+		choice := lcommon.Vote(vote.Vote)
+		switch vote.VoterType {
+		case models.VoterTypeCC:
+			state.CommitteeVotes[stakeCredentialFromVote(vote)] = choice
+		case models.VoterTypeDRep:
+			state.DRepVotes[stakeCredentialFromVote(vote)] = choice
+		case models.VoterTypeSPO:
+			state.SPOVotes[ledger.NewBlake2b224(vote.VoterCredential)] = choice
+		default:
+			return olocalstatequery.GovActionState{}, fmt.Errorf(
+				"unsupported governance voter type: %d",
+				vote.VoterType,
+			)
+		}
+	}
+	return state, nil
+}
+
+func stakeCredentialFromVote(
+	vote *models.GovernanceVote,
+) olocalstatequery.StakeCredential {
+	return olocalstatequery.StakeCredential{
+		Tag:   uint64(vote.VoterCredentialTag),
+		Bytes: ledger.NewBlake2b224(vote.VoterCredential),
+	}
 }
 
 func (ls *LedgerState) queryShelleyUtxoByTxIn(

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -37,6 +37,7 @@ import (
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -616,6 +617,167 @@ func TestQueryShelleyFilteredDelegationAndRewardAccounts_TagAware(t *testing.T) 
 	assert.Equal(t, uint64(100), rwds[keyCred])
 	assert.Equal(t, toBlake2b224(scriptPool), dels[scriptCred])
 	assert.Equal(t, uint64(200), rwds[scriptCred])
+}
+
+func TestQueryShelleyStakeDelegDeposits(t *testing.T) {
+	db := newTestDB(t)
+	stakeKey := stakeCred28(0x51)
+	cred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.NewBlake2b224(stakeKey),
+	}
+	txBuilder := mockledger.NewTransactionBuilder()
+	txBuilder.WithId(bytes.Repeat([]byte{0x52}, 32))
+	txBuilder.WithValid(true)
+	input, err := mockledger.NewSimpleTransactionInput(
+		bytes.Repeat([]byte{0x54}, 32),
+		0,
+	)
+	require.NoError(t, err)
+	txBuilder.WithInputs(input)
+	output, err := mockledger.NewTransactionOutputBuilder().
+		WithAddress(
+			"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		).
+		WithLovelace(1_000_000).
+		Build()
+	require.NoError(t, err)
+	txBuilder.WithOutputs(output)
+	txBuilder.WithCertificates(&lcommon.StakeRegistrationCertificate{
+		StakeCredential: cred,
+	})
+	tx, err := txBuilder.Build()
+	require.NoError(t, err)
+	require.NoError(t, db.SetTransactionMetadataOnly(
+		tx,
+		ocommon.NewPoint(100, bytes.Repeat([]byte{0x53}, 32)),
+		0,
+		map[int]uint64{0: 2_000_000},
+		nil,
+	))
+
+	ls := &LedgerState{db: db}
+	queryCred := olocalstatequery.StakeCredential{
+		Tag:   0,
+		Bytes: lcommon.NewBlake2b224(stakeKey),
+	}
+	unknownCred := olocalstatequery.StakeCredential{
+		Tag:   0,
+		Bytes: lcommon.NewBlake2b224(stakeCred28(0x55)),
+	}
+	result, err := ls.queryShelleyStakeDelegDeposits(
+		[]olocalstatequery.StakeCredential{queryCred, unknownCred},
+	)
+	require.NoError(t, err)
+	outer, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, outer, 1)
+	deposits, ok := outer[0].(olocalstatequery.StakeDelegDepositsResult)
+	require.True(t, ok)
+	assert.Equal(t, uint64(2_000_000), deposits[queryCred])
+	assert.NotContains(t, deposits, unknownCred)
+
+	encoded, err := cbor.Encode(result)
+	require.NoError(t, err)
+	var decoded olocalstatequery.StakeDelegDepositsResult
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2_000_000), decoded[queryCred])
+}
+
+func TestQueryShelleyFilteredVoteDelegatees(t *testing.T) {
+	db := newTestDB(t)
+	stakeKey := stakeCred28(0x61)
+	drepKey := stakeCred28(0x62)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Drep:          drepKey,
+		DrepType:      models.DrepTypeAddrKeyHash,
+		Active:        true,
+	}))
+	ls := &LedgerState{db: db}
+	cred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.NewBlake2b224(stakeKey),
+	}
+
+	result, err := ls.queryShelleyFilteredVoteDelegatees(
+		[]lcommon.Credential{cred},
+	)
+	require.NoError(t, err)
+	outer, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, outer, 1)
+	delegatees, ok := outer[0].(olocalstatequery.FilteredVoteDelegateesResult)
+	require.True(t, ok)
+	queryCred := olocalstatequery.StakeCredential{
+		Tag:   0,
+		Bytes: lcommon.NewBlake2b224(stakeKey),
+	}
+	require.Contains(t, delegatees, queryCred)
+	assert.Equal(t, int(models.DrepTypeAddrKeyHash), delegatees[queryCred].Type)
+	assert.Equal(t, drepKey, delegatees[queryCred].Credential)
+
+	encoded, err := cbor.Encode(result)
+	require.NoError(t, err)
+	var decoded olocalstatequery.FilteredVoteDelegateesResult
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, delegatees[queryCred], decoded[queryCred])
+}
+
+func TestQueryShelleyGetProposalsReturnsDepositProcedure(t *testing.T) {
+	db := newTestDB(t)
+	txHash := bytes.Repeat([]byte{0x71}, 32)
+	returnAddressBytes := append(
+		[]byte{0xe0},
+		bytes.Repeat([]byte{0x72}, 28)...,
+	)
+	govAction, err := cbor.Encode([]any{uint64(lcommon.GovActionTypeInfo)})
+	require.NoError(t, err)
+	proposal := &models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   1,
+		ActionType:    uint8(lcommon.GovActionTypeInfo),
+		ProposedEpoch: 0,
+		ExpiresEpoch:  10,
+		AnchorURL:     "https://example.com/proposal.json",
+		AnchorHash:    bytes.Repeat([]byte{0x73}, 32),
+		Deposit:       100_000_000,
+		ReturnAddress: returnAddressBytes,
+		GovActionCbor: govAction,
+		AddedSlot:     100,
+	}
+	require.NoError(t, db.SetGovernanceProposal(proposal, nil))
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:         proposal.ID,
+		VoterType:          models.VoterTypeDRep,
+		VoterCredentialTag: 0,
+		VoterCredential:    stakeCred28(0x74),
+		Vote:               models.VoteYes,
+		AddedSlot:          101,
+	}, nil))
+	ls := &LedgerState{db: db}
+	ls.publishSnapshotsLocked()
+
+	result, err := ls.queryShelleyGetProposals(nil)
+	require.NoError(t, err)
+	outer, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, outer, 1)
+	proposals, ok := outer[0].(olocalstatequery.ProposalsResult)
+	require.True(t, ok)
+	require.Len(t, proposals, 1)
+	assert.Len(t, proposals[0].DRepVotes, 1)
+
+	var procedure conway.ConwayProposalProcedure
+	_, err = cbor.Decode(proposals[0].ProposalProcedure, &procedure)
+	require.NoError(t, err)
+	assert.Equal(t, proposal.Deposit, procedure.Deposit())
+	gotReturnAddress, err := procedure.RewardAccount().Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, returnAddressBytes, gotReturnAddress)
 }
 
 func TestEpochPicoseconds(t *testing.T) {


### PR DESCRIPTION
Closes #2933 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for stake-address-info via the node-to-client LocalStateQuery server. The node now returns delegations/rewards, stake delegation deposits, DRep delegatees, and active governance proposals so `cardano-cli query stake-address-info` works end-to-end.

- **New Features**
  - Implemented LSQ handlers: StakeDelegDeposits, FilteredVoteDelegatees, and GetProposals with correct wire shapes.
  - Reconstructed proposal procedure (deposit, return address, action CBOR, anchor) and included live votes.
  - Added a devnet test that runs the exact stake-address-info LSQ sequence (works for unregistered creds), unit tests for deposits/delegatees/procedure, and documented the LSQ flow.

- **Dependencies**
  - Bumped `github.com/blinklabs-io/gouroboros` to `v0.189.4` for new LSQ query types.

<sup>Written for commit dbb6a9a11561eef835bb886ef2799476b7ba3616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local state queries for stake delegation deposits, DRep delegatees, and active governance proposals.
  - Governance proposal results now include deposit details, return addresses, anchors, and voting information.
  - Added devnet coverage for querying stake address information.

- **Documentation**
  - Documented local state query support and stake-address inspection behavior.

- **Tests**
  - Added coverage validating query results and their encoded representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->