### PR TITLE
fix(chainselection): anchor Genesis density to intersection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1422,6 +1422,18 @@ genesis params (`GenesisWindowSlotsForParams`) or overridden by
 `genesisWindowSlots`. Each tracked peer keeps a bounded recent frontier of
 `(slot, hash)` points (`PeerChainTip.observedPoints`, in lockstep with the
 `observedSlots` used for density), trimmed to the window and on rollback.
+That rolling frontier ranks peers before a fork is available locally; it is not
+the authoritative fork-choice measurement. When an incoming header conflicts
+with the primary chain, ledger fork resolution reconstructs the peer's fetched
+header path with `findPeerForkPath`, locates the exact common ancestor, and
+counts both the peer and primary-chain blocks in
+`(intersectionSlot, intersectionSlot + genesisWindow]`. Greater density wins;
+equal density falls back to the normal Praos length/select-view comparison.
+Node composition injects an atomic Genesis-mode/window query from
+`ChainSelector` into ledger, so the same resolver automatically returns to
+Praos once the selector exits Genesis mode. Chainsync and ledger retain enough
+per-peer header ancestry for the active slot window while Genesis is active,
+then shrink back to their normal bounded history after exit.
 
 The trust problem Genesis solves for **biased fast-sync sources** — e.g. a
 local shallow peer or the Genesis Sync Accelerator (GSA), which serve blocks
@@ -1537,30 +1549,23 @@ once a corroborated peer has served its chain up to (near) it, which is reached
 exactly when the local tip has caught up. This satisfies both bounds — no
 single-peer liveness pin (an unbounded slot never counts until delivered) and no
 premature exit at the start of sync (delivered headers only reach the far tip
-once caught up). The trade-off is that an uncorroborated source ahead in block
-number could win Praos selection after exit; closing that residual needs
-density-at-intersection (deferred, below). A change
-to any tracked peer's frontier re-runs selection while corroboration is active,
-so corroboration granted or revoked takes effect immediately rather than on the
-next periodic tick.
+once caught up). A change to any tracked peer's frontier re-runs selection while
+corroboration is active, so corroboration granted or revoked takes effect
+immediately rather than on the next periodic tick.
 
-**Deferred / not implemented** (explicit scope boundary — some of these are
-security limitations, not only performance): the gate is a corroboration check,
-not the reference implementation's full Ouroboros Genesis density-at-intersection
-with **ChainSync Jumping** and devoted BlockFetch dynamics. It confirms that a
-witness's chain is a prefix of the candidate's within the overlapping window; it
-does **not** resolve a fork whose intersection lies *inside* the window by
-counting blocks after the exact intersection, and it cannot testify about blocks
-a fast source produced *beyond* every witness's frontier. Consequently a fast
+**Deferred / not implemented**: Dingo does not yet implement **ChainSync
+Jumping** or **Devoted BlockFetch**. The corroboration gate also cannot
+testify about blocks a fast source produced beyond every witness's frontier: a
 source that stays consistent with honest peers up to their frontiers but forks
-only in the not-yet-witnessed suffix is corroborated until a witness advances
-past the fork — full density-at-intersection would decide such cases sooner, so
-its absence is a **security** limitation for that window, mitigated (not closed)
-by the fail-closed overlap requirement and the per-header density comparison.
-Wiring peer-governance demotion to the corroboration-failure event is likewise
-deferred. These remain future work; the density comparison plus the corroboration
-gate provide the from-origin property that a fast source cannot steer the node
-onto a chain no independent witness shares.
+only in the not-yet-witnessed suffix remains corroborated until a witness
+advances past the fork. Intersection-anchored fork resolution still compares
+that fetched suffix against the local candidate, but independent corroboration
+of the suffix necessarily waits for witnesses to observe it. Wiring
+peer-governance demotion to the corroboration-failure event is likewise
+deferred. These remain future work; the corroboration gate confirms only the
+overlap that independent witnesses have observed. Density-at-intersection can
+compare an unseen suffix with the local candidate, but does not independently
+corroborate that suffix.
 
 #### Anti-flap incumbent pin
 

--- a/GENESIS_SYNC.md
+++ b/GENESIS_SYNC.md
@@ -50,8 +50,11 @@ Assumptions (the security property holds only under these):
 
 Under these assumptions a bad or divergent fast source can at worst stall the
 node. A fork that diverges only in blocks no honest peer has yet observed is not
-detected until a corroborator advances past it — full Ouroboros Genesis
-density-at-intersection would resolve such cases sooner (see Limitations).
+independently contradicted until a corroborator advances past it. If that fork
+conflicts with the local chain, the authoritative resolver still compares the
+fully fetched peer and local paths by density from their exact common
+intersection. That comparison does not provide independent witness confirmation
+of the unseen suffix.
 
 ## Configuration
 
