### PR TITLE
fix(database): keep live-stake index during API backfill

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2575,11 +2575,14 @@ distinguishes an upgraded database with accounts but no aggregate rows from a
 legitimately fresh empty database. Node startup performs the check and rebuild
 after database recovery and before ledger processing. Mithril ledger-state
 import also invokes the rebuild directly, at the end of import once accounts and
-UTxOs are populated. That import runs with the deferred-index manifest dropped
-for bulk load, so the SQLite backend applies its `INDEXED BY
-idx_utxo_staking_deleted_amount` query-planner hint only when the index is
-present; while the index is deferred the rebuild falls back to a planner-chosen
-plan rather than aborting with `no such index`.
+UTxOs are populated. `idx_utxo_staking_deleted_amount` is deliberately kept
+out of the deferred-index manifest: the API-mode metadata backfill refreshes
+per-credential live-stake aggregates on every flushed batch, and without the
+index each refresh degenerates into a full scan of the growing `utxo` table,
+making the backfill quadratic. The SQLite backend still applies its `INDEXED
+BY idx_utxo_staking_deleted_amount` query-planner hint only when the index is
+present (a defensive fallback for databases where it is missing), falling back
+to a planner-chosen plan rather than aborting with `no such index`.
 
 Pool registration lookup reconstructs the parameters effective during the
 ended epoch for per-pool input capture. Reward calculation and application

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -195,13 +195,16 @@ var Manifest = []Index{
 		Notes:    "Composite SearchUtxos index; primary utxorpc query path",
 		Critical: true,
 	},
-	{
-		Model: &models.Utxo{}, Name: "idx_utxo_staking_deleted_amount", Table: "utxo",
-		Notes: "DRep voting-power live UTxO SUM; live query path. RebuildRewardLiveStake " +
-			"runs during ledger-state import and hints this index, but the sqlite backend " +
-			"applies the INDEXED BY hint only when the index exists, so it stays deferrable.",
-		Critical: true,
-	},
+	// idx_utxo_staking_deleted_amount is deliberately NOT deferred.
+	// FlushBatch -> refreshRewardLiveStakeAggregates runs a per-credential
+	// live UTxO SUM (WHERE credential_tag = ? AND staking_key = ? AND
+	// deleted_slot = 0) on every API-mode backfill batch. With this index
+	// dropped each of those SUMs is a full scan of the growing utxo table,
+	// making the backfill quadratic: measured on preview, throughput
+	// collapsed from ~1700 to ~4 blocks/sec by 3% progress. The one-shot
+	// RebuildRewardLiveStake at the end of ledger-state import tolerates a
+	// missing index (single full scan), but the per-batch incremental
+	// refresh cannot.
 	{
 		Model: &models.Utxo{}, Name: "idx_utxo_deleted_payment_script", Table: "utxo",
 		Notes:    "Script-locked supply SUM (blockfrost /network); live query path",

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -70,7 +70,10 @@ func TestCriticalManifestNotEmpty(t *testing.T) {
 		t.Fatal("CriticalManifest returned empty slice")
 	}
 	// Pin the expected count so accidental de-classification is caught.
-	const wantCritical = 13
+	// idx_utxo_staking_deleted_amount left the manifest entirely: the
+	// API-backfill per-batch live-stake SUM needs it during bulk load,
+	// so it is never dropped and no longer needs a critical rebuild slot.
+	const wantCritical = 12
 	if len(critical) != wantCritical {
 		t.Errorf("CriticalManifest: got %d entries, want %d — update this constant if the classification changed intentionally", len(critical), wantCritical)
 	}


### PR DESCRIPTION
Removes idx_utxo_staking_deleted_amount from the deferred-index manifest so
it stays in place during Mithril bulk load.

FlushBatch refreshes live-stake aggregates on every API-backfill batch with a
per-credential SUM over utxo (credential_tag, staking_key, deleted_slot).
With the index dropped, each of those sums is a full scan of the growing utxo
table and the backfill turns quadratic. 

A possible follow-up (upstream's call): skip the per-batch refresh entirely
during bulk load, since historical replay below the snapshot tip should not
change the final aggregates - that would allow deferring the index again. Kept
out of this PR since it touches reward-state logic.

Fixes #2953

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the `idx_utxo_staking_deleted_amount` index active during API backfill to avoid full-table scans and restore backfill performance during Mithril bulk load. Removed it from the deferred-index manifest and adjusted docs/tests.

- **Bug Fixes**
  - Remove `idx_utxo_staking_deleted_amount` from the deferred manifest so per-batch live-stake SUMs use the index during backfill.
  - Clarify in ARCHITECTURE.md why the index stays active and note SQLite’s `INDEXED BY` fallback behavior when the index is missing.
  - Update the critical-manifest test to reflect the index is no longer deferred (count adjusted).

<sup>Written for commit 58692a2a0f7be26548f4632f4d33cb395ad4ce63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward metadata backfill performance by preserving a key database index, preventing progressively slower rebuilds on larger datasets.
  * SQLite rebuilds now safely fall back to the query planner when the optional index is unavailable, avoiding failures.

* **Documentation**
  * Clarified index behavior and performance considerations for reward metadata state rebuilding.
  * Updated related validation expectations to reflect the revised index configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->