### PR TITLE
test(devnet): add an event-driven accelerated release scenario

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -928,6 +928,22 @@ All event types follow the `subsystem.snake_case_name` convention.
   worker pool means it also delays unrelated async event types. Consumers of
   `Subscribe` channels must drain for the life of the subscription and
   `Unsubscribe` when they stop
+- **Never `Publish` while holding a lock that a subscriber of that event
+  acquires.** Because delivery blocks rather than drops, this is a deadlock,
+  not merely a slow path: once the subscriber's buffer fills, the subscriber
+  waits for the lock the publisher holds while the publisher waits for the
+  capacity the subscriber would free. `ledger`'s `pendingPublishes`
+  (`ledger/pending_publish.go`) is the pattern for this — queue the event under
+  the lock and flush after the unlock, registering the flush with `defer`
+  *before* taking the lock so LIFO order runs it last. The invariant is
+  enforced for `chainsyncMutex` by `TestNoEventBusPublishWhileHoldingChainsyncMutex`
+- The blast radius of such a stall is not local. `LedgerState.handleConnectionClosedEvent`
+  takes `chainsyncMutex`, so a stall there stops `ledger.conn_closed` draining;
+  the `node.go` handler translating `connmanager.conn_closed` into
+  `ledger.conn_closed` then blocks inside its own callback, which stops
+  `connmanager.conn_closed` draining, and every subsequent connection close
+  parks another publisher goroutine. Handlers that re-publish are therefore
+  coupling two topics' backpressure and must not block
 - Prometheus metrics for event delivery tracking and latency, including
   `event_delivery_blocked_total{type,kind}` and
   `event_async_enqueue_blocked_total{type}` for backpressure

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -935,7 +935,18 @@ All event types follow the `subsystem.snake_case_name` convention.
   publisher holds while the publisher waits for the capacity the subscriber
   would free. `PublishAsync` is no exception — it waits for room in the shared
   async queue, which is drained by a worker pool running subscriber handlers,
-  so a handler blocked on the publisher's lock closes the same cycle. `ledger`'s `pendingPublishes`
+  so a handler blocked on the publisher's lock closes the same cycle. Both
+  `LedgerState.chainsyncMutex` and `chainsyncBlockfetchMutex` count:
+  `RecoverAfterLocalRollback` takes the first and nests the second inside it,
+  so holding either while publishing is enough to deadlock.
+- The rule is not yet fully enforced in `ledger`. Several helpers reachable
+  from a lock holder still publish `ChainsyncResyncEventType` inline; they are
+  pinned in `knownResyncPublishPathsUnderLock`
+  (`ledger/publish_under_lock_test.go`) and tracked for conversion, which has
+  to happen as one change because a helper flushing on its own return still
+  publishes while a parent frame holds the lock. Read the rule as the target
+  state plus an explicit exception list, not as an invariant already holding
+  everywhere in that package. `ledger`'s `pendingPublishes`
   (`ledger/pending_publish.go`) is the pattern for this — queue the event under
   the lock and flush after the unlock, registering the flush with `defer`
   *before* taking the lock so LIFO order runs it last. The invariant is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -928,11 +928,14 @@ All event types follow the `subsystem.snake_case_name` convention.
   worker pool means it also delays unrelated async event types. Consumers of
   `Subscribe` channels must drain for the life of the subscription and
   `Unsubscribe` when they stop
-- **Never `Publish` while holding a lock that a subscriber of that event
-  acquires.** Because delivery blocks rather than drops, this is a deadlock,
-  not merely a slow path: once the subscriber's buffer fills, the subscriber
-  waits for the lock the publisher holds while the publisher waits for the
-  capacity the subscriber would free. `ledger`'s `pendingPublishes`
+- **Never `Publish`, `PublishAsync`, or `PublishBlocking` while holding a lock
+  that a subscriber of that event acquires.** Because all three wait for
+  capacity rather than dropping, this is a deadlock, not merely a slow path:
+  once the subscriber's buffer fills, the subscriber waits for the lock the
+  publisher holds while the publisher waits for the capacity the subscriber
+  would free. `PublishAsync` is no exception — it waits for room in the shared
+  async queue, which is drained by a worker pool running subscriber handlers,
+  so a handler blocked on the publisher's lock closes the same cycle. `ledger`'s `pendingPublishes`
   (`ledger/pending_publish.go`) is the pattern for this — queue the event under
   the lock and flush after the unlock, registering the flush with `defer`
   *before* taking the lock so LIFO order runs it last. The invariant is

--- a/event/doc.go
+++ b/event/doc.go
@@ -43,7 +43,12 @@
 // backpressure never trades event loss for unbounded memory.
 //
 // The practical consequence is that a subscriber which stops draining
-// stalls its publishers. Subscribers that take a channel from Subscribe
+// stalls its publishers. It also means a publisher must not hold a lock
+// that a subscriber of the same event acquires: once the buffer fills,
+// the subscriber waits for the lock and the publisher waits for the
+// capacity the subscriber would free, and neither proceeds. Queue such
+// events and publish them after releasing the lock (see ledger's
+// pendingPublishes). Subscribers that take a channel from Subscribe
 // must drain it for as long as they hold the subscription and must
 // Unsubscribe when they stop. A delivery parked for a long time is
 // reported by the event_delivery_blocked_total metric and an "event

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -374,7 +374,7 @@ harness and the compose port mappings always agree.
 |------------------------------|---------|
 | `docker-compose.yml`         | Service, volume, and network definitions for both the `dingo` and `conformance` profiles |
 | `Dockerfile.configurator`    | Builds the genesis/key generator image (cardano-foundation/testnet-generation-tool v0.1.0) |
-| `configurator.sh`            | Runs inside the configurator: drives `genesis-cli.py`, builds ring topology (mode-aware pool count via `DINGO_POOL_IDS`), sets `systemStart`, relaxes key permissions for non-root node containers |
+| `configurator.sh`            | Runs inside the configurator: drives `genesis-cli.py`, builds ring topology (mode-aware pool count via `DINGO_POOL_IDS`), sets `systemStart`, relaxes key permissions for non-root node containers and chowns each Dingo pool's keys to `DINGO_UID`/`DINGO_GID` (passed in by compose, defaulting to the `1000:1000` pinned in the repo root `Dockerfile`) |
 | `testnet-dingo.yaml`         | Network spec for dingo mode: 3 pools, `poolPledge: 0` |
 | `testnet.yaml`               | Network spec for conformance mode: 2 pools |
 | `topology/dingo-1.json`, `dingo-2.json`, `dingo-3.json`, `dingo-relay.json` | Static peer lists for dingo mode |

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -198,8 +198,10 @@ standalone.
 ```bash
 ./start.sh               # dingo mode (default): 3 producers + relay
 ./start.sh --conformance # conformance mode: dingo + cardano-node
+./start.sh --accelerated # bring the network up on the accelerated spec
 ./stop.sh                 # tear down the default dingo network
 ./stop.sh --conformance   # tear down the conformance network
+./stop.sh --accelerated   # accepted and ignored; teardown is spec-independent
 ```
 
 Both scripts set `COMPOSE_PROFILES` for you (`dingo` or `conformance`), so
@@ -397,7 +399,7 @@ and queries delegations + reward balances via
 `GetFilteredDelegationsAndRewardAccounts`.
 
 This TCP-based approach replaced an earlier unix-socket host bind-mount
-design: the Dingo image runs as uid 100 and cannot bind a socket inside a
+design: the Dingo image runs as uid 1000 and cannot bind a socket inside a
 host-owned bind mount, so the in-container socket (used by `txpump` and the
 healthcheck) stays on a named Docker volume, and the host harness talks NtC
 over TCP instead. There is no host socket bind mount and no

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -21,9 +21,16 @@ Two networks are available, selected by a Docker Compose profile:
 The Go test harness lives alongside this directory: `internal/test/devnet/`
 (helpers and config loader at the top level, runnable scenarios under
 `internal/test/devnet/scenarios/`). The layout mirrors
-`internal/test/antithesis/`. All test files are gated by the `devnet` build
-tag; conformance-only tests additionally require `devnet_conformance` (see
-Test scenarios below).
+`internal/test/antithesis/`. Everything that talks to a running network is
+gated by the `devnet` build tag, and conformance-only tests additionally
+require `devnet_conformance` (see Test scenarios below).
+
+The pure logic the harness is built on — the network-spec loader and its
+validation, the observed-chain state machine, and the scenario plan — is
+deliberately **not** tagged, so its unit tests run in the ordinary
+`go test ./...` with no Docker involved. That is what keeps an invalid
+accelerated spec or a broken rollback rule from only surfacing as a
+mysterious DevNet stall.
 
 ## Topology — dingo mode (default)
 
@@ -83,6 +90,38 @@ Dingo mode differs in pool count and pledge: `poolCount: 3`, `poolPledge: 0`,
 `delegatedSupply: 2100000000000` (divisible by 3, required by the
 generator). The zero pledge is deliberate — it's what makes the CIP-50
 pledge-leverage scenario meaningful (see Test scenarios below).
+
+### Accelerated network parameters
+
+`--accelerated` swaps the network spec for a compressed-timing variant —
+`testnet-dingo-accelerated.yaml` (dingo mode) or `testnet-accelerated.yaml`
+(conformance mode) — so a whole scenario fits the reference-runner budget:
+
+- `epochLength: 120` slots, `slotLength: 0.5s` → **60s epochs**
+- `activeSlotsCoeff: 0.4`, `securityParam (k): 10` → a block every ~1.25s
+- Byron `protocolConsts.k` tracks `securityParam`
+- Everything else (network magic, hard forks at epoch 0, supply) matches
+  the canonical specs.
+
+Shortening an epoch is only safe if the stability windows still fit inside
+it, and both are derived from `k` and `f` rather than configured directly:
+
+| Window | Formula | Accelerated | Canonical |
+|--------|---------|-------------|-----------|
+| nonce stability | `4k/f` | 100 slots | 400 slots |
+| blockfetch stability | `3k/f` | 75 slots | 300 slots |
+| epoch length | — | 120 slots | 500 slots |
+
+`DevNetConfig.Validate()` enforces `4k/f < epochLength` and
+`3k/f < epochLength`, and `TestCheckedInSpecsAreValid` in
+`internal/test/devnet/config_test.go` runs it against every checked-in
+spec. That test carries **no build tag**, so an edit that shrinks an epoch
+without shrinking `k` fails in the ordinary `go test ./...` run instead of
+turning into a DevNet stall nobody can explain.
+
+The canonical specs are deliberately *not* accelerated: they are what soak
+and canary runs use, and `TestCanonicalSpecsKeepCanonicalTiming` fails if
+someone quietly speeds them up.
 
 ## Prerequisites
 
@@ -200,6 +239,8 @@ node's NtC endpoint.
 ```bash
 ./run-tests.sh                              # dingo mode (default): bring up, run devnet tests, tear down
 ./run-tests.sh --conformance                 # conformance mode: dingo + cardano-node
+./run-tests.sh --accelerated                # fast event-driven scenario timeline (see below)
+./run-tests.sh --accelerated --conformance  # the same timeline against the reference topology
 ./run-tests.sh -run TestBasicBlockForging   # forward -run (and other flags) to `go test`
 ./run-tests.sh --keep-up                    # leave the network running on success (for poking around)
 DEVNET_MEMPOOL_PROVIDER=dag ./run-tests.sh  # exercise the DAG mempool on every Dingo node
@@ -223,9 +264,113 @@ What it does:
    ./internal/test/devnet/...` — `devnet` alone in dingo mode, `devnet
    devnet_conformance` in conformance mode.
 6. Tears the network down. On failure it dumps the last 100 lines of compose
