### PR TITLE
fix: detect blob-only commit timestamp divergence

### DIFF
--- a/database/commit_timestamp.go
+++ b/database/commit_timestamp.go
@@ -46,10 +46,6 @@ func (b *Database) checkCommitTimestamp() error {
 			metadataErr,
 		)
 	}
-	// No timestamp in the database
-	if metadataTimestamp <= 0 {
-		return nil
-	}
 	// Get value from blob
 	blobTimestamp, blobErr := b.Blob().GetCommitTimestamp()
 	if blobErr != nil {

--- a/database/commit_timestamp_repro_test.go
+++ b/database/commit_timestamp_repro_test.go
@@ -79,3 +79,36 @@ func TestCheckCommitTimestamp_MetadataOnly(t *testing.T) {
 		"missing blob timestamp must not surface as raw ErrBlobKeyNotFound",
 	)
 }
+
+// TestCheckCommitTimestamp_BlobOnly verifies that startup detects a blob
+// timestamp with no corresponding metadata timestamp. This is the inverse of
+// TestCheckCommitTimestamp_MetadataOnly and must be handled by the same
+// recovery path.
+func TestCheckCommitTimestamp_BlobOnly(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{
+		DataDir: t.TempDir(),
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	require.NoError(t, err)
+	dataDir := db.config.DataDir
+
+	blobTxn := db.Blob().NewTransaction(true)
+	require.NoError(t, db.Blob().SetCommitTimestamp(123456789, blobTxn))
+	require.NoError(t, blobTxn.Commit())
+	require.NoError(t, closeTestDatabase(db))
+
+	db2, err := newTestDatabase(t, &Config{
+		DataDir: dataDir,
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if db2 != nil {
+		defer closeTestDatabase(db2)
+	}
+	require.Error(t, err)
+	var cte CommitTimestampError
+	require.ErrorAs(t, err, &cte, "expected recoverable CommitTimestampError, got: %v", err)
+	require.Equal(t, int64(0), cte.MetadataTimestamp)
+	require.Equal(t, int64(123456789), cte.BlobTimestamp)
+}


### PR DESCRIPTION
Blob-only timestamp mismatch detection.
Regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect blob-only commit timestamp divergence at startup and return a recoverable CommitTimestampError to trigger the existing recovery path. Removes the early exit when the metadata timestamp is missing and adds a regression test for the blob-only case.

<sup>Written for commit 57f29c73f38cf22f6df95ab617583481ab2a2daa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

