### PR TITLE
fix(database): parse Leios pool reward accounts

### DIFF
--- a/database/plugin/metadata/internal/certutil/pool.go
+++ b/database/plugin/metadata/internal/certutil/pool.go
@@ -47,19 +47,32 @@ func PoolRewardAccount(
 ) (credentialTag uint8, hash []byte, err error) {
 	rawCbor := cert.Cbor()
 	if len(rawCbor) > 0 {
-		// Pool cert CBOR is a flat array:
+		// Legacy pool cert CBOR is a 10-field flat array:
 		//   [cert_type, operator, vrf_keyhash, pledge, cost, margin,
 		//    reward_account, pool_owners, relays, pool_metadata]
-		// reward_account is at index 6.
+		// Dijkstra/Leios adds leios_key after vrf_keyhash, producing an
+		// 11-field array and shifting reward_account from index 6 to 7.
 		var raw []gcbor.RawMessage
 		if _, decErr := gcbor.Decode(rawCbor, &raw); decErr != nil {
 			return 0, nil, fmt.Errorf("decode pool cert CBOR: %w", decErr)
 		}
-		if len(raw) <= 6 {
-			return 0, nil, fmt.Errorf("pool cert CBOR array too short: got %d fields, want >6", len(raw))
+		var rewardAccountIndex int
+		switch len(raw) {
+		case 10:
+			rewardAccountIndex = 6
+		case 11:
+			rewardAccountIndex = 7
+		default:
+			return 0, nil, fmt.Errorf(
+				"pool cert CBOR: got %d fields, want 10 or 11",
+				len(raw),
+			)
 		}
 		var rewardAddrBytes []byte
-		if _, decErr := gcbor.Decode(raw[6], &rewardAddrBytes); decErr != nil {
+		if _, decErr := gcbor.Decode(
+			raw[rewardAccountIndex],
+			&rewardAddrBytes,
+		); decErr != nil {
 			return 0, nil, fmt.Errorf("decode pool cert reward_account field: %w", decErr)
 		}
 		if len(rewardAddrBytes) != 29 {

--- a/database/plugin/metadata/internal/certutil/pool_test.go
+++ b/database/plugin/metadata/internal/certutil/pool_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certutil
+
+import (
+	"bytes"
+	"testing"
+
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolRewardAccountCBORLayouts(t *testing.T) {
+	rewardHash := bytes.Repeat([]byte{0x42}, lcommon.Blake2b224Size)
+
+	tests := []struct {
+		name        string
+		certificate []any
+		wantTag     uint8
+	}{
+		{
+			name: "legacy key hash",
+			certificate: poolRegistrationFields(
+				append([]byte{0xE1}, rewardHash...),
+				false,
+			),
+			wantTag: 0,
+		},
+		{
+			name: "Dijkstra script hash",
+			certificate: poolRegistrationFields(
+				append([]byte{0xF1}, rewardHash...),
+				true,
+			),
+			wantTag: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := gcbor.Encode(test.certificate)
+			require.NoError(t, err)
+
+			cert := &lcommon.PoolRegistrationCertificate{}
+			cert.SetCbor(raw)
+
+			gotTag, gotHash, err := PoolRewardAccount(cert)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantTag, gotTag)
+			assert.Equal(t, rewardHash, gotHash)
+		})
+	}
+}
+
+func TestPoolRewardAccountRejectsInvalidLayout(t *testing.T) {
+	fields := poolRegistrationFields(
+		append([]byte{0xE1}, bytes.Repeat([]byte{0x42}, lcommon.Blake2b224Size)...),
+		false,
+	)
+	fields = fields[:9]
+	raw, err := gcbor.Encode(fields)
+	require.NoError(t, err)
+
+	cert := &lcommon.PoolRegistrationCertificate{}
+	cert.SetCbor(raw)
+
+	_, _, err = PoolRewardAccount(cert)
+	require.EqualError(t, err, "pool cert CBOR: got 9 fields, want 10 or 11")
+}
+
+func poolRegistrationFields(rewardAddress []byte, leios bool) []any {
+	fields := []any{
+		uint(lcommon.CertificateTypePoolRegistration),
+		bytes.Repeat([]byte{0x01}, lcommon.Blake2b224Size),
+		bytes.Repeat([]byte{0x02}, lcommon.Blake2b256Size),
+		uint64(1_000_000),
+		uint64(340_000_000),
+		[]uint64{1, 20},
+		rewardAddress,
+		[]any{},
+		[]any{},
+		nil,
+	}
+	if leios {
+		leiosKey := &lcommon.LeiosKey{
+			PublicKey: bytes.Repeat(
+				[]byte{0x03},
+				lcommon.LeiosBlsPublicKeySize,
+			),
+			PossessionProof: bytes.Repeat(
+				[]byte{0x04},
+				lcommon.LeiosBlsPossessionProofSize,
+			),
+		}
+		fields = append(
+			fields[:3],
+			append([]any{leiosKey}, fields[3:]...)...,
+		)
+	}
+	return fields
+}


### PR DESCRIPTION
Closes #2976 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes parsing of pool reward accounts to support Leios/Dijkstra pool registrations that add a `leios_key` field. Prevents misreading the reward account and ensures correct tag/hash extraction for both 10- and 11-field CBOR layouts.

- Bug Fixes
  - `PoolRewardAccount` now handles 10- and 11-field pool cert CBOR arrays; selects reward_account at index 6 or 7 accordingly.
  - Returns a clear error when field count is not 10 or 11.
  - Adds tests for legacy key-hash and Dijkstra script-hash reward accounts, plus an invalid layout case.

<sup>Written for commit 8a6f38879e13d3071ad29005438ae8fa7c94cfbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool registration certificate processing to support both legacy and newer CBOR formats.
  * Added clearer validation errors for certificates with unexpected field counts.
  * Preserved existing reward-account extraction and fallback behavior.

* **Tests**
  * Added coverage for supported certificate layouts and invalid field counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->