### PR TITLE
fix: warn when tracing stdout is set without tracing enabled

### DIFF
--- a/node.go
+++ b/node.go
@@ -189,6 +189,7 @@ func (n *Node) apiPluginSelection(
 //nolint:contextcheck // Run is the lifecycle boundary and derives n.ctx from the caller context.
 func (n *Node) Run(ctx context.Context) error {
 	// Configure tracing
+	n.warnIfTracingMisconfigured()
 	if n.config.tracing {
 		if err := n.setupTracing(ctx); err != nil {
 			return err

--- a/tracing.go
+++ b/tracing.go
@@ -25,6 +25,22 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+// warnIfTracingMisconfigured logs a warning when stdout span export is
+// requested while tracing itself is disabled. setupTracing is only called
+// when tracing is enabled (see Node.Run), so tracingStdout on its own never
+// creates an exporter and would otherwise be silently ignored.
+func (n *Node) warnIfTracingMisconfigured() {
+	if n.config.tracing || !n.config.tracingStdout {
+		return
+	}
+	n.config.logger.Warn(
+		"tracing stdout export is enabled but tracing is disabled, so no spans"+
+			" will be exported; enable tracing (yaml tracing: true, --tracing,"+
+			" or DINGO_TRACING_ENABLED=true) or turn off the stdout option",
+		"component", "tracing",
+	)
+}
+
 func (n *Node) setupTracing(ctx context.Context) error {
 	// Set up propagator.
 	otel.SetTextMapPropagator(

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWarnIfTracingMisconfigured covers the tracingStdout-without-tracing
+// combination: setupTracing only runs when tracing is enabled, so stdout
+// export alone exports nothing and must not fail silently.
+func TestWarnIfTracingMisconfigured(t *testing.T) {
+	tests := []struct {
+		name          string
+		tracing       bool
+		tracingStdout bool
+		wantWarning   bool
+	}{
+		{name: "both disabled"},
+		{name: "both enabled", tracing: true, tracingStdout: true},
+		{name: "tracing only", tracing: true},
+		{
+			name:          "stdout without tracing",
+			tracingStdout: true,
+			wantWarning:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			n := &Node{
+				config: Config{
+					logger:        slog.New(slog.NewJSONHandler(&logs, nil)),
+					tracing:       test.tracing,
+					tracingStdout: test.tracingStdout,
+				},
+			}
+			n.warnIfTracingMisconfigured()
+			if !test.wantWarning {
+				require.Empty(t, logs.String())
+				return
+			}
+			require.Contains(t, logs.String(), `"level":"WARN"`)
+			require.Contains(t, logs.String(), `"component":"tracing"`)
+			require.Contains(
+				t,
+				logs.String(),
+				"tracing stdout export is enabled but tracing is disabled",
+			)
+			// The operator must be told how to fix it, not just that it is wrong.
+			require.Contains(t, logs.String(), "--tracing")
+			require.Contains(t, logs.String(), "DINGO_TRACING_ENABLED=true")
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Warns when stdout span export is enabled but tracing is disabled, preventing a silent no-op. The node logs a WARN with clear steps to enable tracing or turn off stdout export.

- **Bug Fixes**
  - Added `warnIfTracingMisconfigured()` and call it during `Node.Run()` before tracing setup; warning includes guidance to enable tracing (`--tracing`, `DINGO_TRACING_ENABLED=true`, YAML `tracing: true`) or disable stdout export.
  - Added tests to verify the warning is emitted only for this misconfiguration and includes remediation hints.

<sup>Written for commit e812541e1ff03c9f7e164147754794270269ed50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

