### PR TITLE
fix(leios): set MessageType on forged-EB MsgBlockOffer so it diffuses

### DIFF
--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -36,6 +36,7 @@ import (
 // be announced to peers via LeiosNotify.
 type leiosForgedEBEntry struct {
 	point *ocommon.Point
+	size  uint64
 	vote  *lcommon.LeiosPrototypeVote
 }
 
@@ -320,7 +321,7 @@ func (o *Ouroboros) BroadcastEndorserBlock(
 	if err := o.storeLeiosEndorserBlock(point, data, txsRaw); err != nil {
 		return fmt.Errorf("store forged endorser block: %w", err)
 	}
-	o.leiosEBLog.append(leiosForgedEBEntry{point: &point})
+	o.leiosEBLog.append(leiosForgedEBEntry{point: &point, size: uint64(len(data))})
 	return nil
 }
 
@@ -1077,6 +1078,26 @@ func leiosCollectTxs(result []cbor.RawMessage) []cbor.RawMessage {
 	return out
 }
 
+// leiosForgedEBOffer builds the LeiosNotify offer for a queued forged-EB log
+// entry: a votes-offer for a locally emitted vote, or a block-offer for a
+// forged endorser block. Both go through the gouroboros constructors so the
+// message MessageType (and, for a block offer, the EB size) are set. A bare
+// struct literal would leave MessageType at its zero value, which the leios-
+// notify state machine rejects when the server has agency in the Busy state,
+// so the EB would never be offered, fetched, voted on, or certified.
+func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
+	switch {
+	case entry.vote != nil:
+		return oleiosnotify.NewMsgVotesOfferPrototype(
+			[]lcommon.LeiosPrototypeVote{*entry.vote},
+		)
+	case entry.point != nil:
+		return oleiosnotify.NewMsgBlockOffer(*entry.point, entry.size)
+	default:
+		return nil
+	}
+}
+
 func (o *Ouroboros) leiosnotifyServerRequestNext(
 	ctx oleiosnotify.CallbackContext,
 ) (protocol.Message, error) {
@@ -1098,13 +1119,8 @@ func (o *Ouroboros) leiosnotifyServerRequestNext(
 	for {
 		entry, wakeCh := o.leiosEBLog.next(connKey)
 		if entry != nil {
-			if entry.vote != nil {
-				return oleiosnotify.NewMsgVotesOfferPrototype(
-					[]lcommon.LeiosPrototypeVote{*entry.vote},
-				), nil
-			}
-			if entry.point != nil {
-				return &oleiosnotify.MsgBlockOffer{Point: *entry.point}, nil
+			if msg := leiosForgedEBOffer(entry); msg != nil {
+				return msg, nil
 			}
 		}
 		select {

--- a/ouroboros/leiosnotify_offer_test.go
+++ b/ouroboros/leiosnotify_offer_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	oleiosnotify "github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/stretchr/testify/require"
+)
+
+// A forged endorser block must be offered as a MsgBlockOffer whose MessageType
+// is set. A bare struct literal leaves MessageType at 0, which the gouroboros
+// leios-notify state machine rejects in the Busy state ("not allowed in current
+// protocol state Busy"), so the EB is never offered, fetched, voted on, or
+// certified.
+func TestLeiosForgedEBOfferSetsBlockOfferType(t *testing.T) {
+	point := ocommon.Point{Slot: 42, Hash: []byte("eb-hash")}
+	entry := &leiosForgedEBEntry{point: &point, size: 1234}
+
+	msg := leiosForgedEBOffer(entry)
+	require.NotNil(t, msg)
+	require.Equal(t, uint8(oleiosnotify.MessageTypeBlockOffer), msg.Type())
+
+	offer, ok := msg.(*oleiosnotify.MsgBlockOffer)
+	require.True(t, ok)
+	require.Equal(t, point, offer.Point)
+	require.Equal(t, uint64(1234), offer.Size)
+}
+
+// A locally emitted vote must be offered as a MsgVotesOffer with its type set.
+func TestLeiosForgedEBOfferSetsVotesOfferType(t *testing.T) {
+	vote := lcommon.LeiosPrototypeVote{
+		AnnouncingRbHash: lcommon.NewBlake2b256([]byte("announcing-rb")),
+		VoterId:          7,
+		VoteSignature:    make([]byte, lcommon.LeiosBlsSignatureSize),
+	}
+	entry := &leiosForgedEBEntry{vote: &vote}
+
+	msg := leiosForgedEBOffer(entry)
+	require.NotNil(t, msg)
+	require.Equal(t, uint8(oleiosnotify.MessageTypeVotesOffer), msg.Type())
+}
+
+// An empty entry yields no offer.
+func TestLeiosForgedEBOfferEmptyEntryNil(t *testing.T) {
+	require.Nil(t, leiosForgedEBOffer(&leiosForgedEBEntry{}))
+}


### PR DESCRIPTION
## Summary

Locally-forged endorser blocks are never served to peers, so they never certify. The leios-notify server builds the block offer with a bare struct literal, leaving the message's `MessageType` at `0`; gouroboros rejects the send in the `Busy` state and drops the connection.

## The bug

`ouroboros/leiosnotify.go`, server `RequestNext` callback:

```go
return &oleiosnotify.MsgBlockOffer{Point: *entry.point}, nil
```

`MsgBlockOffer` embeds `protocol.MessageBase`, and `Type()` returns its `MessageType` field. The literal leaves that at `0` (and `Size` at 0). gouroboros validates every send in `protocol.nextState()` by matching `transition.MsgType == msg.Type()`; `StateBusy` allows only message types 1–4, so a type-0 message yields exactly:

```
message *leiosnotify.MsgBlockOffer not allowed in current protocol state Busy
```

The send fails, the peer connection is torn down, and the EB is never offered → fetched → voted → certified. The adjacent vote path already used `NewMsgVotesOfferPrototype` (type set), which is why vote diffusion worked but EB serving did not.

## The fix

Route both offer paths through the gouroboros constructors via a small `leiosForgedEBOffer` helper, and carry the EB size on the forged-EB log entry so `NewMsgBlockOffer(point, size)` advertises it. Adds a regression test asserting the forged-EB offer reports `MessageTypeBlockOffer` with a non-zero size.

## Verification (live Musashi)

Built from this branch, run as a registered BP under transaction load:

- **before:** continuous `MsgBlockOffer not allowed … Busy` at every forge; EB stuck at pipeline stage `produce`; pool `CERTS = 0`.
- **after:** zero `MsgBlockOffer` errors; EB reaches stake quorum; **pool leios certs 0 → 1** — a 578-tx EB certified ~3 slots later (on-chain `certified_eb_size` matched the EB).

`go test ./ouroboros/ -run TestLeiosForgedEBOffer` — 3 new tests pass.

Addresses #2630.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes forged endorser block diffusion by constructing `MsgBlockOffer` via `gouroboros` so `MessageType` and size are set. Prevents Busy-state rejection and lets locally forged EBs be offered, fetched, and certified.

- **Bug Fixes**
  - Route forged-EB and vote offers through `gouroboros` constructors via a `leiosForgedEBOffer` helper (`oleiosnotify.NewMsgBlockOffer`, `NewMsgVotesOfferPrototype`).
  - Store EB size on the log entry and pass it to `NewMsgBlockOffer(point, size)` so peers see a non-zero size.
  - Add tests to assert block offers use `MessageTypeBlockOffer` with non-zero size and vote offers use the correct type. Addresses #2630.

<sup>Written for commit 9a4bbfc0c67f7113a22442771935809f8dbd8e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forged endorser-block notifications now preserve the serialized block size.
  * Notifications consistently produce valid typed block or vote offers.
  * Empty forged entries are handled safely without creating an offer.

* **Tests**
  * Added coverage for block offers, vote offers, preserved metadata, and empty entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->