### PR TITLE
test(api/mesh): add endpoint and Rosetta contract coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3260,12 +3260,18 @@ Two contracts follow from that boundary:
   same translation `api/blockfrost`'s block-by-height lookup and
   `midnight/server`'s `databaseAdapter` perform. Handlers deal only in
   consensus block numbers.
-- **No historical balance lookup.** `/network/options` advertises
-  `historical_balance_lookup: false`, and `/account/balance` enforces it: a
-  request carrying a `block_identifier` is refused with the `not implemented`
-  error (code 7, HTTP 501) rather than being answered with the current tip
-  balance under a historical identifier. Balances and coins are always reported
-  against the tip returned in the response's `block_identifier`.
+- **Historical balances are pinned to the requested point.**
+  `/network/options` advertises `historical_balance_lookup: true`, and
+  `/account/balance` honors it. A request carrying a `block_identifier`
+  resolves that block through the same lookup `/block` uses, reads the UTxO set
+  at the block's slot via `MeshLedgerState.UtxosByAddressAtSlot` (UTxOs added
+  at or before the slot and not spent until after it), and echoes the resolved
+  block back as the response's `block_identifier` — never the tip. A point the
+  node cannot resolve, including the hash of a rolled-back block, fails with
+  `block not found` rather than falling back to another point. An identifier
+  carrying neither hash nor index is treated as absent, since clients commonly
+  send the field unconditionally. `/account/coins` has no block identifier in
+  the Rosetta schema and always reports the tip.
 
 ### UTxO RPC (`api/utxorpc/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3244,6 +3244,29 @@ datum metadata are not yet sourced and return `null`.
 
 Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access.
 
+The server depends on four narrow interfaces (`api/mesh/node_interface.go`) —
+`MeshChain`, `MeshDatabase`, `MeshLedgerState`, and `MeshMempool` — rather than
+on the concrete chain, database, ledger, and mempool types, so the handlers stay
+free of storage-layer concerns and are testable without a node.
+`meshDatabaseAdapter` (`api/mesh/adapter.go`) is the only binding between those
+interfaces and real storage.
+
+Two contracts follow from that boundary:
+
+- **Block numbering.** `block_identifier.index` is the Cardano block height in
+  both directions: `/block` reports it, and `/block` accepts it. The blob
+  store's own block index is 1-based (`database.BlockInitialIndex`), so
+  `meshDatabaseAdapter.BlockByIndex` translates height to internal index, the
+  same translation `api/blockfrost`'s block-by-height lookup and
+  `midnight/server`'s `databaseAdapter` perform. Handlers deal only in
+  consensus block numbers.
+- **No historical balance lookup.** `/network/options` advertises
+  `historical_balance_lookup: false`, and `/account/balance` enforces it: a
+  request carrying a `block_identifier` is refused with the `not implemented`
+  error (code 7, HTTP 501) rather than being answered with the current tip
+  balance under a historical identifier. Balances and coins are always reported
+  against the tip returned in the response's `block_identifier`.
+
 ### UTxO RPC (`api/utxorpc/`)
 
 A gRPC server implementing the UTxO RPC specification with query, submit, sync, and watch services. The same listener exposes both the `utxorpc.v1alpha` and `utxorpc.v1beta` service namespaces. Every method other than v1beta's additional `QueryService.ReadState` is wire-compatible across the two, so the beta routes rewrite the service path onto the alpha handlers; `ReadState` is served by `betaQueryServiceServer` (`api/utxorpc/readstate.go`) instead. It answers the one Cardano state query v1beta defines, `GetStakePoolDistribution`, from `ledger.LedgerState.PoolStakeDistribution` — the same read that backs the node-to-client `GetPoolDistr2` query. The `ledger_tip` it reports is the tip that read took inside its own transaction, carried back on the result, rather than one sampled while building the reply: the two can straddle an epoch boundary, and a later tip would name an epoch whose stake snapshot is not the one the reply carries. `LedgerState` is an optional dependency that `Utxorpc.Start` admits as an untyped nil, so the handler checks it per request and reports `Unavailable` rather than panicking. The `pool_keyhashes` filter is capped by `MaxPoolFilter` (default 1000), like the `ReadUtxos` and `ReadData` key lists, since it sizes the snapshot and registration reads it drives; asking for every pool is an empty filter and one bulk read. An empty `pool_keyhashes` means every pool, per the proto; a filter entry that is not 28 bytes is rejected as `InvalidArgument` rather than padded or truncated into a different pool. Because the protobuf `RationalNumber` is an int32 over a uint32, a stake fraction whose exact ratio does not fit — the normal case on a real network, where the denominator is total active stake in lovelace — is rescaled onto a fixed denominator of 1e9 rather than failing. `newServeMux` is the single wiring site for the routing table, and one service-name list (`servedServiceNames`) feeds the `grpc_health_v1` checker and both reflection wire versions, so `grpc.reflection.v1` and `grpc.reflection.v1alpha` clients discover the same services — v1alpha is an older reflection protocol, not an older API surface. Supports optional TLS.

