### PR TITLE
fix(config): sync network magic compat field after name resolution

### DIFF
--- a/config.go
+++ b/config.go
@@ -194,6 +194,14 @@ func (n *Node) configPopulateNetworkMagic() error {
 			return fmt.Errorf("unknown network name: %s", n.config.cfg.Network)
 		}
 		n.config.cfg.NetworkMagic = tmpNetwork.NetworkMagic
+		// Refresh the compat mirror fields from the now-resolved canonical
+		// config. syncCompatFields ran at construction time, before the magic
+		// was derived from the network name, leaving Config.networkMagic at 0.
+		// The ouroboros handshake reads Config.networkMagic (see node.go), and
+		// gouroboros refuses every connection whose configured magic is 0
+		// ("invalid network magic value provided: 0"), so it must be synced
+		// here after resolution or a network started by name never connects.
+		n.config.syncCompatFields()
 	}
 	return nil
 }

--- a/config_network_magic_test.go
+++ b/config_network_magic_test.go
@@ -1,0 +1,41 @@
+package dingo
+
+import "testing"
+
+// TestConfigPopulateNetworkMagicSyncsCompatField is a regression test for the
+// devnet handshake blocker: a config built by network NAME (magic left 0, the
+// production path from internal/node) must resolve the compat networkMagic
+// field that the ouroboros handshake reads. configPopulateNetworkMagic resolves
+// the canonical cfg.NetworkMagic, but the handshake reads Config.networkMagic
+// (set only by syncCompatFields at construction time, before the name was
+// resolved). If the compat field stays 0, gouroboros refuses every connection
+// with "invalid network magic value provided: 0". This affects any network
+// started by name (devnet, preview, ...), not just devnet.
+func TestConfigPopulateNetworkMagicSyncsCompatField(t *testing.T) {
+	cases := []struct {
+		network string
+		want    uint32
+	}{
+		{"devnet", 42},
+		{"preview", 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.network, func(t *testing.T) {
+			cfg := NewConfig(WithNetwork(tc.network))
+			n := &Node{config: cfg}
+			if err := n.configPopulateNetworkMagic(); err != nil {
+				t.Fatalf("configPopulateNetworkMagic: %v", err)
+			}
+			if got := n.config.cfg.NetworkMagic; got != tc.want {
+				t.Fatalf("cfg.NetworkMagic = %d, want %d", got, tc.want)
+			}
+			// The compat field the ouroboros handshake actually reads.
+			if got := n.config.networkMagic; got != tc.want {
+				t.Fatalf(
+					"config.networkMagic = %d, want %d (handshake would get 0)",
+					got, tc.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

When the network magic is resolved from a network name (rather than passed explicitly), the resolved value was written to the canonical config field but not to the legacy compat mirror that the Ouroboros handshake actually reads, so the node handshook with magic 0 and every dingo-to-dingo and node-to-client connection was rejected with "invalid network magic value provided: 0".

`configPopulateNetworkMagic` now calls `syncCompatFields()` after it resolves the magic from the network name, so the compat mirror (`config.networkMagic`, read by the N2N and N2C handshakes at `node.go:385` and `node.go:1392`) matches the canonical `cfg.NetworkMagic`.

## Why

The handshake reads the compat mirror `n.config.networkMagic`. `configPopulateNetworkMagic` (called from `node.go` startup) resolved the magic from the network name into the canonical `cfg.NetworkMagic` but left the mirror at its zero value, because the compat fields are only synced at load time, before name resolution runs. Any node that gets its magic from name resolution (the DevNet, which starts with `CARDANO_NETWORK=devnet` and no explicit magic) therefore advertised magic 0 and could not complete a single handshake.

Nodes that pass the magic explicitly (`WithNetworkMagic(cfg.NetworkMagic)` with a non-zero value, e.g. a CLI run whose genesis carries `networkMagic`) were unaffected, because that path sets both fields; this is why preview/preprod/mainnet runs connect normally and the failure was DevNet-only.

## Validation

- `go build ./...`: pass.
- New regression test `config_network_magic_test.go`: asserts the compat mirror equals the canonical field after name resolution. Pass.
- End-to-end: with this fix the all-dingo DevNet ring completes handshakes and the nodes peer and share a chain; on plain main every handshake was rejected with magic 0.

## Scope

Config-only; no ledger/consensus/database change. `DATABASE.md` / `ARCHITECTURE.md` not affected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handshake failures by syncing the legacy network magic field after resolving it from the network name. Nodes started by name no longer advertise magic 0 and can connect.

- **Bug Fixes**
  - After resolving `cfg.NetworkMagic` in `configPopulateNetworkMagic`, call `n.config.syncCompatFields()` so `config.networkMagic` matches the canonical value and handshakes succeed.
  - Added `config_network_magic_test.go` to ensure the compat mirror equals the canonical field (covers `devnet` and `preview`).

<sup>Written for commit b769dfb3684dabec164594a10b876b3059adb26b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

