### PR TITLE
fix(consensus): extend live horizon past known transition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1505,13 +1505,20 @@ Before resolving or eagerly forecasting an epoch for a live header,
 The in-memory summary uses the same configured era safe zone and
 `TransitionInfo` as the NtC era-history query: an unknown transition is bounded
 from the applied tip by the era's stability window (`3k/f` for Shelley and
-later), a known transition is bounded at the announced era boundary, and an
-impossible transition keeps the same rolling safe-zone bound so live slot
-processing can cross a confirmed same-era epoch boundary. (The point-in-time
-NtC query may conservatively stop its reported range at that confirmed
-boundary.) A header at or past the live bound fails with
-`hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the forecasted
-epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
+later) and an impossible transition keeps the same rolling safe-zone bound so
+live slot processing can cross a confirmed same-era epoch boundary. A known
+transition is bounded at the announced era boundary for the point-in-time NtC
+query, but the live summary appends an open successor era starting at that
+boundary so the header horizon extends one epoch past the transition. This is
+required for liveness: the rollover into the first post-boundary epoch is
+deterministic within the stability window, so its header can be verified, and
+without the extra epoch the gate would reject that first header and the node
+could never apply the block that consumes the transition and extends era
+history (a boundary deadlock). The successor era uses the next era's params from
+the configured shape, falling back to the current era's params when the ledger
+already occupies the last modeled era. A header past this extended live bound
+fails with `hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the
+forecasted epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
 rolled the applied chain back to its common ancestor, so permitted epoch-nonce
 forecasts and the epoch-specific Mark stake snapshot used for leader
 eligibility are read from that intersection state.

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -159,5 +159,46 @@ func (ls *LedgerState) HardForkSummary() (*hardfork.Summary, error) {
 		return nil, err
 	}
 	summary.Transition = transitionInfo
+
+	// When a known transition is armed, BuildSummary bounds the current era at
+	// the announced epoch boundary (mkUpperBound) and appends no successor era.
+	// That leaves the summary's last era bounded, so eraForSlot / SlotToEpoch
+	// return ErrPastHorizon for every slot at or past the boundary. The header
+	// forecast-horizon gate in verify_header.go then hard-rejects the first
+	// header of the post-boundary epoch, and the node can never apply the block
+	// that would consume the transition and extend era history — a liveness
+	// deadlock at the boundary. Unlike the NtC era-history query, which serves a
+	// point-in-time answer and is intentionally bounded, live header
+	// verification must see the horizon extend at least one epoch past a known
+	// transition, because the rollover is deterministic within the stability
+	// window. Append the successor era as an open (unbounded) era starting at
+	// the announced boundary so the horizon covers the first post-boundary
+	// epoch. Use the next era's params from the shape; when the current era is
+	// the last modeled era (the transition re-arms an era the ledger already
+	// occupies), reuse the current era's params — epoch length and slot length
+	// are constant across post-Byron eras, which is all SlotToEpoch needs.
+	// Mirrors the successor-era append in Haskell HFC reconstructSummary.
+	if transitionInfo.State == hardfork.TransitionKnown && len(summary.Eras) > 0 {
+		bounded := summary.Eras[len(summary.Eras)-1]
+		if bounded.End != nil {
+			succEraID := bounded.EraID
+			succParams := bounded.Params
+			if next, ok := shape.EraForID(bounded.EraID + 1); ok {
+				succEraID = next.EraID
+				succParams = next.Params
+			}
+			summary.Eras = append(summary.Eras, hardfork.EraSummary{
+				EraID: succEraID,
+				Start: *bounded.End,
+				End:   nil,
+				Params: hardfork.EraParams{
+					EpochSize:     succParams.EpochSize,
+					SlotLength:    succParams.SlotLength,
+					SafeZoneSlots: succParams.SafeZoneSlots,
+					GenesisWindow: succParams.GenesisWindow,
+				},
+			})
+		}
+	}
 	return &summary, nil
 }

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -191,11 +191,96 @@ func TestHardForkSummary_CarriesTransitionInfo(t *testing.T) {
 		time.Date(2022, 10, 25, 0, 0, 0, 0, time.UTC),
 		sum.SystemStart,
 	)
-	require.Len(t, sum.Eras, 1)
+	// A known transition bounds the current era at the announced epoch
+	// boundary and appends an open successor era so the header forecast
+	// horizon still covers the first post-boundary epoch (see HardForkSummary).
+	require.Len(t, sum.Eras, 2)
 	require.NotNil(t, sum.Eras[0].End)
 	assert.Zero(t, sum.Eras[0].Params.SafeZoneSlots)
 	assert.Equal(t, uint64(700), sum.Eras[0].End.Slot)
 	assert.Equal(t, uint64(7), sum.Eras[0].End.Epoch)