--- a/api/mesh/account.go
+++ b/api/mesh/account.go
@@ -17,7 +17,6 @@ package mesh
 import (
 	"cmp"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -40,14 +39,13 @@ func (s *Server) handleAccountBalance(
 		return
 	}
 
-	// /network/options advertises
-	// historical_balance_lookup=false, so a request pinned to an
-	// earlier block cannot be answered. Refuse it explicitly instead
-	// of returning the current tip balance under a historical block
-	// identifier, which would silently misreport the account.
-	if meshErr := rejectHistoricalLookup(
+	// Resolve the point before touching the ledger: a balance pinned
+	// to a block the node cannot resolve must fail rather than fall
+	// back to another point.
+	point, meshErr := s.resolveBalancePoint(
 		req.BlockIdentifier,
-	); meshErr != nil {
+	)
+	if meshErr != nil {
 		writeError(w, meshErr)
 		return
 	}
@@ -60,26 +58,34 @@ func (s *Server) handleAccountBalance(
 		return
 	}
 
-	utxos, err := s.config.LedgerState.UtxosByAddress(
-		addr,
+	var (
+		utxos []models.Utxo
+		err   error
 	)
+	if point.historical {
+		utxos, err = s.config.LedgerState.
+			UtxosByAddressAtSlot(addr, point.slot)
+	} else {
+		utxos, err = s.config.LedgerState.UtxosByAddress(
+			addr,
+		)
+	}
 	if err != nil {
 		s.logger.Error(
 			"failed to query UTxOs for account",
 			"address",
 			req.AccountIdentifier.Address,
+			"slot", point.slot,
+			"historical", point.historical,
 			"error", err,
 		)
 		writeError(w, wrapErr(ErrInternal, err))
 		return
 	}
 
-	balances := aggregateBalances(utxos)
-	tip := s.config.Chain.Tip()
-
 	writeJSON(w, http.StatusOK, &AccountBalanceResponse{
-		BlockIdentifier: s.tipBlockID(tip),
-		Balances:        balances,
+		BlockIdentifier: point.blockID,
+		Balances:        aggregateBalances(utxos),
 	})
 }
 
@@ -144,29 +150,46 @@ func (s *Server) parseAccountAddress(
 	return addr, nil
 }
 
-// rejectHistoricalLookup returns an error when the caller pinned a
-// request to a specific block. An identifier present but carrying
-// neither a hash nor an index is treated as absent, matching clients
-// that always send the field.
-func rejectHistoricalLookup(
+// balancePoint is the chain point a balance response is pinned to: the
+// identifier echoed back to the client, the slot the UTxO set is read
+// at, and whether that point is an earlier block rather than the tip.
+type balancePoint struct {
+	blockID    *BlockIdentifier
+	slot       uint64
+	historical bool
+}
+
+// resolveBalancePoint determines the point a balance request is pinned
+// to. A nil identifier, or one carrying neither a hash nor an index, is
+// treated as the current tip -- clients commonly send the field
+// unconditionally. Anything else is resolved through the same block
+// lookup /block uses, so an unknown or rolled-back point fails with
+// block-not-found instead of silently answering from the tip.
+func (s *Server) resolveBalancePoint(
 	id *PartialBlockIdentifier,
-) *Error {
-	if id == nil {
-		return nil
-	}
-	hasHash := id.Hash != nil && *id.Hash != ""
-	hasIndex := id.Index != nil
+) (balancePoint, *Error) {
+	hasHash := id != nil && id.Hash != nil && *id.Hash != ""
+	hasIndex := id != nil && id.Index != nil
 	if !hasHash && !hasIndex {
-		return nil
+		tip := s.config.Chain.Tip()
+		return balancePoint{
+			blockID: s.tipBlockID(tip),
+			slot:    tip.Point.Slot,
+		}, nil
 	}
-	return wrapErr(
-		ErrNotImplemented,
-		errors.New(
-			"historical balance lookup is not supported; "+
-				"omit block_identifier to query the "+
-				"current tip",
-		),
-	)
+
+	block, meshErr := s.lookupBlock(id)
+	if meshErr != nil {
+		return balancePoint{}, meshErr
+	}
+	return balancePoint{
+		blockID: &BlockIdentifier{
+			Index: int64(block.Number), // #nosec G115
+			Hash:  hex.EncodeToString(block.Hash),
+		},
+		slot:       block.Slot,
+		historical: true,
+	}, nil
 }
 
 // aggregateBalances sums ADA and native asset amounts

--- a/api/mesh/account.go
+++ b/api/mesh/account.go
@@ -17,6 +17,7 @@ package mesh
 import (
 	"cmp"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -34,6 +35,18 @@ func (s *Server) handleAccountBalance(
 	var req AccountBalanceRequest
 	if meshErr := s.decodeAndValidate(
 		w, r, &req,
+	); meshErr != nil {
+		writeError(w, meshErr)
+		return
+	}
+
+	// /network/options advertises
+	// historical_balance_lookup=false, so a request pinned to an
+	// earlier block cannot be answered. Refuse it explicitly instead
+	// of returning the current tip balance under a historical block
+	// identifier, which would silently misreport the account.
+	if meshErr := rejectHistoricalLookup(
+		req.BlockIdentifier,
 	); meshErr != nil {
 		writeError(w, meshErr)
 		return
@@ -129,6 +142,31 @@ func (s *Server) parseAccountAddress(
 			wrapErr(ErrInvalidRequest, err)
 	}
 	return addr, nil
+}
+
+// rejectHistoricalLookup returns an error when the caller pinned a
+// request to a specific block. An identifier present but carrying
+// neither a hash nor an index is treated as absent, matching clients
+// that always send the field.
+func rejectHistoricalLookup(
+	id *PartialBlockIdentifier,
+) *Error {
+	if id == nil {
+		return nil
+	}
+	hasHash := id.Hash != nil && *id.Hash != ""
+	hasIndex := id.Index != nil
+	if !hasHash && !hasIndex {
+		return nil
+	}
+	return wrapErr(
+		ErrNotImplemented,
+		errors.New(
+			"historical balance lookup is not supported; "+
+				"omit block_identifier to query the "+
+				"current tip",
+		),
+	)
 }
 
 // aggregateBalances sums ADA and native asset amounts

--- a/api/mesh/account_test.go
+++ b/api/mesh/account_test.go
@@ -175,30 +175,223 @@ func TestAccountBalanceAggregatesAssets(t *testing.T) {
 	)
 }
 
-// TestAccountBalanceRejectsHistoricalLookup covers the Mesh contract
-// that an unsupported operation fails explicitly: /network/options
-// advertises historical_balance_lookup=false, so a request pinned to an
-// older block must be refused rather than silently answered with the
-// current tip balance.
-func TestAccountBalanceRejectsHistoricalLookup(t *testing.T) {
+// TestAccountBalanceHistoricalByIndex covers a balance pinned to an
+// earlier block: the ledger must be queried at that block's slot, and
+// the response must report the requested block rather than the tip, so
+// a client can tell which point the balance belongs to.
+func TestAccountBalanceHistoricalByIndex(t *testing.T) {
 	deps := newTestDeps()
+	paymentKey := testKeyHash(0x30)
 	addr := testAddress(
-		t, lcommon.AddressTypeKeyNone, testKeyHash(0x06), nil,
+		t, lcommon.AddressTypeKeyNone, paymentKey, nil,
 	)
+	histHash := testHash(0x31)
+	deps.chain.tip = ochainsync.Tip{
+		Point:       ocommon.NewPoint(9000, testHash(0x32)),
+		BlockNumber: 900,
+	}
+	deps.database.blockByIndex = func(
+		idx uint64,
+	) (models.Block, error) {
+		require.Equal(t, uint64(120), idx)
+		return models.Block{
+			Hash:   histHash,
+			Number: 120,
+			Slot:   1200,
+		}, nil
+	}
 	deps.ledger.utxos = func(
 		lcommon.Address,
 	) ([]models.Utxo, error) {
-		t.Fatal("ledger must not be queried for a historical point")
+		t.Fatal("historical request must not read the tip UTxO set")
+		return nil, nil
+	}
+	deps.ledger.utxosAtSlot = func(
+		got lcommon.Address,
+		slot uint64,
+	) ([]models.Utxo, error) {
+		require.Equal(t, addr, got.String())
+		require.Equal(t, uint64(1200), slot)
+		return []models.Utxo{
+			testUtxo(
+				testHash(0x33), 0, 7_000_000, paymentKey, nil,
+			),
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	req := balanceRequest(addr)
+	req.BlockIdentifier = byIndex(120)
+	rec := postJSON(t, h, "/account/balance", req)
+
+	resp := decodeResponse[AccountBalanceResponse](t, rec)
+	require.Equal(
+		t,
+		&BlockIdentifier{Index: 120, Hash: hexString(histHash)},
+		resp.BlockIdentifier,
+	)
+	require.Len(t, resp.Balances, 1)
+	require.Equal(t, "7000000", resp.Balances[0].Value)
+}
+
+// TestAccountBalanceHistoricalByHash covers pinning by block hash,
+// which is the identifier a client holds after reading a block.
+func TestAccountBalanceHistoricalByHash(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x34), nil,
+	)
+	histHash := testHash(0x35)
+	deps.database.blockByHash = func(
+		hash []byte,
+	) (models.Block, error) {
+		require.Equal(t, histHash, hash)
+		return models.Block{
+			Hash:   histHash,
+			Number: 55,
+			Slot:   550,
+		}, nil
+	}
+	deps.ledger.utxosAtSlot = func(
+		_ lcommon.Address,
+		slot uint64,
+	) ([]models.Utxo, error) {
+		require.Equal(t, uint64(550), slot)
 		return nil, nil
 	}
 	h := newTestHandler(t, deps)
 
 	req := balanceRequest(addr)
-	req.BlockIdentifier = byIndex(10)
+	req.BlockIdentifier = byHash(hexString(histHash))
 	rec := postJSON(t, h, "/account/balance", req)
 
-	requireMeshError(
-		t, rec, ErrNotImplemented, http.StatusNotImplemented,
+	resp := decodeResponse[AccountBalanceResponse](t, rec)
+	require.Equal(
+		t,
+		&BlockIdentifier{Index: 55, Hash: hexString(histHash)},
+		resp.BlockIdentifier,
+	)
+	// An account with no UTxOs at that point still reports zero ADA.
+	require.Len(t, resp.Balances, 1)
+	require.Equal(t, "0", resp.Balances[0].Value)
+}
+
+// TestAccountBalanceHistoricalEmptyIdentifier asserts a block
+// identifier carrying neither hash nor index is treated as absent, so
+// clients that always send the field still get the tip balance.
+func TestAccountBalanceHistoricalEmptyIdentifier(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x36), nil,
+	)
+	deps.chain.tip = ochainsync.Tip{
+		Point:       ocommon.NewPoint(70, testHash(0x37)),
+		BlockNumber: 7,
+	}
+	called := false
+	deps.ledger.utxos = func(
+		lcommon.Address,
+	) ([]models.Utxo, error) {
+		called = true
+		return nil, nil
+	}
+	deps.ledger.utxosAtSlot = func(
+		lcommon.Address, uint64,
+	) ([]models.Utxo, error) {
+		t.Fatal("empty identifier must not take the historical path")
+		return nil, nil
+	}
+	h := newTestHandler(t, deps)
+
+	req := balanceRequest(addr)
+	req.BlockIdentifier = &PartialBlockIdentifier{}
+	rec := postJSON(t, h, "/account/balance", req)
+
+	resp := decodeResponse[AccountBalanceResponse](t, rec)
+	require.True(t, called)
+	require.Equal(t, int64(7), resp.BlockIdentifier.Index)
+}
+
+// TestAccountBalanceHistoricalBlockNotFound covers a point the node
+// cannot resolve, including the reorg case where the client holds the
+// hash of a block that was rolled back: the balance must not silently
+// fall back to another point.
+func TestAccountBalanceHistoricalBlockNotFound(t *testing.T) {
+	rolledBack := testHash(0x38)
+	tests := map[string]*PartialBlockIdentifier{
+		"unknown index":    byIndex(999999),
+		"rolled-back hash": byHash(hexString(rolledBack)),
+	}
+	for name, id := range tests {
+		t.Run(name, func(t *testing.T) {
+			deps := newTestDeps()
+			addr := testAddress(
+				t, lcommon.AddressTypeKeyNone,
+				testKeyHash(0x39), nil,
+			)
+			deps.database.blockByIndex = func(
+				uint64,
+			) (models.Block, error) {
+				return models.Block{},
+					models.ErrBlockNotFound
+			}
+			deps.database.blockByHash = func(
+				[]byte,
+			) (models.Block, error) {
+				return models.Block{},
+					models.ErrBlockNotFound
+			}
+			deps.ledger.utxosAtSlot = func(
+				lcommon.Address, uint64,
+			) ([]models.Utxo, error) {
+				t.Fatal("must not query an unresolved point")
+				return nil, nil
+			}
+			h := newTestHandler(t, deps)
+
+			req := balanceRequest(addr)
+			req.BlockIdentifier = id
+			rec := postJSON(t, h, "/account/balance", req)
+
+			requireMeshError(
+				t, rec, ErrBlockNotFound,
+				http.StatusNotFound,
+			)
+		})
+	}
+}
+
+// TestAccountBalanceHistoricalLedgerError asserts a failure reading the
+// historical UTxO set is reported rather than degraded to an empty
+// balance.
+func TestAccountBalanceHistoricalLedgerError(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x3a), nil,
+	)
+	deps.database.blockByIndex = func(
+		uint64,
+	) (models.Block, error) {
+		return models.Block{
+			Hash: testHash(0x3b), Number: 4, Slot: 40,
+		}, nil
+	}
+	deps.ledger.utxosAtSlot = func(
+		lcommon.Address, uint64,
+	) ([]models.Utxo, error) {
+		return nil, errors.New("historical read failed")
+	}
+	h := newTestHandler(t, deps)
+
+	req := balanceRequest(addr)
+	req.BlockIdentifier = byIndex(4)
+	rec := postJSON(t, h, "/account/balance", req)
+
+	got := requireMeshError(
+		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+	require.Equal(
+		t, "historical read failed", got.Details["error"],
 	)
 }
 
@@ -338,5 +531,45 @@ func TestAccountCoinsLedgerError(t *testing.T) {
 
 	requireMeshError(
 		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+}
+
+// TestAccountBalanceHonorsAdvertisedCapability ties the capability
+// advertised by /network/options to what /account/balance actually
+// does. The two drifting apart is a client-visible contract break:
+// a client that trusts the flag would either skip historical queries
+// the node supports, or send ones it rejects.
+func TestAccountBalanceHonorsAdvertisedCapability(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x3c), nil,
+	)
+	deps.database.blockByIndex = func(
+		uint64,
+	) (models.Block, error) {
+		return models.Block{
+			Hash: testHash(0x3d), Number: 2, Slot: 20,
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	optsRec := postJSON(t, h, "/network/options", NetworkRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	})
+	opts := decodeResponse[NetworkOptionsResponse](t, optsRec)
+
+	req := balanceRequest(addr)
+	req.BlockIdentifier = byIndex(2)
+	rec := postJSON(t, h, "/account/balance", req)
+
+	if opts.Allow.HistoricalBalanceLookup {
+		resp := decodeResponse[AccountBalanceResponse](t, rec)
+		require.Equal(t, int64(2), resp.BlockIdentifier.Index)
+		return
+	}
+	requireMeshError(
+		t, rec, ErrNotImplemented, http.StatusNotImplemented,
 	)
 }

--- a/api/mesh/account_test.go
+++ b/api/mesh/account_test.go
@@ -203,18 +203,23 @@ func TestAccountBalanceRejectsHistoricalLookup(t *testing.T) {
 }
 
 func TestAccountBalanceInvalidAccount(t *testing.T) {
-	tests := map[string]string{
-		"missing account identifier": "",
-		"empty address":              "",
-		"malformed address":          "not-an-address",
+	// An absent identifier and one carrying an empty address are
+	// separate branches of parseAccountAddress, so the empty-address
+	// case sets a non-nil identifier rather than relying on
+	// balanceRequest("") leaving the field nil.
+	emptyAddress := balanceRequest("")
+	emptyAddress.AccountIdentifier = &AccountIdentifier{}
+
+	tests := map[string]AccountBalanceRequest{
+		"missing account identifier": balanceRequest(""),
+		"empty address":              emptyAddress,
+		"malformed address":          balanceRequest("not-an-address"),
 	}
-	for name, addr := range tests {
+	for name, req := range tests {
 		t.Run(name, func(t *testing.T) {
 			h := newTestHandler(t, newTestDeps())
 
-			rec := postJSON(
-				t, h, "/account/balance", balanceRequest(addr),
-			)
+			rec := postJSON(t, h, "/account/balance", req)
 
 			requireMeshError(
 				t, rec, ErrInvalidRequest,

--- a/api/mesh/account_test.go
+++ b/api/mesh/account_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// balanceRequest builds an /account/balance request.
+func balanceRequest(addr string) AccountBalanceRequest {
+	req := AccountBalanceRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	}
+	if addr != "" {
+		req.AccountIdentifier = &AccountIdentifier{Address: addr}
+	}
+	return req
+}
+
+// coinsRequest builds an /account/coins request.
+func coinsRequest(addr string) AccountCoinsRequest {
+	req := AccountCoinsRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	}
+	if addr != "" {
+		req.AccountIdentifier = &AccountIdentifier{Address: addr}
+	}
+	return req
+}
+
+func TestAccountBalance(t *testing.T) {
+	deps := newTestDeps()
+	paymentKey := testKeyHash(0x03)
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, paymentKey, nil,
+	)
+	tipHash := testHash(0x99)
+	deps.chain.tip = ochainsync.Tip{
+		Point:       ocommon.NewPoint(500, tipHash),
+		BlockNumber: 25,
+	}
+	deps.ledger.utxos = func(
+		got lcommon.Address,
+	) ([]models.Utxo, error) {
+		require.Equal(t, addr, got.String())
+		return []models.Utxo{
+			testUtxo(
+				testHash(0x01), 0, 2_000_000, paymentKey, nil,
+			),
+			testUtxo(
+				testHash(0x02), 1, 3_500_000, paymentKey, nil,
+			),
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/balance", balanceRequest(addr))
+
+	resp := decodeResponse[AccountBalanceResponse](t, rec)
+	require.Equal(
+		t,
+		&BlockIdentifier{Index: 25, Hash: hexString(tipHash)},
+		resp.BlockIdentifier,
+	)
+	require.Len(t, resp.Balances, 1)
+	require.Equal(t, "5500000", resp.Balances[0].Value)
+	require.Equal(t, "ADA", resp.Balances[0].Currency.Symbol)
+	require.Equal(t, int32(6), resp.Balances[0].Currency.Decimals)
+}
+
+// TestAccountBalanceEmptyAccount asserts an address with no UTxOs still
+// reports an explicit zero ADA balance rather than an empty list, which
+// Mesh clients treat as a malformed response.
+func TestAccountBalanceEmptyAccount(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x04), nil,
+	)
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/balance", balanceRequest(addr))
+
+	resp := decodeResponse[AccountBalanceResponse](t, rec)
+	require.Len(t, resp.Balances, 1)
+	require.Equal(t, "0", resp.Balances[0].Value)
+}
+
+// TestAccountBalanceAggregatesAssets covers native asset totals summed
+// across UTxOs and the deterministic policy/name ordering clients rely
+// on for stable diffs.
+func TestAccountBalanceAggregatesAssets(t *testing.T) {
+	deps := newTestDeps()
+	paymentKey := testKeyHash(0x05)
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, paymentKey, nil,
+	)
+	policyB := testKeyHash(0xbb)
+	policyA := testKeyHash(0xaa)
+	deps.ledger.utxos = func(
+		lcommon.Address,
+	) ([]models.Utxo, error) {
+		return []models.Utxo{
+			testUtxo(
+				testHash(0x01), 0, 1_000_000, paymentKey,
+				[]models.Asset{
+					testAsset(policyB, []byte("zeta"), 5),
+					testAsset(policyA, []byte("beta"), 7),
+				},
+			),
+			testUtxo(
+				testHash(0x02), 0, 1_000_000, paymentKey,
+				[]models.Asset{
+					testAsset(policyA, []byte("beta"), 3),
+					testAsset(policyA, []byte("alpha"), 1),
+				},
+			),
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/balance", balanceRequest(addr))
+
+	resp := decodeResponse[AccountBalanceResponse](t, rec)
+	require.Len(t, resp.Balances, 4)
+	require.Equal(t, "2000000", resp.Balances[0].Value)
+	require.Equal(t, "ADA", resp.Balances[0].Currency.Symbol)
+	// Sorted by policy then asset name, so policyA/alpha precedes
+	// policyA/beta, which precedes policyB/zeta.
+	require.Equal(
+		t,
+		hexString([]byte("alpha")),
+		resp.Balances[1].Currency.Symbol,
+	)
+	require.Equal(t, "1", resp.Balances[1].Value)
+	require.Equal(
+		t,
+		hexString([]byte("beta")),
+		resp.Balances[2].Currency.Symbol,
+	)
+	require.Equal(t, "10", resp.Balances[2].Value)
+	require.Equal(
+		t,
+		hexString([]byte("zeta")),
+		resp.Balances[3].Currency.Symbol,
+	)
+	require.Equal(t, "5", resp.Balances[3].Value)
+	require.Equal(
+		t,
+		hexString(policyA),
+		resp.Balances[1].Currency.Metadata["policyId"],
+	)
+}
+
+// TestAccountBalanceRejectsHistoricalLookup covers the Mesh contract
+// that an unsupported operation fails explicitly: /network/options
+// advertises historical_balance_lookup=false, so a request pinned to an
+// older block must be refused rather than silently answered with the
+// current tip balance.
+func TestAccountBalanceRejectsHistoricalLookup(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x06), nil,
+	)
+	deps.ledger.utxos = func(
+		lcommon.Address,
+	) ([]models.Utxo, error) {
+		t.Fatal("ledger must not be queried for a historical point")
+		return nil, nil
+	}
+	h := newTestHandler(t, deps)
+
+	req := balanceRequest(addr)
+	req.BlockIdentifier = byIndex(10)
+	rec := postJSON(t, h, "/account/balance", req)
+
+	requireMeshError(
+		t, rec, ErrNotImplemented, http.StatusNotImplemented,
+	)
+}
+
+func TestAccountBalanceInvalidAccount(t *testing.T) {
+	tests := map[string]string{
+		"missing account identifier": "",
+		"empty address":              "",
+		"malformed address":          "not-an-address",
+	}
+	for name, addr := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+
+			rec := postJSON(
+				t, h, "/account/balance", balanceRequest(addr),
+			)
+
+			requireMeshError(
+				t, rec, ErrInvalidRequest,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+func TestAccountBalanceLedgerError(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x07), nil,
+	)
+	deps.ledger.utxos = func(
+		lcommon.Address,
+	) ([]models.Utxo, error) {
+		return nil, errors.New("ledger unavailable")
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/balance", balanceRequest(addr))
+
+	got := requireMeshError(
+		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+	require.Equal(t, "ledger unavailable", got.Details["error"])
+}
+
+func TestAccountCoins(t *testing.T) {
+	deps := newTestDeps()
+	paymentKey := testKeyHash(0x08)
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, paymentKey, nil,
+	)
+	txID := testHash(0x0a)
+	policy := testKeyHash(0xcc)
+	deps.chain.tip = ochainsync.Tip{
+		Point:       ocommon.NewPoint(9, testHash(0x0b)),
+		BlockNumber: 3,
+	}
+	deps.ledger.utxos = func(
+		lcommon.Address,
+	) ([]models.Utxo, error) {
+		return []models.Utxo{
+			testUtxo(
+				txID, 2, 6_000_000, paymentKey,
+				[]models.Asset{
+					testAsset(policy, []byte("tok"), 42),
+				},
+			),
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/coins", coinsRequest(addr))
+
+	resp := decodeResponse[AccountCoinsResponse](t, rec)
+	require.Equal(t, int64(3), resp.BlockIdentifier.Index)
+	require.Len(t, resp.Coins, 2)
+	require.Equal(
+		t,
+		hexString(txID)+":2",
+		resp.Coins[0].CoinIdentifier.Identifier,
+	)
+	require.Equal(t, "6000000", resp.Coins[0].Amount.Value)
+	// Native assets are reported as sub-coins of the owning UTxO.
+	require.Equal(
+		t,
+		hexString(txID)+":2:"+hexString(policy)+":"+
+			hexString([]byte("tok")),
+		resp.Coins[1].CoinIdentifier.Identifier,
+	)
+	require.Equal(t, "42", resp.Coins[1].Amount.Value)
+}
+
+func TestAccountCoinsEmptyAccount(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x09), nil,
+	)
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/coins", coinsRequest(addr))
+
+	resp := decodeResponse[AccountCoinsResponse](t, rec)
+	require.NotNil(t, resp.Coins)
+	require.Empty(t, resp.Coins)
+}
+
+func TestAccountCoinsInvalidAccount(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(
+		t, h, "/account/coins", coinsRequest("not-an-address"),
+	)
+
+	requireMeshError(
+		t, rec, ErrInvalidRequest, http.StatusBadRequest,
+	)
+}
+
+func TestAccountCoinsLedgerError(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x0c), nil,
+	)
+	deps.ledger.utxos = func(
+		lcommon.Address,
+	) ([]models.Utxo, error) {
+		return nil, errors.New("ledger unavailable")
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/account/coins", coinsRequest(addr))
+
+	requireMeshError(
+		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+}

--- a/api/mesh/adapter.go
+++ b/api/mesh/adapter.go
@@ -15,6 +15,9 @@
 package mesh
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 )
@@ -39,10 +42,30 @@ func (a *meshDatabaseAdapter) BlockByHash(
 	return database.BlockByHash(a.db, hash)
 }
 
+// BlockByIndex resolves a Cardano block height, which is what the Mesh
+// API exposes as block_identifier.index. Cardano block numbers are
+// 0-based while the blob store's internal index is 1-based
+// (database.BlockInitialIndex), so translate here the same way
+// api/blockfrost's block-by-height lookup and midnight/server's
+// databaseAdapter do. Without the translation a client feeding back the
+// index from a /block response gets the block below the one it asked
+// for, and height 0 never resolves. Guard the addition first: no real
+// chain approaches math.MaxUint64, but without the check that value
+// would wrap to internal index 0 instead of failing.
 func (a *meshDatabaseAdapter) BlockByIndex(
-	idx uint64,
+	height uint64,
 ) (models.Block, error) {
-	return a.db.BlockByIndex(idx, nil)
+	if height > math.MaxUint64-database.BlockInitialIndex {
+		return models.Block{}, fmt.Errorf(
+			"block height %d overflows internal index: %w",
+			height,
+			models.ErrBlockNotFound,
+		)
+	}
+	return a.db.BlockByIndex(
+		height+database.BlockInitialIndex,
+		nil,
+	)
 }
 
 func (a *meshDatabaseAdapter) GetTransactionByHash(

--- a/api/mesh/adapter_test.go
+++ b/api/mesh/adapter_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+// newAdapterDatabase opens a real database backed by the default
+// badger/sqlite providers in a temporary directory. The adapter is the
+// only place where Mesh's dependency interface meets the storage
+// layer's own numbering and lookup helpers, so it is exercised against
+// real storage rather than a double.
+func newAdapterDatabase(t *testing.T) *database.Database {
+	t.Helper()
+	dataDir := t.TempDir()
+	logger := slog.New(
+		slog.NewTextHandler(newDiscardWriter(), nil),
+	)
+	host := plugin.NewHost()
+	require.NoError(t, badger.RegisterProvider(host))
+	require.NoError(t, sqlite.RegisterProvider(host))
+
+	blobStore, err := plugin.Resolve[blob.BlobStore](
+		context.Background(),
+		host,
+		plugin.CapabilityStorageBlob,
+		"badger",
+		nil,
+		blob.ProviderDependencies{
+			DataDir: dataDir,
+			Logger:  logger,
+		},
+	)
+	require.NoError(t, err)
+	metadataStore, err := plugin.Resolve[metadata.MetadataStore](
+		context.Background(),
+		host,
+		plugin.CapabilityStorageMetadata,
+		"sqlite",
+		nil,
+		metadata.ProviderDependencies{
+			DataDir: dataDir,
+			Logger:  logger,
+		},
+	)
+	require.NoError(t, err)
+
+	db, err := database.New(
+		&database.Config{DataDir: dataDir, Logger: logger},
+		database.Stores{
+			Blob: blobStore, Metadata: metadataStore,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+		require.NoError(t, host.Stop(context.Background()))
+	})
+	return db
+}
+
+// TestMeshDatabaseAdapterBlockByIndexUsesChainHeight covers the block
+// numbering contract between the Mesh API and storage. /block reports
+// block_identifier.index as the Cardano block height, so feeding that
+// index back into /block must return the same block. The blob store
+// keys blocks by a 1-based storage index, so the adapter translates
+// height to that index -- the same translation the Blockfrost adapter
+// documents and applies.
+func TestMeshDatabaseAdapterBlockByIndexUsesChainHeight(t *testing.T) {
+	db := newAdapterDatabase(t)
+	meshDB := NewMeshDatabase(db)
+
+	// Heights 0, 1 and 2, stored in chain order as a from-genesis node
+	// would, so storage indices run 1, 2, 3.
+	for height := range uint64(3) {
+		var prevHash []byte
+		if height > 0 {
+			prevHash = testHash(byte(height - 1))
+		}
+		require.NoError(t, db.BlockCreate(models.Block{
+			Hash:     testHash(byte(height)),
+			PrevHash: prevHash,
+			Number:   height,
+			Slot:     height * 20,
+		}, nil))
+	}
+
+	for height := range uint64(3) {
+		block, err := meshDB.BlockByIndex(height)
+
+		require.NoError(t, err, "height %d", height)
+		require.Equal(
+			t, height, block.Number,
+			"index %d resolved to height %d",
+			height, block.Number,
+		)
+		require.Equal(
+			t, testHash(byte(height)), block.Hash,
+		)
+	}
+}
+
+// TestMeshDatabaseAdapterBlockByIndexNotFound asserts an unknown height
+// surfaces the shared not-found error, which the /block handler maps to
+// the Mesh block-not-found code.
+func TestMeshDatabaseAdapterBlockByIndexNotFound(t *testing.T) {
+	db := newAdapterDatabase(t)
+	meshDB := NewMeshDatabase(db)
+
+	_, err := meshDB.BlockByIndex(9999)
+
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}
+
+// TestMeshDatabaseAdapterBlockByHash asserts hash lookups reach the
+// blob store's hash index rather than the height index.
+func TestMeshDatabaseAdapterBlockByHash(t *testing.T) {
+	db := newAdapterDatabase(t)
+	meshDB := NewMeshDatabase(db)
+	hash := testHash(0x5a)
+	require.NoError(t, db.BlockCreate(models.Block{
+		Hash:   hash,
+		Number: 41,
+		Slot:   410,
+	}, nil))
+
+	block, err := meshDB.BlockByHash(hash)
+
+	require.NoError(t, err)
+	require.Equal(t, hash, block.Hash)
+	require.Equal(t, uint64(41), block.Number)
+
+	_, err = meshDB.BlockByHash(testHash(0x5b))
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}
+
+// TestMeshDatabaseAdapterTransactionLookups asserts the transaction
+// methods reach the metadata store and report a miss as an empty
+// result, which the handlers translate into transaction-not-found.
+func TestMeshDatabaseAdapterTransactionLookups(t *testing.T) {
+	db := newAdapterDatabase(t)
+	meshDB := NewMeshDatabase(db)
+
+	tx, err := meshDB.GetTransactionByHash(testHash(0x5c))
+	require.NoError(t, err)
+	require.Nil(t, tx)
+
+	txs, err := meshDB.GetTransactionsByBlockHash(testHash(0x5d))
+	require.NoError(t, err)
+	require.Empty(t, txs)
+}
+
+// TestMeshDatabaseAdapterBlockIndexOverflow asserts a height that would
+// overflow the storage index is reported as not found rather than
+// wrapping around to a valid index.
+func TestMeshDatabaseAdapterBlockIndexOverflow(t *testing.T) {
+	db := newAdapterDatabase(t)
+	meshDB := NewMeshDatabase(db)
+
+	_, err := meshDB.BlockByIndex(math.MaxUint64)
+
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}

--- a/api/mesh/block_test.go
+++ b/api/mesh/block_test.go
@@ -1,0 +1,535 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// blockRequest builds a /block request for the given identifier.
+func blockRequest(id *PartialBlockIdentifier) BlockRequest {
+	return BlockRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		BlockIdentifier: id,
+	}
+}
+
+// byIndex and byHash build partial block identifiers.
+func byIndex(idx int64) *PartialBlockIdentifier {
+	return &PartialBlockIdentifier{Index: &idx}
+}
+
+func byHash(hash string) *PartialBlockIdentifier {
+	return &PartialBlockIdentifier{Hash: &hash}
+}
+
+func TestBlockByIndex(t *testing.T) {
+	deps := newTestDeps()
+	blockHash := testHash(0x11)
+	prevHash := testHash(0x10)
+	deps.database.blockByIndex = func(
+		idx uint64,
+	) (models.Block, error) {
+		require.Equal(t, uint64(42), idx)
+		return models.Block{
+			Hash:     blockHash,
+			PrevHash: prevHash,
+			Number:   42,
+			Slot:     4200,
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block", blockRequest(byIndex(42)))
+
+	resp := decodeResponse[BlockResponse](t, rec)
+	require.NotNil(t, resp.Block)
+	require.Equal(
+		t,
+		&BlockIdentifier{
+			Index: 42, Hash: hexString(blockHash),
+		},
+		resp.Block.BlockIdentifier,
+	)
+	require.Equal(
+		t,
+		&BlockIdentifier{
+			Index: 41, Hash: hexString(prevHash),
+		},
+		resp.Block.ParentBlockIdentifier,
+	)
+	require.Equal(
+		t,
+		(testGenesisStartTimeSec+4200)*1000,
+		resp.Block.Timestamp,
+	)
+	require.Empty(t, resp.Block.Transactions)
+}
+
+func TestBlockByHash(t *testing.T) {
+	deps := newTestDeps()
+	blockHash := testHash(0x22)
+	deps.database.blockByHash = func(
+		hash []byte,
+	) (models.Block, error) {
+		require.True(t, bytes.Equal(blockHash, hash))
+		return models.Block{
+			Hash:     blockHash,
+			PrevHash: testHash(0x21),
+			Number:   7,
+			Slot:     700,
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(
+		t, h, "/block",
+		blockRequest(byHash(hexString(blockHash))),
+	)
+
+	resp := decodeResponse[BlockResponse](t, rec)
+	require.Equal(
+		t, hexString(blockHash), resp.Block.BlockIdentifier.Hash,
+	)
+}
+
+// TestBlockHashTakesPrecedenceOverIndex pins the resolution order when a
+// client sends both fields: the hash identifies the block exactly, so it
+// must win over the ambiguous index.
+func TestBlockHashTakesPrecedenceOverIndex(t *testing.T) {
+	deps := newTestDeps()
+	wanted := testHash(0x33)
+	deps.database.blockByHash = func(
+		[]byte,
+	) (models.Block, error) {
+		return models.Block{
+			Hash: wanted, PrevHash: testHash(0x32), Number: 5,
+		}, nil
+	}
+	deps.database.blockByIndex = func(
+		uint64,
+	) (models.Block, error) {
+		t.Fatal("BlockByIndex must not be consulted")
+		return models.Block{}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	idx := int64(999)
+	hashStr := hexString(wanted)
+	rec := postJSON(t, h, "/block", blockRequest(
+		&PartialBlockIdentifier{Hash: &hashStr, Index: &idx},
+	))
+
+	resp := decodeResponse[BlockResponse](t, rec)
+	require.Equal(t, int64(5), resp.Block.BlockIdentifier.Index)
+}
+
+// TestBlockGenesisParentIsSelf covers the Mesh requirement that the
+// genesis block reports itself as its own parent.
+func TestBlockGenesisParentIsSelf(t *testing.T) {
+	deps := newTestDeps()
+	genesisHash := mustDecodeHex(t, testGenesisHash)
+	deps.database.blockByIndex = func(
+		uint64,
+	) (models.Block, error) {
+		return models.Block{
+			Hash:   genesisHash,
+			Number: 0,
+			Slot:   0,
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block", blockRequest(byIndex(0)))
+
+	resp := decodeResponse[BlockResponse](t, rec)
+	require.Equal(
+		t,
+		resp.Block.BlockIdentifier,
+		resp.Block.ParentBlockIdentifier,
+	)
+}
+
+func TestBlockWithTransactions(t *testing.T) {
+	deps := newTestDeps()
+	blockHash := testHash(0x44)
+	txHash := testHash(0x45)
+	paymentKey := testKeyHash(0x01)
+	deps.database.blockByIndex = func(
+		uint64,
+	) (models.Block, error) {
+		return models.Block{
+			Hash:     blockHash,
+			PrevHash: testHash(0x43),
+			Number:   9,
+			Slot:     900,
+		}, nil
+	}
+	deps.database.txsByBlockHash = func(
+		hash []byte,
+	) ([]models.Transaction, error) {
+		require.True(t, bytes.Equal(blockHash, hash))
+		return []models.Transaction{
+			{
+				Hash:  txHash,
+				Valid: true,
+				Inputs: []models.Utxo{
+					testUtxo(
+						testHash(0x40), 0, 5_000_000,
+						paymentKey, nil,
+					),
+				},
+				Outputs: []models.Utxo{
+					testUtxo(
+						txHash, 0, 4_000_000,
+						paymentKey, nil,
+					),
+				},
+			},
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block", blockRequest(byIndex(9)))
+
+	resp := decodeResponse[BlockResponse](t, rec)
+	require.Len(t, resp.Block.Transactions, 1)
+	tx := resp.Block.Transactions[0]
+	require.Equal(t, hexString(txHash), tx.TransactionIdentifier.Hash)
+	require.Len(t, tx.Operations, 2)
+	require.Equal(t, OpInput, tx.Operations[0].Type)
+	require.Equal(t, "-5000000", tx.Operations[0].Amount.Value)
+	require.Equal(t, OpOutput, tx.Operations[1].Type)
+	require.Equal(t, "4000000", tx.Operations[1].Amount.Value)
+	// Outputs relate back to the inputs they consume.
+	require.Equal(
+		t,
+		[]*OperationIdentifier{{Index: 0}},
+		tx.Operations[1].RelatedOperations,
+	)
+}
+
+func TestBlockNotFound(t *testing.T) {
+	tests := map[string]*PartialBlockIdentifier{
+		"by index": byIndex(1234),
+		"by hash":  byHash(hexString(testHash(0x55))),
+	}
+	for name, id := range tests {
+		t.Run(name, func(t *testing.T) {
+			deps := newTestDeps()
+			deps.database.blockByIndex = func(
+				uint64,
+			) (models.Block, error) {
+				return models.Block{},
+					models.ErrBlockNotFound
+			}
+			deps.database.blockByHash = func(
+				[]byte,
+			) (models.Block, error) {
+				return models.Block{},
+					models.ErrBlockNotFound
+			}
+			h := newTestHandler(t, deps)
+
+			rec := postJSON(t, h, "/block", blockRequest(id))
+
+			requireMeshError(
+				t, rec, ErrBlockNotFound,
+				http.StatusNotFound,
+			)
+		})
+	}
+}
+
+func TestBlockInvalidIdentifier(t *testing.T) {
+	tests := map[string]*PartialBlockIdentifier{
+		"missing identifier": nil,
+		"empty identifier":   {},
+		"empty hash string":  byHash(""),
+		"invalid hex hash":   byHash("nothex"),
+		"negative index":     byIndex(-1),
+	}
+	for name, id := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+
+			rec := postJSON(t, h, "/block", blockRequest(id))
+
+			requireMeshError(
+				t, rec, ErrInvalidRequest,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+func TestBlockDatabaseErrors(t *testing.T) {
+	t.Run("block lookup fails", func(t *testing.T) {
+		deps := newTestDeps()
+		deps.database.blockByIndex = func(
+			uint64,
+		) (models.Block, error) {
+			return models.Block{}, errors.New("disk on fire")
+		}
+		h := newTestHandler(t, deps)
+
+		rec := postJSON(t, h, "/block", blockRequest(byIndex(1)))
+
+		got := requireMeshError(
+			t, rec, ErrInternal,
+			http.StatusInternalServerError,
+		)
+		require.Equal(t, "disk on fire", got.Details["error"])
+	})
+
+	t.Run("transaction lookup fails", func(t *testing.T) {
+		deps := newTestDeps()
+		deps.database.blockByIndex = func(
+			uint64,
+		) (models.Block, error) {
+			return models.Block{
+				Hash:     testHash(0x66),
+				PrevHash: testHash(0x65),
+				Number:   3,
+			}, nil
+		}
+		deps.database.txsByBlockHash = func(
+			[]byte,
+		) ([]models.Transaction, error) {
+			return nil, errors.New("query failed")
+		}
+		h := newTestHandler(t, deps)
+
+		rec := postJSON(t, h, "/block", blockRequest(byIndex(3)))
+
+		requireMeshError(
+			t, rec, ErrInternal,
+			http.StatusInternalServerError,
+		)
+	})
+}
+
+// TestBlockAfterRollbackIsNotFound covers the reorg case: a block that
+// was rolled back is no longer resolvable by its hash, so a client
+// holding the old identifier gets a stable not-found rather than the
+// block that replaced it at the same index.
+func TestBlockAfterRollbackIsNotFound(t *testing.T) {
+	rolledBack := testHash(0x77)
+	replacement := testHash(0x78)
+	deps := newTestDeps()
+	deps.database.blockByHash = func(
+		hash []byte,
+	) (models.Block, error) {
+		if bytes.Equal(hash, rolledBack) {
+			return models.Block{}, models.ErrBlockNotFound
+		}
+		return models.Block{
+			Hash:     replacement,
+			PrevHash: testHash(0x76),
+			Number:   12,
+		}, nil
+	}
+	deps.database.blockByIndex = func(
+		uint64,
+	) (models.Block, error) {
+		return models.Block{
+			Hash:     replacement,
+			PrevHash: testHash(0x76),
+			Number:   12,
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(
+		t, h, "/block",
+		blockRequest(byHash(hexString(rolledBack))),
+	)
+	requireMeshError(
+		t, rec, ErrBlockNotFound, http.StatusNotFound,
+	)
+
+	// The same height now resolves to the replacement block.
+	rec = postJSON(t, h, "/block", blockRequest(byIndex(12)))
+	resp := decodeResponse[BlockResponse](t, rec)
+	require.Equal(
+		t, hexString(replacement), resp.Block.BlockIdentifier.Hash,
+	)
+}
+
+// blockTxRequest builds a /block/transaction request.
+func blockTxRequest(
+	blockHash string,
+	txHash string,
+) BlockTransactionRequest {
+	req := BlockTransactionRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	}
+	if blockHash != "" {
+		req.BlockIdentifier = &BlockIdentifier{Hash: blockHash}
+	}
+	if txHash != "" {
+		req.TransactionIdentifier = &TransactionIdentifier{
+			Hash: txHash,
+		}
+	}
+	return req
+}
+
+func TestBlockTransaction(t *testing.T) {
+	deps := newTestDeps()
+	blockHash := testHash(0x88)
+	txHash := testHash(0x89)
+	paymentKey := testKeyHash(0x02)
+	deps.database.txByHash = func(
+		hash []byte,
+	) (*models.Transaction, error) {
+		require.True(t, bytes.Equal(txHash, hash))
+		return &models.Transaction{
+			Hash:      txHash,
+			BlockHash: blockHash,
+			Valid:     true,
+			Outputs: []models.Utxo{
+				testUtxo(
+					txHash, 0, 1_500_000, paymentKey, nil,
+				),
+			},
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block/transaction", blockTxRequest(
+		hexString(blockHash), hexString(txHash),
+	))
+
+	resp := decodeResponse[BlockTransactionResponse](t, rec)
+	require.Equal(
+		t,
+		hexString(txHash),
+		resp.Transaction.TransactionIdentifier.Hash,
+	)
+	require.Len(t, resp.Transaction.Operations, 1)
+	require.Equal(
+		t, "1500000", resp.Transaction.Operations[0].Amount.Value,
+	)
+}
+
+// TestBlockTransactionWrongBlock covers the cross-block ambiguity guard:
+// a transaction that exists but belongs to another block must not be
+// served for the requested block.
+func TestBlockTransactionWrongBlock(t *testing.T) {
+	deps := newTestDeps()
+	txHash := testHash(0x8a)
+	deps.database.txByHash = func(
+		[]byte,
+	) (*models.Transaction, error) {
+		return &models.Transaction{
+			Hash:      txHash,
+			BlockHash: testHash(0x8b),
+		}, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block/transaction", blockTxRequest(
+		hexString(testHash(0x8c)), hexString(txHash),
+	))
+
+	requireMeshError(
+		t, rec, ErrTransactionNotFound, http.StatusNotFound,
+	)
+}
+
+func TestBlockTransactionNotFound(t *testing.T) {
+	deps := newTestDeps()
+	deps.database.txByHash = func(
+		[]byte,
+	) (*models.Transaction, error) {
+		return nil, nil
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block/transaction", blockTxRequest(
+		hexString(testHash(0x8d)), hexString(testHash(0x8e)),
+	))
+
+	requireMeshError(
+		t, rec, ErrTransactionNotFound, http.StatusNotFound,
+	)
+}
+
+func TestBlockTransactionInvalidRequest(t *testing.T) {
+	tests := map[string]BlockTransactionRequest{
+		"missing transaction identifier": blockTxRequest(
+			hexString(testHash(0x8f)), "",
+		),
+		"missing block identifier": blockTxRequest(
+			"", hexString(testHash(0x90)),
+		),
+		"invalid transaction hash hex": blockTxRequest(
+			hexString(testHash(0x91)), "zz",
+		),
+		"invalid block hash hex": blockTxRequest(
+			"zz", hexString(testHash(0x92)),
+		),
+	}
+	for name, req := range tests {
+		t.Run(name, func(t *testing.T) {
+			deps := newTestDeps()
+			deps.database.txByHash = func(
+				[]byte,
+			) (*models.Transaction, error) {
+				return &models.Transaction{
+					Hash:      testHash(0x92),
+					BlockHash: testHash(0x91),
+				}, nil
+			}
+			h := newTestHandler(t, deps)
+
+			rec := postJSON(t, h, "/block/transaction", req)
+
+			requireMeshError(
+				t, rec, ErrInvalidRequest,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+func TestBlockTransactionDatabaseError(t *testing.T) {
+	deps := newTestDeps()
+	deps.database.txByHash = func(
+		[]byte,
+	) (*models.Transaction, error) {
+		return nil, errors.New("query failed")
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/block/transaction", blockTxRequest(
+		hexString(testHash(0x93)), hexString(testHash(0x94)),
+	))
+
+	requireMeshError(
+		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+}

--- a/api/mesh/construction_test.go
+++ b/api/mesh/construction_test.go
@@ -392,7 +392,6 @@ func TestConstructionPayloadsPerSignerPayloads(t *testing.T) {
 }
 
 func TestConstructionPayloadsTTL(t *testing.T) {
-	addr := ""
 	tests := map[string]struct {
 		ttl     any
 		wantTTL uint64
@@ -403,7 +402,7 @@ func TestConstructionPayloadsTTL(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			h := newTestHandler(t, newTestDeps())
-			addr = testAddress(
+			addr := testAddress(
 				t, lcommon.AddressTypeKeyNone,
 				testKeyHash(0x19), nil,
 			)
@@ -435,7 +434,6 @@ func TestConstructionPayloadsTTL(t *testing.T) {
 }
 
 func TestConstructionPayloadsInvalidRequest(t *testing.T) {
-	addr := "" // set per-case below
 	validCoin := hexString(testHash(0xb2)) + ":0"
 
 	tests := map[string]struct {
@@ -633,7 +631,7 @@ func TestConstructionPayloadsInvalidRequest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			h := newTestHandler(t, newTestDeps())
-			addr = testAddress(
+			addr := testAddress(
 				t, lcommon.AddressTypeKeyNone,
 				testKeyHash(0x1a), nil,
 			)
@@ -752,26 +750,27 @@ func TestConstructionCombine(t *testing.T) {
 func TestConstructionCombineInvalidRequest(t *testing.T) {
 	pub, _ := testKeyPair(t, 0x1e)
 	validSig := hexString(make([]byte, 64))
-	validUnsigned := ""
 
+	// Each case receives the well-formed unsigned transaction built
+	// inside its own subtest, so nothing is shared between cases.
 	tests := map[string]struct {
-		unsigned func() string
+		unsigned func(valid string) string
 		sigs     []*Signature
 		wantErr  *Error
 	}{
 		"non-hex unsigned transaction": {
-			unsigned: func() string { return "zz" },
+			unsigned: func(string) string { return "zz" },
 			wantErr:  ErrInvalidTransaction,
 		},
 		"signature without public key": {
-			unsigned: func() string { return validUnsigned },
+			unsigned: func(valid string) string { return valid },
 			sigs: []*Signature{
 				{HexBytes: validSig},
 			},
 			wantErr: ErrInvalidPublicKey,
 		},
 		"non-hex public key": {
-			unsigned: func() string { return validUnsigned },
+			unsigned: func(valid string) string { return valid },
 			sigs: []*Signature{
 				{
 					PublicKey: &PublicKey{HexBytes: "zz"},
@@ -781,7 +780,7 @@ func TestConstructionCombineInvalidRequest(t *testing.T) {
 			wantErr: ErrInvalidPublicKey,
 		},
 		"short public key": {
-			unsigned: func() string { return validUnsigned },
+			unsigned: func(valid string) string { return valid },
 			sigs: []*Signature{
 				{
 					PublicKey: &PublicKey{
@@ -795,7 +794,7 @@ func TestConstructionCombineInvalidRequest(t *testing.T) {
 			wantErr: ErrInvalidPublicKey,
 		},
 		"non-hex signature": {
-			unsigned: func() string { return validUnsigned },
+			unsigned: func(valid string) string { return valid },
 			sigs: []*Signature{
 				{
 					PublicKey: &PublicKey{
@@ -807,7 +806,7 @@ func TestConstructionCombineInvalidRequest(t *testing.T) {
 			wantErr: ErrInvalidTransaction,
 		},
 		"short signature": {
-			unsigned: func() string { return validUnsigned },
+			unsigned: func(valid string) string { return valid },
 			sigs: []*Signature{
 				{
 					PublicKey: &PublicKey{
@@ -827,11 +826,13 @@ func TestConstructionCombineInvalidRequest(t *testing.T) {
 				t, lcommon.AddressTypeKeyNone,
 				testKeyHash(0x1f), nil,
 			)
-			validUnsigned = requestPayloads(t, h, addr)
+			validUnsigned := requestPayloads(t, h, addr)
 
 			rec := postJSON(
 				t, h, "/construction/combine",
-				combineRequest(tc.unsigned(), tc.sigs),
+				combineRequest(
+					tc.unsigned(validUnsigned), tc.sigs,
+				),
 			)
 
 			requireMeshError(
@@ -874,7 +875,7 @@ func TestConstructionParseSigned(t *testing.T) {
 	require.Equal(t, addr, resp.Operations[1].Account.Address)
 	// Signers are reported as the blake2b-224 hash of each witness key.
 	require.Len(t, resp.AccountIdentifierSigners, 1)
-	signerKey, _ := testKeyPair(t, 0x42)
+	signerKey, _ := testKeyPair(t, testSignerSeed)
 	keyHash := lcommon.Blake2b224Hash(signerKey)
 	require.Equal(
 		t,
@@ -931,6 +932,20 @@ func TestConstructionParseCertificates(t *testing.T) {
 				},
 			},
 			{
+				// No Mesh operation type: this one must be
+				// dropped without consuming an operation index.
+				Type: uint(
+					lcommon.CertificateTypeAuthCommitteeHot,
+				),
+				Certificate: &lcommon.AuthCommitteeHotCertificate{
+					CertType: uint(
+						lcommon.CertificateTypeAuthCommitteeHot,
+					),
+					ColdCredential: stakeCred,
+					HotCredential:  stakeCred,
+				},
+			},
+			{
 				Type: uint(
 					lcommon.CertificateTypeStakeDelegation,
 				),
@@ -947,6 +962,14 @@ func TestConstructionParseCertificates(t *testing.T) {
 		},
 	)
 	txCbor := testSignedTx(t, bodyCbor, nil)
+
+	// Guard the fixture: the dropped certificate must survive the
+	// encode/decode round trip and reach the converter, otherwise the
+	// assertion below would pass for the wrong reason.
+	decoded, meshErr := decodeTxCbor(hexString(txCbor))
+	require.Nil(t, meshErr)
+	require.NotNil(t, decoded)
+	require.Len(t, decoded.Certificates(), 3)
 
 	rec := postJSON(t, h, "/construction/parse", parseRequest(
 		hexString(txCbor), true,

--- a/api/mesh/construction_test.go
+++ b/api/mesh/construction_test.go
@@ -1,0 +1,1385 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+// --- /construction/derive ----------------------------------------------
+
+func deriveRequest(pk *PublicKey) ConstructionDeriveRequest {
+	return ConstructionDeriveRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		PublicKey: pk,
+	}
+}
+
+func TestConstructionDerive(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	pub, _ := testKeyPair(t, 0x11)
+
+	rec := postJSON(t, h, "/construction/derive", deriveRequest(
+		&PublicKey{
+			HexBytes:  hexString(pub),
+			CurveType: Edwards25519,
+		},
+	))
+
+	resp := decodeResponse[ConstructionDeriveResponse](t, rec)
+	require.True(
+		t,
+		strings.HasPrefix(
+			resp.AccountIdentifier.Address, "addr_test1",
+		),
+		"expected a testnet address, got %q",
+		resp.AccountIdentifier.Address,
+	)
+	// The address must be the enterprise address for blake2b-224 of
+	// the key, which is what a client will re-derive locally.
+	keyHash := lcommon.Blake2b224Hash(pub)
+	require.Equal(
+		t,
+		testAddress(
+			t, lcommon.AddressTypeKeyNone, keyHash[:], nil,
+		),
+		resp.AccountIdentifier.Address,
+	)
+}
+
+// TestConstructionDeriveMainnet asserts the address network follows the
+// configured network magic rather than a compile-time default.
+func TestConstructionDeriveMainnet(t *testing.T) {
+	h := newTestHandler(
+		t,
+		newTestDeps(),
+		func(cfg *ServerConfig) {
+			cfg.NetworkMagic = mainnetMagic
+			cfg.Network = "mainnet"
+		},
+	)
+	pub, _ := testKeyPair(t, 0x12)
+
+	rec := postJSON(t, h, "/construction/derive",
+		ConstructionDeriveRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: &NetworkIdentifier{
+					Blockchain: blockchain,
+					Network:    "mainnet",
+				},
+			},
+			PublicKey: &PublicKey{
+				HexBytes:  hexString(pub),
+				CurveType: Edwards25519,
+			},
+		},
+	)
+
+	resp := decodeResponse[ConstructionDeriveResponse](t, rec)
+	require.True(
+		t,
+		strings.HasPrefix(
+			resp.AccountIdentifier.Address, "addr1",
+		),
+		"expected a mainnet address, got %q",
+		resp.AccountIdentifier.Address,
+	)
+}
+
+func TestConstructionDeriveInvalidPublicKey(t *testing.T) {
+	pub, _ := testKeyPair(t, 0x13)
+	tests := map[string]*PublicKey{
+		"missing public key": nil,
+		"unsupported curve": {
+			HexBytes:  hexString(pub),
+			CurveType: "secp256k1",
+		},
+		"non-hex bytes": {
+			HexBytes:  "zzzz",
+			CurveType: Edwards25519,
+		},
+		"wrong key length": {
+			HexBytes:  hexString(testKeyHash(0x01)),
+			CurveType: Edwards25519,
+		},
+	}
+	for name, pk := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+
+			rec := postJSON(
+				t, h, "/construction/derive",
+				deriveRequest(pk),
+			)
+
+			requireMeshError(
+				t, rec, ErrInvalidPublicKey,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// --- /construction/preprocess ------------------------------------------
+
+func TestConstructionPreprocess(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x14), nil,
+	)
+	coinID := hexString(testHash(0xa1)) + ":0"
+
+	rec := postJSON(t, h, "/construction/preprocess",
+		ConstructionPreprocessRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+			Operations: []*Operation{
+				{
+					OperationIdentifier: &OperationIdentifier{},
+					Type:                OpInput,
+					Account: &AccountIdentifier{
+						Address: addr,
+					},
+					CoinChange: &CoinChange{
+						CoinIdentifier: &CoinIdentifier{
+							Identifier: coinID,
+						},
+						CoinAction: CoinSpent,
+					},
+				},
+				{
+					OperationIdentifier: &OperationIdentifier{
+						Index: 1,
+					},
+					Type: OpOutput,
+					Account: &AccountIdentifier{
+						Address: addr,
+					},
+				},
+			},
+		},
+	)
+
+	resp := decodeResponse[ConstructionPreprocessResponse](t, rec)
+	require.Equal(
+		t,
+		[]any{coinID},
+		resp.Options["input_refs"],
+	)
+	// Only input operations contribute required signing keys.
+	require.Equal(
+		t,
+		[]*AccountIdentifier{{Address: addr}},
+		resp.RequiredPublicKeys,
+	)
+}
+
+func TestConstructionPreprocessNoOperations(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(t, h, "/construction/preprocess",
+		ConstructionPreprocessRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+		},
+	)
+
+	resp := decodeResponse[ConstructionPreprocessResponse](t, rec)
+	require.Nil(t, resp.Options["input_refs"])
+	require.Empty(t, resp.RequiredPublicKeys)
+}
+
+// --- /construction/metadata --------------------------------------------
+
+func metadataRequest() ConstructionMetadataRequest {
+	return ConstructionMetadataRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	}
+}
+
+func TestConstructionMetadata(t *testing.T) {
+	deps := newTestDeps()
+	deps.ledger.pparams = testPParams(44, 155381)
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(
+		t, h, "/construction/metadata", metadataRequest(),
+	)
+
+	resp := decodeResponse[ConstructionMetadataResponse](t, rec)
+	require.Equal(
+		t, float64(44), resp.Metadata["min_fee_coefficient"],
+	)
+	require.Equal(
+		t, float64(155381), resp.Metadata["min_fee_constant"],
+	)
+	require.Len(t, resp.SuggestedFee, 1)
+	require.Equal(
+		t, "168581", resp.SuggestedFee[0].Value,
+	)
+	require.Equal(t, "ADA", resp.SuggestedFee[0].Currency.Symbol)
+}
+
+// TestConstructionMetadataUnavailable covers a node that has not yet
+// loaded protocol parameters: clients must get a retriable error rather
+// than a zero fee they would sign into a transaction.
+func TestConstructionMetadataUnavailable(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(
+		t, h, "/construction/metadata", metadataRequest(),
+	)
+
+	got := requireMeshError(
+		t, rec, ErrUnavailable, http.StatusServiceUnavailable,
+	)
+	require.True(t, got.Retriable)
+}
+
+// --- /construction/payloads --------------------------------------------
+
+// payloadOps builds a valid input/output operation pair.
+func payloadOps(t *testing.T, addr string) []*Operation {
+	t.Helper()
+	return []*Operation{
+		{
+			OperationIdentifier: &OperationIdentifier{Index: 0},
+			Type:                OpInput,
+			Account:             &AccountIdentifier{Address: addr},
+			Amount: &Amount{
+				Value:    "-2000000",
+				Currency: adaCurrency(),
+			},
+			CoinChange: &CoinChange{
+				CoinIdentifier: &CoinIdentifier{
+					Identifier: hexString(
+						testHash(0xb1),
+					) + ":0",
+				},
+				CoinAction: CoinSpent,
+			},
+		},
+		{
+			OperationIdentifier: &OperationIdentifier{Index: 0},
+			Type:                OpOutput,
+			Account:             &AccountIdentifier{Address: addr},
+			Amount: &Amount{
+				Value:    "1830000",
+				Currency: adaCurrency(),
+			},
+		},
+	}
+}
+
+func payloadsRequest(
+	ops []*Operation,
+	metadata map[string]any,
+	keys []*PublicKey,
+) ConstructionPayloadsRequest {
+	return ConstructionPayloadsRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		Operations: ops,
+		Metadata:   metadata,
+		PublicKeys: keys,
+	}
+}
+
+func TestConstructionPayloads(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x15), nil,
+	)
+
+	rec := postJSON(t, h, "/construction/payloads", payloadsRequest(
+		payloadOps(t, addr),
+		map[string]any{"fee": "170000"},
+		nil,
+	))
+
+	resp := decodeResponse[ConstructionPayloadsResponse](t, rec)
+	require.NotEmpty(t, resp.UnsignedTransaction)
+	require.Len(t, resp.Payloads, 1)
+	require.Equal(t, Ed25519, resp.Payloads[0].SignatureType)
+	require.Nil(t, resp.Payloads[0].AccountIdentifier)
+
+	// The unsigned transaction must be a decodable Conway body whose
+	// fee and outputs match what was requested.
+	bodyBytes := mustDecodeHex(t, resp.UnsignedTransaction)
+	var body conway.ConwayTransactionBody
+	_, err := cbor.Decode(bodyBytes, &body)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(170000), body.Fee())
+	require.Len(t, body.Outputs(), 1)
+	require.Equal(
+		t, addr, body.Outputs()[0].Address().String(),
+	)
+	require.Equal(
+		t,
+		big.NewInt(1830000),
+		body.Outputs()[0].Amount(),
+	)
+	require.Len(t, body.Inputs(), 1)
+}
+
+// TestConstructionPayloadsPerSignerPayloads asserts one payload is
+// emitted per unique signing key, with the derived account attached so
+// the client knows which key to use.
+func TestConstructionPayloadsPerSignerPayloads(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x16), nil,
+	)
+	pubA, _ := testKeyPair(t, 0x17)
+	pubB, _ := testKeyPair(t, 0x18)
+
+	rec := postJSON(t, h, "/construction/payloads", payloadsRequest(
+		payloadOps(t, addr),
+		map[string]any{"fee": "170000"},
+		[]*PublicKey{
+			{HexBytes: hexString(pubA), CurveType: Edwards25519},
+			{HexBytes: hexString(pubB), CurveType: Edwards25519},
+			// Duplicate keys must not produce duplicate payloads.
+			{HexBytes: hexString(pubA), CurveType: Edwards25519},
+		},
+	))
+
+	resp := decodeResponse[ConstructionPayloadsResponse](t, rec)
+	require.Len(t, resp.Payloads, 2)
+	seen := map[string]struct{}{}
+	for _, p := range resp.Payloads {
+		require.NotNil(t, p.AccountIdentifier)
+		require.Equal(t, Ed25519, p.SignatureType)
+		// Every payload signs the same body hash.
+		require.Equal(
+			t, resp.Payloads[0].HexBytes, p.HexBytes,
+		)
+		seen[p.AccountIdentifier.Address] = struct{}{}
+	}
+	require.Len(t, seen, 2)
+}
+
+func TestConstructionPayloadsTTL(t *testing.T) {
+	addr := ""
+	tests := map[string]struct {
+		ttl     any
+		wantTTL uint64
+	}{
+		"string ttl": {ttl: "12345", wantTTL: 12345},
+		"number ttl": {ttl: float64(6789), wantTTL: 6789},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+			addr = testAddress(
+				t, lcommon.AddressTypeKeyNone,
+				testKeyHash(0x19), nil,
+			)
+
+			rec := postJSON(
+				t, h, "/construction/payloads",
+				payloadsRequest(
+					payloadOps(t, addr),
+					map[string]any{
+						"fee": "170000",
+						"ttl": tc.ttl,
+					},
+					nil,
+				),
+			)
+
+			resp := decodeResponse[ConstructionPayloadsResponse](
+				t, rec,
+			)
+			var body conway.ConwayTransactionBody
+			_, err := cbor.Decode(
+				mustDecodeHex(t, resp.UnsignedTransaction),
+				&body,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTTL, body.TTL())
+		})
+	}
+}
+
+func TestConstructionPayloadsInvalidRequest(t *testing.T) {
+	addr := "" // set per-case below
+	validCoin := hexString(testHash(0xb2)) + ":0"
+
+	tests := map[string]struct {
+		ops      func(addr string) []*Operation
+		metadata map[string]any
+		wantErr  *Error
+	}{
+		"missing fee metadata": {
+			ops:      func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{},
+			wantErr:  ErrInvalidRequest,
+		},
+		"non-numeric fee": {
+			ops:      func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{"fee": "many"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"non-string fee": {
+			ops:      func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{"fee": float64(170000)},
+			wantErr:  ErrInvalidRequest,
+		},
+		"non-numeric ttl": {
+			ops: func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{
+				"fee": "170000", "ttl": "soon",
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		"fractional ttl": {
+			ops: func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{
+				"fee": "170000", "ttl": 1.5,
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		"negative ttl": {
+			ops: func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{
+				"fee": "170000", "ttl": float64(-1),
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		"unsupported ttl type": {
+			ops: func(a string) []*Operation { return payloadOpsFor(a, validCoin) },
+			metadata: map[string]any{
+				"fee": "170000", "ttl": true,
+			},
+			wantErr: ErrInvalidRequest,
+		},
+		"input without coin change": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[0].CoinChange = nil
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"coin id without index": {
+			ops: func(a string) []*Operation {
+				return payloadOpsFor(a, hexString(testHash(0xb3)))
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"coin id with non-hex hash": {
+			ops: func(a string) []*Operation {
+				return payloadOpsFor(a, "nothex:0")
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"coin id with short hash": {
+			ops: func(a string) []*Operation {
+				return payloadOpsFor(
+					a, hexString(testKeyHash(0x01))+":0",
+				)
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"coin id with negative index": {
+			ops: func(a string) []*Operation {
+				return payloadOpsFor(
+					a, hexString(testHash(0xb4))+":-1",
+				)
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"coin id with non-numeric index": {
+			ops: func(a string) []*Operation {
+				return payloadOpsFor(
+					a, hexString(testHash(0xb5))+":x",
+				)
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"output without account": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Account = nil
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"output without amount": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Amount = nil
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"output without operation identifier": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].OperationIdentifier = nil
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"output index out of range": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].OperationIdentifier.Index = 10001
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"duplicate output index": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				dup := *ops[1]
+				return append(ops, &dup)
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"invalid output address": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Account.Address = "not-an-address"
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"non-ada output currency": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Amount.Currency = nativeAssetCurrency(
+					hexString(testKeyHash(0xcd)), "6162",
+				)
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"missing output currency": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Amount.Currency = nil
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"non-numeric output amount": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Amount.Value = "lots"
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+		"unsupported operation type": {
+			ops: func(a string) []*Operation {
+				ops := payloadOpsFor(a, validCoin)
+				ops[1].Type = OpStakeDelegation
+				return ops
+			},
+			metadata: map[string]any{"fee": "170000"},
+			wantErr:  ErrInvalidRequest,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+			addr = testAddress(
+				t, lcommon.AddressTypeKeyNone,
+				testKeyHash(0x1a), nil,
+			)
+
+			rec := postJSON(
+				t, h, "/construction/payloads",
+				payloadsRequest(
+					tc.ops(addr), tc.metadata, nil,
+				),
+			)
+
+			requireMeshError(
+				t, rec, tc.wantErr, http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// TestConstructionPayloadsInvalidPublicKey asserts a malformed signing
+// key is rejected rather than producing a payload no client can sign.
+func TestConstructionPayloadsInvalidPublicKey(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x1b), nil,
+	)
+
+	rec := postJSON(t, h, "/construction/payloads", payloadsRequest(
+		payloadOps(t, addr),
+		map[string]any{"fee": "170000"},
+		[]*PublicKey{{HexBytes: "abcd", CurveType: Edwards25519}},
+	))
+
+	requireMeshError(
+		t, rec, ErrInvalidPublicKey, http.StatusBadRequest,
+	)
+}
+
+// payloadOpsFor builds an input/output operation pair for a given coin
+// identifier, without a *testing.T so it can be used in table entries.
+func payloadOpsFor(addr, coinID string) []*Operation {
+	return []*Operation{
+		{
+			OperationIdentifier: &OperationIdentifier{Index: 0},
+			Type:                OpInput,
+			Account:             &AccountIdentifier{Address: addr},
+			CoinChange: &CoinChange{
+				CoinIdentifier: &CoinIdentifier{
+					Identifier: coinID,
+				},
+				CoinAction: CoinSpent,
+			},
+		},
+		{
+			OperationIdentifier: &OperationIdentifier{Index: 0},
+			Type:                OpOutput,
+			Account:             &AccountIdentifier{Address: addr},
+			Amount: &Amount{
+				Value:    "1830000",
+				Currency: adaCurrency(),
+			},
+		},
+	}
+}
+
+// --- /construction/combine ---------------------------------------------
+
+func combineRequest(
+	unsigned string,
+	sigs []*Signature,
+) ConstructionCombineRequest {
+	return ConstructionCombineRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		UnsignedTransaction: unsigned,
+		Signatures:          sigs,
+	}
+}
+
+func TestConstructionCombine(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x1c), nil,
+	)
+	unsigned := requestPayloads(t, h, addr)
+	pub, _ := testKeyPair(t, 0x1d)
+
+	rec := postJSON(t, h, "/construction/combine", combineRequest(
+		unsigned,
+		[]*Signature{
+			{
+				PublicKey: &PublicKey{
+					HexBytes:  hexString(pub),
+					CurveType: Edwards25519,
+				},
+				SignatureType: Ed25519,
+				HexBytes:      hexString(make([]byte, 64)),
+			},
+		},
+	))
+
+	resp := decodeResponse[ConstructionCombineResponse](t, rec)
+	// The result must be a decodable transaction carrying the witness.
+	txBytes := mustDecodeHex(t, resp.SignedTransaction)
+	txType, err := gledger.DetermineTransactionType(txBytes)
+	require.NoError(t, err)
+	tx, err := gledger.NewTransactionFromCbor(txType, txBytes)
+	require.NoError(t, err)
+	require.NotNil(t, tx.Witnesses())
+	require.Len(t, tx.Witnesses().Vkey(), 1)
+	require.Equal(
+		t, []byte(pub), tx.Witnesses().Vkey()[0].Vkey,
+	)
+}
+
+func TestConstructionCombineInvalidRequest(t *testing.T) {
+	pub, _ := testKeyPair(t, 0x1e)
+	validSig := hexString(make([]byte, 64))
+	validUnsigned := ""
+
+	tests := map[string]struct {
+		unsigned func() string
+		sigs     []*Signature
+		wantErr  *Error
+	}{
+		"non-hex unsigned transaction": {
+			unsigned: func() string { return "zz" },
+			wantErr:  ErrInvalidTransaction,
+		},
+		"signature without public key": {
+			unsigned: func() string { return validUnsigned },
+			sigs: []*Signature{
+				{HexBytes: validSig},
+			},
+			wantErr: ErrInvalidPublicKey,
+		},
+		"non-hex public key": {
+			unsigned: func() string { return validUnsigned },
+			sigs: []*Signature{
+				{
+					PublicKey: &PublicKey{HexBytes: "zz"},
+					HexBytes:  validSig,
+				},
+			},
+			wantErr: ErrInvalidPublicKey,
+		},
+		"short public key": {
+			unsigned: func() string { return validUnsigned },
+			sigs: []*Signature{
+				{
+					PublicKey: &PublicKey{
+						HexBytes: hexString(
+							testKeyHash(0x01),
+						),
+					},
+					HexBytes: validSig,
+				},
+			},
+			wantErr: ErrInvalidPublicKey,
+		},
+		"non-hex signature": {
+			unsigned: func() string { return validUnsigned },
+			sigs: []*Signature{
+				{
+					PublicKey: &PublicKey{
+						HexBytes: hexString(pub),
+					},
+					HexBytes: "zz",
+				},
+			},
+			wantErr: ErrInvalidTransaction,
+		},
+		"short signature": {
+			unsigned: func() string { return validUnsigned },
+			sigs: []*Signature{
+				{
+					PublicKey: &PublicKey{
+						HexBytes: hexString(pub),
+					},
+					HexBytes: hexString(make([]byte, 32)),
+				},
+			},
+			wantErr: ErrInvalidTransaction,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+			addr := testAddress(
+				t, lcommon.AddressTypeKeyNone,
+				testKeyHash(0x1f), nil,
+			)
+			validUnsigned = requestPayloads(t, h, addr)
+
+			rec := postJSON(
+				t, h, "/construction/combine",
+				combineRequest(tc.unsigned(), tc.sigs),
+			)
+
+			requireMeshError(
+				t, rec, tc.wantErr, http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// --- /construction/parse -----------------------------------------------
+
+func parseRequest(
+	tx string,
+	signed bool,
+) ConstructionParseRequest {
+	return ConstructionParseRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		Transaction: tx,
+		Signed:      signed,
+	}
+}
+
+func TestConstructionParseSigned(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x20), nil,
+	)
+	txCbor, _ := testSimpleSignedTx(t, addr)
+
+	rec := postJSON(t, h, "/construction/parse", parseRequest(
+		hexString(txCbor), true,
+	))
+
+	resp := decodeResponse[ConstructionParseResponse](t, rec)
+	require.Len(t, resp.Operations, 2)
+	require.Equal(t, OpInput, resp.Operations[0].Type)
+	require.Equal(t, OpOutput, resp.Operations[1].Type)
+	require.Equal(t, addr, resp.Operations[1].Account.Address)
+	// Signers are reported as the blake2b-224 hash of each witness key.
+	require.Len(t, resp.AccountIdentifierSigners, 1)
+	signerKey, _ := testKeyPair(t, 0x42)
+	keyHash := lcommon.Blake2b224Hash(signerKey)
+	require.Equal(
+		t,
+		hexString(keyHash[:]),
+		resp.AccountIdentifierSigners[0].Address,
+	)
+}
+
+func TestConstructionParseUnsigned(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x22), nil,
+	)
+	unsigned := requestPayloads(t, h, addr)
+
+	rec := postJSON(t, h, "/construction/parse", parseRequest(
+		unsigned, false,
+	))
+
+	resp := decodeResponse[ConstructionParseResponse](t, rec)
+	require.Len(t, resp.Operations, 2)
+	require.Equal(t, OpInput, resp.Operations[0].Type)
+	require.Equal(t, OpOutput, resp.Operations[1].Type)
+	require.Equal(t, "1830000", resp.Operations[1].Amount.Value)
+	// An unsigned body carries no witnesses, so no signers.
+	require.Empty(t, resp.AccountIdentifierSigners)
+}
+
+// TestConstructionParseCertificates covers the certificate shapes the
+// converter recognizes: each supported certificate becomes exactly one
+// operation, and unsupported ones are dropped rather than mis-typed.
+func TestConstructionParseCertificates(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x23), nil,
+	)
+	stakeCred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.CredentialHash(testKeyHash(0x24)),
+	}
+	bodyCbor := testTxBodyWithCerts(
+		t,
+		addr,
+		[]lcommon.CertificateWrapper{
+			{
+				Type: uint(
+					lcommon.CertificateTypeStakeRegistration,
+				),
+				Certificate: &lcommon.StakeRegistrationCertificate{
+					CertType: uint(
+						lcommon.CertificateTypeStakeRegistration,
+					),
+					StakeCredential: stakeCred,
+				},
+			},
+			{
+				Type: uint(
+					lcommon.CertificateTypeStakeDelegation,
+				),
+				Certificate: &lcommon.StakeDelegationCertificate{
+					CertType: uint(
+						lcommon.CertificateTypeStakeDelegation,
+					),
+					StakeCredential: &stakeCred,
+					PoolKeyHash: lcommon.PoolKeyHash(
+						testKeyHash(0x25),
+					),
+				},
+			},
+		},
+	)
+	txCbor := testSignedTx(t, bodyCbor, nil)
+
+	rec := postJSON(t, h, "/construction/parse", parseRequest(
+		hexString(txCbor), true,
+	))
+
+	resp := decodeResponse[ConstructionParseResponse](t, rec)
+	types := make([]string, 0, len(resp.Operations))
+	for _, op := range resp.Operations {
+		types = append(types, op.Type)
+	}
+	require.Equal(
+		t,
+		[]string{
+			OpInput,
+			OpOutput,
+			OpStakeKeyRegistration,
+			OpStakeDelegation,
+		},
+		types,
+	)
+	// Operation indices stay contiguous across sections.
+	for i, op := range resp.Operations {
+		require.Equal(
+			t, int64(i), op.OperationIdentifier.Index,
+		)
+	}
+}
+
+func TestConstructionParseInvalid(t *testing.T) {
+	tests := map[string]struct {
+		tx     string
+		signed bool
+	}{
+		"signed non-hex":     {tx: "zz", signed: true},
+		"signed garbage":     {tx: "ffffff", signed: true},
+		"unsigned non-hex":   {tx: "zz", signed: false},
+		"unsigned garbage":   {tx: "ffffff", signed: false},
+		"signed empty":       {tx: "", signed: true},
+		"unsigned truncated": {tx: "a1", signed: false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+
+			rec := postJSON(
+				t, h, "/construction/parse",
+				parseRequest(tc.tx, tc.signed),
+			)
+
+			requireMeshError(
+				t, rec, ErrInvalidTransaction,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// --- /construction/hash ------------------------------------------------
+
+func TestConstructionHash(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x26), nil,
+	)
+	txCbor, tx := testSimpleSignedTx(t, addr)
+
+	rec := postJSON(t, h, "/construction/hash",
+		ConstructionHashRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+			SignedTransaction: hexString(txCbor),
+		},
+	)
+
+	resp := decodeResponse[ConstructionHashResponse](t, rec)
+	require.Equal(
+		t,
+		tx.Hash().String(),
+		resp.TransactionIdentifier.Hash,
+	)
+}
+
+func TestConstructionHashInvalid(t *testing.T) {
+	for name, tx := range map[string]string{
+		"non-hex": "zz",
+		"garbage": "ffffff",
+		"empty":   "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+
+			rec := postJSON(t, h, "/construction/hash",
+				ConstructionHashRequest{
+					networkIdentifierField: networkIdentifierField{
+						NetworkIdentifier: testNetworkID(),
+					},
+					SignedTransaction: tx,
+				},
+			)
+
+			requireMeshError(
+				t, rec, ErrInvalidTransaction,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// --- /construction/submit ----------------------------------------------
+
+func submitRequest(tx string) ConstructionSubmitRequest {
+	return ConstructionSubmitRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		SignedTransaction: tx,
+	}
+}
+
+func TestConstructionSubmit(t *testing.T) {
+	deps := newTestDeps()
+	h := newTestHandler(t, deps)
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x27), nil,
+	)
+	txCbor, tx := testSimpleSignedTx(t, addr)
+
+	rec := postJSON(
+		t, h, "/construction/submit",
+		submitRequest(hexString(txCbor)),
+	)
+
+	resp := decodeResponse[ConstructionSubmitResponse](t, rec)
+	require.Equal(
+		t, tx.Hash().String(), resp.TransactionIdentifier.Hash,
+	)
+	// The exact submitted bytes must reach the mempool unmodified.
+	submissions := deps.mempool.submissions()
+	require.Len(t, submissions, 1)
+	require.Equal(
+		t, uint(gledger.TxTypeConway), submissions[0].txType,
+	)
+	require.Equal(t, txCbor, submissions[0].txBytes)
+}
+
+// TestConstructionSubmitRejected covers a mempool that refuses the
+// transaction: the client must get the retriable submit-failed error
+// with the underlying reason, not a success.
+func TestConstructionSubmitRejected(t *testing.T) {
+	deps := newTestDeps()
+	deps.mempool.addErr = errors.New("fee too small")
+	h := newTestHandler(t, deps)
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x28), nil,
+	)
+	txCbor, _ := testSimpleSignedTx(t, addr)
+
+	rec := postJSON(
+		t, h, "/construction/submit",
+		submitRequest(hexString(txCbor)),
+	)
+
+	got := requireMeshError(
+		t, rec, ErrSubmitFailed, http.StatusBadRequest,
+	)
+	require.True(t, got.Retriable)
+	require.Contains(t, got.Details["error"], "fee too small")
+}
+
+func TestConstructionSubmitInvalid(t *testing.T) {
+	for name, tx := range map[string]string{
+		"non-hex": "zz",
+		"garbage": "ffffff",
+		"empty":   "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			deps := newTestDeps()
+			h := newTestHandler(t, deps)
+
+			rec := postJSON(
+				t, h, "/construction/submit",
+				submitRequest(tx),
+			)
+
+			requireMeshError(
+				t, rec, ErrInvalidTransaction,
+				http.StatusBadRequest,
+			)
+			require.Empty(t, deps.mempool.submissions())
+		})
+	}
+}
+
+// --- round trip ---------------------------------------------------------
+
+// TestConstructionRoundTrip walks the full Mesh construction flow and
+// asserts the stages agree: the transaction produced by combine parses
+// back to the operations that were requested, and hash and submit report
+// the same transaction identifier.
+func TestConstructionRoundTrip(t *testing.T) {
+	deps := newTestDeps()
+	deps.ledger.pparams = testPParams(44, 155381)
+	h := newTestHandler(t, deps)
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x29), nil,
+	)
+	pub, priv := testKeyPair(t, 0x2a)
+	ops := payloadOps(t, addr)
+
+	// preprocess -> the options a client feeds into metadata.
+	preRec := postJSON(t, h, "/construction/preprocess",
+		ConstructionPreprocessRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+			Operations: ops,
+		},
+	)
+	pre := decodeResponse[ConstructionPreprocessResponse](t, preRec)
+	require.NotEmpty(t, pre.RequiredPublicKeys)
+
+	// metadata -> suggested fee used for the body.
+	metaRec := postJSON(t, h, "/construction/metadata",
+		ConstructionMetadataRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+			Options: pre.Options,
+		},
+	)
+	meta := decodeResponse[ConstructionMetadataResponse](t, metaRec)
+	fee := meta.SuggestedFee[0].Value
+
+	// payloads -> unsigned body plus the payload to sign.
+	payRec := postJSON(t, h, "/construction/payloads",
+		payloadsRequest(
+			ops,
+			map[string]any{"fee": fee},
+			[]*PublicKey{
+				{
+					HexBytes:  hexString(pub),
+					CurveType: Edwards25519,
+				},
+			},
+		),
+	)
+	pay := decodeResponse[ConstructionPayloadsResponse](t, payRec)
+	require.Len(t, pay.Payloads, 1)
+
+	// combine -> signed transaction.
+	sig := signPayload(t, priv, pay.Payloads[0].HexBytes)
+	comRec := postJSON(t, h, "/construction/combine", combineRequest(
+		pay.UnsignedTransaction,
+		[]*Signature{
+			{
+				SigningPayload: pay.Payloads[0],
+				PublicKey: &PublicKey{
+					HexBytes:  hexString(pub),
+					CurveType: Edwards25519,
+				},
+				SignatureType: Ed25519,
+				HexBytes:      hexString(sig),
+			},
+		},
+	))
+	com := decodeResponse[ConstructionCombineResponse](t, comRec)
+
+	// parse(signed) -> the same operations, plus the signer.
+	parseRec := postJSON(t, h, "/construction/parse", parseRequest(
+		com.SignedTransaction, true,
+	))
+	parsed := decodeResponse[ConstructionParseResponse](t, parseRec)
+	require.Len(t, parsed.Operations, len(ops))
+	require.Equal(t, OpInput, parsed.Operations[0].Type)
+	require.Equal(
+		t,
+		ops[0].CoinChange.CoinIdentifier.Identifier,
+		parsed.Operations[0].CoinChange.CoinIdentifier.Identifier,
+	)
+	require.Equal(t, OpOutput, parsed.Operations[1].Type)
+	require.Equal(
+		t, addr, parsed.Operations[1].Account.Address,
+	)
+	require.Equal(
+		t,
+		ops[1].Amount.Value,
+		parsed.Operations[1].Amount.Value,
+	)
+	keyHash := lcommon.Blake2b224Hash(pub)
+	require.Equal(
+		t,
+		[]*AccountIdentifier{
+			{Address: hexString(keyHash[:])},
+		},
+		parsed.AccountIdentifierSigners,
+	)
+
+	// hash and submit must agree on the transaction identifier.
+	hashRec := postJSON(t, h, "/construction/hash",
+		ConstructionHashRequest{
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+			SignedTransaction: com.SignedTransaction,
+		},
+	)
+	hashed := decodeResponse[ConstructionHashResponse](t, hashRec)
+
+	subRec := postJSON(
+		t, h, "/construction/submit",
+		submitRequest(com.SignedTransaction),
+	)
+	submitted := decodeResponse[ConstructionSubmitResponse](t, subRec)
+
+	require.Equal(
+		t,
+		hashed.TransactionIdentifier.Hash,
+		submitted.TransactionIdentifier.Hash,
+	)
+	require.Len(t, deps.mempool.submissions(), 1)
+	require.Equal(
+		t,
+		mustDecodeHex(t, com.SignedTransaction),
+		deps.mempool.submissions()[0].txBytes,
+	)
+}
+
+// requestPayloads runs /construction/payloads and returns the unsigned
+// transaction, for tests that need a well-formed body to work from.
+func requestPayloads(
+	t *testing.T,
+	h http.Handler,
+	addr string,
+) string {
+	t.Helper()
+	rec := postJSON(t, h, "/construction/payloads", payloadsRequest(
+		payloadOps(t, addr),
+		map[string]any{"fee": "170000"},
+		nil,
+	))
+	resp := decodeResponse[ConstructionPayloadsResponse](t, rec)
+	return resp.UnsignedTransaction
+}
+
+// signPayload signs a hex-encoded signing payload with priv.
+func signPayload(
+	t *testing.T,
+	priv []byte,
+	payloadHex string,
+) []byte {
+	t.Helper()
+	payload, err := hex.DecodeString(payloadHex)
+	require.NoError(t, err)
+	return ed25519Sign(priv, payload)
+}
+
+// TestConstructionParseNativeAssetOutputs covers multi-asset outputs in
+// the parse path: each asset in an output becomes its own operation
+// with a sub-coin identifier, alongside the output's ADA operation.
+func TestConstructionParseNativeAssetOutputs(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x2b), nil,
+	)
+	policy := lcommon.Blake2b224(testKeyHash(0xce))
+	name := cbor.NewByteString([]byte("tok"))
+	assets := lcommon.NewMultiAsset(
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policy: {name: big.NewInt(12)},
+		},
+	)
+	output := testOutput(t, addr, 1_000_000)
+	output.OutputAmount.Assets = &assets
+	bodyCbor := testTxBody(
+		t,
+		[]shelley.ShelleyTransactionInput{
+			shelley.NewShelleyTransactionInput(
+				hexString(testHash(0xd3)), 0,
+			),
+		},
+		[]babbage.BabbageTransactionOutput{output},
+		170_000,
+	)
+	txCbor := testSignedTx(t, bodyCbor, nil)
+
+	rec := postJSON(t, h, "/construction/parse", parseRequest(
+		hexString(txCbor), true,
+	))
+
+	resp := decodeResponse[ConstructionParseResponse](t, rec)
+	require.Len(t, resp.Operations, 3)
+	require.Equal(t, OpOutput, resp.Operations[1].Type)
+	require.Equal(t, "1000000", resp.Operations[1].Amount.Value)
+	assetOp := resp.Operations[2]
+	require.Equal(t, OpOutput, assetOp.Type)
+	require.Equal(t, "12", assetOp.Amount.Value)
+	require.Equal(
+		t,
+		hexString([]byte("tok")),
+		assetOp.Amount.Currency.Symbol,
+	)
+	require.Equal(
+		t,
+		hexString(policy[:]),
+		assetOp.Amount.Currency.Metadata["policyId"],
+	)
+	require.Equal(
+		t,
+		resp.Operations[1].CoinChange.CoinIdentifier.Identifier+
+			":"+hexString(policy[:])+":"+
+			hexString([]byte("tok")),
+		assetOp.CoinChange.CoinIdentifier.Identifier,
+	)
+	require.Equal(t, int64(2), assetOp.OperationIdentifier.Index)
+}
+
+// TestConstructionMetadataConversionFailure covers protocol parameters
+// that cannot be converted for the response: the endpoint must report a
+// server error rather than emitting a zero suggested fee.
+func TestConstructionMetadataConversionFailure(t *testing.T) {
+	deps := newTestDeps()
+	// A nil A0 makes the utxorpc conversion fail.
+	pparams := testPParams(44, 155381)
+	pparams.A0 = nil
+	deps.ledger.pparams = pparams
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(
+		t, h, "/construction/metadata", metadataRequest(),
+	)
+
+	requireMeshError(
+		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+}

--- a/api/mesh/convert_test.go
+++ b/api/mesh/convert_test.go
@@ -1,0 +1,582 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaCurrency(t *testing.T) {
+	c := adaCurrency()
+	require.Equal(t, "ADA", c.Symbol)
+	require.Equal(t, int32(6), c.Decimals)
+	require.Nil(t, c.Metadata)
+}
+
+func TestNativeAssetCurrency(t *testing.T) {
+	policy := hexString(testKeyHash(0xaa))
+	name := hexString([]byte("token"))
+
+	c := nativeAssetCurrency(policy, name)
+
+	require.Equal(t, name, c.Symbol)
+	require.Equal(t, int32(0), c.Decimals)
+	require.Equal(t, policy, c.Metadata["policyId"])
+	require.Equal(t, name, c.Metadata["assetName"])
+}
+
+func TestConvertAmount(t *testing.T) {
+	require.Equal(t, "0", convertAmount(0).Value)
+	require.Equal(
+		t,
+		"18446744073709551615",
+		convertAmount(^uint64(0)).Value,
+	)
+}
+
+func TestConvertAssetAmount(t *testing.T) {
+	policy := testKeyHash(0xab)
+	name := []byte("tok")
+
+	amt := convertAssetAmount(policy, name, 25)
+
+	require.Equal(t, "25", amt.Value)
+	require.Equal(t, hexString(name), amt.Currency.Symbol)
+	require.Equal(
+		t, hexString(policy), amt.Currency.Metadata["policyId"],
+	)
+}
+
+func TestTxStatus(t *testing.T) {
+	require.Equal(t, StatusSuccess, *txStatus(true))
+	require.Equal(t, StatusInvalid, *txStatus(false))
+}
+
+// TestUtxoAddressCredentialCombinations covers the CIP-19 address types
+// reconstructed from the payment/staking credentials stored with a UTxO.
+// A wrong mapping here silently reports coins under the wrong address.
+func TestUtxoAddressCredentialCombinations(t *testing.T) {
+	paymentKey := testKeyHash(0x30)
+	stakingKey := testKeyHash(0x31)
+
+	tests := map[string]struct {
+		utxo      models.Utxo
+		wantType  uint8
+		wantStake bool
+	}{
+		"key payment, no stake": {
+			utxo:     models.Utxo{PaymentKey: paymentKey},
+			wantType: lcommon.AddressTypeKeyNone,
+		},
+		"script payment, no stake": {
+			utxo: models.Utxo{
+				PaymentKey:    paymentKey,
+				PaymentScript: true,
+			},
+			wantType: lcommon.AddressTypeScriptNone,
+		},
+		"key payment, key stake": {
+			utxo: models.Utxo{
+				PaymentKey: paymentKey,
+				StakingKey: stakingKey,
+			},
+			wantType:  lcommon.AddressTypeKeyKey,
+			wantStake: true,
+		},
+		"key payment, script stake": {
+			utxo: models.Utxo{
+				PaymentKey:    paymentKey,
+				StakingKey:    stakingKey,
+				CredentialTag: 1,
+			},
+			wantType:  lcommon.AddressTypeKeyScript,
+			wantStake: true,
+		},
+		"script payment, key stake": {
+			utxo: models.Utxo{
+				PaymentKey:    paymentKey,
+				StakingKey:    stakingKey,
+				PaymentScript: true,
+			},
+			wantType:  lcommon.AddressTypeScriptKey,
+			wantStake: true,
+		},
+		"script payment, script stake": {
+			utxo: models.Utxo{
+				PaymentKey:    paymentKey,
+				StakingKey:    stakingKey,
+				PaymentScript: true,
+				CredentialTag: 1,
+			},
+			wantType:  lcommon.AddressTypeScriptScript,
+			wantStake: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := utxoAddress(
+				&tc.utxo, lcommon.AddressNetworkTestnet,
+			)
+
+			var stake []byte
+			if tc.wantStake {
+				stake = stakingKey
+			}
+			require.Equal(
+				t,
+				testAddress(
+					t, tc.wantType, paymentKey, stake,
+				),
+				got,
+			)
+			// Round-tripping through the parser must recover the
+			// same address, proving the encoding is well formed.
+			parsed, err := lcommon.NewAddress(got)
+			require.NoError(t, err)
+			require.Equal(t, got, parsed.String())
+		})
+	}
+}
+
+// TestUtxoAddressByronPlaceholder covers Byron-era outputs, which carry
+// no payment key hash: the Mesh spec requires a non-empty address, so a
+// distinguishable placeholder is returned instead.
+func TestUtxoAddressByronPlaceholder(t *testing.T) {
+	txID := testHash(0x32)
+
+	got := utxoAddress(
+		&models.Utxo{TxId: txID},
+		lcommon.AddressNetworkTestnet,
+	)
+
+	require.Equal(t, "byron:"+hexString(txID), got)
+	require.True(t, strings.HasPrefix(got, "byron:"))
+}
+
+// TestUtxoAddressFallbackOnInvalidCredential covers a malformed payment
+// key: the converter must degrade to the hex hash rather than panic.
+func TestUtxoAddressFallbackOnInvalidCredential(t *testing.T) {
+	short := []byte{0x01, 0x02}
+
+	got := utxoAddress(
+		&models.Utxo{PaymentKey: short},
+		lcommon.AddressNetworkTestnet,
+	)
+
+	require.Equal(t, hexString(short), got)
+}
+
+// TestUtxoAddressNetworkPrefix asserts the configured network selects
+// the bech32 prefix, so mainnet coins are never reported under testnet
+// addresses.
+func TestUtxoAddressNetworkPrefix(t *testing.T) {
+	utxo := models.Utxo{PaymentKey: testKeyHash(0x33)}
+
+	testnet := utxoAddress(
+		&utxo, lcommon.AddressNetworkTestnet,
+	)
+	mainnet := utxoAddress(
+		&utxo, lcommon.AddressNetworkMainnet,
+	)
+
+	require.True(t, strings.HasPrefix(testnet, "addr_test1"))
+	require.True(t, strings.HasPrefix(mainnet, "addr1"))
+	require.NotEqual(t, testnet, mainnet)
+}
+
+func TestConvertBlockGenesisParent(t *testing.T) {
+	hash := testHash(0x34)
+
+	block := convertBlock(
+		models.Block{Hash: hash, Number: 0, Slot: 0},
+		nil,
+		lcommon.AddressNetworkTestnet,
+		func(slot uint64) int64 { return int64(slot) * 1000 },
+	)
+
+	require.Equal(
+		t,
+		&BlockIdentifier{Index: 0, Hash: hexString(hash)},
+		block.BlockIdentifier,
+	)
+	require.Equal(
+		t, block.BlockIdentifier, block.ParentBlockIdentifier,
+	)
+	require.Equal(t, int64(0), block.Timestamp)
+	require.Empty(t, block.Transactions)
+}
+
+func TestConvertBlockParent(t *testing.T) {
+	hash := testHash(0x35)
+	prev := testHash(0x36)
+
+	block := convertBlock(
+		models.Block{
+			Hash: hash, PrevHash: prev, Number: 10, Slot: 20,
+		},
+		nil,
+		lcommon.AddressNetworkTestnet,
+		func(slot uint64) int64 { return int64(slot) * 1000 },
+	)
+
+	require.Equal(
+		t,
+		&BlockIdentifier{Index: 9, Hash: hexString(prev)},
+		block.ParentBlockIdentifier,
+	)
+	require.Equal(t, int64(20000), block.Timestamp)
+}
+
+// TestConvertTransactionInvalidStatus covers phase-2 failures: every
+// operation must carry the "invalid" status so clients do not credit
+// balances from a failed transaction.
+func TestConvertTransactionInvalidStatus(t *testing.T) {
+	txHash := testHash(0x37)
+	paymentKey := testKeyHash(0x38)
+
+	tx := convertTransaction(
+		models.Transaction{
+			Hash:  txHash,
+			Valid: false,
+			Inputs: []models.Utxo{
+				testUtxo(
+					testHash(0x39), 0, 1_000_000,
+					paymentKey, nil,
+				),
+			},
+			Outputs: []models.Utxo{
+				testUtxo(txHash, 0, 900_000, paymentKey, nil),
+			},
+		},
+		lcommon.AddressNetworkTestnet,
+	)
+
+	require.Len(t, tx.Operations, 2)
+	for _, op := range tx.Operations {
+		require.NotNil(t, op.Status)
+		require.Equal(t, StatusInvalid, *op.Status)
+	}
+}
+
+// TestConvertTransactionAssetOperations covers native assets: each
+// asset becomes its own operation with a sub-coin identifier, and the
+// operation indices stay contiguous across ADA and asset entries.
+func TestConvertTransactionAssetOperations(t *testing.T) {
+	txHash := testHash(0x3a)
+	inputTxID := testHash(0x3b)
+	paymentKey := testKeyHash(0x3c)
+	policy := testKeyHash(0xcd)
+
+	tx := convertTransaction(
+		models.Transaction{
+			Hash:  txHash,
+			Valid: true,
+			Inputs: []models.Utxo{
+				testUtxo(
+					inputTxID, 1, 5_000_000, paymentKey,
+					[]models.Asset{
+						testAsset(
+							policy, []byte("tok"), 4,
+						),
+					},
+				),
+			},
+			Outputs: []models.Utxo{
+				testUtxo(
+					txHash, 0, 4_500_000, paymentKey,
+					[]models.Asset{
+						testAsset(
+							policy, []byte("tok"), 4,
+						),
+					},
+				),
+			},
+		},
+		lcommon.AddressNetworkTestnet,
+	)
+
+	require.Len(t, tx.Operations, 4)
+	for i, op := range tx.Operations {
+		require.Equal(
+			t, int64(i), op.OperationIdentifier.Index,
+		)
+	}
+	// Inputs are negated; outputs are not.
+	require.Equal(t, "-5000000", tx.Operations[0].Amount.Value)
+	require.Equal(t, "-4", tx.Operations[1].Amount.Value)
+	require.Equal(t, "4500000", tx.Operations[2].Amount.Value)
+	require.Equal(t, "4", tx.Operations[3].Amount.Value)
+	// Asset operations reference the owning UTxO as a sub-coin.
+	require.Equal(
+		t,
+		hexString(inputTxID)+":1:"+hexString(policy)+":"+
+			hexString([]byte("tok")),
+		tx.Operations[1].CoinChange.CoinIdentifier.Identifier,
+	)
+	require.Equal(t, CoinSpent, tx.Operations[0].CoinChange.CoinAction)
+	require.Equal(
+		t, CoinCreated, tx.Operations[2].CoinChange.CoinAction,
+	)
+	// Only the primary ADA input operation is related to outputs, so
+	// clients do not double-count asset sub-operations.
+	require.Equal(
+		t,
+		[]*OperationIdentifier{{Index: 0}},
+		tx.Operations[2].RelatedOperations,
+	)
+	require.Nil(t, tx.Operations[0].RelatedOperations)
+}
+
+// TestConvertBodyToOpsWithdrawalsAreSorted covers the deterministic
+// ordering of withdrawal operations. Go map iteration is randomized, so
+// without sorting the operation indices would differ between calls for
+// the same transaction.
+func TestConvertBodyToOpsWithdrawalsAreSorted(t *testing.T) {
+	addrs := make([]*lcommon.Address, 0, 3)
+	for _, b := range []byte{0x03, 0x01, 0x02} {
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyNone,
+			lcommon.AddressNetworkTestnet,
+			testKeyHash(b),
+			nil,
+		)
+		require.NoError(t, err)
+		addrs = append(addrs, &addr)
+	}
+	withdrawals := map[*lcommon.Address]*big.Int{
+		addrs[0]: big.NewInt(30),
+		addrs[1]: big.NewInt(10),
+		addrs[2]: big.NewInt(20),
+	}
+
+	var first []string
+	for range 8 {
+		ops := convertBodyToOps(
+			nil, nil, nil, withdrawals, "",
+		)
+		require.Len(t, ops, 3)
+		got := make([]string, 0, len(ops))
+		for i, op := range ops {
+			require.Equal(t, OpWithdrawal, op.Type)
+			require.Equal(
+				t, int64(i), op.OperationIdentifier.Index,
+			)
+			got = append(got, op.Account.Address)
+		}
+		if first == nil {
+			first = got
+			require.True(
+				t,
+				got[0] < got[1] && got[1] < got[2],
+				"withdrawals not sorted: %v", got,
+			)
+			continue
+		}
+		require.Equal(t, first, got)
+	}
+}
+
+// certFixtures returns one real certificate value per certificate type
+// the ledger defines, so the mapping below is exercised against the
+// same types that arrive from a decoded transaction.
+func certFixtures() map[lcommon.CertificateType]gledger.Certificate {
+	ct := func(t lcommon.CertificateType) uint { return uint(t) }
+	return map[lcommon.CertificateType]gledger.Certificate{
+		lcommon.CertificateTypeStakeRegistration: &lcommon.StakeRegistrationCertificate{
+			CertType: ct(lcommon.CertificateTypeStakeRegistration),
+		},
+		lcommon.CertificateTypeStakeDeregistration: &lcommon.StakeDeregistrationCertificate{
+			CertType: ct(lcommon.CertificateTypeStakeDeregistration),
+		},
+		lcommon.CertificateTypeStakeDelegation: &lcommon.StakeDelegationCertificate{
+			CertType: ct(lcommon.CertificateTypeStakeDelegation),
+		},
+		lcommon.CertificateTypePoolRegistration: &lcommon.PoolRegistrationCertificate{
+			CertType: ct(lcommon.CertificateTypePoolRegistration),
+		},
+		lcommon.CertificateTypePoolRetirement: &lcommon.PoolRetirementCertificate{
+			CertType: ct(lcommon.CertificateTypePoolRetirement),
+		},
+		lcommon.CertificateTypeGenesisKeyDelegation: &lcommon.GenesisKeyDelegationCertificate{
+			CertType: ct(lcommon.CertificateTypeGenesisKeyDelegation),
+		},
+		lcommon.CertificateTypeMoveInstantaneousRewards: &lcommon.MoveInstantaneousRewardsCertificate{
+			CertType: ct(lcommon.CertificateTypeMoveInstantaneousRewards),
+		},
+		lcommon.CertificateTypeRegistration: &lcommon.RegistrationCertificate{
+			CertType: ct(lcommon.CertificateTypeRegistration),
+		},
+		lcommon.CertificateTypeDeregistration: &lcommon.DeregistrationCertificate{
+			CertType: ct(lcommon.CertificateTypeDeregistration),
+		},
+		lcommon.CertificateTypeVoteDelegation: &lcommon.VoteDelegationCertificate{
+			CertType: ct(lcommon.CertificateTypeVoteDelegation),
+		},
+		lcommon.CertificateTypeStakeVoteDelegation: &lcommon.StakeVoteDelegationCertificate{
+			CertType: ct(lcommon.CertificateTypeStakeVoteDelegation),
+		},
+		lcommon.CertificateTypeStakeRegistrationDelegation: &lcommon.StakeRegistrationDelegationCertificate{
+			CertType: ct(lcommon.CertificateTypeStakeRegistrationDelegation),
+		},
+		lcommon.CertificateTypeVoteRegistrationDelegation: &lcommon.VoteRegistrationDelegationCertificate{
+			CertType: ct(lcommon.CertificateTypeVoteRegistrationDelegation),
+		},
+		lcommon.CertificateTypeStakeVoteRegistrationDelegation: &lcommon.StakeVoteRegistrationDelegationCertificate{
+			CertType: ct(
+				lcommon.CertificateTypeStakeVoteRegistrationDelegation,
+			),
+		},
+		lcommon.CertificateTypeAuthCommitteeHot: &lcommon.AuthCommitteeHotCertificate{
+			CertType: ct(lcommon.CertificateTypeAuthCommitteeHot),
+		},
+		lcommon.CertificateTypeResignCommitteeCold: &lcommon.ResignCommitteeColdCertificate{
+			CertType: ct(lcommon.CertificateTypeResignCommitteeCold),
+		},
+		lcommon.CertificateTypeRegistrationDrep: &lcommon.RegistrationDrepCertificate{
+			CertType: ct(lcommon.CertificateTypeRegistrationDrep),
+		},
+		lcommon.CertificateTypeDeregistrationDrep: &lcommon.DeregistrationDrepCertificate{
+			CertType: ct(lcommon.CertificateTypeDeregistrationDrep),
+		},
+		lcommon.CertificateTypeUpdateDrep: &lcommon.UpdateDrepCertificate{
+			CertType: ct(lcommon.CertificateTypeUpdateDrep),
+		},
+	}
+}
+
+// TestCertToOpType pins the certificate-to-operation mapping. The
+// operation type is part of the Mesh contract, and unsupported
+// certificates must map to the empty string so they are dropped rather
+// than reported under a wrong type.
+func TestCertToOpType(t *testing.T) {
+	want := map[lcommon.CertificateType]string{
+		lcommon.CertificateTypeStakeRegistration:   OpStakeKeyRegistration,
+		lcommon.CertificateTypeRegistration:        OpStakeKeyRegistration,
+		lcommon.CertificateTypeStakeDeregistration: OpStakeKeyDeregistration,
+		lcommon.CertificateTypeDeregistration:      OpStakeKeyDeregistration,
+		lcommon.CertificateTypeStakeDelegation:     OpStakeDelegation,
+		lcommon.CertificateTypePoolRegistration:    OpPoolRegistration,
+		lcommon.CertificateTypePoolRetirement:      OpPoolRetirement,
+		lcommon.CertificateTypeVoteDelegation:      OpVoteDRepDelegation,
+	}
+
+	for certType, cert := range certFixtures() {
+		require.Equal(
+			t,
+			want[certType],
+			certToOpType(cert),
+			"certificate type %d", certType,
+		)
+	}
+}
+
+// TestCertToOpTypeUnknown covers a certificate type outside the known
+// range, which must not be reported as an operation.
+func TestCertToOpTypeUnknown(t *testing.T) {
+	require.Equal(
+		t,
+		"",
+		certToOpType(&lcommon.StakeRegistrationCertificate{
+			CertType: 250,
+		}),
+	)
+}
+
+// TestOperationTypesCoverCertificateMapping asserts every operation type
+// the certificate mapping can produce is advertised by
+// /network/options, so clients can recognize it.
+func TestOperationTypesCoverCertificateMapping(t *testing.T) {
+	advertised := make(map[string]struct{})
+	for _, opType := range OperationTypes() {
+		advertised[opType] = struct{}{}
+	}
+	mapped := 0
+	for certType, cert := range certFixtures() {
+		opType := certToOpType(cert)
+		if opType == "" {
+			continue
+		}
+		mapped++
+		require.Contains(
+			t, advertised, opType,
+			"certificate type %d maps to unadvertised "+
+				"operation %q", certType, opType,
+		)
+	}
+	require.Positive(t, mapped)
+}
+
+// TestConvertBodyToOpsSkipsUnmappedCertificates asserts certificates
+// without a Mesh operation type produce no operation and do not consume
+// an operation index, keeping indices contiguous.
+func TestConvertBodyToOpsSkipsUnmappedCertificates(t *testing.T) {
+	fixtures := certFixtures()
+	certs := []gledger.Certificate{
+		fixtures[lcommon.CertificateTypeStakeRegistration],
+		fixtures[lcommon.CertificateTypeAuthCommitteeHot],
+		fixtures[lcommon.CertificateTypeStakeDelegation],
+	}
+
+	ops := convertBodyToOps(nil, nil, certs, nil, "")
+
+	require.Len(t, ops, 2)
+	require.Equal(t, OpStakeKeyRegistration, ops[0].Type)
+	require.Equal(t, int64(0), ops[0].OperationIdentifier.Index)
+	require.Equal(t, OpStakeDelegation, ops[1].Type)
+	require.Equal(t, int64(1), ops[1].OperationIdentifier.Index)
+}
+
+func TestDecodeTxCborErrors(t *testing.T) {
+	tests := map[string]string{
+		"non-hex":     "zz",
+		"empty":       "",
+		"not a tx":    "a10101",
+		"truncated":   "84",
+		"wrong shape": "820102",
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx, meshErr := decodeTxCbor(input)
+
+			require.Nil(t, tx)
+			require.NotNil(t, meshErr)
+			require.Equal(
+				t, ErrInvalidTransaction.Code, meshErr.Code,
+			)
+			require.NotEmpty(t, meshErr.Details["error"])
+		})
+	}
+}
+
+func TestDecodeTxCborSuccess(t *testing.T) {
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x3d), nil,
+	)
+	txCbor, want := testSimpleSignedTx(t, addr)
+
+	tx, meshErr := decodeTxCbor(hexString(txCbor))
+
+	require.Nil(t, meshErr)
+	require.NotNil(t, tx)
+	require.Equal(t, want.Hash().String(), tx.Hash().String())
+}

--- a/api/mesh/errors_test.go
+++ b/api/mesh/errors_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrorCodesAreStable pins the wire values of every Mesh error.
+// Clients branch on these codes, so a change here is a breaking API
+// change and must be deliberate.
+func TestErrorCodesAreStable(t *testing.T) {
+	want := map[int32]struct {
+		message   string
+		retriable bool
+	}{
+		1:  {"network not supported", false},
+		2:  {"block not found", false},
+		3:  {"transaction not found", false},
+		4:  {"account not found", false},
+		5:  {"invalid request", false},
+		6:  {"internal error", true},
+		7:  {"not implemented", false},
+		8:  {"invalid public key", false},
+		9:  {"invalid transaction", false},
+		10: {"transaction submit failed", true},
+		11: {"service unavailable", true},
+	}
+
+	all := AllErrors()
+	require.Len(t, all, len(want))
+	seen := make(map[int32]struct{}, len(all))
+	for _, err := range all {
+		spec, ok := want[err.Code]
+		require.True(t, ok, "unexpected error code %d", err.Code)
+		require.Equal(t, spec.message, err.Message)
+		require.Equal(t, spec.retriable, err.Retriable)
+		require.NotEmpty(t, err.Description)
+		_, dup := seen[err.Code]
+		require.False(t, dup, "duplicate error code %d", err.Code)
+		seen[err.Code] = struct{}{}
+	}
+}
+
+// TestWriteErrorStatusMapping pins the HTTP status each Mesh error maps
+// to. Rosetta clients and proxies key retry behavior off the status as
+// well as the code.
+func TestWriteErrorStatusMapping(t *testing.T) {
+	want := map[*Error]int{
+		ErrNetworkNotSupported: http.StatusNotFound,
+		ErrBlockNotFound:       http.StatusNotFound,
+		ErrTransactionNotFound: http.StatusNotFound,
+		ErrAccountNotFound:     http.StatusNotFound,
+		ErrInvalidRequest:      http.StatusBadRequest,
+		ErrInvalidPublicKey:    http.StatusBadRequest,
+		ErrInvalidTransaction:  http.StatusBadRequest,
+		ErrSubmitFailed:        http.StatusBadRequest,
+		ErrNotImplemented:      http.StatusNotImplemented,
+		ErrUnavailable:         http.StatusServiceUnavailable,
+		ErrInternal:            http.StatusInternalServerError,
+	}
+	// Every defined error must have a pinned status.
+	require.Len(t, want, len(AllErrors()))
+
+	for meshErr, status := range want {
+		rec := httptest.NewRecorder()
+
+		writeError(rec, meshErr)
+
+		require.Equal(
+			t, status, rec.Code,
+			"error code %d", meshErr.Code,
+		)
+		require.Equal(
+			t,
+			"application/json",
+			rec.Header().Get("Content-Type"),
+		)
+		var got Error
+		require.NoError(
+			t, json.Unmarshal(rec.Body.Bytes(), &got),
+		)
+		require.Equal(t, meshErr.Code, got.Code)
+	}
+}
+
+// TestWriteErrorUnknownCodeIsInternal covers an error outside the
+// defined set, which must fail closed as a server error rather than
+// being reported as success.
+func TestWriteErrorUnknownCodeIsInternal(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	writeError(rec, &Error{Code: 999, Message: "unknown"})
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestWrapErr(t *testing.T) {
+	t.Run("nil detail returns the base error", func(t *testing.T) {
+		require.Same(
+			t, ErrInternal, wrapErr(ErrInternal, nil),
+		)
+	})
+
+	t.Run("detail is attached", func(t *testing.T) {
+		wrapped := wrapErr(
+			ErrInternal, errors.New("disk on fire"),
+		)
+
+		require.Equal(t, ErrInternal.Code, wrapped.Code)
+		require.Equal(t, ErrInternal.Message, wrapped.Message)
+		require.Equal(
+			t, ErrInternal.Description, wrapped.Description,
+		)
+		require.Equal(
+			t, ErrInternal.Retriable, wrapped.Retriable,
+		)
+		require.Equal(t, "disk on fire", wrapped.Details["error"])
+	})
+
+	t.Run("base error is not mutated", func(t *testing.T) {
+		wrapErr(ErrBlockNotFound, errors.New("detail"))
+
+		require.Nil(t, ErrBlockNotFound.Details)
+	})
+}
+
+// TestErrorJSONShape pins the serialized field names, which are part of
+// the Rosetta response schema.
+func TestErrorJSONShape(t *testing.T) {
+	raw, err := json.Marshal(
+		wrapErr(ErrInvalidRequest, errors.New("bad")),
+	)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Equal(t, float64(5), decoded["code"])
+	require.Equal(t, "invalid request", decoded["message"])
+	require.Equal(t, false, decoded["retriable"])
+	require.NotEmpty(t, decoded["description"])
+	require.Equal(
+		t,
+		map[string]any{"error": "bad"},
+		decoded["details"],
+	)
+
+	// Optional fields are omitted when unset, while retriable is
+	// always present so clients never have to infer it.
+	raw, err = json.Marshal(&Error{Code: 1, Message: "m"})
+	require.NoError(t, err)
+	minimal := map[string]any{}
+	require.NoError(t, json.Unmarshal(raw, &minimal))
+	require.NotContains(t, minimal, "description")
+	require.NotContains(t, minimal, "details")
+	require.Contains(t, minimal, "retriable")
+}

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -147,6 +147,15 @@ func freePort(t *testing.T) string {
 // startOnFreePort starts a server on a free loopback port, retrying on
 // a lost race for the port, and returns it with the address it bound.
 // The caller owns shutdown.
+//
+// Each attempt gets its own cancellable context. Start launches the
+// context-monitor goroutine before it binds, so a failed bind returns
+// an error while leaving that goroutine parked on the context; Stop
+// does not release it, because the goroutine waits on the context
+// rather than on server state. Cancelling the failed attempt's context
+// retires its goroutine immediately instead of holding one per retry
+// until the test ends. The surviving attempt's context stays a child of
+// the caller's, so cancelling that still shuts the server down.
 func startOnFreePort(
 	t *testing.T,
 	ctx context.Context,
@@ -164,10 +173,13 @@ func startOnFreePort(
 			func(c *ServerConfig) { c.ListenAddress = addr },
 		)
 		srv := newTestServer(t, deps, attemptOpts...)
-		if err := srv.Start(ctx); err != nil {
+		attemptCtx, cancel := context.WithCancel(ctx)
+		if err := srv.Start(attemptCtx); err != nil {
+			cancel()
 			lastErr = err
 			continue
 		}
+		t.Cleanup(cancel)
 		return srv, addr
 	}
 	t.Fatalf(

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -124,8 +124,17 @@ func TestNewServerAddressNetworkFollowsMagic(t *testing.T) {
 
 // --- listener lifecycle -------------------------------------------------
 
+// bindAttempts bounds how many ports a test tries before giving up.
+// The server binds the address in its config and does not expose the
+// address it resolved, so a test cannot ask the kernel for a port with
+// :0 and read it back. Reserving a port and releasing it leaves a
+// window in which another process can claim it, so callers retry
+// instead of treating one bind failure as a test failure.
+const bindAttempts = 8
+
 // freePort reserves a loopback port and releases it, returning the
-// address. The server binds the same address immediately afterwards.
+// address. The port is not guaranteed to still be free when the caller
+// binds it -- see bindAttempts.
 func freePort(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -133,6 +142,39 @@ func freePort(t *testing.T) string {
 	addr := ln.Addr().String()
 	require.NoError(t, ln.Close())
 	return addr
+}
+
+// startOnFreePort starts a server on a free loopback port, retrying on
+// a lost race for the port, and returns it with the address it bound.
+// The caller owns shutdown.
+func startOnFreePort(
+	t *testing.T,
+	ctx context.Context,
+	deps *testDeps,
+	opts ...serverOption,
+) (*Server, string) {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		addr := freePort(t)
+		attemptOpts := make([]serverOption, 0, len(opts)+1)
+		attemptOpts = append(attemptOpts, opts...)
+		attemptOpts = append(
+			attemptOpts,
+			func(c *ServerConfig) { c.ListenAddress = addr },
+		)
+		srv := newTestServer(t, deps, attemptOpts...)
+		if err := srv.Start(ctx); err != nil {
+			lastErr = err
+			continue
+		}
+		return srv, addr
+	}
+	t.Fatalf(
+		"could not bind a free loopback port in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil, ""
 }
 
 // startTestServer starts a server on a free port and stops it when the
@@ -143,16 +185,9 @@ func startTestServer(
 	opts ...serverOption,
 ) (*Server, string) {
 	t.Helper()
-	addr := freePort(t)
-	opts = append(
-		opts,
-		func(c *ServerConfig) { c.ListenAddress = addr },
-	)
-	srv := newTestServer(t, deps, opts...)
-
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
-	require.NoError(t, srv.Start(ctx))
+	srv, addr := startOnFreePort(t, ctx, deps, opts...)
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(
 			context.Background(), 5*time.Second,
@@ -233,13 +268,9 @@ func TestServerStopIsIdempotent(t *testing.T) {
 // TestServerGracefulShutdown asserts Stop closes the listener so the
 // port stops accepting connections.
 func TestServerGracefulShutdown(t *testing.T) {
-	addr := freePort(t)
-	srv := newTestServer(
-		t,
-		newTestDeps(),
-		func(c *ServerConfig) { c.ListenAddress = addr },
+	srv, addr := startOnFreePort(
+		t, t.Context(), newTestDeps(),
 	)
-	require.NoError(t, srv.Start(t.Context()))
 
 	stopCtx, cancel := context.WithTimeout(
 		t.Context(), 5*time.Second,
@@ -259,14 +290,8 @@ func TestServerGracefulShutdown(t *testing.T) {
 // passed to Start shuts the listener down, which is how the node stops
 // the API during its own shutdown.
 func TestServerShutdownOnContextCancel(t *testing.T) {
-	addr := freePort(t)
-	srv := newTestServer(
-		t,
-		newTestDeps(),
-		func(c *ServerConfig) { c.ListenAddress = addr },
-	)
 	ctx, cancel := context.WithCancel(t.Context())
-	require.NoError(t, srv.Start(ctx))
+	_, addr := startOnFreePort(t, ctx, newTestDeps())
 
 	cancel()
 
@@ -379,13 +404,19 @@ func TestRequestBodyLimit(t *testing.T) {
 	)
 }
 
-// TestRequestBodyAtLimitIsAccepted asserts the cap is not so tight that
-// ordinary requests are rejected.
+// TestRequestBodyAtLimitIsAccepted pins the accepting side of the cap
+// at the exact boundary: a body of precisely maxRequestBody bytes must
+// still be served, so a regression that tightens the limit is caught
+// rather than hidden behind a comfortably small request.
 func TestRequestBodyAtLimitIsAccepted(t *testing.T) {
 	h := newTestHandler(t, newTestDeps())
-	padded := `{"network_identifier":{"blockchain":"cardano",` +
-		`"network":"preview"},"metadata":{"pad":"` +
-		strings.Repeat("a", 1024) + `"}}`
+	const prefix = `{"network_identifier":{"blockchain":"cardano",` +
+		`"network":"preview"},"metadata":{"pad":"`
+	const suffix = `"}}`
+	padded := prefix +
+		strings.Repeat("a", maxRequestBody-len(prefix)-len(suffix)) +
+		suffix
+	require.Len(t, padded, maxRequestBody)
 
 	rec := postRaw(t, h, "/network/status", padded)
 

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -1,0 +1,447 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// --- construction validation -------------------------------------------
+
+// TestNewServerRequiresDependencies asserts every dependency the
+// handlers dereference is validated up front, so a misconfigured node
+// fails at startup rather than on the first request.
+func TestNewServerRequiresDependencies(t *testing.T) {
+	tests := map[string]func(*ServerConfig){
+		"missing chain": func(c *ServerConfig) {
+			c.Chain = nil
+		},
+		"missing database": func(c *ServerConfig) {
+			c.Database = nil
+		},
+		"missing ledger state": func(c *ServerConfig) {
+			c.LedgerState = nil
+		},
+		"missing mempool": func(c *ServerConfig) {
+			c.Mempool = nil
+		},
+		"missing network": func(c *ServerConfig) {
+			c.Network = ""
+		},
+		"missing genesis hash": func(c *ServerConfig) {
+			c.GenesisHash = ""
+		},
+		"non-hex genesis hash": func(c *ServerConfig) {
+			c.GenesisHash = "not-hex"
+		},
+		"zero genesis start time": func(c *ServerConfig) {
+			c.GenesisStartTimeSec = 0
+		},
+		"negative genesis start time": func(c *ServerConfig) {
+			c.GenesisStartTimeSec = -1
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			deps := newTestDeps()
+			cfg := ServerConfig{
+				LedgerState:         deps.ledger,
+				Database:            deps.database,
+				Chain:               deps.chain,
+				Mempool:             deps.mempool,
+				Network:             testNetwork,
+				NetworkMagic:        testNetworkMagic,
+				GenesisHash:         testGenesisHash,
+				GenesisStartTimeSec: testGenesisStartTimeSec,
+			}
+			mutate(&cfg)
+
+			srv, err := NewServer(cfg)
+
+			require.Error(t, err)
+			require.Nil(t, srv)
+			require.Contains(t, err.Error(), "mesh:")
+		})
+	}
+}
+
+// TestNewServerDefaults covers the optional configuration: a nil logger
+// and an empty listen address must not leave the server unusable.
+func TestNewServerDefaults(t *testing.T) {
+	deps := newTestDeps()
+	srv, err := NewServer(ServerConfig{
+		LedgerState:         deps.ledger,
+		Database:            deps.database,
+		Chain:               deps.chain,
+		Mempool:             deps.mempool,
+		Network:             testNetwork,
+		GenesisHash:         testGenesisHash,
+		GenesisStartTimeSec: testGenesisStartTimeSec,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, srv.logger)
+	require.Equal(t, defaultListenAddr, srv.config.ListenAddress)
+}
+
+// TestNewServerAddressNetworkFollowsMagic asserts the address network
+// used for every derived address is chosen from the network magic.
+func TestNewServerAddressNetworkFollowsMagic(t *testing.T) {
+	deps := newTestDeps()
+
+	testnet := newTestServer(t, deps)
+	mainnet := newTestServer(
+		t, deps,
+		func(c *ServerConfig) { c.NetworkMagic = mainnetMagic },
+	)
+
+	require.Equal(t, uint8(0), testnet.addrNetworkID)
+	require.Equal(t, uint8(1), mainnet.addrNetworkID)
+}
+
+// --- listener lifecycle -------------------------------------------------
+
+// freePort reserves a loopback port and releases it, returning the
+// address. The server binds the same address immediately afterwards.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// startTestServer starts a server on a free port and stops it when the
+// test ends, returning the base URL.
+func startTestServer(
+	t *testing.T,
+	deps *testDeps,
+	opts ...serverOption,
+) (*Server, string) {
+	t.Helper()
+	addr := freePort(t)
+	opts = append(
+		opts,
+		func(c *ServerConfig) { c.ListenAddress = addr },
+	)
+	srv := newTestServer(t, deps, opts...)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+
+	return srv, "http://" + addr
+}
+
+func TestServerServesRequests(t *testing.T) {
+	deps := newTestDeps()
+	_, baseURL := startTestServer(t, deps)
+
+	body, err := json.Marshal(MetadataRequest{})
+	require.NoError(t, err)
+	resp, err := http.Post(
+		baseURL+"/network/list",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var decoded NetworkListResponse
+	require.NoError(
+		t, json.NewDecoder(resp.Body).Decode(&decoded),
+	)
+	require.Len(t, decoded.NetworkIdentifiers, 1)
+}
+
+// TestServerBindFailure covers a listen address already in use: Start
+// must report the failure instead of silently running without a
+// listener.
+func TestServerBindFailure(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = occupied.Close() })
+
+	srv := newTestServer(
+		t,
+		newTestDeps(),
+		func(c *ServerConfig) {
+			c.ListenAddress = occupied.Addr().String()
+		},
+	)
+
+	err = srv.Start(t.Context())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to listen")
+	// A failed start must leave the server restartable.
+	require.Nil(t, srv.httpServer)
+}
+
+// TestServerDoubleStart asserts a second Start is refused rather than
+// leaking the first listener.
+func TestServerDoubleStart(t *testing.T) {
+	srv, _ := startTestServer(t, newTestDeps())
+
+	err := srv.Start(t.Context())
+
+	require.ErrorContains(t, err, "already started")
+}
+
+// TestServerStopIsIdempotent asserts Stop on a server that was never
+// started, or stopped twice, is a no-op rather than an error.
+func TestServerStopIsIdempotent(t *testing.T) {
+	srv := newTestServer(t, newTestDeps())
+
+	require.NoError(t, srv.Stop(t.Context()))
+	require.NoError(t, srv.Stop(t.Context()))
+}
+
+// TestServerGracefulShutdown asserts Stop closes the listener so the
+// port stops accepting connections.
+func TestServerGracefulShutdown(t *testing.T) {
+	addr := freePort(t)
+	srv := newTestServer(
+		t,
+		newTestDeps(),
+		func(c *ServerConfig) { c.ListenAddress = addr },
+	)
+	require.NoError(t, srv.Start(t.Context()))
+
+	stopCtx, cancel := context.WithTimeout(
+		t.Context(), 5*time.Second,
+	)
+	defer cancel()
+	require.NoError(t, srv.Stop(stopCtx))
+
+	testutil.WaitForCondition(
+		t,
+		func() bool { return !portAccepts(addr) },
+		5*time.Second,
+		"listener still accepting after Stop",
+	)
+}
+
+// TestServerShutdownOnContextCancel asserts cancelling the context
+// passed to Start shuts the listener down, which is how the node stops
+// the API during its own shutdown.
+func TestServerShutdownOnContextCancel(t *testing.T) {
+	addr := freePort(t)
+	srv := newTestServer(
+		t,
+		newTestDeps(),
+		func(c *ServerConfig) { c.ListenAddress = addr },
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	require.NoError(t, srv.Start(ctx))
+
+	cancel()
+
+	testutil.WaitForCondition(
+		t,
+		func() bool { return !portAccepts(addr) },
+		5*time.Second,
+		"listener still accepting after context cancel",
+	)
+}
+
+// portAccepts reports whether a TCP connection to addr succeeds.
+func portAccepts(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// --- CORS ---------------------------------------------------------------
+
+// TestServerCORSPreflight covers browser access: a preflight from an
+// allowed origin succeeds, and one from any other origin is refused.
+func TestServerCORSPreflight(t *testing.T) {
+	const allowed = "https://wallet.example"
+	_, baseURL := startTestServer(
+		t,
+		newTestDeps(),
+		func(c *ServerConfig) {
+			c.CORSAllowedOrigins = []string{allowed}
+		},
+	)
+
+	t.Run("allowed origin", func(t *testing.T) {
+		resp := preflight(t, baseURL, allowed)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(
+			t,
+			allowed,
+			resp.Header.Get("Access-Control-Allow-Origin"),
+		)
+	})
+
+	t.Run("disallowed origin", func(t *testing.T) {
+		resp := preflight(t, baseURL, "https://evil.example")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		require.Empty(
+			t,
+			resp.Header.Get("Access-Control-Allow-Origin"),
+		)
+	})
+}
+
+// TestServerCORSDisabledByDefault asserts no CORS headers are emitted
+// when no origins are configured, so a browser cannot read responses
+// from an unconfigured deployment.
+func TestServerCORSDisabledByDefault(t *testing.T) {
+	_, baseURL := startTestServer(t, newTestDeps())
+
+	resp := preflight(t, baseURL, "https://wallet.example")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Empty(
+		t, resp.Header.Get("Access-Control-Allow-Origin"),
+	)
+}
+
+// preflight issues a CORS preflight request against /network/list.
+func preflight(
+	t *testing.T,
+	baseURL string,
+	origin string,
+) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodOptions,
+		baseURL+"/network/list",
+		nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+// --- request bounds -----------------------------------------------------
+
+// TestRequestBodyLimit covers the 1 MiB request cap: an oversized body
+// is rejected as an invalid request rather than being buffered whole.
+func TestRequestBodyLimit(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	oversized := `{"network_identifier":{"blockchain":"cardano",` +
+		`"network":"preview"},"metadata":{"pad":"` +
+		strings.Repeat("a", maxRequestBody) + `"}}`
+
+	rec := postRaw(t, h, "/network/status", oversized)
+
+	requireMeshError(
+		t, rec, ErrInvalidRequest, http.StatusBadRequest,
+	)
+}
+
+// TestRequestBodyAtLimitIsAccepted asserts the cap is not so tight that
+// ordinary requests are rejected.
+func TestRequestBodyAtLimitIsAccepted(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	padded := `{"network_identifier":{"blockchain":"cardano",` +
+		`"network":"preview"},"metadata":{"pad":"` +
+		strings.Repeat("a", 1024) + `"}}`
+
+	rec := postRaw(t, h, "/network/status", padded)
+
+	decodeResponse[NetworkStatusResponse](t, rec)
+}
+
+// TestServerTimeoutsAreConfigured pins the listener timeouts, which
+// bound how long a slow or idle client can hold a connection.
+func TestServerTimeoutsAreConfigured(t *testing.T) {
+	srv, _ := startTestServer(t, newTestDeps())
+
+	srv.mu.Lock()
+	httpServer := srv.httpServer
+	srv.mu.Unlock()
+
+	require.NotNil(t, httpServer)
+	require.Equal(
+		t, 60*time.Second, httpServer.ReadHeaderTimeout,
+	)
+	require.Equal(t, 30*time.Second, httpServer.WriteTimeout)
+	require.Equal(t, 120*time.Second, httpServer.IdleTimeout)
+}
+
+// --- routing ------------------------------------------------------------
+
+// TestUnknownRouteIsNotFound asserts an unregistered path does not fall
+// through to a handler.
+func TestUnknownRouteIsNotFound(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postRaw(t, h, "/does/not/exist", "{}")
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestRoutesRejectNonPost asserts every Mesh endpoint is POST-only, as
+// the Rosetta specification requires.
+func TestRoutesRejectNonPost(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+	paths := append(
+		[]string{"/network/list"}, networkValidatedRoutes()...,
+	)
+
+	for _, path := range paths {
+		for _, method := range []string{
+			http.MethodGet, http.MethodPut, http.MethodDelete,
+		} {
+			req := newRequest(t, method, path)
+			rec := recordRequest(h, req)
+
+			require.Equal(
+				t,
+				http.StatusMethodNotAllowed,
+				rec.Code,
+				"%s %s", method, path,
+			)
+		}
+	}
+}

--- a/api/mesh/mempool_api_test.go
+++ b/api/mesh/mempool_api_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/mempool"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func networkReq() NetworkRequest {
+	return NetworkRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	}
+}
+
+func TestMempool(t *testing.T) {
+	deps := newTestDeps()
+	deps.mempool.txs = []mempool.MempoolTransaction{
+		{Hash: hexString(testHash(0xe1))},
+		{Hash: hexString(testHash(0xe2))},
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/mempool", networkReq())
+
+	resp := decodeResponse[MempoolResponse](t, rec)
+	require.Equal(
+		t,
+		[]*TransactionIdentifier{
+			{Hash: hexString(testHash(0xe1))},
+			{Hash: hexString(testHash(0xe2))},
+		},
+		resp.TransactionIdentifiers,
+	)
+}
+
+// TestMempoolEmpty asserts an empty mempool serializes as an empty list
+// rather than JSON null, which Mesh clients reject.
+func TestMempoolEmpty(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(t, h, "/mempool", networkReq())
+
+	resp := decodeResponse[MempoolResponse](t, rec)
+	require.NotNil(t, resp.TransactionIdentifiers)
+	require.Empty(t, resp.TransactionIdentifiers)
+	require.Contains(
+		t, rec.Body.String(), `"transaction_identifiers":[]`,
+	)
+}
+
+func TestMempoolTransaction(t *testing.T) {
+	deps := newTestDeps()
+	addr := testAddress(
+		t, lcommon.AddressTypeKeyNone, testKeyHash(0x0d), nil,
+	)
+	txCbor, tx := testSimpleSignedTx(t, addr)
+	deps.mempool.txs = []mempool.MempoolTransaction{
+		{
+			Hash: tx.Hash().String(),
+			Cbor: txCbor,
+			Type: gledger.TxTypeConway,
+		},
+	}
+	h := newTestHandler(t, deps)
+
+	req := MempoolTransactionRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		TransactionIdentifier: &TransactionIdentifier{
+			Hash: tx.Hash().String(),
+		},
+	}
+	rec := postJSON(t, h, "/mempool/transaction", req)
+
+	resp := decodeResponse[MempoolTransactionResponse](t, rec)
+	require.Equal(
+		t,
+		tx.Hash().String(),
+		resp.Transaction.TransactionIdentifier.Hash,
+	)
+	require.Len(t, resp.Transaction.Operations, 2)
+	require.Equal(t, OpInput, resp.Transaction.Operations[0].Type)
+	require.Equal(t, OpOutput, resp.Transaction.Operations[1].Type)
+	require.Equal(
+		t, addr, resp.Transaction.Operations[1].Account.Address,
+	)
+	require.Equal(
+		t, "1000000", resp.Transaction.Operations[1].Amount.Value,
+	)
+}
+
+func TestMempoolTransactionNotFound(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	req := MempoolTransactionRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		TransactionIdentifier: &TransactionIdentifier{
+			Hash: hexString(testHash(0xe3)),
+		},
+	}
+	rec := postJSON(t, h, "/mempool/transaction", req)
+
+	requireMeshError(
+		t, rec, ErrTransactionNotFound, http.StatusNotFound,
+	)
+}
+
+func TestMempoolTransactionMissingIdentifier(t *testing.T) {
+	for name, req := range map[string]MempoolTransactionRequest{
+		"nil identifier": {
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+		},
+		"empty hash": {
+			networkIdentifierField: networkIdentifierField{
+				NetworkIdentifier: testNetworkID(),
+			},
+			TransactionIdentifier: &TransactionIdentifier{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+
+			rec := postJSON(t, h, "/mempool/transaction", req)
+
+			requireMeshError(
+				t, rec, ErrInvalidRequest,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// TestMempoolTransactionUndecodable covers a mempool entry whose CBOR
+// cannot be parsed: the endpoint must report an internal error rather
+// than panicking or returning an empty transaction.
+func TestMempoolTransactionUndecodable(t *testing.T) {
+	deps := newTestDeps()
+	hash := hexString(testHash(0xe4))
+	deps.mempool.txs = []mempool.MempoolTransaction{
+		{
+			Hash: hash,
+			Cbor: []byte{0xff, 0xff, 0xff},
+			Type: gledger.TxTypeConway,
+		},
+	}
+	h := newTestHandler(t, deps)
+
+	req := MempoolTransactionRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+		TransactionIdentifier: &TransactionIdentifier{Hash: hash},
+	}
+	rec := postJSON(t, h, "/mempool/transaction", req)
+
+	requireMeshError(
+		t, rec, ErrInternal, http.StatusInternalServerError,
+	)
+}

--- a/api/mesh/network.go
+++ b/api/mesh/network.go
@@ -62,7 +62,7 @@ func (s *Server) handleNetworkOptions(
 			OperationStatuses:       OperationStatuses(),
 			OperationTypes:          OperationTypes(),
 			Errors:                  AllErrors(),
-			HistoricalBalanceLookup: false,
+			HistoricalBalanceLookup: true,
 			MempoolCoins:            false,
 		},
 	}

--- a/api/mesh/network_test.go
+++ b/api/mesh/network_test.go
@@ -73,9 +73,10 @@ func TestNetworkOptions(t *testing.T) {
 		t, OperationStatuses(), resp.Allow.OperationStatuses,
 	)
 	require.Len(t, resp.Allow.Errors, len(AllErrors()))
-	// Historical lookups and mempool coins are not implemented, and
-	// clients rely on these flags to skip those calls entirely.
-	require.False(t, resp.Allow.HistoricalBalanceLookup)
+	// Clients rely on these flags to decide which calls to make:
+	// /account/balance honors a block_identifier, while mempool coins
+	// are not implemented.
+	require.True(t, resp.Allow.HistoricalBalanceLookup)
 	require.False(t, resp.Allow.MempoolCoins)
 }
 

--- a/api/mesh/network_test.go
+++ b/api/mesh/network_test.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkList(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(t, h, "/network/list", MetadataRequest{})
+
+	resp := decodeResponse[NetworkListResponse](t, rec)
+	require.Equal(
+		t,
+		[]*NetworkIdentifier{
+			{Blockchain: "cardano", Network: testNetwork},
+		},
+		resp.NetworkIdentifiers,
+	)
+}
+
+// TestNetworkListMalformedBody documents that /network/list rejects a
+// body that is not a JSON object rather than treating it as empty.
+func TestNetworkListMalformedBody(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postRaw(t, h, "/network/list", "{not json")
+
+	requireMeshError(
+		t, rec, ErrInvalidRequest, http.StatusBadRequest,
+	)
+}
+
+func TestNetworkOptions(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(t, h, "/network/options", NetworkRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	})
+
+	resp := decodeResponse[NetworkOptionsResponse](t, rec)
+	require.NotNil(t, resp.Version)
+	require.Equal(t, rosettaVersion, resp.Version.RosettaVersion)
+	require.Equal(t, nodeVersion, resp.Version.NodeVersion)
+	require.NotNil(t, resp.Allow)
+	require.Equal(
+		t, OperationTypes(), resp.Allow.OperationTypes,
+	)
+	require.Equal(
+		t, OperationStatuses(), resp.Allow.OperationStatuses,
+	)
+	require.Len(t, resp.Allow.Errors, len(AllErrors()))
+	// Historical lookups and mempool coins are not implemented, and
+	// clients rely on these flags to skip those calls entirely.
+	require.False(t, resp.Allow.HistoricalBalanceLookup)
+	require.False(t, resp.Allow.MempoolCoins)
+}
+
+// TestNetworkOptionsAdvertisesEveryError guards the contract that
+// /network/options enumerates every error a client can encounter, so
+// stable codes stay discoverable.
+func TestNetworkOptionsAdvertisesEveryError(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(t, h, "/network/options", NetworkRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	})
+
+	resp := decodeResponse[NetworkOptionsResponse](t, rec)
+	advertised := make(map[int32]*Error, len(resp.Allow.Errors))
+	for _, e := range resp.Allow.Errors {
+		advertised[e.Code] = e
+	}
+	for _, want := range AllErrors() {
+		got, ok := advertised[want.Code]
+		require.True(
+			t, ok, "error code %d not advertised", want.Code,
+		)
+		require.Equal(t, want.Message, got.Message)
+		require.Equal(t, want.Description, got.Description)
+		require.Equal(t, want.Retriable, got.Retriable)
+	}
+}
+
+func TestNetworkStatus(t *testing.T) {
+	deps := newTestDeps()
+	tipHash := testHash(0xab)
+	deps.chain.tip = ochainsync.Tip{
+		Point:       ocommon.NewPoint(4242, tipHash),
+		BlockNumber: 99,
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/network/status", NetworkRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	})
+
+	resp := decodeResponse[NetworkStatusResponse](t, rec)
+	require.Equal(
+		t,
+		&BlockIdentifier{
+			Index: 99,
+			Hash:  hexString(tipHash),
+		},
+		resp.CurrentBlockIdentifier,
+	)
+	require.Equal(
+		t,
+		&BlockIdentifier{Index: 0, Hash: testGenesisHash},
+		resp.GenesisBlockIdentifier,
+	)
+	require.Equal(
+		t,
+		time.Unix(testGenesisStartTimeSec+4242, 0).UnixMilli(),
+		resp.CurrentBlockTimestamp,
+	)
+	require.NotNil(t, resp.SyncStatus)
+	require.NotNil(t, resp.SyncStatus.Synced)
+	require.True(t, *resp.SyncStatus.Synced)
+	require.NotNil(t, resp.Peers)
+	require.Empty(t, resp.Peers)
+}
+
+// TestNetworkStatusSlotToTimeFallback covers the path where the epoch
+// cache is not yet populated: the handler must still return a timestamp
+// derived from genesis rather than failing the request.
+func TestNetworkStatusSlotToTimeFallback(t *testing.T) {
+	deps := newTestDeps()
+	deps.ledger.slotToTime = func(uint64) (time.Time, error) {
+		return time.Time{}, errors.New("epoch cache empty")
+	}
+	deps.chain.tip = ochainsync.Tip{
+		Point:       ocommon.NewPoint(120, testHash(0x01)),
+		BlockNumber: 7,
+	}
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(t, h, "/network/status", NetworkRequest{
+		networkIdentifierField: networkIdentifierField{
+			NetworkIdentifier: testNetworkID(),
+		},
+	})
+
+	resp := decodeResponse[NetworkStatusResponse](t, rec)
+	require.Equal(
+		t,
+		(testGenesisStartTimeSec+120)*1000,
+		resp.CurrentBlockTimestamp,
+	)
+}
+
+// TestNetworkValidationRejectsUnknownNetwork covers every endpoint that
+// carries a network identifier: an identifier for another chain or
+// network must fail with a stable 404 rather than being ignored.
+func TestNetworkValidationRejectsUnknownNetwork(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	for _, path := range networkValidatedRoutes() {
+		t.Run(path, func(t *testing.T) {
+			for _, id := range []*NetworkIdentifier{
+				{Blockchain: "bitcoin", Network: testNetwork},
+				{Blockchain: blockchain, Network: "mainnet"},
+			} {
+				rec := postJSON(t, h, path, NetworkRequest{
+					networkIdentifierField: networkIdentifierField{
+						NetworkIdentifier: id,
+					},
+				})
+				requireMeshError(
+					t,
+					rec,
+					ErrNetworkNotSupported,
+					http.StatusNotFound,
+				)
+			}
+		})
+	}
+}
+
+// TestNetworkValidationRequiresIdentifier asserts a missing
+// network_identifier is rejected before any handler-specific work.
+func TestNetworkValidationRequiresIdentifier(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	for _, path := range networkValidatedRoutes() {
+		t.Run(path, func(t *testing.T) {
+			rec := postRaw(t, h, path, `{}`)
+			requireMeshError(
+				t,
+				rec,
+				ErrInvalidRequest,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// TestNetworkValidationRejectsMalformedBody asserts malformed JSON is
+// reported as an invalid request on every network-validated route.
+func TestNetworkValidationRejectsMalformedBody(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	for _, path := range networkValidatedRoutes() {
+		t.Run(path, func(t *testing.T) {
+			rec := postRaw(t, h, path, "{")
+			requireMeshError(
+				t,
+				rec,
+				ErrInvalidRequest,
+				http.StatusBadRequest,
+			)
+		})
+	}
+}
+
+// networkValidatedRoutes lists every route that runs the shared
+// network-identifier validation, so the checks above stay in step with
+// registerRoutes.
+func networkValidatedRoutes() []string {
+	return []string{
+		"/network/options",
+		"/network/status",
+		"/block",
+		"/block/transaction",
+		"/account/balance",
+		"/account/coins",
+		"/mempool",
+		"/mempool/transaction",
+		"/construction/derive",
+		"/construction/preprocess",
+		"/construction/metadata",
+		"/construction/payloads",
+		"/construction/combine",
+		"/construction/parse",
+		"/construction/hash",
+		"/construction/submit",
+	}
+}

--- a/api/mesh/node_interface.go
+++ b/api/mesh/node_interface.go
@@ -46,6 +46,13 @@ type MeshLedgerState interface {
 	GetCurrentPParams() lcommon.ProtocolParameters
 	SlotToTime(slot uint64) (time.Time, error)
 	UtxosByAddress(addr lcommon.Address) ([]models.Utxo, error)
+	// UtxosByAddressAtSlot returns the UTxOs the address held at the
+	// given slot -- those added at or before it and not spent until
+	// after it. It backs historical /account/balance queries.
+	UtxosByAddressAtSlot(
+		addr lcommon.Address,
+		slot uint64,
+	) ([]models.Utxo, error)
 }
 
 // MeshMempool is the subset of mempool.Mempool needed by the Mesh server.

--- a/api/mesh/node_interface.go
+++ b/api/mesh/node_interface.go
@@ -32,7 +32,11 @@ type MeshChain interface {
 // All calls implicitly use a nil transaction (auto-transaction per method).
 type MeshDatabase interface {
 	BlockByHash(hash []byte) (models.Block, error)
-	BlockByIndex(idx uint64) (models.Block, error)
+	// BlockByIndex looks up a block by its Cardano block height, which is
+	// the numbering the Mesh API exposes as block_identifier.index.
+	// Translating that height to the storage layer's own block index is
+	// the implementation's responsibility -- see NewMeshDatabase.
+	BlockByIndex(height uint64) (models.Block, error)
 	GetTransactionByHash(hash []byte) (*models.Transaction, error)
 	GetTransactionsByBlockHash(hash []byte) ([]models.Transaction, error)
 }

--- a/api/mesh/provider.go
+++ b/api/mesh/provider.go
@@ -23,8 +23,20 @@ import (
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
+// defaultProviderPort is the TCP port the Mesh listener uses when the
+// node's configuration does not set one.
+const defaultProviderPort uint = 8080
+
 type ProviderConfig struct {
 	Port uint `yaml:"port"`
+}
+
+// providerDefaults returns the configuration the plugin host applies
+// before decoding the node's own settings over it. RegisterProvider
+// hands this to plugin.Register, so it is the single definition of the
+// Mesh provider's defaults.
+func providerDefaults() ProviderConfig {
+	return ProviderConfig{Port: defaultProviderPort}
 }
 
 type ProviderDependencies struct {
@@ -49,7 +61,7 @@ func RegisterProvider(host *plugin.Host) error {
 			Name:        "builtin",
 			Description: "built-in Mesh-compatible Rosetta HTTP API",
 		},
-		func() ProviderConfig { return ProviderConfig{Port: 8080} },
+		providerDefaults,
 		func(_ context.Context, cfg ProviderConfig, deps ProviderDependencies) (*Server, plugin.Instance, error) {
 			server, err := NewServer(ServerConfig{
 				Logger: deps.Logger, LedgerState: deps.LedgerState,

--- a/api/mesh/provider_test.go
+++ b/api/mesh/provider_test.go
@@ -139,30 +139,19 @@ func TestProviderBuildsListenAddress(t *testing.T) {
 	require.True(t, portAccepts(srv.config.ListenAddress))
 }
 
-// TestProviderDefaultPort pins the documented default so a deployment
-// that omits the port keeps the same listener address.
+// TestProviderDefaultPort pins the port a deployment gets when its
+// configuration omits one. Resolving with no port would exercise the
+// default end to end but would bind 8080 on the test host, so assert
+// the defaults the plugin host is handed instead -- RegisterProvider
+// passes providerDefaults itself, so a change to the default port is a
+// change to what this asserts.
 func TestProviderDefaultPort(t *testing.T) {
-	host := plugin.NewHost()
-	require.NoError(t, RegisterProvider(host))
-
-	// Construct through NewServer directly rather than resolving, so
-	// the default does not bind port 8080 during the test run.
-	deps := newTestDeps()
-	pd := providerDeps(deps)
-	srv, err := NewServer(ServerConfig{
-		LedgerState:         pd.LedgerState,
-		Database:            pd.Database,
-		Chain:               pd.Chain,
-		Mempool:             pd.Mempool,
-		ListenAddress:       net.JoinHostPort(pd.Host, "8080"),
-		Network:             pd.Network,
-		NetworkMagic:        pd.NetworkMagic,
-		GenesisHash:         pd.GenesisHash,
-		GenesisStartTimeSec: pd.GenesisStartTimeSec,
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, "127.0.0.1:8080", srv.config.ListenAddress)
+	require.Equal(t, uint(8080), defaultProviderPort)
+	require.Equal(
+		t,
+		ProviderConfig{Port: defaultProviderPort},
+		providerDefaults(),
+	)
 }
 
 // TestProviderPropagatesDependencies asserts the node-supplied network

--- a/api/mesh/provider_test.go
+++ b/api/mesh/provider_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+// newProviderHost registers the built-in Mesh provider on a fresh host.
+func newProviderHost(t *testing.T) *plugin.Host {
+	t.Helper()
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+	t.Cleanup(func() {
+		require.NoError(t, host.Stop(context.Background()))
+	})
+	return host
+}
+
+// providerDeps builds provider dependencies over test doubles.
+func providerDeps(deps *testDeps) ProviderDependencies {
+	return ProviderDependencies{
+		LedgerState:         deps.ledger,
+		Database:            deps.database,
+		Chain:               deps.chain,
+		Mempool:             deps.mempool,
+		Host:                "127.0.0.1",
+		Network:             testNetwork,
+		NetworkMagic:        testNetworkMagic,
+		GenesisHash:         testGenesisHash,
+		GenesisStartTimeSec: testGenesisStartTimeSec,
+	}
+}
+
+// freeLoopbackPort reserves and releases a loopback port, returning it.
+func freeLoopbackPort(t *testing.T) uint {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(freePort(t))
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	require.NoError(t, err)
+	return uint(port)
+}
+
+// TestRegisterProviderDescriptor asserts the provider is advertised
+// under the capability and name the node's configuration selects.
+func TestRegisterProviderDescriptor(t *testing.T) {
+	host := newProviderHost(t)
+
+	var found *plugin.Descriptor
+	for _, d := range host.Providers() {
+		if d.Capability == plugin.CapabilityAPIMesh {
+			found = &d
+			break
+		}
+	}
+
+	require.NotNil(t, found)
+	require.Equal(t, "builtin", found.Name)
+	require.NotEmpty(t, found.Description)
+}
+
+// TestRegisterProviderRejectsNilHost asserts registration fails loudly
+// rather than silently leaving the capability unavailable.
+func TestRegisterProviderRejectsNilHost(t *testing.T) {
+	require.Error(t, RegisterProvider(nil))
+}
+
+// TestProviderBuildsListenAddress covers the host/port composition: the
+// server must listen on the address the node's config asks for.
+func TestProviderBuildsListenAddress(t *testing.T) {
+	host := newProviderHost(t)
+	deps := newTestDeps()
+	port := freeLoopbackPort(t)
+
+	srv, err := plugin.Resolve[*Server](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIMesh,
+		"builtin",
+		map[string]any{"port": port},
+		providerDeps(deps),
+	)
+
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		net.JoinHostPort(
+			"127.0.0.1",
+			strconv.FormatUint(uint64(port), 10),
+		),
+		srv.config.ListenAddress,
+	)
+	// Resolve starts the instance, so the port must be accepting.
+	require.True(t, portAccepts(srv.config.ListenAddress))
+}
+
+// TestProviderDefaultPort pins the documented default so a deployment
+// that omits the port keeps the same listener address.
+func TestProviderDefaultPort(t *testing.T) {
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+
+	// Construct through NewServer directly rather than resolving, so
+	// the default does not bind port 8080 during the test run.
+	deps := newTestDeps()
+	pd := providerDeps(deps)
+	srv, err := NewServer(ServerConfig{
+		LedgerState:         pd.LedgerState,
+		Database:            pd.Database,
+		Chain:               pd.Chain,
+		Mempool:             pd.Mempool,
+		ListenAddress:       net.JoinHostPort(pd.Host, "8080"),
+		Network:             pd.Network,
+		NetworkMagic:        pd.NetworkMagic,
+		GenesisHash:         pd.GenesisHash,
+		GenesisStartTimeSec: pd.GenesisStartTimeSec,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:8080", srv.config.ListenAddress)
+}
+
+// TestProviderPropagatesDependencies asserts the node-supplied network
+// identity and CORS policy reach the server rather than being dropped
+// in the provider wiring.
+func TestProviderPropagatesDependencies(t *testing.T) {
+	host := newProviderHost(t)
+	deps := newTestDeps()
+	pd := providerDeps(deps)
+	pd.CORSAllowedOrigins = []string{"https://wallet.example"}
+
+	srv, err := plugin.Resolve[*Server](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIMesh,
+		"builtin",
+		map[string]any{"port": freeLoopbackPort(t)},
+		pd,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, testNetwork, srv.config.Network)
+	require.Equal(t, testNetworkMagic, srv.config.NetworkMagic)
+	require.Equal(t, testGenesisHash, srv.config.GenesisHash)
+	require.Equal(
+		t,
+		testGenesisStartTimeSec,
+		srv.config.GenesisStartTimeSec,
+	)
+	require.Equal(
+		t,
+		[]string{"https://wallet.example"},
+		srv.config.CORSAllowedOrigins,
+	)
+	require.Same(t, deps.chain, srv.config.Chain)
+	require.Same(t, deps.database, srv.config.Database)
+	require.Same(t, deps.ledger, srv.config.LedgerState)
+	require.Same(t, deps.mempool, srv.config.Mempool)
+}
+
+// TestProviderRejectsInvalidDependencies asserts a misconfigured node
+// fails at plugin resolution, before a listener is opened.
+func TestProviderRejectsInvalidDependencies(t *testing.T) {
+	host := newProviderHost(t)
+	pd := providerDeps(newTestDeps())
+	pd.GenesisHash = ""
+
+	srv, err := plugin.Resolve[*Server](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIMesh,
+		"builtin",
+		map[string]any{"port": freeLoopbackPort(t)},
+		pd,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, srv)
+	require.Contains(t, err.Error(), "GenesisHash")
+}
+
+// TestProviderStopClosesListener asserts the host's shutdown path stops
+// the Mesh listener, so a capability restart can rebind the port.
+func TestProviderStopClosesListener(t *testing.T) {
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+	deps := newTestDeps()
+	port := freeLoopbackPort(t)
+
+	srv, err := plugin.Resolve[*Server](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIMesh,
+		"builtin",
+		map[string]any{"port": port},
+		providerDeps(deps),
+	)
+	require.NoError(t, err)
+	addr := srv.config.ListenAddress
+	require.True(t, portAccepts(addr))
+
+	require.NoError(t, host.Stop(t.Context()))
+
+	require.False(t, portAccepts(addr))
+}

--- a/api/mesh/provider_test.go
+++ b/api/mesh/provider_test.go
@@ -51,6 +51,8 @@ func providerDeps(deps *testDeps) ProviderDependencies {
 }
 
 // freeLoopbackPort reserves and releases a loopback port, returning it.
+// The port can be claimed before the provider binds it, so callers that
+// expect resolution to succeed go through resolveOnFreePort.
 func freeLoopbackPort(t *testing.T) uint {
 	t.Helper()
 	_, portStr, err := net.SplitHostPort(freePort(t))
@@ -58,6 +60,39 @@ func freeLoopbackPort(t *testing.T) uint {
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	require.NoError(t, err)
 	return uint(port)
+}
+
+// resolveOnFreePort resolves the Mesh provider on a free loopback port,
+// retrying on a lost race for the port. Resolve starts the instance, so
+// a port claimed between reservation and bind surfaces as a resolution
+// error rather than a test failure worth reporting.
+func resolveOnFreePort(
+	t *testing.T,
+	host *plugin.Host,
+	deps ProviderDependencies,
+) *Server {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		srv, err := plugin.Resolve[*Server](
+			t.Context(),
+			host,
+			plugin.CapabilityAPIMesh,
+			"builtin",
+			map[string]any{"port": freeLoopbackPort(t)},
+			deps,
+		)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return srv
+	}
+	t.Fatalf(
+		"could not resolve the Mesh provider in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil
 }
 
 // TestRegisterProviderDescriptor asserts the provider is advertised
@@ -89,26 +124,17 @@ func TestRegisterProviderRejectsNilHost(t *testing.T) {
 func TestProviderBuildsListenAddress(t *testing.T) {
 	host := newProviderHost(t)
 	deps := newTestDeps()
-	port := freeLoopbackPort(t)
 
-	srv, err := plugin.Resolve[*Server](
-		t.Context(),
-		host,
-		plugin.CapabilityAPIMesh,
-		"builtin",
-		map[string]any{"port": port},
-		providerDeps(deps),
-	)
+	srv := resolveOnFreePort(t, host, providerDeps(deps))
 
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		net.JoinHostPort(
-			"127.0.0.1",
-			strconv.FormatUint(uint64(port), 10),
-		),
+	// The address is the configured host joined to the configured
+	// port, not a default or a bare port.
+	wantHost, wantPort, err := net.SplitHostPort(
 		srv.config.ListenAddress,
 	)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", wantHost)
+	require.NotEmpty(t, wantPort)
 	// Resolve starts the instance, so the port must be accepting.
 	require.True(t, portAccepts(srv.config.ListenAddress))
 }
@@ -148,16 +174,8 @@ func TestProviderPropagatesDependencies(t *testing.T) {
 	pd := providerDeps(deps)
 	pd.CORSAllowedOrigins = []string{"https://wallet.example"}
 
-	srv, err := plugin.Resolve[*Server](
-		t.Context(),
-		host,
-		plugin.CapabilityAPIMesh,
-		"builtin",
-		map[string]any{"port": freeLoopbackPort(t)},
-		pd,
-	)
+	srv := resolveOnFreePort(t, host, pd)
 
-	require.NoError(t, err)
 	require.Equal(t, testNetwork, srv.config.Network)
 	require.Equal(t, testNetworkMagic, srv.config.NetworkMagic)
 	require.Equal(t, testGenesisHash, srv.config.GenesisHash)
@@ -204,17 +222,8 @@ func TestProviderStopClosesListener(t *testing.T) {
 	host := plugin.NewHost()
 	require.NoError(t, RegisterProvider(host))
 	deps := newTestDeps()
-	port := freeLoopbackPort(t)
 
-	srv, err := plugin.Resolve[*Server](
-		t.Context(),
-		host,
-		plugin.CapabilityAPIMesh,
-		"builtin",
-		map[string]any{"port": port},
-		providerDeps(deps),
-	)
-	require.NoError(t, err)
+	srv := resolveOnFreePort(t, host, providerDeps(deps))
 	addr := srv.config.ListenAddress
 	require.True(t, portAccepts(addr))
 

--- a/api/mesh/testsupport_test.go
+++ b/api/mesh/testsupport_test.go
@@ -113,9 +113,13 @@ func (f *fakeDatabase) GetTransactionsByBlockHash(
 
 // fakeLedgerState is a MeshLedgerState with per-test behavior.
 type fakeLedgerState struct {
-	pparams    lcommon.ProtocolParameters
-	slotToTime func(slot uint64) (time.Time, error)
-	utxos      func(addr lcommon.Address) ([]models.Utxo, error)
+	pparams     lcommon.ProtocolParameters
+	slotToTime  func(slot uint64) (time.Time, error)
+	utxos       func(addr lcommon.Address) ([]models.Utxo, error)
+	utxosAtSlot func(
+		addr lcommon.Address,
+		slot uint64,
+	) ([]models.Utxo, error)
 }
 
 func (f *fakeLedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
@@ -142,6 +146,16 @@ func (f *fakeLedgerState) UtxosByAddress(
 		return nil, nil
 	}
 	return f.utxos(addr)
+}
+
+func (f *fakeLedgerState) UtxosByAddressAtSlot(
+	addr lcommon.Address,
+	slot uint64,
+) ([]models.Utxo, error) {
+	if f.utxosAtSlot == nil {
+		return nil, nil
+	}
+	return f.utxosAtSlot(addr, slot)
 }
 
 // submittedTx records one accepted MeshMempool.AddTransaction call.

--- a/api/mesh/testsupport_test.go
+++ b/api/mesh/testsupport_test.go
@@ -1,0 +1,653 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/mempool"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/stretchr/testify/require"
+)
+
+// Fixed network identity shared by every test in the package so that
+// requests can be built without threading configuration through each
+// helper. The magic deliberately differs from mainnetMagic so the
+// default server under test uses testnet-prefixed addresses.
+const (
+	testNetwork      = "preview"
+	testNetworkMagic = uint32(2)
+	testGenesisHash  = "268ae601af9f5e0d5e0a3e8f8a3a19d0a2ac6b93" +
+		"b6f5d8e3c8fbc9d1a2b3c4d5"
+	testGenesisStartTimeSec = int64(1666656000)
+)
+
+// --- dependency doubles -------------------------------------------------
+//
+// Each double implements one of the package-local dependency interfaces
+// from node_interface.go. Behavior is supplied per test through function
+// fields; a nil field means "return the zero value", which keeps tests
+// that only care about one dependency free of unrelated setup.
+
+// fakeChain is a MeshChain returning a fixed tip.
+type fakeChain struct {
+	tip ochainsync.Tip
+}
+
+func (f *fakeChain) Tip() ochainsync.Tip { return f.tip }
+
+// fakeDatabase is a MeshDatabase whose lookups are supplied per test.
+type fakeDatabase struct {
+	blockByHash    func(hash []byte) (models.Block, error)
+	blockByIndex   func(idx uint64) (models.Block, error)
+	txByHash       func(hash []byte) (*models.Transaction, error)
+	txsByBlockHash func(hash []byte) ([]models.Transaction, error)
+}
+
+func (f *fakeDatabase) BlockByHash(
+	hash []byte,
+) (models.Block, error) {
+	if f.blockByHash == nil {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	return f.blockByHash(hash)
+}
+
+func (f *fakeDatabase) BlockByIndex(
+	idx uint64,
+) (models.Block, error) {
+	if f.blockByIndex == nil {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	return f.blockByIndex(idx)
+}
+
+func (f *fakeDatabase) GetTransactionByHash(
+	hash []byte,
+) (*models.Transaction, error) {
+	if f.txByHash == nil {
+		return nil, nil
+	}
+	return f.txByHash(hash)
+}
+
+func (f *fakeDatabase) GetTransactionsByBlockHash(
+	hash []byte,
+) ([]models.Transaction, error) {
+	if f.txsByBlockHash == nil {
+		return nil, nil
+	}
+	return f.txsByBlockHash(hash)
+}
+
+// fakeLedgerState is a MeshLedgerState with per-test behavior.
+type fakeLedgerState struct {
+	pparams    lcommon.ProtocolParameters
+	slotToTime func(slot uint64) (time.Time, error)
+	utxos      func(addr lcommon.Address) ([]models.Utxo, error)
+}
+
+func (f *fakeLedgerState) GetCurrentPParams() lcommon.ProtocolParameters {
+	return f.pparams
+}
+
+func (f *fakeLedgerState) SlotToTime(
+	slot uint64,
+) (time.Time, error) {
+	if f.slotToTime == nil {
+		// Mirror the ledger's Shelley-era 1s slots so handlers that
+		// do not exercise the fallback path get stable timestamps.
+		return time.Unix(
+			testGenesisStartTimeSec+int64(slot), 0,
+		).UTC(), nil
+	}
+	return f.slotToTime(slot)
+}
+
+func (f *fakeLedgerState) UtxosByAddress(
+	addr lcommon.Address,
+) ([]models.Utxo, error) {
+	if f.utxos == nil {
+		return nil, nil
+	}
+	return f.utxos(addr)
+}
+
+// submittedTx records one accepted MeshMempool.AddTransaction call.
+type submittedTx struct {
+	txType  uint
+	txBytes []byte
+}
+
+// fakeMempool is a MeshMempool backed by an in-memory transaction list.
+// Submissions are recorded so tests can assert what reached the mempool.
+type fakeMempool struct {
+	mu        sync.Mutex
+	txs       []mempool.MempoolTransaction
+	addErr    error
+	submitted []submittedTx
+}
+
+func (f *fakeMempool) AddTransaction(
+	txType uint,
+	txBytes []byte,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.submitted = append(f.submitted, submittedTx{
+		txType:  txType,
+		txBytes: bytes.Clone(txBytes),
+	})
+	return nil
+}
+
+func (f *fakeMempool) GetTransaction(
+	hash string,
+) (mempool.MempoolTransaction, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, tx := range f.txs {
+		if tx.Hash == hash {
+			return tx, true
+		}
+	}
+	return mempool.MempoolTransaction{}, false
+}
+
+func (f *fakeMempool) Transactions() []mempool.MempoolTransaction {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append(
+		[]mempool.MempoolTransaction(nil), f.txs...,
+	)
+}
+
+func (f *fakeMempool) submissions() []submittedTx {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]submittedTx(nil), f.submitted...)
+}
+
+// --- server construction ------------------------------------------------
+
+// testDeps bundles the doubles handed to a test server so a test can
+// reach into them after wiring.
+type testDeps struct {
+	chain    *fakeChain
+	database *fakeDatabase
+	ledger   *fakeLedgerState
+	mempool  *fakeMempool
+}
+
+// newTestDeps returns doubles with no configured behavior.
+func newTestDeps() *testDeps {
+	return &testDeps{
+		chain:    &fakeChain{},
+		database: &fakeDatabase{},
+		ledger:   &fakeLedgerState{},
+		mempool:  &fakeMempool{},
+	}
+}
+
+// serverOption mutates the ServerConfig before NewServer is called.
+type serverOption func(*ServerConfig)
+
+// newTestServer builds a Server over the supplied doubles. It fails the
+// test if construction fails, so callers testing validation errors should
+// call NewServer directly.
+func newTestServer(
+	t *testing.T,
+	deps *testDeps,
+	opts ...serverOption,
+) *Server {
+	t.Helper()
+	cfg := ServerConfig{
+		LedgerState:         deps.ledger,
+		Database:            deps.database,
+		Chain:               deps.chain,
+		Mempool:             deps.mempool,
+		Network:             testNetwork,
+		NetworkMagic:        testNetworkMagic,
+		GenesisHash:         testGenesisHash,
+		GenesisStartTimeSec: testGenesisStartTimeSec,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+	return srv
+}
+
+// newTestHandler returns the routed handler for a server built over the
+// supplied doubles, plus the doubles themselves.
+func newTestHandler(
+	t *testing.T,
+	deps *testDeps,
+	opts ...serverOption,
+) http.Handler {
+	t.Helper()
+	srv := newTestServer(t, deps, opts...)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+	return mux
+}
+
+// --- request helpers ----------------------------------------------------
+
+// testNetworkID returns the NetworkIdentifier accepted by a test server.
+func testNetworkID() *NetworkIdentifier {
+	return &NetworkIdentifier{
+		Blockchain: blockchain,
+		Network:    testNetwork,
+	}
+}
+
+// postJSON marshals body and posts it to path.
+func postJSON(
+	t *testing.T,
+	h http.Handler,
+	path string,
+	body any,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	return postRaw(t, h, path, string(raw))
+}
+
+// postRaw posts an unmarshaled request body, for malformed-input cases.
+func postRaw(
+	t *testing.T,
+	h http.Handler,
+	path string,
+	body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(
+		http.MethodPost, path, bytes.NewBufferString(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// decodeResponse decodes a successful JSON response into T, asserting
+// the 200 status first so a failure reports the endpoint's error body.
+func decodeResponse[T any](
+	t *testing.T,
+	rec *httptest.ResponseRecorder,
+) *T {
+	t.Helper()
+	require.Equal(
+		t, http.StatusOK, rec.Code,
+		"unexpected status, body: %s", rec.Body.String(),
+	)
+	require.Equal(
+		t,
+		"application/json",
+		rec.Header().Get("Content-Type"),
+	)
+	var out T
+	require.NoError(
+		t, json.Unmarshal(rec.Body.Bytes(), &out),
+	)
+	return &out
+}
+
+// requireMeshError asserts that the response is the given Mesh error
+// with the given HTTP status, and returns the decoded error so callers
+// can inspect its details.
+func requireMeshError(
+	t *testing.T,
+	rec *httptest.ResponseRecorder,
+	want *Error,
+	wantStatus int,
+) *Error {
+	t.Helper()
+	require.Equal(
+		t, wantStatus, rec.Code,
+		"unexpected status, body: %s", rec.Body.String(),
+	)
+	var got Error
+	require.NoError(
+		t, json.Unmarshal(rec.Body.Bytes(), &got),
+	)
+	require.Equal(t, want.Code, got.Code)
+	require.Equal(t, want.Message, got.Message)
+	require.Equal(t, want.Retriable, got.Retriable)
+	return &got
+}
+
+// --- fixture builders ---------------------------------------------------
+
+// mustDecodeHex decodes a hex string or fails the test.
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+// hexString hex-encodes bytes for comparison against response fields.
+func hexString(b []byte) string { return hex.EncodeToString(b) }
+
+// testHash returns a deterministic 32-byte hash seeded by b.
+func testHash(b byte) []byte {
+	h := make([]byte, 32)
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// testKeyHash returns a deterministic 28-byte credential hash.
+func testKeyHash(b byte) []byte {
+	h := make([]byte, 28)
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// testAddress builds a bech32 testnet address from raw credentials.
+func testAddress(
+	t *testing.T,
+	addrType uint8,
+	payment []byte,
+	staking []byte,
+) string {
+	t.Helper()
+	addr, err := lcommon.NewAddressFromParts(
+		addrType,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		staking,
+	)
+	require.NoError(t, err)
+	return addr.String()
+}
+
+// testUtxo builds a UTxO owned by a key-only testnet address.
+func testUtxo(
+	txID []byte,
+	idx uint32,
+	lovelace uint64,
+	paymentKey []byte,
+	assets []models.Asset,
+) models.Utxo {
+	return models.Utxo{
+		TxId:       txID,
+		OutputIdx:  idx,
+		Amount:     types.Uint64(lovelace),
+		PaymentKey: paymentKey,
+		Assets:     assets,
+	}
+}
+
+// testAsset builds a native asset holding.
+func testAsset(
+	policyID []byte,
+	name []byte,
+	amount uint64,
+) models.Asset {
+	return models.Asset{
+		PolicyId: policyID,
+		Name:     name,
+		Amount:   types.Uint64(amount),
+	}
+}
+
+// --- transaction fixtures -----------------------------------------------
+
+// testTxBody encodes a minimal Conway transaction body spending the
+// given inputs into the given outputs. It mirrors the body shape
+// produced by /construction/payloads so fixtures and the construction
+// flow stay in agreement.
+func testTxBody(
+	t *testing.T,
+	inputs []shelley.ShelleyTransactionInput,
+	outputs []babbage.BabbageTransactionOutput,
+	fee uint64,
+) []byte {
+	t.Helper()
+	body := conway.ConwayTransactionBody{
+		TxInputs: conway.NewConwayTransactionInputSet(
+			inputs,
+		),
+		TxOutputs: outputs,
+		TxFee:     fee,
+	}
+	bodyCbor, err := cbor.Encode(&body)
+	require.NoError(t, err)
+	return bodyCbor
+}
+
+// testSignedTx wraps an encoded body in the signed-transaction envelope
+// [body, witness_set, is_valid, auxiliary_data].
+func testSignedTx(
+	t *testing.T,
+	bodyCbor []byte,
+	witnesses []lcommon.VkeyWitness,
+) []byte {
+	t.Helper()
+	signed := []any{
+		cbor.RawMessage(bodyCbor),
+		map[int]any{0: witnesses},
+		true,
+		nil,
+	}
+	txCbor, err := cbor.Encode(signed)
+	require.NoError(t, err)
+	return txCbor
+}
+
+// testOutput builds a lovelace-only transaction output.
+func testOutput(
+	t *testing.T,
+	address string,
+	lovelace uint64,
+) babbage.BabbageTransactionOutput {
+	t.Helper()
+	addr, err := lcommon.NewAddress(address)
+	require.NoError(t, err)
+	return babbage.BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount: mary.MaryTransactionOutputValue{
+			Amount: lovelace,
+		},
+	}
+}
+
+// testKeyPair returns a deterministic ed25519 key pair. The seed byte
+// keeps separate signers distinguishable within a test.
+func testKeyPair(
+	t *testing.T,
+	seed byte,
+) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	seedBytes := make([]byte, ed25519.SeedSize)
+	for i := range seedBytes {
+		seedBytes[i] = seed
+	}
+	priv := ed25519.NewKeyFromSeed(seedBytes)
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	require.True(t, ok)
+	return pub, priv
+}
+
+// testSimpleSignedTx builds a signed single-input, single-output
+// transaction and returns its CBOR alongside the decoded transaction.
+func testSimpleSignedTx(
+	t *testing.T,
+	address string,
+) ([]byte, gledger.Transaction) {
+	t.Helper()
+	pub, _ := testKeyPair(t, 0x42)
+	bodyCbor := testTxBody(
+		t,
+		[]shelley.ShelleyTransactionInput{
+			shelley.NewShelleyTransactionInput(
+				hexString(testHash(0xd1)), 0,
+			),
+		},
+		[]babbage.BabbageTransactionOutput{
+			testOutput(t, address, 1_000_000),
+		},
+		170_000,
+	)
+	txCbor := testSignedTx(
+		t,
+		bodyCbor,
+		[]lcommon.VkeyWitness{
+			{
+				Vkey:      pub,
+				Signature: make([]byte, 64),
+			},
+		},
+	)
+	txType, err := gledger.DetermineTransactionType(txCbor)
+	require.NoError(t, err)
+	tx, err := gledger.NewTransactionFromCbor(txType, txCbor)
+	require.NoError(t, err)
+	return txCbor, tx
+}
+
+// testTxBodyWithCerts encodes a Conway body carrying certificates
+// alongside a single input and output, for exercising the certificate
+// paths in the operation converter.
+func testTxBodyWithCerts(
+	t *testing.T,
+	address string,
+	certs []lcommon.CertificateWrapper,
+) []byte {
+	t.Helper()
+	body := conway.ConwayTransactionBody{
+		TxInputs: conway.NewConwayTransactionInputSet(
+			[]shelley.ShelleyTransactionInput{
+				shelley.NewShelleyTransactionInput(
+					hexString(testHash(0xd2)), 0,
+				),
+			},
+		),
+		TxOutputs: []babbage.BabbageTransactionOutput{
+			testOutput(t, address, 1_000_000),
+		},
+		TxFee:          170_000,
+		TxCertificates: certs,
+	}
+	bodyCbor, err := cbor.Encode(&body)
+	require.NoError(t, err)
+	return bodyCbor
+}
+
+// ed25519Sign signs message with an ed25519 private key.
+func ed25519Sign(priv []byte, message []byte) []byte {
+	return ed25519.Sign(ed25519.PrivateKey(priv), message)
+}
+
+// testPParams returns Conway protocol parameters with every rational
+// field populated, so conversion to the utxorpc representation (which
+// rejects nil rationals) succeeds.
+func testPParams(
+	minFeeA uint,
+	minFeeB uint,
+) *conway.ConwayProtocolParameters {
+	rat := func(num, denom int64) *cbor.Rat {
+		return &cbor.Rat{Rat: big.NewRat(num, denom)}
+	}
+	return &conway.ConwayProtocolParameters{
+		MinFeeA:            minFeeA,
+		MinFeeB:            minFeeB,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2_000_000,
+		PoolDeposit:        500_000_000,
+		MaxEpoch:           18,
+		NOpt:               150,
+		A0:                 rat(3, 10),
+		Rho:                rat(3, 1000),
+		Tau:                rat(2, 10),
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 10,
+		},
+		MinPoolCost:    170_000_000,
+		AdaPerUtxoByte: 4310,
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  rat(577, 10000),
+			StepPrice: rat(721, 10000000),
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 14_000_000,
+			Steps:  10_000_000_000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62_000_000,
+			Steps:  20_000_000_000,
+		},
+		MaxValueSize:               5000,
+		CollateralPercentage:       150,
+		MaxCollateralInputs:        3,
+		MinFeeRefScriptCostPerByte: rat(15, 1),
+	}
+}
+
+// newRequest builds a request with no body for method assertions.
+func newRequest(
+	t *testing.T,
+	method string,
+	path string,
+) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(method, path, nil)
+}
+
+// recordRequest serves req against h and returns the recorder.
+func recordRequest(
+	h http.Handler,
+	req *http.Request,
+) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newDiscardWriter returns a writer that drops everything written to
+// it, for silencing component loggers in tests.
+func newDiscardWriter() io.Writer { return io.Discard }

--- a/api/mesh/testsupport_test.go
+++ b/api/mesh/testsupport_test.go
@@ -511,6 +511,11 @@ func testKeyPair(
 	return pub, priv
 }
 
+// testSignerSeed is the key seed testSimpleSignedTx signs with. Tests
+// asserting on the resulting signer identity derive the key from this
+// constant rather than repeating the value.
+const testSignerSeed = byte(0x42)
+
 // testSimpleSignedTx builds a signed single-input, single-output
 // transaction and returns its CBOR alongside the decoded transaction.
 func testSimpleSignedTx(
@@ -518,7 +523,7 @@ func testSimpleSignedTx(
 	address string,
 ) ([]byte, gledger.Transaction) {
 	t.Helper()
-	pub, _ := testKeyPair(t, 0x42)
+	pub, _ := testKeyPair(t, testSignerSeed)
 	bodyCbor := testTxBody(
 		t,
 		[]shelley.ShelleyTransactionInput{


### PR DESCRIPTION
Closes blinklabs-io/dingo#3002

## Problem

`api/mesh` holds the Mesh-compatible Rosetta server — 17 routes across network, block, account, mempool, construction, conversion, and transaction submission — and contained **no `_test.go` files at all**, while `api/blockfrost` (13 test files) and `api/utxorpc` (10) each carry a full suite. API semantics, error mapping, lifecycle behavior, rollback handling, and transaction construction had no package-level regression protection.

## What this adds

11 test files built on the package's existing dependency seams (`node_interface.go`), so no live node or network is needed:

- **Every route** — success, malformed input, not-found, and internal-error paths, plus the shared network-identifier validation exercised across all 16 routes that carry one.
- **Construction round-trip** — `preprocess → metadata → payloads → combine → parse → hash → submit` proving the stages agree on operations and transaction identifier, signed with a real ed25519 key.
- **Error contract** — stable Rosetta codes, HTTP status mapping, and response schemas pinned; every advertised error in `/network/options` checked against `AllErrors()`.
- **Historical and reorg cases** — balances pinned by index and by hash, unresolvable and rolled-back points, and blocks that resolve to a replacement at the same height after a rollback.
- **Submission** — accepted and rejected mempool outcomes, asserting the exact submitted bytes reach the mempool unmodified.
- **Listener** — bind failure, double start, graceful shutdown, context-cancel shutdown, CORS preflight (allowed and refused origins), and the request cap at its exact boundary.
- **Provider** — registration, listen-address composition, dependency propagation, and capability shutdown closing the listener.
- **Adapter** — run against a real badger+sqlite database, since that is the only place Mesh meets storage.

Coverage: **0% → 96.7%** of statements. `go test -race ./api/mesh/...` passes.

## Three defects found while writing them

**1. `/block` index numbering was off by one.** The response reports `block_identifier.index` as the Cardano block height, but the request path passed that value straight to the blob store's 1-based block index. A client feeding a returned index back into `/block` received the block below it, and height 0 never resolved at all.

`meshDatabaseAdapter.BlockByIndex` now translates height to internal index — the same translation `api/blockfrost/adapter.go` (block-by-height lookup) and `midnight/server/adapter.go` already perform with explanatory comments, and which `ARCHITECTURE.md` already described this adapter as doing.

**2. `/account/balance` ignored `block_identifier`.** It accepted the field and answered from the current tip, silently misreporting the account under a point the node never queried — the opposite of the "pinned to the requested point" behavior the issue asks for.

It now resolves the requested block through the same lookup `/block` uses, reads the UTxO set at that block's slot via `LedgerState.UtxosByAddressAtSlot`, and echoes the resolved block back as the response's `block_identifier`. An unresolvable point, including the hash of a rolled-back block, fails with block-not-found rather than falling back. `/network/options` now advertises `historical_balance_lookup: true`, and a test ties that flag to the endpoint's actual behavior, since the two drifting apart is itself a contract break. `/account/coins` is unchanged — the Rosetta schema gives it no block identifier.

**3. `TestProviderDefaultPort` could not fail.** It hardcoded `8080` into the config it built and asserted `8080` came back, never reading the default `RegisterProvider` registers. The default now has one definition (`defaultProviderPort` / `providerDefaults`) that both `RegisterProvider` and the test consume; mutation-checked by changing the constant and confirming the test fails.

## Acceptance criteria

All met except the listener tests for **TLS handshake, missing credentials, and valid credentials**, which cannot be written against `main`: `ServerConfig` has no TLS or auth fields yet. That surface is added by #3162 (issue #2996), which also adds `api/mesh/mesh_test.go` carrying exactly those tests. This PR deliberately avoids that filename and names its doubles `fake*` rather than `stub*` so the two merge without conflict.

## Docs

- `ARCHITECTURE.md` — the Mesh section was a two-line stub; it now documents the dependency-interface boundary and the two contracts this change pins (block-height numbering, historical balance pinning).
- `DATABASE.md` — checked, not affected. No schema, blob key layout, query surface, or encoding changed.

## Testing

`go test -race ./api/... ./midnight/...` green. `internal/test/conformance` passes. `golangci-lint` (0 issues), `nilaway`, `modernize`, `golines`, `make import-boundaries`, `make docs-parity`, `make gorm-check` all clean; `sql-check` not applicable.

Tests use `internal/test/testutil` for synchronization and contain no `time.Sleep`.

DevNet was not run: this touches no consensus, block production, or protocol path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)