### PR TITLE
feat(blockfrost): add pools list endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2505,7 +2505,10 @@ the ORDER BY is itself a per-pool ranking computed over the whole
 registration/retirement history, so the entire active set must be ranked
 before any page boundary exists, and a SQL-side LIMIT would only trim rows
 after that ranking work, not reduce it. See DATABASE.md for the query's index
-usage.
+usage per backend (verified with real Postgres 16 and MySQL 8.4 containers at
+mainnet-comparable scale, not assumed from sqlite) and for the cross-backend
+behavioral tests confirming sqlite, postgres, and mysql return the identical
+oldest-first sequence against the same fixture.
 
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2403,8 +2403,8 @@ fields protect every API listener.
 
 A Blockfrost-compatible REST API that provides read access to chain data and
 transaction submission. The current router includes health/root, blocks,
-epochs/parameters, network/eras, genesis, assets, pools/extended, retiring
-pools, pool detail, pool metadata, governance DRep list and lookup, address
+epochs/parameters, network/eras, genesis, assets, pools list, pools/extended,
+retiring pools, pool detail, pool metadata, governance DRep list and lookup, address
 summary, address UTxOs and transactions, metadata label JSON/CBOR,
 transaction content/CBOR/metadata/UTxOs/certificates/redeemers/required
 signers, and account/delegation/registration/reward/UTxOs/withdrawals/
@@ -2488,6 +2488,24 @@ be loaded (`LedgerState.Start()` having completed): a required, non-nullable
 schema field cannot fall back to a placeholder value, so the request fails
 outright rather than serving a fabricated 0.0 when they are not yet
 available.
+
+`GET /pools` (pool_list) returns bare bech32 pool IDs for the same active-pool
+set `/pools/extended` reads, but ordered rather than left in incidental row
+order: `GetActivePoolKeyHashesOrdered` (shared across the sqlite/postgres/mysql
+backends via `poolorder`, mirroring the `poolcerthistory` pattern) sorts
+oldest-first by each pool's EARLIEST registration certificate
+(added_slot/block_index/cert_index ascending, pool_key_hash as a final
+deterministic tie-break), not its most recent parameter update -- a pool that
+re-registers to change its margin keeps its original list position rather than
+jumping to the end. `desc` is the in-memory reverse of the same ordered slice,
+so the two are exact reverses by construction. Pagination is applied in
+memory over the full active-pool result (matching `/pools/retiring`'s
+`GetRetiringPools`/`PoolsRetiring` split), not pushed into SQL LIMIT/OFFSET:
+the ORDER BY is itself a per-pool ranking computed over the whole
+registration/retirement history, so the entire active set must be ranked
+before any page boundary exists, and a SQL-side LIMIT would only trim rows
+after that ranking work, not reduce it. See DATABASE.md for the query's index
+usage.
 
 `GET /assets/{asset}` derives its mint-history fields from the API-mode
 `asset_mint_burn` table, which the transaction indexer populates from

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1943,6 +1943,87 @@ slot. Such rows have no `certs`/`transaction` join, so without the
 tie-break to a registration, incorrectly keeping the pool active for stake
 snapshots and reward inputs.
 
