### PR TITLE
docs(examples): update Kubernetes image pins for 0.69.0

### DIFF
--- a/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
+++ b/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-gov-lens/k8s/dingo-values.yaml
+++ b/examples/dingo-gov-lens/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-sundae-preview/k8s/dingo-values.yaml
+++ b/examples/dingo-sundae-preview/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION
## Summary

Update the three example Kubernetes values files to pin the Dingo image to
`0.69.0`:

- Blockfrost Explorer
- Dingo Gov Lens
- Sundae Preview

Release notes are intentionally excluded; Doc Holiday owns them.

## Validation

- `git diff --check origin/main...HEAD`

This PR contains one clean commit and is for human review and merge.