### PR TITLE
feat(blockfrost): add pool detail endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2377,8 +2377,8 @@ fields protect every API listener.
 A Blockfrost-compatible REST API that provides read access to chain data and
 transaction submission. The current router includes health/root, blocks,
 epochs/parameters, network/eras, genesis, assets, pools/extended, retiring
-pools, pool metadata, governance DRep list and lookup, address summary,
-address UTxOs and transactions, metadata label JSON/CBOR,
+pools, pool detail, pool metadata, governance DRep list and lookup, address
+summary, address UTxOs and transactions, metadata label JSON/CBOR,
 transaction content/CBOR/metadata/UTxOs/certificates/redeemers/required
 signers, and account/delegation/registration/reward endpoints. It uses an
 adapter pattern to translate between Dingo's internal state and Blockfrost

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1315,6 +1315,44 @@ WHERE r.rn = 1
 ORDER BY r.epoch, r.added_slot, r.block_index, r.cert_index;
 ```
 
+### `GetPoolCertificateHistory`
+
+Backs the Blockfrost pool-detail `registration`/`retirement` transaction-hash
+arrays. Two independent queries, one per certificate type, each an inner join
+from the certificate table to `certs` to `transaction` ordered chronologically
+(`added_slot`, `block_index`, `cert_index` ascending). The inner joins
+naturally exclude certificates with no linked transaction — rows synthesized
+by the Mithril ledger-state import carry `certificate_id = 0`, which matches
+no `certs` row — since they have no originating transaction to report; a
+Mithril-bootstrapped node therefore cannot show registration/retirement
+history that predates its snapshot, the same inherent gap documented for
+`account` above. Both `pool_registration.pool_key_hash` and
+`pool_retirement.pool_key_hash` are indexed, so each query is a small, indexed
+lookup rather than a table scan:
+
+```sql
+-- One of two symmetric queries (registration shown; retirement is the same
+-- shape over pool_retirement).
+SELECT "transaction".hash AS tx_hash
+FROM pool_registration
+JOIN certs ON certs.id = pool_registration.certificate_id
+JOIN "transaction" ON "transaction".id = certs.transaction_id
+WHERE pool_registration.pool_key_hash = $1
+ORDER BY pool_registration.added_slot ASC,
+         "transaction".block_index ASC,
+         certs.cert_index ASC;
+```
+
+The Blockfrost pool-detail endpoint's `blocks_minted` (lifetime) and
+`blocks_epoch` (current epoch) fields reuse the existing `pool_opcert_sequence`
+table and `CountPoolBlocksInSlotRange` query documented above, with the slot
+range widened to the pool's full history (`blocks_minted`) or narrowed to the
+current epoch's slot range (`blocks_epoch`); no new storage or index was
+needed. The upper slot bound passed for "no bound" is `math.MaxInt64`, not
+`math.MaxUint64`: slot columns are bound as signed 64-bit integers through
+`database/sql`, and a `uint64` value with the high bit set is rejected by the
+sqlite driver.
+
 ### `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, `GetDRepVotingPowerByType`
 
 All three DRep voting-power queries take an `expiryEpoch uint64` argument that

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1353,6 +1353,27 @@ needed. The upper slot bound passed for "no bound" is `math.MaxInt64`, not
 `database/sql`, and a `uint64` value with the high bit set is rejected by the
 sqlite driver.
 
+`blocks_minted` undercounts on a Mithril-bootstrapped node. `pool_opcert_sequence`
+is populated only by `UpdatePoolOpCertSequence`, called from the same
+block-apply path documented above ("Observed operational certificate sequence
+by slot"); the Mithril ledger-state importer (`ledgerstate.ImportLedgerState`)
+calls `ImportPool` to seed the pool's registration state but never calls
+`UpdatePoolOpCertSequence` or otherwise writes this table — confirmed by
+inspecting `ledgerstate/import.go` and the rest of the `mithril` package,
+neither of which references `PoolOpCertSequence` at all. A node bootstrapped
+from a Mithril snapshot therefore has no rows for any slot before the
+snapshot's boundary, so a pool's lifetime `blocks_minted` only reflects blocks
+dingo has itself applied block-by-block since that boundary, not the pool's
+true full-history total; the gap is silent (no error, just a smaller count)
+and permanent (it does not shrink or get backfilled as the node runs). This
+is the same class of Mithril-boundary gap as the `account` table's
+pre-snapshot registration history documented above. `blocks_epoch` (current
+epoch only) is not affected in ordinary steady-state operation, since a
+caught-up node's current epoch is entirely post-boundary, but it inherits the
+same gap for the one epoch that straddles the snapshot's boundary slot: if
+that epoch has not yet rolled over, `blocks_epoch` only counts the
+post-boundary portion of it.
+
 ### `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, `GetDRepVotingPowerByType`
 
 All three DRep voting-power queries take an `expiryEpoch uint64` argument that

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -765,7 +765,7 @@ func (a *NodeAdapter) Network() (NetworkInfo, error) {
 		)
 	}
 
-	liveStake, err := a.liveStake()
+	liveStake, err := a.liveStake(nil)
 	if err != nil {
 		return NetworkInfo{}, err
 	}
@@ -1652,9 +1652,15 @@ func (a *NodeAdapter) latestBlockData(
 	return block, decodedBlock, nil
 }
 
-func (a *NodeAdapter) liveStake() (uint64, error) {
+// liveStake sums delegated stake across every active pool for the
+// network-wide live-stake total. txn scopes the reads to the caller's
+// transaction (nil for no transaction, matching every other call in this
+// file that takes a *types.Txn-shaped parameter): passing the caller's txn
+// keeps this read in the same snapshot as the caller's other reads, rather
+// than potentially straddling a block boundary against them.
+func (a *NodeAdapter) liveStake(txn dbtypes.Txn) (uint64, error) {
 	poolKeyHashes, err := a.ledgerState.Database().Metadata().
-		GetActivePoolKeyHashes(nil)
+		GetActivePoolKeyHashes(txn)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"get active pool key hashes: %w",
@@ -1665,7 +1671,7 @@ func (a *NodeAdapter) liveStake() (uint64, error) {
 		return 0, nil
 	}
 	stakeByPool, _, err := a.ledgerState.Database().Metadata().
-		GetStakeByPools(poolKeyHashes, nil)
+		GetStakeByPools(poolKeyHashes, txn)
 	if err != nil {
 		return 0, fmt.Errorf("get live stake by pools: %w", err)
 	}

--- a/api/blockfrost/adapter_pool_detail.go
+++ b/api/blockfrost/adapter_pool_detail.go
@@ -168,18 +168,21 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 		return PoolDetailInfo{}, err
 	}
 
-	// nOpt drives live_saturation. Protocol parameters may not be loaded
-	// yet early in a node's life (before the first epoch boundary); that is
-	// treated as nOpt = 0 (no saturation figure) rather than failing pool
-	// detail entirely, the same way other pool queries in this package
-	// degrade when startup-dependent state isn't ready yet (see
-	// GetActivePoolRelays and GetPool's retirement check).
-	nOpt := 0
-	if protocolParams, ppErr := a.CurrentProtocolParams(); ppErr == nil {
-		nOpt = protocolParams.NOpt
+	// nOpt drives live_saturation, which is a required, non-nullable float
+	// in the OpenAPI schema: there is no schema-compatible way to signal
+	// "unknown" for it, and 0.0 is a legitimate saturation value (a pool
+	// with no live stake), so it cannot double as a placeholder for
+	// "protocol parameters aren't loaded yet". Propagate the error instead
+	// of guessing.
+	protocolParams, err := a.CurrentProtocolParams()
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get protocol parameters: %w", err,
+		)
 	}
 	liveSize, activeSize, liveSaturation := poolSizeSaturation(
-		liveStake, activeStake, totalLiveStake, totalActiveStake, nOpt,
+		liveStake, activeStake, totalLiveStake, totalActiveStake,
+		protocolParams.NOpt,
 	)
 
 	// Live pledge: the live stake currently delegated to this pool by its
@@ -286,9 +289,11 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 // protocol parameter, matching Blockfrost's live_size, active_size, and
 // live_saturation semantics: live_size and active_size are the pool's share
 // of total live/active stake, and live_saturation is live stake relative to
-// the per-pool saturation threshold (total active stake / nOpt). Each ratio
-// is zero when its denominator is zero (network totals not yet available,
-// or nOpt not yet configured) rather than dividing by zero.
+// the per-pool saturation threshold (total active stake / nOpt). The caller
+// is responsible for nOpt being a real, loaded protocol parameter value —
+// this function only guards the pathological case of a zero denominator
+// (e.g. a network with no active stake yet captured) to avoid dividing by
+// zero; it does not stand in for "nOpt unavailable".
 func poolSizeSaturation(
 	liveStake uint64,
 	activeStake uint64,

--- a/api/blockfrost/adapter_pool_detail.go
+++ b/api/blockfrost/adapter_pool_detail.go
@@ -16,6 +16,7 @@ package blockfrost
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -131,30 +132,33 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 	liveDelegators := delegatorsByPool[string(pool.PoolKeyHash)]
 
 	// Active stake: the Mark snapshot at currentEpoch-2, matching
-	// PoolsExtended and Network.
+	// PoolsExtended and Network. A single targeted row lookup rather than
+	// GetPoolStakeSnapshotsByEpoch's full-network fetch-then-linear-scan:
+	// on mainnet that call returns ~3,000 pools' rows to find the one that
+	// matches.
 	currentEpoch := a.ledgerState.CurrentEpoch()
 	activeStakeEpoch := uint64(0)
 	if currentEpoch >= 2 {
 		activeStakeEpoch = currentEpoch - 2
 	}
-	snapshots, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
-		activeStakeEpoch, "mark", txn.Metadata(),
+	snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+		activeStakeEpoch, "mark", pool.PoolKeyHash, txn.Metadata(),
 	)
 	if err != nil {
 		return PoolDetailInfo{}, fmt.Errorf(
-			"get pool stake snapshots for epoch %d: %w",
+			"get pool stake snapshot for epoch %d: %w",
 			activeStakeEpoch, err,
 		)
 	}
 	var activeStake uint64
-	for _, snapshot := range snapshots {
-		if string(snapshot.PoolKeyHash) == string(pool.PoolKeyHash) {
-			activeStake = uint64(snapshot.TotalStake)
-			break
-		}
+	if snapshot != nil {
+		activeStake = uint64(snapshot.TotalStake)
 	}
 
-	// Network-wide totals for the live/active size ratios and saturation.
+	// Network-wide total active stake, for active_size. GetTotalActiveStake
+	// is already a targeted aggregate (an EpochSummary fast path, falling
+	// back to a single SUM query), not a per-pool scan, so nothing further
+	// to avoid here.
 	totalActiveStake, err := db.Metadata().GetTotalActiveStake(
 		activeStakeEpoch, "mark", txn.Metadata(),
 	)
@@ -163,7 +167,31 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 			"get total active stake: %w", err,
 		)
 	}
-	totalLiveStake, err := a.liveStake()
+	// active_size is a required, non-nullable float with no schema-
+	// compatible "unknown" placeholder — the same constraint documented
+	// on live_saturation below. 0.0 is a value a real pool can
+	// legitimately have (no active stake), so it cannot double as a
+	// placeholder for "no snapshot captured for this epoch yet".
+	// activeStakeEpoch floors to 0 for currentEpoch < 2, and any node
+	// missing that epoch's snapshot hits this through the normal path,
+	// not a pathological one. Error instead of silently reporting every
+	// pool as 0% active-saturated, consistent with the protocol-parameters
+	// case below.
+	if totalActiveStake == 0 {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get total active stake for epoch %d: no snapshot captured",
+			activeStakeEpoch,
+		)
+	}
+
+	// Network-wide total live stake, for live_size. Unlike active stake's
+	// total, there is no pre-aggregated column to query directly here, so
+	// this genuinely requires summing every pool's delegated stake — the
+	// same cost PoolsExtended and Network already pay for the same
+	// number. liveStake reads within txn so this stays in the same
+	// snapshot as the reads above (see liveStake's doc comment for the
+	// one read that still can't).
+	totalLiveStake, err := a.liveStake(txn.Metadata())
 	if err != nil {
 		return PoolDetailInfo{}, err
 	}
@@ -174,15 +202,33 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 	// with no live stake), so it cannot double as a placeholder for
 	// "protocol parameters aren't loaded yet". Propagate the error instead
 	// of guessing.
+	//
+	// CurrentProtocolParams reads the ledger state's own cached current
+	// parameters rather than a value scoped to txn — the same convention
+	// PoolsExtended and Network already rely on for their own out-of-txn
+	// reads (see liveStake). It matters less here in practice than it
+	// would for a live-stake read: protocol parameters only change at
+	// epoch boundaries via governance action, not every block, so the
+	// window in which this could disagree with the rest of this
+	// snapshot is far narrower.
 	protocolParams, err := a.CurrentProtocolParams()
 	if err != nil {
 		return PoolDetailInfo{}, fmt.Errorf(
 			"get protocol parameters: %w", err,
 		)
 	}
+
+	// live_saturation's denominator is total circulating supply, not
+	// total active stake: see totalCirculation's doc comment.
+	totalCirculation, err := a.totalCirculation(txn.Metadata())
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get total circulation: %w", err,
+		)
+	}
 	liveSize, activeSize, liveSaturation := poolSizeSaturation(
 		liveStake, activeStake, totalLiveStake, totalActiveStake,
-		protocolParams.NOpt,
+		totalCirculation, protocolParams.NOpt,
 	)
 
 	// Live pledge: the live stake currently delegated to this pool by its
@@ -223,18 +269,30 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 		)
 	}
 
-	epochStartSlot := uint64(0)
+	// blocks_epoch narrows the lifetime query above to the current epoch's
+	// slot range. If GetEpoch returns nil for the current epoch, the state
+	// needed to do that narrowing isn't there: defaulting epochStartSlot
+	// to 0 would silently reproduce the blocks_minted query above
+	// (0..noSlotUpperBound) and report the pool's entire history as
+	// current-epoch blocks, so this errors instead.
+	//
+	// The upper bound is noSlotUpperBound, not the epoch's end slot — only
+	// correct because this is always the CURRENT epoch, where no blocks
+	// exist past the synced tip. Reusing this for a historical epoch would
+	// need the epoch's actual end slot as the upper bound instead.
 	epochRow, err := db.GetEpoch(currentEpoch, txn)
 	if err != nil {
 		return PoolDetailInfo{}, fmt.Errorf(
 			"get epoch %d: %w", currentEpoch, err,
 		)
 	}
