### PR TITLE
fix(ledger): use effective epoch params for genesis overlay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1388,6 +1388,14 @@ rolled the applied chain back to its common ancestor, so permitted epoch-nonce
 forecasts and the epoch-specific Mark stake snapshot used for leader
 eligibility are read from that intersection state.
 
+Genesis-overlay activity is resolved separately from the forward protocol-
+parameter forecast: header validation first uses the epoch containing the
+slot and reads that epoch's effective parameter row, so an epoch-boundary
+decentralization update cannot be mistaken for the prior epoch's overlay
+schedule. If the target epoch is not authoritative yet, blockfetch defers the
+stateful overlay decision until ledger apply; full historical validation and
+the normal leader checks remain enabled.
+
 Slot/epoch query adapters preserve `hardfork.ErrPastHorizon` in their error
 chains so callers can defer until the ledger advances. `EpochInfo` serves an
 already materialized epoch directly from the immutable epoch cache before

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -694,7 +694,7 @@ func activeSlotCoeffInverse(activeSlotsCoeff *big.Rat) uint64 {
 }
 
 func (ls *LedgerState) genesisDelegationActiveForSlot(slot uint64) bool {
-	if pparams := ls.ProtocolParamsForSlot(slot); pparams != nil {
+	if pparams := ls.genesisOverlayProtocolParamsForSlot(slot); pparams != nil {
 		return decentralizedParamActive(pparams)
 	}
 	if ls.config.CardanoNodeConfig == nil {
@@ -709,7 +709,7 @@ func (ls *LedgerState) genesisDelegationActiveForSlot(slot uint64) bool {
 }
 
 func (ls *LedgerState) decentralizationParamRatForSlot(slot uint64) *big.Rat {
-	if pparams := ls.ProtocolParamsForSlot(slot); pparams != nil {
+	if pparams := ls.genesisOverlayProtocolParamsForSlot(slot); pparams != nil {
 		return decentralizationParamRat(pparams)
 	}
 	if ls.config.CardanoNodeConfig == nil {
@@ -721,6 +721,38 @@ func (ls *LedgerState) decentralizationParamRatForSlot(slot uint64) *big.Rat {
 		return nil
 	}
 	return shelleyGenesis.ProtocolParameters.Decentralization.Rat
+}
+
+// genesisOverlayProtocolParamsForSlot resolves the protocol parameters that
+// govern the slot's epoch. ProtocolParamsForSlot intentionally forecasts from
+// the current state for forging, but that is not a historical lookup: at an
+// epoch boundary it can return the previous epoch's decentralization value.
+// Prefer the epoch-specific metadata row, falling back to the current/forecast
+// value only when the target epoch is not persisted yet. Header callers defer
+// that not-yet-authoritative case before making an overlay decision.
+func (ls *LedgerState) genesisOverlayProtocolParamsForSlot(
+	slot uint64,
+) lcommon.ProtocolParameters {
+	if epoch, err := ls.epochForSlot(slot); err == nil {
+		snapshot := ls.loadConsensusSnapshot()
+		if epoch.EpochId == snapshot.currentEpoch.EpochId {
+			return snapshot.currentPParams
+		}
+		if ls.db != nil {
+			era, ok := ls.eraById(epoch.EraId)
+			if ok && era != nil && era.DecodePParamsFunc != nil {
+				if pparams, pparamsErr := ls.db.GetPParams(
+					epoch.EpochId,
+					era.Id,
+					era.DecodePParamsFunc,
+					nil,
+				); pparamsErr == nil && pparams != nil {
+					return pparams
+				}
+			}
+		}
+	}
+	return ls.ProtocolParamsForSlot(slot)
 }
 
 func decentralizedParamActive(

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/consensus"
 	"github.com/blinklabs-io/gouroboros/kes"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1242,6 +1243,84 @@ func TestVerifyBlockHeaderState_GenesisDelegateInactiveAtDZero(
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, models.ErrPoolNotFound)
+}
+
+func TestGenesisOverlayUsesEffectiveEpochPParamsAtBoundary(t *testing.T) {
+	genesisCfg := newGenesisDelegateShelleyGenesisCfgWithActiveSlots(
+		t,
+		strings.Repeat("00", lcommon.Blake2b224Size),
+		strings.Repeat("00", lcommon.Blake2b256Size),
+		"0.05",
+	)
+	initialPParams := &alonzo.AlonzoProtocolParameters{
+		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
+	}
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) }) //nolint:errcheck
+
+	ls := &LedgerState{
+		db: db,
+		currentEpoch: models.Epoch{
+			EpochId:       1,
+			StartSlot:     86_400,
+			LengthInSlots: 86_400,
+			SlotLength:    1,
+			EraId:         eras.AlonzoEraDesc.Id,
+		},
+		currentEra:     eras.AlonzoEraDesc,
+		currentPParams: initialPParams,
+		epochCache: []models.Epoch{
+			{
+				EpochId:       1,
+				StartSlot:     86_400,
+				LengthInSlots: 86_400,
+				SlotLength:    1,
+				EraId:         eras.AlonzoEraDesc.Id,
+			},
+			{
+				EpochId:       2,
+				StartSlot:     172_800,
+				LengthInSlots: 86_400,
+				SlotLength:    1,
+				EraId:         eras.AlonzoEraDesc.Id,
+			},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: genesisCfg,
+			Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	// The epoch-2 update is already part of historical metadata even though
+	// the in-memory current epoch is still epoch 1. This is the state observed
+	// while a boundary block is being checked.
+	nextPParams := &alonzo.AlonzoProtocolParameters{
+		Decentralization: &cbor.Rat{Rat: big.NewRat(0, 1)},
+	}
+	nextPParamsCbor, err := cbor.Encode(nextPParams)
+	require.NoError(t, err)
+	require.NoError(t, db.SetPParams(
+		nextPParamsCbor,
+		172_800,
+		2,
+		eras.AlonzoEraDesc.Id,
+		nil,
+	))
+
+	// The preceding epoch remains genesis-overlay active, while canonical
+	// epoch-2 slots use decentralisationParam=0 and must fall through to the
+	// normal pool path. A current-epoch-only lookup regresses here by reading
+	// epoch-1's d=1 and returning genesisOverlayNonActive.
+	require.True(t, ls.genesisDelegationActiveForSlot(172_780))
+	require.False(t, ls.genesisDelegationActiveForSlot(172_836))
+	_, status, err := ls.genesisOverlayDelegationForSlot(
+		172_836,
+		genesisCfg.ShelleyGenesis(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, genesisOverlayNone, status)
 }
 
 func TestVerifyBlockHeaderState_GenesisDelegateInactiveOverlaySlotFails(


### PR DESCRIPTION
Closes #3061 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the target epoch’s effective protocol parameters for genesis overlay decisions during header validation in `ledger`. Fixes epoch-boundary misclassification of overlay slots caused by reading the previous epoch’s decentralization (d), addressing #3061.

- **Bug Fixes**
  - Header validation now reads the epoch’s stored parameters via `genesisOverlayProtocolParamsForSlot`, falling back to `ProtocolParamsForSlot` only if the target epoch isn’t materialized; overlay decisions are deferred until ledger apply in that case.
  - Added a boundary test and updated `ARCHITECTURE.md` to ensure d=1 (epoch N) and d=0 (epoch N+1) are handled correctly.

<sup>Written for commit 8dec4de9535212464407e66587d3a5f2df6629de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected genesis-overlay validation at epoch boundaries by using the effective protocol parameters for the slot’s epoch.
  * Preserved historical validation and standard leader checks.
  * Ensured overlay activity and delegation behavior transition correctly when decentralization settings change.

* **Tests**
  * Added regression coverage for protocol-parameter selection across epoch boundaries.

* **Documentation**
  * Documented genesis-overlay header-validation behavior and parameter resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->