@@ -157,24 +160,23 @@ fast source, and per-peer density/corroboration for metrics or debugging.
 
 ## Limitations (deferred)
 
-This is a corroboration gate, not the reference implementation's full Ouroboros
-Genesis. Specifically **not** implemented:
+Dingo implements intersection-anchored density for authoritative local fork
+choice, but not every optimization in the reference implementation.
+Specifically **not** implemented:
 
-- **ChainSync Jumping** and devoted BlockFetch dynamics (a
+- **ChainSync Jumping** and **Devoted BlockFetch** (a
   performance/robustness optimization for downloading across many peers).
-- **Density-at-intersection** resolution of a fork whose intersection is *inside*
-  the window. The gate confirms a witness's chain is a prefix of the candidate's
-  within their overlap; it does not count blocks after an exact intersection, and
-  it cannot testify about blocks the fast source produced *beyond* every
-  witness's frontier. A fast source that stays consistent with honest peers up to
-  their frontiers but forks in the not-yet-witnessed suffix is followed until a
-  corroborator advances past the fork. This is a **security** limitation for that
-  window (not merely performance), mitigated but not closed by the fail-closed
-  overlap requirement and the per-header density comparison.
+- **Independent testimony beyond every witness frontier.** The corroboration
+  gate confirms a witness's chain within their overlap, but cannot testify about
+  a not-yet-witnessed suffix. A fast source that forks only after every honest
+  witness's frontier remains corroborated until a witness advances past the
+  fork. Intersection-anchored density still resolves a conflict with the local
+  candidate; independent confirmation of the suffix cannot happen before a
+  witness observes it.
 - **Peer-governance demotion** wired to the corroboration-failure event; today
   the source is denied selection (stall) but kept connected so it can serve
   blocks once corroboration arrives.
 
-The first and third are performance/refinement work; the second is a residual
-security limitation of the density-based approach, documented here so operators
-do not over-rely on the gate to resolve every in-window fork.
+The first and third are performance/refinement work; the second is an inherent
+limit on what the configured corroborators have observed, documented here so
+operators do not mistake current overlap for testimony about a future suffix.

--- a/chainselection/doc.go
+++ b/chainselection/doc.go
@@ -18,9 +18,11 @@
 // then the reference implementation's equal-length opcert/VRF tiebreaker when
 // it is armed.
 //
-// Genesis selection mode can be enabled at startup to prefer observed
-// density during bootstrap before automatically falling back to Praos once
-// the local tip is close enough to the best observed peer tip.
+// Genesis selection mode can be enabled at startup. The selector's rolling
+// observed density ranks peers during bootstrap; when fetched candidates fork,
+// ledger resolution performs the authoritative density comparison from their
+// exact common intersection. Both automatically fall back to Praos once the
+// local tip is close enough to the best observed peer tip.
 //
 // ChainSelector is the top-level type. It consumes PeerTipUpdateEvent
 // events from chainsync, compares peer tips against the local tip, and

--- a/chainselection/genesis.go
+++ b/chainselection/genesis.go
@@ -59,3 +59,35 @@ func GenesisWindowSlotsForParams(
 	}
 	return uint64(window)
 }
+
+// DensityFromIntersection counts candidate blocks in the Genesis window that
+// starts immediately after the common intersection and ends at
+// intersectionSlot+window, inclusive. The intersection block itself belongs
+// to both candidates and is therefore excluded.
+//
+// Slots must describe one candidate path in ascending order. Values outside
+// the window are ignored so callers may pass the complete fetched fragment.
+func DensityFromIntersection(
+	intersectionSlot uint64,
+	window uint64,
+	slots []uint64,
+) uint64 {
+	if window == 0 || len(slots) == 0 {
+		return 0
+	}
+	windowEnd := intersectionSlot + window
+	if windowEnd < intersectionSlot {
+		windowEnd = math.MaxUint64
+	}
+	var density uint64
+	for _, slot := range slots {
+		if slot <= intersectionSlot {
+			continue
+		}
+		if slot > windowEnd {
+			break
+		}
+		density++
+	}
+	return density
+}

