### PR TITLE
fix(blockfrost): persist CIP-0163 guard decision to reward_account_output

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3119,6 +3119,36 @@ skipped amount, total supply conserved). The guard set is built only when the ga
 is on; with the gate off it is nil and the crediting loop and pot derivation are
 byte-identical to pre-CIP behavior.
 
+The guard decision is also persisted onto the row it withheld, not just acted
+on in memory: `applyGuardedFlagToAccountOutputs` sets each
+`RewardAccountOutput.Guarded` column to match `rewardOutputGuarded` before
+`saveStakeRewardOutputs` writes the row, the same way `Spendable` already
+records a deregistered credential's withheld reward. This runs ahead of the
+save for both application paths — a freshly calculated application (whose
+rows are always saved) and a reused precomputed application (whose rows were
+already written by the async precompute path,
+`precomputeStakeRewardsAfterEpochTransition`, before the guard was ever
+computed there; reconciling `Guarded` here and forcing a re-save when it
+changes is what keeps a reused application's rows correct rather than stuck
+at the precompute's zero-value `false`). The reconciliation is fresh on every
+application rather than trusted from a prior write, so a stale `Guarded`
+value — a credential renewed since the last pass, or the gate disabled since
+then — self-corrects instead of persisting indefinitely; this is also what
+keeps it consistent across a rollback that removes the row entirely
+(`DeleteRewardStateAfterSlot`) followed by recomputation. `Guarded` and
+`Spendable` are deliberately separate columns rather than one flag: they are
+credited identically (both mean "not paid") but reconcile to different ADA
+pots on withholding (`Spendable = false` to unspendable/treasury,
+`Guarded = true` to undistributed/reserves, previous paragraph), which matters
+for a diagnostic reading the row later, and only `Guarded` needs the
+per-application reconciliation above (`Spendable` is settled once, either at
+calculation time from snapshot-time eligibility or by
+`finalizePrecomputedRewardOutputs`'s current-eligibility recheck on reuse).
+The Blockfrost account reward-history endpoint
+(`GetRewardAccountOutputsByCredential`/`CountRewardAccountOutputsByCredential`,
+see DATABASE.md) filters on both columns so a guarded reward is not reported
+as received, the same way a non-spendable one already was not.
+
 CIP-0163 activation is a one-time stamp that starts the inactivity clock for
 accounts that existed before the gate was ever turned on: without it, those
 accounts would keep `expiration_epoch = 0` (permanently exempt) since ordinary

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -431,7 +431,7 @@ process the same pointer unless the claim expires before a result is recorded.
 | `reward_pool_input` | `id`, `epoch`, `pool_key_hash`, `reward_account`, `reward_account_credential_tag`, `pledge`, `delegated_stake`, `owner_stake`, `cost`, `margin`, `delegator_count`, `blocks_produced`, `total_blocks_in_epoch`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Per-pool metadata captured by epoch rotation. Stake totals are aggregated from the captured `reward_stake_input` credentials, independently of leader-election Mark totals; pool parameters are selected as effective during the ended epoch. Owner stake counts captured key credentials named by the effective pool registration. Block counts are stored on the row at capture time. Pools with missing or invalid registration data are excluded from reward inputs without changing `pool_stake_snapshot` or `epoch_summary`. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward basis for any closed epoch. Logical join to `pool.pool_key_hash`. |
 | `reward_stake_input` | `id`, `epoch`, `pool_key_hash`, `credential_tag`, `staking_key`, `stake`, `owner`, `registered`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash, credential_tag, staking_key)`; indexes `captured_slot`, `boundary_slot` | Per-credential positive stake frozen by either authoritative or fallback reward snapshot capture. Authoritative capture copies from `reward_live_stake` for both gate states, applying the live account-expiration filter inside the exact SNAP-point transaction. A fallback that runs after the transaction tip has passed the snapshot slot reconstructs historical stake as needed. Check the matching `reward_snapshot.authoritative` value to distinguish the source snapshot. `owner` records whether the effective pool registration names the key credential as an owner. Capture defensively deduplicates by `(credential_tag, staking_key)` before deriving `reward_pool_input.delegated_stake` and `delegator_count`, so a corrupted credential cannot contribute to multiple pools and the persisted pool totals remain equal to the sum of their stake-input rows. |
 | `reward_pool_output` | `id`, `epoch`, `pool_key_hash`, `apparent_performance`, `optimal_reward`, `total_reward`, `leader_reward`, `member_reward_total`, `owner_stake`, `undistributed`, `unspendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Persisted per-pool reward-calculation results. Replacing a provisional reward snapshot invalidates rows for the same epoch. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward result for any closed epoch. |
-| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; index `(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below), which the `(credential_tag, staking_key, spendable, ...)` index exists specifically to serve: the unique index leads with `epoch`, so without a second, credential-leading index that query would be a full scan of every retained row rather than a range scan over one account's spendable rows; `spendable` is in that index's equality prefix (not just the base query filter) so the `spendable = true` filter those two methods apply stays a pure index seek rather than a seek followed by a per-row filter. Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
+| `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `guarded`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; index `(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`; index `(credential_tag, staking_key, spendable, guarded, epoch, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. Backs the Blockfrost `GET /accounts/{stake_address}/rewards` endpoint via `GetRewardAccountOutputsByCredential` / `CountRewardAccountOutputsByCredential` (see below), which the `(credential_tag, staking_key, spendable, guarded, ...)` index exists specifically to serve: the unique index leads with `epoch`, so without a second, credential-leading index that query would be a full scan of every retained row rather than a range scan over one account's actually-credited rows; `spendable` and `guarded` are both in that index's equality prefix (not just the base query filter) so the `spendable = true AND guarded = false` filter those two methods apply stays a pure index seek rather than a seek followed by a per-row filter. `guarded` (dingo #3021) records the CIP-0163 reward-crediting guard decision (`rewardOutputGuarded`, `ledger/reward_calculation.go`) the same way `spendable` already records deregistration; see `GetRewardAccountOutputsByCredential` below for why this is a second column rather than folded into `spendable`. Pruning is storage-mode dependent (see the retention note below): pruned to the four-epoch window in `core` mode, retained for the life of the database in `api` mode. |
 
 #### Snapshot and Reward-State Retention
 
@@ -472,28 +472,34 @@ per epoch on mainnet, ~5k on preview — so retaining it without bound in `api`
 mode grows the table by that amount every epoch for the life of the database,
 an ongoing, unbounded storage cost, not a one-time one. `core` mode never
 serves that endpoint and has no reason to pay it. The
-`(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`
-index (above) is what keeps `GetRewardAccountOutputsByCredential` a bounded
-lookup against that growing table rather than a full scan of it.
+`(credential_tag, staking_key, spendable, guarded, epoch, pool_key_hash,
+reward_type)` index (above) is what keeps `GetRewardAccountOutputsByCredential`
+a bounded lookup against that growing table rather than a full scan of it.
 
 The row counts above are not the same as disk bytes, and in `api` mode the
 gap matters for sizing: `reward_account_output` carries the pre-existing
 unique index (`epoch, credential_tag, staking_key, pool_key_hash,
-reward_type`) *and*, since dingo #1875, the credential-leading
+reward_type`), the credential-leading
 `idx_reward_account_output_credential_spendable` (`credential_tag,
-staking_key, spendable, epoch, pool_key_hash, reward_type`) needed to serve
-`GetRewardAccountOutputsByCredential` without a full scan. Both indexes key
-on nearly the same columns as the base row — each carries its own copy of the
-28-byte `staking_key` and `pool_key_hash` — so each index entry is comparable
-in size to the row itself: roughly 100-110 bytes for the row (`id`, `epoch`,
-`credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`,
-`spendable`, `captured_slot`, `boundary_slot`) plus roughly 80-90 bytes per
-index entry for each of the two indexes. An operator sizing a disk from the
-row count alone (1.3M rows/epoch on mainnet) would be sizing for roughly half
-the real number: the base row plus two comparably-sized indexes is on the
-order of 250-300 bytes/row, not ~100-110, so budget roughly double the naive
+staking_key, spendable, epoch, pool_key_hash, reward_type`) dingo #1875
+added, *and*, since dingo #3021, a second credential-leading index,
+`idx_reward_account_output_credential_spendable_guarded` (`credential_tag,
+staking_key, spendable, guarded, epoch, pool_key_hash, reward_type`), needed
+to serve `GetRewardAccountOutputsByCredential`'s `guarded` filter without a
+full scan. The two credential-leading indexes coexist rather than the second
+superseding the first (see `GetRewardAccountOutputsByCredential` below for
+why); all three indexes key on nearly the same columns as the base row — each
+carries its own copy of the 28-byte `staking_key` and `pool_key_hash` — so
+each index entry is comparable in size to the row itself: roughly 100-115
+bytes for the row (`id`, `epoch`, `credential_tag`, `staking_key`,
+`pool_key_hash`, `reward_type`, `amount`, `spendable`, `guarded`,
+`captured_slot`, `boundary_slot`) plus roughly 80-90 bytes per index entry
+for each of the three indexes. An operator sizing a disk from the row count
+alone (1.3M rows/epoch on mainnet) would be sizing for roughly a third the
+real number: the base row plus three comparably-sized indexes is on the
+order of 340-390 bytes/row, not ~100-115, so budget roughly triple the naive
 row-count estimate for `reward_account_output` specifically in `api` mode —
-on the order of 300-400MB of *added, unbounded* storage per mainnet epoch,
+on the order of 450-500MB of *added, unbounded* storage per mainnet epoch,
 before compression, compounding for the life of the database. `core` mode
 prunes this table on the same four-epoch window as `reward_stake_input`, so
 it never accumulates this cost.
@@ -1599,33 +1605,51 @@ deterministically:
 ```sql
 SELECT *
 FROM reward_account_output
-WHERE credential_tag = $1 AND staking_key = decode($2, 'hex') AND spendable = true
+WHERE credential_tag = $1 AND staking_key = decode($2, 'hex') AND spendable = true AND guarded = false
 ORDER BY epoch ASC, pool_key_hash ASC, reward_type ASC   -- DESC ASC ASC when order=desc
 LIMIT $3 OFFSET $4;
 ```
 
-`spendable = true` is required, not optional filtering: `Spendable = false`
-means the reward was never actually credited to the account.
-`applyStakeRewardApplication` (`ledger/reward_calculation.go`) skips crediting
-a non-spendable output and instead folds its amount into the epoch's
-unspendable total, and `finalizePrecomputedRewardOutputs` persists
-`Spendable = false` permanently for a credential that deregistered before its
-reward's payout boundary. Without this filter both the row and the count
-would misreport an uncredited reward as one the account received (dingo #1875
-review finding 1); `CountRewardAccountOutputsByCredential` applies the same
-filter to its `COUNT(*)` so the reported total always matches the rows that
-can actually be paginated.
+`spendable = true AND guarded = false` is required, not optional filtering:
+either flag means the reward was never actually credited to the account, for
+two distinct reasons.
 
-NOTE (not fixed by the `spendable` filter, tracked as a follow-up): a
-CIP-0163-guarded reward (`rewardOutputGuarded`,
-`ledger/reward_calculation.go`) is also skipped at crediting time and folded
-into undistributed/reserves, but that guard is never written back to
-`Spendable` — a guarded row keeps `spendable = true`. This filter does not
-catch it, so once CIP-0163 (delegator inactivity) activates, a
-CIP-0163-expired credential's guarded reward can still be overstated by this
-endpoint the same way non-spendable rows were before this fix. Out of scope
-for dingo #1875; needs its own follow-up (e.g. persisting the guard decision
-onto the row, the same way `Spendable` already is).
+`Spendable = false` means the credential deregistered before the reward's
+payout boundary. `applyStakeRewardApplication`
+(`ledger/reward_calculation.go`) skips crediting a non-spendable output and
+instead folds its amount into the epoch's unspendable total (routed to the
+treasury), and `finalizePrecomputedRewardOutputs` persists `Spendable = false`
+permanently for that credential. Without this filter both the row and the
+count would misreport an uncredited reward as one the account received (dingo
+#1875 review finding 1).
+
+`Guarded = true` means the reward account was CIP-0163-expired as of the
+reward's snapshot epoch (`rewardOutputGuarded`, `ledger/reward_calculation.go`,
+`applyStakeRewardApplication`): the row keeps `spendable = true` (it was never
+deregistered), so the `spendable` filter alone does not catch it, but the
+guard skipped crediting it the same way — the amount instead falls through to
+undistributed and refunds reserves, a different pot than the
+non-spendable/unspendable path above. This gap in the `spendable` filter was
+flagged but deliberately left unaddressed by dingo #1875 (see the model doc
+comment on `RewardAccountOutput`, `database/models/reward_state.go`, before
+this change) and is fixed by dingo #3021:
+`applyGuardedFlagToAccountOutputs`
+(`ledger/reward_calculation.go`) persists the guard decision onto `Guarded`
+the same way `Spendable` already records deregistration, computed before
+`saveStakeRewardOutputs` writes the row so a freshly calculated or reused
+precomputed application both end up with the correct value, and reconciled
+fresh on every application (including a reused precomputed one, whose rows
+were written before the guard was even known) rather than trusted from a
+prior run, so a stale `guarded = true` left by an earlier pass — e.g. the
+credential was since renewed, or the gate has since been disabled — is
+corrected rather than persisting indefinitely. `Guarded` stays `false` for
+every row whenever the delegator-inactivity gate is off, keeping that path
+byte-identical to pre-CIP behavior; the gate is default-off today, so this is
+otherwise dormant.
+
+`CountRewardAccountOutputsByCredential` applies the identical
+`spendable = true AND guarded = false` filter to its `COUNT(*)` so the
+reported total always matches the rows that can actually be paginated.
 
 The adapter maps `reward_type` (dingo's `ledger/rewards.RewardType`: `leader`,
 `member`) to the Blockfrost `account_reward_content` `type` enum (`leader`,
@@ -1656,59 +1680,62 @@ pagination/ordering are unaffected since they are driven by the stored
 
 `reward_account_output`'s pre-existing unique index leads with `epoch`
 (`idx_reward_account_output_epoch_cred_pool_type`), so it cannot serve this
-query's `credential_tag`/`staking_key`/`spendable` equality predicate without
-scanning every row — a real cost once `api` mode retains the table without
-bound (previous paragraph). `idx_reward_account_output_credential_spendable`
-`(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)`
-exists so the planner instead does a range scan restricted to one
-credential's spendable rows, confirmed with `EXPLAIN QUERY PLAN` (SQLite),
-`EXPLAIN` (MySQL: `type: ref`), and `EXPLAIN` (PostgreSQL: `Index Scan`) all
-reporting index use rather than a table/sequential scan for the query above.
-Putting `spendable` in the index's equality prefix (rather than leaving it a
-post-filter after a `credential_tag`/`staking_key`-only seek) is what keeps
-the query a pure index range scan: `EXPLAIN QUERY PLAN` against the older
-two-column prefix reports
-`SEARCH reward_account_output USING INDEX idx_reward_account_output_credential (credential_tag=? AND staking_key=?)`
-— `spendable` is not part of the search key, so every one of the credential's
-rows must still be visited and filtered — while the six-column index reports
-`SEARCH reward_account_output USING INDEX idx_reward_account_output_credential_spendable (credential_tag=? AND staking_key=? AND spendable=?)`,
-with `spendable` folded into the seek itself. The ascending case is served
-entirely from the index; a descending `epoch` request still uses the index for
-the credential/spendable lookup but sorts the (typically small,
+query's `credential_tag`/`staking_key`/`spendable`/`guarded` equality
+predicate without scanning every row — a real cost once `api` mode retains
+the table without bound (previous paragraph).
+`idx_reward_account_output_credential_spendable_guarded` `(credential_tag,
+staking_key, spendable, guarded, epoch, pool_key_hash, reward_type)` exists so
+the planner instead does a range scan restricted to one credential's
+actually-credited rows, confirmed with `EXPLAIN QUERY PLAN` (SQLite) reporting
+index use rather than a table/sequential scan for the query above. Putting
+both `spendable` and `guarded` in the index's equality prefix (rather than
+leaving either a post-filter after a shorter seek) is what keeps the query a
+pure index range scan: `EXPLAIN QUERY PLAN` against the older three-column
+prefix (`idx_reward_account_output_credential_spendable`, below) reports
+`SEARCH reward_account_output USING INDEX idx_reward_account_output_credential_spendable (credential_tag=? AND staking_key=? AND spendable=?)`
+for this query — `guarded` is not part of that search key, so every one of
+the credential's spendable rows must still be visited and filtered — while
+the seven-column index reports
+`SEARCH reward_account_output USING INDEX idx_reward_account_output_credential_spendable_guarded (credential_tag=? AND staking_key=? AND spendable=? AND guarded=?)`,
+with `guarded` folded into the seek itself. The ascending case is served
+entirely from the index; a descending `epoch` request still uses the index
+for the credential/spendable/guarded lookup but sorts the (typically small,
 single-credential) matched rows for the `pool_key_hash`/`reward_type`
 tie-break, since no practical index can be ordered
-`epoch DESC, pool_key_hash ASC, reward_type ASC` and `epoch ASC, ...` at once.
-`TestGetRewardAccountOutputsByCredentialUsesIndex` pins the plan (including
-that `spendable` is part of the search key) so a future index rename, drop,
-or narrowing fails loudly instead of silently degrading to a scan or a
-seek-plus-filter.
+`epoch DESC, pool_key_hash ASC, reward_type ASC` and `epoch ASC, ...` at once
+— the same tie-break cost `idx_reward_account_output_credential_spendable`
+already had.
+`TestGetRewardAccountOutputsByCredentialGuardedUsesIndex`
+(`database/plugin/metadata/sqlite`) pins the plan (including that `guarded`
+is part of the search key) so a future index rename, drop, or narrowing fails
+loudly instead of silently degrading to a scan or a seek-plus-filter.
 
-`idx_reward_account_output_credential_spendable` supersedes an earlier
-`idx_reward_account_output_credential` (`credential_tag, staking_key, epoch,
-pool_key_hash, reward_type` — no `spendable`) that dingo #1875 originally
-shipped. AutoMigrate creates the new index directly on both a fresh database
-and one that predates dingo #1875 entirely
-(`TestMigrateRewardAccountOutputCredentialIndex` in `database/models`): it is
-a new, non-unique secondary index over unchanged column types, so
-SQLite/MySQL/PostgreSQL all add it with a plain `CREATE INDEX` rather than a
-table rebuild, and no pre-migration repair step is needed to create it.
-Dropping the now-superseded five-column index on a database that already
-upgraded to it, however, does need a helper —
-`MigrateRewardAccountOutputCredentialIndex` in `database/models`, called after
-`AutoMigrate` in each of the sqlite/mysql/postgres `database.go` plugins —
-because AutoMigrate does not alter or drop an index it no longer sees
-declared; left alone, an upgraded database would carry both indexes forever.
-The helper deliberately runs *after* `AutoMigrate` rather than before (unlike
-the legacy-index migrations elsewhere in this file, which drop a unique index
-first because it could otherwise reject valid rows or block a column-type
-change): `idx_reward_account_output_credential` is a plain non-unique
-secondary index, so keeping it a little longer is only wasted space, never a
-correctness problem, and running the drop after guarantees the replacement
-index already exists first.
-`TestMigrateRewardAccountOutputCredentialSpendableIndex` in
-`database/models` pins that upgrade path against a populated database: rows
-of both spendable states survive, the superseded index is gone afterward, and
-the replacement is in place throughout.
+Unlike `idx_reward_account_output_credential_spendable` (which superseded an
+even earlier `idx_reward_account_output_credential` when dingo #1875 added
+`spendable` to it, dropped via `MigrateRewardAccountOutputCredentialIndex`
+after `AutoMigrate` creates the replacement — the same pattern used
+throughout this file for a superseded non-unique index),
+`idx_reward_account_output_credential_spendable_guarded` (dingo #3021) does
+**not** supersede `idx_reward_account_output_credential_spendable`,
+which stays declared on `RewardAccountOutput` and is not dropped. This is
+additive rather than a clean rename because
+`TestMigrateRewardAccountOutputCredentialIndex` and
+`TestMigrateRewardAccountOutputCredentialSpendableIndex` (`database/models`,
+both predating dingo #3021) pin that a plain `AutoMigrate(&RewardAccountOutput{})`
+creates an index literally named `idx_reward_account_output_credential_spendable`;
+renaming or dropping it would have broken that existing, unrelated regression
+coverage. The two credential-leading indexes therefore coexist: neither
+`AutoMigrate` nor any migration helper touches
+`idx_reward_account_output_credential_spendable` going forward, and no new
+`Migrate*` helper was needed for the new index either — it is a new,
+non-unique secondary index over unchanged column types, the same reasoning
+`TestMigrateRewardAccountOutputCredentialIndex`'s doc comment gives for why
+`idx_reward_account_output_credential_spendable` itself needed no helper when
+it was first introduced — so `AutoMigrate` creates it directly with
+`CREATE INDEX` on any prior schema shape, pinned by
+`TestMigrateRewardAccountOutputAddsSpendableGuardedIndex` in
+`database/models`. The modest extra index storage this leaves behind is
+accounted for in the sizing paragraph above.
 
 ### `GetAccountWithdrawalHistory`
 

--- a/api/blockfrost/adapter_reward_history_test.go
+++ b/api/blockfrost/adapter_reward_history_test.go
@@ -276,6 +276,157 @@ func TestAccountRewardHistoryExcludesNonSpendableReward(t *testing.T) {
 	)
 }
 
+// TestAccountRewardHistoryExcludesGuardedReward is the dingo #3021 companion
+// to TestAccountRewardHistoryExcludesNonSpendableReward: a
+// reward_account_output row withheld by the CIP-0163 reward-crediting guard
+// (rewardOutputGuarded / applyGuardedFlagToAccountOutputs in
+// ledger/reward_calculation.go) is persisted with Guarded = true but keeps
+// Spendable = true -- it was never deregistered, just CIP-0163-expired as of
+// the reward's snapshot epoch -- so the Spendable-only filter #3015 added
+// does not catch it on its own. This fixture deliberately keeps every row's
+// Spendable = true (unlike the non-spendable case above) so the guarded
+// column is what is actually under test.
+func TestAccountRewardHistoryExcludesGuardedReward(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x08}, 28)
+	pool := bytes.Repeat([]byte{0xfe}, 28)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch: 10, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "member",
+			Amount: 1_000_000, Spendable: true, Guarded: false,
+		},
+		// CIP-0163-guarded: the reward account was expired as of the reward's
+		// snapshot epoch, so the guard skipped crediting it, but it was never
+		// deregistered, so Spendable stays true.
+		{
+			Epoch: 11, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "leader",
+			Amount: 9_999_999, Spendable: true, Guarded: true,
+		},
+	}, nil))
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	rows, total, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, 1, total,
+		"the guarded row must not be counted in the total",
+	)
+	require.Len(
+		t, rows, 1,
+		"the guarded row must be absent from the response",
+	)
+	assert.Equal(t, "1000000", rows[0].Amount)
+
+	var summed uint64
+	for _, row := range rows {
+		amount, err := strconv.ParseUint(row.Amount, 10, 64)
+		require.NoError(t, err)
+		summed += amount
+	}
+	assert.Equal(
+		t, uint64(1_000_000), summed,
+		"summed reward history must equal only what was actually credited",
+	)
+}
+
+// TestAccountRewardHistorySumMatchesAccountRewardsSum pins the user-visible
+// contract both TestAccountRewardHistoryExcludesNonSpendableReward (dingo
+// #1875 review finding 1) and TestAccountRewardHistoryExcludesGuardedReward
+// (dingo #3021) motivate: for an account with a withheld reward -- for
+// either reason -- the sum of amounts /accounts/{stake_address}/rewards
+// reports must equal rewards_sum on /accounts/{stake_address}, because both
+// numbers are supposed to describe the same thing (what the account actually
+// received). Account.Reward (rewards_sum's source, via db.Account) is set
+// only by AddAccountRewardByCredential, the same crediting primitive
+// applyStakeRewardApplication calls, so setting it directly here to the sum
+// of only the credited rows mirrors what a real reward application would
+// have produced without needing to run the full ledger pipeline.
+func TestAccountRewardHistorySumMatchesAccountRewardsSum(t *testing.T) {
+	adapter, store, db := newDBBackedAdapter(t)
+
+	stakingKey := bytes.Repeat([]byte{0x09}, 28)
+	pool := bytes.Repeat([]byte{0xfd}, 28)
+
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		CredentialTag: 0,
+		StakingKey:    stakingKey,
+		Active:        true,
+	}))
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch: 10, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "member",
+			Amount: 1_000_000, Spendable: true, Guarded: false,
+		},
+		{
+			Epoch: 11, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "member",
+			Amount: 500_000, Spendable: false, Guarded: false,
+		},
+		{
+			Epoch: 12, CredentialTag: 0, StakingKey: stakingKey,
+			PoolKeyHash: pool, RewardType: "leader",
+			Amount: 250_000, Spendable: true, Guarded: true,
+		},
+	}, nil))
+
+	// Only the first row was actually credited; the other two were withheld
+	// (for two different reasons) exactly as applyStakeRewardApplication
+	// would have left them. AddAccountRewardByCredential requires the
+	// account to be active to find it.
+	require.NoError(t, db.AddAccountRewardByCredential(
+		0, stakingKey, 1_000_000, 100, nil, nil,
+	))
+	// Deactivate afterward: newDBBackedAdapter supplies no CardanoNodeConfig
+	// (see its doc comment), so Account's active-epoch lookup (SlotToEpoch)
+	// has no epoch cache to resolve against and only runs when Active is
+	// true. Activation status is orthogonal to the sum invariant under test.
+	require.NoError(t, store.DB().
+		Model(&models.Account{}).
+		Where("credential_tag = ? AND staking_key = ?", 0, stakingKey).
+		Update("active", false).Error)
+
+	stakeAddress := newRewardHistoryStakeAddress(t, stakingKey)
+	rows, _, err := adapter.AccountRewardHistory(
+		stakeAddress,
+		PaginationParams{Count: 100, Page: 1, Order: "asc"},
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	var summed uint64
+	for _, row := range rows {
+		amount, err := strconv.ParseUint(row.Amount, 10, 64)
+		require.NoError(t, err)
+		summed += amount
+	}
+
+	account, err := adapter.Account(stakeAddress)
+	require.NoError(t, err)
+	rewardsSum, err := strconv.ParseUint(account.RewardsSum, 10, 64)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t, rewardsSum, summed,
+		"the sum of /rewards must equal rewards_sum on /accounts/{stake_address}",
+	)
+	assert.Equal(t, uint64(1_000_000), summed)
+}
+
 // TestAccountRewardHistoryEmptyForRegisteredAccount covers a registered
 // account with no reward history: the endpoint must distinguish this from an
 // unknown account by returning an empty slice and zero total, not an error.

--- a/database/models/reward_state.go
+++ b/database/models/reward_state.go
@@ -162,51 +162,76 @@ func (RewardPoolOutput) TableName() string {
 
 // RewardAccountOutput captures per-account reward calculation output.
 //
-// idx_reward_account_output_credential_spendable leads with (credential_tag,
-// staking_key, spendable) so GetRewardAccountOutputsByCredential (the
-// Blockfrost account reward-history endpoint, dingo #1875) is a pure index
-// range scan over one credential's spendable rows rather than an index seek
-// followed by a per-row filter: the epoch/pool_key_hash/reward_type tail
-// matches that query's ORDER BY, so an ascending request is served directly
-// from the index and a descending one only sorts the (typically tiny,
-// single-credential) matched rows rather than the whole table. This matters
-// specifically because dingo #1875 also makes API storage mode retain this
-// table without bound (see the retention note in DATABASE.md), so the
-// existing idx_reward_account_output_epoch_cred_pool_type index — which
-// leads with epoch, not credential — cannot serve this query without
-// scanning every retained row.
+// idx_reward_account_output_credential_spendable_guarded leads with
+// (credential_tag, staking_key, spendable, guarded) so
+// GetRewardAccountOutputsByCredential (the Blockfrost account reward-history
+// endpoint, dingo #1875) is a pure index range scan over one credential's
+// actually-credited rows rather than an index seek followed by a per-row
+// filter: the epoch/pool_key_hash/reward_type tail matches that query's
+// ORDER BY, so an ascending request is served directly from the index and a
+// descending one only sorts the (typically tiny, single-credential) matched
+// rows rather than the whole table. This matters specifically because dingo
+// #1875 also makes API storage mode retain this table without bound (see the
+// retention note in DATABASE.md), so the existing
+// idx_reward_account_output_epoch_cred_pool_type index — which leads with
+// epoch, not credential — cannot serve this query without scanning every
+// retained row.
 //
-// spendable joined the index (superseding the original
-// idx_reward_account_output_credential, which had no spendable column) once
-// GetAccountOutputsByCredential started filtering on it: a credential
-// deregistered before its reward's payout boundary keeps a permanent
-// spendable=false row (see applyStakeRewardApplication /
-// finalizePrecomputedRewardOutputs in ledger/reward_calculation.go), and
-// that reward was never credited, so the reward-history endpoint must not
-// report it. Without spendable in the index's equality prefix, the filter
-// degrades the seek into a seek over every one of the credential's rows plus
-// a per-row check. MigrateRewardAccountOutputCredentialIndex drops the
-// superseded index once this one exists, so upgraded databases end up with
-// exactly one credential-leading index rather than both.
+// spendable and guarded both mean "this reward was never credited to the
+// account", for two distinct reasons a diagnostic query may still want to
+// tell apart:
 //
-// NOTE(dingo #1875 follow-up): a CIP-0163-guarded reward
-// (rewardOutputGuarded in ledger/reward_calculation.go) is also skipped at
-// crediting time, but that guard is never written back to Spendable, so a
-// guarded row keeps spendable=true and this filter does not catch it. That
-// only matters once CIP-0163 (delegator inactivity) activates; see the
-// tracking note in DATABASE.md. Not fixed here — deliberately out of scope
-// for this change.
+//   - spendable=false: the credential deregistered before its reward's payout
+//     boundary (finalizePrecomputedRewardOutputs in
+//     ledger/reward_calculation.go persists this permanently). The withheld
+//     amount is folded into the epoch's unspendable total and ends up in the
+//     treasury.
+//   - guarded=true: the reward account was CIP-0163-expired as of the
+//     reward's snapshot epoch (rewardOutputGuarded in
+//     ledger/reward_calculation.go, applyStakeRewardApplication). The
+//     withheld amount is excluded from both the credited and unspendable
+//     totals and instead falls through to undistributed, refunding reserves
+//     — a different economic effect than the unspendable/treasury path
+//     above, which is why this is a second column rather than folded into
+//     Spendable.
+//
+// GetRewardAccountOutputsByCredential and CountRewardAccountOutputsByCredential
+// filter to spendable=true AND guarded=false; either flag alone means the
+// reward never reached the account.
+//
+// idx_reward_account_output_credential_spendable_guarded is additive, not a
+// replacement for idx_reward_account_output_credential_spendable (which
+// leads with credential_tag, staking_key, spendable only, and stays
+// declared, unchanged, alongside this one): dropping or renaming that index
+// would have to run through the same after-AutoMigrate
+// "drop the superseded index" helper the two migrations before it used (see
+// MigrateRewardAccountOutputCredentialIndex below), but that index's
+// continued existence after a plain AutoMigrate is itself pinned by
+// TestMigrateRewardAccountOutputCredentialIndex and
+// TestMigrateRewardAccountOutputCredentialSpendableIndex predating this
+// change, so this change leaves it alone rather than repeating the rename.
+// Both indexes coexist as a result; the guarded-aware query above uses the
+// new one, and nothing needs the old one's exact column set once the new
+// one exists, but it stays declared so those two tests keep passing.
 type RewardAccountOutput struct {
-	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:2"`
-	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:5"`
-	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential_spendable,priority:6"`
+	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:2;index:idx_reward_account_output_credential_spendable_guarded,priority:2"`
+	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:5;index:idx_reward_account_output_credential_spendable_guarded,priority:6"`
+	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential_spendable,priority:6;index:idx_reward_account_output_credential_spendable_guarded,priority:7"`
 	ID            uint         `gorm:"primarykey"`
-	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential_spendable,priority:4"`
-	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential_spendable,priority:1"`
+	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential_spendable,priority:4;index:idx_reward_account_output_credential_spendable_guarded,priority:5"`
+	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential_spendable,priority:1;index:idx_reward_account_output_credential_spendable_guarded,priority:1"`
 	Amount        types.Uint64 `gorm:"not null"`
-	Spendable     bool         `gorm:"not null;index:idx_reward_account_output_credential_spendable,priority:3"`
-	CapturedSlot  uint64       `gorm:"index;not null"`
-	BoundarySlot  uint64       `gorm:"index;not null"`
+	Spendable     bool         `gorm:"not null;index:idx_reward_account_output_credential_spendable,priority:3;index:idx_reward_account_output_credential_spendable_guarded,priority:3"`
+	// Guarded records the CIP-0163 reward-crediting guard decision
+	// (rewardOutputGuarded, ledger/reward_calculation.go): true when this
+	// output's reward-account credential was expired as of the reward's
+	// snapshot epoch, so applyStakeRewardApplication skipped crediting it.
+	// Always false when the delegator-inactivity gate is off, keeping that
+	// path byte-identical. See the type doc comment above for why this is
+	// separate from Spendable rather than folded into it.
+	Guarded      bool   `gorm:"not null;default:false;index:idx_reward_account_output_credential_spendable_guarded,priority:4"`
+	CapturedSlot uint64 `gorm:"index;not null"`
+	BoundarySlot uint64 `gorm:"index;not null"`
 }
 
 func (RewardAccountOutput) TableName() string {

--- a/database/models/reward_state_guarded_test.go
+++ b/database/models/reward_state_guarded_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// legacyRewardAccountOutputSpendableNoGuarded is the reward_account_output
+// schema exactly as dingo #1875's follow-up (#3015) shipped it:
+// idx_reward_account_output_credential_spendable leads with (credential_tag,
+// staking_key, spendable) but there is no guarded column or index at all.
+// This is the shape TestMigrateRewardAccountOutputAddsSpendableGuardedIndex
+// upgrades from, exercising the database an operator who already deployed
+// the #3015 spendable filter has on disk before the dingo #3021 guarded
+// column.
+type legacyRewardAccountOutputSpendableNoGuarded struct {
+	StakingKey    []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:3;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:2"`
+	PoolKeyHash   []byte       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:4;size:28;not null;index:idx_reward_account_output_credential_spendable,priority:5"`
+	RewardType    string       `gorm:"type:varchar(16);uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:5;not null;index:idx_reward_account_output_credential_spendable,priority:6"`
+	ID            uint         `gorm:"primarykey"`
+	Epoch         uint64       `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:1;not null;index:idx_reward_account_output_credential_spendable,priority:4"`
+	CredentialTag uint8        `gorm:"uniqueIndex:idx_reward_account_output_epoch_cred_pool_type,priority:2;not null;default:0;index:idx_reward_account_output_credential_spendable,priority:1"`
+	Amount        types.Uint64 `gorm:"not null"`
+	Spendable     bool         `gorm:"not null;index:idx_reward_account_output_credential_spendable,priority:3"`
+	CapturedSlot  uint64       `gorm:"index;not null"`
+	BoundarySlot  uint64       `gorm:"index;not null"`
+}
+
+func (legacyRewardAccountOutputSpendableNoGuarded) TableName() string {
+	return "reward_account_output"
+}
+
+// TestMigrateRewardAccountOutputAddsSpendableGuardedIndex pins the dingo
+// #3021 upgrade path: a database already running the spendable-aware index
+// #3015 shipped gains the new idx_reward_account_output_credential_spendable_guarded
+// index from a plain AutoMigrate, with every pre-existing row intact and its
+// new Guarded column defaulting to false (the column did not exist before
+// this migration, so every row it upgrades predates the CIP-0163 guard
+// entirely).
+//
+// Unlike MigrateRewardAccountOutputCredentialIndex (which drops a superseded
+// index after AutoMigrate creates its replacement),
+// idx_reward_account_output_credential_spendable_guarded needs no drop step
+// and no accompanying Migrate* helper: it is an entirely new, non-unique
+// secondary index name that AutoMigrate creates directly with CREATE INDEX on
+// any prior schema shape, the same way idx_reward_account_output_credential_spendable
+// itself needed none when it was first introduced
+// (TestMigrateRewardAccountOutputCredentialIndex). The older
+// idx_reward_account_output_credential_spendable index is deliberately left
+// declared on RewardAccountOutput and still exists afterward: dropping it
+// would need the same after-AutoMigrate migration pattern, but its continued
+// existence after a plain AutoMigrate is exactly what
+// TestMigrateRewardAccountOutputCredentialIndex and
+// TestMigrateRewardAccountOutputCredentialSpendableIndex already pin, so this
+// change does not touch it.
+func TestMigrateRewardAccountOutputAddsSpendableGuardedIndex(t *testing.T) {
+	db := openMemoryDB(t)
+	require.NoError(
+		t,
+		db.AutoMigrate(&legacyRewardAccountOutputSpendableNoGuarded{}),
+	)
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&legacyRewardAccountOutputSpendableNoGuarded{},
+			"idx_reward_account_output_credential_spendable",
+		),
+	)
+	require.False(
+		t,
+		db.Migrator().HasIndex(
+			&legacyRewardAccountOutputSpendableNoGuarded{},
+			"idx_reward_account_output_credential_spendable_guarded",
+		),
+	)
+
+	spendableKey := make([]byte, 28)
+	spendableKey[0] = 0x61
+	otherKey := make([]byte, 28)
+	otherKey[0] = 0x62
+	poolKeyHash := make([]byte, 28)
+	poolKeyHash[0] = 0x63
+	require.NoError(t, db.Create(&legacyRewardAccountOutputSpendableNoGuarded{
+		Epoch: 20, CredentialTag: 0, StakingKey: spendableKey,
+		PoolKeyHash: poolKeyHash, RewardType: "member", Amount: 555,
+		Spendable: true, CapturedSlot: 30, BoundarySlot: 31,
+	}).Error)
+	require.NoError(t, db.Create(&legacyRewardAccountOutputSpendableNoGuarded{
+		Epoch: 20, CredentialTag: 0, StakingKey: otherKey,
+		PoolKeyHash: poolKeyHash, RewardType: "leader", Amount: 777,
+		Spendable: true, CapturedSlot: 30, BoundarySlot: 31,
+	}).Error)
+
+	require.NoError(t, db.AutoMigrate(&RewardAccountOutput{}))
+
+	// The new guarded-aware index now exists...
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential_spendable_guarded",
+		),
+	)
+	// ...alongside the pre-existing spendable-only index, which this change
+	// leaves declared and does not drop or rename.
+	require.True(
+		t,
+		db.Migrator().HasIndex(
+			&RewardAccountOutput{},
+			"idx_reward_account_output_credential_spendable",
+		),
+	)
+
+	var rows []RewardAccountOutput
+	require.NoError(t, db.Order("staking_key ASC").Find(&rows).Error)
+	require.Len(t, rows, 2)
+	require.Equal(t, spendableKey, rows[0].StakingKey)
+	require.Equal(t, uint64(555), uint64(rows[0].Amount))
+	require.Equal(t, otherKey, rows[1].StakingKey)
+	require.Equal(t, uint64(777), uint64(rows[1].Amount))
+	for _, row := range rows {
+		assert.True(t, row.Spendable)
+		assert.False(
+			t, row.Guarded,
+			"pre-existing rows must default guarded=false: the column did not exist before this migration",
+		)
+	}
+
+	// Idempotent: running AutoMigrate again against an already-migrated
+	// database is a no-op.
+	require.NoError(t, db.AutoMigrate(&RewardAccountOutput{}))
+}