-	if epochRow != nil {
-		epochStartSlot = epochRow.StartSlot
+	if epochRow == nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get epoch %d: no epoch row found", currentEpoch,
+		)
 	}
 	blocksEpochByPool, _, err := db.Metadata().CountPoolBlocksInSlotRange(
-		[]lcommon.PoolKeyHash{pkh}, epochStartSlot, noSlotUpperBound, txn.Metadata(),
+		[]lcommon.PoolKeyHash{pkh}, epochRow.StartSlot, noSlotUpperBound, txn.Metadata(),
 	)
 	if err != nil {
 		return PoolDetailInfo{}, fmt.Errorf(
@@ -284,21 +342,65 @@ func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
 	}, nil
 }
 
+// totalCirculation returns MaxLovelaceSupply minus Reserves: the sigma
+// denominator the reward calculation uses for the per-pool saturation
+// threshold. ledger/rewards/rewards.go:287 computes exactly this quantity
+// (`totalCirculation := params.MaxLovelaceSupply - pots.Reserves`), and
+// rewards.go:~1028-1034 passes it as totalStake into
+// optimalPoolRewardChecked, where sigma = poolStake/totalStake is capped at
+// z0 = 1/optimalPoolCount — a deliberately different denominator from
+// totalActiveStake, which the same call passes to apparentPerformance one
+// line above.
+//
+// This is NOT the same figure as Network()'s local "circulating" value
+// (adapter.go), which further subtracts treasury and script-locked supply
+// for display purposes. Callers computing a saturation threshold must use
+// this function's result, never that one.
+func (a *NodeAdapter) totalCirculation(txn dbtypes.Txn) (uint64, error) {
+	nodeCfg := a.ledgerState.CardanoNodeConfig()
+	if nodeCfg == nil || nodeCfg.ShelleyGenesis() == nil {
+		return 0, errors.New("shelley genesis not available")
+	}
+	maxSupply := nodeCfg.ShelleyGenesis().MaxLovelaceSupply
+
+	state, err := a.ledgerState.Database().Metadata().GetNetworkState(txn)
+	if err != nil {
+		return 0, fmt.Errorf("get network state: %w", err)
+	}
+	reserves := uint64(0)
+	if state != nil {
+		reserves = uint64(state.Reserves)
+	}
+	if reserves > maxSupply {
+		return 0, nil
+	}
+	return maxSupply - reserves, nil
+}
+
 // poolSizeSaturation computes a pool's live/active stake-size ratios and
-// live-saturation fraction relative to network-wide totals and the nOpt (k)
-// protocol parameter, matching Blockfrost's live_size, active_size, and
-// live_saturation semantics: live_size and active_size are the pool's share
-// of total live/active stake, and live_saturation is live stake relative to
-// the per-pool saturation threshold (total active stake / nOpt). The caller
-// is responsible for nOpt being a real, loaded protocol parameter value —
-// this function only guards the pathological case of a zero denominator
-// (e.g. a network with no active stake yet captured) to avoid dividing by
-// zero; it does not stand in for "nOpt unavailable".
+// live-saturation fraction, matching Blockfrost's live_size, active_size,
+// and live_saturation semantics. The three outputs each divide by a
+// different network-wide total:
+//   - live_size divides by totalLiveStake, the network's total delegated
+//     (live) stake.
+//   - active_size divides by totalActiveStake, the network's total Mark-
+//     snapshot (active) stake for the relevant epoch.
+//   - live_saturation divides live stake by the per-pool saturation
+//     threshold, totalCirculation / nOpt. totalCirculation is deliberately
+//     NOT totalActiveStake: see the totalCirculation doc comment above for
+//     why the reward calculation requires this distinction.
+//
+// The caller is responsible for nOpt being a real, loaded protocol
+// parameter value — this function only guards the pathological case of a
+// zero denominator (e.g. a network with no active stake or circulation
+// figure yet captured) to avoid dividing by zero; it does not stand in for
+// "nOpt unavailable" or "totalCirculation unavailable".
 func poolSizeSaturation(
 	liveStake uint64,
 	activeStake uint64,
 	totalLiveStake uint64,
 	totalActiveStake uint64,
+	totalCirculation uint64,
 	nOpt int,
 ) (liveSize float64, activeSize float64, liveSaturation float64) {
 	if totalLiveStake > 0 {
@@ -306,11 +408,11 @@ func poolSizeSaturation(
 	}
 	if totalActiveStake > 0 {
 		activeSize = float64(activeStake) / float64(totalActiveStake)
-		if nOpt > 0 {
-			saturationThreshold := float64(totalActiveStake) / float64(nOpt)
-			if saturationThreshold > 0 {
-				liveSaturation = float64(liveStake) / saturationThreshold
-			}
+	}
+	if totalCirculation > 0 && nOpt > 0 {
+		saturationThreshold := float64(totalCirculation) / float64(nOpt)
+		if saturationThreshold > 0 {
+			liveSaturation = float64(liveStake) / saturationThreshold
 		}
 	}
 	return liveSize, activeSize, liveSaturation

--- a/api/blockfrost/adapter_pool_detail.go
+++ b/api/blockfrost/adapter_pool_detail.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// noSlotUpperBound stands in for "no upper bound" in slot-range queries
+// that want everything synced so far. math.MaxInt64, not math.MaxUint64:
+// slot columns are bound through database/sql as signed 64-bit integers,
+// and a uint64 value with the high bit set (like math.MaxUint64) is
+// rejected by the sqlite driver. MaxInt64 slots are billions of years past
+// any real chain tip, so it is effectively unbounded for this purpose.
+const noSlotUpperBound = uint64(math.MaxInt64)
+
+// PoolDetail returns the OpenAPI pool detail object for the requested pool
+// (bech32 or hex ID). Epoch-sensitive aggregates (active stake, saturation,
+// blocks_epoch) are computed for the current epoch.
+func (a *NodeAdapter) PoolDetail(poolID string) (PoolDetailInfo, error) {
+	poolKeyHash, err := parsePoolID(poolID)
+	if err != nil {
+		return PoolDetailInfo{}, err
+	}
+	pkh := lcommon.PoolKeyHash(poolKeyHash)
+
+	db := a.ledgerState.Database()
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	pool, err := db.Metadata().GetPool(pkh, true, txn.Metadata())
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get pool %x: %w", poolKeyHash, err,
+		)
+	}
+	if pool == nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"pool %x: %w", poolKeyHash, models.ErrPoolNotFound,
+		)
+	}
+	if len(pool.Registration) == 0 {
+		// A pool row with no registration at all should not exist in
+		// practice (GetPool preloads the latest one), but guard against it
+		// rather than indexing into an empty slice below.
+		return PoolDetailInfo{}, fmt.Errorf(
+			"pool %x has no registration: %w",
+			poolKeyHash, models.ErrPoolNotFound,
+		)
+	}
+	reg := pool.Registration[0]
+
+	networkID := a.networkID()
+
+	rewardCredType := uint(lcommon.CredentialTypeAddrKeyHash)
+	if pool.RewardAccountCredentialTag == 1 {
+		rewardCredType = uint(lcommon.CredentialTypeScriptHash)
+	}
+	rewardAccount, err := stakeAddressFromCredential(
+		lcommon.Credential{
+			CredType: rewardCredType,
+			Credential: lcommon.CredentialHash(
+				lcommon.NewBlake2b224(pool.RewardAccount),
+			),
+		},
+		networkID,
+	)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"encode reward account for pool %x: %w", poolKeyHash, err,
+		)
+	}
+
+	// Owners are always key-hash credentials per the pool registration
+	// certificate spec (unlike the reward account, which may be a script).
+	owners := make([]string, 0, len(reg.Owners))
+	ownerKeyHashes := make([][]byte, 0, len(reg.Owners))
+	for _, owner := range reg.Owners {
+		addr, err := stakeAddressFromCredential(
+			lcommon.Credential{
+				CredType: uint(lcommon.CredentialTypeAddrKeyHash),
+				Credential: lcommon.CredentialHash(
+					lcommon.NewBlake2b224(owner.KeyHash),
+				),
+			},
+			networkID,
+		)
+		if err != nil {
+			return PoolDetailInfo{}, fmt.Errorf(
+				"encode owner address for pool %x: %w", poolKeyHash, err,
+			)
+		}
+		owners = append(owners, addr)
+		ownerKeyHashes = append(ownerKeyHashes, owner.KeyHash)
+	}
+
+	marginCost := 0.0
+	if pool.Margin != nil && pool.Margin.Rat != nil {
+		marginCost, _ = pool.Margin.Float64()
+	}
+
+	// Live stake and delegator count.
+	liveStakeByPool, delegatorsByPool, err := db.Metadata().GetStakeByPools(
+		[][]byte{pool.PoolKeyHash}, txn.Metadata(),
+	)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get live stake for pool %x: %w", poolKeyHash, err,
+		)
+	}
+	liveStake := liveStakeByPool[string(pool.PoolKeyHash)]
+	liveDelegators := delegatorsByPool[string(pool.PoolKeyHash)]
+
+	// Active stake: the Mark snapshot at currentEpoch-2, matching
+	// PoolsExtended and Network.
+	currentEpoch := a.ledgerState.CurrentEpoch()
+	activeStakeEpoch := uint64(0)
+	if currentEpoch >= 2 {
+		activeStakeEpoch = currentEpoch - 2
+	}
+	snapshots, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+		activeStakeEpoch, "mark", txn.Metadata(),
+	)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get pool stake snapshots for epoch %d: %w",
+			activeStakeEpoch, err,
+		)
+	}
+	var activeStake uint64
+	for _, snapshot := range snapshots {
+		if string(snapshot.PoolKeyHash) == string(pool.PoolKeyHash) {
+			activeStake = uint64(snapshot.TotalStake)
+			break
+		}
+	}
+
+	// Network-wide totals for the live/active size ratios and saturation.
+	totalActiveStake, err := db.Metadata().GetTotalActiveStake(
+		activeStakeEpoch, "mark", txn.Metadata(),
+	)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get total active stake: %w", err,
+		)
+	}
+	totalLiveStake, err := a.liveStake()
+	if err != nil {
+		return PoolDetailInfo{}, err
+	}
+
+	// nOpt drives live_saturation. Protocol parameters may not be loaded
+	// yet early in a node's life (before the first epoch boundary); that is
+	// treated as nOpt = 0 (no saturation figure) rather than failing pool
+	// detail entirely, the same way other pool queries in this package
+	// degrade when startup-dependent state isn't ready yet (see
+	// GetActivePoolRelays and GetPool's retirement check).
+	nOpt := 0
+	if protocolParams, ppErr := a.CurrentProtocolParams(); ppErr == nil {
+		nOpt = protocolParams.NOpt
+	}
+	liveSize, activeSize, liveSaturation := poolSizeSaturation(
+		liveStake, activeStake, totalLiveStake, totalActiveStake, nOpt,
+	)
+
+	// Live pledge: the live stake currently delegated to this pool by its
+	// declared owner credentials (CIP-50 "current pledge"), as of now.
+	// noSlotUpperBound and expiryEpoch/inactivityPeriod = 0 mean "as of the
+	// synced tip, with the CIP-0163 inactivity gate off", matching every
+	// other at-tip caller of this store method.
+	var livePledge uint64
+	if len(ownerKeyHashes) > 0 {
+		ownerStake, err := db.Metadata().GetPoolOwnerStakeAtSlot(
+			ownerKeyHashes, noSlotUpperBound, 0, 0, txn.Metadata(),
+		)
+		if err != nil {
+			return PoolDetailInfo{}, fmt.Errorf(
+				"get live pledge for pool %x: %w", poolKeyHash, err,
+			)
+		}
+		for _, ownerKeyHash := range ownerKeyHashes {
+			livePledge += ownerStake[dbtypes.PoolCredentialStakeKey(
+				pool.PoolKeyHash, 0, ownerKeyHash,
+			)]
+		}
+	}
+
+	// Lifetime blocks minted: every observed op-cert-sequence row for this
+	// pool. That table is written once per block the pool has produced and
+	// is never pruned by epoch (see UpdatePoolOpCertSequence in
+	// database/pool.go and DATABASE.md's pool_opcert_sequence entry), so a
+	// full-range count is a genuine lifetime total, not an approximation.
+	// blocks_epoch narrows the same indexed query to the current epoch's
+	// slot range.
+	blocksMintedByPool, _, err := db.Metadata().CountPoolBlocksInSlotRange(
+		[]lcommon.PoolKeyHash{pkh}, 0, noSlotUpperBound, txn.Metadata(),
+	)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"count lifetime blocks for pool %x: %w", poolKeyHash, err,
+		)
+	}
+
+	epochStartSlot := uint64(0)
+	epochRow, err := db.GetEpoch(currentEpoch, txn)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get epoch %d: %w", currentEpoch, err,
+		)
+	}
+	if epochRow != nil {
+		epochStartSlot = epochRow.StartSlot
+	}
+	blocksEpochByPool, _, err := db.Metadata().CountPoolBlocksInSlotRange(
+		[]lcommon.PoolKeyHash{pkh}, epochStartSlot, noSlotUpperBound, txn.Metadata(),
+	)
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"count epoch blocks for pool %x: %w", poolKeyHash, err,
+		)
+	}
+
+	registrationTxHashes, retirementTxHashes, err := db.Metadata().
+		GetPoolCertificateHistory(pkh, txn.Metadata())
+	if err != nil {
+		return PoolDetailInfo{}, fmt.Errorf(
+			"get certificate history for pool %x: %w", poolKeyHash, err,
+		)
+	}
+	registration := make([]string, 0, len(registrationTxHashes))
+	for _, h := range registrationTxHashes {
+		registration = append(registration, hex.EncodeToString(h))
+	}
+	retirement := make([]string, 0, len(retirementTxHashes))
+	for _, h := range retirementTxHashes {
+		retirement = append(retirement, hex.EncodeToString(h))
+	}
+
+	return PoolDetailInfo{
+		PoolID: lcommon.PoolId(
+			lcommon.NewBlake2b224(poolKeyHash),
+		).String(),
+		Hex:            hex.EncodeToString(poolKeyHash),
+		VrfKey:         hex.EncodeToString(pool.VrfKeyHash),
+		BlocksMinted:   blocksMintedByPool[string(pool.PoolKeyHash)],
+		BlocksEpoch:    blocksEpochByPool[string(pool.PoolKeyHash)],
+		LiveStake:      strconv.FormatUint(liveStake, 10),
+		LiveSize:       liveSize,
+		LiveSaturation: liveSaturation,
+		LiveDelegators: liveDelegators,
+		ActiveStake:    strconv.FormatUint(activeStake, 10),
+		ActiveSize:     activeSize,
+		DeclaredPledge: strconv.FormatUint(uint64(pool.Pledge), 10),
+		LivePledge:     strconv.FormatUint(livePledge, 10),
+		MarginCost:     marginCost,
+		FixedCost:      strconv.FormatUint(uint64(pool.Cost), 10),
+		RewardAccount:  rewardAccount,
+		Owners:         owners,
+		Registration:   registration,
+		Retirement:     retirement,
+		CalidusKey:     nil,
+	}, nil
+}
+
+// poolSizeSaturation computes a pool's live/active stake-size ratios and
+// live-saturation fraction relative to network-wide totals and the nOpt (k)
+// protocol parameter, matching Blockfrost's live_size, active_size, and
+// live_saturation semantics: live_size and active_size are the pool's share
+// of total live/active stake, and live_saturation is live stake relative to
+// the per-pool saturation threshold (total active stake / nOpt). Each ratio
+// is zero when its denominator is zero (network totals not yet available,
+// or nOpt not yet configured) rather than dividing by zero.
+func poolSizeSaturation(
+	liveStake uint64,
+	activeStake uint64,
+	totalLiveStake uint64,
+	totalActiveStake uint64,
+	nOpt int,
+) (liveSize float64, activeSize float64, liveSaturation float64) {
+	if totalLiveStake > 0 {
+		liveSize = float64(liveStake) / float64(totalLiveStake)
+	}
+	if totalActiveStake > 0 {
+		activeSize = float64(activeStake) / float64(totalActiveStake)
+		if nOpt > 0 {
+			saturationThreshold := float64(totalActiveStake) / float64(nOpt)
+			if saturationThreshold > 0 {
+				liveSaturation = float64(liveStake) / saturationThreshold
+			}
+		}
+	}
+	return liveSize, activeSize, liveSaturation
+}

