### PR TITLE
docs(examples): update Kubernetes image pins for 0.69.0

### DIFF
--- a/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
+++ b/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-gov-lens/k8s/dingo-values.yaml
+++ b/examples/dingo-gov-lens/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-sundae-preview/k8s/dingo-values.yaml
+++ b/examples/dingo-sundae-preview/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION
## Summary

Update the three example Kubernetes values files to pin the Dingo image to
`0.69.0`:

- Blockfrost Explorer
- Dingo Gov Lens
- Sundae Preview

Release notes are intentionally excluded; Doc Holiday owns them.

## Validation

- `git diff --check origin/main...HEAD`

This PR contains one clean commit and is for human review and merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `ghcr.io/blinklabs-io/dingo` image to 0.69.0 in the Kubernetes example values for Blockfrost Explorer, Dingo Gov Lens, and Sundae Preview to align with the 0.69.0 release.

<sup>Written for commit 902cbf4f1de6624ad7c3c5324c531823c52488ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

