### PR TITLE
fix(ledger): defer stale genesis overlay checks during historical sync

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -287,6 +287,7 @@ sequenceDiagram
     OB->>EB: publish BlockfetchEvent(block)
     EB->>LS: handleEventBlockfetchBlock()
     LS->>LS: decode CBOR, match to queued header
+    LS->>LS: defer future-slot stateful overlay checks until ledger apply
 
     Note over Peer,DB: Stage 3 — Block Processing
     OB->>EB: publish BlockfetchEvent(batchDone)

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -360,7 +360,10 @@ func (ls *LedgerState) verifyBlockHeaderState(
 	epochId uint64,
 	allowStateDefer bool,
 ) error {
-	if handled, err := ls.verifyGenesisDelegateHeader(block); handled || err != nil {
+	if handled, err := ls.verifyGenesisDelegateHeader(
+		block,
+		allowStateDefer,
+	); handled || err != nil {
 		return err
 	}
 
@@ -400,9 +403,9 @@ func (ls *LedgerState) verifyBlockHeaderState(
 
 func (ls *LedgerState) verifyGenesisDelegateHeader(
 	block ledger.Block,
+	allowStateDefer bool,
 ) (bool, error) {
-	if block.Era().Id == byron.EraIdByron ||
-		!ls.genesisDelegationActiveForSlot(block.SlotNumber()) {
+	if block.Era().Id == byron.EraIdByron {
 		return false, nil
 	}
 	if ls.config.CardanoNodeConfig == nil {
@@ -410,6 +413,23 @@ func (ls *LedgerState) verifyGenesisDelegateHeader(
 	}
 	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if shelleyGenesis == nil || len(shelleyGenesis.GenDelegs) == 0 {
+		return false, nil
+	}
+	// The overlay decision uses protocol parameters for the block's epoch.
+	// Blockfetch can verify a header ahead of ledger apply, while the
+	// in-memory parameters still describe the previous epoch. Defer any
+	// state-dependent overlay decision until the rollover has installed the
+	// target epoch's parameters. This must precede genesisDelegationActiveForSlot
+	// and genesisOverlayDelegationForSlot because stale parameters can otherwise
+	// classify a future slot as having no overlay and return early.
+	if allowStateDefer && ls.ledgerTipBehindSlot(block.SlotNumber()) {
+		return true, fmt.Errorf(
+			"%w: genesis overlay state for slot %d is not yet authoritative",
+			errHeaderVerificationDeferred,
+			block.SlotNumber(),
+		)
+	}
+	if !ls.genesisDelegationActiveForSlot(block.SlotNumber()) {
 		return false, nil
 	}
 

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1242,6 +1242,13 @@ func TestVerifyBlockHeaderState_GenesisDelegateInactiveOverlaySlotFails(
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reserved for the genesis overlay schedule")
 	assert.Contains(t, err.Error(), "not active")
+
+	// Header verification can run ahead of ledger apply. In that path the
+	// current epoch's protocol parameters may still be in memory, so defer a
+	// state-dependent overlay rejection until the epoch rollover is committed.
+	err = ls.verifyBlockHeaderState(tb.block, 5, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errHeaderVerificationDeferred)
 }
 
 func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotFallsThrough(
@@ -1267,6 +1274,13 @@ func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotFallsThrough(
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, models.ErrPoolNotFound)
+
+	// A stale decentralized parameter set can classify this future slot as
+	// genesisOverlayNone. Header verification must defer before that
+	// classification can bypass the apply-time state recheck.
+	err = ls.verifyBlockHeaderState(tb.block, 5, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errHeaderVerificationDeferred)
 }
 
 func TestVerifyBlockHeaderState_GenesisDelegateUsesActiveDelegation(


### PR DESCRIPTION
Fixes #3061

Historical validation can inspect a blockfetch header ahead of ledger apply, while the in-memory protocol parameters still describe the previous epoch. At a decentralization boundary this caused valid canonical blocks to be rejected as inactive genesis-overlay slots.

Defer state-dependent genesis-overlay decisions for future slots until ledger apply, when the target epoch rollover has installed authoritative protocol parameters. Keep immediate rejection when validation is performed at the applied tip, and add regression coverage.

Tests:
- go test ./ledger/...
- go test ./...
- go test -race ./ledger -run TestVerifyBlockHeaderState_GenesisDelegate -count=1

Documentation: ARCHITECTURE.md updated; DATABASE.md checked and unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers state-dependent genesis overlay validation for headers ahead of ledger apply to avoid rejecting valid blocks at epoch boundaries during historical sync. Keeps strict rejection at the applied tip and adds regression coverage.

- **Bug Fixes**
  - Defer future-slot overlay checks when the ledger tip is behind by propagating `allowStateDefer` and returning `errHeaderVerificationDeferred`.
  - Perform the deferral before overlay classification to prevent stale epoch parameters from mislabeling future slots as non-overlay.
  - Add tests covering deferred paths for both inactive and non-overlay cases, and update `ARCHITECTURE.md` to document the new step.

<sup>Written for commit a6b6a32e8839df0b2696a910209d4d69df928947. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block header verification when the ledger is behind the block’s slot.
  * Defers overlay-related validation until authoritative ledger state is available, preventing premature rejections.

* **Documentation**
  * Clarified when stateful overlay checks are performed during ledger processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->