### PR TITLE
feat(blockfrost): implement account reward history endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2791,16 +2791,29 @@ off).
 Snapshot types: `"mark"` for epoch-boundary lovelace totals, `"set"` and `"go"` for historical rotation metadata, and `"actv"` for Mithril-imported active `pool-distr` fractions.
 
 The Cleanup step of each epoch transition (`cleanupOldSnapshots`) prunes only
-what scales with delegator count — `RewardStakeInput` and `RewardAccountOutput`,
-plus `PoolStakeSnapshot` — to the four epochs the rotation and delayed reward
-model need (current through current-3). `EpochSummary`, `RewardAdaPots`,
-`RewardSnapshot`, `RewardPoolInput`, and `RewardPoolOutput` are exempt and
-retained for the life of the database, so full per-epoch and per-pool reward
-history stays queryable and a missing summary row keeps its diagnostic meaning of
-a boundary that was never captured. Because a retained snapshot can outlive its
-per-credential rows, `applyStakeRewards` skips an epoch whose snapshot claims
-delegators over an empty `RewardStakeInput` set rather than failing the rollover.
-See the retention section in `DATABASE.md` for the per-table detail.
+what scales with delegator count — `RewardStakeInput` and (in `core` storage
+mode) `RewardAccountOutput`, plus `PoolStakeSnapshot` — to the four epochs the
+rotation and delayed reward model need (current through current-3).
+`EpochSummary`, `RewardAdaPots`, `RewardSnapshot`, `RewardPoolInput`, and
+`RewardPoolOutput` are exempt and retained for the life of the database, so
+full per-epoch and per-pool reward history stays queryable and a missing
+summary row keeps its diagnostic meaning of a boundary that was never
+captured. Because a retained snapshot can outlive its per-credential rows,
+`applyStakeRewards` skips an epoch whose snapshot claims delegators over an
+empty `RewardStakeInput` set rather than failing the rollover. See the
+retention section in `DATABASE.md` for the per-table detail.
+
+Since dingo #1875, `cleanupOldSnapshots` reads `Database.StorageMode()` and
+diverges for `RewardAccountOutput` only: in `api` storage mode it is exempted
+from the epoch-window prune and retained for the life of the database instead,
+so the Blockfrost account reward-history endpoint
+(`NodeAdapter.AccountRewardHistory`, `GET /accounts/{stake_address}/rewards`)
+can answer for any epoch rather than only the trailing four; `core` mode is
+unchanged. `RewardStakeInput` is pruned to the same four-epoch window in both
+modes regardless — it is not a Blockfrost-visible table and remains too large
+to retain unconditionally. The rollback path, `DeleteRewardStateAfterSlot`, is
+unaffected: it does not consult storage mode and always removes reward-state
+rows (including `RewardAccountOutput`) above the rollback slot in every mode.
 
 ### Reward Metadata State
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -428,7 +428,7 @@ process the same pointer unless the claim expires before a result is recorded.
 | `reward_pool_input` | `id`, `epoch`, `pool_key_hash`, `reward_account`, `reward_account_credential_tag`, `pledge`, `delegated_stake`, `owner_stake`, `cost`, `margin`, `delegator_count`, `blocks_produced`, `total_blocks_in_epoch`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Per-pool metadata captured by epoch rotation. Stake totals are aggregated from the captured `reward_stake_input` credentials, independently of leader-election Mark totals; pool parameters are selected as effective during the ended epoch. Owner stake counts captured key credentials named by the effective pool registration. Block counts are stored on the row at capture time. Pools with missing or invalid registration data are excluded from reward inputs without changing `pool_stake_snapshot` or `epoch_summary`. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward basis for any closed epoch. Logical join to `pool.pool_key_hash`. |
 | `reward_stake_input` | `id`, `epoch`, `pool_key_hash`, `credential_tag`, `staking_key`, `stake`, `owner`, `registered`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash, credential_tag, staking_key)`; indexes `captured_slot`, `boundary_slot` | Per-credential positive stake frozen by either authoritative or fallback reward snapshot capture. Authoritative capture copies from `reward_live_stake` for both gate states, applying the live account-expiration filter inside the exact SNAP-point transaction. A fallback that runs after the transaction tip has passed the snapshot slot reconstructs historical stake as needed. Check the matching `reward_snapshot.authoritative` value to distinguish the source snapshot. `owner` records whether the effective pool registration names the key credential as an owner. Capture defensively deduplicates by `(credential_tag, staking_key)` before deriving `reward_pool_input.delegated_stake` and `delegator_count`, so a corrupted credential cannot contribute to multiple pools and the persisted pool totals remain equal to the sum of their stake-input rows. |
 | `reward_pool_output` | `id`, `epoch`, `pool_key_hash`, `apparent_performance`, `optimal_reward`, `total_reward`, `leader_reward`, `member_reward_total`, `owner_stake`, `undistributed`, `unspendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Persisted per-pool reward-calculation results. Replacing a provisional reward snapshot invalidates rows for the same epoch. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward result for any closed epoch. |
-| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; index `(credential_tag, staking_key, epoch, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below), which the `(credential_tag, staking_key, ...)` index exists specifically to serve: the unique index leads with `epoch`, so without a second, credential-leading index that query would be a full scan of every retained row rather than a range scan over one account's rows. Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
+| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; index `(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below), which the `(credential_tag, staking_key, spendable, ...)` index exists specifically to serve: the unique index leads with `epoch`, so without a second, credential-leading index that query would be a full scan of every retained row rather than a range scan over one account's spendable rows; `spendable` is in that index's equality prefix (not just the base query filter) so the `spendable = true` filter those two methods apply stays a pure index seek rather than a seek followed by a per-row filter. Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
 
 #### Snapshot and Reward-State Retention
 
@@ -469,9 +469,31 @@ per epoch on mainnet, ~5k on preview — so retaining it without bound in `api`
 mode grows the table by that amount every epoch for the life of the database,
 an ongoing, unbounded storage cost, not a one-time one. `core` mode never
 serves that endpoint and has no reason to pay it. The
-`(credential_tag, staking_key, epoch, pool_key_hash, reward_type)` index
-(above) is what keeps `GetRewardAccountOutputsByCredential` a bounded lookup
-against that growing table rather than a full scan of it.
+`(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`
+index (above) is what keeps `GetRewardAccountOutputsByCredential` a bounded
+lookup against that growing table rather than a full scan of it.
+
+The row counts above are not the same as disk bytes, and in `api` mode the
+gap matters for sizing: `reward_account_output` carries the pre-existing
+unique index (`epoch, credential_tag, staking_key, pool_key_hash,
+reward_type`) *and*, since dingo #1875, the credential-leading
+`idx_reward_account_output_credential_spendable` (`credential_tag,
+staking_key, spendable, epoch, pool_key_hash, reward_type`) needed to serve
+`GetRewardAccountOutputsByCredential` without a full scan. Both indexes key
+on nearly the same columns as the base row — each carries its own copy of the
+28-byte `staking_key` and `pool_key_hash` — so each index entry is comparable
+in size to the row itself: roughly 100-110 bytes for the row (`id`, `epoch`,
+`credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`,
+`spendable`, `captured_slot`, `boundary_slot`) plus roughly 80-90 bytes per
+index entry for each of the two indexes. An operator sizing a disk from the
+row count alone (1.3M rows/epoch on mainnet) would be sizing for roughly half
+the real number: the base row plus two comparably-sized indexes is on the
+order of 250-300 bytes/row, not ~100-110, so budget roughly double the naive
+row-count estimate for `reward_account_output` specifically in `api` mode —
+on the order of 300-400MB of *added, unbounded* storage per mainnet epoch,
+before compression, compounding for the life of the database. `core` mode
+prunes this table on the same four-epoch window as `reward_stake_input`, so
+it never accumulates this cost.
 
 Retained for the life of the database regardless of storage mode: `epoch`,
 `epoch_summary`, `reward_ada_pots`, `reward_snapshot`, `reward_pool_input`, and
@@ -1471,44 +1493,116 @@ deterministically:
 ```sql
 SELECT *
 FROM reward_account_output
-WHERE credential_tag = $1 AND staking_key = decode($2, 'hex')
+WHERE credential_tag = $1 AND staking_key = decode($2, 'hex') AND spendable = true
 ORDER BY epoch ASC, pool_key_hash ASC, reward_type ASC   -- DESC ASC ASC when order=desc
 LIMIT $3 OFFSET $4;
 ```
 
+`spendable = true` is required, not optional filtering: `Spendable = false`
+means the reward was never actually credited to the account.
+`applyStakeRewardApplication` (`ledger/reward_calculation.go`) skips crediting
+a non-spendable output and instead folds its amount into the epoch's
+unspendable total, and `finalizePrecomputedRewardOutputs` persists
+`Spendable = false` permanently for a credential that deregistered before its
+reward's payout boundary. Without this filter both the row and the count
+would misreport an uncredited reward as one the account received (dingo #1875
+review finding 1); `CountRewardAccountOutputsByCredential` applies the same
+filter to its `COUNT(*)` so the reported total always matches the rows that
+can actually be paginated.
+
+NOTE (not fixed by the `spendable` filter, tracked as a follow-up): a
+CIP-0163-guarded reward (`rewardOutputGuarded`,
+`ledger/reward_calculation.go`) is also skipped at crediting time and folded
+into undistributed/reserves, but that guard is never written back to
+`Spendable` — a guarded row keeps `spendable = true`. This filter does not
+catch it, so once CIP-0163 (delegator inactivity) activates, a
+CIP-0163-expired credential's guarded reward can still be overstated by this
+endpoint the same way non-spendable rows were before this fix. Out of scope
+for dingo #1875; needs its own follow-up (e.g. persisting the guard decision
+onto the row, the same way `Spendable` already is).
+
 The adapter maps `reward_type` (dingo's `ledger/rewards.RewardType`: `leader`,
 `member`) to the Blockfrost `account_reward_content` `type` enum (`leader`,
-`member`, `pool_deposit_refund`); the two currently-produced values already
-match verbatim, and any value dingo does not yet model is passed through
-lowercased rather than dropped. `pool_key_hash` is rendered as a bech32 pool ID
-the same way `GetAccountDelegationHistory` does. See the retention note above
-for how far back this query can answer: unbounded in `api` storage mode,
-windowed to the last four epochs in `core` mode.
+`member`, `pool_deposit_refund`) by lowercasing it; the two currently-produced
+values already match verbatim. `blockfrostRewardTypes` (a package-level
+allow-list in `api/blockfrost/adapter.go`, not a translation table) checks
+membership rather than translating: a lowercased value outside the allow-list
+still passes through rather than being dropped, but the adapter also logs a
+warning, since a value outside `leader`/`member`/`pool_deposit_refund` would
+otherwise silently make the closed Blockfrost OpenAPI enum for this field
+invalid. `pool_key_hash` is rendered as a bech32 pool ID the same way
+`GetAccountDelegationHistory` does. See the retention note above for how far
+back this query can answer: unbounded in `api` storage mode, windowed to the
+last four epochs in `core` mode.
+
+The stored `epoch` column is the reward-calculation *snapshot* epoch
+(`stakeRewardEpochsForNewEpoch`'s `snapshot = newEpoch - 3` in
+`ledger/reward_calculation.go`, which is what `rewardAccountOutputs` persists
+into this column), not the earned epoch Blockfrost reports. A reward computed
+from snapshot epoch `S` is credited at the boundary into epoch `S+3`, i.e. it
+becomes spendable in `S+3`. cardano-db-sync, which is what Blockfrost serves
+this endpoint from, models `spendable_epoch = earned_epoch + 2`, so
+`earned_epoch = (S+3) - 2 = S+1` — one higher than the stored value, and equal
+to `stakeRewardEpochs.performance` for the same boundary. The adapter reports
+`row.Epoch + 1`, which cannot underflow since it is unsigned addition, and
+pagination/ordering are unaffected since they are driven by the stored
+(snapshot) epoch, only the reported value is shifted.
 
 `reward_account_output`'s pre-existing unique index leads with `epoch`
 (`idx_reward_account_output_epoch_cred_pool_type`), so it cannot serve this
-query's `credential_tag`/`staking_key` equality predicate without scanning
-every row — a real cost once `api` mode retains the table without bound
-(previous paragraph). `idx_reward_account_output_credential`
-`(credential_tag, staking_key, epoch, pool_key_hash, reward_type)` exists so
-the planner instead does a range scan restricted to one credential's rows,
-confirmed with `EXPLAIN QUERY PLAN` (SQLite), `EXPLAIN` (MySQL: `type: ref`),
-and `EXPLAIN` (PostgreSQL: `Index Scan`) all reporting index use rather than a
-table/sequential scan for the query above. The ascending case is served
+query's `credential_tag`/`staking_key`/`spendable` equality predicate without
+scanning every row — a real cost once `api` mode retains the table without
+bound (previous paragraph). `idx_reward_account_output_credential_spendable`
+`(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`
+exists so the planner instead does a range scan restricted to one
+credential's spendable rows, confirmed with `EXPLAIN QUERY PLAN` (SQLite),
+`EXPLAIN` (MySQL: `type: ref`), and `EXPLAIN` (PostgreSQL: `Index Scan`) all
+reporting index use rather than a table/sequential scan for the query above.
+Putting `spendable` in the index's equality prefix (rather than leaving it a
+post-filter after a `credential_tag`/`staking_key`-only seek) is what keeps
+the query a pure index range scan: `EXPLAIN QUERY PLAN` against the older
+two-column prefix reports
+`SEARCH reward_account_output USING INDEX idx_reward_account_output_credential (credential_tag=? AND staking_key=?)`
+— `spendable` is not part of the search key, so every one of the credential's
+rows must still be visited and filtered — while the six-column index reports
+`SEARCH reward_account_output USING INDEX idx_reward_account_output_credential_spendable (credential_tag=? AND staking_key=? AND spendable=?)`,
+with `spendable` folded into the seek itself. The ascending case is served
 entirely from the index; a descending `epoch` request still uses the index for
-the credential lookup but sorts the (typically small, single-credential)
-matched rows for the `pool_key_hash`/`reward_type` tie-break, since no
-practical index can be ordered `epoch DESC, pool_key_hash ASC, reward_type ASC`
-and `epoch ASC, ...` at once.
-`TestGetRewardAccountOutputsByCredentialUsesIndex` pins the plan so a future
-index rename or drop fails loudly instead of silently degrading to a scan.
-AutoMigrate creates this index on both a fresh database and an existing
-populated one (`TestMigrateRewardAccountOutputCredentialIndex` in
-`database/models`); no legacy-index migration helper (as
-`MigrateRewardLiveStakePoolIndex` is for `reward_live_stake`) is needed because
-this is a new, non-unique secondary index over unchanged column types, which
-SQLite/MySQL/PostgreSQL all add with a plain `CREATE INDEX` rather than a table
-rebuild.
+the credential/spendable lookup but sorts the (typically small,
+single-credential) matched rows for the `pool_key_hash`/`reward_type`
+tie-break, since no practical index can be ordered
+`epoch DESC, pool_key_hash ASC, reward_type ASC` and `epoch ASC, ...` at once.
+`TestGetRewardAccountOutputsByCredentialUsesIndex` pins the plan (including
+that `spendable` is part of the search key) so a future index rename, drop,
+or narrowing fails loudly instead of silently degrading to a scan or a
+seek-plus-filter.
+
+`idx_reward_account_output_credential_spendable` supersedes an earlier
+`idx_reward_account_output_credential` (`credential_tag, staking_key, epoch,
+pool_key_hash, reward_type` — no `spendable`) that dingo #1875 originally
+shipped. AutoMigrate creates the new index directly on both a fresh database
+and one that predates dingo #1875 entirely
+(`TestMigrateRewardAccountOutputCredentialIndex` in `database/models`): it is
+a new, non-unique secondary index over unchanged column types, so
+SQLite/MySQL/PostgreSQL all add it with a plain `CREATE INDEX` rather than a
+table rebuild, and no pre-migration repair step is needed to create it.
+Dropping the now-superseded five-column index on a database that already
+upgraded to it, however, does need a helper —
+`MigrateRewardAccountOutputCredentialIndex` in `database/models`, called after
+`AutoMigrate` in each of the sqlite/mysql/postgres `database.go` plugins —
+because AutoMigrate does not alter or drop an index it no longer sees
+declared; left alone, an upgraded database would carry both indexes forever.
+The helper deliberately runs *after* `AutoMigrate` rather than before (unlike
+the legacy-index migrations elsewhere in this file, which drop a unique index
+first because it could otherwise reject valid rows or block a column-type
+change): `idx_reward_account_output_credential` is a plain non-unique
+secondary index, so keeping it a little longer is only wasted space, never a
+correctness problem, and running the drop after guarantees the replacement
+index already exists first.
+`TestMigrateRewardAccountOutputCredentialSpendableIndex` in
+`database/models` pins that upgrade path against a populated database: rows
+of both spendable states survive, the superseded index is gone afterward, and
+the replacement is in place throughout.
 
 ### `GetAccountSumsByCredential`
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -428,7 +428,7 @@ process the same pointer unless the claim expires before a result is recorded.
 | `reward_pool_input` | `id`, `epoch`, `pool_key_hash`, `reward_account`, `reward_account_credential_tag`, `pledge`, `delegated_stake`, `owner_stake`, `cost`, `margin`, `delegator_count`, `blocks_produced`, `total_blocks_in_epoch`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Per-pool metadata captured by epoch rotation. Stake totals are aggregated from the captured `reward_stake_input` credentials, independently of leader-election Mark totals; pool parameters are selected as effective during the ended epoch. Owner stake counts captured key credentials named by the effective pool registration. Block counts are stored on the row at capture time. Pools with missing or invalid registration data are excluded from reward inputs without changing `pool_stake_snapshot` or `epoch_summary`. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward basis for any closed epoch. Logical join to `pool.pool_key_hash`. |
 | `reward_stake_input` | `id`, `epoch`, `pool_key_hash`, `credential_tag`, `staking_key`, `stake`, `owner`, `registered`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash, credential_tag, staking_key)`; indexes `captured_slot`, `boundary_slot` | Per-credential positive stake frozen by either authoritative or fallback reward snapshot capture. Authoritative capture copies from `reward_live_stake` for both gate states, applying the live account-expiration filter inside the exact SNAP-point transaction. A fallback that runs after the transaction tip has passed the snapshot slot reconstructs historical stake as needed. Check the matching `reward_snapshot.authoritative` value to distinguish the source snapshot. `owner` records whether the effective pool registration names the key credential as an owner. Capture defensively deduplicates by `(credential_tag, staking_key)` before deriving `reward_pool_input.delegated_stake` and `delegator_count`, so a corrupted credential cannot contribute to multiple pools and the persisted pool totals remain equal to the sum of their stake-input rows. |
 | `reward_pool_output` | `id`, `epoch`, `pool_key_hash`, `apparent_performance`, `optimal_reward`, `total_reward`, `leader_reward`, `member_reward_total`, `owner_stake`, `undistributed`, `unspendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Persisted per-pool reward-calculation results. Replacing a provisional reward snapshot invalidates rows for the same epoch. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward result for any closed epoch. |
-| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below). Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
+| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; index `(credential_tag, staking_key, epoch, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below), which the `(credential_tag, staking_key, ...)` index exists specifically to serve: the unique index leads with `epoch`, so without a second, credential-leading index that query would be a full scan of every retained row rather than a range scan over one account's rows. Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
 
 #### Snapshot and Reward-State Retention
 
@@ -464,9 +464,14 @@ before dingo #1875 (this is the "prune exactly as it does today" path).
 reward-history endpoint) can answer for any epoch in the database's history
 rather than only the trailing four. The trade is deliberate and paid only by
 operators who chose `api` mode: `reward_account_output` scales with delegator
-count the same way `reward_stake_input` does, so retaining it without bound is
+count the same way `reward_stake_input` does — on the order of 1.3M new rows
+per epoch on mainnet, ~5k on preview — so retaining it without bound in `api`
+mode grows the table by that amount every epoch for the life of the database,
 an ongoing, unbounded storage cost, not a one-time one. `core` mode never
-serves that endpoint and has no reason to pay it.
+serves that endpoint and has no reason to pay it. The
+`(credential_tag, staking_key, epoch, pool_key_hash, reward_type)` index
+(above) is what keeps `GetRewardAccountOutputsByCredential` a bounded lookup
+against that growing table rather than a full scan of it.
 
 Retained for the life of the database regardless of storage mode: `epoch`,
 `epoch_summary`, `reward_ada_pots`, `reward_snapshot`, `reward_pool_input`, and
@@ -1479,6 +1484,31 @@ lowercased rather than dropped. `pool_key_hash` is rendered as a bech32 pool ID
 the same way `GetAccountDelegationHistory` does. See the retention note above
 for how far back this query can answer: unbounded in `api` storage mode,
 windowed to the last four epochs in `core` mode.
+
+`reward_account_output`'s pre-existing unique index leads with `epoch`
+(`idx_reward_account_output_epoch_cred_pool_type`), so it cannot serve this
+query's `credential_tag`/`staking_key` equality predicate without scanning
+every row — a real cost once `api` mode retains the table without bound
+(previous paragraph). `idx_reward_account_output_credential`
+`(credential_tag, staking_key, epoch, pool_key_hash, reward_type)` exists so
+the planner instead does a range scan restricted to one credential's rows,
+confirmed with `EXPLAIN QUERY PLAN` (SQLite), `EXPLAIN` (MySQL: `type: ref`),
+and `EXPLAIN` (PostgreSQL: `Index Scan`) all reporting index use rather than a
+table/sequential scan for the query above. The ascending case is served
+entirely from the index; a descending `epoch` request still uses the index for
+the credential lookup but sorts the (typically small, single-credential)
+matched rows for the `pool_key_hash`/`reward_type` tie-break, since no
+practical index can be ordered `epoch DESC, pool_key_hash ASC, reward_type ASC`
+and `epoch ASC, ...` at once.
+`TestGetRewardAccountOutputsByCredentialUsesIndex` pins the plan so a future
+index rename or drop fails loudly instead of silently degrading to a scan.
+AutoMigrate creates this index on both a fresh database and an existing
+populated one (`TestMigrateRewardAccountOutputCredentialIndex` in
+`database/models`); no legacy-index migration helper (as
+`MigrateRewardLiveStakePoolIndex` is for `reward_live_stake`) is needed because
+this is a new, non-unique secondary index over unchanged column types, which
+SQLite/MySQL/PostgreSQL all add with a plain `CREATE INDEX` rather than a table
+rebuild.
 
 ### `GetAccountSumsByCredential`
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -428,7 +428,7 @@ process the same pointer unless the claim expires before a result is recorded.
 | `reward_pool_input` | `id`, `epoch`, `pool_key_hash`, `reward_account`, `reward_account_credential_tag`, `pledge`, `delegated_stake`, `owner_stake`, `cost`, `margin`, `delegator_count`, `blocks_produced`, `total_blocks_in_epoch`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Per-pool metadata captured by epoch rotation. Stake totals are aggregated from the captured `reward_stake_input` credentials, independently of leader-election Mark totals; pool parameters are selected as effective during the ended epoch. Owner stake counts captured key credentials named by the effective pool registration. Block counts are stored on the row at capture time. Pools with missing or invalid registration data are excluded from reward inputs without changing `pool_stake_snapshot` or `epoch_summary`. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward basis for any closed epoch. Logical join to `pool.pool_key_hash`. |
 | `reward_stake_input` | `id`, `epoch`, `pool_key_hash`, `credential_tag`, `staking_key`, `stake`, `owner`, `registered`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash, credential_tag, staking_key)`; indexes `captured_slot`, `boundary_slot` | Per-credential positive stake frozen by either authoritative or fallback reward snapshot capture. Authoritative capture copies from `reward_live_stake` for both gate states, applying the live account-expiration filter inside the exact SNAP-point transaction. A fallback that runs after the transaction tip has passed the snapshot slot reconstructs historical stake as needed. Check the matching `reward_snapshot.authoritative` value to distinguish the source snapshot. `owner` records whether the effective pool registration names the key credential as an owner. Capture defensively deduplicates by `(credential_tag, staking_key)` before deriving `reward_pool_input.delegated_stake` and `delegator_count`, so a corrupted credential cannot contribute to multiple pools and the persisted pool totals remain equal to the sum of their stake-input rows. |
 | `reward_pool_output` | `id`, `epoch`, `pool_key_hash`, `apparent_performance`, `optimal_reward`, `total_reward`, `leader_reward`, `member_reward_total`, `owner_stake`, `undistributed`, `unspendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Persisted per-pool reward-calculation results. Replacing a provisional reward snapshot invalidates rows for the same epoch. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward result for any closed epoch. |
-| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. |
+| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below). Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
 
 #### Snapshot and Reward-State Retention
 
@@ -436,25 +436,49 @@ Every epoch transition runs `cleanupOldSnapshots`, which prunes to the four
 epochs the Shelley rotation and delayed reward model need: current, current-1,
 current-2 for Go, and current-3 so reward calculation can be replayed after a
 rollback across the boundary where those rewards were applied. Retention is not
-configurable, and it only ever deletes rows below that window.
+configurable per se, but since dingo #1875 it is storage-mode dependent for one
+table (`reward_account_output`, below); it always only ever deletes rows below
+that window.
 
-Pruned at `epoch < current-3`:
+Pruned at `epoch < current-3` in every storage mode:
 
 | Table | Scales with | Pruned by |
 |---|---|---|
 | `pool_stake_snapshot` | pools per epoch | `DeletePoolStakeSnapshotsBeforeEpoch` |
-| `reward_stake_input` | delegators per epoch | `DeleteRewardStateBeforeEpoch` |
+| `reward_stake_input` | delegators per epoch | `DeleteRewardStateBeforeEpoch` (`core`) / `DeleteRewardStakeInputBeforeEpoch` (`api`) |
+
+Pruned at `epoch < current-3` in `core` storage mode only, retained for the
+life of the database in `api` storage mode:
+
+| Table | Scales with | Pruned by (`core` mode) |
+|---|---|---|
 | `reward_account_output` | delegators per epoch | `DeleteRewardStateBeforeEpoch` |
 
-Retained for the life of the database: `epoch`, `epoch_summary`,
-`reward_ada_pots`, `reward_snapshot`, `reward_pool_input`, and
+`cleanupOldSnapshots` reads `Database.StorageMode()` once per cleanup pass and
+picks the call accordingly: `core` mode calls `DeleteRewardStateBeforeEpoch`,
+which prunes both `reward_stake_input` and `reward_account_output` exactly as
+before dingo #1875 (this is the "prune exactly as it does today" path).
+`api` mode calls `DeleteRewardStakeInputBeforeEpoch` instead, which prunes only
+`reward_stake_input` and leaves `reward_account_output` untouched, so
+`GetRewardAccountOutputsByCredential` (used by the Blockfrost account
+reward-history endpoint) can answer for any epoch in the database's history
+rather than only the trailing four. The trade is deliberate and paid only by
+operators who chose `api` mode: `reward_account_output` scales with delegator
+count the same way `reward_stake_input` does, so retaining it without bound is
+an ongoing, unbounded storage cost, not a one-time one. `core` mode never
+serves that endpoint and has no reason to pay it.
+
+Retained for the life of the database regardless of storage mode: `epoch`,
+`epoch_summary`, `reward_ada_pots`, `reward_snapshot`, `reward_pool_input`, and
 `reward_pool_output`. The first four are one row per epoch and the last two are
 roughly one row per pool per epoch, so full history is on the order of a few
 hundred thousand rows on a test network and a few million on mainnet. Only the
 two per-credential tables scale with delegator count — about 5k rows per epoch on
-preview and 1.3M on mainnet — which is why they alone stay windowed. No
-before-epoch delete method exists for any retained table on
-`metadata.MetadataStore`.
+preview and 1.3M on mainnet — which is why `reward_stake_input` alone stays
+windowed in every mode, and why `reward_account_output` staying windowed is the
+default (`core` mode) rather than something dingo can afford to do
+unconditionally. No before-epoch delete method exists for any of the other
+retained tables on `metadata.MetadataStore`.
 
 Together the retained tables are the full per-epoch reward record a historical
 closed-epoch comparison needs: the pots the epoch was paid from, both sets of
@@ -463,9 +487,12 @@ aggregates (leader-election totals in `epoch_summary` and reward-basis totals in
 `reward_live_stake` and excludes pools with degraded registration data), each
 pool's inputs (delegated and owner stake, pledge, cost, margin, reward account,
 block counts), and each pool's results (apparent performance, optimal and total
-reward, leader reward, member reward total). What is not answerable outside the
-window is anything per-delegator: which credentials backed a pool's stake, and
-what each account was paid.
+reward, leader reward, member reward total). In `core` storage mode, what is
+not answerable outside the window is anything per-delegator: which credentials
+backed a pool's stake, and what each account was paid. In `api` storage mode,
+`reward_account_output` (what each account was paid, and from which pool) IS
+answerable outside the window, for the reason above; only "which credentials
+backed a pool's stake" (`reward_stake_input`) stays windowed in both modes.
 
 Retaining a `reward_snapshot` whose `reward_stake_input` rows have been pruned
 cannot produce a wrong reward calculation. `applyStakeRewards` detects the
@@ -486,6 +513,11 @@ therefore re-crossed on the selected chain, where `SavePoolStakeSnapshots`
 replaces that epoch's rows and `SaveEpochSummary` upserts the summary.
 `DeleteEpochSummariesAfterEpoch` and `DeletePoolStakeSnapshotsAfterEpoch` exist
 on `metadata.MetadataStore` for that case but currently have no callers.
+`DeleteRewardStateAfterSlot` does not read storage mode: it unconditionally
+deletes every reward-state row (including `reward_account_output`) with
+`captured_slot`/`boundary_slot` above the rollback point in both `core` and
+`api` mode, so `api` mode's unbounded retention of `reward_account_output`
+does not leave stale rows above a rollback point.
 
 ## Blob Store Reference
 
@@ -1419,6 +1451,34 @@ deposit (`deposit_amount` for registrations, the refund `amount` for the legacy
 `deregistration` table, `0` where the certificate carries none), `tx.slot`
 (`tx_slot`), and `tx.block_hash` (`block_hash`, resolved to `block_height` by
 the adapter as above).
+
+### `GetRewardAccountOutputsByCredential` and `CountRewardAccountOutputsByCredential`
+
+Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint
+(dingo #1875). Unlike the certificate-history queries above, this is a plain
+filter over `reward_account_output` (no UNION across certificate tables:
+reward outputs already live in a single table), ordered by `epoch` with
+`pool_key_hash` then `reward_type` as tie-breakers so an account with more than
+one reward row in the same epoch (a pool owner's leader and member reward, or
+rewards from two different pools around a mid-epoch delegation change) paginates
+deterministically:
+
+```sql
+SELECT *
+FROM reward_account_output
+WHERE credential_tag = $1 AND staking_key = decode($2, 'hex')
+ORDER BY epoch ASC, pool_key_hash ASC, reward_type ASC   -- DESC ASC ASC when order=desc
+LIMIT $3 OFFSET $4;
+```
+
+The adapter maps `reward_type` (dingo's `ledger/rewards.RewardType`: `leader`,
+`member`) to the Blockfrost `account_reward_content` `type` enum (`leader`,
+`member`, `pool_deposit_refund`); the two currently-produced values already
+match verbatim, and any value dingo does not yet model is passed through
+lowercased rather than dropped. `pool_key_hash` is rendered as a bech32 pool ID
+the same way `GetAccountDelegationHistory` does. See the retention note above
+for how far back this query can answer: unbounded in `api` storage mode,
+windowed to the last four epochs in `core` mode.
 
 ### `GetAccountSumsByCredential`
 

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -2413,11 +2413,70 @@ func (a *NodeAdapter) AccountRewardHistory(
 		); err != nil {
 		return nil, 0, err
 	}
-	// TODO(#1875): Implement reward history once Dingo persists
-	// per-account, per-epoch reward records. This endpoint remains
-	// stubbed in this PR because the backing reward-history storage
-	// and rollback-safe ledger/database plumbing do not exist yet.
-	return []AccountRewardHistoryInfo{}, 0, nil
+	offset := (params.Page - 1) * params.Count
+	total, err := a.ledgerState.Database().
+		CountRewardAccountOutputsByCredential(
+			credentialTag,
+			stakeKey,
+			nil,
+		)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count account reward history: %w",
+			err,
+		)
+	}
+	if offset >= total {
+		return []AccountRewardHistoryInfo{}, total, nil
+	}
+	rows, err := a.ledgerState.Database().
+		GetRewardAccountOutputsByCredential(
+			credentialTag,
+			stakeKey,
+			params.Count,
+			offset,
+			params.Order,
+			nil,
+		)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get account reward history: %w",
+			err,
+		)
+	}
+	// blockfrostRewardTypes maps dingo's stored reward_account_output.reward_type
+	// values (ledger/rewards.RewardType: "leader", "member") to the Blockfrost
+	// account_reward_content enum spelling (leader, member,
+	// pool_deposit_refund). The two overlapping spellings already match
+	// verbatim; this only defends against case variance and normalizes a
+	// not-yet-modeled reward type to lowercase rather than silently dropping
+	// it, so a future addition (e.g. a CIP-0163 pool deposit refund) still
+	// surfaces in the response.
+	blockfrostRewardTypes := map[string]string{
+		"leader":              "leader",
+		"member":              "member",
+		"pool_deposit_refund": "pool_deposit_refund",
+	}
+	ret := make([]AccountRewardHistoryInfo, 0, len(rows))
+	for _, row := range rows {
+		epoch, err := uint64ToInt32(row.Epoch, "reward epoch")
+		if err != nil {
+			return nil, 0, err
+		}
+		rewardType, ok := blockfrostRewardTypes[strings.ToLower(row.RewardType)]
+		if !ok {
+			rewardType = strings.ToLower(row.RewardType)
+		}
+		ret = append(ret, AccountRewardHistoryInfo{
+			Epoch:  epoch,
+			Amount: strconv.FormatUint(uint64(row.Amount), 10),
+			PoolID: lcommon.PoolId(
+				lcommon.NewBlake2b224(row.PoolKeyHash),
+			).String(),
+			Type: rewardType,
+		})
+	}
+	return ret, total, nil
 }
 
 func blockIssuer(issuer lcommon.IssuerVkey) string {

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"math/big"
 	"net/http"
@@ -2394,6 +2395,26 @@ func (a *NodeAdapter) AccountRegistrationHistory(
 	return ret, total, nil
 }
 
+// blockfrostRewardTypes is the allow-list of reward_account_output.reward_type
+// values (ledger/rewards.RewardType: RewardTypeLeader "leader", RewardTypeMember
+// "member") that dingo produces today, plus "pool_deposit_refund", which
+// dingo does not yet produce but the Blockfrost account_reward_content "type"
+// enum already defines. It is a package-level var, built once rather than
+// per-request.
+//
+// Membership, not translation, is the point: every recognized value already
+// matches its lowercased form verbatim, so this is not a mapping table. Its
+// job is to catch the day dingo starts producing a reward_type outside this
+// closed set — which would silently make the Blockfrost response
+// schema-invalid otherwise. AccountRewardHistory logs a warning when a row's
+// type is not in this set and still passes the lowercased value through
+// rather than dropping the row.
+var blockfrostRewardTypes = map[string]struct{}{
+	"leader":              {},
+	"member":              {},
+	"pool_deposit_refund": {},
+}
+
 // AccountRewardHistory returns reward history rows for
 // the requested stake address.
 func (a *NodeAdapter) AccountRewardHistory(
@@ -2404,22 +2425,28 @@ func (a *NodeAdapter) AccountRewardHistory(
 	if err != nil {
 		return nil, 0, err
 	}
-	if _, err := a.ledgerState.Database().
-		GetAccountByCredential(
-			credentialTag,
-			stakeKey,
-			true,
-			nil,
-		); err != nil {
+	db := a.ledgerState.Database()
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	if _, err := db.GetAccountByCredential(
+		credentialTag,
+		stakeKey,
+		true,
+		txn,
+	); err != nil {
 		return nil, 0, err
 	}
 	offset := (params.Page - 1) * params.Count
-	total, err := a.ledgerState.Database().
-		CountRewardAccountOutputsByCredential(
-			credentialTag,
-			stakeKey,
-			nil,
-		)
+	// count and rows share the read txn opened above so an epoch boundary
+	// landing between the two queries cannot change total relative to the
+	// page: with two independent nil-txn reads, a client paging through
+	// history at a boundary could see a row twice or miss one.
+	total, err := db.CountRewardAccountOutputsByCredential(
+		credentialTag,
+		stakeKey,
+		txn,
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"count account reward history: %w",
@@ -2429,43 +2456,45 @@ func (a *NodeAdapter) AccountRewardHistory(
 	if offset >= total {
 		return []AccountRewardHistoryInfo{}, total, nil
 	}
-	rows, err := a.ledgerState.Database().
-		GetRewardAccountOutputsByCredential(
-			credentialTag,
-			stakeKey,
-			params.Count,
-			offset,
-			params.Order,
-			nil,
-		)
+	rows, err := db.GetRewardAccountOutputsByCredential(
+		credentialTag,
+		stakeKey,
+		params.Count,
+		offset,
+		params.Order,
+		txn,
+	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get account reward history: %w",
 			err,
 		)
 	}
-	// blockfrostRewardTypes maps dingo's stored reward_account_output.reward_type
-	// values (ledger/rewards.RewardType: "leader", "member") to the Blockfrost
-	// account_reward_content enum spelling (leader, member,
-	// pool_deposit_refund). The two overlapping spellings already match
-	// verbatim; this only defends against case variance and normalizes a
-	// not-yet-modeled reward type to lowercase rather than silently dropping
-	// it, so a future addition (e.g. a CIP-0163 pool deposit refund) still
-	// surfaces in the response.
-	blockfrostRewardTypes := map[string]string{
-		"leader":              "leader",
-		"member":              "member",
-		"pool_deposit_refund": "pool_deposit_refund",
-	}
 	ret := make([]AccountRewardHistoryInfo, 0, len(rows))
 	for _, row := range rows {
-		epoch, err := uint64ToInt32(row.Epoch, "reward epoch")
+		// row.Epoch is the snapshot epoch (stakeRewardEpochsForNewEpoch's
+		// "snapshot" = newEpoch-3 in ledger/reward_calculation.go, which is
+		// what rewardAccountOutputs persists into this column), not the
+		// earned epoch Blockfrost reports. Rewards computed from that
+		// snapshot are credited at the boundary into newEpoch, i.e. they
+		// become spendable in newEpoch = snapshot+3. cardano-db-sync, which
+		// backs this endpoint on Blockfrost, models
+		// spendable_epoch = earned_epoch + 2, so earned_epoch = newEpoch-2 =
+		// snapshot+1 (the "performance" epoch in the same struct). Adding 1
+		// cannot underflow: row.Epoch is a uint64 and this is addition, so a
+		// stored epoch of 0 (or any value) yields a valid earned epoch.
+		earnedEpoch := row.Epoch + 1
+		epoch, err := uint64ToInt32(earnedEpoch, "reward epoch")
 		if err != nil {
 			return nil, 0, err
 		}
-		rewardType, ok := blockfrostRewardTypes[strings.ToLower(row.RewardType)]
-		if !ok {
-			rewardType = strings.ToLower(row.RewardType)
+		rewardType := strings.ToLower(row.RewardType)
+		if _, ok := blockfrostRewardTypes[rewardType]; !ok {
+			slog.Warn(
+				"account reward history: reward_type outside the Blockfrost account_reward_content enum",
+				"reward_type", row.RewardType,
+				"credential_tag", credentialTag,
+			)
 		}
 		ret = append(ret, AccountRewardHistoryInfo{
 			Epoch:  epoch,

--- a/api/blockfrost/adapter_reward_history_test.go
+++ b/api/blockfrost/adapter_reward_history_test.go
@@ -16,6 +16,9 @@ package blockfrost
 
 import (
 	"bytes"
+	"log/slog"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -49,6 +52,14 @@ func newRewardHistoryStakeAddress(
 // owner's leader reward alongside a member reward in the same epoch), and
 // verifies the default (ascending) ordering plus the Blockfrost field
 // mapping, including the "type" enum value.
+//
+// Stored Epoch is the reward-calculation snapshot epoch, not the earned
+// epoch Blockfrost reports (dingo #1875 review finding 2): the reward
+// computed from snapshot epoch S is credited at the boundary into S+3, which
+// is when it becomes spendable, and cardano-db-sync (what Blockfrost serves
+// this endpoint from) models spendable_epoch = earned_epoch + 2, so
+// earned_epoch = S+1. Row ordering is still driven by the stored (snapshot)
+// epoch; only the reported value is shifted.
 func TestAccountRewardHistoryMultiEpochMultiPool(t *testing.T) {
 	adapter, store, _ := newDBBackedAdapter(t)
 
@@ -113,24 +124,30 @@ func TestAccountRewardHistoryMultiEpochMultiPool(t *testing.T) {
 	poolAID := lcommon.PoolId(lcommon.NewBlake2b224(poolA)).String()
 	poolBID := lcommon.PoolId(lcommon.NewBlake2b224(poolB)).String()
 
+	// Reported epochs are stored+1 (snapshot epoch 1, 2, 3 -> earned epoch
+	// 2, 3, 4).
 	assert.Equal(t, AccountRewardHistoryInfo{
-		Epoch: 1, Amount: "100", PoolID: poolAID, Type: "member",
+		Epoch: 2, Amount: "100", PoolID: poolAID, Type: "member",
 	}, rows[0])
 	assert.Equal(t, AccountRewardHistoryInfo{
-		Epoch: 2, Amount: "200", PoolID: poolBID, Type: "member",
+		Epoch: 3, Amount: "200", PoolID: poolBID, Type: "member",
 	}, rows[1])
-	// Epoch 3 has two rows; pool_key_hash breaks the tie (poolA < poolB).
+	// Stored epoch 3 has two rows; pool_key_hash breaks the tie (poolA <
+	// poolB). Both report earned epoch 4.
 	assert.Equal(t, AccountRewardHistoryInfo{
-		Epoch: 3, Amount: "300", PoolID: poolAID, Type: "leader",
+		Epoch: 4, Amount: "300", PoolID: poolAID, Type: "leader",
 	}, rows[2])
 	assert.Equal(t, AccountRewardHistoryInfo{
-		Epoch: 3, Amount: "50", PoolID: poolBID, Type: "member",
+		Epoch: 4, Amount: "50", PoolID: poolBID, Type: "member",
 	}, rows[3])
 }
 
 // TestAccountRewardHistoryPaginationAndOrder verifies that Count/Page/Order
 // are applied against the full reward history rather than just returning
-// everything, and that "desc" reverses the epoch ordering.
+// everything, and that "desc" reverses the epoch ordering. Stored epochs are
+// 1-5; reported epochs are stored+1 (2-6, see the earned-epoch note on
+// TestAccountRewardHistoryMultiEpochMultiPool), but pagination and ordering
+// are still driven by the stored (snapshot) epoch.
 func TestAccountRewardHistoryPaginationAndOrder(t *testing.T) {
 	adapter, store, _ := newDBBackedAdapter(t)
 
@@ -159,7 +176,8 @@ func TestAccountRewardHistoryPaginationAndOrder(t *testing.T) {
 
 	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
 
-	// Page 2 of 2-per-page, ascending: epochs 3 and 4.
+	// Page 2 of 2-per-page, ascending: stored epochs 3 and 4 -> reported 4
+	// and 5.
 	rows, total, err := adapter.AccountRewardHistory(
 		stakeAddress,
 		PaginationParams{Count: 2, Page: 2, Order: "asc"},
@@ -167,10 +185,11 @@ func TestAccountRewardHistoryPaginationAndOrder(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 5, total)
 	require.Len(t, rows, 2)
-	assert.Equal(t, int32(3), rows[0].Epoch)
-	assert.Equal(t, int32(4), rows[1].Epoch)
+	assert.Equal(t, int32(4), rows[0].Epoch)
+	assert.Equal(t, int32(5), rows[1].Epoch)
 
-	// Descending order, first page: epochs 5 and 4.
+	// Descending order, first page: stored epochs 5 and 4 -> reported 6 and
+	// 5.
 	rows, total, err = adapter.AccountRewardHistory(
 		stakeAddress,
 		PaginationParams{Count: 2, Page: 1, Order: "desc"},
@@ -178,8 +197,8 @@ func TestAccountRewardHistoryPaginationAndOrder(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 5, total)
 	require.Len(t, rows, 2)
-	assert.Equal(t, int32(5), rows[0].Epoch)
-	assert.Equal(t, int32(4), rows[1].Epoch)
+	assert.Equal(t, int32(6), rows[0].Epoch)
+	assert.Equal(t, int32(5), rows[1].Epoch)
 
 	// A page beyond the available rows returns an empty slice but still
 	// reports the true total.
@@ -190,6 +209,71 @@ func TestAccountRewardHistoryPaginationAndOrder(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 5, total)
 	assert.Empty(t, rows)
+}
+
+// TestAccountRewardHistoryExcludesNonSpendableReward pins review finding 1:
+// a reward_account_output row with Spendable = false was never actually
+// credited to the account (applyStakeRewardApplication in
+// ledger/reward_calculation.go skips crediting it and instead accumulates
+// the amount into the epoch's unspendable total), typically because the
+// credential deregistered before the reward's payout boundary
+// (finalizePrecomputedRewardOutputs persists that as a permanent
+// spendable=false row). Reporting it here would overstate both the reward
+// list and the total. This mirrors the maintainer's reproduction: one
+// spendable row (amount 1000000) and one non-spendable row (amount
+// 9999999) for the same credential; only the spendable row and its amount
+// may appear.
+func TestAccountRewardHistoryExcludesNonSpendableReward(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x07}, 28)
+	pool := bytes.Repeat([]byte{0xff}, 28)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch: 10, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "member",
+			Amount: 1_000_000, Spendable: true,
+		},
+		{
+			Epoch: 11, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "member",
+			Amount: 9_999_999, Spendable: false,
+		},
+	}, nil))
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	rows, total, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, 1, total,
+		"the non-spendable row must not be counted in the total",
+	)
+	require.Len(
+		t, rows, 1,
+		"the non-spendable row must be absent from the response",
+	)
+	assert.Equal(t, "1000000", rows[0].Amount)
+
+	var summed uint64
+	for _, row := range rows {
+		amount, err := strconv.ParseUint(row.Amount, 10, 64)
+		require.NoError(t, err)
+		summed += amount
+	}
+	assert.Equal(
+		t, uint64(1_000_000), summed,
+		"summed reward history must equal only what was actually credited",
+	)
 }
 
 // TestAccountRewardHistoryEmptyForRegisteredAccount covers a registered
@@ -257,8 +341,14 @@ func TestAccountRewardHistoryDatabaseError(t *testing.T) {
 }
 
 // TestAccountRewardHistoryTypeMapping verifies the reward_type -> Blockfrost
-// "type" enum mapping, including case-insensitivity and pass-through of a
-// reward type dingo does not yet model.
+// "type" enum handling: case-insensitivity, pass-through of a reward type
+// outside the recognized allow-list (blockfrostRewardTypes), and that
+// exactly the unrecognized value triggers the warn-and-pass-through path —
+// recognized values must not. A plain strings.ToLower would satisfy the
+// Type assertions below on its own, so what actually pins
+// blockfrostRewardTypes as a real allow-list (rather than the no-op mapping
+// review finding 3 identified) is the slog assertions: recognized values
+// produce no warning, and "some_future_type" produces exactly one.
 func TestAccountRewardHistoryTypeMapping(t *testing.T) {
 	adapter, store, _ := newDBBackedAdapter(t)
 
@@ -292,6 +382,14 @@ func TestAccountRewardHistoryTypeMapping(t *testing.T) {
 		},
 	}, nil))
 
+	// Capture slog output for the duration of the call so the warn path can
+	// be asserted on directly, rather than relying on the Type value alone
+	// (which a plain strings.ToLower would also produce).
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
 	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
 	rows, total, err := adapter.AccountRewardHistory(
 		stakeAddress,
@@ -304,5 +402,18 @@ func TestAccountRewardHistoryTypeMapping(t *testing.T) {
 	assert.Equal(t, "leader", rows[0].Type)
 	assert.Equal(t, "member", rows[1].Type)
 	assert.Equal(t, "pool_deposit_refund", rows[2].Type)
+	// Unrecognized value still passes through lowercased rather than being
+	// dropped.
 	assert.Equal(t, "some_future_type", rows[3].Type)
+
+	logOutput := logBuf.String()
+	assert.Equal(
+		t, 1, strings.Count(logOutput, "level=WARN"),
+		"expected exactly one warning (for some_future_type), got log: %s",
+		logOutput,
+	)
+	assert.Contains(t, logOutput, "some_future_type")
+	assert.NotContains(t, logOutput, "reward_type=leader")
+	assert.NotContains(t, logOutput, "reward_type=member")
+	assert.NotContains(t, logOutput, "reward_type=pool_deposit_refund")
 }

--- a/api/blockfrost/adapter_reward_history_test.go
+++ b/api/blockfrost/adapter_reward_history_test.go
@@ -1,0 +1,308 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRewardHistoryStakeAddress builds a valid bech32 stake address for a
+// key-hash staking credential, matching the shape parseStakeAddress expects
+// (empty payment part, non-zero staking key hash).
+func newRewardHistoryStakeAddress(
+	t *testing.T,
+	stakingKeyHash []byte,
+) string {
+	t.Helper()
+	addr, err := stakeAddressFromCredential(
+		lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.CredentialHash(stakingKeyHash),
+		},
+		lcommon.AddressNetworkTestnet,
+	)
+	require.NoError(t, err)
+	return addr
+}
+
+// TestAccountRewardHistoryMultiEpochMultiPool covers an account with reward
+// rows spanning more than one epoch and more than one pool (including a pool
+// owner's leader reward alongside a member reward in the same epoch), and
+// verifies the default (ascending) ordering plus the Blockfrost field
+// mapping, including the "type" enum value.
+func TestAccountRewardHistoryMultiEpochMultiPool(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x01}, 28)
+	poolA := bytes.Repeat([]byte{0xaa}, 28)
+	poolB := bytes.Repeat([]byte{0xbb}, 28)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch:         1,
+			CredentialTag: 0,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolA,
+			RewardType:    "member",
+			Amount:        100,
+			Spendable:     true,
+		},
+		{
+			Epoch:         2,
+			CredentialTag: 0,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolB,
+			RewardType:    "member",
+			Amount:        200,
+			Spendable:     true,
+		},
+		{
+			Epoch:         3,
+			CredentialTag: 0,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolA,
+			RewardType:    "leader",
+			Amount:        300,
+			Spendable:     true,
+		},
+		{
+			Epoch:         3,
+			CredentialTag: 0,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   poolB,
+			RewardType:    "member",
+			Amount:        50,
+			Spendable:     true,
+		},
+	}, nil))
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	rows, total, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 4, total)
+	require.Len(t, rows, 4)
+
+	poolAID := lcommon.PoolId(lcommon.NewBlake2b224(poolA)).String()
+	poolBID := lcommon.PoolId(lcommon.NewBlake2b224(poolB)).String()
+
+	assert.Equal(t, AccountRewardHistoryInfo{
+		Epoch: 1, Amount: "100", PoolID: poolAID, Type: "member",
+	}, rows[0])
+	assert.Equal(t, AccountRewardHistoryInfo{
+		Epoch: 2, Amount: "200", PoolID: poolBID, Type: "member",
+	}, rows[1])
+	// Epoch 3 has two rows; pool_key_hash breaks the tie (poolA < poolB).
+	assert.Equal(t, AccountRewardHistoryInfo{
+		Epoch: 3, Amount: "300", PoolID: poolAID, Type: "leader",
+	}, rows[2])
+	assert.Equal(t, AccountRewardHistoryInfo{
+		Epoch: 3, Amount: "50", PoolID: poolBID, Type: "member",
+	}, rows[3])
+}
+
+// TestAccountRewardHistoryPaginationAndOrder verifies that Count/Page/Order
+// are applied against the full reward history rather than just returning
+// everything, and that "desc" reverses the epoch ordering.
+func TestAccountRewardHistoryPaginationAndOrder(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x02}, 28)
+	pool := bytes.Repeat([]byte{0xcc}, 28)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	outputs := make([]*models.RewardAccountOutput, 0, 5)
+	for epoch := uint64(1); epoch <= 5; epoch++ {
+		outputs = append(outputs, &models.RewardAccountOutput{
+			Epoch:         epoch,
+			CredentialTag: 0,
+			StakingKey:    stakingKey,
+			PoolKeyHash:   pool,
+			RewardType:    "member",
+			Amount:        types.Uint64(epoch * 10),
+			Spendable:     true,
+		})
+	}
+	require.NoError(t, store.SaveRewardAccountOutputs(outputs, nil))
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+
+	// Page 2 of 2-per-page, ascending: epochs 3 and 4.
+	rows, total, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 2, Page: 2, Order: "asc"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	require.Len(t, rows, 2)
+	assert.Equal(t, int32(3), rows[0].Epoch)
+	assert.Equal(t, int32(4), rows[1].Epoch)
+
+	// Descending order, first page: epochs 5 and 4.
+	rows, total, err = adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 2, Page: 1, Order: "desc"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	require.Len(t, rows, 2)
+	assert.Equal(t, int32(5), rows[0].Epoch)
+	assert.Equal(t, int32(4), rows[1].Epoch)
+
+	// A page beyond the available rows returns an empty slice but still
+	// reports the true total.
+	rows, total, err = adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 2, Page: 10, Order: "asc"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	assert.Empty(t, rows)
+}
+
+// TestAccountRewardHistoryEmptyForRegisteredAccount covers a registered
+// account with no reward history: the endpoint must distinguish this from an
+// unknown account by returning an empty slice and zero total, not an error.
+func TestAccountRewardHistoryEmptyForRegisteredAccount(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x03}, 28)
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	rows, total, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, rows)
+}
+
+// TestAccountRewardHistoryUnknownAccount covers a well-formed stake address
+// with no backing account row: the endpoint must surface an error rather
+// than a misleadingly empty history.
+func TestAccountRewardHistoryUnknownAccount(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x04}, 28)
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+
+	_, _, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.Error(t, err)
+}
+
+// TestAccountRewardHistoryDatabaseError verifies that a query failure against
+// the reward_account_output backing store surfaces as an error instead of a
+// silently empty/successful response.
+func TestAccountRewardHistoryDatabaseError(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x05}, 28)
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	require.NoError(
+		t, store.DB().Exec("DROP TABLE reward_account_output").Error,
+	)
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	_, _, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.ErrorContains(t, err, "count account reward history")
+}
+
+// TestAccountRewardHistoryTypeMapping verifies the reward_type -> Blockfrost
+// "type" enum mapping, including case-insensitivity and pass-through of a
+// reward type dingo does not yet model.
+func TestAccountRewardHistoryTypeMapping(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x06}, 28)
+	pool := bytes.Repeat([]byte{0xee}, 28)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch: 1, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "LEADER", Amount: 1, Spendable: true,
+		},
+		{
+			Epoch: 2, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "Member", Amount: 2, Spendable: true,
+		},
+		{
+			Epoch: 3, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "pool_deposit_refund", Amount: 3,
+			Spendable: true,
+		},
+		{
+			Epoch: 4, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "some_future_type", Amount: 4,
+			Spendable: true,
+		},
+	}, nil))
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	rows, total, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 4, total)
+	require.Len(t, rows, 4)
+
+	assert.Equal(t, "leader", rows[0].Type)
+	assert.Equal(t, "member", rows[1].Type)
+	assert.Equal(t, "pool_deposit_refund", rows[2].Type)
+	assert.Equal(t, "some_future_type", rows[3].Type)
+}

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -757,4 +757,7 @@ type AccountRewardHistoryInfo struct {
 	Epoch  int32
 	Amount string
 	PoolID string
+	// Type is the Blockfrost reward-type enum spelling (leader, member,
+	// pool_deposit_refund) mapped from models.RewardAccountOutput.RewardType.
+	Type string
 }

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -581,4 +581,7 @@ type AccountRewardHistoryResponse struct {
 	Epoch  int32  `json:"epoch"`
 	Amount string `json:"amount"`
 	PoolID string `json:"pool_id"`
+	// Type is one of leader, member, or pool_deposit_refund, per the
+	// Blockfrost account_reward_content schema.
+	Type string `json:"type"`
 }

--- a/database/models/reward_state.go
+++ b/database/models/reward_state.go
@@ -150,13 +150,26 @@ func (RewardPoolOutput) TableName() string {
 }
 
 // RewardAccountOutput captures per-account reward calculation output.
+//
+// idx_reward_account_output_credential leads with (credential_tag,
+// staking_key) so GetRewardAccountOutputsByCredential (the Blockfrost account
+// reward-history endpoint, dingo #1875) is an index range scan over one
+// credential's rows rather than a full-table scan: the epoch/pool_key_hash/
+// reward_type tail matches that query's ORDER BY, so an ascending request is
+// served directly from the index and a descending one only sorts the
+// (typically tiny, single-credential) matched rows rather than the whole
+// table. This matters specifically because dingo #1875 also makes API storage
+// mode retain this table without bound (see the retention note in
+// DATABASE.md), so the existing idx_reward_account_output_epoch_cred_pool_type
+// index — which leads with epoch, not credential — cannot serve this query
+// without scanning every retained row.
 type RewardAccountOutput struct {
-	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null"`
-	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null"`
-	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null"`
+	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential,priority:2"`
+	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential,priority:4"`
+	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential,priority:5"`
 	ID            uint         `gorm:"primarykey"`
