### PR TITLE
docs(examples): gov lens rewards and drep expiry

### DIFF
--- a/examples/dingo-gov-lens/README.md
+++ b/examples/dingo-gov-lens/README.md
@@ -13,12 +13,61 @@ dependencies live in this directory's `go.mod`.
 - Chain freshness from `tip`, `epoch`, and `node_settings`
 - Governance actions from `governance_proposal`
 - Vote breakdowns from `governance_vote`
-- Active DReps from `drep`
+- Active DReps from `drep`, plus how many registered DReps have expired by
+  inactivity and are therefore excluded from the voting-power denominator
 - DRep vote, update, registration, and delegation views
+- Per-DRep inactivity expiry: the epochs left before `expiry_epoch` is reached,
+  a filter for expired vs unexpired DReps, the credential's first on-chain
+  appearance, and the slot of its most recent real registration certificate
+- Retained epoch and reward state per epoch: ADA pots, leader-election and
+  reward-basis stake totals, pool and delegator counts, whether the boundary
+  snapshot was captured authoritatively, and how many per-pool reward results
+  exist
 - Stake credential lookup from `account`, either pasted manually or derived
   locally from a CIP-30 wallet reward address, including the immutable slot at
-  which Dingo first observed the account
+  which Dingo first observed the account, its CIP-0163 inactivity expiry, its
+  per-epoch reward outputs, and its reward-withdrawal witnesses
 - Links out to Preview GovTool for proposal and voting workflows
+
+### Inactivity And Expiry
+
+Two separate expiry mechanisms show up in the UI, and neither is the same thing
+as a registration being active.
+
+A DRep's `active` flag only clears on deregistration. Inactivity expiry is
+separate: a DRep vote, registration, or update certificate sets
+`last_activity_epoch` and pushes `expiry_epoch` out by the protocol's DRep
+inactivity period, and the Conway tally drops a DRep whose `expiry_epoch` has
+been reached. The DReps table shows both, so a DRep can read active and expired
+at the same time. The expiry filter uses the same test the tally uses: a zero
+`expiry_epoch` means no activity has been recorded yet and counts as unexpired.
+
+Reward-account inactivity is the CIP-0163 equivalent for stake credentials, held
+behind a node flag. With the flag off, every `account.expiration_epoch` is 0 and
+the stake lookup reports the expiry as not enabled. Enabling it also requires a
+from-genesis sync, because the column cannot be reconstructed from a Mithril
+snapshot, so the Compose stack in this directory always reports it as not
+enabled. The withdrawal witnesses below it are recorded either way: Dingo
+records a witness for every valid reward-withdrawal map entry, so a withdrawal
+that moved no reward still appears, marked as a zero amount.
+
+### Retention
+
+Epoch and reward history is retained asymmetrically, which decides how far back
+each panel can look:
+
+- Retained for the life of the database: `epoch`, `epoch_summary`,
+  `reward_ada_pots`, `reward_snapshot`, `reward_pool_input`, and
+  `reward_pool_output`. These are one row per epoch, or roughly one row per pool
+  per epoch, and they are what the Epochs panel reads.
+- Pruned at every epoch transition to the last four epochs:
+  `pool_stake_snapshot`, `reward_stake_input`, and `reward_account_output`.
+  These scale with delegator count.
+
+So the Epochs panel reaches back to the first boundary the node captured, while
+the per-epoch reward outputs in the stake lookup only cover the current epoch and
+the three before it. An older epoch showing no reward rows for an account is
+retention, not a missing calculation.
 
 ## Bootstrap Dingo Quickly
 
@@ -120,6 +169,20 @@ For Kubernetes, start from `k8s/dingo-values.yaml`. Replace the Postgres DSN
 with your cluster-local database service and mount the configured CA certificate
 from a Secret in your own chart overlay.
 
+### Dingo version
+
+Use 0.68.0 or newer. DRep activity renewal from certificates landed in 0.68.0,
+and without it `drep.expiry_epoch` is not maintained from vote and update
+certificates, so the expiry column and the `expiry` filter report stale
+answers rather than wrong-looking ones. CIP-0163 account expiry columns need
+0.67.0, and the reward metadata tables need 0.65.0.
+
+The Epochs tab reaches only the last four epochs on a released node. Retaining
+`epoch_summary` and the per-epoch reward tables for the life of the database is
+newer than 0.68.0 and not in a tagged release yet; before it, those rows were
+pruned to `epoch < current-3` at every epoch transition. The tab works either
+way, it just shows a short window until you run a node built from `main`.
+
 ## Read-Only Database User
 
 Create an application role that can only read the Dingo metadata schema:
@@ -131,6 +194,14 @@ psql "$ADMIN_DATABASE_URL" -f sql/create-readonly-user.sql
 Edit the SQL first so the database name, Dingo owner role, and password match
 your environment.
 Use the read-only role in the app's `DATABASE_URL`.
+
+The grants are schema-wide rather than a table list: `GRANT SELECT ON ALL TABLES
+IN SCHEMA public` covers whatever exists when the script runs, and the
+`ALTER DEFAULT PRIVILEGES FOR ROLE <dingo owner>` line covers every table Dingo
+creates later. Tables added by a Dingo upgrade, including the reward and
+inactivity tables this app reads, are therefore readable without editing the
+script. The same is true of `docker/postgres-init/001-create-readonly-user.sh`,
+which runs at cluster init before Dingo has created any table.
 
 ## Run The App
 
@@ -150,12 +221,34 @@ Open `http://127.0.0.1:8088`.
 - `GET /api/status`
 - `GET /api/proposals?lifecycle=active&action_type=6`
 - `GET /api/proposals/{txHash}/{actionIndex}`
-- `GET /api/dreps?active=true`
+- `GET /api/dreps?active=true&expiry=expired`
 - `GET /api/dreps/{credentialHex}?credential_tag=0`
 - `GET /api/stake/{stakeCredentialHex}?credential_tag=0`
+- `GET /api/epochs?limit=50`
+
+`expiry` accepts `expired` or `active` and can be combined with `active`, which
+filters on registration instead.
+
+`/api/status` reports `expiredDrepCount`, `latestRewardEpoch` (the newest epoch
+with captured ADA pots), and `accountInactivity`, which says whether the one-time
+CIP-0163 activation has run and in which epoch.
+
+`/api/stake/{credential}` adds `expirationEpoch`, `inactivityActivated`,
+`rewards` (per-epoch reward outputs within the retained window), and
+`withdrawals` (reward-withdrawal witnesses, with `zeroAmount` set when the
+withdrawal moved nothing).
 
 All query handlers use direct SQL against Dingo metadata tables. The browser
 never connects to Postgres directly.
+
+Tables read: `node_settings`, `commit_timestamp`, `tip`, `epoch`,
+`epoch_summary`, `backfill_checkpoint`, `sync_state`, `governance_proposal`,
+`governance_vote`, `drep`, `registration_drep`, `update_drep`,
+`deregistration_drep`, `vote_delegation`, `stake_vote_delegation`,
+`vote_registration_delegation`, `stake_vote_registration_delegation`, `certs`,
+`transaction`, `account`, `account_inactivity_activation`,
+`account_withdrawal_witness`, `account_reward_delta`, `reward_ada_pots`,
+`reward_snapshot`, `reward_pool_output`, and `reward_account_output`.
 
 ## Local Checks
 

