### PR TITLE
ci(antithesis): submit runs without polling by default

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -15,6 +15,10 @@ on:
         description: 'Disable fault injection'
         type: boolean
         default: false
+      poll_results:
+        description: 'Poll Antithesis until the test completes (default: submit and exit)'
+        type: boolean
+        default: false
       moog_tag:
         # The deployed MPFS at mpfs.plutimus.com runs the moog v0.5.x line, so
         # the requester CLI must match it (same pin as the cardano-foundation
@@ -30,8 +34,8 @@ on:
 concurrency:
   group: antithesis
   # Once submitted, an Antithesis test continues running outside GitHub.
-  # Keep its polling workflow alive so the result is not lost and the next
-  # test waits for the active run to finish.
+  # The default workflow exits after submission; callers can opt into polling
+  # with the poll_results dispatch input.
   cancel-in-progress: false
 
 env:
@@ -226,8 +230,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 600
-    # Shared Moog env for the submit + wait steps (the wait step polls
-    # MOOG_MPFS_HOST read-only, so it needs the same host/token/requester).
+    # Shared Moog env for the submit and optional wait steps. The default path
+    # submits the test and exits without querying its status.
     env:
       MOOG_WALLET_FILE: wallet.json
       MOOG_MPFS_HOST: ${{ vars.MOOG_MPFS_HOST || 'https://mpfs.plutimus.com' }}
@@ -248,9 +252,6 @@ jobs:
             echo "::error::Duration must be at least one hour"
             exit 1
           fi
-          # The wait step allows one extra hour for Antithesis to publish the
-          # result. Leave another hour for this job's setup and cleanup within
-          # its 600-minute timeout.
           if ((HOURS > 8)); then
             echo "::error::Duration must be no more than 8 hours"
             exit 1
@@ -331,8 +332,11 @@ jobs:
           NO_FAULTS: ${{ inputs.no_faults || 'false' }}
           DURATION_HOURS: ${{ steps.duration.outputs.hours }}
 
-      - name: Wait for results
+      - name: Poll for results
+        if: inputs.poll_results == true
         run: |
+          # Polling is opt-in. The normal workflow path ends after the
+          # submission step, while Antithesis continues independently.
           timeout $(((DURATION_HOURS + 1) * 3600)) \
             ./internal/test/antithesis/scripts/wait-for-test.sh \
             "$ANTITHESIS_TEST_RUN_ID"

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -35,7 +35,10 @@ concurrency:
   group: antithesis
   # Once submitted, an Antithesis test continues running outside GitHub.
   # The default workflow exits after submission; callers can opt into polling
-  # with the poll_results dispatch input.
+  # with the poll_results dispatch input. Submit-only mode releases this
+  # GitHub Actions lock when submission finishes, so it cannot serialize
+  # external Antithesis runs; use poll_results=true when that serialization is
+  # required.
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -60,6 +60,8 @@ jobs:
         run: echo "tag=sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.2.0
+      - name: Validate Antithesis testnet wiring
+        run: internal/test/antithesis/scripts/validate-config.sh
       - name: Login to GHCR
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0 https://github.com/docker/login-action/releases/tag/v4.0.0
         with:

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -28,6 +28,7 @@
 #   CARDANO_DATABASE_PATH - Database storage location (default: /data/db)
 #   DINGO_SOCKET_PATH     - Unix socket path for NtC (default: /ipc/dingo.socket)
 #   DINGO_DEBUG           - Set to any value to enable debug logging and set -x
+#   DINGO_LOG_FILE        - Optional file receiving dingo stdout/stderr
 #   RESTORE_SNAPSHOT      - Set to any value to bootstrap from Mithril snapshot on first run
 
 set -euo pipefail
@@ -244,8 +245,16 @@ fi
 
 log "Starting dingo ${DINGO_ARGS[*]}"
 
-# Start dingo in the background so we can forward signals
-dingo "${DINGO_ARGS[@]}" &
+# Persist structured output for test harnesses when requested, while keeping
+# stdout as the default for normal deployments.
+if [[ -n "${DINGO_LOG_FILE:-}" ]]; then
+  mkdir -p "$(dirname "${DINGO_LOG_FILE}")"
+  touch "${DINGO_LOG_FILE}"
+  chmod 0644 "${DINGO_LOG_FILE}"
+  dingo "${DINGO_ARGS[@]}" >>"${DINGO_LOG_FILE}" 2>&1 &
+else
+  dingo "${DINGO_ARGS[@]}" &
+fi
 DINGO_PID=$!
 trap cleanup SIGTERM SIGINT
 

--- a/internal/test/antithesis/Dockerfile.analysis
+++ b/internal/test/antithesis/Dockerfile.analysis
@@ -15,7 +15,7 @@ FROM debian:bookworm-slim
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-RUN useradd -m analysis
+RUN useradd --uid 1000 -m analysis
 COPY --from=build /code/analysis /bin/analysis
 USER analysis
 ENTRYPOINT ["/bin/analysis"]

--- a/internal/test/antithesis/Dockerfile.configurator
+++ b/internal/test/antithesis/Dockerfile.configurator
@@ -56,6 +56,7 @@ RUN chmod 0755 /configurator.sh && \
         /configs/4 /configs/4/configs \
         /configs/5 /configs/5/configs \
         /configs/utxo-keys \
+        /logs \
         /tmp/testnet && \
     chown -R cardano:cardano \
         /home/cardano \

--- a/internal/test/antithesis/Dockerfile.txpump
+++ b/internal/test/antithesis/Dockerfile.txpump
@@ -1,3 +1,5 @@
+FROM ghcr.io/blinklabs-io/cardano-cli:11.0.0.0-1 AS cardano-cli
+
 FROM ghcr.io/blinklabs-io/go:1.25.7-1 AS build
 
 WORKDIR /code
@@ -14,8 +16,14 @@ RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache \
 
 FROM debian:bookworm-slim
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get install -y --no-install-recommends ca-certificates passwd && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /logs
+COPY --from=cardano-cli /usr/local/bin/cardano-cli /usr/local/bin/cardano-cli
+COPY --from=cardano-cli /usr/local/lib/ /usr/local/lib/
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+RUN useradd --uid 1000 --create-home --shell /bin/sh txpump && \
+    mkdir -p /logs && chmod 0777 /logs
 COPY --from=build /code/txpump /bin/txpump
-ENTRYPOINT ["/bin/txpump"]
+COPY internal/test/antithesis/scripts/txpump-entrypoint.sh /bin/txpump-entrypoint.sh
+RUN chmod 0755 /bin/txpump-entrypoint.sh
+ENTRYPOINT ["/bin/txpump-entrypoint.sh"]

--- a/internal/test/antithesis/cmd/txpump/main.go
+++ b/internal/test/antithesis/cmd/txpump/main.go
@@ -147,6 +147,7 @@ func main() {
 		"tx_count_min", cfg.TxCountMin,
 		"tx_count_max", cfg.TxCountMax,
 		"types", cfg.Types,
+		"startup_timeout", cfg.StartupTimeout,
 	)
 
 	runErr := pump.Run(ctx)

--- a/internal/test/antithesis/docker-compose.yaml
+++ b/internal/test/antithesis/docker-compose.yaml
@@ -218,6 +218,7 @@ services:
       TXPUMP_COOLDOWN_MIN: "5"
       TXPUMP_COOLDOWN_MAX: "15"
       TXPUMP_TYPES: "payment,delegation,governance,plutus"
+      TXPUMP_STARTUP_TIMEOUT: "60"
       TXPUMP_GENESIS_FILE: "/testnet/testnet.yaml"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:

--- a/internal/test/antithesis/docker-compose.yaml
+++ b/internal/test/antithesis/docker-compose.yaml
@@ -91,7 +91,9 @@ services:
       CARDANO_TOPOLOGY: /configs/configs/dingo-topology.json
       CARDANO_DATABASE_PATH: /data/db
       CARDANO_NODE_SOCKET_PATH: /ipc/dingo.socket
-      DINGO_DEBUG: "1"
+      CARDANO_PRIVATE_BIND_ADDR: "0.0.0.0"
+      DINGO_LOGGING_FORMAT: json
+      DINGO_LOGGING_LEVEL: info
       # Block production credentials (pool 1)
       CARDANO_BLOCK_PRODUCER: "true"
       CARDANO_SHELLEY_VRF_KEY: /configs/keys/vrf.skey