-	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null"`
-	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0"`
+	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential,priority:3"`
+	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential,priority:1"`
 	Amount        types.Uint64 `gorm:"not null"`
 	Spendable     bool         `gorm:"not null"`
 	CapturedSlot  uint64       `gorm:"index;not null"`

--- a/database/models/reward_state.go
+++ b/database/models/reward_state.go
@@ -151,33 +151,114 @@ func (RewardPoolOutput) TableName() string {
 
 // RewardAccountOutput captures per-account reward calculation output.
 //
-// idx_reward_account_output_credential leads with (credential_tag,
-// staking_key) so GetRewardAccountOutputsByCredential (the Blockfrost account
-// reward-history endpoint, dingo #1875) is an index range scan over one
-// credential's rows rather than a full-table scan: the epoch/pool_key_hash/
-// reward_type tail matches that query's ORDER BY, so an ascending request is
-// served directly from the index and a descending one only sorts the
-// (typically tiny, single-credential) matched rows rather than the whole
-// table. This matters specifically because dingo #1875 also makes API storage
-// mode retain this table without bound (see the retention note in
-// DATABASE.md), so the existing idx_reward_account_output_epoch_cred_pool_type
-// index — which leads with epoch, not credential — cannot serve this query
-// without scanning every retained row.
+// idx_reward_account_output_credential_spendable leads with (credential_tag,
+// staking_key, spendable) so GetRewardAccountOutputsByCredential (the
+// Blockfrost account reward-history endpoint, dingo #1875) is a pure index
+// range scan over one credential's spendable rows rather than an index seek
+// followed by a per-row filter: the epoch/pool_key_hash/reward_type tail
+// matches that query's ORDER BY, so an ascending request is served directly
+// from the index and a descending one only sorts the (typically tiny,
+// single-credential) matched rows rather than the whole table. This matters
+// specifically because dingo #1875 also makes API storage mode retain this
+// table without bound (see the retention note in DATABASE.md), so the
+// existing idx_reward_account_output_epoch_cred_pool_type index — which
+// leads with epoch, not credential — cannot serve this query without
+// scanning every retained row.
+//
+// spendable joined the index (superseding the original
+// idx_reward_account_output_credential, which had no spendable column) once
+// GetAccountOutputsByCredential started filtering on it: a credential
+// deregistered before its reward's payout boundary keeps a permanent
+// spendable=false row (see applyStakeRewardApplication /
+// finalizePrecomputedRewardOutputs in ledger/reward_calculation.go), and
+// that reward was never credited, so the reward-history endpoint must not
+// report it. Without spendable in the index's equality prefix, the filter
+// degrades the seek into a seek over every one of the credential's rows plus
+// a per-row check. MigrateRewardAccountOutputCredentialIndex drops the
+// superseded index once this one exists, so upgraded databases end up with
+// exactly one credential-leading index rather than both.
+//
+// NOTE(dingo #1875 follow-up): a CIP-0163-guarded reward
+// (rewardOutputGuarded in ledger/reward_calculation.go) is also skipped at
+// crediting time, but that guard is never written back to Spendable, so a
+// guarded row keeps spendable=true and this filter does not catch it. That
+// only matters once CIP-0163 (delegator inactivity) activates; see the
+// tracking note in DATABASE.md. Not fixed here — deliberately out of scope
+// for this change.
 type RewardAccountOutput struct {
-	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential,priority:2"`
-	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential,priority:4"`
-	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential,priority:5"`
+	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:2"`
+	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:5"`
+	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential_spendable,priority:6"`
 	ID            uint         `gorm:"primarykey"`
-	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential,priority:3"`
-	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential,priority:1"`
+	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential_spendable,priority:4"`
+	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential_spendable,priority:1"`
 	Amount        types.Uint64 `gorm:"not null"`
-	Spendable     bool         `gorm:"not null"`
+	Spendable     bool         `gorm:"not null;index:idx_reward_account_output_credential_spendable,priority:3"`
 	CapturedSlot  uint64       `gorm:"index;not null"`
 	BoundarySlot  uint64       `gorm:"index;not null"`
 }
 
 func (RewardAccountOutput) TableName() string {
 	return "reward_account_output"
+}
+
+// MigrateRewardAccountOutputCredentialIndex drops the superseded
+// idx_reward_account_output_credential index (credential_tag, staking_key,
+// epoch, pool_key_hash, reward_type) once its replacement,
+// idx_reward_account_output_credential_spendable, exists. The replacement
+// adds spendable to the equality prefix so GetAccountOutputsByCredential's
+// new spendable=true filter (dingo #1875 follow-up) stays a pure index range
+// scan instead of degrading to a seek over every one of the credential's
+// rows plus a per-row filter.
+//
+// Unlike MigrateRewardLiveStakePoolIndex and the other legacy-index
+// migrations in this file, this one runs AFTER AutoMigrate rather than
+// before. Those migrations drop a unique index that could otherwise reject
+// valid rows or block a column-type change, so they must run first.
+// idx_reward_account_output_credential is a plain non-unique secondary
+// index: keeping it around a little longer is only wasted space, never a
+// correctness problem, so there is no reason to risk a window with no
+// credential-leading index at all. Calling this after AutoMigrate
+// guarantees the replacement already exists before the old index is
+// dropped.
+func MigrateRewardAccountOutputCredentialIndex(
+	db *gorm.DB,
+	logger *slog.Logger,
+) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&RewardAccountOutput{}) {
+		return nil
+	}
+	if !db.Migrator().HasIndex(
+		&RewardAccountOutput{},
+		"idx_reward_account_output_credential",
+	) {
+		return nil
+	}
+	if !db.Migrator().HasIndex(
+		&RewardAccountOutput{},
+		"idx_reward_account_output_credential_spendable",
+	) {
+		// The replacement has not been created yet (should not happen when
+		// called after AutoMigrate); leave the old index in place rather
+		// than dropping the only credential-leading index available.
+		return nil
+	}
+	logger.Info(
+		"dropping superseded reward_account_output credential index",
+	)
+	if err := db.Migrator().DropIndex(
+		&RewardAccountOutput{},
+		"idx_reward_account_output_credential",
+	); err != nil {
+		return fmt.Errorf(
+			"drop reward_account_output credential index: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // MigrateRewardLiveStakePoolIndex drops the legacy pool/total_stake index.

--- a/database/models/reward_state_test.go
+++ b/database/models/reward_state_test.go
@@ -52,6 +52,29 @@ func (legacyRewardPoolInput) TableName() string {
 	return "reward_pool_input"
 }
 
+// legacyRewardAccountOutput is the reward_account_output schema from before
+// dingo #1875 added idx_reward_account_output_credential (credential_tag,
+// staking_key, epoch, pool_key_hash, reward_type). Every other tag is
+// identical to the current RewardAccountOutput, so migrating from this shape
+// to the current one exercises exactly what an operator upgrading an
+// existing database sees.
+type legacyRewardAccountOutput struct {
+	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null"`
+	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null"`
+	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null"`
+	ID            uint         `gorm:"primarykey"`
+	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null"`
+	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0"`
+	Amount        types.Uint64 `gorm:"not null"`
+	Spendable     bool         `gorm:"not null"`
+	CapturedSlot  uint64       `gorm:"index;not null"`
+	BoundarySlot  uint64       `gorm:"index;not null"`
+}
+
+func (legacyRewardAccountOutput) TableName() string {
+	return "reward_account_output"
+}
+
 func TestRewardPoolInputMigrationDefaultsOwnerStake(t *testing.T) {
 	db := openMemoryDB(t)
 	require.NoError(t, db.AutoMigrate(&legacyRewardPoolInput{}))
@@ -189,4 +212,69 @@ func TestDedupeRewardLiveStake(t *testing.T) {
 
 	// Idempotent: a second run with no duplicates is a no-op.
 	require.NoError(t, DedupeRewardLiveStake(db, nil))
+}
+
+// TestMigrateRewardAccountOutputCredentialIndex pins that AutoMigrate adds
+// idx_reward_account_output_credential to a database that predates dingo
+// #1875 (an in-place upgrade), not only to a freshly created one, and that
+// pre-existing rows survive untouched. Unlike idx_reward_live_stake_pool_order
+// (MigrateRewardLiveStakePoolIndex) this index needs no pre-migration repair
+// step: it is a new, non-unique secondary index over columns whose types are
+// unchanged, so AutoMigrate creates it directly with CREATE INDEX rather than
+// rebuilding the table.
+func TestMigrateRewardAccountOutputCredentialIndex(t *testing.T) {
+	db := openMemoryDB(t)
+	require.NoError(t, db.AutoMigrate(&legacyRewardAccountOutput{}))
+	require.False(
+		t,
+		db.Migrator().HasIndex(
+			&legacyRewardAccountOutput{},
+			"idx_reward_account_output_credential",
+		),
+	)
+
+	stakingKey := make([]byte, 28)
+	stakingKey[0] = 0x41
+	poolKeyHash := make([]byte, 28)
+	poolKeyHash[0] = 0x42
+	require.NoError(t, db.Create(&legacyRewardAccountOutput{
+		Epoch:         7,
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		PoolKeyHash:   poolKeyHash,
+		RewardType:    "member",
+		Amount:        123,
+		Spendable:     true,
+		CapturedSlot:  10,
+		BoundarySlot:  11,
+	}).Error)
+
+	require.NoError(t, db.AutoMigrate(&RewardAccountOutput{}))
+
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential",
+		),
+	)
+	// The pre-existing unique index survives alongside the new one.
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_epoch_cred_pool_type",
+		),
+	)
+
+	var migrated RewardAccountOutput
+	require.NoError(t, db.First(&migrated).Error)
+	require.Equal(t, uint64(7), migrated.Epoch)
+	require.Equal(t, stakingKey, migrated.StakingKey)
+	require.Equal(t, poolKeyHash, migrated.PoolKeyHash)
+	require.Equal(t, "member", migrated.RewardType)
+	require.Equal(t, uint64(123), uint64(migrated.Amount))
+
+	// Idempotent: migrating an already-migrated database is a no-op.
+	require.NoError(t, db.AutoMigrate(&RewardAccountOutput{}))
 }

