### PR TITLE
chore(deps): move to gouroboros v0.192.2 and drop the dead ProtocolMajor wiring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.27.5
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.192.0
+	github.com/blinklabs-io/gouroboros v0.192.2
 	github.com/blinklabs-io/ouroboros-mock v0.15.0
 	github.com/blinklabs-io/plutigo v0.2.0
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.27.5
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/gouroboros v0.191.3
+	github.com/blinklabs-io/gouroboros v0.192.0
 	github.com/blinklabs-io/ouroboros-mock v0.15.0
 	github.com/blinklabs-io/plutigo v0.2.0
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.191.3 h1:RcHmU7YMIFnZ5sVBwtIIDyazklNEMVx6s+PIXQ7h+ts=
-github.com/blinklabs-io/gouroboros v0.191.3/go.mod h1:E9LvQXTSCuUsshd4bnc9/y3STzfDIKt8tiM7DM8/iLI=
+github.com/blinklabs-io/gouroboros v0.192.0 h1:f+3t07cziitumxHkz3TYh4cJEeqUkcV/wlyeLwwaL6E=
+github.com/blinklabs-io/gouroboros v0.192.0/go.mod h1:E9LvQXTSCuUsshd4bnc9/y3STzfDIKt8tiM7DM8/iLI=
 github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.2.0 h1:r0o/a+sbXL3IzTIOyrO7qybmd1cR8zQtz5mVbR1+1jI=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.192.0 h1:f+3t07cziitumxHkz3TYh4cJEeqUkcV/wlyeLwwaL6E=
-github.com/blinklabs-io/gouroboros v0.192.0/go.mod h1:E9LvQXTSCuUsshd4bnc9/y3STzfDIKt8tiM7DM8/iLI=
+github.com/blinklabs-io/gouroboros v0.192.2 h1:NYpMoYpx20cOk3ezOPnkXF1rdGj8eG9aNIcsZHoHO3g=
+github.com/blinklabs-io/gouroboros v0.192.2/go.mod h1:E9LvQXTSCuUsshd4bnc9/y3STzfDIKt8tiM7DM8/iLI=
 github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.2.0 h1:r0o/a+sbXL3IzTIOyrO7qybmd1cR8zQtz5mVbR1+1jI=

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -397,7 +397,6 @@ func validateTxPlutusConwayWithContext(
 		ls,
 		tx,
 		plutusCtx.scriptInputs.resolvedAllInputs,
-		pp,
 	)
 	for redeemerKey, redeemerValue := range plutusCtx.redeemers.Iter() {
 		purpose, ok := buildConwayScriptPurpose(
@@ -871,7 +870,6 @@ type conwayTxInfoCache struct {
 	txInfoV1       script.TxInfoV1
 	txInfoV2       script.TxInfoV2
 	txInfoV3       script.TxInfoV3
-	pparams        *conway.ConwayProtocolParameters
 	txInfoV1Built  bool
 	txInfoV2Built  bool
 	txInfoV3Built  bool
@@ -879,30 +877,20 @@ type conwayTxInfoCache struct {
 
 // newConwayTxInfoCache builds the per-tx PlutusV1/V2/V3 TxInfo cache.
 //
-// pparams must be non-nil. The PlutusV1/V2 txInfoMint rendering depends on the
-// active major protocol version, and an omitted (zero) major silently produces a
-// pre-Plomin script context at PV10+, changing both the evaluated ex-units and
-// the script result. Taking the parameter set rather than a bare major keeps a
-// caller from passing a version that drifts from the active one.
+// The cache takes no protocol version. gouroboros v0.192.0 renders the
+// PlutusV1/V2 txInfoMint the same way at every protocol version, matching
+// cardano-ledger's ungated transMintValue, so there is nothing left for a
+// version to select.
 func newConwayTxInfoCache(
 	ls lcommon.LedgerState,
 	tx lcommon.Transaction,
 	resolvedInputs []lcommon.Utxo,
-	pparams *conway.ConwayProtocolParameters,
 ) *conwayTxInfoCache {
 	return &conwayTxInfoCache{
 		ls:             ls,
 		tx:             tx,
 		resolvedInputs: resolvedInputs,
-		pparams:        pparams,
 	}
-}
-
-// protocolMajor reports the active major protocol version. The Conway plutus
-// entry points reject a nil (including typed-nil) parameter set before the cache
-// is built, so this does not paper over a missing version.
-func (c *conwayTxInfoCache) protocolMajor() uint {
-	return c.pparams.ProtocolVersion.Major
 }
 
 func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
@@ -917,7 +905,6 @@ func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
 				Err: err,
 			}
 		}
-		txInfo.ProtocolMajor = c.protocolMajor()
 		c.txInfoV1 = txInfo
 		c.txInfoV1Built = true
 	}
@@ -936,7 +923,6 @@ func (c *conwayTxInfoCache) v2() (script.TxInfoV2, error) {
 				Err: err,
 			}
 		}
