### PR TITLE
fix(bark): verify archive block bytes against the requested point

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2306,11 +2306,19 @@ local blocks expire; `internal/historyexpiry.Pruner` owns that lifecycle when
 Because the archive controls both the download URL and the response body, the
 client re-establishes block identity locally rather than trusting the response.
 Downloaded bytes are decoded with body-hash validation enabled, and the block's
-computed hash and slot must match the point that was requested; the archive's
-own block type is treated as a decode hint, since a wrong type either fails to
-decode or produces a different hash. Block metadata is derived from the decoded
-block, and archive-reported height or previous hash that disagrees with it fails
-the fetch. Both entry points — `GetBlock` and the iterator's expired-history
+computed hash and slot must match the point that was requested.
+
+The block era needs its own check. For Shelley and later the hash covers the
+header alone, and adjacent eras share that header layout, so one set of bytes
+decodes under several eras with an identical hash and slot — the hash cannot
+police the era. The era is therefore derived from the header itself via
+`ledger.DetermineBlockType` and must equal what the archive claimed. Byron is
+exempt because its hash is taken over the block type byte followed by the
+header, so the hash already binds it. An era that cannot be derived at all is
+refused rather than taken on the archive's word.
+
+Block metadata is derived from the decoded block, and archive-reported height
+or previous hash that disagrees with it fails the fetch. Both entry points — `GetBlock` and the iterator's expired-history
 resolution — share this path, so neither is an unchecked route into archive
 data.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2303,6 +2303,17 @@ remote Bark archive and downloading the signed URL. Bark does not decide which
 local blocks expire; `internal/historyexpiry.Pruner` owns that lifecycle when
 `historyExpiry.enabled` is configured.
 
+Because the archive controls both the download URL and the response body, the
+client re-establishes block identity locally rather than trusting the response.
+Downloaded bytes are decoded with body-hash validation enabled, and the block's
+computed hash and slot must match the point that was requested; the archive's
+own block type is treated as a decode hint, since a wrong type either fails to
+decode or produces a different hash. Block metadata is derived from the decoded
+block, and archive-reported height or previous hash that disagrees with it fails
+the fetch. Both entry points — `GetBlock` and the iterator's expired-history
+resolution — share this path, so neither is an unchecked route into archive
+data.
+
 ### Midnight Indexer (`midnight/indexer/`)
 
 An optional block scanner that indexes Midnight chain events into multiple

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2305,8 +2305,19 @@ local blocks expire; `internal/historyexpiry.Pruner` owns that lifecycle when
 
 Because the archive controls both the download URL and the response body, the
 client re-establishes block identity locally rather than trusting the response.
-Downloaded bytes are decoded with body-hash validation enabled, and the block's
+Downloaded bytes are decoded with body validation enabled, and the block's
 computed hash and slot must match the point that was requested.
+
+That binding is complete for every era except Byron main. gouroboros checks a
+Byron main block's transaction, delegation, and update proofs but not
+`ssc_proof`, whose hashes cover cardano-ledger's own encoding of the SSC
+sub-payloads rather than the bytes carried in the block. An alteration confined
+to the SSC payload would therefore leave the hash, slot, height, and previous
+hash — all taken from the untouched header — unchanged. Rather than serve a
+body that is only partly authenticated, Bark refuses Byron main archive reads
+outright; the restriction lifts once Byron SSC proof validation exists
+upstream. Byron epoch boundary blocks are unaffected, carrying neither
+transactions nor an SSC payload, so one body hash covers their whole body.
 
 The block era needs its own check. For Shelley and later the hash covers the
 header alone, and adjacent eras share that header layout, so one set of bytes

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -593,7 +593,13 @@ older than the ledger stability window:
   download URLs before fetching: they must be HTTPS, must not contain embedded
   credentials, and must resolve to the `barkBaseUrl` hostname or a configured
   `barkBlockDownloadHosts` entry; downloads are also size-limited to the archive
-  block response cap.
+  block response cap. Downloaded bytes are then verified locally before any
+  caller sees them: the block is decoded (with body-hash validation enabled) and
+  its computed hash and slot must match the requested point. The returned
+  `types.BlockMetadata` type, height, and previous hash come from the decoded
+  block, and archive-reported height or previous hash that contradicts it is an
+  error rather than an override. The archive is therefore trusted to store block
+  bytes, not to identify them.
 
 ### Block Hash Index Contract
 

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -420,6 +420,33 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 	return blockBody, meta, nil
 }
 
+// Errors reported when an archive response fails local verification. They are
+// distinct from transport failures on purpose: a transport error is worth
+// retrying, whereas these mean the archive served something that is not the
+// block that was asked for, and its answers cannot be trusted as chain data.
+var (
+	// ErrArchiveBlockUndecodable reports an archive response body that does
+	// not decode as a block of the type the archive claimed.
+	ErrArchiveBlockUndecodable = errors.New(
+		"bark: archive block could not be decoded",
+	)
+	// ErrArchiveBlockHashMismatch reports a decoded block whose computed
+	// hash is not the hash that was requested.
+	ErrArchiveBlockHashMismatch = errors.New(
+		"bark: archive block hash does not match the requested hash",
+	)
+	// ErrArchiveBlockSlotMismatch reports a decoded block that does not sit
+	// at the slot that was requested.
+	ErrArchiveBlockSlotMismatch = errors.New(
+		"bark: archive block slot does not match the requested slot",
+	)
+	// ErrArchiveMetadataMismatch reports archive-supplied metadata that
+	// contradicts the contents of the verified block it accompanied.
+	ErrArchiveMetadataMismatch = errors.New(
+		"bark: archive metadata contradicts the block",
+	)
+)
+
 // verifyArchiveBlock establishes locally that the bytes the archive returned
 // really are the block that was requested. Bark chooses both the download URL
 // and the response body, so it can only be trusted to store blocks, not to