--- a/database/models/reward_state_test.go
+++ b/database/models/reward_state_test.go
@@ -53,11 +53,13 @@ func (legacyRewardPoolInput) TableName() string {
 }
 
 // legacyRewardAccountOutput is the reward_account_output schema from before
-// dingo #1875 added idx_reward_account_output_credential (credential_tag,
-// staking_key, epoch, pool_key_hash, reward_type). Every other tag is
-// identical to the current RewardAccountOutput, so migrating from this shape
-// to the current one exercises exactly what an operator upgrading an
-// existing database sees.
+// dingo #1875 added any credential-leading index at all (it predates both
+// idx_reward_account_output_credential and its later replacement,
+// idx_reward_account_output_credential_spendable; see
+// legacyRewardAccountOutputCredentialNoSpendable below for the intermediate
+// shape). Every other tag is identical to the current RewardAccountOutput, so
+// migrating from this shape to the current one exercises exactly what an
+// operator upgrading a database that predates dingo #1875 entirely sees.
 type legacyRewardAccountOutput struct {
 	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null"`
 	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null"`
@@ -215,13 +217,17 @@ func TestDedupeRewardLiveStake(t *testing.T) {
 }
 
 // TestMigrateRewardAccountOutputCredentialIndex pins that AutoMigrate adds
-// idx_reward_account_output_credential to a database that predates dingo
-// #1875 (an in-place upgrade), not only to a freshly created one, and that
-// pre-existing rows survive untouched. Unlike idx_reward_live_stake_pool_order
-// (MigrateRewardLiveStakePoolIndex) this index needs no pre-migration repair
-// step: it is a new, non-unique secondary index over columns whose types are
-// unchanged, so AutoMigrate creates it directly with CREATE INDEX rather than
-// rebuilding the table.
+// idx_reward_account_output_credential_spendable to a database that predates
+// dingo #1875 entirely (an in-place upgrade), not only to a freshly created
+// one, and that pre-existing rows survive untouched. Unlike
+// idx_reward_live_stake_pool_order (MigrateRewardLiveStakePoolIndex) this
+// index needs no pre-migration repair step to be created: it is a new,
+// non-unique secondary index over columns whose types are unchanged, so
+// AutoMigrate creates it directly with CREATE INDEX rather than rebuilding
+// the table. See TestMigrateRewardAccountOutputCredentialSpendableIndex for
+// the narrower upgrade from the index shape dingo #1875 originally shipped
+// (credential-leading but without spendable), which does need the
+// post-AutoMigrate drop step.
 func TestMigrateRewardAccountOutputCredentialIndex(t *testing.T) {
 	db := openMemoryDB(t)
 	require.NoError(t, db.AutoMigrate(&legacyRewardAccountOutput{}))
@@ -229,7 +235,7 @@ func TestMigrateRewardAccountOutputCredentialIndex(t *testing.T) {
 		t,
 		db.Migrator().HasIndex(
 			&legacyRewardAccountOutput{},
-			"idx_reward_account_output_credential",
+			"idx_reward_account_output_credential_spendable",
 		),
 	)
 
@@ -255,7 +261,7 @@ func TestMigrateRewardAccountOutputCredentialIndex(t *testing.T) {
 		t,
 		db.Migrator().HasIndex(
 			&RewardAccountOutput{},
-			"idx_reward_account_output_credential",
+			"idx_reward_account_output_credential_spendable",
 		),
 	)
 	// The pre-existing unique index survives alongside the new one.
@@ -277,4 +283,134 @@ func TestMigrateRewardAccountOutputCredentialIndex(t *testing.T) {
 
 	// Idempotent: migrating an already-migrated database is a no-op.
 	require.NoError(t, db.AutoMigrate(&RewardAccountOutput{}))
+}
+
+// legacyRewardAccountOutputCredentialNoSpendable is the reward_account_output
+// schema as dingo #1875 originally shipped it: idx_reward_account_output_credential
+// leads with (credential_tag, staking_key) but has no spendable column, so a
+// query filtering on spendable degrades that index's seek into a seek over
+// every one of the credential's rows plus a per-row filter (the "Finding 1"
+// fix). This is the shape TestMigrateRewardAccountOutputCredentialSpendableIndex
+// upgrades from, exercising the exact database an operator who already
+// deployed dingo #1875 has on disk.
+type legacyRewardAccountOutputCredentialNoSpendable struct {
+	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential,priority:2"`
+	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential,priority:4"`
+	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential,priority:5"`
+	ID            uint         `gorm:"primarykey"`
+	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential,priority:3"`
+	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential,priority:1"`
+	Amount        types.Uint64 `gorm:"not null"`
+	Spendable     bool         `gorm:"not null"`
+	CapturedSlot  uint64       `gorm:"index;not null"`
+	BoundarySlot  uint64       `gorm:"index;not null"`
+}
+
+func (legacyRewardAccountOutputCredentialNoSpendable) TableName() string {
+	return "reward_account_output"
+}
+
+// TestMigrateRewardAccountOutputCredentialSpendableIndex pins the upgrade
+// path for the Finding 1 fix: a database already running the
+// credential-leading index dingo #1875 originally shipped (no spendable
+// column) ends up with exactly the new idx_reward_account_output_credential_spendable
+// index and none of the superseded idx_reward_account_output_credential,
+// with every pre-existing row (both spendable and non-spendable) intact.
+//
+// This is the "prove the upgrade path works on a populated database" case:
+// AutoMigrate alone only adds the new index (GORM does not alter or drop an
+// existing index it no longer sees declared), so without
+// MigrateRewardAccountOutputCredentialIndex a migrated database would carry
+// both indexes forever. The migration runs after AutoMigrate specifically so
+// the replacement always exists before the old one is removed.
+func TestMigrateRewardAccountOutputCredentialSpendableIndex(t *testing.T) {
+	db := openMemoryDB(t)
+	require.NoError(
+		t,
+		db.AutoMigrate(&legacyRewardAccountOutputCredentialNoSpendable{}),
+	)
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&legacyRewardAccountOutputCredentialNoSpendable{},
+			"idx_reward_account_output_credential",
+		),
+	)
+	require.False(
+		t,
+		db.Migrator().HasIndex(
+			&legacyRewardAccountOutputCredentialNoSpendable{},
+			"idx_reward_account_output_credential_spendable",
+		),
+	)
+
+	spendableKey := make([]byte, 28)
+	spendableKey[0] = 0x51
+	unspendableKey := make([]byte, 28)
+	unspendableKey[0] = 0x52
+	poolKeyHash := make([]byte, 28)
+	poolKeyHash[0] = 0x53
+	require.NoError(t, db.Create(&legacyRewardAccountOutputCredentialNoSpendable{
+		Epoch: 9, CredentialTag: 0, StakingKey: spendableKey,
+		PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 111,
+		Spendable: true, CapturedSlot: 20, BoundarySlot: 21,
+	}).Error)
+	require.NoError(t, db.Create(&legacyRewardAccountOutputCredentialNoSpendable{
+		Epoch: 9, CredentialTag: 0, StakingKey: unspendableKey,
+		PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 222,
+		Spendable: false, CapturedSlot: 20, BoundarySlot: 21,
+	}).Error)
+
+	// AutoMigrate on its own only adds the replacement index; it does not
+	// drop the superseded one, since GORM never alters/removes an existing
+	// index that the current struct simply no longer declares.
+	require.NoError(t, db.AutoMigrate(&RewardAccountOutput{}))
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential_spendable",
+		),
+	)
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential",
+		),
+		"superseded index must still be present before the migration helper runs",
+	)
+
+	require.NoError(t, MigrateRewardAccountOutputCredentialIndex(db, nil))
+
+	require.False(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential",
+		),
+		"superseded index must be dropped once the replacement exists",
+	)
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential_spendable",
+		),
+	)
+
+	// Pre-existing rows of both spendable states survive the migration.
+	var rows []RewardAccountOutput
+	require.NoError(t, db.Order("staking_key ASC").Find(&rows).Error)
+	require.Len(t, rows, 2)
+	require.Equal(t, spendableKey, rows[0].StakingKey)
+	require.True(t, rows[0].Spendable)
+	require.Equal(t, uint64(111), uint64(rows[0].Amount))
+	require.Equal(t, unspendableKey, rows[1].StakingKey)
+	require.False(t, rows[1].Spendable)
+	require.Equal(t, uint64(222), uint64(rows[1].Amount))
+
+	// Idempotent: running the migration again against an already-migrated
+	// database (superseded index already gone) is a no-op.
+	require.NoError(t, MigrateRewardAccountOutputCredentialIndex(db, nil))
 }

