### PR TITLE
test(devnet): start txpump for payment-only runs (creds gating + N2C TCP)

### DIFF
--- a/internal/test/antithesis/scripts/txpump-entrypoint.sh
+++ b/internal/test/antithesis/scripts/txpump-entrypoint.sh
@@ -3,14 +3,25 @@ set -eu
 
 # The analyzer image uses uid 1000. Running txpump with the same uid keeps its
 # 0640 structured log readable through the shared volume.
-stake_key="/utxo-keys/stake/txpump.stake.vkey"
-pool_key="/configs/keys/cold.vkey"
-if [ ! -f "${stake_key}" ] || [ ! -f "${pool_key}" ]; then
-  echo "txpump: delegation credentials are missing" >&2
-  exit 1
-fi
-export TXPUMP_DELEGATION_STAKE_KEY_HASH="$(cardano-cli stake-address key-hash --stake-verification-key-file "${stake_key}")"
-export TXPUMP_DELEGATION_POOL_KEY_HASH="$(cardano-cli stake-pool id --cold-verification-key-file "${pool_key}" --output-format hex)"
+
+# Delegation credentials are only needed when "delegation" is an enabled
+# workload type (see internal/txpump: Config.delegationEnabled() and
+# pump.go enabledTypes()). For payment-only runs the pump never touches
+# delegation, so requiring/deriving the stake+cold key hashes would abort a
+# perfectly valid run. Gate the requirement on TXPUMP_TYPES accordingly.
+case ",${TXPUMP_TYPES:-},"  in
+  *,delegation,*)
+    stake_key="/utxo-keys/stake/txpump.stake.vkey"
+    pool_key="/configs/keys/cold.vkey"
+    if [ ! -f "${stake_key}" ] || [ ! -f "${pool_key}" ]; then
+      echo "txpump: delegation credentials are missing" >&2
+      exit 1
+    fi
+    TXPUMP_DELEGATION_STAKE_KEY_HASH="$(cardano-cli stake-address key-hash --stake-verification-key-file "${stake_key}")"
+    TXPUMP_DELEGATION_POOL_KEY_HASH="$(cardano-cli stake-pool id --cold-verification-key-file "${pool_key}" --output-format hex)"
+    export TXPUMP_DELEGATION_STAKE_KEY_HASH TXPUMP_DELEGATION_POOL_KEY_HASH
+    ;;
+esac
 
 chown -R txpump:txpump /logs
 exec su -s /bin/sh txpump -c 'exec /bin/txpump'

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -215,7 +215,14 @@ services:
       dingo-1:
         condition: service_healthy
     environment:
-      TXPUMP_NODE_ADDR: "/ipc/dingo.socket"
+      # Connect over the node-to-client TCP port (3002) rather than the
+      # in-container unix socket. The dingo node creates /ipc/dingo.socket
+      # as 0755 owned by its own uid (100); txpump runs as uid 1000 and
+      # cannot connect() to that socket (needs the write bit), so the socket
+      # path fails with EACCES. TCP N2C is also the proven path used by the
+      # antithesis dingo-praos testnet. dingo-1 binds N2C on 0.0.0.0:3002
+      # via DINGO_PRIVATE_BIND_ADDR.
+      TXPUMP_NODE_ADDR: "dingo-1:3002"
       TXPUMP_NETWORK_MAGIC: "42"
       TXPUMP_TX_COUNT_MIN: "10"
       TXPUMP_TX_COUNT_MAX: "50"
@@ -225,7 +232,6 @@ services:
       TXPUMP_LOG_DIR: "/logs"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:
-      - dingo-1-ipc:/ipc:ro
       - logs:/logs
       - utxo-keys:/utxo-keys:ro
     networks:
@@ -252,6 +258,11 @@ services:
       CARDANO_SHELLEY_VRF_KEY: /configs/keys/vrf.skey
       CARDANO_SHELLEY_KES_KEY: /configs/keys/kes.skey
       CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE: /configs/keys/opcert.cert