@@ -440,19 +467,21 @@ func verifyArchiveBlock(
 	decoded, err := gledger.NewBlockFromCbor(blockType, body)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"bark: decoding archive block for slot %d: %w", slot, err,
+			"%w: slot %d, type %d: %w",
+			ErrArchiveBlockUndecodable, slot, blockType, err,
 		)
 	}
 	decodedHash := decoded.Hash()
 	if !bytes.Equal(decodedHash[:], hash) {
 		return nil, fmt.Errorf(
-			"bark: archive returned block with hash %x for requested hash %x",
-			decodedHash[:], hash,
+			"%w: got %x, requested %x",
+			ErrArchiveBlockHashMismatch, decodedHash[:], hash,
 		)
 	}
 	if decoded.SlotNumber() != slot {
 		return nil, fmt.Errorf(
-			"bark: archive block %x is at slot %d, requested slot %d",
+			"%w: block %x is at slot %d, requested slot %d",
+			ErrArchiveBlockSlotMismatch,
 			decodedHash[:], decoded.SlotNumber(), slot,
 		)
 	}
@@ -475,15 +504,15 @@ func archiveBlockMetadata(
 	height := decoded.BlockNumber()
 	if archiveHeight != 0 && archiveHeight != height {
 		return types.BlockMetadata{}, fmt.Errorf(
-			"bark: archive reported height %d for block at height %d",
-			archiveHeight, height,
+			"%w: reported height %d, block height %d",
+			ErrArchiveMetadataMismatch, archiveHeight, height,
 		)
 	}
 	prevHash := decoded.PrevHash()
 	if len(archivePrevHash) > 0 && !bytes.Equal(archivePrevHash, prevHash[:]) {
 		return types.BlockMetadata{}, fmt.Errorf(
-			"bark: archive reported previous hash %x for block whose previous hash is %x",
-			archivePrevHash, prevHash[:],
+			"%w: reported previous hash %x, block previous hash %x",
+			ErrArchiveMetadataMismatch, archivePrevHash, prevHash[:],
 		)
 	}
 	blockType := decoded.Type()

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -15,6 +15,7 @@
 package bark
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -31,6 +32,7 @@ import (
 	archiveconnect "github.com/blinklabs-io/bark/proto/v1alpha1/archive/archivev1alpha1connect"
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
@@ -296,9 +298,10 @@ func (b *BlobStoreBark) GetBlock(
 		return nil, types.BlockMetadata{}, archErr
 	}
 	// Prefer the local metadata for ID (the archive does not know our
-	// local block IDs), but trust the archive for Type/Height/PrevHash
-	// in case upstream returned a zero metadata struct alongside the
-	// expired-history error.
+	// local block IDs), and fill Type/Height/PrevHash from the archive
+	// result when upstream returned a zero metadata struct alongside the
+	// expired-history error. Those fields are derived from the decoded,
+	// hash-verified block rather than from the archive's own claims.
 	merged := upstreamMeta
 	if merged.Type == 0 {
 		merged.Type = archiveMeta.Type
@@ -389,7 +392,7 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 			fmt.Errorf("bark: archive response exceeds %d-byte limit", maxArchiveBlockSize)
 	}
 
-	prevHash, err := hex.DecodeString(block.GetMeta().GetPrevHash())
+	archivePrevHash, err := hex.DecodeString(block.GetMeta().GetPrevHash())
 	if err != nil {
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("failed decoding previous hash: %w", err)
@@ -401,10 +404,98 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 			fmt.Errorf("invalid block type: %d", blockType)
 	}
 
-	return blockBody, types.BlockMetadata{
+	decoded, err := verifyArchiveBlock(
+		(uint)(blockType), blockBody, slot, hash,
+	)
+	if err != nil {
+		return nil, types.BlockMetadata{}, err
+	}
+	meta, err := archiveBlockMetadata(
+		decoded, block.GetBlock().GetHeight(), archivePrevHash,
+	)
+	if err != nil {
+		return nil, types.BlockMetadata{}, err
+	}
+
+	return blockBody, meta, nil
+}
+
+// verifyArchiveBlock establishes locally that the bytes the archive returned
+// really are the block that was requested. Bark chooses both the download URL
+// and the response body, so it can only be trusted to store blocks, not to
+// identify them: consensus-relevant identity is re-derived here before any
+// caller sees the data.
+//
+// The block type carried in the archive response is a decode hint only. A
+// wrong type either fails to decode or yields a different block hash, and
+// both outcomes are rejected below, so it cannot be used to smuggle in
+// substitute bytes. Decoding runs with validation enabled, so a block whose
+// header is genuine but whose body was swapped fails the body-hash check.
+func verifyArchiveBlock(
+	blockType uint,
+	body []byte,
+	slot uint64,
+	hash []byte,
+) (gledger.Block, error) {
+	decoded, err := gledger.NewBlockFromCbor(blockType, body)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"bark: decoding archive block for slot %d: %w", slot, err,
+		)
+	}
+	decodedHash := decoded.Hash()
+	if !bytes.Equal(decodedHash[:], hash) {
+		return nil, fmt.Errorf(
+			"bark: archive returned block with hash %x for requested hash %x",
+			decodedHash[:], hash,
+		)
+	}
+	if decoded.SlotNumber() != slot {
+		return nil, fmt.Errorf(
+			"bark: archive block %x is at slot %d, requested slot %d",
+			decodedHash[:], decoded.SlotNumber(), slot,
+		)
+	}
+	return decoded, nil
+}
+
+// archiveBlockMetadata derives block metadata from the verified block rather
+// than from what the archive claimed alongside it, and rejects archive-supplied
+// values that contradict the block. The bytes are already hash-verified by this
+// point, so a disagreement means the archive is misreporting; failing is more
+// useful than silently preferring the decoded value and carrying on.
+//
+// Zero-valued archive fields are treated as absent rather than as a conflict:
+// the archive is not required to populate them.
+func archiveBlockMetadata(
+	decoded gledger.Block,
+	archiveHeight uint64,
+	archivePrevHash []byte,
+) (types.BlockMetadata, error) {
+	height := decoded.BlockNumber()
+	if archiveHeight != 0 && archiveHeight != height {
+		return types.BlockMetadata{}, fmt.Errorf(
+			"bark: archive reported height %d for block at height %d",
+			archiveHeight, height,
+		)
+	}
+	prevHash := decoded.PrevHash()
+	if len(archivePrevHash) > 0 && !bytes.Equal(archivePrevHash, prevHash[:]) {
+		return types.BlockMetadata{}, fmt.Errorf(
+			"bark: archive reported previous hash %x for block whose previous hash is %x",
+			archivePrevHash, prevHash[:],
+		)
+	}
+	blockType := decoded.Type()
+	if blockType < 0 {
+		return types.BlockMetadata{}, fmt.Errorf(
+			"bark: decoded block has invalid type %d", blockType,
+		)
+	}
+	return types.BlockMetadata{
 		Type:     (uint)(blockType),
-		Height:   block.GetBlock().GetHeight(),
-		PrevHash: prevHash,
+		Height:   height,
+		PrevHash: prevHash[:],
 	}, nil
 }
 

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -410,8 +410,12 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
+	era, err := blockEraFromHeader(decoded, (uint)(blockType))
+	if err != nil {
+		return nil, types.BlockMetadata{}, err
+	}
 	meta, err := archiveBlockMetadata(
-		decoded, block.GetBlock().GetHeight(), archivePrevHash,
+		decoded, era, block.GetBlock().GetHeight(), archivePrevHash,
 	)
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
@@ -445,7 +449,56 @@ var (
 	ErrArchiveMetadataMismatch = errors.New(
 		"bark: archive metadata contradicts the block",
 	)
+	// ErrArchiveBlockTypeMismatch reports a block whose era, derived from its
+	// own header, is not the era the archive claimed.
+	ErrArchiveBlockTypeMismatch = errors.New(
+		"bark: archive block era does not match the block header",
+	)
 )
