### PR TITLE
feat(blockfrost): implement retiring pools and pool metadata endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2152,8 +2152,9 @@ Dingo provides three client-facing APIs plus Bark. All are optional and gated by
 
 A Blockfrost-compatible REST API that provides read access to chain data and
 transaction submission. The current router includes health/root, blocks,
-epochs/parameters, network/eras, genesis, assets, pools/extended, governance
-DRep lookup, address UTxOs and transactions, metadata label JSON/CBOR,
+epochs/parameters, network/eras, genesis, assets, pools/extended, retiring
+pools, pool metadata, governance DRep list and lookup, address summary,
+address UTxOs and transactions, metadata label JSON/CBOR,
 transaction content/CBOR/metadata/UTxOs/certificates/redeemers/required
 signers, and account/delegation/registration/reward endpoints. It uses an
 adapter pattern to translate between Dingo's internal state and Blockfrost

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1122,6 +1122,38 @@ SELECT drep_type, MIN(slot) AS slot FROM (
 ) u GROUP BY drep_type;
 ```
 
+### `GetRetiringPools`
+
+Pools whose latest retirement certificate targets a future epoch and has
+not been cancelled by a later registration. Certificate recency compares
+`(added_slot, synthetic-import precedence, block_index, cert_index)` —
+rows written by the Mithril ledger-state import carry
+`certificate_id = 0` and take precedence within their slot, mirroring
+the `GetPools` preload ordering. Results order by retirement epoch and
+then announcement position, matching hosted Blockfrost:
+
+```sql
+WITH latest_reg AS (
+    SELECT pool_key_hash, added_slot, ...,
+           ROW_NUMBER() OVER (PARTITION BY pool_key_hash
+               ORDER BY added_slot DESC, synth DESC,
+                        block_index DESC, cert_index DESC) AS rn
+    FROM pool_registration
+    LEFT JOIN certs ON certs.id = certificate_id
+    LEFT JOIN "transaction" ON "transaction".id = certs.transaction_id
+),
+latest_ret AS (SELECT ... FROM pool_retirement ...)
+SELECT r.pool_key_hash, r.epoch
+FROM latest_ret r
+LEFT JOIN latest_reg g ON g.pool_key_hash = r.pool_key_hash AND g.rn = 1
+WHERE r.rn = 1
+  AND r.epoch > $1
+  AND (g.pool_key_hash IS NULL
+       OR (r.added_slot, r.synth, r.block_index, r.cert_index)
+          > (g.added_slot, g.synth, g.block_index, g.cert_index))
+ORDER BY r.epoch, r.added_slot, r.block_index, r.cert_index;
+```
+
 ### `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, `GetDRepVotingPowerByType`
 
 All three DRep voting-power queries take an `expiryEpoch uint64` argument that

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"net/http"
 	"slices"
 	"sort"
 	"strconv"
