### PR TITLE
fix(database): round utxo condition max terms down to a power of two

### DIFF
--- a/database/plugin/metadata/internal/utxocond/utxocond.go
+++ b/database/plugin/metadata/internal/utxocond/utxocond.go
@@ -31,7 +31,10 @@
 // the prepared-statement cache can reuse them.
 package utxocond
 
-import "strings"
+import (
+	"math/bits"
+	"strings"
+)
 
 // Ref is a (tx_id, output_idx) UTxO reference.
 type Ref struct {
@@ -43,8 +46,9 @@ type Ref struct {
 type Chunk struct {
 	// Condition is the parenthesized OR-list, e.g.
 	// "(tx_id = ? AND output_idx = ?) OR (tx_id = ? AND output_idx = ?)".
-	// Its placeholder count is padded to a power of two, so only a handful
-	// of distinct Condition strings are ever produced.
+	// Its term count is always a power of two and never exceeds the maxTerms
+	// passed to Chunks, so only a handful of distinct Condition strings are
+	// ever produced.
 	Condition string
 	// Args holds TxID, Idx pairs for every term including padding, in order:
 	// len(Args) == 2 * (padded term count).
@@ -64,12 +68,18 @@ const DefaultMaxTerms = 256
 
 const term = "(tx_id = ? AND output_idx = ?)"
 
-// Chunks splits refs into chunks of at most maxTerms terms and pads each chunk's
-// term count up to the next power of two (repeating the chunk's last ref). It
-// returns nil for an empty input. maxTerms values below 1 fall back to
-// DefaultMaxTerms; a maxTerms that is not a power of two is used as-is for the
-// split boundary, but padded chunk lengths are still powers of two capped at
-// maxTerms.
+// Chunks splits refs into chunks and pads each chunk's term count up to the
+// next power of two (repeating the chunk's last ref). It returns nil for an
+// empty input.
+//
+// maxTerms is an upper bound on the padded term count, and so on the bound
+// parameter count (two per term) of the statements callers build from a Chunk.
+// Every padded term count is a power of two and must not exceed maxTerms, so
+// the effective bound is maxTerms rounded down to a power of two: rounding down
+// (never up) is what keeps the parameter count inside the caller's limit. The
+// split boundary uses that same rounded value, so a chunk is never larger than
+// the term count it is padded to. maxTerms values below 1 fall back to
+// DefaultMaxTerms, which is already a power of two.
 func Chunks(refs []Ref, maxTerms int) []Chunk {
 	if len(refs) == 0 {
 		return nil
@@ -77,6 +87,10 @@ func Chunks(refs []Ref, maxTerms int) []Chunk {
 	if maxTerms < 1 {
 		maxTerms = DefaultMaxTerms
 	}
+	// Round the caller's bound down to a power of two so that padded term
+	// counts are always powers of two (bounding the number of distinct SQL
+	// shapes) and always <= maxTerms (respecting driver parameter limits).
+	maxTerms = floorPow2(maxTerms)
 	var chunks []Chunk
 	for start := 0; start < len(refs); start += maxTerms {
 		end := min(start+maxTerms, len(refs))
@@ -116,7 +130,9 @@ func condition(n int) string {
 }
 
 // nextPow2Capped returns the smallest power of two >= n, capped at limit. n is
-// assumed to be in [1, limit].
+// assumed to be in [1, limit] and limit is assumed to be a power of two (Chunks
+// guarantees both), so the result is always a power of two and never exceeds
+// limit. The cap is defensive: it cannot trigger while those preconditions hold.
 func nextPow2Capped(n, limit int) int {
 	p := 1
 	for p < n {
@@ -126,4 +142,9 @@ func nextPow2Capped(n, limit int) int {
 		return limit
 	}
 	return p
+}
+
+// floorPow2 returns the largest power of two <= n. n is assumed to be >= 1.
+func floorPow2(n int) int {
+	return 1 << (bits.Len(uint(n)) - 1)
 }

--- a/database/plugin/metadata/internal/utxocond/utxocond_test.go
+++ b/database/plugin/metadata/internal/utxocond/utxocond_test.go
@@ -112,6 +112,118 @@ func TestChunksSplitsOverMaxTerms(t *testing.T) {
 	}
 }
 
+// TestChunksNonPowerOfTwoMaxTerms pins the invariant documented on
+// Chunk.Condition when maxTerms is not a power of two: the effective bound is
+// maxTerms rounded down to a power of two, so every chunk's term count is a
+// power of two AND stays within the caller's maxTerms (which bounds the driver
+// bind-parameter count at two per term). Real, arg count and padding-by-repeat
+// semantics are unchanged.
+func TestChunksNonPowerOfTwoMaxTerms(t *testing.T) {
+	for _, maxTerms := range []int{3, 5, 100, 200, 255, 257, 999} {
+		for _, n := range []int{1, 2, 7, 63, 150, 300, 1001} {
+			refs := mkRefs(n)
+			chunks := Chunks(refs, maxTerms)
+			if len(chunks) == 0 {
+				t.Fatalf("maxTerms=%d n=%d: expected chunks", maxTerms, n)
+			}
+			total := 0
+			for i, c := range chunks {
+				terms := strings.Count(c.Condition, "output_idx")
+				if terms&(terms-1) != 0 {
+					t.Fatalf(
+						"maxTerms=%d n=%d chunk %d: term count %d is not a power of two",
+						maxTerms, n, i, terms,
+					)
+				}
+				if terms > maxTerms {
+					t.Fatalf(
+						"maxTerms=%d n=%d chunk %d: term count %d exceeds maxTerms",
+						maxTerms, n, i, terms,
+					)
+				}
+				if c.Real < 1 || c.Real > terms {
+					t.Fatalf(
+						"maxTerms=%d n=%d chunk %d: Real=%d out of range for %d terms",
+						maxTerms, n, i, c.Real, terms,
+					)
+				}
+				if len(c.Args) != terms*2 {
+					t.Fatalf(
+						"maxTerms=%d n=%d chunk %d: expected %d args, got %d",
+						maxTerms, n, i, terms*2, len(c.Args),
+					)
+				}
+				// Real args are the input refs in order; padding repeats the
+				// chunk's last real ref, which is what makes it idempotent.
+				lastReal := refs[total+c.Real-1]
+				for j := range terms {
+					want := lastReal
+					if j < c.Real {
+						want = refs[total+j]
+					}
+					idx, ok := c.Args[j*2+1].(uint32)
+					if !ok || idx != want.Idx {
+						t.Fatalf(
+							"maxTerms=%d n=%d chunk %d arg %d: expected idx %d, got %v",
+							maxTerms, n, i, j, want.Idx, c.Args[j*2+1],
+						)
+					}
+				}
+				total += c.Real
+			}
+			if total != n {
+				t.Fatalf(
+					"maxTerms=%d n=%d: expected sum(Real)=%d, got %d",
+					maxTerms, n, n, total,
+				)
+			}
+		}
+	}
+}
+
+// TestChunksNonPowerOfTwoMaxTermsBoundsShapes is the #2943 property for a
+// non-power-of-two maxTerms: the distinct-shape set must still be bounded by
+// the powers of two under the effective bound, not gain an extra ragged shape.
+func TestChunksNonPowerOfTwoMaxTermsBoundsShapes(t *testing.T) {
+	shapes := make(map[int]struct{})
+	for n := 1; n <= 500; n++ {
+		for _, c := range Chunks(mkRefs(n), 200) {
+			shapes[strings.Count(c.Condition, "output_idx")] = struct{}{}
+		}
+	}
+	// Effective bound is 128 (200 rounded down), so shapes are 1..128: 8 total.
+	if len(shapes) > 8 {
+		t.Fatalf("expected at most 8 distinct shapes, got %d: %v", len(shapes), shapes)
+	}
+	for terms := range shapes {
+		if terms&(terms-1) != 0 || terms > 200 {
+			t.Fatalf("invalid shape term count %d", terms)
+		}
+	}
+}
+
+// TestChunksMaxTermsBelowOne pins the documented fallback to DefaultMaxTerms.
+func TestChunksMaxTermsBelowOne(t *testing.T) {
+	for _, maxTerms := range []int{0, -1, -256} {
+		got := Chunks(mkRefs(300), maxTerms)
+		want := Chunks(mkRefs(300), DefaultMaxTerms)
+		if len(got) != len(want) {
+			t.Fatalf("maxTerms=%d: expected %d chunks, got %d",
+				maxTerms, len(want), len(got))
+		}
+		for i := range got {
+			if got[i].Condition != want[i].Condition ||
+				got[i].Real != want[i].Real {
+				t.Fatalf("maxTerms=%d chunk %d: expected Real=%d/%d terms, got Real=%d/%d terms",
+					maxTerms, i, want[i].Real,
+					strings.Count(want[i].Condition, "output_idx"),
+					got[i].Real,
+					strings.Count(got[i].Condition, "output_idx"))
+			}
+		}
+	}
+}
+
 func TestChunksEmpty(t *testing.T) {
 	if Chunks(nil, DefaultMaxTerms) != nil {
 		t.Fatal("expected nil for empty input")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Round `maxTerms` down to a power of two in `database/plugin/metadata/internal/utxocond` so UTxO condition chunks always use power‑of‑two term counts. This removes ragged SQL shapes, improves prepared‑statement cache reuse, and ensures parameter limits are respected.

- **Bug Fixes**
  - In `Chunks`, round `maxTerms` down (floor) to the nearest power of two and use it for both splitting and padding.
  - Guarantee each chunk’s term count is a power of two and never exceeds the caller’s `maxTerms`.
  - Add tests for non‑power‑of‑two inputs, bounded shape counts, and fallback when `maxTerms < 1`.

<sup>Written for commit d7084bd1c1106a9eedec21f7b9976681054ff47d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

