### PR TITLE
fix(ledger): carry the protocol major into the Conway Plutus context

### DIFF
--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -397,7 +397,7 @@ func validateTxPlutusConwayWithContext(
 		ls,
 		tx,
 		plutusCtx.scriptInputs.resolvedAllInputs,
-		pp.ProtocolVersion.Major,
+		pp,
 	)
 	for redeemerKey, redeemerValue := range plutusCtx.redeemers.Iter() {
 		purpose, ok := buildConwayScriptPurpose(
@@ -871,29 +871,38 @@ type conwayTxInfoCache struct {
 	txInfoV1       script.TxInfoV1
 	txInfoV2       script.TxInfoV2
 	txInfoV3       script.TxInfoV3
-	protocolMajor  uint
+	pparams        *conway.ConwayProtocolParameters
 	txInfoV1Built  bool
 	txInfoV2Built  bool
 	txInfoV3Built  bool
 }
 
 // newConwayTxInfoCache builds the per-tx PlutusV1/V2/V3 TxInfo cache.
-// protocolMajor is the active major protocol version and must be supplied: the
-// PlutusV1/V2 txInfoMint rendering depends on it, so an omitted (zero) value
-// silently produces a pre-Plomin script context at PV10+, which changes both
-// the evaluated ex-units and the script result.
+//
+// pparams must be non-nil. The PlutusV1/V2 txInfoMint rendering depends on the
+// active major protocol version, and an omitted (zero) major silently produces a
+// pre-Plomin script context at PV10+, changing both the evaluated ex-units and
+// the script result. Taking the parameter set rather than a bare major keeps a
+// caller from passing a version that drifts from the active one.
 func newConwayTxInfoCache(
 	ls lcommon.LedgerState,
 	tx lcommon.Transaction,
 	resolvedInputs []lcommon.Utxo,
-	protocolMajor uint,
+	pparams *conway.ConwayProtocolParameters,
 ) *conwayTxInfoCache {
 	return &conwayTxInfoCache{
 		ls:             ls,
 		tx:             tx,
 		resolvedInputs: resolvedInputs,
-		protocolMajor:  protocolMajor,
+		pparams:        pparams,
 	}
+}
+
+// protocolMajor reports the active major protocol version. The Conway plutus
+// entry points reject a nil (including typed-nil) parameter set before the cache
+// is built, so this does not paper over a missing version.
+func (c *conwayTxInfoCache) protocolMajor() uint {
+	return c.pparams.ProtocolVersion.Major
 }
 
 func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
@@ -908,7 +917,7 @@ func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
 				Err: err,
 			}
 		}
-		txInfo.ProtocolMajor = c.protocolMajor
+		txInfo.ProtocolMajor = c.protocolMajor()
 		c.txInfoV1 = txInfo
 		c.txInfoV1Built = true
 	}
@@ -927,7 +936,7 @@ func (c *conwayTxInfoCache) v2() (script.TxInfoV2, error) {
 				Err: err,
 			}
 		}
-		txInfo.ProtocolMajor = c.protocolMajor
+		txInfo.ProtocolMajor = c.protocolMajor()
 		c.txInfoV2 = txInfo
 		c.txInfoV2Built = true
 	}
