### PR TITLE
feat(api): add top-level API security config with per-plugin TLS/auth overrides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3111,12 +3111,73 @@ those indexes in place while deferring the remaining manifest entries.
 
 Dingo provides three client-facing APIs plus Bark. All are optional and gated by port configuration. UTxO RPC, Blockfrost, and Mesh are general-purpose external APIs and require `storageMode: api`. Bark is different: it is Dingo's own protocol for Dingo-to-Dingo C2/archive services, not a general-purpose application API.
 
-The current client-facing API security configuration is asymmetric. UTxO RPC
-receives the process-level TLS certificate/key pair; Blockfrost and Mesh do not,
-and none of the three authenticates clients in-process. Public deployments
-therefore require a reverse proxy or API gateway for uniform TLS,
-authentication, and rate limiting. Composition must not imply that the root TLS
-fields protect every API listener.
+All three general-purpose APIs (Blockfrost, Mesh, UTxO RPC) share one TLS and
+authentication surface (dingo #2996/#2998). Each provider's `ProviderConfig`
+still decodes only its own `plugins.api.<capability>.config` (currently just
+`port`); TLS/auth are not provider-specific YAML fields. Instead, a top-level
+`api:` section (`internal/config.APIConfig`, fields `tls` and `auth`) supplies
+shared defaults, and a provider can override any field for itself under its
+own `plugins.api.<capability>.config.tls`/`.auth`. Composition — not the API
+domain packages under `api/blockfrost`, `api/mesh`, `api/utxorpc` — resolves
+this: `Config.EffectiveAPIPolicy()` folds the deprecated root
+`tlsCertFilePath`/`tlsKeyFilePath` fields in as the fallback default for
+`api.tls` when `api.tls` itself is entirely unset (so an upgraded deployment
+keeps its existing TLS listener without any config change), and
+`config.ResolveAPISecurity(policy, selection)` merges that top-level policy
+with a provider's raw `tls`/`auth` config maps field-by-field — not as
+whole-object replacement — into a `ResolvedAPISecurity`: a concrete,
+instance-owned settings snapshot with no further mode-conditional logic left
+for a provider to apply. Node composition (`node.go`'s `Run`) calls
+`ResolveAPISecurity` once per API capability and passes the result through
+each provider's `ProviderDependencies` (`TLSCertFilePath`/`TLSKeyFilePath`,
+`AuthMode`/`AuthTokenFilePath`) alongside the existing `Host`/
+`CORSAllowedOrigins` fields, the same way it already threaded those. Both
+`Run` and the live database Restore/Truncate reinit path
+(`node_lifecycle.go`'s `reinitializeAPIServers`, which rebuilds the same
+three providers in place after storage is swapped) call this resolution
+through one shared `*Node` helper (`resolveAPISecurity`, `node.go`) rather
+than each resolving it separately, so a live restore/truncate can never
+rebuild a provider with different effective TLS/auth settings than the
+initial startup would have produced for the same `Config`. A provider field
+is only treated as an explicit override when it is a
+non-empty value (including the disabling sentinels `"off"`/`"none"`); an
+absent key, or one present with an empty string, inherits the top-level
+field instead — so a provider can affirmatively disable an inherited TLS or
+auth policy, but an accidental blank value cannot silently disable one.
+`Config.Validate` checks the effective merged policy for every provider
+selection (active or not) via `ResolveAPISecurity`/`ValidateAPISecurity`,
+reporting the full provider config path (e.g.
+`plugins.api.mesh.config.auth`) in any error, and only the resolved settings
+struct ever reaches a provider — never a partially-applied intermediate
+state. `bindAddr` and `corsAllowedOrigins` remain root-level fields rather
+than moving under `api:`: `bindAddr` is a node-wide bind address shared by
+non-API listeners too (relay, private, metrics, debug, bark), not an
+API-specific setting, and `corsAllowedOrigins` has no per-provider override
+requirement, so duplicating it under `api:` would only create a second
+source of truth for the same setting.
+
+TLS is now available on all three listeners (previously only UTxO RPC);
+Blockfrost and Mesh gained the identical `tls.LoadX509KeyPair` +
+`tlsutil.ServerConfig` + `http.Server.ServeTLS` wiring UTxO RPC already used.
+Authentication is enforced by one shared implementation,
+`internal/apiauth.Verifier`, used by all three providers as an innermost
+`net/http` middleware wrapping each provider's mux (applied after CORS
+preflight handling, so a browser's OPTIONS preflight is never rejected for
+lacking a credential). Two modes are supported: `"none"` (default) performs
+no check; `"token"` requires an `Authorization: Bearer <token>` header, or,
+as a Blockfrost-compatible alias accepted on every provider (not just
+Blockfrost), a `project_id: <token>` header — the same shared token, matching
+Blockfrost's own client convention. A missing or incorrect credential fails
+closed with HTTP 401; Connect's own client-side protocol implementation maps
+a bare 401 (outside its error envelope) to `CodeUnauthenticated` for
+Connect/gRPC-Web callers of UTxO RPC, so this single HTTP-level check also
+answers "Unauthenticated" for that transport without a dedicated
+`connect.Interceptor`. `apiauth.Verifier` never logs its loaded token
+(`String`/`LogValue` redact it), and configuration only ever carries the
+token's file path, never its contents, so effective-config/debug output has
+no auth material to leak. Native gRPC trailers-only transport is not served
+by dingo's API providers, so mapping this middleware onto it is out of
+scope.
 
 ### Blockfrost API (`api/blockfrost/`)
 
@@ -3132,7 +3193,9 @@ Dingo's internal state and Blockfrost response types and supports
 Blockfrost-style pagination headers. The root document is served only at the
 literal `/` path (`GET /{$}`); any other unregistered path falls through to a
 catch-all `404` handler instead of the root document, matching real
-Blockfrost's behavior for unimplemented routes.
+Blockfrost's behavior for unimplemented routes. Shares the TLS/auth surface
+described above with Mesh and UTxO RPC; its shared-token auth mode also
+accepts the real Blockfrost `project_id` header as an alias.
 
 The account UTxOs, withdrawals, and transactions endpoints resolve everything
 by stake credential rather than a single address. Account UTxOs reuse the
@@ -3242,11 +3305,11 @@ datum metadata are not yet sourced and return `null`.
 
 ### Mesh API (`api/mesh/`)
 
-Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access.
+Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access. Shares the TLS/auth surface described above with Blockfrost and UTxO RPC.
 
 ### UTxO RPC (`api/utxorpc/`)
 
-A gRPC server implementing the UTxO RPC specification with query, submit, sync, and watch services. The same listener exposes both the `utxorpc.v1alpha` and `utxorpc.v1beta` service namespaces. Every method other than v1beta's additional `QueryService.ReadState` is wire-compatible across the two, so the beta routes rewrite the service path onto the alpha handlers; `ReadState` is served by `betaQueryServiceServer` (`api/utxorpc/readstate.go`) instead. It answers the one Cardano state query v1beta defines, `GetStakePoolDistribution`, from `ledger.LedgerState.PoolStakeDistribution` — the same read that backs the node-to-client `GetPoolDistr2` query. The `ledger_tip` it reports is the tip that read took inside its own transaction, carried back on the result, rather than one sampled while building the reply: the two can straddle an epoch boundary, and a later tip would name an epoch whose stake snapshot is not the one the reply carries. `LedgerState` is an optional dependency that `Utxorpc.Start` admits as an untyped nil, so the handler checks it per request and reports `Unavailable` rather than panicking. The `pool_keyhashes` filter is capped by `MaxPoolFilter` (default 1000), like the `ReadUtxos` and `ReadData` key lists, since it sizes the snapshot and registration reads it drives; asking for every pool is an empty filter and one bulk read. An empty `pool_keyhashes` means every pool, per the proto; a filter entry that is not 28 bytes is rejected as `InvalidArgument` rather than padded or truncated into a different pool. Because the protobuf `RationalNumber` is an int32 over a uint32, a stake fraction whose exact ratio does not fit — the normal case on a real network, where the denominator is total active stake in lovelace — is rescaled onto a fixed denominator of 1e9 rather than failing. `newServeMux` is the single wiring site for the routing table, and one service-name list (`servedServiceNames`) feeds the `grpc_health_v1` checker and both reflection wire versions, so `grpc.reflection.v1` and `grpc.reflection.v1alpha` clients discover the same services — v1alpha is an older reflection protocol, not an older API surface. Supports optional TLS.
+A gRPC server implementing the UTxO RPC specification with query, submit, sync, and watch services. The same listener exposes both the `utxorpc.v1alpha` and `utxorpc.v1beta` service namespaces. Every method other than v1beta's additional `QueryService.ReadState` is wire-compatible across the two, so the beta routes rewrite the service path onto the alpha handlers; `ReadState` is served by `betaQueryServiceServer` (`api/utxorpc/readstate.go`) instead. It answers the one Cardano state query v1beta defines, `GetStakePoolDistribution`, from `ledger.LedgerState.PoolStakeDistribution` — the same read that backs the node-to-client `GetPoolDistr2` query. The `ledger_tip` it reports is the tip that read took inside its own transaction, carried back on the result, rather than one sampled while building the reply: the two can straddle an epoch boundary, and a later tip would name an epoch whose stake snapshot is not the one the reply carries. `LedgerState` is an optional dependency that `Utxorpc.Start` admits as an untyped nil, so the handler checks it per request and reports `Unavailable` rather than panicking. The `pool_keyhashes` filter is capped by `MaxPoolFilter` (default 1000), like the `ReadUtxos` and `ReadData` key lists, since it sizes the snapshot and registration reads it drives; asking for every pool is an empty filter and one bulk read. An empty `pool_keyhashes` means every pool, per the proto; a filter entry that is not 28 bytes is rejected as `InvalidArgument` rather than padded or truncated into a different pool. Because the protobuf `RationalNumber` is an int32 over a uint32, a stake fraction whose exact ratio does not fit — the normal case on a real network, where the denominator is total active stake in lovelace — is rescaled onto a fixed denominator of 1e9 rather than failing. `newServeMux` is the single wiring site for the routing table, and one service-name list (`servedServiceNames`) feeds the `grpc_health_v1` checker and both reflection wire versions, so `grpc.reflection.v1` and `grpc.reflection.v1alpha` clients discover the same services — v1alpha is an older reflection protocol, not an older API surface. Supports optional TLS and shares the TLS/auth surface described above with Blockfrost and Mesh.
 
 ### Koios Parity Tracker (`cmd/koios-parity/`, `internal/koiosparity/`)
 
@@ -4208,6 +4271,22 @@ The pre-plugin API port names `DINGO_UTXORPC_PORT`,
 `DINGO_BLOCKFROST_PORT`, and `DINGO_MESH_PORT` are compatibility aliases for
 their `DINGO_PLUGINS_API_*_CONFIG_PORT` counterparts. Within the environment
 tier, the plugin-form name takes precedence when both forms are set.
+
+The top-level `api:` TLS/auth policy (dingo #2998; see "External Interfaces"
+above) is a separate, additional layer on top of this same source
+precedence, not a bypass of it: CLI/env/YAML resolve `api.tls`/`api.auth`
+and each provider's own `plugins.api.<capability>.config.tls`/`.auth`
+exactly like any other field, through the ordinary precedence chain above.
+Only once that merged `Config` is final does composition apply the *scope*
+layering — explicit provider field, then top-level `api` field, then a
+disabled-by-default provider default — via `Config.EffectiveAPIPolicy()`
+and `config.ResolveAPISecurity`. The CLI/env tier is currently flat for the
+top-level `api:` fields only (five explicit `envconfig` names, e.g.
+`DINGO_API_TLS_MODE`, plus matching `--api-tls-mode`-style flags); a
+provider's own nested `tls`/`auth` overrides are YAML-only today, since the
+generic plugin environment overlay (`hostplugin.ApplyEnvironment`) does not
+attempt to flatten nested provider config keys (see its own doc comment) and
+this change does not extend that.
 
 `LoadConfig` (`internal/config`) only parses and merges the YAML and
 environment sources; it makes no semantic judgments about the merged values,

--- a/README.md
+++ b/README.md
@@ -112,10 +112,22 @@ The following environment variables modify Dingo's behavior:
   - Log output format: `text` (default, human-readable) or `json` (machine-parseable, for ELK/Loki ingestion)
 - `DINGO_LOGGING_LEVEL`
   - Minimum log level: `debug`, `info` (default), `warn`, or `error` (the `--debug` flag overrides this to `debug`)
-- `TLS_CERT_FILE_PATH` - TLS certificate used by the built-in UTxO RPC
-  listener, requires `TLS_KEY_FILE_PATH` (default: empty)
-- `TLS_KEY_FILE_PATH` - TLS private key used by the built-in UTxO RPC listener
+- `TLS_CERT_FILE_PATH` - TLS certificate used directly by bark and Midnight;
+  deprecated as an API TLS source in favor of `DINGO_API_TLS_CERT_FILE_PATH`
+  below, kept only as its fallback default. Requires `TLS_KEY_FILE_PATH`
   (default: empty)
+- `TLS_KEY_FILE_PATH` - TLS private key used directly by bark and Midnight;
+  see `TLS_CERT_FILE_PATH` (default: empty)
+- `DINGO_API_TLS_MODE` - Shared TLS mode for every built-in API provider
+  (Blockfrost, Mesh, UTxO RPC): `off` (default) or `server`
+- `DINGO_API_TLS_CERT_FILE_PATH` / `DINGO_API_TLS_KEY_FILE_PATH` - Shared
+  API TLS certificate/key, required together when `DINGO_API_TLS_MODE` is
+  `server`
+- `DINGO_API_AUTH_MODE` - Shared in-process authentication mode for every
+  built-in API provider: `none` (default) or `token`
+- `DINGO_API_AUTH_TOKEN_FILE_PATH` - File containing the shared bearer
+  credential, required when `DINGO_API_AUTH_MODE` is `token`. See "API
+  Servers and Bark" below for the full `api:`/per-provider override shape.
 
 ### Block Production (SPO Mode)
 
@@ -213,9 +225,55 @@ interface.
 Bark is Dingo's own Dingo-to-Dingo archive protocol rather than an application
 API. It is configured separately with `barkPort` and `barkBaseUrl`.
 
