### PR TITLE
fix: replay-path recovery loop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1801,9 +1801,33 @@ detector itself breaks a loop by skipping a rollback it can no longer cross,
 it feeds that same point-keyed tracker so the escalation and metric fire on
 the skip path too, rather than silently suppressing the rollback.
 
-A separate recovery path handles transaction-validation failures that occur
-after the node has reached the chain tip (`recoverAtTipFromTxValidationError`
-in `ledger/replay_recovery.go`). When a block fails per-tx validation at tip,
+A separate recovery path handles transaction-validation failures during replay
+and after the node has reached the chain tip (`ledger/replay_recovery.go`).
+Replay first resolves missing inputs to producer blocks from metadata, CBOR
+offsets, or a bounded primary-chain scan; when it can resolve the producer, it
+rolls metadata back to the earliest producer's parent and replays the retained
+primary chain. An unresolvable input instead uses the security-parameter
+fallback anchor. Because that condition means the retained primary chain
+contains a consumer without its producer, recovery prunes the primary-chain
+suffix and rolls metadata back to the same point, then publishes
+`chainsync.resync` through the metadata rollback's local-ledger-rollback event
+so peers can redeliver a consistent suffix. A corrective rewind may span more
+than `k` blocks because the primary-chain tip can be ahead of the failing replay
+block. It is therefore performed as a sequence of ordinary rollbacks of at most
+`k` blocks each. Every step publishes the normal `chain.ChainRollbackEvent` on
+`chain.update`, preserves the event's bounded contract, and limits retained
+block payloads to one security-parameter window. If a later step fails, the
+primary chain remains at the last committed intermediate point; the standard
+startup/live reconciliation paths can synchronize metadata to that valid tip.
+The chain moves before metadata because the retained rollback anchor must remain
+queryable while metadata reconstructs its tip and nonce. If that metadata step
+fails, the primary chain is already at a valid target and the same reconciliation
+paths finish bringing metadata to its common ancestor. Live at-tip recovery uses
+the same bounded event-aware helper; startup-only speculative-tail cleanup stays
+eventless because subscribers have not begun consuming live chain events.
+Rewinding metadata alone would replay the same corrupt chain indefinitely.
+
+When a block fails per-tx validation at tip,
 the node rewinds the primary chain and rolls the ledger back so ChainSelection
 can re-pick a candidate chain; repeating the *same* `(block, tx)` failure
 escalates the rewind progressively deeper, up to the era stability window, to

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	dbtypes "github.com/blinklabs-io/dingo/database/types"
@@ -119,6 +120,9 @@ type replayRecoveryCandidate struct {
 	ProducerBlock models.Block
 	RollbackPoint ocommon.Point
 	Strategy      string
+	// ProducerUnresolved distinguishes the security-parameter fallback from
+	// strategies that found a concrete producer. Strategy remains a log label.
+	ProducerUnresolved bool
 }
 
 type replayRecoveryPendingInput struct {
@@ -184,8 +188,14 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 	if candidate.ProducerTx != nil {
 		producerTxHash = hex.EncodeToString(candidate.ProducerTx.Hash)
 	}
+	rewindPrimaryChain := candidate.ProducerUnresolved &&
+		ls.config.ChainManager != nil
+	recoveryAction := "rewinding metadata state"
+	if rewindPrimaryChain {
+		recoveryAction = "rewinding primary chain and metadata state"
+	}
 	ls.config.Logger.Warn(
-		"detected inconsistent local ledger state during replay, rewinding metadata state",
+		"detected inconsistent local ledger state during replay, "+recoveryAction,
 		"component", "ledger",
 		"recovery_strategy", candidate.Strategy,
 		"tx_hash", hex.EncodeToString(validationErr.TxHash),
@@ -206,6 +216,20 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		}
 		return true, nil
 	}