+      # Expose node-to-client over TCP (private port 3002) on all interfaces
+      # so the in-network txpump can submit transactions without a cross-uid
+      # unix-socket mount (the socket is owned by uid 100; txpump is uid 1000).
+      DINGO_PRIVATE_BIND_ADDR: "0.0.0.0"
+      CARDANO_PRIVATE_BIND_ADDR: "0.0.0.0"
     volumes:
       - p1-configs:/configs:ro
       - ./topology/dingo-producer.json:/topology/topology.json:ro
@@ -328,7 +339,13 @@ services:
       dingo-producer:
         condition: service_healthy
     environment:
-      TXPUMP_NODE_ADDR: "/ipc/dingo.socket"
+      # Connect over the node-to-client TCP port (3002) rather than the
+      # in-container unix socket. The dingo node creates the socket 0755
+      # owned by its own uid (100); txpump runs as uid 1000 and cannot
+      # connect() to it (EACCES). dingo-producer binds N2C on 0.0.0.0:3002
+      # via DINGO_PRIVATE_BIND_ADDR. Mirrors txpump-dingo and the proven
+      # antithesis dingo-praos TCP N2C path.
+      TXPUMP_NODE_ADDR: "dingo-producer:3002"
       TXPUMP_NETWORK_MAGIC: "42"
       TXPUMP_TX_COUNT_MIN: "10"
       TXPUMP_TX_COUNT_MAX: "50"
@@ -338,7 +355,6 @@ services:
       TXPUMP_LOG_DIR: "/logs"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:
-      - dingo-producer-ipc:/ipc:ro
       - logs:/logs
       - utxo-keys:/utxo-keys:ro
     networks:


### PR DESCRIPTION
## What

Two DevNet test-harness fixes so the txpump mempool feeder can start. Test-infra only (an entrypoint gating condition and docker-compose transport config); no node code.

1. txpump-entrypoint.sh gates the delegation-credential requirement on delegation actually being an enabled workload (TXPUMP_TYPES containing "delegation"). Previously the entrypoint unconditionally required a stake vkey and a pool cold vkey at /configs/keys/cold.vkey and exited with "delegation credentials are missing". But both devnet txpump services run TXPUMP_TYPES=payment, the configurator removes /configs/keys, and neither service mounts /configs, so the creds are neither present nor needed. For payment-only runs txpump now starts with no delegation creds. This matches txpump's own config: delegationEnabled() treats the hashes as optional and the pump only exercises delegation when it is an enabled workload. Networks that do enable delegation (the antithesis dingo-praos testnet) still mount the key paths, so the entrypoint still requires and derives them there.

2. Both txpump services connect to the node over node-to-client TCP (dingo-1:3002 / dingo-producer:3002) instead of the in-container unix socket. The node creates /ipc/dingo.socket owned by uid 100, but the shared entrypoint must run txpump as uid 1000 (the antithesis analyzer expects that uid on the shared log), so connect() failed with EACCES. TCP N2C on 3002 is the path already used by the Go devnet harness (LSQ) and the antithesis dingo-praos testnet; the dingo-profile nodes already expose it.

## Why

DevNet run-tests.sh aborts both profiles at the txpump readiness check ("txpump is not running", it then aborts because mempool traffic would be absent). Reproduced on plain origin/main.

## Validation

- Credential fix: confirmed. run-tests.sh now logs "txpump is running" and proceeds into the Go suite, where it previously aborted 100% of the time before any test ran.
- The socket-to-TCP change addresses the confirmed cross-uid EACCES and uses the already-proven N2C path, but end-to-end validation (txpump submitting transactions, suite passing) is blocked by a separate, pre-existing node-level failure: dingo-to-dingo (and N2C, and the Go harness) ouroboros handshakes are rejected with "invalid network magic value provided: 0" on plain main, with zero successful handshakes. That is the DevNet-validation blocker noted in the project docs and is out of scope for this test-infra change; these harness fixes are prerequisites to a green DevNet run but not sufficient on their own until that handshake issue is resolved.

## Scope

DATABASE.md / ARCHITECTURE.md not affected (test-infra only).
