### PR TITLE
fix: exact address match for utxos

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2180,6 +2180,19 @@ payload. The candidate query includes snapshot-imported live UTxOs that lack a
 producing transaction relationship, and missing or undecodable candidate CBOR
 fails the request rather than silently reporting a partial or zero balance.
 
+Full-address UTxO queries are exact at the database boundary. Metadata plugins
+first narrow candidates with payment/stake credential columns, then the
+coordinated database layer resolves each candidate's output CBOR and compares
+the complete serialized address. Credential-scoped callers explicitly use
+payment or delegation parts instead. Blockfrost address summaries and UTxO
+listings therefore distinguish enterprise and pointer addresses sharing a
+payment credential, while bare `addr_vkh`/`script` summaries intentionally
+aggregate them. UTxO-RPC `SearchUtxos` carries exact/payment/delegation intent
+as one ANDed address pattern; exact keyset queries scan through nonmatching
+coarse candidates before forming a limited page, preserving continuation-token
+correctness. Blockfrost address-transaction reads apply the same CBOR-backed
+exact check over credential-index candidates and paginate the exact matches.
+
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from
 `tx.AssetMint()` (recorded in `SetTransaction`, `SetTransactionBatched`, and

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -905,6 +905,23 @@ complete `(slot, block_index, output_idx, tx_id)` tuple; the transaction hash
 is the final key that makes the cursor unique when snapshot fallback fields
 collide.
 
+UTxO address queries carry an explicit `UtxoAddressPattern`. A complete
+`ExactAddress` is distinct from credential-scoped `PaymentPart` and
+`DelegationPart` fields; fields in one pattern are ANDed and multiple patterns
+are ORed. SQLite, MySQL, and Postgres use the stored credential columns only to
+narrow candidates. The coordinated database layer resolves output CBOR and
+compares the complete address bytes for exact patterns, which distinguishes
+enterprise addresses, pointer payloads, network IDs, and other address forms
+that share credentials. Ordered exact queries continue scanning coarse SQL
+pages until the requested number of exact matches is collected, so limits and
+UTxO-RPC continuation tokens do not skip matches hidden behind nonmatching
+credential siblings.
+
+The `address_transaction` table likewise remains a credential-based candidate
+index. Full-address transaction reads resolve participating UTxO CBOR, compare
+complete address bytes, and scan candidate pages before applying the requested
+offset and limit.
+
 ### `GetTransactionsByMetadataLabel`
 
 Transactions by metadata label:

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -2528,76 +2528,28 @@ func parseAddressOrPaymentCred(
 	return addr, false, nil
 }
 
-// isPointerAddress reports whether the address carries a pointer
-// staking reference (Shelley address types 0x4/0x5).
-func isPointerAddress(addr lcommon.Address) bool {
-	switch addr.Type() {
-	case lcommon.AddressTypeKeyPointer, lcommon.AddressTypeScriptPointer:
-		return true
-	default:
-		return false
-	}
-}
-
-// pointerAddressBalance aggregates balances for a pointer address by
-// exact address identity: SQL narrows the candidates to outputs sharing
-// the payment credential, and each candidate's output CBOR is decoded
-// to compare the full address bytes. Pointer addresses are vanishingly
-// rare, so the candidate sets stay small.
-func (a *NodeAdapter) pointerAddressBalance(
+// exactAddressBalance aggregates balances after the database layer has
+// compared each candidate's complete decoded output address.
+func (a *NodeAdapter) exactAddressBalance(
 	addr lcommon.Address,
 	txn *database.Txn,
 ) (models.AddressBalance, error) {
 	var ret models.AddressBalance
-	wantBytes, err := addr.Bytes()
+	pattern, err := models.ExactUtxoAddressPattern(addr)
 	if err != nil {
-		return ret, fmt.Errorf("encode pointer address: %w", err)
+		return ret, err
 	}
 
 	candidates, err := a.ledgerState.Database().UtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
-			Addresses: []lcommon.Address{addr},
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
 		},
 		txn,
 	)
 	if err != nil {
-		return ret, fmt.Errorf("get pointer address candidates: %w", err)
+		return ret, fmt.Errorf("get exact address UTxOs: %w", err)
 	}
-	if len(candidates) == 0 {
-		return ret, nil
-	}
-
 	for i := range candidates {
-		raw := candidates[i].Cbor
-		if len(raw) == 0 {
-			return ret, fmt.Errorf(
-				"pointer address candidate %x#%d has no output CBOR",
-				candidates[i].TxId,
-				candidates[i].OutputIdx,
-			)
-		}
-		output, err := gledger.NewTransactionOutputFromCbor(raw)
-		if err != nil {
-			return ret, fmt.Errorf(
-				"decode pointer address candidate %x#%d: %w",
-				candidates[i].TxId,
-				candidates[i].OutputIdx,
-				err,
-			)
-		}
-		outAddr := output.Address()
-		gotBytes, err := outAddr.Bytes()
-		if err != nil {
-			return ret, fmt.Errorf(
-				"encode pointer address candidate %x#%d: %w",
-				candidates[i].TxId,
-				candidates[i].OutputIdx,
-				err,
-			)
-		}
-		if !bytes.Equal(gotBytes, wantBytes) {
-			continue
-		}
 		ret.UtxoCount++
 		ret.Lovelace += uint64(candidates[i].Amount)
 		for _, asset := range candidates[i].Assets {
@@ -2674,23 +2626,16 @@ func (a *NodeAdapter) Address(
 	// forms sharing the payment credential are excluded; bare
 	// payment credentials (addr_vkh/script) deliberately aggregate
 	// across forms.
-	matchMode := models.UtxoAddressMatchExact
-	if isPaymentCred {
-		matchMode = models.UtxoAddressMatchPaymentCred
-	}
-
 	var balance models.AddressBalance
-	if !isPaymentCred && isPointerAddress(addr) {
-		// Pointer addresses cannot be distinguished from
-		// enterprise addresses (or from each other) by the stored
-		// credential columns: the pointer payload is not
-		// represented in the utxo table. Narrow candidates by
-		// payment credential in SQL, then keep only outputs whose
-		// decoded address matches the request exactly.
-		balance, err = a.pointerAddressBalance(addr, txn)
-	} else {
+	if isPaymentCred {
 		balance, err = db.Metadata().
-			GetUtxoBalanceByAddress(addr, matchMode, txn.Metadata())
+			GetUtxoBalanceByAddress(
+				addr,
+				models.UtxoAddressMatchPaymentCred,
+				txn.Metadata(),
+			)
+	} else {
+		balance, err = a.exactAddressBalance(addr, txn)
 	}
 	if err != nil {
 		return AddressInfo{}, fmt.Errorf(
@@ -2700,19 +2645,21 @@ func (a *NodeAdapter) Address(
 		)
 	}
 	if balance.UtxoCount == 0 {
-		var txCount int
+		var hasTransactions bool
 		if isPaymentCred {
 			// The synthetic enterprise address would only match
 			// enterprise usage in the per-address transaction
 			// index; a spent-out credential used via base
 			// addresses must still resolve, so count across every
 			// address carrying the payment credential.
+			var txCount int
 			txCount, err = db.CountTransactionsByPaymentCred(
 				addr.PaymentKeyHash().Bytes(),
 				txn,
 			)
+			hasTransactions = txCount > 0
 		} else {
-			txCount, err = db.CountTransactionsByAddress(addr, txn)
+			hasTransactions, err = db.HasTransactionsByAddress(addr, txn)
 		}
 		if err != nil {
 			return AddressInfo{}, fmt.Errorf(
@@ -2721,7 +2668,7 @@ func (a *NodeAdapter) Address(
 				err,
 			)
 		}
-		if txCount == 0 {
+		if !hasTransactions {
 			return AddressInfo{}, fmt.Errorf(
 				"address %q: %w",
 				address,
@@ -2814,9 +2761,13 @@ func (a *NodeAdapter) AddressUTXOs(
 		)
 	}
 
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	if err != nil {
+		return nil, 0, err
+	}
 	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
-			Addresses: []lcommon.Address{addr},
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
 		},
 	)
 	if err != nil {

--- a/api/blockfrost/adapter_block_db_test.go
+++ b/api/blockfrost/adapter_block_db_test.go
@@ -216,6 +216,63 @@ func TestNodeAdapterAddressPointerRejectsMissingCandidateCbor(t *testing.T) {
 	require.ErrorContains(t, err, "utxo cbor unavailable")
 }
 
+func TestNodeAdapterEnterpriseAddressExcludesPointerUtxos(t *testing.T) {
+	adapter, store, db := newDBBackedAdapter(t)
+
+	paymentHash := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	enterprise, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		paymentHash,
+		nil,
+	)
+	require.NoError(t, err)
+	pointer := testPointerAddress(t, paymentHash, 0x01)
+	addresses := []lcommon.Address{enterprise, pointer}
+
+	for i := range addresses {
+		txID := uint(i + 1)
+		txHash := fill32(byte(i + 1))
+		require.NoError(t, store.DB().Create(&models.Transaction{
+			ID:         txID,
+			Hash:       txHash,
+			BlockHash:  fill32(0xf0),
+			Slot:       uint64(i + 1),
+			BlockIndex: uint32(i),
+		}).Error)
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TransactionID: &txID,
+			TxId:          txHash,
+			OutputIdx:     0,
+			PaymentKey:    paymentHash,
+			AddedSlot:     uint64(i + 1),
+			Amount:        types.Uint64((i + 1) * 1_000_000),
+		}).Error)
+		raw, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+			OutputAddress: addresses[i],
+			OutputAmount:  uint64((i + 1) * 1_000_000),
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.BlobTxn(true).Do(func(txn *database.Txn) error {
+			return db.Blob().SetUtxo(txn.Blob(), txHash, 0, raw)
+		}))
+	}
+
+	info, err := adapter.Address(enterprise.String())
+	require.NoError(t, err)
+	require.Len(t, info.Amount, 1)
+	assert.Equal(t, "1000000", info.Amount[0].Quantity)
+
+	utxos, total, err := adapter.AddressUTXOs(
+		enterprise.String(),
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	assert.Equal(t, 1, total)
+	assert.Equal(t, hex.EncodeToString(fill32(0x01)), utxos[0].TxHash)
+}
+
 // TestNodeAdapterBlockOutputAndFees exercises the real DB aggregation path,
 // including the phase-2 invalid transaction branch where the collateral return
 // (not the discarded outputs) counts toward block output.

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -1653,8 +1653,8 @@ func parsePaginationOrWriteError(
 	w http.ResponseWriter,
 	r *http.Request,
 ) (PaginationParams, bool) {
-	params, err := ParsePagination(r)
-	if err != nil {
+	params, errMsg := ParsePaginationStrict(r)
+	if errMsg != "" {
 		writeError(
 			w,
 			http.StatusBadRequest,

--- a/api/utxorpc/doc.go
+++ b/api/utxorpc/doc.go
@@ -23,8 +23,10 @@
 //
 // # Predicate evaluation
 //
-// SearchUtxos uses UtxoPredicate filters over live UTxOs; a nil
-// SearchUtxos predicate scans all addresses. TxPredicate evaluation for
+// SearchUtxos uses UtxoPredicate filters over live UTxOs. Exact addresses are
+// compared by complete output address bytes, while payment/delegation parts
+// are credential-scoped; a nil SearchUtxos predicate scans all addresses.
+// TxPredicate evaluation for
 // transaction streams uses composite operators (not / all_of / any_of)
 // around leaf predicates (address, policy, certificate, consumes,
 // produces, …). That path is stricter: evalTxPredicateOutcome returns

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -181,33 +181,53 @@ func searchUtxoModelToAnyData(utxo *models.UtxoWithOrdering) (*query.AnyUtxoData
 	return &aud, nil
 }
 
-// dedupeSearchAddresses drops duplicate ledger addresses with the same full
-// payment credential identity (type + hash) and full stake credential identity
-// (type + hash). A key-hash payment and a script-hash payment that share the
-// same 28-byte hash are distinct addresses and must not be collapsed.
-func dedupeSearchAddresses(addrs []ledger.Address) []ledger.Address {
-	if len(addrs) < 2 {
-		return addrs
+func searchUtxoAddressPatterns(
+	addressPattern *utxorpcCardano.AddressPattern,
+) ([]models.UtxoAddressPattern, error) {
+	if addressPattern == nil {
+		return nil, nil
 	}
-	seen := make(map[string]struct{}, len(addrs))
-	out := make([]ledger.Address, 0, len(addrs))
-	for _, a := range addrs {
-		pkb := a.PaymentKeyHash().Bytes()
-		skb := a.StakeKeyHash().Bytes()
-		paymentTag := byte(a.Type() & lcommon.AddressTypeScriptBit)
-		stakeTag := byte(0)
-		if _, ok := a.StakingPayload().(lcommon.AddressPayloadScriptHash); ok {
-			stakeTag = 1
-		}
-		key := string([]byte{paymentTag}) + string(pkb) + "\x00" +
-			string([]byte{stakeTag}) + string(skb)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, a)
+	pattern := models.UtxoAddressPattern{
+		ExactAddress:   addressPattern.GetExactAddress(),
+		PaymentPart:    addressPattern.GetPaymentPart(),
+		DelegationPart: addressPattern.GetDelegationPart(),
 	}
-	return out
+	if len(pattern.ExactAddress) > 0 {
+		if _, err := lcommon.NewAddressFromBytes(
+			pattern.ExactAddress,
+		); err != nil {
+			return nil, connect.NewError(
+				connect.CodeInvalidArgument,
+				fmt.Errorf("failed to decode exact address: %w", err),
+			)
+		}
+	}
+	if len(pattern.PaymentPart) > 0 &&
+		len(pattern.PaymentPart) != lcommon.AddressHashSize {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			fmt.Errorf(
+				"invalid payment part length %d",
+				len(pattern.PaymentPart),
+			),
+		)
+	}
+	if len(pattern.DelegationPart) > 0 &&
+		len(pattern.DelegationPart) != lcommon.AddressHashSize {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			fmt.Errorf(
+				"invalid delegation part length %d",
+				len(pattern.DelegationPart),
+			),
+		)
+	}
+	if len(pattern.ExactAddress) == 0 &&
+		len(pattern.PaymentPart) == 0 &&
+		len(pattern.DelegationPart) == 0 {
+		return nil, nil
+	}
+	return []models.UtxoAddressPattern{pattern}, nil
 }
 
 // ReadParams
@@ -562,50 +582,12 @@ func (s *queryServiceServer) SearchUtxos(
 		assetPattern,
 	)
 
-	var addresses []ledger.Address
-	if addressPattern != nil {
-		exactAddressBytes := addressPattern.GetExactAddress()
-		if exactAddressBytes != nil {
-			var addr ledger.Address
-			err := addr.UnmarshalCBOR(exactAddressBytes)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"failed to decode exact address: %w",
-					err,
-				)
-			}
-			addresses = append(addresses, addr)
-		}
-
-		paymentPart := addressPattern.GetPaymentPart()
-		if paymentPart != nil {
-			s.utxorpc.config.Logger.Info("PaymentPart is present, decoding...")
-			var paymentAddr ledger.Address
-			err := paymentAddr.UnmarshalCBOR(paymentPart)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode payment part: %w", err)
-			}
-			addresses = append(addresses, paymentAddr)
-		}
-
-		delegationPart := addressPattern.GetDelegationPart()
-		if delegationPart != nil {
-			s.utxorpc.config.Logger.Info(
-				"DelegationPart is present, decoding...",
-			)
-			var delegationAddr ledger.Address
-			err := delegationAddr.UnmarshalCBOR(delegationPart)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"failed to decode delegation part: %w",
-					err,
-				)
-			}
-			addresses = append(addresses, delegationAddr)
-		}
+	addressPatterns, err := searchUtxoAddressPatterns(addressPattern)
+	if err != nil {
+		return nil, err
 	}
 
-	if !matchAllAddresses && len(addresses) == 0 {
+	if !matchAllAddresses && len(addressPatterns) == 0 {
 		resp.LedgerTip = s.searchUtxosLedgerTip()
 		return connect.NewResponse(resp), nil
 	}
@@ -629,10 +611,6 @@ func (s *queryServiceServer) SearchUtxos(
 		assetName = assetPattern.GetAssetName()
 	}
 
-	if !matchAllAddresses {
-		addresses = dedupeSearchAddresses(addresses)
-	}
-
 	after, err := parseSearchUtxosStartToken(startToken)
 	if err != nil {
 		return nil, err
@@ -640,7 +618,7 @@ func (s *queryServiceServer) SearchUtxos(
 
 	utxoQ := &models.UtxoWithOrderingQuery{
 		MatchAllAddresses: matchAllAddresses,
-		Addresses:         addresses,
+		AddressPatterns:   addressPatterns,
 		After:             after,
 		Limit:             int(effectiveMax) + 1,
 		FilterByAsset:     filterByAsset,

--- a/api/utxorpc/query_test.go
+++ b/api/utxorpc/query_test.go
@@ -19,8 +19,10 @@ import (
 	"math"
 	"testing"
 
+	"connectrpc.com/connect"
+	"github.com/blinklabs-io/dingo/database/models"
 	ouroboros "github.com/blinklabs-io/gouroboros"
-	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/require"
 	utxorpcCardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 	query "github.com/utxorpc/go-codegen/utxorpc/v1alpha/query"
@@ -147,15 +149,67 @@ func TestSearchUtxosMatchAllAddresses(t *testing.T) {
 	require.True(t, searchUtxosMatchAllAddresses(nil, nil, nil))
 }
 
-func TestDedupeSearchAddresses(t *testing.T) {
-	paymentKey := make([]byte, 28)
-	stakeKey := make([]byte, 28)
-	a1, err := ledger.NewAddressFromParts(0, 0, paymentKey, stakeKey)
+func TestSearchUtxoAddressPatternsPreservesMatchIntent(t *testing.T) {
+	payment := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	stake := bytes.Repeat([]byte{0xcd}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		stake,
+	)
 	require.NoError(t, err)
-	a2, err := ledger.NewAddressFromParts(0, 0, paymentKey, stakeKey)
+	addrBytes, err := addr.Bytes()
 	require.NoError(t, err)
-	out := dedupeSearchAddresses([]ledger.Address{a1, a2})
-	require.Len(t, out, 1)
+
+	got, err := searchUtxoAddressPatterns(&utxorpcCardano.AddressPattern{
+		ExactAddress:   addrBytes,
+		PaymentPart:    payment,
+		DelegationPart: stake,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []models.UtxoAddressPattern{{
+		ExactAddress:   addrBytes,
+		PaymentPart:    payment,
+		DelegationPart: stake,
+	}}, got)
+}
+
+func TestSearchUtxoAddressPatternsRejectsInvalidCredentialLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern *utxorpcCardano.AddressPattern
+		message string
+	}{
+		{
+			name: "exact address",
+			pattern: &utxorpcCardano.AddressPattern{
+				ExactAddress: []byte{0x01},
+			},
+			message: "failed to decode exact address",
+		},
+		{
+			name: "payment part",
+			pattern: &utxorpcCardano.AddressPattern{
+				PaymentPart: []byte{0x01},
+			},
+			message: "invalid payment part length",
+		},
+		{
+			name: "delegation part",
+			pattern: &utxorpcCardano.AddressPattern{
+				DelegationPart: []byte{0x01},
+			},
+			message: "invalid delegation part length",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := searchUtxoAddressPatterns(tc.pattern)
+			require.ErrorContains(t, err, tc.message)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		})
+	}
 }
 
 func TestExtractSearchPredicatePatterns_NilPredicate(t *testing.T) {

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -15,7 +15,10 @@
 package models
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -27,17 +30,154 @@ var (
 	ErrNilUtxoWithOrderingQuery = errors.New(
 		"nil UtxoWithOrderingQuery",
 	)
-	ErrEmptyAssetPolicyID = errors.New("empty asset policy id")
+	ErrEmptyAssetPolicyID       = errors.New("empty asset policy id")
+	ErrEmptyUtxoAddressPattern  = errors.New("empty UTxO address pattern")
+	ErrExactAddressRequiresCbor = errors.New(
+		"exact address matching requires output CBOR",
+	)
 )
+
+// UtxoAddressPattern carries explicit address-match intent through the shared
+// query API. Fields within one pattern are ANDed; multiple patterns are ORed.
+// ExactAddress is the complete serialized address, while PaymentPart and
+// DelegationPart deliberately match credentials across address forms.
+type UtxoAddressPattern struct {
+	ExactAddress   []byte
+	PaymentPart    []byte
+	DelegationPart []byte
+}
+
+// ExactUtxoAddressPattern builds an exact pattern from a decoded address.
+func ExactUtxoAddressPattern(addr ledger.Address) (UtxoAddressPattern, error) {
+	addrBytes, err := addr.Bytes()
+	if err != nil {
+		return UtxoAddressPattern{}, fmt.Errorf("encode exact address: %w", err)
+	}
+	return UtxoAddressPattern{ExactAddress: addrBytes}, nil
+}
+
+// RequiresExactAddressFilter reports whether candidate rows must be checked
+// against decoded output CBOR after the coarse SQL credential predicate.
+func RequiresExactAddressFilter(patterns []UtxoAddressPattern) bool {
+	for i := range patterns {
+		if len(patterns[i].ExactAddress) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesUtxoAddressPatterns applies the full address-pattern contract to a
+// decoded output address.
+func MatchesUtxoAddressPatterns(
+	addr ledger.Address,
+	patterns []UtxoAddressPattern,
+) (bool, error) {
+	if len(patterns) == 0 {
+		return false, nil
+	}
+	for i := range patterns {
+		if len(patterns[i].ExactAddress) == 0 &&
+			len(patterns[i].PaymentPart) == 0 &&
+			len(patterns[i].DelegationPart) == 0 {
+			return false, ErrEmptyUtxoAddressPattern
+		}
+	}
+	addrBytes, err := addr.Bytes()
+	if err != nil {
+		return false, fmt.Errorf("encode output address: %w", err)
+	}
+	for i := range patterns {
+		pattern := patterns[i]
+		if len(pattern.ExactAddress) > 0 &&
+			!bytes.Equal(addrBytes, pattern.ExactAddress) {
+			continue
+		}
+		if len(pattern.PaymentPart) > 0 &&
+			!bytes.Equal(addr.PaymentKeyHash().Bytes(), pattern.PaymentPart) {
+			continue
+		}
+		if len(pattern.DelegationPart) > 0 &&
+			!bytes.Equal(addr.StakeKeyHash().Bytes(), pattern.DelegationPart) {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// AppendUtxoAddressPatternOrBranch appends one coarse SQL branch. Exact
+// addresses are narrowed by their stored credentials and later compared by
+// complete serialized bytes after CBOR resolution.
+func AppendUtxoAddressPatternOrBranch(
+	ors *[]string,
+	args *[]any,
+	pattern UtxoAddressPattern,
+) error {
+	var ands []string
+	var branchArgs []any
+	if len(pattern.ExactAddress) > 0 {
+		addr, err := lcommon.NewAddressFromBytes(pattern.ExactAddress)
+		if err != nil {
+			return fmt.Errorf("decode exact address: %w", err)
+		}
+		var exactOrs []string
+		var exactArgs []any
+		if err := AppendUtxoAddressOrBranchMode(
+			&exactOrs,
+			&exactArgs,
+			addr,
+			UtxoAddressMatchPaymentCred,
+		); err != nil {
+			return err
+		}
+		if len(exactOrs) == 0 {
+			ands = append(
+				ands,
+				"((utxo.payment_key IS NULL OR LENGTH(utxo.payment_key) = 0) AND (utxo.staking_key IS NULL OR LENGTH(utxo.staking_key) = 0))",
+			)
+		} else {
+			ands = append(ands, exactOrs[0])
+			branchArgs = append(branchArgs, exactArgs...)
+		}
+	}
+	if len(pattern.PaymentPart) > 0 {
+		if len(pattern.PaymentPart) != lcommon.AddressHashSize {
+			return fmt.Errorf(
+				"payment part length %d, expected %d",
+				len(pattern.PaymentPart),
+				lcommon.AddressHashSize,
+			)
+		}
+		ands = append(ands, "utxo.payment_key = ?")
+		branchArgs = append(branchArgs, pattern.PaymentPart)
+	}
+	if len(pattern.DelegationPart) > 0 {
+		if len(pattern.DelegationPart) != lcommon.AddressHashSize {
+			return fmt.Errorf(
+				"delegation part length %d, expected %d",
+				len(pattern.DelegationPart),
+				lcommon.AddressHashSize,
+			)
+		}
+		ands = append(ands, "utxo.staking_key = ?")
+		branchArgs = append(branchArgs, pattern.DelegationPart)
+	}
+	if len(ands) == 0 {
+		return ErrEmptyUtxoAddressPattern
+	}
+	*ors = append(*ors, "("+strings.Join(ands, " AND ")+")")
+	*args = append(*args, branchArgs...)
+	return nil
+}
 
 // UtxoAddressMatchMode selects how an address matches utxo rows.
 type UtxoAddressMatchMode int
 
 const (
-	// UtxoAddressMatchExact preserves full-address identity: a
-	// payment-only (enterprise/pointer) address matches only rows
-	// with no staking part, so base-address UTxOs sharing the same
-	// payment credential are excluded.
+	// UtxoAddressMatchExact requests full-address identity. Metadata-only
+	// aggregate queries reject this mode because exact identity requires
+	// output CBOR; use UtxoAddressPattern through the coordinated Database.
 	UtxoAddressMatchExact UtxoAddressMatchMode = iota
 	// UtxoAddressMatchPaymentCred aggregates across every address
 	// form sharing the payment credential, mirroring Blockfrost's
@@ -68,6 +208,9 @@ func AppendUtxoAddressOrBranchMode(
 	addr ledger.Address,
 	mode UtxoAddressMatchMode,
 ) error {
+	if mode == UtxoAddressMatchExact {
+		return ErrExactAddressRequiresCbor
+	}
 	zeroHash := lcommon.NewBlake2b224(nil)
 	pk := addr.PaymentKeyHash()
 	sk := addr.StakeKeyHash()
@@ -92,16 +235,6 @@ func AppendUtxoAddressOrBranchMode(
 			sk.Bytes(),
 		)
 	case hasPayment:
-		if mode == UtxoAddressMatchExact {
-			// LENGTH counts bytes for blob columns on SQLite,
-			// MySQL, and Postgres alike.
-			*ors = append(
-				*ors,
-				"(utxo.payment_script = ? AND utxo.payment_key = ? AND (utxo.staking_key IS NULL OR LENGTH(utxo.staking_key) = 0))",
-			)
-			*args = append(*args, paymentScript, pk.Bytes())
-			break
-		}
 		*ors = append(*ors, "(utxo.payment_script = ? AND utxo.payment_key = ?)")
 		*args = append(*args, paymentScript, pk.Bytes())
 	case hasStake:
@@ -177,11 +310,10 @@ type UtxoOrderingCursor struct {
 //   - MatchAllAddresses true: do not filter by payment/stake keys (all live UTxOs, subject
 //     to asset filter if set). SearchUtxos sets this when the predicate is nil or is
 //     asset-only (no address pattern).
-//   - MatchAllAddresses false and len(Addresses) == 0: match no rows (caller uses this when
+//   - MatchAllAddresses false and len(AddressPatterns) == 0: match no rows (caller uses this when
 //     a predicate was given but no Cardano address parts could be decoded).
-//   - MatchAllAddresses false and len(Addresses) > 0: match UTxOs that satisfy ANY branch
-//     (OR): exact / payment-only / stake-only per address, same rules as legacy
-//     addressWhereClause.
+//   - MatchAllAddresses false and len(AddressPatterns) > 0: match UTxOs that
+//     satisfy any pattern. Fields within a pattern are ANDed; patterns are ORed.
 //
 // After + Limit: keyset pagination; Limit <= 0 means no SQL LIMIT. SearchUtxos sets Limit to
 // effective page size + 1.
@@ -190,7 +322,7 @@ type UtxoOrderingCursor struct {
 // the policy (same semantics as GetUtxosByAssets).
 type UtxoWithOrderingQuery struct {
 	MatchAllAddresses bool
-	Addresses         []ledger.Address
+	AddressPatterns   []UtxoAddressPattern
 	After             *UtxoOrderingCursor
 	Limit             int
 	FilterByAsset     bool

--- a/database/models/utxo_test.go
+++ b/database/models/utxo_test.go
@@ -93,3 +93,26 @@ func TestUtxoLedgerToModelPaymentScript(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesUtxoAddressPatternsRejectsEmptyPattern(t *testing.T) {
+	payment := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+
+	addrBytes, err := addr.Bytes()
+	require.NoError(t, err)
+	match, err := MatchesUtxoAddressPatterns(
+		addr,
+		[]UtxoAddressPattern{
+			{ExactAddress: addrBytes},
+			{},
+		},
+	)
+	require.ErrorIs(t, err, ErrEmptyUtxoAddressPattern)
+	require.False(t, match)
+}

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -305,9 +305,25 @@ func addressWhereClause(
 	}
 }
 
+func addressPatternWhereClause(
+	db *gorm.DB,
+	pattern models.UtxoAddressPattern,
+) (*gorm.DB, error) {
+	var ors []string
+	var args []any
+	if err := models.AppendUtxoAddressPatternOrBranch(
+		&ors,
+		&args,
+		pattern,
+	); err != nil {
+		return nil, err
+	}
+	return db.Where(ors[0], args...), nil
+}
+
 // GetUtxosByAddress returns a list of Utxos
 func (d *MetadataStoreMysql) GetUtxosByAddress(
-	addr ledger.Address,
+	pattern models.UtxoAddressPattern,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
@@ -315,7 +331,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery, err := addressWhereClause(db, addr)
+	addrQuery, err := addressPatternWhereClause(db, pattern)
 	if err != nil {
 		return nil, err
 	}
@@ -410,16 +426,20 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 		Joins("LEFT JOIN transaction ON utxo.transaction_id = transaction.id").
 		Where("utxo.deleted_slot = 0")
 
-	addrs := q.Addresses
+	patterns := q.AddressPatterns
 	switch {
 	case q.MatchAllAddresses:
-	case len(addrs) == 0:
+	case len(patterns) == 0:
 		base = base.Where("1 = 0")
 	default:
 		var ors []string
 		var args []any
-		for i := range addrs {
-			if err := models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i]); err != nil {
+		for i := range patterns {
+			if err := models.AppendUtxoAddressPatternOrBranch(
+				&ors,
+				&args,
+				patterns[i],
+			); err != nil {
 				return nil, fmt.Errorf(
 					"GetUtxosByAddressWithOrdering: %w",
 					err,
@@ -532,7 +552,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddressWithOrdering(
 // GetUtxosByAddressAtSlot returns UTxOs for an address
 // that existed at a specific slot.
 func (d *MetadataStoreMysql) GetUtxosByAddressAtSlot(
-	addr lcommon.Address,
+	pattern models.UtxoAddressPattern,
 	slot uint64,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
@@ -541,7 +561,7 @@ func (d *MetadataStoreMysql) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery, err := addressWhereClause(db, addr)
+	addrQuery, err := addressPatternWhereClause(db, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -361,9 +361,25 @@ func addressWhereClause(
 	}
 }
 
+func addressPatternWhereClause(
+	db *gorm.DB,
+	pattern models.UtxoAddressPattern,
+) (*gorm.DB, error) {
+	var ors []string
+	var args []any
+	if err := models.AppendUtxoAddressPatternOrBranch(
+		&ors,
+		&args,
+		pattern,
+	); err != nil {
+		return nil, err
+	}
+	return db.Where(ors[0], args...), nil
+}
+
 // GetUtxosByAddress returns a list of Utxos
 func (d *MetadataStorePostgres) GetUtxosByAddress(
-	addr ledger.Address,
+	pattern models.UtxoAddressPattern,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
@@ -371,7 +387,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery, err := addressWhereClause(db, addr)
+	addrQuery, err := addressPatternWhereClause(db, pattern)
 	if err != nil {
 		return nil, err
 	}
@@ -410,16 +426,20 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 		Joins("LEFT JOIN transaction ON utxo.transaction_id = transaction.id").
 		Where("utxo.deleted_slot = 0")
 
-	addrs := q.Addresses
+	patterns := q.AddressPatterns
 	switch {
 	case q.MatchAllAddresses:
-	case len(addrs) == 0:
+	case len(patterns) == 0:
 		base = base.Where("1 = 0")
 	default:
 		var ors []string
 		var args []any
-		for i := range addrs {
-			if err := models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i]); err != nil {
+		for i := range patterns {
+			if err := models.AppendUtxoAddressPatternOrBranch(
+				&ors,
+				&args,
+				patterns[i],
+			); err != nil {
 				return nil, fmt.Errorf(
 					"GetUtxosByAddressWithOrdering: %w",
 					err,
@@ -532,7 +552,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddressWithOrdering(
 // GetUtxosByAddressAtSlot returns UTxOs for an address
 // that existed at a specific slot.
 func (d *MetadataStorePostgres) GetUtxosByAddressAtSlot(
-	addr lcommon.Address,
+	pattern models.UtxoAddressPattern,
 	slot uint64,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
@@ -541,7 +561,7 @@ func (d *MetadataStorePostgres) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery, err := addressWhereClause(db, addr)
+	addrQuery, err := addressPatternWhereClause(db, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -376,9 +376,25 @@ func addressWhereClause(
 	}
 }
 
+func addressPatternWhereClause(
+	db *gorm.DB,
+	pattern models.UtxoAddressPattern,
+) (*gorm.DB, error) {
+	var ors []string
+	var args []any
+	if err := models.AppendUtxoAddressPatternOrBranch(
+		&ors,
+		&args,
+		pattern,
+	); err != nil {
+		return nil, err
+	}
+	return db.Where(ors[0], args...), nil
+}
+
 // GetUtxosByAddress returns a list of Utxos
 func (d *MetadataStoreSqlite) GetUtxosByAddress(
-	addr ledger.Address,
+	pattern models.UtxoAddressPattern,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	var ret []models.Utxo
@@ -386,7 +402,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddress(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery, err := addressWhereClause(db, addr)
+	addrQuery, err := addressPatternWhereClause(db, pattern)
 	if err != nil {
 		return nil, err
 	}
@@ -487,17 +503,21 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 		).
 		Where("utxo.deleted_slot = 0")
 
-	addrs := q.Addresses
+	patterns := q.AddressPatterns
 	switch {
 	case q.MatchAllAddresses:
 		// No payment_key / staking_key filter.
-	case len(addrs) == 0:
+	case len(patterns) == 0:
 		base = base.Where("1 = 0")
 	default:
 		var ors []string
 		var args []any
-		for i := range addrs {
-			if err := models.AppendUtxoAddressOrBranch(&ors, &args, addrs[i]); err != nil {
+		for i := range patterns {
+			if err := models.AppendUtxoAddressPatternOrBranch(
+				&ors,
+				&args,
+				patterns[i],
+			); err != nil {
 				return nil, fmt.Errorf(
 					"GetUtxosByAddressWithOrdering: %w",
 					err,
@@ -610,7 +630,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressWithOrdering(
 // GetUtxosByAddressAtSlot returns UTxOs for an address
 // that existed at a specific slot.
 func (d *MetadataStoreSqlite) GetUtxosByAddressAtSlot(
-	addr lcommon.Address,
+	pattern models.UtxoAddressPattern,
 	slot uint64,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
@@ -619,7 +639,7 @@ func (d *MetadataStoreSqlite) GetUtxosByAddressAtSlot(
 	if err != nil {
 		return nil, err
 	}
-	addrQuery, err := addressWhereClause(db, addr)
+	addrQuery, err := addressPatternWhereClause(db, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/database/plugin/metadata/sqlite/utxo_test.go
+++ b/database/plugin/metadata/sqlite/utxo_test.go
@@ -716,20 +716,26 @@ func TestGetUtxosByAddressUsesPaymentScript(t *testing.T) {
 	require.NoError(t, store.DB().Create(&keyUtxo).Error)
 	require.NoError(t, store.DB().Create(&scriptUtxo).Error)
 
-	keyRows, err := store.GetUtxosByAddress(keyAddr, nil)
+	keyPattern, err := models.ExactUtxoAddressPattern(keyAddr)
+	require.NoError(t, err)
+	keyRows, err := store.GetUtxosByAddress(keyPattern, nil)
 	require.NoError(t, err)
 	require.Len(t, keyRows, 1)
 	assert.False(t, keyRows[0].PaymentScript)
 	assert.Equal(t, keyUtxo.TxId, keyRows[0].TxId)
 
-	scriptRows, err := store.GetUtxosByAddress(scriptAddr, nil)
+	scriptPattern, err := models.ExactUtxoAddressPattern(scriptAddr)
+	require.NoError(t, err)
+	scriptRows, err := store.GetUtxosByAddress(scriptPattern, nil)
 	require.NoError(t, err)
 	require.Len(t, scriptRows, 1)
 	assert.True(t, scriptRows[0].PaymentScript)
 	assert.Equal(t, scriptUtxo.TxId, scriptRows[0].TxId)
 
 	orderedRows, err := store.GetUtxosByAddressWithOrdering(
-		&models.UtxoWithOrderingQuery{Addresses: []lcommon.Address{scriptAddr}},
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{scriptPattern},
+		},
 		nil,
 	)
 	require.NoError(t, err)
@@ -779,10 +785,12 @@ func TestGetUtxosByAddressWithOrderingIncludesSnapshotUtxos(t *testing.T) {
 	for i := range rows {
 		require.NoError(t, store.DB().Create(&rows[i]).Error)
 	}
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
 
 	got, err := store.GetUtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
-			Addresses: []lcommon.Address{addr},
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
 		},
 		nil,
 	)
@@ -836,11 +844,13 @@ func TestGetUtxosByAddressWithOrderingPaginatesCollidingSnapshotUtxos(
 	for i := range rows {
 		require.NoError(t, store.DB().Create(&rows[i]).Error)
 	}
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
 
 	firstPage, err := store.GetUtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
-			Addresses: []lcommon.Address{addr},
-			Limit:     2,
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+			Limit:           2,
 		},
 		nil,
 	)
@@ -852,7 +862,7 @@ func TestGetUtxosByAddressWithOrderingPaginatesCollidingSnapshotUtxos(
 	last := firstPage[len(firstPage)-1]
 	secondPage, err := store.GetUtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
-			Addresses: []lcommon.Address{addr},
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
 			After: &models.UtxoOrderingCursor{
 				Slot:       last.TxSlot,
 				BlockIndex: last.TxBlockIndex,
@@ -888,14 +898,6 @@ func TestGetUtxoBalanceByAddressMatchModes(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	baseAddr, err := lcommon.NewAddressFromParts(
-		lcommon.AddressTypeKeyKey,
-		lcommon.AddressNetworkTestnet,
-		paymentHash,
-		stakeHash,
-	)
-	require.NoError(t, err)
-
 	rows := []models.Utxo{
 		// Enterprise-form UTxO (no staking part).
 		{
@@ -949,25 +951,16 @@ func TestGetUtxoBalanceByAddressMatchModes(t *testing.T) {
 		require.NoError(t, store.DB().Create(&rows[i]).Error)
 	}
 
-	// Exact enterprise matching excludes the base-address UTxO.
-	balance, err := store.GetUtxoBalanceByAddress(
+	// Metadata-only aggregation cannot promise exact identity because pointer
+	// payloads and network IDs are available only in output CBOR.
+	_, err = store.GetUtxoBalanceByAddress(
 		enterpriseAddr, models.UtxoAddressMatchExact, nil,
 	)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(5_000_000), balance.Lovelace)
-	assert.Equal(t, int64(2), balance.UtxoCount)
-
-	// Exact base matching returns only the base-address UTxO.
-	balance, err = store.GetUtxoBalanceByAddress(
-		baseAddr, models.UtxoAddressMatchExact, nil,
-	)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(2_000_000), balance.Lovelace)
-	assert.Equal(t, int64(1), balance.UtxoCount)
+	require.ErrorIs(t, err, models.ErrExactAddressRequiresCbor)
 
 	// Payment-credential matching aggregates every live UTxO sharing
 	// the credential, across address forms.
-	balance, err = store.GetUtxoBalanceByAddress(
+	balance, err := store.GetUtxoBalanceByAddress(
 		enterpriseAddr, models.UtxoAddressMatchPaymentCred, nil,
 	)
 	require.NoError(t, err)

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1147,8 +1147,13 @@ type MetadataStore interface {
 	// window for historical transaction queries.
 	GetUtxosBySlot(uint64, types.Txn) ([]models.UtxoId, error)
 
-	// GetUtxosByAddress retrieves all UTxOs for a given address.
-	GetUtxosByAddress(ledger.Address, types.Txn) ([]models.Utxo, error)
+	// GetUtxosByAddress retrieves coarse SQL candidates for an explicit
+	// address pattern. The database layer performs full exact-address CBOR
+	// filtering when ExactAddress is set.
+	GetUtxosByAddress(
+		models.UtxoAddressPattern,
+		types.Txn,
+	) ([]models.Utxo, error)
 
 	// GetControlledAmountByCredential returns the sum of live UTxO
 	// amounts controlled by the given stake credential.
@@ -1165,11 +1170,10 @@ type MetadataStore interface {
 
 	// GetUtxoBalanceByAddress returns the live-UTxO lovelace balance,
 	// per-asset balances (ordered by policy id then name), and live UTxO
-	// count for the given address, aggregated in SQL. The match mode
-	// selects full-address identity (exact) or payment-credential
-	// aggregation. Used by the Blockfrost address summary endpoint,
-	// where loading every UTxO row for aggregation in Go is too slow
-	// for large addresses.
+	// count for the given address, aggregated in SQL. Payment-credential
+	// mode aggregates across address forms. Exact mode returns
+	// models.ErrExactAddressRequiresCbor; exact summaries use the coordinated
+	// Database query path instead.
 	GetUtxoBalanceByAddress(
 		lcommon.Address,
 		models.UtxoAddressMatchMode,
@@ -1188,7 +1192,7 @@ type MetadataStore interface {
 
 	// GetUtxosByAddressAtSlot retrieves all UTxOs for a given address at a specific slot.
 	GetUtxosByAddressAtSlot(
-		lcommon.Address,
+		models.UtxoAddressPattern,
 		uint64,
 		types.Txn,
 	) ([]models.Utxo, error)

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1080,25 +1080,8 @@ func (d *Database) GetTransactionsByAddress(
 	offset int,
 	txn *Txn,
 ) ([]models.Transaction, error) {
-	zeroHash := lcommon.NewBlake2b224(nil)
-	var paymentKey []byte
-	var credentialTag uint8
-	var stakingKey []byte
-	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
-		paymentKey = pkh.Bytes()
-	}
-	if skh := addr.StakeKeyHash(); skh != zeroHash {
-		var ok bool
-		credentialTag, ok = models.StakeCredentialTagFromAddress(addr)
-		if !ok {
-			return nil, errors.New("derive stake credential tag from address")
-		}
-		stakingKey = skh.Bytes()
-	}
-	return d.GetTransactionsByAddressKeys(
-		paymentKey,
-		credentialTag,
-		stakingKey,
+	return d.getTransactionsByExactAddress(
+		addr,
 		limit,
 		offset,
 		"desc",
@@ -1115,6 +1098,18 @@ func (d *Database) GetTransactionsByAddressWithOrder(
 	order string,
 	txn *Txn,
 ) ([]models.Transaction, error) {
+	return d.getTransactionsByExactAddress(
+		addr,
+		limit,
+		offset,
+		order,
+		txn,
+	)
+}
+
+func addressTransactionKeys(
+	addr lcommon.Address,
+) ([]byte, uint8, []byte, error) {
 	zeroHash := lcommon.NewBlake2b224(nil)
 	var paymentKey []byte
 	var credentialTag uint8
@@ -1126,19 +1121,146 @@ func (d *Database) GetTransactionsByAddressWithOrder(
 		var ok bool
 		credentialTag, ok = models.StakeCredentialTagFromAddress(addr)
 		if !ok {
-			return nil, errors.New("derive stake credential tag from address")
+			return nil, 0, nil, errors.New(
+				"derive stake credential tag from address",
+			)
 		}
 		stakingKey = skh.Bytes()
 	}
-	return d.GetTransactionsByAddressKeys(
-		paymentKey,
-		credentialTag,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		txn,
+	return paymentKey, credentialTag, stakingKey, nil
+}
+
+func (d *Database) getTransactionsByExactAddress(
+	addr lcommon.Address,
+	limit int,
+	offset int,
+	order string,
+	txn *Txn,
+) ([]models.Transaction, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	paymentKey, credentialTag, stakingKey, err := addressTransactionKeys(addr)
+	if err != nil {
+		return nil, err
+	}
+	exactAddress, err := addr.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encode exact transaction address: %w", err)
+	}
+
+	const candidateBatchSize = 128
+	initialCapacity := min(max(limit, 0), candidateBatchSize)
+	ret := make([]models.Transaction, 0, initialCapacity)
+	candidateOffset := 0
+	candidatesProcessed := 0
+	matchesSkipped := 0
+	for {
+		remainingCandidates := exactAddressCandidateScanLimit -
+			candidatesProcessed
+		if remainingCandidates <= 0 {
+			return ret, errExactAddressCandidateScanLimit
+		}
+		batchSize := min(candidateBatchSize, remainingCandidates)
+		candidates, err := d.metadata.GetTransactionsByAddress(
+			paymentKey,
+			credentialTag,
+			stakingKey,
+			batchSize,
+			candidateOffset,
+			order,
+			txn.Metadata(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"get exact-address transaction candidates: %w",
+				err,
+			)
+		}
+		candidatesProcessed += len(candidates)
+		for i := range candidates {
+			match, err := transactionContainsExactAddress(
+				&candidates[i],
+				exactAddress,
+				txn,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if !match {
+				continue
+			}
+			if matchesSkipped < offset {
+				matchesSkipped++
+				continue
+			}
+			ret = append(ret, candidates[i])
+			if limit > 0 && len(ret) == limit {
+				return ret, nil
+			}
+		}
+		if len(candidates) < batchSize {
+			return ret, nil
+		}
+		if candidatesProcessed >= exactAddressCandidateScanLimit {
+			return ret, errExactAddressCandidateScanLimit
+		}
+		candidateOffset += len(candidates)
+	}
+}
+
+func transactionContainsExactAddress(
+	tx *models.Transaction,
+	exactAddress []byte,
+	txn *Txn,
+) (bool, error) {
+	utxos := make([]*models.Utxo, 0,
+		len(tx.Inputs)+len(tx.Outputs)+len(tx.Collateral)+
+			len(tx.ReferenceInputs)+1,
 	)
+	for i := range tx.Inputs {
+		utxos = append(utxos, &tx.Inputs[i])
+	}
+	for i := range tx.Outputs {
+		utxos = append(utxos, &tx.Outputs[i])
+	}
+	for i := range tx.Collateral {
+		utxos = append(utxos, &tx.Collateral[i])
+	}
+	for i := range tx.ReferenceInputs {
+		utxos = append(utxos, &tx.ReferenceInputs[i])
+	}
+	if tx.CollateralReturn != nil {
+		utxos = append(utxos, tx.CollateralReturn)
+	}
+	for _, utxo := range utxos {
+		if err := loadCbor(utxo, txn); err != nil {
+			return false, fmt.Errorf(
+				"load transaction UTxO %x#%d for exact address match: %w",
+				utxo.TxId,
+				utxo.OutputIdx,
+				err,
+			)
+		}
+		output, err := utxo.Decode()
+		if err != nil {
+			return false, fmt.Errorf(
+				"decode transaction UTxO %x#%d for exact address match: %w",
+				utxo.TxId,
+				utxo.OutputIdx,
+				err,
+			)
+		}
+		addressBytes, err := output.Address().Bytes()
+		if err != nil {
+			return false, fmt.Errorf("encode transaction UTxO address: %w", err)
+		}
+		if bytes.Equal(addressBytes, exactAddress) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // GetTransactionsByAddressKeys returns transactions for a payment/staking
@@ -1185,27 +1307,36 @@ func (d *Database) CountTransactionsByAddress(
 	addr lcommon.Address,
 	txn *Txn,
 ) (int, error) {
-	zeroHash := lcommon.NewBlake2b224(nil)
-	var paymentKey []byte
-	var credentialTag uint8
-	var stakingKey []byte
-	if pkh := addr.PaymentKeyHash(); pkh != zeroHash {
-		paymentKey = pkh.Bytes()
-	}
-	if skh := addr.StakeKeyHash(); skh != zeroHash {
-		var ok bool
-		credentialTag, ok = models.StakeCredentialTagFromAddress(addr)
-		if !ok {
-			return 0, errors.New("derive stake credential tag from address")
-		}
-		stakingKey = skh.Bytes()
-	}
-	return d.CountTransactionsByAddressKeys(
-		paymentKey,
-		credentialTag,
-		stakingKey,
+	txs, err := d.getTransactionsByExactAddress(
+		addr,
+		0,
+		0,
+		"desc",
 		txn,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return len(txs), nil
+}
+
+// HasTransactionsByAddress reports whether at least one transaction involves
+// the given exact address.
+func (d *Database) HasTransactionsByAddress(
+	addr lcommon.Address,
+	txn *Txn,
+) (bool, error) {
+	txs, err := d.getTransactionsByExactAddress(
+		addr,
+		1,
+		0,
+		"desc",
+		txn,
+	)
+	if err != nil {
+		return false, err
+	}
+	return len(txs) > 0, nil
 }
 
 // CountTransactionsByAddressKeys returns the total number

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -42,6 +42,12 @@ var ErrUtxoNotFound = types.ErrUtxoNotFound
 // that only need indexed metadata fields can ignore this error.
 var ErrUtxoCborUnavailable = errors.New("utxo cbor unavailable")
 
+const exactAddressCandidateScanLimit = 10_000
+
+var errExactAddressCandidateScanLimit = errors.New(
+	"exact address candidate scan limit reached",
+)
+
 // deleteUtxoBlobs performs best-effort deletion of blob data for the given
 // [models.Utxo] entries. Metadata remains the authoritative source of truth;
 // blob deletions are supplementary. The caller [*Txn] is ignored — this
@@ -517,7 +523,11 @@ func (d *Database) UtxosByAddress(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	utxos, err := d.metadata.GetUtxosByAddress(addr, txn.Metadata())
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	if err != nil {
+		return nil, err
+	}
+	utxos, err := d.metadata.GetUtxosByAddress(pattern, txn.Metadata())
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +536,9 @@ func (d *Database) UtxosByAddress(
 			return nil, err
 		}
 	}
-	return utxos, nil
+	return filterUtxosByAddressPatterns(utxos, []models.UtxoAddressPattern{
+		pattern,
+	})
 }
 
 // GetControlledAmountByCredential returns the sum of live UTxO amounts
@@ -564,19 +576,72 @@ func (d *Database) UtxosByAddressWithOrdering(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	utxos, err := d.metadata.GetUtxosByAddressWithOrdering(
-		q,
-		txn.Metadata(),
-	)
-	if err != nil {
-		return nil, err
+	if q == nil {
+		return nil, models.ErrNilUtxoWithOrderingQuery
 	}
-	for i := range utxos {
-		if err := loadCbor(&utxos[i].Utxo, txn); err != nil {
+	if q.MatchAllAddresses ||
+		!models.RequiresExactAddressFilter(q.AddressPatterns) ||
+		q.Limit <= 0 {
+		utxos, err := d.metadata.GetUtxosByAddressWithOrdering(
+			q,
+			txn.Metadata(),
+		)
+		if err != nil {
 			return nil, err
 		}
+		return d.loadAndFilterOrderedUtxos(utxos, q.AddressPatterns, txn)
 	}
-	return utxos, nil
+
+	// Exact address identity is only available in output CBOR. Scan coarse SQL
+	// candidates in keyset order until Limit exact matches are collected, so a
+	// page full of enterprise/pointer siblings cannot truncate the result.
+	scanQuery := *q
+	scanQuery.Limit = max(q.Limit, 128)
+	ret := make([]models.UtxoWithOrdering, 0, q.Limit)
+	candidatesProcessed := 0
+	for len(ret) < q.Limit {
+		remainingCandidates := exactAddressCandidateScanLimit -
+			candidatesProcessed
+		if remainingCandidates <= 0 {
+			return ret, errExactAddressCandidateScanLimit
+		}
+		scanQuery.Limit = min(scanQuery.Limit, remainingCandidates)
+		batch, err := d.metadata.GetUtxosByAddressWithOrdering(
+			&scanQuery,
+			txn.Metadata(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		candidatesProcessed += len(batch)
+		filtered, err := d.loadAndFilterOrderedUtxos(
+			batch,
+			q.AddressPatterns,
+			txn,
+		)
+		if err != nil {
+			return nil, err
+		}
+		remaining := q.Limit - len(ret)
+		if len(filtered) > remaining {
+			filtered = filtered[:remaining]
+		}
+		ret = append(ret, filtered...)
+		if len(batch) < scanQuery.Limit || len(batch) == 0 {
+			break
+		}
+		if len(ret) < q.Limit &&
+			candidatesProcessed >= exactAddressCandidateScanLimit {
+			return ret, errExactAddressCandidateScanLimit
+		}
+		last := batch[len(batch)-1]
+		scanQuery.After = &models.UtxoOrderingCursor{
+			Slot:       last.TxSlot,
+			BlockIndex: last.TxBlockIndex,
+			OutputIdx:  last.OutputIdx,
+		}
+	}
+	return ret, nil
 }
 
 func (d *Database) UtxosByAddressAtSlot(
@@ -588,8 +653,12 @@ func (d *Database) UtxosByAddressAtSlot(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	if err != nil {
+		return nil, err
+	}
 	utxos, err := d.metadata.GetUtxosByAddressAtSlot(
-		addr,
+		pattern,
 		slot,
 		txn.Metadata(),
 	)
@@ -601,7 +670,79 @@ func (d *Database) UtxosByAddressAtSlot(
 			return nil, err
 		}
 	}
-	return utxos, nil
+	return filterUtxosByAddressPatterns(utxos, []models.UtxoAddressPattern{
+		pattern,
+	})
+}
+
+func filterUtxosByAddressPatterns(
+	utxos []models.Utxo,
+	patterns []models.UtxoAddressPattern,
+) ([]models.Utxo, error) {
+	if !models.RequiresExactAddressFilter(patterns) {
+		return utxos, nil
+	}
+	ret := make([]models.Utxo, 0, len(utxos))
+	for i := range utxos {
+		output, err := utxos[i].Decode()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"decode UTxO %x#%d for exact address match: %w",
+				utxos[i].TxId,
+				utxos[i].OutputIdx,
+				err,
+			)
+		}
+		match, err := models.MatchesUtxoAddressPatterns(
+			output.Address(),
+			patterns,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			ret = append(ret, utxos[i])
+		}
+	}
+	return ret, nil
+}
+
+func (d *Database) loadAndFilterOrderedUtxos(
+	utxos []models.UtxoWithOrdering,
+	patterns []models.UtxoAddressPattern,
+	txn *Txn,
+) ([]models.UtxoWithOrdering, error) {
+	for i := range utxos {
+		if err := loadCbor(&utxos[i].Utxo, txn); err != nil {
+			return nil, err
+		}
+	}
+	if !models.RequiresExactAddressFilter(patterns) {
+		return utxos, nil
+	}
+	ret := make([]models.UtxoWithOrdering, 0, len(utxos))
+	for i := range utxos {
+		output, err := utxos[i].Decode()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"decode UTxO %x#%d for exact address match: %w",
+				utxos[i].TxId,
+				utxos[i].OutputIdx,
+				err,
+			)
+		}
+		match, err := models.MatchesUtxoAddressPatterns(
+			output.Address(),
+			patterns,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			ret = append(ret, utxos[i])
+		}
+	}
+	return ret, nil
 }
 
 // UtxosByAssets returns UTxOs that contain the specified assets

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func exactAddressTestPointer(
+	t *testing.T,
+	payment []byte,
+	pointer byte,
+) lcommon.Address {
+	t.Helper()
+	raw := []byte{
+		(lcommon.AddressTypeKeyPointer << 4) |
+			lcommon.AddressNetworkTestnet,
+	}
+	raw = append(raw, payment...)
+	raw = append(raw, pointer, 0x00, 0x00)
+	addr, err := lcommon.NewAddressFromBytes(raw)
+	require.NoError(t, err)
+	return addr
+}
+
+func seedExactAddressUtxo(
+	t *testing.T,
+	db *Database,
+	store *sqliteplugin.MetadataStoreSqlite,
+	addr lcommon.Address,
+	slot uint64,
+	hashByte byte,
+) models.Utxo {
+	t.Helper()
+	txID := uint(slot)
+	txHash := bytes.Repeat([]byte{hashByte}, 32)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID:         txID,
+		Hash:       txHash,
+		Slot:       slot,
+		BlockIndex: 0,
+	}).Error)
+	row := models.Utxo{
+		TransactionID: &txID,
+		TxId:          txHash,
+		OutputIdx:     0,
+		PaymentKey:    addr.PaymentKeyHash().Bytes(),
+		AddedSlot:     slot,
+		Amount:        types.Uint64(slot * 1_000_000),
+	}
+	if stake := addr.StakeKeyHash(); stake != lcommon.NewBlake2b224(nil) {
+		row.StakingKey = stake.Bytes()
+	}
+	require.NoError(t, store.DB().Create(&row).Error)
+	require.NoError(t, store.DB().Create(&models.AddressTransaction{
+		PaymentKey:    row.PaymentKey,
+		StakingKey:    row.StakingKey,
+		CredentialTag: row.CredentialTag,
+		TransactionID: txID,
+		Slot:          slot,
+	}).Error)
+	raw, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  uint64(row.Amount),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+		return db.Blob().SetUtxo(txn.Blob(), row.TxId, row.OutputIdx, raw)
+	}))
+	return row
+}
+
+func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
+	db := openTestDB(t)
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+
+	payment := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	stake := bytes.Repeat([]byte{0xcd}, lcommon.AddressHashSize)
+	enterprise, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+	base, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		stake,
+	)
+	require.NoError(t, err)
+	pointerOne := exactAddressTestPointer(t, payment, 0x01)
+	pointerTwo := exactAddressTestPointer(t, payment, 0x02)
+
+	rows := []struct {
+		addr lcommon.Address
+		slot uint64
+		hash byte
+	}{
+		{pointerOne, 1, 0x01},
+		{enterprise, 2, 0x02},
+		{pointerTwo, 3, 0x03},
+		{enterprise, 4, 0x04},
+		{base, 5, 0x05},
+		{enterprise, 6, 0x06},
+	}
+	seeded := make([]models.Utxo, len(rows))
+	for i := range rows {
+		seeded[i] = seedExactAddressUtxo(
+			t,
+			db,
+			store,
+			rows[i].addr,
+			rows[i].slot,
+			rows[i].hash,
+		)
+	}
+
+	for _, tc := range []struct {
+		name string
+		addr lcommon.Address
+		want [][]byte
+	}{
+		{
+			name: "enterprise",
+			addr: enterprise,
+			want: [][]byte{seeded[1].TxId, seeded[3].TxId, seeded[5].TxId},
+		},
+		{name: "base", addr: base, want: [][]byte{seeded[4].TxId}},
+		{name: "pointer one", addr: pointerOne, want: [][]byte{seeded[0].TxId}},
+		{name: "pointer two", addr: pointerTwo, want: [][]byte{seeded[2].TxId}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := db.UtxosByAddress(tc.addr, nil)
+			require.NoError(t, err)
+			gotIDs := make([][]byte, len(got))
+			for i := range got {
+				gotIDs[i] = got[i].TxId
+			}
+			assert.ElementsMatch(t, tc.want, gotIDs)
+		})
+	}
+
+	pattern, err := models.ExactUtxoAddressPattern(enterprise)
+	require.NoError(t, err)
+	first, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+			Limit:           2,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, []byte{0x02, 0x04}, []byte{
+		first[0].TxId[0], first[1].TxId[0],
+	})
+
+	second, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+			After: &models.UtxoOrderingCursor{
+				Slot:       first[1].TxSlot,
+				BlockIndex: first[1].TxBlockIndex,
+				OutputIdx:  first[1].OutputIdx,
+			},
+			Limit: 2,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, byte(0x06), second[0].TxId[0])
+
+	credentialRows, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{{
+				PaymentPart: payment,
+			}},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, credentialRows, len(rows))
+
+	enterpriseBytes, err := enterprise.Bytes()
+	require.NoError(t, err)
+	andMatch, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{{
+				ExactAddress: enterpriseBytes,
+				PaymentPart:  payment,
+			}},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, andMatch, 3)
+
+	andMismatch, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{{
+				ExactAddress: enterpriseBytes,
+				PaymentPart: bytes.Repeat(
+					[]byte{0xee},
+					lcommon.AddressHashSize,
+				),
+			}},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, andMismatch)
+
+	atSlot, err := db.UtxosByAddressAtSlot(enterprise, 6, nil)
+	require.NoError(t, err)
+	require.Len(t, atSlot, 3)
+
+	enterpriseTxs, err := db.GetTransactionsByAddressWithOrder(
+		enterprise,
+		2,
+		1,
+		"asc",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, enterpriseTxs, 2)
+	assert.Equal(t, []byte{0x04, 0x06}, []byte{
+		enterpriseTxs[0].Hash[0],
+		enterpriseTxs[1].Hash[0],
+	})
+	enterpriseTxCount, err := db.CountTransactionsByAddress(enterprise, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3, enterpriseTxCount)
+	hasEnterpriseTx, err := db.HasTransactionsByAddress(enterprise, nil)
+	require.NoError(t, err)
+	assert.True(t, hasEnterpriseTx)
+}


### PR DESCRIPTION
Closes #2960 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make UTxO and transaction address queries exact by comparing full CBOR-decoded address bytes after credential narrowing, fixing enterprise vs pointer mix-ups and preserving pagination/continuations across `api/blockfrost` and `api/utxorpc`. Also caps transaction pagination preallocation to avoid large memory use.

- **Bug Fixes**
  - Added `models.UtxoAddressPattern` with `ExactAddress`, `PaymentPart`, and `DelegationPart`; DB narrows by credential columns and then filters by full decoded address, scanning candidate pages so limits and tokens remain correct.
  - `api/utxorpc` `SearchUtxos` now accepts an address pattern, validates part lengths, ANDs fields within a pattern, ORs across patterns, and drops address dedupe; returns `InvalidArgument` on bad inputs.
  - `api/blockfrost` address summary and UTXO endpoints use exact matching; removed pointer-specific path; enterprise queries no longer include pointer UTxOs sharing a payment key; pagination parsing is strict; empty balances fall back to an exact-address transaction existence check.
  - Transaction reads scan credential-index candidates in small batches, compare decoded output addresses, and paginate exact matches; adds `HasTransactionsByAddress`; preallocation is capped.
  - Metadata-only exact balance queries return `ErrExactAddressRequiresCbor`; exact summaries use the coordinated `database` path.

- **Migration**
  - `MetadataStore` now takes `models.UtxoAddressPattern` for `GetUtxosByAddress` and `GetUtxosByAddressAtSlot`; `GetUtxosByAddressWithOrdering` accepts `AddressPatterns`. Update custom plugins to build SQL with `AppendUtxoAddressPatternOrBranch`.
  - Replace exact balance calls to `GetUtxoBalanceByAddress(..., UtxoAddressMatchExact)` with coordinated exact queries in the `database` layer.

<sup>Written for commit 3af5c9ff297dba3378091475cd5fbe7f47e2e46c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Address-based UTxO and transaction queries now distinguish enterprise, pointer, and other address forms sharing credentials.
  * Exact-address balances, results, counts, and historical lookups now exclude nearby but non-matching addresses.
  * Pagination and continuation handling remain accurate when non-matching address candidates are encountered.
  * Invalid address and credential inputs now return clear validation errors.

* **Documentation**
  * Clarified exact-address matching, filtering, summaries, and pagination behavior across API and database documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->