### PR TITLE
test: assert journaled reward delta hashes and drop dead branch

### DIFF
--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -652,24 +652,20 @@ func TestChainSelectorSwitchesOnOneBlockObservedTipLead(t *testing.T) {
 
 	// Challenger has the same confirmed Tip but has received one block header
 	// ahead via ObservedTip — simulating "announced header before incumbent did".
-	// This is done by calling updatePeerTipObserved directly.
 	oneAheadTip := ochainsync.Tip{
 		Point:       ocommon.Point{Slot: 101, Hash: []byte("one-ahead")},
 		BlockNumber: 51,
 	}
-	cs.mutex.Lock()
-	if pt, ok := cs.peerTips[challengerConn]; ok {
-		pt.UpdateTipWithObserved(confirmedTip, oneAheadTip, nil)
-	} else {
-		cs.mutex.Unlock()
-		// Add via normal path first, then update observed
-		cs.UpdatePeerTip(challengerConn, confirmedTip, nil)
+	// UpdatePeerTip takes cs.mutex itself, so the challenger must be registered
+	// before the lock is acquired to reach its PeerChainTip directly.
+	cs.UpdatePeerTip(challengerConn, confirmedTip, nil)
+	func() {
 		cs.mutex.Lock()
-		if pt, ok := cs.peerTips[challengerConn]; ok {
-			pt.UpdateTipWithObserved(confirmedTip, oneAheadTip, nil)
-		}
-	}
-	cs.mutex.Unlock()
+		defer cs.mutex.Unlock()
+		pt, ok := cs.peerTips[challengerConn]
+		require.True(t, ok, "challenger must be registered before observing")
+		pt.UpdateTipWithObserved(confirmedTip, oneAheadTip, nil)
+	}()
 
 	switched := cs.EvaluateAndSwitch()
 	assert.True(

--- a/internal/offchainmetadata/fetcher_test.go
+++ b/internal/offchainmetadata/fetcher_test.go
@@ -525,18 +525,17 @@ func TestResolveFetchURLRejectsBroadcastIPv4(t *testing.T) {
 	require.ErrorContains(t, err, "not allowed")
 }
 
-// TestFetchOneEnforcesPerSourcePoolMetadataSizeLimit verifies that a pool
-// document is capped at 512 bytes at fetch time even though the fetcher's
-// generic max bytes (here left at the default 1 MiB) is far larger: pool
-// sources get the stake-pool-specific limit, not the generic one.
-func TestFetchOneEnforcesPerSourcePoolMetadataSizeLimit(t *testing.T) {
-	padding := strings.Repeat("a", 500)
-	body := []byte(
-		`{"name":"` + padding + `","description":"d","ticker":"TEST",` +
-			`"homepage":"https://example.com"}`,
-	)
-	require.Greater(t, len(body), poolMetadataMaxBytes)
-	hash := blake2b.Sum256(body)
+// newFetchTestServerDoc starts a test server that serves body for every
+// request and returns a Fetcher wired to that server plus an OffchainMetadata
+// document for sourceType whose Hash is body's blake2b digest, so the fetch
+// passes hash verification and only per-source handling is under test. The
+// server is closed on test cleanup.
+func newFetchTestServerDoc(
+	t *testing.T,
+	sourceType string,
+	body []byte,
+) (*Fetcher, models.OffchainMetadata) {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write(body)
@@ -551,11 +550,30 @@ func TestFetchOneEnforcesPerSourcePoolMetadataSizeLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	doc := models.OffchainMetadata{
-		SourceType: models.OffchainMetadataSourcePool,
+	hash := blake2b.Sum256(body)
+	return fetcher, models.OffchainMetadata{
+		SourceType: sourceType,
 		URL:        server.URL,
 		Hash:       hash[:],
 	}
+}
+
+// TestFetchOneEnforcesPerSourcePoolMetadataSizeLimit verifies that a pool
+// document is capped at 512 bytes at fetch time even though the fetcher's
+// generic max bytes (here left at the default 1 MiB) is far larger: pool
+// sources get the stake-pool-specific limit, not the generic one.
+func TestFetchOneEnforcesPerSourcePoolMetadataSizeLimit(t *testing.T) {
+	padding := strings.Repeat("a", 500)
+	body := []byte(
+		`{"name":"` + padding + `","description":"d","ticker":"TEST",` +
+			`"homepage":"https://example.com"}`,
+	)
+	require.Greater(t, len(body), poolMetadataMaxBytes)
+	fetcher, doc := newFetchTestServerDoc(
+		t,
+		models.OffchainMetadataSourcePool,
+		body,
+	)
 	fetcher.fetchOne(context.Background(), &doc)
 
 	require.Equal(t, models.OffchainMetadataStatusFailed, doc.Status)
@@ -574,26 +592,11 @@ func TestFetchOneDoesNotReducePoolLimitForOtherSources(t *testing.T) {
 		`{"abstract":"` + strings.Repeat("a", 600) + `"}`,
 	)
 	require.Greater(t, len(body), poolMetadataMaxBytes)
-	hash := blake2b.Sum256(body)
-	server := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write(body)
-		},
-	))
-	t.Cleanup(server.Close)
-
-	fetcher, err := New(Config{
-		Store:                 fakeStore{},
-		HTTPClient:            server.Client(),
-		AllowPrivateAddresses: true,
-	})
-	require.NoError(t, err)
-
-	doc := models.OffchainMetadata{
-		SourceType: models.OffchainMetadataSourceDrep,
-		URL:        server.URL,
-		Hash:       hash[:],
-	}
+	fetcher, doc := newFetchTestServerDoc(
+		t,
+		models.OffchainMetadataSourceDrep,
+		body,
+	)
 	fetcher.fetchOne(context.Background(), &doc)
 
 	require.Equal(t, models.OffchainMetadataStatusFetched, doc.Status)
@@ -607,26 +610,11 @@ func TestFetchOneDoesNotReducePoolLimitForOtherSources(t *testing.T) {
 // classification rather than stored as a successful fetch.
 func TestFetchOneRejectsInvalidPoolMetadataContent(t *testing.T) {
 	body := []byte(`{}`)
-	hash := blake2b.Sum256(body)
-	server := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write(body)
-		},
-	))
-	t.Cleanup(server.Close)
-
-	fetcher, err := New(Config{
-		Store:                 fakeStore{},
-		HTTPClient:            server.Client(),
-		AllowPrivateAddresses: true,
-	})
-	require.NoError(t, err)
-
-	doc := models.OffchainMetadata{
-		SourceType: models.OffchainMetadataSourcePool,
-		URL:        server.URL,
-		Hash:       hash[:],
-	}
+	fetcher, doc := newFetchTestServerDoc(
+		t,
+		models.OffchainMetadataSourcePool,
+		body,
+	)
 	fetcher.fetchOne(context.Background(), &doc)
 
 	require.Equal(t, models.OffchainMetadataStatusFailed, doc.Status)
@@ -644,26 +632,11 @@ func TestFetchOneAcceptsValidPoolMetadataContent(t *testing.T) {
 		`{"name":"Test Pool","description":"A pool used for testing.",` +
 			`"ticker":"TEST","homepage":"https://example.com"}`,
 	)
-	hash := blake2b.Sum256(body)
-	server := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write(body)
-		},
-	))
-	t.Cleanup(server.Close)
-
-	fetcher, err := New(Config{
-		Store:                 fakeStore{},
-		HTTPClient:            server.Client(),
-		AllowPrivateAddresses: true,
-	})
-	require.NoError(t, err)
-
-	doc := models.OffchainMetadata{
-		SourceType: models.OffchainMetadataSourcePool,
-		URL:        server.URL,
-		Hash:       hash[:],
-	}
+	fetcher, doc := newFetchTestServerDoc(
+		t,
+		models.OffchainMetadataSourcePool,
+		body,
+	)
 	fetcher.fetchOne(context.Background(), &doc)
 
 	require.Equal(t, models.OffchainMetadataStatusFetched, doc.Status)

