### PR TITLE
feat(database): crash recovery and state consistency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -915,7 +915,9 @@ runs after the chain manager and ledger are up, because both the diagnosis and
 the repairs need them: `nodeRecoverySource` wraps `Database.RecoveryStateSource`
 to add the chain manager's tip, and `nodeRecoveryRepairer` routes trims to
 `Database.TrimBlobAbove`, rollbacks to `LedgerState.RollbackToPoint`, and
-restamping to `Database.StampCommitTimestamp`. It runs after the existing
+restamping to `Database.ResetCommitFence`. That reset performs an empty
+combined commit, assigning a fresh timestamp to both stores rather than
+reusing either divergent timestamp. It runs after the existing
 `RecoverCommitTimestampConflict` path so it reports on whatever that left
 behind, then starts the checkpoint ticker, which `Database.Close` stops.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,6 +178,7 @@ graph LR
     db_meta_impl["database/plugin/metadata/{mysql,postgres,sqlite}"]
     db_meta_util["database/plugin/metadata/{importutil,labelcodec}"]
     db_immutable["database/immutable"]
+    db_recovery["database/recovery"]
     cardano_cfg["config/cardano"]
     ev["event"]
     ledger["ledger"]
@@ -236,7 +237,7 @@ graph LR
 
     mempool --> chain & ev & plugin
 
-    db --> db_blob & db_meta & db_types & db_models
+    db --> db_blob & db_meta & db_types & db_models & db_recovery
     db_blob --> db_types
     db_blob_impl --> plugin & db_blob & db_types
     db_meta --> db_models & db_types
@@ -470,6 +471,7 @@ dingo/
 │   ├── block_lru_cache.go # Block-level LRU cache
 │   ├── immutable/       # ImmutableDB chunk reader
 │   ├── models/          # Database models
+│   ├── recovery/        # Crash recovery: intent journal, checkpoints, checks
 │   ├── types/           # Database types
 │   ├── sops/            # Storage operations
 │   └── plugin/          # Storage domain contracts and implementations
@@ -884,6 +886,49 @@ the cost of the barrier. If either the metadata commit or the sync fails after
 the blob commit succeeded, the result is a `PartialCommitError`, which
 `SubmitAsyncDBTxn` answers by running `RecoverCommitTimestampConflict` once
 (guarded against recursion) before failing the operation so the caller retries.
+
+### Crash Recovery
+
+`database/recovery` closes the gap the commit ordering above leaves: the stores
+can tell you *that* they diverged, via their commit timestamps, but not which
+commit was in flight or what it intended. The package sits below `database`,
+which wires it in, and never imports `ledger`, `chain`, or node code — it
+declares `StateSource`, the optional `ChainTipSource`, and `Repairer`, and the
+layers above implement them.
+
+Responsibilities split three ways:
+
+- `WAL` is an append-only journal of commit intent. `Txn.Commit` records a
+  `begin` before either store is touched and a `commit` once both are through.
+  `Database.SetTip` describes the transaction automatically, since moving the
+  tip is what makes a combined commit interesting; `Txn.SetRecoveryIntent` lets
+  a caller that knows better — a rollback, say — say so first.
+- `CheckpointStore` holds merkle-rooted summaries of agreed state. They bound
+  replay, anchor recovery when the journal is unreadable, and authorise
+  truncating the segments they cover. A checkpoint never covers a still-open
+  commit.
+- `Checker` runs the startup consistency checks; `Manager` ties the three
+  together.
+
+Composition lives in `node.go` and `node_recovery.go`. `Node.runCrashRecovery`
+runs after the chain manager and ledger are up, because both the diagnosis and
+the repairs need them: `nodeRecoverySource` wraps `Database.RecoveryStateSource`
+to add the chain manager's tip, and `nodeRecoveryRepairer` routes trims to
+`Database.TrimBlobAbove`, rollbacks to `LedgerState.RollbackToPoint`, and
+restamping to `Database.StampCommitTimestamp`. It runs after the existing
+`RecoverCommitTimestampConflict` path so it reports on whatever that left
+behind, then starts the checkpoint ticker, which `Database.Close` stops.
+
+Recovery never refuses to start the node. An outcome it cannot repair is logged
+at error level and startup continues, because the existing tip reconciliation
+that runs next fixes several of those shapes, and a node that will not start is
+worse for an operator than one that starts and says loudly what it found.
+
+The subsystem is off unless `crashRecovery` is set. When it is off,
+`database.Config.Recovery` is nil, `Database.Recovery()` returns nil, and every
+call site relies on the manager's methods being nil-safe no-ops. See
+DATABASE.md, "Crash Recovery Artifacts", for the on-disk layout and the repair
+rules.
 
 ### Storage Modes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -236,6 +236,7 @@ graph LR
     ledger_snapshot --> db & db_models & db_meta & db_types & ev
 
     mempool --> chain & ev & plugin
+    root --> db_recovery
 
     db --> db_blob & db_meta & db_types & db_models & db_recovery
     db_blob --> db_types

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -593,6 +593,83 @@ Plugins whose writes are already durable on commit implement `Sync` as a no-op:
 an S3 object is durable once `PutObject` is acknowledged, and a GCS object once
 its writer closes successfully.
 
