### PR TITLE
fix(event): apply backpressure instead of dropping events

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -809,9 +809,18 @@ All event types follow the `subsystem.snake_case_name` convention.
 - Asynchronous delivery via worker pool (4 workers, 1000-entry async queue)
 - Default subscriber buffers of 1024 events, with opt-in 100000-entry burst
   buffers for high-volume ledger chainsync/blockfetch paths
-- Non-blocking `Publish`, blocking `PublishBlocking` for ordering-critical
-  streams, and `PublishAsync` for best-effort async work
-- Prometheus metrics for event delivery tracking and latency
+- Lossless delivery with producer backpressure: when a subscriber buffer or the
+  async queue is full, `Publish`, `PublishBlocking`, and `PublishAsync` all wait
+  for capacity instead of dropping the event. Waits end on `Stop`, `Close`, or
+  `Unsubscribe`. `PublishBlocking` differs only in returning
+  `ErrEventBusStopped` when the bus shuts down mid-delivery
+- A subscriber that stops draining stalls its publishers, and the shared async
+  worker pool means it also delays unrelated async event types. Consumers of
+  `Subscribe` channels must drain for the life of the subscription and
+  `Unsubscribe` when they stop
+- Prometheus metrics for event delivery tracking and latency, including
+  `event_delivery_blocked_total{type,kind}` and
+  `event_async_enqueue_blocked_total{type}` for backpressure
 
 ## Storage Architecture
 

--- a/event/backpressure_ext_test.go
+++ b/event/backpressure_ext_test.go
@@ -1,0 +1,480 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event_test
+
+import (
+	"maps"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file cover blinklabs-io/dingo#2932: neither the
+// per-subscriber channel nor the shared async queue may discard events under
+// sustained load, and backpressure must not wedge shutdown.
+
+// TestPublishDeliversEveryEventUnderBackpressure is the headline regression:
+// a producer far faster than its subscriber loses nothing.
+func TestPublishDeliversEveryEventUnderBackpressure(t *testing.T) {
+	const testEvtType event.EventType = "test.nodrop.publish"
+	const eventCount = 5000
+
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	// Deliberately tiny buffer: the producer spends nearly all its time
+	// backpressured.
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 8)
+
+	received := make(chan []int, 1)
+	go func() {
+		got := make([]int, 0, eventCount)
+		for evt := range subCh {
+			v, ok := evt.Data.(int)
+			if !ok {
+				continue
+			}
+			got = append(got, v)
+			if len(got) == eventCount {
+				received <- got
+				return
+			}
+		}
+		received <- got
+	}()
+
+	for i := range eventCount {
+		eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
+	}
+
+	got := testutil.RequireReceive(
+		t,
+		received,
+		10*time.Second,
+		"subscriber did not receive every published event",
+	)
+	require.Len(t, got, eventCount, "no event may be dropped")
+	for i, v := range got {
+		require.Equal(t, i, v, "events must arrive in publish order")
+	}
+}
+
+// TestPublishAsyncDeliversEveryEventUnderBackpressure covers the second drop
+// site: the shared async queue. This is the ledger.tx shape from the issue.
+func TestPublishAsyncDeliversEveryEventUnderBackpressure(t *testing.T) {
+	const testEvtType event.EventType = "test.nodrop.async"
+	const eventCount = 5000
+
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 8)
+
+	received := make(chan int, 1)
+	go func() {
+		count := 0
+		for range subCh {
+			count++
+			if count == eventCount {
+				received <- count
+				return
+			}
+		}
+		received <- count
+	}()
+
+	for i := range eventCount {
+		require.True(
+			t,
+			eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i)),
+			"PublishAsync must not drop event %d", i,
+		)
+	}
+
+	require.Equal(
+		t,
+		eventCount,
+		testutil.RequireReceive(
+			t,
+			received,
+			10*time.Second,
+			"subscriber did not receive every async-published event",
+		),
+	)
+}
+
+// TestPublishAsyncBlocksWhenQueueFull verifies PublishAsync waits for queue
+// capacity instead of returning false and discarding the event.
+func TestPublishAsyncBlocksWhenQueueFull(t *testing.T) {
+	const testEvtType event.EventType = "test.async.full"
+
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	// One-slot subscriber that nobody drains yet. The async workers park on
+	// it, and the shared queue then fills behind them.
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 1)
+
+	// Enough to fill the subscriber buffer, occupy every async worker, and
+	// saturate the queue.
+	total := event.AsyncQueueSize + event.AsyncWorkerPoolSize + 8
+	enqueued := make(chan bool, 1)
+	go func() {
+		for i := range total {
+			if !eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i)) {
+				enqueued <- false
+				return
+			}
+		}
+		enqueued <- true
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		enqueued,
+		250*time.Millisecond,
+		"PublishAsync should block once the async queue is full",
+	)
+
+	// Draining lets everything through; nothing was discarded.
+	drained := make(chan int, 1)
+	go func() {
+		count := 0
+		for range subCh {
+			count++
+			if count == total {
+				drained <- count
+				return
+			}
+		}
+		drained <- count
+	}()
+
+	require.True(
+		t,
+		testutil.RequireReceive(
+			t,
+			enqueued,
+			10*time.Second,
+			"PublishAsync did not complete after the subscriber drained",
+		),
+		"PublishAsync must not drop events",
+	)
+	require.Equal(
+		t,
+		total,
+		testutil.RequireReceive(
+			t,
+			drained,
+			10*time.Second,
+			"not every async event was delivered",
+		),
+	)
+}
+
+// TestPublishUnblocksOnStop is the shutdown-deadlock regression: a producer
+// parked on a full subscriber must not prevent Stop from completing.
+func TestPublishUnblocksOnStop(t *testing.T) {
+	const testEvtType event.EventType = "test.backpressure.stop"
+
+	eb := event.NewEventBus(nil, nil)
+	_, _ = eb.SubscribeWithBuffer(testEvtType, 1)
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "fill"))
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		eb.Publish(testEvtType, event.NewEvent(testEvtType, "blocked"))
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		published,
+		50*time.Millisecond,
+		"Publish returned before Stop despite a full subscriber buffer",
+	)
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		eb.Stop()
+	}()
+
+	testutil.RequireReceive(
+		t,
+		stopped,
+		5*time.Second,
+		"Stop deadlocked behind a backpressured Publish",
+	)
+	testutil.RequireReceive(
+		t,
+		published,
+		5*time.Second,
+		"Publish did not return after Stop",
+	)
+}
+
+// TestPublishUnblocksOnUnsubscribe verifies a backpressured producer is
+// released when the slow subscriber goes away.
+func TestPublishUnblocksOnUnsubscribe(t *testing.T) {
+	const testEvtType event.EventType = "test.backpressure.unsubscribe"
+
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	subId, _ := eb.SubscribeWithBuffer(testEvtType, 1)
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "fill"))
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		eb.Publish(testEvtType, event.NewEvent(testEvtType, "blocked"))
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		published,
+		50*time.Millisecond,
+		"Publish returned despite a full subscriber buffer",
+	)
+
+	eb.Unsubscribe(testEvtType, subId)
+
+	testutil.RequireReceive(
+		t,
+		published,
+		5*time.Second,
+		"Publish did not return after the slow subscriber unsubscribed",
+	)
+}
+
+// TestPublishAsyncUnblocksOnStop covers the same shutdown property for a
+// producer parked on a full async queue.
+func TestPublishAsyncUnblocksOnStop(t *testing.T) {
+	const testEvtType event.EventType = "test.async.stop.unblock"
+
+	eb := event.NewEventBus(nil, nil)
+	_, _ = eb.SubscribeWithBuffer(testEvtType, 1)
+
+	// Fill the subscriber, park every async worker, then saturate the queue.
+	total := event.AsyncQueueSize + event.AsyncWorkerPoolSize + 8
+	result := make(chan bool, 1)
+	go func() {
+		for i := range total {
+			if !eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i)) {
+				result <- false
+				return
+			}
+		}
+		result <- true
+	}()
+
+	testutil.RequireNoReceive(
+		t,
+		result,
+		250*time.Millisecond,
+		"PublishAsync should block once the async queue is full",
+	)
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		eb.Stop()
+	}()
+
+	testutil.RequireReceive(
+		t,
+		stopped,
+		5*time.Second,
+		"Stop deadlocked behind a backpressured PublishAsync",
+	)
+	require.False(
+		t,
+		testutil.RequireReceive(
+			t,
+			result,
+			5*time.Second,
+			"PublishAsync did not return after Stop",
+		),
+		"PublishAsync should report failure only because the bus stopped",
+	)
+}
+
+// TestCloseCompletesWithBlockedProducers checks the permanent-shutdown path as
+// well as the reusable Stop path.
+func TestCloseCompletesWithBlockedProducers(t *testing.T) {
+	const testEvtType event.EventType = "test.backpressure.close"
+
+	eb := event.NewEventBus(nil, nil)
+	_, _ = eb.SubscribeWithBuffer(testEvtType, 1)
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "fill"))
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Go(func() {
+			eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
+		})
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		eb.Close()
+	}()
+	testutil.RequireReceive(
+		t,
+		closed,
+		5*time.Second,
+		"Close deadlocked behind backpressured publishers",
+	)
+
+	producersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(producersDone)
+	}()
+	testutil.RequireReceive(
+		t,
+		producersDone,
+		5*time.Second,
+		"backpressured publishers did not return after Close",
+	)
+}
+
+// TestBackpressureMetrics asserts the drop counter is gone and replaced by
+// counters that report waiting instead of loss.
+func TestBackpressureMetrics(t *testing.T) {
+	const testEvtType event.EventType = "test.metrics.backpressure"
+
+	reg := prometheus.NewRegistry()
+	eb := event.NewEventBus(reg, nil)
+	defer eb.Stop()
+
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 1)
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "fill"))
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		eb.Publish(testEvtType, event.NewEvent(testEvtType, "blocked"))
+	}()
+
+	require.Eventually(t, func() bool {
+		return counterValue(t, reg, "event_delivery_blocked_total", map[string]string{
+			"type": string(testEvtType),
+			"kind": "in-memory",
+		}) >= 1
+	}, 2*time.Second, 5*time.Millisecond,
+		"a backpressured delivery should be counted",
+	)
+
+	<-subCh
+	testutil.RequireReceive(
+		t,
+		published,
+		5*time.Second,
+		"Publish did not complete after capacity was freed",
+	)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != "event_delivery_errors_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				require.NotEqual(
+					t,
+					"async-dropped",
+					label.GetValue(),
+					"nothing may be reported as dropped",
+				)
+			}
+		}
+	}
+}
+
+// TestAsyncEnqueueBlockedMetric asserts a saturated async queue is reported as
+// waiting rather than as a dropped event.
+func TestAsyncEnqueueBlockedMetric(t *testing.T) {
+	const testEvtType event.EventType = "test.metrics.async"
+
+	reg := prometheus.NewRegistry()
+	eb := event.NewEventBus(reg, nil)
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 1)
+
+	total := event.AsyncQueueSize + event.AsyncWorkerPoolSize + 8
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range total {
+			eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i))
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		return counterValue(t, reg, "event_async_enqueue_blocked_total", map[string]string{
+			"type": string(testEvtType),
+		}) >= 1
+	}, 5*time.Second, 10*time.Millisecond,
+		"a backpressured async enqueue should be counted",
+	)
+
+	go func() {
+		for range subCh {
+		}
+	}()
+	testutil.RequireReceive(
+		t,
+		done,
+		10*time.Second,
+		"PublishAsync did not complete after the subscriber drained",
+	)
+	eb.Stop()
+}
+
+// counterValue returns the value of a labeled counter in reg, or -1 when the
+// metric is absent.
+func counterValue(
+	t *testing.T,
+	reg prometheus.Gatherer,
+	name string,
+	labels map[string]string,
+) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			got := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				got[label.GetName()] = label.GetValue()
+			}
+			if maps.Equal(got, labels) {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return -1
+}