@@ -58,6 +59,7 @@ var (
 	ErrAssetNotFound       = errors.New("asset not found")
 	ErrDRepNotFound        = errors.New("drep not found")
 	ErrInvalidTransaction  = errors.New("invalid transaction")
+	ErrInvalidPoolID       = errors.New("invalid pool id")
 	ErrMempoolUnavailable  = errors.New("mempool unavailable")
 	ErrMempoolFull         = errors.New("mempool full")
 	ErrTransactionNotFound = errors.New("transaction not found")
@@ -1676,8 +1678,232 @@ func (a *NodeAdapter) liveStake() (uint64, error) {
 	return total, nil
 }
 
+// offchainFetchError maps a failed off-chain metadata cache row to
+// Blockfrost's error object, matching the hosted API's codes and
+// message formats. sourceLabel is the capitalized source name used in
+// the message ("Pool", "Drep").
+func offchainFetchError(
+	sourceLabel string,
+	url string,
+	expectedHash []byte,
+	doc *models.OffchainMetadata,
+) *OffchainFetchErrorInfo {
+	// LastError and LastHTTPStatus describe the most recent fetch
+	// attempt; BodyHash persists across attempts and is only
+	// meaningful for the hash-mismatch case.
+	switch {
+	case doc.LastError == models.OffchainFetchErrHashMismatch:
+		return &OffchainFetchErrorInfo{
+			Code: "HASH_MISMATCH",
+			Message: fmt.Sprintf(
+				"Hash mismatch when fetching metadata from %s. "+
+					"Expected %q but got %q.",
+				url,
+				hex.EncodeToString(expectedHash),
+				hex.EncodeToString(doc.BodyHash),
+			),
+		}
+	case strings.HasPrefix(
+		doc.LastError, models.OffchainFetchErrBodyTooLargePrefix,
+	):
+		return &OffchainFetchErrorInfo{
+			Code: "SIZE_EXCEEDED",
+			Message: fmt.Sprintf(
+				"Error Offchain %s: Size error when fetching "+
+					"metadata from %s.",
+				sourceLabel,
+				url,
+			),
+		}
+	case doc.LastHTTPStatus > 0 &&
+		(doc.LastHTTPStatus < 200 || doc.LastHTTPStatus >= 300):
+		statusText := http.StatusText(int(doc.LastHTTPStatus))
+		return &OffchainFetchErrorInfo{
+			Code: "HTTP_RESPONSE_ERROR",
+			Message: fmt.Sprintf(
+				"Error Offchain %s: HTTP Response error from %s "+
+					"resulted in HTTP status code : %d %q",
+				sourceLabel,
+				url,
+				doc.LastHTTPStatus,
+				statusText,
+			),
+		}
+	default:
+		return &OffchainFetchErrorInfo{
+			Code: "CONNECTION_ERROR",
+			Message: fmt.Sprintf(
+				"Error Offchain %s: Connection failure error when "+
+					"fetching metadata from %s.",
+				sourceLabel,
+				url,
+			),
+		}
+	}
+}
+
 // PoolsExtended returns the current active pools with
 // extended details.
+// parsePoolID parses a pool identifier in bech32 ("pool1...") or raw
+// 56-character hex form into the 28-byte pool key hash.
+func parsePoolID(id string) ([]byte, error) {
+	if len(id) == 56 {
+		if hash, err := hex.DecodeString(id); err == nil {
+			return hash, nil
+		}
+	}
+	hrp, data, err := bech32.Decode(id)
+	if err != nil {
+		return nil, fmt.Errorf("decode pool bech32: %w", ErrInvalidPoolID)
+	}
+	if strings.ToLower(hrp) != "pool" {
+		return nil, fmt.Errorf("pool prefix %q: %w", hrp, ErrInvalidPoolID)
+	}
+	payload, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil || len(payload) != 28 {
+		return nil, fmt.Errorf("pool payload: %w", ErrInvalidPoolID)
+	}
+	return payload, nil
+}
+
+// PoolsRetiring returns the paginated list of pools with a pending
+// retirement: a retirement certificate for a future epoch that has not
+// been cancelled by a later re-registration. Entries are ordered by
+// retirement epoch and then announcement position, matching hosted
+// Blockfrost.
+func (a *NodeAdapter) PoolsRetiring(
+	params PaginationParams,
+) ([]PoolRetiringInfo, int, error) {
+	db := a.ledgerState.Database()
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	rows, err := db.Metadata().GetRetiringPools(
+		a.ledgerState.CurrentEpoch(), txn.Metadata(),
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("get retiring pools: %w", err)
+	}
+	if params.Order == PaginationOrderDesc {
+		slices.Reverse(rows)
+	}
+	total := len(rows)
+
+	start := (params.Page - 1) * params.Count
+	if start >= len(rows) {
+		return []PoolRetiringInfo{}, total, nil
+	}
+	end := min(start+params.Count, len(rows))
+
+	ret := make([]PoolRetiringInfo, 0, end-start)
+	for _, row := range rows[start:end] {
+		poolID := lcommon.PoolId(lcommon.NewBlake2b224(row.PoolKeyHash))
+		ret = append(ret, PoolRetiringInfo{
+			PoolID: poolID.String(),
+			Epoch:  row.Epoch,
+		})
+	}
+	return ret, total, nil
+}
+
+// PoolMetadata returns the registered metadata for the requested pool:
+// the on-chain anchor from the latest registration plus the off-chain
+// document fields when the cached fetch succeeded.
+func (a *NodeAdapter) PoolMetadata(
+	poolID string,
+) (PoolMetadataInfo, error) {
+	poolKeyHash, err := parsePoolID(poolID)
+	if err != nil {
+		return PoolMetadataInfo{}, err
+	}
+
+	db := a.ledgerState.Database()
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	pool, err := db.Metadata().GetPool(
+		lcommon.PoolKeyHash(poolKeyHash), true, txn.Metadata(),
+	)
+	if err != nil {
+		return PoolMetadataInfo{}, fmt.Errorf(
+			"get pool %x: %w", poolKeyHash, err,
+		)
+	}
+	// The metadata store returns (nil, nil) for unknown pools.
+	if pool == nil {
+		return PoolMetadataInfo{}, fmt.Errorf(
+			"pool %x: %w", poolKeyHash, models.ErrPoolNotFound,
+		)
+	}
+
+	var metadataURL string
+	var metadataHash []byte
+	if len(pool.Registration) > 0 {
+		metadataURL = pool.Registration[0].MetadataUrl
+		metadataHash = pool.Registration[0].MetadataHash
+	}
+
+	ret := PoolMetadataInfo{
+		PoolID: lcommon.PoolId(
+			lcommon.NewBlake2b224(poolKeyHash),
+		).String(),
+		Hex: hex.EncodeToString(poolKeyHash),
+	}
+	if metadataURL == "" {
+		return ret, nil
+	}
+	url := metadataURL
+	hash := hex.EncodeToString(metadataHash)
+	ret.URL = &url
+	ret.Hash = &hash
+
+	doc, err := db.Metadata().GetOffchainMetadata(
+		models.OffchainMetadataSourcePool,
+		metadataURL,
+		metadataHash,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return PoolMetadataInfo{}, fmt.Errorf(
+			"get offchain metadata for pool %x: %w", poolKeyHash, err,
+		)
+	}
+	if doc == nil || doc.Status == models.OffchainMetadataStatusPending {
+		return ret, nil
+	}
+	if doc.Status == models.OffchainMetadataStatusFailed {
+		ret.Error = offchainFetchError(
+			"Pool", metadataURL, metadataHash, doc,
+		)
+		return ret, nil
+	}
+	if len(doc.Content) == 0 {
+		return ret, nil
+	}
+	var offchain struct {
+		Name        *string `json:"name"`
+		Description *string `json:"description"`
+		Ticker      *string `json:"ticker"`
+		Homepage    *string `json:"homepage"`
+	}
+	if err := json.Unmarshal(doc.Content, &offchain); err != nil {
+		ret.Error = &OffchainFetchErrorInfo{
+			Code: "DECODE_ERROR",
+			Message: fmt.Sprintf(
+				"Error Offchain Pool: JSON decode error when "+
+					"fetching metadata from %s.",
+				metadataURL,
+			),
+		}
+		return ret, nil
+	}
+	ret.Name = offchain.Name
+	ret.Description = offchain.Description
+	ret.Ticker = offchain.Ticker
+	ret.Homepage = offchain.Homepage
+	return ret, nil
+}
+
 func (a *NodeAdapter) PoolsExtended() (
 	[]PoolExtendedInfo, error,
 ) {

--- a/api/blockfrost/adapter_block_db_test.go
+++ b/api/blockfrost/adapter_block_db_test.go
@@ -224,3 +224,43 @@ func TestNodeAdapterNextBlockHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, next)
 }
