### PR TITLE
test(devnet): add cross-node ledger-state comparison in conformance mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1788,10 +1788,12 @@ from the database; proposal results reconstruct the on-wire proposal procedure
 from the persisted action CBOR, return address, deposit, anchor, and votes.
 Supported query leaves also include epoch number, current protocol parameters,
 Shelley genesis configuration, UTxO-by-address/transaction-input lookups,
-stake-delegation deposits, the ledger peer snapshot, stake pools, DRep state,
-and account state. `GetCBOR` is a query combinator: it re-runs the wrapped
-inner query through the same dispatch path and returns the result as a tag-24
-CBOR-in-CBOR `Serialised` value, matching cardano-node. `GetStakeSnapshots`
+the whole live UTxO set (`GetUTxOWhole`), stake-delegation deposits, the
+ledger peer snapshot, stake pools, DRep state, account state, and the
+unfiltered stake distribution (`GetStakeDistribution`). `GetCBOR` is a query
+combinator: it re-runs the wrapped inner query through the same dispatch path
+and returns the result as a tag-24 CBOR-in-CBOR `Serialised` value, matching
+cardano-node. `GetStakeSnapshots`
 returns the mark/set/go stake for each requested pool and the corresponding
 totals. For protocol version 11 and later, requested pools whose mark, set,
 and go stake are all zero are omitted; without a pool filter, the result
@@ -1864,6 +1866,24 @@ counter whose issuer key is not a pool key hash. Omitting a pool leaves the
 reported fractions summing to slightly under one, since its stake stays in
 `TotalActiveStake`; a caller checking its own leadership is unaffected, because
 its own fraction is its stake over that same unchanged total.
