### PR TITLE
fix(ledger): refuse blob recovery of off-primary-chain producers during catch-up

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -820,6 +820,22 @@ so every existing ingest path — bootstrap, gap-closure, historical/trusted
 replay, and the `SkipConsumedInputRecovery` Leios apply above — keeps its
 recovery behavior unchanged.
 
+`StrictAppliedInputConservation` is armed only at tip, so it does not cover a
+divergence baked in during catch-up (a validated block below the tip stability
+window). To close that gap, `recoverConsumedUtxo` applies a primary-chain
+membership check for every validated block past the `mithril_ledger_slot`
+boundary: after resolving the producer block that owns a blob-recovered UTxO, it
+refuses (`ErrUtxoNotFound`) if that block is not the block currently indexed on
+the applied primary chain at its height. The append-only blob store retains
+abandoned-fork blocks, so a producer present in the blob is not necessarily on
+the applied chain; the membership check (`BlockByPoint` locates the producer,
+`BlockByIndex` reveals which block is canonical at that height, mirroring
+`LedgerState.primaryChainContainsPoint`) refuses only the off-chain case, so a
+legitimate on-chain producer whose `utxo` row is merely absent is still
+recovered. This check is not applied below the boundary or on the Mithril
+gap-closure recovery path, where imported history need not carry a block-index
+entry for the producer.
+
 ### Archive And History Expiry Contract
 
 Archive nodes and history-expiry nodes use the same logical blob keys. The

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -828,11 +828,15 @@ boundary: after resolving the producer block that owns a blob-recovered UTxO, it
 refuses (`ErrUtxoNotFound`) if that block is not the block currently indexed on
 the applied primary chain at its height. The append-only blob store retains
 abandoned-fork blocks, so a producer present in the blob is not necessarily on