--- a/database/plugin/metadata/internal/rewardstate/state.go
+++ b/database/plugin/metadata/internal/rewardstate/state.go
@@ -17,6 +17,7 @@ package rewardstate
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -593,6 +594,76 @@ func GetAccountOutputs(db *gorm.DB, epoch uint64) ([]*models.RewardAccountOutput
 	return outputs, result.Error
 }
 
+// GetAccountOutputsByCredential retrieves reward account output rows for a
+// stake credential across every epoch that has not yet been pruned,
+// paginated and ordered by epoch. Ties within an epoch (an account can have
+// more than one row per epoch: e.g. a pool owner's leader and member reward,
+// or rewards from two different pools around a delegation change) are broken
+// by pool_key_hash then reward_type so results are stable across pages. Used
+// by the Blockfrost account reward-history endpoint
+// (GET /accounts/{stake_address}/rewards, dingo #1875).
+func GetAccountOutputsByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+) ([]*models.RewardAccountOutput, error) {
+	ret := make([]*models.RewardAccountOutput, 0)
+	if len(stakingKey) == 0 {
+		return ret, nil
+	}
+	query := db.Where(
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakingKey,
+	)
+	if strings.EqualFold(order, "desc") {
+		query = query.Order("epoch DESC, pool_key_hash ASC, reward_type ASC")
+	} else {
+		query = query.Order("epoch ASC, pool_key_hash ASC, reward_type ASC")
+	}
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if offset > 0 {
+		query = query.Offset(offset)
+	}
+	if err := query.Find(&ret).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return ret, nil
+}
+
+// CountAccountOutputsByCredential returns the total count of reward account
+// output rows for a stake credential across every epoch that has not yet
+// been pruned.
+func CountAccountOutputsByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	var count int64
+	if err := db.Model(&models.RewardAccountOutput{}).Where(
+		"credential_tag = ? AND staking_key = ?",
+		credentialTag,
+		stakingKey,
+	).Count(&count).Error; err != nil {
+		return 0, fmt.Errorf(
+			"count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return int(count), nil
+}
+
 // DeleteStateAfterSlot deletes reward-state rows captured from rolled-back
 // blocks. When txn is non-nil, db is used as-is; otherwise the deletes are
 // wrapped in their own transaction.
@@ -646,23 +717,40 @@ func DeleteStateAfterSlot(
 // snapshot window that scale with delegator count. When txn is non-nil, db is
 // used as-is; otherwise the deletes are wrapped in their own transaction.
 //
-// Only reward_stake_input and reward_account_output are pruned. Everything else
-// the reward path writes — reward_ada_pots and reward_snapshot at one row per
-// epoch, reward_pool_input and reward_pool_output at roughly one row per pool per
-// epoch — is retained for the life of the database, because that is the full
-// reward record a historical closed-epoch comparison needs: the pots the epoch
-// was paid from, the reward-side stake totals (which differ from epoch_summary's
+// This is the CORE storage-mode pruning path and unconditionally deletes both
+// reward_stake_input and reward_account_output, matching dingo's original
+// pre-#1875 pruning behavior exactly. Everything else the reward path writes —
+// reward_ada_pots and reward_snapshot at one row per epoch, reward_pool_input
+// and reward_pool_output at roughly one row per pool per epoch — is retained
+// for the life of the database, because that is the full reward record a
+// historical closed-epoch comparison needs: the pots the epoch was paid from,
+// the reward-side stake totals (which differ from epoch_summary's
 // leader-election totals), each pool's delegated/owner stake, pledge, cost,
 // margin, reward account and block counts, and each pool's resulting apparent
 // performance, leader reward and member reward total. See dingo #2987.
 //
-// The per-credential rows are the only ones that scale with delegator count
-// (~5k/epoch on preview, ~1.3M/epoch on mainnet), so they alone cannot be kept.
+// The per-credential rows (reward_stake_input and reward_account_output) are
+// the ones that scale with delegator count (~5k/epoch on preview, ~1.3M/epoch
+// on mainnet), which is why core mode cannot keep them.
 //
 // Retaining the rest while pruning those cannot produce a wrong reward
 // calculation: applyStakeRewards detects a retained snapshot whose stake inputs
 // have aged out and skips the epoch, and the precompute-reuse path rejects the
 // same state through validateRewardCalculatorInputs and recalculates.
+//
+// API storage mode does NOT call this function. It calls
+// DeleteStakeInputBeforeEpoch instead, which prunes only reward_stake_input and
+// leaves reward_account_output untouched. reward_account_output is
+// models.RewardAccountOutput, the only per-account, per-epoch reward record
+// dingo persists, and is the backing store for the Blockfrost account
+// reward-history endpoint (GET /accounts/{stake_address}/rewards, dingo #1875):
+// pruning it to a rolling window would make that endpoint silently go blank for
+// any epoch older than the window, the same kind of misleading "no data" #2987
+// already identified for epoch_summary. reward_account_output scales with
+// delegator count the same way reward_stake_input does, so retaining it
+// unbounded is a real, ongoing storage cost — one API storage mode operators
+// have already opted into in exchange for full API-queryable history, and one
+// core storage mode (which does not serve this API) has no reason to pay.
 func DeleteStateBeforeEpoch(
 	db *gorm.DB,
 	epoch uint64,
@@ -676,6 +764,34 @@ func DeleteStateBeforeEpoch(
 			if err := tx.Where("epoch < ?", epoch).Delete(model).Error; err != nil {
 				return fmt.Errorf("delete reward state before epoch: %w", err)
 			}
+		}
+		return nil
+	}
+
+	if txn != nil {
+		return deleteRows(db)
+	}
+	return db.Transaction(deleteRows)
+}
+
+// DeleteStakeInputBeforeEpoch deletes only reward_stake_input rows older than
+// the retained snapshot window, leaving reward_account_output intact. This is
+// the API storage-mode counterpart to DeleteStateBeforeEpoch: see that
+// function's doc comment for the full retention rationale (dingo #1875,
+// #2987). When txn is non-nil, db is used as-is; otherwise the delete is
+// wrapped in its own transaction.
+func DeleteStakeInputBeforeEpoch(
+	db *gorm.DB,
+	epoch uint64,
+	txn types.Txn,
+) error {
+	deleteRows := func(tx *gorm.DB) error {
+		if err := tx.Where("epoch < ?", epoch).
+			Delete(&models.RewardStakeInput{}).Error; err != nil {
+			return fmt.Errorf(
+				"delete reward stake input before epoch: %w",
+				err,
+			)
 		}
 		return nil
 	}

--- a/database/plugin/metadata/internal/rewardstate/state.go
+++ b/database/plugin/metadata/internal/rewardstate/state.go
@@ -602,6 +602,28 @@ func GetAccountOutputs(db *gorm.DB, epoch uint64) ([]*models.RewardAccountOutput
 // by pool_key_hash then reward_type so results are stable across pages. Used
 // by the Blockfrost account reward-history endpoint
 // (GET /accounts/{stake_address}/rewards, dingo #1875).
+//
+// Filters to spendable = true. applyStakeRewardApplication
+// (ledger/reward_calculation.go) never credits a reward whose row has
+// Spendable = false — the amount is added to the epoch's unspendable total
+// instead — so a non-spendable row here was never actually paid to the
+// account. Reporting it as reward history would overstate what the account
+// received (and, added into the endpoint's total, overstate the count of
+// rewards too). finalizePrecomputedRewardOutputs persists Spendable = false
+// permanently for a credential that deregistered before its reward's payout
+// boundary, so this is not a transient state.
+//
+// idx_reward_account_output_credential_spendable puts spendable in the
+// index's equality prefix alongside credential_tag/staking_key specifically
+// so this filter stays a pure index range scan.
+//
+// NOTE(dingo #1875 follow-up, not fixed here): a CIP-0163-guarded reward
+// (rewardOutputGuarded, ledger/reward_calculation.go) is also skipped at
+// crediting time without ever being credited, but that guard is not written
+// back to Spendable, so a guarded row keeps spendable = true and this filter
+// does not catch it. That only bites once CIP-0163 (delegator inactivity)
+// activates; see DATABASE.md and the RewardAccountOutput doc comment for the
+// same note. Tracked as a follow-up, not addressed in this change.
 func GetAccountOutputsByCredential(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -615,9 +637,10 @@ func GetAccountOutputsByCredential(
 		return ret, nil
 	}
 	query := db.Where(
-		"credential_tag = ? AND staking_key = ?",
+		"credential_tag = ? AND staking_key = ? AND spendable = ?",
 		credentialTag,
 		stakingKey,
+		true,
 	)
 	if strings.EqualFold(order, "desc") {
 		query = query.Order("epoch DESC, pool_key_hash ASC, reward_type ASC")
@@ -641,7 +664,10 @@ func GetAccountOutputsByCredential(
 
 // CountAccountOutputsByCredential returns the total count of reward account
 // output rows for a stake credential across every epoch that has not yet
-// been pruned.
+// been pruned. Filters to spendable = true for the same reason
+// GetAccountOutputsByCredential does: a non-spendable row was never credited,
+// so it must not be counted as reward history either, or pagination
+// advertises pages of rewards that were never paid.
 func CountAccountOutputsByCredential(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -652,9 +678,10 @@ func CountAccountOutputsByCredential(
 	}
 	var count int64
 	if err := db.Model(&models.RewardAccountOutput{}).Where(
-		"credential_tag = ? AND staking_key = ?",
+		"credential_tag = ? AND staking_key = ? AND spendable = ?",
 		credentialTag,
 		stakingKey,
+		true,
 	).Count(&count).Error; err != nil {
 		return 0, fmt.Errorf(
 			"count reward account outputs by credential: %w",

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -486,6 +486,15 @@ func (d *MetadataStoreMysql) Start() error {
 			return err
 		}
 	}
+	// Drop the superseded reward_account_output credential index now that
+	// AutoMigrate above has created its spendable-aware replacement.
+	if err := models.MigrateRewardAccountOutputCredentialIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"reward account output credential index migration failed: %w", err,
+		)
+	}
 	if backfillAccountCreatedSlot {
 		if err := models.BackfillAccountCreatedSlot(d.db, d.logger); err != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/mysql/reward_state.go
+++ b/database/plugin/metadata/mysql/reward_state.go
@@ -268,6 +268,68 @@ func (d *MetadataStoreMysql) GetRewardAccountOutputs(epoch uint64, txn types.Txn
 	return rewardstate.GetAccountOutputs(db, epoch)
 }
 
+// GetRewardAccountOutputsByCredential retrieves reward account output rows
+// for a stake credential tag/hash pair, paginated and ordered by epoch.
+func (d *MetadataStoreMysql) GetRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]*models.RewardAccountOutput, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve read DB for reward account outputs by credential: %w",
+			err,
+		)
+	}
+	rows, err := rewardstate.GetAccountOutputsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// CountRewardAccountOutputsByCredential retrieves the total count of reward
+// account output rows for a stake credential tag/hash pair.
+func (d *MetadataStoreMysql) CountRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	count, err := rewardstate.CountAccountOutputsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 // DeleteRewardStateAfterSlot deletes reward-state rows captured from
 // rolled-back blocks.
 func (d *MetadataStoreMysql) DeleteRewardStateAfterSlot(
@@ -292,4 +354,21 @@ func (d *MetadataStoreMysql) DeleteRewardStateBeforeEpoch(
 		return fmt.Errorf("delete reward state before epoch: resolve db: %w", err)
 	}
 	return rewardstate.DeleteStateBeforeEpoch(db, epoch, txn)
+}
+
+// DeleteRewardStakeInputBeforeEpoch deletes only reward_stake_input rows
+// older than the retained snapshot window, leaving reward_account_output
+// intact. Used in API storage mode.
+func (d *MetadataStoreMysql) DeleteRewardStakeInputBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"delete reward stake input before epoch: resolve db: %w",
+			err,
+		)
+	}
+	return rewardstate.DeleteStakeInputBeforeEpoch(db, epoch, txn)
 }

--- a/database/plugin/metadata/mysql/reward_state_credential_test.go
+++ b/database/plugin/metadata/mysql/reward_state_credential_test.go
@@ -30,7 +30,7 @@ import (
 // and ordering.
 func TestGetRewardAccountOutputsByCredentialMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	stakingKey := testHash28("reward-history-cred")
@@ -64,7 +64,7 @@ func TestGetRewardAccountOutputsByCredentialMysql(t *testing.T) {
 // reward_account_output is left untouched.
 func TestDeleteRewardStakeInputBeforeEpochMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	poolKeyHash := testHash28("reward-history-retention-pool")

--- a/database/plugin/metadata/mysql/reward_state_credential_test.go
+++ b/database/plugin/metadata/mysql/reward_state_credential_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// TestGetRewardAccountOutputsByCredentialMysql exercises the
+// credential-filtered reward-history query (backing the Blockfrost account
+// reward-history endpoint, dingo #1875) against mysql, covering pagination
+// and ordering.
+func TestGetRewardAccountOutputsByCredentialMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	stakingKey := testHash28("reward-history-cred")
+	poolA := testHash28("reward-history-pool-a")
+	poolB := testHash28("reward-history-pool-b")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 1, 1, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, uint64(2), rows[0].Epoch)
+}
+
+// TestDeleteRewardStakeInputBeforeEpochMysql verifies the API storage-mode
+// retention path on mysql: reward_stake_input is pruned while
+// reward_account_output is left untouched.
+func TestDeleteRewardStakeInputBeforeEpochMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	poolKeyHash := testHash28("reward-history-retention-pool")
+	stakingKey := testHash28("reward-history-retention-cred")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardStakeInput{}).Error
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardStakeInputs([]*models.RewardStakeInput{
+		{Epoch: 1, PoolKeyHash: poolKeyHash, StakingKey: stakingKey, Stake: 1, Registered: true},
+		{Epoch: 2, PoolKeyHash: poolKeyHash, StakingKey: stakingKey, Stake: 1, Registered: true},
+	}, nil))
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 1},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 2},
+	}, nil))
+
+	require.NoError(t, store.DeleteRewardStakeInputBeforeEpoch(2, nil))
+
+	stakeInputs1, err := store.GetRewardStakeInputs(1, nil)
+	require.NoError(t, err)
+	for _, row := range stakeInputs1 {
+		require.NotEqual(t, stakingKey, row.StakingKey, "epoch 1 reward_stake_input must be pruned")
+	}
+
+	accountOutputs1, err := store.GetRewardAccountOutputs(1, nil)
+	require.NoError(t, err)
+	found := false
+	for _, row := range accountOutputs1 {
+		if string(row.StakingKey) == string(stakingKey) {
+			found = true
+		}
+	}
+	require.True(t, found, "reward_account_output for epoch 1 must survive")
+}

