### PR TITLE
fix(ledger): resolve the next slot time while the ledger is behind the horizon

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1577,7 +1577,11 @@ already materialized epoch directly from the immutable epoch cache before
 forecasting. The operational slot clock is the deliberate exception to
 wall-clock forecast refusal: near-now `TimeToSlot` and `SlotToTime` calls
 extrapolate the current era while a stale node catches up, but arbitrary time
-queries and all header validation remain bounded. Both directions are needed
+queries and all header validation remain bounded. The accepted window is one
+slot length plus a fixed tolerance rather than a fixed 5s, because the clock
+resolves the *next* boundary -- up to one slot length ahead -- and a fixed
+window would reject that on any era with longer slots (Byron is 20s in real
+Cardano shapes). Both directions are needed
 because the clock's tick loop converts now to a slot and then that slot back to
 a time; with only the first, the clock could not resolve the next slot boundary
 and retried every 100ms for the whole catch-up instead of ticking.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1575,9 +1575,17 @@ Slot/epoch query adapters preserve `hardfork.ErrPastHorizon` in their error
 chains so callers can defer until the ledger advances. `EpochInfo` serves an
 already materialized epoch directly from the immutable epoch cache before
 forecasting. The operational slot clock is the deliberate exception to
-wall-clock forecast refusal: a near-now `TimeToSlot` call extrapolates the
-current era while a stale node catches up, but arbitrary time queries and all
-header validation remain bounded. Blockfrost epoch/era end timestamps are
+wall-clock forecast refusal: near-now `TimeToSlot` and `SlotToTime` calls
+extrapolate the current era while a stale node catches up, but arbitrary time
+queries and all header validation remain bounded. Both directions are needed
+because the clock's tick loop converts now to a slot and then that slot back to
+a time; with only the first, the clock could not resolve the next slot boundary
+and retried every 100ms for the whole catch-up instead of ticking.
+`SlotToEpoch` is deliberately not extrapolated -- a tick's `Epoch` and
+`IsEpochStart` drive subscriber epoch-boundary work, so a fabricated epoch would
+be worse than no tick. While the applied era history does not reach the current
+slot the clock emits no tick and reports entering and leaving that state once
+each, rather than an error per slot. Blockfrost epoch/era end timestamps are
 calculated as interval endpoints from cached epoch durations rather than
 treating the exclusive end as a forecastable header slot.
 When the next-epoch nonce becomes stable before that header horizon opens,

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -109,8 +109,11 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 		// downtime. Preserve its legacy current-era extrapolation without
 		// weakening the bounded Summary used by header validation and arbitrary
 		// time queries.
+		// Same slot-length-aware window as SlotToTime: these two are inverses,
+		// so a fixed tolerance here would reject the very boundary time
+		// SlotToTime just handed out on an era with slots longer than it.
 		if errors.Is(sumErr, hardfork.ErrPastHorizon) &&
