### PR TITLE
fix: leiosnotify w31

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1278,7 +1278,10 @@ changing the block wire format. Duplicate observations and a third distinct
 announcement for one election are suppressed, and accepted traces log the
 observed slot and lateness. Before an announcement can affect the cross-peer
 EB-size invariant, the decoded ranking header is verified against the current
-ledger state, including VRF/KES and leader eligibility. Deduplication state is
+ledger state, including VRF/KES and leader eligibility. Announcements are
+rejected when ledger state is unavailable, and slot/freshness and structural
+checks run before cryptographic validation. Header-only validation does not
+advance the shared epoch cache. Deduplication state is
 pruned when its announced slot leaves the ten-minute acceptance window,
 including the EB-size and per-election indexes. The Go dependency has no
 separate Lookahead state type; its bounded pipelined request window is configured to the protocol

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1266,16 +1266,20 @@ fields correctly; malformed key/proof lengths reject that pool state. The same
 prototype release also changes `MsgLeiosBlockAnnouncement` from a null
 placeholder to the full ranking-block header. The LeiosNotify client accepts
 that header. In prototype-2026w31, `ouroboros/` decodes the Dijkstra header,
-requires a valid `leios_announcement`, rejects future or more-than-two-slot-old
-announcements, and rejects a repeated endorser-block hash whose size differs
-from an earlier observation. Accepted headers retain their original CBOR and
-enter the same per-connection delivery log as locally forged announcements,
-so followers consume them and relays diffuse them without changing the block
-wire format. Duplicate observations are suppressed, and accepted traces log
-the observed slot and lateness. The Go dependency has no separate Lookahead
-state type; its bounded pipelined request window is configured to the protocol
-maximum, providing the w31 Lookahead behavior while remaining compatible with
-w30 peers that accept and ignore the announcement payload. Full consensus
+requires a valid `leios_announcement`, rejects future or more-than-ten-minute-
+old announcements, and rejects a repeated endorser-block hash whose size
+differs from an earlier observation. A valid announcement is relayed only
+while it is at most five minutes old; older-but-still-valid announcements are
+consumed without further propagation. Accepted headers retain their original
+CBOR; headers within the relay-age bound enter the same per-connection delivery
+log as locally forged announcements, so followers consume them and relays
+diffuse them without
+changing the block wire format. Duplicate observations and a third distinct
+announcement for one election are suppressed, and accepted traces log the
+observed slot and lateness. The Go dependency has no separate Lookahead state
+type; its bounded pipelined request window is configured to the protocol
+maximum, providing the w31 request-window behavior while remaining compatible
+with w30 peers that accept and ignore the announcement payload. Full consensus
 validation of the announced endorser block remains outside LeiosNotify and is
 intentionally handled by the existing leios-fetch/ledger paths.
 Dijkstra blocks and transactions retain their original wire CBOR when

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1276,8 +1276,12 @@ log as locally forged announcements, so followers consume them and relays
 diffuse them without
 changing the block wire format. Duplicate observations and a third distinct
 announcement for one election are suppressed, and accepted traces log the
-observed slot and lateness. The Go dependency has no separate Lookahead state
-type; its bounded pipelined request window is configured to the protocol
+observed slot and lateness. Before an announcement can affect the cross-peer
+EB-size invariant, the decoded ranking header is verified against the current
+ledger state, including VRF/KES and leader eligibility. Deduplication state is
+pruned when its announced slot leaves the ten-minute acceptance window,
+including the EB-size and per-election indexes. The Go dependency has no
+separate Lookahead state type; its bounded pipelined request window is configured to the protocol
 maximum, providing the w31 request-window behavior while remaining compatible
 with w30 peers that accept and ignore the announcement payload. Full consensus
 validation of the announced endorser block remains outside LeiosNotify and is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1281,7 +1281,10 @@ EB-size invariant, the decoded ranking header is verified against the current
 ledger state, including VRF/KES and leader eligibility. Announcements are
 rejected when ledger state is unavailable, and slot/freshness and structural
 checks run before cryptographic validation. Header-only validation does not
-advance the shared epoch cache. Deduplication state is
+advance the shared epoch cache. If the required epoch data is not cached yet,
+the announcement is retained in a bounded pending set and retried after chain
+updates or epoch transitions; it is never relayed until validation succeeds.
+Deduplication state is
 pruned when its announced slot leaves the ten-minute acceptance window,
 including the EB-size and per-election indexes. The Go dependency has no
 separate Lookahead state type; its bounded pipelined request window is configured to the protocol

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1265,8 +1265,19 @@ importer nevertheless recognizes the matching Dijkstra `StakePoolState` field
 fields correctly; malformed key/proof lengths reject that pool state. The same
 prototype release also changes `MsgLeiosBlockAnnouncement` from a null
 placeholder to the full ranking-block header. The LeiosNotify client accepts
-that header and intentionally ignores it until ranking-header announcements
-feed a Dingo pipeline; chain-sync remains the source of ranking blocks.
+that header. In prototype-2026w31, `ouroboros/` decodes the Dijkstra header,
+requires a valid `leios_announcement`, rejects future or more-than-two-slot-old
+announcements, and rejects a repeated endorser-block hash whose size differs
+from an earlier observation. Accepted headers retain their original CBOR and
+enter the same per-connection delivery log as locally forged announcements,
+so followers consume them and relays diffuse them without changing the block
+wire format. Duplicate observations are suppressed, and accepted traces log
+the observed slot and lateness. The Go dependency has no separate Lookahead
+state type; its bounded pipelined request window is configured to the protocol
+maximum, providing the w31 Lookahead behavior while remaining compatible with
+w30 peers that accept and ignore the announcement payload. Full consensus
+validation of the announced endorser block remains outside LeiosNotify and is
+intentionally handled by the existing leios-fetch/ledger paths.
 Dijkstra blocks and transactions retain their original wire CBOR when
 re-encoded, avoiding the definite/indefinite-list rewrite that
 prototype-2026w30 exposed in the Haskell ledger bridge.

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -86,6 +86,21 @@ func (ls *LedgerState) verifyBlockHeaderOnlyCrypto(header ledger.BlockHeader) er
 	return err
 }
 
+// ValidateBlockHeaderCrypto validates a header using the current ledger
+// state.  It is used by protocol handlers that receive a header without its
+// block body (for example LeiosNotify announcements) and must not let an
+// unauthenticated header influence shared state.
+func (ls *LedgerState) ValidateBlockHeaderCrypto(header ledger.BlockHeader) error {
+	if header == nil {
+		return errors.New("nil block header")
+	}
+	return ls.verifyBlockHeaderCryptoWithEpochAdvance(
+		headerOnlyBlock{header: header},
+		true,
+		false,
+	)
+}
+
 // verifyBlockHeader performs cryptographic verification of a block header.
 // This includes VRF proof verification and KES signature verification.
 // Byron-era blocks are skipped because they use a different consensus

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -61,7 +61,8 @@ var (
 )
 
 // IsHeaderVerificationDeferred reports whether header-only verification could