+
+// TestNodeAdapterPoolMetadataOffchainStoreError guards the error path at the
+// PoolMetadata boundary: a failing off-chain metadata store query must
+// propagate as an error rather than degrade into a successful URL/hash-only
+// response that hides the store failure.
+func TestNodeAdapterPoolMetadataOffchainStoreError(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	poolKeyHash := bytes.Repeat([]byte{0x0a}, 28)
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		Registration: []models.PoolRegistration{
+			{
+				PoolKeyHash:  poolKeyHash,
+				MetadataUrl:  "https://example.com/pool.json",
+				MetadataHash: fill32(0x0b),
+				AddedSlot:    1,
+			},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+
+	poolID := hex.EncodeToString(poolKeyHash)
+
+	// Sanity check: with an intact store and no cached document, the lookup
+	// succeeds as a URL/hash-only partial response.
+	info, err := adapter.PoolMetadata(poolID)
+	require.NoError(t, err)
+	require.NotNil(t, info.URL)
+	assert.Equal(t, "https://example.com/pool.json", *info.URL)
+	assert.Nil(t, info.Name)
+
+	// Break the store so GetOffchainMetadata fails; the failure must surface
+	// instead of producing a successful partial response.
+	require.NoError(
+		t, store.DB().Exec("DROP TABLE offchain_metadata").Error,
+	)
+	_, err = adapter.PoolMetadata(poolID)
+	require.ErrorContains(t, err, "get offchain metadata")
+}

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -117,6 +117,14 @@ func (b *Blockfrost) handler() http.Handler {
 		b.handlePoolsExtended,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/pools/retiring",
+		b.handlePoolsRetiring,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/pools/{pool_id}/metadata",
+		b.handlePoolMetadata,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/governance/dreps",
 		b.handleDReps,
 	)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -17,7 +17,9 @@ package blockfrost
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -65,6 +67,9 @@ type mockNode struct {
 	networkEras                   []NetworkEraInfo
 	genesis                       GenesisInfo
 	pools                         []PoolExtendedInfo
+	poolsRetiring                 []PoolRetiringInfo
+	poolsRetiringTotal            int
+	poolMetadata                  PoolMetadataInfo
 	asset                         AssetInfo
 	assetHolders                  []AssetHolderInfo
 	assetHoldersTotal             int
@@ -115,6 +120,8 @@ type mockNode struct {
 	networkErasErr                error
 	genesisErr                    error
 	poolsErr                      error
+	poolsRetiringErr              error
+	poolMetadataErr               error
 	assetErr                      error
 	assetAddressesErr             error
 	drepErr                       error
@@ -209,6 +216,18 @@ func (m *mockNode) PoolsExtended() (
 	[]PoolExtendedInfo, error,
 ) {
 	return m.pools, m.poolsErr
+}
+
+func (m *mockNode) PoolsRetiring(
+	_ PaginationParams,
+) ([]PoolRetiringInfo, int, error) {
+	return m.poolsRetiring, m.poolsRetiringTotal, m.poolsRetiringErr
+}
+
+func (m *mockNode) PoolMetadata(
+	_ string,
+) (PoolMetadataInfo, error) {
+	return m.poolMetadata, m.poolMetadataErr
 }
 
 func (m *mockNode) Asset(
@@ -993,6 +1012,181 @@ func TestAssetHoldersFromUtxosPreservesPointerAddress(t *testing.T) {
 	require.Len(t, holders, 1)
 	assert.Equal(t, addr.String(), holders[0].Address)
 	assert.Equal(t, "7", holders[0].Quantity)
+}
+
+func TestHandlePoolsRetiring(t *testing.T) {
+	mock := &mockNode{
+		poolsRetiringTotal: 1,
+		poolsRetiring: []PoolRetiringInfo{
+			{PoolID: "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec", Epoch: 1400},
+		},
+	}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/retiring?count=10", nil,
+	)
+	w := httptest.NewRecorder()
+	b.handlePoolsRetiring(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "1", w.Header().Get("X-Pagination-Count-Total"))
+	var resp []PoolRetiringResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, uint64(1400), resp[0].Epoch)
+}
+
+func TestHandlePoolsRetiringInvalidPagination(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{})
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/retiring?order=a", nil,
+	)
+	w := httptest.NewRecorder()
+	b.handlePoolsRetiring(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(
+		t,
+		"querystring/order must be equal to one of the allowed values",
+		resp.Message,
+	)
+}
+
+func TestHandlePoolMetadata(t *testing.T) {
+	url := "https://example.com/pool.json"
+	hash := "18c2dcb8d69024dbe95beebcef4a49a2bdc3f0b1c60e5e669007e5e39edd4a7f"
+	ticker := "TEST"
+	mock := &mockNode{
+		poolMetadata: PoolMetadataInfo{
+			PoolID: "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec",
+			Hex:    "6080b9c76b4b19c21d17b4091aa205417cb80a5449f638c27eec0946",
+			URL:    &url,
+			Hash:   &hash,
+			Ticker: &ticker,
+		},
+	}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec/metadata",
+		nil,
+	)
+	req.SetPathValue("pool_id", "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec")
+	w := httptest.NewRecorder()
+	b.handlePoolMetadata(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp PoolMetadataResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, mock.poolMetadata.PoolID, resp.PoolID)
+	require.NotNil(t, resp.URL)
+	assert.Equal(t, url, *resp.URL)
+	require.NotNil(t, resp.Ticker)
+	assert.Nil(t, resp.Name)
+}
+
+func TestHandlePoolMetadataNoAnchor(t *testing.T) {
+	// A pool without registered metadata answers with an empty JSON
+	// object, matching hosted Blockfrost.
+	b := newTestBlockfrost(&mockNode{
+		poolMetadata: PoolMetadataInfo{
+			PoolID: "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec",
+			Hex:    "6080b9c76b4b19c21d17b4091aa205417cb80a5449f638c27eec0946",
+		},
+	})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec/metadata",
+		nil,
+	)
+	req.SetPathValue("pool_id", "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec")
+	w := httptest.NewRecorder()
+	b.handlePoolMetadata(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, "{}", w.Body.String())
+}
+
+func TestOffchainFetchErrorClassification(t *testing.T) {
+	url := "https://example.com/meta.json"
+	expected := bytes.Repeat([]byte{0x01}, 32)
+	stale := bytes.Repeat([]byte{0x02}, 32)
+
+	// Latest attempt failed with 404; the stale BodyHash from an
+	// earlier hash-mismatch attempt must not win.
+	err404 := offchainFetchError("Pool", url, expected, &models.OffchainMetadata{
+		LastError:      "unexpected HTTP status 404",
+		LastHTTPStatus: 404,
+		BodyHash:       stale,
+	})
+	assert.Equal(t, "HTTP_RESPONSE_ERROR", err404.Code)
+	assert.Contains(t, err404.Message, `404 "Not Found"`)
+
+	mismatch := offchainFetchError("Pool", url, expected, &models.OffchainMetadata{
+		LastError:      models.OffchainFetchErrHashMismatch,
+		LastHTTPStatus: 200,
+		BodyHash:       stale,
+	})
+	assert.Equal(t, "HASH_MISMATCH", mismatch.Code)
+	assert.Contains(t, mismatch.Message, hex.EncodeToString(stale))
+
+	size := offchainFetchError("Pool", url, expected, &models.OffchainMetadata{
+		LastError:      models.OffchainFetchErrBodyTooLargePrefix + " 1048576 bytes",
+		LastHTTPStatus: 200,
+	})
+	assert.Equal(t, "SIZE_EXCEEDED", size.Code)
+
+	conn := offchainFetchError("Pool", url, expected, &models.OffchainMetadata{
+		LastError: "dial tcp: connection refused",
+	})
+	assert.Equal(t, "CONNECTION_ERROR", conn.Code)
+}
+
+func TestHandlePoolMetadataInvalidID(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{poolMetadataErr: ErrInvalidPoolID})
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/pool1stonks/metadata", nil,
+	)
+	req.SetPathValue("pool_id", "pool1stonks")
+	w := httptest.NewRecorder()
+	b.handlePoolMetadata(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Invalid or malformed pool id format.", resp.Message)
+}
+
+func TestHandlePoolMetadataNotFound(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		poolMetadataErr: fmt.Errorf("get pool: %w", models.ErrPoolNotFound),
+	})
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d/metadata", nil,
+	)
+	req.SetPathValue("pool_id", "pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d")
+	w := httptest.NewRecorder()
+	b.handlePoolMetadata(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestParsePoolID(t *testing.T) {
+	hash, err := parsePoolID("pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec")
+	require.NoError(t, err)
+	assert.Equal(t, "6080b9c76b4b19c21d17b4091aa205417cb80a5449f638c27eec0946", hex.EncodeToString(hash))
+
+	hash2, err := parsePoolID("6080b9c76b4b19c21d17b4091aa205417cb80a5449f638c27eec0946")
+	require.NoError(t, err)
+	assert.Equal(t, hash, hash2)
+
+	_, err = parsePoolID("pool1stonks")
+	require.Error(t, err)
+
+	_, err = parsePoolID("drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n")
+	require.Error(t, err)
 }
 
 func TestHandleDRep(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -546,6 +546,102 @@ func (b *Blockfrost) handleAssetAddresses(
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// handlePoolsRetiring handles GET /api/v0/pools/retiring and returns
+// the paginated list of pools with a pending retirement.
+func (b *Blockfrost) handlePoolsRetiring(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, errMsg := ParsePaginationStrict(r)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, "Bad Request", errMsg)
+		return
+	}
+	pools, total, err := b.node.PoolsRetiring(params)
+	if err != nil {
+		b.logger.Error(
+			"failed to list retiring pools",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve retiring pools",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make([]PoolRetiringResponse, 0, len(pools))
+	for _, pool := range pools {
+		resp = append(resp, PoolRetiringResponse(pool))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handlePoolMetadata handles GET /api/v0/pools/{pool_id}/metadata and
+// returns the pool's registered metadata.
+func (b *Blockfrost) handlePoolMetadata(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	poolID := r.PathValue("pool_id")
+	info, err := b.node.PoolMetadata(poolID)
+	if err != nil {
+		if errors.Is(err, ErrInvalidPoolID) {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"Invalid or malformed pool id format.",
+			)
+			return
+		}
+		if errors.Is(err, models.ErrPoolNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested component has not been found.",
+			)
+			return
+		}
+		b.logger.Error(
+			"failed to get pool metadata",
+			"pool_id", poolID,
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve pool metadata",
+		)
+		return
+	}
+	// A pool without a registered metadata anchor answers with an
+	// empty JSON object, matching hosted Blockfrost.
+	if info.URL == nil {
+		writeJSON(w, http.StatusOK, struct{}{})
+		return
+	}
+	resp := PoolMetadataResponse{
+		PoolID:      info.PoolID,
+		Hex:         info.Hex,
+		URL:         info.URL,
+		Hash:        info.Hash,
+		Ticker:      info.Ticker,
+		Name:        info.Name,
+		Description: info.Description,
+		Homepage:    info.Homepage,
+	}
+	if info.Error != nil {
+		respErr := OffchainFetchErrorResponse(*info.Error)
+		resp.Error = &respErr
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // handlePoolsExtended handles GET /api/v0/pools/extended
 // and returns active pools with extended details.
 func (b *Blockfrost) handlePoolsExtended(

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -65,6 +65,14 @@ type BlockfrostNode interface {
 	// including balances aggregated across its live UTxOs.
 	Address(address string) (AddressInfo, error)
 
+	// PoolsRetiring returns the paginated list of pools with a
+	// pending retirement announcement, along with the total number
+	// of matching results before pagination.
+	PoolsRetiring(PaginationParams) ([]PoolRetiringInfo, int, error)
+
+	// PoolMetadata returns the registered metadata for a pool.
+	PoolMetadata(poolID string) (PoolMetadataInfo, error)
+
 	// AddressUTXOs returns the paginated current UTxOs for
 	// an address along with the total number of matching
 	// results before pagination.
@@ -357,6 +365,35 @@ type GenesisInfo struct {
 	SlotLength             int
 	MaxKESEvolutions       int
 	SecurityParam          int
+}
+
+// PoolRetiringInfo is one entry of the retiring pools list.
+type PoolRetiringInfo struct {
+	PoolID string
+	Epoch  uint64
+}
+
+// PoolMetadataInfo holds a pool's registered metadata: the on-chain
+// anchor (URL and hash) plus the off-chain document fields when the
+// document has been fetched and validated. Error carries the fetch
+// failure when the document could not be retrieved or validated.
+type PoolMetadataInfo struct {
+	PoolID      string
+	Hex         string
+	URL         *string
+	Hash        *string
+	Ticker      *string
+	Name        *string
+	Description *string
+	Homepage    *string
+	Error       *OffchainFetchErrorInfo
+}
+
+// OffchainFetchErrorInfo describes a failed off-chain metadata fetch in
+// Blockfrost's error-object form.
+type OffchainFetchErrorInfo struct {
+	Code    string
+	Message string
 }
 
 // PoolExtendedInfo holds pool data needed by the

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -293,6 +293,34 @@ type DRepMetadataResponse struct {
 	Bytes        string          `json:"bytes"`
 }
 
+// PoolRetiringResponse is one entry of the Blockfrost retiring pools
+// list.
+type PoolRetiringResponse struct {
+	PoolID string `json:"pool_id"`
+	Epoch  uint64 `json:"epoch"`
+}
+
+// PoolMetadataResponse represents Blockfrost pool metadata. The error
+// object is only present when the off-chain document fetch failed.
+type PoolMetadataResponse struct {
+	PoolID      string                      `json:"pool_id"`
+	Hex         string                      `json:"hex"`
+	URL         *string                     `json:"url"`
+	Hash        *string                     `json:"hash"`
+	Ticker      *string                     `json:"ticker"`
+	Name        *string                     `json:"name"`
+	Description *string                     `json:"description"`
+	Homepage    *string                     `json:"homepage"`
+	Error       *OffchainFetchErrorResponse `json:"error,omitempty"`
+}
+
+// OffchainFetchErrorResponse is the Blockfrost error object attached to
+// metadata whose off-chain document fetch failed.
+type OffchainFetchErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 // ErrorResponse represents a Blockfrost error response.
 type ErrorResponse struct {
 	StatusCode int    `json:"status_code"`

--- a/database/models/offchain_metadata.go
+++ b/database/models/offchain_metadata.go
@@ -26,6 +26,15 @@ const (
 	OffchainMetadataSourceConstitution       = "constitution"
 	OffchainMetadataSourceCommitteeResign    = "committee_resign"
 
+	// OffchainFetchErrHashMismatch is the exact LastError recorded when
+	// the fetched document does not match the on-chain anchor hash. The
+	// API error classification matches on it, so the fetcher and API
+	// must agree on the text.
+	OffchainFetchErrHashMismatch = "metadata hash mismatch"
+	// OffchainFetchErrBodyTooLargePrefix prefixes the LastError recorded
+	// when the response body exceeds the fetch size limit.
+	OffchainFetchErrBodyTooLargePrefix = "response body exceeds"
+
 	OffchainMetadataStatusPending = "pending"
 	OffchainMetadataStatusFetched = "fetched"
 	OffchainMetadataStatusFailed  = "failed"

--- a/database/models/pool.go
+++ b/database/models/pool.go
@@ -113,6 +113,15 @@ func (PoolRegistrationRelay) TableName() string {
 	return "pool_registration_relay"
 }
 
+// PoolRetiringRow is one pending-retirement entry returned by
+// GetRetiringPools: the latest retirement certificate for a pool that
+// has not been cancelled by a later registration and whose epoch is
+// still in the future.
+type PoolRetiringRow struct {
+	PoolKeyHash []byte
+	Epoch       uint64
+}
+
 type PoolRetirement struct {
 	PoolKeyHash   []byte `gorm:"index;size:28"`
 	CertificateID uint   `gorm:"index"`

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -1200,3 +1200,71 @@ func (d *MetadataStoreMysql) GetPoolOwnerStakeAtSlot(
 		db, ownerKeyHashes, slot, expiryEpoch, inactivityPeriod,
 	)
 }
+
+// GetRetiringPools returns pools whose latest retirement certificate
+// targets an epoch after currentEpoch and has not been cancelled by a
+// later registration certificate. Certificate recency compares
+// (added_slot, synthetic-import precedence, block_index, cert_index),
+// mirroring the GetPools preload ordering; rows written by the Mithril
+// ledger-state import carry certificate_id = 0 and take precedence
+// within their slot. Results are ordered by retirement epoch, then
+// announcement position, matching hosted Blockfrost.
+func (d *MetadataStoreMysql) GetRetiringPools(
+	currentEpoch uint64,
+	txn types.Txn,
+) ([]models.PoolRetiringRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	const sql = `
+		WITH latest_reg AS (
+			SELECT pr.pool_key_hash, pr.added_slot,
+			       CASE WHEN pr.certificate_id = 0 THEN 1 ELSE 0 END AS synth,
+			       COALESCE(t.block_index, 0) AS block_index,
+			       COALESCE(c.cert_index, 0) AS cert_index,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY pr.pool_key_hash
+			           ORDER BY pr.added_slot DESC,
+			               CASE WHEN pr.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+			               COALESCE(t.block_index, 0) DESC,
+			               COALESCE(c.cert_index, 0) DESC
+			       ) AS rn
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN transaction t ON t.id = c.transaction_id
+		),
+		latest_ret AS (
+			SELECT pt.pool_key_hash, pt.epoch, pt.added_slot,
+			       CASE WHEN pt.certificate_id = 0 THEN 1 ELSE 0 END AS synth,
+			       COALESCE(t.block_index, 0) AS block_index,
+			       COALESCE(c.cert_index, 0) AS cert_index,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY pt.pool_key_hash
+			           ORDER BY pt.added_slot DESC,
+			               CASE WHEN pt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+			               COALESCE(t.block_index, 0) DESC,
+			               COALESCE(c.cert_index, 0) DESC
+			       ) AS rn
+			FROM pool_retirement pt
+			LEFT JOIN certs c ON c.id = pt.certificate_id
+			LEFT JOIN transaction t ON t.id = c.transaction_id
+		)
+		SELECT r.pool_key_hash, r.epoch
+		FROM latest_ret r
+		LEFT JOIN latest_reg g
+			ON g.pool_key_hash = r.pool_key_hash AND g.rn = 1
+		WHERE r.rn = 1
+		  AND r.epoch > ?
+		  AND (
+		      g.pool_key_hash IS NULL
+		      OR (r.added_slot, r.synth, r.block_index, r.cert_index)
+		         > (g.added_slot, g.synth, g.block_index, g.cert_index)
+		  )
+		ORDER BY r.epoch, r.added_slot, r.block_index, r.cert_index`
+	var rows []models.PoolRetiringRow
+	if err := db.Raw(sql, currentEpoch).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get retiring pools: %w", err)
+	}
+	return rows, nil
+}

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -1251,3 +1251,71 @@ func (d *MetadataStorePostgres) GetPoolOwnerStakeAtSlot(
 		db, ownerKeyHashes, slot, expiryEpoch, inactivityPeriod,
 	)
 }
+
+// GetRetiringPools returns pools whose latest retirement certificate
+// targets an epoch after currentEpoch and has not been cancelled by a
+// later registration certificate. Certificate recency compares
+// (added_slot, synthetic-import precedence, block_index, cert_index),
+// mirroring the GetPools preload ordering; rows written by the Mithril
+// ledger-state import carry certificate_id = 0 and take precedence
+// within their slot. Results are ordered by retirement epoch, then
+// announcement position, matching hosted Blockfrost.
+func (d *MetadataStorePostgres) GetRetiringPools(
+	currentEpoch uint64,
+	txn types.Txn,
+) ([]models.PoolRetiringRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	const sql = `
+		WITH latest_reg AS (
+			SELECT pr.pool_key_hash, pr.added_slot,
+			       CASE WHEN pr.certificate_id = 0 THEN 1 ELSE 0 END AS synth,
+			       COALESCE(t.block_index, 0) AS block_index,
+			       COALESCE(c.cert_index, 0) AS cert_index,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY pr.pool_key_hash
+			           ORDER BY pr.added_slot DESC,
+			               CASE WHEN pr.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+			               COALESCE(t.block_index, 0) DESC,
+			               COALESCE(c.cert_index, 0) DESC
+			       ) AS rn
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+		),
+		latest_ret AS (
+			SELECT pt.pool_key_hash, pt.epoch, pt.added_slot,
+			       CASE WHEN pt.certificate_id = 0 THEN 1 ELSE 0 END AS synth,
+			       COALESCE(t.block_index, 0) AS block_index,
+			       COALESCE(c.cert_index, 0) AS cert_index,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY pt.pool_key_hash
+			           ORDER BY pt.added_slot DESC,
+			               CASE WHEN pt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+			               COALESCE(t.block_index, 0) DESC,
+			               COALESCE(c.cert_index, 0) DESC
+			       ) AS rn
+			FROM pool_retirement pt
+			LEFT JOIN certs c ON c.id = pt.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+		)
+		SELECT r.pool_key_hash, r.epoch
+		FROM latest_ret r
+		LEFT JOIN latest_reg g
+			ON g.pool_key_hash = r.pool_key_hash AND g.rn = 1
+		WHERE r.rn = 1
+		  AND r.epoch > ?
+		  AND (
+		      g.pool_key_hash IS NULL
+		      OR (r.added_slot, r.synth, r.block_index, r.cert_index)
+		         > (g.added_slot, g.synth, g.block_index, g.cert_index)
+		  )
+		ORDER BY r.epoch, r.added_slot, r.block_index, r.cert_index`
+	var rows []models.PoolRetiringRow
+	if err := db.Raw(sql, currentEpoch).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get retiring pools: %w", err)
+	}
+	return rows, nil
+}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1312,3 +1312,71 @@ func (d *MetadataStoreSqlite) GetPoolOwnerStakeAtSlot(
 		db, ownerKeyHashes, slot, expiryEpoch, inactivityPeriod,
 	)
 }
+
+// GetRetiringPools returns pools whose latest retirement certificate
+// targets an epoch after currentEpoch and has not been cancelled by a
+// later registration certificate. Certificate recency compares
+// (added_slot, synthetic-import precedence, block_index, cert_index),
+// mirroring the GetPools preload ordering; rows written by the Mithril
+// ledger-state import carry certificate_id = 0 and take precedence
+// within their slot. Results are ordered by retirement epoch, then
+// announcement position, matching hosted Blockfrost.
+func (d *MetadataStoreSqlite) GetRetiringPools(
+	currentEpoch uint64,
+	txn types.Txn,
+) ([]models.PoolRetiringRow, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	const sql = `
+		WITH latest_reg AS (
+			SELECT pr.pool_key_hash, pr.added_slot,
+			       CASE WHEN pr.certificate_id = 0 THEN 1 ELSE 0 END AS synth,
+			       COALESCE(t.block_index, 0) AS block_index,
+			       COALESCE(c.cert_index, 0) AS cert_index,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY pr.pool_key_hash
+			           ORDER BY pr.added_slot DESC,
+			               CASE WHEN pr.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+			               COALESCE(t.block_index, 0) DESC,
+			               COALESCE(c.cert_index, 0) DESC
+			       ) AS rn
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+		),
+		latest_ret AS (
+			SELECT pt.pool_key_hash, pt.epoch, pt.added_slot,
+			       CASE WHEN pt.certificate_id = 0 THEN 1 ELSE 0 END AS synth,
+			       COALESCE(t.block_index, 0) AS block_index,
+			       COALESCE(c.cert_index, 0) AS cert_index,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY pt.pool_key_hash
+			           ORDER BY pt.added_slot DESC,
+			               CASE WHEN pt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+			               COALESCE(t.block_index, 0) DESC,
+			               COALESCE(c.cert_index, 0) DESC
+			       ) AS rn
+			FROM pool_retirement pt
+			LEFT JOIN certs c ON c.id = pt.certificate_id
+			LEFT JOIN "transaction" t ON t.id = c.transaction_id
+		)
+		SELECT r.pool_key_hash, r.epoch
+		FROM latest_ret r
+		LEFT JOIN latest_reg g
+			ON g.pool_key_hash = r.pool_key_hash AND g.rn = 1
+		WHERE r.rn = 1
+		  AND r.epoch > ?
+		  AND (
+		      g.pool_key_hash IS NULL
+		      OR (r.added_slot, r.synth, r.block_index, r.cert_index)
+		         > (g.added_slot, g.synth, g.block_index, g.cert_index)
+		  )
+		ORDER BY r.epoch, r.added_slot, r.block_index, r.cert_index`
+	var rows []models.PoolRetiringRow
+	if err := db.Raw(sql, currentEpoch).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get retiring pools: %w", err)
+	}
+	return rows, nil
+}

--- a/database/plugin/metadata/sqlite/pool_test.go
+++ b/database/plugin/metadata/sqlite/pool_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetRetiringPools covers pending-retirement selection: a future
+// retirement is pending, a later registration cancels it (including a
+// same-slot registration ordered after it by cert_index), past-epoch
+// retirements are excluded, and results order by retirement epoch.
+func TestGetRetiringPools(t *testing.T) {
+	store := setupTestDB(t)
+
+	seenTxs := map[uint]bool{}
+	makeCert := func(id uint, txID uint, certIndex uint, blockIndex uint32) {
+		if !seenTxs[txID] {
+			seenTxs[txID] = true
+			require.NoError(t, store.DB().Create(&models.Transaction{
+				ID:         txID,
+				Hash:       append(bytes.Repeat([]byte{0x00}, 31), byte(txID)),
+				Slot:       100,
+				BlockIndex: blockIndex,
+			}).Error)
+		}
+		require.NoError(t, store.DB().Exec(
+			"INSERT INTO certs (id, transaction_id, cert_index, cert_type, slot) VALUES (?, ?, ?, 0, 100)",
+			id, txID, certIndex,
+		).Error)
+	}
+
+	poolA := bytes.Repeat([]byte{0xA1}, 28) // pending at epoch 20
+	poolB := bytes.Repeat([]byte{0xB2}, 28) // cancelled by later-slot rereg
+	poolC := bytes.Repeat([]byte{0xC3}, 28) // cancelled by same-slot rereg (cert order)
+	poolD := bytes.Repeat([]byte{0xD4}, 28) // retirement epoch already passed
+	poolE := bytes.Repeat([]byte{0xE5}, 28) // pending at epoch 15 (orders first)
+
+	makeCert(1, 1, 0, 0) // poolA reg
+	makeCert(2, 2, 0, 0) // poolA retire
+	makeCert(3, 3, 0, 0) // poolB reg
+	makeCert(4, 4, 0, 0) // poolB retire
+	makeCert(5, 5, 0, 0) // poolB rereg (later slot)
+	makeCert(6, 6, 0, 0) // poolC reg
+	makeCert(7, 7, 0, 0) // poolC retire (same slot as rereg, lower cert_index)
+	makeCert(8, 7, 1, 0) // poolC rereg (same slot+tx block, higher cert_index)
+	makeCert(9, 9, 0, 0)  // poolD reg
+	makeCert(10, 10, 0, 0) // poolD retire (past epoch)
+	makeCert(11, 11, 0, 0) // poolE reg
+	makeCert(12, 12, 0, 0) // poolE retire
+
+	pools := [][]byte{poolA, poolB, poolC, poolD, poolE}
+	poolIDs := map[string]uint{}
+	for i, keyHash := range pools {
+		pool := models.Pool{
+			PoolKeyHash: keyHash,
+			VrfKeyHash:  bytes.Repeat([]byte{byte(0xF0 + i)}, 32),
+		}
+		require.NoError(t, store.DB().Create(&pool).Error)
+		poolIDs[string(keyHash)] = pool.ID
+	}
+
+	regs := []models.PoolRegistration{
+		{PoolKeyHash: poolA, AddedSlot: 100, CertificateID: 1},
+		{PoolKeyHash: poolB, AddedSlot: 100, CertificateID: 3},
+		{PoolKeyHash: poolB, AddedSlot: 300, CertificateID: 5},
+		{PoolKeyHash: poolC, AddedSlot: 100, CertificateID: 6},
+		{PoolKeyHash: poolC, AddedSlot: 200, CertificateID: 8},
+		{PoolKeyHash: poolD, AddedSlot: 100, CertificateID: 9},
+		{PoolKeyHash: poolE, AddedSlot: 100, CertificateID: 11},
+	}
+	for i := range regs {
+		regs[i].PoolID = poolIDs[string(regs[i].PoolKeyHash)]
+		require.NoError(t, store.DB().Create(&regs[i]).Error)
+	}
+	rets := []models.PoolRetirement{
+		{PoolKeyHash: poolA, Epoch: 20, AddedSlot: 200, CertificateID: 2},
+		{PoolKeyHash: poolB, Epoch: 20, AddedSlot: 200, CertificateID: 4},
+		{PoolKeyHash: poolC, Epoch: 20, AddedSlot: 200, CertificateID: 7},
+		{PoolKeyHash: poolD, Epoch: 5, AddedSlot: 200, CertificateID: 10},
+		{PoolKeyHash: poolE, Epoch: 15, AddedSlot: 300, CertificateID: 12},
+	}
+	for i := range rets {
+		rets[i].PoolID = poolIDs[string(rets[i].PoolKeyHash)]
+		require.NoError(t, store.DB().Create(&rets[i]).Error)
+	}
+
+	rows, err := store.GetRetiringPools(10, nil)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	// Ordered by retirement epoch: poolE (15) before poolA (20).
+	assert.Equal(t, poolE, rows[0].PoolKeyHash)
+	assert.Equal(t, uint64(15), rows[0].Epoch)
+	assert.Equal(t, poolA, rows[1].PoolKeyHash)
+	assert.Equal(t, uint64(20), rows[1].Epoch)
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -323,6 +323,17 @@ type MetadataStore interface {
 		txn types.Txn,
 	) (*models.OffchainMetadata, error)
 
+	// GetRetiringPools returns pools whose latest retirement
+	// certificate targets an epoch after currentEpoch and has not been
+	// cancelled by a later registration certificate. Certificate
+	// recency compares (added_slot, synthetic-import precedence,
+	// block_index, cert_index). Results are ordered by retirement
+	// epoch, then announcement position, matching Blockfrost.
+	GetRetiringPools(
+		currentEpoch uint64,
+		txn types.Txn,
+	) ([]models.PoolRetiringRow, error)
+
 	// GetPoolRegistrations retrieves all registration certificates for a pool.
 	GetPoolRegistrations(
 		lcommon.PoolKeyHash,

--- a/internal/offchainmetadata/fetcher.go
+++ b/internal/offchainmetadata/fetcher.go
@@ -320,7 +320,7 @@ func (f *Fetcher) fetchOne(
 		f.markFailure(
 			doc,
 			uint(resp.StatusCode),
-			errors.New("metadata hash mismatch"),
+			errors.New(models.OffchainFetchErrHashMismatch),
 		)
 		return nil
 	}
@@ -357,7 +357,11 @@ func readLimited(r io.Reader, maxBytes int64) ([]byte, error) {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}
 	if int64(len(body)) > maxBytes {
-		return nil, fmt.Errorf("response body exceeds %d bytes", maxBytes)
+		return nil, fmt.Errorf(
+			"%s %d bytes",
+			models.OffchainFetchErrBodyTooLargePrefix,
+			maxBytes,
+		)
 	}
 	return body, nil
 }


### PR DESCRIPTION
Adds two pool endpoints:

**GET /pools/retiring**

- pools whose latest retirement certificate targets a future epoch and was not cancelled by a later re-registration. Certificate recency compares (added_slot, block_index, cert_index), so a same-slot re-registration cancels correctly. Rows written by the Mithril ledger-state import (certificate_id = 0) keep their precedence within a slot.
- ordered by retirement epoch, then announcement position, same as hosted

**GET /pools/{pool_id}/metadata**

- accepts bech32 or hex pool ids, responds with the bech32 id
- on-chain url/hash from the latest registration, off-chain ticker/name/description/homepage from the metadata cache
- a pool without a metadata anchor returns {} like hosted
- failed fetches return the error object with the hosted codes and message formats: HTTP_RESPONSE_ERROR, HASH_MISMATCH, CONNECTION_ERROR, SIZE_EXCEEDED, and DECODE_ERROR for hash-valid but malformed JSON

New read-only store query GetRetiringPools (all three backends), documented in DATABASE.md. ARCHITECTURE.md router inventory updated (also adds the DRep list and address summary entries that were missing).

Validation:

- blockfrost-tests preview suite: 18/18, and the same 18 pass against hosted with a real project id, so the fixtures reflect current reality
- 50 random pools diffed byte-for-byte against hosted: everything deterministic matches, including error objects. The only differences are failure messages for pools with dead metadata URLs, where each fetcher reports its own network experience (timeouts, localhost refusal, link shorteners behaving differently per client).

Part of #2936

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blockfrost-compatible endpoints for retiring pools and pool metadata with hosted ordering, pagination, and error behavior. Also adds a cross-backend query and exact off-chain metadata error mapping.

- **New Features**
  - GET /pools/retiring: lists pools pending retirement (future epoch not canceled), ordered by epoch then announcement; paginated with standard Blockfrost headers.
  - GET /pools/{pool_id}/metadata: accepts bech32 or 56-char hex; responds with bech32 `pool_id` and `hex`; includes on-chain URL/hash and cached off-chain fields (ticker/name/description/homepage); returns {} if no anchor; returns an error object on fetch failure (HTTP_RESPONSE_ERROR, HASH_MISMATCH, SIZE_EXCEEDED, CONNECTION_ERROR, DECODE_ERROR); 400 on invalid id; 404 if pool not found.
  - New read-only `GetRetiringPools` across MySQL/Postgres/SQLite using certificate recency `(added_slot, synthetic-import precedence, block_index, cert_index)`; Mithril (`certificate_id = 0`) takes precedence within a slot. Updated `ARCHITECTURE.md`/`DATABASE.md` and added tests.

<sup>Written for commit 861ac0bc49c67b13103987299e58f019b9283b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoints for viewing pools scheduled for retirement.
  * Added pool metadata lookup, including off-chain details and fetch status.
  * Added support for both hexadecimal and bech32 pool identifiers.
* **Documentation**
  * Updated API documentation to clarify supported endpoints.
  * Added database documentation for identifying retiring pools.
* **Bug Fixes**
  * Improved metadata error reporting for hash mismatches, oversized responses, HTTP errors, and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->