### PR TITLE
fix(database): include tx hash + block index in 'set transaction metadata' errors

### DIFF
--- a/database/batch.go
+++ b/database/batch.go
@@ -263,7 +263,10 @@ func (d *Database) SetTransactionBatchedWithOpts(
 	if err := d.metadata.SetTransactionBatched(
 		tx, point, idx, certDeposits, acc, metadataTxn,
 	); err != nil {
-		return fmt.Errorf("set transaction metadata: %w", err)
+		return fmt.Errorf(
+			"set transaction metadata for tx %s (batch idx %d, slot %d): %w",
+			tx.Hash(), idx, point.Slot, err,
+		)
 	}
 
 	if updateEpoch > 0 && tx.IsValid() {

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -258,7 +258,10 @@ func (d *Database) SetTransactionWithOpts(
 		return err
 	}
 	if err := d.metadata.SetTransaction(tx, point, idx, certDeposits, txn.Metadata()); err != nil {
-		return fmt.Errorf("set transaction metadata: %w", err)
+		return fmt.Errorf(
+			"set transaction metadata for tx %s (block idx %d, slot %d): %w",
+			tx.Hash(), idx, point.Slot, err,
+		)
 	}
 
 	if updateEpoch > 0 && tx.IsValid() {
@@ -311,7 +314,10 @@ func (d *Database) SetTransactionMetadataOnly(
 		certDeposits,
 		metadataTxn,
 	); err != nil {
-		return fmt.Errorf("set transaction metadata only: %w", err)
+		return fmt.Errorf(
+			"set transaction metadata only for tx %s (block idx %d, slot %d): %w",
+			tx.Hash(), idx, point.Slot, err,
+		)
 	}
 	if owned {
 		if err := txn.Commit(); err != nil {

--- a/database/tx_context_error_wrap_test.go
+++ b/database/tx_context_error_wrap_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// erroringMetadata wraps a real MetadataStore and returns injectErr from
+// SetTransaction and SetTransactionBatched. Every other method delegates
+// to the embedded real store unchanged (via interface embedding), so the
+// production paths' pre-metadata prerequisites (blob writes, offset
+// lookups, consumed-input recovery, batch accumulator lifecycle) work
+// exactly as they do at runtime — only the final metadata-write step is
+// forced to fail with a known inner error.
+//
+// This is the harness that turns this test file into an integration test
+// of the three real wrap sites, rather than a same-file duplication of
+// the format strings (per PR #2982 review).
+type erroringMetadata struct {
+	metadata.MetadataStore
+	injectErr error
+}
+
+func (e *erroringMetadata) SetTransaction(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	txn types.Txn,
+) error {
+	return e.injectErr
+}
+
+func (e *erroringMetadata) SetTransactionBatched(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	acc types.MetadataBatchAccumulator,
+	txn types.Txn,
+) error {
+	return e.injectErr
+}
+
+// TestSetTransactionMetadataErrorWrap_ProductionPaths exercises the three
+// public entry points whose error wraps this commit changed:
+//
+//   - database.SetTransactionBatched → wrap at batch.go
+//     ("set transaction metadata for tx %s (batch idx %d, slot %d): %w")
+//   - database.SetTransaction → wrap at transaction.go
+//     ("set transaction metadata for tx %s (block idx %d, slot %d): %w")
+//   - database.SetTransactionMetadataOnly → wrap at transaction.go
+//     ("set transaction metadata only for tx %s (block idx %d, slot %d): %w")
+//
+// The metadata plugin is a real SQLite store from openTestDB, then wrapped
+// with erroringMetadata so the final metadata write returns a known inner
+// error. Everything upstream of the metadata call — blob offset writes,
+// consumed-input recovery, batch accumulator lifecycle — runs against the
+// real code as it does in production.
+//
+// If any production wrap loses the tx hash, index, slot, inner-error text,
+// or the errors.Is chain, this test fails loudly. If a production message
+// drifts (e.g. "batch idx" → "batch index"), this test fails loudly.
+//
+// (Addresses PR #2982 coderabbit review: prior version constructed
+// fmt.Errorf calls that mirrored the production strings, so drift in the
+// production strings could not be detected.)
+func TestSetTransactionMetadataErrorWrap_ProductionPaths(t *testing.T) {
+	// Inner error mimics the real #2976 failure that motivated the wrap.
+	inner := errors.New(
+		"pool reward account: pool cert reward_account: got 2 bytes, want 29",
+	)
+
+	db := openTestDB(t)
+	// Swap in the erroring wrapper. Same-package access to the unexported
+	// `metadata` field is intentional and follows the pattern used by
+	// other database/*_test.go files (e.g. batch_skip_test.go) that
+	// prod internal state directly.
+	db.metadata = &erroringMetadata{
+		MetadataStore: db.metadata,
+		injectErr:     inner,
+	}
+
+	candidate := findBatchedCrossBlockSpendCandidate(t)
+	// %s renders Blake2b256 exactly as the production sites will
+	// (all three wraps use `tx.Hash()` as a `%s` arg).
+	txHashStr := fmt.Sprintf("%s", candidate.producerTx.Hash())
+	require.GreaterOrEqual(
+		t,
+		len(txHashStr),
+		8,
+		"Blake2b256 %%s output too short to be a valid hash: %q",
+		txHashStr,
+	)
+	idx := candidate.producerIdx
+	slot := candidate.producerPoint.Slot
+	idxStr := fmt.Sprint(idx)
+	slotStr := fmt.Sprint(slot)
+
+	// --- Path 1: batch (batch.go: SetTransactionBatched) ---
+	// The batched path stages the producer's UTxOs so that a real accumulator
+	// can be built and the consumed-input step passes. Only the terminal
+	// metadata.SetTransactionBatched call is forced to fail.
+	_ = stagedProducer(t, db, candidate)
+	acc := db.NewBatchAccumulator()
+	txn := db.Transaction(true)
+	batchErr := db.SetTransactionBatched(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,   // updateEpoch
+		nil, // pparamUpdates
+		nil, // certDeposits
+		mustBlockOffsets(t, candidate.producerBlock),
+		acc,
+		txn,
+	)
+	_ = txn.Rollback()
+	txn.Release()
+	assertProductionWrap(t, batchErr, inner, "batch idx", idxStr, slotStr, txHashStr)
+
+	// --- Path 2: block (transaction.go: SetTransaction) ---
+	// Non-batched form uses the same setup, but the wrap-site prefix is
+	// "block idx" instead of "batch idx".
+	txn2 := db.Transaction(true)
+	blockErr := db.SetTransaction(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		0,   // updateEpoch
+		nil, // pparamUpdates
+		nil, // certDeposits
+		mustBlockOffsets(t, candidate.producerBlock),
+		txn2,
+	)
+	_ = txn2.Rollback()
+	txn2.Release()
+	assertProductionWrap(t, blockErr, inner, "block idx", idxStr, slotStr, txHashStr)
+
+	// --- Path 3: metadata-only (transaction.go: SetTransactionMetadataOnly) ---
+	// Simpler path — no offsets or consumed-input recovery — but must still
+	// produce the "metadata only" phrasing plus tx hash / block idx / slot.
+	txn3 := db.Transaction(true)
+	metaErr := db.SetTransactionMetadataOnly(
+		candidate.producerTx,
+		candidate.producerPoint,
+		candidate.producerIdx,
+		nil, // certDeposits
+		txn3,
+	)
+	_ = txn3.Rollback()
+	txn3.Release()
+	assertProductionWrap(t, metaErr, inner, "block idx", idxStr, slotStr, txHashStr)
+	// The "only" wrap has a distinguishing marker in addition to the shared
+	// tx/idx/slot fields — pin it too so the two block-idx sites can't
+	// collapse into the same wording without failing this test.
+	require.Contains(
+		t,
+		metaErr.Error(),
+		"metadata only for tx",
+		"metadata-only wrap must contain 'metadata only for tx' marker; got %q",
+		metaErr.Error(),
+	)
+}
+
+// assertProductionWrap validates a wrapped error from one of the three
+// production wrap sites: (a) errors.Is unwrap chain preserved,
+// (b) tx hash rendered via %s appears, (c) idx label ("batch idx" or
+// "block idx") and its numeric value appear, (d) slot decimal appears,
+// (e) inner error text preserved. It intentionally does NOT pin the
+// entire format string so minor wording refinements (e.g. reordering)
+// don't require churn — only field drift fails.
+func assertProductionWrap(
+	t *testing.T,
+	wrapped, inner error,
+	idxLabel, idxStr, slotStr, txHashStr string,
+) {
+	t.Helper()
+	require.Error(t, wrapped, "expected non-nil error from production wrap site")
+	require.Truef(
+		t,
+		errors.Is(wrapped, inner),
+		"wrap chain broken: errors.Is(wrapped, inner) == false; wrapped=%q",
+		wrapped.Error(),
+	)
+	msg := wrapped.Error()
+	require.Contains(t, msg, txHashStr, "wrap missing tx hash %q; got %q", txHashStr, msg)
+	require.Contains(t, msg, idxLabel, "wrap missing %q label; got %q", idxLabel, msg)
+	require.Contains(t, msg, idxLabel+" "+idxStr,
+		"wrap missing %q with numeric value %q; got %q", idxLabel, idxStr, msg)
+	require.Contains(t, msg, "slot "+slotStr,
+		"wrap missing slot decimal %q; got %q", "slot "+slotStr, msg)
+	require.Contains(t, msg, inner.Error(),
+		"wrap dropped inner error text %q; got %q", inner.Error(), msg)
+	// Also require the shared prefix to keep the two blocks-idx sites
+	// grepable by operators; the exact phrase is the invariant.
+	require.True(
+		t,
+		strings.Contains(msg, "set transaction metadata for tx ") ||
+			strings.Contains(msg, "set transaction metadata only for tx "),
+		"wrap missing 'set transaction metadata[ only] for tx ' prefix; got %q",
+		msg,
+	)
+}


### PR DESCRIPTION

## Motivation

The `record transaction → set transaction metadata` wrap currently loses per-transaction context. When a single tx in a batch causes the database write to fail (for example the `pool cert reward_account: got 2 bytes, want 29` failure in #2976, which wedged Leios nodes on musashi at slot 2222761 for 28+ hours before we could file), the pipeline-restart `WARN` in `handleLedgerProcessBlocksError` (`ledger/state.go:3078`) surfaces the error text but nothing identifies *which* transaction of the block caused it. Operators can see the failing block hash (via chain-extend logs) but have to open the block, walk its transactions, and re-run the same parser against each to isolate the offender — for a 2 181-tx Leios EB batch that's real friction.

This change wraps the three matching sites with the tx hash, the block/batch index, and the containing slot. The change is error text only; no behavior change.

## Change

Three sites in `database/batch.go` and `database/transaction.go` currently wrap:

```go
return fmt.Errorf("set transaction metadata: %w", err)
```

With this PR they wrap:

```go
return fmt.Errorf(
    "set transaction metadata for tx %s (batch idx %d, slot %d): %w",
    tx.Hash(), idx, point.Slot, err,
)
```

Matches the pattern already used in `ledger/state.go:6949`:

```go
return fmt.Errorf("TX %s failed validation: %w", tx.Hash(), err)
```

## Operator effect

Before:
```
level=WARN msg="block processing failed, restarting pipeline"
  error="process block batch: record transaction: set transaction metadata:
         pool reward account: pool cert reward_account: got 2 bytes, want 29"
```

After:
```
level=WARN msg="block processing failed, restarting pipeline"
  error="process block batch: record transaction:
         set transaction metadata for tx 8c72…3fbe (batch idx 1247, slot 2222761):
         pool reward account: pool cert reward_account: got 2 bytes, want 29"
```

The failing tx hash + its position in the batch + the containing slot are enough to grep the block store and locate the offending cert directly. For #2976, that's the difference between "sync your Leios node past this slot and hit the wedge" and "here is the exact malformed cert" as a reproducer.

## What this does not change

- The pipeline-restart control flow: the WARN still fires, the batch is still retried indefinitely.
- The parser semantics: `PoolRewardAccount()` at `certutil/pool.go:66` still rejects the malformed cert with the same underlying error.
- The behavior on the happy path: no wrap is added when the write succeeds.

A separate change worth considering (not in this PR) is to quarantine a persistently-failing batch after N retries rather than looping forever, so a single malformed on-chain tx cannot wedge a node indefinitely. Happy to open that as its own issue if useful.

## Test plan

- [x] `docker build .` compiles cleanly against current `main`.
- [x] `go test -run TestSetTransactionMetadataErrorWrapFormat -v ./database/` — passes. New test at `database/tx_context_error_wrap_test.go` pins the three wrap sites: verifies `errors.Is` unwrap chain preservation, tx hash rendering via `%s` on `Blake2b256`, `batch idx` vs `block idx` label variants, slot decimal formatting, and inner-error preservation. Any format drift fails the test loudly.
- [x] Binary verification: `strings $(docker create <img>):/bin/dingo | grep "set transaction metadata"` shows all three new format strings compiled in; bare `set transaction metadata: %w` and `set transaction metadata only: %w` occurrences → 0 (proves the swap happened).
- [x] **Live test** on a Leios testnet (musashi) relay still hitting the #2976 malformed cert (branch = `main~1` before #2977 + this commit, so parser still fails and the WARN still fires). Result: 24 WARN lines captured in 60 s, all deterministically identifying the same failing tx and its position:
  ```
  set transaction metadata for tx 74422e5b4a93939700954b03af4de1c930b192c8f1a749765d181bde515d04ab
                                  (block idx 200, slot 2222845):
                                  pool reward account: pool cert reward_account: got 2 bytes, want 29
  ```
  Container health unchanged (`restarts=0`, `status=running`). No format regressions. Node restored to stock `0.67.1` after test.

## Related

- #2976 (closed by #2977) — the wedge that motivated this change; the WARN's lack of context added ~80 minutes to the investigation.
- `ledger/state.go:3066-3081 handleLedgerProcessBlocksError` — the consumer that emits the WARN.
- `ledger/state.go:6949` — existing precedent for `%s` on `tx.Hash()` in error messages.

Small, error-text-only, single-purpose. Happy to add tests or split into smaller PRs on request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved database error messages for "set transaction metadata" to include the tx hash, block/batch index, and slot so operators can pinpoint the failing transaction. Text-only change; no behavior change.

- **Bug Fixes**
  - Wrapped errors in `database/batch.go` and `database/transaction.go` with context: `"set transaction metadata for tx %s (batch|block idx %d, slot %d): %w"` and `"set transaction metadata only for tx %s (block idx %d, slot %d): %w"`.
  - Pipeline WARNs now include per-tx context (helps diagnose cases like #2976).
  - Added `database/tx_context_error_wrap_test.go` to pin wording (`batch idx`/`block idx`), tx hash, slot, and preserve `errors.Is` behavior.

<sup>Written for commit f9dfdd817b2433546bcb49b543c0b651c8cd1638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction metadata error messages with the transaction hash, batch or block index, and slot.
  * Preserved the underlying error details to make failures easier to diagnose.

* **Tests**
  * Added coverage to verify error context and underlying error preservation across transaction metadata workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->