### PR TITLE
docs(examples): sundae dingo network check and utxo views

### DIFF
--- a/examples/dingo-sundae-preview/README.md
+++ b/examples/dingo-sundae-preview/README.md
@@ -26,10 +26,21 @@ cd examples/dingo-sundae-preview
 ./scripts/port-forward-dingo.sh
 ```
 
-The example values pin Dingo `0.64.0`. The chart uses a `LoadBalancer` service
+The example values pin Dingo `0.68.0`. The chart uses a `LoadBalancer` service
 and enables only `DINGO_PLUGINS_API_UTXORPC_CONFIG_PORT`.
 If the load balancer is not reachable from the dev host, keep the port-forward
 open while running the frontend.
+
+Dingo `0.68.0` or newer is required. Earlier releases decoded the UTxO RPC
+`exact_address` search field as CBOR, so the raw address bytes that Blaze and
+the UTxO RPC SDK send were rejected, and the `payment_part` and
+`delegation_part` fields were decoded as whole addresses instead of 28-byte
+credentials. The address-scoped queries described below only work against
+`0.68.0` or newer.
+
+The app talks plain HTTP to Dingo through the Vite dev proxy. If you put Dingo
+behind its own TLS certificate instead, note that its UTxO RPC listener now
+requires TLS 1.2 or newer.
 
 ## Frontend
 
@@ -44,9 +55,66 @@ For a reachable LoadBalancer service, replace `DINGO_UTXORPC_URL` with that
 service URL, for example `http://192.168.4.211:9090`.
 
 The Vite dev server proxies UTxO RPC paths to Dingo, so the browser talks to the
-frontend origin while Dingo remains the only chain API. When Dingo is ready, the
-app scans Sundae V3 pool UTxOs through UTxO RPC, fills the pool dropdown, and
-shows reserve-derived spot prices and a price-impact chart. Until then it keeps
-a curated Preview pool fallback list. Connect a Preview-capable CIP-30 wallet,
-load a pool, choose either ADA-to-token or token-to-ADA, build/evaluate the
-order, then sign and submit through Dingo.
+frontend origin while Dingo remains the only chain API. On startup the app asks
+Dingo for its genesis and refuses to continue unless the endpoint reports the
+Preview network magic, because the Sundae V3 script hashes it uses are Preview
+only. It then scans Sundae V3 pool UTxOs through UTxO RPC, fills the pool
+dropdown, and shows reserve-derived spot prices and a price-impact chart. Until
+then it keeps a curated Preview pool fallback list. Connect a Preview-capable
+CIP-30 wallet, load a pool, choose either ADA-to-token or token-to-ADA,
+build/evaluate the order, then sign and submit through Dingo.
+
+## Wallet view from Dingo
+
+The wallet dropdown shows what Dingo itself holds for the connected wallet,
+next to what CIP-30 reports, so the two can be compared:
+
+- `Dingo UTxOs` is an exact-address search. Dingo compares the complete
+  serialized address bytes, so a base address does not pick up enterprise UTxOs
+  that merely share its payment credential.
+- `Stake cred` is a delegation-part search on the address stake credential. It
+  covers every address form that shares that credential, so it spans the whole
+  wallet rather than one address. It resolves at most the first 200 UTxOs and
+  says so when it truncates.
+
+Both refresh on connect and after a submitted order confirms.
+
+## What UTxO RPC does not answer
+
+Live staking state is not part of the UTxO RPC surface. Dingo answers
+stake-address-info and stake-snapshot queries over node-to-client
+LocalStateQuery only, so this app cannot show delegated stake, the delegated
+pool, available rewards, or DRep delegation. The stake-credential row above is a
+UTxO view of a stake credential, not a stake-address-info answer. A client that
+needs those values has to speak node-to-client to Dingo instead.
+
+The UTxO RPC surface Dingo exposes today is `ReadParams`, `ReadEraSummary`,
+`ReadUtxos`, `SearchUtxos`, `ReadData`, `ReadTx`, and `ReadGenesis` on the query
+service; `SubmitTx`, `WaitForTx`, `EvalTx`, `ReadMempool`, and `WatchMempool` on
+the submit service; `FetchBlock`, `DumpHistory`, `FollowTip`, and `ReadTip` on
+the sync service; and `WatchTx` on the watch service. This app uses the query
+and submit services.
+
+Order submission goes to Dingo's mempool, which now runs a configurable FIFO
+backend with double-buffered revalidation on the node side. That is a node
+configuration concern with no client-visible RPC change: `SubmitTx` still
+returns the transaction hash and `WaitForTx` still streams to the confirmed
+stage.
+
+## Dependency note
+
+`@blaze-cardano/sdk` is held at 0.2.48 on purpose. Both `@sundaeswap/core`
+2.12.0 and `@utxorpc/blaze-provider` 0.3.9 depend on 0.2.48, so pinning the
+direct dependency to the same version leaves exactly one copy of the SDK in
+the tree.
+
+Do not bump this to 0.3.x on its own. A 0.3.x direct dependency makes npm
+install a second copy of the SDK, and the `Blaze` instance this app builds
+then becomes a different nominal type from the one `TxBuilderV3` expects,
+which breaks `npm run build`. Casting past that error compiles but is worse
+than the error: it hands a 0.3.x object to code built against 0.2.48 inside
+the swap path, where a mismatch would surface as a malformed transaction
+rather than a type failure.
+
+Bump it when `@sundaeswap/core` and `@utxorpc/blaze-provider` move up, so all
+three stay on one version.

