### PR TITLE
refactor(ledger): share the restrictive plutus budget across eras

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"slices"
 
@@ -308,7 +307,10 @@ func ValidateTxAlonzo(
 				datum,
 				redeemer.Data,
 				sc.ToPlutusData(),
-				lcommon.ExUnits{Steps: math.MaxInt64 / 2, Memory: math.MaxInt64 / 2},
+				lcommon.ExUnits{
+					Steps:  restrictiveEnormousBudget,
+					Memory: restrictiveEnormousBudget,
+				},
 				evalContext,
 			)
 			if err != nil {

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"slices"
 
@@ -334,7 +333,10 @@ func ValidateTxBabbage(
 				datum,
 				redeemer.Data,
 				sc.ToPlutusData(),
-				lcommon.ExUnits{Steps: math.MaxInt64 / 2, Memory: math.MaxInt64 / 2},
+				lcommon.ExUnits{
+					Steps:  restrictiveEnormousBudget,
+					Memory: restrictiveEnormousBudget,
+				},
 				evalContext,
 			)
 			if err != nil {
@@ -378,7 +380,10 @@ func ValidateTxBabbage(
 				datum,
 				redeemer.Data,
 				sc.ToPlutusData(),
-				lcommon.ExUnits{Steps: math.MaxInt64 / 2, Memory: math.MaxInt64 / 2},
+				lcommon.ExUnits{
+					Steps:  restrictiveEnormousBudget,
+					Memory: restrictiveEnormousBudget,
+				},
 				evalContext,
 			)
 			if err != nil {

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -949,6 +949,10 @@ func (c *conwayTxInfoCache) v3() (script.TxInfoV3, error) {
 // declared redeemer budget.
 //
 // math.MaxInt64/2 avoids overflow in ExBudget arithmetic (consumed = enormous - remaining).
+//
+// The Alonzo and Babbage phase-2 script validation helpers in this package use
+// the same value, so changing it changes script validation in every era from
+// Alonzo onward.
 const restrictiveEnormousBudget = int64(math.MaxInt64 / 2)
 
 func evaluateConwayPlutusScript(
@@ -961,13 +965,19 @@ func evaluateConwayPlutusScript(
 	txInfos *conwayTxInfoCache,
 	skipFinalSlippageFlush bool,
 ) (lcommon.ExUnits, error, error) {
-	// In restrictive mode (skipFinalSlippageFlush=true), pass an enormous
-	// budget to gouroboros/plutigo so intermediate slippage-batch flushes
-	// never exhaust the budget mid-execution. After execution we compare the
-	// consumed amount (final batch already excluded by SkipFinalSlippageFlush)
-	// against the declared redeemer budget. This matches cardano-node's
-	// restrictingEnormous mode. In exact mode the declared budget is used as
-	// the machine limit (unchanged behavior).
+	// In restrictive mode (skipFinalSlippageFlush=true), ignore the budget
+	// argument as a machine limit and pass an enormous budget to
+	// gouroboros/plutigo so intermediate slippage-batch flushes never exhaust
+	// the budget mid-execution. After execution we compare the consumed amount
+	// (final batch already excluded by SkipFinalSlippageFlush) against the
+	// budget argument, which callers set to the declared redeemer budget. This
+	// matches cardano-node's restrictingEnormous mode.
+	//
+	// In exact mode (skipFinalSlippageFlush=false) the caller-supplied budget
+	// argument is itself the machine limit, and no post-execution comparison is
+	// done. EvaluateTxConway uses that mode and passes tmpPparams.MaxTxExUnits,
+	// so the limit there is the protocol per-transaction maximum rather than
+	// any redeemer-declared budget.
 	evalBudget := budget
 	if skipFinalSlippageFlush {
 		evalBudget = lcommon.ExUnits{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Share a single restrictive Plutus budget across Alonzo, Babbage, and Conway to keep script validation consistent and easier to maintain. No behavior change; centralizes the math.MaxInt64/2 budget and clarifies restrictive vs exact modes.

- **Refactors**
  - Define one restrictive budget constant and reuse it in Alonzo/Babbage validators.
  - Replace inline math.MaxInt64/2 ExUnits with the shared constant to prevent overflow and align with cardano-node’s restrictingEnormous behavior.
  - Clarify Conway evaluator docs: restrictive mode ignores the machine limit and compares post-execution usage to the redeemer budget; exact mode uses the provided limit (e.g., protocol max).

<sup>Written for commit a6a000d9829c886520d2acca25dbe72133f61972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