+
+// blockEraFromHeader derives a block's era from its own header rather than
+// from the era the archive nominated.
+//
+// This is needed because the hash does not pin the era for Shelley and later:
+// those hashes cover the header alone, and adjacent eras share its layout, so
+// one set of bytes decodes under several eras with an identical hash and slot.
+// Byron is the exception — its hash is taken over the block type byte followed
+// by the header, so the era is already bound by the hash check and there is
+// nothing further to derive.
+func blockEraFromHeader(
+	decoded gledger.Block,
+	claimed uint,
+) (uint, error) {
+	if claimed == gledger.BlockTypeByronEbb ||
+		claimed == gledger.BlockTypeByronMain {
+		return claimed, nil
+	}
+	header := decoded.Header()
+	if header == nil {
+		return 0, fmt.Errorf(
+			"%w: block has no header to derive the era from",
+			ErrArchiveBlockTypeMismatch,
+		)
+	}
+	derived, err := gledger.DetermineBlockType(header.Cbor())
+	if err != nil {
+		// Fail closed. An era that cannot be derived cannot be checked, and
+		// falling back to the archive's claim would hand era selection back to
+		// it. A block this node cannot classify is one it could not process
+		// anyway, so refusing costs nothing it could otherwise have used.
+		return 0, fmt.Errorf(
+			"%w: deriving era from header: %w",
+			ErrArchiveBlockTypeMismatch, err,
+		)
+	}
+	if derived != claimed {
+		return 0, fmt.Errorf(
+			"%w: header is era %d, archive claimed %d",
+			ErrArchiveBlockTypeMismatch, derived, claimed,
+		)
+	}
+	return derived, nil
+}
 
 // verifyArchiveBlock establishes locally that the bytes the archive returned
 // really are the block that was requested. Bark chooses both the download URL
@@ -498,6 +551,7 @@ func verifyArchiveBlock(
 // the archive is not required to populate them.
 func archiveBlockMetadata(
 	decoded gledger.Block,
+	era uint,
 	archiveHeight uint64,
 	archivePrevHash []byte,
 ) (types.BlockMetadata, error) {
@@ -515,14 +569,8 @@ func archiveBlockMetadata(
 			ErrArchiveMetadataMismatch, archivePrevHash, prevHash[:],
 		)
 	}
-	blockType := decoded.Type()
-	if blockType < 0 {
-		return types.BlockMetadata{}, fmt.Errorf(
-			"bark: decoded block has invalid type %d", blockType,
-		)
-	}
 	return types.BlockMetadata{
-		Type:     (uint)(blockType),
+		Type:     era,
 		Height:   height,
 		PrevHash: prevHash[:],
 	}, nil

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -414,6 +414,9 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
+	if err := assertBodyFullyAuthenticated(era); err != nil {
+		return nil, types.BlockMetadata{}, err
+	}
 	meta, err := archiveBlockMetadata(
 		decoded, era, block.GetBlock().GetHeight(), archivePrevHash,
 	)
@@ -454,7 +457,39 @@ var (
 	ErrArchiveBlockTypeMismatch = errors.New(
 		"bark: archive block era does not match the block header",
 	)
+	// ErrArchiveBlockNotFullyAuthenticated reports a block whose body cannot
+	// be bound to its header in full, so the archive could alter the
+	// unauthenticated part without changing anything checked here.
+	ErrArchiveBlockNotFullyAuthenticated = errors.New(
+		"bark: archive block body cannot be fully authenticated",
+	)
 )
+
+// assertBodyFullyAuthenticated refuses blocks whose body is only partly bound
+// to their header.
+//
+// Byron main blocks are the sole case. gouroboros checks their transaction,
+// delegation, and update proofs but not ssc_proof, because the SSC proof
+// hashes cardano-ledger's own encoding of the sub-payloads rather than the
+// bytes carried in the block. An alteration confined to the SSC payload
+// therefore changes nothing this package verifies — hash, slot, height, and
+// previous hash all come from the untouched header — so the archive could
+// still substitute part of a historical block.
+//
+// Epoch boundary blocks are unaffected: they carry no transactions and no SSC
+// payload, and a single body hash covers the whole body.
+//
+// This restriction can be lifted once Byron SSC proof validation exists
+// upstream.
+func assertBodyFullyAuthenticated(blockType uint) error {
+	if blockType == gledger.BlockTypeByronMain {
+		return fmt.Errorf(
+			"%w: byron main block ssc payload is unverified",
+			ErrArchiveBlockNotFullyAuthenticated,
+		)
+	}
+	return nil
+}
 
 // blockEraFromHeader derives a block's era from its own header rather than
 // from the era the archive nominated.

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -398,6 +398,120 @@ func TestGetBlock_AcceptsVerifiedArchiveBlock(t *testing.T) {
 	}
 }
 