--- a/ledger/governance/enact_test.go
+++ b/ledger/governance/enact_test.go
@@ -386,6 +386,35 @@ func TestApplyTreasuryWithdrawal_DistinguishesSameTxActionIndex(
 		proposalRewardSourceHash(first),
 		proposalRewardSourceHash(second),
 	)
+	// Pin the caller contract: each journaled row must carry the per-proposal
+	// source hash as its replay discriminator, so the same tx hash at two
+	// action indexes cannot collapse into one row. Rows are matched by their
+	// stored discriminator rather than by query order.
+	bySourceHash := make(map[string]models.AccountRewardDelta, len(deltas))
+	for _, delta := range deltas {
+		bySourceHash[string(delta.TxHash)] = delta
+	}
+	require.Len(t, bySourceHash, 2, "journaled TxHash values must be distinct")
+	for _, tc := range []struct {
+		name     string
+		proposal *models.GovernanceProposal
+		amount   uint64
+	}{
+		{name: "first", proposal: first, amount: 7},
+		{name: "second", proposal: second, amount: 11},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wantHash := proposalRewardSourceHash(tc.proposal)
+			delta, ok := bySourceHash[string(wantHash)]
+			require.True(
+				t,
+				ok,
+				"no reward delta journaled with proposalRewardSourceHash",
+			)
+			assert.Equal(t, wantHash, delta.TxHash)
+			assert.Equal(t, tc.amount, uint64(delta.Amount))
+		})
+	}
 }
 
 func TestApplyTreasuryWithdrawal_RejectsOverdrawnTreasury(

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -100,6 +100,35 @@ func TestRefundProposalDeposit_DistinguishesSameTxActionIndex(t *testing.T) {
 		proposalRewardSourceHash(first),
 		proposalRewardSourceHash(second),
 	)
+	// Pin the caller contract: refundProposalDeposit must journal each refund
+	// under its own per-proposal source hash, so two refunds sharing a tx hash
+	// stay distinct replay-idempotent rows. Rows are matched by their stored
+	// discriminator rather than by query order.
+	bySourceHash := make(map[string]models.AccountRewardDelta, len(deltas))
+	for _, delta := range deltas {
+		bySourceHash[string(delta.TxHash)] = delta
+	}
+	require.Len(t, bySourceHash, 2, "journaled TxHash values must be distinct")
+	for _, tc := range []struct {
+		name     string
+		proposal *models.GovernanceProposal
+		amount   uint64
+	}{
+		{name: "first", proposal: first, amount: 7},
+		{name: "second", proposal: second, amount: 11},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wantHash := proposalRewardSourceHash(tc.proposal)
+			delta, ok := bySourceHash[string(wantHash)]
+			require.True(
+				t,
+				ok,
+				"no reward delta journaled with proposalRewardSourceHash",
+			)
+			assert.Equal(t, wantHash, delta.TxHash)
+			assert.Equal(t, tc.amount, uint64(delta.Amount))
+		})
+	}
 }
 
 func TestProcessEpochExpiresProposalAndRefundsDeposit(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Strengthens tests to assert journaled reward deltas use per‑proposal source hashes, ensuring distinct and idempotent rows. Also refactors fetcher tests with a shared helper and simplifies the chain selection test by registering the challenger before locking and removing a dead branch.

<sup>Written for commit 5ae9633d0382a0536e04daa4d2aa88000d456494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

