### PR TITLE
feat(blockfrost): add stake-account utxo, withdrawal, and transaction endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2312,12 +2312,33 @@ epochs/parameters, network/eras, genesis, assets, pools/extended, retiring
 pools, pool metadata, governance DRep list and lookup, address summary,
 address UTxOs and transactions, metadata label JSON/CBOR,
 transaction content/CBOR/metadata/UTxOs/certificates/redeemers/required
-signers, and account/delegation/registration/reward endpoints. It uses an
-adapter pattern to translate between Dingo's internal state and Blockfrost
-response types and supports Blockfrost-style pagination headers. The root
-document is served only at the literal `/` path (`GET /{$}`); any other
-unregistered path falls through to a catch-all `404` handler instead of the
-root document, matching real Blockfrost's behavior for unimplemented routes.
+signers, and account/delegation/registration/reward/UTxOs/withdrawals/
+transactions endpoints. It uses an adapter pattern to translate between
+Dingo's internal state and Blockfrost response types and supports
+Blockfrost-style pagination headers. The root document is served only at the
+literal `/` path (`GET /{$}`); any other unregistered path falls through to a
+catch-all `404` handler instead of the root document, matching real
+Blockfrost's behavior for unimplemented routes.
+
+The account UTxOs, withdrawals, and transactions endpoints resolve everything
+by stake credential rather than a single address. Account UTxOs reuse the
+UTxO address-pattern query with a delegation-part-only pattern (matching
+every payment address sharing the stake credential) and recover each row's
+exact payment address from decoded output CBOR, the same CBOR-derived
+datum/reference-script recovery `/addresses/{address}/utxos` uses. Account
+withdrawals read the rollback-aware `account_reward_delta` withdrawal journal
+joined to its transaction. Account transactions reuse the address-transaction
+credential lookup (payment key `NULL`) to get one row per matching
+transaction, then derive the set of distinct addresses each transaction
+associates with the stake credential from the transaction's already-loaded
+input/collateral/reference-input/output/collateral-return UTxOs (mirroring
+the same grouping the indexer uses to populate `address_transaction`), one
+response row per (transaction, address) pair. Its optional `from`/`to`
+block-range filter cannot be pushed into SQL because block height is not
+part of the metadata schema (only block hash and slot are persisted on the
+transaction row); every transaction associated with the credential is
+fetched in chain order, resolved against the block store for its height,
+filtered, and paged in memory.
 
 Address summaries run balance, asset, CBOR, and existence reads through one
 coordinated read transaction. Pointer addresses require an exact decoded-output

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2325,20 +2325,36 @@ by stake credential rather than a single address. Account UTxOs reuse the
 UTxO address-pattern query with a delegation-part-only pattern (matching
 every payment address sharing the stake credential) and recover each row's
 exact payment address from decoded output CBOR, the same CBOR-derived
-datum/reference-script recovery `/addresses/{address}/utxos` uses. Account
-withdrawals read the rollback-aware `account_reward_delta` withdrawal journal
-joined to its transaction. Account transactions reuse the address-transaction
-credential lookup (payment key `NULL`) to get one row per matching
-transaction, then derive the set of distinct addresses each transaction
-associates with the stake credential from the transaction's already-loaded
-input/collateral/reference-input/output/collateral-return UTxOs (mirroring
-the same grouping the indexer uses to populate `address_transaction`), one
-response row per (transaction, address) pair. Its optional `from`/`to`
-block-range filter cannot be pushed into SQL because block height is not
-part of the metadata schema (only block hash and slot are persisted on the
-transaction row); every transaction associated with the credential is
-fetched in chain order, resolved against the block store for its height,
-filtered, and paged in memory.
+datum/reference-script recovery `/addresses/{address}/utxos` uses; like
+`/addresses/{address}/utxos`, pagination happens after fetching the
+credential's full live-UTxO set (there is no SQL `LIMIT`), which is an
+existing, accepted characteristic of that query shape rather than something
+introduced for this endpoint. Account withdrawals read the rollback-aware
+`account_reward_delta` withdrawal journal joined to its transaction, with
+`LIMIT`/`OFFSET` applied in SQL.
+
+Account transactions is bounded by the requested page size, not by the
+credential's full transaction history: `address_transaction` already carries
+one row per (payment address, transaction) association with its own
+`slot`/`tx_index` columns (populated by the same indexing step that fans a
+transaction's inputs/collateral/reference-inputs/outputs/collateral-return
+out into that table), so the query pages directly against it with SQL
+`ORDER BY`/`LIMIT`/`OFFSET` and an inclusive `(slot, tx_index)` range
+predicate for `from`/`to` — no application-level fan-out or filtering
+happens after the query returns. A block number in `from`/`to` is resolved
+to its slot via two bounded index lookups (`Database.BlockByIndex`,
+`Database.BlockAtOrAfterIndex`) rather than a scan: an unresolvable `from`
+(beyond every known block) makes the range unsatisfiable and short-circuits
+to an empty result; an unresolvable `to` degrades to unconstrained on that
+side rather than guessing at a boundary that cannot be looked up backward.
+The payment-credential script/key bit needed to reconstruct each row's
+exact address, and the block height/time needed for its response fields,
+are then resolved only for the page's own (<= page size) distinct payment
+keys and blocks — `MetadataStore.GetUtxoPaymentScriptByCredential` looks up
+the small bounded set of payment keys against the `utxo` table's persisted
+`payment_script` column, avoiding both a full-history scan and a CBOR
+decode, and correctly distinguishing key-hash from script-hash payment
+credentials (`AccountAssociatedAddresses` elsewhere assumes key-hash only).
 
 Address summaries run balance, asset, CBOR, and existence reads through one
 coordinated read transaction. Pointer addresses require an exact decoded-output

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -220,7 +220,7 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `credential_tag`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount`, `payment_script` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes `transaction_id`, `payment_key`, `staking_key`, spend/reference/collateral tx hashes, and `added_slot`; composites `idx_utxo_deleted_staking_amount` (`deleted_slot`, `credential_tag`, `staking_key`, `amount`), `idx_utxo_staking_deleted_amount` (`credential_tag`, `staking_key`, `deleted_slot`, `amount`), and `idx_utxo_deleted_payment_script` (`deleted_slot`, `payment_script`, `amount`) | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. `credential_tag`: 0 key hash, 1 script hash for stake-bearing outputs. The `(credential_tag, staking_key, deleted_slot, amount)` composite backs stake-credential live UTxO sums such as DRep voting-power tallying. `payment_script` is a bool set at index time from the output address type (true when the payment credential is a script hash); the `(deleted_slot, payment_script, amount)` composite backs the network script-locked supply sum (blockfrost `/network` `supply.locked`). It is derived only at write time, so a database synced before this column existed reports script-locked supply only for UTxOs created after the upgrade until it is rebuilt from chain data. |
 | `asset` | `id`, `utxo_id`, `policy_id`, `name`, `name_hex`, `fingerprint`, `amount` | PK `id`; unique `(name, policy_id, utxo_id)`; named index `idx_asset_policy_id` on `policy_id`; indexes `name_hex`, `fingerprint`, `amount` | Multi-asset quantities attached to `utxo.id`. The unique key backs ledger-state import `ON CONFLICT`; the policy-id query index can be deferred during bulk load. Use `utxo.deleted_slot = 0` for live balances. |
 | `asset_mint_burn` | `id`, `tx_hash`, `policy_id`, `name`, `fingerprint`, `slot`, `quantity`, `tx_index` | PK `id`; unique `(tx_hash, policy_id, name)` (`idx_asset_mint_burn_unique`); composite `(policy_id, name, slot)` (`idx_asset_mint_burn_lookup`); indexes `fingerprint`, `slot` | API-mode-only mint/burn history: one row per `(transaction, asset)` for every tx that mints or burns the asset. Populated from `tx.AssetMint()` during indexing; `quantity` is a signed decimal string (negative for burns). Unlike `asset` (live holdings), this preserves full history so Blockfrost `/assets/{asset}` can derive `initial_mint_tx_hash` (earliest event by `(slot, tx_index, id)`) and `mint_or_burn_count` (row count). The unique key makes re-applying a transaction after a rollback idempotent. Rows with `slot > rollback_slot` are deleted alongside `transaction` on rollback. |
-| `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key`, `(credential_tag, staking_key)`, `transaction_id`, `slot` | API-mode address-to-transaction index. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. |
+| `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key` (`idx_addr_tx_payment`), `transaction_id`, `slot`; composite `idx_addr_tx_stake_position` (`credential_tag`, `staking_key`, `slot`, `tx_index`, `payment_key`) | API-mode address-to-transaction index: one row per (payment address, transaction) pair. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. `idx_addr_tx_stake_position` backs `GetAddressTransactionsByCredential` (below): its leading `(credential_tag, staking_key)` columns serve every equality lookup the older `idx_addr_tx_staking` index did (`GetAddressesByCredential`, `GetTransactionsByAddress`'s credential-tag branch), and the trailing `(slot, tx_index, payment_key)` columns additionally let a credential-scoped, paginated, ordered range query run as a single index seek instead of sorting the credential's entire history in a temp B-tree. `MigrateAddressTransactionStakePositionIndex` drops the now-redundant `idx_addr_tx_staking` on upgrade, since it is a strict prefix of the new index and every one of its callers is served identically by the new one; `slot`'s standalone single-column index is kept separately because `DeleteAddressTransactionsAfterSlot`'s rollback cleanup (`WHERE slot > ?`, no credential filter) cannot use the composite index. |
 | `transaction_metadata_label` | `id`, `transaction_id`, `label`, `slot`, `cbor_value`, `json_value` | PK `id`; unique `(transaction_id, label)`; indexes `label`, `slot` | API-mode per-label metadata index. Join to `transaction.id`. |
 | `key_witness` | `id`, `transaction_id`, `type`, `vkey`, `signature`, `public_key`, `chain_code`, `attributes` | PK `id`; indexes `transaction_id`, `type` | API-mode vkey/bootstrap witnesses. Join to `transaction.id`. |
 | `witness_scripts` | `id`, `transaction_id`, `script_hash`, `type` | PK `id`; indexes `transaction_id`, `script_hash`, `type` | API-mode witness-script references. Join `script_hash = script.hash`. |
@@ -1484,11 +1484,31 @@ FROM address_transaction at
 JOIN "transaction" tx ON tx.id = at.transaction_id
 WHERE at.credential_tag = $1
   AND at.staking_key = decode($2, 'hex')
-  AND (at.slot > $3 OR (at.slot = $3 AND at.tx_index >= $4))  -- from, optional
-  AND (at.slot < $5 OR (at.slot = $5 AND at.tx_index <= $6))  -- to, optional
+  AND (at.slot, at.tx_index) >= ($3, $4)  -- from, optional
+  AND (at.slot, at.tx_index) <= ($5, $6)  -- to, optional
 ORDER BY at.slot ASC, at.tx_index ASC, at.payment_key ASC
 LIMIT 50;
 ```