+// realEraBlock loads a block produced by the reference implementation for the
+// named era fixture, returning its CBOR and true block type. Generated blocks
+// are no use here: cross-era decoding has to be exercised against bytes whose
+// header layout is genuinely shared between eras.
+func realEraBlock(t *testing.T, name string) ([]byte, uint) {
+	t.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(t.TempDir())
+	require.NoError(t, err)
+	f, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/"+name,
+	)
+	require.NoError(t, err)
+	raw, err := f.ConsensusLedgerBlockBytes()
+	require.NoError(t, err)
+	blockType, err := f.LedgerBlockType()
+	require.NoError(t, err)
+	return raw, blockType
+}
+
+// TestGetBlock_RejectsArchiveBlockTypeMismatch covers an archive that serves
+// genuine block bytes while misreporting their era.
+//
+// The block hash for Shelley and later is taken over the header alone, and
+// adjacent eras share that header layout, so the same bytes decode under more
+// than one era with an identical hash and slot. The hash check therefore
+// cannot police the era, and without an independent derivation the archive
+// would dictate BlockMetadata.Type.
+func TestGetBlock_RejectsArchiveBlockTypeMismatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		claimed  archive.BlockType
+		claimedN uint
+	}{
+		{
+			name:     "babbage served as conway",
+			fixture:  "Block_Babbage",
+			claimed:  archive.BlockType_BLOCK_TYPE_CONWAY,
+			claimedN: gledger.BlockTypeConway,
+		},
+		{
+			name:     "shelley served as mary",
+			fixture:  "Block_Shelley",
+			claimed:  archive.BlockType_BLOCK_TYPE_MARY,
+			claimedN: gledger.BlockTypeMary,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, trueType := realEraBlock(t, tc.fixture)
+			require.NotEqual(t, trueType, tc.claimedN,
+				"fixture era must differ from the claimed era")
+
+			// The misreported era must still decode, otherwise the test
+			// would pass for the wrong reason.
+			decoded, err := gledger.NewBlockFromCbor(tc.claimedN, raw)
+			require.NoError(t, err,
+				"cross-era decode must succeed for this test to be meaningful")
+			hash := decoded.Hash()
+
+			db := newTestDB(t)
+			baseURL, fakeArch, httpClient := startFakeArchive(
+				t, map[string][]byte{hex.EncodeToString(hash[:]): raw},
+			)
+			fakeArch.blockType = tc.claimed
+			fakeArch.height = decoded.BlockNumber()
+			prevHash := decoded.PrevHash()
+			fakeArch.prevHash = prevHash[:]
+
+			store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+			rTxn := store.NewTransaction(false)
+			t.Cleanup(func() { _ = rTxn.Rollback() })
+
+			_, _, err = store.GetBlock(rTxn, decoded.SlotNumber(), hash[:])
+			require.ErrorIs(t, err, ErrArchiveBlockTypeMismatch)
+		})
+	}
+}
+
+// TestGetBlock_RejectsUnclassifiableEra pins the fail-closed behaviour when a
+// block's era cannot be derived from its header.
+//
+// The consensus golden fixtures carry synthetic protocol versions that
+// DetermineBlockType does not map, which stands in for a block from an era
+// this node does not know. Trusting the archive's claim in that case would
+// hand era selection straight back to it, so the fetch is refused. A node that
+// cannot classify a block could not process it anyway.
+func TestGetBlock_RejectsUnclassifiableEra(t *testing.T) {
+	raw, trueType := realEraBlock(t, "Block_Babbage")
+	decoded, err := gledger.NewBlockFromCbor(trueType, raw)
+	require.NoError(t, err)
+	hash := decoded.Hash()
+
+	db := newTestDB(t)
+	baseURL, fakeArch, httpClient := startFakeArchive(
+		t, map[string][]byte{hex.EncodeToString(hash[:]): raw},
+	)
+	fakeArch.blockType = archive.BlockType(trueType) //nolint:gosec // fixture-derived era
+	fakeArch.height = decoded.BlockNumber()
+	prevHash := decoded.PrevHash()
+	fakeArch.prevHash = prevHash[:]
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	// Even though the archive reported the fixture's own era, the era cannot
+	// be confirmed from the header, so the block is not accepted.
+	_, _, err = store.GetBlock(rTxn, decoded.SlotNumber(), hash[:])
+	require.ErrorIs(t, err, ErrArchiveBlockTypeMismatch)
+}
+
 // TestGetBlock_RejectsArchiveBlockForDifferentPoint is the core regression for
 // the finding: the archive is asked for one block and answers with a
 // different, individually valid block. The substituted block must not reach

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -479,6 +479,70 @@ func TestGetBlock_RejectsArchiveBlockTypeMismatch(t *testing.T) {
 	}
 }
 
