### PR TITLE
fix(database): keep version on v1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,9 +59,8 @@ fixtures when schema seeding or assertions require raw SQL.
 Startup reserves the write connection, acquires the backend migration lock,
 rejects unversioned metadata tables (users must delete the data directory,
 including metadata and blob stores, and resync), and validates/resumes versioned expand/backfill/contract work before
-advertising readiness. The initial schema release is `v1alpha1` (integer
-migration version 1); subsequent schema work advances the ordered migration
-registry. It then checks the read pool. File-backed SQLite uses a
+advertising readiness. The database schema is currently `v1alpha1` (integer
+migration version 1). It then checks the read pool. File-backed SQLite uses a
 cross-process lock file; isolated in-memory databases use a process lock. A
 failed or interrupted phase leaves readiness false and carries the migration
 version and phase in the returned error. Backfill data and its opaque cursor

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -54,26 +54,9 @@ in the v1alpha1 `utxo_reference_input` association table so multiple
 transactions can reference one output; the legacy single-column marker is not
 used by the new store.
 
-`v2alpha1`, integer version 2, adds
+The v1alpha1 schema also includes
 `idx_pool_opcert_sequence_pool_sequence` (see `pool_opcert_sequence` below).
-It is a separate version rather than an edit to v1 because a completed
-migration's checksum is fixed: changing v1's DDL would make every database
-that had already run it fail startup on checksum drift. Only the initial
-version contains `CREATE TABLE` statements, and MySQL derives its blob-column
-prefix lengths by reading them, so later versions are translated against the
-accumulated schema rather than against their own statements — a version
-indexing a blob column it did not create would otherwise emit a key MySQL
-rejects.
-
-Upgrading to `v2alpha1` builds that index over the whole of
-`pool_opcert_sequence`, which holds one row per block for the life of the chain
-— millions of rows on a synced mainnet database. The build runs inside
-`Store.Start()`, before the store accepts readers or writers, so the first
-start after upgrading stalls for as long as the backend takes to index that
-table, with no incremental progress reported. It is a one-time cost per
-database and is not repeated on later starts. Operators upgrading a large
-mainnet node should expect that pause rather than read it as a hang; a fresh
-database creates the index as part of its initial schema and never sees it.
+It is created as part of the initial schema on fresh databases.
 
 The upgrade runner owns a `schema_migrations` row per contiguous integer version with
 `version`, stable `name`, SHA-256 `checksum`, `phase`, opaque `cursor`, `dirty`,
@@ -523,7 +506,7 @@ PostgreSQL/MySQL repeatable-read read-only transactions.
 | `pool_registration_owner` | `id`, `pool_registration_id`, `pool_id`, `key_hash` | PK `id`; indexes `pool_registration_id`, `pool_id` | Owners for a pool registration. Join `pool_registration_id -> pool_registration.id`; `pool_id -> pool.id`. |
 | `pool_registration_relay` | `id`, `pool_registration_id`, `pool_id`, `ipv4`, `ipv6`, `hostname`, `port` | PK `id`; indexes `pool_registration_id`, `pool_id` | Relay addresses for a pool registration. |
 | `pool_retirement` | `id`, `pool_id`, `pool_key_hash`, `certificate_id`, `epoch`, `added_slot` | PK `id`; indexes `pool_id`, `pool_key_hash`, `certificate_id`, `added_slot` | Pool retirement certificate. Synthetic reconcile retirements written by a Mithril v2 catch-up have `certificate_id = 0` and no `certs` row (`epoch`/`added_slot` are the catch-up tip); joins on `certificate_id` must be LEFT JOINs to keep them visible, and active-pool queries rank them ahead of certificate-backed rows at the same slot. |
-| `pool_opcert_sequence` | `id`, `pool_key_hash`, `slot`, `sequence` | PK `id`; unique `(pool_key_hash, slot)`; index `slot`; index `(pool_key_hash, sequence)` | Observed operational certificate sequence by slot. Read before write inside the block-apply transaction to enforce inbound opcert counter monotonicity; per-slot rows let rollback drop entries past the rollback slot and recompute `pool.latest_op_cert_sequence`. Reward calculation can read the ordered raw issuer rows for an ended epoch and exclude TPraos overlay slots before deriving pool performance. `LatestPoolOpCertSequences` reduces the whole table to one highest `sequence` per `pool_key_hash` (`GROUP BY pool_key_hash`) for the `GetChainDepState` query; because the table is keyed by issuer rather than joined to `pool`, that set includes cold keys whose pool has left the active set, which is what the chain still enforces against. That aggregate has no slot bound available to narrow it — the table takes a row per block minted, is pruned only by rollback, and holds nothing above the tip — so `(pool_key_hash, sequence)` exists to serve it from an index alone: SQLite and PostgreSQL fold it without reading a table row, and MySQL can skip through the index a pool at a time. It is declared by migration `v2alpha1`. The cost is one further index maintained per minted block. |
+| `pool_opcert_sequence` | `id`, `pool_key_hash`, `slot`, `sequence` | PK `id`; unique `(pool_key_hash, slot)`; index `slot`; index `(pool_key_hash, sequence)` | Observed operational certificate sequence by slot. Read before write inside the block-apply transaction to enforce inbound opcert counter monotonicity; per-slot rows let rollback drop entries past the rollback slot and recompute `pool.latest_op_cert_sequence`. Reward calculation can read the ordered raw issuer rows for an ended epoch and exclude TPraos overlay slots before deriving pool performance. `LatestPoolOpCertSequences` reduces the whole table to one highest `sequence` per `pool_key_hash` (`GROUP BY pool_key_hash`) for the `GetChainDepState` query; because the table is keyed by issuer rather than joined to `pool`, that set includes cold keys whose pool has left the active set, which is what the chain still enforces against. That aggregate has no slot bound available to narrow it — the table takes a row per block minted, is pruned only by rollback, and holds nothing above the tip — so `(pool_key_hash, sequence)` exists to serve it from an index alone: SQLite and PostgreSQL fold it without reading a table row, and MySQL can skip through the index a pool at a time. It is declared by migration `v1alpha1`. The cost is one further index maintained per minted block. |
 
 ### DReps, Governance, and Committee
 