-		txInfo.ProtocolMajor = c.protocolMajor()
 		c.txInfoV2 = txInfo
 		c.txInfoV2Built = true
 	}
@@ -1228,7 +1214,6 @@ func EvaluateTxConway(
 		ls,
 		tx,
 		scriptInputs.resolvedAllInputs,
-		tmpPparams,
 	)
 	var txInfoV3 script.TxInfoV3
 	if txHasRedeemers(tx) {

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/blinklabs-io/plutigo/lang"
 	"github.com/blinklabs-io/plutigo/syn"
 	"github.com/stretchr/testify/assert"
@@ -2837,20 +2838,24 @@ func TestCheckPoolMarginFloor(t *testing.T) {
 	})
 }
 
-// TestConwayTxInfoCachePropagatesProtocolMajor guards the wiring that carries
-// the active major protocol version into the PlutusV1/V2 script context.
-// gouroboros renders txInfoMint differently from PV10 (Plomin) on: V1/V2 gain a
-// zero-lovelace ada entry, matching cardano-ledger's transMintValue. That
-// rendering is selected by TxInfo.ProtocolMajor, whose zero value means
-// "pre-Plomin". dingo builds the Conway script context itself rather than going
-// through gouroboros' conway.UtxoValidatePlutusScripts, so leaving the field
-// unset silently evaluates every PV10+ V1/V2 script against a pre-Plomin
-// context, changing both the ex-units charged and the script result.
-func TestConwayTxInfoCachePropagatesProtocolMajor(t *testing.T) {
+// TestConwayTxInfoCacheRendersMintIndependentOfProtocolVersion pins the
+// invariant that replaced the one this test used to assert.
+//
+// It previously required PV9 and PV10 to render txInfoMint differently, because
+// gouroboros gated the zero-lovelace ada entry on PV10. That gate was the bug:
+// cardano-ledger's transMintValue takes no protocol version, so pre-Plomin
+// scripts that inspect txInfoMint were costed against a mint field one entry
+// short and diverged from the node that produced the block. gouroboros v0.192.0
+// removed the gate, so the rendering is now identical in every era, and this
+// test fails if the gate returns.
+func TestConwayTxInfoCacheRendersMintIndependentOfProtocolVersion(t *testing.T) {
 	input := newTestInput(0x01, 0)
 	tx := &mockConwayFeeTx{
 		mockFeeTx: mockFeeTx{
-			fee:       big.NewInt(0),
+			// Non-zero so the fee field cannot be mistaken for the mint field:
+			// both render as a single-entry map keyed by the empty policy, and
+			// a zero fee would make them identical.
+			fee:       big.NewInt(311_505),
 			witnesses: &mockWitnessSet{},
 		},
 		inputs: []lcommon.TransactionInput{input},
@@ -2859,97 +2864,61 @@ func TestConwayTxInfoCachePropagatesProtocolMajor(t *testing.T) {
 	ls.addUtxo(input, newTestOutput(1_000_000))
 	resolved := []lcommon.Utxo{{Id: input, Output: newTestOutput(1_000_000)}}
 
-	// The mint rendering differs even for a tx that mints nothing, so no mint
-	// fixture is needed to observe the two renderings. Driving this through a
-	// parameter set rather than a bare major mirrors production: the cache reads
-	// the version out of the pparams the caller is already holding, so a call
-	// site cannot supply a version that drifts from the active one.
-	build := func(t *testing.T, major uint) (script.TxInfoV1, script.TxInfoV2) {
-		t.Helper()
-		pp := &conway.ConwayProtocolParameters{}
-		pp.ProtocolVersion.Major = major
-		cache := newConwayTxInfoCache(ls, tx, resolved, pp)
-		v1, err := cache.v1()
-		require.NoError(t, err)
-		v2, err := cache.v2()
-		require.NoError(t, err)
-		require.Equal(t, major, v1.ProtocolMajor)
-		require.Equal(t, major, v2.ProtocolMajor)
-		return v1, v2
-	}
-
-	preV1, preV2 := build(t, lcommon.ProtocolVersionConway)
-	postV1, postV2 := build(t, lcommon.ProtocolVersionPlomin)
-
-	assert.NotEqual(
-		t,
-		preV1.ToPlutusData(),
-		postV1.ToPlutusData(),
-		"PV10 must render a different V1 txInfoMint than PV9",
-	)
-	assert.NotEqual(
-		t,
-		preV2.ToPlutusData(),
-		postV2.ToPlutusData(),
-		"PV10 must render a different V2 txInfoMint than PV9",
-	)
-}
-
-// TestConwayTxInfoCacheReadsMajorFromPparams pins the cache to the version in
-// the parameter set it was given. Combined with the cache taking
-// *conway.ConwayProtocolParameters, this is what keeps the two production call
-// sites honest: neither can pass a standalone version at all, so the only way to
-// reach a wrong major is to change what the pparams themselves say.
-func TestConwayTxInfoCacheReadsMajorFromPparams(t *testing.T) {
-	input := newTestInput(0x01, 0)
-	tx := &mockConwayFeeTx{
-		mockFeeTx: mockFeeTx{
-			fee:       big.NewInt(0),
-			witnesses: &mockWitnessSet{},
-		},
-		inputs: []lcommon.TransactionInput{input},
-	}
-	ls := newMockLedgerState()
-	ls.addUtxo(input, newTestOutput(1_000_000))
-
-	plutusCtx, err := newConwayPlutusValidationContext(tx, ls)
-	require.NoError(t, err)
-	pp := &conway.ConwayProtocolParameters{}
-	pp.ProtocolVersion.Major = lcommon.ProtocolVersionPlomin
-
-	cache := newConwayTxInfoCache(
-		ls,
-		tx,
-		plutusCtx.scriptInputs.resolvedAllInputs,
-		pp,
-	)
+	// A tx that mints nothing still carries the ada entry, so no mint fixture
+	// is needed to observe the rendering.
+	cache := newConwayTxInfoCache(ls, tx, resolved)
 	v1, err := cache.v1()
 	require.NoError(t, err)
 	v2, err := cache.v2()
 	require.NoError(t, err)
 
-	assert.Equal(t, lcommon.ProtocolVersionPlomin, v1.ProtocolMajor)
-	assert.Equal(t, lcommon.ProtocolVersionPlomin, v2.ProtocolMajor)
+	// txInfo field order differs by version: V1 is
+	// [inputs, outputs, fee, mint, ...] while V2 inserts reference inputs
+	// ahead of outputs, so its mint sits one later.
+	mintOf := func(d data.PlutusData, idx int) data.PlutusData {
+		constr, ok := d.(*data.Constr)
+		require.True(t, ok)
+		require.Greater(t, len(constr.Fields), idx)
+		return constr.Fields[idx]
+	}
+	for _, tc := range []struct {
+		name string
+		mint data.PlutusData
+	}{
+		{"v1", mintOf(v1.ToPlutusData(), 3)},
+		{"v2", mintOf(v2.ToPlutusData(), 4)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, ok := tc.mint.(*data.Map)
+			require.True(t, ok, "txInfoMint must be a map")
+			require.Len(t, m.Pairs, 1,
+				"an empty mint must still carry the zero-lovelace ada entry")
+			policy, ok := m.Pairs[0][0].(*data.ByteString)
+			require.True(t, ok)
+			assert.Empty(t, policy.Inner, "ada policy id is the empty bytestring")
 
-	// A later version in the same parameter set must follow through, so the
-	// cache cannot be reading a constant.
-	pp.ProtocolVersion.Major = lcommon.ProtocolVersionVanRossem
-	later := newConwayTxInfoCache(
-		ls,
-		tx,
-		plutusCtx.scriptInputs.resolvedAllInputs,
-		pp,
-	)
-	laterV1, err := later.v1()
-	require.NoError(t, err)
-
-	assert.Equal(t, lcommon.ProtocolVersionVanRossem, laterV1.ProtocolMajor)
+			// Assert the amount too. Without it the fee field, which is also a
+			// single-entry map keyed by the empty policy, satisfies the checks
+			// above and the test would not notice a wrong field index.
+			inner, ok := m.Pairs[0][1].(*data.Map)
+			require.True(t, ok, "ada entry must map asset name to amount")
+			require.Len(t, inner.Pairs, 1)
+			name, ok := inner.Pairs[0][0].(*data.ByteString)
+			require.True(t, ok)
+			assert.Empty(t, name.Inner, "ada asset name is the empty bytestring")
+			amount, ok := inner.Pairs[0][1].(*data.Integer)
+			require.True(t, ok)
+			assert.Zero(t, amount.Inner.Int64(),
+				"the prepended ada entry mints zero")
+		})
+	}
 }
 
 // TestConwayPlutusRejectsNilPparams covers the typed-nil pointer case: a nil
 // *conway.ConwayProtocolParameters satisfies the protocol-parameters type
-// assertion, and the Conway plutus path now dereferences pparams to read the
-// protocol major, so an unguarded nil would panic instead of erroring.
+// assertion, and the Conway plutus path dereferences pparams for cost models
+// and the protocol version, so an unguarded nil would panic instead of
+// erroring.
 func TestConwayPlutusRejectsNilPparams(t *testing.T) {
 	tx := &mockConwayFeeTx{
 		mockFeeTx: mockFeeTx{


### PR DESCRIPTION
Moves dingo to gouroboros v0.192.2, which carries two script-context fixes, and removes the dingo-side wiring the first of them makes dead.

## What the bump brings

`txInfoMint` gated on PV10 (gouroboros#1952, in v0.192.0). cardano-ledger's `transMintValue` takes no protocol version, so the zero-lovelace ada entry belongs in every era. Before this, every pre-Plomin PlutusV1/V2 script that inspects the mint field was costed against a field one entry short.

Zero-quantity assets kept in values (gouroboros#1961, in v0.192.2). cardano-ledger's `Value` decoder applies `pruneZeroMultiAsset`, so a zero-quantity asset never reaches a ledger rule or a script context. A burn that leaves a zero entry in an output made every script in that transaction traverse an entry the producing node did not have.

## Dingo-side change

`TxInfo.ProtocolMajor` is inert once the mint rendering no longer depends on a protocol version, and gouroboros marks it deprecated, so staticcheck flags the assignment #3125 added. This removes that mechanism: the pparams field on the Conway TxInfo cache, the `protocolMajor` accessor, the two assignments, and the extra constructor argument. The typed-nil pparams guards from #3125 stay, since the Conway plutus path still dereferences the parameter set for cost models and the protocol version.

`TestConwayTxInfoCachePropagatesProtocolMajor` asserted that PV9 and PV10 render `txInfoMint` differently. That was the bug, so it is replaced by `TestConwayTxInfoCacheRendersMintIndependentOfProtocolVersion`, which asserts the ada entry is present for both V1 and V2 and fails if the gate returns. Its fixture uses a non-zero fee so the mint field cannot be confused with the fee field, both being single-entry maps keyed by the empty policy.

## Effect on replay

A full `dingo load` of `database/immutable/testdata` completes with exit 0, no errors and no chain rewinds.

Producer disagreements go from 4 before either fix, to 12 with the mint fix alone, to 8 with both. The rise in the middle is expected and is the point: the old mint rendering under-counted, which partly cancelled a separate over-count, and correcting it removed that accidental compensation. The net is that dingo's cost now matches the budget the chain accepted, exactly, for every script in the transactions analysed.

Verified against the reference implementation rather than a reimplementation. `uplc` 1.66.0.0, the Haskell evaluator from IntersectMBO/plutus, run on the exact term dingo evaluates:

| script | uplc memory | declared on chain |
| --- | ---: | ---: |
| `3b8684b7` | 1241840 | 1241840 |
| `b21f7e15` | 7749812 | 7749812 |
| `b4c2f977` (idx 0, 3, 4) | 1171904 | 1171904 |

The remaining 8 disagreements are tracked in #3123 and are a separate context defect, not addressed here.

Testing: `go test ./ledger/eras/`, conformance, `golangci-lint run ./...` (0 issues), `nilaway ./ledger/...` (0), `make import-boundaries`, `make docs-parity`. DevNet could not run on this host: the compose file binds port 3022, which is in use by an unrelated node.

`DATABASE.md` and `ARCHITECTURE.md` were checked and are not affected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `gouroboros` to v0.192.2 to fix script-context mint rendering and zero-quantity asset handling, and removes the now-dead `TxInfo.ProtocolMajor` wiring in Conway Plutus code and tests. This makes Plutus V1/V2 `txInfoMint` consistent across protocol versions and simplifies the cache.

- **Dependencies**
  - Upgrade `github.com/blinklabs-io/gouroboros` to `v0.192.2`.
    - Ungates the zero-lovelace ADA entry in `txInfoMint` for all eras.
    - Prunes zero-quantity MultiAsset entries so values align with node decoding.

- **Refactors**
  - Drop `ProtocolMajor` from the Conway TxInfo cache and stop assigning it in V1/V2 TxInfo.
  - Update constructors and call sites to remove the unused protocol-parameters arg.
  - Replace the PV9 vs PV10 mint test with one that asserts the ADA entry is always present and not confused with the fee field.
  - Keep typed-nil pparams guards, since cost models and protocol version are still read.

<sup>Written for commit 560f6718d1fc8ee4984cc7b44439146fa0fd0b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Conway transaction processing so Plutus transaction information consistently includes the zero-value ADA mint entry.
  * Removed protocol-version-dependent differences in transaction-info mint rendering.
* **Maintenance**
  * Updated the Cardano ledger integration dependency to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->