+	if rewindPrimaryChain {
+		if err := ls.rollbackPrimaryChainInSecurityParamWindows(
+			candidate.RollbackPoint,
+		); err != nil {
+			return false, fmt.Errorf(
+				"rewind primary chain for replay recovery: %w",
+				err,
+			)
+		}
+	}
+	// The chain moves first while the rollback anchor is guaranteed to remain
+	// available. If metadata synchronization fails, the primary chain is still
+	// at a valid retained point and the standard divergence reconciler can
+	// finish rolling metadata back to its common ancestor.
 	if err := ls.rollback(candidate.RollbackPoint); err != nil {
 		return false, fmt.Errorf(
 			"rollback ledger state for replay recovery: %w",
@@ -213,6 +237,73 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		)
 	}
 	return true, nil
+}
+
+// rollbackPrimaryChainInSecurityParamWindows reaches a deep corrective rewind
+// by applying a sequence of ordinary, security-parameter-bounded rollbacks.
+// Each step therefore preserves ChainRollbackEvent's k-bounded contract and
+// bounds the blocks retained for event delivery. A failure leaves the chain at
+// the last committed intermediate point; startup/live reconciliation can then
+// replay or finish rolling metadata back to that valid primary-chain tip.
+func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
+	point ocommon.Point,
+) error {
+	securityParam := ls.SecurityParam()
+	if securityParam <= 0 {
+		return chain.ErrSecurityParamNotConfigured
+	}
+
+	targetIndex := uint64(0)
+	if point.Slot > 0 || len(point.Hash) > 0 {
+		targetBlock, err := database.BlockByPoint(ls.db, point)
+		if err != nil {
+			return fmt.Errorf("lookup replay recovery target: %w", err)
+		}
+		targetIndex = targetBlock.ID
+	}
+
+	tip := ls.chain.Tip()
+	if tip.Point.Slot == point.Slot &&
+		bytes.Equal(tip.Point.Hash, point.Hash) {
+		return nil
+	}
+	tipBlock, err := database.BlockByPoint(ls.db, tip.Point)
+	if err != nil {
+		return fmt.Errorf("lookup primary chain tip: %w", err)
+	}
+	tipIndex := tipBlock.ID
+	if tipIndex < targetIndex {
+		return fmt.Errorf(
+			"primary chain tip index %d is behind replay recovery target %d",
+			tipIndex,
+			targetIndex,
+		)
+	}
+	window := uint64(securityParam)
+	for tipIndex-targetIndex > window {
+		nextIndex := tipIndex - window
+		nextBlock, err := ls.db.BlockByIndex(nextIndex, nil)
+		if err != nil {
+			return fmt.Errorf(
+				"lookup intermediate replay recovery block %d: %w",
+				nextIndex,
+				err,
+			)
+		}
+		nextPoint := ocommon.NewPoint(nextBlock.Slot, nextBlock.Hash)
+		if err := ls.chain.Rollback(nextPoint); err != nil {
+			return fmt.Errorf(
+				"rollback primary chain to intermediate point %d: %w",
+				nextIndex,
+				err,
+			)
+		}
+		tipIndex = nextIndex
+	}
+	if err := ls.chain.Rollback(point); err != nil {
+		return fmt.Errorf("rollback primary chain to recovery point: %w", err)
+	}
+	return nil
 }
 
 func (ls *LedgerState) recoveryRollbackExceedsMithrilBoundary(
@@ -398,7 +489,7 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		"attempt", attempts,
 		"holding", ls.atTipRecoveryHolding,
 	)