-// not proceed because the epoch data is not in the cache yet.
+// not proceed because required ledger state, epoch data, or stake snapshot
+// data is not available yet.
 func IsHeaderVerificationDeferred(err error) bool {
 	return errors.Is(err, errHeaderVerificationDeferred)
 }

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -96,7 +96,7 @@ func (ls *LedgerState) ValidateBlockHeaderCrypto(header ledger.BlockHeader) erro
 	}
 	return ls.verifyBlockHeaderCryptoWithEpochAdvance(
 		headerOnlyBlock{header: header},
-		true,
+		false,
 		false,
 	)
 }

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -60,6 +60,12 @@ var (
 	errLeaderStakeSnapshotUnavailable = errors.New("leader stake snapshot unavailable")
 )
 
+// IsHeaderVerificationDeferred reports whether header-only verification could
+// not proceed because the epoch data is not in the cache yet.
+func IsHeaderVerificationDeferred(err error) bool {
+	return errors.Is(err, errHeaderVerificationDeferred)
+}
+
 func (b headerOnlyBlock) Header() ledger.BlockHeader { return b.header }
 func (b headerOnlyBlock) Type() int                  { return 0 }
 func (b headerOnlyBlock) Transactions() []lcommon.Transaction {

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -931,6 +931,7 @@ func TestVerifyBlockHeaderCryptoBeforeApplyDefersMissingPoolState(
 	err := ls.verifyBlockHeaderCryptoBeforeApply(tb.block)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errHeaderVerificationDeferred)
+	assert.True(t, IsHeaderVerificationDeferred(err))
 
 	err = ls.verifyBlockHeaderCrypto(tb.block)
 	require.Error(t, err)

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -760,6 +760,32 @@ func TestHeaderVerificationEpochRejectsPastForecastBeforeCacheAdvance(
 		"past-horizon rejection must happen before forecast cache mutation")
 }
 
+func TestValidateBlockHeaderCryptoDoesNotAdvanceEpochCache(t *testing.T) {
+	const futureSlot = uint64(1001)
+	ls := &LedgerState{
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(500, []byte("tip"))},
+		epochCache: []models.Epoch{{
+			EpochId:       500,
+			StartSlot:     0,
+			SlotLength:    1_000,
+			LengthInSlots: 1_000,
+			EraId:         eras.ConwayEraDesc.Id,
+			Nonce:         []byte{0x01},
+		}},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	err := ls.ValidateBlockHeaderCrypto(&mockBabbageBlock{slot: futureSlot})
+	require.Error(t, err)
+	assert.Len(t, ls.loadConsensusSnapshot().epochCache, 1,
+		"header-only validation must not advance the shared epoch cache")
+}
+
 // TestVerifyBlockHeaderCrypto_RejectsBlockWithNoNonce verifies that a block
 // in an epoch that has no nonce (e.g., epoch rollover not yet processed)
 // is rejected.

--- a/node_forging.go
+++ b/node_forging.go
@@ -38,6 +38,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/consensus"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -306,6 +307,17 @@ func (n *Node) initBlockForger(
 		leiosEBCaster = n.ouroboros
 		leiosMempool = mempoolAdapter
 	}
+	blockForged := n.ledgerState.RecordForgedBlock
+	if n.ouroboros != nil {
+		blockForged = func(block gledger.Block, blockCbor []byte, latency time.Duration) {
+			n.ledgerState.RecordForgedBlock(block, blockCbor, latency)
+			if header, ok := block.Header().(*gdijkstra.DijkstraBlockHeader); ok {
+				if _, _, announces := header.LeiosAnnouncement(); announces {
+					n.ouroboros.EnqueueLeiosBlockAnnouncement(header.Cbor())
+				}
+			}
+		}
+	}
 
 	// Wire self-validation when the operator opts in. The validator runs
 	// header crypto, body-hash, and per-tx ledger checks before AddBlock.