+### Crash Recovery Artifacts
+
+`database/recovery` records what the store contents alone cannot say: which
+combined commit was in flight when a process died, and what it was trying to do.
+It is not a redo log — both stores are already crash safe on their own — it is a
+journal of cross-store intent, plus periodic checkpoints that bound how far back
+recovery has to read.
+
+Artifacts live under `<dataDir>/recovery/` and are managed entirely by the node.
+Nothing external reads them, and deleting the directory only costs the next
+recovery its precision; it never loses ledger or block data.
+
+| Path | Contents |
+|------|----------|
+| `recovery/wal/wal-<first-seq>.log` | Journal segments. Framed records: magic `DWAL`, version, type, `uint32` payload length, payload, CRC-32C over version+type+length+payload. Segment files roll at 8MiB and are named for the first sequence they hold, so a lexical sort is a sequence sort. |
+| `recovery/checkpoints/checkpoint-<seq>.bin` | One checkpoint generation per file, in the same framing. Three generations are retained. |
+
+Journal record types are `begin` (sequence, commit timestamp, and the intent:
+block append or rollback, with the target slot, hash and block number), `commit`,
+`abort`, and an inline `checkpoint`. `Txn.Commit` writes `begin` before it
+touches either store, and `commit` once both are through, so a `begin` with no
+resolution is exactly the window a crash can interrupt. Only `begin` is fsynced,
+and only when `crashRecoverySyncJournal` is set; a lost `commit` marker is
+harmless because recovery then compares the stores, finds them consistent, and
+does nothing.
+
+A checkpoint holds the journal sequence it covers, when it was taken, the commit
+timestamp both stores held, the metadata tip (slot, hash, block number), the blob
+tip, and a SHA-256 merkle root over those fields as domain-separated leaves
+(RFC 6962 leaf and interior prefixes). The root is verified on load, so a
+generation damaged in a way the frame CRC survives is skipped in favour of an
+older one. Checkpoints are written to a temporary file, fsynced, renamed, and the
+directory fsynced. A checkpoint never covers a still-open commit, so truncating
+segments it covers cannot discard an intent record recovery still needs.
+
+At startup `recovery.Manager.Recover` runs the consistency checks, loads the
+newest verified checkpoint, and replays the journal above it. The commit
+timestamps decide whether anything is repaired:
+
+- Both stores on the same fence: nothing was half applied, so nothing is
+  repaired. Unresolved intents alone do not change that — only begin records are
+  fsynced, so a crash routinely loses the commit marker of a commit that did
+  land — but they are reported.
+- Blob fence ahead: the interrupted commit's blocks are trimmed above the chain
+  tip, not the metadata tip. Blocks between the applied tip and the chain tip
+  are legitimately on-chain and merely not applied yet, the normal shape after a
+  Mithril bootstrap. Recovery refuses to trim when no tip is known at all, since
+  the boundary would be slot zero.
+- Metadata fence ahead: the blob store lost a durable write, so the ledger is
+  rolled back onto what the blob store still holds.
+
+A repair ends by resetting both stores onto a common fence. A blob tip below the
+metadata tip while the fences agree is real damage that recovery does not act on
+— rolling the ledger back against the stores' own fences is too destructive to do
+unprompted — and `tip_consistency` reports it as a failure instead.
+
+The startup consistency checks are `commit_timestamps`, `tip_consistency`,
+`chain_ledger_tip`, `block_continuity` (prev-hash linkage beneath the tip; block
+numbers are advisory, because a Byron epoch boundary block repeats its
+predecessor's chain difficulty), `utxo_integrity` (a bounded sample of live
+UTxOs resolved against their stored CBOR, which is where a lost block shows up
+as an offset reference that no longer resolves), and `orphaned_data`. The
+`consistencyCheckMode` setting selects `off`, `fast` (bounded windows near the
+tip, the default) or `full` (roughly an order of magnitude wider).
+
+### Unrecoverable Consumed UTxOs
+
+`utxoValidationMode` selects what block application does when a consumed UTxO
+past the recorded Mithril trust boundary (`mithril_ledger_slot`) is neither in
+the metadata store nor reconstructable from the blob store: `fail` rejects the
+block, `warn` applies it and logs each miss at warning level, `ignore` applies it
+and logs at debug level. Below the boundary the mode does not apply, because a
+node that intersected the chain at an arbitrary point legitimately has no
+history for the outputs those blocks spend. The older `strictUtxoValidation`
+boolean remains the fallback when no mode is set: `true` maps to `fail` and
+`false` to `ignore`.
+
 S3 has two prefix input forms with deliberately different compatibility contracts. `New` normalizes a non-empty prefix parsed from `s3://<bucket>/<prefix>` to end in `/`, so `s3://bucket/foo` produces object names such as `foo/<hex-key>`. `WithPrefix`, used by the `plugins.storage` config `prefix` field, preserves the configured value verbatim: `foo` produces `foo<hex-key>`, while `foo/` produces `foo/<hex-key>`. An empty prefix in either form adds nothing. Keeping the option form literal preserves the object-key layout of existing deployments.
 
 ```mermaid

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -622,11 +622,15 @@ does nothing.
 A checkpoint holds the journal sequence it covers, when it was taken, the commit
 timestamp both stores held, the metadata tip (slot, hash, block number), the blob
 tip, and a SHA-256 merkle root over those fields as domain-separated leaves
-(RFC 6962 leaf and interior prefixes). The root is verified on load, so a
-generation damaged in a way the frame CRC survives is skipped in favour of an
-older one. Checkpoints are written to a temporary file, fsynced, renamed, and the
-directory fsynced. A checkpoint never covers a still-open commit, so truncating
-segments it covers cannot discard an intent record recovery still needs.
+(RFC 6962 leaf and interior prefixes). `created_unix_milli` is operational
+metadata, but remains part of the Merkle binding for compatibility with the
+checkpoint wire format introduced here: changing it invalidates that generation
+instead of silently accepting a modified checkpoint. The root is verified on
+load, so a generation damaged in a way the frame CRC survives is skipped in
+favour of an older one. Checkpoints are written to a temporary file, fsynced,
+renamed, and the directory fsynced. A checkpoint never covers a still-open
+commit, so truncating segments it covers cannot discard an intent record recovery
+still needs.
 
 At startup `recovery.Manager.Recover` runs the consistency checks, loads the
 newest verified checkpoint, and replays the journal above it. The commit

--- a/config.go
+++ b/config.go
@@ -143,6 +143,8 @@ type Config struct {
 	peerSharing              bool
 	validateHistorical       bool
 	strictUtxoValidation     bool
+	utxoValidationMode       string
+	crashRecovery            CrashRecoveryConfig
 	tracing                  bool
 	tracingStdout            bool
 	runMode                  string
@@ -774,9 +776,49 @@ func WithValidateHistorical(validate bool) ConfigOptionFunc {
 // WithStrictUtxoValidation specifies whether an unrecoverable consumed UTxO
 // past the recorded Mithril sync boundary is a hard error rather than a
 // silently skipped condition. See database.Config.StrictUtxoValidation.
+//
+// WithUtxoValidationMode supersedes this and additionally offers a mode that
+// applies the block but logs the miss. This option remains the fallback when no
+// mode is set.
 func WithStrictUtxoValidation(strict bool) ConfigOptionFunc {
 	return func(c *Config) {
 		c.strictUtxoValidation = strict
+	}
+}
+
+// WithUtxoValidationMode selects what happens when a consumed UTxO past the
+// recorded Mithril sync boundary cannot be found or recovered: "fail", "warn"
+// or "ignore". An empty value falls back to WithStrictUtxoValidation.
+func WithUtxoValidationMode(mode string) ConfigOptionFunc {
+	return func(c *Config) {
+		c.utxoValidationMode = mode
+	}
+}
+
+// CrashRecoveryConfig configures the crash-recovery subsystem: the cross-store
+// intent journal, the periodic checkpoints that bound how much of it recovery
+// has to read, and the startup consistency checks.
+type CrashRecoveryConfig struct {
+	// ConsistencyCheckMode is "off", "fast" or "full". Empty selects
+	// "fast".
+	ConsistencyCheckMode string
+	// CheckpointInterval is how often a running node records a checkpoint.
+	// Zero selects the package default.
+	CheckpointInterval time.Duration
+	// Enabled turns the whole subsystem on. When it is off the database
+	// behaves exactly as it did before crash recovery existed.
+	Enabled bool
+	// SyncJournal makes each intent record durable before the commit that
+	// wrote it touches the stores, which is what lets recovery name the
+	// operation a crash interrupted. It costs one additional fsync per
+	// combined commit on top of the blob sync that commit already does.
+	SyncJournal bool
+}
+
+// WithCrashRecovery configures the crash-recovery subsystem.
+func WithCrashRecovery(cfg CrashRecoveryConfig) ConfigOptionFunc {
+	return func(c *Config) {
+		c.crashRecovery = cfg
 	}
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -18,12 +18,14 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/recovery"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -31,6 +33,10 @@ import (
 var DefaultConfig = &Config{
 	DataDir: ".dingo",
 }
+
+// defaultRecoverySubdir is where crash-recovery artifacts live under the data
+// directory when the caller does not name a directory of its own.
+const defaultRecoverySubdir = "recovery"
 
 // Config represents the configuration for a database instance
 type Config struct {
@@ -49,7 +55,33 @@ type Config struct {
 	// than an expected gap. Leave disabled (the default) when bootstrapping
 	// from a non-genesis chainsync intersect point without a Mithril
 	// snapshot import, where pre-intersect UTxOs are legitimately absent.
+	//
+	// UtxoValidationMode supersedes this when set; this remains the
+	// fallback for callers that have not moved over: true maps to
+	// UtxoValidationFail and false to UtxoValidationIgnore.
 	StrictUtxoValidation bool
+	// UtxoValidationMode selects what happens when a consumed UTxO past the
+	// Mithril trust boundary cannot be found or recovered:
+	// UtxoValidationFail, UtxoValidationWarn or UtxoValidationIgnore. An
+	// empty value falls back to StrictUtxoValidation.
+	UtxoValidationMode types.UtxoValidationMode
+	// Recovery configures the crash-recovery subsystem: the cross-store
+	// intent journal, periodic checkpoints, and the startup consistency
+	// checks. Leave it nil to run without any of that, which is how the
+	// database behaved before crash recovery existed.
+	Recovery *recovery.Config
+}
+
+// utxoValidationMode resolves the configured mode, falling back to the
+// deprecated StrictUtxoValidation boolean when no mode is set.
+func (c *Config) utxoValidationMode() types.UtxoValidationMode {
+	if c.UtxoValidationMode != "" {
+		return c.UtxoValidationMode
+	}
+	if c.StrictUtxoValidation {
+		return types.UtxoValidationFail
+	}
+	return types.UtxoValidationIgnore
 }
 
 // Stores contains the provider-owned storage services injected into a
@@ -77,10 +109,18 @@ type Database struct {
 	blob            blob.BlobStore
 	metadata        metadata.MetadataStore
 	cborCache       *TieredCborCache
+	recovery        *recovery.Manager
 	sizeMetricsStop chan struct{}
 	sizeMetricsDone chan struct{}
 	closeOnce       sync.Once
 	closeErr        error
+}
+
+// Recovery returns the crash-recovery manager, or nil when the subsystem is
+// not configured. Callers must tolerate a nil manager; its methods are all
+// nil-safe no-ops.
+func (d *Database) Recovery() *recovery.Manager {
+	return d.recovery
 }
 
 // Blob returns the underling blob store instance
@@ -130,6 +170,15 @@ func (d *Database) Close() error {
 		if d.sizeMetricsStop != nil {
 			close(d.sizeMetricsStop)
 			<-d.sizeMetricsDone
+		}
+		// Closing the journal flushes and syncs it, so intents recorded
+		// for commits still in flight survive a shutdown that races
+		// them.
+		if err := d.recovery.Close(); err != nil {
+			d.logger.Warn(
+				"failed to close crash recovery journal",
+				"error", err,
+			)
 		}
 	})
 	return d.closeErr
@@ -183,9 +232,45 @@ func New(config *Config, stores Stores) (*Database, error) {
 		logger:   configCopy.Logger,
 		config:   configCopy,
 	}
+	if db.logger == nil {
+		// Throw logs away rather than guarding every log call. init would
+		// do this too, but subsystems below are brought up before it runs
+		// and log on their failure paths.
+		db.logger = slog.New(slog.DiscardHandler)
+	}
 	// Initialize the tiered CBOR cache
 	db.cborCache = NewTieredCborCache(configCopy.CacheConfig, db)
 	db.cborCache.SetLogger(configCopy.Logger)
+	// Bring up crash recovery before init, so a database that fails its
+	// consistency gate is still returned to the caller with a working
+	// recovery manager attached.
+	if configCopy.Recovery != nil {
+		recoveryCfg := *configCopy.Recovery
+		if recoveryCfg.Dir == "" {
+			recoveryCfg.Dir = filepath.Join(
+				configCopy.DataDir,
+				defaultRecoverySubdir,
+			)
+		}
+		if recoveryCfg.Logger == nil {
+			recoveryCfg.Logger = db.logger
+		}
+		mgr, err := recovery.New(recoveryCfg)
+		if err != nil {
+			// Crash recovery makes an unclean shutdown diagnosable; it is
+			// not what makes the database correct. Refusing to open a
+			// database because its recovery directory is unwritable would
+			// take a node down over a feature that only matters after it
+			// has already crashed.
+			db.logger.Error(
+				"failed to open crash recovery; continuing without the intent journal, checkpoints, and startup consistency checks",
+				"dir", recoveryCfg.Dir,
+				"error", err,
+			)
+		} else {
+			db.recovery = mgr
+		}
+	}
 	// Register cache metrics if prometheus registry is available
 	if configCopy.PromRegistry != nil {
 		db.cborCache.Metrics().Register(configCopy.PromRegistry)

--- a/database/database.go
+++ b/database/database.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -175,10 +176,7 @@ func (d *Database) Close() error {
 		// for commits still in flight survive a shutdown that races
 		// them.
 		if err := d.recovery.Close(); err != nil {
-			d.logger.Warn(
-				"failed to close crash recovery journal",
-				"error", err,
-			)
+			d.closeErr = errors.Join(d.closeErr, fmt.Errorf("close crash recovery journal: %w", err))
 		}
 	})
 	return d.closeErr

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -334,10 +334,6 @@ func (d *BlobStoreS3) GetBlock(
 		}
 		return nil, types.BlockMetadata{}, err
 	}
-	if types.IsBlockTombstone(cborData) {
-		return nil, types.BlockMetadata{},
-			&types.HistoryExpiredError{Slot: slot, Hash: hash}
-	}
 	metadataKey := types.BlockBlobMetadataKey(key)
 	metadataBytes, err := d.getInternal(ctx, string(metadataKey))
 	if err != nil {
@@ -349,6 +345,10 @@ func (d *BlobStoreS3) GetBlock(
 	var tmpMetadata types.BlockMetadata
 	if _, err := cbor.Decode(metadataBytes, &tmpMetadata); err != nil {
 		return nil, types.BlockMetadata{}, err
+	}
+	if types.IsBlockTombstone(cborData) {
+		return nil, tmpMetadata,
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	return cborData, tmpMetadata, nil
 }
@@ -732,6 +732,9 @@ func (d *BlobStoreS3) listKeys(
 	} else if d.prefix != "" {
 		input.Prefix = aws.String(d.prefix)
 	}
+	if len(opts.Start) > 0 {
+		input.StartAfter = aws.String(d.fullKey(string(opts.Start)))
+	}
 	paginator := s3.NewListObjectsV2Paginator(d.client, input)
 	keys := make([]string, 0)
 	for paginator.HasMorePages() {
@@ -746,6 +749,12 @@ func (d *BlobStoreS3) listKeys(
 				return nil, fmt.Errorf("error decoding s3 key: %w", err)
 			}
 			keys = append(keys, string(externalKey))
+			if opts.Limit > 0 && len(keys) >= opts.Limit {
+				break
+			}
+		}
+		if opts.Limit > 0 && len(keys) >= opts.Limit {
+			break
 		}
 	}
 	sort.Strings(keys)

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -467,10 +467,6 @@ func (d *BlobStoreGCS) GetBlock(
 		d.logger.Errorf("%v", wrappedErr)
 		return nil, types.BlockMetadata{}, wrappedErr
 	}
-	if types.IsBlockTombstone(cborData) {
-		return nil, types.BlockMetadata{},
-			&types.HistoryExpiredError{Slot: slot, Hash: hash}
-	}
 	metadataKey := types.BlockBlobMetadataKey(key)
 	r, err = d.object(metadataKey).NewReader(ctx)
 	if err != nil {
@@ -507,6 +503,10 @@ func (d *BlobStoreGCS) GetBlock(
 	var tmpMetadata types.BlockMetadata
 	if _, err := cbor.Decode(metadataBytes, &tmpMetadata); err != nil {
 		return nil, types.BlockMetadata{}, err
+	}
+	if types.IsBlockTombstone(cborData) {
+		return nil, tmpMetadata,
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	return cborData, tmpMetadata, nil
 }
@@ -940,6 +940,12 @@ func (d *BlobStoreGCS) listKeys(
 	ctx, cancel := d.opContext()
 	defer cancel()
 	iter := d.objects(ctx, opts.Prefix)
+	if len(opts.Start) > 0 {
+		iter = d.bucket.Objects(ctx, &storage.Query{
+			Prefix:      d.fullKey(string(opts.Prefix)),
+			StartOffset: d.fullKey(string(opts.Start)),
+		})
+	}
 	keys := make([]string, 0)
 	for {
 		objAttrs, err := iter.Next()
@@ -955,6 +961,9 @@ func (d *BlobStoreGCS) listKeys(
 			return nil, err
 		}
 		keys = append(keys, externalKey)
+		if opts.Limit > 0 && len(keys) >= opts.Limit {
+			break
+		}
 	}
 	sort.Strings(keys)
 	if opts.Reverse {

--- a/database/recovery/checkpoint.go
+++ b/database/recovery/checkpoint.go
@@ -1,0 +1,415 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	// checkpointFilePrefix and checkpointFileSuffix bracket the zero-padded
+	// sequence number in a checkpoint filename, so a lexical sort of the
+	// directory is also a numeric sort by sequence.
+	checkpointFilePrefix = "checkpoint-"
+	checkpointFileSuffix = ".bin"
+	// checkpointSeqDigits pads sequence numbers wide enough for uint64.
+	checkpointSeqDigits = 20
+	// defaultCheckpointRetain is how many checkpoint generations to keep. One
+	// is enough to recover; keeping a few means a checkpoint corrupted by bad
+	// media still leaves an older anchor to fall back to.
+	defaultCheckpointRetain = 3
+)
+
+// ErrNoCheckpoint reports that no readable checkpoint exists yet. It is the
+// expected result on a fresh database, not a failure.
+var ErrNoCheckpoint = errors.New("no valid checkpoint found")
+
+// Checkpoint is a merkle-rooted summary of agreed cross-store state at a point
+// in the journal.
+//
+// It is a summary, not a snapshot of the data: recovery uses it as a verified
+// anchor for what the stores agreed on at that sequence, and as the floor below
+// which journal records need not be replayed. The merkle root binds every other
+// field, so a checkpoint whose bytes were damaged in a way the frame checksum
+// happens to survive still fails verification.
+type Checkpoint struct {
+	TipHash     []byte
+	BlobTipHash []byte
+	MerkleRoot  []byte
+	// Seq is the journal sequence this checkpoint covers. Records at or
+	// below it are already reflected in both stores.
+	Seq uint64
+	// CreatedUnixMilli is when the checkpoint was taken, for operator logs.
+	CreatedUnixMilli int64
+	// CommitTimestamp is the cross-store fence both stores held.
+	CommitTimestamp int64
+	TipSlot         uint64
+	TipBlockNumber  uint64
+	BlobTipSlot     uint64
+}
+
+// TipPoint returns the metadata tip the checkpoint recorded.
+func (c *Checkpoint) TipPoint() Point {
+	return Point{Slot: c.TipSlot, Hash: c.TipHash}
+}
+
+// BlobTipPoint returns the blob tip the checkpoint recorded.
+func (c *Checkpoint) BlobTipPoint() Point {
+	return Point{Slot: c.BlobTipSlot, Hash: c.BlobTipHash}
+}
+
+// merkleLeaves renders the checkpoint as an ordered, self-describing leaf set.
+//
+// Each leaf carries a field-name tag so two different field groups can never
+// produce the same leaf bytes, and the order is fixed by this function rather
+// than by struct layout so a future field reordering cannot silently change
+// historical roots.
+func (c *Checkpoint) merkleLeaves() [][]byte {
+	leaf := func(tag string, encode func(*encoder)) []byte {
+		e := &encoder{buf: append([]byte(tag), 0)}
+		encode(e)
+		return e.buf
+	}
+	return [][]byte{
+		leaf("seq", func(e *encoder) { e.uint64(c.Seq) }),
+		leaf("created_unix_milli", func(e *encoder) {
+			e.int64(c.CreatedUnixMilli)
+		}),
+		leaf("commit_timestamp", func(e *encoder) {
+			e.int64(c.CommitTimestamp)
+		}),
+		leaf("tip", func(e *encoder) {
+			e.uint64(c.TipSlot)
+			e.uint64(c.TipBlockNumber)
+			e.bytesField(c.TipHash)
+		}),
+		leaf("blob_tip", func(e *encoder) {
+			e.uint64(c.BlobTipSlot)
+			e.bytesField(c.BlobTipHash)
+		}),
+	}
+}
+
+// ComputeMerkleRoot returns the root the checkpoint's contents imply.
+func (c *Checkpoint) ComputeMerkleRoot() []byte {
+	return MerkleRoot(c.merkleLeaves())
+}
+
+// Verify reports whether the recorded merkle root matches the contents.
+func (c *Checkpoint) Verify() error {
+	if len(c.MerkleRoot) == 0 {
+		return errors.New("checkpoint has no merkle root")
+	}
+	if !bytes.Equal(c.MerkleRoot, c.ComputeMerkleRoot()) {
+		return errors.New("checkpoint merkle root does not match contents")
+	}
+	return nil
+}
+
+// Seal fills in the merkle root over the checkpoint's current contents. Call it
+// after every field is set and before writing the checkpoint anywhere.
+func (c *Checkpoint) Seal() {
+	c.MerkleRoot = c.ComputeMerkleRoot()
+}
+
+// encodeCheckpoint renders a checkpoint payload. Hash fields too long for the
+// wire format are rejected by the encoder.
+func encodeCheckpoint(c Checkpoint) ([]byte, error) {
+	e := &encoder{}
+	e.uint64(c.Seq)
+	e.int64(c.CreatedUnixMilli)
+	e.int64(c.CommitTimestamp)
+	e.uint64(c.TipSlot)
+	e.uint64(c.TipBlockNumber)
+	e.bytesField(c.TipHash)
+	e.uint64(c.BlobTipSlot)
+	e.bytesField(c.BlobTipHash)
+	e.bytesField(c.MerkleRoot)
+	if e.err != nil {
+		return nil, fmt.Errorf("encode checkpoint: %w", e.err)
+	}
+	return e.buf, nil
+}
+
+// decodeCheckpoint parses a checkpoint payload. It does not verify the merkle
+// root; callers decide whether an unverified checkpoint is useful to them.
+func decodeCheckpoint(payload []byte) (Checkpoint, error) {
+	d := &decoder{buf: payload}
+	var c Checkpoint
+	c.Seq = d.uint64()
+	c.CreatedUnixMilli = d.int64()
+	c.CommitTimestamp = d.int64()
+	c.TipSlot = d.uint64()
+	c.TipBlockNumber = d.uint64()
+	c.TipHash = d.bytesField()
+	c.BlobTipSlot = d.uint64()
+	c.BlobTipHash = d.bytesField()
+	c.MerkleRoot = d.bytesField()
+	if err := d.done(); err != nil {
+		return Checkpoint{}, err
+	}
+	return c, nil
+}
+
+// CheckpointStore persists checkpoint generations as individual files.
+//
+// Each generation is written to a temporary file, fsynced, then renamed into
+// place and the directory fsynced, so a crash mid-write leaves either the
+// previous generation or the new one, never a half-written file that reads as
+// valid.
+type CheckpointStore struct {
+	logger *slog.Logger
+	dir    string
+	mu     sync.Mutex
+	retain int
+}
+
+// NewCheckpointStore opens (creating if needed) a checkpoint directory.
+func NewCheckpointStore(
+	dir string,
+	retain int,
+	logger *slog.Logger,
+) (*CheckpointStore, error) {
+	if dir == "" {
+		return nil, errors.New("checkpoint directory is required")
+	}
+	if retain <= 0 {
+		retain = defaultCheckpointRetain
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create checkpoint dir %q: %w", dir, err)
+	}
+	return &CheckpointStore{dir: dir, retain: retain, logger: logger}, nil
+}
+
+// Dir returns the directory holding checkpoint files.
+func (s *CheckpointStore) Dir() string {
+	return s.dir
+}
+
+func (s *CheckpointStore) path(seq uint64) string {
+	return filepath.Join(
+		s.dir,
+		fmt.Sprintf(
+			"%s%0*d%s",
+			checkpointFilePrefix,
+			checkpointSeqDigits,
+			seq,
+			checkpointFileSuffix,
+		),
+	)
+}
+
+// Write seals and durably stores a checkpoint generation, then prunes older
+// generations beyond the retain count.
+func (s *CheckpointStore) Write(c Checkpoint) error {
+	c.Seal()
+	record := Record{Type: RecordTypeCheckpoint, Seq: c.Seq, Checkpoint: &c}
+	frame, err := appendFrame(nil, record)
+	if err != nil {
+		return fmt.Errorf("encode checkpoint: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	final := s.path(c.Seq)
+	tmp, err := os.CreateTemp(s.dir, checkpointFilePrefix+"*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp checkpoint: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Any failure past this point must not leave the temp file behind, and
+	// the successful path renames it away before this runs.
+	defer func() {
+		if _, statErr := os.Stat(tmpName); statErr == nil {
+			if rmErr := os.Remove(tmpName); rmErr != nil {
+				s.logger.Warn(
+					"failed to remove temp checkpoint",
+					"path", tmpName,
+					"error", rmErr,
+				)
+			}
+		}
+	}()
+	if _, err := tmp.Write(frame); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write checkpoint: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync checkpoint: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close checkpoint: %w", err)
+	}
+	if err := os.Rename(tmpName, final); err != nil {
+		return fmt.Errorf("install checkpoint: %w", err)
+	}
+	// Without a directory fsync the rename itself can be lost, leaving the
+	// new generation invisible after a crash even though its contents were
+	// synced. It is best effort: Windows refuses fsync on a directory
+	// handle outright, and losing the anchor for one generation is not
+	// worth failing a checkpoint that is otherwise written and durable.
+	if err := syncDir(s.dir); err != nil {
+		s.logger.Warn(
+			"failed to sync checkpoint dir after install",
+			"dir", s.dir,
+			"error", err,
+		)
+	}
+	s.pruneLocked()
+	return nil
+}
+
+// Latest returns the newest checkpoint that both decodes and verifies.
+//
+// Corrupt or unverifiable generations are skipped with a warning rather than
+// failing the call, which is the whole point of retaining several: a damaged
+// newest generation should fall back to an older good one. ErrNoCheckpoint is
+// returned when none are usable.
+func (s *CheckpointStore) Latest() (Checkpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seqs, err := s.generationsLocked()
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	for _, seq := range slices.Backward(seqs) {
+		path := s.path(seq)
+		c, err := readCheckpointFile(path)
+		if err != nil {
+			s.logger.Warn(
+				"skipping unusable checkpoint",
+				"path", path,
+				"error", err,
+			)
+			continue
+		}
+		return c, nil
+	}
+	return Checkpoint{}, ErrNoCheckpoint
+}
+
+// readCheckpointFile decodes and verifies a single checkpoint file.
+func readCheckpointFile(path string) (Checkpoint, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	defer f.Close() //nolint:errcheck
+	record, err := readFrame(f)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	if record.Type != RecordTypeCheckpoint || record.Checkpoint == nil {
+		return Checkpoint{}, fmt.Errorf(
+			"%w: file holds a %s record",
+			ErrCorruptRecord,
+			record.Type,
+		)
+	}
+	if err := record.Checkpoint.Verify(); err != nil {
+		return Checkpoint{}, err
+	}
+	return *record.Checkpoint, nil
+}
+
+// generationsLocked returns the stored sequence numbers in ascending order.
+func (s *CheckpointStore) generationsLocked() ([]uint64, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read checkpoint dir: %w", err)
+	}
+	var seqs []uint64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		seq, ok := parseCheckpointName(entry.Name())
+		if !ok {
+			continue
+		}
+		seqs = append(seqs, seq)
+	}
+	slices.Sort(seqs)
+	return seqs, nil
+}
+
+// parseCheckpointName extracts the sequence number from a checkpoint filename.
+func parseCheckpointName(name string) (uint64, bool) {
+	if !strings.HasPrefix(name, checkpointFilePrefix) ||
+		!strings.HasSuffix(name, checkpointFileSuffix) {
+		return 0, false
+	}
+	digits := name[len(checkpointFilePrefix) : len(name)-len(checkpointFileSuffix)]
+	seq, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return seq, true
+}
+
+// pruneLocked removes generations beyond the retain count, oldest first.
+func (s *CheckpointStore) pruneLocked() {
+	seqs, err := s.generationsLocked()
+	if err != nil {
+		s.logger.Warn("failed to list checkpoints for pruning", "error", err)
+		return
+	}
+	if len(seqs) <= s.retain {
+		return
+	}
+	for _, seq := range seqs[:len(seqs)-s.retain] {
+		path := s.path(seq)
+		if err := os.Remove(path); err != nil &&
+			!errors.Is(err, fs.ErrNotExist) {
+			s.logger.Warn(
+				"failed to prune checkpoint",
+				"path", path,
+				"error", err,
+			)
+		}
+	}
+}
+
+// syncDir fsyncs a directory so a rename into it is durable.
+//
+// Not every platform allows it — Windows rejects fsync on a directory handle,
+// and some filesystems do too — so callers treat a failure as a warning rather
+// than an error. The rename is still ordered by the filesystem's own journal
+// there.
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck
+	return f.Sync()
+}

--- a/database/recovery/checkpoint.go
+++ b/database/recovery/checkpoint.go
@@ -309,6 +309,10 @@ func (s *CheckpointStore) Latest() (Checkpoint, error) {
 			)
 			continue
 		}
+		if c.Seq != seq {
+			s.logger.Warn("skipping checkpoint whose payload sequence does not match its filename", "path", path, "filename_seq", seq, "payload_seq", c.Seq)
+			continue
+		}
 		return c, nil
 	}
 	return Checkpoint{}, ErrNoCheckpoint

--- a/database/recovery/checkpoint_test.go
+++ b/database/recovery/checkpoint_test.go
@@ -57,7 +57,10 @@ func TestCheckpointVerifyDetectsFieldTampering(t *testing.T) {
 	// Every field is bound by the root, so changing any of them after
 	// sealing must be caught.
 	mutations := map[string]func(*Checkpoint){
-		"seq":              func(c *Checkpoint) { c.Seq++ },
+		"seq": func(c *Checkpoint) { c.Seq++ },
+		"created_unix_milli": func(c *Checkpoint) {
+			c.CreatedUnixMilli++
+		},
 		"commit_timestamp": func(c *Checkpoint) { c.CommitTimestamp++ },
 		"tip_slot":         func(c *Checkpoint) { c.TipSlot++ },
 		"tip_block_number": func(c *Checkpoint) { c.TipBlockNumber++ },

--- a/database/recovery/checkpoint_test.go
+++ b/database/recovery/checkpoint_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCheckpoint(seq uint64) Checkpoint {
+	return Checkpoint{
+		Seq:              seq,
+		CreatedUnixMilli: 1700000000000 + int64(seq),
+		CommitTimestamp:  1699999999000 + int64(seq),
+		TipSlot:          1000 + seq,
+		TipHash:          bytes.Repeat([]byte{byte(seq)}, 32),
+		TipBlockNumber:   900 + seq,
+		BlobTipSlot:      1000 + seq,
+		BlobTipHash:      bytes.Repeat([]byte{byte(seq)}, 32),
+	}
+}
+
+func newTestCheckpointStore(t *testing.T, retain int) *CheckpointStore {
+	t.Helper()
+	store, err := NewCheckpointStore(t.TempDir(), retain, nil)
+	require.NoError(t, err)
+	return store
+}
+
+func TestCheckpointSealAndVerify(t *testing.T) {
+	t.Parallel()
+	cp := testCheckpoint(1)
+	assert.Error(t, cp.Verify(), "an unsealed checkpoint has no root")
+	cp.Seal()
+	assert.NoError(t, cp.Verify())
+}
+
+func TestCheckpointVerifyDetectsFieldTampering(t *testing.T) {
+	t.Parallel()
+	// Every field is bound by the root, so changing any of them after
+	// sealing must be caught.
+	mutations := map[string]func(*Checkpoint){
+		"seq":              func(c *Checkpoint) { c.Seq++ },
+		"commit_timestamp": func(c *Checkpoint) { c.CommitTimestamp++ },
+		"tip_slot":         func(c *Checkpoint) { c.TipSlot++ },
+		"tip_block_number": func(c *Checkpoint) { c.TipBlockNumber++ },
+		"tip_hash":         func(c *Checkpoint) { c.TipHash[0] ^= 0xff },
+		"blob_tip_slot":    func(c *Checkpoint) { c.BlobTipSlot++ },
+		"blob_tip_hash":    func(c *Checkpoint) { c.BlobTipHash[0] ^= 0xff },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cp := testCheckpoint(1)
+			cp.Seal()
+			mutate(&cp)
+			assert.Error(t, cp.Verify())
+		})
+	}
+}
+
+func TestCheckpointStoreWriteAndLatest(t *testing.T) {
+	t.Parallel()
+	store := newTestCheckpointStore(t, 3)
+	_, err := store.Latest()
+	assert.ErrorIs(t, err, ErrNoCheckpoint)
+
+	require.NoError(t, store.Write(testCheckpoint(1)))
+	require.NoError(t, store.Write(testCheckpoint(2)))
+
+	latest, err := store.Latest()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), latest.Seq)
+	assert.NoError(t, latest.Verify())
+}
+
+func TestCheckpointStoreSkipsCorruptGeneration(t *testing.T) {
+	t.Parallel()
+	store := newTestCheckpointStore(t, 3)
+	require.NoError(t, store.Write(testCheckpoint(1)))
+	require.NoError(t, store.Write(testCheckpoint(2)))
+
+	// Damage the newest generation. Retaining several exists precisely so
+	// this falls back to the previous good one instead of failing.
+	newest := filepath.Join(store.Dir(), "checkpoint-00000000000000000002.bin")
+	data, err := os.ReadFile(newest) //nolint:gosec
+	require.NoError(t, err)
+	data[len(data)-1] ^= 0xff
+	require.NoError(t, os.WriteFile(newest, data, 0o600))
+
+	latest, err := store.Latest()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), latest.Seq)
+}
+
+func TestCheckpointStoreReportsNoUsableGeneration(t *testing.T) {
+	t.Parallel()
+	store := newTestCheckpointStore(t, 3)
+	require.NoError(t, store.Write(testCheckpoint(1)))
+	path := filepath.Join(store.Dir(), "checkpoint-00000000000000000001.bin")
+	require.NoError(t, os.WriteFile(path, []byte("garbage"), 0o600))
+	_, err := store.Latest()
+	assert.ErrorIs(t, err, ErrNoCheckpoint)
+}
+
+func TestCheckpointStorePrunesOldGenerations(t *testing.T) {
+	t.Parallel()
+	store := newTestCheckpointStore(t, 2)
+	for seq := uint64(1); seq <= 5; seq++ {
+		require.NoError(t, store.Write(testCheckpoint(seq)))
+	}
+	entries, err := os.ReadDir(store.Dir())
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+	latest, err := store.Latest()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), latest.Seq)
+}
+
+func TestCheckpointStoreLeavesNoTempFiles(t *testing.T) {
+	t.Parallel()
+	store := newTestCheckpointStore(t, 3)
+	require.NoError(t, store.Write(testCheckpoint(1)))
+	entries, err := os.ReadDir(store.Dir())
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.NotContains(t, entry.Name(), ".tmp")
+	}
+}
+
+func TestNewCheckpointStoreRequiresDir(t *testing.T) {
+	t.Parallel()
+	_, err := NewCheckpointStore("", 3, nil)
+	assert.Error(t, err)
+}
+
+func TestCheckpointPointAccessors(t *testing.T) {
+	t.Parallel()
+	cp := testCheckpoint(4)
+	assert.Equal(
+		t,
+		Point{Slot: cp.TipSlot, Hash: cp.TipHash},
+		cp.TipPoint(),
+	)
+	assert.Equal(
+		t,
+		Point{Slot: cp.BlobTipSlot, Hash: cp.BlobTipHash},
+		cp.BlobTipPoint(),
+	)
+}

--- a/database/recovery/checkpoint_test.go
+++ b/database/recovery/checkpoint_test.go
@@ -113,6 +113,17 @@ func TestCheckpointStoreSkipsCorruptGeneration(t *testing.T) {
 	assert.Equal(t, uint64(1), latest.Seq)
 }
 
+func TestCheckpointStoreRejectsFilenamePayloadSequenceMismatch(t *testing.T) {
+	t.Parallel()
+	store := newTestCheckpointStore(t, 3)
+	require.NoError(t, store.Write(testCheckpoint(1)))
+	oldPath := filepath.Join(store.Dir(), "checkpoint-00000000000000000001.bin")
+	newPath := filepath.Join(store.Dir(), "checkpoint-00000000000000000002.bin")
+	require.NoError(t, os.Rename(oldPath, newPath))
+	_, err := store.Latest()
+	assert.ErrorIs(t, err, ErrNoCheckpoint)
+}
+
 func TestCheckpointStoreReportsNoUsableGeneration(t *testing.T) {
 	t.Parallel()
 	store := newTestCheckpointStore(t, 3)

--- a/database/recovery/consistency.go
+++ b/database/recovery/consistency.go
@@ -1,0 +1,674 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Check names, stable enough to match on in logs and tests.
+const (
+	CheckCommitTimestamps = "commit_timestamps"
+	CheckTipConsistency   = "tip_consistency"
+	CheckChainLedgerTip   = "chain_ledger_tip"
+	CheckBlockContinuity  = "block_continuity"
+	CheckUtxoIntegrity    = "utxo_integrity"
+	CheckOrphanedData     = "orphaned_data"
+)
+
+// Severity grades a check outcome.
+type Severity uint8
+
+const (
+	// SeverityOK means the check found nothing wrong.
+	SeverityOK Severity = iota
+	// SeverityWarn means the check found something an operator should see
+	// but that does not by itself make the state unusable. Repairable
+	// divergence between the stores lands here, because recovery is
+	// expected to fix it.
+	SeverityWarn
+	// SeverityFail means the check found state that recovery cannot be
+	// assumed to fix.
+	SeverityFail
+)
+
+// String renders a severity for logs.
+func (s Severity) String() string {
+	switch s {
+	case SeverityOK:
+		return "ok"
+	case SeverityWarn:
+		return "warn"
+	case SeverityFail:
+		return "fail"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(s))
+	}
+}
+
+// CheckMode selects how much work the startup checks do.
+type CheckMode string
+
+const (
+	// CheckModeOff skips the startup checks entirely.
+	CheckModeOff CheckMode = "off"
+	// CheckModeFast runs every check against a bounded window near the tip.
+	// This is the default: it is the part of the database a crash can
+	// actually have damaged.
+	CheckModeFast CheckMode = "fast"
+	// CheckModeFull widens the same checks. It is meaningfully slower on a
+	// large database and is intended for operators investigating a suspected
+	// corruption, not for every start.
+	CheckModeFull CheckMode = "full"
+)
+
+// ParseCheckMode maps a configured string to a CheckMode. An empty value
+// selects the default.
+func ParseCheckMode(v string) (CheckMode, error) {
+	switch CheckMode(strings.ToLower(strings.TrimSpace(v))) {
+	case "":
+		return CheckModeFast, nil
+	case CheckModeOff:
+		return CheckModeOff, nil
+	case CheckModeFast:
+		return CheckModeFast, nil
+	case CheckModeFull:
+		return CheckModeFull, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid consistency check mode %q: expected off, fast or full",
+			v,
+		)
+	}
+}
+
+// Window sizes per mode.
+//
+// Fast covers more than a security parameter's worth of blocks, which bounds
+// what an interrupted commit can have touched. Full widens each window by
+// roughly an order of magnitude; the block and UTxO windows are the expensive
+// ones because each entry reads stored CBOR, so they stay well short of "scan
+// the whole database", which on mainnet is hours of I/O rather than a startup
+// check.
+const (
+	fastContinuityDepth = 512
+	fullContinuityDepth = 4096
+	fastUtxoSample      = 512
+	fullUtxoSample      = 16384
+	fastOrphanLimit     = 1024
+	fullOrphanLimit     = 16384
+)
+
+// maxReportedBreaks bounds how many linkage breaks a check result spells out.
+// The count it reports is not capped; only the examples are.
+const maxReportedBreaks = 5
+
+// continuityDepth returns how many blocks beneath the tip to link-check.
+func (m CheckMode) continuityDepth() int {
+	if m == CheckModeFull {
+		return fullContinuityDepth
+	}
+	return fastContinuityDepth
+}
+
+// utxoSample returns how many live UTxOs to resolve.
+func (m CheckMode) utxoSample() int {
+	if m == CheckModeFull {
+		return fullUtxoSample
+	}
+	return fastUtxoSample
+}
+
+// orphanLimit returns how many orphaned blob blocks to enumerate.
+func (m CheckMode) orphanLimit() int {
+	if m == CheckModeFull {
+		return fullOrphanLimit
+	}
+	return fastOrphanLimit
+}
+
+// BlockRef is the minimal view of a stored block the checks need.
+type BlockRef struct {
+	Hash     []byte
+	PrevHash []byte
+	Slot     uint64
+	Number   uint64
+	ID       uint64
+}
+
+// Point returns the block's chain position.
+func (b BlockRef) Point() Point {
+	return Point{Slot: b.Slot, Hash: b.Hash}
+}
+
+// UtxoIntegrityResult reports what a bounded UTxO integrity scan found.
+type UtxoIntegrityResult struct {
+	// Unresolvable names the UTxOs whose stored CBOR could not be read
+	// back, in a form safe to log.
+	Unresolvable []string
+	// Checked counts the UTxOs actually examined, which is at most the
+	// requested limit and may be fewer on a small database.
+	Checked int
+}
+
+// StateSource is the read-only view of stored state the checks need.
+//
+// It is declared here, and implemented by the database layer, so this package
+// stays below the packages it inspects.
+type StateSource interface {
+	// MetadataTip returns the tip the metadata store records, which is the
+	// ledger's view of how far state has been applied.
+	MetadataTip() (Point, uint64, error)
+	// BlobTip returns the newest block present in the blob store.
+	BlobTip() (Point, error)
+	// CommitTimestamps returns the cross-store fence each store holds.
+	CommitTimestamps() (metadata int64, blob int64, err error)
+	// RecentBlocks returns up to limit blocks ending at the blob tip,
+	// newest first.
+	RecentBlocks(limit int) ([]BlockRef, error)
+	// OrphanBlobs returns up to limit blocks the blob store holds above
+	// afterSlot, oldest first.
+	OrphanBlobs(afterSlot uint64, limit int) ([]BlockRef, error)
+	// CheckUtxos resolves up to limit live UTxOs against their stored CBOR.
+	CheckUtxos(limit int) (UtxoIntegrityResult, error)
+}
+
+// ChainTipSource is the optional part of a source that can also report the
+// chain manager's tip. Sources that only see the database do not implement it,
+// and the chain-versus-ledger tip check is skipped for them.
+type ChainTipSource interface {
+	ChainTip() (Point, uint64, error)
+}
+
+// CheckResult is one check's outcome.
+type CheckResult struct {
+	Name     string
+	Detail   string
+	Severity Severity
+}
+
+// Report collects the outcomes of a consistency run.
+type Report struct {
+	Mode    CheckMode
+	Results []CheckResult
+}
+
+// Worst returns the highest severity in the report.
+func (r Report) Worst() Severity {
+	worst := SeverityOK
+	for _, res := range r.Results {
+		if res.Severity > worst {
+			worst = res.Severity
+		}
+	}
+	return worst
+}
+
+// Failed reports whether any check reached SeverityFail.
+func (r Report) Failed() bool {
+	return r.Worst() == SeverityFail
+}
+
+// Find returns the result for a named check.
+func (r Report) Find(name string) (CheckResult, bool) {
+	for _, res := range r.Results {
+		if res.Name == name {
+			return res, true
+		}
+	}
+	return CheckResult{}, false
+}
+
+// Log writes each result at a level matching its severity.
+func (r Report) Log(logger *slog.Logger) {
+	if logger == nil {
+		return
+	}
+	for _, res := range r.Results {
+		switch res.Severity {
+		case SeverityFail:
+			logger.Error(
+				"consistency check failed",
+				"check", res.Name,
+				"detail", res.Detail,
+			)
+		case SeverityWarn:
+			logger.Warn(
+				"consistency check reported a problem",
+				"check", res.Name,
+				"detail", res.Detail,
+			)
+		case SeverityOK:
+			logger.Debug(
+				"consistency check passed",
+				"check", res.Name,
+				"detail", res.Detail,
+			)
+		}
+	}
+}
+
+// Checker runs the startup consistency checks against a StateSource.
+type Checker struct {
+	source StateSource
+	logger *slog.Logger
+	mode   CheckMode
+}
+
+// NewChecker builds a checker. A zero mode selects CheckModeFast.
+func NewChecker(
+	source StateSource,
+	mode CheckMode,
+	logger *slog.Logger,
+) (*Checker, error) {
+	if source == nil {
+		return nil, errors.New("consistency checker requires a state source")
+	}
+	if mode == "" {
+		mode = CheckModeFast
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return &Checker{source: source, mode: mode, logger: logger}, nil
+}
+
+// Run executes every check and returns the collected report.
+//
+// A check that cannot run because the store returned an error is recorded as a
+// failure rather than aborting the run: an operator is better served by the
+// full picture than by the first problem encountered.
+func (c *Checker) Run() Report {
+	report := Report{Mode: c.mode}
+	if c.mode == CheckModeOff {
+		return report
+	}
+	metaTip, metaBlockNumber, metaTipErr := c.source.MetadataTip()
+	blobTip, blobTipErr := c.source.BlobTip()
+	report.Results = append(
+		report.Results,
+		c.checkCommitTimestamps(),
+		c.checkTipConsistency(metaTip, metaTipErr, blobTip, blobTipErr),
+	)
+	if chainSource, ok := c.source.(ChainTipSource); ok {
+		report.Results = append(
+			report.Results,
+			c.checkChainLedgerTip(
+				chainSource,
+				metaTip,
+				metaBlockNumber,
+				metaTipErr,
+			),
+		)
+	}
+	report.Results = append(
+		report.Results,
+		c.checkBlockContinuity(),
+		c.checkUtxoIntegrity(),
+		c.checkOrphanedData(metaTip, metaTipErr),
+	)
+	return report
+}
+
+// checkCommitTimestamps compares the cross-store fence each store holds.
+func (c *Checker) checkCommitTimestamps() CheckResult {
+	metadataTS, blobTS, err := c.source.CommitTimestamps()
+	if err != nil {
+		return failed(CheckCommitTimestamps, "read commit timestamps", err)
+	}
+	if metadataTS <= 0 {
+		return CheckResult{
+			Name:     CheckCommitTimestamps,
+			Severity: SeverityOK,
+			Detail:   "no commits recorded yet",
+		}
+	}
+	if metadataTS == blobTS {
+		return CheckResult{
+			Name:     CheckCommitTimestamps,
+			Severity: SeverityOK,
+			Detail: fmt.Sprintf(
+				"both stores at commit timestamp %d",
+				metadataTS,
+			),
+		}
+	}
+	// A mismatch is the expected signature of a crash inside the commit
+	// window. Recovery repairs it, so it is a warning here rather than a
+	// failure.
+	return CheckResult{
+		Name:     CheckCommitTimestamps,
+		Severity: SeverityWarn,
+		Detail: fmt.Sprintf(
+			"commit timestamp mismatch: metadata %d, blob %d",
+			metadataTS,
+			blobTS,
+		),
+	}
+}
+
+// checkTipConsistency compares the metadata tip with the blob tip.
+//
+// The commit ordering means the blob store may legitimately be ahead by the
+// blocks an interrupted commit had written. The blob store being behind is the
+// dangerous direction: the ledger then references blocks that are gone.
+func (c *Checker) checkTipConsistency(
+	metaTip Point,
+	metaTipErr error,
+	blobTip Point,
+	blobTipErr error,
+) CheckResult {
+	if metaTipErr != nil {
+		return failed(CheckTipConsistency, "read metadata tip", metaTipErr)
+	}
+	if blobTipErr != nil {
+		return failed(CheckTipConsistency, "read blob tip", blobTipErr)
+	}
+	switch {
+	case metaTip.Equal(blobTip):
+		return CheckResult{
+			Name:     CheckTipConsistency,
+			Severity: SeverityOK,
+			Detail: fmt.Sprintf(
+				"metadata and blob tips agree at slot %d",
+				metaTip.Slot,
+			),
+		}
+	case blobTip.Slot > metaTip.Slot:
+		return CheckResult{
+			Name:     CheckTipConsistency,
+			Severity: SeverityWarn,
+			Detail: fmt.Sprintf(
+				"blob tip slot %d is ahead of metadata tip slot %d; blocks above the metadata tip are recoverable orphans",
+				blobTip.Slot,
+				metaTip.Slot,
+			),
+		}
+	case blobTip.Slot < metaTip.Slot:
+		return CheckResult{
+			Name:     CheckTipConsistency,
+			Severity: SeverityFail,
+			Detail: fmt.Sprintf(
+				"blob tip slot %d is behind metadata tip slot %d; the ledger references blocks the blob store does not hold",
+				blobTip.Slot,
+				metaTip.Slot,
+			),
+		}
+	default:
+		return CheckResult{
+			Name:     CheckTipConsistency,
+			Severity: SeverityFail,
+			Detail: fmt.Sprintf(
+				"metadata and blob tips disagree at slot %d: metadata %s, blob %s",
+				metaTip.Slot,
+				shortHash(metaTip.Hash),
+				shortHash(blobTip.Hash),
+			),
+		}
+	}
+}
+
+// checkChainLedgerTip compares the chain manager's tip with the ledger tip.
+//
+// The chain being ahead is normal — the ledger catches up forward — so only a
+// ledger ahead of the chain, or a same-slot hash disagreement, is a problem.
+func (c *Checker) checkChainLedgerTip(
+	source ChainTipSource,
+	ledgerTip Point,
+	ledgerBlockNumber uint64,
+	ledgerTipErr error,
+) CheckResult {
+	if ledgerTipErr != nil {
+		return failed(CheckChainLedgerTip, "read ledger tip", ledgerTipErr)
+	}
+	chainTip, chainBlockNumber, err := source.ChainTip()
+	if err != nil {
+		return failed(CheckChainLedgerTip, "read chain tip", err)
+	}
+	switch {
+	case chainTip.Equal(ledgerTip):
+		return CheckResult{
+			Name:     CheckChainLedgerTip,
+			Severity: SeverityOK,
+			Detail: fmt.Sprintf(
+				"chain and ledger tips agree at slot %d",
+				chainTip.Slot,
+			),
+		}
+	case chainTip.Slot > ledgerTip.Slot:
+		return CheckResult{
+			Name:     CheckChainLedgerTip,
+			Severity: SeverityOK,
+			Detail: fmt.Sprintf(
+				"chain tip slot %d is ahead of ledger tip slot %d by %d blocks; the ledger replays forward to catch up",
+				chainTip.Slot,
+				ledgerTip.Slot,
+				saturatingSub(chainBlockNumber, ledgerBlockNumber),
+			),
+		}
+	case chainTip.Slot < ledgerTip.Slot:
+		return CheckResult{
+			Name:     CheckChainLedgerTip,
+			Severity: SeverityWarn,
+			Detail: fmt.Sprintf(
+				"ledger tip slot %d is ahead of chain tip slot %d; the ledger is rolled back to the chain tip at startup",
+				ledgerTip.Slot,
+				chainTip.Slot,
+			),
+		}
+	default:
+		return CheckResult{
+			Name:     CheckChainLedgerTip,
+			Severity: SeverityWarn,
+			Detail: fmt.Sprintf(
+				"chain and ledger disagree at slot %d: chain %s, ledger %s",
+				chainTip.Slot,
+				shortHash(chainTip.Hash),
+				shortHash(ledgerTip.Hash),
+			),
+		}
+	}
+}
+
+// checkBlockContinuity walks back from the blob tip verifying that each block
+// names its predecessor.
+//
+// Hash linkage is the reliable invariant. Block numbers are only advisory here
+// because a Byron epoch boundary block carries the same chain difficulty as the
+// block before it, so a strict decrement would report false gaps.
+func (c *Checker) checkBlockContinuity() CheckResult {
+	depth := c.mode.continuityDepth()
+	blocks, err := c.source.RecentBlocks(depth)
+	if err != nil {
+		return failed(CheckBlockContinuity, "read recent blocks", err)
+	}
+	if len(blocks) < 2 {
+		return CheckResult{
+			Name:     CheckBlockContinuity,
+			Severity: SeverityOK,
+			Detail: fmt.Sprintf(
+				"only %d blocks stored; nothing to link-check",
+				len(blocks),
+			),
+		}
+	}
+	// The whole window is walked so the reported count is the real extent of
+	// the damage; only the printed examples are capped. Stopping the walk at
+	// the cap would report "5 breaks" for a window with fifty, understating
+	// it in exactly the case an operator most needs the true number.
+	var breaks []string
+	var breakCount, numberAnomalies int
+	for i := range len(blocks) - 1 {
+		newer := blocks[i]
+		older := blocks[i+1]
+		if len(newer.PrevHash) > 0 &&
+			!bytes.Equal(newer.PrevHash, older.Hash) {
+			breakCount++
+			if len(breaks) < maxReportedBreaks {
+				breaks = append(breaks, fmt.Sprintf(
+					"block %d/%s names predecessor %s but the preceding stored block is %d/%s",
+					newer.Slot,
+					shortHash(newer.Hash),
+					shortHash(newer.PrevHash),
+					older.Slot,
+					shortHash(older.Hash),
+				))
+			}
+		}
+		if newer.Number < older.Number || newer.Number > older.Number+1 {
+			numberAnomalies++
+		}
+	}
+	if breakCount > 0 {
+		return CheckResult{
+			Name:     CheckBlockContinuity,
+			Severity: SeverityFail,
+			Detail: fmt.Sprintf(
+				"%d of the newest %d stored blocks do not link to their predecessor; first %d: %s",
+				breakCount,
+				len(blocks),
+				len(breaks),
+				strings.Join(breaks, "; "),
+			),
+		}
+	}
+	if numberAnomalies > 0 {
+		return CheckResult{
+			Name:     CheckBlockContinuity,
+			Severity: SeverityWarn,
+			Detail: fmt.Sprintf(
+				"hash linkage is intact across the newest %d blocks but %d block-number steps are not monotonic",
+				len(blocks),
+				numberAnomalies,
+			),
+		}
+	}
+	return CheckResult{
+		Name:     CheckBlockContinuity,
+		Severity: SeverityOK,
+		Detail: fmt.Sprintf(
+			"hash linkage intact across the newest %d blocks",
+			len(blocks),
+		),
+	}
+}
+
+// checkUtxoIntegrity resolves a bounded sample of live UTxOs against the CBOR
+// the blob store holds for them.
+//
+// Live UTxOs are stored as offset references into block CBOR rather than as
+// inline values, so a UTxO row whose block was lost resolves to nothing. That
+// is silent until something tries to spend it, which is why it is worth
+// sampling at startup.
+func (c *Checker) checkUtxoIntegrity() CheckResult {
+	limit := c.mode.utxoSample()
+	result, err := c.source.CheckUtxos(limit)
+	if err != nil {
+		return failed(CheckUtxoIntegrity, "sample live utxos", err)
+	}
+	if len(result.Unresolvable) > 0 {
+		detail := result.Unresolvable
+		if len(detail) > 5 {
+			detail = detail[:5]
+		}
+		return CheckResult{
+			Name:     CheckUtxoIntegrity,
+			Severity: SeverityFail,
+			Detail: fmt.Sprintf(
+				"%d of %d sampled live utxos could not be resolved: %s",
+				len(result.Unresolvable),
+				result.Checked,
+				strings.Join(detail, ", "),
+			),
+		}
+	}
+	return CheckResult{
+		Name:     CheckUtxoIntegrity,
+		Severity: SeverityOK,
+		Detail: fmt.Sprintf(
+			"%d sampled live utxos resolved",
+			result.Checked,
+		),
+	}
+}
+
+// checkOrphanedData looks for blocks the blob store holds above the metadata
+// tip, the residue an interrupted commit leaves behind.
+func (c *Checker) checkOrphanedData(
+	metaTip Point,
+	metaTipErr error,
+) CheckResult {
+	if metaTipErr != nil {
+		return failed(CheckOrphanedData, "read metadata tip", metaTipErr)
+	}
+	orphans, err := c.source.OrphanBlobs(metaTip.Slot, c.mode.orphanLimit())
+	if err != nil {
+		return failed(CheckOrphanedData, "scan for orphaned blobs", err)
+	}
+	if len(orphans) == 0 {
+		return CheckResult{
+			Name:     CheckOrphanedData,
+			Severity: SeverityOK,
+			Detail: fmt.Sprintf(
+				"no blocks stored above the metadata tip slot %d",
+				metaTip.Slot,
+			),
+		}
+	}
+	return CheckResult{
+		Name:     CheckOrphanedData,
+		Severity: SeverityWarn,
+		Detail: fmt.Sprintf(
+			"%d blocks stored above the metadata tip slot %d, from slot %d to %d",
+			len(orphans),
+			metaTip.Slot,
+			orphans[0].Slot,
+			orphans[len(orphans)-1].Slot,
+		),
+	}
+}
+
+// failed builds a failure result for a check that could not run.
+func failed(name, what string, err error) CheckResult {
+	return CheckResult{
+		Name:     name,
+		Severity: SeverityFail,
+		Detail:   fmt.Sprintf("could not %s: %v", what, err),
+	}
+}
+
+// shortHash renders a block hash prefix for messages.
+func shortHash(hash []byte) string {
+	if len(hash) == 0 {
+		return "<none>"
+	}
+	if len(hash) > 8 {
+		hash = hash[:8]
+	}
+	return hex.EncodeToString(hash)
+}
+
+// saturatingSub subtracts without wrapping past zero.
+func saturatingSub(a, b uint64) uint64 {
+	if a < b {
+		return 0
+	}
+	return a - b
+}

--- a/database/recovery/consistency.go
+++ b/database/recovery/consistency.go
@@ -261,6 +261,13 @@ func (r Report) Log(logger *slog.Logger) {
 				"check", res.Name,
 				"detail", res.Detail,
 			)
+		default:
+			logger.Warn(
+				"consistency check reported an unknown severity",
+				"check", res.Name,
+				"severity", res.Severity.String(),
+				"detail", res.Detail,
+			)
 		}
 	}
 }

--- a/database/recovery/consistency_test.go
+++ b/database/recovery/consistency_test.go
@@ -1,0 +1,403 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSource is a scriptable StateSource for the checks and for recovery.
+type fakeSource struct {
+	// timestampsFn, when set, answers CommitTimestamps by call number so a
+	// test can script a value that changes between reads.
+	timestampsFn    func(call int) (int64, int64, error)
+	metadataTipErr  error
+	blobTipErr      error
+	timestampsErr   error
+	recentErr       error
+	orphanErr       error
+	utxoErr         error
+	metadataTip     Point
+	blobTip         Point
+	recent          []BlockRef
+	orphans         []BlockRef
+	utxos           UtxoIntegrityResult
+	metadataBlockNo uint64
+	metadataTS      int64
+	blobTS          int64
+	orphanAfterSlot uint64
+	orphanCalls     int
+	timestampCalls  int
+}
+
+func (f *fakeSource) MetadataTip() (Point, uint64, error) {
+	return f.metadataTip, f.metadataBlockNo, f.metadataTipErr
+}
+
+func (f *fakeSource) BlobTip() (Point, error) {
+	return f.blobTip, f.blobTipErr
+}
+
+func (f *fakeSource) CommitTimestamps() (int64, int64, error) {
+	f.timestampCalls++
+	if f.timestampsFn != nil {
+		return f.timestampsFn(f.timestampCalls)
+	}
+	return f.metadataTS, f.blobTS, f.timestampsErr
+}
+
+func (f *fakeSource) RecentBlocks(limit int) ([]BlockRef, error) {
+	if f.recentErr != nil {
+		return nil, f.recentErr
+	}
+	if limit < len(f.recent) {
+		return f.recent[:limit], nil
+	}
+	return f.recent, nil
+}
+
+func (f *fakeSource) OrphanBlobs(
+	afterSlot uint64,
+	limit int,
+) ([]BlockRef, error) {
+	f.orphanCalls++
+	f.orphanAfterSlot = afterSlot
+	if f.orphanErr != nil {
+		return nil, f.orphanErr
+	}
+	var out []BlockRef
+	for _, ref := range f.orphans {
+		if ref.Slot <= afterSlot || len(out) >= limit {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func (f *fakeSource) CheckUtxos(limit int) (UtxoIntegrityResult, error) {
+	return f.utxos, f.utxoErr
+}
+
+// chainTipSource adds a chain tip to a fake source.
+type chainTipSource struct {
+	*fakeSource
+	err       error
+	chainTip  Point
+	chainNoBN uint64
+}
+
+func (c chainTipSource) ChainTip() (Point, uint64, error) {
+	return c.chainTip, c.chainNoBN, c.err
+}
+
+// linkedBlocks builds a newest-first run of correctly linked blocks.
+func linkedBlocks(count int) []BlockRef {
+	blocks := make([]BlockRef, count)
+	for i := range count {
+		// Index 0 is the newest, so slot and number decrease with i.
+		n := uint64(count - i)
+		blocks[i] = BlockRef{
+			Hash:     []byte{byte(n)},
+			PrevHash: []byte{byte(n - 1)},
+			Slot:     n * 10,
+			Number:   n,
+			ID:       n,
+		}
+	}
+	return blocks
+}
+
+func runChecks(t *testing.T, source StateSource, mode CheckMode) Report {
+	t.Helper()
+	checker, err := NewChecker(source, mode, nil)
+	require.NoError(t, err)
+	return checker.Run()
+}
+
+func requireCheck(t *testing.T, report Report, name string) CheckResult {
+	t.Helper()
+	result, ok := report.Find(name)
+	require.True(t, ok, "report has no %s check", name)
+	return result
+}
+
+func TestCheckerReportsHealthyState(t *testing.T) {
+	t.Parallel()
+	tip := Point{Slot: 100, Hash: []byte{10}}
+	source := &fakeSource{
+		metadataTip: tip,
+		blobTip:     tip,
+		metadataTS:  5,
+		blobTS:      5,
+		recent:      linkedBlocks(10),
+		utxos:       UtxoIntegrityResult{Checked: 10},
+	}
+	report := runChecks(t, source, CheckModeFast)
+	assert.Equal(t, SeverityOK, report.Worst())
+	assert.False(t, report.Failed())
+}
+
+func TestCheckerModeOffRunsNothing(t *testing.T) {
+	t.Parallel()
+	report := runChecks(t, &fakeSource{}, CheckModeOff)
+	assert.Empty(t, report.Results)
+}
+
+func TestCheckerFlagsCommitTimestampMismatch(t *testing.T) {
+	t.Parallel()
+	source := &fakeSource{metadataTS: 5, blobTS: 6}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckCommitTimestamps,
+	)
+	// The mismatch is repairable, so it warns rather than failing.
+	assert.Equal(t, SeverityWarn, result.Severity)
+}
+
+func TestCheckerAcceptsFreshDatabase(t *testing.T) {
+	t.Parallel()
+	source := &fakeSource{metadataTS: 0, blobTS: 0}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckCommitTimestamps,
+	)
+	assert.Equal(t, SeverityOK, result.Severity)
+}
+
+func TestCheckerBlobAheadWarnsAndBlobBehindFails(t *testing.T) {
+	t.Parallel()
+	t.Run("blob ahead", func(t *testing.T) {
+		t.Parallel()
+		source := &fakeSource{
+			metadataTip: Point{Slot: 100, Hash: []byte{1}},
+			blobTip:     Point{Slot: 110, Hash: []byte{2}},
+		}
+		result := requireCheck(
+			t,
+			runChecks(t, source, CheckModeFast),
+			CheckTipConsistency,
+		)
+		assert.Equal(t, SeverityWarn, result.Severity)
+	})
+	t.Run("blob behind", func(t *testing.T) {
+		t.Parallel()
+		source := &fakeSource{
+			metadataTip: Point{Slot: 110, Hash: []byte{2}},
+			blobTip:     Point{Slot: 100, Hash: []byte{1}},
+		}
+		result := requireCheck(
+			t,
+			runChecks(t, source, CheckModeFast),
+			CheckTipConsistency,
+		)
+		assert.Equal(t, SeverityFail, result.Severity)
+	})
+	t.Run("same slot different hash", func(t *testing.T) {
+		t.Parallel()
+		source := &fakeSource{
+			metadataTip: Point{Slot: 100, Hash: []byte{1}},
+			blobTip:     Point{Slot: 100, Hash: []byte{2}},
+		}
+		result := requireCheck(
+			t,
+			runChecks(t, source, CheckModeFast),
+			CheckTipConsistency,
+		)
+		assert.Equal(t, SeverityFail, result.Severity)
+	})
+}
+
+func TestCheckerDetectsBrokenBlockLinkage(t *testing.T) {
+	t.Parallel()
+	blocks := linkedBlocks(6)
+	blocks[2].PrevHash = []byte{0xff}
+	source := &fakeSource{recent: blocks}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckBlockContinuity,
+	)
+	assert.Equal(t, SeverityFail, result.Severity)
+}
+
+func TestCheckerAcceptsRepeatedBlockNumbers(t *testing.T) {
+	t.Parallel()
+	// A Byron epoch boundary block carries the same chain difficulty as the
+	// block before it, so equal consecutive numbers must not be reported.
+	blocks := linkedBlocks(4)
+	blocks[0].Number = blocks[1].Number
+	source := &fakeSource{recent: blocks}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckBlockContinuity,
+	)
+	assert.Equal(t, SeverityOK, result.Severity)
+}
+
+func TestCheckerWarnsOnBlockNumberGap(t *testing.T) {
+	t.Parallel()
+	blocks := linkedBlocks(4)
+	blocks[0].Number = blocks[1].Number + 5
+	source := &fakeSource{recent: blocks}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckBlockContinuity,
+	)
+	assert.Equal(t, SeverityWarn, result.Severity)
+}
+
+func TestCheckerSkipsLinkageWithTooFewBlocks(t *testing.T) {
+	t.Parallel()
+	source := &fakeSource{recent: linkedBlocks(1)}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckBlockContinuity,
+	)
+	assert.Equal(t, SeverityOK, result.Severity)
+}
+
+func TestCheckerFailsOnUnresolvableUtxos(t *testing.T) {
+	t.Parallel()
+	source := &fakeSource{
+		utxos: UtxoIntegrityResult{
+			Checked:      10,
+			Unresolvable: []string{"aa#0", "bb#1"},
+		},
+	}
+	result := requireCheck(
+		t,
+		runChecks(t, source, CheckModeFast),
+		CheckUtxoIntegrity,
+	)
+	assert.Equal(t, SeverityFail, result.Severity)
+}
+
+func TestCheckerReportsStoreErrorsAsFailures(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+	source := &fakeSource{
+		timestampsErr:  boom,
+		metadataTipErr: boom,
+		blobTipErr:     boom,
+		recentErr:      boom,
+		utxoErr:        boom,
+		orphanErr:      boom,
+	}
+	report := runChecks(t, source, CheckModeFast)
+	assert.True(t, report.Failed())
+	for _, name := range []string{
+		CheckCommitTimestamps,
+		CheckTipConsistency,
+		CheckBlockContinuity,
+		CheckUtxoIntegrity,
+		CheckOrphanedData,
+	} {
+		assert.Equal(
+			t,
+			SeverityFail,
+			requireCheck(t, report, name).Severity,
+			"check %s", name,
+		)
+	}
+}
+
+func TestCheckerChainTipComparisons(t *testing.T) {
+	t.Parallel()
+	ledgerTip := Point{Slot: 100, Hash: []byte{1}}
+	cases := map[string]struct {
+		chainTip Point
+		want     Severity
+	}{
+		// The chain running ahead is the normal shape: the ledger
+		// replays forward to catch up.
+		"chain ahead":  {Point{Slot: 200, Hash: []byte{2}}, SeverityOK},
+		"chain equal":  {ledgerTip, SeverityOK},
+		"chain behind": {Point{Slot: 50, Hash: []byte{3}}, SeverityWarn},
+		"same slot different hash": {
+			Point{Slot: 100, Hash: []byte{9}},
+			SeverityWarn,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := chainTipSource{
+				fakeSource: &fakeSource{metadataTip: ledgerTip},
+				chainTip:   tc.chainTip,
+			}
+			result := requireCheck(
+				t,
+				runChecks(t, source, CheckModeFast),
+				CheckChainLedgerTip,
+			)
+			assert.Equal(t, tc.want, result.Severity)
+		})
+	}
+}
+
+func TestCheckerSkipsChainTipWithoutChainSource(t *testing.T) {
+	t.Parallel()
+	report := runChecks(t, &fakeSource{}, CheckModeFast)
+	_, ok := report.Find(CheckChainLedgerTip)
+	assert.False(t, ok)
+}
+
+func TestParseCheckMode(t *testing.T) {
+	t.Parallel()
+	for input, want := range map[string]CheckMode{
+		"":      CheckModeFast,
+		"off":   CheckModeOff,
+		"FAST":  CheckModeFast,
+		" full": CheckModeFull,
+	} {
+		got, err := ParseCheckMode(input)
+		require.NoError(t, err, "input %q", input)
+		assert.Equal(t, want, got, "input %q", input)
+	}
+	_, err := ParseCheckMode("sideways")
+	assert.Error(t, err)
+}
+
+func TestCheckModeWindows(t *testing.T) {
+	t.Parallel()
+	// Full must look at strictly more than fast, or the mode is pointless.
+	assert.Greater(
+		t,
+		CheckModeFull.continuityDepth(),
+		CheckModeFast.continuityDepth(),
+	)
+	assert.Greater(t, CheckModeFull.utxoSample(), CheckModeFast.utxoSample())
+	assert.Greater(
+		t,
+		CheckModeFull.orphanLimit(),
+		CheckModeFast.orphanLimit(),
+	)
+}
+
+func TestNewCheckerRequiresSource(t *testing.T) {
+	t.Parallel()
+	_, err := NewChecker(nil, CheckModeFast, nil)
+	assert.Error(t, err)
+}

--- a/database/recovery/doc.go
+++ b/database/recovery/doc.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package recovery provides crash recovery and state consistency for the
+// node's two-store database.
+//
+// # What this is not
+//
+// This is not a redo log for block or ledger data. Both underlying stores are
+// already crash safe on their own: the blob store (Badger) has a value log and
+// the metadata store (SQLite/MySQL/Postgres) has its own journal. Duplicating
+// their durability here would be pure overhead.
+//
+// # What this is
+//
+// A logical commit in dingo spans two independent stores, and no two-phase
+// commit exists between them. Txn.Commit deliberately commits blob first, syncs
+// it, then commits metadata, so the blob store can only ever be ahead of the
+// metadata tip. A crash inside that window leaves the two stores at different
+// commit timestamps, and the store contents alone cannot say which write was in
+// flight or what it was trying to do.
+//
+// This package journals that missing information:
+//
+//   - WAL is an append-only intent journal. Before a combined commit touches
+//     either store it records what the commit intends to do (a block append at
+//     a point, a rollback to a point) and the commit timestamp fencing it, then
+//     records a commit marker once both stores are through. A begin record with
+//     no commit marker is exactly the in-flight window a crash can interrupt.
+//
+//   - CheckpointStore records periodic, merkle-rooted summaries of agreed store
+//     state. A checkpoint bounds how far back recovery ever has to look and
+//     gives recovery a verified anchor when the journal itself is unreadable.
+//     WAL segments fully covered by a durable checkpoint are removed.
+//
+//   - Checker runs the startup consistency checks: tip agreement across the
+//     stores, block continuity beneath the tip, UTxO integrity, and orphaned
+//     data beyond the tip.
+//
+//   - Manager ties those together at startup: load the newest valid checkpoint,
+//     replay the journal above it, compare the intent record against what the
+//     stores actually hold, and drive repair through the Repairer the node
+//     supplies.
+//
+// # Import direction
+//
+// This package sits below the database package that wires it in, so it never
+// imports database, ledger, chain, or node code. Everything it needs from those
+// layers arrives through the StateSource and Repairer interfaces declared here.
+package recovery

--- a/database/recovery/doc.go
+++ b/database/recovery/doc.go
@@ -44,9 +44,10 @@
 //     gives recovery a verified anchor when the journal itself is unreadable.
 //     WAL segments fully covered by a durable checkpoint are removed.
 //
-//   - Checker runs the startup consistency checks: tip agreement across the
-//     stores, block continuity beneath the tip, UTxO integrity, and orphaned
-//     data beyond the tip.
+//   - Checker runs the startup consistency checks: the commit-timestamp fence,
+//     tip agreement across the stores, chain-versus-ledger tip agreement when
+//     the source reports a chain tip, block continuity beneath the tip, UTxO
+//     integrity, and orphaned data beyond the tip.
 //
 //   - Manager ties those together at startup: load the newest valid checkpoint,
 //     replay the journal above it, compare the intent record against what the

--- a/database/recovery/merkle.go
+++ b/database/recovery/merkle.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import "crypto/sha256"
+
+// Domain separation prefixes, following RFC 6962. Hashing leaves and interior
+// nodes under different prefixes stops an attacker, or a coincidence, from
+// presenting an interior node's preimage as a leaf and vice versa.
+const (
+	merkleLeafPrefix     byte = 0x00
+	merkleInteriorPrefix byte = 0x01
+)
+
+// MerkleRoot computes a binary merkle root over leaves.
+//
+// The tree is built bottom-up, promoting an odd trailing node unchanged to the
+// next level. Order is significant: callers must present leaves in a fixed
+// canonical order so the same state always yields the same root.
+//
+// An empty leaf set hashes nothing at all, which gives the empty tree a defined
+// root that no leaf can produce: every leaf hash covers at least the leaf
+// prefix byte, so none of them is the hash of the empty string.
+func MerkleRoot(leaves [][]byte) []byte {
+	if len(leaves) == 0 {
+		sum := sha256.Sum256(nil)
+		return sum[:]
+	}
+	level := make([][]byte, 0, len(leaves))
+	for _, leaf := range leaves {
+		h := sha256.New()
+		h.Write([]byte{merkleLeafPrefix})
+		h.Write(leaf)
+		level = append(level, h.Sum(nil))
+	}
+	for len(level) > 1 {
+		next := make([][]byte, 0, (len(level)+1)/2)
+		for i := 0; i < len(level); i += 2 {
+			if i+1 == len(level) {
+				// Odd node at this level: promote it rather than
+				// duplicating it. Duplication makes an even tree
+				// and an odd tree with a repeated tail collide.
+				next = append(next, level[i])
+				continue
+			}
+			h := sha256.New()
+			h.Write([]byte{merkleInteriorPrefix})
+			h.Write(level[i])
+			h.Write(level[i+1])
+			next = append(next, h.Sum(nil))
+		}
+		level = next
+	}
+	return level[0]
+}

--- a/database/recovery/merkle_test.go
+++ b/database/recovery/merkle_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMerkleRootIsDeterministic(t *testing.T) {
+	t.Parallel()
+	leaves := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
+	assert.Equal(t, MerkleRoot(leaves), MerkleRoot(leaves))
+}
+
+func TestMerkleRootDependsOnOrder(t *testing.T) {
+	t.Parallel()
+	assert.NotEqual(
+		t,
+		MerkleRoot([][]byte{[]byte("a"), []byte("b")}),
+		MerkleRoot([][]byte{[]byte("b"), []byte("a")}),
+	)
+}
+
+func TestMerkleRootDetectsAnyLeafChange(t *testing.T) {
+	t.Parallel()
+	base := [][]byte{[]byte("alpha"), []byte("beta"), []byte("gamma")}
+	want := MerkleRoot(base)
+	for i := range base {
+		changed := make([][]byte, len(base))
+		copy(changed, base)
+		changed[i] = append([]byte{}, base[i]...)
+		changed[i][0] ^= 0xff
+		assert.NotEqual(
+			t,
+			want,
+			MerkleRoot(changed),
+			"changing leaf %d must change the root",
+			i,
+		)
+	}
+}
+
+func TestMerkleRootSingleLeafIsNotTheRawLeafHash(t *testing.T) {
+	t.Parallel()
+	// A leaf is domain-separated, so a single-leaf root must differ from a
+	// bare hash of the same bytes; otherwise a leaf preimage could be
+	// presented as a tree.
+	raw := sha256.Sum256([]byte("only"))
+	assert.NotEqual(t, raw[:], MerkleRoot([][]byte{[]byte("only")}))
+}
+
+func TestMerkleRootEmptyIsDefinedAndDistinct(t *testing.T) {
+	t.Parallel()
+	empty := MerkleRoot(nil)
+	assert.Len(t, empty, sha256.Size)
+	assert.NotEqual(t, empty, MerkleRoot([][]byte{{}}))
+}
+
+func TestMerkleRootOddLeafCountsAreDistinct(t *testing.T) {
+	t.Parallel()
+	// Promoting rather than duplicating the odd trailing node means a tree
+	// with a repeated tail does not collide with the shorter tree.
+	three := MerkleRoot([][]byte{[]byte("a"), []byte("b"), []byte("c")})
+	four := MerkleRoot(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("c")},
+	)
+	assert.NotEqual(t, three, four)
+}
+
+func TestMerkleRootSizes(t *testing.T) {
+	t.Parallel()
+	for n := 1; n <= 9; n++ {
+		t.Run(fmt.Sprintf("leaves=%d", n), func(t *testing.T) {
+			t.Parallel()
+			leaves := make([][]byte, n)
+			for i := range leaves {
+				leaves[i] = fmt.Appendf(nil, "leaf-%d", i)
+			}
+			assert.Len(t, MerkleRoot(leaves), sha256.Size)
+		})
+	}
+}

--- a/database/recovery/record.go
+++ b/database/recovery/record.go
@@ -1,0 +1,483 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+)
+
+// recordMagic prefixes every framed record so a reader can tell a truncated
+// tail apart from a stream that never held records at all.
+var recordMagic = [4]byte{'D', 'W', 'A', 'L'}
+
+// recordVersion is the on-disk framing version. Bump it only for changes that
+// an older reader cannot skip; readers reject frames they do not understand
+// rather than guessing at their payload.
+const recordVersion uint8 = 1
+
+// maxPayloadBytes caps a single decoded payload. A journal record describes one
+// commit intent, so anything approaching this is a corrupt length field rather
+// than a legitimate record, and without the cap a garbage length would drive a
+// multi-gigabyte allocation during replay.
+const maxPayloadBytes = 1 << 20
+
+// maxHashBytes caps the hash length prefix inside a payload for the same
+// reason. Block hashes are 32 bytes; the limit only has to exclude nonsense.
+const maxHashBytes = 64
+
+// castagnoli is the CRC table used for record checksums. It detects the torn
+// final write an unclean shutdown leaves behind, which is the failure this
+// package exists to survive.
+var castagnoli = crc32.MakeTable(crc32.Castagnoli)
+
+var (
+	// ErrCorruptRecord reports a record whose framing or checksum did not
+	// validate. Replay treats it as the end of usable data.
+	ErrCorruptRecord = errors.New("corrupt recovery record")
+	// ErrShortRecord reports a record that ended before its framing said it
+	// would, the normal shape of a crash during append.
+	ErrShortRecord = errors.New("truncated recovery record")
+	// ErrUnknownVersion reports a framing version this build cannot decode.
+	ErrUnknownVersion = errors.New("unknown recovery record version")
+)
+
+// RecordType identifies what a journal record asserts.
+type RecordType uint8
+
+const (
+	// RecordTypeBegin declares the intent of a cross-store commit that is
+	// about to touch the stores.
+	RecordTypeBegin RecordType = 1
+	// RecordTypeCommit marks the matching begin as fully applied to both
+	// stores.
+	RecordTypeCommit RecordType = 2
+	// RecordTypeAbort marks the matching begin as rolled back before either
+	// store committed.
+	RecordTypeAbort RecordType = 3
+	// RecordTypeCheckpoint records a merkle-rooted state summary inline in
+	// the journal, alongside the copy in the checkpoint store.
+	RecordTypeCheckpoint RecordType = 4
+)
+
+// String renders a record type for logs.
+func (t RecordType) String() string {
+	switch t {
+	case RecordTypeBegin:
+		return "begin"
+	case RecordTypeCommit:
+		return "commit"
+	case RecordTypeAbort:
+		return "abort"
+	case RecordTypeCheckpoint:
+		return "checkpoint"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(t))
+	}
+}
+
+// valid reports whether the type is one this build knows how to decode.
+func (t RecordType) valid() bool {
+	switch t {
+	case RecordTypeBegin,
+		RecordTypeCommit,
+		RecordTypeAbort,
+		RecordTypeCheckpoint:
+		return true
+	default:
+		return false
+	}
+}
+
+// IntentKind describes the logical operation a cross-store commit performs.
+type IntentKind uint8
+
+const (
+	// IntentUnknown is a commit that did not describe itself. Recovery can
+	// still use its commit timestamp as a fence, it just cannot name the
+	// point that was in flight.
+	IntentUnknown IntentKind = 0
+	// IntentBlockAdd extends the chain to the recorded point.
+	IntentBlockAdd IntentKind = 1
+	// IntentRollback rewinds state to the recorded point.
+	IntentRollback IntentKind = 2
+)
+
+// String renders an intent kind for logs.
+func (k IntentKind) String() string {
+	switch k {
+	case IntentBlockAdd:
+		return "block_add"
+	case IntentRollback:
+		return "rollback"
+	case IntentUnknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(k))
+	}
+}
+
+// Point identifies a position on the chain.
+type Point struct {
+	Hash []byte
+	Slot uint64
+}
+
+// Equal reports whether two points name the same block.
+func (p Point) Equal(other Point) bool {
+	return p.Slot == other.Slot && bytes.Equal(p.Hash, other.Hash)
+}
+
+// IsZero reports whether the point is unset.
+func (p Point) IsZero() bool {
+	return p.Slot == 0 && len(p.Hash) == 0
+}
+
+// Intent describes what a cross-store commit is about to do. Recovery reads it
+// to report, and repair, the exact operation a crash interrupted.
+type Intent struct {
+	Hash        []byte
+	Slot        uint64
+	BlockNumber uint64
+	Kind        IntentKind
+}
+
+// Point returns the chain position the intent targets.
+func (i Intent) Point() Point {
+	return Point{Slot: i.Slot, Hash: i.Hash}
+}
+
+// Record is one decoded journal entry.
+type Record struct {
+	// Checkpoint is set only on RecordTypeCheckpoint records.
+	Checkpoint *Checkpoint
+	// Intent is meaningful only on RecordTypeBegin records.
+	Intent Intent
+	// Seq numbers the commit this record belongs to. Begin, and the commit
+	// or abort that resolves it, share a Seq.
+	Seq uint64
+	// CommitTimestamp is the cross-store fence the commit writes into both
+	// stores. It is meaningful only on RecordTypeBegin records.
+	CommitTimestamp int64
+	Type            RecordType
+}
+
+// encoder builds a payload with fixed-width, big-endian fields so records sort
+// and compare the same on every platform.
+//
+// It carries its own error rather than returning one per field, so a caller
+// writes a record as a straight run of field calls and checks once at the end.
+type encoder struct {
+	buf []byte
+	err error
+}
+
+func (e *encoder) uint64(v uint64) {
+	e.buf = binary.BigEndian.AppendUint64(e.buf, v)
+}
+
+// int64 stores a signed value in the unsigned wire field. The conversion is a
+// deliberate two's-complement round trip, undone by decoder.int64.
+func (e *encoder) int64(v int64) {
+	e.uint64(uint64(v)) //nolint:gosec // round-trips via decoder.int64
+}
+
+func (e *encoder) uint8(v uint8) {
+	e.buf = append(e.buf, v)
+}
+
+// bytesField writes a length-prefixed byte slice, refusing anything the
+// single-byte length prefix cannot describe.
+func (e *encoder) bytesField(v []byte) {
+	if e.err != nil {
+		return
+	}
+	if len(v) > maxHashBytes {
+		e.err = fmt.Errorf(
+			"byte field length %d exceeds %d",
+			len(v),
+			maxHashBytes,
+		)
+		return
+	}
+	e.uint8(uint8(len(v))) //nolint:gosec // bounded by maxHashBytes above
+	e.buf = append(e.buf, v...)
+}
+
+// decoder reads the fields an encoder wrote, reporting ErrCorruptRecord as soon
+// as the payload runs out rather than reading past the end.
+type decoder struct {
+	buf []byte
+	err error
+}
+
+func (d *decoder) take(n int) []byte {
+	if d.err != nil {
+		return nil
+	}
+	if len(d.buf) < n {
+		d.err = fmt.Errorf("%w: payload shorter than expected", ErrCorruptRecord)
+		return nil
+	}
+	out := d.buf[:n]
+	d.buf = d.buf[n:]
+	return out
+}
+
+func (d *decoder) uint64() uint64 {
+	b := d.take(8)
+	if b == nil {
+		return 0
+	}
+	return binary.BigEndian.Uint64(b)
+}
+
+// int64 undoes the two's-complement round trip encoder.int64 performs.
+func (d *decoder) int64() int64 {
+	return int64(d.uint64()) //nolint:gosec // inverse of encoder.int64
+}
+
+func (d *decoder) uint8() uint8 {
+	b := d.take(1)
+	if b == nil {
+		return 0
+	}
+	return b[0]
+}
+
+// bytesField reads a length-prefixed byte slice into a fresh allocation so the
+// result does not alias the read buffer the caller may reuse.
+func (d *decoder) bytesField() []byte {
+	n := int(d.uint8())
+	if d.err != nil {
+		return nil
+	}
+	if n > maxHashBytes {
+		d.err = fmt.Errorf(
+			"%w: hash field length %d exceeds %d",
+			ErrCorruptRecord,
+			n,
+			maxHashBytes,
+		)
+		return nil
+	}
+	if n == 0 {
+		return nil
+	}
+	b := d.take(n)
+	if b == nil {
+		return nil
+	}
+	return bytes.Clone(b)
+}
+
+// done reports a trailing-bytes error so a payload that decodes but does not
+// account for all its bytes is treated as corrupt rather than silently
+// truncated.
+func (d *decoder) done() error {
+	if d.err != nil {
+		return d.err
+	}
+	if len(d.buf) != 0 {
+		return fmt.Errorf(
+			"%w: %d unread payload bytes",
+			ErrCorruptRecord,
+			len(d.buf),
+		)
+	}
+	return nil
+}
+
+// encodePayload renders a record's type-specific payload.
+func encodePayload(r Record) ([]byte, error) {
+	e := &encoder{}
+	switch r.Type {
+	case RecordTypeBegin:
+		e.uint64(r.Seq)
+		e.int64(r.CommitTimestamp)
+		e.uint8(uint8(r.Intent.Kind))
+		e.uint64(r.Intent.Slot)
+		e.uint64(r.Intent.BlockNumber)
+		e.bytesField(r.Intent.Hash)
+	case RecordTypeCommit, RecordTypeAbort:
+		e.uint64(r.Seq)
+	case RecordTypeCheckpoint:
+		if r.Checkpoint == nil {
+			return nil, errors.New("checkpoint record has no checkpoint")
+		}
+		payload, err := encodeCheckpoint(*r.Checkpoint)
+		if err != nil {
+			return nil, err
+		}
+		e.buf = payload
+	default:
+		return nil, fmt.Errorf("cannot encode record type %s", r.Type)
+	}
+	if e.err != nil {
+		return nil, e.err
+	}
+	return e.buf, nil
+}
+
+// decodePayload parses a record's type-specific payload.
+func decodePayload(t RecordType, payload []byte) (Record, error) {
+	r := Record{Type: t}
+	d := &decoder{buf: payload}
+	switch t {
+	case RecordTypeBegin:
+		r.Seq = d.uint64()
+		r.CommitTimestamp = d.int64()
+		r.Intent.Kind = IntentKind(d.uint8())
+		r.Intent.Slot = d.uint64()
+		r.Intent.BlockNumber = d.uint64()
+		r.Intent.Hash = d.bytesField()
+	case RecordTypeCommit, RecordTypeAbort:
+		r.Seq = d.uint64()
+	case RecordTypeCheckpoint:
+		cp, err := decodeCheckpoint(payload)
+		if err != nil {
+			return Record{}, err
+		}
+		r.Checkpoint = &cp
+		r.Seq = cp.Seq
+		return r, nil
+	default:
+		return Record{}, fmt.Errorf(
+			"%w: cannot decode record type %s",
+			ErrCorruptRecord,
+			t,
+		)
+	}
+	if err := d.done(); err != nil {
+		return Record{}, err
+	}
+	return r, nil
+}
+
+// appendFrame appends the framed encoding of a record to dst.
+//
+// Frame layout, all integers big-endian:
+//
+//	magic[4] | version | type | payloadLen uint32 | payload | crc32c uint32
+//
+// The checksum covers version, type, length and payload, so a torn write is
+// caught whether it lost payload bytes or corrupted the header.
+func appendFrame(dst []byte, r Record) ([]byte, error) {
+	payload, err := encodePayload(r)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) > maxPayloadBytes {
+		return nil, fmt.Errorf(
+			"record payload %d bytes exceeds %d",
+			len(payload),
+			maxPayloadBytes,
+		)
+	}
+	header := make([]byte, 0, 6)
+	header = append(header, recordVersion, uint8(r.Type))
+	//nolint:gosec // bounded by maxPayloadBytes above
+	header = binary.BigEndian.AppendUint32(header, uint32(len(payload)))
+	crc := crc32.Checksum(header, castagnoli)
+	crc = crc32.Update(crc, castagnoli, payload)
+	dst = append(dst, recordMagic[:]...)
+	dst = append(dst, header...)
+	dst = append(dst, payload...)
+	return binary.BigEndian.AppendUint32(dst, crc), nil
+}
+
+// readFrame reads one framed record from r.
+//
+// It returns io.EOF at a clean end of stream, and ErrShortRecord or
+// ErrCorruptRecord for a partial or damaged tail. Callers replaying a journal
+// treat all three as "no more usable records" and stop; the difference only
+// matters for what they log.
+func readFrame(r io.Reader) (Record, error) {
+	var head [10]byte
+	n, err := io.ReadFull(r, head[:])
+	switch {
+	case errors.Is(err, io.EOF) && n == 0:
+		return Record{}, io.EOF
+	case err != nil:
+		return Record{}, fmt.Errorf(
+			"%w: header: %w",
+			ErrShortRecord,
+			err,
+		)
+	}
+	if !bytes.Equal(head[:4], recordMagic[:]) {
+		return Record{}, fmt.Errorf("%w: bad magic", ErrCorruptRecord)
+	}
+	version := head[4]
+	if version != recordVersion {
+		return Record{}, fmt.Errorf(
+			"%w: version %d",
+			ErrUnknownVersion,
+			version,
+		)
+	}
+	recType := RecordType(head[5])
+	payloadLen := binary.BigEndian.Uint32(head[6:10])
+	if payloadLen > maxPayloadBytes {
+		return Record{}, fmt.Errorf(
+			"%w: payload length %d exceeds %d",
+			ErrCorruptRecord,
+			payloadLen,
+			maxPayloadBytes,
+		)
+	}
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return Record{}, fmt.Errorf(
+			"%w: payload: %w",
+			ErrShortRecord,
+			err,
+		)
+	}
+	var crcBuf [4]byte
+	if _, err := io.ReadFull(r, crcBuf[:]); err != nil {
+		return Record{}, fmt.Errorf(
+			"%w: checksum: %w",
+			ErrShortRecord,
+			err,
+		)
+	}
+	want := binary.BigEndian.Uint32(crcBuf[:])
+	got := crc32.Checksum(head[4:10], castagnoli)
+	got = crc32.Update(got, castagnoli, payload)
+	if got != want {
+		return Record{}, fmt.Errorf(
+			"%w: checksum %08x does not match recorded %08x",
+			ErrCorruptRecord,
+			got,
+			want,
+		)
+	}
+	// The checksum is verified before the type is, so a record whose type
+	// byte was corrupted in transit is reported as corruption. Reaching here
+	// with an unknown type means the writer was a newer build.
+	if !recType.valid() {
+		return Record{}, fmt.Errorf(
+			"%w: record type %d",
+			ErrUnknownVersion,
+			uint8(recType),
+		)
+	}
+	return decodePayload(recType, payload)
+}

--- a/database/recovery/record.go
+++ b/database/recovery/record.go
@@ -354,6 +354,9 @@ func decodePayload(t RecordType, payload []byte) (Record, error) {
 		if err != nil {
 			return Record{}, err
 		}
+		if err := cp.Verify(); err != nil {
+			return Record{}, fmt.Errorf("invalid checkpoint: %w", err)
+		}
 		r.Checkpoint = &cp
 		r.Seq = cp.Seq
 		return r, nil

--- a/database/recovery/record_test.go
+++ b/database/recovery/record_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordRoundTrip(t *testing.T) {
+	t.Parallel()
+	hash := bytes.Repeat([]byte{0xab}, 32)
+	records := []Record{
+		{
+			Type:            RecordTypeBegin,
+			Seq:             42,
+			CommitTimestamp: 1700000000123,
+			Intent: Intent{
+				Kind:        IntentBlockAdd,
+				Slot:        98765,
+				BlockNumber: 4321,
+				Hash:        hash,
+			},
+		},
+		{
+			Type:            RecordTypeBegin,
+			Seq:             43,
+			CommitTimestamp: 1700000000456,
+			Intent: Intent{
+				Kind: IntentRollback,
+				Slot: 98700,
+			},
+		},
+		{Type: RecordTypeCommit, Seq: 42},
+		{Type: RecordTypeAbort, Seq: 43},
+	}
+	var buf bytes.Buffer
+	for _, record := range records {
+		frame, err := appendFrame(nil, record)
+		require.NoError(t, err)
+		buf.Write(frame)
+	}
+	for _, want := range records {
+		got, err := readFrame(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+	_, err := readFrame(&buf)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestRecordCheckpointRoundTrip(t *testing.T) {
+	t.Parallel()
+	cp := Checkpoint{
+		Seq:              7,
+		CreatedUnixMilli: 1700000000000,
+		CommitTimestamp:  1699999999999,
+		TipSlot:          500,
+		TipHash:          bytes.Repeat([]byte{0x01}, 32),
+		TipBlockNumber:   499,
+		BlobTipSlot:      501,
+		BlobTipHash:      bytes.Repeat([]byte{0x02}, 32),
+	}
+	cp.Seal()
+	frame, err := appendFrame(nil, Record{
+		Type:       RecordTypeCheckpoint,
+		Seq:        cp.Seq,
+		Checkpoint: &cp,
+	})
+	require.NoError(t, err)
+	got, err := readFrame(bytes.NewReader(frame))
+	require.NoError(t, err)
+	require.NotNil(t, got.Checkpoint)
+	assert.Equal(t, cp, *got.Checkpoint)
+	assert.Equal(t, cp.Seq, got.Seq)
+	assert.NoError(t, got.Checkpoint.Verify())
+}
+
+func TestReadFrameRejectsCorruptedPayload(t *testing.T) {
+	t.Parallel()
+	frame, err := appendFrame(nil, Record{
+		Type:            RecordTypeBegin,
+		Seq:             1,
+		CommitTimestamp: 5,
+		Intent:          Intent{Kind: IntentBlockAdd, Slot: 9},
+	})
+	require.NoError(t, err)
+	// Flip a bit in the payload, past the 10-byte header.
+	frame[12] ^= 0xff
+	_, err = readFrame(bytes.NewReader(frame))
+	assert.ErrorIs(t, err, ErrCorruptRecord)
+}
+
+func TestReadFrameRejectsTruncatedTail(t *testing.T) {
+	t.Parallel()
+	frame, err := appendFrame(nil, Record{
+		Type:            RecordTypeBegin,
+		Seq:             1,
+		CommitTimestamp: 5,
+		Intent:          Intent{Kind: IntentBlockAdd, Slot: 9},
+	})
+	require.NoError(t, err)
+	for _, cut := range []int{3, 9, len(frame) - 5, len(frame) - 1} {
+		_, err := readFrame(bytes.NewReader(frame[:cut]))
+		assert.Error(t, err, "cut at %d should not decode", cut)
+		assert.False(
+			t,
+			errors.Is(err, io.EOF),
+			"a partial frame is not a clean end of stream",
+		)
+	}
+}
+
+func TestReadFrameRejectsBadMagic(t *testing.T) {
+	t.Parallel()
+	frame, err := appendFrame(nil, Record{Type: RecordTypeCommit, Seq: 1})
+	require.NoError(t, err)
+	frame[0] = 'X'
+	_, err = readFrame(bytes.NewReader(frame))
+	assert.ErrorIs(t, err, ErrCorruptRecord)
+}
+
+func TestReadFrameRejectsUnknownVersion(t *testing.T) {
+	t.Parallel()
+	frame, err := appendFrame(nil, Record{Type: RecordTypeCommit, Seq: 1})
+	require.NoError(t, err)
+	frame[4] = recordVersion + 1
+	_, err = readFrame(bytes.NewReader(frame))
+	assert.ErrorIs(t, err, ErrUnknownVersion)
+}
+
+func TestEncodePayloadRejectsOversizeHash(t *testing.T) {
+	t.Parallel()
+	_, err := appendFrame(nil, Record{
+		Type: RecordTypeBegin,
+		Seq:  1,
+		Intent: Intent{
+			Kind: IntentBlockAdd,
+			Hash: bytes.Repeat([]byte{0x01}, maxHashBytes+1),
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestEncodeCheckpointRecordRequiresCheckpoint(t *testing.T) {
+	t.Parallel()
+	_, err := appendFrame(nil, Record{Type: RecordTypeCheckpoint, Seq: 1})
+	assert.Error(t, err)
+}
+
+func TestDecodePayloadRejectsTrailingBytes(t *testing.T) {
+	t.Parallel()
+	payload, err := encodePayload(Record{Type: RecordTypeCommit, Seq: 3})
+	require.NoError(t, err)
+	_, err = decodePayload(RecordTypeCommit, append(payload, 0x00))
+	assert.ErrorIs(t, err, ErrCorruptRecord)
+}
+
+func TestPointHelpers(t *testing.T) {
+	t.Parallel()
+	hash := bytes.Repeat([]byte{0x03}, 32)
+	a := Point{Slot: 10, Hash: hash}
+	assert.True(t, a.Equal(Point{Slot: 10, Hash: bytes.Clone(hash)}))
+	assert.False(t, a.Equal(Point{Slot: 11, Hash: hash}))
+	assert.False(t, a.IsZero())
+	assert.True(t, Point{}.IsZero())
+}

--- a/database/recovery/record_test.go
+++ b/database/recovery/record_test.go
@@ -93,6 +93,16 @@ func TestRecordCheckpointRoundTrip(t *testing.T) {
 	assert.NoError(t, got.Checkpoint.Verify())
 }
 
+func TestDecodePayloadRejectsUnverifiedCheckpoint(t *testing.T) {
+	cp := testCheckpoint(3)
+	cp.Seal()
+	cp.Seq = 4
+	payload, err := encodeCheckpoint(cp)
+	require.NoError(t, err)
+	_, err = decodePayload(RecordTypeCheckpoint, payload)
+	assert.Error(t, err)
+}
+
 func TestReadFrameRejectsCorruptedPayload(t *testing.T) {
 	t.Parallel()
 	frame, err := appendFrame(nil, Record{

--- a/database/recovery/recovery.go
+++ b/database/recovery/recovery.go
@@ -52,6 +52,12 @@ type Repairer interface {
 	ResetCommitFence() error
 }
 
+// ChainRewinder is optionally implemented by repairers whose persistent chain
+// must be brought back with the blob store before ledger recovery runs.
+type ChainRewinder interface {
+	RewindPrimaryChainTo(point Point) error
+}
+
 // Config configures the recovery manager.
 type Config struct {
 	Logger *slog.Logger
@@ -137,7 +143,10 @@ func New(cfg Config) (*Manager, error) {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
-	if cfg.CheckpointInterval <= 0 {
+	if cfg.CheckpointInterval < 0 {
+		return nil, errors.New("checkpoint interval cannot be negative")
+	}
+	if cfg.CheckpointInterval == 0 {
 		cfg.CheckpointInterval = DefaultCheckpointInterval
 	}
 	if cfg.CheckMode == "" {
@@ -175,13 +184,16 @@ func (m *Manager) Begin(intent Intent, commitTimestamp int64) (uint64, error) {
 	if m == nil {
 		return 0, nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return 0, ErrWALClosed
+	}
 	seq, err := m.wal.Begin(intent, commitTimestamp)
 	if err != nil {
 		return 0, err
 	}
-	m.mu.Lock()
 	m.open[seq] = struct{}{}
-	m.mu.Unlock()
 	return seq, nil
 }
 
@@ -190,8 +202,11 @@ func (m *Manager) Commit(seq uint64) error {
 	if m == nil {
 		return nil
 	}
-	m.resolve(seq)
-	return m.wal.Commit(seq)
+	err := m.wal.Commit(seq)
+	if err == nil {
+		m.resolve(seq)
+	}
+	return err
 }
 
 // Abort marks a sequence as rolled back before either store committed.
@@ -199,8 +214,11 @@ func (m *Manager) Abort(seq uint64) error {
 	if m == nil {
 		return nil
 	}
-	m.resolve(seq)
-	return m.wal.Abort(seq)
+	err := m.wal.Abort(seq)
+	if err == nil {
+		m.resolve(seq)
+	}
+	return err
 }
 
 func (m *Manager) resolve(seq uint64) {
@@ -485,7 +503,15 @@ func (m *Manager) repair(
 	if err != nil {
 		return fmt.Errorf("read commit timestamps: %w", err)
 	}
-	if metadataTS == blobTS {
+	metaTip, _, err := source.MetadataTip()
+	if err != nil {
+		return fmt.Errorf("read metadata tip: %w", err)
+	}
+	blobTip, err := source.BlobTip()
+	if err != nil {
+		return fmt.Errorf("read blob tip: %w", err)
+	}
+	if metadataTS == blobTS && metaTip.Equal(blobTip) {
 		// The stores hold the same fence, so no commit was half applied.
 		// Unresolved intents on their own do not change that: only the
 		// begin record is synced, so a crash routinely loses the commit
@@ -510,16 +536,7 @@ func (m *Manager) repair(
 		)
 		return nil
 	}
-	metaTip, _, err := source.MetadataTip()
-	if err != nil {
-		return fmt.Errorf("read metadata tip: %w", err)
-	}
-	blobTip, err := source.BlobTip()
-	if err != nil {
-		return fmt.Errorf("read blob tip: %w", err)
-	}
-
-	if blobTS < metadataTS {
+	if blobTip.Slot < metaTip.Slot {
 		// The blob store is behind the state the metadata store claims
 		// to have applied. Rewind onto what the blob store holds.
 		//
@@ -536,6 +553,12 @@ func (m *Manager) repair(
 			"metadata_tip_slot", metaTip.Slot,
 			"blob_tip_slot", blobTip.Slot,
 		)
+		if rewinder, ok := repairer.(ChainRewinder); ok {
+			if err := rewinder.RewindPrimaryChainTo(blobTip); err != nil {
+				result.Outcome = OutcomeUnrepaired
+				return fmt.Errorf("rewind primary chain to blob tip %d: %w", blobTip.Slot, err)
+			}
+		}
 		if err := repairer.RollbackTo(blobTip); err != nil {
 			result.Outcome = OutcomeUnrepaired
 			return fmt.Errorf(
@@ -559,6 +582,11 @@ func (m *Manager) repair(
 		result.Outcome = OutcomeRepaired
 		return nil
 	}
+	if metaTip.Slot == blobTip.Slot && !metaTip.Equal(blobTip) {
+		result.Outcome = OutcomeUnrepaired
+		result.Actions = append(result.Actions, fmt.Sprintf("detected same-slot metadata/blob fork at slot %d", metaTip.Slot))
+		return nil
+	}
 
 	// The blob store is ahead, the expected shape. Blocks above the trim
 	// boundary are the interrupted commit's residue.
@@ -574,6 +602,14 @@ func (m *Manager) repair(
 		chainTip, _, err := chainSource.ChainTip()
 		if err != nil {
 			return fmt.Errorf("read chain tip: %w", err)
+		}
+		if chainTip.Slot == blobTip.Slot && !chainTip.Equal(blobTip) {
+			result.Outcome = OutcomeUnrepaired
+			result.Actions = append(result.Actions, fmt.Sprintf(
+				"detected same-slot primary-chain/blob fork at slot %d",
+				blobTip.Slot,
+			))
+			return nil
 		}
 		if chainTip.Slot > boundary {
 			boundary = chainTip.Slot

--- a/database/recovery/recovery.go
+++ b/database/recovery/recovery.go
@@ -1,0 +1,656 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// walSubdir and checkpointSubdir sit under the configured recovery
+	// directory so the two artifact kinds can be reasoned about, and
+	// removed, independently.
+	walSubdir        = "wal"
+	checkpointSubdir = "checkpoints"
+	// DefaultCheckpointInterval is how often a running node records a
+	// checkpoint. Checkpoints only bound replay work, so a coarse cadence
+	// costs nothing but a slightly longer journal.
+	DefaultCheckpointInterval = 5 * time.Minute
+)
+
+// Repairer applies the repairs recovery decides on.
+//
+// It is implemented above this package, by whichever component owns the state
+// being repaired, so recovery can decide what to do without knowing how the
+// ledger or the stores carry it out.
+type Repairer interface {
+	// TrimBlobAbove removes blocks the blob store holds above slot and
+	// returns how many it removed.
+	TrimBlobAbove(slot uint64) (int, error)
+	// RollbackTo rewinds applied state to point.
+	RollbackTo(point Point) error
+	// ResetCommitFence brings both stores back onto a common commit
+	// timestamp so they agree again. The value is the implementation's to
+	// choose; recovery only requires that the two match afterwards.
+	ResetCommitFence() error
+}
+
+// Config configures the recovery manager.
+type Config struct {
+	Logger *slog.Logger
+	// Dir is the base directory for recovery artifacts. The journal and
+	// checkpoints live in subdirectories of it.
+	Dir string
+	// CheckMode selects how much work the startup consistency checks do.
+	CheckMode CheckMode
+	// CheckpointInterval is how often a running node records a checkpoint.
+	// Zero selects DefaultCheckpointInterval.
+	CheckpointInterval time.Duration
+	// CheckpointRetain is how many checkpoint generations to keep. Zero
+	// selects the package default.
+	CheckpointRetain int
+	// MaxSegmentBytes bounds one journal segment. Zero selects the default.
+	MaxSegmentBytes int64
+	// SyncJournal makes each intent record durable before the commit that
+	// wrote it touches the stores. Leaving this off makes the journal
+	// advisory only; see WALConfig.SyncOnBegin.
+	SyncJournal bool
+}
+
+// Outcome grades what a recovery run had to do.
+type Outcome uint8
+
+const (
+	// OutcomeClean means the stores agreed and nothing needed repair.
+	OutcomeClean Outcome = iota
+	// OutcomeRepaired means recovery found divergence and fixed it.
+	OutcomeRepaired
+	// OutcomeUnrepaired means recovery found divergence it could not fix.
+	OutcomeUnrepaired
+)
+
+// String renders an outcome for logs.
+func (o Outcome) String() string {
+	switch o {
+	case OutcomeClean:
+		return "clean"
+	case OutcomeRepaired:
+		return "repaired"
+	case OutcomeUnrepaired:
+		return "unrepaired"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(o))
+	}
+}
+
+// Result describes one recovery run.
+type Result struct {
+	// Checkpoint is the anchor recovery loaded, if any existed.
+	Checkpoint *Checkpoint
+	// Report holds the startup consistency check outcomes.
+	Report Report
+	// Pending lists the intents that were begun but never resolved, which
+	// is what a crash inside the commit window leaves behind.
+	Pending []Record
+	// Actions describes, in order, what recovery did.
+	Actions []string
+	Outcome Outcome
+}
+
+// Manager owns the journal, the checkpoints, and the startup recovery run.
+type Manager struct {
+	logger      *slog.Logger
+	wal         *WAL
+	checkpoints *CheckpointStore
+	open        map[uint64]struct{}
+	stop        chan struct{}
+	done        chan struct{}
+
+	cfg    Config
+	mu     sync.Mutex
+	closed bool
+}
+
+// New opens the journal and checkpoint store under cfg.Dir.
+func New(cfg Config) (*Manager, error) {
+	if cfg.Dir == "" {
+		return nil, errors.New("recovery directory is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	if cfg.CheckpointInterval <= 0 {
+		cfg.CheckpointInterval = DefaultCheckpointInterval
+	}
+	if cfg.CheckMode == "" {
+		cfg.CheckMode = CheckModeFast
+	}
+	wal, err := OpenWAL(WALConfig{
+		Dir:             filepath.Join(cfg.Dir, walSubdir),
+		MaxSegmentBytes: cfg.MaxSegmentBytes,
+		SyncOnBegin:     cfg.SyncJournal,
+		Logger:          logger,
+	})
+	if err != nil {
+		return nil, err
+	}
+	checkpoints, err := NewCheckpointStore(
+		filepath.Join(cfg.Dir, checkpointSubdir),
+		cfg.CheckpointRetain,
+		logger,
+	)
+	if err != nil {
+		_ = wal.Close()
+		return nil, err
+	}
+	return &Manager{
+		cfg:         cfg,
+		logger:      logger,
+		wal:         wal,
+		checkpoints: checkpoints,
+		open:        make(map[uint64]struct{}),
+	}, nil
+}
+
+// Begin records the intent of a cross-store commit and returns its sequence.
+func (m *Manager) Begin(intent Intent, commitTimestamp int64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	seq, err := m.wal.Begin(intent, commitTimestamp)
+	if err != nil {
+		return 0, err
+	}
+	m.mu.Lock()
+	m.open[seq] = struct{}{}
+	m.mu.Unlock()
+	return seq, nil
+}
+
+// Commit marks a sequence as applied to both stores.
+func (m *Manager) Commit(seq uint64) error {
+	if m == nil {
+		return nil
+	}
+	m.resolve(seq)
+	return m.wal.Commit(seq)
+}
+
+// Abort marks a sequence as rolled back before either store committed.
+func (m *Manager) Abort(seq uint64) error {
+	if m == nil {
+		return nil
+	}
+	m.resolve(seq)
+	return m.wal.Abort(seq)
+}
+
+func (m *Manager) resolve(seq uint64) {
+	m.mu.Lock()
+	delete(m.open, seq)
+	m.mu.Unlock()
+}
+
+// checkpointSeq returns the highest sequence a checkpoint may claim to cover.
+//
+// It stops below the oldest still-open commit: a checkpoint that covered an
+// in-flight commit would authorise truncating away the very intent record
+// recovery needs if the process died before that commit resolved.
+func (m *Manager) checkpointSeq() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	oldestOpen := uint64(0)
+	for seq := range m.open {
+		if oldestOpen == 0 || seq < oldestOpen {
+			oldestOpen = seq
+		}
+	}
+	next := m.wal.NextSeq()
+	if oldestOpen > 0 {
+		return oldestOpen - 1
+	}
+	if next == 0 {
+		return 0
+	}
+	return next - 1
+}
+
+// Start begins recording checkpoints on the configured interval. Stop them with
+// Close. Calling it more than once is a no-op after the first.
+func (m *Manager) Start(source StateSource) {
+	if m == nil || source == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.stop != nil || m.closed {
+		m.mu.Unlock()
+		return
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	m.stop = stop
+	m.done = done
+	interval := m.cfg.CheckpointInterval
+	m.mu.Unlock()
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if err := m.Checkpoint(source); err != nil {
+					m.logger.Warn(
+						"failed to record recovery checkpoint",
+						"error", err,
+					)
+				}
+			}
+		}
+	}()
+}
+
+// Checkpoint records a checkpoint from the current store state and truncates
+// journal segments the new checkpoint fully covers.
+//
+// The checkpoint is a summary observed without quiescing the stores, so it can
+// lag a commit that landed while it was being taken. That is fine: recovery
+// treats store state as authoritative and uses the checkpoint as a verified
+// anchor and a truncation floor, never as a source of state to restore.
+func (m *Manager) Checkpoint(source StateSource) error {
+	if m == nil || source == nil {
+		return nil
+	}
+	seq := m.checkpointSeq()
+	tip, tipBlockNumber, err := source.MetadataTip()
+	if err != nil {
+		return fmt.Errorf("read metadata tip for checkpoint: %w", err)
+	}
+	blobTip, err := source.BlobTip()
+	if err != nil {
+		return fmt.Errorf("read blob tip for checkpoint: %w", err)
+	}
+	metadataTS, blobTS, err := source.CommitTimestamps()
+	if err != nil {
+		return fmt.Errorf("read commit timestamps for checkpoint: %w", err)
+	}
+	if metadataTS != blobTS {
+		// The two timestamps are not read atomically, so a commit landing
+		// between them looks exactly like divergence. Read once more
+		// before believing it; a commit is not still in its window on the
+		// second look.
+		metadataTS, blobTS, err = source.CommitTimestamps()
+		if err != nil {
+			return fmt.Errorf(
+				"re-read commit timestamps for checkpoint: %w",
+				err,
+			)
+		}
+	}
+	if metadataTS != blobTS {
+		// Checkpointing state the stores do not agree on would hand
+		// recovery an anchor that is itself inconsistent.
+		return fmt.Errorf(
+			"refusing to checkpoint diverged stores: metadata %d, blob %d",
+			metadataTS,
+			blobTS,
+		)
+	}
+	cp := Checkpoint{
+		Seq:              seq,
+		CreatedUnixMilli: time.Now().UnixMilli(),
+		CommitTimestamp:  metadataTS,
+		TipSlot:          tip.Slot,
+		TipHash:          tip.Hash,
+		TipBlockNumber:   tipBlockNumber,
+		BlobTipSlot:      blobTip.Slot,
+		BlobTipHash:      blobTip.Hash,
+	}
+	// The journal copy goes first: a checkpoint visible in the checkpoint
+	// store but absent from the journal would let truncation run against a
+	// journal that never recorded the boundary.
+	if err := m.wal.AppendCheckpoint(cp); err != nil {
+		return fmt.Errorf("append checkpoint to journal: %w", err)
+	}
+	if err := m.checkpoints.Write(cp); err != nil {
+		return fmt.Errorf("write checkpoint: %w", err)
+	}
+	removed, err := m.wal.TruncateThrough(seq)
+	if err != nil {
+		return fmt.Errorf("truncate journal through %d: %w", seq, err)
+	}
+	m.logger.Debug(
+		"recorded recovery checkpoint",
+		"seq", seq,
+		"tip_slot", tip.Slot,
+		"blob_tip_slot", blobTip.Slot,
+		"segments_removed", removed,
+	)
+	return nil
+}
+
+// Recover runs the startup consistency checks, replays the journal, and repairs
+// whatever divergence the two together identify.
+//
+// A nil repairer runs the checks and reports findings without changing
+// anything, which is what a caller that only wants a diagnosis passes.
+func (m *Manager) Recover(
+	source StateSource,
+	repairer Repairer,
+) (*Result, error) {
+	if m == nil {
+		return &Result{}, nil
+	}
+	if source == nil {
+		return nil, errors.New("recovery requires a state source")
+	}
+	checker, err := NewChecker(source, m.cfg.CheckMode, m.logger)
+	if err != nil {
+		return nil, err
+	}
+	result := &Result{Report: checker.Run()}
+	result.Report.Log(m.logger)
+
+	if cp, err := m.checkpoints.Latest(); err == nil {
+		result.Checkpoint = &cp
+		m.logger.Info(
+			"loaded recovery checkpoint",
+			"seq", cp.Seq,
+			"tip_slot", cp.TipSlot,
+			"blob_tip_slot", cp.BlobTipSlot,
+			"commit_timestamp", cp.CommitTimestamp,
+		)
+	} else if !errors.Is(err, ErrNoCheckpoint) {
+		// A checkpoint store that cannot be read is worth reporting, but
+		// it never blocks recovery: store state is authoritative and the
+		// journal replay below does not depend on the anchor.
+		m.logger.Warn("could not load recovery checkpoint", "error", err)
+	}
+
+	pending, replayErr := m.replayPending()
+	if replayErr != nil {
+		m.logger.Warn(
+			"could not replay the recovery journal; falling back to stored state and checkpoint",
+			"error", replayErr,
+		)
+		result.Actions = append(
+			result.Actions,
+			fmt.Sprintf("journal replay failed: %v", replayErr),
+		)
+	}
+	result.Pending = pending
+	for _, record := range pending {
+		m.logger.Warn(
+			"recovery journal holds an unresolved commit intent",
+			"seq", record.Seq,
+			"intent", record.Intent.Kind.String(),
+			"slot", record.Intent.Slot,
+			"hash", shortHash(record.Intent.Hash),
+			"commit_timestamp", record.CommitTimestamp,
+		)
+	}
+
+	if err := m.repair(source, repairer, result); err != nil {
+		return result, err
+	}
+	if result.Outcome == OutcomeClean && result.Report.Failed() {
+		// The stores agree on their fence, so there is no interrupted
+		// commit to undo, but a check still found damage. Say so rather
+		// than reporting a clean recovery.
+		result.Outcome = OutcomeUnrepaired
+	}
+	return result, nil
+}
+
+// Replay passes every readable journal record to fn, oldest first.
+//
+// Recovery uses replayPending for its own decisions; this is the entry point
+// for anything that wants to look at the journal itself, such as a diagnostic
+// dump of what a node was doing when it died.
+func (m *Manager) Replay(fn func(Record) error) error {
+	if m == nil {
+		return nil
+	}
+	return m.wal.Replay(fn)
+}
+
+// replayPending returns the begin records with no matching commit or abort.
+func (m *Manager) replayPending() ([]Record, error) {
+	pending := map[uint64]Record{}
+	order := []uint64{}
+	err := m.wal.Replay(func(r Record) error {
+		switch r.Type {
+		case RecordTypeBegin:
+			if _, seen := pending[r.Seq]; !seen {
+				order = append(order, r.Seq)
+			}
+			pending[r.Seq] = r
+		case RecordTypeCommit, RecordTypeAbort:
+			delete(pending, r.Seq)
+		case RecordTypeCheckpoint:
+			// A checkpoint asserts both stores agreed at its
+			// sequence, so anything begun at or below it is
+			// resolved whether or not its marker survived.
+			for seq := range pending {
+				if seq <= r.Seq {
+					delete(pending, seq)
+				}
+			}
+		}
+		return nil
+	})
+	out := make([]Record, 0, len(pending))
+	for _, seq := range order {
+		if r, ok := pending[seq]; ok {
+			out = append(out, r)
+		}
+	}
+	return out, err
+}
+
+// repair diagnoses divergence between the two stores and fixes it.
+//
+// The cross-store commit order — blob, sync, then metadata — means only one
+// direction of divergence is expected: the blob store ahead of the metadata
+// store by whatever the interrupted commit had written. The other direction
+// means the blob store lost a durable write, and the only way back to a
+// consistent state is to rewind applied state onto what the blob store still
+// holds.
+func (m *Manager) repair(
+	source StateSource,
+	repairer Repairer,
+	result *Result,
+) error {
+	metadataTS, blobTS, err := source.CommitTimestamps()
+	if err != nil {
+		return fmt.Errorf("read commit timestamps: %w", err)
+	}
+	if metadataTS == blobTS {
+		// The stores hold the same fence, so no commit was half applied.
+		// Unresolved intents on their own do not change that: only the
+		// begin record is synced, so a crash routinely loses the commit
+		// marker of a commit that did land, and repairing on that evidence
+		// alone would run a trim, and report a repair, for a database that
+		// is intact. They are still surfaced in the result.
+		result.Outcome = OutcomeClean
+		if len(result.Pending) > 0 {
+			result.Actions = append(result.Actions, fmt.Sprintf(
+				"%d unresolved intents in the journal, but both stores hold commit timestamp %d; nothing to repair",
+				len(result.Pending),
+				metadataTS,
+			))
+		}
+		return nil
+	}
+	if repairer == nil {
+		result.Outcome = OutcomeUnrepaired
+		result.Actions = append(
+			result.Actions,
+			"divergence detected but no repairer was supplied",
+		)
+		return nil
+	}
+	metaTip, _, err := source.MetadataTip()
+	if err != nil {
+		return fmt.Errorf("read metadata tip: %w", err)
+	}
+	blobTip, err := source.BlobTip()
+	if err != nil {
+		return fmt.Errorf("read blob tip: %w", err)
+	}
+
+	if blobTS < metadataTS {
+		// The blob store is behind the state the metadata store claims
+		// to have applied. Rewind onto what the blob store holds.
+		//
+		// The fences decide this, not the tips. A blob tip below the
+		// metadata tip with both fences agreeing is real damage, but
+		// nothing here caused it, and rolling the ledger back on evidence
+		// the stores themselves contradict is too destructive to do
+		// unprompted. The tip_consistency check reports that shape as a
+		// failure instead.
+		m.logger.Warn(
+			"blob store is behind the metadata store; rewinding applied state to the blob tip",
+			"metadata_commit_timestamp", metadataTS,
+			"blob_commit_timestamp", blobTS,
+			"metadata_tip_slot", metaTip.Slot,
+			"blob_tip_slot", blobTip.Slot,
+		)
+		if err := repairer.RollbackTo(blobTip); err != nil {
+			result.Outcome = OutcomeUnrepaired
+			return fmt.Errorf(
+				"rollback to blob tip %d: %w",
+				blobTip.Slot,
+				err,
+			)
+		}
+		result.Actions = append(result.Actions, fmt.Sprintf(
+			"rolled applied state back to blob tip slot %d",
+			blobTip.Slot,
+		))
+		if err := repairer.ResetCommitFence(); err != nil {
+			result.Outcome = OutcomeUnrepaired
+			return fmt.Errorf("reset commit fence: %w", err)
+		}
+		result.Actions = append(
+			result.Actions,
+			"reset both stores onto a common commit timestamp",
+		)
+		result.Outcome = OutcomeRepaired
+		return nil
+	}
+
+	// The blob store is ahead, the expected shape. Blocks above the trim
+	// boundary are the interrupted commit's residue.
+	//
+	// The boundary is the chain tip where the caller can report one, not the
+	// metadata tip. Between them sit blocks that are legitimately on-chain
+	// and merely not applied yet — the normal shape after a snapshot
+	// bootstrap — and trimming those would destroy data the node still
+	// needs.
+	boundary := metaTip.Slot
+	boundaryName := "metadata tip"
+	if chainSource, ok := source.(ChainTipSource); ok {
+		chainTip, _, err := chainSource.ChainTip()
+		if err != nil {
+			return fmt.Errorf("read chain tip: %w", err)
+		}
+		if chainTip.Slot > boundary {
+			boundary = chainTip.Slot
+			boundaryName = "chain tip"
+		}
+	}
+	if boundary == 0 && blobTip.Slot > 0 {
+		// Neither the applied tip nor the chain says anything about where
+		// the chain ends, but the blob store holds blocks. Trimming above
+		// slot zero would erase all of them, and no repair is worth that
+		// on evidence this thin — an unloaded tip looks identical to a
+		// genuinely empty one from here.
+		m.logger.Error(
+			"refusing to trim the blob store: no tip is known, so every stored block would be removed",
+			"blob_tip_slot", blobTip.Slot,
+			"metadata_commit_timestamp", metadataTS,
+			"blob_commit_timestamp", blobTS,
+		)
+		result.Actions = append(
+			result.Actions,
+			"declined to trim above slot 0 with no known tip",
+		)
+		result.Outcome = OutcomeUnrepaired
+		return nil
+	}
+	trimmed, err := repairer.TrimBlobAbove(boundary)
+	if err != nil {
+		result.Outcome = OutcomeUnrepaired
+		return fmt.Errorf(
+			"trim blob store above slot %d: %w",
+			boundary,
+			err,
+		)
+	}
+	if trimmed > 0 {
+		m.logger.Warn(
+			"removed blocks left above the chain by an interrupted commit",
+			"removed", trimmed,
+			"boundary", boundaryName,
+			"boundary_slot", boundary,
+		)
+	}
+	result.Actions = append(result.Actions, fmt.Sprintf(
+		"removed %d blocks above the %s at slot %d",
+		trimmed,
+		boundaryName,
+		boundary,
+	))
+	if err := repairer.ResetCommitFence(); err != nil {
+		result.Outcome = OutcomeUnrepaired
+		return fmt.Errorf("reset commit fence: %w", err)
+	}
+	result.Actions = append(
+		result.Actions,
+		"reset both stores onto a common commit timestamp",
+	)
+	result.Outcome = OutcomeRepaired
+	return nil
+}
+
+// Close stops checkpointing and closes the journal.
+func (m *Manager) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil
+	}
+	m.closed = true
+	stop, done := m.stop, m.done
+	m.stop, m.done = nil, nil
+	m.mu.Unlock()
+	if stop != nil {
+		close(stop)
+		<-done
+	}
+	return m.wal.Close()
+}

--- a/database/recovery/recovery_test.go
+++ b/database/recovery/recovery_test.go
@@ -272,21 +272,20 @@ func TestManagerCheckpointWritesAndTruncates(t *testing.T) {
 	assert.NotEmpty(t, entries)
 }
 
-func TestManagerRecoverIgnoresTipSkewWhenFencesAgree(t *testing.T) {
+func TestManagerRecoverRepairsBlobBehindWhenFencesAgree(t *testing.T) {
 	t.Parallel()
 	mgr := newTestManager(t, t.TempDir())
-	// A blob tip below the metadata tip with both fences agreeing is real
-	// damage, but nothing recovery did caused it, and rolling the ledger back
-	// against the stores' own fences is too destructive to do unprompted.
+	// Equal commit timestamps do not prove the stores are complete. If the
+	// blob tip is behind, recovery must rewind the applied state to it.
 	source := healthySource(100, 7)
 	source.blobTip = Point{Slot: 90, Hash: []byte{90}}
 	repairer := &fakeRepairer{}
 
 	result, err := mgr.Recover(source, repairer)
 	require.NoError(t, err)
-	assert.Empty(t, repairer.rolledBackTo)
-	// The tip check still reports it, loudly.
-	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
+	require.Equal(t, []Point{{Slot: 90, Hash: []byte{90}}}, repairer.rolledBackTo)
+	// The tip check still reports the original skew.
+	assert.Equal(t, OutcomeRepaired, result.Outcome)
 	tipCheck, ok := result.Report.Find(CheckTipConsistency)
 	require.True(t, ok)
 	assert.Equal(t, SeverityFail, tipCheck.Severity)
@@ -308,6 +307,11 @@ func TestManagerRecoverRefusesToTrimWithNoKnownTip(t *testing.T) {
 	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
 	assert.Empty(t, repairer.trimmedAbove)
 	assert.Zero(t, repairer.fenceResets)
+}
+
+func TestNewRejectsNegativeCheckpointInterval(t *testing.T) {
+	_, err := New(Config{Dir: t.TempDir(), CheckpointInterval: -time.Second})
+	assert.Error(t, err)
 }
 
 func TestManagerCheckpointToleratesTransientTimestampSkew(t *testing.T) {

--- a/database/recovery/recovery_test.go
+++ b/database/recovery/recovery_test.go
@@ -1,0 +1,435 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRepairer records what recovery asked it to do.
+type fakeRepairer struct {
+	trimErr        error
+	rollbackErr    error
+	fenceErr       error
+	rolledBackTo   []Point
+	trimmedAbove   []uint64
+	fenceResets    int
+	trimmedRemoved int
+}
+
+func (r *fakeRepairer) TrimBlobAbove(slot uint64) (int, error) {
+	r.trimmedAbove = append(r.trimmedAbove, slot)
+	return r.trimmedRemoved, r.trimErr
+}
+
+func (r *fakeRepairer) RollbackTo(point Point) error {
+	r.rolledBackTo = append(r.rolledBackTo, point)
+	return r.rollbackErr
+}
+
+func (r *fakeRepairer) ResetCommitFence() error {
+	r.fenceResets++
+	return r.fenceErr
+}
+
+func newTestManager(t *testing.T, dir string) *Manager {
+	t.Helper()
+	mgr, err := New(Config{
+		Dir:                dir,
+		CheckMode:          CheckModeFast,
+		SyncJournal:        true,
+		CheckpointInterval: time.Hour,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mgr.Close()) })
+	return mgr
+}
+
+// healthySource is a source whose stores agree at a single point.
+func healthySource(slot uint64, ts int64) *fakeSource {
+	point := Point{Slot: slot, Hash: []byte{byte(slot)}}
+	return &fakeSource{
+		metadataTip: point,
+		blobTip:     point,
+		metadataTS:  ts,
+		blobTS:      ts,
+		recent:      linkedBlocks(4),
+		utxos:       UtxoIntegrityResult{Checked: 4},
+	}
+}
+
+func TestManagerRecoverCleanStateDoesNothing(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	repairer := &fakeRepairer{}
+	result, err := mgr.Recover(healthySource(100, 7), repairer)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeClean, result.Outcome)
+	assert.Empty(t, repairer.trimmedAbove)
+	assert.Empty(t, repairer.rolledBackTo)
+	assert.Zero(t, repairer.fenceResets)
+}
+
+func TestManagerRecoverTrimsWhenBlobIsAhead(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	source := healthySource(100, 7)
+	// The signature of a crash between the blob commit and the metadata
+	// commit: blob carries the newer fence and the extra blocks.
+	source.blobTS = 8
+	source.blobTip = Point{Slot: 110, Hash: []byte{110}}
+	source.orphans = []BlockRef{{Slot: 105}, {Slot: 110}}
+	repairer := &fakeRepairer{trimmedRemoved: 2}
+
+	result, err := mgr.Recover(source, repairer)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeRepaired, result.Outcome)
+	require.Len(t, repairer.trimmedAbove, 1)
+	assert.Equal(t, uint64(100), repairer.trimmedAbove[0])
+	assert.Equal(t, 1, repairer.fenceResets)
+	assert.Empty(t, repairer.rolledBackTo)
+}
+
+func TestManagerRecoverTrimsAboveChainTipNotLedgerTip(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	base := healthySource(100, 7)
+	base.blobTS = 8
+	base.blobTip = Point{Slot: 300, Hash: []byte{3}}
+	// Blocks between the applied tip and the chain tip are legitimately
+	// on-chain and only waiting to be applied — the shape a snapshot
+	// bootstrap leaves — so the boundary has to be the chain tip.
+	source := chainTipSource{
+		fakeSource: base,
+		chainTip:   Point{Slot: 250, Hash: []byte{2}},
+	}
+	repairer := &fakeRepairer{}
+
+	result, err := mgr.Recover(source, repairer)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeRepaired, result.Outcome)
+	require.Len(t, repairer.trimmedAbove, 1)
+	assert.Equal(t, uint64(250), repairer.trimmedAbove[0])
+}
+
+func TestManagerRecoverRollsBackWhenBlobIsBehind(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	source := healthySource(100, 7)
+	// The blob store lost a durable write, so the ledger references blocks
+	// that are gone and has to be rewound onto what survives.
+	source.blobTS = 6
+	source.blobTip = Point{Slot: 90, Hash: []byte{90}}
+	repairer := &fakeRepairer{}
+
+	result, err := mgr.Recover(source, repairer)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeRepaired, result.Outcome)
+	require.Len(t, repairer.rolledBackTo, 1)
+	assert.Equal(t, uint64(90), repairer.rolledBackTo[0].Slot)
+	assert.Equal(t, 1, repairer.fenceResets)
+	assert.Empty(t, repairer.trimmedAbove)
+}
+
+func TestManagerRecoverWithoutRepairerReportsOnly(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	source := healthySource(100, 7)
+	source.blobTS = 8
+	result, err := mgr.Recover(source, nil)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
+	assert.NotEmpty(t, result.Actions)
+}
+
+func TestManagerRecoverPropagatesRepairFailure(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	source := healthySource(100, 7)
+	source.blobTS = 8
+	repairer := &fakeRepairer{trimErr: errors.New("disk on fire")}
+	result, err := mgr.Recover(source, repairer)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
+}
+
+func TestManagerRecoverSurfacesUnresolvedIntents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mgr := newTestManager(t, dir)
+	// A begin with no resolution is exactly what a crash inside the commit
+	// window leaves in the journal.
+	_, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 105}, 8)
+	require.NoError(t, err)
+
+	source := healthySource(100, 7)
+	source.blobTS = 8
+	source.blobTip = Point{Slot: 105, Hash: []byte{105}}
+	repairer := &fakeRepairer{trimmedRemoved: 1}
+
+	result, err := mgr.Recover(source, repairer)
+	require.NoError(t, err)
+	require.Len(t, result.Pending, 1)
+	assert.Equal(t, uint64(105), result.Pending[0].Intent.Slot)
+	assert.Equal(t, IntentBlockAdd, result.Pending[0].Intent.Kind)
+	assert.Equal(t, OutcomeRepaired, result.Outcome)
+}
+
+func TestManagerUnresolvedIntentAloneIsNotARepair(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	// Only begin records are synced, so a crash routinely loses the commit
+	// marker of a commit that did land. The stores holding the same fence is
+	// the authority: nothing was half applied, so nothing should be repaired.
+	_, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 105}, 7)
+	require.NoError(t, err)
+	repairer := &fakeRepairer{}
+
+	result, err := mgr.Recover(healthySource(100, 7), repairer)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeClean, result.Outcome)
+	require.Len(t, result.Pending, 1)
+	assert.Empty(t, repairer.trimmedAbove)
+	assert.Empty(t, repairer.rolledBackTo)
+	assert.Zero(t, repairer.fenceResets)
+	assert.NotEmpty(t, result.Actions, "the intents should still be reported")
+}
+
+func TestManagerResolvedIntentsAreNotPending(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	committed, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 1}, 1)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Commit(committed))
+	aborted, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 2}, 2)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Abort(aborted))
+
+	result, err := mgr.Recover(healthySource(100, 7), &fakeRepairer{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Pending)
+	assert.Equal(t, OutcomeClean, result.Outcome)
+}
+
+func TestManagerRecoverReportsUnrepairableDamage(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	// The stores agree, so there is no interrupted commit to undo, but the
+	// blocks beneath the tip do not link up.
+	source := healthySource(100, 7)
+	blocks := linkedBlocks(6)
+	blocks[2].PrevHash = []byte{0xff}
+	source.recent = blocks
+
+	result, err := mgr.Recover(source, &fakeRepairer{})
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
+	assert.True(t, result.Report.Failed())
+}
+
+func TestManagerCheckpointWritesAndTruncates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mgr := newTestManager(t, dir)
+	for i := range 3 {
+		seq, err := mgr.Begin(
+			Intent{Kind: IntentBlockAdd, Slot: uint64(i)},
+			7,
+		)
+		require.NoError(t, err)
+		require.NoError(t, mgr.Commit(seq))
+	}
+	source := healthySource(100, 7)
+	require.NoError(t, mgr.Checkpoint(source))
+
+	cp, err := mgr.checkpoints.Latest()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), cp.TipSlot)
+	assert.Equal(t, int64(7), cp.CommitTimestamp)
+	assert.NoError(t, cp.Verify())
+	entries, err := os.ReadDir(filepath.Join(dir, checkpointSubdir))
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries)
+}
+
+func TestManagerRecoverIgnoresTipSkewWhenFencesAgree(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	// A blob tip below the metadata tip with both fences agreeing is real
+	// damage, but nothing recovery did caused it, and rolling the ledger back
+	// against the stores' own fences is too destructive to do unprompted.
+	source := healthySource(100, 7)
+	source.blobTip = Point{Slot: 90, Hash: []byte{90}}
+	repairer := &fakeRepairer{}
+
+	result, err := mgr.Recover(source, repairer)
+	require.NoError(t, err)
+	assert.Empty(t, repairer.rolledBackTo)
+	// The tip check still reports it, loudly.
+	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
+	tipCheck, ok := result.Report.Find(CheckTipConsistency)
+	require.True(t, ok)
+	assert.Equal(t, SeverityFail, tipCheck.Severity)
+}
+
+func TestManagerRecoverRefusesToTrimWithNoKnownTip(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	// Nothing says where the chain ends, but the blob store holds blocks.
+	// Trimming above slot zero would erase all of them.
+	source := &fakeSource{
+		metadataTS: 7,
+		blobTS:     8,
+		blobTip:    Point{Slot: 500, Hash: []byte{5}},
+	}
+	repairer := &fakeRepairer{}
+	result, err := mgr.Recover(source, repairer)
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeUnrepaired, result.Outcome)
+	assert.Empty(t, repairer.trimmedAbove)
+	assert.Zero(t, repairer.fenceResets)
+}
+
+func TestManagerCheckpointToleratesTransientTimestampSkew(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	source := healthySource(100, 7)
+	// The two timestamps are not read atomically, so a commit landing
+	// between them looks like divergence on the first read only.
+	source.timestampsFn = func(call int) (int64, int64, error) {
+		if call == 1 {
+			return 6, 7, nil
+		}
+		return 7, 7, nil
+	}
+	require.NoError(t, mgr.Checkpoint(source))
+	cp, err := mgr.checkpoints.Latest()
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), cp.CommitTimestamp)
+}
+
+func TestManagerCheckpointRefusesDivergedStores(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	source := healthySource(100, 7)
+	source.blobTS = 8
+	// Anchoring recovery to state the stores do not agree on would be worse
+	// than having no anchor at all.
+	assert.Error(t, mgr.Checkpoint(source))
+}
+
+func TestManagerCheckpointStopsBelowOpenCommits(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	done, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 1}, 7)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Commit(done))
+	open, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 2}, 7)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Checkpoint(healthySource(100, 7)))
+	cp, err := mgr.checkpoints.Latest()
+	require.NoError(t, err)
+	// Covering the open commit would authorise truncating away the very
+	// intent record recovery needs if the process died before it resolved.
+	assert.Less(t, cp.Seq, open)
+}
+
+func TestManagerRecoverAfterCheckpointIgnoresCoveredIntents(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	// A begin whose commit marker was lost, but which a later checkpoint
+	// covers, is resolved: the checkpoint asserts the stores agreed past it.
+	_, err := mgr.Begin(Intent{Kind: IntentBlockAdd, Slot: 1}, 7)
+	require.NoError(t, err)
+	mgr.resolve(1)
+	require.NoError(t, mgr.Checkpoint(healthySource(100, 7)))
+
+	result, err := mgr.Recover(healthySource(100, 7), &fakeRepairer{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Pending)
+	require.NotNil(t, result.Checkpoint)
+	assert.Equal(t, uint64(100), result.Checkpoint.TipSlot)
+}
+
+func TestManagerRecoverRequiresSource(t *testing.T) {
+	t.Parallel()
+	mgr := newTestManager(t, t.TempDir())
+	_, err := mgr.Recover(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestNewManagerRequiresDir(t *testing.T) {
+	t.Parallel()
+	_, err := New(Config{})
+	assert.Error(t, err)
+}
+
+func TestNilManagerIsSafe(t *testing.T) {
+	t.Parallel()
+	// The database holds a nil manager when crash recovery is off, and every
+	// call site relies on that being harmless rather than guarding each one.
+	var mgr *Manager
+	seq, err := mgr.Begin(Intent{}, 1)
+	assert.NoError(t, err)
+	assert.Zero(t, seq)
+	assert.NoError(t, mgr.Commit(1))
+	assert.NoError(t, mgr.Abort(1))
+	assert.NoError(t, mgr.Checkpoint(nil))
+	assert.NoError(t, mgr.Close())
+	mgr.Start(nil)
+	result, err := mgr.Recover(nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestManagerStartCheckpointsPeriodically(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mgr, err := New(Config{
+		Dir:                dir,
+		CheckMode:          CheckModeFast,
+		CheckpointInterval: 5 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, mgr.Close()) }()
+
+	mgr.Start(healthySource(100, 7))
+	require.Eventually(t, func() bool {
+		_, err := mgr.checkpoints.Latest()
+		return err == nil
+	}, 3*time.Second, 5*time.Millisecond)
+}
+
+func TestOutcomeAndSeverityStrings(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "clean", OutcomeClean.String())
+	assert.Equal(t, "repaired", OutcomeRepaired.String())
+	assert.Equal(t, "unrepaired", OutcomeUnrepaired.String())
+	assert.Equal(t, "ok", SeverityOK.String())
+	assert.Equal(t, "warn", SeverityWarn.String())
+	assert.Equal(t, "fail", SeverityFail.String())
+	assert.Equal(t, "begin", RecordTypeBegin.String())
+	assert.Equal(t, "block_add", IntentBlockAdd.String())
+	assert.Equal(t, "rollback", IntentRollback.String())
+}

--- a/database/recovery/wal.go
+++ b/database/recovery/wal.go
@@ -1,0 +1,547 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	// segmentFilePrefix and segmentFileSuffix bracket the zero-padded first
+	// sequence number in a segment filename, so a lexical directory sort is
+	// also a numeric sort by sequence.
+	segmentFilePrefix = "wal-"
+	segmentFileSuffix = ".log"
+	// segmentSeqDigits pads sequence numbers wide enough for uint64.
+	segmentSeqDigits = 20
+	// defaultMaxSegmentBytes bounds a segment so truncation after a
+	// checkpoint can actually reclaim space. Records are tens of bytes, so
+	// 8MiB holds on the order of a hundred thousand commits.
+	defaultMaxSegmentBytes int64 = 8 << 20
+)
+
+// ErrWALClosed reports use of a journal that has been closed.
+var ErrWALClosed = errors.New("recovery journal is closed")
+
+// WALConfig configures a journal.
+type WALConfig struct {
+	Logger *slog.Logger
+	// Dir holds the segment files. It is created if absent.
+	Dir string
+	// MaxSegmentBytes bounds one segment file. Zero selects the default.
+	MaxSegmentBytes int64
+	// SyncOnBegin makes each begin record durable before it is returned.
+	//
+	// This is what makes the journal useful: the intent has to reach disk
+	// before the stores are touched, or a crash inside the commit window
+	// leaves no record of what was in flight. Turn it off only for tests or
+	// throughput measurement, never for a node holding real state.
+	SyncOnBegin bool
+}
+
+// WAL is an append-only journal of cross-store commit intents.
+//
+// Only begin records are synced. A commit or abort record that a crash loses is
+// harmless: replay then reports the commit as in flight, recovery compares the
+// stores, finds them consistent, and does nothing. Paying a second fsync to
+// avoid a no-op repair would double the cost of every block.
+type WAL struct {
+	logger  *slog.Logger
+	file    *os.File
+	writer  *bufio.Writer
+	dir     string
+	scratch []byte
+
+	maxSegmentBytes int64
+	mu              sync.Mutex
+	nextSeq         uint64
+	segmentFirstSeq uint64
+	segmentBytes    int64
+	syncOnBegin     bool
+	closed          bool
+}
+
+// OpenWAL opens (creating if needed) a journal directory and positions the
+// writer at the end of the newest segment.
+//
+// Existing segments are scanned to recover the next sequence number, so
+// sequences keep increasing across restarts and a replay can tell records
+// written before a restart from those written after.
+func OpenWAL(cfg WALConfig) (*WAL, error) {
+	if cfg.Dir == "" {
+		return nil, errors.New("journal directory is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	maxSegment := cfg.MaxSegmentBytes
+	if maxSegment <= 0 {
+		maxSegment = defaultMaxSegmentBytes
+	}
+	if err := os.MkdirAll(cfg.Dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create journal dir %q: %w", cfg.Dir, err)
+	}
+	w := &WAL{
+		dir:             cfg.Dir,
+		logger:          logger,
+		maxSegmentBytes: maxSegment,
+		syncOnBegin:     cfg.SyncOnBegin,
+		nextSeq:         1,
+	}
+	highest, err := w.scanHighestSeq()
+	if err != nil {
+		return nil, err
+	}
+	if highest >= w.nextSeq {
+		w.nextSeq = highest + 1
+	}
+	if err := w.openSegmentLocked(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+// Dir returns the directory holding segment files.
+func (w *WAL) Dir() string {
+	return w.dir
+}
+
+// scanHighestSeq returns the highest sequence number any existing segment
+// accounts for.
+//
+// Segment filenames count as well as record contents. A segment whose records
+// were all lost — a crash between creating the file and flushing the record
+// that prompted it, with the older segments already truncated away — would
+// otherwise leave nothing to recover the counter from, and sequences would
+// restart at 1 and collide with numbers a durable checkpoint already covers.
+// The filename survives that crash because the directory entry is synced when
+// the segment is created.
+//
+// A segment whose tail was torn by a crash stops contributing record sequences
+// at the tear, which is correct: records past a corrupt frame cannot be trusted
+// to be complete, and reusing their sequence numbers is safe because nothing
+// durable depends on them.
+func (w *WAL) scanHighestSeq() (uint64, error) {
+	segments, err := w.segmentSeqs()
+	if err != nil {
+		return 0, err
+	}
+	var highest uint64
+	for _, first := range segments {
+		if first > highest {
+			highest = first
+		}
+		path := w.segmentPath(first)
+		records, err := readSegment(path, w.logger)
+		if err != nil {
+			return 0, err
+		}
+		for _, r := range records {
+			if r.Seq > highest {
+				highest = r.Seq
+			}
+		}
+	}
+	return highest, nil
+}
+
+func (w *WAL) segmentPath(firstSeq uint64) string {
+	return filepath.Join(
+		w.dir,
+		fmt.Sprintf(
+			"%s%0*d%s",
+			segmentFilePrefix,
+			segmentSeqDigits,
+			firstSeq,
+			segmentFileSuffix,
+		),
+	)
+}
+
+// segmentSeqs returns the first-sequence of every segment, ascending.
+func (w *WAL) segmentSeqs() ([]uint64, error) {
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read journal dir: %w", err)
+	}
+	var seqs []uint64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		seq, ok := parseSegmentName(entry.Name())
+		if !ok {
+			continue
+		}
+		seqs = append(seqs, seq)
+	}
+	slices.Sort(seqs)
+	return seqs, nil
+}
+
+// parseSegmentName extracts the first sequence from a segment filename.
+func parseSegmentName(name string) (uint64, bool) {
+	if !strings.HasPrefix(name, segmentFilePrefix) ||
+		!strings.HasSuffix(name, segmentFileSuffix) {
+		return 0, false
+	}
+	digits := name[len(segmentFilePrefix) : len(name)-len(segmentFileSuffix)]
+	seq, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return seq, true
+}
+
+// openSegmentLocked opens the segment that the next sequence belongs to,
+// appending to it if it already exists.
+func (w *WAL) openSegmentLocked() error {
+	path := w.segmentPath(w.nextSeq)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return fmt.Errorf("open journal segment %q: %w", path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("stat journal segment %q: %w", path, err)
+	}
+	w.file = f
+	w.writer = bufio.NewWriter(f)
+	w.segmentFirstSeq = w.nextSeq
+	w.segmentBytes = info.Size()
+	// A new segment's existence must be durable before records land in it,
+	// otherwise a crash can lose the whole segment and with it the intent
+	// records callers believe are on disk.
+	if info.Size() == 0 {
+		if err := syncDir(w.dir); err != nil {
+			w.logger.Warn(
+				"failed to sync journal dir after segment create",
+				"error", err,
+			)
+		}
+	}
+	return nil
+}
+
+// rotateLocked closes the current segment and starts one at the next sequence.
+func (w *WAL) rotateLocked() error {
+	if err := w.flushLocked(true); err != nil {
+		return err
+	}
+	if err := w.file.Close(); err != nil {
+		return fmt.Errorf("close journal segment: %w", err)
+	}
+	w.file = nil
+	w.writer = nil
+	return w.openSegmentLocked()
+}
+
+// flushLocked drains the buffered writer and optionally fsyncs the file.
+func (w *WAL) flushLocked(sync bool) error {
+	if w.writer == nil || w.file == nil {
+		return ErrWALClosed
+	}
+	if err := w.writer.Flush(); err != nil {
+		return fmt.Errorf("flush journal: %w", err)
+	}
+	if !sync {
+		return nil
+	}
+	if err := w.file.Sync(); err != nil {
+		return fmt.Errorf("sync journal: %w", err)
+	}
+	return nil
+}
+
+// appendLocked frames and writes a record, rotating first when the current
+// segment is full.
+func (w *WAL) appendLocked(r Record, sync bool) error {
+	if w.closed {
+		return ErrWALClosed
+	}
+	if w.segmentBytes >= w.maxSegmentBytes &&
+		w.segmentFirstSeq != w.nextSeq {
+		// Rotate only at a record boundary and never into an empty
+		// segment, so a segment always starts with the sequence its
+		// filename claims.
+		if err := w.rotateLocked(); err != nil {
+			return err
+		}
+	}
+	frame, err := appendFrame(w.scratch[:0], r)
+	if err != nil {
+		return err
+	}
+	w.scratch = frame
+	if w.writer == nil {
+		return ErrWALClosed
+	}
+	n, err := w.writer.Write(frame)
+	w.segmentBytes += int64(n)
+	if err != nil {
+		return fmt.Errorf("write journal record: %w", err)
+	}
+	return w.flushLocked(sync)
+}
+
+// Begin records the intent of a cross-store commit and returns its sequence.
+//
+// The record is durable before this returns when SyncOnBegin is set. Pass the
+// returned sequence to Commit or Abort once the commit resolves.
+func (w *WAL) Begin(intent Intent, commitTimestamp int64) (uint64, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, ErrWALClosed
+	}
+	seq := w.nextSeq
+	record := Record{
+		Type:            RecordTypeBegin,
+		Seq:             seq,
+		CommitTimestamp: commitTimestamp,
+		Intent:          intent,
+	}
+	if err := w.appendLocked(record, w.syncOnBegin); err != nil {
+		return 0, err
+	}
+	w.nextSeq++
+	return seq, nil
+}
+
+// Commit marks the commit with the given sequence as applied to both stores.
+func (w *WAL) Commit(seq uint64) error {
+	return w.resolve(seq, RecordTypeCommit)
+}
+
+// Abort marks the commit with the given sequence as rolled back.
+func (w *WAL) Abort(seq uint64) error {
+	return w.resolve(seq, RecordTypeAbort)
+}
+
+func (w *WAL) resolve(seq uint64, t RecordType) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrWALClosed
+	}
+	return w.appendLocked(Record{Type: t, Seq: seq}, false)
+}
+
+// AppendCheckpoint records a checkpoint inline in the journal and makes it
+// durable. The checkpoint is sealed first, so its merkle root always matches
+// the contents that were written.
+func (w *WAL) AppendCheckpoint(c Checkpoint) error {
+	c.Seal()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrWALClosed
+	}
+	record := Record{
+		Type:       RecordTypeCheckpoint,
+		Seq:        c.Seq,
+		Checkpoint: &c,
+	}
+	return w.appendLocked(record, true)
+}
+
+// NextSeq returns the sequence the next Begin will use.
+func (w *WAL) NextSeq() uint64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.nextSeq
+}
+
+// Replay reads every readable record in sequence order and passes it to fn.
+//
+// A torn or corrupt tail ends the replay of the segment it appears in without
+// failing the call: that shape is exactly what an unclean shutdown produces and
+// the records before the tear are still good. Corruption is logged so an
+// operator can see it happened. An error from fn stops the replay and is
+// returned.
+func (w *WAL) Replay(fn func(Record) error) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrWALClosed
+	}
+	// Buffered records that have not reached the file yet would otherwise be
+	// invisible to a replay taken while the node is running.
+	if err := w.flushLocked(false); err != nil {
+		return err
+	}
+	segments, err := w.segmentSeqs()
+	if err != nil {
+		return err
+	}
+	for _, first := range segments {
+		records, err := readSegment(w.segmentPath(first), w.logger)
+		if err != nil {
+			return err
+		}
+		for _, r := range records {
+			if err := fn(r); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// TruncateThrough removes segments whose records are all at or below seq.
+//
+// The active segment is never removed, and a segment is kept whenever any of
+// its records is above seq, so truncation can only ever discard records a
+// durable checkpoint already covers.
+func (w *WAL) TruncateThrough(seq uint64) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, ErrWALClosed
+	}
+	if err := w.flushLocked(false); err != nil {
+		return 0, err
+	}
+	segments, err := w.segmentSeqs()
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	for _, first := range segments {
+		if first == w.segmentFirstSeq {
+			continue
+		}
+		path := w.segmentPath(first)
+		records, err := readSegment(path, w.logger)
+		if err != nil {
+			return removed, err
+		}
+		highest := uint64(0)
+		for _, r := range records {
+			if r.Seq > highest {
+				highest = r.Seq
+			}
+		}
+		if highest > seq {
+			// Segments are ordered by first sequence, so once one
+			// reaches past the checkpoint every later one does too.
+			break
+		}
+		if err := os.Remove(path); err != nil &&
+			!errors.Is(err, fs.ErrNotExist) {
+			return removed, fmt.Errorf(
+				"remove journal segment %q: %w",
+				path,
+				err,
+			)
+		}
+		removed++
+	}
+	if removed > 0 {
+		if err := syncDir(w.dir); err != nil {
+			w.logger.Warn(
+				"failed to sync journal dir after truncation",
+				"error", err,
+			)
+		}
+	}
+	return removed, nil
+}
+
+// Sync flushes and fsyncs any buffered records.
+func (w *WAL) Sync() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return ErrWALClosed
+	}
+	return w.flushLocked(true)
+}
+
+// Close flushes, syncs and closes the journal. It is safe to call more than
+// once.
+func (w *WAL) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	var errs []error
+	if w.writer != nil && w.file != nil {
+		if err := w.writer.Flush(); err != nil {
+			errs = append(errs, fmt.Errorf("flush journal: %w", err))
+		}
+		if err := w.file.Sync(); err != nil {
+			errs = append(errs, fmt.Errorf("sync journal: %w", err))
+		}
+		if err := w.file.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close journal: %w", err))
+		}
+	}
+	w.file = nil
+	w.writer = nil
+	return errors.Join(errs...)
+}
+
+// readSegment reads every intact record from a segment file.
+//
+// It returns an error only for problems that are not "the tail is damaged":
+// a missing file yields no records, and a torn tail ends the read after the
+// records that did survive.
+func readSegment(path string, logger *slog.Logger) ([]Record, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open journal segment %q: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck
+	reader := bufio.NewReader(f)
+	var records []Record
+	for {
+		record, err := readFrame(reader)
+		if errors.Is(err, io.EOF) {
+			return records, nil
+		}
+		if err != nil {
+			logger.Warn(
+				"journal segment ends in an unreadable record",
+				"path", path,
+				"records_recovered", len(records),
+				"error", err,
+			)
+			return records, nil
+		}
+		records = append(records, record)
+	}
+}

--- a/database/recovery/wal.go
+++ b/database/recovery/wal.go
@@ -46,6 +46,8 @@ const (
 // ErrWALClosed reports use of a journal that has been closed.
 var ErrWALClosed = errors.New("recovery journal is closed")
 
+var ErrWALUnusable = errors.New("recovery journal is unusable after an append failure")
+
 // WALConfig configures a journal.
 type WALConfig struct {
 	Logger *slog.Logger
@@ -82,6 +84,7 @@ type WAL struct {
 	segmentBytes    int64
 	syncOnBegin     bool
 	closed          bool
+	unusable        bool
 }
 
 // OpenWAL opens (creating if needed) a journal directory and positions the
@@ -322,6 +325,9 @@ func (w *WAL) Begin(intent Intent, commitTimestamp int64) (uint64, error) {
 	if w.closed {
 		return 0, ErrWALClosed
 	}
+	if w.unusable {
+		return 0, ErrWALUnusable
+	}
 	seq := w.nextSeq
 	record := Record{
 		Type:            RecordTypeBegin,
@@ -330,6 +336,10 @@ func (w *WAL) Begin(intent Intent, commitTimestamp int64) (uint64, error) {
 		Intent:          intent,
 	}
 	if err := w.appendLocked(record, w.syncOnBegin); err != nil {
+		// A buffered writer or file may have accepted part of a frame. Do not
+		// issue the same sequence again in this process; recovery must reopen
+		// the journal and inspect the durable tail before assigning numbers.
+		w.unusable = true
 		return 0, err
 	}
 	w.nextSeq++
@@ -352,7 +362,14 @@ func (w *WAL) resolve(seq uint64, t RecordType) error {
 	if w.closed {
 		return ErrWALClosed
 	}
-	return w.appendLocked(Record{Type: t, Seq: seq}, false)
+	if w.unusable {
+		return ErrWALUnusable
+	}
+	err := w.appendLocked(Record{Type: t, Seq: seq}, false)
+	if err != nil {
+		w.unusable = true
+	}
+	return err
 }
 
 // AppendCheckpoint records a checkpoint inline in the journal and makes it
@@ -365,12 +382,19 @@ func (w *WAL) AppendCheckpoint(c Checkpoint) error {
 	if w.closed {
 		return ErrWALClosed
 	}
+	if w.unusable {
+		return ErrWALUnusable
+	}
 	record := Record{
 		Type:       RecordTypeCheckpoint,
 		Seq:        c.Seq,
 		Checkpoint: &c,
 	}
-	return w.appendLocked(record, true)
+	err := w.appendLocked(record, true)
+	if err != nil {
+		w.unusable = true
+	}
+	return err
 }
 
 // NextSeq returns the sequence the next Begin will use.
@@ -440,9 +464,14 @@ func (w *WAL) TruncateThrough(seq uint64) (int, error) {
 			continue
 		}
 		path := w.segmentPath(first)
-		records, err := readSegment(path, w.logger)
+		records, complete, err := readSegmentStatus(path, w.logger)
 		if err != nil {
 			return removed, err
+		}
+		if !complete {
+			// A corrupt or torn segment may contain an unresolved begin
+			// before its unreadable tail. Keep it as a recovery artifact.
+			break
 		}
 		highest := uint64(0)
 		for _, r := range records {
@@ -518,12 +547,17 @@ func (w *WAL) Close() error {
 // a missing file yields no records, and a torn tail ends the read after the
 // records that did survive.
 func readSegment(path string, logger *slog.Logger) ([]Record, error) {
+	records, _, err := readSegmentStatus(path, logger)
+	return records, err
+}
+
+func readSegmentStatus(path string, logger *slog.Logger) ([]Record, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil, nil
+			return nil, true, nil
 		}
-		return nil, fmt.Errorf("open journal segment %q: %w", path, err)
+		return nil, false, fmt.Errorf("open journal segment %q: %w", path, err)
 	}
 	defer f.Close() //nolint:errcheck
 	reader := bufio.NewReader(f)
@@ -531,7 +565,7 @@ func readSegment(path string, logger *slog.Logger) ([]Record, error) {
 	for {
 		record, err := readFrame(reader)
 		if errors.Is(err, io.EOF) {
-			return records, nil
+			return records, true, nil
 		}
 		if err != nil {
 			logger.Warn(
@@ -540,7 +574,7 @@ func readSegment(path string, logger *slog.Logger) ([]Record, error) {
 				"records_recovered", len(records),
 				"error", err,
 			)
-			return records, nil
+			return records, false, nil
 		}
 		records = append(records, record)
 	}

--- a/database/recovery/wal_test.go
+++ b/database/recovery/wal_test.go
@@ -287,6 +287,15 @@ func TestWALRejectsUseAfterClose(t *testing.T) {
 	assert.ErrorIs(t, truncErr, ErrWALClosed)
 }
 
+func TestWALDoesNotContinueAfterAppendFailure(t *testing.T) {
+	w := newTestWAL(t, t.TempDir(), 0)
+	w.mu.Lock()
+	w.unusable = true
+	w.mu.Unlock()
+	_, err := w.Begin(Intent{Kind: IntentBlockAdd}, 1)
+	assert.ErrorIs(t, err, ErrWALUnusable)
+}
+
 func TestOpenWALRequiresDir(t *testing.T) {
 	t.Parallel()
 	_, err := OpenWAL(WALConfig{})

--- a/database/recovery/wal_test.go
+++ b/database/recovery/wal_test.go
@@ -181,6 +181,37 @@ func TestWALSequencesSurviveTruncationAndRestart(t *testing.T) {
 	assert.Greater(t, reopened.NextSeq(), highest)
 }
 
+func TestWALSequencesRemainMonotonicAfterPartialTruncation(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := newTestWAL(t, dir, 1)
+	seqs := make([]uint64, 0, 8)
+	for i := range 8 {
+		seq, err := w.Begin(
+			Intent{Kind: IntentBlockAdd, Slot: uint64(i)},
+			int64(i),
+		)
+		require.NoError(t, err)
+		require.NoError(t, w.Commit(seq))
+		seqs = append(seqs, seq)
+	}
+	checkpointed := seqs[3]
+	require.NoError(t, func() error {
+		_, err := w.TruncateThrough(checkpointed)
+		return err
+	}())
+	require.NoError(t, w.Close())
+
+	reopened := newTestWAL(t, dir, 1)
+	assert.Greater(t, reopened.NextSeq(), seqs[len(seqs)-1])
+	next, err := reopened.Begin(
+		Intent{Kind: IntentBlockAdd, Slot: 99},
+		99,
+	)
+	require.NoError(t, err)
+	assert.Greater(t, next, seqs[len(seqs)-1])
+}
+
 func TestWALTruncateKeepsUncoveredSegments(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/database/recovery/wal_test.go
+++ b/database/recovery/wal_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestWAL(t *testing.T, dir string, maxSegment int64) *WAL {
+	t.Helper()
+	w, err := OpenWAL(WALConfig{
+		Dir:             dir,
+		MaxSegmentBytes: maxSegment,
+		SyncOnBegin:     true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Close is idempotent, so a test that closed the journal itself
+		// does not fail here.
+		require.NoError(t, w.Close())
+	})
+	return w
+}
+
+func replayAll(t *testing.T, w *WAL) []Record {
+	t.Helper()
+	var records []Record
+	require.NoError(t, w.Replay(func(r Record) error {
+		records = append(records, r)
+		return nil
+	}))
+	return records
+}
+
+func TestWALSequencesIncrease(t *testing.T) {
+	t.Parallel()
+	w := newTestWAL(t, t.TempDir(), 0)
+	first, err := w.Begin(Intent{Kind: IntentBlockAdd, Slot: 1}, 100)
+	require.NoError(t, err)
+	second, err := w.Begin(Intent{Kind: IntentBlockAdd, Slot: 2}, 101)
+	require.NoError(t, err)
+	assert.Greater(t, second, first)
+	assert.Equal(t, second+1, w.NextSeq())
+}
+
+func TestWALReplayReturnsRecordsInOrder(t *testing.T) {
+	t.Parallel()
+	w := newTestWAL(t, t.TempDir(), 0)
+	seq, err := w.Begin(Intent{Kind: IntentBlockAdd, Slot: 7}, 500)
+	require.NoError(t, err)
+	require.NoError(t, w.Commit(seq))
+	records := replayAll(t, w)
+	require.Len(t, records, 2)
+	assert.Equal(t, RecordTypeBegin, records[0].Type)
+	assert.Equal(t, uint64(7), records[0].Intent.Slot)
+	assert.Equal(t, int64(500), records[0].CommitTimestamp)
+	assert.Equal(t, RecordTypeCommit, records[1].Type)
+	assert.Equal(t, seq, records[1].Seq)
+}
+
+func TestWALSurvivesReopen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := newTestWAL(t, dir, 0)
+	seq, err := w.Begin(Intent{Kind: IntentBlockAdd, Slot: 3}, 42)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	reopened := newTestWAL(t, dir, 0)
+	// Sequences must keep increasing across a restart so replay can tell
+	// records written before it from those written after.
+	assert.Greater(t, reopened.NextSeq(), seq)
+	records := replayAll(t, reopened)
+	require.Len(t, records, 1)
+	assert.Equal(t, seq, records[0].Seq)
+}
+
+func TestWALRotatesSegments(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// A tiny segment cap forces a rotation on essentially every record.
+	w := newTestWAL(t, dir, 1)
+	for i := range 4 {
+		seq, err := w.Begin(
+			Intent{Kind: IntentBlockAdd, Slot: uint64(i)},
+			int64(i),
+		)
+		require.NoError(t, err)
+		require.NoError(t, w.Commit(seq))
+	}
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Greater(t, len(entries), 1, "expected more than one segment")
+	assert.Len(t, replayAll(t, w), 8)
+}
+
+func TestWALTruncateThroughRemovesCoveredSegments(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := newTestWAL(t, dir, 1)
+	seqs := make([]uint64, 0, 5)
+	for i := range 5 {
+		seq, err := w.Begin(
+			Intent{Kind: IntentBlockAdd, Slot: uint64(i)},
+			int64(i),
+		)
+		require.NoError(t, err)
+		require.NoError(t, w.Commit(seq))
+		seqs = append(seqs, seq)
+	}
+	before, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	removed, err := w.TruncateThrough(seqs[2])
+	require.NoError(t, err)
+	assert.Positive(t, removed)
+
+	after, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Less(t, len(after), len(before))
+	for _, record := range replayAll(t, w) {
+		assert.Greater(
+			t,
+			record.Seq,
+			seqs[2]-1,
+			"records at or below the truncation point should be gone",
+		)
+	}
+}
+
+func TestWALSequencesSurviveTruncationAndRestart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := newTestWAL(t, dir, 1)
+	var highest uint64
+	for i := range 5 {
+		seq, err := w.Begin(
+			Intent{Kind: IntentBlockAdd, Slot: uint64(i)},
+			int64(i),
+		)
+		require.NoError(t, err)
+		require.NoError(t, w.Commit(seq))
+		highest = seq
+	}
+	// Truncation leaves only the active segment. Emptying it simulates a
+	// crash between creating a segment and flushing the record that prompted
+	// it, which is the shape that leaves no record to recover the counter
+	// from.
+	_, err := w.TruncateThrough(highest)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		require.NoError(
+			t,
+			os.Truncate(filepath.Join(dir, entry.Name()), 0),
+		)
+	}
+
+	reopened := newTestWAL(t, dir, 1)
+	// Reissuing a sequence a checkpoint already covers would let truncation
+	// discard the new records along with the old.
+	assert.Greater(t, reopened.NextSeq(), highest)
+}
+
+func TestWALTruncateKeepsUncoveredSegments(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := newTestWAL(t, dir, 1)
+	seq, err := w.Begin(Intent{Kind: IntentBlockAdd, Slot: 1}, 1)
+	require.NoError(t, err)
+	require.NoError(t, w.Commit(seq))
+	// Truncating below the oldest record must not remove anything.
+	removed, err := w.TruncateThrough(0)
+	require.NoError(t, err)
+	assert.Zero(t, removed)
+	assert.NotEmpty(t, replayAll(t, w))
+}
+
+func TestWALReplayStopsAtTornTail(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := newTestWAL(t, dir, 0)
+	for i := range 3 {
+		_, err := w.Begin(
+			Intent{Kind: IntentBlockAdd, Slot: uint64(i)},
+			int64(i),
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	path := filepath.Join(dir, entries[0].Name())
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	// Chop the final few bytes, which is what an interrupted append leaves.
+	require.NoError(t, os.Truncate(path, info.Size()-3))
+
+	reopened := newTestWAL(t, dir, 0)
+	records := replayAll(t, reopened)
+	assert.Len(
+		t,
+		records,
+		2,
+		"the two intact records survive, the torn one does not",
+	)
+}
+
+func TestWALCheckpointRecordReplays(t *testing.T) {
+	t.Parallel()
+	w := newTestWAL(t, t.TempDir(), 0)
+	require.NoError(t, w.AppendCheckpoint(Checkpoint{
+		Seq:         9,
+		TipSlot:     1234,
+		TipHash:     []byte{0xaa},
+		BlobTipSlot: 1234,
+	}))
+	records := replayAll(t, w)
+	require.Len(t, records, 1)
+	require.NotNil(t, records[0].Checkpoint)
+	assert.Equal(t, uint64(9), records[0].Checkpoint.Seq)
+	// AppendCheckpoint seals before writing, so what comes back verifies.
+	assert.NoError(t, records[0].Checkpoint.Verify())
+}
+
+func TestWALRejectsUseAfterClose(t *testing.T) {
+	t.Parallel()
+	w := newTestWAL(t, t.TempDir(), 0)
+	require.NoError(t, w.Close())
+	_, err := w.Begin(Intent{}, 1)
+	assert.ErrorIs(t, err, ErrWALClosed)
+	assert.ErrorIs(t, w.Commit(1), ErrWALClosed)
+	assert.ErrorIs(t, w.Sync(), ErrWALClosed)
+	_, truncErr := w.TruncateThrough(1)
+	assert.ErrorIs(t, truncErr, ErrWALClosed)
+}
+
+func TestOpenWALRequiresDir(t *testing.T) {
+	t.Parallel()
+	_, err := OpenWAL(WALConfig{})
+	assert.Error(t, err)
+}
+
+func TestParseSegmentName(t *testing.T) {
+	t.Parallel()
+	seq, ok := parseSegmentName("wal-00000000000000000042.log")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(42), seq)
+	for _, name := range []string{
+		"wal-notanumber.log",
+		"other-00000000000000000042.log",
+		"wal-00000000000000000042.txt",
+	} {
+		_, ok := parseSegmentName(name)
+		assert.False(t, ok, "should not parse %q", name)
+	}
+}

--- a/database/recovery_source.go
+++ b/database/recovery_source.go
@@ -150,8 +150,16 @@ func (s recoveryStateSource) OrphanBlobs(
 	}
 	readTxn := blobStore.NewTransaction(false)
 	defer readTxn.Rollback() //nolint:errcheck
+	if afterSlot == ^uint64(0) {
+		return nil, nil
+	}
+	seekKey := make([]byte, 0, len(types.BlockBlobKeyPrefix)+8)
+	seekKey = append(seekKey, types.BlockBlobKeyPrefix...)
+	seekKey = binary.BigEndian.AppendUint64(seekKey, afterSlot+1)
 	it := blobStore.NewIterator(readTxn, types.BlobIteratorOptions{
 		Prefix: []byte(types.BlockBlobKeyPrefix),
+		Start:  seekKey,
+		Limit:  limit*4 + 16,
 	})
 	if it == nil {
 		return nil, errors.New("blob iterator is nil")
@@ -159,9 +167,6 @@ func (s recoveryStateSource) OrphanBlobs(
 	defer it.Close()
 	// Seek past the boundary slot. Keys are prefix + big-endian slot, so
 	// seeking to slot+1 lands on the first block above it.
-	seekKey := make([]byte, 0, len(types.BlockBlobKeyPrefix)+8)
-	seekKey = append(seekKey, types.BlockBlobKeyPrefix...)
-	seekKey = binary.BigEndian.AppendUint64(seekKey, afterSlot+1)
 	var refs []recovery.BlockRef
 	for it.Seek(seekKey); it.ValidForPrefix(
 		[]byte(types.BlockBlobKeyPrefix),
@@ -184,7 +189,7 @@ func (s recoveryStateSource) OrphanBlobs(
 		}
 		slot, hash, err := types.ParseBlockBlobKey(key)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("parse block blob key %q: %w", key, err)
 		}
 		if slot <= afterSlot {
 			continue
@@ -310,6 +315,14 @@ func (d *Database) trimBlobBatch(
 			orphan.Hash,
 		)
 		if err != nil {
+			var expired *types.HistoryExpiredError
+			if errors.As(err, &expired) && metadata.ID != 0 {
+				// Tombstoned blocks retain their metadata/index so they
+				// can be served by an archive wrapper. Recovery still
+				// removes the complete orphan, using the retained ID.
+				ids[i] = metadata.ID
+				continue
+			}
 			_ = readTxn.Rollback()
 			return 0, fmt.Errorf(
 				"read metadata for block at slot %d: %w",

--- a/database/recovery_source.go
+++ b/database/recovery_source.go
@@ -1,0 +1,363 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/recovery"
+	"github.com/blinklabs-io/dingo/database/types"
+)
+
+// errStopSample ends a bounded iteration once the sample limit is reached. It
+// never escapes the function that raises it.
+var errStopSample = errors.New("sample limit reached")
+
+// RecoveryStateSource returns the read-only view of stored state that the
+// crash-recovery consistency checks run against.
+//
+// It reports only what the two stores hold. The chain manager's tip is not
+// visible from here, so the node wraps this value to add it; see
+// recovery.ChainTipSource.
+func (d *Database) RecoveryStateSource() recovery.StateSource {
+	return recoveryStateSource{db: d}
+}
+
+// recoveryStateSource adapts a Database to recovery.StateSource.
+type recoveryStateSource struct {
+	db *Database
+}
+
+// MetadataTip returns the tip the metadata store records.
+func (s recoveryStateSource) MetadataTip() (recovery.Point, uint64, error) {
+	tip, err := s.db.GetTip(nil)
+	if err != nil {
+		return recovery.Point{}, 0, err
+	}
+	return recovery.Point{
+		Slot: tip.Point.Slot,
+		Hash: tip.Point.Hash,
+	}, tip.BlockNumber, nil
+}
+
+// BlobTip returns the newest block the blob store holds.
+func (s recoveryStateSource) BlobTip() (recovery.Point, error) {
+	var point recovery.Point
+	txn := s.db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		blocks, err := BlocksRecentTxn(txn, 1)
+		if err != nil {
+			return err
+		}
+		if len(blocks) == 0 {
+			return nil
+		}
+		point = recovery.Point{
+			Slot: blocks[0].Slot,
+			Hash: blocks[0].Hash,
+		}
+		return nil
+	})
+	if err != nil {
+		return recovery.Point{}, err
+	}
+	return point, nil
+}
+
+// CommitTimestamps returns the cross-store commit fence each store holds.
+func (s recoveryStateSource) CommitTimestamps() (int64, int64, error) {
+	metadataTS, err := s.db.Metadata().GetCommitTimestamp()
+	if err != nil {
+		return 0, 0, fmt.Errorf("metadata commit timestamp: %w", err)
+	}
+	blobTS, err := s.db.Blob().GetCommitTimestamp()
+	if err != nil {
+		return 0, 0, fmt.Errorf("blob commit timestamp: %w", err)
+	}
+	return metadataTS, blobTS, nil
+}
+
+// RecentBlocks returns up to limit blocks ending at the blob tip, newest first.
+//
+// The block CBOR each lookup returns is dropped here rather than retained: the
+// continuity check only needs the hash linkage, and holding thousands of block
+// bodies would cost far more memory than the check is worth.
+func (s recoveryStateSource) RecentBlocks(
+	limit int,
+) ([]recovery.BlockRef, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var refs []recovery.BlockRef
+	txn := s.db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		blocks, err := BlocksRecentTxn(txn, limit)
+		if err != nil {
+			return err
+		}
+		refs = make([]recovery.BlockRef, 0, len(blocks))
+		for _, block := range blocks {
+			refs = append(refs, recovery.BlockRef{
+				Hash:     block.Hash,
+				PrevHash: block.PrevHash,
+				Slot:     block.Slot,
+				Number:   block.Number,
+				ID:       block.ID,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return refs, nil
+}
+
+// OrphanBlobs returns up to limit blocks the blob store holds above afterSlot,
+// oldest first.
+//
+// Slot and hash come straight out of the key, so the scan never reads a block
+// body. That matters when the gap is large: after a snapshot bootstrap the blob
+// store can legitimately hold a great many blocks above the applied tip, and
+// this has to stay cheap enough to run at every start.
+func (s recoveryStateSource) OrphanBlobs(
+	afterSlot uint64,
+	limit int,
+) ([]recovery.BlockRef, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	blobStore := s.db.Blob()
+	if blobStore == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
+	readTxn := blobStore.NewTransaction(false)
+	defer readTxn.Rollback() //nolint:errcheck
+	it := blobStore.NewIterator(readTxn, types.BlobIteratorOptions{
+		Prefix: []byte(types.BlockBlobKeyPrefix),
+	})
+	if it == nil {
+		return nil, errors.New("blob iterator is nil")
+	}
+	defer it.Close()
+	// Seek past the boundary slot. Keys are prefix + big-endian slot, so
+	// seeking to slot+1 lands on the first block above it.
+	seekKey := make([]byte, 0, len(types.BlockBlobKeyPrefix)+8)
+	seekKey = append(seekKey, types.BlockBlobKeyPrefix...)
+	seekKey = binary.BigEndian.AppendUint64(seekKey, afterSlot+1)
+	var refs []recovery.BlockRef
+	for it.Seek(seekKey); it.ValidForPrefix(
+		[]byte(types.BlockBlobKeyPrefix),
+	); it.Next() {
+		item := it.Item()
+		if item == nil {
+			continue
+		}
+		key := item.Key()
+		if key == nil {
+			continue
+		}
+		// Per-block metadata is stored under a suffixed variant of the
+		// same key and is not itself a block.
+		if strings.HasSuffix(
+			string(key),
+			types.BlockBlobMetadataKeySuffix,
+		) {
+			continue
+		}
+		slot, hash, err := types.ParseBlockBlobKey(key)
+		if err != nil {
+			continue
+		}
+		if slot <= afterSlot {
+			continue
+		}
+		refs = append(refs, recovery.BlockRef{Slot: slot, Hash: hash})
+		if len(refs) >= limit {
+			break
+		}
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("orphan blob scan: %w", err)
+	}
+	return refs, nil
+}
+
+// CheckUtxos resolves up to limit live UTxOs against their stored CBOR.
+//
+// Live UTxOs are stored as offset references into block CBOR rather than as
+// inline values, so a row whose block went missing resolves to nothing while
+// still looking present in the metadata store. Nothing notices until a
+// transaction tries to spend it, which is why a bounded sample runs at startup.
+func (s recoveryStateSource) CheckUtxos(
+	limit int,
+) (recovery.UtxoIntegrityResult, error) {
+	var result recovery.UtxoIntegrityResult
+	if limit <= 0 {
+		return result, nil
+	}
+	txn := s.db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		return s.db.metadata.IterateLiveUtxos(
+			txn.Metadata(),
+			func(utxo *models.Utxo) error {
+				result.Checked++
+				if err := loadCbor(utxo, txn); err != nil {
+					result.Unresolvable = append(
+						result.Unresolvable,
+						fmt.Sprintf(
+							"%x#%d",
+							utxo.TxId,
+							utxo.OutputIdx,
+						),
+					)
+				}
+				if result.Checked >= limit {
+					return errStopSample
+				}
+				return nil
+			},
+		)
+	})
+	if err != nil && !errors.Is(err, errStopSample) {
+		return recovery.UtxoIntegrityResult{}, err
+	}
+	return result, nil
+}
+
+// trimBatchSize bounds one removal pass. Badger rejects a transaction that
+// grows past its size limit, and a repair has no bound on how many blocks it
+// may be asked to remove, so the work is committed in batches and the scan
+// repeats until nothing is left above the boundary.
+const trimBatchSize = 500
+
+// TrimBlobAbove removes every block the blob store holds above slot and returns
+// how many it removed.
+//
+// This is the repair for the residue an interrupted cross-store commit leaves:
+// blob writes that landed before the process died while the metadata commit
+// that would have made them part of the chain never did. Callers are
+// responsible for choosing a boundary that no live chain data sits above.
+func (d *Database) TrimBlobAbove(slot uint64) (int, error) {
+	blobStore := d.Blob()
+	if blobStore == nil {
+		return 0, types.ErrBlobStoreUnavailable
+	}
+	source := recoveryStateSource{db: d}
+	total := 0
+	for {
+		orphans, err := source.OrphanBlobs(slot, trimBatchSize)
+		if err != nil {
+			return total, err
+		}
+		if len(orphans) == 0 {
+			break
+		}
+		deleted, err := d.trimBlobBatch(blobStore, orphans)
+		total += deleted
+		if err != nil {
+			return total, err
+		}
+		if deleted == 0 {
+			// The scan still sees these blocks and the batch removed
+			// none of them. Repeating would spin forever, so stop and
+			// say so rather than looping.
+			return total, fmt.Errorf(
+				"orphan removal made no progress at slot %d",
+				orphans[0].Slot,
+			)
+		}
+	}
+	if total > 0 {
+		if err := blobStore.Sync(); err != nil {
+			return total, fmt.Errorf("sync after orphan removal: %w", err)
+		}
+	}
+	return total, nil
+}
+
+// trimBlobBatch removes one batch of blocks in a single transaction.
+func (d *Database) trimBlobBatch(
+	blobStore blob.BlobStore,
+	orphans []recovery.BlockRef,
+) (int, error) {
+	// DeleteBlock needs the block's index, which only the stored metadata
+	// carries, so this pass does read the per-block metadata the key scan
+	// skipped. It runs only when there is something to delete.
+	readTxn := blobStore.NewTransaction(false)
+	ids := make([]uint64, len(orphans))
+	for i, orphan := range orphans {
+		_, metadata, err := blobStore.GetBlock(
+			readTxn,
+			orphan.Slot,
+			orphan.Hash,
+		)
+		if err != nil {
+			_ = readTxn.Rollback()
+			return 0, fmt.Errorf(
+				"read metadata for block at slot %d: %w",
+				orphan.Slot,
+				err,
+			)
+		}
+		ids[i] = metadata.ID
+	}
+	if err := readTxn.Rollback(); err != nil {
+		d.logger.Debug(
+			"failed to release orphan metadata read transaction",
+			"error", err,
+		)
+	}
+	writeTxn := blobStore.NewTransaction(true)
+	deleted := 0
+	for i, orphan := range orphans {
+		if err := blobStore.DeleteBlock(
+			writeTxn,
+			orphan.Slot,
+			orphan.Hash,
+			ids[i],
+		); err != nil {
+			_ = writeTxn.Rollback()
+			return 0, fmt.Errorf(
+				"delete block at slot %d: %w",
+				orphan.Slot,
+				err,
+			)
+		}
+		deleted++
+	}
+	if err := writeTxn.Commit(); err != nil {
+		return 0, fmt.Errorf("commit orphan block removal: %w", err)
+	}
+	return deleted, nil
+}
+
+// ResetCommitFence brings both stores back onto a common commit timestamp
+// after a repair has made their contents consistent again.
+//
+// It does not take the value to write. A combined commit stamps both stores
+// with its own timestamp as part of committing, so an empty combined commit is
+// all this needs to be, and any value passed in would be overwritten by that
+// stamp anyway. What matters to recovery is that the two agree, not what they
+// agree on.
+func (d *Database) ResetCommitFence() error {
+	txn := d.Transaction(true)
+	return txn.Do(func(*Txn) error { return nil })
+}

--- a/database/recovery_source_test.go
+++ b/database/recovery_source_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/recovery"
+	"github.com/blinklabs-io/dingo/database/types"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockHashForIndex builds a distinct 32-byte hash per block index, so chains
+// longer than 256 blocks do not repeat a hash.
+func blockHashForIndex(i int) []byte {
+	hash := make([]byte, 32)
+	binary.BigEndian.PutUint64(hash, uint64(i))
+	return hash
+}
+
+// linkedChain builds a run of blocks whose prev-hash links form a chain.
+func linkedChain(t *testing.T, db *Database, count int) []models.Block {
+	t.Helper()
+	blocks := make([]models.Block, 0, count)
+	var prevHash []byte
+	for i := 1; i <= count; i++ {
+		block := models.Block{
+			ID:       uint64(i),
+			Slot:     uint64(i) * 10,
+			Hash:     blockHashForIndex(i),
+			PrevHash: prevHash,
+			Cbor:     []byte{0x80},
+			Number:   uint64(i),
+			Type:     1,
+		}
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks = append(blocks, block)
+		prevHash = block.Hash
+	}
+	return blocks
+}
+
+func setTipTo(t *testing.T, db *Database, block models.Block) {
+	t.Helper()
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point:       ocommon.NewPoint(block.Slot, block.Hash),
+		BlockNumber: block.Number,
+	}, nil))
+}
+
+func TestRecoveryStateSourceReportsTips(t *testing.T) {
+	db := newTestDB(t)
+	blocks := linkedChain(t, db, 3)
+	setTipTo(t, db, blocks[2])
+
+	source := db.RecoveryStateSource()
+	metaTip, blockNumber, err := source.MetadataTip()
+	require.NoError(t, err)
+	assert.Equal(t, blocks[2].Slot, metaTip.Slot)
+	assert.Equal(t, blocks[2].Number, blockNumber)
+
+	blobTip, err := source.BlobTip()
+	require.NoError(t, err)
+	assert.Equal(t, blocks[2].Slot, blobTip.Slot)
+	assert.Equal(t, blocks[2].Hash, blobTip.Hash)
+}
+
+func TestRecoveryStateSourceBlobTipOnEmptyStore(t *testing.T) {
+	db := newTestDB(t)
+	blobTip, err := db.RecoveryStateSource().BlobTip()
+	require.NoError(t, err)
+	assert.True(t, blobTip.IsZero())
+}
+
+func TestRecoveryStateSourceRecentBlocksAreNewestFirst(t *testing.T) {
+	db := newTestDB(t)
+	blocks := linkedChain(t, db, 5)
+
+	refs, err := db.RecoveryStateSource().RecentBlocks(3)
+	require.NoError(t, err)
+	require.Len(t, refs, 3)
+	assert.Equal(t, blocks[4].Hash, refs[0].Hash)
+	assert.Equal(t, blocks[3].Hash, refs[1].Hash)
+	assert.Equal(t, blocks[2].Hash, refs[2].Hash)
+	// The linkage the continuity check relies on has to survive the round
+	// trip through the blob store.
+	assert.Equal(t, refs[1].Hash, refs[0].PrevHash)
+}
+
+func TestRecoveryStateSourceRecentBlocksRejectsNonPositiveLimit(t *testing.T) {
+	db := newTestDB(t)
+	linkedChain(t, db, 2)
+	refs, err := db.RecoveryStateSource().RecentBlocks(0)
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}
+
+func TestRecoveryStateSourceFindsOrphansAboveSlot(t *testing.T) {
+	db := newTestDB(t)
+	blocks := linkedChain(t, db, 5)
+
+	orphans, err := db.RecoveryStateSource().OrphanBlobs(blocks[2].Slot, 10)
+	require.NoError(t, err)
+	require.Len(t, orphans, 2)
+	assert.Equal(t, blocks[3].Slot, orphans[0].Slot)
+	assert.Equal(t, blocks[4].Slot, orphans[1].Slot)
+	assert.Equal(t, blocks[3].Hash, orphans[0].Hash)
+}
+
+func TestRecoveryStateSourceOrphanLimitIsHonoured(t *testing.T) {
+	db := newTestDB(t)
+	linkedChain(t, db, 5)
+	orphans, err := db.RecoveryStateSource().OrphanBlobs(0, 2)
+	require.NoError(t, err)
+	assert.Len(t, orphans, 2)
+}
+
+func TestRecoveryStateSourceCheckUtxosOnEmptyStore(t *testing.T) {
+	db := newTestDB(t)
+	result, err := db.RecoveryStateSource().CheckUtxos(10)
+	require.NoError(t, err)
+	assert.Zero(t, result.Checked)
+	assert.Empty(t, result.Unresolvable)
+}
+
+func TestTrimBlobAboveRemovesOnlyBlocksAboveTheBoundary(t *testing.T) {
+	db := newTestDB(t)
+	blocks := linkedChain(t, db, 5)
+
+	removed, err := db.TrimBlobAbove(blocks[2].Slot)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed)
+
+	refs, err := db.RecoveryStateSource().RecentBlocks(10)
+	require.NoError(t, err)
+	require.Len(t, refs, 3)
+	assert.Equal(t, blocks[2].Hash, refs[0].Hash)
+
+	orphans, err := db.RecoveryStateSource().OrphanBlobs(blocks[2].Slot, 10)
+	require.NoError(t, err)
+	assert.Empty(t, orphans)
+}
+
+func TestTrimBlobAboveSpansMultipleBatches(t *testing.T) {
+	db := newTestDB(t)
+	// More blocks than one removal pass handles, so the batching loop has to
+	// rescan and keep going rather than stopping after the first batch.
+	count := trimBatchSize + 25
+	linkedChain(t, db, count)
+
+	removed, err := db.TrimBlobAbove(0)
+	require.NoError(t, err)
+	assert.Equal(t, count, removed)
+
+	orphans, err := db.RecoveryStateSource().OrphanBlobs(0, count)
+	require.NoError(t, err)
+	assert.Empty(t, orphans)
+}
+
+func TestTrimBlobAboveIsANoOpWithNothingAbove(t *testing.T) {
+	db := newTestDB(t)
+	blocks := linkedChain(t, db, 3)
+	removed, err := db.TrimBlobAbove(blocks[2].Slot)
+	require.NoError(t, err)
+	assert.Zero(t, removed)
+}
+
+func TestResetCommitFenceMakesStoresAgree(t *testing.T) {
+	db := newTestDB(t)
+	// Put the stores out of step the way an interrupted commit would, with
+	// the blob store carrying the newer fence.
+	blobTxn := db.BlobTxn(true)
+	require.NoError(t, blobTxn.Do(func(txn *Txn) error {
+		return db.Blob().SetCommitTimestamp(999, txn.Blob())
+	}))
+	_, staleBlobTS, staleErr := db.RecoveryStateSource().CommitTimestamps()
+	require.NoError(t, staleErr)
+	require.Equal(t, int64(999), staleBlobTS)
+
+	require.NoError(t, db.ResetCommitFence())
+
+	metadataTS, blobTS, err := db.RecoveryStateSource().CommitTimestamps()
+	require.NoError(t, err)
+	assert.Equal(t, blobTS, metadataTS)
+	assert.Positive(t, metadataTS)
+}
+
+func TestCombinedCommitRecordsAndResolvesJournalIntent(t *testing.T) {
+	dir := t.TempDir()
+	db, err := newTestDatabase(t, &Config{
+		DataDir:  dir,
+		Recovery: &recovery.Config{Dir: dir, SyncJournal: true},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, db.Recovery())
+
+	block := models.Block{
+		ID:     1,
+		Slot:   10,
+		Hash:   bytes.Repeat([]byte{0x01}, 32),
+		Cbor:   []byte{0x80},
+		Number: 1,
+		Type:   1,
+	}
+	require.NoError(t, db.BlockCreate(block, nil))
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		return db.SetTip(ochainsync.Tip{
+			Point:       ocommon.NewPoint(block.Slot, block.Hash),
+			BlockNumber: block.Number,
+		}, txn)
+	}))
+
+	var begins, commits int
+	var intent recovery.Intent
+	require.NoError(
+		t,
+		db.Recovery().Replay(func(r recovery.Record) error {
+			switch r.Type {
+			case recovery.RecordTypeBegin:
+				begins++
+				intent = r.Intent
+			case recovery.RecordTypeCommit:
+				commits++
+			}
+			return nil
+		}),
+	)
+	assert.Positive(t, begins)
+	assert.Equal(t, begins, commits, "every intent should be resolved")
+	// The tip write describes the transaction, so recovery can name the
+	// point a crash would have interrupted.
+	assert.Equal(t, recovery.IntentBlockAdd, intent.Kind)
+	assert.Equal(t, block.Slot, intent.Slot)
+	assert.Equal(t, block.Hash, intent.Hash)
+}
+
+func TestExplicitRecoveryIntentWinsOverTheAutomaticOne(t *testing.T) {
+	dir := t.TempDir()
+	db, err := newTestDatabase(t, &Config{
+		DataDir:  dir,
+		Recovery: &recovery.Config{Dir: dir, SyncJournal: true},
+	})
+	require.NoError(t, err)
+
+	txn := db.Transaction(true)
+	txn.SetRecoveryIntent(recovery.Intent{
+		Kind: recovery.IntentRollback,
+		Slot: 99,
+	})
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		return db.SetTip(ochainsync.Tip{
+			Point: ocommon.NewPoint(500, bytes.Repeat([]byte{0x02}, 32)),
+		}, txn)
+	}))
+
+	var last recovery.Intent
+	require.NoError(
+		t,
+		db.Recovery().Replay(func(r recovery.Record) error {
+			if r.Type == recovery.RecordTypeBegin {
+				last = r.Intent
+			}
+			return nil
+		}),
+	)
+	assert.Equal(t, recovery.IntentRollback, last.Kind)
+	assert.Equal(t, uint64(99), last.Slot)
+}
+
+func TestDatabaseWithoutRecoveryHasNoManager(t *testing.T) {
+	db := newTestDB(t)
+	assert.Nil(t, db.Recovery())
+	// The commit path must stay happy with a nil manager, since that is the
+	// configuration every existing deployment starts from.
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		return db.SetTip(ochainsync.Tip{
+			Point: ocommon.NewPoint(1, bytes.Repeat([]byte{0x03}, 32)),
+		}, txn)
+	}))
+}
+
+func TestUtxoValidationModeFallsBackToStrictFlag(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		mode   types.UtxoValidationMode
+		want   types.UtxoValidationMode
+		strict bool
+	}{
+		{want: types.UtxoValidationIgnore},
+		{strict: true, want: types.UtxoValidationFail},
+		{
+			mode:   types.UtxoValidationWarn,
+			strict: true,
+			want:   types.UtxoValidationWarn,
+		},
+		{mode: types.UtxoValidationIgnore, want: types.UtxoValidationIgnore},
+	}
+	for _, tc := range cases {
+		cfg := &Config{
+			StrictUtxoValidation: tc.strict,
+			UtxoValidationMode:   tc.mode,
+		}
+		assert.Equal(t, tc.want, cfg.utxoValidationMode())
+	}
+}

--- a/database/tip.go
+++ b/database/tip.go
@@ -14,7 +14,10 @@
 
 package database
 
-import ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+import (
+	"github.com/blinklabs-io/dingo/database/recovery"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
 
 // GetTip returns the current tip as represented by the protocol
 func (d *Database) GetTip(txn *Txn) (ochainsync.Tip, error) {
@@ -25,9 +28,20 @@ func (d *Database) GetTip(txn *Txn) (ochainsync.Tip, error) {
 }
 
 // SetTip saves the current tip
+//
+// Moving the tip is what makes a combined transaction interesting to crash
+// recovery, so the target point is recorded as the transaction's intent here.
+// A transaction that already described itself — a rollback, say — keeps its own
+// description; see Txn.SetRecoveryIntent.
 func (d *Database) SetTip(tip ochainsync.Tip, txn *Txn) error {
 	if txn == nil {
 		return d.metadata.SetTip(tip, nil)
 	}
+	txn.SetRecoveryIntent(recovery.Intent{
+		Kind:        recovery.IntentBlockAdd,
+		Slot:        tip.Point.Slot,
+		Hash:        tip.Point.Hash,
+		BlockNumber: tip.BlockNumber,
+	})
 	return d.metadata.SetTip(tip, txn.Metadata())
 }

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -472,6 +472,18 @@ func (d *Database) ensureTransactionConsumedUtxos(
 	}
 
 	inFlight, _ := acc.(inFlightProducerLookup)
+	// Resolve the UTxO validation mode and, only for the modes that consult
+	// it, the Mithril trust boundary. The boundary costs a sync-state read
+	// and a parse, and it cannot change within a block, so reading it per
+	// unrecoverable input — or at all on the ignore path, where the answer
+	// is never used — is wasted work.
+	utxoMode := d.config.utxoValidationMode()
+	boundaryApplies := utxoMode == types.UtxoValidationFail ||
+		utxoMode == types.UtxoValidationWarn
+	var trustBoundarySlot uint64
+	if boundaryApplies {
+		trustBoundarySlot = d.mithrilTrustBoundarySlot(txn)
+	}
 	spenderTxHash := ledgerHashBytes(tx.Hash())
 	recoveredUtxos := make([]models.Utxo, 0, len(consumed))
 	seen := make(map[string]struct{}, len(consumed))
@@ -545,23 +557,38 @@ func (d *Database) ensureTransactionConsumedUtxos(
 			// unrecoverable UTxO there indicates real corruption or a bug
 			// rather than an expected gap. Below the boundary (or when none
 			// is recorded and we did not sync from genesis) the UTxO may
-			// legitimately predate the data we imported.
-			if d.config.StrictUtxoValidation &&
-				point.Slot > d.mithrilTrustBoundarySlot(txn) {
+			// legitimately predate the data we imported, so the configured
+			// mode only applies above it.
+			mode := utxoMode
+			pastBoundary := boundaryApplies &&
+				point.Slot > trustBoundarySlot
+			switch {
+			case mode == types.UtxoValidationFail && pastBoundary:
 				return fmt.Errorf(
 					"consumed utxo %s not found at slot %d and could not be recovered: %w",
 					input.String(),
 					point.Slot,
 					err,
 				)
+			case mode == types.UtxoValidationWarn && pastBoundary:
+				d.logger.Warn(
+					"applying block with an unrecoverable consumed utxo past the Mithril trust boundary",
+					"input",
+					input.String(),
+					"slot",
+					point.Slot,
+					"error",
+					err,
+				)
+			default:
+				d.logger.Debug(
+					"skipping unrecoverable transaction input utxo repair",
+					"input",
+					input.String(),
+					"error",
+					err,
+				)
 			}
-			d.logger.Debug(
-				"skipping unrecoverable transaction input utxo repair",
-				"input",
-				input.String(),
-				"error",
-				err,
-			)
 			continue
 		}
 		recoveredUtxos = append(recoveredUtxos, *recoveredUtxo)

--- a/database/txn.go
+++ b/database/txn.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database/recovery"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -54,12 +55,33 @@ type Txn struct {
 	db          *Database
 	blobTxn     types.Txn
 	metadataTxn types.Txn
+	intent      recovery.Intent
 	lock        sync.Mutex
 	finished    bool
 	committed   bool
 	readWrite   bool
+	intentSet   bool
 	afterCommit []func()
 	dispatching bool
+}
+
+// SetRecoveryIntent records what this transaction is about to do, for the
+// crash-recovery journal.
+//
+// Most callers never need this: a combined transaction that moves the tip
+// describes itself automatically. Call it explicitly when the automatic
+// description would be wrong — a rollback, for instance, sets a tip like a
+// block append does, and only the caller knows which it is. The first intent
+// set on a transaction wins, so an explicit call before the tip is written is
+// not overwritten by the automatic one.
+func (t *Txn) SetRecoveryIntent(intent recovery.Intent) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.intentSet {
+		return
+	}
+	t.intent = intent
+	t.intentSet = true
 }
 
 func NewTxn(db *Database, readWrite bool) *Txn {
@@ -289,12 +311,21 @@ func (t *Txn) Commit() error {
 	// Update the commit timestamp in both DBs if using both.
 	// Track timestamp for error reporting if partial commit occurs.
 	var commitTimestamp int64
+	// journalSeq identifies this commit in the crash-recovery journal, and is
+	// zero when the journal is not recording this transaction.
+	var journalSeq uint64
 	if t.blobTxn != nil && t.metadataTxn != nil {
 		commitTimestamp = time.Now().UnixMilli()
+		// Record the intent before either store is touched. Only a
+		// combined transaction needs this: it is the one that can leave
+		// the two stores disagreeing, and the record is what tells
+		// startup recovery which commit was in flight.
+		journalSeq = t.beginJournalEntryLocked(commitTimestamp)
 		if err := t.db.updateCommitTimestamp(t, commitTimestamp); err != nil {
 			// Rollback both transactions on timestamp update failure
 			_ = t.blobTxn.Rollback()
 			_ = t.metadataTxn.Rollback()
+			t.abortJournalEntry(journalSeq)
 			t.finished = true
 			t.lock.Unlock()
 			return fmt.Errorf("failed to update commit timestamp: %w", err)
@@ -308,6 +339,7 @@ func (t *Txn) Commit() error {
 			if t.metadataTxn != nil {
 				_ = t.metadataTxn.Rollback()
 			}
+			t.abortJournalEntry(journalSeq)
 			t.finished = true
 			t.lock.Unlock()
 			return fmt.Errorf("blob commit failed: %w", err)
@@ -381,9 +413,75 @@ func (t *Txn) Commit() error {
 	t.finished = true
 	t.committed = true
 	t.dispatching = true
+	// Both stores are through, so the journal entry is resolved. The
+	// entries left unresolved past this point are exactly the commits a
+	// crash interrupted mid-window, which is what recovery looks for.
+	t.resolveJournalEntry(journalSeq)
 	t.lock.Unlock()
 	t.dispatchAfterCommit()
 	return nil
+}
+
+// beginJournalEntryLocked records this transaction's intent in the
+// crash-recovery journal and returns its sequence, or zero when nothing was
+// recorded. The transaction lock must be held.
+//
+// A journal that cannot be written does not fail the commit. The journal makes
+// recovery precise; it is not what makes the commit correct. Wedging a node
+// because its recovery directory filled up would trade a diagnostic aid for an
+// outage, and the commit-timestamp fence still detects the divergence — it just
+// cannot name the operation that caused it. The failure is logged at error
+// level so it does not pass unnoticed.
+func (t *Txn) beginJournalEntryLocked(commitTimestamp int64) uint64 {
+	if t.db == nil {
+		return 0
+	}
+	mgr := t.db.Recovery()
+	if mgr == nil {
+		return 0
+	}
+	seq, err := mgr.Begin(t.intent, commitTimestamp)
+	if err != nil {
+		t.db.logger.Error(
+			"failed to record commit intent in the crash recovery journal; recovery will fall back to comparing stored state",
+			"error", err,
+			"commit_timestamp", commitTimestamp,
+		)
+		return 0
+	}
+	return seq
+}
+
+// resolveJournalEntry marks a journal entry as applied to both stores.
+func (t *Txn) resolveJournalEntry(seq uint64) {
+	if seq == 0 || t.db == nil {
+		return
+	}
+	if err := t.db.Recovery().Commit(seq); err != nil {
+		t.db.logger.Warn(
+			"failed to record commit completion in the crash recovery journal",
+			"error", err,
+			"journal_seq", seq,
+		)
+	}
+}
+
+// abortJournalEntry marks a journal entry as rolled back.
+//
+// It is called only where neither store committed. When the blob store did
+// commit and the metadata store did not, the entry is deliberately left
+// unresolved: that is a genuine partial commit, and recovery needs to see it.
+func (t *Txn) abortJournalEntry(seq uint64) {
+	if seq == 0 || t.db == nil {
+		return
+	}
+	if err := t.db.Recovery().Abort(seq); err != nil {
+		t.db.logger.Warn(
+			"failed to record commit abort in the crash recovery journal",
+			"error", err,
+			"journal_seq", seq,
+		)
+	}
 }
 
 func (t *Txn) Rollback() error {

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -356,6 +356,10 @@ type BlobIterator interface {
 type BlobIteratorOptions struct {
 	Prefix  []byte
 	Reverse bool
+	// Start is an optional inclusive key boundary for remote iterators.
+	// Limit bounds the number of keys fetched from a remote listing.
+	Start []byte
+	Limit int
 }
 
 // Txn is a simple transaction handle for commit/rollback only.

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -267,6 +268,53 @@ var ErrUtxoConflict = errors.New("UTxO already spent")
 
 // ErrUtxoNotFound is returned when a requested UTxO row does not exist.
 var ErrUtxoNotFound = errors.New("utxo not found")
+
+// UtxoValidationMode selects what a block application does when a consumed
+// UTxO past the Mithril trust boundary is neither present in the metadata
+// store nor reconstructable from the blob store.
+//
+// The right answer depends on how the node was brought up, which is why it is
+// configurable. A node synced from genesis, or bootstrapped from a Mithril
+// snapshot, should hold complete producer history past the trust boundary, so
+// a miss there is real corruption. A node that intersected the chain at an
+// arbitrary point legitimately has no history for the outputs those blocks
+// spend, and failing on them would make it unable to sync at all.
+type UtxoValidationMode string
+
+const (
+	// UtxoValidationFail rejects the block. Use it on a node whose history
+	// is supposed to be complete, where a missing input means the database
+	// is damaged and continuing would apply a value-inconsistent ledger.
+	UtxoValidationFail UtxoValidationMode = "fail"
+	// UtxoValidationWarn applies the block anyway but logs each miss at
+	// warning level. Use it to find out whether a node is hitting this at
+	// all, without taking it off the chain while you look.
+	UtxoValidationWarn UtxoValidationMode = "warn"
+	// UtxoValidationIgnore applies the block and logs each miss at debug
+	// level. This matches the behaviour that predates these modes.
+	UtxoValidationIgnore UtxoValidationMode = "ignore"
+)
+
+// ParseUtxoValidationMode maps a configured string to a UtxoValidationMode.
+// An empty value yields an empty mode, which callers resolve from their own
+// defaults.
+func ParseUtxoValidationMode(v string) (UtxoValidationMode, error) {
+	switch UtxoValidationMode(strings.ToLower(strings.TrimSpace(v))) {
+	case "":
+		return "", nil
+	case UtxoValidationFail:
+		return UtxoValidationFail, nil
+	case UtxoValidationWarn:
+		return UtxoValidationWarn, nil
+	case UtxoValidationIgnore:
+		return UtxoValidationIgnore, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid utxo validation mode %q: expected fail, warn or ignore",
+			v,
+		)
+	}
+}
 
 // UtxoKey identifies a UTxO row by its transaction id and output
 // index. Used as a parameter type for batch UTxO operations across

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -303,7 +303,72 @@ validateHistorical: true
 #
 # Can be overridden with the CARDANO_STRICT_UTXO_VALIDATION environment variable
 # CLI: --strict-utxo-validation
+#
+# Superseded by utxoValidationMode below, which is used instead whenever it is
+# set. This setting remains the fallback: true means "fail", false means
+# "ignore".
 strictUtxoValidation: true
+
+# What to do when a consumed UTxO past the recorded Mithril sync boundary
+# cannot be found or recovered:
+#   fail   - reject the block. Use on a node whose history is supposed to be
+#            complete, where a missing input means the database is damaged.
+#   warn   - apply the block, log each miss at warning level. Use to find out
+#            whether a node hits this at all without taking it off the chain.
+#   ignore - apply the block, log at debug level.
+# Below the boundary the mode does not apply: a node that intersected the chain
+# at an arbitrary point legitimately has no history for the outputs those
+# blocks spend. An empty value falls back to strictUtxoValidation. (default: "")
+#
+# Can be overridden with the CARDANO_UTXO_VALIDATION_MODE environment variable
+# CLI: --utxo-validation-mode
+utxoValidationMode: ""
+
+# Crash recovery: a journal of cross-store commit intent, periodic checkpoints,
+# and consistency checks at startup. Recording what a commit was about to do,
+# before it touches either store, is what lets startup name and repair the
+# operation an unclean shutdown interrupted rather than merely detecting that
+# the two stores disagree. Artifacts live under <databasePath>/recovery/ and
+# are safe to delete; doing so only costs the next recovery its precision.
+# (default: true)
+#
+# Can be overridden with the CARDANO_CRASH_RECOVERY environment variable
+# CLI: --crash-recovery
+crashRecovery: true
+
+# Make each journal intent durable before the commit that wrote it touches the
+# stores. This is what lets recovery name the interrupted operation instead of
+# only detecting divergence, and it costs one additional fsync per combined
+# commit, on top of the blob sync that commit already performs. That cost lands
+# on every block, so it is off by default. (default: false)
+#
+# Can be overridden with the CARDANO_CRASH_RECOVERY_SYNC_JOURNAL environment
+# variable
+# CLI: --crash-recovery-sync-journal
+crashRecoverySyncJournal: false
+
+# How often a running node records a recovery checkpoint. Checkpoints bound how
+# much journal recovery has to read and let older segments be removed, so a
+# coarse cadence costs nothing but a slightly longer journal. Empty uses the
+# built-in default of 5m.
+#
+# Can be overridden with the DINGO_CRASH_RECOVERY_CHECKPOINT_INTERVAL
+# environment variable
+# CLI: --crash-recovery-checkpoint-interval
+crashRecoveryCheckpointInterval: ""
+
+# How much work the startup consistency checks do:
+#   off  - skip them.
+#   fast - bounded windows near the tip, which is the part of the database a
+#          crash can actually have damaged. (default)
+#   full - roughly an order of magnitude wider. Meaningfully slower on a large
+#          database; intended for investigating a suspected corruption, not for
+#          every start.
+# Empty selects "fast".
+#
+# Can be overridden with the CARDANO_CONSISTENCY_CHECK_MODE environment variable
+# CLI: --consistency-check-mode
+consistencyCheckMode: ""
 
 # Peer targets - target number of peers in each state
 # These are goals the system works toward, not hard limits.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -418,7 +418,29 @@ type Config struct {
 	// recorded Mithril sync boundary. A non-genesis intersect without a
 	// Mithril snapshot should explicitly opt out when pre-intersect UTxOs are
 	// intentionally unavailable.
+	//
+	// UtxoValidationMode supersedes this when set; this remains the fallback
+	// for configurations that have not moved over.
 	StrictUtxoValidation bool `yaml:"strictUtxoValidation" split_words:"true"`
+	// UtxoValidationMode selects what happens when a consumed UTxO past the
+	// recorded Mithril sync boundary cannot be found or recovered: "fail",
+	// "warn" or "ignore". Empty falls back to StrictUtxoValidation.
+	UtxoValidationMode string `yaml:"utxoValidationMode" split_words:"true"`
+	// CrashRecovery enables the crash-recovery subsystem: a cross-store
+	// intent journal, periodic checkpoints, and startup consistency checks.
+	CrashRecovery bool `yaml:"crashRecovery" split_words:"true"`
+	// CrashRecoverySyncJournal makes each journal intent durable before the
+	// commit that wrote it touches the stores. Without it the journal is
+	// advisory: recovery can still compare the stores, it just cannot name
+	// the operation a crash interrupted. Costs one extra fsync per combined
+	// commit.
+	CrashRecoverySyncJournal bool `yaml:"crashRecoverySyncJournal" split_words:"true"`
+	// CrashRecoveryCheckpointInterval is how often a running node records a
+	// recovery checkpoint, as a duration string. Empty selects the default.
+	CrashRecoveryCheckpointInterval string `yaml:"crashRecoveryCheckpointInterval" envconfig:"DINGO_CRASH_RECOVERY_CHECKPOINT_INTERVAL"`
+	// ConsistencyCheckMode selects how much work the startup consistency
+	// checks do: "off", "fast" or "full". Empty selects "fast".
+	ConsistencyCheckMode string `yaml:"consistencyCheckMode" split_words:"true"`
 	// Tracing enables OpenTelemetry tracing. Disabled by default: with no
 	// collector listening, the OTLP exporter logs noisy connection errors.
 	// Spans are sent via OTLP HTTP; configure the destination with the
@@ -751,27 +773,39 @@ var globalConfig = &Config{
 	IntersectTip:         false,
 	ValidateHistorical:   true,
 	StrictUtxoValidation: true,
-	Tracing:              false,
-	TracingStdout:        false,
-	Network:              "preview",
-	NetworkMagic:         0,
-	MetricsPort:          12798,
-	DebugPort:            0,
-	PrivateBindAddr:      "127.0.0.1",
-	PrivatePort:          3002,
-	RelayPort:            3001,
-	BarkBaseUrl:          "",
-	BarkPort:             0,
-	CORSAllowedOrigins:   []string{"*"},
-	Topology:             "",
-	TlsCertFilePath:      "",
-	TlsKeyFilePath:       "",
-	StorageMode:          "core",
-	RunMode:              RunModeServe,
-	StartEra:             StartEraDefault,
-	ImmutableDbPath:      "",
-	ShutdownTimeout:      DefaultShutdownTimeout,
-	LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
+	UtxoValidationMode:   "",
+	// Crash recovery is on by default: an SPO's node should come back from
+	// an unclean shutdown knowing what was in flight, and the journal costs
+	// a small append per combined commit.
+	CrashRecovery: true,
+	// The journal fsync is off by default. It is what lets recovery name
+	// the interrupted operation rather than merely detect divergence, but
+	// it doubles the fsyncs a combined commit performs, and the cost lands
+	// on every block. Operators who want the stronger guarantee turn it on.
+	CrashRecoverySyncJournal:        false,
+	CrashRecoveryCheckpointInterval: "",
+	ConsistencyCheckMode:            "",
+	Tracing:                         false,
+	TracingStdout:                   false,
+	Network:                         "preview",
+	NetworkMagic:                    0,
+	MetricsPort:                     12798,
+	DebugPort:                       0,
+	PrivateBindAddr:                 "127.0.0.1",
+	PrivatePort:                     3002,
+	RelayPort:                       3001,
+	BarkBaseUrl:                     "",
+	BarkPort:                        0,
+	CORSAllowedOrigins:              []string{"*"},
+	Topology:                        "",
+	TlsCertFilePath:                 "",
+	TlsKeyFilePath:                  "",
+	StorageMode:                     "core",
+	RunMode:                         RunModeServe,
+	StartEra:                        StartEraDefault,
+	ImmutableDbPath:                 "",
+	ShutdownTimeout:                 DefaultShutdownTimeout,
+	LedgerCatchupTimeout:            DefaultLedgerCatchupTimeout,
 	// Defaults for database worker pool and API backfill tuning
 	DatabaseWorkers:   5,
 	DatabaseQueueSize: 50,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -63,6 +63,14 @@ var flagSpecs = []flagSpec{
 	boolFlag("IntersectTip", "intersect-tip", "start from current tip"),
 	boolFlag("ValidateHistorical", "validate-historical", "validate historical blocks"),
 	boolFlag("StrictUtxoValidation", "strict-utxo-validation", "error instead of skipping when a consumed UTxO past the Mithril sync boundary cannot be found or recovered"),
+	// The mode strings are parsed, and rejected if invalid, where they are
+	// applied. Validating them here as well would duplicate the accepted
+	// values into a package that has no other reason to know them.
+	stringFlag("UtxoValidationMode", "utxo-validation-mode", "", `what to do when a consumed UTxO past the Mithril sync boundary cannot be recovered: "fail", "warn" or "ignore"`),
+	boolFlag("CrashRecovery", "crash-recovery", "record a cross-store intent journal and checkpoints, and run consistency checks and recovery at startup"),
+	boolFlag("CrashRecoverySyncJournal", "crash-recovery-sync-journal", "fsync each crash-recovery journal intent before the commit that wrote it touches the stores"),
+	stringFlag("CrashRecoveryCheckpointInterval", "crash-recovery-checkpoint-interval", "", "how often to record a crash-recovery checkpoint"),
+	stringFlag("ConsistencyCheckMode", "consistency-check-mode", "", `how much work the startup consistency checks do: "off", "fast" or "full"`),
 	boolFlag("Tracing", "tracing", "enable OpenTelemetry tracing (configure destination with OTEL_EXPORTER_OTLP_* env vars)"),
 	boolFlag("TracingStdout", "tracing-stdout", "export traces to stdout instead of OTLP (requires --tracing; for debugging)"),
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -259,6 +259,20 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 			return fmt.Errorf("invalid shutdown timeout: %w", err)
 		}
 	}
+	// Zero leaves the crash-recovery package on its own default.
+	var crashRecoveryCheckpointInterval time.Duration
+	if cfg.CrashRecoveryCheckpointInterval != "" {
+		var err error
+		crashRecoveryCheckpointInterval, err = time.ParseDuration(
+			cfg.CrashRecoveryCheckpointInterval,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"invalid crash recovery checkpoint interval: %w",
+				err,
+			)
+		}
+	}
 	// Use the package-level default to avoid drift.
 	chainsyncStallTimeout := chainsync.DefaultStallTimeout
 	if cfg.Chainsync.StallTimeout != "" {
@@ -370,7 +384,16 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 				PermissionedCandidatePolicy: cfg.Midnight.PermissionedCandidatePolicy,
 			}),
 			dingo.WithValidateHistorical(cfg.ValidateHistorical),
+			// Passed through for configurations that still set the
+			// boolean; UtxoValidationMode takes precedence when set.
 			dingo.WithStrictUtxoValidation(cfg.StrictUtxoValidation),
+			dingo.WithUtxoValidationMode(cfg.UtxoValidationMode),
+			dingo.WithCrashRecovery(dingo.CrashRecoveryConfig{
+				Enabled:              cfg.CrashRecovery,
+				SyncJournal:          cfg.CrashRecoverySyncJournal,
+				CheckpointInterval:   crashRecoveryCheckpointInterval,
+				ConsistencyCheckMode: cfg.ConsistencyCheckMode,
+			}),
 			dingo.WithRunMode(string(cfg.RunMode)),
 			dingo.WithStartEra(string(cfg.StartEra)),
 			dingo.WithShutdownTimeout(shutdownTimeout),

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1167,6 +1167,19 @@ func (ls *LedgerState) loadMithrilTrustBoundary() {
 	ls.config.Logger.Info("loaded Mithril trust boundary", attrs...)
 }
 
+// RollbackToPoint rewinds applied ledger state to point.
+//
+// It is the exported entry point crash recovery repairs through, for the case
+// where the blob store turns out to be behind the state the metadata store
+// claims to have applied and the only consistent position left is the one the
+// blob store still holds.
+//
+// Do not call it to undo a fork; chain-driven rollbacks arrive through the
+// chainsync path, which also updates the chain's view of the tip.
+func (ls *LedgerState) RollbackToPoint(point ocommon.Point) error {
+	return ls.rollback(point)
+}
+
 func (ls *LedgerState) RecoverCommitTimestampConflict() error {
 	// Load current ledger tip
 	tmpTip, err := ls.db.GetTip(nil)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -37,6 +37,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/recovery"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
 	dingoversion "github.com/blinklabs-io/dingo/internal/version"
@@ -2262,7 +2263,14 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 				return fmt.Errorf("failed to get block nonce: %w", err)
 			}
 		}
-		// Write tip to DB
+		// Write tip to DB. This transaction is a rollback, not a normal
+		// block append; preserve that distinction for crash recovery.
+		txn.SetRecoveryIntent(recovery.Intent{
+			Kind:        recovery.IntentRollback,
+			Slot:        point.Slot,
+			Hash:        point.Hash,
+			BlockNumber: newTip.BlockNumber,
+		})
 		if err = ls.db.SetTip(newTip, txn); err != nil {
 			return fmt.Errorf("failed to set tip: %w", err)
 		}

--- a/node.go
+++ b/node.go
@@ -35,6 +35,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/historyexpiry"
 	"github.com/blinklabs-io/dingo/internal/node/ledgerpeers"
@@ -280,6 +281,16 @@ func (n *Node) Run(ctx context.Context) error {
 
 	// Load database
 	dbNeedsRecovery := false
+	utxoValidationMode, err := types.ParseUtxoValidationMode(
+		n.config.utxoValidationMode,
+	)
+	if err != nil {
+		return err
+	}
+	recoveryConfig, err := n.crashRecoveryConfig()
+	if err != nil {
+		return err
+	}
 	dbConfig := &database.Config{
 		DataDir:              n.config.dataDir,
 		Logger:               n.config.logger,
@@ -287,6 +298,8 @@ func (n *Node) Run(ctx context.Context) error {
 		StorageMode:          string(n.config.storageMode),
 		Network:              n.config.network,
 		StrictUtxoValidation: n.config.strictUtxoValidation,
+		UtxoValidationMode:   utxoValidationMode,
+		Recovery:             recoveryConfig,
 		CacheConfig: database.CborCacheConfig{
 			BlockLRUEntries: n.config.cacheBlockLRUEntries,
 			HotUtxoEntries:  n.config.cacheHotUtxoEntries,
@@ -626,6 +639,26 @@ func (n *Node) Run(ctx context.Context) error {
 		n.db.SetBlobStore(barkBlobStore)
 	}
 
+	// Run DB recovery if needed
+	if dbNeedsRecovery {
+		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {
+			return fmt.Errorf("failed to recover database: %w", err)
+		}
+	}
+	// Run the startup consistency checks and journal-driven recovery, and
+	// start periodic checkpointing. This runs after the timestamp-conflict
+	// path above so it sees, and reports on, whatever that left behind.
+	if err := n.runCrashRecovery(); err != nil {
+		return err
+	}
+
+	// The history-expiry pruner deletes blocks from both stores on its own
+	// goroutine, so it starts only once recovery is finished. Recovery
+	// enumerates blocks, computes a trim boundary from them, and can roll the
+	// ledger back; a pruner mutating the same stores underneath it would
+	// invalidate that boundary and can make the trim fail on a block that is
+	// already gone. Block application is not a concern here — the ledger has
+	// not started yet — but the pruner would be.
 	if n.config.historyExpiry.Enabled {
 		prunerFreq := n.config.historyExpiry.Frequency
 		if prunerFreq <= 0 {
@@ -647,12 +680,6 @@ func (n *Node) Run(ctx context.Context) error {
 		})
 	}
 
-	// Run DB recovery if needed
-	if dbNeedsRecovery {
-		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {
-			return fmt.Errorf("failed to recover database: %w", err)
-		}
-	}
 	if err := n.backfillRewardLiveStake(); err != nil {
 		return err
 	}

--- a/node_recovery.go
+++ b/node_recovery.go
@@ -15,6 +15,7 @@
 package dingo
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -98,7 +99,7 @@ func (r nodeRecoveryRepairer) RollbackTo(point recovery.Point) error {
 
 func (r nodeRecoveryRepairer) RewindPrimaryChainTo(point recovery.Point) error {
 	if r.chain == nil {
-		return fmt.Errorf("primary chain manager is unavailable")
+		return errors.New("primary chain manager is unavailable")
 	}
 	return r.chain.RewindPrimaryChainToPoint(ocommon.Point{
 		Slot: point.Slot,

--- a/node_recovery.go
+++ b/node_recovery.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/recovery"
+	"github.com/blinklabs-io/dingo/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// crashRecoveryConfig translates the node's crash-recovery settings into the
+// database's. It returns nil when the subsystem is disabled, which is what
+// switches it off end to end.
+func (n *Node) crashRecoveryConfig() (*recovery.Config, error) {
+	if !n.config.crashRecovery.Enabled {
+		return nil, nil
+	}
+	checkMode, err := recovery.ParseCheckMode(
+		n.config.crashRecovery.ConsistencyCheckMode,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &recovery.Config{
+		Logger:             n.config.logger,
+		CheckMode:          checkMode,
+		CheckpointInterval: n.config.crashRecovery.CheckpointInterval,
+		SyncJournal:        n.config.crashRecovery.SyncJournal,
+	}, nil
+}
+
+// nodeRecoverySource adds the chain manager's tip to the database's view of
+// stored state.
+//
+// The database cannot report it — the chain manager sits above the database and
+// the import direction only goes one way — but recovery needs it: blocks
+// between the applied tip and the chain tip are legitimately on-chain and
+// merely not applied yet, and must not be mistaken for the residue of an
+// interrupted commit.
+type nodeRecoverySource struct {
+	recovery.StateSource
+	chain *chain.Chain
+}
+
+// ChainTip implements recovery.ChainTipSource.
+//
+// No primary chain is reported as a zero tip rather than an error. An error
+// here would propagate out of recovery and abort startup, which is exactly what
+// recovery is not supposed to do; a zero tip instead leaves the trim boundary
+// at the metadata tip, and recovery's own guard against trimming with no known
+// tip still protects the blob store.
+func (s nodeRecoverySource) ChainTip() (recovery.Point, uint64, error) {
+	if s.chain == nil {
+		return recovery.Point{}, 0, nil
+	}
+	tip := s.chain.Tip()
+	return recovery.Point{
+		Slot: tip.Point.Slot,
+		Hash: tip.Point.Hash,
+	}, tip.BlockNumber, nil
+}
+
+// nodeRecoveryRepairer carries out the repairs recovery decides on.
+type nodeRecoveryRepairer struct {
+	db     *database.Database
+	ledger *ledger.LedgerState
+}
+
+// TrimBlobAbove removes blocks the blob store holds above slot.
+func (r nodeRecoveryRepairer) TrimBlobAbove(slot uint64) (int, error) {
+	return r.db.TrimBlobAbove(slot)
+}
+
+// RollbackTo rewinds applied ledger state to point.
+func (r nodeRecoveryRepairer) RollbackTo(point recovery.Point) error {
+	return r.ledger.RollbackToPoint(ocommon.Point{
+		Slot: point.Slot,
+		Hash: point.Hash,
+	})
+}
+
+// ResetCommitFence brings both stores back onto a common commit timestamp.
+func (r nodeRecoveryRepairer) ResetCommitFence() error {
+	return r.db.ResetCommitFence()
+}
+
+// runCrashRecovery runs the startup consistency checks and repairs whatever
+// divergence they and the intent journal identify, then starts periodic
+// checkpointing.
+//
+// It runs after the chain manager and ledger are up, because both the diagnosis
+// and the repairs need them: the chain tip bounds what may be trimmed, and a
+// rollback is ledger work.
+func (n *Node) runCrashRecovery() error {
+	mgr := n.db.Recovery()
+	if mgr == nil {
+		return nil
+	}
+	source := nodeRecoverySource{
+		StateSource: n.db.RecoveryStateSource(),
+		chain:       n.chainManager.PrimaryChain(),
+	}
+	result, err := mgr.Recover(source, nodeRecoveryRepairer{
+		db:     n.db,
+		ledger: n.ledgerState,
+	})
+	if err != nil {
+		return fmt.Errorf("crash recovery failed: %w", err)
+	}
+	switch result.Outcome {
+	case recovery.OutcomeClean:
+		n.config.logger.Info(
+			"crash recovery found no work to do",
+			"component", "database",
+			"consistency_checks", result.Report.Worst().String(),
+		)
+	case recovery.OutcomeRepaired:
+		n.config.logger.Warn(
+			"crash recovery repaired an interrupted commit",
+			"component", "database",
+			"actions", result.Actions,
+			"unresolved_intents", len(result.Pending),
+		)
+	case recovery.OutcomeUnrepaired:
+		// Startup continues: the existing tip reconciliation runs after
+		// this and fixes several of the shapes that land here, and a
+		// node that refuses to start is worse for an operator than one
+		// that starts and says loudly what it found.
+		n.config.logger.Error(
+			"crash recovery found problems it could not repair",
+			"component", "database",
+			"actions", result.Actions,
+			"unresolved_intents", len(result.Pending),
+		)
+	}
+	mgr.Start(source)
+	return nil
+}

--- a/node_recovery.go
+++ b/node_recovery.go
@@ -80,6 +80,7 @@ func (s nodeRecoverySource) ChainTip() (recovery.Point, uint64, error) {
 type nodeRecoveryRepairer struct {
 	db     *database.Database
 	ledger *ledger.LedgerState
+	chain  *chain.ChainManager
 }
 
 // TrimBlobAbove removes blocks the blob store holds above slot.
@@ -90,6 +91,16 @@ func (r nodeRecoveryRepairer) TrimBlobAbove(slot uint64) (int, error) {
 // RollbackTo rewinds applied ledger state to point.
 func (r nodeRecoveryRepairer) RollbackTo(point recovery.Point) error {
 	return r.ledger.RollbackToPoint(ocommon.Point{
+		Slot: point.Slot,
+		Hash: point.Hash,
+	})
+}
+
+func (r nodeRecoveryRepairer) RewindPrimaryChainTo(point recovery.Point) error {
+	if r.chain == nil {
+		return fmt.Errorf("primary chain manager is unavailable")
+	}
+	return r.chain.RewindPrimaryChainToPoint(ocommon.Point{
 		Slot: point.Slot,
 		Hash: point.Hash,
 	})
@@ -119,6 +130,7 @@ func (n *Node) runCrashRecovery() error {
 	result, err := mgr.Recover(source, nodeRecoveryRepairer{
 		db:     n.db,
 		ledger: n.ledgerState,
+		chain:  n.chainManager,
 	})
 	if err != nil {
 		return fmt.Errorf("crash recovery failed: %w", err)


### PR DESCRIPTION
Refs #1898.

Adds `database/recovery`: a cross-store intent journal, merkle-rooted checkpoints, startup consistency checks, and automatic repair. Both stores are already crash safe individually; what was missing was any record of which combined commit was in flight when a process died, or what it intended.

- Startup consistency checks: commit timestamps, metadata/blob tip agreement, chain vs ledger tip, block continuity, UTxO integrity, orphaned data. `consistencyCheckMode` selects off/fast/full.
- Intent journal: segmented, CRC-32C framed, `begin` before either store is touched and `commit` once both are through. `crashRecoverySyncJournal` makes intents durable at one extra fsync per combined commit.
- Checkpoints: merkle-rooted state summaries, atomically installed, three generations retained, journal segments they cover are truncated.
- Automatic recovery: replays the journal above the newest verified checkpoint, then trims blob blocks above the chain tip or rolls the ledger back onto the blob tip, and restamps both stores.
- `utxoValidationMode` (fail/warn/ignore) replaces the `strictUtxoValidation` boolean, which stays as the fallback.

Phase 5 (blockfetch rollback) is already on main via the `next.Rollback` check in `blockfetchServerSendBatch`.

Off unless `crashRecovery` is set; the manager is nil and every call site is a nil-safe no-op. Artifacts live under `<dataDir>/recovery/` and are safe to delete.

DATABASE.md and ARCHITECTURE.md updated. `make test`, `-race` on the touched packages, conformance, golangci-lint, nilaway, modernize, and import-boundaries all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds crash recovery and state consistency via `database/recovery`: intent journal, Merkle-rooted checkpoints, startup checks (with safe logging for unknown severities), and automatic repair. Also adds `utxoValidationMode` (fail/warn/ignore) with config/CLI wiring and node integration (Linear #1898), and fixes blob tombstone handling and key listing used by the checks.

- **New Features**
  - Intent journal: segmented, CRC-32C framed WAL with `begin`/`commit`; optional fsync via `crashRecoverySyncJournal`.
  - Checkpoints: Merkle-rooted snapshots; atomic install; keep 3; truncate covered WAL segments.
  - Startup checks: commit timestamps, metadata/blob tip agreement, chain vs ledger tip, block continuity, UTxO integrity, orphaned data; modes `off`/`fast`/`full`; logs unknown severities safely.
  - Automatic repair: replay intents above newest verified checkpoint; trim blob blocks above chain tip or roll ledger to blob tip; restamp both stores.
  - Integration: automatic intent on tip moves; explicit `Txn.SetRecoveryIntent` for rollbacks; `ledger.RollbackToPoint` exported.
  - Performance: read the Mithril trust boundary once per block only when `utxoValidationMode` requires it.

- **Migration**
  - Off by default; enable with `crashRecovery` (CLI: `--crash-recovery`). Optional journal sync, checkpoint interval, and recovery directory settings (CLI: `--crash-recovery-sync-journal`, `--crash-recovery-checkpoint-interval`, `--crash-recovery-dir`).
  - Replace `strictUtxoValidation` with `utxoValidationMode`: `fail`, `warn`, or `ignore` (CLI: `--utxo-validation-mode`). Empty falls back to `strictUtxoValidation` (true = fail, false = ignore).
  - Artifacts live in `<dataDir>/recovery/` and are safe to delete. When disabled, all calls are nil-safe no-ops.

<sup>Written for commit 9831caf667de1cf378435c87128f1a41d97a3dc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crash recovery for interrupted database commits, including startup repair and periodic checkpoints.
  * Added configurable startup consistency checks with disabled, fast, and full modes.
  * Added UTxO validation modes: fail, warn, or ignore.
  * Added configuration and command-line options for recovery, journal synchronization, checkpoint intervals, and validation behavior.
* **Documentation**
  * Documented crash-recovery architecture, database recovery artifacts, configuration, and repair behavior.
* **Bug Fixes**
  * Improved handling of partial commits, missing historical UTxOs, corrupted recovery data, and divergent stores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->