--- a/database/plugin/metadata/mysql/reward_state_credential_test.go
+++ b/database/plugin/metadata/mysql/reward_state_credential_test.go
@@ -43,8 +43,8 @@ func TestGetRewardAccountOutputsByCredentialMysql(t *testing.T) {
 	})
 
 	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
-		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100},
-		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200},
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100, Spendable: true},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200, Spendable: true},
 	}, nil))
 
 	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
@@ -57,6 +57,41 @@ func TestGetRewardAccountOutputsByCredentialMysql(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, uint64(2), rows[0].Epoch)
+}
+
+// TestGetRewardAccountOutputsByCredentialExcludesNonSpendableMysql pins
+// Finding 1 against mysql: a row whose reward was never actually credited
+// (Spendable = false, e.g. a credential that deregistered before its
+// reward's payout boundary) must be absent from both the returned rows and
+// the count.
+func TestGetRewardAccountOutputsByCredentialExcludesNonSpendableMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	t.Cleanup(func() { _ = store.Close() })
+	db := store.DB()
+
+	stakingKey := testHash28("reward-history-nonspendable-cred")
+	pool := testHash28("reward-history-nonspendable-pool")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 10, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 1_000_000, Spendable: true},
+		{Epoch: 11, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 9_999_999, Spendable: false},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "the non-spendable row must not be counted")
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the non-spendable row must be absent from the results")
+	require.Equal(t, uint64(10), rows[0].Epoch)
 }
 
 // TestDeleteRewardStakeInputBeforeEpochMysql verifies the API storage-mode

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -395,6 +395,15 @@ func (d *MetadataStorePostgres) Start() error {
 			return err
 		}
 	}
+	// Drop the superseded reward_account_output credential index now that
+	// AutoMigrate above has created its spendable-aware replacement.
+	if err := models.MigrateRewardAccountOutputCredentialIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"reward account output credential index migration failed: %w", err,
+		)
+	}
 	if backfillAccountCreatedSlot {
 		if err := models.BackfillAccountCreatedSlot(d.db, d.logger); err != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/postgres/reward_state.go
+++ b/database/plugin/metadata/postgres/reward_state.go
@@ -270,6 +270,68 @@ func (d *MetadataStorePostgres) GetRewardAccountOutputs(epoch uint64, txn types.
 	return rewardstate.GetAccountOutputs(db, epoch)
 }
 
+// GetRewardAccountOutputsByCredential retrieves reward account output rows
+// for a stake credential tag/hash pair, paginated and ordered by epoch.
+func (d *MetadataStorePostgres) GetRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]*models.RewardAccountOutput, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve read DB for reward account outputs by credential: %w",
+			err,
+		)
+	}
+	rows, err := rewardstate.GetAccountOutputsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// CountRewardAccountOutputsByCredential retrieves the total count of reward
+// account output rows for a stake credential tag/hash pair.
+func (d *MetadataStorePostgres) CountRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	count, err := rewardstate.CountAccountOutputsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 // DeleteRewardStateAfterSlot deletes reward-state rows captured from
 // rolled-back blocks.
 func (d *MetadataStorePostgres) DeleteRewardStateAfterSlot(
@@ -294,4 +356,21 @@ func (d *MetadataStorePostgres) DeleteRewardStateBeforeEpoch(
 		return fmt.Errorf("delete reward state before epoch: resolve db: %w", err)
 	}
 	return rewardstate.DeleteStateBeforeEpoch(db, epoch, txn)
+}
+
+// DeleteRewardStakeInputBeforeEpoch deletes only reward_stake_input rows
+// older than the retained snapshot window, leaving reward_account_output
+// intact. Used in API storage mode.
+func (d *MetadataStorePostgres) DeleteRewardStakeInputBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"delete reward stake input before epoch: resolve db: %w",
+			err,
+		)
+	}
+	return rewardstate.DeleteStakeInputBeforeEpoch(db, epoch, txn)
 }

--- a/database/plugin/metadata/postgres/reward_state_credential_test.go
+++ b/database/plugin/metadata/postgres/reward_state_credential_test.go
@@ -30,7 +30,7 @@ import (
 // and ordering.
 func TestGetRewardAccountOutputsByCredentialPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	stakingKey := testHash28("reward-history-cred")
@@ -64,7 +64,7 @@ func TestGetRewardAccountOutputsByCredentialPostgres(t *testing.T) {
 // reward_account_output is left untouched.
 func TestDeleteRewardStakeInputBeforeEpochPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	poolKeyHash := testHash28("reward-history-retention-pool")

--- a/database/plugin/metadata/postgres/reward_state_credential_test.go
+++ b/database/plugin/metadata/postgres/reward_state_credential_test.go
@@ -43,8 +43,8 @@ func TestGetRewardAccountOutputsByCredentialPostgres(t *testing.T) {
 	})
 
 	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
-		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100},
-		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200},
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100, Spendable: true},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200, Spendable: true},
 	}, nil))
 
 	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
@@ -57,6 +57,41 @@ func TestGetRewardAccountOutputsByCredentialPostgres(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, uint64(2), rows[0].Epoch)
+}
+
+// TestGetRewardAccountOutputsByCredentialExcludesNonSpendablePostgres pins
+// Finding 1 against postgres: a row whose reward was never actually
+// credited (Spendable = false, e.g. a credential that deregistered before
+// its reward's payout boundary) must be absent from both the returned rows
+// and the count.
+func TestGetRewardAccountOutputsByCredentialExcludesNonSpendablePostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	t.Cleanup(func() { _ = store.Close() })
+	db := store.DB()
+
+	stakingKey := testHash28("reward-history-nonspendable-cred")
+	pool := testHash28("reward-history-nonspendable-pool")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 10, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 1_000_000, Spendable: true},
+		{Epoch: 11, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 9_999_999, Spendable: false},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "the non-spendable row must not be counted")
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the non-spendable row must be absent from the results")
+	require.Equal(t, uint64(10), rows[0].Epoch)
 }
 
 // TestDeleteRewardStakeInputBeforeEpochPostgres verifies the API storage-mode

--- a/database/plugin/metadata/postgres/reward_state_credential_test.go
+++ b/database/plugin/metadata/postgres/reward_state_credential_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// TestGetRewardAccountOutputsByCredentialPostgres exercises the
+// credential-filtered reward-history query (backing the Blockfrost account
+// reward-history endpoint, dingo #1875) against postgres, covering pagination
+// and ordering.
+func TestGetRewardAccountOutputsByCredentialPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	stakingKey := testHash28("reward-history-cred")
+	poolA := testHash28("reward-history-pool-a")
+	poolB := testHash28("reward-history-pool-b")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 1, 1, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, uint64(2), rows[0].Epoch)
+}
+
+// TestDeleteRewardStakeInputBeforeEpochPostgres verifies the API storage-mode
+// retention path on postgres: reward_stake_input is pruned while
+// reward_account_output is left untouched.
+func TestDeleteRewardStakeInputBeforeEpochPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	defer store.Close() //nolint:errcheck
+	db := store.DB()
+
+	poolKeyHash := testHash28("reward-history-retention-pool")
+	stakingKey := testHash28("reward-history-retention-cred")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardStakeInput{}).Error
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardStakeInputs([]*models.RewardStakeInput{
+		{Epoch: 1, PoolKeyHash: poolKeyHash, StakingKey: stakingKey, Stake: 1, Registered: true},
+		{Epoch: 2, PoolKeyHash: poolKeyHash, StakingKey: stakingKey, Stake: 1, Registered: true},
+	}, nil))
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 1},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 2},
+	}, nil))
+
+	require.NoError(t, store.DeleteRewardStakeInputBeforeEpoch(2, nil))
+
+	stakeInputs1, err := store.GetRewardStakeInputs(1, nil)
+	require.NoError(t, err)
+	for _, row := range stakeInputs1 {
+		require.NotEqual(t, stakingKey, row.StakingKey, "epoch 1 reward_stake_input must be pruned")
+	}
+
+	accountOutputs1, err := store.GetRewardAccountOutputs(1, nil)
+	require.NoError(t, err)
+	found := false
+	for _, row := range accountOutputs1 {
+		if string(row.StakingKey) == string(stakingKey) {
+			found = true
+		}
+	}
+	require.True(t, found, "reward_account_output for epoch 1 must survive")
+}

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -590,6 +590,15 @@ func (d *MetadataStoreSqlite) Start() error {
 	if err := d.db.AutoMigrate(models.MigrateModels...); err != nil {
 		return err
 	}
+	// Drop the superseded reward_account_output credential index now that
+	// AutoMigrate above has created its spendable-aware replacement.
+	if err := models.MigrateRewardAccountOutputCredentialIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"reward account output credential index migration failed: %w", err,
+		)
+	}
 	if backfillAccountCreatedSlot {
 		if err := models.BackfillAccountCreatedSlot(d.db, d.logger); err != nil {
 			return fmt.Errorf(

--- a/database/plugin/metadata/sqlite/reward_state.go
+++ b/database/plugin/metadata/sqlite/reward_state.go
@@ -270,6 +270,68 @@ func (d *MetadataStoreSqlite) GetRewardAccountOutputs(epoch uint64, txn types.Tx
 	return rewardstate.GetAccountOutputs(db, epoch)
 }
 
+// GetRewardAccountOutputsByCredential retrieves reward account output rows
+// for a stake credential tag/hash pair, paginated and ordered by epoch.
+func (d *MetadataStoreSqlite) GetRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]*models.RewardAccountOutput, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve read DB for reward account outputs by credential: %w",
+			err,
+		)
+	}
+	rows, err := rewardstate.GetAccountOutputsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// CountRewardAccountOutputsByCredential retrieves the total count of reward
+// account output rows for a stake credential tag/hash pair.
+func (d *MetadataStoreSqlite) CountRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	count, err := rewardstate.CountAccountOutputsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 // DeleteRewardStateAfterSlot deletes reward-state rows captured from
 // rolled-back blocks.
 func (d *MetadataStoreSqlite) DeleteRewardStateAfterSlot(
@@ -294,4 +356,21 @@ func (d *MetadataStoreSqlite) DeleteRewardStateBeforeEpoch(
 		return fmt.Errorf("delete reward state before epoch: resolve db: %w", err)
 	}
 	return rewardstate.DeleteStateBeforeEpoch(db, epoch, txn)
+}
+
+// DeleteRewardStakeInputBeforeEpoch deletes only reward_stake_input rows
+// older than the retained snapshot window, leaving reward_account_output
+// intact. Used in API storage mode.
+func (d *MetadataStoreSqlite) DeleteRewardStakeInputBeforeEpoch(
+	epoch uint64,
+	txn types.Txn,
+) error {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return fmt.Errorf(
+			"delete reward stake input before epoch: resolve db: %w",
+			err,
+		)
+	}
+	return rewardstate.DeleteStakeInputBeforeEpoch(db, epoch, txn)
 }