+// TestGetBlock_RejectsByronMainArchiveBlock covers the one era whose body
+// cannot be fully bound to its header.
+//
+// gouroboros validates a Byron main block's transaction, delegation, and
+// update proofs but not ssc_proof, so an alteration confined to the SSC
+// payload changes no value this package checks: the hash, slot, height, and
+// previous hash all come from the untouched header. Rather than serve bytes
+// whose body is only partly authenticated, the fetch is refused.
+func TestGetBlock_RejectsByronMainArchiveBlock(t *testing.T) {
+	raw, trueType := realEraBlock(t, "Block_Byron_regular")
+	require.Equal(t, uint(gledger.BlockTypeByronMain), trueType,
+		"fixture must be a Byron main block")
+	decoded, err := gledger.NewBlockFromCbor(trueType, raw)
+	require.NoError(t, err)
+	hash := decoded.Hash()
+
+	db := newTestDB(t)
+	baseURL, fakeArch, httpClient := startFakeArchive(
+		t, map[string][]byte{hex.EncodeToString(hash[:]): raw},
+	)
+	fakeArch.blockType = archive.BlockType_BLOCK_TYPE_BYRON_MAIN
+	fakeArch.height = decoded.BlockNumber()
+	prevHash := decoded.PrevHash()
+	fakeArch.prevHash = prevHash[:]
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err = store.GetBlock(rTxn, decoded.SlotNumber(), hash[:])
+	require.ErrorIs(t, err, ErrArchiveBlockNotFullyAuthenticated)
+}
+
+// TestGetBlock_AcceptsByronEpochBoundaryArchiveBlock is the boundary of that
+// restriction. An epoch boundary block carries no transactions and no SSC
+// payload, so a single body hash covers the whole body and the block is fully
+// bound to its header. Refusing it too would give up history for no gain.
+func TestGetBlock_AcceptsByronEpochBoundaryArchiveBlock(t *testing.T) {
+	raw, trueType := realEraBlock(t, "Block_Byron_EBB")
+	require.Equal(t, uint(gledger.BlockTypeByronEbb), trueType,
+		"fixture must be a Byron epoch boundary block")
+	decoded, err := gledger.NewBlockFromCbor(trueType, raw)
+	require.NoError(t, err)
+	hash := decoded.Hash()
+
+	db := newTestDB(t)
+	baseURL, fakeArch, httpClient := startFakeArchive(
+		t, map[string][]byte{hex.EncodeToString(hash[:]): raw},
+	)
+	fakeArch.blockType = archive.BlockType_BLOCK_TYPE_BYRON_EBB_UNSPECIFIED
+	fakeArch.height = decoded.BlockNumber()
+	prevHash := decoded.PrevHash()
+	fakeArch.prevHash = prevHash[:]
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	cbor, meta, err := store.GetBlock(rTxn, decoded.SlotNumber(), hash[:])
+	require.NoError(t, err)
+	assert.Equal(t, raw, cbor)
+	assert.Equal(t, uint(gledger.BlockTypeByronEbb), meta.Type)
+}
+
 // TestGetBlock_RejectsUnclassifiableEra pins the fail-closed behaviour when a
 // block's era cannot be derived from its header.
 //

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -30,21 +30,29 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // fakeArchive serves FetchBlock responses pointing at downloadURL, where
 // downloadURL replies with the configured CBOR bytes per (slot, hash).
+//
+// substituteBody models a misbehaving or hostile archive: when set, the
+// download endpoint serves those bytes for every request regardless of which
+// block was actually asked for.
 type fakeArchive struct {
-	t           *testing.T
-	downloadURL string
-	blocks      map[string][]byte // hex(hash) -> CBOR bytes
-	prevHash    []byte
-	height      uint64
-	blockType   archive.BlockType
-	redirectURL string
-	oversize    bool
+	t              *testing.T
+	downloadURL    string
+	blocks         map[string][]byte // hex(hash) -> CBOR bytes
+	prevHash       []byte
+	height         uint64
+	blockType      archive.BlockType
+	redirectURL    string
+	oversize       bool
+	substituteBody []byte
 
 	fetchCalls int
 }
