### PR TITLE
fix: open database ownership-safety

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,14 @@ Database receives provider-owned stores through `database.Stores`.
 API providers are resolved for lifecycle only because node composition has no
 in-process consumer of their concrete server values.
 
+Command and bootstrap composition that opens a standalone database uses
+`internal/plugins.OpenDatabase`. Its return contract keeps ownership
+unambiguous: a non-nil error never accompanies a live runtime, while a
+recoverable commit-timestamp mismatch is available from
+`DatabaseRuntime.RecoveryError()` on the successfully returned runtime. The
+caller must close every returned runtime, and `DatabaseRuntime.Close` preserves
+database-before-provider shutdown order.
+
 Composition injects the application `databasePath` into both storage provider
 dependency bundles, preserving `CARDANO_DATABASE_PATH` and `--data-dir` as a
 shortcut for both stores. Local providers can independently override that

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -11,6 +11,14 @@ behavior, and persisted formats are unchanged. Library callers of Mithril
 `Sync` or `NeedsSync` may leave `SyncConfig.StoragePlugins` unset to select the
 local `badger` blob and `sqlite` metadata providers.
 
+Standalone command/bootstrap composition owns these stores through
+`internal/plugins.DatabaseRuntime`. `OpenDatabase` returns either a live
+runtime with a nil error or a nil runtime with an error, so conventional error
+handling cannot leak provider resources. A live runtime may report a
+recoverable commit-timestamp mismatch through `RecoveryError()`; callers that
+perform repair or forward import can inspect it before continuing and must
+still close the runtime.
+
 `databasePath` (including its `CARDANO_DATABASE_PATH` environment binding and
 the `--data-dir` flag) is the shared data-directory shortcut for both local
 storage providers. `plugins.storage.blob.config.dataDir` and

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -97,27 +97,22 @@ func checkSyncState(
 	runtime, err := openConfiguredDatabase(
 		context.Background(), cfg, logger, 1,
 	)
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
 	db, runtimeErr := runtimeDatabase(runtime)
 	if runtimeErr != nil {
-		if err != nil {
-			return fmt.Errorf("opening database: %w", err)
-		}
 		return runtimeErr
 	}
-	// runtime is non-nil past this point (runtimeDatabase only succeeds for a
-	// runtime that carries a database), so close it on every return below —
-	// including the non-recoverable error path, which openConfiguredDatabase
-	// can reach with a live runtime when database.New fails after opening the
-	// stores.
 	defer runtime.Close(context.Background()) //nolint:contextcheck
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		// A commit-timestamp mismatch is recoverable downstream in
 		// node.Run. We only need to read sync_status here, which
 		// works on the partially-initialised db handle returned with
 		// the error.
 		var cte database.CommitTimestampError
-		if !errors.As(err, &cte) {
-			return fmt.Errorf("opening database: %w", err)
+		if !errors.As(recoveryErr, &cte) {
+			return fmt.Errorf("opening database: %w", recoveryErr)
 		}
 		logger.Warn(
 			"sync state check observed commit timestamp mismatch; "+
@@ -164,20 +159,20 @@ func checkMithrilInactivityCompat(
 	runtime, err := openConfiguredDatabase(
 		context.Background(), cfg, logger, 1,
 	)
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
 	db, runtimeErr := runtimeDatabase(runtime)
 	if runtimeErr != nil {
-		if err != nil {
-			return fmt.Errorf("opening database: %w", err)
-		}
 		return runtimeErr
 	}
 	defer runtime.Close(context.Background()) //nolint:contextcheck
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		// A commit-timestamp mismatch is recovered downstream in node.Run;
 		// the marker read works on the partially-initialised handle.
 		var cte database.CommitTimestampError
-		if !errors.As(err, &cte) {
-			return fmt.Errorf("opening database: %w", err)
+		if !errors.As(recoveryErr, &cte) {
+			return fmt.Errorf("opening database: %w", recoveryErr)
 		}
 	}
 
@@ -199,18 +194,18 @@ func repairDeferredIndexes(
 	runtime, err := openConfiguredDatabase(
 		context.Background(), cfg, logger, cfg.DatabaseWorkers,
 	)
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
 	db, runtimeErr := runtimeDatabase(runtime)
 	if runtimeErr != nil {
-		if err != nil {
-			return fmt.Errorf("opening database: %w", err)
-		}
 		return runtimeErr
 	}
 	defer runtime.Close(context.Background()) //nolint:contextcheck
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		var cte database.CommitTimestampError
-		if !errors.As(err, &cte) {
-			return fmt.Errorf("opening database: %w", err)
+		if !errors.As(recoveryErr, &cte) {
+			return fmt.Errorf("opening database: %w", recoveryErr)
 		}
 	}
 	return node.RepairDeferredIndexes(db, logger)
@@ -251,22 +246,22 @@ func resumeBackfill(
 	runtime, err := openConfiguredDatabase(
 		ctx, cfg, logger, cfg.DatabaseWorkers,
 	)
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
 	db, runtimeErr := runtimeDatabase(runtime)
 	if runtimeErr != nil {
-		if err != nil {
-			return fmt.Errorf("opening database: %w", err)
-		}
 		return runtimeErr
 	}
 	defer runtime.Close(context.Background()) //nolint:contextcheck
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		// Backfill writes through full transactions which heal a
 		// commit-timestamp mismatch as it makes progress, and
 		// node.Run will run a full recovery pass afterwards. So a
 		// recoverable mismatch should not block the resume.
 		var cte database.CommitTimestampError
-		if !errors.As(err, &cte) {
-			return fmt.Errorf("opening database: %w", err)
+		if !errors.As(recoveryErr, &cte) {
+			return fmt.Errorf("opening database: %w", recoveryErr)
 		}
 		logger.Warn(
 			"backfill observed commit timestamp mismatch; "+

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -145,10 +145,10 @@ func ensureDB(
 			Logger: logger,
 		},
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating database: %w", err)
+	}
 	if runtime == nil || runtime.Database == nil {
-		if err != nil {
-			return nil, nil, fmt.Errorf("creating database: %w", err)
-		}
 		return nil, nil, errors.New(
 			"creating database: runtime did not provide a database",
 		)
@@ -157,14 +157,16 @@ func ensureDB(
 	cleanup := func() {
 		_ = runtime.Close(context.Background())
 	}
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		// Bootstrap paths (load / mithril sync) tolerate a recoverable
 		// commit-timestamp mismatch: the import work that follows
 		// writes through full transactions which heal the timestamps.
 		// Returning the error here would leave the user unable to
 		// re-run a load / re-bootstrap from a previous interrupted
 		// import.
-		if cte, ok := errors.AsType[database.CommitTimestampError](err); ok {
+		if cte, ok := errors.AsType[database.CommitTimestampError](
+			recoveryErr,
+		); ok {
 			logger.Warn(
 				"opened database with commit timestamp mismatch; "+
 					"continuing — import will heal it",
@@ -173,7 +175,7 @@ func ensureDB(
 			)
 			return newDB, cleanup, nil
 		}
-		return nil, nil, fmt.Errorf("creating database: %w", err)
+		return nil, nil, fmt.Errorf("creating database: %w", recoveryErr)
 	}
 	return newDB, cleanup, nil
 }

--- a/internal/plugins/storage.go
+++ b/internal/plugins/storage.go
@@ -98,10 +98,22 @@ func ResolveStorage(
 // DatabaseRuntime is a composed database plus the plugin host that owns its
 // injected stores. Close preserves database-before-store shutdown ordering.
 type DatabaseRuntime struct {
-	Database *database.Database
-	Host     *plugin.Host
-	once     sync.Once
-	err      error
+	Database      *database.Database
+	Host          *plugin.Host
+	once          sync.Once
+	err           error
+	recoveryError error
+}
+
+// RecoveryError reports a recoverable error encountered while opening the
+// database. OpenDatabase returns these errors on the owned runtime instead of
+// as its error result, so a non-nil returned error always means there is no
+// live runtime for the caller to close.
+func (r *DatabaseRuntime) RecoveryError() error {
+	if r == nil {
+		return nil
+	}
+	return r.recoveryError
 }
 
 // Close stops database-owned resources before provider-owned stores.
@@ -121,7 +133,9 @@ func (r *DatabaseRuntime) Close(ctx context.Context) error {
 }
 
 // OpenDatabase explicitly composes a fresh host, storage providers, and a
-// database. A non-nil runtime may accompany a recoverable database error.
+// database. A non-nil error is returned only after all started resources have
+// been stopped. Recoverable database initialization errors are exposed through
+// DatabaseRuntime.RecoveryError on the successfully owned runtime.
 func OpenDatabase(
 	ctx context.Context,
 	dbConfig *database.Config,
@@ -140,11 +154,24 @@ func OpenDatabase(
 	db, err := database.New(dbConfig, stores) //nolint:contextcheck
 	runtime := &DatabaseRuntime{Database: db, Host: host}
 	if db == nil {
-		_ = runtime.Close(context.WithoutCancel(ctx))
+		closeErr := runtime.Close(context.WithoutCancel(ctx))
 		if err != nil {
-			return nil, err
+			return nil, errors.Join(err, closeErr)
 		}
-		return nil, errors.New("database construction returned no database")
+		return nil, errors.Join(
+			errors.New("database construction returned no database"),
+			closeErr,
+		)
 	}
-	return runtime, err
+	if err != nil {
+		if _, ok := errors.AsType[database.CommitTimestampError](err); ok {
+			runtime.recoveryError = err
+			return runtime, nil
+		}
+		return nil, errors.Join(
+			err,
+			runtime.Close(context.WithoutCancel(ctx)),
+		)
+	}
+	return runtime, nil
 }

--- a/internal/plugins/storage_test.go
+++ b/internal/plugins/storage_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func localStorageSelections() StorageSelections {
+	return StorageSelections{
+		Blob: plugin.Selection{
+			Provider: "badger",
+			Config:   map[string]any{},
+		},
+		Metadata: plugin.Selection{
+			Provider: "sqlite",
+			Config:   map[string]any{},
+		},
+	}
+}
+
+func TestOpenDatabaseReturnsRecoveryErrorOnRuntime(t *testing.T) {
+	dataDir := t.TempDir()
+	deps := StorageDependencies{DataDir: dataDir}
+	runtime, err := OpenDatabase(
+		context.Background(),
+		&database.Config{DataDir: dataDir},
+		localStorageSelections(),
+		deps,
+	)
+	require.NoError(t, err)
+	firstRuntime := runtime
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		require.NoError(t, firstRuntime.Close(ctx))
+	})
+
+	metaTxn := runtime.Database.Metadata().Transaction()
+	require.NoError(
+		t,
+		runtime.Database.Metadata().SetCommitTimestamp(123456789, metaTxn),
+	)
+	require.NoError(t, metaTxn.Commit())
+	require.NoError(t, runtime.Close(context.Background()))
+
+	runtime, err = OpenDatabase(
+		context.Background(),
+		&database.Config{DataDir: dataDir},
+		localStorageSelections(),
+		deps,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, runtime)
+	t.Cleanup(func() {
+		require.NoError(t, runtime.Close(context.Background()))
+	})
+	var timestampErr database.CommitTimestampError
+	require.ErrorAs(t, runtime.RecoveryError(), &timestampErr)
+	require.Equal(t, int64(123456789), timestampErr.MetadataTimestamp)
+	require.Zero(t, timestampErr.BlobTimestamp)
+}
+
+func TestOpenDatabaseErrorDoesNotReturnLiveRuntime(t *testing.T) {
+	selections := localStorageSelections()
+	selections.Metadata.Provider = "missing"
+	runtime, err := OpenDatabase(
+		context.Background(),
+		&database.Config{DataDir: t.TempDir()},
+		selections,
+		StorageDependencies{DataDir: t.TempDir()},
+	)
+	require.Error(t, err)
+	require.Nil(t, runtime)
+	require.ErrorContains(
+		t,
+		err,
+		"plugin provider not found: storage.metadata/missing",
+	)
+}

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -385,24 +385,22 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 	// download: chunks are copied into the blob store in contiguous order as
 	// they finish downloading, instead of waiting for the whole download.
 	runtime, err := openDatabase(ctx, cfg, logger, cfg.DatabaseWorkers)
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("opening database: %w", err)
+	}
 	if runtime == nil || runtime.Database == nil {
-		if err != nil {
-			return SyncResult{}, fmt.Errorf("opening database: %w", err)
-		}
 		return SyncResult{}, errors.New(
 			"opening database: runtime did not provide a database",
 		)
 	}
 	db := runtime.Database
-	// runtime carries a live database past the guard above, so close it on
-	// every return below, including the non-recoverable error path that
-	// openDatabase can reach with a live runtime when database.New fails after
-	// opening the stores.
 	defer runtime.Close(context.Background()) //nolint:contextcheck
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		// Tolerate a recoverable commit-timestamp mismatch from a previously
 		// interrupted run; mithril import heals it on forward progress.
-		if cte, ok := errors.AsType[database.CommitTimestampError](err); ok {
+		if cte, ok := errors.AsType[database.CommitTimestampError](
+			recoveryErr,
+		); ok {
 			logger.Warn(
 				"opened database with commit timestamp mismatch; "+
 					"continuing mithril sync — import will heal it",
@@ -411,7 +409,10 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 				"blob_timestamp", cte.BlobTimestamp,
 			)
 		} else {
-			return SyncResult{}, fmt.Errorf("opening database: %w", err)
+			return SyncResult{}, fmt.Errorf(
+				"opening database: %w",
+				recoveryErr,
+			)
 		}
 	}
 
@@ -1092,20 +1093,20 @@ func NeedsSync(cfg SyncConfig) (bool, error) {
 		logger = slog.Default()
 	}
 	runtime, err := openDatabase(context.Background(), cfg, logger, 1)
+	if err != nil {
+		return false, fmt.Errorf("opening database: %w", err)
+	}
 	if runtime == nil || runtime.Database == nil {
-		if err != nil {
-			return false, fmt.Errorf("opening database: %w", err)
-		}
 		return false, errors.New(
 			"opening database: runtime did not provide a database",
 		)
 	}
 	db := runtime.Database
 	defer runtime.Close(context.Background())
-	if err != nil {
+	if recoveryErr := runtime.RecoveryError(); recoveryErr != nil {
 		var cte database.CommitTimestampError
-		if !errors.As(err, &cte) {
-			return false, fmt.Errorf("opening database: %w", err)
+		if !errors.As(recoveryErr, &cte) {
+			return false, fmt.Errorf("opening database: %w", recoveryErr)
 		}
 	}
 	val, err := db.GetSyncState("sync_status", nil)

--- a/node_plugin_selection_test.go
+++ b/node_plugin_selection_test.go
@@ -15,12 +15,136 @@
 package dingo
 
 import (
+	"context"
+	"errors"
+	"io/fs"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/dingo/api/blockfrost"
+	"github.com/blinklabs-io/dingo/api/mesh"
+	"github.com/blinklabs-io/dingo/api/utxorpc"
 	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type apiProbeConfig struct {
+	Port uint `yaml:"port"`
+}
+
+type apiLifecycleProbe struct {
+	starts   atomic.Int32
+	stops    atomic.Int32
+	startErr error
+}
+
+func (p *apiLifecycleProbe) instance() plugin.Instance {
+	return plugin.Lifecycle{
+		StartFunc: func(context.Context) error {
+			p.starts.Add(1)
+			return p.startErr
+		},
+		StopFunc: func(context.Context) error {
+			p.stops.Add(1)
+			return nil
+		},
+	}
+}
+
+func registerAPIProbe(
+	t *testing.T,
+	host *plugin.Host,
+	capability plugin.Capability,
+	name string,
+	probe *apiLifecycleProbe,
+) {
+	t.Helper()
+	descriptor := plugin.Descriptor{Capability: capability, Name: name}
+	var err error
+	switch capability {
+	case plugin.CapabilityAPIUtxorpc:
+		err = plugin.Register(
+			host,
+			descriptor,
+			func() apiProbeConfig { return apiProbeConfig{} },
+			func(
+				context.Context,
+				apiProbeConfig,
+				utxorpc.ProviderDependencies,
+			) (string, plugin.Instance, error) {
+				return name, probe.instance(), nil
+			},
+		)
+	case plugin.CapabilityAPIBlockfrost:
+		err = plugin.Register(
+			host,
+			descriptor,
+			func() apiProbeConfig { return apiProbeConfig{} },
+			func(
+				context.Context,
+				apiProbeConfig,
+				blockfrost.ProviderDependencies,
+			) (string, plugin.Instance, error) {
+				return name, probe.instance(), nil
+			},
+		)
+	case plugin.CapabilityAPIMesh:
+		err = plugin.Register(
+			host,
+			descriptor,
+			func() apiProbeConfig { return apiProbeConfig{} },
+			func(
+				context.Context,
+				apiProbeConfig,
+				mesh.ProviderDependencies,
+			) (string, plugin.Instance, error) {
+				return name, probe.instance(), nil
+			},
+		)
+	default:
+		t.Fatalf("unsupported API capability %s", capability)
+	}
+	require.NoError(t, err)
+}
+
+func newAPIPluginRuntimeNode(t *testing.T) *Node {
+	t.Helper()
+	cardanoCfg := newNodeTestCardanoNodeCfg(t)
+	n, err := New(NewConfig(
+		WithDatabasePath(t.TempDir()),
+		WithCardanoNodeConfig(cardanoCfg),
+		WithNetworkMagic(cardanoCfg.ShelleyGenesis().NetworkMagic),
+		WithPrometheusRegistry(prometheus.NewRegistry()),
+		WithStorageMode(StorageModeAPI),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithMidnightConfig(MidnightConfig{Port: 0}),
+		WithShutdownTimeout(5*time.Second),
+	))
+	require.NoError(t, err)
+	// New validates the production requirement for at least one listener.
+	// Runtime plugin tests do not need a network socket, so remove it after
+	// validation to keep these tests hermetic in restricted environments.
+	n.config.listeners = nil
+	return n
+}
+
+func selectAPIProbe(
+	n *Node,
+	capability plugin.Capability,
+	name string,
+	port uint,
+) {
+	n.config.pluginSelections[capability] = plugin.Selection{
+		Provider: name,
+		Config:   map[string]any{"port": port},
+	}
+}
 
 // newAPISelectionNode builds a Node whose only plugin selection is sel under
 // the Blockfrost API capability, for exercising apiPluginSelection.
@@ -156,4 +280,83 @@ func TestAPIPluginSelectionDefaultPortPerCapability(t *testing.T) {
 		require.NoErrorf(t, err, "capability %s", capability)
 		assert.Equalf(t, wantPort, port, "capability %s", capability)
 	}
+}
+
+func TestNodeRunSkipsZeroPortAPIProviders(t *testing.T) {
+	n := newAPIPluginRuntimeNode(t)
+	probes := map[plugin.Capability]*apiLifecycleProbe{
+		plugin.CapabilityAPIUtxorpc:    {},
+		plugin.CapabilityAPIBlockfrost: {},
+		plugin.CapabilityAPIMesh:       {},
+	}
+	for capability, probe := range probes {
+		registerAPIProbe(t, n.pluginHost, capability, "probe", probe)
+		selectAPIProbe(n, capability, "probe", 0)
+	}
+	// Force a deterministic failure after the API startup section so Run
+	// returns without requiring an external shutdown signal. Reaching block
+	// producer validation proves all three zero-port decisions were exercised.
+	n.config.blockProducer = true
+
+	require.ErrorIs(
+		t,
+		n.Run(context.Background()),
+		fs.ErrNotExist,
+	)
+	for capability, probe := range probes {
+		assert.Zero(
+			t,
+			probe.starts.Load(),
+			"capability %s started with port 0",
+			capability,
+		)
+		assert.Zero(
+			t,
+			probe.stops.Load(),
+			"capability %s stopped despite never starting",
+			capability,
+		)
+	}
+}
+
+func TestNodeRunAPIStartupFailureCleansUpStartedProviders(t *testing.T) {
+	n := newAPIPluginRuntimeNode(t)
+	utxorpcProbe := &apiLifecycleProbe{}
+	blockfrostProbe := &apiLifecycleProbe{
+		startErr: errors.New("injected API startup failure"),
+	}
+	meshProbe := &apiLifecycleProbe{}
+	registerAPIProbe(
+		t,
+		n.pluginHost,
+		plugin.CapabilityAPIUtxorpc,
+		"probe",
+		utxorpcProbe,
+	)
+	registerAPIProbe(
+		t,
+		n.pluginHost,
+		plugin.CapabilityAPIBlockfrost,
+		"probe",
+		blockfrostProbe,
+	)
+	registerAPIProbe(
+		t,
+		n.pluginHost,
+		plugin.CapabilityAPIMesh,
+		"probe",
+		meshProbe,
+	)
+	selectAPIProbe(n, plugin.CapabilityAPIUtxorpc, "probe", 19090)
+	selectAPIProbe(n, plugin.CapabilityAPIBlockfrost, "probe", 13000)
+	selectAPIProbe(n, plugin.CapabilityAPIMesh, "probe", 0)
+
+	err := n.Run(context.Background())
+	require.ErrorContains(t, err, "injected API startup failure")
+	assert.Equal(t, int32(1), utxorpcProbe.starts.Load())
+	assert.Equal(t, int32(1), utxorpcProbe.stops.Load())
+	assert.Equal(t, int32(1), blockfrostProbe.starts.Load())
+	assert.Equal(t, int32(1), blockfrostProbe.stops.Load())
+	assert.Zero(t, meshProbe.starts.Load())
+	assert.Zero(t, meshProbe.stops.Load())
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -19,7 +19,12 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 type testConfig struct {
@@ -415,5 +420,154 @@ func TestResolveRejectsTypedNilMapInstance(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "nil lifecycle") {
 		t.Fatalf("error = %v, want nil lifecycle", err)
+	}
+}
+
+func TestStopCapabilityRacingWithResolveUnwindsNewInstance(t *testing.T) {
+	host := NewHost()
+	existingStopStarted := make(chan struct{})
+	releaseExistingStop := make(chan struct{})
+	racingStartFinished := make(chan struct{})
+	releaseRacingStart := make(chan struct{})
+	var releaseExistingOnce sync.Once
+	var releaseRacingOnce sync.Once
+	var existingStopStartedOnce sync.Once
+	var racingStartFinishedOnce sync.Once
+	releaseExisting := func() {
+		releaseExistingOnce.Do(func() { close(releaseExistingStop) })
+	}
+	releaseRacing := func() {
+		releaseRacingOnce.Do(func() { close(releaseRacingStart) })
+	}
+	t.Cleanup(releaseExisting)
+	t.Cleanup(releaseRacing)
+
+	var existingStops atomic.Int32
+	var racingStops atomic.Int32
+	register := func(
+		name string,
+		start func(context.Context) error,
+		stop func(context.Context) error,
+	) {
+		t.Helper()
+		err := Register(
+			host,
+			Descriptor{Capability: CapabilityMempool, Name: name},
+			func() testConfig { return testConfig{} },
+			func(
+				context.Context,
+				testConfig,
+				testDeps,
+			) (string, Instance, error) {
+				return name, Lifecycle{
+					StartFunc: start,
+					StopFunc:  stop,
+				}, nil
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	register(
+		"existing",
+		nil,
+		func(context.Context) error {
+			existingStops.Add(1)
+			existingStopStartedOnce.Do(func() { close(existingStopStarted) })
+			<-releaseExistingStop
+			return nil
+		},
+	)
+	register(
+		"racing",
+		func(context.Context) error {
+			racingStartFinishedOnce.Do(func() { close(racingStartFinished) })
+			<-releaseRacingStart
+			return nil
+		},
+		func(context.Context) error {
+			racingStops.Add(1)
+			return nil
+		},
+	)
+
+	_, err := Resolve[string](
+		context.Background(),
+		host,
+		CapabilityMempool,
+		"existing",
+		nil,
+		testDeps{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolveDone := make(chan error, 1)
+	go func() {
+		_, resolveErr := Resolve[string](
+			context.Background(),
+			host,
+			CapabilityMempool,
+			"racing",
+			nil,
+			testDeps{},
+		)
+		resolveDone <- resolveErr
+	}()
+	testutil.RequireReceive(
+		t,
+		racingStartFinished,
+		3*time.Second,
+		"racing provider start",
+	)
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- host.StopCapability(
+			context.Background(),
+			CapabilityMempool,
+		)
+	}()
+	testutil.RequireReceive(
+		t,
+		existingStopStarted,
+		3*time.Second,
+		"existing provider stop",
+	)
+
+	releaseRacing()
+	err = testutil.RequireReceive(
+		t,
+		resolveDone,
+		3*time.Second,
+		"racing provider resolution",
+	)
+	if err == nil ||
+		!strings.Contains(err.Error(), "stopped during resolution") {
+		t.Fatalf("resolve error = %v, want capability stopped error", err)
+	}
+	if got := racingStops.Load(); got != 1 {
+		t.Fatalf("racing provider stop count = %d, want 1", got)
+	}
+
+	releaseExisting()
+	if err := testutil.RequireReceive(
+		t,
+		stopDone,
+		3*time.Second,
+		"capability stop",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := existingStops.Load(); got != 1 {
+		t.Fatalf("existing provider stop count = %d, want 1", got)
+	}
+	if err := host.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := racingStops.Load(); got != 1 {
+		t.Fatalf("racing provider stop count after host stop = %d, want 1", got)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make opening the database ownership-safe. Non-recoverable errors no longer return a live runtime, and recoverable commit-timestamp mismatches are reported on the runtime so callers can handle them and close resources cleanly.

- **Bug Fixes**
  - Ensure `internal/plugins.OpenDatabase` never returns a live runtime with a non‑nil error; recoverable `database.CommitTimestampError` is exposed via `DatabaseRuntime.RecoveryError()`.
  - Return errors only after stopping any started resources and join cleanup errors, preventing leaks and preserving database‑before‑provider shutdown order.
  - Update callers in serve, mithril sync, and bootstrap paths to check `err` first, then handle `RecoveryError()`, avoiding provider leaks and keeping shutdown ordering intact.

- **Refactors**
  - Add `DatabaseRuntime.RecoveryError()` and tighten `Close` semantics; document the contract in `ARCHITECTURE.md` and `DATABASE.md`.
  - Expand tests to cover recovery error on the runtime, no runtime on hard errors, zero‑port API provider skips, cleanup on API startup failure, and capability stop racing with resolve.

<sup>Written for commit 5d29dc82bd752b156f8c9250ef9a02d67202040a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database startup and recovery handling for timestamp mismatches.
  - Prevented resource leaks when database initialization fails.
  - Improved synchronization, repair, and backfill operations when recovering from database state issues.
  - Ensured service providers shut down cleanly after startup failures or concurrent shutdowns.
  - Providers configured with port 0 are now correctly skipped during startup.

- **Documentation**
  - Clarified database lifecycle, recovery behavior, and shutdown guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->