### PR TITLE
fix(consensus): extend header forecast horizon past a known transition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1502,23 +1502,32 @@ When a network config supplies a `CheckpointsFile` (mainnet and preview ship one
 
 Before resolving or eagerly forecasting an epoch for a live header,
 `headerVerificationEpoch` checks the slot against `LedgerState.HardForkSummary`.
-The in-memory summary uses the same configured era safe zone and
-`TransitionInfo` as the NtC era-history query: an unknown transition is bounded
+The in-memory summary reads the same configured era safe zone and
+`TransitionInfo` as the NtC era-history query, but the two horizons are not
+interchangeable: the NtC query answers a point in time, while the live summary
+must stay ahead of header processing. An unknown transition is bounded in both
 from the applied tip by the era's stability window (`3k/f` for Shelley and
-later) and an impossible transition keeps the same rolling safe-zone bound so
-live slot processing can cross a confirmed same-era epoch boundary. A known
-transition is bounded at the announced era boundary for the point-in-time NtC
-query, but the live summary appends an open successor era starting at that
-boundary so the header horizon extends one epoch past the transition. This is
-required for liveness: the rollover into the first post-boundary epoch is
-deterministic within the stability window, so its header can be verified, and
-without the extra epoch the gate would reject that first header and the node
-could never apply the block that consumes the transition and extends era
-history (a boundary deadlock). The successor era uses the next era's params from
-the configured shape, falling back to the current era's params when the ledger
-already occupies the last modeled era. A header past this extended live bound
-fails with `hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the
-forecasted epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
+later). An impossible transition diverges — the NtC query reports the confirmed
+current-epoch end measured from the era start, whereas the live summary treats
+it as unknown and rolls the safe zone forward from the tip, so live slot
+processing can cross a confirmed same-era epoch boundary. A known transition is
+bounded at the announced era boundary for the NtC query, while the live summary
+additionally appends the successor era starting at that boundary so the header
+horizon reaches past the transition. This is required for liveness: the rollover
+into the first post-boundary epoch is deterministic within the stability window,
+so its header can be verified, and without the extra epoch the gate would reject
+that first header and the node could never apply the block that consumes the
+transition and extends era history (a boundary deadlock). The successor era
+takes the next era's params by configured shape order (not `EraID + 1`, which
+would break on non-contiguous era IDs), falling back to the current era's params
+when the ledger already occupies the last modeled era. `hardfork.SuccessorEra`
+bounds it by the successor's own safe zone measured from the boundary, which
+always snaps up to at least the end of the first post-boundary epoch; the
+successor stays open only when the resolved safe zone is zero
+(`UnsafeIndefiniteSafeZone`), the same rule `BuildSummary` applies to the
+current era. Where that live bound is finite, a header past it fails with
+`hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the forecasted
+epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
 rolled the applied chain back to its common ancestor, so permitted epoch-nonce
 forecasts and the epoch-specific Mark stake snapshot used for leader
 eligibility are read from that intersection state.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1505,13 +1505,20 @@ Before resolving or eagerly forecasting an epoch for a live header,
 The in-memory summary uses the same configured era safe zone and
 `TransitionInfo` as the NtC era-history query: an unknown transition is bounded
 from the applied tip by the era's stability window (`3k/f` for Shelley and
-later), a known transition is bounded at the announced era boundary, and an
-impossible transition keeps the same rolling safe-zone bound so live slot
-processing can cross a confirmed same-era epoch boundary. (The point-in-time
-NtC query may conservatively stop its reported range at that confirmed
-boundary.) A header at or past the live bound fails with
-`hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the forecasted
-epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
+later) and an impossible transition keeps the same rolling safe-zone bound so
+live slot processing can cross a confirmed same-era epoch boundary. A known
+transition is bounded at the announced era boundary for the point-in-time NtC
+query, but the live summary appends an open successor era starting at that
+boundary so the header horizon extends one epoch past the transition. This is
+required for liveness: the rollover into the first post-boundary epoch is
+deterministic within the stability window, so its header can be verified, and
+without the extra epoch the gate would reject that first header and the node
+could never apply the block that consumes the transition and extends era
+history (a boundary deadlock). The successor era uses the next era's params from
+the configured shape, falling back to the current era's params when the ledger
+already occupies the last modeled era. A header past this extended live bound
+fails with `hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the
+forecasted epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
 rolled the applied chain back to its common ancestor, so permitted epoch-nonce
 forecasts and the epoch-specific Mark stake snapshot used for leader
 eligibility are read from that intersection state.

