### PR TITLE
fix: pointer snapshot utxos

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2162,6 +2162,13 @@ document is served only at the literal `/` path (`GET /{$}`); any other
 unregistered path falls through to a catch-all `404` handler instead of the
 root document, matching real Blockfrost's behavior for unimplemented routes.
 
+Address summaries run balance, asset, CBOR, and existence reads through one
+coordinated read transaction. Pointer addresses require an exact decoded-output
+address comparison because the metadata columns do not store their pointer
+payload. The candidate query includes snapshot-imported live UTxOs that lack a
+producing transaction relationship, and missing or undecodable candidate CBOR
+fails the request rather than silently reporting a partial or zero balance.
+
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from
 `tx.AssetMint()` (recorded in `SetTransaction`, `SetTransactionBatched`, and

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -900,7 +900,10 @@ snapshot even though those rows have no `transaction_id` or historical
 `transaction` row. Its ordering join is therefore a left join. Transaction-
 backed UTxOs use the producing transaction's `(slot, block_index, output_idx)`;
 snapshot-only UTxOs use `(utxo.added_slot, 0, output_idx)`. SQLite, MySQL, and
-Postgres implement the same fallback and keyset-cursor contract.
+Postgres implement the same fallback. Keyset cursors and ordering use the
+complete `(slot, block_index, output_idx, tx_id)` tuple; the transaction hash
+is the final key that makes the cursor unique when snapshot fallback fields
+collide.
 
 ### `GetTransactionsByMetadataLabel`
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -895,6 +895,13 @@ quantities by that address. Decoding CBOR is required because some valid
 addresses, such as pointer addresses, cannot be reconstructed from the
 metadata credential-hash columns alone.
 
+`GetUtxosByAddressWithOrdering` includes live UTxOs imported from a ledger-state
+snapshot even though those rows have no `transaction_id` or historical
+`transaction` row. Its ordering join is therefore a left join. Transaction-
+backed UTxOs use the producing transaction's `(slot, block_index, output_idx)`;
+snapshot-only UTxOs use `(utxo.added_slot, 0, output_idx)`. SQLite, MySQL, and
+Postgres implement the same fallback and keyset-cursor contract.
+
 ### `GetTransactionsByMetadataLabel`
 
 Transactions by metadata label:

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -2546,6 +2546,7 @@ func isPointerAddress(addr lcommon.Address) bool {
 // rare, so the candidate sets stay small.
 func (a *NodeAdapter) pointerAddressBalance(
 	addr lcommon.Address,
+	txn *database.Txn,
 ) (models.AddressBalance, error) {
 	var ret models.AddressBalance
 	wantBytes, err := addr.Bytes()
@@ -2553,10 +2554,11 @@ func (a *NodeAdapter) pointerAddressBalance(
 		return ret, fmt.Errorf("encode pointer address: %w", err)
 	}
 
-	candidates, err := a.ledgerState.UtxosByAddressWithOrdering(
+	candidates, err := a.ledgerState.Database().UtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
 			Addresses: []lcommon.Address{addr},
 		},
+		txn,
 	)
 	if err != nil {
 		return ret, fmt.Errorf("get pointer address candidates: %w", err)
@@ -2565,24 +2567,35 @@ func (a *NodeAdapter) pointerAddressBalance(
 		return ret, nil
 	}
 
-	utxoCbor, err := a.addressUtxoCbor(candidates)
-	if err != nil {
-		return ret, fmt.Errorf(
-			"resolve CBOR for pointer address candidates: %w", err,
-		)
-	}
 	for i := range candidates {
-		raw := utxoCbor[utxoRef(candidates[i].Utxo)]
+		raw := candidates[i].Cbor
 		if len(raw) == 0 {
-			continue
+			return ret, fmt.Errorf(
+				"pointer address candidate %x#%d has no output CBOR",
+				candidates[i].TxId,
+				candidates[i].OutputIdx,
+			)
 		}
 		output, err := gledger.NewTransactionOutputFromCbor(raw)
 		if err != nil {
-			continue
+			return ret, fmt.Errorf(
+				"decode pointer address candidate %x#%d: %w",
+				candidates[i].TxId,
+				candidates[i].OutputIdx,
+				err,
+			)
 		}
 		outAddr := output.Address()
 		gotBytes, err := outAddr.Bytes()
-		if err != nil || !bytes.Equal(gotBytes, wantBytes) {
+		if err != nil {
+			return ret, fmt.Errorf(
+				"encode pointer address candidate %x#%d: %w",
+				candidates[i].TxId,
+				candidates[i].OutputIdx,
+				err,
+			)
+		}
+		if !bytes.Equal(gotBytes, wantBytes) {
 			continue
 		}
 		ret.UtxoCount++
@@ -2674,7 +2687,7 @@ func (a *NodeAdapter) Address(
 		// represented in the utxo table. Narrow candidates by
 		// payment credential in SQL, then keep only outputs whose
 		// decoded address matches the request exactly.
-		balance, err = a.pointerAddressBalance(addr)
+		balance, err = a.pointerAddressBalance(addr, txn)
 	} else {
 		balance, err = db.Metadata().
 			GetUtxoBalanceByAddress(addr, matchMode, txn.Metadata())

--- a/api/blockfrost/adapter_block_db_test.go
+++ b/api/blockfrost/adapter_block_db_test.go
@@ -29,6 +29,9 @@ import (
 	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,6 +76,144 @@ func newDBBackedAdapter(
 // values in tests.
 func fill32(b byte) []byte {
 	return bytes.Repeat([]byte{b}, 32)
+}
+
+func testPointerAddress(
+	t *testing.T,
+	paymentHash []byte,
+	pointer byte,
+) lcommon.Address {
+	t.Helper()
+	addrBytes := []byte{
+		(lcommon.AddressTypeKeyPointer << 4) |
+			lcommon.AddressNetworkTestnet,
+	}
+	addrBytes = append(addrBytes, paymentHash...)
+	addrBytes = append(addrBytes, pointer, 0x00, 0x00)
+	addr, err := lcommon.NewAddressFromBytes(addrBytes)
+	require.NoError(t, err)
+	return addr
+}
+
+func storePointerOutputCbor(
+	t *testing.T,
+	db *database.Database,
+	txID []byte,
+	outputIdx uint32,
+	addr lcommon.Address,
+	amount uint64,
+) {
+	t.Helper()
+	raw, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  amount,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *database.Txn) error {
+		return db.Blob().SetUtxo(txn.Blob(), txID, outputIdx, raw)
+	}))
+}
+
+func TestNodeAdapterAddressPointerIncludesSnapshotUtxos(t *testing.T) {
+	adapter, store, db := newDBBackedAdapter(t)
+
+	paymentHash := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	wantAddr := testPointerAddress(t, paymentHash, 0x01)
+	otherAddr := testPointerAddress(t, paymentHash, 0x02)
+	policyID := bytes.Repeat([]byte{0xcd}, lcommon.AddressHashSize)
+	assetName := []byte("TOKEN")
+
+	transactionID := uint(1)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID:         transactionID,
+		Hash:       fill32(0x10),
+		Slot:       10,
+		BlockIndex: 2,
+	}).Error)
+
+	rows := []models.Utxo{
+		{
+			TransactionID: &transactionID,
+			TxId:          fill32(0x10),
+			OutputIdx:     0,
+			PaymentKey:    paymentHash,
+			AddedSlot:     10,
+			Amount:        types.Uint64(1_000_000),
+			Assets: []models.Asset{{
+				PolicyId: policyID,
+				Name:     assetName,
+				Amount:   types.Uint64(2),
+			}},
+		},
+		{
+			// Mithril snapshot imports intentionally have no TransactionID.
+			TxId:       fill32(0x20),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  20,
+			Amount:     types.Uint64(2_000_000),
+			Assets: []models.Asset{{
+				PolicyId: policyID,
+				Name:     assetName,
+				Amount:   types.Uint64(3),
+			}},
+		},
+		{
+			// A different pointer payload sharing the payment credential must
+			// remain excluded by the full decoded-address comparison.
+			TxId:       fill32(0x30),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  20,
+			Amount:     types.Uint64(4_000_000),
+			Assets: []models.Asset{{
+				PolicyId: policyID,
+				Name:     assetName,
+				Amount:   types.Uint64(7),
+			}},
+		},
+	}
+	for i := range rows {
+		require.NoError(t, store.DB().Create(&rows[i]).Error)
+	}
+	storePointerOutputCbor(
+		t, db, rows[0].TxId, rows[0].OutputIdx, wantAddr, 1_000_000,
+	)
+	storePointerOutputCbor(
+		t, db, rows[1].TxId, rows[1].OutputIdx, wantAddr, 2_000_000,
+	)
+	storePointerOutputCbor(
+		t, db, rows[2].TxId, rows[2].OutputIdx, otherAddr, 4_000_000,
+	)
+
+	info, err := adapter.Address(wantAddr.String())
+	require.NoError(t, err)
+	require.Len(t, info.Amount, 2)
+	assert.Equal(t, "lovelace", info.Amount[0].Unit)
+	assert.Equal(t, "3000000", info.Amount[0].Quantity)
+	assert.Equal(
+		t,
+		hex.EncodeToString(policyID)+hex.EncodeToString(assetName),
+		info.Amount[1].Unit,
+	)
+	assert.Equal(t, "5", info.Amount[1].Quantity)
+}
+
+func TestNodeAdapterAddressPointerRejectsMissingCandidateCbor(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	paymentHash := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	addr := testPointerAddress(t, paymentHash, 0x01)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       fill32(0x40),
+		OutputIdx:  0,
+		PaymentKey: paymentHash,
+		AddedSlot:  20,
+		Amount:     types.Uint64(2_000_000),
+	}).Error)
+
+	_, err := adapter.Address(addr.String())
+	require.ErrorContains(t, err, "utxo cbor unavailable")
 }
 
 // TestNodeAdapterBlockOutputAndFees exercises the real DB aggregation path,

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -95,10 +95,12 @@ func parseSearchUtxosStartToken(
 		return nil, nil
 	}
 	parts := strings.Split(startToken, ":")