-	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(
+	if err := ls.rollbackPrimaryChainInSecurityParamWindows(
 		rewindPoint,
 	); err != nil {
 		return false, fmt.Errorf(
@@ -414,8 +505,8 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 	// looks up its inputs, finds them already marked consumed, and
 	// returns "rule 22 bad input(s) ... rule 24 value not conserved
 	// (consumed 0)" again, looping the recovery indefinitely until
-	// process restart. RewindPrimaryChainToPoint by design only touches
-	// the chain blob — the matching ledger rollback must be explicit.
+	// process restart. Primary-chain rollback only touches the chain
+	// store — the matching ledger rollback must be explicit.
 	if err := ls.rollback(rewindPoint); err != nil {
 		return false, fmt.Errorf(
 			"rollback ledger state after validation failure: %w",
@@ -484,7 +575,7 @@ func (ls *LedgerState) rejectRecoveryAtMithrilBoundary(
 		)
 	}
 	logRejection(mithrilLedgerSlot, rewindPoint)
-	if err := ls.config.ChainManager.RewindPrimaryChainToPoint(rewindPoint); err != nil {
+	if err := ls.rollbackPrimaryChainInSecurityParamWindows(rewindPoint); err != nil {
 		return fmt.Errorf(
 			"rewind primary chain to Mithril trust boundary: %w",
 			err,
@@ -866,10 +957,11 @@ func (ls *LedgerState) replayRecoveryFallbackCandidate(
 		return nil, err
 	}
 	return &replayRecoveryCandidate{
-		Input:         inputs[0],
-		ProducerBlock: anchorBlock,
-		RollbackPoint: rollbackPoint,
-		Strategy:      "security-param-fallback",
+		Input:              inputs[0],
+		ProducerBlock:      anchorBlock,
+		RollbackPoint:      rollbackPoint,
+		Strategy:           "security-param-fallback",
+		ProducerUnresolved: true,
 	}, nil
 }
 

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -299,6 +299,7 @@ func TestTryRecoverFromTxValidationErrorRejectsReplayBelowMithrilBoundary(
 		},
 	})
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 	shadowConnId := ouroboros.ConnectionId{
 		LocalAddr: &net.TCPAddr{
@@ -450,6 +451,7 @@ func TestTryRecoverFromTxValidationErrorAtTipRewindsPrimaryChain(
 		),
 	})
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 
 	ledgerTip := ochainsync.Tip{
@@ -582,6 +584,7 @@ func newAtTipDescentLedger(t *testing.T) (*LedgerState, ochainsync.Tip) {
 		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 	})
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 
 	ledgerTip := ochainsync.Tip{
@@ -793,6 +796,7 @@ func TestTryRecoverFromTxValidationErrorAtTipRejectsRewindBelowMithrilBoundary(
 		},
 	})
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 
 	ledgerTip := ochainsync.Tip{
@@ -1071,6 +1075,7 @@ func TestTryRecoverFromTxValidationErrorFallsBackToChainScan(t *testing.T) {
 		),
 	})
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
@@ -1219,6 +1224,7 @@ func TestTryRecoverFromTxValidationErrorRecoversDependencyClosure(
 		),
 	})
 	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
@@ -1252,7 +1258,10 @@ func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
 	})
 	require.NoError(t, err)
 
-	cm, err := chain.NewManager(db, nil)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+
+	cm, err := chain.NewManager(db, bus)
 	require.NoError(t, err)
 
 	blocks := []chain.RawBlock{
@@ -1266,15 +1275,55 @@ func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
 	blocks[3].PrevHash = blocks[2].Hash
 	require.NoError(t, cm.PrimaryChain().AddRawBlocks(blocks))
 
+	resyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	resyncSubId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			resync, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- resync:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, resyncSubId)
+	})
+	rollbackCh := make(chan chain.ChainRollbackEvent, len(blocks))
+	rollbackSubId := bus.SubscribeFunc(
+		chain.ChainUpdateEventType,
+		func(evt event.Event) {
+			rollback, ok := evt.Data.(chain.ChainRollbackEvent)
+			if !ok {
+				return
+			}
+			select {
+			case rollbackCh <- rollback:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(chain.ChainUpdateEventType, rollbackSubId)
+	})
+
+	nodeConfig := newTestShelleyGenesisCfg(t)
+	nodeConfig.ShelleyGenesis().SecurityParam = 2
 	ls, err := NewLedgerState(LedgerStateConfig{
 		Database:          db,
 		ChainManager:      cm,
-		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		EventBus:          bus,
+		CardanoNodeConfig: nodeConfig,
 		Logger: slog.New(
 			slog.NewJSONHandler(io.Discard, nil),
 		),
 	})
 	require.NoError(t, err)
+	ls.currentEra.Id = 1
+	require.NoError(t, cm.SetLedger(ls))
 	ls.metrics.init(prometheus.NewRegistry())
 
 	currentTip := ochainsync.Tip{
@@ -1292,6 +1341,20 @@ func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
 		),
 	)
 	require.NoError(t, db.SetTip(currentTip, nil))
