### PR TITLE
fix(chain): guard fork depth against rollback ahead of persistent tip

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -689,6 +689,35 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	return nil
 }
 
+// rollbackForkDepth returns the number of blocks a rollback to
+// rollbackBlockIndex removes from the chain. The rollback point is normally at
+// or behind the tip, but it can sit ahead of the tip: rolled-back blocks stay
+// resolvable through the manager's block cache with their original (higher)
+// block index, and ephemeral fork chains index above the primary chain tip, so
+// fork resolution can hand us a rollback point above the current tip. Nothing
+// sits between the tip and a point ahead of it, so the fork depth is zero.
+// Subtracting directly would wrap around uint64 and make any such rollback look
+// deeper than the security parameter K, which rejected and denied every peer
+// permanently (issue #3035).
+//
+// Callers must hold c.mutex.
+func (c *Chain) rollbackForkDepth(
+	point ocommon.Point,
+	rollbackBlockIndex uint64,
+) uint64 {
+	if rollbackBlockIndex <= c.tipBlockIndex {
+		return c.tipBlockIndex - rollbackBlockIndex
+	}
+	slog.Default().Warn(
+		"rollback point is ahead of chain tip, treating fork depth as zero",
+		"rollback_slot", point.Slot,
+		"rollback_block_index", rollbackBlockIndex,
+		"tip_slot", c.currentTip.Point.Slot,
+		"tip_block_index", c.tipBlockIndex,
+	)
+	return 0
+}
+
 // ValidateRollback verifies that Rollback(point) would be accepted without
 // mutating chain state. Callers can use this to avoid applying external
 // side effects before the chain's rollback pre-checks have run.
@@ -734,7 +763,7 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 		rollbackBlockIndex = tmpBlock.ID
 	}
 	// Calculate fork depth before deleting blocks
-	forkDepth := c.tipBlockIndex - rollbackBlockIndex
+	forkDepth := c.rollbackForkDepth(point, rollbackBlockIndex)
 	// Reject rollbacks that exceed the security parameter K on
 	// the persistent chain. Ephemeral (fork-tracking) chains are
 	// not subject to this limit. When the chain is shorter than K
@@ -807,7 +836,7 @@ func (c *Chain) rollbackLocked(
 		rollbackBlockIndex = tmpBlock.ID
 	}
 	// Calculate fork depth before deleting blocks
-	forkDepth := c.tipBlockIndex - rollbackBlockIndex
+	forkDepth := c.rollbackForkDepth(point, rollbackBlockIndex)
 	// Reject rollbacks that exceed the security parameter K on
 	// the persistent chain. Ephemeral (fork-tracking) chains are
 	// not subject to this limit. When the chain is shorter than K

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1605,6 +1605,67 @@ func TestChainRollbackWithinSecurityParam(t *testing.T) {
 	}
 }
 
+// TestChainRollbackPointAheadOfTipIsNotDeepFork covers issue #3035: a rollback
+// point whose block index is ahead of the persistent tip must not be treated as
+// a deep fork. Rolled-back blocks stay resolvable through the manager's block
+// cache with their original (higher) block index, so a later fork resolution
+// can hand the chain a rollback point above the current tip. Subtracting that
+// index from the tip wrapped around uint64, making every such rollback look
+// deeper than K, which permanently denied every peer.
+func TestChainRollbackPointAheadOfTipIsNotDeepFork(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	// K=2 allows the first rollback (depth 2) while remaining small enough
+	// that an underflowed fork depth would exceed it.
+	mustSetLedger(t, cm, 2)
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	// Roll back the last two blocks (block index 6 -> 4). The removed blocks
+	// remain in the manager's block cache with block index 5 and 6.
+	rollbackBlock := testBlocks[len(testBlocks)-3]
+	rollbackPoint := ocommon.Point{
+		Slot: rollbackBlock.SlotNumber(),
+		Hash: rollbackBlock.Hash().Bytes(),
+	}
+	if err := c.Rollback(rollbackPoint); err != nil {
+		t.Fatalf("unexpected error rolling back chain: %s", err)
+	}
+	// Now roll back to a point that is still resolvable but whose block index
+	// (6) is ahead of the current tip index (4).
+	aheadBlock := testBlocks[len(testBlocks)-1]
+	aheadPoint := ocommon.Point{
+		Slot: aheadBlock.SlotNumber(),
+		Hash: aheadBlock.Hash().Bytes(),
+	}
+	if err := c.ValidateRollback(aheadPoint); err != nil {
+		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
+			t.Fatalf(
+				"rollback point ahead of tip must not be reported as "+
+					"exceeding security param K: %s",
+				err,
+			)
+		}
+		t.Fatalf("unexpected error validating rollback: %s", err)
+	}
+	if err := c.Rollback(aheadPoint); err != nil {
+		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
+			t.Fatalf(
+				"rollback point ahead of tip must not be rejected for "+
+					"exceeding security param K: %s",
+				err,
+			)
+		}
+		t.Fatalf("unexpected error rolling back chain: %s", err)
+	}
+}
+
 func TestRewindPrimaryChainToPointPrunesPersistentTail(t *testing.T) {
 	db := newTestDB(t)
 	cm, err := chain.NewManager(db, nil)


### PR DESCRIPTION
Rollback and ValidateRollback computed fork depth as tipBlockIndex - rollbackBlockIndex without checking the order of the two uint64 values. A rollback point can resolve to a block index above the tip, since rolled-back blocks stay resolvable through the manager block cache with their original higher index and ephemeral fork chains index above the primary tip, so the subtraction wrapped around and every such rollback looked deeper than the security parameter K. The node rejected the fork resolution and temporarily denied the peer, repeated that for every peer, and never followed a chain again. Fork depth now comes from one shared helper used by both call sites that returns 0 when the rollback point is ahead of the tip and logs the unusual state; the K threshold, held-tip recovery behaviour, and peer-denial policy are unchanged.

Fixes #3035

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fork-depth underflow when a rollback point resolves above the tip. Prevents false K-limit rejections and peer denial (fixes #3035).

- **Bug Fixes**
  - Compute fork depth via one helper used by `ValidateRollback` and rollback.
  - When rollback index > tip index, treat depth as 0 and log a warning.
  - Add a test covering the ahead-of-tip case to ensure it doesn’t trigger K-limit errors.

<sup>Written for commit 08f18d58add9432d9493e01260d7c39c0ff0b689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

