### PR TITLE
feat(api): add uniform TLS/auth surface and top-level security defaults

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,12 @@ none of them. Failures unwind providers in reverse order. Normal shutdown
 orders APIs, mempool, ledger/database, then storage.
 Database receives provider-owned stores through `database.Stores`.
 API providers are resolved for lifecycle only because node composition has no
-in-process consumer of their concrete server values.
+in-process consumer of their concrete server values. Each API provider's
+TLS/authentication policy is resolved the same way: node composition merges
+the shared `api.tls`/`api.auth` default into that provider's own config
+before resolving it (see "API security" under External Interfaces), so a
+provider always receives an already-resolved, instance-owned policy and
+never has to know a shared, top-level default exists.
 
 Command and bootstrap composition that opens a standalone database uses
 `internal/plugins.OpenDatabase`. Its return contract keeps ownership
@@ -3117,14 +3122,127 @@ those indexes in place while deferring the remaining manifest entries.
 
 Dingo provides three client-facing APIs plus Bark. All are optional and gated by port configuration. UTxO RPC, Blockfrost, and Mesh are general-purpose external APIs and require `storageMode: api`. Bark is different: it is Dingo's own protocol for Dingo-to-Dingo C2/archive services, not a general-purpose application API.
 
-The current client-facing API security configuration is asymmetric. UTxO RPC
-receives the process-level TLS certificate/key pair; Blockfrost and Mesh do not,
-and none of the three authenticates clients in-process. Public deployments
-therefore require a reverse proxy or API gateway for uniform TLS,
-authentication, and rate limiting. Composition must not imply that the root TLS
-fields protect every API listener.
+### API security (TLS and authentication)
+
+Blockfrost, Mesh, and UTxO RPC share one TLS/authentication contract
+(dingo#2996/#2998), rather than each exposing its own ad hoc surface. A
+reverse proxy or API gateway in front of these listeners remains fully
+supported — TLS/auth here is additive, not a replacement requirement — but
+an operator can now also secure any subset of the three in-process,
+without one.
+
+- **Policy types (`internal/apiconfig`).** `TLSPolicy` (`mode`,
+  `certFilePath`, `keyFilePath`) and `AuthPolicy` (`mode`, `token`,
+  `tokenFilePath`) are YAML-decodable, tri-state structs: every field is a
+  pointer, so "not set at this scope" (nil) is distinguishable from an
+  explicit value such as `mode: disabled`. `mode` is `"disabled"` or
+  `"server"` for TLS, `"disabled"` or `"token"` for auth; an unset mode at
+  every scope resolves to `"disabled"`, so an upgraded deployment that
+  never configured either gets no behavior change. The same two types back
+  both the top-level `api:` policy (`internal/config.APIConfig`) and every
+  provider's own `plugins.api.<name>.config.tls`/`config.auth` — from a
+  provider's point of view an inherited field and an inline one are
+  indistinguishable.
+- **Scope resolution happens once, at composition, before a provider ever
+  sees its config** — never inside an API domain package. `node.go`'s
+  `apiPluginSelection`/`apiProviderConfig` merges, field by field
+  (`apiconfig.MergeProviderConfig`/`MergeTLS`/`MergeAuth`), three layers
+  from lowest to highest priority: the legacy UTxO RPC-only compatibility
+  fields (below), the shared top-level `api.tls`/`api.auth` default, and
+  the provider's own `config.tls`/`config.auth`. The merge is a plain
+  struct-field fold, not a map walk, so the result never depends on map
+  iteration order. `Node.New` runs this same merge (see
+  `validateAPIProviderSecurityPolicy`) against every configured API
+  capability before constructing anything, so an invalid effective policy
+  — e.g. a partial certificate/key pair, or an unrecognized mode — is
+  rejected at construction time, before any listener starts, with an
+  error naming the full config path (`plugins.api.blockfrost.config.tls`,
+  not just `tls`). Each provider's own `RegisterProvider` factory
+  (`ProviderConfig.TLS.Resolve`/`ProviderConfig.Auth.Resolve`) repeats the
+  same validation immediately before constructing its server, so the
+  provider is self-contained and cannot be started with an unvalidated
+  policy through any other code path. What a provider receives after this
+  point is always a fully resolved, instance-owned `apiconfig.EffectiveTLS`/
+  `EffectiveAuth` — composition performs resolution, providers only act on
+  the result.
+- **Environment variable scope.** The shared top-level `api.tls`/`api.auth`
+  fields participate in the normal `DINGO_API_TLS_*`/`DINGO_API_AUTH_*`
+  environment variables and `--api-tls-*`/`--api-auth-*` CLI flags, layered
+  through the same CLI > environment > YAML > defaults precedence as any
+  other `Config` field. A per-provider override
+  (`plugins.api.<name>.config.tls`/`config.auth`) is YAML-only: the generic
+  `DINGO_PLUGINS_API_<NAME>_CONFIG_*` environment mechanism
+  (`plugin.ApplyEnvironment`) flattens its suffix to one field name and has
+  no way to address a nested `tls`/`auth` sub-object, by design (see
+  `setEnvironmentPath`'s own doc comment) — an operator who needs an
+  environment-driven per-provider override sets the whole provider config
+  through other means, or uses YAML for that provider's override alongside
+  environment variables for the shared default.
+- **Credential verification is one implementation (`internal/apiauth`),
+  adapted per transport.** `apiauth.Verifier.Verify` does a constant-time
+  comparison against the configured shared-secret token (inline `token` or
+  read once from `tokenFilePath` at listener startup, matching
+  `EffectiveTLS`'s own deferral of certificate loading to listener
+  startup rather than config-resolution time). `apiauth.Middleware` adapts
+  it to `net/http` (Blockfrost, Mesh, UTxO RPC's own HTTP mux), responding
+  `401` and never calling the wrapped handler on a missing/invalid
+  credential. `apiauth.Interceptor` adapts the identical `Verifier` to a
+  `connect.Interceptor` (UTxO RPC's Connect/gRPC handlers, including
+  health and reflection — there is no separate unauthenticated allowlist
+  for those two), responding `connect.CodeUnauthenticated` (surfaced over
+  HTTP as `401` by the Connect protocol). Neither adapter re-implements
+  comparison logic; both read a `Authorization: Bearer <token>` header (or,
+  additionally, Blockfrost's own `project_id: <token>` header — see
+  below) and delegate to the same `Verify` call.
+- **Ordering with CORS.** `httpcors.Handler` must wrap `apiauth.Middleware`
+  (CORS outer, auth inner), not the reverse: it fully answers an `OPTIONS`
+  preflight itself and never invokes the wrapped handler for one, and
+  browsers never attach `Authorization` to a preflight request — requiring
+  a credential there would make cross-origin browser access impossible
+  regardless of what the real request later sends. Every other request,
+  including a non-preflight `OPTIONS`, still authenticates normally. All
+  three providers wire the chain in this order; `*_test.go`'s
+  `TestServerCORSPreflightBypassesAuth`/`TestBlockfrostCORSPreflightBypassesAuth`/
+  `TestUtxorpcCORSPreflightBypassesAuth` pin it down.
+- **Blockfrost's `project_id` header is an alias for the same shared
+  token**, not a separate credential mechanism: real Blockfrost clients
+  send their API key as `project_id: <value>` rather than a bearer
+  token, so `apiauth.Middleware(verifier, apiauth.WithAliasHeader("project_id"))`
+  accepts that header's raw value as equivalent to
+  `Authorization: Bearer <value>`. Configuring `auth.mode: token` secures
+  Blockfrost against both header styles from the one configured
+  `token`/`tokenFilePath` — there is no separate `project_id` setting.
+- **Redaction.** `AuthPolicy`/`EffectiveAuth` implement `slog.LogValuer`
+  (`LogValue`), replacing `token` with `"***redacted***"` in any
+  structured log call; `tokenFilePath` (a filesystem path, not a secret)
+  and `mode` are logged as-is. Error messages from `Resolve` never embed
+  the token or certificate/key file contents, only paths and mode names.
+- **Compatibility.** The pre-#2996 root `tlsCertFilePath`/`tlsKeyFilePath`
+  fields (and the `--utxorpc-tls-cert-file-path`/`--utxorpc-tls-key-file-path`
+  flags and `WithUtxorpcTlsCertFilePath`/`WithUtxorpcTlsKeyFilePath`
+  options that set them) remain exactly what they were: a **UTxO
+  RPC-only** default TLS policy, expressed as the lowest-priority input to
+  the merge above (`node.go`'s `legacyUtxorpcTLSPolicy`). They are
+  deliberately **not** promoted into the shared `api.tls` default: doing
+  so would silently switch Blockfrost/Mesh from plaintext to TLS on
+  upgrade for any deployment that had set them only for UTxO RPC, which
+  they never protected. An operator opting Blockfrost/Mesh into TLS does so
+  explicitly, through `api.tls` or their own `plugins.api.<name>.config.tls`.
+  `bindAddr` and `corsAllowedOrigins` are unaffected by any of this and
+  stay at the `Config` root exactly as before: `bindAddr` is not
+  API-specific (the relay/NtN and metrics/debug listeners use it too), and
+  `corsAllowedOrigins`'s single shared value already applies uniformly to
+  all three API providers today, so duplicating either field under `api:`
+  would only add a second source of truth with no behavioral gain.
+  Authentication has no legacy root field at all — its default is simply
+  `"disabled"` everywhere, so existing reverse-proxy/no-auth deployments
+  are unaffected regardless.
 
 ### Blockfrost API (`api/blockfrost/`)
+
+TLS and token authentication (including the `project_id` header alias) are
+configured through `plugins.api.blockfrost.config.tls`/`config.auth`; see
+"API security" above.
 
 A Blockfrost-compatible REST API that provides read access to chain data and
 transaction submission. The current router includes health/root, blocks,
@@ -3248,6 +3366,9 @@ datum metadata are not yet sourced and return `null`.
 
 ### Mesh API (`api/mesh/`)
 
+TLS and token authentication are configured through
+`plugins.api.mesh.config.tls`/`config.auth`; see "API security" above.
+
 Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access.
 
 The server depends on four narrow interfaces (`api/mesh/node_interface.go`) —
@@ -3281,7 +3402,7 @@ Two contracts follow from that boundary:
 
 ### UTxO RPC (`api/utxorpc/`)
 
-A gRPC server implementing the UTxO RPC specification with query, submit, sync, and watch services. The same listener exposes both the `utxorpc.v1alpha` and `utxorpc.v1beta` service namespaces. Every method other than v1beta's additional `QueryService.ReadState` is wire-compatible across the two, so the beta routes rewrite the service path onto the alpha handlers; `ReadState` is served by `betaQueryServiceServer` (`api/utxorpc/readstate.go`) instead. It answers the one Cardano state query v1beta defines, `GetStakePoolDistribution`, from `ledger.LedgerState.PoolStakeDistribution` — the same read that backs the node-to-client `GetPoolDistr2` query. The `ledger_tip` it reports is the tip that read took inside its own transaction, carried back on the result, rather than one sampled while building the reply: the two can straddle an epoch boundary, and a later tip would name an epoch whose stake snapshot is not the one the reply carries. `LedgerState` is an optional dependency that `Utxorpc.Start` admits as an untyped nil, so the handler checks it per request and reports `Unavailable` rather than panicking. The `pool_keyhashes` filter is capped by `MaxPoolFilter` (default 1000), like the `ReadUtxos` and `ReadData` key lists, since it sizes the snapshot and registration reads it drives; asking for every pool is an empty filter and one bulk read. An empty `pool_keyhashes` means every pool, per the proto; a filter entry that is not 28 bytes is rejected as `InvalidArgument` rather than padded or truncated into a different pool. Because the protobuf `RationalNumber` is an int32 over a uint32, a stake fraction whose exact ratio does not fit — the normal case on a real network, where the denominator is total active stake in lovelace — is rescaled onto a fixed denominator of 1e9 rather than failing. `newServeMux` is the single wiring site for the routing table, and one service-name list (`servedServiceNames`) feeds the `grpc_health_v1` checker and both reflection wire versions, so `grpc.reflection.v1` and `grpc.reflection.v1alpha` clients discover the same services — v1alpha is an older reflection protocol, not an older API surface. Supports optional TLS.
+A gRPC server implementing the UTxO RPC specification with query, submit, sync, and watch services. The same listener exposes both the `utxorpc.v1alpha` and `utxorpc.v1beta` service namespaces. Every method other than v1beta's additional `QueryService.ReadState` is wire-compatible across the two, so the beta routes rewrite the service path onto the alpha handlers; `ReadState` is served by `betaQueryServiceServer` (`api/utxorpc/readstate.go`) instead. It answers the one Cardano state query v1beta defines, `GetStakePoolDistribution`, from `ledger.LedgerState.PoolStakeDistribution` — the same read that backs the node-to-client `GetPoolDistr2` query. The `ledger_tip` it reports is the tip that read took inside its own transaction, carried back on the result, rather than one sampled while building the reply: the two can straddle an epoch boundary, and a later tip would name an epoch whose stake snapshot is not the one the reply carries. `LedgerState` is an optional dependency that `Utxorpc.Start` admits as an untyped nil, so the handler checks it per request and reports `Unavailable` rather than panicking. The `pool_keyhashes` filter is capped by `MaxPoolFilter` (default 1000), like the `ReadUtxos` and `ReadData` key lists, since it sizes the snapshot and registration reads it drives; asking for every pool is an empty filter and one bulk read. An empty `pool_keyhashes` means every pool, per the proto; a filter entry that is not 28 bytes is rejected as `InvalidArgument` rather than padded or truncated into a different pool. Because the protobuf `RationalNumber` is an int32 over a uint32, a stake fraction whose exact ratio does not fit — the normal case on a real network, where the denominator is total active stake in lovelace — is rescaled onto a fixed denominator of 1e9 rather than failing. `newServeMux` is the single wiring site for the routing table, and one service-name list (`servedServiceNames`) feeds the `grpc_health_v1` checker and both reflection wire versions, so `grpc.reflection.v1` and `grpc.reflection.v1alpha` clients discover the same services — v1alpha is an older reflection protocol, not an older API surface. TLS and token authentication are configured through the shared `plugins.api.utxorpc.config.tls`/`config.auth` surface described in "API security" above (applied to every Connect/gRPC handler this listener serves, including health and reflection), not a UTxO RPC-specific mechanism; the legacy process-level `tlsCertFilePath`/`tlsKeyFilePath` fields remain a supported, UTxO RPC-only default for that same `tls` policy.
 
 ### Koios Parity Tracker (`cmd/koios-parity/`, `internal/koiosparity/`)
 
@@ -4243,6 +4364,19 @@ The pre-plugin API port names `DINGO_UTXORPC_PORT`,
 `DINGO_BLOCKFROST_PORT`, and `DINGO_MESH_PORT` are compatibility aliases for
 their `DINGO_PLUGINS_API_*_CONFIG_PORT` counterparts. Within the environment
 tier, the plugin-form name takes precedence when both forms are set.
+
+The `api.tls`/`api.auth` shared defaults (`--api-tls-mode`/`DINGO_API_TLS_MODE`/
+`api.tls.mode` and their `certFilePath`/`keyFilePath`/auth counterparts;
+see "API security" under External Interfaces) participate in this same
+CLI > environment > YAML > defaults source precedence like any other
+`Config` field. That is a separate, orthogonal axis from *scope*
+inheritance — explicit provider field (`plugins.api.<name>.config.tls`) >
+shared top-level default (`api.tls`) > disabled — which is resolved once at
+node composition (`node.go`'s `apiProviderConfig`), after every
+configuration source has already been merged into a single `Config`. A CLI
+flag can override which *value* the top-level default carries; it cannot
+skip the scope-resolution step that decides whether a given provider
+actually uses that value, an override of its own, or neither.
 
 `LoadConfig` (`internal/config`) only parses and merges the YAML and
 environment sources; it makes no semantic judgments about the merged values,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,11 +18,21 @@ orders APIs, mempool, ledger/database, then storage.
 Database receives provider-owned stores through `database.Stores`.
 API providers are resolved for lifecycle only because node composition has no
 in-process consumer of their concrete server values. Each API provider's
-TLS/authentication policy is resolved the same way: node composition merges
-the shared `api.tls`/`api.auth` default into that provider's own config
-before resolving it (see "API security" under External Interfaces), so a
-provider always receives an already-resolved, instance-owned policy and
-never has to know a shared, top-level default exists.
+TLS/authentication policy goes through a merged-config handoff, not a
+pre-resolved one: node composition merges the shared `api.tls`/`api.auth`
+default into that provider's own `config.tls`/`config.auth` fields, field by
+field, before the provider ever decodes its config (see "API security" under
+External Interfaces) — so from a provider's point of view an inherited
+field and an inline one are indistinguishable — but the merged result is
+still the raw, tri-state `TLSPolicy`/`AuthPolicy` shape. Each provider's own
+`RegisterProvider` factory decodes that merged config and calls
+`Resolve` itself during construction, producing the concrete
+`EffectiveTLS`/`EffectiveAuth` its listener acts on. `Node.New` separately
+runs the same merge-and-resolve as an early validation pass against every
+configured API capability, so an invalid effective policy is rejected at
+construction time rather than deferred to listener startup — but that pass
+exists for fail-fast validation, not to hand a provider an already-resolved
+policy in place of provider-side resolution.
 
 Command and bootstrap composition that opens a standalone database uses
 `internal/plugins.OpenDatabase`. Its return contract keeps ownership
@@ -3143,28 +3153,34 @@ without one.
   provider's own `plugins.api.<name>.config.tls`/`config.auth` — from a
   provider's point of view an inherited field and an inline one are
   indistinguishable.
-- **Scope resolution happens once, at composition, before a provider ever
-  sees its config** — never inside an API domain package. `node.go`'s
+- **Field-level merge happens once, at composition; final validation and
+  resolution happen provider-side** — never inside an API domain package
+  for the merge step, but always inside one for `Resolve`. `node.go`'s
   `apiPluginSelection`/`apiProviderConfig` merges, field by field
   (`apiconfig.MergeProviderConfig`/`MergeTLS`/`MergeAuth`), three layers
   from lowest to highest priority: the legacy UTxO RPC-only compatibility
   fields (below), the shared top-level `api.tls`/`api.auth` default, and
   the provider's own `config.tls`/`config.auth`. The merge is a plain
   struct-field fold, not a map walk, so the result never depends on map
-  iteration order. `Node.New` runs this same merge (see
-  `validateAPIProviderSecurityPolicy`) against every configured API
+  iteration order. The merge's output is still the raw, tri-state
+  `TLSPolicy`/`AuthPolicy` shape (a `ProviderConfig.TLS`/`ProviderConfig.Auth`
+  field, not an `EffectiveTLS`/`EffectiveAuth`) — composition hands a
+  provider a fully merged config, not a fully resolved policy. `Node.New`
+  runs this same merge, then calls `Resolve` on the result (see
+  `validateAPIProviderSecurityPolicy`), against every configured API
   capability before constructing anything, so an invalid effective policy
   — e.g. a partial certificate/key pair, or an unrecognized mode — is
   rejected at construction time, before any listener starts, with an
   error naming the full config path (`plugins.api.blockfrost.config.tls`,
   not just `tls`). Each provider's own `RegisterProvider` factory
   (`ProviderConfig.TLS.Resolve`/`ProviderConfig.Auth.Resolve`) repeats the
-  same validation immediately before constructing its server, so the
-  provider is self-contained and cannot be started with an unvalidated
-  policy through any other code path. What a provider receives after this
-  point is always a fully resolved, instance-owned `apiconfig.EffectiveTLS`/
-  `EffectiveAuth` — composition performs resolution, providers only act on
-  the result.
+  same validate-and-resolve step itself, immediately before constructing
+  its server — this is the one and only place a provider's `EffectiveTLS`/
+  `EffectiveAuth` is actually produced; `Node.New`'s earlier pass exists
+  for fail-fast validation, not to hand the provider a pre-resolved value in
+  its place. This makes each provider self-contained: it cannot be started
+  with an unresolved or unvalidated policy through any other code path, and
+  it never depends on `Node.New` having run first.
 - **Environment variable scope.** The shared top-level `api.tls`/`api.auth`
   fields participate in the normal `DINGO_API_TLS_*`/`DINGO_API_AUTH_*`
   environment variables and `--api-tls-*`/`--api-auth-*` CLI flags, layered
@@ -3190,8 +3206,20 @@ without one.
   `connect.Interceptor` (UTxO RPC's Connect/gRPC handlers, including
   health and reflection — there is no separate unauthenticated allowlist
   for those two), responding `connect.CodeUnauthenticated` (surfaced over
-  HTTP as `401` by the Connect protocol). Neither adapter re-implements
-  comparison logic; both read a `Authorization: Bearer <token>` header (or,
+  HTTP as `401` by the Connect protocol). This is a deliberate design
+  choice, applied uniformly across all three providers, not a
+  UTxO-RPC-specific gap: Blockfrost's own `GET /health` route sits behind
+  the identical `apiauth.Middleware` wrapping its whole mux, so no provider
+  carves out an unauthenticated allowlist for health/liveness checking once
+  `auth.mode: token` is set. The operator-facing consequence — a
+  container-orchestrator liveness/readiness probe against these routes
+  needs to present the shared credential once auth is enabled, or must be
+  redirected to a plain TCP check or a separate unauthenticated path — is
+  documented in the README's "Authentication" section rather than solved
+  in code, to keep every route on an authenticated listener behind the
+  single uniform policy an operator configured. Neither adapter
+  re-implements comparison logic; both read a `Authorization: Bearer
+  <token>` header (or,
   additionally, Blockfrost's own `project_id: <token>` header — see
   below) and delegate to the same `Verify` call.
 - **Ordering with CORS.** `httpcors.Handler` must wrap `apiauth.Middleware`

--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ Bark is Dingo's own Dingo-to-Dingo archive protocol rather than an application
 API. It is configured separately with `barkPort` and `barkBaseUrl`.
 
 For public client access, place the API listeners behind a reverse proxy or API
-gateway. UTxO RPC currently supports the process TLS certificate/key pair;
-Blockfrost and Mesh do not, and the built-in APIs do not authenticate clients.
+gateway — that remains fully supported. In addition, UTxO RPC, Blockfrost, and
+Mesh share one in-process TLS/authentication surface, so an operator can also
+secure any subset of them without a proxy in front.
 
 The shorter `DINGO_UTXORPC_PORT`, `DINGO_BLOCKFROST_PORT`, and
 `DINGO_MESH_PORT` names remain supported for compatibility. If both a
@@ -246,6 +247,85 @@ plugins:
     blockfrost: {provider: builtin, config: {port: 3100}}
     utxorpc: {provider: builtin, config: {port: 9090}}
 ```
+
+### API TLS and Authentication
+
+`api.tls`/`api.auth` set a shared default TLS and authentication policy for
+every selected `plugins.api.*` provider (Blockfrost, Mesh, UTxO RPC). Each
+field resolves independently: `plugins.api.<name>.config.tls`/`config.auth`
+overrides any field for that provider only, and an explicit
+`mode: disabled` at the provider level turns off an inherited policy rather
+than merely leaving it unset. The default everywhere is `disabled`, so an
+existing reverse-proxy/no-auth deployment is unaffected on upgrade.
+
+```yaml
+api:
+  tls:
+    mode: server
+    certFilePath: /run/secrets/api.crt
+    keyFilePath: /run/secrets/api.key
+  auth:
+    mode: token
+    tokenFilePath: /run/secrets/api-token
+
+plugins:
+  api:
+    # Inherits TLS and auth from api.tls/api.auth above unchanged.
+    utxorpc:
+      provider: builtin
+      config:
+        port: 9090
+    # Explicitly opts out of the inherited token auth (e.g. this listener
+    # sits behind its own gateway that already authenticates callers).
+    mesh:
+      provider: builtin
+      config:
+        port: 8080
+        auth:
+          mode: disabled
+    # Overrides just the certificate/key for this provider; the inherited
+    # api.tls.mode ("server") still applies.
+    blockfrost:
+      provider: builtin
+      config:
+        port: 3000
+        tls:
+          certFilePath: /run/secrets/blockfrost.crt
+          keyFilePath: /run/secrets/blockfrost.key
+```
+
+Credential locations:
+
+- **HTTP** (Blockfrost, Mesh, UTxO RPC's own REST/JSON access): send
+  `Authorization: Bearer <token>`. Blockfrost also accepts its own
+  `project_id: <token>` header as an alias for the same shared token — real
+  Blockfrost clients already send their API key that way, so
+  `auth.mode: token` secures Blockfrost against both header styles from one
+  configured token.
+- **Connect/gRPC** (UTxO RPC): send the identical
+  `Authorization: Bearer <token>` request header; every Connect/gRPC
+  handler UTxO RPC serves, including health checking and reflection,
+  requires it once auth is enabled.
+- A missing or invalid credential fails closed: `401` over HTTP,
+  `Unauthenticated` over Connect/gRPC. A browser's CORS preflight
+  (`OPTIONS`) never needs a credential — browsers never attach
+  `Authorization` to one — but every other request, including a
+  non-preflight `OPTIONS`, still authenticates normally.
+- A partial `certFilePath`/`keyFilePath` pair (only one set) fails
+  validation at startup, before any listener binds, with an error naming
+  the full config path (e.g. `plugins.api.blockfrost.config.tls`).
+- Tokens and certificate/key file *contents* are never written to logs,
+  error messages, or effective-config output — only file paths and mode
+  names are.
+
+The pre-existing root `tlsCertFilePath`/`tlsKeyFilePath` fields remain a
+supported, **UTxO RPC-only** compatibility default (unaffected by anything
+above unless UTxO RPC's own `tls` config and the shared `api.tls` are both
+unset) — they are not promoted onto Blockfrost or Mesh, since doing so would
+silently switch a previously plaintext listener to TLS on upgrade. `bindAddr`
+and `corsAllowedOrigins` are unrelated to this policy and remain root-level
+settings shared by all listeners (`bindAddr` is also used by the relay/NtN
+listener, not just the APIs).
 
 ### Archive And History Expiry Nodes
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,20 @@ Credential locations:
   `Authorization: Bearer <token>` request header; every Connect/gRPC
   handler UTxO RPC serves, including health checking and reflection,
   requires it once auth is enabled.
+- **Liveness/readiness probes.** This is deliberate, not an oversight: once
+  `auth.mode: token` is set for a provider, *every* route it serves requires
+  the credential, with no separate unauthenticated allowlist for health
+  checking — Blockfrost's `GET /health` and UTxO RPC's
+  `grpc.health.v1.Health/Check` are no exception, matching how every other
+  route on that listener behaves. A container-orchestrator probe (e.g. a
+  Kubernetes liveness/readiness check) that cannot attach the shared
+  credential will therefore fail once auth is enabled. Configure the probe
+  to send the same `Authorization: Bearer <token>` header the rest of your
+  clients use (most probe mechanisms support a custom header/exec command),
+  or point liveness/readiness checks at a plain TCP connect to the listener
+  port instead of the HTTP/gRPC health route, or run the probe against an
+  unauthenticated in-cluster path (e.g. a `mode: disabled` provider carrying
+  only observability traffic) rather than the public listener.
 - A missing or invalid credential fails closed: `401` over HTTP,
   `Unauthenticated` over Connect/gRPC. A browser's CORS preflight
   (`OPTIONS`) never needs a credential — browsers never attach
@@ -319,13 +333,17 @@ Credential locations:
   names are.
 
 The pre-existing root `tlsCertFilePath`/`tlsKeyFilePath` fields remain a
-supported, **UTxO RPC-only** compatibility default (unaffected by anything
-above unless UTxO RPC's own `tls` config and the shared `api.tls` are both
-unset) — they are not promoted onto Blockfrost or Mesh, since doing so would
-silently switch a previously plaintext listener to TLS on upgrade. `bindAddr`
-and `corsAllowedOrigins` are unrelated to this policy and remain root-level
-settings shared by all listeners (`bindAddr` is also used by the relay/NtN
-listener, not just the APIs).
+supported, **UTxO RPC-only** compatibility default. They merge in as the
+lowest-priority input, field by field, alongside the shared `api.tls`
+default and UTxO RPC's own `tls` config — not as an all-or-nothing fallback
+that only applies when both of those are completely unset. For example, if
+the shared `api.tls` sets only `mode: server` with no `certFilePath`/
+`keyFilePath` of its own, UTxO RPC still inherits those two fields from the
+legacy root settings. They are not promoted onto Blockfrost or Mesh, since
+doing so would silently switch a previously plaintext listener to TLS on
+upgrade. `bindAddr` and `corsAllowedOrigins` are unrelated to this policy
+and remain root-level settings shared by all listeners (`bindAddr` is also
+used by the relay/NtN listener, not just the APIs).
 
 ### Archive And History Expiry Nodes
 

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -25,8 +25,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
+	"github.com/blinklabs-io/dingo/internal/tlsutil"
 )
+
+// blockfrostProjectIDHeader is the header real Blockfrost clients send
+// their API key in. Presenting the shared token there authenticates
+// exactly as presenting it via "Authorization: Bearer <token>" does --
+// see ARCHITECTURE.md/README.md's "API security" section for this
+// compatibility decision.
+const blockfrostProjectIDHeader = "project_id"
 
 // Blockfrost is the Blockfrost-compatible REST API server.
 type Blockfrost struct {
@@ -34,6 +43,7 @@ type Blockfrost struct {
 	logger     *slog.Logger
 	node       BlockfrostNode
 	httpServer *http.Server
+	verifier   *apiauth.Verifier
 	mu         sync.Mutex
 }
 
@@ -258,8 +268,21 @@ func (b *Blockfrost) handler() http.Handler {
 	// Wrap handler with a request body size limit (1 MB)
 	// as defense-in-depth against oversized payloads.
 	const maxRequestBodyBytes int64 = 1 << 20 // 1 MB
+	limited := http.MaxBytesHandler(mux, maxRequestBodyBytes)
+	// CORS must wrap authentication, not the reverse: httpcors.Handler
+	// fully answers an OPTIONS preflight itself and never calls the
+	// handler it wraps for one, so browsers -- which never attach
+	// Authorization to a preflight request -- never need a credential to
+	// pass CORS negotiation. Every other request, including a
+	// non-preflight OPTIONS, still reaches the mux normally. See
+	// internal/apiauth's Middleware doc comment for the general statement
+	// of this ordering rule.
+	authenticated := apiauth.Middleware(
+		b.verifier,
+		apiauth.WithAliasHeader(blockfrostProjectIDHeader),
+	)(limited)
 	return httpcors.Handler(
-		http.MaxBytesHandler(mux, maxRequestBodyBytes),
+		authenticated,
 		httpcors.Config{
 			AllowedOrigins: b.config.CORSAllowedOrigins,
 		},
@@ -270,11 +293,18 @@ func (b *Blockfrost) handler() http.Handler {
 func (b *Blockfrost) Start(
 	ctx context.Context,
 ) error {
+	// Built before the handler so handler() can install the shared
+	// credential-verification middleware (internal/apiauth).
+	verifier, err := apiauth.NewVerifier(b.config.Auth)
+	if err != nil {
+		return fmt.Errorf("blockfrost: %w", err)
+	}
 	b.mu.Lock()
 	if b.httpServer != nil {
 		b.mu.Unlock()
 		return errors.New("server already started")
 	}
+	b.verifier = verifier
 
 	server := &http.Server{
 		Addr:              b.config.ListenAddress,
@@ -366,6 +396,19 @@ func (b *Blockfrost) Stop(
 func (b *Blockfrost) startServer(
 	server *http.Server,
 ) error {
+	useTLS := b.config.TLS.Enabled
+	if useTLS {
+		if err := tlsutil.ConfigureServerTLS(
+			server,
+			b.config.TLS.CertFilePath,
+			b.config.TLS.KeyFilePath,
+		); err != nil {
+			return fmt.Errorf(
+				"failed to load TLS keypair for Blockfrost API server: %w",
+				err,
+			)
+		}
+	}
 	ln, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		return fmt.Errorf(
@@ -375,11 +418,17 @@ func (b *Blockfrost) startServer(
 		)
 	}
 	go func() {
-		if err := server.Serve(ln); err != nil &&
-			!errors.Is(err, http.ErrServerClosed) {
+		var serveErr error
+		if useTLS {
+			serveErr = server.ServeTLS(ln, "", "")
+		} else {
+			serveErr = server.Serve(ln)
+		}
+		if serveErr != nil &&
+			!errors.Is(serveErr, http.ErrServerClosed) {
 			b.logger.Error(
 				"Blockfrost API server error",
-				"error", err,
+				"error", serveErr,
 			)
 		}
 	}()

--- a/api/blockfrost/config.go
+++ b/api/blockfrost/config.go
@@ -14,6 +14,8 @@
 
 package blockfrost
 
+import "github.com/blinklabs-io/dingo/internal/apiconfig"
+
 // BlockfrostConfig holds configuration for the Blockfrost
 // API server.
 type BlockfrostConfig struct {
@@ -23,4 +25,9 @@ type BlockfrostConfig struct {
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.
 	CORSAllowedOrigins []string
+	// TLS and Auth are the resolved (merged, validated) TLS/authentication
+	// policy for this listener -- see ProviderConfig's doc comment and
+	// ARCHITECTURE.md's "API security" section.
+	TLS  apiconfig.EffectiveTLS
+	Auth apiconfig.EffectiveAuth
 }

--- a/api/blockfrost/provider.go
+++ b/api/blockfrost/provider.go
@@ -16,15 +16,25 @@ package blockfrost
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"strconv"
 
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
+// ProviderConfig's TLS and Auth fields are documented in ARCHITECTURE.md's
+// "API security" section. Composition (node.go) merges the top-level
+// api.tls/api.auth defaults into these fields before this provider ever
+// decodes them, so from this package's point of view they are always
+// already-resolved-for-this-provider settings, identical in shape to a
+// provider that set every field inline.
 type ProviderConfig struct {
-	Port uint `yaml:"port"`
+	Port uint                 `yaml:"port"`
+	TLS  apiconfig.TLSPolicy  `yaml:"tls"`
+	Auth apiconfig.AuthPolicy `yaml:"auth"`
 }
 
 type ProviderDependencies struct {
@@ -44,12 +54,24 @@ func RegisterProvider(host *plugin.Host) error {
 		},
 		func() ProviderConfig { return ProviderConfig{Port: 3000} },
 		func(_ context.Context, cfg ProviderConfig, deps ProviderDependencies) (*Blockfrost, plugin.Instance, error) {
+			tls, err := cfg.TLS.Resolve("plugins.api.blockfrost.config.tls")
+			if err != nil {
+				return nil, nil, fmt.Errorf("blockfrost: %w", err)
+			}
+			auth, err := cfg.Auth.Resolve(
+				"plugins.api.blockfrost.config.auth",
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("blockfrost: %w", err)
+			}
 			server := New(BlockfrostConfig{
 				ListenAddress: net.JoinHostPort(
 					deps.Host,
 					strconv.FormatUint(uint64(cfg.Port), 10),
 				),
 				CORSAllowedOrigins: deps.CORSAllowedOrigins,
+				TLS:                tls,
+				Auth:               auth,
 			}, deps.Node, deps.Logger)
 			return server, server, nil
 		},

--- a/api/blockfrost/provider_test.go
+++ b/api/blockfrost/provider_test.go
@@ -38,7 +38,7 @@ func newProviderHost(t *testing.T) *plugin.Host {
 
 func freeLoopbackPort(t *testing.T) uint {
 	t.Helper()
-	_, portStr, err := net.SplitHostPort(freePort(t))
+	_, portStr, err := net.SplitHostPort(testutil.FreePort(t))
 	require.NoError(t, err)
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func resolveOnFreePortWithConfig(
 ) *Blockfrost {
 	t.Helper()
 	var lastErr error
-	for range bindAttempts {
+	for range testutil.BindAttempts {
 		cfg := map[string]any{"port": freeLoopbackPort(t)}
 		maps.Copy(cfg, extra)
 		srv, err := plugin.Resolve[*Blockfrost](
@@ -74,7 +74,7 @@ func resolveOnFreePortWithConfig(
 	}
 	t.Fatalf(
 		"could not resolve the Blockfrost provider in %d attempts: %v",
-		bindAttempts, lastErr,
+		testutil.BindAttempts, lastErr,
 	)
 	return nil
 }

--- a/api/blockfrost/provider_test.go
+++ b/api/blockfrost/provider_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"context"
+	"maps"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func newProviderHost(t *testing.T) *plugin.Host {
+	t.Helper()
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+	t.Cleanup(func() {
+		require.NoError(t, host.Stop(context.Background()))
+	})
+	return host
+}
+
+func freeLoopbackPort(t *testing.T) uint {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(freePort(t))
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	require.NoError(t, err)
+	return uint(port)
+}
+
+// resolveOnFreePortWithConfig resolves the built-in Blockfrost provider on
+// a free loopback port with extra config fields (e.g. "tls"/"auth")
+// merged alongside "port", retrying on a lost race for the port.
+func resolveOnFreePortWithConfig(
+	t *testing.T,
+	host *plugin.Host,
+	extra map[string]any,
+) *Blockfrost {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		cfg := map[string]any{"port": freeLoopbackPort(t)}
+		maps.Copy(cfg, extra)
+		srv, err := plugin.Resolve[*Blockfrost](
+			t.Context(),
+			host,
+			plugin.CapabilityAPIBlockfrost,
+			"builtin",
+			cfg,
+			ProviderDependencies{Node: &mockNode{}, Host: "127.0.0.1"},
+		)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return srv
+	}
+	t.Fatalf(
+		"could not resolve the Blockfrost provider in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil
+}
+
+func TestRegisterProviderDescriptor(t *testing.T) {
+	host := newProviderHost(t)
+
+	var found *plugin.Descriptor
+	for _, d := range host.Providers() {
+		if d.Capability == plugin.CapabilityAPIBlockfrost {
+			found = &d
+			break
+		}
+	}
+
+	require.NotNil(t, found)
+	require.Equal(t, "builtin", found.Name)
+	require.NotEmpty(t, found.Description)
+}
+
+func TestRegisterProviderRejectsNilHost(t *testing.T) {
+	require.Error(t, RegisterProvider(nil))
+}
+
+func TestProviderRejectsPartialTLSPair(t *testing.T) {
+	host := newProviderHost(t)
+
+	_, err := plugin.Resolve[*Blockfrost](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIBlockfrost,
+		"builtin",
+		map[string]any{
+			"port": freeLoopbackPort(t),
+			"tls": map[string]any{
+				"mode":        "server",
+				"keyFilePath": "/only/key.pem",
+			},
+		},
+		ProviderDependencies{Node: &mockNode{}, Host: "127.0.0.1"},
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugins.api.blockfrost.config.tls")
+	require.ErrorContains(t, err, "must both be set")
+}
+
+func TestProviderRejectsInvalidAuthMode(t *testing.T) {
+	host := newProviderHost(t)
+
+	_, err := plugin.Resolve[*Blockfrost](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIBlockfrost,
+		"builtin",
+		map[string]any{
+			"port": freeLoopbackPort(t),
+			"auth": map[string]any{"mode": "bogus"},
+		},
+		ProviderDependencies{Node: &mockNode{}, Host: "127.0.0.1"},
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugins.api.blockfrost.config.auth")
+	require.ErrorContains(t, err, "invalid mode")
+}
+
+func TestProviderPropagatesTLSAndAuth(t *testing.T) {
+	host := newProviderHost(t)
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+
+	srv := resolveOnFreePortWithConfig(t, host, map[string]any{
+		"tls": map[string]any{
+			"mode":         "server",
+			"certFilePath": certPath,
+			"keyFilePath":  keyPath,
+		},
+		"auth": map[string]any{
+			"mode":  "token",
+			"token": "shared-secret",
+		},
+	})
+
+	require.True(t, srv.config.TLS.Enabled)
+	require.Equal(t, certPath, srv.config.TLS.CertFilePath)
+	require.Equal(t, keyPath, srv.config.TLS.KeyFilePath)
+	require.True(t, srv.config.Auth.Enabled)
+	require.Equal(t, "shared-secret", srv.config.Auth.Token)
+}

--- a/api/blockfrost/tls_auth_test.go
+++ b/api/blockfrost/tls_auth_test.go
@@ -16,8 +16,6 @@ package blockfrost
 
 import (
 	"context"
-	"crypto/tls"
-	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -26,21 +24,6 @@ import (
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
-
-// bindAttempts bounds how many ports a test tries before giving up,
-// matching api/mesh's identical helper.
-const bindAttempts = 8
-
-// freePort reserves a loopback port and releases it. Not guaranteed to
-// still be free when the caller binds it -- see bindAttempts.
-func freePort(t *testing.T) string {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	require.NoError(t, ln.Close())
-	return addr
-}
 
 // startOnFreePort starts a Blockfrost server with cfg (ListenAddress
 // overwritten to a free loopback port) and returns it with the address it
@@ -52,8 +35,8 @@ func startOnFreePort(
 ) (*Blockfrost, string) {
 	t.Helper()
 	var lastErr error
-	for range bindAttempts {
-		addr := freePort(t)
+	for range testutil.BindAttempts {
+		addr := testutil.FreePort(t)
 		attemptCfg := cfg
 		attemptCfg.ListenAddress = addr
 		srv := New(attemptCfg, &mockNode{}, nil)
@@ -68,7 +51,7 @@ func startOnFreePort(
 	}
 	t.Fatalf(
 		"could not bind a free loopback port in %d attempts: %v",
-		bindAttempts, lastErr,
+		testutil.BindAttempts, lastErr,
 	)
 	return nil, ""
 }
@@ -96,16 +79,6 @@ func startTestServerTLSAuth(
 		scheme = "https://"
 	}
 	return srv, scheme + addr
-}
-
-func insecureHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
-			},
-		},
-	}
 }
 
 func getHealth(
@@ -146,7 +119,7 @@ func TestBlockfrostTLSNoAuth(t *testing.T) {
 		},
 		apiconfig.EffectiveAuth{},
 	)
-	resp := getHealth(t, insecureHTTPClient(), baseURL, "", "")
+	resp := getHealth(t, testutil.InsecureHTTPClient(), baseURL, "", "")
 	t.Cleanup(func() { _ = resp.Body.Close() })
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -163,7 +136,7 @@ func TestBlockfrostTLSAuth(t *testing.T) {
 		},
 		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
 	)
-	client := insecureHTTPClient()
+	client := testutil.InsecureHTTPClient()
 
 	t.Run("missing credential", func(t *testing.T) {
 		resp := getHealth(t, client, baseURL, "", "")

--- a/api/blockfrost/tls_auth_test.go
+++ b/api/blockfrost/tls_auth_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// bindAttempts bounds how many ports a test tries before giving up,
+// matching api/mesh's identical helper.
+const bindAttempts = 8
+
+// freePort reserves a loopback port and releases it. Not guaranteed to
+// still be free when the caller binds it -- see bindAttempts.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// startOnFreePort starts a Blockfrost server with cfg (ListenAddress
+// overwritten to a free loopback port) and returns it with the address it
+// bound, retrying on a lost race for the port. The caller owns shutdown.
+func startOnFreePort(
+	t *testing.T,
+	ctx context.Context,
+	cfg BlockfrostConfig,
+) (*Blockfrost, string) {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		addr := freePort(t)
+		attemptCfg := cfg
+		attemptCfg.ListenAddress = addr
+		srv := New(attemptCfg, &mockNode{}, nil)
+		attemptCtx, cancel := context.WithCancel(ctx)
+		if err := srv.Start(attemptCtx); err != nil {
+			cancel()
+			lastErr = err
+			continue
+		}
+		t.Cleanup(cancel)
+		return srv, addr
+	}
+	t.Fatalf(
+		"could not bind a free loopback port in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil, ""
+}
+
+func startTestServerTLSAuth(
+	t *testing.T,
+	tlsCfg apiconfig.EffectiveTLS,
+	auth apiconfig.EffectiveAuth,
+) (*Blockfrost, string) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	srv, addr := startOnFreePort(
+		t, ctx, BlockfrostConfig{TLS: tlsCfg, Auth: auth},
+	)
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+	scheme := "http://"
+	if tlsCfg.Enabled {
+		scheme = "https://"
+	}
+	return srv, scheme + addr
+}
+
+func insecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
+			},
+		},
+	}
+}
+
+func getHealth(
+	t *testing.T,
+	client *http.Client,
+	baseURL string,
+	headerName, headerValue string,
+) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, baseURL+"/health", nil,
+	)
+	require.NoError(t, err)
+	if headerName != "" {
+		req.Header.Set(headerName, headerValue)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+func TestBlockfrostPlaintextNoAuth(t *testing.T) {
+	_, baseURL := startTestServerTLSAuth(
+		t, apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
+	)
+	resp := getHealth(t, http.DefaultClient, baseURL, "", "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestBlockfrostTLSNoAuth(t *testing.T) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	_, baseURL := startTestServerTLSAuth(
+		t,
+		apiconfig.EffectiveTLS{
+			Enabled: true, CertFilePath: certPath, KeyFilePath: keyPath,
+		},
+		apiconfig.EffectiveAuth{},
+	)
+	resp := getHealth(t, insecureHTTPClient(), baseURL, "", "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestBlockfrostTLSAuth covers a TLS-and-token-authenticated listener,
+// both via the standard Authorization header and via the Blockfrost-
+// compatible project_id alias header.
+func TestBlockfrostTLSAuth(t *testing.T) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	_, baseURL := startTestServerTLSAuth(
+		t,
+		apiconfig.EffectiveTLS{
+			Enabled: true, CertFilePath: certPath, KeyFilePath: keyPath,
+		},
+		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
+	)
+	client := insecureHTTPClient()
+
+	t.Run("missing credential", func(t *testing.T) {
+		resp := getHealth(t, client, baseURL, "", "")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("wrong credential", func(t *testing.T) {
+		resp := getHealth(t, client, baseURL, "Authorization", "Bearer wrong")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("valid bearer credential", func(t *testing.T) {
+		resp := getHealth(
+			t, client, baseURL, "Authorization", "Bearer shared-secret",
+		)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("valid project_id alias credential", func(t *testing.T) {
+		resp := getHealth(t, client, baseURL, "project_id", "shared-secret")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("wrong project_id alias credential", func(t *testing.T) {
+		resp := getHealth(t, client, baseURL, "project_id", "wrong")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+// TestBlockfrostCORSPreflightBypassesAuth documents and tests the
+// decision that an OPTIONS CORS preflight never needs a credential.
+func TestBlockfrostCORSPreflightBypassesAuth(t *testing.T) {
+	const allowed = "https://wallet.example"
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	srv, addr := startOnFreePort(t, ctx, BlockfrostConfig{
+		Auth: apiconfig.EffectiveAuth{
+			Enabled: true,
+			Token:   "shared-secret",
+		},
+		CORSAllowedOrigins: []string{allowed},
+	})
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+	baseURL := "http://" + addr
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodOptions, baseURL+"/health", nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Origin", allowed)
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// A real (non-preflight) request without a credential is still
+	// rejected.
+	realResp := getHealth(t, http.DefaultClient, baseURL, "", "")
+	t.Cleanup(func() { _ = realResp.Body.Close() })
+	require.Equal(t, http.StatusUnauthorized, realResp.StatusCode)
+}

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -124,26 +124,6 @@ func TestNewServerAddressNetworkFollowsMagic(t *testing.T) {
 
 // --- listener lifecycle -------------------------------------------------
 
-// bindAttempts bounds how many ports a test tries before giving up.
-// The server binds the address in its config and does not expose the
-// address it resolved, so a test cannot ask the kernel for a port with
-// :0 and read it back. Reserving a port and releasing it leaves a
-// window in which another process can claim it, so callers retry
-// instead of treating one bind failure as a test failure.
-const bindAttempts = 8
-
-// freePort reserves a loopback port and releases it, returning the
-// address. The port is not guaranteed to still be free when the caller
-// binds it -- see bindAttempts.
-func freePort(t *testing.T) string {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	require.NoError(t, ln.Close())
-	return addr
-}
-
 // startOnFreePort starts a server on a free loopback port, retrying on
 // a lost race for the port, and returns it with the address it bound.
 // The caller owns shutdown.
@@ -164,8 +144,8 @@ func startOnFreePort(
 ) (*Server, string) {
 	t.Helper()
 	var lastErr error
-	for range bindAttempts {
-		addr := freePort(t)
+	for range testutil.BindAttempts {
+		addr := testutil.FreePort(t)
 		attemptOpts := make([]serverOption, 0, len(opts)+1)
 		attemptOpts = append(attemptOpts, opts...)
 		attemptOpts = append(
@@ -184,7 +164,7 @@ func startOnFreePort(
 	}
 	t.Fatalf(
 		"could not bind a free loopback port in %d attempts: %v",
-		bindAttempts, lastErr,
+		testutil.BindAttempts, lastErr,
 	)
 	return nil, ""
 }

--- a/api/mesh/mesh.go
+++ b/api/mesh/mesh.go
@@ -27,7 +27,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/apiauth"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
+	"github.com/blinklabs-io/dingo/internal/tlsutil"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
@@ -67,6 +70,11 @@ type ServerConfig struct {
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.
 	CORSAllowedOrigins []string
+	// TLS and Auth are the resolved (merged, validated) TLS/authentication
+	// policy for this listener -- see ProviderConfig's doc comment and
+	// ARCHITECTURE.md's "API security" section.
+	TLS  apiconfig.EffectiveTLS
+	Auth apiconfig.EffectiveAuth
 }
 
 // Server is the Mesh-compatible REST API server.
@@ -78,6 +86,7 @@ type Server struct {
 	genesisStartTimeSec int64
 	addrNetworkID       uint8
 	httpServer          *http.Server
+	verifier            *apiauth.Verifier
 	mu                  sync.Mutex
 }
 
@@ -165,19 +174,35 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 
 // Start starts the HTTP server in a background goroutine.
 func (s *Server) Start(ctx context.Context) error {
+	// Built before the handler chain so it can install the shared
+	// credential-verification middleware (internal/apiauth).
+	verifier, err := apiauth.NewVerifier(s.config.Auth)
+	if err != nil {
+		return fmt.Errorf("mesh: %w", err)
+	}
 	s.mu.Lock()
 	if s.httpServer != nil {
 		s.mu.Unlock()
 		return errors.New("server already started")
 	}
+	s.verifier = verifier
 
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
 
+	// CORS must wrap authentication, not the reverse: httpcors.Handler
+	// fully answers an OPTIONS preflight itself and never calls the
+	// handler it wraps for one, so browsers -- which never attach
+	// Authorization to a preflight request -- never need a credential to
+	// pass CORS negotiation. Every other request, including a
+	// non-preflight OPTIONS, still reaches the mux normally. See
+	// internal/apiauth's Middleware doc comment for the general statement
+	// of this ordering rule.
+	authenticated := apiauth.Middleware(s.verifier)(mux)
 	server := &http.Server{
 		Addr: s.config.ListenAddress,
 		Handler: httpcors.Handler(
-			mux,
+			authenticated,
 			httpcors.Config{
 				AllowedOrigins: s.config.CORSAllowedOrigins,
 			},
@@ -264,6 +289,19 @@ func (s *Server) Stop(ctx context.Context) error {
 func (s *Server) startServer(
 	server *http.Server,
 ) error {
+	useTLS := s.config.TLS.Enabled
+	if useTLS {
+		if err := tlsutil.ConfigureServerTLS(
+			server,
+			s.config.TLS.CertFilePath,
+			s.config.TLS.KeyFilePath,
+		); err != nil {
+			return fmt.Errorf(
+				"failed to load TLS keypair for Mesh API server: %w",
+				err,
+			)
+		}
+	}
 	ln, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		return fmt.Errorf(
@@ -272,11 +310,17 @@ func (s *Server) startServer(
 		)
 	}
 	go func() {
-		if err := server.Serve(ln); err != nil &&
-			!errors.Is(err, http.ErrServerClosed) {
+		var serveErr error
+		if useTLS {
+			serveErr = server.ServeTLS(ln, "", "")
+		} else {
+			serveErr = server.Serve(ln)
+		}
+		if serveErr != nil &&
+			!errors.Is(serveErr, http.ErrServerClosed) {
 			s.logger.Error(
 				"Mesh API server error",
-				"error", err,
+				"error", serveErr,
 			)
 		}
 	}()

--- a/api/mesh/provider.go
+++ b/api/mesh/provider.go
@@ -16,10 +16,12 @@ package mesh
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"strconv"
 
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
@@ -27,8 +29,16 @@ import (
 // node's configuration does not set one.
 const defaultProviderPort uint = 8080
 
+// ProviderConfig's TLS and Auth fields are documented in ARCHITECTURE.md's
+// "API security" section. Composition (node.go) merges the top-level
+// api.tls/api.auth defaults into these fields before this provider ever
+// decodes them, so from this package's point of view they are always
+// already-resolved-for-this-provider settings, identical in shape to a
+// provider that set every field inline.
 type ProviderConfig struct {
-	Port uint `yaml:"port"`
+	Port uint                 `yaml:"port"`
+	TLS  apiconfig.TLSPolicy  `yaml:"tls"`
+	Auth apiconfig.AuthPolicy `yaml:"auth"`
 }
 
 // providerDefaults returns the configuration the plugin host applies
@@ -63,6 +73,14 @@ func RegisterProvider(host *plugin.Host) error {
 		},
 		providerDefaults,
 		func(_ context.Context, cfg ProviderConfig, deps ProviderDependencies) (*Server, plugin.Instance, error) {
+			tls, err := cfg.TLS.Resolve("plugins.api.mesh.config.tls")
+			if err != nil {
+				return nil, nil, fmt.Errorf("mesh: %w", err)
+			}
+			auth, err := cfg.Auth.Resolve("plugins.api.mesh.config.auth")
+			if err != nil {
+				return nil, nil, fmt.Errorf("mesh: %w", err)
+			}
 			server, err := NewServer(ServerConfig{
 				Logger: deps.Logger, LedgerState: deps.LedgerState,
 				Database: deps.Database, Chain: deps.Chain, Mempool: deps.Mempool,
@@ -73,6 +91,8 @@ func RegisterProvider(host *plugin.Host) error {
 				Network: deps.Network, NetworkMagic: deps.NetworkMagic,
 				GenesisHash: deps.GenesisHash, GenesisStartTimeSec: deps.GenesisStartTimeSec,
 				CORSAllowedOrigins: deps.CORSAllowedOrigins,
+				TLS:                tls,
+				Auth:               auth,
 			})
 			if err != nil {
 				return nil, nil, err

--- a/api/mesh/provider_test.go
+++ b/api/mesh/provider_test.go
@@ -57,7 +57,7 @@ func providerDeps(deps *testDeps) ProviderDependencies {
 // expect resolution to succeed go through resolveOnFreePort.
 func freeLoopbackPort(t *testing.T) uint {
 	t.Helper()
-	_, portStr, err := net.SplitHostPort(freePort(t))
+	_, portStr, err := net.SplitHostPort(testutil.FreePort(t))
 	require.NoError(t, err)
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	require.NoError(t, err)
@@ -67,34 +67,15 @@ func freeLoopbackPort(t *testing.T) uint {
 // resolveOnFreePort resolves the Mesh provider on a free loopback port,
 // retrying on a lost race for the port. Resolve starts the instance, so
 // a port claimed between reservation and bind surfaces as a resolution
-// error rather than a test failure worth reporting.
+// error rather than a test failure worth reporting. It is
+// resolveOnFreePortWithConfig with no extra config fields.
 func resolveOnFreePort(
 	t *testing.T,
 	host *plugin.Host,
 	deps ProviderDependencies,
 ) *Server {
 	t.Helper()
-	var lastErr error
-	for range bindAttempts {
-		srv, err := plugin.Resolve[*Server](
-			t.Context(),
-			host,
-			plugin.CapabilityAPIMesh,
-			"builtin",
-			map[string]any{"port": freeLoopbackPort(t)},
-			deps,
-		)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		return srv
-	}
-	t.Fatalf(
-		"could not resolve the Mesh provider in %d attempts: %v",
-		bindAttempts, lastErr,
-	)
-	return nil
+	return resolveOnFreePortWithConfig(t, host, deps, nil)
 }
 
 // resolveOnFreePortWithConfig is resolveOnFreePort with additional
@@ -107,7 +88,7 @@ func resolveOnFreePortWithConfig(
 ) *Server {
 	t.Helper()
 	var lastErr error
-	for range bindAttempts {
+	for range testutil.BindAttempts {
 		cfg := map[string]any{"port": freeLoopbackPort(t)}
 		maps.Copy(cfg, extra)
 		srv, err := plugin.Resolve[*Server](
@@ -126,7 +107,7 @@ func resolveOnFreePortWithConfig(
 	}
 	t.Fatalf(
 		"could not resolve the Mesh provider in %d attempts: %v",
-		bindAttempts, lastErr,
+		testutil.BindAttempts, lastErr,
 	)
 	return nil
 }

--- a/api/mesh/provider_test.go
+++ b/api/mesh/provider_test.go
@@ -16,10 +16,12 @@ package mesh
 
 import (
 	"context"
+	"maps"
 	"net"
 	"strconv"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/plugin"
 	"github.com/stretchr/testify/require"
 )
@@ -80,6 +82,40 @@ func resolveOnFreePort(
 			plugin.CapabilityAPIMesh,
 			"builtin",
 			map[string]any{"port": freeLoopbackPort(t)},
+			deps,
+		)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return srv
+	}
+	t.Fatalf(
+		"could not resolve the Mesh provider in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil
+}
+
+// resolveOnFreePortWithConfig is resolveOnFreePort with additional
+// provider config fields (e.g. "tls"/"auth") merged alongside "port".
+func resolveOnFreePortWithConfig(
+	t *testing.T,
+	host *plugin.Host,
+	deps ProviderDependencies,
+	extra map[string]any,
+) *Server {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		cfg := map[string]any{"port": freeLoopbackPort(t)}
+		maps.Copy(cfg, extra)
+		srv, err := plugin.Resolve[*Server](
+			t.Context(),
+			host,
+			plugin.CapabilityAPIMesh,
+			"builtin",
+			cfg,
 			deps,
 		)
 		if err != nil {
@@ -219,4 +255,83 @@ func TestProviderStopClosesListener(t *testing.T) {
 	require.NoError(t, host.Stop(t.Context()))
 
 	require.False(t, portAccepts(addr))
+}
+
+// TestProviderRejectsPartialTLSPair asserts a provider config with tls
+// mode "server" and only one of certFilePath/keyFilePath set fails
+// resolution -- before any listener is opened -- with an error naming
+// the full provider config path, not just "tls".
+func TestProviderRejectsPartialTLSPair(t *testing.T) {
+	host := newProviderHost(t)
+
+	_, err := plugin.Resolve[*Server](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIMesh,
+		"builtin",
+		map[string]any{
+			"port": freeLoopbackPort(t),
+			"tls": map[string]any{
+				"mode":         "server",
+				"certFilePath": "/only/cert.pem",
+			},
+		},
+		providerDeps(newTestDeps()),
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugins.api.mesh.config.tls")
+	require.ErrorContains(t, err, "must both be set")
+}
+
+// TestProviderRejectsInvalidAuthMode asserts an unrecognized auth.mode is
+// rejected at resolution, with an error naming the full provider config
+// path.
+func TestProviderRejectsInvalidAuthMode(t *testing.T) {
+	host := newProviderHost(t)
+
+	_, err := plugin.Resolve[*Server](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIMesh,
+		"builtin",
+		map[string]any{
+			"port": freeLoopbackPort(t),
+			"auth": map[string]any{"mode": "bogus"},
+		},
+		providerDeps(newTestDeps()),
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugins.api.mesh.config.auth")
+	require.ErrorContains(t, err, "invalid mode")
+}
+
+// TestProviderPropagatesTLSAndAuth asserts a valid provider tls/auth
+// config reaches the server's resolved (EffectiveTLS/EffectiveAuth)
+// settings.
+func TestProviderPropagatesTLSAndAuth(t *testing.T) {
+	host := newProviderHost(t)
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+
+	srv := resolveOnFreePortWithConfig(
+		t, host, providerDeps(newTestDeps()),
+		map[string]any{
+			"tls": map[string]any{
+				"mode":         "server",
+				"certFilePath": certPath,
+				"keyFilePath":  keyPath,
+			},
+			"auth": map[string]any{
+				"mode":  "token",
+				"token": "shared-secret",
+			},
+		},
+	)
+
+	require.True(t, srv.config.TLS.Enabled)
+	require.Equal(t, certPath, srv.config.TLS.CertFilePath)
+	require.Equal(t, keyPath, srv.config.TLS.KeyFilePath)
+	require.True(t, srv.config.Auth.Enabled)
+	require.Equal(t, "shared-secret", srv.config.Auth.Token)
 }

--- a/api/mesh/tls_auth_test.go
+++ b/api/mesh/tls_auth_test.go
@@ -1,0 +1,225 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// startTestServerTLSAuth starts a server on a free loopback port with the
+// given TLS/Auth policy and returns it with a scheme-appropriate base URL.
+func startTestServerTLSAuth(
+	t *testing.T,
+	tlsCfg apiconfig.EffectiveTLS,
+	auth apiconfig.EffectiveAuth,
+) (*Server, string) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	srv, addr := startOnFreePort(
+		t, ctx, newTestDeps(),
+		func(c *ServerConfig) {
+			c.TLS = tlsCfg
+			c.Auth = auth
+		},
+	)
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+	scheme := "http://"
+	if tlsCfg.Enabled {
+		scheme = "https://"
+	}
+	return srv, scheme + addr
+}
+
+func insecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
+			},
+		},
+	}
+}
+
+func postNetworkList(
+	t *testing.T,
+	client *http.Client,
+	baseURL string,
+	authHeader string,
+) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(MetadataRequest{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodPost, baseURL+"/network/list",
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+// TestServerPlaintextNoAuth is the baseline: no TLS, no auth, matching
+// existing pre-dingo#2996 deployments exactly.
+func TestServerPlaintextNoAuth(t *testing.T) {
+	_, baseURL := startTestServerTLSAuth(
+		t, apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
+	)
+	resp := postNetworkList(t, http.DefaultClient, baseURL, "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestServerTLSNoAuth covers a TLS-enabled, unauthenticated listener: the
+// handshake succeeds and the request is served.
+func TestServerTLSNoAuth(t *testing.T) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	_, baseURL := startTestServerTLSAuth(
+		t,
+		apiconfig.EffectiveTLS{
+			Enabled: true, CertFilePath: certPath, KeyFilePath: keyPath,
+		},
+		apiconfig.EffectiveAuth{},
+	)
+	resp := postNetworkList(t, insecureHTTPClient(), baseURL, "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestServerTLSAuth covers a TLS-and-token-authenticated listener: a
+// request with no credential and one with the wrong credential are both
+// rejected with 401; the correct bearer credential is accepted, over TLS.
+func TestServerTLSAuth(t *testing.T) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	_, baseURL := startTestServerTLSAuth(
+		t,
+		apiconfig.EffectiveTLS{
+			Enabled: true, CertFilePath: certPath, KeyFilePath: keyPath,
+		},
+		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
+	)
+	client := insecureHTTPClient()
+
+	t.Run("missing credential", func(t *testing.T) {
+		resp := postNetworkList(t, client, baseURL, "")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("wrong credential", func(t *testing.T) {
+		resp := postNetworkList(t, client, baseURL, "Bearer wrong")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("valid credential", func(t *testing.T) {
+		resp := postNetworkList(t, client, baseURL, "Bearer shared-secret")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// TestServerPlaintextAuth covers auth enabled without TLS -- reverse-proxy
+// deployments that terminate TLS upstream must still be able to enable the
+// shared token check on the plaintext listener behind them.
+func TestServerPlaintextAuth(t *testing.T) {
+	_, baseURL := startTestServerTLSAuth(
+		t,
+		apiconfig.EffectiveTLS{},
+		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
+	)
+	resp := postNetworkList(t, http.DefaultClient, baseURL, "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	resp2 := postNetworkList(
+		t, http.DefaultClient, baseURL, "Bearer shared-secret",
+	)
+	t.Cleanup(func() { _ = resp2.Body.Close() })
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// TestServerCORSPreflightBypassesAuth documents and tests the decision
+// that an OPTIONS CORS preflight never needs a credential -- browsers
+// never attach Authorization to a preflight request, so requiring one
+// would make every browser client's cross-origin access impossible
+// regardless of what credential it later sends with the real request.
+// Every non-preflight request, including one with no credential at all,
+// still authenticates normally.
+func TestServerCORSPreflightBypassesAuth(t *testing.T) {
+	const allowed = "https://wallet.example"
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	srv, addr := startOnFreePort(
+		t, ctx, newTestDeps(),
+		func(c *ServerConfig) {
+			c.Auth = apiconfig.EffectiveAuth{
+				Enabled: true,
+				Token:   "shared-secret",
+			}
+			c.CORSAllowedOrigins = []string{allowed}
+		},
+	)
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer stopCancel()
+		require.NoError(t, srv.Stop(stopCtx))
+	})
+	baseURL := "http://" + addr
+
+	t.Run("preflight needs no credential", func(t *testing.T) {
+		resp := preflight(t, baseURL, allowed)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("real request without credential still rejected", func(t *testing.T) {
+		resp := postNetworkList(t, http.DefaultClient, baseURL, "")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("real request with credential accepted", func(t *testing.T) {
+		resp := postNetworkList(
+			t, http.DefaultClient, baseURL, "Bearer shared-secret",
+		)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}

--- a/api/mesh/tls_auth_test.go
+++ b/api/mesh/tls_auth_test.go
@@ -17,7 +17,6 @@ package mesh
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -57,16 +56,6 @@ func startTestServerTLSAuth(
 		scheme = "https://"
 	}
 	return srv, scheme + addr
-}
-
-func insecureHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
-			},
-		},
-	}
 }
 
 func postNetworkList(
@@ -115,7 +104,7 @@ func TestServerTLSNoAuth(t *testing.T) {
 		},
 		apiconfig.EffectiveAuth{},
 	)
-	resp := postNetworkList(t, insecureHTTPClient(), baseURL, "")
+	resp := postNetworkList(t, testutil.InsecureHTTPClient(), baseURL, "")
 	t.Cleanup(func() { _ = resp.Body.Close() })
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -132,7 +121,7 @@ func TestServerTLSAuth(t *testing.T) {
 		},
 		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
 	)
-	client := insecureHTTPClient()
+	client := testutil.InsecureHTTPClient()
 
 	t.Run("missing credential", func(t *testing.T) {
 		resp := postNetworkList(t, client, baseURL, "")

--- a/api/utxorpc/provider.go
+++ b/api/utxorpc/provider.go
@@ -16,13 +16,23 @@ package utxorpc
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/plugin"
 )
 
+// ProviderConfig's TLS and Auth fields are documented in ARCHITECTURE.md's
+// "API security" section. Composition (node.go) merges the top-level
+// api.tls/api.auth defaults into these fields before this provider ever
+// decodes them, so from this package's point of view they are always
+// already-resolved-for-this-provider settings, identical in shape to a
+// provider that set every field inline.
 type ProviderConfig struct {
-	Port uint `yaml:"port"`
+	Port uint                 `yaml:"port"`
+	TLS  apiconfig.TLSPolicy  `yaml:"tls"`
+	Auth apiconfig.AuthPolicy `yaml:"auth"`
 }
 
 type ProviderDependencies struct {
@@ -31,8 +41,6 @@ type ProviderDependencies struct {
 	LedgerState        UtxorpcLedgerState
 	Mempool            UtxorpcMempool
 	Host               string
-	TLSCertFilePath    string
-	TLSKeyFilePath     string
 	CORSAllowedOrigins []string
 }
 
@@ -46,12 +54,19 @@ func RegisterProvider(host *plugin.Host) error {
 		},
 		func() ProviderConfig { return ProviderConfig{Port: 9090} },
 		func(_ context.Context, cfg ProviderConfig, deps ProviderDependencies) (*Utxorpc, plugin.Instance, error) {
+			tls, err := cfg.TLS.Resolve("plugins.api.utxorpc.config.tls")
+			if err != nil {
+				return nil, nil, fmt.Errorf("utxorpc: %w", err)
+			}
+			auth, err := cfg.Auth.Resolve("plugins.api.utxorpc.config.auth")
+			if err != nil {
+				return nil, nil, fmt.Errorf("utxorpc: %w", err)
+			}
 			server := NewUtxorpc(UtxorpcConfig{
 				Logger: deps.Logger, EventBus: deps.EventBus,
 				LedgerState: deps.LedgerState, Mempool: deps.Mempool,
 				Host: deps.Host, Port: cfg.Port,
-				TlsCertFilePath:    deps.TLSCertFilePath,
-				TlsKeyFilePath:     deps.TLSKeyFilePath,
+				TLS: tls, Auth: auth,
 				CORSAllowedOrigins: deps.CORSAllowedOrigins,
 			})
 			return server, server, nil

--- a/api/utxorpc/provider_test.go
+++ b/api/utxorpc/provider_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func newProviderHost(t *testing.T) *plugin.Host {
+	t.Helper()
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+	t.Cleanup(func() {
+		require.NoError(t, host.Stop(context.Background()))
+	})
+	return host
+}
+
+func freeLoopbackPort(t *testing.T) uint {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(freePort(t))
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	require.NoError(t, err)
+	return uint(port)
+}
+
+func providerDeps() ProviderDependencies {
+	return ProviderDependencies{
+		Logger:   slog.Default(),
+		EventBus: event.NewEventBus(nil, nil),
+		Host:     "127.0.0.1",
+	}
+}
+
+// resolveOnFreePortWithConfig resolves the built-in UTxO RPC provider on a
+// free loopback port with extra config fields (e.g. "tls"/"auth") merged
+// alongside "port", retrying on a lost race for the port.
+func resolveOnFreePortWithConfig(
+	t *testing.T,
+	host *plugin.Host,
+	extra map[string]any,
+) *Utxorpc {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		cfg := map[string]any{"port": freeLoopbackPort(t)}
+		maps.Copy(cfg, extra)
+		srv, err := plugin.Resolve[*Utxorpc](
+			t.Context(),
+			host,
+			plugin.CapabilityAPIUtxorpc,
+			"builtin",
+			cfg,
+			providerDeps(),
+		)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return srv
+	}
+	t.Fatalf(
+		"could not resolve the UTxO RPC provider in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil
+}
+
+func TestRegisterProviderDescriptor(t *testing.T) {
+	host := newProviderHost(t)
+
+	var found *plugin.Descriptor
+	for _, d := range host.Providers() {
+		if d.Capability == plugin.CapabilityAPIUtxorpc {
+			found = &d
+			break
+		}
+	}
+
+	require.NotNil(t, found)
+	require.Equal(t, "builtin", found.Name)
+	require.NotEmpty(t, found.Description)
+}
+
+func TestProviderRejectsPartialTLSPair(t *testing.T) {
+	host := newProviderHost(t)
+
+	_, err := plugin.Resolve[*Utxorpc](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIUtxorpc,
+		"builtin",
+		map[string]any{
+			"port": freeLoopbackPort(t),
+			"tls": map[string]any{
+				"mode":         "server",
+				"certFilePath": "/only/cert.pem",
+			},
+		},
+		providerDeps(),
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugins.api.utxorpc.config.tls")
+	require.ErrorContains(t, err, "must both be set")
+}
+
+func TestProviderRejectsInvalidAuthMode(t *testing.T) {
+	host := newProviderHost(t)
+
+	_, err := plugin.Resolve[*Utxorpc](
+		t.Context(),
+		host,
+		plugin.CapabilityAPIUtxorpc,
+		"builtin",
+		map[string]any{
+			"port": freeLoopbackPort(t),
+			"auth": map[string]any{"mode": "bogus"},
+		},
+		providerDeps(),
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugins.api.utxorpc.config.auth")
+	require.ErrorContains(t, err, "invalid mode")
+}
+
+func TestProviderPropagatesTLSAndAuth(t *testing.T) {
+	host := newProviderHost(t)
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+
+	srv := resolveOnFreePortWithConfig(t, host, map[string]any{
+		"tls": map[string]any{
+			"mode":         "server",
+			"certFilePath": certPath,
+			"keyFilePath":  keyPath,
+		},
+		"auth": map[string]any{
+			"mode":  "token",
+			"token": "shared-secret",
+		},
+	})
+
+	require.True(t, srv.config.TLS.Enabled)
+	require.Equal(t, certPath, srv.config.TLS.CertFilePath)
+	require.Equal(t, keyPath, srv.config.TLS.KeyFilePath)
+	require.True(t, srv.config.Auth.Enabled)
+	require.Equal(t, "shared-secret", srv.config.Auth.Token)
+}

--- a/api/utxorpc/provider_test.go
+++ b/api/utxorpc/provider_test.go
@@ -40,32 +40,43 @@ func newProviderHost(t *testing.T) *plugin.Host {
 
 func freeLoopbackPort(t *testing.T) uint {
 	t.Helper()
-	_, portStr, err := net.SplitHostPort(freePort(t))
+	_, portStr, err := net.SplitHostPort(testutil.FreePort(t))
 	require.NoError(t, err)
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	require.NoError(t, err)
 	return uint(port)
 }
 
-func providerDeps() ProviderDependencies {
+// providerDeps builds provider dependencies over a test-owned EventBus.
+// The bus is permanently shut down via t.Cleanup(bus.Close) rather than
+// bus.Stop -- Stop leaves the worker pool restartable (for a component
+// that reuses one EventBus across a stop/start cycle), which would leak
+// its four workers for the rest of the test run instead of releasing them.
+func providerDeps(t *testing.T) ProviderDependencies {
+	t.Helper()
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
 	return ProviderDependencies{
 		Logger:   slog.Default(),
-		EventBus: event.NewEventBus(nil, nil),
+		EventBus: bus,
 		Host:     "127.0.0.1",
 	}
 }
 
 // resolveOnFreePortWithConfig resolves the built-in UTxO RPC provider on a
 // free loopback port with extra config fields (e.g. "tls"/"auth") merged
-// alongside "port", retrying on a lost race for the port.
+// alongside "port", retrying on a lost race for the port. The provider
+// dependencies (including the EventBus) are built once and reused across
+// every attempt, rather than one per attempt.
 func resolveOnFreePortWithConfig(
 	t *testing.T,
 	host *plugin.Host,
 	extra map[string]any,
 ) *Utxorpc {
 	t.Helper()
+	deps := providerDeps(t)
 	var lastErr error
-	for range bindAttempts {
+	for range testutil.BindAttempts {
 		cfg := map[string]any{"port": freeLoopbackPort(t)}
 		maps.Copy(cfg, extra)
 		srv, err := plugin.Resolve[*Utxorpc](
@@ -74,7 +85,7 @@ func resolveOnFreePortWithConfig(
 			plugin.CapabilityAPIUtxorpc,
 			"builtin",
 			cfg,
-			providerDeps(),
+			deps,
 		)
 		if err != nil {
 			lastErr = err
@@ -84,7 +95,7 @@ func resolveOnFreePortWithConfig(
 	}
 	t.Fatalf(
 		"could not resolve the UTxO RPC provider in %d attempts: %v",
-		bindAttempts, lastErr,
+		testutil.BindAttempts, lastErr,
 	)
 	return nil
 }
@@ -120,7 +131,7 @@ func TestProviderRejectsPartialTLSPair(t *testing.T) {
 				"certFilePath": "/only/cert.pem",
 			},
 		},
-		providerDeps(),
+		providerDeps(t),
 	)
 
 	require.Error(t, err)
@@ -140,7 +151,7 @@ func TestProviderRejectsInvalidAuthMode(t *testing.T) {
 			"port": freeLoopbackPort(t),
 			"auth": map[string]any{"mode": "bogus"},
 		},
-		providerDeps(),
+		providerDeps(t),
 	)
 
 	require.Error(t, err)

--- a/api/utxorpc/tls_auth_test.go
+++ b/api/utxorpc/tls_auth_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// bindAttempts bounds how many ports a test tries before giving up,
+// matching api/mesh's and api/blockfrost's identical helper.
+const bindAttempts = 8
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// startOnFreePort starts a Utxorpc server on a free loopback port, retrying
+// on a lost race for the port, and returns it with the address it bound.
+// The caller owns shutdown.
+func startOnFreePort(
+	t *testing.T,
+	ctx context.Context,
+	tlsCfg apiconfig.EffectiveTLS,
+	auth apiconfig.EffectiveAuth,
+) (*Utxorpc, string) {
+	t.Helper()
+	var lastErr error
+	for range bindAttempts {
+		addr := freePort(t)
+		host, port, err := net.SplitHostPort(addr)
+		require.NoError(t, err)
+		portNum, err := strconv.ParseUint(port, 10, 16)
+		require.NoError(t, err)
+		u := NewUtxorpc(UtxorpcConfig{
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EventBus: event.NewEventBus(nil, nil),
+			Host:     host,
+			Port:     uint(portNum),
+			TLS:      tlsCfg,
+			Auth:     auth,
+		})
+		attemptCtx, cancel := context.WithCancel(ctx)
+		if err := u.Start(attemptCtx); err != nil {
+			cancel()
+			lastErr = err
+			continue
+		}
+		t.Cleanup(cancel)
+		return u, addr
+	}
+	t.Fatalf(
+		"could not bind a free loopback port in %d attempts: %v",
+		bindAttempts, lastErr,
+	)
+	return nil, ""
+}
+
+func stopUtxorpc(t *testing.T, u *Utxorpc) {
+	t.Helper()
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, u.Stop(stopCtx))
+}
+
+func insecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
+			},
+		},
+	}
+}
+
+// healthCheck issues a Connect-protocol unary health check (works over
+// plain HTTP/1.1 or TLS, no HTTP/2 client machinery required) and returns
+// the response.
+func healthCheck(
+	t *testing.T,
+	client *http.Client,
+	baseURL, authHeader string,
+) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		baseURL+"/grpc.health.v1.Health/Check",
+		bytes.NewReader([]byte("{}")),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connect-Protocol-Version", "1")
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+func TestUtxorpcPlaintextNoAuth(t *testing.T) {
+	u, addr := startOnFreePort(
+		t, t.Context(), apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
+	)
+	t.Cleanup(func() { stopUtxorpc(t, u) })
+
+	resp := healthCheck(t, http.DefaultClient, "http://"+addr, "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestUtxorpcTLSNoAuth(t *testing.T) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	u, addr := startOnFreePort(
+		t, t.Context(),
+		apiconfig.EffectiveTLS{
+			Enabled: true, CertFilePath: certPath, KeyFilePath: keyPath,
+		},
+		apiconfig.EffectiveAuth{},
+	)
+	t.Cleanup(func() { stopUtxorpc(t, u) })
+
+	resp := healthCheck(t, insecureHTTPClient(), "https://"+addr, "")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestUtxorpcTLSAuth covers a TLS-and-token-authenticated listener: a
+// missing or wrong credential is rejected with the Connect/gRPC
+// Unauthenticated code (surfaced over HTTP as 401 by the Connect
+// protocol), and the correct bearer credential is accepted.
+func TestUtxorpcTLSAuth(t *testing.T) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	u, addr := startOnFreePort(
+		t, t.Context(),
+		apiconfig.EffectiveTLS{
+			Enabled: true, CertFilePath: certPath, KeyFilePath: keyPath,
+		},
+		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
+	)
+	t.Cleanup(func() { stopUtxorpc(t, u) })
+	client := insecureHTTPClient()
+	baseURL := "https://" + addr
+
+	t.Run("missing credential", func(t *testing.T) {
+		resp := healthCheck(t, client, baseURL, "")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		// The Connect protocol maps CodeUnauthenticated to HTTP 401.
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("wrong credential", func(t *testing.T) {
+		resp := healthCheck(t, client, baseURL, "Bearer wrong")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("valid credential", func(t *testing.T) {
+		resp := healthCheck(t, client, baseURL, "Bearer shared-secret")
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// TestUtxorpcCORSPreflightBypassesAuth documents and tests the decision
+// that an OPTIONS CORS preflight never needs a credential.
+func TestUtxorpcCORSPreflightBypassesAuth(t *testing.T) {
+	const allowed = "https://wallet.example"
+	addr := freePort(t)
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	portNum, err := strconv.ParseUint(port, 10, 16)
+	require.NoError(t, err)
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil, nil),
+		Host:     host,
+		Port:     uint(portNum),
+		Auth: apiconfig.EffectiveAuth{
+			Enabled: true,
+			Token:   "shared-secret",
+		},
+		CORSAllowedOrigins: []string{allowed},
+	})
+	require.NoError(t, u.Start(t.Context()))
+	t.Cleanup(func() { stopUtxorpc(t, u) })
+	baseURL := "http://" + addr
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodOptions,
+		baseURL+"/grpc.health.v1.Health/Check", nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Origin", allowed)
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	realResp := healthCheck(t, http.DefaultClient, baseURL, "")
+	t.Cleanup(func() { _ = realResp.Body.Close() })
+	require.Equal(t, http.StatusUnauthorized, realResp.StatusCode)
+}

--- a/api/utxorpc/tls_auth_test.go
+++ b/api/utxorpc/tls_auth_test.go
@@ -17,7 +17,6 @@ package utxorpc
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"io"
 	"log/slog"
 	"net"
@@ -32,19 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// bindAttempts bounds how many ports a test tries before giving up,
-// matching api/mesh's and api/blockfrost's identical helper.
-const bindAttempts = 8
-
-func freePort(t *testing.T) string {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	require.NoError(t, ln.Close())
-	return addr
-}
-
 // startOnFreePort starts a Utxorpc server on a free loopback port, retrying
 // on a lost race for the port, and returns it with the address it bound.
 // The caller owns shutdown.
@@ -55,20 +41,36 @@ func startOnFreePort(
 	auth apiconfig.EffectiveAuth,
 ) (*Utxorpc, string) {
 	t.Helper()
+	return startOnFreePortWithCORS(t, ctx, tlsCfg, auth, nil)
+}
+
+// startOnFreePortWithCORS is startOnFreePort plus an optional
+// CORSAllowedOrigins list, so CORS-specific tests still get the same
+// retry-safe port acquisition as every other test in this file instead of
+// a bespoke bind that can flake on a lost port race.
+func startOnFreePortWithCORS(
+	t *testing.T,
+	ctx context.Context,
+	tlsCfg apiconfig.EffectiveTLS,
+	auth apiconfig.EffectiveAuth,
+	corsAllowedOrigins []string,
+) (*Utxorpc, string) {
+	t.Helper()
 	var lastErr error
-	for range bindAttempts {
-		addr := freePort(t)
+	for range testutil.BindAttempts {
+		addr := testutil.FreePort(t)
 		host, port, err := net.SplitHostPort(addr)
 		require.NoError(t, err)
 		portNum, err := strconv.ParseUint(port, 10, 16)
 		require.NoError(t, err)
 		u := NewUtxorpc(UtxorpcConfig{
-			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
-			EventBus: event.NewEventBus(nil, nil),
-			Host:     host,
-			Port:     uint(portNum),
-			TLS:      tlsCfg,
-			Auth:     auth,
+			Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EventBus:           event.NewEventBus(nil, nil),
+			Host:               host,
+			Port:               uint(portNum),
+			TLS:                tlsCfg,
+			Auth:               auth,
+			CORSAllowedOrigins: corsAllowedOrigins,
 		})
 		attemptCtx, cancel := context.WithCancel(ctx)
 		if err := u.Start(attemptCtx); err != nil {
@@ -81,7 +83,7 @@ func startOnFreePort(
 	}
 	t.Fatalf(
 		"could not bind a free loopback port in %d attempts: %v",
-		bindAttempts, lastErr,
+		testutil.BindAttempts, lastErr,
 	)
 	return nil, ""
 }
@@ -91,16 +93,6 @@ func stopUtxorpc(t *testing.T, u *Utxorpc) {
 	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	require.NoError(t, u.Stop(stopCtx))
-}
-
-func insecureHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
-			},
-		},
-	}
 }
 
 // healthCheck issues a Connect-protocol unary health check (works over
@@ -152,7 +144,7 @@ func TestUtxorpcTLSNoAuth(t *testing.T) {
 	)
 	t.Cleanup(func() { stopUtxorpc(t, u) })
 
-	resp := healthCheck(t, insecureHTTPClient(), "https://"+addr, "")
+	resp := healthCheck(t, testutil.InsecureHTTPClient(), "https://"+addr, "")
 	t.Cleanup(func() { _ = resp.Body.Close() })
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -171,7 +163,7 @@ func TestUtxorpcTLSAuth(t *testing.T) {
 		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
 	)
 	t.Cleanup(func() { stopUtxorpc(t, u) })
-	client := insecureHTTPClient()
+	client := testutil.InsecureHTTPClient()
 	baseURL := "https://" + addr
 
 	t.Run("missing credential", func(t *testing.T) {
@@ -198,23 +190,12 @@ func TestUtxorpcTLSAuth(t *testing.T) {
 // that an OPTIONS CORS preflight never needs a credential.
 func TestUtxorpcCORSPreflightBypassesAuth(t *testing.T) {
 	const allowed = "https://wallet.example"
-	addr := freePort(t)
-	host, port, err := net.SplitHostPort(addr)
-	require.NoError(t, err)
-	portNum, err := strconv.ParseUint(port, 10, 16)
-	require.NoError(t, err)
-	u := NewUtxorpc(UtxorpcConfig{
-		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus: event.NewEventBus(nil, nil),
-		Host:     host,
-		Port:     uint(portNum),
-		Auth: apiconfig.EffectiveAuth{
-			Enabled: true,
-			Token:   "shared-secret",
-		},
-		CORSAllowedOrigins: []string{allowed},
-	})
-	require.NoError(t, u.Start(t.Context()))
+	u, addr := startOnFreePortWithCORS(
+		t, t.Context(),
+		apiconfig.EffectiveTLS{},
+		apiconfig.EffectiveAuth{Enabled: true, Token: "shared-secret"},
+		[]string{allowed},
+	)
 	t.Cleanup(func() { stopUtxorpc(t, u) })
 	baseURL := "http://" + addr
 

--- a/api/utxorpc/utxorpc.go
+++ b/api/utxorpc/utxorpc.go
@@ -16,7 +16,6 @@ package utxorpc
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -32,6 +31,8 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
 	"connectrpc.com/grpcreflect"
+	"github.com/blinklabs-io/dingo/internal/apiauth"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
 	"github.com/blinklabs-io/dingo/internal/tlsutil"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
@@ -65,20 +66,25 @@ const (
 )
 
 type Utxorpc struct {
-	server *http.Server
-	config UtxorpcConfig
-	mu     sync.Mutex
+	server   *http.Server
+	config   UtxorpcConfig
+	verifier *apiauth.Verifier
+	mu       sync.Mutex
 }
 
 type UtxorpcConfig struct {
-	Logger          *slog.Logger
-	EventBus        UtxorpcEventBus
-	LedgerState     UtxorpcLedgerState
-	Mempool         UtxorpcMempool
-	TlsCertFilePath string
-	TlsKeyFilePath  string
-	Host            string
-	Port            uint
+	Logger      *slog.Logger
+	EventBus    UtxorpcEventBus
+	LedgerState UtxorpcLedgerState
+	Mempool     UtxorpcMempool
+	// TLS and Auth are the resolved (merged, validated) equivalents of
+	// what was previously TlsCertFilePath/TlsKeyFilePath fields here --
+	// see ProviderConfig's doc comment and ARCHITECTURE.md's "API
+	// security" section.
+	TLS  apiconfig.EffectiveTLS
+	Auth apiconfig.EffectiveAuth
+	Host string
+	Port uint
 
 	// Request size limits (0 = use default)
 	MaxBlockRefs int
@@ -169,11 +175,28 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 	if u.config.Mempool != nil && isNilInterface(u.config.Mempool) {
 		return errors.New("utxorpc: Mempool must not be a typed nil")
 	}
+	// Built before the mux so newServeMux can install the shared
+	// credential-verification interceptor (internal/apiauth) on every
+	// Connect/gRPC handler it registers, including health and reflection.
+	verifier, err := apiauth.NewVerifier(u.config.Auth)
+	if err != nil {
+		return fmt.Errorf("utxorpc: %w", err)
+	}
 	u.mu.Lock()
 	if u.server != nil {
 		u.mu.Unlock()
 		return errors.New("server already started")
 	}
+	u.verifier = verifier
+	// CORS must wrap authentication, not the reverse: httpcors.Handler
+	// fully answers an OPTIONS preflight itself and never calls the
+	// handler it wraps for one, so browsers -- which never attach
+	// Authorization to a preflight request -- never need a credential to
+	// pass CORS negotiation. Every other request, including a
+	// non-preflight OPTIONS, still reaches the mux (and so the
+	// per-procedure auth interceptor) normally. See internal/apiauth's
+	// Middleware doc comment for the HTTP-side statement of the same
+	// ordering rule.
 	handler := httpcors.Handler(
 		u.newServeMux(),
 		httpcors.Config{
@@ -181,7 +204,7 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 		},
 	)
 	var server *http.Server
-	if u.config.TlsCertFilePath != "" && u.config.TlsKeyFilePath != "" {
+	if u.config.TLS.Enabled {
 		u.config.Logger.Info(
 			fmt.Sprintf(
 				"starting utxorpc gRPC TLS listener on %s:%d",
@@ -270,6 +293,16 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 func (u *Utxorpc) newServeMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	compress1KB := connect.WithCompressMinBytes(1024)
+	// When authentication is enabled, every Connect/gRPC handler this mux
+	// registers -- including health and reflection -- requires a valid
+	// credential; there is no separate unauthenticated allowlist for
+	// those two, unlike CORS preflight (see Start's doc comment).
+	if u.verifier != nil {
+		compress1KB = connect.WithOptions(
+			compress1KB,
+			connect.WithInterceptors(apiauth.Interceptor(u.verifier)),
+		)
+	}
 	queryPath, queryHandler := queryconnect.NewQueryServiceHandler(
 		&queryServiceServer{utxorpc: u},
 		compress1KB,
@@ -519,30 +552,20 @@ func forceCloseUtxorpc(server *http.Server, shutdownErr <-chan error) error {
 // keypair synchronously so port and certificate errors surface before
 // returning, then serves in a background goroutine.
 func (u *Utxorpc) startServer(server *http.Server) error {
-	if (u.config.TlsCertFilePath != "") != (u.config.TlsKeyFilePath != "") {
-		return errors.New(
-			"failed to start utxorpc gRPC server: both tls cert and key must be specified",
-		)
-	}
-	useTLS := u.config.TlsCertFilePath != "" && u.config.TlsKeyFilePath != ""
+	useTLS := u.config.TLS.Enabled
 	serverType := "non-TLS"
 	if useTLS {
 		serverType = "TLS"
-		cert, err := tls.LoadX509KeyPair(
-			u.config.TlsCertFilePath,
-			u.config.TlsKeyFilePath,
-		)
-		if err != nil {
+		if err := tlsutil.ConfigureServerTLS(
+			server,
+			u.config.TLS.CertFilePath,
+			u.config.TLS.KeyFilePath,
+		); err != nil {
 			return fmt.Errorf(
 				"failed to load TLS keypair for utxorpc gRPC %s server: %w",
 				serverType, err,
 			)
 		}
-		server.TLSConfig = tlsutil.ServerConfig(server.TLSConfig)
-		server.TLSConfig.Certificates = append(
-			server.TLSConfig.Certificates,
-			cert,
-		)
 	}
 	ln, err := net.Listen("tcp", server.Addr)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -168,11 +168,16 @@ type Config struct {
 	chainsyncStallTimeout time.Duration
 	// Compatibility mirrors used by the composition layer. cfg remains the
 	// canonical loaded configuration; these are refreshed by syncCompatFields.
-	dataDir                                                                             string
-	bindAddr                                                                            string
-	pluginSelections                                                                    map[hostplugin.Capability]hostplugin.Selection
-	network                                                                             string
-	tlsCertFilePath, tlsKeyFilePath                                                     string
+	dataDir                         string
+	bindAddr                        string
+	pluginSelections                map[hostplugin.Capability]hostplugin.Selection
+	network                         string
+	tlsCertFilePath, tlsKeyFilePath string
+	// apiConfig mirrors cfg.API -- the shared api.tls/api.auth policy
+	// defaults merged into every selected plugins.api.* provider's own
+	// config by node.go before that provider resolves. See
+	// ARCHITECTURE.md's "API security" section.
+	apiConfig                                                                           internalconfig.APIConfig
 	outboundSourcePort, barkPort                                                        uint
 	barkBaseUrl                                                                         string
 	barkBlockDownloadHosts                                                              []string
@@ -635,6 +640,7 @@ func (c *Config) syncCompatFields() {
 	c.dataDir, c.bindAddr = c.cfg.DatabasePath, c.cfg.BindAddr
 	c.network, c.networkMagic = c.cfg.Network, c.cfg.NetworkMagic
 	c.tlsCertFilePath, c.tlsKeyFilePath = c.cfg.TlsCertFilePath, c.cfg.TlsKeyFilePath
+	c.apiConfig = c.cfg.API
 	c.barkBaseUrl, c.barkPort, c.barkBlockDownloadHosts = c.cfg.BarkBaseUrl, c.cfg.BarkPort, c.cfg.BarkBlockDownloadHosts
 	c.barkHost = c.cfg.BarkHost
 	c.barkClientCAFilePath = c.cfg.BarkClientCAFilePath
@@ -967,6 +973,16 @@ func WithUtxorpcTlsKeyFilePath(path string) ConfigOptionFunc {
 func WithUtxorpcPort(port uint) ConfigOptionFunc {
 	return func(c *Config) {
 		c.cfg.Plugins.API.Utxorpc.Config["port"] = port
+	}
+}
+
+// WithAPIConfig sets the shared api.tls/api.auth policy applied to every
+// selected plugins.api.* provider (Blockfrost, Mesh, UTxORPC) unless that
+// provider's own plugins.api.<name>.config.tls/auth overrides a field.
+// See internal/apiconfig and ARCHITECTURE.md's "API security" section.
+func WithAPIConfig(cfg internalconfig.APIConfig) ConfigOptionFunc {
+	return func(c *Config) {
+		c.cfg.API = cfg
 	}
 }
 
@@ -1948,6 +1964,12 @@ func (c *Config) Midnight() internalconfig.MidnightConfig {
 // CORSAllowedOrigins returns the CORS allowed origins list.
 func (c *Config) CORSAllowedOrigins() []string {
 	return c.cfg.CORSAllowedOrigins
+}
+
+// API returns the shared api.tls/api.auth policy defaults applied to
+// every selected plugins.api.* provider. See WithAPIConfig.
+func (c *Config) API() internalconfig.APIConfig {
+	return c.cfg.API
 }
 
 // SlotsPerKESPeriod returns the number of slots per KES period.

--- a/config.go
+++ b/config.go
@@ -1674,6 +1674,13 @@ func (c *Config) TlsKeyFilePath() string {
 	return c.cfg.TlsKeyFilePath
 }
 
+// APIConfig returns the shared api.tls/api.auth policy defaults applied to
+// every selected plugins.api.* provider unless overridden. See
+// WithAPIConfig and ARCHITECTURE.md's "API security" section.
+func (c *Config) APIConfig() internalconfig.APIConfig {
+	return c.cfg.API
+}
+
 // IntersectTip returns whether to start chainsync at the current chain tip.
 func (c *Config) IntersectTip() bool {
 	return c.cfg.IntersectTip

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -51,6 +51,15 @@ plugins:
       provider: "builtin"
       config:
         port: 3000
+        # Per-provider overrides of the shared api.tls/api.auth defaults
+        # below (uncomment to use). Any field left unset here inherits the
+        # corresponding api.tls/api.auth field; mode: disabled explicitly
+        # turns off an inherited policy for this provider only.
+        # tls:
+        #   certFilePath: "/run/secrets/blockfrost.crt"
+        #   keyFilePath: "/run/secrets/blockfrost.key"
+        # auth:
+        #   mode: disabled
     mesh:
       provider: "builtin"
       config:
@@ -59,6 +68,31 @@ plugins:
       provider: "builtin"
       config:
         port: 9090
+
+# Shared TLS and authentication defaults for every selected plugins.api.*
+# provider (Blockfrost, Mesh, UTxO RPC). Each field resolves independently:
+# plugins.api.<name>.config.tls/config.auth overrides any field for that
+# provider only (see the commented example above). The default everywhere
+# is "disabled", so leaving this section out changes nothing for an
+# existing deployment.
+#
+# api:
+#   tls:
+#     # "disabled" (default) or "server".
+#     mode: server
+#     certFilePath: "/run/secrets/api.crt"
+#     keyFilePath: "/run/secrets/api.key"
+#   auth:
+#     # "disabled" (default) or "token". Callers present the shared secret
+#     # as "Authorization: Bearer <token>" (HTTP and Connect/gRPC); the
+#     # built-in Blockfrost API also accepts it via its own "project_id"
+#     # header, matching real Blockfrost clients. token and tokenFilePath
+#     # are mutually exclusive; tokenFilePath is preferred (also settable
+#     # via DINGO_API_AUTH_TOKEN_FILE_PATH -- token has no environment
+#     # variable of its own, to avoid encouraging secrets into a
+#     # container's env dump).
+#     mode: token
+#     tokenFilePath: "/run/secrets/api-token"
 
 # Path to the UNIX domain socket file used by the server
 # CLI: --socket-path
@@ -78,14 +112,21 @@ logging:
   format: text
   level: info
 
-# TLS certificate file path for the built-in UTxO RPC listener.
-# Blockfrost and Mesh do not currently consume this setting; place public API
-# listeners behind a TLS-terminating and authenticating reverse proxy.
+# TLS certificate file path. Also used by Bark (bark/) when barkPort is set.
+#
+# For the built-in UTxO RPC listener specifically, this is a compatibility
+# default equivalent to setting plugins.api.utxorpc.config.tls (mode: server,
+# this certFilePath/keyFilePath) -- it is not promoted to Blockfrost or Mesh,
+# since doing so would silently switch a previously plaintext listener to
+# TLS on upgrade. To secure Blockfrost and/or Mesh (or to override UTxO
+# RPC's own certificate independently of this shared one), use the top-level
+# api.tls section or each provider's own plugins.api.<name>.config.tls --
+# see the "api:" section above and README.md's "API TLS and Authentication".
 #
 # Can be overridden with the TLS_CERT_FILE_PATH environment variable
 tlsCertFilePath: ""
 
-# TLS private key file path for the built-in UTxO RPC listener.
+# TLS private key file path, paired with tlsCertFilePath above.
 #
 # Can be overridden with the TLS_KEY_FILE_PATH environment variable
 tlsKeyFilePath: ""

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -56,6 +56,7 @@ plugins:
         # corresponding api.tls/api.auth field; mode: disabled explicitly
         # turns off an inherited policy for this provider only.
         # tls:
+        #   mode: server
         #   certFilePath: "/run/secrets/blockfrost.crt"
         #   keyFilePath: "/run/secrets/blockfrost.key"
         # auth:

--- a/internal/apiauth/apiauth.go
+++ b/internal/apiauth/apiauth.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apiauth is the single credential-verification implementation
+// shared by every built-in API provider (Blockfrost, Mesh, UTxORPC). Only
+// the wire transport differs per protocol: http.go adapts it to HTTP
+// request headers (failing closed with 401), connect.go adapts it to
+// Connect/gRPC request/streaming headers (failing closed with
+// connect.CodeUnauthenticated). Neither adapter re-implements credential
+// comparison; both call through to Verifier.Verify.
+package apiauth
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+)
+
+// Verifier holds a resolved shared-secret token and compares presented
+// credentials against it in constant time. A nil *Verifier always
+// succeeds -- callers construct one only when authentication is enabled,
+// and skip installing the HTTP/Connect adapters entirely otherwise, so a
+// nil Verifier is only ever reached by code that also treats it as
+// "authentication disabled" (see Verify).
+type Verifier struct {
+	token []byte
+}
+
+// NewVerifier builds a Verifier from an EffectiveAuth. It returns (nil,
+// nil) when cfg.Enabled is false: authentication is disabled, and callers
+// should skip installing any credential check at all rather than call
+// Verify with an always-succeeding nil Verifier implicitly. TokenFilePath
+// (if set instead of an inline Token) is read here, at construction --
+// i.e. at listener startup, matching TLSPolicy's own deferral of
+// certificate loading to listener startup rather than config resolution.
+func NewVerifier(cfg apiconfig.EffectiveAuth) (*Verifier, error) {
+	if !cfg.Enabled {
+		return nil, nil //nolint:nilnil // nil Verifier is the documented "auth disabled" value
+	}
+	token := cfg.Token
+	if cfg.TokenFilePath != "" {
+		data, err := os.ReadFile(cfg.TokenFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("reading auth tokenFilePath: %w", err)
+		}
+		token = strings.TrimSpace(string(data))
+	}
+	if token == "" {
+		return nil, errors.New(
+			"auth token resolves to an empty value",
+		)
+	}
+	return &Verifier{token: []byte(token)}, nil
+}
+
+// Verify reports whether presented matches the configured token, using a
+// constant-time comparison so response timing cannot be used to guess the
+// token byte by byte. A nil Verifier (authentication disabled) always
+// succeeds.
+func (v *Verifier) Verify(presented string) bool {
+	if v == nil {
+		return true
+	}
+	if presented == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare(v.token, []byte(presented)) == 1
+}
+
+// bearerToken extracts the credential from a standard
+// "Authorization: Bearer <token>" header value, or "" if header does not
+// use the Bearer scheme.
+func bearerToken(header string) string {
+	const prefix = "Bearer "
+	if len(header) <= len(prefix) {
+		return ""
+	}
+	if !strings.EqualFold(header[:len(prefix)], prefix) {
+		return ""
+	}
+	return header[len(prefix):]
+}

--- a/internal/apiauth/apiauth.go
+++ b/internal/apiauth/apiauth.go
@@ -84,7 +84,10 @@ func (v *Verifier) Verify(presented string) bool {
 
 // bearerToken extracts the credential from a standard
 // "Authorization: Bearer <token>" header value, or "" if header does not
-// use the Bearer scheme.
+// use the Bearer scheme. The credential portion is trimmed of surrounding
+// whitespace, since some HTTP/Connect/gRPC client defaults insert extra
+// internal whitespace after "Bearer" that would otherwise reject an
+// otherwise-correct token.
 func bearerToken(header string) string {
 	const prefix = "Bearer "
 	if len(header) <= len(prefix) {
@@ -93,5 +96,5 @@ func bearerToken(header string) string {
 	if !strings.EqualFold(header[:len(prefix)], prefix) {
 		return ""
 	}
-	return header[len(prefix):]
+	return strings.TrimSpace(header[len(prefix):])
 }

--- a/internal/apiauth/apiauth_test.go
+++ b/internal/apiauth/apiauth_test.go
@@ -87,6 +87,11 @@ func TestBearerToken(t *testing.T) {
 	assert.Equal(t, "", bearerToken(""))
 	assert.Equal(t, "", bearerToken("Basic abc123"))
 	assert.Equal(t, "", bearerToken("Bearer"))
+	// Extra internal whitespace after "Bearer " is trimmed rather than
+	// rejecting an otherwise-correct token.
+	assert.Equal(t, "abc123", bearerToken("Bearer  abc123"))
+	assert.Equal(t, "abc123", bearerToken("Bearer abc123 "))
+	assert.Equal(t, "abc123", bearerToken("Bearer   abc123   "))
 }
 
 func TestMiddlewareNilVerifierIsNoOp(t *testing.T) {

--- a/internal/apiauth/apiauth_test.go
+++ b/internal/apiauth/apiauth_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVerifierDisabled(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{})
+	require.NoError(t, err)
+	assert.Nil(t, v)
+	// A nil Verifier always succeeds -- this is the documented
+	// "authentication disabled" behavior.
+	assert.True(t, v.Verify("anything"))
+	assert.True(t, v.Verify(""))
+}
+
+func TestNewVerifierInlineToken(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{
+		Enabled: true,
+		Token:   "shared-secret",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	assert.True(t, v.Verify("shared-secret"))
+	assert.False(t, v.Verify("wrong"))
+	assert.False(t, v.Verify(""))
+}
+
+func TestNewVerifierTokenFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(path, []byte("file-secret\n"), 0o600))
+	v, err := NewVerifier(apiconfig.EffectiveAuth{
+		Enabled:       true,
+		TokenFilePath: path,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	// Trailing whitespace/newline in the file must be trimmed.
+	assert.True(t, v.Verify("file-secret"))
+}
+
+func TestNewVerifierMissingTokenFile(t *testing.T) {
+	_, err := NewVerifier(apiconfig.EffectiveAuth{
+		Enabled:       true,
+		TokenFilePath: filepath.Join(t.TempDir(), "missing"),
+	})
+	require.Error(t, err)
+}
+
+func TestNewVerifierEmptyTokenFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(path, []byte("  \n"), 0o600))
+	_, err := NewVerifier(apiconfig.EffectiveAuth{
+		Enabled:       true,
+		TokenFilePath: path,
+	})
+	require.Error(t, err)
+}
+
+func TestBearerToken(t *testing.T) {
+	assert.Equal(t, "abc123", bearerToken("Bearer abc123"))
+	assert.Equal(t, "abc123", bearerToken("bearer abc123"))
+	assert.Equal(t, "", bearerToken(""))
+	assert.Equal(t, "", bearerToken("Basic abc123"))
+	assert.Equal(t, "", bearerToken("Bearer"))
+}
+
+func TestMiddlewareNilVerifierIsNoOp(t *testing.T) {
+	called := false
+	handler := Middleware(nil)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) { called = true },
+	))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareRejectsMissingCredential(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	called := false
+	handler := Middleware(v)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) { called = true },
+	))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.False(t, called)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.NotEmpty(t, rec.Header().Get("WWW-Authenticate"))
+}
+
+func TestMiddlewareAcceptsBearerCredential(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	called := false
+	handler := Middleware(v)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) { called = true },
+	))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer t")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareRejectsWrongBearerCredential(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	handler := Middleware(v)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {},
+	))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestMiddlewareAliasHeaderBlockfrostProjectId(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	called := false
+	handler := Middleware(v, WithAliasHeader("project_id"))(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) { called = true },
+	))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("project_id", "t")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareBearerTakesPrecedenceOverAlias(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	handler := Middleware(v, WithAliasHeader("project_id"))(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {},
+	))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer t")
+	req.Header.Set("project_id", "wrong")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestConnectInterceptorNilVerifierIsNoOp(t *testing.T) {
+	interceptor := Interceptor(nil)
+	req := connect.NewRequest(&struct{}{})
+	called := false
+	unary := interceptor.WrapUnary(
+		func(ctx context.Context, r connect.AnyRequest) (connect.AnyResponse, error) {
+			called = true
+			return connect.NewResponse(&struct{}{}), nil
+		},
+	)
+	_, err := unary(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestConnectInterceptorRejectsMissingCredential(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	interceptor := Interceptor(v)
+	req := connect.NewRequest(&struct{}{})
+	called := false
+	unary := interceptor.WrapUnary(
+		func(ctx context.Context, r connect.AnyRequest) (connect.AnyResponse, error) {
+			called = true
+			return connect.NewResponse(&struct{}{}), nil
+		},
+	)
+	_, err = unary(context.Background(), req)
+	require.Error(t, err)
+	assert.False(t, called)
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+}
+
+func TestConnectInterceptorAcceptsValidCredential(t *testing.T) {
+	v, err := NewVerifier(apiconfig.EffectiveAuth{Enabled: true, Token: "t"})
+	require.NoError(t, err)
+	interceptor := Interceptor(v)
+	req := connect.NewRequest(&struct{}{})
+	req.Header().Set("Authorization", "Bearer t")
+	called := false
+	unary := interceptor.WrapUnary(
+		func(ctx context.Context, r connect.AnyRequest) (connect.AnyResponse, error) {
+			called = true
+			return connect.NewResponse(&struct{}{}), nil
+		},
+	)
+	_, err = unary(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestConnectInterceptorWrapStreamingClientIsPassthrough(t *testing.T) {
+	interceptor := Interceptor(nil)
+	called := false
+	client := interceptor.WrapStreamingClient(
+		func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+			called = true
+			return nil
+		},
+	)
+	client(context.Background(), connect.Spec{})
+	assert.True(t, called)
+}

--- a/internal/apiauth/connect.go
+++ b/internal/apiauth/connect.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"connectrpc.com/connect"
+)
+
+// errInvalidCredential is returned to a Connect/gRPC caller as
+// connect.CodeUnauthenticated. It never embeds the presented or expected
+// credential.
+var errInvalidCredential = errors.New(
+	"missing or invalid Authorization credential",
+)
+
+// Interceptor returns a connect.Interceptor that requires every unary and
+// streaming call to present a credential verifier accepts in the standard
+// "Authorization: Bearer <token>" request header, failing closed with
+// connect.CodeUnauthenticated otherwise. A nil verifier (authentication
+// disabled) returns a no-op interceptor -- Interceptor(nil) is a
+// documented no-op, matching Verifier's own "nil means disabled" and
+// Middleware's own contract.
+//
+// This is the same Verifier.Verify credential check http.go's Middleware
+// uses; only the transport this file reads the credential from (Connect/
+// gRPC request headers instead of a net/http request's headers) differs.
+func Interceptor(verifier *Verifier) connect.Interceptor {
+	return &connectInterceptor{verifier: verifier}
+}
+
+type connectInterceptor struct {
+	verifier *Verifier
+}
+
+func (i *connectInterceptor) authorize(header http.Header) error {
+	if i.verifier == nil {
+		return nil
+	}
+	credential := bearerToken(header.Get("Authorization"))
+	if !i.verifier.Verify(credential) {
+		return connect.NewError(
+			connect.CodeUnauthenticated,
+			errInvalidCredential,
+		)
+	}
+	return nil
+}
+
+// WrapUnary authenticates every unary call before it reaches the real
+// handler.
+func (i *connectInterceptor) WrapUnary(
+	next connect.UnaryFunc,
+) connect.UnaryFunc {
+	return func(
+		ctx context.Context,
+		req connect.AnyRequest,
+	) (connect.AnyResponse, error) {
+		if err := i.authorize(req.Header()); err != nil {
+			return nil, err
+		}
+		return next(ctx, req)
+	}
+}
+
+// WrapStreamingClient is a pass-through no-op: it governs outgoing calls
+// this process makes as a Connect client, which this interceptor is never
+// installed on -- API providers only use it server-side, to gate incoming
+// requests.
+func (i *connectInterceptor) WrapStreamingClient(
+	next connect.StreamingClientFunc,
+) connect.StreamingClientFunc {
+	return next
+}
+
+// WrapStreamingHandler is WrapUnary's server-streaming counterpart.
+func (i *connectInterceptor) WrapStreamingHandler(
+	next connect.StreamingHandlerFunc,
+) connect.StreamingHandlerFunc {
+	return func(
+		ctx context.Context,
+		conn connect.StreamingHandlerConn,
+	) error {
+		if err := i.authorize(conn.RequestHeader()); err != nil {
+			return err
+		}
+		return next(ctx, conn)
+	}
+}

--- a/internal/apiauth/http.go
+++ b/internal/apiauth/http.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiauth
+
+import "net/http"
+
+// options configures Middleware's credential extraction.
+type options struct {
+	aliasHeaders []string
+}
+
+// Option configures Middleware.
+type Option func(*options)
+
+// WithAliasHeader accepts header's raw value as a bearer-equivalent
+// credential, in addition to the standard "Authorization: Bearer <token>"
+// header. This is how Blockfrost's real `project_id` header authenticates
+// against the same shared token mechanism every other built-in API
+// provider uses: a Blockfrost-compatible client sends
+// "project_id: <token>" instead of an Authorization header, and dingo
+// treats presenting the correct value there as equivalent to presenting
+// it as a bearer credential. See ARCHITECTURE.md/README.md's "API
+// security" section for this compatibility decision.
+func WithAliasHeader(header string) Option {
+	return func(o *options) {
+		o.aliasHeaders = append(o.aliasHeaders, header)
+	}
+}
+
+// Middleware wraps next so every request must present a credential
+// verifier accepts, responding 401 and never calling next otherwise. A
+// nil verifier (authentication disabled) returns next completely
+// unwrapped -- Middleware(nil) is a documented no-op, matching Verifier's
+// own "nil means disabled" contract.
+//
+// Middleware must be installed inside (nearer the mux than) CORS
+// middleware, not outside it: a CORS preflight (OPTIONS with
+// Access-Control-Request-Method) never carries the caller's real
+// credential -- browsers do not attach Authorization to preflight
+// requests -- so it must be answered by CORS before authentication would
+// see it, or every preflight would fail closed and break browser access
+// entirely. httpcors.Handler already fully answers OPTIONS preflights
+// itself and never calls its wrapped handler for one, so wrapping
+// Middleware's result in httpcors.Handler (not the reverse) is what
+// achieves this. Every non-preflight request -- including a plain
+// unauthenticated OPTIONS with no CORS negotiation headers -- still
+// reaches Middleware and must authenticate like any other request.
+func Middleware(
+	verifier *Verifier,
+	opts ...Option,
+) func(http.Handler) http.Handler {
+	if verifier == nil {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			credential := bearerToken(r.Header.Get("Authorization"))
+			if credential == "" {
+				for _, header := range o.aliasHeaders {
+					if v := r.Header.Get(header); v != "" {
+						credential = v
+						break
+					}
+				}
+			}
+			if !verifier.Verify(credential) {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="dingo"`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/apiconfig/apiconfig.go
+++ b/internal/apiconfig/apiconfig.go
@@ -1,0 +1,402 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apiconfig defines the TLS and authentication configuration
+// surface shared by every built-in API provider (Blockfrost, Mesh,
+// UTxORPC): a top-level `api.tls`/`api.auth` default policy that each
+// provider's own `plugins.api.<name>.config.tls`/`config.auth` can
+// override field by field. See ARCHITECTURE.md's "API security" section
+// for the overall design and dingo#2996/#2998 for the issues this
+// implements.
+//
+// TLSPolicy and AuthPolicy are the YAML-decodable, tri-state
+// representations used at both the top-level `api:` scope and the
+// provider-config scope: every field is a pointer so "not set at this
+// scope" (nil, inherit from a broader scope or fall back to the disabled
+// default) is distinguishable from an explicit, zero-value-looking
+// setting such as `mode: disabled`. Merge folds two scopes together field
+// by field (MergeTLS, MergeAuth); Resolve validates a fully merged policy
+// and turns it into the concrete EffectiveTLS/EffectiveAuth a listener
+// actually acts on.
+package apiconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TLSMode discriminates a (resolved or override) TLS policy's behavior.
+type TLSMode string
+
+const (
+	// TLSModeDisabled turns TLS off, even overriding a broader scope that
+	// enables it. It is also the effective default when no scope sets
+	// tls.mode at all, so upgrading a deployment that never configured TLS
+	// for a given provider changes nothing.
+	TLSModeDisabled TLSMode = "disabled"
+	// TLSModeServer serves TLS using CertFilePath/KeyFilePath.
+	TLSModeServer TLSMode = "server"
+)
+
+// AuthMode discriminates a (resolved or override) authentication policy's
+// behavior.
+type AuthMode string
+
+const (
+	// AuthModeDisabled accepts every request without checking credentials.
+	// It is also the effective default when no scope sets auth.mode at
+	// all, so upgrading a deployment that never configured authentication
+	// changes nothing -- existing reverse-proxy/no-auth deployments keep
+	// working unmodified.
+	AuthModeDisabled AuthMode = "disabled"
+	// AuthModeToken requires a shared-secret bearer credential; see Token/
+	// TokenFilePath on AuthPolicy.
+	AuthModeToken AuthMode = "token"
+)
+
+// TLSPolicy is the YAML shape of both the top-level `api.tls` defaults and
+// every `plugins.api.<name>.config.tls` override. A nil field means "not
+// set at this scope"; MergeTLS lets a narrower scope's explicit field win
+// over a broader scope's, independently per field.
+type TLSPolicy struct {
+	// Mode is TLSModeDisabled or TLSModeServer. Nil resolves to
+	// TLSModeDisabled unless a broader scope sets it. The envconfig tags
+	// here take effect only when this type is embedded in a struct
+	// envconfig.Process actually walks (internal/config.APIConfig, for
+	// the top-level api.tls policy); a provider's own
+	// plugins.api.<name>.config.tls decodes through YAML only (see
+	// plugin.Register's strict decode) and ignores them.
+	Mode         *string `yaml:"mode,omitempty"         envconfig:"DINGO_API_TLS_MODE"`
+	CertFilePath *string `yaml:"certFilePath,omitempty" envconfig:"DINGO_API_TLS_CERT_FILE_PATH"`
+	KeyFilePath  *string `yaml:"keyFilePath,omitempty"  envconfig:"DINGO_API_TLS_KEY_FILE_PATH"`
+}
+
+// AuthPolicy is TLSPolicy's authentication counterpart.
+type AuthPolicy struct {
+	// Mode is AuthModeDisabled or AuthModeToken. Nil resolves to
+	// AuthModeDisabled unless a broader scope sets it.
+	Mode *string `yaml:"mode,omitempty"          envconfig:"DINGO_API_AUTH_MODE"`
+	// Token is the shared secret presented credentials are compared
+	// against, inline in configuration. Mutually exclusive with
+	// TokenFilePath. Never logged -- see LogValue. Deliberately has no
+	// environment variable binding of its own (unlike every other field
+	// here): an inline secret is still settable via YAML, but not via an
+	// environment variable, to avoid encouraging a pattern where the
+	// secret ends up duplicated into process-inspection-visible places
+	// such as a container's env dump. Use TokenFilePath for anything but
+	// local testing.
+	Token *string `yaml:"token,omitempty"`
+	// TokenFilePath names a file whose trimmed contents are the shared
+	// secret, read at listener startup (not at Resolve time, matching
+	// TLSPolicy's own deferral of certificate loading to listener
+	// startup). Mutually exclusive with Token.
+	TokenFilePath *string `yaml:"tokenFilePath,omitempty" envconfig:"DINGO_API_AUTH_TOKEN_FILE_PATH"`
+}
+
+// EffectiveTLS is a fully resolved and validated TLS policy: the concrete
+// answer a listener needs to decide whether, and how, to serve TLS.
+type EffectiveTLS struct {
+	Enabled      bool
+	CertFilePath string
+	KeyFilePath  string
+}
+
+// EffectiveAuth is a fully resolved and validated authentication policy.
+type EffectiveAuth struct {
+	Enabled bool
+	// Token is the inline shared secret, if configured directly. Empty
+	// when TokenFilePath is set instead.
+	Token string
+	// TokenFilePath is the shared-secret file path, if configured that
+	// way. Empty when Token is set directly.
+	TokenFilePath string
+}
+
+func stringVal(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func firstSet(override, base *string) *string {
+	if override != nil {
+		return override
+	}
+	return base
+}
+
+// MergeTLS resolves override's fields against base, field by field:
+// whatever override explicitly sets (including an explicit "disabled"
+// Mode) wins outright; any field override leaves nil falls back to base.
+// The result does not depend on how base or override were themselves
+// constructed (e.g. any map iteration order upstream), because merging
+// happens per named struct field rather than by replacing the whole
+// policy or walking a generic map.
+func MergeTLS(base, override TLSPolicy) TLSPolicy {
+	return TLSPolicy{
+		Mode:         firstSet(override.Mode, base.Mode),
+		CertFilePath: firstSet(override.CertFilePath, base.CertFilePath),
+		KeyFilePath:  firstSet(override.KeyFilePath, base.KeyFilePath),
+	}
+}
+
+// MergeAuth is MergeTLS's authentication counterpart.
+func MergeAuth(base, override AuthPolicy) AuthPolicy {
+	return AuthPolicy{
+		Mode:          firstSet(override.Mode, base.Mode),
+		Token:         firstSet(override.Token, base.Token),
+		TokenFilePath: firstSet(override.TokenFilePath, base.TokenFilePath),
+	}
+}
+
+// Resolve validates p and returns the concrete TLS behavior it selects.
+// path identifies p's position in the configuration tree (e.g.
+// "plugins.api.blockfrost.config.tls") purely to make a returned error
+// actionable; it does not affect resolution. Resolve does not read
+// CertFilePath/KeyFilePath from disk -- that happens at listener startup,
+// matching the existing UTxO RPC precedent of surfacing a missing/invalid
+// certificate file as a listener startup error rather than a config
+// validation error.
+func (p TLSPolicy) Resolve(path string) (EffectiveTLS, error) {
+	mode := TLSModeDisabled
+	if m := stringVal(p.Mode); m != "" {
+		mode = TLSMode(m)
+	}
+	switch mode {
+	case TLSModeDisabled:
+		return EffectiveTLS{}, nil
+	case TLSModeServer:
+		cert := stringVal(p.CertFilePath)
+		key := stringVal(p.KeyFilePath)
+		if (cert == "") != (key == "") {
+			return EffectiveTLS{}, fmt.Errorf(
+				"%s: certFilePath and keyFilePath must both be set (only one is set)",
+				path,
+			)
+		}
+		if cert == "" {
+			return EffectiveTLS{}, fmt.Errorf(
+				"%s: certFilePath and keyFilePath are required when mode is %q",
+				path, TLSModeServer,
+			)
+		}
+		return EffectiveTLS{
+			Enabled:      true,
+			CertFilePath: cert,
+			KeyFilePath:  key,
+		}, nil
+	default:
+		return EffectiveTLS{}, fmt.Errorf(
+			"%s: invalid mode %q (must be %q or %q)",
+			path, mode, TLSModeDisabled, TLSModeServer,
+		)
+	}
+}
+
+// Resolve is TLSPolicy.Resolve's authentication counterpart. It does not
+// read TokenFilePath from disk -- that happens at listener startup.
+func (p AuthPolicy) Resolve(path string) (EffectiveAuth, error) {
+	mode := AuthModeDisabled
+	if m := stringVal(p.Mode); m != "" {
+		mode = AuthMode(m)
+	}
+	switch mode {
+	case AuthModeDisabled:
+		return EffectiveAuth{}, nil
+	case AuthModeToken:
+		token := stringVal(p.Token)
+		tokenFile := stringVal(p.TokenFilePath)
+		if token != "" && tokenFile != "" {
+			return EffectiveAuth{}, fmt.Errorf(
+				"%s: token and tokenFilePath are mutually exclusive",
+				path,
+			)
+		}
+		if token == "" && tokenFile == "" {
+			return EffectiveAuth{}, fmt.Errorf(
+				"%s: token or tokenFilePath is required when mode is %q",
+				path, AuthModeToken,
+			)
+		}
+		return EffectiveAuth{
+			Enabled:       true,
+			Token:         token,
+			TokenFilePath: tokenFile,
+		}, nil
+	default:
+		return EffectiveAuth{}, fmt.Errorf(
+			"%s: invalid mode %q (must be %q or %q)",
+			path, mode, AuthModeDisabled, AuthModeToken,
+		)
+	}
+}
+
+// LogValue redacts Token so a structured slog call never reveals the
+// shared secret. TokenFilePath is a filesystem path, not a secret, and is
+// logged as-is.
+func (p AuthPolicy) LogValue() slog.Value {
+	var attrs []slog.Attr
+	if p.Mode != nil {
+		attrs = append(attrs, slog.String("mode", *p.Mode))
+	}
+	if p.Token != nil {
+		attrs = append(attrs, slog.String("token", "***redacted***"))
+	}
+	if p.TokenFilePath != nil {
+		attrs = append(attrs, slog.String("tokenFilePath", *p.TokenFilePath))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// LogValue redacts Token so a structured slog call never reveals the
+// shared secret.
+func (a EffectiveAuth) LogValue() slog.Value {
+	attrs := []slog.Attr{slog.Bool("enabled", a.Enabled)}
+	if a.Token != "" {
+		attrs = append(attrs, slog.String("token", "***redacted***"))
+	}
+	if a.TokenFilePath != "" {
+		attrs = append(attrs, slog.String("tokenFilePath", a.TokenFilePath))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// decodeSection extracts raw[key] (if present) into a T using the same
+// strict-ish YAML decoding provider configs already use elsewhere, so a
+// caller working purely in map[string]any (a plugin.Selection.Config) gets
+// the identical field shapes a typed ProviderConfig would.
+func decodeSection[T any](raw map[string]any, key string) (T, error) {
+	var dst T
+	if raw == nil {
+		return dst, nil
+	}
+	value, ok := raw[key]
+	if !ok {
+		return dst, nil
+	}
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return dst, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&dst); err != nil && !errors.Is(err, io.EOF) {
+		return dst, err
+	}
+	return dst, nil
+}
+
+// DecodeTLSPolicy extracts raw["tls"] into a TLSPolicy, or the zero value
+// if raw has no "tls" key.
+func DecodeTLSPolicy(raw map[string]any) (TLSPolicy, error) {
+	return decodeSection[TLSPolicy](raw, "tls")
+}
+
+// DecodeAuthPolicy extracts raw["auth"] into an AuthPolicy, or the zero
+// value if raw has no "auth" key.
+func DecodeAuthPolicy(raw map[string]any) (AuthPolicy, error) {
+	return decodeSection[AuthPolicy](raw, "auth")
+}
+
+func isZeroTLS(p TLSPolicy) bool {
+	return p.Mode == nil && p.CertFilePath == nil && p.KeyFilePath == nil
+}
+
+func isZeroAuth(p AuthPolicy) bool {
+	return p.Mode == nil && p.Token == nil && p.TokenFilePath == nil
+}
+
+func setSection(
+	raw map[string]any,
+	key string,
+	policy any,
+) (map[string]any, error) {
+	data, err := yaml.Marshal(policy)
+	if err != nil {
+		return nil, err
+	}
+	var value map[string]any
+	if err := yaml.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	clone := make(map[string]any, len(raw)+1)
+	maps.Copy(clone, raw)
+	clone[key] = value
+	return clone, nil
+}
+
+// MergeProviderConfig folds a capability's shared top-level `api.tls`/
+// `api.auth` defaults -- and, for legacy-compatibility callers only, an
+// additional lower-priority TLS base -- into raw's own "tls"/"auth"
+// sections, field by field, and returns a new map; raw itself is never
+// mutated. Precedence from lowest to highest: legacyTLS, then apiTLS/
+// apiAuth (the shared api.tls/api.auth policy), then whatever raw's own
+// "tls"/"auth" sections already set. Every other key in raw (e.g. "port")
+// passes through unchanged.
+//
+// This keeps the merge deterministic and independent of map iteration
+// order: each named field resolves through MergeTLS/MergeAuth rather than
+// by replacing raw's whole "tls"/"auth" value or iterating it as a
+// generic map.
+//
+// If the merge result is entirely empty (nothing set at any scope) for a
+// section, that section's key is left out of the result entirely rather
+// than written as an empty mapping -- identical to raw never having had
+// that key. This matters for a provider registered under one of these
+// capabilities whose own config type has no "tls"/"auth" field at all
+// (e.g. a third-party or test provider that predates -- or simply does
+// not support -- dingo#2996's shared security surface): as long as no
+// operator-visible TLS/auth policy actually applies to it, its config
+// still decodes exactly as it did before this merge step existed. Once a
+// real policy applies (top level, legacy compat, or the provider's own
+// config), the section is written and a provider whose config type can't
+// decode it fails -- correctly, since that provider cannot honor the
+// policy the operator configured.
+func MergeProviderConfig(
+	raw map[string]any,
+	legacyTLS, apiTLS TLSPolicy,
+	apiAuth AuthPolicy,
+) (map[string]any, error) {
+	providerTLS, err := DecodeTLSPolicy(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode tls: %w", err)
+	}
+	providerAuth, err := DecodeAuthPolicy(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode auth: %w", err)
+	}
+	mergedTLS := MergeTLS(MergeTLS(legacyTLS, apiTLS), providerTLS)
+	mergedAuth := MergeAuth(apiAuth, providerAuth)
+	result := raw
+	if !isZeroTLS(mergedTLS) {
+		result, err = setSection(result, "tls", mergedTLS)
+		if err != nil {
+			return nil, fmt.Errorf("encode merged tls: %w", err)
+		}
+	}
+	if !isZeroAuth(mergedAuth) {
+		result, err = setSection(result, "auth", mergedAuth)
+		if err != nil {
+			return nil, fmt.Errorf("encode merged auth: %w", err)
+		}
+	}
+	return result, nil
+}

--- a/internal/apiconfig/apiconfig.go
+++ b/internal/apiconfig/apiconfig.go
@@ -102,7 +102,13 @@ type AuthPolicy struct {
 	// secret ends up duplicated into process-inspection-visible places
 	// such as a container's env dump. Use TokenFilePath for anything but
 	// local testing.
-	Token *string `yaml:"token,omitempty"`
+	//
+	// The `ignored:"true"` tag is load-bearing, not decorative: envconfig
+	// auto-derives an environment variable name for every exported struct
+	// field it walks even without an explicit `envconfig` tag (here,
+	// CARDANO_API_AUTH_TOKEN), so omitting envconfig alone does not
+	// actually suppress a binding -- only `ignored:"true"` does.
+	Token *string `yaml:"token,omitempty"                                                    ignored:"true"`
 	// TokenFilePath names a file whose trimmed contents are the shared
 	// secret, read at listener startup (not at Resolve time, matching
 	// TLSPolicy's own deferral of certificate loading to listener
@@ -158,13 +164,27 @@ func MergeTLS(base, override TLSPolicy) TLSPolicy {
 	}
 }
 
-// MergeAuth is MergeTLS's authentication counterpart.
+// MergeAuth is MergeTLS's authentication counterpart, except that Token and
+// TokenFilePath are merged as a single credential-source unit rather than
+// independently per field like Mode: Resolve rejects a policy with both
+// fields set (they are mutually exclusive), so if override explicitly sets
+// either one, it is switching the credential source and override's values
+// for both fields replace base's wholesale -- base's Token/TokenFilePath
+// are not carried forward to mix with override's. Only when override sets
+// neither field does base's credential source (Token and TokenFilePath
+// together) pass through unchanged.
 func MergeAuth(base, override AuthPolicy) AuthPolicy {
-	return AuthPolicy{
-		Mode:          firstSet(override.Mode, base.Mode),
-		Token:         firstSet(override.Token, base.Token),
-		TokenFilePath: firstSet(override.TokenFilePath, base.TokenFilePath),
+	merged := AuthPolicy{
+		Mode: firstSet(override.Mode, base.Mode),
 	}
+	if override.Token != nil || override.TokenFilePath != nil {
+		merged.Token = override.Token
+		merged.TokenFilePath = override.TokenFilePath
+	} else {
+		merged.Token = base.Token
+		merged.TokenFilePath = base.TokenFilePath
+	}
+	return merged
 }
 
 // Resolve validates p and returns the concrete TLS behavior it selects.

--- a/internal/apiconfig/apiconfig_test.go
+++ b/internal/apiconfig/apiconfig_test.go
@@ -23,9 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//go:fix inline
-func ptr(s string) *string { return new(s) }
-
 func TestMergeTLSFieldByField(t *testing.T) {
 	base := TLSPolicy{
 		Mode:         new(string(TLSModeServer)),
@@ -82,6 +79,48 @@ func TestMergeAuthExplicitDisableOverridesInheritedToken(t *testing.T) {
 	effective, err := merged.Resolve("test")
 	require.NoError(t, err)
 	assert.False(t, effective.Enabled)
+}
+
+// TestMergeAuthOverrideSwitchesCredentialSource asserts that a provider
+// override which sets only TokenFilePath (switching credential source away
+// from a base policy's inline Token, not adding to it) fully replaces the
+// base's credential fields rather than leaving both Token and
+// TokenFilePath set -- which would make Resolve always fail with "mutually
+// exclusive" and make it impossible for a provider to ever switch
+// credential source away from an inherited one.
+func TestMergeAuthOverrideSwitchesCredentialSource(t *testing.T) {
+	base := AuthPolicy{
+		Mode:  new(string(AuthModeToken)),
+		Token: new("shared-secret"),
+	}
+	override := AuthPolicy{TokenFilePath: new("/override/token")}
+	merged := MergeAuth(base, override)
+	assert.Nil(t, merged.Token)
+	require.NotNil(t, merged.TokenFilePath)
+	assert.Equal(t, "/override/token", *merged.TokenFilePath)
+
+	effective, err := merged.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	assert.Empty(t, effective.Token)
+	assert.Equal(t, "/override/token", effective.TokenFilePath)
+}
+
+// TestMergeAuthUnsetCredentialInheritsBaseUnchanged asserts that when the
+// override sets neither Token nor TokenFilePath, the base's credential
+// source passes through unchanged (mirroring MergeTLS's per-field
+// inheritance for every other field).
+func TestMergeAuthUnsetCredentialInheritsBaseUnchanged(t *testing.T) {
+	base := AuthPolicy{
+		Mode:  new(string(AuthModeToken)),
+		Token: new("shared-secret"),
+	}
+	merged := MergeAuth(base, AuthPolicy{})
+	effective, err := merged.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	assert.Equal(t, "shared-secret", effective.Token)
+	assert.Empty(t, effective.TokenFilePath)
 }
 
 func TestTLSResolveDefaultsToDisabled(t *testing.T) {

--- a/internal/apiconfig/apiconfig_test.go
+++ b/internal/apiconfig/apiconfig_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiconfig
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:fix inline
+func ptr(s string) *string { return new(s) }
+
+func TestMergeTLSFieldByField(t *testing.T) {
+	base := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/base/cert.pem"),
+		KeyFilePath:  new("/base/key.pem"),
+	}
+	// Overriding only certFilePath must not blow away the inherited
+	// keyFilePath -- this is the "per-field merge" requirement from
+	// dingo#2998.
+	override := TLSPolicy{CertFilePath: new("/override/cert.pem")}
+	merged := MergeTLS(base, override)
+	require.NotNil(t, merged.Mode)
+	assert.Equal(t, string(TLSModeServer), *merged.Mode)
+	require.NotNil(t, merged.CertFilePath)
+	assert.Equal(t, "/override/cert.pem", *merged.CertFilePath)
+	require.NotNil(t, merged.KeyFilePath)
+	assert.Equal(t, "/base/key.pem", *merged.KeyFilePath)
+}
+
+func TestMergeTLSExplicitDisableOverridesInheritedEnable(t *testing.T) {
+	base := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/base/cert.pem"),
+		KeyFilePath:  new("/base/key.pem"),
+	}
+	override := TLSPolicy{Mode: new(string(TLSModeDisabled))}
+	merged := MergeTLS(base, override)
+	effective, err := merged.Resolve("test")
+	require.NoError(t, err)
+	assert.False(t, effective.Enabled)
+}
+
+func TestMergeTLSUnsetInheritsBaseUnchanged(t *testing.T) {
+	base := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/base/cert.pem"),
+		KeyFilePath:  new("/base/key.pem"),
+	}
+	merged := MergeTLS(base, TLSPolicy{})
+	effective, err := merged.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	assert.Equal(t, "/base/cert.pem", effective.CertFilePath)
+	assert.Equal(t, "/base/key.pem", effective.KeyFilePath)
+}
+
+func TestMergeAuthExplicitDisableOverridesInheritedToken(t *testing.T) {
+	base := AuthPolicy{
+		Mode:  new(string(AuthModeToken)),
+		Token: new("shared-secret"),
+	}
+	override := AuthPolicy{Mode: new(string(AuthModeDisabled))}
+	merged := MergeAuth(base, override)
+	effective, err := merged.Resolve("test")
+	require.NoError(t, err)
+	assert.False(t, effective.Enabled)
+}
+
+func TestTLSResolveDefaultsToDisabled(t *testing.T) {
+	effective, err := TLSPolicy{}.Resolve("plugins.api.mesh.config.tls")
+	require.NoError(t, err)
+	assert.Equal(t, EffectiveTLS{}, effective)
+}
+
+func TestTLSResolvePartialPairFails(t *testing.T) {
+	_, err := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/only/cert.pem"),
+	}.Resolve("plugins.api.blockfrost.config.tls")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugins.api.blockfrost.config.tls")
+	assert.Contains(t, err.Error(), "must both be set")
+}
+
+func TestTLSResolveServerRequiresCertAndKey(t *testing.T) {
+	_, err := TLSPolicy{Mode: new(string(TLSModeServer))}.Resolve("api.tls")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestTLSResolveInvalidMode(t *testing.T) {
+	_, err := TLSPolicy{Mode: new("bogus")}.Resolve("api.tls")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+func TestAuthResolveDefaultsToDisabled(t *testing.T) {
+	effective, err := AuthPolicy{}.Resolve("plugins.api.mesh.config.auth")
+	require.NoError(t, err)
+	assert.Equal(t, EffectiveAuth{}, effective)
+}
+
+func TestAuthResolveTokenAndTokenFilePathMutuallyExclusive(t *testing.T) {
+	_, err := AuthPolicy{
+		Mode:          new(string(AuthModeToken)),
+		Token:         new("secret"),
+		TokenFilePath: new("/path/to/token"),
+	}.Resolve("api.auth")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestAuthResolveTokenModeRequiresCredential(t *testing.T) {
+	_, err := AuthPolicy{Mode: new(string(AuthModeToken))}.Resolve("api.auth")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestAuthResolveInvalidMode(t *testing.T) {
+	_, err := AuthPolicy{Mode: new("bogus")}.Resolve("api.auth")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+func TestMergeProviderConfigPrecedenceProviderOverTopLevelOverLegacy(
+	t *testing.T,
+) {
+	legacyTLS := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/legacy/cert.pem"),
+		KeyFilePath:  new("/legacy/key.pem"),
+	}
+	apiTLS := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/toplevel/cert.pem"),
+		KeyFilePath:  new("/toplevel/key.pem"),
+	}
+	apiAuth := AuthPolicy{Mode: new(string(AuthModeDisabled))}
+	raw := map[string]any{
+		"port": 3000,
+		"tls": map[string]any{
+			"certFilePath": "/provider/cert.pem",
+		},
+	}
+	merged, err := MergeProviderConfig(raw, legacyTLS, apiTLS, apiAuth)
+	require.NoError(t, err)
+	// Untouched keys pass through.
+	assert.Equal(t, 3000, merged["port"])
+	providerTLS, err := DecodeTLSPolicy(merged)
+	require.NoError(t, err)
+	effective, err := providerTLS.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	// certFilePath: explicit provider override wins.
+	assert.Equal(t, "/provider/cert.pem", effective.CertFilePath)
+	// keyFilePath: not set by provider, falls through to the top-level
+	// default (not the legacy value, since top-level is higher priority).
+	assert.Equal(t, "/toplevel/key.pem", effective.KeyFilePath)
+}
+
+func TestMergeProviderConfigLegacyOnlyAppliesWhenNothingElseSet(t *testing.T) {
+	legacyTLS := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/legacy/cert.pem"),
+		KeyFilePath:  new("/legacy/key.pem"),
+	}
+	merged, err := MergeProviderConfig(
+		map[string]any{"port": 9090},
+		legacyTLS,
+		TLSPolicy{},
+		AuthPolicy{},
+	)
+	require.NoError(t, err)
+	providerTLS, err := DecodeTLSPolicy(merged)
+	require.NoError(t, err)
+	effective, err := providerTLS.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	assert.Equal(t, "/legacy/cert.pem", effective.CertFilePath)
+}
+
+func TestMergeProviderConfigDoesNotMutateInput(t *testing.T) {
+	raw := map[string]any{
+		"tls": map[string]any{"certFilePath": "/provider/cert.pem"},
+	}
+	apiTLS := TLSPolicy{Mode: new(string(TLSModeServer))}
+	_, err := MergeProviderConfig(raw, TLSPolicy{}, apiTLS, AuthPolicy{})
+	require.NoError(t, err)
+	// raw's own "tls" section must be untouched by the merge.
+	tlsSection, ok := raw["tls"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, tlsSection, 1)
+	assert.Equal(t, "/provider/cert.pem", tlsSection["certFilePath"])
+}
+
+func TestMergeProviderConfigDeterministicRegardlessOfInputMapOrder(
+	t *testing.T,
+) {
+	legacyTLS := TLSPolicy{}
+	apiTLS := TLSPolicy{
+		Mode:         new(string(TLSModeServer)),
+		CertFilePath: new("/a/cert.pem"),
+		KeyFilePath:  new("/a/key.pem"),
+	}
+	apiAuth := AuthPolicy{Mode: new(string(AuthModeToken)), Token: new("t")}
+
+	// Two maps built by inserting keys in different orders (Go map literals
+	// don't guarantee iteration order, but constructing them differently
+	// here exercises the same risk MergeProviderConfig must avoid: any
+	// dependency on map iteration order rather than named-field merging).
+	rawA := map[string]any{}
+	rawA["port"] = 8080
+	rawA["tls"] = map[string]any{"certFilePath": "/provider/cert.pem"}
+
+	rawB := map[string]any{}
+	rawB["tls"] = map[string]any{"certFilePath": "/provider/cert.pem"}
+	rawB["port"] = 8080
+
+	mergedA, err := MergeProviderConfig(rawA, legacyTLS, apiTLS, apiAuth)
+	require.NoError(t, err)
+	mergedB, err := MergeProviderConfig(rawB, legacyTLS, apiTLS, apiAuth)
+	require.NoError(t, err)
+
+	tlsA, err := DecodeTLSPolicy(mergedA)
+	require.NoError(t, err)
+	tlsB, err := DecodeTLSPolicy(mergedB)
+	require.NoError(t, err)
+	effA, err := tlsA.Resolve("test")
+	require.NoError(t, err)
+	effB, err := tlsB.Resolve("test")
+	require.NoError(t, err)
+	assert.Equal(t, effA, effB)
+}
+
+func TestAuthPolicyLogValueRedactsToken(t *testing.T) {
+	policy := AuthPolicy{
+		Mode:          new(string(AuthModeToken)),
+		Token:         new("super-secret"),
+		TokenFilePath: new("/path/token"),
+	}
+	rendered := renderLogValue(t, policy)
+	assert.NotContains(t, rendered, "super-secret")
+	assert.Contains(t, rendered, "***redacted***")
+	assert.Contains(t, rendered, "/path/token")
+}
+
+func TestEffectiveAuthLogValueRedactsToken(t *testing.T) {
+	effective := EffectiveAuth{Enabled: true, Token: "super-secret"}
+	rendered := renderLogValue(t, effective)
+	assert.NotContains(t, rendered, "super-secret")
+	assert.Contains(t, rendered, "***redacted***")
+}
+
+// renderLogValue renders v through a real slog.Logger (as node.go's own
+// logging would) and returns the emitted line, so the test exercises the
+// same LogValue path a structured log call takes rather than calling
+// LogValue directly.
+func renderLogValue(t *testing.T, v any) string {
+	t.Helper()
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	logger.Info("test", "value", v)
+	return buf.String()
+}

--- a/internal/config/api_security_test.go
+++ b/internal/config/api_security_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoad_APITLSAuthYAMLDefaults covers the top-level api.tls/api.auth
+// section: a YAML-only configuration populates it, with the per-provider
+// plugins.api.* selections left untouched (the merge into each provider's
+// own config happens at node composition, not here -- see node.go's
+// apiProviderConfig).
+func TestLoad_APITLSAuthYAMLDefaults(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n"+
+			"  tls:\n"+
+			"    mode: server\n"+
+			"    certFilePath: /run/secrets/api.crt\n"+
+			"    keyFilePath: /run/secrets/api.key\n"+
+			"  auth:\n"+
+			"    mode: token\n"+
+			"    tokenFilePath: /run/secrets/api-token\n",
+	), 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.API.TLS.Mode)
+	assert.Equal(t, "server", *cfg.API.TLS.Mode)
+	require.NotNil(t, cfg.API.TLS.CertFilePath)
+	assert.Equal(t, "/run/secrets/api.crt", *cfg.API.TLS.CertFilePath)
+	require.NotNil(t, cfg.API.TLS.KeyFilePath)
+	assert.Equal(t, "/run/secrets/api.key", *cfg.API.TLS.KeyFilePath)
+	require.NotNil(t, cfg.API.Auth.Mode)
+	assert.Equal(t, "token", *cfg.API.Auth.Mode)
+	require.NotNil(t, cfg.API.Auth.TokenFilePath)
+	assert.Equal(
+		t, "/run/secrets/api-token", *cfg.API.Auth.TokenFilePath,
+	)
+}
+
+// TestLoad_APITLSEnvironmentOverridesYAML covers source precedence
+// (env over YAML) for the new api.tls fields, mirroring
+// TestMempoolProviderSourcePrecedence's pattern for the existing plugin
+// selection fields.
+func TestLoad_APITLSEnvironmentOverridesYAML(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_API_TLS_MODE", "disabled")
+	t.Setenv("DINGO_API_TLS_CERT_FILE_PATH", "/env/cert.pem")
+	t.Setenv("DINGO_API_TLS_KEY_FILE_PATH", "/env/key.pem")
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n"+
+			"  tls:\n"+
+			"    mode: server\n"+
+			"    certFilePath: /yaml/cert.pem\n"+
+			"    keyFilePath: /yaml/key.pem\n",
+	), 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.API.TLS.Mode)
+	assert.Equal(t, "disabled", *cfg.API.TLS.Mode, "environment overrides YAML")
+	require.NotNil(t, cfg.API.TLS.CertFilePath)
+	assert.Equal(t, "/env/cert.pem", *cfg.API.TLS.CertFilePath)
+}
+
+// TestApplyFlags_APITLSCLIOverridesEnvironment covers the top of the
+// source precedence chain: a CLI flag beats both environment and YAML.
+func TestApplyFlags_APITLSCLIOverridesEnvironment(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DINGO_API_TLS_MODE", "disabled")
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n  tls:\n    mode: server\n",
+	), 0o600))
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.API.TLS.Mode)
+	assert.Equal(t, "disabled", *cfg.API.TLS.Mode)
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	require.NoError(t, cmd.ParseFlags([]string{"--api-tls-mode=server"}))
+	require.NoError(t, ApplyFlags(cmd, cfg))
+
+	require.NotNil(t, cfg.API.TLS.Mode)
+	assert.Equal(t, "server", *cfg.API.TLS.Mode, "CLI overrides environment")
+}
+
+// TestLoad_APIAuthCLIExplicitDisable covers representing an explicit
+// "disabled" as distinct from "unset": a CLI flag can turn off an
+// environment/YAML-inherited auth mode rather than merely leaving it at
+// its default.
+func TestLoad_APIAuthCLIExplicitDisable(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n  auth:\n    mode: token\n    tokenFilePath: /run/secrets/api-token\n",
+	), 0o600))
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	cmd := &cobra.Command{Use: "dingo"}
+	RegisterFlags(cmd)
+	require.NoError(t, cmd.ParseFlags([]string{"--api-auth-mode=disabled"}))
+	require.NoError(t, ApplyFlags(cmd, cfg))
+
+	require.NotNil(t, cfg.API.Auth.Mode)
+	assert.Equal(t, "disabled", *cfg.API.Auth.Mode)
+	// The inherited tokenFilePath is untouched -- disabling mode does not
+	// require also clearing the (now irrelevant) credential fields.
+	require.NotNil(t, cfg.API.Auth.TokenFilePath)
+	assert.Equal(t, "/run/secrets/api-token", *cfg.API.Auth.TokenFilePath)
+}
+
+// TestLoad_APIProviderConfigPerFieldOverride is the end-to-end shape from
+// dingo#2998's issue body: a shared top-level api.tls default plus a
+// provider-level override of only one nested field. It exercises the real
+// LoadConfig YAML path together with apiconfig.MergeProviderConfig (the
+// same merge node.go's apiProviderConfig performs at composition), rather
+// than re-deriving the same fields by hand, so a regression in either
+// layer's field names would be caught here.
+func TestLoad_APIProviderConfigPerFieldOverride(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n"+
+			"  tls:\n"+
+			"    mode: server\n"+
+			"    certFilePath: /shared/cert.pem\n"+
+			"    keyFilePath: /shared/key.pem\n"+
+			"plugins:\n"+
+			"  api:\n"+
+			"    blockfrost:\n"+
+			"      provider: builtin\n"+
+			"      config:\n"+
+			"        port: 3000\n"+
+			"        tls:\n"+
+			"          certFilePath: /blockfrost/cert.pem\n",
+	), 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	merged, err := apiconfig.MergeProviderConfig(
+		cfg.Plugins.API.Blockfrost.Config,
+		apiconfig.TLSPolicy{},
+		cfg.API.TLS,
+		cfg.API.Auth,
+	)
+	require.NoError(t, err)
+	tlsPolicy, err := apiconfig.DecodeTLSPolicy(merged)
+	require.NoError(t, err)
+	effective, err := tlsPolicy.Resolve("test")
+	require.NoError(t, err)
+
+	assert.True(t, effective.Enabled)
+	// certFilePath: the provider's own explicit override wins.
+	assert.Equal(t, "/blockfrost/cert.pem", effective.CertFilePath)
+	// keyFilePath: not set by the provider, inherited from the top-level
+	// default -- overriding one nested field must not blow away the
+	// other.
+	assert.Equal(t, "/shared/key.pem", effective.KeyFilePath)
+}
+
+// TestLoad_APIProviderConfigExplicitDisable covers a provider explicitly
+// opting out of an inherited top-level policy.
+func TestLoad_APIProviderConfigExplicitDisable(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n"+
+			"  auth:\n"+
+			"    mode: token\n"+
+			"    token: shared-secret\n"+
+			"plugins:\n"+
+			"  api:\n"+
+			"    mesh:\n"+
+			"      provider: builtin\n"+
+			"      config:\n"+
+			"        port: 8080\n"+
+			"        auth:\n"+
+			"          mode: disabled\n",
+	), 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	merged, err := apiconfig.MergeProviderConfig(
+		cfg.Plugins.API.Mesh.Config,
+		apiconfig.TLSPolicy{},
+		cfg.API.TLS,
+		cfg.API.Auth,
+	)
+	require.NoError(t, err)
+	authPolicy, err := apiconfig.DecodeAuthPolicy(merged)
+	require.NoError(t, err)
+	effective, err := authPolicy.Resolve("test")
+	require.NoError(t, err)
+
+	assert.False(t, effective.Enabled)
+}
+
+// TestLoad_APIProviderConfigInvalidMergedTLSPair covers the "invalid
+// merged certificate/key pair" acceptance criterion: a top-level
+// certFilePath with a provider-level keyFilePath removal (impossible to
+// express by omission, so this uses an explicit provider override that
+// still leaves the pair incomplete) fails Resolve with a path-qualified
+// error.
+func TestLoad_APIProviderConfigInvalidMergedTLSPair(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+
+	configFile := filepath.Join(t.TempDir(), "dingo.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(
+		"api:\n"+
+			"  tls:\n"+
+			"    mode: server\n"+
+			"    certFilePath: /shared/cert.pem\n"+
+			"plugins:\n"+
+			"  api:\n"+
+			"    utxorpc:\n"+
+			"      provider: builtin\n"+
+			"      config:\n"+
+			"        port: 9090\n",
+	), 0o600))
+
+	cfg, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	merged, err := apiconfig.MergeProviderConfig(
+		cfg.Plugins.API.Utxorpc.Config,
+		apiconfig.TLSPolicy{},
+		cfg.API.TLS,
+		cfg.API.Auth,
+	)
+	require.NoError(t, err)
+	tlsPolicy, err := apiconfig.DecodeTLSPolicy(merged)
+	require.NoError(t, err)
+	_, err = tlsPolicy.Resolve("plugins.api.utxorpc.config.tls")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugins.api.utxorpc.config.tls")
+	assert.Contains(t, err.Error(), "must both be set")
+}
+
+// TestValidate_InvalidAPITLSMode covers the fail-fast top-level mode
+// enum check: a typo in api.tls.mode is rejected once, with a clear
+// message, by Validate rather than only surfacing later from each of the
+// three API providers that would otherwise inherit it.
+func TestValidate_InvalidAPITLSMode(t *testing.T) {
+	resetGlobalConfig()
+	cfg := GetConfig()
+	cfg.ApplyDefaults()
+	bogus := "bogus"
+	cfg.API.TLS.Mode = &bogus
+
+	err := cfg.Validate(RunModeLoad)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api.tls.mode")
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+// TestValidate_InvalidAPIAuthMode is TestValidate_InvalidAPITLSMode's
+// auth counterpart.
+func TestValidate_InvalidAPIAuthMode(t *testing.T) {
+	resetGlobalConfig()
+	cfg := GetConfig()
+	cfg.ApplyDefaults()
+	bogus := "bogus"
+	cfg.API.Auth.Mode = &bogus
+
+	err := cfg.Validate(RunModeLoad)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api.auth.mode")
+	assert.Contains(t, err.Error(), "invalid mode")
+}
+
+// TestGetConfigSnapshotDoesNotShareAPIPolicy asserts GetConfig's snapshot
+// deep-copies api.tls/api.auth pointer fields, matching the existing
+// nested-plugin-config isolation guarantee: mutating one snapshot's
+// policy must not be visible through another.
+func TestGetConfigSnapshotDoesNotShareAPIPolicy(t *testing.T) {
+	resetGlobalConfig()
+	mode := "server"
+	globalConfig.API.TLS.Mode = &mode
+
+	snapshotA := GetConfig()
+	snapshotB := GetConfig()
+	require.NotNil(t, snapshotA.API.TLS.Mode)
+	require.NotNil(t, snapshotB.API.TLS.Mode)
+	require.NotSame(t, snapshotA.API.TLS.Mode, snapshotB.API.TLS.Mode)
+
+	disabled := "disabled"
+	snapshotA.API.TLS.Mode = &disabled
+	assert.Equal(t, "server", *snapshotB.API.TLS.Mode)
+}

--- a/internal/config/api_security_test.go
+++ b/internal/config/api_security_test.go
@@ -92,6 +92,27 @@ func TestLoad_APITLSEnvironmentOverridesYAML(t *testing.T) {
 	assert.Equal(t, "/env/cert.pem", *cfg.API.TLS.CertFilePath)
 }
 
+// TestLoad_APIAuthTokenHasNoEnvironmentBinding pins
+// apiconfig.AuthPolicy.Token's documented security property: an inline
+// secret is settable only via YAML, never via an environment variable
+// (unlike every other api.auth/api.tls field). Without the `ignored:"true"`
+// struct tag, envconfig.Process would still auto-derive and honor
+// CARDANO_API_AUTH_TOKEN even with no explicit `envconfig` tag present --
+// omitting the tag alone does not suppress the binding.
+func TestLoad_APIAuthTokenHasNoEnvironmentBinding(t *testing.T) {
+	resetGlobalConfig()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CARDANO_API_AUTH_TOKEN", "leaked-secret")
+
+	cfg, err := LoadConfig("")
+	require.NoError(t, err)
+
+	assert.Nil(
+		t, cfg.API.Auth.Token,
+		"api.auth.token must never be settable via environment variable",
+	)
+}
+
 // TestApplyFlags_APITLSCLIOverridesEnvironment covers the top of the
 // source precedence chain: a CLI flag beats both environment and YAML.
 func TestApplyFlags_APITLSCLIOverridesEnvironment(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	hostplugin "github.com/blinklabs-io/dingo/plugin"
 	"github.com/blinklabs-io/dingo/topology"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -441,24 +442,27 @@ func DefaultMidnightConfig() MidnightConfig {
 }
 
 type Config struct {
-	Plugins                PluginsConfig `yaml:"plugins"`
-	TlsKeyFilePath         string        `yaml:"tlsKeyFilePath"         envconfig:"TLS_KEY_FILE_PATH"`
-	Topology               string        `yaml:"topology"`
-	CardanoConfig          string        `yaml:"cardanoConfig"          envconfig:"config"`
-	DatabasePath           string        `yaml:"databasePath"                                                       split_words:"true"`
-	SocketPath             string        `yaml:"socketPath"                                                         split_words:"true"`
-	TlsCertFilePath        string        `yaml:"tlsCertFilePath"        envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr               string        `yaml:"bindAddr"                                                           split_words:"true"`
-	PrivateBindAddr        string        `yaml:"privateBindAddr"                                                    split_words:"true"`
-	ShutdownTimeout        string        `yaml:"shutdownTimeout"                                                    split_words:"true"`
-	LedgerCatchupTimeout   string        `yaml:"ledgerCatchupTimeout"   envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
-	Network                string        `yaml:"network"`
-	NetworkMagic           uint32        `yaml:"networkMagic"                                                       split_words:"true"`
-	PrivatePort            uint          `yaml:"privatePort"                                                        split_words:"true"`
-	RelayPort              uint          `yaml:"relayPort"              envconfig:"port"`
-	BarkBaseUrl            string        `yaml:"barkBaseUrl"            envconfig:"DINGO_BARK_BASE_URL"`
-	BarkBlockDownloadHosts []string      `yaml:"barkBlockDownloadHosts" envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
-	BarkPort               uint          `yaml:"barkPort"               envconfig:"DINGO_BARK_PORT"`
+	Plugins PluginsConfig `yaml:"plugins"`
+	// API holds shared TLS/auth policy defaults for every selected
+	// plugins.api.* provider. See APIConfig's own doc comment.
+	API                    APIConfig `yaml:"api"`
+	TlsKeyFilePath         string    `yaml:"tlsKeyFilePath"         envconfig:"TLS_KEY_FILE_PATH"`
+	Topology               string    `yaml:"topology"`
+	CardanoConfig          string    `yaml:"cardanoConfig"          envconfig:"config"`
+	DatabasePath           string    `yaml:"databasePath"                                                       split_words:"true"`
+	SocketPath             string    `yaml:"socketPath"                                                         split_words:"true"`
+	TlsCertFilePath        string    `yaml:"tlsCertFilePath"        envconfig:"TLS_CERT_FILE_PATH"`
+	BindAddr               string    `yaml:"bindAddr"                                                           split_words:"true"`
+	PrivateBindAddr        string    `yaml:"privateBindAddr"                                                    split_words:"true"`
+	ShutdownTimeout        string    `yaml:"shutdownTimeout"                                                    split_words:"true"`
+	LedgerCatchupTimeout   string    `yaml:"ledgerCatchupTimeout"   envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
+	Network                string    `yaml:"network"`
+	NetworkMagic           uint32    `yaml:"networkMagic"                                                       split_words:"true"`
+	PrivatePort            uint      `yaml:"privatePort"                                                        split_words:"true"`
+	RelayPort              uint      `yaml:"relayPort"              envconfig:"port"`
+	BarkBaseUrl            string    `yaml:"barkBaseUrl"            envconfig:"DINGO_BARK_BASE_URL"`
+	BarkBlockDownloadHosts []string  `yaml:"barkBlockDownloadHosts" envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
+	BarkPort               uint      `yaml:"barkPort"               envconfig:"DINGO_BARK_PORT"`
 	// BarkHost is the interface Bark binds to. Left empty, node.go defaults
 	// it to loopback-only (127.0.0.1) whenever the database lifecycle
 	// service (Restore/Truncate and friends — gated on BarkClientCAFilePath,
@@ -664,6 +668,25 @@ type APIPluginsConfig struct {
 	Blockfrost hostplugin.Selection `yaml:"blockfrost"`
 	Mesh       hostplugin.Selection `yaml:"mesh"`
 	Utxorpc    hostplugin.Selection `yaml:"utxorpc"`
+}
+
+// APIConfig holds the shared TLS and authentication policy defaults
+// applied to every selected plugins.api.* provider (Blockfrost, Mesh,
+// UTxORPC) unless that provider's own plugins.api.<name>.config.tls/auth
+// overrides a field. See ARCHITECTURE.md's "API security" section and
+// internal/apiconfig for the merge/validation rules; composition (node.go)
+// performs the actual per-provider merge, not this package.
+//
+// bindAddr and corsAllowedOrigins deliberately stay at the Config root
+// rather than moving under this section: bindAddr is not API-specific
+// (the relay/NtN and metrics/debug listeners use it too), and
+// corsAllowedOrigins already applies uniformly to all three API providers
+// today with no override need identified by dingo#2996/#2998, so
+// duplicating either here would only add a second source of truth for no
+// behavioral gain.
+type APIConfig struct {
+	TLS  apiconfig.TLSPolicy  `yaml:"tls"`
+	Auth apiconfig.AuthPolicy `yaml:"auth"`
 }
 
 func defaultPluginsConfig() PluginsConfig {
@@ -1044,6 +1067,35 @@ func clonePluginSelection(selection hostplugin.Selection) hostplugin.Selection {
 	return clone
 }
 
+func cloneStringPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+// cloneTLSPolicy and cloneAuthPolicy deep-copy every pointer field so a
+// clone never shares a *string with the Config it was cloned from --
+// matching PeerSharing's own defensive-copy discipline just above, even
+// though every pointer in practice is replaced wholesale (never mutated
+// in place) once set.
+func cloneTLSPolicy(p apiconfig.TLSPolicy) apiconfig.TLSPolicy {
+	return apiconfig.TLSPolicy{
+		Mode:         cloneStringPtr(p.Mode),
+		CertFilePath: cloneStringPtr(p.CertFilePath),
+		KeyFilePath:  cloneStringPtr(p.KeyFilePath),
+	}
+}
+
+func cloneAuthPolicy(p apiconfig.AuthPolicy) apiconfig.AuthPolicy {
+	return apiconfig.AuthPolicy{
+		Mode:          cloneStringPtr(p.Mode),
+		Token:         cloneStringPtr(p.Token),
+		TokenFilePath: cloneStringPtr(p.TokenFilePath),
+	}
+}
+
 func cloneConfig(cfg *Config) *Config {
 	if cfg == nil {
 		return nil
@@ -1058,6 +1110,8 @@ func cloneConfig(cfg *Config) *Config {
 		peerSharing := *cfg.PeerSharing
 		clone.PeerSharing = &peerSharing
 	}
+	clone.API.TLS = cloneTLSPolicy(cfg.API.TLS)
+	clone.API.Auth = cloneAuthPolicy(cfg.API.Auth)
 	if cfg.LeiosVoterPublicKeys != nil {
 		clone.LeiosVoterPublicKeys = make(
 			map[string]string,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -199,6 +199,37 @@ var flagSpecs = []flagSpec{
 		"cors-allowed-origins",
 		"CORS allowed origins for API servers",
 	),
+
+	// API security (shared TLS/auth defaults for every selected
+	// plugins.api.* provider; see internal/apiconfig and
+	// ARCHITECTURE.md's "API security" section). Explicit
+	// plugins.api.<name>.config.tls/auth fields override these per
+	// provider.
+	stringPtrFlag(
+		"API.TLS.Mode",
+		"api-tls-mode",
+		`shared API TLS mode: "disabled" or "server" (unset: inherit provider setting, else disabled)`,
+	),
+	stringPtrFlag(
+		"API.TLS.CertFilePath",
+		"api-tls-cert-file-path",
+		"shared API TLS certificate file path",
+	),
+	stringPtrFlag(
+		"API.TLS.KeyFilePath",
+		"api-tls-key-file-path",
+		"shared API TLS private key file path",
+	),
+	stringPtrFlag(
+		"API.Auth.Mode",
+		"api-auth-mode",
+		`shared API auth mode: "disabled" or "token" (unset: inherit provider setting, else disabled)`,
+	),
+	stringPtrFlag(
+		"API.Auth.TokenFilePath",
+		"api-auth-token-file-path",
+		"shared API auth bearer token file path",
+	),
 	durationFlag(
 		"OffchainMetadata.Interval",
 		"offchain-metadata-interval",
@@ -909,6 +940,34 @@ func boolPtrFlag(field, name, help string) flagSpec {
 				return nil
 			}
 			v, err := f.GetBool(name)
+			if err != nil {
+				return err
+			}
+			targetValue(cfg, field).Set(reflect.ValueOf(&v))
+			return nil
+		},
+	}
+}
+
+// stringPtrFlag binds a CLI flag to a *string field. The pointer
+// distinguishes "operator did not set this" (nil, inherit from a broader
+// scope or fall back to a disabled default) from an explicit value --
+// needed for the api.tls/api.auth policy fields (internal/apiconfig),
+// where an explicit "disabled" is meaningfully different from never
+// setting a mode at all. We only write to the field when the flag was
+// explicitly passed, matching boolPtrFlag's own contract.
+func stringPtrFlag(field, name, help string) flagSpec {
+	return flagSpec{
+		field: field,
+		name:  name,
+		register: func(f *pflag.FlagSet, defaults *Config) {
+			f.String(name, "", help)
+		},
+		apply: func(f *pflag.FlagSet, cfg *Config) error {
+			if !f.Changed(name) {
+				return nil
+			}
+			v, err := f.GetString(name)
 			if err != nil {
 				return err
 			}

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -37,6 +37,12 @@ func TestRegisterFlags_CoversAllExportedConfigFields(t *testing.T) {
 
 	specFields := map[string]string{}
 	yamlOnlyFields := map[string]struct{}{
+		// Deliberately has no CLI flag (unlike every sibling api.auth/
+		// api.tls field): a raw inline secret should not be encouraged
+		// onto a command line, where it is visible via `ps` and shell
+		// history. Use --api-auth-token-file-path (API.Auth.TokenFilePath)
+		// or YAML instead. See AuthPolicy.Token's own doc comment.
+		"API.Auth.Token":                       {},
 		"Plugins.Storage.Blob.Config":          {},
 		"Plugins.Storage.Metadata.Config":      {},
 		"Plugins.Mempool.Config":               {},

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -751,12 +751,6 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 	return errors.Join(errs...)
 }
 
-// validatePort checks a configured TCP port. Ports are uints, so
-// values above 65535 are representable but unbindable; ports below
-// minBindable are privileged ports the process may not bind; and 0
-// either disables the component (required=false) or is nonsense for a
-// mandatory listener (required=true, binding port 0 picks a random
-// port).
 // validateAPIMode rejects a mode value that is neither unset (inherit/
 // default) nor one of the two accepted enum values.
 func validateAPIMode(
@@ -776,6 +770,12 @@ func validateAPIMode(
 	)
 }
 
+// validatePort checks a configured TCP port. Ports are uints, so
+// values above 65535 are representable but unbindable; ports below
+// minBindable are privileged ports the process may not bind; and 0
+// either disables the component (required=false) or is nonsense for a
+// mandatory listener (required=true, binding port 0 picks a random
+// port).
 func validatePort(
 	setting string,
 	port uint,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 )
 
@@ -371,6 +372,30 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 			"tlsCertFilePath and tlsKeyFilePath must both be set to enable TLS "+
 				"(only one is set)",
 		))
+	}
+
+	// The shared api.tls/api.auth mode enums are checked here so a typo is
+	// caught once, with a single clear message, rather than surfacing
+	// identically from every one of the three API providers that inherit
+	// it. Certificate/key (and token) presence is deliberately NOT
+	// checked here: a provider legitimately may supply only its own
+	// certFilePath/keyFilePath while inheriting just `mode: server` from
+	// this shared default (see internal/apiconfig.MergeTLS), so
+	// completeness can only be judged after node.go merges this default
+	// into each provider's own plugins.api.<name>.config.tls/auth --
+	// which is where the full pair-completeness check runs, before that
+	// provider's listener starts.
+	if err := validateAPIMode(
+		"api.tls.mode", c.API.TLS.Mode,
+		string(apiconfig.TLSModeDisabled), string(apiconfig.TLSModeServer),
+	); err != nil {
+		errs = append(errs, err)
+	}
+	if err := validateAPIMode(
+		"api.auth.mode", c.API.Auth.Mode,
+		string(apiconfig.AuthModeDisabled), string(apiconfig.AuthModeToken),
+	); err != nil {
+		errs = append(errs, err)
 	}
 
 	// Bark's DatabaseService mounts its destructive RPCs (CreateSnapshot/
@@ -732,6 +757,25 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 // either disables the component (required=false) or is nonsense for a
 // mandatory listener (required=true, binding port 0 picks a random
 // port).
+// validateAPIMode rejects a mode value that is neither unset (inherit/
+// default) nor one of the two accepted enum values.
+func validateAPIMode(
+	setting string,
+	mode *string,
+	disabled, enabled string,
+) error {
+	if mode == nil || *mode == "" {
+		return nil
+	}
+	if *mode == disabled || *mode == enabled {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s: invalid mode %q (must be %q or %q)",
+		setting, *mode, disabled, enabled,
+	)
+}
+
 func validatePort(
 	setting string,
 	port uint,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -314,191 +314,16 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	)
 
 	d, err := dingo.New(
-		dingo.NewConfig(
-			dingo.WithIntersectTip(cfg.IntersectTip),
-			dingo.WithLogger(logger),
-			dingo.WithDatabasePath(cfg.DatabasePath),
-			dingo.WithPluginSelection(
-				plugin.CapabilityStorageBlob,
-				cfg.Plugins.Storage.Blob,
-			),
-			dingo.WithPluginSelection(
-				plugin.CapabilityStorageMetadata,
-				cfg.Plugins.Storage.Metadata,
-			),
-			dingo.WithPluginSelection(
-				plugin.CapabilityMempool,
-				cfg.Plugins.Mempool,
-			),
-			dingo.WithPluginSelection(
-				plugin.CapabilityAPIBlockfrost,
-				cfg.Plugins.API.Blockfrost,
-			),
-			dingo.WithPluginSelection(
-				plugin.CapabilityAPIMesh,
-				cfg.Plugins.API.Mesh,
-			),
-			dingo.WithPluginSelection(
-				plugin.CapabilityAPIUtxorpc,
-				cfg.Plugins.API.Utxorpc,
-			),
-			dingo.WithNetwork(cfg.Network),
-			dingo.WithNetworkMagic(cfg.NetworkMagic),
-			dingo.WithCardanoNodeConfig(nodeCfg),
-			dingo.WithListeners(listeners...),
-			dingo.WithOutboundSourcePort(cfg.RelayPort),
-			dingo.WithPeerSharing(peerSharing),
-			dingo.WithUtxorpcTlsCertFilePath(cfg.TlsCertFilePath),
-			dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
-			dingo.WithBarkBaseUrl(cfg.BarkBaseUrl),
-			dingo.WithBarkBlockDownloadHosts(cfg.BarkBlockDownloadHosts),
-			dingo.WithBarkPort(cfg.BarkPort),
-			dingo.WithBarkHost(cfg.BarkHost),
-			dingo.WithBarkClientCAFilePath(cfg.BarkClientCAFilePath),
-			dingo.WithHistoryExpiry(dingo.HistoryExpiryConfig{
-				Enabled:   cfg.HistoryExpiry.Enabled,
-				Frequency: cfg.HistoryExpiry.Frequency,
-			}),
-			dingo.WithKoiosParity(dingo.KoiosParityConfig{
-				Enabled:    cfg.KoiosParity.Enabled,
-				Network:    cfg.KoiosParity.Network,
-				CachePath:  cfg.KoiosParity.CachePath,
-				APIKey:     cfg.KoiosParity.APIKey,
-				Strict:     cfg.KoiosParity.Strict,
-				GraceHours: cfg.KoiosParity.GraceHours,
-			}),
-			dingo.WithCORSAllowedOrigins(cfg.CORSAllowedOrigins),
-			dingo.WithOffchainMetadataConfig(
-				dingo.OffchainMetadataConfig{
-					Interval: cfg.OffchainMetadata.Interval,
-					RequestTimeout: cfg.OffchainMetadata.
-						RequestTimeout,
-					UserAgent: cfg.OffchainMetadata.UserAgent,
-					IPFSGatewayURL: cfg.OffchainMetadata.
-						IPFSGatewayURL,
-					BatchSize: cfg.OffchainMetadata.BatchSize,
-					MaxBytes:  cfg.OffchainMetadata.MaxBytes,
-					AllowPrivateAddresses: cfg.OffchainMetadata.
-						AllowPrivateAddresses,
-				},
-			),
-			dingo.WithMidnightConfig(dingo.MidnightConfig{
-				Enabled:                     cfg.Midnight.Enabled,
-				Port:                        cfg.Midnight.Port,
-				Host:                        cfg.Midnight.Host,
-				CNightPolicyID:              cfg.Midnight.CNightPolicyID,
-				CNightAssetName:             cfg.Midnight.CNightAssetName,
-				MappingValidatorAddress:     cfg.Midnight.MappingValidatorAddress,
-				AuthTokenPolicyID:           cfg.Midnight.AuthTokenPolicyID,
-				AuthTokenAssetName:          cfg.Midnight.AuthTokenAssetName,
-				CommitteeCandidateAddress:   cfg.Midnight.CommitteeCandidateAddress,
-				TechnicalCommitteeAddress:   cfg.Midnight.TechnicalCommitteeAddress,
-				TechnicalCommitteePolicyID:  cfg.Midnight.TechnicalCommitteePolicyID,
-				CouncilAddress:              cfg.Midnight.CouncilAddress,
-				CouncilPolicyID:             cfg.Midnight.CouncilPolicyID,
-				PermissionedCandidatePolicy: cfg.Midnight.PermissionedCandidatePolicy,
-			}),
-			dingo.WithValidateHistorical(cfg.ValidateHistorical),
-			dingo.WithStrictUtxoValidation(cfg.StrictUtxoValidation),
-			dingo.WithRunMode(string(cfg.RunMode)),
-			dingo.WithStartEra(string(cfg.StartEra)),
-			dingo.WithShutdownTimeout(shutdownTimeout),
-			// Enable metrics with default prometheus registry
-			dingo.WithPrometheusRegistry(prometheus.DefaultRegisterer),
-			dingo.WithTracing(cfg.Tracing),
-			dingo.WithTracingStdout(cfg.TracingStdout),
-			dingo.WithTopologyConfig(config.GetTopologyConfig()),
-			dingo.WithDatabaseWorkerPoolConfig(ledger.DatabaseWorkerPoolConfig{
-				WorkerPoolSize: cfg.DatabaseWorkers,
-				TaskQueueSize:  cfg.DatabaseQueueSize,
-				Disabled:       false,
-			}),
-			dingo.WithPeerTargets(
-				cfg.TargetNumberOfKnownPeers,
-				cfg.TargetNumberOfEstablishedPeers,
-				cfg.TargetNumberOfActivePeers,
-			),
-			dingo.WithGenesisBootstrap(cfg.GenesisBootstrap.Enabled),
-			dingo.WithGenesisWindowSlots(cfg.GenesisBootstrap.WindowSlots),
-			dingo.WithGenesisCorroborationPeers(
-				cfg.GenesisBootstrap.CorroborationPeers,
-			),
-			dingo.WithBootstrapPromotionMinDiversityGroups(
-				cfg.GenesisBootstrap.PromotionMinDiversityGroups,
-			),
-			dingo.WithActivePeersQuotas(
-				cfg.ActivePeersTopologyQuota,
-				cfg.ActivePeersGossipQuota,
-				cfg.ActivePeersLedgerQuota,
-			),
-			dingo.WithMinHotPeers(cfg.MinHotPeers),
-			dingo.WithReconcileInterval(cfg.ReconcileInterval),
-			dingo.WithInactivityTimeout(cfg.InactivityTimeout),
-			dingo.WithInboundPeerGovernance(
-				cfg.InboundWarmTarget,
-				cfg.InboundHotQuota,
-				cfg.InboundMinTenure,
-				cfg.InboundHotScoreThreshold,
-				cfg.InboundPruneAfter,
-				cfg.InboundDuplexOnlyForHot,
-				cfg.InboundCooldown,
-			),
-			dingo.WithMaxConnectionsPerIP(cfg.MaxConnectionsPerIP),
-			dingo.WithMaxInboundConns(cfg.MaxInboundConns),
-			dingo.WithCacheConfig(
-				cfg.Cache.BlockLRUEntries,
-				cfg.Cache.HotUtxoEntries,
-				cfg.Cache.HotTxEntries,
-				cfg.Cache.HotTxMaxBytes,
-			),
-			dingo.WithChainsyncMaxClients(
-				cfg.Chainsync.MaxClients,
-			),
-			dingo.WithChainsyncStallTimeout(
-				chainsyncStallTimeout,
-			),
-			dingo.WithChainsyncHeaderStrategy(
-				chainsyncStrategy,
-			),
-			dingo.WithBindAddr(cfg.BindAddr),
-			dingo.WithStorageMode(storageMode),
-			// CIP-23 minimum pool margin (consensus-affecting)
-			dingo.WithMinPoolMargin(cfg.MinPoolMargin),
-			// CIP-50 pledge-leverage staking rewards (consensus-affecting)
-			dingo.WithPledgeLeverage(
-				cfg.PledgeLeverageEnabled,
-				cfg.PledgeLeverage,
-			),
-			// CIP-0163 full-pot reward distribution (consensus-affecting)
-			dingo.WithFullPotRewards(cfg.FullPotRewardsEnabled),
-			dingo.WithUnsafeFullPotRewardsOnStandardNetworks(
-				cfg.UnsafeFullPotRewardsOnStandardNetworks,
-			),
-			// Block production (SPO mode)
-			dingo.WithBlockProducer(cfg.BlockProducer),
-			dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),
-			dingo.WithShelleyKESKey(cfg.ShelleyKESKey),
-			dingo.WithShelleyOperationalCertificate(
-				cfg.ShelleyOperationalCertificate,
-			),
-			dingo.WithForgeSyncToleranceSlots(
-				cfg.ForgeSyncToleranceSlots,
-			),
-			dingo.WithForgeStaleGapThresholdSlots(
-				cfg.ForgeStaleGapThresholdSlots,
-			),
-			dingo.WithValidateForgedBlock(cfg.ValidateForgedBlock),
-			// CIP-0163 reward-account inactivity expiry (consensus-affecting)
-			dingo.WithDelegatorInactivity(
-				cfg.DelegatorInactivityEnabled,
-				cfg.DelegatorInactivity,
-			),
-			dingo.WithDatabaseLifecycle(cfg.DatabaseLifecycle),
-			// Leios voting (experimental)
-			dingo.WithLeiosVoteSigningKeyFile(
-				cfg.LeiosVoteSigningKeyFile,
-			),
-			dingo.WithLeiosVoterPublicKeys(cfg.LeiosVoterPublicKeys),
+		buildDingoConfig(
+			cfg,
+			logger,
+			nodeCfg,
+			listeners,
+			peerSharing,
+			storageMode,
+			shutdownTimeout,
+			chainsyncStallTimeout,
+			chainsyncStrategy,
 		),
 	)
 	if err != nil {
@@ -632,4 +457,210 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 	}
 
 	return err
+}
+
+// buildDingoConfig translates the loaded internal/config.Config, plus the
+// values Run derives from it (the resolved cardano-node config, listeners,
+// peer-sharing decision, storage mode, and parsed durations/strategy), into
+// a dingo.Config. It is split out from Run so that the full field mapping
+// -- including cfg.API, the shared api.tls/api.auth policy defaults -- can
+// be asserted directly in tests without needing to start the node.
+func buildDingoConfig(
+	cfg *config.Config,
+	logger *slog.Logger,
+	nodeCfg *cardano.CardanoNodeConfig,
+	listeners []dingo.ListenerConfig,
+	peerSharing bool,
+	storageMode dingo.StorageMode,
+	shutdownTimeout time.Duration,
+	chainsyncStallTimeout time.Duration,
+	chainsyncStrategy chainsync.HeaderSyncStrategy,
+) dingo.Config {
+	return dingo.NewConfig(
+		dingo.WithIntersectTip(cfg.IntersectTip),
+		dingo.WithLogger(logger),
+		dingo.WithDatabasePath(cfg.DatabasePath),
+		dingo.WithPluginSelection(
+			plugin.CapabilityStorageBlob,
+			cfg.Plugins.Storage.Blob,
+		),
+		dingo.WithPluginSelection(
+			plugin.CapabilityStorageMetadata,
+			cfg.Plugins.Storage.Metadata,
+		),
+		dingo.WithPluginSelection(
+			plugin.CapabilityMempool,
+			cfg.Plugins.Mempool,
+		),
+		dingo.WithPluginSelection(
+			plugin.CapabilityAPIBlockfrost,
+			cfg.Plugins.API.Blockfrost,
+		),
+		dingo.WithPluginSelection(
+			plugin.CapabilityAPIMesh,
+			cfg.Plugins.API.Mesh,
+		),
+		dingo.WithPluginSelection(
+			plugin.CapabilityAPIUtxorpc,
+			cfg.Plugins.API.Utxorpc,
+		),
+		dingo.WithNetwork(cfg.Network),
+		dingo.WithNetworkMagic(cfg.NetworkMagic),
+		dingo.WithCardanoNodeConfig(nodeCfg),
+		dingo.WithListeners(listeners...),
+		dingo.WithOutboundSourcePort(cfg.RelayPort),
+		dingo.WithPeerSharing(peerSharing),
+		dingo.WithUtxorpcTlsCertFilePath(cfg.TlsCertFilePath),
+		dingo.WithUtxorpcTlsKeyFilePath(cfg.TlsKeyFilePath),
+		dingo.WithAPIConfig(cfg.API),
+		dingo.WithBarkBaseUrl(cfg.BarkBaseUrl),
+		dingo.WithBarkBlockDownloadHosts(cfg.BarkBlockDownloadHosts),
+		dingo.WithBarkPort(cfg.BarkPort),
+		dingo.WithBarkHost(cfg.BarkHost),
+		dingo.WithBarkClientCAFilePath(cfg.BarkClientCAFilePath),
+		dingo.WithHistoryExpiry(dingo.HistoryExpiryConfig{
+			Enabled:   cfg.HistoryExpiry.Enabled,
+			Frequency: cfg.HistoryExpiry.Frequency,
+		}),
+		dingo.WithKoiosParity(dingo.KoiosParityConfig{
+			Enabled:    cfg.KoiosParity.Enabled,
+			Network:    cfg.KoiosParity.Network,
+			CachePath:  cfg.KoiosParity.CachePath,
+			APIKey:     cfg.KoiosParity.APIKey,
+			Strict:     cfg.KoiosParity.Strict,
+			GraceHours: cfg.KoiosParity.GraceHours,
+		}),
+		dingo.WithCORSAllowedOrigins(cfg.CORSAllowedOrigins),
+		dingo.WithOffchainMetadataConfig(
+			dingo.OffchainMetadataConfig{
+				Interval: cfg.OffchainMetadata.Interval,
+				RequestTimeout: cfg.OffchainMetadata.
+					RequestTimeout,
+				UserAgent: cfg.OffchainMetadata.UserAgent,
+				IPFSGatewayURL: cfg.OffchainMetadata.
+					IPFSGatewayURL,
+				BatchSize: cfg.OffchainMetadata.BatchSize,
+				MaxBytes:  cfg.OffchainMetadata.MaxBytes,
+				AllowPrivateAddresses: cfg.OffchainMetadata.
+					AllowPrivateAddresses,
+			},
+		),
+		dingo.WithMidnightConfig(dingo.MidnightConfig{
+			Enabled:                     cfg.Midnight.Enabled,
+			Port:                        cfg.Midnight.Port,
+			Host:                        cfg.Midnight.Host,
+			CNightPolicyID:              cfg.Midnight.CNightPolicyID,
+			CNightAssetName:             cfg.Midnight.CNightAssetName,
+			MappingValidatorAddress:     cfg.Midnight.MappingValidatorAddress,
+			AuthTokenPolicyID:           cfg.Midnight.AuthTokenPolicyID,
+			AuthTokenAssetName:          cfg.Midnight.AuthTokenAssetName,
+			CommitteeCandidateAddress:   cfg.Midnight.CommitteeCandidateAddress,
+			TechnicalCommitteeAddress:   cfg.Midnight.TechnicalCommitteeAddress,
+			TechnicalCommitteePolicyID:  cfg.Midnight.TechnicalCommitteePolicyID,
+			CouncilAddress:              cfg.Midnight.CouncilAddress,
+			CouncilPolicyID:             cfg.Midnight.CouncilPolicyID,
+			PermissionedCandidatePolicy: cfg.Midnight.PermissionedCandidatePolicy,
+		}),
+		dingo.WithValidateHistorical(cfg.ValidateHistorical),
+		dingo.WithStrictUtxoValidation(cfg.StrictUtxoValidation),
+		dingo.WithRunMode(string(cfg.RunMode)),
+		dingo.WithStartEra(string(cfg.StartEra)),
+		dingo.WithShutdownTimeout(shutdownTimeout),
+		// Enable metrics with default prometheus registry
+		dingo.WithPrometheusRegistry(prometheus.DefaultRegisterer),
+		dingo.WithTracing(cfg.Tracing),
+		dingo.WithTracingStdout(cfg.TracingStdout),
+		dingo.WithTopologyConfig(config.GetTopologyConfig()),
+		dingo.WithDatabaseWorkerPoolConfig(ledger.DatabaseWorkerPoolConfig{
+			WorkerPoolSize: cfg.DatabaseWorkers,
+			TaskQueueSize:  cfg.DatabaseQueueSize,
+			Disabled:       false,
+		}),
+		dingo.WithPeerTargets(
+			cfg.TargetNumberOfKnownPeers,
+			cfg.TargetNumberOfEstablishedPeers,
+			cfg.TargetNumberOfActivePeers,
+		),
+		dingo.WithGenesisBootstrap(cfg.GenesisBootstrap.Enabled),
+		dingo.WithGenesisWindowSlots(cfg.GenesisBootstrap.WindowSlots),
+		dingo.WithGenesisCorroborationPeers(
+			cfg.GenesisBootstrap.CorroborationPeers,
+		),
+		dingo.WithBootstrapPromotionMinDiversityGroups(
+			cfg.GenesisBootstrap.PromotionMinDiversityGroups,
+		),
+		dingo.WithActivePeersQuotas(
+			cfg.ActivePeersTopologyQuota,
+			cfg.ActivePeersGossipQuota,
+			cfg.ActivePeersLedgerQuota,
+		),
+		dingo.WithMinHotPeers(cfg.MinHotPeers),
+		dingo.WithReconcileInterval(cfg.ReconcileInterval),
+		dingo.WithInactivityTimeout(cfg.InactivityTimeout),
+		dingo.WithInboundPeerGovernance(
+			cfg.InboundWarmTarget,
+			cfg.InboundHotQuota,
+			cfg.InboundMinTenure,
+			cfg.InboundHotScoreThreshold,
+			cfg.InboundPruneAfter,
+			cfg.InboundDuplexOnlyForHot,
+			cfg.InboundCooldown,
+		),
+		dingo.WithMaxConnectionsPerIP(cfg.MaxConnectionsPerIP),
+		dingo.WithMaxInboundConns(cfg.MaxInboundConns),
+		dingo.WithCacheConfig(
+			cfg.Cache.BlockLRUEntries,
+			cfg.Cache.HotUtxoEntries,
+			cfg.Cache.HotTxEntries,
+			cfg.Cache.HotTxMaxBytes,
+		),
+		dingo.WithChainsyncMaxClients(
+			cfg.Chainsync.MaxClients,
+		),
+		dingo.WithChainsyncStallTimeout(
+			chainsyncStallTimeout,
+		),
+		dingo.WithChainsyncHeaderStrategy(
+			chainsyncStrategy,
+		),
+		dingo.WithBindAddr(cfg.BindAddr),
+		dingo.WithStorageMode(storageMode),
+		// CIP-23 minimum pool margin (consensus-affecting)
+		dingo.WithMinPoolMargin(cfg.MinPoolMargin),
+		// CIP-50 pledge-leverage staking rewards (consensus-affecting)
+		dingo.WithPledgeLeverage(
+			cfg.PledgeLeverageEnabled,
+			cfg.PledgeLeverage,
+		),
+		// CIP-0163 full-pot reward distribution (consensus-affecting)
+		dingo.WithFullPotRewards(cfg.FullPotRewardsEnabled),
+		dingo.WithUnsafeFullPotRewardsOnStandardNetworks(
+			cfg.UnsafeFullPotRewardsOnStandardNetworks,
+		),
+		// Block production (SPO mode)
+		dingo.WithBlockProducer(cfg.BlockProducer),
+		dingo.WithShelleyVRFKey(cfg.ShelleyVRFKey),
+		dingo.WithShelleyKESKey(cfg.ShelleyKESKey),
+		dingo.WithShelleyOperationalCertificate(
+			cfg.ShelleyOperationalCertificate,
+		),
+		dingo.WithForgeSyncToleranceSlots(
+			cfg.ForgeSyncToleranceSlots,
+		),
+		dingo.WithForgeStaleGapThresholdSlots(
+			cfg.ForgeStaleGapThresholdSlots,
+		),
+		dingo.WithValidateForgedBlock(cfg.ValidateForgedBlock),
+		// CIP-0163 reward-account inactivity expiry (consensus-affecting)
+		dingo.WithDelegatorInactivity(
+			cfg.DelegatorInactivityEnabled,
+			cfg.DelegatorInactivity,
+		),
+		dingo.WithDatabaseLifecycle(cfg.DatabaseLifecycle),
+		// Leios voting (experimental)
+		dingo.WithLeiosVoteSigningKeyFile(
+			cfg.LeiosVoteSigningKeyFile,
+		),
+		dingo.WithLeiosVoterPublicKeys(cfg.LeiosVoterPublicKeys),
+	)
 }

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -24,6 +24,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/blinklabs-io/dingo"
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/config"
 )
 
 func TestWaitForSignalOrErrorPrefersQueuedError(t *testing.T) {
@@ -157,5 +162,63 @@ func TestShutdownNodeResourcesReturnsNilWithoutErrors(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("expected nil shutdown error, got %v", err)
+	}
+}
+
+// TestBuildDingoConfigWiresAPIConfig asserts that a loaded
+// internal/config.Config's api.tls/api.auth policy (as set via YAML/env/CLI)
+// actually reaches the dingo.Config that Run() hands to dingo.New() --
+// regression test for the top-level API security defaults (dingo#2998)
+// being silently dropped because Run's real composition call never invoked
+// dingo.WithAPIConfig.
+func TestBuildDingoConfigWiresAPIConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		API: config.APIConfig{
+			TLS: apiconfig.TLSPolicy{
+				Mode:         new("server"),
+				CertFilePath: new("/shared/cert.pem"),
+				KeyFilePath:  new("/shared/key.pem"),
+			},
+			Auth: apiconfig.AuthPolicy{
+				Mode:  new("token"),
+				Token: new("shared-secret"),
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(new(bytes.Buffer), nil))
+
+	built := buildDingoConfig(
+		cfg,
+		logger,
+		nil,
+		nil,
+		false,
+		dingo.StorageModeCore,
+		30*time.Second,
+		chainsync.DefaultStallTimeout,
+		chainsync.HeaderSyncStrategyPrimary,
+	)
+
+	got := built.APIConfig()
+	if got.TLS.Mode == nil || *got.TLS.Mode != "server" {
+		t.Fatalf("expected api.tls.mode to flow through, got %+v", got.TLS)
+	}
+	if got.TLS.CertFilePath == nil ||
+		*got.TLS.CertFilePath != "/shared/cert.pem" {
+		t.Fatalf(
+			"expected api.tls.certFilePath to flow through, got %+v",
+			got.TLS,
+		)
+	}
+	if got.Auth.Mode == nil || *got.Auth.Mode != "token" {
+		t.Fatalf("expected api.auth.mode to flow through, got %+v", got.Auth)
+	}
+	if got.Auth.Token == nil || *got.Auth.Token != "shared-secret" {
+		t.Fatalf(
+			"expected api.auth.token to flow through, got %+v",
+			got.Auth,
+		)
 	}
 }

--- a/internal/test/testutil/tls.go
+++ b/internal/test/testutil/tls.go
@@ -18,11 +18,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +32,38 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// BindAttempts bounds how many ports a test tries before giving up when
+// racing another process for a loopback port (see FreePort). Shared by
+// every built-in API provider's TLS/auth test suite (Blockfrost, Mesh,
+// UTxO RPC).
+const BindAttempts = 8
+
+// FreePort reserves a loopback port and releases it, returning the bound
+// address ("host:port"). The port is not guaranteed to still be free when
+// the caller binds it -- retry up to BindAttempts times instead of treating
+// one bind failure as a test failure.
+func FreePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// InsecureHTTPClient returns an *http.Client that skips TLS certificate
+// verification, for exercising a listener's throwaway self-signed test
+// certificate (see GenerateTestTLSCertKey).
+func InsecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // test-only, throwaway self-signed server cert
+			},
+		},
+	}
+}
 
 // GenerateTestTLSCertKey generates a throwaway self-signed certificate/key
 // pair valid for 127.0.0.1 and writes them as PEM files under a fresh

--- a/internal/test/testutil/tls.go
+++ b/internal/test/testutil/tls.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GenerateTestTLSCertKey generates a throwaway self-signed certificate/key
+// pair valid for 127.0.0.1 and writes them as PEM files under a fresh
+// t.TempDir(), returning their paths. Used to exercise a listener's TLS
+// startup path (Blockfrost, Mesh, UTxORPC, Bark) without depending on any
+// fixed certificate checked into the repo.
+func GenerateTestTLSCertKey(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(
+		rand.Reader, template, template, &priv.PublicKey, priv,
+	)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+
+	certOut, err := os.Create(certPath)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}),
+	)
+	require.NoError(t, certOut.Close())
+
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyOut, err := os.OpenFile(
+		keyPath,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		0o600,
+	)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}),
+	)
+	require.NoError(t, keyOut.Close())
+
+	return certPath, keyPath
+}

--- a/internal/tlsutil/tls.go
+++ b/internal/tlsutil/tls.go
@@ -82,10 +82,13 @@ func ConfigureServerTLS(
 		return fmt.Errorf("loading TLS keypair: %w", err)
 	}
 	server.TLSConfig = ServerConfig(server.TLSConfig)
-	server.TLSConfig.Certificates = append(
-		server.TLSConfig.Certificates,
-		cert,
-	)
+	// Assign a fresh single-element slice rather than appending: every
+	// caller loads exactly one keypair, and appending to whatever
+	// Certificates already held could silently accumulate a stale entry
+	// (from a reused/reinitialized *http.Server or a pre-populated
+	// TLSConfig) alongside the new one, letting Go's SNI cert selection
+	// pick the wrong certificate.
+	server.TLSConfig.Certificates = []tls.Certificate{cert}
 	return nil
 }
 

--- a/internal/tlsutil/tls.go
+++ b/internal/tlsutil/tls.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"os"
 )
 
@@ -60,6 +61,32 @@ func ServerConfig(config *tls.Config) *tls.Config {
 		}
 	}
 	return config
+}
+
+// ConfigureServerTLS loads the certificate/key pair at certFilePath/
+// keyFilePath and installs it on server's TLSConfig (creating one via
+// ServerConfig if server.TLSConfig is nil), applying the shared minimum
+// TLS version floor. It is the single keypair-loading implementation
+// shared by every built-in API provider (Blockfrost, Mesh, UTxORPC),
+// replacing what was previously duplicated tls.LoadX509KeyPair-plus-floor
+// logic per provider. Callers must still call server.ServeTLS (not
+// Serve) after this returns successfully -- this only prepares the
+// config, it does not decide whether the caller wants a TLS listener at
+// all (see EffectiveTLS.Enabled in package apiconfig).
+func ConfigureServerTLS(
+	server *http.Server,
+	certFilePath, keyFilePath string,
+) error {
+	cert, err := tls.LoadX509KeyPair(certFilePath, keyFilePath)
+	if err != nil {
+		return fmt.Errorf("loading TLS keypair: %w", err)
+	}
+	server.TLSConfig = ServerConfig(server.TLSConfig)
+	server.TLSConfig.Certificates = append(
+		server.TLSConfig.Certificates,
+		cert,
+	)
+	return nil
 }
 
 // LoadClientCAPool reads a PEM-encoded CA bundle from path and returns an

--- a/internal/tlsutil/tls_test.go
+++ b/internal/tlsutil/tls_test.go
@@ -16,8 +16,10 @@ package tlsutil
 
 import (
 	"crypto/tls"
+	"net/http"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -141,4 +143,32 @@ func TestServerConfig_GetConfigForClientNilResult(t *testing.T) {
 	selected, err := config.GetConfigForClient(&tls.ClientHelloInfo{})
 	require.NoError(t, err)
 	require.Nil(t, selected)
+}
+
+// TestConfigureServerTLSReplacesRatherThanAccumulatesCertificates verifies
+// that a server whose TLSConfig.Certificates is already populated (e.g. a
+// reused/reinitialized *http.Server, or one an earlier call already
+// configured) ends up with exactly the newly loaded certificate afterward,
+// not the old one(s) plus the new one. Accumulating stale entries could let
+// Go's SNI cert selection pick the wrong (old) certificate.
+func TestConfigureServerTLSReplacesRatherThanAccumulatesCertificates(
+	t *testing.T,
+) {
+	certPath, keyPath := testutil.GenerateTestTLSCertKey(t)
+	staleCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	require.NoError(t, err)
+
+	server := &http.Server{
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{staleCert, staleCert},
+		},
+	}
+
+	require.NoError(t, ConfigureServerTLS(server, certPath, keyPath))
+	require.Len(t, server.TLSConfig.Certificates, 1)
+
+	// A second call (simulating a restart/reinitialization) must still
+	// leave exactly one certificate, not accumulate further.
+	require.NoError(t, ConfigureServerTLS(server, certPath, keyPath))
+	require.Len(t, server.TLSConfig.Certificates, 1)
 }

--- a/node.go
+++ b/node.go
@@ -39,6 +39,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/nodesettings"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/internal/chainsyncrecycler"
 	internalconfig "github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/dblifecycle"
@@ -175,6 +176,24 @@ func New(cfg Config) (*Node, error) {
 		destinationRegistry: destinationRegistry,
 	}
 	for capability, selection := range cfg.pluginSelections {
+		// API capabilities are validated against their *merged* config
+		// (shared api.tls/api.auth defaults folded in) so an invalid
+		// effective TLS/auth policy -- e.g. a partial certificate/key
+		// pair -- is rejected here, before any listener starts, using
+		// the exact same merge apiPluginSelection applies at Start()/
+		// reinitializeAPIServers time. See apiProviderConfig.
+		if configPath, ok := apiProviderConfigPath[capability]; ok {
+			var err error
+			selection, err = cfg.apiProviderConfig(capability, selection)
+			if err != nil {
+				return nil, fmt.Errorf("invalid plugin selection: %w", err)
+			}
+			if err := validateAPIProviderSecurityPolicy(
+				configPath, selection.Config,
+			); err != nil {
+				return nil, fmt.Errorf("invalid plugin selection: %w", err)
+			}
+		}
 		if err := pluginHost.ValidateSelection(
 			capability, selection.Provider, selection.Config,
 		); err != nil {
@@ -212,6 +231,98 @@ func New(cfg Config) (*Node, error) {
 	return n, nil
 }
 
+// legacyUtxorpcTLSPolicy expresses the pre-#2996 root tlsCertFilePath/
+// tlsKeyFilePath fields as an apiconfig.TLSPolicy, for UTxORPC only. It
+// deliberately does not feed cfg.apiConfig.TLS (the shared api.tls default
+// every provider inherits from): UTxORPC was the only provider these root
+// fields ever configured TLS for, and promoting them to a shared default
+// would silently switch Blockfrost/Mesh from plaintext to TLS on upgrade
+// for any deployment that set them, breaking existing plaintext clients.
+// See ARCHITECTURE.md's "API security" section for this compatibility
+// decision. Returns the zero TLSPolicy (no effect on the merge) unless
+// both root fields are set.
+func legacyUtxorpcTLSPolicy(cfg *Config) apiconfig.TLSPolicy {
+	if cfg.tlsCertFilePath == "" || cfg.tlsKeyFilePath == "" {
+		return apiconfig.TLSPolicy{}
+	}
+	mode := string(apiconfig.TLSModeServer)
+	return apiconfig.TLSPolicy{
+		Mode:         &mode,
+		CertFilePath: &cfg.tlsCertFilePath,
+		KeyFilePath:  &cfg.tlsKeyFilePath,
+	}
+}
+
+// apiProviderConfig merges the shared api.tls/api.auth policy (and, for
+// UTxORPC only, the legacy root TLS compatibility fields) into selection's
+// own "tls"/"auth" config sections, field by field, and returns the result.
+// It is the single place this merge happens, called both by the early
+// plugin-selection validation in New() and by apiPluginSelection, so a
+// provider config validated at startup and the one actually resolved at
+// Start()/reinitializeAPIServers time can never diverge.
+func (c *Config) apiProviderConfig(
+	capability plugin.Capability,
+	selection plugin.Selection,
+) (plugin.Selection, error) {
+	var legacyTLS apiconfig.TLSPolicy
+	if capability == plugin.CapabilityAPIUtxorpc {
+		legacyTLS = legacyUtxorpcTLSPolicy(c)
+	}
+	merged, err := apiconfig.MergeProviderConfig(
+		selection.Config,
+		legacyTLS,
+		c.apiConfig.TLS,
+		c.apiConfig.Auth,
+	)
+	if err != nil {
+		return selection, fmt.Errorf(
+			"merge api security policy for capability %s: %w",
+			capability, err,
+		)
+	}
+	selection.Config = merged
+	return selection, nil
+}
+
+// apiProviderConfigPath maps each API capability to the dotted config path
+// its provider config lives at, for error messages -- see
+// validateAPIProviderSecurityPolicy and each provider's own
+// cfg.TLS.Resolve/cfg.Auth.Resolve call, which use the identical path.
+var apiProviderConfigPath = map[plugin.Capability]string{
+	plugin.CapabilityAPIBlockfrost: "plugins.api.blockfrost.config",
+	plugin.CapabilityAPIMesh:       "plugins.api.mesh.config",
+	plugin.CapabilityAPIUtxorpc:    "plugins.api.utxorpc.config",
+}
+
+// validateAPIProviderSecurityPolicy resolves and validates the merged
+// tls/auth sections of an API provider's config (already merged with the
+// shared api.tls/api.auth defaults by apiProviderConfig), surfacing a
+// partial certificate/key pair or an invalid mode before any listener
+// starts -- the same validation each provider's own RegisterProvider
+// factory performs at Resolve()/Start() time, run here again so New()
+// itself rejects it at construction, before Run() ever attempts to start
+// a listener.
+func validateAPIProviderSecurityPolicy(
+	configPath string,
+	rawConfig map[string]any,
+) error {
+	tlsPolicy, err := apiconfig.DecodeTLSPolicy(rawConfig)
+	if err != nil {
+		return fmt.Errorf("%s.tls: %w", configPath, err)
+	}
+	if _, err := tlsPolicy.Resolve(configPath + ".tls"); err != nil {
+		return err
+	}
+	authPolicy, err := apiconfig.DecodeAuthPolicy(rawConfig)
+	if err != nil {
+		return fmt.Errorf("%s.auth: %w", configPath, err)
+	}
+	if _, err := authPolicy.Resolve(configPath + ".auth"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (n *Node) apiPluginSelection(
 	capability plugin.Capability,
 ) (plugin.Selection, uint, error) {
@@ -227,6 +338,13 @@ func (n *Node) apiPluginSelection(
 			"plugin provider is empty for capability %s",
 			capability,
 		)
+	}
+	if _, ok := apiProviderConfigPath[capability]; ok {
+		var err error
+		selection, err = n.config.apiProviderConfig(capability, selection)
+		if err != nil {
+			return selection, 0, err
+		}
 	}
 	portValue, ok := selection.Config["port"]
 	if !ok {
@@ -1317,8 +1435,6 @@ func (n *Node) Run(ctx context.Context) error {
 				Logger: n.config.logger, EventBus: n.eventBus,
 				LedgerState: n.ledgerState, Mempool: n.mempool,
 				Host:               n.config.bindAddr,
-				TLSCertFilePath:    n.config.tlsCertFilePath,
-				TLSKeyFilePath:     n.config.tlsKeyFilePath,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
 			},
 		)

--- a/node_api_security_test.go
+++ b/node_api_security_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	internalconfig "github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:fix inline
+func strPtr(s string) *string { return new(s) }
+
+// TestAPIProviderConfigMergesTopLevelDefault asserts a provider selection
+// with no tls/auth of its own inherits the shared api.tls/api.auth
+// policy.
+func TestAPIProviderConfigMergesTopLevelDefault(t *testing.T) {
+	cfg := Config{
+		apiConfig: internalconfig.APIConfig{
+			TLS: apiconfig.TLSPolicy{
+				Mode:         new("server"),
+				CertFilePath: new("/shared/cert.pem"),
+				KeyFilePath:  new("/shared/key.pem"),
+			},
+		},
+	}
+	selection := plugin.Selection{
+		Provider: "builtin",
+		Config:   map[string]any{"port": uint(3000)},
+	}
+
+	merged, err := cfg.apiProviderConfig(
+		plugin.CapabilityAPIBlockfrost, selection,
+	)
+	require.NoError(t, err)
+
+	tlsPolicy, err := apiconfig.DecodeTLSPolicy(merged.Config)
+	require.NoError(t, err)
+	effective, err := tlsPolicy.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	assert.Equal(t, "/shared/cert.pem", effective.CertFilePath)
+	assert.Equal(t, "/shared/key.pem", effective.KeyFilePath)
+}
+
+// TestAPIProviderConfigProviderOverrideWins asserts an explicit provider
+// field beats the shared top-level default for that field only.
+func TestAPIProviderConfigProviderOverrideWins(t *testing.T) {
+	cfg := Config{
+		apiConfig: internalconfig.APIConfig{
+			TLS: apiconfig.TLSPolicy{
+				Mode:         new("server"),
+				CertFilePath: new("/shared/cert.pem"),
+				KeyFilePath:  new("/shared/key.pem"),
+			},
+		},
+	}
+	selection := plugin.Selection{
+		Provider: "builtin",
+		Config: map[string]any{
+			"port": uint(3000),
+			"tls": map[string]any{
+				"certFilePath": "/provider/cert.pem",
+			},
+		},
+	}
+
+	merged, err := cfg.apiProviderConfig(
+		plugin.CapabilityAPIBlockfrost, selection,
+	)
+	require.NoError(t, err)
+
+	tlsPolicy, err := apiconfig.DecodeTLSPolicy(merged.Config)
+	require.NoError(t, err)
+	effective, err := tlsPolicy.Resolve("test")
+	require.NoError(t, err)
+	assert.True(t, effective.Enabled)
+	assert.Equal(t, "/provider/cert.pem", effective.CertFilePath)
+	// keyFilePath falls through to the shared default.
+	assert.Equal(t, "/shared/key.pem", effective.KeyFilePath)
+}
+
+// TestAPIProviderConfigExplicitDisableOverridesInherited asserts a
+// provider can turn off an inherited auth policy explicitly.
+func TestAPIProviderConfigExplicitDisableOverridesInherited(t *testing.T) {
+	cfg := Config{
+		apiConfig: internalconfig.APIConfig{
+			Auth: apiconfig.AuthPolicy{
+				Mode:  new("token"),
+				Token: new("shared-secret"),
+			},
+		},
+	}
+	selection := plugin.Selection{
+		Provider: "builtin",
+		Config: map[string]any{
+			"port": uint(8080),
+			"auth": map[string]any{"mode": "disabled"},
+		},
+	}
+
+	merged, err := cfg.apiProviderConfig(plugin.CapabilityAPIMesh, selection)
+	require.NoError(t, err)
+
+	authPolicy, err := apiconfig.DecodeAuthPolicy(merged.Config)
+	require.NoError(t, err)
+	effective, err := authPolicy.Resolve("test")
+	require.NoError(t, err)
+	assert.False(t, effective.Enabled)
+}
+
+// TestLegacyUtxorpcTLSPolicyIsUtxorpcOnly asserts the legacy root
+// tlsCertFilePath/tlsKeyFilePath compatibility fields feed only UTxORPC's
+// default TLS policy, never Blockfrost's or Mesh's -- promoting them to
+// every API provider would silently switch previously-plaintext listeners
+// to TLS on upgrade for any deployment that had set them (see
+// legacyUtxorpcTLSPolicy's own doc comment).
+func TestLegacyUtxorpcTLSPolicyIsUtxorpcOnly(t *testing.T) {
+	cfg := Config{
+		tlsCertFilePath: "/legacy/cert.pem",
+		tlsKeyFilePath:  "/legacy/key.pem",
+	}
+	selection := plugin.Selection{
+		Provider: "builtin",
+		Config:   map[string]any{"port": uint(9090)},
+	}
+
+	for _, tc := range []struct {
+		capability   plugin.Capability
+		wantEnabled  bool
+		wantCertPath string
+	}{
+		{plugin.CapabilityAPIUtxorpc, true, "/legacy/cert.pem"},
+		{plugin.CapabilityAPIBlockfrost, false, ""},
+		{plugin.CapabilityAPIMesh, false, ""},
+	} {
+		merged, err := cfg.apiProviderConfig(tc.capability, selection)
+		require.NoErrorf(t, err, "capability %s", tc.capability)
+		tlsPolicy, err := apiconfig.DecodeTLSPolicy(merged.Config)
+		require.NoErrorf(t, err, "capability %s", tc.capability)
+		effective, err := tlsPolicy.Resolve("test")
+		require.NoErrorf(t, err, "capability %s", tc.capability)
+		assert.Equalf(
+			t, tc.wantEnabled, effective.Enabled,
+			"capability %s", tc.capability,
+		)
+		assert.Equalf(
+			t, tc.wantCertPath, effective.CertFilePath,
+			"capability %s", tc.capability,
+		)
+	}
+}
+
+// TestLegacyUtxorpcTLSPolicyYieldsToExplicitPolicy asserts the shared
+// api.tls default and any provider-level override both still take
+// precedence over the legacy compatibility fields for UTxORPC, matching
+// the canonical-over-compatibility precedence used elsewhere (e.g.
+// applyAPIPortCompatibilityEnvironment).
+func TestLegacyUtxorpcTLSPolicyYieldsToExplicitPolicy(t *testing.T) {
+	cfg := Config{
+		tlsCertFilePath: "/legacy/cert.pem",
+		tlsKeyFilePath:  "/legacy/key.pem",
+		apiConfig: internalconfig.APIConfig{
+			TLS: apiconfig.TLSPolicy{Mode: new("disabled")},
+		},
+	}
+	selection := plugin.Selection{
+		Provider: "builtin",
+		Config:   map[string]any{"port": uint(9090)},
+	}
+
+	merged, err := cfg.apiProviderConfig(
+		plugin.CapabilityAPIUtxorpc, selection,
+	)
+	require.NoError(t, err)
+	tlsPolicy, err := apiconfig.DecodeTLSPolicy(merged.Config)
+	require.NoError(t, err)
+	effective, err := tlsPolicy.Resolve("test")
+	require.NoError(t, err)
+	assert.False(t, effective.Enabled)
+}
+
+// TestNewRejectsInvalidMergedAPITLSPolicy asserts a partial certificate/
+// key pair in the shared api.tls default is rejected at New(), before any
+// listener starts -- not merely logged or deferred to Start() time.
+func TestNewRejectsInvalidMergedAPITLSPolicy(t *testing.T) {
+	cardanoCfg := newNodeTestCardanoNodeCfg(t)
+	_, err := New(NewConfig(
+		WithDatabasePath(t.TempDir()),
+		WithCardanoNodeConfig(cardanoCfg),
+		WithNetworkMagic(cardanoCfg.ShelleyGenesis().NetworkMagic),
+		WithPrometheusRegistry(prometheus.NewRegistry()),
+		WithStorageMode(StorageModeAPI),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithMidnightConfig(MidnightConfig{Port: 0}),
+		WithShutdownTimeout(5*time.Second),
+		WithAPIConfig(internalconfig.APIConfig{
+			TLS: apiconfig.TLSPolicy{
+				Mode:         new("server"),
+				CertFilePath: new("/only/cert.pem"),
+			},
+		}),
+	))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config.tls")
+	assert.Contains(t, err.Error(), "must both be set")
+}
+
+// TestNewRejectsInvalidAPIAuthMode asserts an invalid auth mode is
+// likewise rejected at New().
+func TestNewRejectsInvalidAPIAuthMode(t *testing.T) {
+	cardanoCfg := newNodeTestCardanoNodeCfg(t)
+	_, err := New(NewConfig(
+		WithDatabasePath(t.TempDir()),
+		WithCardanoNodeConfig(cardanoCfg),
+		WithNetworkMagic(cardanoCfg.ShelleyGenesis().NetworkMagic),
+		WithPrometheusRegistry(prometheus.NewRegistry()),
+		WithStorageMode(StorageModeAPI),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithMidnightConfig(MidnightConfig{Port: 0}),
+		WithShutdownTimeout(5*time.Second),
+		WithAPIConfig(internalconfig.APIConfig{
+			Auth: apiconfig.AuthPolicy{Mode: new("bogus")},
+		}),
+	))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config.auth")
+	assert.Contains(t, err.Error(), "invalid mode")
+}

--- a/node_api_security_test.go
+++ b/node_api_security_test.go
@@ -26,9 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//go:fix inline
-func strPtr(s string) *string { return new(s) }
-
 // TestAPIProviderConfigMergesTopLevelDefault asserts a provider selection
 // with no tls/auth of its own inherits the shared api.tls/api.auth
 // policy.

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -1043,8 +1043,6 @@ func (n *Node) reinitializeAPIServers() error {
 				Logger: n.config.logger, EventBus: n.eventBus,
 				LedgerState: n.ledgerState, Mempool: n.mempool,
 				Host:               n.config.bindAddr,
-				TLSCertFilePath:    n.config.tlsCertFilePath,
-				TLSKeyFilePath:     n.config.tlsKeyFilePath,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
 			},
 		)


### PR DESCRIPTION
Closes #2996
Closes #2998

Adds a uniform per-plugin TLS and authentication surface for the Blockfrost, Mesh, and UTxORPC API plugins (#2996), backed by a shared `internal/tlsutil`, `internal/apiauth` (HTTP + Connect middleware), and `internal/apiconfig` merge layer.

On top of that, adds top-level `api.tls` / `api.auth` security-defaults config (#2998) that merges into each plugin's config with field-by-field override and explicit-disable semantics, while preserving the existing legacy TLS/auth fields on UTxORPC for backward compatibility.

## Acceptance criteria coverage
- Uniform TLS config surface (cert/key/client-CA/mTLS) available identically on Blockfrost, Mesh, and UTxORPC plugin configs.
- Uniform auth surface (bearer token / basic auth, as applicable per transport) available identically across the three plugins.
- Top-level `api.tls` and `api.auth` act as defaults; any field set explicitly at the plugin level overrides the corresponding top-level default.
- A plugin can explicitly disable TLS or auth even when top-level defaults enable it.
- Legacy UTxORPC-specific TLS/auth fields keep working unchanged for existing configs.

## Deliberately out of scope (flagging for reviewers)
- No per-provider `bindAddr` override under `plugins.api.<name>.config` — bind address remains governed by existing top-level/plugin wiring, unrelated to the TLS/auth surface being added here.
- Provider-level `tls`/`auth` overrides are YAML-only; they are not addressable through the generic env-var flattening mechanism, since these are nested struct fields rather than flat scalars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a uniform TLS/auth configuration for all built-in API providers and top-level security defaults, now applied at runtime by the node. Backwards compatible with existing UTxO RPC configs.

- **New Features**
  - Unified per-plugin TLS/auth for `blockfrost`, `mesh`, and `utxorpc` via `internal/apiconfig`, `internal/apiauth` (HTTP + Connect), and `internal/tlsutil`.
  - Top-level `api.tls` and `api.auth` defaults merge into each `plugins.api.<name>.config` with field-level overrides and explicit per-provider disable; merged policies are validated before listeners start.
  - Token auth supported with a shared verifier; Blockfrost `project_id` header is accepted as a bearer alias; new CLI flags `--api-tls-*` and `--api-auth-*`.

- **Bug Fixes**
  - Wired `api.tls`/`api.auth` into the real startup path (`dingo.WithAPIConfig`) so defaults take effect at runtime.
  - Improved auth handling: `Token`/`TokenFilePath` are treated as one source, and bearer/`project_id` values are trimmed before comparison.
  - `tlsutil.ConfigureServerTLS` now replaces (not accumulates) certificates to avoid stale cert selection.
  - Suppressed env auto-binding of inline tokens to avoid leaking secrets; prefer token files or YAML.

<sup>Written for commit 57a124a851bb08fc643ec512ef1dd040b64e2a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared TLS and authentication configuration for UTxO RPC, Blockfrost, and Mesh APIs.
  * Supports bearer-token authentication, Blockfrost project-ID credentials, token files, and provider-specific overrides.
  * Added HTTPS support with configurable certificates and keys.
  * CORS preflight requests continue to work without authentication.
* **Bug Fixes**
  * Invalid security settings are now detected during startup with clearer validation errors.
  * Authentication secrets are excluded from logs.
* **Documentation**
  * Expanded configuration and security guidance, including defaults and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->