### PR TITLE
ci: set an explicit go test timeout on the race-instrumented job

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -98,7 +98,14 @@ jobs:
       - name: go-build-minimal
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race ./...
+        # Explicit -timeout because this job is race-instrumented. Go's
+        # default is 10m per package binary, and under -race the ledger
+        # package alone uses roughly 485s of it, so a runner 15-25% slower
+        # than average pushes it past the limit and fails a job on whichever
+        # PR happens to be running. See dingo #3032 for restoring real
+        # headroom; this only stops the default from being the binding
+        # constraint in the meantime.
+        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race -timeout 20m ./...
 
   # macOS and Windows jobs without Postgres service
   go-test-other:


### PR DESCRIPTION
Adds `-timeout 20m` to the Linux go-test job. One line plus a comment explaining why.

## Why

That job runs `go test -tags dingo_extra_plugins -ldflags="-s -w" -race ./...`. Go defaults to a 10 minute timeout per package binary, and under `-race` the `ledger` package alone consumes roughly 485s of it. That leaves about two minutes of headroom, so the default is acting as the binding constraint rather than as a safety net: a runner 15 to 25 percent slower than average crosses the line.

When that happens the failure lands on whichever pull request happens to be running, and reads as if that change broke something.

## Evidence it is runner variance, not a regression

Observed twice consecutively on #3020:

```
panic: test timed out after 10m0s
FAIL	github.com/blinklabs-io/dingo/ledger	600.143s
```

Every other package in that run passed. #3020 changes 16 files, none under `ledger/`, and its only cross-package change is a new `MetadataStore` interface method that no ledger path calls.

The same content passes on the branch stacked directly on top of it:

```
ok  	github.com/blinklabs-io/dingo/ledger	480.954s   (feat/3011-pools-list)
ok  	github.com/blinklabs-io/dingo/ledger	491.393s   (feat/2934-account-activity-endpoints)
ok  	github.com/blinklabs-io/dingo/ledger	483.337s   (main)
```

macOS and Windows pass on the identical commit because `go-test-other` does not enable `-race`.

Comparing package durations between the failing run and a passing one shows the whole runner was slower, not one test:

| package | failing | passing | delta |
|---|---|---|---|
| ledger/governance | 123.7s | 100.3s | +23% |
| ledgerstate | 39.6s | 34.9s | +14% |
| ouroboros | 55.6s | 48.8s | +14% |
| midnight/indexer | 76.5s | 69.9s | +9% |
| ledger/snapshot | 215.0s | 218.4s | -2% |
| mithril | 80.9s | 89.1s | -9% |

At a 485s baseline, a 15 to 23 percent slower runner puts `ledger` between 558s and 597s, straddling the limit. That accounts for the timeouts without any change in behavior.

The goroutine dump reported `running tests: TestVerifyRegisteredVrfKey_AcceptsRetiredPoolRegistration (1s)`, i.e. one test alive for one second when the alarm fired. Nothing is deadlocked; the package simply accumulated the full budget.

## What this does and does not do

It does not make the suite faster, and it does not remove the underlying fragility. It stops ordinary runner variance from turning into a failed check on unrelated work.

Restoring real headroom is tracked in #3032, which asks for per-test durations under `-race` so the dominant contributors are known rather than guessed. Raising the timeout alone would hide that trend, which is why the issue stays open and the comment in the workflow points at it.

Only the race-instrumented job is changed. The macOS and Windows jobs keep the default, since without `-race` they finish in about 4 and 12 minutes respectively and have plenty of margin.

## Scope note

20m is chosen to sit roughly 2x above the current 485s worst case, so it absorbs variance without being so large that a genuine hang would sit in CI for a long time before failing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a 20m timeout for `go test -race` in the Linux CI job to prevent flaky timeouts when the `ledger` package approaches Go’s 10m per-package default. This stabilizes the race-instrumented job on slower runners; macOS and Windows jobs are unchanged.

<sup>Written for commit b70cb381ea7472ba6cce0d9ce831784e6029527f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for Linux race-detection tests to 20 minutes.
  * Added documentation clarifying the timeout and expected test runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->