--- a/examples/dingo-gov-lens/k8s/dingo-values.yaml
+++ b/examples/dingo-gov-lens/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.64.0"
+  tag: "0.68.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-gov-lens/main.go
+++ b/examples/dingo-gov-lens/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -41,17 +42,29 @@ type app struct {
 }
 
 type statusResponse struct {
-	Network             string          `json:"network"`
-	StorageMode         string          `json:"storageMode"`
-	Tip                 *tip            `json:"tip,omitempty"`
-	LatestEpoch         *epoch          `json:"latestEpoch,omitempty"`
-	ProposalCount       int64           `json:"proposalCount"`
-	GovernanceVoteCount int64           `json:"governanceVoteCount"`
-	ActiveDrepCount     int64           `json:"activeDrepCount"`
-	MinLiveProposalSlot uint64          `json:"minLiveProposalSlot,omitempty"`
-	Backfill            *backfillStatus `json:"backfill,omitempty"`
-	VoteBackfillPending bool            `json:"voteBackfillPending"`
-	LastMetadataWrite   *time.Time      `json:"lastMetadataWrite,omitempty"`
+	Network             string             `json:"network"`
+	StorageMode         string             `json:"storageMode"`
+	Tip                 *tip               `json:"tip,omitempty"`
+	LatestEpoch         *epoch             `json:"latestEpoch,omitempty"`
+	ProposalCount       int64              `json:"proposalCount"`
+	GovernanceVoteCount int64              `json:"governanceVoteCount"`
+	ActiveDrepCount     int64              `json:"activeDrepCount"`
+	ExpiredDrepCount    int64              `json:"expiredDrepCount"`
+	MinLiveProposalSlot uint64             `json:"minLiveProposalSlot,omitempty"`
+	LatestRewardEpoch   *uint64            `json:"latestRewardEpoch,omitempty"`
+	AccountInactivity   *accountInactivity `json:"accountInactivity,omitempty"`
+	Backfill            *backfillStatus    `json:"backfill,omitempty"`
+	VoteBackfillPending bool               `json:"voteBackfillPending"`
+	LastMetadataWrite   *time.Time         `json:"lastMetadataWrite,omitempty"`
+}
+
+// accountInactivity reports whether the node has run the one-time CIP-0163
+// reward-account inactivity activation. Without it, every
+// account.expiration_epoch is 0 (unset) and reward-account expiry is not being
+// enforced, so the stake lookup must not present the column as meaningful.
+type accountInactivity struct {
+	Activated       bool   `json:"activated"`
+	ActivationEpoch uint64 `json:"activationEpoch"`
 }
 
 type tip struct {
@@ -137,9 +150,23 @@ type drep struct {
 	AddedSlot         uint64 `json:"addedSlot"`
 	LastActivityEpoch uint64 `json:"lastActivityEpoch"`
 	ExpiryEpoch       uint64 `json:"expiryEpoch"`
+	// ExpiryStatus is the inactivity state the Conway tally applies:
+	// "expired" when expiry_epoch has been reached, "active" when it has
+	// not, "unknown" when no activity has ever been recorded (expiry_epoch
+	// 0) or the latest epoch is not known yet. Independent of Active, which
+	// only tracks registration.
+	ExpiryStatus string `json:"expiryStatus"`
+	// EpochsUntilExpiry is expiry_epoch minus the latest epoch, so a
+	// non-positive value means the DRep is already expired. Nil when
+	// ExpiryStatus is "unknown".
+	EpochsUntilExpiry *int64 `json:"epochsUntilExpiry,omitempty"`
 	Active            bool   `json:"active"`
 	DelegatorCount    int64  `json:"delegatorCount"`
 	VoteCount         int64  `json:"voteCount"`
+	// FirstSeenSlot and LastRegistrationSlot come from certificate history
+	// and are only populated by the DRep detail endpoint.
+	FirstSeenSlot        uint64 `json:"firstSeenSlot,omitempty"`
+	LastRegistrationSlot uint64 `json:"lastRegistrationSlot,omitempty"`
 }
 
 type drepDetail struct {
@@ -186,6 +213,61 @@ type stakeLookup struct {
 	DRepType      int64  `json:"drepType"`
 	Reward        string `json:"reward"`
 	Active        bool   `json:"active"`
+	// ExpirationEpoch is the CIP-0163 reward-account inactivity expiry. 0
+	// means unset, which is every account on a node running without
+	// delegator inactivity enabled.
+	ExpirationEpoch uint64 `json:"expirationEpoch"`
+	// InactivityActivated reports membership in the one-time CIP-0163
+	// activation stamp (account_inactivity_activation).
+	InactivityActivated bool                `json:"inactivityActivated"`
+	Rewards             []accountReward     `json:"rewards"`
+	Withdrawals         []withdrawalWitness `json:"withdrawals"`
+}
+
+// accountReward is one persisted per-epoch reward-calculation output row for a
+// stake credential. Only the retained snapshot window (the current epoch and
+// the three before it) is queryable; older per-credential rows are pruned.
+type accountReward struct {
+	Epoch        uint64 `json:"epoch"`
+	PoolKeyHash  string `json:"poolKeyHash,omitempty"`
+	RewardType   string `json:"rewardType"`
+	Amount       string `json:"amount"`
+	Spendable    bool   `json:"spendable"`
+	BoundarySlot uint64 `json:"boundarySlot"`
+}
+
+// withdrawalWitness is one CIP-0163 reward-withdrawal witness. Every valid
+// withdrawal-map entry is recorded, so a witness with no matching reward delta
+// is a zero-amount withdrawal that still counts as account activity.
+type withdrawalWitness struct {
+	TxHash     string `json:"txHash"`
+	AddedSlot  uint64 `json:"addedSlot"`
+	Amount     string `json:"amount,omitempty"`
+	ZeroAmount bool   `json:"zeroAmount"`
+}
+
+// epochRow is one epoch of retained epoch and reward state. Every table joined
+// here is retained for the life of the database, so the history reaches back to
+// the first boundary the node captured.
+type epochRow struct {
+	EpochID          uint64 `json:"epochId"`
+	StartSlot        uint64 `json:"startSlot"`
+	EraID            uint64 `json:"eraId"`
+	Treasury         string `json:"treasury,omitempty"`
+	Reserves         string `json:"reserves,omitempty"`
+	Fees             string `json:"fees,omitempty"`
+	Rewards          string `json:"rewards,omitempty"`
+	PotsCapturedSlot uint64 `json:"potsCapturedSlot,omitempty"`
+	ActiveStake      string `json:"activeStake,omitempty"`
+	PoolCount        uint64 `json:"poolCount"`
+	DelegatorCount   uint64 `json:"delegatorCount"`
+	SnapshotReady    bool   `json:"snapshotReady"`
+	// RewardBasisStake is the reward-side stake total, which differs from
+	// ActiveStake because the reward basis excludes pools with degraded
+	// registration data.
+	RewardBasisStake string `json:"rewardBasisStake,omitempty"`
+	Authoritative    bool   `json:"authoritative"`
+	PoolOutputCount  int64  `json:"poolOutputCount"`
 }
 
 func main() {
@@ -220,6 +302,7 @@ func main() {
 	mux.HandleFunc("GET /api/dreps", a.handleDreps)
 	mux.HandleFunc("GET /api/dreps/{credential}", a.handleDrepDetail)
 	mux.HandleFunc("GET /api/stake/{credential}", a.handleStakeLookup)
+	mux.HandleFunc("GET /api/epochs", a.handleEpochs)
 
 	static, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -326,6 +409,35 @@ func (a *app) handleStatus(w http.ResponseWriter, r *http.Request) {
 		serverError(w, r, "count dreps", err)
 		return
 	}
+	// Registered DReps whose inactivity expiry has passed. They still read
+	// active (that flag only clears on deregistration) but the Conway tally
+	// drops them from the voting-power denominator.
+	if err := a.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM drep d
+		WHERE d.active = true
+			AND `+drepExpiredPredicate).Scan(&ret.ExpiredDrepCount); err != nil {
+		serverError(w, r, "count expired dreps", err)
+		return
+	}
+	var latestRewardEpoch sql.NullInt64
+	if err := a.db.QueryRowContext(ctx, `
+		SELECT MAX(epoch)
+		FROM reward_ada_pots
+	`).Scan(&latestRewardEpoch); err != nil {
+		serverError(w, r, "query latest reward epoch", err)
+		return
+	}
+	if latestRewardEpoch.Valid && latestRewardEpoch.Int64 >= 0 {
+		v := uint64(latestRewardEpoch.Int64)
+		ret.LatestRewardEpoch = &v
+	}
+	inactivity, err := a.accountInactivityStatus(ctx)
+	if err != nil {
+		serverError(w, r, "query account inactivity", err)
+		return
+	}
+	ret.AccountInactivity = inactivity
 	var bf backfillStatus
 	var bfUpdatedAt sql.NullTime
 	switch err := a.db.QueryRowContext(ctx, `
@@ -382,6 +494,46 @@ func voteBackfillPending(
 		backfill != nil &&
 		!backfill.Completed &&
 		backfill.LastSlot < minLiveProposalSlot
+}
+
+// accountInactivityStatus reads the CIP-0163 activation state. The marker row
+// carries the activation epoch, but it lives in sync_state, which a completed
+// sync/load run clears wholesale, so the recorded activation membership is used
+// as the fallback signal that activation has already happened.
+func (a *app) accountInactivityStatus(
+	ctx context.Context,
+) (*accountInactivity, error) {
+	ret := &accountInactivity{}
+	var marker string
+	switch err := a.db.QueryRowContext(ctx, `
+		SELECT value
+		FROM sync_state
+		WHERE sync_key = 'delegator_inactivity_activated'
+	`).Scan(&marker); {
+	case err == nil:
+		marker = strings.TrimSpace(marker)
+		if marker != "" {
+			ret.Activated = true
+			if epoch, parseErr := strconv.ParseUint(marker, 10, 64); parseErr == nil {
+				ret.ActivationEpoch = epoch
+			}
+		}
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, err
+	}
+	if ret.Activated {
+		return ret, nil
+	}
+	if err := a.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM account_inactivity_activation
+		)
+	`).Scan(&ret.Activated); err != nil {
+		return nil, err
+	}
+	return ret, nil
 }
 
 func (a *app) handleProposals(w http.ResponseWriter, r *http.Request) {
@@ -601,6 +753,19 @@ func (a *app) handleDreps(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid active filter", http.StatusBadRequest)
 		return
 	}
+	expiryClause, ok := drepExpiryPredicate(r.URL.Query().Get("expiry"))
+	if !ok {
+		http.Error(w, "invalid expiry filter", http.StatusBadRequest)
+		return
+	}
+	if expiryClause != "" {
+		where = append(where, expiryClause)
+	}
+	latestEpoch, err := a.latestEpochID(ctx)
+	if err != nil {
+		serverError(w, r, "query latest epoch", err)
+		return
+	}
 	args = append(args, limit)
 	rows, err := a.db.QueryContext(ctx, `
 		SELECT
@@ -609,8 +774,8 @@ func (a *app) handleDreps(w http.ResponseWriter, r *http.Request) {
 			COALESCE(d.anchor_url, ''),
 			COALESCE(encode(d.anchor_hash, 'hex'), ''),
 			d.added_slot,
-			d.last_activity_epoch,
-			d.expiry_epoch,
+			COALESCE(d.last_activity_epoch, 0),
+			COALESCE(d.expiry_epoch, 0),
 			d.active,
 			COUNT(DISTINCT a.id) FILTER (WHERE a.active = true) AS delegator_count,
 			COUNT(DISTINCT gv.id) FILTER (WHERE gv.deleted_slot IS NULL) AS vote_count
@@ -649,6 +814,10 @@ func (a *app) handleDreps(w http.ResponseWriter, r *http.Request) {
 			serverError(w, r, "scan drep", err)
 			return
 		}
+		item.ExpiryStatus, item.EpochsUntilExpiry = drepExpiryState(
+			item.ExpiryEpoch,
+			latestEpoch,
+		)
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -678,8 +847,8 @@ func (a *app) handleDrepDetail(w http.ResponseWriter, r *http.Request) {
 			COALESCE(d.anchor_url, ''),
 			COALESCE(encode(d.anchor_hash, 'hex'), ''),
 			d.added_slot,
-			d.last_activity_epoch,
-			d.expiry_epoch,
+			COALESCE(d.last_activity_epoch, 0),
+			COALESCE(d.expiry_epoch, 0),
 			d.active,
 			COUNT(DISTINCT a.id) FILTER (WHERE a.active = true) AS delegator_count,
 			COUNT(DISTINCT gv.id) FILTER (WHERE gv.deleted_slot IS NULL) AS vote_count
@@ -727,6 +896,26 @@ func (a *app) handleDrepDetail(w http.ResponseWriter, r *http.Request) {
 		serverError(w, r, "query drep history", err)
 		return
 	}
+	firstSeen, lastRegistration, err := a.drepCertSlots(
+		ctx,
+		credential,
+		credentialTag,
+	)
+	if err != nil {
+		serverError(w, r, "query drep certificate slots", err)
+		return
+	}
+	ret.DRep.FirstSeenSlot = firstSeenSlot(firstSeen, ret.DRep.AddedSlot)
+	ret.DRep.LastRegistrationSlot = lastRegistration
+	latestEpoch, err := a.latestEpochID(ctx)
+	if err != nil {
+		serverError(w, r, "query latest epoch", err)
+		return
+	}
+	ret.DRep.ExpiryStatus, ret.DRep.EpochsUntilExpiry = drepExpiryState(
+		ret.DRep.ExpiryEpoch,
+		latestEpoch,
+	)
 	writeJSON(w, http.StatusOK, ret)
 }
 
@@ -752,7 +941,8 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 			COALESCE(encode(drep, 'hex'), ''),
 			drep_type,
 			reward::text,
-			active
+			active,
+			COALESCE(expiration_epoch, 0)
 		FROM account
 		WHERE staking_key = decode($1, 'hex')
 			AND credential_tag = $2
@@ -765,6 +955,7 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 		&ret.DRepType,
 		&ret.Reward,
 		&ret.Active,
+		&ret.ExpirationEpoch,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		http.NotFound(w, r)
@@ -774,7 +965,100 @@ func (a *app) handleStakeLookup(w http.ResponseWriter, r *http.Request) {
 		serverError(w, r, "query account", err)
 		return
 	}
+	if err := a.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM account_inactivity_activation
+			WHERE staking_key = decode($1, 'hex')
+				AND credential_tag = $2
+		)
+	`, credential, credentialTag).Scan(&ret.InactivityActivated); err != nil {
+		serverError(w, r, "query account activation", err)
+		return
+	}
+	ret.Rewards, err = a.accountRewards(ctx, credential, credentialTag)
+	if err != nil {
+		serverError(w, r, "query account rewards", err)
+		return
+	}
+	ret.Withdrawals, err = a.accountWithdrawals(ctx, credential, credentialTag)
+	if err != nil {
+		serverError(w, r, "query account withdrawals", err)
+		return
+	}
 	writeJSON(w, http.StatusOK, ret)
+}
+
+func (a *app) handleEpochs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	limit := boundedLimit(r.URL.Query().Get("limit"), 50, 250)
+	// Every joined table is retained for the life of the database, so this
+	// reaches every boundary the node captured. The per-credential reward
+	// tables are the only ones pruned to the four-epoch snapshot window.
+	rows, err := a.db.QueryContext(ctx, `
+		SELECT
+			COALESCE(e.epoch_id, 0),
+			COALESCE(e.start_slot, 0),
+			COALESCE(e.era_id, 0),
+			COALESCE(p.treasury::text, ''),
+			COALESCE(p.reserves::text, ''),
+			COALESCE(p.fees::text, ''),
+			COALESCE(p.rewards::text, ''),
+			COALESCE(p.captured_slot, 0),
+			COALESCE(es.total_active_stake::text, ''),
+			COALESCE(es.total_pool_count, 0),
+			COALESCE(es.total_delegators, 0),
+			COALESCE(es.snapshot_ready, false),
+			COALESCE(rs.total_active_stake::text, ''),
+			COALESCE(rs.authoritative, false),
+			(
+				SELECT COUNT(*)
+				FROM reward_pool_output rpo
+				WHERE rpo.epoch = e.epoch_id
+			) AS pool_output_count
+		FROM epoch e
+		LEFT JOIN reward_ada_pots p ON p.epoch = e.epoch_id
+		LEFT JOIN epoch_summary es ON es.epoch = e.epoch_id
+		LEFT JOIN reward_snapshot rs ON rs.epoch = e.epoch_id
+			AND rs.snapshot_type = 'mark'
+		ORDER BY e.epoch_id DESC
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		serverError(w, r, "query epochs", err)
+		return
+	}
+	defer rows.Close()
+	items := []epochRow{}
+	for rows.Next() {
+		var item epochRow
+		if err := rows.Scan(
+			&item.EpochID,
+			&item.StartSlot,
+			&item.EraID,
+			&item.Treasury,
+			&item.Reserves,
+			&item.Fees,
+			&item.Rewards,
+			&item.PotsCapturedSlot,
+			&item.ActiveStake,
+			&item.PoolCount,
+			&item.DelegatorCount,
+			&item.SnapshotReady,
+			&item.RewardBasisStake,
+			&item.Authoritative,
+			&item.PoolOutputCount,
+		); err != nil {
+			serverError(w, r, "scan epoch", err)
+			return
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		serverError(w, r, "read epochs", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, items)
 }
 
 func (a *app) proposalVotes(ctx context.Context, proposalID int64) ([]voteRow, voteStats, error) {
@@ -977,6 +1261,171 @@ func (a *app) drepHistory(
 	return ret, rows.Err()
 }
 
+// drepCertSlots returns the credential's first on-chain appearance slot and the
+// added_slot of its most recent real registration certificate. The first
+// appearance survives deregister/re-register cycles because it also considers
+// update and vote-delegation references. Both are 0 when no certificate history
+// exists, which is the normal state for a core-mode or pre-backfill database.
+func (a *app) drepCertSlots(
+	ctx context.Context,
+	credential string,
+	credentialTag uint8,
+) (uint64, uint64, error) {
+	var firstSeen, lastRegistration sql.NullInt64
+	// certificate_id filters out the synthetic registration rows a Mithril
+	// ledger-state import writes at the bootstrap slot; only real on-chain
+	// certificates count as a registration.
+	err := a.db.QueryRowContext(ctx, `
+		SELECT MIN(first_slot), MAX(registration_slot)
+		FROM (
+			SELECT
+				MIN(added_slot) AS first_slot,
+				MAX(
+					CASE
+						WHEN certificate_id IS NOT NULL AND certificate_id != 0
+						THEN added_slot
+					END
+				) AS registration_slot
+			FROM registration_drep
+			WHERE drep_credential = decode($1, 'hex')
+				AND credential_tag = $2::bigint
+
+			UNION ALL
+			SELECT MIN(added_slot), NULL
+			FROM update_drep
+			WHERE credential = decode($1, 'hex')
+				AND credential_tag = $2::bigint
+
+			UNION ALL
+			SELECT MIN(added_slot), NULL
+			FROM vote_delegation
+			WHERE drep = decode($1, 'hex')
+				AND drep_type = $2::bigint
+
+			UNION ALL
+			SELECT MIN(added_slot), NULL
+			FROM stake_vote_delegation
+			WHERE drep = decode($1, 'hex')
+				AND drep_type = $2::bigint
+
+			UNION ALL
+			SELECT MIN(added_slot), NULL
+			FROM vote_registration_delegation
+			WHERE drep = decode($1, 'hex')
+				AND drep_type = $2::bigint
+
+			UNION ALL
+			SELECT MIN(added_slot), NULL
+			FROM stake_vote_registration_delegation
+			WHERE drep = decode($1, 'hex')
+				AND drep_type = $2::bigint
+		) slots
+	`, credential, credentialTag).Scan(&firstSeen, &lastRegistration)
+	if err != nil {
+		return 0, 0, err
+	}
+	return nullSlot(firstSeen), nullSlot(lastRegistration), nil
+}
+
+// latestEpochID returns the highest known epoch, invalid when the node has not
+// recorded an epoch yet.
+func (a *app) latestEpochID(ctx context.Context) (sql.NullInt64, error) {
+	var ret sql.NullInt64
+	if err := a.db.QueryRowContext(ctx, `
+		SELECT MAX(epoch_id)
+		FROM epoch
+	`).Scan(&ret); err != nil {
+		return sql.NullInt64{}, err
+	}
+	return ret, nil
+}
+
+func (a *app) accountRewards(
+	ctx context.Context,
+	credential string,
+	credentialTag uint8,
+) ([]accountReward, error) {
+	rows, err := a.db.QueryContext(ctx, `
+		SELECT
+			epoch,
+			COALESCE(encode(pool_key_hash, 'hex'), ''),
+			reward_type,
+			amount::text,
+			spendable,
+			boundary_slot
+		FROM reward_account_output
+		WHERE staking_key = decode($1, 'hex')
+			AND credential_tag = $2
+		ORDER BY epoch DESC, reward_type ASC, pool_key_hash ASC
+		LIMIT 25
+	`, credential, credentialTag)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ret := []accountReward{}
+	for rows.Next() {
+		var item accountReward
+		if err := rows.Scan(
+			&item.Epoch,
+			&item.PoolKeyHash,
+			&item.RewardType,
+			&item.Amount,
+			&item.Spendable,
+			&item.BoundarySlot,
+		); err != nil {
+			return nil, err
+		}
+		ret = append(ret, item)
+	}
+	return ret, rows.Err()
+}
+
+// accountWithdrawals returns the account's CIP-0163 withdrawal witnesses joined
+// to the reward journal. A witness with no journal row is a zero-amount
+// withdrawal: the withdrawal path records a witness for every valid
+// withdrawal-map entry but only journals a delta when the amount is non-zero.
+func (a *app) accountWithdrawals(
+	ctx context.Context,
+	credential string,
+	credentialTag uint8,
+) ([]withdrawalWitness, error) {
+	rows, err := a.db.QueryContext(ctx, `
+		SELECT
+			encode(w.tx_hash, 'hex'),
+			w.added_slot,
+			COALESCE(d.amount::text, '')
+		FROM account_withdrawal_witness w
+		LEFT JOIN account_reward_delta d ON d.withdrawal = true
+			AND d.tx_hash = w.tx_hash
+			AND d.credential_tag = w.credential_tag
+			AND d.staking_key = w.staking_key
+			AND d.added_slot = w.added_slot
+		WHERE w.staking_key = decode($1, 'hex')
+			AND w.credential_tag = $2
+		ORDER BY w.added_slot DESC, w.tx_hash ASC
+		LIMIT 25
+	`, credential, credentialTag)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ret := []withdrawalWitness{}
+	for rows.Next() {
+		var item withdrawalWitness
+		if err := rows.Scan(
+			&item.TxHash,
+			&item.AddedSlot,
+			&item.Amount,
+		); err != nil {
+			return nil, err
+		}
+		item.ZeroAmount = withdrawalZeroAmount(item.Amount)
+		ret = append(ret, item)
+	}
+	return ret, rows.Err()
+}
+
 func enrichProposal(p *proposal, govtoolURL string) {
 	p.ActionTypeName = actionTypeName(p.ActionType)
 	p.GovToolURL = govtoolActionURL(govtoolURL, p.TxHash, p.ActionIndex)
@@ -1033,6 +1482,77 @@ func actionTypeName(v int64) string {
 	default:
 		return fmt.Sprintf("Type %d", v)
 	}
+}
+
+// drepExpiredPredicate and drepUnexpiredPredicate mirror the Conway tally's
+// inactivity test: a DRep is expired once expiry_epoch is set and has been
+// reached, and a zero expiry_epoch means no activity has been recorded yet and
+// is treated as unexpired. Both are independent of drep.active, which only
+// clears on deregistration.
+// expiry_epoch is a nullable column, so every comparison folds NULL into the
+// unset value first.
+const (
+	drepExpiredPredicate = `COALESCE(d.expiry_epoch, 0) > 0
+			AND COALESCE(d.expiry_epoch, 0) <=
+				COALESCE((SELECT MAX(epoch_id) FROM epoch), 0)`
+	drepUnexpiredPredicate = `(COALESCE(d.expiry_epoch, 0) = 0
+			OR COALESCE(d.expiry_epoch, 0) >
+				COALESCE((SELECT MAX(epoch_id) FROM epoch), 0))`
+)
+
+// drepExpiryPredicate maps the expiry filter to its SQL predicate. An empty
+// filter matches every DRep and returns an empty predicate.
+func drepExpiryPredicate(filter string) (string, bool) {
+	switch filter {
+	case "":
+		return "", true
+	case "expired":
+		return drepExpiredPredicate, true
+	case "active":
+		return drepUnexpiredPredicate, true
+	default:
+		return "", false
+	}
+}
+
+// drepExpiryState reports the inactivity state for a DRep's expiry epoch and
+// how many epochs remain before it expires. A non-positive remainder means the
+// DRep is already expired and its voting power is excluded from the tally.
+func drepExpiryState(
+	expiryEpoch uint64,
+	latestEpoch sql.NullInt64,
+) (string, *int64) {
+	if expiryEpoch == 0 || expiryEpoch > math.MaxInt64 ||
+		!latestEpoch.Valid || latestEpoch.Int64 < 0 {
+		return "unknown", nil
+	}
+	remaining := int64(expiryEpoch) - latestEpoch.Int64
+	if remaining <= 0 {
+		return "expired", &remaining
+	}
+	return "active", &remaining
+}
+
+// firstSeenSlot falls back to the DRep's current registration slot when no
+// certificate history is present to derive a first appearance from.
+func firstSeenSlot(certSlot, addedSlot uint64) uint64 {
+	if certSlot == 0 {
+		return addedSlot
+	}
+	return certSlot
+}
+
+// withdrawalZeroAmount reports whether a withdrawal witness moved no reward.
+func withdrawalZeroAmount(amount string) bool {
+	trimmed := strings.TrimSpace(amount)
+	return trimmed == "" || strings.Trim(trimmed, "0") == ""
+}
+
+func nullSlot(value sql.NullInt64) uint64 {
+	if !value.Valid || value.Int64 <= 0 {
+		return 0
+	}
+	return uint64(value.Int64)
 }
 
 func voterTypeName(v int64) string {

--- a/examples/dingo-gov-lens/main_test.go
+++ b/examples/dingo-gov-lens/main_test.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"database/sql"
+	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -87,6 +90,170 @@ func TestVoteBackfillPending(t *testing.T) {
 		Completed: true,
 	}) {
 		t.Fatal("completed backfill should not be pending")
+	}
+}
+
+func TestDrepExpiryPredicate(t *testing.T) {
+	tests := map[string]struct {
+		want string
+		ok   bool
+	}{
+		"":        {want: "", ok: true},
+		"expired": {want: drepExpiredPredicate, ok: true},
+		"active":  {want: drepUnexpiredPredicate, ok: true},
+		"bogus":   {want: "", ok: false},
+		"ACTIVE":  {want: "", ok: false},
+	}
+	for filter, expected := range tests {
+		got, ok := drepExpiryPredicate(filter)
+		if ok != expected.ok {
+			t.Fatalf("drepExpiryPredicate(%q) ok = %v, want %v", filter, ok, expected.ok)
+		}
+		if got != expected.want {
+			t.Fatalf("drepExpiryPredicate(%q) = %q, want %q", filter, got, expected.want)
+		}
+	}
+}
+
+func TestDrepExpiryState(t *testing.T) {
+	epoch := func(v int64) sql.NullInt64 {
+		return sql.NullInt64{Int64: v, Valid: true}
+	}
+
+	status, remaining := drepExpiryState(0, epoch(120))
+	if status != "unknown" || remaining != nil {
+		t.Fatalf("zero expiry epoch = (%q, %v), want (unknown, nil)", status, remaining)
+	}
+
+	status, remaining = drepExpiryState(120, sql.NullInt64{})
+	if status != "unknown" || remaining != nil {
+		t.Fatalf("unknown latest epoch = (%q, %v), want (unknown, nil)", status, remaining)
+	}
+
+	status, remaining = drepExpiryState(125, epoch(120))
+	if status != "active" || remaining == nil || *remaining != 5 {
+		t.Fatalf("unexpired = (%q, %v), want (active, 5)", status, remaining)
+	}
+
+	// The Conway tally treats expiry_epoch <= current epoch as expired, so
+	// an equal epoch is already expired rather than about to expire.
+	status, remaining = drepExpiryState(120, epoch(120))
+	if status != "expired" || remaining == nil || *remaining != 0 {
+		t.Fatalf("expiry at current epoch = (%q, %v), want (expired, 0)", status, remaining)
+	}
+
+	status, remaining = drepExpiryState(100, epoch(120))
+	if status != "expired" || remaining == nil || *remaining != -20 {
+		t.Fatalf("expired = (%q, %v), want (expired, -20)", status, remaining)
+	}
+
+	// A bigint column cannot hold an epoch this large, so an unrepresentable
+	// value is reported as unknown rather than wrapped into a bogus count.
+	status, remaining = drepExpiryState(math.MaxUint64, epoch(120))
+	if status != "unknown" || remaining != nil {
+		t.Fatalf("unrepresentable expiry = (%q, %v), want (unknown, nil)", status, remaining)
+	}
+}
+
+func TestFirstSeenSlot(t *testing.T) {
+	if got := firstSeenSlot(4_000, 9_000); got != 4_000 {
+		t.Fatalf("firstSeenSlot with cert history = %d, want 4000", got)
+	}
+	if got := firstSeenSlot(0, 9_000); got != 9_000 {
+		t.Fatalf("firstSeenSlot without cert history = %d, want 9000", got)
+	}
+}
+
+func TestWithdrawalZeroAmount(t *testing.T) {
+	tests := map[string]bool{
+		"":        true,
+		" ":       true,
+		"0":       true,
+		"000":     true,
+		"1":       false,
+		"100":     false,
+		"1000000": false,
+	}
+	for amount, expected := range tests {
+		if got := withdrawalZeroAmount(amount); got != expected {
+			t.Fatalf("withdrawalZeroAmount(%q) = %v, want %v", amount, got, expected)
+		}
+	}
+}
+
+func TestNullSlot(t *testing.T) {
+	if got := nullSlot(sql.NullInt64{}); got != 0 {
+		t.Fatalf("nullSlot(invalid) = %d, want 0", got)
+	}
+	if got := nullSlot(sql.NullInt64{Int64: -5, Valid: true}); got != 0 {
+		t.Fatalf("nullSlot(negative) = %d, want 0", got)
+	}
+	if got := nullSlot(sql.NullInt64{Int64: 77, Valid: true}); got != 77 {
+		t.Fatalf("nullSlot(77) = %d, want 77", got)
+	}
+}
+
+func TestDrepJSONOmitsUnknownExpiryFields(t *testing.T) {
+	body, err := json.Marshal(drep{
+		Credential:   "aa",
+		ExpiryStatus: "unknown",
+	})
+	if err != nil {
+		t.Fatalf("marshal drep: %v", err)
+	}
+	encoded := string(body)
+	for _, field := range []string{
+		"epochsUntilExpiry",
+		"firstSeenSlot",
+		"lastRegistrationSlot",
+	} {
+		if strings.Contains(encoded, field) {
+			t.Fatalf("drep JSON = %s, want %q omitted", encoded, field)
+		}
+	}
+	if !strings.Contains(encoded, `"expiryStatus":"unknown"`) {
+		t.Fatalf("drep JSON = %s, want expiryStatus", encoded)
+	}
+}
+
+func TestHandleDrepsRejectsInvalidFilters(t *testing.T) {
+	// A nil database is safe here: both filters are validated before any
+	// query runs, so a rejected request must never reach the database.
+	a := &app{}
+	for _, query := range []string{
+		"/api/dreps?active=maybe",
+		"/api/dreps?expiry=soon",
+	} {
+		req := httptest.NewRequest(http.MethodGet, query, nil)
+		rec := httptest.NewRecorder()
+		a.handleDreps(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("GET %s status = %d, want %d", query, rec.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestHandleStakeLookupRejectsInvalidInput(t *testing.T) {
+	a := &app{}
+	validCredential := strings.Repeat("ab", 28)
+	tests := map[string]string{
+		"short credential": "/api/stake/abcd?credential_tag=0",
+		"missing tag":      "/api/stake/" + validCredential,
+		"invalid tag":      "/api/stake/" + validCredential + "?credential_tag=2",
+	}
+	for name, target := range tests {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		// PathValue is only populated by the router, so set the pattern
+		// values the handler reads directly.
+		req.SetPathValue("credential", strings.TrimSuffix(
+			strings.TrimPrefix(strings.Split(target, "?")[0], "/api/stake/"),
+			"/",
+		))
+		a.handleStakeLookup(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, want %d", name, rec.Code, http.StatusBadRequest)
+		}
 	}
 }
 

--- a/examples/dingo-gov-lens/static/app.js
+++ b/examples/dingo-gov-lens/static/app.js
@@ -8,6 +8,7 @@ const statusEl = $("#status");
 const metadataNotice = $("#metadata-notice");
 const proposalRows = $("#proposal-rows");
 const drepRows = $("#drep-rows");
+const epochRows = $("#epoch-rows");
 const dialog = $("#detail-dialog");
 const detailContent = $("#detail-content");
 
@@ -32,6 +33,7 @@ $("#refresh").addEventListener("click", asyncHandler(refresh));
 $("#proposal-lifecycle").addEventListener("change", asyncHandler(loadProposals));
 $("#proposal-type").addEventListener("change", asyncHandler(loadProposals));
 $("#drep-active").addEventListener("change", asyncHandler(loadDreps));
+$("#drep-expiry").addEventListener("change", asyncHandler(loadDreps));
 $("#wallet-connect").addEventListener("click", asyncHandler(connectWallet, showStakeError));
 $("#stake-form").addEventListener("submit", async (event) => {
   event.preventDefault();
@@ -46,18 +48,7 @@ $("#stake-form").addEventListener("submit", async (event) => {
     const data = await api(
       `/api/stake/${encodeURIComponent(credential)}?credential_tag=${encodeURIComponent(credentialTag)}`,
     );
-    result.innerHTML = `
-      <div class="detail-grid">
-        ${metric("Stake", shortHex(data.stakingKey))}
-        ${metric("Type", credentialTypeName(data.credentialTag))}
-        ${metric("Created slot", number(data.createdSlot))}
-        ${metric("Active", data.active ? "yes" : "no")}
-        ${metric("Reward", lovelace(data.reward))}
-        ${metric("DRep type", data.drepType)}
-      </div>
-      <p class="mono">Pool: ${data.pool || "none"}</p>
-      <p class="mono">DRep: ${data.drep || "none"}</p>
-    `;
+    result.innerHTML = renderStakeAccount(data);
   } catch (error) {
     result.innerHTML = `<div class="empty">${escapeHtml(error.message)}</div>`;
   }
@@ -71,6 +62,8 @@ async function refresh() {
     await loadProposals();
   } else if (state.view === "dreps") {
     await loadDreps();
+  } else if (state.view === "epochs") {
+    await loadEpochs();
   }
 }
 
@@ -85,6 +78,8 @@ async function loadStatus() {
     metric("Actions", number(data.proposalCount)),
     metric("Votes", number(data.governanceVoteCount)),
     metric("Active DReps", number(data.activeDrepCount)),
+    metric("Expired DReps", number(data.expiredDrepCount)),
+    metric("Reward epoch", number(data.latestRewardEpoch)),
     metric("Backfill", data.backfill?.completed ? "complete" : number(data.backfill?.lastSlot)),
   ].join("");
   renderMetadataNotice(data);
@@ -172,13 +167,15 @@ async function showProposal(txHash, index) {
 }
 
 async function loadDreps() {
-  drepRows.innerHTML = loadingRow(5);
+  drepRows.innerHTML = loadingRow(6);
   const params = new URLSearchParams();
   const active = $("#drep-active").value;
+  const expiry = $("#drep-expiry").value;
   if (active) params.set("active", active);
+  if (expiry) params.set("expiry", expiry);
   const rows = await api(`/api/dreps?${params.toString()}`);
   if (!rows.length) {
-    drepRows.innerHTML = emptyRow(5, "No matching DReps.");
+    drepRows.innerHTML = emptyRow(6, "No matching DReps.");
     return;
   }
   drepRows.innerHTML = rows
@@ -192,6 +189,7 @@ async function loadDreps() {
           ${renderAnchorBreak(row.anchorUrl)}
         </td>
         <td><span class="pill ${row.active ? "active" : "inactive"}">${row.active ? "active" : "inactive"}</span></td>
+        <td>${expiryPill(row)}</td>
         <td>activity ${number(row.lastActivityEpoch)}<br />expiry ${number(row.expiryEpoch)}</td>
         <td>${number(row.delegatorCount)}</td>
         <td>${number(row.voteCount)}</td>
@@ -220,6 +218,9 @@ async function showDrep(credential, credentialTag) {
       ${metric("Delegators", number(d.delegatorCount))}
       ${metric("Votes", number(d.voteCount))}
       ${metric("Expiry", number(d.expiryEpoch))}
+      ${metric("Inactivity", expiryText(d))}
+      ${metric("First seen slot", number(d.firstSeenSlot))}
+      ${metric("Last registration slot", d.lastRegistrationSlot ? number(d.lastRegistrationSlot) : "none")}
     </div>
     ${d.anchorUrl ? `<p>Anchor: ${renderLinkedUrl(d.anchorUrl)}</p>` : ""}
     <div class="detail-section">
@@ -260,6 +261,128 @@ async function showDrep(credential, credentialTag) {
     </div>
   `;
   dialog.showModal();
+}
+
+async function loadEpochs() {
+  epochRows.innerHTML = loadingRow(8);
+  const rows = await api("/api/epochs");
+  if (!rows.length) {
+    epochRows.innerHTML = emptyRow(8, "No epochs recorded yet.");
+    return;
+  }
+  epochRows.innerHTML = rows
+    .map((row) => `
+      <tr>
+        <td>${number(row.epochId)}<br /><span class="muted">era ${number(row.eraId)}</span></td>
+        <td>${lovelace(row.treasury)}</td>
+        <td>${lovelace(row.reserves)}</td>
+        <td>${lovelace(row.fees)}</td>
+        <td>${lovelace(row.rewards)}</td>
+        <td>${lovelace(row.activeStake)}<br /><span class="muted">reward basis ${lovelace(row.rewardBasisStake)}</span></td>
+        <td>${number(row.poolCount)} / ${number(row.delegatorCount)}</td>
+        <td>${captureCell(row)}</td>
+      </tr>
+    `)
+    .join("");
+}
+
+function captureCell(row) {
+  const pills = [];
+  if (row.snapshotReady) {
+    pills.push(`<span class="pill active">snapshot</span>`);
+  }
+  if (row.authoritative) {
+    pills.push(`<span class="pill active">authoritative</span>`);
+  } else if (row.snapshotReady) {
+    pills.push(`<span class="pill pending">provisional</span>`);
+  }
+  if (!pills.length) {
+    pills.push(`<span class="pill inactive">not captured</span>`);
+  }
+  return `${pills.join(" ")}<br /><span class="muted">${number(row.poolOutputCount)} pool results</span>`;
+}
+
+function renderStakeAccount(data) {
+  return `
+    <div class="detail-grid">
+      ${metric("Stake", shortHex(data.stakingKey))}
+      ${metric("Type", credentialTypeName(data.credentialTag))}
+      ${metric("Created slot", number(data.createdSlot))}
+      ${metric("Active", data.active ? "yes" : "no")}
+      ${metric("Reward", lovelace(data.reward))}
+      ${metric("DRep type", data.drepType)}
+      ${metric("Inactivity expiry", accountExpiryText(data))}
+    </div>
+    <p class="mono">Pool: ${escapeHtml(data.pool || "none")}</p>
+    <p class="mono">DRep: ${escapeHtml(data.drep || "none")}</p>
+    <div class="detail-section">
+      <h3>Reward outputs</h3>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Epoch</th><th>Type</th><th>Pool</th><th>Amount</th><th>Spendable</th></tr></thead>
+          <tbody>
+            ${(data.rewards || []).length ? data.rewards.map((reward) => `
+              <tr>
+                <td>${number(reward.epoch)}</td>
+                <td>${escapeHtml(reward.rewardType)}</td>
+                <td class="mono">${escapeHtml(shortHex(reward.poolKeyHash))}</td>
+                <td>${lovelace(reward.amount)}</td>
+                <td>${reward.spendable ? "yes" : "no"}</td>
+              </tr>
+            `).join("") : emptyRow(5, "No per-epoch reward rows in the retained four-epoch window.")}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="detail-section">
+      <h3>Withdrawal witnesses</h3>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Slot</th><th>Transaction</th><th>Amount</th></tr></thead>
+          <tbody>
+            ${(data.withdrawals || []).length ? data.withdrawals.map((withdrawal) => `
+              <tr>
+                <td>${number(withdrawal.addedSlot)}</td>
+                <td class="mono">${escapeHtml(shortHex(withdrawal.txHash))}</td>
+                <td>${withdrawal.zeroAmount
+                  ? `<span class="pill">zero amount</span>`
+                  : lovelace(withdrawal.amount)}</td>
+              </tr>
+            `).join("") : emptyRow(3, "No reward withdrawals recorded.")}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `;
+}
+
+function accountExpiryText(data) {
+  if (!state.status?.accountInactivity?.activated) {
+    return "not enabled";
+  }
+  if (!Number(data.expirationEpoch)) {
+    return "unset";
+  }
+  const activated = data.inactivityActivated ? " (activated)" : "";
+  return `epoch ${number(data.expirationEpoch)}${activated}`;
+}
+
+function expiryPill(row) {
+  const status = row.expiryStatus || "unknown";
+  const label = status === "unknown" ? "no activity" : status;
+  return `<span class="pill ${status === "active" ? "active" : status === "expired" ? "expired" : "pending"}">${escapeHtml(label)}</span>` +
+    `${status === "active" ? `<br /><span class="muted">${number(row.epochsUntilExpiry)} epochs left</span>` : ""}`;
+}
+
+function expiryText(row) {
+  const status = row.expiryStatus || "unknown";
+  if (status === "active") {
+    return `active, ${number(row.epochsUntilExpiry)} epochs left`;
+  }
+  if (status === "expired") {
+    return "expired";
+  }
+  return "no activity recorded";
 }
 
 async function api(path) {

--- a/examples/dingo-gov-lens/static/index.html
+++ b/examples/dingo-gov-lens/static/index.html
@@ -23,6 +23,7 @@
         <div class="tabs" role="tablist">
           <button class="tab active" id="tab-proposals" data-view="proposals" type="button" role="tab" aria-selected="true" aria-controls="panel-proposals">Actions</button>
           <button class="tab" id="tab-dreps" data-view="dreps" type="button" role="tab" aria-selected="false" aria-controls="panel-dreps">DReps</button>
+          <button class="tab" id="tab-epochs" data-view="epochs" type="button" role="tab" aria-selected="false" aria-controls="panel-epochs">Epochs</button>
           <button class="tab" id="tab-stake" data-view="stake" type="button" role="tab" aria-selected="false" aria-controls="panel-stake">Stake Lookup</button>
         </div>
         <button class="icon-button" id="refresh" type="button" title="Refresh">Refresh</button>
@@ -74,11 +75,19 @@
       <section class="view" id="panel-dreps" role="tabpanel" aria-labelledby="tab-dreps" aria-hidden="true">
         <div class="filters">
           <label>
-            Activity
+            Registration
             <select id="drep-active">
               <option value="true">Active</option>
               <option value="">All</option>
               <option value="false">Inactive</option>
+            </select>
+          </label>
+          <label>
+            Inactivity expiry
+            <select id="drep-expiry">
+              <option value="">Any</option>
+              <option value="active">Not expired</option>
+              <option value="expired">Expired</option>
             </select>
           </label>
         </div>
@@ -88,12 +97,38 @@
               <tr>
                 <th>DRep</th>
                 <th>Status</th>
+                <th>Expiry</th>
                 <th>Epochs</th>
                 <th>Delegators</th>
                 <th>Votes</th>
               </tr>
             </thead>
             <tbody id="drep-rows"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="view" id="panel-epochs" role="tabpanel" aria-labelledby="tab-epochs" aria-hidden="true">
+        <p class="muted">
+          Retained epoch and reward state. Per-epoch ADA pots, stake aggregates,
+          and per-pool reward results are kept for the life of the database; the
+          per-delegator rows behind them are pruned to the last four epochs.
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Epoch</th>
+                <th>Treasury</th>
+                <th>Reserves</th>
+                <th>Fees</th>
+                <th>Rewards</th>
+                <th>Active stake</th>
+                <th>Pools / Delegators</th>
+                <th>Capture</th>
+              </tr>
+            </thead>
+            <tbody id="epoch-rows"></tbody>
           </table>
         </div>
       </section>


### PR DESCRIPTION
Surfaces ledger and reward state in the gov lens example that landed since it was last updated.

## DRep inactivity expiry

DRep activity is now renewed from vote and update certificates, which makes `drep.expiry_epoch` trustworthy. Each DRep reports an expiry status and the epochs remaining, using the tally rule that `expiry_epoch > 0 AND expiry_epoch <= currentEpoch` is expired, and that a zero `expiry_epoch` has never been active and so is not expired.

Adds an `expiry=expired|active` filter, an Expiry column, and an expired DRep count in `/api/status`. The point is that a DRep can be registered and active while being expired by inactivity, so it is excluded from the voting power denominator. The old UI could not show that.

## DRep certificate provenance

The detail endpoint reports the credential's first on-chain appearance, taken as the earliest of the registration, update, and four vote delegation tables so it survives re-registration, plus the most recent real registration slot. Rows with `certificate_id = 0` are synthetic Mithril import rows and are excluded.

Kept on the detail endpoint rather than the list: resolving it for every DRep needs a six-table CTE, and the list query already does two grouped LEFT JOINs.

## Epochs endpoint and tab

New `GET /api/epochs` over the per-epoch reward record: the pots each epoch was paid from, epoch summary stake and pool totals with their snapshot-ready flag, the reward-side stake basis with its authoritative flag, and a per-epoch pool output count. The reward-side totals differ from the leader-election totals in `epoch_summary`, which is why both are shown.

## Stake lookup

Per-epoch reward outputs, and withdrawal witnesses joined to their reward deltas. Witnesses that moved no reward are marked as such, since a zero-amount withdrawal still counts as account activity and that is precisely why the witness table exists.

## CIP-0163 account expiry

Reads the account expiration epoch together with per-credential activation membership, falling back to membership when the sync-state marker has been cleared. Reports the gate as not enabled rather than implying the column is meaningful while it is off.

## Nullable column handling

`drep.expiry_epoch`, `drep.last_activity_epoch`, `account.expiration_epoch`, and the epoch listing columns are nullable but were scanned straight into `uint64`, so a NULL would fail the request. The columns this change reads or filters on are now coalesced and degrade to an unknown status. Dingo does not write NULLs there today, so this is defensive.

## Notes

No read-only role change is needed. Both grant scripts already use `GRANT SELECT ON ALL TABLES IN SCHEMA public` plus `ALTER DEFAULT PRIVILEGES`, which covers tables Dingo creates later, so a table list here would only rot.

Per-account reward history cannot exceed the retained window: `reward_account_output` and `reward_stake_input` are pruned at `epoch < currentEpoch-3` on every epoch transition in all storage modes. The UI and README state this, so absent rows do not look like a missing calculation.

Helm values move from 0.64.0 to 0.68.0, and the README records the version floor. Full epoch history additionally needs a build newer than 0.68.0, since retaining `epoch_summary` and the per-epoch reward tables for the life of the database is not in a tagged release yet.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test -count=1 ./...` passes, 13 tests (5 pre-existing, 8 added). No existing test or assertion was modified.
- `golangci-lint run ./...` reports the same finding set as the base commit
- Exercised against a throwaway Postgres whose schema came from `models.MigrateModels` AutoMigrate, covering every endpoint including both DRep detail cases, the expiry filters, a rejected filter value, a synthetic-registration credential, a zero-amount witness, and a NULL-valued row

`DATABASE.md` and `ARCHITECTURE.md` checked and not affected. This is confined to an example app in its own module and changes no models, migrations, store surfaces, EventBus topics, or component boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DRep inactivity expiry and per‑epoch reward/ledger insights to the `dingo-gov-lens` example so users can see expired DReps, stake snapshots, and reward provenance at a glance. Also surfaces CIP‑0163 account expiry, per‑epoch rewards, and withdrawal witnesses in stake lookup.

- **New Features**
  - DRePs: expiry status and epochs remaining; new `expiry=expired|active` filter, Expiry column, and `expiredDrepCount` in `/api/status` (independent of registration).
  - DRep detail: first on‑chain appearance and last real registration slot (excludes synthetic Mithril rows).
  - Epochs: new `GET /api/epochs` endpoint and tab showing ADA pots, leader vs reward-basis stake, snapshot/authority flags, and per-epoch pool result count.
  - Stake lookup: per‑epoch reward outputs (retained window), withdrawal witnesses with zero‑amount marking, `expirationEpoch`, and activation membership; `/api/status` adds `latestRewardEpoch` and `accountInactivity`.
  - Robust null handling for nullable columns (expiry/activity/account/epoch fields degrade to “unknown” instead of failing).

- **Dependencies**
  - Bump `ghcr.io/blinklabs-io/dingo` to `0.68.0` (DRep activity renewal; CIP‑0163 fields). Full epoch history requires a build newer than `0.68.0`.

<sup>Written for commit d6af18c33000589b0d2d6abba9c4545918a0b84c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