--- a/database/models/pool.go
+++ b/database/models/pool.go
@@ -67,7 +67,7 @@ type Pool struct {
 // scan. Worth the write cost for a one-shot query behind
 // `leadership-schedule`; it would not be for something on a hot path.
 //
-// Migration v2 declares it; the schema lives in SQL rather than in tags on this
+// Migration v1 declares it; the schema lives in SQL rather than in tags on this
 // struct.
 type PoolOpCertSequence struct {
 	PoolKeyHash []byte

--- a/database/plugin/metadata/sqlstore/migrations/registry.go
+++ b/database/plugin/metadata/sqlstore/migrations/registry.go
@@ -30,19 +30,15 @@ var migrationSQL embed.FS
 
 const (
 	initialSchemaRelease = "v1alpha1"
-	opCertIndexRelease   = "v2alpha1"
 )
 
-// schemaVersions names every migration in ascending version order. A version
-// with no post-backfill work simply ships no contract.sql; only the initial
-// version needs one on record.
+// schemaVersions names every migration in ascending version order.
 var schemaVersions = []struct {
 	Version int
 	Name    string
 	Dir     string
 }{
 	{Version: 1, Name: initialSchemaRelease, Dir: "v1"},
-	{Version: 2, Name: opCertIndexRelease, Dir: "v2"},
 }
 
 // SQLiteRegistry returns the checked-in SQLite migration registry.

--- a/database/plugin/metadata/sqlstore/migrations/registry_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/registry_test.go
@@ -27,40 +27,11 @@ func TestSQLiteRegistry(t *testing.T) {
 	registry, err := SQLiteRegistry()
 	require.NoError(t, err)
 	require.NoError(t, validateRegistry(registry, "sqlite"))
-	require.Len(t, registry, 2)
+	require.Len(t, registry, 1)
 	require.Equal(t, 1, registry[0].Version)
 	require.Equal(t, "v1alpha1", registry[0].Name)
-	require.GreaterOrEqual(t, len(registry[0].SQL["sqlite"].Expand), 302)
-	require.Equal(t, 2, registry[1].Version)
-	require.Equal(t, "v2alpha1", registry[1].Name)
-	// v2 adds an index and nothing else, so it ships no contract.sql; the
-	// loader has to read that absence as empty rather than as an error.
-	require.Empty(t, registry[1].SQL["sqlite"].Contract)
-}
-
-// TestMySQLTranslationPrefixesBlobIndexAddedByLaterVersion pins the schema
-// context a later migration is translated against.
-//
-// Every CREATE TABLE lives in v1, and MySQL only learns which columns are
-// blobs by reading them. v2 indexes pool_key_hash without creating the table
-// it belongs to, so translating v2 against its own lone statement would leave
-// the prefix length off and MySQL would reject the key. This fails if the
-// registry ever goes back to translating a version in isolation.
-func TestMySQLTranslationPrefixesBlobIndexAddedByLaterVersion(t *testing.T) {
-	t.Parallel()
-	registry, err := MySQLRegistry()
-	require.NoError(t, err)
-	require.Len(t, registry, 2)
-
-	statements := registry[1].SQL["mysql"].Expand
-	require.Len(t, statements, 1)
-	require.Contains(t, statements[0], "`pool_key_hash`(255)")
-	// The prefix belongs to the blob column alone; an integer column given one
-	// would be a different error in the same place.
-	require.Contains(t, statements[0], "`sequence`)")
-	// MySQL has no CREATE INDEX IF NOT EXISTS; re-running is made safe by the
-	// runner's duplicate-object tolerance instead.
-	require.NotContains(t, statements[0], "IF NOT EXISTS")
+	require.GreaterOrEqual(t, len(registry[0].SQL["sqlite"].Expand), 303)
+	require.Contains(t, registry[0].SQL["sqlite"].Expand, "CREATE INDEX IF NOT EXISTS `idx_pool_opcert_sequence_pool_sequence` ON `pool_opcert_sequence`(`pool_key_hash`,`sequence`)")
 }
 
 func TestMySQLSchemaTranslationPrefixesBlobIndexes(t *testing.T) {

--- a/database/plugin/metadata/sqlstore/migrations/registry_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/registry_test.go
@@ -34,6 +34,15 @@ func TestSQLiteRegistry(t *testing.T) {
 	require.Contains(t, registry[0].SQL["sqlite"].Expand, "CREATE INDEX IF NOT EXISTS `idx_pool_opcert_sequence_pool_sequence` ON `pool_opcert_sequence`(`pool_key_hash`,`sequence`)")
 }
 
+func TestMySQLRegistryPrefixesPoolOpCertSequenceIndex(t *testing.T) {
+	t.Parallel()
+	registry, err := MySQLRegistry()
+	require.NoError(t, err)
+	require.NoError(t, validateRegistry(registry, "mysql"))
+	require.Len(t, registry, 1)
+	require.Contains(t, registry[0].SQL["mysql"].Expand, "CREATE INDEX `idx_pool_opcert_sequence_pool_sequence` ON `pool_opcert_sequence`(`pool_key_hash`(255),`sequence`)")
+}
+
 func TestMySQLSchemaTranslationPrefixesBlobIndexes(t *testing.T) {
 	expand, err := loadSQL("v1/sqlite/expand.sql")
 	require.NoError(t, err)

--- a/database/plugin/metadata/sqlstore/migrations/v1/sqlite/expand.sql
+++ b/database/plugin/metadata/sqlstore/migrations/v1/sqlite/expand.sql
@@ -180,6 +180,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS `idx_pool_pool_key_hash` ON `pool`(`pool_key_h
 CREATE TABLE IF NOT EXISTS `pool_opcert_sequence` (`pool_key_hash` blob,`id` integer PRIMARY KEY AUTOINCREMENT,`slot` integer,`sequence` integer);
 CREATE INDEX IF NOT EXISTS `idx_pool_opcert_sequence_slot` ON `pool_opcert_sequence`(`slot`);
 CREATE UNIQUE INDEX IF NOT EXISTS `idx_pool_opcert_sequence_pool_slot` ON `pool_opcert_sequence`(`pool_key_hash`,`slot`);
+CREATE INDEX IF NOT EXISTS `idx_pool_opcert_sequence_pool_sequence` ON `pool_opcert_sequence`(`pool_key_hash`,`sequence`);
 CREATE TABLE IF NOT EXISTS `pool_registration` (`margin` text,`metadata_url` text,`vrf_key_hash` blob,`pool_key_hash` blob,`reward_account` blob,`reward_account_credential_tag` integer NOT NULL DEFAULT 0,`metadata_hash` blob,`pledge` text,`cost` text,`certificate_id` integer,`id` integer PRIMARY KEY AUTOINCREMENT,`pool_id` integer,`added_slot` integer,`deposit_amount` text,CONSTRAINT `fk_pool_registration` FOREIGN KEY (`pool_id`) REFERENCES `pool`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX IF NOT EXISTS `idx_pool_reg_pool_slot` ON `pool_registration`(`pool_id`,`added_slot`);
 CREATE INDEX IF NOT EXISTS `idx_pool_registration_certificate_id` ON `pool_registration`(`certificate_id`);

--- a/database/plugin/metadata/sqlstore/migrations/v2/sqlite/expand.sql
+++ b/database/plugin/metadata/sqlstore/migrations/v2/sqlite/expand.sql
@@ -1,4 +1,0 @@
--- Version 2 (v2alpha1) adds the covering index behind GetChainDepState's
--- operational-certificate counters.
--- This file is immutable after release; changes are detected by its checksum.
-CREATE INDEX IF NOT EXISTS `idx_pool_opcert_sequence_pool_sequence` ON `pool_opcert_sequence`(`pool_key_hash`,`sequence`);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the database schema at `v1alpha1` until 0.69.0 and fold the `pool_opcert_sequence` covering index into v1 expand for SQLite and MySQL. Fresh databases get the index; existing v1 databases stay unchanged for now.

- **Refactors**
  - Removed `v2alpha1` from the migration registry and deleted its SQLite SQL file.
  - Added `idx_pool_opcert_sequence_pool_sequence` to `v1/sqlite/expand.sql`; MySQL translation includes the `pool_key_hash`(255) prefix.
  - Updated `ARCHITECTURE.md` and `DATABASE.md` to reflect `v1alpha1` and the index declared in v1.
  - Updated tests to expect a single v1 migration and assert the index is present in v1 expand for SQLite and MySQL.

<sup>Written for commit 020cbb0fc39a2dc02b07e1140f0c06c79a4f8c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected database schema documentation to reflect the current initial migration version.
  - Ensured newly created SQLite databases include the pool operation certificate sequence index.
  - Removed outdated migration references and descriptions.

- **Documentation**
  - Updated architecture and database documentation to accurately describe schema and index availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->