--- a/api/blockfrost/adapter_pool_detail.go
+++ b/api/blockfrost/adapter_pool_detail.go
@@ -371,8 +371,16 @@ func (a *NodeAdapter) totalCirculation(txn dbtypes.Txn) (uint64, error) {
 	if state != nil {
 		reserves = uint64(state.Reserves)
 	}
+	// An impossible ledger state, but returning 0 here would feed a zero
+	// denominator into live_saturation and surface as a plausible-looking
+	// 0.0 — the fabricated value every other unavailable input in this
+	// function errors on rather than guessing.
 	if reserves > maxSupply {
-		return 0, nil
+		return 0, fmt.Errorf(
+			"reserves %d exceed max lovelace supply %d",
+			reserves,
+			maxSupply,
+		)
 	}
 	return maxSupply - reserves, nil
 }

--- a/api/blockfrost/adapter_pool_detail_db_test.go
+++ b/api/blockfrost/adapter_pool_detail_db_test.go
@@ -385,7 +385,11 @@ func TestNodeAdapterPoolDetailEpochRowMissing(t *testing.T) {
 	)
 
 	_, err := adapter.PoolDetail(hex.EncodeToString(poolKeyHash))
-	require.ErrorContains(t, err, "epoch")
+	// Match the epoch-row branch specifically: earlier failure paths in
+	// PoolDetail also mention "epoch" ("get pool stake snapshot for epoch
+	// %d", "get total active stake for epoch %d"), so a bare "epoch"
+	// substring would pass without ever reaching the branch under test.
+	require.ErrorContains(t, err, "no epoch row found")
 }
 
 // TestNodeAdapterPoolDetailInvalidID covers a malformed pool ID (neither

--- a/api/blockfrost/adapter_pool_detail_db_test.go
+++ b/api/blockfrost/adapter_pool_detail_db_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeAdapterPoolDetailFullResponse seeds a pool with a real
+// transaction-backed registration, an owner delegating its own stake back
+// to the pool, a separate delegator, and observed block production across
+// two epochs, then verifies every PoolDetailInfo field the adapter
+// computes from real DB state.
+func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
+	adapter, store, db := newDBBackedAdapter(t)
+
+	poolKeyHash := fill32(0x11)[:28]
+	vrfKeyHash := fill32(0x22)
+	rewardAccountHash := fill32(0x33)[:28]
+	ownerKeyHash := fill32(0x44)[:28]
+	delegatorStakingKey := fill32(0x55)[:28]
+
+	pool := &models.Pool{
+		PoolKeyHash:   poolKeyHash,
+		VrfKeyHash:    vrfKeyHash,
+		RewardAccount: rewardAccountHash,
+		Pledge:        types.Uint64(5_000_000_000),
+		Cost:          types.Uint64(340_000_000),
+		Margin:        &types.Rat{Rat: big.NewRat(5, 100)},
+		Registration: []models.PoolRegistration{
+			{
+				PoolKeyHash:   poolKeyHash,
+				VrfKeyHash:    vrfKeyHash,
+				RewardAccount: rewardAccountHash,
+				Pledge:        types.Uint64(5_000_000_000),
+				Cost:          types.Uint64(340_000_000),
+				Margin:        &types.Rat{Rat: big.NewRat(5, 100)},
+				AddedSlot:     1,
+				CertificateID: 1,
+			},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+	// PoolRegistrationOwner.PoolID is a denormalized convenience column,
+	// not the association GORM tracks (that's PoolRegistrationID), so it
+	// is not auto-populated by a nested create and must be set explicitly
+	// once the parent IDs exist.
+	require.NoError(t, store.DB().Create(&models.PoolRegistrationOwner{
+		KeyHash:            ownerKeyHash,
+		PoolRegistrationID: pool.Registration[0].ID,
+		PoolID:             pool.ID,
+	}).Error)
+
+	// Registration certificate history: a real transaction backing the
+	// registration row's certificate_id = 1.
+	regTxHash := fill32(0x66)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: 1, Hash: regTxHash, Slot: 1, BlockIndex: 0,
+	}).Error)
+	require.NoError(t, store.DB().Exec(
+		"INSERT INTO certs (id, transaction_id, cert_index, cert_type, slot) VALUES (1, 1, 0, 0, 1)",
+	).Error)
+
+	// A plain delegator (not an owner) with a live UTxO delegated to the
+	// pool.
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: delegatorStakingKey,
+		Pool:       poolKeyHash,
+		Active:     true,
+		AddedSlot:  1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       fill32(0x77),
+		OutputIdx:  0,
+		StakingKey: delegatorStakingKey,
+		Amount:     types.Uint64(6_900_000_000),
+		AddedSlot:  1,
+	}).Error)
+
+	// The pool's own owner, also delegating its stake to the pool: this is
+	// what live_pledge reports.
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey: ownerKeyHash,
+		Pool:       poolKeyHash,
+		Active:     true,
+		AddedSlot:  1,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId:       fill32(0x88),
+		OutputIdx:  0,
+		StakingKey: ownerKeyHash,
+		Amount:     types.Uint64(5_000_000_001),
+		AddedSlot:  1,
+	}).Error)
+
+	// Two blocks produced: one before the current epoch's start slot, one
+	// within it, so blocks_minted (lifetime) and blocks_epoch (current
+	// epoch only) diverge.
+	pkh := lcommon.PoolKeyHash(poolKeyHash)
+	require.NoError(t, db.UpdatePoolOpCertSequence(pkh, 1, 10, nil))
+	require.NoError(t, db.UpdatePoolOpCertSequence(pkh, 2, 500, nil))
+	// ls.CurrentEpoch() is 0 in this lightweight harness (no ls.Start()),
+	// so the adapter resolves "current epoch" to epoch_id 0 regardless of
+	// slot; giving it a start_slot of 100 excludes the block at slot 10
+	// from blocks_epoch while still counting it in the lifetime total.
+	require.NoError(t, store.DB().Create(&models.Epoch{
+		EpochId:       0,
+		StartSlot:     100,
+		LengthInSlots: 1000,
+	}).Error)
+
+	poolID := hex.EncodeToString(poolKeyHash)
+	info, err := adapter.PoolDetail(poolID)
+	require.NoError(t, err)
+
+	assert.Equal(t, poolID, info.Hex)
+	assert.Equal(t,
+		lcommon.PoolId(lcommon.NewBlake2b224(poolKeyHash)).String(),
+		info.PoolID,
+	)
+	assert.Equal(t, hex.EncodeToString(vrfKeyHash), info.VrfKey)
+	assert.Equal(t, uint64(2), info.BlocksMinted)
+	assert.Equal(t, uint64(1), info.BlocksEpoch)
+	assert.Equal(t, "11900000001", info.LiveStake)
+	assert.Equal(t, uint64(2), info.LiveDelegators)
+	assert.Equal(t, "5000000000", info.DeclaredPledge)
+	assert.Equal(t, "5000000001", info.LivePledge)
+	assert.InDelta(t, 0.05, info.MarginCost, 0.0001)
+	assert.Equal(t, "340000000", info.FixedCost)
+	require.Len(t, info.Owners, 1)
+	require.Len(t, info.Registration, 1)
+	assert.Equal(t, hex.EncodeToString(regTxHash), info.Registration[0])
+	assert.Empty(t, info.Retirement)
+	assert.NotNil(t, info.Retirement)
+	assert.Nil(t, info.CalidusKey)
+	// Protocol parameters are never loaded in this lightweight harness
+	// (ls.Start() is not called), so nOpt is unavailable and saturation
+	// degrades to zero rather than the request failing outright.
+	assert.Zero(t, info.LiveSaturation)
+	// Active stake/size are likewise zero: no pool_stake_snapshot row was
+	// seeded for this test, which is a legitimate "not captured yet" state
+	// distinct from a query failure.
+	assert.Equal(t, "0", info.ActiveStake)
+}
+
+// TestNodeAdapterPoolDetailBech32AndHexSameResult is the ID-format
+// acceptance criterion: bech32 and hex forms of the same pool key hash must
+// resolve to an identical PoolDetailInfo.
+func TestNodeAdapterPoolDetailBech32AndHexSameResult(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	poolKeyHash := fill32(0x99)[:28]
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		VrfKeyHash:  fill32(0xaa),
+		Registration: []models.PoolRegistration{
+			{PoolKeyHash: poolKeyHash, AddedSlot: 1},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+
+	hexID := hex.EncodeToString(poolKeyHash)
+	bech32ID := lcommon.PoolId(lcommon.NewBlake2b224(poolKeyHash)).String()
+	require.NotEqual(t, hexID, bech32ID)
+
+	byHex, err := adapter.PoolDetail(hexID)
+	require.NoError(t, err)
+	byBech32, err := adapter.PoolDetail(bech32ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, byHex, byBech32)
+	assert.Equal(t, bech32ID, byHex.PoolID)
+	assert.Equal(t, hexID, byHex.Hex)
+}
+
+// TestNodeAdapterPoolDetailInvalidID covers a malformed pool ID (neither
+// valid bech32 nor 56-character hex).
+func TestNodeAdapterPoolDetailInvalidID(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	_, err := adapter.PoolDetail("not-a-pool-id")
+	require.ErrorIs(t, err, ErrInvalidPoolID)
+}
+
+// TestNodeAdapterPoolDetailNotFound covers a well-formed pool ID with no
+// matching pool row.
+func TestNodeAdapterPoolDetailNotFound(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	missing := hex.EncodeToString(fill32(0xfe)[:28])
+	_, err := adapter.PoolDetail(missing)
+	require.ErrorIs(t, err, models.ErrPoolNotFound)
+}
+
+// TestNodeAdapterPoolDetailDatabaseFailure guards against a backing-store
+// failure being silently swallowed into an incomplete success response: a
+// broken stake query must surface as an error.
+func TestNodeAdapterPoolDetailDatabaseFailure(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	poolKeyHash := fill32(0xcc)[:28]
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		VrfKeyHash:  fill32(0xdd),
+		Registration: []models.PoolRegistration{
+			{PoolKeyHash: poolKeyHash, AddedSlot: 1},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+
+	// Break the store so GetStakeByPools fails; the failure must surface
+	// instead of a partial/zeroed response.
+	require.NoError(t, store.DB().Exec("DROP TABLE account").Error)
+
+	_, err := adapter.PoolDetail(hex.EncodeToString(poolKeyHash))
+	require.ErrorContains(t, err, "get live stake")
+}

--- a/api/blockfrost/adapter_pool_detail_db_test.go
+++ b/api/blockfrost/adapter_pool_detail_db_test.go
@@ -231,10 +231,23 @@ func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
 	// captured snapshot row, so it holds the entire active-stake total.
 	assert.Equal(t, "4200000000", info.ActiveStake)
 	assert.InDelta(t, 1.0, info.ActiveSize, 1e-9)
-	// live_saturation is computed from the real devnet nOpt (100), not a
-	// placeholder: saturation_threshold = totalActiveStake / nOpt, and
-	// live_saturation = liveStake / saturation_threshold.
-	wantSaturation := float64(wantLiveStake) / (float64(activeStake) / float64(wantNOpt))
+	// live_saturation is computed from the real devnet nOpt (100) and real
+	// total circulating supply, not a placeholder: saturation_threshold =
+	// totalCirculation / nOpt, and live_saturation = liveStake /
+	// saturation_threshold. totalCirculation (MaxLovelaceSupply minus
+	// Reserves) is deliberately NOT totalActiveStake -- see
+	// totalCirculation's doc comment in adapter_pool_detail.go for why the
+	// reward calculation requires that distinction. Both figures are
+	// derivable from the same devnet-genesis fixture this test already
+	// starts a real LedgerState against: MaxLovelaceSupply is fixed by
+	// config/cardano/devnet/shelley-genesis.json, and Reserves is whatever
+	// ls.Start() computed and persisted as the genesis network state
+	// (MaxLovelaceSupply minus the sum of all genesis UTxOs).
+	const wantMaxLovelaceSupply = uint64(2_000_000_000_000) // config/cardano/devnet/shelley-genesis.json
+	var networkState models.NetworkState
+	require.NoError(t, store.DB().Order("slot DESC").First(&networkState).Error)
+	wantCirculation := wantMaxLovelaceSupply - uint64(networkState.Reserves)
+	wantSaturation := float64(wantLiveStake) / (float64(wantCirculation) / float64(wantNOpt))
 	assert.InDelta(t, wantSaturation, info.LiveSaturation, 1e-6)
 }
 
@@ -256,6 +269,15 @@ func TestNodeAdapterPoolDetailProtocolParamsUnavailable(t *testing.T) {
 		},
 	}
 	require.NoError(t, store.DB().Create(pool).Error)