--- a/ledger/hardfork/build.go
+++ b/ledger/hardfork/build.go
@@ -90,6 +90,26 @@ func BuildSummary(
 	}, nil
 }
 
+// SuccessorEra builds the era that follows a bounded era whose End is an
+// announced transition boundary. The successor has not started yet, so its own
+// end is the standard safe zone measured from its start — identical to what
+// BuildSummary computes for TransitionImpossible, and to what TransitionUnknown
+// computes while the tip is still below the era start. The bound always snaps up
+// to at least the next epoch boundary, so the successor covers the whole first
+// post-boundary epoch. A zero SafeZoneSlots means UnsafeIndefiniteSafeZone and
+// leaves the successor open, matching BuildSummary.
+//
+// Mirrors the recursion into the next era in
+// Ouroboros.Consensus.HardFork.Combinator.State.Infra.reconstructSummary.
+func SuccessorEra(start Bound, eraID uint, params EraParams) EraSummary {
+	return EraSummary{
+		EraID:  eraID,
+		Start:  start,
+		End:    applySafeZone(params, start, start.Slot),
+		Params: params,
+	}
+}
+
 // mkUpperBound computes a Bound at the start of hiEpoch, given the era's
 // lower bound lo and its params. Mirrors Haskell's mkUpperBound.
 func mkUpperBound(params EraParams, lo Bound, hiEpoch uint64) Bound {

--- a/ledger/hardfork/build_test.go
+++ b/ledger/hardfork/build_test.go
@@ -200,3 +200,41 @@ func TestBuildSummary_RoundTripSlotTime(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(150_000), back)
 }
+
+// ------------------------------------------------------------- successor era
+
+// SuccessorEra bounds the era that follows an announced transition boundary by
+// that era's own safe zone, snapped up to an epoch boundary, so the successor
+// always covers the whole first post-boundary epoch and no more than the safe
+// zone allows.
+func TestSuccessorEra_BoundedBySafeZone(t *testing.T) {
+	// Boundary at the start of epoch 1 in a Shelley-shaped era.
+	start := hardfork.Bound{
+		RelativeTime: 432_000 * time.Second,
+		Slot:         432_000,
+		Epoch:        1,
+	}
+	succ := hardfork.SuccessorEra(start, 6, shelleyParams)
+	assert.Equal(t, uint(6), succ.EraID)
+	assert.Equal(t, start, succ.Start)
+	assert.Equal(t, shelleyParams, succ.Params)
+	// 432000 + 25920 lands inside epoch 1, so the bound snaps up to the start
+	// of epoch 2: the whole first post-boundary epoch is covered.
+	require.NotNil(t, succ.End)
+	assert.Equal(t, uint64(864_000), succ.End.Slot)
+	assert.Equal(t, uint64(2), succ.End.Epoch)
+	assert.Equal(t, 864_000*time.Second, succ.End.RelativeTime)
+}
+
+// A zero SafeZoneSlots is UnsafeIndefiniteSafeZone and leaves the successor
+// open, matching how BuildSummary treats the current era.
+func TestSuccessorEra_ZeroSafeZoneStaysOpen(t *testing.T) {
+	params := shelleyParams
+	params.SafeZoneSlots = 0
+	succ := hardfork.SuccessorEra(
+		hardfork.Bound{Slot: 432_000, Epoch: 1},
+		6,
+		params,
+	)
+	assert.Nil(t, succ.End)
+}

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -171,33 +171,39 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 	// point-in-time answer and is intentionally bounded, live header
 	// verification must see the horizon extend at least one epoch past a known
 	// transition, because the rollover is deterministic within the stability