@@ -1219,7 +1228,7 @@ func EvaluateTxConway(
 		ls,
 		tx,
 		scriptInputs.resolvedAllInputs,
-		tmpPparams.ProtocolVersion.Major,
+		tmpPparams,
 	)
 	txInfoV3, err := txInfos.v3()
 	if err != nil {

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -151,7 +151,7 @@ func CertDepositConway(
 	pp lcommon.ProtocolParameters,
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*conway.ConwayProtocolParameters)
-	if !ok {
+	if !ok || tmpPparams == nil {
 		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {
@@ -181,7 +181,7 @@ func ValidateTxConway(
 	pp lcommon.ProtocolParameters,
 ) error {
 	tmpPparams, ok := pp.(*conway.ConwayProtocolParameters)
-	if !ok {
+	if !ok || tmpPparams == nil {
 		return ErrIncompatibleProtocolParams
 	}
 	normalizedTx, err := normalizeScriptDataHashCbor(tx)
@@ -336,6 +336,9 @@ func ValidateTxPlutusConway(
 	ls lcommon.LedgerState,
 	pp *conway.ConwayProtocolParameters,
 ) error {
+	if pp == nil {
+		return ErrIncompatibleProtocolParams
+	}
 	return validateTxPlutusConway(tx, ls, pp, true)
 }
 
@@ -394,6 +397,7 @@ func validateTxPlutusConwayWithContext(
 		ls,
 		tx,
 		plutusCtx.scriptInputs.resolvedAllInputs,
+		pp.ProtocolVersion.Major,
 	)
 	for redeemerKey, redeemerValue := range plutusCtx.redeemers.Iter() {
 		purpose, ok := buildConwayScriptPurpose(
@@ -867,20 +871,28 @@ type conwayTxInfoCache struct {
 	txInfoV1       script.TxInfoV1
 	txInfoV2       script.TxInfoV2
 	txInfoV3       script.TxInfoV3
+	protocolMajor  uint
 	txInfoV1Built  bool
 	txInfoV2Built  bool
 	txInfoV3Built  bool
 }
 
+// newConwayTxInfoCache builds the per-tx PlutusV1/V2/V3 TxInfo cache.
+// protocolMajor is the active major protocol version and must be supplied: the
+// PlutusV1/V2 txInfoMint rendering depends on it, so an omitted (zero) value
+// silently produces a pre-Plomin script context at PV10+, which changes both
+// the evaluated ex-units and the script result.
 func newConwayTxInfoCache(
 	ls lcommon.LedgerState,
 	tx lcommon.Transaction,
 	resolvedInputs []lcommon.Utxo,
+	protocolMajor uint,
 ) *conwayTxInfoCache {
 	return &conwayTxInfoCache{
 		ls:             ls,
 		tx:             tx,
 		resolvedInputs: resolvedInputs,
+		protocolMajor:  protocolMajor,
 	}
 }
 
@@ -896,6 +908,7 @@ func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
 				Err: err,
 			}
 		}
+		txInfo.ProtocolMajor = c.protocolMajor
 		c.txInfoV1 = txInfo
 		c.txInfoV1Built = true
 	}
@@ -914,6 +927,7 @@ func (c *conwayTxInfoCache) v2() (script.TxInfoV2, error) {
 				Err: err,
 			}
 		}
+		txInfo.ProtocolMajor = c.protocolMajor
 		c.txInfoV2 = txInfo
 		c.txInfoV2Built = true
 	}
@@ -1191,7 +1205,7 @@ func EvaluateTxConway(
 	pp lcommon.ProtocolParameters,
 ) (uint64, lcommon.ExUnits, map[lcommon.RedeemerKey]lcommon.ExUnits, error) {
 	tmpPparams, ok := pp.(*conway.ConwayProtocolParameters)
-	if !ok {
+	if !ok || tmpPparams == nil {
 		return 0, lcommon.ExUnits{}, nil, ErrIncompatibleProtocolParams
 	}
 	scriptInputs, err := resolveConwayScriptInputs(tx, ls, true)
@@ -1205,6 +1219,7 @@ func EvaluateTxConway(
 		ls,
 		tx,
 		scriptInputs.resolvedAllInputs,
+		tmpPparams.ProtocolVersion.Major,
 	)
 	txInfoV3, err := txInfos.v3()
 	if err != nil {

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -2688,10 +2688,15 @@ func TestConwayTxInfoCachePropagatesProtocolMajor(t *testing.T) {
 	resolved := []lcommon.Utxo{{Id: input, Output: newTestOutput(1_000_000)}}
 
 	// The mint rendering differs even for a tx that mints nothing, so no mint
-	// fixture is needed to observe the two renderings.
+	// fixture is needed to observe the two renderings. Driving this through a
+	// parameter set rather than a bare major mirrors production: the cache reads
+	// the version out of the pparams the caller is already holding, so a call
+	// site cannot supply a version that drifts from the active one.
 	build := func(t *testing.T, major uint) (script.TxInfoV1, script.TxInfoV2) {
 		t.Helper()
-		cache := newConwayTxInfoCache(ls, tx, resolved, major)
+		pp := &conway.ConwayProtocolParameters{}
+		pp.ProtocolVersion.Major = major
+		cache := newConwayTxInfoCache(ls, tx, resolved, pp)
 		v1, err := cache.v1()
 		require.NoError(t, err)
 		v2, err := cache.v2()
@@ -2718,10 +2723,12 @@ func TestConwayTxInfoCachePropagatesProtocolMajor(t *testing.T) {
 	)
 }
 
-// TestValidateTxPlutusConwayUsesPparamsProtocolMajor asserts the protocol major
-// reaches the cache from the protocol parameters rather than defaulting to
-// zero, which is what makes the rendering above reachable in production.
-func TestValidateTxPlutusConwayUsesPparamsProtocolMajor(t *testing.T) {
+// TestConwayTxInfoCacheReadsMajorFromPparams pins the cache to the version in
+// the parameter set it was given. Combined with the cache taking
+// *conway.ConwayProtocolParameters, this is what keeps the two production call
+// sites honest: neither can pass a standalone version at all, so the only way to
+// reach a wrong major is to change what the pparams themselves say.
+func TestConwayTxInfoCacheReadsMajorFromPparams(t *testing.T) {
 	input := newTestInput(0x01, 0)
 	tx := &mockConwayFeeTx{
 		mockFeeTx: mockFeeTx{
@@ -2742,12 +2749,29 @@ func TestValidateTxPlutusConwayUsesPparamsProtocolMajor(t *testing.T) {
 		ls,
 		tx,
 		plutusCtx.scriptInputs.resolvedAllInputs,
-		pp.ProtocolVersion.Major,
+		pp,
 	)
 	v1, err := cache.v1()
 	require.NoError(t, err)
+	v2, err := cache.v2()
+	require.NoError(t, err)
 
 	assert.Equal(t, lcommon.ProtocolVersionPlomin, v1.ProtocolMajor)
+	assert.Equal(t, lcommon.ProtocolVersionPlomin, v2.ProtocolMajor)
+
+	// A later version in the same parameter set must follow through, so the
+	// cache cannot be reading a constant.
+	pp.ProtocolVersion.Major = lcommon.ProtocolVersionVanRossem
+	later := newConwayTxInfoCache(
+		ls,
+		tx,
+		plutusCtx.scriptInputs.resolvedAllInputs,
+		pp,
+	)
+	laterV1, err := later.v1()
+	require.NoError(t, err)
+
+	assert.Equal(t, lcommon.ProtocolVersionVanRossem, laterV1.ProtocolMajor)
 }
 
 // TestConwayPlutusRejectsNilPparams covers the typed-nil pointer case: a nil
@@ -2776,4 +2800,10 @@ func TestConwayPlutusRejectsNilPparams(t *testing.T) {
 	)
 	_, _, _, err := EvaluateTxConway(tx, ls, nilPparams)
 	assert.ErrorIs(t, err, ErrIncompatibleProtocolParams)
+	// CertDepositConway takes the same guard and reads pparams fields directly.
+	_, certErr := CertDepositConway(
+		&lcommon.StakeRegistrationCertificate{},
+		nilPparams,
+	)
+	assert.ErrorIs(t, certErr, ErrIncompatibleProtocolParams)
 }

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -2664,3 +2664,116 @@ func TestCheckPoolMarginFloor(t *testing.T) {
 			[]lcommon.Certificate{nilReg}, nil))
 	})
 }
+
+// TestConwayTxInfoCachePropagatesProtocolMajor guards the wiring that carries
+// the active major protocol version into the PlutusV1/V2 script context.
+// gouroboros renders txInfoMint differently from PV10 (Plomin) on: V1/V2 gain a
+// zero-lovelace ada entry, matching cardano-ledger's transMintValue. That
+// rendering is selected by TxInfo.ProtocolMajor, whose zero value means
+// "pre-Plomin". dingo builds the Conway script context itself rather than going
+// through gouroboros' conway.UtxoValidatePlutusScripts, so leaving the field
+// unset silently evaluates every PV10+ V1/V2 script against a pre-Plomin
+// context, changing both the ex-units charged and the script result.
+func TestConwayTxInfoCachePropagatesProtocolMajor(t *testing.T) {
+	input := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			fee:       big.NewInt(0),
+			witnesses: &mockWitnessSet{},
+		},
+		inputs: []lcommon.TransactionInput{input},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(input, newTestOutput(1_000_000))
+	resolved := []lcommon.Utxo{{Id: input, Output: newTestOutput(1_000_000)}}
+
+	// The mint rendering differs even for a tx that mints nothing, so no mint
+	// fixture is needed to observe the two renderings.
+	build := func(t *testing.T, major uint) (script.TxInfoV1, script.TxInfoV2) {
+		t.Helper()
+		cache := newConwayTxInfoCache(ls, tx, resolved, major)
+		v1, err := cache.v1()
+		require.NoError(t, err)
+		v2, err := cache.v2()
+		require.NoError(t, err)
+		require.Equal(t, major, v1.ProtocolMajor)
+		require.Equal(t, major, v2.ProtocolMajor)
+		return v1, v2
+	}
+
+	preV1, preV2 := build(t, lcommon.ProtocolVersionConway)
+	postV1, postV2 := build(t, lcommon.ProtocolVersionPlomin)
+
+	assert.NotEqual(
+		t,
+		preV1.ToPlutusData(),
+		postV1.ToPlutusData(),
+		"PV10 must render a different V1 txInfoMint than PV9",
+	)
+	assert.NotEqual(
+		t,
+		preV2.ToPlutusData(),
+		postV2.ToPlutusData(),
+		"PV10 must render a different V2 txInfoMint than PV9",
+	)
+}
+
+// TestValidateTxPlutusConwayUsesPparamsProtocolMajor asserts the protocol major
+// reaches the cache from the protocol parameters rather than defaulting to
+// zero, which is what makes the rendering above reachable in production.
+func TestValidateTxPlutusConwayUsesPparamsProtocolMajor(t *testing.T) {
+	input := newTestInput(0x01, 0)
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			fee:       big.NewInt(0),
+			witnesses: &mockWitnessSet{},
+		},
+		inputs: []lcommon.TransactionInput{input},
+	}
+	ls := newMockLedgerState()
+	ls.addUtxo(input, newTestOutput(1_000_000))
+
+	plutusCtx, err := newConwayPlutusValidationContext(tx, ls)
+	require.NoError(t, err)
+	pp := &conway.ConwayProtocolParameters{}
+	pp.ProtocolVersion.Major = lcommon.ProtocolVersionPlomin
+
+	cache := newConwayTxInfoCache(
+		ls,
+		tx,
+		plutusCtx.scriptInputs.resolvedAllInputs,
+		pp.ProtocolVersion.Major,
+	)
+	v1, err := cache.v1()
+	require.NoError(t, err)
+
+	assert.Equal(t, lcommon.ProtocolVersionPlomin, v1.ProtocolMajor)
+}
+
+// TestConwayPlutusRejectsNilPparams covers the typed-nil pointer case: a nil
+// *conway.ConwayProtocolParameters satisfies the protocol-parameters type
+// assertion, and the Conway plutus path now dereferences pparams to read the
+// protocol major, so an unguarded nil would panic instead of erroring.
+func TestConwayPlutusRejectsNilPparams(t *testing.T) {
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			fee:       big.NewInt(0),
+			witnesses: &mockWitnessSet{},
+		},
+	}
+	ls := newMockLedgerState()
+	var nilPparams *conway.ConwayProtocolParameters
+
+	assert.Equal(
+		t,
+		ErrIncompatibleProtocolParams,
+		ValidateTxPlutusConway(tx, 0, ls, nilPparams),
+	)
+	assert.ErrorIs(
+		t,
+		ValidateTxConway(tx, 0, ls, nilPparams),
+		ErrIncompatibleProtocolParams,
+	)
+	_, _, _, err := EvaluateTxConway(tx, ls, nilPparams)
+	assert.ErrorIs(t, err, ErrIncompatibleProtocolParams)
+}