+	// A captured active-stake snapshot so this test exercises the
+	// protocol-params failure specifically, not the (also required)
+	// missing-active-stake-snapshot failure checked just before it.
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        0,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(1_000_000),
+	}).Error)
 
 	_, err := adapter.PoolDetail(hex.EncodeToString(poolKeyHash))
 	require.ErrorContains(t, err, "protocol parameters")
@@ -276,6 +298,17 @@ func TestNodeAdapterPoolDetailBech32AndHexSameResult(t *testing.T) {
 		},
 	}
 	require.NoError(t, store.DB().Create(pool).Error)
+	// A captured active-stake snapshot: PoolDetail now errors rather than
+	// silently reporting active_size == 0.0 when none exists for the
+	// current epoch (see the active_size doc comment in
+	// adapter_pool_detail.go), and this test wants both ID-format calls to
+	// succeed.
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        0,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(1_000_000),
+	}).Error)
 
 	hexID := hex.EncodeToString(poolKeyHash)
 	bech32ID := lcommon.PoolId(lcommon.NewBlake2b224(poolKeyHash)).String()
@@ -289,6 +322,70 @@ func TestNodeAdapterPoolDetailBech32AndHexSameResult(t *testing.T) {
 	assert.Equal(t, byHex, byBech32)
 	assert.Equal(t, bech32ID, byHex.PoolID)
 	assert.Equal(t, hexID, byHex.Hex)
+}
+
+// TestNodeAdapterPoolDetailActiveStakeSnapshotUnavailable covers the case
+// where activeStakeEpoch has no captured Mark snapshot for any pool
+// (GetTotalActiveStake returns 0): active_size is a required, non-nullable
+// float in the OpenAPI schema, and 0.0 is itself a legitimate active_size
+// value (a pool with no active stake), so there is no schema-compatible
+// placeholder for "unknown". PoolDetail must fail the whole request rather
+// than silently report every pool as 0% active-saturated. This is
+// reachable through the normal path, not a pathological one:
+// activeStakeEpoch floors to 0 for currentEpoch < 2, and any node missing
+// that epoch's snapshot hits it too.
+func TestNodeAdapterPoolDetailActiveStakeSnapshotUnavailable(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapterWithProtocolParams(t)
+
+	poolKeyHash := fill32(0xf1)[:28]
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		VrfKeyHash:  fill32(0xf2),
+		Registration: []models.PoolRegistration{
+			{PoolKeyHash: poolKeyHash, AddedSlot: 1},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+	// Deliberately no PoolStakeSnapshot row for epoch 0.
+
+	_, err := adapter.PoolDetail(hex.EncodeToString(poolKeyHash))
+	require.ErrorContains(t, err, "active stake")
+}
+
+// TestNodeAdapterPoolDetailEpochRowMissing covers the case where GetEpoch
+// returns nil for the current epoch: falling back to epochStartSlot = 0
+// would make the blocks_epoch query byte-identical to the blocks_minted
+// query above it (both 0..noSlotUpperBound) and silently report the
+// pool's entire lifetime block count as its current-epoch count. PoolDetail
+// must fail instead, since the state needed to answer blocks_epoch isn't
+// there.
+func TestNodeAdapterPoolDetailEpochRowMissing(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapterWithProtocolParams(t)
+
+	poolKeyHash := fill32(0xf3)[:28]
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		VrfKeyHash:  fill32(0xf4),
+		Registration: []models.PoolRegistration{
+			{PoolKeyHash: poolKeyHash, AddedSlot: 1},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        0,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(1_000_000),
+	}).Error)
+	// Start() against the devnet genesis writes the epoch_id = 0 row;
+	// delete it to simulate a node missing the current epoch's row.
+	require.NoError(
+		t,
+		store.DB().Where("epoch_id = ?", 0).Delete(&models.Epoch{}).Error,
+	)
+
+	_, err := adapter.PoolDetail(hex.EncodeToString(poolKeyHash))
+	require.ErrorContains(t, err, "epoch")
 }
 
 // TestNodeAdapterPoolDetailInvalidID covers a malformed pool ID (neither

--- a/api/blockfrost/adapter_pool_detail_db_test.go
+++ b/api/blockfrost/adapter_pool_detail_db_test.go
@@ -16,23 +16,79 @@ package blockfrost
 
 import (
 	"encoding/hex"
+	"io"
+	"log/slog"
 	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// newDBBackedAdapterWithProtocolParams builds a NodeAdapter over a real
+// LedgerState that has actually completed Start(), using the embedded
+// devnet genesis (all hard forks at epoch 0, nOpt = 100 per
+// config/cardano/devnet/shelley-genesis.json). Unlike newDBBackedAdapter
+// (adapter_block_db_test.go), this loads real protocol parameters, which
+// PoolDetail now requires in order to compute live_saturation -- a
+// required, non-nullable schema field that cannot be faked with a zero
+// placeholder. Start() completes synchronously against the empty, freshly
+// created database (no chain synced yet), so this stays a fast unit test.
+func newDBBackedAdapterWithProtocolParams(
+	t *testing.T,
+) (*NodeAdapter, *sqliteplugin.MetadataStoreSqlite, *database.Database) {
+	t.Helper()
+	cfg, err := cardano.NewCardanoNodeConfigFromEmbedFS(
+		cardano.EmbeddedConfigFS, "devnet/config.json",
+	)
+	require.NoError(t, err)
+
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	ls, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: cfg,
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DatabaseWorkerPoolConfig: ledger.DatabaseWorkerPoolConfig{
+			Disabled: true,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ls.Start(t.Context()))
+
+	adapter, err := NewNodeAdapter(ls, nil)
+	require.NoError(t, err)
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+
+	return adapter, store, db
+}
+
 // TestNodeAdapterPoolDetailFullResponse seeds a pool with a real
 // transaction-backed registration, an owner delegating its own stake back
-// to the pool, a separate delegator, and observed block production across
-// two epochs, then verifies every PoolDetailInfo field the adapter
-// computes from real DB state.
+// to the pool, a separate delegator, a captured active-stake snapshot, and
+// observed block production across two epochs, then verifies every
+// PoolDetailInfo field the adapter computes from real DB state, including
+// live_saturation computed from the real devnet nOpt (100).
 func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
-	adapter, store, db := newDBBackedAdapter(t)
+	adapter, store, db := newDBBackedAdapterWithProtocolParams(t)
 
 	poolKeyHash := fill32(0x11)[:28]
 	vrfKeyHash := fill32(0x22)
@@ -56,7 +112,7 @@ func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
 				Cost:          types.Uint64(340_000_000),
 				Margin:        &types.Rat{Rat: big.NewRat(5, 100)},
 				AddedSlot:     1,
-				CertificateID: 1,
+				CertificateID: 90001,
 			},
 		},
 	}
@@ -72,13 +128,16 @@ func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
 	}).Error)
 
 	// Registration certificate history: a real transaction backing the
-	// registration row's certificate_id = 1.
+	// registration row's certificate_id = 90001. Both IDs use a large,
+	// distinctive value because Start() against the devnet genesis writes
+	// its own low-numbered genesis-staking transaction/cert rows, which
+	// low hardcoded IDs like 1 would collide with.
 	regTxHash := fill32(0x66)
 	require.NoError(t, store.DB().Create(&models.Transaction{
-		ID: 1, Hash: regTxHash, Slot: 1, BlockIndex: 0,
+		ID: 90001, Hash: regTxHash, Slot: 1, BlockIndex: 0,
 	}).Error)
 	require.NoError(t, store.DB().Exec(
-		"INSERT INTO certs (id, transaction_id, cert_index, cert_type, slot) VALUES (1, 1, 0, 0, 1)",
+		"INSERT INTO certs (id, transaction_id, cert_index, cert_type, slot) VALUES (90001, 90001, 0, 0, 1)",
 	).Error)
 
 	// A plain delegator (not an owner) with a live UTxO delegated to the
@@ -119,19 +178,34 @@ func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
 	pkh := lcommon.PoolKeyHash(poolKeyHash)
 	require.NoError(t, db.UpdatePoolOpCertSequence(pkh, 1, 10, nil))
 	require.NoError(t, db.UpdatePoolOpCertSequence(pkh, 2, 500, nil))
-	// ls.CurrentEpoch() is 0 in this lightweight harness (no ls.Start()),
-	// so the adapter resolves "current epoch" to epoch_id 0 regardless of
-	// slot; giving it a start_slot of 100 excludes the block at slot 10
-	// from blocks_epoch while still counting it in the lifetime total.
-	require.NoError(t, store.DB().Create(&models.Epoch{
-		EpochId:       0,
-		StartSlot:     100,
-		LengthInSlots: 1000,
+	// ls.CurrentEpoch() stays 0 on a freshly started ledger with no synced
+	// chain (Start() only loads persisted state; it does not advance the
+	// epoch by wall-clock time), so the adapter resolves "current epoch"
+	// to epoch_id 0 regardless of slot. Start() against the devnet genesis
+	// already wrote the epoch_id = 0 row; update its start_slot to 100 so
+	// the block at slot 10 is excluded from blocks_epoch while still
+	// counting toward the lifetime total.
+	require.NoError(t, store.DB().Model(&models.Epoch{}).
+		Where("epoch_id = ?", 0).
+		Update("start_slot", 100).Error)
+
+	// A captured Mark active-stake snapshot for epoch 0 (activeStakeEpoch
+	// is currentEpoch-2, clamped to 0 below epoch 2): this pool is the only
+	// one in the snapshot, so active_size should come out to exactly 1.0.
+	const activeStake = uint64(4_200_000_000)
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        0,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(activeStake),
 	}).Error)
 
 	poolID := hex.EncodeToString(poolKeyHash)
 	info, err := adapter.PoolDetail(poolID)
 	require.NoError(t, err)