-	// window. Append the successor era as an open (unbounded) era starting at
-	// the announced boundary so the horizon covers the first post-boundary
-	// epoch. Use the next era's params from the shape; when the current era is
-	// the last modeled era (the transition re-arms an era the ledger already
+	// window. Append the successor era starting at the announced boundary so the
+	// horizon covers the first post-boundary epoch. hardfork.SuccessorEra bounds
+	// it by the successor's own safe zone measured from that boundary, which
+	// always snaps up to at least the next epoch boundary; the successor stays
+	// open only when the resolved safe zone is zero
+	// (UnsafeIndefiniteSafeZone), the same rule BuildSummary applies to the
+	// current era. Take the successor by shape order rather than EraID+1 so
+	// non-contiguous EraID values still resolve; when the current era is the
+	// last modeled era (the transition re-arms an era the ledger already
 	// occupies), reuse the current era's params — epoch length and slot length
 	// are constant across post-Byron eras, which is all SlotToEpoch needs.
-	// Mirrors the successor-era append in Haskell HFC reconstructSummary.
+	// Mirrors the successor-era recursion in Haskell HFC reconstructSummary.
 	if transitionInfo.State == hardfork.TransitionKnown && len(summary.Eras) > 0 {
 		bounded := summary.Eras[len(summary.Eras)-1]
 		if bounded.End != nil {
 			succEraID := bounded.EraID
 			succParams := bounded.Params
-			if next, ok := shape.EraForID(bounded.EraID + 1); ok {
+			if idx, ok := shape.EraIndex(bounded.EraID); ok &&
+				idx+1 < len(shape.Eras) {
+				next := shape.Eras[idx+1]
 				succEraID = next.EraID
 				succParams = next.Params
 			}
-			summary.Eras = append(summary.Eras, hardfork.EraSummary{
-				EraID: succEraID,
-				Start: *bounded.End,
-				End:   nil,
-				Params: hardfork.EraParams{
+			summary.Eras = append(summary.Eras, hardfork.SuccessorEra(
+				*bounded.End,
+				succEraID,
+				hardfork.EraParams{
 					EpochSize:     succParams.EpochSize,
 					SlotLength:    succParams.SlotLength,
 					SafeZoneSlots: succParams.SafeZoneSlots,
 					GenesisWindow: succParams.GenesisWindow,
 				},
-			})
+			))
 		}
 	}
 	return &summary, nil

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -159,5 +159,46 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		return nil, err
 	}
 	summary.Transition = transitionInfo
+
+	// When a known transition is armed, BuildSummary bounds the current era at
+	// the announced epoch boundary (mkUpperBound) and appends no successor era.
+	// That leaves the summary's last era bounded, so eraForSlot / SlotToEpoch
+	// return ErrPastHorizon for every slot at or past the boundary. The header
+	// forecast-horizon gate in verify_header.go then hard-rejects the first
+	// header of the post-boundary epoch, and the node can never apply the block
+	// that would consume the transition and extend era history — a liveness
+	// deadlock at the boundary. Unlike the NtC era-history query, which serves a
+	// point-in-time answer and is intentionally bounded, live header
+	// verification must see the horizon extend at least one epoch past a known
+	// transition, because the rollover is deterministic within the stability
+	// window. Append the successor era as an open (unbounded) era starting at
+	// the announced boundary so the horizon covers the first post-boundary
+	// epoch. Use the next era's params from the shape; when the current era is
+	// the last modeled era (the transition re-arms an era the ledger already
+	// occupies), reuse the current era's params — epoch length and slot length
+	// are constant across post-Byron eras, which is all SlotToEpoch needs.
+	// Mirrors the successor-era append in Haskell HFC reconstructSummary.
+	if transitionInfo.State == hardfork.TransitionKnown && len(summary.Eras) > 0 {
+		bounded := summary.Eras[len(summary.Eras)-1]
+		if bounded.End != nil {
+			succEraID := bounded.EraID
+			succParams := bounded.Params
+			if next, ok := shape.EraForID(bounded.EraID + 1); ok {
+				succEraID = next.EraID
+				succParams = next.Params
+			}
+			summary.Eras = append(summary.Eras, hardfork.EraSummary{
+				EraID: succEraID,
+				Start: *bounded.End,
+				End:   nil,
+				Params: hardfork.EraParams{
+					EpochSize:     succParams.EpochSize,
+					SlotLength:    succParams.SlotLength,
+					SafeZoneSlots: succParams.SafeZoneSlots,
+					GenesisWindow: succParams.GenesisWindow,
+				},
+			})
+		}
+	}
 	return &summary, nil
 }

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -505,6 +505,79 @@ func TestHardForkSummary_KnownTransitionCoversStabilityWindow(t *testing.T) {
 	}
 }
 