--- a/event/backpressure_test.go
+++ b/event/backpressure_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file cover blinklabs-io/dingo#2932: channelSubscriber must
+// wait for buffer capacity rather than dropping events, without reintroducing
+// the Close() deadlock that the original non-blocking send avoided.
+
+// TestDeliverWaitsForCapacityThenDelivers is the core no-loss property: a
+// delivery into a full buffer parks until a slot frees, then lands.
+func TestDeliverWaitsForCapacityThenDelivers(t *testing.T) {
+	sub := newChannelSubscriber(1, nil)
+	require.NoError(t, sub.Deliver(NewEvent("test", "first")))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Deliver(NewEvent("test", "second"))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Deliver returned while the buffer was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.Equal(t, "first", (<-sub.ch).Data)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Deliver did not complete after capacity was freed")
+	}
+	require.Equal(t, "second", (<-sub.ch).Data)
+}
+
+// TestDeliverUnblocksOnClose is the constraint the original non-blocking send
+// existed to satisfy: Close must not deadlock behind an in-flight Deliver.
+// Deliver holds mu.RLock while waiting, so Close has to signal waiters before
+// it takes mu.Lock.
+func TestDeliverUnblocksOnClose(t *testing.T) {
+	sub := newChannelSubscriber(1, nil)
+	require.NoError(t, sub.Deliver(NewEvent("test", "fill")))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Deliver(NewEvent("test", "blocked"))
+	}()
+
+	// Make sure Deliver is actually parked before closing.
+	select {
+	case <-done:
+		t.Fatal("Deliver returned while the buffer was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		sub.Close()
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close deadlocked behind a blocked Deliver")
+	}
+
+	select {
+	case err := <-done:
+		// Deliver swallows the closed error so Publish does not treat a
+		// shutting-down subscriber as a delivery failure.
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Deliver did not return after Close")
+	}
+}
+
+// TestDeliverBlockingUnblocksOnClose is the same property for the variant
+// PublishBlocking uses, which must surface the closed error so PublishBlocking
+// can report ErrEventBusStopped.
+func TestDeliverBlockingUnblocksOnClose(t *testing.T) {
+	sub := newChannelSubscriber(1, nil)
+	require.NoError(t, sub.DeliverBlocking(NewEvent("test", "fill")))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.DeliverBlocking(NewEvent("test", "blocked"))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("DeliverBlocking returned while the buffer was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	sub.Close()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, errChannelSubscriberClosed)
+	case <-time.After(2 * time.Second):
+		t.Fatal("DeliverBlocking did not return after Close")
+	}
+}
+
+// TestCloseRaceWithBlockedDelivers stresses the window between a waiting send
+// and close(ch). A send that resumes after the channel is closed would panic.
+func TestCloseRaceWithBlockedDelivers(t *testing.T) {
+	const iters = 500
+	const senders = 8
+	for range iters {
+		sub := newChannelSubscriber(1, nil)
+		require.NoError(t, sub.Deliver(NewEvent("test", "fill")))
+
+		var wg sync.WaitGroup
+		for i := range senders {
+			wg.Go(func() {
+				_ = sub.Deliver(NewEvent("test", i))
+			})
+		}
+		wg.Go(func() {
+			// Free a slot so at least one sender resumes concurrently
+			// with Close.
+			<-sub.ch
+		})
+		wg.Go(sub.Close)
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("blocked Deliver and Close deadlocked")
+		}
+	}
+}
+
+// TestDeliverStallWarning verifies operators still get a signal when a
+// subscriber stops draining. Backpressure is normal under load, so the warning
+// is emitted only after a delivery has been parked for a full interval, and it
+// repeats at most once per interval rather than once per event.
+func TestDeliverStallWarning(t *testing.T) {
+	origInterval := deliveryStallWarnInterval
+	deliveryStallWarnInterval = 20 * time.Millisecond
+	t.Cleanup(func() { deliveryStallWarnInterval = origInterval })
+
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	sub := newChannelSubscriber(1, logger)
+	require.NoError(t, sub.Deliver(NewEvent("test.stalled", "fill")))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.Deliver(NewEvent("test.stalled", "blocked"))
+	}()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), "event delivery stalled")
+	}, 2*time.Second, 5*time.Millisecond,
+		"a stalled delivery should be reported",
+	)
+	require.Contains(t, buf.String(), "test.stalled", "warning names the type")
+
+	// The delivery still completes once capacity appears.
+	<-sub.ch
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("stalled Deliver did not complete after capacity was freed")
+	}
+	require.Equal(t, "blocked", (<-sub.ch).Data)
+}
+
+// TestDeliverDoesNotWarnWhenCapacityIsAvailable guards against reintroducing
+// the per-event log spam from blinklabs-io/dingo#1556.
+func TestDeliverDoesNotWarnWhenCapacityIsAvailable(t *testing.T) {
+	origInterval := deliveryStallWarnInterval
+	deliveryStallWarnInterval = 20 * time.Millisecond
+	t.Cleanup(func() { deliveryStallWarnInterval = origInterval })
+
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	sub := newChannelSubscriber(4, logger)
+
+	for i := range 1000 {
+		require.NoError(t, sub.Deliver(NewEvent("test.quiet", i)))
+		<-sub.ch
+	}
+	require.Empty(t, buf.String(), "steady-state delivery must not log")
+}
+
+// TestDeliverAfterCloseReturnsClosed keeps the post-close contract explicit:
+// DeliverBlocking reports the closed subscriber, Deliver swallows it.
+func TestDeliverAfterCloseReturnsClosed(t *testing.T) {
+	sub := newChannelSubscriber(1, nil)
+	sub.Close()
+
+	require.True(
+		t,
+		errors.Is(sub.DeliverBlocking(NewEvent("test", "x")), errChannelSubscriberClosed),
+	)
+	require.NoError(t, sub.Deliver(NewEvent("test", "x")))
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/event/delivery_test.go
+++ b/event/delivery_test.go
@@ -45,11 +45,11 @@ func TestDeliverFailureUnregisters(t *testing.T) {
 	}
 }
 