-   logs first. It also checks that `txpump` logged at least one accepted
-   submission; zero accepted submissions fails the run even if the Go tests
-   passed.
+   logs first, then preserves the full failure evidence (see Failure
+   artifacts below). It also checks that `txpump` logged at least one
+   accepted submission; zero accepted submissions fails the run even if the
+   Go tests passed.
+
+It also exports `DEVNET_TESTNET_YAML` pointing at the spec it actually
+brought the network up with, so `devnet.LoadDevNetConfig()` in the tests
+reads the same parameters the configurator generated genesis from rather
+than falling back to `testnet.yaml`.
+
+## Accelerated scenario timeline
+
+`--accelerated` is the fast path used for scheduled and release
+integration evidence. It brings the network up on the accelerated spec and
+runs one test — `TestAcceleratedScenarioTimeline` — instead of the full
+suite.
+
+What makes it fast is not just the shorter slots. The canonical suite
+queries each node's tip by opening a fresh Node-to-Node connection every
+couple of seconds, because a short-lived ChainSync client only ever
+reports the tip it captured when it intersected. The accelerated scenario
+instead opens **one persistent ChainSync session per node** and follows
+the chain, so `RollForward` and `RollBackward` arrive as the nodes produce
+them. Assertions are then conditions over those observed events bounded by
+a context deadline — there is no polling interval and no `time.Sleep`
+anywhere in the synchronisation path.
+
+The second difference is that every assertion shares **one timeline**.
+Each phase's deadline is measured from the scenario's start rather than
+from the end of the previous phase, so a phase that finishes early hands
+its slack forward instead of each test paying for its own relative slot
+window:
+
+| Phase | What it verifies |
+|-------|-------------------|
+| `readiness` | Every node accepted a ChainSync session and sent a header |
+| `propagation` | A block forged after the baseline reaches every node, including the relay, with matching hashes; and one carrying transactions does too |
+| `agreement` | Every node agrees on the block hash at the deepest slot they have all observed |
+| `epoch-transition` | The chain crosses the next epoch boundary and the nodes agree on a header built above it (exercising the new epoch nonce) |
+| `peer-interruption` | A producer is stopped, the network visibly advances without it, and it rejoins and reconverges |
+| `relay-restart` | The same for the relay |
+
+Both disruption phases hold the node down until the rest of the network
+has advanced a derived number of blocks — `k/2`, so the outage stays
+inside what the security parameter can reconcile — rather than for a fixed
+wall-clock time. That keeps the disruption equally meaningful on a fast
+and a slow runner.
+
+The whole schedule is derived from the network spec by
+`devnet.NewScenarioPlan`. For the accelerated spec it works out as
+`readiness<=45s propagation<=1m10s agreement<=1m22.5s
+epoch-transition<=2m50s peer-interruption<=3m33.75s relay-restart<=4m17.5s`
+— a **4m17.5s** worst case against a **5-minute hard timeout**. Those are
+ceilings, not expected times; the run ends as soon as the last condition
+is observed. Both bounds are asserted
+without Docker by `TestAcceleratedPlanFitsReferenceBudgetAndCanonicalDoesNot`,
+which also asserts that the canonical spec does *not* fit — so the fast
+scenario can never be quietly pointed at the soak configuration.
+
+Reference runner: a 4-vCPU / 16 GB Linux runner (GitHub Actions
+`ubuntu-latest` class) with images already built. Image build time is
+excluded from the budget; `run-tests.sh` rebuilds before starting, and the
+scenario's clock only starts once the containers are healthy.
+
+The scenario runs in **both topologies**: it derives the producer it
+interrupts and the relay it restarts from `LoadEndpoints()`, so
+`--accelerated` gives the all-Dingo network and `--accelerated
+--conformance` gives Dingo beside `cardano-node`. In both cases the node
+it interrupts is the last producer, which is never the node `txpump`
+submits to, so mempool traffic keeps flowing through the outage.
+
+To drive it by hand against a network you brought up yourself:
+
+```bash
+./start.sh --accelerated
+DEVNET_ACCELERATED=1 \
+  DEVNET_TESTNET_YAML=$PWD/testnet-dingo-accelerated.yaml \
+  DEVNET_COMPOSE_FILE=$PWD/docker-compose.yml \
+  go test -tags devnet -run TestAcceleratedScenarioTimeline -timeout 8m \
+  ./internal/test/devnet/scenarios/
+./stop.sh --accelerated
+```
+
+`TestAcceleratedScenarioTimeline` skips unless `DEVNET_ACCELERATED=1` is
+set, so it never runs against the canonical-timing network, where its
+budget could not be met.
+
+## Failure artifacts
+
+When a run fails, `run-tests.sh` keeps `DEVNET_ARTIFACT_DIR` (a temp
+directory it creates, or one you set) and prints its path instead of
+deleting it. On success the directory is removed.
+
+| Path | Contents |
+|------|----------|
+| `network/container-status.txt` | `docker compose ps --all` for the profile |
+| `network/compose.log` | Full compose logs for every service |
+| `network/generated-configs/` | The genesis and node configuration the configurator generated |
+| `network/testnet*.yaml` | The network spec the run used |
+| `accelerated-timeline/observed-chains.json` | Every node's observed chain: tip, retained headers, roll-forward/roll-backward counts, deepest rollback, connect/disconnect churn |
+| `accelerated-timeline/container-status.txt` | Container status as the scenario saw it |
+| `accelerated-timeline/<service>.log` | Per-service logs captured by the scenario |
+
+The `accelerated-timeline/` entries are written by the scenario itself
+through `NodeControl.CaptureFailureArtifacts`, so the observed chain
+events survive even though the network is torn down immediately
+afterwards.
 
 The harness reads endpoint addresses from mode-specific environment
 variables that `run-tests.sh` sets based on the host port mappings (dingo
@@ -316,6 +461,7 @@ mode:
 | `TestRelayPropagation` | Blocks reach the non-forging relay |
 | `TestSustainedConsensus` | All nodes stay in agreement across multiple sampling intervals |
 | `TestEpochBoundaryConsensus` | All nodes remain in consensus across at least one epoch boundary (exercises candidate-nonce freeze, lab nonce roll, and new-epoch VRF verification) |
+| `TestAcceleratedScenarioTimeline` | The accelerated scenario timeline: readiness, block and transaction propagation, chain agreement, an epoch transition, a peer interruption with recovery, and a relay restart — all on one shared clock, driven by streamed ChainSync events. Skipped unless `DEVNET_ACCELERATED=1`; see Accelerated scenario timeline above. |
 
 Reference-conformance scenario (`//go:build devnet && devnet_conformance`),
 runs only with `--conformance`:
@@ -375,15 +521,22 @@ harness and the compose port mappings always agree.
 | `docker-compose.yml`         | Service, volume, and network definitions for both the `dingo` and `conformance` profiles |
 | `Dockerfile.configurator`    | Builds the genesis/key generator image (cardano-foundation/testnet-generation-tool v0.1.0) |
 | `configurator.sh`            | Runs inside the configurator: drives `genesis-cli.py`, builds ring topology (mode-aware pool count via `DINGO_POOL_IDS`), sets `systemStart`, relaxes key permissions for non-root node containers and chowns each Dingo pool's keys to `DINGO_UID`/`DINGO_GID` (passed in by compose, defaulting to the `1000:1000` pinned in the repo root `Dockerfile`) |
-| `testnet-dingo.yaml`         | Network spec for dingo mode: 3 pools, `poolPledge: 0` |
-| `testnet.yaml`               | Network spec for conformance mode: 2 pools |
+| `testnet-dingo.yaml`         | Canonical network spec for dingo mode: 3 pools, `poolPledge: 0` |
+| `testnet.yaml`               | Canonical network spec for conformance mode: 2 pools |
+| `testnet-dingo-accelerated.yaml` | Accelerated dingo-mode spec: 60s epochs, `k: 10`, 0.5s slots |
+| `testnet-accelerated.yaml`   | Accelerated conformance-mode spec: same timing, 2 pools |
 | `topology/dingo-1.json`, `dingo-2.json`, `dingo-3.json`, `dingo-relay.json` | Static peer lists for dingo mode |
 | `topology/dingo-producer.json`, `cardano-producer.json`, `relay.json` | Static peer lists for conformance mode |
 | `.env`                       | Sets the default `COMPOSE_PROFILES=dingo` |
 | `start.sh` / `stop.sh`       | Convenience wrappers around `docker compose up -d` / `down -v`; accept `--conformance` |
 | `run-tests.sh`               | Full bring-up → test → tear-down cycle used by CI; accepts `--conformance`, `--keep-up`, and forwards other flags to `go test` |
 | `../antithesis/Dockerfile.txpump`, `../antithesis/cmd/txpump/` | Source for the `txpump` load generator image |
-| `harness.go`, `config.go`    | Go test harness package: Ouroboros NtN client, tip queries, consensus checks, `testnet*.yaml` loader (build tag `devnet`) |
+| `harness.go`                 | Go test harness: Ouroboros NtN client, tip queries, consensus checks, and the `WaitForChainStart` genesis gate (build tag `devnet`) |
+| `config.go`                  | `testnet*.yaml` loader, derived timings, and spec validation (**no build tag** — its tests run in the ordinary `go test ./...`) |
+| `chainstate.go`              | Observed-chain state machine: applies RollForward/RollBackward, tracks tip and retained headers, and exposes cross-node agreement helpers and bounded-context conditions (**no build tag**) |
+| `timeline.go`                | `ScenarioPlan`: derives the accelerated scenario's phases, deadlines, outage length, and hard timeout from the network spec (**no build tag**) |
+| `observer.go`                | Persistent per-node ChainSync sessions feeding `chainstate.go`, with automatic reconnect across container restarts (build tag `devnet`) |
+| `nodectl.go`                 | Stops/starts compose services for the disruption phases and captures failure artifacts (build tag `devnet`) |
 | `endpoints_dingo.go`         | Dingo-mode node endpoints and NtC addresses (`//go:build devnet && !devnet_conformance`) |
 | `endpoints_conformance.go`   | Conformance-mode node endpoints (`//go:build devnet && devnet_conformance`) |
 | `lsq.go`                     | `RewardAccountsByNtc` / `RewardAccountsByNtcForCreds`: LocalStateQuery over NtC TCP (build tag `devnet`) |
@@ -419,6 +572,27 @@ docker volume ls | grep devnet                       # inspect leftovers
 - Dingo image is stale. `run-tests.sh` rebuilds the active profile's Dingo
   images on every invocation; for `start.sh` runs, force a rebuild with
   `docker compose -f docker-compose.yml build` (scoped by `COMPOSE_PROFILES`).
+- A single scenario fails on its own but the whole suite passes. Every
+  scenario now calls `WaitForChainStart` before taking a baseline, so this
+  should no longer happen. The cause was that the configurator schedules
+  `systemStart` 30s after it exits while the compose health checks pass as
+  soon as a node opens its socket: a node answers tip queries reporting
+  slot 0 / block 0 for that whole window. Timeouts derived from slot
+  counts only measure chain time, so charging one against the pre-genesis
+  wait expired it before the chain produced anything — and a test only
+  passed because an earlier one in the package had already absorbed the
+  wait. If you add a scenario, gate it on `WaitForChainStart` rather than
+  relying on ordering.
+- `TestAcceleratedScenarioTimeline` skips. It requires
+  `DEVNET_ACCELERATED=1`, which `run-tests.sh --accelerated` sets. Running
+  it against the canonical-timing network is deliberately prevented: its
+  phase budgets are derived from the spec and cannot be met at
+  `epochLength: 500`, `slotLength: 1s`.
+- The accelerated scenario fails at `NewNodeControl`. It needs to reach
+  Docker Compose to stop and start nodes. Run it through `run-tests.sh`,
+  which exports `DEVNET_COMPOSE_FILE`, or set that variable yourself. It
+  fails rather than skipping the disruption phases on purpose — a pass
+  that quietly omitted them would not be release evidence.
 - `TestCIP50PledgeLeverageRewardEffect` skips. It requires
   `DEVNET_CIP50_TEST=1` and a non-empty `DEVNET_STAKE_KEYS_DIR` to run at
   all, and needs two separately launched networks (leverage off, then

--- a/internal/test/devnet/chainstate.go
+++ b/internal/test/devnet/chainstate.go
@@ -1,0 +1,582 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package devnet provides a test harness for running integration tests
+// against a private Cardano DevNet consisting of Dingo and cardano-node
+// instances connected via Docker Compose.
+//
+// The chain-observation types in this file carry no build tag so the
+// state machine driving the DevNet scenarios is unit-tested on every
+// ordinary `go test ./...` run, without Docker. The pieces that dial real
+// nodes are gated behind the `devnet` tag.
+package devnet
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// maxRetainedHeaders bounds the per-node observed-header window. A
+// scenario only ever reasons about recent chain state, and an unbounded
+// slice would grow for the life of a soak run.
+const maxRetainedHeaders = 4096
+
+// ChainTip holds the chain tip information retrieved from a node.
+type ChainTip struct {
+	SlotNumber  uint64 `json:"slot"`
+	BlockNumber uint64 `json:"block"`
+	Hash        []byte `json:"hash"`
+}
+
+// ChainPoint is a slot/hash pair identifying a position on a chain. The
+// zero value is the origin.
+type ChainPoint struct {
+	Slot uint64 `json:"slot"`
+	Hash []byte `json:"hash"`
+}
+
+// IsOrigin reports whether the point refers to the chain origin, which
+// ChainSync encodes as an empty point rather than a slot/hash pair.
+func (p ChainPoint) IsOrigin() bool {
+	return p.Slot == 0 && len(p.Hash) == 0
+}
+
+// ObservedHeader is one block header seen in a ChainSync RollForward.
+type ObservedHeader struct {
+	Slot        uint64 `json:"slot"`
+	BlockNumber uint64 `json:"block"`
+	Hash        []byte `json:"hash"`
+	// BodySize is the header's declared block body size. It is what
+	// lets a scenario tell a block carrying transactions from an empty
+	// one without a node-to-client connection, which the mixed
+	// cardano-node topology does not expose.
+	BodySize uint64 `json:"bodySize"`
+}
+
+// ChainSnapshot is a consistent point-in-time copy of one node's
+// observed chain, safe to read without holding the observer's lock.
+// The json tags matter: a snapshot is what
+// NodeControl.CaptureFailureArtifacts writes to observed-chains.json, and
+// that file is often the only surviving record of what a node's chain did
+// once the DevNet has been torn down.
+type ChainSnapshot struct {
+	Node             string           `json:"node"`
+	Tip              ChainTip         `json:"tip"`
+	ServerTip        ChainTip         `json:"serverTip"`
+	Headers          []ObservedHeader `json:"headers"`
+	RollForwards     int              `json:"rollForwards"`
+	RollBackwards    int              `json:"rollBackwards"`
+	MaxRollbackDepth uint64           `json:"maxRollbackDepth"`
+	Connects         int              `json:"connects"`
+	Disconnects      int              `json:"disconnects"`
+	Connected        bool             `json:"connected"`
+	LastError        string           `json:"lastError,omitempty"`
+}
+
+// HashAt returns the observed header hash at slot, if the slot is still
+// inside the retained window.
+func (s ChainSnapshot) HashAt(slot uint64) ([]byte, bool) {
+	for _, h := range s.Headers {
+		if h.Slot == slot {
+			return h.Hash, true
+		}
+	}
+	return nil, false
+}
+
+// String renders the snapshot as a single diagnostic line. Await failures
+// embed it so a timeout says what the node was actually doing.
+func (s ChainSnapshot) String() string {
+	return fmt.Sprintf(
+		"%s{tip=slot %d/block %d, connected=%t, fwd=%d, back=%d,"+
+			" maxRollback=%d, lastErr=%q}",
+		s.Node, s.Tip.SlotNumber, s.Tip.BlockNumber, s.Connected,
+		s.RollForwards, s.RollBackwards, s.MaxRollbackDepth, s.LastError,
+	)
+}
+
+// broadcaster wakes every waiter whenever observed state changes. The
+// channel is closed and replaced rather than sent on, so any number of
+// waiters observe a single change without the signaller blocking.
+type broadcaster struct {
+	mu sync.Mutex
+	ch chan struct{}
+}
+
+func newBroadcaster() *broadcaster {
+	return &broadcaster{ch: make(chan struct{})}
+}
+
+// wait returns the channel closed by the next signal.
+func (b *broadcaster) wait() <-chan struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.ch
+}
+
+func (b *broadcaster) signal() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	close(b.ch)
+	b.ch = make(chan struct{})
+}
+
+// ObservedChain accumulates the ChainSync messages one node sends and
+// exposes them as timeout-bound conditions. It replaces polling a node's
+// tip over repeated short-lived connections: the chain view is pushed by
+// the node, so a condition becomes true as soon as the protocol event
+// that satisfies it arrives.
+//
+// All methods are safe for concurrent use; the observer goroutine writes
+// while scenario assertions read.
+type ObservedChain struct {
+	node   string
+	notify *broadcaster
+
+	mu               sync.Mutex
+	headers          []ObservedHeader
+	tip              ChainTip
+	serverTip        ChainTip
+	rollForwards     int
+	rollBackwards    int
+	maxRollbackDepth uint64
+	connects         int
+	disconnects      int
+	connected        bool
+	lastErr          string
+}
+
+// NewObservedChain returns an observer for a single named node.
+func NewObservedChain(node string) *ObservedChain {
+	return &ObservedChain{node: node, notify: newBroadcaster()}
+}
+
+// Node returns the node name this chain was observed from.
+func (c *ObservedChain) Node() string { return c.node }
+
+// RollForward records a header the node sent, extending the observed
+// chain. serverTip is the node's own reported tip from the same message.
+func (c *ObservedChain) RollForward(h ObservedHeader, serverTip ChainTip) {
+	c.mu.Lock()
+	c.headers = append(c.headers, h)
+	if len(c.headers) > maxRetainedHeaders {
+		// Retain the newest window. Copy into a fresh slice so the
+		// dropped headers become collectable instead of being pinned
+		// by the backing array.
+		trimmed := make([]ObservedHeader, maxRetainedHeaders)
+		copy(trimmed, c.headers[len(c.headers)-maxRetainedHeaders:])
+		c.headers = trimmed
+	}
+	c.tip = ChainTip{
+		SlotNumber:  h.Slot,
+		BlockNumber: h.BlockNumber,
+		Hash:        h.Hash,
+	}
+	c.serverTip = serverTip
+	c.rollForwards++
+	c.mu.Unlock()
+	c.notify.signal()
+}
+
+// RollBackward records a rollback to point, dropping every observed
+// header above it. A rollback to the origin clears the observed chain.
+//
+// The recorded depth counts dropped headers still inside the retained
+// window, so a rollback deeper than that window under-reports rather
+// than over-reports.
+func (c *ObservedChain) RollBackward(point ChainPoint, serverTip ChainTip) {
+	c.mu.Lock()
+	before := len(c.headers)
+	if point.IsOrigin() {
+		c.headers = nil
+		c.tip = ChainTip{}
+	} else {
+		keep := 0
+		for _, h := range c.headers {
+			if h.Slot > point.Slot {
+				break
+			}
+			keep++
+		}
+		c.headers = c.headers[:keep]
+		// Recover the block number from the retained chain: the
+		// rollback point is normally a header we already saw, but a
+		// point below the retained window leaves the nearest header
+		// below it as the best available answer.
+		var blockNum uint64
+		if keep > 0 {
+			blockNum = c.headers[keep-1].BlockNumber
+		}
+		c.tip = ChainTip{
+			SlotNumber:  point.Slot,
+			BlockNumber: blockNum,
+			Hash:        point.Hash,
+		}
+	}
+	// Truncation only ever shrinks the slice, so the difference is
+	// non-negative.
+	//nolint:gosec // before >= len(c.headers) by construction
+	if dropped := uint64(before - len(c.headers)); dropped >
+		c.maxRollbackDepth {
+		c.maxRollbackDepth = dropped
+	}
+	c.serverTip = serverTip
+	c.rollBackwards++
+	c.mu.Unlock()
+	c.notify.signal()
+}
+
+// Connected records that the observer established (or re-established) a
+// ChainSync session with the node.
+func (c *ObservedChain) Connected() {
+	c.mu.Lock()
+	c.connects++
+	c.connected = true
+	c.lastErr = ""
+	c.mu.Unlock()
+	c.notify.signal()
+}
+
+// Disconnected records that the ChainSync session dropped. The observed
+// chain is deliberately preserved so a reconnect resumes from it.
+func (c *ObservedChain) Disconnected(err error) {
+	c.mu.Lock()
+	c.disconnects++
+	c.connected = false
+	if err != nil {
+		c.lastErr = err.Error()
+	}
+	c.mu.Unlock()
+	c.notify.signal()
+}
+
+// Snapshot returns a deep-enough copy for assertions to read safely.
+func (c *ObservedChain) Snapshot() ChainSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	headers := make([]ObservedHeader, len(c.headers))
+	copy(headers, c.headers)
+	return ChainSnapshot{
+		Node:             c.node,
+		Tip:              c.tip,
+		ServerTip:        c.serverTip,
+		Headers:          headers,
+		RollForwards:     c.rollForwards,
+		RollBackwards:    c.rollBackwards,
+		MaxRollbackDepth: c.maxRollbackDepth,
+		Connects:         c.connects,
+		Disconnects:      c.disconnects,
+		Connected:        c.connected,
+		LastError:        c.lastErr,
+	}
+}
+
+// Await blocks until cond holds for this node's observed chain or ctx
+// expires. cond is evaluated once before waiting, then again after every
+// observed protocol event, so no polling interval is involved.
+func (c *ObservedChain) Await(
+	ctx context.Context,
+	desc string,
+	cond func(ChainSnapshot) bool,
+) error {
+	for {
+		changed := c.notify.wait()
+		snap := c.Snapshot()
+		if cond(snap) {
+			return nil
+		}
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return fmt.Errorf(
+				"devnet: %q not satisfied by %s: %w",
+				desc, snap, ctx.Err(),
+			)
+		}
+	}
+}
+
+// ChainGroup observes several nodes at once and lets a scenario wait on
+// conditions that span them. Every member shares one change broadcaster,
+// so a group wait costs a single channel receive regardless of how many
+// nodes the topology has.
+type ChainGroup struct {
+	notify *broadcaster
+	order  []string
+	chains map[string]*ObservedChain
+}
+
+// NewChainGroup returns a group observing the named nodes.
+func NewChainGroup(nodes ...string) *ChainGroup {
+	g := &ChainGroup{
+		notify: newBroadcaster(),
+		order:  make([]string, 0, len(nodes)),
+		chains: make(map[string]*ObservedChain, len(nodes)),
+	}
+	for _, n := range nodes {
+		if _, dup := g.chains[n]; dup {
+			continue
+		}
+		g.chains[n] = &ObservedChain{node: n, notify: g.notify}
+		g.order = append(g.order, n)
+	}
+	return g
+}
+
+// Chain returns the observer for a node, or nil if it is not in the
+// group.
+func (g *ChainGroup) Chain(node string) *ObservedChain {
+	return g.chains[node]
+}
+
+// Chains returns every observer in the order the group was built.
+func (g *ChainGroup) Chains() []*ObservedChain {
+	out := make([]*ObservedChain, 0, len(g.order))
+	for _, n := range g.order {
+		if c := g.chains[n]; c != nil {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Snapshots returns one snapshot per node, in group order.
+func (g *ChainGroup) Snapshots() []ChainSnapshot {
+	out := make([]ChainSnapshot, 0, len(g.order))
+	for _, n := range g.order {
+		if c := g.chains[n]; c != nil {
+			out = append(out, c.Snapshot())
+		}
+	}
+	return out
+}
+
+// Await blocks until cond holds across every node's observed chain or
+// ctx expires. On timeout the error reports each node's state.
+func (g *ChainGroup) Await(
+	ctx context.Context,
+	desc string,
+	cond func([]ChainSnapshot) bool,
+) error {
+	for {
+		changed := g.notify.wait()
+		snaps := g.Snapshots()
+		if cond(snaps) {
+			return nil
+		}
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			parts := make([]string, 0, len(snaps))
+			for _, s := range snaps {
+				parts = append(parts, s.String())
+			}
+			return fmt.Errorf(
+				"devnet: %q not satisfied by [%s]: %w",
+				desc, strings.Join(parts, ", "), ctx.Err(),
+			)
+		}
+	}
+}
+
+// AgreementResult reports whether a set of nodes agree on the chain at
+// the deepest slot they have all observed.
+type AgreementResult struct {
+	Slot   uint64
+	Agree  bool
+	Hashes map[string]string
+}
+
+// String renders the per-node hashes for failure messages.
+func (r AgreementResult) String() string {
+	nodes := make([]string, 0, len(r.Hashes))
+	for n := range r.Hashes {
+		nodes = append(nodes, n)
+	}
+	sort.Strings(nodes)
+	parts := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		parts = append(parts, fmt.Sprintf("%s=%s", n, r.Hashes[n]))
+	}
+	return fmt.Sprintf(
+		"slot %d agree=%t [%s]", r.Slot, r.Agree, strings.Join(parts, " "),
+	)
+}
+
+// AgreementAtDeepestCommonSlot picks the highest slot every snapshot
+// observed a header for and compares the hashes there. Using a slot all
+// nodes actually reached makes the check a deterministic expected point
+// rather than a tolerance window: nodes at different tips still get
+// compared on the chain they share, and a fork shows up as a hash
+// mismatch instead of being masked by a slot-distance allowance.
+//
+// The second return is false when the snapshots share no observed slot,
+// which means the comparison could not be made at all.
+func AgreementAtDeepestCommonSlot(
+	snaps []ChainSnapshot,
+) (AgreementResult, bool) {
+	if len(snaps) < 2 {
+		return AgreementResult{}, false
+	}
+	byNode := make([]map[uint64]string, len(snaps))
+	for i, s := range snaps {
+		m := make(map[uint64]string, len(s.Headers))
+		for _, h := range s.Headers {
+			m[h.Slot] = hex.EncodeToString(h.Hash)
+		}
+		byNode[i] = m
+	}
+	var (
+		bestSlot  uint64
+		haveSlot  bool
+		bestFound = false
+	)
+	for slot := range byNode[0] {
+		common := true
+		for _, m := range byNode[1:] {
+			if _, ok := m[slot]; !ok {
+				common = false
+				break
+			}
+		}
+		if !common {
+			continue
+		}
+		if !bestFound || slot > bestSlot {
+			bestSlot, bestFound, haveSlot = slot, true, true
+		}
+	}
+	if !haveSlot {
+		return AgreementResult{}, false
+	}
+	result := AgreementResult{
+		Slot:   bestSlot,
+		Agree:  true,
+		Hashes: make(map[string]string, len(snaps)),
+	}
+	var first string
+	for i, s := range snaps {
+		h := byNode[i][bestSlot]
+		result.Hashes[s.Node] = h
+		if i == 0 {
+			first = h
+		} else if h != first {
+			result.Agree = false
+		}
+	}
+	return result, true
+}
+
+// AgreedHeaderAbove returns the lowest header above minSlot that every
+// snapshot observed with an identical hash, and whether one exists.
+//
+// This is the propagation check: a header only becomes "agreed" once it
+// has reached every node in the topology, including the non-forging
+// relay, so a block that never diffused is never mistaken for one that
+// did. Taking the lowest such header rather than the deepest makes the
+// answer the first block produced after the caller's baseline, which is
+// what a propagation assertion is actually about.
+func AgreedHeaderAbove(
+	snaps []ChainSnapshot,
+	minSlot uint64,
+) (ObservedHeader, bool) {
+	if len(snaps) == 0 {
+		return ObservedHeader{}, false
+	}
+	candidates := make([]ObservedHeader, 0, len(snaps[0].Headers))
+	for _, h := range snaps[0].Headers {
+		if h.Slot > minSlot {
+			candidates = append(candidates, h)
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Slot < candidates[j].Slot
+	})
+	for _, cand := range candidates {
+		agreed := true
+		for _, s := range snaps[1:] {
+			other, ok := s.HashAt(cand.Slot)
+			if !ok || !bytes.Equal(other, cand.Hash) {
+				agreed = false
+				break
+			}
+		}
+		if agreed {
+			return cand, true
+		}
+	}
+	return ObservedHeader{}, false
+}
+
+// MinTipSlot returns the lowest tip slot across snapshots, i.e. how far
+// the slowest node has got.
+func MinTipSlot(snaps []ChainSnapshot) uint64 {
+	if len(snaps) == 0 {
+		return 0
+	}
+	minSlot := snaps[0].Tip.SlotNumber
+	for _, s := range snaps[1:] {
+		if s.Tip.SlotNumber < minSlot {
+			minSlot = s.Tip.SlotNumber
+		}
+	}
+	return minSlot
+}
+
+// MaxTipSlot returns the highest tip slot across snapshots.
+func MaxTipSlot(snaps []ChainSnapshot) uint64 {
+	var maxSlot uint64
+	for _, s := range snaps {
+		if s.Tip.SlotNumber > maxSlot {
+			maxSlot = s.Tip.SlotNumber
+		}
+	}
+	return maxSlot
+}
+
+// MaxServerTipSlot returns the highest slot any node reported as its own
+// tip.
+//
+// This is not the same as MaxTipSlot: an observer intersects at origin
+// and replays history before it reaches the tip, so its observed tip lags
+// during catch-up. Assertions about what the chain is doing *now* — a
+// baseline for "forged after this point", or the next epoch boundary to
+// cross — must use the peer's reported tip, or replayed history could
+// satisfy them without the network having done anything.
+func MaxServerTipSlot(snaps []ChainSnapshot) uint64 {
+	var maxSlot uint64
+	for _, s := range snaps {
+		if s.ServerTip.SlotNumber > maxSlot {
+			maxSlot = s.ServerTip.SlotNumber
+		}
+	}
+	return maxSlot
+}
+
+// MaxBlockNumber returns the highest observed block height across
+// snapshots.
+func MaxBlockNumber(snaps []ChainSnapshot) uint64 {
+	var maxBlock uint64
+	for _, s := range snaps {
+		if s.Tip.BlockNumber > maxBlock {
+			maxBlock = s.Tip.BlockNumber
+		}
+	}
+	return maxBlock
+}

--- a/internal/test/devnet/chainstate.go
+++ b/internal/test/devnet/chainstate.go
@@ -167,9 +167,6 @@ func NewObservedChain(node string) *ObservedChain {
 	return &ObservedChain{node: node, notify: newBroadcaster()}
 }
 
-// Node returns the node name this chain was observed from.
-func (c *ObservedChain) Node() string { return c.node }
-
 // RollForward records a header the node sent, extending the observed
 // chain. serverTip is the node's own reported tip from the same message.
 func (c *ObservedChain) RollForward(h ObservedHeader, serverTip ChainTip) {
@@ -567,16 +564,4 @@ func MaxServerTipSlot(snaps []ChainSnapshot) uint64 {
 		}
 	}
 	return maxSlot
-}
-
-// MaxBlockNumber returns the highest observed block height across
-// snapshots.
-func MaxBlockNumber(snaps []ChainSnapshot) uint64 {
-	var maxBlock uint64
-	for _, s := range snaps {
-		if s.Tip.BlockNumber > maxBlock {
-			maxBlock = s.Tip.BlockNumber
-		}
-	}
-	return maxBlock
 }

--- a/internal/test/devnet/chainstate.go
+++ b/internal/test/devnet/chainstate.go
@@ -547,6 +547,20 @@ func MaxTipSlot(snaps []ChainSnapshot) uint64 {
 	return maxSlot
 }
 
+// MaxBlockNumber returns the highest observed block height across
+// snapshots. The scenario uses it to require forward progress between
+// disruption phases, so that each outage starts from a network that is
+// demonstrably still producing rather than merely converged.
+func MaxBlockNumber(snaps []ChainSnapshot) uint64 {
+	var maxBlock uint64
+	for _, s := range snaps {
+		if s.Tip.BlockNumber > maxBlock {
+			maxBlock = s.Tip.BlockNumber
+		}
+	}
+	return maxBlock
+}
+
 // MaxServerTipSlot returns the highest slot any node reported as its own
 // tip.
 //

--- a/internal/test/devnet/chainstate_test.go
+++ b/internal/test/devnet/chainstate_test.go
@@ -472,6 +472,19 @@ func TestAgreedHeaderAboveNeedsEveryNode(t *testing.T) {
 	require.False(t, ok, "a header only one node saw has not propagated")
 }
 
+func TestMaxBlockNumber(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+	ha := hdr(40, 7, 'a')
+	a.RollForward(ha, tipOf(ha))
+	hb := hdr(25, 3, 'a')
+	b.RollForward(hb, tipOf(hb))
+
+	snaps := []ChainSnapshot{a.Snapshot(), b.Snapshot()}
+	require.Equal(t, uint64(7), MaxBlockNumber(snaps))
+	require.Equal(t, uint64(0), MaxBlockNumber(nil))
+}
+
 func TestMinAndMaxTipSlot(t *testing.T) {
 	a := NewObservedChain("dingo-1")
 	b := NewObservedChain("dingo-2")

--- a/internal/test/devnet/chainstate_test.go
+++ b/internal/test/devnet/chainstate_test.go
@@ -1,0 +1,510 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// hdr builds an observed header with a deterministic hash derived from
+// the slot and a discriminator byte, so tests can construct competing
+// chains at the same slot.
+func hdr(slot, blockNum uint64, disc byte) ObservedHeader {
+	return ObservedHeader{
+		Slot:        slot,
+		BlockNumber: blockNum,
+		Hash:        []byte{disc, byte(slot), byte(slot >> 8)},
+	}
+}
+
+func tipOf(h ObservedHeader) ChainTip {
+	return ChainTip{
+		SlotNumber:  h.Slot,
+		BlockNumber: h.BlockNumber,
+		Hash:        h.Hash,
+	}
+}
+
+func TestObservedChainRollForwardTracksTip(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+
+	require.Equal(t, uint64(0), c.Snapshot().Tip.SlotNumber,
+		"a fresh chain has no tip")
+
+	for i := uint64(1); i <= 3; i++ {
+		h := hdr(i*10, i, 'a')
+		c.RollForward(h, tipOf(h))
+	}
+
+	snap := c.Snapshot()
+	require.Equal(t, uint64(30), snap.Tip.SlotNumber)
+	require.Equal(t, uint64(3), snap.Tip.BlockNumber)
+	require.Equal(t, 3, snap.RollForwards)
+	require.Equal(t, 0, snap.RollBackwards)
+	require.Len(t, snap.Headers, 3)
+	require.Equal(t, uint64(30), snap.ServerTip.SlotNumber,
+		"the peer-reported tip is recorded alongside our own")
+}
+
+func TestObservedChainRollBackwardTruncatesToPoint(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+	for i := uint64(1); i <= 5; i++ {
+		h := hdr(i*10, i, 'a')
+		c.RollForward(h, tipOf(h))
+	}
+
+	// Roll back to slot 20, dropping the headers at slots 30, 40, 50.
+	c.RollBackward(ChainPoint{Slot: 20, Hash: hdr(20, 2, 'a').Hash},
+		ChainTip{SlotNumber: 50, BlockNumber: 5})
+
+	snap := c.Snapshot()
+	require.Equal(t, uint64(20), snap.Tip.SlotNumber,
+		"tip follows the rollback point")
+	require.Equal(t, uint64(2), snap.Tip.BlockNumber,
+		"block number is recovered from the retained header")
+	require.Len(t, snap.Headers, 2)
+	require.Equal(t, 1, snap.RollBackwards)
+	require.Equal(t, uint64(3), snap.MaxRollbackDepth,
+		"three headers were dropped")
+
+	// A subsequent roll forward extends from the rollback point.
+	h := hdr(25, 3, 'b')
+	c.RollForward(h, tipOf(h))
+	snap = c.Snapshot()
+	require.Equal(t, uint64(25), snap.Tip.SlotNumber)
+	require.Len(t, snap.Headers, 3)
+}
+
+func TestObservedChainRollBackwardToOriginClearsChain(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+	for i := uint64(1); i <= 3; i++ {
+		h := hdr(i*10, i, 'a')
+		c.RollForward(h, tipOf(h))
+	}
+
+	c.RollBackward(ChainPoint{}, ChainTip{})
+
+	snap := c.Snapshot()
+	require.Empty(t, snap.Headers, "rollback to origin clears the chain")
+	require.Equal(t, uint64(0), snap.Tip.SlotNumber)
+	require.Equal(t, uint64(0), snap.Tip.BlockNumber)
+	require.Equal(t, uint64(3), snap.MaxRollbackDepth)
+}
+
+// A rollback to a slot the observer never saw a header for must still
+// truncate everything above it rather than silently keeping headers that
+// the peer has abandoned.
+func TestObservedChainRollBackwardToUnknownSlotTruncates(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+	for i := uint64(1); i <= 4; i++ {
+		h := hdr(i*10, i, 'a')
+		c.RollForward(h, tipOf(h))
+	}
+
+	c.RollBackward(ChainPoint{Slot: 25, Hash: []byte{'z'}}, ChainTip{})
+
+	snap := c.Snapshot()
+	require.Len(t, snap.Headers, 2,
+		"headers above the rollback slot are dropped")
+	require.Equal(t, uint64(25), snap.Tip.SlotNumber)
+	require.Equal(t, uint64(2), snap.MaxRollbackDepth)
+}
+
+func TestObservedChainAwaitReturnsWhenAlreadySatisfied(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+	h := hdr(100, 7, 'a')
+	c.RollForward(h, tipOf(h))
+
+	// An already-true condition must not block, even with a dead context
+	// deadline: Await evaluates before it waits.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	err := c.Await(ctx, "tip at slot 100", func(s ChainSnapshot) bool {
+		return s.Tip.SlotNumber >= 100
+	})
+	require.NoError(t, err)
+}
+
+func TestObservedChainAwaitWakesOnEvent(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Await(ctx, "block 5", func(s ChainSnapshot) bool {
+			return s.Tip.BlockNumber >= 5
+		})
+	}()
+
+	for i := uint64(1); i <= 5; i++ {
+		h := hdr(i*10, i, 'a')
+		c.RollForward(h, tipOf(h))
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("Await did not wake on roll-forward events")
+	}
+}
+
+func TestObservedChainAwaitRespectsContextDeadline(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		50*time.Millisecond,
+	)
+	defer cancel()
+
+	err := c.Await(ctx, "unreachable block 99", func(s ChainSnapshot) bool {
+		return s.Tip.BlockNumber >= 99
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "unreachable block 99",
+		"the failure names the condition that timed out")
+	require.Contains(t, err.Error(), "dingo-1",
+		"the failure names the node being observed")
+}
+
+// Connection churn is part of the observed record: the scenario restarts a
+// relay and interrupts a peer, and the assertions need to know that the
+// observer actually saw the drop and the recovery.
+func TestObservedChainRecordsConnectionChurn(t *testing.T) {
+	c := NewObservedChain("dingo-relay")
+
+	c.Connected()
+	h := hdr(10, 1, 'a')
+	c.RollForward(h, tipOf(h))
+	c.Disconnected(context.Canceled)
+	c.Connected()
+
+	snap := c.Snapshot()
+	require.Equal(t, 2, snap.Connects)
+	require.Equal(t, 1, snap.Disconnects)
+	require.True(t, snap.Connected)
+	require.Equal(t, uint64(10), snap.Tip.SlotNumber,
+		"a reconnect preserves the observed chain")
+}
+
+func TestObservedChainHeaderRetentionIsBounded(t *testing.T) {
+	c := NewObservedChain("dingo-1")
+
+	total := uint64(maxRetainedHeaders + 100)
+	for i := uint64(1); i <= total; i++ {
+		h := hdr(i, i, 'a')
+		c.RollForward(h, tipOf(h))
+	}
+
+	snap := c.Snapshot()
+	require.Len(t, snap.Headers, maxRetainedHeaders,
+		"retained headers are capped so long runs stay bounded")
+	require.Equal(t, total, snap.Tip.SlotNumber,
+		"the tip still tracks the newest header")
+	require.Equal(t, uint64(101), snap.Headers[0].Slot,
+		"the oldest retained header is the cap window's start")
+}
+
+func TestChainAgreementAtDeepestCommonSlot(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-relay")
+
+	// Both nodes observe the same chain; the relay lags by one header.
+	for i := uint64(1); i <= 4; i++ {
+		h := hdr(i*10, i, 'a')
+		a.RollForward(h, tipOf(h))
+		if i < 4 {
+			b.RollForward(h, tipOf(h))
+		}
+	}
+
+	result, ok := AgreementAtDeepestCommonSlot(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()},
+	)
+	require.True(t, ok, "a common slot exists")
+	require.Equal(t, uint64(30), result.Slot,
+		"agreement is checked at the deepest slot both nodes observed")
+	require.True(t, result.Agree)
+}
+
+func TestChainAgreementDetectsHashMismatch(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+
+	for i := uint64(1); i <= 3; i++ {
+		ha := hdr(i*10, i, 'a')
+		a.RollForward(ha, tipOf(ha))
+		// dingo-2 is on a fork from slot 30 onwards.
+		disc := byte('a')
+		if i == 3 {
+			disc = 'b'
+		}
+		hb := hdr(i*10, i, disc)
+		b.RollForward(hb, tipOf(hb))
+	}
+
+	result, ok := AgreementAtDeepestCommonSlot(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()},
+	)
+	require.True(t, ok)
+	require.Equal(t, uint64(30), result.Slot)
+	require.False(t, result.Agree, "the fork at slot 30 is detected")
+	require.Len(t, result.Hashes, 2,
+		"both nodes' hashes are reported for diagnosis")
+}
+
+func TestChainAgreementWithoutCommonSlot(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+	ha := hdr(10, 1, 'a')
+	a.RollForward(ha, tipOf(ha))
+	hb := hdr(11, 1, 'a')
+	b.RollForward(hb, tipOf(hb))
+
+	_, ok := AgreementAtDeepestCommonSlot(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()},
+	)
+	require.False(t, ok, "no slot was observed by both nodes")
+}
+
+func TestChainGroupAwaitAcrossNodes(t *testing.T) {
+	g := NewChainGroup("dingo-1", "dingo-2", "dingo-relay")
+	require.Len(t, g.Chains(), 3)
+	require.NotNil(t, g.Chain("dingo-2"))
+	require.Nil(t, g.Chain("nope"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.Await(ctx, "all nodes past slot 20",
+			func(snaps []ChainSnapshot) bool {
+				for _, s := range snaps {
+					if s.Tip.SlotNumber < 20 {
+						return false
+					}
+				}
+				return true
+			})
+	}()
+
+	// Feed the nodes one at a time; the group condition must only fire
+	// once the last one crosses the threshold.
+	for _, name := range []string{"dingo-1", "dingo-2", "dingo-relay"} {
+		h := hdr(20, 2, 'a')
+		c := g.Chain(name)
+		require.NotNil(t, c)
+		c.RollForward(h, tipOf(h))
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("group Await did not observe all three nodes advancing")
+	}
+}
+
+func TestChainGroupAwaitReportsLaggingNodes(t *testing.T) {
+	g := NewChainGroup("dingo-1", "dingo-2")
+	h := hdr(20, 2, 'a')
+	lead := g.Chain("dingo-1")
+	require.NotNil(t, lead)
+	lead.RollForward(h, tipOf(h))
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		50*time.Millisecond,
+	)
+	defer cancel()
+	err := g.Await(ctx, "all nodes past slot 20",
+		func(snaps []ChainSnapshot) bool {
+			for _, s := range snaps {
+				if s.Tip.SlotNumber < 20 {
+					return false
+				}
+			}
+			return true
+		})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "dingo-2",
+		"the timeout names the node state so failures are diagnosable")
+}
+
+// The observer writes from a ChainSync callback goroutine while scenario
+// assertions read; -race must stay clean.
+func TestObservedChainConcurrentApplyAndAwait(t *testing.T) {
+	g := NewChainGroup("dingo-1", "dingo-2")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, name := range []string{"dingo-1", "dingo-2"} {
+		wg.Go(func() {
+			c := g.Chain(name)
+			if c == nil {
+				return
+			}
+			for i := uint64(1); i <= 200; i++ {
+				h := hdr(i, i, 'a')
+				c.RollForward(h, tipOf(h))
+				if i%50 == 0 {
+					c.RollBackward(
+						ChainPoint{Slot: i - 5, Hash: hdr(i-5, i-5, 'a').Hash},
+						tipOf(h),
+					)
+				}
+			}
+		})
+	}
+
+	readers := make(chan error, 4)
+	for range 4 {
+		go func() {
+			readers <- g.Await(ctx, "both nodes reach block 100",
+				func(snaps []ChainSnapshot) bool {
+					for _, s := range snaps {
+						if s.Tip.BlockNumber < 100 {
+							return false
+						}
+					}
+					return true
+				})
+		}()
+	}
+
+	wg.Wait()
+	for range 4 {
+		require.NoError(t, <-readers)
+	}
+}
+
+func TestAgreedHeaderAboveFindsFirstCommonBlock(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-relay")
+
+	// Both nodes observe slots 10..40 identically.
+	for i := uint64(1); i <= 4; i++ {
+		h := hdr(i*10, i, 'a')
+		h.BodySize = i * 100
+		a.RollForward(h, tipOf(h))
+		b.RollForward(h, tipOf(h))
+	}
+
+	got, ok := AgreedHeaderAbove(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()}, 15,
+	)
+	require.True(t, ok)
+	require.Equal(t, uint64(20), got.Slot,
+		"the lowest agreed header above the baseline is returned")
+	require.Equal(t, uint64(200), got.BodySize,
+		"body size travels with the header so tx carriage is checkable")
+
+	// Nothing above the newest slot has been observed yet.
+	_, ok = AgreedHeaderAbove(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()}, 40,
+	)
+	require.False(t, ok)
+}
+
+func TestAgreedHeaderAboveIgnoresDisagreement(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+
+	// Slot 20 differs; slot 30 agrees again.
+	for _, spec := range []struct {
+		slot uint64
+		blk  uint64
+		da   byte
+		db   byte
+	}{
+		{10, 1, 'a', 'a'},
+		{20, 2, 'a', 'b'},
+		{30, 3, 'a', 'a'},
+	} {
+		ha := hdr(spec.slot, spec.blk, spec.da)
+		hb := hdr(spec.slot, spec.blk, spec.db)
+		a.RollForward(ha, tipOf(ha))
+		b.RollForward(hb, tipOf(hb))
+	}
+
+	got, ok := AgreedHeaderAbove(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()}, 15,
+	)
+	require.True(t, ok)
+	require.Equal(t, uint64(30), got.Slot,
+		"a slot the nodes disagree on is not treated as propagated")
+}
+
+func TestAgreedHeaderAboveNeedsEveryNode(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+	ha := hdr(20, 2, 'a')
+	a.RollForward(ha, tipOf(ha))
+
+	_, ok := AgreedHeaderAbove(
+		[]ChainSnapshot{a.Snapshot(), b.Snapshot()}, 0,
+	)
+	require.False(t, ok, "a header only one node saw has not propagated")
+}
+
+func TestMinAndMaxTipSlot(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+	ha := hdr(40, 4, 'a')
+	a.RollForward(ha, tipOf(ha))
+	hb := hdr(25, 2, 'a')
+	b.RollForward(hb, tipOf(hb))
+
+	snaps := []ChainSnapshot{a.Snapshot(), b.Snapshot()}
+	require.Equal(t, uint64(25), MinTipSlot(snaps))
+	require.Equal(t, uint64(40), MaxTipSlot(snaps))
+	require.Equal(t, uint64(0), MinTipSlot(nil))
+}
+
+// The observers intersect at origin and replay history before they reach
+// the tip, so our own tip lags the node's real one during catch-up. A
+// baseline taken from the observed tip would let an already-replayed
+// header satisfy a "newly forged" assertion, and would let an
+// already-passed epoch boundary satisfy the epoch phase. The peer's
+// reported tip is the honest answer to "where is the chain now".
+func TestMaxServerTipSlotIgnoresReplayLag(t *testing.T) {
+	a := NewObservedChain("dingo-1")
+	b := NewObservedChain("dingo-2")
+
+	// Both observers are only at slot 10 but the nodes report slot 400.
+	h := hdr(10, 1, 'a')
+	a.RollForward(h, ChainTip{SlotNumber: 400, BlockNumber: 160})
+	b.RollForward(h, ChainTip{SlotNumber: 395, BlockNumber: 158})
+
+	snaps := []ChainSnapshot{a.Snapshot(), b.Snapshot()}
+	require.Equal(t, uint64(10), MaxTipSlot(snaps),
+		"the observed tip still reflects how far replay has got")
+	require.Equal(t, uint64(400), MaxServerTipSlot(snaps),
+		"the peer-reported tip reflects where the chain actually is")
+	require.Equal(t, uint64(0), MaxServerTipSlot(nil))
+}

