### PR TITLE
fix(consensus): defer past-horizon header rejection instead of recycling the peer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1538,7 +1538,15 @@ successor stays open only when the resolved safe zone is zero
 (`UnsafeIndefiniteSafeZone`), the same rule `BuildSummary` applies to the
 current era. Where that live bound is finite, a header past it fails with
 `hardfork.ErrPastHorizon` before `ensureEpochForSlot` can extend the forecasted
-epoch/nonce cache. Candidate fork blockfetch begins after fork resolution has
+epoch/nonce cache. That past-horizon failure is classified as a deferred
+condition (wrapped in `errHeaderVerificationDeferred`), not a peer fault: during
+catch-up the header chain legitimately runs ahead of the applied tip and crosses
+epoch boundaries, so the block is kept queued for in-order re-verification once
+the applied tip advances into range, and the peer that served it is not
+recycled. Recycling honest peers on these benign past-horizon rejections would
+starve the peer pool the block and Leios endorser-block fetch depend on and
+deadlock catch-up at each epoch boundary. Candidate fork blockfetch begins after
+fork resolution has
 rolled the applied chain back to its common ancestor, so permitted epoch-nonce
 forecasts and the epoch-specific Mark stake snapshot used for leader
 eligibility are read from that intersection state.

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -611,6 +611,40 @@ func TestHardForkSummary_RejectsSlotPastSafeZone(t *testing.T) {
 	assert.ErrorIs(t, err, hardfork.ErrPastHorizon)
 }
 
+// TestHeaderVerificationEpoch_PastHorizonDeferred verifies that a header past
+// the forecast horizon is classified as a deferred condition (not a hard
+// peer-fault rejection). This is what keeps chainsync/blockfetch from recycling
+// the honest peer that served the header: recycling on past-horizon starves the
+// peer pool during catch-up and deadlocks at epoch boundaries. The error must
+// still carry ErrPastHorizon so the no-apply-past-horizon guard is unchanged.
+func TestHeaderVerificationEpoch_PastHorizonDeferred(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       500,
+			StartSlot:     100_000,
+			SlotLength:    1_000,
+			LengthInSlots: 432_000,
+			EraId:         eras.ConwayEraDesc.Id,
+		}},
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(200_000, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	// The forecast horizon ends at slot 532_000; a header past it must be
+	// classified deferred, and still carry ErrPastHorizon.
+	_, err := ls.headerVerificationEpoch(600_000, false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errHeaderVerificationDeferred,
+		"past-horizon header must be deferred, not a peer-fault rejection")
+	require.ErrorIs(t, err, hardfork.ErrPastHorizon)
+}
+
 func TestHardForkSummary_MainnetForecastBoundary(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -320,8 +320,21 @@ func (ls *LedgerState) headerVerificationEpoch(
 		}
 		if _, err := summary.SlotToEpoch(blockSlot); err != nil {
 			if errors.Is(err, hardfork.ErrPastHorizon) {
+				// A header past the forecast horizon cannot be verified yet:
+				// the applied ledger has not advanced far enough to know its
+				// epoch and nonce. This is a deferred condition, not a peer
+				// fault. Classify it as deferred so the block stays queued for
+				// in-order re-verification once the applied tip advances into
+				// range (preserving the no-apply-past-horizon guard), instead
+				// of being treated as a crypto failure that recycles the honest
+				// peer. Recycling on past-horizon starves the peer pool the
+				// block and Leios endorser-block fetch depend on and deadlocks
+				// catch-up at epoch boundaries; the chainsync recycle paths skip
+				// deferred errors.
 				return models.Epoch{}, fmt.Errorf(
-					"block header verification rejected at slot %d: %w",
+					"%w: block header verification deferred past era horizon "+
+						"at slot %d: %w",
+					errHeaderVerificationDeferred,
 					blockSlot,
 					err,
 				)


### PR DESCRIPTION
## What

`headerVerificationEpoch` wraps its `ErrPastHorizon` return in `errHeaderVerificationDeferred` (carrying both errors), so a header past the forecast horizon is classified as a deferred condition rather than a hard verification failure.

## Why

During catch-up the header chain runs ahead of the applied ledger and crosses an epoch boundary. Blocks past the applied tip's forecast horizon (the era safe zone, 3k/f) are rejected with `ErrPastHorizon`. That error's string contained "block header crypto verification failed", so `handleEventBlockfetchBlock` and the chainsync-header path published `ConnectionRecycleRequested` and dropped the peer that served the valid-but-not-yet-verifiable header. Both recycle paths already skip `errHeaderVerificationDeferred` and instead queue the header for in-order re-verification once the applied tip advances, so classifying past-horizon as deferred stops the peer from being recycled. The no-apply-past-horizon guard is unchanged: the block is queued, not applied early.

## Validation

- `TestHeaderVerificationEpoch_PastHorizonDeferred`: a past-horizon slot is classified deferred and still carries `ErrPastHorizon`.
- `go test ./ledger/...` and conformance (`internal/test/conformance`) pass; golangci-lint 0 issues; nilaway no new findings; `make import-boundaries` and `make docs-parity` pass.
- On a musashi from-genesis node this eliminates the header-verification connection recycling that dropped honest peers on past-horizon rejections (48 recycles before this change, 0 after) and lets the applied ledger cross the epoch boundary at slot 604788 that previously stalled it.

## Docs

`ARCHITECTURE.md` updated: past-horizon is a deferred, non-recycling condition. `DATABASE.md` not affected.