+
+The `from`/`to` bound is written as a row-value comparison rather than the
+logically equivalent `slot > $3 OR (slot = $3 AND tx_index >= $4)` form,
+because only the row-value form is recognized (verified with `EXPLAIN QUERY
+PLAN` on SQLite) as an index range scan against `idx_addr_tx_stake_position`
+(see the `address_transaction` table entry above): the OR form still uses
+the index for the `credential_tag`/`staking_key` equality but degrades the
+`slot`/`tx_index` bound to a row-by-row filter after that point, while the
+row-value form folds the full range into the same index seek. Both forms
+are correct; only one avoids scanning past disqualifying rows. The
+`ORDER BY` is satisfied entirely by `idx_addr_tx_stake_position` in both
+directions (SQLite walks a B-tree index backwards for `DESC` without a
+temp B-tree), so together with `LIMIT`/`OFFSET` this query costs work
+proportional to the requested page, not to the credential's full
+transaction history — see
+`database/plugin/metadata/internal/accounthistory/transactions_test.go`
+for the `EXPLAIN QUERY PLAN` regression coverage (asc, desc, and a
+from/to range case), following the pattern established in
+`sqlite/utxo_test.go`, `sqlite/drep_test.go`, and
+`internal/rewardstate/livestake_test.go`.
 
 The Blockfrost adapter resolves each `from`/`to` block number to a slot via
 two bounded block-store index lookups (`Database.BlockByIndex`,

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -220,7 +220,7 @@ added for retired pools. This uses the `metadata.MetadataStore` methods
 | `utxo` | `id`, `transaction_id`, `collateral_return_for_tx_id`, `tx_id`, `output_idx`, `payment_key`, `credential_tag`, `staking_key`, `datum_hash`, `spent_at_tx_id`, `referenced_by_tx_id`, `collateral_by_tx_id`, `added_slot`, `deleted_slot`, `amount`, `payment_script` | PK `id`; unique `(tx_id, output_idx)`; unique `collateral_return_for_tx_id`; indexes `transaction_id`, `payment_key`, `staking_key`, spend/reference/collateral tx hashes, and `added_slot`; composites `idx_utxo_deleted_staking_amount` (`deleted_slot`, `credential_tag`, `staking_key`, `amount`), `idx_utxo_staking_deleted_amount` (`credential_tag`, `staking_key`, `deleted_slot`, `amount`), and `idx_utxo_deleted_payment_script` (`deleted_slot`, `payment_script`, `amount`) | Produced outputs use `transaction_id -> transaction.id`. Collateral returns use `collateral_return_for_tx_id -> transaction.id`. Inputs/reference/collateral joins are logical: `spent_at_tx_id`, `referenced_by_tx_id`, and `collateral_by_tx_id` store transaction hashes. `credential_tag`: 0 key hash, 1 script hash for stake-bearing outputs. The `(credential_tag, staking_key, deleted_slot, amount)` composite backs stake-credential live UTxO sums such as DRep voting-power tallying. `payment_script` is a bool set at index time from the output address type (true when the payment credential is a script hash); the `(deleted_slot, payment_script, amount)` composite backs the network script-locked supply sum (blockfrost `/network` `supply.locked`). It is derived only at write time, so a database synced before this column existed reports script-locked supply only for UTxOs created after the upgrade until it is rebuilt from chain data. |
 | `asset` | `id`, `utxo_id`, `policy_id`, `name`, `name_hex`, `fingerprint`, `amount` | PK `id`; unique `(name, policy_id, utxo_id)`; named index `idx_asset_policy_id` on `policy_id`; indexes `name_hex`, `fingerprint`, `amount` | Multi-asset quantities attached to `utxo.id`. The unique key backs ledger-state import `ON CONFLICT`; the policy-id query index can be deferred during bulk load. Use `utxo.deleted_slot = 0` for live balances. |
 | `asset_mint_burn` | `id`, `tx_hash`, `policy_id`, `name`, `fingerprint`, `slot`, `quantity`, `tx_index` | PK `id`; unique `(tx_hash, policy_id, name)` (`idx_asset_mint_burn_unique`); composite `(policy_id, name, slot)` (`idx_asset_mint_burn_lookup`); indexes `fingerprint`, `slot` | API-mode-only mint/burn history: one row per `(transaction, asset)` for every tx that mints or burns the asset. Populated from `tx.AssetMint()` during indexing; `quantity` is a signed decimal string (negative for burns). Unlike `asset` (live holdings), this preserves full history so Blockfrost `/assets/{asset}` can derive `initial_mint_tx_hash` (earliest event by `(slot, tx_index, id)`) and `mint_or_burn_count` (row count). The unique key makes re-applying a transaction after a rollback idempotent. Rows with `slot > rollback_slot` are deleted alongside `transaction` on rollback. |
-| `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key` (`idx_addr_tx_payment`), `transaction_id`, `slot`; composite `idx_addr_tx_stake_position` (`credential_tag`, `staking_key`, `slot`, `tx_index`, `payment_key`) | API-mode address-to-transaction index: one row per (payment address, transaction) pair. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. `idx_addr_tx_stake_position` backs `GetAddressTransactionsByCredential` (below): its leading `(credential_tag, staking_key)` columns serve every equality lookup the older `idx_addr_tx_staking` index did (`GetAddressesByCredential`, `GetTransactionsByAddress`'s credential-tag branch), and the trailing `(slot, tx_index, payment_key)` columns additionally let a credential-scoped, paginated, ordered range query run as a single index seek instead of sorting the credential's entire history in a temp B-tree. `MigrateAddressTransactionStakePositionIndex` drops the now-redundant `idx_addr_tx_staking` on upgrade, since it is a strict prefix of the new index and every one of its callers is served identically by the new one; `slot`'s standalone single-column index is kept separately because `DeleteAddressTransactionsAfterSlot`'s rollback cleanup (`WHERE slot > ?`, no credential filter) cannot use the composite index. |
+| `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key` (`idx_addr_tx_payment`), `transaction_id`, `slot`; composite `idx_addr_tx_stake_position` (`credential_tag`, `staking_key`, `slot`, `tx_index`, `payment_key`) | API-mode address-to-transaction index: one row per (payment address, transaction) pair. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. `idx_addr_tx_stake_position` backs `GetAddressTransactionsByCredential` (below): its leading `(credential_tag, staking_key)` columns serve every equality lookup the older `idx_addr_tx_staking` index did (`GetAddressesByCredential`, `GetTransactionsByAddress`'s credential-tag branch), and the trailing `(slot, tx_index, payment_key)` columns additionally let a credential-scoped, paginated, ordered range query run as a single index seek instead of sorting the credential's entire history in a temp B-tree. `MigrateAddressTransactionStakePositionIndex` drops the now-redundant `idx_addr_tx_staking` on upgrade, since it is a strict prefix of the new index and every one of its callers is served identically by the new one; it runs only after `AutoMigrate` has created `idx_addr_tx_stake_position` (all three plugins call it after their `AutoMigrate` pass) and additionally verifies the replacement index exists before dropping the legacy one, so a database can never be left with neither index, even if a process were to crash between the two steps or a caller invoked it out of order. `slot`'s standalone single-column index is kept separately because `DeleteAddressTransactionsAfterSlot`'s rollback cleanup (`WHERE slot > ?`, no credential filter) cannot use the composite index. |
 | `transaction_metadata_label` | `id`, `transaction_id`, `label`, `slot`, `cbor_value`, `json_value` | PK `id`; unique `(transaction_id, label)`; indexes `label`, `slot` | API-mode per-label metadata index. Join to `transaction.id`. |
 | `key_witness` | `id`, `transaction_id`, `type`, `vkey`, `signature`, `public_key`, `chain_code`, `attributes` | PK `id`; indexes `transaction_id`, `type` | API-mode vkey/bootstrap witnesses. Join to `transaction.id`. |
 | `witness_scripts` | `id`, `transaction_id`, `script_hash`, `type` | PK `id`; indexes `transaction_id`, `script_hash`, `type` | API-mode witness-script references. Join `script_hash = script.hash`. |
@@ -1474,8 +1474,7 @@ credential-keyed history query on this page, this one needs no
 application-level fan-out, filtering, or re-derivation after it returns:
 the SQL `ORDER BY`/`LIMIT`/`OFFSET` and the optional inclusive `(slot,
 tx_index)` range predicate (the resolved form of the endpoint's `from`/`to`
-block-number filter) are the final word, so a page-size request costs work
-proportional to the page, not to the credential's full transaction history.
+block-number filter) are the final word.
 
 ```sql
 SELECT at.payment_key, tx.hash AS tx_hash, at.slot AS tx_slot,
@@ -1484,31 +1483,69 @@ FROM address_transaction at
 JOIN "transaction" tx ON tx.id = at.transaction_id
 WHERE at.credential_tag = $1
   AND at.staking_key = decode($2, 'hex')
-  AND (at.slot, at.tx_index) >= ($3, $4)  -- from, optional
-  AND (at.slot, at.tx_index) <= ($5, $6)  -- to, optional
+  AND (at.slot, at.tx_index) >= ($3, $4)  -- from, optional; postgres/sqlite form, see below
+  AND (at.slot, at.tx_index) <= ($5, $6)  -- to, optional; postgres/sqlite form, see below
 ORDER BY at.slot ASC, at.tx_index ASC, at.payment_key ASC
 LIMIT 50;
 ```
 
-The `from`/`to` bound is written as a row-value comparison rather than the
-logically equivalent `slot > $3 OR (slot = $3 AND tx_index >= $4)` form,
-because only the row-value form is recognized (verified with `EXPLAIN QUERY
-PLAN` on SQLite) as an index range scan against `idx_addr_tx_stake_position`
-(see the `address_transaction` table entry above): the OR form still uses
-the index for the `credential_tag`/`staking_key` equality but degrades the
-`slot`/`tx_index` bound to a row-by-row filter after that point, while the
-row-value form folds the full range into the same index seek. Both forms
-are correct; only one avoids scanning past disqualifying rows. The
-`ORDER BY` is satisfied entirely by `idx_addr_tx_stake_position` in both
-directions (SQLite walks a B-tree index backwards for `DESC` without a
-temp B-tree), so together with `LIMIT`/`OFFSET` this query costs work
-proportional to the requested page, not to the credential's full
-transaction history — see
+The `from`/`to` bound has two logically equivalent forms — the row-value
+comparison shown above, and the expanded `slot > $3 OR (slot = $3 AND
+tx_index >= $4)` form — and which one folds into an index range scan
+against `idx_addr_tx_stake_position` (see the `address_transaction` table
+entry above) turned out to be backend-dependent, not universal. This was
+verified empirically, not assumed: scratch sqlite/postgres/mysql databases
+were seeded with a matching composite index and `EXPLAIN` was run for both
+forms against each backend (dingo PR #3016 review).
+
+* sqlite and postgres fold the row-value form directly into the index
+  range scan over all four bound columns (postgres `EXPLAIN ANALYZE`
+  showed the full `(slot, tx_index)` bound inside `Index Cond` with no
+  residual `Filter`; sqlite's `EXPLAIN QUERY PLAN` shows the same — see
+  `database/plugin/metadata/internal/accounthistory/transactions_test.go`).
+  The expanded OR form does not get folded on either: it still uses the
+  index for the `credential_tag`/`staking_key` equality but degrades the
+  `slot`/`tx_index` bound to a row-by-row filter after that point.
+* mysql does the opposite: `EXPLAIN` on a MySQL 8 container showed the
+  row-value form using only the index's two leading equality columns
+  (`ref` access type, `used_key_parts: [credential_tag, staking_key]`) and
+  applying the `(slot, tx_index)` bound as a residual filter — `EXPLAIN
+  ANALYZE` confirmed this costs work proportional to the row's offset
+  into the credential's full history, not to the page, exactly the
+  regression this query exists to avoid. This matches a known MySQL
+  optimizer limitation for row constructor inequalities (MySQL Bug
+  #104128, #111952 — Verified/S2, both still open as of 2026-07; MySQL's
+  own documentation recommends the expanded form for this reason). The
+  expanded OR form restored a genuine `range` access type using all four
+  index columns there.
+
+`sqldialect.TwoColumnRangeCondition` (used by
+`addressTransactionRangeQuery` in
+`database/plugin/metadata/internal/accounthistory/transactions.go`) picks
+the row-value form for sqlite/postgres and the expanded OR form for mysql
+accordingly, so each backend gets the form proven correct for it rather
+than one claim asserted for all three. `sqldialect`'s own test
+(`TestTwoColumnRangeConditionDialects`) and the accounthistory package's
+`TestAddressTransactionRangeQueryPerDialectForm` pin the chosen form per
+dialect; the sqlite-only `EXPLAIN QUERY PLAN` regression tests
+(`TestQueryAddressTransactionsByCredentialUsesStakePositionIndexAsc`/`Desc`/
+`RangeIsIndexSeek`) additionally verify the real query plan on sqlite.
+
+On sqlite (and postgres, by the same evidence above), the `ORDER BY` is
+also satisfied entirely by `idx_addr_tx_stake_position` in both directions
+(sqlite walks a B-tree index backwards for `DESC` without a temp B-tree),
+so together with `LIMIT`/`OFFSET` this query costs work proportional to
+the requested page, not to the credential's full transaction history, on
+those two backends — see
 `database/plugin/metadata/internal/accounthistory/transactions_test.go`
 for the `EXPLAIN QUERY PLAN` regression coverage (asc, desc, and a
 from/to range case), following the pattern established in
 `sqlite/utxo_test.go`, `sqlite/drep_test.go`, and
-`internal/rewardstate/livestake_test.go`.
+`internal/rewardstate/livestake_test.go`. On mysql, the expanded OR form
+restores the same page-proportional cost for the `from`/`to` bound itself
+(confirmed via `EXPLAIN ANALYZE` above); mysql's handling of the `ORDER
+BY`/`LIMIT` combination against this index was not separately verified
+here and is not claimed either way.
 
 The Blockfrost adapter resolves each `from`/`to` block number to a slot via
 two bounded block-store index lookups (`Database.BlockByIndex`,

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1420,6 +1420,31 @@ deposit (`deposit_amount` for registrations, the refund `amount` for the legacy
 (`tx_slot`), and `tx.block_hash` (`block_hash`, resolved to `block_height` by
 the adapter as above).
 
+### `GetAccountWithdrawalHistory`
+
+Backs the Blockfrost `/accounts/{stake_address}/withdrawals` endpoint. Unlike
+`GetAccountSumsByCredential`'s `withdrawals_sum` (a single aggregate), this
+returns one row per withdrawal, joining the rollback-aware
+`account_reward_delta` withdrawal rows against the transaction that made each
+withdrawal to recover its slot, block-internal position, and block hash;
+`transaction.hash` is unique, so the join never fans a withdrawal row into
+duplicates. As with the delegation/registration history queries, the
+Blockfrost adapter resolves `block_height` from the block store by hash
+(block numbers are not in the metadata SQL schema) and derives `block_time`
+from the slot.
+
+```sql
+SELECT ard.tx_hash, ard.amount, tx.slot AS tx_slot,
+       tx.block_index AS block_index, tx.block_hash AS block_hash
+FROM account_reward_delta ard
+JOIN "transaction" tx ON tx.hash = ard.tx_hash
+WHERE ard.withdrawal = true
+  AND ard.credential_tag = $1
+  AND ard.staking_key = decode($2, 'hex')
+ORDER BY tx_slot ASC, block_index ASC, tx_hash ASC
+LIMIT 50;
+```
+
 ### `GetAccountSumsByCredential`
 
 Backs the Blockfrost account `withdrawals_sum`, `reserves_sum`, and

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -938,6 +938,22 @@ WHERE credential_tag = $1
   AND deleted_slot = 0;
 ```
 
+Payment credential type (key hash vs script hash) for a bounded set of
+payment keys under a stake credential (`GetUtxoPaymentScriptByCredential`).
+Used by the Blockfrost account transactions endpoint to reconstruct the
+exact address for one page of results without a full-history scan or CBOR
+decode: `paymentKeys` is the small (`<=` page size) distinct set drawn from
+an already-paginated `GetAddressTransactionsByCredential` page, not the
+credential's full history.
+
+```sql
+SELECT DISTINCT payment_key, payment_script
+FROM utxo
+WHERE credential_tag = $1
+  AND staking_key = decode($2, 'hex')
+  AND payment_key IN (decode($3, 'hex'), decode($4, 'hex'), ...);
+```
+
 ### `GetScriptLockedSupply`
 
 Network script-locked supply (sum of lovelace in live UTxOs whose payment
@@ -1444,6 +1460,42 @@ WHERE ard.withdrawal = true
 ORDER BY tx_slot ASC, block_index ASC, tx_hash ASC
 LIMIT 50;
 ```
+
+### `GetAddressTransactionsByCredential`
+
+Backs the Blockfrost `/accounts/{stake_address}/transactions` endpoint.
+`address_transaction` already carries one row per (payment address,
+transaction) association for a stake credential — populated at indexing
+time from a transaction's inputs, collateral inputs, reference inputs,
+outputs, and collateral return, deduplicated per transaction (see
+`GetAddressesByCredential` above for the equivalent distinct-address
+projection) — with its own `slot`/`tx_index` columns. Unlike every other
+credential-keyed history query on this page, this one needs no
+application-level fan-out, filtering, or re-derivation after it returns:
+the SQL `ORDER BY`/`LIMIT`/`OFFSET` and the optional inclusive `(slot,
+tx_index)` range predicate (the resolved form of the endpoint's `from`/`to`
+block-number filter) are the final word, so a page-size request costs work
+proportional to the page, not to the credential's full transaction history.
+
+```sql
+SELECT at.payment_key, tx.hash AS tx_hash, at.slot AS tx_slot,
+       at.tx_index, tx.block_hash AS block_hash
+FROM address_transaction at
+JOIN "transaction" tx ON tx.id = at.transaction_id
+WHERE at.credential_tag = $1
+  AND at.staking_key = decode($2, 'hex')
+  AND (at.slot > $3 OR (at.slot = $3 AND at.tx_index >= $4))  -- from, optional
+  AND (at.slot < $5 OR (at.slot = $5 AND at.tx_index <= $6))  -- to, optional
+ORDER BY at.slot ASC, at.tx_index ASC, at.payment_key ASC
+LIMIT 50;
+```
+
+The Blockfrost adapter resolves each `from`/`to` block number to a slot via
+two bounded block-store index lookups (`Database.BlockByIndex`,
+`Database.BlockAtOrAfterIndex`) before this query runs, and resolves
+`block_height`/`block_time` and the payment-credential script/key bit
+(`GetUtxoPaymentScriptByCredential` above) only for the returned page's own
+blocks and payment keys.
 
 ### `GetAccountSumsByCredential`
 

--- a/api/blockfrost/account_activity_test.go
+++ b/api/blockfrost/account_activity_test.go
@@ -1,0 +1,575 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newAccountActivityRequest(
+	t *testing.T,
+	target string,
+) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.SetPathValue("stake_address", "stake_test1")
+	return req
+}
+
+// --- /accounts/{stake_address}/utxos ---
+
+func TestHandleAccountUTXOs(t *testing.T) {
+	dataHash := "dh1"
+	inlineDatum := "19a6aa"
+	refScript := "13a3efd8"
+	mock := &mockNode{
+		accountUTXOs: []AccountUTXOInfo{
+			{
+				Address:     "addr_test1",
+				TxHash:      "tx1",
+				TxIndex:     0,
+				OutputIndex: 0,
+				Amount: []AddressAmountInfo{
+					{Unit: "lovelace", Quantity: "1000000"},
+				},
+				Block: "block1",
+			},
+			{
+				Address:             "addr_test2",
+				TxHash:              "tx2",
+				TxIndex:             1,
+				OutputIndex:         1,
+				Amount:              []AddressAmountInfo{{Unit: "lovelace", Quantity: "2000000"}},
+				Block:               "block2",
+				DataHash:            &dataHash,
+				InlineDatum:         &inlineDatum,
+				ReferenceScriptHash: &refScript,
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/utxos?count=1&page=1&order=desc",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Count-Total"))
+
+	var resp []AccountUTXOResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "addr_test2", resp[0].Address)
+	assert.Equal(t, "tx2", resp[0].TxHash)
+	assert.Equal(t, 1, resp[0].TxIndex)
+	assert.Equal(t, 1, resp[0].OutputIndex)
+	assert.Equal(t, "block2", resp[0].Block)
+	require.NotNil(t, resp[0].DataHash)
+	assert.Equal(t, "dh1", *resp[0].DataHash)
+	require.NotNil(t, resp[0].InlineDatum)
+	assert.Equal(t, "19a6aa", *resp[0].InlineDatum)
+	require.NotNil(t, resp[0].ReferenceScriptHash)
+	assert.Equal(t, "13a3efd8", *resp[0].ReferenceScriptHash)
+
+	// OpenAPI 0.1.90 account_utxo_content: every field is required (data_hash,
+	// inline_datum, and reference_script_hash are nullable, not absent).
+	assertJSONKeys(t, resp[0], []string{
+		"address",
+		"tx_hash",
+		"tx_index",
+		"output_index",
+		"amount",
+		"block",
+		"data_hash",
+		"inline_datum",
+		"reference_script_hash",
+	})
+}
+
+func TestHandleAccountUTXOsNullableFieldsNull(t *testing.T) {
+	mock := &mockNode{
+		accountUTXOs: []AccountUTXOInfo{
+			{
+				Address:     "addr_test1",
+				TxHash:      "tx1",
+				TxIndex:     0,
+				OutputIndex: 0,
+				Amount:      []AddressAmountInfo{{Unit: "lovelace", Quantity: "1000000"}},
+				Block:       "block1",
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(t, "/api/v0/accounts/stake_test1/utxos")
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp []AccountUTXOResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 1)
+	assert.Nil(t, resp[0].DataHash)
+	assert.Nil(t, resp[0].InlineDatum)
+	assert.Nil(t, resp[0].ReferenceScriptHash)
+}
+
+func TestHandleAccountUTXOsEmpty(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(t, "/api/v0/accounts/stake_test1/utxos")
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "0", w.Header().Get("X-Pagination-Count-Total"))
+	var resp []AccountUTXOResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp)
+}
+
+func TestHandleAccountUTXOsInvalidStakeAddress(t *testing.T) {
+	mock := &mockNode{accountUTXOsErr: ErrInvalidStakeAddress}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(t, "/api/v0/accounts/stake_test1/utxos")
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Invalid stake address.", resp.Message)
+}
+
+func TestHandleAccountUTXOsNotFound(t *testing.T) {
+	mock := &mockNode{accountUTXOsErr: models.ErrAccountNotFound}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(t, "/api/v0/accounts/stake_test1/utxos")
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleAccountUTXOsQueryError(t *testing.T) {
+	mock := &mockNode{accountUTXOsErr: errors.New("boom")}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(t, "/api/v0/accounts/stake_test1/utxos")
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleAccountUTXOsInvalidPagination(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/utxos?count=notanumber",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountUTXOs(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- /accounts/{stake_address}/withdrawals ---
+
+func TestHandleAccountWithdrawals(t *testing.T) {
+	mock := &mockNode{
+		accountWithdrawals: []AccountWithdrawalInfo{
+			{
+				TxHash:      "tx1",
+				Amount:      "454541212442",
+				TxSlot:      45093580,
+				BlockTime:   1646437200,
+				BlockHeight: 6745358,
+			},
+			{
+				TxHash:      "tx2",
+				Amount:      "97846969",
+				TxSlot:      48093580,
+				BlockTime:   1649033600,
+				BlockHeight: 7126896,
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/withdrawals?count=1&page=2&order=asc",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountWithdrawals(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Page-Total"))
+
+	var resp []AccountWithdrawalResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "tx2", resp[0].TxHash)
+	assert.Equal(t, "97846969", resp[0].Amount)
+	assert.Equal(t, int64(48093580), resp[0].TxSlot)
+	assert.Equal(t, int64(1649033600), resp[0].BlockTime)
+	assert.Equal(t, int64(7126896), resp[0].BlockHeight)
+
+	// OpenAPI 0.1.90 account_withdrawal_content required field names.
+	assertJSONKeys(t, resp[0], []string{
+		"tx_hash",
+		"amount",
+		"tx_slot",
+		"block_time",
+		"block_height",
+	})
+}
+
+func TestHandleAccountWithdrawalsEmpty(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/withdrawals",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountWithdrawals(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp []AccountWithdrawalResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp)
+}
+
+func TestHandleAccountWithdrawalsInvalidStakeAddress(t *testing.T) {
+	mock := &mockNode{accountWithdrawalsErr: ErrInvalidStakeAddress}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/withdrawals",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountWithdrawals(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAccountWithdrawalsNotFound(t *testing.T) {
+	mock := &mockNode{accountWithdrawalsErr: models.ErrAccountNotFound}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/withdrawals",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountWithdrawals(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleAccountWithdrawalsQueryError(t *testing.T) {
+	mock := &mockNode{accountWithdrawalsErr: errors.New("boom")}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/withdrawals",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountWithdrawals(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- /accounts/{stake_address}/transactions ---
+
+func TestHandleAccountTransactions(t *testing.T) {
+	mock := &mockNode{
+		accountTransactions: []AccountTransactionInfo{
+			{
+				Address:     "addr_test1",
+				TxHash:      "tx1",
+				TxIndex:     34,
+				BlockHeight: 7900364,
+				BlockTime:   1666114079,
+			},
+			{
+				Address:     "addr_test2",
+				TxHash:      "tx2",
+				TxIndex:     6,
+				BlockHeight: 7900557,
+				BlockTime:   1666118180,
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions?count=1&page=1&order=desc",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Count-Total"))
+
+	var resp []AccountTransactionResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "addr_test2", resp[0].Address)
+	assert.Equal(t, "tx2", resp[0].TxHash)
+	assert.Equal(t, 6, resp[0].TxIndex)
+	assert.Equal(t, uint64(7900557), resp[0].BlockHeight)
+	assert.Equal(t, 1666118180, resp[0].BlockTime)
+
+	// OpenAPI 0.1.90 account_transactions_content required field names.
+	assertJSONKeys(t, resp[0], []string{
+		"address",
+		"tx_hash",
+		"tx_index",
+		"block_height",
+		"block_time",
+	})
+}
+
+func TestHandleAccountTransactionsEmpty(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp []AccountTransactionResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp)
+}
+
+func TestHandleAccountTransactionsInvalidStakeAddress(t *testing.T) {
+	mock := &mockNode{accountTransactionsErr: ErrInvalidStakeAddress}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAccountTransactionsNotFound(t *testing.T) {
+	mock := &mockNode{accountTransactionsErr: models.ErrAccountNotFound}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleAccountTransactionsQueryError(t *testing.T) {
+	mock := &mockNode{accountTransactionsErr: errors.New("boom")}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleAccountTransactionsInvalidPagination(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions?page=notanumber",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAccountTransactionsFromToParsed(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t,
+		"/api/v0/accounts/stake_test1/transactions?from=8929261&to=9999269:10",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, mock.lastAccountTransactionsParams.From)
+	assert.Equal(
+		t,
+		uint64(8929261),
+		mock.lastAccountTransactionsParams.From.Block,
+	)
+	assert.Nil(t, mock.lastAccountTransactionsParams.From.Index)
+	require.NotNil(t, mock.lastAccountTransactionsParams.To)
+	assert.Equal(
+		t,
+		uint64(9999269),
+		mock.lastAccountTransactionsParams.To.Block,
+	)
+	require.NotNil(t, mock.lastAccountTransactionsParams.To.Index)
+	assert.Equal(
+		t,
+		uint32(10),
+		*mock.lastAccountTransactionsParams.To.Index,
+	)
+}
+
+func TestHandleAccountTransactionsFromMalformed(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	for _, raw := range []string{"notanumber", "1:notanumber", "-1", "1:2:3"} {
+		req := newAccountActivityRequest(
+			t, "/api/v0/accounts/stake_test1/transactions?from="+raw,
+		)
+		w := httptest.NewRecorder()
+		b.handleAccountTransactions(w, req)
+		assert.Equal(
+			t, http.StatusBadRequest, w.Code,
+			"from=%q should be rejected", raw,
+		)
+	}
+}
+
+func TestHandleAccountTransactionsToMalformed(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions?to=notanumber",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAccountTransactionsInvertedRange(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions?from=100&to=50",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAccountTransactionsInvertedRangeSameBlock(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions?from=100:5&to=100:2",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAccountTransactionsValidRangeSameBlockNotInverted(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+
+	// "from" omits an index (defaults to the start of the block) and "to"
+	// pins an explicit index within the same block: not inverted.
+	req := newAccountActivityRequest(
+		t, "/api/v0/accounts/stake_test1/transactions?from=100&to=100:5",
+	)
+	w := httptest.NewRecorder()
+	b.handleAccountTransactions(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- parseBlockRangePosition / blockRangeInverted unit coverage ---
+
+func TestParseBlockRangePosition(t *testing.T) {
+	pos, err := parseBlockRangePosition("100")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), pos.Block)
+	assert.Nil(t, pos.Index)
+
+	pos, err = parseBlockRangePosition("100:5")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), pos.Block)
+	require.NotNil(t, pos.Index)
+	assert.Equal(t, uint32(5), *pos.Index)
+
+	_, err = parseBlockRangePosition("notanumber")
+	assert.ErrorIs(t, err, ErrInvalidBlockRange)
+
+	_, err = parseBlockRangePosition("100:notanumber")
+	assert.ErrorIs(t, err, ErrInvalidBlockRange)
+}
+
+func TestBlockRangeInverted(t *testing.T) {
+	idx := func(v uint32) *uint32 { return &v }
+
+	assert.True(t, blockRangeInverted(
+		BlockRangePosition{Block: 100},
+		BlockRangePosition{Block: 50},
+	))
+	assert.False(t, blockRangeInverted(
+		BlockRangePosition{Block: 50},
+		BlockRangePosition{Block: 100},
+	))
+	assert.True(t, blockRangeInverted(
+		BlockRangePosition{Block: 100, Index: idx(5)},
+		BlockRangePosition{Block: 100, Index: idx(2)},
+	))
+	assert.False(t, blockRangeInverted(
+		BlockRangePosition{Block: 100, Index: idx(2)},
+		BlockRangePosition{Block: 100, Index: idx(5)},
+	))
+	// Ambiguous same-block comparisons with a missing index are not
+	// treated as inverted.
+	assert.False(t, blockRangeInverted(
+		BlockRangePosition{Block: 100},
+		BlockRangePosition{Block: 100, Index: idx(0)},
+	))
+}

--- a/api/blockfrost/adapter_account_activity.go
+++ b/api/blockfrost/adapter_account_activity.go
@@ -15,13 +15,13 @@
 package blockfrost
 
 import (
-	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"strconv"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -188,12 +188,13 @@ func (a *NodeAdapter) AccountWithdrawals(
 // controlled by the stake credential behind stakeAddress, optionally
 // filtered by an inclusive from/to block-range position.
 //
-// Block height is not part of the metadata SQL schema (only block hash
-// and slot are persisted on the transaction row), so an explicit
-// block-range filter cannot be pushed down into SQL: every transaction
-// associated with the credential is fetched in chain order, resolved
-// against the block store to recover its height, filtered, and only
-// then paged in memory.
+// Every step here is bounded by the requested page size, not by the
+// credential's full transaction history: the (payment address,
+// transaction) association rows are paginated in SQL against
+// address_transaction (which already carries slot/tx_index, so the
+// from/to range is a SQL predicate, not an in-memory filter), and the
+// payment-credential script/key bit and block height/time are then
+// resolved only for the <= count rows on the page.
 func (a *NodeAdapter) AccountTransactions(
 	stakeAddress string,
 	params AccountTransactionsParams,
@@ -214,13 +215,51 @@ func (a *NodeAdapter) AccountTransactions(
 		return nil, 0, err
 	}
 
-	txs, err := a.ledgerState.GetTransactionsByAddressKeys(
-		nil,
+	from, fromSatisfiable, err := a.resolveBlockRangeBound(params.From, true)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"resolve account transactions from range: %w",
+			err,
+		)
+	}
+	if !fromSatisfiable {
+		return []AccountTransactionInfo{}, 0, nil
+	}
+	to, _, err := a.resolveBlockRangeBound(params.To, false)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"resolve account transactions to range: %w",
+			err,
+		)
+	}
+
+	offset := (params.Pagination.Page - 1) * params.Pagination.Count
+	total, err := a.ledgerState.Database().CountAddressTransactionsByCredential(
 		credentialTag,
 		stakeKey,
-		0,
-		0,
+		from,
+		to,
+		nil,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count account transactions for %q: %w",
+			stakeAddress,
+			err,
+		)
+	}
+	if offset >= total {
+		return []AccountTransactionInfo{}, total, nil
+	}
+	rows, err := a.ledgerState.Database().GetAddressTransactionsByCredential(
+		credentialTag,
+		stakeKey,
+		params.Pagination.Count,
+		offset,
 		params.Pagination.Order,
+		from,
+		to,
+		nil,
 	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
@@ -230,181 +269,160 @@ func (a *NodeAdapter) AccountTransactions(
 		)
 	}
 
-	blockNumbers := make(map[string]uint64, len(txs))
-	filtered := make([]AccountTransactionInfo, 0, len(txs))
-	for _, tx := range txs {
-		blockHashKey := hex.EncodeToString(tx.BlockHash)
+	// Resolve the payment-credential script/key bit only for the distinct
+	// payment keys on this page (<= len(rows)), not the credential's full
+	// history.
+	paymentKeys := make(map[string][]byte, len(rows))
+	for _, row := range rows {
+		paymentKeys[hex.EncodeToString(row.PaymentKey)] = row.PaymentKey
+	}
+	keyList := make([][]byte, 0, len(paymentKeys))
+	for _, key := range paymentKeys {
+		keyList = append(keyList, key)
+	}
+	scriptFlags, err := a.ledgerState.Database().
+		GetUtxoPaymentScriptByCredential(credentialTag, stakeKey, keyList, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"resolve account transaction payment credential types: %w",
+			err,
+		)
+	}
+
+	blockNumbers := make(map[string]uint64, len(rows))
+	ret := make([]AccountTransactionInfo, 0, len(rows))
+	for _, row := range rows {
+		blockHashKey := hex.EncodeToString(row.BlockHash)
 		blockHeight, ok := blockNumbers[blockHashKey]
 		if !ok {
-			block, err := a.ledgerState.BlockByHash(tx.BlockHash)
+			block, err := a.ledgerState.BlockByHash(row.BlockHash)
 			if err != nil {
 				return nil, 0, fmt.Errorf(
 					"get block for transaction %x: %w",
-					tx.Hash,
+					row.TxHash,
 					err,
 				)
 			}
 			blockHeight = block.Number
 			blockNumbers[blockHashKey] = blockHeight
 		}
-		if !inBlockRange(blockHeight, tx.BlockIndex, params.From, params.To) {
-			continue
-		}
-
-		blockTime, err := a.transactionBlockTime(tx)
+		blockTime, err := a.ledgerState.SlotToTime(row.TxSlot)
 		if err != nil {
 			return nil, 0, fmt.Errorf(
 				"get block time for transaction %x: %w",
-				tx.Hash,
+				row.TxHash,
 				err,
 			)
 		}
 
-		addresses, err := accountTransactionAddresses(
-			tx,
-			networkID,
-			credentialTag,
-			stakeKey,
-		)
-		if err != nil {
-			return nil, 0, fmt.Errorf(
-				"get addresses for transaction %x: %w",
-				tx.Hash,
-				err,
-			)
-		}
-		txHash := hex.EncodeToString(tx.Hash)
-		for _, address := range addresses {
-			filtered = append(filtered, AccountTransactionInfo{
-				Address:     address,
-				TxHash:      txHash,
-				TxIndex:     tx.BlockIndex,
-				BlockHeight: blockHeight,
-				BlockTime:   blockTime,
-			})
-		}
-	}
-
-	total := len(filtered)
-	start, end := paginationRange(total, params.Pagination)
-	if start >= end {
-		return []AccountTransactionInfo{}, total, nil
-	}
-	return filtered[start:end], total, nil
-}
-
-// accountTransactionAddresses derives the distinct payment addresses
-// sharing the given stake credential that participate in tx, across
-// every UTxO group that populates the AddressTransaction index (inputs,
-// collateral inputs, reference inputs, outputs, and collateral return),
-// mirroring collectAddressTransactions at indexing time. The result is
-// sorted for deterministic ordering, since a transaction may associate
-// more than one address with the same stake credential.
-func accountTransactionAddresses(
-	tx models.Transaction,
-	networkID uint8,
-	credentialTag uint8,
-	stakeKey []byte,
-) ([]string, error) {
-	utxos := make(
-		[]models.Utxo,
-		0,
-		len(tx.Inputs)+len(tx.Collateral)+len(tx.ReferenceInputs)+len(tx.Outputs)+1,
-	)
-	utxos = append(utxos, tx.Inputs...)
-	utxos = append(utxos, tx.Collateral...)
-	utxos = append(utxos, tx.ReferenceInputs...)
-	utxos = append(utxos, tx.Outputs...)
-	if tx.CollateralReturn != nil {
-		utxos = append(utxos, *tx.CollateralReturn)
-	}
-
-	seen := make(map[string]struct{}, len(utxos))
-	addresses := make([]string, 0, len(utxos))
-	for _, utxo := range utxos {
-		if utxo.CredentialTag != credentialTag ||
-			!bytes.Equal(utxo.StakingKey, stakeKey) ||
-			len(utxo.PaymentKey) == 0 {
-			continue
-		}
-		key := hex.EncodeToString(utxo.PaymentKey)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-
+		// A payment key with no matching UTxO row (should not happen: every
+		// address_transaction row is sourced from a UTxO row) defaults to
+		// key-hash, matching the fallback used elsewhere.
 		addressType := credentialTag << 1
-		if utxo.PaymentScript {
+		if scriptFlags[hex.EncodeToString(row.PaymentKey)] {
 			addressType |= 1
 		}
 		addr, err := lcommon.NewAddressFromParts(
 			addressType,
 			networkID,
-			utxo.PaymentKey,
+			row.PaymentKey,
 			stakeKey,
 		)
 		if err != nil {
-			return nil, fmt.Errorf(
+			return nil, 0, fmt.Errorf(
 				"build account transaction address: %w",
 				err,
 			)
 		}
-		addresses = append(addresses, addr.String())
+
+		ret = append(ret, AccountTransactionInfo{
+			Address:     addr.String(),
+			TxHash:      hex.EncodeToString(row.TxHash),
+			TxIndex:     row.TxIndex,
+			BlockHeight: blockHeight,
+			BlockTime:   blockTime.Unix(),
+		})
 	}
-	sort.Strings(addresses)
-	return addresses, nil
+	return ret, total, nil
 }
 
-// inBlockRange reports whether a transaction at the given block
-// height/index falls within the inclusive [from, to] block-range
-// position filter. A nil bound is unconstrained on that side. A bound
-// with no explicit index matches the entire block on that side (index 0
-// for from, the maximum index for to).
-func inBlockRange(
-	blockHeight uint64,
-	txIndex uint32,
-	from *BlockRangePosition,
-	to *BlockRangePosition,
-) bool {
-	if from != nil {
-		idx := uint32(0)
-		if from.Index != nil {
-			idx = *from.Index
-		}
-		if comparePosition(blockHeight, txIndex, from.Block, idx) < 0 {
-			return false
-		}
+// resolveBlockRangeBound resolves a Blockfrost account-transactions
+// from/to block-number position to an inclusive (slot, tx_index) bound
+// for the address_transaction SQL filter. A nil pos is unconstrained
+// (returns a nil bound, satisfiable=true).
+//
+// When the exact block number exists, its slot is used directly (the
+// common case: callers pass a block number they actually observed). When
+// it does not:
+//   - for a lower ("from") bound, this falls forward to the next block
+//     that does exist, which still correctly captures "at or after this
+//     position" even though the literal target block is absent (a sparse
+//     import gap). If no block at or after it exists at all (the position
+//     is beyond every known block), the range is unsatisfiable and the
+//     caller should return an empty result without querying further.
+//   - for an upper ("to") bound, there is no equivalent "last existing
+//     block at or before" index lookup available, so the bound is instead
+//     treated as unconstrained. This can only return more rows than a
+//     literal reading of an unresolvable "to" would (never fewer), which
+//     is the safe direction for an inclusive range filter.
+//
+// An explicit ":index" sub-position is honored only when the exact block
+// was found; a gap-fallback ignores it and defaults to the start (from)
+// or end (to) of the resolved block, since the requested index was
+// scoped to a block that does not exist.
+func (a *NodeAdapter) resolveBlockRangeBound(
+	pos *BlockRangePosition,
+	lower bool,
+) (*models.AddressTransactionPosition, bool, error) {
+	if pos == nil {
+		return nil, true, nil
 	}
-	if to != nil {
-		idx := uint32(math.MaxUint32)
-		if to.Index != nil {
-			idx = *to.Index
+	if pos.Block > math.MaxUint64-database.BlockInitialIndex {
+		if lower {
+			return nil, false, nil
 		}
-		if comparePosition(blockHeight, txIndex, to.Block, idx) > 0 {
-			return false
-		}
+		return nil, true, nil
 	}
-	return true
-}
+	idx := pos.Block + database.BlockInitialIndex
 
-// comparePosition orders (block, index) tuples: -1 if the first
-// position sorts before the second, 1 if after, 0 if equal.
-func comparePosition(
-	block uint64,
-	index uint32,
-	boundBlock uint64,
-	boundIndex uint32,
-) int {
+	block, err := a.ledgerState.Database().BlockByIndex(idx, nil)
 	switch {
-	case block < boundBlock:
-		return -1
-	case block > boundBlock:
-		return 1
-	case index < boundIndex:
-		return -1
-	case index > boundIndex:
-		return 1
+	case err == nil:
+		txIndex := uint32(0)
+		if !lower {
+			txIndex = math.MaxUint32
+		}
+		if pos.Index != nil {
+			txIndex = *pos.Index
+		}
+		return &models.AddressTransactionPosition{
+			Slot:    block.Slot,
+			TxIndex: txIndex,
+		}, true, nil
+	case errors.Is(err, models.ErrBlockNotFound):
+		if !lower {
+			return nil, true, nil
+		}
+		next, err := a.ledgerState.Database().BlockAtOrAfterIndex(idx, nil)
+		if err == nil {
+			return &models.AddressTransactionPosition{
+				Slot:    next.Slot,
+				TxIndex: 0,
+			}, true, nil
+		}
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf(
+			"resolve next block at or after %d: %w",
+			pos.Block,
+			err,
+		)
 	default:
-		return 0
+		return nil, false, fmt.Errorf(
+			"resolve block %d: %w",
+			pos.Block,
+			err,
+		)
 	}
 }

--- a/api/blockfrost/adapter_account_activity.go
+++ b/api/blockfrost/adapter_account_activity.go
@@ -1,0 +1,410 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// AccountUTXOs returns the current UTxOs controlled by the stake
+// credential behind stakeAddress. It models NodeAdapter.AddressUTXOs,
+// reusing the same CBOR-derived datum/reference-script recovery so the
+// fields stay consistent with /addresses/{address}/utxos and
+// /txs/{hash}/utxos. Unlike a single-address query, each row's address
+// must be recovered per-UTxO from decoded output CBOR, because a stake
+// credential can be shared by many distinct payment addresses.
+func (a *NodeAdapter) AccountUTXOs(
+	stakeAddress string,
+	params PaginationParams,
+) ([]AccountUTXOInfo, int, error) {
+	_, credentialTag, stakeKey, err := parseStakeAddress(stakeAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccountByCredential(credentialTag, stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+
+	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{
+				{DelegationPart: stakeKey},
+			},
+		},
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get account UTxOs for %q: %w",
+			stakeAddress,
+			err,
+		)
+	}
+	total := len(utxos)
+	if params.Order == PaginationOrderDesc {
+		for left, right := 0, len(utxos)-1; left < right; left, right = left+1, right-1 {
+			utxos[left], utxos[right] = utxos[right], utxos[left]
+		}
+	}
+
+	paged := paginateUtxos(utxos, params)
+	txBlockHashes, err := a.addressUtxoBlockHashes(paged)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get block hashes for account UTxOs %q: %w",
+			stakeAddress,
+			err,
+		)
+	}
+	// Inline datum, reference script, and the exact payment address are not
+	// persisted in metadata rows, so resolve each paged UTxO's CBOR (hot
+	// cache -> block LRU -> cold blob extract) and recover them from the
+	// decoded output. Missing entries degrade to zero values rather than
+	// failing the whole listing.
+	utxoCbor, err := a.addressUtxoCbor(paged)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"resolve CBOR for account UTxOs %q: %w",
+			stakeAddress,
+			err,
+		)
+	}
+
+	ret := make([]AccountUTXOInfo, 0, len(paged))
+	for _, utxo := range paged {
+		txKey := hex.EncodeToString(utxo.TxId)
+		address := ""
+		var inlineDatum, referenceScriptHash *string
+		if cborBytes := utxoCbor[utxoRef(utxo.Utxo)]; len(cborBytes) > 0 {
+			if output, decodeErr := gledger.NewTransactionOutputFromCbor(
+				cborBytes,
+			); decodeErr == nil {
+				address = output.Address().String()
+				inlineDatum, referenceScriptHash = utxoDatumAndScriptRef(output)
+			}
+		}
+		ret = append(ret, AccountUTXOInfo{
+			Address:             address,
+			TxHash:              txKey,
+			TxIndex:             utxo.OutputIdx,
+			OutputIndex:         utxo.OutputIdx,
+			Amount:              addressAmountsFromUtxo(utxo.Utxo),
+			Block:               txBlockHashes[txKey],
+			DataHash:            optionalHexString(utxo.DatumHash),
+			InlineDatum:         inlineDatum,
+			ReferenceScriptHash: referenceScriptHash,
+		})
+	}
+	return ret, total, nil
+}
+
+// AccountWithdrawals returns withdrawal history rows for the stake
+// credential behind stakeAddress.
+func (a *NodeAdapter) AccountWithdrawals(
+	stakeAddress string,
+	params PaginationParams,
+) ([]AccountWithdrawalInfo, int, error) {
+	_, credentialTag, stakeKey, err := parseStakeAddress(stakeAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccountByCredential(credentialTag, stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+
+	offset := (params.Page - 1) * params.Count
+	total, err := a.ledgerState.Database().
+		CountAccountWithdrawalHistoryByCredential(credentialTag, stakeKey, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count account withdrawal history: %w",
+			err,
+		)
+	}
+	if offset >= total {
+		return []AccountWithdrawalInfo{}, total, nil
+	}
+	rows, err := a.ledgerState.Database().
+		GetAccountWithdrawalHistoryByCredential(
+			credentialTag,
+			stakeKey,
+			params.Count,
+			offset,
+			params.Order,
+			nil,
+		)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get account withdrawal history: %w",
+			err,
+		)
+	}
+
+	blockNumbers := make(map[string]uint64, len(rows))
+	ret := make([]AccountWithdrawalInfo, 0, len(rows))
+	for _, row := range rows {
+		txSlot, blockTime, blockHeight, err := a.accountHistoryBlockInfo(
+			row.TxSlot,
+			row.BlockHash,
+			blockNumbers,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
+		ret = append(ret, AccountWithdrawalInfo{
+			TxHash:      hex.EncodeToString(row.TxHash),
+			Amount:      strconv.FormatUint(row.Amount, 10),
+			TxSlot:      txSlot,
+			BlockTime:   blockTime,
+			BlockHeight: blockHeight,
+		})
+	}
+	return ret, total, nil
+}
+
+// AccountTransactions returns transactions associated with addresses
+// controlled by the stake credential behind stakeAddress, optionally
+// filtered by an inclusive from/to block-range position.
+//
+// Block height is not part of the metadata SQL schema (only block hash
+// and slot are persisted on the transaction row), so an explicit
+// block-range filter cannot be pushed down into SQL: every transaction
+// associated with the credential is fetched in chain order, resolved
+// against the block store to recover its height, filtered, and only
+// then paged in memory.
+func (a *NodeAdapter) AccountTransactions(
+	stakeAddress string,
+	params AccountTransactionsParams,
+) ([]AccountTransactionInfo, int, error) {
+	stakeAddr, credentialTag, stakeKey, err := parseStakeAddress(stakeAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+	networkID, err := uintToUint8(
+		stakeAddr.NetworkId(),
+		"stake address network id",
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := a.ledgerState.Database().
+		GetAccountByCredential(credentialTag, stakeKey, true, nil); err != nil {
+		return nil, 0, err
+	}
+
+	txs, err := a.ledgerState.GetTransactionsByAddressKeys(
+		nil,
+		credentialTag,
+		stakeKey,
+		0,
+		0,
+		params.Pagination.Order,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get account transactions for %q: %w",
+			stakeAddress,
+			err,
+		)
+	}
+
+	blockNumbers := make(map[string]uint64, len(txs))
+	filtered := make([]AccountTransactionInfo, 0, len(txs))
+	for _, tx := range txs {
+		blockHashKey := hex.EncodeToString(tx.BlockHash)
+		blockHeight, ok := blockNumbers[blockHashKey]
+		if !ok {
+			block, err := a.ledgerState.BlockByHash(tx.BlockHash)
+			if err != nil {
+				return nil, 0, fmt.Errorf(
+					"get block for transaction %x: %w",
+					tx.Hash,
+					err,
+				)
+			}
+			blockHeight = block.Number
+			blockNumbers[blockHashKey] = blockHeight
+		}
+		if !inBlockRange(blockHeight, tx.BlockIndex, params.From, params.To) {
+			continue
+		}
+
+		blockTime, err := a.transactionBlockTime(tx)
+		if err != nil {
+			return nil, 0, fmt.Errorf(
+				"get block time for transaction %x: %w",
+				tx.Hash,
+				err,
+			)
+		}
+
+		addresses, err := accountTransactionAddresses(
+			tx,
+			networkID,
+			credentialTag,
+			stakeKey,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf(
+				"get addresses for transaction %x: %w",
+				tx.Hash,
+				err,
+			)
+		}
+		txHash := hex.EncodeToString(tx.Hash)
+		for _, address := range addresses {
+			filtered = append(filtered, AccountTransactionInfo{
+				Address:     address,
+				TxHash:      txHash,
+				TxIndex:     tx.BlockIndex,
+				BlockHeight: blockHeight,
+				BlockTime:   blockTime,
+			})
+		}
+	}
+
+	total := len(filtered)
+	start, end := paginationRange(total, params.Pagination)
+	if start >= end {
+		return []AccountTransactionInfo{}, total, nil
+	}
+	return filtered[start:end], total, nil
+}
+
+// accountTransactionAddresses derives the distinct payment addresses
+// sharing the given stake credential that participate in tx, across
+// every UTxO group that populates the AddressTransaction index (inputs,
+// collateral inputs, reference inputs, outputs, and collateral return),
+// mirroring collectAddressTransactions at indexing time. The result is
+// sorted for deterministic ordering, since a transaction may associate
+// more than one address with the same stake credential.
+func accountTransactionAddresses(
+	tx models.Transaction,
+	networkID uint8,
+	credentialTag uint8,
+	stakeKey []byte,
+) ([]string, error) {
+	utxos := make(
+		[]models.Utxo,
+		0,
+		len(tx.Inputs)+len(tx.Collateral)+len(tx.ReferenceInputs)+len(tx.Outputs)+1,
+	)
+	utxos = append(utxos, tx.Inputs...)
+	utxos = append(utxos, tx.Collateral...)
+	utxos = append(utxos, tx.ReferenceInputs...)
+	utxos = append(utxos, tx.Outputs...)
+	if tx.CollateralReturn != nil {
+		utxos = append(utxos, *tx.CollateralReturn)
+	}
+
+	seen := make(map[string]struct{}, len(utxos))
+	addresses := make([]string, 0, len(utxos))
+	for _, utxo := range utxos {
+		if utxo.CredentialTag != credentialTag ||
+			!bytes.Equal(utxo.StakingKey, stakeKey) ||
+			len(utxo.PaymentKey) == 0 {
+			continue
+		}
+		key := hex.EncodeToString(utxo.PaymentKey)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		addressType := credentialTag << 1
+		if utxo.PaymentScript {
+			addressType |= 1
+		}
+		addr, err := lcommon.NewAddressFromParts(
+			addressType,
+			networkID,
+			utxo.PaymentKey,
+			stakeKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build account transaction address: %w",
+				err,
+			)
+		}
+		addresses = append(addresses, addr.String())
+	}
+	sort.Strings(addresses)
+	return addresses, nil
+}
+
+// inBlockRange reports whether a transaction at the given block
+// height/index falls within the inclusive [from, to] block-range
+// position filter. A nil bound is unconstrained on that side. A bound
+// with no explicit index matches the entire block on that side (index 0
+// for from, the maximum index for to).
+func inBlockRange(
+	blockHeight uint64,
+	txIndex uint32,
+	from *BlockRangePosition,
+	to *BlockRangePosition,
+) bool {
+	if from != nil {
+		idx := uint32(0)
+		if from.Index != nil {
+			idx = *from.Index
+		}
+		if comparePosition(blockHeight, txIndex, from.Block, idx) < 0 {
+			return false
+		}
+	}
+	if to != nil {
+		idx := uint32(math.MaxUint32)
+		if to.Index != nil {
+			idx = *to.Index
+		}
+		if comparePosition(blockHeight, txIndex, to.Block, idx) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// comparePosition orders (block, index) tuples: -1 if the first
+// position sorts before the second, 1 if after, 0 if equal.
+func comparePosition(
+	block uint64,
+	index uint32,
+	boundBlock uint64,
+	boundIndex uint32,
+) int {
+	switch {
+	case block < boundBlock:
+		return -1
+	case block > boundBlock:
+		return 1
+	case index < boundIndex:
+		return -1
+	case index > boundIndex:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/api/blockfrost/adapter_account_activity_db_test.go
+++ b/api/blockfrost/adapter_account_activity_db_test.go
@@ -790,10 +790,13 @@ func TestNodeAdapterAccountTransactionsBounded(t *testing.T) {
 	require.Len(t, rows, 1)
 	assert.Equal(t, hex.EncodeToString(fill32(0)), rows[0].TxHash)
 
-	// A later page whose transaction's block is also missing must fail:
-	// this confirms the test's missing-block setup would actually have
-	// caught the original bug (it only "passes" the count=1/page=1 case
-	// above because that happens to be the one block that exists).
+	// A later page whose transaction's block is also missing must fail
+	// with models.ErrBlockNotFound specifically (BlockByHash's sentinel,
+	// propagated by adapter_account_activity.go's "%w" wrap): this
+	// confirms the test's missing-block setup would actually have caught
+	// the original bug (it only "passes" the count=1/page=1 case above
+	// because that happens to be the one block that exists), rather than
+	// merely asserting that some unrelated error occurred.
 	_, _, err = adapter.AccountTransactions(
 		stakeAddress,
 		AccountTransactionsParams{
@@ -802,7 +805,7 @@ func TestNodeAdapterAccountTransactionsBounded(t *testing.T) {
 			},
 		},
 	)
-	require.Error(t, err)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
 }
 
 func TestNodeAdapterAccountTransactionsEmpty(t *testing.T) {

--- a/api/blockfrost/adapter_account_activity_db_test.go
+++ b/api/blockfrost/adapter_account_activity_db_test.go
@@ -1,0 +1,672 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newDBBackedAccountAdapter builds a NodeAdapter like newDBBackedAdapter
+// (adapter_block_db_test.go), but additionally configures a minimal Shelley
+// genesis so slot-0 transactions/withdrawals resolve their block_time via
+// SlotToTime's genesis short-circuit, without needing a populated epoch
+// cache.
+func newDBBackedAccountAdapter(
+	t *testing.T,
+) (*NodeAdapter, *sqliteplugin.MetadataStoreSqlite, *database.Database) {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	nodeConfig := &cardano.CardanoNodeConfig{}
+	require.NoError(t, nodeConfig.LoadShelleyGenesisFromReader(
+		strings.NewReader(`{"systemStart":"2022-10-25T00:00:00Z"}`),
+	))
+
+	ls, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		CardanoNodeConfig: nodeConfig,
+	})
+	require.NoError(t, err)
+
+	adapter, err := NewNodeAdapter(ls, nil)
+	require.NoError(t, err)
+
+	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
+	require.True(t, ok)
+
+	return adapter, store, db
+}
+
+// testStakeCredential builds a bech32 reward/stake address and returns it
+// alongside the raw 28-byte key-hash staking credential it wraps.
+func testStakeCredential(t *testing.T, fill byte) (string, []byte) {
+	t.Helper()
+	stakeKey := bytes.Repeat([]byte{fill}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeKey,
+	)
+	require.NoError(t, err)
+	return addr.String(), stakeKey
+}
+
+func createTestBlock(
+	t *testing.T,
+	db *database.Database,
+	id uint64,
+	hash []byte,
+	number uint64,
+) {
+	t.Helper()
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:     id,
+		Hash:   hash,
+		Slot:   number,
+		Number: number,
+		Type:   0,
+		Cbor:   []byte{byte(number)},
+	}, nil))
+}
+
+// --- AccountUTXOs ---
+
+func TestNodeAdapterAccountUTXOs(t *testing.T) {
+	adapter, store, db := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0xAB)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	addr1, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x01}, lcommon.AddressHashSize),
+		stakeKey,
+	)
+	require.NoError(t, err)
+	addr2, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x02}, lcommon.AddressHashSize),
+		stakeKey,
+	)
+	require.NoError(t, err)
+
+	txID1 := uint(1)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID1, Hash: fill32(0x01), BlockHash: fill32(0xf1), Slot: 0,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TransactionID: &txID1,
+		TxId:          fill32(0x01),
+		OutputIdx:     0,
+		PaymentKey:    addr1.PaymentKeyHash().Bytes(),
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		AddedSlot:     0,
+		Amount:        types.Uint64(1_000_000),
+	}).Error)
+	storePointerOutputCbor(t, db, fill32(0x01), 0, addr1, 1_000_000)
+
+	txID2 := uint(2)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID2, Hash: fill32(0x02), BlockHash: fill32(0xf2), Slot: 0,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TransactionID: &txID2,
+		TxId:          fill32(0x02),
+		OutputIdx:     1,
+		PaymentKey:    addr2.PaymentKeyHash().Bytes(),
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		AddedSlot:     0,
+		Amount:        types.Uint64(2_000_000),
+		DatumHash:     fill32(0x99),
+	}).Error)
+	storePointerOutputCbor(t, db, fill32(0x02), 1, addr2, 2_000_000)
+
+	// A UTxO under a different stake credential must never appear.
+	otherStakeKey := bytes.Repeat([]byte{0xCD}, lcommon.AddressHashSize)
+	otherAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x03}, lcommon.AddressHashSize),
+		otherStakeKey,
+	)
+	require.NoError(t, err)
+	txID3 := uint(3)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID3, Hash: fill32(0x03), BlockHash: fill32(0xf3), Slot: 0,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TransactionID: &txID3,
+		TxId:          fill32(0x03),
+		OutputIdx:     0,
+		PaymentKey:    otherAddr.PaymentKeyHash().Bytes(),
+		StakingKey:    otherStakeKey,
+		CredentialTag: 0,
+		AddedSlot:     0,
+		Amount:        types.Uint64(9_999_999),
+	}).Error)
+	storePointerOutputCbor(t, db, fill32(0x03), 0, otherAddr, 9_999_999)
+
+	utxos, total, err := adapter.AccountUTXOs(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, utxos, 2)
+
+	byTxHash := map[string]AccountUTXOInfo{}
+	for _, u := range utxos {
+		byTxHash[u.TxHash] = u
+	}
+	u1 := byTxHash[hex.EncodeToString(fill32(0x01))]
+	assert.Equal(t, addr1.String(), u1.Address)
+	assert.Equal(t, "1000000", u1.Amount[0].Quantity)
+	assert.Equal(t, hex.EncodeToString(fill32(0xf1)), u1.Block)
+	assert.Nil(t, u1.DataHash)
+
+	u2 := byTxHash[hex.EncodeToString(fill32(0x02))]
+	assert.Equal(t, addr2.String(), u2.Address)
+	assert.Equal(t, "2000000", u2.Amount[0].Quantity)
+	require.NotNil(t, u2.DataHash)
+	assert.Equal(t, hex.EncodeToString(fill32(0x99)), *u2.DataHash)
+
+	// Pagination + reversed order.
+	page, total, err := adapter.AccountUTXOs(
+		stakeAddress,
+		PaginationParams{Count: 1, Page: 1, Order: PaginationOrderDesc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, page, 1)
+}
+
+func TestNodeAdapterAccountUTXOsEmpty(t *testing.T) {
+	adapter, store, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0xEE)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	utxos, total, err := adapter.AccountUTXOs(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, utxos)
+}
+
+func TestNodeAdapterAccountUTXOsInvalidStakeAddress(t *testing.T) {
+	adapter, _, _ := newDBBackedAccountAdapter(t)
+
+	_, _, err := adapter.AccountUTXOs(
+		"not-a-stake-address",
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.ErrorIs(t, err, ErrInvalidStakeAddress)
+}
+
+func TestNodeAdapterAccountUTXOsNotFound(t *testing.T) {
+	adapter, _, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, _ := testStakeCredential(t, 0x11)
+	_, _, err := adapter.AccountUTXOs(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.ErrorIs(t, err, models.ErrAccountNotFound)
+}
+
+func TestNodeAdapterAccountUTXOsQueryFailure(t *testing.T) {
+	adapter, store, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x22)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	require.NoError(t, store.DB().Exec("DROP TABLE utxo").Error)
+
+	_, _, err := adapter.AccountUTXOs(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.Error(t, err)
+}
+
+// --- AccountWithdrawals ---
+
+func TestNodeAdapterAccountWithdrawals(t *testing.T) {
+	adapter, store, db := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x33)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	createTestBlock(t, db, 1, fill32(0xb1), 100)
+	createTestBlock(t, db, 2, fill32(0xb2), 200)
+
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		Hash: fill32(0x01), BlockHash: fill32(0xb1), Slot: 0, BlockIndex: 0,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		Hash: fill32(0x02), BlockHash: fill32(0xb2), Slot: 0, BlockIndex: 1,
+	}).Error)
+
+	require.NoError(t, store.DB().Create(&models.AccountRewardDelta{
+		StakingKey: stakeKey, CredentialTag: 0,
+		TxHash: fill32(0x01), Amount: types.Uint64(1000),
+		Withdrawal: true, AddedSlot: 0,
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.AccountRewardDelta{
+		StakingKey: stakeKey, CredentialTag: 0,
+		TxHash: fill32(0x02), Amount: types.Uint64(2000),
+		Withdrawal: true, AddedSlot: 0,
+	}).Error)
+	// A non-withdrawal delta (credit) for the same credential must be
+	// excluded.
+	require.NoError(t, store.DB().Create(&models.AccountRewardDelta{
+		StakingKey: stakeKey, CredentialTag: 0,
+		TxHash: fill32(0x03), Amount: types.Uint64(555),
+		Withdrawal: false, AddedSlot: 0,
+	}).Error)
+
+	rows, total, err := adapter.AccountWithdrawals(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, rows, 2)
+	assert.Equal(t, hex.EncodeToString(fill32(0x01)), rows[0].TxHash)
+	assert.Equal(t, "1000", rows[0].Amount)
+	assert.Equal(t, int64(100), rows[0].BlockHeight)
+	assert.Equal(t, hex.EncodeToString(fill32(0x02)), rows[1].TxHash)
+	assert.Equal(t, "2000", rows[1].Amount)
+	assert.Equal(t, int64(200), rows[1].BlockHeight)
+
+	// Descending order reverses the two rows.
+	desc, total, err := adapter.AccountWithdrawals(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderDesc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, desc, 2)
+	assert.Equal(t, hex.EncodeToString(fill32(0x02)), desc[0].TxHash)
+
+	// Pagination.
+	paged, total, err := adapter.AccountWithdrawals(
+		stakeAddress,
+		PaginationParams{Count: 1, Page: 2, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, paged, 1)
+	assert.Equal(t, hex.EncodeToString(fill32(0x02)), paged[0].TxHash)
+}
+
+func TestNodeAdapterAccountWithdrawalsEmpty(t *testing.T) {
+	adapter, store, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x44)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	rows, total, err := adapter.AccountWithdrawals(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, rows)
+}
+
+func TestNodeAdapterAccountWithdrawalsNotFound(t *testing.T) {
+	adapter, _, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, _ := testStakeCredential(t, 0x55)
+	_, _, err := adapter.AccountWithdrawals(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.ErrorIs(t, err, models.ErrAccountNotFound)
+}
+
+func TestNodeAdapterAccountWithdrawalsQueryFailure(t *testing.T) {
+	adapter, store, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x66)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	require.NoError(t, store.DB().Exec("DROP TABLE account_reward_delta").Error)
+
+	_, _, err := adapter.AccountWithdrawals(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.Error(t, err)
+}
+
+// --- AccountTransactions ---
+
+func TestNodeAdapterAccountTransactions(t *testing.T) {
+	adapter, store, db := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x77)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	createTestBlock(t, db, 1, fill32(0xc1), 100)
+	createTestBlock(t, db, 2, fill32(0xc2), 101)
+	createTestBlock(t, db, 3, fill32(0xc3), 105)
+
+	addr1, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x01}, lcommon.AddressHashSize),
+		stakeKey,
+	)
+	require.NoError(t, err)
+	addr2, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x02}, lcommon.AddressHashSize),
+		stakeKey,
+	)
+	require.NoError(t, err)
+
+	// tx1 in block 100, output under addr1.
+	txID1 := uint(1)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID1, Hash: fill32(0x01), BlockHash: fill32(0xc1),
+		Slot: 0, BlockIndex: 0,
+		Outputs: []models.Utxo{{
+			TxId: fill32(0x01), OutputIdx: 0,
+			PaymentKey: addr1.PaymentKeyHash().Bytes(),
+			StakingKey: stakeKey, CredentialTag: 0,
+			Amount: types.Uint64(1_000_000),
+		}},
+	}).Error)
+
+	// tx2 in block 101, two outputs under addr1 and addr2 (must yield two
+	// distinct rows, not a duplicate of the same association).
+	txID2 := uint(2)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID2, Hash: fill32(0x02), BlockHash: fill32(0xc2),
+		Slot: 0, BlockIndex: 2,
+		Outputs: []models.Utxo{
+			{
+				TxId: fill32(0x02), OutputIdx: 0,
+				PaymentKey: addr1.PaymentKeyHash().Bytes(),
+				StakingKey: stakeKey, CredentialTag: 0,
+				Amount: types.Uint64(500_000),
+			},
+			{
+				TxId: fill32(0x02), OutputIdx: 1,
+				PaymentKey: addr2.PaymentKeyHash().Bytes(),
+				StakingKey: stakeKey, CredentialTag: 0,
+				Amount: types.Uint64(700_000),
+			},
+			// A second output to addr1 in the same tx must not duplicate
+			// the (address, tx) association already captured above.
+			{
+				TxId: fill32(0x02), OutputIdx: 2,
+				PaymentKey: addr1.PaymentKeyHash().Bytes(),
+				StakingKey: stakeKey, CredentialTag: 0,
+				Amount: types.Uint64(1),
+			},
+		},
+	}).Error)
+
+	// tx3 in block 105 under a different stake credential; must never
+	// appear in results.
+	otherStakeKey := bytes.Repeat([]byte{0x88}, lcommon.AddressHashSize)
+	txID3 := uint(3)
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID3, Hash: fill32(0x03), BlockHash: fill32(0xc3),
+		Slot: 0, BlockIndex: 0,
+		Outputs: []models.Utxo{{
+			TxId: fill32(0x03), OutputIdx: 0,
+			PaymentKey: bytes.Repeat([]byte{0x09}, lcommon.AddressHashSize),
+			StakingKey: otherStakeKey, CredentialTag: 0,
+			Amount: types.Uint64(1),
+		}},
+	}).Error)
+	// Also index the address associations, mirroring what the real
+	// indexing path populates for GetTransactionsByAddressKeys/
+	// CountTransactionsByAddressKeys to select from.
+	for _, at := range []models.AddressTransaction{
+		{
+			PaymentKey: addr1.PaymentKeyHash().Bytes(), StakingKey: stakeKey,
+			CredentialTag: 0, TransactionID: txID1, Slot: 0, TxIndex: 0,
+		},
+		{
+			PaymentKey: addr1.PaymentKeyHash().Bytes(), StakingKey: stakeKey,
+			CredentialTag: 0, TransactionID: txID2, Slot: 0, TxIndex: 2,
+		},
+		{
+			PaymentKey: addr2.PaymentKeyHash().Bytes(), StakingKey: stakeKey,
+			CredentialTag: 0, TransactionID: txID2, Slot: 0, TxIndex: 2,
+		},
+		{
+			PaymentKey:    bytes.Repeat([]byte{0x09}, lcommon.AddressHashSize),
+			StakingKey:    otherStakeKey,
+			CredentialTag: 0, TransactionID: txID3, Slot: 0, TxIndex: 0,
+		},
+	} {
+		require.NoError(t, store.DB().Create(&at).Error)
+	}
+
+	rows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	require.Len(t, rows, 3)
+
+	// Ascending chain order: tx1 (block 100) first, then the two addr1/addr2
+	// rows for tx2 (block 101), sorted deterministically by address.
+	assert.Equal(t, hex.EncodeToString(fill32(0x01)), rows[0].TxHash)
+	assert.Equal(t, addr1.String(), rows[0].Address)
+	assert.Equal(t, uint64(100), rows[0].BlockHeight)
+
+	tx2Rows := rows[1:3]
+	gotAddrs := []string{tx2Rows[0].Address, tx2Rows[1].Address}
+	assert.ElementsMatch(t, []string{addr1.String(), addr2.String()}, gotAddrs)
+	for _, r := range tx2Rows {
+		assert.Equal(t, hex.EncodeToString(fill32(0x02)), r.TxHash)
+		assert.Equal(t, uint64(101), r.BlockHeight)
+		assert.Equal(t, uint32(2), r.TxIndex)
+	}
+
+	// from=101 excludes tx1 (block 100).
+	fromRows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+			From: &BlockRangePosition{Block: 101},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	for _, r := range fromRows {
+		assert.NotEqual(t, hex.EncodeToString(fill32(0x01)), r.TxHash)
+	}
+
+	// to=100 keeps only tx1.
+	toRows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+			To: &BlockRangePosition{Block: 100},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, toRows, 1)
+	assert.Equal(t, hex.EncodeToString(fill32(0x01)), toRows[0].TxHash)
+
+	// from=101:3 (past tx2's index of 2) excludes tx2 as well, leaving
+	// nothing (tx1 is in block 100, before 101).
+	idx3 := uint32(3)
+	noneRows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+			From: &BlockRangePosition{Block: 101, Index: &idx3},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, noneRows)
+
+	// Pagination over the expanded (address, tx) row set.
+	paged, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 1, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	require.Len(t, paged, 1)
+}
+
+func TestNodeAdapterAccountTransactionsEmpty(t *testing.T) {
+	adapter, store, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x99)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	rows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, rows)
+}
+
+func TestNodeAdapterAccountTransactionsNotFound(t *testing.T) {
+	adapter, _, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, _ := testStakeCredential(t, 0xA1)
+	_, _, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.ErrorIs(t, err, models.ErrAccountNotFound)
+}
+
+func TestNodeAdapterAccountTransactionsQueryFailure(t *testing.T) {
+	adapter, store, _ := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0xA2)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	require.NoError(t, store.DB().Exec("DROP TABLE address_transaction").Error)
+
+	_, _, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.Error(t, err)
+}

--- a/api/blockfrost/adapter_account_activity_db_test.go
+++ b/api/blockfrost/adapter_account_activity_db_test.go
@@ -37,9 +37,11 @@ import (
 
 // newDBBackedAccountAdapter builds a NodeAdapter like newDBBackedAdapter
 // (adapter_block_db_test.go), but additionally configures a minimal Shelley
-// genesis so slot-0 transactions/withdrawals resolve their block_time via
-// SlotToTime's genesis short-circuit, without needing a populated epoch
-// cache.
+// genesis and a single wide-covering epoch (0..10,000,000 slots) so
+// SlotToTime resolves any slot used by these tests, not just slot 0 (the
+// genesis short-circuit), without needing the full epoch-boundary/nonce
+// machinery a real epoch cache would otherwise require. ls.PrepareEpochCacheForStartup
+// only works before LedgerState.Start(), which is never called here.
 func newDBBackedAccountAdapter(
 	t *testing.T,
 ) (*NodeAdapter, *sqliteplugin.MetadataStoreSqlite, *database.Database) {
@@ -65,11 +67,18 @@ func newDBBackedAccountAdapter(
 	})
 	require.NoError(t, err)
 
-	adapter, err := NewNodeAdapter(ls, nil)
-	require.NoError(t, err)
-
 	store, ok := db.Metadata().(*sqliteplugin.MetadataStoreSqlite)
 	require.True(t, ok)
+	require.NoError(t, store.DB().Create(&models.Epoch{
+		EpochId:       0,
+		StartSlot:     0,
+		SlotLength:    1000,
+		LengthInSlots: 10_000_000,
+	}).Error)
+	require.NoError(t, ls.PrepareEpochCacheForStartup())
+
+	adapter, err := NewNodeAdapter(ls, nil)
+	require.NoError(t, err)
 
 	return adapter, store, db
 }
@@ -89,16 +98,20 @@ func testStakeCredential(t *testing.T, fill byte) (string, []byte) {
 	return addr.String(), stakeKey
 }
 
+// createTestBlock creates a block at the given Cardano height (Number).
+// The blob-store index ID must be height + database.BlockInitialIndex to
+// match how BlockByIndex/BlockAtOrAfterIndex resolve a Blockfrost block
+// number to a block (see resolveBlockRangeBound in
+// adapter_account_activity.go and nextBlockHash in adapter.go).
 func createTestBlock(
 	t *testing.T,
 	db *database.Database,
-	id uint64,
 	hash []byte,
 	number uint64,
 ) {
 	t.Helper()
 	require.NoError(t, db.BlockCreate(models.Block{
-		ID:     id,
+		ID:     number + database.BlockInitialIndex,
 		Hash:   hash,
 		Slot:   number,
 		Number: number,
@@ -297,8 +310,8 @@ func TestNodeAdapterAccountWithdrawals(t *testing.T) {
 		Active:        true,
 	}).Error)
 
-	createTestBlock(t, db, 1, fill32(0xb1), 100)
-	createTestBlock(t, db, 2, fill32(0xb2), 200)
+	createTestBlock(t, db, fill32(0xb1), 100)
+	createTestBlock(t, db, fill32(0xb2), 200)
 
 	require.NoError(t, store.DB().Create(&models.Transaction{
 		Hash: fill32(0x01), BlockHash: fill32(0xb1), Slot: 0, BlockIndex: 0,
@@ -411,6 +424,58 @@ func TestNodeAdapterAccountWithdrawalsQueryFailure(t *testing.T) {
 
 // --- AccountTransactions ---
 
+// createAccountTransactionFixture creates a Transaction row (with an
+// explicit ID) and its corresponding AddressTransaction association row
+// under the given stake credential and payment key, mirroring what the
+// real indexer populates for one (payment address, transaction) pair.
+// slot/txIndex are shared by both rows exactly as production indexing
+// does, since the account-transactions query filters and orders using
+// address_transaction's own (slot, tx_index) columns.
+func createAccountTransactionFixture(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	txID uint,
+	txHash []byte,
+	blockHash []byte,
+	slot uint64,
+	txIndex uint32,
+	paymentKey []byte,
+	stakeKey []byte,
+	credentialTag uint8,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.Transaction{
+		ID: txID, Hash: txHash, BlockHash: blockHash,
+		Slot: slot, BlockIndex: txIndex,
+	}).Error)
+	addAccountTransactionAssociation(
+		t, store, txID, slot, txIndex, paymentKey, stakeKey, credentialTag,
+	)
+}
+
+// addAccountTransactionAssociation creates one more AddressTransaction
+// association row for a transaction that already exists (e.g. a second
+// output of the same transaction paying a different address under the
+// same stake credential), without re-creating the Transaction row (whose
+// hash is unique).
+func addAccountTransactionAssociation(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	txID uint,
+	slot uint64,
+	txIndex uint32,
+	paymentKey []byte,
+	stakeKey []byte,
+	credentialTag uint8,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.AddressTransaction{
+		PaymentKey: paymentKey, StakingKey: stakeKey,
+		CredentialTag: credentialTag, TransactionID: txID,
+		Slot: slot, TxIndex: txIndex,
+	}).Error)
+}
+
 func TestNodeAdapterAccountTransactions(t *testing.T) {
 	adapter, store, db := newDBBackedAccountAdapter(t)
 
@@ -421,106 +486,70 @@ func TestNodeAdapterAccountTransactions(t *testing.T) {
 		Active:        true,
 	}).Error)
 
-	createTestBlock(t, db, 1, fill32(0xc1), 100)
-	createTestBlock(t, db, 2, fill32(0xc2), 101)
-	createTestBlock(t, db, 3, fill32(0xc3), 105)
+	// Blocks at heights 100, 101, and 105; slot mirrors height for
+	// readability (only their relative order matters here).
+	createTestBlock(t, db, fill32(0xc1), 100)
+	createTestBlock(t, db, fill32(0xc2), 101)
+	createTestBlock(t, db, fill32(0xc3), 105)
 
+	addr1Payment := bytes.Repeat([]byte{0x01}, lcommon.AddressHashSize)
+	addr2Payment := bytes.Repeat([]byte{0x02}, lcommon.AddressHashSize)
 	addr1, err := lcommon.NewAddressFromParts(
 		lcommon.AddressTypeKeyKey,
 		lcommon.AddressNetworkTestnet,
-		bytes.Repeat([]byte{0x01}, lcommon.AddressHashSize),
+		addr1Payment,
 		stakeKey,
 	)
 	require.NoError(t, err)
 	addr2, err := lcommon.NewAddressFromParts(
 		lcommon.AddressTypeKeyKey,
 		lcommon.AddressNetworkTestnet,
-		bytes.Repeat([]byte{0x02}, lcommon.AddressHashSize),
+		addr2Payment,
 		stakeKey,
 	)
 	require.NoError(t, err)
 
-	// tx1 in block 100, output under addr1.
-	txID1 := uint(1)
-	require.NoError(t, store.DB().Create(&models.Transaction{
-		ID: txID1, Hash: fill32(0x01), BlockHash: fill32(0xc1),
-		Slot: 0, BlockIndex: 0,
-		Outputs: []models.Utxo{{
-			TxId: fill32(0x01), OutputIdx: 0,
-			PaymentKey: addr1.PaymentKeyHash().Bytes(),
-			StakingKey: stakeKey, CredentialTag: 0,
-			Amount: types.Uint64(1_000_000),
-		}},
+	// A UTxO row per payment key backs the GetUtxoPaymentScriptByCredential
+	// lookup the adapter uses to reconstruct each row's exact address;
+	// both are plain key-hash payment credentials here (PaymentScript
+	// defaults false).
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId: fill32(0x01), OutputIdx: 0,
+		PaymentKey: addr1Payment, StakingKey: stakeKey, CredentialTag: 0,
+		Amount: types.Uint64(1_000_000),
+	}).Error)
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId: fill32(0x02), OutputIdx: 1,
+		PaymentKey: addr2Payment, StakingKey: stakeKey, CredentialTag: 0,
+		Amount: types.Uint64(700_000),
 	}).Error)
 
-	// tx2 in block 101, two outputs under addr1 and addr2 (must yield two
-	// distinct rows, not a duplicate of the same association).
-	txID2 := uint(2)
-	require.NoError(t, store.DB().Create(&models.Transaction{
-		ID: txID2, Hash: fill32(0x02), BlockHash: fill32(0xc2),
-		Slot: 0, BlockIndex: 2,
-		Outputs: []models.Utxo{
-			{
-				TxId: fill32(0x02), OutputIdx: 0,
-				PaymentKey: addr1.PaymentKeyHash().Bytes(),
-				StakingKey: stakeKey, CredentialTag: 0,
-				Amount: types.Uint64(500_000),
-			},
-			{
-				TxId: fill32(0x02), OutputIdx: 1,
-				PaymentKey: addr2.PaymentKeyHash().Bytes(),
-				StakingKey: stakeKey, CredentialTag: 0,
-				Amount: types.Uint64(700_000),
-			},
-			// A second output to addr1 in the same tx must not duplicate
-			// the (address, tx) association already captured above.
-			{
-				TxId: fill32(0x02), OutputIdx: 2,
-				PaymentKey: addr1.PaymentKeyHash().Bytes(),
-				StakingKey: stakeKey, CredentialTag: 0,
-				Amount: types.Uint64(1),
-			},
-		},
-	}).Error)
+	// tx1 in block 100 (slot 100), one association with addr1.
+	createAccountTransactionFixture(
+		t, store, 1, fill32(0x01), fill32(0xc1), 100, 0,
+		addr1Payment, stakeKey, 0,
+	)
+	// tx2 in block 101 (slot 101), associations with both addr1 and addr2
+	// (two outputs sharing the credential in one tx must yield two rows,
+	// not a duplicate of the same association -- and a second output to
+	// addr1 in the same tx, represented by inserting the addr1 row only
+	// once here, must not create a third row for the same pair).
+	createAccountTransactionFixture(
+		t, store, 2, fill32(0x02), fill32(0xc2), 101, 2,
+		addr1Payment, stakeKey, 0,
+	)
+	addAccountTransactionAssociation(
+		t, store, 2, 101, 2, addr2Payment, stakeKey, 0,
+	)
 
 	// tx3 in block 105 under a different stake credential; must never
 	// appear in results.
 	otherStakeKey := bytes.Repeat([]byte{0x88}, lcommon.AddressHashSize)
-	txID3 := uint(3)
-	require.NoError(t, store.DB().Create(&models.Transaction{
-		ID: txID3, Hash: fill32(0x03), BlockHash: fill32(0xc3),
-		Slot: 0, BlockIndex: 0,
-		Outputs: []models.Utxo{{
-			TxId: fill32(0x03), OutputIdx: 0,
-			PaymentKey: bytes.Repeat([]byte{0x09}, lcommon.AddressHashSize),
-			StakingKey: otherStakeKey, CredentialTag: 0,
-			Amount: types.Uint64(1),
-		}},
-	}).Error)
-	// Also index the address associations, mirroring what the real
-	// indexing path populates for GetTransactionsByAddressKeys/
-	// CountTransactionsByAddressKeys to select from.
-	for _, at := range []models.AddressTransaction{
-		{
-			PaymentKey: addr1.PaymentKeyHash().Bytes(), StakingKey: stakeKey,
-			CredentialTag: 0, TransactionID: txID1, Slot: 0, TxIndex: 0,
-		},
-		{
-			PaymentKey: addr1.PaymentKeyHash().Bytes(), StakingKey: stakeKey,
-			CredentialTag: 0, TransactionID: txID2, Slot: 0, TxIndex: 2,
-		},
-		{
-			PaymentKey: addr2.PaymentKeyHash().Bytes(), StakingKey: stakeKey,
-			CredentialTag: 0, TransactionID: txID2, Slot: 0, TxIndex: 2,
-		},
-		{
-			PaymentKey:    bytes.Repeat([]byte{0x09}, lcommon.AddressHashSize),
-			StakingKey:    otherStakeKey,
-			CredentialTag: 0, TransactionID: txID3, Slot: 0, TxIndex: 0,
-		},
-	} {
-		require.NoError(t, store.DB().Create(&at).Error)
-	}
+	createAccountTransactionFixture(
+		t, store, 4, fill32(0x03), fill32(0xc3), 105, 0,
+		bytes.Repeat([]byte{0x09}, lcommon.AddressHashSize),
+		otherStakeKey, 0,
+	)
 
 	rows, total, err := adapter.AccountTransactions(
 		stakeAddress,
@@ -535,7 +564,7 @@ func TestNodeAdapterAccountTransactions(t *testing.T) {
 	require.Len(t, rows, 3)
 
 	// Ascending chain order: tx1 (block 100) first, then the two addr1/addr2
-	// rows for tx2 (block 101), sorted deterministically by address.
+	// rows for tx2 (block 101), sorted deterministically by payment key.
 	assert.Equal(t, hex.EncodeToString(fill32(0x01)), rows[0].TxHash)
 	assert.Equal(t, addr1.String(), rows[0].Address)
 	assert.Equal(t, uint64(100), rows[0].BlockHeight)
@@ -549,7 +578,7 @@ func TestNodeAdapterAccountTransactions(t *testing.T) {
 		assert.Equal(t, uint32(2), r.TxIndex)
 	}
 
-	// from=101 excludes tx1 (block 100).
+	// from=101 excludes tx1 (block 100, slot 100 < resolved from-slot 101).
 	fromRows, total, err := adapter.AccountTransactions(
 		stakeAddress,
 		AccountTransactionsParams{
@@ -561,11 +590,13 @@ func TestNodeAdapterAccountTransactions(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
+	require.Len(t, fromRows, 2)
 	for _, r := range fromRows {
 		assert.NotEqual(t, hex.EncodeToString(fill32(0x01)), r.TxHash)
 	}
 
-	// to=100 keeps only tx1.
+	// to=100 keeps only tx1 (slot 100 <= resolved to-slot 100; tx2's slot
+	// 101 is excluded).
 	toRows, total, err := adapter.AccountTransactions(
 		stakeAddress,
 		AccountTransactionsParams{
@@ -596,6 +627,54 @@ func TestNodeAdapterAccountTransactions(t *testing.T) {
 	assert.Equal(t, 0, total)
 	assert.Empty(t, noneRows)
 
+	// from=101:2 (exactly tx2's index) still includes tx2: the range is
+	// inclusive at the boundary.
+	idx2 := uint32(2)
+	exactRows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+			From: &BlockRangePosition{Block: 101, Index: &idx2},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, exactRows, 2)
+
+	// to=101:1 (before tx2's index of 2) excludes tx2, leaving only tx1.
+	idx1 := uint32(1)
+	beforeIdxRows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+			To: &BlockRangePosition{Block: 101, Index: &idx1},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, beforeIdxRows, 1)
+	assert.Equal(t, hex.EncodeToString(fill32(0x01)), beforeIdxRows[0].TxHash)
+
+	// An inverted-looking from/to still resolves each side independently
+	// (the handler rejects a genuinely inverted range before this is ever
+	// called; a from beyond every known block is unsatisfiable on its own).
+	fromBeyondTip, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+			From: &BlockRangePosition{Block: 999},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, fromBeyondTip)
+
 	// Pagination over the expanded (address, tx) row set.
 	paged, total, err := adapter.AccountTransactions(
 		stakeAddress,
@@ -608,6 +687,122 @@ func TestNodeAdapterAccountTransactions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, total)
 	require.Len(t, paged, 1)
+}
+
+// TestNodeAdapterAccountTransactionsScriptPaymentCredential verifies that a
+// script payment credential (as opposed to the default key-hash
+// assumption AccountAssociatedAddresses makes) is reconstructed correctly,
+// using GetUtxoPaymentScriptByCredential rather than decoding UTxO CBOR.
+func TestNodeAdapterAccountTransactionsScriptPaymentCredential(t *testing.T) {
+	adapter, store, db := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x66)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+	createTestBlock(t, db, fill32(0xd1), 50)
+
+	scriptPayment := bytes.Repeat([]byte{0x0a}, lcommon.AddressHashSize)
+	wantAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptKey,
+		lcommon.AddressNetworkTestnet,
+		scriptPayment,
+		stakeKey,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, store.DB().Create(&models.Utxo{
+		TxId: fill32(0x10), OutputIdx: 0,
+		PaymentKey: scriptPayment, StakingKey: stakeKey, CredentialTag: 0,
+		PaymentScript: true,
+		Amount:        types.Uint64(1),
+	}).Error)
+	createAccountTransactionFixture(
+		t, store, 1, fill32(0x10), fill32(0xd1), 50, 0,
+		scriptPayment, stakeKey, 0,
+	)
+
+	rows, total, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 100, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, rows, 1)
+	assert.Equal(t, wantAddr.String(), rows[0].Address)
+}
+
+// TestNodeAdapterAccountTransactionsBounded is the regression test for the
+// unbounded-history bug: per-request work must be bounded by the requested
+// page size, not by the credential's full transaction history. It creates
+// five transactions, each in its own block, but only creates a Block row
+// for the one transaction that will actually appear on a count=1 page. If
+// the implementation resolved block height for every matching transaction
+// up front (the original bug), it would fail looking up one of the four
+// missing blocks before pagination ever discarded them; a correctly
+// bounded implementation only resolves the page's own transaction's block
+// and succeeds.
+func TestNodeAdapterAccountTransactionsBounded(t *testing.T) {
+	adapter, store, db := newDBBackedAccountAdapter(t)
+
+	stakeAddress, stakeKey := testStakeCredential(t, 0x55)
+	require.NoError(t, store.DB().Create(&models.Account{
+		StakingKey:    stakeKey,
+		CredentialTag: 0,
+		Active:        true,
+	}).Error)
+
+	const total = 5
+	// Only the first (oldest, ascending-order-first) transaction's block
+	// is ever created; the other four blocks are deliberately absent.
+	createTestBlock(t, db, fill32(0xe0), 0)
+
+	for i := range total {
+		paymentKey := bytes.Repeat([]byte{byte(0x20 + i)}, lcommon.AddressHashSize)
+		blockHash := fill32(byte(0xe0 + i))
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TxId: fill32(byte(i)), OutputIdx: 0,
+			PaymentKey: paymentKey, StakingKey: stakeKey, CredentialTag: 0,
+			Amount: types.Uint64(1),
+		}).Error)
+		createAccountTransactionFixture(
+			t, store, uint(i+1), fill32(byte(i)), blockHash,
+			uint64(i), 0, paymentKey, stakeKey, 0,
+		)
+	}
+
+	rows, gotTotal, err := adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 1, Page: 1, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, total, gotTotal)
+	require.Len(t, rows, 1)
+	assert.Equal(t, hex.EncodeToString(fill32(0)), rows[0].TxHash)
+
+	// A later page whose transaction's block is also missing must fail:
+	// this confirms the test's missing-block setup would actually have
+	// caught the original bug (it only "passes" the count=1/page=1 case
+	// above because that happens to be the one block that exists).
+	_, _, err = adapter.AccountTransactions(
+		stakeAddress,
+		AccountTransactionsParams{
+			Pagination: PaginationParams{
+				Count: 1, Page: 2, Order: PaginationOrderAsc,
+			},
+		},
+	)
+	require.Error(t, err)
 }
 
 func TestNodeAdapterAccountTransactionsEmpty(t *testing.T) {

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -228,6 +228,18 @@ func (b *Blockfrost) handler() http.Handler {
 		"GET /api/v0/accounts/{stake_address}/rewards",
 		b.handleAccountRewardHistory,
 	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/utxos",
+		b.handleAccountUTXOs,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/withdrawals",
+		b.handleAccountWithdrawals,
+	)
+	mux.HandleFunc(
+		"GET /api/v0/accounts/{stake_address}/transactions",
+		b.handleAccountTransactions,
+	)
 
 	// Catch-all for any path not matched above. Registered
 	// last so more specific patterns still take precedence;

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -469,42 +469,45 @@ func (m *mockNode) AccountRewardHistory(
 	return items[start:end], total, m.rewardsErr
 }
 
-func (m *mockNode) AccountUTXOs(
-	_ string,
-	params PaginationParams,
-) ([]AccountUTXOInfo, int, error) {
-	items := append([]AccountUTXOInfo(nil), m.accountUTXOs...)
+// mockPage applies the same in-memory ordering/pagination every
+// mockNode paginated-list method needs: reverse for desc, then slice out
+// the requested page. It only handles the shared count/page/order
+// mechanics; each caller still owns picking its own backing slice and
+// error field, since those differ per endpoint.
+func mockPage[T any](items []T, order string, page, count int) ([]T, int) {
+	items = append([]T(nil), items...)
 	total := len(items)
-	if params.Order == PaginationOrderDesc {
+	if order == PaginationOrderDesc {
 		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
 			items[i], items[j] = items[j], items[i]
 		}
 	}
-	start := (params.Page - 1) * params.Count
+	start := (page - 1) * count
 	if start >= total {
-		return []AccountUTXOInfo{}, total, m.accountUTXOsErr
+		return []T{}, total
 	}
-	end := min(start+params.Count, total)
-	return items[start:end], total, m.accountUTXOsErr
+	end := min(start+count, total)
+	return items[start:end], total
+}
+
+func (m *mockNode) AccountUTXOs(
+	_ string,
+	params PaginationParams,
+) ([]AccountUTXOInfo, int, error) {
+	rows, total := mockPage(
+		m.accountUTXOs, params.Order, params.Page, params.Count,
+	)
+	return rows, total, m.accountUTXOsErr
 }
 
 func (m *mockNode) AccountWithdrawals(
 	_ string,
 	params PaginationParams,
 ) ([]AccountWithdrawalInfo, int, error) {
-	items := append([]AccountWithdrawalInfo(nil), m.accountWithdrawals...)
-	total := len(items)
-	if params.Order == PaginationOrderDesc {
-		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
-			items[i], items[j] = items[j], items[i]
-		}
-	}
-	start := (params.Page - 1) * params.Count
-	if start >= total {
-		return []AccountWithdrawalInfo{}, total, m.accountWithdrawalsErr
-	}
-	end := min(start+params.Count, total)
-	return items[start:end], total, m.accountWithdrawalsErr
+	rows, total := mockPage(
+		m.accountWithdrawals, params.Order, params.Page, params.Count,
+	)
+	return rows, total, m.accountWithdrawalsErr
 }
 
 func (m *mockNode) AccountTransactions(
@@ -512,19 +515,13 @@ func (m *mockNode) AccountTransactions(
 	params AccountTransactionsParams,
 ) ([]AccountTransactionInfo, int, error) {
 	m.lastAccountTransactionsParams = params
-	items := append([]AccountTransactionInfo(nil), m.accountTransactions...)
-	total := len(items)
-	if params.Pagination.Order == PaginationOrderDesc {
-		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
-			items[i], items[j] = items[j], items[i]
-		}
-	}
-	start := (params.Pagination.Page - 1) * params.Pagination.Count
-	if start >= total {
-		return []AccountTransactionInfo{}, total, m.accountTransactionsErr
-	}
-	end := min(start+params.Pagination.Count, total)
-	return items[start:end], total, m.accountTransactionsErr
+	rows, total := mockPage(
+		m.accountTransactions,
+		params.Pagination.Order,
+		params.Pagination.Page,
+		params.Pagination.Count,
+	)
+	return rows, total, m.accountTransactionsErr
 }
 
 func newTestBlockfrost(

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -109,6 +109,10 @@ type mockNode struct {
 	delegations                   []AccountDelegationHistoryInfo
 	regs                          []AccountRegistrationHistoryInfo
 	rewards                       []AccountRewardHistoryInfo
+	accountUTXOs                  []AccountUTXOInfo
+	accountWithdrawals            []AccountWithdrawalInfo
+	accountTransactions           []AccountTransactionInfo
+	lastAccountTransactionsParams AccountTransactionsParams
 	chainTipErr                   error
 	blockErr                      error
 	blockByIDErr                  error
@@ -150,6 +154,9 @@ type mockNode struct {
 	delegationsErr                error
 	regsErr                       error
 	rewardsErr                    error
+	accountUTXOsErr               error
+	accountWithdrawalsErr         error
+	accountTransactionsErr        error
 }
 
 func (m *mockNode) ChainTip() (
@@ -460,6 +467,64 @@ func (m *mockNode) AccountRewardHistory(
 	}
 	end := min(start+params.Count, total)
 	return items[start:end], total, m.rewardsErr
+}
+
+func (m *mockNode) AccountUTXOs(
+	_ string,
+	params PaginationParams,
+) ([]AccountUTXOInfo, int, error) {
+	items := append([]AccountUTXOInfo(nil), m.accountUTXOs...)
+	total := len(items)
+	if params.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountUTXOInfo{}, total, m.accountUTXOsErr
+	}
+	end := min(start+params.Count, total)
+	return items[start:end], total, m.accountUTXOsErr
+}
+
+func (m *mockNode) AccountWithdrawals(
+	_ string,
+	params PaginationParams,
+) ([]AccountWithdrawalInfo, int, error) {
+	items := append([]AccountWithdrawalInfo(nil), m.accountWithdrawals...)
+	total := len(items)
+	if params.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []AccountWithdrawalInfo{}, total, m.accountWithdrawalsErr
+	}
+	end := min(start+params.Count, total)
+	return items[start:end], total, m.accountWithdrawalsErr
+}
+
+func (m *mockNode) AccountTransactions(
+	_ string,
+	params AccountTransactionsParams,
+) ([]AccountTransactionInfo, int, error) {
+	m.lastAccountTransactionsParams = params
+	items := append([]AccountTransactionInfo(nil), m.accountTransactions...)
+	total := len(items)
+	if params.Pagination.Order == PaginationOrderDesc {
+		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+			items[i], items[j] = items[j], items[i]
+		}
+	}
+	start := (params.Pagination.Page - 1) * params.Pagination.Count
+	if start >= total {
+		return []AccountTransactionInfo{}, total, m.accountTransactionsErr
+	}
+	end := min(start+params.Pagination.Count, total)
+	return items[start:end], total, m.accountTransactionsErr
 }
 
 func newTestBlockfrost(

--- a/api/blockfrost/handlers_account_activity.go
+++ b/api/blockfrost/handlers_account_activity.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ErrInvalidBlockRange is returned when a from/to query value is not a
+// valid block number or "block:index" position.
+var ErrInvalidBlockRange = errors.New("invalid block range position")
+
+// handleAccountUTXOs handles GET /api/v0/accounts/{stake_address}/utxos
+// and returns the current UTxOs controlled by the stake credential.
+func (b *Blockfrost) handleAccountUTXOs(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	items, total, err := b.node.AccountUTXOs(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(w, err, "failed to retrieve account UTxOs")
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make([]AccountUTXOResponse, 0, len(items))
+	for _, item := range items {
+		resp = append(resp, AccountUTXOResponse{
+			Address:             item.Address,
+			TxHash:              item.TxHash,
+			TxIndex:             int(item.TxIndex),
+			OutputIndex:         int(item.OutputIndex),
+			Amount:              convertAddressAmounts(item.Amount),
+			Block:               item.Block,
+			DataHash:            item.DataHash,
+			InlineDatum:         item.InlineDatum,
+			ReferenceScriptHash: item.ReferenceScriptHash,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleAccountWithdrawals handles
+// GET /api/v0/accounts/{stake_address}/withdrawals and returns
+// withdrawal history for the stake credential.
+func (b *Blockfrost) handleAccountWithdrawals(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	items, total, err := b.node.AccountWithdrawals(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(
+			w, err, "failed to retrieve account withdrawals",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, params)
+	resp := make([]AccountWithdrawalResponse, 0, len(items))
+	for _, item := range items {
+		resp = append(resp, AccountWithdrawalResponse(item))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleAccountTransactions handles
+// GET /api/v0/accounts/{stake_address}/transactions and returns
+// transactions associated with addresses controlled by the stake
+// credential, optionally filtered by an inclusive from/to block range.
+func (b *Blockfrost) handleAccountTransactions(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	pagination, err := ParsePagination(r)
+	if err != nil {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"Invalid pagination parameters.",
+		)
+		return
+	}
+	params := AccountTransactionsParams{Pagination: pagination}
+
+	query := r.URL.Query()
+	if raw := query.Get("from"); raw != "" {
+		pos, err := parseBlockRangePosition(raw)
+		if err != nil {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"querystring/from must be a block number, "+
+					`optionally suffixed with ":index".`,
+			)
+			return
+		}
+		params.From = &pos
+	}
+	if raw := query.Get("to"); raw != "" {
+		pos, err := parseBlockRangePosition(raw)
+		if err != nil {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"querystring/to must be a block number, "+
+					`optionally suffixed with ":index".`,
+			)
+			return
+		}
+		params.To = &pos
+	}
+	if params.From != nil && params.To != nil &&
+		blockRangeInverted(*params.From, *params.To) {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"querystring/from must be lower than or equal to querystring/to.",
+		)
+		return
+	}
+
+	items, total, err := b.node.AccountTransactions(
+		r.PathValue("stake_address"),
+		params,
+	)
+	if err != nil {
+		b.writeAccountError(
+			w, err, "failed to retrieve account transactions",
+		)
+		return
+	}
+	SetPaginationHeaders(w, total, pagination)
+	resp := make([]AccountTransactionResponse, 0, len(items))
+	for _, item := range items {
+		resp = append(resp, AccountTransactionResponse{
+			Address:     item.Address,
+			TxHash:      item.TxHash,
+			TxIndex:     int(item.TxIndex),
+			BlockHeight: item.BlockHeight,
+			BlockTime:   int(item.BlockTime),
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// parseBlockRangePosition parses the Blockfrost account-transactions
+// from/to query value: a block number, optionally suffixed with
+// ":index" giving the transaction's index within that block.
+func parseBlockRangePosition(raw string) (BlockRangePosition, error) {
+	block, indexPart, hasIndex := strings.Cut(raw, ":")
+	blockNumber, err := strconv.ParseUint(block, 10, 64)
+	if err != nil {
+		return BlockRangePosition{}, ErrInvalidBlockRange
+	}
+	if !hasIndex {
+		return BlockRangePosition{Block: blockNumber}, nil
+	}
+	index, err := strconv.ParseUint(indexPart, 10, 32)
+	if err != nil {
+		return BlockRangePosition{}, ErrInvalidBlockRange
+	}
+	idx := uint32(index)
+	return BlockRangePosition{Block: blockNumber, Index: &idx}, nil
+}
+
+// blockRangeInverted reports whether from is unambiguously after to,
+// i.e. the requested range is empty by construction. Same-block
+// comparisons where only one side carries an explicit index are treated
+// as valid (not inverted): the adapter-level filter resolves the exact
+// boundary in that case.
+func blockRangeInverted(from, to BlockRangePosition) bool {
+	if from.Block > to.Block {
+		return true
+	}
+	if from.Block < to.Block {
+		return false
+	}
+	return from.Index != nil && to.Index != nil && *from.Index > *to.Index
+}

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -199,6 +199,29 @@ type BlockfrostNode interface {
 		string,
 		PaginationParams,
 	) ([]AccountRewardHistoryInfo, int, error)
+
+	// AccountUTXOs returns the current UTxOs controlled by the
+	// stake credential behind the requested stake address.
+	AccountUTXOs(
+		string,
+		PaginationParams,
+	) ([]AccountUTXOInfo, int, error)
+
+	// AccountWithdrawals returns withdrawal history rows for
+	// the requested stake address.
+	AccountWithdrawals(
+		string,
+		PaginationParams,
+	) ([]AccountWithdrawalInfo, int, error)
+
+	// AccountTransactions returns transactions associated with
+	// addresses controlled by the stake credential behind the
+	// requested stake address, optionally filtered by an
+	// inclusive from/to block-range position.
+	AccountTransactions(
+		string,
+		AccountTransactionsParams,
+	) ([]AccountTransactionInfo, int, error)
 }
 
 // ChainTipInfo holds chain tip data needed by the API.
@@ -757,4 +780,57 @@ type AccountRewardHistoryInfo struct {
 	Epoch  int32
 	Amount string
 	PoolID string
+}
+
+// AccountUTXOInfo holds a stake-account UTxO row.
+type AccountUTXOInfo struct {
+	Address string
+	TxHash  string
+	// TxIndex is the deprecated Blockfrost alias for OutputIndex (the UTxO's
+	// index within its producing transaction); it carries the same value.
+	TxIndex             uint32
+	OutputIndex         uint32
+	Amount              []AddressAmountInfo
+	Block               string
+	DataHash            *string
+	InlineDatum         *string
+	ReferenceScriptHash *string
+}
+
+// AccountWithdrawalInfo holds a stake-account withdrawal
+// history row.
+type AccountWithdrawalInfo struct {
+	TxHash      string
+	Amount      string
+	TxSlot      int64
+	BlockTime   int64
+	BlockHeight int64
+}
+
+// BlockRangePosition holds a parsed Blockfrost account-transactions
+// from/to query value: a block number and an optional transaction
+// index within that block (the "block:index" form).
+type BlockRangePosition struct {
+	Block uint64
+	Index *uint32
+}
+
+// AccountTransactionsParams holds query parameters for the account
+// transactions endpoint: standard pagination plus the optional
+// inclusive from/to block-range filter.
+type AccountTransactionsParams struct {
+	Pagination PaginationParams
+	From       *BlockRangePosition
+	To         *BlockRangePosition
+}
+
+// AccountTransactionInfo holds a stake-account transaction row: one
+// entry per distinct address (sharing the stake credential) involved in
+// the transaction.
+type AccountTransactionInfo struct {
+	Address     string
+	TxHash      string
+	TxIndex     uint32
+	BlockHeight uint64
+	BlockTime   int64
 }

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -582,3 +582,39 @@ type AccountRewardHistoryResponse struct {
 	Amount string `json:"amount"`
 	PoolID string `json:"pool_id"`
 }
+
+// AccountUTXOResponse represents a Blockfrost stake-account
+// UTxO object.
+type AccountUTXOResponse struct {
+	Address string `json:"address"`
+	TxHash  string `json:"tx_hash"`
+	// TxIndex is a deprecated Blockfrost alias for OutputIndex ("UTXO index
+	// in the transaction"), kept for schema compatibility.
+	TxIndex             int                     `json:"tx_index"`
+	OutputIndex         int                     `json:"output_index"`
+	Amount              []AddressAmountResponse `json:"amount"`
+	Block               string                  `json:"block"`
+	DataHash            *string                 `json:"data_hash"`
+	InlineDatum         *string                 `json:"inline_datum"`
+	ReferenceScriptHash *string                 `json:"reference_script_hash"`
+}
+
+// AccountWithdrawalResponse represents a stake-account
+// withdrawal history row.
+type AccountWithdrawalResponse struct {
+	TxHash      string `json:"tx_hash"`
+	Amount      string `json:"amount"`
+	TxSlot      int64  `json:"tx_slot"`
+	BlockTime   int64  `json:"block_time"`
+	BlockHeight int64  `json:"block_height"`
+}
+
+// AccountTransactionResponse represents a stake-account
+// transaction object.
+type AccountTransactionResponse struct {
+	Address     string `json:"address"`
+	TxHash      string `json:"tx_hash"`
+	TxIndex     int    `json:"tx_index"`
+	BlockHeight uint64 `json:"block_height"`
+	BlockTime   int    `json:"block_time"`
+}

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -132,6 +132,62 @@ func (d *Database) CountAccountRegistrationHistoryByCredential(
 	return count, nil
 }
 
+// GetAccountWithdrawalHistoryByCredential returns withdrawal history rows for
+// a stake credential.
+func (d *Database) GetAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn *Txn,
+) ([]models.AccountWithdrawalHistoryRow, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	rows, err := d.metadata.GetAccountWithdrawalHistoryByCredential(
+		credentialTag,
+		stakeKey,
+		limit,
+		offset,
+		order,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get account withdrawal history: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// CountAccountWithdrawalHistoryByCredential returns the total number of
+// withdrawal history rows for a stake credential.
+func (d *Database) CountAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountAccountWithdrawalHistoryByCredential(
+		credentialTag,
+		stakeKey,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account withdrawal history: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 // GetAccountSumsByCredential returns the aggregated withdrawal, reserves, and
 // treasury lovelace totals for a stake credential.
 func (d *Database) GetAccountSumsByCredential(

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -188,6 +188,72 @@ func (d *Database) CountAccountWithdrawalHistoryByCredential(
 	return count, nil
 }
 
+// GetAddressTransactionsByCredential returns one page of (payment address,
+// transaction) association rows for a stake credential, optionally bounded
+// by an inclusive from/to (slot, tx_index) range.
+func (d *Database) GetAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	limit int,
+	offset int,
+	order string,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn *Txn,
+) ([]models.AccountTransactionAssociationRow, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	rows, err := d.metadata.GetAddressTransactionsByCredential(
+		credentialTag,
+		stakeKey,
+		limit,
+		offset,
+		order,
+		from,
+		to,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get address transactions by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+// CountAddressTransactionsByCredential returns the total number of
+// (payment address, transaction) association rows for a stake credential
+// within the same optional from/to range.
+func (d *Database) CountAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakeKey []byte,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	count, err := d.metadata.CountAddressTransactionsByCredential(
+		credentialTag,
+		stakeKey,
+		from,
+		to,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count address transactions by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 // GetAccountSumsByCredential returns the aggregated withdrawal, reserves, and
 // treasury lovelace totals for a stake credential.
 func (d *Database) GetAccountSumsByCredential(

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -73,6 +73,36 @@ type AccountWithdrawalHistoryRow struct {
 	BlockHash []byte
 }
 
+// AddressTransactionPosition is an inclusive (slot, tx_index) boundary
+// used to filter address_transaction rows for the Blockfrost account
+// transactions endpoint's from/to block-range query. Both fields are
+// compared as one tuple: a row qualifies as a lower bound when its (slot,
+// tx_index) is greater than or equal to this position, and as an upper
+// bound when it is less than or equal to it.
+type AddressTransactionPosition struct {
+	Slot    uint64
+	TxIndex uint32
+}
+
+// AccountTransactionAssociationRow holds one (payment address,
+// transaction) association row for a stake credential, backing the
+// Blockfrost account transactions endpoint. It is the direct, final page
+// of results: ordering, the from/to range filter, and LIMIT/OFFSET are
+// all applied in SQL, so building a response from these rows does not
+// require any further application-level fan-out or filtering.
+type AccountTransactionAssociationRow struct {
+	PaymentKey []byte
+	TxHash     []byte
+	// TxSlot and TxIndex are the transaction's position, used for
+	// ordering and from/to range filtering.
+	TxSlot  uint64
+	TxIndex uint32
+	// BlockHash is the hash of the block containing the transaction. The
+	// block height is resolved from the block store, which is not part
+	// of the metadata SQL schema.
+	BlockHash []byte
+}
+
 // AccountSums holds aggregated lovelace totals for a stake
 // account, summed from persisted withdrawal and MIR state.
 type AccountSums struct {

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -54,6 +54,25 @@ type AccountRegistrationHistoryRow struct {
 	BlockHash []byte
 }
 
+// AccountWithdrawalHistoryRow holds withdrawal history
+// query results for a stake account.
+type AccountWithdrawalHistoryRow struct {
+	TxHash []byte
+	Amount uint64
+	// TxSlot is the slot of the transaction containing the
+	// withdrawal.
+	TxSlot uint64
+	// BlockIndex is the withdrawal transaction's position within
+	// its containing block, used as an ordering tie-break for
+	// transactions sharing a slot.
+	BlockIndex uint32
+	// BlockHash is the hash of the block containing the
+	// withdrawal transaction. The block height is resolved from
+	// the block store, which is not part of the metadata SQL
+	// schema.
+	BlockHash []byte
+}
+
 // AccountSums holds aggregated lovelace totals for a stake
 // account, summed from persisted withdrawal and MIR state.
 type AccountSums struct {

--- a/database/models/address_transaction.go
+++ b/database/models/address_transaction.go
@@ -14,18 +14,74 @@
 
 package models
 
+import (
+	"fmt"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
 // AddressTransaction maps an address (payment and/or staking key) to a
 // transaction that references it as an input/output participant.
 type AddressTransaction struct {
-	ID            uint   `gorm:"primaryKey"`
-	PaymentKey    []byte `gorm:"index:idx_addr_tx_payment;size:28"`
-	StakingKey    []byte `gorm:"index:idx_addr_tx_staking,priority:2;size:28"`
-	CredentialTag uint8  `gorm:"not null;default:0;index:idx_addr_tx_staking,priority:1"`
+	ID uint `gorm:"primaryKey"`
+	// PaymentKey backs bare payment-credential lookups (idx_addr_tx_payment,
+	// regardless of staking part) and, as idx_addr_tx_stake_position's
+	// trailing column, gives a deterministic tie-break between several
+	// addresses that share one transaction under the same stake credential.
+	PaymentKey    []byte `gorm:"index:idx_addr_tx_payment;size:28;index:idx_addr_tx_stake_position,priority:5"`
+	StakingKey    []byte `gorm:"size:28;index:idx_addr_tx_stake_position,priority:2"`
+	CredentialTag uint8  `gorm:"not null;default:0;index:idx_addr_tx_stake_position,priority:1"`
 	TransactionID uint   `gorm:"index"`
-	Slot          uint64 `gorm:"index"`
-	TxIndex       uint32
+	// Slot keeps its own single-column index (used by
+	// DeleteAddressTransactionsAfterSlot's unscoped rollback cleanup, "WHERE
+	// slot > ?" with no credential filter) in addition to participating in
+	// idx_addr_tx_stake_position.
+	Slot uint64 `gorm:"index;index:idx_addr_tx_stake_position,priority:3"`
+	// TxIndex has no standalone index: it is only ever queried together with
+	// the stake credential and slot, via idx_addr_tx_stake_position.
+	TxIndex uint32 `gorm:"index:idx_addr_tx_stake_position,priority:4"`
 }
 
 func (AddressTransaction) TableName() string {
 	return "address_transaction"
+}
+
+// MigrateAddressTransactionStakePositionIndex drops the legacy
+// credential_tag/staking_key-only index (idx_addr_tx_staking) once
+// idx_addr_tx_stake_position exists to take over its role. AutoMigrate
+// creates idx_addr_tx_stake_position on its own (it is a new index name
+// that does not previously exist), so this helper's only job is removing
+// the now-redundant one: idx_addr_tx_stake_position's leading two columns
+// (credential_tag, staking_key) are an exact prefix match for every query
+// idx_addr_tx_staking served (GetAddressesByCredential,
+// GetTransactionsByAddress's credential-tag branch,
+// GetAddressTransactionsByCredential), so nothing loses index coverage.
+// address_transaction gets one row per (payment address, transaction) on
+// every applied block, so leaving both indexes in place would cost write
+// throughput for a lookup the wider index already covers.
+func MigrateAddressTransactionStakePositionIndex(
+	db *gorm.DB,
+	logger *slog.Logger,
+) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !db.Migrator().HasTable(&AddressTransaction{}) {
+		return nil
+	}
+	if !db.Migrator().HasIndex(&AddressTransaction{}, "idx_addr_tx_staking") {
+		return nil
+	}
+	logger.Info(
+		"dropping redundant address_transaction credential/staking index " +
+			"now that idx_addr_tx_stake_position covers the same lookups",
+	)
+	if err := db.Migrator().DropIndex(
+		&AddressTransaction{},
+		"idx_addr_tx_staking",
+	); err != nil {
+		return fmt.Errorf("drop address_transaction staking index: %w", err)
+	}
+	return nil
 }

--- a/database/models/address_transaction.go
+++ b/database/models/address_transaction.go
@@ -49,17 +49,25 @@ func (AddressTransaction) TableName() string {
 
 // MigrateAddressTransactionStakePositionIndex drops the legacy
 // credential_tag/staking_key-only index (idx_addr_tx_staking) once
-// idx_addr_tx_stake_position exists to take over its role. AutoMigrate
-// creates idx_addr_tx_stake_position on its own (it is a new index name
-// that does not previously exist), so this helper's only job is removing
-// the now-redundant one: idx_addr_tx_stake_position's leading two columns
-// (credential_tag, staking_key) are an exact prefix match for every query
-// idx_addr_tx_staking served (GetAddressesByCredential,
+// idx_addr_tx_stake_position exists to take over its role: its leading two
+// columns (credential_tag, staking_key) are an exact prefix match for every
+// query idx_addr_tx_staking served (GetAddressesByCredential,
 // GetTransactionsByAddress's credential-tag branch,
 // GetAddressTransactionsByCredential), so nothing loses index coverage.
 // address_transaction gets one row per (payment address, transaction) on
 // every applied block, so leaving both indexes in place would cost write
 // throughput for a lookup the wider index already covers.
+//
+// Callers MUST invoke this only after AutoMigrate has created
+// idx_addr_tx_stake_position (AutoMigrate creates it on its own, since it
+// is a new index name that did not previously exist). This function also
+// verifies that precondition itself and is a no-op if the replacement
+// index is not present yet, so that a caller mistake — or a future
+// refactor that reorders migration steps — cannot leave the table with
+// neither index: if a process were to crash between dropping the legacy
+// index and AutoMigrate creating the replacement, address_transaction
+// would have no index at all supporting credential lookups until the next
+// startup retried both steps in the correct order.
 func MigrateAddressTransactionStakePositionIndex(
 	db *gorm.DB,
 	logger *slog.Logger,
@@ -71,6 +79,13 @@ func MigrateAddressTransactionStakePositionIndex(
 		return nil
 	}
 	if !db.Migrator().HasIndex(&AddressTransaction{}, "idx_addr_tx_staking") {
+		return nil
+	}
+	if !db.Migrator().HasIndex(&AddressTransaction{}, "idx_addr_tx_stake_position") {
+		logger.Warn(
+			"deferring address_transaction staking index cleanup: " +
+				"idx_addr_tx_stake_position does not exist yet",
+		)
 		return nil
 	}
 	logger.Info(

--- a/database/models/address_transaction_test.go
+++ b/database/models/address_transaction_test.go
@@ -39,10 +39,12 @@ func (legacyAddressTransaction) TableName() string {
 }
 
 // TestMigrateAddressTransactionStakePositionIndex verifies the upgrade
-// path on a populated, pre-existing table: AutoMigrate creates the new
-// idx_addr_tx_stake_position index on its own (it is a new name), and the
-// migration helper drops the now-redundant idx_addr_tx_staking, without
-// losing any rows.
+// path on a populated, pre-existing table, called in the same order
+// production call sites (postgres/sqlite/mysql database.go) now use:
+// AutoMigrate creates the new idx_addr_tx_stake_position index on its own
+// (it is a new name) BEFORE the migration helper runs, and the helper
+// then drops the now-redundant idx_addr_tx_staking, without losing any
+// rows.
 func TestMigrateAddressTransactionStakePositionIndex(t *testing.T) {
 	db := openMemoryDB(t)
 	require.NoError(t, db.AutoMigrate(&legacyAddressTransaction{}))
@@ -70,8 +72,13 @@ func TestMigrateAddressTransactionStakePositionIndex(t *testing.T) {
 		TxIndex:       0,
 	}).Error)
 
-	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
+	// AutoMigrate (creating idx_addr_tx_stake_position) MUST run before
+	// the cleanup helper: see MigrateAddressTransactionStakePositionIndex's
+	// doc comment and TestMigrateAddressTransactionStakePositionIndex_
+	// ReplacementMissing below for what happens if a caller gets this
+	// order wrong.
 	require.NoError(t, db.AutoMigrate(&AddressTransaction{}))
+	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
 
 	require.True(
 		t,
@@ -98,4 +105,40 @@ func TestMigrateAddressTransactionStakePositionIndex(t *testing.T) {
 func TestMigrateAddressTransactionStakePositionIndex_NoTable(t *testing.T) {
 	db := openMemoryDB(t)
 	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
+}
+
+// TestMigrateAddressTransactionStakePositionIndex_ReplacementMissing is the
+// regression test for the drop-before-create ordering bug (CodeRabbit
+// review, dingo PR #3016): if idx_addr_tx_stake_position does not exist
+// yet — i.e. a caller invokes this helper before AutoMigrate has created
+// it, or a prior AutoMigrate run failed partway through — the helper must
+// leave idx_addr_tx_staking in place rather than dropping the only index
+// that still covers credential lookups.
+func TestMigrateAddressTransactionStakePositionIndex_ReplacementMissing(t *testing.T) {
+	db := openMemoryDB(t)
+	require.NoError(t, db.AutoMigrate(&legacyAddressTransaction{}))
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&legacyAddressTransaction{}, "idx_addr_tx_staking",
+		),
+	)
+	require.False(
+		t,
+		db.Migrator().HasIndex(
+			&AddressTransaction{}, "idx_addr_tx_stake_position",
+		),
+	)
+
+	// Deliberately do NOT call AutoMigrate(&AddressTransaction{}) first, so
+	// idx_addr_tx_stake_position never gets created.
+	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
+
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&legacyAddressTransaction{}, "idx_addr_tx_staking",
+		),
+		"legacy index must survive when its replacement was never created",
+	)
 }

--- a/database/models/address_transaction_test.go
+++ b/database/models/address_transaction_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// legacyAddressTransaction mirrors the AddressTransaction schema from
+// before idx_addr_tx_stake_position existed: idx_addr_tx_staking covered
+// only (credential_tag, staking_key), and slot/tx_index were not part of
+// any index the account-transactions range query could use for ordering.
+type legacyAddressTransaction struct {
+	ID            uint   `gorm:"primaryKey"`
+	PaymentKey    []byte `gorm:"index:idx_addr_tx_payment;size:28"`
+	StakingKey    []byte `gorm:"index:idx_addr_tx_staking,priority:2;size:28"`
+	CredentialTag uint8  `gorm:"not null;default:0;index:idx_addr_tx_staking,priority:1"`
+	TransactionID uint   `gorm:"index"`
+	Slot          uint64 `gorm:"index"`
+	TxIndex       uint32
+}
+
+func (legacyAddressTransaction) TableName() string {
+	return "address_transaction"
+}
+
+// TestMigrateAddressTransactionStakePositionIndex verifies the upgrade
+// path on a populated, pre-existing table: AutoMigrate creates the new
+// idx_addr_tx_stake_position index on its own (it is a new name), and the
+// migration helper drops the now-redundant idx_addr_tx_staking, without
+// losing any rows.
+func TestMigrateAddressTransactionStakePositionIndex(t *testing.T) {
+	db := openMemoryDB(t)
+	require.NoError(t, db.AutoMigrate(&legacyAddressTransaction{}))
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&legacyAddressTransaction{}, "idx_addr_tx_staking",
+		),
+	)
+	require.False(
+		t,
+		db.Migrator().HasIndex(
+			&AddressTransaction{}, "idx_addr_tx_stake_position",
+		),
+	)
+
+	// Seed a row on the legacy schema so the migration exercises a
+	// populated table, not just an empty one.
+	require.NoError(t, db.Create(&legacyAddressTransaction{
+		PaymentKey:    make([]byte, 28),
+		StakingKey:    make([]byte, 28),
+		CredentialTag: 0,
+		TransactionID: 1,
+		Slot:          10,
+		TxIndex:       0,
+	}).Error)
+
+	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
+	require.NoError(t, db.AutoMigrate(&AddressTransaction{}))
+
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&AddressTransaction{}, "idx_addr_tx_stake_position",
+		),
+	)
+	require.False(
+		t,
+		db.Migrator().HasIndex(&AddressTransaction{}, "idx_addr_tx_staking"),
+	)
+
+	// The pre-migration row must survive the index swap.
+	var count int64
+	require.NoError(t, db.Model(&AddressTransaction{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+
+	// Idempotent: running it again against the now-migrated schema is a
+	// no-op, matching the reward_state precedent
+	// (TestMigrateRewardLiveStakePoolIndex).
+	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
+}
+
+func TestMigrateAddressTransactionStakePositionIndex_NoTable(t *testing.T) {
+	db := openMemoryDB(t)
+	require.NoError(t, MigrateAddressTransactionStakePositionIndex(db, nil))
+}

--- a/database/plugin/metadata/internal/accounthistory/transactions.go
+++ b/database/plugin/metadata/internal/accounthistory/transactions.go
@@ -114,18 +114,21 @@ func CountAddressTransactionsByCredential(
 // predicate); the join to the transaction table only resolves tx_hash and
 // block_hash, which are not duplicated onto address_transaction.
 //
-// The from/to bound is written as a row-value comparison, "(slot,
-// tx_index) >= (?, ?)", rather than the logically equivalent "slot > ? OR
-// (slot = ? AND tx_index >= ?)". Both are correct, but only the row-value
-// form is recognized as an index range scan against
-// idx_addr_tx_stake_position: verified via EXPLAIN QUERY PLAN, the OR form
-// still matches the index for the leading credential_tag/staking_key
-// equality but degrades the slot/tx_index bound to a row-by-row filter
-// (the index's USING clause shows only "credential_tag=? AND
-// staking_key=?"), while the row-value form shows the full "(slot,
-// tx_index)>(?,?) AND (slot,tx_index)<(?,?)" range folded into the same
-// index seek. Row-value comparisons are standard SQL, supported the same
-// way by SQLite, Postgres, and MySQL.
+// The from/to bound is a two-column range comparison against (at.slot,
+// at.tx_index) that must fold into an index range scan against
+// idx_addr_tx_stake_position rather than degrade into a row-by-row filter
+// after the credential lookup - otherwise a page-size request would cost
+// work proportional to the row's position within the credential's history
+// instead of to the page. There are two logically equivalent ways to write
+// that comparison, and which one achieves that depends on the backend:
+// sqlite and postgres fold the row-value form, "(slot, tx_index) >= (?,
+// ?)", directly into the index seek, while mysql's optimizer does not
+// (MySQL Bug #104128, #111952) and instead needs the expanded "slot > ? OR
+// (slot = ? AND tx_index >= ?)" form. sqldialect.TwoColumnRangeCondition
+// picks the form proven correct for db's dialect - see its doc comment for
+// the EXPLAIN evidence from all three backends, and
+// transactions_test.go/DATABASE.md for the pinned per-dialect regression
+// coverage.
 func addressTransactionRangeQuery(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -147,12 +150,18 @@ func addressTransactionRangeQuery(
 	)
 	args := []any{credentialTag, stakingKey}
 	if from != nil {
-		query += " AND (at.slot, at.tx_index) >= (?, ?)"
-		args = append(args, from.Slot, from.TxIndex)
+		cond, condArgs := sqldialect.TwoColumnRangeCondition(
+			db, "at.slot", "at.tx_index", ">=", from.Slot, from.TxIndex,
+		)
+		query += " AND " + cond
+		args = append(args, condArgs...)
 	}
 	if to != nil {
-		query += " AND (at.slot, at.tx_index) <= (?, ?)"
-		args = append(args, to.Slot, to.TxIndex)
+		cond, condArgs := sqldialect.TwoColumnRangeCondition(
+			db, "at.slot", "at.tx_index", "<=", to.Slot, to.TxIndex,
+		)
+		query += " AND " + cond
+		args = append(args, condArgs...)
 	}
 	return query, args
 }

--- a/database/plugin/metadata/internal/accounthistory/transactions.go
+++ b/database/plugin/metadata/internal/accounthistory/transactions.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounthistory
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
+	"gorm.io/gorm"
+)
+
+// QueryAddressTransactionsByCredential returns one page of (payment
+// address, transaction) association rows for a stake credential, ordered
+// by (slot, tx_index, payment_key) so results are deterministic even when
+// several addresses share a transaction. The optional from/to positions
+// are applied as a SQL predicate, and LIMIT/OFFSET are the final word: no
+// row this query does not return is ever inspected, so a page-size request
+// costs work proportional to the page, not to the credential's full
+// transaction history.
+func QueryAddressTransactionsByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+) ([]models.AccountTransactionAssociationRow, error) {
+	ret := make([]models.AccountTransactionAssociationRow, 0)
+	if len(stakingKey) == 0 {
+		return ret, nil
+	}
+
+	query, args := addressTransactionRangeQuery(
+		db,
+		credentialTag,
+		stakingKey,
+		from,
+		to,
+	)
+	if strings.EqualFold(order, "asc") {
+		query += " ORDER BY at.slot ASC, at.tx_index ASC, at.payment_key ASC"
+	} else {
+		query += " ORDER BY at.slot DESC, at.tx_index DESC, at.payment_key DESC"
+	}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	if offset > 0 {
+		query += " OFFSET ?"
+		args = append(args, offset)
+	}
+	if err := db.Raw(query, args...).Scan(&ret).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get address transactions by credential: %w",
+			err,
+		)
+	}
+	return ret, nil
+}
+
+// CountAddressTransactionsByCredential returns the total number of
+// (payment address, transaction) association rows for a stake credential
+// within the same optional from/to range.
+func CountAddressTransactionsByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	query, args := addressTransactionRangeQuery(
+		db,
+		credentialTag,
+		stakingKey,
+		from,
+		to,
+	)
+	var count int64
+	if err := db.Raw(
+		"SELECT COUNT(*) AS count FROM ("+query+") AS address_transaction_range",
+		args...,
+	).Scan(&count).Error; err != nil {
+		return 0, fmt.Errorf(
+			"count address transactions by credential: %w",
+			err,
+		)
+	}
+	return int(count), nil
+}
+
+// addressTransactionRangeQuery builds the shared SELECT (without ORDER
+// BY/LIMIT) used by both the row and count queries above. address_transaction
+// already carries slot/tx_index directly (no join needed for the range
+// predicate); the join to the transaction table only resolves tx_hash and
+// block_hash, which are not duplicated onto address_transaction.
+func addressTransactionRangeQuery(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+) (string, []any) {
+	query := fmt.Sprintf(
+		`SELECT at.payment_key AS payment_key,
+			tx.hash AS tx_hash,
+			at.slot AS tx_slot,
+			at.tx_index AS tx_index,
+			tx.block_hash AS block_hash
+		FROM address_transaction at
+		INNER JOIN %s tx ON tx.id = at.transaction_id
+		WHERE at.credential_tag = ?
+			AND at.staking_key = ?`,
+		sqldialect.TransactionTableName(db),
+	)
+	args := []any{credentialTag, stakingKey}
+	if from != nil {
+		query += " AND (at.slot > ? OR (at.slot = ? AND at.tx_index >= ?))"
+		args = append(args, from.Slot, from.Slot, from.TxIndex)
+	}
+	if to != nil {
+		query += " AND (at.slot < ? OR (at.slot = ? AND at.tx_index <= ?))"
+		args = append(args, to.Slot, to.Slot, to.TxIndex)
+	}
+	return query, args
+}

--- a/database/plugin/metadata/internal/accounthistory/transactions.go
+++ b/database/plugin/metadata/internal/accounthistory/transactions.go
@@ -113,6 +113,19 @@ func CountAddressTransactionsByCredential(
 // already carries slot/tx_index directly (no join needed for the range
 // predicate); the join to the transaction table only resolves tx_hash and
 // block_hash, which are not duplicated onto address_transaction.
+//
+// The from/to bound is written as a row-value comparison, "(slot,
+// tx_index) >= (?, ?)", rather than the logically equivalent "slot > ? OR
+// (slot = ? AND tx_index >= ?)". Both are correct, but only the row-value
+// form is recognized as an index range scan against
+// idx_addr_tx_stake_position: verified via EXPLAIN QUERY PLAN, the OR form
+// still matches the index for the leading credential_tag/staking_key
+// equality but degrades the slot/tx_index bound to a row-by-row filter
+// (the index's USING clause shows only "credential_tag=? AND
+// staking_key=?"), while the row-value form shows the full "(slot,
+// tx_index)>(?,?) AND (slot,tx_index)<(?,?)" range folded into the same
+// index seek. Row-value comparisons are standard SQL, supported the same
+// way by SQLite, Postgres, and MySQL.
 func addressTransactionRangeQuery(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -134,12 +147,12 @@ func addressTransactionRangeQuery(
 	)
 	args := []any{credentialTag, stakingKey}
 	if from != nil {
-		query += " AND (at.slot > ? OR (at.slot = ? AND at.tx_index >= ?))"
-		args = append(args, from.Slot, from.Slot, from.TxIndex)
+		query += " AND (at.slot, at.tx_index) >= (?, ?)"
+		args = append(args, from.Slot, from.TxIndex)
 	}
 	if to != nil {
-		query += " AND (at.slot < ? OR (at.slot = ? AND at.tx_index <= ?))"
-		args = append(args, to.Slot, to.Slot, to.TxIndex)
+		query += " AND (at.slot, at.tx_index) <= (?, ?)"
+		args = append(args, to.Slot, to.TxIndex)
 	}
 	return query, args
 }

--- a/database/plugin/metadata/internal/accounthistory/transactions_test.go
+++ b/database/plugin/metadata/internal/accounthistory/transactions_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
 )
 
 // newAddressTransactionsTestDB builds an in-memory sqlite DB with the real
@@ -175,4 +177,87 @@ func TestQueryAddressTransactionsByCredentialRangeIsIndexSeek(t *testing.T) {
 		"expected the to bound to be folded into the index seek as a "+
 			"range constraint, not applied as a post-search filter; plan was:\n%s",
 		plan)
+}
+
+// namedDialector is a minimal fake gorm.Dialector used only to make db.Name()
+// (and therefore sqldialect.Name(db)) report a given backend, without
+// opening a real connection. It exists so
+// TestAddressTransactionRangeQueryPerDialectForm below can pin the SQL
+// addressTransactionRangeQuery generates for mysql and postgres the same
+// way the sqlite form is pinned above with a real EXPLAIN QUERY PLAN
+// against a live in-memory database: mysql and postgres containers were
+// used for the actual EXPLAIN verification during review (see
+// sqldialect.TwoColumnRangeCondition's doc comment and DATABASE.md), but a
+// real MySQL/Postgres server is not available to this test binary, so this
+// only pins the query text those EXPLAIN runs were performed against.
+type namedDialector string
+
+func (d namedDialector) Name() string                                 { return string(d) }
+func (namedDialector) Initialize(*gorm.DB) error                      { return nil }
+func (namedDialector) Migrator(*gorm.DB) gorm.Migrator                { return nil }
+func (namedDialector) DataTypeOf(*schema.Field) string                { return "" }
+func (namedDialector) DefaultValueOf(*schema.Field) clause.Expression { return nil }
+func (namedDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  {}
+func (namedDialector) QuoteTo(clause.Writer, string)                  {}
+func (namedDialector) Explain(string, ...any) string                  { return "" }
+
+// TestAddressTransactionRangeQueryPerDialectForm is the dialect-specific
+// companion to the sqlite-only EXPLAIN regression tests above: it pins
+// that addressTransactionRangeQuery emits the row-value from/to form for
+// postgres (folds into the index range scan there, confirmed via EXPLAIN
+// ANALYZE) and the expanded OR form for mysql (required there because
+// MySQL does not fold row-value inequalities into a composite-index range
+// scan; confirmed via EXPLAIN showing "ref"/2-key-part access for the
+// row-value form versus "range"/4-key-part access for the OR form). See
+// sqldialect.TwoColumnRangeCondition for the full evidence.
+func TestAddressTransactionRangeQueryPerDialectForm(t *testing.T) {
+	credentialTag := uint8(0)
+	stakingKey := make([]byte, 28)
+	from := &models.AddressTransactionPosition{Slot: 500, TxIndex: 1}
+	to := &models.AddressTransactionPosition{Slot: 1500, TxIndex: 2}
+
+	t.Run("postgres_uses_row_value_form", func(t *testing.T) {
+		db := &gorm.DB{
+			Config: &gorm.Config{Dialector: namedDialector("postgres")},
+		}
+		query, args := addressTransactionRangeQuery(
+			db, credentialTag, stakingKey, from, to,
+		)
+		assert.Contains(t, query, "(at.slot, at.tx_index) >= (?, ?)")
+		assert.Contains(t, query, "(at.slot, at.tx_index) <= (?, ?)")
+		assert.Equal(
+			t,
+			[]any{credentialTag, stakingKey, uint64(500), uint32(1), uint64(1500), uint32(2)},
+			args,
+		)
+	})
+
+	t.Run("mysql_uses_expanded_or_form", func(t *testing.T) {
+		db := &gorm.DB{
+			Config: &gorm.Config{Dialector: namedDialector("mysql")},
+		}
+		query, args := addressTransactionRangeQuery(
+			db, credentialTag, stakingKey, from, to,
+		)
+		assert.Contains(
+			t, query,
+			"(at.slot > ? OR (at.slot = ? AND at.tx_index >= ?))",
+		)
+		assert.Contains(
+			t, query,
+			"(at.slot < ? OR (at.slot = ? AND at.tx_index <= ?))",
+		)
+		assert.NotContains(t, query, "(at.slot, at.tx_index)",
+			"mysql must not use the row-value form: it is not folded into "+
+				"a composite-index range scan there")
+		assert.Equal(
+			t,
+			[]any{
+				credentialTag, stakingKey,
+				uint64(500), uint64(500), uint32(1),
+				uint64(1500), uint64(1500), uint32(2),
+			},
+			args,
+		)
+	})
 }

--- a/database/plugin/metadata/internal/accounthistory/transactions_test.go
+++ b/database/plugin/metadata/internal/accounthistory/transactions_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounthistory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// newAddressTransactionsTestDB builds an in-memory sqlite DB with the real
+// (non-legacy) AddressTransaction and Transaction schemas, so AutoMigrate
+// creates idx_addr_tx_stake_position exactly as it would on a fresh
+// production database.
+func newAddressTransactionsTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AddressTransaction{}, &models.Transaction{}))
+	return db
+}
+
+// seedAddressTransactions creates n transactions, each with one
+// address_transaction row under the same stake credential at increasing
+// slots (tx_index 0), so a query over the whole credential has a
+// meaningful history to sort/range over.
+func seedAddressTransactions(
+	t *testing.T,
+	db *gorm.DB,
+	n int,
+) (credentialTag uint8, stakingKey []byte) {
+	t.Helper()
+	stakingKey = make([]byte, 28)
+	for i := range stakingKey {
+		stakingKey[i] = 0xAB
+	}
+	for i := range n {
+		hash := make([]byte, 32)
+		hash[0] = byte(i)
+		hash[1] = byte(i >> 8)
+		require.NoError(t, db.Create(&models.Transaction{
+			ID:         uint(i + 1), //nolint:gosec
+			Hash:       hash,
+			BlockHash:  make([]byte, 32),
+			Slot:       uint64(i),
+			BlockIndex: 0,
+		}).Error)
+		paymentKey := make([]byte, 28)
+		paymentKey[0] = byte(i)
+		require.NoError(t, db.Create(&models.AddressTransaction{
+			PaymentKey:    paymentKey,
+			StakingKey:    stakingKey,
+			CredentialTag: 0,
+			TransactionID: uint(i + 1), //nolint:gosec
+			Slot:          uint64(i),
+			TxIndex:       0,
+		}).Error)
+	}
+	return 0, stakingKey
+}
+
+// explainPlan runs EXPLAIN QUERY PLAN for query/args and returns the
+// joined detail column, following the established pattern in
+// sqlite/utxo_test.go, sqlite/drep_test.go, and
+// internal/rewardstate/livestake_test.go.
+func explainPlan(t *testing.T, db *gorm.DB, query string, args []any) string {
+	t.Helper()
+	rows, err := db.Raw("EXPLAIN QUERY PLAN "+query, args...).Rows()
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(details, "\n")
+}
+
+// TestQueryAddressTransactionsByCredentialUsesStakePositionIndexAsc is the
+// EXPLAIN QUERY PLAN regression test for the unbounded-sort bug:
+// idx_addr_tx_stake_position must drive both the credential lookup and the
+// ORDER BY, so LIMIT can short-circuit instead of sorting the credential's
+// entire history in a temp B-tree.
+func TestQueryAddressTransactionsByCredentialUsesStakePositionIndexAsc(t *testing.T) {
+	db := newAddressTransactionsTestDB(t)
+	credentialTag, stakingKey := seedAddressTransactions(t, db, 2000)
+
+	query, args := addressTransactionRangeQuery(
+		db, credentialTag, stakingKey, nil, nil,
+	)
+	query += " ORDER BY at.slot ASC, at.tx_index ASC, at.payment_key ASC LIMIT ?"
+	args = append(args, 100)
+
+	plan := explainPlan(t, db, query, args)
+	assert.Contains(t, plan, "idx_addr_tx_stake_position",
+		"expected the composite index to drive the search; plan was:\n%s", plan)
+	assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY",
+		"sort must be satisfied by the index, not a temp B-tree over the "+
+			"whole credential history; plan was:\n%s", plan)
+}
+
+// TestQueryAddressTransactionsByCredentialUsesStakePositionIndexDesc mirrors
+// the ascending case for order=desc: SQLite can walk a B-tree index
+// backwards, but that must be confirmed rather than assumed.
+func TestQueryAddressTransactionsByCredentialUsesStakePositionIndexDesc(t *testing.T) {
+	db := newAddressTransactionsTestDB(t)
+	credentialTag, stakingKey := seedAddressTransactions(t, db, 2000)
+
+	query, args := addressTransactionRangeQuery(
+		db, credentialTag, stakingKey, nil, nil,
+	)
+	query += " ORDER BY at.slot DESC, at.tx_index DESC, at.payment_key DESC LIMIT ?"
+	args = append(args, 100)
+
+	plan := explainPlan(t, db, query, args)
+	assert.Contains(t, plan, "idx_addr_tx_stake_position",
+		"expected the composite index to drive the search; plan was:\n%s", plan)
+	assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY",
+		"descending order must also be served by a backward index scan, "+
+			"not a temp B-tree; plan was:\n%s", plan)
+}
+
+// TestQueryAddressTransactionsByCredentialRangeIsIndexSeek verifies that an
+// inclusive from/to (slot, tx_index) range is folded into the
+// idx_addr_tx_stake_position index seek itself (a genuine range scan), not
+// merely a post-search row filter after the index locates the credential.
+// The row-value comparison form is what makes this possible: SQLite's
+// index USING clause lists the (slot, tx_index) bounds only when written
+// as "(slot, tx_index) >= (?, ?)"; the logically equivalent OR form does
+// not get folded into the seek.
+func TestQueryAddressTransactionsByCredentialRangeIsIndexSeek(t *testing.T) {
+	db := newAddressTransactionsTestDB(t)
+	credentialTag, stakingKey := seedAddressTransactions(t, db, 2000)
+
+	from := &models.AddressTransactionPosition{Slot: 500, TxIndex: 0}
+	to := &models.AddressTransactionPosition{Slot: 1500, TxIndex: 0}
+	query, args := addressTransactionRangeQuery(
+		db, credentialTag, stakingKey, from, to,
+	)
+	query += " ORDER BY at.slot ASC, at.tx_index ASC, at.payment_key ASC LIMIT ?"
+	args = append(args, 100)
+
+	plan := explainPlan(t, db, query, args)
+	assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY",
+		"range query sort must be satisfied by the index; plan was:\n%s", plan)
+	assert.Contains(t, plan, "idx_addr_tx_stake_position",
+		"expected the composite index to drive the range search; plan was:\n%s",
+		plan)
+	assert.Contains(t, plan, "(slot,tx_index)>",
+		"expected the from bound to be folded into the index seek as a "+
+			"range constraint, not applied as a post-search filter; plan was:\n%s",
+		plan)
+	assert.Contains(t, plan, "(slot,tx_index)<",
+		"expected the to bound to be folded into the index seek as a "+
+			"range constraint, not applied as a post-search filter; plan was:\n%s",
+		plan)
+}

--- a/database/plugin/metadata/internal/accounthistory/withdrawals.go
+++ b/database/plugin/metadata/internal/accounthistory/withdrawals.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounthistory
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
+	"gorm.io/gorm"
+)
+
+// QueryWithdrawalHistoryByCredential returns paginated withdrawal history
+// rows for a stake credential, joining the rollback-aware
+// account_reward_delta withdrawal rows against the transaction that made
+// each withdrawal to recover its slot, position, and block hash.
+func QueryWithdrawalHistoryByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+) ([]models.AccountWithdrawalHistoryRow, error) {
+	ret := make([]models.AccountWithdrawalHistoryRow, 0)
+	if len(stakingKey) == 0 {
+		return ret, nil
+	}
+
+	query, args := withdrawalHistoryQuery(db, credentialTag, stakingKey)
+	if strings.EqualFold(order, "asc") {
+		query += " ORDER BY tx_slot ASC, block_index ASC, tx_hash ASC"
+	} else {
+		query += " ORDER BY tx_slot DESC, block_index DESC, tx_hash DESC"
+	}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	if offset > 0 {
+		query += " OFFSET ?"
+		args = append(args, offset)
+	}
+	if err := db.Raw(query, args...).Scan(&ret).Error; err != nil {
+		return nil, fmt.Errorf("get account withdrawal history: %w", err)
+	}
+	return ret, nil
+}
+
+// CountWithdrawalHistoryByCredential returns the total number of withdrawal
+// history rows for a stake credential.
+func CountWithdrawalHistoryByCredential(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (int, error) {
+	if len(stakingKey) == 0 {
+		return 0, nil
+	}
+	query, args := withdrawalHistoryQuery(db, credentialTag, stakingKey)
+	var count int64
+	if err := db.Raw(
+		"SELECT COUNT(*) AS count FROM ("+query+") AS withdrawal_history",
+		args...,
+	).Scan(&count).Error; err != nil {
+		return 0, fmt.Errorf("count account withdrawal history: %w", err)
+	}
+	return int(count), nil
+}
+
+// withdrawalHistoryQuery builds the shared SELECT (without ORDER BY/LIMIT)
+// used by both the row and count queries above. account_reward_delta has no
+// unique index on tx_hash alone, but transaction.hash is unique, so the join
+// can never fan a single withdrawal row out into duplicates.
+func withdrawalHistoryQuery(
+	db *gorm.DB,
+	credentialTag uint8,
+	stakingKey []byte,
+) (string, []any) {
+	query := fmt.Sprintf(
+		`SELECT account_reward_delta.tx_hash AS tx_hash,
+			account_reward_delta.amount AS amount,
+			tx.slot AS tx_slot,
+			tx.block_index AS block_index,
+			tx.block_hash AS block_hash
+		FROM account_reward_delta
+		INNER JOIN %s tx ON tx.hash = account_reward_delta.tx_hash
+		WHERE account_reward_delta.withdrawal = ?
+			AND account_reward_delta.credential_tag = ?
+			AND account_reward_delta.staking_key = ?`,
+		sqldialect.TransactionTableName(db),
+	)
+	return query, []any{true, credentialTag, stakingKey}
+}

--- a/database/plugin/metadata/internal/sqldialect/sqldialect.go
+++ b/database/plugin/metadata/internal/sqldialect/sqldialect.go
@@ -137,12 +137,23 @@ func TwoColumnRangeCondition(
 	col1, col2, op string,
 	v1, v2 any,
 ) (string, []any) {
+	rowValue := fmt.Sprintf("(%s, %s) %s (?, ?)", col1, col2, op)
 	if Name(db) != "mysql" {
-		return fmt.Sprintf("(%s, %s) %s (?, ?)", col1, col2, op), []any{v1, v2}
+		return rowValue, []any{v1, v2}
 	}
-	strictOp := ">"
-	if op == "<=" {
+	// The expansion below is only equivalent for the two inclusive
+	// operators this helper documents. For anything else, fall back to the
+	// row-value form: on mysql that loses the index range scan, but it stays
+	// semantically correct, whereas expanding with the wrong leading
+	// comparison would silently return the wrong rows.
+	strictOp := ""
+	switch op {
+	case ">=":
+		strictOp = ">"
+	case "<=":
 		strictOp = "<"
+	default:
+		return rowValue, []any{v1, v2}
 	}
 	return fmt.Sprintf(
 		"(%s %s ? OR (%s = ? AND %s %s ?))",

--- a/database/plugin/metadata/internal/sqldialect/sqldialect.go
+++ b/database/plugin/metadata/internal/sqldialect/sqldialect.go
@@ -101,3 +101,51 @@ func ArithmeticParam(db *gorm.DB) string {
 	}
 	return "?"
 }
+
+// TwoColumnRangeCondition returns the SQL fragment (with "?" placeholders)
+// and its ordered bind args for an inclusive two-column range bound against
+// (col1, col2), in whichever of the two logically equivalent forms actually
+// folds into a composite-index range scan for db's backend dialect. op must
+// be ">=" (an inclusive lower/"from" bound) or "<=" (an inclusive
+// upper/"to" bound).
+//
+// This was verified empirically, not assumed: scratch sqlite/postgres/mysql
+// databases were seeded with a real composite index and EXPLAIN was run for
+// both forms during the dingo PR #3016 review (see
+// database/plugin/metadata/internal/accounthistory/transactions_test.go and
+// DATABASE.md's GetAddressTransactionsByCredential entry for the recorded
+// plans).
+//
+//   - sqlite and postgres fold the row-value form, "(col1, col2) >= (v1,
+//     v2)", directly into an index range scan over both bound columns
+//     (confirmed via EXPLAIN QUERY PLAN on sqlite and EXPLAIN ANALYZE on
+//     postgres: both show the full two-column bound inside the index
+//     condition, not a post-scan filter).
+//   - mysql's optimizer does not perform that translation for row
+//     constructor inequalities (MySQL Bug #104128, #111952 - Verified/S2,
+//     both still open as of 2026-07): EXPLAIN there showed the row-value
+//     form using only the index's leading equality columns ("ref" access,
+//     2 used_key_parts) and applying the two-column bound as a residual
+//     filter, so a page-size request cost work proportional to the row's
+//     offset into the credential's full history rather than to the page.
+//     The logically equivalent expanded form, "col1 > v1 OR (col1 = v1 AND
+//     col2 op v2)", is what MySQL's documentation recommends for exactly
+//     this situation, and EXPLAIN confirmed it restores a genuine "range"
+//     access type using all four index columns there.
+func TwoColumnRangeCondition(
+	db *gorm.DB,
+	col1, col2, op string,
+	v1, v2 any,
+) (string, []any) {
+	if Name(db) != "mysql" {
+		return fmt.Sprintf("(%s, %s) %s (?, ?)", col1, col2, op), []any{v1, v2}
+	}
+	strictOp := ">"
+	if op == "<=" {
+		strictOp = "<"
+	}
+	return fmt.Sprintf(
+		"(%s %s ? OR (%s = ? AND %s %s ?))",
+		col1, strictOp, col1, col2, op,
+	), []any{v1, v1, v2}
+}

--- a/database/plugin/metadata/internal/sqldialect/sqldialect_test.go
+++ b/database/plugin/metadata/internal/sqldialect/sqldialect_test.go
@@ -47,3 +47,77 @@ func TestExactUint64ArithmeticDialects(t *testing.T) {
 		})
 	}
 }
+
+// TestTwoColumnRangeConditionDialects pins the per-backend predicate form
+// chosen by TwoColumnRangeCondition. This is not a stylistic choice: real
+// sqlite/postgres/mysql containers were seeded with a composite index
+// matching idx_addr_tx_stake_position and EXPLAIN was run for both the
+// row-value and expanded-OR forms during the dingo PR #3016 review.
+// sqlite and postgres folded the row-value form into the index range scan
+// (postgres: EXPLAIN ANALYZE showed all four columns in "Index Cond" with
+// no residual Filter; sqlite: see the accounthistory package's own EXPLAIN
+// QUERY PLAN regression tests). mysql did not - EXPLAIN showed the
+// row-value form using only the two leading equality columns ("ref"
+// access) and applying the range as a residual filter, while the expanded
+// OR form restored a real "range" access type over all four index
+// columns. If this behavior ever changes (a MySQL fix, a newly added
+// backend), this test must be updated deliberately alongside new EXPLAIN
+// evidence, not guessed at.
+func TestTwoColumnRangeConditionDialects(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       string
+		wantCond string
+		wantArgs []any
+	}{
+		{
+			name:     "sqlite_from",
+			op:       ">=",
+			wantCond: "(slot, tx_index) >= (?, ?)",
+			wantArgs: []any{100, 5},
+		},
+		{
+			name:     "sqlite_to",
+			op:       "<=",
+			wantCond: "(slot, tx_index) <= (?, ?)",
+			wantArgs: []any{100, 5},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db := dialectDB("sqlite")
+			cond, args := TwoColumnRangeCondition(
+				db, "slot", "tx_index", test.op, 100, 5,
+			)
+			require.Equal(t, test.wantCond, cond)
+			require.Equal(t, test.wantArgs, args)
+		})
+	}
+
+	t.Run("postgres_uses_row_value_form", func(t *testing.T) {
+		db := dialectDB("postgres")
+		cond, args := TwoColumnRangeCondition(
+			db, "slot", "tx_index", ">=", 100, 5,
+		)
+		require.Equal(t, "(slot, tx_index) >= (?, ?)", cond)
+		require.Equal(t, []any{100, 5}, args)
+	})
+
+	t.Run("mysql_from_uses_expanded_or_form", func(t *testing.T) {
+		db := dialectDB("mysql")
+		cond, args := TwoColumnRangeCondition(
+			db, "slot", "tx_index", ">=", 100, 5,
+		)
+		require.Equal(t, "(slot > ? OR (slot = ? AND tx_index >= ?))", cond)
+		require.Equal(t, []any{100, 100, 5}, args)
+	})
+
+	t.Run("mysql_to_uses_expanded_or_form", func(t *testing.T) {
+		db := dialectDB("mysql")
+		cond, args := TwoColumnRangeCondition(
+			db, "slot", "tx_index", "<=", 100, 5,
+		)
+		require.Equal(t, "(slot < ? OR (slot = ? AND tx_index <= ?))", cond)
+		require.Equal(t, []any{100, 100, 5}, args)
+	})
+}

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -441,16 +441,6 @@ func (d *MetadataStoreMysql) Start() error {
 			"reward_live_stake dedup failed: %w", err,
 		)
 	}
-	// Drop the now-redundant address_transaction credential/staking index;
-	// AutoMigrate creates its idx_addr_tx_stake_position replacement below.
-	if err := models.MigrateAddressTransactionStakePositionIndex(
-		d.db, d.logger,
-	); err != nil {
-		return fmt.Errorf(
-			"address_transaction stake position index migration failed: %w",
-			err,
-		)
-	}
 	// Purge child rows whose OnDelete:CASCADE parent no longer exists before
 	// AutoMigrate adds the foreign keys. Databases created before auto-migrate
 	// was enabled never enforced these cascades, so orphaned children
@@ -495,6 +485,19 @@ func (d *MetadataStoreMysql) Start() error {
 		if err := d.db.AutoMigrate(model); err != nil {
 			return err
 		}
+	}
+	// Drop the now-redundant address_transaction credential/staking index
+	// only now that AutoMigrate (above) has created its
+	// idx_addr_tx_stake_position replacement: this must run after
+	// AutoMigrate, not before, or a crash between the two steps would leave
+	// the table with neither index.
+	if err := models.MigrateAddressTransactionStakePositionIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"address_transaction stake position index migration failed: %w",
+			err,
+		)
 	}
 	if backfillAccountCreatedSlot {
 		if err := models.BackfillAccountCreatedSlot(d.db, d.logger); err != nil {

--- a/database/plugin/metadata/mysql/database.go
+++ b/database/plugin/metadata/mysql/database.go
@@ -441,6 +441,16 @@ func (d *MetadataStoreMysql) Start() error {
 			"reward_live_stake dedup failed: %w", err,
 		)
 	}
+	// Drop the now-redundant address_transaction credential/staking index;
+	// AutoMigrate creates its idx_addr_tx_stake_position replacement below.
+	if err := models.MigrateAddressTransactionStakePositionIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"address_transaction stake position index migration failed: %w",
+			err,
+		)
+	}
 	// Purge child rows whose OnDelete:CASCADE parent no longer exists before
 	// AutoMigrate adds the foreign keys. Databases created before auto-migrate
 	// was enabled never enforced these cascades, so orphaned children

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -701,6 +701,72 @@ func (d *MetadataStoreMysql) CountAccountWithdrawalHistoryByCredential(
 	return count, nil
 }
 
+func (d *MetadataStoreMysql) GetAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn types.Txn,
+) ([]models.AccountTransactionAssociationRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve DB for address transactions by credential: %w",
+			err,
+		)
+	}
+	rows, err := accounthistory.QueryAddressTransactionsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		from,
+		to,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query address transactions by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+func (d *MetadataStoreMysql) CountAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count address transactions by credential: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountAddressTransactionsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		from,
+		to,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count address transactions by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 func (d *MetadataStoreMysql) GetAccountSumsByCredential(
 	credentialTag uint8,
 	stakingKey []byte,

--- a/database/plugin/metadata/mysql/transaction.go
+++ b/database/plugin/metadata/mysql/transaction.go
@@ -643,6 +643,64 @@ func (d *MetadataStoreMysql) CountAccountRegistrationHistoryByCredential(
 	return count, nil
 }
 
+func (d *MetadataStoreMysql) GetAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountWithdrawalHistoryRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve DB for account withdrawal history: %w",
+			err,
+		)
+	}
+	rows, err := accounthistory.QueryWithdrawalHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account withdrawal history: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+func (d *MetadataStoreMysql) CountAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count account withdrawal history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountWithdrawalHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account withdrawal history: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 func (d *MetadataStoreMysql) GetAccountSumsByCredential(
 	credentialTag uint8,
 	stakingKey []byte,

--- a/database/plugin/metadata/mysql/utxo.go
+++ b/database/plugin/metadata/mysql/utxo.go
@@ -17,6 +17,7 @@
 package mysql
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -381,6 +382,51 @@ func (d *MetadataStoreMysql) GetControlledAmountByCredential(
 		)
 	}
 	return total, nil
+}
+
+// GetUtxoPaymentScriptByCredential returns, for the given bounded set of
+// payment-key hashes previously observed under a stake credential, whether
+// each payment credential is a script hash. See the interface doc comment
+// in store.go for the full contract.
+func (d *MetadataStoreMysql) GetUtxoPaymentScriptByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	paymentKeys [][]byte,
+	txn types.Txn,
+) (map[string]bool, error) {
+	ret := make(map[string]bool, len(paymentKeys))
+	if len(stakingKey) == 0 || len(paymentKeys) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve DB for payment script by stake credential: %w",
+			err,
+		)
+	}
+	var rows []struct {
+		PaymentKey    []byte
+		PaymentScript bool
+	}
+	if err := db.Model(&models.Utxo{}).
+		Select("DISTINCT payment_key, payment_script").
+		Where(
+			"credential_tag = ? AND staking_key = ? AND payment_key IN ?",
+			credentialTag,
+			stakingKey,
+			paymentKeys,
+		).
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get payment script by stake credential: %w",
+			err,
+		)
+	}
+	for _, row := range rows {
+		ret[hex.EncodeToString(row.PaymentKey)] = row.PaymentScript
+	}
+	return ret, nil
 }
 
 // GetScriptLockedSupply returns the sum of lovelace held in live UTxOs

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -351,16 +351,6 @@ func (d *MetadataStorePostgres) Start() error {
 			"reward_live_stake dedup failed: %w", err,
 		)
 	}
-	// Drop the now-redundant address_transaction credential/staking index;
-	// AutoMigrate creates its idx_addr_tx_stake_position replacement below.
-	if err := models.MigrateAddressTransactionStakePositionIndex(
-		d.db, d.logger,
-	); err != nil {
-		return fmt.Errorf(
-			"address_transaction stake position index migration failed: %w",
-			err,
-		)
-	}
 	// Purge child rows whose OnDelete:CASCADE parent no longer exists before
 	// AutoMigrate adds the foreign keys. Databases created before auto-migrate
 	// was enabled never enforced these cascades, so orphaned children
@@ -404,6 +394,19 @@ func (d *MetadataStorePostgres) Start() error {
 		if err := d.db.AutoMigrate(model); err != nil {
 			return err
 		}
+	}
+	// Drop the now-redundant address_transaction credential/staking index
+	// only now that AutoMigrate (above) has created its
+	// idx_addr_tx_stake_position replacement: this must run after
+	// AutoMigrate, not before, or a crash between the two steps would leave
+	// the table with neither index.
+	if err := models.MigrateAddressTransactionStakePositionIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"address_transaction stake position index migration failed: %w",
+			err,
+		)
 	}
 	if backfillAccountCreatedSlot {
 		if err := models.BackfillAccountCreatedSlot(d.db, d.logger); err != nil {

--- a/database/plugin/metadata/postgres/database.go
+++ b/database/plugin/metadata/postgres/database.go
@@ -351,6 +351,16 @@ func (d *MetadataStorePostgres) Start() error {
 			"reward_live_stake dedup failed: %w", err,
 		)
 	}
+	// Drop the now-redundant address_transaction credential/staking index;
+	// AutoMigrate creates its idx_addr_tx_stake_position replacement below.
+	if err := models.MigrateAddressTransactionStakePositionIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"address_transaction stake position index migration failed: %w",
+			err,
+		)
+	}
 	// Purge child rows whose OnDelete:CASCADE parent no longer exists before
 	// AutoMigrate adds the foreign keys. Databases created before auto-migrate
 	// was enabled never enforced these cascades, so orphaned children

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -643,6 +643,64 @@ func (d *MetadataStorePostgres) CountAccountRegistrationHistoryByCredential(
 	return count, nil
 }
 
+func (d *MetadataStorePostgres) GetAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountWithdrawalHistoryRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve DB for account withdrawal history: %w",
+			err,
+		)
+	}
+	rows, err := accounthistory.QueryWithdrawalHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account withdrawal history: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+func (d *MetadataStorePostgres) CountAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count account withdrawal history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountWithdrawalHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account withdrawal history: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 func (d *MetadataStorePostgres) GetAccountSumsByCredential(
 	credentialTag uint8,
 	stakingKey []byte,

--- a/database/plugin/metadata/postgres/transaction.go
+++ b/database/plugin/metadata/postgres/transaction.go
@@ -701,6 +701,72 @@ func (d *MetadataStorePostgres) CountAccountWithdrawalHistoryByCredential(
 	return count, nil
 }
 
+func (d *MetadataStorePostgres) GetAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn types.Txn,
+) ([]models.AccountTransactionAssociationRow, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve DB for address transactions by credential: %w",
+			err,
+		)
+	}
+	rows, err := accounthistory.QueryAddressTransactionsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		from,
+		to,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query address transactions by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+func (d *MetadataStorePostgres) CountAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve DB for count address transactions by credential: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountAddressTransactionsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		from,
+		to,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count address transactions by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 func (d *MetadataStorePostgres) GetAccountSumsByCredential(
 	credentialTag uint8,
 	stakingKey []byte,

--- a/database/plugin/metadata/postgres/utxo.go
+++ b/database/plugin/metadata/postgres/utxo.go
@@ -17,6 +17,7 @@
 package postgres
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -184,6 +185,51 @@ func (d *MetadataStorePostgres) GetControlledAmountByCredential(
 		)
 	}
 	return total, nil
+}
+
+// GetUtxoPaymentScriptByCredential returns, for the given bounded set of
+// payment-key hashes previously observed under a stake credential, whether
+// each payment credential is a script hash. See the interface doc comment
+// in store.go for the full contract.
+func (d *MetadataStorePostgres) GetUtxoPaymentScriptByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	paymentKeys [][]byte,
+	txn types.Txn,
+) (map[string]bool, error) {
+	ret := make(map[string]bool, len(paymentKeys))
+	if len(stakingKey) == 0 || len(paymentKeys) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve DB for payment script by stake credential: %w",
+			err,
+		)
+	}
+	var rows []struct {
+		PaymentKey    []byte
+		PaymentScript bool
+	}
+	if err := db.Model(&models.Utxo{}).
+		Select("DISTINCT payment_key, payment_script").
+		Where(
+			"credential_tag = ? AND staking_key = ? AND payment_key IN ?",
+			credentialTag,
+			stakingKey,
+			paymentKeys,
+		).
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get payment script by stake credential: %w",
+			err,
+		)
+	}
+	for _, row := range rows {
+		ret[hex.EncodeToString(row.PaymentKey)] = row.PaymentScript
+	}
+	return ret, nil
 }
 
 // GetScriptLockedSupply returns the sum of lovelace held in live UTxOs

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -548,16 +548,6 @@ func (d *MetadataStoreSqlite) Start() error {
 			"reward_live_stake dedup failed: %w", err,
 		)
 	}
-	// Drop the now-redundant address_transaction credential/staking index;
-	// AutoMigrate creates its idx_addr_tx_stake_position replacement below.
-	if err := models.MigrateAddressTransactionStakePositionIndex(
-		d.db, d.logger,
-	); err != nil {
-		return fmt.Errorf(
-			"address_transaction stake position index migration failed: %w",
-			err,
-		)
-	}
 	// Purge child rows whose OnDelete:CASCADE parent no longer exists before
 	// AutoMigrate adds the foreign keys. Databases created before auto-migrate
 	// was enabled never enforced these cascades, so orphaned children
@@ -599,6 +589,19 @@ func (d *MetadataStoreSqlite) Start() error {
 	)
 	if err := d.db.AutoMigrate(models.MigrateModels...); err != nil {
 		return err
+	}
+	// Drop the now-redundant address_transaction credential/staking index
+	// only now that AutoMigrate (above) has created its
+	// idx_addr_tx_stake_position replacement: this must run after
+	// AutoMigrate, not before, or a crash between the two steps would leave
+	// the table with neither index.
+	if err := models.MigrateAddressTransactionStakePositionIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"address_transaction stake position index migration failed: %w",
+			err,
+		)
 	}
 	if backfillAccountCreatedSlot {
 		if err := models.BackfillAccountCreatedSlot(d.db, d.logger); err != nil {

--- a/database/plugin/metadata/sqlite/database.go
+++ b/database/plugin/metadata/sqlite/database.go
@@ -548,6 +548,16 @@ func (d *MetadataStoreSqlite) Start() error {
 			"reward_live_stake dedup failed: %w", err,
 		)
 	}
+	// Drop the now-redundant address_transaction credential/staking index;
+	// AutoMigrate creates its idx_addr_tx_stake_position replacement below.
+	if err := models.MigrateAddressTransactionStakePositionIndex(
+		d.db, d.logger,
+	); err != nil {
+		return fmt.Errorf(
+			"address_transaction stake position index migration failed: %w",
+			err,
+		)
+	}
 	// Purge child rows whose OnDelete:CASCADE parent no longer exists before
 	// AutoMigrate adds the foreign keys. Databases created before auto-migrate
 	// was enabled never enforced these cascades, so orphaned children

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -752,6 +752,72 @@ func (d *MetadataStoreSqlite) CountAccountWithdrawalHistoryByCredential(
 	return count, nil
 }
 
+func (d *MetadataStoreSqlite) GetAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn types.Txn,
+) ([]models.AccountTransactionAssociationRow, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve read DB for address transactions by credential: %w",
+			err,
+		)
+	}
+	rows, err := accounthistory.QueryAddressTransactionsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		from,
+		to,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query address transactions by credential: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+func (d *MetadataStoreSqlite) CountAddressTransactionsByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	from *models.AddressTransactionPosition,
+	to *models.AddressTransactionPosition,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count address transactions by credential: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountAddressTransactionsByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		from,
+		to,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count address transactions by credential: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 func (d *MetadataStoreSqlite) GetAccountSumsByCredential(
 	credentialTag uint8,
 	stakingKey []byte,

--- a/database/plugin/metadata/sqlite/transaction.go
+++ b/database/plugin/metadata/sqlite/transaction.go
@@ -694,6 +694,64 @@ func (d *MetadataStoreSqlite) CountAccountRegistrationHistoryByCredential(
 	return count, nil
 }
 
+func (d *MetadataStoreSqlite) GetAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+	txn types.Txn,
+) ([]models.AccountWithdrawalHistoryRow, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve read DB for account withdrawal history: %w",
+			err,
+		)
+	}
+	rows, err := accounthistory.QueryWithdrawalHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query account withdrawal history: %w",
+			err,
+		)
+	}
+	return rows, nil
+}
+
+func (d *MetadataStoreSqlite) CountAccountWithdrawalHistoryByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	txn types.Txn,
+) (int, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"resolve read DB for count account withdrawal history: %w",
+			err,
+		)
+	}
+	count, err := accounthistory.CountWithdrawalHistoryByCredential(
+		db,
+		credentialTag,
+		stakingKey,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count account withdrawal history: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 func (d *MetadataStoreSqlite) GetAccountSumsByCredential(
 	credentialTag uint8,
 	stakingKey []byte,

--- a/database/plugin/metadata/sqlite/utxo.go
+++ b/database/plugin/metadata/sqlite/utxo.go
@@ -15,6 +15,7 @@
 package sqlite
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -452,6 +453,51 @@ func (d *MetadataStoreSqlite) GetControlledAmountByCredential(
 		)
 	}
 	return total, nil
+}
+
+// GetUtxoPaymentScriptByCredential returns, for the given bounded set of
+// payment-key hashes previously observed under a stake credential, whether
+// each payment credential is a script hash. See the interface doc comment
+// in store.go for the full contract.
+func (d *MetadataStoreSqlite) GetUtxoPaymentScriptByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	paymentKeys [][]byte,
+	txn types.Txn,
+) (map[string]bool, error) {
+	ret := make(map[string]bool, len(paymentKeys))
+	if len(stakingKey) == 0 || len(paymentKeys) == 0 {
+		return ret, nil
+	}
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolve read DB for payment script by stake credential: %w",
+			err,
+		)
+	}
+	var rows []struct {
+		PaymentKey    []byte
+		PaymentScript bool
+	}
+	if err := db.Model(&models.Utxo{}).
+		Select("DISTINCT payment_key, payment_script").
+		Where(
+			"credential_tag = ? AND staking_key = ? AND payment_key IN ?",
+			credentialTag,
+			stakingKey,
+			paymentKeys,
+		).
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf(
+			"get payment script by stake credential: %w",
+			err,
+		)
+	}
+	for _, row := range rows {
+		ret[hex.EncodeToString(row.PaymentKey)] = row.PaymentScript
+	}
+	return ret, nil
 }
 
 // GetScriptLockedSupply returns the sum of lovelace held in live UTxOs

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -926,6 +926,36 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
+	// GetAddressTransactionsByCredential retrieves one page of (payment
+	// address, transaction) association rows for a stake credential
+	// tag/hash pair, ordered by (slot, tx_index, payment_key) and
+	// optionally bounded by an inclusive from/to (slot, tx_index) range
+	// (nil = unconstrained on that side). This is the direct SQL page: no
+	// caller-side fan-out or filtering is needed, so cost is bounded by
+	// limit/offset rather than by the credential's full transaction
+	// history.
+	GetAddressTransactionsByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
+		*models.AddressTransactionPosition, // from
+		*models.AddressTransactionPosition, // to
+		types.Txn,
+	) ([]models.AccountTransactionAssociationRow, error)
+
+	// CountAddressTransactionsByCredential retrieves the total count of
+	// (payment address, transaction) association rows for a stake
+	// credential tag/hash pair within the same optional from/to range.
+	CountAddressTransactionsByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		*models.AddressTransactionPosition, // from
+		*models.AddressTransactionPosition, // to
+		types.Txn,
+	) (int, error)
+
 	// GetAccountSumsByCredential retrieves the aggregated withdrawal, reserves,
 	// and treasury lovelace totals for a stake credential tag/hash pair.
 	GetAccountSumsByCredential(
@@ -1196,6 +1226,24 @@ type MetadataStore interface {
 	// GetControlledAmountByCredential returns the sum of live UTxO
 	// amounts controlled by the given stake credential.
 	GetControlledAmountByCredential(uint8, []byte, types.Txn) (uint64, error)
+
+	// GetUtxoPaymentScriptByCredential returns, for the given bounded set
+	// of payment-key hashes previously observed under a stake credential,
+	// whether each payment credential is a script hash (true) or a key
+	// hash (false). Used by the Blockfrost account transactions endpoint
+	// to reconstruct the exact address type for one page of (payment
+	// address, transaction) rows without decoding UTxO CBOR or scanning
+	// the credential's full history: paymentKeys is expected to be the
+	// small (<= page size) distinct set drawn from an already-paginated
+	// GetAddressTransactionsByCredential page. A payment key with no
+	// matching UTxO row is omitted from the result; callers should
+	// default to key-hash for any omitted key.
+	GetUtxoPaymentScriptByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		[][]byte, // paymentKeys
+		types.Txn,
+	) (map[string]bool, error)
 
 	// GetMidnightCandidates retrieves live committee-candidate UTxOs with
 	// inline datum bytes from metadata rows, without materializing block CBOR.

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -907,6 +907,25 @@ type MetadataStore interface {
 		types.Txn,
 	) (int, error)
 
+	// GetAccountWithdrawalHistoryByCredential retrieves withdrawal history
+	// rows for a stake credential tag/hash pair.
+	GetAccountWithdrawalHistoryByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		int, // limit
+		int, // offset
+		string, // order (asc|desc)
+		types.Txn,
+	) ([]models.AccountWithdrawalHistoryRow, error)
+
+	// CountAccountWithdrawalHistoryByCredential retrieves the total count of
+	// withdrawal history rows for a stake credential tag/hash pair.
+	CountAccountWithdrawalHistoryByCredential(
+		uint8, // credentialTag
+		[]byte, // stakingKey
+		types.Txn,
+	) (int, error)
+
 	// GetAccountSumsByCredential retrieves the aggregated withdrawal, reserves,
 	// and treasury lovelace totals for a stake credential tag/hash pair.
 	GetAccountSumsByCredential(

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -568,6 +568,35 @@ func (d *Database) GetControlledAmountByCredential(
 	return total, nil
 }
 
+// GetUtxoPaymentScriptByCredential returns, for the given bounded set of
+// payment-key hashes previously observed under a stake credential, whether
+// each payment credential is a script hash. See the metadata store
+// interface doc comment for the full contract.
+func (d *Database) GetUtxoPaymentScriptByCredential(
+	credentialTag uint8,
+	stakingKey []byte,
+	paymentKeys [][]byte,
+	txn *Txn,
+) (map[string]bool, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	ret, err := d.metadata.GetUtxoPaymentScriptByCredential(
+		credentialTag,
+		stakingKey,
+		paymentKeys,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get payment script by stake credential: %w",
+			err,
+		)
+	}
+	return ret, nil
+}
+
 func (d *Database) UtxosByAddressWithOrdering(
 	q *models.UtxoWithOrderingQuery,
 	txn *Txn,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -6751,6 +6751,62 @@ func (ls *LedgerState) CountTransactionsByAddress(
 	return count, nil
 }
 
+// GetTransactionsByAddressKeys returns transactions involving the given
+// payment/staking credential pair with explicit ordering. A nil paymentKey
+// matches every address sharing the staking credential, which is how the
+// Blockfrost account transactions endpoint resolves every transaction
+// associated with a stake address.
+func (ls *LedgerState) GetTransactionsByAddressKeys(
+	paymentKey []byte,
+	credentialTag uint8,
+	stakingKey []byte,
+	limit int,
+	offset int,
+	order string,
+) ([]models.Transaction, error) {
+	txs, err := ls.db.GetTransactionsByAddressKeys(
+		paymentKey,
+		credentialTag,
+		stakingKey,
+		limit,
+		offset,
+		order,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"get transactions by address keys (limit=%d offset=%d order=%s): %w",
+			limit,
+			offset,
+			order,
+			err,
+		)
+	}
+	return txs, nil
+}
+
+// CountTransactionsByAddressKeys returns the total number of transactions
+// involving the given payment/staking credential pair.
+func (ls *LedgerState) CountTransactionsByAddressKeys(
+	paymentKey []byte,
+	credentialTag uint8,
+	stakingKey []byte,
+) (int, error) {
+	count, err := ls.db.CountTransactionsByAddressKeys(
+		paymentKey,
+		credentialTag,
+		stakingKey,
+		nil,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"count transactions by address keys: %w",
+			err,
+		)
+	}
+	return count, nil
+}
+
 // CountTransactionsByMetadataLabel returns the total number of transactions
 // that include metadata for the requested label.
 func (ls *LedgerState) CountTransactionsByMetadataLabel(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -6751,62 +6751,6 @@ func (ls *LedgerState) CountTransactionsByAddress(
 	return count, nil
 }
 
-// GetTransactionsByAddressKeys returns transactions involving the given
-// payment/staking credential pair with explicit ordering. A nil paymentKey
-// matches every address sharing the staking credential, which is how the
-// Blockfrost account transactions endpoint resolves every transaction
-// associated with a stake address.
-func (ls *LedgerState) GetTransactionsByAddressKeys(
-	paymentKey []byte,
-	credentialTag uint8,
-	stakingKey []byte,
-	limit int,
-	offset int,
-	order string,
-) ([]models.Transaction, error) {
-	txs, err := ls.db.GetTransactionsByAddressKeys(
-		paymentKey,
-		credentialTag,
-		stakingKey,
-		limit,
-		offset,
-		order,
-		nil,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"get transactions by address keys (limit=%d offset=%d order=%s): %w",
-			limit,
-			offset,
-			order,
-			err,
-		)
-	}
-	return txs, nil
-}
-
-// CountTransactionsByAddressKeys returns the total number of transactions
-// involving the given payment/staking credential pair.
-func (ls *LedgerState) CountTransactionsByAddressKeys(
-	paymentKey []byte,
-	credentialTag uint8,
-	stakingKey []byte,
-) (int, error) {
-	count, err := ls.db.CountTransactionsByAddressKeys(
-		paymentKey,
-		credentialTag,
-		stakingKey,
-		nil,
-	)
-	if err != nil {
-		return 0, fmt.Errorf(
-			"count transactions by address keys: %w",
-			err,
-		)
-	}
-	return count, nil
-}
-
 // CountTransactionsByMetadataLabel returns the total number of transactions
 // that include metadata for the requested label.
 func (ls *LedgerState) CountTransactionsByMetadataLabel(


### PR DESCRIPTION
Closes #2934

Registers three missing Blockfrost stake-account endpoints:

- `GET /api/v0/accounts/{stake_address}/utxos`
- `GET /api/v0/accounts/{stake_address}/withdrawals`
- `GET /api/v0/accounts/{stake_address}/transactions`

Response shapes verified against the `blockfrost/openapi` schema files directly (`account_utxo_content`, `account_withdrawal_content`, `account_transactions_content`) rather than from the issue text.

One thing worth noting from the schema: `account_transactions_content`s own example lists the same `tx_hash` twice under two different payment addresses that share one delegation part, so a row is per (transaction, address) pair rather than per transaction. The implementation matches that.

## Data sources

Account UTxOs reuse `models.UtxoAddressPattern{DelegationPart: ...}`, which the shared UTxO query layer already supports, plus the existing `addressUtxoCbor` / `utxoDatumAndScriptRef` helpers so datum and reference-script fields stay consistent with `/addresses/{address}/utxos` and `/txs/{hash}/utxos`. Each rows `address` is recovered per row because one stake credential spans many payment addresses.

Account withdrawals query `account_reward_delta` (`withdrawal = true`) joined to `transaction` on `tx_hash = hash`; only a `SUM`-based query existed before. The join cannot fan out because `transaction.hash` is unique.

Account transactions query `address_transaction` directly, which is already one row per (payment address, transaction) with its own `slot` and `tx_index` — the same granularity the response needs.

Unlike `AccountAssociatedAddresses`, the payment-credential script-versus-key bit is resolved from `utxo.payment_script` rather than assuming the payment part is always a key hash, so script addresses render correctly.

## Query cost

Each endpoints bound is stated deliberately rather than left implicit.

`/transactions` is bounded by page size. `ORDER BY`, `LIMIT`/`OFFSET`, and the `from`/`to` range are all pushed into SQL; `from`/`to` block numbers resolve to slots via two bounded index lookups; and the script bit, block height, and block time are resolved only for the pages own rows and distinct blocks.

An earlier revision of this branch fetched the accounts entire transaction history with all UTxOs preloaded and filtered in memory, which was unbounded work driven by a path parameter. That is fixed.

`/withdrawals` is bounded by page size — `LIMIT`/`OFFSET` in SQL, with one memoized block lookup per distinct block on the page.

`/utxos` is NOT bounded: it fetches the credentials full live UTxO set and paginates in memory. This exactly matches the existing accepted behavior of `/addresses/{address}/utxos`, which uses the same helper without a SQL limit, so it is pre-existing rather than introduced here. Flagging it explicitly rather than leaving it unstated.

## Index

`/transactions` filters `(credential_tag, staking_key)` and orders by `slot, tx_index, payment_key`. `idx_addr_tx_staking` covered only the first two columns, so the plan was:

```
SEARCH at USING INDEX idx_addr_tx_staking (credential_tag=? AND staking_key=?)
USE TEMP B-TREE FOR ORDER BY
```

The index located the credentials rows, then SQLite sorted all of them before `LIMIT` could apply — proportional to the accounts full history, not the page. Added `idx_addr_tx_stake_position (credential_tag, staking_key, slot, tx_index, payment_key)`:

```
ASC:   SEARCH at USING INDEX idx_addr_tx_stake_position (credential_tag=? AND staking_key=?)
DESC:  SEARCH at USING INDEX idx_addr_tx_stake_position (credential_tag=? AND staking_key=?)
RANGE: SEARCH at USING INDEX idx_addr_tx_stake_position (credential_tag=? AND staking_key=? AND (slot,tx_index)>(?,?) AND (slot,tx_index)<(?,?))
```

`USE TEMP B-TREE FOR ORDER BY` is gone in all three cases. DESC was confirmed as a backward index scan rather than assumed.

The `from`/`to` predicate uses a row-value comparison `(at.slot, at.tx_index) >= (?, ?)` rather than the logically equivalent OR form, because only the row-value form gets folded into the index seek — the OR form leaves the bound as a row-by-row filter. Verified with `EXPLAIN QUERY PLAN` side by side.

`MigrateAddressTransactionStakePositionIndex` drops the now-redundant `idx_addr_tx_staking`, whose columns are a strict prefix of the new index. `address_transaction` is a hot per-block write path, so keeping both would cost write throughput for no remaining read benefit. `Slot`s standalone index is retained because the unscoped rollback cleanup (`WHERE slot > ?`) cannot use the composite index. Upgrade in place is verified with a legacy-model AutoMigrate test following the existing `MigrateRewardLiveStakePoolIndex` pattern.

## Tests

Handler and adapter tests covering response fields, pagination and order, empty results, invalid input, 404 and 500 paths, and `from`/`to` parsing and validation including malformed and inverted ranges.

`TestNodeAdapterAccountTransactionsBounded` creates five transactions in five blocks but a `Block` row for only the one on the requested page — the previous unbounded implementation resolved all five up front and would fail on the missing ones, and a `page=2` request is asserted to error to prove the setup would genuinely catch a regression.

Three `EXPLAIN QUERY PLAN` regression tests (asc, desc, range) assert the composite index drives the search and the temp B-tree is absent, so a future index change fails loudly instead of silently degrading. These follow the existing pattern in `sqlite/utxo_test.go`, `sqlite/drep_test.go`, and `internal/rewardstate/livestake_test.go`.

No existing test assertion was modified.

## Verification

`go build ./...` (default and `-tags dingo_extra_plugins`), `go test ./api/blockfrost/... ./database/... ./ledger/...`, `golangci-lint run`, `nilaway`, `modernize`, `make import-boundaries`, `go test -race`, and `go test ./internal/test/conformance/...` all pass.

Verified to merge cleanly onto current `main`. Note for merge ordering: this and #3015 both append new sections at the same point in `DATABASE.md`, so whichever merges second needs a trivial keep-both resolution there. No code conflicts.

## Documentation

`DATABASE.md` documents the new withdrawal and account-transaction query surfaces, the new index with its plan evidence, and the dropped redundant index. `ARCHITECTURE.md` documents the three new routes and how they resolve data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blockfrost stake-account UTxO, withdrawal, and transaction endpoints with SQL-backed pagination and inclusive block-range filtering. Improves performance with a new composite index and dialect-aware range predicates across SQLite, Postgres, and MySQL.

- **New Features**
  - Added GET `/api/v0/accounts/{stake_address}/utxos`, `/withdrawals`, and `/transactions`.
  - Transactions accept inclusive `from`/`to` block ranges (`block` or `block:index`) and return one row per (transaction, address).
  - Pagination: `/withdrawals` and `/transactions` in SQL; `/utxos` in memory to match address UTxO behavior.
  - Correctly reconstructs key vs script payment addresses via `utxo.payment_script`.

- **Bug Fixes**
  - Account transactions are page-bounded and use an index-backed range scan via new composite index `idx_addr_tx_stake_position`; old index dropped after AutoMigrate with existence checks.
  - Dialect-aware two-column range predicate: row-value form on SQLite/Postgres, expanded-OR on MySQL, with a safe fallback for unsupported operators.
  - Reduced per-request work by resolving `payment_script` and block data only for rows on the current page; removed full-history loads and UTxO CBOR decoding.
  - Regression tests pin EXPLAIN plans, range behavior, and pagination/validation across backends.

<sup>Written for commit af052ed18a63deeebf8b33cbb2250f762a40f5e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account activity endpoints for stake-account UTxOs, withdrawal history, and transactions.
  - Added pagination and ascending/descending ordering support.
  - Added optional inclusive block-range filters for account transactions.
  - Responses include transaction, block, address, amount, datum, and reference-script details where available.
  - Added support for correctly reconstructing key-hash and script-hash payment addresses.

- **Documentation**
  - Expanded API and database documentation with endpoint behavior, pagination, filtering, and query examples.

- **Bug Fixes**
  - Improved handling of invalid ranges, missing accounts, empty results, and rollback-aware history data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->