--- a/examples/dingo-sundae-preview/k8s/dingo-values.yaml
+++ b/examples/dingo-sundae-preview/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.64.0"
+  tag: "0.68.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-sundae-preview/package-lock.json
+++ b/examples/dingo-sundae-preview/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dingo-sundae-preview",
       "version": "0.1.0",
       "dependencies": {
-        "@blaze-cardano/sdk": "0.3.1",
+        "@blaze-cardano/sdk": "0.2.48",
         "@sundaeswap/asset": "1.0.11",
         "@sundaeswap/core": "2.12.0",
         "@utxorpc/blaze-provider": "0.3.9"
@@ -53,27 +53,12 @@
       }
     },
     "node_modules/@blaze-cardano/data": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/data/-/data-0.6.8.tgz",
-      "integrity": "sha512-qrQ1ebGb99/xFf5w14FVcX/+PkhWvdrmNKgq2RIkG/1e1j8J1WsUW1orbPmtICsvb2ThPVNqNtVqDNrfFEU3/w==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/data/-/data-0.6.6.tgz",
+      "integrity": "sha512-wmk1LZRlSSkOHlASkTC4YMXhPU3WXdFo0lDl9maono9tJnD7PjhH1NI15j8NoZRgZHBFf2vJosLvp3L9lpME/w==",
       "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
+        "@blaze-cardano/core": "0.8.0",
         "@sinclair/typebox": "^0.34.28"
-      }
-    },
-    "node_modules/@blaze-cardano/data/node_modules/@blaze-cardano/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-fsZHKeHqDhqBM6THb7nH7xaKualUer8409nGL7UlGCPFxUb4TUlFGHbeS33/Bu3SYgizyafe1l+8R8WrelNe7A==",
-      "dependencies": {
-        "@cardano-sdk/core": "^0.46",
-        "@cardano-sdk/crypto": "^0.4",
-        "@cardano-sdk/util": "^0.17",
-        "@noble/curves": "^1.8.1",
-        "@noble/ed25519": "^2.2.3",
-        "@noble/hashes": "^1.7.1",
-        "@scure/bip39": "^1.5.4",
-        "blakejs": "^1.2.1"
       }
     },
     "node_modules/@blaze-cardano/jest-config": {
@@ -105,42 +90,15 @@
       }
     },
     "node_modules/@blaze-cardano/sdk": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.3.1.tgz",
-      "integrity": "sha512-znQqSJxK8bbTzlGut5BVd/EtkX1oLgTnVe8Py7waNhlL8ZHFPhFxh452CCrcMLSUcsszY4Xjt0OnMpj8hlYgTA==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.2.48.tgz",
+      "integrity": "sha512-2gmqilbwEiIOuOpUFTLsBoGFKIYgQ4O0NA8RWlH82XEOKbOhnaU9LDkZAF2/+5U4HpggUsrn1HnBlB+oiwdvbw==",
       "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/query": "^0.6.1",
-        "@blaze-cardano/tx": "^0.15.1",
-        "@blaze-cardano/uplc": "^0.5.1",
-        "@blaze-cardano/wallet": "^0.6.1"
-      }
-    },
-    "node_modules/@blaze-cardano/sdk/node_modules/@blaze-cardano/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-fsZHKeHqDhqBM6THb7nH7xaKualUer8409nGL7UlGCPFxUb4TUlFGHbeS33/Bu3SYgizyafe1l+8R8WrelNe7A==",
-      "dependencies": {
-        "@cardano-sdk/core": "^0.46",
-        "@cardano-sdk/crypto": "^0.4",
-        "@cardano-sdk/util": "^0.17",
-        "@noble/curves": "^1.8.1",
-        "@noble/ed25519": "^2.2.3",
-        "@noble/hashes": "^1.7.1",
-        "@scure/bip39": "^1.5.4",
-        "blakejs": "^1.2.1"
-      }
-    },
-    "node_modules/@blaze-cardano/sdk/node_modules/@blaze-cardano/query": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/query/-/query-0.6.1.tgz",
-      "integrity": "sha512-bwLViPB78lYspkLgc511ioL8ALNWKlifyKIx2UsF6IbdTX7JwPijfpmel5C3awd7bUWnzt+GtLrhWN48iaXU+w==",
-      "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/ogmios": "^0.0.7",
-        "@cardano-ogmios/schema": "^6.6.1",
-        "@cardanosolutions/json-bigint": "^1.0.2",
-        "ws": "^8.17.1"
+        "@blaze-cardano/core": "0.8.0",
+        "@blaze-cardano/query": "0.5.6",
+        "@blaze-cardano/tx": "0.14.1",
+        "@blaze-cardano/uplc": "0.4.3",
+        "@blaze-cardano/wallet": "0.5.3"
       }
     },
     "node_modules/@blaze-cardano/tsconfig": {
@@ -150,115 +108,44 @@
       "license": "MIT"
     },
     "node_modules/@blaze-cardano/tx": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.15.1.tgz",
-      "integrity": "sha512-QO26m9Adnz9eTGuXEbm9QReEl9yKQNDC8+DI33mFxuQRHFbirFxoOG+dW5awUMYCwCBAfp+gdA3zJ1SC/NoFcw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.14.1.tgz",
+      "integrity": "sha512-8FiiWxbYsEj3Kq6/xw9NMxXG2FFZ5nLcs+vYQfxGFY2AA0duNI2onwAw9ZoY30n6mMoDQ7bHFXSP4GuQo86/BQ==",
       "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/vm": "^0.3.1"
-      }
-    },
-    "node_modules/@blaze-cardano/tx/node_modules/@blaze-cardano/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-fsZHKeHqDhqBM6THb7nH7xaKualUer8409nGL7UlGCPFxUb4TUlFGHbeS33/Bu3SYgizyafe1l+8R8WrelNe7A==",
-      "dependencies": {
-        "@cardano-sdk/core": "^0.46",
-        "@cardano-sdk/crypto": "^0.4",
-        "@cardano-sdk/util": "^0.17",
-        "@noble/curves": "^1.8.1",
-        "@noble/ed25519": "^2.2.3",
-        "@noble/hashes": "^1.7.1",
-        "@scure/bip39": "^1.5.4",
-        "blakejs": "^1.2.1"
+        "@blaze-cardano/core": "0.8.0",
+        "@blaze-cardano/vm": "0.2.3"
       }
     },
     "node_modules/@blaze-cardano/uplc": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.5.1.tgz",