+
+`GetStakeDistribution` (`ledger/queries_stakedistribution.go`) and
+`GetUTxOWhole` (`ledger/queries_utxowhole.go`) close out two entries of the
+`// TODO (#394)` block in `ledger/queries.go`'s query dispatcher; the rest of
+that block remains unimplemented. `GetStakeDistribution` reads the same
+`PoolStakeDistribution` helper as `GetPoolDistr2` with no pool filter (this
+query has none on the wire, unlike `GetPoolDistr2`), so it cannot report a
+different snapshot or VRF key for the same chain than `GetPoolDistr2` or the
+UTxO RPC `ReadState` handler. `GetUTxOWhole` iterates every live row via
+`database.IterateLiveUtxos` and decodes each one's stored CBOR into the
+node-to-client reply shape; each row's CBOR buffer is defensively cloned
+before decoding, since `IterateLiveUtxos` documents that the buffer backing
+a row may be reused by the next callback invocation. Both queries exist to
+support cross-node ledger-state comparison in the devnet conformance
+harness (`internal/test/devnet`, see its README's "LocalStateQuery in
+conformance mode" section) rather than as an operator-facing query aimed at
+a mainnet-scale chain — a whole-UTxO dump is, as with `cardano-cli query
+utxo --whole-utxo`, only practical against a small network.
 
 ## Chain Management
 

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -44,18 +44,23 @@ producer-to-producer sync. Network spec: `testnet-dingo.yaml` (3 pools,
 
 ## Topology — conformance mode (`--conformance`)
 
-| Service            | Role                                | Host port | Container IP  |
-|--------------------|-------------------------------------|-----------|----------------|
-| `configurator`     | One-shot: generates keys + genesis  | —         | —              |
-| `dingo-producer`   | Dingo, forging with pool 1 keys     | `3010`    | `172.20.0.10`  |
-| `cardano-producer` | `cardano-node`, forging with pool 2 | `3011`    | `172.20.0.11`  |
-| `cardano-relay`    | `cardano-node` relay (no forging)   | `3012`    | `172.20.0.12`  |
-| `txpump`           | Submits payment txs into Dingo      | —         | `172.20.0.20`  |
+| Service            | Role                                | Container IP  | NtN host port | NtC (LocalStateQuery) host port |
+|--------------------|--------------------------------------|---------------|---------------|----------------------------------|
+| `configurator`     | One-shot: generates keys + genesis  | —             | —             | —                                 |
+| `dingo-producer`   | Dingo, forging with pool 1 keys     | `172.20.0.10` | `3010`        | `3020`                            |
+| `cardano-producer` | `cardano-node`, forging with pool 2 | `172.20.0.11` | `3011`        | `3021`                            |
+| `cardano-relay`    | `cardano-node` relay (no forging)   | `172.20.0.12` | `3012`        | —                                 |
+| `txpump`           | Submits payment txs into Dingo      | `172.20.0.20` | —             | —                                 |
 
 This is unchanged from the original two-pool network: pool 1 and pool 2 are
-wired into a ring topology, the relay peers with both producers, and
-`cardano-producer`/`cardano-relay` have no NtC host port mapped (conformance
-scenarios do not run LocalStateQuery). Network spec: `testnet.yaml`.
+wired into a ring topology, and the relay peers with both producers. Network
+spec: `testnet.yaml`.
+
+`dingo-producer` and `cardano-producer` — the two nodes that actually forge
+blocks — both have an NtC host port mapped, so the host test harness can run
+LocalStateQuery against each and compare ledger state (see
+`TestLedgerStateConsensus` under Test scenarios below). `cardano-relay` has no
+NtC host port mapped; it isn't part of that comparison.
 
 In both modes, `txpump` is a load generator: it talks Ouroboros NtC over a
 Dingo node's UNIX socket (on a named IPC volume, container-internal only) and
@@ -258,8 +263,53 @@ healthcheck) stays on a named Docker volume, and the host harness talks NtC
 over TCP instead. There is no host socket bind mount and no
 `DEVNET_IPC_DIR` environment variable.
 
-Conformance mode does not expose an NtC host port and has no LocalStateQuery
-helper — conformance scenarios only check chain tip/growth, not ledger state.
+### LocalStateQuery in conformance mode
+
+Conformance mode exposes NtC for both producers, so ledger state (not just
+chain tip/growth) can be compared against the reference implementation
+(`TestLedgerStateConsensus`, blinklabs-io/dingo#1900):
+
+- `dingo-producer` (in `--conformance` mode) exposes NtC the same way dingo
+  mode's nodes do (`DINGO_PRIVATE_BIND_ADDR=0.0.0.0` on private port 3002),
+  mapped to host port `3020` unless overridden with `DEVNET_DINGO_NTC_ADDR`
+  or `DEVNET_DINGO_NTC_PORT`.
+- `cardano-producer` (in `--conformance` mode) has no built-in TCP NtC
+  support — cardano-node only serves LocalStateQuery over its unix socket.
+  The `ghcr.io/blinklabs-io/cardano-node` image's `run-node` entrypoint
+  bridges this: setting `SOCAT_PORT` spawns a background `socat
+  TCP-LISTEN:<port>,fork UNIX-CLIENT:<socket-path>` inside the container.
+  `docker-compose.yml` sets `SOCAT_PORT: "3002"` on `cardano-producer` (the
+  same private-port number Dingo uses, purely by convention — it has no
+  special meaning to cardano-node), mapped to host port `3021` unless
+  overridden with `DEVNET_CARDANO_NTC_ADDR` or `DEVNET_CARDANO_NTC_PORT`.
+
+`internal/test/devnet/endpoints_conformance.go`'s `DingoProducerNtcAddr()`
+and `CardanoProducerNtcAddr()` return these host addresses, and
+`internal/test/devnet/ledger_state.go`'s `LedgerStateAtTip(addr, magic)`
+queries one node's current protocol parameters, stake distribution, and
+whole UTxO set (normalized into a comparable form) via a single acquired
+LocalStateQuery session; `DiffLedgerStates(a, b)` reports every divergence
+between two such snapshots.
+
+`GetStakeDistribution` and `GetUTxOWhole` (the two queries `LedgerStateAtTip`
+needs beyond the ones already used elsewhere in this harness) did not have
+server-side support in Dingo before this scenario — they were part of the
+`// TODO (#394)` block in `ledger/queries.go`'s query dispatcher. They are
+implemented in `ledger/queries_stakedistribution.go` and
+`ledger/queries_utxowhole.go`, closing out #394 for those two query types
+specifically (the rest of that TODO block is unrelated to this scenario and
+remains open).
+
+Dingo's LocalStateQuery server (`ouroboros/localstatequery.go`) does not yet
+implement point-specific ledger views: every `Acquire` — even
+`Acquire(point)` for a specific historical block — is answered against the
+node's live tip (tracked upstream as blinklabs-io/dingo#382). Until that
+lands, `LedgerStateAtTip` only supports "acquire the current volatile tip",
+and comparing two nodes at the same point requires confirming via NtN
+chain-tip polling that both report an identical tip immediately before and
+after the LocalStateQuery round trip — see `TestLedgerStateConsensus` for
+the retry loop this requires. This is why the scenario samples ledger state
+periodically at settled common tips rather than replaying every block.
 
 ### Running the CIP-50 pledge-leverage scenario
 
@@ -323,6 +373,7 @@ runs only with `--conformance`:
 | Test | What it verifies |
 |------|-------------------|
 | `TestCardanoProducerChainAdvances` | `cardano-producer`'s tip advances (sanity check on the reference node) |
+| `TestLedgerStateConsensus` | dingo-producer's and cardano-producer's ledger state (protocol parameters, stake distribution, whole UTxO set) match at several settled common-tip samples over the run; fails with a diagnostic naming every divergence found |
 
 Dingo-only feature scenario (`//go:build devnet && !devnet_conformance`),
 runs only in the default dingo mode — no `cardano-node` reference exists for
@@ -356,11 +407,15 @@ Dingo mode:
 
 Conformance mode:
 
-| Variable              | Default | Used by                                |
-|-----------------------|---------|------------------------------------------|
-| `DEVNET_DINGO_PORT`   | `3010`  | docker-compose host port for Dingo     |
-| `DEVNET_CARDANO_PORT` | `3011`  | docker-compose host port for cardano  |
-| `DEVNET_RELAY_PORT`   | `3012`  | docker-compose host port for relay    |
+| Variable                 | Default | Used by                                     |
+|--------------------------|---------|-----------------------------------------------|
+| `DEVNET_DINGO_PORT`      | `3010`  | docker-compose host port for Dingo NtN      |
+| `DEVNET_CARDANO_PORT`    | `3011`  | docker-compose host port for cardano NtN   |
+| `DEVNET_RELAY_PORT`      | `3012`  | docker-compose host port for relay NtN     |
+| `DEVNET_DINGO_NTC_PORT`  | `3020`  | docker-compose host port for `dingo-producer` NtC |
+| `DEVNET_CARDANO_NTC_PORT`| `3021`  | docker-compose host port for `cardano-producer` NtC (bridged by socat) |
+| `DEVNET_DINGO_NTC_ADDR`  | `localhost:<port above>` | `DingoProducerNtcAddr()` override |
+| `DEVNET_CARDANO_NTC_ADDR`| `localhost:<port above>` | `CardanoProducerNtcAddr()` override |
 | `DINGO_PORT`          | falls back to `DEVNET_DINGO_PORT`   | `run-tests.sh` only |
 | `CARDANO_PORT`        | falls back to `DEVNET_CARDANO_PORT` | `run-tests.sh` only |
 | `RELAY_PORT`          | falls back to `DEVNET_RELAY_PORT`   | `run-tests.sh` only |
@@ -385,8 +440,9 @@ harness and the compose port mappings always agree.
 | `../antithesis/Dockerfile.txpump`, `../antithesis/cmd/txpump/` | Source for the `txpump` load generator image |
 | `harness.go`, `config.go`    | Go test harness package: Ouroboros NtN client, tip queries, consensus checks, `testnet*.yaml` loader (build tag `devnet`) |
 | `endpoints_dingo.go`         | Dingo-mode node endpoints and NtC addresses (`//go:build devnet && !devnet_conformance`) |
-| `endpoints_conformance.go`   | Conformance-mode node endpoints (`//go:build devnet && devnet_conformance`) |
+| `endpoints_conformance.go`   | Conformance-mode node endpoints, plus `DingoProducerNtcAddr()` / `CardanoProducerNtcAddr()` (`//go:build devnet && devnet_conformance`) |
 | `lsq.go`                     | `RewardAccountsByNtc` / `RewardAccountsByNtcForCreds`: LocalStateQuery over NtC TCP (build tag `devnet`) |
+| `ledger_state.go`            | `LedgerStateAtTip` / `DiffLedgerStates`: normalized protocol-params/stake-distribution/whole-UTxO snapshot and diff for cross-node ledger-state comparison (build tag `devnet`) |
 | `credentials.go`             | Loads genesis stake credentials for the CIP-50 scenario (build tag `devnet`) |
 | `harness_test.go`, `credentials_test.go` | Tests for the harness/credential helpers themselves (build tag `devnet`) |
 | `scenarios/`                 | Devnet test scenarios (one or more `Test*` per file, gated per the Test scenarios table above) |

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -29,15 +29,22 @@
 #   - dingo-producer:   Dingo node forging with pool 1 keys
 #   - cardano-producer: Official cardano-node forging with pool 2 keys
 #   - cardano-relay:    Relay connecting both producers (no block production)
+#   NtN host ports: 3010 (dingo-producer), 3011 (cardano-producer),
+#   3012 (cardano-relay).
+#   NtC host ports: 3020 (dingo-producer), 3021 (cardano-producer, bridged
+#   from its unix socket by socat via SOCAT_PORT). cardano-relay has no NtC
+#   host port; only the two producers' ledger states are compared.
 #
 # Usage:
 #   docker compose up -d       # Start all services in the selected profile
 #   docker compose down -v     # Stop and remove volumes
 #
 # Host port overrides (set in environment or .env file, conformance profile):
-#   DEVNET_DINGO_PORT     - Dingo producer host port    (default: 3010)
-#   DEVNET_CARDANO_PORT   - Cardano producer host port  (default: 3011)
-#   DEVNET_RELAY_PORT     - Cardano relay host port     (default: 3012)
+#   DEVNET_DINGO_PORT       - Dingo producer host port (NtN)   (default: 3010)
+#   DEVNET_CARDANO_PORT     - Cardano producer host port (NtN) (default: 3011)
+#   DEVNET_RELAY_PORT       - Cardano relay host port (NtN)    (default: 3012)
+#   DEVNET_DINGO_NTC_PORT   - Dingo producer host port (NtC)   (default: 3020)
+#   DEVNET_CARDANO_NTC_PORT - Cardano producer host port (NtC) (default: 3021)
 #
 # Each profile's configurator service runs first (via depends_on) to generate
 # unique key sets and genesis files for each pool from its testnet*.yaml.
@@ -270,6 +277,7 @@ services:
       - dingo-producer-ipc:/ipc
     ports:
       - "${DEVNET_DINGO_PORT:-3010}:3001"
+      - "${DEVNET_DINGO_NTC_PORT:-3020}:3002"
     networks:
       devnet:
         ipv4_address: 172.20.0.10
@@ -290,6 +298,15 @@ services:
     environment:
       CARDANO_BLOCK_PRODUCER: "true"
       RESTORE_SNAPSHOT: "false"
+      # Bridge node-to-client (LocalStateQuery) to TCP so the host test
+      # harness can query cardano-producer's ledger state and compare it
+      # against dingo-producer's (cross-node ledger-state conformance,
+      # blinklabs-io/dingo#1900). cardano-node has no built-in TCP NtC
+      # support; the run-node entrypoint spawns "socat TCP-LISTEN:<port>
+      # ... UNIX-CLIENT:<socket-path>" in the background when SOCAT_PORT is
+      # set. Mirrors the private port dingo binds its own NtC TCP listener
+      # on via DINGO_PRIVATE_BIND_ADDR.
+      SOCAT_PORT: "3002"
     command:
       - "run"
       - "--config"
@@ -315,6 +332,7 @@ services:
       - cardano-producer-ipc:/ipc
     ports:
       - "${DEVNET_CARDANO_PORT:-3011}:3001"
+      - "${DEVNET_CARDANO_NTC_PORT:-3021}:3002"
     networks:
       devnet:
         ipv4_address: 172.20.0.11

--- a/internal/test/devnet/endpoints_conformance.go
+++ b/internal/test/devnet/endpoints_conformance.go
@@ -50,3 +50,28 @@ func LoadEndpoints() []NodeEndpoint {
 		},
 	}
 }