--- a/internal/test/devnet/config.go
+++ b/internal/test/devnet/config.go
@@ -12,26 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build devnet
-
 package devnet
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
-// defaultTestnetYAMLPath is the default path to testnet.yaml, relative
-// to the scenarios test package directory (internal/test/devnet/scenarios/).
-// Tests outside scenarios/ (e.g. in internal/test/devnet/ itself) must
-// override this via the DEVNET_TESTNET_YAML environment variable —
-// typically with t.Setenv("DEVNET_TESTNET_YAML", "./testnet.yaml") —
-// or by passing an explicit path, otherwise LoadDevNetConfig will fail
-// to find the file.
+// defaultTestnetYAMLPath is the fallback path to the network spec,
+// relative to the scenarios test package directory
+// (internal/test/devnet/scenarios/). It is only a fallback: run-tests.sh
+// exports DEVNET_TESTNET_YAML for the mode it actually brought up, so
+// the harness reads the same spec the configurator generated genesis
+// from. Tests outside scenarios/ (e.g. in internal/test/devnet/ itself)
+// must set DEVNET_TESTNET_YAML or call LoadDevNetConfigFrom with an
+// explicit path, otherwise LoadDevNetConfig will fail to find the file.
 const defaultTestnetYAMLPath = "../testnet.yaml"
 
 // testnetParams holds the required testnet parameters from document 1.
@@ -85,19 +86,28 @@ func (c *DevNetConfig) ExpectedBlockTime() time.Duration {
 	)
 }
 
-// LoadDevNetConfig reads testnet.yaml and returns the parsed DevNetConfig.
-// The path is taken from the DEVNET_TESTNET_YAML environment variable; if
-// unset, it defaults to defaultTestnetYAMLPath (relative to the test package).
+// LoadDevNetConfig reads the active network spec and returns the parsed
+// DevNetConfig. The path is taken from the DEVNET_TESTNET_YAML environment
+// variable; if unset, it defaults to defaultTestnetYAMLPath (relative to
+// the test package).
 func LoadDevNetConfig() (*DevNetConfig, error) {
 	path := os.Getenv("DEVNET_TESTNET_YAML")
 	if path == "" {
 		path = defaultTestnetYAMLPath
 	}
+	return LoadDevNetConfigFrom(path)
+}
 
+// LoadDevNetConfigFrom parses the network spec at an explicit path. It is
+// the form used by tests that check the checked-in specs directly, without
+// depending on which mode is currently exported to the environment.
+func LoadDevNetConfigFrom(path string) (*DevNetConfig, error) {
+	//nolint:gosec // network spec path comes from the harness or a test,
+	// never from network input
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"LoadDevNetConfig: reading %s: %w", path, err,
+			"LoadDevNetConfigFrom: reading %s: %w", path, err,
 		)
 	}
 