-      "integrity": "sha512-FogDA42Ddpv59oxp3fca7IlsMinpTN72rtTvRQbxS6kj2l2oCmWHxZq5MOumPB9/Yx6Fktu5+v78sbtQk8BzUg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.4.3.tgz",
+      "integrity": "sha512-S3eJq6hpU7YaUk72EUVph7er8faFOG35WkzFeLbdo9KnFndjYV65q0OJY2Zzk+mHZCvyx3AJvJO6TloN4q1nfQ==",
       "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/data": "^0.6.8",
+        "@blaze-cardano/core": "0.8.0",
+        "@blaze-cardano/data": "0.6.6",
         "hex-encoding": "^2.0.2"
       }
     },
-    "node_modules/@blaze-cardano/uplc/node_modules/@blaze-cardano/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-fsZHKeHqDhqBM6THb7nH7xaKualUer8409nGL7UlGCPFxUb4TUlFGHbeS33/Bu3SYgizyafe1l+8R8WrelNe7A==",
-      "dependencies": {
-        "@cardano-sdk/core": "^0.46",
-        "@cardano-sdk/crypto": "^0.4",
-        "@cardano-sdk/util": "^0.17",
-        "@noble/curves": "^1.8.1",
-        "@noble/ed25519": "^2.2.3",
-        "@noble/hashes": "^1.7.1",
-        "@scure/bip39": "^1.5.4",
-        "blakejs": "^1.2.1"
-      }
-    },
     "node_modules/@blaze-cardano/vm": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/vm/-/vm-0.3.1.tgz",
-      "integrity": "sha512-GLu/vrFSoicKEIKbTu+w2KExwmtGR8xA2ESA6QOYodPBsJbLXV77iXx9TVZVh+AujGA3wyJDNmKseXUe9inoYQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/vm/-/vm-0.2.3.tgz",
+      "integrity": "sha512-TFOx6ARCLIqt+IbjvvWyrwLG8uh/voNYWhfpdQ8cHxxZox+lUHjJvxqzA/2HaSbmfW17Ljcca8T98TG1A6OFEw==",
       "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/uplc": "^0.5.1"
-      }
-    },
-    "node_modules/@blaze-cardano/vm/node_modules/@blaze-cardano/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-fsZHKeHqDhqBM6THb7nH7xaKualUer8409nGL7UlGCPFxUb4TUlFGHbeS33/Bu3SYgizyafe1l+8R8WrelNe7A==",
-      "dependencies": {
-        "@cardano-sdk/core": "^0.46",
-        "@cardano-sdk/crypto": "^0.4",
-        "@cardano-sdk/util": "^0.17",
-        "@noble/curves": "^1.8.1",
-        "@noble/ed25519": "^2.2.3",
-        "@noble/hashes": "^1.7.1",
-        "@scure/bip39": "^1.5.4",
-        "blakejs": "^1.2.1"
+        "@blaze-cardano/core": "0.8.0",
+        "@blaze-cardano/uplc": "0.4.3"
       }
     },
     "node_modules/@blaze-cardano/wallet": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.6.1.tgz",
-      "integrity": "sha512-ML3rSc3iznv27MvFwan9fv85iobmsC3H+aBBvb0Rw7atDWNVt6EniM+UQ7LL366Vj1C7ZcwY/dLuArb/XGPSnA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.5.3.tgz",
+      "integrity": "sha512-6UxqbGi56m5qu5gwi+04OFm+2FOgNid5HgsIoDZuXSiUdjP7R98WqaPe6lwCvLvLVcAZP+9Ht+99JvZzdHibUQ==",
       "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/query": "^0.6.1",
-        "@blaze-cardano/tx": "^0.15.1",
+        "@blaze-cardano/core": "0.8.0",
+        "@blaze-cardano/jest-config": "0.0.1",
+        "@blaze-cardano/query": "0.5.6",
+        "@blaze-cardano/tx": "0.14.1",
         "@emurgo/cardano-message-signing-browser": "^1.1.0",
         "@emurgo/cardano-message-signing-nodejs": "^1.1.0"