+// TestHardForkSummary_KnownTransitionRejectsPastSuccessorBound is the negative
+// half of TestHardForkSummary_KnownTransitionCoversStabilityWindow: the
+// successor era extends the horizon but must not make it unbounded. With the
+// same shape (boundary at slot 600, safe zone 250), the successor's safe zone
+// snaps up to the start of epoch 9, so slot 900 and beyond are past-horizon
+// again. Without this, an accidentally open successor would still satisfy the
+// in-window assertions.
+func TestHardForkSummary_KnownTransitionRejectsPastSuccessorBound(t *testing.T) {
+	const (
+		epochSize  = uint64(100)
+		safeZone   = uint64(250)
+		startEpoch = uint64(5)
+		startSlot  = uint64(500)
+		knownEpoch = uint64(6)
+		tipSlot    = uint64(560)
+		// 600 + 250 = 850 lands mid-epoch 8, so the successor's bound snaps up
+		// to the start of epoch 9 at slot 900.
+		succEndSlot = uint64(900)
+	)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       startEpoch,
+			StartSlot:     startSlot,
+			SlotLength:    1_000,
+			LengthInSlots: 100,
+			EraId:         1,
+		}},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(knownEpoch),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	shape := hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     epochSize,
+				SlotLength:    time.Second,
+				SafeZoneSlots: safeZone,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+
+	// The successor is bounded, and its bound is where the horizon ends.
+	require.Len(t, sum.Eras, 2)
+	require.NotNil(t, sum.Eras[1].End)
+	assert.Equal(t, succEndSlot, sum.Eras[1].End.Slot)
+
+	// The last slot inside the window still resolves...
+	info, err := sum.SlotToEpoch(succEndSlot - 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(8), info.Epoch)
+
+	// ...and the bound itself, plus anything past it, does not.
+	for _, slot := range []uint64{
+		succEndSlot,
+		succEndSlot + 1,
+		succEndSlot + epochSize,
+		succEndSlot + 10*epochSize,
+	} {
+		_, err := sum.SlotToEpoch(slot)
+		require.ErrorIsf(t, err, hardfork.ErrPastHorizon,
+			"slot %d must be past horizon", slot)
+	}
+}
+
 func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {
 	ls := &LedgerState{
 		epochCache: []models.Epoch{

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -431,6 +431,80 @@ func TestHardForkSummary_KnownTransitionSuccessorByShapeOrder(t *testing.T) {
 	assert.Equal(t, 2*time.Second, sum.Eras[1].Params.SlotLength)
 }
 
+// TestHardForkSummary_KnownTransitionCoversStabilityWindow probes whether the
+// successor era appended for a known transition covers the full deterministic
+// forecast window from the tip, not merely the first post-boundary epoch. This
+// is the scenario where a coverage gap would hide: chainsync verifies headers
+// ahead of the applied tip, so a header several epochs past the boundary but
+// still within one stability window of the tip must resolve. Because the
+// successor's own safe zone is measured from the announced boundary (which is
+// at or ahead of the tip), one successor already reaches at least tip+safeZone,
+// so there is no gap; a slot beyond the deterministic window is still rejected.
+func TestHardForkSummary_KnownTransitionCoversStabilityWindow(t *testing.T) {
+	const (
+		epochSize  = uint64(100)
+		safeZone   = uint64(250) // spans 2.5 epochs
+		startEpoch = uint64(5)
+		startSlot  = uint64(500)
+		knownEpoch = uint64(6)   // boundary at slot 600
+		boundary   = uint64(600) // first slot of epoch 6
+		tipSlot    = uint64(560) // in epoch 5, before the boundary
+	)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       startEpoch,
+			StartSlot:     startSlot,
+			SlotLength:    1_000,
+			LengthInSlots: 100,
+			EraId:         1,
+		}},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(knownEpoch),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(tipSlot, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	shape := hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     epochSize,
+				SlotLength:    time.Second,
+				SafeZoneSlots: safeZone,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+
+	// Every slot from the boundary through the deterministic window
+	// (tip+safeZone = 810) must resolve, including slots several epochs past the
+	// boundary — this is the chainsync-ahead-of-applied-tip case. A single
+	// boundary-snapped successor must cover all of it, with no transient
+	// past-horizon rejection at the intervening epoch boundaries (700, 800).
+	window := tipSlot + safeZone // 810
+	for _, tc := range []struct {
+		slot  uint64
+		epoch uint64
+	}{
+		{boundary, 6}, // first post-boundary epoch
+		{699, 6},      // end of epoch 6
+		{700, 7},      // next boundary, one epoch past the transition
+		{800, 8},      // epoch 8 start, two epochs past the transition
+		{window, 8},   // edge of the deterministic window (810, epoch 8)
+	} {
+		info, err := sum.SlotToEpoch(tc.slot)
+		require.NoErrorf(
+			t, err, "slot %d within deterministic window must resolve", tc.slot,
+		)
+		assert.Equalf(t, tc.epoch, info.Epoch, "slot %d epoch", tc.slot)
+	}
+}
+
 func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {
 	ls := &LedgerState{
 		epochCache: []models.Epoch{

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -191,11 +191,96 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 		time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC),
 		sum.SystemStart,
 	)
-	require.Len(t, sum.Eras, 1)
+	// A known transition bounds the current era at the announced epoch
+	// boundary and appends an open successor era so the header forecast
+	// horizon still covers the first post-boundary epoch (see HardForkSummary).
+	require.Len(t, sum.Eras, 2)
 	require.NotNil(t, sum.Eras[0].End)
 	assert.Zero(t, sum.Eras[0].Params.SafeZoneSlots)
 	assert.Equal(t, uint64(700), sum.Eras[0].End.Slot)
 	assert.Equal(t, uint64(7), sum.Eras[0].End.Epoch)
+	// The appended successor era is open (unbounded) and starts exactly at the
+	// announced boundary, so SlotToEpoch resolves slots in the first
+	// post-boundary epoch instead of returning ErrPastHorizon.
+	assert.Equal(t, *sum.Eras[0].End, sum.Eras[1].Start)
+	assert.Nil(t, sum.Eras[1].End)
+	info, err := sum.SlotToEpoch(700)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7), info.Epoch)
+}
+
+// TestHardForkSummary_KnownTransitionExtendsHeaderHorizon is a regression test
+// for the header forecast-horizon deadlock: a pending hard-fork initiation arms
+// TransitionKnown before an epoch boundary, BuildSummary bounds the current era
+// at that boundary, and the header verification gate then rejected the first
+// header of the post-boundary epoch as past-horizon, so the node could never
+// apply the block that would consume the transition and extend era history.
+// HardForkSummary must append an open successor era at the boundary so the
+// first post-boundary epoch stays within the forecast horizon. Reproduces the
+// musashi epoch 6 to 7 wedge in miniature.
+func TestHardForkSummary_KnownTransitionExtendsHeaderHorizon(t *testing.T) {
+	const (
+		epochSize    = uint64(100)
+		startEpoch   = uint64(4)
+		startSlot    = uint64(400)
+		knownEpoch   = uint64(7)
+		boundarySlot = uint64(700) // first slot of epoch 7 (400 + (7-4)*100)
+	)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       startEpoch,
+			StartSlot:     startSlot,
+			SlotLength:    1_000,
+			LengthInSlots: 100,
+			EraId:         1,
+		}},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(knownEpoch),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(688, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	// A single modeled era: the ledger already occupies the last era, so the
+	// appended successor era reuses the current era's params.
+	shape := hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     epochSize,
+				SlotLength:    time.Second,
+				SafeZoneSlots: 0,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+
+	// The first block of the post-boundary epoch, and slots within it, must
+	// resolve to that epoch rather than returning ErrPastHorizon.
+	for _, slot := range []uint64{
+		boundarySlot,
+		boundarySlot + 10,
+		boundarySlot + epochSize - 1,
+	} {
+		info, err := sum.SlotToEpoch(slot)
+		require.NoErrorf(t, err, "slot %d must be within horizon", slot)
+		assert.Equalf(t, knownEpoch, info.Epoch, "slot %d epoch", slot)
+	}
+
+	// The successor era is open and reuses the current (last modeled) era's
+	// params; the bounded era still ends exactly at the announced boundary.
+	require.Len(t, sum.Eras, 2)
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Equal(t, boundarySlot, sum.Eras[0].End.Slot)
+	assert.Equal(t, *sum.Eras[0].End, sum.Eras[1].Start)
+	assert.Nil(t, sum.Eras[1].End)
+	assert.Equal(t, sum.Eras[0].EraID, sum.Eras[1].EraID)
+	assert.Equal(t, sum.Eras[0].Params.EpochSize, sum.Eras[1].Params.EpochSize)
+	assert.Equal(t, sum.Eras[0].Params.SlotLength, sum.Eras[1].Params.SlotLength)
 }
 
 func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -199,9 +199,12 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 	assert.Zero(t, sum.Eras[0].Params.SafeZoneSlots)
 	assert.Equal(t, uint64(700), sum.Eras[0].End.Slot)
 	assert.Equal(t, uint64(7), sum.Eras[0].End.Epoch)