@@ -111,7 +121,7 @@ func LoadDevNetConfig() (*DevNetConfig, error) {
 	// docs[3] is document 3 (Shelley genesis overrides).
 	if len(docs) < 4 {
 		return nil, fmt.Errorf(
-			"LoadDevNetConfig: expected at least 4 YAML documents in %s, got %d",
+			"LoadDevNetConfigFrom: expected at least 4 YAML documents in %s, got %d",
 			path,
 			len(docs),
 		)
@@ -120,14 +130,14 @@ func LoadDevNetConfig() (*DevNetConfig, error) {
 	var params testnetParams
 	if err := yaml.Unmarshal(docs[1], &params); err != nil {
 		return nil, fmt.Errorf(
-			"LoadDevNetConfig: parsing testnet params (doc 1): %w", err,
+			"LoadDevNetConfigFrom: parsing testnet params (doc 1): %w", err,
 		)
 	}
 
 	var shelley shelleyGenesisOverride
 	if err := yaml.Unmarshal(docs[3], &shelley); err != nil {
 		return nil, fmt.Errorf(
-			"LoadDevNetConfig: parsing shelley genesis overrides (doc 3): %w",
+			"LoadDevNetConfigFrom: parsing shelley genesis overrides (doc 3): %w",
 			err,
 		)
 	}
@@ -140,4 +150,98 @@ func LoadDevNetConfig() (*DevNetConfig, error) {
 		ActiveSlotsCoeff: shelley.ActiveSlotsCoeff,
 		SecurityParam:    shelley.SecurityParam,
 	}, nil
+}
+
+// NonceStabilityWindowSlots returns 4k/f, the window cardano-node uses
+// for the candidate-nonce freeze. The candidate nonce for the next epoch
+// stops evolving this many slots before the epoch ends, so an epoch
+// shorter than the window can never freeze it.
+func (c *DevNetConfig) NonceStabilityWindowSlots() uint64 {
+	if c.ActiveSlotsCoeff <= 0 {
+		return 0
+	}
+	return uint64(4 * float64(c.SecurityParam) / c.ActiveSlotsCoeff)
+}
+
+// BlockFetchStabilityWindowSlots returns 3k/f, the shorter window used
+// for blockfetch stability.
+func (c *DevNetConfig) BlockFetchStabilityWindowSlots() uint64 {
+	if c.ActiveSlotsCoeff <= 0 {
+		return 0
+	}
+	return uint64(3 * float64(c.SecurityParam) / c.ActiveSlotsCoeff)
+}
+
+// EpochDuration returns the wall-clock length of one epoch.
+func (c *DevNetConfig) EpochDuration() time.Duration {
+	return SlotsDuration(c.EpochLength, c.SlotDuration())
+}
+
+// SlotsDuration returns the wall-clock time n slots take. DevNet slot
+// counts come from a checked-in spec and are small, but the conversion is
+// clamped rather than trusted so a nonsensical spec cannot wrap a
+// duration into the past.
+func SlotsDuration(slots uint64, slotDuration time.Duration) time.Duration {
+	if slots > math.MaxInt32 {
+		slots = math.MaxInt32
+	}
+	return time.Duration(slots) * slotDuration //nolint:gosec // clamped above
+}
+
+// NextEpochBoundary returns the first epoch-start slot strictly after
+// slot. Deriving the target from the observed tip rather than assuming
+// slot == epochLength lets a scenario cross a real transition even when
+// it attaches to a network that has been running for a while.
+func (c *DevNetConfig) NextEpochBoundary(slot uint64) uint64 {
+	if c.EpochLength == 0 {
+		return 0
+	}
+	return (slot/c.EpochLength + 1) * c.EpochLength
+}
+
+// Validate checks that the spec describes an internally consistent
+// network. Every violation is reported, not just the first, so shrinking
+// a network's timing tells you everything that has to move with it.
+func (c *DevNetConfig) Validate() error {
+	var errs []error
+	if c.PoolCount <= 0 {
+		errs = append(errs, fmt.Errorf("poolCount %d must be positive",
+			c.PoolCount))
+	}
+	if c.NetworkMagic == 0 {
+		errs = append(errs, errors.New("networkMagic must be non-zero"))
+	}
+	if c.SlotLength <= 0 {
+		errs = append(errs, fmt.Errorf("slotLength %.4f must be positive",
+			c.SlotLength))
+	}
+	if c.SecurityParam == 0 {
+		errs = append(errs, errors.New("securityParam must be non-zero"))
+	}
+	if c.EpochLength == 0 {
+		errs = append(errs, errors.New("epochLength must be non-zero"))
+	}
+	if c.ActiveSlotsCoeff <= 0 || c.ActiveSlotsCoeff > 1 {
+		errs = append(errs, fmt.Errorf(
+			"activeSlotsCoeff %.4f must be in (0, 1]", c.ActiveSlotsCoeff,
+		))
+		// The stability windows below divide by f; without a usable
+		// coefficient they carry no information.
+		return errors.Join(errs...)
+	}
+	if nonce := c.NonceStabilityWindowSlots(); nonce >= c.EpochLength {
+		errs = append(errs, fmt.Errorf(
+			"nonce stability window 4k/f = %d slots must be shorter than"+
+				" epochLength %d (k=%d, f=%.4f)",
+			nonce, c.EpochLength, c.SecurityParam, c.ActiveSlotsCoeff,
+		))
+	}
+	if fetch := c.BlockFetchStabilityWindowSlots(); fetch >= c.EpochLength {
+		errs = append(errs, fmt.Errorf(
+			"blockfetch stability window 3k/f = %d slots must be shorter"+
+				" than epochLength %d (k=%d, f=%.4f)",
+			fetch, c.EpochLength, c.SecurityParam, c.ActiveSlotsCoeff,
+		))
+	}
+	return errors.Join(errs...)
 }

--- a/internal/test/devnet/config_test.go
+++ b/internal/test/devnet/config_test.go
@@ -15,6 +15,9 @@
 package devnet
 
 import (
+	"os"
+	"regexp"
+	"slices"
 	"testing"
 	"time"
 
@@ -81,6 +84,59 @@ func TestCanonicalSpecsKeepCanonicalTiming(t *testing.T) {
 			require.Equal(t, time.Second, cfg.SlotDuration())
 		})
 	}
+}
+
+// run-tests.sh and start.sh each map a mode to a network spec, and
+// docker-compose.yml supplies the defaults. Nothing makes them agree, so a
+// rename that updates one and not another would leave the Go harness
+// deriving its timings from a different spec than the configurator
+// generated genesis from — the scenario would still run, just against a
+// network whose parameters it has wrong.
+//
+// Rather than route all three through a shared resolver (indirection
+// across a shell/compose/Go boundary for two filenames), assert that every
+// spec they name exists and that the two scripts agree on the accelerated
+// pair.
+func TestScriptsAndComposeAgreeOnSpecFiles(t *testing.T) {
+	specRe := regexp.MustCompile(`testnet[a-z-]*\.yaml`)
+	acceleratedRe := regexp.MustCompile(`testnet[a-z-]*accelerated\.yaml`)
+
+	referenced := map[string][]string{}
+	for _, file := range []string{
+		"run-tests.sh", "start.sh", "docker-compose.yml",
+	} {
+		data, err := os.ReadFile(file)
+		require.NoError(t, err)
+		for _, name := range specRe.FindAllString(string(data), -1) {
+			referenced[file] = append(referenced[file], name)
+		}
+	}
+
+	for file, names := range referenced {
+		require.NotEmpty(t, names, "%s names no network spec", file)
+		for _, name := range names {
+			require.FileExists(t, name,
+				"%s references %s, which does not exist", file, name)
+		}
+	}
+
+	accelerated := func(file string) []string {
+		var out []string
+		for _, name := range referenced[file] {
+			if acceleratedRe.MatchString(name) && !slices.Contains(out, name) {
+				out = append(out, name)
+			}
+		}
+		slices.Sort(out)
+		return out
+	}
+	runTests := accelerated("run-tests.sh")
+	require.Len(t, runTests, 2,
+		"run-tests.sh should name both accelerated specs")
+	require.Equal(t, runTests, accelerated("start.sh"),
+		"start.sh and run-tests.sh must select the same accelerated specs;"+
+			" if they drift, the harness and the running network resolve"+
+			" different timings")
 }
 
 func TestLoadDevNetConfigFromMissingFile(t *testing.T) {

--- a/internal/test/devnet/config_test.go
+++ b/internal/test/devnet/config_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckedInSpecsAreValid parses every network spec in this directory
+// and enforces the consensus-timing invariants on it. This is the guard
+// that keeps an accelerated configuration internally valid: shortening
+// the epoch without also shrinking k would put the candidate-nonce freeze
+// outside the epoch, which fails here rather than as a mystifying DevNet
+// stall.
+func TestCheckedInSpecsAreValid(t *testing.T) {
+	for _, spec := range []struct {
+		file      string
+		poolCount int
+	}{
+		{"testnet.yaml", 2},
+		{"testnet-dingo.yaml", 3},
+		{"testnet-accelerated.yaml", 2},
+		{"testnet-dingo-accelerated.yaml", 3},
+	} {
+		t.Run(spec.file, func(t *testing.T) {
+			cfg, err := LoadDevNetConfigFrom(spec.file)
+			require.NoError(t, err)
+			require.NoError(t, cfg.Validate())
+			require.Equal(t, spec.poolCount, cfg.PoolCount)
+			require.Equal(t, uint32(42), cfg.NetworkMagic)
+		})
+	}
+}
+
+// The accelerated specs exist to make a full scenario fit the reference
+// runner budget; if someone relaxes their timing back toward canonical,
+// this fails before CI spends five minutes discovering it.
+func TestAcceleratedSpecsMeetTheRunnerBudget(t *testing.T) {
+	for _, file := range []string{
+		"testnet-accelerated.yaml",
+		"testnet-dingo-accelerated.yaml",
+	} {
+		t.Run(file, func(t *testing.T) {
+			cfg, err := LoadDevNetConfigFrom(file)
+			require.NoError(t, err)
+
+			plan, err := NewScenarioPlan(cfg)
+			require.NoError(t, err)
+			require.LessOrEqual(t, plan.Total(), ReferenceRunnerBudget)
+		})
+	}
+}
+
+// The canonical specs must stay on canonical timing: they are what the
+// soak and canary runs use, and quietly accelerating them would remove
+// the long-wall-clock coverage the fast scenario deliberately does not
+// provide.
+func TestCanonicalSpecsKeepCanonicalTiming(t *testing.T) {
+	for _, file := range []string{"testnet.yaml", "testnet-dingo.yaml"} {
+		t.Run(file, func(t *testing.T) {
+			cfg, err := LoadDevNetConfigFrom(file)
+			require.NoError(t, err)
+			require.Equal(t, uint64(500), cfg.EpochLength)
+			require.Equal(t, 1.0, cfg.SlotLength)
+			require.Equal(t, uint64(40), cfg.SecurityParam)
+			require.Equal(t, time.Second, cfg.SlotDuration())
+		})
+	}
+}
+
+func TestLoadDevNetConfigFromMissingFile(t *testing.T) {
+	_, err := LoadDevNetConfigFrom("no-such-testnet.yaml")
+	require.Error(t, err)
+}
+
+func TestLoadDevNetConfigHonoursEnvOverride(t *testing.T) {
+	t.Setenv("DEVNET_TESTNET_YAML", "testnet-dingo-accelerated.yaml")
+	cfg, err := LoadDevNetConfig()
+	require.NoError(t, err)
+	require.Equal(t, 3, cfg.PoolCount)
+	require.Equal(t, 500*time.Millisecond, cfg.SlotDuration())
+}

--- a/internal/test/devnet/configurator.sh
+++ b/internal/test/devnet/configurator.sh
@@ -194,8 +194,8 @@ find /configs -type f -exec chmod 0644 {} +
 
 # cardano-node refuses to start when vrf.skey has "other" read permissions,
 # so the per-pool keys directories must be 0700/0600. Pools listed in
-# DINGO_POOL_IDS are consumed by dingo containers (uid 100, gid 101 in the
-# dingo image) and get chowned below to match. Any pool NOT listed stays
+# DINGO_POOL_IDS are consumed by dingo containers, which run as a non-root
+# user, and get chowned below to match. Any pool NOT listed stays
 # root-owned for its cardano-node container, which runs as root - e.g. pool
 # 2 (and 3) in conformance mode, where DINGO_POOL_IDS defaults to "1".
 for pool_dir in /configs/[0-9]*; do
@@ -206,11 +206,23 @@ for pool_dir in /configs/[0-9]*; do
     fi
 done
 # Chown the key dirs of pools consumed by dingo containers to the dingo
-# image uid/gid (100:101). Conformance mode sets DINGO_POOL_IDS="1" (only
-# pool 1 is dingo); the all-dingo configurator sets "1 2 3".
+# image's uid/gid. Conformance mode sets DINGO_POOL_IDS="1" (only pool 1
+# is dingo); the all-dingo configurator sets "1 2 3".
+#
+# The uid/gid come from docker-compose.yml rather than being hardcoded
+# here, because the authoritative value is the `adduser --uid` pin in the
+# repo root Dockerfile and the two must not drift. They did drift once:
+# the image moved from uid 100 to 1000 while this script still chowned to
+# 100:101, so every Dingo block producer failed startup with
+# "failed to read key file .../vrf.skey: permission denied" — the keys
+# directory is 0700 by necessity, since cardano-node refuses to start when
+# vrf.skey is group- or world-readable.
 DINGO_POOL_IDS="${DINGO_POOL_IDS:-1}"
+DINGO_UID="${DINGO_UID:-1000}"
+DINGO_GID="${DINGO_GID:-1000}"
+echo "chowning dingo pool keys to ${DINGO_UID}:${DINGO_GID} (pools: ${DINGO_POOL_IDS})"
 for id in ${DINGO_POOL_IDS}; do
     if [ -d "/configs/${id}/keys" ]; then
-        chown -R 100:101 "/configs/${id}/keys"
+        chown -R "${DINGO_UID}:${DINGO_GID}" "/configs/${id}/keys"
     fi
 done

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -34,6 +34,10 @@
 #   docker compose up -d       # Start all services in the selected profile
 #   docker compose down -v     # Stop and remove volumes
 #
+# Network spec overrides (set by the scripts' --accelerated flag):
+#   DEVNET_DINGO_SPEC       - dingo profile spec      (default: ./testnet-dingo.yaml)
+#   DEVNET_CONFORMANCE_SPEC - conformance profile spec (default: ./testnet.yaml)
+#
 # Host port overrides (set in environment or .env file, conformance profile):
 #   DEVNET_DINGO_PORT     - Dingo producer host port    (default: 3010)
 #   DEVNET_CARDANO_PORT   - Cardano producer host port  (default: 3011)
@@ -55,7 +59,9 @@ services:
       DINGO_UID: "${DEVNET_DINGO_UID:-1000}"
       DINGO_GID: "${DEVNET_DINGO_GID:-1000}"
     volumes:
-      - ./testnet.yaml:/testnet.yaml
+      # Network spec: canonical by default, accelerated when the scripts'
+      # --accelerated flag exports DEVNET_CONFORMANCE_SPEC.
+      - ${DEVNET_CONFORMANCE_SPEC:-./testnet.yaml}:/testnet.yaml
       - p1-configs:/configs/1
       - p2-configs:/configs/2
       - utxo-keys:/configs/utxo-keys
@@ -73,7 +79,9 @@ services:
       DINGO_UID: "${DEVNET_DINGO_UID:-1000}"
       DINGO_GID: "${DEVNET_DINGO_GID:-1000}"
     volumes:
-      - ./testnet-dingo.yaml:/testnet.yaml
+      # Network spec: canonical by default, accelerated when the scripts'
+      # --accelerated flag exports DEVNET_DINGO_SPEC.
+      - ${DEVNET_DINGO_SPEC:-./testnet-dingo.yaml}:/testnet.yaml
       - p1-configs:/configs/1
       - p2-configs:/configs/2
       - p3-configs:/configs/3

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -49,6 +49,11 @@ services:
       dockerfile: Dockerfile.configurator
     container_name: devnet-configurator
     profiles: ["conformance"]
+    environment:
+      # Must match the dingo user pinned in the repo root Dockerfile;
+      # configurator.sh chowns the pool key directories to it.
+      DINGO_UID: "${DEVNET_DINGO_UID:-1000}"
+      DINGO_GID: "${DEVNET_DINGO_GID:-1000}"
     volumes:
       - ./testnet.yaml:/testnet.yaml
       - p1-configs:/configs/1
@@ -63,6 +68,10 @@ services:
     profiles: ["dingo"]
     environment:
       DINGO_POOL_IDS: "1 2 3"
+      # Must match the dingo user pinned in the repo root Dockerfile;
+      # configurator.sh chowns the pool key directories to it.
+      DINGO_UID: "${DEVNET_DINGO_UID:-1000}"
+      DINGO_GID: "${DEVNET_DINGO_GID:-1000}"
     volumes:
       - ./testnet-dingo.yaml:/testnet.yaml
       - p1-configs:/configs/1
@@ -95,7 +104,7 @@ services:
       DINGO_PLUGINS_MEMPOOL_PROVIDER: "${DEVNET_MEMPOOL_PROVIDER:-fifo}"
       # Expose node-to-client over TCP (private port 3002) so the host test
       # harness can run LocalStateQuery. Avoids a cross-uid host socket mount:
-      # the dingo image runs as uid 100 and cannot bind a socket in a
+      # the dingo image runs as uid 1000 and cannot bind a socket in a
       # host-owned bind mount. The in-container unix socket lives on a named
       # volume (like conformance mode) for txpump and the healthcheck.
       DINGO_PRIVATE_BIND_ADDR: "0.0.0.0"
@@ -260,7 +269,7 @@ services:
       CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE: /configs/keys/opcert.cert
       # Expose node-to-client over TCP (private port 3002) on all interfaces
       # so the in-network txpump can submit transactions without a cross-uid
-      # unix-socket mount (the socket is owned by uid 100; txpump is uid 1000).
+      # unix-socket mount (the socket is owned by the dingo uid).
       DINGO_PRIVATE_BIND_ADDR: "0.0.0.0"
       CARDANO_PRIVATE_BIND_ADDR: "0.0.0.0"
     volumes:

--- a/internal/test/devnet/endpoints_conformance.go
+++ b/internal/test/devnet/endpoints_conformance.go
@@ -31,19 +31,22 @@ func LoadEndpoints() []NodeEndpoint {
 	}
 	return []NodeEndpoint{
 		{
-			Name:    "dingo-producer",
-			Address: addr("DEVNET_DINGO_ADDR", "localhost:3010"),
-			Role:    "producer",
-			IsDingo: true,
+			Name:      "dingo-producer",
+			Container: "dingo-producer",
+			Address:   addr("DEVNET_DINGO_ADDR", "localhost:3010"),
+			Role:      "producer",
+			IsDingo:   true,
 		},
 		{
 			Name:        "cardano-producer",
+			Container:   "cardano-producer",
 			Address:     addr("DEVNET_CARDANO_ADDR", "localhost:3011"),
 			Role:        "producer",
 			IsReference: true,
 		},
 		{
 			Name:        "cardano-relay",
+			Container:   "cardano-relay",
 			Address:     addr("DEVNET_RELAY_ADDR", "localhost:3012"),
 			Role:        "relay",
 			IsReference: true,

--- a/internal/test/devnet/endpoints_dingo.go
+++ b/internal/test/devnet/endpoints_dingo.go
@@ -30,28 +30,32 @@ func LoadEndpoints() []NodeEndpoint {
 	}
 	return []NodeEndpoint{
 		{
-			Name:    "dingo-1",
-			Address: addr("DEVNET_DINGO1_ADDR", "localhost:3010"),
-			Role:    "producer",
-			IsDingo: true,
+			Name:      "dingo-1",
+			Container: "dingo-1",
+			Address:   addr("DEVNET_DINGO1_ADDR", "localhost:3010"),
+			Role:      "producer",
+			IsDingo:   true,
 		},
 		{
-			Name:    "dingo-2",
-			Address: addr("DEVNET_DINGO2_ADDR", "localhost:3013"),
-			Role:    "producer",
-			IsDingo: true,
+			Name:      "dingo-2",
+			Container: "dingo-2",
+			Address:   addr("DEVNET_DINGO2_ADDR", "localhost:3013"),
+			Role:      "producer",
+			IsDingo:   true,
 		},
 		{
-			Name:    "dingo-3",
-			Address: addr("DEVNET_DINGO3_ADDR", "localhost:3014"),
-			Role:    "producer",
-			IsDingo: true,
+			Name:      "dingo-3",
+			Container: "dingo-3",
+			Address:   addr("DEVNET_DINGO3_ADDR", "localhost:3014"),
+			Role:      "producer",
+			IsDingo:   true,
 		},
 		{
-			Name:    "dingo-relay",
-			Address: addr("DEVNET_DINGO_RELAY_ADDR", "localhost:3015"),
-			Role:    "relay",
-			IsDingo: true,
+			Name:      "dingo-relay",
+			Container: "dingo-relay",
+			Address:   addr("DEVNET_DINGO_RELAY_ADDR", "localhost:3015"),
+			Role:      "relay",
+			IsDingo:   true,
 		},
 	}
 }

--- a/internal/test/devnet/harness.go
+++ b/internal/test/devnet/harness.go
@@ -14,9 +14,6 @@
 
 //go:build devnet
 
-// Package devnet provides a test harness for running integration tests
-// against a private Cardano DevNet consisting of Dingo and cardano-node
-// instances connected via Docker Compose.
 package devnet
 
 import (
@@ -35,6 +32,14 @@ import (
 // in shelley-genesis.json.
 const DefaultNetworkMagic = 42
 
+// ChainStartTimeout bounds the wait for the network to pass its genesis
+// system start and forge a first block. configurator.sh schedules
+// systemStart 30s after it exits (key generation is too slow for the
+// generator's own systemStartDelay), and the compose health checks pass
+// as soon as a node opens its socket — well before that. This covers the
+// pre-genesis wait plus the first few slot-leader draws.
+const ChainStartTimeout = 90 * time.Second
+
 // NodeEndpoint describes a node that the test harness can connect to
 // using the Ouroboros Node-to-Node mini-protocol over TCP.
 type NodeEndpoint struct {
@@ -43,13 +48,12 @@ type NodeEndpoint struct {
 	Role        string // "producer" or "relay"
 	IsDingo     bool   // node runs Dingo
 	IsReference bool   // node runs the cardano-node reference impl
-}
-
-// ChainTip holds the chain tip information retrieved from a node.
-type ChainTip struct {
-	SlotNumber  uint64
-	BlockNumber uint64
-	Hash        []byte
+	// Container is the compose service name, used by the scenario to
+	// interrupt and restart the node. A disruption step against an
+	// endpoint with no container fails rather than being skipped: a run
+	// that quietly omitted its interruption phases would not be the
+	// release evidence it claims to be.
+	Container string
 }
 
 // TestHarness manages connections to DevNet nodes and provides
@@ -359,6 +363,50 @@ func (h *TestHarness) VerifyChainConsensus(
 		"nodes did not reach consensus within %s (tolerance: %d slots)",
 		timeout, slotTolerance,
 	)
+}
+
+// WaitForChainStart blocks until some node reports a block, i.e. the
+// network has passed its genesis system start and slot leaders have begun
+// forging. It returns the tip that satisfied the wait.
+//
+// Reachability is not chain liveness: a node answers tip queries for
+// ~30s before genesis, reporting slot 0 / block 0 the whole time. Every
+// timeout below is derived from slot counts, which only measure elapsed
+// chain time, so charging one against the pre-genesis wait can expire it
+// before the chain has produced anything at all.
+//
+// Gating here is also what keeps a test independent. Without it, a test
+// only passes because an earlier one in the package happened to absorb
+// the wait first, so it fails the moment it is run on its own with
+// `run-tests.sh -run <name>` — exactly when someone is trying to debug
+// it.
+func (h *TestHarness) WaitForChainStart(timeout time.Duration) ChainTip {
+	h.t.Helper()
+	var started ChainTip
+	require.Eventually(h.t, func() bool {
+		for _, ep := range h.endpoints {
+			tip, err := h.GetChainTip(ep)
+			if err != nil {
+				h.t.Logf(
+					"WaitForChainStart: error querying %s: %v", ep.Name, err,
+				)
+				continue
+			}
+			if tip.BlockNumber > 0 {
+				h.t.Logf(
+					"WaitForChainStart: %s forged through slot %d, block %d",
+					ep.Name, tip.SlotNumber, tip.BlockNumber,
+				)
+				started = tip
+				return true
+			}
+		}
+		return false
+	}, timeout, 2*time.Second,
+		"no node produced a block within %s; the network may not have "+
+			"reached its genesis system start", timeout,
+	)
+	return started
 }
 
 // WaitForAllNodesReady polls all endpoints until each one is reachable

--- a/internal/test/devnet/nodectl.go
+++ b/internal/test/devnet/nodectl.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build devnet
+
+package devnet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// defaultComposeFile is where the scenarios package finds the DevNet
+// compose file. run-tests.sh exports DEVNET_COMPOSE_FILE explicitly; this
+// is the fallback for a hand-run `go test` from the scenarios directory.
+const defaultComposeFile = "../docker-compose.yml"
+
+// stopGracePeriod is how long a container gets to exit on SIGTERM before
+// it is killed. The scenario is testing recovery, not shutdown, so this
+// stays short to keep the interruption inside the k-block window.
+const stopGracePeriod = 2 * time.Second
+
+// NodeControl stops and starts DevNet containers so a scenario can
+// exercise peer interruption and relay restart against the real
+// topology.
+type NodeControl struct {
+	composeFile string
+	logf        func(format string, args ...any)
+}
+
+// NewNodeControl returns a controller for the running DevNet. It fails
+// when Docker Compose or the compose file are not reachable, since a
+// scenario that silently skipped its disruption phases would report a
+// pass it did not earn.
+func NewNodeControl(
+	logf func(format string, args ...any),
+) (*NodeControl, error) {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	composeFile := os.Getenv("DEVNET_COMPOSE_FILE")
+	if composeFile == "" {
+		composeFile = defaultComposeFile
+	}
+	//nolint:gosec // compose path comes from the harness environment
+	if _, err := os.Stat(composeFile); err != nil {
+		return nil, fmt.Errorf(
+			"devnet: compose file %q not readable (%w); run the scenario"+
+				" via internal/test/devnet/run-tests.sh, or set"+
+				" DEVNET_COMPOSE_FILE",
+			composeFile, err,
+		)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := runCompose(
+		ctx, composeFile, "version",
+	); err != nil {
+		return nil, fmt.Errorf("devnet: docker compose unusable: %w", err)
+	}
+	return &NodeControl{composeFile: composeFile, logf: logf}, nil
+}
+
+// Stop halts one node, leaving its volumes intact so a later Start
+// resumes the same node rather than bootstrapping a fresh one.
+//
+// This drives `docker` directly rather than `docker compose`, because
+// compose resolves depends_on: `docker compose start dingo-3` also starts
+// the configurator it depends on, which regenerates genesis into the
+// shared config volumes. The restarted node then refuses to start at all,
+// with a genesis-hash mismatch against the database it already has —
+// a network-wide reset dressed up as a single-node restart. Every DevNet
+// service pins container_name to its service name, so addressing the
+// container by name is exact and touches nothing else.
+func (n *NodeControl) Stop(ctx context.Context, container string) error {
+	n.logf("nodectl: stopping %s", container)
+	if _, err := runDocker(
+		ctx,
+		"stop", "-t", strconv.Itoa(int(stopGracePeriod.Seconds())), container,
+	); err != nil {
+		return fmt.Errorf("stop %s: %w", container, err)
+	}
+	return nil
+}
+
+// Start brings a stopped node back up. See Stop for why this bypasses
+// compose.
+func (n *NodeControl) Start(ctx context.Context, container string) error {
+	n.logf("nodectl: starting %s", container)
+	if _, err := runDocker(ctx, "start", container); err != nil {
+		return fmt.Errorf("start %s: %w", container, err)
+	}
+	return nil
+}
+
+// ContainerStatus returns `docker compose ps` output for the active
+// profile.
+func (n *NodeControl) ContainerStatus(ctx context.Context) (string, error) {
+	out, err := runCompose(ctx, n.composeFile, "ps", "--all")
+	return out, err
+}
+
+// Logs returns a service's container logs.
+func (n *NodeControl) Logs(
+	ctx context.Context,
+	service string,
+) (string, error) {
+	return runCompose(
+		ctx, n.composeFile, "logs", "--no-color", "--no-log-prefix", service,
+	)
+}
+
+// ArtifactDir returns the directory failure evidence is written to, and
+// whether one is configured. run-tests.sh creates it and preserves it on
+// failure.
+func ArtifactDir() (string, bool) {
+	dir := os.Getenv("DEVNET_ARTIFACT_DIR")
+	return dir, dir != ""
+}
+
+// CaptureFailureArtifacts writes the evidence a failed scenario needs to
+// be diagnosable after the network is gone: what every node's chain
+// actually did, which containers were up, and each service's logs.
+//
+// It is best-effort by design — a capture error must not mask the test
+// failure that triggered it — so problems are logged rather than
+// returned.
+func (n *NodeControl) CaptureFailureArtifacts(
+	ctx context.Context,
+	name string,
+	snapshots []ChainSnapshot,
+	services []string,
+) {
+	dir, ok := ArtifactDir()
+	if !ok {
+		n.logf(
+			"nodectl: DEVNET_ARTIFACT_DIR unset; skipping artifact capture",
+		)
+		return
+	}
+	dir = filepath.Join(dir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		n.logf("nodectl: creating %s: %v", dir, err)
+		return
+	}
+
+	if data, err := json.MarshalIndent(snapshots, "", "  "); err != nil {
+		n.logf("nodectl: encoding chain events: %v", err)
+	} else {
+		n.writeArtifact(dir, "observed-chains.json", data)
+	}
+
+	if status, err := n.ContainerStatus(ctx); err != nil {
+		n.logf("nodectl: container status: %v", err)
+	} else {
+		n.writeArtifact(dir, "container-status.txt", []byte(status))
+	}
+
+	for _, svc := range services {
+		logs, err := n.Logs(ctx, svc)
+		if err != nil {
+			n.logf("nodectl: logs for %s: %v", svc, err)
+			continue
+		}
+		n.writeArtifact(dir, svc+".log", []byte(logs))
+	}
+	n.logf("nodectl: failure artifacts written to %s", dir)
+}
+
+func (n *NodeControl) writeArtifact(dir, name string, data []byte) {
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		n.logf("nodectl: writing %s: %v", path, err)
+	}
+}
+
+// runCompose invokes docker compose against the DevNet compose file. The
+// active COMPOSE_PROFILES is inherited from the environment run-tests.sh
+// set up, so the command targets the topology that is actually running.
+// Use it for whole-topology reads (status, logs), never to start or stop
+// an individual node — see Stop.
+func runCompose(
+	ctx context.Context,
+	composeFile string,
+	args ...string,
+) (string, error) {
+	return runDocker(
+		ctx, append([]string{"compose", "-f", composeFile}, args...)...,
+	)
+}
+
+// runDocker runs the docker CLI and returns its stdout.
+func runDocker(ctx context.Context, args ...string) (string, error) {
+	//nolint:gosec // args are container/service names owned by the harness
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf(
+			"docker %v: %w: %s", args, err, stderr.String(),
+		)
+	}
+	return stdout.String(), nil
+}

--- a/internal/test/devnet/observer.go
+++ b/internal/test/devnet/observer.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build devnet
+
+package devnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	// observerDialTimeout bounds a single connection attempt.
+	observerDialTimeout = 10 * time.Second
+	// observerMinBackoff and observerMaxBackoff bound the reconnect
+	// delay. The scenario deliberately stops containers, so a node being
+	// unreachable is an expected state to sit in, not a failure — but
+	// recovery has to be picked up quickly enough that the recovery
+	// budget measures the node rather than the observer.
+	observerMinBackoff = 250 * time.Millisecond
+	observerMaxBackoff = 2 * time.Second
+)
+
+// ChainObservers holds one persistent ChainSync session per node.
+//
+// This replaces opening a fresh Node-to-Node connection per tip query.
+// A short-lived connection can only ever report the tip captured when it
+// intersected, which is why the polling harness had to reconnect on every
+// check; a session that stays up and follows the chain instead receives
+// RollForward and RollBackward as the node produces them. Scenario
+// assertions then wait on observed protocol events with a bounded
+// context rather than sampling on an interval.
+type ChainObservers struct {
+	group     *ChainGroup
+	endpoints map[string]NodeEndpoint
+	magic     uint32
+	logf      func(format string, args ...any)
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// StartObservers opens a ChainSync session to every endpoint and follows
+// each node's chain until Stop is called or ctx is cancelled. Sessions
+// reconnect on their own, so a node that is stopped and started again
+// resumes without the caller doing anything.
+func StartObservers(
+	ctx context.Context,
+	endpoints []NodeEndpoint,
+	magic uint32,
+	logf func(format string, args ...any),
+) *ChainObservers {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	names := make([]string, 0, len(endpoints))
+	byName := make(map[string]NodeEndpoint, len(endpoints))
+	for _, ep := range endpoints {
+		names = append(names, ep.Name)
+		byName[ep.Name] = ep
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	o := &ChainObservers{
+		group:     NewChainGroup(names...),
+		endpoints: byName,
+		magic:     magic,
+		logf:      logf,
+		cancel:    cancel,
+	}
+	for _, ep := range endpoints {
+		o.wg.Add(1)
+		go func(ep NodeEndpoint) {
+			defer o.wg.Done()
+			o.follow(runCtx, ep)
+		}(ep)
+	}
+	return o
+}
+
+// Group returns the observed chains, for waiting on conditions.
+func (o *ChainObservers) Group() *ChainGroup { return o.group }
+
+// Chain returns one node's observed chain.
+func (o *ChainObservers) Chain(node string) *ObservedChain {
+	return o.group.Chain(node)
+}
+
+// Endpoint returns the endpoint definition for a node.
+func (o *ChainObservers) Endpoint(node string) (NodeEndpoint, bool) {
+	ep, ok := o.endpoints[node]
+	return ep, ok
+}
+
+// Stop tears every session down and waits for the goroutines to exit.
+func (o *ChainObservers) Stop() {
+	o.cancel()
+	o.wg.Wait()
+}
+
+// follow keeps one node's session alive for the life of the scenario.
+func (o *ChainObservers) follow(ctx context.Context, ep NodeEndpoint) {
+	chain := o.group.Chain(ep.Name)
+	if chain == nil {
+		return
+	}
+	backoff := observerMinBackoff
+	for ctx.Err() == nil {
+		established, err := o.session(ctx, ep, chain)
+		if ctx.Err() != nil {
+			return
+		}
+		chain.Disconnected(err)
+		o.logf(
+			"observer %s: session ended (%v); reconnecting in %s",
+			ep.Name, err, backoff,
+		)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		// Back off only against a node that will not talk to us at all.
+		// A session that got as far as following the chain and then
+		// dropped — which is exactly what a restarted node looks like —
+		// starts over at the shortest delay, so the recovery budget
+		// measures the node rather than the observer's patience.
+		if established {
+			backoff = observerMinBackoff
+		} else {
+			backoff = min(2*backoff, observerMaxBackoff)
+		}
+	}
+}
+
+// session runs one connection from dial to teardown. It reports whether
+// the session got as far as following the chain, and the reason it ended;
+// a cancelled context returns a nil error.
+func (o *ChainObservers) session(
+	ctx context.Context,
+	ep NodeEndpoint,
+	chain *ObservedChain,
+) (established bool, err error) {
+	dialer := &net.Dialer{Timeout: observerDialTimeout}
+	rawConn, err := dialer.DialContext(ctx, "tcp", ep.Address)
+	if err != nil {
+		return false, fmt.Errorf("dial %s: %w", ep.Address, err)
+	}
+
+	rollForward := func(
+		_ chainsync.CallbackContext,
+		_ uint,
+		headerAny any,
+		tip chainsync.Tip,
+	) error {
+		header, ok := headerAny.(lcommon.BlockHeader)
+		if !ok {
+			return fmt.Errorf(
+				"observer %s: unexpected header type %T", ep.Name, headerAny,
+			)
+		}
+		hash := header.Hash()
+		chain.RollForward(
+			ObservedHeader{
+				Slot:        header.SlotNumber(),
+				BlockNumber: header.BlockNumber(),
+				Hash:        hash.Bytes(),
+				BodySize:    header.BlockBodySize(),
+			},
+			tipFrom(tip),
+		)
+		return nil
+	}
+	rollBackward := func(
+		_ chainsync.CallbackContext,
+		point pcommon.Point,
+		tip chainsync.Tip,
+	) error {
+		chain.RollBackward(
+			ChainPoint{Slot: point.Slot, Hash: point.Hash},
+			tipFrom(tip),
+		)
+		return nil
+	}
+
+	conn, err := ouroboros.NewConnection(
+		ouroboros.WithConnection(rawConn),
+		ouroboros.WithNetworkMagic(o.magic),
+		ouroboros.WithNodeToNode(true),
+		// A session outlives many blocks, so it needs keep-alive to stay
+		// up through the quiet stretches the scenario creates when it
+		// stops a producer.
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithChainSyncConfig(chainsync.NewConfig(
+			chainsync.WithRollForwardFunc(rollForward),
+			chainsync.WithRollBackwardFunc(rollBackward),
+		)),
+	)
+	if err != nil {
+		_ = rawConn.Close()
+		return false, fmt.Errorf(
+			"ouroboros handshake with %s: %w", ep.Name, err,
+		)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	cs := conn.ChainSync()
+	if cs == nil || cs.Client == nil {
+		return false, fmt.Errorf(
+			"observer %s: no chain-sync client", ep.Name,
+		)
+	}
+	if err := cs.Client.Sync(o.intersectPoints(chain)); err != nil {
+		return false, fmt.Errorf("observer %s: sync: %w", ep.Name, err)
+	}
+	chain.Connected()
+	o.logf("observer %s: following chain from %s", ep.Name, ep.Address)
+
+	select {
+	case <-ctx.Done():
+		return true, nil
+	case err, ok := <-conn.ErrorChan():
+		if !ok {
+			return true, errors.New("connection closed")
+		}
+		return true, err
+	}
+}
+
+// intersectPoints builds the ladder of points offered to FindIntersect.
+// Recent points first so a reconnect resumes where the previous session
+// stopped, thinning out with depth, and always ending at origin so the
+// intersect succeeds even when the node has rolled back past everything
+// we retained or has been rebuilt from scratch.
+func (o *ChainObservers) intersectPoints(
+	chain *ObservedChain,
+) []pcommon.Point {
+	headers := chain.Snapshot().Headers
+	points := make([]pcommon.Point, 0, 12)
+	for step := 1; step <= len(headers); step *= 2 {
+		h := headers[len(headers)-step]
+		points = append(points, pcommon.NewPoint(h.Slot, h.Hash))
+	}
+	return append(points, pcommon.NewPointOrigin())
+}
+
+// tipFrom converts the peer's reported tip into the harness type.
+func tipFrom(t chainsync.Tip) ChainTip {
+	return ChainTip{
+		SlotNumber:  t.Point.Slot,
+		BlockNumber: t.BlockNumber,
+		Hash:        t.Point.Hash,
+	}
+}

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -25,8 +25,17 @@
 # Usage:
 #   ./run-tests.sh                    # Run all devnet tests (default: all-dingo network)
 #   ./run-tests.sh --conformance      # Run against the dingo + cardano-node reference network
+#   ./run-tests.sh --accelerated      # Run the fast event-driven scenario timeline
 #   ./run-tests.sh -run TestBasic     # Run specific test pattern
 #   ./run-tests.sh --keep-up          # Don't tear down on success (for debugging)
+#
+# --accelerated brings the network up on the accelerated spec (shorter
+# slots, epochs and security parameter) and runs the single scenario
+# timeline in scenarios/accelerated_timeline_test.go, which is bounded by
+# a hard timeout. It composes with --conformance to run the same timeline
+# against the dingo + cardano-node topology. Without it the canonical
+# timing network and the full suite run as before, which is what soak and
+# canary runs use.
 
 set -euo pipefail
 
@@ -36,14 +45,19 @@ COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 
 # Parse arguments
 KEEP_UP=false
+ACCELERATED=false
 # Mode selection: default dingo (all-dingo network), --conformance for the
 # dingo + cardano-node reference network.
 MODE="${MODE:-dingo}"
 TEST_ARGS=()
+USER_RUN_FILTER=false
 for arg in "$@"; do
   case "${arg}" in
     --keep-up)     KEEP_UP=true ;;
     --conformance) MODE="conformance" ;;
+    --accelerated) ACCELERATED=true ;;
+    -run|-run=*|-test.run=*)
+                   USER_RUN_FILTER=true; TEST_ARGS+=("${arg}") ;;
     *)             TEST_ARGS+=("${arg}") ;;
   esac
 done
@@ -56,12 +70,37 @@ if [[ "${MODE}" == "conformance" ]]; then
   GO_TAGS="devnet devnet_conformance"
   HEALTH_SERVICES=(dingo-producer cardano-producer cardano-relay)
   TXPUMP_SERVICE="txpump"
+  SPEC_VAR="DEVNET_CONFORMANCE_SPEC"
+  CANONICAL_SPEC="./testnet.yaml"
+  ACCELERATED_SPEC="./testnet-accelerated.yaml"
 else
   export COMPOSE_PROFILES="dingo"
   GO_TAGS="devnet"
   HEALTH_SERVICES=(dingo-1 dingo-2 dingo-3 dingo-relay)
   TXPUMP_SERVICE="txpump-dingo"
+  SPEC_VAR="DEVNET_DINGO_SPEC"
+  CANONICAL_SPEC="./testnet-dingo.yaml"
+  ACCELERATED_SPEC="./testnet-dingo-accelerated.yaml"
 fi
+
+# Select the network spec the configurator generates genesis from, and
+# point the Go harness at the same file so its derived timings match the
+# network that is actually running.
+if [[ "${ACCELERATED}" == "true" ]]; then
+  ACTIVE_SPEC="${ACCELERATED_SPEC}"
+  export DEVNET_ACCELERATED=1
+else
+  ACTIVE_SPEC="${CANONICAL_SPEC}"
+fi
+export "${SPEC_VAR}=${ACTIVE_SPEC}"
+export DEVNET_TESTNET_YAML="${SCRIPT_DIR}/${ACTIVE_SPEC#./}"
+# The scenario stops and starts containers, and captures compose logs and
+# status on failure.
+export DEVNET_COMPOSE_FILE="${COMPOSE_FILE}"
+
+# Failure evidence goes here and is preserved when the run fails.
+DEVNET_ARTIFACT_DIR="${DEVNET_ARTIFACT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/dingo-devnet-artifacts.XXXXXX")}"
+export DEVNET_ARTIFACT_DIR
 
 # --------------------------------------------------------------------------- #
 # Logging
@@ -75,6 +114,33 @@ die()  { echo "[run-tests] ERROR: $*" >&2; exit 1; }
 # Cleanup on exit
 # --------------------------------------------------------------------------- #
 