@@ -324,7 +336,7 @@ func (n *Node) initBlockForger(
 		LeaderChecker:                   election,
 		BlockBuilder:                    builder,
 		BlockBroadcaster:                broadcaster,
-		BlockForged:                     n.ledgerState.RecordForgedBlock,
+		BlockForged:                     blockForged,
 		SlotClock:                       slotClock,
 		ForgeSyncToleranceSlots:         n.config.forgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots:     n.config.forgeStaleGapThresholdSlots,

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -247,7 +247,7 @@ func TestLeiosNotifyBlockTxsOfferCacheMissIsNonFatal(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestLeiosNotifyBlockAnnouncementWithHeaderIsIgnored(t *testing.T) {
+func TestLeiosNotifyBlockAnnouncementIsConsumedAndDeduplicated(t *testing.T) {
 	cm := connmanager.NewConnectionManager(connmanager.ConnectionManagerConfig{})
 	conn, err := gouroboros.New()
 	require.NoError(t, err)
@@ -262,12 +262,50 @@ func TestLeiosNotifyBlockAnnouncementWithHeaderIsIgnored(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, components, 2)
 
+	var ebHash lcommon.Blake2b256
+	ebHash[0] = 0xaa
+	var headerTop []cbor.RawMessage
+	_, err = cbor.Decode(components[0], &headerTop)
+	require.NoError(t, err)
+	var headerBody []cbor.RawMessage
+	_, err = cbor.Decode(headerTop[0], &headerBody)
+	require.NoError(t, err)
+	headerBody = append(headerBody,
+		mustCbor(t, false),
+		mustCbor(t, []any{ebHash.Bytes(), uint64(1234)}),
+	)
+	headerTop[0], err = cbor.Encode(headerBody)
+	require.NoError(t, err)
+	headerRaw, err := cbor.Encode(headerTop)
+	require.NoError(t, err)
+
 	o := NewOuroboros(OuroborosConfig{ConnManager: cm, EnableLeios: true})
+	o.leiosEBLog.registerConn("test")
 	err = o.leiosnotifyClientNotification(
 		oleiosnotify.CallbackContext{ConnectionId: conn.Id()},
-		oleiosnotify.NewMsgBlockAnnouncement(components[0]),
+		oleiosnotify.NewMsgBlockAnnouncement(headerRaw),
 	)
 	require.NoError(t, err)
+	err = o.leiosnotifyClientNotification(
+		oleiosnotify.CallbackContext{ConnectionId: conn.Id()},
+		oleiosnotify.NewMsgBlockAnnouncement(headerRaw),
+	)
+	require.NoError(t, err)
+	entry, _ := o.leiosEBLog.next("test")
+	require.NotNil(t, entry)
+	require.Equal(t, headerRaw, entry.announcement)
+	o.leiosEBLog.complete("test", true)
+	entry, _ = o.leiosEBLog.next("test")
+	require.Nil(t, entry)
+
+	// A different ranking block may not change the established size for the
+	// same endorser-block hash.
+	headerBody[len(headerBody)-1] = mustCbor(t, []any{ebHash.Bytes(), uint64(4321)})
+	headerTop[0], err = cbor.Encode(headerBody)
+	require.NoError(t, err)
+	headerRaw, err = cbor.Encode(headerTop)
+	require.NoError(t, err)
+	require.ErrorContains(t, o.acceptLeiosAnnouncement(headerRaw, "test"), "inconsistent")
 }
 
 var errLeiosEndorserBlockNotCached = errors.New("leios endorser block not cached")

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -292,6 +292,22 @@ func TestLeiosNotifyBlockAnnouncementIsConsumedAndDeduplicated(t *testing.T) {
 	)
 	require.NoError(t, err)
 	entry, _ := o.leiosEBLog.next("test")
+	require.Nil(t, entry)
+
+	record := func(raw []byte) error {
+		header, err := gdijkstra.NewDijkstraBlockHeaderFromCbor(raw)
+		if err != nil {
+			return err
+		}
+		ebHash, ebSize, ok := header.LeiosAnnouncement()
+		if !ok {
+			return errors.New("missing announcement")
+		}
+		return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, "test", true)
+	}
+	require.NoError(t, record(headerRaw))
+	require.NoError(t, record(headerRaw))
+	entry, _ = o.leiosEBLog.next("test")
 	require.NotNil(t, entry)
 	require.Equal(t, headerRaw, entry.announcement)
 	o.leiosEBLog.complete("test", true)
@@ -305,7 +321,7 @@ func TestLeiosNotifyBlockAnnouncementIsConsumedAndDeduplicated(t *testing.T) {
 	require.NoError(t, err)
 	headerRaw, err = cbor.Encode(headerTop)
 	require.NoError(t, err)
-	require.ErrorContains(t, o.acceptLeiosAnnouncement(headerRaw, "test"), "inconsistent")
+	require.ErrorContains(t, record(headerRaw), "inconsistent")
 
 	// A peer may announce at most two distinct ranking blocks for one
 	// slot/issuer election. The third distinct message is suppressed even when
@@ -316,19 +332,20 @@ func TestLeiosNotifyBlockAnnouncementIsConsumedAndDeduplicated(t *testing.T) {
 	require.NoError(t, err)
 	headerRaw, err = cbor.Encode(headerTop)
 	require.NoError(t, err)
-	require.NoError(t, o.acceptLeiosAnnouncement(headerRaw, "test"))
+	require.NoError(t, record(headerRaw))
 	headerBody[0] = mustCbor(t, uint64(3))
 	headerTop[0], err = cbor.Encode(headerBody)
 	require.NoError(t, err)
 	headerRaw, err = cbor.Encode(headerTop)
 	require.NoError(t, err)
-	require.NoError(t, o.acceptLeiosAnnouncement(headerRaw, "test"))
-	headerBody[0] = mustCbor(t, uint64(4))
-	headerTop[0], err = cbor.Encode(headerBody)
-	require.NoError(t, err)
-	headerRaw, err = cbor.Encode(headerTop)
-	require.NoError(t, err)
-	require.ErrorContains(t, o.acceptLeiosAnnouncement(headerRaw, "test"), "third distinct")
+	require.ErrorContains(t, record(headerRaw), "third distinct")
+}
+
+func TestAcceptLeiosAnnouncementRejectsWithoutLedgerState(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	require.ErrorContains(t, o.acceptLeiosAnnouncement([]byte("not cbor"), "test"), "without ledger state")
+	require.Empty(t, o.leiosAnnouncements)
+	require.Empty(t, o.leiosEBLog.items)
 }
 
 var errLeiosEndorserBlockNotCached = errors.New("leios endorser block not cached")

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -343,9 +343,14 @@ func TestLeiosNotifyBlockAnnouncementIsConsumedAndDeduplicated(t *testing.T) {
 
 func TestAcceptLeiosAnnouncementRejectsWithoutLedgerState(t *testing.T) {
 	o := NewOuroboros(OuroborosConfig{EnableLeios: true})
+	o.leiosDeferredAnnouncements["pending"] = leiosDeferredAnnouncement{
+		raw: []byte("deferred"), source: "peer",
+	}
 	require.ErrorContains(t, o.acceptLeiosAnnouncement([]byte("not cbor"), "test"), "without ledger state")
 	require.Empty(t, o.leiosAnnouncements)
 	require.Empty(t, o.leiosEBLog.items)
+	_, stillDeferred := o.leiosDeferredAnnouncements["pending"]
+	require.True(t, stillDeferred)
 }
 
 var errLeiosEndorserBlockNotCached = errors.New("leios endorser block not cached")

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -306,6 +306,29 @@ func TestLeiosNotifyBlockAnnouncementIsConsumedAndDeduplicated(t *testing.T) {
 	headerRaw, err = cbor.Encode(headerTop)
 	require.NoError(t, err)
 	require.ErrorContains(t, o.acceptLeiosAnnouncement(headerRaw, "test"), "inconsistent")
+
+	// A peer may announce at most two distinct ranking blocks for one
+	// slot/issuer election. The third distinct message is suppressed even when
+	// its endorser-block size is otherwise consistent.
+	headerBody[len(headerBody)-1] = mustCbor(t, []any{ebHash.Bytes(), uint64(1234)})
+	headerBody[0] = mustCbor(t, uint64(2))
+	headerTop[0], err = cbor.Encode(headerBody)
+	require.NoError(t, err)
+	headerRaw, err = cbor.Encode(headerTop)
+	require.NoError(t, err)
+	require.NoError(t, o.acceptLeiosAnnouncement(headerRaw, "test"))
+	headerBody[0] = mustCbor(t, uint64(3))
+	headerTop[0], err = cbor.Encode(headerBody)
+	require.NoError(t, err)
+	headerRaw, err = cbor.Encode(headerTop)
+	require.NoError(t, err)
+	require.NoError(t, o.acceptLeiosAnnouncement(headerRaw, "test"))
+	headerBody[0] = mustCbor(t, uint64(4))
+	headerTop[0], err = cbor.Encode(headerBody)
+	require.NoError(t, err)
+	headerRaw, err = cbor.Encode(headerTop)
+	require.NoError(t, err)
+	require.ErrorContains(t, o.acceptLeiosAnnouncement(headerRaw, "test"), "third distinct")
 }
 
 var errLeiosEndorserBlockNotCached = errors.New("leios endorser block not cached")

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -23,6 +23,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -61,6 +64,13 @@ type leiosAnnouncement struct {
 	// electionKey lets pruning rebuild the bounded per-election index.
 	electionKey string
 }
+
+type leiosDeferredAnnouncement struct {
+	raw    []byte
+	source string
+}
+
+const leiosMaxDeferredAnnouncements = 128
 
 type leiosDeliveryReservation struct {
 	index int
@@ -1143,6 +1153,15 @@ func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
 // the w31 relay-age bound. The raw header is retained so the relay preserves
 // the producer's signed bytes.
 func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
+	o.retryDeferredLeiosAnnouncements()
+	return o.acceptLeiosAnnouncementInternal(raw, source, true)
+}
+
+func (o *Ouroboros) acceptLeiosAnnouncementInternal(
+	raw []byte,
+	source string,
+	deferVerification bool,
+) error {
 	if o.LedgerState == nil {
 		return errors.New("cannot accept leios announcement without ledger state")
 	}
@@ -1173,6 +1192,9 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 		return fmt.Errorf("announcement is stale by %s", age)
 	}
 	if err := o.LedgerState.ValidateBlockHeaderCrypto(header); err != nil {
+		if ledger.IsHeaderVerificationDeferred(err) && deferVerification {
+			o.deferLeiosAnnouncement(header, raw, source)
+		}
 		return fmt.Errorf("validate ranking-block header: %w", err)
 	}
 	// Drop announcements that can no longer affect the acceptance window
@@ -1194,6 +1216,53 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 		return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, false)
 	}
 	return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, true)
+}
+
+func (o *Ouroboros) deferLeiosAnnouncement(
+	header *gdijkstra.DijkstraBlockHeader,
+	raw []byte,
+	source string,
+) {
+	key := fmt.Sprintf("%s:%x", source, header.Hash().Bytes())
+	o.leiosDeferredMu.Lock()
+	defer o.leiosDeferredMu.Unlock()
+	if len(o.leiosDeferredAnnouncements) >= leiosMaxDeferredAnnouncements {
+		return
+	}
+	if _, exists := o.leiosDeferredAnnouncements[key]; !exists {
+		o.leiosDeferredAnnouncements[key] = leiosDeferredAnnouncement{
+			raw: append([]byte(nil), raw...), source: source,
+		}
+	}
+}
+
+// retryDeferredLeiosAnnouncements retries headers after ledger activity has
+// had an opportunity to populate the epoch cache. Deferred headers are never
+// relayed before this validation succeeds.
+func (o *Ouroboros) retryDeferredLeiosAnnouncements() {
+	o.leiosDeferredMu.Lock()
+	pending := make(map[string]leiosDeferredAnnouncement, len(o.leiosDeferredAnnouncements))
+	for key, announcement := range o.leiosDeferredAnnouncements {
+		pending[key] = announcement
+	}
+	o.leiosDeferredMu.Unlock()
+	for key, announcement := range pending {
+		err := o.acceptLeiosAnnouncementInternal(announcement.raw, announcement.source, false)
+		if err == nil || !ledger.IsHeaderVerificationDeferred(err) {
+			o.leiosDeferredMu.Lock()
+			delete(o.leiosDeferredAnnouncements, key)
+			o.leiosDeferredMu.Unlock()
+		}
+	}
+}
+
+func (o *Ouroboros) subscribeLeiosAnnouncementRetries() {
+	if !o.config.EnableLeios || o.EventBus == nil {
+		return
+	}
+	retry := func(event.Event) { o.retryDeferredLeiosAnnouncements() }
+	o.EventBus.SubscribeFunc(chain.ChainUpdateEventType, retry)
+	o.EventBus.SubscribeFunc(event.EpochTransitionEventType, retry)
 }
 
 // pruneLeiosAnnouncements bounds announcement deduplication state to the

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -1143,58 +1143,55 @@ func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
 // the w31 relay-age bound. The raw header is retained so the relay preserves
 // the producer's signed bytes.
 func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
