### PR TITLE
perf(database): pool delegation fetch

### DIFF
--- a/database/plugin/metadata/sqlite/account.go
+++ b/database/plugin/metadata/sqlite/account.go
@@ -224,6 +224,81 @@ func batchFetchCerts(
 	return cache, nil
 }
 
+// batchFetchPoolDelegations fetches only certificate types that can update a
+// credential's pool delegation. Reward-live-stake refreshes do not consume
+// registration, deregistration, or DRep-only state, so using batchFetchCerts
+// there would execute six additional windowed queries whose results are
+// discarded.
+func batchFetchPoolDelegations(
+	db *gorm.DB,
+	refs []models.StakeCredentialRef,
+	slot uint64,
+) (*accountCertCache, error) {
+	cache := newAccountCertCache(len(refs))
+
+	// The SQL IN clause filters by staking-key hash. Keep the composite
+	// credential keys so results for an unrequested credential variant can be
+	// removed after the queries.
+	requested := make(map[string]struct{}, len(refs))
+	seenHash := make(map[string]struct{}, len(refs))
+	var stakingKeys [][]byte
+	for _, ref := range refs {
+		requested[accountCertCacheKey(ref.Tag, ref.Key)] = struct{}{}
+		h := string(ref.Key)
+		if _, ok := seenHash[h]; !ok {
+			seenHash[h] = struct{}{}
+			stakingKeys = append(stakingKeys, ref.Key)
+		}
+	}
+
+	if len(stakingKeys) == 0 {
+		return cache, nil
+	}
+
+	for keyChunk := range slices.Chunk(stakingKeys, sqliteBindVarLimit) {
+		if err := batchFetchStakeRegistrationDelegation(
+			db,
+			keyChunk,
+			slot,
+			cache,
+		); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeVoteRegistrationDelegation(
+			db,
+			keyChunk,
+			slot,
+			cache,
+		); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeDelegation(
+			db,
+			keyChunk,
+			slot,
+			cache,
+		); err != nil {
+			return nil, err
+		}
+		if err := batchFetchStakeVoteDelegation(
+			db,
+			keyChunk,
+			slot,
+			cache,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	for key := range cache.poolDelegation {
+		if _, ok := requested[key]; !ok {
+			delete(cache.poolDelegation, key)
+		}
+	}
+
+	return cache, nil
+}
+
 func batchFetchStakeRegistration(
 	db *gorm.DB,
 	stakingKeys [][]byte,

--- a/database/plugin/metadata/sqlite/reward_live_stake.go
+++ b/database/plugin/metadata/sqlite/reward_live_stake.go
@@ -163,7 +163,7 @@ func rewardStakeRefsFromUtxoSpends(
 }
 
 // flattenPoolDelegationCache converts this package's local certificate cache
-// (populated by batchFetchCerts in account.go) into the shared package's
+// (populated by batchFetchPoolDelegations in account.go) into the shared package's
 // PoolDelegationCache. account.go's accountCertCache/certRecord types carry
 // registration/deregistration/DRep-delegation data used elsewhere in that
 // file; only the pool-delegation slice is relevant to the reward-live-stake
@@ -186,11 +186,9 @@ func flattenPoolDelegationCache(
 	return flat
 }
 
-// refreshRewardLiveStakeAggregates batch-fetches certificate state once per
-// distinct slot (via batchFetchCerts, which is local to this package because
-// it shares account.go's certificate-batching machinery) and then refreshes
-// each credential's reward_live_stake row through the shared package's
-// per-credential engine.
+// refreshRewardLiveStakeAggregates batch-fetches pool-delegation certificate
+// state once per distinct slot and then refreshes each credential's
+// reward_live_stake row through the shared package's per-credential engine.
 func refreshRewardLiveStakeAggregates(
 	db *gorm.DB,
 	refs map[string]rewardCredentialSlotRef,
@@ -213,7 +211,7 @@ func refreshRewardLiveStakeAggregates(
 		len(refsBySlot),
 	)
 	for slot, slotRefs := range refsBySlot {
-		cache, err := batchFetchCerts(db, slotRefs, slot)
+		cache, err := batchFetchPoolDelegations(db, slotRefs, slot)
 		if err != nil {
 			return fmt.Errorf(
 				"query reward live stake pool delegations: %w",
@@ -246,7 +244,11 @@ func refreshRewardLiveStakeAggregate(
 	if len(ref.Key) == 0 {
 		return nil
 	}
-	cache, err := batchFetchCerts(db, []models.StakeCredentialRef{ref}, slot)
+	cache, err := batchFetchPoolDelegations(
+		db,
+		[]models.StakeCredentialRef{ref},
+		slot,
+	)
 	if err != nil {
 		return fmt.Errorf(
 			"query reward live stake pool delegation: %w",

--- a/database/plugin/metadata/sqlite/reward_live_stake_test.go
+++ b/database/plugin/metadata/sqlite/reward_live_stake_test.go
@@ -14,7 +14,61 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
+
+func TestRewardLiveStakeRefreshQueriesOnlyPoolCertificateTables(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	key := bytes.Repeat([]byte{0xA3}, 28)
+	require.NoError(t, store.DB().Create(&models.Account{
+		CredentialTag: 0,
+		StakingKey:    key,
+		Active:        true,
+		Reward:        types.Uint64(1),
+	}).Error)
+
+	recorder := &importSQLRecorder{}
+	db := store.DB().Session(&gorm.Session{Logger: recorder})
+	ref := models.StakeCredentialRef{Tag: 0, Key: key}
+	err := refreshRewardLiveStakeAggregates(
+		db,
+		map[string]rewardCredentialSlotRef{
+			ref.MapKey(): {ref: ref, slot: 100},
+		},
+	)
+	require.NoError(t, err)
+
+	recorder.mu.Lock()
+	var statements []string
+	for _, statement := range recorder.statements {
+		if strings.Contains(strings.ToLower(statement), "with ranked as") {
+			statements = append(statements, statement)
+		}
+	}
+	recorder.mu.Unlock()
+	require.Len(t, statements, 4)
+
+	queries := strings.ToLower(strings.Join(statements, "\n"))
+	for _, table := range []string{
+		"stake_registration_delegation",
+		"stake_vote_registration_delegation",
+		"stake_delegation",
+		"stake_vote_delegation",
+	} {
+		require.Contains(t, queries, "from "+table+" t")
+	}
+	for _, table := range []string{
+		"stake_registration",
+		"vote_registration_delegation",
+		"registration",
+		"stake_deregistration",
+		"deregistration",
+		"vote_delegation",
+	} {
+		require.NotContains(t, queries, "from "+table+" t")
+	}
+}
 
 func TestRewardLiveStakeNeedsBackfillAcceptsReadTransaction(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes #2993 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize reward_live_stake refresh by querying only pool-delegation certificates, skipping six unused registration/deregistration/DRep queries to speed up updates. Adds `batchFetchPoolDelegations`, updates reward_live_stake refresh paths to use it, and includes a test ensuring only the four delegation tables are queried.

<sup>Written for commit 7ad90bad883405e36c6e32ebaab66a8825cbdd93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved live stake refreshes by querying only certificate data relevant to pool delegation.
  * Reduced unnecessary database queries during stake and reward updates.

* **Bug Fixes**
  * Improved filtering of delegation data to ensure only requested staking credentials are processed.

* **Tests**
  * Added coverage verifying that live stake refreshes query only pool-certificate data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->