+### `GetActivePoolKeyHashesOrdered`
+
+Backs the Blockfrost `GET /pools` (`pool_list`) endpoint: the same active-pool
+set as `GetActivePoolKeyHashes`/`GetActivePoolKeyHashesAtSlot` (registration
+with `added_slot <= tip`, no retirement or the retirement is cancelled by a
+later registration or targets a not-yet-started epoch), but with an explicit,
+deterministic order instead of `GetActivePoolKeyHashesAtSlot`'s incidental row
+order (no terminal `ORDER BY`, so its result order is not a documented
+contract). "Oldest first, newest last" (the OpenAPI schema's wording) is keyed
+on each pool's EARLIEST registration certificate, not its most recent one: a
+pool that later re-registers to update its margin or relays keeps its
+original list position rather than jumping to the end. The query, shared
+verbatim across the sqlite/postgres/mysql backends
+(`database/plugin/metadata/internal/poolorder`, mirroring the
+`poolcerthistory` sharing pattern above), computes both the latest-registration
+ranking (needed for the active/retired determination) and the
+earliest-registration ranking (needed for the sort key) as two `ROW_NUMBER()`
+columns over one CTE scan of `pool_registration` joined to `certs`/
+`transaction`, rather than scanning that join twice:
+
+```sql
+WITH reg_ranked AS (
+  SELECT pr.pool_id, pr.added_slot,
+    COALESCE(t.block_index, 0) AS blk_idx,
+    COALESCE(c.cert_index, 0) AS cert_idx,
+    ROW_NUMBER() OVER (
+      PARTITION BY pr.pool_id
+      ORDER BY pr.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+    ) AS rn_latest,
+    ROW_NUMBER() OVER (
+      PARTITION BY pr.pool_id
+      ORDER BY pr.added_slot ASC, COALESCE(t.block_index, 0) ASC, COALESCE(c.cert_index, 0) ASC
+    ) AS rn_first
+  FROM pool_registration pr
+  LEFT JOIN certs c ON c.id = pr.certificate_id
+  LEFT JOIN "transaction" t ON t.id = c.transaction_id
+  WHERE pr.added_slot <= $1
+),
+latest_ret AS ( -- same shape as GetActivePoolKeyHashesAtSlot's latest_ret
+  ...
+)
+SELECT p.pool_key_hash
+FROM pool p
+INNER JOIN reg_ranked lr ON lr.pool_id = p.id AND lr.rn_latest = 1
+INNER JOIN reg_ranked fr ON fr.pool_id = p.id AND fr.rn_first = 1
+LEFT JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+WHERE lrt.pool_id IS NULL
+  OR lrt.added_slot < lr.added_slot
+  OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx < lr.blk_idx)
+  OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+  OR lrt.epoch > $2
+ORDER BY fr.added_slot ASC, fr.blk_idx ASC, fr.cert_idx ASC, p.pool_key_hash ASC;
+```
+
+A final `p.pool_key_hash ASC` tie-break makes the order fully deterministic
+even when two rows collapse to the same `(added_slot, block_index,
+cert_index)` key, e.g. registrations with no linked certificate/transaction
+(both default to 0 via `COALESCE`).
+
+Query cost (verified with `EXPLAIN QUERY PLAN` on sqlite): the `reg_ranked`
+CTE does `SCAN pr USING INDEX idx_pool_reg_pool_slot` -- a full scan of that
+index, since its leading column is `pool_id` rather than `added_slot`, so the
+`added_slot <= ?` filter cannot narrow the index range and is evaluated
+row-by-row. This is bounded by the total historical `pool_registration` row
+count, not just the active-pool count, but it is the same cost `/pools/extended`
+already pays via `GetActivePoolKeyHashesAtSlot`, which has the identical
+`WHERE pr.added_slot <= ?` filter over the same table and index; this query
+adds one extra `ROW_NUMBER()` column computed over the same already-scanned
+rows, not a second scan. `latest_ret` fares better: `SEARCH rt USING INDEX
+idx_pool_retirement_added_slot (added_slot<?)`, a genuine range search. The
+final join/sort touches one row per active pool (`SEARCH p USING INTEGER
+PRIMARY KEY`, `SEARCH fr/lrt USING AUTOMATIC PARTIAL COVERING INDEX`).
+Because the sort key is a per-pool ranking computed across the whole
+registration/retirement history, the entire active set must be ranked before
+any page boundary can be determined; the Blockfrost adapter (`PoolsList`,
+`api/blockfrost/adapter_pools_list.go`) therefore fetches every active pool's
+key hash in this one query and applies `count`/`page`/`order` in memory
+(reversing the slice for `desc`), matching `GetRetiringPools`/`PoolsRetiring`'s
+existing split below rather than pushing `LIMIT`/`OFFSET` into SQL, which
+would only trim rows after the ranking work, not reduce it.
+
 ### `GetPoolsRetiringAtEpoch`
 
 Pools whose effective retirement takes effect at a given epoch, with the reward

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1954,7 +1954,23 @@ order (no terminal `ORDER BY`, so its result order is not a documented
 contract). "Oldest first, newest last" (the OpenAPI schema's wording) is keyed
 on each pool's EARLIEST registration certificate, not its most recent one: a
 pool that later re-registers to update its margin or relays keeps its
-original list position rather than jumping to the end. The query, shared
+original list position rather than jumping to the end. This is a deliberate
+semantic choice, not one pinned by the schema itself -- the schema only says
+"oldest first" without defining "oldest" -- so a future change that keys the
+sort on the LATEST registration instead would be a silent behavior reversal,
+not a bug fix; if that is ever revisited, update this paragraph, the
+`poolorder.GetActivePoolKeyHashesOrdered` doc comment, and
+`PoolsList`'s doc comment (`api/blockfrost/adapter_pools_list.go`) together.
+Verified identical across backends: `TestNodeAdapterPoolsListOrderingAndActiveSet`
+(sqlite, via the Blockfrost adapter) and its direct-store counterparts
+`TestGetActivePoolKeyHashesOrderedPostgres`/`TestGetActivePoolKeyHashesOrderedMysql`
+(`database/plugin/metadata/{postgres,mysql}/pool_active_ordered_test.go`, run
+against real Postgres 16 / MySQL 8.4 containers) seed the same 8-pool fixture
+-- a re-registration, a retirement cancelled by a later re-registration, a
+same-slot three-way tie broken by `block_index`/`cert_index`, a pending
+future retirement, and an already-effective retirement that must be excluded
+-- and assert the exact same expected oldest-first sequence on all three
+backends, not independently-relaxed per-backend expectations. The query, shared
 verbatim across the sqlite/postgres/mysql backends
 (`database/plugin/metadata/internal/poolorder`, mirroring the
 `poolcerthistory` sharing pattern above), computes both the latest-registration
@@ -2002,19 +2018,33 @@ even when two rows collapse to the same `(added_slot, block_index,
 cert_index)` key, e.g. registrations with no linked certificate/transaction
 (both default to 0 via `COALESCE`).
 
-Query cost (verified with `EXPLAIN QUERY PLAN` on sqlite): the `reg_ranked`
-CTE does `SCAN pr USING INDEX idx_pool_reg_pool_slot` -- a full scan of that
-index, since its leading column is `pool_id` rather than `added_slot`, so the
-`added_slot <= ?` filter cannot narrow the index range and is evaluated
-row-by-row. This is bounded by the total historical `pool_registration` row
-count, not just the active-pool count, but it is the same cost `/pools/extended`
-already pays via `GetActivePoolKeyHashesAtSlot`, which has the identical
-`WHERE pr.added_slot <= ?` filter over the same table and index; this query
-adds one extra `ROW_NUMBER()` column computed over the same already-scanned
-rows, not a second scan. `latest_ret` fares better: `SEARCH rt USING INDEX
-idx_pool_retirement_added_slot (added_slot<?)`, a genuine range search. The
-final join/sort touches one row per active pool (`SEARCH p USING INTEGER
-PRIMARY KEY`, `SEARCH fr/lrt USING AUTOMATIC PARTIAL COVERING INDEX`).
+Query cost was verified per backend, not assumed to generalize from one:
+`EXPLAIN QUERY PLAN` on sqlite, `EXPLAIN` on a real Postgres 16 container, and
+`EXPLAIN FORMAT=TREE` on a real MySQL 8.4 container, the latter two populated
+with ~8,000 pools / ~10,000 historical registrations (including ~2,000
+re-registrations, to exercise the `rn_latest`/`rn_first` split at scale) /
+~500 retirements -- large enough that a backend-specific plan flip would show
+up, rather than the toy row counts a unit test would otherwise use. All three
+agree on the shape: the `reg_ranked` CTE does a full scan of `pool_registration`
+(sqlite: `SCAN pr USING INDEX idx_pool_reg_pool_slot`, a full index scan since
+its leading column is `pool_id` rather than `added_slot`, so `added_slot <= ?`
+can't narrow the index range; Postgres: `Seq Scan on pool_registration ...
+Filter: (added_slot <= ...)`; MySQL: `Table scan on pr ... Filter: (pr.added_slot
+<= ...)`) -- bounded by the total historical `pool_registration` row count, not
+just the active-pool count, on every backend. This is the same cost
+`/pools/extended` already pays via `GetActivePoolKeyHashesAtSlot`, which has
+the identical `WHERE pr.added_slot <= ?` filter over the same table; this
+query adds one extra `ROW_NUMBER()` column computed over the same
+already-scanned rows, not a second scan. `pool_retirement` fares better on
+sqlite at small scale (`SEARCH rt USING INDEX idx_pool_retirement_added_slot
+(added_slot<?)`, a genuine range search) but all three backends fell back to
+a full scan of `pool_retirement` at the populated scale above, since the
+`added_slot <= ?` filter matched nearly every row (Postgres and sqlite's
+planners both prefer a full scan over an index scan once the filter is not
+selective; this is normal cost-based planning, not a regression). No backend
+was materially worse than the others for this query, unlike a prior branch in
+this campaign where a SQLite-verified plan did not hold on MySQL. The final
+join/sort touches one row per active pool on all three backends.
 Because the sort key is a per-pool ranking computed across the whole
 registration/retirement history, the entire active set must be ranked before
 any page boundary can be determined; the Blockfrost adapter (`PoolsList`,

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -68,6 +68,7 @@ flowchart LR
 
 ## SQL Conventions
 
+- Minimum backend versions: MySQL 8.0, PostgreSQL 12, SQLite 3.25. Several queries use window functions (`ROW_NUMBER() OVER (...)`) and common table expressions (`WITH`), which are unavailable below those versions and fail at query time rather than at startup or migration. Examples across the backends include `GetActivePoolKeyHashesOrdered` (`internal/poolorder`), the live-stake ranking in `internal/rewardstate`, and per-backend queries in `account.go`, `drep.go`, `governance.go`, `pool.go`, and `poolreap.go`. CI exercises PostgreSQL 16 and MySQL 8.4, so those are the versions actually covered by tests.
 - Table and column names are snake_case GORM names unless a model has an explicit `gorm:"column:..."` tag.
 - Byte columns store raw bytes, not hex strings. In Postgres use `encode(col, 'hex')` and `decode($1, 'hex')`. In MySQL use `HEX(col)` and `UNHEX(?)`.
 - `types.Uint64` values such as `amount`, `reward`, `pledge`, `cost`, treasury/reserves, and stake totals are persisted as unsigned decimal values through the Go SQL driver. Use numeric casts if your SQL client reports them as text in a specific backend.

--- a/api/blockfrost/adapter_pools_list.go
+++ b/api/blockfrost/adapter_pools_list.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"fmt"
+	"slices"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// PoolsList returns the paginated list of currently registered
+// (active, non-retired) stake pool IDs, along with the total number of
+// matching results before pagination.
+//
+// Ordering: the store query (GetActivePoolKeyHashesOrdered) returns every
+// active pool key hash already sorted oldest-first by each pool's first
+// on-chain registration certificate, which is the chain-derived order the
+// pool_list schema's "oldest first, newest last" wording calls for (see
+// poolorder.GetActivePoolKeyHashesOrdered's doc comment for the full
+// rationale). asc uses that order as-is; desc reverses the same slice, so
+// the two are exact reverses of each other by construction rather than by
+// two independently-sorted queries agreeing.
+//
+// Query cost: this issues exactly one query returning one row per active
+// pool (~3,000 on mainnet), the same result-set shape PoolsExtended
+// already reads via GetActivePoolKeyHashes/GetActivePoolKeyHashesAtSlot;
+// no per-page query is added. Pagination is then applied in memory
+// (slice), matching PoolsRetiring (GetRetiringPools + PoolsRetiring)
+// rather than pushing LIMIT/OFFSET into SQL: the ORDER BY here is derived
+// from a per-pool window-function ranking computed across the full
+// registration/retirement history, so the whole active set must be
+// ranked before any page boundary can be determined -- a SQL-side
+// LIMIT/OFFSET would trim rows only after that ranking work is done, and
+// would not reduce it. The response is bare pool ID strings, so slicing
+// the resulting hash slice in memory before conversion is cheap relative
+// to that query.
+func (a *NodeAdapter) PoolsList(
+	params PaginationParams,
+) ([]string, int, error) {
+	db := a.ledgerState.Database()
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	poolKeyHashes, err := db.Metadata().GetActivePoolKeyHashesOrdered(
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get active pool key hashes ordered: %w",
+			err,
+		)
+	}
+
+	if params.Order == PaginationOrderDesc {
+		slices.Reverse(poolKeyHashes)
+	}
+	total := len(poolKeyHashes)
+
+	start := (params.Page - 1) * params.Count
+	if start >= total {
+		return []string{}, total, nil
+	}
+	end := min(start+params.Count, total)
+
+	ret := make([]string, 0, end-start)
+	for _, pkh := range poolKeyHashes[start:end] {
+		poolID := lcommon.PoolId(lcommon.NewBlake2b224(pkh))
+		ret = append(ret, poolID.String())
+	}
+	return ret, total, nil
+}

--- a/api/blockfrost/adapter_pools_list.go
+++ b/api/blockfrost/adapter_pools_list.go
@@ -26,23 +26,34 @@ import (
 // matching results before pagination.
 //
 // Ordering: the store query (GetActivePoolKeyHashesOrdered) returns every
-// active pool key hash already sorted oldest-first by each pool's first
-// on-chain registration certificate, which is the chain-derived order the
-// pool_list schema's "oldest first, newest last" wording calls for (see
-// poolorder.GetActivePoolKeyHashesOrdered's doc comment for the full
-// rationale). asc uses that order as-is; desc reverses the same slice, so
-// the two are exact reverses of each other by construction rather than by
-// two independently-sorted queries agreeing.
+// active pool key hash already sorted oldest-first by each pool's FIRST
+// on-chain registration certificate -- not its most recent one -- which is
+// the chain-derived order the pool_list schema's "oldest first, newest
+// last" wording calls for (see poolorder.GetActivePoolKeyHashesOrdered's
+// doc comment for the full rationale, including why this is a deliberate,
+// reversible semantic choice rather than one the schema pins). asc uses
+// that order as-is; desc reverses the same slice, so the two are exact
+// reverses of each other by construction rather than by two
+// independently-sorted queries agreeing. This ordering and the
+// active/retired determination are verified identical across sqlite,
+// postgres, and mysql against the same 8-pool fixture: see
+// TestNodeAdapterPoolsListOrderingAndActiveSet (pools_list_test.go) and its
+// direct-store postgres/mysql counterparts
+// (database/plugin/metadata/{postgres,mysql}/pool_active_ordered_test.go).
 //
-// Query cost: this issues exactly one query returning one row per active
-// pool (~3,000 on mainnet), the same result-set shape PoolsExtended
-// already reads via GetActivePoolKeyHashes/GetActivePoolKeyHashesAtSlot;
-// no per-page query is added. Pagination is then applied in memory
-// (slice), matching PoolsRetiring (GetRetiringPools + PoolsRetiring)
-// rather than pushing LIMIT/OFFSET into SQL: the ORDER BY here is derived
-// from a per-pool window-function ranking computed across the full
-// registration/retirement history, so the whole active set must be
-// ranked before any page boundary can be determined -- a SQL-side
+// Query cost: the result is one row per active pool (~3,000 on mainnet),
+// the same result-set shape PoolsExtended already reads via
+// GetActivePoolKeyHashes/GetActivePoolKeyHashesAtSlot; no per-page query is
+// added. The underlying scan cost is bounded by the total historical
+// pool_registration row count instead (verified via EXPLAIN on all three
+// backends, see DATABASE.md), since the added_slot filter can't use the
+// (pool_id, added_slot) index on any backend -- the same bound
+// GetActivePoolKeyHashesAtSlot already pays for PoolsExtended. Pagination
+// is applied in memory (slice), matching PoolsRetiring (GetRetiringPools +
+// PoolsRetiring) rather than pushing LIMIT/OFFSET into SQL: the ORDER BY
+// here is derived from a per-pool window-function ranking computed across
+// the full registration/retirement history, so the whole active set must
+// be ranked before any page boundary can be determined -- a SQL-side
 // LIMIT/OFFSET would trim rows only after that ranking work is done, and
 // would not reduce it. The response is bare pool ID strings, so slicing
 // the resulting hash slice in memory before conversion is cheap relative

--- a/api/blockfrost/adapter_pools_list.go
+++ b/api/blockfrost/adapter_pools_list.go
@@ -65,9 +65,7 @@ func (a *NodeAdapter) PoolsList(
 	txn := db.Transaction(false)
 	defer txn.Release()
 
-	poolKeyHashes, err := db.Metadata().GetActivePoolKeyHashesOrdered(
-		txn.Metadata(),
-	)
+	poolKeyHashes, err := db.GetActivePoolKeyHashesOrdered(txn)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get active pool key hashes ordered: %w",

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -113,6 +113,10 @@ func (b *Blockfrost) handler() http.Handler {
 		b.handleAssetAddresses,
 	)
 	mux.HandleFunc(
+		"GET /api/v0/pools",
+		b.handlePoolsList,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/pools/extended",
 		b.handlePoolsExtended,
 	)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -67,6 +67,9 @@ type mockNode struct {
 	networkEras                   []NetworkEraInfo
 	genesis                       GenesisInfo
 	pools                         []PoolExtendedInfo
+	poolsList                     []string
+	poolsListTotal                int
+	poolsListParams               PaginationParams
 	poolsRetiring                 []PoolRetiringInfo
 	poolsRetiringTotal            int
 	poolMetadata                  PoolMetadataInfo
@@ -126,6 +129,7 @@ type mockNode struct {
 	networkErasErr                error
 	genesisErr                    error
 	poolsErr                      error
+	poolsListErr                  error
 	poolsRetiringErr              error
 	poolMetadataErr               error
 	assetErr                      error
@@ -225,6 +229,13 @@ func (m *mockNode) PoolsExtended() (
 	[]PoolExtendedInfo, error,
 ) {
 	return m.pools, m.poolsErr
+}
+
+func (m *mockNode) PoolsList(
+	params PaginationParams,
+) ([]string, int, error) {
+	m.poolsListParams = params
+	return m.poolsList, m.poolsListTotal, m.poolsListErr
 }
 
 func (m *mockNode) PoolsRetiring(

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -654,10 +654,12 @@ func TestRouterUnimplementedRouteReturns404(t *testing.T) {
 	b := newTestBlockfrost(mock)
 	handler := b.handler()
 
+	// "/api/v0/pools" used to belong here as an unimplemented route. It is
+	// now registered (dingo #3011), so it no longer falls through to the
+	// catch-all. The remaining entries still cover that path.
 	paths := []string{
 		"/api/v0/",
 		"/api/v0/scripts",
-		"/api/v0/pools",
 		"/does-not-exist",
 	}
 	for _, path := range paths {

--- a/api/blockfrost/handlers_pools_list.go
+++ b/api/blockfrost/handlers_pools_list.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import "net/http"
+
+// handlePoolsList handles GET /api/v0/pools and returns the paginated
+// list of registered stake pool IDs (pool_list): a flat array of bech32
+// pool ID strings, nothing more. See PoolsList for the ordering and
+// query-cost rationale.
+func (b *Blockfrost) handlePoolsList(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	params, errMsg := ParsePaginationStrict(r)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, "Bad Request", errMsg)
+		return
+	}
+
+	pools, total, err := b.node.PoolsList(params)
+	if err != nil {
+		b.logger.Error(
+			"failed to list pools",
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to retrieve pools",
+		)
+		return
+	}
+
+	SetPaginationHeaders(w, total, params)
+	writeJSON(w, http.StatusOK, pools)
+}

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -61,6 +61,11 @@ type BlockfrostNode interface {
 	// extended details.
 	PoolsExtended() ([]PoolExtendedInfo, error)
 
+	// PoolsList returns the paginated list of registered (active,
+	// non-retired) stake pool IDs, along with the total number of
+	// matching results before pagination.
+	PoolsList(PaginationParams) ([]string, int, error)
+
 	// Address returns summary information for an address,
 	// including balances aggregated across its live UTxOs.
 	Address(address string) (AddressInfo, error)

--- a/api/blockfrost/pools_list_test.go
+++ b/api/blockfrost/pools_list_test.go
@@ -1,0 +1,596 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	sqliteplugin "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------
+// Handler tests (mockNode)
+// ---------------------------------------------------------------------
+
+// TestHandlePoolsList covers the basic response shape: a flat JSON array
+// of bech32 pool ID strings (pool_list), plus the X-Pagination-* headers.
+func TestHandlePoolsList(t *testing.T) {
+	mock := &mockNode{
+		poolsList: []string{
+			"pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy",
+			"pool1hn7hlwrschqykupwwrtdfkvt2u4uaxvsgxyh6z63703p2knj288",
+		},
+		poolsListTotal: 2,
+	}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools", nil)
+	w := httptest.NewRecorder()
+	b.handlePoolsList(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "2", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "1", w.Header().Get("X-Pagination-Page-Total"))
+
+	var resp []string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, mock.poolsList, resp)
+
+	// Default pagination: count=100, page=1, order=asc.
+	assert.Equal(t, DefaultPaginationCount, mock.poolsListParams.Count)
+	assert.Equal(t, DefaultPaginationPage, mock.poolsListParams.Page)
+	assert.Equal(t, PaginationOrderAsc, mock.poolsListParams.Order)
+}
+
+// TestHandlePoolsListPaginationParams verifies count/page/order query
+// parameters reach PoolsList unchanged.
+func TestHandlePoolsListPaginationParams(t *testing.T) {
+	mock := &mockNode{}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools?count=5&page=3&order=desc", nil,
+	)
+	w := httptest.NewRecorder()
+	b.handlePoolsList(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 5, mock.poolsListParams.Count)
+	assert.Equal(t, 3, mock.poolsListParams.Page)
+	assert.Equal(t, PaginationOrderDesc, mock.poolsListParams.Order)
+}
+
+// TestHandlePoolsListInvalidPagination covers Blockfrost-exact fastify
+// validation error messages (ParsePaginationStrict), matching the sibling
+// /pools/retiring handler's pagination behavior.
+func TestHandlePoolsListInvalidPagination(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{})
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools?order=sideways", nil,
+	)
+	w := httptest.NewRecorder()
+	b.handlePoolsList(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(
+		t,
+		"querystring/order must be equal to one of the allowed values",
+		resp.Message,
+	)
+}
+
+// TestHandlePoolsListInvalidCount covers the count-out-of-range case
+// specifically, since it exercises a different ParsePaginationStrict
+// branch than order.
+func TestHandlePoolsListInvalidCount(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools?count=101", nil)
+	w := httptest.NewRecorder()
+	b.handlePoolsList(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "querystring/count must be <= 100", resp.Message)
+}
+
+// TestHandlePoolsListEmpty covers the no-active-pools case: the response
+// must be an empty JSON array, not null, with zeroed pagination headers.
+func TestHandlePoolsListEmpty(t *testing.T) {
+	mock := &mockNode{poolsList: []string{}, poolsListTotal: 0}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools", nil)
+	w := httptest.NewRecorder()
+	b.handlePoolsList(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "0", w.Header().Get("X-Pagination-Count-Total"))
+	assert.Equal(t, "0", w.Header().Get("X-Pagination-Page-Total"))
+	assert.Equal(t, "[]\n", w.Body.String())
+}
+
+// TestHandlePoolsListDatabaseFailure covers a backing-store failure: it
+// must surface as a generic 500, not be silently swallowed.
+func TestHandlePoolsListDatabaseFailure(t *testing.T) {
+	mock := &mockNode{poolsListErr: errors.New("database is closed")}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools", nil)
+	w := httptest.NewRecorder()
+	b.handlePoolsList(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "failed to retrieve pools", resp.Message)
+}
+
+// TestPoolsListRouteDoesNotSwallowSiblings is the acceptance test for
+// route registration required by #3011: "GET /api/v0/pools" must resolve
+// to handlePoolsList, and every other pools route --
+// "/pools/extended", "/pools/retiring", "/pools/{pool_id}/metadata", and
+// "/pools/{pool_id}" -- must still resolve to its own handler rather than
+// being captured by the bare "/pools" route or the "/pools/{pool_id}"
+// wildcard. This exercises the real http.ServeMux built by
+// (*Blockfrost).handler(), not a direct method call, so it verifies Go's
+// actual pattern-specificity resolution rather than assuming it (Go 1.22+
+// ServeMux prefers the most specific literal match). This is additive to
+// TestPoolsRouteOrderingPoolDetailDoesNotSwallowSiblings
+// (pool_detail_test.go), which predates the "/pools" route and is left
+// unmodified.
+func TestPoolsListRouteDoesNotSwallowSiblings(t *testing.T) {
+	metadataURL := "https://example.com/pool.json"
+	mock := &mockNode{
+		poolsListTotal:     1,
+		poolsList:          []string{"pool1list"},
+		poolsRetiringTotal: 1,
+		poolsRetiring: []PoolRetiringInfo{
+			{PoolID: "pool1retiring", Epoch: 10},
+		},
+		pools: []PoolExtendedInfo{
+			{PoolID: "pool1extended"},
+		},
+		poolDetail: PoolDetailInfo{PoolID: "pool1detail"},
+		poolMetadata: PoolMetadataInfo{
+			PoolID: "pool1metadata",
+			// A non-nil URL is required for handlePoolMetadata to return
+			// the full PoolMetadataResponse; a nil URL (no registered
+			// anchor) instead answers with an empty JSON object, which
+			// would make this route-precedence check indistinguishable
+			// from a routing bug.
+			URL: &metadataURL,
+		},
+	}
+	b := newTestBlockfrost(mock)
+	handler := b.handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var listResp []string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&listResp))
+	require.Equal(t, []string{"pool1list"}, listResp)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v0/pools/extended", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var extendedResp []PoolExtendedResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&extendedResp))
+	require.Len(t, extendedResp, 1)
+	assert.Equal(t, "pool1extended", extendedResp[0].PoolID)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v0/pools/retiring", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var retiringResp []PoolRetiringResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&retiringResp))
+	require.Len(t, retiringResp, 1)
+	assert.Equal(t, "pool1retiring", retiringResp[0].PoolID)
+
+	req = httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/pool1notretiringnorextended/metadata", nil,
+	)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var metadataResp PoolMetadataResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&metadataResp))
+	assert.Equal(t, "pool1metadata", metadataResp.PoolID)
+
+	req = httptest.NewRequest(
+		http.MethodGet, "/api/v0/pools/pool1notretiringnorextended", nil,
+	)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var detailResp PoolDetailResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&detailResp))
+	assert.Equal(t, "pool1detail", detailResp.PoolID)
+}
+
+// ---------------------------------------------------------------------
+// Adapter tests (real sqlite-backed NodeAdapter)
+// ---------------------------------------------------------------------
+
+// ensurePoolsListChainTip writes the tip and epoch rows
+// GetActivePoolKeyHashesOrdered needs to resolve "active as of the
+// current tip". Slot 1000 / epoch length 2000 gives headroom for the
+// added_slot values used by the ordering tests below (up to slot 500).
+func ensurePoolsListChainTip(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().
+		Where("id = ?", 1).
+		Attrs(models.Tip{Slot: 1000}).
+		FirstOrCreate(&models.Tip{ID: 1}).Error)
+	require.NoError(t, store.DB().
+		Where("epoch_id = ?", 0).
+		Attrs(models.Epoch{StartSlot: 0, LengthInSlots: 2000}).
+		FirstOrCreate(&models.Epoch{EpochId: 0}).Error)
+}
+
+// seedPoolListPool creates a bare pool row and returns its surrogate ID
+// (needed to attach PoolRegistration/PoolRetirement rows by PoolID).
+func seedPoolListPool(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	poolKeyHash []byte,
+) uint {
+	t.Helper()
+	pool := &models.Pool{PoolKeyHash: poolKeyHash}
+	require.NoError(t, store.DB().Create(pool).Error)
+	return pool.ID
+}
+
+// seedPoolListRegistration adds a registration certificate for an
+// already-created pool. certificateID is 0 for registrations that do not
+// need a real (block_index, cert_index) tie-break position (a distinct
+// added_slot alone is enough to order them), matching seedExtendedPool's
+// use of AddedSlot alone elsewhere in this package.
+func seedPoolListRegistration(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	poolID uint,
+	poolKeyHash []byte,
+	addedSlot uint64,
+	certificateID uint,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.PoolRegistration{
+		PoolID:        poolID,
+		PoolKeyHash:   poolKeyHash,
+		AddedSlot:     addedSlot,
+		CertificateID: certificateID,
+	}).Error)
+}
+
+// seedPoolListRetirement adds a retirement certificate for an
+// already-created pool.
+func seedPoolListRetirement(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	poolID uint,
+	poolKeyHash []byte,
+	addedSlot uint64,
+	epoch uint64,
+) {
+	t.Helper()
+	require.NoError(t, store.DB().Create(&models.PoolRetirement{
+		PoolID:      poolID,
+		PoolKeyHash: poolKeyHash,
+		AddedSlot:   addedSlot,
+		Epoch:       epoch,
+	}).Error)
+}
+
+// seedPoolListCert creates a transaction plus one certificate row so a
+// registration's on-chain position can be pinned to a specific
+// (block_index, cert_index), for the same-slot tie-break tests. txID and
+// certID must be unique across the whole test (they are primary keys).
+func seedPoolListCert(
+	t *testing.T,
+	store *sqliteplugin.MetadataStoreSqlite,
+	txID uint,
+	certID uint,
+	slot uint64,
+	blockIndex uint32,
+	certIndex uint,
+) uint {
+	t.Helper()
+	// Transaction.Hash has a uniqueIndex; txID is small and unique per
+	// call, so it doubles as a distinct fill byte.
+	hash := fill32(byte(txID))
+	var existing models.Transaction
+	err := store.DB().Where("id = ?", txID).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		require.NoError(t, store.DB().Create(&models.Transaction{
+			ID:         txID,
+			Slot:       slot,
+			BlockIndex: blockIndex,
+			Hash:       hash,
+		}).Error)
+	} else {
+		require.NoError(t, err)
+	}
+	require.NoError(t, store.DB().Create(&models.Certificate{
+		ID:            certID,
+		TransactionID: txID,
+		Slot:          slot,
+		CertIndex:     certIndex,
+	}).Error)
+	return certID
+}
+
+func poolListBech32(t *testing.T, poolKeyHash []byte) string {
+	t.Helper()
+	return lcommon.PoolId(lcommon.NewBlake2b224(poolKeyHash)).String()
+}
+
+// TestNodeAdapterPoolsListOrderingAndActiveSet is the empirical ordering
+// test #3011 calls for: it seeds a mix of pools exercising every ordering
+// and active-set edge case in one DB, then asserts the adapter's asc
+// order matches the expected chain position exactly, desc is the exact
+// reverse of asc, and excluded (effectively retired) pools never appear.
+//
+// Cases, by expected asc position:
+//  0. reregisteredCancelled: first registered at slot 1, a retirement at
+//     slot 6/epoch 0 looks effective, but a second registration at slot
+//     400 cancels it (the pool is active because its LATEST registration
+//     postdates the retirement). Its sort position is still keyed on its
+//     FIRST registration (slot 1) -- proving ordering uses first
+//     registration, not latest.
+//  1. oldest: single registration at slot 10.
+//  2. reregisteredMargin: first registered at slot 50, then re-registers
+//     at slot 500 (simulating a margin/relay update). If ordering used
+//     the latest registration, this pool would sort last; since it uses
+//     the first, it sorts right after "oldest".
+//  3. retiredFuture: registered at slot 90, retirement at slot 91
+//     targeting epoch 5 (still in the future relative to epoch 0 at the
+//     tip) -- pending retirement, still active.
+//     4-6. Three pools registered in the same slot (100), disambiguated by
+//     block_index then cert_index: (blk0,cert0) < (blk0,cert1) <
+//     (blk1,cert0).
+//
+// retiredEffective (registered slot 5, retired slot 6/epoch 0, which has
+// already started) must not appear at all.
+func TestNodeAdapterPoolsListOrderingAndActiveSet(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+	ensurePoolsListChainTip(t, store)
+
+	reregisteredCancelledHash := fill32(0x01)[:28]
+	oldestHash := fill32(0x02)[:28]
+	reregisteredMarginHash := fill32(0x03)[:28]
+	retiredFutureHash := fill32(0x04)[:28]
+	ssBlk0Cert0Hash := fill32(0x05)[:28]
+	ssBlk0Cert1Hash := fill32(0x06)[:28]
+	ssBlk1Cert0Hash := fill32(0x07)[:28]
+	retiredEffectiveHash := fill32(0x08)[:28]
+
+	// reregisteredCancelled: slot 1 -> retirement slot 6 (epoch 0) ->
+	// re-registration slot 400 cancels it.
+	id := seedPoolListPool(t, store, reregisteredCancelledHash)
+	seedPoolListRegistration(t, store, id, reregisteredCancelledHash, 1, 0)
+	seedPoolListRetirement(t, store, id, reregisteredCancelledHash, 6, 0)
+	seedPoolListRegistration(t, store, id, reregisteredCancelledHash, 400, 0)
+
+	// oldest: slot 10.
+	id = seedPoolListPool(t, store, oldestHash)
+	seedPoolListRegistration(t, store, id, oldestHash, 10, 0)
+
+	// reregisteredMargin: slot 50, then slot 500 (later param update).
+	id = seedPoolListPool(t, store, reregisteredMarginHash)
+	seedPoolListRegistration(t, store, id, reregisteredMarginHash, 50, 0)
+	seedPoolListRegistration(t, store, id, reregisteredMarginHash, 500, 0)
+
+	// retiredFuture: slot 90, retirement slot 91 targets epoch 5 (future).
+	id = seedPoolListPool(t, store, retiredFutureHash)
+	seedPoolListRegistration(t, store, id, retiredFutureHash, 90, 0)
+	seedPoolListRetirement(t, store, id, retiredFutureHash, 91, 5)
+
+	// Same-slot trio at slot 100: tx 1 (block_index 0) carries two certs
+	// (cert_index 0 and 1); tx 2 (block_index 1) carries one cert.
+	cert1 := seedPoolListCert(t, store, 1, 1, 100, 0, 0)
+	cert2 := seedPoolListCert(t, store, 1, 2, 100, 0, 1)
+	cert3 := seedPoolListCert(t, store, 2, 3, 100, 1, 0)
+
+	id = seedPoolListPool(t, store, ssBlk0Cert0Hash)
+	seedPoolListRegistration(t, store, id, ssBlk0Cert0Hash, 100, cert1)
+	id = seedPoolListPool(t, store, ssBlk0Cert1Hash)
+	seedPoolListRegistration(t, store, id, ssBlk0Cert1Hash, 100, cert2)
+	id = seedPoolListPool(t, store, ssBlk1Cert0Hash)
+	seedPoolListRegistration(t, store, id, ssBlk1Cert0Hash, 100, cert3)
+
+	// retiredEffective: slot 5, retired at slot 6/epoch 0 -- epoch 0 has
+	// already started at the tip's epoch (0), so this pool is excluded.
+	id = seedPoolListPool(t, store, retiredEffectiveHash)
+	seedPoolListRegistration(t, store, id, retiredEffectiveHash, 5, 0)
+	seedPoolListRetirement(t, store, id, retiredEffectiveHash, 6, 0)
+
+	wantAsc := []string{
+		poolListBech32(t, reregisteredCancelledHash),
+		poolListBech32(t, oldestHash),
+		poolListBech32(t, reregisteredMarginHash),
+		poolListBech32(t, retiredFutureHash),
+		poolListBech32(t, ssBlk0Cert0Hash),
+		poolListBech32(t, ssBlk0Cert1Hash),
+		poolListBech32(t, ssBlk1Cert0Hash),
+	}
+	retiredEffectiveID := poolListBech32(t, retiredEffectiveHash)
+
+	ascResult, ascTotal, err := adapter.PoolsList(PaginationParams{
+		Count: 100, Page: 1, Order: PaginationOrderAsc,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, len(wantAsc), ascTotal)
+	assert.Equal(t, wantAsc, ascResult)
+	assert.NotContains(t, ascResult, retiredEffectiveID)
+
+	descResult, descTotal, err := adapter.PoolsList(PaginationParams{
+		Count: 100, Page: 1, Order: PaginationOrderDesc,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, len(wantAsc), descTotal)
+
+	wantDesc := slices.Clone(wantAsc)
+	slices.Reverse(wantDesc)
+	assert.Equal(
+		t, wantDesc, descResult,
+		"desc must be the exact reverse of asc",
+	)
+}
+
+// TestNodeAdapterPoolsListPagination covers count/page slicing over a
+// controlled, fully ordered set of active pools.
+func TestNodeAdapterPoolsListPagination(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+	ensurePoolsListChainTip(t, store)
+
+	var hashes [][]byte
+	for i := range 5 {
+		h := fill32(byte(0x10 + i))[:28]
+		hashes = append(hashes, h)
+		id := seedPoolListPool(t, store, h)
+		seedPoolListRegistration(t, store, id, h, uint64(10*(i+1)), 0)
+	}
+
+	wantIDs := make([]string, len(hashes))
+	for i, h := range hashes {
+		wantIDs[i] = poolListBech32(t, h)
+	}
+
+	result, total, err := adapter.PoolsList(PaginationParams{
+		Count: 2, Page: 2, Order: PaginationOrderAsc,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	assert.Equal(t, wantIDs[2:4], result)
+
+	// Past the last page: empty, non-nil, total unchanged.
+	result, total, err = adapter.PoolsList(PaginationParams{
+		Count: 2, Page: 10, Order: PaginationOrderAsc,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+// TestNodeAdapterPoolsListEmpty covers the no-active-pools case: no error,
+// an empty (non-nil) slice, and a zero total.
+func TestNodeAdapterPoolsListEmpty(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	result, total, err := adapter.PoolsList(PaginationParams{
+		Count: 100, Page: 1, Order: PaginationOrderAsc,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+// TestNodeAdapterPoolsListDatabaseFailure guards against a backing-store
+// failure being silently swallowed: a broken query must surface as an
+// error, not an incomplete success response.
+func TestNodeAdapterPoolsListDatabaseFailure(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+	ensurePoolsListChainTip(t, store)
+
+	id := seedPoolListPool(t, store, fill32(0xaa)[:28])
+	seedPoolListRegistration(t, store, id, fill32(0xaa)[:28], 0, 0)
+
+	require.NoError(t, store.DB().Exec("DROP TABLE pool_registration").Error)
+
+	_, _, err := adapter.PoolsList(PaginationParams{
+		Count: 100, Page: 1, Order: PaginationOrderAsc,
+	})
+	require.Error(t, err)
+}
+
+// TestNodeAdapterPoolsListQueryPlan is the query-cost acceptance check:
+// it captures the literal SQL GetActivePoolKeyHashesOrdered issues and
+// runs EXPLAIN QUERY PLAN against it, logging the plan so the actual
+// per-request cost is visible rather than assumed. This mirrors
+// TestNodeAdapterPoolsExtendedMetadataSingleBatchedQuery's technique
+// (adapter_pools_extended_db_test.go).
+func TestNodeAdapterPoolsListQueryPlan(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+	ensurePoolsListChainTip(t, store)
+
+	id := seedPoolListPool(t, store, fill32(0xbb)[:28])
+	seedPoolListRegistration(t, store, id, fill32(0xbb)[:28], 0, 0)
+
+	var capturedSQL string
+	var capturedVars []any
+	const callbackName = "test:capture_pools_list_query"
+	// db.Raw(...).Scan(...) resolves via *gorm.DB.Rows() internally,
+	// which runs the Row callback chain ("gorm:row"), not the Query
+	// chain ("gorm:query") that Find/First use -- confirmed against
+	// gorm.io/gorm's Scan/Rows implementation, since registering on the
+	// Query chain here never observed this call.
+	require.NoError(t, store.ReadDB().Callback().Row().
+		After("gorm:row").
+		Register(callbackName, func(tx *gorm.DB) {
+			sql := tx.Statement.SQL.String()
+			if !strings.Contains(sql, "reg_ranked") {
+				return
+			}
+			if capturedSQL == "" {
+				capturedSQL = sql
+				capturedVars = append([]any(nil), tx.Statement.Vars...)
+			}
+		}))
+	t.Cleanup(func() {
+		_ = store.ReadDB().Callback().Row().Remove(callbackName)
+	})
+
+	_, _, err := adapter.PoolsList(PaginationParams{
+		Count: 100, Page: 1, Order: PaginationOrderAsc,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedSQL, "did not capture the pools-list query")
+
+	planRows, err := store.DB().
+		Raw("EXPLAIN QUERY PLAN "+capturedSQL, capturedVars...).
+		Rows()
+	require.NoError(t, err)
+	defer planRows.Close()
+
+	var details []string
+	for planRows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NotEmpty(t, details)
+	t.Logf("pools-list query: %s | vars=%v", capturedSQL, capturedVars)
+	t.Logf("EXPLAIN QUERY PLAN: %v", details)
+}

--- a/database/plugin/metadata/internal/poolorder/poolorder.go
+++ b/database/plugin/metadata/internal/poolorder/poolorder.go
@@ -50,7 +50,13 @@ import (
 // naturally as pool age (when it joined the chain), not freshness of its
 // last registration certificate. A pool that re-registers years later to
 // change its margin or relays keeps its original list position rather
-// than jumping to the end of the list.
+// than jumping to the end of the list. This is a deliberate, reversible
+// semantic choice, not one the schema pins -- it only says "oldest first"
+// without defining "oldest" -- so a future change to key the sort on the
+// LATEST registration instead would be a silent behavior reversal to
+// evaluate on its own merits, not an obvious bug fix. Verified identical
+// across sqlite, postgres, and mysql against the same fixture; see
+// DATABASE.md's GetActivePoolKeyHashesOrdered section.
 //
 // A pool is considered active at slot under the same semantics as
 // GetActivePoolKeyHashesAtSlot: it has a registration with added_slot <=

--- a/database/plugin/metadata/internal/poolorder/poolorder.go
+++ b/database/plugin/metadata/internal/poolorder/poolorder.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package poolorder centralizes the chain-ordered active-pool-key-hash
+// query shared by the sqlite, postgres, and mysql metadata store backends,
+// following the same rationale as poolcerthistory: the three backends
+// differ only in how the "transaction" table is quoted
+// (sqldialect.TransactionTableName), so keeping the query itself in one
+// place prevents that single quoting difference from drifting into three
+// independently-maintained copies.
+package poolorder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/sqldialect"
+	"github.com/blinklabs-io/dingo/database/types"
+	"gorm.io/gorm"
+)
+
+// GetActivePoolKeyHashesOrdered returns the key hashes of pools active at
+// slot, ordered oldest-first by each pool's EARLIEST registration
+// certificate (added_slot ascending, then block_index and cert_index
+// ascending to disambiguate certificates recorded in the same slot --
+// block_index orders transactions within a block, cert_index orders
+// certificates within a transaction). A final pool_key_hash tie-break
+// makes the order fully deterministic even when two rows collapse to the
+// same (added_slot, block_index, cert_index) key, e.g. registrations with
+// no linked certificate/transaction (block_index/cert_index both default
+// to 0 via COALESCE) such as those synthesized by the Mithril
+// ledger-state import.
+//
+// "Oldest first" is deliberately keyed on each pool's FIRST on-chain
+// registration, not its most recent parameter update: the Blockfrost
+// pool_list schema documents order as "the ordering of items from the
+// point of view of the blockchain... we return oldest first", which reads
+// naturally as pool age (when it joined the chain), not freshness of its
+// last registration certificate. A pool that re-registers years later to
+// change its margin or relays keeps its original list position rather
+// than jumping to the end of the list.
+//
+// A pool is considered active at slot under the same semantics as
+// GetActivePoolKeyHashesAtSlot: it has a registration with added_slot <=
+// slot, and either no retirement, or the latest retirement certificate
+// precedes the latest registration certificate (a later re-registration
+// cancels a pending retirement), or the retirement targets an epoch that
+// had not started by slot. Determining the LATEST registration (for the
+// active/retired comparison) requires a separate ranking from the
+// FIRST registration (for ordering); both rankings are computed in a
+// single reg_ranked CTE via two ROW_NUMBER window functions over the same
+// joined rows, rather than scanning pool_registration/certs/transaction
+// twice.
+//
+// Returns types.ErrNoEpochData (wrapped) if epoch data has not been
+// synced for the requested slot, mirroring GetActivePoolKeyHashesAtSlot.
+func GetActivePoolKeyHashesOrdered(
+	db *gorm.DB,
+	slot uint64,
+) ([][]byte, error) {
+	var epochAtSlot models.Epoch
+	if res := db.Where(
+		"start_slot <= ?",
+		slot,
+	).Order("start_slot DESC").First(&epochAtSlot); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf(
+				"GetActivePoolKeyHashesOrdered: %w",
+				types.ErrNoEpochData,
+			)
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: get epoch at slot: %w",
+			res.Error,
+		)
+	}
+
+	// Verify the slot falls within the epoch's duration -- see
+	// GetActivePoolKeyHashesAtSlot's identical check for the rationale
+	// (a stale epoch ID could incorrectly treat retired pools as active).
+	if slot >= epochAtSlot.StartSlot+uint64(epochAtSlot.LengthInSlots) {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: %w",
+			types.ErrNoEpochData,
+		)
+	}
+
+	transactionTable := sqldialect.TransactionTableName(db)
+
+	type poolResult struct {
+		PoolKeyHash []byte
+	}
+	var results []poolResult
+
+	query := fmt.Sprintf(`
+		WITH reg_ranked AS (
+			SELECT pr.pool_id, pr.added_slot,
+				COALESCE(t.block_index, 0) AS blk_idx,
+				COALESCE(c.cert_index, 0) AS cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY pr.pool_id
+					ORDER BY pr.added_slot DESC,
+						COALESCE(t.block_index, 0) DESC,
+						COALESCE(c.cert_index, 0) DESC
+				) AS rn_latest,
+				ROW_NUMBER() OVER (
+					PARTITION BY pr.pool_id
+					ORDER BY pr.added_slot ASC,
+						COALESCE(t.block_index, 0) ASC,
+						COALESCE(c.cert_index, 0) ASC
+				) AS rn_first
+			FROM pool_registration pr
+			LEFT JOIN certs c ON c.id = pr.certificate_id
+			LEFT JOIN %[1]s t ON t.id = c.transaction_id
+			WHERE pr.added_slot <= ?
+		),
+		latest_ret AS (
+			SELECT rt.pool_id, rt.added_slot, rt.epoch,
+				CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END AS synthetic_ret,
+				COALESCE(t.block_index, 0) AS blk_idx,
+				COALESCE(c.cert_index, 0) AS cert_idx,
+				ROW_NUMBER() OVER (
+					PARTITION BY rt.pool_id
+					ORDER BY rt.added_slot DESC,
+						CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+						COALESCE(t.block_index, 0) DESC,
+						COALESCE(c.cert_index, 0) DESC
+				) AS rn
+			FROM pool_retirement rt
+			LEFT JOIN certs c ON c.id = rt.certificate_id
+			LEFT JOIN %[1]s t ON t.id = c.transaction_id
+			WHERE rt.added_slot <= ?
+		)
+		SELECT p.pool_key_hash
+		FROM pool p
+		INNER JOIN reg_ranked lr ON lr.pool_id = p.id AND lr.rn_latest = 1
+		INNER JOIN reg_ranked fr ON fr.pool_id = p.id AND fr.rn_first = 1
+		LEFT JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+		WHERE lrt.pool_id IS NULL
+			OR lrt.added_slot < lr.added_slot
+			OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx < lr.blk_idx)
+			OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+			OR lrt.epoch > ?
+		ORDER BY fr.added_slot ASC, fr.blk_idx ASC, fr.cert_idx ASC, p.pool_key_hash ASC`,
+		transactionTable,
+	)
+
+	if err := db.Raw(query, slot, slot, epochAtSlot.EpochId).Scan(&results).Error; err != nil {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: query pools: %w",
+			err,
+		)
+	}
+
+	poolKeyHashes := make([][]byte, len(results))
+	for i, r := range results {
+		poolKeyHashes[i] = r.PoolKeyHash
+	}
+
+	return poolKeyHashes, nil
+}

--- a/database/plugin/metadata/mysql/pool.go
+++ b/database/plugin/metadata/mysql/pool.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolcerthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolorder"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1067,6 +1068,38 @@ func (d *MetadataStoreMysql) GetActivePoolKeyHashesAtSlot(
 	}
 
 	return poolKeyHashes, nil
+}
+
+// GetActivePoolKeyHashesOrdered retrieves the key hashes of all currently
+// active pools, ordered oldest-first by each pool's first on-chain
+// registration certificate. See poolorder.GetActivePoolKeyHashesOrdered for
+// the full ordering and active-pool semantics; this delegates to it using
+// the current tip's slot, mirroring GetActivePoolKeyHashes's delegation to
+// GetActivePoolKeyHashesAtSlot.
+func (d *MetadataStoreMysql) GetActivePoolKeyHashesOrdered(
+	txn types.Txn,
+) ([][]byte, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: resolve db: %w",
+			err,
+		)
+	}
+
+	// Get the current tip slot
+	var tmpTip models.Tip
+	if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: get tip: %w",
+			res.Error,
+		)
+	}
+
+	return poolorder.GetActivePoolKeyHashesOrdered(db, tmpTip.Slot)
 }
 
 // GetStakeByPool returns the total delegated stake and delegator count for a pool.

--- a/database/plugin/metadata/mysql/pool_active_ordered_test.go
+++ b/database/plugin/metadata/mysql/pool_active_ordered_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package mysql
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestGetActivePoolKeyHashesOrderedMysql is the cross-backend behavioral
+// counterpart to the sqlite ordering test
+// (sqlite/pool_active_ordered_test.go's TestNodeAdapterPoolsListOrderingAndActiveSet
+// equivalent -- see api/blockfrost/pools_list_test.go for the original,
+// adapter-level version of this fixture). ROW_NUMBER() window functions,
+// multi-key ORDER BY, and NULL/COALESCE handling are exactly where sqlite,
+// postgres, and mysql diverge, so this exercises the real query against a
+// real mysql server rather than trusting sqlite behavior to generalize.
+//
+// This test runs against a shared, persistent integration-test database
+// (MYSQL_* env vars), not a fresh per-test database, so other tests in
+// this package may leave unrelated rows in pool/pool_registration/
+// pool_retirement. To stay correct regardless of that shared state, this
+// filters the full result down to just the 8 pool key hashes this test
+// created (by set membership) before asserting order, rather than
+// asserting on the total result length.
+func TestGetActivePoolKeyHashesOrderedMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (that
+	// exact ordering bug is why TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql's
+	// own epoch cleanup below silently never executes -- see the epoch_id
+	// <= 5 delete below).
+	t.Cleanup(func() { _ = store.Close() })
+	db := store.DB()
+
+	// A tip/epoch row is a global singleton this package's other tests
+	// never write directly, so it is safe to create fresh here. Slot
+	// 1_000_000 / epoch length 2_000_000 gives ample headroom above every
+	// added_slot used below (max 500).
+	require.NoError(t, db.
+		Where("id = ?", 1).
+		Attrs(models.Tip{Slot: 1_000_000}).
+		FirstOrCreate(&models.Tip{ID: 1}).Error)
+	// epoch_id 0-5 is TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql's
+	// fixture range (pool_atslot_test.go). That test's own cleanup never
+	// actually runs (same plain-defer-before-t.Cleanup ordering bug
+	// described above, pre-existing in that file and not touched here),
+	// so epoch_id 0 persists in this shared integration database with a
+	// narrow length_in_slots=100 that would make GetActivePoolKeyHashesOrdered's
+	// epoch-at-tip-slot lookup pick that stale row instead of this test's
+	// and fail with ErrNoEpochData. Clearing that known range before
+	// creating our own epoch_id=0 makes this test self-sufficient
+	// regardless of that pre-existing bug or test run order.
+	require.NoError(t, db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error)
+	require.NoError(t, db.
+		Where("epoch_id = ?", 0).
+		Attrs(models.Epoch{StartSlot: 0, LengthInSlots: 2_000_000}).
+		FirstOrCreate(&models.Epoch{EpochId: 0}).Error)
+
+	reregisteredCancelledHash := bytes.Repeat([]byte{0xF1}, 28)
+	oldestHash := bytes.Repeat([]byte{0xF2}, 28)
+	reregisteredMarginHash := bytes.Repeat([]byte{0xF3}, 28)
+	retiredFutureHash := bytes.Repeat([]byte{0xF4}, 28)
+	ssBlk0Cert0Hash := bytes.Repeat([]byte{0xF5}, 28)
+	ssBlk0Cert1Hash := bytes.Repeat([]byte{0xF6}, 28)
+	ssBlk1Cert0Hash := bytes.Repeat([]byte{0xF7}, 28)
+	retiredEffectiveHash := bytes.Repeat([]byte{0xF8}, 28)
+
+	allHashes := [][]byte{
+		reregisteredCancelledHash, oldestHash, reregisteredMarginHash,
+		retiredFutureHash, ssBlk0Cert0Hash, ssBlk0Cert1Hash, ssBlk1Cert0Hash,
+		retiredEffectiveHash,
+	}
+	cleanup := func() {
+		for _, h := range allHashes {
+			_ = db.Where("pool_key_hash = ?", h).Delete(&models.PoolRegistration{}).Error
+			_ = db.Where("pool_key_hash = ?", h).Delete(&models.PoolRetirement{}).Error
+			_ = db.Where("pool_key_hash = ?", h).Delete(&models.Pool{}).Error
+		}
+		// Test-specific transaction/cert IDs used for the same-slot trio
+		// below (90001-90003); scoped high enough to avoid any other
+		// test's fixture IDs.
+		_ = db.Where("id IN (?)", []uint{90001, 90002, 90003}).
+			Delete(&models.Certificate{}).Error
+		_ = db.Where("id IN (?)", []uint{90001, 90002}).
+			Delete(&models.Transaction{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	seedPool := func(poolKeyHash []byte) uint {
+		pool := &models.Pool{PoolKeyHash: poolKeyHash}
+		require.NoError(t, db.Create(pool).Error)
+		return pool.ID
+	}
+	seedReg := func(poolID uint, poolKeyHash []byte, addedSlot uint64, certID uint) {
+		require.NoError(t, db.Create(&models.PoolRegistration{
+			PoolID: poolID, PoolKeyHash: poolKeyHash,
+			AddedSlot: addedSlot, CertificateID: certID,
+		}).Error)
+	}
+	seedRet := func(poolID uint, poolKeyHash []byte, addedSlot, epoch uint64) {
+		require.NoError(t, db.Create(&models.PoolRetirement{
+			PoolID: poolID, PoolKeyHash: poolKeyHash,
+			AddedSlot: addedSlot, Epoch: epoch,
+		}).Error)
+	}
+	seedCert := func(txID, certID uint, slot uint64, blockIndex uint32, certIndex uint) uint {
+		var existing models.Transaction
+		err := db.Where("id = ?", txID).First(&existing).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			require.NoError(t, db.Create(&models.Transaction{
+				ID: txID, Slot: slot, BlockIndex: blockIndex,
+				Hash: bytes.Repeat([]byte{byte(txID)}, 32),
+			}).Error)
+		} else {
+			require.NoError(t, err)
+		}
+		require.NoError(t, db.Create(&models.Certificate{
+			ID: certID, TransactionID: txID, Slot: slot, CertIndex: certIndex,
+		}).Error)
+		return certID
+	}
+
+	// Same fixture as the sqlite/adapter-level test: see
+	// api/blockfrost/pools_list_test.go's
+	// TestNodeAdapterPoolsListOrderingAndActiveSet doc comment for the
+	// full rationale of each case.
+	id := seedPool(reregisteredCancelledHash)
+	seedReg(id, reregisteredCancelledHash, 1, 0)
+	seedRet(id, reregisteredCancelledHash, 6, 0)
+	seedReg(id, reregisteredCancelledHash, 400, 0)
+
+	id = seedPool(oldestHash)
+	seedReg(id, oldestHash, 10, 0)
+
+	id = seedPool(reregisteredMarginHash)
+	seedReg(id, reregisteredMarginHash, 50, 0)
+	seedReg(id, reregisteredMarginHash, 500, 0)
+
+	id = seedPool(retiredFutureHash)
+	seedReg(id, retiredFutureHash, 90, 0)
+	seedRet(id, retiredFutureHash, 91, 5)
+
+	cert1 := seedCert(90001, 90001, 100, 0, 0)
+	cert2 := seedCert(90001, 90002, 100, 0, 1)
+	cert3 := seedCert(90002, 90003, 100, 1, 0)
+
+	id = seedPool(ssBlk0Cert0Hash)
+	seedReg(id, ssBlk0Cert0Hash, 100, cert1)
+	id = seedPool(ssBlk0Cert1Hash)
+	seedReg(id, ssBlk0Cert1Hash, 100, cert2)
+	id = seedPool(ssBlk1Cert0Hash)
+	seedReg(id, ssBlk1Cert0Hash, 100, cert3)
+
+	id = seedPool(retiredEffectiveHash)
+	seedReg(id, retiredEffectiveHash, 5, 0)
+	seedRet(id, retiredEffectiveHash, 6, 0)
+
+	wantAsc := []string{
+		hex.EncodeToString(reregisteredCancelledHash),
+		hex.EncodeToString(oldestHash),
+		hex.EncodeToString(reregisteredMarginHash),
+		hex.EncodeToString(retiredFutureHash),
+		hex.EncodeToString(ssBlk0Cert0Hash),
+		hex.EncodeToString(ssBlk0Cert1Hash),
+		hex.EncodeToString(ssBlk1Cert0Hash),
+	}
+	retiredEffectiveHex := hex.EncodeToString(retiredEffectiveHash)
+
+	knownHex := make(map[string]bool, len(wantAsc)+1)
+	for _, h := range wantAsc {
+		knownHex[h] = true
+	}
+	knownHex[retiredEffectiveHex] = true
+
+	result, err := store.GetActivePoolKeyHashesOrdered(nil)
+	require.NoError(t, err)
+
+	var filtered []string
+	for _, pkh := range result {
+		h := hex.EncodeToString(pkh)
+		if knownHex[h] {
+			filtered = append(filtered, h)
+		}
+	}
+
+	require.Equal(
+		t, wantAsc, filtered,
+		"mysql GetActivePoolKeyHashesOrdered must return this fixture's "+
+			"active pools in the same oldest-first order as sqlite",
+	)
+	require.NotContains(t, filtered, retiredEffectiveHex)
+}

--- a/database/plugin/metadata/mysql/pool_active_ordered_test.go
+++ b/database/plugin/metadata/mysql/pool_active_ordered_test.go
@@ -108,18 +108,25 @@ func TestGetActivePoolKeyHashesOrderedMysql(t *testing.T) {
 			Delete(&models.Certificate{}).Error
 		_ = db.Where("id IN (?)", []uint{90001, 90002}).
 			Delete(&models.Transaction{}).Error
-		// Tear down the epoch fixture this test creates. Leaving
-		// epoch_id = 0 behind with length_in_slots = 2_000_000 would
-		// persist in this shared integration database, where
-		// pool_atslot_test.go's FirstOrCreate picks up the existing row
-		// rather than creating its own -- turning a currently
-		// order-independent test into an order-dependent one. Same class
-		// of leak as the pre-existing one described above; this test must
-		// not add another (see dingo #3025).
-		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
 	}
 	cleanup()
 	t.Cleanup(cleanup)
+	// Tear down the epoch fixture created above. Deliberately a separate
+	// t.Cleanup rather than part of cleanup(): cleanup() also runs up front
+	// (line above) to clear leftovers from an earlier run, and by that point
+	// the epoch fixture already exists, so deleting it there would remove
+	// the row this test depends on.
+	//
+	// It has to be torn down somewhere, though. Leaving epoch_id = 0 behind
+	// with length_in_slots = 2_000_000 persists in this shared integration
+	// database, where pool_atslot_test.go's FirstOrCreate adopts the
+	// existing row instead of creating its own -- turning a currently
+	// order-independent test into an order-dependent one. Same class of leak
+	// as the pre-existing one described above (see dingo #3025); this test
+	// must not add another.
+	t.Cleanup(func() {
+		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
+	})
 
 	seedPool := func(poolKeyHash []byte) uint {
 		pool := &models.Pool{PoolKeyHash: poolKeyHash}

--- a/database/plugin/metadata/mysql/pool_active_ordered_test.go
+++ b/database/plugin/metadata/mysql/pool_active_ordered_test.go
@@ -108,6 +108,15 @@ func TestGetActivePoolKeyHashesOrderedMysql(t *testing.T) {
 			Delete(&models.Certificate{}).Error
 		_ = db.Where("id IN (?)", []uint{90001, 90002}).
 			Delete(&models.Transaction{}).Error
+		// Tear down the epoch fixture this test creates. Leaving
+		// epoch_id = 0 behind with length_in_slots = 2_000_000 would
+		// persist in this shared integration database, where
+		// pool_atslot_test.go's FirstOrCreate picks up the existing row
+		// rather than creating its own -- turning a currently
+		// order-independent test into an order-dependent one. Same class
+		// of leak as the pre-existing one described above; this test must
+		// not add another (see dingo #3025).
+		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
 	}
 	cleanup()
 	t.Cleanup(cleanup)

--- a/database/plugin/metadata/postgres/pool.go
+++ b/database/plugin/metadata/postgres/pool.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolcerthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolorder"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -926,6 +927,38 @@ func (d *MetadataStorePostgres) GetActivePoolKeyHashesAtSlot(
 	}
 
 	return poolKeyHashes, nil
+}
+
+// GetActivePoolKeyHashesOrdered retrieves the key hashes of all currently
+// active pools, ordered oldest-first by each pool's first on-chain
+// registration certificate. See poolorder.GetActivePoolKeyHashesOrdered for
+// the full ordering and active-pool semantics; this delegates to it using
+// the current tip's slot, mirroring GetActivePoolKeyHashes's delegation to
+// GetActivePoolKeyHashesAtSlot.
+func (d *MetadataStorePostgres) GetActivePoolKeyHashesOrdered(
+	txn types.Txn,
+) ([][]byte, error) {
+	db, err := d.resolveDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: resolve db: %w",
+			err,
+		)
+	}
+
+	// Get the current tip slot
+	var tmpTip models.Tip
+	if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: get tip: %w",
+			res.Error,
+		)
+	}
+
+	return poolorder.GetActivePoolKeyHashesOrdered(db, tmpTip.Slot)
 }
 
 // GetActivePoolRelays returns all relays from currently active pools.

--- a/database/plugin/metadata/postgres/pool_active_ordered_test.go
+++ b/database/plugin/metadata/postgres/pool_active_ordered_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package postgres
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestGetActivePoolKeyHashesOrderedPostgres is the cross-backend behavioral
+// counterpart to the sqlite ordering test
+// (sqlite/pool_active_ordered_test.go's TestNodeAdapterPoolsListOrderingAndActiveSet
+// equivalent -- see api/blockfrost/pools_list_test.go for the original,
+// adapter-level version of this fixture). ROW_NUMBER() window functions,
+// multi-key ORDER BY, and NULL/COALESCE handling are exactly where sqlite,
+// postgres, and mysql diverge, so this exercises the real query against a
+// real postgres server rather than trusting sqlite behavior to generalize.
+//
+// This test runs against a shared, persistent integration-test database
+// (POSTGRES_* env vars), not a fresh per-test database, so other tests in
+// this package may leave unrelated rows in pool/pool_registration/
+// pool_retirement. To stay correct regardless of that shared state, this
+// filters the full result down to just the 8 pool key hashes this test
+// created (by set membership) before asserting order, rather than
+// asserting on the total result length.
+func TestGetActivePoolKeyHashesOrderedPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (that
+	// exact ordering bug is why TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres's
+	// own epoch cleanup below silently never executes -- see the epoch_id
+	// <= 5 delete below).
+	t.Cleanup(func() { _ = store.Close() })
+	db := store.DB()
+
+	// A tip/epoch row is a global singleton this package's other tests
+	// never write directly, so it is safe to create fresh here. Slot
+	// 1_000_000 / epoch length 2_000_000 gives ample headroom above every
+	// added_slot used below (max 500).
+	require.NoError(t, db.
+		Where("id = ?", 1).
+		Attrs(models.Tip{Slot: 1_000_000}).
+		FirstOrCreate(&models.Tip{ID: 1}).Error)
+	// epoch_id 0-5 is TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres's
+	// fixture range (pool_atslot_test.go). That test's own cleanup never
+	// actually runs (same plain-defer-before-t.Cleanup ordering bug
+	// described above, pre-existing in that file and not touched here),
+	// so epoch_id 0 persists in this shared integration database with a
+	// narrow length_in_slots=100 that would make GetActivePoolKeyHashesOrdered's
+	// epoch-at-tip-slot lookup pick that stale row instead of this test's
+	// and fail with ErrNoEpochData. Clearing that known range before
+	// creating our own epoch_id=0 makes this test self-sufficient
+	// regardless of that pre-existing bug or test run order.
+	require.NoError(t, db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error)
+	require.NoError(t, db.
+		Where("epoch_id = ?", 0).
+		Attrs(models.Epoch{StartSlot: 0, LengthInSlots: 2_000_000}).
+		FirstOrCreate(&models.Epoch{EpochId: 0}).Error)
+
+	reregisteredCancelledHash := bytes.Repeat([]byte{0xF1}, 28)
+	oldestHash := bytes.Repeat([]byte{0xF2}, 28)
+	reregisteredMarginHash := bytes.Repeat([]byte{0xF3}, 28)
+	retiredFutureHash := bytes.Repeat([]byte{0xF4}, 28)
+	ssBlk0Cert0Hash := bytes.Repeat([]byte{0xF5}, 28)
+	ssBlk0Cert1Hash := bytes.Repeat([]byte{0xF6}, 28)
+	ssBlk1Cert0Hash := bytes.Repeat([]byte{0xF7}, 28)
+	retiredEffectiveHash := bytes.Repeat([]byte{0xF8}, 28)
+
+	allHashes := [][]byte{
+		reregisteredCancelledHash, oldestHash, reregisteredMarginHash,
+		retiredFutureHash, ssBlk0Cert0Hash, ssBlk0Cert1Hash, ssBlk1Cert0Hash,
+		retiredEffectiveHash,
+	}
+	cleanup := func() {
+		for _, h := range allHashes {
+			_ = db.Where("pool_key_hash = ?", h).Delete(&models.PoolRegistration{}).Error
+			_ = db.Where("pool_key_hash = ?", h).Delete(&models.PoolRetirement{}).Error
+			_ = db.Where("pool_key_hash = ?", h).Delete(&models.Pool{}).Error
+		}
+		// Test-specific transaction/cert IDs used for the same-slot trio
+		// below (90001-90003); scoped high enough to avoid any other
+		// test's fixture IDs.
+		_ = db.Where("id IN (?)", []uint{90001, 90002, 90003}).
+			Delete(&models.Certificate{}).Error
+		_ = db.Where("id IN (?)", []uint{90001, 90002}).
+			Delete(&models.Transaction{}).Error
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	seedPool := func(poolKeyHash []byte) uint {
+		pool := &models.Pool{PoolKeyHash: poolKeyHash}
+		require.NoError(t, db.Create(pool).Error)
+		return pool.ID
+	}
+	seedReg := func(poolID uint, poolKeyHash []byte, addedSlot uint64, certID uint) {
+		require.NoError(t, db.Create(&models.PoolRegistration{
+			PoolID: poolID, PoolKeyHash: poolKeyHash,
+			AddedSlot: addedSlot, CertificateID: certID,
+		}).Error)
+	}
+	seedRet := func(poolID uint, poolKeyHash []byte, addedSlot, epoch uint64) {
+		require.NoError(t, db.Create(&models.PoolRetirement{
+			PoolID: poolID, PoolKeyHash: poolKeyHash,
+			AddedSlot: addedSlot, Epoch: epoch,
+		}).Error)
+	}
+	seedCert := func(txID, certID uint, slot uint64, blockIndex uint32, certIndex uint) uint {
+		var existing models.Transaction
+		err := db.Where("id = ?", txID).First(&existing).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			require.NoError(t, db.Create(&models.Transaction{
+				ID: txID, Slot: slot, BlockIndex: blockIndex,
+				Hash: bytes.Repeat([]byte{byte(txID)}, 32),
+			}).Error)
+		} else {
+			require.NoError(t, err)
+		}
+		require.NoError(t, db.Create(&models.Certificate{
+			ID: certID, TransactionID: txID, Slot: slot, CertIndex: certIndex,
+		}).Error)
+		return certID
+	}
+
+	// Same fixture as the sqlite/adapter-level test: see
+	// api/blockfrost/pools_list_test.go's
+	// TestNodeAdapterPoolsListOrderingAndActiveSet doc comment for the
+	// full rationale of each case.
+	id := seedPool(reregisteredCancelledHash)
+	seedReg(id, reregisteredCancelledHash, 1, 0)
+	seedRet(id, reregisteredCancelledHash, 6, 0)
+	seedReg(id, reregisteredCancelledHash, 400, 0)
+
+	id = seedPool(oldestHash)
+	seedReg(id, oldestHash, 10, 0)
+
+	id = seedPool(reregisteredMarginHash)
+	seedReg(id, reregisteredMarginHash, 50, 0)
+	seedReg(id, reregisteredMarginHash, 500, 0)
+
+	id = seedPool(retiredFutureHash)
+	seedReg(id, retiredFutureHash, 90, 0)
+	seedRet(id, retiredFutureHash, 91, 5)
+
+	cert1 := seedCert(90001, 90001, 100, 0, 0)
+	cert2 := seedCert(90001, 90002, 100, 0, 1)
+	cert3 := seedCert(90002, 90003, 100, 1, 0)
+
+	id = seedPool(ssBlk0Cert0Hash)
+	seedReg(id, ssBlk0Cert0Hash, 100, cert1)
+	id = seedPool(ssBlk0Cert1Hash)
+	seedReg(id, ssBlk0Cert1Hash, 100, cert2)
+	id = seedPool(ssBlk1Cert0Hash)
+	seedReg(id, ssBlk1Cert0Hash, 100, cert3)
+
+	id = seedPool(retiredEffectiveHash)
+	seedReg(id, retiredEffectiveHash, 5, 0)
+	seedRet(id, retiredEffectiveHash, 6, 0)
+
+	wantAsc := []string{
+		hex.EncodeToString(reregisteredCancelledHash),
+		hex.EncodeToString(oldestHash),
+		hex.EncodeToString(reregisteredMarginHash),
+		hex.EncodeToString(retiredFutureHash),
+		hex.EncodeToString(ssBlk0Cert0Hash),
+		hex.EncodeToString(ssBlk0Cert1Hash),
+		hex.EncodeToString(ssBlk1Cert0Hash),
+	}
+	retiredEffectiveHex := hex.EncodeToString(retiredEffectiveHash)
+
+	knownHex := make(map[string]bool, len(wantAsc)+1)
+	for _, h := range wantAsc {
+		knownHex[h] = true
+	}
+	knownHex[retiredEffectiveHex] = true
+
+	result, err := store.GetActivePoolKeyHashesOrdered(nil)
+	require.NoError(t, err)
+
+	var filtered []string
+	for _, pkh := range result {
+		h := hex.EncodeToString(pkh)
+		if knownHex[h] {
+			filtered = append(filtered, h)
+		}
+	}
+
+	require.Equal(
+		t, wantAsc, filtered,
+		"postgres GetActivePoolKeyHashesOrdered must return this fixture's "+
+			"active pools in the same oldest-first order as sqlite",
+	)
+	require.NotContains(t, filtered, retiredEffectiveHex)
+}

--- a/database/plugin/metadata/postgres/pool_active_ordered_test.go
+++ b/database/plugin/metadata/postgres/pool_active_ordered_test.go
@@ -108,6 +108,15 @@ func TestGetActivePoolKeyHashesOrderedPostgres(t *testing.T) {
 			Delete(&models.Certificate{}).Error
 		_ = db.Where("id IN (?)", []uint{90001, 90002}).
 			Delete(&models.Transaction{}).Error
+		// Tear down the epoch fixture this test creates. Leaving
+		// epoch_id = 0 behind with length_in_slots = 2_000_000 would
+		// persist in this shared integration database, where
+		// pool_atslot_test.go's FirstOrCreate picks up the existing row
+		// rather than creating its own -- turning a currently
+		// order-independent test into an order-dependent one. Same class
+		// of leak as the pre-existing one described above; this test must
+		// not add another (see dingo #3025).
+		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
 	}
 	cleanup()
 	t.Cleanup(cleanup)

--- a/database/plugin/metadata/postgres/pool_active_ordered_test.go
+++ b/database/plugin/metadata/postgres/pool_active_ordered_test.go
@@ -108,18 +108,25 @@ func TestGetActivePoolKeyHashesOrderedPostgres(t *testing.T) {
 			Delete(&models.Certificate{}).Error
 		_ = db.Where("id IN (?)", []uint{90001, 90002}).
 			Delete(&models.Transaction{}).Error
-		// Tear down the epoch fixture this test creates. Leaving
-		// epoch_id = 0 behind with length_in_slots = 2_000_000 would
-		// persist in this shared integration database, where
-		// pool_atslot_test.go's FirstOrCreate picks up the existing row
-		// rather than creating its own -- turning a currently
-		// order-independent test into an order-dependent one. Same class
-		// of leak as the pre-existing one described above; this test must
-		// not add another (see dingo #3025).
-		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
 	}
 	cleanup()
 	t.Cleanup(cleanup)
+	// Tear down the epoch fixture created above. Deliberately a separate
+	// t.Cleanup rather than part of cleanup(): cleanup() also runs up front
+	// (line above) to clear leftovers from an earlier run, and by that point
+	// the epoch fixture already exists, so deleting it there would remove
+	// the row this test depends on.
+	//
+	// It has to be torn down somewhere, though. Leaving epoch_id = 0 behind
+	// with length_in_slots = 2_000_000 persists in this shared integration
+	// database, where pool_atslot_test.go's FirstOrCreate adopts the
+	// existing row instead of creating its own -- turning a currently
+	// order-independent test into an order-dependent one. Same class of leak
+	// as the pre-existing one described above (see dingo #3025); this test
+	// must not add another.
+	t.Cleanup(func() {
+		_ = db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error
+	})
 
 	seedPool := func(poolKeyHash []byte) uint {
 		pool := &models.Pool{PoolKeyHash: poolKeyHash}

--- a/database/plugin/metadata/sqlite/pool.go
+++ b/database/plugin/metadata/sqlite/pool.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolcerthistory"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/poolorder"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/internal/stakequery"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1158,6 +1159,38 @@ func (d *MetadataStoreSqlite) GetActivePoolKeyHashesAtSlot(
 	}
 
 	return poolKeyHashes, nil
+}
+
+// GetActivePoolKeyHashesOrdered retrieves the key hashes of all currently
+// active pools, ordered oldest-first by each pool's first on-chain
+// registration certificate. See poolorder.GetActivePoolKeyHashesOrdered for
+// the full ordering and active-pool semantics; this delegates to it using
+// the current tip's slot, mirroring GetActivePoolKeyHashes's delegation to
+// GetActivePoolKeyHashesAtSlot.
+func (d *MetadataStoreSqlite) GetActivePoolKeyHashesOrdered(
+	txn types.Txn,
+) ([][]byte, error) {
+	db, err := d.resolveReadDB(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: resolve db: %w",
+			err,
+		)
+	}
+
+	// Get the current tip slot
+	var tmpTip models.Tip
+	if res := db.Where("id = ?", tipEntryId).First(&tmpTip); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return [][]byte{}, nil
+		}
+		return nil, fmt.Errorf(
+			"GetActivePoolKeyHashesOrdered: get tip: %w",
+			res.Error,
+		)
+	}
+
+	return poolorder.GetActivePoolKeyHashesOrdered(db, tmpTip.Slot)
 }
 
 // GetStakeByPool returns the total delegated stake and delegator count for a pool.

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -448,6 +448,18 @@ type MetadataStore interface {
 	// the retirement epoch is in the future.
 	GetActivePoolKeyHashes(types.Txn) ([][]byte, error)
 
+	// GetActivePoolKeyHashesOrdered retrieves the key hashes of all
+	// currently active pools (same active-pool semantics as
+	// GetActivePoolKeyHashes), ordered oldest-first by each pool's
+	// earliest on-chain registration certificate: added_slot ascending,
+	// then block_index and cert_index ascending to disambiguate
+	// certificates recorded in the same slot. This backs the Blockfrost
+	// pool_list endpoint's documented "oldest first, newest last"
+	// ordering. See poolorder.GetActivePoolKeyHashesOrdered for the full
+	// rationale, including why "oldest" is keyed on first registration
+	// rather than the most recent one.
+	GetActivePoolKeyHashesOrdered(types.Txn) ([][]byte, error)
+
 	// GetPoolCertificateHistory returns the transaction hashes of a pool's
 	// registration and retirement certificates, in chronological order
 	// (added_slot, block_index, cert_index ascending). Certificates with no

--- a/database/pool.go
+++ b/database/pool.go
@@ -203,6 +203,21 @@ func (d *Database) GetActivePoolKeyHashes(
 	return d.metadata.GetActivePoolKeyHashes(txn.Metadata())
 }
 
+// GetActivePoolKeyHashesOrdered returns the key hashes of all currently
+// active (registered, non-retired) stake pools, ordered oldest-first by
+// each pool's earliest on-chain registration certificate. See
+// metadata.MetadataStore.GetActivePoolKeyHashesOrdered for the full
+// ordering semantics. This backs the Blockfrost pool_list endpoint.
+func (d *Database) GetActivePoolKeyHashesOrdered(
+	txn *Txn,
+) ([][]byte, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	return d.metadata.GetActivePoolKeyHashesOrdered(txn.Metadata())
+}
+
 // GetPoolCertificateHistory returns the transaction hashes of a pool's
 // registration and retirement certificates, in chronological order.
 func (d *Database) GetPoolCertificateHistory(


### PR DESCRIPTION
Closes #3011

Registers `GET /api/v0/pools`. It was the only Blockfrost pools route missing: `/pools/extended`, `/pools/retiring`, `/pools/{pool_id}` and `/pools/{pool_id}/metadata` all resolve, so a spec-following client asking for the pool list got the catch-all 404.

## Response

`pool_list` is a flat JSON array of bech32 pool IDs, with `count`, `page`, and `order`. Verified against `src/schemas/pools/pool_list.yaml` and `src/paths/api/pools/index.yaml`.

The active set comes from the same non-retired pool definition `/pools/extended` uses, so the two endpoints agree on which pools exist.

## Ordering, and a decision the schema does not pin

The spec documents `order` as "the ordering of items from the point of view of the blockchain, not the page listing itself. By default, we return oldest first, newest last."

`GetActivePoolKeyHashesAtSlot` has no terminal `ORDER BY`, so its row order is incidental rather than contractual. Sorting that incidental order by pool ID would have satisfied a naive test while silently violating "oldest first", so this adds `GetActivePoolKeyHashesOrdered`, shared across all three backends, ranking each active pool by its registration certificate position: `added_slot`, then `block_index`, then `cert_index` ascending, with a `pool_key_hash` final tie-break for full determinism.

It ranks by the EARLIEST registration, not the latest. A pool that re-registers years later to change its margin keeps its original position rather than jumping to the newest slot, which is what "oldest first" means for pool age. The OpenAPI schema does not pin this, so it is a deliberate and reversible decision — stated as such in `DATABASE.md`, `ARCHITECTURE.md`, and both doc comments rather than left implicit.

`desc` is `slices.Reverse` of the same slice `asc` returns, so the two are exact reverses by construction rather than by two independently-sorted queries happening to agree. A test asserts that.

## Cross-backend verification

The ordering query uses a `ROW_NUMBER()` window function shared by sqlite, postgres, and mysql — exactly the kind of SQL where the three diverge — so compile-time parity is not evidence. Verified behaviorally against real PostgreSQL 16 and MySQL 8 containers with the same 8-pool fixture the sqlite test uses, covering a re-registration, a re-registration that cancels a pending retirement, a same-slot three-way tie broken by `block_index`/`cert_index`, a pending future retirement, and an already-effective retirement that must be excluded.

All three backends produce the identical oldest-first sequence. No assertion was relaxed to accommodate a backend.

## Query cost

Stated per backend rather than measured on one and asserted for all, since a sibling branch in this stack had to be corrected for exactly that.

At mainnet-comparable scale (~8,000 pools, ~10,000 historical registrations, ~500 retirements) all three backends fall back to a full scan of `pool_registration`: the available index leads with the pool, not `added_slot`, so the slot filter cannot become an index range. No backend is materially worse than the others. This is the same cost `/pools/extended` already pays through `GetActivePoolKeyHashesAtSlot` — the added `ROW_NUMBER()` is computed over the same already-joined rows rather than requiring a second pass. Plan excerpts are recorded in `DATABASE.md`.

Pagination is applied in memory over the ordered active set, matching the existing `/pools/retiring` split. The ranking is computed across the whole registration and retirement history, so the full active set must be ranked before any page boundary exists; a SQL `LIMIT` would trim rows after that work rather than avoid it.

## Route precedence

`TestPoolsListRouteDoesNotSwallowSiblings` builds the real mux via `handler()` and asserts `/pools`, `/pools/extended`, `/pools/retiring`, `/pools/{pool_id}` and `/pools/{pool_id}/metadata` each reach their own handler. Asserted rather than reasoned from `ServeMux` specificity rules.

## One pre-existing test changed, with maintainer sign-off

`TestRouterUnimplementedRouteReturns404` used `/api/v0/pools` as an example of a route falling through to the catch-all — the precise gap this PR closes — so that subtest became stale. The entry is removed with sign-off; `/api/v0/`, `/api/v0/scripts` and `/does-not-exist` still exercise the same path, so coverage is unchanged.

## Noted for follow-up, not fixed here

While running the postgres and mysql suites I found `TestGetRewardStakeInputsForPoolsUsesHistoricalExpiration{Postgres,Mysql}` in `pool_atslot_test.go` registers `t.Cleanup` after a plain `defer store.Close()`, so its cleanup queries run against an already-closed connection and silently no-op, leaving stale `epoch` rows behind in a shared integration database. That is pre-existing and untouched; the new tests here are made self-sufficient instead. Filing separately.

## Verification

`go build ./...` (default and `-tags dingo_extra_plugins`), `go test ./api/blockfrost/... ./database/...` with 0 `^FAIL` and 0 `^--- FAIL`, `golangci-lint run` 0 issues, `nilaway`, `modernize`, `make import-boundaries`, `go test -race ./api/blockfrost/...` with no data races, and conformance all pass. Full postgres and mysql metadata suites also pass against real containers under the plugin build tag; both containers were removed.

## Documentation

`DATABASE.md` gains a `GetActivePoolKeyHashesOrdered` section with the SQL, tie-break, ordering decision, and per-backend plans. `ARCHITECTURE.md` adds the route to the Blockfrost router inventory plus the ordering and pagination semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Blockfrost stake pool list endpoint that returns a paginated array of bech32 pool IDs with deterministic chain order. Completes #3011 and closes the 404 gap for spec-following clients calling /pools.

- **New Features**
  - Register GET `/api/v0/pools` (pool_list); returns active (registered, non-retired) pools using the same active set as `/pools/extended`.
  - Add `GetActivePoolKeyHashesOrdered` (shared via `database/plugin/metadata/internal/poolorder`); sorts oldest-first by earliest registration with a deterministic tie-break; `desc` reverses the same slice.
  - Apply in-memory pagination with standard headers; verified identical ordering across sqlite and real Postgres 16/MySQL 8.4; documented ordering, query cost, and minimum backend versions.

- **Refactors**
  - Use `Database.GetActivePoolKeyHashesOrdered` in the adapter instead of calling the plugin directly.
  - Fix Postgres/MySQL ordering tests: register epoch teardown outside the shared cleanup so it runs after the test, preventing premature fixture deletion and “no epoch data” failures while keeping the shared integration DB clean.

<sup>Written for commit f08e3c02cc648ac10e61098f53b75494ee0334cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/api/v0/pools` endpoint for listing active stake-pool IDs.
  * Supports pagination, ascending or descending registration order, total-result headers, and deterministic ordering.
  * Excludes pools that are effectively retired.
* **Bug Fixes**
  * Added validation for invalid pagination parameters and clear handling of empty results and backend errors.
* **Documentation**
  * Documented the new endpoint, ordering behavior, pagination, and active-pool selection rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->