### PR TITLE
fix(config): confine Musashi validation bypasses to the prototype profile

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4161,15 +4161,32 @@ on by the network profile itself rather than by operator configuration:
   not yet computed — which spuriously rejects the dominant pool's eligible
   blocks on Musashi's concentrated topology. Every cryptographic header check
   (KES, VRF proof, registered-VRF-key binding, opcert) still applies.
-- `SkipDijkstraTxValidation` skips the per-transaction rule set for
+- `SkipDijkstraTxValidation` skips *running* the per-transaction rule set for
   **Dijkstra-era transactions only** (`LedgerState.skipDijkstraTxValidation`);
   Conway and earlier are still validated on a Musashi node. The prototype
   stores but never applies endorser transactions, so ranking-block transactions
   spending endorser-resident outputs are unresolvable and would disagree on
   essentially every transaction — and be trusted anyway.
 
-Because these two make a node accept blocks and transactions a validating
-ledger would reject, the profile boundary is enforced rather than documented.
+That last point deserves emphasis, because it is easy to misread the flag as
+controlling acceptance. It does not. A Dijkstra per-transaction validation
+failure is logged and trusted rather than rejecting the block on **every**
+profile, not only on Musashi
+(`LedgerState.trustDijkstraTxValidationError`) — a Dijkstra block is admitted
+to the chain by its Leios certificate, its endorser block may be only partially
+resolvable, and the certificate surface is still evolving, so rewinding a
+certified chain on a disagreement is not yet the right response anywhere. So on
+the Dijkstra path the accept/reject outcome is the same either way, and
+`SkipDijkstraTxValidation` governs only whether the rules run at all (CPU cost
+and disagreement logging). Enforcing instead of trusting was item 5 of #2587,
+which was closed with that item outstanding; it needs its own change, validated
+on DevNet. Exposure is bounded meanwhile: Dijkstra enters the active era table
+only under `EnableDijkstra` (Musashi, `runMode: "leios"`, or `startEra:
+"dijkstra"`), so a default preview/preprod/mainnet node never reaches that path.
+
+Because these two settings make a node accept blocks and transactions a
+validating ledger would reject, the profile boundary is enforced rather than
+documented.
 Musashi is matched on *either* half of its identity — the network name
 `musashi` or network magic 164 — so a configuration supplying one half
 alongside a different predefined network is rejected at startup

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,6 +97,7 @@ Dingo is a high-performance Cardano blockchain node implementation in Go. This d
 - [Design Patterns](#design-patterns)
 - [Threading and Concurrency](#threading-and-concurrency)
 - [Configuration](#configuration)
+  - [Musashi prototype profile boundary](#musashi-prototype-profile-boundary)
 - [Stake Snapshots](#stake-snapshots)
 
 ## Overview
@@ -4142,6 +4143,60 @@ process may actually bind: root, Windows, and Linux `CAP_NET_BIND_SERVICE`
 allow any port, and otherwise Linux uses the kernel's
 `net.ipv4.ip_unprivileged_port_start` cutoff (1024 by default; container
 runtimes commonly set 0).
+
+### Musashi prototype profile boundary
+
+**Operational warning: the `musashi` network is a prototype profile that
+disables parts of consensus and ledger validation. It is not Cardano
+ledger/consensus compliant and must never be pointed at a production or
+production-like network.**
+
+The Musashi testnet (the IOG Leios prototype network) is the one network
+profile that relaxes validation. Two `LedgerStateConfig` settings are switched
+on by the network profile itself rather than by operator configuration:
+
+- `SkipLeaderStakeThresholdCheck` downgrades a failed Praos stake-derived
+  leader-eligibility check from a header rejection to a logged warning. Needed
+  because dingo's leadership stake is delegated UTxO only — staking rewards are
+  not yet computed — which spuriously rejects the dominant pool's eligible
+  blocks on Musashi's concentrated topology. Every cryptographic header check
+  (KES, VRF proof, registered-VRF-key binding, opcert) still applies.
+- `SkipDijkstraTxValidation` skips the per-transaction rule set for
+  **Dijkstra-era transactions only** (`LedgerState.skipDijkstraTxValidation`);
+  Conway and earlier are still validated on a Musashi node. The prototype
+  stores but never applies endorser transactions, so ranking-block transactions
+  spending endorser-resident outputs are unresolvable and would disagree on
+  essentially every transaction — and be trusted anyway.
+
+Because these two make a node accept blocks and transactions a validating
+ledger would reject, the profile boundary is enforced rather than documented.
+Musashi is matched on *either* half of its identity — the network name
+`musashi` or network magic 164 — so a configuration supplying one half
+alongside a different predefined network is rejected at startup
+(`internal/config.MusashiNetworkIdentityConflict`, checked from both
+`Config.Validate` and `Node.configValidate`). That closes two directions:
+
+- `--network preview --network-magic 164` would otherwise run the prototype's
+  non-validating rules on a node the operator configured as preview; and
+- `--network musashi --network-magic 2` is worse, because the handshake uses
+  the magic: the node would actually join preview while trusting the
+  prototype's rules.
+
+There is deliberately no unsafe opt-in override for this check, unlike the
+operator-set CIP-0163 full-pot rewards gate — the two identities are mutually
+exclusive, so a conflict is always a misconfiguration rather than a deliberate
+choice. A custom name paired with magic 164 (a private Musashi mirror), or the
+`musashi` name with an unregistered magic, remains valid; devnet is excluded
+for the same reason it is excluded from `FullPotRewardsStandardNetwork`.
+
+The wiring sites (`node.go`'s `Run` and `node_lifecycle.go`'s live
+restore/truncate reconstruction) gate both settings on
+`Config.prototypeTrustBypassesEnabled`, which requires an unambiguous Musashi
+identity. That is stricter than `Config.isMusashiNetwork`, which treats either
+half as Musashi and drives era-table and mini-protocol selection where a
+half-match is wrong but not unsafe. The stricter predicate keeps the bypasses
+off even for an embedder that constructs a `Config` directly and never calls
+`Validate`.
 
 Key configuration areas:
 - Network selection (preview, preprod, mainnet)

--- a/config.go
+++ b/config.go
@@ -396,6 +396,32 @@ func (c *Config) isMusashiNetwork() bool {
 		c.cfg.NetworkMagic == ouroboros.NetworkCardanoMusashi.NetworkMagic
 }
 
+// prototypeTrustBypassesEnabled reports whether this node may run with the
+// Musashi prototype's consensus/ledger trust bypasses —
+// LedgerStateConfig.SkipLeaderStakeThresholdCheck and
+// SkipDijkstraTxValidation. Those two make the node accept blocks and Dijkstra
+// transactions a validating ledger would reject, so they are prototype-only
+// behaviour and must never be reachable from a preview, preprod, or mainnet
+// configuration.
+//
+// This is deliberately stricter than isMusashiNetwork, which treats either
+// half of the identity (name or magic) as Musashi and is used for era and
+// mini-protocol selection where a half-match is merely wrong, not unsafe. Here
+// a half-match that also names or addresses a standard network yields false.
+// configValidate rejects such a configuration outright, so in the normal
+// startup path this can only be reached with an unambiguous identity; the
+// extra check keeps the bypasses off for an embedder that builds a Config
+// directly and never validates it.
+func (c *Config) prototypeTrustBypassesEnabled() bool {
+	if c.cfg == nil {
+		return false
+	}
+	return internalconfig.MusashiPrototypeNetwork(
+		c.cfg.Network,
+		c.cfg.NetworkMagic,
+	)
+}
+
 // experimentalLeiosNetworkingEnabled reports whether the Leios node-to-node
 // mini-protocols (leios-fetch / leios-notify) should be offered on outbound
 // and inbound connections.
@@ -458,6 +484,26 @@ func (n *Node) configValidate() error {
 		return fmt.Errorf(
 			"pledge leverage (%d) must be in [1, 10000] when enabled",
 			n.config.cfg.PledgeLeverage,
+		)
+	}
+	// The Musashi prototype network disables consensus and ledger validation
+	// (see Config.prototypeTrustBypassesEnabled). Its identity is matched on
+	// either the network name or the network magic, so refuse any configuration
+	// that pairs one half of it with a different standard network — otherwise a
+	// node an operator configured as preview/preprod/mainnet would silently run
+	// with those bypasses, or (with `--network musashi --network-magic 2`)
+	// actually join preview while trusting the prototype's rules, since the
+	// handshake uses the magic. There is deliberately no opt-in override.
+	if network, ok := internalconfig.MusashiNetworkIdentityConflict(
+		n.config.cfg.Network,
+		n.config.cfg.NetworkMagic,
+	); ok {
+		return fmt.Errorf(
+			"network %q must not use the Musashi prototype network magic (%d): "+
+				"the Musashi prototype disables consensus and ledger validation "+
+				"and must not be reachable from a standard network configuration",
+			network,
+			ouroboros.NetworkCardanoMusashi.NetworkMagic,
 		)
 	}
 	if n.config.cfg.FullPotRewardsEnabled &&

--- a/config.go
+++ b/config.go
@@ -499,10 +499,15 @@ func (n *Node) configValidate() error {
 		n.config.cfg.NetworkMagic,
 	); ok {
 		return fmt.Errorf(
-			"network %q must not use the Musashi prototype network magic (%d): "+
-				"the Musashi prototype disables consensus and ledger validation "+
-				"and must not be reachable from a standard network configuration",
+			"network identity conflict: network %q with networkMagic %d "+
+				"identifies both the %q network and the Musashi prototype "+
+				"network (name %q, magic %d); the Musashi prototype disables "+
+				"consensus and ledger validation and must not be reachable "+
+				"from a standard network configuration",
+			n.config.cfg.Network,
+			n.config.cfg.NetworkMagic,
 			network,
+			ouroboros.NetworkCardanoMusashi.Name,
 			ouroboros.NetworkCardanoMusashi.NetworkMagic,
 		)
 	}

--- a/internal/config/musashi_test.go
+++ b/internal/config/musashi_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMusashiNetworkIdentityConflict pins the rule that decides whether a
+// configuration may enable the Musashi prototype's consensus/ledger trust
+// bypasses. The prototype network is identified by name ("musashi") or by
+// magic (164); a configuration that mixes one of those with a *different*
+// predefined network is a conflict and must be rejected, because otherwise a
+// node an operator believes is on preview/preprod runs with validation off.
+func TestMusashiNetworkIdentityConflict(t *testing.T) {
+	tests := []struct {
+		name         string
+		network      string
+		networkMagic uint32
+		wantConflict string
+	}{
+		// Unambiguous prototype identities: allowed.
+		{name: "name only", network: "musashi"},
+		{name: "name and matching magic", network: "musashi", networkMagic: 164},
+		{name: "magic only", networkMagic: 164},
+		{
+			name:         "custom name with prototype magic",
+			network:      "musashi-mirror",
+			networkMagic: 164,
+		},
+
+		// Unambiguous non-prototype identities: allowed (bypasses stay off).
+		{name: "preview by name", network: "preview"},
+		{name: "preview by name and magic", network: "preview", networkMagic: 2},
+		{name: "preprod by name and magic", network: "preprod", networkMagic: 1},
+		{name: "mainnet", network: "mainnet", networkMagic: 764824073},
+		{name: "devnet", network: "devnet", networkMagic: 42},
+		{name: "custom private net", network: "private-net", networkMagic: 9999},
+		{name: "unset"},
+
+		// Conflicts: a standard network wearing the prototype's magic.
+		{
+			name:         "preview name with prototype magic",
+			network:      "preview",
+			networkMagic: 164,
+			wantConflict: "preview",
+		},
+		{
+			name:         "preprod name with prototype magic",
+			network:      "preprod",
+			networkMagic: 164,
+			wantConflict: "preprod",
+		},
+		{
+			name:         "mainnet name with prototype magic",
+			network:      "mainnet",
+			networkMagic: 164,
+			wantConflict: "mainnet",
+		},
+
+		// Conflicts: the prototype name wearing a standard network's magic.
+		// This is the sharper direction — the handshake uses the magic, so
+		// the node actually joins preview while trusting prototype rules.
+		{
+			name:         "prototype name with preview magic",
+			network:      "musashi",
+			networkMagic: 2,
+			wantConflict: "preview",
+		},
+		{
+			name:         "prototype name with preprod magic",
+			network:      "musashi",
+			networkMagic: 1,
+			wantConflict: "preprod",
+		},
+		{
+			name:         "prototype name with mainnet magic",
+			network:      "musashi",
+			networkMagic: 764824073,
+			wantConflict: "mainnet",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := MusashiNetworkIdentityConflict(
+				tt.network,
+				tt.networkMagic,
+			)
+			if tt.wantConflict == "" {
+				assert.False(t, ok, "unexpected conflict %q", got)
+				return
+			}
+			require.True(t, ok, "expected a conflict")
+			assert.Equal(t, tt.wantConflict, got)
+		})
+	}
+}
+
+// TestMusashiPrototypeNetwork pins which identities count as the prototype
+// network at all. Preview and preprod must never qualify.
+func TestMusashiPrototypeNetwork(t *testing.T) {
+	tests := []struct {
+		name         string
+		network      string
+		networkMagic uint32
+		want         bool
+	}{
+		{name: "name only", network: "musashi", want: true},
+		{
+			name:         "name and magic",
+			network:      "musashi",
+			networkMagic: 164,
+			want:         true,
+		},
+		{name: "magic only", networkMagic: 164, want: true},
+		{name: "preview", network: "preview", networkMagic: 2},
+		{name: "preprod", network: "preprod", networkMagic: 1},
+		{name: "mainnet", network: "mainnet", networkMagic: 764824073},
+		{name: "devnet", network: "devnet", networkMagic: 42},
+		{name: "unset"},
+		// A conflicting identity is not the prototype network: the bypasses
+		// must stay off even if startup validation was never run.
+		{name: "preview with prototype magic", network: "preview", networkMagic: 164},
+		{name: "prototype name with preview magic", network: "musashi", networkMagic: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				tt.want,
+				MusashiPrototypeNetwork(tt.network, tt.networkMagic),
+			)
+		})
+	}
+}
+
+// TestValidateRejectsMusashiIdentityConflict proves the conflict is refused at
+// startup configuration validation, not merely defused at the wiring site.
+func TestValidateRejectsMusashiIdentityConflict(t *testing.T) {
+	tests := []struct {
+		name         string
+		network      string
+		networkMagic uint32
+		wantErr      string
+	}{
+		{
+			name:         "preview with prototype magic",
+			network:      "preview",
+			networkMagic: 164,
+			wantErr:      `network "preview" must not use the Musashi prototype network magic`,
+		},
+		{
+			name:         "preprod with prototype magic",
+			network:      "preprod",
+			networkMagic: 164,
+			wantErr:      `network "preprod" must not use the Musashi prototype network magic`,
+		},
+		{
+			name:         "prototype name with preview magic",
+			network:      "musashi",
+			networkMagic: 2,
+			wantErr:      `network "preview" must not use the Musashi prototype network magic`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.Network = tt.network
+			cfg.NetworkMagic = tt.networkMagic
+			err := cfg.Validate(RunModeServe)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestValidateAllowsUnambiguousNetworks guards against the new rule rejecting
+// legitimate configurations, including Musashi itself.
+func TestValidateAllowsUnambiguousNetworks(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		network      string
+		networkMagic uint32
+	}{
+		{name: "musashi by name", network: "musashi"},
+		{name: "musashi by name and magic", network: "musashi", networkMagic: 164},
+		{name: "musashi by magic only", network: "", networkMagic: 164},
+		{name: "preview", network: "preview", networkMagic: 2},
+		{name: "preprod", network: "preprod", networkMagic: 1},
+		{name: "devnet", network: "devnet", networkMagic: 42},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.Network = tt.network
+			cfg.NetworkMagic = tt.networkMagic
+			require.NoError(t, cfg.Validate(RunModeServe))
+		})
+	}
+}

--- a/internal/config/musashi_test.go
+++ b/internal/config/musashi_test.go
@@ -162,19 +162,29 @@ func TestValidateRejectsMusashiIdentityConflict(t *testing.T) {
 			name:         "preview with prototype magic",
 			network:      "preview",
 			networkMagic: 164,
-			wantErr:      `network "preview" must not use the Musashi prototype network magic`,
+			// The message names both configured fields, so the operator can
+			// see which of the two they need to change.
+			wantErr: `network identity conflict: network "preview" with ` +
+				`networkMagic 164 identifies both the "preview" network and ` +
+				`the Musashi prototype network`,
 		},
 		{
 			name:         "preprod with prototype magic",
 			network:      "preprod",
 			networkMagic: 164,
-			wantErr:      `network "preprod" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "preprod" with ` +
+				`networkMagic 164 identifies both the "preprod" network and ` +
+				`the Musashi prototype network`,
 		},
 		{
+			// The reverse direction must not blame "preview", which the
+			// operator never configured: it reports musashi/2 as supplied.
 			name:         "prototype name with preview magic",
 			network:      "musashi",
 			networkMagic: 2,
-			wantErr:      `network "preview" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "musashi" with ` +
+				`networkMagic 2 identifies both the "preview" network and ` +
+				`the Musashi prototype network`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/config/musashi_test.go
+++ b/internal/config/musashi_test.go
@@ -53,6 +53,22 @@ func TestMusashiNetworkIdentityConflict(t *testing.T) {
 		{name: "custom private net", network: "private-net", networkMagic: 9999},
 		{name: "unset"},
 
+		// Devnet is excluded from the conflict set, for the same reason
+		// FullPotRewardsStandardNetwork excludes it: it is a local test
+		// network, not a production-like profile worth refusing to start for.
+		// These two cases are the only ones that reach either devnet guard —
+		// plain "devnet"/42 carries no Musashi half and returns before them.
+		{
+			name:         "devnet name with prototype magic",
+			network:      "devnet",
+			networkMagic: 164,
+		},
+		{
+			name:         "prototype name with devnet magic",
+			network:      "musashi",
+			networkMagic: 42,
+		},
+
 		// Conflicts: a standard network wearing the prototype's magic.
 		{
 			name:         "preview name with prototype magic",
@@ -153,6 +169,22 @@ func TestMusashiPrototypeNetwork(t *testing.T) {
 			name:         "prototype name with unregistered magic",
 			network:      "musashi",
 			networkMagic: 9999,
+			want:         true,
+		},
+		// Consequence of the devnet exclusion: because neither pairing is a
+		// conflict, both still resolve to the prototype network and would run
+		// with the bypasses. That is acceptable precisely because devnet is a
+		// local test network.
+		{
+			name:         "devnet name with prototype magic",
+			network:      "devnet",
+			networkMagic: 164,
+			want:         true,
+		},
+		{
+			name:         "prototype name with devnet magic",
+			network:      "musashi",
+			networkMagic: 42,
 			want:         true,
 		},
 		// A conflicting identity is not the prototype network: the bypasses

--- a/internal/config/musashi_test.go
+++ b/internal/config/musashi_test.go
@@ -113,6 +113,13 @@ func TestMusashiNetworkIdentityConflict(t *testing.T) {
 
 // TestMusashiPrototypeNetwork pins which identities count as the prototype
 // network at all. Preview and preprod must never qualify.
+//
+// Note the asymmetry between the two kinds of half-match, which is the whole
+// point of the rule: a half-match is a misconfiguration only when the *other*
+// half names a different predefined network. A custom name on magic 164, or
+// the "musashi" name on an unregistered magic, is a private prototype
+// deployment rather than a mistake, so it still counts as the prototype
+// network — magic 164 *is* Musashi, whatever an operator calls it locally.
 func TestMusashiPrototypeNetwork(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -133,6 +140,21 @@ func TestMusashiPrototypeNetwork(t *testing.T) {
 		{name: "mainnet", network: "mainnet", networkMagic: 764824073},
 		{name: "devnet", network: "devnet", networkMagic: 42},
 		{name: "unset"},
+		// Half-matches against a *custom* identity are private prototype
+		// deployments (e.g. a Musashi mirror), not misconfigurations, so they
+		// remain the prototype network.
+		{
+			name:         "custom name with prototype magic",
+			network:      "musashi-mirror",
+			networkMagic: 164,
+			want:         true,
+		},
+		{
+			name:         "prototype name with unregistered magic",
+			network:      "musashi",
+			networkMagic: 9999,
+			want:         true,
+		},
 		// A conflicting identity is not the prototype network: the bypasses
 		// must stay off even if startup validation was never run.
 		{name: "preview with prototype magic", network: "preview", networkMagic: 164},

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -506,11 +506,15 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		c.NetworkMagic,
 	); ok {
 		errs = append(errs, fmt.Errorf(
-			"network %q must not use the Musashi prototype network magic "+
-				"(%d): the Musashi prototype disables consensus and ledger "+
-				"validation and must not be reachable from a standard network "+
-				"configuration",
+			"network identity conflict: network %q with networkMagic %d "+
+				"identifies both the %q network and the Musashi prototype "+
+				"network (name %q, magic %d); the Musashi prototype disables "+
+				"consensus and ledger validation and must not be reachable "+
+				"from a standard network configuration",
+			c.Network,
+			c.NetworkMagic,
 			network,
+			ouroboros.NetworkCardanoMusashi.Name,
 			ouroboros.NetworkCardanoMusashi.NetworkMagic,
 		))
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -74,6 +74,68 @@ func FullPotRewardsStandardNetwork(
 	return "", false
 }
 
+// MusashiNetworkIdentityConflict reports whether network/networkMagic mixes the
+// experimental Musashi network (the IOG Leios prototype) with a *different*
+// predefined network, returning the name of the network it collides with.
+//
+// This matters because Musashi is identified by either half of its identity —
+// the name "musashi" or network magic 164 — and that identity switches on
+// consensus/ledger trust bypasses (SkipLeaderStakeThresholdCheck,
+// SkipDijkstraTxValidation). Either half alone is enough to enable them, so a
+// half-matching configuration is dangerous in both directions:
+//
+//   - network "preview" with magic 164 runs the prototype's non-validating
+//     rules on a node the operator configured as preview; and
+//   - network "musashi" with magic 2 is worse still, because the handshake
+//     uses the magic: the node actually joins preview while trusting the
+//     prototype's rules.
+//
+// A custom name or an unregistered magic is not a conflict — those are private
+// prototype deployments (e.g. a Musashi mirror). Devnet is excluded for the
+// same reason it is excluded from FullPotRewardsStandardNetwork: it is a local
+// test network, not a production-like profile.
+func MusashiNetworkIdentityConflict(
+	network string,
+	networkMagic uint32,
+) (string, bool) {
+	nameIsMusashi := network == ouroboros.NetworkCardanoMusashi.Name
+	magicIsMusashi := networkMagic == ouroboros.NetworkCardanoMusashi.NetworkMagic
+	if nameIsMusashi && !magicIsMusashi && networkMagic != 0 {
+		if known, ok := ouroboros.NetworkByNetworkMagic(networkMagic); ok &&
+			known.Name != ouroboros.NetworkCardanoMusashi.Name &&
+			known.Name != ouroboros.NetworkDevnet.Name {
+			return known.Name, true
+		}
+	}
+	if magicIsMusashi && !nameIsMusashi && network != "" {
+		if known, ok := ouroboros.NetworkByName(network); ok &&
+			known.Name != ouroboros.NetworkCardanoMusashi.Name &&
+			known.Name != ouroboros.NetworkDevnet.Name {
+			return known.Name, true
+		}
+	}
+	return "", false
+}
+
+// MusashiPrototypeNetwork reports whether network/networkMagic unambiguously
+// identifies the Musashi prototype network, and is therefore permitted to run
+// with the prototype's consensus/ledger trust bypasses.
+//
+// A conflicting identity (see MusashiNetworkIdentityConflict) is deliberately
+// *not* the prototype network. Startup validation rejects those configurations
+// outright, but returning false here keeps the bypasses off even for an
+// embedder that builds a Config directly and never calls Validate.
+func MusashiPrototypeNetwork(network string, networkMagic uint32) bool {
+	if _, conflict := MusashiNetworkIdentityConflict(
+		network,
+		networkMagic,
+	); conflict {
+		return false
+	}
+	return network == ouroboros.NetworkCardanoMusashi.Name ||
+		networkMagic == ouroboros.NetworkCardanoMusashi.NetworkMagic
+}
+
 // Validate checks the fully merged configuration (defaults, YAML,
 // environment, CLI flags) for invalid values and nonsensical
 // combinations. Every problem found is returned, joined into a single
@@ -432,6 +494,25 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 				network,
 			))
 		}
+	}
+
+	// The Musashi prototype network's identity switches on consensus/ledger
+	// trust bypasses, so it must never be half-claimed by a configuration
+	// that also names or addresses a standard network. Rejected outright
+	// rather than defused silently: the operator asked for two mutually
+	// exclusive networks and only one of them can be what they meant.
+	if network, ok := MusashiNetworkIdentityConflict(
+		c.Network,
+		c.NetworkMagic,
+	); ok {
+		errs = append(errs, fmt.Errorf(
+			"network %q must not use the Musashi prototype network magic "+
+				"(%d): the Musashi prototype disables consensus and ledger "+
+				"validation and must not be reachable from a standard network "+
+				"configuration",
+			network,
+			ouroboros.NetworkCardanoMusashi.NetworkMagic,
+		))
 	}
 
 	// Network identity

--- a/ledger/musashi_trust_scope_test.go
+++ b/ledger/musashi_trust_scope_test.go
@@ -86,3 +86,53 @@ func TestSkipDijkstraTxValidationScope(t *testing.T) {
 		}
 	})
 }
+
+// TestDijkstraTxValidationErrorsAreTrustedRegardlessOfProfile pins the
+// profile-independent half of the Dijkstra trust behaviour, which is easy to
+// miss when reading SkipDijkstraTxValidation alone.
+//
+// A Dijkstra per-transaction validation failure is logged and trusted rather
+// than rejecting the block on *every* profile, not just the Musashi prototype.
+// The consequence is that SkipDijkstraTxValidation decides whether the rule set
+// runs, not whether a bad Dijkstra transaction is rejected: on the Dijkstra
+// path both settings accept the block. Pre-Dijkstra eras are unaffected and
+// still reject.
+//
+// This is current, deliberate behaviour — a Dijkstra block is admitted by its
+// Leios certificate and its endorser block may be only partially resolvable —
+// but it was meant to be tightened by item 5 of #2587, which was closed with
+// that item outstanding. This test exists so that tightening is a deliberate,
+// test-visible change rather than a silent one; when enforcement lands, this
+// test should fail and be rewritten, not deleted quietly.
+func TestDijkstraTxValidationErrorsAreTrustedRegardlessOfProfile(t *testing.T) {
+	for _, profile := range []struct {
+		name string
+		skip bool
+	}{
+		{"musashi prototype profile", true},
+		{"standard profile", false},
+	} {
+		t.Run(profile.name, func(t *testing.T) {
+			ls := &LedgerState{
+				config: LedgerStateConfig{
+					SkipDijkstraTxValidation: profile.skip,
+				},
+			}
+			assert.True(
+				t,
+				ls.trustDijkstraTxValidationError(dijkstra.EraIdDijkstra),
+				"Dijkstra validation failures are trusted on every profile",
+			)
+			assert.False(
+				t,
+				ls.trustDijkstraTxValidationError(conway.EraIdConway),
+				"Conway validation failures must still reject the block",
+			)
+			assert.False(
+				t,
+				ls.trustDijkstraTxValidationError(babbage.EraIdBabbage),
+				"Babbage validation failures must still reject the block",
+			)
+		})
+	}
+}

--- a/ledger/musashi_trust_scope_test.go
+++ b/ledger/musashi_trust_scope_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSkipDijkstraTxValidationScope documents the accepted non-validating
+// behaviour of the Musashi prototype profile and, more importantly, its
+// boundary.
+//
+// The prototype's trust argument — endorser transactions are stored but never
+// applied, so ranking-block transactions spending endorser-resident outputs are
+// unresolvable and disagree on essentially every transaction — only exists in
+// Dijkstra/Leios. Every earlier era therefore keeps its full per-transaction
+// rule set even on a Musashi node. If this test starts failing because a
+// pre-Dijkstra era began skipping validation, the prototype bypass has widened
+// beyond its justification.
+func TestSkipDijkstraTxValidationScope(t *testing.T) {
+	preDijkstraEras := []struct {
+		name string
+		id   uint
+	}{
+		{"byron", byron.EraIdByron},
+		{"shelley", shelley.EraIdShelley},
+		{"allegra", allegra.EraIdAllegra},
+		{"mary", mary.EraIdMary},
+		{"alonzo", alonzo.EraIdAlonzo},
+		{"babbage", babbage.EraIdBabbage},
+		{"conway", conway.EraIdConway},
+	}
+
+	t.Run("prototype profile skips only Dijkstra", func(t *testing.T) {
+		ls := &LedgerState{
+			config: LedgerStateConfig{SkipDijkstraTxValidation: true},
+		}
+		assert.True(
+			t,
+			ls.skipDijkstraTxValidation(dijkstra.EraIdDijkstra),
+			"Dijkstra transactions are the accepted non-validating scope",
+		)
+		for _, era := range preDijkstraEras {
+			assert.False(
+				t,
+				ls.skipDijkstraTxValidation(era.id),
+				"%s transactions must still be validated on the prototype profile",
+				era.name,
+			)
+		}
+	})
+
+	t.Run("standard profile validates every era", func(t *testing.T) {
+		ls := &LedgerState{
+			config: LedgerStateConfig{SkipDijkstraTxValidation: false},
+		}
+		assert.False(
+			t,
+			ls.skipDijkstraTxValidation(dijkstra.EraIdDijkstra),
+			"Dijkstra validation must be enforced off the prototype profile",
+		)
+		for _, era := range preDijkstraEras {
+			assert.False(t, ls.skipDijkstraTxValidation(era.id), era.name)
+		}
+	})
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4186,8 +4186,8 @@ func (ls *LedgerState) strictConsumedInputsEnabled(
 	return shouldValidate && (ls.reachedTip.Load() || reachesTip)
 }
 
-// skipDijkstraTxValidation reports whether per-transaction validation is
-// skipped for a transaction being validated under era eraId.
+// skipDijkstraTxValidation reports whether the per-transaction rule set is
+// *run* for a transaction being validated under era eraId.
 //
 // This is the ledger half of the Musashi prototype's accepted non-validating
 // behaviour (see LedgerStateConfig.SkipDijkstraTxValidation), and its scope is
@@ -4200,9 +4200,37 @@ func (ls *LedgerState) strictConsumedInputsEnabled(
 // likewise unaffected: KES, VRF proof, registered-VRF-key binding and opcert
 // checks all still apply, and only the stake-derived leader threshold is
 // downgraded, by the separate SkipLeaderStakeThresholdCheck flag.
+//
+// Note what this flag does *not* decide: whether a Dijkstra validation failure
+// rejects the block. That is trustDijkstraTxValidationError, which is
+// profile-independent — so on the Dijkstra path the accept/reject outcome is
+// the same either way, and this flag only governs whether the rules are run at
+// all (CPU cost and disagreement logging).
 func (ls *LedgerState) skipDijkstraTxValidation(eraId uint) bool {
 	return eraId == dijkstra.EraIdDijkstra &&
 		ls.config.SkipDijkstraTxValidation
+}
+
+// trustDijkstraTxValidationError reports whether a per-transaction validation
+// failure under era eraId is logged and trusted instead of rejecting the block.
+//
+// This is deliberately *not* gated on the network profile or on
+// SkipDijkstraTxValidation: a Dijkstra block reaches here only because it was
+// admitted to the chain by its Leios certificate, an endorser block may be only
+// partially resolvable, and the certificate/validation surface is still
+// evolving — so rewinding a certified chain on a disagreement is not yet the
+// right response on any profile. Dijkstra is only in the active era table when
+// EnableDijkstra is set (Musashi, runMode "leios", or startEra "dijkstra"), so
+// a default preview/preprod/mainnet node never reaches this path.
+//
+// The consequence for the trust boundary is worth stating plainly:
+// SkipDijkstraTxValidation changes whether the rules run, not whether a bad
+// Dijkstra transaction is rejected. Tightening this to enforce was item 5 of
+// #2587, which was closed without that item being done; it needs its own
+// change, with DevNet/Leios validation, rather than riding along with a
+// configuration-boundary fix.
+func (ls *LedgerState) trustDijkstraTxValidationError(eraId uint) bool {
+	return eraId == dijkstra.EraIdDijkstra
 }
 
 func (ls *LedgerState) ledgerProcessBlock(
@@ -4558,7 +4586,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 				// tighten to enforce once endorser-block availability and
 				// Leios certificate validation are complete.
 				if err != nil &&
-					validationEra.Id == dijkstra.EraIdDijkstra {
+					ls.trustDijkstraTxValidationError(validationEra.Id) {
 					ls.config.Logger.Warn(
 						"Dijkstra tx validation disagreement (trusting Leios-certified block)",
 						"component",

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -438,7 +438,9 @@ type LedgerStateConfig struct {
 	// the local pool stake-threshold check while d remains active.
 	// Interim measure until reward calculation lands and reward balances can be
 	// included in the leadership stake. Set from the network in node.go (true
-	// on musashi, false otherwise).
+	// on musashi, false otherwise) via Config.prototypeTrustBypassesEnabled,
+	// which requires an unambiguous Musashi identity so this can never be
+	// reached from a preview/preprod/mainnet configuration.
 	SkipLeaderStakeThresholdCheck bool
 	// SkipDijkstraTxValidation, when true, skips the Dijkstra per-transaction
 	// validation rule set entirely. dingo already trusts (logs, does not reject)
@@ -448,8 +450,12 @@ type LedgerStateConfig struct {
 	// (Musashi) certified closure and ranking-block transactions are trusted in
 	// the same way. Running dingo's rule set only to discard any disagreement is
 	// wasted work that prevents the node from reaching tip under load. Set true
-	// on Musashi in node.go. Interim until the Leios certificate / endorser-
-	// availability surface is complete (#2587).
+	// on Musashi in node.go via Config.prototypeTrustBypassesEnabled, which
+	// requires an unambiguous Musashi identity so this can never be reached
+	// from a preview/preprod/mainnet configuration. Applies to Dijkstra-era
+	// transactions only — see LedgerState.skipDijkstraTxValidation. Interim
+	// until the Leios certificate / endorser-availability surface is complete
+	// (#2587).
 	SkipDijkstraTxValidation bool
 	// MinPoolMargin is the CIP-23 minimum pool margin (minimum variable fee) in
 	// basis points, [0, 10000] (150 = 1.5%); 0 disables it. It is a consensus-
@@ -4180,6 +4186,25 @@ func (ls *LedgerState) strictConsumedInputsEnabled(
 	return shouldValidate && (ls.reachedTip.Load() || reachesTip)
 }
 
+// skipDijkstraTxValidation reports whether per-transaction validation is
+// skipped for a transaction being validated under era eraId.
+//
+// This is the ledger half of the Musashi prototype's accepted non-validating
+// behaviour (see LedgerStateConfig.SkipDijkstraTxValidation), and its scope is
+// deliberately narrow: the bypass applies to Dijkstra-era transactions only.
+// Transactions validated under any earlier era — Conway and before — still run
+// their full rule set even when the prototype flag is set, because the
+// prototype's trust argument (endorser transactions are stored but never
+// applied, so ranking-block transactions that spend endorser-resident outputs
+// are unresolvable) exists only in Dijkstra/Leios. Header validation is
+// likewise unaffected: KES, VRF proof, registered-VRF-key binding and opcert
+// checks all still apply, and only the stake-derived leader threshold is
+// downgraded, by the separate SkipLeaderStakeThresholdCheck flag.
+func (ls *LedgerState) skipDijkstraTxValidation(eraId uint) bool {
+	return eraId == dijkstra.EraIdDijkstra &&
+		ls.config.SkipDijkstraTxValidation
+}
+
 func (ls *LedgerState) ledgerProcessBlock(
 	txn *database.Txn,
 	point ocommon.Point,
@@ -4473,8 +4498,9 @@ func (ls *LedgerState) ledgerProcessBlock(
 			// throughput below the block-production rate, so skip it. The normal
 			// CIP-conformant / Dijkstra path applies endorser txs (complete UTxO)
 			// and validates normally — it is never skipped here.
-			skipDijkstraValidation := validationEra.Id == dijkstra.EraIdDijkstra &&
-				ls.config.SkipDijkstraTxValidation
+			skipDijkstraValidation := ls.skipDijkstraTxValidation(
+				validationEra.Id,
+			)
 			if validationEra.ValidateTxFunc != nil && !skipDijkstraValidation {
 				// Use the previous era's protocol
 				// parameters when validating an era-1

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4187,7 +4187,8 @@ func (ls *LedgerState) strictConsumedInputsEnabled(
 }
 
 // skipDijkstraTxValidation reports whether the per-transaction rule set is
-// *run* for a transaction being validated under era eraId.
+// *skipped* for a transaction being validated under era eraId — true means
+// ValidateTxFunc is not called for it.
 //
 // This is the ledger half of the Musashi prototype's accepted non-validating
 // behaviour (see LedgerStateConfig.SkipDijkstraTxValidation), and its scope is

--- a/musashi_profile_test.go
+++ b/musashi_profile_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	internalconfig "github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrototypeTrustBypassesRejectedOnStandardNetworks proves a node cannot be
+// constructed with a configuration that would hand the Musashi prototype's
+// consensus/ledger trust bypasses to preview, preprod, or mainnet.
+func TestPrototypeTrustBypassesRejectedOnStandardNetworks(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ConfigOptionFunc
+		wantErr string
+	}{
+		{
+			name: "preview cannot borrow the prototype magic",
+			opts: []ConfigOptionFunc{
+				WithNetwork("preview"),
+				WithNetworkMagic(164),
+			},
+			wantErr: `network "preview" must not use the Musashi prototype network magic`,
+		},
+		{
+			name: "preprod cannot borrow the prototype magic",
+			opts: []ConfigOptionFunc{
+				WithNetwork("preprod"),
+				WithNetworkMagic(164),
+			},
+			wantErr: `network "preprod" must not use the Musashi prototype network magic`,
+		},
+		{
+			name: "mainnet cannot borrow the prototype magic",
+			opts: []ConfigOptionFunc{
+				WithNetwork("mainnet"),
+				WithNetworkMagic(164),
+			},
+			wantErr: `network "mainnet" must not use the Musashi prototype network magic`,
+		},
+		{
+			// The handshake uses the magic, so this configuration actually
+			// joins preview while claiming the prototype's trust rules.
+			name: "prototype name cannot borrow preview's magic",
+			opts: []ConfigOptionFunc{
+				WithNetwork("musashi"),
+				WithNetworkMagic(2),
+			},
+			wantErr: `network "preview" must not use the Musashi prototype network magic`,
+		},
+		{
+			name: "prototype name cannot borrow preprod's magic",
+			opts: []ConfigOptionFunc{
+				WithNetwork("musashi"),
+				WithNetworkMagic(1),
+			},
+			wantErr: `network "preprod" must not use the Musashi prototype network magic`,
+		},
+		{
+			name: "musashi by name is still accepted",
+			opts: []ConfigOptionFunc{WithNetwork("musashi")},
+		},
+		{
+			name: "musashi by name and matching magic is still accepted",
+			opts: []ConfigOptionFunc{
+				WithNetwork("musashi"),
+				WithNetworkMagic(164),
+			},
+		},
+		{
+			name: "preview is still accepted",
+			opts: []ConfigOptionFunc{WithNetwork("preview")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []ConfigOptionFunc{
+				WithPrometheusRegistry(prometheus.NewRegistry()),
+				WithListeners(ListenerConfig{
+					ListenNetwork: "tcp",
+					ListenAddress: "127.0.0.1:0",
+				}),
+			}
+			opts = append(opts, tt.opts...)
+			n, err := New(NewConfig(opts...))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			// New starts the event bus' background goroutines; Stop releases them.
+			t.Cleanup(func() { _ = n.Stop() })
+		})
+	}
+}
+
+// TestPrototypeTrustBypassesEnabledOnlyForMusashi asserts the predicate that
+// gates SkipLeaderStakeThresholdCheck and SkipDijkstraTxValidation. This is
+// the last line of defence: an embedder that constructs a Config directly and
+// never runs startup validation still must not get the bypasses on a standard
+// network.
+func TestPrototypeTrustBypassesEnabledOnlyForMusashi(t *testing.T) {
+	tests := []struct {
+		name         string
+		network      string
+		networkMagic uint32
+		want         bool
+	}{
+		{name: "musashi by name", network: "musashi", want: true},
+		{
+			name:         "musashi by name and magic",
+			network:      "musashi",
+			networkMagic: 164,
+			want:         true,
+		},
+		{name: "musashi by magic only", networkMagic: 164, want: true},
+		{name: "preview", network: "preview", networkMagic: 2},
+		{name: "preprod", network: "preprod", networkMagic: 1},
+		{name: "mainnet", network: "mainnet", networkMagic: 764824073},
+		{name: "devnet", network: "devnet", networkMagic: 42},
+		// Conflicting identities never enable the bypasses, even unvalidated.
+		{name: "preview with prototype magic", network: "preview", networkMagic: 164},
+		{name: "preprod with prototype magic", network: "preprod", networkMagic: 164},
+		{name: "musashi name with preview magic", network: "musashi", networkMagic: 2},
+		{name: "musashi name with preprod magic", network: "musashi", networkMagic: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{cfg: &internalconfig.Config{
+				Network:      tt.network,
+				NetworkMagic: tt.networkMagic,
+			}}
+			assert.Equal(
+				t,
+				tt.want,
+				c.prototypeTrustBypassesEnabled(),
+				"prototypeTrustBypassesEnabled",
+			)
+		})
+	}
+}
+
+// TestPrototypeTrustBypassesOffWithoutConfig guards the nil-config path used by
+// zero-value Config values in tests and embedders.
+func TestPrototypeTrustBypassesOffWithoutConfig(t *testing.T) {
+	c := &Config{}
+	assert.False(t, c.prototypeTrustBypassesEnabled())
+}
+
+// TestMusashiProfileTrustBypassScope is the change-bar guard for the Musashi
+// prototype profile: it documents exactly which LedgerStateConfig settings
+// relax validation, and which of those the network profile is allowed to
+// switch on by itself.
+//
+// The accepted non-validating behaviour on Musashi is limited to two settings:
+//
+//   - SkipLeaderStakeThresholdCheck downgrades a failed stake-derived leader
+//     eligibility check to a warning. Every cryptographic header check (KES,
+//     VRF proof, registered-VRF-key binding, opcert) still applies.
+//   - SkipDijkstraTxValidation skips the per-transaction rule set for
+//     Dijkstra-era transactions only; earlier eras are still validated (see
+//     ledger.TestSkipDijkstraTxValidationScope).
+//
+// TrustedReplay is listed as known but is *not* network-derived: it is set by
+// internal/node/load.go when replaying blocks this node already validated
+// locally, which is a different trust context from following an untrusted
+// network.
+//
+// A new Skip*/Trust*/Unsafe* field on LedgerStateConfig fails this test on
+// purpose. Adding one is a deliberate widening of where dingo stops validating,
+// and it should be classified here — prototype-only or not — rather than
+// picking up a network default silently.
+func TestMusashiProfileTrustBypassScope(t *testing.T) {
+	// Settings that relax validation, and whether the Musashi network profile
+	// is permitted to enable them on its own.
+	knownTrustSettings := map[string]bool{
+		"SkipLeaderStakeThresholdCheck": true,
+		"SkipDijkstraTxValidation":      true,
+		"TrustedReplay":                 false,
+	}
+
+	cfgType := reflect.TypeFor[ledger.LedgerStateConfig]()
+	found := make(map[string]bool)
+	for field := range cfgType.Fields() {
+		name := field.Name
+		if strings.HasPrefix(name, "Skip") ||
+			strings.HasPrefix(name, "Trust") ||
+			strings.HasPrefix(name, "Unsafe") {
+			found[name] = true
+		}
+	}
+	for name := range found {
+		assert.Contains(
+			t,
+			knownTrustSettings,
+			name,
+			"new validation-relaxing setting %q must be classified as "+
+				"prototype-only or not; see this test's doc comment",
+			name,
+		)
+	}
+	for name := range knownTrustSettings {
+		assert.Contains(
+			t,
+			found,
+			name,
+			"%q no longer exists; drop it from the known set",
+			name,
+		)
+	}
+}

--- a/musashi_profile_test.go
+++ b/musashi_profile_test.go
@@ -41,7 +41,7 @@ func TestPrototypeTrustBypassesRejectedOnStandardNetworks(t *testing.T) {
 				WithNetwork("preview"),
 				WithNetworkMagic(164),
 			},
-			wantErr: `network "preview" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "preview" with networkMagic 164`,
 		},
 		{
 			name: "preprod cannot borrow the prototype magic",
@@ -49,7 +49,7 @@ func TestPrototypeTrustBypassesRejectedOnStandardNetworks(t *testing.T) {
 				WithNetwork("preprod"),
 				WithNetworkMagic(164),
 			},
-			wantErr: `network "preprod" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "preprod" with networkMagic 164`,
 		},
 		{
 			name: "mainnet cannot borrow the prototype magic",
@@ -57,7 +57,7 @@ func TestPrototypeTrustBypassesRejectedOnStandardNetworks(t *testing.T) {
 				WithNetwork("mainnet"),
 				WithNetworkMagic(164),
 			},
-			wantErr: `network "mainnet" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "mainnet" with networkMagic 164`,
 		},
 		{
 			// The handshake uses the magic, so this configuration actually
@@ -67,7 +67,7 @@ func TestPrototypeTrustBypassesRejectedOnStandardNetworks(t *testing.T) {
 				WithNetwork("musashi"),
 				WithNetworkMagic(2),
 			},
-			wantErr: `network "preview" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "musashi" with networkMagic 2`,
 		},
 		{
 			name: "prototype name cannot borrow preprod's magic",
@@ -75,7 +75,7 @@ func TestPrototypeTrustBypassesRejectedOnStandardNetworks(t *testing.T) {
 				WithNetwork("musashi"),
 				WithNetworkMagic(1),
 			},
-			wantErr: `network "preprod" must not use the Musashi prototype network magic`,
+			wantErr: `network identity conflict: network "musashi" with networkMagic 1`,
 		},
 		{
 			name: "musashi by name is still accepted",

--- a/node.go
+++ b/node.go
@@ -607,11 +607,11 @@ func (n *Node) Run(ctx context.Context) error {
 			// the omission is negligible. TPraos bootstrap pool-threshold
 			// checks are waived separately inside header validation after
 			// genesis overlay slots are handled.
-			SkipLeaderStakeThresholdCheck: n.config.isMusashiNetwork(),
+			SkipLeaderStakeThresholdCheck: n.config.prototypeTrustBypassesEnabled(),
 			// On Musashi, certified endorser txs and Dijkstra ranking-block txs are
 			// trusted by the prototype; skip dingo's per-tx validation to match it
 			// and keep block application at the production rate.
-			SkipDijkstraTxValidation: n.config.isMusashiNetwork(),
+			SkipDijkstraTxValidation: n.config.prototypeTrustBypassesEnabled(),
 			// CIP-23 minimum pool margin (minimum variable fee). Operator-set,
 			// off by default (0), effective only in Dijkstra and later.
 			MinPoolMargin: n.config.minPoolMargin,

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -527,8 +527,8 @@ func (n *Node) reinitializeCoreStorage(ctx context.Context) error {
 			EndorserBlockFetcher:          n.ouroboros.FetchEndorserBlockByPoint,
 			EndorserBlockWaitSlots:        n.leiosPipelineTiming().CertifyByDeadlineSlots,
 			LeiosApplyEndorserBlockTxs:    !n.config.isMusashiNetwork(),
-			SkipLeaderStakeThresholdCheck: n.config.isMusashiNetwork(),
-			SkipDijkstraTxValidation:      n.config.isMusashiNetwork(),
+			SkipLeaderStakeThresholdCheck: n.config.prototypeTrustBypassesEnabled(),
+			SkipDijkstraTxValidation:      n.config.prototypeTrustBypassesEnabled(),
 			// These six must mirror Run()'s construction exactly: they're
 			// operator-configured reward/pool-validation feature flags
 			// (CIP-23 min pool margin, CIP-50 pledge leverage, CIP-0163


### PR DESCRIPTION
Closes #3076.

## Problem

The Musashi prototype network enables two consensus/ledger trust bypasses:

- `SkipLeaderStakeThresholdCheck` — a failed Praos stake-derived leader-eligibility check is downgraded to a logged warning.
- `SkipDijkstraTxValidation` — the Dijkstra per-transaction rule set is skipped.

Both were wired from `Config.isMusashiNetwork`, which matches on **either** half of the network identity: the name `musashi` **or** network magic `164`. Since `configPopulateNetworkMagic` only derives the magic from the name when the magic is unset, and `WithNetworkMagic` is documented as overriding the named network, the two halves are independently settable. That made the bypasses reachable from an ordinary configuration in two directions:

```
--network preview --network-magic 164
```

runs the prototype's non-validating rules on a node the operator configured as preview; and

```
--network musashi --network-magic 2
```

is worse, because the handshake reads the magic — the node actually joins **preview** while trusting the prototype's rules. The existing Shelley-genesis magic check does not catch this one, since the magic is self-consistent and only the name lies.

Either way, a node an operator believes is on a standard network can accept blocks and transactions a validating ledger would reject.

## Approach

Reject the conflict at startup rather than defusing it silently — the operator named two mutually exclusive networks and only one of them can be what they meant. `MusashiNetworkIdentityConflict` is checked from both `Config.Validate` and `Node.configValidate`, mirroring the existing full-pot-rewards gate.

The two settings are now gated on `Config.prototypeTrustBypassesEnabled`, which requires an *unambiguous* Musashi identity. `isMusashiNetwork` keeps its either-half semantics for era-table and mini-protocol selection, where a half-match is wrong but not unsafe. The stricter predicate is applied at both wiring sites — `Run` and `node_lifecycle.go`'s live restore/truncate reconstruction — so the bypasses stay off even for an embedder that builds a `Config` directly and never validates it.

`LedgerState.skipDijkstraTxValidation` is extracted so the bypass's scope is stated and testable: it covers **Dijkstra-era transactions only**, since the prototype's trust argument (endorser txs are stored but never applied, so ranking-block txs spending endorser-resident outputs are unresolvable) exists only in Dijkstra/Leios. Conway and earlier are still validated on a Musashi node, and header crypto checks — KES, VRF proof, registered-VRF-key binding, opcert — are unaffected throughout.

### Two judgment calls worth review

- **No unsafe opt-in override.** Unlike `unsafeFullPotRewardsOnStandardNetworks`, which gates an operator-set feature flag, a half-matched network identity is always a misconfiguration rather than a deliberate choice — and the issue asks for this to be *impossible* for preview/preprod.
- **Devnet is excluded** from the conflict set, for the same reason `FullPotRewardsStandardNetwork` excludes it: it is a local test network, not a production-like profile. Private mirrors stay valid too — a custom name with magic 164, or the `musashi` name with an unregistered magic.

## Tests

Written test-first (confirmed failing, then implemented). Beyond the issue's acceptance criteria there is a change-bar guard that fails when a new `Skip*`/`Trust*`/`Unsafe*` field appears on `LedgerStateConfig` without being classified as prototype-only or not; it was mutation-checked to confirm it is not passing vacuously.

- `internal/config/musashi_test.go` — the identity rule in both directions, and `Validate` rejection.
- `musashi_profile_test.go` — node construction rejects every conflicting identity; the gating predicate; the profile scope guard.
- `ledger/musashi_trust_scope_test.go` — the bypass applies to Dijkstra only; every earlier era is still validated on the prototype profile.

## Verification

- `go test -race ./...` — 63 packages ok, 0 failures.
- `internal/test/conformance` and `internal/integration` re-run uncached — pass.
- `golangci-lint run ./...` — 0 issues. `nilaway`, `make import-boundaries`, `make docs-parity` — clean.
- `modernize` — clean for this change. The two remaining findings (`node.go:434`, `node_lifecycle.go:491`, `errors.As`) are pre-existing and untouched by this diff.

**DevNet was not run** — Docker was unavailable on the machine this was developed on, so it needs a run on a Docker-capable host before merge. Mitigating analysis: the predicate's result is identical to the old one for every network DevNet exercises (devnet magic 42 → false before and after; musashi → true before and after), and the `skipDijkstraTxValidation` extraction is a literally identical boolean expression. The only behavioral delta is the startup rejection of conflicting identities.

## Docs

- `ARCHITECTURE.md` — new "Musashi prototype profile boundary" section under Configuration, carrying the operational warning, the scope of each bypass, and both misconfiguration directions; TOC updated.
- `DATABASE.md` — checked, not affected; no storage, schema, encoding, or query-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down Musashi-only validation bypasses and reject mixed network identities at startup so preview/preprod/mainnet can’t run with prototype trust rules. Dijkstra validation failures are trusted on all profiles; the bypass only skips running those rules for Dijkstra, and the startup error now names the configured network and magic.

- **Bug Fixes**
  - Gate the leader stake-threshold and Dijkstra tx-validation bypasses behind `prototypeTrustBypassesEnabled` (requires an unambiguous Musashi identity) in both Run and `node_lifecycle.go`.
  - Reject Musashi identity conflicts at startup via `Config.Validate` and `Node.configValidate`; the error includes the configured network, magic, and the colliding predefined network.
  - Keep `isMusashiNetwork` for era/mini-protocol selection only.
  - Scope `SkipDijkstraTxValidation` to Dijkstra via `LedgerState.skipDijkstraTxValidation`, and add `LedgerState.trustDijkstraTxValidationError` to state that Dijkstra validation errors are trusted on all profiles.
  - Fix `skipDijkstraTxValidation` doc polarity and expand tests to cover private mirrors (custom name + 164), the `musashi` name with an unregistered magic, and the devnet exclusions (`devnet` + 164, `musashi` + 42).

- **Migration**
  - Startup now fails for mixed identities like `--network preview --network-magic 164` or `--network musashi --network-magic 2`. Use a single, unambiguous identity.
  - Private mirrors (custom name + 164) still work; devnet is excluded. No unsafe override.

<sup>Written for commit f9ec5e0d2fd70fbb2245fe75c2583f8f54a3e4df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

