### PR TITLE
test(ledger): clean up reward calculation transaction

### DIFF
--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -3523,6 +3523,7 @@ func TestPrecomputedStakeRewardsRejectEarlyPreBabbageOutputs(t *testing.T) {
 		seedOutputs(t, db)
 
 		txn := db.Transaction(false)
+		defer func() { _ = txn.Rollback() }()
 		app, ok, err := ls.precomputedStakeRewardApplication(
 			txn,
 			newEpoch,


### PR DESCRIPTION
## Summary

Roll back the read-only transaction created by
`TestPrecomputedStakeRewardsRejectEarlyPreBabbageOutputs` during test cleanup.
This prevents the transaction from lingering after the assertion path.

## Validation

- `go test -run '^TestPrecomputedStakeRewardsRejectEarlyPreBabbageOutputs$' ./ledger`

This PR contains one clean commit and is for human review and merge. Release
notes and unrelated documentation are excluded.