### PR TITLE
fix(mempool): double-buffer FIFO revalidation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1954,12 +1954,37 @@ clearing transaction and consumer state; later transaction admission returns
 prevents in-flight protocol callbacks from repopulating a pool whose background
 expiry and chain-update workers have already been stopped.
 
-Mempool mutations are serialized by a dedicated mutation gate so admission and
-chain-update revalidation use a stable UTxO-overlay view. CBOR decoding and
-ledger validation run without the primary pool RW lock or consumer lock;
-transaction snapshots, lookups, and relay reads therefore remain available
-during slow script validation. Revalidation commits its rebuilt overlay and any
-invalid removals atomically before releasing the mutation gate.
+Ordinary FIFO mutations are serialized by a dedicated mutation gate, but
+chain-update revalidation does not hold that gate while it validates the whole
+pool. A rebuild briefly snapshots the live FIFO and starts a mutation journal,
+then constructs a private candidate state while admissions, confirmed/manual
+removals, descendant pruning, expiry, and watermark eviction continue against
+the live state. The bounded journal aborts a candidate instead of growing
+without limit. Otherwise, the candidate catches up by mutation sequence,
+leaving at most the configured `revalidationDeltaCap` residual per pass, and
+commits only after it reaches the current sequence. The final critical section
+translates consumer cursors and swaps the candidate overlay, ordered
+transaction slice, hash index, and byte totals; its work is independent of
+total pool occupancy. Shutdown is a terminal journal state, and repeated
+ledger-generation changes abandon the candidate after a bounded retry so chain
+activity cannot create a busy loop.
+
+`LedgerState.WithTxValidationSession` is the narrow boundary for a rebuild. It
+pins one published ledger generation (tip, era, and protocol parameters), one
+validation reference slot, and one repeatable-read metadata/blob transaction
+for every transaction in the batch. The mempool verifies that generation again
+immediately before the swap; if a block or rollback published a newer one, the
+candidate is discarded and retried from the live FIFO. This prevents a single
+candidate from mixing transaction results from different ledger or database
+views.
+
+CBOR decoding and ledger validation run without the primary pool RW lock or
+consumer lock. `Transactions` likewise snapshots transaction values under the
+read lock and clones their immutable CBOR bytes after releasing it. Forging,
+relay reads, admission, and removals therefore remain available during slow
+script validation and large forging snapshots. Add/remove events remain
+published outside all locks, and candidate rejection emits only the same
+removal event and gauge changes as the former in-place rebuild.
 
 ## Block Production
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' 
 BUILD_TAGS ?= dingo_extra_plugins
 GO_TAG_FLAGS=$(if $(strip $(BUILD_TAGS)),-tags "$(BUILD_TAGS)",)
 
-.PHONY: all build help mod-tidy clean format golines lint import-boundaries proto test bench test-load test-load-log test-load-profile test-devnet
+.PHONY: all build help mod-tidy clean format golines lint import-boundaries proto test bench bench-mempool-revalidation test-load test-load-log test-load-profile test-devnet
 
 # Default target
 all: format build ## Format and build (default)
@@ -102,6 +102,9 @@ test: mod-tidy ## Run tests with race detection
 
 bench: mod-tidy ## Run benchmarks
 	go test $(GO_TAG_FLAGS) -run=^$$ -bench=. -benchmem ./...
+
+bench-mempool-revalidation: ## Benchmark FIFO admission during normal and degenerate rebuilds
+	go test $(GO_TAG_FLAGS) -run=^$$ -bench='^BenchmarkFIFO(AdmissionNoRevalidation|Revalidation)$$' -benchmem ./mempool
 
 test-load: build ## Load test data into a fresh database
 	rm -rf .dingo

--- a/config.go
+++ b/config.go
@@ -545,6 +545,7 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 			plugin.CapabilityStorageMetadata: {Provider: "sqlite", Config: map[string]any{}},
 			plugin.CapabilityMempool: {Provider: "default", Config: map[string]any{
 				"evictionWatermark": 0.90, "rejectionWatermark": 0.95,
+				"revalidationDeltaCap": 64,
 			}},
 			plugin.CapabilityAPIBlockfrost: {Provider: "builtin", Config: map[string]any{"port": uint(3000)}},
 			plugin.CapabilityAPIMesh:       {Provider: "builtin", Config: map[string]any{"port": uint(8080)}},

--- a/config.go
+++ b/config.go
@@ -545,7 +545,7 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 			plugin.CapabilityStorageMetadata: {Provider: "sqlite", Config: map[string]any{}},
 			plugin.CapabilityMempool: {Provider: "default", Config: map[string]any{
 				"evictionWatermark": 0.90, "rejectionWatermark": 0.95,
-				"revalidationDeltaCap": 64,
+				"revalidationDeltaCap": internalconfig.DefaultMempoolRevalidationDeltaCap,
 			}},
 			plugin.CapabilityAPIBlockfrost: {Provider: "builtin", Config: map[string]any{"port": uint(3000)}},
 			plugin.CapabilityAPIMesh:       {Provider: "builtin", Config: map[string]any{"port": uint(8080)}},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,7 @@ const (
 	DefaultForgeStaleGapThresholdSlots = 1000
 	DefaultMempoolCapacityPraos        = 1048576  // 1 MiB
 	DefaultMempoolCapacityLeios        = 26214400 // 25 MiB
+	DefaultMempoolRevalidationDeltaCap = 64
 	DefaultMempoolImplementation       = "fifo"
 )
 
@@ -583,8 +584,9 @@ func defaultPluginsConfig() PluginsConfig {
 			Metadata: hostplugin.Selection{Provider: "sqlite", Config: map[string]any{}},
 		},
 		Mempool: hostplugin.Selection{Provider: "default", Config: map[string]any{
-			"evictionWatermark":  DefaultEvictionWatermark,
-			"rejectionWatermark": DefaultRejectionWatermark,
+			"evictionWatermark":    DefaultEvictionWatermark,
+			"rejectionWatermark":   DefaultRejectionWatermark,
+			"revalidationDeltaCap": DefaultMempoolRevalidationDeltaCap,
 		}},
 		API: APIPluginsConfig{
 			Blockfrost: hostplugin.Selection{Provider: "builtin", Config: map[string]any{"port": 3000}},
@@ -989,6 +991,10 @@ func (c *Config) ApplyDefaults() {
 	}
 	if pluginFloat64(c.Plugins.Mempool.Config["rejectionWatermark"]) == 0 {
 		c.Plugins.Mempool.Config["rejectionWatermark"] = DefaultRejectionWatermark
+	}
+	if _, ok := c.Plugins.Mempool.Config["revalidationDeltaCap"]; !ok {
+		defaultDeltaCap := DefaultMempoolRevalidationDeltaCap
+		c.Plugins.Mempool.Config["revalidationDeltaCap"] = defaultDeltaCap
 	}
 	if c.ForgeSyncToleranceSlots == 0 {
 		c.ForgeSyncToleranceSlots = DefaultForgeSyncToleranceSlots

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -319,6 +319,15 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 			rejectionWatermark,
 		))
 	}
