### PR TITLE
fix(ledger): bound decoded block buffering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -365,6 +365,14 @@ the underlying gouroboros protocol send queue to drain. This keeps large Leios
 catch-up ranges from filling the mux pending-message queue and turning a slow
 consumer into a connection-level protocol violation.
 
+On the client path, BlockFetch events carry fully decoded blocks. The ledger
+subscriber therefore buffers one eight-block chain-store commit batch; when it
+fills, lossless EventBus delivery backpressures the protocol receive loop
+instead of retaining the rest of a large decoded range. The subsequent chain
+reader likewise decodes at most one 50-block metadata transaction batch at a
+time. These bounds matter for Dijkstra bodies, whose nested canonical-CBOR
+views make a live decoded block substantially larger than its wire bytes.
+
 Opening that iterator is also what decides whether the range is servable at
 all, so `chain`'s forward and reverse iterator constructors require the start
 point to be a block the chain still holds at that block index, not merely one
@@ -914,7 +922,9 @@ All event types follow the `subsystem.snake_case_name` convention.
 
 - Asynchronous delivery via worker pool (4 workers, 1000-entry async queue)
 - Default subscriber buffers of 1024 events, with opt-in 100000-entry burst
-  buffers for high-volume ledger chainsync/blockfetch paths
+  buffers for high-volume ledger chainsync and chain-update paths. The
+  payload-heavy ledger blockfetch path uses an eight-entry buffer and relies
+  on lossless backpressure once one chain-store commit batch is queued
 - Lossless delivery with producer backpressure: when a subscriber buffer or the
   async queue is full, `Publish`, `PublishBlocking`, and `PublishAsync` all wait
   for capacity instead of dropping the event. Waits end on `Stop`, `Close`, or

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1061,9 +1061,11 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	}
 	// Setup event handlers only after startup nonce repair is complete, so a
 	// Mithril-bootstrapped node cannot process chainsync/blockfetch events with
-	// stale gap-block nonces. The chainsync/blockfetch/chain-update streams can
-	// burst at bulk-sync rates (#1556 / #1914), so they opt into the large
-	// EventQueueSize buffer. Sparser streams use the default.
+	// stale gap-block nonces. ChainSync and chain-update can burst at bulk-sync
+	// rates (#1556 / #1914), so they opt into the large EventQueueSize buffer.
+	// Blockfetch events retain fully decoded blocks, so keep that lossless queue
+	// to one commit batch and let EventBus backpressure bound decoded CBOR while
+	// the chain store catches up. Sparser streams use the default.
 	if ls.config.EventBus != nil {
 		ls.chainsyncSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			ChainsyncEventType,
@@ -1076,7 +1078,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		)
 		ls.blockfetchSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			BlockfetchEventType,
-			event.EventQueueSize,
+			blockfetchCommitBatchSize,
 			ls.handleEventBlockfetch,
 		)
 		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
@@ -3050,8 +3052,11 @@ func (ls *LedgerState) ledgerReadChainIterator(
 			return
 		default:
 		}
-		// We chose 500 as an arbitrary max batch size. A "chain extended" message will be logged after each batch
-		nextBatch := make([]ledger.Block, 0, 500)
+		// Keep only one database transaction batch decoded at a time. Dijkstra
+		// bodies retain several canonical-CBOR views while they are live, so
+		// the old arbitrary 500-block read-ahead could amplify a slow metadata
+		// commit into gigabytes of otherwise reclaimable heap.
+		nextBatch := make([]ledger.Block, 0, batchSize)
 		// Gather up next batch of blocks
 		for {
 			if cachedNext != nil {


### PR DESCRIPTION
## Summary

- backpressure decoded BlockFetch delivery after one eight-block chain-store commit batch
- decode one 50-block metadata transaction batch at a time instead of retaining an arbitrary 500-block read-ahead
- document the payload-specific bounds in `ARCHITECTURE.md`

The Musashi heap profile showed reclaimable decoded Dijkstra blocks retained
simultaneously in BlockFetch delivery and chain replay. Dijkstra's nested
canonical-CBOR views materially amplify each live block, so the old count-only
bounds could retain gigabytes while SQLite-backed ledger application lagged.
This keeps delivery lossless using the backpressure contract from #2978 and
does not change validation, storage, or chain-selection semantics.

Related: #2106, #2166, #2932, #2978.

## Testing

- `go test ./ledger -count=1 -timeout=8m`
- focused `go test -race` coverage for ledger read-chain and BlockFetch tests
- `go test -race ./event -count=1 -timeout=3m`
- `go test -race ./internal/test/conformance/... -count=1 -timeout=3m`
- `golangci-lint run ./ledger/... ./event/...`
- `nilaway ./ledger/... ./event/...`
- `modernize ./ledger/... ./event/...`
- `make import-boundaries docs-parity golines gorm-check`

The all-dingo DevNet images built successfully, but the run could not start
`dingo-3` because host port `3022` was already occupied by another environment.
The harness collected logs and tore down its own project; it was not retried to
avoid disturbing the existing run.

## Documentation

- `ARCHITECTURE.md` updated
- `DATABASE.md` checked; no schema, storage format, query, or pruning impact


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound decoded block buffering in ledger BlockFetch and chain replay to cap memory use during bulk sync. Uses lossless backpressure and smaller decode batches; no changes to validation, storage, or chain selection.

- **Bug Fixes**
  - Backpressure BlockFetch delivery once one 8-block commit batch is queued (subscriber buffer set to `blockfetchCommitBatchSize`).
  - Limit chain reader to decode one 50-block metadata batch at a time (replaces 500-block read-ahead).
  - Document bounds and queue behavior updates in ARCHITECTURE.md.

<sup>Written for commit dd7a98aac61edbfddc6f5c023a6466246b3485ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved block-fetch processing with bounded buffering and controlled commit batches.
  * Reduced chain-read memory usage by limiting read-ahead allocation to the active batch size.
  * Preserved high-volume buffering for chain-sync and chain-update processing.

* **Documentation**
  * Added guidance on buffering, backpressure, batching, and memory considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->