-	// The appended successor era is open (unbounded) and starts exactly at the
-	// announced boundary, so SlotToEpoch resolves slots in the first
-	// post-boundary epoch instead of returning ErrPastHorizon.
+	// The appended successor era starts exactly at the announced boundary, so
+	// SlotToEpoch resolves slots in the first post-boundary epoch instead of
+	// returning ErrPastHorizon. It is open here only because the resolved safe
+	// zone is zero (UnsafeIndefiniteSafeZone); see
+	// TestHardForkSummary_KnownTransitionSuccessorBoundedBySafeZone for the
+	// bounded case.
 	assert.Equal(t, *sum.Eras[0].End, sum.Eras[1].Start)
 	assert.Nil(t, sum.Eras[1].End)
 	info, err := sum.SlotToEpoch(700)
@@ -271,8 +274,9 @@ func TestHardForkSummary_KnownTransitionExtendsHeaderHorizon(t *testing.T) {
 		assert.Equalf(t, knownEpoch, info.Epoch, "slot %d epoch", slot)
 	}
 
-	// The successor era is open and reuses the current (last modeled) era's
-	// params; the bounded era still ends exactly at the announced boundary.
+	// The successor era reuses the current (last modeled) era's params and is
+	// open because this shape resolves a zero safe zone; the bounded era still
+	// ends exactly at the announced boundary.
 	require.Len(t, sum.Eras, 2)
 	require.NotNil(t, sum.Eras[0].End)
 	assert.Equal(t, boundarySlot, sum.Eras[0].End.Slot)
