### PR TITLE
ci: reduce actions usage

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -29,7 +29,6 @@ on:
 
 concurrency:
   group: antithesis
-  queue: max
   # Once submitted, an Antithesis test continues running outside GitHub.
   # Keep its polling workflow alive so the result is not lost and the next
   # test waits for the active run to finish.

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -11,6 +11,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     strategy:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -6,6 +6,10 @@ name: Conventional Commits
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Conventional Commits

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,15 +1,14 @@
 name: go-test
 
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - main
   pull_request:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Linux job with Postgres, MySQL and MinIO (fake s3) services for integration tests
@@ -98,47 +97,6 @@ jobs:
       - name: go-build-minimal
         run: go build ./cmd/dingo
       - name: go-test
-        # Explicit -timeout because this job is race-instrumented and Go's
-        # default is 10m per package binary. The ledger package used to spend
-        # much of that re-migrating an in-memory schema once per test; it now
-        # replays a recorded schema instead, which bought back most of the
-        # margin (dingo #3032). The explicit timeout stays as a guard so the
-        # default cannot become the binding constraint again.
-        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race -timeout 20m ./...
-
-  # macOS and Windows jobs without Postgres service
-  go-test-other:
-    name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
-    strategy:
-      matrix:
-        go-version: [1.26.x]
-        platform: [macos-latest, windows-latest]
-        include:
-          - platform: macos-latest
-            cache_path: ~/Library/Caches/go-build
-          - platform: windows-latest
-            cache_path: ~\AppData\Local\go-build
-    runs-on: ${{ matrix.platform }}
-    env:
-      # Use Go's internal linker. Without this, Windows runners auto-enable CGO
-      # because gcc is in PATH, then MinGW's ld.exe runs out of memory linking
-      # the integration test binary. The project has no cgo code, and -race
-      # (the only consumer of CGO) only runs on the Linux job.
-      CGO_ENABLED: 0
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
-        with:
-          go-version: ${{ matrix.go-version }}
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
-        with:
-          path: |
-            ~/go/pkg/mod
-            ${{ matrix.cache_path }}
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}-
-      - name: go-build
-        run: go build ./cmd/dingo
-      - name: go-test
-        run: go test ./...
+        # Keep PR feedback fast by omitting race instrumentation. Release
+        # validation runs in the publish workflow before draft creation.
+        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -timeout 20m ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,14 +6,99 @@ on:
     tags:
       - 'v*.*.*'
 
-concurrency: ${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Never interrupt a tag release after publication has started. Branch image
+  # builds can be superseded by a newer main push.
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 env:
   APPLICATION_NAME: 'dingo'
 
 jobs:
+  # Release validation happens before creating the draft release. Main pushes
+  # publish images and binaries without paying for the full test suite.
+  ci:
+    name: ci (Linux)
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: dingo_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_DATABASE: dingo_test
+        options: >-
+          --health-cmd "sh -c 'mysqladmin ping -h 127.0.0.1 -u root -p$MYSQL_ROOT_PASSWORD'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+      minio:
+        image: blinklabs/minio:main
+        options: >-
+          --health-cmd "curl localhost:9000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 9000:9000
+          - 9001:9001
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DATABASE: dingo_test
+      MYSQL_HOST: localhost
+      MYSQL_PORT: '3306'
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_DATABASE: dingo_test
+      MYSQL_ROOT_PASSWORD: mysql
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_ENDPOINT: "http://127.0.0.1:9000/"
+      AWS_REGION: us-east-1
+      DINGO_TEST_S3_BUCKET: dingo-test
+    steps:
+      - name: setup-s3-bucket
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install --update
+          aws --endpoint-url $AWS_ENDPOINT s3api create-bucket --bucket $DINGO_TEST_S3_BUCKET
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: 1.26.x
+      - name: go-build
+        run: go build -tags dingo_extra_plugins ./cmd/dingo
+      - name: go-build-minimal
+        run: go build ./cmd/dingo
+      - name: go-test
+        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -timeout 20m ./...
+
   create-draft-release:
     runs-on: ubuntu-latest
+    needs: [ci]
+    if: always() && (github.ref_type != 'tag' || needs.ci.result == 'success')
     permissions:
       contents: write
     outputs:
@@ -43,6 +128,42 @@ jobs:
               core.setFailed(error.message);
             }
 
+  # Run the platform-specific suite only after Linux release validation and
+  # draft creation have succeeded.
+  go-test-other:
+    name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
+    needs: [ci, create-draft-release]
+    if: always() && github.ref_type == 'tag' && needs.ci.result == 'success' && needs.create-draft-release.result == 'success'
+    strategy:
+      matrix:
+        go-version: [1.26.x]
+        platform: [macos-latest, windows-latest]
+        include:
+          - platform: macos-latest
+            cache_path: ~/Library/Caches/go-build
+          - platform: windows-latest
+            cache_path: ~\AppData\Local\go-build
+    runs-on: ${{ matrix.platform }}
+    env:
+      CGO_ENABLED: 0
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ${{ matrix.cache_path }}
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
+      - name: go-build
+        run: go build ./cmd/dingo
+      - name: go-test
+        run: go test ./...
+
   build-binaries:
     strategy:
       matrix:
@@ -69,7 +190,8 @@ jobs:
             os: windows
             arch: arm64
     runs-on: ${{ matrix.runner }}
-    needs: [create-draft-release]
+    needs: [create-draft-release, go-test-other]
+    if: always() && (github.ref_type != 'tag' || (needs.create-draft-release.result == 'success' && needs.go-test-other.result == 'success'))
     permissions:
       actions: write
       attestations: write
@@ -132,7 +254,8 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: arm64
     runs-on: ${{ matrix.os }}
-    needs: [create-draft-release]
+    needs: [create-draft-release, go-test-other]
+    if: always() && (github.ref_type != 'tag' || (needs.create-draft-release.result == 'success' && needs.go-test-other.result == 'success'))
     permissions:
       actions: write
       attestations: write
@@ -308,7 +431,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [create-draft-release, build-binaries, build-images, build-image-manifest]
+    needs: [create-draft-release, go-test-other, build-binaries, build-images, build-image-manifest]
+    if: always() && (github.ref_type != 'tag' || (needs.create-draft-release.result == 'success' && needs.go-test-other.result == 'success' && needs.build-binaries.result == 'success' && needs.build-images.result == 'success' && needs.build-image-manifest.result == 'success'))
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts GitHub Actions minutes and speeds up PR feedback by adding concurrency and shifting full release validation to the `publish` workflow. PRs run a lean Linux test suite; full platform tests run only on tag releases.

- **Refactors**
  - Add concurrency with cancel-in-progress to `ci-docker`, `conventional-commits`, `go-test`, and `golangci-lint`; update `publish` to group by workflow/ref and never cancel tag releases.
  - PR CI: `go-test` now triggers only on pull requests, runs Linux-only non-race tests with a 20m timeout; macOS/Windows jobs removed from PRs.
  - Release CI: add Linux integration tests (Postgres/MySQL/MinIO) in `publish` before draft creation; run macOS/Windows tests only for tagged releases; gate images/binaries and final publish on test success.
  - Remove `queue: max` from the Antithesis workflow concurrency.

<sup>Written for commit 15139016e00bcbd4b8b63e9353434285b563f31b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow management by canceling outdated duplicate runs.
  * Preserved active release and submission workflows from cancellation.
  * Streamlined pull request testing by limiting selected platform and race-enabled tests to non-pull-request events.
  * Updated build and release workflows to handle branch and tag runs more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->