### PR TITLE
fix(consensus): support Dijkstra headers in Praos chain-selection tiebreaker views

### DIFF
--- a/consensus/praos/view.go
+++ b/consensus/praos/view.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -171,6 +172,11 @@ func headerIssueNo(header ledger.BlockHeader) (uint64, bool) {
 		return uint64(h.Body.OpCert.SequenceNumber), true
 	case *conway.ConwayBlockHeader:
 		return uint64(h.Body.OpCert.SequenceNumber), true
+	case *dijkstra.DijkstraBlockHeader:
+		// Distinct concrete type embedding BabbageBlockHeader; a type switch
+		// won't fall through to the Babbage case, so it needs an explicit
+		// entry or the Dijkstra tiebreaker view is silently dropped.
+		return uint64(h.Body.OpCert.SequenceNumber), true
 	default:
 		return 0, false
 	}
@@ -204,6 +210,8 @@ func GetVRFOutput(header ledger.BlockHeader) []byte {
 	case *babbage.BabbageBlockHeader:
 		return h.Body.VrfResult.Output
 	case *conway.ConwayBlockHeader:
+		return h.Body.VrfResult.Output
+	case *dijkstra.DijkstraBlockHeader:
 		return h.Body.VrfResult.Output
 	default:
 		return nil

--- a/consensus/praos/view_test.go
+++ b/consensus/praos/view_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package praos
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dijkstraHeaderForView(t *testing.T) *dijkstra.DijkstraBlockHeader {
+	t.Helper()
+	issuer := common.IssuerVkey{}
+	issuer[0] = 0xAB
+	return &dijkstra.DijkstraBlockHeader{
+		BabbageBlockHeader: babbage.BabbageBlockHeader{
+			Body: babbage.BabbageBlockHeaderBody{
+				BlockNumber: 7,
+				Slot:        200,
+				IssuerVkey:  issuer,
+				VrfResult: common.VrfResult{
+					Output: make64ByteVRF(0x11),
+				},
+				OpCert: babbage.BabbageOpCert{
+					SequenceNumber: 3,
+				},
+			},
+		},
+	}
+}
+
+// TestGetVRFOutput_Dijkstra pins that a Dijkstra header's VRF output is
+// extracted, since DijkstraBlockHeader is a distinct concrete type embedding
+// BabbageBlockHeader and Go type switches do not fall through to the
+// embedded type's case.
+func TestGetVRFOutput_Dijkstra(t *testing.T) {
+	header := dijkstraHeaderForView(t)
+	got := GetVRFOutput(header)
+	assert.Equal(t, header.Body.VrfResult.Output, got)
+	assert.Len(t, got, VRFOutputSize)
+}
+
+// TestGetPraosTiebreakerView_Dijkstra pins that GetPraosTiebreakerView
+// returns a complete, usable view for a Dijkstra header rather than the
+// (PraosTiebreakerView{}, false) fallback that a missing type-switch case
+// produces.
+func TestGetPraosTiebreakerView_Dijkstra(t *testing.T) {
+	header := dijkstraHeaderForView(t)
+
+	view, ok := GetPraosTiebreakerView(header)
+	require.True(t, ok, "Dijkstra header must produce a valid tiebreaker view")
+
+	assert.Equal(t, header.SlotNumber(), view.Slot)
+	assert.Equal(t, uint64(3), view.IssueNo)
+	issuer := header.IssuerVkey()
+	assert.Equal(t, issuer[:], view.Issuer)
+	assert.Equal(t, header.Body.VrfResult.Output, view.TieBreakVRF)
+	assert.True(t, view.hasIssuerIssueNo())
+	assert.Equal(t, PraosTiebreakerConfigConway(), view.TiebreakerConfig,
+		"Dijkstra must use the Conway-compatible restricted VRF tiebreaker config")
+}
+
+// TestComparePraosTipsDijkstraVRFTiebreak confirms the extracted Dijkstra
+// view actually participates in chain-selection comparison: two equal-length
+// Dijkstra tips within the restricted-tiebreaker slot distance must be
+// decided by VRF output, not treated as an unresolved tie.
+func TestComparePraosTipsDijkstraVRFTiebreak(t *testing.T) {
+	lowerVRFHeader := dijkstraHeaderForView(t)
+	lowerVRFHeader.Body.VrfResult.Output = make64ByteVRFFirstByte(0x01)
+	higherVRFHeader := dijkstraHeaderForView(t)
+	higherVRFHeader.Body.VrfResult.Output = make64ByteVRFFirstByte(0xFF)
+	higherVRFHeader.Body.Slot = 202
+
+	ours := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: lowerVRFHeader.Body.Slot, Hash: []byte("ours")},
+		BlockNumber: 50,
+	}
+	candidate := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: higherVRFHeader.Body.Slot, Hash: []byte("candidate")},
+		BlockNumber: 50,
+	}
+
+	oursView, ok := GetPraosTiebreakerView(lowerVRFHeader)
+	require.True(t, ok)
+	candidateView, ok := GetPraosTiebreakerView(higherVRFHeader)
+	require.True(t, ok)
+
+	got := ComparePraosTips(ours, candidate, oursView, candidateView)
+	assert.Equal(t, ChainABetter, got,
+		"lower VRF output must win the Dijkstra equal-length tiebreak")
+
+	got = ComparePraosTips(candidate, ours, candidateView, oursView)
+	assert.Equal(t, ChainBBetter, got, "VRF tiebreak must be symmetric")
+}