--- a/chainselection/genesis_corroboration.go
+++ b/chainselection/genesis_corroboration.go
@@ -30,10 +30,10 @@ import (
 // divergent source on a private fork that no honest peer reports — is denied
 // chain selection so it stalls rather than steering the local chain.
 //
-// This is a corroboration gate, not full Ouroboros Genesis density-at-
-// intersection with ChainSync Jumping. See ARCHITECTURE.md ("Ouroboros Genesis
-// trust model") for the supported trust model and the explicitly deferred
-// pieces.
+// This gate supplies the independent-peer trust check. Authoritative
+// density-at-intersection is performed by ledger fork resolution; ChainSync
+// Jumping remains separate deferred work. See ARCHITECTURE.md ("Ouroboros
+// Genesis trust model").
 
 // genesisCorroborationActiveLocked reports whether the Genesis corroboration
 // gate is in effect (Genesis mode with a positive threshold). When false the

--- a/chainselection/genesis_test.go
+++ b/chainselection/genesis_test.go
@@ -37,6 +37,47 @@ func TestGenesisWindowSlotsForParams(t *testing.T) {
 	)
 }
 
+func TestDensityFromIntersection(t *testing.T) {
+	assert.Equal(
+		t,
+		uint64(3),
+		DensityFromIntersection(100, 30, []uint64{
+			99, 100, 101, 120, 130, 131,
+		}),
+		"exclude the common block and include the window end",
+	)
+	assert.Zero(t, DensityFromIntersection(100, 0, []uint64{101}))
+	assert.Equal(
+		t,
+		uint64(2),
+		DensityFromIntersection(
+			math.MaxUint64-2,
+			10,
+			[]uint64{math.MaxUint64 - 1, math.MaxUint64},
+		),
+		"an overflowing window saturates at MaxUint64",
+	)
+}
+
+func TestGenesisSelectionStateTransitionsAtomically(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:        true,
+		GenesisWindowSlots: 30,
+	})
+
+	active, window := cs.GenesisSelectionState()
+	require.True(t, active)
+	assert.Equal(t, uint64(30), window)
+
+	cs.mutex.Lock()
+	cs.mode = SelectionModePraos
+	cs.mutex.Unlock()
+
+	active, window = cs.GenesisSelectionState()
+	assert.False(t, active)
+	assert.Equal(t, uint64(30), window)
+}
+
 func TestChainSelectorGenesisObservedDensityTracksRollingWindow(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{
 		GenesisMode:   true,

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -274,9 +274,8 @@ func (cs *ChainSelector) genesisWindowSlotsLocked() uint64 {
 // tip is trustworthy and becomes the exit target — reached exactly when the
 // local tip has caught up.
 //
-// Residual (documented, deferred): an uncorroborated source ahead in block
-// number could win Praos selection after exit; closing that needs
-// density-at-intersection (see ARCHITECTURE.md).
+// Once this transition fires, both peer ranking and authoritative ledger fork
+// resolution intentionally return to Praos.
 func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
 	window := cs.genesisWindowSlotsLocked()
 	var best uint64
@@ -799,6 +798,16 @@ func (cs *ChainSelector) GenesisWindowSlots() uint64 {
 	cs.mutex.RLock()
 	defer cs.mutex.RUnlock()
 	return cs.genesisWindowSlotsLocked()
+}
+
+// GenesisSelectionState returns an atomic snapshot of whether Genesis
+// selection is active and the density window it is using. Composition code
+// injects this narrow state query into fork resolution so the authoritative
+// local decision follows the selector's one-way Genesis-to-Praos transition.
+func (cs *ChainSelector) GenesisSelectionState() (bool, uint64) {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	return cs.mode == SelectionModeGenesis, cs.genesisWindowSlotsLocked()
 }
 
 // GetBestPeer returns the connection ID of the peer with the best chain, or

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -142,6 +142,11 @@ type Config struct {
 	// derived from the ledger's current stability window (falling back to
 	// defaultSeenHeadersRetention when no ledger state is available).
 	SeenHeadersRetention uint64
+	// ObservedHeaderLimitFunc returns the per-connection ancestry limit used
+	// by fork resolution. A non-positive result uses the bounded default.
+	// Genesis composition raises this to the active density window so a fully
+	// fetched candidate remains reconstructable from its intersection.
+	ObservedHeaderLimitFunc func() int
 	// PromRegistry, when non-nil, is used to register chainsync metrics
 	// such as the current header deduplication cache size.
 	PromRegistry prometheus.Registerer
@@ -814,12 +819,21 @@ func (s *State) RecordObservedHeader(h ObservedHeader) {
 		header:   h,
 		prevHash: append([]byte(nil), prevHash...),
 	}
-	if len(chainHistory.order) <= maxObservedHeadersPerConn {
-		return
+	limit := s.observedHeaderLimit()
+	for len(chainHistory.order) > limit {
+		evictKey := chainHistory.order[0]
+		chainHistory.order = chainHistory.order[1:]
+		delete(chainHistory.byHash, evictKey)
 	}
-	evictKey := chainHistory.order[0]
-	chainHistory.order = chainHistory.order[1:]
-	delete(chainHistory.byHash, evictKey)
+}
+
+func (s *State) observedHeaderLimit() int {
+	if s.config.ObservedHeaderLimitFunc != nil {
+		if limit := s.config.ObservedHeaderLimitFunc(); limit > 0 {
+			return limit
+		}
+	}
+	return maxObservedHeadersPerConn
 }
 
 // LookupObservedHeader returns a previously observed header for the given

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1537,6 +1537,67 @@ func TestObservedHeader_RoundTrip(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestObservedHeaderLimitFollowsSelectionState(t *testing.T) {
+	limit := 3
+	cfg := chainsync.DefaultConfig()
+	cfg.ObservedHeaderLimitFunc = func() int {
+		return limit
+	}
+	s := newTestState(t, newTestEventBus(t), cfg)
+	conn := newTestConnId(43)
+
+	var (
+		prevHash  []byte
+		firstHash []byte
+	)
+	for i := 1; i <= 4; i++ {
+		hash := lcommon.NewBlake2b256(
+			[]byte(fmt.Sprintf("observed-header-%d", i)),
+		).Bytes()
+		if i == 1 {
+			firstHash = append([]byte(nil), hash...)
+		}
+		header := testBlockHeader{
+			hash:        lcommon.NewBlake2b256(hash),
+			prevHash:    lcommon.NewBlake2b256(prevHash),
+			blockNumber: uint64(i),
+			slot:        uint64(i),
+		}
+		s.RecordObservedHeader(chainsync.ObservedHeader{
+			ConnectionId: conn,
+			BlockHeader:  header,
+			Point:        ocommon.NewPoint(uint64(i), hash),
+			BlockNumber:  uint64(i),
+			Type:         1,
+		})
+		prevHash = hash
+	}
+
+	_, _, ok := s.LookupObservedHeader(conn, firstHash)
+	require.False(t, ok, "the dynamic three-header limit should evict the oldest")
+
+	limit = 2
+	fifthHash := lcommon.NewBlake2b256([]byte("observed-header-5")).Bytes()
+	s.RecordObservedHeader(chainsync.ObservedHeader{
+		ConnectionId: conn,
+		BlockHeader: testBlockHeader{
+			hash:        lcommon.NewBlake2b256(fifthHash),
+			prevHash:    lcommon.NewBlake2b256(prevHash),
+			blockNumber: 5,
+			slot:        5,
+		},
+		Point:       ocommon.NewPoint(5, fifthHash),
+		BlockNumber: 5,
+		Type:        1,
+	})
+
+	thirdHash := lcommon.NewBlake2b256([]byte("observed-header-3")).Bytes()
+	_, _, ok = s.LookupObservedHeader(conn, thirdHash)
+	require.False(t, ok, "lowering the limit should trim the retained ancestry")
+	_, _, ok = s.LookupObservedHeader(conn, fifthHash)
+	require.True(t, ok)
+}
+
 // --- Blockfetch latency metric tests ---
 
 const blockfetchLatencyMetricName = "dingo_chainsync_blockfetch_latency_seconds"

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -905,12 +905,58 @@ func (ls *LedgerState) recordPeerHeaderHistory(e ChainsyncEvent) {
 		event:    e,
 		prevHash: append([]byte(nil), e.BlockHeader.PrevHash().Bytes()...),
 	}
-	if len(history.order) <= maxPeerHeaderHistoryPerConn {
-		return
+	limit := ls.peerHeaderHistoryLimit()
+	for len(history.order) > limit {
+		evictKey := history.order[0]
+		history.order = history.order[1:]
+		delete(history.byHash, evictKey)
 	}
-	evictKey := history.order[0]
-	history.order = history.order[1:]
-	delete(history.byHash, evictKey)
+}
+
+func (ls *LedgerState) genesisSelectionState() (bool, uint64) {
+	if ls.config.GenesisSelectionStateFunc == nil {
+		return false, 0
+	}
+	active, window := ls.config.GenesisSelectionStateFunc()
+	return active && window > 0, window
+}
+
+func (ls *LedgerState) peerHeaderHistoryLimit() int {
+	limit := maxPeerHeaderHistoryPerConn
+	active, window := ls.genesisSelectionState()
+	if !active || window <= uint64(limit) {
+		return limit
+	}
+	if window > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+	// The MaxInt check above makes this conversion safe on both 32- and
+	// 64-bit platforms.
+	return int(window) //nolint:gosec // G115: window is bounded by MaxInt
+}
+
+// headerAtOrImmediatelyBeforeTip recognizes only points already accepted into
+// the current queued chain: its exact tip or the tip's direct observed parent.
+// Other earlier headers may be genuine competing candidates and must continue
+// through fork resolution.
+func (ls *LedgerState) headerAtOrImmediatelyBeforeTip(
+	e ChainsyncEvent,
+) bool {
+	headerTip := ls.chain.HeaderTip()
+	if pointMatches(e.Point, headerTip.Point) {
+		return true
+	}
+	if len(e.Point.Hash) == 0 || len(headerTip.Point.Hash) == 0 {
+		return false
+	}
+	tipHashKey := hex.EncodeToString(headerTip.Point.Hash)
+	for _, history := range ls.peerHeaderHistory {
+		tipRecord, ok := history.byHash[tipHashKey]
+		if ok && bytes.Equal(tipRecord.prevHash, e.Point.Hash) {
+			return true
+		}
+	}
+	return false
 }
 
 func (ls *LedgerState) findPeerForkPath(
@@ -923,7 +969,8 @@ func (ls *LedgerState) findPeerForkPath(
 	visited := map[string]struct{}{
 		hex.EncodeToString(e.Point.Hash): {},
 	}
-	for depth := 0; depth < maxPeerHeaderHistoryPerConn &&
+	limit := ls.peerHeaderHistoryLimit()
+	for depth := 0; depth < limit &&
 		len(prevHash) > 0; depth++ {
 		// Resolve the ancestor by O(1) hash index only: database.BlockByHash
 		// no longer falls back to a sequential blob scan on a miss, so this
@@ -978,6 +1025,70 @@ func (ls *LedgerState) findPeerForkPath(
 		prevHash = append(prevHash[:0], record.prevHash...)
 	}
 	return nil, nil, nil
+}
+
+func (ls *LedgerState) localGenesisDensity(
+	ancestorPoint ocommon.Point,
+	window uint64,
+) (uint64, error) {
+	iter, err := ls.chain.FromPoint(ancestorPoint, false)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"iterate local candidate after intersection %d: %w",
+			ancestorPoint.Slot,
+			err,
+		)
+	}
+	defer iter.Cancel()
+
+	windowEnd := ancestorPoint.Slot + window
+	if windowEnd < ancestorPoint.Slot {
+		windowEnd = math.MaxUint64
+	}
+	slots := make([]uint64, 0)
+	for {
+		result, nextErr := iter.Next(false)
+		if errors.Is(nextErr, chain.ErrIteratorChainTip) {
+			break
+		}
+		if nextErr != nil {
+			return 0, fmt.Errorf(
+				"iterate local candidate after intersection %d: %w",
+				ancestorPoint.Slot,
+				nextErr,
+			)
+		}
+		if result.Rollback {
+			return 0, errors.New(
+				"local candidate changed while computing Genesis density",
+			)
+		}
+		if result.Point.Slot > windowEnd {
+			break
+		}
+		slots = append(slots, result.Point.Slot)
+	}
+	return chainselection.DensityFromIntersection(
+		ancestorPoint.Slot,
+		window,
+		slots,
+	), nil
+}
+
+func genesisForkPathDensity(
+	ancestorPoint ocommon.Point,
+	window uint64,
+	forkPath []ChainsyncEvent,
+) uint64 {
+	slots := make([]uint64, 0, len(forkPath))
+	for _, forkEvent := range forkPath {
+		slots = append(slots, forkEvent.Point.Slot)
+	}
+	return chainselection.DensityFromIntersection(
+		ancestorPoint.Slot,
+		window,
+		slots,
+	)
 }
 
 func (ls *LedgerState) blockByHash(hash []byte) (models.Block, error) {
@@ -2079,7 +2190,17 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 	}
 	if err != nil {
 		if notFitErr, ok := errors.AsType[chain.BlockNotFitChainTipError](err); ok {
+			if ls.headerAtOrImmediatelyBeforeTip(e) {
+				ls.config.Logger.Debug(
+					"ignoring duplicate or reordered roll forward",
+					"component", "ledger",
+					"slot", e.Point.Slot,
+					"connection_id", e.ConnectionId.String(),
+				)
+				return nil
+			}
 			localTip := ls.chain.Tip()
+			genesisActive, _ := ls.genesisSelectionState()
 			// A header behind the local tip is stale only if the
 			// Praos comparison also says it cannot beat the local
 			// tip. At equal block number, cardano-node resolves the
@@ -2089,6 +2210,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 			// headers and let a future observed header prove the
 			// advertised tip.
 			if e.Point.Slot < localTip.Point.Slot &&
+				!genesisActive &&
 				!ls.earlierHeaderCanBeatLocalTip(
 					e,
 					localTip,
@@ -2315,14 +2437,16 @@ func (ls *LedgerState) tryResolveFork(
 	e ChainsyncEvent,
 	notFitErr chain.BlockNotFitChainTipError,
 ) (bool, error) {
-	// Only resolve forks when the peer's chain is genuinely better than
-	// ours per Praos rules. Longer chains win first; at equal length,
-	// cardano-node uses the Praos VRF tiebreaker, not a lower-slot rule.
 	localTip := ls.chain.Tip()
-	if ls.compareIncomingHeaderToLocalTip(
+	praosComparison := ls.compareIncomingHeaderToLocalTip(
 		e,
 		localTip,
-	) != praos.ChainABetter {
+	)
+	genesisActive, genesisWindow := ls.genesisSelectionState()
+	// Once the selector has converged back to Praos, preserve the normal
+	// length-first decision and avoid the more expensive fork-path density
+	// walk for a candidate that cannot win.
+	if !genesisActive && praosComparison != praos.ChainABetter {
 		return false, nil
 	}
 
@@ -2365,6 +2489,38 @@ func (ls *LedgerState) tryResolveFork(
 			event.ChainsyncResyncReasonRollbackNotFound,
 		)
 		return true, nil
+	}
+	if genesisActive {
+		peerDensity := genesisForkPathDensity(
+			*ancestorPoint,
+			genesisWindow,
+			forkPath,
+		)
+		localDensity, densityErr := ls.localGenesisDensity(
+			*ancestorPoint,
+			genesisWindow,
+		)
+		if densityErr != nil {
+			return false, densityErr
+		}
+		ls.config.Logger.Debug(
+			"compared fork density from common intersection",
+			"component", "ledger",
+			"connection_id", e.ConnectionId.String(),
+			"intersection_slot", ancestorPoint.Slot,
+			"genesis_window_slots", genesisWindow,
+			"peer_density", peerDensity,
+			"local_density", localDensity,
+		)
+		switch {
+		case peerDensity < localDensity:
+			return false, nil
+		case peerDensity == localDensity &&
+			praosComparison != praos.ChainABetter:
+			// Equal density converges on the usual Praos length/VRF
+			// comparison, matching selector peer-ranking behavior.
+			return false, nil
+		}
 	}
 	ancestorBlock, err := ls.blockByHash(ancestorPoint.Hash)
 	if err != nil {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -412,6 +412,258 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 	assert.Equal(t, fixture.ancestorTip, dbTip)
 }
 
+func TestTryResolveForkGenesisRejectsLongerSparseCandidate(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.config.GenesisSelectionStateFunc = func() (bool, uint64) {
+		return true, 15
+	}
+
+	// The local candidate has one block inside (10, 25]. The peer advertises
+	// a longer chain, but its first fetched fork block is outside that exact
+	// intersection-anchored window, so Genesis density must reject it.
+	forkHash := testHashBytes("genesis-sparse-fork")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        30,
+	}
+	err := fixture.ls.chain.AddBlockHeader(header)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved, err := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        ocommon.NewPoint(header.slot, forkHash),
+			BlockHeader:  header,
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(header.slot, forkHash),
+				BlockNumber: fixture.currentTip.BlockNumber + 1,
+			},
+		},
+		notFitErr,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, resolved)
+	assert.Equal(t, fixture.currentTip, fixture.ls.chain.Tip())
+	assert.Zero(t, fixture.ls.chain.HeaderCount())
+}
+
+func TestTryResolveForkGenesisAcceptsDenserShorterCandidate(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	require.NoError(
+		t,
+		fixture.ls.config.ChainManager.SetLedger(
+			testSecurityParamLedger{securityParam: 10},
+		),
+	)
+	fixture.ls.config.GenesisSelectionStateFunc = func() (bool, uint64) {
+		return true, 15
+	}
+
+	// Extend the local chain beyond the Genesis window. It is longer overall
+	// (block 4 versus the peer's block 3), but still has only the slot-20
+	// block inside (10, 25].
+	localHash3 := testHashBytes("genesis-local-3")
+	localHash4 := testHashBytes("genesis-local-4")
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        30,
+			Hash:        localHash3,
+			BlockNumber: 3,
+			Type:        1,
+			PrevHash:    fixture.currentTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+		{
+			Slot:        40,
+			Hash:        localHash4,
+			BlockNumber: 4,
+			Type:        1,
+			PrevHash:    localHash3,
+			Cbor:        []byte{0x80},
+		},
+	}))
+
+	forkHash1 := testHashBytes("genesis-dense-fork-1")
+	forkHash2 := testHashBytes("genesis-dense-fork-2")
+	header1 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash1),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: 2,
+		slot:        12,
+	}
+	header2 := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash2),
+		prevHash:    lcommon.NewBlake2b256(forkHash1),
+		blockNumber: 3,
+		slot:        14,
+	}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        ocommon.NewPoint(header1.slot, forkHash1),
+		BlockHeader:  header1,
+	})
+	err := fixture.ls.handleEventChainsyncBlockHeader(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        ocommon.NewPoint(header2.slot, forkHash2),
+			BlockHeader:  header2,
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(header2.slot, forkHash2),
+				BlockNumber: header2.blockNumber,
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, 2, fixture.ls.chain.HeaderCount())
+}
+
+func TestTryResolveForkUsesPraosAfterGenesisExit(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.config.GenesisSelectionStateFunc = func() (bool, uint64) {
+		return false, 15
+	}
+
+	// This candidate has no blocks in the Genesis window, but Genesis has
+	// exited and its greater block number must therefore win under Praos.
+	forkHash := testHashBytes("post-genesis-praos-fork")
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(forkHash),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        30,
+	}
+	err := fixture.ls.chain.AddBlockHeader(header)
+	var notFitErr chain.BlockNotFitChainTipError
+	require.ErrorAs(t, err, &notFitErr)
+
+	resolved, err := fixture.ls.tryResolveFork(
+		ChainsyncEvent{
+			ConnectionId: fixture.connId,
+			Point:        ocommon.NewPoint(header.slot, forkHash),
+			BlockHeader:  header,
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(header.slot, forkHash),
+				BlockNumber: fixture.currentTip.BlockNumber + 1,
+			},
+		},
+		notFitErr,
+	)
+
+	require.NoError(t, err)
+	require.True(t, resolved)
+	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
+	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
+}
+
+func TestHandleEventChainsyncBlockHeaderIgnoresObservedPredecessor(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name          string
+		differentPeer bool
+		replayTip     bool
+	}{
+		{
+			name:      "same_peer_duplicate_tip",
+			replayTip: true,
+		},
+		{
+			name:          "different_peer_reordered_predecessor",
+			differentPeer: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newChainsyncRollbackFixture(t)
+			fixture.ls.config.GenesisSelectionStateFunc = func() (bool, uint64) {
+				return true, 15
+			}
+
+			firstHash := testHashBytes(
+				"observed-predecessor-first-" + testCase.name,
+			)
+			secondHash := testHashBytes(
+				"observed-predecessor-second-" + testCase.name,
+			)
+			firstHeader := mockHeader{
+				hash:        lcommon.NewBlake2b256(firstHash),
+				prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+				blockNumber: fixture.currentTip.BlockNumber + 1,
+				slot:        fixture.currentTip.Point.Slot + 1,
+			}
+			secondHeader := mockHeader{
+				hash:        lcommon.NewBlake2b256(secondHash),
+				prevHash:    lcommon.NewBlake2b256(firstHash),
+				blockNumber: fixture.currentTip.BlockNumber + 2,
+				slot:        fixture.currentTip.Point.Slot + 2,
+			}
+			require.NoError(t, fixture.ls.chain.AddBlockHeader(firstHeader))
+			require.NoError(t, fixture.ls.chain.AddBlockHeader(secondHeader))
+
+			historyConn := fixture.connId
+			if testCase.differentPeer {
+				historyConn = testChainsyncConnId(4301, 4302)
+			}
+			for _, header := range []mockHeader{firstHeader, secondHeader} {
+				fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+					ConnectionId: historyConn,
+					Point: ocommon.NewPoint(
+						header.SlotNumber(),
+						header.Hash().Bytes(),
+					),
+					BlockHeader: header,
+				})
+			}
+
+			replayedHeader := firstHeader
+			if testCase.replayTip {
+				replayedHeader = secondHeader
+			}
+			clearCalls := 0
+			fixture.ls.config.ClearSeenHeadersFromFunc = func(uint64) {
+				clearCalls++
+			}
+			fixture.ls.headerMismatchCount = 7
+			err := fixture.ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+				ConnectionId: fixture.connId,
+				Point: ocommon.NewPoint(
+					replayedHeader.SlotNumber(),
+					replayedHeader.Hash().Bytes(),
+				),
+				BlockHeader: replayedHeader,
+				Tip: ochainsync.Tip{
+					Point: ocommon.NewPoint(
+						secondHeader.SlotNumber(),
+						secondHeader.Hash().Bytes(),
+					),
+					BlockNumber: secondHeader.BlockNumber(),
+				},
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, 2, fixture.ls.chain.HeaderCount())
+			assert.Equal(t, 7, fixture.ls.headerMismatchCount)
+			assert.Zero(t, clearCalls)
+			assert.True(
+				t,
+				pointMatches(
+					fixture.ls.chain.HeaderTip().Point,
+					ocommon.NewPoint(
+						secondHeader.SlotNumber(),
+						secondHeader.Hash().Bytes(),
+					),
+				),
+			)
+		})
+	}
+}
+
 func TestTryResolveForkExceedsKReconcilesDivergedLedgerTip(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 	putPrimaryChainOnForkBeyondK(t, fixture, "live-fork-resolution")

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -365,6 +365,10 @@ type PeerHeaderLookupFunc func(
 	hash []byte,
 ) (ChainsyncEvent, []byte, bool)
 
+// GenesisSelectionStateFunc returns whether authoritative fork resolution
+// should use Ouroboros Genesis density and the active window in slots.
+type GenesisSelectionStateFunc func() (active bool, window uint64)
+
 type LedgerStateConfig struct {
 	PromRegistry                prometheus.Registerer
 	Logger                      *slog.Logger
@@ -382,6 +386,7 @@ type LedgerStateConfig struct {
 	ConnectionSwitchFunc        ConnectionSwitchFunc
 	ClearSeenHeadersFromFunc    ClearSeenHeadersFromFunc
 	PeerHeaderLookupFunc        PeerHeaderLookupFunc
+	GenesisSelectionStateFunc   GenesisSelectionStateFunc
 	FatalErrorFunc              FatalErrorFunc
 	ForgedBlockChecker          ForgedBlockChecker
 	SlotBattleRecorder          SlotBattleRecorder

--- a/node.go
+++ b/node.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"slices"
 	"sync"
@@ -584,6 +585,12 @@ func (n *Node) Run(ctx context.Context) error {
 					Rollback:     h.Rollback,
 				}, prevHash, true
 			},
+			GenesisSelectionStateFunc: func() (bool, uint64) {
+				if n.chainSelector == nil {
+					return false, 0
+				}
+				return n.chainSelector.GenesisSelectionState()
+			},
 			FatalErrorFunc: func(err error) {
 				n.config.logger.Error(
 					"fatal ledger error, initiating shutdown",
@@ -822,6 +829,21 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	chainsyncCfg.HeaderSyncStrategy = n.config.chainsyncStrategy
 	chainsyncCfg.PromRegistry = n.config.promRegistry
+	chainsyncCfg.ObservedHeaderLimitFunc = func() int {
+		if n.chainSelector == nil {
+			return 0
+		}
+		active, window := n.chainSelector.GenesisSelectionState()
+		if !active {
+			return 0
+		}
+		if window > uint64(math.MaxInt) {
+			return math.MaxInt
+		}
+		// The MaxInt check above makes this conversion safe on both 32- and
+		// 64-bit platforms.
+		return int(window) //nolint:gosec // G115: window is bounded by MaxInt
+	}
 	n.chainsyncState = chainsync.NewStateWithConfig(
 		n.eventBus,
 		n.ledgerState,


### PR DESCRIPTION
Closes #2610 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchor Genesis density to the exact fork intersection and use it for authoritative fork choice during Genesis. `chainsync`/`ledger` now keep only the ancestry needed within the active window and automatically return to Praos after exit.

- New Features
  - `ledger`: Intersection-anchored density for fork resolution; equal density falls back to Praos length/VRF. Skip Praos-only early rejections during Genesis, ignore duplicate/reordered tip headers, and retain per‑peer header history up to the active window.
  - `chainselection`: Add `DensityFromIntersection` and an atomic `GenesisSelectionState()`; update docs to reflect intersection‑anchored density and current trust limits.
  - `chainsync`: Add `ObservedHeaderLimitFunc` to size per‑connection ancestry dynamically to the active Genesis window.
  - `node`: Wire selector state into `ledger` (`GenesisSelectionStateFunc`) and `chainsync` (`ObservedHeaderLimitFunc`). Add tests covering density calc, state transitions, dynamic limits, and fork‑resolution cases.

<sup>Written for commit 6319f1e0bded49c120df895a68f2e6e403d66f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/2999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved genesis-mode peer and fork selection using density within the configured genesis window.
  * Automatically transitions from genesis selection to normal Praos selection when appropriate.
  * Added bounded, dynamically adjusted peer header history for fork resolution.

* **Bug Fixes**
  * Prevents longer but less-dense candidate forks from incorrectly replacing the local chain.
  * Preserves relevant headers during genesis selection for more reliable resolution.

* **Documentation**
  * Clarified genesis trust, corroboration behavior, transition rules, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->