### PR TITLE
fix: recover storage before history expiry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -745,8 +745,10 @@ When `Node.Run()` is called, components are initialized in this order:
  3. ChainManager initialization and block-proposed event subscription
  4. Ouroboros protocol handler creation
  5. LedgerState creation, followed by mempool provider resolution
- 6. Bark remote archive adapter and History Expiry worker (if configured)
- 7. Database recovery, if startup detects a recoverable timestamp conflict
+ 6. Bark remote archive adapter, then database recovery if startup detects a
+    recoverable timestamp conflict
+ 7. History Expiry worker (if configured), after recovery has settled the
+    ledger tip and blob contents
  8. Ledger startup epoch-cache preparation, then Midnight indexer creation +
     backfill + EventBus subscription (if API storage mode).
     Indexes cNIGHT creates/spends, mapping-validator registrations/deregistrations,

--- a/node.go
+++ b/node.go
@@ -750,6 +750,14 @@ func (n *Node) Run(ctx context.Context) error {
 		n.db.SetBlobStore(barkBlobStore)
 	}
 
+	// Recovery changes both the ledger tip and blob contents. Complete it
+	// before starting background maintenance that reads or prunes either store.
+	if dbNeedsRecovery {
+		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {
+			return fmt.Errorf("failed to recover database: %w", err)
+		}
+	}
+
 	if n.config.historyExpiry.Enabled {
 		prunerFreq := n.config.historyExpiry.Frequency
 		if prunerFreq <= 0 {
@@ -771,12 +779,6 @@ func (n *Node) Run(ctx context.Context) error {
 		})
 	}
 
-	// Run DB recovery if needed
-	if dbNeedsRecovery {
-		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {
-			return fmt.Errorf("failed to recover database: %w", err)
-		}
-	}
 	if err := n.backfillRewardLiveStake(); err != nil {
 		return err
 	}

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -655,6 +655,14 @@ func (n *Node) reinitializeCoreStorage(ctx context.Context) error {
 		n.db.SetBlobStore(barkBlobStore)
 	}
 
+	// Recovery changes both the ledger tip and blob contents. Complete it
+	// before starting background maintenance that reads or prunes either store.
+	if dbNeedsRecovery {
+		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {
+			return fmt.Errorf("failed to recover database: %w", err)
+		}
+	}
+
 	if n.config.historyExpiry.Enabled {
 		prunerFreq := n.config.historyExpiry.Frequency
 		if prunerFreq <= 0 {
@@ -671,11 +679,6 @@ func (n *Node) reinitializeCoreStorage(ctx context.Context) error {
 		}
 	}
 
-	if dbNeedsRecovery {
-		if err := n.ledgerState.RecoverCommitTimestampConflict(); err != nil {
-			return fmt.Errorf("failed to recover database: %w", err)
-		}
-	}
 	if err := n.backfillRewardLiveStake(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Recovery precedes History Expiry startup.
Normal and live reinitialization covered.
Architecture order updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run database recovery before starting the History Expiry worker so pruning never runs against an inconsistent ledger tip or blob store. Applies to normal startup and live reinit; architecture docs updated to reflect the new order.

- **Bug Fixes**
  - Move recovery ahead of History Expiry in Node.Run and reinitializeCoreStorage.
  - Ensure recovery completes before any background maintenance that reads or prunes storage.
  - Update ARCHITECTURE.md to show Bark adapter init, then recovery, then start History Expiry.

<sup>Written for commit 6f738e06a7ad2fee368462216eec0452b893ed53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup sequencing so database recovery completes before history-expiry maintenance begins.
  * Ensured ledger state and blob contents are fully settled before expiry processing.
  * Reduced the risk of inconsistent history cleanup during node initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->