+	rewindTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(blocks[0].Slot, blocks[0].Hash),
+		BlockNumber: blocks[0].BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			rewindTip.Point.Hash,
+			rewindTip.Point.Slot,
+			[]byte("nonce-rewind"),
+			false,
+			nil,
+		),
+	)
 	ls.currentTip = currentTip
 	ls.currentTipBlockNonce = []byte("nonce-current")
 	ls.publishSnapshotsLocked()
@@ -1311,7 +1374,47 @@ func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
 	)
 	require.NoError(t, err)
 	require.True(t, recovered)
-	assert.Equal(t, ochainsync.Tip{}, ls.currentTip)
+	assert.Equal(t, rewindTip, ls.currentTip)
+	assert.Equal(t, rewindTip, ls.chain.Tip())
+	_, err = database.BlockByPoint(db, currentTip.Point)
+	assert.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	resync := testutil.RequireReceive(
+		t,
+		resyncCh,
+		5*time.Second,
+		"expected chainsync resync after unresolved replay recovery",
+	)
+	assert.Equal(
+		t,
+		event.ChainsyncResyncReasonLocalLedgerRollback,
+		resync.Reason,
+	)
+	assert.Equal(t, rewindTip.Point, resync.Point)
+
+	var rolledBackBlocks []models.Block
+	expectedRollbackCount := len(blocks) - 1
+	for len(rolledBackBlocks) < expectedRollbackCount {
+		rollback := testutil.RequireReceive(
+			t,
+			rollbackCh,
+			5*time.Second,
+			"expected chain rollback event after unresolved replay recovery",
+		)
+		assert.LessOrEqual(
+			t,
+			len(rollback.RolledBackBlocks),
+			ls.SecurityParam(),
+		)
+		rolledBackBlocks = append(
+			rolledBackBlocks,
+			rollback.RolledBackBlocks...,
+		)
+	}
+	require.Len(t, rolledBackBlocks, expectedRollbackCount)
+	for i, block := range rolledBackBlocks {
+		assert.Equal(t, blocks[len(blocks)-1-i].Hash, block.Hash)
+	}
 }
 
 func TestTryRecoverFromTxValidationErrorSkipsUnknownProducer(t *testing.T) {


### PR DESCRIPTION
Closes #2971 
Closes #2941 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the replay recovery loop by rewinding an inconsistent primary-chain suffix in security-parameter windows when a transaction’s producer can’t be resolved, then rolling back metadata and signaling resync to stop endless replays. Normal ingestion now fails fast on missing-input spends; Musashi Leios `ValidateNone` still treats absent inputs as no-ops.

- **Bug Fixes**
  - Replay recovery resolves missing inputs via metadata/CBOR/scan; if still unresolved, it rewinds the primary chain in ≤`k`-block steps, then rolls back metadata, emits `chainsync.resync`, and publishes `chain.ChainRollbackEvent` on `chain.update` with removed blocks, preserving the k-bounded event contract.
  - Metadata plugins for `sqlite`, `mysql`, and `postgres` now return `types.ErrUtxoNotFound` on absent consumed UTxOs, so normal replay and trust-mode commits fail fast; `StrictUtxoValidation` applies only to the recovery pass.
  - Added `AllowMissingConsumedInputs` to `database.BatchedTxIngestOpts`; propagated through `ledger.LedgerDelta` and batched writes. Used only with `SkipConsumedInputRecovery` for Musashi Leios `ValidateNone`, which filters consumed inputs to those present.

<sup>Written for commit f3b5468b17a4e3d72aa677c4f9bd838b82e3d1e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing consumed UTxOs now produce a clear validation error instead of being silently skipped.
  * Replay recovery can roll back the primary chain and prevent repeated processing of invalid blocks.
  * Recovery now handles unresolved transaction producers more safely.

* **New Features**
  * Added a specialized validation path for protocol scenarios where missing reference inputs are treated as no-ops.
  * Improved strict UTxO validation behavior and command-line guidance.

* **Documentation**
  * Expanded documentation describing transaction recovery, rollback, and missing-input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->