### PR TITLE
ci: exclude go test fixtures from the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,16 @@ dingo
 Dockerfile
 README.md
 internal/test/archive-demo/tmp/
+
+# Go test fixtures. Only ever read by *_test.go at test time; no image build
+# runs tests, and no Dockerfile COPYs a testdata path. database/immutable/testdata
+# alone is ~84MB of the ~106MB build context sent for every root-context build
+# (Dockerfile, Dockerfile.txpump, Dockerfile.analysis, devnet/erastest/archive-demo).
+**/testdata/
+
+# Local dev artifacts. Gitignored, so absent in CI, but large in developer
+# trees that build devnet/archive-demo images with the repo root as context.
+.devnet/
+.tools/
+*.prof
+*.test


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude Go test fixtures and local dev artifacts from the Docker build context to cut size and speed up builds. Removes `**/testdata/` (~84MB of ~106MB root-context) and `.devnet/`, `.tools/`, `*.prof`, `*.test`; images don't copy tests, so this is safe.

<sup>Written for commit c414d6eb80b2270d8a956cb012166e5415d769d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