+	if o.LedgerState == nil {
+		return errors.New("cannot accept leios announcement without ledger state")
+	}
 	header, err := gdijkstra.NewDijkstraBlockHeaderFromCbor(raw)
 	if err != nil {
 		return fmt.Errorf("decode ranking-block header: %w", err)
-	}
-	if o.LedgerState != nil {
-		if err := o.LedgerState.ValidateBlockHeaderCrypto(header); err != nil {
-			return fmt.Errorf("validate ranking-block header: %w", err)
-		}
 	}
 	ebHash, ebSize, ok := header.LeiosAnnouncement()
 	if !ok {
 		return errors.New("ranking-block header has no valid endorser-block announcement")
 	}
-	if o.LedgerState != nil {
-		currentSlot, slotErr := o.LedgerState.CurrentSlot()
-		if slotErr != nil {
-			return fmt.Errorf("read current slot for announcement validation: %w", slotErr)
-		}
-		if header.SlotNumber() > currentSlot {
-			return fmt.Errorf("announcement slot %d is ahead of current slot %d", header.SlotNumber(), currentSlot)
-		}
-		announcementStart, timeErr := o.LedgerState.SlotToTime(
-			header.SlotNumber(),
-		)
-		if timeErr != nil {
-			return fmt.Errorf("read announcement slot time: %w", timeErr)
-		}
-		age := time.Since(announcementStart)
-		if age < 0 {
-			return fmt.Errorf("announcement slot %d is in the future", header.SlotNumber())
-		}
-		if age > leiosNotifyMaxAnnouncementAge {
-			return fmt.Errorf("announcement is stale by %s", age)
-		}
-		// Drop announcements that can no longer affect the acceptance window
-		// before adding this one. This is deliberately done for local and peer
-		// announcements alike; otherwise a long-lived node retains every RB
-		// header it has ever seen.
-		o.pruneLeiosAnnouncements()
-		o.config.Logger.Debug(
-			"accepted leios announcement",
-			"component", "network",
-			"protocol", "leios-notify",
-			"connection_id", source,
-			"slot", header.SlotNumber(),
-			"lateness", age,
-		)
-		if age > leiosNotifyRelayAnnouncementAge {
-			// The announcement is still valid for the receiver, but the w31
-			// relay bound prevents an old message from propagating indefinitely.
-			return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, false)
-		}
+	currentSlot, slotErr := o.LedgerState.CurrentSlot()
+	if slotErr != nil {
+		return fmt.Errorf("read current slot for announcement validation: %w", slotErr)
+	}
+	if header.SlotNumber() > currentSlot {
+		return fmt.Errorf("announcement slot %d is ahead of current slot %d", header.SlotNumber(), currentSlot)
+	}
+	announcementStart, timeErr := o.LedgerState.SlotToTime(header.SlotNumber())
+	if timeErr != nil {
+		return fmt.Errorf("read announcement slot time: %w", timeErr)
+	}
+	age := time.Since(announcementStart)
+	if age < 0 {
+		return fmt.Errorf("announcement slot %d is in the future", header.SlotNumber())
+	}
+	if age > leiosNotifyMaxAnnouncementAge {
+		return fmt.Errorf("announcement is stale by %s", age)
+	}
+	if err := o.LedgerState.ValidateBlockHeaderCrypto(header); err != nil {
+		return fmt.Errorf("validate ranking-block header: %w", err)
+	}
+	// Drop announcements that can no longer affect the acceptance window
+	// before adding this one. This is deliberately done for local and peer
+	// announcements alike; otherwise a long-lived node retains every RB
+	// header it has ever seen.
+	o.pruneLeiosAnnouncements()
+	o.config.Logger.Debug(
+		"accepted leios announcement",
+		"component", "network",
+		"protocol", "leios-notify",
+		"connection_id", source,
+		"slot", header.SlotNumber(),
+		"lateness", age,
+	)
+	if age > leiosNotifyRelayAnnouncementAge {
+		// The announcement is still valid for the receiver, but the w31
+		// relay bound prevents an old message from propagating indefinitely.
+		return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, false)
 	}
 	return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, true)
 }