@@ -103,6 +111,11 @@ func startFakeArchive(
 			if a.oversize {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(bytes.Repeat([]byte{0xFF}, maxArchiveBlockSize+1))
+				return
+			}
+			if a.substituteBody != nil {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(a.substituteBody)
 				return
 			}
 			hashHex := r.URL.Query().Get("hash")
@@ -293,21 +306,287 @@ func TestGetBlock_CapsResponseSize(t *testing.T) {
 	assert.Contains(t, err.Error(), "limit")
 }
 
+// archiveBlockFixtures returns count real Conway blocks whose CBOR
+// round-trips through ledger.NewBlockFromCbor, so Hash(), SlotNumber(),
+// BlockNumber(), and PrevHash() are internally consistent with the bytes.
+// That consistency is precisely what the archive verification path checks,
+// so hand-rolled CBOR would not exercise it.
+func archiveBlockFixtures(t *testing.T, count int) []gledger.Block {
+	t.Helper()
+	blocks, err := fixtures.GenerateConwayChain(
+		1,                    // startBlockNumber
+		lcommon.Blake2b256{}, // prevHash of the first block
+		1000,                 // startSlot
+		10,                   // slotIncrement
+		count,
+	)
+	require.NoError(t, err)
+	require.Len(t, blocks, count)
+	return blocks
+}
+
+// serveArchiveBlock points the fake archive at a real block: it serves the
+// block's CBOR and reports metadata consistent with the block contents.
+func serveArchiveBlock(
+	t *testing.T, block gledger.Block,
+) (map[string][]byte, func(*fakeArchive)) {
+	t.Helper()
+	hash := block.Hash()
+	prevHash := block.PrevHash()
+	return map[string][]byte{
+			hex.EncodeToString(hash[:]): block.Cbor(),
+		}, func(a *fakeArchive) {
+			a.height = block.BlockNumber()
+			a.prevHash = prevHash[:]
+			a.blockType = archive.BlockType_BLOCK_TYPE_CONWAY
+		}
+}
+
+// TestGetBlock_AcceptsVerifiedArchiveBlock is the happy path: an archive that
+// serves the block that was actually requested is accepted, and the returned
+// metadata is derived from the decoded block.
+//
+// The "archive omits metadata" case is what proves the derivation: with the
+// archive reporting nothing, correct height and previous hash can only have
+// come from decoding the block bytes.
+func TestGetBlock_AcceptsVerifiedArchiveBlock(t *testing.T) {
+	// Use the second block so PrevHash is a real hash rather than zeroes.
+	block := archiveBlockFixtures(t, 2)[1]
+	hash := block.Hash()
+	prevHash := block.PrevHash()
+
+	tests := []struct {
+		name   string
+		mutate func(*fakeArchive)
+	}{
+		{
+			name:   "archive reports consistent metadata",
+			mutate: func(*fakeArchive) {},
+		},
+		{
+			name: "archive omits metadata",
+			mutate: func(a *fakeArchive) {
+				a.height = 0
+				a.prevHash = nil
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			blocks, configure := serveArchiveBlock(t, block)
+			baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+			configure(fakeArch)
+			tc.mutate(fakeArch)
+
+			store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+			rTxn := store.NewTransaction(false)
+			t.Cleanup(func() { _ = rTxn.Rollback() })
+
+			cbor, meta, err := store.GetBlock(
+				rTxn, block.SlotNumber(), hash[:],
+			)
+			require.NoError(t, err)
+			assert.Equal(t, block.Cbor(), cbor)
+			assert.Equal(t, uint(gledger.BlockTypeConway), meta.Type,
+				"type must come from the decoded block")
+			assert.Equal(t, block.BlockNumber(), meta.Height,
+				"height must come from the decoded block")
+			assert.Equal(t, prevHash[:], meta.PrevHash,
+				"previous hash must come from the decoded block")
+		})
+	}
+}
+
+// TestGetBlock_RejectsArchiveBlockForDifferentPoint is the core regression for
+// the finding: the archive is asked for one block and answers with a
+// different, individually valid block. The substituted block must not reach
+// the caller.
+func TestGetBlock_RejectsArchiveBlockForDifferentPoint(t *testing.T) {
+	db := newTestDB(t)
+	chain := archiveBlockFixtures(t, 2)
+	requested, substituted := chain[0], chain[1]
+
+	blocks, configure := serveArchiveBlock(t, requested)
+	baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+	configure(fakeArch)
+	fakeArch.substituteBody = substituted.Cbor()
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	requestedHash := requested.Hash()
+	_, _, err := store.GetBlock(
+		rTxn, requested.SlotNumber(), requestedHash[:],
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hash")
+}
+
+// TestGetBlock_RejectsUndecodableArchiveBlock covers an archive response that
+// is not a well-formed block at all.
+func TestGetBlock_RejectsUndecodableArchiveBlock(t *testing.T) {
+	db := newTestDB(t)
+	block := archiveBlockFixtures(t, 1)[0]
+
+	blocks, configure := serveArchiveBlock(t, block)
+	baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+	configure(fakeArch)
+	fakeArch.substituteBody = []byte("not-a-block")
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	hash := block.Hash()
+	_, _, err := store.GetBlock(rTxn, block.SlotNumber(), hash[:])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decod")
+}
+
+// TestGetBlock_RejectsArchiveBlockSlotMismatch covers a block whose bytes are
+// genuine but which does not sit at the slot the caller asked about.
+func TestGetBlock_RejectsArchiveBlockSlotMismatch(t *testing.T) {
+	db := newTestDB(t)
+	block := archiveBlockFixtures(t, 1)[0]
+
+	blocks, configure := serveArchiveBlock(t, block)
+	baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+	configure(fakeArch)
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	hash := block.Hash()
+	_, _, err := store.GetBlock(rTxn, block.SlotNumber()+1, hash[:])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slot")
+}
+
+// TestGetBlock_RejectsArchiveMetadataMismatch covers Bark-supplied metadata
+// that contradicts the block it accompanies. The block bytes verify, so the
+// disagreement means the archive is misreporting and must not be trusted.
+func TestGetBlock_RejectsArchiveMetadataMismatch(t *testing.T) {
+	block := archiveBlockFixtures(t, 2)[1]
+	hash := block.Hash()
+
+	tests := []struct {
+		name    string
+		mutate  func(*fakeArchive)
+		wantErr string
+	}{
+		{
+			name:    "height disagrees with block",
+			mutate:  func(a *fakeArchive) { a.height = block.BlockNumber() + 7 },
+			wantErr: "height",
+		},
+		{
+			name: "previous hash disagrees with block",
+			mutate: func(a *fakeArchive) {
+				a.prevHash = bytes.Repeat([]byte{0x99}, 32)
+			},
+			wantErr: "previous hash",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			blocks, configure := serveArchiveBlock(t, block)
+			baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+			configure(fakeArch)
+			tc.mutate(fakeArch)
+
+			store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+			rTxn := store.NewTransaction(false)
+			t.Cleanup(func() { _ = rTxn.Rollback() })
+
+			_, _, err := store.GetBlock(rTxn, block.SlotNumber(), hash[:])
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestBarkIterator_RejectsArchiveBlockForDifferentPoint proves the iterator's
+// expired-history resolution is covered by the same verification as GetBlock,
+// rather than being a second, unchecked way into archive data.
+func TestBarkIterator_RejectsArchiveBlockForDifferentPoint(t *testing.T) {
+	db := newTestDB(t)
+	chain := archiveBlockFixtures(t, 2)
+	requested, substituted := chain[0], chain[1]
+	hash := requested.Hash()
+
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot: requested.SlotNumber(),
+		Hash: hash[:],
+		Cbor: requested.Cbor(),
+		Type: gledger.BlockTypeConway,
+	}, nil))
+
+	wTxn := db.BlobTxn(true)
+	require.NoError(t, wTxn.Do(func(txn *database.Txn) error {
+		return db.Blob().TombstoneBlock(
+			txn.Blob(), requested.SlotNumber(), hash[:],
+		)
+	}))
+
+	blocks, configure := serveArchiveBlock(t, requested)
+	baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+	configure(fakeArch)
+	fakeArch.substituteBody = substituted.Cbor()
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	it := store.NewIterator(rTxn, types.BlobIteratorOptions{
+		Prefix: []byte(types.BlockBlobKeyPrefix),
+	})
+	require.NotNil(t, it)
+	t.Cleanup(it.Close)
+
+	var sawExpired bool
+	for it.Seek([]byte(types.BlockBlobKeyPrefix)); it.ValidForPrefix(
+		[]byte(types.BlockBlobKeyPrefix),
+	); it.Next() {
+		item := it.Item()
+		require.NotNil(t, item)
+		if bytes.HasSuffix(
+			item.Key(), []byte(types.BlockBlobMetadataKeySuffix),
+		) {
+			continue
+		}
+		sawExpired = true
+		_, err := item.ValueCopy(nil)
+		require.Error(t, err,
+			"iterator must not surface a block the archive substituted")
+		assert.Contains(t, err.Error(), "hash")
+	}
+	require.NoError(t, it.Err())
+	require.True(t, sawExpired, "iterator did not visit the bp key")
+}
+
 // TestBarkIterator_ResolvesExpiredHistoryViaArchive seeds the database with a
 // block, marks it expired locally, then iterates through the bark wrapper.
 // ValueCopy must surface the archive's CBOR, not the local expiry marker.
 func TestBarkIterator_ResolvesExpiredHistoryViaArchive(t *testing.T) {
 	db := newTestDB(t)
 
-	const slot uint64 = 100
-	hash := bytes.Repeat([]byte{0xAB}, 32)
-	cbor := []byte("real-block-cbor-from-archive")
+	// A real block: the archive-resolved bytes are hash-verified against the
+	// requested point, so fabricated CBOR would be rejected on arrival.
+	block := archiveBlockFixtures(t, 2)[1]
+	blockHash := block.Hash()
+	slot := block.SlotNumber()
+	hash := blockHash[:]
+	cbor := block.Cbor()
 
 	require.NoError(t, db.BlockCreate(models.Block{
 		Slot: slot,
 		Hash: hash,
-		Cbor: []byte("local-cbor"),
-		Type: 1,
+		Cbor: cbor,
+		Type: gledger.BlockTypeConway,
 	}, nil))
 
 	wTxn := db.BlobTxn(true)
@@ -315,9 +594,9 @@ func TestBarkIterator_ResolvesExpiredHistoryViaArchive(t *testing.T) {
 		return db.Blob().TombstoneBlock(txn.Blob(), slot, hash)
 	}))
 
-	baseURL, archiveSrv, httpClient := startFakeArchive(t, map[string][]byte{
-		hex.EncodeToString(hash): cbor,
-	})
+	blocks, configure := serveArchiveBlock(t, block)
+	baseURL, archiveSrv, httpClient := startFakeArchive(t, blocks)
+	configure(archiveSrv)
 	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
 
 	rTxn := store.NewTransaction(false)

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -420,8 +420,7 @@ func TestGetBlock_RejectsArchiveBlockForDifferentPoint(t *testing.T) {
 	_, _, err := store.GetBlock(
 		rTxn, requested.SlotNumber(), requestedHash[:],
 	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "hash")
+	require.ErrorIs(t, err, ErrArchiveBlockHashMismatch)
 }
 
 // TestGetBlock_RejectsUndecodableArchiveBlock covers an archive response that
@@ -441,8 +440,7 @@ func TestGetBlock_RejectsUndecodableArchiveBlock(t *testing.T) {
 
 	hash := block.Hash()
 	_, _, err := store.GetBlock(rTxn, block.SlotNumber(), hash[:])
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "decod")
+	require.ErrorIs(t, err, ErrArchiveBlockUndecodable)
 }
 
 // TestGetBlock_RejectsArchiveBlockSlotMismatch covers a block whose bytes are
