### PR TITLE
docs: use SetCbor(nil) to clear gouroboros cached CBOR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ make golines
 
 - EventBus for async cross-component notifications: use `event.EventBus.SubscribeFunc()` for block/chain/mempool/peer events. Synchronous state queries between components still use direct method calls.
 - CBOR offsets: UTxOs/txs stored as 52-byte refs (magic `"DOFF"` + slot + hash + offset + length), resolved by `TieredCborCache` (hot → block LRU → cold extract). See `database/cbor_offset.go`.
+- gouroboros types embedding `DecodeStoreCbor` (blocks, tx bodies, etc.) return the original decoded bytes verbatim from `MarshalCBOR()` whenever `Cbor()` is non-nil — mutating a decoded struct's fields and re-marshaling silently re-emits the pre-mutation bytes. Call `SetCbor(nil)` before marshaling after mutating fields, or the change is dropped.
 - Cert ordering: `Order("added_slot DESC, block_index DESC, cert_index DESC")` — `cert_index` resets per tx, so `block_index` is required to disambiguate across txs in the same block.
 - Rollbacks: delivered on `chain.update` as a `chain.ChainRollbackEvent` payload (no separate `chain.rollback` topic); also subscribe to `chain.fork_detected` for fork metrics. Check `TransactionEvent.Rollback` for undo.
 - Stake snapshots: mark/set/go rotation at epoch boundaries (Praos). `LedgerView.GetStakeDistribution(epoch)` for leader election. Per-pool stake in `PoolStakeSnapshot`; aggregates in `EpochSummary`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ make import-boundaries
 ## Non-obvious invariants
 
 - CBOR offsets: UTxOs/txs store 52-byte `CborOffset` refs (magic `"DOFF"` + slot + hash + offset + length), not full CBOR. Resolved via `TieredCborCache` (hot → block LRU → cold blob extract). See `database/cbor_offset.go`, `database/cbor_cache.go`, `database/block_indexer.go`.
+- gouroboros types embedding `DecodeStoreCbor` (blocks, tx bodies, etc.) return the original decoded bytes verbatim from `MarshalCBOR()` whenever `Cbor()` is non-nil — mutating a decoded struct's fields and re-marshaling silently re-emits the pre-mutation bytes. Call `SetCbor(nil)` before marshaling after mutating fields, or the change is dropped.
 - EventBus for async cross-component notifications: block/chain/mempool/peer events go through `event.EventBus.SubscribeFunc()`. Synchronous state queries between components still use direct method calls.
 - Cert ordering: multiple certs per slot — tie-break with `Order("added_slot DESC, block_index DESC, cert_index DESC")` (`cert_index` resets per tx, so `block_index` is required to disambiguate across txs in the same block).
 - Rollbacks: `Chain.Rollback(point)` emits `ChainRollbackEvent`; check `TransactionEvent.Rollback` for undo.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies `gouroboros` CBOR caching behavior: types with `DecodeStoreCbor` will re-emit the original bytes from `MarshalCBOR()` unless the cached CBOR is cleared.
Adds guidance in `AGENTS.md` and `CLAUDE.md` to call `SetCbor(nil)` before marshaling after mutating fields so changes are applied.

<sup>Written for commit 647f16f5f030fdde3f7be696c3c640a19149c78a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