+# collect_failure_artifacts preserves everything a post-mortem needs
+# before the network (and its volumes) are removed: container status, full
+# node logs, and the genesis/configuration the configurator generated.
+collect_failure_artifacts() {
+  local dest="${DEVNET_ARTIFACT_DIR}/network"
+  mkdir -p "${dest}" 2>/dev/null || return 0
+  docker compose -f "${COMPOSE_FILE}" ps --all \
+    >"${dest}/container-status.txt" 2>&1 || true
+  docker compose -f "${COMPOSE_FILE}" logs --no-color \
+    >"${dest}/compose.log" 2>&1 || true
+  cp "${SCRIPT_DIR}/${ACTIVE_SPEC#./}" "${dest}/" 2>/dev/null || true
+  # The generated genesis and node config live on the pool-1 config
+  # volume; copy them out while the volume still exists.
+  local configs_volume
+  configs_volume="$(docker volume ls \
+    --filter label=com.docker.compose.volume=p1-configs \
+    --format '{{.Name}}' | head -n1)"
+  if [[ -n "${configs_volume}" ]]; then
+    docker run --rm \
+      -v "${configs_volume}:/c:ro" \
+      -v "${dest}:/out" \
+      alpine sh -c 'cp -r /c/configs /out/generated-configs' \
+      2>/dev/null || true
+  fi
+  log "Failure artifacts preserved in ${DEVNET_ARTIFACT_DIR}"
+}
+
 cleanup() {
   local exit_code=$?
   if [[ "${KEEP_UP}" == "true" ]] && [[ ${exit_code} -eq 0 ]]; then
@@ -85,6 +151,9 @@ cleanup() {
   if [[ ${exit_code} -ne 0 ]]; then
     log "Collecting logs before teardown..."
     docker compose -f "${COMPOSE_FILE}" logs --tail=100 2>/dev/null || true
+    collect_failure_artifacts
+  else
+    rm -rf "${DEVNET_ARTIFACT_DIR}"
   fi
   log "Tearing down DevNet..."
   docker compose -f "${COMPOSE_FILE}" down -v 2>/dev/null || true
@@ -109,6 +178,9 @@ fi
 # --------------------------------------------------------------------------- #
 # Start DevNet
 # --------------------------------------------------------------------------- #
+
+log "Mode: ${MODE}$([[ "${ACCELERATED}" == "true" ]] && echo ' (accelerated)')"
+log "Network spec: ${ACTIVE_SPEC}"
 
 log "Building DevNet Docker images..."
 # No service names: compose only builds services in the active
@@ -232,8 +304,19 @@ else
 fi
 
 # Run tests with the mode's build tags.
-# The -count=1 flag disables test caching
-TEST_TIMEOUT="${TEST_TIMEOUT:-20m}"
+# The -count=1 flag disables test caching.
+#
+# The accelerated run is a single scenario timeline, so it selects that
+# test and takes a much tighter timeout: the scenario enforces its own
+# hard timeout internally, and this is the outer backstop.
+if [[ "${ACCELERATED}" == "true" ]]; then
+  TEST_TIMEOUT="${TEST_TIMEOUT:-8m}"
+  if [[ "${USER_RUN_FILTER}" == "false" ]]; then
+    TEST_ARGS+=(-run 'TestAcceleratedScenarioTimeline')
+  fi
+else
+  TEST_TIMEOUT="${TEST_TIMEOUT:-20m}"
+fi
 set +e
 go test \
   -tags "${GO_TAGS}" \

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -56,7 +56,7 @@ for arg in "$@"; do
     --keep-up)     KEEP_UP=true ;;
     --conformance) MODE="conformance" ;;
     --accelerated) ACCELERATED=true ;;
-    -run|-run=*|-test.run=*)
+    -run|-run=*|-test.run|-test.run=*)
                    USER_RUN_FILTER=true; TEST_ARGS+=("${arg}") ;;
     *)             TEST_ARGS+=("${arg}") ;;
   esac
@@ -91,6 +91,10 @@ if [[ "${ACCELERATED}" == "true" ]]; then
   export DEVNET_ACCELERATED=1
 else
   ACTIVE_SPEC="${CANONICAL_SPEC}"
+  # Only --accelerated enables the accelerated scenario. Inheriting a stale
+  # DEVNET_ACCELERATED=1 would run it against the canonical-timing network,
+  # whose budget it is designed not to meet, failing the whole suite.
+  unset DEVNET_ACCELERATED
 fi
 export "${SPEC_VAR}=${ACTIVE_SPEC}"
 export DEVNET_TESTNET_YAML="${SCRIPT_DIR}/${ACTIVE_SPEC#./}"
@@ -98,8 +102,15 @@ export DEVNET_TESTNET_YAML="${SCRIPT_DIR}/${ACTIVE_SPEC#./}"
 # status on failure.
 export DEVNET_COMPOSE_FILE="${COMPOSE_FILE}"
 
-# Failure evidence goes here and is preserved when the run fails.
-DEVNET_ARTIFACT_DIR="${DEVNET_ARTIFACT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/dingo-devnet-artifacts.XXXXXX")}"
+# Failure evidence goes here and is preserved when the run fails. A
+# caller-supplied directory is used as-is and never deleted; only one this
+# script created is cleaned up on success, so a passing run cannot destroy
+# a shared or pre-existing path.
+ARTIFACT_DIR_IS_OURS=false
+if [[ -z "${DEVNET_ARTIFACT_DIR:-}" ]]; then
+  DEVNET_ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dingo-devnet-artifacts.XXXXXX")"
+  ARTIFACT_DIR_IS_OURS=true
+fi
 export DEVNET_ARTIFACT_DIR
 
 # --------------------------------------------------------------------------- #
@@ -152,7 +163,7 @@ cleanup() {
     log "Collecting logs before teardown..."
     docker compose -f "${COMPOSE_FILE}" logs --tail=100 2>/dev/null || true
     collect_failure_artifacts
-  else
+  elif [[ "${ARTIFACT_DIR_IS_OURS}" == "true" ]]; then
     rm -rf "${DEVNET_ARTIFACT_DIR}"
   fi
   log "Tearing down DevNet..."

--- a/internal/test/devnet/scenarios/accelerated_timeline_test.go
+++ b/internal/test/devnet/scenarios/accelerated_timeline_test.go
@@ -1,0 +1,413 @@
+//go:build devnet
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/devnet"
+	"github.com/stretchr/testify/require"
+)
+
+// minTxBearingBodySize is the block body size above which a block is
+// taken to be carrying transactions.
+//
+// An empty Conway block body is a four-element CBOR array of empty
+// arrays — a handful of bytes. The smallest transaction txpump submits
+// is a signed payment well over 200 bytes. Anything above this threshold
+// therefore cannot be an empty block, and any block with a transaction
+// in it clears the threshold comfortably. Body size is used because the
+// mixed cardano-node topology publishes no node-to-client port, so the
+// Node-to-Node header stream is the only evidence available in both
+// topologies.
+const minTxBearingBodySize = 128
+
+// TestAcceleratedScenarioTimeline is the fast, event-driven scenario used
+// for scheduled and release integration evidence.
+//
+// One timeline covers readiness, block and transaction propagation, chain
+// agreement, an epoch transition, a controlled peer interruption with
+// recovery, and a relay restart. Every wait is a condition over observed
+// ChainSync events bounded by a deadline on that single shared clock, so
+// phases hand their slack forward instead of each one paying for its own
+// relative slot window. The canonical-timing DevNet keeps the statistical
+// block-rate and long-wall-clock checks; nothing here samples a rate.
+//
+// It runs in both supported topologies — all-Dingo producers plus relay,
+// and Dingo beside cardano-node — because it derives every node it acts
+// on from LoadEndpoints rather than naming containers.
+func TestAcceleratedScenarioTimeline(t *testing.T) {
+	if os.Getenv("DEVNET_ACCELERATED") != "1" {
+		t.Skip(
+			"accelerated scenario requires the accelerated network; run" +
+				" internal/test/devnet/run-tests.sh --accelerated",
+		)
+	}
+
+	cfg, err := devnet.LoadDevNetConfig()
+	require.NoError(t, err, "failed to load the devnet network spec")
+	require.NoError(t, cfg.Validate(), "network spec is not internally valid")
+
+	plan, err := devnet.NewScenarioPlan(cfg)
+	require.NoError(t, err)
+	require.True(t, plan.FitsReferenceBudget(),
+		"this network's timing cannot meet the reference runner budget"+
+			" (%s > %s); use an accelerated spec",
+		plan.Total(), devnet.ReferenceRunnerBudget,
+	)
+	t.Log(plan.String())
+
+	endpoints := devnet.LoadEndpoints()
+	require.NotEmpty(t, endpoints)
+
+	ctl, err := devnet.NewNodeControl(t.Logf)
+	require.NoError(t, err,
+		"the scenario must be able to interrupt and restart nodes")
+
+	// One clock for the whole scenario, with the hard timeout the issue
+	// asks for wrapped around it.
+	start := time.Now()
+	scenarioCtx, cancelScenario := context.WithTimeout(
+		context.Background(), plan.HardTimeout,
+	)
+	defer cancelScenario()
+
+	observers := devnet.StartObservers(
+		scenarioCtx, endpoints, cfg.NetworkMagic, t.Logf,
+	)
+	defer observers.Stop()
+	group := observers.Group()
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		// Preserve the evidence before the network is torn down: what
+		// each node's chain actually did, container status, and logs.
+		capCtx, capCancel := context.WithTimeout(
+			context.Background(), time.Minute,
+		)
+		defer capCancel()
+		services := make([]string, 0, len(endpoints))
+		for _, ep := range endpoints {
+			if ep.Container != "" {
+				services = append(services, ep.Container)
+			}
+		}
+		ctl.CaptureFailureArtifacts(
+			capCtx, "accelerated-timeline", group.Snapshots(), services,
+		)
+	})
+
+	// phase returns a context that expires at the phase's deadline on the
+	// shared timeline, not after a fresh per-phase duration.
+	phase := func(name string) (context.Context, context.CancelFunc) {
+		ph, ok := plan.Phase(name)
+		require.True(t, ok, "unknown phase %q", name)
+		remaining := time.Until(start.Add(ph.Deadline))
+		t.Logf(
+			"=== phase %s: deadline %s from start (%s remaining)",
+			name, ph.Deadline, remaining.Round(time.Millisecond),
+		)
+		return context.WithDeadline(scenarioCtx, start.Add(ph.Deadline))
+	}
+
+	// --- readiness ---------------------------------------------------
+	readyCtx, cancel := phase(devnet.PhaseReadiness)
+	require.NoError(t, group.Await(readyCtx,
+		"every node accepted a chain-sync session and sent a header",
+		func(snaps []devnet.ChainSnapshot) bool {
+			for _, s := range snaps {
+				if !s.Connected || s.RollForwards == 0 {
+					return false
+				}
+			}
+			return true
+		}))
+	cancel()
+	t.Logf("readiness: %d nodes streaming chain events", len(endpoints))
+
+	// --- block and transaction propagation ---------------------------
+	// Baseline at the highest tip the *nodes* report, not the highest an
+	// observer has replayed to. An observer intersects at origin and
+	// walks history first, so a baseline from its own tip would let an
+	// already-replayed header pass as a newly forged one.
+	baseline := devnet.MaxServerTipSlot(group.Snapshots())
+	propCtx, cancel := phase(devnet.PhasePropagation)
+
+	var propagated devnet.ObservedHeader
+	require.NoError(t, group.Await(propCtx,
+		fmt.Sprintf("a block forged above slot %d reaches every node",
+			baseline),
+		func(snaps []devnet.ChainSnapshot) bool {
+			h, ok := devnet.AgreedHeaderAbove(snaps, baseline)
+			if ok {
+				propagated = h
+			}
+			return ok
+		}))
+	t.Logf(
+		"block propagation: slot %d block %d reached all %d nodes",
+		propagated.Slot, propagated.BlockNumber, len(endpoints),
+	)
+
+	var carrying devnet.ObservedHeader
+	require.NoError(t, group.Await(propCtx,
+		"a block carrying transactions reaches every node",
+		func(snaps []devnet.ChainSnapshot) bool {
+			from := baseline
+			for {
+				h, ok := devnet.AgreedHeaderAbove(snaps, from)
+				if !ok {
+					return false
+				}
+				if h.BodySize >= minTxBearingBodySize {
+					carrying = h
+					return true
+				}
+				from = h.Slot
+			}
+		}))
+	cancel()
+	t.Logf(
+		"transaction propagation: slot %d carries a %d-byte body on all"+
+			" nodes", carrying.Slot, carrying.BodySize,
+	)
+
+	// --- chain agreement ---------------------------------------------
+	agreeCtx, cancel := phase(devnet.PhaseAgreement)
+	requireAgreement(t, agreeCtx, group, "steady state")
+	cancel()
+	requireBoundedRollbacks(t, group, cfg)
+
+	// --- epoch transition --------------------------------------------
+	// Derive the boundary from where the chain actually is, so the
+	// scenario crosses a real transition whether it attached at genesis
+	// or to a network that has been up for a while. NextEpochBoundary is
+	// strictly greater than its input, so taking the nodes' reported tip
+	// puts the target in the future rather than on a boundary the chain
+	// has already passed.
+	boundary := cfg.NextEpochBoundary(
+		devnet.MaxServerTipSlot(group.Snapshots()),
+	)
+	target := boundary + plan.EpochMargin
+	epochCtx, cancel := phase(devnet.PhaseEpochTransition)
+	require.NoError(t, group.Await(epochCtx,
+		fmt.Sprintf(
+			"every node past slot %d, i.e. %d slots beyond the epoch"+
+				" boundary at %d", target, plan.EpochMargin, boundary),
+		func(snaps []devnet.ChainSnapshot) bool {
+			return devnet.MinTipSlot(snaps) >= target
+		}))
+	// Agreement on a header built after the boundary exercises the new
+	// epoch nonce, not just the boundary block itself.
+	require.NoError(t, group.Await(epochCtx,
+		fmt.Sprintf("every node agrees on a header above the epoch"+
+			" boundary at %d", boundary),
+		func(snaps []devnet.ChainSnapshot) bool {
+			h, ok := devnet.AgreedHeaderAbove(snaps, boundary)
+			return ok && h.Slot > boundary
+		}))
+	cancel()
+	t.Logf("epoch transition: crossed the boundary at slot %d", boundary)
+
+	// --- controlled peer interruption and recovery -------------------
+	// The last producer is deliberately not the one txpump submits to,
+	// so mempool traffic keeps flowing through the outage.
+	victim := lastProducer(t, endpoints)
+	interruptCtx, cancel := phase(devnet.PhasePeerInterruption)
+	runOutage(t, interruptCtx, ctl, group, plan, victim, "peer interruption")
+	cancel()
+
+	// --- relay restart -----------------------------------------------
+	relay := relayEndpoint(t, endpoints)
+	relayCtx, cancel := phase(devnet.PhaseRelayRestart)
+	runOutage(t, relayCtx, ctl, group, plan, relay, "relay restart")
+	cancel()
+
+	requireBoundedRollbacks(t, group, cfg)
+	t.Logf(
+		"accelerated scenario completed in %s (hard timeout %s)",
+		time.Since(start).Round(time.Millisecond), plan.HardTimeout,
+	)
+}
+
+// runOutage stops a node, holds it down until the rest of the network has
+// visibly moved on, brings it back, and requires it to rejoin and
+// reconverge.
+//
+// The outage length is measured in observed blocks rather than wall
+// clock: that keeps the disruption equally meaningful on a fast and a
+// slow runner, and keeps it inside what the security parameter can
+// reconcile.
+func runOutage(
+	t *testing.T,
+	ctx context.Context,
+	ctl *devnet.NodeControl,
+	group *devnet.ChainGroup,
+	plan *devnet.ScenarioPlan,
+	ep devnet.NodeEndpoint,
+	label string,
+) {
+	t.Helper()
+	require.NotEmpty(t, ep.Container,
+		"%s: %s has no container to control", label, ep.Name)
+
+	chain := group.Chain(ep.Name)
+	require.NotNil(t, chain, "%s: no observer for %s", label, ep.Name)
+
+	before := chain.Snapshot()
+	survivorBlock := maxBlockExcluding(group.Snapshots(), ep.Name)
+
+	require.NoError(t, ctl.Stop(ctx, ep.Container),
+		"%s: stopping %s", label, ep.Container)
+
+	// The dropped session is the observed evidence that the interruption
+	// actually happened, rather than an assumption that the stop worked.
+	require.NoError(t, chain.Await(ctx,
+		label+": chain-sync session to "+ep.Name+" dropped",
+		func(s devnet.ChainSnapshot) bool {
+			return s.Disconnects > before.Disconnects
+		}))
+
+	require.NoError(t, group.Await(ctx,
+		fmt.Sprintf("%s: the network advances %d blocks while %s is down",
+			label, plan.OutageBlocks, ep.Name),
+		func(snaps []devnet.ChainSnapshot) bool {
+			return maxBlockExcluding(snaps, ep.Name) >=
+				survivorBlock+plan.OutageBlocks
+		}))
+
+	require.NoError(t, ctl.Start(ctx, ep.Container),
+		"%s: starting %s", label, ep.Container)
+
+	require.NoError(t, group.Await(ctx,
+		label+": "+ep.Name+" rejoins and catches up to the network",
+		func(snaps []devnet.ChainSnapshot) bool {
+			target := maxBlockExcluding(snaps, ep.Name)
+			for _, s := range snaps {
+				if s.Node != ep.Name {
+					continue
+				}
+				// Two blocks of slack: the network keeps producing while
+				// the node syncs, so requiring an exact match would chase
+				// a moving tip forever.
+				return s.Connected && s.Tip.BlockNumber+2 >= target
+			}
+			return false
+		}))
+
+	requireAgreement(t, ctx, group, label+": after recovery")
+
+	after := chain.Snapshot()
+	t.Logf(
+		"%s: %s recovered (connects %d->%d, tip slot %d, block %d)",
+		label, ep.Name, before.Connects, after.Connects,
+		after.Tip.SlotNumber, after.Tip.BlockNumber,
+	)
+}
+
+// requireAgreement waits until every node agrees on the chain at the
+// deepest slot they have all observed.
+func requireAgreement(
+	t *testing.T,
+	ctx context.Context,
+	group *devnet.ChainGroup,
+	label string,
+) {
+	t.Helper()
+	var result devnet.AgreementResult
+	require.NoError(t, group.Await(ctx,
+		label+": nodes agree at their deepest common slot",
+		func(snaps []devnet.ChainSnapshot) bool {
+			res, ok := devnet.AgreementAtDeepestCommonSlot(snaps)
+			if !ok {
+				return false
+			}
+			result = res
+			return res.Agree
+		}))
+	t.Logf("%s: %s", label, result)
+}
+
+// requireBoundedRollbacks fails if any node reverted more than the
+// security parameter allows, which would mean chain selection went
+// further back than Praos permits rather than merely recovering.
+func requireBoundedRollbacks(
+	t *testing.T,
+	group *devnet.ChainGroup,
+	cfg *devnet.DevNetConfig,
+) {
+	t.Helper()
+	for _, s := range group.Snapshots() {
+		require.LessOrEqualf(t, s.MaxRollbackDepth, cfg.SecurityParam,
+			"%s rolled back %d headers, beyond k=%d",
+			s.Node, s.MaxRollbackDepth, cfg.SecurityParam,
+		)
+	}
+}
+
+// maxBlockExcluding returns the highest observed block height among every
+// node other than the named one.
+func maxBlockExcluding(snaps []devnet.ChainSnapshot, node string) uint64 {
+	var maxBlock uint64
+	for _, s := range snaps {
+		if s.Node == node {
+			continue
+		}
+		if s.Tip.BlockNumber > maxBlock {
+			maxBlock = s.Tip.BlockNumber
+		}
+	}
+	return maxBlock
+}
+
+// lastProducer returns the final producer in the endpoint list. Both
+// topologies put the node txpump submits to first, so this is always a
+// producer whose loss leaves the transaction path intact.
+func lastProducer(
+	t *testing.T,
+	endpoints []devnet.NodeEndpoint,
+) devnet.NodeEndpoint {
+	t.Helper()
+	var found devnet.NodeEndpoint
+	for _, ep := range endpoints {
+		if ep.Role == "producer" {
+			found = ep
+		}
+	}
+	require.NotEmpty(t, found.Name, "no producer endpoint configured")
+	return found
+}
+
+func relayEndpoint(
+	t *testing.T,
+	endpoints []devnet.NodeEndpoint,
+) devnet.NodeEndpoint {
+	t.Helper()
+	for _, ep := range endpoints {
+		if ep.Role == "relay" {
+			return ep
+		}
+	}
+	t.Fatal("no relay endpoint configured")
+	return devnet.NodeEndpoint{}
+}