+
+	const wantLiveStake = uint64(11_900_000_001) // 6_900_000_000 + 5_000_000_001
+	const wantNOpt = 100                         // config/cardano/devnet/shelley-genesis.json
 
 	assert.Equal(t, poolID, info.Hex)
 	assert.Equal(t,
@@ -153,21 +227,45 @@ func TestNodeAdapterPoolDetailFullResponse(t *testing.T) {
 	assert.Empty(t, info.Retirement)
 	assert.NotNil(t, info.Retirement)
 	assert.Nil(t, info.CalidusKey)
-	// Protocol parameters are never loaded in this lightweight harness
-	// (ls.Start() is not called), so nOpt is unavailable and saturation
-	// degrades to zero rather than the request failing outright.
-	assert.Zero(t, info.LiveSaturation)
-	// Active stake/size are likewise zero: no pool_stake_snapshot row was
-	// seeded for this test, which is a legitimate "not captured yet" state
-	// distinct from a query failure.
-	assert.Equal(t, "0", info.ActiveStake)
+	// Active stake and active_size: this pool is the network's only
+	// captured snapshot row, so it holds the entire active-stake total.
+	assert.Equal(t, "4200000000", info.ActiveStake)
+	assert.InDelta(t, 1.0, info.ActiveSize, 1e-9)
+	// live_saturation is computed from the real devnet nOpt (100), not a
+	// placeholder: saturation_threshold = totalActiveStake / nOpt, and
+	// live_saturation = liveStake / saturation_threshold.
+	wantSaturation := float64(wantLiveStake) / (float64(activeStake) / float64(wantNOpt))
+	assert.InDelta(t, wantSaturation, info.LiveSaturation, 1e-6)
+}
+
+// TestNodeAdapterPoolDetailProtocolParamsUnavailable covers the case where
+// protocol parameters have not been loaded yet (e.g. very early in a
+// node's life, before Start() has run): live_saturation is a required,
+// non-nullable float in the OpenAPI schema, and 0.0 is itself a legitimate
+// saturation value, so there is no schema-compatible placeholder for
+// "unknown". PoolDetail must fail the whole request rather than guess.
+func TestNodeAdapterPoolDetailProtocolParamsUnavailable(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	poolKeyHash := fill32(0xe1)[:28]
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		VrfKeyHash:  fill32(0xe2),
+		Registration: []models.PoolRegistration{
+			{PoolKeyHash: poolKeyHash, AddedSlot: 1},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+
+	_, err := adapter.PoolDetail(hex.EncodeToString(poolKeyHash))
+	require.ErrorContains(t, err, "protocol parameters")
 }
 
 // TestNodeAdapterPoolDetailBech32AndHexSameResult is the ID-format
 // acceptance criterion: bech32 and hex forms of the same pool key hash must
 // resolve to an identical PoolDetailInfo.
 func TestNodeAdapterPoolDetailBech32AndHexSameResult(t *testing.T) {
-	adapter, store, _ := newDBBackedAdapter(t)
+	adapter, store, _ := newDBBackedAdapterWithProtocolParams(t)
 
 	poolKeyHash := fill32(0x99)[:28]
 	pool := &models.Pool{

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -125,6 +125,10 @@ func (b *Blockfrost) handler() http.Handler {
 		b.handlePoolMetadata,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/pools/{pool_id}",
+		b.handlePoolDetail,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/governance/dreps",
 		b.handleDReps,
 	)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -70,6 +70,8 @@ type mockNode struct {
 	poolsRetiring                 []PoolRetiringInfo
 	poolsRetiringTotal            int
 	poolMetadata                  PoolMetadataInfo
+	poolDetail                    PoolDetailInfo
+	poolDetailErr                 error
 	asset                         AssetInfo
 	assetHolders                  []AssetHolderInfo
 	assetHoldersTotal             int
@@ -228,6 +230,12 @@ func (m *mockNode) PoolMetadata(
 	_ string,
 ) (PoolMetadataInfo, error) {
 	return m.poolMetadata, m.poolMetadataErr
+}
+
+func (m *mockNode) PoolDetail(
+	_ string,
+) (PoolDetailInfo, error) {
+	return m.poolDetail, m.poolDetailErr
 }
 
 func (m *mockNode) Asset(

--- a/api/blockfrost/handlers_pool_detail.go
+++ b/api/blockfrost/handlers_pool_detail.go
@@ -69,19 +69,15 @@ func (b *Blockfrost) handlePoolDetail(
 // the OpenAPI schema, so a nil slice is normalized to an empty one rather
 // than encoding as JSON null.
 func poolDetailResponse(info PoolDetailInfo) PoolDetailResponse {
+	// info.CalidusKey is always nil: dingo does not currently ingest
+	// CIP-0088 Calidus key registrations from any source (see
+	// PoolCalidusKeyInfo's doc comment in node_interface.go), so there is
+	// no producer that could set it, and no PoolCalidusKeyInfo ->
+	// PoolCalidusKeyResponse conversion to reach. PoolCalidusKeyResponse
+	// itself stays, since nullable: true in the OpenAPI schema makes null
+	// the correct wire representation and the type still documents that
+	// shape.
 	var calidusKey *PoolCalidusKeyResponse
-	if info.CalidusKey != nil {
-		resp := PoolCalidusKeyResponse{
-			ID:          info.CalidusKey.ID,
-			PubKey:      info.CalidusKey.PubKey,
-			Nonce:       info.CalidusKey.Nonce,
-			TxHash:      info.CalidusKey.TxHash,
-			BlockHeight: info.CalidusKey.BlockHeight,
-			BlockTime:   info.CalidusKey.BlockTime,
-			Epoch:       info.CalidusKey.Epoch,
-		}
-		calidusKey = &resp
-	}
 	owners := info.Owners
 	if owners == nil {
 		owners = []string{}

--- a/api/blockfrost/handlers_pool_detail.go
+++ b/api/blockfrost/handlers_pool_detail.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// handlePoolDetail handles GET /api/v0/pools/{pool_id} and returns the
+// OpenAPI pool detail object for the requested pool.
+func (b *Blockfrost) handlePoolDetail(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	poolID := r.PathValue("pool_id")
+	info, err := b.node.PoolDetail(poolID)
+	if err != nil {
+		if errors.Is(err, ErrInvalidPoolID) {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"Invalid or malformed pool id format.",
+			)
+			return
+		}
+		if errors.Is(err, models.ErrPoolNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"The requested component has not been found.",
+			)
+			return
+		}
+		b.logger.Error(
+			"failed to get pool detail",
+			"pool_id", poolID,
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve pool detail",
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, poolDetailResponse(info))
+}
+
+// poolDetailResponse converts a PoolDetailInfo into its Blockfrost wire
+// shape. Owners, Registration, and Retirement are non-nullable arrays in
+// the OpenAPI schema, so a nil slice is normalized to an empty one rather
+// than encoding as JSON null.
+func poolDetailResponse(info PoolDetailInfo) PoolDetailResponse {
+	var calidusKey *PoolCalidusKeyResponse
+	if info.CalidusKey != nil {
+		resp := PoolCalidusKeyResponse{
+			ID:          info.CalidusKey.ID,
+			PubKey:      info.CalidusKey.PubKey,
+			Nonce:       info.CalidusKey.Nonce,
+			TxHash:      info.CalidusKey.TxHash,
+			BlockHeight: info.CalidusKey.BlockHeight,
+			BlockTime:   info.CalidusKey.BlockTime,
+			Epoch:       info.CalidusKey.Epoch,
+		}
+		calidusKey = &resp
+	}
+	owners := info.Owners
+	if owners == nil {
+		owners = []string{}
+	}
+	registration := info.Registration
+	if registration == nil {
+		registration = []string{}
+	}
+	retirement := info.Retirement
+	if retirement == nil {
+		retirement = []string{}
+	}
+	return PoolDetailResponse{
+		PoolID:         info.PoolID,
+		Hex:            info.Hex,
+		VrfKey:         info.VrfKey,
+		BlocksMinted:   info.BlocksMinted,
+		BlocksEpoch:    info.BlocksEpoch,
+		LiveStake:      info.LiveStake,
+		LiveSize:       info.LiveSize,
+		LiveSaturation: info.LiveSaturation,
+		LiveDelegators: info.LiveDelegators,
+		ActiveStake:    info.ActiveStake,
+		ActiveSize:     info.ActiveSize,
+		DeclaredPledge: info.DeclaredPledge,
+		LivePledge:     info.LivePledge,
+		MarginCost:     info.MarginCost,
+		FixedCost:      info.FixedCost,
+		RewardAccount:  info.RewardAccount,
+		Owners:         owners,
+		Registration:   registration,
+		Retirement:     retirement,
+		CalidusKey:     calidusKey,
+	}
+}

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -73,6 +73,12 @@ type BlockfrostNode interface {
 	// PoolMetadata returns the registered metadata for a pool.
 	PoolMetadata(poolID string) (PoolMetadataInfo, error)
 
+	// PoolDetail returns the OpenAPI pool detail object for the requested
+	// pool (bech32 or hex ID), computing epoch-sensitive aggregates
+	// (blocks_epoch, live/active stake, saturation) as of the current
+	// epoch.
+	PoolDetail(poolID string) (PoolDetailInfo, error)
+
 	// AddressUTXOs returns the paginated current UTxOs for
 	// an address along with the total number of matching
 	// results before pagination.
@@ -416,6 +422,51 @@ type PoolRelayInfo struct {
 	IPv6 string
 	DNS  string
 	Port *int
+}
+
+// PoolDetailInfo holds pool data needed by the /pools/{pool_id} endpoint,
+// following the Blockfrost OpenAPI 0.1.90 pool schema.
+type PoolDetailInfo struct {
+	PoolID         string
+	Hex            string
+	VrfKey         string
+	LiveStake      string
+	ActiveStake    string
+	DeclaredPledge string
+	LivePledge     string
+	FixedCost      string
+	RewardAccount  string
+	Owners         []string
+	// Registration and Retirement are the transaction hashes of the pool's
+	// registration and retirement certificates, oldest first. Certificates
+	// with no linked transaction (rows synthesized by a Mithril
+	// ledger-state import) are excluded since they have no originating
+	// transaction to report.
+	Registration   []string
+	Retirement     []string
+	CalidusKey     *PoolCalidusKeyInfo
+	BlocksMinted   uint64
+	BlocksEpoch    uint64
+	LiveDelegators uint64
+	LiveSize       float64
+	LiveSaturation float64
+	ActiveSize     float64
+	MarginCost     float64
+}
+
+// PoolCalidusKeyInfo holds a pool's latest valid CIP-0088 Calidus key
+// registration (Blockfrost's calidus_key object). dingo does not currently
+// ingest Calidus key registrations from any source, so every
+// BlockfrostNode implementation returns a nil *PoolCalidusKeyInfo here; the
+// type exists so PoolDetailInfo mirrors the OpenAPI schema exactly.
+type PoolCalidusKeyInfo struct {
+	ID          string
+	PubKey      string
+	Nonce       uint64
+	TxHash      string
+	BlockHeight uint64
+	BlockTime   int64
+	Epoch       uint64
 }
 
 // AddressAmountInfo holds amount data needed by address

--- a/api/blockfrost/pool_detail_test.go
+++ b/api/blockfrost/pool_detail_test.go
@@ -269,7 +269,11 @@ func TestPoolSizeSaturation(t *testing.T) {
 			wantLiveSaturation: 0,
 		},
 		{
-			name:               "nOpt not yet available",
+			// Defensive zero-denominator guard only: PoolDetail never calls
+			// this with nOpt == 0 in practice, since it now requires
+			// CurrentProtocolParams to succeed before computing saturation
+			// at all.
+			name:               "nOpt is zero",
 			liveStake:          1000,
 			totalLive:          10_000,
 			activeStake:        500,

--- a/api/blockfrost/pool_detail_test.go
+++ b/api/blockfrost/pool_detail_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlePoolDetail(t *testing.T) {
+	mock := &mockNode{
+		poolDetail: PoolDetailInfo{
+			PoolID:         "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec",
+			Hex:            "6080b9c76b4b19c21d17b4091aa205417cb80a5449f638c27eec0946",
+			VrfKey:         "0b5245f9934ec2151116fb8ec00f35fd00e0aa3b075c4ed12cce440f999d823",
+			BlocksMinted:   69,
+			BlocksEpoch:    4,
+			LiveStake:      "6900000000",
+			LiveSize:       0.42,
+			LiveSaturation: 0.93,
+			LiveDelegators: 127,
+			ActiveStake:    "4200000000",
+			ActiveSize:     0.43,
+			DeclaredPledge: "5000000000",
+			LivePledge:     "5000000001",
+			MarginCost:     0.05,
+			FixedCost:      "340000000",
+			RewardAccount:  "stake1uxkptsa4lkr55jleztw43t37vgdn88l6ghclfwuxld2eykgpgvg3f",
+			Owners:         []string{"stake1u98nnlkvkk23vtvf9273uq7cph5ww6u2yq2389psuqet90sv4xv9v"},
+			Registration:   []string{"9f83e5484f543e05b52e99988272a31da373f3aab4c064c76db96643a355d9dc"},
+			Retirement:     []string{},
+			CalidusKey:     nil,
+		},
+	}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec",
+		nil,
+	)
+	req.SetPathValue("pool_id", "pool1vzqtn3mtfvvuy8ghksy34gs9g97tszj5f8mr3sn7asy5vk577ec")
+	w := httptest.NewRecorder()
+	b.handlePoolDetail(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Every field name and type must match the OpenAPI 0.1.90 pool schema
+	// exactly: string amounts, float ratios, integer counts, and a
+	// nullable calidus_key that must be present in the payload as null,
+	// not omitted.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	calidusKey, ok := raw["calidus_key"]
+	require.True(t, ok, "calidus_key must be present in the response")
+	assert.Nil(t, calidusKey)
+
+	var resp PoolDetailResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, mock.poolDetail.PoolID, resp.PoolID)
+	assert.Equal(t, mock.poolDetail.Hex, resp.Hex)
+	assert.Equal(t, mock.poolDetail.VrfKey, resp.VrfKey)
+	assert.Equal(t, uint64(69), resp.BlocksMinted)
+	assert.Equal(t, uint64(4), resp.BlocksEpoch)
+	assert.Equal(t, "6900000000", resp.LiveStake)
+	assert.InDelta(t, 0.42, resp.LiveSize, 0.0001)
+	assert.InDelta(t, 0.93, resp.LiveSaturation, 0.0001)
+	assert.Equal(t, uint64(127), resp.LiveDelegators)
+	assert.Equal(t, "4200000000", resp.ActiveStake)
+	assert.InDelta(t, 0.43, resp.ActiveSize, 0.0001)
+	assert.Equal(t, "5000000000", resp.DeclaredPledge)
+	assert.Equal(t, "5000000001", resp.LivePledge)
+	assert.InDelta(t, 0.05, resp.MarginCost, 0.0001)
+	assert.Equal(t, "340000000", resp.FixedCost)
+	assert.Equal(t, mock.poolDetail.RewardAccount, resp.RewardAccount)
+	assert.Equal(t, mock.poolDetail.Owners, resp.Owners)
+	assert.Equal(t, mock.poolDetail.Registration, resp.Registration)
+	assert.Empty(t, resp.Retirement)
+	assert.NotNil(t, resp.Retirement)
+	assert.Nil(t, resp.CalidusKey)
+}
+
+// TestHandlePoolDetailEmptyArraysNotNull guards the non-nullable owners,
+// registration, and retirement arrays: a zero-value PoolDetailInfo (nil
+// slices) must still encode as "[]", never JSON null, since the OpenAPI
+// schema marks them required arrays without nullable: true.
+func TestHandlePoolDetailEmptyArraysNotNull(t *testing.T) {
+	mock := &mockNode{poolDetail: PoolDetailInfo{PoolID: "pool1empty"}}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools/pool1empty", nil)
+	req.SetPathValue("pool_id", "pool1empty")
+	w := httptest.NewRecorder()
+	b.handlePoolDetail(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	for _, field := range []string{"owners", "registration", "retirement"} {
+		v, ok := raw[field]
+		require.True(t, ok, "%s must be present", field)
+		arr, isArray := v.([]any)
+		require.True(t, isArray, "%s must encode as a JSON array, got %T", field, v)
+		assert.Empty(t, arr)
+	}
+}
+
+func TestHandlePoolDetailInvalidID(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{poolDetailErr: ErrInvalidPoolID})
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools/pool1stonks", nil)
+	req.SetPathValue("pool_id", "pool1stonks")
+	w := httptest.NewRecorder()
+	b.handlePoolDetail(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Invalid or malformed pool id format.", resp.Message)
+}
+
+func TestHandlePoolDetailNotFound(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		poolDetailErr: fmt.Errorf("get pool: %w", models.ErrPoolNotFound),
+	})
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d",
+		nil,
+	)
+	req.SetPathValue("pool_id", "pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d")
+	w := httptest.NewRecorder()
+	b.handlePoolDetail(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestHandlePoolDetailDatabaseFailure covers an opaque backing-store error
+// (neither the invalid-ID nor not-found sentinels): it must surface as a
+// generic 500 rather than being misclassified as a 400/404.
+func TestHandlePoolDetailDatabaseFailure(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		poolDetailErr: errors.New("database is closed"),
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools/pool1whatever", nil)
+	req.SetPathValue("pool_id", "pool1whatever")
+	w := httptest.NewRecorder()
+	b.handlePoolDetail(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "failed to retrieve pool detail", resp.Message)
+}
+
+// TestPoolsRouteOrderingPoolDetailDoesNotSwallowSiblings is the acceptance
+// test for route registration: even though "/pools/{pool_id}" is
+// registered, requests for the literal sibling paths "/pools/retiring" and
+// "/pools/extended" must still resolve to their own handlers, not be
+// captured by the pool-detail wildcard. This exercises the real
+// http.ServeMux built by (*Blockfrost).handler(), not a direct method
+// call, so it verifies Go's actual pattern-specificity resolution rather
+// than assuming it.
+func TestPoolsRouteOrderingPoolDetailDoesNotSwallowSiblings(t *testing.T) {
+	mock := &mockNode{
+		poolsRetiringTotal: 1,
+		poolsRetiring: []PoolRetiringInfo{
+			{PoolID: "pool1retiring", Epoch: 10},
+		},
+		pools: []PoolExtendedInfo{
+			{PoolID: "pool1extended"},
+		},
+		poolDetail: PoolDetailInfo{PoolID: "pool1detail"},
+	}
+	b := newTestBlockfrost(mock)
+	handler := b.handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools/retiring", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var retiringResp []PoolRetiringResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&retiringResp))
+	require.Len(t, retiringResp, 1)
+	assert.Equal(t, "pool1retiring", retiringResp[0].PoolID)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v0/pools/extended", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var extendedResp []PoolExtendedResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&extendedResp))
+	require.Len(t, extendedResp, 1)
+	assert.Equal(t, "pool1extended", extendedResp[0].PoolID)
+
+	req = httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/pool1notretiringnorextended", nil,
+	)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var detailResp PoolDetailResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&detailResp))
+	assert.Equal(t, "pool1detail", detailResp.PoolID)
+
+	req = httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/pool1detail/metadata", nil,
+	)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPoolSizeSaturation(t *testing.T) {
+	tests := []struct {
+		name                                             string
+		liveStake, activeStake, totalLive, totalActive   uint64
+		nOpt                                             int
+		wantLiveSize, wantActiveSize, wantLiveSaturation float64
+	}{
+		{
+			name:               "normal pool",
+			liveStake:          6_900_000_000,
+			activeStake:        4_200_000_000,
+			totalLive:          16_428_571_428,
+			totalActive:        420_000_000_000,
+			nOpt:               500,
+			wantLiveSize:       6_900_000_000.0 / 16_428_571_428.0,
+			wantActiveSize:     4_200_000_000.0 / 420_000_000_000.0,
+			wantLiveSaturation: 6_900_000_000.0 / (420_000_000_000.0 / 500.0),
+		},
+		{
+			name:               "zero total live stake",
+			liveStake:          1000,
+			totalLive:          0,
+			totalActive:        1_000_000,
+			activeStake:        500,
+			nOpt:               100,
+			wantLiveSize:       0,
+			wantActiveSize:     500.0 / 1_000_000.0,
+			wantLiveSaturation: 1000.0 / (1_000_000.0 / 100.0),
+		},
+		{
+			name:               "zero total active stake",
+			liveStake:          1000,
+			totalLive:          10_000,
+			activeStake:        0,
+			totalActive:        0,
+			nOpt:               100,
+			wantLiveSize:       1000.0 / 10_000.0,
+			wantActiveSize:     0,
+			wantLiveSaturation: 0,
+		},
+		{
+			name:               "nOpt not yet available",
+			liveStake:          1000,
+			totalLive:          10_000,
+			activeStake:        500,
+			totalActive:        1_000_000,
+			nOpt:               0,
+			wantLiveSize:       1000.0 / 10_000.0,
+			wantActiveSize:     500.0 / 1_000_000.0,
+			wantLiveSaturation: 0,
+		},
+		{
+			name: "all zero",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			liveSize, activeSize, liveSaturation := poolSizeSaturation(
+				tt.liveStake, tt.activeStake, tt.totalLive, tt.totalActive, tt.nOpt,
+			)
+			assert.InDelta(t, tt.wantLiveSize, liveSize, 1e-9)
+			assert.InDelta(t, tt.wantActiveSize, activeSize, 1e-9)
+			assert.InDelta(t, tt.wantLiveSaturation, liveSaturation, 1e-9)
+		})
+	}
+}

--- a/api/blockfrost/pool_detail_test.go
+++ b/api/blockfrost/pool_detail_test.go
@@ -232,19 +232,26 @@ func TestPoolSizeSaturation(t *testing.T) {
 	tests := []struct {
 		name                                             string
 		liveStake, activeStake, totalLive, totalActive   uint64
+		totalCirculation                                 uint64
 		nOpt                                             int
 		wantLiveSize, wantActiveSize, wantLiveSaturation float64
 	}{
 		{
+			// totalCirculation is deliberately different from totalActive
+			// here (as it always is in practice: circulating supply is
+			// always larger than total staked), so this case would catch
+			// live_saturation being computed against the wrong
+			// denominator.
 			name:               "normal pool",
 			liveStake:          6_900_000_000,
 			activeStake:        4_200_000_000,
 			totalLive:          16_428_571_428,
 			totalActive:        420_000_000_000,
+			totalCirculation:   700_000_000_000,
 			nOpt:               500,
 			wantLiveSize:       6_900_000_000.0 / 16_428_571_428.0,
 			wantActiveSize:     4_200_000_000.0 / 420_000_000_000.0,
-			wantLiveSaturation: 6_900_000_000.0 / (420_000_000_000.0 / 500.0),
+			wantLiveSaturation: 6_900_000_000.0 / (700_000_000_000.0 / 500.0),
 		},
 		{
 			name:               "zero total live stake",
@@ -252,21 +259,31 @@ func TestPoolSizeSaturation(t *testing.T) {
 			totalLive:          0,
 			totalActive:        1_000_000,
 			activeStake:        500,
+			totalCirculation:   2_000_000,
 			nOpt:               100,
 			wantLiveSize:       0,
 			wantActiveSize:     500.0 / 1_000_000.0,
-			wantLiveSaturation: 1000.0 / (1_000_000.0 / 100.0),
+			wantLiveSaturation: 1000.0 / (2_000_000.0 / 100.0),
 		},
 		{
+			// totalActive == 0 (no snapshot captured) no longer affects
+			// live_saturation at all: it now depends solely on
+			// totalCirculation and nOpt, so it comes out nonzero here even
+			// though active_size is forced to zero by the totalActive
+			// guard. PoolDetail itself errors before calling this function
+			// when totalActive == 0 (see the active_size doc comment on
+			// poolSizeSaturation in adapter_pool_detail.go); this case
+			// only pins poolSizeSaturation's own defensive guard.
 			name:               "zero total active stake",
 			liveStake:          1000,
 			totalLive:          10_000,
 			activeStake:        0,
 			totalActive:        0,
+			totalCirculation:   5_000_000,
 			nOpt:               100,
 			wantLiveSize:       1000.0 / 10_000.0,
 			wantActiveSize:     0,
-			wantLiveSaturation: 0,
+			wantLiveSaturation: 1000.0 / (5_000_000.0 / 100.0),
 		},
 		{
 			// Defensive zero-denominator guard only: PoolDetail never calls
@@ -278,7 +295,24 @@ func TestPoolSizeSaturation(t *testing.T) {
 			totalLive:          10_000,
 			activeStake:        500,
 			totalActive:        1_000_000,
+			totalCirculation:   2_000_000,
 			nOpt:               0,
+			wantLiveSize:       1000.0 / 10_000.0,
+			wantActiveSize:     500.0 / 1_000_000.0,
+			wantLiveSaturation: 0,
+		},
+		{
+			// Defensive zero-denominator guard only: PoolDetail never calls
+			// this with totalCirculation == 0 in practice, since it now
+			// requires totalCirculation to be computed successfully before
+			// calling this function at all.
+			name:               "zero total circulation",
+			liveStake:          1000,
+			totalLive:          10_000,
+			activeStake:        500,
+			totalActive:        1_000_000,
+			totalCirculation:   0,
+			nOpt:               100,
 			wantLiveSize:       1000.0 / 10_000.0,
 			wantActiveSize:     500.0 / 1_000_000.0,
 			wantLiveSaturation: 0,
@@ -286,15 +320,36 @@ func TestPoolSizeSaturation(t *testing.T) {
 		{
 			name: "all zero",
 		},
+		{
+			// Mainnet-shaped: circulating supply and total staked diverge
+			// enough (~1.68x) that the two denominators disagree sharply.
+			// A pool at 72M ADA live stake should land at ~1.0 saturation
+			// against the correct denominator (circulating supply / nOpt =
+			// 72.2M ADA), the shape the pre-fix formula (totalActive /
+			// nOpt = 43M ADA) could not express: it would have reported
+			// this same pool at ~1.674. Values are lovelace
+			// (1 ADA = 1_000_000 lovelace).
+			name:               "mainnet-shaped: circulating vs staked diverge",
+			liveStake:          72_000_000_000_000,     // 72M ADA
+			activeStake:        72_000_000_000_000,     // 72M ADA
+			totalLive:          21_500_000_000_000_000, // 21.5B ADA
+			totalActive:        21_500_000_000_000_000, // 21.5B ADA
+			totalCirculation:   36_100_000_000_000_000, // 36.1B ADA
+			nOpt:               500,
+			wantLiveSize:       72_000_000_000_000.0 / 21_500_000_000_000_000.0,
+			wantActiveSize:     72_000_000_000_000.0 / 21_500_000_000_000_000.0,
+			wantLiveSaturation: 72_000_000_000_000.0 / (36_100_000_000_000_000.0 / 500.0),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			liveSize, activeSize, liveSaturation := poolSizeSaturation(
-				tt.liveStake, tt.activeStake, tt.totalLive, tt.totalActive, tt.nOpt,
+				tt.liveStake, tt.activeStake, tt.totalLive, tt.totalActive,
+				tt.totalCirculation, tt.nOpt,
 			)
 			assert.InDelta(t, tt.wantLiveSize, liveSize, 1e-9)
 			assert.InDelta(t, tt.wantActiveSize, activeSize, 1e-9)
-			assert.InDelta(t, tt.wantLiveSaturation, liveSaturation, 1e-9)
+			assert.InDelta(t, tt.wantLiveSaturation, liveSaturation, 1e-6)
 		})
 	}
 }

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -321,6 +321,44 @@ type OffchainFetchErrorResponse struct {
 	Message string `json:"message"`
 }
 
+// PoolDetailResponse represents a Blockfrost pool detail object (OpenAPI
+// 0.1.90 pool schema).
+type PoolDetailResponse struct {
+	PoolID         string                  `json:"pool_id"`
+	Hex            string                  `json:"hex"`
+	VrfKey         string                  `json:"vrf_key"`
+	BlocksMinted   uint64                  `json:"blocks_minted"`
+	BlocksEpoch    uint64                  `json:"blocks_epoch"`
+	LiveStake      string                  `json:"live_stake"`
+	LiveSize       float64                 `json:"live_size"`
+	LiveSaturation float64                 `json:"live_saturation"`
+	LiveDelegators uint64                  `json:"live_delegators"`
+	ActiveStake    string                  `json:"active_stake"`
+	ActiveSize     float64                 `json:"active_size"`
+	DeclaredPledge string                  `json:"declared_pledge"`
+	LivePledge     string                  `json:"live_pledge"`
+	MarginCost     float64                 `json:"margin_cost"`
+	FixedCost      string                  `json:"fixed_cost"`
+	RewardAccount  string                  `json:"reward_account"`
+	Owners         []string                `json:"owners"`
+	Registration   []string                `json:"registration"`
+	Retirement     []string                `json:"retirement"`
+	CalidusKey     *PoolCalidusKeyResponse `json:"calidus_key"`
+}
+
+// PoolCalidusKeyResponse represents a pool's latest valid CIP-0088 Calidus
+// key registration. dingo does not ingest Calidus key registrations from
+// any source, so this field is always null in responses.
+type PoolCalidusKeyResponse struct {
+	ID          string `json:"id"`
+	PubKey      string `json:"pub_key"`
+	Nonce       uint64 `json:"nonce"`
+	TxHash      string `json:"tx_hash"`
+	BlockHeight uint64 `json:"block_height"`
+	BlockTime   int64  `json:"block_time"`
+	Epoch       uint64 `json:"epoch"`
+}
+
 // ErrorResponse represents a Blockfrost error response.
 type ErrorResponse struct {
 	StatusCode int    `json:"status_code"`

--- a/database/plugin/metadata/internal/poolcerthistory/poolcerthistory.go
+++ b/database/plugin/metadata/internal/poolcerthistory/poolcerthistory.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package poolcerthistory centralizes the pool-certificate-history query
+// shared by the sqlite, postgres, and mysql metadata store backends. The
+// three backends differ only in how the "transaction" table is quoted
+// (sqldialect.TransactionTableName), so keeping the query itself in one
+// place prevents that single quoting difference from drifting into three
+// independently-maintained copies.
+package poolcerthistory
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"gorm.io/gorm"
+)
+
+// GetPoolCertificateHistory returns the transaction hashes of a pool's
+// registration and retirement certificates, ordered chronologically
+// (added_slot, block_index, cert_index ascending). The inner joins to certs
+// and transaction naturally exclude rows with no linked transaction —
+// certificates synthesized by the Mithril ledger-state import carry
+// certificate_id = 0, which matches no certs row — since they have no
+// originating transaction to report. Both pool_registration.pool_key_hash
+// and pool_retirement.pool_key_hash are indexed, so each query is a small,
+// indexed lookup rather than a table scan.
+func GetPoolCertificateHistory(
+	db *gorm.DB,
+	pkh lcommon.PoolKeyHash,
+) ([][]byte, [][]byte, error) {
+	transactionTable := sqldialect.TransactionTableName(db)
+
+	type certTxRow struct {
+		TxHash []byte
+	}
+
+	var regRows []certTxRow
+	if err := db.Table("pool_registration").
+		Select(transactionTable+".hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
+		Joins("JOIN "+transactionTable+" ON "+transactionTable+".id = certs.transaction_id").
+		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_registration.added_slot ASC, " +
+				transactionTable + ".block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&regRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query registrations: %w", err,
+		)
+	}
+
+	var retRows []certTxRow
+	if err := db.Table("pool_retirement").
+		Select(transactionTable+".hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
+		Joins("JOIN "+transactionTable+" ON "+transactionTable+".id = certs.transaction_id").
+		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_retirement.added_slot ASC, " +
+				transactionTable + ".block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&retRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query retirements: %w", err,
+		)
+	}
+
+	registrationTxHashes := make([][]byte, 0, len(regRows))
+	for _, row := range regRows {
+		registrationTxHashes = append(registrationTxHashes, row.TxHash)
+	}
+	retirementTxHashes := make([][]byte, 0, len(retRows))
+	for _, row := range retRows {
+		retirementTxHashes = append(retirementTxHashes, row.TxHash)
+	}
+	return registrationTxHashes, retirementTxHashes, nil
+}

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -1268,3 +1268,70 @@ func (d *MetadataStoreMysql) GetRetiringPools(
 	}
 	return rows, nil
 }
+
+// GetPoolCertificateHistory returns the transaction hashes of a pool's
+// registration and retirement certificates, ordered chronologically
+// (added_slot, block_index, cert_index ascending). The inner joins to certs
+// and transaction naturally exclude rows with no linked transaction —
+// certificates synthesized by the Mithril ledger-state import carry
+// certificate_id = 0, which matches no certs row — since they have no
+// originating transaction to report. Both pool_registration.pool_key_hash
+// and pool_retirement.pool_key_hash are indexed, so each query is a small,
+// indexed lookup rather than a table scan.
+func (d *MetadataStoreMysql) GetPoolCertificateHistory(
+	pkh lcommon.PoolKeyHash,
+	txn types.Txn,
+) ([][]byte, [][]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	type certTxRow struct {
+		TxHash []byte
+	}
+
+	var regRows []certTxRow
+	if err := db.Table("pool_registration").
+		Select("`transaction`.hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
+		Joins("JOIN `transaction` ON `transaction`.id = certs.transaction_id").
+		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_registration.added_slot ASC, " +
+				"`transaction`.block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&regRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query registrations: %w", err,
+		)
+	}
+
+	var retRows []certTxRow
+	if err := db.Table("pool_retirement").
+		Select("`transaction`.hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
+		Joins("JOIN `transaction` ON `transaction`.id = certs.transaction_id").
+		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_retirement.added_slot ASC, " +
+				"`transaction`.block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&retRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query retirements: %w", err,
+		)
+	}
+
+	registrationTxHashes := make([][]byte, 0, len(regRows))
+	for _, row := range regRows {
+		registrationTxHashes = append(registrationTxHashes, row.TxHash)
+	}
+	retirementTxHashes := make([][]byte, 0, len(retRows))
+	for _, row := range retRows {
+		retirementTxHashes = append(retirementTxHashes, row.TxHash)
+	}
+	return registrationTxHashes, retirementTxHashes, nil
+}

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolcerthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1270,14 +1271,10 @@ func (d *MetadataStoreMysql) GetRetiringPools(
 }
 
 // GetPoolCertificateHistory returns the transaction hashes of a pool's
-// registration and retirement certificates, ordered chronologically
-// (added_slot, block_index, cert_index ascending). The inner joins to certs
-// and transaction naturally exclude rows with no linked transaction —
-// certificates synthesized by the Mithril ledger-state import carry
-// certificate_id = 0, which matches no certs row — since they have no
-// originating transaction to report. Both pool_registration.pool_key_hash
-// and pool_retirement.pool_key_hash are indexed, so each query is a small,
-// indexed lookup rather than a table scan.
+// registration and retirement certificates. See
+// poolcerthistory.GetPoolCertificateHistory for the query and its semantics
+// — this is a one-line delegation shared with the sqlite and postgres
+// backends, which differ only in how they quote the "transaction" table.
 func (d *MetadataStoreMysql) GetPoolCertificateHistory(
 	pkh lcommon.PoolKeyHash,
 	txn types.Txn,
@@ -1286,52 +1283,5 @@ func (d *MetadataStoreMysql) GetPoolCertificateHistory(
 	if err != nil {
 		return nil, nil, err
 	}
-
-	type certTxRow struct {
-		TxHash []byte
-	}
-
-	var regRows []certTxRow
-	if err := db.Table("pool_registration").
-		Select("`transaction`.hash AS tx_hash").
-		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
-		Joins("JOIN `transaction` ON `transaction`.id = certs.transaction_id").
-		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
-		Order(
-			"pool_registration.added_slot ASC, " +
-				"`transaction`.block_index ASC, " +
-				"certs.cert_index ASC",
-		).
-		Find(&regRows).Error; err != nil {
-		return nil, nil, fmt.Errorf(
-			"GetPoolCertificateHistory: query registrations: %w", err,
-		)
-	}
-
-	var retRows []certTxRow
-	if err := db.Table("pool_retirement").
-		Select("`transaction`.hash AS tx_hash").
-		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
-		Joins("JOIN `transaction` ON `transaction`.id = certs.transaction_id").
-		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
-		Order(
-			"pool_retirement.added_slot ASC, " +
-				"`transaction`.block_index ASC, " +
-				"certs.cert_index ASC",
-		).
-		Find(&retRows).Error; err != nil {
-		return nil, nil, fmt.Errorf(
-			"GetPoolCertificateHistory: query retirements: %w", err,
-		)
-	}
-
-	registrationTxHashes := make([][]byte, 0, len(regRows))
-	for _, row := range regRows {
-		registrationTxHashes = append(registrationTxHashes, row.TxHash)
-	}
-	retirementTxHashes := make([][]byte, 0, len(retRows))
-	for _, row := range retRows {
-		retirementTxHashes = append(retirementTxHashes, row.TxHash)
-	}
-	return registrationTxHashes, retirementTxHashes, nil
+	return poolcerthistory.GetPoolCertificateHistory(db, pkh)
 }

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolcerthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1321,14 +1322,10 @@ func (d *MetadataStorePostgres) GetRetiringPools(
 }
 
 // GetPoolCertificateHistory returns the transaction hashes of a pool's
-// registration and retirement certificates, ordered chronologically
-// (added_slot, block_index, cert_index ascending). The inner joins to certs
-// and transaction naturally exclude rows with no linked transaction —
-// certificates synthesized by the Mithril ledger-state import carry
-// certificate_id = 0, which matches no certs row — since they have no
-// originating transaction to report. Both pool_registration.pool_key_hash
-// and pool_retirement.pool_key_hash are indexed, so each query is a small,
-// indexed lookup rather than a table scan.
+// registration and retirement certificates. See
+// poolcerthistory.GetPoolCertificateHistory for the query and its semantics
+// — this is a one-line delegation shared with the sqlite and mysql
+// backends, which differ only in how they quote the "transaction" table.
 func (d *MetadataStorePostgres) GetPoolCertificateHistory(
 	pkh lcommon.PoolKeyHash,
 	txn types.Txn,
@@ -1337,52 +1334,5 @@ func (d *MetadataStorePostgres) GetPoolCertificateHistory(
 	if err != nil {
 		return nil, nil, err
 	}
-
-	type certTxRow struct {
-		TxHash []byte
-	}
-
-	var regRows []certTxRow
-	if err := db.Table("pool_registration").
-		Select("\"transaction\".hash AS tx_hash").
-		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
-		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
-		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
-		Order(
-			"pool_registration.added_slot ASC, " +
-				"\"transaction\".block_index ASC, " +
-				"certs.cert_index ASC",
-		).
-		Find(&regRows).Error; err != nil {
-		return nil, nil, fmt.Errorf(
-			"GetPoolCertificateHistory: query registrations: %w", err,
-		)
-	}
-
-	var retRows []certTxRow
-	if err := db.Table("pool_retirement").
-		Select("\"transaction\".hash AS tx_hash").
-		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
-		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
-		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
-		Order(
-			"pool_retirement.added_slot ASC, " +
-				"\"transaction\".block_index ASC, " +
-				"certs.cert_index ASC",
-		).
-		Find(&retRows).Error; err != nil {
-		return nil, nil, fmt.Errorf(
-			"GetPoolCertificateHistory: query retirements: %w", err,
-		)
-	}
-
-	registrationTxHashes := make([][]byte, 0, len(regRows))
-	for _, row := range regRows {
-		registrationTxHashes = append(registrationTxHashes, row.TxHash)
-	}
-	retirementTxHashes := make([][]byte, 0, len(retRows))
-	for _, row := range retRows {
-		retirementTxHashes = append(retirementTxHashes, row.TxHash)
-	}
-	return registrationTxHashes, retirementTxHashes, nil
+	return poolcerthistory.GetPoolCertificateHistory(db, pkh)
 }

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -1319,3 +1319,70 @@ func (d *MetadataStorePostgres) GetRetiringPools(
 	}
 	return rows, nil
 }
+
+// GetPoolCertificateHistory returns the transaction hashes of a pool's
+// registration and retirement certificates, ordered chronologically
+// (added_slot, block_index, cert_index ascending). The inner joins to certs
+// and transaction naturally exclude rows with no linked transaction —
+// certificates synthesized by the Mithril ledger-state import carry
+// certificate_id = 0, which matches no certs row — since they have no
+// originating transaction to report. Both pool_registration.pool_key_hash
+// and pool_retirement.pool_key_hash are indexed, so each query is a small,
+// indexed lookup rather than a table scan.
+func (d *MetadataStorePostgres) GetPoolCertificateHistory(
+	pkh lcommon.PoolKeyHash,
+	txn types.Txn,
+) ([][]byte, [][]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	type certTxRow struct {
+		TxHash []byte
+	}
+
+	var regRows []certTxRow
+	if err := db.Table("pool_registration").
+		Select("\"transaction\".hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
+		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
+		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_registration.added_slot ASC, " +
+				"\"transaction\".block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&regRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query registrations: %w", err,
+		)
+	}
+
+	var retRows []certTxRow
+	if err := db.Table("pool_retirement").
+		Select("\"transaction\".hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
+		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
+		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_retirement.added_slot ASC, " +
+				"\"transaction\".block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&retRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query retirements: %w", err,
+		)
+	}
+
+	registrationTxHashes := make([][]byte, 0, len(regRows))
+	for _, row := range regRows {
+		registrationTxHashes = append(registrationTxHashes, row.TxHash)
+	}
+	retirementTxHashes := make([][]byte, 0, len(retRows))
+	for _, row := range retRows {
+		retirementTxHashes = append(retirementTxHashes, row.TxHash)
+	}
+	return registrationTxHashes, retirementTxHashes, nil
+}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -1380,3 +1380,70 @@ func (d *MetadataStoreSqlite) GetRetiringPools(
 	}
 	return rows, nil
 }
+
+// GetPoolCertificateHistory returns the transaction hashes of a pool's
+// registration and retirement certificates, ordered chronologically
+// (added_slot, block_index, cert_index ascending). The inner joins to certs
+// and transaction naturally exclude rows with no linked transaction —
+// certificates synthesized by the Mithril ledger-state import carry
+// certificate_id = 0, which matches no certs row — since they have no
+// originating transaction to report. Both pool_registration.pool_key_hash
+// and pool_retirement.pool_key_hash are indexed, so each query is a small,
+// indexed lookup rather than a table scan.
+func (d *MetadataStoreSqlite) GetPoolCertificateHistory(
+	pkh lcommon.PoolKeyHash,
+	txn types.Txn,
+) ([][]byte, [][]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	type certTxRow struct {
+		TxHash []byte
+	}
+
+	var regRows []certTxRow
+	if err := db.Table("pool_registration").
+		Select("\"transaction\".hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
+		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
+		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_registration.added_slot ASC, " +
+				"\"transaction\".block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&regRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query registrations: %w", err,
+		)
+	}
+
+	var retRows []certTxRow
+	if err := db.Table("pool_retirement").
+		Select("\"transaction\".hash AS tx_hash").
+		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
+		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
+		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
+		Order(
+			"pool_retirement.added_slot ASC, " +
+				"\"transaction\".block_index ASC, " +
+				"certs.cert_index ASC",
+		).
+		Find(&retRows).Error; err != nil {
+		return nil, nil, fmt.Errorf(
+			"GetPoolCertificateHistory: query retirements: %w", err,
+		)
+	}
+
+	registrationTxHashes := make([][]byte, 0, len(regRows))
+	for _, row := range regRows {
+		registrationTxHashes = append(registrationTxHashes, row.TxHash)
+	}
+	retirementTxHashes := make([][]byte, 0, len(retRows))
+	for _, row := range retRows {
+		retirementTxHashes = append(retirementTxHashes, row.TxHash)
+	}
+	return registrationTxHashes, retirementTxHashes, nil
+}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -20,6 +20,7 @@ import (
 	"math"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolcerthistory"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1382,14 +1383,10 @@ func (d *MetadataStoreSqlite) GetRetiringPools(
 }
 
 // GetPoolCertificateHistory returns the transaction hashes of a pool's