-// TestChannelSubscriberDeliverNonBlocking verifies that channelSubscriber.Deliver
-// does not block when the channel buffer is full. This is the core fix for the
-// MEM-06 goroutine leak: previously, Deliver used a blocking send which caused
-// goroutines spawned by publishWithTimeout to leak.
-func TestChannelSubscriberDeliverNonBlocking(t *testing.T) {
+// TestChannelSubscriberDeliverWaitsForCapacity verifies that
+// channelSubscriber.Deliver waits for buffer capacity instead of dropping the
+// event. Regression test for blinklabs-io/dingo#2932: the non-blocking send
+// this replaces silently discarded events under sustained load.
+func TestChannelSubscriberDeliverWaitsForCapacity(t *testing.T) {
 	const bufferSize = 5
 	sub := newChannelSubscriber(bufferSize, nil)
 
@@ -61,38 +61,50 @@ func TestChannelSubscriberDeliverNonBlocking(t *testing.T) {
 		}
 	}
 
-	// Deliver to the full buffer should return immediately without blocking.
+	// Deliver to the full buffer must wait rather than drop.
 	done := make(chan error, 1)
 	go func() {
 		done <- sub.Deliver(NewEvent("test", "overflow"))
 	}()
 
 	select {
+	case <-done:
+		t.Fatal("Deliver returned while the buffer was full; event was dropped")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: Deliver is waiting for capacity.
+	}
+
+	// Draining one slot releases the waiting Deliver.
+	first := <-sub.ch
+
+	select {
 	case err := <-done:
 		if err != nil {
-			t.Fatalf("unexpected error on non-blocking deliver: %v", err)
+			t.Fatalf("unexpected error after capacity freed: %v", err)
 		}
-		// Good: Deliver returned without blocking
-	case <-time.After(1 * time.Second):
-		t.Fatal("Deliver blocked on full channel buffer; expected non-blocking drop")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Deliver did not complete after buffer capacity was freed")
 	}
 
-	// Verify the original buffered events are still present
+	// Every event is accounted for: the drained one, the rest of the
+	// original batch, and the event that had to wait.
+	got := []any{first.Data}
 	for range bufferSize {
 		select {
-		case <-sub.ch:
-			// Expected
+		case evt := <-sub.ch:
+			got = append(got, evt.Data)
 		default:
-			t.Fatal("expected buffered event not found")
+			t.Fatalf("expected %d events, only got %d", bufferSize+1, len(got))
 		}
 	}
-
-	// Verify no extra event was inserted (the overflow should have been dropped)
-	select {
-	case evt := <-sub.ch:
-		t.Fatalf("unexpected extra event in channel: %v", evt)
-	default:
-		// Good: buffer only contains the original events
+	want := []any{0, 1, 2, 3, 4, "overflow"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event %d: expected %v, got %v", i, want[i], got[i])
+		}
 	}
 }
 

--- a/event/doc.go
+++ b/event/doc.go
@@ -32,6 +32,23 @@
 // Use PublishAsync for events that do not need to be delivered
 // synchronously with the publisher's call stack.
 //
+// # Delivery guarantees
+//
+// The bus does not drop events. When a subscriber's channel buffer or
+// the shared async queue is full, the publisher waits for capacity
+// rather than discarding the event, so ingestion slows instead of
+// losing work that subscribers derive state from. Waiting is bounded
+// only by shutdown: Stop, Close, and Unsubscribe all release publishers
+// parked on a full buffer. Buffers themselves stay bounded, so
+// backpressure never trades event loss for unbounded memory.
+//
+// The practical consequence is that a subscriber which stops draining
+// stalls its publishers. Subscribers that take a channel from Subscribe
+// must drain it for as long as they hold the subscription and must
+// Unsubscribe when they stop. A delivery parked for a long time is
+// reported by the event_delivery_blocked_total metric and an "event
+// delivery stalled" warning.
+//
 // # Subscribing
 //
 //	eventBus.SubscribeFunc(chain.ChainForkEventType, func(evt event.Event) {
@@ -43,8 +60,9 @@
 // The bus runs a pool of async worker goroutines (default 4) to
 // dispatch subscribers. Subscriber callbacks must be non-blocking; if
 // a callback needs to do real work, push it onto its own goroutine.
-// A slow subscriber can backpressure the bus and delay delivery of
-// unrelated events.
+// A slow subscriber backpressures the bus and delays delivery of
+// unrelated events: the async workers are a shared pool, so a
+// subscriber that parks them holds up every async event type.
 //
 // Event type constants live alongside the package that owns the
 // event: ChainForkEventType in chain, ChainSwitchEventType in