--- a/internal/test/devnet/scenarios/accelerated_timeline_test.go
+++ b/internal/test/devnet/scenarios/accelerated_timeline_test.go
@@ -319,6 +319,20 @@ func runOutage(
 
 	requireAgreement(t, ctx, group, label+": after recovery")
 
+	// Agreement alone only says the nodes converged; it does not say the
+	// network resumed producing. Without this the next phase can stack a
+	// second outage onto a network that has converged but stalled, and
+	// then blame the second outage for the stall. Requiring forward
+	// progress first means each disruption starts from a healthy
+	// baseline.
+	resumed := devnet.MaxBlockNumber(group.Snapshots())
+	require.NoError(t, group.Await(ctx,
+		fmt.Sprintf("%s: block production resumed after recovery"+
+			" (past block %d)", label, resumed),
+		func(snaps []devnet.ChainSnapshot) bool {
+			return devnet.MaxBlockNumber(snaps) > resumed
+		}))
+
 	after := chain.Snapshot()
 	t.Logf(
 		"%s: %s recovered (connects %d->%d, tip slot %d, block %d)",

--- a/internal/test/devnet/scenarios/accelerated_timeline_test.go
+++ b/internal/test/devnet/scenarios/accelerated_timeline_test.go
@@ -223,8 +223,10 @@ func TestAcceleratedScenarioTimeline(t *testing.T) {
 		fmt.Sprintf("every node agrees on a header above the epoch"+
 			" boundary at %d", boundary),
 		func(snaps []devnet.ChainSnapshot) bool {
-			h, ok := devnet.AgreedHeaderAbove(snaps, boundary)
-			return ok && h.Slot > boundary
+			// AgreedHeaderAbove only returns headers above its bound, so
+			// finding one is already proof of agreement past the boundary.
+			_, ok := devnet.AgreedHeaderAbove(snaps, boundary)
+			return ok
 		}))
 	cancel()
 	t.Logf("epoch transition: crossed the boundary at slot %d", boundary)
@@ -232,7 +234,7 @@ func TestAcceleratedScenarioTimeline(t *testing.T) {
 	// --- controlled peer interruption and recovery -------------------
 	// The last producer is deliberately not the one txpump submits to,
 	// so mempool traffic keeps flowing through the outage.
-	victim := lastProducer(t, endpoints)
+	victim := interruptionVictim(t, endpoints)
 	interruptCtx, cancel := phase(devnet.PhasePeerInterruption)
 	runOutage(t, interruptCtx, ctl, group, plan, victim, "peer interruption")
 	cancel()
@@ -380,22 +382,36 @@ func maxBlockExcluding(snaps []devnet.ChainSnapshot, node string) uint64 {
 	return maxBlock
 }
 
-// lastProducer returns the final producer in the endpoint list. Both
-// topologies put the node txpump submits to first, so this is always a
-// producer whose loss leaves the transaction path intact.
-func lastProducer(
+// interruptionVictim returns the producer to stop during the peer
+// interruption phase: the last one in the endpoint list.
+//
+// txpump submits to the first producer in both topologies, so choosing the
+// last one keeps transactions flowing through the outage. That ordering is
+// a property of LoadEndpoints and docker-compose rather than something the
+// types enforce, so it is asserted here instead of assumed: if the list is
+// ever reordered so that the victim is also the submission target, this
+// fails loudly rather than silently removing the mempool traffic the phase
+// depends on.
+func interruptionVictim(
 	t *testing.T,
 	endpoints []devnet.NodeEndpoint,
 ) devnet.NodeEndpoint {
 	t.Helper()
-	var found devnet.NodeEndpoint
+	var first, last devnet.NodeEndpoint
 	for _, ep := range endpoints {
-		if ep.Role == "producer" {
-			found = ep
+		if ep.Role != "producer" {
+			continue
 		}
+		if first.Name == "" {
+			first = ep
+		}
+		last = ep
 	}
-	require.NotEmpty(t, found.Name, "no producer endpoint configured")
-	return found
+	require.NotEmpty(t, last.Name, "no producer endpoint configured")
+	require.NotEqual(t, first.Name, last.Name,
+		"the interruption victim must not be the producer txpump submits"+
+			" to, or the outage also stops mempool traffic")
+	return last
 }
 
 func relayEndpoint(

--- a/internal/test/devnet/scenarios/basic_forging_test.go
+++ b/internal/test/devnet/scenarios/basic_forging_test.go
@@ -128,8 +128,12 @@ func TestDingoChainAdvances(t *testing.T) {
 
 	dingoEndpoint := h.DingoNode()
 
-	// Wait for Dingo to be reachable
-	h.WaitForNodeSlot(dingoEndpoint, 0, 60*time.Second)
+	// Wait for the chain to actually start. Waiting for "slot >= 0" was
+	// a no-op — every tip satisfies it, including the slot 0 / block 0 a
+	// node reports for ~30s before genesis — so the slot-derived budget
+	// below was charged against the pre-genesis wait and this test only
+	// passed when an earlier test in the package had already absorbed it.
+	h.WaitForChainStart(devnet.ChainStartTimeout)
 
 	// Get initial tip
 	initialTip, err := h.GetChainTip(dingoEndpoint)

--- a/internal/test/devnet/scenarios/chain_growth_test.go
+++ b/internal/test/devnet/scenarios/chain_growth_test.go
@@ -59,8 +59,11 @@ func TestChainGrowthRate(t *testing.T) {
 	dingoEndpoint := h.DingoNode()
 
 	// Wait for the chain to stabilize at slot 50.
-	// Timeout: 50 slots + 5 expected block times for margin.
+	// Timeout: 50 slots + 5 expected block times for margin, measured
+	// from chain start — readiness alone is reached before genesis, and
+	// the budget below only counts chain time.
 	h.WaitForAllNodesReady(60 * time.Second)
+	h.WaitForChainStart(devnet.ChainStartTimeout)
 	const stabilizeSlot = 50
 	stabilizeTimeout := time.Duration(stabilizeSlot)*cfg.SlotDuration() +
 		cfg.ExpectedBlockTime()*5
@@ -152,8 +155,11 @@ func TestRelayPropagation(t *testing.T) {
 
 	relayEndpoint := h.Relay()
 
-	// Wait for all nodes including relay
+	// Wait for all nodes including relay, then for the chain to start:
+	// the slot-derived timeout below only counts chain time and must not
+	// be charged against the pre-genesis wait.
 	h.WaitForAllNodesReady(60 * time.Second)
+	h.WaitForChainStart(devnet.ChainStartTimeout)
 
 	// Wait for the relay to advance to slot 30.
 	// Timeout: 30 slots + 5 expected block times for margin.
@@ -189,6 +195,9 @@ func TestSustainedConsensus(t *testing.T) {
 	)
 
 	h.WaitForAllNodesReady(60 * time.Second)
+	// The checkpoints below are relative to this baseline but their
+	// timeouts are not, so the chain has to be live before it is taken.
+	h.WaitForChainStart(devnet.ChainStartTimeout)
 
 	// Get the current tip to compute relative checkpoints.
 	// The chain may already be well past genesis when the tests run.

--- a/internal/test/devnet/scenarios/epoch_boundary_test.go
+++ b/internal/test/devnet/scenarios/epoch_boundary_test.go
@@ -53,6 +53,11 @@ func TestEpochBoundaryConsensus(t *testing.T) {
 	)
 
 	h.WaitForAllNodesReady(60 * time.Second)
+	// The budget below covers 1.4 epochs of chain time and nothing more.
+	// Without this gate it is also charged the ~30s spent waiting for
+	// genesis, which leaves under a second of margin: an isolated run
+	// measured 724.04s against its own 725s timeout.
+	h.WaitForChainStart(devnet.ChainStartTimeout)
 
 	// Target a slot well past the first epoch boundary so we have
 	// blocks on both sides of the rollover. 1.4 * epochLength puts

--- a/internal/test/devnet/start.sh
+++ b/internal/test/devnet/start.sh
@@ -22,6 +22,7 @@
 # Usage:
 #   ./start.sh               # all-dingo network (default)
 #   ./start.sh --conformance # dingo + cardano-node reference network
+#   ./start.sh --accelerated # bring the network up on the accelerated spec
 
 set -euo pipefail
 
@@ -29,9 +30,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Mode selection precedence: CLI, COMPOSE_PROFILES, then dingo.
 MODE=""
+ACCELERATED=false
 for arg in "$@"; do
   case "${arg}" in
     --conformance) MODE="conformance" ;;
+    --accelerated) ACCELERATED=true ;;
     *)
       echo "Unknown argument: ${arg}" >&2
       exit 1
@@ -47,6 +50,27 @@ case "${MODE}" in
     exit 1
     ;;
 esac
+
+# Pick the network spec the configurator generates genesis from. The
+# accelerated spec compresses slot, epoch and security-parameter timing so
+# a full scenario fits the reference-runner budget; the canonical spec is
+# what soak and canary runs use.
+if [[ "${ACCELERATED}" == "true" ]]; then
+  if [[ "${MODE}" == "conformance" ]]; then
+    export DEVNET_CONFORMANCE_SPEC="./testnet-accelerated.yaml"
+    ACTIVE_SPEC="${DEVNET_CONFORMANCE_SPEC}"
+  else
+    export DEVNET_DINGO_SPEC="./testnet-dingo-accelerated.yaml"
+    ACTIVE_SPEC="${DEVNET_DINGO_SPEC}"
+  fi
+  echo "Using accelerated network spec: ${ACTIVE_SPEC}"
+  echo "Run the scenario with:"
+  echo "  DEVNET_ACCELERATED=1 \\"
+  echo "  DEVNET_TESTNET_YAML=${SCRIPT_DIR}/${ACTIVE_SPEC#./} \\"
+  echo "  DEVNET_COMPOSE_FILE=${SCRIPT_DIR}/docker-compose.yml \\"
+  echo "  go test -tags devnet -run TestAcceleratedScenarioTimeline \\"
+  echo "    -timeout 8m ./internal/test/devnet/scenarios/"
+fi
 
 echo "Starting DevNet containers (mode: ${MODE})..."
 docker compose -f "${SCRIPT_DIR}/docker-compose.yml" up -d

--- a/internal/test/devnet/stop.sh
+++ b/internal/test/devnet/stop.sh
@@ -19,6 +19,9 @@
 # Usage:
 #   ./stop.sh               # all-dingo network (default)
 #   ./stop.sh --conformance # dingo + cardano-node reference network
+#   ./stop.sh --accelerated # accepted and ignored; teardown removes the
+#                           # profile's volumes regardless of which network
+#                           # spec generated them
 
 set -euo pipefail
 
@@ -29,6 +32,10 @@ MODE=""
 for arg in "$@"; do
   case "${arg}" in
     --conformance) MODE="conformance" ;;
+    # Teardown is spec-independent, but accept the flag so a --accelerated
+    # bring-up can be torn down with the same arguments it was started
+    # with.
+    --accelerated) ;;
     *)
       echo "Unknown argument: ${arg}" >&2
       exit 1

--- a/internal/test/devnet/testnet-accelerated.yaml
+++ b/internal/test/devnet/testnet-accelerated.yaml
@@ -1,0 +1,63 @@
+# DevNet configurator spec: accelerated conformance network (2 pools).
+#
+# The mixed Dingo/cardano-node counterpart to
+# testnet-dingo-accelerated.yaml: same compressed consensus timing, but
+# the two-pool layout the conformance profile wires up. The canonical
+# testnet.yaml stays the configuration for soak and canary runs.
+#
+# Timing invariants (enforced by DevNetConfig.Validate, covered by
+# internal/test/devnet/config_test.go):
+#   nonceStabilityWindow      = 4k/f = 4*10/0.4 = 100 < 120 = epochLength
+#   blockfetchStabilityWindow = 3k/f = 3*10/0.4 =  75 < 120 = epochLength
+#
+# Partition tolerance with two pools: per-pool rate = 1-(1-f)^(1/n), which
+# for f=0.4, n=2 is ~0.225 blocks/slot, so k=10 corresponds to roughly
+# 45 slots (~22s at 0.5s slots) of isolation. The scenario's interruption
+# hold is derived from k and stays well inside that.
+#
+# Format: 6 YAML documents (see testnet.yaml for the document map).
+
+--- # Required Testnet Parameters
+poolCount: 2
+poolCost: 0
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 2000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: devnet
+
+--- # Byron Genesis Override
+protocolConsts:
+  k: 10
+
+--- # Shelley Genesis Override
+epochLength: 120
+slotLength: 0.5
+activeSlotsCoeff: 0.4
+securityParam: 10
+maxLovelaceSupply: 6000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Alonzo Genesis Override
+
+--- # Conway Genesis Override
+
+--- # Node Config Override
+TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+TraceForge: true
+TraceChainDb: true
+TraceMempool: true
+TurnOnLogging: true

--- a/internal/test/devnet/testnet-dingo-accelerated.yaml
+++ b/internal/test/devnet/testnet-dingo-accelerated.yaml
@@ -1,0 +1,68 @@
+# DevNet configurator spec: accelerated all-dingo network (3 pools).
+#
+# Mirrors testnet-dingo.yaml but with compressed consensus timing so one
+# scenario timeline — readiness, propagation, agreement, an epoch
+# transition, a peer interruption, and a relay restart — fits the
+# reference-runner budget in internal/test/devnet/README.md. The canonical
+# testnet-dingo.yaml stays the configuration for soak and canary runs;
+# this file is not a replacement for it.
+#
+# Timing invariants (enforced by DevNetConfig.Validate, covered by
+# internal/test/devnet/config_test.go so a bad edit fails in CI rather
+# than as a DevNet stall):
+#   nonceStabilityWindow     = 4k/f = 4*10/0.4 = 100 < 120 = epochLength
+#   blockfetchStabilityWindow = 3k/f = 3*10/0.4 =  75 < 120 = epochLength
+# The candidate nonce therefore freezes 100 slots before the epoch ends,
+# at slot 20 of each epoch, and still inside the epoch.
+#
+# With slotLength 0.5s an epoch is 60s of wall clock and the network
+# produces a block every ~1.25s (f=0.4), so a full epoch transition is
+# reachable inside a single short scenario.
+#
+# Format: 6 YAML documents (see testnet.yaml for the document map).
+
+--- # Required Testnet Parameters
+poolCount: 3
+poolCost: 0
+poolMargin: 0.0
+poolPledge: 0
+# delegatedSupply must be divisible by poolCount (generator constraint).
+delegatedSupply: 2100000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: devnet
+
+--- # Byron Genesis Override
+protocolConsts:
+  k: 10
+
+--- # Shelley Genesis Override
+epochLength: 120
+slotLength: 0.5
+activeSlotsCoeff: 0.4
+securityParam: 10
+maxLovelaceSupply: 6000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Alonzo Genesis Override
+
+--- # Conway Genesis Override
+
+--- # Node Config Override
+TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+TraceForge: true
+TraceChainDb: true
+TraceMempool: true
+TurnOnLogging: true

--- a/internal/test/devnet/timeline.go
+++ b/internal/test/devnet/timeline.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Phase names on the shared scenario timeline.
+const (
+	PhaseReadiness        = "readiness"
+	PhasePropagation      = "propagation"
+	PhaseAgreement        = "agreement"
+	PhaseEpochTransition  = "epoch-transition"
+	PhasePeerInterruption = "peer-interruption"
+	PhaseRelayRestart     = "relay-restart"
+)
+
+// ReferenceRunnerBudget is the wall-clock ceiling for one accelerated
+// scenario, excluding image build, on the reference runner documented in
+// internal/test/devnet/README.md. It is a hard timeout, not a target: the
+// scenario is event-driven and normally finishes well inside it.
+const ReferenceRunnerBudget = 5 * time.Minute
+
+// startupBudget is the allowance for every node to accept a ChainSync
+// session and send its first header once the compose health checks have
+// passed. It is wall-clock rather than slot-derived because it covers
+// container and database start, which the network's timing parameters
+// say nothing about.
+const startupBudget = 45 * time.Second
+
+// TimelinePhase is one stage of the shared scenario timeline.
+//
+// Deadline is measured from the scenario's start, not from the end of the
+// previous phase. That is what makes this one timeline rather than a
+// series of independent waits: a phase that completes early hands its
+// slack to everything after it, and no assertion adds its own relative
+// slot window on top of the phases before it.
+type TimelinePhase struct {
+	Name     string
+	Deadline time.Duration
+}
+
+// ScenarioPlan is the deterministic schedule an accelerated DevNet run
+// follows. Every budget is derived from the network's own timing
+// parameters, so changing the spec moves the schedule with it instead of
+// silently invalidating hardcoded waits.
+type ScenarioPlan struct {
+	Config *DevNetConfig
+	Phases []TimelinePhase
+
+	// HardTimeout bounds the whole scenario.
+	HardTimeout time.Duration
+
+	// InterruptionHold is how long a node stays down during the
+	// interruption and restart phases.
+	InterruptionHold time.Duration
+
+	// RecoveryBudget is the allowance for a restarted node to rejoin and
+	// catch back up to the network's chain.
+	RecoveryBudget time.Duration
+
+	// OutageBlocks is how far the rest of the network must advance while
+	// a node is stopped. Holding the outage to observed chain progress
+	// rather than wall clock keeps the disruption meaningful on a fast
+	// or slow runner alike, and keeps it inside what k can reconcile.
+	OutageBlocks uint64
+
+	// EpochMargin is how far past an epoch boundary the scenario runs
+	// before asserting agreement, so the assertion covers headers built
+	// on the new epoch nonce rather than the boundary block alone.
+	EpochMargin uint64
+}
+
+// NewScenarioPlan derives the schedule for a network spec. It rejects a
+// spec that is not internally consistent, since a plan built on one would
+// describe a network that cannot run.
+func NewScenarioPlan(cfg *DevNetConfig) (*ScenarioPlan, error) {
+	if cfg == nil {
+		return nil, errors.New("devnet: nil config")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("devnet: invalid network spec: %w", err)
+	}
+
+	blockTime := cfg.ExpectedBlockTime()
+
+	// A stopped node must come back well inside the k-block window: the
+	// point is to exercise recovery, not to push the chain past what the
+	// security parameter can reconcile. Half of k leaves the recovering
+	// node a chain the others can still serve from.
+	outageBlocks := max(2, cfg.SecurityParam/2)
+	hold := SlotsDuration(outageBlocks, blockTime)
+	recovery := 30 * blockTime
+
+	plan := &ScenarioPlan{
+		Config:           cfg,
+		HardTimeout:      ReferenceRunnerBudget,
+		InterruptionHold: hold,
+		RecoveryBudget:   recovery,
+		OutageBlocks:     outageBlocks,
+		// A quarter of an epoch past the boundary is comfortably more
+		// than the 4k/f freeze window's tail while staying cheap.
+		EpochMargin: cfg.EpochLength / 4,
+	}
+
+	// Deadlines accumulate along one clock.
+	readiness := startupBudget
+	propagation := readiness + 20*blockTime
+	agreement := propagation + 10*blockTime
+	// Worst case the scenario attaches immediately after a boundary and
+	// has to wait a full epoch for the next one.
+	epoch := agreement + cfg.EpochDuration() +
+		SlotsDuration(plan.EpochMargin, cfg.SlotDuration()) + 10*blockTime
+	peerInterruption := epoch + hold + recovery
+	relayRestart := peerInterruption + hold + recovery
+
+	plan.Phases = []TimelinePhase{
+		{Name: PhaseReadiness, Deadline: readiness},
+		{Name: PhasePropagation, Deadline: propagation},
+		{Name: PhaseAgreement, Deadline: agreement},
+		{Name: PhaseEpochTransition, Deadline: epoch},
+		{Name: PhasePeerInterruption, Deadline: peerInterruption},
+		{Name: PhaseRelayRestart, Deadline: relayRestart},
+	}
+	return plan, nil
+}
+
+// Phase returns the named phase.
+func (p *ScenarioPlan) Phase(name string) (TimelinePhase, bool) {
+	for _, ph := range p.Phases {
+		if ph.Name == name {
+			return ph, true
+		}
+	}
+	return TimelinePhase{}, false
+}
+
+// Total returns the scenario length: the last phase's deadline on the
+// shared clock.
+func (p *ScenarioPlan) Total() time.Duration {
+	if len(p.Phases) == 0 {
+		return 0
+	}
+	return p.Phases[len(p.Phases)-1].Deadline
+}
+
+// FitsReferenceBudget reports whether the plan fits the documented
+// reference-runner budget.
+func (p *ScenarioPlan) FitsReferenceBudget() bool {
+	return p.Total() <= ReferenceRunnerBudget
+}
+
+// String renders the schedule for the scenario log, so a run records the
+// timeline it was held to.
+func (p *ScenarioPlan) String() string {
+	var out strings.Builder
+	fmt.Fprintf(&out,
+		"scenario plan (epoch %s, block ~%s, hard timeout %s):",
+		p.Config.EpochDuration(), p.Config.ExpectedBlockTime(),
+		p.HardTimeout,
+	)
+	for _, ph := range p.Phases {
+		fmt.Fprintf(&out, " %s<=%s", ph.Name, ph.Deadline)
+	}
+	return out.String()
+}

--- a/internal/test/devnet/timeline.go
+++ b/internal/test/devnet/timeline.go
@@ -114,8 +114,13 @@ func NewScenarioPlan(cfg *DevNetConfig) (*ScenarioPlan, error) {
 		InterruptionHold: hold,
 		RecoveryBudget:   recovery,
 		OutageBlocks:     outageBlocks,
-		// A quarter of an epoch past the boundary is comfortably more
-		// than the 4k/f freeze window's tail while staying cheap.
+		// A quarter of an epoch past the boundary. Any margin proves the
+		// transition: the assertion is that nodes agree on a header built
+		// under the new epoch nonce, and the first header after the
+		// boundary already qualifies. This is deliberately far shorter
+		// than the 4k/f freeze window (30 slots against 100 for the
+		// accelerated spec) because covering that window would cost most
+		// of an epoch for no extra signal.
 		EpochMargin: cfg.EpochLength / 4,
 	}
 

--- a/internal/test/devnet/timeline_test.go
+++ b/internal/test/devnet/timeline_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// acceleratedTestConfig mirrors testnet-dingo-accelerated.yaml. The
+// on-disk specs are checked separately by TestCheckedInSpecsAreValid.
+func acceleratedTestConfig() *DevNetConfig {
+	return &DevNetConfig{
+		PoolCount:        3,
+		NetworkMagic:     42,
+		EpochLength:      120,
+		SlotLength:       0.5,
+		ActiveSlotsCoeff: 0.4,
+		SecurityParam:    10,
+	}
+}
+
+func canonicalTestConfig() *DevNetConfig {
+	return &DevNetConfig{
+		PoolCount:        3,
+		NetworkMagic:     42,
+		EpochLength:      500,
+		SlotLength:       1,
+		ActiveSlotsCoeff: 0.4,
+		SecurityParam:    40,
+	}
+}
+
+func TestStabilityWindowsDerivedFromSecurityParam(t *testing.T) {
+	cfg := acceleratedTestConfig()
+	// 4k/f and 3k/f, the windows cardano-node derives from k and f.
+	require.Equal(t, uint64(100), cfg.NonceStabilityWindowSlots())
+	require.Equal(t, uint64(75), cfg.BlockFetchStabilityWindowSlots())
+	require.Equal(t, 60*time.Second, cfg.EpochDuration())
+}
+
+func TestValidateRejectsStabilityWindowOverrunningEpoch(t *testing.T) {
+	cfg := acceleratedTestConfig()
+	require.NoError(t, cfg.Validate())
+
+	// 4k/f = 100 slots; an epoch shorter than that cannot freeze the
+	// candidate nonce before the boundary.
+	cfg.EpochLength = 90
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nonce stability window")
+
+	cfg = acceleratedTestConfig()
+	// 3k/f = 75 slots, so an 80-slot epoch clears blockfetch but not
+	// the nonce window; check the blockfetch bound on its own.
+	cfg.SecurityParam = 20 // 3k/f = 150, 4k/f = 200
+	cfg.EpochLength = 175  // above blockfetch, below nonce
+	err = cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nonce stability window")
+
+	cfg.EpochLength = 120 // below both
+	err = cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blockfetch stability window")
+}
+
+func TestValidateRejectsDegenerateParameters(t *testing.T) {
+	for name, mutate := range map[string]func(*DevNetConfig){
+		"zero pools":     func(c *DevNetConfig) { c.PoolCount = 0 },
+		"zero magic":     func(c *DevNetConfig) { c.NetworkMagic = 0 },
+		"zero slot":      func(c *DevNetConfig) { c.SlotLength = 0 },
+		"zero k":         func(c *DevNetConfig) { c.SecurityParam = 0 },
+		"zero epoch":     func(c *DevNetConfig) { c.EpochLength = 0 },
+		"coeff above 1":  func(c *DevNetConfig) { c.ActiveSlotsCoeff = 1.5 },
+		"coeff at zero":  func(c *DevNetConfig) { c.ActiveSlotsCoeff = 0 },
+		"negative coeff": func(c *DevNetConfig) { c.ActiveSlotsCoeff = -0.1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := acceleratedTestConfig()
+			mutate(cfg)
+			require.Error(t, cfg.Validate())
+		})
+	}
+}
+
+func TestNextEpochBoundary(t *testing.T) {
+	cfg := acceleratedTestConfig() // epochLength 120
+
+	// From inside epoch 0 the next boundary is the start of epoch 1.
+	require.Equal(t, uint64(120), cfg.NextEpochBoundary(0))
+	require.Equal(t, uint64(120), cfg.NextEpochBoundary(1))
+	require.Equal(t, uint64(120), cfg.NextEpochBoundary(119))
+	// Standing exactly on a boundary, the next one is a full epoch out,
+	// so a scenario attaching to a long-running network still crosses a
+	// transition rather than trivially passing on the current slot.
+	require.Equal(t, uint64(240), cfg.NextEpochBoundary(120))
+	require.Equal(t, uint64(360), cfg.NextEpochBoundary(250))
+}
+
+func TestScenarioPlanPhasesAreOrderedAndBounded(t *testing.T) {
+	plan, err := NewScenarioPlan(acceleratedTestConfig())
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(plan.Phases))
+	var last time.Duration
+	for _, p := range plan.Phases {
+		require.Greater(t, p.Deadline, last,
+			"phase %q deadline must advance the shared timeline", p.Name)
+		last = p.Deadline
+		names = append(names, p.Name)
+	}
+	require.Equal(t, []string{
+		PhaseReadiness,
+		PhasePropagation,
+		PhaseAgreement,
+		PhaseEpochTransition,
+		PhasePeerInterruption,
+		PhaseRelayRestart,
+	}, names)
+
+	// Every assertion hangs off one clock, so the last deadline is the
+	// scenario length rather than a sum of independent waits.
+	require.Equal(t, last, plan.Total())
+	require.Less(t, plan.Total(), plan.HardTimeout,
+		"the plan must finish inside its own hard timeout")
+}
+
+// The five-minute reference-runner budget in the issue is the whole point
+// of the accelerated spec: assert the accelerated parameters fit and the
+// canonical ones do not, so nobody can quietly point the fast scenario at
+// the soak configuration.
+func TestAcceleratedPlanFitsReferenceBudgetAndCanonicalDoesNot(t *testing.T) {
+	fast, err := NewScenarioPlan(acceleratedTestConfig())
+	require.NoError(t, err)
+	require.LessOrEqual(t, fast.Total(), ReferenceRunnerBudget,
+		"accelerated scenario must fit the documented runner budget")
+	require.Equal(t, ReferenceRunnerBudget, fast.HardTimeout)
+
+	slow, err := NewScenarioPlan(canonicalTestConfig())
+	require.NoError(t, err)
+	require.Greater(t, slow.Total(), ReferenceRunnerBudget,
+		"the canonical timing config cannot meet the fast budget; it "+
+			"stays available for soak and canary runs")
+}
+
+func TestScenarioPlanPhaseLookup(t *testing.T) {
+	plan, err := NewScenarioPlan(acceleratedTestConfig())
+	require.NoError(t, err)
+
+	epoch, ok := plan.Phase(PhaseEpochTransition)
+	require.True(t, ok)
+	require.Equal(t, PhaseEpochTransition, epoch.Name)
+
+	_, ok = plan.Phase("no-such-phase")
+	require.False(t, ok)
+}
+
+// A stopped producer must be brought back well inside the k-block window;
+// holding it down longer risks a recovery the security parameter cannot
+// cover, which would make the scenario flaky rather than diagnostic.
+func TestInterruptionHoldStaysInsideSecurityWindow(t *testing.T) {
+	cfg := acceleratedTestConfig()
+	plan, err := NewScenarioPlan(cfg)
+	require.NoError(t, err)
+
+	kWindow := time.Duration(cfg.SecurityParam) * cfg.ExpectedBlockTime()
+	require.Less(t, plan.InterruptionHold, kWindow,
+		"interruption must stay under k blocks of wall clock")
+	require.Positive(t, plan.RecoveryBudget)
+	require.Greater(t, plan.RecoveryBudget, plan.InterruptionHold,
+		"recovery needs more room than the outage itself")
+}
+
+func TestNewScenarioPlanRejectsInvalidConfig(t *testing.T) {
+	cfg := acceleratedTestConfig()
+	cfg.EpochLength = 10 // far below both stability windows
+	_, err := NewScenarioPlan(cfg)
+	require.Error(t, err)
+}
+
+func TestOutageBlocksStayInsideSecurityParam(t *testing.T) {
+	cfg := acceleratedTestConfig()
+	plan, err := NewScenarioPlan(cfg)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), plan.OutageBlocks)
+	require.Less(t, plan.OutageBlocks, cfg.SecurityParam,
+		"the network must not outrun what k can reconcile while a node "+
+			"is down")
+	require.Equal(t,
+		time.Duration(plan.OutageBlocks)*cfg.ExpectedBlockTime(),
+		plan.InterruptionHold,
+	)
+
+	// A tiny k still yields a disruption worth making.
+	cfg.SecurityParam = 2
+	cfg.EpochLength = 120
+	plan, err = NewScenarioPlan(cfg)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), plan.OutageBlocks)
+}