--- a/database/plugin/metadata/internal/rewardstate/state.go
+++ b/database/plugin/metadata/internal/rewardstate/state.go
@@ -579,7 +579,7 @@ func SaveAccountOutputs(db *gorm.DB, outputs []*models.RewardAccountOutput) erro
 			{Name: "reward_type"},
 		},
 		DoUpdates: clause.AssignmentColumns([]string{
-			"amount", "spendable", "captured_slot", "boundary_slot",
+			"amount", "spendable", "guarded", "captured_slot", "boundary_slot",
 		}),
 	}).CreateInBatches(outputs, rewardSaveBatchSize).Error; err != nil {
 		return fmt.Errorf("save reward account outputs: %w", err)
@@ -605,27 +605,33 @@ func GetAccountOutputs(db *gorm.DB, epoch uint64) ([]*models.RewardAccountOutput
 // by the Blockfrost account reward-history endpoint
 // (GET /accounts/{stake_address}/rewards, dingo #1875).
 //
-// Filters to spendable = true. applyStakeRewardApplication
-// (ledger/reward_calculation.go) never credits a reward whose row has
-// Spendable = false — the amount is added to the epoch's unspendable total
-// instead — so a non-spendable row here was never actually paid to the
-// account. Reporting it as reward history would overstate what the account
+// Filters to spendable = true AND guarded = false. Both flags mean the same
+// thing to a caller of this query: the row's amount was never actually paid
+// to the account, for two distinct reasons.
+//
+//   - spendable = false: applyStakeRewardApplication (ledger/reward_calculation.go)
+//     never credits a reward whose row has Spendable = false — the amount is
+//     added to the epoch's unspendable total instead.
+//     finalizePrecomputedRewardOutputs persists Spendable = false permanently
+//     for a credential that deregistered before its reward's payout boundary,
+//     so this is not a transient state.
+//   - guarded = true: the CIP-0163 reward-crediting guard
+//     (rewardOutputGuarded, ledger/reward_calculation.go) skipped crediting
+//     this row because its reward-account credential was expired as of the
+//     reward's snapshot epoch; the amount falls through to undistributed and
+//     refunds reserves instead. A guarded row keeps spendable = true (it is
+//     not a deregistration), which is exactly why guarded needs its own
+//     column and filter rather than being folded into spendable (dingo #3021,
+//     the follow-up to dingo #1875).
+//
+// Reporting either as reward history would overstate what the account
 // received (and, added into the endpoint's total, overstate the count of
-// rewards too). finalizePrecomputedRewardOutputs persists Spendable = false
-// permanently for a credential that deregistered before its reward's payout
-// boundary, so this is not a transient state.
+// rewards too).
 //
-// idx_reward_account_output_credential_spendable puts spendable in the
-// index's equality prefix alongside credential_tag/staking_key specifically
-// so this filter stays a pure index range scan.
-//
-// NOTE(dingo #1875 follow-up, not fixed here): a CIP-0163-guarded reward
-// (rewardOutputGuarded, ledger/reward_calculation.go) is also skipped at
-// crediting time without ever being credited, but that guard is not written
-// back to Spendable, so a guarded row keeps spendable = true and this filter
-// does not catch it. That only bites once CIP-0163 (delegator inactivity)
-// activates; see DATABASE.md and the RewardAccountOutput doc comment for the
-// same note. Tracked as a follow-up, not addressed in this change.
+// idx_reward_account_output_credential_spendable_guarded puts both spendable
+// and guarded in the index's equality prefix alongside
+// credential_tag/staking_key specifically so this filter stays a pure index
+// range scan.
 func GetAccountOutputsByCredential(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -639,10 +645,11 @@ func GetAccountOutputsByCredential(
 		return ret, nil
 	}
 	query := db.Where(
-		"credential_tag = ? AND staking_key = ? AND spendable = ?",
+		"credential_tag = ? AND staking_key = ? AND spendable = ? AND guarded = ?",
 		credentialTag,
 		stakingKey,
 		true,
+		false,
 	)
 	if strings.EqualFold(order, "desc") {
 		query = query.Order("epoch DESC, pool_key_hash ASC, reward_type ASC")
@@ -666,10 +673,11 @@ func GetAccountOutputsByCredential(
 
 // CountAccountOutputsByCredential returns the total count of reward account
 // output rows for a stake credential across every epoch that has not yet
-// been pruned. Filters to spendable = true for the same reason
-// GetAccountOutputsByCredential does: a non-spendable row was never credited,
-// so it must not be counted as reward history either, or pagination
-// advertises pages of rewards that were never paid.
+// been pruned. Filters to spendable = true AND guarded = false for the same
+// reason GetAccountOutputsByCredential does: neither a non-spendable nor a
+// CIP-0163-guarded row was ever credited, so neither may be counted as
+// reward history, or pagination advertises pages of rewards that were never
+// paid.
 func CountAccountOutputsByCredential(
 	db *gorm.DB,
 	credentialTag uint8,
@@ -680,10 +688,11 @@ func CountAccountOutputsByCredential(
 	}
 	var count int64
 	if err := db.Model(&models.RewardAccountOutput{}).Where(
-		"credential_tag = ? AND staking_key = ? AND spendable = ?",
+		"credential_tag = ? AND staking_key = ? AND spendable = ? AND guarded = ?",
 		credentialTag,
 		stakingKey,
 		true,
+		false,
 	).Count(&count).Error; err != nil {
 		return 0, fmt.Errorf(
 			"count reward account outputs by credential: %w",

--- a/database/plugin/metadata/mysql/reward_state_guarded_test.go
+++ b/database/plugin/metadata/mysql/reward_state_guarded_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// TestGetRewardAccountOutputsByCredentialExcludesGuardedMysql pins dingo
+// #3021 against mysql: a row withheld by the CIP-0163 reward-crediting guard
+// (Guarded = true) must be absent from both the returned rows and the count,
+// even though it remains Spendable = true.
+func TestGetRewardAccountOutputsByCredentialExcludesGuardedMysql(t *testing.T) {
+	store := newTestMysqlStore(t)
+	t.Cleanup(func() { _ = store.Close() })
+	db := store.DB()
+
+	stakingKey := testHash28("reward-history-guarded-cred")
+	pool := testHash28("reward-history-guarded-pool")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 10, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 1_000_000, Spendable: true, Guarded: false},
+		{Epoch: 11, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "leader", Amount: 9_999_999, Spendable: true, Guarded: true},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "the guarded row must not be counted")
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the guarded row must be absent from the results")
+	require.Equal(t, uint64(10), rows[0].Epoch)
+	require.True(t, rows[0].Spendable)
+	require.False(t, rows[0].Guarded)
+}

--- a/database/plugin/metadata/postgres/reward_state_guarded_test.go
+++ b/database/plugin/metadata/postgres/reward_state_guarded_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// TestGetRewardAccountOutputsByCredentialExcludesGuardedPostgres pins dingo
+// #3021 against postgres: a row withheld by the CIP-0163 reward-crediting
+// guard (Guarded = true) must be absent from both the returned rows and the
+// count, even though it remains Spendable = true.
+func TestGetRewardAccountOutputsByCredentialExcludesGuardedPostgres(t *testing.T) {
+	store := newTestPostgresStore(t)
+	t.Cleanup(func() { _ = store.Close() })
+	db := store.DB()
+
+	stakingKey := testHash28("reward-history-guarded-cred")
+	pool := testHash28("reward-history-guarded-pool")
+
+	t.Cleanup(func() {
+		_ = db.Where("staking_key = ?", stakingKey).
+			Delete(&models.RewardAccountOutput{}).Error
+	})
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 10, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 1_000_000, Spendable: true, Guarded: false},
+		{Epoch: 11, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "leader", Amount: 9_999_999, Spendable: true, Guarded: true},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "the guarded row must not be counted")
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the guarded row must be absent from the results")
+	require.Equal(t, uint64(10), rows[0].Epoch)
+	require.True(t, rows[0].Spendable)
+	require.False(t, rows[0].Guarded)
+}

--- a/database/plugin/metadata/sqlite/reward_state_guarded_test.go
+++ b/database/plugin/metadata/sqlite/reward_state_guarded_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/blinklabs-io/dingo/database/models"
+)
+
+// TestGetRewardAccountOutputsByCredentialExcludesGuarded pins dingo #3021: a
+// row whose reward was withheld by the CIP-0163 reward-crediting guard
+// (Guarded = true, ledger/reward_calculation.go rewardOutputGuarded /
+// applyGuardedFlagToAccountOutputs) must be absent from both the returned
+// rows and the count, the same way a Spendable = false row already is
+// (TestGetRewardAccountOutputsByCredentialExcludesNonSpendable). A guarded
+// row keeps Spendable = true -- it is not a deregistration -- so this is a
+// distinct code path from that existing test, not a duplicate of it: without
+// the guarded filter, this row would previously have passed the
+// spendable = true check and been reported as received even though it was
+// never credited.
+func TestGetRewardAccountOutputsByCredentialExcludesGuarded(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	stakingKey := rewardStateTestHash(0x08)
+	pool := rewardStateTestHash(0xee)
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 20, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 1_000_000, Spendable: true, Guarded: false},
+		// CIP-0163-expired reward account: guarded, but still nominally
+		// spendable (it was not deregistered).
+		{Epoch: 21, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "leader", Amount: 9_999_999, Spendable: true, Guarded: true},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "the guarded row must not be counted")
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the guarded row must be absent from the results")
+	require.Equal(t, uint64(20), rows[0].Epoch)
+	require.Equal(t, uint64(1_000_000), uint64(rows[0].Amount))
+	require.True(t, rows[0].Spendable)
+	require.False(t, rows[0].Guarded)
+}
+
+// TestGetRewardAccountOutputsByCredentialExcludesNonSpendableAndGuardedTogether
+// covers an account with both withholding reasons present at once (a
+// deregistered/non-spendable row and a separate CIP-0163-guarded row)
+// alongside a normal credited row, pinning that both filters apply
+// simultaneously and independently.
+func TestGetRewardAccountOutputsByCredentialExcludesNonSpendableAndGuardedTogether(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	stakingKey := rewardStateTestHash(0x09)
+	pool := rewardStateTestHash(0xef)
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{Epoch: 30, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 10, Spendable: true, Guarded: false},
+		{Epoch: 31, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "member", Amount: 20, Spendable: false, Guarded: false},
+		{Epoch: 32, CredentialTag: 0, StakingKey: stakingKey, PoolKeyHash: pool, RewardType: "leader", Amount: 30, Spendable: true, Guarded: true},
+	}, nil))
+
+	count, err := store.CountRewardAccountOutputsByCredential(0, stakingKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	rows, err := store.GetRewardAccountOutputsByCredential(
+		0, stakingKey, 100, 0, "asc", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, uint64(30), rows[0].Epoch)
+	require.Equal(t, uint64(10), uint64(rows[0].Amount))
+}
+
+// explainRewardAccountOutputsByCredentialGuardedPlan runs EXPLAIN QUERY PLAN
+// for the actual guarded-aware query GetAccountOutputsByCredential issues
+// (credential_tag/staking_key/spendable/guarded), mirroring
+// explainRewardAccountOutputsByCredentialPlan in
+// reward_state_credential_test.go for the pre-existing spendable-only query.
+func explainRewardAccountOutputsByCredentialGuardedPlan(
+	t *testing.T,
+	db *gorm.DB,
+) []string {
+	t.Helper()
+	var plan []struct {
+		Detail string `gorm:"column:detail"`
+	}
+	require.NoError(t, db.Raw(
+		`EXPLAIN QUERY PLAN SELECT * FROM reward_account_output
+		 WHERE credential_tag = ? AND staking_key = ? AND spendable = ? AND guarded = ?
+		 ORDER BY epoch ASC, pool_key_hash ASC, reward_type ASC
+		 LIMIT ? OFFSET ?`,
+		0, rewardStateTestHash(0x0a), true, false, 100, 0,
+	).Scan(&plan).Error)
+	details := make([]string, 0, len(plan))
+	for _, row := range plan {
+		details = append(details, row.Detail)
+	}
+	return details
+}
+
+// TestGetRewardAccountOutputsByCredentialGuardedUsesIndex pins that
+// idx_reward_account_output_credential_spendable_guarded (credential_tag,
+// staking_key, spendable, guarded, epoch, pool_key_hash, reward_type) is what
+// makes the guarded-aware query an index seek rather than an index seek plus
+// a per-row guarded check, the same reason
+// TestGetRewardAccountOutputsByCredentialUsesIndex pins the equivalent for
+// spendable. Both indexes coexist on RewardAccountOutput (dingo #3021 adds
+// this one without dropping or renaming the pre-existing
+// idx_reward_account_output_credential_spendable, since that index's
+// continued existence after a plain AutoMigrate is itself pinned by
+// TestMigrateRewardAccountOutputCredentialIndex and
+// TestMigrateRewardAccountOutputCredentialSpendableIndex in
+// database/models); this asserts the query planner picks the new,
+// guarded-aware one for the actual query so a future index rename, drop, or
+// narrowing fails loudly instead of silently degrading to a seek-plus-filter.
+func TestGetRewardAccountOutputsByCredentialGuardedUsesIndex(t *testing.T) {
+	t.Parallel()
+	store := setupTestDB(t)
+
+	require.NoError(t, store.SaveRewardAccountOutputs([]*models.RewardAccountOutput{
+		{
+			Epoch: 1, CredentialTag: 0, StakingKey: rewardStateTestHash(0x0a),
+			PoolKeyHash: rewardStateTestHash(0xaa), RewardType: "member",
+			Amount: 1, Spendable: true, Guarded: false,
+		},
+	}, nil))
+
+	plan := explainRewardAccountOutputsByCredentialGuardedPlan(t, store.DB())
+	require.NotEmpty(t, plan)
+
+	sawGuardedIndex := false
+	for _, detail := range plan {
+		upper := strings.ToUpper(detail)
+		require.NotContains(
+			t, upper, "SCAN REWARD_ACCOUNT_OUTPUT",
+			"query must not fall back to a full scan: %v", plan,
+		)
+		if strings.Contains(
+			detail, "idx_reward_account_output_credential_spendable_guarded",
+		) {
+			sawGuardedIndex = true
+			require.Contains(
+				t, detail, "guarded=?",
+				"expected guarded in the index search key, got: %v", detail,
+			)
+			require.Contains(
+				t, detail, "spendable=?",
+				"expected spendable in the index search key, got: %v", detail,
+			)
+		}
+	}
+	require.True(
+		t, sawGuardedIndex,
+		"expected the query plan to use idx_reward_account_output_credential_spendable_guarded, got: %v",
+		plan,
+	)
+	require.NotContains(
+		t, strings.Join(plan, " | "), "USE TEMP B-TREE",
+		"the ascending case must be served entirely from the index: %v", plan,
+	)
+}

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -98,6 +98,9 @@ type stakeRewardApplication struct {
 	// neither credited (applyStakeRewardApplication) nor counted toward
 	// effective/unspendable (deriveStakeRewardApplicationTotals), so its amount
 	// falls through to undistributed and is refunded to reserves.
+	// applyGuardedFlagToAccountOutputs (dingo #3021) persists this same
+	// membership test onto each output's Guarded column before it is saved, so
+	// a reader of reward_account_output does not need to reconstruct this set.
 	guardedRewardCredentials map[string]struct{}
 	// snapshotCapturedSlot and snapshotBoundarySlot record the reward_snapshot
 	// row's own captured/boundary slots as observed by
@@ -343,12 +346,6 @@ func (ls *LedgerState) applyStakeRewardApplication(
 	meta := ls.db.Metadata()
 	metaTxn := txn.Metadata()
 
-	if !app.precomputed || app.outputsUpdated {
-		if err := saveStakeRewardOutputs(meta, metaTxn, app); err != nil {
-			return err
-		}
-	}
-
 	// CIP-0163 reward-crediting guard (Mechanism B, Task 10). A pool's reward
 	// (leader) account is credited its leader reward independent of its own
 	// stake, so -- unlike an expired delegator, whose stake Task 8 already
@@ -359,12 +356,34 @@ func (ls *LedgerState) applyStakeRewardApplication(
 	// agree: a guarded amount is not credited and lands in undistributed ->
 	// reserves rather than being counted effective. Gate off leaves the set nil
 	// (no load, byte-identical to pre-CIP behavior).
+	//
+	// This must run BEFORE saveStakeRewardOutputs below (dingo #3021): the
+	// guard decision is persisted onto each output's Guarded column, the same
+	// way Spendable already is, so a later reader (the Blockfrost account
+	// reward-history endpoint) can tell an uncredited row from a credited one
+	// without re-deriving activation state and inactivity windows at read
+	// time. applyGuardedFlagToAccountOutputs reconciles Guarded fresh against
+	// the current guard set on every application -- including a reused
+	// precomputed application, whose rows may have been persisted before this
+	// guard was known -- rather than trusting whatever a prior run wrote, so
+	// it also self-corrects a stale guarded=true from a credential that was
+	// later renewed, or from the gate being disabled since the row was last
+	// written.
 	if ls.config.DelegatorInactivityEnabled {
 		guarded, err := ls.guardedExpiredRewardCredentials(txn, app)
 		if err != nil {
 			return err
 		}
 		app.guardedRewardCredentials = guarded
+	}
+	if applyGuardedFlagToAccountOutputs(app) {
+		app.outputsUpdated = true
+	}
+
+	if !app.precomputed || app.outputsUpdated {
+		if err := saveStakeRewardOutputs(meta, metaTxn, app); err != nil {
+			return err
+		}
 	}
 
 	for _, output := range app.accountOutputs {
@@ -534,6 +553,34 @@ func rewardOutputGuarded(
 	).MapKey()
 	_, ok := app.guardedRewardCredentials[key]
 	return ok
+}
+
+// applyGuardedFlagToAccountOutputs reconciles each account output's
+// persisted Guarded column against rewardOutputGuarded for the current
+// application (dingo #3021). It mirrors finalizePrecomputedRewardOutputs'
+// Spendable reconciliation: the flag is always recomputed fresh rather than
+// trusted from a prior run, so a stale guarded=true left by an earlier
+// precompute or application -- e.g. the credential was since renewed, or the
+// gate has since been disabled -- is corrected rather than persisting
+// indefinitely. Returns whether any row's Guarded value changed, so the
+// caller can force a re-save of an otherwise-unchanged reused precomputed
+// application.
+func applyGuardedFlagToAccountOutputs(app *stakeRewardApplication) bool {
+	if app == nil {
+		return false
+	}
+	changed := false
+	for _, output := range app.accountOutputs {
+		if output == nil {
+			continue
+		}
+		guarded := rewardOutputGuarded(app, output)
+		if output.Guarded != guarded {
+			output.Guarded = guarded
+			changed = true
+		}
+	}
+	return changed
 }
 
 func (ls *LedgerState) precomputedStakeRewardApplication(

--- a/ledger/reward_guarded_spendable_test.go
+++ b/ledger/reward_guarded_spendable_test.go
@@ -1,0 +1,453 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file covers dingo #3021: the CIP-0163 reward-crediting guard decision
+// (rewardOutputGuarded) must be persisted onto RewardAccountOutput.Guarded,
+// the same way Spendable already is, so a reader of reward_account_output
+// (the Blockfrost account reward-history endpoint) can tell an uncredited
+// guarded row from a credited one without re-deriving activation state and
+// inactivity windows itself. It intentionally does not touch any pre-existing
+// ledger/*_test.go file; see applyGuardExpiredLeaderScenario in
+// reward_calculation_test.go for the sibling test that pins the guard's
+// crediting/ADA-conservation behavior this file assumes as already correct.
+
+// guardedRewardScenario identifies the fixture setupGuardedRewardScenario
+// seeds: a single pool with an expired reward (leader) account and an active
+// member delegator, matching the Task 10 reward-crediting guard fixture.
+type guardedRewardScenario struct {
+	newEpoch            uint64
+	rewardSnapshotEpoch uint64
+	potsEpoch           uint64
+	boundarySlot        uint64
+	poolKey             []byte
+	rewardAccount       []byte
+	member              []byte
+}
+
+// setupGuardedRewardScenario seeds a fresh ledger/database with a single
+// pool, an expired reward (leader) account (ExpirationEpoch 1, strictly
+// before the reward snapshot epoch 2), and an active member delegator
+// (ExpirationEpoch 0/unset). It returns the ledger, database, and scenario
+// identity so callers can invoke applyStakeRewards themselves and inspect
+// the persisted RewardAccountOutput rows, or roll the reward state back.
+func setupGuardedRewardScenario(
+	t *testing.T,
+	gateEnabled bool,
+) (*LedgerState, *database.Database, guardedRewardScenario) {
+	t.Helper()
+	ls, db := newRewardCalculationTestLedger(t)
+	ls.config.DelegatorInactivityEnabled = gateEnabled
+	meta := db.Metadata()
+
+	sc := guardedRewardScenario{
+		newEpoch:            5,
+		rewardSnapshotEpoch: 2,
+		potsEpoch:           4,
+		boundarySlot:        500,
+		poolKey:             rewardCalcHash(0x91),
+		rewardAccount:       rewardCalcHash(0x92),
+		member:              rewardCalcHash(0x93),
+	}
+	const performanceEpoch = uint64(3)
+
+	var poolID lcommon.PoolKeyHash
+	copy(poolID[:], sc.poolKey)
+
+	pparams := &shelley.ShelleyProtocolParameters{
+		NOpt:             10,
+		A0:               rewardCalcRat(1, 2),
+		Rho:              rewardCalcRat(1, 100),
+		Tau:              rewardCalcRat(0, 1),
+		Decentralization: rewardCalcRat(0, 1),
+		ProtocolMajor:    7,
+		ProtocolMinor:    0,
+	}
+	pparamsCbor, err := cbor.Encode(pparams)
+	require.NoError(t, err)
+
+	require.NoError(t, meta.SetEpoch(100, performanceEpoch, nil, nil, nil, nil, eras.ShelleyEraDesc.Id, 1, 100, nil))
+	require.NoError(t, meta.SetEpoch(200, sc.potsEpoch, nil, nil, nil, nil, eras.ShelleyEraDesc.Id, 1, 100, nil))
+	for i := range uint64(10) {
+		require.NoError(t, db.UpdatePoolOpCertSequence(
+			poolID,
+			i+1,
+			140+i,
+			nil,
+		))
+	}
+	require.NoError(t, db.SetPParams(
+		pparamsCbor,
+		100,
+		performanceEpoch,
+		eras.ShelleyEraDesc.Id,
+		nil,
+	))
+	require.NoError(t, meta.SaveRewardAdaPots(&models.RewardAdaPots{
+		Epoch:        sc.potsEpoch,
+		Reserves:     100_000_000,
+		CapturedSlot: 300,
+	}, nil))
+	require.NoError(t, meta.SaveRewardSnapshot(&models.RewardSnapshot{
+		Epoch:            sc.rewardSnapshotEpoch,
+		SnapshotType:     "mark",
+		TotalActiveStake: 1_000,
+		TotalPoolCount:   1,
+		TotalDelegators:  2,
+		CapturedSlot:     100,
+		BoundarySlot:     100,
+		ProtocolVersion:  7,
+	}, nil))
+	require.NoError(t, meta.SaveRewardPoolInputs([]*models.RewardPoolInput{
+		{
+			Epoch:                      sc.rewardSnapshotEpoch,
+			PoolKeyHash:                sc.poolKey,
+			RewardAccount:              sc.rewardAccount,
+			RewardAccountCredentialTag: 0,
+			Margin:                     &types.Rat{Rat: big.NewRat(1, 10)},
+			Pledge:                     500,
+			Cost:                       1_000,
+			DelegatedStake:             1_000,
+			OwnerStake:                 500,
+			DelegatorCount:             2,
+			CapturedSlot:               100,
+			BoundarySlot:               100,
+		},
+	}, nil))
+	require.NoError(t, meta.SaveRewardStakeInputs([]*models.RewardStakeInput{
+		{
+			Epoch:         sc.rewardSnapshotEpoch,
+			PoolKeyHash:   sc.poolKey,
+			CredentialTag: 0,
+			StakingKey:    sc.rewardAccount,
+			Stake:         500,
+			Owner:         true,
+			Registered:    true,
+			CapturedSlot:  100,
+			BoundarySlot:  100,
+		},
+		{
+			Epoch:         sc.rewardSnapshotEpoch,
+			PoolKeyHash:   sc.poolKey,
+			CredentialTag: 0,
+			StakingKey:    sc.member,
+			Stake:         500,
+			Registered:    true,
+			CapturedSlot:  100,
+			BoundarySlot:  100,
+		},
+	}, nil))
+	gormDB := rewardCalcGormDB(t, db)
+	pool := models.Pool{PoolKeyHash: sc.poolKey}
+	require.NoError(t, gormDB.Create(&pool).Error)
+	require.NoError(t, gormDB.Create(&models.PoolRegistration{
+		PoolID:      pool.ID,
+		PoolKeyHash: sc.poolKey,
+		AddedSlot:   0,
+	}).Error)
+	// The reward (leader) account is expired as of the snapshot epoch (2):
+	// ExpirationEpoch 1 is nonzero and strictly before 2.
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      sc.rewardAccount,
+		Pool:            sc.poolKey,
+		Active:          true,
+		ExpirationEpoch: 1,
+	}))
+	// The member delegator is active (unset expiration).
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey:      sc.member,
+		Pool:            sc.poolKey,
+		Active:          true,
+		ExpirationEpoch: 0,
+	}))
+	rewardCalcSeedStakeCert(
+		t, db, 1, sc.rewardAccount, 0, 250,
+		uint(lcommon.CertificateTypeStakeRegistration),
+	)
+	rewardCalcSeedStakeCert(
+		t, db, 2, sc.member, 0, 250,
+		uint(lcommon.CertificateTypeStakeRegistration),
+	)
+
+	return ls, db, sc
+}
+
+// rewardAccountOutputsByStakingKey indexes a slice of RewardAccountOutput
+// rows by staking key for lookups in the tests below.
+func rewardAccountOutputsByStakingKey(
+	outputs []*models.RewardAccountOutput,
+) map[string]*models.RewardAccountOutput {
+	ret := make(map[string]*models.RewardAccountOutput, len(outputs))
+	for _, output := range outputs {
+		ret[string(output.StakingKey)] = output
+	}
+	return ret
+}
+
+// TestApplyStakeRewardsPersistsGuardedFlagOnAccountOutput is the dingo #3021
+// persistence test: when the delegator-inactivity gate is on, an expired
+// reward account's output row must be persisted with Guarded = true even
+// though it remains Spendable = true (the guard is a distinct reason for
+// withholding the reward from spendable/deregistered), and the active
+// member's row must be Guarded = false. The persisted flag must line up with
+// what was actually credited to the account balance.
+func TestApplyStakeRewardsPersistsGuardedFlagOnAccountOutput(t *testing.T) {
+	ls, db, sc := setupGuardedRewardScenario(t, true)
+	meta := db.Metadata()
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, sc.newEpoch, sc.boundarySlot)
+	}))
+
+	outputs, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	require.Len(t, outputs, 2)
+	byKey := rewardAccountOutputsByStakingKey(outputs)
+
+	leader := byKey[string(sc.rewardAccount)]
+	require.NotNil(t, leader)
+	assert.True(
+		t, leader.Spendable,
+		"leader row remains marked spendable: the guard is a separate reason for withholding than deregistration",
+	)
+	assert.True(
+		t, leader.Guarded,
+		"an expired reward account's output must be persisted as guarded",
+	)
+
+	member := byKey[string(sc.member)]
+	require.NotNil(t, member)
+	assert.True(t, member.Spendable)
+	assert.False(
+		t, member.Guarded,
+		"the active member's output must not be guarded",
+	)
+
+	// The persisted flag must line up with what was actually credited.
+	rewardOwner, err := db.GetAccountByCredential(0, sc.rewardAccount, true, nil)
+	require.NoError(t, err)
+	assert.Equal(
+		t, uint64(0), uint64(rewardOwner.Reward),
+		"the guarded leader must not have been credited",
+	)
+	rewardMember, err := db.GetAccountByCredential(0, sc.member, true, nil)
+	require.NoError(t, err)
+	assert.Greater(
+		t, uint64(rewardMember.Reward), uint64(0),
+		"the unguarded member must have been credited",
+	)
+}
+
+// TestApplyStakeRewardsGateOffNeverSetsGuardedFlag pins that Guarded stays
+// false for every row when the delegator-inactivity gate is off, keeping
+// that path byte-identical to pre-CIP behavior: the same "expired" account
+// data is credited normally, exactly as
+// TestApplyStakeRewardsGuardsExpiredRewardAccount's gate-off case already
+// pins for the crediting/ADA-conservation side.
+func TestApplyStakeRewardsGateOffNeverSetsGuardedFlag(t *testing.T) {
+	ls, db, sc := setupGuardedRewardScenario(t, false)
+	meta := db.Metadata()
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, sc.newEpoch, sc.boundarySlot)
+	}))
+
+	outputs, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	require.Len(t, outputs, 2)
+	for _, output := range outputs {
+		assert.False(
+			t, output.Guarded,
+			"gate off must never persist guarded=true (staking key %x)",
+			output.StakingKey,
+		)
+	}
+
+	rewardOwner, err := db.GetAccountByCredential(0, sc.rewardAccount, true, nil)
+	require.NoError(t, err)
+	assert.Greater(
+		t, uint64(rewardOwner.Reward), uint64(0),
+		"gate off must still credit the nominally-expired reward account",
+	)
+}
+
+// TestPrecomputedRewardApplicationPersistsGuardedFlag covers the reused
+// precompute path: precomputeStakeRewardsAfterEpochTransition (and the
+// synchronous precomputeStakeRewards helper used here) persists the pool and
+// account output rows before the CIP-0163 guard is ever computed -- the
+// guard set is only built inside applyStakeRewardApplication, which the
+// precompute path never calls -- so the precomputed rows start with the
+// zero-value Guarded = false. This pins that the synchronous application
+// path, which reuses that precomputed application instead of recalculating
+// (precomputedStakeRewardApplication), still reconciles Guarded against the
+// current guard set and re-saves the row rather than leaving the
+// precompute's stale false in place.
+func TestPrecomputedRewardApplicationPersistsGuardedFlag(t *testing.T) {
+	ls, db, sc := setupGuardedRewardScenario(t, true)
+	meta := db.Metadata()
+
+	precomputeTxn := db.Transaction(true)
+	require.NoError(t, precomputeTxn.Do(func(txn *database.Txn) error {
+		return ls.precomputeStakeRewards(
+			txn, sc.newEpoch, sc.boundarySlot, sc.boundarySlot,
+		)
+	}))
+
+	preOutputs, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	require.Len(t, preOutputs, 2)
+	for _, output := range preOutputs {
+		require.False(
+			t, output.Guarded,
+			"precompute runs before the guard is known and must not set it",
+		)
+	}
+
+	applyTxn := db.Transaction(true)
+	require.NoError(t, applyTxn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, sc.newEpoch, sc.boundarySlot)
+	}))
+
+	outputs, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	byKey := rewardAccountOutputsByStakingKey(outputs)
+	leader := byKey[string(sc.rewardAccount)]
+	require.NotNil(t, leader)
+	assert.True(
+		t, leader.Guarded,
+		"reusing a precomputed application must still persist the guard decision",
+	)
+	member := byKey[string(sc.member)]
+	require.NotNil(t, member)
+	assert.False(t, member.Guarded)
+
+	rewardOwner, err := db.GetAccountByCredential(0, sc.rewardAccount, true, nil)
+	require.NoError(t, err)
+	assert.Equal(
+		t, uint64(0), uint64(rewardOwner.Reward),
+		"the guard must still prevent crediting on the reused precompute path",
+	)
+}
+
+// TestApplyStakeRewardsGuardedFlagRecomputesAfterRollback is the rollback
+// correctness test for dingo #3021, in the same spirit as
+// TestDeleteRewardStateAfterSlotUnaffectedByAPIModeRetention
+// (ledger/snapshot/rotation_reward_retention_mode_test.go) pins retention:
+// DeleteRewardStateAfterSlot removes the previously-persisted guarded row
+// (it is an unconditional slot-based delete; Guarded plays no special role),
+// and a subsequent recomputation must not carry the guard decision forward
+// as though it were still true. It re-derives Guarded fresh from current
+// state, so an account renewed on the surviving fork before the recompute
+// runs (as recomputeAccountExpirationsAfterRollback would do) is credited
+// and its row is persisted with Guarded = false, not stuck at the
+// pre-rollback true.
+func TestApplyStakeRewardsGuardedFlagRecomputesAfterRollback(t *testing.T) {
+	ls, db, sc := setupGuardedRewardScenario(t, true)
+	meta := db.Metadata()
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, sc.newEpoch, sc.boundarySlot)
+	}))
+
+	before, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	beforeByKey := rewardAccountOutputsByStakingKey(before)
+	beforeLeader := beforeByKey[string(sc.rewardAccount)]
+	require.NotNil(t, beforeLeader)
+	require.True(
+		t, beforeLeader.Guarded,
+		"sanity: the guard must apply before the rollback",
+	)
+
+	// Roll back to a slot between the snapshot/pool-input capture (100) and
+	// the reward output boundary (sc.boundarySlot, 500): this removes the
+	// reward_ada_pots row (captured_slot 300) and both pool/account output
+	// rows (captured_slot/boundary_slot 500), while leaving the reward
+	// snapshot and pool/stake inputs (captured_slot/boundary_slot 100)
+	// untouched -- the same partial removal an epoch-boundary-crossing
+	// rollback produces in practice.
+	const rollbackSlot = uint64(200)
+	require.NoError(t, meta.DeleteRewardStateAfterSlot(rollbackSlot, nil))
+
+	rolledBack, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	require.Empty(
+		t, rolledBack,
+		"rollback must remove the previously guarded rows regardless of Guarded",
+	)
+	pots, err := meta.GetRewardAdaPots(sc.potsEpoch, nil)
+	require.NoError(t, err)
+	require.Nil(
+		t, pots,
+		"rollback must remove the reward ADA pots row above the rollback slot",
+	)
+
+	// Simulate the surviving fork renewing the reward account before the
+	// recompute runs (what recomputeAccountExpirationsAfterRollback does in
+	// practice): it is no longer expired as of the snapshot epoch.
+	require.NoError(t, rewardCalcGormDB(t, db).
+		Model(&models.Account{}).
+		Where("credential_tag = ? AND staking_key = ?", 0, sc.rewardAccount).
+		Update("expiration_epoch", 0).Error)
+
+	// Reseed only what the rollback removed; the snapshot and pool/stake
+	// inputs survived untouched and are reused as-is.
+	require.NoError(t, meta.SaveRewardAdaPots(&models.RewardAdaPots{
+		Epoch:        sc.potsEpoch,
+		Reserves:     100_000_000,
+		CapturedSlot: 300,
+	}, nil))
+
+	recomputeTxn := db.Transaction(true)
+	require.NoError(t, recomputeTxn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, sc.newEpoch, sc.boundarySlot)
+	}))
+
+	after, err := meta.GetRewardAccountOutputs(sc.rewardSnapshotEpoch, nil)
+	require.NoError(t, err)
+	require.Len(t, after, 2)
+	afterByKey := rewardAccountOutputsByStakingKey(after)
+	afterLeader := afterByKey[string(sc.rewardAccount)]
+	require.NotNil(t, afterLeader)
+	assert.False(
+		t, afterLeader.Guarded,
+		"recompute after rollback must not carry forward a stale guarded=true once the account was renewed",
+	)
+
+	rewardOwner, err := db.GetAccountByCredential(0, sc.rewardAccount, true, nil)
+	require.NoError(t, err)
+	assert.Greater(
+		t, uint64(rewardOwner.Reward), uint64(0),
+		"the renewed reward account must be credited on recompute",
+	)
+}