@@ -1242,6 +1239,7 @@ func (o *Ouroboros) recordLeiosAnnouncement(
 ) error {
 	key := string(header.Hash().Bytes())
 	o.leiosAnnouncementsMu.Lock()
+	defer o.leiosAnnouncementsMu.Unlock()
 	if o.leiosAnnouncements == nil {
 		o.leiosAnnouncements = make(map[string]leiosAnnouncement)
 	}
@@ -1253,15 +1251,12 @@ func (o *Ouroboros) recordLeiosAnnouncement(
 	}
 	ebKey := string(ebHash.Bytes())
 	if previousSize, exists := o.leiosAnnouncementSizes[ebKey]; exists && previousSize != ebSize {
-		o.leiosAnnouncementsMu.Unlock()
 		return errors.New("announcement size is inconsistent with a previously observed endorser block")
 	}
 	if previous, exists := o.leiosAnnouncements[key]; exists {
 		if previous.ebHash != ebHash || previous.ebSize != ebSize || string(previous.raw) != string(raw) {
-			o.leiosAnnouncementsMu.Unlock()
 			return errors.New("announcement is inconsistent with a previously observed ranking block")
 		}
-		o.leiosAnnouncementsMu.Unlock()
 		return nil
 	}
 	issuer := header.IssuerVkey()
@@ -1272,7 +1267,6 @@ func (o *Ouroboros) recordLeiosAnnouncement(
 		o.leiosAnnouncementElections[electionKey] = electionAnnouncements
 	}
 	if len(electionAnnouncements) >= 2 {
-		o.leiosAnnouncementsMu.Unlock()
 		return errors.New("announcement is the third distinct message for a previously observed election")
 	}
 	electionAnnouncements[key] = struct{}{}
@@ -1281,7 +1275,6 @@ func (o *Ouroboros) recordLeiosAnnouncement(
 		electionKey: electionKey,
 	}
 	o.leiosAnnouncementSizes[ebKey] = ebSize
-	o.leiosAnnouncementsMu.Unlock()
 	if relay {
 		o.leiosEBLog.append(leiosForgedEBEntry{announcement: append([]byte(nil), raw...)})
 	}

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -44,10 +44,14 @@ type leiosForgedEBEntry struct {
 	announcement []byte
 }
 
-// prototype-2026w31 accepts an announcement only while it is recent enough
-// to be useful for the current diffusion round. A header from a future slot
-// is never valid; an older header is stale once this bound is exceeded.
-const leiosNotifyMaxAnnouncementAge = 2
+// prototype-2026w31 accepts announcements for up to ten minutes, and only
+// relays them while they are at most five minutes old. The reference node
+// measures these bounds from the announced slot's wall-clock onset. Dingo
+// uses the ledger's era-aware slot-time conversion below.
+const (
+	leiosNotifyMaxAnnouncementAge   = 10 * time.Minute
+	leiosNotifyRelayAnnouncementAge = 5 * time.Minute
+)
 
 type leiosAnnouncement struct {
 	raw    []byte
@@ -1133,8 +1137,9 @@ func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
 }
 
 // acceptLeiosAnnouncement validates and records one w31 announcement, then
-// queues it for diffusion to all connected LeiosNotify peers. The raw header
-// is retained so the relay preserves the producer's signed bytes.
+// queues it for diffusion to all connected LeiosNotify peers when it is within
+// the w31 relay-age bound. The raw header is retained so the relay preserves
+// the producer's signed bytes.
 func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 	header, err := gdijkstra.NewDijkstraBlockHeaderFromCbor(raw)
 	if err != nil {
@@ -1152,9 +1157,18 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 		if header.SlotNumber() > currentSlot {
 			return fmt.Errorf("announcement slot %d is ahead of current slot %d", header.SlotNumber(), currentSlot)
 		}
-		age := currentSlot - header.SlotNumber()
+		announcementStart, timeErr := o.LedgerState.SlotToTime(
+			header.SlotNumber(),
+		)
+		if timeErr != nil {
+			return fmt.Errorf("read announcement slot time: %w", timeErr)
+		}
+		age := time.Since(announcementStart)
+		if age < 0 {
+			return fmt.Errorf("announcement slot %d is in the future", header.SlotNumber())
+		}
 		if age > leiosNotifyMaxAnnouncementAge {
-			return fmt.Errorf("announcement is stale by %d slots", age)
+			return fmt.Errorf("announcement is stale by %s", age)
 		}
 		o.config.Logger.Debug(
 			"accepted leios announcement",
@@ -1164,7 +1178,26 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 			"slot", header.SlotNumber(),
 			"lateness", age,
 		)
+		if source != "local" && age > leiosNotifyRelayAnnouncementAge {
+			// The announcement is still valid for the receiver, but the w31
+			// relay bound prevents an old message from propagating indefinitely.
+			return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, false)
+		}
 	}