-// registration and retirement certificates, ordered chronologically
-// (added_slot, block_index, cert_index ascending). The inner joins to certs
-// and transaction naturally exclude rows with no linked transaction —
-// certificates synthesized by the Mithril ledger-state import carry
-// certificate_id = 0, which matches no certs row — since they have no
-// originating transaction to report. Both pool_registration.pool_key_hash
-// and pool_retirement.pool_key_hash are indexed, so each query is a small,
-// indexed lookup rather than a table scan.
+// registration and retirement certificates. See
+// poolcerthistory.GetPoolCertificateHistory for the query and its semantics
+// — this is a one-line delegation shared with the postgres and mysql
+// backends, which differ only in how they quote the "transaction" table.
 func (d *MetadataStoreSqlite) GetPoolCertificateHistory(
 	pkh lcommon.PoolKeyHash,
 	txn types.Txn,
@@ -1398,52 +1395,5 @@ func (d *MetadataStoreSqlite) GetPoolCertificateHistory(
 	if err != nil {
 		return nil, nil, err
 	}
-
-	type certTxRow struct {
-		TxHash []byte
-	}
-
-	var regRows []certTxRow
-	if err := db.Table("pool_registration").
-		Select("\"transaction\".hash AS tx_hash").
-		Joins("JOIN certs ON certs.id = pool_registration.certificate_id").
-		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
-		Where("pool_registration.pool_key_hash = ?", pkh.Bytes()).
-		Order(
-			"pool_registration.added_slot ASC, " +
-				"\"transaction\".block_index ASC, " +
-				"certs.cert_index ASC",
-		).
-		Find(&regRows).Error; err != nil {
-		return nil, nil, fmt.Errorf(
-			"GetPoolCertificateHistory: query registrations: %w", err,
-		)
-	}
-
-	var retRows []certTxRow
-	if err := db.Table("pool_retirement").
-		Select("\"transaction\".hash AS tx_hash").
-		Joins("JOIN certs ON certs.id = pool_retirement.certificate_id").
-		Joins("JOIN \"transaction\" ON \"transaction\".id = certs.transaction_id").
-		Where("pool_retirement.pool_key_hash = ?", pkh.Bytes()).
-		Order(
-			"pool_retirement.added_slot ASC, " +
-				"\"transaction\".block_index ASC, " +
-				"certs.cert_index ASC",
-		).
-		Find(&retRows).Error; err != nil {
-		return nil, nil, fmt.Errorf(
-			"GetPoolCertificateHistory: query retirements: %w", err,
-		)
-	}
-
-	registrationTxHashes := make([][]byte, 0, len(regRows))
-	for _, row := range regRows {
-		registrationTxHashes = append(registrationTxHashes, row.TxHash)
-	}
-	retirementTxHashes := make([][]byte, 0, len(retRows))
-	for _, row := range retRows {
-		retirementTxHashes = append(retirementTxHashes, row.TxHash)
-	}
-	return registrationTxHashes, retirementTxHashes, nil
+	return poolcerthistory.GetPoolCertificateHistory(db, pkh)
 }

--- a/database/plugin/metadata/sqlite/pool_test.go
+++ b/database/plugin/metadata/sqlite/pool_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,15 +54,15 @@ func TestGetRetiringPools(t *testing.T) {
 	poolD := bytes.Repeat([]byte{0xD4}, 28) // retirement epoch already passed
 	poolE := bytes.Repeat([]byte{0xE5}, 28) // pending at epoch 15 (orders first)
 
-	makeCert(1, 1, 0, 0) // poolA reg
-	makeCert(2, 2, 0, 0) // poolA retire
-	makeCert(3, 3, 0, 0) // poolB reg
-	makeCert(4, 4, 0, 0) // poolB retire
-	makeCert(5, 5, 0, 0) // poolB rereg (later slot)
-	makeCert(6, 6, 0, 0) // poolC reg
-	makeCert(7, 7, 0, 0) // poolC retire (same slot as rereg, lower cert_index)
-	makeCert(8, 7, 1, 0) // poolC rereg (same slot+tx block, higher cert_index)
-	makeCert(9, 9, 0, 0)  // poolD reg
+	makeCert(1, 1, 0, 0)   // poolA reg
+	makeCert(2, 2, 0, 0)   // poolA retire
+	makeCert(3, 3, 0, 0)   // poolB reg
+	makeCert(4, 4, 0, 0)   // poolB retire
+	makeCert(5, 5, 0, 0)   // poolB rereg (later slot)
+	makeCert(6, 6, 0, 0)   // poolC reg
+	makeCert(7, 7, 0, 0)   // poolC retire (same slot as rereg, lower cert_index)
+	makeCert(8, 7, 1, 0)   // poolC rereg (same slot+tx block, higher cert_index)
+	makeCert(9, 9, 0, 0)   // poolD reg
 	makeCert(10, 10, 0, 0) // poolD retire (past epoch)
 	makeCert(11, 11, 0, 0) // poolE reg
 	makeCert(12, 12, 0, 0) // poolE retire
@@ -110,4 +111,102 @@ func TestGetRetiringPools(t *testing.T) {
 	assert.Equal(t, uint64(15), rows[0].Epoch)
 	assert.Equal(t, poolA, rows[1].PoolKeyHash)
 	assert.Equal(t, uint64(20), rows[1].Epoch)
+}
+
+// TestGetPoolCertificateHistory covers the transaction-hash history behind
+// the Blockfrost pool-detail registration/retirement arrays: multiple
+// registrations and a retirement return their transaction hashes in
+// chronological (added_slot, block_index, cert_index) order, and a
+// certificate with no linked transaction -- as synthesized by the Mithril
+// ledger-state import (certificate_id = 0) -- is excluded rather than
+// erroring or appearing as a zero hash.
+func TestGetPoolCertificateHistory(t *testing.T) {
+	store := setupTestDB(t)
+
+	makeTxAndCert := func(certID uint, txID uint, txHash []byte, certIndex uint, blockIndex uint32) {
+		require.NoError(t, store.DB().Create(&models.Transaction{
+			ID:         txID,
+			Hash:       txHash,
+			Slot:       100,
+			BlockIndex: blockIndex,
+		}).Error)
+		require.NoError(t, store.DB().Exec(
+			"INSERT INTO certs (id, transaction_id, cert_index, cert_type, slot) VALUES (?, ?, ?, 0, 100)",
+			certID, txID, certIndex,
+		).Error)
+	}
+
+	poolA := bytes.Repeat([]byte{0xA9}, 28)
+	pool := models.Pool{
+		PoolKeyHash: poolA,
+		VrfKeyHash:  bytes.Repeat([]byte{0xF9}, 32),
+	}
+	require.NoError(t, store.DB().Create(&pool).Error)
+
+	firstRegTxHash := bytes.Repeat([]byte{0x01}, 32)
+	rereg1TxHash := bytes.Repeat([]byte{0x02}, 32)
+	rereg2TxHash := bytes.Repeat([]byte{0x03}, 32)
+	retireTxHash := bytes.Repeat([]byte{0x04}, 32)
+
+	// Registered first at slot 100, re-registered at slots 200 and 300, then
+	// retired at slot 400 (pool_registration/pool_retirement enforce one row
+	// per (pool, added_slot), so distinct certificates need distinct
+	// slots). Insert out of chronological order to ensure the query orders
+	// by added_slot, not insertion order.
+	makeTxAndCert(3, 3, rereg1TxHash, 0, 1)
+	makeTxAndCert(1, 1, firstRegTxHash, 0, 0)
+	makeTxAndCert(4, 4, retireTxHash, 0, 3)
+	makeTxAndCert(5, 5, rereg2TxHash, 0, 2)
+
+	// A synthetic Mithril-imported registration: certificate_id = 0 has no
+	// matching certs row, so it must be excluded from the result.
+	regs := []models.PoolRegistration{
+		{PoolID: pool.ID, PoolKeyHash: poolA, AddedSlot: 50, CertificateID: 0},
+		{PoolID: pool.ID, PoolKeyHash: poolA, AddedSlot: 100, CertificateID: 1},
+		{PoolID: pool.ID, PoolKeyHash: poolA, AddedSlot: 200, CertificateID: 3},
+		{PoolID: pool.ID, PoolKeyHash: poolA, AddedSlot: 300, CertificateID: 5},
+	}
+	for i := range regs {
+		require.NoError(t, store.DB().Create(&regs[i]).Error)
+	}
+	rets := []models.PoolRetirement{
+		{PoolID: pool.ID, PoolKeyHash: poolA, Epoch: 20, AddedSlot: 400, CertificateID: 4},
+	}
+	for i := range rets {
+		require.NoError(t, store.DB().Create(&rets[i]).Error)
+	}
+
+	registrationHashes, retirementHashes, err := store.GetPoolCertificateHistory(
+		lcommon.PoolKeyHash(poolA), nil,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, registrationHashes, 3)
+	assert.Equal(t, firstRegTxHash, registrationHashes[0])
+	assert.Equal(t, rereg1TxHash, registrationHashes[1])
+	assert.Equal(t, rereg2TxHash, registrationHashes[2])
+
+	require.Len(t, retirementHashes, 1)
+	assert.Equal(t, retireTxHash, retirementHashes[0])
+}
+
+// TestGetPoolCertificateHistoryNoCertificates covers a pool with no
+// transaction-backed registrations or retirements at all (e.g. entirely
+// Mithril-imported): both histories must be empty, non-nil slices rather
+// than an error.
+func TestGetPoolCertificateHistoryNoCertificates(t *testing.T) {
+	store := setupTestDB(t)
+
+	poolB := bytes.Repeat([]byte{0xB8}, 28)
+	require.NoError(t, store.DB().Create(&models.Pool{
+		PoolKeyHash: poolB,
+		VrfKeyHash:  bytes.Repeat([]byte{0xE8}, 32),
+	}).Error)
+
+	registrationHashes, retirementHashes, err := store.GetPoolCertificateHistory(
+		lcommon.PoolKeyHash(poolB), nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, registrationHashes)
+	assert.Empty(t, retirementHashes)
 }

--- a/database/plugin/metadata/sqlite/pool_test.go
+++ b/database/plugin/metadata/sqlite/pool_test.go
@@ -207,6 +207,11 @@ func TestGetPoolCertificateHistoryNoCertificates(t *testing.T) {
 		lcommon.PoolKeyHash(poolB), nil,
 	)
 	require.NoError(t, err)
+	// Non-nil is the contract, not just empty: assert.Empty also passes for
+	// nil, and the pool detail response requires these arrays to serialize
+	// as [] rather than null.
+	require.NotNil(t, registrationHashes)
+	require.NotNil(t, retirementHashes)
 	assert.Empty(t, registrationHashes)
 	assert.Empty(t, retirementHashes)
 }

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -431,6 +431,17 @@ type MetadataStore interface {
 	// the retirement epoch is in the future.
 	GetActivePoolKeyHashes(types.Txn) ([][]byte, error)
 
+	// GetPoolCertificateHistory returns the transaction hashes of a pool's
+	// registration and retirement certificates, in chronological order
+	// (added_slot, block_index, cert_index ascending). Certificates with no
+	// linked transaction — rows synthesized by the Mithril ledger-state
+	// import, which carry certificate_id = 0 — are excluded since they have
+	// no originating transaction to report.
+	GetPoolCertificateHistory(
+		lcommon.PoolKeyHash,
+		types.Txn,
+	) (registrationTxHashes [][]byte, retirementTxHashes [][]byte, err error)
+
 	// GetActivePoolKeyHashesAtSlot retrieves the key hashes of pools that were
 	// active at the given slot. A pool was active at a slot if:
 	// 1. It had a registration with added_slot <= slot

--- a/database/pool.go
+++ b/database/pool.go
@@ -202,3 +202,16 @@ func (d *Database) GetActivePoolKeyHashes(
 	}
 	return d.metadata.GetActivePoolKeyHashes(txn.Metadata())
 }
+
+// GetPoolCertificateHistory returns the transaction hashes of a pool's
+// registration and retirement certificates, in chronological order.
+func (d *Database) GetPoolCertificateHistory(
+	pkh lcommon.PoolKeyHash,
+	txn *Txn,
+) ([][]byte, [][]byte, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetPoolCertificateHistory(pkh, txn.Metadata())
+}


### PR DESCRIPTION
Closes #2936

Registers `GET /api/v0/pools/{pool_id}`, the last of the three endpoints #2936 asked for. `/pools/retiring` and `/pools/{pool_id}/metadata` already landed in #2969, so this completes the issue.

Accepts bech32 or hex pool IDs via the existing `parsePoolID`, so both forms resolve to the same pool. A route-ordering test asserts `/pools/retiring` and `/pools/extended` still reach their own handlers now that `{pool_id}` is registered.

## Field sourcing

| Field | Source |
|---|---|
| pool_id, hex, vrf_key | pool row, bech32 via `lcommon.PoolId` |
| declared_pledge, fixed_cost, margin_cost, reward_account | denormalized `Pool` columns, same convention as `PoolsExtended` |
| owners | latest registrations `Owners`, bech32 via existing `stakeAddressFromCredential` |
| live_stake, live_delegators | `GetStakeByPools` (its second return was previously discarded) |
| active_stake | `GetPoolStakeSnapshotsByEpoch` mark snapshot, matching `PoolsExtended` and `Network` |
| live_size, active_size, live_saturation | new `poolSizeSaturation` pure function over those totals plus `nOpt` |
| live_pledge | `GetPoolOwnerStakeAtSlot` over owner credentials |
| registration, retirement | new `GetPoolCertificateHistory` query, hex tx hashes, chronological |
| blocks_minted, blocks_epoch | existing `CountPoolBlocksInSlotRange` over `pool_opcert_sequence` |
| calidus_key | always null, see below |

No new table, index, or migration was needed.

## blocks_minted uses an existing lifetime counter

`pool_opcert_sequence` is written once per forged block (`FirstOrCreate` against the unique `(pool_key_hash, slot)` index), so it is a genuine lifetime per-pool block count rather than a per-epoch snapshot. `blocks_minted` widens the existing `CountPoolBlocksInSlotRange` to the pools full history and `blocks_epoch` narrows it to the current epochs slot range, resolved via `Database.GetEpoch` rather than the heavier hardfork-summary path.

The no-upper-bound slot sentinel is `math.MaxInt64`, not `math.MaxUint64`: slot columns bind as signed 64-bit integers through `database/sql` and a `uint64` with the high bit set is rejected by the driver.

### Known limitation, documented

`blocks_minted` undercounts on a Mithril-bootstrapped node. `pool_opcert_sequence` is written only by the live block-apply path (`UpdatePoolOpCertSequence`, called from `ledger/state.go`); `ledgerstate.ImportLedgerState` seeds pool registration state via `ImportPool` but never writes this table. So pre-snapshot history is permanently absent, not merely delayed. This is called out in `DATABASE.md` next to the query description, alongside the existing `account` table Mithril-boundary caveat. Flagging it rather than papering over it, since it affects exactly the nodes most likely to serve API traffic.

## live_saturation fails rather than guessing

`live_saturation` is a required, non-nullable `number` in the OpenAPI `pool` schema, and `calidus_key` is the only nullable field in the whole object. There is therefore no schema-compatible way to encode "unknown", and `0.0` is a value a real pool can legitimately have. So when `CurrentProtocolParams()` is unavailable (protocol parameters are not loaded until after `LedgerState.Start()`), the request errors instead of emitting a fabricated `0.0` that a client could not distinguish from a genuinely unsaturated pool.

An earlier revision of this branch did substitute `nOpt = 0` in that case. That was wrong for the reason above and has been removed; `poolSizeSaturation`s `nOpt > 0` check is now purely a divide-by-zero guard and is documented as such. The adapter test was changed to start a real `LedgerState` against the embedded devnet genesis (`nOpt = 100`) so it asserts real end-to-end saturation math, rather than keeping the test cheap at the responses expense. A separate test pins the error path.

## calidus_key

Always null. There is no reference to Calidus or CIP-0088 anywhere in the repository, so dingo ingests no Calidus key registrations from any source. `nullable: true` in the schema makes null the correct representation, and this is a real absence rather than a placeholder for an aggregate that exists.

## Tests

Handler tests, route-ordering tests, pure-function saturation tests, and real-sqlite-backed adapter tests covering both ID formats, missing pools, database failures, and the protocol-parameters error path. Additions to `sqlite/pool_test.go` are new cases only; the diff also shows gofmt comment realignment in an existing block, with no assertion or expected value changed.

## Verification

`go build ./...` (default and `-tags dingo_extra_plugins`), `go test ./api/blockfrost/... ./database/...`, `golangci-lint run`, `nilaway`, `modernize`, `make import-boundaries`, `go test -race ./api/blockfrost/...`, and `go test ./internal/test/conformance/...` all pass. Verified to merge cleanly with #3012 and to build and pass tests in combination with it.

## Documentation

`DATABASE.md` gains a `GetPoolCertificateHistory` section plus the `blocks_minted` Mithril caveat. `ARCHITECTURE.md` adds pool detail to the Blockfrost router inventory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /api/v0/pools/{pool_id}` for Blockfrost pool detail, completing #2936. Accepts bech32 or hex IDs and preserves `/pools/retiring` and `/pools/extended` routing.

- **New Features**
  - Returns identifiers, VRF key, pledge/margin/fixed cost, reward account, and owners from the latest registration.
  - Live stake/delegators via `GetStakeByPools`; active stake from the Mark snapshot at `currentEpoch-2`; computes `live_size`, `active_size`, and `live_saturation` using network totals and `nOpt` (circulating-supply based).
  - Lifetime and current-epoch block counts via `CountPoolBlocksInSlotRange`; registration/retirement tx hashes via shared `GetPoolCertificateHistory`; `calidus_key` is always null.

- **Bug Fixes**
  - Corrects `live_saturation` to divide by circulating supply (`MaxLovelaceSupply - Reserves`) and errors if reserves exceed max supply.
  - Fails the request when protocol params are unavailable, when no Mark snapshot exists for the target epoch, or when the current-epoch row is missing.
  - Scopes live-stake reads to the handler’s transaction for consistent snapshots; replaces full-network scans with targeted `GetPoolStakeSnapshot`; deduplicates `GetPoolCertificateHistory` into a shared internal query.

<sup>Written for commit 48354a68f281abc8861cd3f427a23b35929f3682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Blockfrost-compatible pool detail endpoint: `GET /api/v0/pools/{pool_id}`.
  - Pool details now include stake, pledge, delegation, saturation, block production, owner, and registration/retirement history data.
  - Supports pool identifiers provided in hexadecimal or bech32 format.
  - Added clear responses for invalid, missing, and unavailable pool data.

- **Documentation**
  - Updated architecture and database documentation to describe pool detail support and certificate history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->