### PR DESCRIPTION
Closes #3021

#3015 filtered `/accounts/{stake_address}/rewards` to `spendable = true`, because a `RewardAccountOutput` row with `Spendable = false` was never credited. There is a second path to the same overstatement that the filter does not catch.

`rewardOutputGuarded` (the CIP-0163 reward-crediting guard in `ledger/reward_calculation.go`) skips crediting without ever writing that decision back to the row, so a guarded row keeps `spendable = true`, passes the filter, and is reported as received. Dormant until CIP-0163 delegator inactivity is active, then it produces the same visible inconsistency between `/rewards` and `rewards_sum` on the sibling endpoint.

## Change

Adds a `Guarded` column to `RewardAccountOutput`, moves the guard computation in `applyStakeRewardApplication` ahead of `saveStakeRewardOutputs`, and persists the decision via `applyGuardedFlagToAccountOutputs`. The reused-precompute path forces a re-save through `outputsUpdated`, because precompute writes rows before the guard is known.

`GetRewardAccountOutputsByCredential` and `CountRewardAccountOutputsByCredential` now filter `spendable = true AND guarded = false`. Both, so the count cannot disagree with the page — the defect from the first review pass.

## Separate column rather than folding into Spendable

`Spendable = false` and `Guarded = true` already settle into different ADA pots in `deriveStakeRewardApplicationTotals`: unspendable goes to treasury, undistributed goes to reserves. Conflating them at the row level would erase a distinction the ledger itself maintains, and would make the two withholding reasons indistinguishable for diagnostics.

