### PR TITLE
test(database): register store.Close via t.Cleanup ahead of data cleanup

### DIFF
--- a/database/plugin/metadata/mysql/pool_active_ordered_test.go
+++ b/database/plugin/metadata/mysql/pool_active_ordered_test.go
@@ -50,10 +50,10 @@ func TestGetActivePoolKeyHashesOrderedMysql(t *testing.T) {
 	// connection closes: t.Cleanup callbacks run after every plain defer
 	// in this function body has already executed, so a plain
 	// "defer store.Close()" here would close the connection before any
-	// later-registered t.Cleanup data cleanup runs against it (that
-	// exact ordering bug is why TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql's
-	// own epoch cleanup below silently never executes -- see the epoch_id
-	// <= 5 delete below).
+	// later-registered t.Cleanup data cleanup runs against it (that exact
+	// ordering bug previously made TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql's
+	// own epoch cleanup silently never execute; fixed in dingo #3025 -- see
+	// the epoch_id <= 5 delete below, which stays as a defensive measure).
 	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
@@ -66,15 +66,14 @@ func TestGetActivePoolKeyHashesOrderedMysql(t *testing.T) {
 		Attrs(models.Tip{Slot: 1_000_000}).
 		FirstOrCreate(&models.Tip{ID: 1}).Error)
 	// epoch_id 0-5 is TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql's
-	// fixture range (pool_atslot_test.go). That test's own cleanup never
-	// actually runs (same plain-defer-before-t.Cleanup ordering bug
-	// described above, pre-existing in that file and not touched here),
-	// so epoch_id 0 persists in this shared integration database with a
-	// narrow length_in_slots=100 that would make GetActivePoolKeyHashesOrdered's
+	// fixture range (pool_atslot_test.go). That test's own cleanup now runs
+	// (dingo #3025 fixed the plain-defer-before-t.Cleanup ordering bug
+	// described above, which is why it used to leave epoch_id 0 behind with
+	// a narrow length_in_slots=100 that would make GetActivePoolKeyHashesOrdered's
 	// epoch-at-tip-slot lookup pick that stale row instead of this test's
-	// and fail with ErrNoEpochData. Clearing that known range before
-	// creating our own epoch_id=0 makes this test self-sufficient
-	// regardless of that pre-existing bug or test run order.
+	// and fail with ErrNoEpochData). Clearing that known range before
+	// creating our own epoch_id=0 keeps this test self-sufficient
+	// regardless of test run order or a regression in that fix.
 	require.NoError(t, db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error)
 	require.NoError(t, db.
 		Where("epoch_id = ?", 0).

--- a/database/plugin/metadata/mysql/pool_atslot_test.go
+++ b/database/plugin/metadata/mysql/pool_atslot_test.go
@@ -18,7 +18,14 @@ import (
 // backend-specific regressions that the sqlite tests cannot.
 func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	poolA := bytes.Repeat([]byte{0xA1}, 28)
@@ -75,7 +82,14 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsMysql(t *testing.T) {
 // yields non-zero stake.
 func TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	poolA := bytes.Repeat([]byte{0xA2}, 28)
@@ -125,7 +139,14 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalanceMysql(t *testing.T) {
 // 2^53 expose MySQL's lossy implicit DOUBLE conversion.
 func TestGetStakeByPoolsPreservesIntegerPrecisionMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	pool := bytes.Repeat([]byte{0xC1}, 28)
@@ -181,7 +202,14 @@ func TestGetStakeByPoolsPreservesIntegerPrecisionMysql(t *testing.T) {
 // catching backend-specific regressions the sqlite test cannot.
 func TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationMysql(t *testing.T) {
 	store := newTestMysqlStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	pool := bytes.Repeat([]byte{0xD5}, 28)

--- a/database/plugin/metadata/postgres/pool_active_ordered_test.go
+++ b/database/plugin/metadata/postgres/pool_active_ordered_test.go
@@ -50,10 +50,10 @@ func TestGetActivePoolKeyHashesOrderedPostgres(t *testing.T) {
 	// connection closes: t.Cleanup callbacks run after every plain defer
 	// in this function body has already executed, so a plain
 	// "defer store.Close()" here would close the connection before any
-	// later-registered t.Cleanup data cleanup runs against it (that
-	// exact ordering bug is why TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres's
-	// own epoch cleanup below silently never executes -- see the epoch_id
-	// <= 5 delete below).
+	// later-registered t.Cleanup data cleanup runs against it (that exact
+	// ordering bug previously made TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres's
+	// own epoch cleanup silently never execute; fixed in dingo #3025 -- see
+	// the epoch_id <= 5 delete below, which stays as a defensive measure).
 	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
@@ -66,15 +66,14 @@ func TestGetActivePoolKeyHashesOrderedPostgres(t *testing.T) {
 		Attrs(models.Tip{Slot: 1_000_000}).
 		FirstOrCreate(&models.Tip{ID: 1}).Error)
 	// epoch_id 0-5 is TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres's
-	// fixture range (pool_atslot_test.go). That test's own cleanup never
-	// actually runs (same plain-defer-before-t.Cleanup ordering bug
-	// described above, pre-existing in that file and not touched here),
-	// so epoch_id 0 persists in this shared integration database with a
-	// narrow length_in_slots=100 that would make GetActivePoolKeyHashesOrdered's
+	// fixture range (pool_atslot_test.go). That test's own cleanup now runs
+	// (dingo #3025 fixed the plain-defer-before-t.Cleanup ordering bug
+	// described above, which is why it used to leave epoch_id 0 behind with
+	// a narrow length_in_slots=100 that would make GetActivePoolKeyHashesOrdered's
 	// epoch-at-tip-slot lookup pick that stale row instead of this test's
-	// and fail with ErrNoEpochData. Clearing that known range before
-	// creating our own epoch_id=0 makes this test self-sufficient
-	// regardless of that pre-existing bug or test run order.
+	// and fail with ErrNoEpochData). Clearing that known range before
+	// creating our own epoch_id=0 keeps this test self-sufficient
+	// regardless of test run order or a regression in that fix.
 	require.NoError(t, db.Where("epoch_id <= ?", 5).Delete(&models.Epoch{}).Error)
 	require.NoError(t, db.
 		Where("epoch_id = ?", 0).

--- a/database/plugin/metadata/postgres/pool_atslot_test.go
+++ b/database/plugin/metadata/postgres/pool_atslot_test.go
@@ -19,7 +19,14 @@ import (
 // text-encoded amount column) that the sqlite tests cannot.
 func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	poolA := bytes.Repeat([]byte{0xA1}, 28)
@@ -74,7 +81,14 @@ func TestGetStakeByPoolsAtSlotAggregatesFallbackAccountsPostgres(t *testing.T) {
 // stake query casts the text-encoded amount to BIGINT before SUM.
 func TestGetStakeByPoolsAggregatesTextAmountsPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	pool := bytes.Repeat([]byte{0xC1}, 28)
@@ -128,7 +142,14 @@ func TestGetStakeByPoolsAggregatesTextAmountsPostgres(t *testing.T) {
 // yields non-zero stake.
 func TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	poolA := bytes.Repeat([]byte{0xA2}, 28)
@@ -181,7 +202,14 @@ func TestGetStakeByPoolsAtSlotIncludesRewardBalancePostgres(t *testing.T) {
 // catching backend-specific regressions the sqlite test cannot.
 func TestGetRewardStakeInputsForPoolsUsesHistoricalExpirationPostgres(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	// Registered via t.Cleanup (not a plain defer) and ahead of the data
+	// cleanup below so LIFO ordering runs the data cleanup BEFORE the
+	// connection closes: t.Cleanup callbacks run after every plain defer
+	// in this function body has already executed, so a plain
+	// "defer store.Close()" here would close the connection before any
+	// later-registered t.Cleanup data cleanup runs against it (see
+	// dingo #3025).
+	t.Cleanup(func() { _ = store.Close() })
 	db := store.DB()
 
 	pool := bytes.Repeat([]byte{0xD5}, 28)

--- a/database/plugin/metadata/postgres/postgres_test.go
+++ b/database/plugin/metadata/postgres/postgres_test.go
@@ -657,7 +657,11 @@ func TestPostgresSetTransactionWithdrawalsClearRewardBalance(t *testing.T) {
 // the database constraint alone cannot reject these two replay rows.
 func TestPostgresConcurrentWithdrawalReplayAtDifferentSlots(t *testing.T) {
 	store := newTestPostgresStore(t)
-	defer store.Close() //nolint:errcheck
+	// t.Cleanup, not a plain defer: a plain "defer store.Close()" here would
+	// run before the "blocker" transaction's t.Cleanup rollback below (see
+	// dingo #3025). TestMysqlConcurrentWithdrawalReplayAtDifferentSlots
+	// (mysql/reward_live_stake_test.go) already uses this ordering.
+	t.Cleanup(func() { _ = store.Close() })
 
 	stakeKey := bytes.Repeat([]byte{0xE3}, lcommon.AddressHashSize)
 	txHash := bytes.Repeat([]byte{0x73}, 32)


### PR DESCRIPTION
Closes #3025

Postgres and MySQL backend tests registered their store close with a plain `defer store.Close()` and their row cleanup with a later `t.Cleanup`. Go runs every plain defer in a function before any `t.Cleanup` callback, so the connection closed first and the cleanup DELETEs then ran against a closed connection, failing silently.

Fix is the ordering: register the close through `t.Cleanup` as well, ahead of the data cleanup registration, so LIFO runs the data cleanup first and the close last.

## Scope is wider than the issue described

The issue named one test. The same shape was present in all four tests in each of `postgres/pool_atslot_test.go` and `mysql/pool_atslot_test.go`, plus `TestPostgresConcurrentWithdrawalReplayAtDifferentSlots` in `postgres/postgres_test.go`.

The other three tests in each `pool_atslot_test.go` were not visibly broken only because each uses disjoint per-test keys with no shared un-namespaced table like `epoch`, so their leaked rows never collided with anything. They were leaking all the same.

The concurrent-withdrawal case was benign before the fix: its competing `t.Cleanup` only rolled back an uncommitted lock-holding transaction that never wrote data, so the ordering had no data consequence. Changed for parity with its MySQL counterpart, which already had the correct ordering, rather than because it leaked.

## Instances deliberately left alone

`drep_test.go`, `rollback_imported_account_test.go`, `pool_test.go`, `reconcile_test.go`, `account_created_slot_test.go`, `batch_accumulator_test.go` and `options_test.go` in both backends use a plain `defer store.Close()` with no competing `t.Cleanup` in the same function, so there is no ordering hazard. Some rely on an up-front delete-existing-rows pattern instead of teardown, which is a separate longstanding convention and not this bug.

The `t.Run` subtests in `postgres_test.go` and `mysql_test.go` were checked individually: each has only a bare `defer store.Close()` with no nested `t.Cleanup`.

`reward_state_credential_test.go`, `reward_live_stake_test.go`, `stake_snapshot_test.go` and `transaction_gap_test.go` already use the correct pattern.

sqlite has no instances. Each sqlite test gets its own isolated database rather than a shared one, so the cross-test leak mechanism does not apply there even in principle.

## Verified against real containers

postgres:16 and mysql:8, removed afterwards.

Before the fix, the affected tests logged `level=ERROR msg="sql: database is closed"` for every cleanup DELETE, and `SELECT epoch_id, length_in_slots FROM epoch` afterwards showed six leftover rows (`0..5`, `length_in_slots=100`) on both backends.

After the fix, against the same already-dirty database with no manual intervention: no `database is closed` errors, and the epoch table is empty on both backends. `account`, `utxo`, `account_withdrawal_witness` and `reward_live_stake` rows for the tests staking keys are gone as well.

Full packages pass: postgres 55 tests and mysql 60 tests, zero failures, `ok ... 133.6s` and `ok ... 54.7s`. No test changed behavior once its cleanup began running, which was the main risk worth checking — a cleanup that has never run since it was written can be hiding a test that depends on its own leftovers.

## Note on the related change already on main

`pool_active_ordered_test.go` in both backends carried comments describing this bug as pre-existing and unfixed, and defensively clears `epoch_id <= 5` before seeding. The comments are updated to say it is fixed; the defensive clear stays as a hedge against run order and regression. Its own epoch teardown, added in #3024, is untouched.

## Verification

`go build ./...` and `-tags dingo_extra_plugins` clean, `go vet -tags dingo_extra_plugins ./database/plugin/metadata/...` clean, `golangci-lint run ./database/...` 0 issues, `make import-boundaries` ok.

Test-lifecycle only: no assertions, seeded values, or verified behavior changed. `DATABASE.md` and `ARCHITECTURE.md` checked and not affected — no models, migrations, query surfaces, blob layout, plugin interfaces or component boundaries touched, and `DATABASE.md` does not currently document the shared integration-test database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix test cleanup ordering for Postgres and MySQL backends by registering `store.Close` with `t.Cleanup` before data cleanup, so DELETEs run before the connection closes. This stops silent cleanup failures and cross-test data leaks; addresses #3025.

- **Bug Fixes**
  - Use `t.Cleanup(func() { _ = store.Close() })` registered before data cleanup in all `pool_atslot_test.go` tests for both Postgres and MySQL.
  - Update `pool_active_ordered_test.go` comments; keep the defensive `epoch_id <= 5` clear.
  - Make `TestPostgresConcurrentWithdrawalReplayAtDifferentSlots` use the same ordering as MySQL.
  - Verified on Postgres 16 and MySQL 8; suites pass with no behavior changes.

<sup>Written for commit 39d3eb138cbc1f4d6b1424c5393ad912c76e40ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved database test cleanup ordering to ensure cleanup callbacks run before connections close.
  * Updated MySQL and PostgreSQL tests for more reliable isolation and consistent results across repeated runs.
  * Documented fixes for historical cleanup and transaction rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->