+	return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, true)
+}
+
+// recordLeiosAnnouncement performs the consistency checks shared by local
+// announcements and peer announcements, and optionally queues a valid
+// announcement for relay.
+func (o *Ouroboros) recordLeiosAnnouncement(
+	raw []byte,
+	ebHash lcommon.Blake2b256,
+	ebSize uint64,
+	header *gdijkstra.DijkstraBlockHeader,
+	source string,
+	relay bool,
+) error {
 	key := string(header.Hash().Bytes())
 	o.leiosAnnouncementsMu.Lock()
 	if o.leiosAnnouncements == nil {
@@ -1172,6 +1205,9 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 	}
 	if o.leiosAnnouncementSizes == nil {
 		o.leiosAnnouncementSizes = make(map[string]uint64)
+	}
+	if o.leiosAnnouncementElections == nil {
+		o.leiosAnnouncementElections = make(map[string]map[string]struct{})
 	}
 	ebKey := string(ebHash.Bytes())
 	if previousSize, exists := o.leiosAnnouncementSizes[ebKey]; exists && previousSize != ebSize {
@@ -1186,12 +1222,26 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 		o.leiosAnnouncementsMu.Unlock()
 		return nil
 	}
+	issuer := header.IssuerVkey()
+	electionKey := fmt.Sprintf("%s:%d:%x", source, header.SlotNumber(), issuer)
+	electionAnnouncements := o.leiosAnnouncementElections[electionKey]
+	if electionAnnouncements == nil {
+		electionAnnouncements = make(map[string]struct{})
+		o.leiosAnnouncementElections[electionKey] = electionAnnouncements
+	}
+	if len(electionAnnouncements) >= 2 {
+		o.leiosAnnouncementsMu.Unlock()
+		return errors.New("announcement is the third distinct message for a previously observed election")
+	}
+	electionAnnouncements[key] = struct{}{}
 	o.leiosAnnouncements[key] = leiosAnnouncement{
 		raw: append([]byte(nil), raw...), ebHash: ebHash, ebSize: ebSize, slot: header.SlotNumber(),
 	}
 	o.leiosAnnouncementSizes[ebKey] = ebSize
 	o.leiosAnnouncementsMu.Unlock()
-	o.leiosEBLog.append(leiosForgedEBEntry{announcement: append([]byte(nil), raw...)})
+	if relay {
+		o.leiosEBLog.append(leiosForgedEBEntry{announcement: append([]byte(nil), raw...)})
+	}
 	return nil
 }
 

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -1153,7 +1153,6 @@ func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
 // the w31 relay-age bound. The raw header is retained so the relay preserves
 // the producer's signed bytes.
 func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
-	o.retryDeferredLeiosAnnouncements()
 	return o.acceptLeiosAnnouncementInternal(raw, source, true)
 }
 

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -58,6 +58,8 @@ type leiosAnnouncement struct {
 	ebHash lcommon.Blake2b256
 	ebSize uint64
 	slot   uint64
+	// electionKey lets pruning rebuild the bounded per-election index.
+	electionKey string
 }
 
 type leiosDeliveryReservation struct {
@@ -1145,6 +1147,11 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 	if err != nil {
 		return fmt.Errorf("decode ranking-block header: %w", err)
 	}
+	if o.LedgerState != nil {
+		if err := o.LedgerState.ValidateBlockHeaderCrypto(header); err != nil {
+			return fmt.Errorf("validate ranking-block header: %w", err)
+		}
+	}
 	ebHash, ebSize, ok := header.LeiosAnnouncement()
 	if !ok {
 		return errors.New("ranking-block header has no valid endorser-block announcement")
@@ -1170,6 +1177,11 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 		if age > leiosNotifyMaxAnnouncementAge {
 			return fmt.Errorf("announcement is stale by %s", age)
 		}
+		// Drop announcements that can no longer affect the acceptance window
+		// before adding this one. This is deliberately done for local and peer
+		// announcements alike; otherwise a long-lived node retains every RB
+		// header it has ever seen.
+		o.pruneLeiosAnnouncements()
 		o.config.Logger.Debug(
 			"accepted leios announcement",
 			"component", "network",
@@ -1178,13 +1190,43 @@ func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
 			"slot", header.SlotNumber(),
 			"lateness", age,
 		)
-		if source != "local" && age > leiosNotifyRelayAnnouncementAge {
+		if age > leiosNotifyRelayAnnouncementAge {
 			// The announcement is still valid for the receiver, but the w31
 			// relay bound prevents an old message from propagating indefinitely.
 			return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, false)
 		}
 	}
 	return o.recordLeiosAnnouncement(raw, ebHash, ebSize, header, source, true)
+}
+
+// pruneLeiosAnnouncements bounds announcement deduplication state to the
+// same ten-minute window used by acceptLeiosAnnouncement. The size index is
+// rebuilt from the retained announcements so an old EB cannot keep its size
+// invariant alive after its announcements expire.
+func (o *Ouroboros) pruneLeiosAnnouncements() {
+	if o.LedgerState == nil {
+		return
+	}
+	now := time.Now()
+	o.leiosAnnouncementsMu.Lock()
+	defer o.leiosAnnouncementsMu.Unlock()
+	for key, announcement := range o.leiosAnnouncements {
+		start, err := o.LedgerState.SlotToTime(announcement.slot)
+		if err != nil || now.Sub(start) > leiosNotifyMaxAnnouncementAge {
+			delete(o.leiosAnnouncements, key)
+		}
+	}
+	o.leiosAnnouncementSizes = make(map[string]uint64, len(o.leiosAnnouncements))
+	o.leiosAnnouncementElections = make(map[string]map[string]struct{})
+	for key, announcement := range o.leiosAnnouncements {
+		o.leiosAnnouncementSizes[string(announcement.ebHash.Bytes())] = announcement.ebSize
+		election := o.leiosAnnouncementElections[announcement.electionKey]
+		if election == nil {
+			election = make(map[string]struct{})
+			o.leiosAnnouncementElections[announcement.electionKey] = election
+		}
+		election[key] = struct{}{}
+	}
 }
 
 // recordLeiosAnnouncement performs the consistency checks shared by local
