### PR TITLE
fix(consensus): enforce header forecast horizon

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1307,6 +1307,20 @@ rolled the applied chain back to its common ancestor, so permitted epoch-nonce
 forecasts and the epoch-specific Mark stake snapshot used for leader
 eligibility are read from that intersection state.
 
+Slot/epoch query adapters preserve `hardfork.ErrPastHorizon` in their error
+chains so callers can defer until the ledger advances. `EpochInfo` serves an
+already materialized epoch directly from the immutable epoch cache before
+forecasting. The operational slot clock is the deliberate exception to
+wall-clock forecast refusal: a near-now `TimeToSlot` call extrapolates the
+current era while a stale node catches up, but arbitrary time queries and all
+header validation remain bounded. Blockfrost epoch/era end timestamps are
+calculated as interval endpoints from cached epoch durations rather than
+treating the exclusive end as a forecastable header slot.
+When the next-epoch nonce becomes stable before that header horizon opens,
+the node-level leader adapter derives only the immediate next Praos epoch's
+slot range from the current epoch dimensions so schedule precomputation can
+proceed without broadening general ledger forecasts.
+
 ### Operational Certificate Validation
 
 Inbound operational-certificate (opcert) validation is split by its data

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1291,6 +1291,22 @@ When a network config supplies a `CheckpointsFile` (mainnet and preview ship one
 - KES signature verification with period checks
 - Slot leader eligibility checking
 
+Before resolving or eagerly forecasting an epoch for a live header,
+`headerVerificationEpoch` checks the slot against `LedgerState.HardForkSummary`.
+The in-memory summary uses the same configured era safe zone and
+`TransitionInfo` as the NtC era-history query: an unknown transition is bounded
+from the applied tip by the era's stability window (`3k/f` for Shelley and
+later), a known transition is bounded at the announced era boundary, and an
+impossible transition keeps the same rolling safe-zone bound so live slot
+processing can cross a confirmed same-era epoch boundary. (The point-in-time
+NtC query may conservatively stop its reported range at that confirmed
+boundary.) A header at or past the live bound fails with
+`hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the forecasted
+epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
+rolled the applied chain back to its common ancestor, so permitted epoch-nonce
+forecasts and the epoch-specific Mark stake snapshot used for leader
+eligibility are read from that intersection state.
+
 ### Operational Certificate Validation
 
 Inbound operational-certificate (opcert) validation is split by its data

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -537,15 +538,7 @@ func (a *NodeAdapter) CurrentEpoch() (
 			err,
 		)
 	}
-	endSlot := tipEpoch.StartSlot + uint64(tipEpoch.LengthInSlots)
-	endTime, err := a.ledgerState.SlotToTime(endSlot)
-	if err != nil {
-		return EpochInfo{}, fmt.Errorf(
-			"get epoch end time for slot %d: %w",
-			endSlot,
-			err,
-		)
-	}
+	endTime := epochEndTime(startTime, tipEpoch)
 	blockCount, firstBlockSlot, lastBlockSlot, err := a.ledgerState.CountBlocksInSlotRange(
 		tipEpoch.StartSlot,
 		tip.Point.Slot,
@@ -836,13 +829,9 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 			)
 		}
 		endSlot := last.StartSlot + uint64(last.LengthInSlots)
-		endTime, err := a.ledgerState.SlotToTime(endSlot)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"get era %s end time: %w",
-				era.Name,
-				err,
-			)
+		endTime := startTime
+		for _, epoch := range epochs {
+			endTime = epochEndTime(endTime, epoch)
 		}
 		slotLengthMs := uint64(last.SlotLength)
 		slotLengthSeconds := (slotLengthMs + 500) / 1000
@@ -869,6 +858,14 @@ func (a *NodeAdapter) NetworkEras() ([]NetworkEraInfo, error) {
 		})
 	}
 	return ret, nil
+}
+
+func epochEndTime(startTime time.Time, epoch models.Epoch) time.Time {
+	// Epoch length and slot length are protocol-bounded.
+	// #nosec G115
+	duration := time.Duration(epoch.LengthInSlots) *
+		time.Duration(epoch.SlotLength) * time.Millisecond
+	return startTime.Add(duration)
 }
 
 // Genesis returns Shelley genesis configuration values.

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -26,11 +26,10 @@ import (
 // transition info.
 //
 // The returned Summary's past eras are closed with bounds computed by walking
-// the epoch cache grouped by EraId. The current era (the last group) is left
-// unbounded (SafeZoneSlots == 0), preserving the existing "project forward
-// using the current era's parameters" behavior of LedgerState.SlotToTime and
-// friends. Once dingo tracks per-era safe zones end-to-end, this will flip to
-// a bounded end sourced from BuildSummary + the real TransitionInfo.
+// the epoch cache grouped by EraId. The current era is passed through
+// hardfork.BuildSummary with the safe zone from the configured era Shape and
+// the ledger's current TransitionInfo. This gives in-memory callers the same
+// bounded forecast inputs used by the NtC HardForkEraHistory query.
 func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 	// SystemStart is sourced from the Shelley genesis when available. When it
 	// isn't (e.g. SlotToEpoch-style callers that work from the epoch cache
@@ -43,9 +42,10 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		}
 	}
 
-	snapshot := ls.loadConsensusSnapshot()
-	cache := snapshot.epochCache
-	transitionInfo := snapshot.transitionInfo
+	consensusState, tipState := ls.loadStateSnapshots()
+	cache := consensusState.epochCache
+	transitionInfo := consensusState.transitionInfo
+	tipSlot := tipState.currentTip.Point.Slot
 
 	if len(cache) == 0 {
 		return nil, errors.New("ledger: no epochs in cache")
@@ -54,7 +54,7 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 	// Walk the epoch cache grouping contiguous epochs by EraId. Each group
 	// becomes one EraSummary; its Start is derived from the first epoch of
 	// the group, and its End (for past eras) is the Start of the next group.
-	var eras []hardfork.EraSummary
+	eraSummaries := make([]hardfork.EraSummary, 0, len(cache))
 	relTime := time.Duration(0)
 
 	i := 0
@@ -93,13 +93,13 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 			Epoch:        last.EpochId + 1,
 		}
 
-		era := hardfork.EraSummary{
+		eraSummary := hardfork.EraSummary{
 			EraID: eraID,
 			Start: start,
 			Params: hardfork.EraParams{
 				EpochSize:     epochSize,
 				SlotLength:    slotLen,
-				SafeZoneSlots: 0, // UnsafeIndefiniteSafeZone — preserve projection
+				SafeZoneSlots: 0,
 				GenesisWindow: 0,
 			},
 		}
@@ -107,16 +107,55 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		isLast := j == len(cache)
 		if !isLast {
 			// Close this era at the next era's start.
-			era.End = &end
+			eraSummary.End = &end
 		}
-		eras = append(eras, era)
+		eraSummaries = append(eraSummaries, eraSummary)
 
 		i = j
 	}
 
-	return &hardfork.Summary{
-		SystemStart: systemStart,
-		Eras:        eras,
-		Transition:  transitionInfo,
-	}, nil
+	current := eraSummaries[len(eraSummaries)-1]
+	past := eraSummaries[:len(eraSummaries)-1]
+
+	// Use the same configured safe-zone source as the NtC era-history query.
+	// Tests and early bootstrap callers may construct a LedgerState without a
+	// complete node configuration; in that case eraShape is unavailable and
+	// the legacy indefinite safe zone remains the only defensible answer.
+	shape := ls.eraShape()
+	shapeEntry, shapeAvailable := shape.EraForID(current.EraID)
+	if shapeAvailable {
+		current.Params.SafeZoneSlots = shapeEntry.Params.SafeZoneSlots
+		current.Params.GenesisWindow = shapeEntry.Params.GenesisWindow
+		systemStart = shape.SystemStart
+	}
+	if !shapeAvailable {
+		return &hardfork.Summary{
+			SystemStart: systemStart,
+			Eras:        append(past, current),
+			Transition:  transitionInfo,
+		}, nil
+	}
+
+	effectiveTransition := transitionInfo
+	if transitionInfo.State == hardfork.TransitionImpossible {
+		// queryHardForkEraHistory can stop at the confirmed current epoch
+		// boundary because it serves a point-in-time answer. Live slot and
+		// header processing must remain able to cross that boundary in the
+		// same era. Apply the rolling safe zone from the tip while preserving
+		// TransitionImpossible on the returned Summary.
+		effectiveTransition = hardfork.NewTransitionUnknown()
+	}
+
+	summary, err := hardfork.BuildSummary(
+		hardfork.Shape{SystemStart: systemStart},
+		past,
+		current,
+		tipSlot,
+		effectiveTransition,
+	)
+	if err != nil {
+		return nil, err
+	}
+	summary.Transition = transitionInfo
+	return &summary, nil
 }

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -126,7 +126,9 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 	if shapeAvailable {
 		current.Params.SafeZoneSlots = shapeEntry.Params.SafeZoneSlots
 		current.Params.GenesisWindow = shapeEntry.Params.GenesisWindow
-		systemStart = shape.SystemStart
+		if !shape.SystemStart.IsZero() {
+			systemStart = shape.SystemStart
+		}
 	}
 	if !shapeAvailable {
 		return &hardfork.Summary{

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -15,7 +15,6 @@
 package ledger
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -29,15 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// minimalShelleyGenesisCfg loads a shelley genesis with only SystemStart
-// populated — matching the pattern used by slot_test.go.
+// minimalShelleyGenesisCfg returns the smallest test configuration that also
+// provides the era shape and stability-window inputs used by HardForkSummary.
 func minimalShelleyGenesisCfg(t *testing.T) *cardano.CardanoNodeConfig {
 	t.Helper()
-	cfg := &cardano.CardanoNodeConfig{}
-	require.NoError(t, cfg.LoadShelleyGenesisFromReader(
-		strings.NewReader(`{"systemStart": "2022-10-25T00:00:00Z"}`),
-	))
-	return cfg
+	return newTestEraHistoryCfg(t)
 }
 
 // TestHardForkSummary_SingleEra verifies the simple case: one era spanning
@@ -66,14 +61,17 @@ func TestHardForkSummary_SingleEra(t *testing.T) {
 	era := sum.Eras[0]
 	assert.Equal(t, uint(1), era.EraID)
 	assert.Equal(t, hardfork.Bound{RelativeTime: 0, Slot: 0, Epoch: 0}, era.Start)
-	assert.Nil(t, era.End, "current era should be unbounded")
+	require.NotNil(t, era.End, "current era should be safe-zone bounded")
+	assert.Equal(t, uint64(26_200), era.End.Slot)
+	assert.Equal(t, uint64(262), era.End.Epoch)
 	assert.Equal(t, uint64(100), era.Params.EpochSize)
 	assert.Equal(t, time.Second, era.Params.SlotLength)
-	assert.Equal(t, uint64(0), era.Params.SafeZoneSlots, "current era unbounded ⇒ SafeZoneSlots=0")
+	assert.Equal(t, uint64(25_920), era.Params.SafeZoneSlots)
+	assert.Equal(t, uint64(25_920), era.Params.GenesisWindow)
 }
 
 // TestHardForkSummary_TwoEras verifies two contiguous eras produce a Summary
-// with the first era bounded and the second (current) era unbounded.
+// with the first era bounded and the second (current) era safe-zone bounded.
 func TestHardForkSummary_TwoEras(t *testing.T) {
 	ls := &LedgerState{
 		epochCache: []models.Epoch{
@@ -111,7 +109,9 @@ func TestHardForkSummary_TwoEras(t *testing.T) {
 	assert.Equal(t, uint(1), shelley.EraID)
 	// Shelley's Start must line up with Byron's End.
 	assert.Equal(t, *byron.End, shelley.Start)
-	assert.Nil(t, shelley.End, "current era unbounded")
+	require.NotNil(t, shelley.End, "current era should be safe-zone bounded")
+	assert.Equal(t, uint64(26_984), shelley.End.Slot)
+	assert.Equal(t, uint64(64), shelley.End.Epoch)
 	assert.Equal(t, uint64(432), shelley.Params.EpochSize)
 	assert.Equal(t, time.Second, shelley.Params.SlotLength)
 
@@ -168,8 +168,96 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
 		},
 	}
+	// A resolved zero safe zone is valid and must still flow through
+	// BuildSummary so TransitionKnown can set the confirmed era boundary.
+	shape := hardfork.Shape{
+		SystemStart: time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC),
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     100,
+				SlotLength:    time.Second,
+				SafeZoneSlots: 0,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
 	ls.publishSnapshotsLocked()
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
 	assert.Equal(t, hardfork.NewTransitionKnown(7), sum.Transition)
+	require.Len(t, sum.Eras, 1)
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Zero(t, sum.Eras[0].Params.SafeZoneSlots)
+	assert.Equal(t, uint64(700), sum.Eras[0].End.Slot)
+	assert.Equal(t, uint64(7), sum.Eras[0].End.Epoch)
+}
+
+func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       500,
+				StartSlot:     100_000,
+				SlotLength:    1_000,
+				LengthInSlots: 432_000,
+				EraId:         eras.ConwayEraDesc.Id,
+			},
+		},
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(200_000, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	require.Len(t, sum.Eras, 1)
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Equal(t, uint64(532_000), sum.Eras[0].End.Slot)
+
+	_, err = sum.SlotToEpoch(531_999)
+	require.NoError(t, err)
+	_, err = sum.SlotToEpoch(532_000)
+	assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+}
+
+func TestHardForkSummary_TransitionImpossibleKeepsLiveForecastRolling(
+	t *testing.T,
+) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				SlotLength:    1_000,
+				LengthInSlots: 500,
+				EraId:         eras.ConwayEraDesc.Id,
+			},
+		},
+		currentEra:     eras.ConwayEraDesc,
+		transitionInfo: hardfork.NewTransitionImpossible(),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(455, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	assert.Equal(t, hardfork.NewTransitionImpossible(), sum.Transition)
+	require.Len(t, sum.Eras, 1)
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Equal(t, uint64(26_500), sum.Eras[0].End.Slot)
+
+	_, err = sum.SlotToEpoch(500)
+	require.NoError(t, err,
+		"a known same-era epoch boundary must remain forecastable")
 }

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -169,9 +169,9 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 		},
 	}
 	// A resolved zero safe zone is valid and must still flow through
-	// BuildSummary so TransitionKnown can set the confirmed era boundary.
+	// BuildSummary so TransitionKnown can set the confirmed era boundary. Its
+	// zero SystemStart must not replace the Shelley genesis value.
 	shape := hardfork.Shape{
-		SystemStart: time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC),
 		Eras: []hardfork.ShapeEntry{{
 			EraID: 1,
 			Params: hardfork.EraParams{
@@ -186,6 +186,11 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
 	assert.Equal(t, hardfork.NewTransitionKnown(7), sum.Transition)
+	assert.Equal(
+		t,
+		time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC),
+		sum.SystemStart,
+	)
 	require.Len(t, sum.Eras, 1)
 	require.NotNil(t, sum.Eras[0].End)
 	assert.Zero(t, sum.Eras[0].Params.SafeZoneSlots)
@@ -224,6 +229,137 @@ func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {
 	require.NoError(t, err)
 	_, err = sum.SlotToEpoch(532_000)
 	assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+}
+
+func TestHardForkSummary_MainnetForecastBoundary(t *testing.T) {
+	testCases := []struct {
+		name          string
+		tipSlot       uint64
+		wantEndSlot   uint64
+		nextEpochOpen bool
+	}{
+		{
+			name:        "before nonce cutoff",
+			tipSlot:     302_399,
+			wantEndSlot: 432_000,
+		},
+		{
+			name:          "at nonce cutoff",
+			tipSlot:       302_400,
+			wantEndSlot:   864_000,
+			nextEpochOpen: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := minimalShelleyGenesisCfg(t)
+			ls := &LedgerState{
+				epochCache: []models.Epoch{{
+					EpochId:       0,
+					StartSlot:     0,
+					SlotLength:    1_000,
+					LengthInSlots: 432_000,
+					EraId:         eras.ConwayEraDesc.Id,
+				}},
+				currentEra: eras.ConwayEraDesc,
+				currentTip: ochainsync.Tip{
+					Point: ocommon.NewPoint(
+						testCase.tipSlot,
+						[]byte("tip"),
+					),
+				},
+				config: LedgerStateConfig{CardanoNodeConfig: cfg},
+			}
+			shape := hardfork.Shape{
+				SystemStart: cfg.ShelleyGenesis().SystemStart,
+				Eras: []hardfork.ShapeEntry{{
+					EraID: eras.ConwayEraDesc.Id,
+					Params: hardfork.EraParams{
+						EpochSize:     432_000,
+						SlotLength:    time.Second,
+						SafeZoneSlots: 129_600,
+						GenesisWindow: 129_600,
+					},
+				}},
+			}
+			ls.cachedShape.Store(&shape)
+			ls.publishSnapshotsLocked()
+
+			sum, err := ls.HardForkSummary()
+			require.NoError(t, err)
+			require.Len(t, sum.Eras, 1)
+			require.NotNil(t, sum.Eras[0].End)
+			assert.Equal(t, testCase.wantEndSlot, sum.Eras[0].End.Slot)
+
+			_, err = ls.EpochInfo(1)
+			if testCase.nextEpochOpen {
+				require.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+			}
+
+			// Arbitrary time queries stay bounded at the exclusive end.
+			endTime := sum.SystemStart.Add(
+				time.Duration(testCase.wantEndSlot) * time.Second,
+			)
+			_, err = ls.TimeToSlot(endTime)
+			assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+
+			// Operational near-now timing remains available to a node whose
+			// ledger is catching up from behind the forecast.
+			currentSlot, err := ls.TimeToSlot(time.Now())
+			require.NoError(t, err)
+			assert.Greater(t, currentSlot, testCase.wantEndSlot)
+		})
+	}
+}
+
+func TestEpochInfoUsesMaterializedEpochPastForecast(t *testing.T) {
+	cfg := minimalShelleyGenesisCfg(t)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				SlotLength:    1_000,
+				LengthInSlots: 100,
+				EraId:         eras.ShelleyEraDesc.Id,
+			},
+			{
+				EpochId:       10,
+				StartSlot:     1_000,
+				SlotLength:    1_000,
+				LengthInSlots: 100,
+				EraId:         eras.ShelleyEraDesc.Id,
+			},
+		},
+		currentEra: eras.ShelleyEraDesc,
+		config:     LedgerStateConfig{CardanoNodeConfig: cfg},
+	}
+	shape := hardfork.Shape{
+		SystemStart: cfg.ShelleyGenesis().SystemStart,
+		Eras: []hardfork.ShapeEntry{{
+			EraID: eras.ShelleyEraDesc.Id,
+			Params: hardfork.EraParams{
+				EpochSize:     100,
+				SlotLength:    time.Second,
+				SafeZoneSlots: 1,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	_, err = sum.EpochInfo(10)
+	require.ErrorIs(t, err, hardfork.ErrPastHorizon)
+
+	info, err := ls.EpochInfo(10)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000), info.StartSlot)
+	assert.Equal(t, uint(100), info.LengthInSlots)
 }
 
 func TestHardForkSummary_TransitionImpossibleKeepsLiveForecastRolling(

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -33,10 +33,8 @@ var ErrBeforeGenesis = errors.New("time is before genesis start")
 //
 // Slot 0 always maps to Shelley genesis SystemStart, regardless of whether
 // the epoch cache is populated. Other slots are resolved via the
-// hardfork.Summary built from the LedgerState's epoch cache; slots past the
-// last known epoch are projected using the current era's slot length (the
-// Summary's current era is unbounded, mirroring the legacy projection
-// behavior).
+// hardfork.Summary built from the LedgerState's epoch cache. The current era
+// can be projected only through its configured safe-zone horizon.
 func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 	if slot > math.MaxInt64 {
 		return time.Time{}, errors.New("slot is larger than time.Duration")
@@ -81,9 +79,7 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 	}
 	slot, sumErr := sum.TimeToSlot(t)
 	if sumErr != nil {
-		// With an unbounded current era in HardForkSummary this is
-		// unreachable for t >= SystemStart, but we preserve the legacy
-		// error message for any future bounded-summary configuration.
+		// Do not project wall-clock time past the HFC forecast horizon.
 		return 0, errors.New("time not found in known epochs")
 	}
 	return slot, nil
@@ -91,10 +87,10 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 
 // SlotToEpoch returns the epoch containing the given slot.
 //
-// Slots within the known epoch cache resolve to the cached epoch's
-// parameters; slots past the cache are projected using the current era's
-// parameters. Returns an error for an empty cache or for slots before the
-// first known epoch (matching legacy error messages).
+// Slots within the known epoch cache resolve to the cached epoch's parameters;
+// slots past the cache are projected using the current era's parameters only
+// through the configured safe-zone horizon. Returns an error for an empty
+// cache or for slots outside that range.
 func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	sum, err := ls.HardForkSummary()
 	if err != nil {
@@ -128,10 +124,10 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 
 // EpochInfo returns boundary information for the given epoch.
 //
-// Epochs within the known epoch cache resolve to cached-era parameters;
-// epochs past the cache are projected using the current era's parameters.
-// Returns an error for an empty cache or for epochs before the first known
-// era.
+// Epochs within the known epoch cache resolve to cached-era parameters; epochs
+// past the cache are projected using the current era's parameters only through
+// the configured safe-zone horizon. Returns an error for an empty cache or for
+// epochs outside that range.
 func (ls *LedgerState) EpochInfo(epoch uint64) (models.Epoch, error) {
 	sum, err := ls.HardForkSummary()
 	if err != nil {

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -16,8 +16,10 @@ package ledger
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -55,10 +57,10 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 
 // TimeToSlot returns the slot containing the given wall-clock time.
 //
-// Returns ErrBeforeGenesis when t is before SystemStart. When the epoch cache
-// is empty but t is within 5 seconds of now, falls back to a coarse
-// approximation using the Shelley genesis slot length — this is useful at
-// chain genesis before any epochs have been persisted.
+// Returns ErrBeforeGenesis when t is before SystemStart. Near-now calls used by
+// the operational slot clock retain current-era extrapolation when the ledger
+// is empty or behind the HFC forecast horizon; arbitrary time queries remain
+// bounded.
 func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil {
@@ -69,18 +71,23 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 	}
 	sum, err := ls.HardForkSummary()
 	if err != nil {
-		// time.Since(t) == now - t, so it is negative for future times.
-		// Guard both directions so arbitrary future times don't match the
-		// "near now" fallback.
-		if d := time.Since(t); d >= -5*time.Second && d < 5*time.Second {
+		if isNearNow(t) {
 			return nearNowSlot(shelleyGenesis), nil
 		}
 		return 0, errors.New("time not found in known epochs")
 	}
 	slot, sumErr := sum.TimeToSlot(t)
 	if sumErr != nil {
-		// Do not project wall-clock time past the HFC forecast horizon.
-		return 0, errors.New("time not found in known epochs")
+		// CurrentSlot drives operational timing while a node catches up after
+		// downtime. Preserve its legacy current-era extrapolation without
+		// weakening the bounded Summary used by header validation and arbitrary
+		// time queries.
+		if errors.Is(sumErr, hardfork.ErrPastHorizon) && isNearNow(t) {
+			if currentSlot, ok := currentEraSlotAtTime(sum, t); ok {
+				return currentSlot, nil
+			}
+		}
+		return 0, fmt.Errorf("time not found in known epochs: %w", sumErr)
 	}
 	return slot, nil
 }
@@ -99,11 +106,9 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 	info, err := sum.SlotToEpoch(slot)
 	if err != nil {
 		if errors.Is(err, hardfork.ErrPastHorizon) {
-			// ErrPastHorizon fires for slots outside every era's bounds —
-			// either below the first era's start or past the last bounded
-			// era's end. Don't claim a direction we don't know.
-			return models.Epoch{}, errors.New(
-				"slot is outside the known epoch range",
+			return models.Epoch{}, fmt.Errorf(
+				"slot is outside the known epoch range: %w",
+				err,
 			)
 		}
 		return models.Epoch{}, err
@@ -129,6 +134,13 @@ func (ls *LedgerState) SlotToEpoch(slot uint64) (models.Epoch, error) {
 // the configured safe-zone horizon. Returns an error for an empty cache or for
 // epochs outside that range.
 func (ls *LedgerState) EpochInfo(epoch uint64) (models.Epoch, error) {
+	cache := ls.loadConsensusSnapshot().epochCache
+	for _, cachedEpoch := range slices.Backward(cache) {
+		if cachedEpoch.EpochId == epoch {
+			return epochBoundaryInfo(cachedEpoch), nil
+		}
+	}
+
 	sum, err := ls.HardForkSummary()
 	if err != nil {
 		return models.Epoch{}, errors.New("no epochs in cache")
@@ -136,8 +148,9 @@ func (ls *LedgerState) EpochInfo(epoch uint64) (models.Epoch, error) {
 	info, err := sum.EpochInfo(epoch)
 	if err != nil {
 		if errors.Is(err, hardfork.ErrPastHorizon) {
-			return models.Epoch{}, errors.New(
-				"epoch is outside the known epoch range",
+			return models.Epoch{}, fmt.Errorf(
+				"epoch is outside the known epoch range: %w",
+				err,
 			)
 		}
 		return models.Epoch{}, err
@@ -153,6 +166,46 @@ func (ls *LedgerState) EpochInfo(epoch uint64) (models.Epoch, error) {
 		// #nosec G115
 		LengthInSlots: uint(info.LengthInSlots),
 	}, nil
+}
+
+func epochBoundaryInfo(epoch models.Epoch) models.Epoch {
+	return models.Epoch{
+		EpochId:       epoch.EpochId,
+		StartSlot:     epoch.StartSlot,
+		EraId:         epoch.EraId,
+		SlotLength:    epoch.SlotLength,
+		LengthInSlots: epoch.LengthInSlots,
+	}
+}
+
+func isNearNow(t time.Time) bool {
+	// time.Since(t) == now - t, so it is negative for future times. Guard both
+	// directions so arbitrary future times do not match the operational fallback.
+	d := time.Since(t)
+	return d >= -5*time.Second && d < 5*time.Second
+}
+
+func currentEraSlotAtTime(
+	sum *hardfork.Summary,
+	t time.Time,
+) (uint64, bool) {
+	if sum == nil || len(sum.Eras) == 0 {
+		return 0, false
+	}
+	current := sum.Eras[len(sum.Eras)-1]
+	relativeTime := t.Sub(sum.SystemStart)
+	if relativeTime < current.Start.RelativeTime ||
+		current.Params.SlotLength <= 0 {
+		return 0, false
+	}
+	slotOffset := (relativeTime - current.Start.RelativeTime) /
+		current.Params.SlotLength
+	// slotOffset is non-negative and time.Duration-bounded.
+	slotsIntoEra := uint64(slotOffset) // #nosec G115
+	if slotsIntoEra > math.MaxUint64-current.Start.Slot {
+		return 0, false
+	}
+	return current.Start.Slot + slotsIntoEra, true
 }
 
 // shelleySlotLengthMs returns the Shelley genesis slot length in milliseconds,

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -15,12 +15,14 @@
 package ledger
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 )
 
 func TestSlotCalc(t *testing.T) {
@@ -302,7 +304,10 @@ func TestSlotToEpochBeforeFirstEpoch(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for slot before first known epoch")
 	}
-	if err.Error() != "slot is outside the known epoch range" {
+	if !errors.Is(err, hardfork.ErrPastHorizon) {
+		t.Errorf("expected ErrPastHorizon, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "slot is outside the known epoch range") {
 		t.Errorf("unexpected error message: %s", err.Error())
 	}
 

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/consensus/praos"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -282,6 +283,35 @@ func (ls *LedgerState) headerVerificationEpoch(
 	blockSlot uint64,
 	allowEpochCacheAdvance bool,
 ) (models.Epoch, error) {
+	// The epoch cache can be forecast forward for near-future headers, but it
+	// must never be advanced past the HFC safe zone or a known era boundary.
+	// Check the immutable summary first so ErrPastHorizon is surfaced before
+	// ensureEpochForSlot mutates any forecasted nonce state.
+	if len(ls.loadConsensusSnapshot().epochCache) > 0 {
+		summary, err := ls.HardForkSummary()
+		if err != nil {
+			return models.Epoch{}, fmt.Errorf(
+				"block header verification rejected: build forecast for slot %d: %w",
+				blockSlot,
+				err,
+			)
+		}
+		if _, err := summary.SlotToEpoch(blockSlot); err != nil {
+			if errors.Is(err, hardfork.ErrPastHorizon) {
+				return models.Epoch{}, fmt.Errorf(
+					"block header verification rejected at slot %d: %w",
+					blockSlot,
+					err,
+				)
+			}
+			return models.Epoch{}, fmt.Errorf(
+				"block header verification rejected: forecast slot %d: %w",
+				blockSlot,
+				err,
+			)
+		}
+	}
+
 	// Look up the epoch for this block's slot from the epoch cache.
 	// This is an epoch-aware lookup that searches through all known
 	// epochs rather than only the current one, ensuring that blocks

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -36,6 +36,7 @@ import (
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	ledgersnapshot "github.com/blinklabs-io/dingo/ledger/snapshot"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/consensus"
@@ -45,6 +46,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/stretchr/testify/assert"
@@ -717,6 +719,45 @@ func TestVerifyBlockHeaderCrypto_RejectsBlockOutsideKnownEpochs(
 		"block outside known epochs must be rejected, not skipped",
 	)
 	assert.Contains(t, err.Error(), "no epoch data for slot")
+}
+
+func TestHeaderVerificationEpochRejectsPastForecastBeforeCacheAdvance(
+	t *testing.T,
+) {
+	const horizonSlot = uint64(532_000)
+	ls := &LedgerState{
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(200_000, []byte("tip")),
+		},
+		epochCache: []models.Epoch{
+			{
+				EpochId:       500,
+				StartSlot:     100_000,
+				SlotLength:    1_000,
+				LengthInSlots: 432_000,
+				EraId:         eras.ConwayEraDesc.Id,
+				Nonce:         []byte{0x01},
+			},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger: slog.New(
+				slog.NewJSONHandler(io.Discard, nil),
+			),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	epoch, err := ls.headerVerificationEpoch(horizonSlot-1, true)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(500), epoch.EpochId)
+
+	_, err = ls.headerVerificationEpoch(horizonSlot, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
+	assert.Len(t, ls.loadConsensusSnapshot().epochCache, 1,
+		"past-horizon rejection must happen before forecast cache mutation")
 }
 
 // TestVerifyBlockHeaderCrypto_RejectsBlockWithNoNonce verifies that a block

--- a/node_forging.go
+++ b/node_forging.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/dingo/internal/leiosheader"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/dingo/ledger/leader"
 	"github.com/blinklabs-io/dingo/ledger/leios"
 	"github.com/blinklabs-io/dingo/ledger/snapshot"
@@ -577,7 +578,40 @@ func (a *epochInfoAdapter) EpochSlotRange(
 ) (leader.EpochSlotRange, error) {
 	info, err := a.ledgerState.EpochInfo(epoch)
 	if err != nil {
-		return leader.EpochSlotRange{}, err
+		if !errors.Is(err, hardfork.ErrPastHorizon) {
+			return leader.EpochSlotRange{}, err
+		}
+		// The nonce-stability cutoff can precede the HFC header horizon. Once
+		// the next epoch's nonce is stable, leader election still needs that
+		// immediate Praos epoch's slot range to precompute its schedule. All
+		// Praos eras use the Shelley genesis epoch/slot dimensions.
+		readyEpoch, ready := a.ledgerState.NextEpochNonceReadyEpoch()
+		currentEpoch := a.ledgerState.CurrentEpoch()
+		if !ready ||
+			readyEpoch != epoch ||
+			currentEpoch == ^uint64(0) ||
+			epoch != currentEpoch+1 {
+			return leader.EpochSlotRange{}, err
+		}
+		currentInfo, currentErr := a.ledgerState.EpochInfo(
+			currentEpoch,
+		)
+		if currentErr != nil {
+			return leader.EpochSlotRange{}, currentErr
+		}
+		slotCount := uint64(currentInfo.LengthInSlots)
+		if slotCount == 0 ||
+			currentInfo.StartSlot > ^uint64(0)-slotCount {
+			return leader.EpochSlotRange{}, fmt.Errorf(
+				"current epoch slot range is invalid: start=%d count=%d",
+				currentInfo.StartSlot,
+				slotCount,
+			)
+		}
+		return leader.EpochSlotRange{
+			StartSlot: currentInfo.StartSlot + slotCount,
+			SlotCount: slotCount,
+		}, nil
 	}
 	return leader.EpochSlotRange{
 		StartSlot: info.StartSlot,

--- a/node_plugin_selection_test.go
+++ b/node_plugin_selection_test.go
@@ -113,6 +113,10 @@ func registerAPIProbe(
 func newAPIPluginRuntimeNode(t *testing.T) *Node {
 	t.Helper()
 	cardanoCfg := newNodeTestCardanoNodeCfg(t)
+	// The embedded Preview genesis is historical, while this fixture starts
+	// with a zero-slot ledger. Keep wall-clock startup inside the bounded HFC
+	// forecast so these API lifecycle tests can reach their intended path.
+	cardanoCfg.ShelleyGenesis().SystemStart = time.Now().Add(-time.Minute)
 	n, err := New(NewConfig(
 		WithDatabasePath(t.TempDir()),
 		WithCardanoNodeConfig(cardanoCfg),

--- a/node_plugin_selection_test.go
+++ b/node_plugin_selection_test.go
@@ -113,10 +113,6 @@ func registerAPIProbe(
 func newAPIPluginRuntimeNode(t *testing.T) *Node {
 	t.Helper()
 	cardanoCfg := newNodeTestCardanoNodeCfg(t)
-	// The embedded Preview genesis is historical, while this fixture starts
-	// with a zero-slot ledger. Keep wall-clock startup inside the bounded HFC
-	// forecast so these API lifecycle tests can reach their intended path.
-	cardanoCfg.ShelleyGenesis().SystemStart = time.Now().Add(-time.Minute)
 	n, err := New(NewConfig(
 		WithDatabasePath(t.TempDir()),
 		WithCardanoNodeConfig(cardanoCfg),


### PR DESCRIPTION
Closes #2611

## Summary

- Bound live header verification and slot/epoch/time forecasts to the configured hard-fork safe zone.
- Preserve `hardfork.ErrPastHorizon` through ledger query adapters and serve already-materialized epochs from the immutable cache.
- Preserve valid zero safe-zone values and retain the Shelley genesis system start when a cached shape does not provide one.
- Calculate Blockfrost epoch/era interval endpoints without querying the exclusive end slot.
- Keep stale-node operational `TimeToSlot(time.Now())` available without allowing arbitrary out-of-horizon time queries.
- Allow leader-election precomputation only for the nonce-ready immediate next Praos epoch; general ledger and header forecasts remain bounded.

## Horizon semantics

The live in-memory summary deliberately applies a rolling `TransitionUnknown`
calculation when stored transition state is `TransitionImpossible`, then restores
the reported transition state. This differs from the point-in-time NtC
hard-fork-history response: a live node must continue within the current era
after the confirmed boundary instead of halting there.

The current-era end remains exclusive and is not extended by an extra epoch.
Blockfrost treats it as an interval endpoint, while leader scheduling gets only
the immediate next epoch after its nonce becomes stable. Header acceptance is
therefore still limited to the 3k/f forecast horizon.

## Validation

- `go test ./...`
- `go test -race -count=1 -run 'TestHardForkSummary|TestEpochInfoUsesMaterialized' ./ledger`
- `golangci-lint run ./...`
- `make import-boundaries`
- `make golines`
- all-Dingo `TestEpochBoundaryConsensus`: passed after rollover, all nodes converged at slot 717
- mixed Dingo/cardano-node `TestEpochBoundaryConsensus`: passed after rollover, nodes converged at slots 719-720

`ARCHITECTURE.md` documents the bounded query behavior and narrow operational
exceptions. `DATABASE.md` was checked and is not affected.
