### PR TITLE
feat(blockfrost): implement /addresses/{address} endpoint

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -716,6 +716,18 @@ WHERE atx.payment_key = decode($1, 'hex')
   AND (atx.staking_key IS NULL OR length(atx.staking_key) = 0)
 ```
 
+### `CountTransactionsByPaymentCred`
+
+Counts transactions for a payment credential across every address carrying
+it, regardless of staking part. Used by the Blockfrost payment-credential
+(`addr_vkh`/`script`) address lookups:
+
+```sql
+SELECT COUNT(DISTINCT atx.transaction_id) AS tx_count
+FROM address_transaction atx
+WHERE atx.payment_key = decode($1, 'hex');
+```
+
 ### `GetAddressesByCredential`
 
 ```sql
@@ -728,6 +740,43 @@ GROUP BY payment_key, credential_tag, staking_key
 ORDER BY payment_key ASC
 LIMIT 100;
 ```
+
+### `GetUtxoBalanceByAddress`
+
+Aggregates live-UTxO balances for an address in SQL (used by the Blockfrost
+`/addresses/{address}` summary). Lovelace and count:
+
+```sql
+SELECT COUNT(*) AS cnt, COALESCE(SUM(amount), 0) AS lovelace
+FROM utxo
+WHERE utxo.deleted_slot = 0
+  AND (utxo.payment_script = $1 AND utxo.payment_key = decode($2, 'hex')
+       AND utxo.credential_tag = $3 AND utxo.staking_key = decode($4, 'hex'));
+```
+
+Per-asset balances, ordered for deterministic unit output:
+
+```sql
+SELECT asset.policy_id, asset.name, COALESCE(SUM(asset.amount), 0) AS amount
+FROM asset
+JOIN utxo ON asset.utxo_id = utxo.id
+WHERE utxo.deleted_slot = 0
+  AND (utxo.payment_script = $1 AND utxo.payment_key = decode($2, 'hex')
+       AND utxo.credential_tag = $3 AND utxo.staking_key = decode($4, 'hex'))
+GROUP BY asset.policy_id, asset.name
+ORDER BY asset.policy_id, asset.name;
+```
+
+The address condition follows the same payment/staking branch rules as the
+UTxO listing queries, with an explicit match mode: exact matching adds
+`AND (staking_key IS NULL OR LENGTH(staking_key) = 0)` for payment-only
+(enterprise/pointer) addresses so base-address UTxOs sharing the payment
+credential are excluded, while payment-credential mode (bare
+`addr_vkh`/`script` lookups) keeps the payment-only predicate and
+aggregates across address forms. Pointer addresses are further narrowed
+by the API adapter, which compares each candidate output's decoded
+address bytes, because the pointer payload is not represented in the
+`utxo` table.
 
 ### `GetUtxosByAddress`, `GetUtxosByAddressAtSlot`, and `GetControlledAmountByCredential`
 

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -50,6 +51,7 @@ import (
 
 var (
 	ErrInvalidAddress      = errors.New("invalid address")
+	ErrAddressNotFound     = errors.New("address not found")
 	ErrInvalidBlockID      = errors.New("invalid block id")
 	ErrBlockNotFound       = errors.New("block not found")
 	ErrEpochNotFound       = errors.New("epoch not found")
@@ -2462,6 +2464,330 @@ func uintToInt(v uint) int {
 
 // AddressUTXOs returns paginated current UTxOs for the
 // requested address.
+// parseAddressOrPaymentCred parses a full address, or a bare payment
+// credential in CIP-5 "addr_vkh"/"script" bech32 form as accepted by the
+// Blockfrost address endpoints. A payment credential maps to a synthetic
+// enterprise address so UTxO queries aggregate across every address sharing
+// that credential, mirroring Blockfrost's paymentCred behavior; the second
+// return value reports that form so callers can adjust semantics.
+func parseAddressOrPaymentCred(
+	address string,
+) (lcommon.Address, bool, error) {
+	if hrp, data, err := bech32.Decode(address); err == nil {
+		var addrType uint8
+		isPaymentCred := true
+		switch strings.ToLower(hrp) {
+		case "addr_vkh":
+			addrType = lcommon.AddressTypeKeyNone
+		case "script":
+			addrType = lcommon.AddressTypeScriptNone
+		default:
+			isPaymentCred = false
+		}
+		if isPaymentCred {
+			payload, err := bech32.ConvertBits(data, 5, 8, false)
+			if err != nil {
+				return lcommon.Address{}, false, fmt.Errorf(
+					"decode payment credential payload: %w",
+					err,
+				)
+			}
+			// The network id only affects the synthetic address's
+			// textual form, which is never used; queries match on
+			// the credential.
+			addr, err := lcommon.NewAddressFromParts(
+				addrType,
+				lcommon.AddressNetworkTestnet,
+				payload,
+				nil,
+			)
+			return addr, true, err
+		}
+	}
+	addr, err := lcommon.NewAddress(address)
+	if err != nil {
+		return lcommon.Address{}, false, err
+	}
+	// NewAddress falls back to base58 and accepts arbitrary bytes without
+	// structural validation, so require the parsed address to round-trip
+	// back to the input to reject malformed input like "addr1stonks".
+	if addr.String() != address {
+		return lcommon.Address{}, false, fmt.Errorf(
+			"address does not round-trip: %w",
+			ErrInvalidAddress,
+		)
+	}
+	// Reject inputs without a payment part (e.g. stake addresses), which
+	// the Blockfrost address endpoints treat as malformed.
+	if addr.PaymentKeyHash() == lcommon.NewBlake2b224(nil) {
+		return lcommon.Address{}, false, fmt.Errorf(
+			"address has no payment part: %w",
+			ErrInvalidAddress,
+		)
+	}
+	return addr, false, nil
+}
+
+// isPointerAddress reports whether the address carries a pointer
+// staking reference (Shelley address types 0x4/0x5).
+func isPointerAddress(addr lcommon.Address) bool {
+	switch addr.Type() {
+	case lcommon.AddressTypeKeyPointer, lcommon.AddressTypeScriptPointer:
+		return true
+	default:
+		return false
+	}
+}
+
+// pointerAddressBalance aggregates balances for a pointer address by
+// exact address identity: SQL narrows the candidates to outputs sharing
+// the payment credential, and each candidate's output CBOR is decoded
+// to compare the full address bytes. Pointer addresses are vanishingly
+// rare, so the candidate sets stay small.
+func (a *NodeAdapter) pointerAddressBalance(
+	addr lcommon.Address,
+) (models.AddressBalance, error) {
+	var ret models.AddressBalance
+	wantBytes, err := addr.Bytes()
+	if err != nil {
+		return ret, fmt.Errorf("encode pointer address: %w", err)
+	}
+
+	candidates, err := a.ledgerState.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			Addresses: []lcommon.Address{addr},
+		},
+	)
+	if err != nil {
+		return ret, fmt.Errorf("get pointer address candidates: %w", err)
+	}
+	if len(candidates) == 0 {
+		return ret, nil
+	}
+
+	utxoCbor, err := a.addressUtxoCbor(candidates)
+	if err != nil {
+		return ret, fmt.Errorf(
+			"resolve CBOR for pointer address candidates: %w", err,
+		)
+	}
+	for i := range candidates {
+		raw := utxoCbor[utxoRef(candidates[i].Utxo)]
+		if len(raw) == 0 {
+			continue
+		}
+		output, err := gledger.NewTransactionOutputFromCbor(raw)
+		if err != nil {
+			continue
+		}
+		outAddr := output.Address()
+		gotBytes, err := outAddr.Bytes()
+		if err != nil || !bytes.Equal(gotBytes, wantBytes) {
+			continue
+		}
+		ret.UtxoCount++
+		ret.Lovelace += uint64(candidates[i].Amount)
+		for _, asset := range candidates[i].Assets {
+			ret.Assets = append(ret.Assets, models.AssetBalance{
+				PolicyId: asset.PolicyId,
+				Name:     asset.Name,
+				Amount:   uint64(asset.Amount),
+			})
+		}
+	}
+	// Merge duplicate asset units and restore the (policy id, name)
+	// ordering the SQL path provides.
+	merged := make(map[string]*models.AssetBalance)
+	for i := range ret.Assets {
+		key := string(ret.Assets[i].PolicyId) + "\x00" + string(ret.Assets[i].Name)
+		if existing, ok := merged[key]; ok {
+			existing.Amount += ret.Assets[i].Amount
+			continue
+		}
+		assetCopy := ret.Assets[i]
+		merged[key] = &assetCopy
+	}
+	ret.Assets = ret.Assets[:0]
+	for _, asset := range merged {
+		ret.Assets = append(ret.Assets, *asset)
+	}
+	sort.Slice(ret.Assets, func(i, j int) bool {
+		if c := bytes.Compare(
+			ret.Assets[i].PolicyId, ret.Assets[j].PolicyId,
+		); c != 0 {
+			return c < 0
+		}
+		return bytes.Compare(
+			ret.Assets[i].Name, ret.Assets[j].Name,
+		) < 0
+	})
+	return ret, nil
+}
+
+// Address returns summary details for the requested address, with balances
+// aggregated across its live UTxOs. Addresses never seen on chain map to
+// ErrAddressNotFound; addresses with spent history resolve with a zero
+// lovelace balance.
+func (a *NodeAdapter) Address(
+	address string,
+) (AddressInfo, error) {
+	addr, isPaymentCred, err := parseAddressOrPaymentCred(address)
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf(
+			"parse address %q: %w",
+			address,
+			ErrInvalidAddress,
+		)
+	}
+	// Blockfrost rejects addresses encoded for a different network than
+	// the node's; queries match on bare credential hashes, so without
+	// this check a foreign-network address would return this network's
+	// balances. Bare payment credentials carry no network id.
+	if !isPaymentCred && addr.NetworkId() != uint(a.networkID()) {
+		return AddressInfo{}, fmt.Errorf(
+			"address %q network mismatch: %w",
+			address,
+			ErrInvalidAddress,
+		)
+	}
+
+	// Read every query from one snapshot so a block committed
+	// mid-request cannot mix two chain states in the response.
+	db := a.ledgerState.Database()
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	// Full addresses use exact matching so UTxOs at other address
+	// forms sharing the payment credential are excluded; bare
+	// payment credentials (addr_vkh/script) deliberately aggregate
+	// across forms.
+	matchMode := models.UtxoAddressMatchExact
+	if isPaymentCred {
+		matchMode = models.UtxoAddressMatchPaymentCred
+	}
+
+	var balance models.AddressBalance
+	if !isPaymentCred && isPointerAddress(addr) {
+		// Pointer addresses cannot be distinguished from
+		// enterprise addresses (or from each other) by the stored
+		// credential columns: the pointer payload is not
+		// represented in the utxo table. Narrow candidates by
+		// payment credential in SQL, then keep only outputs whose
+		// decoded address matches the request exactly.
+		balance, err = a.pointerAddressBalance(addr)
+	} else {
+		balance, err = db.Metadata().
+			GetUtxoBalanceByAddress(addr, matchMode, txn.Metadata())
+	}
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf(
+			"get address balance for %q: %w",
+			address,
+			err,
+		)
+	}
+	if balance.UtxoCount == 0 {
+		var txCount int
+		if isPaymentCred {
+			// The synthetic enterprise address would only match
+			// enterprise usage in the per-address transaction
+			// index; a spent-out credential used via base
+			// addresses must still resolve, so count across every
+			// address carrying the payment credential.
+			txCount, err = db.CountTransactionsByPaymentCred(
+				addr.PaymentKeyHash().Bytes(),
+				txn,
+			)
+		} else {
+			txCount, err = db.CountTransactionsByAddress(addr, txn)
+		}
+		if err != nil {
+			return AddressInfo{}, fmt.Errorf(
+				"count address transactions for %q: %w",
+				address,
+				err,
+			)
+		}
+		if txCount == 0 {
+			return AddressInfo{}, fmt.Errorf(
+				"address %q: %w",
+				address,
+				ErrAddressNotFound,
+			)
+		}
+	}
+
+	// Balances are aggregated in SQL (see GetUtxoBalanceByAddress);
+	// assets arrive ordered by (policy id, name), which matches the
+	// hex-string unit ordering Blockfrost emits.
+	amounts := make([]AddressAmountInfo, 0, len(balance.Assets)+1)
+	amounts = append(amounts, AddressAmountInfo{
+		Unit:     "lovelace",
+		Quantity: strconv.FormatUint(balance.Lovelace, 10),
+	})
+	for _, asset := range balance.Assets {
+		amounts = append(amounts, AddressAmountInfo{
+			Unit: hex.EncodeToString(asset.PolicyId) +
+				hex.EncodeToString(asset.Name),
+			Quantity: strconv.FormatUint(asset.Amount, 10),
+		})
+	}
+
+	var stakeAddress *string
+	if stakeAddr := addr.StakeAddress(); stakeAddr != nil {
+		encoded := stakeAddr.String()
+		stakeAddress = &encoded
+	} else if addr.Type() == lcommon.AddressTypeKeyScript {
+		// gouroboros Address.StakeAddress() has no case for
+		// key-payment/script-staking base addresses; build the script
+		// stake address from the staking credential directly.
+		networkID, err := uintToUint8(
+			addr.NetworkId(),
+			"address network id",
+		)
+		if err != nil {
+			return AddressInfo{}, err
+		}
+		encoded, err := stakeAddressFromCredential(
+			lcommon.Credential{
+				CredType:   lcommon.CredentialTypeScriptHash,
+				Credential: lcommon.CredentialHash(addr.StakeKeyHash()),
+			},
+			networkID,
+		)
+		if err != nil {
+			return AddressInfo{}, fmt.Errorf(
+				"derive script stake address for %q: %w",
+				address,
+				err,
+			)
+		}
+		stakeAddress = &encoded
+	}
+
+	addrType := "shelley"
+	if addr.Type() == lcommon.AddressTypeByron {
+		addrType = "byron"
+	}
+
+	script := false
+	switch addr.Type() {
+	case lcommon.AddressTypeScriptKey,
+		lcommon.AddressTypeScriptScript,
+		lcommon.AddressTypeScriptPointer,
+		lcommon.AddressTypeScriptNone:
+		script = true
+	}
+
+	return AddressInfo{
+		Address:      address,
+		Amount:       amounts,
+		StakeAddress: stakeAddress,
+		Type:         addrType,
+		Script:       script,
+	}, nil
+}
+
 func (a *NodeAdapter) AddressUTXOs(
 	address string,
 	params PaginationParams,

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -125,6 +125,10 @@ func (b *Blockfrost) handler() http.Handler {
 		b.handleDRep,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/addresses/{address}",
+		b.handleAddress,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/addresses/{address}/utxos",
 		b.handleAddressUTXOs,
 	)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -76,6 +76,7 @@ type mockNode struct {
 	drepListTotal                 int
 	drepListParams                DRepListParams
 	drepCredential                DRepCredential
+	addressInfo                   AddressInfo
 	addressUTXOs                  []AddressUTXOInfo
 	addressTransactions           []AddressTransactionInfo
 	metadataJSON                  []MetadataTransactionJSONInfo
@@ -118,6 +119,7 @@ type mockNode struct {
 	assetAddressesErr             error
 	drepErr                       error
 	drepListErr                   error
+	addressInfoErr                error
 	addressUTXOsErr               error
 	addressTransactionsErr        error
 	metadataJSONErr               error
@@ -239,6 +241,12 @@ func (m *mockNode) DReps(
 ) ([]DRepListItemInfo, int, error) {
 	m.drepListParams = params
 	return m.drepList, m.drepListTotal, m.drepListErr
+}
+
+func (m *mockNode) Address(
+	_ string,
+) (AddressInfo, error) {
+	return m.addressInfo, m.addressInfoErr
 }
 
 func (m *mockNode) AddressUTXOs(
@@ -2708,6 +2716,159 @@ func TestDefaultListenAddress(t *testing.T) {
 		slog.Default(),
 	)
 	assert.Equal(t, ":3000", b.config.ListenAddress)
+}
+
+func TestParseAddressOrPaymentCred(t *testing.T) {
+	// CIP-5 payment key hash credential
+	addr, isPaymentCred, err := parseAddressOrPaymentCred(
+		"addr_vkh1x0ph3nhyrvhpttyy3alk78f00q244vfdjwm38h5f3kz47kpgum5",
+	)
+	require.NoError(t, err)
+	assert.True(t, isPaymentCred)
+	assert.Equal(t, uint8(lcommon.AddressTypeKeyNone), addr.Type())
+	assert.Nil(t, addr.StakeAddress())
+
+	// CIP-5 script hash credential
+	addr, isPaymentCred, err = parseAddressOrPaymentCred(
+		"script1tx3c5y302fupjrm0xs3skumkaw97h2le97rjgrfzw8spydzr5ej",
+	)
+	require.NoError(t, err)
+	assert.True(t, isPaymentCred)
+	assert.Equal(t, uint8(lcommon.AddressTypeScriptNone), addr.Type())
+
+	// Full base address still parses through the normal path
+	addr, isPaymentCred, err = parseAddressOrPaymentCred(
+		"addr_test1qprwyxzmswhtjstxvj7epjc28gskffsqcxuurx80qrjdy3uayerntq74us2hsgxymgk3f5nka58z46zcqgctv9c05ctq8g0qn7",
+	)
+	require.NoError(t, err)
+	assert.False(t, isPaymentCred)
+	require.NotNil(t, addr.StakeAddress())
+	assert.Equal(
+		t,
+		"stake_test1uzwjv3e4s027g9tcyrzd5tg56fmw6r32apvqyv9kzu86v9sqrx6ye",
+		addr.StakeAddress().String(),
+	)
+
+	// Garbage input fails despite decoding as base58 bytes
+	_, _, err = parseAddressOrPaymentCred("addr1stonks")
+	require.Error(t, err)
+
+	// Stake addresses have no payment part and are rejected
+	_, _, err = parseAddressOrPaymentCred(
+		"stake_test1uzwjv3e4s027g9tcyrzd5tg56fmw6r32apvqyv9kzu86v9sqrx6ye",
+	)
+	require.Error(t, err)
+}
+
+func TestKeyScriptStakeAddressDerivation(t *testing.T) {
+	// gouroboros StakeAddress() returns nil for type-2 base addresses
+	// (key payment / script staking); the adapter derives the script
+	// stake address from the staking credential instead.
+	paymentHash := bytes.Repeat([]byte{0x01}, lcommon.AddressHashSize)
+	stakeScriptHash := bytes.Repeat([]byte{0x02}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyScript,
+		lcommon.AddressNetworkTestnet,
+		paymentHash,
+		stakeScriptHash,
+	)
+	require.NoError(t, err)
+	require.Nil(t, addr.StakeAddress())
+
+	encoded, err := stakeAddressFromCredential(
+		lcommon.Credential{
+			CredType:   lcommon.CredentialTypeScriptHash,
+			Credential: lcommon.CredentialHash(addr.StakeKeyHash()),
+		},
+		lcommon.AddressNetworkTestnet,
+	)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(encoded, "stake_test17"))
+
+	stakeAddr, err := lcommon.NewAddress(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, stakeScriptHash, stakeAddr.StakeKeyHash().Bytes())
+}
+
+func TestHandleAddress(t *testing.T) {
+	stakeAddress := "stake_test1upwlsqc..."
+	mock := &mockNode{
+		addressInfo: AddressInfo{
+			Address: "addr_test1vr8nl4...",
+			Amount: []AddressAmountInfo{
+				{Unit: "lovelace", Quantity: "3000"},
+				{Unit: "policyasset", Quantity: "7"},
+			},
+			StakeAddress: &stakeAddress,
+			Type:         "shelley",
+			Script:       false,
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/addr_test1vr8nl4...",
+		nil,
+	)
+	req.SetPathValue("address", "addr_test1vr8nl4...")
+	w := httptest.NewRecorder()
+	b.handleAddress(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp AddressResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "addr_test1vr8nl4...", resp.Address)
+	require.Len(t, resp.Amount, 2)
+	assert.Equal(t, "lovelace", resp.Amount[0].Unit)
+	assert.Equal(t, "3000", resp.Amount[0].Quantity)
+	assert.Equal(t, "policyasset", resp.Amount[1].Unit)
+	assert.Equal(t, "7", resp.Amount[1].Quantity)
+	require.NotNil(t, resp.StakeAddress)
+	assert.Equal(t, stakeAddress, *resp.StakeAddress)
+	assert.Equal(t, "shelley", resp.Type)
+	assert.False(t, resp.Script)
+}
+
+func TestHandleAddressNotFound(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		addressInfoErr: ErrAddressNotFound,
+	})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/addr_test1vr8nl4...",
+		nil,
+	)
+	req.SetPathValue("address", "addr_test1vr8nl4...")
+	w := httptest.NewRecorder()
+	b.handleAddress(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	var resp ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"The requested component has not been found.",
+		resp.Message,
+	)
+}
+
+func TestHandleAddressInvalidAddress(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		addressInfoErr: ErrInvalidAddress,
+	})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/addresses/not_an_address",
+		nil,
+	)
+	req.SetPathValue("address", "not_an_address")
+	w := httptest.NewRecorder()
+	b.handleAddress(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestHandleAddressUTXOs(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -778,6 +778,46 @@ func (b *Blockfrost) handleDReps(
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// handleAddress handles GET /api/v0/addresses/{address}
+// and returns summary information for an address.
+func (b *Blockfrost) handleAddress(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	address := r.PathValue("address")
+	info, err := b.node.Address(address)
+	if err != nil {
+		if errors.Is(err, ErrAddressNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested component has not been found.",
+			)
+			return
+		}
+		b.logger.Error(
+			"failed to get address",
+			"address", address,
+			"error", err,
+		)
+		writeNodeQueryError(
+			w,
+			err,
+			"failed to retrieve address",
+		)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, AddressResponse{
+		Address:      info.Address,
+		Amount:       convertAddressAmounts(info.Amount),
+		StakeAddress: info.StakeAddress,
+		Type:         info.Type,
+		Script:       info.Script,
+	})
+}
+
 // handleAddressUTXOs handles GET /api/v0/addresses/{address}/utxos
 // and returns the current UTxOs for an address.
 func (b *Blockfrost) handleAddressUTXOs(
@@ -1778,7 +1818,7 @@ func writeNodeQueryError(
 			w,
 			http.StatusBadRequest,
 			"Bad Request",
-			"Invalid address provided.",
+			"Invalid address for this network or malformed address format.",
 		)
 		return
 	}

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -61,6 +61,10 @@ type BlockfrostNode interface {
 	// extended details.
 	PoolsExtended() ([]PoolExtendedInfo, error)
 
+	// Address returns summary information for an address,
+	// including balances aggregated across its live UTxOs.
+	Address(address string) (AddressInfo, error)
+
 	// AddressUTXOs returns the paginated current UTxOs for
 	// an address along with the total number of matching
 	// results before pagination.
@@ -382,6 +386,15 @@ type PoolRelayInfo struct {
 type AddressAmountInfo struct {
 	Unit     string
 	Quantity string
+}
+
+// AddressInfo holds address summary data needed by the API.
+type AddressInfo struct {
+	Address      string
+	Amount       []AddressAmountInfo
+	StakeAddress *string
+	Type         string
+	Script       bool
 }
 
 // AddressUTXOInfo holds address UTxO data needed by the

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -198,6 +198,16 @@ type AddressAmountResponse struct {
 	Quantity string `json:"quantity"`
 }
 
+// AddressResponse represents a Blockfrost address summary
+// object.
+type AddressResponse struct {
+	Address      string                  `json:"address"`
+	Amount       []AddressAmountResponse `json:"amount"`
+	StakeAddress *string                 `json:"stake_address"`
+	Type         string                  `json:"type"`
+	Script       bool                    `json:"script"`
+}
+
 // AddressUTXOResponse represents a Blockfrost address
 // UTxO object.
 type AddressUTXOResponse struct {

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -30,13 +30,43 @@ var (
 	ErrEmptyAssetPolicyID = errors.New("empty asset policy id")
 )
 
+// UtxoAddressMatchMode selects how an address matches utxo rows.
+type UtxoAddressMatchMode int
+
+const (
+	// UtxoAddressMatchExact preserves full-address identity: a
+	// payment-only (enterprise/pointer) address matches only rows
+	// with no staking part, so base-address UTxOs sharing the same
+	// payment credential are excluded.
+	UtxoAddressMatchExact UtxoAddressMatchMode = iota
+	// UtxoAddressMatchPaymentCred aggregates across every address
+	// form sharing the payment credential, mirroring Blockfrost's
+	// bare-credential (addr_vkh/script) lookups.
+	UtxoAddressMatchPaymentCred
+)
+
 // AppendUtxoAddressOrBranch appends an OR branch for the given address
 // to the ors/args slices. It uses standard "?" placeholders that work
-// across SQLite, MySQL, and Postgres via GORM.
+// across SQLite, MySQL, and Postgres via GORM. Payment-only addresses
+// use payment-credential matching; see AppendUtxoAddressOrBranchMode
+// for exact full-address semantics.
 func AppendUtxoAddressOrBranch(
 	ors *[]string,
 	args *[]any,
 	addr ledger.Address,
+) error {
+	return AppendUtxoAddressOrBranchMode(
+		ors, args, addr, UtxoAddressMatchPaymentCred,
+	)
+}
+
+// AppendUtxoAddressOrBranchMode appends an OR branch for the given
+// address with an explicit match mode.
+func AppendUtxoAddressOrBranchMode(
+	ors *[]string,
+	args *[]any,
+	addr ledger.Address,
+	mode UtxoAddressMatchMode,
 ) error {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	pk := addr.PaymentKeyHash()
@@ -62,6 +92,16 @@ func AppendUtxoAddressOrBranch(
 			sk.Bytes(),
 		)
 	case hasPayment:
+		if mode == UtxoAddressMatchExact {
+			// LENGTH counts bytes for blob columns on SQLite,
+			// MySQL, and Postgres alike.
+			*ors = append(
+				*ors,
+				"(utxo.payment_script = ? AND utxo.payment_key = ? AND (utxo.staking_key IS NULL OR LENGTH(utxo.staking_key) = 0))",
+			)
+			*args = append(*args, paymentScript, pk.Bytes())
+			break
+		}
 		*ors = append(*ors, "(utxo.payment_script = ? AND utxo.payment_key = ?)")
 		*args = append(*args, paymentScript, pk.Bytes())
 	case hasStake:
@@ -221,6 +261,22 @@ func StakeCredentialTagFromAddress(addr ledger.Address) (uint8, bool) {
 
 func PaymentScriptFromAddress(addr ledger.Address) bool {
 	return addr.Type()&lcommon.AddressTypeScriptBit == lcommon.AddressTypeScriptBit
+}
+
+// AddressBalance holds SQL-aggregated live-UTxO balances for an address.
+type AddressBalance struct {
+	Lovelace  uint64
+	UtxoCount int64
+	// Assets is ordered by (policy id, name) so callers emit
+	// deterministic unit ordering without re-sorting.
+	Assets []AssetBalance
+}
+
+// AssetBalance is one aggregated native-asset balance.
+type AssetBalance struct {
+	PolicyId []byte
+	Name     []byte
+	Amount   uint64
 }
 
 // UtxoSlot allows providing a slot number with a ledger.Utxo object

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -422,6 +422,36 @@ func (d *MetadataStoreMysql) CountTransactionsByAddress(
 	return int(count), nil
 }
 
+// CountTransactionsByPaymentCred returns the total number of distinct
+// transactions involving the given payment credential across every address
+// that carries it, regardless of staking part.
+func (d *MetadataStoreMysql) CountTransactionsByPaymentCred(
+	paymentKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(paymentKey) == 0 {
+		return 0, nil
+	}
+
+	var count int64
+	result := db.Model(&models.AddressTransaction{}).
+		Where("payment_key = ?", paymentKey).
+		Distinct("transaction_id").
+		Count(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"count txs by payment cred: %w",
+			result.Error,
+		)
+	}
+	return int(count), nil
+}
+
 // GetAddressesByCredential returns distinct addresses mapped to a stake credential.
 func (d *MetadataStoreMysql) GetAddressesByCredential(
 	credentialTag uint8,

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -955,3 +955,62 @@ func (d *MetadataStoreMysql) MarkUtxosDeletedAtSlot(
 	}
 	return refreshRewardLiveStakeAggregates(db, rewardRefs)
 }
+
+// GetUtxoBalanceByAddress returns the live-UTxO lovelace balance, per-asset
+// balances, and live UTxO count for the given address, aggregated in SQL.
+// Assets are ordered by (policy id, name) for deterministic output.
+func (d *MetadataStoreMysql) GetUtxoBalanceByAddress(
+	addr lcommon.Address,
+	mode models.UtxoAddressMatchMode,
+	txn types.Txn,
+) (models.AddressBalance, error) {
+	var ret models.AddressBalance
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, fmt.Errorf(
+			"resolve DB for utxo balance by address: %w",
+			err,
+		)
+	}
+	var ors []string
+	var args []any
+	if err := models.AppendUtxoAddressOrBranchMode(
+		&ors, &args, addr, mode,
+	); err != nil {
+		return ret, fmt.Errorf("utxo balance by address: %w", err)
+	}
+	if len(ors) == 0 {
+		return ret, nil
+	}
+	addrCond := "(" + strings.Join(ors, " OR ") + ")"
+
+	var totals struct {
+		Cnt      int64
+		Lovelace uint64
+	}
+	if err := db.Model(&models.Utxo{}).
+		Where("utxo.deleted_slot = 0 AND "+addrCond, args...).
+		Select("COUNT(*) AS cnt, COALESCE(SUM(amount), 0) AS lovelace").
+		Scan(&totals).Error; err != nil {
+		return ret, fmt.Errorf("sum utxo balance by address: %w", err)
+	}
+	ret.UtxoCount = totals.Cnt
+	ret.Lovelace = totals.Lovelace
+	if ret.UtxoCount == 0 {
+		return ret, nil
+	}
+
+	if err := db.Model(&models.Asset{}).
+		Joins("JOIN utxo ON asset.utxo_id = utxo.id").
+		Where("utxo.deleted_slot = 0 AND "+addrCond, args...).
+		Select("asset.policy_id AS policy_id, asset.name AS name, COALESCE(SUM(asset.amount), 0) AS amount").
+		Group("asset.policy_id, asset.name").
+		Order("asset.policy_id, asset.name").
+		Scan(&ret.Assets).Error; err != nil {
+		return ret, fmt.Errorf(
+			"sum utxo asset balances by address: %w",
+			err,
+		)
+	}
+	return ret, nil
+}

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -422,6 +422,36 @@ func (d *MetadataStorePostgres) CountTransactionsByAddress(
 	return int(count), nil
 }
 
+// CountTransactionsByPaymentCred returns the total number of distinct
+// transactions involving the given payment credential across every address
+// that carries it, regardless of staking part.
+func (d *MetadataStorePostgres) CountTransactionsByPaymentCred(
+	paymentKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(paymentKey) == 0 {
+		return 0, nil
+	}
+
+	var count int64
+	result := db.Model(&models.AddressTransaction{}).
+		Where("payment_key = ?", paymentKey).
+		Distinct("transaction_id").
+		Count(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"count txs by payment cred: %w",
+			result.Error,
+		)
+	}
+	return int(count), nil
+}
+
 // GetAddressesByCredential returns distinct addresses mapped to a stake credential.
 func (d *MetadataStorePostgres) GetAddressesByCredential(
 	credentialTag uint8,

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -956,3 +956,62 @@ func (d *MetadataStorePostgres) MarkUtxosDeletedAtSlot(
 	}
 	return refreshRewardLiveStakeAggregates(db, rewardRefs)
 }
+
+// GetUtxoBalanceByAddress returns the live-UTxO lovelace balance, per-asset
+// balances, and live UTxO count for the given address, aggregated in SQL.
+// Assets are ordered by (policy id, name) for deterministic output.
+func (d *MetadataStorePostgres) GetUtxoBalanceByAddress(
+	addr lcommon.Address,
+	mode models.UtxoAddressMatchMode,
+	txn types.Txn,
+) (models.AddressBalance, error) {
+	var ret models.AddressBalance
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return ret, fmt.Errorf(
+			"resolve DB for utxo balance by address: %w",
+			err,
+		)
+	}
+	var ors []string
+	var args []any
+	if err := models.AppendUtxoAddressOrBranchMode(
+		&ors, &args, addr, mode,
+	); err != nil {
+		return ret, fmt.Errorf("utxo balance by address: %w", err)
+	}
+	if len(ors) == 0 {
+		return ret, nil
+	}
+	addrCond := "(" + strings.Join(ors, " OR ") + ")"
+
+	var totals struct {
+		Cnt      int64
+		Lovelace uint64
+	}
+	if err := db.Model(&models.Utxo{}).
+		Where("utxo.deleted_slot = 0 AND "+addrCond, args...).
+		Select("COUNT(*) AS cnt, COALESCE(SUM(amount), 0) AS lovelace").
+		Scan(&totals).Error; err != nil {
+		return ret, fmt.Errorf("sum utxo balance by address: %w", err)
+	}
+	ret.UtxoCount = totals.Cnt
+	ret.Lovelace = totals.Lovelace
+	if ret.UtxoCount == 0 {
+		return ret, nil
+	}
+
+	if err := db.Model(&models.Asset{}).
+		Joins("JOIN utxo ON asset.utxo_id = utxo.id").
+		Where("utxo.deleted_slot = 0 AND "+addrCond, args...).
+		Select("asset.policy_id AS policy_id, asset.name AS name, COALESCE(SUM(asset.amount), 0) AS amount").
+		Group("asset.policy_id, asset.name").
+		Order("asset.policy_id, asset.name").
+		Scan(&ret.Assets).Error; err != nil {
+		return ret, fmt.Errorf(
+			"sum utxo asset balances by address: %w",
+			err,
+		)
+	}
+	return ret, nil
+}

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -472,6 +472,36 @@ func (d *MetadataStoreSqlite) CountTransactionsByAddress(
 	return int(count), nil
 }
 
+// CountTransactionsByPaymentCred returns the total number of distinct
+// transactions involving the given payment credential across every address
+// that carries it, regardless of staking part.
+func (d *MetadataStoreSqlite) CountTransactionsByPaymentCred(
+	paymentKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(paymentKey) == 0 {
+		return 0, nil
+	}
+
+	var count int64
+	result := db.Model(&models.AddressTransaction{}).
+		Where("payment_key = ?", paymentKey).
+		Distinct("transaction_id").
+		Count(&count)
+	if result.Error != nil {
+		return 0, fmt.Errorf(
+			"count txs by payment cred: %w",
+			result.Error,
+		)
+	}
+	return int(count), nil
+}
+
 // GetAddressesByCredential returns distinct addresses mapped to a stake credential.
 func (d *MetadataStoreSqlite) GetAddressesByCredential(
 	credentialTag uint8,

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -1051,3 +1051,97 @@ func (d *MetadataStoreSqlite) MarkUtxosDeletedAtSlot(
 	}
 	return db.Transaction(mutation)
 }
+
+// GetUtxoBalanceByAddress returns the live-UTxO lovelace balance, per-asset
+// balances, and live UTxO count for the given address, aggregated in SQL.
+// Assets are ordered by (policy id, name) for deterministic output.
+//
+// SQLite's planner tends to pick idx_utxo_deleted_payment_script for these
+// aggregates (it matches deleted_slot + payment_script, i.e. nearly every
+// live UTxO) and then filters the credential row by row, which takes tens of
+// seconds on large chains. Force the credential-selective index when it is
+// present; fall back to the planner when it is missing (e.g. during bulk
+// load), mirroring the live-stake INDEXED BY handling.
+func (d *MetadataStoreSqlite) GetUtxoBalanceByAddress(
+	addr lcommon.Address,
+	mode models.UtxoAddressMatchMode,
+	txn types.Txn,
+) (models.AddressBalance, error) {
+	var ret models.AddressBalance
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return ret, fmt.Errorf(
+			"resolve DB for utxo balance by address: %w",
+			err,
+		)
+	}
+	var ors []string
+	var args []any
+	if err := models.AppendUtxoAddressOrBranchMode(
+		&ors, &args, addr, mode,
+	); err != nil {
+		return ret, fmt.Errorf("utxo balance by address: %w", err)
+	}
+	if len(ors) == 0 {
+		return ret, nil
+	}
+	addrCond := "(" + strings.Join(ors, " OR ") + ")"
+
+	// Pick the credential-selective index for the address form: payment
+	// lookups drive through the payment key, staking-only lookups through
+	// the staking composite.
+	zeroHash := lcommon.NewBlake2b224(nil)
+	hintIndex := "idx_utxo_payment_key"
+	if addr.PaymentKeyHash() == zeroHash {
+		hintIndex = "idx_utxo_staking_deleted_amount"
+	}
+	indexedBy := ""
+	var indexPresent bool
+	if err := db.Raw(
+		"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?)",
+		hintIndex,
+	).Scan(&indexPresent).Error; err != nil {
+		return ret, fmt.Errorf(
+			"probe index for utxo balance by address: %w",
+			err,
+		)
+	}
+	if indexPresent {
+		indexedBy = "INDEXED BY " + hintIndex
+	}
+
+	var totals struct {
+		Cnt      int64
+		Lovelace uint64
+	}
+	if err := db.Raw(
+		"SELECT COUNT(*) AS cnt, COALESCE(SUM(amount), 0) AS lovelace "+
+			"FROM utxo "+indexedBy+
+			" WHERE utxo.deleted_slot = 0 AND "+addrCond,
+		args...,
+	).Scan(&totals).Error; err != nil {
+		return ret, fmt.Errorf("sum utxo balance by address: %w", err)
+	}
+	ret.UtxoCount = totals.Cnt
+	ret.Lovelace = totals.Lovelace
+	if ret.UtxoCount == 0 {
+		return ret, nil
+	}
+
+	if err := db.Raw(
+		"SELECT asset.policy_id AS policy_id, asset.name AS name, "+
+			"COALESCE(SUM(asset.amount), 0) AS amount "+
+			"FROM utxo "+indexedBy+
+			" JOIN asset ON asset.utxo_id = utxo.id"+
+			" WHERE utxo.deleted_slot = 0 AND "+addrCond+
+			" GROUP BY asset.policy_id, asset.name"+
+			" ORDER BY asset.policy_id, asset.name",
+		args...,
+	).Scan(&ret.Assets).Error; err != nil {
+		return ret, fmt.Errorf(
+			"sum utxo asset balances by address: %w",
+			err,
+		)
+	}
+	return ret, nil
+}

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -737,3 +737,110 @@ func TestGetUtxosByAddressUsesPaymentScript(t *testing.T) {
 	assert.True(t, orderedRows[0].PaymentScript)
 	assert.Equal(t, scriptUtxo.TxId, orderedRows[0].TxId)
 }
+
+// TestGetUtxoBalanceByAddressMatchModes seeds enterprise, base, and
+// pointer UTxOs sharing one payment hash and verifies that exact
+// matching keeps full-address identity while payment-credential
+// matching deliberately aggregates across address forms. Regression
+// coverage for the address-conflation review on the Blockfrost address
+// summary endpoint.
+func TestGetUtxoBalanceByAddressMatchModes(t *testing.T) {
+	store := setupTestDB(t)
+
+	paymentHash := bytes.Repeat([]byte{0xAB}, lcommon.AddressHashSize)
+	stakeHash := bytes.Repeat([]byte{0xCD}, lcommon.AddressHashSize)
+	otherPayment := bytes.Repeat([]byte{0xEE}, lcommon.AddressHashSize)
+
+	enterpriseAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		paymentHash,
+		nil,
+	)
+	require.NoError(t, err)
+	baseAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		paymentHash,
+		stakeHash,
+	)
+	require.NoError(t, err)
+
+	rows := []models.Utxo{
+		// Enterprise-form UTxO (no staking part).
+		{
+			TxId:       bytes.Repeat([]byte{0x01}, 32),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  10,
+			Amount:     types.Uint64(1_000_000),
+		},
+		// Base-address UTxO sharing the same payment hash.
+		{
+			TxId:          bytes.Repeat([]byte{0x02}, 32),
+			OutputIdx:     0,
+			PaymentKey:    paymentHash,
+			StakingKey:    stakeHash,
+			CredentialTag: 0,
+			AddedSlot:     11,
+			Amount:        types.Uint64(2_000_000),
+		},
+		// Pointer-address UTxO: like enterprise it carries no staking
+		// key in the row, so it lands in the payment-only bucket. The
+		// adapter separates real pointer addresses by exact CBOR
+		// address comparison; at the storage layer it is part of the
+		// staking-less set.
+		{
+			TxId:       bytes.Repeat([]byte{0x03}, 32),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  12,
+			Amount:     types.Uint64(4_000_000),
+		},
+		// Unrelated payment credential: never included.
+		{
+			TxId:       bytes.Repeat([]byte{0x04}, 32),
+			OutputIdx:  0,
+			PaymentKey: otherPayment,
+			AddedSlot:  13,
+			Amount:     types.Uint64(64_000_000),
+		},
+		// Spent UTxO on the shared credential: never included.
+		{
+			TxId:        bytes.Repeat([]byte{0x05}, 32),
+			OutputIdx:   0,
+			PaymentKey:  paymentHash,
+			AddedSlot:   14,
+			DeletedSlot: 20,
+			Amount:      types.Uint64(32_000_000),
+		},
+	}
+	for i := range rows {
+		require.NoError(t, store.DB().Create(&rows[i]).Error)
+	}
+
+	// Exact enterprise matching excludes the base-address UTxO.
+	balance, err := store.GetUtxoBalanceByAddress(
+		enterpriseAddr, models.UtxoAddressMatchExact, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5_000_000), balance.Lovelace)
+	assert.Equal(t, int64(2), balance.UtxoCount)
+
+	// Exact base matching returns only the base-address UTxO.
+	balance, err = store.GetUtxoBalanceByAddress(
+		baseAddr, models.UtxoAddressMatchExact, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2_000_000), balance.Lovelace)
+	assert.Equal(t, int64(1), balance.UtxoCount)
+
+	// Payment-credential matching aggregates every live UTxO sharing
+	// the credential, across address forms.
+	balance, err = store.GetUtxoBalanceByAddress(
+		enterpriseAddr, models.UtxoAddressMatchPaymentCred, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7_000_000), balance.Lovelace)
+	assert.Equal(t, int64(3), balance.UtxoCount)
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -824,6 +824,15 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
+	// CountTransactionsByPaymentCred returns the total number of
+	// transactions involving the provided payment credential across every
+	// address that carries it, regardless of staking part. Used by the
+	// Blockfrost payment-credential (addr_vkh/script) address lookups.
+	CountTransactionsByPaymentCred(
+		[]byte, // paymentKey
+		types.Txn,
+	) (int, error)
+
 	// GetAddressesByCredential retrieves distinct address mappings for a stake credential.
 	GetAddressesByCredential(
 		uint8, // credentialTag
@@ -1153,6 +1162,19 @@ type MetadataStore interface {
 	// UTxOs whose payment credential is a script. This is the network's
 	// script-locked supply (blockfrost /network supply.locked).
 	GetScriptLockedSupply(types.Txn) (uint64, error)
+
+	// GetUtxoBalanceByAddress returns the live-UTxO lovelace balance,
+	// per-asset balances (ordered by policy id then name), and live UTxO
+	// count for the given address, aggregated in SQL. The match mode
+	// selects full-address identity (exact) or payment-credential
+	// aggregation. Used by the Blockfrost address summary endpoint,
+	// where loading every UTxO row for aggregation in Go is too slow
+	// for large addresses.
+	GetUtxoBalanceByAddress(
+		lcommon.Address,
+		models.UtxoAddressMatchMode,
+		types.Txn,
+	) (models.AddressBalance, error)
 
 	// GetUtxosByAddressWithOrdering runs q against live UTxOs with ordering metadata.
 	// See models.UtxoWithOrderingQuery. q must be non-nil.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1237,6 +1237,31 @@ func (d *Database) CountTransactionsByAddressKeys(
 	return count, nil
 }
 
+// CountTransactionsByPaymentCred returns the total number of transactions
+// involving a payment credential across every address that carries it,
+// regardless of staking part.
+func (d *Database) CountTransactionsByPaymentCred(
+	paymentKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountTransactionsByPaymentCred(
+		paymentKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count txs by payment cred %x: %w",
+			paymentKey,
+			err,
+		)
+	}
+	return count, nil
+}
+
 // GetAddressesByCredential returns distinct address mappings for a stake credential.
 func (d *Database) GetAddressesByCredential(
 	credentialTag uint8,

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -424,20 +424,20 @@ func extractAddressKeys(addr []byte, result *ParsedUTxO) {
 	addrType := (headerByte >> 4) & 0x0f
 
 	// Even address types (0,2,4,6) have payment KEY credentials;
-	// odd types (1,3,5,7) have payment SCRIPT credentials.
+	// odd types (1,3,5,7) have payment SCRIPT credentials. The payment
+	// credential hash is stored for both kinds — the CBOR parsing path
+	// (parseCborTxOut) and live sync (UtxoLedgerToModel) both store
+	// script hashes in PaymentKey, and payment-credential queries
+	// (address lookups, blockfrost addr_vkh/script) match on it.
 	// For staking: types 0,1 have staking KEY; types 2,3 have
-	// staking SCRIPT. Only store key hashes, not script hashes,
-	// to match the CBOR parsing path (parseCborTxOut).
-	paymentIsKey := addrType%2 == 0
+	// staking SCRIPT.
+	paymentIsScript := addrType%2 == 1
 
 	switch {
 	case addrType <= 3 && len(addr) >= 57:
 		// Base address: 1 header + 28 payment + 28 staking
-		if paymentIsKey {
-			result.PaymentKey = bytes.Clone(addr[1:29])
-		} else {
-			result.PaymentScript = true
-		}
+		result.PaymentKey = bytes.Clone(addr[1:29])
+		result.PaymentScript = paymentIsScript
 		if addrType <= 1 { // staking is key for types 0,1
 			result.StakingKey = bytes.Clone(addr[29:57])
 			result.CredentialTag = 0
@@ -447,18 +447,12 @@ func extractAddressKeys(addr []byte, result *ParsedUTxO) {
 		}
 	case (addrType == 4 || addrType == 5) && len(addr) >= 29:
 		// Pointer address: 1 header + 28 payment + pointer
-		if paymentIsKey {
-			result.PaymentKey = bytes.Clone(addr[1:29])
-		} else {
-			result.PaymentScript = true
-		}
+		result.PaymentKey = bytes.Clone(addr[1:29])
+		result.PaymentScript = paymentIsScript
 	case (addrType == 6 || addrType == 7) && len(addr) >= 29:
 		// Enterprise address: 1 header + 28 payment
-		if paymentIsKey {
-			result.PaymentKey = bytes.Clone(addr[1:29])
-		} else {
-			result.PaymentScript = true
-		}
+		result.PaymentKey = bytes.Clone(addr[1:29])
+		result.PaymentScript = paymentIsScript
 	}
 }
 

--- a/ledgerstate/utxo_test.go
+++ b/ledgerstate/utxo_test.go
@@ -61,7 +61,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			name:         "type1_script_payment_key_staking",
 			addr:         buildShelleyAddr(1, 1, payHash, stakeHash),
 			wantScript:   true,
-			wantPayKey:   false,
+			wantPayKey:   true,
 			wantStakeKey: true,
 			wantStakeTag: 0,
 		},
@@ -79,7 +79,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			name:         "type3_script_payment_script_staking",
 			addr:         buildShelleyAddr(3, 1, payHash, stakeHash),
 			wantScript:   true,
-			wantPayKey:   false,
+			wantPayKey:   true,
 			wantStakeKey: true,
 			wantStakeTag: 1,
 		},
@@ -88,7 +88,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			name:       "type5_script_payment_pointer",
 			addr:       buildShelleyAddr(5, 1, payHash, nil),
 			wantScript: true,
-			wantPayKey: false,
+			wantPayKey: true,
 		},
 		{
 			// Type 6: enterprise key payment — NOT script
@@ -102,7 +102,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			name:       "type7_enterprise_script",
 			addr:       buildShelleyAddr(7, 1, payHash, nil),
 			wantScript: true,
-			wantPayKey: false,
+			wantPayKey: true,
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestExtractAddressKeys_ScriptPaymentTypes(t *testing.T) {
 			if tc.wantPayKey {
 				require.Equal(t, payHash, result.PaymentKey, "PaymentKey")
 			} else {
-				require.Empty(t, result.PaymentKey, "PaymentKey should be empty for script payment")
+				require.Empty(t, result.PaymentKey, "PaymentKey should be empty for truncated/unknown address types")
 			}
 			if tc.wantStakeKey {
 				require.Equal(t, stakeHash, result.StakingKey, "StakingKey")


### PR DESCRIPTION
Closes #2935 

Adds the Blockfrost address summary endpoint: balances aggregated across
live UTxOs, stake_address, type, and script flag.

- balances are aggregated in SQL (new GetUtxoBalanceByAddress); the sqlite
  backend needs an INDEXED BY hint or the planner scans every live UTxO
- accepts CIP-5 payment credentials (addr_vkh1/script1) like Blockfrost,
  aggregating across all addresses sharing the credential
- rejects wrong-network addresses, stake addresses, and malformed input
- includes a fix for the Mithril snapshot import leaving payment_key empty
  for script-payment UTxOs, which made them invisible to address queries
  (separate commit)

Validated against the official blockfrost-tests preview suite: 15/15.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Blockfrost `/addresses/{address}` to return an address summary with SQL‑aggregated balances, with CIP‑5 credential support, strict network/format checks, and correct pointer‑address handling. Also fixes a snapshot import bug that hid script‑payment UTxOs.

- **New Features**
  - Added `GET /api/v0/addresses/{address}` in `api/blockfrost`: returns lovelace and per‑asset totals, `stake_address`, `type`, and `script`.
  - Accepts CIP‑5 payment credentials (`addr_vkh`, `script`); aggregates across all addresses sharing the credential and avoids false 404s via `CountTransactionsByPaymentCred`.
  - Validates network; rejects stake addresses and malformed/base58 inputs; derives script stake address for key/script base addresses; preserves pointer address identity via exact CBOR address matching.
  - Database: added `GetUtxoBalanceByAddress` (MySQL/Postgres/SQLite) to aggregate balances in SQL; SQLite uses an `INDEXED BY` hint for large chains.

- **Bug Fixes**
  - Snapshot import: store script payment hashes in `payment_key` for script‑payment UTxOs, making them visible to address and credential queries.

<sup>Written for commit 5b4db1daf5870b6bad85c16739b287645efa562d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Blockfrost-compatible endpoint for retrieving address summaries.
  * Address responses now include balances, native assets, stake addresses, address type, and script indicators.
  * Supports bare payment credentials in supported address queries.
  * Improved handling of missing, malformed, and network-mismatched addresses.

* **Bug Fixes**
  * Corrected payment credential extraction for script-based addresses.
  * Improved detection of previously seen addresses with no live UTxOs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->