### PR TITLE
fix(chain): reject rollback to a point the chain no longer holds

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2011,6 +2011,11 @@ paths finish bringing metadata to its common ancestor. Live at-tip recovery uses
 the same bounded event-aware helper; startup-only speculative-tail cleanup stays
 eventless because subscribers have not begun consuming live chain events.
 Rewinding metadata alone would replay the same corrupt chain indefinitely.
+The continuation audit is run only after a fetched body is accepted by the
+queued primary chain, so late bodies from an abandoned fetch cannot seed its
+producer window. Its diagnostic database probes are also capped per block
+while the blockfetch pipeline lock is held; this keeps the audit bounded and
+non-blocking for pathological transaction counts.
 The unresolved-producer fallback also tracks the applied ledger high-water
 mark across attempts. Different candidate continuations can move the failing
 block forward slightly while rebuilding to the same applied tip, so failure

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1466,6 +1466,52 @@ The `ChainManager` (`chain/manager.go`) manages multiple chains:
     -------------------------------------------------
 ```
 
+#### Retained block cache and the rollback-target invariant
+
+`ChainManager.removeBlockByIndex` deletes a rolled-back block's row but first
+puts the block into the manager's LRU block cache, because ephemeral fork
+chains reconcile against the primary chain by walking prev-hash links
+(`Chain.reconcile`) and must still be able to resolve blocks the primary chain
+has abandoned. `ChainManager.blockByPoint` and `blockByHash` therefore answer
+from that cache *before* the database, so an abandoned block stays resolvable
+by point and by hash and still reports the block index it used to occupy.
+
+That retention is deliberate, but it means "resolvable" does not imply "on the
+chain". Rolling the primary chain back to such a point truncated the chain to a
+stale index that a competing fork had already taken over, leaving `currentTip`
+naming a block the chain no longer stores while the block physically at
+`tipBlockIndex` belonged to the other fork. Every block appended afterwards was
+then spliced onto a parent absent from the chain, which is how a spender reached
+the ledger whose producing block was never applied — unresolvable by
+`UtxoByRef`, by transaction metadata, and by the backward chain scan, and
+therefore not fixable by replaying (issue #3005).
+
+`Chain.rollbackPointBlock` closes this: both `Rollback` and `ValidateRollback`
+resolve the target through it, and it rejects any target the chain does not
+currently hold at the resolved index, returning
+`chain.ErrRollbackPointNotOnChain` (which wraps `models.ErrBlockNotFound`).
+Callers already treat "point not found" as a signal to re-intersect, so a peer
+offering a continuation from a fork the node abandoned gets a fresh chainsync
+intersection instead of a spliced chain. Each rejection logs `cross-fork splice
+prevented: rejecting rollback to a point this chain no longer holds` and
+increments `dingo_chain_rollback_point_not_on_chain_total`. The invariant this
+establishes is that `currentTip` always names the block stored at
+`tipBlockIndex`, which is what makes the prev-hash check in `addBlockLocked` /
+`addRawBlockLocked` meaningful.
+
+Two shapes are rejected. A resolved index at or below the tip that holds a
+*different* block is the splice above. A resolved index *ahead* of the tip is
+the issue #3035/#3040 shape: no chain block occupies it, so adopting the point
+raised `tipBlockIndex` past the last stored block and punched a hole that chain
+iteration stops at. Both are refused as not-on-chain, deliberately **not** as
+`ErrRollbackExceedsSecurityParam`: #3035 was a node permanently denying every
+peer because the ahead-of-tip case was misclassified as over-K, and an over-K
+rejection is unrecoverable where a not-found rejection re-intersects.
+`rollbackForkDepth` keeps the saturating arithmetic that fixed the underlying
+uint64 underflow — it is no longer reached with an above-tip index from either
+rollback entry point, and is unit-tested directly so the underflow cannot return
+through a future caller.
+
 ### Chain Selection (Ouroboros Praos)
 
 The `ChainSelector` (`chainselection/`) implements Ouroboros Praos rules:
@@ -1981,6 +2027,31 @@ step has already pruned the primary chain below the applied ledger tip, the
 primary-chain rewind is an already-held no-op while ChainSync refills it.
 Successful block application beyond the recorded high-water mark clears the
 hold and restores the normal fallback budget.
+
+That hold bounds the damage but cannot explain where an unresolvable producer
+came from, so a bounded diagnostic attributes it
+(`ledger/continuation_audit.go`). A local rollback — chainsync rollback via
+`rollbackChainAndState`, or a replay-recovery rewind — arms a
+`continuationAuditWindow` at the rollback point. While armed, every body
+delivered by blockfetch above that point is checked input by input: an input
+resolves when its producing transaction was created by a block already seen in
+the window (fetched and on the chain, not yet applied), when the ledger still
+holds the UTxO, or when transaction metadata records the producer. Anything
+left over logs `continuation block spends an input with no producer on the
+local applied chain` with the delivering peer, the block, the offending input,
+and the fork point the node had rolled back to, and increments
+`dingo_ledger_continuation_input_unresolved_total`. The audit never rejects a
+block; the splice it detects is prevented upstream in the chain layer, and
+bodies that still fail reach the ordinary validation and recovery guards
+unchanged. Arming on rollback is both the cost gate — a healthy node never runs
+the per-input probes on the steady-state blockfetch path — and what makes the
+check sound, since a rollback leaves the chain and the ledger at the same point
+so every later block arrives through the window. Each arming inspects at most
+`continuationAuditBlockBudget` bodies and retains at most
+`continuationAuditMaxProducedTxs` in-window producers. The audit is also skipped
+while block validation is off, which is how historical catch-up runs: the splice
+it diagnoses is a live tip-band failure, and bulk sync fetches far too many
+bodies per second to pay for the probes.
 
 When a block fails per-tx validation at tip,
 the node rewinds the primary chain and rolls the ledger back so ChainSelection

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -700,6 +700,12 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 // deeper than the security parameter K, which rejected and denied every peer
 // permanently (issue #3035).
 //
+// rollbackPointBlock now refuses a point above the tip before either rollback
+// entry point reaches this function, so the saturating branch is not exercised
+// from Rollback or ValidateRollback any more. It is kept, and unit-tested
+// directly by TestRollbackForkDepthSaturates, so the underflow cannot creep
+// back in through a future caller.
+//
 // Callers must hold c.mutex.
 func (c *Chain) rollbackForkDepth(
 	point ocommon.Point,
@@ -716,6 +722,73 @@ func (c *Chain) rollbackForkDepth(
 		"tip_block_index", c.tipBlockIndex,
 	)
 	return 0
+}
+
+// rollbackPointBlock resolves a rollback target to the block this chain must
+// truncate to, rejecting any target the chain does not currently hold.
+//
+// The lookup itself goes through ChainManager.blockByPoint, which answers from
+// the retained block cache before the database. That cache deliberately keeps
+// blocks the primary chain rolled back so ephemeral fork chains can still
+// reconcile against them (see removeBlockByIndex and Chain.reconcile), which
+// means an abandoned block stays resolvable by point and still reports the
+// block index it used to occupy. Another fork has usually taken that index over
+// by the time a peer offers the abandoned point again.
+//
+// Truncating to that stale index leaves the chain claiming a tip it does not
+// store: the block physically at tipBlockIndex belongs to the competing fork,
+// while currentTip names the abandoned one. Every block appended afterwards is
+// then spliced onto a parent that is absent from the chain, so a spender can
+// reach the ledger whose producing block was never applied and cannot be found
+// by UtxoByRef, by transaction metadata, or by the backward chain scan. That is
+// the non-converging tip-band wedge in issue #3005.
+//
+// A target whose retained index sits ahead of the tip is refused here too. That
+// is the issue #3035/#3040 shape: no chain block occupies the index, so obeying
+// it raised tipBlockIndex above the last block the chain actually stores and
+// left currentTip naming an absent block, punching a hole that chain iteration
+// stops at. It must be refused as not-on-chain rather than as an over-K
+// rollback: #3035 was a node permanently denying every peer because that case
+// was misclassified as exceeding the security parameter, whereas a not-found
+// rollback makes callers re-intersect and recover. rollbackForkDepth keeps its
+// saturating arithmetic so no future caller can reintroduce the uint64
+// underflow that caused the misclassification.
+//
+// Callers must hold c.mutex and c.manager.mutex.
+func (c *Chain) rollbackPointBlock(
+	point ocommon.Point,
+) (models.Block, error) {
+	tmpBlock, err := c.manager.blockByPoint(point, nil)
+	if err != nil {
+		return models.Block{}, fmt.Errorf("lookup rollback point: %w", err)
+	}
+	if c.holdsBlockAtIndex(tmpBlock.ID, tmpBlock.Hash) {
+		return tmpBlock, nil
+	}
+	occupantHash := []byte(nil)
+	if occupant, occErr := c.blockByIndex(tmpBlock.ID); occErr == nil {
+		occupantHash = occupant.Hash
+	}
+	c.manager.recordRollbackPointNotOnChain()
+	slog.Default().Error(
+		"cross-fork splice prevented: rejecting rollback to a point this chain no longer holds",
+		"component", "chain",
+		"chain_id", c.id,
+		"rollback_slot", point.Slot,
+		"rollback_hash", hex.EncodeToString(point.Hash),
+		"retained_block_index", tmpBlock.ID,
+		"block_hash_at_index", hex.EncodeToString(occupantHash),
+		"tip_block_index", c.tipBlockIndex,
+		"tip_slot", c.currentTip.Point.Slot,
+		"tip_hash", hex.EncodeToString(c.currentTip.Point.Hash),
+	)
+	return models.Block{}, fmt.Errorf(
+		"%w: slot %d hash %s resolved to block index %d, which this chain no longer holds",
+		ErrRollbackPointNotOnChain,
+		point.Slot,
+		hex.EncodeToString(point.Hash),
+		tmpBlock.ID,
+	)
 }
 
 // ValidateRollback verifies that Rollback(point) would be accepted without
@@ -756,9 +829,9 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 	// Lookup block for rollback point
 	var rollbackBlockIndex uint64
 	if point.Slot > 0 {
-		tmpBlock, err := c.manager.blockByPoint(point, nil)
+		tmpBlock, err := c.rollbackPointBlock(point)
 		if err != nil {
-			return fmt.Errorf("lookup rollback point: %w", err)
+			return err
 		}
 		rollbackBlockIndex = tmpBlock.ID
 	}
@@ -827,11 +900,9 @@ func (c *Chain) rollbackLocked(
 	var tmpBlock models.Block
 	if point.Slot > 0 {
 		var err error
-		tmpBlock, err = c.manager.blockByPoint(point, nil)
+		tmpBlock, err = c.rollbackPointBlock(point)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"lookup rollback point: %w", err,
-			)
+			return nil, err
 		}
 		rollbackBlockIndex = tmpBlock.ID
 	}
@@ -1299,6 +1370,22 @@ func (c *Chain) BlockBeforeSlot(slotNumber uint64) (models.Block, error) {
 		return models.Block{}, models.ErrBlockNotFound
 	}
 	return result, nil
+}
+
+// holdsBlockAtIndex reports whether this chain currently has the block with
+// the given hash at the given index. It distinguishes a point that is still
+// part of the chain from one that merely remains resolvable through the
+// manager's retained-block cache after a rollback, since blockByPoint answers
+// from that cache. Callers must hold c.mutex.
+func (c *Chain) holdsBlockAtIndex(blockIndex uint64, blockHash []byte) bool {
+	if blockIndex < initialBlockIndex || blockIndex > c.tipBlockIndex {
+		return false
+	}
+	tmpBlock, err := c.blockByIndex(blockIndex)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(tmpBlock.Hash, blockHash)
 }
 
 func (c *Chain) blockByIndex(

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1612,6 +1612,15 @@ func TestChainRollbackWithinSecurityParam(t *testing.T) {
 // can hand the chain a rollback point above the current tip. Subtracting that
 // index from the tip wrapped around uint64, making every such rollback look
 // deeper than K, which permanently denied every peer.
+//
+// The rollback is now refused outright (issue #3005): adopting a point the
+// chain does not hold set tipBlockIndex above the last stored block and left
+// currentTip naming an absent block. What #3035 requires is unchanged and is
+// still asserted here — the refusal must NOT be an over-K rejection, because
+// that is the classification that denied every peer permanently. It is instead
+// ErrRollbackPointNotOnChain, which wraps models.ErrBlockNotFound so callers
+// re-intersect and recover. The saturating fork-depth arithmetic that fixed the
+// underflow is retained and covered directly by TestRollbackForkDepthSaturates.
 func TestChainRollbackPointAheadOfTipIsNotDeepFork(t *testing.T) {
 	db := newTestDB(t)
 	cm, err := chain.NewManager(db, nil)
@@ -1644,25 +1653,59 @@ func TestChainRollbackPointAheadOfTipIsNotDeepFork(t *testing.T) {
 		Slot: aheadBlock.SlotNumber(),
 		Hash: aheadBlock.Hash().Bytes(),
 	}
-	if err := c.ValidateRollback(aheadPoint); err != nil {
-		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
-			t.Fatalf(
-				"rollback point ahead of tip must not be reported as "+
-					"exceeding security param K: %s",
-				err,
-			)
-		}
-		t.Fatalf("unexpected error validating rollback: %s", err)
+	validateErr := c.ValidateRollback(aheadPoint)
+	if validateErr == nil {
+		t.Fatal(
+			"rollback point ahead of tip must be rejected: the chain does " +
+				"not hold a block at that index",
+		)
 	}
-	if err := c.Rollback(aheadPoint); err != nil {
-		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
-			t.Fatalf(
-				"rollback point ahead of tip must not be rejected for "+
-					"exceeding security param K: %s",
-				err,
-			)
-		}
-		t.Fatalf("unexpected error rolling back chain: %s", err)
+	if errors.Is(validateErr, chain.ErrRollbackExceedsSecurityParam) {
+		t.Fatalf(
+			"rollback point ahead of tip must not be reported as "+
+				"exceeding security param K: %s",
+			validateErr,
+		)
+	}
+	if !errors.Is(validateErr, chain.ErrRollbackPointNotOnChain) {
+		t.Fatalf(
+			"expected ErrRollbackPointNotOnChain validating rollback, got: %s",
+			validateErr,
+		)
+	}
+	if !errors.Is(validateErr, models.ErrBlockNotFound) {
+		t.Fatalf(
+			"rejection must wrap ErrBlockNotFound so callers re-intersect, "+
+				"got: %s",
+			validateErr,
+		)
+	}
+	rollbackErr := c.Rollback(aheadPoint)
+	if rollbackErr == nil {
+		t.Fatal(
+			"rollback to a point ahead of tip must be rejected: the chain " +
+				"does not hold a block at that index",
+		)
+	}
+	if errors.Is(rollbackErr, chain.ErrRollbackExceedsSecurityParam) {
+		t.Fatalf(
+			"rollback point ahead of tip must not be rejected for "+
+				"exceeding security param K: %s",
+			rollbackErr,
+		)
+	}
+	if !errors.Is(rollbackErr, chain.ErrRollbackPointNotOnChain) {
+		t.Fatalf(
+			"expected ErrRollbackPointNotOnChain rolling back, got: %s",
+			rollbackErr,
+		)
+	}
+	if !errors.Is(rollbackErr, models.ErrBlockNotFound) {
+		t.Fatalf(
+			"rejection must wrap ErrBlockNotFound so callers re-intersect, "+
+				"got: %s",
+			rollbackErr,
+		)
 	}
 }
 

--- a/chain/crossfork_splice_test.go
+++ b/chain/crossfork_splice_test.go
@@ -1,0 +1,373 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// spliceForkHashPrefix keeps competing fork blocks distinct from the shared
+// testBlocks fixtures while staying 32 bytes wide.
+const spliceForkHashPrefix = "00004744abababababababababababababababababababababababababab"
+
+func mockBlockPoint(b *MockBlock) ocommon.Point {
+	return ocommon.Point{
+		Slot: b.SlotNumber(),
+		Hash: b.Hash().Bytes(),
+	}
+}
+
+// buildAbandonedForkChain sets up the exact state that precedes the #3005
+// cross-fork splice:
+//
+//	index 1: testBlocks[0]        (shared ancestor)
+//	index 2: testBlocks[1]        (shared ancestor, rollback target)
+//	index 3: forkB[0]             (fork B, currently on the chain)
+//	index 4: forkB[1]             (fork B tip)
+//
+// while testBlocks[2] and testBlocks[3] (fork A) were rolled back off the chain
+// and therefore only survive in the manager's retained block cache, still
+// carrying their old indices 3 and 4.
+//
+// It returns the chain plus fork A's first rolled-back block.
+func buildAbandonedForkChain(
+	t *testing.T,
+	db *database.Database,
+) (*chain.Chain, *MockBlock, []*MockBlock) {
+	t.Helper()
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 100)
+	c := cm.PrimaryChain()
+	// Fork A: the shared ancestors plus two blocks we later abandon.
+	for _, testBlock := range testBlocks[:4] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding fork A block: %s", err)
+		}
+	}
+	// Abandon fork A back to the shared ancestor at index 2.
+	sharedAncestor := testBlocks[1]
+	if err := c.Rollback(mockBlockPoint(sharedAncestor)); err != nil {
+		t.Fatalf("unexpected error rolling back to shared ancestor: %s", err)
+	}
+	// Fork B replaces indices 3 and 4 with different blocks.
+	forkB := []*MockBlock{
+		{
+			MockBlockNumber: 3,
+			MockSlot:        41,
+			MockHash:        spliceForkHashPrefix + "0003",
+			MockPrevHash:    sharedAncestor.MockHash,
+		},
+		{
+			MockBlockNumber: 4,
+			MockSlot:        61,
+			MockHash:        spliceForkHashPrefix + "0004",
+			MockPrevHash:    spliceForkHashPrefix + "0003",
+		},
+	}
+	for _, forkBlock := range forkB {
+		if err := c.AddBlock(forkBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding fork B block: %s", err)
+		}
+	}
+	// Precondition for the wedge: fork A's abandoned block is still
+	// resolvable by point out of the retained block cache, and it still
+	// reports the index that fork B now occupies.
+	abandoned := testBlocks[2]
+	cachedBlock, err := c.BlockByPoint(mockBlockPoint(abandoned), nil)
+	if err != nil {
+		t.Fatalf(
+			"expected abandoned fork A block to stay resolvable by point: %s",
+			err,
+		)
+	}
+	if cachedBlock.ID != 3 {
+		t.Fatalf(
+			"expected retained fork A block to keep index 3, got %d",
+			cachedBlock.ID,
+		)
+	}
+	return c, abandoned, forkB
+}
+
+// assertChainPrevHashContiguous walks the persisted chain from origin and
+// verifies every block's PrevHash matches the hash of the block stored at the
+// preceding index. A cross-fork splice shows up here as a block whose parent is
+// not the block that physically precedes it, which is precisely the shape that
+// leaves a spender on the chain whose producing block was never applied.
+func assertChainPrevHashContiguous(t *testing.T, c *chain.Chain) {
+	t.Helper()
+	iter, err := c.FromPoint(ocommon.NewPointOrigin(), false)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain iterator: %s", err)
+	}
+	defer iter.Cancel()
+	var prevHash []byte
+	var prevSlot uint64
+	for {
+		next, err := iter.Next(false)
+		if errors.Is(err, chain.ErrIteratorChainTip) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error iterating chain: %s", err)
+		}
+		if next == nil {
+			t.Fatal("unexpected nil iterator result")
+		}
+		blk := next.Block
+		if prevHash != nil && !bytes.Equal(blk.PrevHash, prevHash) {
+			t.Fatalf(
+				"cross-fork splice: block at index %d (slot %d) has prev hash %s "+
+					"but the preceding chain block (slot %d) has hash %s",
+				blk.ID,
+				blk.Slot,
+				hex.EncodeToString(blk.PrevHash),
+				prevSlot,
+				hex.EncodeToString(prevHash),
+			)
+		}
+		prevHash = blk.Hash
+		prevSlot = blk.Slot
+	}
+}
+
+// TestRollbackRejectsPointNotOnChain covers the root cause of issue #3005.
+//
+// Chain.rollbackLocked resolves the rollback point through
+// ChainManager.blockByPoint, which answers from the retained block cache before
+// the database. A block this chain already rolled back therefore still resolves
+// and still reports its old block index, an index another fork now occupies.
+// Rolling back to it truncates to that stale index and moves currentTip to a
+// point the chain does not hold, so the next block is appended above a block
+// that is not its parent: a cross-fork splice.
+func TestRollbackRejectsPointNotOnChain(t *testing.T) {
+	db := newTestDB(t)
+	c, abandoned, forkB := buildAbandonedForkChain(t, db)
+	forkBTip := mockBlockPoint(forkB[len(forkB)-1])
+
+	err := c.Rollback(mockBlockPoint(abandoned))
+	if err == nil {
+		t.Fatal(
+			"expected Rollback to reject a point this chain no longer holds",
+		)
+	}
+	if !errors.Is(err, models.ErrBlockNotFound) {
+		t.Fatalf("expected ErrBlockNotFound, got: %s", err)
+	}
+	tip := c.Tip()
+	if tip.Point.Slot != forkBTip.Slot ||
+		!bytes.Equal(tip.Point.Hash, forkBTip.Hash) {
+		t.Fatalf(
+			"rejected rollback must leave the tip untouched: got %d/%s, want %d/%s",
+			tip.Point.Slot,
+			hex.EncodeToString(tip.Point.Hash),
+			forkBTip.Slot,
+			hex.EncodeToString(forkBTip.Hash),
+		)
+	}
+	assertChainPrevHashContiguous(t, c)
+}
+
+// TestValidateRollbackRejectsPointNotOnChain covers the pre-check the chainsync
+// rollback-loop detector uses to decide whether a repeated peer rollback is
+// "crossable". A point resolvable only through the retained cache must not be
+// reported as crossable, otherwise the detector keeps re-applying the very
+// rollback that splices the chain.
+func TestValidateRollbackRejectsPointNotOnChain(t *testing.T) {
+	db := newTestDB(t)
+	c, abandoned, _ := buildAbandonedForkChain(t, db)
+
+	err := c.ValidateRollback(mockBlockPoint(abandoned))
+	if err == nil {
+		t.Fatal(
+			"expected ValidateRollback to reject a point this chain no longer holds",
+		)
+	}
+	if !errors.Is(err, models.ErrBlockNotFound) {
+		t.Fatalf("expected ErrBlockNotFound, got: %s", err)
+	}
+}
+
+// TestRollbackToRetainedPointDoesNotSpliceChain drives the full defect: after
+// the bad rollback the chain accepts a continuation built on the abandoned fork
+// while the block physically stored at the preceding index belongs to the other
+// fork. Iterating the chain then yields a block whose parent is absent, which is
+// what leaves the ledger unable to resolve the producer of that block's inputs.
+func TestRollbackToRetainedPointDoesNotSpliceChain(t *testing.T) {
+	db := newTestDB(t)
+	c, abandoned, _ := buildAbandonedForkChain(t, db)
+
+	// A peer serving fork A rolls us back to its own block, then feeds the
+	// next block on fork A.
+	if err := c.Rollback(mockBlockPoint(abandoned)); err == nil {
+		// Only the unfixed code reaches here; keep going so the assertion
+		// below reports the splice rather than a bare "expected error".
+		continuation := testBlocks[3]
+		if addErr := c.AddBlock(continuation, nil); addErr != nil {
+			t.Fatalf(
+				"unexpected error adding fork A continuation: %s",
+				addErr,
+			)
+		}
+	}
+	assertChainPrevHashContiguous(t, c)
+}
+
+// TestRollbackRejectsPointAheadOfTip covers the other shape of the same defect.
+//
+// After a rollback the abandoned blocks keep their original, higher block
+// indexes in the retained cache, so a peer can hand back a point that resolves
+// above the current tip. Obeying it set tipBlockIndex above the last block the
+// chain actually stores and moved currentTip to a block absent from the chain,
+// leaving a hole: the next block was written past the gap, chain iteration
+// stopped short of it, and prev-hash contiguity was enforced against a phantom
+// tip. Like the stale-index shape, the chain must refuse rather than adopt a
+// tip it does not hold.
+//
+// It must be refused as "point not found", never as an over-K rollback: issue
+// #3035 was a node permanently denying every peer because this case was
+// misclassified as exceeding the security parameter. Not-on-chain re-intersects
+// and recovers; over-K does not.
+func TestRollbackRejectsPointAheadOfTip(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 2)
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	// Roll back the last two blocks (index 6 -> 4). The removed blocks stay in
+	// the manager's cache carrying indexes 5 and 6.
+	if err := c.Rollback(mockBlockPoint(testBlocks[len(testBlocks)-3])); err != nil {
+		t.Fatalf("unexpected error rolling back chain: %s", err)
+	}
+	tipBefore := c.Tip()
+	aheadPoint := mockBlockPoint(testBlocks[len(testBlocks)-1])
+
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "ValidateRollback",
+			call: func() error { return c.ValidateRollback(aheadPoint) },
+		},
+		{
+			name: "Rollback",
+			call: func() error { return c.Rollback(aheadPoint) },
+		},
+	} {
+		err := tc.call()
+		if err == nil {
+			t.Fatalf(
+				"%s: expected rejection of a point ahead of the chain tip",
+				tc.name,
+			)
+		}
+		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
+			t.Fatalf(
+				"%s: a point ahead of the tip must not be reported as "+
+					"exceeding security param K (issue #3035): %s",
+				tc.name,
+				err,
+			)
+		}
+		if !errors.Is(err, chain.ErrRollbackPointNotOnChain) {
+			t.Fatalf(
+				"%s: expected ErrRollbackPointNotOnChain, got: %s",
+				tc.name,
+				err,
+			)
+		}
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			t.Fatalf(
+				"%s: rejection must wrap ErrBlockNotFound so callers "+
+					"re-intersect, got: %s",
+				tc.name,
+				err,
+			)
+		}
+	}
+
+	tipAfter := c.Tip()
+	if tipAfter.Point.Slot != tipBefore.Point.Slot ||
+		!bytes.Equal(tipAfter.Point.Hash, tipBefore.Point.Hash) {
+		t.Fatalf(
+			"rejected rollback must leave the tip untouched: got %d/%s, want %d/%s",
+			tipAfter.Point.Slot,
+			hex.EncodeToString(tipAfter.Point.Hash),
+			tipBefore.Point.Slot,
+			hex.EncodeToString(tipBefore.Point.Hash),
+		)
+	}
+	assertChainPrevHashContiguous(t, c)
+}
+
+// TestRollbackStillAcceptsPointsOnChain guards against the fix over-rejecting:
+// ordinary rollbacks to blocks the chain still holds must keep working, and a
+// rollback to origin must remain possible.
+func TestRollbackStillAcceptsPointsOnChain(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 100)
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	target := mockBlockPoint(testBlocks[2])
+	if err := c.ValidateRollback(target); err != nil {
+		t.Fatalf("unexpected error validating on-chain rollback: %s", err)
+	}
+	if err := c.Rollback(target); err != nil {
+		t.Fatalf("unexpected error rolling back to on-chain point: %s", err)
+	}
+	tip := c.Tip()
+	if tip.Point.Slot != target.Slot ||
+		!bytes.Equal(tip.Point.Hash, target.Hash) {
+		t.Fatalf(
+			"expected tip at rollback point %d, got %d",
+			target.Slot,
+			tip.Point.Slot,
+		)
+	}
+	assertChainPrevHashContiguous(t, c)
+	if err := c.Rollback(ocommon.NewPointOrigin()); err != nil {
+		t.Fatalf("unexpected error rolling back to origin: %s", err)
+	}
+	if c.Tip().Point.Slot != 0 {
+		t.Fatalf("expected origin tip, got slot %d", c.Tip().Point.Slot)
+	}
+}

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -17,6 +17,8 @@ package chain
 import (
 	"errors"
 	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 // DefaultMaxQueuedHeaders is the minimum header queue capacity (floor).
@@ -42,6 +44,19 @@ var (
 	)
 	ErrRollbackExceedsSecurityParam = errors.New(
 		"rollback depth exceeds security parameter K",
+	)
+	// ErrRollbackPointNotOnChain is returned when a rollback target resolves
+	// to a block that this chain no longer holds at that block index.
+	// Rolled-back blocks stay resolvable through the manager's retained block
+	// cache with their original index, so a point another fork has since
+	// overwritten still looks valid; rolling back to it truncates to a stale
+	// index and moves the tip to a block the chain does not have, splicing a
+	// continuation onto a parent that is absent from the chain (issue #3005).
+	// It wraps models.ErrBlockNotFound so existing callers keep treating an
+	// unusable rollback target as "point not found" and re-intersect.
+	ErrRollbackPointNotOnChain = fmt.Errorf(
+		"%w: rollback point is not on this chain",
+		models.ErrBlockNotFound,
 	)
 	ErrIteratorChainTip = errors.New(
 		"chain iterator is at chain tip",

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -28,6 +28,7 @@ import (
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type ChainId uint64
@@ -46,7 +47,12 @@ type ChainManager struct {
 	chains              map[ChainId]*Chain
 	chainRollbackEvents map[ChainId][]uint64
 	blockCache          *blockCache
-	mutex               sync.RWMutex
+	// rollbackPointNotOnChain counts rollback targets rejected because the
+	// chain no longer holds the resolved block at its retained index. A
+	// non-zero value means a peer (or local recovery) tried to splice a
+	// continuation onto an abandoned fork; see Chain.rollbackPointBlock.
+	rollbackPointNotOnChain prometheus.Counter
+	mutex                   sync.RWMutex
 }
 
 func NewManager(
@@ -70,10 +76,27 @@ func NewManager(
 			registry,
 		),
 	}
+	if registry != nil {
+		cm.rollbackPointNotOnChain = promauto.With(registry).NewCounter(
+			prometheus.CounterOpts{
+				Name: "dingo_chain_rollback_point_not_on_chain_total",
+				Help: "rollback targets rejected because the chain no longer holds the resolved block at its retained index",
+			},
+		)
+	}
 	if err := cm.loadPrimaryChain(); err != nil {
 		return nil, err
 	}
 	return cm, nil
+}
+
+// recordRollbackPointNotOnChain increments the rejected-rollback-target
+// counter when metrics are registered.
+func (cm *ChainManager) recordRollbackPointNotOnChain() {
+	if cm == nil || cm.rollbackPointNotOnChain == nil {
+		return
+	}
+	cm.rollbackPointNotOnChain.Inc()
 }
 
 // SetLedger configures the Ouroboros security parameter K from the ledger.

--- a/chain/rollback_fork_depth_internal_test.go
+++ b/chain/rollback_fork_depth_internal_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// TestRollbackForkDepthSaturates keeps issue #3040's underflow fix covered at
+// the unit level.
+//
+// The behavioral test that used to reach this branch
+// (TestChainRollbackPointAheadOfTipIsNotDeepFork) now asserts that a rollback
+// point above the tip is refused outright as not-on-chain (issue #3005), so it
+// no longer drives rollbackForkDepth with such an index. The saturating
+// computation still has to be correct: any future caller that reaches it with a
+// point above the tip must get zero, not a wrapped-around uint64 that reads as
+// a fork deeper than any security parameter and denies every peer.
+func TestRollbackForkDepthSaturates(t *testing.T) {
+	c := &Chain{
+		tipBlockIndex: 4,
+		currentTip: ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 60, Hash: []byte("tip")},
+			BlockNumber: 4,
+		},
+	}
+	point := ocommon.Point{Slot: 100, Hash: []byte("ahead")}
+
+	for _, tc := range []struct {
+		name               string
+		rollbackBlockIndex uint64
+		want               uint64
+	}{
+		{name: "behind tip", rollbackBlockIndex: 1, want: 3},
+		{name: "at tip", rollbackBlockIndex: 4, want: 0},
+		{name: "one ahead of tip", rollbackBlockIndex: 5, want: 0},
+		{name: "far ahead of tip", rollbackBlockIndex: 1 << 40, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := c.rollbackForkDepth(point, tc.rollbackBlockIndex)
+			if got != tc.want {
+				t.Fatalf(
+					"rollbackForkDepth(tip=%d, rollback=%d) = %d, want %d",
+					c.tipBlockIndex,
+					tc.rollbackBlockIndex,
+					got,
+					tc.want,
+				)
+			}
+		})
+	}
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2478,6 +2478,14 @@ func (ls *LedgerState) tryResolveFork(
 		// view or we have not yet seen enough of its ancestry to resolve
 		// the fork locally. Request a chainsync re-sync so the intersect
 		// protocol finds the common point with the peer.
+		// Keep the candidate rollback point across the reset/reconnect
+		// cycle; otherwise repeated stale-ancestor resyncs lose the only
+		// point-keyed evidence that the same divergence is recurring.
+		ls.reportUnrecoverableRollbackIfStuck(
+			e.Point,
+			event.ChainsyncResyncReasonRollbackNotFound,
+			e.ConnectionId,
+		)
 		ls.config.Logger.Debug(
 			"common ancestor not found locally, triggering chainsync re-sync",
 			"component", "ledger",
@@ -2671,6 +2679,10 @@ func (ls *LedgerState) tryResolveFork(
 			)
 		}
 	}
+	// This fork rollback is genuine forward progress. Clear evidence from
+	// stale-ancestor / failed-rollback cycles so an unrelated later fork does
+	// not inherit the old divergence count.
+	ls.clearUnrecoverableRollbacks()
 
 	// Mark state as rollback so the next block header event logs
 	// "switched to fork" and increments the fork metric.
@@ -2800,9 +2812,6 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 			}
 		}
 	}
-	// Cross-fork splice diagnostic (#3005). No-op unless a recent local
-	// rollback armed it; see ledger/continuation_audit.go.
-	ls.auditContinuationBlock(e, validationEnabled)
 	ls.pendingBlockfetchEvents = append(ls.pendingBlockfetchEvents, e)
 	ls.batchBlocksReceived++
 	if len(ls.pendingBlockfetchEvents) >= blockfetchCommitBatchSize {
@@ -3018,6 +3027,12 @@ func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
 			nil,
 		)
 		if addBlockErr == nil {
+			// Audit only after the body has extended the queued chain. A body
+			// from an abandoned fetch may still be delivered after a fork
+			// restart; auditing it here would poison producedTxs with stale
+			// fork transactions.
+			validationEnabled, _ := ls.validationStateSnapshot()
+			ls.auditContinuationBlock(pendingEvent, validationEnabled)
 			ls.checkSlotBattle(pendingEvent, nil)
 			continue
 		}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2588,6 +2588,28 @@ func (ls *LedgerState) tryResolveFork(
 	)
 
 	if err := ls.rollbackChainAndState(rollbackPoint); err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			// The ancestor resolved but the chain no longer holds it at that
+			// index, so rolling back would splice a continuation onto a parent
+			// the chain does not have (issue #3005). Re-intersect instead of
+			// treating this as an internal failure.
+			ls.config.Logger.Warn(
+				"fork ancestor is no longer on the local chain, triggering chainsync re-sync",
+				"component", "ledger",
+				"error", err,
+				"ancestor_slot", ancestorBlock.Slot,
+				"ancestor_hash", hex.EncodeToString(ancestorBlock.Hash),
+				"local_tip_slot", ls.chain.Tip().Point.Slot,
+				"connection_id", e.ConnectionId.String(),
+			)
+			ls.headerMismatchCount = 0
+			ls.rollbackHistory = nil
+			ls.requestChainsyncResync(
+				e.ConnectionId,
+				event.ChainsyncResyncReasonRollbackNotFound,
+			)
+			return true, nil
+		}
 		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
 			reconciled, reconcileErr := ls.reconcileLivePrimaryChainLedgerDivergence(
 				"fork resolution exceeds security parameter K",
@@ -2778,6 +2800,9 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 			}
 		}
 	}
+	// Cross-fork splice diagnostic (#3005). No-op unless a recent local
+	// rollback armed it; see ledger/continuation_audit.go.
+	ls.auditContinuationBlock(e, validationEnabled)
 	ls.pendingBlockfetchEvents = append(ls.pendingBlockfetchEvents, e)
 	ls.batchBlocksReceived++
 	if len(ls.pendingBlockfetchEvents) >= blockfetchCommitBatchSize {

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -54,6 +54,11 @@ const (
 	// continuationAuditMaxReportsPerBlock caps log volume for a body with
 	// many unresolvable inputs. The first few identify the fork just as well.
 	continuationAuditMaxReportsPerBlock = 4
+	// continuationAuditMaxInputsPerBlock bounds diagnostic database work while
+	// the chainsync/blockfetch pipeline mutex is held. The audit is diagnostic,
+	// so truncating a pathological block is preferable to delaying the
+	// blockfetch pipeline behind unbounded per-input probes.
+	continuationAuditMaxInputsPerBlock = 32
 )
 
 // continuationAuditWindow is the state of one armed audit run. It is published
@@ -144,8 +149,13 @@ func (ls *LedgerState) auditContinuationBlock(
 		window.producedTxs[string(tx.Hash().Bytes())] = struct{}{}
 	}
 	reports := 0
+	inputsAudited := 0
 	for _, tx := range txs {
 		for _, input := range collectReferencedInputs(tx) {
+			if inputsAudited >= continuationAuditMaxInputsPerBlock {
+				return
+			}
+			inputsAudited++
 			if reports >= continuationAuditMaxReportsPerBlock {
 				return
 			}

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// The cross-fork continuation audit answers the question issue #3005 could not
+// answer from the failure site: when a block reaches the ledger spending an
+// input whose producer is nowhere on the local chain, which peer delivered that
+// body and which fork was the node following at the time?
+//
+// Cost and gating. A full per-input producer probe on every fetched body would
+// add a database round trip per input to the steady-state blockfetch path, so
+// the audit is armed only by a local rollback (rollbackChainAndState and the
+// replay-recovery rewind) and then runs for a bounded number of blocks. That is
+// exactly the fork-churn / recovery regime where the splice appears.
+//
+// Arming on rollback is also what makes the audit sound. A rollback rewinds the
+// primary chain and the ledger to the same point, so from that instant every
+// block above the rollback point arrives through the audit. An input can
+// therefore be resolved without a chain scan: it is legitimate when its
+// producing transaction was created by a block already seen in this window
+// (fetched, on the chain, not yet applied), or when the ledger already holds
+// the UTxO, or when transaction metadata knows the producer. Anything left over
+// has no producer on the local applied chain.
+const (
+	// continuationAuditBlockBudget bounds how many fetched blocks a single
+	// arming inspects. Each local rollback re-arms, so a node churning at the
+	// tip keeps the audit live while a healthy node pays nothing.
+	continuationAuditBlockBudget = 512
+	// continuationAuditMaxProducedTxs bounds the in-window producer set so a
+	// long run cannot grow memory without limit. Exceeding it disarms the
+	// window rather than risking false reports from a truncated set.
+	continuationAuditMaxProducedTxs = 100_000
+	// continuationAuditMaxReportsPerBlock caps log volume for a body with
+	// many unresolvable inputs. The first few identify the fork just as well.
+	continuationAuditMaxReportsPerBlock = 4
+)
+
+// continuationAuditWindow is the state of one armed audit run. It is published
+// through an atomic pointer, but only the blockfetch handler mutates it, so the
+// counters and the producer set need no further synchronization: arming always
+// installs a freshly allocated window.
+type continuationAuditWindow struct {
+	producedTxs map[string]struct{}
+	forkPoint   ocommon.Point
+	forkReason  string
+	forkPeer    string
+	remaining   int
+	blocksSeen  int
+}
+
+// armContinuationAudit starts a bounded continuation audit at a rollback point.
+// Callers must have rolled back both the primary chain and the ledger to point,
+// which is what lets the audit treat blocks it has not yet seen as absent.
+func (ls *LedgerState) armContinuationAudit(
+	point ocommon.Point,
+	reason string,
+) {
+	forkPeer := ""
+	if ls.config.GetActiveConnectionFunc != nil {
+		if connId := ls.config.GetActiveConnectionFunc(); connId != nil {
+			forkPeer = connId.String()
+		}
+	}
+	ls.continuationAudit.Store(&continuationAuditWindow{
+		producedTxs: make(map[string]struct{}),
+		forkPoint: ocommon.Point{
+			Slot: point.Slot,
+			Hash: append([]byte(nil), point.Hash...),
+		},
+		forkReason: reason,
+		forkPeer:   forkPeer,
+		remaining:  continuationAuditBlockBudget,
+	})
+}
+
+// auditContinuationBlock checks that every input a freshly fetched body spends
+// has a producer on the local applied chain, and logs loudly when one does not.
+// It is a diagnostic only: it never rejects a block, because the cross-fork
+// splice it detects is prevented upstream in chain.Chain.rollbackPointBlock and
+// any body that still slips through must reach the ledger's own validation and
+// the #2973 / #3008 guards unchanged.
+//
+// It is also skipped while block validation is off, which is how historical
+// catch-up runs: the splice this diagnoses is a live tip-band failure, and
+// bulk sync fetches far too many bodies per second to pay for the probes.
+//
+// Callers must hold ls.chainsyncBlockfetchMutex.
+func (ls *LedgerState) auditContinuationBlock(
+	e BlockfetchEvent,
+	validationEnabled bool,
+) {
+	if !validationEnabled {
+		return
+	}
+	window := ls.continuationAudit.Load()
+	if window == nil || window.remaining <= 0 || e.Block == nil {
+		return
+	}
+	// Bodies at or below the fork point are in-flight leftovers from the
+	// batch the rollback abandoned. They cannot extend the chain, so auditing
+	// them would only add noise.
+	if e.Point.Slot <= window.forkPoint.Slot {
+		return
+	}
+	window.remaining--
+	window.blocksSeen++
+	txs := e.Block.Transactions()
+	// Record this block's producers before checking its inputs. A later
+	// transaction may spend an output created by an earlier one in the same
+	// block, and treating the whole block as a producer errs toward silence
+	// rather than toward a false report.
+	if len(window.producedTxs)+len(txs) > continuationAuditMaxProducedTxs {
+		ls.config.Logger.Debug(
+			"disarming cross-fork continuation audit: producer set at capacity",
+			"component", "ledger",
+			"blocks_audited", window.blocksSeen,
+			"produced_txs", len(window.producedTxs),
+		)
+		window.remaining = 0
+		return
+	}
+	for _, tx := range txs {
+		window.producedTxs[string(tx.Hash().Bytes())] = struct{}{}
+	}
+	reports := 0
+	for _, tx := range txs {
+		for _, input := range collectReferencedInputs(tx) {
+			if reports >= continuationAuditMaxReportsPerBlock {
+				return
+			}
+			resolved, err := ls.continuationInputHasProducer(window, input)
+			if err != nil {
+				ls.config.Logger.Debug(
+					"cross-fork continuation audit could not resolve input",
+					"component", "ledger",
+					"error", err,
+					"slot", e.Point.Slot,
+					"input", input.String(),
+				)
+				continue
+			}
+			if resolved {
+				continue
+			}
+			reports++
+			ls.metrics.continuationInputUnresolved.Inc()
+			ls.config.Logger.Error(
+				"continuation block spends an input with no producer on the local applied chain",
+				"component", "ledger",
+				"peer", e.ConnectionId.String(),
+				"block_slot", e.Point.Slot,
+				"block_hash", hex.EncodeToString(e.Point.Hash),
+				"block_prev_hash",
+				e.Block.PrevHash().String(),
+				"tx_hash", tx.Hash().String(),
+				"input", input.String(),
+				"producer_tx_hash", input.Id().String(),
+				"fork_rollback_slot", window.forkPoint.Slot,
+				"fork_rollback_hash",
+				hex.EncodeToString(window.forkPoint.Hash),
+				"fork_reason", window.forkReason,
+				"fork_peer", window.forkPeer,
+				"blocks_since_fork", window.blocksSeen,
+			)
+		}
+	}
+}
+
+// continuationInputHasProducer reports whether an input's producing
+// transaction is reachable from the local chain: created by a block seen in
+// this audit window, still present as an unspent UTxO, or recorded in
+// transaction metadata as applied.
+func (ls *LedgerState) continuationInputHasProducer(
+	window *continuationAuditWindow,
+	input lcommon.TransactionInput,
+) (bool, error) {
+	producerId := input.Id().Bytes()
+	if _, ok := window.producedTxs[string(producerId)]; ok {
+		return true, nil
+	}
+	utxo, err := ls.db.UtxoByRef(producerId, input.Index(), nil)
+	if err != nil && !errors.Is(err, database.ErrUtxoNotFound) {
+		return false, err
+	}
+	if utxo != nil {
+		return true, nil
+	}
+	producerTx, err := ls.db.GetTransactionByHash(producerId, nil)
+	if err != nil {
+		return false, err
+	}
+	return producerTx != nil, nil
+}

--- a/ledger/crossfork_splice_test.go
+++ b/ledger/crossfork_splice_test.go
@@ -365,6 +365,41 @@ func TestContinuationAuditBudgetIsBounded(t *testing.T) {
 	assert.Equal(t, continuationAuditBlockBudget, window.blocksSeen)
 }
 
+// TestContinuationAuditIgnoresAbandonedFetchedBodies verifies that a body
+// delivered after a fork restart is not allowed to seed the producer window.
+// The body fails chain insertion, so the audit must not inspect it.
+func TestContinuationAuditIgnoresAbandonedFetchedBodies(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	var logBuf strings.Builder
+	ls.config.Logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+	ls.armContinuationAudit(fixture.ancestorTip.Point, "test rollback")
+
+	missing := mustSpliceAuditInput(t, testHashBytes("stale-producer"), 0)
+	stale := &spliceAuditBlock{
+		slot: 30,
+		hash: lcommon.NewBlake2b256(testHashBytes("stale-body")),
+		prevHash: lcommon.NewBlake2b256(
+			testHashBytes("abandoned-parent"),
+		),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(t, testHashBytes("stale-spender"),
+				[]lcommon.TransactionInput{missing}),
+		},
+	}
+	ls.pendingBlockfetchEvents = []BlockfetchEvent{{
+		ConnectionId: fixture.connId,
+		Block:        stale,
+		Point:        ocommon.NewPoint(stale.slot, stale.hash.Bytes()),
+	}}
+
+	require.NoError(t, ls.flushPendingBlockfetchBlocks())
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	assert.Equal(t, 0, window.blocksSeen)
+	assert.NotContains(t, logBuf.String(), "no producer on the local applied chain")
+}
+
 // findLogRecord returns the first JSON log record whose message matches msg.
 func findLogRecord(
 	t *testing.T,

--- a/ledger/crossfork_splice_test.go
+++ b/ledger/crossfork_splice_test.go
@@ -1,0 +1,389 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	omockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// TestChainsyncRollbackToAbandonedForkDoesNotSpliceChain is the ledger-level
+// regression for issue #3005.
+//
+// After the node abandons a fork, the rolled-back blocks stay resolvable
+// through the chain manager's retained block cache with the block indexes the
+// replacement fork now occupies. A peer that later asks the node to roll back
+// to one of those abandoned blocks used to be obeyed: the chain truncated to
+// the stale index and moved its tip to a block it no longer stored, so the next
+// block was appended above a parent that is absent from the chain. That splice
+// is what leaves a spender on the primary chain whose producing block was never
+// applied, which the ledger reports as an unresolvable producer and can never
+// replay past.
+//
+// The rollback must instead be refused as "point not found" so chainsync
+// re-intersects with the peer.
+func TestChainsyncRollbackToAbandonedForkDoesNotSpliceChain(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	abandonedPoint := fixture.currentTip.Point
+
+	// Abandon the block at slot 20 and replace its index with a fork block.
+	require.NoError(t, ls.chain.Rollback(fixture.ancestorTip.Point))
+	forkHash := testHashBytes("splice-fork-block")
+	require.NoError(t, ls.chain.AddRawBlocks(
+		[]chain.RawBlock{
+			{
+				Slot:        21,
+				Hash:        forkHash,
+				BlockNumber: fixture.ancestorTip.BlockNumber + 1,
+				Type:        1,
+				PrevHash:    fixture.ancestorTip.Point.Hash,
+				Cbor:        []byte{0x80},
+			},
+		},
+	))
+	forkTip := ls.chain.Tip()
+
+	// The abandoned block is still resolvable by point, and still claims the
+	// block index the fork block now holds. That is the precondition for the
+	// splice.
+	cached, err := ls.chain.BlockByPoint(abandonedPoint, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cached.ID)
+
+	err = ls.handleEventChainsyncRollback(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        abandonedPoint,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		forkTip,
+		ls.chain.Tip(),
+		"rollback to an abandoned fork block must leave the chain tip alone",
+	)
+	tipBlock, err := ls.chain.BlockByPoint(ls.chain.Tip().Point, nil)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		bytes.Equal(tipBlock.Hash, forkHash),
+		"chain tip must still be the block the chain actually stores",
+	)
+}
+
+// TestValidateRollbackRejectsAbandonedForkPoint covers the loop detector's
+// crossability pre-check on the same state: a point resolvable only out of the
+// retained cache must not be reported as a rollback the node can cross,
+// otherwise the detector keeps re-applying the splice instead of breaking the
+// loop.
+func TestValidateRollbackRejectsAbandonedForkPoint(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	abandonedPoint := fixture.currentTip.Point
+
+	require.NoError(t, ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, ls.chain.AddRawBlocks(
+		[]chain.RawBlock{
+			{
+				Slot:        21,
+				Hash:        testHashBytes("crossable-fork-block"),
+				BlockNumber: fixture.ancestorTip.BlockNumber + 1,
+				Type:        1,
+				PrevHash:    fixture.ancestorTip.Point.Hash,
+				Cbor:        []byte{0x80},
+			},
+		},
+	))
+
+	assert.False(
+		t,
+		ls.rollbackIsAppliable(abandonedPoint),
+		"a rollback to an abandoned fork block is not crossable",
+	)
+	assert.True(
+		t,
+		ls.rollbackIsAppliable(fixture.ancestorTip.Point),
+		"a rollback to a block still on the chain stays crossable",
+	)
+}
+
+// spliceAuditBlock is a minimal ledger.Block carrying a fixed transaction set.
+// Only the fields the continuation audit reads are meaningful; the transactions
+// themselves come from the shared ouroboros-mock builders.
+type spliceAuditBlock struct {
+	txs      []lcommon.Transaction
+	hash     lcommon.Blake2b256
+	prevHash lcommon.Blake2b256
+	slot     uint64
+}
+
+func (b *spliceAuditBlock) Hash() lcommon.Blake2b256     { return b.hash }
+func (b *spliceAuditBlock) PrevHash() lcommon.Blake2b256 { return b.prevHash }
+func (b *spliceAuditBlock) SlotNumber() uint64           { return b.slot }
+func (b *spliceAuditBlock) BlockNumber() uint64          { return 1 }
+func (b *spliceAuditBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+func (b *spliceAuditBlock) BlockBodySize() uint64 { return 0 }
+func (b *spliceAuditBlock) Era() lcommon.Era      { return lcommon.Era{} }
+func (b *spliceAuditBlock) Cbor() []byte          { return nil }
+func (b *spliceAuditBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+func (b *spliceAuditBlock) Header() lcommon.BlockHeader { return nil }
+func (b *spliceAuditBlock) Type() int                   { return 0 }
+func (b *spliceAuditBlock) Transactions() []lcommon.Transaction {
+	return b.txs
+}
+func (b *spliceAuditBlock) Utxorpc() (*utxorpc.Block, error) { return nil, nil }
+
+// spliceAuditAddr is an arbitrary well-formed testnet address; the mock
+// transaction builder requires at least one output.
+const spliceAuditAddr = "addr_test1qpe6s9amgfwtu9u6lqj998vke6uncswr4dg88qqft5d7f67kfjf77qy57hqhnefcqyy7hmhsygj9j38rj984hn9r57fswc4wg0"
+
+func mustSpliceAuditTx(
+	t *testing.T,
+	txId []byte,
+	inputs []lcommon.TransactionInput,
+) lcommon.Transaction {
+	t.Helper()
+	output, err := omockledger.NewTransactionOutputBuilder().
+		WithAddress(spliceAuditAddr).
+		WithLovelace(1_000_000).
+		Build()
+	require.NoError(t, err)
+	tx, err := omockledger.NewTransactionBuilder().
+		WithId(txId).
+		WithInputs(inputs...).
+		WithOutputs(output).
+		Build()
+	require.NoError(t, err)
+	return tx
+}
+
+func mustSpliceAuditInput(
+	t *testing.T,
+	txId []byte,
+	index uint32,
+) lcommon.TransactionInput {
+	t.Helper()
+	input, err := omockledger.NewTransactionInputBuilder().
+		WithTxId(txId).
+		WithIndex(index).
+		Build()
+	require.NoError(t, err)
+	return input
+}
+
+// TestContinuationAuditReportsUnresolvableProducer covers the diagnostic the
+// issue asked for: once a local rollback arms the audit, a fetched body that
+// spends an input with no producer on the local applied chain must be reported
+// loudly, naming the peer that delivered it and the fork the node rolled back
+// to.
+func TestContinuationAuditReportsUnresolvableProducer(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	var logBuf strings.Builder
+	ls.config.Logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+
+	// Not armed: the audit must be a no-op on the steady-state path.
+	missing := mustSpliceAuditInput(t, testHashBytes("absent-producer"), 0)
+	body := &spliceAuditBlock{
+		slot: 30,
+		hash: lcommon.NewBlake2b256(testHashBytes("continuation-block")),
+		prevHash: lcommon.NewBlake2b256(
+			testHashBytes("continuation-parent"),
+		),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("spender-tx"),
+				[]lcommon.TransactionInput{missing},
+			),
+		},
+	}
+	e := BlockfetchEvent{
+		ConnectionId: fixture.connId,
+		Block:        body,
+		Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+	}
+	ls.auditContinuationBlock(e, true)
+	require.Empty(
+		t,
+		logBuf.String(),
+		"audit must stay silent until a rollback arms it",
+	)
+
+	ls.armContinuationAudit(fixture.ancestorTip.Point, "test rollback")
+	// Armed, but block validation is off (historical catch-up): the probes
+	// are skipped so bulk sync does not pay for them.
+	ls.auditContinuationBlock(e, false)
+	require.Empty(
+		t,
+		logBuf.String(),
+		"audit must stay silent while block validation is disabled",
+	)
+
+	ls.auditContinuationBlock(e, true)
+
+	report := findLogRecord(
+		t,
+		logBuf.String(),
+		"continuation block spends an input with no producer on the local applied chain",
+	)
+	assert.Equal(t, float64(30), report["block_slot"])
+	assert.Equal(t, missing.String(), report["input"])
+	assert.Equal(t, fixture.connId.String(), report["peer"])
+	assert.Equal(
+		t,
+		float64(fixture.ancestorTip.Point.Slot),
+		report["fork_rollback_slot"],
+	)
+	assert.Equal(t, "test rollback", report["fork_reason"])
+}
+
+// TestContinuationAuditAcceptsProducerInSameWindow guards the audit against
+// false positives: blockfetch runs ahead of ledger application, so a producer
+// delivered earlier in the same audit window is on the local chain even though
+// no UTxO row exists for it yet.
+func TestContinuationAuditAcceptsProducerInSameWindow(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	var logBuf strings.Builder
+	ls.config.Logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+	ls.armContinuationAudit(fixture.ancestorTip.Point, "test rollback")
+
+	producerTxId := testHashBytes("in-window-producer")
+	producerBlock := &spliceAuditBlock{
+		slot: 30,
+		hash: lcommon.NewBlake2b256(testHashBytes("producer-block")),
+		txs: []lcommon.Transaction{
+			// The mock builder requires an input; point it at this same
+			// transaction so the producer block reports nothing of its own
+			// and the assertion below isolates the spender's input.
+			mustSpliceAuditTx(
+				t,
+				producerTxId,
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, producerTxId, 9),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: fixture.connId,
+		Block:        producerBlock,
+		Point: ocommon.NewPoint(
+			producerBlock.slot,
+			producerBlock.hash.Bytes(),
+		),
+	}, true)
+
+	spenderBlock := &spliceAuditBlock{
+		slot: 40,
+		hash: lcommon.NewBlake2b256(testHashBytes("spender-block")),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("in-window-spender"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, producerTxId, 0),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: fixture.connId,
+		Block:        spenderBlock,
+		Point: ocommon.NewPoint(
+			spenderBlock.slot,
+			spenderBlock.hash.Bytes(),
+		),
+	}, true)
+
+	assert.NotContains(
+		t,
+		logBuf.String(),
+		"no producer on the local applied chain",
+		"a producer delivered earlier in the window must not be reported",
+	)
+	assert.Equal(
+		t,
+		2,
+		ls.continuationAudit.Load().blocksSeen,
+		"both bodies must have been audited",
+	)
+}
+
+// TestContinuationAuditBudgetIsBounded verifies the audit stops on its own so a
+// long-lived node never pays for it outside a fork-churn window.
+func TestContinuationAuditBudgetIsBounded(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	ls.config.Logger = slog.New(slog.NewJSONHandler(&strings.Builder{}, nil))
+	ls.armContinuationAudit(fixture.ancestorTip.Point, "test rollback")
+
+	empty := &spliceAuditBlock{
+		slot: 30,
+		hash: lcommon.NewBlake2b256(testHashBytes("empty-block")),
+	}
+	e := BlockfetchEvent{
+		ConnectionId: fixture.connId,
+		Block:        empty,
+		Point:        ocommon.NewPoint(empty.slot, empty.hash.Bytes()),
+	}
+	for range continuationAuditBlockBudget + 5 {
+		ls.auditContinuationBlock(e, true)
+	}
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	assert.Equal(t, 0, window.remaining)
+	assert.Equal(t, continuationAuditBlockBudget, window.blocksSeen)
+}
+
+// findLogRecord returns the first JSON log record whose message matches msg.
+func findLogRecord(
+	t *testing.T,
+	logs string,
+	msg string,
+) map[string]any {
+	t.Helper()
+	for line := range strings.SplitSeq(strings.TrimSpace(logs), "\n") {
+		if line == "" {
+			continue
+		}
+		record := map[string]any{}
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		if record["msg"] == msg {
+			return record
+		}
+	}
+	t.Fatalf("no log record with message %q in:\n%s", msg, logs)
+	return nil
+}

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -54,6 +54,11 @@ type stateMetrics struct {
 	// to move the applied ledger tip forward and holds at that tip instead of
 	// pruning another security-parameter window. See issue #3005.
 	replayRecoveryNonConverging prometheus.Counter
+	// Incremented when the cross-fork continuation audit finds a freshly
+	// fetched body spending an input whose producing transaction is not on
+	// the local applied chain. A rising value means a peer is feeding the
+	// node a continuation from a fork it never applied. See issue #3005.
+	continuationInputUnresolved prometheus.Counter
 }
 
 func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
@@ -163,6 +168,12 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.CounterOpts{
 			Name: "dingo_ledger_replay_recovery_nonconverging_total",
 			Help: "times unresolved-producer replay recovery held at the applied ledger tip because repeated recovery attempts made no forward progress",
+		},
+	)
+	m.continuationInputUnresolved = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_ledger_continuation_input_unresolved_total",
+			Help: "inputs in freshly fetched continuation blocks whose producing transaction is not on the local applied chain (cross-fork splice indicator)",
 		},
 	)
 }

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -285,6 +285,7 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 		// cannot suppress the fresh ChainSync intersection.
 		ls.publishReplayRecoveryNonConvergingResync(rewindPoint)
 	}
+	primaryChainRewound := false
 	if rewindPrimaryChain && !primaryChainAlreadyHeld {
 		if err := ls.rollbackPrimaryChainInSecurityParamWindows(
 			rewindPoint,
@@ -294,6 +295,7 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 				err,
 			)
 		}
+		primaryChainRewound = true
 	}
 	// The chain moves first while the rollback anchor is guaranteed to remain
 	// available. If metadata synchronization fails, the primary chain is still
@@ -305,10 +307,15 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 			err,
 		)
 	}
-	// Recovery rewound the ledger (and usually the chain) to rewindPoint, so
-	// arm the continuation audit to attribute the next offending body to a
-	// peer and a fork instead of only reporting the unresolvable producer.
-	ls.armContinuationAudit(rewindPoint, "replay recovery rewind")
+	// Arm only when the corrective primary-chain rewind actually happened and
+	// metadata now sits at that same point. A replay target ahead of the
+	// applied tip would otherwise make the audit treat an unapplied gap as a
+	// cross-fork continuation and produce false diagnostics.
+	if primaryChainRewound &&
+		pointMatches(ls.chain.Tip().Point, rewindPoint) &&
+		pointMatches(ls.Tip().Point, rewindPoint) {
+		ls.armContinuationAudit(rewindPoint, "replay recovery rewind")
+	}
 	return true, nil
 }
 

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -305,6 +305,10 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 			err,
 		)
 	}
+	// Recovery rewound the ledger (and usually the chain) to rewindPoint, so
+	// arm the continuation audit to attribute the next offending body to a
+	// peer and a fork instead of only reporting the unresolvable producer.
+	ls.armContinuationAudit(rewindPoint, "replay recovery rewind")
 	return true, nil
 }
 

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -1607,6 +1607,112 @@ func TestTryRecoverFromTxValidationErrorReplayFallbackStopsNonConvergingRewinds(
 	assert.Equal(t, ledgerTip.Point, freshResync.Point)
 }
 
+// newReplayRecoveryAuditLedger builds the fallback topology with an
+// unresolved producer. When primaryAhead is false, the primary chain is
+// already below the ledger tip, matching the held-recovery path.
+func newReplayRecoveryAuditLedger(
+	t *testing.T,
+	primaryAhead bool,
+) *LedgerState {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	parentBlock := testRawBlock("audit-parent", 100, 1, nil)
+	replayBlock := testRawBlock("audit-replay", 120, 2, parentBlock.Hash)
+	ledgerTipBlock := testRawBlock("audit-ledger-tip", 140, 3, replayBlock.Hash)
+	failingBlock := testRawBlock("audit-failing", 160, 4, ledgerTipBlock.Hash)
+	blocks := []chain.RawBlock{parentBlock, replayBlock}
+	if primaryAhead {
+		blocks = append(blocks, ledgerTipBlock, failingBlock)
+	}
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(blocks))
+	if !primaryAhead {
+		for _, block := range []chain.RawBlock{ledgerTipBlock, failingBlock} {
+			require.NoError(t, db.BlockCreate(models.Block{
+				Hash: block.Hash, PrevHash: block.PrevHash, Cbor: block.Cbor,
+				Slot: block.Slot, Number: block.BlockNumber, Type: block.Type,
+			}, nil))
+		}
+	}
+
+	nodeConfig := newTestShelleyGenesisCfg(t)
+	nodeConfig.ShelleyGenesis().SecurityParam = 2
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: nodeConfig,
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
+	ls.metrics.init(prometheus.NewRegistry())
+	ls.validationEnabled = true
+
+	ledgerTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(ledgerTipBlock.Slot, ledgerTipBlock.Hash),
+		BlockNumber: ledgerTipBlock.BlockNumber,
+	}
+	for _, tip := range []ochainsync.Tip{
+		{Point: ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash), BlockNumber: parentBlock.BlockNumber},
+		ledgerTip,
+	} {
+		require.NoError(t, db.SetBlockNonce(tip.Point.Hash, tip.Point.Slot, []byte("nonce"), false, nil))
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+	ls.currentTip = ledgerTip
+	ls.currentTipBlockNonce = []byte("nonce")
+	ls.reachedTip.Store(false)
+	ls.publishSnapshotsLocked()
+
+	if !primaryAhead {
+		require.False(t, ls.observeReplayRecoveryTip(ledgerTip.Point.Slot))
+		require.False(t, ls.observeReplayRecoveryTip(ledgerTip.Point.Slot))
+		require.True(t, ls.observeReplayRecoveryTip(ledgerTip.Point.Slot))
+	}
+	return ls
+}
+
+func TestReplayRecoveryArmsAuditAfterPrimaryAndLedgerRewind(t *testing.T) {
+	ls := newReplayRecoveryAuditLedger(t, true)
+
+	recovered, err := ls.tryRecoverFromTxValidationError(&txValidationError{
+		BlockPoint: ocommon.NewPoint(160, testHashBytes("audit-failing")),
+		TxHash:     testHashBytes("audit-failing-tx"),
+		Inputs: []lcommon.TransactionInput{
+			&replayRecoveryInput{txId: testHashBytes("missing-audit-producer")},
+		},
+		Cause: errors.New("bad input"),
+	})
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Equal(t, ls.Tip().Point, ls.chain.Tip().Point)
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	assert.Equal(t, ls.Tip().Point, window.forkPoint)
+}
+
+func TestReplayRecoveryDoesNotArmAuditWhenPrimaryAlreadyHeld(t *testing.T) {
+	ls := newReplayRecoveryAuditLedger(t, false)
+
+	recovered, err := ls.tryRecoverFromTxValidationError(&txValidationError{
+		BlockPoint: ocommon.NewPoint(160, testHashBytes("audit-failing")),
+		TxHash:     testHashBytes("audit-held-failing-tx"),
+		Inputs: []lcommon.TransactionInput{
+			&replayRecoveryInput{txId: testHashBytes("missing-held-audit-producer")},
+		},
+		Cause: errors.New("bad input"),
+	})
+	require.NoError(t, err)
+	require.True(t, recovered)
+	assert.Less(t, ls.chain.Tip().Point.Slot, ls.Tip().Point.Slot)
+	assert.Equal(t, ocommon.Point{Slot: 140, Hash: testHashBytes("audit-ledger-tip")}, ls.Tip().Point)
+	assert.Nil(t, ls.continuationAudit.Load())
+}
+
 func TestResetReplayRecoveryNonProgressRequiresNewHighWater(t *testing.T) {
 	ls := &LedgerState{}
 	require.False(t, ls.observeReplayRecoveryTip(140))

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -674,10 +674,14 @@ type LedgerState struct {
 	replayRecoveryHighWaterSlot   uint64
 	replayRecoveryNoProgressCount int
 	replayRecoveryHolding         bool
-	mithrilLedgerSlot             uint64 // blocks at or below this slot are Mithril-verified; skip validation
-	mithrilLedgerHash             []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
-	lastLocalRollbackSeq          uint64
-	lastLocalRollbackPoint        ocommon.Point
+	// Cross-fork continuation audit (issue #3005). Armed by a local
+	// rollback and consumed by the blockfetch handler; see
+	// ledger/continuation_audit.go for the cost and soundness argument.
+	continuationAudit      atomic.Pointer[continuationAuditWindow]
+	mithrilLedgerSlot      uint64 // blocks at or below this slot are Mithril-verified; skip validation
+	mithrilLedgerHash      []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
+	lastLocalRollbackSeq   uint64
+	lastLocalRollbackPoint ocommon.Point
 
 	// Subscription IDs for event bus unsubscribe on close
 	chainsyncSubID           event.EventSubscriberId
@@ -2487,6 +2491,10 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	if err := ls.rollback(point); err != nil {
 		return fmt.Errorf("synchronize ledger rollback state: %w", err)
 	}
+	// Chain and ledger now sit at the same point, so every block above it
+	// arrives through blockfetch and the continuation audit can resolve
+	// producers without a chain scan.
+	ls.armContinuationAudit(point, "chainsync rollback")
 	return nil
 }
 


### PR DESCRIPTION
Closes #3005 

Rolled-back blocks stay resolvable through the chain manager's retained LRU cache. That retention is deliberate: ephemeral fork chains reconcile against the primary chain by walking prev-hash links and must still be able to resolve blocks the primary chain abandoned. But a retained block also keeps reporting the block index it used to occupy, and both Chain.Rollback and Chain.ValidateRollback resolved their target through that cache.

So a peer offering a rollback to a block the node had already abandoned was obeyed: the chain truncated to a stale index a competing fork had since taken over, currentTip named a block the chain no longer stored, and every block appended afterwards was spliced onto a parent absent from the chain. That splice puts a spender on the primary chain whose producing block was never applied, so the ledger cannot resolve the producer through UtxoByRef, transaction metadata, the tx blob, or the backward chain scan, and rewinding and replaying reproduces the same missing-UTxO state forever. #2999 (chain selection) and #3008 (replay non-convergence guard) moved and bounded that wedge without removing it, because the inconsistent chain was assembled upstream of both.

Chain.rollbackPointBlock now resolves both rollback entry points and rejects any target the chain does not hold at the resolved index, returning chain.ErrRollbackPointNotOnChain (wrapping models.ErrBlockNotFound) so callers re-intersect instead of splicing. The invariant is that currentTip always names the block stored at tipBlockIndex, which is what makes the prev-hash check in addBlockLocked/addRawBlockLocked meaningful. tryResolveFork gets the same "point not found" handling the chainsync rollback handler already had. Each rejection logs "cross-fork splice prevented" and increments dingo_chain_rollback_point_not_on_chain_total.

Two shapes are rejected: a resolved index at or below the tip holding a different block, and a resolved index ahead of the tip, which set tipBlockIndex past the last stored block and punched a hole that chain iteration stops at. Both are refused as not-on-chain and deliberately NOT as ErrRollbackExceedsSecurityParam: #3035 was a node permanently denying every peer because the ahead-of-tip case was misclassified as over-K, and an over-K rejection is unrecoverable where a not-found rejection re-intersects. rollbackForkDepth keeps the saturating arithmetic that fixed that uint64 underflow; it is no longer reached with an above-tip index from either entry point, so
TestRollbackForkDepthSaturates now covers it directly. TestChainRollbackPointAheadOfTipIsNotDeepFork (from #3040) is updated to assert the new refusal while still pinning that it is not an over-K rejection, so #3035 cannot regress silently.

Also adds the requested attribution diagnostic. A local rollback arms a bounded per-input continuation audit (ledger/continuation_audit.go): each body blockfetch delivers above the rollback point is checked input by input, and any input whose producing transaction is not on the local applied chain is logged with the delivering peer, the offending input, and the fork point, plus
dingo_ledger_continuation_input_unresolved_total. Arming on rollback is both the cost gate and what makes the check sound, since a rollback leaves chain and ledger at the same point; it is further gated to validation-enabled operation so bulk sync pays nothing. The audit never rejects a block, so the #2973 and #3008 guards are untouched.

DevNet does not reproduce the cross-fork splice, so it can only show absence of regression, not validate this fix. Across two gated runs the splice guard never fired and the audit reported nothing despite 6-7 rollbacks per run arming it, with no resync storms and scenario failures matching the unrelated #3029 wedge at baseline levels. The condition needs the preview from-genesis tip band under real fork churn; nothing here should be loosened to make it fire on DevNet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject rollbacks to points the node no longer holds to stop cross-fork splices that corrupt the chain tip. Harden fork-resolution and the continuation audit by gating replay-recovery arming and auditing only after safe chain extension.

- **Bug Fixes**
  - `chain`: Resolve rollback targets via `rollbackPointBlock`; reject targets not on the current chain with `ErrRollbackPointNotOnChain` (wraps `models.ErrBlockNotFound`); avoids ahead-of-tip over-K misclassification; logs a prevention message and increments `dingo_chain_rollback_point_not_on_chain_total`.
  - `ledger`: `tryResolveFork` re-intersects on “point not found,” preserves rollback evidence across reset/reconnect and clears it on forward progress.

- **New Features**
  - `ledger`: Continuation audit armed on chainsync rollback and replay-recovery rewind; now only arms when the primary chain actually rewinds and the ledger matches; runs after a body extends the queued chain, skips while validation is off, and caps per-block probes/reports; logs unresolved inputs with peer, block, and fork details; tracked via `dingo_ledger_continuation_input_unresolved_total`.

<sup>Written for commit 67dfea3bbcc5f1a65a9bc234eb17431d5f431ecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rollbacks to blocks from abandoned forks or beyond the current chain tip.
  * Preserved chain continuity and tip state when invalid rollback targets are rejected.
  * Improved fork recovery by requesting re-intersection when a common ancestor is unavailable.
  * Ensured abandoned fetched blocks do not affect recovery validation.

* **Monitoring**
  * Added metrics and diagnostics for rejected rollback targets and unresolved continuation inputs.

* **Reliability**
  * Added bounded validation of recovered transaction continuations to identify unresolved inputs without disrupting block processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->