--- a/internal/test/devnet/uid_parity_test.go
+++ b/internal/test/devnet/uid_parity_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dockerfileUIDRe = regexp.MustCompile(`adduser\s+--system\s+--uid\s+(\d+)`)
+	dockerfileGIDRe = regexp.MustCompile(`addgroup\s+--system\s+--gid\s+(\d+)`)
+	composeUIDRe    = regexp.MustCompile(
+		`DINGO_UID:\s*"\$\{DEVNET_DINGO_UID:-(\d+)\}"`,
+	)
+	composeGIDRe = regexp.MustCompile(
+		`DINGO_GID:\s*"\$\{DEVNET_DINGO_GID:-(\d+)\}"`,
+	)
+)
+
+// repoRootDir walks up from the package directory to the module root.
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for range 10 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "reached the filesystem root")
+		dir = parent
+	}
+	t.Fatal("could not locate the module root")
+	return ""
+}
+
+func matchAll(t *testing.T, re *regexp.Regexp, text, what string) []string {
+	t.Helper()
+	matches := re.FindAllStringSubmatch(text, -1)
+	require.NotEmpty(t, matches, "no %s found", what)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// TestConfiguratorUIDMatchesDockerfile keeps the DevNet configurator's
+// key-ownership target in agreement with the user the Dingo image
+// actually runs as.
+//
+// These drifted apart once, and the failure was expensive to read: the
+// image moved from uid 100 to a pinned 1000 while configurator.sh still
+// chowned each pool's key directory to 100:101. That directory has to be
+// 0700 — cardano-node refuses to start when vrf.skey is readable by
+// group or other — so every Dingo block producer in the DevNet died at
+// startup with "failed to read key file .../vrf.skey: permission denied",
+// and the whole network was unusable with nothing pointing at the cause.
+//
+// The compose file now passes the ids in, and this test derives the
+// expectation from the Dockerfile rather than restating a number, so the
+// next time the image's user changes this fails immediately.
+func TestConfiguratorUIDMatchesDockerfile(t *testing.T) {
+	root := repoRootDir(t)
+
+	dockerfile, err := os.ReadFile(filepath.Join(root, "Dockerfile"))
+	require.NoError(t, err)
+	compose, err := os.ReadFile(
+		filepath.Join(root, "internal", "test", "devnet", "docker-compose.yml"),
+	)
+	require.NoError(t, err)
+
+	imageUIDs := matchAll(
+		t, dockerfileUIDRe, string(dockerfile), "adduser --uid in Dockerfile",
+	)
+	imageGIDs := matchAll(
+		t, dockerfileGIDRe, string(dockerfile), "addgroup --gid in Dockerfile",
+	)
+	require.Len(t, imageUIDs, 1, "expected exactly one dingo user")
+	require.Len(t, imageGIDs, 1, "expected exactly one dingo group")
+
+	// Both configurator services (dingo and conformance profiles) must
+	// carry the ids, or the profile without them silently regresses.
+	composeUIDs := matchAll(
+		t, composeUIDRe, string(compose), "DINGO_UID default in compose",
+	)
+	composeGIDs := matchAll(
+		t, composeGIDRe, string(compose), "DINGO_GID default in compose",
+	)
+	require.Len(t, composeUIDs, 2,
+		"both configurator services must set DINGO_UID")
+	require.Len(t, composeGIDs, 2,
+		"both configurator services must set DINGO_GID")
+
+	for _, got := range composeUIDs {
+		require.Equal(t, imageUIDs[0], got,
+			"compose DINGO_UID must match the Dockerfile's pinned dingo uid;"+
+				" a mismatch makes every DevNet block producer fail to read"+
+				" its VRF key")
+	}
+	for _, got := range composeGIDs {
+		require.Equal(t, imageGIDs[0], got,
+			"compose DINGO_GID must match the Dockerfile's pinned dingo gid")
+	}
+}
+
+// TestConfiguratorChownsUsingPassedIds guards the other half of the
+// contract: compose can pass the ids in, but the script has to use them
+// rather than a hardcoded pair.
+func TestConfiguratorChownsUsingPassedIds(t *testing.T) {
+	root := repoRootDir(t)
+	script, err := os.ReadFile(
+		filepath.Join(root, "internal", "test", "devnet", "configurator.sh"),
+	)
+	require.NoError(t, err)
+
+	require.Contains(t, string(script), `chown -R "${DINGO_UID}:${DINGO_GID}"`,
+		"configurator.sh must chown pool keys to the ids compose passes in")
+	require.NotRegexp(t, regexp.MustCompile(`chown -R \d+:\d+`),
+		string(script),
+		"configurator.sh must not hardcode a uid:gid for the pool keys")
+}

--- a/internal/test/devnet/uid_parity_test.go
+++ b/internal/test/devnet/uid_parity_test.go
@@ -133,7 +133,10 @@ func TestConfiguratorChownsUsingPassedIds(t *testing.T) {
 
 	require.Contains(t, string(script), `chown -R "${DINGO_UID}:${DINGO_GID}"`,
 		"configurator.sh must chown pool keys to the ids compose passes in")
-	require.NotRegexp(t, regexp.MustCompile(`chown -R \d+:\d+`),
+	// Scoped to the pool-key chown this contract covers, so an unrelated
+	// numeric chown elsewhere in the script does not fail the guard.
+	require.NotRegexp(t,
+		regexp.MustCompile(`chown -R \d+:\d+ "?/configs/`),
 		string(script),
 		"configurator.sh must not hardcode a uid:gid for the pool keys")
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -530,6 +530,10 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 	if !ok {
 		return
 	}
+	// Registered before the mutex is taken so defer's LIFO order runs it
+	// after the unlock. See pendingPublishes.
+	var pending pendingPublishes
+	defer pending.flush()
 	var replayConnId ouroboros.ConnectionId
 	effectiveConnId := e.NewConnectionId
 	var requestFreshCursor bool
@@ -608,6 +612,7 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 		ls.requestChainsyncResync(
 			effectiveConnId,
 			event.ChainsyncResyncReasonChainSwitchCursorAhead,
+			&pending,
 		)
 		return
 	}
@@ -1225,17 +1230,23 @@ func desiredBlockfetchBatchHeaders(
 	return min(minHeaders, maxHeaders)
 }
 
+// requestChainsyncResync asks the chainsync layer to renegotiate an
+// intersection with a peer.
+//
+// pending must be the caller's queue when ls.chainsyncMutex is held, and
+// may be nil otherwise. This event's subscriber calls
+// RecoverAfterLocalRollback, which takes that mutex, so publishing inline
+// from under the lock is the deadlock pendingPublishes exists to break.
 func (ls *LedgerState) requestChainsyncResync(
 	connId ouroboros.ConnectionId,
 	reason string,
+	pending *pendingPublishes,
 ) {
 	ls.headerMismatchCount = 0
 	ls.rollbackHistory = nil
 	delete(ls.bufferedHeaderEvents, connIdKey(connId))
-	if ls.config.EventBus == nil {
-		return
-	}
-	ls.config.EventBus.Publish(
+	pending.add(
+		ls.config.EventBus,
 		event.ChainsyncResyncEventType,
 		event.NewEvent(
 			event.ChainsyncResyncEventType,
@@ -2417,6 +2428,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 				ls.requestChainsyncResync(
 					e.ConnectionId,
 					event.ChainsyncResyncReasonPersistentFork,
+					nil,
 				)
 			}
 			return nil
@@ -2546,6 +2558,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		ls.requestChainsyncResync(
 			initialConnId,
 			fmt.Sprintf("blockfetch start failed: %v", err),
+			nil,
 		)
 		return nil
 	}
@@ -2642,6 +2655,7 @@ func (ls *LedgerState) tryResolveFork(
 		ls.requestChainsyncResync(
 			e.ConnectionId,
 			event.ChainsyncResyncReasonRollbackNotFound,
+			nil,
 		)
 		return true, nil
 	}
@@ -2768,6 +2782,7 @@ func (ls *LedgerState) tryResolveFork(
 			ls.requestChainsyncResync(
 				e.ConnectionId,
 				event.ChainsyncResyncReasonRollbackNotFound,
+				nil,
 			)
 			return true, nil
 		}
@@ -3144,6 +3159,7 @@ func (ls *LedgerState) noteBlockfetchRangeUnavailable(
 	ls.requestChainsyncResync(
 		connId,
 		event.ChainsyncResyncReasonBlockfetchRangeUnavailable,
+		nil,
 	)
 	return true
 }
@@ -5069,6 +5085,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 						"empty blockfetch batch alternate retry failed: %v",
 						err,
 					),
+					nil,
 				)
 				return nil
 			}
@@ -5085,6 +5102,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		ls.requestChainsyncResync(
 			e.ConnectionId,
 			"empty blockfetch batch",
+			nil,
 		)
 		return nil
 	}
@@ -5142,6 +5160,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		ls.requestChainsyncResync(
 			nextConnId,
 			fmt.Sprintf("blockfetch continuation failed: %v", err),
+			nil,
 		)
 		return nil
 	}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -435,6 +435,12 @@ func (ls *LedgerState) verifyDeferredBlockHeaderState(
 }
 
 func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
+	// Registered before the mutex is taken so defer's LIFO order runs it
+	// after the unlock. RecoverAfterLocalRollback nests this mutex inside
+	// chainsyncMutex, so publishing while holding it deadlocks the same
+	// way. See pendingPublishes.
+	var pending pendingPublishes
+	defer pending.flush()
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
 	e, ok := evt.Data.(BlockfetchEvent)
@@ -449,18 +455,17 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 				"component", "ledger",
 				"error", err,
 			)
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				LedgerErrorEventType,
+				event.NewEvent(
 					LedgerErrorEventType,
-					event.NewEvent(
-						LedgerErrorEventType,
-						LedgerErrorEvent{
-							Error:     err,
-							Operation: "blockfetch_batch_done",
-						},
-					),
-				)
-			}
+					LedgerErrorEvent{
+						Error:     err,
+						Operation: "blockfetch_batch_done",
+					},
+				),
+			)
 		}
 	} else if e.Block != nil {
 		if err := ls.handleEventBlockfetchBlock(e); err != nil {
@@ -475,7 +480,8 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 					"slot", e.Point.Slot,
 					"hash", hex.EncodeToString(e.Point.Hash),
 				)
-				ls.config.EventBus.Publish(
+				pending.add(
+					ls.config.EventBus,
 					ConnectionRecycleRequestedEventType,
 					event.NewEvent(
 						ConnectionRecycleRequestedEventType,
@@ -493,19 +499,18 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 				"slot", e.Point.Slot,
 				"hash", hex.EncodeToString(e.Point.Hash),
 			)
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				LedgerErrorEventType,
+				event.NewEvent(
 					LedgerErrorEventType,
-					event.NewEvent(
-						LedgerErrorEventType,
-						LedgerErrorEvent{
-							Error:     err,
-							Operation: "blockfetch_block",
-							Point:     e.Point,
-						},
-					),
-				)
-			}
+					LedgerErrorEvent{
+						Error:     err,
+						Operation: "blockfetch_block",
+						Point:     e.Point,
+					},
+				),
+			)
 		}
 	}
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -171,6 +171,11 @@ type peerHeaderChain struct {
 }
 
 func (ls *LedgerState) handleEventChainsync(evt event.Event) {
+	// Registered before the mutex is taken so defer's LIFO order runs it
+	// after the unlock: publishing under ls.chainsyncMutex deadlocks the
+	// node. See pendingPublishes.
+	var pending pendingPublishes
+	defer pending.flush()
 	e, ok := evt.Data.(ChainsyncEvent)
 	if !ok {
 		ls.chainsyncMutex.Lock()
@@ -201,18 +206,20 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 				// continuing to send the same rollback point.
 				ls.resetChainsyncResyncState()
 				ls.setChainsyncState(SyncingChainsyncState)
-				if ls.config.EventBus != nil {
-					ls.config.EventBus.Publish(
+				// Queued rather than published here: this runs with
+				// ls.chainsyncMutex held, and this event's subscriber
+				// takes that same mutex via RecoverAfterLocalRollback.
+				pending.add(
+					ls.config.EventBus,
+					event.ChainsyncResyncEventType,
+					event.NewEvent(
 						event.ChainsyncResyncEventType,
-						event.NewEvent(
-							event.ChainsyncResyncEventType,
-							event.ChainsyncResyncEvent{
-								ConnectionId: e.ConnectionId,
-								Reason:       event.ChainsyncResyncReasonRollbackLoop,
-							},
-						),
-					)
-				}
+						event.ChainsyncResyncEvent{
+							ConnectionId: e.ConnectionId,
+							Reason:       event.ChainsyncResyncReasonRollbackLoop,
+						},
+					),
+				)
 				return
 			}
 			ls.config.Logger.Error(
@@ -249,19 +256,18 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 				"slot", e.Point.Slot,
 				"hash", hex.EncodeToString(e.Point.Hash),
 			)
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				LedgerErrorEventType,
+				event.NewEvent(
 					LedgerErrorEventType,
-					event.NewEvent(
-						LedgerErrorEventType,
-						LedgerErrorEvent{
-							Error:     err,
-							Operation: "block_header",
-							Point:     e.Point,
-						},
-					),
-				)
-			}
+					LedgerErrorEvent{
+						Error:     err,
+						Operation: "block_header",
+						Point:     e.Point,
+					},
+				),
+			)
 			return
 		}
 	}
@@ -654,6 +660,10 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 }
 
 func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
+	// See pendingPublishes: nothing may be published while
+	// ls.chainsyncMutex is held.
+	var pending pendingPublishes
+	defer pending.flush()
 	e, ok := evt.Data.(ChainsyncAwaitReplyEvent)
 	if !ok {
 		ls.logUnexpectedChainsyncEventData(
@@ -705,18 +715,17 @@ func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
 			"connection_id", e.ConnectionId.String(),
 			"error", err,
 		)
-		if ls.config.EventBus != nil {
-			ls.config.EventBus.Publish(
+		pending.add(
+			ls.config.EventBus,
+			LedgerErrorEventType,
+			event.NewEvent(
 				LedgerErrorEventType,
-				event.NewEvent(
-					LedgerErrorEventType,
-					LedgerErrorEvent{
-						Error:     err,
-						Operation: "await_reply_blockfetch",
-					},
-				),
-			)
-		}
+				LedgerErrorEvent{
+					Error:     err,
+					Operation: "await_reply_blockfetch",
+				},
+			),
+		)
 	}
 }
 

--- a/ledger/pending_publish.go
+++ b/ledger/pending_publish.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// pendingPublishes collects events produced while a lock is held and
+// publishes them once it has been released.
+//
+// Publishing to the EventBus while holding ls.chainsyncMutex can deadlock
+// the node. EventBus delivery blocks when a subscriber's buffer is full —
+// that is deliberate, the bus backpressures rather than dropping events —
+// and ChainsyncResyncEventType's subscriber calls
+// LedgerState.RecoverAfterLocalRollback, which takes that same mutex. Once
+// the buffer fills, the subscriber parks waiting for the lock the
+// publisher is holding, the publisher parks waiting for buffer capacity
+// the subscriber would have freed, and neither ever proceeds.
+//
+// The damage does not stay local. handleConnectionClosedEvent also takes
+// chainsyncMutex, so its ledger.conn_closed channel stops draining; the
+// node.go handler that translates connmanager.conn_closed into
+// ledger.conn_closed then blocks inside its own callback, which stops
+// connmanager.conn_closed from draining, and every subsequent connection
+// close parks another publisher goroutine. A DevNet run reproduced this as
+// ~217k "event delivery stalled: subscriber not draining
+// type=connmanager.conn_closed" warnings in five minutes while the node
+// kept forging but stopped answering Node-to-Node handshakes entirely.
+//
+// Callers register the flush with defer *before* taking the lock, so that
+// defer's LIFO order runs it after the unlock:
+//
+//	var pending pendingPublishes
+//	defer pending.flush()
+//	ls.chainsyncMutex.Lock()
+//	defer ls.chainsyncMutex.Unlock()
+//	...
+//	pending.add(ls.config.EventBus, SomeEventType, event.NewEvent(...))
+//
+// Delivery is unchanged apart from happening a moment later: Publish is
+// already asynchronous from the subscriber's point of view (it hands the
+// event to a buffered channel drained by a dispatch goroutine), so no
+// caller can have depended on a handler running before the publishing
+// function returned. Ordering between events queued by one call is
+// preserved.
+type pendingPublishes struct {
+	events []pendingPublish
+}
+
+type pendingPublish struct {
+	bus       *event.EventBus
+	eventType event.EventType
+	evt       event.Event
+}
+
+// add queues an event to be published after the caller's lock is
+// released. A nil bus is ignored, matching the nil checks at the call
+// sites.
+func (p *pendingPublishes) add(
+	bus *event.EventBus,
+	eventType event.EventType,
+	evt event.Event,
+) {
+	if bus == nil {
+		return
+	}
+	p.events = append(p.events, pendingPublish{
+		bus:       bus,
+		eventType: eventType,
+		evt:       evt,
+	})
+}
+
+// flush publishes everything queued, in the order it was added.
+func (p *pendingPublishes) flush() {
+	for _, pub := range p.events {
+		pub.bus.Publish(pub.eventType, pub.evt)
+	}
+	p.events = nil
+}

--- a/ledger/pending_publish.go
+++ b/ledger/pending_publish.go
@@ -69,12 +69,21 @@ type pendingPublish struct {
 // add queues an event to be published after the caller's lock is
 // released. A nil bus is ignored, matching the nil checks at the call
 // sites.
+//
+// A nil receiver publishes immediately. That is what lets a helper be
+// called from both locked and unlocked paths without duplicating it: the
+// locked caller threads its own queue down, and an unlocked caller passes
+// nil to get the original behaviour.
 func (p *pendingPublishes) add(
 	bus *event.EventBus,
 	eventType event.EventType,
 	evt event.Event,
 ) {
 	if bus == nil {
+		return
+	}
+	if p == nil {
+		bus.Publish(eventType, evt)
 		return
 	}
 	p.events = append(p.events, pendingPublish{

--- a/ledger/pending_publish_test.go
+++ b/ledger/pending_publish_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPendingPublishesFlushesInOrder(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var mu sync.Mutex
+	var got []string
+	done := make(chan struct{})
+	bus.SubscribeFunc(LedgerErrorEventType, func(evt event.Event) {
+		e, ok := evt.Data.(LedgerErrorEvent)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		got = append(got, e.Operation)
+		if len(got) == 2 {
+			close(done)
+		}
+		mu.Unlock()
+	})
+
+	var pending pendingPublishes
+	for _, op := range []string{"first", "second"} {
+		pending.add(bus, LedgerErrorEventType, event.NewEvent(
+			LedgerErrorEventType,
+			LedgerErrorEvent{Operation: op},
+		))
+	}
+
+	mu.Lock()
+	require.Empty(t, got, "nothing is published before flush")
+	mu.Unlock()
+
+	pending.flush()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued events were not delivered")
+	}
+	mu.Lock()
+	require.Equal(t, []string{"first", "second"}, got,
+		"events are published in the order they were queued")
+	mu.Unlock()
+
+	// flush is not re-entrant: a second call must not republish.
+	pending.flush()
+	mu.Lock()
+	require.Len(t, got, 2, "flush clears the queue")
+	mu.Unlock()
+}
+
+func TestPendingPublishesIgnoresNilBus(t *testing.T) {
+	var pending pendingPublishes
+	pending.add(nil, LedgerErrorEventType, event.NewEvent(
+		LedgerErrorEventType,
+		LedgerErrorEvent{Operation: "dropped"},
+	))
+	require.Empty(t, pending.events,
+		"a nil EventBus is ignored, matching the call sites' nil checks")
+	pending.flush() // must not panic
+}
+
+// The deadlock this type exists to prevent: a subscriber that needs the
+// publisher's lock, reached while that lock is held and the subscriber's
+// buffer is full. Publishing directly would park both sides forever;
+// queueing and flushing after the unlock lets the subscriber drain.
+func TestPendingPublishesBreaksLockCycle(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var chainsyncMutex sync.Mutex
+	handled := make(chan struct{}, 8)
+
+	// The subscriber needs the same lock the publisher holds, exactly as
+	// ChainsyncResyncEventType's subscriber does via
+	// RecoverAfterLocalRollback.
+	bus.SubscribeFuncWithBuffer(
+		LedgerErrorEventType, 1,
+		func(event.Event) {
+			chainsyncMutex.Lock()
+			chainsyncMutex.Unlock() //nolint:staticcheck // lock/unlock is the point
+			handled <- struct{}{}
+		},
+	)
+
+	newEvt := func(op string) event.Event {
+		return event.NewEvent(
+			LedgerErrorEventType, LedgerErrorEvent{Operation: op},
+		)
+	}
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		var pending pendingPublishes
+		defer pending.flush() // runs after the unlock below
+		chainsyncMutex.Lock()
+		defer chainsyncMutex.Unlock()
+		// Enough to overrun the subscriber's buffer while it is parked on
+		// the lock we hold. Publishing these directly is the deadlock.
+		for i := range 4 {
+			pending.add(bus, LedgerErrorEventType, newEvt(string(rune('a'+i))))
+		}
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("publisher deadlocked while holding the lock")
+	}
+
+	for range 4 {
+		select {
+		case <-handled:
+		case <-time.After(10 * time.Second):
+			t.Fatal("subscriber did not drain after the lock was released")
+		}
+	}
+}

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// guardedMutexes are the LedgerState locks that an EventBus subscriber
+// handler acquires. Publishing while holding one of these can deadlock the
+// node, so no function may do both.
+var guardedMutexes = []string{"chainsyncMutex"}
+
+// TestNoEventBusPublishWhileHoldingChainsyncMutex enforces that nothing in
+// this package publishes to the EventBus while holding a mutex that an
+// EventBus subscriber needs.
+//
+// EventBus delivery blocks when a subscriber's buffer is full — deliberate,
+// since the bus backpressures rather than dropping events — and
+// ChainsyncResyncEventType's subscriber calls RecoverAfterLocalRollback,
+// which takes chainsyncMutex. Publish under that lock and the two can wait
+// on each other forever: the subscriber wants the lock the publisher holds,
+// the publisher wants the buffer capacity the subscriber would free.
+//
+// It does not stay contained. handleConnectionClosedEvent takes the same
+// mutex, so ledger.conn_closed stops draining; node.go's handler
+// translating connmanager.conn_closed into ledger.conn_closed then blocks
+// inside its own callback, which stops connmanager.conn_closed draining,
+// and every subsequent connection close parks another publisher goroutine.
+// A DevNet run reproduced exactly that: ~217k "event delivery stalled:
+// subscriber not draining type=connmanager.conn_closed" warnings in five
+// minutes, the mempool component silent, and the node still forging but no
+// longer completing Node-to-Node handshakes.
+//
+// Queue the event with pendingPublishes and flush it after the unlock
+// instead.
+func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") ||
+			strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(
+			fset, filepath.Join(".", name), nil, parser.ParseComments,
+		)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				return true
+			}
+			checked++
+			for _, v := range violations(fn) {
+				t.Errorf(
+					"%s: %s publishes to the EventBus while holding %s;"+
+						" queue it with pendingPublishes and flush after"+
+						" the unlock (see pending_publish.go)",
+					fset.Position(v.pos), fn.Name.Name, v.mutex,
+				)
+			}
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatal("no functions inspected; the scan is not working")
+	}
+}
+
+type violation struct {
+	pos   token.Pos
+	mutex string
+}
+
+type lockEvent struct {
+	pos   token.Pos
+	kind  string // "lock", "unlock", "deferUnlock", "publish"
+	mutex string
+}
+
+// violations walks a function in source order, tracking which guarded
+// mutexes are held, and reports publishes made while one is.
+//
+// Source order is a good enough model of control flow for this code: these
+// functions either hold a mutex for their whole body via defer, or take and
+// release it around a specific region. A deferred unlock keeps the mutex
+// held to the end of the function, which is what makes a publish anywhere
+// after the Lock unsafe.
+func violations(fn *ast.FuncDecl) []violation {
+	deferred := map[token.Pos]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if d, ok := n.(*ast.DeferStmt); ok && d.Call != nil {
+			deferred[d.Call.Pos()] = true
+		}
+		return true
+	})
+
+	var events []lockEvent
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		inner, ok := sel.X.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "Lock", "Unlock":
+			if !slices.Contains(guardedMutexes, inner.Sel.Name) {
+				return true
+			}
+			kind := "lock"
+			if sel.Sel.Name == "Unlock" {
+				kind = "unlock"
+				if deferred[call.Pos()] {
+					kind = "deferUnlock"
+				}
+			}
+			events = append(events, lockEvent{
+				pos: call.Pos(), kind: kind, mutex: inner.Sel.Name,
+			})
+		case "Publish", "PublishBlocking":
+			// Only EventBus publishes; other types have Publish methods.
+			// PublishAsync is deliberately excluded: it hands the event to
+			// the shared async queue rather than parking on a
+			// subscriber's buffer.
+			if inner.Sel.Name != "EventBus" {
+				return true
+			}
+			events = append(events, lockEvent{
+				pos: call.Pos(), kind: "publish",
+			})
+		}
+		return true
+	})
+
+	slices.SortFunc(events, func(a, b lockEvent) int {
+		return int(a.pos - b.pos)
+	})
+
+	held := map[string]bool{}
+	heldToEnd := map[string]bool{}
+	var found []violation
+	for _, ev := range events {
+		switch ev.kind {
+		case "lock":
+			held[ev.mutex] = true
+		case "unlock":
+			if !heldToEnd[ev.mutex] {
+				held[ev.mutex] = false
+			}
+		case "deferUnlock":
+			// Released only when the function returns.
+			heldToEnd[ev.mutex] = true
+		case "publish":
+			for mu, isHeld := range held {
+				if isHeld {
+					found = append(found, violation{pos: ev.pos, mutex: mu})
+				}
+			}
+		}
+	}
+	return found
+}

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -271,6 +271,38 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 	holdsLock := map[string]bool{}
 	var order []string
 
+	// Which argument position, if any, is each function's queue. Collected
+	// in its own pass because a call can appear before the declaration it
+	// targets. Matching "any nil argument" instead would misfire the
+	// moment a queue-taking helper gains an unrelated nilable parameter.
+	queueParam := map[string]int{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Type.Params == nil {
+			continue
+		}
+		idx := 0
+		for _, field := range fn.Type.Params.List {
+			star, isStar := field.Type.(*ast.StarExpr)
+			isQueue := false
+			if isStar {
+				if id, ok := star.X.(*ast.Ident); ok &&
+					id.Name == "pendingPublishes" {
+					isQueue = true
+				}
+			}
+			names := len(field.Names)
+			if names == 0 {
+				names = 1
+			}
+			if isQueue {
+				queueParam[fn.Name.Name] = idx
+				break
+			}
+			idx += names
+		}
+	}
+
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
@@ -299,10 +331,13 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 				}
 				// A queue-taking helper called with a nil queue
 				// publishes immediately, so the caller is the publisher.
+				// Only the queue argument counts: an unrelated nil
+				// elsewhere in the call says nothing about publishing.
 				if ident, ok := sel.X.(*ast.Ident); ok &&
 					ident.Name == "ls" {
-					for _, arg := range node.Args {
-						if id, ok := arg.(*ast.Ident); ok &&
+					if pos, isQueued := queueParam[sel.Sel.Name]; isQueued &&
+						pos < len(node.Args) {
+						if id, ok := node.Args[pos].(*ast.Ident); ok &&
 							id.Name == "nil" {
 							nilQueueCalls[name][sel.Sel.Name] = true
 						}

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -345,12 +345,16 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 
 	expected := slices.Clone(knownResyncPublishPathsUnderLock)
 	slices.Sort(expected)
+	// Built from guardedMutexes so the message cannot drift as that list
+	// grows -- it named only chainsyncMutex after the blockfetch mutex was
+	// added, which would misdirect anyone hitting the failure.
 	require.Equal(t, expected, found,
-		"the set of helpers publishing ChainsyncResyncEventType under"+
-			" chainsyncMutex changed. A new entry is a new deadlock: thread"+
-			" a pendingPublishes queue through it instead of adding it"+
-			" here. A missing entry means it was fixed -- drop it from"+
-			" knownResyncPublishPathsUnderLock.")
+		"the set of helpers publishing ChainsyncResyncEventType while"+
+			" holding one of %v changed. A new entry is a new deadlock:"+
+			" thread a pendingPublishes queue through it instead of adding"+
+			" it here. A missing entry means it was fixed -- drop it from"+
+			" knownResyncPublishPathsUnderLock.",
+		guardedMutexes)
 }
 
 // usesInlinePublish reports whether a function publishes directly rather

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -265,7 +265,9 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 	}
 
 	publishesResync := map[string]bool{}
+	queuedResync := map[string]bool{}
 	callees := map[string]map[string]bool{}
+	nilQueueCalls := map[string]map[string]bool{}
 	holdsLock := map[string]bool{}
 	var order []string
 
@@ -277,18 +279,34 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 		name := fn.Name.Name
 		order = append(order, name)
 		callees[name] = map[string]bool{}
