### PR TITLE
feat(blockfrost): align pools/extended with OpenAPI 0.1.90

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2471,16 +2471,23 @@ coarse candidates before forming a limited page, preserving continuation-token
 correctness. Blockfrost address-transaction reads apply the same CBOR-backed
 exact check over credential-index candidates and paginate the exact matches.
 
-`/pools/extended` computes `blocks_minted` and `live_saturation` for every
-active pool with one query each (`CountPoolBlocksInSlotRange`,
-`GetOffchainMetadataBatch`) rather than one query per pool; see the Off-chain
-Metadata Worker section above for the metadata half and DATABASE.md for both
-queries' index usage. `live_saturation` reuses pool detail's
-`poolSizeSaturation` and, like pool detail, requires the current protocol
-parameters' `nOpt` to be loaded (`LedgerState.Start()` having completed): a
-required, non-nullable schema field cannot fall back to a placeholder value,
-so the request fails outright rather than serving a fabricated 0.0 when
-protocol parameters are not yet available.
+`/pools/extended` resolves the whole page with two batched queries rather than
+one query per pool: `CountPoolBlocksInSlotRange` returns every active pool's
+`blocks_minted` keyed by pool, and `GetOffchainMetadataBatch` returns every
+pool's cached off-chain document keyed by URL, supplying the nullable
+`metadata` object. See the Off-chain Metadata Worker section above for the
+metadata half and DATABASE.md for both queries' index usage.
+
+`live_saturation` is not a query. It is computed in memory by pool detail's
+`poolSizeSaturation` helper from values already read for the page: the pool's
+live stake, the active-stake snapshot, `nOpt` from the current protocol
+parameters, and total circulation (`MaxLovelaceSupply - Reserves`, the
+denominator `ledger/rewards` uses for the saturation threshold, not total
+active stake). Like pool detail, it therefore requires protocol parameters to
+be loaded (`LedgerState.Start()` having completed): a required, non-nullable
+schema field cannot fall back to a placeholder value, so the request fails
+outright rather than serving a fabricated 0.0 when they are not yet
+available.
 
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1034,6 +1034,18 @@ rows): `PoolMetadata` re-runs `ValidatePoolMetadata` against `Content` before
 returning it, so a stale cached document that would fail today's validation
 does not keep serving as if it were valid, without writing back to the row.
 
+`/pools/extended` needs the same classification for every active pool on a
+page, not one pool at a time, so it does not call `PoolMetadata` per pool
+(that would be one query per row). Instead `NodeAdapter.PoolsExtended`
+resolves every active pool's registered metadata URL in a single
+`MetadataStore.GetOffchainMetadataBatch` call, then applies the same
+pending/failed/fetched classification (including the `offchainFetchError`
+mapping and the read-time `ValidatePoolMetadata` fallback) as pure,
+in-memory logic over the already-fetched rows. The classification itself is
+intentionally duplicated rather than shared by refactoring `PoolMetadata`,
+since the single-pool and batched-page code paths have different callers
+and error-propagation needs.
+
 ### Archive And History Expiry Topology
 
 Dingo's blob-store abstraction supports independent history expiry and archive
@@ -2458,6 +2470,17 @@ as one ANDed address pattern; exact keyset queries scan through nonmatching
 coarse candidates before forming a limited page, preserving continuation-token
 correctness. Blockfrost address-transaction reads apply the same CBOR-backed
 exact check over credential-index candidates and paginate the exact matches.
+
+`/pools/extended` computes `blocks_minted` and `live_saturation` for every
+active pool with one query each (`CountPoolBlocksInSlotRange`,
+`GetOffchainMetadataBatch`) rather than one query per pool; see the Off-chain
+Metadata Worker section above for the metadata half and DATABASE.md for both
+queries' index usage. `live_saturation` reuses pool detail's
+`poolSizeSaturation` and, like pool detail, requires the current protocol
+parameters' `nOpt` to be loaded (`LedgerState.Start()` having completed): a
+required, non-nullable schema field cannot fall back to a placeholder value,
+so the request fails outright rather than serving a fabricated 0.0 when
+protocol parameters are not yet available.
 
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1422,7 +1422,9 @@ current epoch's slot range (`blocks_epoch`); no new storage or index was
 needed. The upper slot bound passed for "no bound" is `math.MaxInt64`, not
 `math.MaxUint64`: slot columns are bound as signed 64-bit integers through
 `database/sql`, and a `uint64` value with the high bit set is rejected by the
-sqlite driver.
+sqlite driver. `/pools/extended` reuses the same lifetime query, called once
+with every active pool's key hash so the whole page's `blocks_minted` values
+come from a single call rather than one per pool.
 
 `blocks_minted` undercounts on a Mithril-bootstrapped node. `pool_opcert_sequence`
 is populated only by `UpdatePoolOpCertSequence`, called from the same
@@ -1438,12 +1440,36 @@ dingo has itself applied block-by-block since that boundary, not the pool's
 true full-history total; the gap is silent (no error, just a smaller count)
 and permanent (it does not shrink or get backfilled as the node runs). This
 is the same class of Mithril-boundary gap as the `account` table's