+
+// DingoProducerNtcAddr returns dingo-producer's host TCP address for the
+// node-to-client (LocalStateQuery) listener. dingo-producer serves NtC on
+// private port 3002 (via DINGO_PRIVATE_BIND_ADDR), mapped to host port
+// 3020 by default (override with DEVNET_DINGO_NTC_ADDR or
+// DEVNET_DINGO_NTC_PORT).
+func DingoProducerNtcAddr() string {
+	if v := os.Getenv("DEVNET_DINGO_NTC_ADDR"); v != "" {
+		return v
+	}
+	return "localhost:3020"
+}
+
+// CardanoProducerNtcAddr returns cardano-producer's host TCP address for
+// its node-to-client (LocalStateQuery) listener. cardano-node has no
+// built-in TCP NtC support; the blinklabs-io/docker-cardano-node image
+// bridges it with a background socat process (SOCAT_PORT=3002 forwards
+// TCP to the node's unix socket), mapped to host port 3021 by default
+// (override with DEVNET_CARDANO_NTC_ADDR or DEVNET_CARDANO_NTC_PORT).
+func CardanoProducerNtcAddr() string {
+	if v := os.Getenv("DEVNET_CARDANO_NTC_ADDR"); v != "" {
+		return v
+	}
+	return "localhost:3021"
+}