@@ -215,9 +217,9 @@ services:
       TXPUMP_TX_COUNT_MAX: "50"
       TXPUMP_COOLDOWN_MIN: "5"
       TXPUMP_COOLDOWN_MAX: "15"
-      TXPUMP_TYPES: "payment"
+      TXPUMP_TYPES: "payment,delegation,governance,plutus"
       TXPUMP_GENESIS_FILE: "/testnet/testnet.yaml"
-      TXPUMP_GENESIS_UTXO_FILE: "/configs/configs/shelley-genesis.json"
+      TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:
       - ./testnet.yaml:/testnet/testnet.yaml:ro
       - p1-configs:/configs:ro

--- a/internal/test/antithesis/internal/analysis/analysis.go
+++ b/internal/test/antithesis/internal/analysis/analysis.go
@@ -23,7 +23,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -32,11 +34,12 @@ var nodeLogName = regexp.MustCompile(`^p([0-9]+)(?:[._-].*)?\.log(?:\.[0-9]+)?$`
 // fileState tracks the read position within a single log file so that
 // successive checks only process new lines.
 type fileState struct {
-	path    string
-	nodeID  string
-	offset  int64
-	modTime time.Time
-	warned  bool
+	path     string
+	nodeID   string
+	identity string
+	offset   int64
+	modTime  time.Time
+	warned   bool
 }
 
 type ingestionStats struct {
@@ -55,23 +58,24 @@ type Analyzer struct {
 	cfg                 *Config
 	metrics             *Metrics
 	files               map[string]*fileState // keyed by file path
+	filesByIdentity     map[string]*fileState
 	logger              *slog.Logger
 	setupDone           bool
 	setupComplete       func()
 	ingestion           ingestionStats
 	observabilityWarned bool
-	directoryWarned     bool
 	walkWarnings        map[string]struct{}
 }
 
 // NewAnalyzer creates an Analyzer with the given config and a fresh Metrics.
 func NewAnalyzer(cfg *Config, logger *slog.Logger) *Analyzer {
 	return &Analyzer{
-		cfg:           cfg,
-		metrics:       NewMetrics(),
-		files:         make(map[string]*fileState),
-		logger:        logger,
-		setupComplete: SetupComplete,
+		cfg:             cfg,
+		metrics:         NewMetrics(),
+		files:           make(map[string]*fileState),
+		filesByIdentity: make(map[string]*fileState),
+		logger:          logger,
+		setupComplete:   SetupComplete,
 		ingestion: ingestionStats{
 			nodeFiles:    make(map[string]struct{}),
 			nodeReadable: make(map[string]struct{}),
@@ -134,7 +138,7 @@ func (a *Analyzer) check() {
 }
 
 func (a *Analyzer) reportObservability(snap MetricsSnapshot) {
-	Always(a.ingestion.nodeEvents > 0, "node-log-observability", map[string]interface{}{
+	Always(len(a.ingestion.nodeReadable) > 0, "node-log-observability", map[string]interface{}{
 		"node_files":          len(a.ingestion.nodeFiles),
 		"readable_node_files": len(a.ingestion.nodeReadable),
 		"node_log_bytes":      a.ingestion.nodeBytes,
@@ -173,7 +177,10 @@ func (a *Analyzer) readNewLines() {
 	// numbered rotations behind. Walk the volume and select only known names.
 	currentNodeFiles := make(map[string]struct{})
 	currentReadable := make(map[string]struct{})
-	err := filepath.WalkDir(a.cfg.LogDir, func(path string, entry os.DirEntry, walkErr error) error {
+	a.ingestion.txpumpReadable = false
+	type logFile struct{ path, role, nodeID string }
+	var logFiles []logFile
+	_ = filepath.WalkDir(a.cfg.LogDir, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			if _, warned := a.walkWarnings[path]; !warned {
 				a.logger.Warn("cannot inspect log path", "path", path, "err", walkErr)
@@ -191,22 +198,27 @@ func (a *Analyzer) readNewLines() {
 		if role == "node" {
 			currentNodeFiles[path] = struct{}{}
 		}
-		if a.readFile(path, role, nodeID) {
-			if role == "node" {
-				currentReadable[path] = struct{}{}
+		logFiles = append(logFiles, logFile{path: path, role: role, nodeID: nodeID})
+		return nil
+	})
+	// Prefer active files over rotations so a renamed active file is not used
+	// as the canonical state when both paths refer to the same inode.
+	sort.Slice(logFiles, func(i, j int) bool {
+		iRotated := isRotatedLog(logFiles[i].path)
+		jRotated := isRotatedLog(logFiles[j].path)
+		if iRotated != jRotated {
+			return !iRotated
+		}
+		return logFiles[i].path < logFiles[j].path
+	})
+	for _, logFile := range logFiles {
+		if a.readFile(logFile.path, logFile.role, logFile.nodeID) {
+			if logFile.role == "node" {
+				currentReadable[logFile.path] = struct{}{}
 			} else {
 				a.ingestion.txpumpReadable = true
 			}
 		}
-		return nil
-	})
-	if err != nil {
-		if !a.directoryWarned {
-			a.logger.Warn("cannot inspect log directory", "path", a.cfg.LogDir, "err", err)
-			a.directoryWarned = true
-		}
-	} else {
-		a.directoryWarned = false
 	}
 	a.ingestion.nodeFiles = currentNodeFiles
 	a.ingestion.nodeReadable = currentReadable
@@ -220,7 +232,6 @@ func (a *Analyzer) readFile(path, role, nodeID string) bool {
 		state = &fileState{path: path, nodeID: nodeID}
 		a.files[path] = state
 	}
-
 	//nolint:gosec // log file path derived from config, not user input
 	f, err := os.Open(path)
 	if err != nil {
@@ -232,13 +243,32 @@ func (a *Analyzer) readFile(path, role, nodeID string) bool {
 		return false
 	}
 	defer f.Close() //nolint:errcheck // read-only open
-	state.warned = false
-	if role == "node" {
-		a.ingestion.nodeReadable[path] = struct{}{}
-	}
-
-	// Fix 7: detect file truncation (e.g. log rotation) and reset.
 	info, err := f.Stat()
+	identity := fileIdentity(info)
+	if ok && state.identity != "" && state.identity != identity {
+		state = nil
+	}
+	if state == nil && identity != "" {
+		state = a.filesByIdentity[identity]
+	}
+	if state == nil {
+		state = &fileState{path: path, nodeID: nodeID}
+	}
+	if identity != "" {
+		if existing := a.filesByIdentity[identity]; existing != nil && existing != state {
+			// A rotated file is the same inode under a new path. It has already
+			// been consumed during this pass under the active path.
+			return true
+		}
+		state.identity = identity
+		a.filesByIdentity[identity] = state
+	}
+	state.path = path
+	state.nodeID = nodeID
+	a.files[path] = state
+	state.warned = false
+
+	// Detect file truncation (e.g. a logger restarting in place) and reset.
 	if err == nil && (info.Size() < state.offset ||
 		(!state.modTime.IsZero() && !info.ModTime().Equal(state.modTime) && info.Size() <= state.offset)) {
 		a.logger.Info("log file truncated, resetting offset", "path", path)
@@ -298,6 +328,22 @@ func (a *Analyzer) readFile(path, role, nodeID string) bool {
 		a.ingestion.nodeBytes += bytesRead
 	}
 	return true
+}
+
+func fileIdentity(info os.FileInfo) string {
+	if info == nil {
+		return ""
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino)
+}
+
+func isRotatedLog(path string) bool {
+	base := filepath.Base(path)
+	return strings.Contains(base, ".log.")
 }
 
 // reportSafetyAssertions evaluates safety properties and fires assertions.

--- a/internal/test/antithesis/internal/analysis/analysis.go
+++ b/internal/test/antithesis/internal/analysis/analysis.go
@@ -22,27 +22,46 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
 
+var nodeLogName = regexp.MustCompile(`^p([0-9]+)(?:[._-].*)?\.log(?:\.[0-9]+)?$`)
+
 // fileState tracks the read position within a single log file so that
 // successive checks only process new lines.
 type fileState struct {
-	path   string
-	nodeID string
-	offset int64
+	path    string
+	nodeID  string
+	offset  int64
+	modTime time.Time
+	warned  bool
+}
+
+type ingestionStats struct {
+	nodeFiles      map[string]struct{}
+	nodeReadable   map[string]struct{}
+	nodeBytes      int64
+	nodeEvents     int
+	openFailures   int
+	txpumpReadable bool
+	txpumpEvents   int
 }
 
 // Analyzer reads node log files, parses events, and reports Antithesis
 // assertions on each check interval.
 type Analyzer struct {
-	cfg           *Config
-	metrics       *Metrics
-	files         map[string]*fileState // keyed by file path
-	logger        *slog.Logger
-	setupDone     bool
-	setupComplete func()
+	cfg                 *Config
+	metrics             *Metrics
+	files               map[string]*fileState // keyed by file path
+	logger              *slog.Logger
+	setupDone           bool
+	setupComplete       func()
+	ingestion           ingestionStats
+	observabilityWarned bool
+	directoryWarned     bool
+	walkWarnings        map[string]struct{}
 }
 
 // NewAnalyzer creates an Analyzer with the given config and a fresh Metrics.
@@ -53,6 +72,11 @@ func NewAnalyzer(cfg *Config, logger *slog.Logger) *Analyzer {
 		files:         make(map[string]*fileState),
 		logger:        logger,
 		setupComplete: SetupComplete,
+		ingestion: ingestionStats{
+			nodeFiles:    make(map[string]struct{}),
+			nodeReadable: make(map[string]struct{}),
+		},
+		walkWarnings: make(map[string]struct{}),
 	}
 }
 
@@ -101,9 +125,35 @@ func (a *Analyzer) Run(ctx context.Context) error {
 func (a *Analyzer) check() {
 	a.readNewLines()
 	snap := a.metrics.Snapshot()
+	a.reportObservability(snap)
 	a.reportSafetyAssertions(&snap)
-	a.reportLivenessAssertions(&snap)
+	if a.ingestion.nodeEvents > 0 {
+		a.reportLivenessAssertions(&snap)
+	}
 	a.reportReachable(&snap)
+}
+
+func (a *Analyzer) reportObservability(snap MetricsSnapshot) {
+	Always(a.ingestion.nodeEvents > 0, "node-log-observability", map[string]interface{}{
+		"node_files":          len(a.ingestion.nodeFiles),
+		"readable_node_files": len(a.ingestion.nodeReadable),
+		"node_log_bytes":      a.ingestion.nodeBytes,
+		"node_events":         a.ingestion.nodeEvents,
+		"open_failures":       a.ingestion.openFailures,
+		"forged_blocks":       snap.TotalBlocksForged,
+		"txpump_readable":     a.ingestion.txpumpReadable,
+		"txpump_events":       a.ingestion.txpumpEvents,
+		"mempool_events":      snap.MempoolTxCount,
+	})
+	if a.ingestion.nodeEvents == 0 && !a.observabilityWarned {
+		a.logger.Warn("no node log events ingested; workload assertions are pending",
+			"node_files", len(a.ingestion.nodeFiles),
+			"readable_node_files", len(a.ingestion.nodeReadable),
+			"node_log_bytes", a.ingestion.nodeBytes,
+			"open_failures", a.ingestion.openFailures,
+		)
+		a.observabilityWarned = true
+	}
 }
 
 // signalSetupComplete emits the Antithesis readiness event once per analyzer.
@@ -116,33 +166,57 @@ func (a *Analyzer) signalSetupComplete() {
 	a.setupDone = true
 }
 
-// readNewLines discovers log files matching p*.log and txpump.log in
-// cfg.LogDir, then reads any new lines since the last pass for each file.
+// readNewLines discovers node and txpump logs anywhere below cfg.LogDir,
+// including numbered rotations, then reads new complete lines.
 func (a *Analyzer) readNewLines() {
-	// Node logs (p1.log, p2.log, ...)
-	pattern := filepath.Join(a.cfg.LogDir, "p*.log")
-	matches, err := filepath.Glob(pattern)
+	// Shared volumes may expose logs in a subdirectory and loggers may leave
+	// numbered rotations behind. Walk the volume and select only known names.
+	currentNodeFiles := make(map[string]struct{})
+	currentReadable := make(map[string]struct{})
+	err := filepath.WalkDir(a.cfg.LogDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if _, warned := a.walkWarnings[path]; !warned {
+				a.logger.Warn("cannot inspect log path", "path", path, "err", walkErr)
+				a.walkWarnings[path] = struct{}{}
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		role, nodeID, ok := logRole(path)
+		if !ok {
+			return nil
+		}
+		if role == "node" {
+			currentNodeFiles[path] = struct{}{}
+		}
+		if a.readFile(path, role, nodeID) {
+			if role == "node" {
+				currentReadable[path] = struct{}{}
+			} else {
+				a.ingestion.txpumpReadable = true
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		a.logger.Warn("glob failed", "pattern", pattern, "err", err)
+		if !a.directoryWarned {
+			a.logger.Warn("cannot inspect log directory", "path", a.cfg.LogDir, "err", err)
+			a.directoryWarned = true
+		}
+	} else {
+		a.directoryWarned = false
 	}
-
-	// txpump transaction log
-	txpumpLog := filepath.Join(a.cfg.LogDir, "txpump.log")
-	if _, statErr := os.Stat(txpumpLog); statErr == nil {
-		matches = append(matches, txpumpLog)
-	}
-
-	for _, path := range matches {
-		a.readFile(path)
-	}
+	a.ingestion.nodeFiles = currentNodeFiles
+	a.ingestion.nodeReadable = currentReadable
 }
 
 // readFile reads new lines from a single log file starting from the last
 // known offset.
-func (a *Analyzer) readFile(path string) {
+func (a *Analyzer) readFile(path, role, nodeID string) bool {
 	state, ok := a.files[path]
 	if !ok {
-		nodeID := nodeIDFromPath(path)
 		state = &fileState{path: path, nodeID: nodeID}
 		a.files[path] = state
 	}
@@ -150,16 +224,28 @@ func (a *Analyzer) readFile(path string) {
 	//nolint:gosec // log file path derived from config, not user input
 	f, err := os.Open(path)
 	if err != nil {
-		a.logger.Warn("cannot open log file", "path", path, "err", err)
-		return
+		a.ingestion.openFailures++
+		if !state.warned {
+			a.logger.Warn("cannot read log file", "path", path, "err", err)
+			state.warned = true
+		}
+		return false
 	}
 	defer f.Close() //nolint:errcheck // read-only open
+	state.warned = false
+	if role == "node" {
+		a.ingestion.nodeReadable[path] = struct{}{}
+	}
 
 	// Fix 7: detect file truncation (e.g. log rotation) and reset.
 	info, err := f.Stat()
-	if err == nil && info.Size() < state.offset {
+	if err == nil && (info.Size() < state.offset ||
+		(!state.modTime.IsZero() && !info.ModTime().Equal(state.modTime) && info.Size() <= state.offset)) {
 		a.logger.Info("log file truncated, resetting offset", "path", path)
 		state.offset = 0
+	}
+	if err == nil {
+		state.modTime = info.ModTime()
 	}
 
 	if state.offset > 0 {
@@ -196,6 +282,11 @@ func (a *Analyzer) readFile(path string) {
 			if ev != nil {
 				ev.NodeID = state.nodeID
 				a.metrics.RecordEvent(ev)
+				if role == "node" {
+					a.ingestion.nodeEvents++
+				} else {
+					a.ingestion.txpumpEvents++
+				}
 			}
 		}
 		if readErr != nil {
@@ -203,6 +294,10 @@ func (a *Analyzer) readFile(path string) {
 		}
 	}
 	state.offset += bytesRead
+	if role == "node" {
+		a.ingestion.nodeBytes += bytesRead
+	}
+	return true
 }
 
 // reportSafetyAssertions evaluates safety properties and fires assertions.
@@ -350,11 +445,21 @@ func (a *Analyzer) reportReachable(snap *MetricsSnapshot) {
 // For example "/logs/p1.log" returns "p1".
 func nodeIDFromPath(path string) string {
 	base := filepath.Base(path)
-	// Strip extension
-	if idx := strings.LastIndex(base, "."); idx > 0 {
-		base = base[:idx]
+	if match := nodeLogName.FindStringSubmatch(base); len(match) > 1 {
+		return "p" + match[1]
 	}
 	return base
+}
+
+func logRole(path string) (role, nodeID string, ok bool) {
+	base := filepath.Base(path)
+	if strings.HasPrefix(base, "txpump.log") {
+		return "txpump", "txpump", true
+	}
+	if nodeID := nodeIDFromPath(path); nodeID != base {
+		return "node", nodeID, true
+	}
+	return "", "", false
 }
 
 // chainTipRange returns the minimum and maximum values in the map.

--- a/internal/test/antithesis/internal/analysis/analysis_test.go
+++ b/internal/test/antithesis/internal/analysis/analysis_test.go
@@ -16,6 +16,7 @@ package analysis
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -103,6 +104,25 @@ func TestAnalyzerReadNewLines_DiscoversNestedRotatedAndIncompleteLogs(t *testing
 	analyzer.readNewLines()
 
 	snap = analyzer.metrics.Snapshot()
+	require.Equal(t, 2, snap.TotalBlocksForged)
+	require.Equal(t, 2, snap.BlocksByNode["p1"])
+}
+
+func TestAnalyzerReadNewLines_DoesNotReprocessRenamedLog(t *testing.T) {
+	logDir := t.TempDir()
+	active := filepath.Join(logDir, "p1.log")
+	record := func(slot int, hash string) []byte {
+		return []byte(fmt.Sprintf(`{"msg":"block produced","slot":%d,"block_hash":"%s"}`+"\n", slot, hash))
+	}
+	require.NoError(t, os.WriteFile(active, record(10, "h10"), 0o644))
+	analyzer := NewAnalyzer(&Config{LogDir: logDir}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	analyzer.readNewLines()
+
+	require.NoError(t, os.Rename(active, active+".1"))
+	require.NoError(t, os.WriteFile(active, record(11, "h11"), 0o644))
+	analyzer.readNewLines()
+
+	snap := analyzer.metrics.Snapshot()
 	require.Equal(t, 2, snap.TotalBlocksForged)
 	require.Equal(t, 2, snap.BlocksByNode["p1"])
 }

--- a/internal/test/antithesis/internal/analysis/analysis_test.go
+++ b/internal/test/antithesis/internal/analysis/analysis_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -71,4 +73,51 @@ func TestChainTipRange_NonEmpty(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, uint64(7), min)
 	require.Equal(t, uint64(99), max)
+}
+
+func TestAnalyzerReadNewLines_DiscoversNestedRotatedAndIncompleteLogs(t *testing.T) {
+	logDir := t.TempDir()
+	nestedDir := filepath.Join(logDir, "p1")
+	require.NoError(t, os.Mkdir(nestedDir, 0o755))
+
+	rotated := filepath.Join(logDir, "p1.log.1")
+	require.NoError(t, os.WriteFile(rotated, []byte(
+		`{"msg":"block produced","slot":10,"block_hash":"h10"}`+"\n"), 0o644))
+	current := filepath.Join(nestedDir, "p1.log")
+	require.NoError(t, os.WriteFile(current, []byte(
+		`{"msg":"block produced","slot":11,"block_hash":"h11"}`), 0o644))
+
+	analyzer := NewAnalyzer(&Config{LogDir: logDir}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	analyzer.readNewLines()
+	snap := analyzer.metrics.Snapshot()
+	require.Equal(t, 1, snap.TotalBlocksForged)
+	require.Equal(t, 1, snap.BlocksByNode["p1"])
+	require.Positive(t, analyzer.ingestion.nodeBytes)
+	require.Len(t, analyzer.ingestion.nodeFiles, 2)
+
+	f, err := os.OpenFile(current, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	analyzer.readNewLines()
+
+	snap = analyzer.metrics.Snapshot()
+	require.Equal(t, 2, snap.TotalBlocksForged)
+	require.Equal(t, 2, snap.BlocksByNode["p1"])
+}
+
+func TestLogRole_RecognizesRotationsAndRejectsUnrelatedFiles(t *testing.T) {
+	role, nodeID, ok := logRole("/logs/p3.log.2")
+	require.True(t, ok)
+	require.Equal(t, "node", role)
+	require.Equal(t, "p3", nodeID)
+
+	role, nodeID, ok = logRole("/logs/txpump.log.1")
+	require.True(t, ok)
+	require.Equal(t, "txpump", role)
+	require.Equal(t, "txpump", nodeID)
+
+	_, _, ok = logRole("/logs/application.log")
+	require.False(t, ok)
 }

--- a/internal/test/antithesis/internal/txpump/config.go
+++ b/internal/test/antithesis/internal/txpump/config.go
@@ -26,6 +26,8 @@ import (
 	"github.com/blinklabs-io/dingo/internal/test/antithesis/internal/genesis"
 )
 
+const maxStartupTimeoutSeconds = int64(^uint64(0)>>1) / int64(time.Second)
+
 // Config holds all runtime configuration for txpump.
 // Values are read from environment variables; defaults apply when a variable
 // is absent or empty.
@@ -191,14 +193,11 @@ func LoadConfig() (*Config, error) {
 	}
 
 	if v := os.Getenv("TXPUMP_STARTUP_TIMEOUT"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil || n < 0 {
-			return nil, fmt.Errorf(
-				"TXPUMP_STARTUP_TIMEOUT: must be a non-negative integer (seconds), got %q",
-				v,
-			)
+		timeout, err := parseStartupTimeout(v)
+		if err != nil {
+			return nil, err
 		}
-		cfg.StartupTimeout = time.Duration(n) * time.Second
+		cfg.StartupTimeout = timeout
 	}
 
 	if v := os.Getenv("TXPUMP_TYPES"); v != "" {
@@ -229,6 +228,17 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func parseStartupTimeout(value string) (time.Duration, error) {
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds < 0 || seconds > maxStartupTimeoutSeconds {
+		return 0, fmt.Errorf(
+			"TXPUMP_STARTUP_TIMEOUT: must be a non-negative integer (seconds) <= %d, got %q",
+			maxStartupTimeoutSeconds, value,
+		)
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 // validate checks that the config values are internally consistent.

--- a/internal/test/antithesis/internal/txpump/config.go
+++ b/internal/test/antithesis/internal/txpump/config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/blinklabs-io/dingo/internal/test/antithesis/internal/genesis"
 )
@@ -66,6 +67,11 @@ type Config struct {
 	// Empty string means no fallback.
 	FallbackAddr string
 
+	// StartupTimeout is the maximum time allowed to establish a connection and
+	// successfully submit the first transaction. A zero value disables the
+	// startup deadline; the default is 60 seconds.
+	StartupTimeout time.Duration
+
 	// GenesisUTxOFile is a path to a directory (or a single JSON file) containing
 	// initial UTxO entries. When signing keys are present it must be a directory:
 	// LoadSigningKeys globs genesis.*.skey inside it, while LoadGenesisUTxOs
@@ -107,6 +113,7 @@ func LoadConfig() (*Config, error) {
 		Types:             []string{"payment", "delegation", "governance", "plutus"},
 		LogDir:            envString("TXPUMP_LOG_DIR", "/logs"),
 		FallbackAddr:      envString("TXPUMP_FALLBACK_ADDR", ""),
+		StartupTimeout:    60 * time.Second,
 		GenesisUTxOFile: envString(
 			"TXPUMP_GENESIS_UTXO_FILE", "",
 		),
@@ -181,6 +188,17 @@ func LoadConfig() (*Config, error) {
 			)
 		}
 		cfg.ConfirmationSlots = n
+	}
+
+	if v := os.Getenv("TXPUMP_STARTUP_TIMEOUT"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return nil, fmt.Errorf(
+				"TXPUMP_STARTUP_TIMEOUT: must be a non-negative integer (seconds), got %q",
+				v,
+			)
+		}
+		cfg.StartupTimeout = time.Duration(n) * time.Second
 	}
 
 	if v := os.Getenv("TXPUMP_TYPES"); v != "" {

--- a/internal/test/antithesis/internal/txpump/config_test.go
+++ b/internal/test/antithesis/internal/txpump/config_test.go
@@ -17,6 +17,7 @@ package txpump
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -90,6 +91,29 @@ func TestLoadConfig_RejectsInvalidStartupTimeout(t *testing.T) {
 
 	_, err := LoadConfig()
 	require.ErrorContains(t, err, "TXPUMP_STARTUP_TIMEOUT")
+}
+
+func TestParseStartupTimeoutBounds(t *testing.T) {
+	timeout, err := parseStartupTimeout(strconv.FormatInt(maxStartupTimeoutSeconds, 10))
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(maxStartupTimeoutSeconds)*time.Second, timeout)
+
+	_, err = parseStartupTimeout(strconv.FormatInt(maxStartupTimeoutSeconds+1, 10))
+	require.Error(t, err)
+	_, err = parseStartupTimeout("-1")
+	require.Error(t, err)
+}
+
+func TestStopStartupTimeoutRemainsDisabledPastDeadline(t *testing.T) {
+	timer := time.NewTimer(10 * time.Millisecond)
+	deadline := timer.C
+	stopStartupTimeout(&timer, &deadline)
+
+	select {
+	case <-deadline:
+		t.Fatal("startup deadline remained active after readiness")
+	case <-time.After(30 * time.Millisecond):
+	}
 }
 
 func clearTxpumpEnv(t *testing.T) {

--- a/internal/test/antithesis/internal/txpump/config_test.go
+++ b/internal/test/antithesis/internal/txpump/config_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +66,32 @@ func TestLoadConfig_LoadsConfirmationSlots(t *testing.T) {
 	require.Equal(t, uint64(42), cfg.ConfirmationSlots)
 }
 
+func TestLoadConfig_StartUpTimeout(t *testing.T) {
+	clearTxpumpEnv(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, 60*time.Second, cfg.StartupTimeout)
+
+	t.Setenv("TXPUMP_STARTUP_TIMEOUT", "7")
+	cfg, err = LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, 7*time.Second, cfg.StartupTimeout)
+
+	t.Setenv("TXPUMP_STARTUP_TIMEOUT", "0")
+	cfg, err = LoadConfig()
+	require.NoError(t, err)
+	require.Zero(t, cfg.StartupTimeout)
+}
+
+func TestLoadConfig_RejectsInvalidStartupTimeout(t *testing.T) {
+	clearTxpumpEnv(t)
+	t.Setenv("TXPUMP_STARTUP_TIMEOUT", "-1")
+
+	_, err := LoadConfig()
+	require.ErrorContains(t, err, "TXPUMP_STARTUP_TIMEOUT")
+}
+
 func clearTxpumpEnv(t *testing.T) {
 	t.Helper()
 
@@ -76,6 +103,7 @@ func clearTxpumpEnv(t *testing.T) {
 		"TXPUMP_COOLDOWN_MIN",
 		"TXPUMP_COOLDOWN_MAX",
 		"TXPUMP_CONFIRMATION_SLOTS",
+		"TXPUMP_STARTUP_TIMEOUT",
 		"TXPUMP_TYPES",
 		"TXPUMP_LOG_DIR",
 		"TXPUMP_FALLBACK_ADDR",

--- a/internal/test/antithesis/internal/txpump/logger.go
+++ b/internal/test/antithesis/internal/txpump/logger.go
@@ -25,14 +25,16 @@ import (
 
 // TxLog records the outcome of a single transaction submission attempt.
 type TxLog struct {
-	Timestamp string `json:"ts"`
-	TxID      string `json:"tx_id"`
-	TxType    string `json:"tx_type"` // "payment" | "delegation" | "governance" | "plutus"
-	EraID     uint16 `json:"era_id"`
-	Status    string `json:"status"` // "submitted" | "rejected" | "error"
-	ErrorMsg  string `json:"error,omitempty"`
-	NodeAddr  string `json:"node_addr"`
-	BatchSize int    `json:"batch_size"`
+	Timestamp     string   `json:"ts"`
+	Event         string   `json:"event,omitempty"` // "ready" for the startup contract signal
+	TxID          string   `json:"tx_id"`
+	TxType        string   `json:"tx_type"` // "payment" | "delegation" | "governance" | "plutus"
+	WorkloadTypes []string `json:"workload_types,omitempty"`
+	EraID         uint16   `json:"era_id"`
+	Status        string   `json:"status"` // "submitted" | "rejected" | "error" | "ready"
+	ErrorMsg      string   `json:"error,omitempty"`
+	NodeAddr      string   `json:"node_addr"`
+	BatchSize     int      `json:"batch_size"`
 }
 
 // TxLogger writes JSON-encoded TxLog entries to a file in a thread-safe

--- a/internal/test/antithesis/internal/txpump/pump.go
+++ b/internal/test/antithesis/internal/txpump/pump.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -58,10 +59,23 @@ func NewPump(
 //  3. Submits the batch, one transaction at a time.
 //  4. Waits a random cooldown in [CooldownMin, CooldownMax] milliseconds.
 func (p *Pump) Run(ctx context.Context) error {
+	var startupTimer *time.Timer
+	var startup <-chan time.Time
+	if p.cfg.StartupTimeout > 0 {
+		startupTimer = time.NewTimer(p.cfg.StartupTimeout)
+		defer startupTimer.Stop()
+		startup = startupTimer.C
+	}
+	ready := false
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-startup:
+			return fmt.Errorf(
+				"txpump readiness timeout after %s: no transaction was successfully submitted",
+				p.cfg.StartupTimeout,
+			)
 		default:
 		}
 
@@ -88,8 +102,26 @@ func (p *Pump) Run(ctx context.Context) error {
 			}
 		}
 
-		p.runBatch(ctx, client, batchSize)
+		submitted := p.runBatch(ctx, client, batchSize)
 		client.Close() //nolint:errcheck // best-effort close
+		if submitted > 0 && !ready {
+			ready = true
+			p.logger.Info(
+				"txpump ready",
+				"workload_types", p.cfg.Types,
+				"submitted", submitted,
+			)
+			if p.txlog != nil {
+				if logErr := p.txlog.Log(TxLog{
+					Event:         "ready",
+					Status:        "ready",
+					NodeAddr:      client.Addr(),
+					WorkloadTypes: append([]string(nil), p.cfg.Types...),
+				}); logErr != nil {
+					p.logger.Error("txlog readiness write failed", "err", logErr)
+				}
+			}
+		}
 
 		if !p.cooldown(ctx) {
 			return ctx.Err()
@@ -169,31 +201,40 @@ func (p *Pump) runBatch(
 	ctx context.Context,
 	client *NodeClient,
 	batchSize int,
-) {
+) int {
 	slot := p.currentSlot()
 	epoch := p.epochFromSlot(slot)
 	active := enabledTypes(p.cfg.Types, epoch, p.cfg.delegationEnabled())
 	if len(active) == 0 {
-		return
+		return 0
 	}
 
+	submitted := 0
 	for i := 0; i < batchSize; i++ {
 		select {
 		case <-ctx.Done():
-			return
+			return submitted
 		default:
 		}
 
 		txType := active[IntRange(0, len(active)-1)]
 		switch txType {
 		case "payment":
-			p.submitPayment(client, batchSize)
+			if p.submitPayment(client, batchSize) {
+				submitted++
+			}
 		case "delegation":
-			p.submitDelegation(client, batchSize)
+			if p.submitDelegation(client, batchSize) {
+				submitted++
+			}
 		case "governance":
-			p.submitGovernance(client, batchSize)
+			if p.submitGovernance(client, batchSize) {
+				submitted++
+			}
 		case "plutus":
-			p.submitPlutus(client, batchSize)
+			if p.submitPlutus(client, batchSize) {
+				submitted++
+			}
 		default:
 			p.logger.Warn(
 				"unknown tx type in config, skipping",
@@ -201,10 +242,11 @@ func (p *Pump) runBatch(
 			)
 		}
 	}
+	return submitted
 }
 
 // submitPayment builds and submits a single payment transaction.
-func (p *Pump) submitPayment(client *NodeClient, batchSize int) {
+func (p *Pump) submitPayment(client *NodeClient, batchSize int) bool {
 	// Determine a send amount between minSendAmount and half the wallet balance
 	// (leaving room for fees and change).  Fall back to minSendAmount when the
 	// balance is very small.
@@ -215,7 +257,7 @@ func (p *Pump) submitPayment(client *NodeClient, batchSize int) {
 			"wallet balance too low for payment, skipping",
 			"balance_lovelace", balance,
 		)
-		return
+		return false
 	}
 
 	upper := maxSend - MinFee
@@ -232,7 +274,7 @@ func (p *Pump) submitPayment(client *NodeClient, batchSize int) {
 			"required_lovelace", required,
 			"err", err,
 		)
-		return
+		return false
 	}
 
 	// Collect a witness key for every distinct signing key among the inputs.
@@ -270,7 +312,7 @@ func (p *Pump) submitPayment(client *NodeClient, batchSize int) {
 	if err != nil {
 		p.logger.Error("build payment failed", "err", err)
 		p.wallet.ReturnUTxOs(inputs)
-		return
+		return false
 	}
 
 	submitErr := client.SubmitTx(conwayEraID, txBytes)
@@ -317,12 +359,13 @@ func (p *Pump) submitPayment(client *NodeClient, batchSize int) {
 			p.logger.Error("txlog write failed", "err", logErr)
 		}
 	}
+	return submitErr == nil
 }
 
 // submitDelegation builds and submits a single stake-delegation transaction.
-func (p *Pump) submitDelegation(client *NodeClient, batchSize int) {
+func (p *Pump) submitDelegation(client *NodeClient, batchSize int) bool {
 	if !p.cfg.delegationEnabled() {
-		return
+		return false
 	}
 	stakeKeyHash, err := decodeConfiguredHash(
 		"TXPUMP_DELEGATION_STAKE_KEY_HASH",
@@ -331,7 +374,7 @@ func (p *Pump) submitDelegation(client *NodeClient, batchSize int) {
 	)
 	if err != nil {
 		p.logger.Error("invalid delegation stake key hash", "err", err)
-		return
+		return false
 	}
 	poolKeyHash, err := decodeConfiguredHash(
 		"TXPUMP_DELEGATION_POOL_KEY_HASH",
@@ -340,7 +383,7 @@ func (p *Pump) submitDelegation(client *NodeClient, batchSize int) {
 	)
 	if err != nil {
 		p.logger.Error("invalid delegation pool key hash", "err", err)
-		return
+		return false
 	}
 
 	required := MinFee
@@ -351,7 +394,7 @@ func (p *Pump) submitDelegation(client *NodeClient, batchSize int) {
 			"required_lovelace", required,
 			"err", err,
 		)
-		return
+		return false
 	}
 
 	changeAddr := deterministicAddr(inputs[0].TxHash)
@@ -360,7 +403,7 @@ func (p *Pump) submitDelegation(client *NodeClient, batchSize int) {
 	if err != nil {
 		p.logger.Error("build delegation failed", "err", err)
 		p.wallet.ReturnUTxOs(inputs)
-		return
+		return false
 	}
 
 	txID := deriveTestTxID(txBytes)
@@ -391,11 +434,12 @@ func (p *Pump) submitDelegation(client *NodeClient, batchSize int) {
 			p.logger.Error("txlog write failed", "err", logErr)
 		}
 	}
+	return submitErr == nil
 }
 
 // submitGovernance builds and submits either a DRep registration or a vote
 // transaction (chosen randomly).
-func (p *Pump) submitGovernance(client *NodeClient, batchSize int) {
+func (p *Pump) submitGovernance(client *NodeClient, batchSize int) bool {
 	// Decide the type first so we can compute the correct coin selection.
 	// DRep registration needs fee + deposit; votes only need the fee.
 	var txKind string
@@ -420,7 +464,7 @@ func (p *Pump) submitGovernance(client *NodeClient, batchSize int) {
 			"kind", txKind,
 			"err", err,
 		)
-		return
+		return false
 	}
 
 	raw, _ := hex.DecodeString(inputs[0].TxHash)
@@ -446,7 +490,7 @@ func (p *Pump) submitGovernance(client *NodeClient, batchSize int) {
 	if buildErr != nil {
 		p.logger.Error("build governance tx failed", "kind", txKind, "err", buildErr)
 		p.wallet.ReturnUTxOs(inputs)
-		return
+		return false
 	}
 
 	txID := deriveTestTxID(txBytes)
@@ -482,11 +526,12 @@ func (p *Pump) submitGovernance(client *NodeClient, batchSize int) {
 			p.logger.Error("txlog write failed", "err", logErr)
 		}
 	}
+	return submitErr == nil
 }
 
 // submitPlutus builds and submits either a Plutus lock or unlock transaction
 // (chosen randomly).
-func (p *Pump) submitPlutus(client *NodeClient, batchSize int) {
+func (p *Pump) submitPlutus(client *NodeClient, batchSize int) bool {
 	txKind := "plutus_lock"
 	var lockedInput UTxO
 	if len(p.plutusLocked) > 0 && IntRange(0, 1) == 1 {
@@ -513,7 +558,7 @@ func (p *Pump) submitPlutus(client *NodeClient, batchSize int) {
 				"required_lovelace", required,
 				"err", err,
 			)
-			return
+			return false
 		}
 	} else {
 		inputs = []UTxO{lockedInput}
@@ -526,7 +571,7 @@ func (p *Pump) submitPlutus(client *NodeClient, batchSize int) {
 				"fee", MinFee,
 			)
 			p.addLockedPlutusUTxO(lockedInput)
-			return
+			return false
 		}
 		change = lockedInput.Amount - MinFee
 	}
@@ -556,7 +601,7 @@ func (p *Pump) submitPlutus(client *NodeClient, batchSize int) {
 		} else {
 			p.addLockedPlutusUTxO(lockedInput)
 		}
-		return
+		return false
 	}
 
 	txID := deriveTestTxID(txBytes)
@@ -608,6 +653,7 @@ func (p *Pump) submitPlutus(client *NodeClient, batchSize int) {
 			p.logger.Error("txlog write failed", "err", logErr)
 		}
 	}
+	return submitErr == nil
 }
 
 func (p *Pump) addLockedPlutusUTxO(utxo UTxO) {

--- a/internal/test/antithesis/internal/txpump/pump.go
+++ b/internal/test/antithesis/internal/txpump/pump.go
@@ -106,6 +106,7 @@ func (p *Pump) Run(ctx context.Context) error {
 		client.Close() //nolint:errcheck // best-effort close
 		if submitted > 0 && !ready {
 			ready = true
+			stopStartupTimeout(&startupTimer, &startup)
 			p.logger.Info(
 				"txpump ready",
 				"workload_types", p.cfg.Types,
@@ -127,6 +128,16 @@ func (p *Pump) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// stopStartupTimeout disables the readiness deadline after the first
+// successful submission. The deadline only protects the pre-ready phase.
+func stopStartupTimeout(timer **time.Timer, deadline *<-chan time.Time) {
+	if *timer != nil {
+		(*timer).Stop()
+		*timer = nil
+	}
+	*deadline = nil
 }
 
 // dialPrimary connects to the primary node address.

--- a/internal/test/antithesis/scripts/configurator.sh
+++ b/internal/test/antithesis/scripts/configurator.sh
@@ -230,10 +230,24 @@ cp /tmp/testnet/utxos/keys/genesis.*.vkey /configs/utxo-keys/
 cp /tmp/testnet/utxos/keys/genesis.*.addr.info /configs/utxo-keys/
 
 # Keep generated stake material in a stable location. txpump derives the
-# delegation and pool hashes at startup, so no generated hash is hard-coded.
+# delegation and pool hashes at startup. Select the generator's first
+# lexically ordered stake verification key and expose only that key under a
+# stable name; an unconstrained find otherwise makes the selected credential
+# depend on filesystem traversal order.
 mkdir -p /configs/utxo-keys/stake
-find /tmp/testnet -type f -name '*stake*.vkey' -exec cp {} /configs/utxo-keys/stake/ \; 2>/dev/null || true
-find /tmp/testnet -type f -name '*stake*.skey' -exec cp {} /configs/utxo-keys/stake/ \; 2>/dev/null || true
+stake_vkey="$(find /tmp/testnet -type f -name '*stake*.vkey' -print 2>/dev/null | sort | head -n 1)"
+if [ -z "$stake_vkey" ]; then
+    echo "no generated delegation stake verification key found" >&2
+    exit 1
+fi
+cp "$stake_vkey" /configs/utxo-keys/stake/txpump.stake.vkey
+if ! cardano-cli stake-address key-hash \
+    --stake-verification-key-file /configs/utxo-keys/stake/txpump.stake.vkey \
+    >/tmp/txpump-stake-key-hash; then
+    echo "generated delegation stake verification key is invalid: $stake_vkey" >&2
+    exit 1
+fi
+test -s /tmp/txpump-stake-key-hash
 
 # Copy testnet.yaml to shared volume for analysis/txpump genesis config
 echo "copying testnet.yaml to /testnet-config/testnet.yaml"

--- a/internal/test/antithesis/scripts/configurator.sh
+++ b/internal/test/antithesis/scripts/configurator.sh
@@ -46,6 +46,18 @@ config_config_json() {
         jq ".PeerSharing = false" "${CONFIG_JSON}" > "$tmp" && mv --force "$tmp" "${CONFIG_JSON}"
     fi
 
+    # The analyzer consumes JSON records from the shared logs volume. Avoid
+    # the configurator's private log path and retain only Info-and-above data.
+    tmp="${CONFIG_JSON}.tmp.$$"
+    jq '.minSeverity = "Info"
+        | .defaultScribes = [["StdoutSK", "stdout"]]
+        | .setupScribes = [{
+            "scKind": "StdoutSK",
+            "scName": "stdout",
+            "scFormat": "ScJson",
+            "scRotation": null
+          }]' "${CONFIG_JSON}" > "$tmp" && mv --force "$tmp" "${CONFIG_JSON}"
+
     # configure UTxO-HD
     # see https://ouroboros-consensus.cardano.intersectmbo.org/docs/for-developers/utxo-hd/migrating
     # FIXME: /state needs to match the --database-path in the
@@ -212,7 +224,16 @@ done
 
 # Copy UTxO keys to shared volume for txpump access
 echo "copying utxo keys to /configs/utxo-keys"
-cp -r /tmp/testnet/utxos /configs/utxo-keys
+cp /configs/1/configs/shelley-genesis.json /configs/utxo-keys/
+cp /tmp/testnet/utxos/keys/genesis.*.skey /configs/utxo-keys/
+cp /tmp/testnet/utxos/keys/genesis.*.vkey /configs/utxo-keys/
+cp /tmp/testnet/utxos/keys/genesis.*.addr.info /configs/utxo-keys/
+
+# Keep generated stake material in a stable location. txpump derives the
+# delegation and pool hashes at startup, so no generated hash is hard-coded.
+mkdir -p /configs/utxo-keys/stake
+find /tmp/testnet -type f -name '*stake*.vkey' -exec cp {} /configs/utxo-keys/stake/ \; 2>/dev/null || true
+find /tmp/testnet -type f -name '*stake*.skey' -exec cp {} /configs/utxo-keys/stake/ \; 2>/dev/null || true
 
 # Copy testnet.yaml to shared volume for analysis/txpump genesis config
 echo "copying testnet.yaml to /testnet-config/testnet.yaml"

--- a/internal/test/antithesis/scripts/txpump-entrypoint.sh
+++ b/internal/test/antithesis/scripts/txpump-entrypoint.sh
@@ -5,7 +5,7 @@ set -eu
 # 0640 structured log readable through the shared volume.
 stake_key="/utxo-keys/stake/txpump.stake.vkey"
 pool_key="/configs/keys/cold.vkey"
-if [ -z "${stake_key}" ] || [ ! -f "${pool_key}" ]; then
+if [ ! -f "${stake_key}" ] || [ ! -f "${pool_key}" ]; then
   echo "txpump: delegation credentials are missing" >&2
   exit 1
 fi

--- a/internal/test/antithesis/scripts/txpump-entrypoint.sh
+++ b/internal/test/antithesis/scripts/txpump-entrypoint.sh
@@ -3,7 +3,7 @@ set -eu
 
 # The analyzer image uses uid 1000. Running txpump with the same uid keeps its
 # 0640 structured log readable through the shared volume.
-stake_key="$(find /utxo-keys/stake -type f -name '*.vkey' -print -quit 2>/dev/null || true)"
+stake_key="/utxo-keys/stake/txpump.stake.vkey"
 pool_key="/configs/keys/cold.vkey"
 if [ -z "${stake_key}" ] || [ ! -f "${pool_key}" ]; then
   echo "txpump: delegation credentials are missing" >&2

--- a/internal/test/antithesis/scripts/txpump-entrypoint.sh
+++ b/internal/test/antithesis/scripts/txpump-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+# The analyzer image uses uid 1000. Running txpump with the same uid keeps its
+# 0640 structured log readable through the shared volume.
+stake_key="$(find /utxo-keys/stake -type f -name '*.vkey' -print -quit 2>/dev/null || true)"
+pool_key="/configs/keys/cold.vkey"
+if [ -z "${stake_key}" ] || [ ! -f "${pool_key}" ]; then
+  echo "txpump: delegation credentials are missing" >&2
+  exit 1
+fi
+export TXPUMP_DELEGATION_STAKE_KEY_HASH="$(cardano-cli stake-address key-hash --stake-verification-key-file "${stake_key}")"
+export TXPUMP_DELEGATION_POOL_KEY_HASH="$(cardano-cli stake-pool id --cold-verification-key-file "${pool_key}" --output-format hex)"
+
+chown -R txpump:txpump /logs
+exec su -s /bin/sh txpump -c 'exec /bin/txpump'

--- a/internal/test/antithesis/scripts/validate-config.sh
+++ b/internal/test/antithesis/scripts/validate-config.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/../testnets/dingo-praos/docker-compose.yaml"
+rendered="$(mktemp)"
+trap 'rm -f "$rendered"' EXIT
+
+docker compose -f "$COMPOSE_FILE" config >"$rendered"
+
+grep -Fq 'CARDANO_PRIVATE_BIND_ADDR: 0.0.0.0' "$rendered"
+grep -Fq 'TXPUMP_NODE_ADDR: p1.example:3002' "$rendered"
+grep -Fq 'TXPUMP_TYPES: payment,delegation,governance,plutus' "$rendered"
+for pool in 1 2 3 4 5; do
+  grep -Fq "/logs/p${pool}.log" "$rendered"
+done
+
+echo "Antithesis compose invariants are valid"

--- a/internal/test/antithesis/scripts/validate-config.sh
+++ b/internal/test/antithesis/scripts/validate-config.sh
@@ -10,6 +10,7 @@ docker compose -f "$COMPOSE_FILE" config >"$rendered"
 
 grep -Fq 'CARDANO_PRIVATE_BIND_ADDR: 0.0.0.0' "$rendered"
 grep -Fq 'TXPUMP_NODE_ADDR: p1.example:3002' "$rendered"
+grep -Fq 'TXPUMP_STARTUP_TIMEOUT: "60"' "$rendered"
 grep -Fq 'TXPUMP_TYPES: payment,delegation,governance,plutus' "$rendered"
 for pool in 1 2 3 4 5; do
   grep -Fq "/logs/p${pool}.log" "$rendered"

--- a/internal/test/antithesis/scripts/validate-config.sh
+++ b/internal/test/antithesis/scripts/validate-config.sh
@@ -2,18 +2,29 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-COMPOSE_FILE="${SCRIPT_DIR}/../testnets/dingo-praos/docker-compose.yaml"
-rendered="$(mktemp)"
-trap 'rm -f "$rendered"' EXIT
+validate_compose() {
+  local compose_file="$1"
+  local rendered
+  rendered="$(mktemp)"
+  trap 'rm -f "$rendered"' RETURN
+  docker compose -f "$compose_file" config >"$rendered"
 
-docker compose -f "$COMPOSE_FILE" config >"$rendered"
+  grep -Eq 'CARDANO_PRIVATE_BIND_ADDR:[[:space:]]*"?0\.0\.0\.0"?' "$rendered"
+  grep -Eq 'TXPUMP_STARTUP_TIMEOUT:[[:space:]]*"?60"?' "$rendered"
+  grep -Eq 'TXPUMP_TYPES:[[:space:]]*"?payment,delegation,governance,plutus"?' "$rendered"
+  if [[ "$compose_file" == *dingo-praos* ]]; then
+    grep -Eq 'TXPUMP_NODE_ADDR:[[:space:]]*"?p1\.example:3002"?' "$rendered"
+  else
+    grep -Eq 'TXPUMP_NODE_ADDR:[[:space:]]*"?/ipc/dingo\.socket"?' "$rendered"
+  fi
+  if [[ "$compose_file" == *dingo-praos* ]]; then
+    for pool in 1 2 3 4 5; do
+      grep -Fq "/logs/p${pool}.log" "$rendered"
+    done
+  fi
+}
 
-grep -Fq 'CARDANO_PRIVATE_BIND_ADDR: 0.0.0.0' "$rendered"
-grep -Fq 'TXPUMP_NODE_ADDR: p1.example:3002' "$rendered"
-grep -Fq 'TXPUMP_STARTUP_TIMEOUT: "60"' "$rendered"
-grep -Fq 'TXPUMP_TYPES: payment,delegation,governance,plutus' "$rendered"
-for pool in 1 2 3 4 5; do
-  grep -Fq "/logs/p${pool}.log" "$rendered"
-done
+validate_compose "${SCRIPT_DIR}/../docker-compose.yaml"
+validate_compose "${SCRIPT_DIR}/../testnets/dingo-praos/docker-compose.yaml"
 
 echo "Antithesis compose invariants are valid"

--- a/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
+++ b/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
@@ -88,6 +88,7 @@ services:
       - p5-configs:/configs/5
       - utxo-keys:/configs/utxo-keys
       - testnet-config:/testnet-config
+      - logs:/logs
     networks:
       - testnet
 

--- a/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
+++ b/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
@@ -207,6 +207,7 @@ services:
       TXPUMP_COOLDOWN_MIN: "5"
       TXPUMP_COOLDOWN_MAX: "15"
       TXPUMP_TYPES: "payment,delegation,governance,plutus"
+      TXPUMP_STARTUP_TIMEOUT: "60"
       TXPUMP_LOG_DIR: "/logs"
       TXPUMP_GENESIS_FILE: "/testnet-config/testnet.yaml"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"

--- a/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
+++ b/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
@@ -50,6 +50,15 @@ x-cardano-node-command: &cardano-node-command
   - "--port"
   - "3001"
 
+x-cardano-node-shell-command: &cardano-node-shell-command
+  - >-
+    umask 022; exec cardano-node run --config /configs/configs/config.json
+    --topology /configs/configs/topology.json --database-path /data/db
+    --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey
+    --shelley-vrf-key /configs/keys/vrf.skey
+    --shelley-operational-certificate /configs/keys/opcert.cert --port 3001
+    > "$$NODE_LOG_FILE" 2>&1
+
 x-cardano-node: &cardano-node
   image: ghcr.io/blinklabs-io/cardano-node:${CARDANO_NODE_VERSION:-11.0.1}
   init: true
@@ -137,9 +146,10 @@ services:
     <<: *cardano-node
     hostname: p2.example
     entrypoint: ["/bin/sh", "-c"]
-    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p2.log 2>&1"]
+    command: *cardano-node-shell-command
     environment:
       <<: *cn-env
+      NODE_LOG_FILE: /logs/p2.log
     volumes:
       - p2-configs:/configs:ro
       - p2-data:/data/db
@@ -150,9 +160,10 @@ services:
     <<: *cardano-node
     hostname: p3.example
     entrypoint: ["/bin/sh", "-c"]
-    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p3.log 2>&1"]
+    command: *cardano-node-shell-command
     environment:
       <<: *cn-env
+      NODE_LOG_FILE: /logs/p3.log
     volumes:
       - p3-configs:/configs:ro
       - p3-data:/data/db
@@ -163,9 +174,10 @@ services:
     <<: *cardano-node
     hostname: p4.example
     entrypoint: ["/bin/sh", "-c"]
-    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p4.log 2>&1"]
+    command: *cardano-node-shell-command
     environment:
       <<: *cn-env
+      NODE_LOG_FILE: /logs/p4.log
     volumes:
       - p4-configs:/configs:ro
       - p4-data:/data/db
@@ -176,9 +188,10 @@ services:
     <<: *cardano-node
     hostname: p5.example
     entrypoint: ["/bin/sh", "-c"]
-    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p5.log 2>&1"]
+    command: *cardano-node-shell-command
     environment:
       <<: *cn-env
+      NODE_LOG_FILE: /logs/p5.log
     volumes:
       - p5-configs:/configs:ro
       - p5-data:/data/db

--- a/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
+++ b/internal/test/antithesis/testnets/dingo-praos/docker-compose.yaml
@@ -107,8 +107,10 @@ services:
       CARDANO_TOPOLOGY: /configs/configs/dingo-topology.json
       CARDANO_DATABASE_PATH: /data/db
       CARDANO_NODE_SOCKET_PATH: /ipc/dingo.socket
-      DINGO_DEBUG: "1"
-      DINGO_PRIVATE_BIND_ADDR: "0.0.0.0"
+      CARDANO_PRIVATE_BIND_ADDR: "0.0.0.0"
+      DINGO_LOG_FILE: /logs/p1.log
+      DINGO_LOGGING_FORMAT: json
+      DINGO_LOGGING_LEVEL: info
       CARDANO_BLOCK_PRODUCER: "true"
       CARDANO_SHELLEY_VRF_KEY: /configs/keys/vrf.skey
       CARDANO_SHELLEY_KES_KEY: /configs/keys/kes.skey
@@ -133,6 +135,8 @@ services:
   p2:
     <<: *cardano-node
     hostname: p2.example
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p2.log 2>&1"]
     environment:
       <<: *cn-env
     volumes:
@@ -144,6 +148,8 @@ services:
   p3:
     <<: *cardano-node
     hostname: p3.example
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p3.log 2>&1"]
     environment:
       <<: *cn-env
     volumes:
@@ -155,6 +161,8 @@ services:
   p4:
     <<: *cardano-node
     hostname: p4.example
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p4.log 2>&1"]
     environment:
       <<: *cn-env
     volumes:
@@ -166,6 +174,8 @@ services:
   p5:
     <<: *cardano-node
     hostname: p5.example
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["umask 022; exec cardano-node run --config /configs/configs/config.json --topology /configs/configs/topology.json --database-path /data/db --socket-path /ipc/node.socket --shelley-kes-key /configs/keys/kes.skey --shelley-vrf-key /configs/keys/vrf.skey --shelley-operational-certificate /configs/keys/opcert.cert --port 3001 > /logs/p5.log 2>&1"]
     environment:
       <<: *cn-env
     volumes:
@@ -195,10 +205,10 @@ services:
       TXPUMP_TX_COUNT_MAX: "50"
       TXPUMP_COOLDOWN_MIN: "5"
       TXPUMP_COOLDOWN_MAX: "15"
-      TXPUMP_TYPES: "payment"
+      TXPUMP_TYPES: "payment,delegation,governance,plutus"
       TXPUMP_LOG_DIR: "/logs"
       TXPUMP_GENESIS_FILE: "/testnet-config/testnet.yaml"
-      TXPUMP_GENESIS_UTXO_FILE: "/configs/configs/shelley-genesis.json"
+      TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:
       - logs:/logs
       - p1-configs:/configs:ro


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Antithesis submissions exit by default and add an opt-in `poll_results` input to wait for completion. Also repairs workload/log wiring and hardens analysis so runs are observable and fail fast when `txpump` isn’t ready. Addresses Linear issue 1646.

- **Bug Fixes**
  - Route node and `txpump` logs to shared `/logs`; enable JSON; initialize volume permissions; add optional `DINGO_LOG_FILE` to persist node output.
  - Analyzer: walk nested/rotated logs, prefer active files, detect truncation/renames, record observability metrics and warn when no events; delay liveness until events exist.
  - `txpump`: emit a readiness event and enforce `TXPUMP_STARTUP_TIMEOUT` (default 60s); stop the deadline after first success; run as uid 1000; derive delegation and pool hashes via `cardano-cli`; validate stake and pool key paths at startup.
  - CI: validate compose invariants and wiring with `internal/test/antithesis/scripts/validate-config.sh`.

- **Migration**
  - To poll for results, set the workflow dispatch input `poll_results: true`.

<sup>Written for commit 0449d96d2f051da46e1171ce8cf8febd2c7d85ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional result polling for Antithesis workflow runs.
  * Added configurable file logging while preserving console output by default.
  * Added transaction pump startup timeouts and readiness reporting.
  * Expanded transaction testing to cover payment, delegation, governance, and Plutus transactions.

* **Bug Fixes**
  * Improved log discovery and handling for nested, rotated, incomplete, or unreadable logs.
  * Added validation for required test environment and logging configuration.

* **Tests**
  * Added coverage for log processing, startup timeout behavior, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->