### PR TITLE
fix(config): name the offending file in YAML parse errors, guard example config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1177,7 +1177,11 @@ func LoadConfig(configFile string) (*Config, error) {
 
 		var root map[string]yaml.Node
 		if err := yaml.Unmarshal(buf, &root); err != nil {
-			return nil, fmt.Errorf("error parsing config file: %w", err)
+			return nil, fmt.Errorf(
+				"error parsing config file %s: %w",
+				configFile,
+				err,
+			)
 		}
 		if _, wrapped := root["config"]; wrapped {
 			tempCfg := tempConfig{Config: cfg}
@@ -1185,7 +1189,11 @@ func LoadConfig(configFile string) (*Config, error) {
 			decoder.KnownFields(true)
 			if err := decoder.Decode(&tempCfg); err != nil &&
 				!errors.Is(err, io.EOF) {
-				return nil, fmt.Errorf("error parsing config section: %w", err)
+				return nil, fmt.Errorf(
+					"error parsing config section in %s: %w",
+					configFile,
+					err,
+				)
 			}
 			if tempCfg.Config == nil {
 				return nil, errors.New("config section must be a mapping")
@@ -1194,7 +1202,11 @@ func LoadConfig(configFile string) (*Config, error) {
 			decoder := yaml.NewDecoder(bytes.NewReader(buf))
 			decoder.KnownFields(true)
 			if err := decoder.Decode(cfg); err != nil && !errors.Is(err, io.EOF) {
-				return nil, fmt.Errorf("error parsing config file: %w", err)
+				return nil, fmt.Errorf(
+					"error parsing config file %s: %w",
+					configFile,
+					err,
+				)
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1196,7 +1196,10 @@ func LoadConfig(configFile string) (*Config, error) {
 				)
 			}
 			if tempCfg.Config == nil {
-				return nil, errors.New("config section must be a mapping")
+				return nil, fmt.Errorf(
+					"config section in %s must be a mapping",
+					configFile,
+				)
 			}
 		} else {
 			decoder := yaml.NewDecoder(bytes.NewReader(buf))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1899,4 +1900,69 @@ func TestLoad_ExampleConfigParses(t *testing.T) {
 		"dingo.yaml.example must parse cleanly as shipped",
 	)
 	require.NotNil(t, cfg)
+}
+
+// TestLoad_ParseErrorIncludesConfigFilePath guards the error-message
+// behavior introduced alongside TestLoad_ExampleConfigParses: every parse
+// failure path in LoadConfig must name the resolved config file so a
+// regression that drops configFile from one of the error wraps is caught.
+func TestLoad_ParseErrorIncludesConfigFilePath(t *testing.T) {
+	t.Run("invalid YAML syntax", func(t *testing.T) {
+		resetGlobalConfig()
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "bad-syntax.yaml")
+		yamlContent := "network: mainnet\n  badIndent: true\n"
+
+		err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+		if err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		_, err = LoadConfig(tmpFile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), tmpFile)
+	})
+
+	t.Run("wrapped config section decode error", func(t *testing.T) {
+		resetGlobalConfig()
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "bad-wrapped-decode.yaml")
+		yamlContent := `
+config:
+  network: mainnet
+  unknownField: true
+`
+
+		err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+		if err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		_, err = LoadConfig(tmpFile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), tmpFile)
+	})
+
+	t.Run("wrapped config section is nil", func(t *testing.T) {
+		resetGlobalConfig()
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "nil-config-section.yaml")
+		yamlContent := "config:\n"
+
+		err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
+		if err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		_, err = LoadConfig(tmpFile)
+		require.Error(t, err)
+		expected := fmt.Sprintf(
+			"config section in %s must be a mapping",
+			tmpFile,
+		)
+		assert.Equal(t, expected, err.Error())
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1863,4 +1864,39 @@ func TestGetConfigSnapshotDoesNotShareNestedPluginConfig(t *testing.T) {
 		globalConfig.Plugins.Mempool.Config["nested"].(map[string]any)["inner"],
 		"mutating a snapshot must not reach globalConfig",
 	)
+}
+
+// exampleConfigPath returns the path to the repo's bundled
+// dingo.yaml.example, independent of the working directory the test binary
+// runs from.
+func exampleConfigPath() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(
+		filepath.Dir(thisFile),
+		"..",
+		"..",
+		"dingo.yaml.example",
+	)
+}
+
+// TestLoad_ExampleConfigParses guards against regressions like #3169, where
+// a single mis-indented line in dingo.yaml.example (the default config
+// shipped to operators) produced a YAML syntax error on startup with no
+// indication of which field was affected. Any change to dingo.yaml.example
+// must keep it loadable as-is.
+func TestLoad_ExampleConfigParses(t *testing.T) {
+	resetGlobalConfig()
+
+	path := exampleConfigPath()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("dingo.yaml.example not found at %s: %v", path, err)
+	}
+
+	cfg, err := LoadConfig(path)
+	require.NoError(
+		t,
+		err,
+		"dingo.yaml.example must parse cleanly as shipped",
+	)
+	require.NotNil(t, cfg)
 }


### PR DESCRIPTION
Closes #3169

## Issue

#3169 reports a "Default configuration failure": loading the bundled `dingo.yaml.example` on v0.69.0 fails with

```
error parsing config file: yaml: line 213: did not find expected key
```

pointing at a comment line near the `koiosParity` config section.

## Investigation

The shipped `dingo.yaml.example` was verified byte-for-byte against the v0.69.0 tag and is consistently 2-space indented — there is no defect in the file as released. The most likely explanation is a one-space indentation slip in the reporter's own local copy of the config: YAML parsers commonly attribute a bad-indentation error to the line *preceding* a malformed mapping key, which is why an innocuous comment line looked like the culprit in the report.

This PR does not confirm the reporter's exact root cause (their config diff would settle that) — it mitigates the failure mode and adds a regression guard. Recommend asking the reporter to share their config diff before closing #3169, to confirm the one-space-indentation theory.

## Changes

- `internal/config/config.go`: the three YAML-parse-error wrap sites in `LoadConfig` now include the resolved config file path in the error message (e.g. `error parsing config file %s: %w`), so a parse failure names which file is bad rather than returning a bare error.
- `internal/config/config_test.go`: adds `TestLoad_ExampleConfigParses`, which loads the real shipped `dingo.yaml.example` through `LoadConfig` and asserts it parses cleanly, guarding against a single mis-indented line ever shipping broken in the bundled example again.

## Testing

- `go build ./...`
- `go test ./internal/config/... -race`
- `golangci-lint run ./...`
- `nilaway ./...`
- `modernize ./...`
- `make import-boundaries`
- `make golines`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the offending file in YAML parse errors and guards the bundled example config. Previously, parse errors omitted the file path; now all `LoadConfig` parse failures include the resolved path, including the "config section must be a mapping" case.

- Wrap YAML unmarshal/decode and nil config-section errors in `LoadConfig` to include the config file path (e.g., "error parsing config file <path>", "error parsing config section in <path>", and "config section in <path> must be a mapping").
- Add `TestLoad_ExampleConfigParses` to assert the repo’s `dingo.yaml.example` loads via `LoadConfig`.
- Add `TestLoad_ParseErrorIncludesConfigFilePath` to ensure every parse-error path includes the file path.
- Note: error message text changed; update any callers/tests that match exact strings.

<sup>Written for commit 1dfc394a208afaa317b6715e9c2818cd2085bedd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration parsing errors now identify the specific file that caused the failure while preserving the original error details.

* **Tests**
  * Added coverage confirming the bundled example configuration exists and loads successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->