### PR TITLE
fix(ledger): stop non-converging replay recovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1882,6 +1882,22 @@ paths finish bringing metadata to its common ancestor. Live at-tip recovery uses
 the same bounded event-aware helper; startup-only speculative-tail cleanup stays
 eventless because subscribers have not begun consuming live chain events.
 Rewinding metadata alone would replay the same corrupt chain indefinitely.
+The unresolved-producer fallback also tracks the applied ledger high-water
+mark across attempts. Different candidate continuations can move the failing
+block forward slightly while rebuilding to the same applied tip, so failure
+slot or transaction identity is not a reliable convergence signal. After
+`maxReplayRecoveryNoProgress` consecutive attempts fail to cross that applied
+tip, recovery holds there instead of pruning another security-parameter
+window, emits `dingo_ledger_replay_recovery_nonconverging_total`, and publishes
+a `chainsync.resync` event with reason
+`replay tx validation recovery not converging`. Node composition routes that
+neutral event to Ouroboros, which closes the active ChainSync connection and
+forces a fresh intersection. The resync is published before local rollback
+work so a rollback error cannot suppress peer rotation. If an earlier recovery
+step has already pruned the primary chain below the applied ledger tip, the
+primary-chain rewind is an already-held no-op while ChainSync refills it.
+Successful block application beyond the recorded high-water mark clears the
+hold and restores the normal fallback budget.
 
 When a block fails per-tx validation at tip,
 the node rewinds the primary chain and rolls the ledger back so ChainSelection

--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -37,6 +37,7 @@ const (
 	ChainsyncResyncReasonForkResolutionExceedsK       = "fork resolution exceeds security parameter K"
 	ChainsyncResyncReasonLocalLedgerRollback          = "local ledger rollback"
 	ChainsyncResyncReasonLiveTxValidationRecovery     = "live tx validation recovery"
+	ChainsyncResyncReasonReplayRecoveryNonConverging  = "replay tx validation recovery not converging"
 	ChainsyncResyncReasonChainSwitchCursorAhead       = "chain switch cursor ahead of local tip"
 	ChainsyncResyncReasonBlockfetchTimeoutRetryFailed = "blockfetch timeout retry failed on all available connections"
 )

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -50,6 +50,10 @@ type stateMetrics struct {
 	// false-positive validation rejection), not a peer/fork problem. See
 	// issue #2939.
 	atTipRecoveryNonConverging prometheus.Counter
+	// Incremented when unresolved-producer replay recovery repeatedly fails
+	// to move the applied ledger tip forward and holds at that tip instead of
+	// pruning another security-parameter window. See issue #3005.
+	replayRecoveryNonConverging prometheus.Counter
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -153,6 +157,12 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.CounterOpts{
 			Name: "dingo_ledger_attip_recovery_nonconverging_total",
 			Help: "times at-tip validation recovery held at the ledger tip instead of rewinding the primary chain deeper, because a descending series of distinct failures indicated local validation divergence (operator intervention required)",
+		},
+	)
+	m.replayRecoveryNonConverging = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_ledger_replay_recovery_nonconverging_total",
+			Help: "times unresolved-producer replay recovery held at the applied ledger tip because repeated recovery attempts made no forward progress",
 		},
 	)
 }

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -87,6 +87,15 @@ const maxAtTipRecoveryAttempts = 3
 // false-positive validation rejection).
 const maxAtTipRecoveryDescents = 2
 
