### PR TITLE
test(leiosnotify): assert vote offer payload

### DIFF
--- a/ouroboros/leiosnotify_offer_test.go
+++ b/ouroboros/leiosnotify_offer_test.go
@@ -54,6 +54,10 @@ func TestLeiosForgedEBOfferSetsVotesOfferType(t *testing.T) {
 	msg := leiosForgedEBOffer(entry)
 	require.NotNil(t, msg)
 	require.Equal(t, uint8(oleiosnotify.MessageTypeVotesOffer), msg.Type())
+
+	offer, ok := msg.(*oleiosnotify.MsgVotesOffer)
+	require.True(t, ok)
+	require.Equal(t, []lcommon.LeiosPrototypeVote{vote}, offer.PrototypeVotes)
 }
 
 // An empty entry yields no offer.


### PR DESCRIPTION
Assert that forged Leios vote offers preserve the expected prototype vote payload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add assertions in `leiosnotify_offer_test.go` to verify `leiosForgedEBOffer` returns an `oleiosnotify.MsgVotesOffer` with the expected `PrototypeVotes` payload. This helps catch regressions where the forged vote offer payload is missing or incorrect.

<sup>Written for commit a3a4b7cb25b54ffd3cf8f61a0e9e4be87f6e3477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded vote-offer test coverage to verify that forged offers include the expected prototype vote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->