-For public client access, place the API listeners behind a reverse proxy or API
-gateway. UTxO RPC currently supports the process TLS certificate/key pair;
-Blockfrost and Mesh do not, and the built-in APIs do not authenticate clients.
+All three providers share one TLS and authentication surface. A top-level
+`api:` section supplies TLS/auth defaults for every provider at once, and any
+field can be overridden per provider under `plugins.api.<name>.config.tls`/
+`.auth`:
+
+```yaml
+api:
+  tls:
+    mode: server
+    certFilePath: /run/secrets/api.crt
+    keyFilePath: /run/secrets/api.key
+  auth:
+    mode: token
+    tokenFilePath: /run/secrets/api-token
+
+plugins:
+  api:
+    mesh:
+      provider: builtin
+      config:
+        port: 8080
+        auth:
+          mode: none # explicitly disable the shared token policy for Mesh only
+    blockfrost:
+      provider: builtin
+      config:
+        port: 3000
+        tls:
+          certFilePath: /run/secrets/blockfrost.crt
+          keyFilePath: /run/secrets/blockfrost.key
+```
+
+`tls.mode` is `off` (default) or `server`; `server` requires both
+`certFilePath` and `keyFilePath` (from the top-level section, a provider
+override, or a mix of both -- resolution is field-by-field, not
+whole-object). `auth.mode` is `none` (default) or `token`; `token` requires
+`tokenFilePath`, whose trimmed contents clients present as
+`Authorization: Bearer <token>` or, for Blockfrost-compatible clients,
+`project_id: <token>`. A missing/incorrect credential gets a `401` (Connect
+clients see `Unauthenticated`). This is still not a substitute for placing
+public listeners behind a TLS-terminating reverse proxy or API gateway for
+rate limiting and defense in depth, but each of the three providers can now
+also enforce TLS and authentication itself.
+
+The deprecated root `tlsCertFilePath`/`tlsKeyFilePath` fields (used directly
+by bark and Midnight) remain a fallback default for `api.tls` when `api.tls`
+is entirely unset, so an existing deployment's API TLS listener keeps working
+unchanged after upgrading; prefer `api.tls.certFilePath`/`api.tls.keyFilePath`
+in new configuration.
 
 The shorter `DINGO_UTXORPC_PORT`, `DINGO_BLOCKFROST_PORT`, and
 `DINGO_MESH_PORT` names remain supported for compatibility. If both a

--- a/api/blockfrost/auth_test.go
+++ b/api/blockfrost/auth_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfrost
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/apiauth"
+	"github.com/stretchr/testify/require"
+)
+
+// doRequest performs req and asserts it completed without a transport
+// error, returning a guaranteed non-nil response. Centralizing the nil
+// guard here (rather than relying on require.NoError alone before
+// dereferencing resp at each call site) keeps every call site provably
+// safe.
+func doRequest(
+	t *testing.T,
+	client *http.Client,
+	req *http.Request,
+) *http.Response {
+	t.Helper()
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	if resp == nil {
+		t.Fatal("http.Client.Do returned a nil response with a nil error")
+	}
+	return resp
+}
+
+// TestHandlerAuthModeNone covers the default (no in-process
+// authentication) behavior: requests reach the mux unauthenticated.
+func TestHandlerAuthModeNone(t *testing.T) {
+	verifier, err := apiauth.NewVerifier(apiauth.Policy{})
+	require.NoError(t, err)
+	b := newTestBlockfrost(&mockNode{})
+	srv := httptest.NewServer(b.handler(verifier))
+	defer srv.Close()
+
+	req, err := http.NewRequest( //nolint:noctx
+		http.MethodGet,
+		srv.URL+"/health",
+		nil,
+	)
+	require.NoError(t, err)
+	resp := doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
+	require.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestHandlerAuthModeToken covers dingo #2996's fail-closed token
+// enforcement at the actual listener level (real TCP connection through
+// net/http, not a direct handler call), including the Blockfrost-specific
+// project_id header alias.
+func TestHandlerAuthModeToken(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("s3cret"), 0o600))
+	verifier, err := apiauth.NewVerifier(apiauth.Policy{
+		Mode:          apiauth.ModeToken,
+		TokenFilePath: tokenPath,
+	})
+	require.NoError(t, err)
+	b := newTestBlockfrost(&mockNode{})
+	srv := httptest.NewServer(b.handler(verifier))
+	defer srv.Close()
+
+	newHealthRequest := func(headers map[string]string) *http.Request {
+		req, reqErr := http.NewRequest( //nolint:noctx
+			http.MethodGet,
+			srv.URL+"/health",
+			nil,
+		)
+		require.NoError(t, reqErr)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		return req
+	}
+
+	// No credential: fails closed with 401.
+	resp := doRequest(t, http.DefaultClient, newHealthRequest(nil))
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.NotEmpty(t, resp.Header.Get("WWW-Authenticate"))
+
+	// Correct bearer credential: reaches the mux.
+	resp = doRequest(t, http.DefaultClient, newHealthRequest(map[string]string{
+		"Authorization": "Bearer s3cret",
+	}))
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Blockfrost-compatible project_id header alias for the same token.
+	resp = doRequest(t, http.DefaultClient, newHealthRequest(map[string]string{
+		"project_id": "s3cret",
+	}))
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Wrong credential: still fails closed.
+	resp = doRequest(t, http.DefaultClient, newHealthRequest(map[string]string{
+		"Authorization": "Bearer wrong",
+	}))
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -16,6 +16,7 @@ package blockfrost
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +26,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
+	"github.com/blinklabs-io/dingo/internal/tlsutil"
 )
 
 // Blockfrost is the Blockfrost-compatible REST API server.
@@ -60,8 +63,11 @@ func New(
 }
 
 // handler builds the HTTP handler for the Blockfrost API,
-// including route registration and middleware.
-func (b *Blockfrost) handler() http.Handler {
+// including route registration and middleware. auth enforces the
+// effective authentication policy (nil or apiauth.ModeNone accepts every
+// request); it wraps the whole mux, so every route -- including /health --
+// requires the configured credential when auth mode is "token".
+func (b *Blockfrost) handler(auth *apiauth.Verifier) http.Handler {
 	mux := http.NewServeMux()
 	// "GET /{$}" matches only the literal root path. Without
 	// "{$}" the pattern would act as a subtree match and
@@ -258,8 +264,14 @@ func (b *Blockfrost) handler() http.Handler {
 	// Wrap handler with a request body size limit (1 MB)
 	// as defense-in-depth against oversized payloads.
 	const maxRequestBodyBytes int64 = 1 << 20 // 1 MB
+	// Authentication runs innermost (after CORS preflight, before request
+	// handling): a browser's CORS preflight OPTIONS request carries no
+	// credential and must not be rejected by auth, while every actual
+	// request is checked before it reaches a route handler.
 	return httpcors.Handler(
-		http.MaxBytesHandler(mux, maxRequestBodyBytes),
+		auth.Middleware(
+			http.MaxBytesHandler(mux, maxRequestBodyBytes),
+		),
 		httpcors.Config{
 			AllowedOrigins: b.config.CORSAllowedOrigins,
 		},
@@ -270,6 +282,11 @@ func (b *Blockfrost) handler() http.Handler {
 func (b *Blockfrost) Start(
 	ctx context.Context,
 ) error {
+	auth, err := apiauth.NewVerifier(b.config.Auth)
+	if err != nil {
+		return fmt.Errorf("blockfrost: %w", err)
+	}
+
 	b.mu.Lock()
 	if b.httpServer != nil {
 		b.mu.Unlock()
@@ -278,10 +295,27 @@ func (b *Blockfrost) Start(
 
 	server := &http.Server{
 		Addr:              b.config.ListenAddress,
-		Handler:           b.handler(),
+		Handler:           b.handler(auth),
 		ReadHeaderTimeout: 60 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
+	}
+	useTLS := b.config.TLSCertFilePath != "" && b.config.TLSKeyFilePath != ""
+	if useTLS {
+		cert, err := tls.LoadX509KeyPair(
+			b.config.TLSCertFilePath,
+			b.config.TLSKeyFilePath,
+		)
+		if err != nil {
+			b.mu.Unlock()
+			return fmt.Errorf(
+				"blockfrost: loading TLS certificate/key: %w",
+				err,
+			)
+		}
+		server.TLSConfig = tlsutil.ServerConfig(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+		})
 	}
 	b.httpServer = server
 	b.mu.Unlock()
@@ -294,9 +328,16 @@ func (b *Blockfrost) Start(
 		return err
 	}
 
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
 	b.logger.Info(
-		"Blockfrost API listener started on " +
+		fmt.Sprintf(
+			"Blockfrost API listener started on %s (%s)",
 			b.config.ListenAddress,
+			scheme,
+		),
 	)
 
 	// Monitor context for cancellation
@@ -375,11 +416,18 @@ func (b *Blockfrost) startServer(
 		)
 	}
 	go func() {
-		if err := server.Serve(ln); err != nil &&
-			!errors.Is(err, http.ErrServerClosed) {
+		var serveErr error
+		if server.TLSConfig != nil {
+			// Certificates are already loaded into TLSConfig, so no
+			// cert/key file paths are passed here.
+			serveErr = server.ServeTLS(ln, "", "")
+		} else {
+			serveErr = server.Serve(ln)
+		}
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			b.logger.Error(
 				"Blockfrost API server error",
-				"error", err,
+				"error", serveErr,
 			)
 		}
 	}()

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -635,7 +635,7 @@ func TestHandleRoot(t *testing.T) {
 func TestRouterRootServesRootDocument(t *testing.T) {
 	mock := &mockNode{}
 	b := newTestBlockfrost(mock)
-	handler := b.handler()
+	handler := b.handler(nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -652,7 +652,7 @@ func TestRouterRootServesRootDocument(t *testing.T) {
 func TestRouterUnimplementedRouteReturns404(t *testing.T) {
 	mock := &mockNode{}
 	b := newTestBlockfrost(mock)
-	handler := b.handler()
+	handler := b.handler(nil)
 
 	// "/api/v0/pools" used to belong here as an unimplemented route. It is
 	// now registered (dingo #3011), so it no longer falls through to the
@@ -681,7 +681,7 @@ func TestRouterUnimplementedRouteReturns404(t *testing.T) {
 func TestRouterImplementedRouteStillWorks(t *testing.T) {
 	mock := &mockNode{}
 	b := newTestBlockfrost(mock)
-	handler := b.handler()
+	handler := b.handler(nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -3272,8 +3272,11 @@ func TestNodeAdapterAddressRejectsInvalidInput(t *testing.T) {
 		)
 		require.True(t, strings.HasPrefix(err.Error(), prefix),
 			"unexpected wrapper shape: %s", err)
-		assert.NotEmpty(t, strings.TrimSpace(strings.TrimPrefix(err.Error(), prefix)),
-			"the underlying parse error is retained, not discarded")
+		assert.NotEmpty(
+			t,
+			strings.TrimSpace(strings.TrimPrefix(err.Error(), prefix)),
+			"the underlying parse error is retained, not discarded",
+		)
 	})
 
 	t.Run("this network resolves to not found", func(t *testing.T) {

--- a/api/blockfrost/config.go
+++ b/api/blockfrost/config.go
@@ -14,6 +14,8 @@
 
 package blockfrost
 
+import "github.com/blinklabs-io/dingo/internal/apiauth"
+
 // BlockfrostConfig holds configuration for the Blockfrost
 // API server.
 type BlockfrostConfig struct {
@@ -23,4 +25,15 @@ type BlockfrostConfig struct {
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.
 	CORSAllowedOrigins []string
+	// TLSCertFilePath and TLSKeyFilePath enable TLS on the listener when
+	// both are set; either one alone is treated as TLS disabled, matching
+	// the built-in UTxO RPC provider's existing convention. Resolved from
+	// the shared api: policy plus this provider's own overrides -- see
+	// internal/config.ResolveAPISecurity (dingo #2996/#2998).
+	TLSCertFilePath string
+	TLSKeyFilePath  string
+	// Auth configures in-process credential enforcement, shared with Mesh
+	// and UTxO RPC via internal/apiauth. The zero value is apiauth.ModeNone
+	// (no authentication).
+	Auth apiauth.Policy
 }

--- a/api/blockfrost/pool_detail_test.go
+++ b/api/blockfrost/pool_detail_test.go
@@ -210,7 +210,7 @@ func TestPoolsRouteOrderingPoolDetailDoesNotSwallowSiblings(t *testing.T) {
 		poolDetail: PoolDetailInfo{PoolID: "pool1detail"},
 	}
 	b := newTestBlockfrost(mock)
-	handler := b.handler()
+	handler := b.handler(nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/pools/retiring", nil)
 	w := httptest.NewRecorder()

--- a/api/blockfrost/provider.go
+++ b/api/blockfrost/provider.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
@@ -27,11 +28,20 @@ type ProviderConfig struct {
 	Port uint `yaml:"port"`
 }
 
+// ProviderDependencies carries resolved, instance-owned settings from
+// composition (internal/config.ResolveAPISecurity merges the shared api:
+// policy with this provider's own plugins.api.blockfrost.config.tls/auth
+// overrides before Run passes the result here) -- this package does not
+// perform that merge itself.
 type ProviderDependencies struct {
 	Node               BlockfrostNode
 	Logger             *slog.Logger
 	Host               string
 	CORSAllowedOrigins []string
+	TLSCertFilePath    string
+	TLSKeyFilePath     string
+	AuthMode           apiauth.Mode
+	AuthTokenFilePath  string
 }
 
 func RegisterProvider(host *plugin.Host) error {
@@ -50,6 +60,12 @@ func RegisterProvider(host *plugin.Host) error {
 					strconv.FormatUint(uint64(cfg.Port), 10),
 				),
 				CORSAllowedOrigins: deps.CORSAllowedOrigins,
+				TLSCertFilePath:    deps.TLSCertFilePath,
+				TLSKeyFilePath:     deps.TLSKeyFilePath,
+				Auth: apiauth.Policy{
+					Mode:          deps.AuthMode,
+					TokenFilePath: deps.AuthTokenFilePath,
+				},
 			}, deps.Node, deps.Logger)
 			return server, server, nil
 		},

--- a/api/blockfrost/tls_listener_test.go
+++ b/api/blockfrost/tls_listener_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfrost
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestTLSCertKey generates a throwaway self-signed cert/key pair valid
+// for 127.0.0.1 and writes them as PEM files under a fresh t.TempDir(),
+// returning their paths. Mirrors bark/tls_test.go's helper of the same
+// name/shape; kept local rather than shared since it's a generic test
+// fixture, not a domain mock.
+func writeTestTLSCertKey(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(
+		rand.Reader, template, template, &priv.PublicKey, priv,
+	)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+
+	certOut, err := os.Create(certPath)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}),
+	)
+	require.NoError(t, certOut.Close())
+
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyOut, err := os.OpenFile(
+		keyPath,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		0o600,
+	)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}),
+	)
+	require.NoError(t, keyOut.Close())
+
+	return certPath, keyPath
+}
+
+// reserveFreePort binds an ephemeral TCP port, closes the listener
+// immediately, and returns the port number, for tests that need a
+// concrete port number up front (Start's ListenAddress is a static
+// string, so ":0" alone can't be resolved back to the OS-assigned port).
+func reserveFreePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+// TestStartTLSHandshake covers dingo #2996/#2998's built-in TLS listener
+// support for Blockfrost (previously only UTxO RPC had it): with
+// TLSCertFilePath/TLSKeyFilePath configured, Start must serve HTTPS, and a
+// plaintext HTTP client must fail against it.
+func TestStartTLSHandshake(t *testing.T) {
+	certPath, keyPath := writeTestTLSCertKey(t)
+	port := reserveFreePort(t)
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+
+	b := New(BlockfrostConfig{
+		ListenAddress:   addr,
+		TLSCertFilePath: certPath,
+		TLSKeyFilePath:  keyPath,
+	}, &mockNode{}, nil)
+
+	require.NoError(t, b.Start(t.Context()))
+	defer func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancel()
+		_ = b.Stop(ctx)
+	}()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			}, //nolint:gosec // test-only, self-signed cert
+		},
+		Timeout: 5 * time.Second,
+	}
+	req, err := http.NewRequest( //nolint:noctx
+		http.MethodGet,
+		"https://"+addr+"/health",
+		nil,
+	)
+	require.NoError(t, err)
+	resp := doRequest(t, client, req)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// A plaintext client must not get a successful response from a TLS
+	// listener. Go's net/http server detects a non-TLS ClientHello and
+	// replies with a plaintext "Client sent an HTTP request to an HTTPS
+	// server" 400 over the same connection rather than failing the
+	// transport outright, so the assertion is on the status code, not a
+	// transport-level error.
+	plainClient := &http.Client{Timeout: 2 * time.Second}
+	plainReq, err := http.NewRequest( //nolint:noctx
+		http.MethodGet,
+		"http://"+addr+"/health",
+		nil,
+	)
+	require.NoError(t, err)
+	plainResp := doRequest(t, plainClient, plainReq)
+	defer plainResp.Body.Close()
+	require.NotEqual(t, http.StatusOK, plainResp.StatusCode)
+}

--- a/api/mesh/mesh.go
+++ b/api/mesh/mesh.go
@@ -16,6 +16,7 @@ package mesh
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -27,7 +28,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
+	"github.com/blinklabs-io/dingo/internal/tlsutil"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
@@ -67,6 +70,17 @@ type ServerConfig struct {
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.
 	CORSAllowedOrigins []string
+	// TLSCertFilePath and TLSKeyFilePath enable TLS on the listener when
+	// both are set; either one alone is treated as TLS disabled, matching
+	// the built-in UTxO RPC provider's existing convention. Resolved from
+	// the shared api: policy plus this provider's own overrides -- see
+	// internal/config.ResolveAPISecurity (dingo #2996/#2998).
+	TLSCertFilePath string
+	TLSKeyFilePath  string
+	// Auth configures in-process credential enforcement, shared with
+	// Blockfrost and UTxO RPC via internal/apiauth. The zero value is
+	// apiauth.ModeNone (no authentication).
+	Auth apiauth.Policy
 }
 
 // Server is the Mesh-compatible REST API server.
@@ -163,28 +177,59 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}, nil
 }
 
+// handler builds the HTTP handler for the Mesh API, including route
+// registration and middleware. auth enforces the effective authentication
+// policy (nil or apiauth.ModeNone accepts every request); it wraps the
+// whole mux, so every route requires the configured credential when auth
+// mode is "token".
+func (s *Server) handler(auth *apiauth.Verifier) http.Handler {
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+	// Authentication runs innermost (after CORS preflight, before request
+	// handling): a browser's CORS preflight OPTIONS request carries no
+	// credential and must not be rejected by auth, while every actual
+	// request is checked before it reaches a route handler.
+	return httpcors.Handler(
+		auth.Middleware(mux),
+		httpcors.Config{
+			AllowedOrigins: s.config.CORSAllowedOrigins,
+		},
+	)
+}
+
 // Start starts the HTTP server in a background goroutine.
 func (s *Server) Start(ctx context.Context) error {
+	auth, err := apiauth.NewVerifier(s.config.Auth)
+	if err != nil {
+		return fmt.Errorf("mesh: %w", err)
+	}
+
 	s.mu.Lock()
 	if s.httpServer != nil {
 		s.mu.Unlock()
 		return errors.New("server already started")
 	}
 
-	mux := http.NewServeMux()
-	s.registerRoutes(mux)
-
 	server := &http.Server{
-		Addr: s.config.ListenAddress,
-		Handler: httpcors.Handler(
-			mux,
-			httpcors.Config{
-				AllowedOrigins: s.config.CORSAllowedOrigins,
-			},
-		),
+		Addr:              s.config.ListenAddress,
+		Handler:           s.handler(auth),
 		ReadHeaderTimeout: 60 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
+	}
+	useTLS := s.config.TLSCertFilePath != "" && s.config.TLSKeyFilePath != ""
+	if useTLS {
+		cert, err := tls.LoadX509KeyPair(
+			s.config.TLSCertFilePath,
+			s.config.TLSKeyFilePath,
+		)
+		if err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("mesh: loading TLS certificate/key: %w", err)
+		}
+		server.TLSConfig = tlsutil.ServerConfig(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+		})
 	}
 	s.httpServer = server
 
@@ -232,9 +277,16 @@ func (s *Server) Start(ctx context.Context) error {
 		return err
 	}
 
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
 	s.logger.Info(
-		"Mesh API listener started on " +
+		fmt.Sprintf(
+			"Mesh API listener started on %s (%s)",
 			s.config.ListenAddress,
+			scheme,
+		),
 	)
 
 	return nil
@@ -272,11 +324,18 @@ func (s *Server) startServer(
 		)
 	}
 	go func() {
-		if err := server.Serve(ln); err != nil &&
-			!errors.Is(err, http.ErrServerClosed) {
+		var serveErr error
+		if server.TLSConfig != nil {
+			// Certificates are already loaded into TLSConfig, so no
+			// cert/key file paths are passed here.
+			serveErr = server.ServeTLS(ln, "", "")
+		} else {
+			serveErr = server.Serve(ln)
+		}
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			s.logger.Error(
 				"Mesh API server error",
-				"error", err,
+				"error", serveErr,
 			)
 		}
 	}()

