### PR TITLE
feat(mempool): dag-based mempool implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1956,21 +1956,25 @@ submission refreshes `LastSeen` without changing position, and oldest entries
 are removed first when watermark eviction is active. FIFO is not a fee-density
 priority queue.
 
-The DAG provider maintains nodes keyed by transaction hash, pending-output
-producer and spender indexes, and explicit parent/child edges. An edge points
-from a pending transaction to a transaction that consumes one of its outputs.
-Only validated transactions enter the graph, parents always precede descendants,
-and the ready frontier uses admission sequence then hash as deterministic
-tie-breakers. Independent transactions therefore retain FIFO behavior. Manual
-removal and expiry use the adjacency index to find the transitive descendant
-closure; confirmed removal detaches only the confirmed nodes because their
-outputs have moved into ledger state. The DAG backend never watermark-evicts
-transactions. Its TxSubmission intake waits for sufficient admission headroom,
-while direct submissions receive `MempoolFullError` above the rejection
-watermark. DAG intake currently requests one transaction ID per TxSubmission
-round trip, which can reduce inbound throughput on high-latency peer links.
-This is required because gouroboros acknowledges every ID returned by a peer;
-support for acknowledging only the fetched prefix would permit batched requests.
+The DAG provider maintains nodes keyed by transaction hash, a pending-output
+producer index, explicit parent/child edges, and a cached transaction order. An
+edge points from a pending transaction to a transaction that consumes one of
+its outputs. Only validated transactions enter the graph, and a pending parent
+must exist before its child can be admitted, so successful-admission order is
+already a stable topological order. Independent transactions therefore retain
+FIFO behavior without sorting the graph during each forging or relay snapshot.
+Manual removal and expiry use the adjacency index to find the transitive
+descendant closure; confirmed removal detaches only the confirmed nodes because
+their outputs have moved into ledger state. The DAG backend never
+watermark-evicts transactions. Its TxSubmission intake waits for sufficient
+admission headroom, while direct submissions receive `MempoolFullError` above
+the rejection watermark. A transaction that repeatedly loses the available
+headroom race to another peer is dropped after a bounded retry streak so that
+one offer cannot stall the connection indefinitely. DAG intake currently
+requests one transaction ID per TxSubmission round trip, which can reduce
+inbound throughput on high-latency peer links. This is required because
+gouroboros acknowledges every ID returned by a peer; support for acknowledging
+only the fetched prefix would permit batched requests.
 
 The selected pool manages pending transactions:
 
@@ -2021,7 +2025,9 @@ cursors and swaps the candidate overlay, ordered transaction slice, hash index,
 and byte totals; DAG additionally rebuilds and swaps its dependency graph. Its
 work is independent of total pool occupancy. Shutdown terminates an in-flight
 rebuild, and bounded ledger-generation retries prevent chain activity from
-creating a busy loop.
+creating a busy loop. If an overlay entry is unexpectedly missing from the
+transaction hash index, both FIFO and DAG reject its dependent transaction cone
+rather than retaining descendants whose parent body cannot be revalidated.
 
 `LedgerState.WithTxValidationSession` is the narrow boundary for every backend
 rebuild. It pins one published ledger generation (tip, era, and protocol

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -541,7 +541,9 @@ dingo/
 │   ├── utxo.go          # UTXO state handling
 │   └── certstate.go     # Certificate state handling
 ├── mempool/             # Transaction pool
-│   ├── mempool.go       # Mempool, validation, capacity
+│   ├── backend.go       # FIFO/DAG backend contract and constructors
+│   ├── dag.go           # Dependency graph and topological ordering
+│   ├── mempool.go       # Shared validation, lifecycle, capacity, providers
 │   └── consumer.go      # Per-consumer transaction tracking
 ├── ouroboros/            # Ouroboros protocol handlers
 │   ├── ouroboros.go      # N2N and N2C protocol management
@@ -634,7 +636,7 @@ type Node struct {
     chainsyncState *chainsync.State               // Multi-peer sync state
     chainSelector  *chainselection.ChainSelector  // Chain comparison
     eventBus       *event.EventBus                // Event routing
-    mempool        mempool.Pool                   // Selected transaction pool
+    mempool        mempool.Service                // Selected transaction pool
     chainManager   *chain.ChainManager            // Blockchain state
     db             *database.Database             // Storage layer
     ledgerState    *ledger.LedgerState            // UTXO/state tracking
@@ -1945,13 +1947,30 @@ ChainSync streams ineligible.
 
 ## Transaction Mempool
 
-`mempool.Pool` is the backend-neutral contract used by node composition.
-`mempool.FIFO` embeds the existing ordered queue and is the default backend.
-Successful admissions append to that queue; independent transactions are
+`mempool.Service` is the backend-neutral contract used by node composition.
+The plugin host resolves either the `fifo` provider (the default) or the `dag`
+provider. The legacy provider name `default` remains an alias for `fifo`.
+Successful FIFO admissions append to one queue; independent transactions are
 therefore exposed to forging and relay consumers in admission order. Duplicate
 submission refreshes `LastSeen` without changing position, and oldest entries
 are removed first when watermark eviction is active. FIFO is not a fee-density
 priority queue.
+
+The DAG provider maintains nodes keyed by transaction hash, pending-output
+producer and spender indexes, and explicit parent/child edges. An edge points
+from a pending transaction to a transaction that consumes one of its outputs.
+Only validated transactions enter the graph, parents always precede descendants,
+and the ready frontier uses admission sequence then hash as deterministic
+tie-breakers. Independent transactions therefore retain FIFO behavior. Manual
+removal and expiry use the adjacency index to find the transitive descendant
+closure; confirmed removal detaches only the confirmed nodes because their
+outputs have moved into ledger state. The DAG backend never watermark-evicts
+transactions. Its TxSubmission intake waits for sufficient admission headroom,
+while direct submissions receive `MempoolFullError` above the rejection
+watermark. DAG intake currently requests one transaction ID per TxSubmission
+round trip, which can reduce inbound throughput on high-latency peer links.
+This is required because gouroboros acknowledges every ID returned by a peer;
+support for acknowledging only the fetched prefix would permit batched requests.
 
 The selected pool manages pending transactions:
 
@@ -1961,7 +1980,7 @@ The selected pool manages pending transactions:
     | Transaction Management                         |
     |   Validation on add (Phase 1 + Phase 2)        |
     |   Capacity limits (configurable)               |
-    |   Watermark-based eviction and rejection       |
+    |   FIFO eviction / DAG intake backpressure      |
     |   Automatic purging on chain updates           |
     |                                                |
     | Consumer Tracking                              |
@@ -1973,14 +1992,14 @@ The selected pool manages pending transactions:
     -------------------------------------------------
 ```
 
-The `mempoolImplementation` setting accepts only `fifo`, which is also the
-default; configuration validation rejects every other value. Selection and
+Selection uses `plugins.mempool.provider: fifo|dag`; provider-specific capacity
+and watermark settings remain under `plugins.mempool.config`. Selection and
 construction happen in `node.go`; networking depends on its own narrow mempool
 interface, forging and APIs retain their existing narrow adapters, and none of
-them import FIFO state. Cardano-compatible metrics and `mempool.add_tx` /
+them import backend state. Cardano-compatible metrics and `mempool.add_tx` /
 `mempool.remove_tx` events remain backend-neutral;
-`dingo_metrics_mempool_info{implementation="fifo"}` identifies the selected
-backend.
+`dingo_metrics_mempool_info{implementation="fifo|dag"}` identifies the
+selected backend.
 
 Mempool shutdown is terminal. `Stop` atomically marks the pool stopped before
 clearing transaction and consumer state; later transaction admission returns
@@ -1988,29 +2007,30 @@ clearing transaction and consumer state; later transaction admission returns
 prevents in-flight protocol callbacks from repopulating a pool whose background
 expiry and chain-update workers have already been stopped.
 
-Ordinary FIFO mutations are serialized by a dedicated mutation gate, but
-chain-update revalidation does not hold that gate while it validates the whole
-pool. A rebuild briefly snapshots the live FIFO and starts a mutation journal,
-then constructs a private candidate state while admissions, confirmed/manual
-removals, descendant pruning, expiry, and watermark eviction continue against
-the live state. The bounded journal aborts a candidate instead of growing
-without limit. Otherwise, the candidate catches up by mutation sequence,
-leaving at most the configured `revalidationDeltaCap` residual per pass, and
-commits only after it reaches the current sequence. The final critical section
-translates consumer cursors and swaps the candidate overlay, ordered
-transaction slice, hash index, and byte totals; its work is independent of
-total pool occupancy. Shutdown is a terminal journal state, and repeated
-ledger-generation changes abandon the candidate after a bounded retry so chain
-activity cannot create a busy loop.
+Ordinary mutations are serialized by a dedicated mutation gate, but chain-update
+revalidation does not hold that gate while it validates the whole pool. Both
+backends briefly snapshot their live state, build a private candidate while
+admissions and removals continue, and replay concurrent changes from a monotonic
+mutation journal. Bounded catch-up loops apply large deltas off the gate and
+leave only a limited residual for the final critical section.
 
-`LedgerState.WithTxValidationSession` is the narrow boundary for a rebuild. It
-pins one published ledger generation (tip, era, and protocol parameters), one
-validation reference slot, and one repeatable-read metadata/blob transaction
-for every transaction in the batch. The mempool verifies that generation again
-immediately before the swap; if a block or rollback published a newer one, the
-candidate is discarded and retried from the live FIFO. This prevents a single
-candidate from mixing transaction results from different ledger or database
-views.
+The shared bounded journal aborts a candidate instead of growing without limit,
+and `plugins.mempool.config.revalidationDeltaCap` controls the residual mutation
+count for both providers. The final critical section translates consumer
+cursors and swaps the candidate overlay, ordered transaction slice, hash index,
+and byte totals; DAG additionally rebuilds and swaps its dependency graph. Its
+work is independent of total pool occupancy. Shutdown terminates an in-flight
+rebuild, and bounded ledger-generation retries prevent chain activity from
+creating a busy loop.
+
+`LedgerState.WithTxValidationSession` is the narrow boundary for every backend
+rebuild. It pins one published ledger generation (tip, era, and protocol
+parameters), one validation reference slot, and one repeatable-read
+metadata/blob transaction for every transaction in the batch. The mempool
+verifies that generation again immediately before the swap; if a block or
+rollback published a newer one, the candidate is discarded and retried from
+the live pool. This prevents one FIFO or DAG candidate from mixing transaction
+results from different ledger or database views.
 
 CBOR decoding and ledger validation run without the primary pool RW lock or
 consumer lock. `Transactions` likewise snapshots transaction values under the

--- a/config.go
+++ b/config.go
@@ -557,7 +557,8 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 		opt(&c)
 	}
 	mempoolSelection := c.pluginSelections[plugin.CapabilityMempool]
-	if mempoolSelection.Provider == "default" {
+	switch mempoolSelection.Provider {
+	case "default", "fifo", "dag":
 		if mempoolSelection.Config == nil {
 			mempoolSelection.Config = make(map[string]any)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -109,6 +109,23 @@ func TestNewConfigPreservesExplicitMempoolCapacity(t *testing.T) {
 	assert.Equal(t, capacity, selection.Config["capacity"])
 }
 
+func TestNewConfigDefaultsBuiltInMempoolCapacity(t *testing.T) {
+	for _, provider := range []string{"default", "fifo", "dag"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg := NewConfig(WithPluginSelection(
+				plugin.CapabilityMempool,
+				plugin.Selection{Provider: provider},
+			))
+			selection := cfg.pluginSelections[plugin.CapabilityMempool]
+			assert.Equal(
+				t,
+				int64(internalconfig.DefaultMempoolCapacityPraos),
+				selection.Config["capacity"],
+			)
+		})
+	}
+}
+
 func TestNewConfigDoesNotDefaultCustomMempoolConfig(t *testing.T) {
 	cfg := NewConfig(
 		WithRunMode(runModeLeios),

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -31,7 +31,10 @@ plugins:
         # Optional SQLite data directory. When unset, databasePath applies.
         # dataDir: ".dingo"
   mempool:
-    provider: "default"
+    # "fifo" preserves successful-admission order. "dag" additionally indexes
+    # transaction dependencies and uses deterministic topological ordering.
+    # "default" remains a compatibility alias for "fifo".
+    provider: "fifo"
     config:
       # Mempool capacity in bytes. Left commented out so the run-mode default
       # applies: 1048576 (1 MiB) for standard modes, 26214400 (25 MiB) for the
@@ -39,6 +42,8 @@ plugins:
       # leios node would silently run with the smaller capacity — uncomment
       # only to pin a specific size for every run mode.
       # capacity: 1048576
+      # FIFO begins oldest-first eviction here. DAG never evicts and applies
+      # TxSubmission backpressure as it approaches rejectionWatermark.
       evictionWatermark: 0.90
       rejectionWatermark: 0.95
   api:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -583,7 +583,7 @@ func defaultPluginsConfig() PluginsConfig {
 			Blob:     hostplugin.Selection{Provider: "badger", Config: map[string]any{}},
 			Metadata: hostplugin.Selection{Provider: "sqlite", Config: map[string]any{}},
 		},
-		Mempool: hostplugin.Selection{Provider: "default", Config: map[string]any{
+		Mempool: hostplugin.Selection{Provider: DefaultMempoolImplementation, Config: map[string]any{
 			"evictionWatermark":    DefaultEvictionWatermark,
 			"rejectionWatermark":   DefaultRejectionWatermark,
 			"revalidationDeltaCap": DefaultMempoolRevalidationDeltaCap,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,7 +71,7 @@ func TestLoad_CompareFullStruct(t *testing.T) {
 	yamlContent := `
 plugins:
   mempool:
-    provider: default
+    provider: fifo
     config:
       capacity: 2097152
       evictionWatermark: 0.90
@@ -213,6 +213,32 @@ mithril:
 		)
 	}
 }