-			isNearNow(ls.now(), t) {
+			withinOperationalWindow(ls.now(), t, currentEraSlotLength(sum)) {
 			if currentSlot, ok := currentEraSlotAtTime(sum, t); ok {
 				return currentSlot, nil
 			}

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -69,7 +69,11 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 		// and the bounded Summary used by header validation are unaffected.
 		if errors.Is(sumErr, hardfork.ErrPastHorizon) {
 			if extrapolated, ok := currentEraTimeAtSlot(sum, slot); ok &&
-				isNearNow(extrapolated) {
+				withinOperationalWindow(
+					ls.now(),
+					extrapolated,
+					currentEraSlotLength(sum),
+				) {
 				return extrapolated, nil
 			}
 		}
@@ -94,7 +98,7 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 	}
 	sum, err := ls.HardForkSummary()
 	if err != nil {
-		if isNearNow(t) {
+		if isNearNow(ls.now(), t) {
 			return nearNowSlot(shelleyGenesis), nil
 		}
 		return 0, errors.New("time not found in known epochs")
@@ -105,7 +109,8 @@ func (ls *LedgerState) TimeToSlot(t time.Time) (uint64, error) {
 		// downtime. Preserve its legacy current-era extrapolation without
 		// weakening the bounded Summary used by header validation and arbitrary
 		// time queries.
-		if errors.Is(sumErr, hardfork.ErrPastHorizon) && isNearNow(t) {
+		if errors.Is(sumErr, hardfork.ErrPastHorizon) &&
+			isNearNow(ls.now(), t) {
 			if currentSlot, ok := currentEraSlotAtTime(sum, t); ok {
 				return currentSlot, nil
 			}
@@ -201,11 +206,59 @@ func epochBoundaryInfo(epoch models.Epoch) models.Epoch {
 	}
 }
 
-func isNearNow(t time.Time) bool {
-	// time.Since(t) == now - t, so it is negative for future times. Guard both
-	// directions so arbitrary future times do not match the operational fallback.
-	d := time.Since(t)
-	return d >= -5*time.Second && d < 5*time.Second
+// now returns the ledger's wall clock. Tests inject a fixed clock so the
+// operational near-now fallbacks are deterministic rather than dependent on when
+// the suite happens to run.
+func (ls *LedgerState) now() time.Time {
+	if ls.nowFunc != nil {
+		return ls.nowFunc()
+	}
+	return time.Now()
+}
+
+// operationalWindow is the minimum tolerance for the near-now fallbacks. Eras
+// with a longer slot length widen it (see withinOperationalWindow).
+const operationalWindow = 5 * time.Second
+
+// isNearNow reports whether t is within the operational window of now.
+func isNearNow(now, t time.Time) bool {
+	return withinOperationalWindow(now, t, 0)
+}
+
+// withinOperationalWindow reports whether t is close enough to now to be an
+// operational timing query rather than an arbitrary one.
+//
+// The tolerance is at least operationalWindow but never less than one slot
+// length, because the slot clock's purpose is to resolve the *next* slot
+// boundary: that time is up to one slot length in the future, so a fixed 5s
+// window would reject it on any era with longer slots (Byron is 20s in real
+// Cardano shapes) and drop the clock back into the error-retry loop this
+// fallback exists to avoid. Times many slot lengths away are still rejected in
+// both directions.
+func withinOperationalWindow(
+	now, t time.Time,
+	slotLength time.Duration,
+) bool {
+	// One slot length covers the clock's next-boundary query exactly; the extra
+	// operationalWindow keeps the comparison off that exact edge and absorbs
+	// scheduling jitter between computing the slot and checking the window.
+	tolerance := operationalWindow
+	if slotLength > 0 {
+		tolerance = slotLength + operationalWindow
+	}
+	// now.Sub(t) is negative for future times. Guard both directions so
+	// arbitrary future times do not match the operational fallback.
+	d := now.Sub(t)
+	return d >= -tolerance && d < tolerance
+}
+
+// currentEraSlotLength returns the current era's slot length, or 0 when the
+// summary has no era to read it from.
+func currentEraSlotLength(sum *hardfork.Summary) time.Duration {
+	if sum == nil || len(sum.Eras) == 0 {
+		return 0
+	}
+	return sum.Eras[len(sum.Eras)-1].Params.SlotLength
 }
 
 func currentEraSlotAtTime(

--- a/ledger/slot.go
+++ b/ledger/slot.go
@@ -52,7 +52,30 @@ func (ls *LedgerState) SlotToTime(slot uint64) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	return sum.SlotToTime(slot)
+	when, sumErr := sum.SlotToTime(slot)
+	if sumErr != nil {
+		// The operational slot clock converts the next wall-clock slot on
+		// every tick. While the applied ledger is far behind the wall clock
+		// (from-genesis sync, `dingo load`, restart after downtime) that slot
+		// is past the forecast horizon by definition, and the bounded Summary
+		// is the wrong instrument: this is wall-clock arithmetic, not a
+		// consensus forecast. Without this the clock cannot resolve the next
+		// slot boundary, so it logs an error and retries every 100ms for the
+		// whole catch-up instead of ticking.
+		//
+		// Mirrors the current-era extrapolation TimeToSlot already applies for
+		// the same reason, and is gated the same way: only a slot whose
+		// extrapolated time is near now qualifies, so arbitrary future slots
+		// and the bounded Summary used by header validation are unaffected.
+		if errors.Is(sumErr, hardfork.ErrPastHorizon) {
+			if extrapolated, ok := currentEraTimeAtSlot(sum, slot); ok &&
+				isNearNow(extrapolated) {
+				return extrapolated, nil
+			}
+		}
+		return time.Time{}, sumErr
+	}
+	return when, nil
 }
 
 // TimeToSlot returns the slot containing the given wall-clock time.
@@ -206,6 +229,37 @@ func currentEraSlotAtTime(
 		return 0, false
 	}
 	return current.Start.Slot + slotsIntoEra, true
+}
+
+// currentEraTimeAtSlot extrapolates a slot's wall-clock start time from the
+// current era's parameters, ignoring the era's forecast horizon. It is the
+// inverse of currentEraSlotAtTime and carries the same caveat: the result is
+// only meaningful for operational near-now timing, because a slot past the
+// horizon may in reality fall in a later era with a different slot length.
+func currentEraTimeAtSlot(
+	sum *hardfork.Summary,
+	slot uint64,
+) (time.Time, bool) {
+	if sum == nil || len(sum.Eras) == 0 {
+		return time.Time{}, false
+	}
+	current := sum.Eras[len(sum.Eras)-1]
+	if slot < current.Start.Slot || current.Params.SlotLength <= 0 {
+		return time.Time{}, false
+	}
+	slotsIntoEra := slot - current.Start.Slot
+	// Keep the duration multiplication inside time.Duration's range.
+	maxSlots := uint64(math.MaxInt64) / uint64(current.Params.SlotLength)
+	if slotsIntoEra > maxSlots {
+		return time.Time{}, false
+	}
+	// slotsIntoEra is bounded above, so the conversion cannot overflow.
+	inEra := time.Duration(slotsIntoEra) * // #nosec G115
+		current.Params.SlotLength
+	if inEra > math.MaxInt64-current.Start.RelativeTime {
+		return time.Time{}, false
+	}
+	return sum.SystemStart.Add(current.Start.RelativeTime + inEra), true
 }
 
 // shelleySlotLengthMs returns the Shelley genesis slot length in milliseconds,

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 )
 
 // SlotTick represents a notification that a slot boundary has been reached
@@ -100,6 +102,12 @@ type SlotClock struct {
 	// Track last emitted epoch to avoid duplicates and detect discrepancies
 	lastEmittedEpoch uint64
 	epochEmitMu      sync.Mutex
+
+	// behindHorizon tracks whether the previous tick was skipped because the
+	// applied ledger's era history did not reach the current slot, so the
+	// transition into and out of that state is reported once instead of once
+	// per slot. Only touched by the single run goroutine.
+	behindHorizon bool
 
 	// For testing: allow injection of custom time source
 	nowFunc func() time.Time
@@ -417,6 +425,34 @@ func (sc *SlotClock) run() {
 		// Emit tick for the slot we're at (might have skipped some if drift is large)
 		tick, err := sc.buildSlotTick(actualSlot, actualNow)
 		if err != nil {
+			// A past-horizon slot is the expected state while the applied
+			// ledger is behind the wall clock (from-genesis sync, bulk load,
+			// restart after downtime): the era history simply does not reach
+			// the current slot yet, so its epoch is unknowable and there is
+			// nothing meaningful to emit. Deliberately not extrapolated -- the
+			// tick's Epoch and IsEpochStart drive subscriber epoch-boundary
+			// work, and a fabricated epoch would be worse than no tick.
+			//
+			// Report the transition once at info rather than an error per slot,
+			// which on a live network meant one error per second for the whole
+			// catch-up.
+			if errors.Is(err, hardfork.ErrPastHorizon) {
+				if !sc.behindHorizon {
+					sc.behindHorizon = true
+					logger.Info(
+						"applied ledger is behind the wall clock; "+
+							"slot ticks are paused until era history reaches "+
+							"the current slot",
+						"slot", actualSlot,
+					)
+				}
+				logger.Debug(
+					"skipping slot tick past era horizon",
+					"slot", actualSlot,
+					"error", err,
+				)
+				continue
+			}
 			logger.Error(
 				"failed to build slot tick",
 				"error",
@@ -425,6 +461,13 @@ func (sc *SlotClock) run() {
 				actualSlot,
 			)
 			continue
+		}
+		if sc.behindHorizon {
+			sc.behindHorizon = false
+			logger.Info(
+				"era history now covers the current slot; resuming slot ticks",
+				"slot", actualSlot,
+			)
 		}
 
 		sc.emitTick(tick)

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -15,11 +15,18 @@
 package ledger
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -693,4 +700,92 @@ func TestSlotClockStopClosesSubscriberChannels(t *testing.T) {
 	clock.mu.RLock()
 	assert.Nil(t, clock.subscribers)
 	clock.mu.RUnlock()
+}
+
+// horizonBoundProvider resolves slot/time arithmetic but refuses to resolve an
+// epoch until it is armed, standing in for a node whose applied era history has
+// not yet reached the current wall-clock slot.
+type horizonBoundProvider struct {
+	*mockSlotTimeProvider
+	resolved atomic.Bool
+}
+
+func (p *horizonBoundProvider) SlotToEpoch(slot uint64) (EpochInfo, error) {
+	if !p.resolved.Load() {
+		return EpochInfo{}, fmt.Errorf(
+			"slot is outside the known epoch range: %w",
+			hardfork.ErrPastHorizon,
+		)
+	}
+	return p.mockSlotTimeProvider.SlotToEpoch(slot)
+}
+
+// A node syncing from genesis on a live network sits past the era horizon for
+// the whole catch-up. That state must not be reported as an error per slot (the
+// field-reported "failed to build slot tick" spam), and no tick may be emitted
+// with a fabricated epoch, since Epoch/IsEpochStart drive subscriber
+// epoch-boundary work.
+func TestSlotClockPastHorizonIsNotAnErrorAndResumes(t *testing.T) {
+	var logBuf bytes.Buffer
+	logMu := &sync.Mutex{}
+	provider := &horizonBoundProvider{
+		mockSlotTimeProvider: newMockSlotTimeProvider(
+			time.Now(), 20*time.Millisecond, 100,
+		),
+	}
+	cfg := DefaultSlotClockConfig()
+	cfg.Logger = slog.New(slog.NewTextHandler(
+		&lockedWriter{mu: logMu, w: &logBuf},
+		&slog.HandlerOptions{Level: slog.LevelInfo},
+	))
+
+	clock := NewSlotClock(provider, cfg)
+	ch := clock.Subscribe()
+	clock.Start(t.Context())
+	defer clock.Stop()
+
+	readLog := func() string {
+		logMu.Lock()
+		defer logMu.Unlock()
+		return logBuf.String()
+	}
+
+	// While past the horizon: the transition is announced once, no ticks.
+	require.Eventually(t, func() bool {
+		return strings.Contains(readLog(), "behind the wall clock")
+	}, 3*time.Second, 10*time.Millisecond,
+		"the clock should report the past-horizon state once")
+	testutil.RequireNoReceive(
+		t, ch, 100*time.Millisecond,
+		"no tick may be emitted while the epoch is unknowable",
+	)
+	assert.NotContains(t, readLog(), "level=ERROR",
+		"a past-horizon slot is expected during catch-up, not an error")
+	assert.Equal(t, 1,
+		strings.Count(readLog(), "behind the wall clock"),
+		"the transition should be reported once, not once per slot")
+
+	// Once era history covers the slot, ticks resume and that is announced.
+	provider.resolved.Store(true)
+	tick := testutil.RequireReceive(
+		t, ch, 3*time.Second, "tick after era history catches up",
+	)
+	assert.NotZero(t, tick.Slot)
+	require.Eventually(t, func() bool {
+		return strings.Contains(readLog(), "resuming slot ticks")
+	}, 3*time.Second, 10*time.Millisecond,
+		"recovery should be reported once")
+	assert.NotContains(t, readLog(), "level=ERROR")
+}
+
+// lockedWriter serializes writes from the clock goroutine against test reads.
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -457,8 +457,8 @@ func TestSlotToTimeExtrapolatesNextSlotOnLongSlotEras(t *testing.T) {
 	_, err = ls.SlotToTime(nextSlot + 100)
 	require.ErrorIs(t, err, hardfork.ErrPastHorizon)
 	_, err = ls.TimeToSlot(now.Add(100 * byronSlotLength))
-	require.Error(t, err,
-		"a time many slot lengths ahead must still be refused")
+	require.ErrorIs(t, err, hardfork.ErrPastHorizon,
+		"a time many slot lengths ahead must still be refused as past-horizon")
 }
 
 // The window scales with slot length but stays a bounded operational window.

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -22,7 +22,12 @@ import (
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSlotCalc(t *testing.T) {
@@ -319,4 +324,74 @@ func TestSlotToEpochBeforeFirstEpoch(t *testing.T) {
 	if epoch.EpochId != 5 {
 		t.Errorf("expected epoch 5, got %d", epoch.EpochId)
 	}
+}
+
+// TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon is the regression test
+// for the slot clock spinning on "failed to get next slot time" for the whole
+// of a from-genesis sync or a `dingo load`.
+//
+// The clock's tick loop calls TimeToSlot(now) and then SlotToTime(slot+1). The
+// first has a near-now current-era extrapolation for exactly this case; the
+// second did not, so on a ledger whose applied tip is still near genesis while
+// the wall clock is years ahead, every tick logged an error and retried after
+// 100ms instead of sleeping to the next slot boundary.
+func TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon(t *testing.T) {
+	cfg := newTestEraHistoryCfg(t)
+	systemStart := cfg.ShelleyGenesis().SystemStart
+
+	// An applied tip near genesis: the era's safe zone bounds the forecast
+	// horizon far below the current wall-clock slot.
+	ls := &LedgerState{
+		epochCache: []models.Epoch{{
+			EpochId:       0,
+			StartSlot:     0,
+			SlotLength:    1000,
+			LengthInSlots: 432_000,
+			EraId:         eras.ConwayEraDesc.Id,
+		}},
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(10, []byte("tip"))},
+		config:     LedgerStateConfig{CardanoNodeConfig: cfg},
+	}
+	ls.publishSnapshotsLocked()
+
+	// The slot the clock is about to tick: 1s slots, so this is now+1.
+	nowSlot := uint64(time.Since(systemStart) / time.Second)
+	nextSlot := nowSlot + 1
+
+	// Confirm the premise: that slot really is past the bounded horizon, so
+	// this test would be vacuous if the era covered it.
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	_, horizonErr := sum.SlotToTime(nextSlot)
+	require.ErrorIs(t, horizonErr, hardfork.ErrPastHorizon,
+		"premise: the next wall-clock slot must be past the forecast horizon")
+
+	// SlotToTime must still resolve it, by extrapolating the current era.
+	when, err := ls.SlotToTime(nextSlot)
+	require.NoError(t, err,
+		"the slot clock must be able to resolve the next slot while behind")
+	assert.WithinDuration(t, time.Now(), when, 5*time.Second,
+		"the extrapolated next-slot time should be ~now")
+	// Consecutive slots stay one slot length apart.
+	next2, err := ls.SlotToTime(nextSlot + 1)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, next2.Sub(when))
+
+	// An arbitrary future slot stays bounded: the escape hatch is only for
+	// near-now operational timing, not a general weakening of the horizon.
+	_, err = ls.SlotToTime(nextSlot + 1_000_000)
+	require.ErrorIs(t, err, hardfork.ErrPastHorizon,
+		"a far-future slot must still be past the horizon")
+
+	// Slot 0 keeps its genesis special case.
+	genesis, err := ls.SlotToTime(0)
+	require.NoError(t, err)
+	assert.Equal(t, systemStart, genesis)
+
+	// A slot inside the horizon is still answered by the bounded Summary,
+	// unchanged.
+	inHorizon, err := ls.SlotToTime(100)
+	require.NoError(t, err)
+	assert.Equal(t, systemStart.Add(100*time.Second), inHorizon)
 }

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -326,26 +326,25 @@ func TestSlotToEpochBeforeFirstEpoch(t *testing.T) {
 	}
 }
 
-// TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon is the regression test
-// for the slot clock spinning on "failed to get next slot time" for the whole
-// of a from-genesis sync or a `dingo load`.
-//
-// The clock's tick loop calls TimeToSlot(now) and then SlotToTime(slot+1). The
-// first has a near-now current-era extrapolation for exactly this case; the
-// second did not, so on a ledger whose applied tip is still near genesis while
-// the wall clock is years ahead, every tick logged an error and retried after
-// 100ms instead of sleeping to the next slot boundary.
-func TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon(t *testing.T) {
+// slotToTimeBehindHorizonState builds a ledger whose applied tip is near
+// genesis, with an injected wall clock far ahead of it, so the forecast horizon
+// is deterministically behind the current slot regardless of when the suite
+// runs.
+func slotToTimeBehindHorizonState(
+	t *testing.T,
+	slotLengthMs uint,
+	slotsAhead uint64,
+) (*LedgerState, uint64, time.Time) {
+	t.Helper()
 	cfg := newTestEraHistoryCfg(t)
 	systemStart := cfg.ShelleyGenesis().SystemStart
+	slotLength := time.Duration(slotLengthMs) * time.Millisecond
 
-	// An applied tip near genesis: the era's safe zone bounds the forecast
-	// horizon far below the current wall-clock slot.
 	ls := &LedgerState{
 		epochCache: []models.Epoch{{
 			EpochId:       0,
 			StartSlot:     0,
-			SlotLength:    1000,
+			SlotLength:    slotLengthMs,
 			LengthInSlots: 432_000,
 			EraId:         eras.ConwayEraDesc.Id,
 		}},
@@ -353,14 +352,32 @@ func TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon(t *testing.T) {
 		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(10, []byte("tip"))},
 		config:     LedgerStateConfig{CardanoNodeConfig: cfg},
 	}
+	// A fixed clock slotsAhead slots past genesis: hermetic, and far enough
+	// ahead that the era's safe zone cannot cover it.
+	now := systemStart.Add(time.Duration(slotsAhead) * slotLength)
+	ls.nowFunc = func() time.Time { return now }
 	ls.publishSnapshotsLocked()
+	return ls, slotsAhead, now
+}
 
-	// The slot the clock is about to tick: 1s slots, so this is now+1.
-	nowSlot := uint64(time.Since(systemStart) / time.Second)
+// TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon is the regression test
+// for the slot clock spinning on "failed to get next slot time" for the whole
+// of a from-genesis sync or a `dingo load`.
+//
+// The clock's tick loop calls TimeToSlot(now) and then SlotToTime(slot+1). The
+// first has a near-now current-era extrapolation for exactly this case; the
+// second did not, so on a ledger whose applied tip is still near genesis while
+// the wall clock is far ahead, every tick logged an error and retried after
+// 100ms instead of sleeping to the next slot boundary.
+func TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon(t *testing.T) {
+	const slotLengthMs = 1000
+	ls, nowSlot, now := slotToTimeBehindHorizonState(
+		t, slotLengthMs, 5_000_000,
+	)
 	nextSlot := nowSlot + 1
 
 	// Confirm the premise: that slot really is past the bounded horizon, so
-	// this test would be vacuous if the era covered it.
+	// this test cannot silently become vacuous.
 	sum, err := ls.HardForkSummary()
 	require.NoError(t, err)
 	_, horizonErr := sum.SlotToTime(nextSlot)
@@ -371,15 +388,16 @@ func TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon(t *testing.T) {
 	when, err := ls.SlotToTime(nextSlot)
 	require.NoError(t, err,
 		"the slot clock must be able to resolve the next slot while behind")
-	assert.WithinDuration(t, time.Now(), when, 5*time.Second,
-		"the extrapolated next-slot time should be ~now")
+	assert.Equal(t, now.Add(time.Second), when,
+		"the next slot starts exactly one slot length after now")
+
 	// Consecutive slots stay one slot length apart.
 	next2, err := ls.SlotToTime(nextSlot + 1)
 	require.NoError(t, err)
 	assert.Equal(t, time.Second, next2.Sub(when))
 
 	// An arbitrary future slot stays bounded: the escape hatch is only for
-	// near-now operational timing, not a general weakening of the horizon.
+	// operational timing, not a general weakening of the horizon.
 	_, err = ls.SlotToTime(nextSlot + 1_000_000)
 	require.ErrorIs(t, err, hardfork.ErrPastHorizon,
 		"a far-future slot must still be past the horizon")
@@ -387,11 +405,68 @@ func TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon(t *testing.T) {
 	// Slot 0 keeps its genesis special case.
 	genesis, err := ls.SlotToTime(0)
 	require.NoError(t, err)
-	assert.Equal(t, systemStart, genesis)
+	assert.Equal(t, ls.config.CardanoNodeConfig.ShelleyGenesis().SystemStart,
+		genesis)
 
-	// A slot inside the horizon is still answered by the bounded Summary,
-	// unchanged.
+	// A slot inside the horizon is still answered by the bounded Summary.
 	inHorizon, err := ls.SlotToTime(100)
 	require.NoError(t, err)
-	assert.Equal(t, systemStart.Add(100*time.Second), inHorizon)
+	assert.Equal(t,
+		ls.config.CardanoNodeConfig.ShelleyGenesis().SystemStart.
+			Add(100*time.Second),
+		inHorizon)
+}
+
+// TestSlotToTimeExtrapolatesNextSlotOnLongSlotEras covers eras whose slot length
+// exceeds the fixed 5s near-now window. Byron is 20s per slot in real Cardano
+// shapes, so the next slot boundary sits 20s in the future: gating on a fixed
+// window rejected it, SlotToTime returned ErrPastHorizon, and the clock fell
+// back into the 100ms error-retry loop this fallback exists to avoid.
+func TestSlotToTimeExtrapolatesNextSlotOnLongSlotEras(t *testing.T) {
+	const (
+		byronSlotLengthMs = 20_000
+		byronSlotLength   = 20 * time.Second
+	)
+	ls, nowSlot, now := slotToTimeBehindHorizonState(
+		t, byronSlotLengthMs, 5_000_000,
+	)
+	nextSlot := nowSlot + 1
+
+	sum, err := ls.HardForkSummary()
+	require.NoError(t, err)
+	_, horizonErr := sum.SlotToTime(nextSlot)
+	require.ErrorIs(t, horizonErr, hardfork.ErrPastHorizon, "premise")
+
+	// The next boundary is a full 20s ahead -- well outside the 5s window.
+	when, err := ls.SlotToTime(nextSlot)
+	require.NoError(t, err,
+		"a 20s-slot era's next boundary must still resolve")
+	assert.Equal(t, now.Add(byronSlotLength), when)
+	assert.Greater(t, when.Sub(now), operationalWindow,
+		"premise: the next boundary is beyond the fixed near-now window")
+
+	// Still bounded: many slot lengths ahead is rejected.
+	_, err = ls.SlotToTime(nextSlot + 100)
+	require.ErrorIs(t, err, hardfork.ErrPastHorizon)
+}
+
+// The window scales with slot length but stays a bounded operational window.
+func TestWithinOperationalWindowScalesWithSlotLength(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// With no slot length it is the plain near-now window.
+	assert.True(t, isNearNow(now, now.Add(4*time.Second)))
+	assert.False(t, isNearNow(now, now.Add(6*time.Second)))
+
+	// A 20s era admits its own next boundary...
+	assert.True(t, withinOperationalWindow(
+		now, now.Add(20*time.Second), 20*time.Second))
+	// ...and still rejects times many slot lengths out.
+	assert.False(t, withinOperationalWindow(
+		now, now.Add(5*time.Minute), 20*time.Second))
+	// Symmetric in the past direction.
+	assert.True(t, withinOperationalWindow(
+		now, now.Add(-20*time.Second), 20*time.Second))
+	assert.False(t, withinOperationalWindow(
+		now, now.Add(-5*time.Minute), 20*time.Second))
 }

--- a/ledger/slot_test.go
+++ b/ledger/slot_test.go
@@ -445,9 +445,20 @@ func TestSlotToTimeExtrapolatesNextSlotOnLongSlotEras(t *testing.T) {
 	assert.Greater(t, when.Sub(now), operationalWindow,
 		"premise: the next boundary is beyond the fixed near-now window")
 
-	// Still bounded: many slot lengths ahead is rejected.
+	// The inverse must accept the same boundary: SlotToTime and TimeToSlot are
+	// a pair, so a fixed window on the reverse direction would reject the very
+	// time SlotToTime just returned.
+	backSlot, err := ls.TimeToSlot(when)
+	require.NoError(t, err,
+		"TimeToSlot must accept the boundary SlotToTime returned")
+	assert.Equal(t, nextSlot, backSlot, "the pair must round-trip")
+
+	// Still bounded in both directions: many slot lengths away is rejected.
 	_, err = ls.SlotToTime(nextSlot + 100)
 	require.ErrorIs(t, err, hardfork.ErrPastHorizon)
+	_, err = ls.TimeToSlot(now.Add(100 * byronSlotLength))
+	require.Error(t, err,
+		"a time many slot lengths ahead must still be refused")
 }
 
 // The window scales with slot length but stays a bounded operational window.

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -592,6 +592,10 @@ type LedgerState struct {
 	metrics   stateMetrics
 	consensus atomic.Pointer[consensusSnapshot]
 	tip       atomic.Pointer[tipSnapshot]
+	// nowFunc overrides the wall clock used by the operational slot/time
+	// fallbacks. Nil outside tests, which inject a fixed clock so those
+	// fallbacks are deterministic.
+	nowFunc func() time.Time
 	// snapshotGeneration is incremented while writers are serialized by Lock.
 	// It lets readers that need both snapshots reject adjacent publications.
 	snapshotGeneration uint64


### PR DESCRIPTION
## What

A node whose applied ledger is far behind the wall clock logged `failed to get next slot time: hardfork: slot/time past era horizon` ten times a second for the entire catch-up. Reported from a fresh `rm -rf .dingo && ./dingo load database/immutable/testdata` on preview, and reproducible on any from-genesis sync or restart after downtime.

## Why

`SlotToTime` and `TimeToSlot` were an asymmetric pair. `TimeToSlot` already extrapolates the current era for a near-now time, precisely so the operational slot clock keeps working while a stale node catches up (`ledger/slot.go`, "CurrentSlot drives operational timing while a node catches up after downtime"). `SlotToTime` had no such path.

The clock's tick loop calls both in sequence: `TimeToSlot(now)` and then `SlotToTime(currentSlot+1)`. The first succeeded via that fallback, the second returned `ErrPastHorizon`, so every tick logged an error and retried after 100ms instead of sleeping to the slot boundary. Two consequences beyond the log noise: the clock never slept to a slot boundary while behind, and it emitted no ticks at all.

`SlotToTime` now applies the same current-era extrapolation under the same near-now gate, so arbitrary future slots and the bounded Summary used by header validation are unaffected.

That leaves `buildSlotTick`, which needs the slot's epoch. While the era history does not reach the current slot that epoch is genuinely unknowable, and it is deliberately **not** extrapolated: a tick's `Epoch` and `IsEpochStart` drive subscriber epoch-boundary work, so a fabricated epoch would be worse than no tick. The tick was already being skipped; only the severity was wrong. The clock now reports entering and leaving that state once each instead of an error per slot.

## Scope

Not a regression from #3107, and not addressed by #3111 (which fixed a different consumer of `ErrPastHorizon` in `verify_header.go`). Reproduced identically on pre-#3107 `bd139e4a`, on `fd6a48fa`, and on `16461c9a`.

## Validation

Reproduced the reported command on each build, counting `slot_clock` ERROR lines in a 45s window:

| Build | ERROR lines |
|---|---|
| pre-#3107 `bd139e4a` | 446 |
| `fd6a48fa` | 447 |
| `16461c9a` (main at time of writing) | 446 |
| with this change | 0, plus one info line naming the condition |

Load progress is unaffected.

- `TestSlotToTimeExtrapolatesNextSlotWhileBehindHorizon`: asserts the premise (the next wall-clock slot really is past the bounded horizon), that `SlotToTime` resolves it, that consecutive slots stay one slot length apart, that a far-future slot still returns `ErrPastHorizon`, that slot 0 keeps its genesis special case, and that an in-horizon slot is still answered exactly by the bounded Summary.
- `TestSlotClockPastHorizonIsNotAnErrorAndResumes`: asserts no tick is emitted while the epoch is unknowable, no ERROR is logged, the transition is reported once rather than per slot, and ticks plus a recovery line follow once era history catches up.

Both fail against the previous behavior (verified by reverting each half).

`go test ./...`, `-race ./ledger/...`, conformance, `golangci-lint` (0 issues), `modernize` (clean on touched files), `nilaway ./ledger/...` (5 findings, identical to main), `make docs-parity`, `make import-boundaries`: all pass.

Three root-package multinode tests (`TestTwoNodeDevnetSyncOverRealNetworking`, `TestLiveTruncateUnderRealForgingAndNetworking`, `TestLiveRestoreUnderRealForgingAndNetworking`) are load-sensitive on the shared host used here. Measured with interleaved sampling (alternating `main` and this branch round-robin, so drift in external load affects both equally): 1 failed run out of 4 on each side, and both failures occurred in the round where host load spiked to 18-19 versus 11-15 in the clean rounds. No difference attributable to this change.

Independently of those run counts, the code path added here is unreachable in those tests: `devnetSystemStartLeadTime` sets genesis `SystemStart` 3s into the future, so the clock waits for genesis and the wall-clock slot is then 0, 1, 2... while the applied era already covers it -- `SlotToTime` never reaches the past-horizon branch.

## Docs

`ARCHITECTURE.md` updated: the operational-slot-clock exception now covers both directions and records why `SlotToEpoch` is deliberately excluded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents slot clock error spam and missed ticks while the ledger is behind the era horizon. Near‑now slot/time conversions now extrapolate using the current era with a slot‑length‑aware window, and ticks pause with a single info log until era history reaches the current slot.

- **Bug Fixes**
  - `SlotToTime` now extrapolates the next slot on `hardfork.ErrPastHorizon`, and `TimeToSlot` uses the same slot‑length‑aware near‑now window; far‑future queries still return `hardfork.ErrPastHorizon`, keeping the pair bounded and consistent.
  - The slot clock skips ticks when the epoch is unknowable (no epoch extrapolation), logging one info on enter and one on resume instead of errors per slot.
  - Hermetic regression tests added (including long‑slot eras) with a `LedgerState` `nowFunc`, round‑trip assertions, and an explicit check that inverse out‑of‑window queries return `hardfork.ErrPastHorizon`; `ARCHITECTURE.md` documents the behavior.

<sup>Written for commit b17c8d88a9998d027f393c6d482003095d884342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved slot-to-time and time-to-slot conversions for near-current slots, including slots just beyond the forecast horizon.
  - Adjusted timing tolerance based on slot duration for more reliable behavior across eras.
  - Added safeguards for invalid or excessively distant future conversions.

- **Bug Fixes**
  - Reduced noisy error reporting when era history is temporarily unavailable.
  - The slot clock now pauses notifications during unavailable history and resumes cleanly once coverage returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->