--- a/internal/test/devnet/ledger_state.go
+++ b/internal/test/devnet/ledger_state.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build devnet
+
+package devnet
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	utxorpccardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// LedgerState is a normalized, comparison-friendly snapshot of the ledger
+// state exposed by a single node's LocalStateQuery interface: current
+// protocol parameters, stake distribution, and the whole UTxO set.
+//
+// Fields are already canonicalized (sorted, stringified) so that two
+// LedgerState values built from independently-decoded LocalStateQuery
+// responses (one per node) can be compared directly, regardless of map
+// iteration order or which node produced them.
+type LedgerState struct {
+	// ProtocolParams is the current protocol parameter set, converted to
+	// its utxorpc representation. Utxorpc() gives a stable, era-neutral
+	// proto.Message we can diff with proto.Equal instead of hand-rolling
+	// a comparison across every gouroboros *ProtocolParameters type.
+	ProtocolParams *utxorpccardano.PParams
+
+	// StakeDistribution maps pool ID to stake fraction, as reported by
+	// GetStakeDistribution.
+	StakeDistribution map[lcommon.PoolId]*big.Rat
+
+	// UTxOEntries maps "<txHash>#<outputIndex>" to a canonical string
+	// encoding of that output's address, lovelace amount, any
+	// multi-asset tokens (sorted by policy then asset name so the
+	// encoding is deterministic), datum, and reference script.
+	UTxOEntries map[string]string
+}
+
+// LedgerStateAtTip dials addr over node-to-client (NtC) TCP, acquires the
+// volatile tip, and queries protocol parameters, stake distribution, and
+// the whole UTxO set as a single LocalStateQuery session so all three
+// reflect one consistent view of that node's ledger state.
+//
+// This intentionally does not support pinning an exact historical block
+// via Acquire(point): Dingo's LocalStateQuery server
+// (ouroboros/localstatequery.go) currently answers every Acquire against
+// its live tip regardless of the requested point (no point-specific
+// ledger view yet; see blinklabs-io/dingo#382), so a caller that needs to
+// compare two nodes at the same point must instead confirm via NtN
+// chain-tip polling that both nodes report an identical tip immediately
+// before and after calling this function, and retry the sample if not.
+func LedgerStateAtTip(addr string, magic uint32) (*LedgerState, error) {
+	conn, err := ouroboros.New(
+		ouroboros.WithNetworkMagic(magic),
+		ouroboros.WithNodeToNode(false),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("ouroboros.New: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	if err := conn.DialTimeout("tcp", addr, 10*time.Second); err != nil {
+		return nil, fmt.Errorf("dial tcp %s: %w", addr, err)
+	}
+
+	lsq := conn.LocalStateQuery()
+	if lsq == nil || lsq.Client == nil {
+		return nil, fmt.Errorf("LocalStateQuery client unavailable on %s", addr)
+	}
+	client := lsq.Client
+	if err := client.AcquireVolatileTip(); err != nil {
+		return nil, fmt.Errorf("acquire tip on %s: %w", addr, err)
+	}
+	defer client.Release() //nolint:errcheck
+
+	pp, err := client.GetCurrentProtocolParams()
+	if err != nil {
+		return nil, fmt.Errorf("protocol params query on %s: %w", addr, err)
+	}
+	ppProto, err := pp.Utxorpc()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"converting protocol params to utxorpc on %s: %w", addr, err,
+		)
+	}
+
+	sd, err := client.GetStakeDistribution()
+	if err != nil {
+		return nil, fmt.Errorf("stake distribution query on %s: %w", addr, err)
+	}
+	stakeDist := make(map[lcommon.PoolId]*big.Rat, len(sd.Results))
+	for poolID, entry := range sd.Results {
+		if entry.StakeFraction == nil {
+			continue
+		}
+		stakeDist[poolID] = entry.StakeFraction.Rat
+	}
+
+	utxos, err := client.GetUTxOWhole()
+	if err != nil {
+		return nil, fmt.Errorf("whole UTxO query on %s: %w", addr, err)
+	}
+	entries := make(map[string]string, len(utxos.Results))
+	for id, out := range utxos.Results {
+		key := fmt.Sprintf("%s#%d", id.Hash.String(), id.Idx)
+		entries[key] = canonicalUTxOEntry(out)
+	}
+
+	return &LedgerState{
+		ProtocolParams:    ppProto,
+		StakeDistribution: stakeDist,
+		UTxOEntries:       entries,
+	}, nil
+}
+
+// canonicalUTxOEntry builds a deterministic string encoding of a UTxO's
+// address, lovelace amount, any multi-asset tokens (sorted by policy then
+// asset name), datum, and reference script, so two independently-decoded
+// outputs with identical content produce identical strings regardless of
+// map iteration order.
+//
+// The output is read through the ledger.TransactionOutput interface
+// rather than the concrete babbage.BabbageTransactionOutput struct so this
+// keeps working if gouroboros ever decodes GetUTxOWhole into a different
+// era-specific type.
+//
+// Datum and reference script are each folded into a single content hash
+// (DatumHash()/Datum().Hash() and ScriptRef().Hash() respectively) rather
+// than re-encoded byte-for-byte: both are already content-addressed by
+// construction, so two hashes matching is exactly the "same content"
+// signal this comparison needs, without pulling in a canonical CBOR/Plutus
+// re-encoding of arbitrary datum or script bytes.
+func canonicalUTxOEntry(out ledger.TransactionOutput) string {
+	var sb strings.Builder
+	sb.WriteString(out.Address().String())
+	sb.WriteString("|")
+	sb.WriteString(out.Amount().String())
+
+	if assets := out.Assets(); assets != nil {
+		policies := assets.Policies()
+		sort.Slice(policies, func(i, j int) bool {
+			return bytes.Compare(policies[i].Bytes(), policies[j].Bytes()) < 0
+		})
+		for _, policy := range policies {
+			names := assets.Assets(policy)
+			sort.Slice(names, func(i, j int) bool {
+				return bytes.Compare(names[i], names[j]) < 0
+			})
+			for _, name := range names {
+				amount := assets.Asset(policy, name)
+				fmt.Fprintf(
+					&sb, "|%s.%s=%s",
+					policy.String(), hex.EncodeToString(name), amount.String(),
+				)
+			}
+		}
+	}
+
+	// DatumHash() covers both wire forms of a datum option: an explicit
+	// hash, or an inline datum (in which case DatumHash() returns the
+	// hash of that inline content) — see
+	// babbage.BabbageTransactionOutput.DatumHash(). One field is enough;
+	// there is no case where a real hash mismatch would hide behind a
+	// matching inline datum or vice versa.
+	if dh := out.DatumHash(); dh != nil {
+		fmt.Fprintf(&sb, "|datum=%s", dh.String())
+	}
+	if sr := out.ScriptRef(); sr != nil {
+		fmt.Fprintf(&sb, "|scriptref=%s", sr.Hash().String())
+	}
+	return sb.String()
+}
+
+// DiffLedgerStates compares two LedgerState snapshots and returns a
+// human-readable description of every divergence found: protocol
+// parameter differences (as a single unified-looking JSON diff), stake
+// distribution differences per pool, and UTxO set differences per output.
+// It returns an empty slice when the two snapshots are equal.
+//
+// UTxO differences are capped at maxUTxODiffReports individual entries to
+// keep failure output readable on a diverged network with many UTxOs; a
+// trailing summary line reports the total count when the cap is hit.
+func DiffLedgerStates(a, b *LedgerState) []string {
+	var diffs []string
+
+	if !proto.Equal(a.ProtocolParams, b.ProtocolParams) {
+		diffs = append(diffs, fmt.Sprintf(
+			"protocol parameters differ:\n--- a ---\n%s\n--- b ---\n%s",
+			protojson.Format(a.ProtocolParams),
+			protojson.Format(b.ProtocolParams),
+		))
+	}
+
+	for poolID, aFrac := range a.StakeDistribution {
+		bFrac, ok := b.StakeDistribution[poolID]
+		switch {
+		case !ok:
+			diffs = append(diffs, fmt.Sprintf(
+				"stake distribution: pool %s present in a, missing in b",
+				poolID,
+			))
+		case aFrac.Cmp(bFrac) != 0:
+			diffs = append(diffs, fmt.Sprintf(
+				"stake distribution: pool %s fraction differs: %s (a) vs %s (b)",
+				poolID,
+				aFrac.RatString(),
+				bFrac.RatString(),
+			))
+		}
+	}
+	for poolID := range b.StakeDistribution {
+		if _, ok := a.StakeDistribution[poolID]; !ok {
+			diffs = append(diffs, fmt.Sprintf(
+				"stake distribution: pool %s present in b, missing in a",
+				poolID,
+			))
+		}
+	}
+
+	const maxUTxODiffReports = 20
+	utxoDiffCount := 0
+	report := func(format string, args ...any) {
+		utxoDiffCount++
+		if utxoDiffCount <= maxUTxODiffReports {
+			diffs = append(diffs, fmt.Sprintf(format, args...))
+		}
+	}
+	for key, aVal := range a.UTxOEntries {
+		bVal, ok := b.UTxOEntries[key]
+		switch {
+		case !ok:
+			report("utxo %s present in a, missing in b: %s", key, aVal)
+		case aVal != bVal:
+			report("utxo %s differs: %s (a) vs %s (b)", key, aVal, bVal)
+		}
+	}
+	for key, bVal := range b.UTxOEntries {
+		if _, ok := a.UTxOEntries[key]; !ok {
+			report("utxo %s present in b, missing in a: %s", key, bVal)
+		}
+	}
+	if utxoDiffCount > maxUTxODiffReports {
+		diffs = append(diffs, fmt.Sprintf(
+			"... %d more utxo differences omitted",
+			utxoDiffCount-maxUTxODiffReports,
+		))
+	}
+
+	return diffs
+}

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -220,6 +220,8 @@ if [[ "${MODE}" == "conformance" ]]; then
   export DEVNET_DINGO_ADDR="localhost:${DINGO_PORT}"
   export DEVNET_CARDANO_ADDR="localhost:${CARDANO_PORT}"
   export DEVNET_RELAY_ADDR="localhost:${RELAY_PORT}"
