### PR TITLE
docs(examples): distinguish failed asset holder requests from empty

### DIFF
--- a/examples/dingo-blockfrost-explorer/src/main.ts
+++ b/examples/dingo-blockfrost-explorer/src/main.ts
@@ -2241,7 +2241,10 @@ async function renderAssetLookup(assetID: string): Promise<void> {
   const encodedAssetID = encodeURIComponent(assetID);
   const [asset, holders] = await Promise.all([
     blockfrostFetch<AssetResponse>(`/api/v0/assets/${encodedAssetID}`),
-    optionalFetchPage<AssetAddressResponse>(
+    // A 404 means this Dingo build does not serve the holder endpoint, which
+    // falls back to the empty holder copy below. Any other failure is reported
+    // as an error instead of being shown as an asset with no holders.
+    fetchPageAllowingNotFound<AssetAddressResponse>(
       `/api/v0/assets/${encodedAssetID}/addresses?count=25&page=1&order=desc`,
     ),
   ]);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes asset holder lookup in the Dingo Blockfrost Explorer by distinguishing a missing holders endpoint (404) from real request failures. 404 now falls back to the empty-holders copy, while other errors are surfaced instead of showing an empty list.

<sup>Written for commit b8e2fa9f18315980d7e4a6908cad93dd67871f2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