### PR DESCRIPTION
Dingo builds the Conway-era Plutus script context in `ledger/eras/conway.go` rather than delegating to gouroboros' `conway.UtxoValidatePlutusScripts`, and that construction never set `TxInfo.ProtocolMajor` on the PlutusV1 and PlutusV2 contexts.

gouroboros selects the `txInfoMint` rendering from that field. From PV10 (Plomin) on, V1/V2 gain a leading zero-lovelace ada entry, matching cardano-ledger's `transMintValue`; below PV10 the entry is absent. The zero value means "pre-Plomin", so every Conway-era V1/V2 script dingo evaluated at PV10 or PV11 saw a pre-Plomin context. That changes both the ex-units charged and, for a validator that inspects the mint field, the script result.

Block application masks the divergence: `isValid=true` downgrades the failure to a WARN and the block is accepted. The mempool and forging paths have no producer to trust, so there the divergence rejects a valid transaction.

This threads the active major from the protocol parameters into the TxInfo cache at both construction sites, `validateTxPlutusConwayWithContext` and `EvaluateTxConway`. Reading the major is the first dereference of pparams on that path, so a typed-nil `*conway.ConwayProtocolParameters` (which satisfies the type assertion) is now rejected with `ErrIncompatibleProtocolParams` instead of panicking.