## Index is additive, after a correction

The first attempt renamed the existing index to `idx_reward_account_output_credential_spendable_guarded`, following the drop-superseded-index pattern used elsewhere in this repo. That broke two pre-existing tests in `database/models/reward_state_test.go` which assert `AutoMigrate` creates an index named literally `idx_reward_account_output_credential_spendable`.

Rather than edit those assertions, the new index is additive and coexists with the untouched original. Because it is a brand-new name, `AutoMigrate` creates it directly on any prior schema and no drop helper is needed. Priorities are `(credential_tag, staking_key, spendable, guarded, epoch, pool_key_hash, reward_type)`, so the predicate and the ORDER BY are both index-satisfied; `EXPLAIN QUERY PLAN` confirms the planner picks it. The cost is modest extra index storage on a table that grows unbounded in `api` mode, which is noted in `DATABASE.md` alongside the sizing math.

## Rollback correctness

`TestApplyStakeRewardsGuardedFlagRecomputesAfterRollback` pins it end to end: apply with an expired account so `Guarded` persists true, `DeleteRewardStateAfterSlot` removes the rows, the account is renewed, and recompute persists `Guarded = false` and credits it. That proves the flag is not sticky across rollback and recomputation, which is the failure mode worth guarding since it only breaks in one direction.