--- a/api/mesh/mesh_test.go
+++ b/api/mesh/mesh_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
+	"github.com/blinklabs-io/dingo/mempool"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/stretchr/testify/require"
+)
+
+// stubChain/stubDatabase/stubLedgerState/stubMempool are minimal
+// interface-satisfying doubles for the package-local dependency
+// interfaces (node_interface.go), used only to get past NewServer's
+// non-nil checks for HTTP-layer tests below. They deliberately do not
+// simulate any real chain/ledger/mempool behavior.
+type stubChain struct{}
+
+func (stubChain) Tip() ochainsync.Tip { return ochainsync.Tip{} }
+
+type stubDatabase struct{}
+
+func (stubDatabase) BlockByHash(hash []byte) (models.Block, error) {
+	return models.Block{}, nil
+}
+
+func (stubDatabase) BlockByIndex(idx uint64) (models.Block, error) {
+	return models.Block{}, nil
+}
+
+func (stubDatabase) GetTransactionByHash(
+	hash []byte,
+) (*models.Transaction, error) {
+	return nil, nil
+}
+
+func (stubDatabase) GetTransactionsByBlockHash(
+	hash []byte,
+) ([]models.Transaction, error) {
+	return nil, nil
+}
+
+type stubLedgerState struct{}
+
+func (stubLedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
+	return nil
+}
+
+func (stubLedgerState) SlotToTime(slot uint64) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (stubLedgerState) UtxosByAddress(
+	addr lcommon.Address,
+) ([]models.Utxo, error) {
+	return nil, nil
+}
+
+type stubMempool struct{}
+
+func (stubMempool) AddTransaction(txType uint, txBytes []byte) error {
+	return nil
+}
+
+func (stubMempool) GetTransaction(
+	hash string,
+) (mempool.MempoolTransaction, bool) {
+	return mempool.MempoolTransaction{}, false
+}
+
+func (stubMempool) Transactions() []mempool.MempoolTransaction { return nil }
+
+func newTestServer(t *testing.T, auth apiauth.Policy) *Server {
+	t.Helper()
+	srv, err := NewServer(ServerConfig{
+		Chain:               stubChain{},
+		Database:            stubDatabase{},
+		LedgerState:         stubLedgerState{},
+		Mempool:             stubMempool{},
+		Network:             "testnet",
+		GenesisHash:         "00",
+		GenesisStartTimeSec: 1,
+		Auth:                auth,
+	})
+	require.NoError(t, err)
+	return srv
+}
+
+// doRequest performs req and asserts it completed without a transport
+// error, returning a guaranteed non-nil response. Centralizing the nil
+// guard here (rather than relying on require.NoError alone before
+// dereferencing resp at each call site) keeps every call site provably
+// safe.
+func doRequest(
+	t *testing.T,
+	client *http.Client,
+	req *http.Request,
+) *http.Response {
+	t.Helper()
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	if resp == nil {
+		t.Fatal("http.Client.Do returned a nil response with a nil error")
+	}
+	return resp
+}
+
+func newNetworkListRequest(t *testing.T, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest( //nolint:noctx
+		http.MethodPost,
+		url+"/network/list",
+		strings.NewReader("{}"),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// TestServerHandlerAuthModeNone covers the default (no in-process
+// authentication) behavior: requests reach the mux unauthenticated.
+func TestServerHandlerAuthModeNone(t *testing.T) {
+	s := newTestServer(t, apiauth.Policy{})
+	verifier, err := apiauth.NewVerifier(s.config.Auth)
+	require.NoError(t, err)
+	srv := httptest.NewServer(s.handler(verifier))
+	defer srv.Close()
+
+	resp := doRequest(
+		t,
+		http.DefaultClient,
+		newNetworkListRequest(t, srv.URL),
+	)
+	defer resp.Body.Close()
+	require.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestServerHandlerAuthModeToken covers dingo #2996's fail-closed token
+// enforcement at the actual listener level (real TCP connection through
+// net/http, not a direct handler call).
+func TestServerHandlerAuthModeToken(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("s3cret"), 0o600))
+
+	s := newTestServer(t, apiauth.Policy{
+		Mode:          apiauth.ModeToken,
+		TokenFilePath: tokenPath,
+	})
+	verifier, err := apiauth.NewVerifier(s.config.Auth)
+	require.NoError(t, err)
+	srv := httptest.NewServer(s.handler(verifier))
+	defer srv.Close()
+
+	// No credential: fails closed with 401.
+	resp := doRequest(
+		t,
+		http.DefaultClient,
+		newNetworkListRequest(t, srv.URL),
+	)
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Correct bearer credential: reaches the mux.
+	req := newNetworkListRequest(t, srv.URL)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	resp = doRequest(t, http.DefaultClient, req)
+	resp.Body.Close()
+	require.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Wrong credential: still fails closed.
+	req2 := newNetworkListRequest(t, srv.URL)
+	req2.Header.Set("Authorization", "Bearer wrong")
+	resp = doRequest(t, http.DefaultClient, req2)
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/api/mesh/provider.go
+++ b/api/mesh/provider.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
@@ -27,6 +28,11 @@ type ProviderConfig struct {
 	Port uint `yaml:"port"`
 }
 
+// ProviderDependencies carries resolved, instance-owned settings from
+// composition (internal/config.ResolveAPISecurity merges the shared api:
+// policy with this provider's own plugins.api.mesh.config.tls/auth
+// overrides before Run passes the result here) -- this package does not
+// perform that merge itself.
 type ProviderDependencies struct {
 	Logger              *slog.Logger
 	LedgerState         MeshLedgerState
@@ -39,6 +45,10 @@ type ProviderDependencies struct {
 	GenesisHash         string
 	GenesisStartTimeSec int64
 	CORSAllowedOrigins  []string
+	TLSCertFilePath     string
+	TLSKeyFilePath      string
+	AuthMode            apiauth.Mode
+	AuthTokenFilePath   string
 }
 
 func RegisterProvider(host *plugin.Host) error {
@@ -61,6 +71,12 @@ func RegisterProvider(host *plugin.Host) error {
 				Network: deps.Network, NetworkMagic: deps.NetworkMagic,
 				GenesisHash: deps.GenesisHash, GenesisStartTimeSec: deps.GenesisStartTimeSec,
 				CORSAllowedOrigins: deps.CORSAllowedOrigins,
+				TLSCertFilePath:    deps.TLSCertFilePath,
+				TLSKeyFilePath:     deps.TLSKeyFilePath,
+				Auth: apiauth.Policy{
+					Mode:          deps.AuthMode,
+					TokenFilePath: deps.AuthTokenFilePath,
+				},
 			})
 			if err != nil {
 				return nil, nil, err

--- a/api/utxorpc/auth_test.go
+++ b/api/utxorpc/auth_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
+	"github.com/stretchr/testify/require"
+)
+
+// newAuthTestServer wires the production Connect routing table behind the
+// same auth.Middleware(mux) chain Start builds, without going through
+// Start's TLS/listener bootstrap -- matching newReflectionTestServer's
+// pattern (reflection_test.go).
+func newAuthTestServer(
+	t *testing.T,
+	auth *apiauth.Verifier,
+) (*httptest.Server, *http.Client) {
+	t.Helper()
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil, nil),
+	})
+	srv := httptest.NewUnstartedServer(auth.Middleware(u.newServeMux()))
+	srv.Config.Protocols = unencryptedHTTP2Protocols()
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv, newConnectH2CClient()
+}
+
+// doRequest performs req and asserts it completed without a transport
+// error, returning a guaranteed non-nil response. Centralizing the nil
+// guard here (rather than relying on require.NoError alone before
+// dereferencing resp at each call site) keeps every call site provably
+// safe.
+func doRequest(
+	t *testing.T,
+	client *http.Client,
+	req *http.Request,
+) *http.Response {
+	t.Helper()
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	if resp == nil {
+		t.Fatal("http.Client.Do returned a nil response with a nil error")
+	}
+	return resp
+}
+
+func newRootRequest(t *testing.T, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url+"/", nil) //nolint:noctx
+	require.NoError(t, err)
+	return req
+}
+
+// TestUtxorpcHandlerAuthModeNone covers the default (no in-process
+// authentication) behavior: requests reach the mux unauthenticated.
+func TestUtxorpcHandlerAuthModeNone(t *testing.T) {
+	verifier, err := apiauth.NewVerifier(apiauth.Policy{})
+	require.NoError(t, err)
+	srv, client := newAuthTestServer(t, verifier)
+
+	resp := doRequest(t, client, newRootRequest(t, srv.URL))
+	defer resp.Body.Close()
+	require.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestUtxorpcHandlerAuthModeToken covers dingo #2996's fail-closed token
+// enforcement at the actual listener level for UTxO RPC's Connect/h2c
+// transport, which is served as an ordinary net/http.Handler.
+func TestUtxorpcHandlerAuthModeToken(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("s3cret"), 0o600))
+	verifier, err := apiauth.NewVerifier(apiauth.Policy{
+		Mode:          apiauth.ModeToken,
+		TokenFilePath: tokenPath,
+	})
+	require.NoError(t, err)
+	srv, client := newAuthTestServer(t, verifier)
+
+	// No credential: fails closed with 401, which Connect's own client
+	// protocol implementation maps to CodeUnauthenticated for Connect/
+	// gRPC-Web callers.
+	resp := doRequest(t, client, newRootRequest(t, srv.URL))
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Correct bearer credential: reaches the mux.
+	req := newRootRequest(t, srv.URL)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	resp = doRequest(t, client, req)
+	resp.Body.Close()
+	require.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Wrong credential: still fails closed.
+	req2 := newRootRequest(t, srv.URL)
+	req2.Header.Set("Authorization", "Bearer wrong")
+	resp = doRequest(t, client, req2)
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/api/utxorpc/provider.go
+++ b/api/utxorpc/provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
@@ -25,6 +26,11 @@ type ProviderConfig struct {
 	Port uint `yaml:"port"`
 }
 