PlutusV3 is unaffected: it uses the V3 `MintValue` representation and `TxInfoV3` does not consult the protocol major. Dijkstra is unaffected: `ValidateTxDijkstra` routes through gouroboros' `dijkstra.UtxoValidatePlutusScripts`, which sets the field. Alonzo and Babbage cap at major 8, so their zero-value behavior was already correct.

Origin of the finding: while checking whether the four known producer-valid budget overages in `database/immutable/testdata` came from a mint-rendering difference, a controlled experiment removed gouroboros' PV10 gate entirely. That made agreement worse, not better, on the same script:

| gouroboros | used cpu | declared cpu |
| --- | --- | --- |
| gate in place | 1805695324 | 1800466965 |
| gate removed | 1811792649 | 1800466965 |

So the gate is correct and was left alone; the bug is that dingo never fed it the protocol version.

Testing:

- three new tests in `ledger/eras/validation_test.go`, each confirmed to fail when the fix is reverted: the cache propagates the major to V1 and V2 and the two protocol versions render different `txInfoMint`; the major arrives from pparams rather than defaulting to zero; and the typed-nil pparams guard returns an error on all three entry points
- `go test -race ./...`
- conformance suite
- `golangci-lint run ./...`, `nilaway ./...`, `modernize ./...`, `make import-boundaries`, `make docs-parity`
- DevNet
- `dingo load database/immutable/testdata`: that data tops out at preview slot 1295990, which is pre-Conway, so this change cannot alter its outcome. Confirmed inert by comparing the full producer-disagreement set against a baseline; identical. The load was run on top of #3121 and #3122, since plain main still aborts at slot 699109 without them.