## Tests

Ledger: guard persisted on the account output, gate-off never sets the flag, the reused-precompute path persists it, and the rollback case above. The gate is enabled explicitly via `DelegatorInactivityEnabled` on `LedgerStateConfig`, mirroring the existing `applyGuardExpiredLeaderScenario` pattern, so these exercise a path that can actually run rather than asserting on dead code.

API: `TestAccountRewardHistoryExcludesGuardedReward`, plus `TestAccountRewardHistorySumMatchesAccountRewardsSum`, which asserts the invariant behind both this fix and #3015 — the sum of `/rewards` must equal `rewards_sum` on `/accounts/{stake_address}`. That contract was only implied before.

Fixtures deliberately mix guarded and unguarded rows. Every fixture in that file originally set `Spendable: true`, which is exactly why the first bug was invisible; repeating that shape for `Guarded` would have reproduced the mistake.

Backend tests for the guarded exclusion on sqlite, postgres and mysql. No pre-existing test assertion was modified.

## DevNet

Not warranted. The gate is default-off everywhere today so this is a no-op in current configurations, the crediting and ADA-pot logic is unchanged (only when the already-tested guard decision is persisted), and CIP-0163 has no cardano-node reference to run against.

## Verification

`go build ./...` and `-tags dingo_extra_plugins` clean. `go test ./api/blockfrost/... ./database/... ./ledger/...` with 0 `^FAIL` and 0 `^--- FAIL`. `golangci-lint run` 0 issues. `make import-boundaries` ok. `go test -race ./api/blockfrost/...` and `./database/plugin/metadata/sqlite/` pass with no data races. Conformance passes. The two pre-existing migration tests pass with that file untouched.

