### PR TITLE
ci: gate archive-demo behind a build flag

### DIFF
--- a/internal/test/archive-demo/README.md
+++ b/internal/test/archive-demo/README.md
@@ -31,6 +31,10 @@ once the chain has crossed the security window it runs a scripted
 BlockFetch from outside the stack against a pre-window block on the
 history-expiry node and prints the byte count and timing.
 
+All Go packages in this directory use the `archive_demo` build tag, so
+normal `go test ./...` runs exclude the demo. Use `run-tests.sh` to build
+the helpers and execute the integration test with the tag enabled.
+
 ## What it shows
 
 The demo and the integration test exercise the same three claims about a

--- a/internal/test/archive-demo/cmd/demo-fetch/main.go
+++ b/internal/test/archive-demo/cmd/demo-fetch/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build archive_demo
+
 // demo-fetch is a small CLI used by the archive-demo's demo.sh to make
 // the BlockFetch step of the demo visible: it connects to a Dingo NtN
 // endpoint, ChainSync-walks from origin to find a block at or past a

--- a/internal/test/archive-demo/cmd/inspect-blob/main.go
+++ b/internal/test/archive-demo/cmd/inspect-blob/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build archive_demo
+
 // inspect-blob is a CLI used by the archive-demo integration test to
 // verify whether a block (slot, hash) is present in a Dingo node's
 // local Badger blob store. It exits 0 if present, 1 if absent, 2 on

--- a/internal/test/archive-demo/demo.sh
+++ b/internal/test/archive-demo/demo.sh
@@ -103,7 +103,7 @@ command -v go     >/dev/null || die "go is not installed"
 say "Building demo-fetch helper..."
 DEMO_BIN_DIR="$(mktemp -d)"
 DEMO_FETCH="${DEMO_BIN_DIR}/demo-fetch"
-( cd "${PROJECT_ROOT}" && go build -o "${DEMO_FETCH}" ./internal/test/archive-demo/cmd/demo-fetch )
+( cd "${PROJECT_ROOT}" && go build -tags archive_demo -o "${DEMO_FETCH}" ./internal/test/archive-demo/cmd/demo-fetch )
 note "built: ${DEMO_FETCH}"
 
 # ---------------------------------------------------------------------------

--- a/internal/test/archive-demo/internal/archivedemo/harness.go
+++ b/internal/test/archive-demo/internal/archivedemo/harness.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build archive_demo
+
 // Package archivedemo provides shared helpers for the archive-node demo
 // at internal/test/archive-demo/. The integration test (under build tag
 // archive_demo) and the demo-fetch CLI both consume it.

--- a/internal/test/archive-demo/run-tests.sh
+++ b/internal/test/archive-demo/run-tests.sh
@@ -67,7 +67,7 @@ command -v go     >/dev/null || die "go is not installed"
 log "Building inspect-blob helper..."
 INSPECT_DIR="$(mktemp -d)"
 INSPECT_BIN="${INSPECT_DIR}/inspect-blob"
-( cd "${PROJECT_ROOT}" && go build -o "${INSPECT_BIN}" ./internal/test/archive-demo/cmd/inspect-blob )
+( cd "${PROJECT_ROOT}" && go build -tags archive_demo -o "${INSPECT_BIN}" ./internal/test/archive-demo/cmd/inspect-blob )
 
 log "Bringing up archive-demo stack..."
 mkdir -p "${PRUNING_DATA_DIR}"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gate the archive demo helpers and tests behind the `archive_demo` build tag so they are excluded from normal builds and `go test` runs. Updated scripts build helpers with `-tags archive_demo`, and the README explains how to run them.

- **Refactors**
  - Added `//go:build archive_demo` to `cmd/demo-fetch`, `cmd/inspect-blob`, and `internal/archivedemo`.
  - Updated `demo.sh` and `run-tests.sh` to pass `-tags archive_demo` when building.
  - Updated README with tag usage and to use `run-tests.sh` for the integration test.

<sup>Written for commit 710d35e550cbd558ba084419ce3ad83204de58c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to run the archive demonstration and integration tests.
  * Documented that the demo is excluded from standard Go test runs unless explicitly enabled.

* **Tests**
  * Updated demo helper builds and integration tests to consistently use the required archive demo build configuration.
  * Prevented demo-only tools from being included in regular builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->