@@ -1236,6 +1278,7 @@ func (o *Ouroboros) recordLeiosAnnouncement(
 	electionAnnouncements[key] = struct{}{}
 	o.leiosAnnouncements[key] = leiosAnnouncement{
 		raw: append([]byte(nil), raw...), ebHash: ebHash, ebSize: ebSize, slot: header.SlotNumber(),
+		electionKey: electionKey,
 	}
 	o.leiosAnnouncementSizes[ebKey] = ebSize
 	o.leiosAnnouncementsMu.Unlock()

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -26,6 +26,7 @@ import (
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
@@ -38,6 +39,21 @@ type leiosForgedEBEntry struct {
 	point *ocommon.Point
 	size  uint64
 	vote  *lcommon.LeiosPrototypeVote
+	// announcement is the raw Dijkstra ranking-block header sent in the
+	// w31 BlockAnnouncement message.
+	announcement []byte
+}
+
+// prototype-2026w31 accepts an announcement only while it is recent enough
+// to be useful for the current diffusion round. A header from a future slot
+// is never valid; an older header is stale once this bound is exceeded.
+const leiosNotifyMaxAnnouncementAge = 2
+
+type leiosAnnouncement struct {
+	raw    []byte
+	ebHash lcommon.Blake2b256
+	ebSize uint64
+	slot   uint64
 }
 
 type leiosDeliveryReservation struct {
@@ -349,6 +365,11 @@ func (o *Ouroboros) leiosnotifyClientConnOpts() []oleiosnotify.LeiosNotifyOption
 				o.leiosnotifyClientNotification,
 			),
 		),
+		// Keep the bounded request window full. This is the gouroboros
+		// equivalent of the prototype's Lookahead server mode: the server can
+		// hold each request until a notification is available, while the client
+		// keeps several requests outstanding.
+		oleiosnotify.WithPipelineLimit(oleiosnotify.MaxPipelineLimit),
 		// Disable the Busy-state timeout. LeiosNotify is a push-based
 		// notification protocol where the server only sends when it has
 		// something to announce. Idle waits of arbitrary length are
@@ -445,10 +466,19 @@ func (o *Ouroboros) leiosnotifyClientNotification(
 	}
 	switch m := msg.(type) {
 	case *oleiosnotify.MsgBlockAnnouncement:
-		// prototype-2026w30 sends the full ranking-block header here instead of
-		// CBOR null. gouroboros retains that payload as raw CBOR; accept it but
-		// intentionally ignore it until dingo's announcement pipeline consumes
-		// ranking-block headers directly.
+		// w31 carries the full ranking-block header. Validate before accepting
+		// it into the relay log; invalid announcements are deliberately
+		// suppressed so a peer cannot tear down a shared connection with a
+		// malformed or stale experimental message.
+		if err := o.acceptLeiosAnnouncement(m.BlockHeaderRaw, connId); err != nil {
+			o.config.Logger.Debug(
+				"suppressing invalid leios announcement",
+				"component", "network",
+				"protocol", "leios-notify",
+				"connection_id", connId,
+				"error", err,
+			)
+		}
 		return nil
 	case *oleiosnotify.MsgBlockOffer:
 		// While the ledger is deeply behind the head, do not prefetch this
@@ -1087,6 +1117,10 @@ func leiosCollectTxs(result []cbor.RawMessage) []cbor.RawMessage {
 // so the EB would never be offered, fetched, voted on, or certified.
 func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
 	switch {
+	case entry.announcement != nil:
+		return oleiosnotify.NewMsgBlockAnnouncement(
+			cbor.RawMessage(entry.announcement),
+		)
 	case entry.vote != nil:
 		return oleiosnotify.NewMsgVotesOfferPrototype(
 			[]lcommon.LeiosPrototypeVote{*entry.vote},
@@ -1095,6 +1129,77 @@ func leiosForgedEBOffer(entry *leiosForgedEBEntry) protocol.Message {
 		return oleiosnotify.NewMsgBlockOffer(*entry.point, entry.size)
 	default:
 		return nil
+	}
+}
+
+// acceptLeiosAnnouncement validates and records one w31 announcement, then
+// queues it for diffusion to all connected LeiosNotify peers. The raw header
+// is retained so the relay preserves the producer's signed bytes.
+func (o *Ouroboros) acceptLeiosAnnouncement(raw []byte, source string) error {
+	header, err := gdijkstra.NewDijkstraBlockHeaderFromCbor(raw)
+	if err != nil {
+		return fmt.Errorf("decode ranking-block header: %w", err)
+	}
+	ebHash, ebSize, ok := header.LeiosAnnouncement()
+	if !ok {
+		return errors.New("ranking-block header has no valid endorser-block announcement")
+	}
+	if o.LedgerState != nil {
+		currentSlot, slotErr := o.LedgerState.CurrentSlot()
+		if slotErr != nil {
+			return fmt.Errorf("read current slot for announcement validation: %w", slotErr)
+		}
+		if header.SlotNumber() > currentSlot {
+			return fmt.Errorf("announcement slot %d is ahead of current slot %d", header.SlotNumber(), currentSlot)
+		}
+		age := currentSlot - header.SlotNumber()
+		if age > leiosNotifyMaxAnnouncementAge {
+			return fmt.Errorf("announcement is stale by %d slots", age)
+		}
+		o.config.Logger.Debug(
+			"accepted leios announcement",
+			"component", "network",
+			"protocol", "leios-notify",
+			"connection_id", source,
+			"slot", header.SlotNumber(),
+			"lateness", age,
+		)
+	}
+	key := string(header.Hash().Bytes())
+	o.leiosAnnouncementsMu.Lock()
+	if o.leiosAnnouncements == nil {
+		o.leiosAnnouncements = make(map[string]leiosAnnouncement)
+	}
+	if o.leiosAnnouncementSizes == nil {
+		o.leiosAnnouncementSizes = make(map[string]uint64)
+	}
+	ebKey := string(ebHash.Bytes())
+	if previousSize, exists := o.leiosAnnouncementSizes[ebKey]; exists && previousSize != ebSize {
+		o.leiosAnnouncementsMu.Unlock()
+		return errors.New("announcement size is inconsistent with a previously observed endorser block")
+	}
+	if previous, exists := o.leiosAnnouncements[key]; exists {
+		if previous.ebHash != ebHash || previous.ebSize != ebSize || string(previous.raw) != string(raw) {
+			o.leiosAnnouncementsMu.Unlock()
+			return errors.New("announcement is inconsistent with a previously observed ranking block")
+		}
+		o.leiosAnnouncementsMu.Unlock()
+		return nil
+	}
+	o.leiosAnnouncements[key] = leiosAnnouncement{
+		raw: append([]byte(nil), raw...), ebHash: ebHash, ebSize: ebSize, slot: header.SlotNumber(),
+	}
+	o.leiosAnnouncementSizes[ebKey] = ebSize
+	o.leiosAnnouncementsMu.Unlock()
+	o.leiosEBLog.append(leiosForgedEBEntry{announcement: append([]byte(nil), raw...)})
+	return nil
+}
+
+// EnqueueLeiosBlockAnnouncement validates and queues a locally forged
+// ranking-block header for LeiosNotify diffusion.
+func (o *Ouroboros) EnqueueLeiosBlockAnnouncement(raw []byte) {
+	if err := o.acceptLeiosAnnouncement(raw, "local"); err != nil {
+		o.config.Logger.Debug("suppressing local leios announcement", "error", err)
 	}
 }
 

--- a/ouroboros/leiosnotify_offer_test.go
+++ b/ouroboros/leiosnotify_offer_test.go
@@ -64,3 +64,12 @@ func TestLeiosForgedEBOfferSetsVotesOfferType(t *testing.T) {
 func TestLeiosForgedEBOfferEmptyEntryNil(t *testing.T) {
 	require.Nil(t, leiosForgedEBOffer(&leiosForgedEBEntry{}))
 }
+
+func TestLeiosForgedEBOfferAnnouncement(t *testing.T) {
+	raw := []byte{0x82, 0x01, 0x02}
+	msg := leiosForgedEBOffer(&leiosForgedEBEntry{announcement: raw})
+	require.Equal(t, uint8(oleiosnotify.MessageTypeBlockAnnouncement), msg.Type())
+	announcement, ok := msg.(*oleiosnotify.MsgBlockAnnouncement)
+	require.True(t, ok)
+	require.Equal(t, raw, []byte(announcement.BlockHeaderRaw))
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -127,6 +127,11 @@ type Ouroboros struct {
 	leiosAnnouncementsMu   sync.Mutex
 	leiosAnnouncements     map[string]leiosAnnouncement
 	leiosAnnouncementSizes map[string]uint64
+	// LeiosNotify permits at most two distinct announcements for one election
+	// (slot plus issuer) from each peer. Keep that bound per source so one
+	// equivocating peer cannot inject an unbounded stream without suppressing
+	// independent observations from other peers.
+	leiosAnnouncementElections map[string]map[string]struct{}
 
 	// Asynchronous best-effort persistence of fetched endorser blocks to the
 	// blob store for historical serving. The blob write (CBOR encode + commit)
@@ -272,17 +277,18 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		cfg.ChainsyncBlockTimeout,
 	)
 	o := &Ouroboros{
-		config:                   cfg,
-		EventBus:                 cfg.EventBus,
-		ConnManager:              cfg.ConnManager,
-		blockFetchStarts:         make(map[ouroboros.ConnectionId]time.Time),
-		blockfetchNoBlocksCounts: make(map[ouroboros.ConnectionId]blockfetchNoBlocksState),
-		chainsyncStats:           make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
-		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
-		leiosClosureWaiters:      make(map[string][]chan struct{}),
-		leiosEBLog:               newLeiosForgedEBLog(),
-		leiosAnnouncements:       make(map[string]leiosAnnouncement),
-		leiosAnnouncementSizes:   make(map[string]uint64),
+		config:                     cfg,
+		EventBus:                   cfg.EventBus,
+		ConnManager:                cfg.ConnManager,
+		blockFetchStarts:           make(map[ouroboros.ConnectionId]time.Time),
+		blockfetchNoBlocksCounts:   make(map[ouroboros.ConnectionId]blockfetchNoBlocksState),
+		chainsyncStats:             make(map[ouroboros.ConnectionId]*chainsyncPeerStats),
+		leiosEndorserBlocks:        make(map[string]*leiosEndorserBlockData),
+		leiosClosureWaiters:        make(map[string][]chan struct{}),
+		leiosEBLog:                 newLeiosForgedEBLog(),
+		leiosAnnouncements:         make(map[string]leiosAnnouncement),
+		leiosAnnouncementSizes:     make(map[string]uint64),
+		leiosAnnouncementElections: make(map[string]map[string]struct{}),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -121,6 +121,12 @@ type Ouroboros struct {
 
 	// Locally-forged EB broadcast log (cursors are owned by the log).
 	leiosEBLog *leiosForgedEBLog
+	// LeiosNotify ranking-block announcements observed on this node. The map
+	// is keyed by announcing ranking-block hash and prevents an inconsistent
+	// second description of the same ranking block from being relayed.
+	leiosAnnouncementsMu   sync.Mutex
+	leiosAnnouncements     map[string]leiosAnnouncement
+	leiosAnnouncementSizes map[string]uint64
 
 	// Asynchronous best-effort persistence of fetched endorser blocks to the
 	// blob store for historical serving. The blob write (CBOR encode + commit)
@@ -275,6 +281,8 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		leiosEndorserBlocks:      make(map[string]*leiosEndorserBlockData),
 		leiosClosureWaiters:      make(map[string][]chan struct{}),
 		leiosEBLog:               newLeiosForgedEBLog(),
+		leiosAnnouncements:       make(map[string]leiosAnnouncement),
+		leiosAnnouncementSizes:   make(map[string]uint64),
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -124,9 +124,11 @@ type Ouroboros struct {
 	// LeiosNotify ranking-block announcements observed on this node. The map
 	// is keyed by announcing ranking-block hash and prevents an inconsistent
 	// second description of the same ranking block from being relayed.
-	leiosAnnouncementsMu   sync.Mutex
-	leiosAnnouncements     map[string]leiosAnnouncement
-	leiosAnnouncementSizes map[string]uint64
+	leiosAnnouncementsMu       sync.Mutex
+	leiosAnnouncements         map[string]leiosAnnouncement
+	leiosDeferredMu            sync.Mutex
+	leiosDeferredAnnouncements map[string]leiosDeferredAnnouncement
+	leiosAnnouncementSizes     map[string]uint64
 	// LeiosNotify permits at most two distinct announcements for one election
 	// (slot plus issuer) from each peer. Keep that bound per source so one
 	// equivocating peer cannot inject an unbounded stream without suppressing
@@ -287,6 +289,7 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		leiosClosureWaiters:        make(map[string][]chan struct{}),
 		leiosEBLog:                 newLeiosForgedEBLog(),
 		leiosAnnouncements:         make(map[string]leiosAnnouncement),
+		leiosDeferredAnnouncements: make(map[string]leiosDeferredAnnouncement),
 		leiosAnnouncementSizes:     make(map[string]uint64),
 		leiosAnnouncementElections: make(map[string]map[string]struct{}),
 	}
@@ -305,6 +308,7 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		o.initProtocolMetrics()
 		o.initLeiosMetrics()
 	}
+	o.subscribeLeiosAnnouncementRetries()
 	return o
 }
 


### PR DESCRIPTION
Closes #3077 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for prototype-2026w31 LeiosNotify ranking-block announcements with header-only crypto validation, strict age/equivocation rules, dedup, and selective relay; also relays locally forged announcements. Remains compatible with w30 peers that ignore the payload.

- **New Features**
  - `leiosnotify` decodes ranking headers and validates them via header-only crypto without advancing the epoch cache; when epoch data is missing, validation defers into a bounded queue (128 max) and is retried on chain updates or epoch transitions; deferred items are never relayed and are not re-added per-message to avoid retry thrash.
  - Age rules: accept up to 10 minutes old and relay only if ≤5 minutes; reject future/stale slots; log slot/lateness; prune dedup state and rebuild EB-size and per-election indexes as slots expire.
  - Consistency and dedup: enforce a stable EB size per EB hash; reject conflicting restatements; allow at most two distinct announcements per election per source; suppress a third; ignore exact duplicates.
  - Preserve original header CBOR and relay it via the per-connection delivery log; the forging path enqueues local announcements when present.
  - Keep the request window full with `WithPipelineLimit(MaxPipelineLimit)` to match w31 lookahead while staying compatible with w30.

<sup>Written for commit e84e63e0b1436b487a19eb0564f719a908776028. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing and relaying Leios endorser-block announcements in Dijkstra ranking blocks.
  * Valid announcements are cryptographically verified, checked for age and size consistency, deduplicated, and queued for delivery.
  * Forged endorser-block announcements are now emitted with their original signed header data.
* **Bug Fixes**
  * Invalid, outdated, duplicate, or excessive announcements are rejected to improve network reliability.
* **Documentation**
  * Updated architecture documentation to describe announcement handling and validation behavior.
* **Tests**
  * Expanded coverage for announcement consumption, deduplication, validation, and relay output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->