+  export DEVNET_DINGO_NTC_ADDR="${DEVNET_DINGO_NTC_ADDR:-localhost:${DEVNET_DINGO_NTC_PORT:-3020}}"
+  export DEVNET_CARDANO_NTC_ADDR="${DEVNET_CARDANO_NTC_ADDR:-localhost:${DEVNET_CARDANO_NTC_PORT:-3021}}"
 else
   export DEVNET_DINGO1_ADDR="localhost:${DEVNET_DINGO1_PORT:-3010}"
   export DEVNET_DINGO2_ADDR="localhost:${DEVNET_DINGO2_PORT:-3013}"

--- a/internal/test/devnet/scenarios/ledger_state_consensus_test.go
+++ b/internal/test/devnet/scenarios/ledger_state_consensus_test.go
@@ -1,0 +1,232 @@
+//go:build devnet && devnet_conformance
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scenarios
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/devnet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerStateConsensus is Dingo's automated cross-node ledger-state
+// comparison against cardano-node (blinklabs-io/dingo#1900): it samples
+// dingo-producer's and cardano-producer's ledger state (current protocol
+// parameters, stake distribution, and the whole UTxO set, normalized into a
+// comparable form) at several points during the run and fails with a
+// diagnostic listing every divergence found.
+//
+// Sampling, not true per-block comparison: Dingo's LocalStateQuery server
+// (ouroboros/localstatequery.go) currently answers every Acquire against
+// its live tip regardless of the requested point — it has no point-specific
+// ledger view yet (tracked upstream as blinklabs-io/dingo#382). That means
+// Acquire(specific historical point) cannot be used to pin an exact block on
+// Dingo today, so a true block-by-block replay comparison isn't possible
+// yet. Instead, each sample: (1) polls both nodes' chain tips over NtN until
+// they report an identical slot and block hash, (2) immediately queries both
+// nodes' LocalStateQuery (AcquireVolatileTip, i.e. "current tip"), and
+// (3) re-polls both tips afterward to confirm neither node advanced during
+// the query round trip, discarding and retrying the sample if it did. This
+// still anchors every successful sample to one exact, agreed-upon block —
+// it just doesn't visit every block, since finding a settled common tip and
+// running three LocalStateQuery calls per node is far more expensive than a
+// chain-tip poll. Revisit this once #382 lands: Acquire(point) would let
+// this walk every block, not just periodic settled samples.
+func TestLedgerStateConsensus(t *testing.T) {
+	cfg, err := devnet.LoadDevNetConfig()
+	require.NoError(t, err, "failed to load devnet config from testnet.yaml")
+
+	endpoints := devnet.LoadEndpoints()
+	h := devnet.NewTestHarness(
+		t, endpoints,
+		devnet.WithNetworkMagic(cfg.NetworkMagic),
+	)
+
+	dingoEP := h.DingoNode()
+	cardanoEP, ok := h.ReferenceNode()
+	require.True(t, ok, "conformance mode must have a reference node")
+
+	h.WaitForAllNodesReady(60 * time.Second)
+
+	dingoNtc := devnet.DingoProducerNtcAddr()
+	cardanoNtc := devnet.CardanoProducerNtcAddr()
+
+	initialTip, err := h.GetChainTip(dingoEP)
+	require.NoError(t, err, "failed to get initial dingo-producer tip")
+
+	const (
+		samples             = 3
+		slotsBetweenSamples = 15
+	)
+	sampleTimeout := time.Duration(slotsBetweenSamples)*cfg.SlotDuration() +
+		cfg.ExpectedBlockTime()*10
+
+	for i := 1; i <= samples; i++ {
+		targetSlot := initialTip.SlotNumber + uint64(i*slotsBetweenSamples)
+		h.WaitForNodeSlot(dingoEP, targetSlot, sampleTimeout)
+		h.WaitForNodeSlot(cardanoEP, targetSlot, sampleTimeout)
+
+		dingoState, cardanoState, tip := sampleLedgerStateAtStableTip(
+			t, h, dingoEP, cardanoEP, dingoNtc, cardanoNtc, cfg.NetworkMagic,
+			cfg.ExpectedBlockTime(),
+		)
+
+		diffs := devnet.DiffLedgerStates(dingoState, cardanoState)
+		require.Empty(t, diffs,
+			"ledger state diverged between dingo-producer and"+
+				" cardano-producer at slot %d (block %d):\n%s",
+			tip.SlotNumber, tip.BlockNumber, strings.Join(diffs, "\n"),
+		)
+
+		t.Logf(
+			"ledger state matched at slot %d (block %d):"+
+				" %d utxos, %d pools in stake distribution",
+			tip.SlotNumber, tip.BlockNumber,
+			len(dingoState.UTxOEntries), len(dingoState.StakeDistribution),
+		)
+	}
+}
+
+// sampleLedgerStateAtStableTip polls dingoEP and cardanoEP until they
+// report an identical chain tip, queries both nodes' LocalStateQuery
+// interfaces, and confirms neither node's tip moved during the query round
+// trip. If either node advanced in the meantime, the two LocalStateQuery
+// responses would reflect different blocks and any divergence found would
+// be meaningless noise rather than a real conformance failure, so the
+// sample is discarded and retried instead.
+//
+// Uses require.Eventually with harness.go's own 2*time.Second polling
+// interval (see e.g. WaitForNodeSlot, VerifyChainConsensus), budgeting the
+// overall timeout off blockTime (cfg.ExpectedBlockTime()) rather than a
+// fixed attempt count: transient tip divergence between two independently
+// forging producers around block-adoption time is the normal case here,
+// not a rare one, so a tight fixed-count retry with no backoff could
+// exhaust its budget in well under one block interval on a legitimate
+// run. Writing the result into the enclosing closure's variables from
+// inside the condition function, then reading them only after
+// require.Eventually returns, mirrors WaitForNodeBlockAbove in
+// harness.go — testify's Eventually never runs the condition function
+// twice concurrently (it waits for one tick's result before scheduling
+// the next), so this needs no additional locking.
+func sampleLedgerStateAtStableTip(
+	t *testing.T,
+	h *devnet.TestHarness,
+	dingoEP, cardanoEP devnet.NodeEndpoint,
+	dingoNtc, cardanoNtc string,
+	magic uint32,
+	blockTime time.Duration,
+) (dingoState, cardanoState *devnet.LedgerState, tip devnet.ChainTip) {
+	t.Helper()
+
+	const pollInterval = 2 * time.Second
+	timeout := blockTime * 20
+
+	var (
+		attempt                int
+		resultDingo, resultRef *devnet.LedgerState
+		resultTip              devnet.ChainTip
+	)
+	require.Eventually(t, func() bool {
+		attempt++
+		before, err := h.GetChainTip(dingoEP)
+		if err != nil {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: dingo-producer"+
+					" tip: %v", attempt, err,
+			)
+			return false
+		}
+		beforeRef, err := h.GetChainTip(cardanoEP)
+		if err != nil {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: cardano-producer"+
+					" tip: %v", attempt, err,
+			)
+			return false
+		}
+		if before.SlotNumber != beforeRef.SlotNumber ||
+			!bytes.Equal(before.Hash, beforeRef.Hash) {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: no common tip yet"+
+					" (dingo-producer slot %d, cardano-producer slot %d)",
+				attempt, before.SlotNumber, beforeRef.SlotNumber,
+			)
+			return false
+		}
+
+		ds, err := devnet.LedgerStateAtTip(dingoNtc, magic)
+		if err != nil {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: dingo-producer"+
+					" ledger state query: %v", attempt, err,
+			)
+			return false
+		}
+		cs, err := devnet.LedgerStateAtTip(cardanoNtc, magic)
+		if err != nil {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: cardano-producer"+
+					" ledger state query: %v", attempt, err,
+			)
+			return false
+		}
+
+		after, err := h.GetChainTip(dingoEP)
+		if err != nil {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: dingo-producer"+
+					" re-check: %v", attempt, err,
+			)
+			return false
+		}
+		afterRef, err := h.GetChainTip(cardanoEP)
+		if err != nil {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: cardano-producer"+
+					" re-check: %v", attempt, err,
+			)
+			return false
+		}
+		if !bytes.Equal(before.Hash, after.Hash) ||
+			!bytes.Equal(beforeRef.Hash, afterRef.Hash) {
+			t.Logf(
+				"sampleLedgerStateAtStableTip: attempt %d: tip advanced"+
+					" during the query round trip",
+				attempt,
+			)
+			return false
+		}
+
+		resultDingo, resultRef, resultTip = ds, cs, before
+		return true
+	}, timeout, pollInterval,
+		"dingo-producer and cardano-producer never settled on a stable"+
+			" common tip within %s",
+		timeout,
+	)
+	// require.Eventually calls t.FailNow() (halting this goroutine) rather
+	// than returning when the condition never succeeds, so resultDingo and
+	// resultRef are always set by the time execution reaches here — this
+	// check is for the static analyzer, not a runtime possibility.
+	require.NotNil(t, resultDingo, "internal error: no dingo-producer result")
+	require.NotNil(t, resultRef, "internal error: no cardano-producer result")
+
+	return resultDingo, resultRef, resultTip
+}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -467,13 +467,15 @@ func (ls *LedgerState) queryShelleyLeaf(query any) (any, error) {
 		return ls.queryShelleyDebugChainDepState()
 	case *olocalstatequery.ShelleyPoolDistr2Query:
 		return ls.queryShelleyPoolDistr2(q)
+	case *olocalstatequery.ShelleyStakeDistributionQuery:
+		return ls.queryShelleyStakeDistribution()
+	case *olocalstatequery.ShelleyUtxoWholeQuery:
+		return ls.queryShelleyUtxoWhole()
 	// TODO (#394)
 	/*
 		case *olocalstatequery.ShelleyLedgerTipQuery:
 		case *olocalstatequery.ShelleyNonMyopicMemberRewardsQuery:
 		case *olocalstatequery.ShelleyProposedProtocolParamsUpdatesQuery:
-		case *olocalstatequery.ShelleyStakeDistributionQuery:
-		case *olocalstatequery.ShelleyUtxoWholeQuery:
 		case *olocalstatequery.ShelleyDebugEpochStateQuery:
 		case *olocalstatequery.ShelleyDebugNewEpochStateQuery:
 		case *olocalstatequery.ShelleyRewardProvenanceQuery:

--- a/ledger/queries_stakedistribution.go
+++ b/ledger/queries_stakedistribution.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// stakeDistributionEntry mirrors the anonymous struct type
+// olocalstatequery.StakeDistributionResult.Results is keyed by. Named here
+// only for readability inside this file: Go's struct types are structural
+// (not nominal) for anonymous struct literals, so a value of this named
+// type is directly assignable into that map without any conversion.
+type stakeDistributionEntry = struct {
+	cbor.StructAsArray
+	StakeFraction *cbor.Rat
+	VrfHash       ledger.Blake2b256
+}
+
+// queryShelleyStakeDistribution answers GetStakeDistribution: the active
+// stake distribution across every block-producing pool in the current mark
+// snapshot. Unlike GetPoolDistr2 (queryShelleyPoolDistr2), this query has
+// no pool filter on the wire, so every pool that holds stake is reported.
+//
+// Reads from PoolStakeDistribution, the same helper queryShelleyPoolDistr2
+// and the UTxO RPC ReadState handler share, so this query cannot report a
+// different snapshot or VRF key for the same chain than either of those.
+func (ls *LedgerState) queryShelleyStakeDistribution() (any, error) {
+	dist, err := ls.PoolStakeDistribution(nil)
+	if err != nil {
+		return nil, err
+	}
+	result := olocalstatequery.StakeDistributionResult{
+		Results: make(
+			map[ledger.PoolId]stakeDistributionEntry,
+			len(dist.Pools),
+		),
+	}
+	for _, pool := range dist.Pools {
+		result.Results[ledger.PoolId(pool.PoolKeyHash)] = stakeDistributionEntry{
+			StakeFraction: pool.StakeFraction,
+			VrfHash:       pool.VrfKeyHash,
+		}
+	}
+	return []any{result}, nil
+}

--- a/ledger/queries_stakedistribution_test.go
+++ b/ledger/queries_stakedistribution_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stakeDistributionQuery wraps the leaf query the way the wire delivers
+// it. GetStakeDistribution has no pool filter on the wire, unlike
+// GetPoolDistr2 (poolDistr2Query in queries_pooldistr2_test.go).
+func stakeDistributionQuery() *olocalstatequery.BlockQuery {
+	return &olocalstatequery.BlockQuery{
+		Query: &olocalstatequery.ShelleyQuery{
+			// simpleQueryBase.Type is unexported; it only routes the
+			// initial CBOR decode, which this test bypasses by
+			// constructing the typed Go value directly.
+			Query: &olocalstatequery.ShelleyStakeDistributionQuery{},
+		},
+	}
+}
+
+// TestQueryShelleyStakeDistribution_ReportsFractionAndVrf covers
+// GetStakeDistribution, which reads from the same PoolStakeDistribution
+// helper as GetPoolDistr2 (queryShelleyPoolDistr2), so the two queries
+// cannot silently disagree about the same chain's stake distribution.
+func TestQueryShelleyStakeDistribution_ReportsFractionAndVrf(t *testing.T) {
+	db := newTestDB(t)
+
+	vrfA := make([]byte, 32)
+	for i := range vrfA {
+		vrfA[i] = 0xAA
+	}
+	vrfB := make([]byte, 32)
+	for i := range vrfB {
+		vrfB[i] = 0xBB
+	}
+	poolA := make([]byte, 28)
+	for i := range poolA {
+		poolA[i] = 0x11
+	}
+	poolB := make([]byte, 28)
+	for i := range poolB {
+		poolB[i] = 0x22
+	}
+
+	// The ledger state under test reports epoch 0, and leader election
+	// reads the snapshot for the preceding epoch, which at epoch 0 is
+	// epoch 0 (see queryShelleyPoolDistr2's own fixture for the same
+	// reasoning).
+	const snapshotEpoch = 0
+	pkhA := seedPoolDistr2Fixture(t, db, poolA, vrfA, 3_000_000, snapshotEpoch)
+	pkhB := seedPoolDistr2Fixture(t, db, poolB, vrfB, 1_000_000, snapshotEpoch)
+
+	ls := newPoolDistr2Ledger(t, db)
+
+	result, err := ls.Query(stakeDistributionQuery())
+	require.NoError(t, err)
+	arr, ok := result.([]any)
+	require.True(t, ok, "expected the []any result wrapper")
+	require.Len(t, arr, 1)
+
+	dist, ok := arr[0].(olocalstatequery.StakeDistributionResult)
+	require.True(t, ok, "expected a StakeDistributionResult, got %T", arr[0])
+	require.Len(t, dist.Results, 2)
+
+	entryA, ok := dist.Results[lcommon.PoolId(pkhA)]
+	require.True(t, ok, "pool A missing from the distribution")
+	require.NotNil(t, entryA.StakeFraction)
+	assert.Equal(t, int64(3), entryA.StakeFraction.Num().Int64())
+	assert.Equal(t, int64(4), entryA.StakeFraction.Denom().Int64())
+	assert.Equal(t, vrfA, entryA.VrfHash[:],
+		"the VRF hash is what a caller checks their own key against")
+
+	entryB, ok := dist.Results[lcommon.PoolId(pkhB)]
+	require.True(t, ok, "pool B missing from the distribution")
+	require.NotNil(t, entryB.StakeFraction)
+	assert.Equal(t, int64(1), entryB.StakeFraction.Num().Int64())
+	assert.Equal(t, int64(4), entryB.StakeFraction.Denom().Int64())
+	assert.Equal(t, vrfB, entryB.VrfHash[:])
+}
+
+// TestQueryShelleyStakeDistribution_EmptySnapshot covers a chain with no
+// stake snapshot yet: the query must return an empty, non-nil map rather
+// than failing.
+func TestQueryShelleyStakeDistribution_EmptySnapshot(t *testing.T) {
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	result, err := ls.queryShelleyStakeDistribution()
+	require.NoError(t, err)
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+
+	dist, ok := arr[0].(olocalstatequery.StakeDistributionResult)
+	require.True(t, ok)
+	assert.Empty(t, dist.Results)
+}

--- a/ledger/queries_utxowhole.go
+++ b/ledger/queries_utxowhole.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// queryShelleyUtxoWhole answers GetUTxOWhole: every live UTxO in the
+// current ledger state.
+//
+// cardano-cli's own client-side guidance is that a whole-UTxO dump
+// ("query utxo --whole-utxo") is only practical against a small network;
+// dingo does not impose an additional limit here, but callers on a
+// mainnet-scale chain should expect this to be slow and to return a large
+// reply. This exists primarily to support LocalStateQuery-based tooling
+// (e.g. the devnet cross-node ledger-state comparison,
+// blinklabs-io/dingo#1900) rather than as a query aimed at a busy chain.
+func (ls *LedgerState) queryShelleyUtxoWhole() (any, error) {
+	ret := make(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	err := ls.db.IterateLiveUtxos(nil, func(u *models.Utxo) error {
+		// IterateLiveUtxos documents that a row's Cbor buffer may be
+		// reused by the next callback invocation; clone it before
+		// decoding so the TransactionOutput retained in ret below never
+		// aliases memory this loop is about to overwrite.
+		cborCopy := bytes.Clone(u.Cbor)
+		txOut, err := ledger.NewTransactionOutputFromCbor(cborCopy)
+		if err != nil {
+			return fmt.Errorf(
+				"decode utxo %x#%d: %w", u.TxId[:8], u.OutputIdx, err,
+			)
+		}
+		ret[olocalstatequery.UtxoId{
+			Hash: ledger.NewBlake2b256(u.TxId),
+			Idx:  int(u.OutputIdx),
+		}] = txOut
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return []any{ret}, nil
+}

--- a/ledger/queries_utxowhole_test.go
+++ b/ledger/queries_utxowhole_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/require"
+)
+
+// utxoWholeQuery wraps the leaf query the way the wire delivers it.
+func utxoWholeQuery() *olocalstatequery.BlockQuery {
+	return &olocalstatequery.BlockQuery{
+		Query: &olocalstatequery.ShelleyQuery{
+			// simpleQueryBase.Type is unexported; it only routes the
+			// initial CBOR decode, which this test bypasses by
+			// constructing the typed Go value directly.
+			Query: &olocalstatequery.ShelleyUtxoWholeQuery{},
+		},
+	}
+}
+
+// seedBabbageUtxo inserts a Utxo metadata row plus a raw-CBOR blob entry for
+// a Babbage-format output at addr, mirroring seedByronUtxo in
+// hardfork_rule_test.go so the iterator's loadCbor path resolves a real
+// decoded output on each row.
+func seedBabbageUtxo(
+	t *testing.T,
+	db *database.Database,
+	txIdSeed byte,
+	outputIdx uint32,
+	addr lcommon.Address,
+	amount uint64,
+) []byte {
+	t.Helper()
+	out := babbage.BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: amount},
+	}
+	cborBytes, err := cbor.Encode(&out)
+	require.NoError(t, err)
+
+	txId := bytes.Repeat([]byte{txIdSeed}, 32)
+	txn := db.Transaction(true)
+	require.NoError(t, db.CreateUtxo(txn, &models.Utxo{
+		TxId:      txId,
+		OutputIdx: outputIdx,
+		AddedSlot: 100,
+	}))
+	blob := db.Blob()
+	require.NotNil(t, blob)
+	require.NoError(t, blob.SetUtxo(txn.Blob(), txId, outputIdx, cborBytes))
+	require.NoError(t, txn.Commit())
+	return txId
+}
+
+// TestQueryShelleyUtxoWhole_ReturnsLiveUtxos covers GetUTxOWhole against a
+// small set of live UTxOs, proving the query decodes every row's address
+// and amount correctly and keys the result by (tx hash, output index).
+func TestQueryShelleyUtxoWhole_ReturnsLiveUtxos(t *testing.T) {
+	db := newTestDB(t)
+
+	addrA, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0xAA}, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+	addrB, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0xBB}, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+
+	txIdA := seedBabbageUtxo(t, db, 0xA1, 0, addrA, 1_000_000)
+	txIdB := seedBabbageUtxo(t, db, 0xB2, 1, addrB, 2_000_000)
+
+	ls := newPoolDistr2Ledger(t, db)
+
+	result, err := ls.Query(utxoWholeQuery())
+	require.NoError(t, err)
+	arr, ok := result.([]any)
+	require.True(t, ok, "expected the []any result wrapper")
+	require.Len(t, arr, 1)
+
+	utxos, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	require.True(t, ok, "expected a UtxoId map, got %T", arr[0])
+	require.Len(t, utxos, 2)
+
+	outA, ok := utxos[olocalstatequery.UtxoId{
+		Hash: ledger.NewBlake2b256(txIdA),
+		Idx:  0,
+	}]
+	require.True(t, ok, "utxo A missing from the whole UTxO set")
+	require.Equal(t, addrA.String(), outA.Address().String())
+	require.Equal(t, uint64(1_000_000), outA.Amount().Uint64())
+
+	outB, ok := utxos[olocalstatequery.UtxoId{
+		Hash: ledger.NewBlake2b256(txIdB),
+		Idx:  1,
+	}]
+	require.True(t, ok, "utxo B missing from the whole UTxO set")
+	require.Equal(t, addrB.String(), outB.Address().String())
+	require.Equal(t, uint64(2_000_000), outB.Amount().Uint64())
+}
+
+// TestQueryShelleyUtxoWhole_EmptyLedger covers a chain with no UTxOs at
+// all: the query must return an empty, non-nil map rather than failing.
+func TestQueryShelleyUtxoWhole_EmptyLedger(t *testing.T) {
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	result, err := ls.queryShelleyUtxoWhole()
+	require.NoError(t, err)
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+
+	utxos, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	require.True(t, ok)
+	require.Empty(t, utxos)
+}


### PR DESCRIPTION
Addresses #1900 (first increment; #1900 is scoped as a Q3 2026 roadmap item and this does not close it in full — see caveats below).

## Summary

Extends devnet's conformance mode (Dingo + `cardano-node` running side by side) with automated ledger-state divergence detection, per #1900's ask to compare Dingo's ledger state against the Haskell reference node and flag divergence.

- `internal/test/devnet/ledger_state.go`: `LedgerStateAtTip` snapshots a node's UTxO set, stake distribution, and protocol params over LocalStateQuery; `DiffLedgerStates` reports every divergence between two snapshots (capped, human-readable).
- `internal/test/devnet/scenarios/ledger_state_consensus_test.go`: `TestLedgerStateConsensus` (conformance-only), samples ledger state 3 times at tips both nodes agree on and asserts no divergence.
- `internal/test/devnet/docker-compose.yml`, `endpoints_conformance.go`, `run-tests.sh`: expose NtC/LocalStateQuery host ports for both `dingo-producer` and `cardano-producer` in conformance mode (cardano-node's via a `socat` bridge, using the `blinklabs-io/docker-cardano-node` image's existing `SOCAT_PORT` env var).
- `ledger/queries_stakedistribution.go`, `ledger/queries_utxowhole.go` (+ tests): implements Dingo's server-side LocalStateQuery handlers for `GetStakeDistribution`/`GetUTxOWhole`, which the comparison needs and which didn't exist before this PR.

### Known limitation this affects how to read "block-by-block"

Dingo's LocalStateQuery `Acquire` currently ignores the requested point and always answers against live tip (#382 — **documented here, not fixed**). Until that's fixed, there's no way to acquire a specific historical block's ledger view, so this can't yet do a true point-in-time, block-by-block replay comparison as #1900 describes. The workaround used here: only sample ledger state when both nodes' NtN tips are confirmed identical immediately before and after the LocalStateQuery round trip (`TestLedgerStateConsensus`'s retry loop, scaled off `cfg.ExpectedBlockTime()`). This catches genuine ledger-state divergence at settled common tips, just not on every single block in sequence.

### Relationship to other issues

- Partially closes out #394 (`GetStakeDistribution`/`GetUTxOWhole` specifically — the rest of that TODO list is untouched and still open).
- Documents but does not fix #382 (see above).

## Validation status — please read before merging

`golangci-lint run ./...`, `nilaway ./...`, `modernize ./...`, `make import-boundaries`, `make docs-parity`, `make gorm-check`, `make golines`, `go build ./...`, `go vet` (with `devnet`/`devnet_conformance` tags), and `go test -race ./ledger/...` (including the new query-handler tests) all pass.

**`./run-tests.sh --conformance` — the dockerized suite that actually brings up Dingo + `cardano-node` and runs `TestLedgerStateConsensus` end-to-end — has NOT been run.** No Docker daemon access in this environment. Per this repo's CLAUDE.md, DevNet conformance validation is required for anything touching consensus/NtC/LocalStateQuery, which this PR does. **This needs to be run by a human or CI before merge.**

## Docs

- `ARCHITECTURE.md` and `internal/test/devnet/README.md` updated (new LocalStateQuery leaves, topology/port changes, test-scenario table, #382 limitation).
- `DATABASE.md` checked, not applicable (no metadata schema/blob-store/query-surface changes).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automated cross-node ledger-state comparison in devnet conformance mode so `dingo-producer` and `cardano-producer` are checked for equivalence. Previously conformance only verified tip/growth; now it compares protocol parameters, stake distribution, and the whole UTxO and fails on divergence.

Implements server-side LocalStateQuery handlers for `GetStakeDistribution` and `GetUTxOWhole` (closing those two items from #394), exposes NtC for both producers in `internal/test/devnet/docker-compose.yml` (bridging `cardano-node` via `SOCAT_PORT`), adds `LedgerStateAtTip`/`DiffLedgerStates`, and introduces `TestLedgerStateConsensus` that samples several settled common tips. Known limitation: Dingo’s LocalStateQuery `Acquire(point)` still answers at live tip (#382), so the test samples only when both nodes report the same tip immediately before and after the queries; this detects real divergence at common tips but not block-by-block.

- **Review and rollout**
  - Run `./internal/test/devnet/run-tests.sh --conformance` with Docker before merging (conformance is required for consensus/NtC/LocalStateQuery changes).
  - Ensure NtC host ports are available or override: `3020` for `dingo-producer` (`DEVNET_DINGO_NTC_PORT`/`DEVNET_DINGO_NTC_ADDR`), `3021` for `cardano-producer` (`DEVNET_CARDANO_NTC_PORT`/`DEVNET_CARDANO_NTC_ADDR`); `cardano-producer` uses `SOCAT_PORT=3002` to bridge its unix socket.
  - Additive only: new LocalStateQuery leaves; no breaking changes.

<sup>Written for commit c3d221d3b746e9ccfb6258f401ba090fc938f699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying complete live UTxO sets and stake distributions through Local State Query.
  * Stake distribution results now include pool stake fractions and VRF keys.
* **Conformance Testing**
  * Added ledger-state comparisons between Dingo and Cardano at matching chain tips, covering protocol parameters, stake pools, and UTxOs.
  * Added configurable node endpoints and conformance networking support.
* **Documentation**
  * Documented supported queries, ledger-state testing, endpoints, and conformance setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->