--- a/database/plugin/metadata/sqlite/reward_state_credential_test.go
+++ b/database/plugin/metadata/sqlite/reward_state_credential_test.go
@@ -38,10 +38,10 @@ func explainRewardAccountOutputsByCredentialPlan(
 	}
 	require.NoError(t, db.Raw(
 		`EXPLAIN QUERY PLAN SELECT * FROM reward_account_output
-		 WHERE credential_tag = ? AND staking_key = ?
+		 WHERE credential_tag = ? AND staking_key = ? AND spendable = ?
 		 ORDER BY epoch ASC, pool_key_hash ASC, reward_type ASC
 		 LIMIT ? OFFSET ?`,
-		0, rewardStateTestHash(0x01), 100, 0,
+		0, rewardStateTestHash(0x01), true, 100, 0,
 	).Scan(&plan).Error)
 	details := make([]string, 0, len(plan))
 	for _, row := range plan {
@@ -54,7 +54,9 @@ func explainRewardAccountOutputsByCredentialPlan(
 // spanning more than one epoch and pool, verifying the credential filter,
 // default ascending order, the pool_key_hash/reward_type tie-break within an
 // epoch, and pagination. This is the query backing the Blockfrost account
-// reward-history endpoint (dingo #1875).
+// reward-history endpoint (dingo #1875). All rows here are spendable; see
+// TestGetRewardAccountOutputsByCredentialExcludesNonSpendable for the
+// Finding 1 regression coverage.
 func TestGetRewardAccountOutputsByCredential(t *testing.T) {
 	t.Parallel()
 	store := setupTestDB(t)
@@ -65,12 +67,12 @@ func TestGetRewardAccountOutputsByCredential(t *testing.T) {
 	poolB := rewardStateTestHash(0xbb)
 
 	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
-		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100},
-		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200},
-		{Epoch: 3, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "leader", Amount: 300},
-		{Epoch: 3, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 50},
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100, Spendable: true},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200, Spendable: true},
+		{Epoch: 3, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "leader", Amount: 300, Spendable: true},
+		{Epoch: 3, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 50, Spendable: true},
 		// Different credential: must never leak into the results below.
-		{Epoch: 1, CredentialTag: 0, StakingKey: otherStakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 999},
+		{Epoch: 1, CredentialTag: 0, StakingKey: otherStakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 999, Spendable: true},
 	}, nil))
 
 	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
@@ -171,17 +173,20 @@ func TestDeleteRewardStakeInputBeforeEpoch(t *testing.T) {
 }
 
 // TestGetRewardAccountOutputsByCredentialUsesIndex pins that
-// idx_reward_account_output_credential (credential_tag, staking_key, epoch,
-// pool_key_hash, reward_type) is what makes GetRewardAccountOutputsByCredential
-// affordable once dingo #1875 lets reward_account_output grow without bound in
-// API storage mode: without a credential-leading index, the existing
+// idx_reward_account_output_credential_spendable (credential_tag,
+// staking_key, spendable, epoch, pool_key_hash, reward_type) is what makes
+// GetRewardAccountOutputsByCredential affordable once dingo #1875 lets
+// reward_account_output grow without bound in API storage mode: without a
+// credential-leading index, the existing
 // idx_reward_account_output_epoch_cred_pool_type index (which leads with
-// epoch) cannot serve the credential_tag/staking_key predicate, and SQLite
-// falls back to a full index/table scan — the query returns the same rows
-// either way, so a plain correctness test would not catch an index being
-// dropped or renamed out from under this query. This asserts on the query
-// plan itself so that regression fails loudly instead of silently degrading
-// to O(table size) per request.
+// epoch) cannot serve the credential_tag/staking_key/spendable predicate, and
+// SQLite falls back to a full index/table scan — the query returns the same
+// rows either way, so a plain correctness test would not catch an index
+// being dropped or renamed out from under this query. This asserts on the
+// query plan itself so that regression fails loudly instead of silently
+// degrading to O(table size) per request. It also pins that spendable is
+// part of the index's search key (not just a post-filter), which is what
+// keeps the Finding 1 spendable=true filter a pure index seek.
 func TestGetRewardAccountOutputsByCredentialUsesIndex(t *testing.T) {
 	t.Parallel()
 	store := setupTestDB(t)
@@ -189,7 +194,8 @@ func TestGetRewardAccountOutputsByCredentialUsesIndex(t *testing.T) {
 	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
 		{
 			Epoch: 1, CredentialTag: 0, StakingKey: rewardStateTestHash(0x01),
-			PoolKeyHash: rewardStateTestHash(0xaa), RewardType: "member", Amount: 1,
+			PoolKeyHash: rewardStateTestHash(0xaa), RewardType: "member",
+			Amount: 1, Spendable: true,
 		},
 	}, nil))
 
@@ -203,13 +209,55 @@ func TestGetRewardAccountOutputsByCredentialUsesIndex(t *testing.T) {
 			t, upper, "SCAN REWARD_ACCOUNT_OUTPUT",
 			"query must not fall back to a full scan: %v", plan,
 		)
-		if strings.Contains(detail, "idx_reward_account_output_credential") {
+		if strings.Contains(detail, "idx_reward_account_output_credential_spendable") {
 			sawCredentialIndex = true
+			// The search key itself must include spendable, not just
+			// credential_tag/staking_key, or the filter is a
+			// seek-plus-filter rather than a pure index range scan.
+			require.Contains(
+				t, detail, "spendable=?",
+				"expected spendable in the index search key, got: %v", detail,
+			)
 		}
 	}
 	require.True(
 		t, sawCredentialIndex,
-		"expected the query plan to use idx_reward_account_output_credential, got: %v",
+		"expected the query plan to use idx_reward_account_output_credential_spendable, got: %v",
 		plan,
 	)
+}
+
+// TestGetRewardAccountOutputsByCredentialExcludesNonSpendable pins Finding 1:
+// a row whose reward was never actually credited (Spendable = false, e.g. a
+// credential that deregistered before its reward's payout boundary — see
+// finalizePrecomputedRewardOutputs in ledger/reward_calculation.go) must be
+// absent from both the returned rows and the count. Before this fix the
+// query filtered only on credential, so this row would have been returned
+// and counted as a reward the account received, even though it was never
+// paid.
+func TestGetRewardAccountOutputsByCredentialExcludesNonSpendable(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	stakingKey := rewardStateTestHash(0x06)
+	pool := rewardStateTestHash(0xdd)
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 10, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 1_000_000, Spendable: true},
+		// Deregistered before the payout boundary: never credited.
+		{Epoch: 11, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 9_999_999, Spendable: false},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "the non-spendable row must not be counted")
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the non-spendable row must be absent from the results")
+	require.Equal(t, uint64(10), rows[0].Epoch)
+	require.Equal(t, uint64(1_000_000), uint64(rows[0].Amount))
+	require.True(t, rows[0].Spendable)
 }

--- a/database/plugin/metadata/sqlite/reward_state_credential_test.go
+++ b/database/plugin/metadata/sqlite/reward_state_credential_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// TestGetRewardAccountOutputsByCredential covers an account with reward rows
+// spanning more than one epoch and pool, verifying the credential filter,
+// default ascending order, the pool_key_hash/reward_type tie-break within an
+// epoch, and pagination. This is the query backing the Blockfrost account
+// reward-history endpoint (dingo #1875).
+func TestGetRewardAccountOutputsByCredential(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	stakingKey := rewardStateTestHash(0x01)
+	otherStakingKey := rewardStateTestHash(0x02)
+	poolA := rewardStateTestHash(0xaa)
+	poolB := rewardStateTestHash(0xbb)
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 100},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 200},
+		{Epoch: 3, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolA, RewardType: "leader", Amount: 300},
+		{Epoch: 3, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolB, RewardType: "member", Amount: 50},
+		// Different credential: must never leak into the results below.
+		{Epoch: 1, CredentialTag: 0, StakingKey: otherStakingKey, PoolKeyHash: poolA, RewardType: "member", Amount: 999},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 4, count)
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+	require.Equal(t, uint64(1), rows[0].Epoch)
+	require.Equal(t, uint64(2), rows[1].Epoch)
+	// Epoch 3 has two rows; pool_key_hash breaks the tie.
+	require.Equal(t, uint64(3), rows[2].Epoch)
+	require.Equal(t, poolA, rows[2].PoolKeyHash)
+	require.Equal(t, "leader", rows[2].RewardType)
+	require.Equal(t, uint64(3), rows[3].Epoch)
+	require.Equal(t, poolB, rows[3].PoolKeyHash)
+
+	// Descending order reverses by epoch.
+	descRows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "desc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, descRows, 4)
+	require.Equal(t, uint64(3), descRows[0].Epoch)
+	require.Equal(t, uint64(1), descRows[3].Epoch)
+
+	// Pagination: limit 2, offset 2 returns the second page in ascending order.
+	page2, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 2, 2, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	require.Equal(t, rows[2], page2[0])
+	require.Equal(t, rows[3], page2[1])
+}
+
+// TestGetRewardAccountOutputsByCredentialEmpty covers a credential with no
+// reward_account_output rows: the query must return an empty slice and a
+// zero count, not an error.
+func TestGetRewardAccountOutputsByCredentialEmpty(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	stakingKey := rewardStateTestHash(0x03)
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
+
+// TestDeleteRewardStakeInputBeforeEpoch verifies the API storage-mode
+// retention path: only reward_stake_input rows are removed, and
+// reward_account_output rows for the same epoch are left untouched.
+func TestDeleteRewardStakeInputBeforeEpoch(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	poolKeyHash := rewardStateTestHash(0xcc)
+	stakingKey := rewardStateTestHash(0x04)
+
+	require.NoError(t, store.SaveRewardStakeInputs([]*models.RewardStakeInput{
+		{Epoch: 1, PoolKeyHash: poolKeyHash, StakingKey: stakingKey, Stake: 1, Registered: true},
+		{Epoch: 2, PoolKeyHash: poolKeyHash, StakingKey: stakingKey, Stake: 1, Registered: true},
+	}, nil))
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 1, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 1},
+		{Epoch: 2, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 2},
+	}, nil))
+
+	require.NoError(t, store.DeleteRewardStakeInputBeforeEpoch(2, nil))
+
+	stakeInputs1, err := store.GetRewardStakeInputs(1, nil)
+	require.NoError(t, err)
+	require.Empty(t, stakeInputs1, "reward_stake_input for epoch 1 must be pruned")
+
+	stakeInputs2, err := store.GetRewardStakeInputs(2, nil)
+	require.NoError(t, err)
+	require.Len(t, stakeInputs2, 1, "reward_stake_input for epoch 2 is inside the window")
+
+	// reward_account_output must survive for BOTH epochs: this function never
+	// touches that table.
+	accountOutputs1, err := store.GetRewardAccountOutputs(1, nil)
+	require.NoError(t, err)
+	require.Len(t, accountOutputs1, 1, "reward_account_output must not be pruned by this function")
+
+	accountOutputs2, err := store.GetRewardAccountOutputs(2, nil)
+	require.NoError(t, err)
+	require.Len(t, accountOutputs2, 1)
+}

--- a/database/plugin/metadata/sqlite/reward_state_credential_test.go
+++ b/database/plugin/metadata/sqlite/reward_state_credential_test.go
@@ -15,12 +15,40 @@
 package sqlite
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/blinklabs-io/dingo/database/models"
 )
+
+// explainRewardAccountOutputsByCredentialPlan runs EXPLAIN QUERY PLAN for the
+// exact query GetAccountOutputsByCredential issues and returns the "detail"
+// column of every plan row. SQLite's EXPLAIN QUERY PLAN output has columns
+// (id, parent, notused, detail); only detail is needed here.
+func explainRewardAccountOutputsByCredentialPlan(
+	t *testing.T,
+	db *gorm.DB,
+) []string {
+	t.Helper()
+	var plan []struct {
+		Detail string `gorm:"column:detail"`
+	}
+	require.NoError(t, db.Raw(
+		`EXPLAIN QUERY PLAN SELECT * FROM reward_account_output
+		 WHERE credential_tag = ? AND staking_key = ?
+		 ORDER BY epoch ASC, pool_key_hash ASC, reward_type ASC
+		 LIMIT ? OFFSET ?`,
+		0, rewardStateTestHash(0x01), 100, 0,
+	).Scan(&plan).Error)
+	details := make([]string, 0, len(plan))
+	for _, row := range plan {
+		details = append(details, row.Detail)
+	}
+	return details
+}
 
 // TestGetRewardAccountOutputsByCredential covers an account with reward rows
 // spanning more than one epoch and pool, verifying the credential filter,
@@ -140,4 +168,48 @@ func TestDeleteRewardStakeInputBeforeEpoch(t *testing.T) {
 	accountOutputs2, err := store.GetRewardAccountOutputs(2, nil)
 	require.NoError(t, err)
 	require.Len(t, accountOutputs2, 1)
+}
+
+// TestGetRewardAccountOutputsByCredentialUsesIndex pins that
+// idx_reward_account_output_credential (credential_tag, staking_key, epoch,
+// pool_key_hash, reward_type) is what makes GetRewardAccountOutputsByCredential
+// affordable once dingo #1875 lets reward_account_output grow without bound in
+// API storage mode: without a credential-leading index, the existing
+// idx_reward_account_output_epoch_cred_pool_type index (which leads with
+// epoch) cannot serve the credential_tag/staking_key predicate, and SQLite
+// falls back to a full index/table scan — the query returns the same rows
+// either way, so a plain correctness test would not catch an index being
+// dropped or renamed out from under this query. This asserts on the query
+// plan itself so that regression fails loudly instead of silently degrading
+// to O(table size) per request.
+func TestGetRewardAccountOutputsByCredentialUsesIndex(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch: 1, CredentialTag: 0, StakingKey: rewardStateTestHash(0x01),
+			PoolKeyHash: rewardStateTestHash(0xaa), RewardType: "member", Amount: 1,
+		},
+	}, nil))
+
+	plan := explainRewardAccountOutputsByCredentialPlan(t, store.DB())
+	require.NotEmpty(t, plan)
+
+	sawCredentialIndex := false
+	for _, detail := range plan {
+		upper := strings.ToUpper(detail)
+		require.NotContains(
+			t, upper, "SCAN REWARD_ACCOUNT_OUTPUT",
+			"query must not fall back to a full scan: %v", plan,
+		)
+		if strings.Contains(detail, "idx_reward_account_output_credential") {
+			sawCredentialIndex = true
+		}
+	}
+	require.True(
+		t, sawCredentialIndex,
+		"expected the query plan to use idx_reward_account_output_credential, got: %v",
+		plan,
+	)
 }

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1363,13 +1363,43 @@ type MetadataStore interface {
 	// GetRewardAccountOutputs retrieves per-account reward calculation outputs.
 	GetRewardAccountOutputs(uint64, types.Txn) ([]*models.RewardAccountOutput, error)
 
+	// GetRewardAccountOutputsByCredential retrieves reward account output
+	// rows for a stake credential tag/hash pair across every epoch that has
+	// not yet been pruned, paginated and ordered by epoch. Used by the
+	// Blockfrost account reward-history endpoint.
+	GetRewardAccountOutputsByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
+		types.Txn,
+	) ([]*models.RewardAccountOutput, error)
+
+	// CountRewardAccountOutputsByCredential retrieves the total count of
+	// reward account output rows for a stake credential tag/hash pair.
+	CountRewardAccountOutputsByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
+
 	// DeleteRewardStateAfterSlot deletes reward-state rows captured from
 	// rolled-back blocks.
 	DeleteRewardStateAfterSlot(uint64, types.Txn) error
 
 	// DeleteRewardStateBeforeEpoch deletes reward-state rows older than the
-	// retained snapshot window.
+	// retained snapshot window. This is the CORE storage-mode pruning path:
+	// it deletes both reward_stake_input and reward_account_output. See
+	// rewardstate.DeleteStateBeforeEpoch for the full rationale.
 	DeleteRewardStateBeforeEpoch(uint64, types.Txn) error