`DATABASE.md` and `ARCHITECTURE.md` were checked and are not affected: this is internal wiring of a script-context field, with no change to component responsibilities, package boundaries, EventBus payloads, storage surfaces, or the Phase-2 trust policy documented in `ARCHITECTURE.md`.

Fixes #3124

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carry the active protocol major into Conway-era Plutus V1/V2 TxInfo to fix txInfoMint at PV10+ (Plomin), aligning ex-units and script results with `gouroboros` and `cardano-ledger`. The TxInfo cache now takes `*conway.ConwayProtocolParameters` to prevent version drift and return clear errors for nil params.

- **Bug Fixes**
  - Set `TxInfo.ProtocolMajor` for V1/V2 so PV10+ mint includes the zero-ADA entry; mempool/forging accept valid txs again.
  - Reject nil or typed-nil `*conway.ConwayProtocolParameters` in Conway validation and evaluation paths instead of panicking.

- **Refactors**
  - Pass `*conway.ConwayProtocolParameters` into the TxInfo cache (reads the major internally) at both call sites to prevent drift from the active protocol version.

<sup>Written for commit c28c727624d2a2d3495c0fcb790a1ac20422fc3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction validation compatibility across protocol major versions.
  * Prevented crashes when protocol parameters are missing or invalid; clear incompatibility errors are now returned instead.
  * Ensured Plutus transaction contexts use the active protocol version consistently.

* **Tests**
  * Added coverage for protocol-version handling, transaction validation, and invalid parameter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->