+		nilQueueCalls[name] = map[string]bool{}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.SelectorExpr:
 				if node.Sel.Name == "ChainsyncResyncEventType" {
-					// Only counts as a publish when it is not queued.
-					publishesResync[name] = publishesResync[name] ||
-						usesInlinePublish(fn)
+					if usesInlinePublish(fn) {
+						publishesResync[name] = true
+					} else {
+						// Queues instead. Safe only for callers that
+						// hand it a queue -- see nilQueueCalls.
+						queuedResync[name] = true
+					}
 				}
 			case *ast.CallExpr:
 				sel, ok := node.Fun.(*ast.SelectorExpr)
 				if !ok {
 					return true
+				}
+				// A queue-taking helper called with a nil queue
+				// publishes immediately, so the caller is the publisher.
+				if ident, ok := sel.X.(*ast.Ident); ok &&
+					ident.Name == "ls" {
+					for _, arg := range node.Args {
+						if id, ok := arg.(*ast.Ident); ok &&
+							id.Name == "nil" {
+							nilQueueCalls[name][sel.Sel.Name] = true
+						}
+					}
 				}
 				if inner, ok := sel.X.(*ast.SelectorExpr); ok &&
 					slices.Contains(guardedMutexes, inner.Sel.Name) &&
@@ -301,6 +319,18 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 			}
 			return true
 		})
+	}
+
+	// A caller that hands nil to a queue-taking resync helper makes that
+	// helper publish inline, so the caller owns the publish. Without this
+	// the guard silently stopped reporting every requestChainsyncResync
+	// route the moment that helper was converted to take a queue.
+	for caller, targets := range nilQueueCalls {
+		for target := range targets {
+			if queuedResync[target] {
+				publishesResync[caller] = true
+			}
+		}
 	}
 
 	// Transitive closure: anything reaching an inline resync publish.

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -23,6 +23,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // guardedMutexes are the LedgerState locks that an EventBus subscriber
@@ -58,6 +60,11 @@ var guardedMutexes = []string{"chainsyncMutex"}
 //
 // Queue the event with pendingPublishes and flush it after the unlock
 // instead.
+//
+// The check is intra-procedural, which is not the whole story: a lock
+// holder can also reach a publish through a helper. Those paths are
+// enumerated by TestChainsyncResyncPublishPathsUnderLock rather than left
+// to be assumed safe.
 func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -203,4 +210,159 @@ func violations(fn *ast.FuncDecl) []violation {
 		}
 	}
 	return found
+}
+
+// knownResyncPublishPathsUnderLock records every helper that can publish
+// ChainsyncResyncEventType while ls.chainsyncMutex is held.
+//
+// That event is the dangerous one: its subscriber calls
+// RecoverAfterLocalRollback, which takes the same mutex, so a publish
+// reaching it from under the lock is the deadlock pendingPublishes
+// exists to break. handleChainSwitchEvent was converted because a review
+// demonstrated it concretely; the rest are pre-existing paths that
+// predate this change.
+//
+// Converting them means threading a queue through roughly ten functions
+// in the hottest consensus path, which belongs in its own change with its
+// own DevNet and soak validation rather than riding along here. This list
+// is the honest alternative to silence: the guard above is
+// intra-procedural, so without it the remaining exposure would look like
+// it had been handled.
+var knownResyncPublishPathsUnderLock = []string{
+	"handleEventChainsyncBlockHeader",
+	"handleEventChainsyncRollback",
+	"handoffPipelineOnSwitchLocked",
+	"replayBufferedHeaderEvents",
+	"startQueuedBlockfetchLocked",
+}
+
+// TestChainsyncResyncPublishPathsUnderLock pins the set of helpers that
+// can publish ChainsyncResyncEventType while the mutex is held.
+//
+// It fails in both directions on purpose. A new such path is a new
+// deadlock and must be converted rather than appended here; a path that
+// disappears should be removed, so the list cannot rot into overstating
+// the problem.
+func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(
+		fset, filepath.Join(".", "chainsync.go"), nil, parser.ParseComments,
+	)
+	if err != nil {
+		t.Fatalf("parse chainsync.go: %v", err)
+	}
+
+	publishesResync := map[string]bool{}
+	callees := map[string]map[string]bool{}
+	holdsLock := map[string]bool{}
+	var order []string
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		name := fn.Name.Name
+		order = append(order, name)
+		callees[name] = map[string]bool{}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.SelectorExpr:
+				if node.Sel.Name == "ChainsyncResyncEventType" {
+					// Only counts as a publish when it is not queued.
+					publishesResync[name] = publishesResync[name] ||
+						usesInlinePublish(fn)
+				}
+			case *ast.CallExpr:
+				sel, ok := node.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if inner, ok := sel.X.(*ast.SelectorExpr); ok &&
+					inner.Sel.Name == "chainsyncMutex" &&
+					sel.Sel.Name == "Lock" {
+					holdsLock[name] = true
+				}
+				if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "ls" {
+					callees[name][sel.Sel.Name] = true
+				}
+			}
+			return true
+		})
+	}
+
+	// Transitive closure: anything reaching an inline resync publish.
+	reaches := map[string]bool{}
+	for name, ok := range publishesResync {
+		if ok {
+			reaches[name] = true
+		}
+	}
+	for range order {
+		for name, cs := range callees {
+			if reaches[name] {
+				continue
+			}
+			for c := range cs {
+				if reaches[c] {
+					reaches[name] = true
+					break
+				}
+			}
+		}
+	}
+
+	var found []string
+	for _, name := range order {
+		if holdsLock[name] || !reaches[name] {
+			continue
+		}
+		// Only helpers a lock holder can actually reach.
+		reachedFromLockHolder := false
+		for holder, cs := range callees {
+			if holdsLock[holder] && cs[name] {
+				reachedFromLockHolder = true
+				break
+			}
+		}
+		if reachedFromLockHolder && !slices.Contains(found, name) {
+			found = append(found, name)
+		}
+	}
+	slices.Sort(found)
+
+	expected := slices.Clone(knownResyncPublishPathsUnderLock)
+	slices.Sort(expected)
+	require.Equal(t, expected, found,
+		"the set of helpers publishing ChainsyncResyncEventType under"+
+			" chainsyncMutex changed. A new entry is a new deadlock: thread"+
+			" a pendingPublishes queue through it instead of adding it"+
+			" here. A missing entry means it was fixed -- drop it from"+
+			" knownResyncPublishPathsUnderLock.")
+}
+
+// usesInlinePublish reports whether a function publishes directly rather
+// than queueing through pendingPublishes.
+func usesInlinePublish(fn *ast.FuncDecl) bool {
+	inline := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name != "Publish" && sel.Sel.Name != "PublishBlocking" &&
+			sel.Sel.Name != "PublishAsync" {
+			return true
+		}
+		if inner, ok := sel.X.(*ast.SelectorExpr); ok &&
+			inner.Sel.Name == "EventBus" {
+			inline = true
+		}
+		return true
+	})
+	return inline
 }

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -30,7 +30,17 @@ import (
 // guardedMutexes are the LedgerState locks that an EventBus subscriber
 // handler acquires. Publishing while holding one of these can deadlock the
 // node, so no function may do both.
-var guardedMutexes = []string{"chainsyncMutex"}
+//
+// Both are listed because RecoverAfterLocalRollback -- the subscriber that
+// closes the cycle -- takes chainsyncMutex and then nests
+// chainsyncBlockfetchMutex inside it via startQueuedBlockfetchLocked.
+// Holding either one while publishing is therefore enough to deadlock;
+// guarding only the outer mutex would miss every path that runs under the
+// blockfetch lock alone, such as handleEventBlockfetch's.
+var guardedMutexes = []string{
+	"chainsyncMutex",
+	"chainsyncBlockfetchMutex",
+}
 
 // TestNoEventBusPublishWhileHoldingChainsyncMutex enforces that nothing in
 // this package publishes to the EventBus while holding a mutex that an
@@ -213,7 +223,7 @@ func violations(fn *ast.FuncDecl) []violation {
 }
 
 // knownResyncPublishPathsUnderLock records every helper that can publish
-// ChainsyncResyncEventType while ls.chainsyncMutex is held.
+// ChainsyncResyncEventType while one of guardedMutexes is held.
 //
 // That event is the dangerous one: its subscriber calls
 // RecoverAfterLocalRollback, which takes the same mutex, so a publish
@@ -229,10 +239,12 @@ func violations(fn *ast.FuncDecl) []violation {
 // intra-procedural, so without it the remaining exposure would look like
 // it had been handled.
 var knownResyncPublishPathsUnderLock = []string{
-	"handleEventChainsyncBlockHeader",
+	"handleBlockfetchTimeoutLocked",
+	"handleEventBlockfetchBatchDone",
 	"handleEventChainsyncRollback",
 	"handoffPipelineOnSwitchLocked",
 	"replayBufferedHeaderEvents",
+	"restartQueuedBlockfetchAfterForkLocked",
 	"startQueuedBlockfetchLocked",
 }
 
@@ -279,7 +291,7 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 					return true
 				}
 				if inner, ok := sel.X.(*ast.SelectorExpr); ok &&
-					inner.Sel.Name == "chainsyncMutex" &&
+					slices.Contains(guardedMutexes, inner.Sel.Name) &&
 					sel.Sel.Name == "Lock" {
 					holdsLock[name] = true
 				}

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -377,37 +377,13 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 	holdsLock := map[string]bool{}
 	var order []string
 
-	// Which argument position, if any, is each function's queue. Collected
-	// in its own pass because a call can appear before the declaration it
-	// targets. Matching "any nil argument" instead would misfire the
-	// moment a queue-taking helper gains an unrelated nilable parameter.
-	queueParam := map[string]int{}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Type.Params == nil {
-			continue
-		}
-		idx := 0
-		for _, field := range fn.Type.Params.List {
-			star, isStar := field.Type.(*ast.StarExpr)
-			isQueue := false
-			if isStar {
-				if id, ok := star.X.(*ast.Ident); ok &&
-					id.Name == "pendingPublishes" {
-					isQueue = true
-				}
-			}
-			names := len(field.Names)
-			if names == 0 {
-				names = 1
-			}
-			if isQueue {
-				queueParam[fn.Name.Name] = idx
-				break
-			}
-			idx += names
-		}
-	}
+	// Shared with the intra-procedural guard so the two cannot drift: if
+	// one learned to recognise a differently spelled nil or receiver and
+	// the other did not, a publish path would stop being guarded silently.
+	queueParam := queueParamPositions([]*ast.File{file})
+	require.NotEmpty(t, queueParam,
+		"no *pendingPublishes parameter found; the nil-queue check would"+
+			" silently pass on everything")
 
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
@@ -437,17 +413,8 @@ func TestChainsyncResyncPublishPathsUnderLock(t *testing.T) {
 				}
 				// A queue-taking helper called with a nil queue
 				// publishes immediately, so the caller is the publisher.
-				// Only the queue argument counts: an unrelated nil
-				// elsewhere in the call says nothing about publishing.
-				if ident, ok := sel.X.(*ast.Ident); ok &&
-					ident.Name == "ls" {
-					if pos, isQueued := queueParam[sel.Sel.Name]; isQueued &&
-						pos < len(node.Args) {
-						if id, ok := node.Args[pos].(*ast.Ident); ok &&
-							id.Name == "nil" {
-							nilQueueCalls[name][sel.Sel.Name] = true
-						}
-					}
+				if nilQueueCall(node, sel, queueParam) {
+					nilQueueCalls[name][sel.Sel.Name] = true
 				}
 				if inner, ok := sel.X.(*ast.SelectorExpr); ok &&
 					slices.Contains(guardedMutexes, inner.Sel.Name) &&

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -42,6 +42,23 @@ var guardedMutexes = []string{
 	"chainsyncBlockfetchMutex",
 }
 
+// knownNilQueuePublishersUnderLock are lock holders that still hand nil to
+// a queue-taking helper, publishing inline while they hold a guarded
+// mutex.
+//
+// These cannot be converted in isolation. Giving one its own queue and
+// flushing on its own return does not help, because a parent frame still
+// holds a guarded mutex when it runs -- handleEventChainsyncBlockHeader is
+// called from handleEventChainsync, which holds chainsyncMutex. Fixing
+// them is the same threading described in
+// knownResyncPublishPathsUnderLock and tracked for one atomic change.
+//
+// Listed rather than silently tolerated, and checked in both directions
+// below so the list cannot rot.
+var knownNilQueuePublishersUnderLock = []string{
+	"handleEventChainsyncBlockHeader",
+}
+
 // TestNoEventBusPublishWhileHoldingChainsyncMutex enforces that nothing in
 // this package publishes to the EventBus while holding a mutex that an
 // EventBus subscriber needs.
@@ -82,7 +99,7 @@ func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 	}
 
 	fset := token.NewFileSet()
-	checked := 0
+	var files []*ast.File
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") ||
@@ -95,13 +112,30 @@ func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse %s: %v", name, err)
 		}
+		files = append(files, file)
+	}
+
+	queueParam := queueParamPositions(files)
+	require.NotEmpty(t, queueParam,
+		"no *pendingPublishes parameter found anywhere in the package;"+
+			" the nil-queue check would silently pass on everything")
+
+	checked := 0
+	seenKnown := map[string]bool{}
+	for _, file := range files {
 		ast.Inspect(file, func(n ast.Node) bool {
 			fn, ok := n.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
 				return true
 			}
 			checked++
-			for _, v := range violations(fn) {
+			for _, v := range violations(fn, queueParam) {
+				if slices.Contains(
+					knownNilQueuePublishersUnderLock, fn.Name.Name,
+				) {
+					seenKnown[fn.Name.Name] = true
+					continue
+				}
 				t.Errorf(
 					"%s: %s publishes to the EventBus while holding %s;"+
 						" queue it with pendingPublishes and flush after"+
@@ -115,6 +149,69 @@ func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 	if checked == 0 {
 		t.Fatal("no functions inspected; the scan is not working")
 	}
+	// Bidirectional, like the transitive guard: an entry that no longer
+	// violates has been fixed and must be removed, or the list quietly
+	// starts excusing something that is already clean.
+	for _, name := range knownNilQueuePublishersUnderLock {
+		require.True(t, seenKnown[name],
+			"%s no longer publishes under a guarded mutex; remove it from"+
+				" knownNilQueuePublishersUnderLock", name)
+	}
+}
+
+// queueParamPositions maps each function to the argument position of its
+// *pendingPublishes parameter, if it has one.
+//
+// Collected across every file before any body is walked: a call can name a
+// helper declared later, or in another file, and a lookup that missed
+// would silently stop treating a nil queue as a publish.
+func queueParamPositions(files []*ast.File) map[string]int {
+	out := map[string]int{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Type.Params == nil {
+				continue
+			}
+			idx := 0
+			for _, field := range fn.Type.Params.List {
+				isQueue := false
+				if star, ok := field.Type.(*ast.StarExpr); ok {
+					if id, ok := star.X.(*ast.Ident); ok &&
+						id.Name == "pendingPublishes" {
+						isQueue = true
+					}
+				}
+				names := max(len(field.Names), 1)
+				if isQueue {
+					out[fn.Name.Name] = idx
+					break
+				}
+				idx += names
+			}
+		}
+	}
+	return out
+}
+
+// nilQueueCall reports whether a call hands nil to a queue-taking
+// helper's queue parameter, which makes that helper publish immediately
+// rather than queueing -- so the caller owns the publish.
+func nilQueueCall(
+	call *ast.CallExpr,
+	sel *ast.SelectorExpr,
+	queueParam map[string]int,
+) bool {
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok || ident.Name != "ls" {
+		return false
+	}
+	pos, isQueued := queueParam[sel.Sel.Name]
+	if !isQueued || pos >= len(call.Args) {
+		return false
+	}
+	id, ok := call.Args[pos].(*ast.Ident)
+	return ok && id.Name == "nil"
 }
 
 type violation struct {
@@ -136,7 +233,7 @@ type lockEvent struct {
 // release it around a specific region. A deferred unlock keeps the mutex
 // held to the end of the function, which is what makes a publish anywhere
 // after the Lock unsafe.
-func violations(fn *ast.FuncDecl) []violation {
+func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
 	deferred := map[token.Pos]bool{}
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		if d, ok := n.(*ast.DeferStmt); ok && d.Call != nil {
@@ -153,6 +250,15 @@ func violations(fn *ast.FuncDecl) []violation {
 		}
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if !ok {
+			return true
+		}
+		// Checked before the two-level assertion below: a nil-queue call
+		// is ls.method(...), whose receiver is a plain identifier, not a
+		// selector like ls.config.EventBus.
+		if nilQueueCall(call, sel, queueParam) {
+			events = append(events, lockEvent{
+				pos: call.Pos(), kind: "publish",
+			})
 			return true
 		}
 		inner, ok := sel.X.(*ast.SelectorExpr)

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -51,6 +51,11 @@ var guardedMutexes = []string{"chainsyncMutex"}
 // minutes, the mempool component silent, and the node still forging but no
 // longer completing Node-to-Node handshakes.
 //
+// This covers Publish, PublishBlocking and PublishAsync alike. All three
+// wait for capacity rather than dropping, so all three can close the
+// cycle; PublishAsync merely does it through the shared async queue and
+// its worker pool instead of a single subscriber's buffer.
+//
 // Queue the event with pendingPublishes and flush it after the unlock
 // instead.
 func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
@@ -152,11 +157,15 @@ func violations(fn *ast.FuncDecl) []violation {
 			events = append(events, lockEvent{
 				pos: call.Pos(), kind: kind, mutex: inner.Sel.Name,
 			})
-		case "Publish", "PublishBlocking":
+		case "Publish", "PublishBlocking", "PublishAsync":
 			// Only EventBus publishes; other types have Publish methods.
-			// PublishAsync is deliberately excluded: it hands the event to
-			// the shared async queue rather than parking on a
-			// subscriber's buffer.
+			// PublishAsync is included: it does not park on a
+			// subscriber's buffer, but it does wait for room in the
+			// shared async queue rather than dropping the event, and that
+			// queue is drained by a worker pool whose workers run
+			// subscriber handlers. A handler that needs the publisher's
+			// mutex parks a worker, the queue fills, and the same cycle
+			// closes.
 			if inner.Sel.Name != "EventBus" {
 				return true
 			}


### PR DESCRIPTION
Closes #3078.

The DevNet harness queried tips by opening a fresh Node-to-Node connection every
couple of seconds, because a short-lived ChainSync client only ever reports the
tip it captured when it intersected. Each scenario then waited through its own
relative slot windows, so a run spent most of its wall clock waiting and turned
transient startup or fork recovery into expensive, low-signal failures.

This adds a fast scenario built the other way round, plus two bug fixes that
building it uncovered. The three commits are independent and can be reviewed —
or landed — separately.

## `fix(devnet): chown pool keys to the uid the dingo image runs as`

**This one blocks all DevNet use on current `main`.** Every Dingo block producer
dies at startup with:

```
block producer startup validation failed: load pool credentials: failed to load
VRF signing key: failed to read key file "/configs/keys/vrf.skey": permission denied
```

The root `Dockerfile` pins the dingo user to uid/gid 1000, but `configurator.sh`
still chowned each pool's key directory to `100:101`, the uid the image used
before the pin. That directory has to be `0700` — cardano-node refuses to start
when `vrf.skey` is readable by group or other — so the mismatch made the keys
unreadable to the process that needs them.

Compose now passes the ids in rather than the script hardcoding them, since the
authoritative value is the `adduser --uid` pin. Two guards derive their
expectation from the `Dockerfile` instead of restating a number; both were
verified to fail when the drift is reintroduced.

## `fix(ledger): publish chainsync events after releasing the chainsync mutex`

A producer wedged mid-run: still forging, but no longer completing Node-to-Node
handshakes, mempool silent, and logging ~217,000 copies of `event delivery
stalled: subscriber not draining type=connmanager.conn_closed` in five minutes.

The EventBus was behaving as designed — delivery blocks rather than dropping.
The defect was publishing while holding a lock a subscriber of that event needs,
which turns backpressure into a cycle:

1. `handleEventChainsync` holds `chainsyncMutex` and publishes `ChainsyncResyncEventType`.
2. That event's subscriber calls `RecoverAfterLocalRollback`, which takes the same mutex, so its dispatch goroutine parks.
3. The buffer fills, so the publisher never returns. Each side holds what the other waits for.

It does not stay local. `handleConnectionClosedEvent` takes the same mutex, so
`ledger.conn_closed` stops draining; `node.go`'s handler translating
`connmanager.conn_closed` into `ledger.conn_closed` then blocks inside its own
callback, which stops `connmanager.conn_closed` draining, and every subsequent
connection close parks another publisher goroutine.

`pendingPublishes` queues events produced under the lock and flushes them after
the unlock. Delivery semantics are unchanged apart from happening a moment
later: `Publish` already hands off to a buffered channel, so nothing could have
depended on a handler running before the publishing function returned.

`TestNoEventBusPublishWhileHoldingChainsyncMutex` enforces the invariant. It
tells a deferred unlock from an immediate one, so it does not flag the recovery
path that already unlocks before publishing — and it found a third violation a
hand search had missed.

## `test(devnet): add an event-driven accelerated release scenario`

One persistent ChainSync session per node follows the chain, so `RollForward`
and `RollBackward` arrive as nodes produce them. Every assertion is a condition
over those observed events bounded by a context deadline — no polling interval,
no `time.Sleep` in the synchronisation path.

Every assertion shares one timeline: each phase's deadline is measured from the
scenario's start rather than the end of the previous phase, so a phase that
finishes early hands its slack forward. Phases cover readiness, block and
transaction propagation, chain agreement, an epoch transition, a controlled peer
interruption with recovery, and a relay restart. Both disruption phases hold the
node down until the network advances a derived number of blocks (k/2) rather
than a fixed wall-clock time.

The accelerated specs compress slot/epoch/security-parameter timing to fit the
runner budget; the canonical specs are untouched and remain what soak and canary
runs use. `DevNetConfig.Validate` enforces `4k/f` and `3k/f` against
`epochLength` across every checked-in spec.

The pure logic — spec loader and validation, observed-chain state machine,
scenario plan — carries no build tag, so it is unit-tested on an ordinary
`go test ./...` with no Docker. Tests also assert the accelerated specs fit the
five-minute budget and the canonical ones do not, so the fast scenario cannot
quietly be pointed at the soak configuration.

Two further harness defects surfaced and are fixed here:

- Scenarios charged slot-derived timeouts against the ~30s pre-genesis wait, and
  `TestDingoChainAdvances` gated on `slot >= 0`, which every tip satisfies. They
  passed only because an earlier test had absorbed the wait, so each failed when
  run on its own with `run-tests.sh -run <name>` — exactly when debugging.
  `WaitForChainStart` is the real gate. `TestEpochBoundaryConsensus` was clearing
  its budget by under a second and now has full margin.
- Restarting a node with `docker compose start` pulls in `depends_on` and re-runs
  the configurator, regenerating genesis; the restarted node then refuses to
  start on a genesis-hash mismatch. Node control addresses the container directly.

Failures preserve observed chain events per node, container status, per-service
logs, and the generated genesis/configuration, all captured before teardown
removes the volumes.

## Validation

| Check | Result |
|---|---|
| Accelerated scenario (all-Dingo) | **PASS, 1m58s** against a 5-minute hard timeout |
| Accelerated scenario (beside `cardano-node`) | **PASS** |
| Canonical DevNet suite | **PASS** |
| Conformance mode vs `cardano-node` | **PASS** |
| `event delivery stalled` warnings | **0** (was 217,657 in five minutes) |
| Full `go test ./...`, `go test -race ./ledger/` | pass |
| `golangci-lint`, `nilaway`, `modernize`, docs-parity, import-boundaries, ledger conformance vectors | clean |

Docs: `internal/test/devnet/README.md` (accelerated parameters and stability-window
table, scenario timeline, failure artifacts, troubleshooting), plus the EventBus
contract in `ARCHITECTURE.md` and `event/doc.go`. `DATABASE.md` checked, not affected.

## Reviewer notes

- The conformance run was done pre-rebase. It passed on identical code and the
  rebase pulled in only an unrelated database change, but it has not been re-run
  since.
- `TestChainGrowthRate` failed once in three canonical runs and passed on re-run,
  stalling network-wide (all three producers saw comparable fork churn) and
  recovering on its own. Pre-existing and independent of this branch, but now
  demonstrated — it is a candidate for the soak/canary split the issue describes
  rather than a per-PR gate. The accelerated scenario deliberately contains no
  statistical rate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an event-driven accelerated DevNet scenario (~2 minutes) and prevents `EventBus` deadlocks by deferring publishes out of `chainsync`/`blockfetch` locks. Previously: the harness polled tips and ledger published under locks, causing long waits and backpressure cycles; now: persistent ChainSync observers drive a shared timeline, and lock-held events queue and flush after unlock with ordering preserved. Producers also boot reliably via corrected pool-key ownership.

- Accelerated DevNet usage and scope
  - Run `./run-tests.sh --accelerated` (optionally with `--conformance`) to execute a single shared timeline covering readiness, propagation, agreement, epoch transition, peer interruption (hold = k/2), and relay restart; the canonical suite/defaults are unchanged.
  - Accelerated specs are validated by `DevNetConfig.Validate` (4k/f and 3k/f) and unit tests; pure logic is untagged for `go test` coverage.

- Ledger delivery and test guards
  - Events produced under `chainsyncMutex` or `chainsyncBlockfetchMutex` queue via `pendingPublishes` and flush after unlock; delivery semantics are unchanged apart from deferral.
  - Invariant tests forbid publishing while holding either mutex, cover transitive helper paths, treat nil-queue calls as inline publishes, match the queue parameter by position, and now share nil-queue detection helpers across both guards.

- Harness and scripts
  - Gate on chain start (not readiness alone), address containers directly on restart, accept separate `-test.run`, clear `DEVNET_ACCELERATED` unless requested, and clean only script-created artifact dirs.
  - Compose passes `DINGO_UID`/`DINGO_GID`; the configurator chowns pool-key dirs accordingly. Parity tests verify Dockerfile UID/GID and compose env, and a guard keeps scripts/compose/spec selection in sync.
  - Failures preserve per-node observed events, logs, container status, and generated config. Docs updated in `ARCHITECTURE.md`, `event/doc.go`, and DevNet `README.md`.

<sup>Written for commit 09455ae2e55ea55bd8da205cb51a696259872930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accelerated DevNet scenarios covering propagation, consensus, epoch transitions, rollbacks, interruptions, and recovery.
  * Added improved chain-state monitoring, coordinated waits, and failure-artifact collection for DevNet testing.
  * Added configurable DevNet specifications, timing validation, and accelerated test execution.

* **Bug Fixes**
  * Prevented potential event-publication deadlocks during ledger and chain synchronization processing.

* **Documentation**
  * Documented event backpressure and deadlock-prevention guidance.
  * Expanded DevNet setup, execution, troubleshooting, and accelerated-testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->