-pre-snapshot registration history documented above. `blocks_epoch` (current
-epoch only) is not affected in ordinary steady-state operation, since a
-caught-up node's current epoch is entirely post-boundary, but it inherits the
-same gap for the one epoch that straddles the snapshot's boundary slot: if
-that epoch has not yet rolled over, `blocks_epoch` only counts the
-post-boundary portion of it.
+pre-snapshot registration history documented above, and it applies equally to
+`/pools/extended`'s `blocks_minted`, which reads the same table the same way.
+`blocks_epoch` (current epoch only) is not affected in ordinary steady-state
+operation, since a caught-up node's current epoch is entirely post-boundary,
+but it inherits the same gap for the one epoch that straddles the snapshot's
+boundary slot: if that epoch has not yet rolled over, `blocks_epoch` only
+counts the post-boundary portion of it.
+
+### `GetOffchainMetadataBatch`
+
+`GetOffchainMetadataBatch(sourceType, urls, txn)` retrieves cached
+`offchain_metadata` rows for many URLs of one source type in a single query
+(`WHERE source_type = ? AND url IN (?, ...)`), for callers that need
+per-item off-chain metadata across a whole page of results without issuing
+one `GetOffchainMetadata` call per item. It uses the leading two columns
+(`source_type`, `url`) of the existing `(source_type, url, hash)` unique
+index (`idx_offchain_metadata_source_url_hash`); no new index was needed.
+Because a URL is only unique together with its hash, two returned rows can
+share a URL under different hashes (metadata republished at the same URL
+with new content); callers match each row against their own `(url, hash)`
+pointer rather than assuming one row per URL. The sqlite implementation
+chunks the `url IN (...)` list at the shared `sqliteBindVarLimit` (400, see
+above) to stay under sqlite's bound-parameter limit; postgres and MySQL,
+whose limits are far higher, issue one query regardless of list size. The
+Blockfrost `/pools/extended` endpoint uses this to resolve every active
+pool's registered metadata anchor in one query for the whole active-pool
+set, instead of one `GetOffchainMetadata` call per pool; its metadata
+object shares the same fetch/validation semantics as `PoolMetadata`
+documented above (pending/failed/fetched off-chain document classification,
+including the `source_type = 'pool'` schema re-validation on read).
 
 ### `GetDRepVotingPower`, `GetDRepVotingPowerBatch`, `GetDRepVotingPowerByType`
 

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -1687,6 +1687,16 @@ func (a *NodeAdapter) liveStake(txn dbtypes.Txn) (uint64, error) {
 // Blockfrost's error object, matching the hosted API's codes and
 // message formats. sourceLabel is the capitalized source name used in
 // the message ("Pool", "Drep").
+//
+// Every current caller passes "Pool" because pool metadata is the only
+// off-chain source whose fetch errors are surfaced through a Blockfrost
+// response so far. The parameter is kept rather than hardcoded because
+// models.OffchainMetadataSource* defines seven other sources (drep,
+// drep_registration, drep_update, gov_proposal, gov_vote, constitution,
+// committee_resign) that share this cache and this error classification,
+// and whose messages differ only by this label.
+//
+//nolint:unparam // sourceLabel is "Pool" for every caller today; see above.
 func offchainFetchError(
 	sourceLabel string,
 	url string,
@@ -1996,6 +2006,14 @@ func (a *NodeAdapter) PoolsExtended() (
 	if err != nil {
 		return nil, fmt.Errorf("get total active stake: %w", err)
 	}
+	// live_saturation's denominator is the per-pool saturation threshold
+	// totalCirculation/nOpt, not total active stake. See
+	// poolSizeSaturation's doc comment and ledger/rewards.
+	// Resolved once for the whole page rather than per pool.
+	totalCirculation, err := a.totalCirculation(txn.Metadata())
+	if err != nil {
+		return nil, fmt.Errorf("get total circulation: %w", err)
+	}
 
 	poolHashes := make([]lcommon.PoolKeyHash, 0, len(poolKeyHashes))
 	for _, poolKeyHash := range poolKeyHashes {
@@ -2067,15 +2085,15 @@ func (a *NodeAdapter) PoolsExtended() (
 		liveStake := liveStakeByPool[string(pool.PoolKeyHash)]
 		activeStake := activeStakeByPool[poolHex]
 		// pool_list_extended only needs live_saturation, which
-		// poolSizeSaturation derives from liveStake/totalActiveStake/nOpt
-		// alone; the live-size/active-size outputs (and the
-		// totalLiveStake input they need) are pool-detail-only fields, so
-		// totalLiveStake is passed as 0 rather than paying for another
-		// network-wide live-stake query just to compute values this
-		// endpoint discards.
+		// poolSizeSaturation derives from liveStake, totalCirculation
+		// and nOpt; the live-size/active-size outputs (and the
+		// totalLiveStake/totalActiveStake inputs they need) are
+		// pool-detail-only fields, so totalLiveStake is passed as 0
+		// rather than paying for another network-wide live-stake query
+		// just to compute values this endpoint discards.
 		_, _, liveSaturation := poolSizeSaturation(
 			liveStake, activeStake, 0, totalActiveStake,
-			protocolParams.NOpt,
+			totalCirculation, protocolParams.NOpt,
 		)
 
 		var metadataURL string

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -1925,6 +1925,11 @@ func (a *NodeAdapter) PoolMetadata(
 	return ret, nil
 }
 
+// PoolsExtended returns the current active pools with the fields required
+// by the Blockfrost OpenAPI 0.1.90 pool_list_extended schema (active/live
+// stake, blocks_minted, live_saturation, margin/pledge/cost, and the
+// nullable off-chain metadata object). Pagination and ordering are applied
+// by the caller (handlePoolsExtended); this returns every active pool.
 func (a *NodeAdapter) PoolsExtended() (
 	[]PoolExtendedInfo, error,
 ) {
@@ -1976,6 +1981,22 @@ func (a *NodeAdapter) PoolsExtended() (
 		activeStakeByPool[hex.EncodeToString(snapshot.PoolKeyHash)] = uint64(snapshot.TotalStake)
 	}
 
+	// live_saturation is a required, non-nullable float in the OpenAPI
+	// schema (0.0 is itself a legitimate saturation value), so there is
+	// no schema-compatible placeholder for "protocol parameters
+	// unavailable"; propagate the error instead of guessing, matching
+	// PoolDetail (adapter_pool_detail.go).
+	protocolParams, err := a.CurrentProtocolParams()
+	if err != nil {
+		return nil, fmt.Errorf("get protocol parameters: %w", err)
+	}
+	totalActiveStake, err := db.Metadata().GetTotalActiveStake(
+		activeStakeEpoch, "mark", txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get total active stake: %w", err)
+	}
+
 	poolHashes := make([]lcommon.PoolKeyHash, 0, len(poolKeyHashes))
 	for _, poolKeyHash := range poolKeyHashes {
 		poolHashes = append(poolHashes, lcommon.PoolKeyHash(poolKeyHash))
@@ -1990,6 +2011,45 @@ func (a *NodeAdapter) PoolsExtended() (
 		poolsByHash[string(pool.PoolKeyHash)] = pool
 	}
 
+	// blocks_minted (lifetime): one query across every active pool,
+	// keyed by pool, exactly like CountPoolBlocksInSlotRange is already
+	// used for pool detail (adapter_pool_detail.go) -- not a per-pool
+	// query. Undercounts on a Mithril-bootstrapped node; see DATABASE.md.
+	blocksMintedByPool, _, err := db.Metadata().CountPoolBlocksInSlotRange(
+		poolHashes, 0, noSlotUpperBound, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("count lifetime blocks for pools: %w", err)
+	}
+
+	// Off-chain metadata: one batched query across every active pool's
+	// registered metadata URL (GetOffchainMetadataBatch), instead of one
+	// GetOffchainMetadata call per pool.
+	metadataURLs := make([]string, 0, len(pools))
+	for i := range pools {
+		if len(pools[i].Registration) > 0 &&
+			pools[i].Registration[0].MetadataUrl != "" {
+			metadataURLs = append(
+				metadataURLs, pools[i].Registration[0].MetadataUrl,
+			)
+		}
+	}
+	metadataDocs, err := db.Metadata().GetOffchainMetadataBatch(
+		models.OffchainMetadataSourcePool, metadataURLs, txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get off-chain metadata for pools: %w", err)
+	}
+	metadataDocsByKey := make(
+		map[string]*models.OffchainMetadata, len(metadataDocs),
+	)
+	for i := range metadataDocs {
+		key := poolExtendedMetadataKey(
+			metadataDocs[i].URL, metadataDocs[i].Hash,
+		)
+		metadataDocsByKey[key] = &metadataDocs[i]
+	}
+
 	ret := make([]PoolExtendedInfo, 0, len(poolKeyHashes))
 	for _, poolKeyHash := range poolKeyHashes {
 		pool, ok := poolsByHash[string(poolKeyHash)]
@@ -1999,47 +2059,50 @@ func (a *NodeAdapter) PoolsExtended() (
 		poolID := lcommon.PoolId(lcommon.NewBlake2b224(pool.PoolKeyHash))
 		poolHex := hex.EncodeToString(pool.PoolKeyHash)
 
-		latestRelays := pool.Relays
-		if len(pool.Registration) > 0 {
-			latestRelays = pool.Registration[0].Relays
-		}
-
-		relays := make([]PoolRelayInfo, 0, len(latestRelays))
-		for _, relay := range latestRelays {
-			tmpRelay := PoolRelayInfo{
-				DNS: relay.Hostname,
-			}
-			if relay.Port != 0 {
-				if relay.Port > uint(math.MaxInt) {
-					return nil, fmt.Errorf("relay port out of range for pool %x", pool.PoolKeyHash)
-				}
-				port := int(relay.Port)
-				tmpRelay.Port = &port
-			}
-			if relay.Ipv4 != nil {
-				tmpRelay.IPv4 = relay.Ipv4.String()
-			}
-			if relay.Ipv6 != nil {
-				tmpRelay.IPv6 = relay.Ipv6.String()
-			}
-			relays = append(relays, tmpRelay)
-		}
-
 		marginCost := 0.0
 		if pool.Margin != nil && pool.Margin.Rat != nil {
 			marginCost, _ = pool.Margin.Float64()
 		}
 
+		liveStake := liveStakeByPool[string(pool.PoolKeyHash)]
+		activeStake := activeStakeByPool[poolHex]
+		// pool_list_extended only needs live_saturation, which
+		// poolSizeSaturation derives from liveStake/totalActiveStake/nOpt
+		// alone; the live-size/active-size outputs (and the
+		// totalLiveStake input they need) are pool-detail-only fields, so
+		// totalLiveStake is passed as 0 rather than paying for another
+		// network-wide live-stake query just to compute values this
+		// endpoint discards.
+		_, _, liveSaturation := poolSizeSaturation(
+			liveStake, activeStake, 0, totalActiveStake,
+			protocolParams.NOpt,
+		)
+
+		var metadataURL string
+		var metadataHash []byte
+		if len(pool.Registration) > 0 {
+			metadataURL = pool.Registration[0].MetadataUrl
+			metadataHash = pool.Registration[0].MetadataHash
+		}
+		var doc *models.OffchainMetadata
+		if metadataURL != "" {
+			key := poolExtendedMetadataKey(metadataURL, metadataHash)
+			doc = metadataDocsByKey[key]
+		}
+
 		ret = append(ret, PoolExtendedInfo{
 			PoolID:         poolID.String(),
 			Hex:            poolHex,
-			VrfKey:         hex.EncodeToString(pool.VrfKeyHash),
-			ActiveStake:    strconv.FormatUint(activeStakeByPool[poolHex], 10),
-			LiveStake:      strconv.FormatUint(liveStakeByPool[string(pool.PoolKeyHash)], 10),
+			ActiveStake:    strconv.FormatUint(activeStake, 10),
+			LiveStake:      strconv.FormatUint(liveStake, 10),
+			BlocksMinted:   blocksMintedByPool[string(pool.PoolKeyHash)],
+			LiveSaturation: liveSaturation,
 			DeclaredPledge: strconv.FormatUint(uint64(pool.Pledge), 10),
-			FixedCost:      strconv.FormatUint(uint64(pool.Cost), 10),
 			MarginCost:     marginCost,
-			Relays:         relays,
+			FixedCost:      strconv.FormatUint(uint64(pool.Cost), 10),
+			Metadata: buildPoolExtendedMetadata(
+				metadataURL, metadataHash, doc,
+			),
 		})
 	}
 

--- a/api/blockfrost/adapter_pools_extended_db_test.go
+++ b/api/blockfrost/adapter_pools_extended_db_test.go
@@ -214,13 +214,26 @@ func TestNodeAdapterPoolsExtendedFullResponse(t *testing.T) {
 	}
 
 	const wantNOpt = 100 // config/cardano/devnet/shelley-genesis.json
-	// The real network-wide total, not a hardcoded sum of the three
-	// seeded pools: it also includes the genesis pool's own stake
-	// snapshot, and GetTotalActiveStake is the exact input PoolsExtended
-	// uses for live_saturation.
-	totalActiveStake, err := store.GetTotalActiveStake(0, "mark", nil)
-	require.NoError(t, err)
-	saturationThreshold := float64(totalActiveStake) / float64(wantNOpt)
+	// live_saturation's denominator is the per-pool saturation threshold
+	// totalCirculation / nOpt, where totalCirculation is
+	// MaxLovelaceSupply minus Reserves. It is deliberately NOT
+	// totalActiveStake -- see totalCirculation's doc comment in
+	// adapter_pool_detail.go, and ledger/rewards, for why the two differ
+	// (using active stake here overstated saturation by ~1.68x on
+	// mainnet-shaped inputs).
+	//
+	// Both inputs come from the same devnet genesis this test starts a
+	// real LedgerState against, rather than being restated from the
+	// implementation: MaxLovelaceSupply is fixed by the genesis file and
+	// Reserves is whatever the ledger actually persisted.
+	const wantMaxLovelaceSupply = uint64(2_000_000_000_000) // config/cardano/devnet/shelley-genesis.json
+	var networkState models.NetworkState
+	require.NoError(
+		t, store.DB().Order("slot DESC").First(&networkState).Error,
+	)
+	wantCirculation := wantMaxLovelaceSupply -
+		uint64(networkState.Reserves)
+	saturationThreshold := float64(wantCirculation) / float64(wantNOpt)
 
 	// Pool A: no anchor.
 	a, ok := byHex[hex.EncodeToString(poolA)]

--- a/api/blockfrost/adapter_pools_extended_db_test.go
+++ b/api/blockfrost/adapter_pools_extended_db_test.go
@@ -1,0 +1,403 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// ensureExtendedPoolChainTip makes pools registered at AddedSlot 0
+// resolve as active. GetActivePoolKeyHashes resolves "active" against the
+// chain tip (the `tip` table), and a freshly created LedgerState -- with
+// or without Start() -- never writes one until a block has actually been
+// synced; without a tip row it silently returns no pools rather than an
+// error (see GetActivePoolKeyHashes, database/plugin/metadata/sqlite/pool.go).
+// Start() against the devnet genesis (newDBBackedAdapterWithProtocolParams)
+// already writes the epoch_id = 0 row (start_slot 0, length_in_slots 5 per
+// the devnet genesis), so Attrs here only matters for newDBBackedAdapter,
+// which starts with neither row.
+func ensureExtendedPoolChainTip(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().
+		Where("id = ?", 1).
+		Attrs(models.Tip{Slot: 0}).
+		FirstOrCreate(&models.Tip{ID: 1}).Error)
+	require.NoError(t, store.DB().
+		Where("epoch_id = ?", 0).
+		Attrs(models.Epoch{StartSlot: 0, LengthInSlots: 1000}).
+		FirstOrCreate(&models.Epoch{EpochId: 0}).Error)
+}
+
+// seedExtendedPool creates one pool with a registration, an active-stake
+// snapshot, a live-stake delegator, and observed block production,
+// exercising the same real-DB path PoolsExtended reads from (metadata
+// store -> pool -> registration -> account/utxo -> pool_opcert_sequence),
+// rather than a hand-built PoolExtendedInfo. metadataURL/metadataHash may
+// be empty/nil for a pool with no registered anchor. AddedSlot is 0 for
+// every row so the pool is active at a freshly started ledger's tip
+// (genesis, slot 0), matching GetActivePoolKeyHashesAtSlot's added_slot <=
+// slot requirement.
+func seedExtendedPool(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	db *database.Database,
+	seed byte,
+	activeStake uint64,
+	liveStake uint64,
+	blocks int,
+	metadataURL string,
+	metadataHash []byte,
+) (poolKeyHash []byte) {
+	t.Helper()
+	poolKeyHash = fill32(seed)[:28]
+	pool := &models.Pool{
+		PoolKeyHash: poolKeyHash,
+		VrfKeyHash:  fill32(seed + 0x10),
+		Pledge:      types.Uint64(1_000_000_000),
+		Cost:        types.Uint64(340_000_000),
+		Margin:      &types.Rat{Rat: big.NewRat(1, 20)},
+		Registration: []models.PoolRegistration{
+			{
+				PoolKeyHash:  poolKeyHash,
+				MetadataUrl:  metadataURL,
+				MetadataHash: metadataHash,
+				AddedSlot:    0,
+			},
+		},
+	}
+	require.NoError(t, store.DB().Create(pool).Error)
+
+	if liveStake > 0 {
+		stakingKey := fill32(seed + 0x20)[:28]
+		require.NoError(t, store.DB().Create(&models.Account{
+			StakingKey: stakingKey,
+			Pool:       poolKeyHash,
+			Active:     true,
+			AddedSlot:  0,
+		}).Error)
+		require.NoError(t, store.DB().Create(&models.Utxo{
+			TxId:       fill32(seed + 0x30),
+			OutputIdx:  0,
+			StakingKey: stakingKey,
+			Amount:     types.Uint64(liveStake),
+			AddedSlot:  0,
+		}).Error)
+	}
+
+	require.NoError(t, store.DB().Create(&models.PoolStakeSnapshot{
+		Epoch:        0,
+		SnapshotType: "mark",
+		PoolKeyHash:  poolKeyHash,
+		TotalStake:   types.Uint64(activeStake),
+	}).Error)
+
+	pkh := lcommon.PoolKeyHash(poolKeyHash)
+	for i := range blocks {
+		require.NoError(
+			t, db.UpdatePoolOpCertSequence(pkh, uint64(i+1), uint64(i), nil),
+		)
+	}
+
+	return poolKeyHash
+}
+
+// seedExtendedPoolMetadataDoc inserts a cached off-chain metadata row for
+// the given pool's anchor, matching the exact table
+// GetOffchainMetadataBatch reads.
+func seedExtendedPoolMetadataDoc(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	url string,
+	hash []byte,
+	status string,
+	content []byte,
+	lastError string,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.OffchainMetadata{
+		SourceType: models.OffchainMetadataSourcePool,
+		URL:        url,
+		Hash:       hash,
+		Status:     status,
+		Content:    content,
+		LastError:  lastError,
+	}).Error)
+}
+
+// TestNodeAdapterPoolsExtendedEmpty covers the no-active-pools case: no
+// query beyond GetActivePoolKeyHashes should run, and the result is an
+// empty (non-nil) slice.
+func TestNodeAdapterPoolsExtendedEmpty(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapterWithProtocolParams(t)
+
+	pools, err := adapter.PoolsExtended()
+	require.NoError(t, err)
+	assert.Empty(t, pools)
+	assert.NotNil(t, pools)
+}
+
+// TestNodeAdapterPoolsExtendedFullResponse seeds three pools covering the
+// three metadata states pool_list_extended's nullable metadata object can
+// take (no anchor at all, anchor with a failed/invalid fetch, anchor with
+// a successfully validated fetch), plus distinct active/live stake and
+// block-production counts, then verifies every PoolExtendedInfo field the
+// adapter computes from real DB state, including live_saturation computed
+// from the real devnet nOpt (100).
+func TestNodeAdapterPoolsExtendedFullResponse(t *testing.T) {
+	adapter, store, db := newDBBackedAdapterWithProtocolParams(t)
+	ensureExtendedPoolChainTip(t, store)
+
+	// Pool A: no registered metadata anchor at all -> metadata: null.
+	poolA := seedExtendedPool(t, store, db, 0x01, 1_000_000_000, 2_000_000_000, 3, "", nil)
+
+	// Pool B: anchor present, cached fetch failed (hash mismatch) ->
+	// metadata is a non-null object with url/hash and the error object,
+	// but every off-chain field left null.
+	urlB := "https://example.com/pool-b.json"
+	hashB := fill32(0x42)
+	poolB := seedExtendedPool(t, store, db, 0x02, 500_000_000, 100_000_000, 1, urlB, hashB)
+	seedExtendedPoolMetadataDoc(
+		t, store, urlB, hashB, models.OffchainMetadataStatusFailed,
+		nil, models.OffchainFetchErrHashMismatch,
+	)
+
+	// Pool C: anchor present, cached fetch succeeded and validates ->
+	// metadata is fully populated with no error.
+	urlC := "https://example.com/pool-c.json"
+	hashC := fill32(0x43)
+	poolC := seedExtendedPool(t, store, db, 0x03, 250_000_000, 0, 0, urlC, hashC)
+	seedExtendedPoolMetadataDoc(
+		t, store, urlC, hashC, models.OffchainMetadataStatusFetched,
+		[]byte(`{"name":"Pool C","description":"A pool.",`+
+			`"ticker":"PLC","homepage":"https://example.com"}`),
+		"",
+	)
+
+	pools, err := adapter.PoolsExtended()
+	require.NoError(t, err)
+	// >= 3, not == 3: Start() against the devnet genesis registers its own
+	// genesis-staking pool (see newDBBackedAdapterWithProtocolParams's
+	// doc comment on low-numbered synthetic rows), so the exact total
+	// active-pool count is not just the three seeded here.
+	require.GreaterOrEqual(t, len(pools), 3)
+
+	byHex := make(map[string]PoolExtendedInfo, len(pools))
+	for _, p := range pools {
+		byHex[p.Hex] = p
+	}
+
+	const wantNOpt = 100 // config/cardano/devnet/shelley-genesis.json
+	// The real network-wide total, not a hardcoded sum of the three
+	// seeded pools: it also includes the genesis pool's own stake
+	// snapshot, and GetTotalActiveStake is the exact input PoolsExtended
+	// uses for live_saturation.
+	totalActiveStake, err := store.GetTotalActiveStake(0, "mark", nil)
+	require.NoError(t, err)
+	saturationThreshold := float64(totalActiveStake) / float64(wantNOpt)
+
+	// Pool A: no anchor.
+	a, ok := byHex[hex.EncodeToString(poolA)]
+	require.True(t, ok)
+	assert.Equal(t, "1000000000", a.ActiveStake)
+	assert.Equal(t, "2000000000", a.LiveStake)
+	assert.Equal(t, uint64(3), a.BlocksMinted)
+	assert.InDelta(
+		t, float64(2_000_000_000)/saturationThreshold, a.LiveSaturation, 1e-6,
+	)
+	assert.Equal(t, "1000000000", a.DeclaredPledge)
+	assert.Equal(t, "340000000", a.FixedCost)
+	assert.InDelta(t, 0.05, a.MarginCost, 0.0001)
+	assert.Nil(t, a.Metadata)
+
+	// Pool B: failed fetch.
+	b, ok := byHex[hex.EncodeToString(poolB)]
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), b.BlocksMinted)
+	require.NotNil(t, b.Metadata)
+	require.NotNil(t, b.Metadata.URL)
+	assert.Equal(t, urlB, *b.Metadata.URL)
+	require.NotNil(t, b.Metadata.Hash)
+	assert.Equal(t, hex.EncodeToString(hashB), *b.Metadata.Hash)
+	require.NotNil(t, b.Metadata.Error)
+	assert.Equal(t, "HASH_MISMATCH", b.Metadata.Error.Code)
+	assert.Nil(t, b.Metadata.Name)
+	assert.Nil(t, b.Metadata.Ticker)
+
+	// Pool C: successful fetch.
+	c, ok := byHex[hex.EncodeToString(poolC)]
+	require.True(t, ok)
+	assert.Equal(t, uint64(0), c.BlocksMinted)
+	require.NotNil(t, c.Metadata)
+	assert.Nil(t, c.Metadata.Error)
+	require.NotNil(t, c.Metadata.Name)
+	assert.Equal(t, "Pool C", *c.Metadata.Name)
+	require.NotNil(t, c.Metadata.Ticker)
+	assert.Equal(t, "PLC", *c.Metadata.Ticker)
+	require.NotNil(t, c.Metadata.Description)
+	assert.Equal(t, "A pool.", *c.Metadata.Description)
+	require.NotNil(t, c.Metadata.Homepage)
+	assert.Equal(t, "https://example.com", *c.Metadata.Homepage)
+}
+
+// TestNodeAdapterPoolsExtendedProtocolParamsUnavailable covers the case
+// where protocol parameters have not been loaded yet: live_saturation is a
+// required, non-nullable float in the OpenAPI schema, and 0.0 is itself a
+// legitimate saturation value, so there is no schema-compatible
+// placeholder for "unknown". PoolsExtended must fail the whole request
+// rather than guess, matching PoolDetail's identical requirement.
+func TestNodeAdapterPoolsExtendedProtocolParamsUnavailable(t *testing.T) {
+	adapter, store, db := newDBBackedAdapter(t)
+	ensureExtendedPoolChainTip(t, store)
+	seedExtendedPool(t, store, db, 0xe1, 1_000_000, 1_000_000, 0, "", nil)
+
+	_, err := adapter.PoolsExtended()
+	require.ErrorContains(t, err, "protocol parameters")
+}
+
+// TestNodeAdapterPoolsExtendedDatabaseFailure guards against a
+// backing-store failure being silently swallowed into an incomplete
+// success response: a broken stake query must surface as an error.
+func TestNodeAdapterPoolsExtendedDatabaseFailure(t *testing.T) {
+	adapter, store, db := newDBBackedAdapterWithProtocolParams(t)
+	ensureExtendedPoolChainTip(t, store)
+	seedExtendedPool(t, store, db, 0xcc, 1_000_000, 1_000_000, 0, "", nil)
+
+	require.NoError(t, store.DB().Exec("DROP TABLE account").Error)
+
+	_, err := adapter.PoolsExtended()
+	require.ErrorContains(t, err, "get live stake")
+}
+
+// TestNodeAdapterPoolsExtendedMetadataSingleBatchedQuery is the
+// performance acceptance test for #2489's hard requirement: metadata for a
+// whole page of pools must come from one batched query, not one query per
+// pool. It seeds five pools each with their own distinct metadata anchor
+// and cached document, counts how many queries actually touch
+// offchain_metadata while serving PoolsExtended, and asserts it stays at
+// exactly one regardless of pool count. It also captures that query's SQL
+// and runs EXPLAIN QUERY PLAN against it, asserting the plan uses the
+// (source_type, url, hash) unique index rather than a table scan.
+func TestNodeAdapterPoolsExtendedMetadataSingleBatchedQuery(t *testing.T) {
+	adapter, store, db := newDBBackedAdapterWithProtocolParams(t)
+	ensureExtendedPoolChainTip(t, store)
+
+	const poolCount = 5
+	seededHex := make(map[string]bool, poolCount)
+	for i := range poolCount {
+		seed := byte(0x50 + i)
+		url := "https://example.com/pool-" + hex.EncodeToString([]byte{seed}) + ".json"
+		hash := fill32(seed)
+		pkh := seedExtendedPool(t, store, db, seed, 1_000_000, 1_000_000, 0, url, hash)
+		seededHex[hex.EncodeToString(pkh)] = true
+		seedExtendedPoolMetadataDoc(
+			t, store, url, hash, models.OffchainMetadataStatusFetched,
+			[]byte(`{"name":"Pool","description":"d.",`+
+				`"ticker":"ABC","homepage":"https://example.com"}`),
+			"",
+		)
+	}
+
+	queryCount := 0
+	var capturedSQL string
+	var capturedVars []any
+	const callbackName = "test:count_offchain_metadata_queries"
+	// Registered on ReadDB(), not DB(): resolveReadDB (used by every
+	// PoolsExtended read, including GetOffchainMetadataBatch) routes to
+	// the separate read-connection pool for a file-based sqlite database
+	// (see ReadDB's doc comment, database/plugin/metadata/sqlite/database.go),
+	// which is a distinct *gorm.DB from DB() and does not share its
+	// registered callbacks.
+	require.NoError(t, store.ReadDB().Callback().Query().
+		After("gorm:query").
+		Register(callbackName, func(tx *gorm.DB) {
+			if tx.Statement.Table != "offchain_metadata" {
+				return
+			}
+			queryCount++
+			if capturedSQL == "" {
+				capturedSQL = tx.Statement.SQL.String()
+				capturedVars = append([]any(nil), tx.Statement.Vars...)
+			}
+		}))
+	t.Cleanup(func() {
+		_ = store.ReadDB().Callback().Query().Remove(callbackName)
+	})
+
+	pools, err := adapter.PoolsExtended()
+	require.NoError(t, err)
+	// >= poolCount, not == poolCount: Start() against the devnet genesis
+	// registers its own genesis-staking pool alongside the poolCount
+	// seeded here (see ensureExtendedPoolChainTip's doc comment); only
+	// the seeded pools are asserted on below.
+	require.GreaterOrEqual(t, len(pools), poolCount)
+	seenSeeded := 0
+	for _, p := range pools {
+		if !seededHex[p.Hex] {
+			continue
+		}
+		seenSeeded++
+		require.NotNil(t, p.Metadata)
+		assert.Equal(t, "Pool", *p.Metadata.Name)
+	}
+	assert.Equal(t, poolCount, seenSeeded)
+	assert.Equal(
+		t, 1, queryCount,
+		"expected exactly one batched off-chain metadata query for the "+
+			"whole page of %d pools, not one per pool", poolCount,
+	)
+	require.NotEmpty(t, capturedSQL, "did not capture the batched metadata query")
+
+	planRows, err := store.DB().
+		Raw("EXPLAIN QUERY PLAN "+capturedSQL, capturedVars...).
+		Rows()
+	require.NoError(t, err)
+	defer planRows.Close()
+
+	var details []string
+	for planRows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NotEmpty(t, details)
+	t.Logf("offchain_metadata query: %s | vars=%v", capturedSQL, capturedVars)
+	t.Logf("EXPLAIN QUERY PLAN: %v", details)
+	for _, detail := range details {
+		assert.NotContains(t, detail, "SCAN", "query plan: %v", details)
+	}
+	assert.Contains(
+		t,
+		strings.Join(details, " | "),
+		"idx_offchain_metadata_source_url_hash",
+		"query plan did not use the (source_type, url, hash) index: %v",
+		details,
+	)
+}

--- a/api/blockfrost/adapter_pools_extended_db_test.go
+++ b/api/blockfrost/adapter_pools_extended_db_test.go
@@ -403,8 +403,20 @@ func TestNodeAdapterPoolsExtendedMetadataSingleBatchedQuery(t *testing.T) {
 	require.NotEmpty(t, details)
 	t.Logf("offchain_metadata query: %s | vars=%v", capturedSQL, capturedVars)
 	t.Logf("EXPLAIN QUERY PLAN: %v", details)
+	// Reject only an UNINDEXED scan of the table, not the bare word "SCAN":
+	// sqlite reports some index-only lookups as
+	// "SCAN offchain_metadata USING COVERING INDEX ...", which is an indexed
+	// access path and must not fail this test.
 	for _, detail := range details {
-		assert.NotContains(t, detail, "SCAN", "query plan: %v", details)
+		if strings.Contains(detail, "SCAN offchain_metadata") {
+			assert.Contains(
+				t,
+				detail,
+				"INDEX",
+				"query plan scans the table without an index: %v",
+				details,
+			)
+		}
 	}
 	assert.Contains(
 		t,

--- a/api/blockfrost/adapter_pools_extended_metadata.go
+++ b/api/blockfrost/adapter_pools_extended_metadata.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/hex"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/internal/offchainmetadata"
+)
+
+// poolExtendedMetadataKey builds the lookup key used to match a batched
+// GetOffchainMetadataBatch result row back to a specific pool's on-chain
+// (url, hash) pointer. Two documents can share a URL under different
+// hashes (metadata republished at the same URL with new content), so the
+// match must be on the (url, hash) pair, not url alone.
+func poolExtendedMetadataKey(url string, hash []byte) string {
+	return url + "\x00" + string(hash)
+}
+
+// buildPoolExtendedMetadata classifies one pool's persisted off-chain
+// metadata state into pool_list_extended's nullable metadata object. It is
+// a pure function over already-fetched state (doc comes from one batched
+// GetOffchainMetadataBatch call across the whole pool set, not a per-pool
+// query) and intentionally mirrors NodeAdapter.PoolMetadata's
+// classification logic (adapter.go): a nil metadataURL means the pool has
+// no registered anchor at all (metadata: null); a pending or missing doc
+// returns the anchor with every off-chain field left nil; a failed doc or
+// one that fails re-validation (internal/offchainmetadata.ValidatePoolMetadata)
+// returns the anchor plus the schema's error object; otherwise every
+// off-chain field is populated. This logic is duplicated rather than
+// factored out of PoolMetadata because that function is owned by the pool
+// detail/metadata feature (#2936/#2995) and is not modified here.
+func buildPoolExtendedMetadata(
+	metadataURL string,
+	metadataHash []byte,
+	doc *models.OffchainMetadata,
+) *PoolExtendedMetadataInfo {
+	if metadataURL == "" {
+		return nil
+	}
+	url := metadataURL
+	hash := hex.EncodeToString(metadataHash)
+	ret := &PoolExtendedMetadataInfo{URL: &url, Hash: &hash}
+
+	if doc == nil || doc.Status == models.OffchainMetadataStatusPending {
+		return ret
+	}
+	if doc.Status == models.OffchainMetadataStatusFailed {
+		ret.Error = offchainFetchError("Pool", metadataURL, metadataHash, doc)
+		return ret
+	}
+	// Validation happens in the fetcher at fetch time
+	// (internal/offchainmetadata.ValidatePoolMetadata, invoked from
+	// fetchOne). This defensive re-validation only matters for rows
+	// persisted as "fetched" before that validation existed; see
+	// PoolMetadata's identical comment in adapter.go for the full
+	// rationale.
+	fields, err := offchainmetadata.ValidatePoolMetadata(doc.Content)
+	if err != nil {
+		legacyFailure := &models.OffchainMetadata{LastError: err.Error()}
+		ret.Error = offchainFetchError(
+			"Pool", metadataURL, metadataHash, legacyFailure,
+		)
+		return ret
+	}
+	ret.Name = &fields.Name
+	ret.Description = &fields.Description
+	ret.Ticker = &fields.Ticker
+	ret.Homepage = &fields.Homepage
+	return ret
+}

--- a/api/blockfrost/adapter_pools_extended_metadata.go
+++ b/api/blockfrost/adapter_pools_extended_metadata.go
@@ -55,11 +55,21 @@ func buildPoolExtendedMetadata(
 	hash := hex.EncodeToString(metadataHash)
 	ret := &PoolExtendedMetadataInfo{URL: &url, Hash: &hash}
 
-	if doc == nil || doc.Status == models.OffchainMetadataStatusPending {
+	if doc == nil {
 		return ret
 	}
-	if doc.Status == models.OffchainMetadataStatusFailed {
+	// Branch on the status explicitly rather than treating "not pending and
+	// not failed" as fetched. An unrecognized future status falling into the
+	// validation path below would report DECODE_ERROR for content that was
+	// simply never fetched; anything but a known-fetched row is treated the
+	// same as pending, i.e. anchor only and no error object.
+	switch doc.Status {
+	case models.OffchainMetadataStatusFailed:
 		ret.Error = offchainFetchError("Pool", metadataURL, metadataHash, doc)
+		return ret
+	case models.OffchainMetadataStatusFetched:
+		// fall through to validation below
+	default:
 		return ret
 	}
 	// Validation happens in the fetcher at fetch time

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -1571,38 +1571,34 @@ func TestHandlePoolsExtended(t *testing.T) {
 			{
 				PoolID:         "pool1zzz",
 				Hex:            "ff",
-				VrfKey:         "vrf2",
 				ActiveStake:    "200",
 				LiveStake:      "300",
+				BlocksMinted:   7,
+				LiveSaturation: 0.8,
 				DeclaredPledge: "400",
 				FixedCost:      "500",
 				MarginCost:     0.2,
-				Relays: []PoolRelayInfo{
-					{
-						IPv4: "192.168.0.1",
-						DNS:  "relay-two.example",
-						Port: new(3002),
-					},
-				},
+				// No registered metadata anchor: pool_list_extended
+				// requires the metadata key to be present as null.
+				Metadata: nil,
 			},
 			{
 				PoolID:         "pool1aaa",
 				Hex:            "01",
-				VrfKey:         "vrf1",
 				ActiveStake:    "20",
 				LiveStake:      "30",
+				BlocksMinted:   69,
+				LiveSaturation: 0.93,
 				DeclaredPledge: "40",
 				FixedCost:      "50",
 				MarginCost:     0.1,
-				Relays: []PoolRelayInfo{
-					{
-						IPv6: "2001:db8::1",
-						DNS:  "relay-one.example",
-						Port: new(3001),
-					},
-					{
-						DNS: "relay-no-port.example",
-					},
+				Metadata: &PoolExtendedMetadataInfo{
+					URL:         new("https://stakenuts.com/mainnet.json"),
+					Hash:        new("47c0c68c"),
+					Ticker:      new("NUTS"),
+					Name:        new("Stake Nuts"),
+					Description: new("The best pool ever"),
+					Homepage:    new("https://stakentus.com/"),
 				},
 			},
 		},
@@ -1629,29 +1625,53 @@ func TestHandlePoolsExtended(t *testing.T) {
 		w.Header().Get("X-Pagination-Page-Total"),
 	)
 
+	// Capture the body before decoding: the raw-JSON assertions at the end
+	// of this test need it, and a json.Decoder over w.Body would drain it.
+	body := w.Body.Bytes()
+
 	var resp []PoolExtendedResponse
-	err := json.NewDecoder(w.Body).Decode(&resp)
+	err := json.Unmarshal(body, &resp)
 	require.NoError(t, err)
 	require.Len(t, resp, 1)
 	assert.Equal(t, "pool1aaa", resp[0].PoolID)
 	assert.Equal(t, "01", resp[0].Hex)
-	assert.Equal(t, "vrf1", resp[0].VrfKey)
 	assert.Equal(t, "20", resp[0].ActiveStake)
 	assert.Equal(t, "30", resp[0].LiveStake)
+	assert.Equal(t, uint64(69), resp[0].BlocksMinted)
+	assert.InDelta(t, 0.93, resp[0].LiveSaturation, 0.0001)
 	assert.Equal(t, "40", resp[0].DeclaredPledge)
 	assert.Equal(t, "50", resp[0].FixedCost)
 	assert.InDelta(t, 0.1, resp[0].MarginCost, 0.0001)
-	require.Len(t, resp[0].Relays, 2)
-	assert.Nil(t, resp[0].Relays[0].IPv4)
-	require.NotNil(t, resp[0].Relays[0].IPv6)
-	assert.Equal(t, "2001:db8::1", *resp[0].Relays[0].IPv6)
-	require.NotNil(t, resp[0].Relays[0].DNS)
-	assert.Equal(t, "relay-one.example", *resp[0].Relays[0].DNS)
-	require.NotNil(t, resp[0].Relays[0].Port)
-	assert.Equal(t, 3001, *resp[0].Relays[0].Port)
-	require.NotNil(t, resp[0].Relays[1].DNS)
-	assert.Equal(t, "relay-no-port.example", *resp[0].Relays[1].DNS)
-	assert.Nil(t, resp[0].Relays[1].Port)
+	// pool_list_extended requires metadata; a registered anchor with a
+	// successfully fetched document populates all six nullable fields
+	// and carries no error object.
+	require.NotNil(t, resp[0].Metadata)
+	require.NotNil(t, resp[0].Metadata.URL)
+	assert.Equal(
+		t,
+		"https://stakenuts.com/mainnet.json",
+		*resp[0].Metadata.URL,
+	)
+	require.NotNil(t, resp[0].Metadata.Hash)
+	assert.Equal(t, "47c0c68c", *resp[0].Metadata.Hash)
+	require.NotNil(t, resp[0].Metadata.Ticker)
+	assert.Equal(t, "NUTS", *resp[0].Metadata.Ticker)
+	require.NotNil(t, resp[0].Metadata.Name)
+	assert.Equal(t, "Stake Nuts", *resp[0].Metadata.Name)
+	require.NotNil(t, resp[0].Metadata.Description)
+	assert.Equal(t, "The best pool ever", *resp[0].Metadata.Description)
+	require.NotNil(t, resp[0].Metadata.Homepage)
+	assert.Equal(t, "https://stakentus.com/", *resp[0].Metadata.Homepage)
+	assert.Nil(t, resp[0].Metadata.Error)
+
+	// vrf_key and relays are not part of pool_list_extended and must not
+	// be emitted. Assert on the raw JSON, since the typed struct can no
+	// longer express them.
+	var raw []map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.Len(t, raw, 1)
+	assert.NotContains(t, raw[0], "vrf_key")
+	assert.NotContains(t, raw[0], "relays")
 }
 
 func TestHandlePoolsExtendedInvalidPagination(t *testing.T) {

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -703,33 +703,32 @@ func (b *Blockfrost) handlePoolsExtended(
 
 	resp := make([]PoolExtendedResponse, 0, end-start)
 	for _, pool := range pools[start:end] {
-		relays := make([]PoolRelayResponse, 0, len(pool.Relays))
-		for _, relay := range pool.Relays {
-			tmpRelay := PoolRelayResponse{}
-			if relay.IPv4 != "" {
-				tmpRelay.IPv4 = &relay.IPv4
+		var metadata *PoolExtendedMetadataResponse
+		if pool.Metadata != nil {
+			metadata = &PoolExtendedMetadataResponse{
+				URL:         pool.Metadata.URL,
+				Hash:        pool.Metadata.Hash,
+				Ticker:      pool.Metadata.Ticker,
+				Name:        pool.Metadata.Name,
+				Description: pool.Metadata.Description,
+				Homepage:    pool.Metadata.Homepage,
 			}
-			if relay.IPv6 != "" {
-				tmpRelay.IPv6 = &relay.IPv6
+			if pool.Metadata.Error != nil {
+				respErr := OffchainFetchErrorResponse(*pool.Metadata.Error)
+				metadata.Error = &respErr
 			}
-			if relay.DNS != "" {
-				tmpRelay.DNS = &relay.DNS
-			}
-			if relay.Port != nil {
-				tmpRelay.Port = relay.Port
-			}
-			relays = append(relays, tmpRelay)
 		}
 		resp = append(resp, PoolExtendedResponse{
 			PoolID:         pool.PoolID,
 			Hex:            pool.Hex,
-			VrfKey:         pool.VrfKey,
 			ActiveStake:    pool.ActiveStake,
 			LiveStake:      pool.LiveStake,
+			BlocksMinted:   pool.BlocksMinted,
+			LiveSaturation: pool.LiveSaturation,
 			DeclaredPledge: pool.DeclaredPledge,
-			FixedCost:      pool.FixedCost,
 			MarginCost:     pool.MarginCost,
-			Relays:         relays,
+			FixedCost:      pool.FixedCost,
+			Metadata:       metadata,
 		})
 	}
 

--- a/api/blockfrost/handlers_pools_extended_test.go
+++ b/api/blockfrost/handlers_pools_extended_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandlePoolsExtendedSchemaFields is the shape/pagination/order and
+// metadata success/absence/failure acceptance test for #2489: it exercises
+// handlePoolsExtended (not the adapter) against a mock that returns the
+// full pool_list_extended field set, including all three metadata states,
+// and does not reference vrf_key or relays, which are not part of the
+// current OpenAPI schema.
+func TestHandlePoolsExtendedSchemaFields(t *testing.T) {
+	ticker := "ABC"
+	name := "Pool ABC"
+	description := "A pool."
+	homepage := "https://example.com"
+	url := "https://example.com/pool.json"
+	hash := "deadbeef"
+
+	mock := &mockNode{
+		pools: []PoolExtendedInfo{
+			{
+				// No registered metadata anchor -> metadata: null.
+				PoolID:         "pool1zzz",
+				Hex:            "ff",
+				ActiveStake:    "200",
+				LiveStake:      "300",
+				BlocksMinted:   7,
+				LiveSaturation: 0.42,
+				DeclaredPledge: "400",
+				MarginCost:     0.2,
+				FixedCost:      "500",
+				Metadata:       nil,
+			},
+			{
+				// Anchor present, fetch failed -> metadata is a non-null
+				// object with the error object and every off-chain field
+				// left null.
+				PoolID:         "pool1mmm",
+				Hex:            "80",
+				ActiveStake:    "150",
+				LiveStake:      "250",
+				BlocksMinted:   1,
+				LiveSaturation: 0.1,
+				DeclaredPledge: "350",
+				MarginCost:     0.15,
+				FixedCost:      "450",
+				Metadata: &PoolExtendedMetadataInfo{
+					URL:  &url,
+					Hash: &hash,
+					Error: &OffchainFetchErrorInfo{
+						Code:    "HASH_MISMATCH",
+						Message: "hash mismatch",
+					},
+				},
+			},
+			{
+				// Anchor present, fetch succeeded -> metadata fully
+				// populated with no error.
+				PoolID:         "pool1aaa",
+				Hex:            "01",
+				ActiveStake:    "20",
+				LiveStake:      "30",
+				BlocksMinted:   3,
+				LiveSaturation: 0.93,
+				DeclaredPledge: "40",
+				MarginCost:     0.1,
+				FixedCost:      "50",
+				Metadata: &PoolExtendedMetadataInfo{
+					URL:         &url,
+					Hash:        &hash,
+					Ticker:      &ticker,
+					Name:        &name,
+					Description: &description,
+					Homepage:    &homepage,
+				},
+			},
+		},
+	}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/extended?count=2&page=1&order=asc",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handlePoolsExtended(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "3", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Page-Total"))
+
+	var resp []PoolExtendedResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 2)
+
+	// Ascending hex order: "01" (pool1aaa) then "80" (pool1mmm), matching
+	// hosted Blockfrost's ordering semantics for this endpoint.
+	assert.Equal(t, "pool1aaa", resp[0].PoolID)
+	assert.Equal(t, "01", resp[0].Hex)
+	assert.Equal(t, "20", resp[0].ActiveStake)
+	assert.Equal(t, "30", resp[0].LiveStake)
+	assert.Equal(t, uint64(3), resp[0].BlocksMinted)
+	assert.InDelta(t, 0.93, resp[0].LiveSaturation, 0.0001)
+	assert.Equal(t, "40", resp[0].DeclaredPledge)
+	assert.Equal(t, "50", resp[0].FixedCost)
+	assert.InDelta(t, 0.1, resp[0].MarginCost, 0.0001)
+	require.NotNil(t, resp[0].Metadata)
+	assert.Nil(t, resp[0].Metadata.Error)
+	require.NotNil(t, resp[0].Metadata.Ticker)
+	assert.Equal(t, "ABC", *resp[0].Metadata.Ticker)
+	require.NotNil(t, resp[0].Metadata.Name)
+	assert.Equal(t, "Pool ABC", *resp[0].Metadata.Name)
+
+	assert.Equal(t, "pool1mmm", resp[1].PoolID)
+	assert.Equal(t, "80", resp[1].Hex)
+	require.NotNil(t, resp[1].Metadata)
+	require.NotNil(t, resp[1].Metadata.URL)
+	assert.Equal(t, url, *resp[1].Metadata.URL)
+	assert.Nil(t, resp[1].Metadata.Name)
+	require.NotNil(t, resp[1].Metadata.Error)
+	assert.Equal(t, "HASH_MISMATCH", resp[1].Metadata.Error.Code)
+
+	// Page 2 holds the pool with no metadata anchor at all.
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/extended?count=2&page=2&order=asc",
+		nil,
+	)
+	w = httptest.NewRecorder()
+	b.handlePoolsExtended(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var page2 []PoolExtendedResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&page2))
+	require.Len(t, page2, 1)
+	assert.Equal(t, "pool1zzz", page2[0].PoolID)
+	assert.Equal(t, uint64(7), page2[0].BlocksMinted)
+	assert.InDelta(t, 0.42, page2[0].LiveSaturation, 0.0001)
+	assert.Nil(t, page2[0].Metadata)
+
+	// Descending order reverses the page-1 ordering.
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/pools/extended?count=2&page=1&order=desc",
+		nil,
+	)
+	w = httptest.NewRecorder()
+	b.handlePoolsExtended(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var descResp []PoolExtendedResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&descResp))
+	require.Len(t, descResp, 2)
+	assert.Equal(t, "pool1zzz", descResp[0].PoolID)
+	assert.Equal(t, "pool1mmm", descResp[1].PoolID)
+}

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -425,26 +425,38 @@ type OffchainFetchErrorInfo struct {
 	Message string
 }
 
-// PoolExtendedInfo holds pool data needed by the
-// /pools/extended endpoint.
+// PoolExtendedInfo holds pool data needed by the /pools/extended endpoint,
+// following the Blockfrost OpenAPI 0.1.90 pool_list_extended schema.
+// Neither vrf_key nor relays is part of that schema (vrf_key belongs to the
+// pool-detail schema instead; see PoolDetailInfo), so this type omits both.
 type PoolExtendedInfo struct {
 	PoolID         string
 	Hex            string
-	VrfKey         string
 	ActiveStake    string
 	LiveStake      string
+	BlocksMinted   uint64
+	LiveSaturation float64
 	DeclaredPledge string
-	FixedCost      string
 	MarginCost     float64
-	Relays         []PoolRelayInfo
+	FixedCost      string
+	Metadata       *PoolExtendedMetadataInfo
 }
 
-// PoolRelayInfo holds relay data for pool responses.
-type PoolRelayInfo struct {
-	IPv4 string
-	IPv6 string
-	DNS  string
-	Port *int
+// PoolExtendedMetadataInfo holds the nullable metadata object nested in
+// pool_list_extended: the on-chain anchor (URL/hash) plus the off-chain
+// document fields when fetched and validated, or Error when the fetch or
+// validation failed. A nil *PoolExtendedMetadataInfo means the pool has no
+// registered metadata anchor at all (metadata: null); this mirrors
+// PoolMetadataInfo's fields but omits PoolID/Hex, which pool_list_extended
+// carries at the parent object level instead of inside metadata.
+type PoolExtendedMetadataInfo struct {
+	URL         *string
+	Hash        *string
+	Ticker      *string
+	Name        *string
+	Description *string
+	Homepage    *string
+	Error       *OffchainFetchErrorInfo
 }
 
 // PoolDetailInfo holds pool data needed by the /pools/{pool_id} endpoint,

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -366,26 +366,37 @@ type ErrorResponse struct {
 	Message    string `json:"message"`
 }
 
-// PoolRelayResponse represents a stake pool relay.
-type PoolRelayResponse struct {
-	IPv4 *string `json:"ipv4"`
-	IPv6 *string `json:"ipv6"`
-	DNS  *string `json:"dns"`
-	Port *int    `json:"port"`
+// PoolExtendedResponse represents an extended stake pool list item,
+// following the Blockfrost OpenAPI 0.1.90 pool_list_extended schema
+// exactly. Neither vrf_key nor relays is part of that schema (vrf_key
+// belongs to the pool-detail schema instead; see PoolDetailResponse), so
+// this type omits both.
+type PoolExtendedResponse struct {
+	PoolID         string                        `json:"pool_id"`
+	Hex            string                        `json:"hex"`
+	ActiveStake    string                        `json:"active_stake"`
+	LiveStake      string                        `json:"live_stake"`
+	BlocksMinted   uint64                        `json:"blocks_minted"`
+	LiveSaturation float64                       `json:"live_saturation"`
+	DeclaredPledge string                        `json:"declared_pledge"`
+	MarginCost     float64                       `json:"margin_cost"`
+	FixedCost      string                        `json:"fixed_cost"`
+	Metadata       *PoolExtendedMetadataResponse `json:"metadata"`
 }
 
-// PoolExtendedResponse represents an extended stake pool
-// list item.
-type PoolExtendedResponse struct {
-	PoolID         string              `json:"pool_id"`
-	Hex            string              `json:"hex"`
-	VrfKey         string              `json:"vrf_key"`
-	ActiveStake    string              `json:"active_stake"`
-	LiveStake      string              `json:"live_stake"`
-	DeclaredPledge string              `json:"declared_pledge"`
-	FixedCost      string              `json:"fixed_cost"`
-	MarginCost     float64             `json:"margin_cost"`
-	Relays         []PoolRelayResponse `json:"relays"`
+// PoolExtendedMetadataResponse represents pool_list_extended's nullable
+// metadata object. It mirrors PoolMetadataResponse's off-chain fields
+// (minus pool_id/hex, which pool_list_extended carries at the parent
+// level) and is omitted (metadata: null) entirely when the pool has no
+// registered metadata anchor.
+type PoolExtendedMetadataResponse struct {
+	URL         *string                     `json:"url"`
+	Hash        *string                     `json:"hash"`
+	Ticker      *string                     `json:"ticker"`
+	Name        *string                     `json:"name"`
+	Description *string                     `json:"description"`
+	Homepage    *string                     `json:"homepage"`
+	Error       *OffchainFetchErrorResponse `json:"error,omitempty"`
 }
 
 // MetadataTransactionJSONResponse represents a Blockfrost

--- a/database/plugin/metadata/mysql/offchain_metadata.go
+++ b/database/plugin/metadata/mysql/offchain_metadata.go
@@ -74,3 +74,18 @@ func (d *MetadataStoreMysql) GetOffchainMetadata(
 	}
 	return offchain.Get(db, sourceType, url, hash)
 }
+
+// GetOffchainMetadataBatch retrieves cached off-chain documents for many
+// URLs in a single query. MySQL's bind-parameter limit (65535) is far
+// above any realistic pool count, so unlike sqlite this does not chunk.
+func (d *MetadataStoreMysql) GetOffchainMetadataBatch(
+	sourceType string,
+	urls []string,
+	txn types.Txn,
+) ([]models.OffchainMetadata, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.GetBatch(db, sourceType, urls)
+}

--- a/database/plugin/metadata/offchain/offchain.go
+++ b/database/plugin/metadata/offchain/offchain.go
@@ -316,19 +316,13 @@ func Get(
 	return &doc, nil
 }
 
-// GetBatch retrieves cached off-chain metadata documents for many URLs of
-// the given source type in a single query, for callers serving a whole
-// page of results (for example, per-pool metadata on /pools/extended) that
-// need to avoid one Get call per item. The source_type + url IN (...)
-// predicate uses the leading two columns of the (source_type, url, hash)
-// unique index. Duplicate and empty URLs are removed before querying;
-// callers must still match returned rows against their own (url, hash)
-// pointer, since two documents can share a URL under different hashes.
-func GetBatch(
-	db *gorm.DB,
-	sourceType string,
-	urls []string,
-) ([]models.OffchainMetadata, error) {
+// DedupeURLs drops empty and repeated URLs, preserving first-seen order.
+//
+// Exported so a backend that has to split a batch into several queries can
+// deduplicate the whole list before chunking. Deduplicating only within each
+// chunk cannot enforce the batch contract: a URL landing in two different
+// chunks would be queried twice and its row returned twice.
+func DedupeURLs(urls []string) []string {
 	seen := make(map[string]struct{}, len(urls))
 	uniq := make([]string, 0, len(urls))
 	for _, url := range urls {
@@ -341,6 +335,23 @@ func GetBatch(
 		seen[url] = struct{}{}
 		uniq = append(uniq, url)
 	}
+	return uniq
+}
+
+// GetBatch retrieves cached off-chain metadata rows for many URLs of
+// the given source type in a single query, for callers serving a whole
+// page of results (for example, per-pool metadata on /pools/extended) that
+// need to avoid one Get call per item. The source_type + url IN (...)
+// predicate uses the leading two columns of the (source_type, url, hash)
+// unique index. Duplicate and empty URLs are removed before querying;
+// callers must still match returned rows against their own (url, hash)
+// pointer, since two documents can share a URL under different hashes.
+func GetBatch(
+	db *gorm.DB,
+	sourceType string,
+	urls []string,
+) ([]models.OffchainMetadata, error) {
+	uniq := DedupeURLs(urls)
 	if len(uniq) == 0 {
 		return nil, nil
 	}

--- a/database/plugin/metadata/offchain/offchain.go
+++ b/database/plugin/metadata/offchain/offchain.go
@@ -315,3 +315,45 @@ func Get(
 	}
 	return &doc, nil
 }
+
+// GetBatch retrieves cached off-chain metadata documents for many URLs of
+// the given source type in a single query, for callers serving a whole
+// page of results (for example, per-pool metadata on /pools/extended) that
+// need to avoid one Get call per item. The source_type + url IN (...)
+// predicate uses the leading two columns of the (source_type, url, hash)
+// unique index. Duplicate and empty URLs are removed before querying;
+// callers must still match returned rows against their own (url, hash)
+// pointer, since two documents can share a URL under different hashes.
+func GetBatch(
+	db *gorm.DB,
+	sourceType string,
+	urls []string,
+) ([]models.OffchainMetadata, error) {
+	seen := make(map[string]struct{}, len(urls))
+	uniq := make([]string, 0, len(urls))
+	for _, url := range urls {
+		if url == "" {
+			continue
+		}
+		if _, ok := seen[url]; ok {
+			continue
+		}
+		seen[url] = struct{}{}
+		uniq = append(uniq, url)
+	}
+	if len(uniq) == 0 {
+		return nil, nil
+	}
+	var docs []models.OffchainMetadata
+	result := db.Where(
+		"source_type = ? AND url IN ?",
+		sourceType,
+		uniq,
+	).Find(&docs)
+	if result.Error != nil {
+		return nil, fmt.Errorf(
+			"get off-chain metadata batch: %w", result.Error,
+		)
+	}
+	return docs, nil
+}

--- a/database/plugin/metadata/postgres/offchain_metadata.go
+++ b/database/plugin/metadata/postgres/offchain_metadata.go
@@ -74,3 +74,18 @@ func (d *MetadataStorePostgres) GetOffchainMetadata(
 	}
 	return offchain.Get(db, sourceType, url, hash)
 }
+
+// GetOffchainMetadataBatch retrieves cached off-chain documents for many
+// URLs in a single query. Postgres's bind-parameter limit (65535) is far
+// above any realistic pool count, so unlike sqlite this does not chunk.
+func (d *MetadataStorePostgres) GetOffchainMetadataBatch(
+	sourceType string,
+	urls []string,
+	txn types.Txn,
+) ([]models.OffchainMetadata, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	return offchain.GetBatch(db, sourceType, urls)
+}

--- a/database/plugin/metadata/sqlite/offchain_metadata.go
+++ b/database/plugin/metadata/sqlite/offchain_metadata.go
@@ -72,3 +72,27 @@ func (d *MetadataStoreSqlite) GetOffchainMetadata(
 	}
 	return offchain.Get(db, sourceType, url, hash)
 }
+
+// GetOffchainMetadataBatch retrieves cached off-chain documents for many
+// URLs in one or more queries, chunked at sqliteBindVarLimit to stay under
+// sqlite's bound-parameter limit for the url IN (...) clause.
+func (d *MetadataStoreSqlite) GetOffchainMetadataBatch(
+	sourceType string,
+	urls []string,
+	txn types.Txn,
+) ([]models.OffchainMetadata, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]models.OffchainMetadata, 0, len(urls))
+	for start := 0; start < len(urls); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(urls))
+		chunk, err := offchain.GetBatch(db, sourceType, urls[start:end])
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, chunk...)
+	}
+	return docs, nil
+}

--- a/database/plugin/metadata/sqlite/offchain_metadata.go
+++ b/database/plugin/metadata/sqlite/offchain_metadata.go
@@ -85,10 +85,17 @@ func (d *MetadataStoreSqlite) GetOffchainMetadataBatch(
 	if err != nil {
 		return nil, err
 	}
-	docs := make([]models.OffchainMetadata, 0, len(urls))
-	for start := 0; start < len(urls); start += sqliteBindVarLimit {
-		end := min(start+sqliteBindVarLimit, len(urls))
-		chunk, err := offchain.GetBatch(db, sourceType, urls[start:end])
+	// Deduplicate across the whole list before chunking, not per chunk:
+	// GetBatch removes duplicates within whatever slice it is handed, so a
+	// URL appearing in two different chunks would otherwise be queried twice
+	// and its row appended twice, breaking the batch's one-row-per-match
+	// contract. Two pools can share a metadata anchor, so repeats are
+	// expected input here rather than pathological.
+	uniq := offchain.DedupeURLs(urls)
+	docs := make([]models.OffchainMetadata, 0, len(uniq))
+	for start := 0; start < len(uniq); start += sqliteBindVarLimit {
+		end := min(start+sqliteBindVarLimit, len(uniq))
+		chunk, err := offchain.GetBatch(db, sourceType, uniq[start:end])
 		if err != nil {
 			return nil, err
 		}

--- a/database/plugin/metadata/sqlite/offchain_metadata_test.go
+++ b/database/plugin/metadata/sqlite/offchain_metadata_test.go
@@ -17,12 +17,14 @@ package sqlite
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -181,4 +183,51 @@ func TestGetOffchainMetadataBatch(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Empty(t, empty)
+}
+
+// TestGetOffchainMetadataBatchDeduplicatesAcrossChunks pins the sqlite
+// backend's dedup-before-chunk behavior. sqlite splits the url IN (...) list
+// at sqliteBindVarLimit, and offchain.GetBatch only removes duplicates within
+// whatever slice it is handed, so deduplicating per chunk instead of over the
+// whole list would query a repeated URL once per chunk it appears in and
+// append its row that many times. Two pools can share a metadata anchor, so a
+// repeated URL is expected input rather than a pathological case.
+func TestGetOffchainMetadataBatchDeduplicatesAcrossChunks(t *testing.T) {
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+
+	url := "https://pool.example.test/shared.json"
+	hash := bytes.Repeat([]byte{0xc1}, 32)
+	require.NoError(t, store.DB().Create(&models.OffchainMetadata{
+		SourceType: models.OffchainMetadataSourcePool,
+		URL:        url,
+		Hash:       hash,
+		Status:     models.OffchainMetadataStatusFetched,
+		Content:    []byte(`{"ticker":"SHR"}`),
+	}).Error)
+
+	// Place the same URL at both ends of a list longer than one chunk, so
+	// the repeats land in different chunks.
+	urls := make([]string, 0, sqliteBindVarLimit+2)
+	urls = append(urls, url)
+	for i := range sqliteBindVarLimit {
+		urls = append(
+			urls,
+			fmt.Sprintf("https://pool.example.test/filler-%d.json", i),
+		)
+	}
+	urls = append(urls, url)
+	require.Greater(t, len(urls), sqliteBindVarLimit)
+
+	docs, err := store.GetOffchainMetadataBatch(
+		models.OffchainMetadataSourcePool, urls, nil,
+	)
+	require.NoError(t, err)
+	require.Len(
+		t,
+		docs,
+		1,
+		"a URL repeated across chunk boundaries must yield one row, not one per chunk",
+	)
+	assert.Equal(t, url, docs[0].URL)
+	assert.Equal(t, hash, docs[0].Hash)
 }

--- a/database/plugin/metadata/sqlite/offchain_metadata_test.go
+++ b/database/plugin/metadata/sqlite/offchain_metadata_test.go
@@ -103,3 +103,82 @@ func TestOffchainMetadataPointersRoundTrip(t *testing.T) {
 	require.NotNil(t, got.FetchedAt)
 	require.True(t, got.FetchedAt.Equal(fetchedAt))
 }
+
+// TestGetOffchainMetadataBatch covers GetOffchainMetadataBatch's batching
+// contract for /pools/extended-style callers: many URLs of the same
+// source type resolved in one query, matching rows returned even when two
+// documents share a URL under different hashes, non-matching/empty URLs
+// ignored, and an empty input returning no rows without querying.
+func TestGetOffchainMetadataBatch(t *testing.T) {
+	store := setupTestDBWithMode(t, types.StorageModeAPI)
+
+	urlA := "https://pool.example.test/a.json"
+	urlB := "https://pool.example.test/b.json"
+	hashA := bytes.Repeat([]byte{0xa1}, 32)
+	hashA2 := bytes.Repeat([]byte{0xa2}, 32)
+	hashB := bytes.Repeat([]byte{0xb1}, 32)
+
+	for _, doc := range []models.OffchainMetadata{
+		{
+			SourceType: models.OffchainMetadataSourcePool,
+			URL:        urlA,
+			Hash:       hashA,
+			Status:     models.OffchainMetadataStatusFetched,
+			Content:    []byte(`{"ticker":"AAA"}`),
+		},
+		{
+			// Same URL as above, different on-chain hash: a pool that
+			// republished its metadata file's content without changing
+			// the URL. Both rows must come back from the batch query.
+			SourceType: models.OffchainMetadataSourcePool,
+			URL:        urlA,
+			Hash:       hashA2,
+			Status:     models.OffchainMetadataStatusFetched,
+			Content:    []byte(`{"ticker":"AA2"}`),
+		},
+		{
+			SourceType: models.OffchainMetadataSourcePool,
+			URL:        urlB,
+			Hash:       hashB,
+			Status:     models.OffchainMetadataStatusPending,
+		},
+		{
+			// Different source type, same URL: must not leak into a
+			// source_type = pool batch query.
+			SourceType: models.OffchainMetadataSourceDrep,
+			URL:        urlA,
+			Hash:       hashA,
+			Status:     models.OffchainMetadataStatusFetched,
+		},
+	} {
+		require.NoError(t, store.DB().Create(&doc).Error)
+	}
+
+	docs, err := store.GetOffchainMetadataBatch(
+		models.OffchainMetadataSourcePool,
+		[]string{urlA, urlB, "", urlA}, // empty and duplicate entries
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, docs, 3)
+
+	byKey := make(map[string]models.OffchainMetadata, len(docs))
+	for _, d := range docs {
+		byKey[d.URL+"\x00"+string(d.Hash)] = d
+	}
+	docA, ok := byKey[urlA+"\x00"+string(hashA)]
+	require.True(t, ok)
+	require.Equal(t, models.OffchainMetadataStatusFetched, docA.Status)
+	docA2, ok := byKey[urlA+"\x00"+string(hashA2)]
+	require.True(t, ok)
+	require.Equal(t, []byte(`{"ticker":"AA2"}`), docA2.Content)
+	docB, ok := byKey[urlB+"\x00"+string(hashB)]
+	require.True(t, ok)
+	require.Equal(t, models.OffchainMetadataStatusPending, docB.Status)
+
+	empty, err := store.GetOffchainMetadataBatch(
+		models.OffchainMetadataSourcePool, nil, nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -321,6 +321,23 @@ type MetadataStore interface {
 		txn types.Txn,
 	) (*models.OffchainMetadata, error)
 
+	// GetOffchainMetadataBatch retrieves cached off-chain documents for
+	// many URLs of the given source type in a single query, rather than
+	// one GetOffchainMetadata call per item. Used by callers that need
+	// per-item off-chain metadata for a whole page of results (for
+	// example, pool metadata for /pools/extended): the unique index on
+	// (source_type, url, hash) covers source_type + url IN (...) as its
+	// leading columns, so this is index-backed the same way
+	// GetOffchainMetadata is. Because two documents can share a URL under
+	// different hashes (metadata republished at the same URL with new
+	// content), callers must still match each returned row against their
+	// own (url, hash) pointer rather than assuming one row per URL.
+	GetOffchainMetadataBatch(
+		sourceType string,
+		urls []string,
+		txn types.Txn,
+	) ([]models.OffchainMetadata, error)
+
 	// GetRetiringPools returns pools whose latest retirement
 	// certificate targets an epoch after currentEpoch and has not been
 	// cancelled by a later registration certificate. Certificate


### PR DESCRIPTION
Closes #2489

Aligns `GET /pools/extended` with the Blockfrost `pool_list_extended` schema: adds the three missing fields, removes two that are not in the schema, and sources pool metadata from persisted off-chain state in a single query per page.

## Response shape

Verified against `src/schemas/pools/pool_list_extended.yaml` and `src/paths/api/pools/extended.yaml` in the spec rather than from the issue text.

Required: `pool_id`, `hex`, `active_stake`, `live_stake`, `blocks_minted`, `live_saturation`, `declared_pledge`, `margin_cost`, `fixed_cost`, `metadata`. Only `metadata` is nullable; when non-null it requires `url`, `hash`, `ticker`, `name`, `description` and `homepage` (all nullable strings) plus an optional `error` object whose `code` and `message` are both required.

So this adds `blocks_minted`, `live_saturation` and `metadata`, which the issue lists as missing.

## Breaking change: relays and vrf_key are removed

`relays` is absent from `pool_list_extended`, as the issue notes.

`vrf_key` is also absent. It belongs to `pool.yaml`, the pool detail schema. The issue does not mention this, but the acceptance criterion is to emit the OpenAPI field set, so it is removed too. Confirmed with the maintainer before doing it.

Anyone reading either field from this endpoint should use `GET /pools/{pool_id}`, which carries `vrf_key` and relay data. `PoolRelayInfo` and `PoolRelayResponse` are deleted; nothing else referenced them, and `TransactionPoolRelayInfo`/`TransactionPoolRelayResponse` are separate types still used by the transaction endpoints.

## live_saturation denominator

`live_saturation` divides live stake by the per-pool saturation threshold `totalCirculation / nOpt`, where `totalCirculation` is `MaxLovelaceSupply - Reserves`.

That quantity, not total active stake, is what defines the threshold: `ledger/rewards` passes `totalCirculation` (`rewards.go:287`) as sigma's denominator into `optimalPoolRewardChecked`, while passing `totalActiveStake` to `apparentPerformance` on the line immediately above. Using active stake instead overstates saturation by about 1.68x on mainnet-shaped inputs, moving the reported 1.0 crossing from roughly 72M ADA to roughly 43M.

Note that `Network()` computes two similar-looking values. The correct one is `maxSupply - reserves`; the `circulating` value on the following line additionally subtracts treasury and script-locked supply and is not what `rewards.go` uses.

`totalCirculation` is resolved once per page rather than per pool.

## Query cost

Two batched queries per page, neither of them per-pool.

Page metadata comes from one new `GetOffchainMetadataBatch(sourceType, urls, txn)` call. Shared logic lives in `database/plugin/metadata/offchain` with thin per-backend wrappers; sqlite chunks the `IN` list at its bind-variable limit, postgres and mysql issue one query. Plan:

```
SEARCH offchain_metadata USING INDEX idx_offchain_metadata_source_url_hash (source_type=? AND url=?)
```

No scan: it uses the leading two columns of the existing composite unique index, so no new index was needed. `TestNodeAdapterPoolsExtendedMetadataSingleBatchedQuery` asserts via a GORM callback counter that exactly one query hits `offchain_metadata` regardless of pool count, and bakes the plan check into the test so a regression to one-query-per-pool fails loudly.

`blocks_minted` reuses `CountPoolBlocksInSlotRange`, which already returns a map keyed by pool, so one call covers the whole page.

Metadata is never fetched over the network in the request path; only persisted state is read.

Because a URL is unique only together with its hash, the batch can return two rows sharing a URL under different hashes (metadata republished at the same URL). Callers match each row against their own `(url, hash)` anchor rather than assuming one row per URL.

## Unavailable inputs error rather than defaulting

`live_saturation` needs `nOpt` from `CurrentProtocolParams()`, which only succeeds once `LedgerState.Start()` has loaded protocol parameters. It is a required, non-nullable number with no schema-compatible way to express "unknown", so the request errors instead of emitting a `0.0` that a client cannot distinguish from a genuinely unsaturated pool. Pinned by `TestNodeAdapterPoolsExtendedProtocolParamsUnavailable`.

`metadata` is genuinely nullable in the schema, so `null` is correct when a pool has no registered anchor. That is a real absence rather than a stand-in for an unavailable value.

## Known limitation

`blocks_minted` undercounts on a Mithril-bootstrapped node: `pool_opcert_sequence` is written only by the live block-apply path, so pre-snapshot history is permanently absent rather than merely delayed. `DATABASE.md`'s existing note for pool detail is extended to cover `/pools/extended`, which reads the same table the same way.

## Tests

New coverage for response shape, pagination and order, metadata success, absence and failure, and database errors.

`TestHandlePoolsExtended` is a pre-existing test and was rewritten in place with maintainer sign-off, since it constructed and asserted the removed `VrfKey` and `Relays` fields. It now asserts `blocks_minted`, `live_saturation` and a fully populated `metadata` object, a second pool covers `metadata: null`, and a raw-JSON assertion confirms `vrf_key` and `relays` are absent from the wire format, which the typed struct can no longer express.

The adapter test derives its expected saturation threshold from the devnet genesis `MaxLovelaceSupply` and the actually-persisted `Reserves`, so it cannot pass by restating the implementation.

## Verification

`go build ./...` and `go build -tags dingo_extra_plugins ./...`, `go test ./api/blockfrost/... ./database/... ./ledger/...` with zero failures, `golangci-lint run` at 0 issues, `nilaway`, `modernize`, `make import-boundaries`, `go test -race ./api/blockfrost/...` with no data races, and `go test ./internal/test/conformance/...` all pass.

## Documentation

`DATABASE.md` gains a `GetOffchainMetadataBatch` section covering the query, index, chunking and the cross-hash-match behavior, plus the extended Mithril caveat. `ARCHITECTURE.md` documents the two batched per-page queries, the `live_saturation` protocol-parameters requirement, and that the metadata classification logic is intentionally duplicated rather than shared with `PoolMetadata`.

## One note for review

Adding a second caller of `offchainFetchError` triggered `unparam`, because every caller passes `"Pool"`. The parameter is kept with a documented exemption rather than hardcoded: `models.OffchainMetadataSource*` defines seven other sources (drep, drep_registration, drep_update, gov_proposal, gov_vote, constitution, committee_resign) that share this cache and this error classification and differ only by that label. Happy to hardcode it instead if you would rather not carry the exemption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated `/pools/extended` to match the latest API schema.
  * Added blocks minted, live saturation, and structured off-chain pool metadata.
  * Added clear metadata error details when off-chain information is unavailable.

* **Changes**
  * Removed relay and VRF key fields from extended pool responses.
  * Improved metadata retrieval efficiency through batched lookups.
  * Requests now fail clearly when required protocol parameters are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->