### PR TITLE
fix(antithesis): signal setup readiness

### DIFF
--- a/internal/test/antithesis/internal/analysis/analysis.go
+++ b/internal/test/antithesis/internal/analysis/analysis.go
@@ -37,20 +37,22 @@ type fileState struct {
 // Analyzer reads node log files, parses events, and reports Antithesis
 // assertions on each check interval.
 type Analyzer struct {
-	cfg       *Config
-	metrics   *Metrics
-	files     map[string]*fileState // keyed by file path
-	logger    *slog.Logger
-	setupDone bool
+	cfg           *Config
+	metrics       *Metrics
+	files         map[string]*fileState // keyed by file path
+	logger        *slog.Logger
+	setupDone     bool
+	setupComplete func()
 }
 
 // NewAnalyzer creates an Analyzer with the given config and a fresh Metrics.
 func NewAnalyzer(cfg *Config, logger *slog.Logger) *Analyzer {
 	return &Analyzer{
-		cfg:     cfg,
-		metrics: NewMetrics(),
-		files:   make(map[string]*fileState),
-		logger:  logger,
+		cfg:           cfg,
+		metrics:       NewMetrics(),
+		files:         make(map[string]*fileState),
+		logger:        logger,
+		setupComplete: SetupComplete,
 	}
 }
 
@@ -75,6 +77,10 @@ func (a *Analyzer) Run(ctx context.Context) error {
 	case <-waitTimer.C:
 	}
 
+	// Signal readiness independently of observed workload. A test run can
+	// legitimately have no forged blocks yet, but Antithesis still needs this
+	// lifecycle event before it will begin fault injection.
+	a.signalSetupComplete()
 	a.logger.Info("initial wait complete; beginning analysis loop")
 
 	ticker := time.NewTicker(a.cfg.CheckInterval)
@@ -95,14 +101,19 @@ func (a *Analyzer) Run(ctx context.Context) error {
 func (a *Analyzer) check() {
 	a.readNewLines()
 	snap := a.metrics.Snapshot()
-	if !a.setupDone && snap.TotalBlocksForged > 0 {
-		SetupComplete()
-		a.logger.Info("setup complete signaled")
-		a.setupDone = true
-	}
 	a.reportSafetyAssertions(&snap)
 	a.reportLivenessAssertions(&snap)
 	a.reportReachable(&snap)
+}
+
+// signalSetupComplete emits the Antithesis readiness event once per analyzer.
+func (a *Analyzer) signalSetupComplete() {
+	if a.setupDone {
+		return
+	}
+	a.setupComplete()
+	a.logger.Info("setup complete signaled")
+	a.setupDone = true
 }
 
 // readNewLines discovers log files matching p*.log and txpump.log in

--- a/internal/test/antithesis/internal/analysis/analysis_test.go
+++ b/internal/test/antithesis/internal/analysis/analysis_test.go
@@ -15,10 +15,45 @@
 package analysis
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestAnalyzerRunSignalsSetupCompleteWithoutForgedBlocks(t *testing.T) {
+	called := make(chan struct{}, 1)
+	analyzer := NewAnalyzer(&Config{
+		InitialWait:   0,
+		CheckInterval: time.Hour,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	analyzer.setupComplete = func() {
+		called <- struct{}{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- analyzer.Run(ctx)
+	}()
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("setup complete was not signaled")
+	}
+
+	cancel()
+	select {
+	case err := <-runDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("analyzer did not stop after context cancellation")
+	}
+}
 
 func TestChainTipRange_Empty(t *testing.T) {
 	min, max, ok := chainTipRange(map[string]uint64{})


### PR DESCRIPTION
Signal Antithesis setup readiness after the analysis initial wait, even before any blocks are forged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Signal Antithesis setup readiness immediately after the initial wait, even with zero forged blocks, so fault injection can start without waiting for workload.

- **Bug Fixes**
  - Emit readiness once per run via a new helper, called from `Run` after the initial wait; remove the forged-blocks gate from `check`.
  - Add an injectable `setupComplete` callback (defaults to `SetupComplete`) for testability.
  - Add a test to verify readiness is signaled with zero forged blocks and that `Run` stops on context cancel.

<sup>Written for commit 5e5de9be371bb135247eb0d6766dc88afd76d90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