--- a/event/event.go
+++ b/event/event.go
@@ -29,7 +29,10 @@ const (
 	// EventQueueSize is the high-burst buffer used by subscribers that may
 	// receive bulk-sync bursts (e.g. chainsync/blockfetch ingest in the
 	// ledger). Subscribers opt in to this size via the *WithBuffer
-	// variants. Sized to absorb the worst case from #1556 / #1914.
+	// variants. Sized to absorb the worst case from #1556 / #1914. Buffer
+	// size no longer decides whether events survive — a full buffer
+	// backpressures the publisher rather than dropping (#2932) — it decides
+	// how large a burst passes through without slowing ingestion.
 	EventQueueSize = 100000
 	// DefaultSubscriberBuffer is the per-subscriber channel buffer used by
 	// Subscribe/SubscribeFunc when no explicit size is requested. Most
@@ -42,7 +45,6 @@ const (
 	AsyncQueueSize          = 1000
 	AsyncWorkerPoolSize     = 4
 	RemoteDeliverTimeout    = 5 * time.Second
-	blockingDeliverRetry    = 10 * time.Millisecond
 )
 
 // ErrEventBusStopped is returned by PublishBlocking when the EventBus is
@@ -50,6 +52,13 @@ const (
 var ErrEventBusStopped = errors.New("event bus stopped")
 
 var errChannelSubscriberClosed = errors.New("channel subscriber closed")
+
+// deliveryStallWarnInterval is how long a single delivery may wait for
+// subscriber capacity before the subscriber is reported as stalled, and how
+// often that report repeats while the wait continues. Backpressure is normal
+// under load, so this deliberately reports a stall rather than each wait.
+// Overridden in tests.
+var deliveryStallWarnInterval = 30 * time.Second
 
 type EventType string
 
@@ -162,10 +171,11 @@ func (e *EventBus) asyncWorker() {
 				return
 			default:
 			}
-			// Publish directly — channelSubscriber.Deliver uses non-blocking
-			// sends so this cannot block forever on in-memory subscribers.
-			// Remote subscribers are time-bounded by deliverWithTimeout in
-			// Publish, so async workers cannot be stalled indefinitely.
+			// Publish directly. A slow in-memory subscriber parks this
+			// worker until it drains, which is the backpressure that
+			// keeps events from being dropped; shutdown closes stopCh
+			// first, releasing any parked delivery. Remote subscribers
+			// are time-bounded by deliverWithTimeout in Publish.
 			e.Publish(ae.eventType, ae.event)
 		}
 	}
@@ -181,15 +191,28 @@ type Subscriber interface {
 }
 
 // channelSubscriber is the in-memory subscriber adapter that preserves the
-// existing channel-based API. Deliver uses a non-blocking send to avoid
-// deadlocks: if the channel buffer is full the event is dropped and a
-// warning is logged. Close closes the channel so SubscribeFunc goroutines
-// exit.
+// existing channel-based API. Delivery waits for buffer capacity rather than
+// dropping: a subscriber that falls behind backpressures its publishers
+// instead of silently losing events (blinklabs-io/dingo#2932). Close closes
+// the channel so SubscribeFunc goroutines exit.
 type channelSubscriber struct {
 	ch     chan Event
 	logger *slog.Logger
-	mu     sync.RWMutex
-	closed bool
+	// closeReq is closed by Close before it takes mu for write. A waiting
+	// send holds mu for read, so signalling first is what lets Close make
+	// progress; see the comment on deliverWait.
+	closeReq chan struct{}
+	// busStop is the owning EventBus's stop channel, snapshotted at
+	// subscribe time. Shutdown closes it before anything else, which
+	// releases waiting sends whose subscriber has not been closed yet.
+	busStop <-chan struct{}
+	// onBlocked, when set, reports that a delivery had to wait for
+	// capacity. Set once at subscribe time, before the subscriber is
+	// reachable by any publisher.
+	onBlocked func()
+	closeOnce sync.Once
+	mu        sync.RWMutex
+	closed    bool
 }
 
 func newChannelSubscriber(
@@ -197,20 +220,23 @@ func newChannelSubscriber(
 	logger *slog.Logger,
 ) *channelSubscriber {
 	return &channelSubscriber{
-		ch:     make(chan Event, buffer),
-		logger: logger,
+		ch:       make(chan Event, buffer),
+		logger:   logger,
+		closeReq: make(chan struct{}),
 	}
 }
 
-func (c *channelSubscriber) Deliver(evt Event) (err error) {
-	// Protect against races with Close by acquiring a read lock.
-	c.mu.RLock()
-	if c.closed {
-		c.mu.RUnlock()
-		return nil
-	}
-	defer c.mu.RUnlock()
-
+// deliverWait hands evt to the subscriber channel, waiting for buffer capacity
+// instead of dropping the event. It returns errChannelSubscriberClosed when
+// the subscriber is closed or the bus stops before the event can be handed
+// off.
+//
+// The read lock is what keeps Close from closing c.ch out from under an
+// in-flight send (which would panic). Holding it across a wait is only safe
+// because Close closes c.closeReq before it asks for the write lock: every
+// waiting send wakes, returns, and releases the read lock, so Close cannot be
+// starved by a full buffer.
+func (c *channelSubscriber) deliverWait(evt Event) (err error) {
 	// Recover from unexpected panics (e.g. if a remote Subscriber
 	// implementation misbehaves).
 	defer func() {
@@ -219,56 +245,77 @@ func (c *channelSubscriber) Deliver(evt Event) (err error) {
 		}
 	}()
 
-	// Non-blocking send. If the channel buffer is full we drop the
-	// event instead of blocking while holding mu.RLock, which would
-	// prevent Close() from ever acquiring mu.Lock (deadlock).
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.closed {
+		return errChannelSubscriberClosed
+	}
+
 	select {
 	case c.ch <- evt:
-		// Delivered successfully.
+		return nil
 	default:
-		// Channel buffer full; drop event and warn.
-		if c.logger != nil {
-			c.logger.Warn(
-				"event dropped: subscriber channel full",
-				"type", evt.Type,
-			)
-		}
 	}
-	return nil
-}
 
-func (c *channelSubscriber) DeliverBlocking(evt Event) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("channel deliver panic: %v", r)
-		}
-	}()
+	// Buffer is full: the publisher waits rather than losing the event.
+	if c.onBlocked != nil {
+		c.onBlocked()
+	}
+	stall := time.NewTimer(deliveryStallWarnInterval)
+	defer stall.Stop()
 	for {
-		c.mu.RLock()
-		if c.closed {
-			c.mu.RUnlock()
-			return errChannelSubscriberClosed
-		}
 		select {
 		case c.ch <- evt:
-			c.mu.RUnlock()
 			return nil
-		default:
-			c.mu.RUnlock()
+		case <-c.closeReq:
+			return errChannelSubscriberClosed
+		case <-c.busStop:
+			return errChannelSubscriberClosed
+		case <-stall.C:
+			if c.logger != nil {
+				c.logger.Warn(
+					"event delivery stalled: subscriber not draining",
+					"type", evt.Type,
+					"buffer", cap(c.ch),
+					"stalled_for", deliveryStallWarnInterval,
+				)
+			}
+			stall.Reset(deliveryStallWarnInterval)
 		}
-		time.Sleep(blockingDeliverRetry)
 	}
+}
+
+// Deliver waits for subscriber capacity and reports success even when the
+// subscriber is shutting down, so Publish does not treat teardown as a
+// delivery failure and unsubscribe.
+func (c *channelSubscriber) Deliver(evt Event) error {
+	err := c.deliverWait(evt)
+	if errors.Is(err, errChannelSubscriberClosed) {
+		return nil
+	}
+	return err
+}
+
+// DeliverBlocking is Deliver with the closed-subscriber case surfaced, so
+// PublishBlocking can distinguish teardown from successful delivery.
+func (c *channelSubscriber) DeliverBlocking(evt Event) error {
+	return c.deliverWait(evt)
 }
 
 func (c *channelSubscriber) Close() {
+	// Release waiting sends before asking for the write lock; they hold the
+	// read lock, so the write lock would otherwise wait on a wait that only
+	// Close can end.
+	c.closeOnce.Do(func() {
+		close(c.closeReq)
+	})
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed {
-		c.mu.Unlock()
 		return
 	}
 	c.closed = true
 	close(c.ch)
-	c.mu.Unlock()
 }
 
 // subscribeInternal does the actual subscription work without checking stopped.