+
+	// DeleteRewardStakeInputBeforeEpoch deletes only reward_stake_input rows
+	// older than the retained snapshot window, leaving reward_account_output
+	// intact. This is the API storage-mode pruning path, used so the
+	// Blockfrost account reward-history endpoint can serve an account's full
+	// reward history. See rewardstate.DeleteStakeInputBeforeEpoch.
+	DeleteRewardStakeInputBeforeEpoch(uint64, types.Txn) error
 
 	// Stake snapshot methods
 

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1367,6 +1367,13 @@ type MetadataStore interface {
 	// rows for a stake credential tag/hash pair across every epoch that has
 	// not yet been pruned, paginated and ordered by epoch. Used by the
 	// Blockfrost account reward-history endpoint.
+	//
+	// Only spendable rows (spendable = true) are returned. A row with
+	// spendable = false was never credited to the account -- crediting skips
+	// it and adds the amount to the epoch's unspendable total instead -- so
+	// returning it would report a reward the account never received. See
+	// rewardstate.GetAccountOutputsByCredential for the full rationale,
+	// including a known gap for CIP-0163-guarded rows (dingo #3021).
 	GetRewardAccountOutputsByCredential(
 		uint8, // credentialTag
 		[]byte, // stakingKey
@@ -1378,6 +1385,10 @@ type MetadataStore interface {
 
 	// CountRewardAccountOutputsByCredential retrieves the total count of
 	// reward account output rows for a stake credential tag/hash pair.
+	//
+	// Counts only spendable rows, matching
+	// GetRewardAccountOutputsByCredential's filter. The two must agree, or
+	// pagination advertises pages of rewards that were never paid.
 	CountRewardAccountOutputsByCredential(
 		uint8, // credentialTag
 		[]byte, // stakingKey

--- a/database/reward_state.go
+++ b/database/reward_state.go
@@ -17,6 +17,7 @@ package database
 import (
 	"fmt"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -62,4 +63,62 @@ func (d *Database) DeleteRewardStateAfterSlot(
 		return fmt.Errorf("delete reward state after slot %d: %w", slot, err)
 	}
 	return nil
+}
+
+// GetRewardAccountOutputsByCredential returns reward account output rows for
+// a stake credential across every epoch that has not yet been pruned,
+// paginated and ordered by epoch. Used by the Blockfrost account
+// reward-history endpoint (GET /accounts/{stake_address}/rewards).
+func (d *Database) GetRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn *Txn,
+) ([]*models.RewardAccountOutput, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	rows, err := d.metadata.GetRewardAccountOutputsByCredential(
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// CountRewardAccountOutputsByCredential returns the total count of reward
+// account output rows for a stake credential.
+func (d *Database) CountRewardAccountOutputsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountRewardAccountOutputsByCredential(
+		credentialTag,
+		stakingKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count reward account outputs by credential: %w",
+			err,
+		)
+	}
+	return count, nil
 }

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -130,6 +130,15 @@ relayPort: 3001
 # - "api": Core data plus full transaction metadata (witnesses, scripts, datums,
 #   redeemers). All APIs start automatically on their default ports.
 #
+# Storage mode also controls how long per-account reward history is kept: in
+# "core" mode, per-account reward rows (reward_account_output) are pruned to
+# the same trailing 4-epoch window as the rest of the reward-calculation
+# snapshot state; in "api" mode they are retained for the life of the
+# database so the Blockfrost account reward-history endpoint
+# (GET /accounts/{stake_address}/rewards) can answer for any epoch, at the
+# cost of unbounded growth in that table. See DATABASE.md's "Snapshot and
+# Reward-State Retention" section for detail.
+#
 # Can be overridden with DINGO_STORAGE_MODE
 # CLI: --storage-mode
 storageMode: "core"

--- a/ledger/snapshot/rotation.go
+++ b/ledger/snapshot/rotation.go
@@ -955,6 +955,20 @@ func (m *Manager) rotateSnapshots(ctx context.Context, newEpoch uint64) {
 // be replayed after a rollback across the boundary where those rewards were
 // applied.
 //
+// reward_stake_input is pruned to that 4-epoch window in every storage mode:
+// it scales with delegator count (~1.3M rows/epoch on mainnet) and is not
+// needed once the epoch it snapshots has finished replaying. reward_account_output
+// is pruned to the same window in CORE storage mode (types.StorageModeCore),
+// matching dingo's original pruning behavior exactly, but retained WITHOUT BOUND
+// in API storage mode (types.StorageModeAPI) so the Blockfrost account
+// reward-history endpoint (GET /accounts/{stake_address}/rewards, dingo #1875)
+// can serve an account's full reward history instead of only the trailing few
+// epochs — the same "silently look empty past the window" failure mode #2987
+// already identified for epoch_summary. See
+// rewardstate.DeleteStateBeforeEpoch (core, prunes both tables) and
+// rewardstate.DeleteStakeInputBeforeEpoch (API, prunes only
+// reward_stake_input) for the implementation and full rationale.
+//
 // epoch_summary is deliberately NOT pruned. It is a single small row per epoch
 // (aggregate stake/pool/delegator totals plus the epoch nonce and boundary
 // slot), so retaining the full history costs one row per epoch — roughly a
@@ -989,7 +1003,16 @@ func (m *Manager) cleanupOldSnapshots(
 		return fmt.Errorf("cleanup pool snapshots: %w", err)
 	}
 
-	if err := meta.DeleteRewardStateBeforeEpoch(
+	if m.db.StorageMode() == types.StorageModeAPI {
+		// API storage mode: retain reward_account_output without bound (see
+		// doc comment above) and prune only reward_stake_input.
+		if err := meta.DeleteRewardStakeInputBeforeEpoch(
+			deleteBeforeEpoch,
+			metaTxn,
+		); err != nil {
+			return fmt.Errorf("cleanup reward state: %w", err)
+		}
+	} else if err := meta.DeleteRewardStateBeforeEpoch(
 		deleteBeforeEpoch,
 		metaTxn,
 	); err != nil {

--- a/ledger/snapshot/rotation_reward_retention_mode_test.go
+++ b/ledger/snapshot/rotation_reward_retention_mode_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// setupTestDBWithStorageMode mirrors setupTestDB (calculator_test.go) but
+// pins the storage mode, so retention tests can compare CORE vs API mode
+// pruning of reward_account_output (dingo #1875).
+func setupTestDBWithStorageMode(
+	t *testing.T,
+	storageMode string,
+) *database.Database {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir:     tmpDir,
+		StorageMode: storageMode,
+	})
+	require.NoError(t, err, "create database")
+
+	return db
+}
+
+// TestCleanupOldSnapshotsCoreModePrunesRewardAccountOutput pins that CORE
+// storage mode's retention behavior is unchanged by dingo #1875: both
+// reward_stake_input and reward_account_output are pruned to the same
+// rotation/reward-replay window.
+func TestCleanupOldSnapshotsCoreModePrunesRewardAccountOutput(t *testing.T) {
+	db := setupTestDBWithStorageMode(t, types.StorageModeCore)
+	require.Equal(t, types.StorageModeCore, db.StorageMode())
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	meta := db.Metadata()
+
+	const currentEpoch = uint64(10)
+	const firstRetainedEpoch = currentEpoch - 3
+	poolKeyHash := bytes.Repeat([]byte{0x11}, 28)
+
+	seedRetentionRows(t, db, poolKeyHash, currentEpoch)
+	require.NoError(
+		t,
+		mgr.cleanupOldSnapshots(context.Background(), currentEpoch),
+	)
+
+	for epoch := range firstRetainedEpoch {
+		accountOutputs, err := meta.GetRewardAccountOutputs(epoch, nil)
+		require.NoError(t, err, "get reward account outputs %d", epoch)
+		require.Empty(
+			t,
+			accountOutputs,
+			"core mode must prune reward_account_output for epoch %d",
+			epoch,
+		)
+		stakeInputs, err := meta.GetRewardStakeInputs(epoch, nil)
+		require.NoError(t, err, "get reward stake inputs %d", epoch)
+		require.Empty(
+			t,
+			stakeInputs,
+			"core mode must prune reward_stake_input for epoch %d",
+			epoch,
+		)
+	}
+	for epoch := firstRetainedEpoch; epoch <= currentEpoch; epoch++ {
+		accountOutputs, err := meta.GetRewardAccountOutputs(epoch, nil)
+		require.NoError(t, err, "get reward account outputs %d", epoch)
+		require.Len(
+			t,
+			accountOutputs,
+			1,
+			"core mode retains reward_account_output inside the window for epoch %d",
+			epoch,
+		)
+	}
+}
+
+// TestCleanupOldSnapshotsAPIModeRetainsRewardAccountOutput is the dingo #1875
+// regression test: in API storage mode, reward_account_output must be
+// retained WITHOUT BOUND (so the Blockfrost account reward-history endpoint
+// can serve an account's full history), while reward_stake_input still
+// cannot be kept and continues to be pruned to the rotation/reward-replay
+// window exactly as in core mode.
+func TestCleanupOldSnapshotsAPIModeRetainsRewardAccountOutput(t *testing.T) {
+	db := setupTestDBWithStorageMode(t, types.StorageModeAPI)
+	require.Equal(t, types.StorageModeAPI, db.StorageMode())
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	meta := db.Metadata()
+
+	const currentEpoch = uint64(10)
+	const firstRetainedEpoch = currentEpoch - 3
+	poolKeyHash := bytes.Repeat([]byte{0x22}, 28)
+
+	seedRetentionRows(t, db, poolKeyHash, currentEpoch)
+	require.NoError(
+		t,
+		mgr.cleanupOldSnapshots(context.Background(), currentEpoch),
+	)
+
+	// reward_account_output survives for every epoch, including those
+	// outside the rotation/reward-replay window.
+	for epoch := uint64(0); epoch <= currentEpoch; epoch++ {
+		accountOutputs, err := meta.GetRewardAccountOutputs(epoch, nil)
+		require.NoError(t, err, "get reward account outputs %d", epoch)
+		require.Len(
+			t,
+			accountOutputs,
+			1,
+			"API mode must retain reward_account_output for epoch %d",
+			epoch,
+		)
+	}
+
+	// reward_stake_input is still pruned to the same window as core mode.
+	for epoch := range firstRetainedEpoch {
+		stakeInputs, err := meta.GetRewardStakeInputs(epoch, nil)
+		require.NoError(t, err, "get reward stake inputs %d", epoch)
+		require.Empty(
+			t,
+			stakeInputs,
+			"API mode must still prune reward_stake_input for epoch %d",
+			epoch,
+		)
+	}
+	for epoch := firstRetainedEpoch; epoch <= currentEpoch; epoch++ {
+		stakeInputs, err := meta.GetRewardStakeInputs(epoch, nil)
+		require.NoError(t, err, "get reward stake inputs %d", epoch)
+		require.Len(
+			t,
+			stakeInputs,
+			1,
+			"reward_stake_input for epoch %d is inside the retained window",
+			epoch,
+		)
+	}
+}
+
+// TestDeleteRewardStateAfterSlotUnaffectedByAPIModeRetention is the rollback
+// correctness check for dingo #1875: retaining reward_account_output without
+// bound in API storage mode must not stop a rollback from removing rows
+// captured above the rollback point. DeleteRewardStateAfterSlot is
+// unconditional (it does not read storage mode at all), so this pins that
+// behavior directly rather than relying on that being true by omission.
+func TestDeleteRewardStateAfterSlotUnaffectedByAPIModeRetention(t *testing.T) {
+	db := setupTestDBWithStorageMode(t, types.StorageModeAPI)
+	meta := db.Metadata()
+
+	poolKeyHash := bytes.Repeat([]byte{0x33}, 28)
+	const throughEpoch = uint64(5)
+	seedRetentionRows(t, db, poolKeyHash, throughEpoch)
+
+	// seedRetentionRows uses boundarySlot := epoch * 432000; roll back to a
+	// slot inside epoch 3's boundary so epochs 0-2 predate the rollback slot
+	// and epochs 3-5 postdate it.
+	rollbackSlot := uint64(3)*432000 - 1
+	require.NoError(t, meta.DeleteRewardStateAfterSlot(rollbackSlot, nil))
+
+	for epoch := range uint64(3) {
+		outputs, err := meta.GetRewardAccountOutputs(epoch, nil)
+		require.NoError(t, err, "get reward account outputs %d", epoch)
+		require.Len(
+			t,
+			outputs,
+			1,
+			"epoch %d predates the rollback slot and must survive",
+			epoch,
+		)
+	}
+	for epoch := uint64(3); epoch <= throughEpoch; epoch++ {
+		outputs, err := meta.GetRewardAccountOutputs(epoch, nil)
+		require.NoError(t, err, "get reward account outputs %d", epoch)
+		require.Empty(
+			t,
+			outputs,
+			"epoch %d is above the rollback slot and must be removed even in API mode",
+			epoch,
+		)
+	}
+}


### PR DESCRIPTION
Closes #1875

`NodeAdapter.AccountRewardHistory` was a stub that validated the stake address and then always returned an empty slice, so an account with real reward history was indistinguishable from one with none.

## The issue text is stale

The stub TODO claimed no backing reward storage existed. It does. `models.RewardAccountOutput` (table `reward_account_output`) is already per-account, per-epoch, with pool ID and reward type, written by the reward calculation engine. So no new table was created. What was actually missing was a credential-filtered query and a retention policy that keeps history long enough to serve.

## Retention is gated on storage mode

Per maintainer direction, full reward history is retained in API storage mode only; core mode prunes exactly as before.

`reward_stake_input` continues to be pruned to the 4-epoch window in BOTH modes. It scales with delegator count, roughly 1.3M rows per epoch on mainnet, and the existing comment in `DeleteStateBeforeEpoch` already documents why it cannot be kept.

`reward_account_output` is pruned as before in `core` mode, so a block producer or relay sees byte-identical behavior, and retained without bound in `api` mode so the endpoint can serve full history instead of the trailing few epochs. `cleanupOldSnapshots` branches on `m.db.StorageMode()`, which was already reachable since the snapshot manager holds the `*database.Database`. A sibling method `DeleteRewardStakeInputBeforeEpoch` was added rather than adding a mode parameter to the existing method, so the core path and its existing test are untouched.

Operators choosing `storageMode: api` should note the growth: this table grows by roughly 1.3M rows per epoch on mainnet, about 5k on preview, for the life of the database. That is stated explicitly in `DATABASE.md` and noted under `storageMode` in `dingo.yaml.example`.

Rollback is unaffected: `DeleteRewardStateAfterSlot` never consults storage mode and still removes retained rows above a rollback point in both modes. A test pins this directly rather than leaving it true by omission.

The precompute-reuse path is also unaffected. `GetRewardAccountOutputs` has one non-test caller, it is scoped to a specific snapshot epoch, and it sits behind an `inputsValid` guard, so retained older rows cannot leak into a reward calculation.

## Index

The new query filters `(credential_tag, staking_key)`, but the only composite index on this table leads with `epoch`, so the query could not use it. Before:

```
SCAN reward_account_output USING INDEX idx_reward_account_output_epoch_cred_pool_type
USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
```

That is a full scan plus a full sort per request, on a table this PR makes grow without bound in API mode. Added `idx_reward_account_output_credential (credential_tag, staking_key, epoch, pool_key_hash, reward_type)` so the predicate and the ORDER BY are both index-satisfied. After:

- SQLite: `SEARCH reward_account_output USING INDEX idx_reward_account_output_credential (credential_tag=? AND staking_key=?)`, no scan, no sort
- MySQL 8.0: `type: ref, key: idx_reward_account_output_credential, key_len: 31`
- PostgreSQL 16: `Index Scan using idx_reward_account_output_credential`

MySQL and Postgres were verified against real containers, not assumed. Worst-case key length is about 129 bytes against InnoDBs 3072-byte limit, and the index is the same column set as the pre-existing unique index, permuted. No `INDEXED BY` hint is used; the planner picks the index on its own in all three backends.

Upgrade in place was verified with a legacy-model AutoMigrate test following this codebases existing `MigrateRewardLiveStakePoolIndex` pattern: the index is added by a plain `CREATE INDEX` with no table rebuild and existing rows survive. No migration helper was needed.

## Response shape

`account_reward_content.yaml` requires a `type` field with enum `leader | member | pool_deposit_refund`, which dingos structs lacked. Added to both the adapter and response structs and mapped from `RewardAccountOutput.RewardType`. dingo only produces `leader` and `member` today and those spellings already match Blockfrost verbatim; a lowercase passthrough fallback means any future value is surfaced rather than silently dropped.

## Tests

Multi-epoch history across more than one pool, pagination and order, empty history for a registered account, unknown account, database errors, `type` mapping, retention behavior in both storage modes, the rollback exemption, a query-plan assertion so a future index drop fails loudly instead of silently degrading to a scan, and the upgrade-in-place migration proof. No existing assertion was modified.

## Verification

`go build ./...` (default and `-tags dingo_extra_plugins`), `go test ./api/blockfrost/... ./database/... ./ledger/...`, `golangci-lint run` (both tag sets), `nilaway`, `modernize`, `make import-boundaries`, `go test -race` across the affected packages, and `go test ./internal/test/conformance/...` all pass. Verified to merge cleanly with #3012 and #3014 and to build and pass tests in combination with them.

## Documentation

`DATABASE.md` documents the per-mode retention split, the growth rate, the new index and its rationale, and the new query surface. `dingo.yaml.example` notes the retention difference under `storageMode`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the Blockfrost account reward history endpoint with a credential-filtered, spendable-only, paginated query; API storage mode retains full per-account reward history while core mode behavior is unchanged. Corrects epoch mapping to the earned epoch and adds a schema-safe reward type in responses.

- **New Features**
  - `api/blockfrost`: Implemented `AccountRewardHistory` (GET /accounts/{stake_address}/rewards) with pagination and asc/desc order; excludes uncredited rewards (`spendable=false`), reports the earned epoch, and returns `type` (leader/member/pool_deposit_refund) with an allow-list and warn-through fallback.
  - Database: Added `GetRewardAccountOutputsByCredential` and `CountRewardAccountOutputsByCredential` across SQLite/MySQL/PostgreSQL and wired through `database.Database`; documented the spendable-only filter on the store interface.
  - Retention: In `api` storage mode, keep full `reward_account_output` history; in `core`, prune as before. `reward_stake_input` is pruned in both modes. Rollback semantics unchanged.

- **Migration**
  - No manual steps. AutoMigrate creates `idx_reward_account_output_credential_spendable` and a migration drops the superseded `idx_reward_account_output_credential`; existing rows are preserved.
  - In `api` mode, expect ~1.3M new `reward_account_output` rows/epoch on mainnet and increased disk usage from the second index. Documentation and `dingo.yaml.example` updated.

<sup>Written for commit 70d318f174f107d303bc3e4a74f9ee06de513c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Blockfrost account reward history with pagination, ordering, reward-type information, and spendable-reward filtering.
  * Added credential-based reward history queries and total counts across supported database backends.
* **Bug Fixes**
  * Corrected reward retention behavior by storage mode: API mode preserves full account history while core mode retains the recent window.
  * Ensured rollback cleanup consistently removes data after the rollback point.
* **Documentation**
  * Updated architecture, database, and configuration guidance for reward history retention and querying.
* **Performance**
  * Improved reward history query efficiency with an index covering credential and spendability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->