+// ProviderDependencies carries resolved, instance-owned settings from
+// composition (internal/config.ResolveAPISecurity merges the shared api:
+// policy with this provider's own plugins.api.utxorpc.config.tls/auth
+// overrides before Run passes the result here) -- this package does not
+// perform that merge itself.
 type ProviderDependencies struct {
 	Logger             *slog.Logger
 	EventBus           UtxorpcEventBus
@@ -34,6 +40,8 @@ type ProviderDependencies struct {
 	TLSCertFilePath    string
 	TLSKeyFilePath     string
 	CORSAllowedOrigins []string
+	AuthMode           apiauth.Mode
+	AuthTokenFilePath  string
 }
 
 func RegisterProvider(host *plugin.Host) error {
@@ -53,6 +61,10 @@ func RegisterProvider(host *plugin.Host) error {
 				TlsCertFilePath:    deps.TLSCertFilePath,
 				TlsKeyFilePath:     deps.TLSKeyFilePath,
 				CORSAllowedOrigins: deps.CORSAllowedOrigins,
+				Auth: apiauth.Policy{
+					Mode:          deps.AuthMode,
+					TokenFilePath: deps.AuthTokenFilePath,
+				},
 			})
 			return server, server, nil
 		},

--- a/api/utxorpc/utxorpc.go
+++ b/api/utxorpc/utxorpc.go
@@ -32,6 +32,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
 	"connectrpc.com/grpcreflect"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
 	"github.com/blinklabs-io/dingo/internal/tlsutil"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
@@ -100,6 +101,10 @@ type UtxorpcConfig struct {
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.
 	CORSAllowedOrigins []string
+	// Auth configures in-process credential enforcement, shared with
+	// Blockfrost and Mesh via internal/apiauth. The zero value is
+	// apiauth.ModeNone (no authentication).
+	Auth apiauth.Policy
 }
 
 func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
@@ -169,13 +174,22 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 	if u.config.Mempool != nil && isNilInterface(u.config.Mempool) {
 		return errors.New("utxorpc: Mempool must not be a typed nil")
 	}
+	auth, err := apiauth.NewVerifier(u.config.Auth)
+	if err != nil {
+		return fmt.Errorf("utxorpc: %w", err)
+	}
 	u.mu.Lock()
 	if u.server != nil {
 		u.mu.Unlock()
 		return errors.New("server already started")
 	}