@@ -280,10 +327,23 @@ func (e *EventBus) subscribeInternal(
 	if buffer <= 0 {
 		buffer = DefaultSubscriberBuffer
 	}
+	// Read under stopMu.RLock, held by the caller: shutdown swaps stopCh
+	// when the bus is restarted. A subscriber created while shutdown is in
+	// progress snapshots the already-closed channel, so a delivery to it
+	// returns immediately instead of waiting on a bus that is going away.
+	busStop := e.stopCh
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	// Create channel-backed subscriber
 	chSub := newChannelSubscriber(buffer, e.Logger)
+	chSub.busStop = busStop
+	if e.metrics != nil {
+		chSub.onBlocked = func() {
+			e.metrics.deliveryBlocked.WithLabelValues(
+				string(eventType), "in-memory",
+			).Inc()
+		}
+	}
 	// Increment subscriber ID
 	subId := e.lastSubId + 1
 	e.lastSubId = subId
@@ -429,9 +489,11 @@ func (e *EventBus) Unsubscribe(eventType EventType, subId EventSubscriberId) {
 }
 
 // deliverWithTimeout calls sub.Deliver with a timeout for non-channel
-// subscribers. channelSubscriber.Deliver is already non-blocking, so it
-// is called directly. For other (e.g. network-backed) implementations,
-// the call is bounded by RemoteDeliverTimeout to prevent worker stalls.
+// subscribers. channelSubscriber.Deliver is called directly: it waits for
+// buffer capacity by design, and bounding that wait would put the drop this
+// package no longer performs back into the delivery path. For other (e.g.
+// network-backed) implementations, the call is bounded by
+// RemoteDeliverTimeout to prevent worker stalls.
 //
 // Bounded goroutine leak on timeout: when the timeout fires, the
 // goroutine running sub.Deliver remains alive until Deliver returns.
@@ -448,7 +510,6 @@ func (e *EventBus) deliverWithTimeout(
 	sub Subscriber,
 	evt Event,
 ) error {
-	// Fast path: in-memory channel subscribers are non-blocking.
 	if _, ok := sub.(*channelSubscriber); ok {
 		return sub.Deliver(evt)
 	}
@@ -548,6 +609,7 @@ func (e *EventBus) PublishBlocking(eventType EventType, evt Event) error {
 		return ErrEventBusStopped
 	}
 	stopSeq := e.stopSeq
+	stopCh := e.stopCh
 	e.stopMu.RUnlock()
 
 	e.mu.RLock()
@@ -569,10 +631,7 @@ func (e *EventBus) PublishBlocking(eventType EventType, evt Event) error {
 		}
 
 		if errors.Is(deliverErr, errChannelSubscriberClosed) {
-			e.stopMu.RLock()
-			stopped := e.stopped || e.closed || e.stopSeq != stopSeq
-			e.stopMu.RUnlock()
-			if stopped {
+			if e.stoppedSince(stopSeq, stopCh) {
 				deliverErr = ErrEventBusStopped
 			} else {
 				deliverErr = nil
@@ -609,19 +668,37 @@ func (e *EventBus) PublishBlocking(eventType EventType, evt Event) error {
 	if e.metrics != nil {
 		e.metrics.eventsTotal.WithLabelValues(string(eventType)).Inc()
 	}
-	e.stopMu.RLock()
-	stopped := e.stopped || e.closed || e.stopSeq != stopSeq
-	e.stopMu.RUnlock()
-	if firstErr == nil && stopped {
+	if firstErr == nil && e.stoppedSince(stopSeq, stopCh) {
 		firstErr = ErrEventBusStopped
 	}
 	return firstErr
 }
 
+// stoppedSince reports whether the EventBus began stopping since the caller
+// snapshotted stopSeq and stopCh. shutdown closes stopCh before it marks the
+// bus stopped, so the channel has to be consulted as well as the flags.
+func (e *EventBus) stoppedSince(
+	stopSeq uint64,
+	stopCh chan struct{},
+) bool {
+	select {
+	case <-stopCh:
+		return true
+	default:
+	}
+	e.stopMu.RLock()
+	defer e.stopMu.RUnlock()
+	return e.stopped || e.closed || e.stopSeq != stopSeq
+}
+
 // PublishAsync enqueues an event for asynchronous delivery to all subscribers.
-// This method returns immediately without blocking on subscriber delivery.
-// Use this for non-critical events where immediate delivery is not required.
-// Returns false if the EventBus is stopped, closed, or the async queue is full.
+// It hands the event to the shared async queue and returns without waiting for
+// subscriber delivery. Use this for events that do not need to be delivered
+// synchronously with the publisher's call stack.
+//
+// When the queue is full the caller waits for space rather than losing the
+// event, so a backlog slows producers instead of discarding work. Returns
+// false only when the EventBus is stopped or closed.
 func (e *EventBus) PublishAsync(eventType EventType, evt Event) bool {
 	e.stopMu.RLock()
 	if e.stopped || e.closed {
@@ -629,26 +706,36 @@ func (e *EventBus) PublishAsync(eventType EventType, evt Event) bool {
 		return false
 	}
 	q := e.asyncQueue
-	defer e.stopMu.RUnlock()
+	stopCh := e.stopCh
+	// Released before waiting on the queue: shutdown needs stopMu for
+	// write, and it is shutdown that releases us.
+	e.stopMu.RUnlock()
 
+	ae := asyncEvent{eventType: eventType, event: evt}
 	select {
-	case q <- asyncEvent{eventType: eventType, event: evt}:
-		return true
+	case q <- ae:
 	default:
-		// Queue is full, log and drop the event
-		if e.Logger != nil {
-			e.Logger.Warn(
-				"async event queue full, dropping event",
-				"type",
-				eventType,
-			)
-		}
+		// Queue is full: wait for space rather than losing the event.
 		if e.metrics != nil {
-			e.metrics.deliveryErrors.WithLabelValues(string(eventType), "async-dropped").
+			e.metrics.asyncEnqueueBlocked.WithLabelValues(string(eventType)).
 				Inc()
 		}
-		return false
+		select {
+		case q <- ae:
+		case <-stopCh:
+			return false
+		}
 	}
+
+	// shutdown closes stopCh before it marks the bus stopped, so an enqueue
+	// can still land in a queue whose workers have already exited. Report
+	// that as a failed publish rather than as a delivery that never happens.
+	select {
+	case <-stopCh:
+		return false
+	default:
+	}
+	return true
 }
 
 // RegisterSubscriber allows external adapters (e.g., network-backed subscribers)
@@ -703,11 +790,24 @@ func (e *EventBus) shutdown(restart bool) {
 	e.stopOpMu.Lock()
 	defer e.stopOpMu.Unlock()
 
+	// Signal quiesce before taking stopMu for write. Publishers park on a
+	// full subscriber buffer or a full async queue while holding stopMu for
+	// read, and stopCh is what releases them, so closing it after acquiring
+	// the write lock would deadlock shutdown against its own backpressure.
+	// stopOpMu serializes shutdowns and stopped only goes false->true
+	// inside one, so this read cannot race a second close.
+	e.stopMu.RLock()
+	wasAlreadyStopped := e.stopped
+	stopCh := e.stopCh
+	e.stopMu.RUnlock()
+	if !wasAlreadyStopped {
+		close(stopCh)
+	}
+
 	// Mark as stopped to prevent new async publishes during shutdown.
 	// Close permanently marks the bus as closed so future Stop() calls
 	// cannot restart the worker pool.
 	e.stopMu.Lock()
-	wasAlreadyStopped := e.stopped
 	if !restart {
 		e.closed = true
 	}
@@ -716,8 +816,7 @@ func (e *EventBus) shutdown(restart bool) {
 	e.stopMu.Unlock()
 
 	if !wasAlreadyStopped {
-		// Signal async workers to stop and wait for them to finish
-		close(e.stopCh)
+		// Wait for the async workers to finish
 		e.asyncWg.Wait()
 	}
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -322,28 +322,40 @@ func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	)
 }
 
-// TestPublishNoGoroutineLeak verifies that publishing to a slow or blocked
-// subscriber does not leak goroutines. This is a regression test for MEM-06
-// where publishWithTimeout spawned goroutines that could never complete when
-// a subscriber's channel buffer was full.
+// TestPublishNoGoroutineLeak verifies that publishing far more events than a
+// subscriber's buffer can hold does not leak goroutines. This is a regression
+// test for MEM-06 where publishWithTimeout spawned goroutines that could never
+// complete when a subscriber's channel buffer was full. Publish now
+// backpressures instead of dropping (#2932), so the subscriber is drained
+// concurrently and the assertion is that repeatedly hitting the full-buffer
+// path spawns no per-event goroutines.
 func TestPublishNoGoroutineLeak(t *testing.T) {
 	const testEvtType event.EventType = "test.leak"
 	eb := event.NewEventBus(nil, nil)
 	defer eb.Stop()
 
-	// Subscribe but never read from the channel, simulating a blocked subscriber.
-	_, _ = eb.Subscribe(testEvtType)
+	// Small buffer so nearly every publish hits the blocked-send path.
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 4)
 
-	// Allow the runtime to settle (async workers, etc.)
+	const eventCount = 5000
+	drained := make(chan int, 1)
+	go func() {
+		count := 0
+		for range subCh {
+			count++
+			if count == eventCount {
+				drained <- count
+				return
+			}
+		}
+		drained <- count
+	}()
+
+	// Allow the runtime to settle (async workers, drain goroutine, etc.)
 	runtime.GC()
 	runtime.Gosched()
 	goroutinesBefore := runtime.NumGoroutine()
 
-	// Publish many more events than the channel buffer can hold
-	// (buffer = EventQueueSize). With the old publishWithTimeout
-	// approach, each publish beyond the buffer would spawn a
-	// goroutine that could never complete.
-	const eventCount = event.EventQueueSize + 10
 	for i := range eventCount {
 		eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
 	}
@@ -353,7 +365,13 @@ func TestPublishNoGoroutineLeak(t *testing.T) {
 	runtime.Gosched()
 	goroutinesAfter := runtime.NumGoroutine()
 
-	// With the fix, Publish returns immediately via non-blocking send.
+	require.Equal(
+		t,
+		eventCount,
+		<-drained,
+		"every published event must reach the subscriber",
+	)
+
 	// Allow a small margin (5) for normal runtime variation.
 	require.InDelta(
 		t,
@@ -361,7 +379,7 @@ func TestPublishNoGoroutineLeak(t *testing.T) {
 		goroutinesAfter,
 		5,
 		"goroutine count should not grow significantly after "+
-			"publishing to a blocked subscriber "+
+			"publishing through a full subscriber buffer "+
 			"(before=%d, after=%d)",
 		goroutinesBefore,
 		goroutinesAfter,
@@ -370,43 +388,52 @@ func TestPublishNoGoroutineLeak(t *testing.T) {
 
 // TestPublishAsyncNoGoroutineLeak verifies that PublishAsync with a slow
 // subscriber does not leak goroutines. The async workers call Publish
-// internally, which previously used publishWithTimeout.
+// internally, which previously used publishWithTimeout. Since #2932 the async
+// queue backpressures instead of dropping, so the subscriber is drained
+// concurrently.
 func TestPublishAsyncNoGoroutineLeak(t *testing.T) {
 	const testEvtType event.EventType = "test.async.leak"
 	eb := event.NewEventBus(nil, nil)
 	defer eb.Stop()
 
-	// Subscribe but never read from the channel.
-	_, _ = eb.Subscribe(testEvtType)
+	// Small buffer so the async workers repeatedly hit the blocked-send path.
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, 4)
+
+	const eventCount = 5000
+	drained := make(chan int, 1)
+	go func() {
+		count := 0
+		for range subCh {
+			count++
+			if count == eventCount {
+				drained <- count
+				return
+			}
+		}
+		drained <- count
+	}()
 
 	// Allow the runtime to settle
 	runtime.GC()
 	runtime.Gosched()
 	goroutinesBefore := runtime.NumGoroutine()
 
-	// PublishAsync many events; async workers will attempt to deliver them
-	// to the blocked subscriber via Publish -> Deliver.
-	const eventCount = event.EventQueueSize + 10
+	// PublishAsync more events than the shared async queue can hold; the
+	// workers deliver them to the slow subscriber via Publish -> Deliver.
 	for i := range eventCount {
-		eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i))
+		require.True(
+			t,
+			eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, i)),
+			"PublishAsync must not drop events",
+		)
 	}
 
-	// Wait for async workers to process the queued events.
-	// We probe by attempting a single PublishAsync; a successful
-	// enqueue means the workers have drained at least one slot.
-	// The flag ensures we stop probing after the first success
-	// so the callback is side-effect-free on subsequent calls.
-	probed := false
-	require.Eventually(t, func() bool {
-		if probed {
-			return true
-		}
-		if eb.PublishAsync(testEvtType, event.NewEvent(testEvtType, -1)) {
-			probed = true
-			return true
-		}
-		return false
-	}, 5*time.Second, 10*time.Millisecond, "async workers should drain the queue")
+	require.Equal(
+		t,
+		eventCount,
+		<-drained,
+		"every async-published event must reach the subscriber",
+	)
 
 	runtime.GC()
 	runtime.Gosched()
@@ -418,57 +445,64 @@ func TestPublishAsyncNoGoroutineLeak(t *testing.T) {
 		goroutinesAfter,
 		5,
 		"goroutine count should not grow after async "+
-			"publishing to a blocked subscriber "+
+			"publishing to a slow subscriber "+
 			"(before=%d, after=%d)",
 		goroutinesBefore,
 		goroutinesAfter,
 	)
 }
 
-// TestPublishDropsEventsOnFullBuffer verifies that when a subscriber's channel
-// buffer is full, Publish drops events gracefully instead of blocking.
-func TestPublishDropsEventsOnFullBuffer(t *testing.T) {
-	const testEvtType event.EventType = "test.drop"
+// TestPublishBlocksOnFullBufferAndLosesNothing verifies that when a
+// subscriber's channel buffer is full, Publish backpressures the producer and
+// every event is eventually delivered. Regression test for
+// blinklabs-io/dingo#2932, which replaced the drop-on-full behavior this test
+// previously asserted.
+func TestPublishBlocksOnFullBufferAndLosesNothing(t *testing.T) {
+	const testEvtType event.EventType = "test.backpressure"
 	eb := event.NewEventBus(nil, nil)
 	defer eb.Stop()
 
-	// Subscribe with the high-burst buffer; never consume events.
-	_, subCh := eb.SubscribeWithBuffer(testEvtType, event.EventQueueSize)
+	const buffer = 16
+	const overflow = 50
+	_, subCh := eb.SubscribeWithBuffer(testEvtType, buffer)
 
-	// Fill the buffer (EventQueueSize)
-	for i := range event.EventQueueSize {
+	// Fill the buffer exactly.
+	for i := range buffer {
 		eb.Publish(testEvtType, event.NewEvent(testEvtType, i))
 	}
 
-	// Publish should return immediately even though the buffer is full.
-	// Use a timeout to ensure Publish doesn't block.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := range 50 {
-			eb.Publish(
-				testEvtType,
-				event.NewEvent(testEvtType, event.EventQueueSize+i),
-			)
+		for i := range overflow {
+			eb.Publish(testEvtType, event.NewEvent(testEvtType, buffer+i))
 		}
 	}()
 
-	select {
-	case <-done:
-		// Good: Publish returned promptly
-	case <-time.After(2 * time.Second):
-		t.Fatal("Publish blocked on full subscriber channel buffer")
+	testutil.RequireNoReceive(
+		t,
+		done,
+		50*time.Millisecond,
+		"Publish should backpressure while the subscriber buffer is full",
+	)
+
+	// Drain everything; each event must arrive exactly once, in order.
+	for i := range buffer + overflow {
+		evt := testutil.RequireReceive(
+			t,
+			subCh,
+			2*time.Second,
+			"expected event to be delivered, not dropped",
+		)
+		require.Equal(t, i, evt.Data, "events must arrive in publish order")
 	}
 
-	// Verify the subscriber still received the first EventQueueSize events.
-	for range event.EventQueueSize {
-		select {
-		case _, ok := <-subCh:
-			require.True(t, ok, "channel should not be closed")
-		case <-time.After(1 * time.Second):
-			t.Fatal("expected buffered event not received")
-		}
-	}
+	testutil.RequireReceive(
+		t,
+		done,
+		2*time.Second,
+		"Publish did not complete after the subscriber drained",
+	)
 }
 
 func TestPublishBlockingWaitsForSubscriberCapacity(t *testing.T) {

--- a/event/metrics.go
+++ b/event/metrics.go
@@ -20,10 +20,12 @@ import (
 )
 
 type eventMetrics struct {
-	eventsTotal      *prometheus.CounterVec
-	subscribers      *prometheus.GaugeVec
-	deliveryErrors   *prometheus.CounterVec
-	deliveryTimeouts *prometheus.CounterVec
+	eventsTotal         *prometheus.CounterVec
+	subscribers         *prometheus.GaugeVec
+	deliveryErrors      *prometheus.CounterVec
+	deliveryTimeouts    *prometheus.CounterVec
+	deliveryBlocked     *prometheus.CounterVec
+	asyncEnqueueBlocked *prometheus.CounterVec
 }
 
 func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
@@ -54,6 +56,22 @@ func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
 		prometheus.CounterOpts{
 			Name: "event_delivery_timeouts_total",
 			Help: "total remote subscriber delivery timeouts by event type",
+		},
+		[]string{"type"},
+	)
+	e.metrics.deliveryBlocked = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_delivery_blocked_total",
+			Help: "total deliveries that waited for subscriber buffer " +
+				"capacity, by event type and kind",
+		},
+		[]string{"type", "kind"},
+	)
+	e.metrics.asyncEnqueueBlocked = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_async_enqueue_blocked_total",
+			Help: "total async publishes that waited for queue capacity, " +
+				"by event type",
 		},
 		[]string{"type"},
 	)

--- a/event/race_test.go
+++ b/event/race_test.go
@@ -178,30 +178,42 @@ func TestStopWaitsForInFlightPublish(t *testing.T) {
 	}
 }
 
-// TestPublishDoesNotBlockOnFullChannel verifies that Publish returns
-// promptly even when a subscriber's channel buffer is completely full.
-// Before the non-blocking send fix, this scenario would deadlock:
-// Deliver() held mu.RLock while blocking on ch<-, and Close() would
-// block trying to acquire mu.Lock.
-func TestPublishDoesNotBlockOnFullChannel(t *testing.T) {
+// TestPublishBlocksOnFullChannelUntilDrained verifies that Publish applies
+// backpressure when a subscriber's channel buffer is full, and that the event
+// is delivered once capacity appears rather than dropped. Regression test for
+// blinklabs-io/dingo#2932. Close() must still be able to run against an
+// in-flight blocked send without deadlocking, which is why the blocked send
+// wakes on the subscriber's close signal.
+func TestPublishBlocksOnFullChannelUntilDrained(t *testing.T) {
 	eb := NewEventBus(nil, nil)
-	typ := EventType("deadlock.test")
+	typ := EventType("backpressure.test")
 
-	_, ch := eb.SubscribeWithBuffer(typ, EventQueueSize)
+	const buffer = 64
+	_, ch := eb.SubscribeWithBuffer(typ, buffer)
 
 	// Fill the subscriber's channel buffer completely.
-	for range EventQueueSize {
-		eb.Publish(typ, NewEvent(typ, "fill"))
+	for i := range buffer {
+		eb.Publish(typ, NewEvent(typ, i))
 	}
 
-	// This next Publish must complete without blocking. With the old
-	// blocking send this would hang forever (deadlock). Use a channel
-	// + require.Eventually to detect the hang.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		eb.Publish(typ, NewEvent(typ, "overflow"))
 	}()
+
+	select {
+	case <-done:
+		t.Fatal("Publish returned while the subscriber buffer was full")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: the publisher is backpressured.
+	}
+
+	// Draining releases the publisher and the event must arrive.
+	drained := make([]any, 0, buffer+1)
+	for range buffer {
+		drained = append(drained, (<-ch).Data)
+	}
 
 	require.Eventually(t, func() bool {
 		select {
@@ -211,31 +223,18 @@ func TestPublishDoesNotBlockOnFullChannel(t *testing.T) {
 			return false
 		}
 	}, 2*time.Second, 5*time.Millisecond,
-		"Publish should not block when subscriber channel is full",
+		"Publish should complete once subscriber capacity is available",
 	)
 
-	// Drain the channel and verify we got EventQueueSize events
-	// (the overflow event was dropped).
-	drained := 0
-	for drained < EventQueueSize {
-		select {
-		case <-ch:
-			drained++
-		default:
-			t.Fatalf(
-				"expected %d buffered events, got %d",
-				EventQueueSize, drained,
-			)
-		}
+	select {
+	case evt := <-ch:
+		drained = append(drained, evt.Data)
+	case <-time.After(time.Second):
+		t.Fatal("event that was backpressured never arrived")
 	}
 
-	// No extra event should be in the channel.
-	select {
-	case <-ch:
-		t.Fatal("overflow event should have been dropped")
-	default:
-		// expected
-	}
+	require.Len(t, drained, buffer+1, "no event may be dropped")
+	require.Equal(t, "overflow", drained[buffer])
 
 	eb.Stop()
 }

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -938,7 +938,11 @@ func (ls *LedgerState) replayRecoveryBlockFromTxBlob(
 func (ls *LedgerState) replayRecoveryParentPoint(
 	block models.Block,
 ) (ocommon.Point, error) {
-	if block.Slot == 0 || len(block.PrevHash) == 0 {
+	// The genesis predecessor is encoded as an all-zero hash, not an empty
+	// one, so a length check alone lets the first block after genesis fall
+	// through to a lookup for a block that cannot exist. Rolling back to
+	// origin is what the callers already do with the zero point.
+	if block.Slot == 0 || isGenesisPrevHash(block.PrevHash) {
 		return ocommon.Point{}, nil
 	}
 	parentBlock, err := database.BlockByHash(ls.db, block.PrevHash)
@@ -950,4 +954,24 @@ func (ls *LedgerState) replayRecoveryParentPoint(
 		)
 	}
 	return ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash), nil
+}
+
+// isGenesisPrevHash reports whether a block's PrevHash refers to the genesis
+// predecessor rather than to a stored block. Decoded blocks may carry no hash
+// at all; forged blocks carry an all-zero Blake2b-256 hash. Any other length
+// is malformed and is deliberately not treated as genesis, so it surfaces as a
+// failed parent lookup rather than being silently rolled back to origin.
+func isGenesisPrevHash(prevHash []byte) bool {
+	if len(prevHash) == 0 {
+		return true
+	}
+	if len(prevHash) != lcommon.Blake2b256Size {
+		return false
+	}
+	for _, b := range prevHash {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -1359,3 +1359,96 @@ func testRawBlock(
 		Cbor:        []byte{0x80},
 	}
 }
+
+// TestReplayRecoveryParentPointGenesisPredecessor covers the first block after
+// genesis, whose PrevHash is the all-zero hash rather than an empty slice.
+// Treating that as a real parent sends replay recovery into BlockByHash for a
+// block that cannot exist, and the resulting error restarts the ledger
+// pipeline in a loop -- observed on DevNet as a producer pinned at its own
+// block 0 (slot 4) for minutes while the rest of the network advanced.
+func TestReplayRecoveryParentPointGenesisPredecessor(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	// A forged first block reports block number 0 at a non-zero slot with an
+	// all-zero PrevHash, which is how the genesis predecessor is encoded.
+	firstBlock := models.Block{
+		Slot:     4,
+		Number:   0,
+		Hash:     testHashBytes("genesis-successor"),
+		PrevHash: make([]byte, 32),
+	}
+
+	point, err := ls.replayRecoveryParentPoint(firstBlock)
+	require.NoError(
+		t,
+		err,
+		"the genesis predecessor has no stored block; it must not be looked up",
+	)
+	require.Equal(
+		t,
+		ocommon.Point{},
+		point,
+		"a block with no real parent must roll back to origin",
+	)
+}
+
+// TestIsGenesisPrevHashRejectsMalformedHashes pins the two encodings that
+// legitimately mean "no parent": a decoded block carrying no prev hash at all,
+// and a forged block carrying the all-zero Blake2b-256 hash. An all-zero slice
+// of any other length is malformed, and treating it as the genesis predecessor
+// would swallow the corruption instead of surfacing it as a failed lookup.
+func TestIsGenesisPrevHashRejectsMalformedHashes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		prevHash []byte
+		want     bool
+	}{
+		{"nil", nil, true},
+		{"empty", []byte{}, true},
+		{
+			"all-zero blake2b-256",
+			make([]byte, lcommon.Blake2b256Size),
+			true,
+		},
+		{"single zero byte", []byte{0}, false},
+		{"short all-zero", make([]byte, 16), false},
+		{"long all-zero", make([]byte, lcommon.Blake2b256Size+8), false},
+		{
+			"real parent hash",
+			bytes.Repeat([]byte{0x42}, lcommon.Blake2b256Size),
+			false,
+		},
+		{
+			"mostly zero with one set byte",
+			append(
+				make([]byte, lcommon.Blake2b256Size-1),
+				0x01,
+			),
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				tc.want,
+				isGenesisPrevHash(tc.prevHash),
+				"prevHash %x", tc.prevHash,
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The EventBus dropped events at two sites, so any subscriber building derived
state from the stream lost data silently with no backfill or replay:

- `channelSubscriber.Deliver` — non-blocking send, discarded the event when the
  per-subscriber buffer was full
- `EventBus.PublishAsync` — discarded when the shared async queue was full

Both now apply producer backpressure instead. Fixes blinklabs-io/dingo#2932.

## How the Close() deadlock is avoided

The non-blocking send existed for a reason: `Deliver` holds `mu.RLock` while
sending, and `Close()` needs `mu.Lock`, so a blocking send would deadlock
`Close`. `Close` now closes a `closeReq` channel **before** asking for the
write lock, so every waiting send wakes, returns, and releases the read lock
first. That keeps the non-deadlock property without losing events, and buffers
stay bounded (no regression against #2106).

Shutdown closes `stopCh` before taking `stopMu` for write. A publisher parked
on a full buffer or queue holds `stopMu` for read, and `stopCh` is what
releases it, so closing it after acquiring the write lock would deadlock
shutdown against its own backpressure.

## Observability

`deliveryErrors{type,"async-dropped"}` is gone — nothing drops. Replaced by
`event_delivery_blocked_total{type,kind}` and
`event_async_enqueue_blocked_total{type}`, plus a throttled
`event delivery stalled` warning. Blocking is normal under load, so only a
genuine stall is reported, which also avoids the log spam of #1556.

## Second commit: a bug this unmasks

`replayRecoveryParentPoint` guarded the no-parent case with
`len(block.PrevHash) == 0`, but a forged first block encodes its genesis
predecessor as an all-zero 32-byte hash. The guard missed it, so replay
recovery looked up a block that cannot exist and restarted the ledger pipeline
in a loop.

That path was previously unreachable only because the events leading into it
were among those being dropped. On DevNet it pinned a producer at its own
block 0 (slot 4) for ~4 minutes while the rest of the network advanced.

| metric | baseline (main) | before ledger fix | after |
|---|---|---|---|
| `lookup parent block ... not found` | 0 | 118 | 0 |
| pipeline restarts | 8 | 122 | 4 |
| `TestSustainedConsensus` | FAIL | PASS | PASS |

## Trade-offs

A slow subscriber now slows its producers instead of losing their events —
that is the point of the issue. The 4 shared async workers can all park on one
slow subscriber, delaying unrelated async event types; this is documented in
`event/doc.go` and `ARCHITECTURE.md`. Every `Subscribe()` consumer in the tree
was audited: all unsubscribe on exit, and `Unsubscribe` releases blocked
producers.

## Testing

- 15 new tests in `event/` covering no-loss delivery, blocked-send/Close
  interaction, unblock-on-Stop/Close/Unsubscribe, and the metrics
- 4 existing tests inverted — they asserted the drop behavior being removed
- 1 new `ledger/` regression test, verified to fail without the guard
- `go test -race ./...` green; `golangci-lint`, `modernize`,
  `make import-boundaries` clean
- DevNet run A/B'd against `main`, sequentially with a full Docker wipe between
  (they share container names). `TestChainGrowthRate` still fails, but fails
  identically on `main` in the same configuration (62.62s vs 62.57s)

## Docs

`ARCHITECTURE.md` and `event/doc.go` updated for the lossless-delivery
contract and its head-of-line-blocking consequence. `DATABASE.md` checked —
not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply backpressure in the `event` bus instead of dropping events, ensuring lossless delivery and clean shutdown. Also fixes replay recovery in `ledger` for blocks that reference the genesis predecessor.

- **Bug Fixes**
  - `Publish`, `PublishBlocking`, and `PublishAsync` now wait when a subscriber buffer or the async queue is full; no events are dropped.
  - Blocked publishers unblock on `Stop`, `Close`, or `Unsubscribe`; `PublishBlocking` returns `ErrEventBusStopped` if shutdown begins mid-delivery.
  - Replaced drop behavior and log spam with `event_delivery_blocked_total` and `event_async_enqueue_blocked_total`, plus a throttled “event delivery stalled” warning; removed `event_delivery_errors_total{kind="async-dropped"}`.
  - Treat an all-zero `PrevHash` as the genesis predecessor in replay recovery to avoid infinite restart loops.

- **Migration**
  - Slow subscribers must drain their `Subscribe` channels or call `Unsubscribe`; shared async workers mean head-of-line blocking across async event types.
  - Update dashboards/alerts to use `event_delivery_blocked_total` and `event_async_enqueue_blocked_total`; the old async drop counter is gone.

<sup>Written for commit 835a11edfe91a003fcfe3fca7c959652109077f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Event delivery now preserves all events by waiting for subscriber or async queue capacity instead of dropping messages.
  - Publishing unblocks cleanly when the bus stops, closes, or a subscriber unsubscribes.
  - Added visibility into delivery backpressure and stalled subscribers through metrics and warnings.

- **Bug Fixes**
  - Improved recovery for blocks immediately following genesis when the predecessor hash is zero-valued.

- **Documentation**
  - Clarified EventBus delivery guarantees, backpressure behavior, shutdown handling, and subscriber draining requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->