-      }
-    },
-    "node_modules/@blaze-cardano/wallet/node_modules/@blaze-cardano/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-fsZHKeHqDhqBM6THb7nH7xaKualUer8409nGL7UlGCPFxUb4TUlFGHbeS33/Bu3SYgizyafe1l+8R8WrelNe7A==",
-      "dependencies": {
-        "@cardano-sdk/core": "^0.46",
-        "@cardano-sdk/crypto": "^0.4",
-        "@cardano-sdk/util": "^0.17",
-        "@noble/curves": "^1.8.1",
-        "@noble/ed25519": "^2.2.3",
-        "@noble/hashes": "^1.7.1",
-        "@scure/bip39": "^1.5.4",
-        "blakejs": "^1.2.1"
-      }
-    },
-    "node_modules/@blaze-cardano/wallet/node_modules/@blaze-cardano/query": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/query/-/query-0.6.1.tgz",
-      "integrity": "sha512-bwLViPB78lYspkLgc511ioL8ALNWKlifyKIx2UsF6IbdTX7JwPijfpmel5C3awd7bUWnzt+GtLrhWN48iaXU+w==",
-      "dependencies": {
-        "@blaze-cardano/core": "^0.9.0",
-        "@blaze-cardano/ogmios": "^0.0.7",
-        "@cardano-ogmios/schema": "^6.6.1",
-        "@cardanosolutions/json-bigint": "^1.0.2",
-        "ws": "^8.17.1"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -754,9 +641,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -774,9 +658,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -794,9 +675,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -814,9 +692,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -834,9 +709,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +726,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1044,68 +913,6 @@
         "@sundaeswap/bigint-math": "^0.6.3",
         "@sundaeswap/fraction": "^1.0.5",
         "@sundaeswap/math": "0.2.2"
-      }
-    },
-    "node_modules/@sundaeswap/core/node_modules/@blaze-cardano/data": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/data/-/data-0.6.6.tgz",
-      "integrity": "sha512-wmk1LZRlSSkOHlASkTC4YMXhPU3WXdFo0lDl9maono9tJnD7PjhH1NI15j8NoZRgZHBFf2vJosLvp3L9lpME/w==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@sinclair/typebox": "^0.34.28"
-      }
-    },
-    "node_modules/@sundaeswap/core/node_modules/@blaze-cardano/sdk": {
-      "version": "0.2.48",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.2.48.tgz",
-      "integrity": "sha512-2gmqilbwEiIOuOpUFTLsBoGFKIYgQ4O0NA8RWlH82XEOKbOhnaU9LDkZAF2/+5U4HpggUsrn1HnBlB+oiwdvbw==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/query": "0.5.6",
-        "@blaze-cardano/tx": "0.14.1",
-        "@blaze-cardano/uplc": "0.4.3",
-        "@blaze-cardano/wallet": "0.5.3"
-      }
-    },
-    "node_modules/@sundaeswap/core/node_modules/@blaze-cardano/tx": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.14.1.tgz",
-      "integrity": "sha512-8FiiWxbYsEj3Kq6/xw9NMxXG2FFZ5nLcs+vYQfxGFY2AA0duNI2onwAw9ZoY30n6mMoDQ7bHFXSP4GuQo86/BQ==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/vm": "0.2.3"
-      }
-    },
-    "node_modules/@sundaeswap/core/node_modules/@blaze-cardano/uplc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.4.3.tgz",
-      "integrity": "sha512-S3eJq6hpU7YaUk72EUVph7er8faFOG35WkzFeLbdo9KnFndjYV65q0OJY2Zzk+mHZCvyx3AJvJO6TloN4q1nfQ==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/data": "0.6.6",
-        "hex-encoding": "^2.0.2"
-      }
-    },
-    "node_modules/@sundaeswap/core/node_modules/@blaze-cardano/vm": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/vm/-/vm-0.2.3.tgz",
-      "integrity": "sha512-TFOx6ARCLIqt+IbjvvWyrwLG8uh/voNYWhfpdQ8cHxxZox+lUHjJvxqzA/2HaSbmfW17Ljcca8T98TG1A6OFEw==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/uplc": "0.4.3"
-      }
-    },
-    "node_modules/@sundaeswap/core/node_modules/@blaze-cardano/wallet": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.5.3.tgz",
-      "integrity": "sha512-6UxqbGi56m5qu5gwi+04OFm+2FOgNid5HgsIoDZuXSiUdjP7R98WqaPe6lwCvLvLVcAZP+9Ht+99JvZzdHibUQ==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/jest-config": "0.0.1",
-        "@blaze-cardano/query": "0.5.6",
-        "@blaze-cardano/tx": "0.14.1",
-        "@emurgo/cardano-message-signing-browser": "^1.1.0",
-        "@emurgo/cardano-message-signing-nodejs": "^1.1.0"
       }
     },
     "node_modules/@sundaeswap/core/node_modules/@sundaeswap/math": {
@@ -1518,68 +1325,6 @@
         "@utxorpc/sdk": "^0.8.0",
         "@utxorpc/spec": "^0.18.1",
         "rxjs": "^7.8.2"
-      }
-    },
-    "node_modules/@utxorpc/blaze-provider/node_modules/@blaze-cardano/data": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/data/-/data-0.6.6.tgz",
-      "integrity": "sha512-wmk1LZRlSSkOHlASkTC4YMXhPU3WXdFo0lDl9maono9tJnD7PjhH1NI15j8NoZRgZHBFf2vJosLvp3L9lpME/w==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@sinclair/typebox": "^0.34.28"
-      }
-    },
-    "node_modules/@utxorpc/blaze-provider/node_modules/@blaze-cardano/sdk": {
-      "version": "0.2.48",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/sdk/-/sdk-0.2.48.tgz",
-      "integrity": "sha512-2gmqilbwEiIOuOpUFTLsBoGFKIYgQ4O0NA8RWlH82XEOKbOhnaU9LDkZAF2/+5U4HpggUsrn1HnBlB+oiwdvbw==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/query": "0.5.6",
-        "@blaze-cardano/tx": "0.14.1",
-        "@blaze-cardano/uplc": "0.4.3",
-        "@blaze-cardano/wallet": "0.5.3"
-      }
-    },
-    "node_modules/@utxorpc/blaze-provider/node_modules/@blaze-cardano/tx": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/tx/-/tx-0.14.1.tgz",
-      "integrity": "sha512-8FiiWxbYsEj3Kq6/xw9NMxXG2FFZ5nLcs+vYQfxGFY2AA0duNI2onwAw9ZoY30n6mMoDQ7bHFXSP4GuQo86/BQ==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/vm": "0.2.3"
-      }
-    },
-    "node_modules/@utxorpc/blaze-provider/node_modules/@blaze-cardano/uplc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/uplc/-/uplc-0.4.3.tgz",
-      "integrity": "sha512-S3eJq6hpU7YaUk72EUVph7er8faFOG35WkzFeLbdo9KnFndjYV65q0OJY2Zzk+mHZCvyx3AJvJO6TloN4q1nfQ==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/data": "0.6.6",
-        "hex-encoding": "^2.0.2"
-      }
-    },
-    "node_modules/@utxorpc/blaze-provider/node_modules/@blaze-cardano/vm": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/vm/-/vm-0.2.3.tgz",
-      "integrity": "sha512-TFOx6ARCLIqt+IbjvvWyrwLG8uh/voNYWhfpdQ8cHxxZox+lUHjJvxqzA/2HaSbmfW17Ljcca8T98TG1A6OFEw==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/uplc": "0.4.3"
-      }
-    },
-    "node_modules/@utxorpc/blaze-provider/node_modules/@blaze-cardano/wallet": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@blaze-cardano/wallet/-/wallet-0.5.3.tgz",
-      "integrity": "sha512-6UxqbGi56m5qu5gwi+04OFm+2FOgNid5HgsIoDZuXSiUdjP7R98WqaPe6lwCvLvLVcAZP+9Ht+99JvZzdHibUQ==",
-      "dependencies": {
-        "@blaze-cardano/core": "0.8.0",
-        "@blaze-cardano/jest-config": "0.0.1",
-        "@blaze-cardano/query": "0.5.6",
-        "@blaze-cardano/tx": "0.14.1",
-        "@emurgo/cardano-message-signing-browser": "^1.1.0",
-        "@emurgo/cardano-message-signing-nodejs": "^1.1.0"
       }
     },
     "node_modules/@utxorpc/sdk": {

--- a/examples/dingo-sundae-preview/package.json
+++ b/examples/dingo-sundae-preview/package.json
@@ -9,7 +9,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@blaze-cardano/sdk": "0.3.1",
+    "@blaze-cardano/sdk": "0.2.48",
     "@sundaeswap/asset": "1.0.11",
     "@sundaeswap/core": "2.12.0",
     "@utxorpc/blaze-provider": "0.3.9"

--- a/examples/dingo-sundae-preview/src/dingo/bytes.ts
+++ b/examples/dingo-sundae-preview/src/dingo/bytes.ts
@@ -1,0 +1,21 @@
+import type { UtxoRpcBytes } from "./utxorpcTypes";
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function hexToBytes(hex: string): UtxoRpcBytes {
+  if (hex.length % 2 !== 0) {
+    throw new Error("Hex string must have an even number of characters.");
+  }
+
+  const bytes = new Uint8Array(hex.length / 2) as UtxoRpcBytes;
+  for (let offset = 0; offset < hex.length; offset += 2) {
+    const byte = Number.parseInt(hex.slice(offset, offset + 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new Error("Hex string contains invalid characters.");
+    }
+    bytes[offset / 2] = byte;
+  }
+  return bytes;
+}

--- a/examples/dingo-sundae-preview/src/dingo/provider.ts
+++ b/examples/dingo-sundae-preview/src/dingo/provider.ts
@@ -1,6 +1,15 @@
 import { Core } from "@blaze-cardano/sdk";
 import { U5C } from "@utxorpc/blaze-provider";
+import { bytesToHex, hexToBytes } from "./bytes";
 import type { DingoQueryClient, UtxoRpcBytes } from "./utxorpcTypes";
+
+// Preview network magic. Dingo reports this from the Shelley genesis it loaded,
+// so it is the authoritative answer for which chain the endpoint is serving.
+const PREVIEW_NETWORK_MAGIC = 2;
+
+// Cap on how many UTxOs a wallet summary resolves through ReadUtxos. Dingo
+// rejects more than 1000 keys per request; this stays well under that.
+const MAX_SUMMARY_UTXOS = 200;
 
 export function createDingoProvider(): U5C {
   const url = import.meta.env.VITE_UTXORPC_URL || window.location.origin;
@@ -19,6 +28,84 @@ export async function assertDingoReady(provider: U5C): Promise<string> {
   return `Protocol ${params.protocolVersion.major}.${params.protocolVersion.minor}, max tx ${params.maxTxSize} bytes`;
 }
 
+// assertDingoNetwork confirms the endpoint really serves Preview before the app
+// builds orders against Preview-only Sundae V3 script hashes. Without this a
+// proxy pointed at another network silently produces unusable transactions.
+export async function assertDingoNetwork(provider: U5C): Promise<string> {
+  const genesis = await queryClientFor(provider).readGenesis();
+  if (genesis.networkMagic !== PREVIEW_NETWORK_MAGIC) {
+    throw new Error(
+      `Dingo reports network magic ${genesis.networkMagic}; this example requires Preview (${PREVIEW_NETWORK_MAGIC}).`,
+    );
+  }
+  return `Preview genesis confirmed (network magic ${genesis.networkMagic}, ${genesis.networkId})`;
+}
+
+export type DingoUtxoSummary = {
+  lovelace: bigint;
+  utxoCount: number;
+  truncated: boolean;
+};
+
+// summarizeDingoAddress reports what Dingo holds for one complete address.
+// Dingo compares the full serialized address bytes, so a base address does not
+// pick up enterprise UTxOs that only share its payment credential.
+export async function summarizeDingoAddress(
+  provider: U5C,
+  address: Core.Address,
+): Promise<DingoUtxoSummary> {
+  return summarizeResolvedUtxos(await provider.getUnspentOutputs(address), false);
+}
+
+// summarizeDingoStakeCredential reports every UTxO whose address delegates to
+// the given stake credential, across all address forms that share it. This is
+// the closest view UTxO RPC offers of a stake address; live delegation, rewards,
+// and pool assignment are node-to-client LocalStateQuery only.
+export async function summarizeDingoStakeCredential(
+  provider: U5C,
+  stakeCredentialHash: string,
+): Promise<DingoUtxoSummary> {
+  const rpcUtxos = await queryClientFor(provider).searchUtxosByDelegationPart(
+    hexToBytes(stakeCredentialHash),
+  );
+  const truncated = rpcUtxos.length > MAX_SUMMARY_UTXOS;
+  const references = rpcUtxos
+    .slice(0, MAX_SUMMARY_UTXOS)
+    .map(
+      (utxo) =>
+        new Core.TransactionInput(
+          Core.TransactionId(bytesToHex(utxo.txoRef.hash)),
+          BigInt(utxo.txoRef.index),
+        ),
+    );
+  if (references.length === 0) {
+    return { lovelace: 0n, utxoCount: 0, truncated };
+  }
+
+  return summarizeResolvedUtxos(
+    await provider.resolveUnspentOutputs(references),
+    truncated,
+  );
+}
+
+// stakeCredentialHashFor returns the address delegation part, key hash or
+// script hash alike, and undefined for forms that carry none such as
+// enterprise, pointer, and Byron addresses.
+export function stakeCredentialHashFor(address: Core.Address): string | undefined {
+  return address.getProps().delegationPart?.hash;
+}
+
+function summarizeResolvedUtxos(
+  utxos: Core.TransactionUnspentOutput[],
+  truncated: boolean,
+): DingoUtxoSummary {
+  let lovelace = 0n;
+  for (const utxo of utxos) {
+    lovelace += utxo.output().amount().coin();
+  }
+  return { lovelace, utxoCount: utxos.length, truncated };
+}
+
 type QueryClientHost = {
   queryClient?: DingoQueryClient;
 };
@@ -31,6 +118,14 @@ type AssetPattern =
 
 const POLICY_ID_BYTES = 28;
 const MAX_ASSET_NAME_BYTES = 32;
+
+function queryClientFor(provider: U5C): DingoQueryClient {
+  const queryClient = (provider as unknown as QueryClientHost).queryClient;
+  if (!queryClient) {
+    throw new Error("Blaze U5C query client is not available.");
+  }
+  return queryClient;
+}
 
 function installDingoAssetSearchCompatibility(provider: U5C): void {
   const queryClient = (provider as unknown as QueryClientHost).queryClient;

--- a/examples/dingo-sundae-preview/src/dingo/utxorpcTypes.ts
+++ b/examples/dingo-sundae-preview/src/dingo/utxorpcTypes.ts
@@ -15,6 +15,13 @@ export type DingoUtxo = {
   };
 };
 
+// DingoGenesis is the subset of the UTxO RPC Query.ReadGenesis Cardano config
+// this example reads. Dingo answers it from the Shelley genesis it loaded.
+export type DingoGenesis = {
+  networkMagic: number;
+  networkId: string;
+};
+
 export type DingoQueryClient = {
   inner: {
     readData(request: { keys: UtxoRpcBytes[] }): Promise<{
@@ -24,7 +31,12 @@ export type DingoQueryClient = {
       }>;
     }>;
   };
+  readGenesis(): Promise<DingoGenesis>;
+  // Dingo matches an address search on the complete serialized address bytes.
   searchUtxosByAddress(address: UtxoRpcBytes): Promise<DingoUtxo[]>;
+  // A delegation part is a 28-byte stake credential, not an address. Dingo
+  // matches it across every address form that shares the credential.
+  searchUtxosByDelegationPart(delegationPart: UtxoRpcBytes): Promise<DingoUtxo[]>;
   searchUtxosByAsset(policyId?: UtxoRpcBytes, name?: UtxoRpcBytes): Promise<DingoUtxo[]>;
   searchUtxosByAddressWithAsset(address: UtxoRpcBytes, policyId?: UtxoRpcBytes, name?: UtxoRpcBytes): Promise<DingoUtxo[]>;
 };

--- a/examples/dingo-sundae-preview/src/main.ts
+++ b/examples/dingo-sundae-preview/src/main.ts
@@ -2,7 +2,15 @@ import "./styles.css";
 import { Blaze, Core, WebWallet, type Wallet } from "@blaze-cardano/sdk";
 import { ADA_METADATA, type IPoolData, type IPoolDataAsset } from "@sundaeswap/core";
 import type { U5C } from "@utxorpc/blaze-provider";
-import { createDingoProvider, assertDingoReady } from "./dingo/provider";
+import {
+  assertDingoNetwork,
+  assertDingoReady,
+  createDingoProvider,
+  stakeCredentialHashFor,
+  summarizeDingoAddress,
+  summarizeDingoStakeCredential,
+  type DingoUtxoSummary,
+} from "./dingo/provider";
 import { formatAssetAmount, metadataFor, parseAssetAmount, unitFromAssetId } from "./sundae/assets";
 import { DingoSundaeQueryProvider } from "./sundae/dingoQueryProvider";
 import { DEFAULT_POOL, POOL_PRESETS, type PoolPreset } from "./sundae/protocol";
@@ -30,6 +38,7 @@ type AppState = {
   blaze?: Blaze<U5C, Wallet>;
   webWallet?: WebWallet;
   walletBalance?: Core.Value;
+  changeAddress?: Core.Address;
   walletApi?: Cip30WalletApi;
   poolOptions: PoolOption[];
   pool?: IPoolData;
@@ -69,11 +78,11 @@ app.innerHTML = `
       </div>
       <div class="header-actions">
         <div
-          class="status ready network-status"
+          class="status network-status"
           id="networkStatus"
-          title="Dingo provider network: cardano-preview"
+          title="Verifying the endpoint network through UTxO RPC ReadGenesis"
         >
-          Network: Preview
+          Network: checking
         </div>
         <div class="status" id="dingoStatus">Dingo: connecting</div>
         <details class="wallet-dropdown" id="walletDetails">
@@ -88,6 +97,8 @@ app.innerHTML = `
               <dt>Network</dt><dd id="walletNetwork">Not connected</dd>
               <dt>Change address</dt><dd id="changeAddress">-</dd>
               <dt>Balance</dt><dd id="walletBalance">-</dd>
+              <dt>Dingo UTxOs</dt><dd id="dingoAddressUtxos">-</dd>
+              <dt>Stake cred</dt><dd id="dingoStakeUtxos">-</dd>
             </dl>
           </div>
         </details>
@@ -187,6 +198,7 @@ app.innerHTML = `
 `;
 
 const els = {
+  networkStatus: byId("networkStatus"),
   dingoStatus: byId("dingoStatus"),
   walletDetails: byId<HTMLDetailsElement>("walletDetails"),
   walletSummary: byId<HTMLElement>("walletSummary"),
@@ -195,6 +207,8 @@ const els = {
   walletNetwork: byId("walletNetwork"),
   changeAddress: byId("changeAddress"),
   walletBalance: byId("walletBalance"),
+  dingoAddressUtxos: byId("dingoAddressUtxos"),
+  dingoStakeUtxos: byId("dingoStakeUtxos"),
   poolSelect: byId<HTMLSelectElement>("poolSelect"),
   loadPool: byId<HTMLButtonElement>("loadPool"),
   poolFee: byId("poolFee"),
@@ -349,14 +363,22 @@ function getWallets(): Array<[string, Cip30Wallet]> {
 
 async function initializeDingo(): Promise<void> {
   try {
+    const network = await assertDingoNetwork(state.provider);
+    els.networkStatus.textContent = "Network: Preview";
+    els.networkStatus.title = network;
+    els.networkStatus.classList.add("ready");
     const status = await assertDingoReady(state.provider);
     const references = await state.queryProvider.validateProtocolReferences();
     els.dingoStatus.textContent = `Dingo: ready`;
     els.dingoStatus.classList.add("ready");
-    log(`${status}; ${references}`);
+    log(`${network}; ${status}; ${references}`);
     await hydratePoolsFromDingo();
     await loadPool();
   } catch (error) {
+    if (!els.networkStatus.classList.contains("ready")) {
+      els.networkStatus.textContent = "Network: unverified";
+      els.networkStatus.classList.add("error");
+    }
     els.dingoStatus.textContent = "Dingo: unavailable";
     els.dingoStatus.classList.add("error");
     log(errorMessage(error));
@@ -384,6 +406,7 @@ async function connectWallet(): Promise<void> {
     const changeAddress = await webWallet.getChangeAddress();
     const balance = await webWallet.getBalance();
     state.walletBalance = balance;
+    state.changeAddress = changeAddress;
     els.walletNetwork.textContent = "Preview-compatible testnet";
     els.changeAddress.textContent = changeAddress.toBech32();
     els.walletBalance.textContent = `${formatAssetAmount(balance.coin(), 6)} ADA`;
@@ -391,6 +414,7 @@ async function connectWallet(): Promise<void> {
     els.walletDetails.open = false;
     renderSwapControls();
     log(`Wallet connected: ${wallet.name ?? els.walletSelect.value}`);
+    await refreshDingoWalletView();
   } catch (error) {
     log(errorMessage(error));
   }
@@ -486,6 +510,49 @@ async function refreshWalletBalance(): Promise<void> {
   state.walletBalance = balance;
   els.walletBalance.textContent = `${formatAssetAmount(balance.coin(), 6)} ADA`;
   renderSwapControls();
+  await refreshDingoWalletView();
+}
+
+// refreshDingoWalletView shows the wallet as Dingo sees it, independently of
+// what CIP-30 reports: one exact-address query and one stake-credential query
+// through UTxO RPC SearchUtxos.
+async function refreshDingoWalletView(): Promise<void> {
+  const changeAddress = state.changeAddress;
+  if (!changeAddress) {
+    return;
+  }
+
+  try {
+    const address = await summarizeDingoAddress(state.provider, changeAddress);
+    els.dingoAddressUtxos.textContent = summaryLabel(address);
+  } catch (error) {
+    els.dingoAddressUtxos.textContent = "-";
+    log(`Dingo address UTxO query failed: ${errorMessage(error)}`);
+  }
+
+  const stakeCredentialHash = stakeCredentialHashFor(changeAddress);
+  if (!stakeCredentialHash) {
+    els.dingoStakeUtxos.textContent = "No delegation part";
+    return;
+  }
+
+  try {
+    const stake = await summarizeDingoStakeCredential(state.provider, stakeCredentialHash);
+    els.dingoStakeUtxos.textContent = summaryLabel(stake);
+    els.dingoStakeUtxos.title = `Stake credential ${stakeCredentialHash}. UTxO RPC reports UTxOs only; delegation and rewards need node-to-client LocalStateQuery.`;
+  } catch (error) {
+    els.dingoStakeUtxos.textContent = "-";
+    log(`Dingo stake-credential UTxO query failed: ${errorMessage(error)}`);
+  }
+}
+
+function summaryLabel(summary: DingoUtxoSummary): string {
+  const ada = formatAssetAmount(summary.lovelace, 6);
+  const utxoLabel = summary.utxoCount === 1 ? "UTxO" : "UTxOs";
+  if (summary.truncated) {
+    return `${ada} ADA across the first ${summary.utxoCount} ${utxoLabel}`;
+  }
+  return `${ada} ADA across ${summary.utxoCount} ${utxoLabel}`;
 }
 
 function labelFor(asset: { assetId: string; ticker?: string; decimals?: number }): string {

--- a/examples/dingo-sundae-preview/src/sundae/dingoQueryProvider.ts
+++ b/examples/dingo-sundae-preview/src/sundae/dingoQueryProvider.ts
@@ -14,6 +14,7 @@ import {
   type TUTXO,
 } from "@sundaeswap/core";
 import type { U5C } from "@utxorpc/blaze-provider";
+import { bytesToHex, hexToBytes } from "../dingo/bytes";
 import type { DingoQueryClient, DingoUtxo } from "../dingo/utxorpcTypes";
 import { assetIdFromTuple, metadataFor, unitFromAssetId, type AssetHint } from "./assets";
 import { SUNDAE_V3_PROTOCOL } from "./protocol";
@@ -338,26 +339,6 @@ export class DingoSundaeQueryProvider extends QueryProviderSundaeSwap {
   private hexBytes(hex: string): Uint8Array<ArrayBuffer> {
     return hexToBytes(hex);
   }
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
-  if (hex.length % 2 !== 0) {
-    throw new Error("Hex string must have an even number of characters.");
-  }
-
-  const bytes = new Uint8Array(hex.length / 2) as Uint8Array<ArrayBuffer>;
-  for (let offset = 0; offset < hex.length; offset += 2) {
-    const byte = Number.parseInt(hex.slice(offset, offset + 2), 16);
-    if (Number.isNaN(byte)) {
-      throw new Error("Hex string contains invalid characters.");
-    }
-    bytes[offset / 2] = byte;
-  }
-  return bytes;
 }
 
 function identFromPoolNftName(assetName: string): string | undefined {


### PR DESCRIPTION
Fixes the swap example's build, verifies the node's network at startup, and adds address-scoped UTxO views that are only correct with exact address matching.

## The app did not build

`npm ci && npm run build` failed with TS2345 at the `TxBuilderV3` constructor. A dependency bump moved the direct `@blaze-cardano/sdk` to 0.3.1, while `@sundaeswap/core` 2.12.0 and `@utxorpc/blaze-provider` 0.3.9 both depend on 0.2.48. npm installed two copies, so `Blaze` and `TxBuilder` became nominally distinct types with separate declarations of a private property.

Holding the direct dependency at 0.2.48 leaves exactly one copy of the SDK in the tree. That fixes the build with no cast and drops the bundle from 1581 KB to 1543 KB.

A cast at the constructor would also compile, but it is worse than the error it hides: it hands a 0.3.1 object to code built against 0.2.48 inside the swap path, where a version mismatch surfaces as a malformed transaction rather than a type failure. The README records why this must not be bumped on its own, and to move it when both consumers move.

A stale `node_modules` masked this locally. `npx tsc --noEmit` passed against it and failed after a clean `npm ci`.

## Network verification at startup

The header claimed Preview as static markup, and the only actual check was the wallet's CIP-30 network id. A `DINGO_UTXORPC_URL` pointed at preprod or mainnet silently produced unusable transactions, because the Sundae V3 script hashes are Preview-only.

Startup now calls ReadGenesis and refuses to continue unless the network magic is Preview, with the badge reflecting the real answer.

## Address-scoped UTxO views

Two rows in the wallet dropdown, fed by Dingo:

- an exact-address UTxO total, from a search with the exact address field
- a delegation-part total, spanning every address form sharing the address stake credential, resolved through a UTxO read and capped at 200 refs with an explicit first-N label

Both are only correct as of exact address matching. Before it, the raw address bytes the UTxO RPC SDK sends were rejected because the field was CBOR-decoded, and the payment and delegation part fields were decoded as whole addresses rather than 28-byte credentials.

## Not reachable, so not shown

Stake address info is a node-to-client LocalStateQuery handler in `ledger/queries.go` with no query service RPC. Delegated stake, delegated pool, rewards, and DRep delegation cannot be shown from this app. The credential UTxO view is the honest reachable answer and is labelled as not being stake address info. The same applies to the CBOR-wrapped stake snapshot query.

The configurable FIFO mempool backend and its double-buffered revalidation are node-side and change no client-visible RPC: submit still returns the hash and the wait still streams to confirmed. The TLS 1.2 minimum applies only when Dingo serves its own certificate, and this example speaks plain HTTP through the Vite dev proxy. Both are README notes only.

## Other

Hex helpers move out of the query provider into a shared module, replacing a private duplicate. No behavior change.

Helm values move from 0.64.0 to 0.68.0, which predates exact address matching, and the README states 0.68.0 as the minimum with the reason.

## Testing

- `npm ci`, `npx tsc --noEmit`, `npm run build` all clean, verified from a clean install in a fresh worktree
- Confirmed the installed tree resolves to a single `@blaze-cardano/sdk@0.2.48` with both consumers deduped against it

The runtime paths are not exercised here. That needs a synced Preview Dingo at 0.68.0 or newer and a CIP-30 wallet.

`dist/` is gitignored and stays generated. `DATABASE.md` and `ARCHITECTURE.md` checked and not affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the swap example build by pinning `@blaze-cardano/sdk` to 0.2.48. Adds a Preview network check at startup and Dingo-backed UTxO totals in the wallet view.

- **New Features**
  - Verify the endpoint network at startup via UTxO RPC ReadGenesis; refuse non-Preview and show the real network in the badge.
  - Add wallet UTxO views from Dingo: exact-address and stake-credential totals; resolves up to 200 UTxOs and labels when truncated.

- **Dependencies**
  - Pin `@blaze-cardano/sdk` to 0.2.48 to match `@sundaeswap/core` 2.12.0 and `@utxorpc/blaze-provider` 0.3.9, fixing TS type mismatches and reducing bundle size.
  - Bump Dingo Helm values to 0.68.0 and document the `>=0.68.0` requirement for exact-address and delegation-part searches.

<sup>Written for commit e73f32be34cf5fb045fe24d51c6f9fea5204d4c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

