### PR TITLE
feat(blockfrost): implement DRep list endpoint and align DRep response

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -995,6 +995,84 @@ FROM active_delegator_stake
 GROUP BY pool_key_hash;
 ```
 
+### `GetDreps` and `GetPredefinedDrepFirstSeenSlots`
+
+Full DRep listing (including deregistered rows) ordered by the
+credential's first on-chain appearance — the earliest registration,
+update, or delegation reference across the certificate tables — which
+survives deregister/re-register cycles and matches hosted Blockfrost's
+db-sync row ordering. Rows without certificate history fall back to the
+current registration slot:
+
+```sql
+WITH first_seen AS (
+    SELECT cred, tag, MIN(slot) AS slot FROM (
+        SELECT drep_credential AS cred, credential_tag AS tag,
+               MIN(added_slot) AS slot
+        FROM registration_drep GROUP BY drep_credential, credential_tag
+        UNION ALL SELECT credential, credential_tag, MIN(added_slot)
+        FROM update_drep GROUP BY credential, credential_tag
+        UNION ALL SELECT drep, drep_type, MIN(added_slot)
+        FROM vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+        UNION ALL SELECT drep, drep_type, MIN(added_slot)
+        FROM stake_vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+        UNION ALL SELECT drep, drep_type, MIN(added_slot)
+        FROM vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+        UNION ALL SELECT drep, drep_type, MIN(added_slot)
+        FROM stake_vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+    ) u GROUP BY cred, tag
+),
+last_reg AS (
+    -- certificate_id filters out the synthetic rows the Mithril
+    -- ledger-state import writes at the bootstrap slot
+    SELECT drep_credential AS cred, credential_tag AS tag,
+           MAX(added_slot) AS slot
+    FROM registration_drep
+    WHERE certificate_id IS NOT NULL AND certificate_id != 0
+    GROUP BY drep_credential, credential_tag
+)
+SELECT drep.*, COALESCE(first_seen.slot, drep.added_slot) AS first_seen_slot,
+       COALESCE(last_reg.slot, 0) AS last_registration_slot
+FROM drep
+LEFT JOIN first_seen
+    ON first_seen.cred = drep.credential
+    AND first_seen.tag = drep.credential_tag
+LEFT JOIN last_reg
+    ON last_reg.cred = drep.credential
+    AND last_reg.tag = drep.credential_tag
+ORDER BY COALESCE(first_seen.slot, drep.added_slot), drep.id;
+```
+
+`last_registration_slot` feeds the Blockfrost `active_epoch` field: the
+mutable `drep.added_slot` is overwritten by update and deregistration
+certificates, so the most recent registration certificate is the correct
+source. `GetDrepLastRegistrationSlot` is the single-credential variant used
+by the DRep detail endpoint:
+
+```sql
+SELECT COALESCE(MAX(added_slot), 0)
+FROM registration_drep
+WHERE credential_tag = $1 AND drep_credential = decode($2, 'hex')
+  AND certificate_id IS NOT NULL AND certificate_id != 0;
+```
+
+`GetPredefinedDrepFirstSeenSlots` returns the earliest delegation slot
+per predefined DRep type (2 = AlwaysAbstain, 3 = AlwaysNoConfidence),
+used to interleave the special DReps into the same listing:
+
+```sql
+SELECT drep_type, MIN(slot) AS slot FROM (
+    SELECT drep_type, MIN(added_slot) AS slot
+    FROM vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+    UNION ALL SELECT drep_type, MIN(added_slot)
+    FROM stake_vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+    UNION ALL SELECT drep_type, MIN(added_slot)
+    FROM vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+    UNION ALL SELECT drep_type, MIN(added_slot)
+    FROM stake_vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+) u GROUP BY drep_type;
+```
+
 ### `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, `GetDRepVotingPowerByType`
 
 All three DRep voting-power queries take an `expiryEpoch uint64` argument that

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -24,11 +24,13 @@ import (
 	"math"
 	"math/big"
 	"slices"
+	"sort"
 	"strconv"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/labelcodec"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/mempool"
@@ -1145,6 +1147,9 @@ func paginateAssetHolders(
 func (a *NodeAdapter) DRep(
 	credential DRepCredential,
 ) (DRepInfo, error) {
+	if credential.Predefined != nil {
+		return a.predefinedDRep(credential)
+	}
 	if credential.CredentialTagKnown {
 		var credentialTag uint8
 		if credential.HasScript {
@@ -1161,6 +1166,68 @@ func (a *NodeAdapter) DRep(
 		return DRepInfo{}, err
 	}
 	return a.drepByCredentialTag(credential, 1)
+}
+
+// predefinedDRep returns the special always-abstain /
+// always-no-confidence DRep summary. These carry no credential, never
+// register, retire, or expire, and have no activity epochs.
+func (a *NodeAdapter) predefinedDRep(
+	credential DRepCredential,
+) (DRepInfo, error) {
+	drepType := *credential.Predefined
+	powers, err := a.ledgerState.Database().Metadata().
+		GetDRepVotingPowerByType([]uint64{drepType}, 0, nil)
+	if err != nil {
+		return DRepInfo{}, fmt.Errorf(
+			"get predefined drep voting power: %w",
+			err,
+		)
+	}
+	return DRepInfo{
+		DRepID: credential.ID,
+		Hex:    "",
+		Amount: strconv.FormatUint(powers[drepType], 10),
+		Active: true,
+	}, nil
+}
+
+// drepInactivityPeriod returns the Conway-era drep_activity protocol
+// parameter (epochs of inactivity before a DRep expires), or 0 when it
+// is unavailable.
+func (a *NodeAdapter) drepInactivityPeriod() uint64 {
+	switch pp := a.ledgerState.GetCurrentPParams().(type) {
+	case *conway.ConwayProtocolParameters:
+		return pp.DRepInactivityPeriod
+	case *dijkstra.DijkstraProtocolParameters:
+		return pp.DRepInactivityPeriod
+	default:
+		return 0
+	}
+}
+
+// drepStatus derives the Blockfrost retirement/expiry view of a DRep
+// row. A DRep with no recorded activity falls back to its registration
+// epoch, and a missing expiry epoch is derived from the drep_activity
+// protocol parameter, matching hosted Blockfrost semantics.
+func drepStatus(
+	active bool,
+	lastActivityEpoch uint64,
+	expiryEpoch uint64,
+	registrationEpoch uint64,
+	currentEpoch uint64,
+	inactivityPeriod uint64,
+) (retired bool, expired bool, lastActive uint64) {
+	retired = !active
+	lastActive = lastActivityEpoch
+	if lastActive == 0 {
+		lastActive = registrationEpoch
+	}
+	expiry := expiryEpoch
+	if expiry == 0 && inactivityPeriod > 0 {
+		expiry = lastActive + inactivityPeriod
+	}
+	expired = !retired && expiry > 0 && expiry <= currentEpoch
+	return retired, expired, lastActive
 }
 
 func (a *NodeAdapter) drepByCredentialTag(
@@ -1195,32 +1262,366 @@ func (a *NodeAdapter) drepByCredentialTag(
 		)
 	}
 
-	registrationEpoch, err := a.ledgerState.SlotToEpoch(drep.AddedSlot)
+	// The most recent registration certificate is the active_epoch
+	// source; drep.added_slot is overwritten by update and
+	// deregistration certificates. Rows without certificate history
+	// (core mode or pre-backfill databases) fall back to added_slot.
+	regSlot, err := db.Metadata().GetDrepLastRegistrationSlot(
+		credentialTag, credential.Hash, nil,
+	)
+	if err != nil {
+		return DRepInfo{}, fmt.Errorf(
+			"get drep last registration slot %x: %w",
+			credential.Hash,
+			err,
+		)
+	}
+	if regSlot == 0 {
+		regSlot = drep.AddedSlot
+	}
+	registrationEpoch, err := a.ledgerState.SlotToEpoch(regSlot)
 	if err != nil {
 		return DRepInfo{}, fmt.Errorf(
 			"get DRep registration epoch for slot %d: %w",
-			drep.AddedSlot,
+			regSlot,
 			err,
 		)
 	}
 
-	currentEpoch := a.ledgerState.CurrentEpoch()
-	registered := drep.Active
-	active := registered &&
-		(drep.ExpiryEpoch == 0 || drep.ExpiryEpoch > currentEpoch)
-	amount := strconv.FormatUint(power, 10)
+	retired, expired, lastActive := drepStatus(
+		drep.Active,
+		drep.LastActivityEpoch,
+		drep.ExpiryEpoch,
+		registrationEpoch.EpochId,
+		a.ledgerState.CurrentEpoch(),
+		a.drepInactivityPeriod(),
+	)
 
+	// Echo the identifier form the caller used: CIP-129 inputs carry
+	// the credential-type prefix byte in hex, legacy inputs the bare
+	// 28-byte hash.
+	hexID := hex.EncodeToString(credential.Hash)
+	if credential.CredentialTagKnown {
+		hexID = hex.EncodeToString(
+			append(
+				[]byte{cip129DRepHeader(hasScript)},
+				credential.Hash...,
+			),
+		)
+	}
+
+	regEpoch := registrationEpoch.EpochId
 	return DRepInfo{
-		DRepID:      credential.ID,
-		Hex:         hex.EncodeToString(credential.Hash),
-		HasScript:   hasScript,
-		Registered:  registered,
-		Epoch:       registrationEpoch.EpochId,
-		Amount:      amount,
-		Active:      active,
-		ActiveEpoch: drep.LastActivityEpoch,
-		LiveStake:   amount,
+		DRepID:          credential.ID,
+		Hex:             hexID,
+		Amount:          strconv.FormatUint(power, 10),
+		Active:          !retired,
+		ActiveEpoch:     &regEpoch,
+		HasScript:       hasScript,
+		Retired:         retired,
+		Expired:         expired,
+		LastActiveEpoch: &lastActive,
 	}, nil
+}
+
+// cip129DRepHeader returns the CIP-129 governance-credential header
+// byte for a DRep: 0x22 for a key-hash credential, 0x23 for a script
+// hash.
+func cip129DRepHeader(hasScript bool) byte {
+	if hasScript {
+		return 0x23
+	}
+	return 0x22
+}
+
+// DReps returns the paginated DRep list. Default ordering follows the
+// credential's first on-chain appearance; order_by=amount sorts by
+// delegated voting power with appearance order as the tie-break. The
+// special always-abstain / always-no-confidence DReps are interleaved
+// at the position of their first delegation, matching hosted
+// Blockfrost.
+func (a *NodeAdapter) DReps(
+	params DRepListParams,
+) ([]DRepListItemInfo, int, error) {
+	db := a.ledgerState.Database()
+	// Read every query from one snapshot so a block committed
+	// mid-request cannot mix two chain states in the response.
+	txn := db.Transaction(false)
+	defer txn.Release()
+	meta := db.Metadata()
+
+	dreps, err := meta.GetDreps(txn.Metadata())
+	if err != nil {
+		return nil, 0, fmt.Errorf("get dreps: %w", err)
+	}
+
+	// Slot-to-epoch resolution walks the epoch table once instead of
+	// querying per DRep.
+	epochs, err := meta.GetEpochs(txn.Metadata())
+	if err != nil {
+		return nil, 0, fmt.Errorf("get epochs: %w", err)
+	}
+	epochForSlot := func(slot uint64) uint64 {
+		id := uint64(0)
+		for i := range epochs {
+			if epochs[i].StartSlot > slot {
+				break
+			}
+			id = epochs[i].EpochId
+		}
+		return id
+	}
+
+	currentEpoch := a.ledgerState.CurrentEpoch()
+	inactivity := a.drepInactivityPeriod()
+
+	type entry struct {
+		predefined *uint64
+		credential []byte
+		tag        uint8
+		id         uint
+		firstSeen  uint64
+		anchorURL  string
+		anchorHash []byte
+		retired    bool
+		expired    bool
+		lastActive *uint64
+		amount     uint64
+	}
+	entries := make([]entry, 0, len(dreps)+2)
+	for i := range dreps {
+		drep := dreps[i]
+		// The most recent registration certificate is the
+		// active_epoch source; drep.added_slot is overwritten by
+		// update and deregistration certificates.
+		regSlot := drep.LastRegistrationSlot
+		if regSlot == 0 {
+			regSlot = drep.AddedSlot
+		}
+		retired, expired, lastActive := drepStatus(
+			drep.Active,
+			drep.LastActivityEpoch,
+			drep.ExpiryEpoch,
+			epochForSlot(regSlot),
+			currentEpoch,
+			inactivity,
+		)
+		entries = append(entries, entry{
+			credential: drep.Credential,
+			tag:        drep.CredentialTag,
+			id:         drep.ID,
+			firstSeen:  drep.FirstSeenSlot,
+			anchorURL:  drep.AnchorURL,
+			anchorHash: drep.AnchorHash,
+			retired:    retired,
+			expired:    expired,
+			lastActive: &lastActive,
+		})
+	}
+	// The special DReps appear at the position of their first
+	// delegation. They never register, retire, or expire.
+	specialSlots, err := meta.GetPredefinedDrepFirstSeenSlots(
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get predefined drep first seen slots: %w", err,
+		)
+	}
+	for _, drepType := range []uint64{
+		models.DrepTypeAlwaysAbstain,
+		models.DrepTypeAlwaysNoConfidence,
+	} {
+		slot, ok := specialSlots[drepType]
+		if !ok {
+			continue
+		}
+		dt := drepType
+		entries = append(entries, entry{
+			predefined: &dt,
+			firstSeen:  slot,
+		})
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].firstSeen != entries[j].firstSeen {
+			return entries[i].firstSeen < entries[j].firstSeen
+		}
+		return entries[i].id < entries[j].id
+	})
+
+	filtered := entries[:0]
+	for _, item := range entries {
+		if params.Retired != nil && item.retired != *params.Retired {
+			continue
+		}
+		if params.Expired != nil && item.expired != *params.Expired {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	entries = filtered
+	total := len(entries)
+
+	fillAmounts := func(items []entry) error {
+		refs := make([]models.StakeCredentialRef, 0, len(items))
+		specialTypes := make([]uint64, 0, 2)
+		for i := range items {
+			if items[i].predefined != nil {
+				specialTypes = append(
+					specialTypes, *items[i].predefined,
+				)
+				continue
+			}
+			refs = append(refs, models.StakeCredentialRef{
+				Tag: items[i].tag,
+				Key: items[i].credential,
+			})
+		}
+		powers := map[string]uint64{}
+		if len(refs) > 0 {
+			powers, err = meta.GetDRepVotingPowerBatch(
+				refs, 0, txn.Metadata(),
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"get drep voting power batch: %w", err,
+				)
+			}
+		}
+		typePowers := map[uint64]uint64{}
+		if len(specialTypes) > 0 {
+			typePowers, err = meta.GetDRepVotingPowerByType(
+				specialTypes, 0, txn.Metadata(),
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"get predefined drep voting power: %w", err,
+				)
+			}
+		}
+		for i := range items {
+			if items[i].predefined != nil {
+				items[i].amount = typePowers[*items[i].predefined]
+				continue
+			}
+			ref := models.StakeCredentialRef{
+				Tag: items[i].tag,
+				Key: items[i].credential,
+			}
+			items[i].amount = powers[ref.MapKey()]
+		}
+		return nil
+	}
+
+	desc := params.Pagination.Order == PaginationOrderDesc
+	if params.OrderByAmount {
+		// Amount ordering needs every candidate's voting power
+		// before pagination.
+		if err := fillAmounts(entries); err != nil {
+			return nil, 0, err
+		}
+		sort.SliceStable(entries, func(i, j int) bool {
+			if entries[i].amount != entries[j].amount {
+				if desc {
+					return entries[i].amount > entries[j].amount
+				}
+				return entries[i].amount < entries[j].amount
+			}
+			return entries[i].firstSeen < entries[j].firstSeen
+		})
+	} else if desc {
+		slices.Reverse(entries)
+	}
+
+	start := (params.Pagination.Page - 1) * params.Pagination.Count
+	if start >= len(entries) {
+		return []DRepListItemInfo{}, total, nil
+	}
+	end := min(start+params.Pagination.Count, len(entries))
+	page := entries[start:end]
+
+	if !params.OrderByAmount {
+		if err := fillAmounts(page); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	ret := make([]DRepListItemInfo, 0, len(page))
+	for i := range page {
+		item := &page[i]
+		if item.predefined != nil {
+			drepID := "drep_always_abstain"
+			if *item.predefined == models.DrepTypeAlwaysNoConfidence {
+				drepID = "drep_always_no_confidence"
+			}
+			ret = append(ret, DRepListItemInfo{
+				DRepID: drepID,
+				Hex:    "",
+				Amount: strconv.FormatUint(item.amount, 10),
+			})
+			continue
+		}
+		hasScript := item.tag == 1
+		payload := append(
+			[]byte{cip129DRepHeader(hasScript)},
+			item.credential...,
+		)
+		drepID, err := bech32EncodeData("drep", payload)
+		if err != nil {
+			return nil, 0, fmt.Errorf(
+				"encode drep id %x: %w",
+				item.credential,
+				err,
+			)
+		}
+		ret = append(ret, DRepListItemInfo{
+			DRepID:          drepID,
+			Hex:             hex.EncodeToString(payload),
+			Amount:          strconv.FormatUint(item.amount, 10),
+			HasScript:       hasScript,
+			Retired:         item.retired,
+			Expired:         item.expired,
+			LastActiveEpoch: item.lastActive,
+			Metadata: a.drepAnchorMetadata(
+				item.anchorURL, item.anchorHash, txn.Metadata(),
+			),
+		})
+	}
+	return ret, total, nil
+}
+
+// drepAnchorMetadata resolves a DRep's anchor document from the
+// off-chain metadata cache. It returns nil when the DRep has no anchor
+// or the document has not been fetched successfully; cache lookup
+// failures degrade to nil rather than failing the listing.
+func (a *NodeAdapter) drepAnchorMetadata(
+	anchorURL string,
+	anchorHash []byte,
+	txn dbtypes.Txn,
+) *DRepMetadataInfo {
+	if anchorURL == "" {
+		return nil
+	}
+	doc, err := a.ledgerState.Database().Metadata().GetOffchainMetadata(
+		models.OffchainMetadataSourceDrep,
+		anchorURL,
+		anchorHash,
+		txn,
+	)
+	if err != nil || doc == nil ||
+		doc.Status != models.OffchainMetadataStatusFetched ||
+		len(doc.Content) == 0 {
+		return nil
+	}
+	ret := &DRepMetadataInfo{
+		URL:   anchorURL,
+		Hash:  hex.EncodeToString(anchorHash),
+		Bytes: "\\x" + hex.EncodeToString(doc.Content),
+	}
+	if json.Valid(doc.Content) {
+		ret.JSONMetadata = json.RawMessage(doc.Content)
+	}
+	return ret
 }
 
 func (a *NodeAdapter) latestBlockData(

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -117,6 +117,10 @@ func (b *Blockfrost) handler() http.Handler {
 		b.handlePoolsExtended,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/governance/dreps",
+		b.handleDReps,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/governance/dreps/{drep_id}",
 		b.handleDRep,
 	)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -72,6 +72,9 @@ type mockNode struct {
 	assetAddressesAssetName       []byte
 	assetAddressesParams          PaginationParams
 	drep                          DRepInfo
+	drepList                      []DRepListItemInfo
+	drepListTotal                 int
+	drepListParams                DRepListParams
 	drepCredential                DRepCredential
 	addressUTXOs                  []AddressUTXOInfo
 	addressTransactions           []AddressTransactionInfo
@@ -114,6 +117,7 @@ type mockNode struct {
 	assetErr                      error
 	assetAddressesErr             error
 	drepErr                       error
+	drepListErr                   error
 	addressUTXOsErr               error
 	addressTransactionsErr        error
 	metadataJSONErr               error
@@ -228,6 +232,13 @@ func (m *mockNode) DRep(
 ) (DRepInfo, error) {
 	m.drepCredential = credential
 	return m.drep, m.drepErr
+}
+
+func (m *mockNode) DReps(
+	params DRepListParams,
+) ([]DRepListItemInfo, int, error) {
+	m.drepListParams = params
+	return m.drepList, m.drepListTotal, m.drepListErr
 }
 
 func (m *mockNode) AddressUTXOs(
@@ -980,17 +991,19 @@ func TestHandleDRep(t *testing.T) {
 	const drepHex = "00000000000000000000000000000000000000000000000000000000"
 	const drepID = drepHex
 
+	activeEpoch := uint64(12)
+	lastActive := uint64(14)
 	mock := &mockNode{
 		drep: DRepInfo{
-			DRepID:      drepID,
-			Hex:         drepHex,
-			HasScript:   false,
-			Registered:  true,
-			Epoch:       12,
-			Amount:      "123456",
-			Active:      true,
-			ActiveEpoch: 14,
-			LiveStake:   "123456",
+			DRepID:          drepID,
+			Hex:             drepHex,
+			Amount:          "123456",
+			Active:          true,
+			ActiveEpoch:     &activeEpoch,
+			HasScript:       false,
+			Retired:         false,
+			Expired:         true,
+			LastActiveEpoch: &lastActive,
 		},
 	}
 	b := newTestBlockfrost(mock)
@@ -1012,18 +1025,121 @@ func TestHandleDRep(t *testing.T) {
 	assert.Equal(t, mock.drep.DRepID, resp.DRepID)
 	assert.Equal(t, mock.drep.Hex, resp.Hex)
 	assert.Equal(t, mock.drep.HasScript, resp.HasScript)
-	assert.Equal(t, mock.drep.Registered, resp.Registered)
-	assert.Equal(t, mock.drep.Epoch, resp.Epoch)
 	assert.Equal(t, mock.drep.Amount, resp.Amount)
 	assert.Equal(t, mock.drep.Active, resp.Active)
-	assert.Equal(t, mock.drep.ActiveEpoch, resp.ActiveEpoch)
-	assert.Equal(t, mock.drep.LiveStake, resp.LiveStake)
+	require.NotNil(t, resp.ActiveEpoch)
+	assert.Equal(t, activeEpoch, *resp.ActiveEpoch)
+	assert.False(t, resp.Retired)
+	assert.True(t, resp.Expired)
+	require.NotNil(t, resp.LastActiveEpoch)
+	assert.Equal(t, lastActive, *resp.LastActiveEpoch)
+}
+
+func TestHandleDReps(t *testing.T) {
+	lastActive := uint64(680)
+	mock := &mockNode{
+		drepListTotal: 42,
+		drepList: []DRepListItemInfo{
+			{
+				DRepID:          "drep1y2zpa7e9f23g7snuhfqss73ufeshsqhdt4qqfu74p9y4kfqcpsxym",
+				Hex:             "22841efb254aa28f427cba41087a3c4e617802ed5d4004f3d509495b24",
+				Amount:          "1000000",
+				HasScript:       false,
+				Retired:         false,
+				Expired:         true,
+				LastActiveEpoch: &lastActive,
+				Metadata: &DRepMetadataInfo{
+					URL:          "https://example.com/drep.json",
+					Hash:         "aa",
+					JSONMetadata: json.RawMessage(`{"a":1}`),
+					Bytes:        "\\x7b2261223a317d",
+				},
+			},
+			{
+				DRepID: "drep1yvvxuvh64q9zdqgrjt76d42eclk5wgdxtnsun4808cwg0dquhj65s",
+				Hex:    "23186e32faa80a26810392fda6d559c7ed4721a65ce1c9d4ef3e1c87b4",
+				Amount: "0", HasScript: true, Retired: true,
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/governance/dreps?count=2&order_by=amount&order=desc&retired=false",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleDReps(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "42", w.Header().Get("X-Pagination-Count-Total"))
+	assert.True(t, mock.drepListParams.OrderByAmount)
+	require.NotNil(t, mock.drepListParams.Retired)
+	assert.False(t, *mock.drepListParams.Retired)
+	assert.Nil(t, mock.drepListParams.Expired)
+	assert.Equal(t, PaginationOrderDesc, mock.drepListParams.Pagination.Order)
+
+	var resp []DRepListItemResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp, 2)
+	assert.Equal(t, "1000000", resp[0].Amount)
+	require.NotNil(t, resp[0].Metadata)
+	assert.Equal(t, "https://example.com/drep.json", resp[0].Metadata.URL)
+	assert.Nil(t, resp[1].Metadata)
+	assert.True(t, resp[1].Retired)
+}
+
+func TestHandleDRepsInvalidParams(t *testing.T) {
+	cases := []struct {
+		query   string
+		message string
+	}{
+		{"order=a", "querystring/order must be equal to one of the allowed values"},
+		{"page=x", "querystring/page must be integer"},
+		{"page=0", "querystring/page must be >= 1"},
+		{"page=99999999999999", "querystring/page must be <= 21474836"},
+		{"count=x", "querystring/count must be integer"},
+		{"count=999999999999999", "querystring/count must be <= 100"},
+		{"count=0", "querystring/count must be >= 1"},
+		{"order_by=bogus", "querystring/order_by must be equal to one of the allowed values"},
+		{"retired=x", "querystring/retired must be boolean"},
+		{"expired=x", "querystring/expired must be boolean"},
+	}
+	b := newTestBlockfrost(&mockNode{})
+	for _, tc := range cases {
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/v0/governance/dreps?"+tc.query,
+			nil,
+		)
+		w := httptest.NewRecorder()
+		b.handleDReps(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code, tc.query)
+		var resp ErrorResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), tc.query)
+		assert.Equal(t, tc.message, resp.Message, tc.query)
+	}
+}
+
+func TestParseDRepIdentifierSpecial(t *testing.T) {
+	cred, err := parseDRepIdentifier("drep_always_abstain")
+	require.NoError(t, err)
+	require.NotNil(t, cred.Predefined)
+	assert.Equal(t, models.DrepTypeAlwaysAbstain, *cred.Predefined)
+
+	cred, err = parseDRepIdentifier("drep_always_no_confidence")
+	require.NoError(t, err)
+	require.NotNil(t, cred.Predefined)
+	assert.Equal(t, models.DrepTypeAlwaysNoConfidence, *cred.Predefined)
 }
 
 // TestHandleDRepCIP129ScriptIdentifier verifies script DRep IDs keep their
 // credential type when the HTTP handler passes them to the node adapter.
 func TestHandleDRepCIP129ScriptIdentifier(t *testing.T) {
-	const drepID = "drep1xvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhknfj5"
+	const drepID = "drep1yvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq770f95"
 	const drepHex = "00000000000000000000000000000000000000000000000000000000"
 
 	mock := &mockNode{
@@ -1065,7 +1181,7 @@ func TestParseDRepIdentifierCIP129CredentialType(t *testing.T) {
 		},
 		{
 			name:          "script",
-			id:            "drep1xvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhknfj5",
+			id:            "drep1yvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq770f95",
 			wantHasScript: true,
 		},
 	}

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -685,6 +685,99 @@ func (b *Blockfrost) handleDRep(
 	writeJSON(w, http.StatusOK, DRepResponse(drep))
 }
 
+// handleDReps handles GET /api/v0/governance/dreps and returns the
+// paginated list of registered DReps.
+func (b *Blockfrost) handleDReps(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	pagination, errMsg := ParsePaginationStrict(r)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, "Bad Request", errMsg)
+		return
+	}
+	params := DRepListParams{Pagination: pagination}
+
+	query := r.URL.Query()
+	switch query.Get("order_by") {
+	case "", "amount":
+		params.OrderByAmount = query.Get("order_by") == "amount"
+	default:
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"querystring/order_by must be equal to one of the allowed values",
+		)
+		return
+	}
+	for _, flag := range []struct {
+		name string
+		dest **bool
+	}{
+		{"retired", &params.Retired},
+		{"expired", &params.Expired},
+	} {
+		switch query.Get(flag.name) {
+		case "":
+		case "true":
+			v := true
+			*flag.dest = &v
+		case "false":
+			v := false
+			*flag.dest = &v
+		default:
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"querystring/"+flag.name+" must be boolean",
+			)
+			return
+		}
+	}
+
+	items, total, err := b.node.DReps(params)
+	if err != nil {
+		b.logger.Error(
+			"failed to list dreps",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve DReps",
+		)
+		return
+	}
+
+	SetPaginationHeaders(w, total, pagination)
+	resp := make([]DRepListItemResponse, 0, len(items))
+	for _, item := range items {
+		var metadata *DRepMetadataResponse
+		if item.Metadata != nil {
+			metadata = &DRepMetadataResponse{
+				URL:          item.Metadata.URL,
+				Hash:         item.Metadata.Hash,
+				JSONMetadata: item.Metadata.JSONMetadata,
+				Bytes:        item.Metadata.Bytes,
+			}
+		}
+		resp = append(resp, DRepListItemResponse{
+			DRepID:          item.DRepID,
+			Hex:             item.Hex,
+			Amount:          item.Amount,
+			HasScript:       item.HasScript,
+			Retired:         item.Retired,
+			Expired:         item.Expired,
+			LastActiveEpoch: item.LastActiveEpoch,
+			Metadata:        metadata,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // handleAddressUTXOs handles GET /api/v0/addresses/{address}/utxos
 // and returns the current UTxOs for an address.
 func (b *Blockfrost) handleAddressUTXOs(
@@ -1587,6 +1680,15 @@ func parseDRepIdentifier(
 	if id == "" {
 		return DRepCredential{}, errors.New("empty DRep identifier")
 	}
+	// The special DReps carry no credential hash.
+	switch id {
+	case "drep_always_abstain":
+		drepType := models.DrepTypeAlwaysAbstain
+		return DRepCredential{ID: id, Predefined: &drepType}, nil
+	case "drep_always_no_confidence":
+		drepType := models.DrepTypeAlwaysNoConfidence
+		return DRepCredential{ID: id, Predefined: &drepType}, nil
+	}
 	// Blockfrost accepts the raw credential hash as hex. Storage uses the
 	// raw 28-byte hash for lookup.
 	if len(id) == drepCredentialHexLen {
@@ -1644,27 +1746,25 @@ func parseDRepIdentifier(
 }
 
 func parseCIP129DRepScriptFlag(header byte) (bool, error) {
+	// CIP-129 header: high nibble is the governance credential kind
+	// (0x2 = DRep), low nibble the credential type (0x2 = key hash,
+	// 0x3 = script hash) — so 0x22 is a key DRep and 0x23 a script
+	// DRep.
 	voterType := header >> 4
 	credentialNibble := header & 0x0f
-	switch voterType {
-	case 2:
-		if credentialNibble != 0x2 {
-			return false, fmt.Errorf(
-				"invalid DRep key credential nibble 0x%x",
-				credentialNibble,
-			)
-		}
+	if voterType != 0x2 {
+		return false, fmt.Errorf("invalid DRep voter type %d", voterType)
+	}
+	switch credentialNibble {
+	case 0x2:
 		return false, nil
-	case 3:
-		if credentialNibble != 0x3 {
-			return false, fmt.Errorf(
-				"invalid DRep script credential nibble 0x%x",
-				credentialNibble,
-			)
-		}
+	case 0x3:
 		return true, nil
 	default:
-		return false, fmt.Errorf("invalid DRep voter type %d", voterType)
+		return false, fmt.Errorf(
+			"invalid DRep credential nibble 0x%x",
+			credentialNibble,
+		)
 	}
 }
 

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -152,6 +152,10 @@ type BlockfrostNode interface {
 	// DRep credential.
 	DRep(DRepCredential) (DRepInfo, error)
 
+	// DReps returns the paginated DRep list along with the total
+	// number of matching results before pagination.
+	DReps(DRepListParams) ([]DRepListItemInfo, int, error)
+
 	// Account returns stake-account information for the
 	// requested stake address.
 	Account(string) (AccountInfo, error)
@@ -602,19 +606,54 @@ type DRepCredential struct {
 	Hash               []byte
 	HasScript          bool
 	CredentialTagKnown bool
+	// Predefined is set for the special DReps
+	// (drep_always_abstain, drep_always_no_confidence), which carry
+	// no credential hash. The value is a models.DrepType* constant.
+	Predefined *uint64
 }
 
-// DRepInfo holds DRep data needed by the governance API.
+// DRepInfo holds DRep data needed by the governance API,
+// following the Blockfrost OpenAPI 0.1.90 drep schema.
 type DRepInfo struct {
-	DRepID      string
-	Hex         string
-	HasScript   bool
-	Registered  bool
-	Epoch       uint64
-	Amount      string
-	Active      bool
-	ActiveEpoch uint64
-	LiveStake   string
+	DRepID          string
+	Hex             string
+	Amount          string
+	Active          bool
+	ActiveEpoch     *uint64
+	HasScript       bool
+	Retired         bool
+	Expired         bool
+	LastActiveEpoch *uint64
+}
+
+// DRepListParams holds query parameters for the DRep list endpoint.
+type DRepListParams struct {
+	Pagination    PaginationParams
+	OrderByAmount bool
+	Retired       *bool
+	Expired       *bool
+}
+
+// DRepListItemInfo is one entry of the DRep list endpoint. Unlike
+// DRepInfo it always uses CIP-129 identifiers and carries the
+// resolved anchor metadata.
+type DRepListItemInfo struct {
+	DRepID          string
+	Hex             string
+	Amount          string
+	HasScript       bool
+	Retired         bool
+	Expired         bool
+	LastActiveEpoch *uint64
+	Metadata        *DRepMetadataInfo
+}
+
+// DRepMetadataInfo is the resolved CIP-119 anchor document for a DRep.
+type DRepMetadataInfo struct {
+	URL          string
+	Hash         string
+	JSONMetadata json.RawMessage
+	Bytes        string
 }
 
 // AccountInfo holds stake-account data needed by the API.

--- a/api/blockfrost/pagination.go
+++ b/api/blockfrost/pagination.go
@@ -95,6 +95,63 @@ func ParsePagination(r *http.Request) (PaginationParams, error) {
 	return params, nil
 }
 
+// MaxPaginationPage mirrors the hosted Blockfrost fastify schema bound
+// for the page parameter.
+const MaxPaginationPage = 21474836
+
+// ParsePaginationStrict parses pagination query parameters with
+// Blockfrost-compatible validation: out-of-range values are rejected with
+// the hosted API's exact fastify error message instead of being clamped.
+// The second return value is the error message, empty when parsing
+// succeeded.
+func ParsePaginationStrict(r *http.Request) (PaginationParams, string) {
+	params := PaginationParams{
+		Count: DefaultPaginationCount,
+		Page:  DefaultPaginationPage,
+		Order: PaginationOrderAsc,
+	}
+
+	query := r.URL.Query()
+	if countParam := query.Get("count"); countParam != "" {
+		count, err := strconv.Atoi(countParam)
+		if err != nil {
+			return params, "querystring/count must be integer"
+		}
+		if count > MaxPaginationCount {
+			return params, "querystring/count must be <= 100"
+		}
+		if count < 1 {
+			return params, "querystring/count must be >= 1"
+		}
+		params.Count = count
+	}
+
+	if pageParam := query.Get("page"); pageParam != "" {
+		page, err := strconv.Atoi(pageParam)
+		if err != nil {
+			return params, "querystring/page must be integer"
+		}
+		if page > MaxPaginationPage {
+			return params, "querystring/page must be <= 21474836"
+		}
+		if page < 1 {
+			return params, "querystring/page must be >= 1"
+		}
+		params.Page = page
+	}
+
+	if orderParam := query.Get("order"); orderParam != "" {
+		switch strings.ToLower(orderParam) {
+		case PaginationOrderAsc, PaginationOrderDesc:
+			params.Order = strings.ToLower(orderParam)
+		default:
+			return params, "querystring/order must be equal to one of the allowed values"
+		}
+	}
+
+	return params, ""
+}
+
 // SetPaginationHeaders sets Blockfrost pagination headers.
 func SetPaginationHeaders(
 	w http.ResponseWriter,

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -247,17 +247,40 @@ type AssetResponse struct {
 	Metadata                *any    `json:"metadata"`
 }
 
-// DRepResponse represents a Blockfrost governance DRep object.
+// DRepResponse represents a Blockfrost governance DRep object
+// (OpenAPI 0.1.90 drep schema; active and active_epoch are deprecated
+// there but remain required).
 type DRepResponse struct {
-	DRepID      string `json:"drep_id"`
-	Hex         string `json:"hex"`
-	HasScript   bool   `json:"has_script"`
-	Registered  bool   `json:"registered"`
-	Epoch       uint64 `json:"epoch"`
-	Amount      string `json:"amount"`
-	Active      bool   `json:"active"`
-	ActiveEpoch uint64 `json:"active_epoch"`
-	LiveStake   string `json:"live_stake"`
+	DRepID          string  `json:"drep_id"`
+	Hex             string  `json:"hex"`
+	Amount          string  `json:"amount"`
+	Active          bool    `json:"active"`
+	ActiveEpoch     *uint64 `json:"active_epoch"`
+	HasScript       bool    `json:"has_script"`
+	Retired         bool    `json:"retired"`
+	Expired         bool    `json:"expired"`
+	LastActiveEpoch *uint64 `json:"last_active_epoch"`
+}
+
+// DRepListItemResponse is one entry of the Blockfrost DRep list.
+type DRepListItemResponse struct {
+	DRepID          string                `json:"drep_id"`
+	Hex             string                `json:"hex"`
+	Amount          string                `json:"amount"`
+	HasScript       bool                  `json:"has_script"`
+	Retired         bool                  `json:"retired"`
+	Expired         bool                  `json:"expired"`
+	LastActiveEpoch *uint64               `json:"last_active_epoch"`
+	Metadata        *DRepMetadataResponse `json:"metadata"`
+}
+
+// DRepMetadataResponse is the resolved CIP-119 anchor document
+// attached to a DRep list entry.
+type DRepMetadataResponse struct {
+	URL          string          `json:"url"`
+	Hash         string          `json:"hash"`
+	JSONMetadata json.RawMessage `json:"json_metadata"`
+	Bytes        string          `json:"bytes"`
 }
 
 // ErrorResponse represents a Blockfrost error response.

--- a/database/models/drep.go
+++ b/database/models/drep.go
@@ -46,6 +46,25 @@ type Drep struct {
 	Active      bool   `gorm:"default:true;index:idx_drep_active"`
 }
 
+// DrepListRow is a Drep row extended with the credential's first
+// on-chain appearance slot, as returned by GetDreps for
+// registration-order listings.
+type DrepListRow struct {
+	AnchorURL         string `gorm:"column:anchor_url"`
+	Credential        []byte
+	AnchorHash        []byte
+	ID                uint
+	AddedSlot         uint64
+	CredentialTag     uint8
+	LastActivityEpoch uint64
+	ExpiryEpoch       uint64
+	Active            bool
+	FirstSeenSlot     uint64
+	// LastRegistrationSlot is the added_slot of the most recent
+	// registration certificate, 0 when no cert history exists.
+	LastRegistrationSlot uint64
+}
+
 // MigrateDrepCredentialTagIndex drops the legacy hash-only DRep uniqueness
 // constraint before AutoMigrate installs the tag-aware composite unique index.
 func MigrateDrepCredentialTagIndex(db *gorm.DB, logger *slog.Logger) error {

--- a/database/plugin/metadata/mysql/drep.go
+++ b/database/plugin/metadata/mysql/drep.go
@@ -776,3 +776,130 @@ func (d *MetadataStoreMysql) RestoreDrepStateAtSlot(
 
 	return nil
 }
+
+// GetDreps retrieves every DRep row, including deregistered ones,
+// ordered by registration (added_slot, then insertion id).
+func (d *MetadataStoreMysql) GetDreps(
+	txn types.Txn,
+) ([]models.DrepListRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var dreps []models.DrepListRow
+	// Order by first on-chain appearance of the credential (earliest
+	// registration, update, or delegation reference), which survives
+	// deregister/re-register cycles and matches hosted Blockfrost's
+	// db-sync row ordering. Rows without cert history (core-mode or
+	// pre-backfill databases) fall back to the current registration
+	// slot.
+	const firstSeenSQL = `
+		WITH first_seen AS (
+			SELECT cred, tag, MIN(slot) AS slot FROM (
+				SELECT drep_credential AS cred, credential_tag AS tag,
+				       MIN(added_slot) AS slot
+				FROM registration_drep GROUP BY drep_credential, credential_tag
+				UNION ALL SELECT credential, credential_tag, MIN(added_slot)
+				FROM update_drep GROUP BY credential, credential_tag
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM stake_vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM stake_vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+			) u GROUP BY cred, tag
+		),
+		last_reg AS (
+			-- certificate_id filters out the synthetic rows the
+			-- Mithril ledger-state import writes at the bootstrap
+			-- slot; only real on-chain certificates count.
+			SELECT drep_credential AS cred, credential_tag AS tag,
+			       MAX(added_slot) AS slot
+			FROM registration_drep
+			WHERE certificate_id IS NOT NULL AND certificate_id != 0
+			GROUP BY drep_credential, credential_tag
+		)
+		SELECT drep.*, COALESCE(first_seen.slot, drep.added_slot) AS first_seen_slot,
+		       COALESCE(last_reg.slot, 0) AS last_registration_slot
+		FROM drep
+		LEFT JOIN first_seen
+			ON first_seen.cred = drep.credential
+			AND first_seen.tag = drep.credential_tag
+		LEFT JOIN last_reg
+			ON last_reg.cred = drep.credential
+			AND last_reg.tag = drep.credential_tag
+		ORDER BY COALESCE(first_seen.slot, drep.added_slot), drep.id`
+	if err := db.Raw(firstSeenSQL).Scan(&dreps).Error; err != nil {
+		return nil, fmt.Errorf("get dreps: %w", err)
+	}
+	return dreps, nil
+}
+
+// GetPredefinedDrepFirstSeenSlots returns the earliest delegation
+// added_slot per predefined DRep type (AlwaysAbstain,
+// AlwaysNoConfidence). Types never delegated to are absent.
+func (d *MetadataStoreMysql) GetPredefinedDrepFirstSeenSlots(
+	txn types.Txn,
+) (map[uint64]uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		DrepType uint64
+		Slot     uint64
+	}
+	var rows []row
+	const sql = `
+		SELECT drep_type, MIN(slot) AS slot FROM (
+			SELECT drep_type, MIN(added_slot) AS slot
+			FROM vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM stake_vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM stake_vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+		) u GROUP BY drep_type`
+	if err := db.Raw(sql).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get predefined drep first seen slots: %w", err,
+		)
+	}
+	out := make(map[uint64]uint64, len(rows))
+	for _, r := range rows {
+		out[r.DrepType] = r.Slot
+	}
+	return out, nil
+}
+
+// GetDrepLastRegistrationSlot returns the added_slot of the most recent
+// registration certificate for the DRep credential, or 0 when no
+// registration certificate history exists.
+func (d *MetadataStoreMysql) GetDrepLastRegistrationSlot(
+	credentialTag uint8,
+	credential []byte,
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	var slot uint64
+	if err := db.Model(&models.RegistrationDrep{}).
+		Where(
+			"credential_tag = ? AND drep_credential = ? "+
+				"AND certificate_id IS NOT NULL AND certificate_id != 0",
+			credentialTag,
+			credential,
+		).
+		Select("COALESCE(MAX(added_slot), 0)").
+		Scan(&slot).Error; err != nil {
+		return 0, fmt.Errorf(
+			"get drep last registration slot: %w", err,
+		)
+	}
+	return slot, nil
+}

--- a/database/plugin/metadata/postgres/drep.go
+++ b/database/plugin/metadata/postgres/drep.go
@@ -745,3 +745,130 @@ func (d *MetadataStorePostgres) RestoreDrepStateAtSlot(
 
 	return nil
 }
+
+// GetDreps retrieves every DRep row, including deregistered ones,
+// ordered by registration (added_slot, then insertion id).
+func (d *MetadataStorePostgres) GetDreps(
+	txn types.Txn,
+) ([]models.DrepListRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var dreps []models.DrepListRow
+	// Order by first on-chain appearance of the credential (earliest
+	// registration, update, or delegation reference), which survives
+	// deregister/re-register cycles and matches hosted Blockfrost's
+	// db-sync row ordering. Rows without cert history (core-mode or
+	// pre-backfill databases) fall back to the current registration
+	// slot.
+	const firstSeenSQL = `
+		WITH first_seen AS (
+			SELECT cred, tag, MIN(slot) AS slot FROM (
+				SELECT drep_credential AS cred, credential_tag AS tag,
+				       MIN(added_slot) AS slot
+				FROM registration_drep GROUP BY drep_credential, credential_tag
+				UNION ALL SELECT credential, credential_tag, MIN(added_slot)
+				FROM update_drep GROUP BY credential, credential_tag
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM stake_vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM stake_vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+			) u GROUP BY cred, tag
+		),
+		last_reg AS (
+			-- certificate_id filters out the synthetic rows the
+			-- Mithril ledger-state import writes at the bootstrap
+			-- slot; only real on-chain certificates count.
+			SELECT drep_credential AS cred, credential_tag AS tag,
+			       MAX(added_slot) AS slot
+			FROM registration_drep
+			WHERE certificate_id IS NOT NULL AND certificate_id != 0
+			GROUP BY drep_credential, credential_tag
+		)
+		SELECT drep.*, COALESCE(first_seen.slot, drep.added_slot) AS first_seen_slot,
+		       COALESCE(last_reg.slot, 0) AS last_registration_slot
+		FROM drep
+		LEFT JOIN first_seen
+			ON first_seen.cred = drep.credential
+			AND first_seen.tag = drep.credential_tag
+		LEFT JOIN last_reg
+			ON last_reg.cred = drep.credential
+			AND last_reg.tag = drep.credential_tag
+		ORDER BY COALESCE(first_seen.slot, drep.added_slot), drep.id`
+	if err := db.Raw(firstSeenSQL).Scan(&dreps).Error; err != nil {
+		return nil, fmt.Errorf("get dreps: %w", err)
+	}
+	return dreps, nil
+}
+
+// GetPredefinedDrepFirstSeenSlots returns the earliest delegation
+// added_slot per predefined DRep type (AlwaysAbstain,
+// AlwaysNoConfidence). Types never delegated to are absent.
+func (d *MetadataStorePostgres) GetPredefinedDrepFirstSeenSlots(
+	txn types.Txn,
+) (map[uint64]uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		DrepType uint64
+		Slot     uint64
+	}
+	var rows []row
+	const sql = `
+		SELECT drep_type, MIN(slot) AS slot FROM (
+			SELECT drep_type, MIN(added_slot) AS slot
+			FROM vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM stake_vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM stake_vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+		) u GROUP BY drep_type`
+	if err := db.Raw(sql).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get predefined drep first seen slots: %w", err,
+		)
+	}
+	out := make(map[uint64]uint64, len(rows))
+	for _, r := range rows {
+		out[r.DrepType] = r.Slot
+	}
+	return out, nil
+}
+
+// GetDrepLastRegistrationSlot returns the added_slot of the most recent
+// registration certificate for the DRep credential, or 0 when no
+// registration certificate history exists.
+func (d *MetadataStorePostgres) GetDrepLastRegistrationSlot(
+	credentialTag uint8,
+	credential []byte,
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	var slot uint64
+	if err := db.Model(&models.RegistrationDrep{}).
+		Where(
+			"credential_tag = ? AND drep_credential = ? "+
+				"AND certificate_id IS NOT NULL AND certificate_id != 0",
+			credentialTag,
+			credential,
+		).
+		Select("COALESCE(MAX(added_slot), 0)").
+		Scan(&slot).Error; err != nil {
+		return 0, fmt.Errorf(
+			"get drep last registration slot: %w", err,
+		)
+	}
+	return slot, nil
+}

--- a/database/plugin/metadata/sqlite/drep.go
+++ b/database/plugin/metadata/sqlite/drep.go
@@ -827,3 +827,130 @@ func (d *MetadataStoreSqlite) GetCommitteeActiveCount(
 	}
 	return int(count), nil
 }
+
+// GetDreps retrieves every DRep row, including deregistered ones,
+// ordered by registration (added_slot, then insertion id).
+func (d *MetadataStoreSqlite) GetDreps(
+	txn types.Txn,
+) ([]models.DrepListRow, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	var dreps []models.DrepListRow
+	// Order by first on-chain appearance of the credential (earliest
+	// registration, update, or delegation reference), which survives
+	// deregister/re-register cycles and matches hosted Blockfrost's
+	// db-sync row ordering. Rows without cert history (core-mode or
+	// pre-backfill databases) fall back to the current registration
+	// slot.
+	const firstSeenSQL = `
+		WITH first_seen AS (
+			SELECT cred, tag, MIN(slot) AS slot FROM (
+				SELECT drep_credential AS cred, credential_tag AS tag,
+				       MIN(added_slot) AS slot
+				FROM registration_drep GROUP BY drep_credential, credential_tag
+				UNION ALL SELECT credential, credential_tag, MIN(added_slot)
+				FROM update_drep GROUP BY credential, credential_tag
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM stake_vote_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+				UNION ALL SELECT drep, drep_type, MIN(added_slot)
+				FROM stake_vote_registration_delegation WHERE drep_type <= 1 GROUP BY drep, drep_type
+			) u GROUP BY cred, tag
+		),
+		last_reg AS (
+			-- certificate_id filters out the synthetic rows the
+			-- Mithril ledger-state import writes at the bootstrap
+			-- slot; only real on-chain certificates count.
+			SELECT drep_credential AS cred, credential_tag AS tag,
+			       MAX(added_slot) AS slot
+			FROM registration_drep
+			WHERE certificate_id IS NOT NULL AND certificate_id != 0
+			GROUP BY drep_credential, credential_tag
+		)
+		SELECT drep.*, COALESCE(first_seen.slot, drep.added_slot) AS first_seen_slot,
+		       COALESCE(last_reg.slot, 0) AS last_registration_slot
+		FROM drep
+		LEFT JOIN first_seen
+			ON first_seen.cred = drep.credential
+			AND first_seen.tag = drep.credential_tag
+		LEFT JOIN last_reg
+			ON last_reg.cred = drep.credential
+			AND last_reg.tag = drep.credential_tag
+		ORDER BY COALESCE(first_seen.slot, drep.added_slot), drep.id`
+	if err := db.Raw(firstSeenSQL).Scan(&dreps).Error; err != nil {
+		return nil, fmt.Errorf("get dreps: %w", err)
+	}
+	return dreps, nil
+}
+
+// GetPredefinedDrepFirstSeenSlots returns the earliest delegation
+// added_slot per predefined DRep type (AlwaysAbstain,
+// AlwaysNoConfidence). Types never delegated to are absent.
+func (d *MetadataStoreSqlite) GetPredefinedDrepFirstSeenSlots(
+	txn types.Txn,
+) (map[uint64]uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	type row struct {
+		DrepType uint64
+		Slot     uint64
+	}
+	var rows []row
+	const sql = `
+		SELECT drep_type, MIN(slot) AS slot FROM (
+			SELECT drep_type, MIN(added_slot) AS slot
+			FROM vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM stake_vote_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+			UNION ALL SELECT drep_type, MIN(added_slot)
+			FROM stake_vote_registration_delegation WHERE drep_type >= 2 GROUP BY drep_type
+		) u GROUP BY drep_type`
+	if err := db.Raw(sql).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get predefined drep first seen slots: %w", err,
+		)
+	}
+	out := make(map[uint64]uint64, len(rows))
+	for _, r := range rows {
+		out[r.DrepType] = r.Slot
+	}
+	return out, nil
+}
+
+// GetDrepLastRegistrationSlot returns the added_slot of the most recent
+// registration certificate for the DRep credential, or 0 when no
+// registration certificate history exists.
+func (d *MetadataStoreSqlite) GetDrepLastRegistrationSlot(
+	credentialTag uint8,
+	credential []byte,
+	txn types.Txn,
+) (uint64, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, err
+	}
+	var slot uint64
+	if err := db.Model(&models.RegistrationDrep{}).
+		Where(
+			"credential_tag = ? AND drep_credential = ? "+
+				"AND certificate_id IS NOT NULL AND certificate_id != 0",
+			credentialTag,
+			credential,
+		).
+		Select("COALESCE(MAX(added_slot), 0)").
+		Scan(&slot).Error; err != nil {
+		return 0, fmt.Errorf(
+			"get drep last registration slot: %w", err,
+		)
+	}
+	return slot, nil
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -658,6 +658,29 @@ type MetadataStore interface {
 	// GetActiveDreps retrieves all active DReps.
 	GetActiveDreps(types.Txn) ([]*models.Drep, error)
 
+	// GetDreps retrieves every DRep row, including deregistered ones,
+	// ordered by the credential's first on-chain appearance (earliest
+	// registration, update, or delegation reference). Used by the
+	// Blockfrost DRep list endpoint.
+	GetDreps(types.Txn) ([]models.DrepListRow, error)
+
+	// GetPredefinedDrepFirstSeenSlots returns the earliest delegation
+	// added_slot per predefined DRep type (AlwaysAbstain,
+	// AlwaysNoConfidence). Types never delegated to are absent.
+	GetPredefinedDrepFirstSeenSlots(types.Txn) (map[uint64]uint64, error)
+
+	// GetDrepLastRegistrationSlot returns the added_slot of the most
+	// recent registration certificate for the DRep credential, or 0
+	// when no registration certificate history exists. Blockfrost's
+	// active_epoch reports the most recent registration, which the
+	// mutable drep.added_slot cannot provide because update and
+	// deregistration certificates overwrite it.
+	GetDrepLastRegistrationSlot(
+		uint8, // credentialTag
+		[]byte, // credential
+		types.Txn,
+	) (uint64, error)
+
 	// GetActiveAccountCredentials returns the stake credentials (tag + key) of
 	// every currently active account. Used by Mithril v2 catch-up
 	// reconciliation to find accounts absent from a newer snapshot's live set.


### PR DESCRIPTION
Adds GET /governance/dreps and updates /governance/dreps/{drep_id} to the current Blockfrost OpenAPI shape (0.1.90).

List endpoint:
- items use CIP-129 ids and carry amount, has_script, retired, expired, last_active_epoch and anchor metadata (from the off-chain metadata cache)
- supports count/page/order, order_by=amount, and retired/expired filters
- default order is the credential's first on-chain appearance, same as hosted Blockfrost. This survives deregister/re-register cycles.
- the special dreps (drep_always_abstain, drep_always_no_confidence) show up in the list at the position of their first delegation, like hosted
- query validation errors use the same messages as hosted

Detail endpoint:
- response now has amount, active, active_epoch, has_script, retired, expired, last_active_epoch. Drops the old registered/epoch/live_stake.
- active_epoch is the registration epoch, last_active_epoch falls back to it when there was no activity, and a missing expiry is derived from the drep_activity protocol parameter
- special dreps work on the detail endpoint too

Also fixes a CIP-129 parsing bug: script drep ids use header byte 0x23, not 0x33, so script ids like drep1yvvx... returned 400 before.

Checked against the blockfrost-tests preview suite for both routes: 28/28 pass. Detail responses for real dreps, CIP-129 ids and the special dreps match hosted Blockfrost byte for byte.

Fixes #2937
Fixes #2488
Tech-debt for later #2956

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the DRep list endpoint and aligns the DRep detail response with Blockfrost OpenAPI 0.1.90 for accurate fields, ordering, and metadata.

- **New Features**
  - Added GET /api/v0/governance/dreps with pagination, order_by=amount, and retired/expired filters; default order is the credential’s first on-chain appearance.
  - Items use CIP-129 IDs and include amount, has_script, retired, expired, last_active_epoch, and resolved anchor metadata from the off-chain cache.
  - Interleaves special DReps (drep_always_abstain, drep_always_no_confidence) at the slot of their first delegation.
  - Query validation matches hosted Blockfrost error messages; pagination parsing is now strict.
  - Updated GET /api/v0/governance/dreps/{drep_id}: returns amount, active, active_epoch, has_script, retired, expired, last_active_epoch; drops registered, epoch, live_stake. active_epoch is the most recent registration, and missing expiry derives from the drep_activity protocol parameter.

- **Bug Fixes**
  - Fixed CIP-129 DRep script header (0x23), allowing script DRep IDs to parse correctly.

<sup>Written for commit 2475cc19b764bddd3f65d35e1adb1895f1153697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Blockfrost-compatible DRep listing endpoint with pagination, filtering, ordering, and result counts.
  - Added support for predefined DReps: always abstain and always no confidence.
  - DRep listings now include lifecycle status, activity history, voting-power ordering, and optional anchor metadata.
  - DRep identifiers and script-based credentials now follow updated CIP-129 formatting.

- **Bug Fixes**
  - Improved DRep registration, retirement, and expiry calculations.
  - Corrected DRep ordering to reflect earliest on-chain appearance.
  - Strengthened pagination and query-parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->