@@ -461,8 +459,7 @@ func TestGetBlock_RejectsArchiveBlockSlotMismatch(t *testing.T) {
 
 	hash := block.Hash()
 	_, _, err := store.GetBlock(rTxn, block.SlotNumber()+1, hash[:])
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "slot")
+	require.ErrorIs(t, err, ErrArchiveBlockSlotMismatch)
 }
 
 // TestGetBlock_RejectsArchiveMetadataMismatch covers Bark-supplied metadata
@@ -503,7 +500,9 @@ func TestGetBlock_RejectsArchiveMetadataMismatch(t *testing.T) {
 			t.Cleanup(func() { _ = rTxn.Rollback() })
 
 			_, _, err := store.GetBlock(rTxn, block.SlotNumber(), hash[:])
-			require.Error(t, err)
+			require.ErrorIs(t, err, ErrArchiveMetadataMismatch)
+			// The sentinel pins the code path; the detail distinguishes
+			// which field disagreed.
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
@@ -560,9 +559,8 @@ func TestBarkIterator_RejectsArchiveBlockForDifferentPoint(t *testing.T) {
 		}
 		sawExpired = true
 		_, err := item.ValueCopy(nil)
-		require.Error(t, err,
+		require.ErrorIs(t, err, ErrArchiveBlockHashMismatch,
 			"iterator must not surface a block the archive substituted")
-		assert.Contains(t, err.Error(), "hash")
 	}
 	require.NoError(t, it.Err())
 	require.True(t, sawExpired, "iterator did not visit the bp key")

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.27.4
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.189.4
+	github.com/blinklabs-io/gouroboros v0.190.0
 	github.com/blinklabs-io/ouroboros-mock v0.15.0
 	github.com/blinklabs-io/plutigo v0.1.17
 	github.com/blockfrost/blockfrost-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yU
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.189.4 h1:9zW9iu+7c/Xou9jH9VoC71CZ9IdvcHvbf4u58u6tnzU=
 github.com/blinklabs-io/gouroboros v0.189.4/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
+github.com/blinklabs-io/gouroboros v0.190.0 h1:Yl+32qXBktWlCrtLMqK2o48au8XQ3wk9GWNSxsW90vs=
+github.com/blinklabs-io/gouroboros v0.190.0/go.mod h1:n1NCfwdivyiavSvEa+hZoNWWSUNc3m6Lqw4WH16GQbQ=
 github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=

--- a/ledger/leader/schedule.go
+++ b/ledger/leader/schedule.go
@@ -244,12 +244,15 @@ func (c *Calculator) CalculateSchedule(
 	// for the epoch — so computing it inside the per-slot loop (which
 	// is what IsSlotLeaderWithMode does) wastes two 20-term big.Rat
 	// Taylor series and a 2^N multiply per slot.
-	threshold := consensus.CertifiedNatThresholdWithMode(
+	threshold, err := consensus.CertifiedNatThresholdWithMode(
 		poolStake,
 		totalStake,
 		activeSlotCoeff,
 		mode,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("compute leadership threshold: %w", err)
+	}
 
 	for slot := epochStartSlot; slot < epochEndSlot; slot++ {
 		vrfInput, err := vrfInputForMode(mode, slot, epochNonce)
@@ -260,11 +263,15 @@ func (c *Calculator) CalculateSchedule(
 		if err != nil {
 			return nil, fmt.Errorf("check slot %d: %w", slot, err)
 		}
-		if consensus.IsVRFOutputBelowThresholdWithMode(
+		belowThreshold, err := consensus.IsVRFOutputBelowThresholdWithMode(
 			output,
 			threshold,
 			mode,
-		) {
+		)
+		if err != nil {
+			return nil, fmt.Errorf("check slot %d: %w", slot, err)
+		}
+		if belowThreshold {
 			schedule.AddLeaderSlot(slot)
 		}
 	}

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -787,17 +787,34 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 	}
 
 	// Compute the Praos leadership threshold and compare.
-	threshold := consensus.CertifiedNatThresholdWithMode(
+	threshold, err := consensus.CertifiedNatThresholdWithMode(
 		poolStake,
 		totalStake,
 		activeSlotCoeffRat,
 		mode,
 	)
-	if !consensus.IsVRFOutputBelowThresholdWithMode(
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"compute leadership threshold: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	belowThreshold, err := consensus.IsVRFOutputBelowThresholdWithMode(
 		vrfResult.Output,
 		threshold,
 		mode,
-	) {
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"compare VRF output against threshold: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	if !belowThreshold {
 		// dingo's leadership stake is delegated UTxO only; staking rewards are
 		// not yet computed, so reward-account balances are missing from the
 		// stake distribution. On the prototype network the dominant pool's


### PR DESCRIPTION
Closes #2038 (DSA-2026-04-24-02, HIGH).

## Problem

The Bark archive fallback requested a specific `(slot, hash)` but returned the downloaded body without checking it was that block. `GetBlock` then explicitly commented that it trusted the archive for `Type`/`Height`/`PrevHash`, taken straight off `block.GetMeta()`.

A misbehaving or hostile archive controls both the download URL and the response body, so it could substitute any block — or misreport height and previous hash — and the bytes would reach callers as historical chain data. The existing URL/redirect/size checks constrain *where* bytes come from, but nothing established *what* they were.

## Change

Verification lives in `fetchBlockFromArchive`, so `GetBlock` and the iterator's expired-history resolution (`ValueCopy`) are both covered by one path rather than one being an unchecked route into archive data.

- Decode the downloaded body and require the computed block hash **and** slot to match the requested point.
- The archive's block type is now only a decode hint: a wrong type either fails to decode or yields a different hash, and both are rejected, so it cannot be used to smuggle in substitute bytes.
- Decoding runs with body-hash validation enabled, so a genuine header with a swapped body is caught too. This matches how blocks arriving over the network are already treated (`ouroboros/blockfetch.go`).
- Block metadata is derived from the decoded block. Archive-reported height or previous hash that contradicts it fails the fetch rather than being silently overridden; zero-valued archive fields are treated as absent, not as a conflict.

The archive remains a storage delegate — trusted to hold block bytes, not to identify them.

## Tests

Written first, and each was confirmed to fail against pre-fix code by reverting the implementation and re-running:

| Test | Covers |
|---|---|
| `TestGetBlock_RejectsArchiveBlockForDifferentPoint` | the finding — a valid but wrong block substituted for a valid requested point |
| `TestBarkIterator_RejectsArchiveBlockForDifferentPoint` | same, via the iterator path |
| `TestGetBlock_RejectsUndecodableArchiveBlock` | body that is not a block |
| `TestGetBlock_RejectsArchiveBlockSlotMismatch` | genuine block, wrong slot |
| `TestGetBlock_RejectsArchiveMetadataMismatch` | height / previous-hash disagreement |
| `TestGetBlock_AcceptsVerifiedArchiveBlock` | happy path, including an "archive omits metadata" case proving metadata is derived from the decoded block |

Fixtures come from `ouroboros-mock`'s `fixtures.GenerateConwayChain` rather than local mocks, per the repo's fixture policy — real blocks whose CBOR round-trips with consistent `Hash()`/`SlotNumber()`/`BlockNumber()`/`PrevHash()`, which is what the verification actually checks. `TestBarkIterator_ResolvesExpiredHistoryViaArchive` previously used fabricated CBOR at a made-up hash and now uses a real block; it would otherwise have failed correctly under the new check.

## Verification

- `go test -race ./bark/... ./database/...` — pass
- `internal/test/conformance` — pass
- `golangci-lint run ./bark/...` (0 issues), `modernize`, `make import-boundaries` — clean

## Documentation

Both updated — each already enumerated Bark's archive validation rules and was stale without the identity check:

- `DATABASE.md` — history-expiry / Bark fallback section
- `ARCHITECTURE.md` — `### Bark (bark/)`

DevNet was assessed and not run: this is the archive fallback read path for historical blocks, not consensus, block production, chain selection, or the protocol surfaces that trigger a DevNet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `bark` archive fallback by locally verifying block bytes against the requested hash and slot, deriving metadata from the decoded block, and refusing Byron main archive reads where the body cannot be fully authenticated. Both `GetBlock` and iterator fallbacks use the same verified path, with sentinel errors to distinguish verification failures.

- **Bug Fixes**
  - Decode with validation and require hash+slot match; reject undecodable, mismatched-hash, or wrong-slot blocks.
  - Derive the era from the header via `ledger.DetermineBlockType`; require it matches the archive claim; reject unclassifiable eras. Byron hashes already bind era.
  - Refuse Byron main archive reads until SSC proofs are verified upstream; Byron EBBs are allowed.
  - Build `types.BlockMetadata` (type/height/prev-hash) from the decoded block; reject archive-reported conflicts; treat zero values as absent.
  - Export sentinel errors for archive verification failures.

- **Dependencies**
  - Bump `github.com/blinklabs-io/gouroboros` to v0.190.0 (includes Byron body proof validation used by archive verification).
  - Propagate error returns from `CertifiedNatThresholdWithMode` and `IsVRFOutputBelowThresholdWithMode` in `ledger` schedule and header verification.

<sup>Written for commit eec3a7d8792238308061139d7bab83ba2723eb40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Archive-sourced blocks are now cryptographically verified before being returned.
  * Block identity, slot, height, and previous-hash metadata are cross-checked for consistency.
  * Invalid, altered, undecodable, or mismatched archive responses are rejected.
  * Expired-history lookups use the same verification safeguards as direct block retrieval.

* **Documentation**
  * Updated architecture and database documentation to describe archive validation and trust boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->