+
+func TestDefaultMempoolProviderIsFIFO(t *testing.T) {
+	if got := defaultPluginsConfig().Mempool.Provider; got != "fifo" {
+		t.Fatalf("default mempool provider = %q, want fifo", got)
+	}
+}
+
+func TestLoad_DAGMempoolProvider(t *testing.T) {
+	resetGlobalConfig()
+	tmpFile := filepath.Join(t.TempDir(), "dag-mempool.yaml")
+	if err := os.WriteFile(
+		tmpFile,
+		[]byte("plugins:\n  mempool:\n    provider: dag\n"),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Plugins.Mempool.Provider; got != "dag" {
+		t.Fatalf("mempool provider = %q, want dag", got)
+	}
+}
+
 func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 	resetGlobalConfig()
 

--- a/internal/plugins/register.go
+++ b/internal/plugins/register.go
@@ -38,7 +38,13 @@ func NewHost() (*plugin.Host, error) {
 		return nil, fmt.Errorf("register sqlite provider: %w", err)
 	}
 	if err := mempool.RegisterProvider(host); err != nil {
-		return nil, fmt.Errorf("register mempool provider: %w", err)
+		return nil, fmt.Errorf("register default mempool provider: %w", err)
+	}
+	if err := mempool.RegisterFIFOProvider(host); err != nil {
+		return nil, fmt.Errorf("register FIFO mempool provider: %w", err)
+	}
+	if err := mempool.RegisterDAGProvider(host); err != nil {
+		return nil, fmt.Errorf("register DAG mempool provider: %w", err)
 	}
 	if err := blockfrost.RegisterProvider(host); err != nil {
 		return nil, fmt.Errorf("register blockfrost provider: %w", err)

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -200,6 +200,7 @@ node's NtC endpoint.
 ./run-tests.sh --conformance                 # conformance mode: dingo + cardano-node
 ./run-tests.sh -run TestBasicBlockForging   # forward -run (and other flags) to `go test`
 ./run-tests.sh --keep-up                    # leave the network running on success (for poking around)
+DEVNET_MEMPOOL_PROVIDER=dag ./run-tests.sh  # exercise the DAG mempool on every Dingo node
 ```
 
 What it does:

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       DINGO_PLEDGE_LEVERAGE_ENABLED: "${DEVNET_DINGO_PLEDGE_LEVERAGE_ENABLED:-false}"
       DINGO_PLEDGE_LEVERAGE: "${DEVNET_DINGO_PLEDGE_LEVERAGE:-100}"
       DINGO_MIN_POOL_MARGIN: "${DEVNET_DINGO_MIN_POOL_MARGIN:-0}"
+      DINGO_PLUGINS_MEMPOOL_PROVIDER: "${DEVNET_MEMPOOL_PROVIDER:-fifo}"
       # Expose node-to-client over TCP (private port 3002) so the host test
       # harness can run LocalStateQuery. Avoids a cross-uid host socket mount:
       # the dingo image runs as uid 100 and cannot bind a socket in a

--- a/internal/test/devnet/harness_test.go
+++ b/internal/test/devnet/harness_test.go
@@ -74,10 +74,12 @@ func TestHarnessWaitForSlot(t *testing.T) {
 
 	h.WaitForAllNodesReady(60 * time.Second)
 
-	// Wait for slot 10. Timeout: 10 slots worth of wall-clock time
-	// plus margin for startup variance.
+	// Wait for slot 10. Container health means the node is queryable, but it
+	// can precede the generated network's system start. Include a fixed startup
+	// allowance in addition to slot and block-production time.
 	const targetSlot = 10
-	timeout := time.Duration(targetSlot)*cfg.SlotDuration() +
+	timeout := 30*time.Second +
+		time.Duration(targetSlot)*cfg.SlotDuration() +
 		cfg.ExpectedBlockTime()*5
 	h.WaitForSlot(targetSlot, timeout)
 }

--- a/mempool/backend.go
+++ b/mempool/backend.go
@@ -27,13 +27,16 @@ type Implementation string
 const (
 	// ImplementationFIFO preserves successful-admission order.
 	ImplementationFIFO Implementation = "fifo"
+	// ImplementationDAG tracks transaction dependencies explicitly and exposes
+	// a deterministic topological order.
+	ImplementationDAG Implementation = "dag"
 )
 
 // Valid reports whether the implementation name is part of the stable config
 // surface.
 func (i Implementation) Valid() bool {
 	switch i {
-	case ImplementationFIFO:
+	case ImplementationFIFO, ImplementationDAG:
 		return true
 	default:
 		return false
@@ -66,8 +69,8 @@ type Pool interface {
 	Consumer(connId ouroboros.ConnectionId) RelayConsumer
 }
 
-// AdmissionHeadroom is the shared capability owned by #2764. Keeping it
-// separate allows that work to land without changing the Pool contract.
+// AdmissionHeadroom is an optional capability used by non-evicting backends to
+// pause network intake before requesting transaction bodies that cannot fit.
 type AdmissionHeadroom interface {
 	AdmissionHeadroomBytes() int64
 	MaxAdmissionHeadroomBytes() int64
@@ -83,7 +86,7 @@ type FIFO struct {
 
 // NewFIFO constructs the FIFO backend.
 func NewFIFO(config MempoolConfig) (*FIFO, error) {
-	pool, err := NewMempool(config)
+	pool, err := newMempool(config, ImplementationFIFO)
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +113,85 @@ func (f *FIFO) Consumer(connId ouroboros.ConnectionId) RelayConsumer {
 	return consumer
 }
 
+// DAG exposes the dependency-indexed mempool backend.
+type DAG struct {
+	*Mempool
+}
+
+// NewDAG constructs the DAG backend.
+func NewDAG(config MempoolConfig) (*DAG, error) {
+	pool, err := newMempool(config, ImplementationDAG)
+	if err != nil {
+		return nil, err
+	}
+	return &DAG{Mempool: pool}, nil
+}
+
+func (d *DAG) Implementation() Implementation {
+	return ImplementationDAG
+}
+
+func (d *DAG) AddConsumer(connId ouroboros.ConnectionId) RelayConsumer {
+	consumer := d.Mempool.AddConsumer(connId)
+	if consumer == nil {
+		return nil
+	}
+	return consumer
+}
+
+func (d *DAG) Consumer(connId ouroboros.ConnectionId) RelayConsumer {
+	consumer := d.Mempool.Consumer(connId)
+	if consumer == nil {
+		return nil
+	}
+	return consumer
+}
+
+// AdmissionHeadroomBytes returns the bytes currently available before DAG
+// admission reaches its rejection watermark.
+func (d *DAG) AdmissionHeadroomBytes() int64 {
+	d.RLock()
+	defer d.RUnlock()
+	return d.admissionHeadroomBytesLocked()
+}
+
+// MaxAdmissionHeadroomBytes returns the maximum DAG admission budget.
+func (d *DAG) MaxAdmissionHeadroomBytes() int64 {
+	return d.admissionLimitBytes()
+}
+
+// WaitForAdmissionHeadroom blocks network intake until the requested admission
+// budget is available or either the connection or mempool stops.
+func (d *DAG) WaitForAdmissionHeadroom(
+	minBytes int64,
+	done <-chan error,
+) bool {
+	if minBytes < 0 || minBytes > d.MaxAdmissionHeadroomBytes() {
+		return false
+	}
+	for {
+		d.RLock()
+		if d.stopped {
+			d.RUnlock()
+			return false
+		}
+		if d.admissionHeadroomBytesLocked() >= minBytes {
+			d.RUnlock()
+			return true
+		}
+		changed := d.headroomChanged
+		d.RUnlock()
+
+		select {
+		case <-changed:
+		case <-done:
+			return false
+		case <-d.done:
+			return false
+		}
+	}
+}
+
 // New constructs the selected mempool implementation. An empty value selects
 // FIFO for compatibility with callers that predate configurable backends.
 func New(implementation Implementation, config MempoolConfig) (Pool, error) {
@@ -119,12 +201,21 @@ func New(implementation Implementation, config MempoolConfig) (Pool, error) {
 	switch implementation {
 	case ImplementationFIFO:
 		return NewFIFO(config)
+	case ImplementationDAG:
+		return NewDAG(config)
 	default:
-		return nil, fmt.Errorf("unknown mempool implementation %q", implementation)
+		return nil, fmt.Errorf(
+			"unknown mempool implementation %q",
+			implementation,
+		)
 	}
 }
 
 var (
-	_ Pool          = (*FIFO)(nil)
-	_ RelayConsumer = (*MempoolConsumer)(nil)
+	_ Pool              = (*FIFO)(nil)
+	_ Pool              = (*DAG)(nil)
+	_ Service           = (*FIFO)(nil)
+	_ Service           = (*DAG)(nil)
+	_ AdmissionHeadroom = (*DAG)(nil)
+	_ RelayConsumer     = (*MempoolConsumer)(nil)
 )

--- a/mempool/backend_contract_test.go
+++ b/mempool/backend_contract_test.go
@@ -45,6 +45,15 @@ func fifoContractFactory(t *testing.T, config MempoolConfig) Pool {
 	return pool
 }
 
+func dagContractFactory(t *testing.T, config MempoolConfig) Pool {
+	t.Helper()
+	config.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	config.PromRegistry = prometheus.NewRegistry()
+	pool, err := New(ImplementationDAG, config)
+	require.NoError(t, err)
+	return pool
+}
+
 func newBackendContractPool(
 	t *testing.T,
 	factory backendContractFactory,
@@ -274,6 +283,34 @@ func TestFIFOBackendContract(t *testing.T) {
 	})
 }
 
+func TestDAGBackendContract(t *testing.T) {
+	runBackendContract(t, dagContractFactory)
+
+	t.Run("revalidation", func(t *testing.T) {
+		const inputHash = "0c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8"
+		inputKey := inputHash + ":1"
+		input := buildMockInput(t, inputHash, 1)
+		validator := newOverlayValidator(map[string]lcommon.Utxo{
+			inputKey: {Id: input, Output: buildMockOutput(t, 50_000_000)},
+		})
+		pool, err := NewDAG(MempoolConfig{
+			Validator:       validator,
+			MempoolCapacity: 1 << 20,
+			PromRegistry:    prometheus.NewRegistry(),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+		require.NoError(
+			t,
+			pool.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t)),
+		)
+		validator.removeBaseUtxo(inputKey)
+		require.NoError(t, pool.rebuildOverlay())
+		assert.Empty(t, pool.Transactions())
+		assert.Empty(t, pool.dag.nodes)
+	})
+}
+
 func TestBackendFactorySelection(t *testing.T) {
 	config := MempoolConfig{
 		Validator:       newMockValidator(),
@@ -284,6 +321,16 @@ func TestBackendFactorySelection(t *testing.T) {
 	pool, err := New("", config)
 	require.NoError(t, err)
 	assert.Equal(t, ImplementationFIFO, pool.Implementation())
+	_, hasHeadroom := pool.(AdmissionHeadroom)
+	assert.False(t, hasHeadroom)
+	require.NoError(t, pool.Stop(context.Background()))
+
+	config.PromRegistry = prometheus.NewRegistry()
+	pool, err = New(ImplementationDAG, config)
+	require.NoError(t, err)
+	assert.Equal(t, ImplementationDAG, pool.Implementation())
+	_, hasHeadroom = pool.(AdmissionHeadroom)
+	assert.True(t, hasHeadroom)
 	require.NoError(t, pool.Stop(context.Background()))
 
 	pool, err = New(Implementation("priority"), config)
@@ -291,9 +338,21 @@ func TestBackendFactorySelection(t *testing.T) {
 	assert.ErrorContains(t, err, "unknown mempool implementation")
 }
 
-func TestFIFOBackendIdentityMetric(t *testing.T) {
+func TestBackendIdentityMetric(t *testing.T) {
+	for _, implementation := range []Implementation{
+		ImplementationFIFO,
+		ImplementationDAG,
+	} {
+		t.Run(string(implementation), func(t *testing.T) {
+			testBackendIdentityMetric(t, implementation)
+		})
+	}
+}
+
+func testBackendIdentityMetric(t *testing.T, implementation Implementation) {
+	t.Helper()
 	registry := prometheus.NewRegistry()
-	pool, err := NewFIFO(MempoolConfig{
+	pool, err := New(implementation, MempoolConfig{
 		Validator:       newMockValidator(),
 		MempoolCapacity: 1 << 20,
 		PromRegistry:    registry,
@@ -311,7 +370,7 @@ func TestFIFOBackendIdentityMetric(t *testing.T) {
 		labels := family.Metric[0].Label
 		require.Len(t, labels, 1)
 		assert.Equal(t, "implementation", labels[0].GetName())
-		assert.Equal(t, "fifo", labels[0].GetValue())
+		assert.Equal(t, string(implementation), labels[0].GetValue())
 		assert.Equal(t, float64(1), family.Metric[0].Gauge.GetValue())
 		return
 	}

--- a/mempool/dag.go
+++ b/mempool/dag.go
@@ -15,7 +15,7 @@
 package mempool
 
 import (
-	"container/heap"
+	"fmt"
 	"slices"
 )
 
@@ -23,11 +23,8 @@ import (
 // Mempool so both implementations preserve the same immutable snapshot and
 // relay behavior.
 type dagNode struct {
-	hash     string
-	sequence uint64
 	parents  map[string]struct{}
 	children map[string]struct{}
-	consumed []string
 	produced []string
 }
 
@@ -37,44 +34,13 @@ type dagNode struct {
 type transactionDAG struct {
 	nodes          map[string]*dagNode
 	producerByUtxo map[string]string
-	spenderByUtxo  map[string]string
-	nextSequence   uint64
-}
-
-type dagReadyQueue []*dagNode
-
-func (q *dagReadyQueue) Len() int {
-	return len(*q)
-}
-
-func (q *dagReadyQueue) Less(i, j int) bool {
-	if (*q)[i].sequence != (*q)[j].sequence {
-		return (*q)[i].sequence < (*q)[j].sequence
-	}
-	return (*q)[i].hash < (*q)[j].hash
-}
-
-func (q *dagReadyQueue) Swap(i, j int) {
-	(*q)[i], (*q)[j] = (*q)[j], (*q)[i]
-}
-
-func (q *dagReadyQueue) Push(value any) {
-	*q = append(*q, value.(*dagNode))
-}
-
-func (q *dagReadyQueue) Pop() any {
-	old := *q
-	last := len(old) - 1
-	node := old[last]
-	*q = old[:last]
-	return node
+	order          []string
 }
 
 func newTransactionDAG() *transactionDAG {
 	return &transactionDAG{
 		nodes:          make(map[string]*dagNode),
 		producerByUtxo: make(map[string]string),
-		spenderByUtxo:  make(map[string]string),
 	}
 }
 
@@ -83,16 +49,11 @@ func (d *transactionDAG) add(tx appliedTx) {
 		return
 	}
 	node := &dagNode{
-		hash:     tx.hash,
-		sequence: d.nextSequence,
 		parents:  make(map[string]struct{}),
 		children: make(map[string]struct{}),
-		consumed: slices.Clone(tx.consumed),
 		produced: make([]string, 0, len(tx.created)),
 	}
-	d.nextSequence++
 	for _, input := range tx.consumed {
-		d.spenderByUtxo[input] = tx.hash
 		if parentHash, ok := d.producerByUtxo[input]; ok {
 			node.parents[parentHash] = struct{}{}
 		}
@@ -101,8 +62,10 @@ func (d *transactionDAG) add(tx appliedTx) {
 		node.produced = append(node.produced, output)
 		d.producerByUtxo[output] = tx.hash
 	}
-	slices.Sort(node.produced)
 	d.nodes[tx.hash] = node
+	// A pending parent must already be admitted before a child can resolve its
+	// output. Admission order is therefore itself a stable topological order.
+	d.order = append(d.order, tx.hash)
 	for parentHash := range node.parents {
 		if parent := d.nodes[parentHash]; parent != nil {
 			parent.children[tx.hash] = struct{}{}
@@ -160,11 +123,6 @@ func (d *transactionDAG) remove(hashes map[string]struct{}) {
 				delete(child.parents, hash)
 			}
 		}
-		for _, input := range node.consumed {
-			if d.spenderByUtxo[input] == hash {
-				delete(d.spenderByUtxo, input)
-			}
-		}
 		for _, output := range node.produced {
 			if d.producerByUtxo[output] == hash {
 				delete(d.producerByUtxo, output)
@@ -172,6 +130,10 @@ func (d *transactionDAG) remove(hashes map[string]struct{}) {
 		}
 		delete(d.nodes, hash)
 	}
+	d.order = slices.DeleteFunc(d.order, func(hash string) bool {
+		_, remove := hashes[hash]
+		return remove
+	})
 }
 
 func (d *transactionDAG) rebuild(applied []appliedTx) {
@@ -182,29 +144,17 @@ func (d *transactionDAG) rebuild(applied []appliedTx) {
 	*d = *replacement
 }
 
-// topologicalOrder returns a stable Kahn traversal. Admission sequence is the
-// primary ready-frontier key and transaction hash is a defensive tie-breaker.
-func (d *transactionDAG) topologicalOrder() []string {
-	indegree := make(map[string]int, len(d.nodes))
-	ready := make(dagReadyQueue, 0, len(d.nodes))
-	for hash, node := range d.nodes {
-		indegree[hash] = len(node.parents)
-		if len(node.parents) == 0 {
-			heap.Push(&ready, node)
-		}
+// topologicalOrder returns the cached stable ordering maintained at mutation
+// time. A count mismatch is an internal index failure, not a representable
+// partial answer: callers must diagnose it and use a complete fallback.
+func (d *transactionDAG) topologicalOrder() ([]string, error) {
+	ret := slices.Clone(d.order)
+	if len(ret) != len(d.nodes) {
+		return ret, fmt.Errorf(
+			"DAG index inconsistent: %d of %d transactions ordered",
+			len(ret),
+			len(d.nodes),
+		)
 	}
-	ret := make([]string, 0, len(d.nodes))
-	for len(ready) > 0 {
-		node := heap.Pop(&ready).(*dagNode)
-		ret = append(ret, node.hash)
-		for childHash := range node.children {
-			indegree[childHash]--
-			if indegree[childHash] == 0 {
-				if child := d.nodes[childHash]; child != nil {
-					heap.Push(&ready, child)
-				}
-			}
-		}
-	}
-	return ret
+	return ret, nil
 }

--- a/mempool/dag.go
+++ b/mempool/dag.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mempool
+
+import (
+	"container/heap"
+	"slices"
+)
+
+// dagNode stores only graph/index metadata. Transaction bodies remain owned by
+// Mempool so both implementations preserve the same immutable snapshot and
+// relay behavior.
+type dagNode struct {
+	hash     string
+	sequence uint64
+	parents  map[string]struct{}
+	children map[string]struct{}
+	consumed []string
+	produced []string
+}
+
+// transactionDAG indexes producer/consumer relationships between pending
+// transactions. All methods are called under Mempool's mutation and state
+// locks, so the graph itself does not need a mutex.
+type transactionDAG struct {
+	nodes          map[string]*dagNode
+	producerByUtxo map[string]string
+	spenderByUtxo  map[string]string
+	nextSequence   uint64
+}
+
+type dagReadyQueue []*dagNode
+
+func (q *dagReadyQueue) Len() int {
+	return len(*q)
+}
+
+func (q *dagReadyQueue) Less(i, j int) bool {
+	if (*q)[i].sequence != (*q)[j].sequence {
+		return (*q)[i].sequence < (*q)[j].sequence
+	}
+	return (*q)[i].hash < (*q)[j].hash
+}
+
+func (q *dagReadyQueue) Swap(i, j int) {
+	(*q)[i], (*q)[j] = (*q)[j], (*q)[i]
+}
+
+func (q *dagReadyQueue) Push(value any) {
+	*q = append(*q, value.(*dagNode))
+}
+
+func (q *dagReadyQueue) Pop() any {
+	old := *q
+	last := len(old) - 1
+	node := old[last]
+	*q = old[:last]
+	return node
+}
+
+func newTransactionDAG() *transactionDAG {
+	return &transactionDAG{
+		nodes:          make(map[string]*dagNode),
+		producerByUtxo: make(map[string]string),
+		spenderByUtxo:  make(map[string]string),
+	}
+}
+
+func (d *transactionDAG) add(tx appliedTx) {
+	if _, exists := d.nodes[tx.hash]; exists {
+		return
+	}
+	node := &dagNode{
+		hash:     tx.hash,
+		sequence: d.nextSequence,
+		parents:  make(map[string]struct{}),
+		children: make(map[string]struct{}),
+		consumed: slices.Clone(tx.consumed),
+		produced: make([]string, 0, len(tx.created)),
+	}
+	d.nextSequence++
+	for _, input := range tx.consumed {
+		d.spenderByUtxo[input] = tx.hash
+		if parentHash, ok := d.producerByUtxo[input]; ok {
+			node.parents[parentHash] = struct{}{}
+		}
+	}
+	for output := range tx.created {
+		node.produced = append(node.produced, output)
+		d.producerByUtxo[output] = tx.hash
+	}
+	slices.Sort(node.produced)
+	d.nodes[tx.hash] = node
+	for parentHash := range node.parents {
+		if parent := d.nodes[parentHash]; parent != nil {
+			parent.children[tx.hash] = struct{}{}
+		}
+	}
+}
+
+// descendants returns roots and every transitively dependent transaction.
+func (d *transactionDAG) descendants(
+	roots map[string]struct{},
+) map[string]struct{} {
+	ret := make(map[string]struct{}, len(roots))
+	queue := make([]string, 0, len(roots))
+	for hash := range roots {
+		if _, ok := d.nodes[hash]; !ok {
+			continue
+		}
+		ret[hash] = struct{}{}
+		queue = append(queue, hash)
+	}
+	for len(queue) > 0 {
+		hash := queue[0]
+		queue = queue[1:]
+		node := d.nodes[hash]
+		if node == nil {
+			continue
+		}
+		for childHash := range node.children {
+			if _, seen := ret[childHash]; seen {
+				continue
+			}
+			ret[childHash] = struct{}{}
+			queue = append(queue, childHash)
+		}
+	}
+	return ret
+}
+
+// remove deletes nodes and their indexes. Edges from surviving children are
+// detached. This is correct for confirmed removal: the former parent's outputs
+// are now resolved through ledger state instead of the pending graph.
+func (d *transactionDAG) remove(hashes map[string]struct{}) {
+	for hash := range hashes {
+		node := d.nodes[hash]
+		if node == nil {
+			continue
+		}
+		for parentHash := range node.parents {
+			if parent := d.nodes[parentHash]; parent != nil {
+				delete(parent.children, hash)
+			}
+		}
+		for childHash := range node.children {
+			if child := d.nodes[childHash]; child != nil {
+				delete(child.parents, hash)
+			}
+		}
+		for _, input := range node.consumed {
+			if d.spenderByUtxo[input] == hash {
+				delete(d.spenderByUtxo, input)
+			}
+		}
+		for _, output := range node.produced {
+			if d.producerByUtxo[output] == hash {
+				delete(d.producerByUtxo, output)
+			}
+		}
+		delete(d.nodes, hash)
+	}
+}
+
+func (d *transactionDAG) rebuild(applied []appliedTx) {
+	replacement := newTransactionDAG()
+	for _, tx := range applied {
+		replacement.add(tx)
+	}
+	*d = *replacement
+}
+
+// topologicalOrder returns a stable Kahn traversal. Admission sequence is the
+// primary ready-frontier key and transaction hash is a defensive tie-breaker.
+func (d *transactionDAG) topologicalOrder() []string {
+	indegree := make(map[string]int, len(d.nodes))
+	ready := make(dagReadyQueue, 0, len(d.nodes))
+	for hash, node := range d.nodes {
+		indegree[hash] = len(node.parents)
+		if len(node.parents) == 0 {
+			heap.Push(&ready, node)
+		}
+	}
+	ret := make([]string, 0, len(d.nodes))
+	for len(ready) > 0 {
+		node := heap.Pop(&ready).(*dagNode)
+		ret = append(ret, node.hash)
+		for childHash := range node.children {
+			indegree[childHash]--
+			if indegree[childHash] == 0 {
+				if child := d.nodes[childHash]; child != nil {
+					heap.Push(&ready, child)
+				}
+			}
+		}
+	}
+	return ret
+}

--- a/mempool/dag_test.go
+++ b/mempool/dag_test.go
@@ -1,0 +1,615 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mempool
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dingotestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/plugin"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type oneShotBlockingValidator struct {
+	blockNext        atomic.Bool
+	advanceEveryCall atomic.Bool
+	generation       atomic.Uint64
+	calls            atomic.Uint64
+	started          chan struct{}
+	release          chan struct{}
+	startOnce        sync.Once
+}
+
+type countingFailValidator struct {
+	failHash string
+	calls    int
+}
+
+func (v *countingFailValidator) ValidateTx(gledger.Transaction) error {
+	return nil
+}
+
+func (v *countingFailValidator) ValidateTxWithOverlay(
+	tx gledger.Transaction,
+	_ map[string]struct{},
+	_ map[string]lcommon.Utxo,
+) error {
+	v.calls++
+	if tx.Hash().String() == v.failHash {
+		return errors.New("rejected for test")
+	}
+	return nil
+}
+
+func newOneShotBlockingValidator() *oneShotBlockingValidator {
+	return &oneShotBlockingValidator{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (v *oneShotBlockingValidator) arm() {
+	v.blockNext.Store(true)
+}
+
+func (v *oneShotBlockingValidator) ValidateTx(gledger.Transaction) error {
+	return nil
+}
+
+func (v *oneShotBlockingValidator) ValidateTxWithOverlay(
+	gledger.Transaction,
+	map[string]struct{},
+	map[string]lcommon.Utxo,
+) error {
+	v.calls.Add(1)
+	if v.advanceEveryCall.Load() {
+		v.generation.Add(1)
+	}
+	if v.blockNext.CompareAndSwap(true, false) {
+		v.startOnce.Do(func() { close(v.started) })
+		<-v.release
+	}
+	return nil
+}
+
+func (v *oneShotBlockingValidator) WithTxValidationSession(
+	fn func(
+		validate func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error,
+		stillCurrent func() bool,
+	) error,
+) error {
+	generation := v.generation.Load()
+	return fn(
+		v.ValidateTxWithOverlay,
+		func() bool {
+			return v.generation.Load() == generation
+		},
+	)
+}
+
+func graphTx(hash string, inputs []string, outputs ...string) appliedTx {
+	created := make(map[string]lcommon.Utxo, len(outputs))
+	for _, output := range outputs {
+		created[output] = lcommon.Utxo{}
+	}
+	return appliedTx{
+		hash:     hash,
+		consumed: inputs,
+		created:  created,
+	}
+}
+
+func TestTransactionDAGTopologicalOrderAndDescendants(t *testing.T) {
+	graph := newTransactionDAG()
+	graph.add(graphTx("parent", []string{"base:0"}, "parent:0", "parent:1"))
+	graph.add(graphTx("independent", []string{"base:1"}, "independent:0"))
+	graph.add(graphTx("left", []string{"parent:0"}, "left:0"))
+	graph.add(graphTx("right", []string{"parent:1"}, "right:0"))
+	graph.add(graphTx("grandchild", []string{"left:0"}, "grandchild:0"))
+
+	assert.Equal(
+		t,
+		[]string{"parent", "independent", "left", "right", "grandchild"},
+		graph.topologicalOrder(),
+	)
+	assert.Equal(t, map[string]struct{}{
+		"parent":     {},
+		"left":       {},
+		"right":      {},
+		"grandchild": {},
+	}, graph.descendants(map[string]struct{}{"parent": {}}))
+	assert.Equal(t, "parent", graph.producerByUtxo["parent:0"])
+	assert.Equal(t, "left", graph.spenderByUtxo["parent:0"])
+}
+
+func TestTransactionDAGConfirmedRemovalPreservesDescendants(t *testing.T) {
+	graph := newTransactionDAG()
+	graph.add(graphTx("parent", []string{"base:0"}, "parent:0"))
+	graph.add(graphTx("child", []string{"parent:0"}, "child:0"))
+
+	graph.remove(map[string]struct{}{"parent": {}})
+
+	assert.Equal(t, []string{"child"}, graph.topologicalOrder())
+	child := graph.nodes["child"]
+	require.NotNil(t, child)
+	assert.Empty(t, child.parents)
+	assert.Equal(
+		t,
+		map[string]struct{}{"child": {}},
+		graph.descendants(map[string]struct{}{"child": {}}),
+	)
+}
+
+func TestDAGTracksAdmittedTransactionDependencies(t *testing.T) {
+	parentBytes, childBytes, parentHash, childHash := getDependentTestTxBytes(t)
+	const originalInputHash = "0c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8"
+	baseInput := buildMockInput(t, originalInputHash, 1)
+	pool, err := NewDAG(MempoolConfig{
+		Validator: newOverlayValidator(map[string]lcommon.Utxo{
+			originalInputHash + ":1": {
+				Id:     baseInput,
+				Output: buildMockOutput(t, 50_000_000),
+			},
+		}),
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), childBytes),
+	)
+
+	require.NotNil(t, pool.dag)
+	parentNode := pool.dag.nodes[parentHash]
+	require.NotNil(t, parentNode)
+	childNode := pool.dag.nodes[childHash]
+	require.NotNil(t, childNode)
+	require.Contains(t, parentNode.children, childHash)
+	require.Contains(t, childNode.parents, parentHash)
+	txs := pool.Transactions()
+	require.Len(t, txs, 2)
+	assert.Equal(t, parentHash, txs[0].Hash)
+	assert.Equal(t, childHash, txs[1].Hash)
+
+	pool.RemoveTxsByHash([]string{parentHash})
+	txs = pool.Transactions()
+	require.Len(t, txs, 1)
+	assert.Equal(t, childHash, txs[0].Hash)
+	childNode = pool.dag.nodes[childHash]
+	require.NotNil(t, childNode)
+	assert.Empty(t, childNode.parents)
+}
+
+func TestDAGDoesNotWatermarkEvict(t *testing.T) {
+	parentBytes, childBytes, _, _ := getDependentTestTxBytes(t)
+	const originalInputHash = "0c07395aed88bdddc6de0518d1462dd0ec7e52e1e3a53599f7cdb24dc80237f8"
+	totalSize := int64(len(parentBytes) + len(childBytes))
+	capacity := totalSize
+	for totalSize > int64(float64(capacity)*DefaultRejectionWatermark) ||
+		totalSize <= int64(float64(capacity)*DefaultEvictionWatermark) {
+		capacity++
+	}
+	pool, err := NewDAG(MempoolConfig{
+		Validator: newOverlayValidator(map[string]lcommon.Utxo{
+			originalInputHash + ":1": {
+				Id:     buildMockInput(t, originalInputHash, 1),
+				Output: buildMockOutput(t, 50_000_000),
+			},
+		}),
+		MempoolCapacity: capacity,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), childBytes),
+	)
+	assert.Len(t, pool.Transactions(), 2)
+
+	pool.Lock()
+	pool.consumersMutex.Lock()
+	assert.Empty(t, pool.evictOldestLocked(0))
+	pool.consumersMutex.Unlock()
+	pool.Unlock()
+	assert.Len(t, pool.Transactions(), 2)
+}
+
+func TestDAGAdmissionHeadroomWaitsForRemoval(t *testing.T) {
+	pool, err := NewDAG(MempoolConfig{
+		Validator:          newMockValidator(),
+		MempoolCapacity:    100,
+		RejectionWatermark: 1,
+		PromRegistry:       prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+
+	pool.Lock()
+	pool.currentSizeBytes = pool.admissionLimitBytes()
+	pool.Unlock()
+	assert.Zero(t, pool.AdmissionHeadroomBytes())
+	assert.Equal(t, int64(100), pool.MaxAdmissionHeadroomBytes())
+
+	entered := make(chan struct{})
+	result := make(chan bool, 1)
+	connectionDone := make(chan error)
+	go func() {
+		close(entered)
+		result <- pool.WaitForAdmissionHeadroom(1, connectionDone)
+	}()
+	dingotestutil.RequireReceive(
+		t,
+		entered,
+		time.Second,
+		"headroom waiter start",
+	)
+
+	pool.Lock()
+	pool.currentSizeBytes--
+	pool.notifyHeadroomChangedLocked()
+	pool.Unlock()
+	assert.True(t, dingotestutil.RequireReceive(
+		t,
+		result,
+		time.Second,
+		"headroom waiter result",
+	))
+}
+
+func TestDAGConcurrentSnapshotsAndMutations(t *testing.T) {
+	txBytes := getTestTxBytes(t)
+	decoded, err := gledger.NewTransactionFromCbor(
+		uint(conway.EraIdConway),
+		txBytes,
+	)
+	require.NoError(t, err)
+	txHash := decoded.Hash().String()
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       newMockValidator(),
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 200)
+	for range 8 {
+		wg.Go(func() {
+			for range 200 {
+				for _, tx := range pool.Transactions() {
+					_, _ = pool.GetTransaction(tx.Hash)
+				}
+			}
+		})
+	}
+	wg.Go(func() {
+		for range 200 {
+			errs <- pool.AddTransaction(uint(conway.EraIdConway), txBytes)
+			pool.RemoveTransaction(txHash)
+		}
+	})
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestDAGAdmissionContinuesDuringRevalidation(t *testing.T) {
+	parentBytes, childBytes, parentHash, childHash := getDependentTestTxBytes(t)
+	validator := newOneShotBlockingValidator()
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+
+	validator.arm()
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- pool.rebuildOverlay() }()
+	dingotestutil.RequireReceive(
+		t,
+		validator.started,
+		time.Second,
+		"DAG revalidation start",
+	)
+
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- pool.AddTransaction(
+			uint(conway.EraIdConway),
+			childBytes,
+		)
+	}()
+	require.NoError(t, dingotestutil.RequireReceive(
+		t,
+		addDone,
+		time.Second,
+		"admission during DAG revalidation",
+	))
+
+	close(validator.release)
+	require.NoError(t, dingotestutil.RequireReceive(
+		t,
+		rebuildDone,
+		time.Second,
+		"DAG revalidation completion",
+	))
+	txs := pool.Transactions()
+	require.Len(t, txs, 2)
+	assert.Equal(t, parentHash, txs[0].Hash)
+	assert.Equal(t, childHash, txs[1].Hash)
+}
+
+func TestDAGRemovalContinuesDuringRevalidation(t *testing.T) {
+	parentBytes, childBytes, parentHash, _ := getDependentTestTxBytes(t)
+	validator := newOneShotBlockingValidator()
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), childBytes),
+	)
+
+	validator.arm()
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- pool.rebuildOverlay() }()
+	dingotestutil.RequireReceive(
+		t,
+		validator.started,
+		time.Second,
+		"DAG revalidation start",
+	)
+
+	removeDone := make(chan struct{}, 1)
+	go func() {
+		pool.RemoveTransaction(parentHash)
+		removeDone <- struct{}{}
+	}()
+	dingotestutil.RequireReceive(
+		t,
+		removeDone,
+		time.Second,
+		"removal during DAG revalidation",
+	)
+
+	close(validator.release)
+	require.NoError(t, dingotestutil.RequireReceive(
+		t,
+		rebuildDone,
+		time.Second,
+		"DAG revalidation completion",
+	))
+	assert.Empty(t, pool.Transactions())
+}
+
+func TestDAGRevalidationRetriesAfterLedgerGenerationChange(t *testing.T) {
+	txBytes := getTestTxBytes(t)
+	validator := newOneShotBlockingValidator()
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), txBytes),
+	)
+	callsBeforeRevalidation := validator.calls.Load()
+
+	validator.arm()
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- pool.rebuildOverlay() }()
+	dingotestutil.RequireReceive(
+		t,
+		validator.started,
+		time.Second,
+		"DAG revalidation start",
+	)
+	validator.generation.Add(1)
+	close(validator.release)
+
+	require.NoError(t, dingotestutil.RequireReceive(
+		t,
+		rebuildDone,
+		time.Second,
+		"DAG revalidation retry completion",
+	))
+	assert.GreaterOrEqual(
+		t,
+		validator.calls.Load()-callsBeforeRevalidation,
+		uint64(2),
+		"transaction should be validated again after the ledger generation changes",
+	)
+	assert.Len(t, pool.Transactions(), 1)
+}
+
+func TestDAGRevalidationBoundsLedgerGenerationRetries(t *testing.T) {
+	txBytes := getTestTxBytes(t)
+	validator := newOneShotBlockingValidator()
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), txBytes),
+	)
+
+	validator.advanceEveryCall.Store(true)
+	err = pool.rebuildOverlay()
+	require.ErrorIs(t, err, errValidationSnapshotChanged)
+	assert.Len(t, pool.Transactions(), 1)
+	assert.False(t, pool.journalActive)
+}
+
+func TestDAGRevalidationJournalOverflowLeavesLiveStateUntouched(t *testing.T) {
+	parentBytes, childBytes, parentHash, childHash := getDependentTestTxBytes(t)
+	validator := newOneShotBlockingValidator()
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+	pool.revalidationJournalCap = 1
+
+	validator.arm()
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- pool.rebuildOverlay() }()
+	dingotestutil.RequireReceive(
+		t,
+		validator.started,
+		time.Second,
+		"DAG revalidation start",
+	)
+	pool.RemoveTransaction(parentHash)
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), childBytes),
+	)
+
+	close(validator.release)
+	require.ErrorIs(
+		t,
+		dingotestutil.RequireReceive(
+			t,
+			rebuildDone,
+			time.Second,
+			"DAG revalidation completion",
+		),
+		errRevalidationJournalOverflow,
+	)
+	txs := pool.Transactions()
+	require.Len(t, txs, 1)
+	assert.Equal(t, childHash, txs[0].Hash)
+	assert.Contains(t, pool.dag.nodes, childHash)
+	assert.NotContains(t, pool.dag.nodes, parentHash)
+	assert.False(t, pool.journalActive)
+}
+
+func TestDAGRevalidationSkipsInvalidDescendantValidation(t *testing.T) {
+	parentBytes, childBytes, parentHash, _ := getDependentTestTxBytes(t)
+	validator := &countingFailValidator{}
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), childBytes),
+	)
+
+	validator.failHash = parentHash
+	validator.calls = 0
+	require.NoError(t, pool.rebuildOverlay())
+
+	assert.Equal(t, 1, validator.calls)
+	assert.Empty(t, pool.Transactions())
+	assert.Empty(t, pool.dag.nodes)
+}
+
+func TestMempoolProvidersIncludeFIFOAndDAG(t *testing.T) {
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+	require.NoError(t, RegisterFIFOProvider(host))
+	require.NoError(t, RegisterDAGProvider(host))
+
+	descriptors := host.Providers()
+	names := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		if descriptor.Capability == plugin.CapabilityMempool {
+			names = append(names, descriptor.Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{"default", "fifo", "dag"}, names)
+
+	service, err := plugin.Resolve[Service](
+		context.Background(),
+		host,
+		plugin.CapabilityMempool,
+		"dag",
+		map[string]any{"capacity": 1 << 20},
+		ProviderDependencies{
+			PromRegistry: prometheus.NewRegistry(),
+			Validator:    newMockValidator(),
+		},
+	)
+	require.NoError(t, err)
+	dagPool, ok := service.(*DAG)
+	require.True(t, ok)
+	assert.Equal(t, ImplementationDAG, dagPool.implementation)
+	require.NoError(t, host.Stop(context.Background()))
+}

--- a/mempool/dag_test.go
+++ b/mempool/dag_test.go
@@ -133,10 +133,12 @@ func TestTransactionDAGTopologicalOrderAndDescendants(t *testing.T) {
 	graph.add(graphTx("right", []string{"parent:1"}, "right:0"))
 	graph.add(graphTx("grandchild", []string{"left:0"}, "grandchild:0"))
 
+	order, err := graph.topologicalOrder()
+	require.NoError(t, err)
 	assert.Equal(
 		t,
 		[]string{"parent", "independent", "left", "right", "grandchild"},
-		graph.topologicalOrder(),
+		order,
 	)
 	assert.Equal(t, map[string]struct{}{
 		"parent":     {},
@@ -145,7 +147,6 @@ func TestTransactionDAGTopologicalOrderAndDescendants(t *testing.T) {
 		"grandchild": {},
 	}, graph.descendants(map[string]struct{}{"parent": {}}))
 	assert.Equal(t, "parent", graph.producerByUtxo["parent:0"])
-	assert.Equal(t, "left", graph.spenderByUtxo["parent:0"])
 }
 
 func TestTransactionDAGConfirmedRemovalPreservesDescendants(t *testing.T) {
@@ -155,7 +156,9 @@ func TestTransactionDAGConfirmedRemovalPreservesDescendants(t *testing.T) {
 
 	graph.remove(map[string]struct{}{"parent": {}})
 
-	assert.Equal(t, []string{"child"}, graph.topologicalOrder())
+	order, err := graph.topologicalOrder()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"child"}, order)
 	child := graph.nodes["child"]
 	require.NotNil(t, child)
 	assert.Empty(t, child.parents)
@@ -164,6 +167,40 @@ func TestTransactionDAGConfirmedRemovalPreservesDescendants(t *testing.T) {
 		map[string]struct{}{"child": {}},
 		graph.descendants(map[string]struct{}{"child": {}}),
 	)
+}
+
+func TestTransactionDAGTopologicalOrderRejectsInconsistentCache(t *testing.T) {
+	graph := newTransactionDAG()
+	graph.add(graphTx("parent", []string{"base:0"}, "parent:0"))
+	graph.add(graphTx("child", []string{"parent:0"}, "child:0"))
+	graph.order = graph.order[:1]
+
+	order, err := graph.topologicalOrder()
+
+	assert.Equal(t, []string{"parent"}, order)
+	require.ErrorContains(t, err, "1 of 2 transactions ordered")
+}
+
+func TestDAGTransactionsFallsBackOnInconsistentOrder(t *testing.T) {
+	pool, err := NewDAG(MempoolConfig{
+		Validator:       newMockValidator(),
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(
+			uint(conway.EraIdConway),
+			getTestTxBytes(t),
+		),
+	)
+	pool.Lock()
+	pool.dag.order = nil
+	pool.Unlock()
+
+	assert.Len(t, pool.Transactions(), 1)
 }
 
 func TestDAGTracksAdmittedTransactionDependencies(t *testing.T) {
@@ -579,6 +616,42 @@ func TestDAGRevalidationSkipsInvalidDescendantValidation(t *testing.T) {
 	assert.Equal(t, 1, validator.calls)
 	assert.Empty(t, pool.Transactions())
 	assert.Empty(t, pool.dag.nodes)
+}
+
+func TestFIFORevalidationPrunesDescendantsOfMissingIndexedTransaction(
+	t *testing.T,
+) {
+	parentBytes, childBytes, parentHash, _ := getDependentTestTxBytes(t)
+	validator := &countingFailValidator{}
+	pool, err := NewFIFO(MempoolConfig{
+		Validator:       validator,
+		MempoolCapacity: 1 << 20,
+		PromRegistry:    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), parentBytes),
+	)
+	require.NoError(
+		t,
+		pool.AddTransaction(uint(conway.EraIdConway), childBytes),
+	)
+
+	// Simulate an inconsistent live index. The missing parent has no
+	// transaction body to add to the invalid set, but its outputs must still
+	// poison the child during the shared FIFO/DAG revalidation pass.
+	pool.Lock()
+	delete(pool.txByHash, parentHash)
+	pool.Unlock()
+	validator.calls = 0
+
+	require.NoError(t, pool.rebuildOverlay())
+
+	assert.Zero(t, validator.calls)
+	assert.Empty(t, pool.Transactions())
+	assert.Empty(t, pool.overlay.applied)
 }
 
 func TestMempoolProvidersIncludeFIFOAndDAG(t *testing.T) {

--- a/mempool/doc.go
+++ b/mempool/doc.go
@@ -17,12 +17,16 @@
 // traffic (N2N), validates them against the current ledger state,
 // and holds them until they are included in a block or evicted.
 //
-// Pool is the backend-neutral node contract. FIFO is the default backend and
-// orders transactions by successful admission: independent submissions retain
-// arrival order, and a duplicate refresh does not move a transaction. Mempool
-// remains the concrete queue embedded by FIFO for source compatibility.
+// Service is the backend-neutral node contract. FIFO is the default backend
+// and orders transactions by successful admission: independent submissions
+// retain arrival order, and a duplicate refresh does not move a transaction.
+// DAG is the alternative backend. It indexes pending producers and spenders
+// plus parent/child edges, and exposes parents before descendants with FIFO
+// tie-breaking between ready transactions. DAG never watermark-evicts; network
+// intake waits for admission headroom instead. Mempool remains the shared
+// engine embedded by both backends for source compatibility.
 //
-// The FIFO backend validates every submitted
+// Both backends validate every submitted
 // transaction through the ledger package — UTxO resolution, fees,
 // ExUnit budgets, validity interval, size, and the full UTxO validation
 // rules enforced by the ledger package — before admitting it. Transactions
@@ -31,15 +35,18 @@
 //
 // # Eviction and watermarks
 //
-// The pool uses a two-level watermark scheme:
+// FIFO uses a two-level watermark scheme:
 //
 //   - EvictionWatermark  — above this fill level, the oldest transactions
 //     are evicted in successful-admission order to make room for new ones
 //   - RejectionWatermark — above this fill level, new submissions are
 //     rejected outright
 //
-// Eviction is oldest-first in successful-admission order. It is not driven by
-// fee density or another priority score.
+// FIFO eviction is oldest-first in successful-admission order. It is not driven
+// by fee density or another priority score. DAG ignores EvictionWatermark,
+// preserves admitted transactions, and exposes admission headroom so network
+// intake pauses before the rejection watermark. Direct submissions above that
+// watermark receive MempoolFullError.
 //
 // # Events
 //

--- a/mempool/doc.go
+++ b/mempool/doc.go
@@ -20,11 +20,12 @@
 // Service is the backend-neutral node contract. FIFO is the default backend
 // and orders transactions by successful admission: independent submissions
 // retain arrival order, and a duplicate refresh does not move a transaction.
-// DAG is the alternative backend. It indexes pending producers and spenders
-// plus parent/child edges, and exposes parents before descendants with FIFO
-// tie-breaking between ready transactions. DAG never watermark-evicts; network
-// intake waits for admission headroom instead. Mempool remains the shared
-// engine embedded by both backends for source compatibility.
+// DAG is the alternative backend. It indexes pending producers plus
+// parent/child edges, and caches successful-admission order, which is
+// topological because a pending parent must exist before a child can be
+// admitted. DAG never watermark-evicts; network intake waits for admission
+// headroom instead. Mempool remains the shared engine embedded by both backends
+// for source compatibility.
 //
 // Both backends validate every submitted
 // transaction through the ledger package — UTxO resolution, fees,

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1138,6 +1138,8 @@ func (m *Mempool) revalidateAppliedTx(
 	) error,
 ) {
 	if tx == nil {
+		// There is no transaction body to record in candidate.invalid, but its
+		// created outputs must still invalidate every dependent transaction.
 		candidate.reject(at, nil)
 		m.logger.Warn(
 			"overlay applied transaction is missing from transaction index during re-validation",
@@ -1358,9 +1360,7 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		}
 		txSize := int64(len(txBytes))
 		newSize := m.currentSizeBytes + txSize
-		rejectionThreshold := int64(
-			float64(m.config.MempoolCapacity) * m.rejectionWatermark,
-		)
+		rejectionThreshold := m.admissionLimitBytes()
 		if newSize > rejectionThreshold {
 			retErr := &MempoolFullError{
 				CurrentSize: int(m.currentSizeBytes),
@@ -1480,22 +1480,41 @@ func (m *Mempool) GetTransaction(txHash string) (MempoolTransaction, bool) {
 
 func (m *Mempool) Transactions() []MempoolTransaction {
 	m.RLock()
-	var ret []MempoolTransaction
+	ret := make([]MempoolTransaction, 0)
+	var dagErr error
 	if m.dag != nil {
-		order := m.dag.topologicalOrder()
-		ret = make([]MempoolTransaction, 0, len(order))
-		for _, hash := range order {
-			if tx := m.txByHash[hash]; tx != nil {
-				ret = append(ret, *tx)
+		var order []string
+		order, dagErr = m.dag.topologicalOrder()
+		if dagErr == nil {
+			ret = make([]MempoolTransaction, 0, len(order))
+			for _, hash := range order {
+				if tx := m.txByHash[hash]; tx != nil {
+					ret = append(ret, *tx)
+				}
+			}
+			if len(ret) != len(m.transactions) {
+				dagErr = fmt.Errorf(
+					"DAG transaction index inconsistent: %d of %d transactions resolved",
+					len(ret),
+					len(m.transactions),
+				)
 			}
 		}
-	} else {
+	}
+	if m.dag == nil || dagErr != nil {
 		ret = make([]MempoolTransaction, len(m.transactions))
 		for i := range m.transactions {
 			ret[i] = *m.transactions[i]
 		}
 	}
 	m.RUnlock()
+	if dagErr != nil {
+		m.logger.Error(
+			"falling back to admission order for mempool snapshot",
+			"component", "mempool",
+			"error", dagErr,
+		)
+	}
 
 	// Transaction CBOR is immutable after admission. Copy the slice headers
 	// under the state lock, then clone the bytes after releasing it so forging

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -136,6 +136,7 @@ type Mempool struct {
 		implementation  prometheus.Gauge
 	}
 	validator              TxValidator
+	implementation         Implementation
 	logger                 *slog.Logger
 	eventBus               *event.EventBus
 	consumers              map[ouroboros.ConnectionId]*MempoolConsumer
@@ -152,13 +153,15 @@ type Mempool struct {
 	revalidationJournalCap int
 	stopped                bool
 	sync.RWMutex
-	doneOnce       sync.Once
-	mutationMutex  sync.Mutex
-	startOnce      sync.Once
-	stopOnce       sync.Once
-	workerWG       sync.WaitGroup
-	consumersMutex sync.Mutex
-	overlay        *utxoOverlay
+	doneOnce        sync.Once
+	mutationMutex   sync.Mutex
+	startOnce       sync.Once
+	stopOnce        sync.Once
+	workerWG        sync.WaitGroup
+	consumersMutex  sync.Mutex
+	overlay         *utxoOverlay
+	dag             *transactionDAG
+	headroomChanged chan struct{}
 
 	// rebuildMutex permits one double-buffer rebuild at a time. mutationSeq and
 	// mutationJournal are protected by mutationMutex and let that rebuild catch
@@ -184,14 +187,37 @@ type revalidationCandidate struct {
 	txByHash     map[string]*MempoolTransaction
 	sizeBytes    int64
 	invalid      map[string]*MempoolTransaction
+	invalidUtxos map[string]struct{}
 }
 
 func newRevalidationCandidate() *revalidationCandidate {
 	return &revalidationCandidate{
-		overlay:  newUtxoOverlay(),
-		txByHash: make(map[string]*MempoolTransaction),
-		invalid:  make(map[string]*MempoolTransaction),
+		overlay:      newUtxoOverlay(),
+		txByHash:     make(map[string]*MempoolTransaction),
+		invalid:      make(map[string]*MempoolTransaction),
+		invalidUtxos: make(map[string]struct{}),
 	}
+}
+
+func (c *revalidationCandidate) reject(
+	at appliedTx,
+	tx *MempoolTransaction,
+) {
+	if tx != nil {
+		c.invalid[at.hash] = tx
+	}
+	for utxo := range at.created {
+		c.invalidUtxos[utxo] = struct{}{}
+	}
+}
+
+func (c *revalidationCandidate) dependsOnInvalid(at appliedTx) bool {
+	for _, utxo := range at.consumed {
+		if _, invalid := c.invalidUtxos[utxo]; invalid {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *revalidationCandidate) remove(hashes map[string]struct{}) {
@@ -225,6 +251,9 @@ func (c *revalidationCandidate) add(
 	c.txByHash[at.hash] = tx
 	c.sizeBytes += int64(len(tx.Cbor))
 	delete(c.invalid, at.hash)
+	for utxo := range at.created {
+		delete(c.invalidUtxos, utxo)
+	}
 }
 
 // appliedTx records a pending transaction and its UTxO effects for overlay rebuild.
@@ -472,8 +501,21 @@ func (e *MempoolFullError) Error() string {
 }
 
 func NewMempool(config MempoolConfig) (*Mempool, error) {
+	return newMempool(config, ImplementationFIFO)
+}
+
+func newMempool(
+	config MempoolConfig,
+	implementation Implementation,
+) (*Mempool, error) {
 	if config.Validator == nil {
 		return nil, ErrNilValidator
+	}
+	if !implementation.Valid() {
+		return nil, fmt.Errorf(
+			"unknown mempool implementation %q",
+			implementation,
+		)
 	}
 	evictionWatermark := config.EvictionWatermark
 	if evictionWatermark == 0 {
@@ -496,11 +538,14 @@ func NewMempool(config MempoolConfig) (*Mempool, error) {
 		revalidationDeltaCap = DefaultRevalidationDeltaCap
 	}
 	m := &Mempool{
-		eventBus:               config.EventBus,
-		consumers:              make(map[ouroboros.ConnectionId]*MempoolConsumer),
+		eventBus: config.EventBus,
+		consumers: make(
+			map[ouroboros.ConnectionId]*MempoolConsumer,
+		),
 		txByHash:               make(map[string]*MempoolTransaction),
 		overlay:                newUtxoOverlay(),
 		validator:              config.Validator,
+		implementation:         implementation,
 		config:                 config,
 		done:                   make(chan struct{}),
 		transactionTTL:         transactionTTL,
@@ -509,6 +554,10 @@ func NewMempool(config MempoolConfig) (*Mempool, error) {
 		rejectionWatermark:     rejectionWatermark,
 		revalidationDeltaCap:   revalidationDeltaCap,
 		revalidationJournalCap: defaultRevalidationJournalCap,
+	}
+	if implementation == ImplementationDAG {
+		m.dag = newTransactionDAG()
+		m.headroomChanged = make(chan struct{})
 	}
 	if config.Logger == nil {
 		// Create logger to throw away logs
@@ -564,7 +613,7 @@ func NewMempool(config MempoolConfig) (*Mempool, error) {
 			Name: "dingo_metrics_mempool_info",
 			Help: "mempool implementation identity",
 			ConstLabels: prometheus.Labels{
-				"implementation": string(ImplementationFIFO),
+				"implementation": string(implementation),
 			},
 		},
 	)
@@ -643,6 +692,7 @@ func (m *Mempool) Stop(ctx context.Context) error {
 		m.stopped = true
 		m.recordMutationLocked(mempoolMutation{stopped: true})
 		m.doneOnce.Do(func() { close(m.done) })
+		m.notifyHeadroomChangedLocked()
 		m.Unlock()
 		m.mutationMutex.Unlock()
 
@@ -686,6 +736,9 @@ func (m *Mempool) Stop(ctx context.Context) error {
 		m.txByHash = make(map[string]*MempoolTransaction)
 		m.currentSizeBytes = 0
 		m.overlay.reset()
+		if m.dag != nil {
+			m.dag.rebuild(nil)
+		}
 		m.metrics.txsInMempool.Set(0)
 		m.metrics.mempoolBytes.Set(0)
 	})
@@ -709,7 +762,8 @@ func (m *Mempool) FindConsumer(connId ouroboros.ConnectionId) Consumer {
 	return consumer
 }
 
-// ProviderConfig is the canonical configuration for the default mempool.
+// ProviderConfig is the canonical configuration for built-in mempool
+// providers.
 type ProviderConfig struct {
 	Capacity             int64   `yaml:"capacity"`
 	EvictionWatermark    float64 `yaml:"evictionWatermark"`
@@ -727,14 +781,35 @@ type ProviderDependencies struct {
 	CurrentSlotFunc func() uint64
 }
 
-// RegisterProvider registers the current implementation as mempool/default.
+// RegisterProvider registers the FIFO compatibility alias as mempool/default.
 func RegisterProvider(host *plugin.Host) error {
+	return registerProvider(host, "default", ImplementationFIFO)
+}
+
+// RegisterFIFOProvider registers the explicit mempool/fifo provider.
+func RegisterFIFOProvider(host *plugin.Host) error {
+	return registerProvider(host, "fifo", ImplementationFIFO)
+}
+
+// RegisterDAGProvider registers the dependency-indexed mempool/dag provider.
+func RegisterDAGProvider(host *plugin.Host) error {
+	return registerProvider(host, "dag", ImplementationDAG)
+}
+
+func registerProvider(
+	host *plugin.Host,
+	name string,
+	implementation Implementation,
+) error {
 	return plugin.Register(
 		host,
 		plugin.Descriptor{
-			Capability:  plugin.CapabilityMempool,
-			Name:        "default",
-			Description: "Dingo transaction mempool",
+			Capability: plugin.CapabilityMempool,
+			Name:       name,
+			Description: fmt.Sprintf(
+				"Dingo %s transaction mempool",
+				implementation,
+			),
 		},
 		func() ProviderConfig {
 			return ProviderConfig{
@@ -744,7 +819,7 @@ func RegisterProvider(host *plugin.Host) error {
 			}
 		},
 		func(_ context.Context, cfg ProviderConfig, deps ProviderDependencies) (Service, plugin.Instance, error) {
-			m, err := NewMempool(MempoolConfig{
+			mempoolConfig := MempoolConfig{
 				PromRegistry: deps.PromRegistry, Validator: deps.Validator,
 				Logger: deps.Logger, EventBus: deps.EventBus,
 				MempoolCapacity:      cfg.Capacity,
@@ -752,11 +827,29 @@ func RegisterProvider(host *plugin.Host) error {
 				RejectionWatermark:   cfg.RejectionWatermark,
 				RevalidationDeltaCap: cfg.RevalidationDeltaCap,
 				CurrentSlotFunc:      deps.CurrentSlotFunc,
-			})
+			}
+			var (
+				service  Service
+				instance plugin.Instance
+				err      error
+			)
+			switch implementation {
+			case ImplementationFIFO:
+				fifo, fifoErr := NewFIFO(mempoolConfig)
+				service, instance, err = fifo, fifo, fifoErr
+			case ImplementationDAG:
+				dag, dagErr := NewDAG(mempoolConfig)
+				service, instance, err = dag, dag, dagErr
+			default:
+				return nil, nil, fmt.Errorf(
+					"unknown mempool implementation %q",
+					implementation,
+				)
+			}
 			if err != nil {
 				return nil, nil, err
 			}
-			return m, m, nil
+			return service, instance, nil
 		},
 	)
 }
@@ -959,6 +1052,10 @@ func (m *Mempool) rebuildOverlayAttempt() ([]event.Event, error) {
 				m.transactions = candidate.transactions
 				m.txByHash = candidate.txByHash
 				m.currentSizeBytes = candidate.sizeBytes
+				if m.dag != nil {
+					m.dag.rebuild(candidate.overlay.applied)
+				}
+				m.notifyHeadroomChangedLocked()
 				m.metrics.txsInMempool.Set(float64(len(candidate.transactions)))
 				m.metrics.mempoolBytes.Set(float64(candidate.sizeBytes))
 				m.consumersMutex.Unlock()
@@ -1005,7 +1102,9 @@ func (m *Mempool) rebuildOverlayAttempt() ([]event.Event, error) {
 				appliedSeq = mutation.seq
 			}
 		}
-		return errors.New("mempool: revalidation could not catch up with mutations")
+		return errors.New(
+			"mempool: revalidation could not catch up with mutations",
+		)
 	})
 	if err != nil {
 		finishJournal()
@@ -1039,17 +1138,25 @@ func (m *Mempool) revalidateAppliedTx(
 	) error,
 ) {
 	if tx == nil {
+		candidate.reject(at, nil)
 		m.logger.Warn(
 			"overlay applied transaction is missing from transaction index during re-validation",
-			"component", "mempool",
-			"tx_hash", at.hash,
-			"tx_type", at.txType,
+			"component",
+			"mempool",
+			"tx_hash",
+			at.hash,
+			"tx_type",
+			at.txType,
 		)
+		return
+	}
+	if candidate.dependsOnInvalid(at) {
+		candidate.reject(at, tx)
 		return
 	}
 	tmpTx, err := gledger.NewTransactionFromCbor(at.txType, at.cbor)
 	if err != nil {
-		candidate.invalid[at.hash] = tx
+		candidate.reject(at, tx)
 		m.logger.Error(
 			"transaction failed decode during re-validation",
 			"component", "mempool",
@@ -1063,7 +1170,7 @@ func (m *Mempool) revalidateAppliedTx(
 		candidate.overlay.consumed,
 		candidate.overlay.created,
 	); err != nil {
-		candidate.invalid[at.hash] = tx
+		candidate.reject(at, tx)
 		m.logger.Debug(
 			"transaction failed re-validation",
 			"component", "mempool",
@@ -1137,11 +1244,24 @@ func (m *Mempool) removeExpiredTransactions() {
 	}
 	directExpiredCount := len(expiredHashes)
 	if directExpiredCount > 0 {
-		// Remove from overlay with descendant pruning
-		pruned := m.overlay.removeBatchWithDescendants(expiredHashes)
-		// Add pruned descendants to the removal set
-		for _, h := range pruned {
-			expiredHashes[h] = struct{}{}
+		var pruned []string
+		if m.dag != nil {
+			allExpired := m.dag.descendants(expiredHashes)
+			for hash := range allExpired {
+				if _, direct := expiredHashes[hash]; !direct {
+					pruned = append(pruned, hash)
+				}
+			}
+			expiredHashes = allExpired
+			m.overlay.removeByHashes(expiredHashes)
+			m.dag.remove(expiredHashes)
+		} else {
+			// Remove from overlay with descendant pruning.
+			pruned = m.overlay.removeBatchWithDescendants(expiredHashes)
+			// Add pruned descendants to the removal set.
+			for _, h := range pruned {
+				expiredHashes[h] = struct{}{}
+			}
 		}
 		// Remove all from transactions list (backward for safe index handling)
 		for i, v := range slices.Backward(m.transactions) {
@@ -1153,7 +1273,9 @@ func (m *Mempool) removeExpiredTransactions() {
 				}
 			}
 		}
-		m.recordMutationLocked(mempoolMutation{removed: maps.Clone(expiredHashes)})
+		m.recordMutationLocked(
+			mempoolMutation{removed: maps.Clone(expiredHashes)},
+		)
 		if len(pruned) > 0 {
 			m.logger.Debug(
 				"pruned orphaned descendant transactions during expiry",
@@ -1255,7 +1377,7 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		evictionThreshold := int64(
 			float64(m.config.MempoolCapacity) * m.evictionWatermark,
 		)
-		if newSize > evictionThreshold {
+		if m.dag == nil && newSize > evictionThreshold {
 			needsEviction = true
 			targetBytes = max(int64(0), evictionThreshold-txSize)
 			// Compute which TXs would be evicted from the front
@@ -1295,6 +1417,10 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		txCbor := slices.Clone(txBytes)
 		m.overlay.applyTx(txHash, txType, overlayCbor, tmpTx)
 		added := cloneAppliedTx(m.overlay.applied[len(m.overlay.applied)-1])
+		if m.dag != nil {
+			applied := m.overlay.applied[len(m.overlay.applied)-1]
+			m.dag.add(applied)
+		}
 		tx := &MempoolTransaction{
 			Hash:     txHash,
 			Type:     txType,
@@ -1304,6 +1430,7 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		m.transactions = append(m.transactions, tx)
 		m.txByHash[txHash] = tx
 		m.currentSizeBytes += txSize
+		m.notifyHeadroomChangedLocked()
 		m.logger.Debug(
 			"added transaction",
 			"component", "mempool",
@@ -1353,14 +1480,27 @@ func (m *Mempool) GetTransaction(txHash string) (MempoolTransaction, bool) {
 
 func (m *Mempool) Transactions() []MempoolTransaction {
 	m.RLock()
-	ret := make([]MempoolTransaction, len(m.transactions))
-	for i := range m.transactions {
-		ret[i] = *m.transactions[i]
+	var ret []MempoolTransaction
+	if m.dag != nil {
+		order := m.dag.topologicalOrder()
+		ret = make([]MempoolTransaction, 0, len(order))
+		for _, hash := range order {
+			if tx := m.txByHash[hash]; tx != nil {
+				ret = append(ret, *tx)
+			}
+		}
+	} else {
+		ret = make([]MempoolTransaction, len(m.transactions))
+		for i := range m.transactions {
+			ret[i] = *m.transactions[i]
+		}
 	}
 	m.RUnlock()
-	// CBOR is immutable after admission, so copying its slice headers while
-	// locked is sufficient; move the potentially expensive byte copies outside
-	// the pool lock to keep writers moving during large snapshots.
+
+	// Transaction CBOR is immutable after admission. Copy the slice headers
+	// under the state lock, then clone the bytes after releasing it so forging
+	// and relay snapshots do not hold up the final revalidation swap in
+	// proportion to total transaction bytes.
 	for i := range ret {
 		ret[i].Cbor = slices.Clone(ret[i].Cbor)
 	}
@@ -1383,6 +1523,28 @@ func (m *Mempool) CapacityBytes() int64 {
 	return m.config.MempoolCapacity
 }
 
+func (m *Mempool) admissionLimitBytes() int64 {
+	return int64(
+		float64(m.config.MempoolCapacity) * m.rejectionWatermark,
+	)
+}
+
+// admissionHeadroomBytesLocked returns available admission capacity. The
+// caller must hold at least the mempool read lock.
+func (m *Mempool) admissionHeadroomBytesLocked() int64 {
+	return max(int64(0), m.admissionLimitBytes()-m.currentSizeBytes)
+}
+
+// notifyHeadroomChangedLocked wakes admission waiters after a size or lifecycle
+// transition. The caller must hold the mempool write lock.
+func (m *Mempool) notifyHeadroomChangedLocked() {
+	if m.headroomChanged == nil {
+		return
+	}
+	close(m.headroomChanged)
+	m.headroomChanged = make(chan struct{})
+}
+
 func (m *Mempool) getTransaction(txHash string) *MempoolTransaction {
 	return m.txByHash[txHash]
 }
@@ -1392,11 +1554,23 @@ func (m *Mempool) RemoveTransaction(txHash string) {
 	m.mutationMutex.Lock()
 	m.Lock()
 	m.consumersMutex.Lock()
-	// Remove from overlay with descendant pruning
 	toRemove := map[string]struct{}{txHash: {}}
-	pruned := m.overlay.removeBatchWithDescendants(toRemove)
-	for _, h := range pruned {
-		toRemove[h] = struct{}{}
+	var pruned []string
+	if m.dag != nil {
+		toRemove = m.dag.descendants(toRemove)
+		for hash := range toRemove {
+			if hash != txHash {
+				pruned = append(pruned, hash)
+			}
+		}
+		m.overlay.removeByHashes(toRemove)
+		m.dag.remove(toRemove)
+	} else {
+		// Remove from overlay with descendant pruning.
+		pruned = m.overlay.removeBatchWithDescendants(toRemove)
+		for _, h := range pruned {
+			toRemove[h] = struct{}{}
+		}
 	}
 	// Remove all from transactions list (backward for safe index handling)
 	var removed bool
@@ -1454,6 +1628,9 @@ func (m *Mempool) RemoveTxsByHash(hashes []string) {
 	m.consumersMutex.Lock()
 	m.overlay.removeByHashes(hashSet)
 	removedHashes := make(map[string]struct{}, len(hashSet))
+	if m.dag != nil {
+		m.dag.remove(hashSet)
+	}
 	for i, v := range slices.Backward(m.transactions) {
 		if _, ok := hashSet[v.Hash]; ok {
 			removedHashes[v.Hash] = struct{}{}
@@ -1495,6 +1672,7 @@ func (m *Mempool) removeTransactionByIndexLocked(
 	)
 	delete(m.txByHash, tx.Hash)
 	m.currentSizeBytes -= txSize
+	m.notifyHeadroomChangedLocked()
 	m.metrics.txsInMempool.Dec()
 	m.metrics.mempoolBytes.Sub(float64(txSize))
 	// Update consumer indexes to reflect removed TX
@@ -1525,6 +1703,9 @@ func (m *Mempool) removeTransactionByIndexLocked(
 // lock and consumersMutex. Returns events to publish after
 // releasing locks (MEM-03).
 func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
+	if m.dag != nil {
+		return nil
+	}
 	// Calculate how many transactions to evict from the front
 	var evicted int
 	var evictedBytes int64
@@ -1542,7 +1723,7 @@ func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
 	for i := range evicted {
 		evictedHashes[m.transactions[i].Hash] = struct{}{}
 	}
-	// Remove from overlay with descendant pruning
+	// Remove from overlay with descendant pruning.
 	pruned := m.overlay.removeBatchWithDescendants(evictedHashes)
 
 	// Clean up hash map, update metrics, and collect events

--- a/ouroboros/metrics_protocol.go
+++ b/ouroboros/metrics_protocol.go
@@ -22,8 +22,9 @@ import (
 )
 
 type protocolMetrics struct {
-	messagesReceived *prometheus.CounterVec
-	messageDuration  *prometheus.HistogramVec
+	messagesReceived             *prometheus.CounterVec
+	messageDuration              *prometheus.HistogramVec
+	txsubmissionAdmissionRetries prometheus.Histogram
 }
 
 func (o *Ouroboros) initProtocolMetrics() {
@@ -51,6 +52,15 @@ func (o *Ouroboros) initProtocolMetrics() {
 			},
 			[]string{"protocol", "outcome"},
 		),
+		txsubmissionAdmissionRetries: factory.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "dingo_txsubmission_admission_retry_streak",
+				Help: "consecutive mempool admission losses for a peer transaction under contention",
+				Buckets: []float64{
+					1, 2, 3, 5, 10, 20, 50,
+				},
+			},
+		),
 	}
 }
 
@@ -76,4 +86,11 @@ func (o *Ouroboros) recordProtocolMessage(
 	o.protocolMetrics.messageDuration.
 		WithLabelValues(protocol, outcome).
 		Observe(dur.Seconds())
+}
+
+func (o *Ouroboros) recordTxsubmissionAdmissionRetry(streak int) {
+	if o.protocolMetrics == nil {
+		return
+	}
+	o.protocolMetrics.txsubmissionAdmissionRetries.Observe(float64(streak))
 }

--- a/ouroboros/metrics_protocol_test.go
+++ b/ouroboros/metrics_protocol_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,4 +75,29 @@ func TestRecordProtocolMessage_NoopWhenMetricsDisabled(t *testing.T) {
 	// Must not panic when metrics are uninitialized.
 	o.recordProtocolMessage("chainsync", nil, time.Millisecond)
 	o.recordProtocolMessage("chainsync", errors.New("x"), time.Millisecond)
+	o.recordTxsubmissionAdmissionRetry(1)
+}
+
+func TestRecordTxsubmissionAdmissionRetry_RecordsStreak(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	o := NewOuroboros(OuroborosConfig{PromRegistry: reg})
+
+	o.recordTxsubmissionAdmissionRetry(1)
+	o.recordTxsubmissionAdmissionRetry(2)
+	o.recordTxsubmissionAdmissionRetry(3)
+
+	assert.Equal(
+		t,
+		1,
+		testutil.CollectAndCount(
+			o.protocolMetrics.txsubmissionAdmissionRetries,
+		),
+	)
+	metric := &dto.Metric{}
+	assert.NoError(
+		t,
+		o.protocolMetrics.txsubmissionAdmissionRetries.Write(metric),
+	)
+	assert.Equal(t, uint64(3), metric.GetHistogram().GetSampleCount())
+	assert.Equal(t, float64(6), metric.GetHistogram().GetSampleSum())
 }

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -31,9 +31,19 @@ import (
 const (
 	txsubmissionRequestTxIdsCount        = 10              // Number of TxIds to request from peer at one time
 	txsubmissionMaxConsecutiveRateLimits = 3               // Drop TxIds after this many consecutive hits
+	txsubmissionMaxAdmissionRetryStreak  = 3               // Drop one offered TX after this many lost headroom races
 	txsubmissionMaxBackoff               = 5 * time.Second // Cap on exponential backoff wait
 	txsubmissionBaseBackoff              = 150 * time.Millisecond
 	txsubmissionLogEvery                 = 10 // Log every Nth rate limit hit after the 1st
+)
+
+var (
+	errTxsubmissionAdmissionRetriesExhausted = errors.New(
+		"txsubmission admission retries exhausted",
+	)
+	errTxsubmissionAdmissionStopped = errors.New(
+		"txsubmission admission wait stopped",
+	)
 )
 
 // txsubmissionBackoffDuration returns the exponential backoff duration
@@ -50,6 +60,36 @@ func txsubmissionBackoffDuration(consecutiveHits int) time.Duration {
 		}
 	}
 	return d
+}
+
+func retryTxsubmissionAdmission(
+	add func() error,
+	waitForHeadroom func() bool,
+	recordRetry func(int),
+) error {
+	for retryStreak := 0; ; {
+		err := add()
+		if err == nil {
+			return nil
+		}
+		var fullErr *mempool.MempoolFullError
+		if !errors.As(err, &fullErr) {
+			return err
+		}
+		retryStreak++
+		recordRetry(retryStreak)
+		if retryStreak >= txsubmissionMaxAdmissionRetryStreak {
+			return fmt.Errorf(
+				"%w after %d capacity failures: %w",
+				errTxsubmissionAdmissionRetriesExhausted,
+				retryStreak,
+				err,
+			)
+		}
+		if !waitForHeadroom() {
+			return errTxsubmissionAdmissionStopped
+		}
+	}
 }
 
 func (o *Ouroboros) txsubmissionServerConnOpts() []txsubmission.TxSubmissionOptionFunc {
@@ -351,34 +391,56 @@ func (o *Ouroboros) txsubmissionServerInit(
 						"role", "server",
 						"connection_id", ctx.ConnectionId.String(),
 					)
-					admissionRetryStreak := 0
-					for {
-						// Admission headroom can be consumed by another peer
-						// between the wait above and this commit. Retry only a
-						// capacity failure after headroom becomes available;
-						// validation and decoding failures remain terminal for
-						// this protocol loop.
+					// Admission headroom can be consumed by another peer
+					// between the wait above and this commit. Retry only
+					// capacity failures, and bound the retry streak so one
+					// contested offer cannot stall this peer indefinitely.
+					if limitAdmission {
+						err = retryTxsubmissionAdmission(
+							func() error {
+								return o.Mempool.AddTransaction(
+									uint(txBody.EraId),
+									txBody.TxBody,
+								)
+							},
+							func() bool {
+								return headroom.WaitForAdmissionHeadroom(
+									int64(len(txBody.TxBody)),
+									conn.ErrorChan(),
+								)
+							},
+							o.recordTxsubmissionAdmissionRetry,
+						)
+					} else {
 						err = o.Mempool.AddTransaction(
 							uint(txBody.EraId),
 							txBody.TxBody,
 						)
-						if err == nil {
-							break
-						}
-						var fullErr *mempool.MempoolFullError
-						if limitAdmission && errors.As(err, &fullErr) {
-							admissionRetryStreak++
-							o.recordTxsubmissionAdmissionRetry(
-								admissionRetryStreak,
-							)
-							if !headroom.WaitForAdmissionHeadroom(
-								int64(len(txBody.TxBody)),
-								conn.ErrorChan(),
-							) {
-								return
-							}
-							continue
-						}
+					}
+					if errors.Is(
+						err,
+						errTxsubmissionAdmissionStopped,
+					) {
+						return
+					}
+					if errors.Is(
+						err,
+						errTxsubmissionAdmissionRetriesExhausted,
+					) {
+						o.config.Logger.Warn(
+							"dropping peer transaction after repeated mempool admission contention",
+							"component", "network",
+							"protocol", "tx-submission",
+							"role", "server",
+							"connection_id", ctx.ConnectionId.String(),
+							"tx_hash", tx.Hash(),
+							"retry_streak",
+							txsubmissionMaxAdmissionRetryStreak,
+							"error", err,
+						)
+						continue
+					}
+					if err != nil {
 						o.config.Logger.Error(
 							fmt.Sprintf(
 								"failed to add tx %x to mempool: %s",

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -163,6 +163,23 @@ func (o *Ouroboros) txsubmissionServerInit(
 		defer backoffTimer.Stop()
 
 		for {
+			headroom, limitAdmission := o.Mempool.(mempool.AdmissionHeadroom)
+			requestCount := txsubmissionRequestTxIdsCount
+			if limitAdmission {
+				if !headroom.WaitForAdmissionHeadroom(
+					1,
+					conn.ErrorChan(),
+				) {
+					return
+				}
+				// Request one ID at a time because gouroboros acknowledges every
+				// ID in a reply on the next request. Requesting a larger batch
+				// and fetching only the prefix that fits would silently discard
+				// the unrequested remainder.
+				// TODO: Restore batched requests when gouroboros can
+				// acknowledge only the fetched prefix.
+				requestCount = 1
+			}
 			done := make(chan struct{})
 			var txIds []txsubmission.TxIdAndSize
 			var err error
@@ -170,7 +187,7 @@ func (o *Ouroboros) txsubmissionServerInit(
 				defer close(done)
 				txIds, err = ctx.Server.RequestTxIds(
 					true,
-					txsubmissionRequestTxIdsCount,
+					requestCount,
 				)
 			}()
 			select {
@@ -261,10 +278,37 @@ func (o *Ouroboros) txsubmissionServerInit(
 				} else {
 					consecutiveRateLimits = 0
 				}
-				// Unwrap inner TxId from TxIdAndSize
-				var requestTxIds []txsubmission.TxId
-				for _, txId := range txIds {
-					requestTxIds = append(requestTxIds, txId.TxId)
+				requestTxIds := make([]txsubmission.TxId, 0, len(txIds))
+				if limitAdmission {
+					if int64(txIds[0].Size) >
+						headroom.MaxAdmissionHeadroomBytes() {
+						o.config.Logger.Warn(
+							"peer offered transaction larger than mempool admission capacity",
+							"component", "network",
+							"protocol", "tx-submission",
+							"role", "server",
+							"connection_id", ctx.ConnectionId.String(),
+							"tx_size", txIds[0].Size,
+							"max_admission_bytes",
+							headroom.MaxAdmissionHeadroomBytes(),
+						)
+						continue
+					}
+					if !headroom.WaitForAdmissionHeadroom(
+						int64(txIds[0].Size),
+						conn.ErrorChan(),
+					) {
+						return
+					}
+					requestTxIds = append(requestTxIds, txIds[0].TxId)
+				} else {
+					// Unwrap inner TxId from TxIdAndSize.
+					for _, txId := range txIds {
+						requestTxIds = append(requestTxIds, txId.TxId)
+					}
+				}
+				if len(requestTxIds) == 0 {
+					continue
 				}
 				// Request TX content for TxIds from above
 				txs, err := ctx.Server.RequestTxs(requestTxIds)
@@ -307,12 +351,34 @@ func (o *Ouroboros) txsubmissionServerInit(
 						"role", "server",
 						"connection_id", ctx.ConnectionId.String(),
 					)
-					// Add transaction to mempool
-					err = o.Mempool.AddTransaction(
-						uint(txBody.EraId),
-						txBody.TxBody,
-					)
-					if err != nil {
+					admissionRetryStreak := 0
+					for {
+						// Admission headroom can be consumed by another peer
+						// between the wait above and this commit. Retry only a
+						// capacity failure after headroom becomes available;
+						// validation and decoding failures remain terminal for
+						// this protocol loop.
+						err = o.Mempool.AddTransaction(
+							uint(txBody.EraId),
+							txBody.TxBody,
+						)
+						if err == nil {
+							break
+						}
+						var fullErr *mempool.MempoolFullError
+						if limitAdmission && errors.As(err, &fullErr) {
+							admissionRetryStreak++
+							o.recordTxsubmissionAdmissionRetry(
+								admissionRetryStreak,
+							)
+							if !headroom.WaitForAdmissionHeadroom(
+								int64(len(txBody.TxBody)),
+								conn.ErrorChan(),
+							) {
+								return
+							}
+							continue
+						}
 						o.config.Logger.Error(
 							fmt.Sprintf(
 								"failed to add tx %x to mempool: %s",

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -86,6 +86,61 @@ func (txsubmissionRejectingValidator) ValidateTxWithOverlay(
 	return errors.New("txsubmissionRejectingValidator: rejected")
 }
 
+func TestRetryTxsubmissionAdmissionBoundsContention(t *testing.T) {
+	var addCalls int
+	var waitCalls int
+	var retryStreaks []int
+	fullErr := &mempool.MempoolFullError{
+		CurrentSize: 10,
+		TxSize:      1,
+		Capacity:    10,
+	}
+
+	err := retryTxsubmissionAdmission(
+		func() error {
+			addCalls++
+			return fullErr
+		},
+		func() bool {
+			waitCalls++
+			return true
+		},
+		func(streak int) {
+			retryStreaks = append(retryStreaks, streak)
+		},
+	)
+
+	require.ErrorIs(t, err, errTxsubmissionAdmissionRetriesExhausted)
+	require.ErrorAs(t, err, &fullErr)
+	require.Equal(t, txsubmissionMaxAdmissionRetryStreak, addCalls)
+	require.Equal(t, txsubmissionMaxAdmissionRetryStreak-1, waitCalls)
+	require.Equal(t, []int{1, 2, 3}, retryStreaks)
+}
+
+func TestRetryTxsubmissionAdmissionSucceedsAfterContention(t *testing.T) {
+	var addCalls int
+	var waitCalls int
+
+	err := retryTxsubmissionAdmission(
+		func() error {
+			addCalls++
+			if addCalls < txsubmissionMaxAdmissionRetryStreak {
+				return &mempool.MempoolFullError{}
+			}
+			return nil
+		},
+		func() bool {
+			waitCalls++
+			return true
+		},
+		func(int) {},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, txsubmissionMaxAdmissionRetryStreak, addCalls)
+	require.Equal(t, txsubmissionMaxAdmissionRetryStreak-1, waitCalls)
+}
+
 // TestTxSubmissionClientRequestTxIds verifies empty, partial, and capped
 // TxId responses when a peer asks what transactions this node can relay.
 func TestTxSubmissionClientRequestTxIds(t *testing.T) {

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -134,13 +134,21 @@ func TestTxSubmissionClientRequestTxIds(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, ids, tt.wantCount)
 			for idx, id := range ids {
-				require.Equal(t, uint16(txsubmissionRelayTestEraId), id.TxId.EraId)
+				require.Equal(
+					t,
+					uint16(txsubmissionRelayTestEraId),
+					id.TxId.EraId,
+				)
 				require.Equal(
 					t,
 					uint32(len(fixtures[idx].body)),
 					id.Size,
 				)
-				require.Equal(t, fixtures[idx].hash, hex.EncodeToString(id.TxId.TxId[:]))
+				require.Equal(
+					t,
+					fixtures[idx].hash,
+					hex.EncodeToString(id.TxId.TxId[:]),
+				)
 			}
 		})
 	}
@@ -286,7 +294,9 @@ func TestTxSubmissionServerInitMissingConnectionReturnsCleanly(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestTxSubmissionClientStartMissingConnectionDoesNotAddConsumer(t *testing.T) {
+func TestTxSubmissionClientStartMissingConnectionDoesNotAddConsumer(
+	t *testing.T,
+) {
 	o, connId := newTxSubmissionTestOuroboros(t)
 
 	err := o.txsubmissionClientStart(connId)
@@ -359,9 +369,11 @@ func newTxSubmissionTestOuroboros(
 	})
 
 	o := NewOuroboros(OuroborosConfig{Logger: logger})
-	o.ConnManager = connmanager.NewConnectionManager(connmanager.ConnectionManagerConfig{
-		Logger: logger,
-	})
+	o.ConnManager = connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{
+			Logger: logger,
+		},
+	)
 	o.Mempool = &mempool.FIFO{Mempool: m}
 	return o, txsubmissionTestConnId(t)
 }
@@ -465,7 +477,10 @@ type txSubmissionRelayHarness struct {
 // deterministic teardown point rather than one deferred until after the
 // test function returns.
 func newTxSubmissionRelayHarness(t *testing.T) *txSubmissionRelayHarness {
-	return newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{})
+	return newTxSubmissionRelayHarnessWithOpts(
+		t,
+		txSubmissionRelayHarnessOpts{},
+	)
 }
 
 // txSubmissionRelayHarnessOpts overrides the harness's defaults. Every
@@ -476,6 +491,8 @@ type txSubmissionRelayHarnessOpts struct {
 	logger     *slog.Logger
 	validatorA mempool.TxValidator
 	validatorB mempool.TxValidator
+	capacityA  int64
+	dagA       bool
 }
 
 func newTxSubmissionRelayHarnessWithOpts(
@@ -496,13 +513,30 @@ func newTxSubmissionRelayHarnessWithOpts(
 		validatorB = txsubmissionTestValidator{}
 	}
 
-	mA, err := mempool.NewMempool(mempool.MempoolConfig{
+	capacityA := opts.capacityA
+	if capacityA == 0 {
+		capacityA = 1024 * 1024
+	}
+	configA := mempool.MempoolConfig{
 		Logger:          logger,
 		PromRegistry:    prometheus.NewRegistry(),
 		Validator:       validatorA,
-		MempoolCapacity: 1024 * 1024,
-	})
-	require.NoError(t, err)
+		MempoolCapacity: capacityA,
+	}
+	var (
+		mA           *mempool.Mempool
+		nodeAMempool mempool.Service
+		err          error
+	)
+	if opts.dagA {
+		dag, dagErr := mempool.NewDAG(configA)
+		require.NoError(t, dagErr)
+		mA, nodeAMempool = dag.Mempool, dag
+	} else {
+		mA, err = mempool.NewMempool(configA)
+		require.NoError(t, err)
+		nodeAMempool = &mempool.FIFO{Mempool: mA}
+	}
 	mB, err := mempool.NewMempool(mempool.MempoolConfig{
 		Logger:          logger,
 		PromRegistry:    prometheus.NewRegistry(),
@@ -519,7 +553,7 @@ func newTxSubmissionRelayHarnessWithOpts(
 	)
 
 	nodeA := NewOuroboros(OuroborosConfig{ConnManager: cmA, Logger: logger})
-	nodeA.Mempool = &mempool.FIFO{Mempool: mA}
+	nodeA.Mempool = nodeAMempool
 	nodeB := NewOuroboros(OuroborosConfig{ConnManager: cmB, Logger: logger})
 	nodeB.Mempool = &mempool.FIFO{Mempool: mB}
 
@@ -652,6 +686,43 @@ func TestTxSubmissionServerInitRelaysMempoolTransactionEndToEnd(t *testing.T) {
 	require.Equal(t, txBytes, relayed.Cbor)
 }
 
+func TestTxSubmissionDAGBackpressureResumesAfterRemoval(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)
+	seed := fixtures[2]
+	offered := fixtures[0]
+	capacity := int64(len(seed.body))
+	for int64(len(seed.body)) >
+		int64(float64(capacity)*mempool.DefaultRejectionWatermark) {
+		capacity++
+	}
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		capacityA: capacity,
+		dagA:      true,
+	})
+	defer h.close(t)
+
+	require.NoError(
+		t,
+		h.mA.AddTransaction(txsubmissionRelayTestEraId, seed.body),
+	)
+	require.NoError(
+		t,
+		h.mB.AddTransaction(txsubmissionRelayTestEraId, offered.body),
+	)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+
+	require.Never(t, func() bool {
+		_, ok := h.mA.GetTransaction(offered.hash)
+		return ok
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	h.mA.RemoveTxsByHash([]string{seed.hash})
+	require.Eventually(t, func() bool {
+		_, ok := h.mA.GetTransaction(offered.hash)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
 // TestTxSubmissionServerInitExitsCleanlyOnPeerDisconnect verifies the
 // server-init relay goroutine does not leak when the peer connection closes
 // while it is parked in a blocking RequestTxIds call. The mempool is seeded
@@ -709,15 +780,21 @@ func TestTxSubmissionServerInitExitsCleanlyOnPeerDisconnect(t *testing.T) {
 // from the mempool beforehand must fall straight through to "not found"
 // rather than erroring or panicking.
 func TestTxSubmissionClientRequestTxsExpiredTransactionNotServed(t *testing.T) {
-	o, connId := newTxSubmissionTestOuroboros(t, func(cfg *mempool.MempoolConfig) {
-		cfg.TransactionTTL = 10 * time.Millisecond
-		cfg.CleanupInterval = 10 * time.Millisecond
-	})
+	o, connId := newTxSubmissionTestOuroboros(
+		t,
+		func(cfg *mempool.MempoolConfig) {
+			cfg.TransactionTTL = 10 * time.Millisecond
+			cfg.CleanupInterval = 10 * time.Millisecond
+		},
+	)
 	o.Mempool.NewConsumer(connId)
 
 	txBytes, err := hex.DecodeString(txsubmissionRelayTestTxHex)
 	require.NoError(t, err)
-	require.NoError(t, o.Mempool.AddTransaction(txsubmissionRelayTestEraId, txBytes))
+	require.NoError(
+		t,
+		o.Mempool.AddTransaction(txsubmissionRelayTestEraId, txBytes),
+	)
 	wantTx, err := gledger.NewTransactionFromCbor(
 		txsubmissionRelayTestEraId,
 		txBytes,
@@ -753,10 +830,15 @@ func TestTxSubmissionClientRequestTxsExpiredTransactionNotServed(t *testing.T) {
 // instead of panicking or wedging the connection. Node A's mempool rejects
 // every transaction so a real, well-formed relay reaches
 // Mempool.AddTransaction's error path inside txsubmissionServerInit.
-func TestTxSubmissionServerInitMempoolRejectionLogsAndStopsCleanly(t *testing.T) {
+func TestTxSubmissionServerInitMempoolRejectionLogsAndStopsCleanly(
+	t *testing.T,
+) {
 	logBuf := &lockedBuffer{}
 	logger := slog.New(
-		slog.NewJSONHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		slog.NewJSONHandler(
+			logBuf,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
 	)
 
 	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DAG-based mempool backend with deterministic parent-before-descendant ordering, shared double-buffered revalidation, and TxSubmission backpressure. FIFO stays the default; nodes can choose `fifo` or `dag` via plugins with no public API changes.

- New Features
  - Providers: `plugins.mempool.provider: fifo|dag` (default `fifo`; `default` aliases `fifo`). Host registers `default`, `fifo`, `dag`. Example config and devnet support `DEVNET_MEMPOOL_PROVIDER`. Built-ins default capacity for `default|fifo|dag`. Metric: `dingo_metrics_mempool_info{implementation="fifo|dag"}`.
  - DAG backend: explicit producer/spender indexes and parent/child edges; caches topological order and falls back to admission order if inconsistent; descendant-aware expiry/removal; confirmed removals detach only; no watermark eviction (capacity managed by intake headroom).
  - Service contract: node now uses `mempool.Service`; FIFO and DAG share the same engine and metrics. Revalidation is shared for both providers: double-buffered rebuild with bounded mutation journal, ledger-generation pin/check, and capped catch-up. Missing overlay parents poison dependents to avoid retaining orphan descendants.
  - Admission/backpressure (DAG only): exposes `AdmissionHeadroom` to gate intake; TxSubmission waits for headroom before requesting IDs/bodies, requests 1 ID per round trip, rejects oversize offers, and retries capacity failures with a bounded streak. Records `dingo_txsubmission_admission_retry_streak`.

- Migration
  - No change if you stay on FIFO. To enable DAG, set `plugins.mempool.provider: dag` (or `DINGO_PLUGINS_MEMPOOL_PROVIDER=dag`) and restart.
  - DAG ignores `evictionWatermark`; tune with `capacity` and `rejectionWatermark`. Events and APIs are unchanged.

<sup>Written for commit 5a0356cd8fee43514dce7886612fa156e607fb72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional DAG-based transaction mempool alongside FIFO.
  * Added provider selection through configuration, with FIFO as the default and `default` retained as an alias.
  * Added dependency-aware transaction ordering and improved admission backpressure for DAG mempools.
  * Mempool metrics now identify the active backend.

* **Documentation**
  * Updated architecture, configuration examples, and development guidance for FIFO and DAG providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->