+// maxReplayRecoveryNoProgress caps consecutive unresolved-producer replay
+// recoveries that rebuild only to the same (or an older) applied ledger tip.
+// The failing block may change and creep forward while the applied high-water
+// mark remains fixed, so the ledger tip—not the failure identity—is the
+// convergence signal. Once tripped, recovery stops pruning another
+// security-parameter window and holds at the applied tip while forcing a fresh
+// ChainSync connection (issue #3005).
+const maxReplayRecoveryNoProgress = 2
+
 type atTipRecoveryAttempt struct {
 	BlockPoint ocommon.Point
 	TxHash     []byte
@@ -188,8 +197,32 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 	if candidate.ProducerTx != nil {
 		producerTxHash = hex.EncodeToString(candidate.ProducerTx.Hash)
 	}
+	if ls.recoveryRollbackExceedsMithrilBoundary(candidate.RollbackPoint) {
+		if err := ls.rejectReplayRecoveryAtMithrilBoundary(
+			validationErr,
+			candidate,
+			producerTxHash,
+		); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	rewindPrimaryChain := candidate.ProducerUnresolved &&
 		ls.config.ChainManager != nil
+	rewindPoint := candidate.RollbackPoint
+	replayHolding := false
+	primaryChainAlreadyHeld := false
+	var ledgerTip ochainsync.Tip
+	if rewindPrimaryChain {
+		ls.RLock()
+		ledgerTip = ls.currentTip
+		ls.RUnlock()
+		replayHolding = ls.observeReplayRecoveryTip(ledgerTip.Point.Slot)
+		if replayHolding {
+			rewindPoint = ledgerTip.Point
+			primaryChainAlreadyHeld = ls.chain.Tip().Point.Slot < rewindPoint.Slot
+		}
+	}
 	recoveryAction := "rewinding metadata state"
 	if rewindPrimaryChain {
 		recoveryAction = "rewinding primary chain and metadata state"
@@ -203,22 +236,33 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		"missing_input", candidate.Input.String(),
 		"producer_tx_hash", producerTxHash,
 		"producer_block_slot", candidate.ProducerBlock.Slot,
-		"rollback_slot", candidate.RollbackPoint.Slot,
-		"rollback_hash", hex.EncodeToString(candidate.RollbackPoint.Hash),
+		"rollback_slot", rewindPoint.Slot,
+		"rollback_hash", hex.EncodeToString(rewindPoint.Hash),
+		"holding", replayHolding,
 	)
-	if ls.recoveryRollbackExceedsMithrilBoundary(candidate.RollbackPoint) {
-		if err := ls.rejectReplayRecoveryAtMithrilBoundary(
-			validationErr,
-			candidate,
-			producerTxHash,
-		); err != nil {
-			return false, err
-		}
-		return true, nil
+	if replayHolding {
+		ls.metrics.replayRecoveryNonConverging.Inc()
+		ls.config.Logger.Warn(
+			"replay recovery not converging after unresolved-producer failures, holding at applied ledger tip",
+			"component", "ledger",
+			"tx_hash", hex.EncodeToString(validationErr.TxHash),
+			"failing_block_slot", validationErr.BlockPoint.Slot,
+			"ledger_tip_slot", ledgerTip.Point.Slot,
+			"ledger_tip_hash", hex.EncodeToString(ledgerTip.Point.Hash),
+			"primary_chain_tip_slot", ls.chain.Tip().Point.Slot,
+			"primary_chain_already_held", primaryChainAlreadyHeld,
+			"no_progress_count", ls.replayRecoveryNoProgressCount,
+			"fallback_rollback_slot", candidate.RollbackPoint.Slot,
+			"hint", "forcing a fresh chainsync intersection; persistent failures may require operator intervention",
+		)
+		// Peer rotation is the escape mechanism for a held recovery. Publish
+		// it before the rollback calls so an unexpected local rollback error
+		// cannot suppress the fresh ChainSync intersection.
+		ls.publishReplayRecoveryNonConvergingResync(rewindPoint)
 	}
-	if rewindPrimaryChain {
+	if rewindPrimaryChain && !primaryChainAlreadyHeld {
 		if err := ls.rollbackPrimaryChainInSecurityParamWindows(
-			candidate.RollbackPoint,
+			rewindPoint,
 		); err != nil {
 			return false, fmt.Errorf(
 				"rewind primary chain for replay recovery: %w",
@@ -230,13 +274,76 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 	// available. If metadata synchronization fails, the primary chain is still
 	// at a valid retained point and the standard divergence reconciler can
 	// finish rolling metadata back to its common ancestor.
-	if err := ls.rollback(candidate.RollbackPoint); err != nil {
+	if err := ls.rollback(rewindPoint); err != nil {
 		return false, fmt.Errorf(
 			"rollback ledger state for replay recovery: %w",
 			err,
 		)
 	}
 	return true, nil
+}
+
+// observeReplayRecoveryTip records the applied tip seen immediately before an
+// unresolved-producer fallback. Recovery is non-converging when repeated
+// attempts fail to exceed the first observed high-water mark, even if peers
+// offer different failing blocks at slightly higher slots each cycle.
+func (ls *LedgerState) observeReplayRecoveryTip(tipSlot uint64) bool {
+	if !ls.replayRecoveryTipTracked {
+		ls.replayRecoveryTipTracked = true
+		ls.replayRecoveryHighWaterSlot = tipSlot
+		return false
+	}
+	if tipSlot <= ls.replayRecoveryHighWaterSlot {
+		ls.replayRecoveryNoProgressCount++
+	} else {
+		ls.replayRecoveryHighWaterSlot = tipSlot
+		ls.replayRecoveryNoProgressCount = 0
+		ls.replayRecoveryHolding = false
+	}
+	if ls.replayRecoveryNoProgressCount >= maxReplayRecoveryNoProgress {
+		ls.replayRecoveryHolding = true
+	}
+	return ls.replayRecoveryHolding
+}
+
+// resetReplayRecoveryNonProgress clears a replay hold only after block
+// application advances beyond the high-water mark that recovery could not
+// cross. Replaying blocks back up to that exact point is not progress.
+func (ls *LedgerState) resetReplayRecoveryNonProgress(newTipSlot uint64) {
+	if !ls.replayRecoveryTipTracked ||
+		newTipSlot <= ls.replayRecoveryHighWaterSlot {
+		return
+	}
+	ls.replayRecoveryTipTracked = false
+	ls.replayRecoveryHighWaterSlot = 0
+	ls.replayRecoveryNoProgressCount = 0
+	ls.replayRecoveryHolding = false
+}
+
+func (ls *LedgerState) publishReplayRecoveryNonConvergingResync(
+	point ocommon.Point,
+) {
+	if ls.config.EventBus == nil {
+		return
+	}
+	var activeConnId ouroboros.ConnectionId
+	if ls.config.GetActiveConnectionFunc != nil {
+		if connId := ls.config.GetActiveConnectionFunc(); connId != nil {
+			activeConnId = *connId
+		}
+	}
+	ls.config.EventBus.Publish(
+		event.ChainsyncResyncEventType,
+		event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{
+				ConnectionId: activeConnId,
+				Reason: event.
+					ChainsyncResyncReasonReplayRecoveryNonConverging,
+				Point: point,
+			},
+		),
+	)
 }
 
 // rollbackPrimaryChainInSecurityParamWindows reaches a deep corrective rewind

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -1417,6 +1417,214 @@ func TestTryRecoverFromTxValidationErrorFallsBackToSecurityParamWindow(
 	}
 }
 
+// TestTryRecoverFromTxValidationErrorReplayFallbackStopsNonConvergingRewinds
+// reproduces the terminal #3005 recovery cycle after prior, distinct failures
+// failed to advance the applied ledger high-water mark. Once the guard trips,
+// recovery must keep the applied tip instead of pruning another
+// security-parameter window and must force a fresh ChainSync connection even
+// when the primary chain was already pruned below that tip.
+func TestTryRecoverFromTxValidationErrorReplayFallbackStopsNonConvergingRewinds(
+	t *testing.T,
+) {
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+
+	cm, err := chain.NewManager(db, bus)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("nonconverging-parent", 100, 1, nil)
+	replayOneBlock := testRawBlock(
+		"nonconverging-replay-1",
+		120,
+		2,
+		parentBlock.Hash,
+	)
+	ledgerTipBlock := testRawBlock(
+		"nonconverging-ledger-tip",
+		140,
+		3,
+		replayOneBlock.Hash,
+	)
+	failingBlock := testRawBlock(
+		"nonconverging-failure",
+		162,
+		4,
+		ledgerTipBlock.Hash,
+	)
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks(
+			[]chain.RawBlock{
+				parentBlock,
+				replayOneBlock,
+			},
+		),
+	)
+	// Preserve the replay candidates in the block store while leaving the
+	// primary chain tip below the applied ledger tip. This is the #3005
+	// topology: an earlier recovery rewind has already moved the primary
+	// chain back, but ledger replay rebuilt to its previous high-water mark.
+	for _, block := range []chain.RawBlock{ledgerTipBlock, failingBlock} {
+		require.NoError(t, db.BlockCreate(models.Block{
+			Hash:     block.Hash,
+			PrevHash: block.PrevHash,
+			Cbor:     block.Cbor,
+			Slot:     block.Slot,
+			Number:   block.BlockNumber,
+			Type:     block.Type,
+		}, nil))
+	}
+
+	activeConnId := ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 3000,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.ParseIP("192.0.2.30"),
+			Port: 3001,
+		},
+	}
+	freshResyncCh := make(chan event.ChainsyncResyncEvent, 1)
+	resyncSubId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			resync, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok ||
+				resync.Reason != event.
+					ChainsyncResyncReasonReplayRecoveryNonConverging {
+				return
+			}
+			select {
+			case freshResyncCh <- resync:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, resyncSubId)
+	})
+
+	nodeConfig := newTestShelleyGenesisCfg(t)
+	nodeConfig.ShelleyGenesis().SecurityParam = 2
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		EventBus:          bus,
+		CardanoNodeConfig: nodeConfig,
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+			return &activeConnId
+		},
+	})
+	require.NoError(t, err)
+	ls.currentEra.Id = 1
+	require.NoError(t, cm.SetLedger(ls))
+	ls.metrics.init(prometheus.NewRegistry())
+
+	ledgerTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			ledgerTipBlock.Slot,
+			ledgerTipBlock.Hash,
+		),
+		BlockNumber: ledgerTipBlock.BlockNumber,
+	}
+	require.NoError(
+		t,
+		db.SetBlockNonce(
+			ledgerTip.Point.Hash,
+			ledgerTip.Point.Slot,
+			[]byte("nonce-nonconverging-tip"),
+			false,
+			nil,
+		),
+	)
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+	ls.currentTip = ledgerTip
+	ls.currentTipBlockNonce = []byte("nonce-nonconverging-tip")
+	ls.publishSnapshotsLocked()
+
+	// Model the two earlier recovery cycles. Failure identities are
+	// intentionally absent from this tracker: #3005 showed that their slots
+	// can creep forward while the applied tip remains unchanged.
+	require.False(t, ls.observeReplayRecoveryTip(ledgerTip.Point.Slot))
+	require.False(t, ls.observeReplayRecoveryTip(ledgerTip.Point.Slot))
+
+	recovered, err := ls.tryRecoverFromTxValidationError(
+		&txValidationError{
+			BlockPoint: ocommon.NewPoint(
+				failingBlock.Slot,
+				failingBlock.Hash,
+			),
+			TxHash: testHashBytes("nonconverging-tx"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  testHashBytes("missing-producer"),
+					index: 0,
+				},
+			},
+			Cause: errors.New("bad input"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	require.True(t, ls.replayRecoveryHolding)
+	assert.Equal(
+		t,
+		maxReplayRecoveryNoProgress,
+		ls.replayRecoveryNoProgressCount,
+	)
+	assert.Equal(t, ledgerTip, ls.currentTip)
+	primaryTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			replayOneBlock.Slot,
+			replayOneBlock.Hash,
+		),
+		BlockNumber: replayOneBlock.BlockNumber,
+	}
+	assert.Equal(t, primaryTip, ls.chain.Tip())
+	assert.Equal(
+		t,
+		1.0,
+		promtestutil.ToFloat64(ls.metrics.replayRecoveryNonConverging),
+	)
+	freshResync := testutil.RequireReceive(
+		t,
+		freshResyncCh,
+		5*time.Second,
+		"expected a fresh ChainSync intersection after replay recovery stopped converging",
+	)
+	assert.Equal(t, activeConnId.String(), freshResync.ConnectionId.String())
+	assert.Equal(t, ledgerTip.Point, freshResync.Point)
+}
+
+func TestResetReplayRecoveryNonProgressRequiresNewHighWater(t *testing.T) {
+	ls := &LedgerState{}
+	require.False(t, ls.observeReplayRecoveryTip(140))
+	require.False(t, ls.observeReplayRecoveryTip(140))
+	require.True(t, ls.observeReplayRecoveryTip(139))
+	require.True(t, ls.replayRecoveryHolding)
+
+	ls.resetReplayRecoveryNonProgress(140)
+	assert.True(t, ls.replayRecoveryHolding)
+	assert.True(t, ls.replayRecoveryTipTracked)
+
+	ls.resetReplayRecoveryNonProgress(141)
+	assert.False(t, ls.replayRecoveryHolding)
+	assert.False(t, ls.replayRecoveryTipTracked)
+	assert.Zero(t, ls.replayRecoveryHighWaterSlot)
+	assert.Zero(t, ls.replayRecoveryNoProgressCount)
+}
+
 func TestTryRecoverFromTxValidationErrorSkipsUnknownProducer(t *testing.T) {
 	db, err := dbtest.NewDatabase(t, &database.Config{
 		DataDir: t.TempDir(),

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -664,10 +664,20 @@ type LedgerState struct {
 	atTipRecoveryLastFailSlot uint64 // failing slot of the previous distinct at-tip failure
 	atTipRecoveryDescentCount int    // consecutive distinct failures that did not advance
 	atTipRecoveryHolding      bool   // sticky: deep rewinds suppressed until forward progress
-	mithrilLedgerSlot         uint64 // blocks at or below this slot are Mithril-verified; skip validation
-	mithrilLedgerHash         []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
-	lastLocalRollbackSeq      uint64
-	lastLocalRollbackPoint    ocommon.Point
+	// Replay recovery non-convergence tracking (issue #3005). The
+	// unresolved-producer fallback can encounter different, slowly advancing
+	// failing blocks while repeatedly rebuilding to the same applied tip.
+	// Track that applied high-water mark so changing failure identities do not
+	// hide the lack of ledger progress. These fields are only accessed by the
+	// ledger pipeline goroutine.
+	replayRecoveryTipTracked      bool
+	replayRecoveryHighWaterSlot   uint64
+	replayRecoveryNoProgressCount int
+	replayRecoveryHolding         bool
+	mithrilLedgerSlot             uint64 // blocks at or below this slot are Mithril-verified; skip validation
+	mithrilLedgerHash             []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
+	lastLocalRollbackSeq          uint64
+	lastLocalRollbackPoint        ocommon.Point
 
 	// Subscription IDs for event bus unsubscribe on close
 	chainsyncSubID           event.EventSubscriberId
@@ -3925,10 +3935,11 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				if len(pendingNonce) > 0 {
 					ls.currentTipBlockNonce = pendingNonce
 				}
-				// Forward progress past a prior at-tip failure clears the
-				// non-convergence hold so a later, unrelated failure gets a
-				// fresh recovery budget (issue #2939).
+				// Forward progress past a prior validation-recovery high-water
+				// mark clears its non-convergence hold so a later, unrelated
+				// failure gets a fresh recovery budget (issues #2939, #3005).
 				ls.resetAtTipRecoveryDescent(pendingTip.Point.Slot)
+				ls.resetReplayRecoveryNonProgress(pendingTip.Point.Slot)
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				if wantEnableValidation {
 					ls.validationEnabled = true

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -144,6 +144,7 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 		event.ChainsyncResyncReasonRollbackNotFound,
 		event.ChainsyncResyncReasonPersistentFork,
 		event.ChainsyncResyncReasonLiveTxValidationRecovery,
+		event.ChainsyncResyncReasonReplayRecoveryNonConverging,
 		event.ChainsyncResyncReasonChainSwitchCursorAhead,
 		event.ChainsyncResyncReasonRollbackExceedsK,
 		event.ChainsyncResyncReasonRollbackExceedsMithril,

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -2781,6 +2781,12 @@ func TestChainsyncResyncMithrilReasonsDenyPeerAndRequireFreshConnection(
 			wantDeniesPeer: false,
 		},
 		{
+			reason: event.
+				ChainsyncResyncReasonReplayRecoveryNonConverging,
+			wantFresh:      true,
+			wantDeniesPeer: false,
+		},
+		{
 			reason:         event.ChainsyncResyncReasonChainSwitchCursorAhead,
 			wantFresh:      true,
 			wantDeniesPeer: false,


### PR DESCRIPTION
Refs #3005

## Summary

- Bound unresolved-producer replay recovery by the applied ledger high-water mark and hold instead of repeatedly pruning another security-parameter window.
- Publish a neutral ChainSync resync request before local rollback work so rollback failures cannot suppress peer rotation.
- Treat a primary chain already below the applied ledger tip as already held while a fresh ChainSync intersection refills it.
- Keep Mithril-boundary rejection ahead of no-progress tracking and rewind logging, so rejected recovery attempts neither consume the no-progress budget nor claim a rewind occurred.
- Add metrics, routing coverage, the ledger-ahead-of-chain regression, and architecture documentation.

This addresses the non-converging replay fallback documented in #3005. It does not claim to fix the unresolved producer root cause or change reachedTip robustness.

## Validation

- go build ./...
- go test -race -count=1 ./ledger/... ./ouroboros/... ./event/...
- go test -race -count=1 ./internal/test/conformance/
- golangci-lint run ./...
- make import-boundaries
- make golines

modernize and nilaway retain unrelated pre-existing findings outside this change.