@@ -281,6 +285,150 @@ func TestHardForkSummary_KnownTransitionExtendsHeaderHorizon(t *testing.T) {
 	assert.Equal(t, sum.Eras[0].EraID, sum.Eras[1].EraID)
 	assert.Equal(t, sum.Eras[0].Params.EpochSize, sum.Eras[1].Params.EpochSize)
 	assert.Equal(t, sum.Eras[0].Params.SlotLength, sum.Eras[1].Params.SlotLength)
+}
+
+// TestHardForkSummary_KnownTransitionSuccessorBoundedBySafeZone asserts the
+// appended successor era is not unconditionally open: with a non-zero configured
+// safe zone it is bounded by that safe zone measured from the announced
+// boundary, snapped up to an epoch boundary. The horizon must still cover the
+// whole first post-boundary epoch (the liveness requirement), while slots beyond
+// the successor's own safe zone are rejected as past-horizon rather than
+// silently accepted.
+func TestHardForkSummary_KnownTransitionSuccessorBoundedBySafeZone(t *testing.T) {
+	const (
+		epochSize     = uint64(100)
+		safeZoneSlots = uint64(250)
+		knownEpoch    = uint64(7)
+		boundarySlot  = uint64(700) // first slot of epoch 7 (400 + (7-4)*100)
+		// 700 + 250 = 950 lands mid-epoch 9, so the bound snaps up to the
+		// start of epoch 10 at slot 1000.
+		succEndSlot = uint64(1_000)
+	)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       4,
+			StartSlot:     400,
+			SlotLength:    1_000,
+			LengthInSlots: 100,
+			EraId:         1,
+		}},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(knownEpoch),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(688, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	shape := hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     epochSize,
+				SlotLength:    time.Second,
+				SafeZoneSlots: safeZoneSlots,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	require.Len(t, sum.Eras, 2)
+
+	// TransitionKnown pins the current era at the announced boundary regardless
+	// of the safe zone.
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Equal(t, boundarySlot, sum.Eras[0].End.Slot)
+
+	// The successor is bounded, not open.
+	require.NotNil(t, sum.Eras[1].End)
+	assert.Equal(t, *sum.Eras[0].End, sum.Eras[1].Start)
+	assert.Equal(t, succEndSlot, sum.Eras[1].End.Slot)
+	assert.Equal(t, safeZoneSlots, sum.Eras[1].Params.SafeZoneSlots)
+
+	// The whole first post-boundary epoch stays inside the horizon.
+	for _, slot := range []uint64{
+		boundarySlot,
+		boundarySlot + epochSize - 1,
+		succEndSlot - 1,
+	} {
+		info, err := sum.SlotToEpoch(slot)
+		require.NoErrorf(t, err, "slot %d must be within horizon", slot)
+		assert.GreaterOrEqualf(t, info.Epoch, knownEpoch, "slot %d epoch", slot)
+	}
+
+	// Slots at or past the successor's bound are past-horizon again.
+	for _, slot := range []uint64{succEndSlot, succEndSlot + epochSize} {
+		_, err := sum.SlotToEpoch(slot)
+		require.ErrorIsf(t, err, hardfork.ErrPastHorizon,
+			"slot %d must be past horizon", slot)
+	}
+}
+
+// TestHardForkSummary_KnownTransitionSuccessorByShapeOrder asserts the successor
+// era is taken by position in the configured shape rather than by EraID + 1.
+// A shape with non-contiguous era IDs would otherwise fail the successor lookup
+// and silently reuse the current era's ID and params.
+func TestHardForkSummary_KnownTransitionSuccessorByShapeOrder(t *testing.T) {
+	const (
+		knownEpoch   = uint64(7)
+		boundarySlot = uint64(700)
+		succEraID    = uint(5)
+	)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       4,
+			StartSlot:     400,
+			SlotLength:    1_000,
+			LengthInSlots: 100,
+			EraId:         1,
+		}},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(knownEpoch),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(688, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	// EraID jumps from 1 to 5: EraForID(1+1) finds nothing, EraIndex(1)+1 finds
+	// the real successor.
+	shape := hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{
+			{
+				EraID: 1,
+				Params: hardfork.EraParams{
+					EpochSize:     100,
+					SlotLength:    time.Second,
+					SafeZoneSlots: 0,
+				},
+			},
+			{
+				EraID: succEraID,
+				Params: hardfork.EraParams{
+					EpochSize:     200,
+					SlotLength:    2 * time.Second,
+					SafeZoneSlots: 0,
+				},
+			},
+		},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	require.Len(t, sum.Eras, 2)
+
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Equal(t, boundarySlot, sum.Eras[0].End.Slot)
+	assert.Equal(t, uint(1), sum.Eras[0].EraID)
+
+	// The successor carries the next shape entry's ID and params, not the
+	// current era's.
+	assert.Equal(t, succEraID, sum.Eras[1].EraID)
+	assert.Equal(t, uint64(200), sum.Eras[1].Params.EpochSize)
+	assert.Equal(t, 2*time.Second, sum.Eras[1].Params.SlotLength)
 }
 
 func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {


### PR DESCRIPTION
## What

Fixes a header forecast-horizon deadlock at an epoch boundary when a hard-fork transition is armed. `HardForkSummary` now appends a successor era starting at the announced boundary, so the live header horizon covers the first post-boundary epoch. The successor is bounded by its own safe zone measured from the boundary (`hardfork.SuccessorEra`), which always snaps up to at least the end of that first epoch, so the horizon is extended without becoming unbounded. The point-in-time NtC era-history query stays bounded at the boundary as before.

## Why

When a pending hard-fork initiation arms `TransitionKnown(E)` before the epoch-E boundary, `BuildSummary` bounds the current era at that boundary and appends no successor era. The live summary's `SlotToEpoch` then returns `ErrPastHorizon` for every slot at or past the boundary, and the header forecast-horizon gate in `verify_header.go` rejects the first header of epoch E with `hardfork: slot/time past era horizon`. To clear the transition and extend era history the node must apply the first block of epoch E, but it can never verify that block's header, so it wedges a few slots before the boundary forever.

The rollover into the first post-boundary epoch is deterministic within the stability window, so its header can be verified from the forecast epoch cache. Appending the successor era at the boundary restores that: `SlotToEpoch` resolves the first post-boundary epoch, the header verifies, the block applies, and the rollover consumes the transition normally. The successor era takes the next era's params by position in the configured shape (`EraIndex`, so non-contiguous era IDs still resolve), falling back to the current era's params when the ledger already occupies the last modeled era (epoch length and slot length are constant across post-Byron eras, which is all `SlotToEpoch` needs). Its end is the standard safe zone measured from the boundary, the same rule `BuildSummary` applies for `TransitionImpossible`; a zero `SafeZoneSlots` remains `UnsafeIndefiniteSafeZone` and leaves the successor open. Mirrors the successor-era recursion in Haskell HFC `reconstructSummary`.

This is a regression from the change that began enforcing the known-era boundary as a hard header horizon. Before it, header verification forecast the epoch cache across the boundary and applied the first block of the next epoch normally.

## Scope

This is not specific to one network. Any from-genesis sync hits it at an epoch boundary where a pending, un-enacted `HardForkInitiation` arms `TransitionKnown`. It was found on a musashi from-genesis sync wedged at the epoch 6 to 7 boundary; preview, preprod, and mainnet from-genesis are subject to the same class.

## Validation

- Conformance (`internal/test/conformance`): pass.
- `go test ./ledger/...` (including `ledger/hardfork`): pass. Updated the `TransitionKnown` case of `TestHardForkSummary_CarriesTransitionInfo` to expect the appended successor era, and added: `TestHardForkSummary_KnownTransitionExtendsHeaderHorizon` (a miniature of the musashi epoch 6 to 7 wedge asserting the first post-boundary epoch is within the horizon), `TestHardForkSummary_KnownTransitionSuccessorBoundedBySafeZone` (the successor is bounded and slots past it are past-horizon again), `TestHardForkSummary_KnownTransitionCoversStabilityWindow` (a header several epochs past the boundary but still within one stability window of the tip resolves, with no transient past-horizon rejection at the intervening epoch boundaries), `TestHardForkSummary_KnownTransitionRejectsPastSuccessorBound` (the negative half: the successor's safe-zone bound is where the horizon ends), `TestHardForkSummary_KnownTransitionSuccessorByShapeOrder` (non-contiguous era IDs resolve the real successor), and `TestSuccessorEra_BoundedBySafeZone` / `TestSuccessorEra_ZeroSafeZoneStaysOpen` in `ledger/hardfork`.
- golangci-lint 0 issues; nilaway no new findings on the changed file; docs-parity pass.
- End-to-end: resuming the wedged musashi database (frozen at slot 604788) on a build with this fix crosses the epoch 6 to 7 boundary (slot 604800) and continues past it, with zero `verification rejected at slot` and zero `block processing failed` events. The same database looped indefinitely on both before this change.

## Docs

`ARCHITECTURE.md` updated to describe the extended live header horizon past a known transition (versus the bounded point-in-time NtC query). `DATABASE.md` not affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a header forecast-horizon deadlock at known hard-fork boundaries by appending a successor era at the announced boundary, bounded by its own safe zone. This keeps the first post-boundary epoch and the deterministic window from the tip within the live horizon so headers verify and the node progresses, while still rejecting slots past the successor’s bound.

- **Bug Fixes**
  - Append a successor era using `hardfork.SuccessorEra`; bound it by the successor’s safe zone from the boundary (snaps to at least the next epoch; open only if `SafeZoneSlots`=0) so `SlotToEpoch` resolves post-boundary slots within the stability window and rejects slots at or beyond the bound with `ErrPastHorizon`.
  - Select the successor by shape order, not `EraID + 1`; take next era params from `hardfork.Shape`, falling back to current era params when on the last modeled era.
  - Keep the NtC era-history query bounded at the boundary; clarify live vs NtC horizons in `ARCHITECTURE.md`. Tests added for stability-window coverage, safe-zone bound enforcement (including the negative case), and non-contiguous era IDs.

<sup>Written for commit 8f31b9bafb7114b2651f9f94e318eae1b23b6abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hard-fork horizon handling for known network transitions.
  - Headers in the first epoch after an announced transition are now validated correctly.
  - Validation beyond the supported horizon now consistently reports that the horizon has been exceeded.
  - When future transition details are unavailable, validation continues using the current era’s parameters.

- **Documentation**
  - Clarified how known, unknown, and unsupported hard-fork transitions affect header validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
