### PR TITLE
fix(mithril): normalize snapshot metadata before cache path checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2824,6 +2824,17 @@ Both backends produce the same `BootstrapResult` (immutable directory,
 ancillary ledger-state directory, synthesized snapshot metadata), so
 everything downstream of `Bootstrap()` is backend-agnostic.
 
+`snapshot.Network`/`Digest` (v1) and `artifact.Network` (v2) arrive from the
+aggregator before certificate/hash verification runs, so `bootstrap.go`'s
+`validateSnapshotIdentity` rejects them against a known-network allowlist
+(`AcceptedNetworks()`, mirroring `AcceptedBackends()`) and the expected
+64-character hex digest format (Blake2b-256/SHA-256, hex-encoded) before
+either backend derives a filesystem path from them. Every filename built
+from these fields, for both the cache-hit check and the actual download, is
+additionally passed through `filepath.Base` at its construction site, so
+the two can never evaluate a different path even if validation is ever
+loosened.
+
 ### Catch-up vs bootstrap dispatch
 
 `mithril.Sync` (the `dingo mithril sync` entry point) selects what to do from

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2824,16 +2824,23 @@ Both backends produce the same `BootstrapResult` (immutable directory,
 ancillary ledger-state directory, synthesized snapshot metadata), so
 everything downstream of `Bootstrap()` is backend-agnostic.
 
-`snapshot.Network`/`Digest` (v1) and `artifact.Network` (v2) arrive from the
-aggregator before certificate/hash verification runs, so `bootstrap.go`'s
-`validateSnapshotIdentity` rejects them against a known-network allowlist
-(`AcceptedNetworks()`, mirroring `AcceptedBackends()`) and the expected
-64-character hex digest format (Blake2b-256/SHA-256, hex-encoded) before
-either backend derives a filesystem path from them. Every filename built
-from these fields, for both the cache-hit check and the actual download, is
+`snapshot.Network`/`Digest` (v1) and `artifact.Network`/`Hash` (v2) arrive
+from the aggregator before certificate/hash verification runs, so
+`bootstrap.go`'s `validateSnapshotIdentity` rejects them before either
+backend derives a filesystem path from them. The network must be either
+one of the default networks (`AcceptedNetworks()`, mirroring
+`AcceptedBackends()`) or an exact match for the operator's own configured
+`BootstrapConfig.Network` — trusted because it's already restricted to
+alphanumeric/hyphen/underscore by `internal/config`'s `ValidateNetworkName`
+before it ever reaches this package — which lets a private/self-hosted
+aggregator serve a non-default network name (e.g. a devnet) without
+loosening what an untrusted response can put on a path. The digest/hash
+must match the expected 64-character hex format (Blake2b-256/SHA-256,
+hex-encoded). Every filename or directory built from these fields, for
+both the cache-hit check and the actual download/extraction, is
 additionally passed through `filepath.Base` at its construction site, so
-the two can never evaluate a different path even if validation is ever
-loosened.
+none of them can ever evaluate a different path even if validation is
+ever loosened.
 
 ### Catch-up vs bootstrap dispatch
 

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -260,6 +262,11 @@ func Bootstrap(
 			err,
 		)
 	}
