### PR TITLE
fix(ouroboros): accept full Byron EBB chain-sync payloads

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1445,7 +1445,21 @@ func (o *Ouroboros) decodeChainsyncHeader(
 		blockType == gledger.BlockTypeConway {
 		return gdijkstra.NewDijkstraBlockHeaderFromCbor(raw)
 	}
-	return gledger.NewBlockHeaderFromCbor(blockType, raw)
+	header, err := gledger.NewBlockHeaderFromCbor(blockType, raw)
+	if err == nil || blockType != gledger.BlockTypeByronEbb {
+		return header, err
+	}
+	// Some dingo peers have sent a complete Byron EBB in the NtN header
+	// payload. A complete EBB is an array of its header, body, and extra data,
+	// so the header decoder rejects it at ConsensusData. Decode that one legacy
+	// representation as a block and return its header; the regular path above
+	// remains the only path for all other block types and correctly encoded EBB
+	// headers.
+	block, blockErr := gledger.NewBlockFromCbor(blockType, raw)
+	if blockErr != nil {
+		return nil, err
+	}
+	return block.Header(), nil
 }
 
 // chainsyncClientRollForwardRaw decodes the raw header itself (via

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -39,11 +39,13 @@ import (
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
 	"github.com/stretchr/testify/require"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
@@ -69,6 +71,54 @@ func TestEffectiveChainsyncBlockTimeoutUsesProtocolMaxAsFloor(t *testing.T) {
 		10*time.Minute,
 		effectiveChainsyncBlockTimeout(10*time.Minute),
 	)
+}
+
+func TestChainsyncByronEbbHeaderRoundTrip(t *testing.T) {
+	ebbCbor := byronEbbFixtureCbor(t)
+
+	msg, err := ochainsync.NewMsgRollForwardNtN(
+		gledger.BlockHeaderTypeByron,
+		gledger.BlockTypeByronEbb,
+		ebbCbor,
+		ochainsync.Tip{},
+	)
+	require.NoError(t, err)
+	wire, err := gcbor.Encode(msg)
+	require.NoError(t, err)
+	var received ochainsync.MsgRollForwardNtN
+	_, err = gcbor.Decode(wire, &received)
+	require.NoError(t, err)
+	_, err = gledger.NewBlockHeaderFromCbor(
+		received.WrappedHeader.ByronType(),
+		received.WrappedHeader.HeaderCbor(),
+	)
+	require.NoError(t, err)
+}
+
+func TestDecodeChainsyncHeaderAcceptsFullByronEbb(t *testing.T) {
+	ebbCbor := byronEbbFixtureCbor(t)
+	expected, err := gledger.NewBlockFromCbor(gledger.BlockTypeByronEbb, ebbCbor)
+	require.NoError(t, err)
+
+	o := NewOuroboros(OuroborosConfig{})
+	header, err := o.decodeChainsyncHeader(gledger.BlockTypeByronEbb, ebbCbor)
+	require.NoError(t, err)
+	require.Equal(t, expected.Header().Hash(), header.Hash())
+}
+
+func byronEbbFixtureCbor(t *testing.T) []byte {
+	t.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(t.TempDir())
+	require.NoError(t, err)
+	fixture, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/Block_Byron_EBB",
+	)
+	require.NoError(t, err)
+	data, err := fixture.ConsensusLedgerBlockBytes()
+	require.NoError(t, err)
+	return data
 }
 
 func (b *lockedBuffer) Write(p []byte) (int, error) {


### PR DESCRIPTION
Closes #3026 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept full Byron EBB payloads in chain-sync NtN headers by decoding the full block and returning its header. Restores compatibility with peers that send complete EBBs in the header payload.

- **Bug Fixes**
  - In `decodeChainsyncHeader`, if Byron EBB header decode fails, fall back to `gledger.NewBlockFromCbor` and return `block.Header()`; other block types are unchanged.
  - Added tests for Byron EBB header round-trip and full-EBB acceptance using `gcbor` and `ouroboros-mock/fixtures`.

<sup>Written for commit 9ab883b331baed04ca7cce5bba20d830a469786f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