+	// Authentication runs innermost (after CORS preflight, before request
+	// handling): a browser/grpc-web CORS preflight OPTIONS request carries
+	// no credential and must not be rejected by auth, while every actual
+	// RPC call (Connect, gRPC-Web, or grpc-health/grpc-reflect) is checked
+	// before it reaches a handler.
 	handler := httpcors.Handler(
-		u.newServeMux(),
+		auth.Middleware(u.newServeMux()),
 		httpcors.Config{
 			AllowedOrigins: u.config.CORSAllowedOrigins,
 		},

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -51,10 +51,25 @@ plugins:
       provider: "builtin"
       config:
         port: 3000
+        # Per-provider overrides for the shared `api:` TLS/auth policy
+        # below (dingo #2996/#2998). Any field set here wins over the
+        # matching top-level api.tls/api.auth field for this provider only;
+        # an omitted field inherits the top-level value. Example: give
+        # Blockfrost its own certificate while every other API provider
+        # uses the shared one.
+        # tls:
+        #   certFilePath: /run/secrets/blockfrost.crt
+        #   keyFilePath: /run/secrets/blockfrost.key
     mesh:
       provider: "builtin"
       config:
         port: 8080
+        # Example: explicitly disable the shared token auth policy for
+        # this provider only ("none"/"off" are recognized disabling
+        # values; an empty/omitted field always means "inherit", never
+        # "disable", so this cannot happen by accident).
+        # auth:
+        #   mode: none
     utxorpc:
       provider: "builtin"
       config:
@@ -78,14 +93,45 @@ logging:
   format: text
   level: info
 
-# TLS certificate file path for the built-in UTxO RPC listener.
-# Blockfrost and Mesh do not currently consume this setting; place public API
-# listeners behind a TLS-terminating and authenticating reverse proxy.
+# Shared TLS and authentication defaults for every built-in API provider
+# (Blockfrost, Mesh, UTxO RPC -- dingo #2996/#2998). A provider overrides
+# any field for itself under its own plugins.api.<name>.config.tls/auth
+# (see the plugins.api section above); an omitted field here or there
+# means "off"/"none" (matching the pre-#2996 default of no TLS/no
+# in-process auth). CLI: --api-tls-mode, --api-tls-cert-file-path,
+# --api-tls-key-file-path, --api-auth-mode, --api-auth-token-file-path.
+# Env: DINGO_API_TLS_MODE, DINGO_API_TLS_CERT_FILE_PATH,
+# DINGO_API_TLS_KEY_FILE_PATH, DINGO_API_AUTH_MODE,
+# DINGO_API_AUTH_TOKEN_FILE_PATH.
+api:
+  tls:
+    # "off" (default) or "server". "server" requires both certFilePath and
+    # keyFilePath (here or via a provider override) to be set.
+    mode: ""
+    certFilePath: ""
+    keyFilePath: ""
+  auth:
+    # "none" (default) or "token". "token" requires tokenFilePath (here or
+    # via a provider override): its trimmed contents are the shared bearer
+    # credential clients present as "Authorization: Bearer <token>", or,
+    # for Blockfrost-compatible clients, "project_id: <token>".
+    mode: ""
+    tokenFilePath: ""
+
+# TLS certificate file path, used directly by bark and Midnight.
+#
+# Deprecated for the built-in API providers (Blockfrost, Mesh, UTxO RPC):
+# prefer api.tls.certFilePath above. This field is kept only as a fallback
+# default for api.tls when api.tls is entirely unset, so an existing
+# deployment's TLS listener keeps working unchanged after upgrading.
 #
 # Can be overridden with the TLS_CERT_FILE_PATH environment variable
 tlsCertFilePath: ""
 
-# TLS private key file path for the built-in UTxO RPC listener.
+# TLS private key file path, used directly by bark and Midnight.
+#
+# Deprecated for the built-in API providers: prefer api.tls.keyFilePath
+# above. See tlsCertFilePath.
 #
 # Can be overridden with the TLS_KEY_FILE_PATH environment variable
 tlsKeyFilePath: ""

--- a/internal/apiauth/apiauth.go
+++ b/internal/apiauth/apiauth.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apiauth is the single, shared credential-verification
+// implementation used by every built-in API provider (Blockfrost, Mesh, and
+// UTxO RPC -- dingo #2996/#2998). Composition/config wiring resolves the
+// effective per-provider policy (internal/config.ResolveAPISecurity) and
+// hands each provider a concrete Policy; this package is the only place
+// that actually compares a request's credential against the configured
+// token, so all three providers fail closed identically.
+//
+// dingo's UTxO RPC provider serves Connect (not raw gRPC-trailers)
+// requests as ordinary HTTP handlers -- there is no separate wire
+// transport to adapt for credential extraction, so a single net/http
+// middleware protects all three providers' listeners uniformly. Connect's
+// own client-side protocol implementation treats a bare, non-Connect-
+// envelope HTTP 401 response as CodeUnauthenticated, so this HTTP-level
+// enforcement point also answers "Unauthenticated" for Connect/gRPC-Web
+// clients without a dedicated connect.Interceptor. Native gRPC
+// trailers-only transport is not served by dingo's API providers today, so
+// mapping this middleware to it is out of scope.
+package apiauth
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Mode identifies a supported API authentication mode.
+type Mode string
+
+const (
+	// ModeNone performs no credential verification. This is the default
+	// when Mode is left empty.
+	ModeNone Mode = "none"
+	// ModeToken requires a bearer credential matching the contents of
+	// Policy.TokenFilePath.
+	ModeToken Mode = "token"
+)
+
+func (m Mode) normalized() Mode {
+	if m == "" {
+		return ModeNone
+	}
+	return m
+}
+
+// Policy is the effective (already merged) authentication policy for one
+// API listener.
+type Policy struct {
+	Mode Mode
+	// TokenFilePath is the path to a file containing the bearer credential
+	// clients must present when Mode is ModeToken. The file's trimmed
+	// contents are read once, at NewVerifier time, and never logged.
+	TokenFilePath string
+}
+
+// Verifier enforces a resolved Policy against inbound HTTP requests. A nil
+// *Verifier is treated as ModeNone (no enforcement), which lets a provider
+// default to open access without a nil check at every call site.
+type Verifier struct {
+	mode  Mode
+	token string
+}
+
+// NewVerifier loads and validates policy, returning a Verifier ready to
+// wrap a listener's handler. ModeNone (or an empty Mode) never rejects a
+// request and does not require TokenFilePath. ModeToken requires a
+// readable, non-empty token file -- the token is read once here so a
+// later-unreadable file cannot silently disable authentication at request
+// time.
+func NewVerifier(policy Policy) (*Verifier, error) {
+	switch policy.Mode.normalized() {
+	case ModeNone:
+		return &Verifier{mode: ModeNone}, nil
+	case ModeToken:
+		if policy.TokenFilePath == "" {
+			return nil, errors.New(
+				"apiauth: tokenFilePath is required when auth mode is \"token\"",
+			)
+		}
+		raw, err := os.ReadFile(
+			policy.TokenFilePath,
+		) //nolint:gosec // operator-configured path
+		if err != nil {
+			return nil, fmt.Errorf("apiauth: reading auth token file: %w", err)
+		}
+		token := strings.TrimSpace(string(raw))
+		if token == "" {
+			return nil, fmt.Errorf(
+				"apiauth: auth token file %q is empty",
+				policy.TokenFilePath,
+			)
+		}
+		return &Verifier{mode: ModeToken, token: token}, nil
+	default:
+		return nil, fmt.Errorf(
+			"apiauth: invalid auth mode %q (must be \"none\" or \"token\")",
+			policy.Mode,
+		)
+	}
+}
+
+// String implements fmt.Stringer so accidental %v/%+v logging of a
+// Verifier (or a struct embedding one) never reflects into the unexported
+// token field.
+func (v *Verifier) String() string {
+	if v == nil {
+		return "apiauth.Verifier(none)"
+	}
+	return fmt.Sprintf("apiauth.Verifier{mode=%s}", v.mode)
+}
+
+// LogValue implements slog.LogValuer for the same reason as String.
+func (v *Verifier) LogValue() slog.Value {
+	if v == nil {
+		return slog.StringValue(string(ModeNone))
+	}
+	return slog.StringValue(string(v.mode))
+}
+
+const (
+	headerAuthorization = "Authorization"
+	// headerProjectID is Blockfrost's own convention for presenting an API
+	// key. It is accepted as an alias for the shared bearer token on every
+	// provider (not just Blockfrost), per #2996's scope decision: operators
+	// running Blockfrost-compatible client tooling (e.g. blockfrost-js)
+	// that only knows how to send "project_id" should not need a second,
+	// provider-specific auth mechanism.
+	headerProjectID = "project_id"
+	bearerPrefix    = "Bearer "
+)
+
+// Middleware wraps next with credential enforcement. In ModeNone (or for a
+// nil Verifier), requests are passed through unconditionally. In
+// ModeToken, a request must present the configured token either as a
+// standard "Authorization: Bearer <token>" header or, as a
+// Blockfrost-compatible alias, a "project_id: <token>" header. A missing
+// or incorrect credential fails closed with 401 Unauthorized.
+func (v *Verifier) Middleware(next http.Handler) http.Handler {
+	if v == nil || v.mode != ModeToken {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !v.authorized(r) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="dingo-api"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (v *Verifier) authorized(r *http.Request) bool {
+	if token, ok := bearerToken(r.Header.Get(headerAuthorization)); ok &&
+		v.equalToken(token) {
+		return true
+	}
+	if projectID := r.Header.Get(headerProjectID); projectID != "" &&
+		v.equalToken(projectID) {
+		return true
+	}
+	return false
+}
+
+func (v *Verifier) equalToken(candidate string) bool {
+	// Constant-time comparison: a credential-verification implementation
+	// must not leak the token's length or contents through timing.
+	return subtle.ConstantTimeCompare([]byte(candidate), []byte(v.token)) == 1
+}
+
+func bearerToken(header string) (string, bool) {
+	if len(header) < len(bearerPrefix) ||
+		!strings.EqualFold(header[:len(bearerPrefix)], bearerPrefix) {
+		return "", false
+	}
+	return header[len(bearerPrefix):], true
+}

--- a/internal/apiauth/apiauth_test.go
+++ b/internal/apiauth/apiauth_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestNewVerifier(t *testing.T) {
+	tokenPath := writeTokenFile(t, "s3cret\n")
+
+	tests := []struct {
+		name    string
+		policy  Policy
+		wantErr string
+	}{
+		{name: "empty mode is none", policy: Policy{}},
+		{name: "explicit none", policy: Policy{Mode: ModeNone}},
+		{
+			name:   "token mode with valid file",
+			policy: Policy{Mode: ModeToken, TokenFilePath: tokenPath},
+		},
+		{
+			name:    "token mode without path",
+			policy:  Policy{Mode: ModeToken},
+			wantErr: "tokenFilePath is required",
+		},
+		{
+			name: "token mode with missing file",
+			policy: Policy{
+				Mode:          ModeToken,
+				TokenFilePath: filepath.Join(t.TempDir(), "missing"),
+			},
+			wantErr: "reading auth token file",
+		},
+		{
+			name: "token mode with empty file",
+			policy: Policy{
+				Mode:          ModeToken,
+				TokenFilePath: writeTokenFile(t, "   \n"),
+			},
+			wantErr: "is empty",
+		},
+		{
+			name:    "invalid mode",
+			policy:  Policy{Mode: "bogus"},
+			wantErr: "invalid auth mode",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := NewVerifier(tt.policy)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				require.Nil(t, v)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, v)
+		})
+	}
+}
+
+func TestVerifierMiddlewareModeNone(t *testing.T) {
+	for _, v := range []*Verifier{nil, mustVerifier(t, Policy{})} {
+		called := false
+		handler := v.Middleware(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			},
+		))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		require.True(t, called)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+}
+
+func TestVerifierMiddlewareModeToken(t *testing.T) {
+	tokenPath := writeTokenFile(t, "s3cret")
+	v := mustVerifier(
+		t,
+		Policy{Mode: ModeToken, TokenFilePath: tokenPath},
+	)
+	handler := v.Middleware(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+
+	tests := []struct {
+		name       string
+		headers    map[string]string
+		wantStatus int
+	}{
+		{
+			name:       "missing credential",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "correct bearer token",
+			headers:    map[string]string{"Authorization": "Bearer s3cret"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "wrong bearer token",
+			headers:    map[string]string{"Authorization": "Bearer wrong"},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "correct project_id alias",
+			headers:    map[string]string{"project_id": "s3cret"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "wrong project_id alias",
+			headers:    map[string]string{"project_id": "wrong"},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "malformed authorization header",
+			headers:    map[string]string{"Authorization": "s3cret"},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			for k, val := range tt.headers {
+				req.Header.Set(k, val)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			require.Equal(t, tt.wantStatus, rr.Code)
+			if tt.wantStatus == http.StatusUnauthorized {
+				require.NotEmpty(t, rr.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+// TestVerifierRedactsToken guards the "never log auth material" invariant:
+// String and LogValue must never expose the loaded token, even via %v/%+v
+// reflection-based formatting.
+func TestVerifierRedactsToken(t *testing.T) {
+	tokenPath := writeTokenFile(t, "s3cret-value")
+	v := mustVerifier(
+		t,
+		Policy{Mode: ModeToken, TokenFilePath: tokenPath},
+	)
+	for _, rendered := range []string{
+		v.String(),
+		v.LogValue().String(),
+	} {
+		require.NotContains(t, rendered, "s3cret-value")
+	}
+}
+
+func mustVerifier(t *testing.T, policy Policy) *Verifier {
+	t.Helper()
+	v, err := NewVerifier(policy)
+	require.NoError(t, err)
+	return v
+}

--- a/internal/config/api_security.go
+++ b/internal/config/api_security.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
+)
+
+// APIConfig is the top-level `api:` configuration section (dingo #2998). It
+// supplies shared TLS and authentication defaults to every selected
+// built-in API provider (Blockfrost, Mesh, UTxO RPC); a provider overrides
+// any field it sets explicitly under its own
+// plugins.api.<capability>.config.tls/auth. See ResolveAPISecurity for the
+// exact field-by-field precedence and EffectiveAPIPolicy for the legacy
+// root-field compatibility fallback.
+type APIConfig struct {
+	TLS  APITLSPolicy  `yaml:"tls"`
+	Auth APIAuthPolicy `yaml:"auth"`
+}
+
+// APITLSPolicy is the shared default server-TLS policy for API listeners.
+// Mode "server" enables TLS, requiring both CertFilePath and KeyFilePath
+// (after a provider's own overrides are applied); "off" and "" both mean
+// disabled. This is unrelated to bark's own mutual-TLS client verification
+// (TlsClientCAFilePath), which is a separate surface.
+type APITLSPolicy struct {
+	Mode         string `yaml:"mode"         envconfig:"DINGO_API_TLS_MODE"`
+	CertFilePath string `yaml:"certFilePath" envconfig:"DINGO_API_TLS_CERT_FILE_PATH"`
+	KeyFilePath  string `yaml:"keyFilePath"  envconfig:"DINGO_API_TLS_KEY_FILE_PATH"`
+}
+
+// APIAuthPolicy is the shared default authentication policy for API
+// listeners. Mode "token" requires clients to present a credential (an
+// "Authorization: Bearer <token>" header, or, as a Blockfrost-compatible
+// alias, a "project_id: <token>" header) matching the contents of
+// TokenFilePath; see internal/apiauth. "none" and "" both mean no
+// in-process authentication.
+type APIAuthPolicy struct {
+	Mode          string `yaml:"mode"          envconfig:"DINGO_API_AUTH_MODE"`
+	TokenFilePath string `yaml:"tokenFilePath" envconfig:"DINGO_API_AUTH_TOKEN_FILE_PATH"`
+}
+
+// EffectiveAPIPolicy returns the top-level API security policy with the
+// legacy root-level TLS compatibility fallback applied: TlsCertFilePath/
+// TlsKeyFilePath (which predate this section and also still configure bark
+// and Midnight) continue to enable TLS for every API provider when api.tls
+// itself is entirely unset, so upgrading an existing deployment does not
+// silently drop its API TLS listener. Setting any of api.tls.mode,
+// api.tls.certFilePath, or api.tls.keyFilePath opts fully into the new
+// section; the root fields then have no effect on the API policy (they
+// still apply to bark/Midnight, which do not participate in this
+// section). Composition should call this instead of reading c.API
+// directly, and should prefer api.tls in new configuration over the root
+// fields.
+func (c *Config) EffectiveAPIPolicy() APIConfig {
+	policy := c.API
+	if policy.TLS.Mode == "" && policy.TLS.CertFilePath == "" &&
+		policy.TLS.KeyFilePath == "" &&
+		(c.TlsCertFilePath != "" || c.TlsKeyFilePath != "") {
+		policy.TLS = APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: c.TlsCertFilePath,
+			KeyFilePath:  c.TlsKeyFilePath,
+		}
+	}
+	return policy
+}
+
+// ResolvedAPISecurity is the fully merged, per-provider effective TLS and
+// authentication policy: a concrete, instance-owned settings snapshot with
+// no further resolution left for a provider to do. TLSCertFilePath/
+// TLSKeyFilePath are only ever non-empty when TLSMode is "server", and
+// AuthTokenFilePath is only ever non-empty when AuthMode is "token" --
+// callers do not need to re-check the mode before using the other fields.
+type ResolvedAPISecurity struct {
+	TLSMode           string
+	TLSCertFilePath   string
+	TLSKeyFilePath    string
+	AuthMode          string
+	AuthTokenFilePath string
+}
+
+// ResolveAPISecurity computes the effective TLS/auth policy for one API
+// provider selection. Resolution is field-by-field and deterministic,
+// independent of map iteration order: each field is chosen by checking, in
+// order, (1) whether the provider's own
+// plugins.api.<capability>.config.tls/auth mapping explicitly sets that
+// field to a non-empty value, (2) whether apiPolicy (see
+// EffectiveAPIPolicy) sets it, then (3) a fixed default ("off"/"none", ""
+// for paths) equivalent to today's pre-#2998 behavior. An explicit
+// empty-string provider field is treated the same as an absent one -- only
+// a real value (including the disabling sentinels "off"/"none") counts as
+// an override -- so a provider can affirmatively disable an inherited
+// policy but cannot ambiguously blank one out.
+func ResolveAPISecurity(
+	apiPolicy APIConfig,
+	selection hostplugin.Selection,
+) ResolvedAPISecurity {
+	providerTLS, _ := selection.Config["tls"].(map[string]any)
+	providerAuth, _ := selection.Config["auth"].(map[string]any)
+	sec := ResolvedAPISecurity{
+		TLSMode: resolveAPIPolicyField(
+			providerTLS, "mode", apiPolicy.TLS.Mode, "off",
+		),
+		TLSCertFilePath: resolveAPIPolicyField(
+			providerTLS, "certFilePath", apiPolicy.TLS.CertFilePath, "",
+		),
+		TLSKeyFilePath: resolveAPIPolicyField(
+			providerTLS, "keyFilePath", apiPolicy.TLS.KeyFilePath, "",
+		),
+		AuthMode: resolveAPIPolicyField(
+			providerAuth, "mode", apiPolicy.Auth.Mode, "none",
+		),
+		AuthTokenFilePath: resolveAPIPolicyField(
+			providerAuth, "tokenFilePath", apiPolicy.Auth.TokenFilePath, "",
+		),
+	}
+	// Normalize the resolved struct to its final answer so callers never
+	// need mode-conditional logic of their own: a provider whose effective
+	// mode is not "server"/"token" has no business reading leftover
+	// path fields from a policy layer it isn't using.
+	if sec.TLSMode != "server" {
+		sec.TLSCertFilePath = ""
+		sec.TLSKeyFilePath = ""
+	}
+	if sec.AuthMode != "token" {
+		sec.AuthTokenFilePath = ""
+	}
+	return sec
+}
+
+// resolveAPIPolicyField resolves a single field's effective value given a
+// provider's own raw config sub-map (nil if the provider does not have
+// that block at all), the top-level default, and the built-in fallback.
+func resolveAPIPolicyField(
+	providerFields map[string]any,
+	key, topLevel, fallback string,
+) string {
+	if providerFields != nil {
+		if raw, ok := providerFields[key]; ok {
+			if s, ok := raw.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	if topLevel != "" {
+		return topLevel
+	}
+	return fallback
+}
+
+// ValidateAPISecurity checks one resolved effective API security policy,
+// returning every problem found. path identifies the full configuration
+// location the operator should look at (e.g.
+// "plugins.api.blockfrost.config" or "api").
+func ValidateAPISecurity(path string, sec ResolvedAPISecurity) []error {
+	var errs []error
+	switch sec.TLSMode {
+	case "", "off", "server":
+	default:
+		errs = append(errs, fmt.Errorf(
+			"invalid %s.tls.mode %q: must be \"off\" or \"server\"",
+			path, sec.TLSMode,
+		))
+	}
+	if sec.TLSMode == "server" &&
+		(sec.TLSCertFilePath == "" || sec.TLSKeyFilePath == "") {
+		errs = append(errs, fmt.Errorf(
+			"%s.tls: mode is \"server\" but certFilePath and keyFilePath "+
+				"must both be set (got certFilePath=%q, keyFilePath=%q)",
+			path, sec.TLSCertFilePath, sec.TLSKeyFilePath,
+		))
+	}
+	switch sec.AuthMode {
+	case "", "none", "token":
+	default:
+		errs = append(errs, fmt.Errorf(
+			"invalid %s.auth.mode %q: must be \"none\" or \"token\"",
+			path, sec.AuthMode,
+		))
+	}
+	if sec.AuthMode == "token" && sec.AuthTokenFilePath == "" {
+		errs = append(errs, fmt.Errorf(
+			"%s.auth: mode is \"token\" but tokenFilePath is not set",
+			path,
+		))
+	}
+	return errs
+}

--- a/internal/config/api_security_test.go
+++ b/internal/config/api_security_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"maps"
+	"testing"
+
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAPISecurityDefaults(t *testing.T) {
+	sec := ResolveAPISecurity(APIConfig{}, hostplugin.Selection{
+		Config: map[string]any{"port": 3000},
+	})
+	assert.Equal(t, ResolvedAPISecurity{
+		TLSMode:  "off",
+		AuthMode: "none",
+	}, sec)
+}
+
+func TestResolveAPISecurityTopLevelDefaultsApplyToEveryProvider(t *testing.T) {
+	apiPolicy := APIConfig{
+		TLS: APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/run/secrets/api.crt",
+			KeyFilePath:  "/run/secrets/api.key",
+		},
+		Auth: APIAuthPolicy{
+			Mode:          "token",
+			TokenFilePath: "/run/secrets/api-token",
+		},
+	}
+	for _, selection := range []hostplugin.Selection{
+		{Config: map[string]any{"port": 3000}},
+		{Config: map[string]any{"port": 8080}},
+		{Config: map[string]any{"port": 9090}},
+	} {
+		sec := ResolveAPISecurity(apiPolicy, selection)
+		assert.Equal(t, ResolvedAPISecurity{
+			TLSMode:           "server",
+			TLSCertFilePath:   "/run/secrets/api.crt",
+			TLSKeyFilePath:    "/run/secrets/api.key",
+			AuthMode:          "token",
+			AuthTokenFilePath: "/run/secrets/api-token",
+		}, sec)
+	}
+}
+
+func TestResolveAPISecurityPartialProviderOverride(t *testing.T) {
+	apiPolicy := APIConfig{
+		TLS: APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/run/secrets/api.crt",
+			KeyFilePath:  "/run/secrets/api.key",
+		},
+	}
+	// Only certFilePath is overridden; mode and keyFilePath must still be
+	// inherited from the top-level policy field-by-field, not replaced as a
+	// whole object.
+	selection := hostplugin.Selection{
+		Config: map[string]any{
+			"port": 3000,
+			"tls": map[string]any{
+				"certFilePath": "/run/secrets/blockfrost.crt",
+			},
+		},
+	}
+	sec := ResolveAPISecurity(apiPolicy, selection)
+	assert.Equal(t, ResolvedAPISecurity{
+		TLSMode:         "server",
+		TLSCertFilePath: "/run/secrets/blockfrost.crt",
+		TLSKeyFilePath:  "/run/secrets/api.key",
+		AuthMode:        "none",
+	}, sec)
+}
+
+func TestResolveAPISecurityExplicitDisable(t *testing.T) {
+	apiPolicy := APIConfig{
+		Auth: APIAuthPolicy{
+			Mode:          "token",
+			TokenFilePath: "/run/secrets/api-token",
+		},
+	}
+	// A provider can affirmatively disable an inherited auth policy.
+	selection := hostplugin.Selection{
+		Config: map[string]any{
+			"port": 8080,
+			"auth": map[string]any{"mode": "none"},
+		},
+	}
+	sec := ResolveAPISecurity(apiPolicy, selection)
+	assert.Equal(t, "none", sec.AuthMode)
+	assert.Empty(
+		t,
+		sec.AuthTokenFilePath,
+		"disabled auth must not leak the inherited token path",
+	)
+}
+
+func TestResolveAPISecurityEmptyProviderFieldDoesNotOverride(t *testing.T) {
+	apiPolicy := APIConfig{
+		TLS: APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/run/secrets/api.crt",
+			KeyFilePath:  "/run/secrets/api.key",
+		},
+	}
+	// An explicit empty string is treated the same as an absent field: it
+	// must not blank out the inherited value.
+	selection := hostplugin.Selection{
+		Config: map[string]any{
+			"tls": map[string]any{"certFilePath": ""},
+		},
+	}
+	sec := ResolveAPISecurity(apiPolicy, selection)
+	assert.Equal(t, "/run/secrets/api.crt", sec.TLSCertFilePath)
+}
+
+func TestResolveAPISecurityDeterministicRegardlessOfMapOrder(t *testing.T) {
+	apiPolicy := APIConfig{
+		TLS:  APITLSPolicy{Mode: "server", CertFilePath: "c", KeyFilePath: "k"},
+		Auth: APIAuthPolicy{Mode: "token", TokenFilePath: "t"},
+	}
+	base := map[string]any{
+		"port": 3000,
+		"tls":  map[string]any{"certFilePath": "override-cert"},
+		"auth": map[string]any{"mode": "none"},
+	}
+	// Constructing the same logical config from freshly built maps (Go map
+	// iteration order is randomized) must produce an identical result every
+	// time.
+	var first ResolvedAPISecurity
+	for i := range 20 {
+		clone := map[string]any{}
+		maps.Copy(clone, base)
+		sec := ResolveAPISecurity(
+			apiPolicy,
+			hostplugin.Selection{Config: clone},
+		)
+		if i == 0 {
+			first = sec
+			continue
+		}
+		require.Equal(t, first, sec)
+	}
+}
+
+func TestEffectiveAPIPolicyLegacyFallback(t *testing.T) {
+	t.Run("legacy fields fill an entirely unset api.tls", func(t *testing.T) {
+		cfg := &Config{
+			TlsCertFilePath: "/etc/dingo/legacy.crt",
+			TlsKeyFilePath:  "/etc/dingo/legacy.key",
+		}
+		policy := cfg.EffectiveAPIPolicy()
+		assert.Equal(t, APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/etc/dingo/legacy.crt",
+			KeyFilePath:  "/etc/dingo/legacy.key",
+		}, policy.TLS)
+	})
+
+	t.Run(
+		"api.tls set takes full precedence over legacy fields",
+		func(t *testing.T) {
+			cfg := &Config{
+				TlsCertFilePath: "/etc/dingo/legacy.crt",
+				TlsKeyFilePath:  "/etc/dingo/legacy.key",
+				API: APIConfig{
+					TLS: APITLSPolicy{Mode: "off"},
+				},
+			}
+			policy := cfg.EffectiveAPIPolicy()
+			assert.Equal(t, APITLSPolicy{Mode: "off"}, policy.TLS)
+		},
+	)
+
+	t.Run("no legacy fields and no api.tls stays disabled", func(t *testing.T) {
+		cfg := &Config{}
+		policy := cfg.EffectiveAPIPolicy()
+		assert.Equal(t, APITLSPolicy{}, policy.TLS)
+	})
+}
+
+// TestValidateAPISecurityPartialMergeAcrossProviders exercises the
+// "invalid merged certificate/key pair" acceptance scenario end to end via
+// Config.validate: the top-level policy alone supplies only a certificate,
+// leaving every provider's merged TLS pair incomplete except the one that
+// fills the gap with its own override.
+func TestValidateAPISecurityPartialMergeAcrossProviders(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.API.TLS = APITLSPolicy{
+		Mode:         "server",
+		CertFilePath: "/run/secrets/api.crt",
+	}
+	cfg.Plugins.API.Mesh.Config["tls"] = map[string]any{
+		"keyFilePath": "/run/secrets/mesh.key",
+	}
+
+	err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "plugins.api.utxorpc.config.tls")
+	assert.Contains(t, msg, "plugins.api.blockfrost.config.tls")
+	assert.NotContains(
+		t,
+		msg,
+		"plugins.api.mesh.config.tls",
+		"mesh supplied the missing keyFilePath itself and must not be "+
+			"flagged",
+	)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,24 +441,45 @@ func DefaultMidnightConfig() MidnightConfig {
 }
 
 type Config struct {
-	Plugins                PluginsConfig `yaml:"plugins"`
-	TlsKeyFilePath         string        `yaml:"tlsKeyFilePath"         envconfig:"TLS_KEY_FILE_PATH"`
-	Topology               string        `yaml:"topology"`
-	CardanoConfig          string        `yaml:"cardanoConfig"          envconfig:"config"`
-	DatabasePath           string        `yaml:"databasePath"                                                       split_words:"true"`
-	SocketPath             string        `yaml:"socketPath"                                                         split_words:"true"`
-	TlsCertFilePath        string        `yaml:"tlsCertFilePath"        envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr               string        `yaml:"bindAddr"                                                           split_words:"true"`
-	PrivateBindAddr        string        `yaml:"privateBindAddr"                                                    split_words:"true"`
-	ShutdownTimeout        string        `yaml:"shutdownTimeout"                                                    split_words:"true"`
-	LedgerCatchupTimeout   string        `yaml:"ledgerCatchupTimeout"   envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
-	Network                string        `yaml:"network"`
-	NetworkMagic           uint32        `yaml:"networkMagic"                                                       split_words:"true"`
-	PrivatePort            uint          `yaml:"privatePort"                                                        split_words:"true"`
-	RelayPort              uint          `yaml:"relayPort"              envconfig:"port"`
-	BarkBaseUrl            string        `yaml:"barkBaseUrl"            envconfig:"DINGO_BARK_BASE_URL"`
-	BarkBlockDownloadHosts []string      `yaml:"barkBlockDownloadHosts" envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
-	BarkPort               uint          `yaml:"barkPort"               envconfig:"DINGO_BARK_PORT"`
+	Plugins PluginsConfig `yaml:"plugins"`
+	// API is the top-level `api:` section providing shared TLS and
+	// authentication defaults for the built-in API providers (Blockfrost,
+	// Mesh, UTxO RPC). See EffectiveAPIPolicy and ResolveAPISecurity
+	// (api_security.go).
+	API APIConfig `yaml:"api"`
+	// TlsKeyFilePath is the process-level TLS private key, used directly by
+	// bark and Midnight.
+	//
+	// For the built-in API providers (Blockfrost, Mesh, UTxO RPC), prefer
+	// api.tls.keyFilePath instead: this field is now only a fallback
+	// default for api.tls (see EffectiveAPIPolicy) when api.tls is
+	// entirely unset, kept so existing deployments keep working unchanged
+	// after upgrading.
+	TlsKeyFilePath string `yaml:"tlsKeyFilePath"         envconfig:"TLS_KEY_FILE_PATH"`
+	Topology       string `yaml:"topology"`
+	CardanoConfig  string `yaml:"cardanoConfig"          envconfig:"config"`
+	DatabasePath   string `yaml:"databasePath"                                                       split_words:"true"`
+	SocketPath     string `yaml:"socketPath"                                                         split_words:"true"`
+	// TlsCertFilePath is the process-level TLS certificate, used directly
+	// by bark and Midnight.
+	//
+	// For the built-in API providers (Blockfrost, Mesh, UTxO RPC), prefer
+	// api.tls.certFilePath instead: this field is now only a fallback
+	// default for api.tls (see EffectiveAPIPolicy) when api.tls is
+	// entirely unset, kept so existing deployments keep working unchanged
+	// after upgrading.
+	TlsCertFilePath        string   `yaml:"tlsCertFilePath"        envconfig:"TLS_CERT_FILE_PATH"`
+	BindAddr               string   `yaml:"bindAddr"                                                           split_words:"true"`
+	PrivateBindAddr        string   `yaml:"privateBindAddr"                                                    split_words:"true"`
+	ShutdownTimeout        string   `yaml:"shutdownTimeout"                                                    split_words:"true"`
+	LedgerCatchupTimeout   string   `yaml:"ledgerCatchupTimeout"   envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
+	Network                string   `yaml:"network"`
+	NetworkMagic           uint32   `yaml:"networkMagic"                                                       split_words:"true"`
+	PrivatePort            uint     `yaml:"privatePort"                                                        split_words:"true"`
+	RelayPort              uint     `yaml:"relayPort"              envconfig:"port"`
+	BarkBaseUrl            string   `yaml:"barkBaseUrl"            envconfig:"DINGO_BARK_BASE_URL"`
+	BarkBlockDownloadHosts []string `yaml:"barkBlockDownloadHosts" envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
+	BarkPort               uint     `yaml:"barkPort"               envconfig:"DINGO_BARK_PORT"`
 	// BarkHost is the interface Bark binds to. Left empty, node.go defaults
 	// it to loopback-only (127.0.0.1) whenever the database lifecycle
 	// service (Restore/Truncate and friends — gated on BarkClientCAFilePath,
@@ -474,11 +495,20 @@ type Config struct {
 	// refuse any caller whose connection didn't present a certificate
 	// verified against this CA — see bark.Bark.Start and bark/auth.go. Also
 	// requires TlsCertFilePath/TlsKeyFilePath to be set.
-	BarkClientCAFilePath string   `yaml:"barkClientCaFilePath"   envconfig:"DINGO_BARK_CLIENT_CA_FILE_PATH"`
-	CORSAllowedOrigins   []string `yaml:"corsAllowedOrigins"     envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
-	MetricsPort          uint     `yaml:"metricsPort"                                                        split_words:"true"`
-	DebugPort            uint     `yaml:"debugPort"              envconfig:"DINGO_DEBUG_PORT"`
-	IntersectTip         bool     `yaml:"intersectTip"                                                       split_words:"true"`
+	BarkClientCAFilePath string `yaml:"barkClientCaFilePath"   envconfig:"DINGO_BARK_CLIENT_CA_FILE_PATH"`
+	// CORSAllowedOrigins and BindAddr remain root-level fields rather than
+	// moving under the api: section (dingo #2998): BindAddr is a node-wide
+	// bind address shared by the relay, private, metrics, debug, and bark
+	// listeners as well as every API provider, not an API-specific setting,
+	// so nesting it under api: would misrepresent its scope. CORSAllowedOrigins
+	// is API-specific, but the api: section only carries security policy
+	// (TLS/auth) that a provider can override per-field; there is no
+	// per-provider CORS override requirement, so duplicating it under api:
+	// would just create a second source of truth for the same setting.
+	CORSAllowedOrigins []string `yaml:"corsAllowedOrigins"     envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
+	MetricsPort        uint     `yaml:"metricsPort"                                                        split_words:"true"`
+	DebugPort          uint     `yaml:"debugPort"              envconfig:"DINGO_DEBUG_PORT"`
+	IntersectTip       bool     `yaml:"intersectTip"                                                       split_words:"true"`
 	// ValidateHistorical validates the complete replay from the selected
 	// intersection. The default from-origin sync path must not trust peers to
 	// have validated historical blocks for us.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1276,6 +1276,148 @@ func TestLoad_APIPortsDefault(t *testing.T) {
 	}
 }
 
+// TestLoad_APISecurityYAML covers dingo #2998's target YAML shape: a
+// top-level api: section supplying shared TLS/auth defaults, with a
+// provider (mesh) overriding one field of its own.
+func TestLoad_APISecurityYAML(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+api:
+  tls:
+    mode: server
+    certFilePath: /run/secrets/api.crt
+    keyFilePath: /run/secrets/api.key
+  auth:
+    mode: token
+    tokenFilePath: /run/secrets/api-token
+plugins:
+  api:
+    mesh:
+      provider: builtin
+      config:
+        port: 8080
+        auth:
+          mode: none
+    blockfrost:
+      provider: builtin
+      config:
+        tls:
+          certFilePath: /run/secrets/blockfrost.crt
+          keyFilePath: /run/secrets/blockfrost.key
+network: "preview"
+`
+	tmpFile := filepath.Join(t.TempDir(), "api-security.yaml")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0o600))
+
+	cfg, err := LoadConfig(tmpFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, APIConfig{
+		TLS: APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/run/secrets/api.crt",
+			KeyFilePath:  "/run/secrets/api.key",
+		},
+		Auth: APIAuthPolicy{
+			Mode:          "token",
+			TokenFilePath: "/run/secrets/api-token",
+		},
+	}, cfg.API)
+
+	policy := cfg.EffectiveAPIPolicy()
+
+	// Mesh explicitly disables the inherited token auth requirement, but
+	// keeps the top-level TLS default (no per-provider override).
+	meshSec := ResolveAPISecurity(policy, cfg.Plugins.API.Mesh)
+	assert.Equal(t, "server", meshSec.TLSMode)
+	assert.Equal(t, "/run/secrets/api.crt", meshSec.TLSCertFilePath)
+	assert.Equal(t, "none", meshSec.AuthMode)
+	assert.Empty(t, meshSec.AuthTokenFilePath)
+
+	// Blockfrost overrides only its TLS cert/key, inheriting the top-level
+	// token auth policy untouched.
+	blockfrostSec := ResolveAPISecurity(policy, cfg.Plugins.API.Blockfrost)
+	assert.Equal(t, "server", blockfrostSec.TLSMode)
+	assert.Equal(
+		t,
+		"/run/secrets/blockfrost.crt",
+		blockfrostSec.TLSCertFilePath,
+	)
+	assert.Equal(t, "/run/secrets/blockfrost.key", blockfrostSec.TLSKeyFilePath)
+	assert.Equal(t, "token", blockfrostSec.AuthMode)
+	assert.Equal(t, "/run/secrets/api-token", blockfrostSec.AuthTokenFilePath)
+
+	// UTxO RPC has no provider override at all, so it inherits every field.
+	utxorpcSec := ResolveAPISecurity(policy, cfg.Plugins.API.Utxorpc)
+	assert.Equal(t, "server", utxorpcSec.TLSMode)
+	assert.Equal(t, "/run/secrets/api.crt", utxorpcSec.TLSCertFilePath)
+	assert.Equal(t, "/run/secrets/api.key", utxorpcSec.TLSKeyFilePath)
+	assert.Equal(t, "token", utxorpcSec.AuthMode)
+	assert.Equal(t, "/run/secrets/api-token", utxorpcSec.AuthTokenFilePath)
+}
+
+// TestLoad_APISecurityEnvVars covers the top-level api: fields' explicit
+// envconfig-tagged environment variables (env is a plain, flat tier for
+// this section; per-provider plugins.api.<name>.config.tls/auth overrides
+// are YAML/CLI-composition-resolved only -- see ResolveAPISecurity's doc
+// comment).
+func TestLoad_APISecurityEnvVars(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_API_TLS_MODE", "server")
+	t.Setenv("DINGO_API_TLS_CERT_FILE_PATH", "/env/api.crt")
+	t.Setenv("DINGO_API_TLS_KEY_FILE_PATH", "/env/api.key")
+	t.Setenv("DINGO_API_AUTH_MODE", "token")
+	t.Setenv("DINGO_API_AUTH_TOKEN_FILE_PATH", "/env/api-token")
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, nil, 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, APIConfig{
+		TLS: APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/env/api.crt",
+			KeyFilePath:  "/env/api.key",
+		},
+		Auth: APIAuthPolicy{
+			Mode:          "token",
+			TokenFilePath: "/env/api-token",
+		},
+	}, cfg.API)
+}
+
+// TestLoad_APISecurityLegacyRootTLSFallback covers the deprecated root-field
+// compatibility path: an existing deployment's tlsCertFilePath/
+// tlsKeyFilePath, with no api: section at all, must still resolve into a
+// "server" mode TLS policy for every API provider after loading.
+func TestLoad_APISecurityLegacyRootTLSFallback(t *testing.T) {
+	resetGlobalConfig()
+	yamlContent := `
+tlsCertFilePath: legacy.crt
+tlsKeyFilePath: legacy.key
+network: "preview"
+`
+	tmpFile := filepath.Join(t.TempDir(), "legacy-tls.yaml")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0o600))
+
+	cfg, err := LoadConfig(tmpFile)
+	require.NoError(t, err)
+
+	// The api: section itself was never set...
+	assert.Equal(t, APIConfig{}, cfg.API)
+	// ...but the effective policy used at composition time still enables
+	// TLS from the legacy fields.
+	policy := cfg.EffectiveAPIPolicy()
+	assert.Equal(t, APITLSPolicy{
+		Mode:         "server",
+		CertFilePath: "legacy.crt",
+		KeyFilePath:  "legacy.key",
+	}, policy.TLS)
+}
+
 func TestLoad_MidnightConfig(t *testing.T) {
 	resetGlobalConfig()
 	yamlContent := `

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -199,6 +199,36 @@ var flagSpecs = []flagSpec{
 		"cors-allowed-origins",
 		"CORS allowed origins for API servers",
 	),
+	stringFlag(
+		"API.TLS.Mode",
+		"api-tls-mode",
+		"",
+		`shared TLS default for API providers (Blockfrost, Mesh, UTxO RPC): "off" or "server"`,
+	),
+	stringFlag(
+		"API.TLS.CertFilePath",
+		"api-tls-cert-file-path",
+		"",
+		"shared TLS certificate default for API providers",
+	),
+	stringFlag(
+		"API.TLS.KeyFilePath",
+		"api-tls-key-file-path",
+		"",
+		"shared TLS private key default for API providers",
+	),
+	stringFlag(
+		"API.Auth.Mode",
+		"api-auth-mode",
+		"",
+		`shared authentication default for API providers: "none" or "token"`,
+	),
+	stringFlag(
+		"API.Auth.TokenFilePath",
+		"api-auth-token-file-path",
+		"",
+		"shared authentication token file default for API providers",
+	),
 	durationFlag(
 		"OffchainMetadata.Interval",
 		"offchain-metadata-interval",

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -330,6 +330,61 @@ func TestApplyFlags_PriorityOrderFlagsOverrideEnv(t *testing.T) {
 	}
 }
 
+// TestApplyFlags_APISecurityCLIOverridesEnvAndYAML covers dingo #2998's
+// CLI > env > YAML > defaults precedence for the top-level api: fields.
+func TestApplyFlags_APISecurityCLIOverridesEnvAndYAML(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_API_TLS_MODE", "server")
+	t.Setenv("DINGO_API_TLS_CERT_FILE_PATH", "/env/api.crt")
+	t.Setenv("DINGO_API_AUTH_MODE", "token")
+
+	yamlContent := "api:\n" +
+		"  tls:\n" +
+		"    keyFilePath: /yaml/api.key\n" +
+		"  auth:\n" +
+		"    tokenFilePath: /yaml/api-token\n"
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(yamlContent), 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	// Env overrides the mode/cert fields; YAML supplies the key/token
+	// fields the env vars didn't set.
+	assert.Equal(t, "server", cfg.API.TLS.Mode)
+	assert.Equal(t, "/env/api.crt", cfg.API.TLS.CertFilePath)
+	assert.Equal(t, "/yaml/api.key", cfg.API.TLS.KeyFilePath)
+	assert.Equal(t, "token", cfg.API.Auth.Mode)
+	assert.Equal(t, "/yaml/api-token", cfg.API.Auth.TokenFilePath)
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--api-tls-cert-file-path=/flag/api.crt",
+		"--api-auth-mode=none",
+	}))
+	require.NoError(t, ApplyFlags(cmd, cfg))
+
+	// CLI overrides only the two flags actually passed; every other field
+	// (env- or YAML-sourced) is left untouched.
+	assert.Equal(t, "server", cfg.API.TLS.Mode)
+	assert.Equal(
+		t,
+		"/flag/api.crt",
+		cfg.API.TLS.CertFilePath,
+		"CLI flag must win over env",
+	)
+	assert.Equal(t, "/yaml/api.key", cfg.API.TLS.KeyFilePath)
+	assert.Equal(
+		t,
+		"none",
+		cfg.API.Auth.Mode,
+		"CLI flag must win over env",
+	)
+	assert.Equal(t, "/yaml/api-token", cfg.API.Auth.TokenFilePath)
+}
+
 func TestMempoolProviderSourcePrecedence(t *testing.T) {
 	resetGlobalConfig()
 	t.Setenv("HOME", t.TempDir())

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 )
 
@@ -365,12 +366,40 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		errs = append(errs, err)
 	}
 
-	// TLS cert and key only work as a pair
+	// TLS cert and key only work as a pair. This is the deprecated
+	// process-level pair still used directly by bark and Midnight; the
+	// built-in API providers' effective TLS/auth policy is validated
+	// separately below, against the merged api:/plugins.api.*.config.tls
+	// policy (which falls back to these same two fields -- see
+	// EffectiveAPIPolicy).
 	if (c.TlsCertFilePath == "") != (c.TlsKeyFilePath == "") {
 		errs = append(errs, errors.New(
 			"tlsCertFilePath and tlsKeyFilePath must both be set to enable TLS "+
 				"(only one is set)",
 		))
+	}
+
+	// Effective per-provider API TLS/auth policy (dingo #2996/#2998):
+	// top-level api: defaults merged field-by-field with each provider's
+	// own plugins.api.<name>.config.tls/auth overrides. Checked for every
+	// selection, active or not, the same way the top-level api: fields are
+	// checked unconditionally further down via the "api" path -- an
+	// operator can misconfigure TLS/auth before ever turning on API
+	// storage mode, and should find out at config-validation time rather
+	// than only after switching storageMode to "api".
+	for _, apiSelection := range []struct {
+		path      string
+		selection hostplugin.Selection
+	}{
+		{"plugins.api.utxorpc.config", c.Plugins.API.Utxorpc},
+		{"plugins.api.blockfrost.config", c.Plugins.API.Blockfrost},
+		{"plugins.api.mesh.config", c.Plugins.API.Mesh},
+	} {
+		sec := ResolveAPISecurity(
+			c.EffectiveAPIPolicy(),
+			apiSelection.selection,
+		)
+		errs = append(errs, ValidateAPISecurity(apiSelection.path, sec)...)
 	}
 
 	// Bark's DatabaseService mounts its destructive RPCs (CreateSnapshot/

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -468,6 +468,67 @@ func TestValidate(t *testing.T) {
 			name:   "empty mithril backend",
 			modify: func(c *Config) { c.Mithril.Backend = "" },
 		},
+		{
+			name: "invalid top-level api.tls.mode",
+			modify: func(c *Config) {
+				c.API.TLS.Mode = "mutual"
+			},
+			wantErr: `invalid plugins.api.utxorpc.config.tls.mode "mutual"`,
+		},
+		{
+			name: "top-level api.tls.mode server without cert/key",
+			modify: func(c *Config) {
+				c.API.TLS.Mode = "server"
+			},
+			wantErr: `plugins.api.utxorpc.config.tls: mode is "server" but ` +
+				`certFilePath and keyFilePath must both be set`,
+		},
+		{
+			name: "top-level api.tls fully set is valid",
+			modify: func(c *Config) {
+				c.API.TLS = APITLSPolicy{
+					Mode:         "server",
+					CertFilePath: "/etc/dingo/api.crt",
+					KeyFilePath:  "/etc/dingo/api.key",
+				}
+			},
+		},
+		{
+			name: "invalid top-level api.auth.mode",
+			modify: func(c *Config) {
+				c.API.Auth.Mode = "basic"
+			},
+			wantErr: `invalid plugins.api.utxorpc.config.auth.mode "basic"`,
+		},
+		{
+			name: "top-level api.auth.mode token without tokenFilePath",
+			modify: func(c *Config) {
+				c.API.Auth.Mode = "token"
+			},
+			wantErr: `plugins.api.utxorpc.config.auth: mode is "token" but ` +
+				`tokenFilePath is not set`,
+		},
+		{
+			name: "provider auth explicitly disables inherited token mode",
+			modify: func(c *Config) {
+				c.API.Auth = APIAuthPolicy{
+					Mode:          "token",
+					TokenFilePath: "/run/secrets/api-token",
+				}
+				c.Plugins.API.Mesh.Config["auth"] = map[string]any{
+					"mode": "none",
+				}
+			},
+		},
+		{
+			name: "provider auth override with invalid mode",
+			modify: func(c *Config) {
+				c.Plugins.API.Blockfrost.Config["auth"] = map[string]any{
+					"mode": "basic",
+				}
+			},
+			wantErr: `invalid plugins.api.blockfrost.config.auth.mode "basic"`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/httpcors/cors.go
+++ b/internal/httpcors/cors.go
@@ -24,7 +24,7 @@ const (
 	allowMethods = "GET, HEAD, POST, OPTIONS"
 	allowHeaders = "Accept, Authorization, Content-Type, " +
 		"Connect-Protocol-Version, Connect-Timeout-Ms, Grpc-Timeout, " +
-		"X-Blockfrost-Project-Id, X-Grpc-Web, X-Requested-With"
+		"project_id, X-Blockfrost-Project-Id, X-Grpc-Web, X-Requested-With"
 	exposeHeaders = "Grpc-Message, Grpc-Status, Grpc-Status-Details-Bin"
 )
 

--- a/node.go
+++ b/node.go
@@ -39,6 +39,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/nodesettings"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	internalconfig "github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/dblifecycle"
 	"github.com/blinklabs-io/dingo/internal/historyexpiry"
@@ -268,6 +269,21 @@ func (n *Node) apiPluginSelection(
 		)
 	}
 	return selection, uint(port), nil
+}
+
+// resolveAPISecurity computes the effective TLS/authentication policy for
+// one API provider selection from the node's currently loaded
+// configuration (dingo #2996/#2998). Both Run()'s initial construction of
+// the utxorpc/blockfrost/mesh providers and reinitializeAPIServers()'s live
+// rebuild of them after a Restore/Truncate call this instead of resolving
+// TLS/auth themselves, so the two paths cannot drift apart.
+func (n *Node) resolveAPISecurity(
+	selection plugin.Selection,
+) internalconfig.ResolvedAPISecurity {
+	return internalconfig.ResolveAPISecurity(
+		n.config.cfg.EffectiveAPIPolicy(),
+		selection,
+	)
 }
 
 // effectiveBarkHost decides the interface Bark actually binds to.
@@ -1480,6 +1496,7 @@ func (n *Node) Run(ctx context.Context) error {
 		return err
 	}
 	if n.config.storageMode.IsAPI() && utxorpcPort > 0 {
+		utxorpcSecurity := n.resolveAPISecurity(utxorpcSelection)
 		err = plugin.ResolveProvider(
 			n.ctx, n.pluginHost, plugin.CapabilityAPIUtxorpc,
 			utxorpcSelection.Provider, utxorpcSelection.Config,
@@ -1487,9 +1504,11 @@ func (n *Node) Run(ctx context.Context) error {
 				Logger: n.config.logger, EventBus: n.eventBus,
 				LedgerState: n.ledgerState, Mempool: n.mempool,
 				Host:               n.config.bindAddr,
-				TLSCertFilePath:    n.config.tlsCertFilePath,
-				TLSKeyFilePath:     n.config.tlsKeyFilePath,
+				TLSCertFilePath:    utxorpcSecurity.TLSCertFilePath,
+				TLSKeyFilePath:     utxorpcSecurity.TLSKeyFilePath,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
+				AuthMode:           apiauth.Mode(utxorpcSecurity.AuthMode),
+				AuthTokenFilePath:  utxorpcSecurity.AuthTokenFilePath,
 			},
 		)
 		if err != nil {
@@ -1623,12 +1642,17 @@ func (n *Node) Run(ctx context.Context) error {
 				err,
 			)
 		}
+		blockfrostSecurity := n.resolveAPISecurity(blockfrostSelection)
 		err = plugin.ResolveProvider(
 			n.ctx, n.pluginHost, plugin.CapabilityAPIBlockfrost,
 			blockfrostSelection.Provider, blockfrostSelection.Config,
 			blockfrost.ProviderDependencies{
 				Node: adapter, Logger: n.config.logger, Host: n.config.bindAddr,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
+				TLSCertFilePath:    blockfrostSecurity.TLSCertFilePath,
+				TLSKeyFilePath:     blockfrostSecurity.TLSKeyFilePath,
+				AuthMode:           apiauth.Mode(blockfrostSecurity.AuthMode),
+				AuthTokenFilePath:  blockfrostSecurity.AuthTokenFilePath,
 			},
 		)
 		if err != nil {
@@ -1661,6 +1685,7 @@ func (n *Node) Run(ctx context.Context) error {
 					"(Byron genesis hash and Shelley genesis)",
 			)
 		}
+		meshSecurity := n.resolveAPISecurity(meshSelection)
 		err = plugin.ResolveProvider(
 			n.ctx, n.pluginHost, plugin.CapabilityAPIMesh,
 			meshSelection.Provider, meshSelection.Config,
@@ -1676,6 +1701,10 @@ func (n *Node) Run(ctx context.Context) error {
 				GenesisHash:         genesisHash,
 				GenesisStartTimeSec: genesisStartTimeSec,
 				CORSAllowedOrigins:  n.config.corsAllowedOrigins,
+				TLSCertFilePath:     meshSecurity.TLSCertFilePath,
+				TLSKeyFilePath:      meshSecurity.TLSKeyFilePath,
+				AuthMode:            apiauth.Mode(meshSecurity.AuthMode),
+				AuthTokenFilePath:   meshSecurity.AuthTokenFilePath,
 			},
 		)
 		if err != nil {

--- a/node_api_security_reinit_test.go
+++ b/node_api_security_reinit_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/api/blockfrost"
+	"github.com/blinklabs-io/dingo/api/mesh"
+	"github.com/blinklabs-io/dingo/api/utxorpc"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
+	internalconfig "github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/mempool"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedAPISecurity is the subset of a provider's ProviderDependencies
+// this file's regression test cares about, normalized across all three
+// built-in API providers so utxorpc/blockfrost/mesh can be asserted on with
+// one shared comparison.
+type capturedAPISecurity struct {
+	tlsCertFilePath   string
+	tlsKeyFilePath    string
+	authMode          string
+	authTokenFilePath string
+}
+
+// apiSecurityCaptures collects one capturedAPISecurity per built-in API
+// provider capability, guarded by a mutex since plugin.ResolveProvider
+// documents no ordering guarantee across capabilities.
+type apiSecurityCaptures struct {
+	mu           sync.Mutex
+	byCapability map[plugin.Capability]capturedAPISecurity
+}
+
+func newAPISecurityCaptures() *apiSecurityCaptures {
+	return &apiSecurityCaptures{
+		byCapability: make(map[plugin.Capability]capturedAPISecurity),
+	}
+}
+
+func (c *apiSecurityCaptures) record(
+	capability plugin.Capability,
+	got capturedAPISecurity,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byCapability[capability] = got
+}
+
+func (c *apiSecurityCaptures) get(
+	capability plugin.Capability,
+) (capturedAPISecurity, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	got, ok := c.byCapability[capability]
+	return got, ok
+}
+
+// registerAPISecurityCapturingProbe registers a no-op provider under name
+// for capability that records the TLS/auth fields it was actually handed in
+// its ProviderDependencies, so a test can compare what a real provider would
+// have been configured with.
+func registerAPISecurityCapturingProbe(
+	t *testing.T,
+	host *plugin.Host,
+	capability plugin.Capability,
+	name string,
+	captures *apiSecurityCaptures,
+) {
+	t.Helper()
+	descriptor := plugin.Descriptor{Capability: capability, Name: name}
+	noop := func() plugin.Instance { return plugin.Lifecycle{} }
+	var err error
+	switch capability {
+	case plugin.CapabilityAPIUtxorpc:
+		err = plugin.Register(
+			host, descriptor,
+			func() apiProbeConfig { return apiProbeConfig{} },
+			func(
+				_ context.Context,
+				_ apiProbeConfig,
+				deps utxorpc.ProviderDependencies,
+			) (string, plugin.Instance, error) {
+				captures.record(capability, capturedAPISecurity{
+					tlsCertFilePath:   deps.TLSCertFilePath,
+					tlsKeyFilePath:    deps.TLSKeyFilePath,
+					authMode:          string(deps.AuthMode),
+					authTokenFilePath: deps.AuthTokenFilePath,
+				})
+				return name, noop(), nil
+			},
+		)
+	case plugin.CapabilityAPIBlockfrost:
+		err = plugin.Register(
+			host, descriptor,
+			func() apiProbeConfig { return apiProbeConfig{} },
+			func(
+				_ context.Context,
+				_ apiProbeConfig,
+				deps blockfrost.ProviderDependencies,
+			) (string, plugin.Instance, error) {
+				captures.record(capability, capturedAPISecurity{
+					tlsCertFilePath:   deps.TLSCertFilePath,
+					tlsKeyFilePath:    deps.TLSKeyFilePath,
+					authMode:          string(deps.AuthMode),
+					authTokenFilePath: deps.AuthTokenFilePath,
+				})
+				return name, noop(), nil
+			},
+		)
+	case plugin.CapabilityAPIMesh:
+		err = plugin.Register(
+			host, descriptor,
+			func() apiProbeConfig { return apiProbeConfig{} },
+			func(
+				_ context.Context,
+				_ apiProbeConfig,
+				deps mesh.ProviderDependencies,
+			) (string, plugin.Instance, error) {
+				captures.record(capability, capturedAPISecurity{
+					tlsCertFilePath:   deps.TLSCertFilePath,
+					tlsKeyFilePath:    deps.TLSKeyFilePath,
+					authMode:          string(deps.AuthMode),
+					authTokenFilePath: deps.AuthTokenFilePath,
+				})
+				return name, noop(), nil
+			},
+		)
+	default:
+		t.Fatalf("unsupported API capability %s", capability)
+	}
+	require.NoError(t, err)
+}
+
+// TestReinitializeAPIServersResolvesSameAPISecurityAsRun is the regression
+// test for the bug where reinitializeAPIServers (the live Restore/Truncate
+// reinit path, node_lifecycle.go) wired utxorpc's TLS off the deprecated
+// root-level fields directly, gave blockfrost and mesh no TLS at all, and
+// set no auth fields on any of the three -- instead of resolving the
+// dingo #2996/#2998 api.tls/api.auth policy the way Run() does.
+//
+// It configures a top-level api.tls/api.auth policy that is deliberately
+// different from the deprecated root-level TLS fields, then calls
+// reinitializeAPIServers directly and asserts every provider's captured
+// ProviderDependencies match n.resolveAPISecurity's resolution for that
+// provider's selection -- the exact helper Run() also calls (node.go) -- and
+// do NOT match the stale root-level fields a pre-fix reinit would have used
+// instead.
+func TestReinitializeAPIServersResolvesSameAPISecurityAsRun(t *testing.T) {
+	n, _ := newLiveLifecycleTestNode(t, 5)
+
+	mp, err := mempool.NewFIFO(mempool.MempoolConfig{
+		Logger:          n.config.logger,
+		Validator:       n.ledgerState,
+		MempoolCapacity: 1024 * 1024,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mp.Start(context.Background()))
+	t.Cleanup(func() { _ = mp.Stop(context.Background()) })
+	n.mempool = mp
+
+	n.config.storageMode = StorageModeAPI
+	n.config.midnight = MidnightConfig{Port: 0}
+	n.config.pluginSelections = map[plugin.Capability]plugin.Selection{
+		plugin.CapabilityAPIUtxorpc: {
+			Provider: "security-probe",
+			Config:   map[string]any{"port": uint(19090)},
+		},
+		plugin.CapabilityAPIBlockfrost: {
+			Provider: "security-probe",
+			Config:   map[string]any{"port": uint(13000)},
+		},
+		plugin.CapabilityAPIMesh: {
+			Provider: "security-probe",
+			Config:   map[string]any{"port": uint(18080)},
+		},
+	}
+
+	// Deliberately distinct from api.tls/api.auth below, so a reinit that
+	// (pre-fix) wired these raw fields instead of resolving through
+	// internal/config is caught by the "does not equal legacy" assertion.
+	n.config.cfg.TlsCertFilePath = "/legacy/root.crt"
+	n.config.cfg.TlsKeyFilePath = "/legacy/root.key"
+	n.config.cfg.API = internalconfig.APIConfig{
+		TLS: internalconfig.APITLSPolicy{
+			Mode:         "server",
+			CertFilePath: "/cfg/api-tls.crt",
+			KeyFilePath:  "/cfg/api-tls.key",
+		},
+		Auth: internalconfig.APIAuthPolicy{
+			Mode:          "token",
+			TokenFilePath: "/cfg/api-auth.token",
+		},
+	}
+
+	captures := newAPISecurityCaptures()
+	for _, capability := range []plugin.Capability{
+		plugin.CapabilityAPIUtxorpc,
+		plugin.CapabilityAPIBlockfrost,
+		plugin.CapabilityAPIMesh,
+	} {
+		registerAPISecurityCapturingProbe(
+			t, n.pluginHost, capability, "security-probe", captures,
+		)
+	}
+
+	require.NoError(t, n.reinitializeAPIServers())
+	t.Cleanup(func() {
+		for _, capability := range []plugin.Capability{
+			plugin.CapabilityAPIUtxorpc,
+			plugin.CapabilityAPIBlockfrost,
+			plugin.CapabilityAPIMesh,
+		} {
+			_ = n.pluginHost.StopCapability(context.Background(), capability)
+		}
+	})
+
+	for _, capability := range []plugin.Capability{
+		plugin.CapabilityAPIUtxorpc,
+		plugin.CapabilityAPIBlockfrost,
+		plugin.CapabilityAPIMesh,
+	} {
+		got, ok := captures.get(capability)
+		require.Truef(t, ok, "capability %s never resolved", capability)
+
+		// This is exactly what Run() would have computed for the same
+		// selection, since Run() and reinitializeAPIServers both now call
+		// this one shared helper (node.go) instead of resolving
+		// separately.
+		want := n.resolveAPISecurity(n.config.pluginSelections[capability])
+		assert.Equalf(t, capturedAPISecurity{
+			tlsCertFilePath:   want.TLSCertFilePath,
+			tlsKeyFilePath:    want.TLSKeyFilePath,
+			authMode:          want.AuthMode,
+			authTokenFilePath: want.AuthTokenFilePath,
+		}, got, "capability %s", capability)
+
+		assert.NotEqualf(
+			t, n.config.cfg.TlsCertFilePath, got.tlsCertFilePath,
+			"capability %s: reinit leaked the deprecated root-level TLS "+
+				"cert instead of resolving api.tls",
+			capability,
+		)
+		assert.NotEmptyf(
+			t, got.authMode,
+			"capability %s: reinit set no auth mode at all",
+			capability,
+		)
+		assert.Equalf(
+			t, string(apiauth.ModeToken), got.authMode,
+			"capability %s", capability,
+		)
+		assert.Equalf(
+			t, "/cfg/api-auth.token", got.authTokenFilePath,
+			"capability %s", capability,
+		)
+	}
+}

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -72,6 +72,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/lifecycle"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/dblifecycle"
 	"github.com/blinklabs-io/dingo/internal/fsyncdir"
 	"github.com/blinklabs-io/dingo/internal/historyexpiry"
@@ -1034,6 +1035,7 @@ func (n *Node) reinitializeAPIServers() error {
 		return err
 	}
 	if n.config.storageMode.IsAPI() && utxorpcPort > 0 {
+		utxorpcSecurity := n.resolveAPISecurity(utxorpcSelection)
 		err = plugin.ResolveProvider(
 			n.ctx, n.pluginHost, plugin.CapabilityAPIUtxorpc,
 			utxorpcSelection.Provider, utxorpcSelection.Config,
@@ -1041,9 +1043,11 @@ func (n *Node) reinitializeAPIServers() error {
 				Logger: n.config.logger, EventBus: n.eventBus,
 				LedgerState: n.ledgerState, Mempool: n.mempool,
 				Host:               n.config.bindAddr,
-				TLSCertFilePath:    n.config.tlsCertFilePath,
-				TLSKeyFilePath:     n.config.tlsKeyFilePath,
+				TLSCertFilePath:    utxorpcSecurity.TLSCertFilePath,
+				TLSKeyFilePath:     utxorpcSecurity.TLSKeyFilePath,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
+				AuthMode:           apiauth.Mode(utxorpcSecurity.AuthMode),
+				AuthTokenFilePath:  utxorpcSecurity.AuthTokenFilePath,
 			},
 		)
 		if err != nil {
@@ -1103,12 +1107,17 @@ func (n *Node) reinitializeAPIServers() error {
 		if err != nil {
 			return fmt.Errorf("recreating blockfrost node adapter: %w", err)
 		}
+		blockfrostSecurity := n.resolveAPISecurity(blockfrostSelection)
 		err = plugin.ResolveProvider(
 			n.ctx, n.pluginHost, plugin.CapabilityAPIBlockfrost,
 			blockfrostSelection.Provider, blockfrostSelection.Config,
 			blockfrost.ProviderDependencies{
 				Node: adapter, Logger: n.config.logger, Host: n.config.bindAddr,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
+				TLSCertFilePath:    blockfrostSecurity.TLSCertFilePath,
+				TLSKeyFilePath:     blockfrostSecurity.TLSKeyFilePath,
+				AuthMode:           apiauth.Mode(blockfrostSecurity.AuthMode),
+				AuthTokenFilePath:  blockfrostSecurity.AuthTokenFilePath,
 			},
 		)
 		if err != nil {
@@ -1137,6 +1146,7 @@ func (n *Node) reinitializeAPIServers() error {
 					"(Byron genesis hash and Shelley genesis)",
 			)
 		}
+		meshSecurity := n.resolveAPISecurity(meshSelection)
 		err = plugin.ResolveProvider(
 			n.ctx, n.pluginHost, plugin.CapabilityAPIMesh,
 			meshSelection.Provider, meshSelection.Config,
@@ -1152,6 +1162,10 @@ func (n *Node) reinitializeAPIServers() error {
 				GenesisHash:         genesisHash,
 				GenesisStartTimeSec: genesisStartTimeSec,
 				CORSAllowedOrigins:  n.config.corsAllowedOrigins,
+				TLSCertFilePath:     meshSecurity.TLSCertFilePath,
+				TLSKeyFilePath:      meshSecurity.TLSKeyFilePath,
+				AuthMode:            apiauth.Mode(meshSecurity.AuthMode),
+				AuthTokenFilePath:   meshSecurity.AuthTokenFilePath,
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

Implements #2998 (top-level API security config with per-plugin overrides), and its prerequisite #2996 (uniform TLS/auth across the built-in API plugins), which was not yet implemented.

- Adds a shared `internal/apiauth` credential-verification package (`none`/`token` modes, fails closed, constant-time comparison, redacts tokens from logs).
- Adds TLS support to Blockfrost and Mesh (mirroring UTxORPC's existing pattern) and wires auth middleware into all three providers.
- Adds a top-level `api: {tls, auth}` config section that supplies defaults to every selected API provider, with deterministic field-by-field merging against `plugins.api.<name>.config.tls/auth` overrides (explicit provider field > top-level api field > provider default), including explicit-disable sentinels.
- Deprecated root `tlsCertFilePath`/`tlsKeyFilePath` fold in as a fallback default only when `api.tls` is entirely unset — existing deployments aren't silently changed on upgrade.
- `bindAddr`/`corsAllowedOrigins` deliberately stay at config root (not moved under `api:`) — documented rationale in ARCHITECTURE.md/README.md.
- Fixes a bug found in review: the live Restore/Truncate reinit path (`reinitializeAPIServers`) previously didn't apply the new resolution at all and would have silently stripped TLS/auth from all three API listeners. Both the initial `Run()` path and the reinit path now share one `resolveAPISecurity()` helper so they can't drift apart.

## Testing

- New/updated tests: `internal/apiauth`, `internal/config/api_security_test.go` (merge determinism regardless of map order, partial overrides, explicit disable, invalid merged cert/key pairs, CLI/env/YAML precedence), per-provider TLS/auth tests (`api/blockfrost`, `api/mesh`, `api/utxorpc` — real TLS handshakes and real HTTP 401/200 round-trips), and `node_api_security_reinit_test.go` (asserts reinit resolves identical policy to `Run()`).
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...`, `nilaway ./...`, `modernize ./...`, `make import-boundaries`, `make gorm-check` all clean.
- Full `go test ./... -race` passes (two unrelated pre-existing anomalies noted separately, not from this change: local docs-parity tooling version check, and the `ledger` package's own `-race` runtime under Go's default per-binary timeout).
- DevNet not run — this change is config/composition/transport-security only; no consensus, chain-sync, mempool, or epoch-boundary logic touched.

## Docs

- `ARCHITECTURE.md`: documents the shared TLS/auth boundary across API plugins, config resolution at composition, and that both `Run()` and the reinit path use the same resolution helper.
- `README.md` / `dingo.yaml.example`: shared-default and per-provider override examples, deprecation note for the old root TLS fields.
- `DATABASE.md`: checked, not affected.

Closes #2998
Closes #2996

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared TLS and authentication policy for all built-in APIs with a new top-level `api: { tls, auth }` config and per-plugin overrides, ensuring consistent security across Blockfrost, Mesh, and UTxORPC. Fixes reinit so TLS/auth remain applied after Restore/Truncate.

- New Features
  - Introduced `internal/apiauth` with `none` and `token` modes, constant-time compare, and redacted logs; accepts Blockfrost `project_id` as a token alias.
  - Enabled TLS for `api/blockfrost` and `api/mesh`; wired auth middleware into `api/blockfrost`, `api/mesh`, and `api/utxorpc`.
  - Added `api: { tls, auth }` defaults with deterministic field-by-field merging against `plugins.api.<name>.config.tls|auth`, including explicit disable.
  - Kept `bindAddr` and global CORS at the config root; deprecated root `tlsCertFilePath`/`tlsKeyFilePath` as fallback only when `api.tls` is unset.
  - Added CLI/env support for new fields (`--api-tls-*`, `--api-auth-*`, `DINGO_API_TLS_*`, `DINGO_API_AUTH_*`).

- Bug Fixes
  - Reinit now uses the same resolver as `Run()` for TLS/auth, preventing listeners from losing security settings after DB restore/truncate.
  - Validates effective provider TLS/auth config, rejecting partial cert/key pairs and invalid modes before starting listeners.

<sup>Written for commit a235893bbcb5e6fabe674a760baa483e53ec441b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable TLS and token authentication for UTxO RPC, Blockfrost, and Mesh APIs.
  - Supports Bearer and `project_id` credentials, returning `401 Unauthorized` for invalid access.
  - Added shared API security defaults with provider-specific overrides.
  - Added CLI, YAML, and environment-variable configuration for API TLS and authentication.
  - API security settings now apply consistently during startup and reinitialization.

- **Documentation**
  - Updated architecture, README, and configuration examples with setup instructions, precedence rules, validation, and legacy TLS fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->