+	// The appended successor era is open (unbounded) and starts exactly at the
+	// announced boundary, so SlotToEpoch resolves slots in the first
+	// post-boundary epoch instead of returning ErrPastHorizon.
+	assert.Equal(t, *sum.Eras[0].End, sum.Eras[1].Start)
+	assert.Nil(t, sum.Eras[1].End)
+	info, err := sum.SlotToEpoch(700)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7), info.Epoch)
+}
+
+// TestHardForkSummary_KnownTransitionExtendsHeaderHorizon is a regression test
+// for the header forecast-horizon deadlock: a pending hard-fork initiation arms
+// TransitionKnown before an epoch boundary, BuildSummary bounds the current era
+// at that boundary, and the header verification gate then rejected the first
+// header of the post-boundary epoch as past-horizon, so the node could never
+// apply the block that would consume the transition and extend era history.
+// HardForkSummary must append an open successor era at the boundary so the
+// first post-boundary epoch stays within the forecast horizon. Reproduces the
+// musashi epoch 6 to 7 wedge in miniature.
+func TestHardForkSummary_KnownTransitionExtendsHeaderHorizon(t *testing.T) {
+	const (
+		epochSize    = uint64(100)
+		startEpoch   = uint64(4)
+		startSlot    = uint64(400)
+		knownEpoch   = uint64(7)
+		boundarySlot = uint64(700) // first slot of epoch 7 (400 + (7-4)*100)
+	)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       startEpoch,
+			StartSlot:     startSlot,
+			SlotLength:    1_000,
+			LengthInSlots: 100,
+			EraId:         1,
+		}},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(knownEpoch),
+		currentTip:     ochainsync.Tip{Point: ocommon.NewPoint(688, []byte("tip"))},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	// A single modeled era: the ledger already occupies the last era, so the
+	// appended successor era reuses the current era's params.
+	shape := hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     epochSize,
+				SlotLength:    time.Second,
+				SafeZoneSlots: 0,
+			},
+		}},
+	}
+	ls.cachedShape.Store(&shape)
+	ls.publishSnapshotsLocked()
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+
+	// The first block of the post-boundary epoch, and slots within it, must
+	// resolve to that epoch rather than returning ErrPastHorizon.
+	for _, slot := range []uint64{
+		boundarySlot,
+		boundarySlot + 10,
+		boundarySlot + epochSize - 1,
+	} {
+		info, err := sum.SlotToEpoch(slot)
+		require.NoErrorf(t, err, "slot %d must be within horizon", slot)
+		assert.Equalf(t, knownEpoch, info.Epoch, "slot %d epoch", slot)
+	}
+
+	// The successor era is open and reuses the current (last modeled) era's
+	// params; the bounded era still ends exactly at the announced boundary.
+	require.Len(t, sum.Eras, 2)
+	require.NotNil(t, sum.Eras[0].End)
+	assert.Equal(t, boundarySlot, sum.Eras[0].End.Slot)
+	assert.Equal(t, *sum.Eras[0].End, sum.Eras[1].Start)
+	assert.Nil(t, sum.Eras[1].End)
+	assert.Equal(t, sum.Eras[0].EraID, sum.Eras[1].EraID)
+	assert.Equal(t, sum.Eras[0].Params.EpochSize, sum.Eras[1].Params.EpochSize)
+	assert.Equal(t, sum.Eras[0].Params.SlotLength, sum.Eras[1].Params.SlotLength)
 }
 
 func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {


### PR DESCRIPTION
## Summary

- Extend the live hardfork summary with an open successor era after a known transition.
- Prevent the slot clock from repeatedly failing to convert the next slot at the transition horizon.
- Preserve bounded point-in-time era-history behavior.

## Validation

- go test ./ledger/...
- git diff --check

## Documentation

- Updated ARCHITECTURE.md.
- DATABASE.md unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the live hard-fork horizon by appending an open successor era after a known transition, so the first post-boundary epoch’s headers are accepted and sync does not deadlock. Also stops repeated past-horizon failures in the slot clock while keeping point-in-time era-history queries bounded.

- **Bug Fixes**
  - Append an open successor era at the announced boundary when `TransitionKnown`, using next era params or reusing current if last modeled.
  - Prevent `ErrPastHorizon` at the boundary; headers pass the forecast-horizon gate in `verify_header.go`.
  - Update tests (add regression) and `ARCHITECTURE.md`; NtC point-in-time range remains bounded.

<sup>Written for commit ecf15a8b327c16fc62a1daf7e48a6879dbc82332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended header processing beyond known hard-fork boundaries, allowing valid post-boundary slots to resolve correctly.
  * Preserved existing stability-window limits for unknown or impossible transitions.
* **Tests**
  * Added coverage for boundary slots, subsequent slots, successor-era parameters, and open forecast horizons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->