### PR TITLE
fix(mithril): require HTTPS for aggregator and snapshot artifact URLs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2716,6 +2716,20 @@ Both backends produce the same `BootstrapResult` (immutable directory,
 ancillary ledger-state directory, synthesized snapshot metadata), so
 everything downstream of `Bootstrap()` is backend-agnostic.
 
+Transport security is a separate boundary from the certificate/ancillary
+authentication above and covers both backends uniformly: the configured
+aggregator URL (`client.go`'s `Client.doGet`) and every snapshot/ancillary
+artifact location the aggregator returns (`download.go`'s
+`DownloadConfig.Validate`) must use HTTPS, checked before the first request
+of each — not just on redirects, where `httpsOnlyRedirect` already blocked
+a downgrade target. An aggregator response can put a plaintext URL in the
+first hop itself, so redirect policy alone doesn't cover it.
+`Mithril.AllowInsecureHTTP` (`--mithril-allow-insecure-http`,
+`DINGO_MITHRIL_ALLOW_INSECURE_HTTP`) is the explicit, default-off escape
+hatch for local development and tests against a plaintext aggregator; it
+threads from config through `SyncConfig`/`BootstrapConfig` down to both
+checks and must not be set in production.
+
 ### Catch-up vs bootstrap dispatch
 
 `mithril.Sync` (the `dingo mithril sync` entry point) selects what to do from

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -67,6 +67,15 @@ func resolveAggregatorURL(
 	return url, nil
 }
 
+// mithrilClientOptions builds the mithril.ClientOption set implied by
+// config, currently just the insecure-HTTP escape hatch.
+func mithrilClientOptions(cfg *config.Config) []mithril.ClientOption {
+	if cfg.Mithril.AllowInsecureHTTP {
+		return []mithril.ClientOption{mithril.WithAllowInsecureHTTP()}
+	}
+	return nil
+}
+
 // resolveMithrilBackend normalizes the configured Mithril artifact
 // backend, applying the node default (v2) when unset. The accepted set
 // comes from mithril.AcceptedBackends so a backend added there is
@@ -114,7 +123,9 @@ func mithrilListCommand() *cobra.Command {
 				return err
 			}
 
-			client := mithril.NewClient(aggregatorURL)
+			client := mithril.NewClient(
+				aggregatorURL, mithrilClientOptions(cfg)...,
+			)
 			if backend == mithril.BackendV2 {
 				return runMithrilListV2(cmd.Context(), client)
 			}
@@ -235,7 +246,9 @@ func mithrilShowCommand() *cobra.Command {
 				return err
 			}
 
-			client := mithril.NewClient(aggregatorURL)
+			client := mithril.NewClient(
+				aggregatorURL, mithrilClientOptions(cfg)...,
+			)
 			if backend == mithril.BackendV2 {
 				return runMithrilShowV2(
 					cmd.Context(), client, args[0],
@@ -559,6 +572,7 @@ func runMithrilSync(
 		CardanoConfigPath:      cfg.CardanoConfig,
 		Backend:                backend,
 		AggregatorURL:          cfg.Mithril.AggregatorURL,
+		AllowInsecureHTTP:      cfg.Mithril.AllowInsecureHTTP,
 		DownloadDir:            cfg.Mithril.DownloadDir,
 		DownloadIdleTimeout:    cfg.Mithril.DownloadIdleTimeout,
 		DownloadMaxIdleRetries: cfg.Mithril.DownloadMaxIdleRetries,

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -513,6 +513,11 @@ mithril:
   # Override aggregator URL (auto-detected from network if empty)
   # Supported networks: mainnet, preprod, preview
   aggregatorUrl: ""
+  # Allow the aggregator URL and snapshot artifact locations to use plain
+  # HTTP instead of HTTPS. Default: false. This is an explicit escape
+  # hatch for local development and tests against a plaintext aggregator;
+  # do not enable it in production.
+  allowInsecureHttp: false
   # Mithril artifact backend: "v2" (default) restores from incremental
   # per-immutable-file archives verified against the certified merkle
   # root; "v1" uses the legacy full snapshot tarballs (being phased

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -798,6 +798,12 @@ type MithrilConfig struct {
 	// AggregatorURL overrides the default aggregator URL for the network.
 	// If empty, the URL is auto-detected from the configured network.
 	AggregatorURL string `yaml:"aggregatorUrl"          envconfig:"DINGO_MITHRIL_AGGREGATOR_URL"`
+	// AllowInsecureHTTP permits AggregatorURL and the snapshot artifact
+	// locations the aggregator returns to use plain HTTP instead of
+	// HTTPS. Defaults to false; this is an explicit escape hatch for
+	// local development and tests against a plaintext aggregator and
+	// should not be enabled in production.
+	AllowInsecureHTTP bool `yaml:"allowInsecureHttp"      envconfig:"DINGO_MITHRIL_ALLOW_INSECURE_HTTP"`
 	// Backend selects the Mithril artifact backend: "v2" (default) uses
 	// incremental Cardano database artifacts; "v1" uses the legacy full
 	// snapshot archives, which upstream Mithril is phasing out.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -640,6 +640,11 @@ var flagSpecs = []flagSpec{
 		"mithril-verify-certs",
 		"verify Mithril certificate chains",
 	),
+	boolFlag(
+		"Mithril.AllowInsecureHTTP",
+		"mithril-allow-insecure-http",
+		"allow plain-HTTP Mithril aggregator/artifact URLs (local dev/test only)",
+	),
 
 	// Database lifecycle (snapshot/restore/truncate)
 	boolFlag(

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -62,6 +62,11 @@ type BootstrapConfig struct {
 	// AggregatorURL overrides the default aggregator URL for the
 	// network. If empty, the default URL for the network is used.
 	AggregatorURL string
+	// AllowInsecureHTTP permits AggregatorURL and snapshot artifact
+	// locations to use plain HTTP instead of HTTPS. Defaults to false;
+	// this is an explicit escape hatch for local development and tests
+	// and should not be set in production.
+	AllowInsecureHTTP bool
 	// DownloadDir is the directory where the snapshot archive will
 	// be downloaded. If empty, a temporary directory is created.
 	DownloadDir string
@@ -252,7 +257,7 @@ func Bootstrap(
 	}
 
 	// Step 1: Fetch latest snapshot
-	client := NewClient(aggregatorURL)
+	client := newMithrilClient(aggregatorURL, cfg.AllowInsecureHTTP)
 	snapshot, err := client.GetLatestSnapshot(ctx)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -443,6 +448,7 @@ func Bootstrap(
 					IdleTimeout:         cfg.DownloadIdleTimeout,
 					MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 					MaxTransientRetries: cfg.DownloadMaxTransientRetries,
+					AllowInsecureHTTP:   cfg.AllowInsecureHTTP,
 				},
 			)
 			if dlErr == nil {
@@ -630,6 +636,7 @@ func downloadAncillary(
 				IdleTimeout:         cfg.DownloadIdleTimeout,
 				MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 				MaxTransientRetries: cfg.DownloadMaxTransientRetries,
+				AllowInsecureHTTP:   cfg.AllowInsecureHTTP,
 			},
 		)
 		if err == nil {

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -152,11 +152,12 @@ func TestBootstrap(t *testing.T) {
 
 	var progressCalled atomic.Int32
 	result, err := Bootstrap(context.Background(), BootstrapConfig{
-		Network:          "preprod",
-		Backend:          BackendV1,
-		AggregatorURL:    server.URL,
-		DownloadDir:      downloadDir,
-		CleanupAfterLoad: true,
+		Network:           "preprod",
+		Backend:           BackendV1,
+		AggregatorURL:     server.URL,
+		AllowInsecureHTTP: true,
+		DownloadDir:       downloadDir,
+		CleanupAfterLoad:  true,
 		OnProgress: func(p DownloadProgress) {
 			progressCalled.Add(1)
 		},
@@ -227,10 +228,11 @@ func TestBootstrapUsesDigestSpecificExtractDir(t *testing.T) {
 	)
 
 	result, err := Bootstrap(context.Background(), BootstrapConfig{
-		Network:       "preprod",
-		Backend:       BackendV1,
-		AggregatorURL: server.URL,
-		DownloadDir:   downloadDir,
+		Network:           "preprod",
+		Backend:           BackendV1,
+		AggregatorURL:     server.URL,
+		AllowInsecureHTTP: true,
+		DownloadDir:       downloadDir,
 	})
 	require.NoError(t, err)
 	require.Equal(
@@ -266,6 +268,7 @@ func TestBootstrapCertVerifyNoCertHash(t *testing.T) {
 		Network:                "preprod",
 		Backend:                BackendV1,
 		AggregatorURL:          server.URL,
+		AllowInsecureHTTP:      true,
 		VerifyCertificateChain: true,
 	})
 	require.Error(t, err)
@@ -282,9 +285,10 @@ func TestBootstrapNoSnapshots(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	_, err := Bootstrap(context.Background(), BootstrapConfig{
-		Network:       "preprod",
-		Backend:       BackendV1,
-		AggregatorURL: server.URL,
+		Network:           "preprod",
+		Backend:           BackendV1,
+		AggregatorURL:     server.URL,
+		AllowInsecureHTTP: true,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no snapshots available")
@@ -313,9 +317,10 @@ func TestBootstrapNoLocations(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	_, err := Bootstrap(context.Background(), BootstrapConfig{
-		Network:       "preprod",
-		Backend:       BackendV1,
-		AggregatorURL: server.URL,
+		Network:           "preprod",
+		Backend:           BackendV1,
+		AggregatorURL:     server.URL,
+		AllowInsecureHTTP: true,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no download locations")
@@ -593,7 +598,7 @@ func TestVerifyCertificateChainAllowsDeepChains(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -659,7 +664,7 @@ func TestVerifyCertificateChainWithModeSTMRejectsContentHashMismatch(
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	_, err = VerifyCertificateChainWithMode(
 		context.Background(),
 		client,
@@ -752,7 +757,7 @@ func TestVerifyCertificateChainWithModeReturnsDetails(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	result, err := VerifyCertificateChainWithMode(
 		context.Background(),
 		client,
@@ -895,6 +900,7 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 		Network:                "preprod",
 		Backend:                BackendV1,
 		AggregatorURL:          server.URL,
+		AllowInsecureHTTP:      true,
 		VerifyCertificateChain: true,
 	})
 	require.Error(t, err)

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -63,7 +63,7 @@ func bootstrapV2(
 	cfg BootstrapConfig,
 	aggregatorURL string,
 ) (*BootstrapResult, error) {
-	client := NewClient(aggregatorURL)
+	client := newMithrilClient(aggregatorURL, cfg.AllowInsecureHTTP)
 
 	// Step 1: Fetch latest artifact and verify its self-hash
 	artifact, err := client.GetLatestCardanoDatabaseSnapshot(ctx)
@@ -602,6 +602,7 @@ func downloadDigestsArchive(
 			IdleTimeout:         cfg.DownloadIdleTimeout,
 			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 			MaxTransientRetries: cfg.DownloadMaxTransientRetries,
+			AllowInsecureHTTP:   cfg.AllowInsecureHTTP,
 		},
 	)
 	if err != nil {
@@ -974,6 +975,7 @@ func fetchImmutableArchive(
 			IdleTimeout:         cfg.DownloadIdleTimeout,
 			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 			MaxTransientRetries: cfg.DownloadMaxTransientRetries,
+			AllowInsecureHTTP:   cfg.AllowInsecureHTTP,
 		},
 	)
 	if err != nil {
@@ -1103,6 +1105,7 @@ func downloadAncillaryV2(
 				IdleTimeout:         cfg.DownloadIdleTimeout,
 				MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
 				MaxTransientRetries: cfg.DownloadMaxTransientRetries,
+				AllowInsecureHTTP:   cfg.AllowInsecureHTTP,
 			},
 		)
 		if err == nil {

--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -636,6 +636,7 @@ func (f *v2Fixture) bootstrapConfig(downloadDir string) BootstrapConfig {
 		Network:                  "preprod",
 		Backend:                  BackendV2,
 		AggregatorURL:            f.server.URL,
+		AllowInsecureHTTP:        true,
 		DownloadDir:              downloadDir,
 		VerifyCertificateChain:   true,
 		AncillaryVerificationKey: f.ancillaryVKey,
@@ -714,13 +715,14 @@ func TestSyncV2NoCertVerificationUsesExtractDirLedgerState(t *testing.T) {
 		fallbackLedgerState: true,
 	})
 	result, err := Sync(context.Background(), SyncConfig{
-		Network:          "preprod",
-		DataDir:          t.TempDir(),
-		StorageMode:      "core",
-		Backend:          BackendV2,
-		AggregatorURL:    fixture.server.URL,
-		VerifyCertChain:  false,
-		CleanupAfterLoad: false,
+		Network:           "preprod",
+		DataDir:           t.TempDir(),
+		StorageMode:       "core",
+		Backend:           BackendV2,
+		AggregatorURL:     fixture.server.URL,
+		AllowInsecureHTTP: true,
+		VerifyCertChain:   false,
+		CleanupAfterLoad:  false,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1000), result.LedgerSlot)

--- a/mithril/catchup_dispatch_test.go
+++ b/mithril/catchup_dispatch_test.go
@@ -70,14 +70,15 @@ func TestSyncCatchUpDispatch(t *testing.T) {
 		seedCompleteDB(t, dataDir, "core", 5, true)
 
 		res, err := Sync(context.Background(), SyncConfig{
-			Network:         "preview",
-			DataDir:         dataDir,
-			StorageMode:     "core",
-			Backend:         BackendV2,
-			AggregatorURL:   fix.server.URL,
-			StoragePlugins:  testStoragePlugins(),
-			DatabaseWorkers: 1,
-			Logger:          discard,
+			Network:           "preview",
+			DataDir:           dataDir,
+			StorageMode:       "core",
+			Backend:           BackendV2,
+			AggregatorURL:     fix.server.URL,
+			AllowInsecureHTTP: true,
+			StoragePlugins:    testStoragePlugins(),
+			DatabaseWorkers:   1,
+			Logger:            discard,
 		})
 		require.NoError(t, err)
 		require.Nil(t, res.Snapshot, "up-to-date catch-up should not sync")
@@ -148,7 +149,7 @@ func TestDecideCatchUp(t *testing.T) {
 		mode := modeOf(t)
 		require.Equal(t, syncModeBootstrap, mode)
 		dec, err := decideCatchUp(
-			ctx, db, mode, BackendV2, "core", noAggregator, discard,
+			ctx, db, mode, BackendV2, "core", noAggregator, true, discard,
 		)
 		require.NoError(t, err)
 		require.False(t, dec.engage)
@@ -171,7 +172,7 @@ func TestDecideCatchUp(t *testing.T) {
 			mode := modeOf(t)
 			require.Equal(t, syncModeCatchUp, mode)
 			dec, err := decideCatchUp(
-				ctx, db, mode, BackendV2, "core", noAggregator, discard,
+				ctx, db, mode, BackendV2, "core", noAggregator, true, discard,
 			)
 			require.NoError(t, err)
 			require.True(t, dec.engage,
@@ -184,7 +185,14 @@ func TestDecideCatchUp(t *testing.T) {
 		func(t *testing.T) {
 			setState(t, "", 0, false)
 			dec, err := decideCatchUp(
-				ctx, db, modeOf(t), BackendV2, "api", noAggregator, discard,
+				ctx,
+				db,
+				modeOf(t),
+				BackendV2,
+				"api",
+				noAggregator,
+				true,
+				discard,
 			)
 			require.NoError(t, err)
 			require.False(t, dec.engage)
@@ -194,7 +202,7 @@ func TestDecideCatchUp(t *testing.T) {
 	t.Run("v1 backend never engages", func(t *testing.T) {
 		setState(t, "", 2, true)
 		dec, err := decideCatchUp(
-			ctx, db, modeOf(t), BackendV1, "core", noAggregator, discard,
+			ctx, db, modeOf(t), BackendV1, "core", noAggregator, true, discard,
 		)
 		require.NoError(t, err)
 		require.False(t, dec.engage)
@@ -207,7 +215,7 @@ func TestDecideCatchUp(t *testing.T) {
 			setState(t, "", 2, true)
 			dec, err := decideCatchUp(
 				ctx, db, modeOf(t), BackendV2, "core", fix.server.URL,
-				discard,
+				true, discard,
 			)
 			require.NoError(t, err)
 			require.True(t, dec.engage)
@@ -218,7 +226,14 @@ func TestDecideCatchUp(t *testing.T) {
 		fix := newV2Fixture(t, v2FixtureOptions{immutableFileNumber: 5})
 		setState(t, "", 5, true)
 		dec, err := decideCatchUp(
-			ctx, db, modeOf(t), BackendV2, "core", fix.server.URL, discard,
+			ctx,
+			db,
+			modeOf(t),
+			BackendV2,
+			"core",
+			fix.server.URL,
+			true,
+			discard,
 		)
 		require.NoError(t, err)
 		require.False(t, dec.engage)
@@ -229,7 +244,7 @@ func TestDecideCatchUp(t *testing.T) {
 		fix := newV2Fixture(t, v2FixtureOptions{immutableFileNumber: 5})
 		setState(t, "", 1, true)
 		_, err := decideCatchUp(
-			ctx, db, modeOf(t), BackendV2, "api", fix.server.URL, discard,
+			ctx, db, modeOf(t), BackendV2, "api", fix.server.URL, true, discard,
 		)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "core storage mode only")
@@ -241,7 +256,7 @@ func TestDecideCatchUp(t *testing.T) {
 			mode := modeOf(t)
 			require.Equal(t, syncModeResume, mode)
 			dec, err := decideCatchUp(
-				ctx, db, mode, BackendV2, "core", noAggregator, discard,
+				ctx, db, mode, BackendV2, "core", noAggregator, true, discard,
 			)
 			require.NoError(t, err)
 			require.True(t, dec.engage,
@@ -253,7 +268,14 @@ func TestDecideCatchUp(t *testing.T) {
 		func(t *testing.T) {
 			setState(t, syncStatusInProgress, 7, true)
 			dec, err := decideCatchUp(
-				ctx, db, modeOf(t), BackendV2, "api", noAggregator, discard,
+				ctx,
+				db,
+				modeOf(t),
+				BackendV2,
+				"api",
+				noAggregator,
+				true,
+				discard,
 			)
 			require.NoError(t, err)
 			require.False(t, dec.engage)
@@ -264,7 +286,14 @@ func TestDecideCatchUp(t *testing.T) {
 		func(t *testing.T) {
 			setState(t, syncStatusInProgress, 0, false)
 			dec, err := decideCatchUp(
-				ctx, db, modeOf(t), BackendV2, "core", noAggregator, discard,
+				ctx,
+				db,
+				modeOf(t),
+				BackendV2,
+				"core",
+				noAggregator,
+				true,
+				discard,
 			)
 			require.NoError(t, err)
 			require.False(t, dec.engage)
@@ -278,7 +307,14 @@ func TestDecideCatchUp(t *testing.T) {
 			setState(t, syncStatusInProgress, 0, false)
 			require.NoError(t, setCatchUpActive(db))
 			dec, err := decideCatchUp(
-				ctx, db, modeOf(t), BackendV2, "core", noAggregator, discard,
+				ctx,
+				db,
+				modeOf(t),
+				BackendV2,
+				"core",
+				noAggregator,
+				true,
+				discard,
 			)
 			require.NoError(t, err)
 			require.True(t, dec.engage,

--- a/mithril/client.go
+++ b/mithril/client.go
@@ -729,6 +729,9 @@ func requireSecureURL(
 	if err != nil {
 		return fmt.Errorf("parsing %s %q: %w", label, rawURL, err)
 	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("parsing %s %q: URL must include a host", label, rawURL)
+	}
 	switch parsed.Scheme {
 	case "https":
 		return nil

--- a/mithril/client.go
+++ b/mithril/client.go
@@ -633,12 +633,24 @@ func AncillaryVerificationKeyURLForNetwork(network string) (string, error) {
 
 // Client is an HTTP client for the Mithril aggregator REST API.
 type Client struct {
-	aggregatorURL string
-	httpClient    *http.Client
+	aggregatorURL     string
+	httpClient        *http.Client
+	allowInsecureHTTP bool
 }
 
 // ClientOption is a functional option for configuring a Client.
 type ClientOption func(*Client)
+
+// WithAllowInsecureHTTP permits the client to send requests to a
+// plain-HTTP aggregator URL. By default, NewClient's aggregatorURL
+// and every request it issues must use HTTPS; this is an explicit
+// escape hatch for local development and tests (e.g. against an
+// httptest server) and should not be set in production.
+func WithAllowInsecureHTTP() ClientOption {
+	return func(c *Client) {
+		c.allowInsecureHTTP = true
+	}
+}
 
 // WithHTTPClient sets a custom *http.Client for the Mithril client.
 // Note: the default client enforces HTTPS-only redirects via
@@ -672,6 +684,17 @@ func NewClient(
 	return c
 }
 
+// newMithrilClient constructs a Client, applying WithAllowInsecureHTTP
+// when allowInsecureHTTP is set. It centralizes the option plumbing
+// shared by every BootstrapConfig/SyncConfig call site so callers don't
+// each re-derive a ClientOption slice from a bool.
+func newMithrilClient(aggregatorURL string, allowInsecureHTTP bool) *Client {
+	if allowInsecureHTTP {
+		return NewClient(aggregatorURL, WithAllowInsecureHTTP())
+	}
+	return NewClient(aggregatorURL)
+}
+
 // httpsOnlyRedirect rejects redirects to non-HTTPS URLs to prevent
 // downgrade attacks and SSRF.
 func httpsOnlyRedirect(
@@ -685,6 +708,34 @@ func httpsOnlyRedirect(
 		return fmt.Errorf(
 			"redirect to non-HTTPS URL blocked: %s",
 			req.URL,
+		)
+	}
+	return nil
+}
+
+// requireSecureURL rejects a non-HTTPS rawURL unless allowInsecureHTTP
+// is set. It complements httpsOnlyRedirect: that guards where a redirect
+// may lead, this guards the initial request, which a redirect policy
+// never sees. label identifies the URL's role (e.g. "mithril aggregator
+// URL") in the returned error.
+func requireSecureURL(
+	rawURL string,
+	label string,
+	allowInsecureHTTP bool,
+) error {
+	if allowInsecureHTTP {
+		return nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parsing %s %q: %w", label, rawURL, err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf(
+			"%s %q must use https; set an explicit allow-insecure-http "+
+				"option for local development or tests",
+			label,
+			rawURL,
 		)
 	}
 	return nil
@@ -910,6 +961,9 @@ func (c *Client) doGet(
 	ctx context.Context,
 	reqURL string,
 ) (io.ReadCloser, error) {
+	if err := requireSecureURL(reqURL, "mithril aggregator URL", c.allowInsecureHTTP); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,

--- a/mithril/client.go
+++ b/mithril/client.go
@@ -713,32 +713,36 @@ func httpsOnlyRedirect(
 	return nil
 }
 
-// requireSecureURL rejects a non-HTTPS rawURL unless allowInsecureHTTP
-// is set. It complements httpsOnlyRedirect: that guards where a redirect
-// may lead, this guards the initial request, which a redirect policy
-// never sees. label identifies the URL's role (e.g. "mithril aggregator
-// URL") in the returned error.
+// requireSecureURL rejects a non-HTTPS rawURL. allowInsecureHTTP widens
+// that to also accept http, and only http — a malformed URL or any
+// other scheme is always rejected, escape hatch or not. It complements
+// httpsOnlyRedirect: that guards where a redirect may lead, this guards
+// the initial request, which a redirect policy never sees. label
+// identifies the URL's role (e.g. "mithril aggregator URL") in the
+// returned error.
 func requireSecureURL(
 	rawURL string,
 	label string,
 	allowInsecureHTTP bool,
 ) error {
-	if allowInsecureHTTP {
-		return nil
-	}
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("parsing %s %q: %w", label, rawURL, err)
 	}
-	if parsed.Scheme != "https" {
-		return fmt.Errorf(
-			"%s %q must use https; set an explicit allow-insecure-http "+
-				"option for local development or tests",
-			label,
-			rawURL,
-		)
+	switch parsed.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if allowInsecureHTTP {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf(
+		"%s %q must use https; set an explicit allow-insecure-http "+
+			"option for local development or tests",
+		label,
+		rawURL,
+	)
 }
 
 // ListSnapshots retrieves the list of available snapshots from the

--- a/mithril/client_test.go
+++ b/mithril/client_test.go
@@ -815,6 +815,24 @@ func TestRequireSecureURL(t *testing.T) {
 			rawURL:  "://not-a-url",
 			wantErr: true,
 		},
+		{
+			name:              "malformed URL rejected even with escape hatch",
+			rawURL:            "://not-a-url",
+			allowInsecureHTTP: true,
+			wantErr:           true,
+		},
+		{
+			name:    "non-http(s) scheme rejected by default",
+			rawURL:  "ftp://aggregator.example.com/aggregator",
+			wantErr: true,
+		},
+		{
+			name: "non-http(s) scheme rejected even with escape hatch " +
+				"(it widens to http, not to any scheme)",
+			rawURL:            "ftp://aggregator.example.com/aggregator",
+			allowInsecureHTTP: true,
+			wantErr:           true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/mithril/client_test.go
+++ b/mithril/client_test.go
@@ -833,6 +833,17 @@ func TestRequireSecureURL(t *testing.T) {
 			allowInsecureHTTP: true,
 			wantErr:           true,
 		},
+		{
+			name:    "https URL with no host rejected",
+			rawURL:  "https:///aggregator",
+			wantErr: true,
+		},
+		{
+			name:              "https URL with no host rejected even with escape hatch",
+			rawURL:            "https:///aggregator",
+			allowInsecureHTTP: true,
+			wantErr:           true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/mithril/client_test.go
+++ b/mithril/client_test.go
@@ -102,7 +102,7 @@ func TestListSnapshots(t *testing.T) {
 		}
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	snapshots, err := client.ListSnapshots(context.Background())
 	require.NoError(t, err)
 	require.Len(t, snapshots, 1)
@@ -159,7 +159,7 @@ func TestGetSnapshot(t *testing.T) {
 		}
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	snapshot, err := client.GetSnapshot(
 		context.Background(),
 		"abc123def456",
@@ -220,7 +220,7 @@ func TestGetCertificate(t *testing.T) {
 		}
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	cert, err := client.GetCertificate(
 		context.Background(),
 		"certhash123",
@@ -262,7 +262,7 @@ func TestGetCertificateGenesis(t *testing.T) {
 		}
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	cert, err := client.GetCertificate(
 		context.Background(),
 		"genesis_cert_hash",
@@ -311,7 +311,7 @@ func TestGetLatestSnapshot(t *testing.T) {
 		}
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	latest, err := client.GetLatestSnapshot(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, latest)
@@ -326,7 +326,7 @@ func TestGetLatestSnapshotEmpty(t *testing.T) {
 		}
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	_, err := client.GetLatestSnapshot(context.Background())
 	require.ErrorIs(t, err, ErrNoSnapshotsAvailable)
 	require.Contains(t, err.Error(), "no snapshots available")
@@ -351,7 +351,7 @@ func TestListMithrilStakeDistributions(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(expected)
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	ret, err := client.ListMithrilStakeDistributions(context.Background())
 	require.NoError(t, err)
 	require.Len(t, ret, 1)
@@ -378,7 +378,7 @@ func TestGetMithrilStakeDistribution(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(expected)
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	ret, err := client.GetMithrilStakeDistribution(
 		context.Background(),
 		"msd123",
@@ -408,7 +408,7 @@ func TestListCardanoStakeDistributions(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(expected)
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	ret, err := client.ListCardanoStakeDistributions(context.Background())
 	require.NoError(t, err)
 	require.Len(t, ret, 1)
@@ -435,7 +435,7 @@ func TestGetCardanoStakeDistribution(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(expected)
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	ret, err := client.GetCardanoStakeDistribution(
 		context.Background(),
 		"csd123",
@@ -451,7 +451,7 @@ func TestClientErrorHandling(t *testing.T) {
 		http.Error(w, "not found", http.StatusNotFound)
 	})
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 
 	_, err := client.ListSnapshots(context.Background())
 	require.Error(t, err)
@@ -483,7 +483,7 @@ func TestClientContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	_, err := client.ListSnapshots(ctx)
 	require.Error(t, err)
 }
@@ -778,6 +778,95 @@ func TestWithHTTPClient(t *testing.T) {
 	require.Equal(t, customClient, client.httpClient)
 }
 
+// TestRequireSecureURL covers requireSecureURL directly: HTTPS is always
+// accepted, HTTP is rejected unless allowInsecureHTTP is set, and a
+// malformed URL is rejected regardless (DSA-2026-04-24-03).
+func TestRequireSecureURL(t *testing.T) {
+	tests := []struct {
+		name              string
+		rawURL            string
+		allowInsecureHTTP bool
+		wantErr           bool
+	}{
+		{
+			name:    "https accepted",
+			rawURL:  "https://aggregator.example.com/aggregator",
+			wantErr: false,
+		},
+		{
+			name:    "http rejected by default",
+			rawURL:  "http://aggregator.example.com/aggregator",
+			wantErr: true,
+		},
+		{
+			name:              "http accepted with escape hatch",
+			rawURL:            "http://aggregator.example.com/aggregator",
+			allowInsecureHTTP: true,
+			wantErr:           false,
+		},
+		{
+			name:              "https still accepted with escape hatch set",
+			rawURL:            "https://aggregator.example.com/aggregator",
+			allowInsecureHTTP: true,
+			wantErr:           false,
+		},
+		{
+			name:    "malformed URL rejected",
+			rawURL:  "://not-a-url",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireSecureURL(
+				tt.rawURL, "test URL", tt.allowInsecureHTTP,
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestClientRejectsPlainHTTPAggregatorByDefault proves the client refuses
+// to send a request to a plain-HTTP aggregator unless the caller opts in
+// via WithAllowInsecureHTTP (DSA-2026-04-24-03): a request must be
+// rejected before it ever reaches redirect handling, since a downgrade or
+// SSRF target can be the first hop, not just a subsequent redirect.
+func TestClientRejectsPlainHTTPAggregatorByDefault(t *testing.T) {
+	called := false
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	client := NewClient(server.URL)
+	_, err := client.ListSnapshots(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must use https")
+	require.False(
+		t,
+		called,
+		"no request should reach a rejected plain-HTTP aggregator",
+	)
+}
+
+// TestClientAllowsPlainHTTPAggregatorWithEscapeHatch proves
+// WithAllowInsecureHTTP is a working, explicit escape hatch for local
+// development and tests against a plaintext aggregator.
+func TestClientAllowsPlainHTTPAggregatorWithEscapeHatch(t *testing.T) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]SnapshotListItem{})
+	})
+
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
+	_, err := client.ListSnapshots(context.Background())
+	require.NoError(t, err)
+}
+
 func TestVerifyCertChainGenesis(t *testing.T) {
 	cert := Certificate{
 		Epoch:            0,
@@ -807,7 +896,7 @@ func TestVerifyCertChainGenesis(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -899,7 +988,7 @@ func TestVerifyCertChainThreeDeep(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -956,7 +1045,7 @@ func TestVerifyCertChainMissingCert(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -999,7 +1088,7 @@ func TestVerifyCertChainEmptyPreviousHash(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -1074,7 +1163,7 @@ func TestVerifyCertChainDigestMismatch(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -1149,7 +1238,7 @@ func TestVerifyCertChainDigestMatch(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -1222,7 +1311,7 @@ func TestVerifyCertChainRejectsStaleHashCrossReferences(t *testing.T) {
 	)
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, WithAllowInsecureHTTP())
 	err := VerifyCertificateChain(
 		context.Background(),
 		client,
@@ -1490,6 +1579,7 @@ func TestBootstrapWithCertVerification(t *testing.T) {
 			Network:                "preprod",
 			Backend:                BackendV1,
 			AggregatorURL:          server.URL,
+			AllowInsecureHTTP:      true,
 			DownloadDir:            downloadDir,
 			GenesisVerificationKey: genesisKeyText,
 			VerifyCertificateChain: true,

--- a/mithril/client_v2_test.go
+++ b/mithril/client_v2_test.go
@@ -181,7 +181,7 @@ func TestGetLatestCardanoDatabaseSnapshot(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	client := NewClient(srv.URL)
+	client := NewClient(srv.URL, WithAllowInsecureHTTP())
 	snapshot, err := client.GetLatestCardanoDatabaseSnapshot(
 		context.Background(),
 	)
@@ -202,7 +202,7 @@ func TestGetLatestCardanoDatabaseSnapshotEmpty(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	client := NewClient(srv.URL)
+	client := NewClient(srv.URL, WithAllowInsecureHTTP())
 	_, err := client.GetLatestCardanoDatabaseSnapshot(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no Cardano database snapshots")
@@ -223,7 +223,7 @@ func TestGetCardanoDatabaseDigests(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	client := NewClient(srv.URL)
+	client := NewClient(srv.URL, WithAllowInsecureHTTP())
 	entries, err := client.GetCardanoDatabaseDigests(context.Background())
 	require.NoError(t, err)
 	require.Len(t, entries, 2)

--- a/mithril/download.go
+++ b/mithril/download.go
@@ -117,6 +117,11 @@ type DownloadConfig struct {
 	// connections are pooled across files. When nil, a per-call client
 	// with keep-alives disabled is used (single-archive downloads).
 	HTTPClient *http.Client
+	// AllowInsecureHTTP permits URL to use plain HTTP instead of HTTPS.
+	// By default, Validate rejects a non-HTTPS URL; this is an explicit
+	// escape hatch for local development and tests (e.g. against an
+	// httptest server) and should not be set in production.
+	AllowInsecureHTTP bool
 }
 
 // Validate checks DownloadConfig values before use.
@@ -126,6 +131,11 @@ func (cfg DownloadConfig) Validate() error {
 			"download config MaxIdleRetries must be >= 0, got %d",
 			cfg.MaxIdleRetries,
 		)
+	}
+	if cfg.URL != "" {
+		if err := requireSecureURL(cfg.URL, "download URL", cfg.AllowInsecureHTTP); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -50,9 +50,10 @@ func TestDownloadSnapshot(t *testing.T) {
 	var progressCalled atomic.Int32
 
 	path, err := DownloadSnapshot(context.Background(), DownloadConfig{
-		URL:      server.URL + "/snapshot.tar.zst",
-		DestDir:  destDir,
-		Filename: "test-snapshot.tar.zst",
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           destDir,
+		Filename:          "test-snapshot.tar.zst",
 		OnProgress: func(p DownloadProgress) {
 			progressCalled.Add(1)
 			// Use assert (not require) because this callback
@@ -129,9 +130,10 @@ func TestDownloadSnapshotResume(t *testing.T) {
 	path, err := DownloadSnapshot(
 		context.Background(),
 		DownloadConfig{
-			URL:      server.URL + "/snapshot.tar.zst",
-			DestDir:  destDir,
-			Filename: "resume-test.tar.zst",
+			URL:               server.URL + "/snapshot.tar.zst",
+			AllowInsecureHTTP: true,
+			DestDir:           destDir,
+			Filename:          "resume-test.tar.zst",
 		},
 	)
 	require.NoError(t, err)
@@ -176,12 +178,13 @@ func TestDownloadSnapshotIdleTimeoutRetriesAndResumes(t *testing.T) {
 
 	destDir := t.TempDir()
 	cfg := DownloadConfig{
-		URL:            server.URL + "/snapshot.tar.zst",
-		DestDir:        destDir,
-		Filename:       "idle-retry.tar.zst",
-		ExpectedSize:   int64(len(fullContent)),
-		IdleTimeout:    50 * time.Millisecond,
-		MaxIdleRetries: 1,
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           destDir,
+		Filename:          "idle-retry.tar.zst",
+		ExpectedSize:      int64(len(fullContent)),
+		IdleTimeout:       50 * time.Millisecond,
+		MaxIdleRetries:    1,
 	}
 	timeout := cfg.IdleTimeout*time.Duration(cfg.MaxIdleRetries+1) +
 		500*time.Millisecond
@@ -265,12 +268,13 @@ func TestDownloadSnapshotIdleRetriesResetAfterProgress(t *testing.T) {
 
 	destDir := t.TempDir()
 	cfg := DownloadConfig{
-		URL:            server.URL + "/snapshot.tar.zst",
-		DestDir:        destDir,
-		Filename:       "idle-progress-reset.tar.zst",
-		ExpectedSize:   int64(len(fullContent)),
-		IdleTimeout:    50 * time.Millisecond,
-		MaxIdleRetries: 1,
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           destDir,
+		Filename:          "idle-progress-reset.tar.zst",
+		ExpectedSize:      int64(len(fullContent)),
+		IdleTimeout:       50 * time.Millisecond,
+		MaxIdleRetries:    1,
 	}
 	timeout := 3*cfg.IdleTimeout + 500*time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -320,6 +324,78 @@ func TestDownloadSnapshotRejectsNegativeMaxIdleRetries(t *testing.T) {
 	require.Contains(t, err.Error(), "MaxIdleRetries")
 }
 
+// TestDownloadSnapshotRejectsPlainHTTPByDefault proves a plain-HTTP
+// artifact URL is rejected before any request is attempted
+// (DSA-2026-04-24-03): the aggregator-supplied download location is
+// untrusted, so the scheme is checked up front rather than relying on
+// httpsOnlyRedirect, which only governs where a redirect may lead.
+func TestDownloadSnapshotRejectsPlainHTTPByDefault(t *testing.T) {
+	called := false
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:     server.URL + "/snapshot.tar.zst",
+		DestDir: t.TempDir(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must use https")
+	require.False(
+		t,
+		called,
+		"no request should reach a rejected plain-HTTP URL",
+	)
+}
+
+// TestDownloadSnapshotAllowsPlainHTTPWithEscapeHatch proves
+// DownloadConfig.AllowInsecureHTTP is a working, explicit escape hatch
+// (used throughout this package's own httptest-based tests).
+func TestDownloadSnapshotAllowsPlainHTTPWithEscapeHatch(t *testing.T) {
+	content := []byte("fake-snapshot-data")
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(content)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	path, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           t.TempDir(),
+		Filename:          "insecure-ok.tar.zst",
+	})
+	require.NoError(t, err)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, data)
+}
+
+// TestDownloadSnapshotAcceptsHTTPSByDefault proves a well-formed HTTPS
+// artifact URL passes scheme validation (the connection itself fails
+// against the loopback TLS test server's self-signed certificate, which
+// is expected — the point is that it isn't rejected for its scheme).
+func TestDownloadSnapshotAcceptsHTTPSByDefault(t *testing.T) {
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:     server.URL + "/snapshot.tar.zst",
+		DestDir: t.TempDir(),
+	})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "must use https")
+}
+
 func TestIdleTimeoutReaderStopsTimerBetweenReads(t *testing.T) {
 	idleCh := make(chan struct{}, 1)
 	reader := newIdleTimeoutReader(
@@ -363,8 +439,9 @@ func TestDownloadSnapshotContextCancel(t *testing.T) {
 
 	destDir := t.TempDir()
 	_, err := DownloadSnapshot(ctx, DownloadConfig{
-		URL:     server.URL + "/snapshot.tar.zst",
-		DestDir: destDir,
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           destDir,
 	})
 	require.Error(t, err)
 }
@@ -384,6 +461,7 @@ func TestDownloadSnapshotServerError(t *testing.T) {
 	destDir := t.TempDir()
 	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
 		URL:                 server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP:   true,
 		DestDir:             destDir,
 		MaxTransientRetries: -1, // disable retries so the test stays fast
 	})
@@ -414,6 +492,7 @@ func TestDownloadSnapshotTransientRetrySucceeds(t *testing.T) {
 	destDir := t.TempDir()
 	path, err := DownloadSnapshot(context.Background(), DownloadConfig{
 		URL:                 server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP:   true,
 		DestDir:             destDir,
 		Filename:            "transient-retry.tar.zst",
 		MaxTransientRetries: 2,
@@ -445,6 +524,7 @@ func TestDownloadSnapshotTransientRetryExhausted(t *testing.T) {
 	destDir := t.TempDir()
 	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
 		URL:                 server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP:   true,
 		DestDir:             destDir,
 		MaxTransientRetries: 2,
 	})
@@ -525,10 +605,11 @@ func TestDownloadSnapshotSizeVerification(t *testing.T) {
 	path, err := DownloadSnapshot(
 		context.Background(),
 		DownloadConfig{
-			URL:          server.URL + "/snapshot.tar.zst",
-			DestDir:      destDir,
-			Filename:     "good.tar.zst",
-			ExpectedSize: int64(len(content)),
+			URL:               server.URL + "/snapshot.tar.zst",
+			AllowInsecureHTTP: true,
+			DestDir:           destDir,
+			Filename:          "good.tar.zst",
+			ExpectedSize:      int64(len(content)),
 		},
 	)
 	require.NoError(t, err)
@@ -554,10 +635,11 @@ func TestDownloadSnapshotSizeMismatch(t *testing.T) {
 	_, err := DownloadSnapshot(
 		context.Background(),
 		DownloadConfig{
-			URL:          server.URL + "/snapshot.tar.zst",
-			DestDir:      destDir,
-			Filename:     "bad.tar.zst",
-			ExpectedSize: 99999,
+			URL:               server.URL + "/snapshot.tar.zst",
+			AllowInsecureHTTP: true,
+			DestDir:           destDir,
+			Filename:          "bad.tar.zst",
+			ExpectedSize:      99999,
 		},
 	)
 	require.Error(t, err)
@@ -574,8 +656,9 @@ func TestDownloadSnapshotDefaultFilename(t *testing.T) {
 
 	destDir := t.TempDir()
 	path, err := DownloadSnapshot(context.Background(), DownloadConfig{
-		URL:     server.URL + "/snapshot.tar.zst",
-		DestDir: destDir,
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           destDir,
 		// Filename is empty, should default to "snapshot.tar.zst"
 	})
 	require.NoError(t, err)
@@ -691,9 +774,10 @@ func TestDownloadSnapshotResumeContentRangeMismatch(t *testing.T) {
 	path, err := DownloadSnapshot(
 		context.Background(),
 		DownloadConfig{
-			URL:      server.URL + "/snapshot.tar.zst",
-			DestDir:  destDir,
-			Filename: "mismatch-test.tar.zst",
+			URL:               server.URL + "/snapshot.tar.zst",
+			AllowInsecureHTTP: true,
+			DestDir:           destDir,
+			Filename:          "mismatch-test.tar.zst",
 		},
 	)
 	require.NoError(t, err)
@@ -745,9 +829,10 @@ func TestDownloadSnapshotResumeMissingContentRange(t *testing.T) {
 	path, err := DownloadSnapshot(
 		context.Background(),
 		DownloadConfig{
-			URL:      server.URL + "/snapshot.tar.zst",
-			DestDir:  destDir,
-			Filename: "no-range.tar.zst",
+			URL:               server.URL + "/snapshot.tar.zst",
+			AllowInsecureHTTP: true,
+			DestDir:           destDir,
+			Filename:          "no-range.tar.zst",
 		},
 	)
 	require.NoError(t, err)

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -389,8 +389,9 @@ func TestDownloadSnapshotAcceptsHTTPSByDefault(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
-		URL:     server.URL + "/snapshot.tar.zst",
-		DestDir: t.TempDir(),
+		URL:                 server.URL + "/snapshot.tar.zst",
+		DestDir:             t.TempDir(),
+		MaxTransientRetries: -1,
 	})
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "must use https")

--- a/mithril/stake_distribution_resolver_test.go
+++ b/mithril/stake_distribution_resolver_test.go
@@ -47,7 +47,7 @@ func TestResolveStakeDistributionForCertificateMithril(t *testing.T) {
 
 	result, err := ResolveStakeDistributionForCertificate(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			SignedEntityKind: signedEntityTypeMithrilStakeDistribution,
 			LeafCertificate: &Certificate{
@@ -86,7 +86,7 @@ func TestResolveStakeDistributionForCertificateCardano(t *testing.T) {
 
 	result, err := ResolveStakeDistributionForCertificate(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			SignedEntityKind: signedEntityTypeCardanoStakeDistribution,
 			LeafCertificate: &Certificate{
@@ -135,7 +135,7 @@ func TestResolveStakeDistributionEpochMatchDoesNotOverrideCertHash(
 	// Mithril variant: same epoch, different cert hash -> must fail.
 	_, err := ResolveStakeDistributionForCertificate(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			SignedEntityKind: signedEntityTypeMithrilStakeDistribution,
 			LeafCertificate: &Certificate{
@@ -154,7 +154,7 @@ func TestResolveStakeDistributionEpochMatchDoesNotOverrideCertHash(
 	// Cardano variant: same epoch, different cert hash -> must fail.
 	_, err = ResolveStakeDistributionForCertificate(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			SignedEntityKind: signedEntityTypeCardanoStakeDistribution,
 			LeafCertificate: &Certificate{
@@ -209,7 +209,7 @@ func TestResolveStakeDistributionFallbackMithril(t *testing.T) {
 
 	result, err := ResolveStakeDistributionForCertificate(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			SignedEntityKind: signedEntityTypeCardanoImmutableFilesFull,
 			LeafCertificate: &Certificate{
@@ -266,7 +266,7 @@ func TestResolveStakeDistributionFallbackCardano(t *testing.T) {
 
 	result, err := ResolveStakeDistributionForCertificate(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			SignedEntityKind: signedEntityTypeCardanoImmutableFilesFull,
 			LeafCertificate: &Certificate{

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -139,6 +139,7 @@ func decideCatchUp(
 	backend string,
 	storageMode string,
 	aggregatorURL string,
+	allowInsecureHTTP bool,
 	logger *slog.Logger,
 ) (catchUpDecision, error) {
 	if backend != BackendV2 {
@@ -207,7 +208,7 @@ func decideCatchUp(
 			)
 			return catchUpDecision{engage: true}, nil
 		}
-		target, targetErr := NewClient(aggregatorURL).
+		target, targetErr := newMithrilClient(aggregatorURL, allowInsecureHTTP).
 			GetLatestCardanoDatabaseSnapshot(ctx)
 		if targetErr != nil {
 			return catchUpDecision{}, fmt.Errorf(
@@ -280,6 +281,7 @@ type SyncConfig struct {
 	CardanoConfigPath      string                     // optional explicit config.json path (else "<network>/config.json")
 	Backend                string                     // Mithril artifact backend; same semantics as BootstrapConfig.Backend (empty selects v2)
 	AggregatorURL          string                     // optional; defaults per-network
+	AllowInsecureHTTP      bool                       // permit plain-HTTP aggregator/artifact URLs; local dev/test only
 	DownloadDir            string                     // optional; defaults to <DataDir>/.mithril-cache
 	DownloadIdleTimeout    string                     // optional; passed to BootstrapConfig
 	DownloadMaxIdleRetries int                        // must be >= 0
@@ -465,7 +467,8 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 		return SyncResult{}, fmt.Errorf("determining sync mode: %w", modeErr)
 	}
 	dec, decErr := decideCatchUp(
-		ctx, db, mode, cfg.Backend, cfg.StorageMode, aggregatorURL, logger,
+		ctx, db, mode, cfg.Backend, cfg.StorageMode, aggregatorURL,
+		cfg.AllowInsecureHTTP, logger,
 	)
 	if decErr != nil {
 		return SyncResult{}, decErr
@@ -561,6 +564,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 			Network:                network,
 			Backend:                cfg.Backend,
 			AggregatorURL:          aggregatorURL,
+			AllowInsecureHTTP:      cfg.AllowInsecureHTTP,
 			DownloadDir:            downloadDir,
 			CleanupAfterLoad:       cfg.CleanupAfterLoad,
 			VerifyCertificateChain: cfg.VerifyCertChain,

--- a/mithril/verification_material_test.go
+++ b/mithril/verification_material_test.go
@@ -58,7 +58,7 @@ func TestBuildVerificationMaterial(t *testing.T) {
 
 	material, err := BuildVerificationMaterial(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			LeafCertificate: &Certificate{
 				Hash:  "leaf",
@@ -118,7 +118,7 @@ func TestBuildVerificationMaterialRejectsMismatchedEpochFallback(t *testing.T) {
 
 	_, err := BuildVerificationMaterial(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			LeafCertificate: &Certificate{
 				Hash:  "leaf",
@@ -158,7 +158,7 @@ func TestBuildVerificationMaterialUsesSupportingCertificatesFromChain(
 
 	material, err := BuildVerificationMaterial(
 		context.Background(),
-		NewClient(server.URL),
+		NewClient(server.URL, WithAllowInsecureHTTP()),
 		&CertificateChainVerificationResult{
 			LeafCertificate: &Certificate{
 				Hash:  "leaf",


### PR DESCRIPTION
## Summary

Fixed a security gap where the Mithril client accepted plaintext HTTP for the aggregator URL and snapshot artifact locations before redirect policy could apply. HTTPS is now required by default, with an explicit AllowInsecureHTTP opt-out for local dev/tests.


## Change

- `Client.doGet` (`mithril/client.go`) now rejects a non-HTTPS
  `reqURL` before issuing any request. This is the single choke point
  every aggregator API call funnels through, so it covers the
  aggregator URL for both v1 and v2 backends in one place.
- `DownloadConfig.Validate()` (`mithril/download.go`) now rejects a
  non-HTTPS `URL` the same way, covering the aggregator-supplied
  snapshot and ancillary artifact locations.
- Both call a shared `requireSecureURL` helper.
- `AllowInsecureHTTP` is an explicit, default-off escape hatch for
  local development and tests against a plaintext aggregator. It
  threads end-to-end:
  `MithrilConfig.AllowInsecureHTTP` (`mithril.allowInsecureHttp` /
  `DINGO_MITHRIL_ALLOW_INSECURE_HTTP` / `--mithril-allow-insecure-http`)
  → `SyncConfig.AllowInsecureHTTP` → `BootstrapConfig.AllowInsecureHTTP`
  → `Client`/`DownloadConfig`.
- `httpsOnlyRedirect` is unchanged — redirect downgrade protection
  still applies exactly as before.

## Tests

- `TestRequireSecureURL` (`client_test.go`) — table test covering:
  - HTTPS accepted
  - HTTP rejected by default
  - HTTP accepted with the escape hatch
  - HTTPS still accepted with the escape hatch set
  - malformed URL rejected
- `TestClientRejectsPlainHTTPAggregatorByDefault` (`client_test.go`) —
  proves a plain-HTTP aggregator request is rejected and the mock
  server never receives it
- `TestClientAllowsPlainHTTPAggregatorWithEscapeHatch` (`client_test.go`) —
  proves `WithAllowInsecureHTTP()` unblocks a plain-HTTP aggregator
- `TestDownloadSnapshotRejectsPlainHTTPByDefault` (`download_test.go`) —
  proves a plain-HTTP artifact URL is rejected before any request
- `TestDownloadSnapshotAllowsPlainHTTPWithEscapeHatch` (`download_test.go`) —
  proves `AllowInsecureHTTP: true` unblocks a plain-HTTP download
- `TestDownloadSnapshotAcceptsHTTPSByDefault` (`download_test.go`) —
  proves an HTTPS URL passes scheme validation (fails later on the
  test server's self-signed cert, which is expected and unrelated)
- Updated ~35 existing `httptest`-based tests across
  `client_test.go`, `client_v2_test.go`, `bootstrap_test.go`,
  `bootstrap_v2_test.go`, `catchup_dispatch_test.go`,
  `stake_distribution_resolver_test.go`, and
  `verification_material_test.go` to opt into `AllowInsecureHTTP`,
  since they exercise the client/downloader against plain-HTTP mock
  servers

## Verification

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run`, `nilaway`, `modernize` — 0 new issues (3
  pre-existing `modernize` findings elsewhere are untouched by this
  change)
- `make import-boundaries`, `make docs-parity` — pass
- `go test -race ./mithril/... ./internal/config/... ./cmd/...` — pass
- `go test ./internal/test/conformance/...` — pass
- DevNet not run — this change doesn't touch consensus, block
  production, or networking protocols

## Documentation

- `dingo.yaml.example` — documents the new `mithril.allowInsecureHttp`
  field
- `ARCHITECTURE.md` — new paragraph in "Mithril Bootstrap" describing
  the transport-security boundary (separate from the existing
  certificate/ancillary authentication model) and the escape hatch
- `DATABASE.md` — checked, not affected (no schema/storage-layer
  changes)


Closes #2039

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require HTTPS for Mithril aggregator and snapshot artifact URLs. Plain HTTP is blocked by default, with an explicit `AllowInsecureHTTP` escape hatch for local dev/tests.

- **Bug Fixes**
  - `mithril.Client.doGet` rejects non-HTTPS aggregator URLs before any request; URLs with an empty host are rejected even with the escape hatch.
  - `mithril.DownloadConfig.Validate` rejects non-HTTPS artifact URLs; same empty-host validation applies.
  - Escape hatch widens only to `http`; all other schemes remain rejected.
  - Shared `requireSecureURL` helper added; HTTPS-only redirect policy unchanged.
  - New `AllowInsecureHTTP` threads from config/CLI/env to clients and downloads across sync/bootstrap/list/show (`mithril.allowInsecureHttp`, `--mithril-allow-insecure-http`, `DINGO_MITHRIL_ALLOW_INSECURE_HTTP`). Tests updated to cover enforcement and the escape hatch.

- **Migration**
  - Production: ensure aggregator and artifact URLs use HTTPS.
  - Local dev/tests: enable `mithril.allowInsecureHttp: true`, or use `--mithril-allow-insecure-http` / `DINGO_MITHRIL_ALLOW_INSECURE_HTTP=1`. Library users can pass `WithAllowInsecureHTTP()` to `NewClient`.

<sup>Written for commit 3976bbabd213092ebe184e382d0afdffbca866ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Mithril connections now require HTTPS by default for aggregators, snapshots, and ancillary artifacts.
  * Added validation to reject insecure URLs before requests begin.
* **Configuration**
  * Added an explicit, disabled-by-default option to allow HTTP for local development and testing.
  * The option is available through configuration, environment variables, and the `--mithril-allow-insecure-http` command-line flag.
  * The setting applies consistently across synchronization, bootstrap, and download workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->