-	if len(parts) != 3 {
+	if len(parts) != 4 {
 		return nil, connect.NewError(
 			connect.CodeInvalidArgument,
-			errors.New("invalid start_token: expected slot:block_index:output_idx"),
+			errors.New(
+				"invalid start_token: expected slot:block_index:output_idx:tx_id",
+			),
 		)
 	}
 
@@ -126,10 +128,19 @@ func parseSearchUtxosStartToken(
 		)
 	}
 
+	cursorTxId, err := hex.DecodeString(parts[3])
+	if err != nil || len(cursorTxId) != 32 {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("invalid start_token tx_id"),
+		)
+	}
+
 	return &models.UtxoOrderingCursor{
 		Slot:       cursorSlot,
 		BlockIndex: uint32(cursorBlockIndex),
 		OutputIdx:  uint32(cursorOutputIdx),
+		TxId:       cursorTxId,
 	}, nil
 }
 
@@ -659,10 +670,11 @@ func (s *queryServiceServer) SearchUtxos(
 	if hasMore && len(utxos) > 0 {
 		last := utxos[len(utxos)-1]
 		resp.NextToken = fmt.Sprintf(
-			"%d:%d:%d",
+			"%d:%d:%d:%x",
 			last.TxSlot,
 			last.TxBlockIndex,
 			last.OutputIdx,
+			last.TxId,
 		)
 	}
 

--- a/api/utxorpc/query_test.go
+++ b/api/utxorpc/query_test.go
@@ -15,6 +15,7 @@
 package utxorpc
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
@@ -83,21 +84,25 @@ func TestEffectiveSearchUtxosMaxItems(t *testing.T) {
 
 func TestParseSearchUtxosStartToken_Valid(t *testing.T) {
 	t.Parallel()
-	cur, err := parseSearchUtxosStartToken("1:2:3")
+	txId := bytes.Repeat([]byte{0xab}, 32)
+	cur, err := parseSearchUtxosStartToken(
+		"1:2:3:abababababababababababababababababababababababababababababababab",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, cur)
 	require.Equal(t, uint64(1), cur.Slot)
 	require.Equal(t, uint32(2), cur.BlockIndex)
 	require.Equal(t, uint32(3), cur.OutputIdx)
+	require.Equal(t, txId, cur.TxId)
 }
 
-func TestParseSearchUtxosStartToken_NotThreeParts(t *testing.T) {
+func TestParseSearchUtxosStartToken_NotFourParts(t *testing.T) {
 	t.Parallel()
-	_, err := parseSearchUtxosStartToken("1:2")
+	_, err := parseSearchUtxosStartToken("1:2:3")
 	require.Error(t, err)
 }
 
-func TestParseSearchUtxosStartToken_FourPartsInvalid(t *testing.T) {
+func TestParseSearchUtxosStartToken_InvalidTxId(t *testing.T) {
 	t.Parallel()
 	_, err := parseSearchUtxosStartToken("10:20:30:42")
 	require.Error(t, err)

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -159,13 +159,16 @@ type UtxoWithOrdering struct {
 
 // UtxoOrderingCursor is the keyset position for SearchUtxos.
 //
-// Text form (non-empty): slot:block_index:output_idx. GetUtxosByAddressWithOrdering
-// uses the producing transaction position for ordering. Snapshot-imported
-// UTxOs without a producing transaction use AddedSlot and block index zero.
+// Text form (non-empty): slot:block_index:output_idx:tx_id.
+// GetUtxosByAddressWithOrdering uses the producing transaction position for
+// ordering. Snapshot-imported UTxOs without a producing transaction use
+// AddedSlot and block index zero. TxId makes the cursor unique when those
+// fallback fields collide.
 type UtxoOrderingCursor struct {
 	Slot       uint64
 	BlockIndex uint32
 	OutputIdx  uint32
+	TxId       []byte
 }
 
 // UtxoWithOrderingQuery drives GetUtxosByAddressWithOrdering (single MetadataStore entry).

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -160,7 +160,8 @@ type UtxoWithOrdering struct {
 // UtxoOrderingCursor is the keyset position for SearchUtxos.
 //
 // Text form (non-empty): slot:block_index:output_idx. GetUtxosByAddressWithOrdering
-// uses the producing transaction position for ordering.
+// uses the producing transaction position for ordering. Snapshot-imported
+// UTxOs without a producing transaction use AddedSlot and block index zero.
 type UtxoOrderingCursor struct {
 	Slot       uint64
 	BlockIndex uint32

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -462,8 +462,9 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 		if q.After != nil {
 			base = base.Where(
 				fmt.Sprintf(
-					"(%s > ?) OR (%s = ? AND %s > ?) OR (%s = ? AND %s = ? AND utxo.output_idx > ?)",
+					"(%s > ?) OR (%s = ? AND %s > ?) OR (%s = ? AND %s = ? AND utxo.output_idx > ?) OR (%s = ? AND %s = ? AND utxo.output_idx = ? AND utxo.tx_id > ?)",
 					slotExpr, slotExpr, biExpr, slotExpr, biExpr,
+					slotExpr, biExpr,
 				),
 				q.After.Slot,
 				q.After.Slot,
@@ -471,11 +472,15 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 				q.After.Slot,
 				q.After.BlockIndex,
 				q.After.OutputIdx,
+				q.After.Slot,
+				q.After.BlockIndex,
+				q.After.OutputIdx,
+				q.After.TxId,
 			)
 		}
 		base = base.Order(
 			fmt.Sprintf(
-				"%s ASC, %s ASC, utxo.output_idx ASC",
+				"%s ASC, %s ASC, utxo.output_idx ASC, utxo.tx_id ASC",
 				slotExpr,
 				biExpr,
 			),
@@ -484,7 +489,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 		base = base.Select(
 			"utxo.*, COALESCE(transaction.slot, utxo.added_slot) as tx_slot, COALESCE(transaction.block_index, 0) as tx_block_index",
 		).Order(
-			"COALESCE(transaction.slot, utxo.added_slot) ASC, COALESCE(transaction.block_index, 0) ASC, utxo.output_idx ASC",
+			"COALESCE(transaction.slot, utxo.added_slot) ASC, COALESCE(transaction.block_index, 0) ASC, utxo.output_idx ASC, utxo.tx_id ASC",
 		)
 	}
 

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -407,7 +407,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 	}
 	base := db.
 		Table("utxo").
-		Joins("INNER JOIN transaction ON utxo.transaction_id = transaction.id").
+		Joins("LEFT JOIN transaction ON utxo.transaction_id = transaction.id").
 		Where("utxo.deleted_slot = 0")
 
 	addrs := q.Addresses
@@ -452,8 +452,8 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 
 	useKeyset := q.Limit > 0 || q.After != nil
 	if useKeyset {
-		slotExpr := "transaction.slot"
-		biExpr := "transaction.block_index"
+		slotExpr := "COALESCE(transaction.slot, utxo.added_slot)"
+		biExpr := "COALESCE(transaction.block_index, 0)"
 		base = base.Select(fmt.Sprintf(
 			"utxo.*, %s as tx_slot, %s as tx_block_index",
 			slotExpr,
@@ -482,9 +482,9 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 		)
 	} else {
 		base = base.Select(
-			"utxo.*, transaction.slot as tx_slot, transaction.block_index as tx_block_index",
+			"utxo.*, COALESCE(transaction.slot, utxo.added_slot) as tx_slot, COALESCE(transaction.block_index, 0) as tx_block_index",
 		).Order(
-			"transaction.slot ASC, transaction.block_index ASC, utxo.output_idx ASC",
+			"COALESCE(transaction.slot, utxo.added_slot) ASC, COALESCE(transaction.block_index, 0) ASC, utxo.output_idx ASC",
 		)
 	}
 

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -462,8 +462,9 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 		if q.After != nil {
 			base = base.Where(
 				fmt.Sprintf(
-					"(%s > ?) OR (%s = ? AND %s > ?) OR (%s = ? AND %s = ? AND utxo.output_idx > ?)",
+					"(%s > ?) OR (%s = ? AND %s > ?) OR (%s = ? AND %s = ? AND utxo.output_idx > ?) OR (%s = ? AND %s = ? AND utxo.output_idx = ? AND utxo.tx_id > ?)",
 					slotExpr, slotExpr, biExpr, slotExpr, biExpr,
+					slotExpr, biExpr,
 				),
 				q.After.Slot,
 				q.After.Slot,
@@ -471,11 +472,15 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 				q.After.Slot,
 				q.After.BlockIndex,
 				q.After.OutputIdx,
+				q.After.Slot,
+				q.After.BlockIndex,
+				q.After.OutputIdx,
+				q.After.TxId,
 			)
 		}
 		base = base.Order(
 			fmt.Sprintf(
-				"%s ASC, %s ASC, utxo.output_idx ASC",
+				"%s ASC, %s ASC, utxo.output_idx ASC, utxo.tx_id ASC",
 				slotExpr,
 				biExpr,
 			),
@@ -484,7 +489,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 		base = base.Select(
 			"utxo.*, COALESCE(transaction.slot, utxo.added_slot) as tx_slot, COALESCE(transaction.block_index, 0) as tx_block_index",
 		).Order(
-			"COALESCE(transaction.slot, utxo.added_slot) ASC, COALESCE(transaction.block_index, 0) ASC, utxo.output_idx ASC",
+			"COALESCE(transaction.slot, utxo.added_slot) ASC, COALESCE(transaction.block_index, 0) ASC, utxo.output_idx ASC, utxo.tx_id ASC",
 		)
 	}
 

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -407,7 +407,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 	}
 	base := db.
 		Table("utxo").
-		Joins("INNER JOIN transaction ON utxo.transaction_id = transaction.id").
+		Joins("LEFT JOIN transaction ON utxo.transaction_id = transaction.id").
 		Where("utxo.deleted_slot = 0")
 
 	addrs := q.Addresses
@@ -452,8 +452,8 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 
 	useKeyset := q.Limit > 0 || q.After != nil
 	if useKeyset {
-		slotExpr := "transaction.slot"
-		biExpr := "transaction.block_index"
+		slotExpr := "COALESCE(transaction.slot, utxo.added_slot)"
+		biExpr := "COALESCE(transaction.block_index, 0)"
 		base = base.Select(fmt.Sprintf(
 			"utxo.*, %s as tx_slot, %s as tx_block_index",
 			slotExpr,
@@ -482,9 +482,9 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 		)
 	} else {
 		base = base.Select(
-			"utxo.*, transaction.slot as tx_slot, transaction.block_index as tx_block_index",
+			"utxo.*, COALESCE(transaction.slot, utxo.added_slot) as tx_slot, COALESCE(transaction.block_index, 0) as tx_block_index",
 		).Order(
-			"transaction.slot ASC, transaction.block_index ASC, utxo.output_idx ASC",
+			"COALESCE(transaction.slot, utxo.added_slot) ASC, COALESCE(transaction.block_index, 0) ASC, utxo.output_idx ASC",
 		)
 	}
 

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -476,12 +476,14 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 	if err != nil {
 		return nil, err
 	}
+	// Snapshot-imported UTxOs have no producing transaction row. Keep them in
+	// the result and fall back to their import slot for stable ordering.
 	// SQLite treats TRANSACTION as a reserved keyword, so table references
 	// must be quoted when joining against the transaction table.
 	base := db.
 		Table("utxo").
 		Joins(
-			`INNER JOIN "transaction" ON utxo.transaction_id = "transaction".id`,
+			`LEFT JOIN "transaction" ON utxo.transaction_id = "transaction".id`,
 		).
 		Where("utxo.deleted_slot = 0")
 
@@ -528,8 +530,8 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 
 	useKeyset := q.Limit > 0 || q.After != nil
 	if useKeyset {
-		slotExpr := `"transaction".slot`
-		biExpr := `"transaction".block_index`
+		slotExpr := `COALESCE("transaction".slot, utxo.added_slot)`
+		biExpr := `COALESCE("transaction".block_index, 0)`
 		base = base.Select(fmt.Sprintf(
 			"utxo.*, %s as tx_slot, %s as tx_block_index",
 			slotExpr,
@@ -558,9 +560,9 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 		)
 	} else {
 		base = base.Select(
-			`utxo.*, "transaction".slot as tx_slot, "transaction".block_index as tx_block_index`,
+			`utxo.*, COALESCE("transaction".slot, utxo.added_slot) as tx_slot, COALESCE("transaction".block_index, 0) as tx_block_index`,
 		).Order(
-			`"transaction".slot ASC, "transaction".block_index ASC, utxo.output_idx ASC`,
+			`COALESCE("transaction".slot, utxo.added_slot) ASC, COALESCE("transaction".block_index, 0) ASC, utxo.output_idx ASC`,
 		)
 	}
 

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -540,8 +540,9 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 		if q.After != nil {
 			base = base.Where(
 				fmt.Sprintf(
-					"(%s > ?) OR (%s = ? AND %s > ?) OR (%s = ? AND %s = ? AND utxo.output_idx > ?)",
+					"(%s > ?) OR (%s = ? AND %s > ?) OR (%s = ? AND %s = ? AND utxo.output_idx > ?) OR (%s = ? AND %s = ? AND utxo.output_idx = ? AND utxo.tx_id > ?)",
 					slotExpr, slotExpr, biExpr, slotExpr, biExpr,
+					slotExpr, biExpr,
 				),
 				q.After.Slot,
 				q.After.Slot,
@@ -549,11 +550,15 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 				q.After.Slot,
 				q.After.BlockIndex,
 				q.After.OutputIdx,
+				q.After.Slot,
+				q.After.BlockIndex,
+				q.After.OutputIdx,
+				q.After.TxId,
 			)
 		}
 		base = base.Order(
 			fmt.Sprintf(
-				"%s ASC, %s ASC, utxo.output_idx ASC",
+				"%s ASC, %s ASC, utxo.output_idx ASC, utxo.tx_id ASC",
 				slotExpr,
 				biExpr,
 			),
@@ -562,7 +567,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 		base = base.Select(
 			`utxo.*, COALESCE("transaction".slot, utxo.added_slot) as tx_slot, COALESCE("transaction".block_index, 0) as tx_block_index`,
 		).Order(
-			`COALESCE("transaction".slot, utxo.added_slot) ASC, COALESCE("transaction".block_index, 0) ASC, utxo.output_idx ASC`,
+			`COALESCE("transaction".slot, utxo.added_slot) ASC, COALESCE("transaction".block_index, 0) ASC, utxo.output_idx ASC, utxo.tx_id ASC`,
 		)
 	}
 

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -738,6 +738,64 @@ func TestGetUtxosByAddressUsesPaymentScript(t *testing.T) {
 	assert.Equal(t, scriptUtxo.TxId, orderedRows[0].TxId)
 }
 
+func TestGetUtxosByAddressWithOrderingIncludesSnapshotUtxos(t *testing.T) {
+	store := setupTestDB(t)
+
+	paymentHash := bytes.Repeat([]byte{0xAB}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		paymentHash,
+		nil,
+	)
+	require.NoError(t, err)
+
+	txID := uint(1)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID:         txID,
+		Hash:       bytes.Repeat([]byte{0x01}, 32),
+		Slot:       10,
+		BlockIndex: 3,
+	}).Error)
+	rows := []models.Utxo{
+		{
+			TransactionID: &txID,
+			TxId:          bytes.Repeat([]byte{0x10}, 32),
+			OutputIdx:     0,
+			PaymentKey:    paymentHash,
+			AddedSlot:     10,
+			Amount:        types.Uint64(1_000_000),
+		},
+		{
+			// Snapshot imports contain the live output but not its historical
+			// transaction relationship.
+			TxId:       bytes.Repeat([]byte{0x20}, 32),
+			OutputIdx:  1,
+			PaymentKey: paymentHash,
+			AddedSlot:  20,
+			Amount:     types.Uint64(2_000_000),
+		},
+	}
+	for i := range rows {
+		require.NoError(t, store.DB().Create(&rows[i]).Error)
+	}
+
+	got, err := store.GetUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			Addresses: []lcommon.Address{addr},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, rows[0].TxId, got[0].TxId)
+	assert.Equal(t, uint64(10), got[0].TxSlot)
+	assert.Equal(t, uint32(3), got[0].TxBlockIndex)
+	assert.Equal(t, rows[1].TxId, got[1].TxId)
+	assert.Equal(t, uint64(20), got[1].TxSlot)
+	assert.Equal(t, uint32(0), got[1].TxBlockIndex)
+}
+
 // TestGetUtxoBalanceByAddressMatchModes seeds enterprise, base, and
 // pointer UTxOs sharing one payment hash and verifies that exact
 // matching keeps full-address identity while payment-credential

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -796,6 +796,78 @@ func TestGetUtxosByAddressWithOrderingIncludesSnapshotUtxos(t *testing.T) {
 	assert.Equal(t, uint32(0), got[1].TxBlockIndex)
 }
 
+func TestGetUtxosByAddressWithOrderingPaginatesCollidingSnapshotUtxos(
+	t *testing.T,
+) {
+	store := setupTestDB(t)
+
+	paymentHash := bytes.Repeat([]byte{0xAB}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		paymentHash,
+		nil,
+	)
+	require.NoError(t, err)
+
+	rows := []models.Utxo{
+		{
+			TxId:       bytes.Repeat([]byte{0x10}, 32),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  20,
+			Amount:     types.Uint64(1_000_000),
+		},
+		{
+			TxId:       bytes.Repeat([]byte{0x20}, 32),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  20,
+			Amount:     types.Uint64(2_000_000),
+		},
+		{
+			TxId:       bytes.Repeat([]byte{0x30}, 32),
+			OutputIdx:  0,
+			PaymentKey: paymentHash,
+			AddedSlot:  20,
+			Amount:     types.Uint64(3_000_000),
+		},
+	}
+	for i := range rows {
+		require.NoError(t, store.DB().Create(&rows[i]).Error)
+	}
+
+	firstPage, err := store.GetUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			Addresses: []lcommon.Address{addr},
+			Limit:     2,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+	assert.Equal(t, rows[0].TxId, firstPage[0].TxId)
+	assert.Equal(t, rows[1].TxId, firstPage[1].TxId)
+
+	last := firstPage[len(firstPage)-1]
+	secondPage, err := store.GetUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			Addresses: []lcommon.Address{addr},
+			After: &models.UtxoOrderingCursor{
+				Slot:       last.TxSlot,
+				BlockIndex: last.TxBlockIndex,
+				OutputIdx:  last.OutputIdx,
+				TxId:       last.TxId,
+			},
+			Limit: 2,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, secondPage, 1)
+	assert.Equal(t, rows[2].TxId, secondPage[0].TxId)
+}
+
 // TestGetUtxoBalanceByAddressMatchModes seeds enterprise, base, and
 // pointer UTxOs sharing one payment hash and verifies that exact
 // matching keeps full-address identity while payment-credential

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1176,8 +1176,10 @@ type MetadataStore interface {
 		types.Txn,
 	) (models.AddressBalance, error)
 
-	// GetUtxosByAddressWithOrdering runs q against live UTxOs with ordering metadata.
-	// See models.UtxoWithOrderingQuery. q must be non-nil.
+	// GetUtxosByAddressWithOrdering runs q against live UTxOs with ordering
+	// metadata. Snapshot-imported UTxOs without a producing transaction use
+	// AddedSlot and block index zero. See models.UtxoWithOrderingQuery. q must
+	// be non-nil.
 	GetUtxosByAddressWithOrdering(
 		*models.UtxoWithOrderingQuery,
 		types.Txn,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1178,8 +1178,9 @@ type MetadataStore interface {
 
 	// GetUtxosByAddressWithOrdering runs q against live UTxOs with ordering
 	// metadata. Snapshot-imported UTxOs without a producing transaction use
-	// AddedSlot and block index zero. See models.UtxoWithOrderingQuery. q must
-	// be non-nil.
+	// AddedSlot and block index zero. Keyset ordering uses the unique tuple
+	// (slot, block_index, output_idx, tx_id). See
+	// models.UtxoWithOrderingQuery. q must be non-nil.
 	GetUtxosByAddressWithOrdering(
 		*models.UtxoWithOrderingQuery,
 		types.Txn,


### PR DESCRIPTION
Closes #2961 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pointer address balances by including snapshot-imported UTxOs and requiring exact decoded-address matches from output CBOR. Also stabilizes UTxO pagination by adding `tx_id` to keyset tokens.

- **Bug Fixes**
  - `GetUtxosByAddressWithOrdering`: include snapshot UTxOs via LEFT JOIN; order with `COALESCE(transaction.slot, utxo.added_slot)` and block index `0` across SQLite/MySQL/Postgres; keyset ordering uses `(slot, block_index, output_idx, tx_id)`.
  - Pointer address balance: read candidates in one transaction, decode each output’s CBOR from the DB, and match the full address; missing or undecodable CBOR now returns an error.
  - `SearchUtxos` pagination: `start_token`/`next_token` now use `slot:block_index:output_idx:tx_id` for stable ordering; parsing and tests updated.
  - Added DB-backed and SQLite tests for snapshot inclusion, collision pagination, and missing-CBOR rejection; updated `ARCHITECTURE.md` and `DATABASE.md`.

<sup>Written for commit 0fb6cf5d7d32d031ca28280381b0631ac0648f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Address balance lookups now include snapshot-imported UTxOs, even when no producing transaction is available.
  - Pointer-address matching now verifies the fully decoded address for accurate balance and asset totals.
  - Requests fail clearly when candidate UTxO data is missing or cannot be decoded, instead of returning incomplete results.
  - UTxO ordering and pagination now remain consistent for snapshot-imported records across supported databases.

- **Documentation**
  - Clarified address lookup behavior and snapshot-based UTxO ordering rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->