+	if err := validateSnapshotIdentity(
+		snapshot.Network, snapshot.Digest,
+	); err != nil {
+		return nil, fmt.Errorf("validating snapshot metadata: %w", err)
+	}
 	if cfg.Network != "" && snapshot.Network != "" &&
 		cfg.Network != snapshot.Network {
 		return nil, fmt.Errorf(
@@ -415,11 +422,11 @@ func Bootstrap(
 	}()
 
 	// Step 3: Download snapshot archive (skip if already complete)
-	archiveFilename := fmt.Sprintf(
+	archiveFilename := filepath.Base(fmt.Sprintf(
 		"%s-%s.tar.zst",
 		snapshot.Network,
 		truncateDigest(snapshot.Digest),
-	)
+	))
 	archivePath := filepath.Join(downloadDir, archiveFilename)
 	snapshotCacheKey := snapshot.Digest
 
@@ -490,7 +497,7 @@ func Bootstrap(
 		ancWg.Go(func() {
 			candidateDir := filepath.Join(
 				downloadDir,
-				"ancillary-"+snapshotCacheKey,
+				filepath.Base("ancillary-"+snapshotCacheKey),
 			)
 			if hasLedgerFiles(candidateDir) {
 				cfg.Logger.Info(
@@ -505,13 +512,13 @@ func Bootstrap(
 				// a prior successful extraction).
 				candidateArchive := filepath.Join(
 					downloadDir,
-					fmt.Sprintf(
+					filepath.Base(fmt.Sprintf(
 						"%s-%s-ancillary.tar.zst",
 						snapshot.Network,
 						truncateDigest(
 							snapshot.Digest,
 						),
-					),
+					)),
 				)
 				if _, err := os.Stat(candidateArchive); err == nil {
 					ancillaryArchivePath = candidateArchive
@@ -611,11 +618,11 @@ func downloadAncillary(
 		"size", snapshot.AncillarySize,
 	)
 
-	ancillaryFilename := fmt.Sprintf(
+	ancillaryFilename := filepath.Base(fmt.Sprintf(
 		"%s-%s-ancillary.tar.zst",
 		snapshot.Network,
 		truncateDigest(snapshot.Digest),
-	)
+	))
 
 	var ancillaryPath string
 	for i, loc := range snapshot.AncillaryLocations {
@@ -1066,6 +1073,33 @@ func truncateDigest(digest string) string {
 		return digest[:16]
 	}
 	return digest
+}
+
+// snapshotDigestLength is the expected length of a Mithril snapshot digest:
+// a Blake2b-256 (v1) or SHA-256 (v2, see CardanoDatabaseSnapshot.ComputeHash)
+// hash, hex-encoded (32 bytes -> 64 hex characters).
+const snapshotDigestLength = 64
+
+// digestPattern matches a digest of exactly snapshotDigestLength hex
+// characters.
+var digestPattern = regexp.MustCompile(
+	fmt.Sprintf(`^[0-9a-fA-F]{%d}$`, snapshotDigestLength),
+)
+
+// validateSnapshotIdentity rejects Mithril aggregator-supplied network and
+// digest values before they are used to construct any filesystem path.
+// Both fields arrive unauthenticated at this point in the flow —
+// certificate/hash verification, when enabled, happens later — so they must
+// be constrained to a known network name and the expected hex digest format
+// first.
+func validateSnapshotIdentity(network, digest string) error {
+	if !slices.Contains(AcceptedNetworks(), network) {
+		return fmt.Errorf("unrecognized Mithril snapshot network %q", network)
+	}
+	if !digestPattern.MatchString(digest) {
+		return fmt.Errorf("invalid Mithril snapshot digest %q", digest)
+	}
+	return nil
 }
 
 // hasFileInSubdirs checks if a file with the given name exists in

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -263,7 +263,7 @@ func Bootstrap(
 		)
 	}
 	if err := validateSnapshotIdentity(
-		snapshot.Network, snapshot.Digest,
+		cfg.Network, snapshot.Network, snapshot.Digest,
 	); err != nil {
 		return nil, fmt.Errorf("validating snapshot metadata: %w", err)
 	}
@@ -477,7 +477,7 @@ func Bootstrap(
 	// vs ancillary/) so they are independent.
 	extractDir := filepath.Join(
 		downloadDir,
-		"immutable-"+snapshotCacheKey,
+		filepath.Base("immutable-"+snapshotCacheKey),
 	)
 	var ancillaryDir string
 	var ancillaryArchivePath string
@@ -662,7 +662,7 @@ func downloadAncillary(
 
 	ancillaryDir := filepath.Join(
 		downloadDir,
-		"ancillary-"+snapshot.Digest,
+		filepath.Base("ancillary-"+snapshot.Digest),
 	)
 	if _, extractErr := ExtractArchive(
 		ctx, ancillaryPath, ancillaryDir, cfg.Logger,
@@ -1091,9 +1091,16 @@ var digestPattern = regexp.MustCompile(
 // Both fields arrive unauthenticated at this point in the flow —
 // certificate/hash verification, when enabled, happens later — so they must
 // be constrained to a known network name and the expected hex digest format
-// first.
-func validateSnapshotIdentity(network, digest string) error {
-	if !slices.Contains(AcceptedNetworks(), network) {
+// first. expectedNetwork is the operator's own configured BootstrapConfig/
+// SyncConfig.Network (already restricted to alphanumeric/hyphen/underscore
+// by internal/config's ValidateNetworkName), which is trusted and accepted
+// in addition to the fixed default-network list — this lets an operator
+// bootstrap against a private/self-hosted aggregator for a non-default
+// network (e.g. a devnet) without loosening what an untrusted aggregator
+// response can put on a path. Pass "" when there is no such expectation.
+func validateSnapshotIdentity(expectedNetwork, network, digest string) error {
+	if network == "" ||
+		(network != expectedNetwork && !slices.Contains(AcceptedNetworks(), network)) {
 		return fmt.Errorf("unrecognized Mithril snapshot network %q", network)
 	}
 	if !digestPattern.MatchString(digest) {

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -456,9 +456,10 @@ func TestBootstrapRejectsPathTraversalInSnapshotNetwork(t *testing.T) {
 	}
 
 	_, err := Bootstrap(context.Background(), BootstrapConfig{
-		Backend:       BackendV1,
-		AggregatorURL: server.URL,
-		DownloadDir:   t.TempDir(),
+		Backend:           BackendV1,
+		AggregatorURL:     server.URL,
+		AllowInsecureHTTP: true,
+		DownloadDir:       t.TempDir(),
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "validating snapshot metadata")
@@ -509,9 +510,10 @@ func TestBootstrapRejectsPathTraversalInSnapshotDigest(t *testing.T) {
 	}
 
 	_, err := Bootstrap(context.Background(), BootstrapConfig{
-		Backend:       BackendV1,
-		AggregatorURL: server.URL,
-		DownloadDir:   t.TempDir(),
+		Backend:           BackendV1,
+		AggregatorURL:     server.URL,
+		AllowInsecureHTTP: true,
+		DownloadDir:       t.TempDir(),
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "validating snapshot metadata")

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -350,33 +350,58 @@ func TestBootstrapUnknownNetwork(t *testing.T) {
 func TestValidateSnapshotIdentity(t *testing.T) {
 	validDigest := "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
 	tests := []struct {
-		name    string
-		network string
-		digest  string
-		wantErr bool
+		name            string
+		expectedNetwork string
+		network         string
+		digest          string
+		wantErr         bool
 	}{
-		{"valid mainnet", "mainnet", validDigest, false},
-		{"valid preprod", "preprod", validDigest, false},
-		{"valid preview", "preview", validDigest, false},
-		{"too-short hex digest", "preprod", "abc123", true},
-		{"unknown network", "devnet", validDigest, true},
-		{"empty network", "", validDigest, true},
-		{"network with path traversal", "../../../etc", validDigest, true},
-		{"empty digest", "preprod", "", true},
-		{"digest with slash", "preprod", "abc/def", true},
-		{"digest with path traversal", "preprod", "../../etc/passwd", true},
-		{"digest with space", "preprod", "abc 123", true},
-		{"non-hex digest", "preprod", "not-hex-at-all", true},
+		{"valid mainnet", "", "mainnet", validDigest, false},
+		{"valid preprod", "", "preprod", validDigest, false},
+		{"valid preview", "", "preview", validDigest, false},
+		{"too-short hex digest", "", "preprod", "abc123", true},
+		{"unknown network", "", "devnet", validDigest, true},
+		{"empty network", "", "", validDigest, true},
+		{"network with path traversal", "", "../../../etc", validDigest, true},
+		{"empty digest", "", "preprod", "", true},
+		{"digest with slash", "", "preprod", "abc/def", true},
+		{"digest with path traversal", "", "preprod", "../../etc/passwd", true},
+		{"digest with space", "", "preprod", "abc 123", true},
+		{"non-hex digest", "", "preprod", "not-hex-at-all", true},
 		{
 			"too-long digest",
+			"",
 			"preprod",
 			strings.Repeat("a", 65),
+			true,
+		},
+		{
+			"custom network matching operator config is trusted",
+			"devnet",
+			"devnet",
+			validDigest,
+			false,
+		},
+		{
+			"custom network not matching operator config is rejected",
+			"devnet",
+			"some-other-net",
+			validDigest,
+			true,
+		},
+		{
+			"path traversal rejected even with a custom expected network",
+			"devnet",
+			"../../../etc",
+			validDigest,
 			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSnapshotIdentity(tt.network, tt.digest)
+			err := validateSnapshotIdentity(
+				tt.expectedNetwork, tt.network, tt.digest,
+			)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -102,7 +103,7 @@ func TestBootstrap(t *testing.T) {
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
-				Digest:  "abc123def456789012345678",
+				Digest:  "a123456789abcdef0a123456789abcdef0a123456789abcdef0a123456789abc",
 				Network: "preprod",
 				Beacon: Beacon{
 					Epoch:               270,
@@ -163,7 +164,7 @@ func TestBootstrap(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, "abc123def456789012345678", result.Snapshot.Digest)
+	require.Equal(t, "a123456789abcdef0a123456789abcdef0a123456789abcdef0a123456789abc", result.Snapshot.Digest)
 	require.NotEmpty(t, result.ImmutableDir)
 	require.NotEmpty(t, result.ArchivePath)
 	assert.Greater(
@@ -179,7 +180,7 @@ func TestBootstrap(t *testing.T) {
 
 func TestBootstrapUsesDigestSpecificExtractDir(t *testing.T) {
 	archiveData := createChunkArchive(t)
-	digest := "newdigest1234567890abcdef"
+	digest := "b123456789abcdef0b123456789abcdef0b123456789abcdef0b123456789abc"
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
@@ -246,7 +247,7 @@ func TestBootstrapCertVerifyNoCertHash(t *testing.T) {
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
-				Digest:          "abc123",
+				Digest:          "c123456789abcdef0c123456789abcdef0c123456789abcdef0c123456789abc",
 				Network:         "preprod",
 				Locations:       []string{"http://example.com/s"},
 				CertificateHash: "",
@@ -294,7 +295,7 @@ func TestBootstrapNoLocations(t *testing.T) {
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
-				Digest:    "abc123",
+				Digest:    "d123456789abcdef0d123456789abcdef0d123456789abcdef0d123456789abc",
 				Network:   "preprod",
 				Locations: []string{},
 			},
@@ -341,6 +342,154 @@ func TestBootstrapUnknownNetwork(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "resolving aggregator URL")
+}
+
+// TestValidateSnapshotIdentity checks that validateSnapshotIdentity accepts
+// known networks with a bounded hex digest and rejects everything else,
+// including path-separator/traversal sequences in either field.
+func TestValidateSnapshotIdentity(t *testing.T) {
+	validDigest := "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+	tests := []struct {
+		name    string
+		network string
+		digest  string
+		wantErr bool
+	}{
+		{"valid mainnet", "mainnet", validDigest, false},
+		{"valid preprod", "preprod", validDigest, false},
+		{"valid preview", "preview", validDigest, false},
+		{"too-short hex digest", "preprod", "abc123", true},
+		{"unknown network", "devnet", validDigest, true},
+		{"empty network", "", validDigest, true},
+		{"network with path traversal", "../../../etc", validDigest, true},
+		{"empty digest", "preprod", "", true},
+		{"digest with slash", "preprod", "abc/def", true},
+		{"digest with path traversal", "preprod", "../../etc/passwd", true},
+		{"digest with space", "preprod", "abc 123", true},
+		{"non-hex digest", "preprod", "not-hex-at-all", true},
+		{
+			"too-long digest",
+			"preprod",
+			strings.Repeat("a", 65),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSnapshotIdentity(tt.network, tt.digest)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestBootstrapRejectsPathTraversalInSnapshotNetwork verifies that a
+// malicious aggregator response with a path-traversal sequence in
+// snapshot.Network is rejected by Bootstrap before the archive download
+// (and thus any filesystem access derived from that field) is attempted.
+func TestBootstrapRejectsPathTraversalInSnapshotNetwork(t *testing.T) {
+	var downloadHit atomic.Bool
+	snapshots := []SnapshotListItem{
+		{
+			SnapshotBase: SnapshotBase{
+				Digest:  "a123456789abcdef0a123456789abcdef0a123456789abcdef0a123456789abc",
+				Network: "../../../../tmp/evil",
+				Size:    203,
+				Locations: []string{
+					"placeholder",
+				},
+			},
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/artifact/snapshots",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(snapshots))
+		},
+	)
+	mux.HandleFunc(
+		"/download/snapshot.tar.zst",
+		func(w http.ResponseWriter, r *http.Request) {
+			downloadHit.Store(true)
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	snapshots[0].Locations = []string{
+		server.URL + "/download/snapshot.tar.zst",
+	}
+
+	_, err := Bootstrap(context.Background(), BootstrapConfig{
+		Backend:       BackendV1,
+		AggregatorURL: server.URL,
+		DownloadDir:   t.TempDir(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validating snapshot metadata")
+	require.False(
+		t,
+		downloadHit.Load(),
+		"archive download must not be attempted for unvalidated metadata",
+	)
+}
+
+// TestBootstrapRejectsPathTraversalInSnapshotDigest is the digest-field
+// counterpart of TestBootstrapRejectsPathTraversalInSnapshotNetwork:
+// snapshot.Digest containing a path-traversal sequence must be rejected
+// before it can influence the cache-check or download path.
+func TestBootstrapRejectsPathTraversalInSnapshotDigest(t *testing.T) {
+	var downloadHit atomic.Bool
+	snapshots := []SnapshotListItem{
+		{
+			SnapshotBase: SnapshotBase{
+				Digest:  "../../../../tmp/evil",
+				Network: "preprod",
+				Size:    203,
+				Locations: []string{
+					"placeholder",
+				},
+			},
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/artifact/snapshots",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(snapshots))
+		},
+	)
+	mux.HandleFunc(
+		"/download/snapshot.tar.zst",
+		func(w http.ResponseWriter, r *http.Request) {
+			downloadHit.Store(true)
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	snapshots[0].Locations = []string{
+		server.URL + "/download/snapshot.tar.zst",
+	}
+
+	_, err := Bootstrap(context.Background(), BootstrapConfig{
+		Backend:       BackendV1,
+		AggregatorURL: server.URL,
+		DownloadDir:   t.TempDir(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validating snapshot metadata")
+	require.False(
+		t,
+		downloadHit.Load(),
+		"archive download must not be attempted for unvalidated metadata",
+	)
 }
 
 func TestBootstrapResultCleanup(t *testing.T) {
@@ -776,7 +925,7 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
-				Digest:          "digest123",
+				Digest:          "e123456789abcdef0e123456789abcdef0e123456789abcdef0e123456789abc",
 				Network:         "preprod",
 				CertificateHash: "cert_leaf",
 				Locations: []string{
@@ -810,7 +959,7 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 			},
 			ProtocolMessage: ProtocolMessage{
 				MessageParts: map[string]string{
-					"snapshot_digest": "digest123",
+					"snapshot_digest": "e123456789abcdef0e123456789abcdef0e123456789abcdef0e123456789abc",
 					"current_epoch":   "270",
 				},
 			},

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -80,6 +80,11 @@ func bootstrapV2(
 			artifact.Hash,
 		)
 	}
+	if err := validateSnapshotIdentity(
+		artifact.Network, artifact.Hash,
+	); err != nil {
+		return nil, fmt.Errorf("validating artifact metadata: %w", err)
+	}
 	if cfg.Network != "" && artifact.Network != "" &&
 		cfg.Network != artifact.Network {
 		return nil, fmt.Errorf(
@@ -202,15 +207,15 @@ func bootstrapV2(
 		ancWg.Go(func() {
 			candidateDir := filepath.Join(
 				downloadDir,
-				"ancillary-"+artifact.Hash,
+				filepath.Base("ancillary-"+artifact.Hash),
 			)
 			candidateArchive := filepath.Join(
 				downloadDir,
-				fmt.Sprintf(
+				filepath.Base(fmt.Sprintf(
 					"%s-%s-ancillary.tar.zst",
 					artifact.Network,
 					truncateDigest(artifact.Hash),
-				),
+				)),
 			)
 			if hasLedgerFiles(candidateDir) {
 				if err := verifyAncillaryExtraction(
@@ -572,12 +577,12 @@ func removeDigestsCache(
 	downloadDir string,
 ) {
 	suffix := truncateDigest(artifact.Hash)
-	_ = os.Remove(filepath.Join(downloadDir, fmt.Sprintf(
+	_ = os.Remove(filepath.Join(downloadDir, filepath.Base(fmt.Sprintf(
 		"digests-%s.tar.zst",
 		suffix,
-	)))
+	))))
 	_ = os.RemoveAll(
-		filepath.Join(downloadDir, "digests-"+suffix),
+		filepath.Join(downloadDir, filepath.Base("digests-"+suffix)),
 	)
 }
 
@@ -594,10 +599,10 @@ func downloadDigestsArchive(
 		ctx, DownloadConfig{
 			URL:     uri,
 			DestDir: downloadDir,
-			Filename: fmt.Sprintf(
+			Filename: filepath.Base(fmt.Sprintf(
 				"digests-%s.tar.zst",
 				truncateDigest(artifact.Hash),
-			),
+			)),
 			Logger:              cfg.Logger,
 			IdleTimeout:         cfg.DownloadIdleTimeout,
 			MaxIdleRetries:      cfg.DownloadMaxIdleRetries,
@@ -609,7 +614,7 @@ func downloadDigestsArchive(
 	}
 	destDir := filepath.Join(
 		downloadDir,
-		"digests-"+truncateDigest(artifact.Hash),
+		filepath.Base("digests-"+truncateDigest(artifact.Hash)),
 	)
 	if _, err := ExtractArchive(
 		ctx, archivePath, destDir, cfg.Logger,
@@ -666,7 +671,7 @@ func downloadImmutables(
 	}
 	archiveDir := filepath.Join(
 		downloadDir,
-		"immutable-archives-"+truncateDigest(artifact.Hash),
+		filepath.Base("immutable-archives-"+truncateDigest(artifact.Hash)),
 	)
 	if err := os.MkdirAll(archiveDir, 0o750); err != nil {
 		return fmt.Errorf("creating archive directory: %w", err)
@@ -1081,11 +1086,11 @@ func downloadAncillaryV2(
 		"size", artifact.Ancillary.SizeUncompressed,
 	)
 
-	ancillaryFilename := fmt.Sprintf(
+	ancillaryFilename := filepath.Base(fmt.Sprintf(
 		"%s-%s-ancillary.tar.zst",
 		artifact.Network,
 		truncateDigest(artifact.Hash),
-	)
+	))
 
 	var ancillaryPath string
 	var err error

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -81,7 +81,7 @@ func bootstrapV2(
 		)
 	}
 	if err := validateSnapshotIdentity(
-		artifact.Network, artifact.Hash,
+		cfg.Network, artifact.Network, artifact.Hash,
 	); err != nil {
 		return nil, fmt.Errorf("validating artifact metadata: %w", err)
 	}
@@ -188,7 +188,7 @@ func bootstrapV2(
 
 	extractDir := filepath.Join(
 		downloadDir,
-		"immutable-"+artifact.Hash,
+		filepath.Base("immutable-"+artifact.Hash),
 	)
 	var ancillaryDir string
 	var ancillaryArchivePath string
@@ -1133,7 +1133,7 @@ func downloadAncillaryV2(
 
 	ancillaryDir := filepath.Join(
 		downloadDir,
-		"ancillary-"+artifact.Hash,
+		filepath.Base("ancillary-"+artifact.Hash),
 	)
 	if _, extractErr := ExtractArchive(
 		ctx, ancillaryPath, ancillaryDir, cfg.Logger,

--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -875,58 +875,27 @@ func TestBootstrapV2RejectsNetworkMismatchBeforeDownload(t *testing.T) {
 // downloaded — artifact.Hash alone isn't enough to trust the metadata,
 // since Network is a separate, unconstrained field.
 func TestBootstrapV2RejectsPathTraversalInArtifactNetwork(t *testing.T) {
-	artifact := &CardanoDatabaseSnapshot{
-		MerkleRoot: "root",
-		Network:    "../../../../tmp/evil",
-		Beacon:     Beacon{Epoch: 0, ImmutableFileNumber: 0},
-	}
-	artifact.Hash = artifact.ComputeHash()
+	// Use the full fixture (real digest/immutable/ancillary/cert wiring) so
+	// that, if validateSnapshotIdentity were removed, the bootstrap would
+	// actually reach and attempt the immutable download this test guards
+	// against — not fail earlier for an unrelated reason (e.g. missing
+	// locations), which would let the immutableHits assertion pass
+	// vacuously.
+	fixture := newV2Fixture(t, v2FixtureOptions{immutableFileNumber: 1})
+	fixture.artifact.Network = "../../../../tmp/evil"
+	cfg := fixture.bootstrapConfig(t.TempDir())
+	// Neither an operator-configured network expectation nor certificate
+	// verification is in play, so the pre-existing cfg.Network-mismatch
+	// check and the certificate's own network check (two distinct,
+	// unrelated guards) can't mask whether validateSnapshotIdentity itself
+	// is the one rejecting this.
+	cfg.Network = ""
+	cfg.VerifyCertificateChain = false
 
-	var immutableHit atomic.Bool
-	mux := http.NewServeMux()
-	mux.HandleFunc(
-		"/artifact/cardano-database",
-		func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			require.NoError(
-				t,
-				json.NewEncoder(w).Encode(
-					[]CardanoDatabaseSnapshotListItem{
-						{Hash: artifact.Hash, Beacon: artifact.Beacon},
-					},
-				),
-			)
-		},
-	)
-	mux.HandleFunc(
-		"/artifact/cardano-database/"+artifact.Hash,
-		func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			require.NoError(t, json.NewEncoder(w).Encode(artifact))
-		},
-	)
-	mux.HandleFunc(
-		"/files/imm/",
-		func(w http.ResponseWriter, r *http.Request) {
-			immutableHit.Store(true)
-			w.WriteHeader(http.StatusOK)
-		},
-	)
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	_, err := Bootstrap(context.Background(), BootstrapConfig{
-		Backend:       BackendV2,
-		AggregatorURL: server.URL,
-		DownloadDir:   t.TempDir(),
-	})
+	_, err := Bootstrap(context.Background(), cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "validating artifact metadata")
-	require.False(
-		t,
-		immutableHit.Load(),
-		"immutable download must not be attempted for unvalidated metadata",
-	)
+	require.Zero(t, fixture.immutableHits.Load())
 }
 
 func TestBootstrapV2VerifiedRequiresAncillaryKey(t *testing.T) {

--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -869,6 +869,66 @@ func TestBootstrapV2RejectsNetworkMismatchBeforeDownload(t *testing.T) {
 	assert.Zero(t, fixture.immutableHits.Load())
 }
 
+// TestBootstrapV2RejectsPathTraversalInArtifactNetwork verifies that a v2
+// artifact whose self-hash checks out but whose Network field contains a
+// path-traversal sequence is rejected before any immutable archive is
+// downloaded — artifact.Hash alone isn't enough to trust the metadata,
+// since Network is a separate, unconstrained field.
+func TestBootstrapV2RejectsPathTraversalInArtifactNetwork(t *testing.T) {
+	artifact := &CardanoDatabaseSnapshot{
+		MerkleRoot: "root",
+		Network:    "../../../../tmp/evil",
+		Beacon:     Beacon{Epoch: 0, ImmutableFileNumber: 0},
+	}
+	artifact.Hash = artifact.ComputeHash()
+
+	var immutableHit atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/artifact/cardano-database",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(
+				t,
+				json.NewEncoder(w).Encode(
+					[]CardanoDatabaseSnapshotListItem{
+						{Hash: artifact.Hash, Beacon: artifact.Beacon},
+					},
+				),
+			)
+		},
+	)
+	mux.HandleFunc(
+		"/artifact/cardano-database/"+artifact.Hash,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(artifact))
+		},
+	)
+	mux.HandleFunc(
+		"/files/imm/",
+		func(w http.ResponseWriter, r *http.Request) {
+			immutableHit.Store(true)
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	_, err := Bootstrap(context.Background(), BootstrapConfig{
+		Backend:       BackendV2,
+		AggregatorURL: server.URL,
+		DownloadDir:   t.TempDir(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validating artifact metadata")
+	require.False(
+		t,
+		immutableHit.Load(),
+		"immutable download must not be attempted for unvalidated metadata",
+	)
+}
+
 func TestBootstrapV2VerifiedRequiresAncillaryKey(t *testing.T) {
 	fixture := newV2Fixture(t, v2FixtureOptions{immutableFileNumber: 1})
 	cfg := fixture.bootstrapConfig(t.TempDir())

--- a/mithril/client.go
+++ b/mithril/client.go
@@ -588,6 +588,18 @@ var defaultNetworkConfigs = map[string]NetworkConfig{
 	},
 }
 
+// AcceptedNetworks returns the recognized Mithril network identifiers.
+// It is the single source for network-name validation: path-safety checks
+// on aggregator-supplied snapshot metadata verify parity against it.
+func AcceptedNetworks() []string {
+	networks := make([]string, 0, len(defaultNetworkConfigs))
+	for network := range defaultNetworkConfigs {
+		networks = append(networks, network)
+	}
+	slices.Sort(networks)
+	return networks
+}
+
 // NetworkConfigForNetwork returns the default Mithril network configuration
 // for the given network name, or an error if the network is not recognized.
 func NetworkConfigForNetwork(network string) (NetworkConfig, error) {

--- a/mithril/client_test.go
+++ b/mithril/client_test.go
@@ -1268,7 +1268,7 @@ func TestBootstrapWithCertVerification(t *testing.T) {
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
-				Digest:  "abc123def456789012345678",
+				Digest:  "f123456789abcdef0f123456789abcdef0f123456789abcdef0f123456789abc",
 				Network: "preprod",
 				Beacon: Beacon{
 					Epoch:               270,
@@ -1303,7 +1303,7 @@ func TestBootstrapWithCertVerification(t *testing.T) {
 			},
 			ProtocolMessage: ProtocolMessage{
 				MessageParts: map[string]string{
-					"snapshot_digest": "abc123def456789012345678",
+					"snapshot_digest": "f123456789abcdef0f123456789abcdef0f123456789abcdef0f123456789abc",
 					"current_epoch":   "270",
 				},
 			},


### PR DESCRIPTION
## Summary

Mithril bootstrap now validates aggregator-supplied `Network`/`Digest` (network allowlist + exact 64-char hex) before building any filesystem path, and applies `filepath.Base` normalization consistently everywhere a filename is built — so untrusted metadata can't influence cache-check or download paths, and the two can never disagree. Added regression tests for path-traversal in both fields, updated `ARCHITECTURE.md`; all builds/tests/lint clean.

## Changes

- **`mithril/client.go`** — added `AcceptedNetworks()`, the known-network
  allowlist (mirrors the existing `AcceptedBackends()`).
- **`mithril/bootstrap.go`** — added `validateSnapshotIdentity()` (network
  allowlist + exact 64-char hex digest check); called right after the v1
  snapshot is fetched, before any archive filename is built; wrapped every
  v1 filename construction (primary + ancillary archive names) in
  `filepath.Base`.
- **`mithril/bootstrap_v2.go`** — wired the same validation call in right
  after the v2 artifact's self-hash check; wrapped every v2 filename
  construction (ancillary, digests, immutable-archive) in `filepath.Base`.
- **`mithril/bootstrap_test.go`, `mithril/bootstrap_v2_test.go`** — new
  regression tests for path-traversal sequences in `Network`/`Digest`/
  `Hash`, a table test for `validateSnapshotIdentity`, and fixes to
  pre-existing placeholder digests that were too short for the new
  exact-length check.
- **`mithril/client_test.go`** — same placeholder-digest fix, limited to
  the one test that actually exercises `Bootstrap()`.
- **`ARCHITECTURE.md`** — documented the new validation and normalization
  in the "Mithril Bootstrap" section.

Closes #2041 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates Mithril snapshot metadata and normalizes all derived filenames and extraction directories before any path use. This blocks path traversal and keeps cache checks, downloads, and extractions on the same safe paths.

- **Bug Fixes**
  - Added `validateSnapshotIdentity`: allowlists default networks or the operator-configured `BootstrapConfig.Network`, and enforces 64‑char hex `Digest`/`Hash`; called immediately after metadata fetch/self-hash.
  - Applied `filepath.Base` at every filename and directory construction (archives, ancillary, digests, immutable archives, extract dirs) so cache, download, and extraction paths cannot diverge.
  - Introduced `AcceptedNetworks()` as the single source of truth for network validation.
  - Strengthened tests: traversal cases for `Network`/`Digest`/`Hash`, rebuilt the v2 traversal test on the full fixture, allowed insecure HTTP in those tests for local servers, updated placeholder digests, and expanded `ARCHITECTURE.md`.

<sup>Written for commit f76d17bb38ccb7e4c3e89b461ea8ac2ddc1a2e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootstrap validation for network identifiers and snapshot digests.
  * Prevented malformed metadata and path traversal values from affecting downloads, extraction, or cache paths.
  * Added safeguards for both standard and version 2 bootstrap flows.
* **New Features**
  * Added a way to retrieve the supported Mithril network identifiers in sorted order.
* **Tests**
  * Added coverage for invalid networks, malformed digests, and malicious path values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->