-the applied chain; the membership check (`BlockByPoint` locates the producer,
-`BlockByIndex` reveals which block is canonical at that height, mirroring
-`LedgerState.primaryChainContainsPoint`) refuses only the off-chain case, so a
-legitimate on-chain producer whose `utxo` row is merely absent is still
-recovered. This check is not applied below the boundary or on the Mithril
+the applied chain; the membership check (`BlockByIndex` reveals which block is
+canonical at the producer's height and a hash mismatch means it was abandoned,
+mirroring `LedgerState.primaryChainContainsPoint`) refuses only the off-chain
+case, so a legitimate on-chain producer whose `utxo` row is merely absent is
+still recovered. The producer's block ID comes from the recovery path that
+already loaded it — the blob's block metadata for offset-format entries, the
+resolved `models.Block` otherwise — so the check adds one `BlockByIndex` lookup
+rather than re-downloading the producer's full CBOR from cold storage once per
+recovered input. This check is not applied below the boundary or on the Mithril
 gap-closure recovery path, where imported history need not carry a block-index
 entry for the producer.
 

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -759,21 +759,21 @@ func (d *Database) ensureGapConsumedUtxos(
 // chain at that height. The append-only blob store retains blocks from
 // abandoned forks, so a producer found in the blob is not necessarily on the
 // applied chain. Mirrors LedgerState.primaryChainContainsPoint at the database
-// layer (BlockByPoint locates the block, BlockByIndex reveals which block is
-// canonical at that height).
+// layer: BlockByIndex reveals which block is canonical at the producer's
+// height, and a hash mismatch means the producer was abandoned.
+//
+// The producer's block ID is supplied by the caller rather than resolved here.
+// Every recovery path has already loaded the producer -- from the blob's block
+// metadata in the offset case, or as a *models.Block in the others -- so
+// looking it up again by point would download the same full block CBOR from
+// cold cloud storage a second time, once per recovered input, on exactly the
+// Mithril catch-up path this check runs on.
 func (d *Database) recoveredProducerOnPrimaryChain(
 	txn *Txn,
-	slot uint64,
+	producerID uint64,
 	hash []byte,
 ) (bool, error) {
-	block, err := BlockByPointTxn(txn, ocommon.Point{Slot: slot, Hash: hash})
-	if err != nil {
-		if errors.Is(err, models.ErrBlockNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	indexed, err := d.BlockByIndex(block.ID, txn)
+	indexed, err := d.BlockByIndex(producerID, txn)
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return false, nil
@@ -794,11 +794,12 @@ func (d *Database) recoveredProducerOnPrimaryChain(
 // carry a block-index entry for the producer.
 func (d *Database) refuseOffPrimaryChainProducer(
 	txn *Txn,
+	producerID uint64,
 	slot uint64,
 	hash []byte,
 	input lcommon.TransactionInput,
 ) error {
-	onChain, err := d.recoveredProducerOnPrimaryChain(txn, slot, hash)
+	onChain, err := d.recoveredProducerOnPrimaryChain(txn, producerID, hash)
 	if err != nil {
 		return fmt.Errorf(
 			"check producer primary-chain membership for %s: %w",
@@ -850,7 +851,7 @@ func (d *Database) recoverConsumedUtxo(
 		if err != nil {
 			return nil, fmt.Errorf("decode utxo offset: %w", err)
 		}
-		blockCbor, _, err := blob.GetBlock(
+		blockCbor, producerMeta, err := blob.GetBlock(
 			blobTxn,
 			offset.BlockSlot,
 			offset.BlockHash[:],
@@ -871,7 +872,11 @@ func (d *Database) recoverConsumedUtxo(
 		addedSlot = offset.BlockSlot
 		if enforcePrimaryChain {
 			if err := d.refuseOffPrimaryChainProducer(
-				txn, offset.BlockSlot, offset.BlockHash[:], input,
+				txn,
+				producerMeta.ID,
+				offset.BlockSlot,
+				offset.BlockHash[:],
+				input,
 			); err != nil {
 				return nil, err
 			}
@@ -900,10 +905,11 @@ func (d *Database) recoverConsumedUtxo(
 		}
 		addedSlot = slot
 		if enforcePrimaryChain {
-			// The legacy metadata slot lookup does not yield the producer
-			// block hash, so resolve the producer block to check primary-chain
-			// membership. Legacy raw-CBOR blob entries do not occur past the
-			// Mithril boundary in practice, so this extra fetch is exceptional.
+			// The legacy metadata slot lookup yields neither the producer
+			// block hash nor its ID, so resolve the producer block to check
+			// primary-chain membership. Legacy raw-CBOR blob entries do not
+			// occur past the Mithril boundary in practice, so this extra
+			// lookup is exceptional.
 			prodBlock, bErr := utxoRecoveryBlockForTx(
 				txn.DB(), txn, ledgerInputIDBytes(input),
 			)
@@ -916,7 +922,7 @@ func (d *Database) recoverConsumedUtxo(
 				return nil, ErrUtxoNotFound
 			}
 			if err := d.refuseOffPrimaryChainProducer(
-				txn, prodBlock.Slot, prodBlock.Hash, input,
+				txn, prodBlock.ID, prodBlock.Slot, prodBlock.Hash, input,
 			); err != nil {
 				return nil, err
 			}
@@ -952,7 +958,7 @@ func (d *Database) recoverConsumedUtxo(
 		addedSlot = block.Slot
 		if enforcePrimaryChain {
 			if err := d.refuseOffPrimaryChainProducer(
-				txn, block.Slot, block.Hash, input,
+				txn, block.ID, block.Slot, block.Hash, input,
 			); err != nil {
 				return nil, err
 			}

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -585,9 +585,17 @@ func (d *Database) ensureTransactionConsumedUtxos(
 				ErrUtxoNotFound,
 			)
 		}
+		// For a validated block past the Mithril trust boundary, refuse to
+		// blob-recover a producer that is not on the applied primary chain
+		// (issue #3005 cross-fork splice). This covers the catch-up case that
+		// the at-tip StrictAppliedInputConservation guard above does not reach:
+		// there reachedTip is not latched, so the guard is off, and a fork
+		// switched to during catch-up could otherwise silently resurrect an
+		// abandoned-fork producer from the append-only blob store.
 		recoveredUtxo, err := d.recoverConsumedUtxo(
 			input,
 			txn,
+			d.config.StrictUtxoValidation && point.Slot > mithrilBoundarySlot,
 		)
 		if err != nil {
 			// Past the Mithril trust boundary the node should have complete
@@ -711,7 +719,10 @@ func (d *Database) ensureGapConsumedUtxos(
 				continue
 			}
 		}
-		recoveredUtxo, err := d.recoverConsumedUtxo(input, txn)
+		// Mithril gap-closure recovers producers from imported history that
+		// legitimately has no block-index entry, so the primary-chain
+		// membership check is not applied on this path.
+		recoveredUtxo, err := d.recoverConsumedUtxo(input, txn, false)
 		if err != nil {
 			return fmt.Errorf(
 				"recover gap input utxo %s at slot %d: %w",
@@ -743,9 +754,77 @@ func (d *Database) ensureGapConsumedUtxos(
 	return nil
 }
 
+// recoveredProducerOnPrimaryChain reports whether the block that produced a
+// blob-recovered UTxO is the block currently indexed on the applied primary
+// chain at that height. The append-only blob store retains blocks from
+// abandoned forks, so a producer found in the blob is not necessarily on the
+// applied chain. Mirrors LedgerState.primaryChainContainsPoint at the database
+// layer (BlockByPoint locates the block, BlockByIndex reveals which block is
+// canonical at that height).
+func (d *Database) recoveredProducerOnPrimaryChain(
+	txn *Txn,
+	slot uint64,
+	hash []byte,
+) (bool, error) {
+	block, err := BlockByPointTxn(txn, ocommon.Point{Slot: slot, Hash: hash})
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	indexed, err := d.BlockByIndex(block.ID, txn)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return bytes.Equal(indexed.Hash, hash), nil
+}
+
+// refuseOffPrimaryChainProducer returns a wrapped ErrUtxoNotFound when the
+// producer block of a blob-recovered consumed input is not on the applied
+// primary chain. Recovering such a producer would splice in a UTxO the applied
+// chain never produced (issue #3005 cross-fork input-conservation violation).
+// It is enforced for validated blocks past the Mithril trust boundary, where
+// the producer must be a live, applied, on-chain UTxO, so an abandoned-fork
+// producer is never legitimate. Below the boundary and on the Mithril
+// gap-closure path the check is not applied, because imported history need not
+// carry a block-index entry for the producer.
+func (d *Database) refuseOffPrimaryChainProducer(
+	txn *Txn,
+	slot uint64,
+	hash []byte,
+	input lcommon.TransactionInput,
+) error {
+	onChain, err := d.recoveredProducerOnPrimaryChain(txn, slot, hash)
+	if err != nil {
+		return fmt.Errorf(
+			"check producer primary-chain membership for %s: %w",
+			input.String(),
+			err,
+		)
+	}
+	if !onChain {
+		return fmt.Errorf(
+			"producer block %x at slot %d for consumed utxo %s is not on the "+
+				"applied primary chain: refusing abandoned-fork blob recovery "+
+				"that would persist an input-conservation violation "+
+				"(issue #3005): %w",
+			hash,
+			slot,
+			input.String(),
+			ErrUtxoNotFound,
+		)
+	}
+	return nil
+}
+
 func (d *Database) recoverConsumedUtxo(
 	input lcommon.TransactionInput,
 	txn *Txn,
+	enforcePrimaryChain bool,
 ) (*models.Utxo, error) {
 	blob := txn.DB().Blob()
 	if blob == nil {
@@ -790,6 +869,13 @@ func (d *Database) recoverConsumedUtxo(
 		}
 		outputCbor = blockCbor[offset.ByteOffset:end]
 		addedSlot = offset.BlockSlot
+		if enforcePrimaryChain {
+			if err := d.refuseOffPrimaryChainProducer(
+				txn, offset.BlockSlot, offset.BlockHash[:], input,
+			); err != nil {
+				return nil, err
+			}
+		}
 	case err == nil:
 		// Legacy format: raw output CBOR is already present in utxoData.
 		// Resolve the producer slot so addedSlot reflects when the UTxO
@@ -813,6 +899,28 @@ func (d *Database) recoverConsumedUtxo(
 			return nil, ErrUtxoNotFound
 		}
 		addedSlot = slot
+		if enforcePrimaryChain {
+			// The legacy metadata slot lookup does not yield the producer
+			// block hash, so resolve the producer block to check primary-chain
+			// membership. Legacy raw-CBOR blob entries do not occur past the
+			// Mithril boundary in practice, so this extra fetch is exceptional.
+			prodBlock, bErr := utxoRecoveryBlockForTx(
+				txn.DB(), txn, ledgerInputIDBytes(input),
+			)
+			if bErr != nil {
+				return nil, fmt.Errorf(
+					"resolve producer block for primary-chain check: %w", bErr,
+				)
+			}
+			if prodBlock == nil {
+				return nil, ErrUtxoNotFound
+			}
+			if err := d.refuseOffPrimaryChainProducer(
+				txn, prodBlock.Slot, prodBlock.Hash, input,
+			); err != nil {
+				return nil, err
+			}
+		}
 	default:
 		block, err := utxoRecoveryBlockForTx(
 			txn.DB(),
@@ -842,6 +950,13 @@ func (d *Database) recoverConsumedUtxo(
 			return nil, err
 		}
 		addedSlot = block.Slot
+		if enforcePrimaryChain {
+			if err := d.refuseOffPrimaryChainProducer(
+				txn, block.Slot, block.Hash, input,
+			); err != nil {
+				return nil, err
+			}
+		}
 		indexer := NewBlockIndexer(block.Slot, block.Hash)
 		offsets, indexErr := indexer.ComputeOffsets(block.Cbor, decodedBlock)
 		if indexErr == nil {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -461,9 +461,73 @@ func TestRecoverConsumedUtxoLegacyRawCborWithoutProducerBlockFails(t *testing.T)
 	txn := db.Transaction(true)
 	defer txn.Release()
 
-	_, err = db.recoverConsumedUtxo(dbtestutil.NewMockInput(txId, 0), txn)
+	_, err = db.recoverConsumedUtxo(dbtestutil.NewMockInput(txId, 0), txn, false)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrUtxoNotFound)
+}
+
+// TestRecoveredProducerOnPrimaryChain verifies the membership check that gates
+// blob-recovery of consumed inputs (issue #3005 Mode B cross-fork splice). A
+// producer block that is present in the append-only blob store but is not the
+// block indexed on the applied primary chain at its height (an abandoned fork)
+// must be reported off-chain, so recoverConsumedUtxo refuses to resurrect it
+// for a validated block past the Mithril boundary.
+func TestRecoveredProducerOnPrimaryChain(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{
+		DataDir:              t.TempDir(),
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		StrictUtxoValidation: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const height = uint64(100)
+	canonHash := bytes.Repeat([]byte{0x11}, 32)
+	forkHash := bytes.Repeat([]byte{0x22}, 32)
+	prevHash := bytes.Repeat([]byte{0x01}, 32)
+
+	create := func(slot uint64, hash []byte) {
+		t.Helper()
+		txn := db.Transaction(true)
+		require.NoError(t, txn.Do(func(itxn *Txn) error {
+			return db.BlockCreate(models.Block{
+				ID:       height,
+				Slot:     slot,
+				Hash:     hash,
+				PrevHash: prevHash,
+				Number:   height,
+				Cbor:     []byte{0x80},
+			}, itxn)
+		}))
+		txn.Release()
+	}
+
+	check := func(slot uint64, hash []byte) bool {
+		t.Helper()
+		txn := db.Transaction(true)
+		defer txn.Release()
+		onChain, cErr := db.recoveredProducerOnPrimaryChain(txn, slot, hash)
+		require.NoError(t, cErr)
+		return onChain
+	}
+
+	// The block currently indexed at this height is on the primary chain.
+	create(1000, canonHash)
+	require.True(t, check(1000, canonHash),
+		"canonical producer must be reported on-chain")
+
+	// Index the same height to a different block: the earlier block remains
+	// retrievable by point (append-only blob) but is no longer the canonical
+	// block at its height, i.e. an abandoned fork.
+	create(2000, forkHash)
+	require.False(t, check(1000, canonHash),
+		"abandoned-fork producer (not indexed at its height) must be off-chain")
+	require.True(t, check(2000, forkHash),
+		"the newly indexed block is now the canonical producer")
+
+	// A producer absent from the store is off-chain.
+	require.False(t, check(3000, bytes.Repeat([]byte{0x33}, 32)),
+		"absent producer must be reported off-chain")
 }
 
 // TestSetTransactionRecoveryPopulatesProducerFK verifies that when

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -502,32 +502,36 @@ func TestRecoveredProducerOnPrimaryChain(t *testing.T) {
 		txn.Release()
 	}
 
-	check := func(slot uint64, hash []byte) bool {
+	// The producer's block ID is supplied by the caller (every recovery path
+	// has already loaded the producer), so the check is by ID and hash.
+	check := func(producerID uint64, hash []byte) bool {
 		t.Helper()
 		txn := db.Transaction(true)
 		defer txn.Release()
-		onChain, cErr := db.recoveredProducerOnPrimaryChain(txn, slot, hash)
+		onChain, cErr := db.recoveredProducerOnPrimaryChain(
+			txn, producerID, hash,
+		)
 		require.NoError(t, cErr)
 		return onChain
 	}
 
 	// The block currently indexed at this height is on the primary chain.
 	create(1000, canonHash)
-	require.True(t, check(1000, canonHash),
+	require.True(t, check(height, canonHash),
 		"canonical producer must be reported on-chain")
 
 	// Index the same height to a different block: the earlier block remains
 	// retrievable by point (append-only blob) but is no longer the canonical
 	// block at its height, i.e. an abandoned fork.
 	create(2000, forkHash)
-	require.False(t, check(1000, canonHash),
+	require.False(t, check(height, canonHash),
 		"abandoned-fork producer (not indexed at its height) must be off-chain")
-	require.True(t, check(2000, forkHash),
+	require.True(t, check(height, forkHash),
 		"the newly indexed block is now the canonical producer")
 
-	// A producer absent from the store is off-chain.
-	require.False(t, check(3000, bytes.Repeat([]byte{0x33}, 32)),
-		"absent producer must be reported off-chain")
+	// A producer at a height the chain never indexed is off-chain.
+	require.False(t, check(height+1, canonHash),
+		"producer at an unindexed height must be reported off-chain")
 }
 
 // TestSetTransactionRecoveryPopulatesProducerFK verifies that when
@@ -954,4 +958,110 @@ func TestEnsureTransactionConsumedUtxosStrictValidation(t *testing.T) {
 		)
 		require.NoError(t, setTransaction(t, db))
 	})
+}
+
+// TestRecoverConsumedUtxoRefusesOffPrimaryChainProducer is the end-to-end guard
+// for the Mode B cross-fork splice (issue #3005): it drives recoverConsumedUtxo
+// itself, with a real offset-format blob entry, rather than only the membership
+// helper. The append-only blob store keeps abandoned-fork blocks, so an
+// offset-format UTxO can still resolve to a producer the applied chain
+// abandoned; recovering it for a validated block past the Mithril boundary would
+// splice in a UTxO the chain never produced.
+//
+// The three cases pin that the gate is what decides: a canonical producer gets
+// past it, an abandoned one is refused with ErrUtxoNotFound, and with the gate
+// off the same abandoned producer gets past it again. "Past the gate" is
+// observed as the later, unrelated output-decode failure, so the test needs no
+// fabricated ledger CBOR.
+func TestRecoverConsumedUtxoRefusesOffPrimaryChainProducer(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{
+		DataDir:              t.TempDir(),
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		StrictUtxoValidation: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const (
+		producerID   = uint64(500)
+		producerSlot = uint64(1_000)
+	)
+	txId := randomHash(t)
+	producerHash := randomHash(t)
+	// Block CBOR whose bytes at [1,4) stand in for the output payload. The
+	// content only has to be sliceable; the refusal happens before any decode.
+	blockCbor := []byte{0x80, 0xa1, 0xb2, 0xc3, 0xd4}
+	payloadOffset, payloadLength := uint32(1), uint32(3)
+
+	createBlock := func(hash []byte, slot uint64) {
+		t.Helper()
+		txn := db.Transaction(true)
+		require.NoError(t, txn.Do(func(itxn *Txn) error {
+			return db.BlockCreate(models.Block{
+				ID:       producerID,
+				Slot:     slot,
+				Hash:     hash,
+				PrevHash: randomHash(t),
+				Number:   producerID,
+				Cbor:     blockCbor,
+				Type:     1,
+			}, itxn)
+		}))
+		txn.Release()
+	}
+
+	// The producer block, canonical at its height, plus an offset-format blob
+	// entry for the consumed input pointing into it.
+	createBlock(producerHash, producerSlot)
+	var producerHashArr [32]byte
+	copy(producerHashArr[:], producerHash)
+	blobTxn := db.BlobTxn(true)
+	require.NoError(t, blobTxn.Do(func(itxn *Txn) error {
+		return db.Blob().SetUtxo(
+			itxn.Blob(), txId, 0,
+			EncodeUtxoOffset(&CborOffset{
+				BlockSlot:  producerSlot,
+				BlockHash:  producerHashArr,
+				ByteOffset: payloadOffset,
+				ByteLength: payloadLength,
+			}),
+		)
+	}))
+
+	recover := func(enforcePrimaryChain bool) error {
+		t.Helper()
+		txn := db.Transaction(true)
+		defer txn.Release()
+		_, rErr := db.recoverConsumedUtxo(
+			dbtestutil.NewMockInput(txId, 0), txn, enforcePrimaryChain,
+		)
+		return rErr
+	}
+
+	// Canonical producer: the gate allows it through, and recovery proceeds to
+	// the output decode.
+	err = recover(true)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUtxoNotFound,
+		"a canonical producer must not be refused by the primary-chain gate")
+	require.ErrorContains(t, err, "decode transaction output",
+		"recovery should reach the decode step for a canonical producer")
+
+	// Index a different block at the producer's height: the producer is still
+	// in the blob and still resolvable by the offset, but is now an abandoned
+	// fork.
+	createBlock(randomHash(t), producerSlot+1)
+
+	err = recover(true)
+	require.ErrorIs(t, err, ErrUtxoNotFound,
+		"an abandoned-fork producer must be refused past the trust boundary")
+	require.ErrorContains(t, err, "not on the applied primary chain")
+
+	// With the gate off (below the boundary, or the Mithril gap-closure path)
+	// the same producer is recovered as before.
+	err = recover(false)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUtxoNotFound,
+		"the gate must be the only thing refusing this producer")
+	require.ErrorContains(t, err, "decode transaction output")
 }


### PR DESCRIPTION
## What

Closes the catch-up gap in the issue #3005 cross-fork input-conservation defense. `recoverConsumedUtxo` now refuses to resurrect a consumed input's producer from the append-only blob store when that producer's block is not the block currently indexed on the applied primary chain at its height, for validated blocks past the Mithril trust boundary.

## Why

`StrictAppliedInputConservation` (#3105) is armed only at tip: `strictConsumedInputsEnabled` requires `reachedTip` or the per-block `reachesTip`, which only turns on within one stability window of the tip. A fork switched to during catch-up (a validated block below that cutoff, for example a from-genesis or old-Mithril catch-up) therefore runs with the guard off, so `ensureTransactionConsumedUtxos` could still silently recover a producer that lives only on an abandoned-fork block. The append-only blob store deliberately retains abandoned-fork blocks, so that recovery imports a UTxO the applied chain never produced. The divergence accumulates until rejoining canonical needs a rollback past the security parameter K or past the Mithril snapshot, which is correctly refused, and the node then denies the honest network and freezes.

## How

`recoverConsumedUtxo` takes a new `enforcePrimaryChain` flag. The validated-apply caller sets it for every block past the Mithril boundary, independent of tip proximity; the Mithril gap-closure caller leaves it off (imported history need not carry a block-index entry for the producer). When set, after resolving the producer block that owns a blob-recovered UTxO, recovery refuses (`ErrUtxoNotFound`) if that block is not the block indexed on the applied primary chain at its height.

The membership check is database-local: `BlockByPoint` locates the producer block, `BlockByIndex` reveals which block is canonical at that height, mirroring `LedgerState.primaryChainContainsPoint`. It adds no database-to-ledger dependency (`make import-boundaries` passes). It refuses only the off-chain case, so a legitimate on-chain producer whose `utxo` row is merely absent is still recovered, unlike a blanket at-tip refusal which would stall that legitimate case.

## Validation

- New `TestRecoveredProducerOnPrimaryChain`: a canonical producer is on-chain; an abandoned-fork block whose height is indexed to a different block is off-chain; an absent producer is off-chain.
- The existing `TestEnsureTransactionConsumedUtxosStrictAppliedInputConservation` still passes, including the "flag off recovers from blob" subtest, confirming an on-chain producer with a deleted `utxo` row is recovered even with the check active.
- `go test ./database/... ./ledger/...`, conformance, golangci-lint (0 issues), nilaway, `make import-boundaries`, `make docs-parity`: all pass.

## Scope

This defends the blob-recovery splice vector, which is the mechanism observed in preprod Mithril catch-up (a fork requiring a rewind past the snapshot, with the honest network denied). It is defense in depth alongside #3072 (stale-index splice) and #3105 (at-tip guard). It does not by itself resolve the separate musashi from-genesis wedge, which is driven by Leios endorser-block availability and epoch-boundary chain-selection thrashing rather than blob recovery.

## Docs

`DATABASE.md` updated (the blob-recovery / `StrictAppliedInputConservation` section). `ARCHITECTURE.md` checked, not affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuse blob recovery of consumed inputs when the producer block isn’t on the applied primary chain during catch-up past the Mithril boundary, closing the Mode B cross-fork input-conservation gap (issue #3005). Uses the producer block ID for a single `BlockByIndex` check.

- **Bug Fixes**
  - Add `enforcePrimaryChain` to `recoverConsumedUtxo`; enabled for validated apply past `mithril_ledger_slot`, off for Mithril gap-closure.
  - Verify producer membership by ID/hash via `BlockByIndex`; if not canonical at its height, return `ErrUtxoNotFound`.
  - Preserve recovery for on-chain producers with a missing `utxo` row.

- **Tests & Docs**
  - Add `TestRecoverConsumedUtxoRefusesOffPrimaryChainProducer` (end-to-end) and `TestRecoveredProducerOnPrimaryChain`.
  - Update `DATABASE.md` to document the ID-based primary-chain check that avoids re-downloading block CBOR.

<sup>Written for commit 83149f51e0a0986c5d5e228fdfc8407ac54b050d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of consumed transaction outputs by validating that their producing blocks belong to the applied primary chain.
  * Prevents recovery from abandoned forks or missing producers, returning a not-found error instead.
  * Preserves valid recovery for canonical-chain outputs and supported gap-closure scenarios.

* **Documentation**
  * Documented primary-chain validation behavior during consumed-output recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->