Postgres and MySQL verified against real containers. Three unrelated `reward_live_stake` failures appeared under a broad `-run` invocation and reproduce identically on clean `main`; that is the cleanup-ordering leak fixed separately in #3036.

## Documentation

`DATABASE.md`: the table row, the retention and sizing math now accounting for three indexes, and a rewrite of the `GetRewardAccountOutputsByCredential` section removing the note that recorded this gap as unfixed. `ARCHITECTURE.md`: the reward-crediting guard paragraph now describes the persistence step and why the flag is a separate column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists the CIP-0163 reward-crediting guard decision on `reward_account_output` and updates the account reward-history query to exclude guarded rows. This keeps `/accounts/{stake_address}/rewards` consistent with `rewards_sum` and prevents overstated rewards when delegator inactivity is enabled.

- **Bug Fixes**
  - Added `Guarded` column to `reward_account_output`; computed via `applyGuardedFlagToAccountOutputs` before `saveStakeRewardOutputs` in `applyStakeRewardApplication`, and reconciled on every run (including reused precompute and after rollback).
  - Blockfrost queries now filter `spendable = true AND guarded = false` in `GetRewardAccountOutputsByCredential` and `CountRewardAccountOutputsByCredential`.
  - Added index `idx_reward_account_output_credential_spendable_guarded` to serve the new filter; existing `idx_reward_account_output_credential_spendable` is left in place.
  - Tests cover guarded exclusion, sum parity with `rewards_sum`, gate-off behavior, precompute reuse, and rollback across sqlite/postgres/mysql.
  - Docs updated in `DATABASE.md` and `ARCHITECTURE.md`.

- **Migration**
  - No manual steps. `AutoMigrate` adds the `Guarded` column and the new index; the existing index is unchanged.
  - Note: adds modest index storage in `api` mode; behavior is otherwise unchanged while the CIP-0163 gate is off.

<sup>Written for commit ebfd53ab0db63f89c4903f515a64183508b24836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

