### PR TITLE
docs(examples): align 0.69.0 image pins and README text

### DIFF
--- a/examples/dingo-blockfrost-explorer/README.md
+++ b/examples/dingo-blockfrost-explorer/README.md
@@ -64,7 +64,7 @@ Dingo from this checkout, so it has both.
 
 ### Kubernetes
 
-The example Helm values use `ghcr.io/blinklabs-io/dingo:0.68.0`, enable all
+The example Helm values use `ghcr.io/blinklabs-io/dingo:0.69.0`, enable all
 API ports, and keep the chart-created Dingo Service internal to the cluster.
 Apply the separate API Service when the frontend proxy needs a Kubernetes
 LoadBalancer:

--- a/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
+++ b/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-gov-lens/k8s/dingo-values.yaml
+++ b/examples/dingo-gov-lens/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-sundae-preview/README.md
+++ b/examples/dingo-sundae-preview/README.md
@@ -26,7 +26,7 @@ cd examples/dingo-sundae-preview
 ./scripts/port-forward-dingo.sh
 ```
 
-The example values pin Dingo `0.68.0`. The chart uses a `LoadBalancer` service
+The example values pin Dingo `0.69.0`. The chart uses a `LoadBalancer` service
 and enables only `DINGO_PLUGINS_API_UTXORPC_CONFIG_PORT`.
 If the load balancer is not reachable from the dev host, keep the port-forward
 open while running the frontend.

--- a/examples/dingo-sundae-preview/k8s/dingo-values.yaml
+++ b/examples/dingo-sundae-preview/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.68.0"
+  tag: "0.69.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION
## Summary

Align the three example Kubernetes image pins and their explicit pinned-image
README text with Dingo `0.69.0`:

- Blockfrost Explorer
- Dingo Gov Lens
- Sundae Preview

Minimum-version compatibility statements remain unchanged. Release notes are
intentionally excluded; Doc Holiday owns them.

## Validation

- `git diff --check origin/main...HEAD`

This PR contains one clean, DCO-signed commit and is for human review and
merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Kubernetes example image pins and README references to `ghcr.io/blinklabs-io/dingo:0.69.0` across Blockfrost Explorer, Dingo Gov Lens, and Sundae Preview.

Minimum-version notes remain unchanged.

<sup>Written for commit 82310afe439837584b3838b9f1b44fa7f5b66665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