+	if value, ok := c.Plugins.Mempool.Config["revalidationDeltaCap"]; ok {
+		revalidationDeltaCap := pluginInt64(value)
+		if revalidationDeltaCap <= 0 {
+			errs = append(errs, fmt.Errorf(
+				"invalid plugins.mempool.config.revalidationDeltaCap: %d (must be positive)",
+				revalidationDeltaCap,
+			))
+		}
+	}
 
 	// Block production needs all three credential paths
 	if c.BlockProducer {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -291,6 +291,13 @@ func TestValidate(t *testing.T) {
 			wantErr: "invalid plugins.mempool.config.rejectionWatermark",
 		},
 		{
+			name: "non-positive mempool revalidation delta cap",
+			modify: func(c *Config) {
+				setMempoolSetting(c, "revalidationDeltaCap", 0)
+			},
+			wantErr: "invalid plugins.mempool.config.revalidationDeltaCap",
+		},
+		{
 			// Every ordered comparison with NaN is false, so a plain
 			// out-of-range check would let NaN through (e.g. from
 			// --eviction-watermark NaN, which strconv parses).

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -6893,6 +6893,98 @@ func validationReferenceSlot(
 	return tipSlot
 }
 
+// WithTxValidationSession pins a mempool revalidation batch to one immutable
+// ledger publication, one validation slot/era/parameter set, and one
+// repeatable-read database transaction. stillCurrent lets the mempool reject
+// the candidate immediately before its atomic swap if a block or rollback
+// published a newer generation while validation was running.
+func (ls *LedgerState) WithTxValidationSession(
+	fn func(
+		validate func(
+			tx ledger.Transaction,
+			consumedUtxos map[string]struct{},
+			createdUtxos map[string]lcommon.Utxo,
+		) error,
+		stillCurrent func() bool,
+	) error,
+) error {
+	consensusState, tipState := ls.loadStateSnapshots()
+	generation := consensusState.generation
+	snapshotEra := consensusState.currentEra
+	snapshotPParams := consensusState.currentPParams
+	snapshotPrevEraPParams := consensusState.prevEraPParams
+	snapshotTipSlot := tipState.currentTip.Point.Slot
+	eraList := ls.eraList()
+
+	currentSlot, currentSlotErr := ls.CurrentSlot()
+	if currentSlotErr != nil {
+		ls.config.Logger.Debug(
+			"slot clock unavailable during tx validation session, falling back to snapshot tip slot",
+			"error",
+			currentSlotErr,
+			"snapshot_tip_slot",
+			snapshotTipSlot,
+		)
+		ls.metrics.slotClockFallbacks.Inc()
+	}
+	snapshotSlot := validationReferenceSlot(
+		snapshotTipSlot,
+		currentSlot,
+		currentSlotErr,
+	)
+
+	txn := ls.db.Transaction(false)
+	return txn.Do(func(txn *database.Txn) error {
+		validate := func(
+			tx ledger.Transaction,
+			consumedUtxos map[string]struct{},
+			createdUtxos map[string]lcommon.Utxo,
+		) error {
+			validationEra, err := resolveValidationEra(
+				tx,
+				snapshotEra,
+				eraList,
+			)
+			if err != nil {
+				return err
+			}
+			if validationEra.ValidateTxFunc == nil {
+				return nil
+			}
+			pp := snapshotPParams
+			if validationEra.Id != snapshotEra.Id &&
+				snapshotPrevEraPParams != nil {
+				pp = snapshotPrevEraPParams
+			}
+			err = validationEra.ValidateTxFunc(
+				tx,
+				snapshotSlot,
+				&LedgerView{
+					txn:             txn,
+					ls:              ls,
+					intraBlockUtxos: createdUtxos,
+					consumedUtxos:   consumedUtxos,
+				},
+				pp,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"TX %s failed validation: %w",
+					tx.Hash(),
+					err,
+				)
+			}
+			return nil
+		}
+		stillCurrent := func() bool {
+			currentConsensus, currentTip := ls.loadStateSnapshots()
+			return currentConsensus.generation == generation &&
+				currentTip.generation == generation
+		}
+		return fn(validate, stillCurrent)
+	})
+}
+
 // validateTxCore is the shared validation flow for ValidateTx and
 // ValidateTxWithOverlay. It snapshots ledger state, resolves the
 // validation era, opens a DB transaction, and invokes the era's

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -6893,6 +6893,43 @@ func validationReferenceSlot(
 	return tipSlot
 }
 
+type txValidationSnapshot struct {
+	generation     uint64
+	currentEra     eras.EraDesc
+	currentPParams lcommon.ProtocolParameters
+	prevEraPParams lcommon.ProtocolParameters
+	eraList        []eras.EraDesc
+	referenceSlot  uint64
+}
+
+func (ls *LedgerState) txValidationSnapshot() txValidationSnapshot {
+	consensusState, tipState := ls.loadStateSnapshots()
+	tipSlot := tipState.currentTip.Point.Slot
+	currentSlot, currentSlotErr := ls.CurrentSlot()
+	if currentSlotErr != nil {
+		ls.config.Logger.Debug(
+			"slot clock unavailable during tx validation, falling back to snapshot tip slot",
+			"error",
+			currentSlotErr,
+			"snapshot_tip_slot",
+			tipSlot,
+		)
+		ls.metrics.slotClockFallbacks.Inc()
+	}
+	return txValidationSnapshot{
+		generation:     consensusState.generation,
+		currentEra:     consensusState.currentEra,
+		currentPParams: consensusState.currentPParams,
+		prevEraPParams: consensusState.prevEraPParams,
+		eraList:        ls.eraList(),
+		referenceSlot: validationReferenceSlot(
+			tipSlot,
+			currentSlot,
+			currentSlotErr,
+		),
+	}
+}
+
 // WithTxValidationSession pins a mempool revalidation batch to one immutable
 // ledger publication, one validation slot/era/parameter set, and one
 // repeatable-read database transaction. stillCurrent lets the mempool reject
@@ -6908,30 +6945,7 @@ func (ls *LedgerState) WithTxValidationSession(
 		stillCurrent func() bool,
 	) error,
 ) error {
-	consensusState, tipState := ls.loadStateSnapshots()
-	generation := consensusState.generation
-	snapshotEra := consensusState.currentEra
-	snapshotPParams := consensusState.currentPParams
-	snapshotPrevEraPParams := consensusState.prevEraPParams
-	snapshotTipSlot := tipState.currentTip.Point.Slot
-	eraList := ls.eraList()
-
-	currentSlot, currentSlotErr := ls.CurrentSlot()
-	if currentSlotErr != nil {
-		ls.config.Logger.Debug(
-			"slot clock unavailable during tx validation session, falling back to snapshot tip slot",
-			"error",
-			currentSlotErr,
-			"snapshot_tip_slot",
-			snapshotTipSlot,
-		)
-		ls.metrics.slotClockFallbacks.Inc()
-	}
-	snapshotSlot := validationReferenceSlot(
-		snapshotTipSlot,
-		currentSlot,
-		currentSlotErr,
-	)
+	snapshot := ls.txValidationSnapshot()
 
 	txn := ls.db.Transaction(false)
 	return txn.Do(func(txn *database.Txn) error {
@@ -6942,8 +6956,8 @@ func (ls *LedgerState) WithTxValidationSession(
 		) error {
 			validationEra, err := resolveValidationEra(
 				tx,
-				snapshotEra,
-				eraList,
+				snapshot.currentEra,
+				snapshot.eraList,
 			)
 			if err != nil {
 				return err
@@ -6951,14 +6965,14 @@ func (ls *LedgerState) WithTxValidationSession(
 			if validationEra.ValidateTxFunc == nil {
 				return nil
 			}
-			pp := snapshotPParams
-			if validationEra.Id != snapshotEra.Id &&
-				snapshotPrevEraPParams != nil {
-				pp = snapshotPrevEraPParams
+			pp := snapshot.currentPParams
+			if validationEra.Id != snapshot.currentEra.Id &&
+				snapshot.prevEraPParams != nil {
+				pp = snapshot.prevEraPParams
 			}
 			err = validationEra.ValidateTxFunc(
 				tx,
-				snapshotSlot,
+				snapshot.referenceSlot,
 				&LedgerView{
 					txn:             txn,
 					ls:              ls,
@@ -6978,8 +6992,8 @@ func (ls *LedgerState) WithTxValidationSession(
 		}
 		stillCurrent := func() bool {
 			currentConsensus, currentTip := ls.loadStateSnapshots()
-			return currentConsensus.generation == generation &&
-				currentTip.generation == generation
+			return currentConsensus.generation == snapshot.generation &&
+				currentTip.generation == snapshot.generation
 		}
 		return fn(validate, stillCurrent)
 	})
@@ -6993,46 +7007,27 @@ func (ls *LedgerState) validateTxCore(
 	tx lcommon.Transaction,
 	buildLV func(txn *database.Txn) *LedgerView,
 ) error {
-	consensusState, tipState := ls.loadStateSnapshots()
-	snapshotEra := consensusState.currentEra
-	snapshotTipSlot := tipState.currentTip.Point.Slot
-	snapshotPParams := consensusState.currentPParams
-	snapshotPrevEraPParams := consensusState.prevEraPParams
-	currentSlot, currentSlotErr := ls.CurrentSlot()
-	if currentSlotErr != nil {
-		ls.config.Logger.Debug(
-			"slot clock unavailable during tx validation, falling back to snapshot tip slot",
-			"error",
-			currentSlotErr,
-			"snapshot_tip_slot",
-			snapshotTipSlot,
-		)
-		ls.metrics.slotClockFallbacks.Inc()
-	}
-	snapshotSlot := validationReferenceSlot(
-		snapshotTipSlot,
-		currentSlot,
-		currentSlotErr,
-	)
+	snapshot := ls.txValidationSnapshot()
 
 	validationEra, err := resolveValidationEra(
 		tx,
-		snapshotEra,
-		ls.eraList(),
+		snapshot.currentEra,
+		snapshot.eraList,
 	)
 	if err != nil {
 		return err
 	}
 	if validationEra.ValidateTxFunc != nil {
-		pp := snapshotPParams
-		if validationEra.Id != snapshotEra.Id && snapshotPrevEraPParams != nil {
-			pp = snapshotPrevEraPParams
+		pp := snapshot.currentPParams
+		if validationEra.Id != snapshot.currentEra.Id &&
+			snapshot.prevEraPParams != nil {
+			pp = snapshot.prevEraPParams
 		}
 		txn := ls.db.Transaction(false)
 		err := txn.Do(func(txn *database.Txn) error {
 			return validationEra.ValidateTxFunc(
 				tx,
-				snapshotSlot,
+				snapshot.referenceSlot,
 				buildLV(txn),
 				pp,
 			)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -854,11 +854,8 @@ func (m *Mempool) rebuildOverlayAttempt() ([]event.Event, error) {
 		m.mutationMutex.Unlock()
 		return nil, ErrMempoolStopped
 	}
-	base := make([]appliedTx, len(m.overlay.applied))
+	base := slices.Clone(m.overlay.applied)
 	baseTxs := make(map[string]*MempoolTransaction, len(m.txByHash))
-	for i, at := range m.overlay.applied {
-		base[i] = cloneAppliedTx(at)
-	}
 	maps.Copy(baseTxs, m.txByHash)
 	startSeq := m.mutationSeq
 	m.mutationJournal = nil
@@ -1042,6 +1039,12 @@ func (m *Mempool) revalidateAppliedTx(
 	) error,
 ) {
 	if tx == nil {
+		m.logger.Warn(
+			"overlay applied transaction is missing from transaction index during re-validation",
+			"component", "mempool",
+			"tx_hash", at.hash,
+			"tx_type", at.txType,
+		)
 		return
 	}
 	tmpTx, err := gledger.NewTransactionFromCbor(at.txType, at.cbor)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -39,10 +39,12 @@ const (
 	AddTransactionEventType    event.EventType = "mempool.add_tx"
 	RemoveTransactionEventType event.EventType = "mempool.remove_tx"
 
-	DefaultEvictionWatermark  = 0.90
-	DefaultRejectionWatermark = 0.95
-	DefaultTransactionTTL     = 5 * time.Minute
-	DefaultCleanupInterval    = 1 * time.Minute
+	DefaultEvictionWatermark      = 0.90
+	DefaultRejectionWatermark     = 0.95
+	DefaultTransactionTTL         = 5 * time.Minute
+	DefaultCleanupInterval        = 1 * time.Minute
+	DefaultRevalidationDeltaCap   = 64
+	defaultRevalidationJournalCap = 65_536
 )
 
 type AddTransactionEvent struct {
@@ -94,17 +96,34 @@ type TxValidator interface {
 		createdUtxos map[string]lcommon.Utxo,
 	) error
 }
+
+// TxValidationSessionProvider optionally pins a batch of validations to one
+// coherent ledger snapshot. LedgerState implements this interface; lightweight
+// validators used by tests and alternate embeddings may continue to implement
+// only TxValidator.
+type TxValidationSessionProvider interface {
+	WithTxValidationSession(func(
+		validate func(
+			tx gledger.Transaction,
+			consumedUtxos map[string]struct{},
+			createdUtxos map[string]lcommon.Utxo,
+		) error,
+		stillCurrent func() bool,
+	) error) error
+}
+
 type MempoolConfig struct {
-	PromRegistry       prometheus.Registerer
-	Validator          TxValidator
-	Logger             *slog.Logger
-	EventBus           *event.EventBus
-	MempoolCapacity    int64
-	TransactionTTL     time.Duration
-	CleanupInterval    time.Duration
-	EvictionWatermark  float64
-	RejectionWatermark float64
-	CurrentSlotFunc    func() uint64 // returns current slot for early TX rejection
+	PromRegistry         prometheus.Registerer
+	Validator            TxValidator
+	Logger               *slog.Logger
+	EventBus             *event.EventBus
+	MempoolCapacity      int64
+	TransactionTTL       time.Duration
+	CleanupInterval      time.Duration
+	EvictionWatermark    float64
+	RejectionWatermark   float64
+	RevalidationDeltaCap int
+	CurrentSlotFunc      func() uint64 // returns current slot for early TX rejection
 }
 
 type Mempool struct {
@@ -116,20 +135,22 @@ type Mempool struct {
 		txsExpired      prometheus.Counter
 		implementation  prometheus.Gauge
 	}
-	validator          TxValidator
-	logger             *slog.Logger
-	eventBus           *event.EventBus
-	consumers          map[ouroboros.ConnectionId]*MempoolConsumer
-	done               chan struct{}
-	config             MempoolConfig
-	transactions       []*MempoolTransaction
-	txByHash           map[string]*MempoolTransaction // O(1) lookup by hash
-	currentSizeBytes   int64                          // Cached total size of all transactions in bytes
-	transactionTTL     time.Duration
-	cleanupInterval    time.Duration
-	evictionWatermark  float64
-	rejectionWatermark float64
-	stopped            bool
+	validator              TxValidator
+	logger                 *slog.Logger
+	eventBus               *event.EventBus
+	consumers              map[ouroboros.ConnectionId]*MempoolConsumer
+	done                   chan struct{}
+	config                 MempoolConfig
+	transactions           []*MempoolTransaction
+	txByHash               map[string]*MempoolTransaction // O(1) lookup by hash
+	currentSizeBytes       int64                          // Cached total size of all transactions in bytes
+	transactionTTL         time.Duration
+	cleanupInterval        time.Duration
+	evictionWatermark      float64
+	rejectionWatermark     float64
+	revalidationDeltaCap   int
+	revalidationJournalCap int
+	stopped                bool
 	sync.RWMutex
 	doneOnce       sync.Once
 	mutationMutex  sync.Mutex
@@ -138,6 +159,72 @@ type Mempool struct {
 	workerWG       sync.WaitGroup
 	consumersMutex sync.Mutex
 	overlay        *utxoOverlay
+
+	// rebuildMutex permits one double-buffer rebuild at a time. mutationSeq and
+	// mutationJournal are protected by mutationMutex and let that rebuild catch
+	// up with admissions/removals performed while ledger validation runs.
+	rebuildMutex    sync.Mutex
+	mutationSeq     uint64
+	mutationJournal []mempoolMutation
+	journalActive   bool
+	journalOverflow bool
+}
+
+type mempoolMutation struct {
+	seq     uint64
+	added   *appliedTx
+	addedTx *MempoolTransaction
+	removed map[string]struct{}
+	stopped bool
+}
+
+type revalidationCandidate struct {
+	overlay      *utxoOverlay
+	transactions []*MempoolTransaction
+	txByHash     map[string]*MempoolTransaction
+	sizeBytes    int64
+	invalid      map[string]*MempoolTransaction
+}
+
+func newRevalidationCandidate() *revalidationCandidate {
+	return &revalidationCandidate{
+		overlay:  newUtxoOverlay(),
+		txByHash: make(map[string]*MempoolTransaction),
+		invalid:  make(map[string]*MempoolTransaction),
+	}
+}
+
+func (c *revalidationCandidate) remove(hashes map[string]struct{}) {
+	if len(hashes) == 0 {
+		return
+	}
+	c.overlay.removeByHashes(hashes)
+	remaining := make([]*MempoolTransaction, 0, len(c.transactions))
+	for _, tx := range c.transactions {
+		if _, remove := hashes[tx.Hash]; remove {
+			delete(c.txByHash, tx.Hash)
+			delete(c.invalid, tx.Hash)
+			c.sizeBytes -= int64(len(tx.Cbor))
+			continue
+		}
+		remaining = append(remaining, tx)
+	}
+	c.transactions = remaining
+	for hash := range hashes {
+		delete(c.invalid, hash)
+	}
+}
+
+func (c *revalidationCandidate) add(
+	at appliedTx,
+	tx *MempoolTransaction,
+	decoded gledger.Transaction,
+) {
+	c.overlay.applyTx(at.hash, at.txType, at.cbor, decoded)
+	c.transactions = append(c.transactions, tx)
+	c.txByHash[at.hash] = tx
+	c.sizeBytes += int64(len(tx.Cbor))
+	delete(c.invalid, at.hash)
 }
 
 // appliedTx records a pending transaction and its UTxO effects for overlay rebuild.
@@ -147,6 +234,29 @@ type appliedTx struct {
 	cbor     []byte
 	consumed []string                // UTxO keys consumed by this TX
 	created  map[string]lcommon.Utxo // UTxO keys created by this TX
+}
+
+func cloneAppliedTx(at appliedTx) appliedTx {
+	ret := at
+	ret.cbor = slices.Clone(at.cbor)
+	ret.consumed = slices.Clone(at.consumed)
+	ret.created = maps.Clone(at.created)
+	return ret
+}
+
+// recordMutationLocked appends an ordered mutation for an active rebuild.
+// The caller must hold mutationMutex and must invoke this only after the live
+// pool and overlay mutation has committed.
+func (m *Mempool) recordMutationLocked(mutation mempoolMutation) {
+	m.mutationSeq++
+	mutation.seq = m.mutationSeq
+	if m.journalActive {
+		if len(m.mutationJournal) >= m.revalidationJournalCap {
+			m.journalOverflow = true
+			return
+		}
+		m.mutationJournal = append(m.mutationJournal, mutation)
+	}
 }
 
 // utxoOverlay tracks cumulative UTxO state changes from all pending mempool TXs.
@@ -381,18 +491,24 @@ func NewMempool(config MempoolConfig) (*Mempool, error) {
 	if cleanupInterval <= 0 {
 		cleanupInterval = DefaultCleanupInterval
 	}
+	revalidationDeltaCap := config.RevalidationDeltaCap
+	if revalidationDeltaCap <= 0 {
+		revalidationDeltaCap = DefaultRevalidationDeltaCap
+	}
 	m := &Mempool{
-		eventBus:           config.EventBus,
-		consumers:          make(map[ouroboros.ConnectionId]*MempoolConsumer),
-		txByHash:           make(map[string]*MempoolTransaction),
-		overlay:            newUtxoOverlay(),
-		validator:          config.Validator,
-		config:             config,
-		done:               make(chan struct{}),
-		transactionTTL:     transactionTTL,
-		cleanupInterval:    cleanupInterval,
-		evictionWatermark:  evictionWatermark,
-		rejectionWatermark: rejectionWatermark,
+		eventBus:               config.EventBus,
+		consumers:              make(map[ouroboros.ConnectionId]*MempoolConsumer),
+		txByHash:               make(map[string]*MempoolTransaction),
+		overlay:                newUtxoOverlay(),
+		validator:              config.Validator,
+		config:                 config,
+		done:                   make(chan struct{}),
+		transactionTTL:         transactionTTL,
+		cleanupInterval:        cleanupInterval,
+		evictionWatermark:      evictionWatermark,
+		rejectionWatermark:     rejectionWatermark,
+		revalidationDeltaCap:   revalidationDeltaCap,
+		revalidationJournalCap: defaultRevalidationJournalCap,
 	}
 	if config.Logger == nil {
 		// Create logger to throw away logs
@@ -525,6 +641,7 @@ func (m *Mempool) Stop(ctx context.Context) error {
 		m.mutationMutex.Lock()
 		m.Lock()
 		m.stopped = true
+		m.recordMutationLocked(mempoolMutation{stopped: true})
 		m.doneOnce.Do(func() { close(m.done) })
 		m.Unlock()
 		m.mutationMutex.Unlock()
@@ -594,9 +711,10 @@ func (m *Mempool) FindConsumer(connId ouroboros.ConnectionId) Consumer {
 
 // ProviderConfig is the canonical configuration for the default mempool.
 type ProviderConfig struct {
-	Capacity           int64   `yaml:"capacity"`
-	EvictionWatermark  float64 `yaml:"evictionWatermark"`
-	RejectionWatermark float64 `yaml:"rejectionWatermark"`
+	Capacity             int64   `yaml:"capacity"`
+	EvictionWatermark    float64 `yaml:"evictionWatermark"`
+	RejectionWatermark   float64 `yaml:"rejectionWatermark"`
+	RevalidationDeltaCap int     `yaml:"revalidationDeltaCap"`
 }
 
 // ProviderDependencies are runtime dependencies assembled after ledger and
@@ -620,18 +738,20 @@ func RegisterProvider(host *plugin.Host) error {
 		},
 		func() ProviderConfig {
 			return ProviderConfig{
-				EvictionWatermark:  DefaultEvictionWatermark,
-				RejectionWatermark: DefaultRejectionWatermark,
+				EvictionWatermark:    DefaultEvictionWatermark,
+				RejectionWatermark:   DefaultRejectionWatermark,
+				RevalidationDeltaCap: DefaultRevalidationDeltaCap,
 			}
 		},
 		func(_ context.Context, cfg ProviderConfig, deps ProviderDependencies) (Service, plugin.Instance, error) {
 			m, err := NewMempool(MempoolConfig{
 				PromRegistry: deps.PromRegistry, Validator: deps.Validator,
 				Logger: deps.Logger, EventBus: deps.EventBus,
-				MempoolCapacity:    cfg.Capacity,
-				EvictionWatermark:  cfg.EvictionWatermark,
-				RejectionWatermark: cfg.RejectionWatermark,
-				CurrentSlotFunc:    deps.CurrentSlotFunc,
+				MempoolCapacity:      cfg.Capacity,
+				EvictionWatermark:    cfg.EvictionWatermark,
+				RejectionWatermark:   cfg.RejectionWatermark,
+				RevalidationDeltaCap: cfg.RevalidationDeltaCap,
+				CurrentSlotFunc:      deps.CurrentSlotFunc,
 			})
 			if err != nil {
 				return nil, nil, err
@@ -684,103 +804,288 @@ func (m *Mempool) processChainEvents() {
 	}
 }
 
-// rebuildOverlay re-validates all pending TXs sequentially, rebuilding the
-// UTxO overlay from scratch. TXs that fail re-validation are removed.
-// Mutations are serialized for the duration, but decoding and ledger validation
-// run without the primary pool lock so snapshot readers remain available.
-//
-// Returns ErrNilValidator if called on a Mempool whose validator is nil —
-// a programmer error the chain-update loop logs rather than crashes on.
+const maxRevalidationCatchupRounds = 16
+
+var errValidationSnapshotChanged = errors.New(
+	"mempool: ledger snapshot changed during revalidation",
+)
+
+var errRevalidationJournalOverflow = errors.New(
+	"mempool: revalidation mutation journal overflow",
+)
+
+// rebuildOverlay re-validates all pending TXs against a stable ledger snapshot
+// in a private overlay. Admissions and removals continue against the live
+// overlay and are replayed from an ordered journal before the candidate is
+// swapped in during a short mutation-lock hold.
 func (m *Mempool) rebuildOverlay() error {
 	if m.validator == nil {
 		return ErrNilValidator
 	}
-	var events []event.Event
-	err := func() error {
-		m.mutationMutex.Lock()
-		defer m.mutationMutex.Unlock()
+	m.rebuildMutex.Lock()
+	defer m.rebuildMutex.Unlock()
 
-		m.RLock()
-		prevApplied := make([]appliedTx, len(m.overlay.applied))
-		for i, at := range m.overlay.applied {
-			prevApplied[i] = at
-			prevApplied[i].cbor = slices.Clone(at.cbor)
+	// A ledger publication racing the batch invalidates its pinned view. Retry
+	// once from the new live pool; a later chain event provides further retries
+	// without allowing a busy chain to spin here indefinitely.
+	for attempt := range 2 {
+		events, err := m.rebuildOverlayAttempt()
+		if errors.Is(err, errValidationSnapshotChanged) && attempt == 0 {
+			continue
 		}
-		m.RUnlock()
-		if len(prevApplied) == 0 {
-			return nil
+		if err != nil {
+			return err
 		}
-
-		newOverlay := newUtxoOverlay()
-		var invalidHashes []string
-		for _, at := range prevApplied {
-			tmpTx, decodeErr := gledger.NewTransactionFromCbor(
-				at.txType,
-				at.cbor,
-			)
-			if decodeErr != nil {
-				invalidHashes = append(invalidHashes, at.hash)
-				m.logger.Error(
-					"transaction failed decode during re-validation",
-					"component", "mempool",
-					"tx_hash", at.hash,
-					"error", decodeErr,
-				)
-				continue
-			}
-			if validateErr := m.validator.ValidateTxWithOverlay(
-				tmpTx,
-				newOverlay.consumed,
-				newOverlay.created,
-			); validateErr != nil {
-				invalidHashes = append(invalidHashes, at.hash)
-				m.logger.Debug(
-					"transaction failed re-validation",
-					"component", "mempool",
-					"tx_hash", at.hash,
-					"error", validateErr,
-				)
-				continue
-			}
-			newOverlay.applyTx(at.hash, at.txType, at.cbor, tmpTx)
-		}
-
-		m.Lock()
-		defer m.Unlock()
-		m.overlay = newOverlay
-		if len(invalidHashes) > 0 {
-			hashSet := make(map[string]struct{}, len(invalidHashes))
-			for _, h := range invalidHashes {
-				hashSet[h] = struct{}{}
-			}
-			m.consumersMutex.Lock()
-			defer m.consumersMutex.Unlock()
-			for i, v := range slices.Backward(m.transactions) {
-				h := v.Hash
-				if _, found := hashSet[h]; found {
-					evt := m.removeTransactionByIndexLocked(i)
-					if evt != nil {
-						events = append(events, *evt)
-					}
-					delete(hashSet, h)
-					if len(hashSet) == 0 {
-						break
-					}
-				}
+		if m.eventBus != nil {
+			for _, evt := range events {
+				m.eventBus.Publish(RemoveTransactionEventType, evt)
 			}
 		}
 		return nil
-	}()
-	if err != nil {
-		return err
+	}
+	return errValidationSnapshotChanged
+}
+
+func (m *Mempool) rebuildOverlayAttempt() ([]event.Event, error) {
+	m.mutationMutex.Lock()
+	m.RLock()
+	if m.stopped {
+		m.RUnlock()
+		m.mutationMutex.Unlock()
+		return nil, ErrMempoolStopped
+	}
+	base := make([]appliedTx, len(m.overlay.applied))
+	baseTxs := make(map[string]*MempoolTransaction, len(m.txByHash))
+	for i, at := range m.overlay.applied {
+		base[i] = cloneAppliedTx(at)
+	}
+	maps.Copy(baseTxs, m.txByHash)
+	startSeq := m.mutationSeq
+	m.mutationJournal = nil
+	m.journalActive = true
+	m.journalOverflow = false
+	m.RUnlock()
+	m.mutationMutex.Unlock()
+
+	finishJournal := func() {
+		m.mutationMutex.Lock()
+		m.journalActive = false
+		m.mutationJournal = nil
+		m.journalOverflow = false
+		m.mutationMutex.Unlock()
 	}
 
-	if m.eventBus != nil {
-		for _, evt := range events {
-			m.eventBus.Publish(RemoveTransactionEventType, evt)
+	var events []event.Event
+	err := m.withTxValidationSession(func(
+		validate func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error,
+		stillCurrent func() bool,
+	) error {
+		candidate := newRevalidationCandidate()
+		for _, at := range base {
+			m.revalidateAppliedTx(candidate, at, baseTxs[at.hash], validate)
+		}
+
+		appliedSeq := startSeq
+		for range maxRevalidationCatchupRounds {
+			m.mutationMutex.Lock()
+			if m.journalOverflow {
+				m.mutationMutex.Unlock()
+				return errRevalidationJournalOverflow
+			}
+			delta := mutationsAfter(m.mutationJournal, appliedSeq)
+			if len(delta) == 0 {
+				m.RLock()
+				liveOrder := slices.Clone(m.transactions)
+				liveSeq := m.mutationSeq
+				m.RUnlock()
+				m.mutationMutex.Unlock()
+
+				// Precompute cursor translations outside both mempool locks.
+				// prefixValid[n] is the number of candidate transactions in
+				// the first n entries of the current live FIFO.
+				prefixValid := make([]int, len(liveOrder)+1)
+				for i, tx := range liveOrder {
+					prefixValid[i+1] = prefixValid[i]
+					if _, ok := candidate.txByHash[tx.Hash]; ok {
+						prefixValid[i+1]++
+					}
+				}
+				invalidHashes := make([]string, 0, len(candidate.invalid))
+				for _, tx := range slices.Backward(liveOrder) {
+					if _, invalid := candidate.invalid[tx.Hash]; invalid {
+						invalidHashes = append(invalidHashes, tx.Hash)
+					}
+				}
+
+				m.mutationMutex.Lock()
+				if m.mutationSeq != liveSeq {
+					m.mutationMutex.Unlock()
+					continue
+				}
+				if !stillCurrent() {
+					m.journalActive = false
+					m.mutationJournal = nil
+					m.journalOverflow = false
+					m.mutationMutex.Unlock()
+					return errValidationSnapshotChanged
+				}
+
+				m.Lock()
+				if m.stopped {
+					m.Unlock()
+					m.journalActive = false
+					m.mutationJournal = nil
+					m.journalOverflow = false
+					m.mutationMutex.Unlock()
+					return ErrMempoolStopped
+				}
+				m.consumersMutex.Lock()
+				for _, consumer := range m.consumers {
+					consumer.nextTxIdxMu.Lock()
+					oldIdx := min(consumer.nextTxIdx, len(liveOrder))
+					consumer.nextTxIdx = prefixValid[oldIdx]
+					consumer.nextTxIdxMu.Unlock()
+				}
+				if m.eventBus != nil {
+					for _, hash := range invalidHashes {
+						events = append(events, event.NewEvent(
+							RemoveTransactionEventType,
+							RemoveTransactionEvent{Hash: hash},
+						))
+					}
+				}
+				m.overlay = candidate.overlay
+				m.transactions = candidate.transactions
+				m.txByHash = candidate.txByHash
+				m.currentSizeBytes = candidate.sizeBytes
+				m.metrics.txsInMempool.Set(float64(len(candidate.transactions)))
+				m.metrics.mempoolBytes.Set(float64(candidate.sizeBytes))
+				m.consumersMutex.Unlock()
+				m.Unlock()
+				m.journalActive = false
+				m.mutationJournal = nil
+				m.journalOverflow = false
+				if len(invalidHashes) > 0 {
+					removed := make(
+						map[string]struct{},
+						len(invalidHashes),
+					)
+					for _, hash := range invalidHashes {
+						removed[hash] = struct{}{}
+					}
+					m.recordMutationLocked(mempoolMutation{removed: removed})
+				}
+				m.mutationMutex.Unlock()
+				return nil
+			}
+			m.mutationMutex.Unlock()
+
+			applyCount := len(delta)
+			if applyCount > m.revalidationDeltaCap {
+				// Drain the excess off-lock, leaving at most the configured
+				// residual for the next catch-up/finalization pass.
+				applyCount -= m.revalidationDeltaCap
+			}
+			for _, mutation := range delta[:applyCount] {
+				if mutation.stopped {
+					return ErrMempoolStopped
+				}
+				if len(mutation.removed) > 0 {
+					candidate.remove(mutation.removed)
+				}
+				if mutation.added != nil {
+					m.revalidateAppliedTx(
+						candidate,
+						*mutation.added,
+						mutation.addedTx,
+						validate,
+					)
+				}
+				appliedSeq = mutation.seq
+			}
+		}
+		return errors.New("mempool: revalidation could not catch up with mutations")
+	})
+	if err != nil {
+		finishJournal()
+		return nil, err
+	}
+	return events, nil
+}
+
+func mutationsAfter(
+	journal []mempoolMutation,
+	seq uint64,
+) []mempoolMutation {
+	idx := len(journal)
+	for i := range journal {
+		if journal[i].seq > seq {
+			idx = i
+			break
 		}
 	}
-	return nil
+	return slices.Clone(journal[idx:])
+}
+
+func (m *Mempool) revalidateAppliedTx(
+	candidate *revalidationCandidate,
+	at appliedTx,
+	tx *MempoolTransaction,
+	validate func(
+		gledger.Transaction,
+		map[string]struct{},
+		map[string]lcommon.Utxo,
+	) error,
+) {
+	if tx == nil {
+		return
+	}
+	tmpTx, err := gledger.NewTransactionFromCbor(at.txType, at.cbor)
+	if err != nil {
+		candidate.invalid[at.hash] = tx
+		m.logger.Error(
+			"transaction failed decode during re-validation",
+			"component", "mempool",
+			"tx_hash", at.hash,
+			"error", err,
+		)
+		return
+	}
+	if err := validate(
+		tmpTx,
+		candidate.overlay.consumed,
+		candidate.overlay.created,
+	); err != nil {
+		candidate.invalid[at.hash] = tx
+		m.logger.Debug(
+			"transaction failed re-validation",
+			"component", "mempool",
+			"tx_hash", at.hash,
+			"error", err,
+		)
+		return
+	}
+	candidate.add(at, tx, tmpTx)
+}
+
+func (m *Mempool) withTxValidationSession(
+	fn func(
+		validate func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error,
+		stillCurrent func() bool,
+	) error,
+) error {
+	if provider, ok := m.validator.(TxValidationSessionProvider); ok {
+		return provider.WithTxValidationSession(fn)
+	}
+	return fn(m.validator.ValidateTxWithOverlay, func() bool { return true })
 }
 
 // expireTransactions periodically removes transactions that have
@@ -845,6 +1150,7 @@ func (m *Mempool) removeExpiredTransactions() {
 				}
 			}
 		}
+		m.recordMutationLocked(mempoolMutation{removed: maps.Clone(expiredHashes)})
 		if len(pruned) > 0 {
 			m.logger.Debug(
 				"pruned orphaned descendant transactions during expiry",
@@ -985,6 +1291,7 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		overlayCbor := slices.Clone(txBytes)
 		txCbor := slices.Clone(txBytes)
 		m.overlay.applyTx(txHash, txType, overlayCbor, tmpTx)
+		added := cloneAppliedTx(m.overlay.applied[len(m.overlay.applied)-1])
 		tx := &MempoolTransaction{
 			Hash:     txHash,
 			Type:     txType,
@@ -1002,6 +1309,7 @@ func (m *Mempool) AddTransaction(txType uint, txBytes []byte) error {
 		m.metrics.txsProcessedNum.Inc()
 		m.metrics.txsInMempool.Inc()
 		m.metrics.mempoolBytes.Add(float64(txSize))
+		m.recordMutationLocked(mempoolMutation{added: &added, addedTx: tx})
 		if m.eventBus != nil {
 			evt := event.NewEvent(
 				AddTransactionEventType,
@@ -1042,10 +1350,16 @@ func (m *Mempool) GetTransaction(txHash string) (MempoolTransaction, bool) {
 
 func (m *Mempool) Transactions() []MempoolTransaction {
 	m.RLock()
-	defer m.RUnlock()
 	ret := make([]MempoolTransaction, len(m.transactions))
 	for i := range m.transactions {
-		ret[i] = *cloneMempoolTransaction(m.transactions[i])
+		ret[i] = *m.transactions[i]
+	}
+	m.RUnlock()
+	// CBOR is immutable after admission, so copying its slice headers while
+	// locked is sufficient; move the potentially expensive byte copies outside
+	// the pool lock to keep writers moving during large snapshots.
+	for i := range ret {
+		ret[i].Cbor = slices.Clone(ret[i].Cbor)
 	}
 	return ret
 }
@@ -1093,6 +1407,7 @@ func (m *Mempool) RemoveTransaction(txHash string) {
 		}
 	}
 	if removed {
+		m.recordMutationLocked(mempoolMutation{removed: maps.Clone(toRemove)})
 		if len(pruned) > 0 {
 			m.logger.Debug(
 				"pruned orphaned descendant transactions",
@@ -1135,13 +1450,18 @@ func (m *Mempool) RemoveTxsByHash(hashes []string) {
 	m.Lock()
 	m.consumersMutex.Lock()
 	m.overlay.removeByHashes(hashSet)
+	removedHashes := make(map[string]struct{}, len(hashSet))
 	for i, v := range slices.Backward(m.transactions) {
 		if _, ok := hashSet[v.Hash]; ok {
+			removedHashes[v.Hash] = struct{}{}
 			evt := m.removeTransactionByIndexLocked(i)
 			if evt != nil {
 				events = append(events, *evt)
 			}
 		}
+	}
+	if len(removedHashes) > 0 {
+		m.recordMutationLocked(mempoolMutation{removed: removedHashes})
 	}
 	m.consumersMutex.Unlock()
 	m.Unlock()
@@ -1282,6 +1602,12 @@ func (m *Mempool) evictOldestLocked(targetBytes int64) []event.Event {
 	}
 
 	totalEvicted := evicted + len(pruned)
+	removedHashes := make(map[string]struct{}, len(evictedHashes)+len(pruned))
+	maps.Copy(removedHashes, evictedHashes)
+	for _, hash := range pruned {
+		removedHashes[hash] = struct{}{}
+	}
+	m.recordMutationLocked(mempoolMutation{removed: removedHashes})
 	m.metrics.txsEvicted.Add(float64(totalEvicted))
 	m.logger.Debug(
 		"evicted transactions from mempool",

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -64,6 +64,92 @@ type blockingOverlayValidator struct {
 	shouldBlock atomic.Bool
 }
 
+type blockingSessionValidator struct {
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+}
+
+type changingSessionValidator struct {
+	sessions atomic.Int32
+}
+
+func (v *changingSessionValidator) ValidateTx(gledger.Transaction) error {
+	return nil
+}
+
+func (v *changingSessionValidator) ValidateTxWithOverlay(
+	gledger.Transaction,
+	map[string]struct{},
+	map[string]lcommon.Utxo,
+) error {
+	return nil
+}
+
+func (v *changingSessionValidator) WithTxValidationSession(
+	fn func(
+		func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error,
+		func() bool,
+	) error,
+) error {
+	v.sessions.Add(1)
+	return fn(
+		func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error {
+			return nil
+		},
+		func() bool { return false },
+	)
+}
+
+func newBlockingSessionValidator() *blockingSessionValidator {
+	return &blockingSessionValidator{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (v *blockingSessionValidator) ValidateTx(gledger.Transaction) error {
+	return nil
+}
+
+func (v *blockingSessionValidator) ValidateTxWithOverlay(
+	gledger.Transaction,
+	map[string]struct{},
+	map[string]lcommon.Utxo,
+) error {
+	return nil
+}
+
+func (v *blockingSessionValidator) WithTxValidationSession(
+	fn func(
+		func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error,
+		func() bool,
+	) error,
+) error {
+	validate := func(
+		gledger.Transaction,
+		map[string]struct{},
+		map[string]lcommon.Utxo,
+	) error {
+		v.startOnce.Do(func() { close(v.started) })
+		<-v.release
+		return nil
+	}
+	return fn(validate, func() bool { return true })
+}
+
 func newBlockingOverlayValidator() *blockingOverlayValidator {
 	return &blockingOverlayValidator{
 		started: make(chan struct{}),
@@ -2809,7 +2895,7 @@ func TestMempool_MEM03_SubscriberAccessesMempoolDuringRemove(
 
 // TestMempool_MEM04_ConcurrentAccessDuringRevalidation synchronizes directly
 // with a paused validator to prove snapshot readers remain available while
-// mutations wait for the rebuild's stable overlay view.
+// mutations continue and are reconciled into the candidate overlay.
 func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(t *testing.T) {
 	validator := newBlockingOverlayValidator()
 	m := newTestMempoolWithValidator(t, validator)
@@ -2853,11 +2939,236 @@ func TestMempool_MEM04_ConcurrentAccessDuringRevalidation(t *testing.T) {
 		m.RemoveTransaction(txs[0].Hash)
 		removeDone <- struct{}{}
 	}()
-	dingotestutil.RequireNoReceive(t, removeDone, 50*time.Millisecond, "mutation during rebuild")
+	dingotestutil.RequireReceive(t, removeDone, time.Second, "mutation during rebuild")
 
 	close(validator.release)
 	require.NoError(t, dingotestutil.RequireReceive(t, rebuildDone, time.Second, "rebuild completion"))
-	dingotestutil.RequireReceive(t, removeDone, time.Second, "queued removal")
+	assert.Empty(t, m.Transactions())
+	assert.Empty(t, m.overlay.applied)
+}
+
+func TestMempool_AdmissionContinuesDuringRevalidation(t *testing.T) {
+	validator := newBlockingSessionValidator()
+	m := newTestMempoolWithValidator(t, validator)
+	defer m.Stop(context.Background())
+
+	require.NoError(
+		t,
+		m.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t)),
+	)
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- m.rebuildOverlay() }()
+	dingotestutil.RequireReceive(t, validator.started, time.Second, "revalidation start")
+
+	secondTx, err := hex.DecodeString(testTxWithValidityStartHex)
+	require.NoError(t, err)
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- m.AddTransaction(uint(conway.EraIdConway), secondTx)
+	}()
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(t, addDone, time.Second, "concurrent admission"),
+	)
+
+	close(validator.release)
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(t, rebuildDone, time.Second, "rebuild completion"),
+	)
+	assert.Len(t, m.Transactions(), 2)
+	assert.Len(t, m.overlay.applied, 2)
+}
+
+func TestMempool_RemovalsContinueDuringRevalidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		remove func(*Mempool, string)
+	}{
+		{
+			name: "confirmed",
+			remove: func(m *Mempool, hash string) {
+				m.RemoveTxsByHash([]string{hash})
+			},
+		},
+		{
+			name: "expired",
+			remove: func(m *Mempool, _ string) {
+				m.Lock()
+				m.transactions[0].LastSeen = time.Now().Add(-time.Hour)
+				m.transactionTTL = time.Minute
+				m.Unlock()
+				m.removeExpiredTransactions()
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validator := newBlockingSessionValidator()
+			m := newTestMempoolWithValidator(t, validator)
+			defer m.Stop(context.Background())
+			require.NoError(
+				t,
+				m.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t)),
+			)
+			hash := m.Transactions()[0].Hash
+
+			rebuildDone := make(chan error, 1)
+			go func() { rebuildDone <- m.rebuildOverlay() }()
+			dingotestutil.RequireReceive(
+				t,
+				validator.started,
+				time.Second,
+				"revalidation start",
+			)
+			removeDone := make(chan struct{}, 1)
+			go func() {
+				test.remove(m, hash)
+				removeDone <- struct{}{}
+			}()
+			dingotestutil.RequireReceive(
+				t,
+				removeDone,
+				time.Second,
+				"concurrent removal",
+			)
+
+			close(validator.release)
+			require.NoError(
+				t,
+				dingotestutil.RequireReceive(
+					t,
+					rebuildDone,
+					time.Second,
+					"rebuild completion",
+				),
+			)
+			assert.Empty(t, m.Transactions())
+			assert.Empty(t, m.overlay.applied)
+		})
+	}
+}
+
+func TestMempool_EvictionIsReconciledDuringRevalidation(t *testing.T) {
+	validator := newBlockingSessionValidator()
+	firstTx := getTestTxBytes(t)
+	secondTx, err := hex.DecodeString(testTxWithValidityStartHex)
+	require.NoError(t, err)
+	totalSize := len(firstTx) + len(secondTx)
+	capacity := int64(float64(totalSize)/0.925) + 1
+	m, err := NewMempool(MempoolConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          validator,
+		MempoolCapacity:    capacity,
+		EvictionWatermark:  0.90,
+		RejectionWatermark: 0.95,
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Start(context.Background()))
+	defer m.Stop(context.Background())
+	require.NoError(t, m.AddTransaction(uint(conway.EraIdConway), firstTx))
+	firstHash := m.Transactions()[0].Hash
+
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- m.rebuildOverlay() }()
+	dingotestutil.RequireReceive(t, validator.started, time.Second, "revalidation start")
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- m.AddTransaction(uint(conway.EraIdConway), secondTx)
+	}()
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(t, addDone, time.Second, "evicting admission"),
+	)
+
+	close(validator.release)
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(t, rebuildDone, time.Second, "rebuild completion"),
+	)
+	txs := m.Transactions()
+	require.Len(t, txs, 1)
+	assert.NotEqual(t, firstHash, txs[0].Hash)
+	require.Len(t, m.overlay.applied, 1)
+	assert.Equal(t, txs[0].Hash, m.overlay.applied[0].hash)
+}
+
+func TestMempool_RevalidationStopsAfterBoundedGenerationRetries(t *testing.T) {
+	validator := &changingSessionValidator{}
+	m := newTestMempoolWithValidator(t, validator)
+	defer m.Stop(context.Background())
+	require.NoError(
+		t,
+		m.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t)),
+	)
+
+	err := m.rebuildOverlay()
+	require.ErrorIs(t, err, errValidationSnapshotChanged)
+	assert.Equal(t, int32(2), validator.sessions.Load())
+	assert.Len(t, m.Transactions(), 1, "failed candidates must not alter live state")
+	assert.Len(t, m.overlay.applied, 1)
+}
+
+func TestMempool_RevalidationJournalOverflowLeavesLiveStateUntouched(
+	t *testing.T,
+) {
+	validator := newBlockingSessionValidator()
+	m := newTestMempoolWithValidator(t, validator)
+	defer m.Stop(context.Background())
+	require.NoError(
+		t,
+		m.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t)),
+	)
+	firstHash := m.Transactions()[0].Hash
+	m.revalidationJournalCap = 1
+
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- m.rebuildOverlay() }()
+	dingotestutil.RequireReceive(t, validator.started, time.Second, "revalidation start")
+	m.RemoveTransaction(firstHash)
+	secondTx, err := hex.DecodeString(testTxWithValidityStartHex)
+	require.NoError(t, err)
+	require.NoError(t, m.AddTransaction(uint(conway.EraIdConway), secondTx))
+
+	close(validator.release)
+	require.ErrorIs(
+		t,
+		dingotestutil.RequireReceive(t, rebuildDone, time.Second, "rebuild completion"),
+		errRevalidationJournalOverflow,
+	)
+	txs := m.Transactions()
+	require.Len(t, txs, 1)
+	assert.NotEqual(t, firstHash, txs[0].Hash)
+	require.Len(t, m.overlay.applied, 1)
+	assert.Equal(t, txs[0].Hash, m.overlay.applied[0].hash)
+}
+
+func TestMempool_StopContinuesDuringRevalidation(t *testing.T) {
+	validator := newBlockingSessionValidator()
+	m := newTestMempoolWithValidator(t, validator)
+	require.NoError(
+		t,
+		m.AddTransaction(uint(conway.EraIdConway), getTestTxBytes(t)),
+	)
+
+	rebuildDone := make(chan error, 1)
+	go func() { rebuildDone <- m.rebuildOverlay() }()
+	dingotestutil.RequireReceive(t, validator.started, time.Second, "revalidation start")
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- m.Stop(context.Background()) }()
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(t, stopDone, time.Second, "mempool stop"),
+	)
+	close(validator.release)
+	require.ErrorIs(
+		t,
+		dingotestutil.RequireReceive(t, rebuildDone, time.Second, "rebuild completion"),
+		ErrMempoolStopped,
+	)
 	assert.Empty(t, m.Transactions())
 }
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -138,12 +138,12 @@ func (v *blockingSessionValidator) WithTxValidationSession(
 		func() bool,
 	) error,
 ) error {
+	v.startOnce.Do(func() { close(v.started) })
 	validate := func(
 		gledger.Transaction,
 		map[string]struct{},
 		map[string]lcommon.Utxo,
 	) error {
-		v.startOnce.Do(func() { close(v.started) })
 		<-v.release
 		return nil
 	}

--- a/mempool/revalidation_benchmark_test.go
+++ b/mempool/revalidation_benchmark_test.go
@@ -15,6 +15,7 @@
 package mempool
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -79,7 +80,7 @@ func BenchmarkFIFOAdmissionNoRevalidation(b *testing.B) {
 	validator := &fifoRevalidationBenchmarkValidator{
 		started: make(chan struct{}),
 	}
-	pool := newFIFORevalidationBenchmarkPool(b, validator)
+	pool, _ := newFIFORevalidationBenchmarkPool(b, validator)
 	generator := &fifoRevalidationTxGenerator{chainGap: 10}
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -110,7 +111,7 @@ func BenchmarkFIFORevalidation(b *testing.B) {
 				validator := &fifoRevalidationBenchmarkValidator{
 					started: make(chan struct{}),
 				}
-				pool := newFIFORevalidationBenchmarkPool(b, validator)
+				pool, cleanup := newFIFORevalidationBenchmarkPool(b, validator)
 				generator := &fifoRevalidationTxGenerator{
 					chainGap: scenario.chainGap,
 				}
@@ -129,7 +130,17 @@ func BenchmarkFIFORevalidation(b *testing.B) {
 				syncStart := time.Now()
 				rebuildDone := make(chan error, 1)
 				go func() { rebuildDone <- pool.rebuildOverlay() }()
-				<-validator.started
+				waitCtx, cancelWait := context.WithTimeout(
+					context.Background(),
+					3*time.Second,
+				)
+				select {
+				case <-validator.started:
+				case <-waitCtx.Done():
+					cancelWait()
+					b.Fatal("timeout waiting for validation session start")
+				}
+				cancelWait()
 
 				admissionStart := time.Now()
 				if err := pool.AddTransaction(
@@ -147,6 +158,8 @@ func BenchmarkFIFORevalidation(b *testing.B) {
 					b.Fatal(err)
 				}
 				syncTotal += time.Since(syncStart)
+				b.StopTimer()
+				cleanup()
 			}
 			b.ReportMetric(
 				float64(admissionTotal.Nanoseconds())/float64(b.N),
@@ -173,19 +186,26 @@ func BenchmarkFIFORevalidation(b *testing.B) {
 func newFIFORevalidationBenchmarkPool(
 	b *testing.B,
 	validator TxValidator,
-) *Mempool {
+) (*Mempool, func()) {
 	b.Helper()
+	eventBus := event.NewEventBus(nil, nil)
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(eventBus.Close)
+	}
+	b.Cleanup(cleanup)
 	pool, err := NewMempool(MempoolConfig{
 		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:        event.NewEventBus(nil, nil),
+		EventBus:        eventBus,
 		PromRegistry:    prometheus.NewRegistry(),
 		Validator:       validator,
 		MempoolCapacity: 1 << 30,
 	})
 	if err != nil {
+		cleanup()
 		b.Fatal(err)
 	}
-	return pool
+	return pool, cleanup
 }
 
 type fifoRevalidationTxGenerator struct {

--- a/mempool/revalidation_benchmark_test.go
+++ b/mempool/revalidation_benchmark_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mempool
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const fifoRevalidationBenchmarkOccupancy = 1_000
+
+type fifoRevalidationBenchmarkValidator struct {
+	delayNS atomic.Int64
+	started chan struct{}
+	once    sync.Once
+}
+
+func (v *fifoRevalidationBenchmarkValidator) ValidateTx(
+	tx gledger.Transaction,
+) error {
+	return v.ValidateTxWithOverlay(tx, nil, nil)
+}
+
+func (v *fifoRevalidationBenchmarkValidator) ValidateTxWithOverlay(
+	gledger.Transaction,
+	map[string]struct{},
+	map[string]lcommon.Utxo,
+) error {
+	if delay := time.Duration(v.delayNS.Load()); delay > 0 {
+		start := time.Now()
+		for time.Since(start) < delay {
+		}
+	}
+	return nil
+}
+
+func (v *fifoRevalidationBenchmarkValidator) WithTxValidationSession(
+	fn func(
+		func(
+			gledger.Transaction,
+			map[string]struct{},
+			map[string]lcommon.Utxo,
+		) error,
+		func() bool,
+	) error,
+) error {
+	v.once.Do(func() { close(v.started) })
+	return fn(v.ValidateTxWithOverlay, func() bool { return true })
+}
+
+func BenchmarkFIFOAdmissionNoRevalidation(b *testing.B) {
+	validator := &fifoRevalidationBenchmarkValidator{
+		started: make(chan struct{}),
+	}
+	pool := newFIFORevalidationBenchmarkPool(b, validator)
+	generator := &fifoRevalidationTxGenerator{chainGap: 10}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		txBytes := generator.next(b)
+		if err := pool.AddTransaction(
+			uint(conway.EraIdConway),
+			txBytes,
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFIFORevalidation(b *testing.B) {
+	for _, scenario := range []struct {
+		name     string
+		chainGap uint64
+	}{
+		{name: "normal", chainGap: 10},
+		{name: "degenerate-deep-chain", chainGap: 1},
+	} {
+		b.Run(scenario.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var admissionTotal, syncTotal, readTotal time.Duration
+			for range b.N {
+				b.StopTimer()
+				validator := &fifoRevalidationBenchmarkValidator{
+					started: make(chan struct{}),
+				}
+				pool := newFIFORevalidationBenchmarkPool(b, validator)
+				generator := &fifoRevalidationTxGenerator{
+					chainGap: scenario.chainGap,
+				}
+				for range fifoRevalidationBenchmarkOccupancy {
+					txBytes := generator.next(b)
+					if err := pool.AddTransaction(
+						uint(conway.EraIdConway),
+						txBytes,
+					); err != nil {
+						b.Fatal(err)
+					}
+				}
+				validator.delayNS.Store(int64(25 * time.Microsecond))
+				b.StartTimer()
+
+				syncStart := time.Now()
+				rebuildDone := make(chan error, 1)
+				go func() { rebuildDone <- pool.rebuildOverlay() }()
+				<-validator.started
+
+				admissionStart := time.Now()
+				if err := pool.AddTransaction(
+					uint(conway.EraIdConway),
+					generator.next(b),
+				); err != nil {
+					b.Fatal(err)
+				}
+				admissionTotal += time.Since(admissionStart)
+
+				readStart := time.Now()
+				_ = pool.Transactions()
+				readTotal += time.Since(readStart)
+				if err := <-rebuildDone; err != nil {
+					b.Fatal(err)
+				}
+				syncTotal += time.Since(syncStart)
+			}
+			b.ReportMetric(
+				float64(admissionTotal.Nanoseconds())/float64(b.N),
+				"admission-ns/avg",
+			)
+			b.ReportMetric(
+				float64(syncTotal.Nanoseconds())/float64(b.N),
+				"sync-ns/avg",
+			)
+			b.ReportMetric(
+				float64(readTotal.Nanoseconds())/float64(b.N),
+				"read-ns/avg",
+			)
+			b.ReportMetric(float64(b.N)/syncTotal.Seconds(), "attempts/s")
+			b.ReportMetric(float64(b.N)/syncTotal.Seconds(), "tx/s")
+			b.ReportMetric(
+				float64(fifoRevalidationBenchmarkOccupancy+1),
+				"txs-final",
+			)
+		})
+	}
+}
+
+func newFIFORevalidationBenchmarkPool(
+	b *testing.B,
+	validator TxValidator,
+) *Mempool {
+	b.Helper()
+	pool, err := NewMempool(MempoolConfig{
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:        event.NewEventBus(nil, nil),
+		PromRegistry:    prometheus.NewRegistry(),
+		Validator:       validator,
+		MempoolCapacity: 1 << 30,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return pool
+}
+
+type fifoRevalidationTxGenerator struct {
+	sequence uint64
+	previous string
+	chainGap uint64
+}
+
+func (g *fifoRevalidationTxGenerator) next(b *testing.B) []byte {
+	b.Helper()
+	inputHash := g.previous
+	if inputHash == "" || g.chainGap == 0 || g.sequence%g.chainGap == 0 {
+		inputHash = fifoRevalidationSeedHash(g.sequence)
+	}
+	template, err := hex.DecodeString(testTxHex)
+	if err != nil {
+		b.Fatal(err)
+	}
+	decoded, err := gledger.NewTransactionFromCbor(
+		uint(conway.EraIdConway),
+		template,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	tx, ok := decoded.(*conway.ConwayTransaction)
+	if !ok {
+		b.Fatalf("transaction template decoded as %T", decoded)
+	}
+	tx.Body.TxInputs.SetItems([]shelley.ShelleyTransactionInput{
+		shelley.NewShelleyTransactionInput(inputHash, 0),
+	})
+	tx.Body.TxFee = 1_000_000 + g.sequence
+	tx.TxIsValid = true
+	tx.Body.SetCbor(nil)
+	tx.SetCbor(nil)
+	txBytes, err := tx.MarshalCBOR()
+	if err != nil {
+		b.Fatal(err)
+	}
+	generated, err := gledger.NewTransactionFromCbor(
+		uint(conway.EraIdConway),
+		txBytes,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	g.previous = generated.Hash().String()
+	g.sequence++
+	return txBytes
+}
+
+func fifoRevalidationSeedHash(sequence uint64) string {
+	var seed [8]byte
+	binary.BigEndian.PutUint64(seed[:], sequence)
+	hash := sha256.Sum256(seed[:])
+	return fmt.Sprintf("%x", hash[:])
+}


### PR DESCRIPTION
Closes #2981 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-buffered FIFO mempool revalidation keeps admissions/removals running during chain updates and swaps a validated candidate atomically, fixing #2981 stalls and lock contention.

- **New Features**
  - Double-buffer rebuild with a private candidate overlay and an ordered mutation journal. Catch-up is bounded by `revalidationDeltaCap` (default 64), and a hard-capped journal aborts safely on overflow. Admissions, confirmations/manual removals, expiry, eviction, and stop continue on the live pool; swap translates consumer cursors and emits removal events for invalids.
  - `LedgerState.WithTxValidationSession` pins era/parameters/slot and a repeatable-read DB txn; candidates are discarded if the ledger generation changed before swap. Introduced `TxValidationSessionProvider` so validators can provide pinned batches; non-session validators still work.
  - `revalidationDeltaCap` added to mempool config with defaults and validation (must be > 0). Provider wiring updated to pass it through. `bench-mempool-revalidation` Make target and microbenchmarks added. Tests cover concurrent add/remove, eviction, journal overflow, shutdown during rebuild, and generation changes.

- **Refactors**
  - Revalidation no longer holds the mutation gate for the full pass; consumers’ cursors are translated on swap. `Transactions()` snapshots under read lock and clones CBOR after unlock to reduce contention. Architecture docs updated with the journaled double-buffer flow and bounded retries.

<sup>Written for commit 21692e4fdf502799c81641aa4c120e31a950e2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Mempool revalidation now runs without blocking transaction admission, removal, eviction, expiry, forging, or relay operations.
  * Revalidation safely reconciles concurrent changes and avoids applying results from outdated ledger states.
  * Added bounded retry and shutdown handling for busy or changing mempools.

* **Configuration**
  * Added a configurable revalidation change limit, defaulting to 64.
  * Invalid non-positive values are now rejected.

* **Benchmarks**
  * Added benchmarks for FIFO admission during normal operation and revalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->