### PR TITLE
chore: document history expiry opt-in and drop dead demo helper

### DIFF
--- a/config.go
+++ b/config.go
@@ -81,6 +81,9 @@ func (m StorageMode) IsAPI() bool {
 }
 
 // HistoryExpiryConfig controls local expiry of immutable block history.
+// Expiry is deliberately opt-in: NewConfig defaults only Frequency and
+// leaves Enabled false, so Enabled must be set to true (usually through
+// WithHistoryExpiry) before the pruner runs.
 type HistoryExpiryConfig struct {
 	Enabled   bool
 	Frequency time.Duration
@@ -530,6 +533,7 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 		// We do this so we don't have to add guards around every log operation
 		logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		genesisBootstrap: true,
+		// Frequency only; Enabled stays false because expiry is opt-in
 		historyExpiry: HistoryExpiryConfig{
 			Frequency: time.Hour,
 		},

--- a/internal/test/archive-demo/demo.sh
+++ b/internal/test/archive-demo/demo.sh
@@ -164,10 +164,6 @@ expiry_rounds() {
   docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'history expiry: completed round' || true
 }
 
-expiry_skipped() {
-  docker logs archivedemo-dingo-pruning 2>&1 | grep -c 'history expiry: skipped because current slot is not high enough' || true
-}
-
 # ---------------------------------------------------------------------------
 # Watch the system grow: print a stats line every 10s until tip clears the
 # security window and History Expiry has had time to act on slot ~50.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Document that history expiry is opt-in and that `NewConfig` sets only a default `Frequency` while leaving `Enabled` false. Remove the dead `expiry_skipped` helper from `internal/test/archive-demo/demo.sh`.

<sup>Written for commit 67faef8611183f7247e35ac75fdaf01c41bc1786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