--- a/ledger/chainsync_praos_dijkstra_test.go
+++ b/ledger/chainsync_praos_dijkstra_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/consensus/praos"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDijkstraBlockCbor builds a minimal, decodable Dijkstra block (empty
+// body, plain Babbage-shaped header) and returns its CBOR. The body hash is
+// computed from the actual empty body so NewDijkstraBlockFromCbor's
+// body-hash check (run by models.Block.Decode via ledger.NewBlockFromCbor)
+// passes; header signature/KES verification is not exercised at decode time.
+func newTestDijkstraBlockCbor(
+	t *testing.T,
+	slot, blockNumber uint64,
+	issuerFirstByte byte,
+	opCertSeqNo uint32,
+	vrfOutput []byte,
+) []byte {
+	t.Helper()
+	body := dijkstra.DijkstraBlockBody{}
+	var issuer lcommon.IssuerVkey
+	issuer[0] = issuerFirstByte
+	header := &dijkstra.DijkstraBlockHeader{
+		BabbageBlockHeader: babbage.BabbageBlockHeader{
+			Body: babbage.BabbageBlockHeaderBody{
+				BlockNumber:   blockNumber,
+				Slot:          slot,
+				IssuerVkey:    issuer,
+				VrfResult:     lcommon.VrfResult{Output: vrfOutput},
+				BlockBodyHash: body.Hash(),
+				OpCert: babbage.BabbageOpCert{
+					SequenceNumber: opCertSeqNo,
+				},
+			},
+		},
+	}
+	block := &dijkstra.DijkstraBlock{BlockHeader: header, BlockBody: body}
+	cborData, err := block.MarshalCBOR()
+	require.NoError(t, err)
+	return cborData
+}
+
+// insertTestDijkstraBlock stores a Dijkstra block built by
+// newTestDijkstraBlockCbor at the given hash so localTipPraosView's
+// database.BlockByHash + Decode round trip can find and decode it.
+func insertTestDijkstraBlock(
+	t *testing.T,
+	db *database.Database,
+	slot, blockNumber uint64,
+	hash []byte,
+	issuerFirstByte byte,
+	opCertSeqNo uint32,
+	vrfOutput []byte,
+) {
+	t.Helper()
+	cborData := newTestDijkstraBlockCbor(
+		t, slot, blockNumber, issuerFirstByte, opCertSeqNo, vrfOutput,
+	)
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot:   slot,
+		Hash:   hash,
+		Cbor:   cborData,
+		Type:   dijkstra.BlockTypeDijkstra,
+		Number: blockNumber,
+	}, nil))
+}
+
+// TestCompareIncomingHeaderToLocalTip_Dijkstra exercises the actual
+// chain-selection caller (ledger/chainsync.go's compareIncomingHeaderToLocalTip,
+// the mechanism issue #3075 identified as reachable from
+// ledger/chainsync.go:1855-1904 and ouroboros/chainsync.go:758) end to end for
+// Dijkstra headers: the local tip is a real Dijkstra block round-tripped
+// through storage (database.BlockByHash -> models.Block.Decode), and the
+// incoming header is a plain in-process *dijkstra.DijkstraBlockHeader as
+// chainsync delivers it. Before the view.go fix this always resolved
+// ChainEqual for a Dijkstra local tip (GetPraosTiebreakerView returned
+// ok=false), silently disarming the VRF tiebreaker in exactly this path.
+func TestCompareIncomingHeaderToLocalTip_Dijkstra(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	ls := &LedgerState{
+		db:     db,
+		config: LedgerStateConfig{Logger: slog.New(slog.NewJSONHandler(io.Discard, nil))},
+	}
+
+	const blockNumber = 50
+	localHash := []byte("dijkstra-local-tip-hash-32-bytes")[:32]
+	localSlot := uint64(200)
+	localTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: localSlot, Hash: localHash},
+		BlockNumber: blockNumber,
+	}
+
+	testCases := []struct {
+		name          string
+		localVRF      []byte
+		incomingVRF   []byte
+		incomingSlot  uint64
+		expectedBeats praos.ChainComparisonResult
+	}{
+		{
+			name:          "incoming lower VRF beats local tip",
+			localVRF:      make64ByteVRFFirstByteLedger(0xFF),
+			incomingVRF:   make64ByteVRFFirstByteLedger(0x01),
+			incomingSlot:  202,
+			expectedBeats: praos.ChainABetter,
+		},
+		{
+			name:          "incoming higher VRF loses to local tip",
+			localVRF:      make64ByteVRFFirstByteLedger(0x01),
+			incomingVRF:   make64ByteVRFFirstByteLedger(0xFF),
+			incomingSlot:  202,
+			expectedBeats: praos.ChainBBetter,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Re-seed the local tip block for each subtest under a
+			// case-specific hash so BlockByHash resolves the intended VRF.
+			hash := append([]byte(nil), localHash...)
+			hash[len(hash)-1] = byte(len(tc.name)) // vary hash per case
+			localTip := localTip
+			localTip.Point.Hash = hash
+			insertTestDijkstraBlock(
+				t, db, localSlot, blockNumber, hash,
+				0xAB, 3, tc.localVRF,
+			)
+
+			incomingHeader := &dijkstra.DijkstraBlockHeader{
+				BabbageBlockHeader: babbage.BabbageBlockHeader{
+					Body: babbage.BabbageBlockHeaderBody{
+						BlockNumber: blockNumber,
+						Slot:        tc.incomingSlot,
+						VrfResult:   lcommon.VrfResult{Output: tc.incomingVRF},
+						OpCert: babbage.BabbageOpCert{
+							SequenceNumber: 3,
+						},
+					},
+				},
+			}
+			event := ChainsyncEvent{
+				BlockHeader: incomingHeader,
+				Point:       ocommon.Point{Slot: tc.incomingSlot, Hash: []byte("incoming-hash")},
+			}
+
+			result := ls.compareIncomingHeaderToLocalTip(event, localTip)
+			require.Equal(t, tc.expectedBeats, result,
+				"Dijkstra local tip must participate in the VRF tiebreaker through the real storage/decode path")
+		})
+	}
+}
+
+// make64ByteVRFFirstByteLedger mirrors consensus/praos's test helper of the
+// same shape; duplicated here since it is unexported in another package.
+func make64ByteVRFFirstByteLedger(first byte) []byte {
+	vrf := make([]byte, praos.VRFOutputSize)
+	vrf[0] = first
+	return vrf
+}


### PR DESCRIPTION
**Summary**

Added the missing `*dijkstra.DijkstraBlockHeader` case to both functions, matching the identical pattern already used in `ledger/verify_opcert.go`/`verify_header_vrf.go` for the same embedding gotcha.

**Changes**
- `consensus/praos/view.go` — added a `*dijkstra.DijkstraBlockHeader` case to `headerIssueNo` and to `GetVRFOutput` so both correctly extract the opcert sequence number and VRF output from Dijkstra headers.
- `consensus/praos/view_test.go` — unit tests proving `GetVRFOutput`, `GetPraosTiebreakerView`, and the Conway/Dijkstra tiebreaker config resolve correctly for a Dijkstra header, plus a `ComparePraosTips` regression showing the VRF tiebreak actually decides between two equal-length Dijkstra tips.
- `ledger/chainsync_praos_dijkstra_test.go` — Added a integration test driving the real `LedgerState.compareIncomingHeaderToLocalTip` path with a genuinely stored-and-decoded Dijkstra block as the local tip, verified to fail with `ChainEqual` against the pre-fix code and pass with the fix.


Closes #3075 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Dijkstra block headers in Praos chain-selection tiebreaker views so the VRF-based tiebreak works with Dijkstra tips. Addresses #3075 by ensuring the tiebreaker view is built and compared correctly.

- **Bug Fixes**
  - Added `*dijkstra.DijkstraBlockHeader` cases to `headerIssueNo` and `GetVRFOutput` in `consensus/praos/view.go`.
  - Added unit tests in `consensus/praos/view_test.go` to confirm `GetVRFOutput`, `GetPraosTiebreakerView`, and `ComparePraosTips` handle Dijkstra headers and resolve equal-length tips via VRF.
  - Added integration test in `ledger/chainsync_praos_dijkstra_test.go` to verify `compareIncomingHeaderToLocalTip` applies the VRF tiebreaker with a stored-and-decoded Dijkstra local tip.

<sup>Written for commit 6db8b62e61a1f07aace5c8c6b19bec1624612993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Dijkstra-era blocks in Praos view extraction.
  * Operational certificate issue numbers and VRF outputs are now recognized from Dijkstra headers.
  * Chain selection correctly uses VRF outputs to break ties between equally long chains.

* **Bug Fixes**
  * Improved compatibility with Dijkstra headers across local and incoming chain comparisons.

* **Tests**
  * Added coverage for Dijkstra VRF extraction, tiebreaking, and database-backed chain selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->