### PR TITLE
fix(ledger): Support multiple addresses in UtxosByAddress

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1263,6 +1263,14 @@ address bytes, because the pointer payload is not represented in the
 
 ### `GetUtxosByAddress`, `GetUtxosByAddressAtSlot`, and `GetControlledAmountByCredential`
 
+`GetUtxosByAddress` accepts multiple address patterns and OR-joins their coarse
+SQL branches into a single query, mirroring `GetUtxosByAddressWithOrdering`.
+The coordinated `Database.UtxosByAddress` builds one exact-address pattern per
+input address and applies the same exact-address CBOR filtering as the
+single-address case. This backs the Ouroboros local-state-query `GetUTxOByAddress`
+handler (`ledger.queryShelleyUtxoByAddress`), whose wire request already
+carries a set of addresses.
+
 Live UTxOs for a payment key with assets:
 
 ```sql

--- a/api/mesh/account.go
+++ b/api/mesh/account.go
@@ -67,7 +67,7 @@ func (s *Server) handleAccountBalance(
 			UtxosByAddressAtSlot(addr, point.slot)
 	} else {
 		utxos, err = s.config.LedgerState.UtxosByAddress(
-			addr,
+			[]ledger.Address{addr},
 		)
 	}
 	if err != nil {
@@ -111,7 +111,7 @@ func (s *Server) handleAccountCoins(
 	}
 
 	utxos, err := s.config.LedgerState.UtxosByAddress(
-		addr,
+		[]ledger.Address{addr},
 	)
 	if err != nil {
 		s.logger.Error(

--- a/api/mesh/account_test.go
+++ b/api/mesh/account_test.go
@@ -64,9 +64,10 @@ func TestAccountBalance(t *testing.T) {
 		BlockNumber: 25,
 	}
 	deps.ledger.utxos = func(
-		got lcommon.Address,
+		got []lcommon.Address,
 	) ([]models.Utxo, error) {
-		require.Equal(t, addr, got.String())
+		require.Len(t, got, 1)
+		require.Equal(t, addr, got[0].String())
 		return []models.Utxo{
 			testUtxo(
 				testHash(0x01), 0, 2_000_000, paymentKey, nil,
@@ -121,7 +122,7 @@ func TestAccountBalanceAggregatesAssets(t *testing.T) {
 	policyB := testKeyHash(0xbb)
 	policyA := testKeyHash(0xaa)
 	deps.ledger.utxos = func(
-		lcommon.Address,
+		[]lcommon.Address,
 	) ([]models.Utxo, error) {
 		return []models.Utxo{
 			testUtxo(
@@ -201,7 +202,7 @@ func TestAccountBalanceHistoricalByIndex(t *testing.T) {
 		}, nil
 	}
 	deps.ledger.utxos = func(
-		lcommon.Address,
+		[]lcommon.Address,
 	) ([]models.Utxo, error) {
 		t.Fatal("historical request must not read the tip UTxO set")
 		return nil, nil
@@ -290,7 +291,7 @@ func TestAccountBalanceHistoricalEmptyIdentifier(t *testing.T) {
 	}
 	called := false
 	deps.ledger.utxos = func(
-		lcommon.Address,
+		[]lcommon.Address,
 	) ([]models.Utxo, error) {
 		called = true
 		return nil, nil
@@ -428,7 +429,7 @@ func TestAccountBalanceLedgerError(t *testing.T) {
 		t, lcommon.AddressTypeKeyNone, testKeyHash(0x07), nil,
 	)
 	deps.ledger.utxos = func(
-		lcommon.Address,
+		[]lcommon.Address,
 	) ([]models.Utxo, error) {
 		return nil, errors.New("ledger unavailable")
 	}
@@ -455,7 +456,7 @@ func TestAccountCoins(t *testing.T) {
 		BlockNumber: 3,
 	}
 	deps.ledger.utxos = func(
-		lcommon.Address,
+		[]lcommon.Address,
 	) ([]models.Utxo, error) {
 		return []models.Utxo{
 			testUtxo(
@@ -521,7 +522,7 @@ func TestAccountCoinsLedgerError(t *testing.T) {
 		t, lcommon.AddressTypeKeyNone, testKeyHash(0x0c), nil,
 	)
 	deps.ledger.utxos = func(
-		lcommon.Address,
+		[]lcommon.Address,
 	) ([]models.Utxo, error) {
 		return nil, errors.New("ledger unavailable")
 	}

--- a/api/mesh/node_interface.go
+++ b/api/mesh/node_interface.go
@@ -45,7 +45,7 @@ type MeshDatabase interface {
 type MeshLedgerState interface {
 	GetCurrentPParams() lcommon.ProtocolParameters
 	SlotToTime(slot uint64) (time.Time, error)
-	UtxosByAddress(addr lcommon.Address) ([]models.Utxo, error)
+	UtxosByAddress(addrs []lcommon.Address) ([]models.Utxo, error)
 	// UtxosByAddressAtSlot returns the UTxOs the address held at the
 	// given slot -- those added at or before it and not spent until
 	// after it. It backs historical /account/balance queries.

--- a/api/mesh/testsupport_test.go
+++ b/api/mesh/testsupport_test.go
@@ -115,7 +115,7 @@ func (f *fakeDatabase) GetTransactionsByBlockHash(
 type fakeLedgerState struct {
 	pparams     lcommon.ProtocolParameters
 	slotToTime  func(slot uint64) (time.Time, error)
-	utxos       func(addr lcommon.Address) ([]models.Utxo, error)
+	utxos       func(addrs []lcommon.Address) ([]models.Utxo, error)
 	utxosAtSlot func(
 		addr lcommon.Address,
 		slot uint64,
@@ -140,12 +140,12 @@ func (f *fakeLedgerState) SlotToTime(
 }
 
 func (f *fakeLedgerState) UtxosByAddress(
-	addr lcommon.Address,
+	addrs []lcommon.Address,
 ) ([]models.Utxo, error) {
 	if f.utxos == nil {
 		return nil, nil
 	}
-	return f.utxos(addr)
+	return f.utxos(addrs)
 }
 
 func (f *fakeLedgerState) UtxosByAddressAtSlot(

--- a/database/plugin/metadata/sqlite/shared_sqlstore_utxo_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_utxo_parity_test.go
@@ -72,6 +72,18 @@ func TestSharedSQLStoreUtxoReadParity(t *testing.T) {
 	_ = exerciseUtxoReadStore(t, store)
 }
 
+// TestGetUtxosByAddressEmptyPatterns proves an empty patterns slice returns
+// (nil, nil) rather than models.ErrEmptyUtxoAddressPattern, matching the
+// coordinated Database.UtxosByAddress's empty-input handling for the same
+// slice-based API.
+func TestGetUtxosByAddressEmptyPatterns(t *testing.T) {
+	t.Parallel()
+	store, _ := newSharedSQLStore(t)
+	got, err := store.GetUtxosByAddress(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
 func exerciseUtxoReadStore(t *testing.T, store utxoReadStore) utxoReadState {
 	t.Helper()
 	paymentKey := bytes.Repeat([]byte{0x11}, 28)

--- a/database/plugin/metadata/sqlite/shared_sqlstore_utxo_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_utxo_parity_test.go
@@ -36,7 +36,7 @@ type utxoReadStore interface {
 		types.Txn,
 	) ([]models.Utxo, error)
 	GetUtxosByAddress(
-		models.UtxoAddressPattern,
+		[]models.UtxoAddressPattern,
 		types.Txn,
 	) ([]models.Utxo, error)
 	GetUtxosByAddressAtSlot(
@@ -135,7 +135,10 @@ func exerciseUtxoReadStore(t *testing.T, store utxoReadStore) utxoReadState {
 	ret.deleted, err = store.GetUtxosDeletedBeforeSlot(25, 1, nil)
 	require.NoError(t, err)
 	pattern := models.UtxoAddressPattern{PaymentPart: paymentKey}
-	ret.byAddress, err = store.GetUtxosByAddress(pattern, nil)
+	ret.byAddress, err = store.GetUtxosByAddress(
+		[]models.UtxoAddressPattern{pattern},
+		nil,
+	)
 	require.NoError(t, err)
 	ret.byAddressAtSlot, err = store.GetUtxosByAddressAtSlot(
 		pattern,

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -873,30 +873,77 @@ func (s *Store) GetUtxosDeletedBeforeSlot(
 	return utxosFromSQLite(rows)
 }
 
+// GetUtxosByAddress runs one OR-joined query per parameter-limit-sized chunk
+// of patterns -- a single statement covering every pattern can exceed the
+// dialect's bound-parameter limit (e.g. SQLite's 999) or its OR-expression
+// tree depth limit once enough base (payment + staking) addresses are
+// requested. Candidates are deduplicated by (tx id, output index) across
+// chunks before returning, since a UTxO can only satisfy one address
+// pattern but coarse credential-only branches from different chunks could
+// otherwise resurface the same row.
 func (s *Store) GetUtxosByAddress(
 	patterns []models.UtxoAddressPattern,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
+	if len(patterns) == 0 {
+		return nil, models.ErrEmptyUtxoAddressPattern
+	}
+	limit := s.dialect.ParameterLimit()
+	type utxoKey struct {
+		txId string
+		idx  uint32
+	}
+	seen := make(map[utxoKey]struct{})
+	var ret []models.Utxo
 	var branches []string
 	var args []any
+	runQuery := func() error {
+		if len(branches) == 0 {
+			return nil
+		}
+		utxos, err := s.queryUtxosWithAssets(
+			txn,
+			"utxo.deleted_slot = 0 AND ("+strings.Join(branches, " OR ")+")",
+			args,
+			"",
+		)
+		if err != nil {
+			return err
+		}
+		for i := range utxos {
+			key := utxoKey{string(utxos[i].TxId), utxos[i].OutputIdx}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			ret = append(ret, utxos[i])
+		}
+		branches = nil
+		args = nil
+		return nil
+	}
 	for _, pattern := range patterns {
+		var branchOrs []string
+		var branchArgs []any
 		if err := models.AppendUtxoAddressPatternOrBranch(
-			&branches,
-			&args,
+			&branchOrs,
+			&branchArgs,
 			pattern,
 		); err != nil {
 			return nil, err
 		}
+		if len(args) > 0 && len(args)+len(branchArgs) > limit {
+			if err := runQuery(); err != nil {
+				return nil, err
+			}
+		}
+		branches = append(branches, branchOrs...)
+		args = append(args, branchArgs...)
 	}
-	if len(branches) == 0 {
-		return nil, models.ErrEmptyUtxoAddressPattern
+	if err := runQuery(); err != nil {
+		return nil, err
 	}
-	return s.queryUtxosWithAssets(
-		txn,
-		"utxo.deleted_slot = 0 AND ("+strings.Join(branches, " OR ")+")",
-		args,
-		"",
-	)
+	return ret, nil
 }
 
 func (s *Store) GetUtxosByAddressWithOrdering(

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -893,7 +893,7 @@ func (s *Store) GetUtxosByAddress(
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	if len(patterns) == 0 {
-		return nil, models.ErrEmptyUtxoAddressPattern
+		return nil, nil
 	}
 	db, err := s.readDBFromTxn(txn)
 	if err != nil {

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -883,15 +883,21 @@ func (s *Store) GetUtxosDeletedBeforeSlot(
 // zero-argument branch in AppendUtxoAddressPatternOrBranch, so
 // argument-count alone would never chunk a run of such patterns before the
 // expression tree overflowed. Candidates are deduplicated by (tx id, output
-// index) across chunks before returning, since a UTxO can only satisfy one
-// address pattern but coarse credential-only branches from different
-// chunks could otherwise resurface the same row.
+// index) across chunks -- a coarse, non-selective branch (e.g. the
+// zero-argument fallback above) can return the same candidate rows from
+// every chunk it appears in -- before assets are loaded once on the final
+// deduplicated set, so asset-loading cost is bounded by the result size
+// rather than chunk count times candidate-set size.
 func (s *Store) GetUtxosByAddress(
 	patterns []models.UtxoAddressPattern,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	if len(patterns) == 0 {
 		return nil, models.ErrEmptyUtxoAddressPattern
+	}
+	db, err := s.readDBFromTxn(txn)
+	if err != nil {
+		return nil, err
 	}
 	limit := s.dialect.ParameterLimit()
 	type utxoKey struct {
@@ -906,7 +912,7 @@ func (s *Store) GetUtxosByAddress(
 		if len(branches) == 0 {
 			return nil
 		}
-		utxos, err := s.queryUtxosWithAssets(
+		utxos, err := s.queryUtxos(
 			txn,
 			"utxo.deleted_slot = 0 AND ("+strings.Join(branches, " OR ")+")",
 			args,
@@ -948,6 +954,13 @@ func (s *Store) GetUtxosByAddress(
 		args = append(args, branchArgs...)
 	}
 	if err := runQuery(); err != nil {
+		return nil, err
+	}
+	pointers := make([]*models.Utxo, len(ret))
+	for i := range ret {
+		pointers[i] = &ret[i]
+	}
+	if err := s.loadUtxoAssets(db, pointers); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -1280,7 +1293,12 @@ func (s *Store) IterateLiveUtxos(
 	return rows.Err()
 }
 
-func (s *Store) queryUtxosWithAssets(
+// queryUtxos runs predicate/args against the utxo table and returns the
+// matching rows without loading assets -- callers that need to deduplicate
+// candidates across multiple queries (e.g. chunked GetUtxosByAddress) should
+// use this and load assets once on the final deduplicated set, rather than
+// paying the asset-load cost once per query.
+func (s *Store) queryUtxos(
 	txn types.Txn,
 	predicate string,
 	args []any,
@@ -1316,6 +1334,23 @@ func (s *Store) queryUtxosWithAssets(
 		ret = append(ret, *model)
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (s *Store) queryUtxosWithAssets(
+	txn types.Txn,
+	predicate string,
+	args []any,
+	order string,
+) ([]models.Utxo, error) {
+	db, err := s.readDBFromTxn(txn)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := s.queryUtxos(txn, predicate, args, order)
+	if err != nil {
 		return nil, err
 	}
 	pointers := make([]*models.Utxo, len(ret))

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -874,24 +874,26 @@ func (s *Store) GetUtxosDeletedBeforeSlot(
 }
 
 func (s *Store) GetUtxosByAddress(
-	pattern models.UtxoAddressPattern,
+	patterns []models.UtxoAddressPattern,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
-	var predicates []string
+	var branches []string
 	var args []any
-	if err := models.AppendUtxoAddressPatternOrBranch(
-		&predicates,
-		&args,
-		pattern,
-	); err != nil {
-		return nil, err
+	for _, pattern := range patterns {
+		if err := models.AppendUtxoAddressPatternOrBranch(
+			&branches,
+			&args,
+			pattern,
+		); err != nil {
+			return nil, err
+		}
 	}
-	if len(predicates) == 0 {
+	if len(branches) == 0 {
 		return nil, models.ErrEmptyUtxoAddressPattern
 	}
 	return s.queryUtxosWithAssets(
 		txn,
-		"utxo.deleted_slot = 0 AND "+predicates[0],
+		"utxo.deleted_slot = 0 AND ("+strings.Join(branches, " OR ")+")",
 		args,
 		"",
 	)

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -873,14 +873,19 @@ func (s *Store) GetUtxosDeletedBeforeSlot(
 	return utxosFromSQLite(rows)
 }
 
-// GetUtxosByAddress runs one OR-joined query per parameter-limit-sized chunk
-// of patterns -- a single statement covering every pattern can exceed the
-// dialect's bound-parameter limit (e.g. SQLite's 999) or its OR-expression
-// tree depth limit once enough base (payment + staking) addresses are
-// requested. Candidates are deduplicated by (tx id, output index) across
-// chunks before returning, since a UTxO can only satisfy one address
-// pattern but coarse credential-only branches from different chunks could
-// otherwise resurface the same row.
+// GetUtxosByAddress runs one OR-joined query per chunk of patterns -- a
+// single statement covering every pattern can exceed the dialect's
+// bound-parameter limit (e.g. SQLite's 999) or its OR-expression tree depth
+// limit once enough addresses are requested. Chunking is bounded by both
+// accumulated bind-argument count and branch count: a pattern whose
+// exact-address hash decodes as the zero hash for both payment and staking
+// (e.g. a Byron address with an all-zero payment hash) falls back to a
+// zero-argument branch in AppendUtxoAddressPatternOrBranch, so
+// argument-count alone would never chunk a run of such patterns before the
+// expression tree overflowed. Candidates are deduplicated by (tx id, output
+// index) across chunks before returning, since a UTxO can only satisfy one
+// address pattern but coarse credential-only branches from different
+// chunks could otherwise resurface the same row.
 func (s *Store) GetUtxosByAddress(
 	patterns []models.UtxoAddressPattern,
 	txn types.Txn,
@@ -932,7 +937,9 @@ func (s *Store) GetUtxosByAddress(
 		); err != nil {
 			return nil, err
 		}
-		if len(args) > 0 && len(args)+len(branchArgs) > limit {
+		if len(branches) > 0 &&
+			(len(args)+len(branchArgs) > limit ||
+				len(branches)+len(branchOrs) >= max(1, limit/2)) {
 			if err := runQuery(); err != nil {
 				return nil, err
 			}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1423,7 +1423,9 @@ type MetadataStore interface {
 	// GetUtxosByAddress retrieves coarse SQL candidates matching any of the
 	// given address patterns (OR-joined, mirroring
 	// GetUtxosByAddressWithOrdering). The database layer performs full
-	// exact-address CBOR filtering when ExactAddress is set.
+	// exact-address CBOR filtering when ExactAddress is set. An empty
+	// patterns slice returns (nil, nil), matching the coordinated
+	// Database.UtxosByAddress's empty-input handling.
 	GetUtxosByAddress(
 		[]models.UtxoAddressPattern,
 		types.Txn,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1420,11 +1420,12 @@ type MetadataStore interface {
 	// window for historical transaction queries.
 	GetUtxosBySlot(uint64, types.Txn) ([]models.UtxoId, error)
 
-	// GetUtxosByAddress retrieves coarse SQL candidates for an explicit
-	// address pattern. The database layer performs full exact-address CBOR
-	// filtering when ExactAddress is set.
+	// GetUtxosByAddress retrieves coarse SQL candidates matching any of the
+	// given address patterns (OR-joined, mirroring
+	// GetUtxosByAddressWithOrdering). The database layer performs full
+	// exact-address CBOR filtering when ExactAddress is set.
 	GetUtxosByAddress(
-		models.UtxoAddressPattern,
+		[]models.UtxoAddressPattern,
 		types.Txn,
 	) ([]models.Utxo, error)
 

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -519,19 +519,27 @@ func (d *Database) UtxoByRefIncludingSpent(
 	return utxo, nil
 }
 
+// UtxosByAddress returns all UTxOs belonging to any of the given addresses.
 func (d *Database) UtxosByAddress(
-	addr ledger.Address,
+	addrs []ledger.Address,
 	txn *Txn,
 ) ([]models.Utxo, error) {
+	if len(addrs) == 0 {
+		return nil, nil
+	}
 	if txn == nil {
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	pattern, err := models.ExactUtxoAddressPattern(addr)
-	if err != nil {
-		return nil, err
+	patterns := make([]models.UtxoAddressPattern, len(addrs))
+	for i, addr := range addrs {
+		pattern, err := models.ExactUtxoAddressPattern(addr)
+		if err != nil {
+			return nil, err
+		}
+		patterns[i] = pattern
 	}
-	utxos, err := d.metadata.GetUtxosByAddress(pattern, txn.Metadata())
+	utxos, err := d.metadata.GetUtxosByAddress(patterns, txn.Metadata())
 	if err != nil {
 		return nil, err
 	}
@@ -540,9 +548,7 @@ func (d *Database) UtxosByAddress(
 			return nil, err
 		}
 	}
-	return filterUtxosByAddressPatterns(utxos, []models.UtxoAddressPattern{
-		pattern,
-	})
+	return filterUtxosByAddressPatterns(utxos, patterns)
 }
 
 // GetControlledAmountByCredential returns the sum of live UTxO amounts

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -308,6 +308,58 @@ func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
 	assert.True(t, hasEnterpriseTx)
 }
 
+// TestUtxosByAddressLoadsAssets proves GetUtxosByAddress still attaches
+// native assets to its results after candidate selection was split from
+// asset loading (assets are now loaded once on the deduplicated result set
+// instead of once per chunk -- see GetUtxosByAddress).
+func TestUtxosByAddressLoadsAssets(t *testing.T) {
+	db := openTestDB(t)
+
+	payment := bytes.Repeat([]byte{0x55}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+
+	txHash := bytes.Repeat([]byte{0x99}, 32)
+	policyID := bytes.Repeat([]byte{0x33}, 28)
+	assetName := []byte("asset")
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+		TxId:       txHash,
+		OutputIdx:  0,
+		PaymentKey: addr.PaymentKeyHash().Bytes(),
+		AddedSlot:  1,
+		Amount:     types.Uint64(1_000_000),
+		Assets: []models.Asset{{
+			Name:        assetName,
+			NameHex:     []byte("6173736574"),
+			PolicyId:    policyID,
+			Fingerprint: []byte("fingerprint"),
+			Amount:      5,
+		}},
+	}))
+
+	encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  1_000_000,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+		return db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded)
+	}))
+
+	got, err := db.UtxosByAddress([]lcommon.Address{addr}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Assets, 1)
+	assert.Equal(t, assetName, got[0].Assets[0].Name)
+	assert.Equal(t, policyID, got[0].Assets[0].PolicyId)
+	assert.Equal(t, types.Uint64(5), got[0].Assets[0].Amount)
+}
+
 // seedManyUtxoAddressesAndAssertRoundTrip builds numAddrs addresses via
 // newAddr, seeds a distinct transaction, UTxO row, and blob CBOR for each,
 // then queries GetUtxosByAddress with the full address set in one call and

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -380,3 +380,84 @@ INSERT INTO utxo (
 	}
 	assert.ElementsMatch(t, txIds, gotIDs)
 }
+
+// TestUtxosByAddressManyZeroArgBranches covers patterns whose coarse SQL
+// branch carries no bind arguments at all: a Byron address whose payment
+// hash bytes happen to be all-zero decodes with both PaymentKeyHash and
+// StakeKeyHash reading as the zero hash, so AppendUtxoAddressPatternOrBranch
+// falls back to a fixed "(payment_key IS NULL...) AND (staking_key IS
+// NULL...)" branch with zero args (see AppendUtxoAddressOrBranchMode).
+// GetUtxosByAddress's chunking must not rely on bind-argument count alone
+// to decide when to flush a chunk, or a long run of these zero-arg branches
+// would never trigger a flush and would overflow SQLite's OR-expression
+// tree depth. Every address's UTxO must still come back exactly once.
+func TestUtxosByAddressManyZeroArgBranches(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	zeroPayment := bytes.Repeat([]byte{0x00}, lcommon.AddressHashSize)
+	const numAddrs = 2000
+	addrs := make([]lcommon.Address, numAddrs)
+	txIds := make([][]byte, numAddrs)
+	for i := range addrs {
+		payload := make([]byte, 4)
+		binary.BigEndian.PutUint32(payload, uint32(i)+1)
+		addr, err := lcommon.NewByronAddressFromParts(
+			0,
+			zeroPayment,
+			lcommon.ByronAddressAttributes{Payload: payload},
+		)
+		require.NoError(t, err)
+		require.Equal(
+			t, lcommon.NewBlake2b224(nil), addr.PaymentKeyHash(),
+			"fixture invariant: payment hash must be zero",
+		)
+		require.Equal(
+			t, lcommon.NewBlake2b224(nil), addr.StakeKeyHash(),
+			"fixture invariant: staking hash must be zero",
+		)
+		addrs[i] = addr
+
+		txID := uint(i + 1)
+		txHash := make([]byte, 32)
+		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+		txIds[i] = txHash
+		amount := uint64(i+1) * 1_000_000
+
+		_, err = raw.Exec(`
+INSERT INTO "transaction" (
+    id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
+) VALUES (?, ?, ?, 0, 0, '0', '0', '0', TRUE)`,
+			txID, txHash, uint64(i+1),
+		)
+		require.NoError(t, err)
+		_, err = raw.Exec(`
+INSERT INTO utxo (
+    transaction_id, tx_id, payment_key, staking_key, credential_tag,
+    added_slot, deleted_slot, amount, output_idx, payment_script
+) VALUES (?, ?, NULL, NULL, 0, ?, 0, ?, 0, FALSE)`,
+			txID, txHash, uint64(i+1),
+			strconv.FormatUint(amount, 10),
+		)
+		require.NoError(t, err)
+
+		encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+			OutputAddress: addr,
+			OutputAmount:  amount,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+			return db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded)
+		}))
+	}
+
+	got, err := db.UtxosByAddress(addrs, nil)
+	require.NoError(t, err)
+	require.Len(t, got, numAddrs)
+
+	gotIDs := make([][]byte, len(got))
+	for i := range got {
+		gotIDs[i] = got[i].TxId
+	}
+	assert.ElementsMatch(t, txIds, gotIDs)
+}

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -17,6 +17,7 @@ package database
 import (
 	"bytes"
 	"database/sql"
+	"encoding/binary"
 	"strconv"
 	"testing"
 
@@ -305,4 +306,77 @@ func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
 	hasEnterpriseTx, err := db.HasTransactionsByAddress(enterprise, nil)
 	require.NoError(t, err)
 	assert.True(t, hasEnterpriseTx)
+}
+
+// TestUtxosByAddressExceedsSQLiteParameterLimit proves GetUtxosByAddress
+// chunks patterns instead of building one statement that can overflow
+// SQLite's limits as the address count grows: without chunking, this test's
+// address count fails with "SQL logic error: Expression tree is too large
+// (maximum depth 1000)" (a single WHERE built from that many OR-branches),
+// and a larger count fails on the 999 bound-parameter limit instead. Every
+// address's UTxO must still come back exactly once from the chunked query.
+func TestUtxosByAddressExceedsSQLiteParameterLimit(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	const numAddrs = 2000
+	addrs := make([]lcommon.Address, numAddrs)
+	txIds := make([][]byte, numAddrs)
+	for i := range addrs {
+		payment := make([]byte, lcommon.AddressHashSize)
+		binary.BigEndian.PutUint32(payment, uint32(i)+1)
+		stake := make([]byte, lcommon.AddressHashSize)
+		binary.BigEndian.PutUint32(stake, uint32(i)+1_000_000)
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyKey,
+			lcommon.AddressNetworkTestnet,
+			payment,
+			stake,
+		)
+		require.NoError(t, err)
+		addrs[i] = addr
+
+		txID := uint(i + 1)
+		txHash := make([]byte, 32)
+		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+		txIds[i] = txHash
+		amount := uint64(i+1) * 1_000_000
+
+		_, err = raw.Exec(`
+INSERT INTO "transaction" (
+    id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
+) VALUES (?, ?, ?, 0, 0, '0', '0', '0', TRUE)`,
+			txID, txHash, uint64(i+1),
+		)
+		require.NoError(t, err)
+		_, err = raw.Exec(`
+INSERT INTO utxo (
+    transaction_id, tx_id, payment_key, staking_key, credential_tag,
+    added_slot, deleted_slot, amount, output_idx, payment_script
+) VALUES (?, ?, ?, ?, 0, ?, 0, ?, 0, FALSE)`,
+			txID, txHash, addr.PaymentKeyHash().Bytes(),
+			addr.StakeKeyHash().Bytes(), uint64(i+1),
+			strconv.FormatUint(amount, 10),
+		)
+		require.NoError(t, err)
+
+		encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+			OutputAddress: addr,
+			OutputAmount:  amount,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+			return db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded)
+		}))
+	}
+
+	got, err := db.UtxosByAddress(addrs, nil)
+	require.NoError(t, err)
+	require.Len(t, got, numAddrs)
+
+	gotIDs := make([][]byte, len(got))
+	for i := range got {
+		gotIDs[i] = got[i].TxId
+	}
+	assert.ElementsMatch(t, txIds, gotIDs)
 }

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -379,50 +379,57 @@ func seedManyUtxoAddressesAndAssertRoundTrip(
 	zeroHash := lcommon.NewBlake2b224(nil)
 	addrs := make([]lcommon.Address, numAddrs)
 	txIds := make([][]byte, numAddrs)
-	for i := range addrs {
-		addr := newAddr(i)
-		addrs[i] = addr
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+		for i := range addrs {
+			addr := newAddr(i)
+			addrs[i] = addr
 
-		txID := uint(i + 1)
-		txHash := make([]byte, 32)
-		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
-		txIds[i] = txHash
-		amount := uint64(i+1) * 1_000_000
+			txID := uint(i + 1)
+			txHash := make([]byte, 32)
+			binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+			txIds[i] = txHash
+			amount := uint64(i+1) * 1_000_000
 
-		_, err := raw.Exec(`
+			if _, err := raw.Exec(`
 INSERT INTO "transaction" (
     id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
 ) VALUES (?, ?, ?, 0, 0, '0', '0', '0', TRUE)`,
-			txID, txHash, uint64(i+1),
-		)
-		require.NoError(t, err)
+				txID, txHash, uint64(i+1),
+			); err != nil {
+				return err
+			}
 
-		var paymentKey, stakingKey any
-		if pk := addr.PaymentKeyHash(); pk != zeroHash {
-			paymentKey = pk.Bytes()
-		}
-		if sk := addr.StakeKeyHash(); sk != zeroHash {
-			stakingKey = sk.Bytes()
-		}
-		_, err = raw.Exec(`
+			var paymentKey, stakingKey any
+			if pk := addr.PaymentKeyHash(); pk != zeroHash {
+				paymentKey = pk.Bytes()
+			}
+			if sk := addr.StakeKeyHash(); sk != zeroHash {
+				stakingKey = sk.Bytes()
+			}
+			if _, err := raw.Exec(`
 INSERT INTO utxo (
     transaction_id, tx_id, payment_key, staking_key, credential_tag,
     added_slot, deleted_slot, amount, output_idx, payment_script
 ) VALUES (?, ?, ?, ?, 0, ?, 0, ?, 0, FALSE)`,
-			txID, txHash, paymentKey, stakingKey, uint64(i+1),
-			strconv.FormatUint(amount, 10),
-		)
-		require.NoError(t, err)
+				txID, txHash, paymentKey, stakingKey, uint64(i+1),
+				strconv.FormatUint(amount, 10),
+			); err != nil {
+				return err
+			}
 
-		encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
-			OutputAddress: addr,
-			OutputAmount:  amount,
-		})
-		require.NoError(t, err)
-		require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
-			return db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded)
-		}))
-	}
+			encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+				OutputAddress: addr,
+				OutputAmount:  amount,
+			})
+			if err != nil {
+				return err
+			}
+			if err := db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
 
 	got, err := db.UtxosByAddress(addrs, nil)
 	require.NoError(t, err)

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -181,7 +181,7 @@ func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
 		{name: "pointer two", addr: pointerTwo, want: [][]byte{seeded[2].TxId}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := db.UtxosByAddress(tc.addr, nil)
+			got, err := db.UtxosByAddress([]lcommon.Address{tc.addr}, nil)
 			require.NoError(t, err)
 			gotIDs := make([][]byte, len(got))
 			for i := range got {
@@ -190,6 +190,26 @@ func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
 			assert.ElementsMatch(t, tc.want, gotIDs)
 		})
 	}
+
+	t.Run("multiple addresses", func(t *testing.T) {
+		got, err := db.UtxosByAddress(
+			[]lcommon.Address{enterprise, base},
+			nil,
+		)
+		require.NoError(t, err)
+		gotIDs := make([][]byte, len(got))
+		for i := range got {
+			gotIDs[i] = got[i].TxId
+		}
+		assert.ElementsMatch(
+			t,
+			[][]byte{
+				seeded[1].TxId, seeded[3].TxId, seeded[5].TxId,
+				seeded[4].TxId,
+			},
+			gotIDs,
+		)
+	})
 
 	pattern, err := models.ExactUtxoAddressPattern(enterprise)
 	require.NoError(t, err)

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -308,32 +308,27 @@ func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
 	assert.True(t, hasEnterpriseTx)
 }
 
-// TestUtxosByAddressExceedsSQLiteParameterLimit proves GetUtxosByAddress
-// chunks patterns instead of building one statement that can overflow
-// SQLite's limits as the address count grows: without chunking, this test's
-// address count fails with "SQL logic error: Expression tree is too large
-// (maximum depth 1000)" (a single WHERE built from that many OR-branches),
-// and a larger count fails on the 999 bound-parameter limit instead. Every
-// address's UTxO must still come back exactly once from the chunked query.
-func TestUtxosByAddressExceedsSQLiteParameterLimit(t *testing.T) {
+// seedManyUtxoAddressesAndAssertRoundTrip builds numAddrs addresses via
+// newAddr, seeds a distinct transaction, UTxO row, and blob CBOR for each,
+// then queries GetUtxosByAddress with the full address set in one call and
+// asserts every address's UTxO comes back exactly once. Shared by the
+// chunking-boundary tests below, which differ only in how the address (and
+// therefore its stored payment/staking key columns, which are NULL when the
+// address's credential hash is the zero hash) is constructed.
+func seedManyUtxoAddressesAndAssertRoundTrip(
+	t *testing.T,
+	numAddrs int,
+	newAddr func(i int) lcommon.Address,
+) {
+	t.Helper()
 	db := openTestDB(t)
 	raw := rawSQLiteMetadataFixture(t, db)
 
-	const numAddrs = 2000
+	zeroHash := lcommon.NewBlake2b224(nil)
 	addrs := make([]lcommon.Address, numAddrs)
 	txIds := make([][]byte, numAddrs)
 	for i := range addrs {
-		payment := make([]byte, lcommon.AddressHashSize)
-		binary.BigEndian.PutUint32(payment, uint32(i)+1)
-		stake := make([]byte, lcommon.AddressHashSize)
-		binary.BigEndian.PutUint32(stake, uint32(i)+1_000_000)
-		addr, err := lcommon.NewAddressFromParts(
-			lcommon.AddressTypeKeyKey,
-			lcommon.AddressNetworkTestnet,
-			payment,
-			stake,
-		)
-		require.NoError(t, err)
+		addr := newAddr(i)
 		addrs[i] = addr
 
 		txID := uint(i + 1)
@@ -342,20 +337,27 @@ func TestUtxosByAddressExceedsSQLiteParameterLimit(t *testing.T) {
 		txIds[i] = txHash
 		amount := uint64(i+1) * 1_000_000
 
-		_, err = raw.Exec(`
+		_, err := raw.Exec(`
 INSERT INTO "transaction" (
     id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
 ) VALUES (?, ?, ?, 0, 0, '0', '0', '0', TRUE)`,
 			txID, txHash, uint64(i+1),
 		)
 		require.NoError(t, err)
+
+		var paymentKey, stakingKey any
+		if pk := addr.PaymentKeyHash(); pk != zeroHash {
+			paymentKey = pk.Bytes()
+		}
+		if sk := addr.StakeKeyHash(); sk != zeroHash {
+			stakingKey = sk.Bytes()
+		}
 		_, err = raw.Exec(`
 INSERT INTO utxo (
     transaction_id, tx_id, payment_key, staking_key, credential_tag,
     added_slot, deleted_slot, amount, output_idx, payment_script
 ) VALUES (?, ?, ?, ?, 0, ?, 0, ?, 0, FALSE)`,
-			txID, txHash, addr.PaymentKeyHash().Bytes(),
-			addr.StakeKeyHash().Bytes(), uint64(i+1),
+			txID, txHash, paymentKey, stakingKey, uint64(i+1),
 			strconv.FormatUint(amount, 10),
 		)
 		require.NoError(t, err)
@@ -381,6 +383,32 @@ INSERT INTO utxo (
 	assert.ElementsMatch(t, txIds, gotIDs)
 }
 
+// TestUtxosByAddressExceedsSQLiteParameterLimit proves GetUtxosByAddress
+// chunks patterns instead of building one statement that can overflow
+// SQLite's limits as the address count grows: without chunking, this test's
+// address count fails with "SQL logic error: Expression tree is too large
+// (maximum depth 1000)" (a single WHERE built from that many OR-branches),
+// and a larger count fails on the 999 bound-parameter limit instead. Every
+// address's UTxO must still come back exactly once from the chunked query.
+func TestUtxosByAddressExceedsSQLiteParameterLimit(t *testing.T) {
+	seedManyUtxoAddressesAndAssertRoundTrip(
+		t, 2000, func(i int) lcommon.Address {
+			payment := make([]byte, lcommon.AddressHashSize)
+			binary.BigEndian.PutUint32(payment, uint32(i)+1)
+			stake := make([]byte, lcommon.AddressHashSize)
+			binary.BigEndian.PutUint32(stake, uint32(i)+1_000_000)
+			addr, err := lcommon.NewAddressFromParts(
+				lcommon.AddressTypeKeyKey,
+				lcommon.AddressNetworkTestnet,
+				payment,
+				stake,
+			)
+			require.NoError(t, err)
+			return addr
+		},
+	)
+}
+
 // TestUtxosByAddressManyZeroArgBranches covers patterns whose coarse SQL
 // branch carries no bind arguments at all: a Byron address whose payment
 // hash bytes happen to be all-zero decodes with both PaymentKeyHash and
@@ -392,72 +420,27 @@ INSERT INTO utxo (
 // would never trigger a flush and would overflow SQLite's OR-expression
 // tree depth. Every address's UTxO must still come back exactly once.
 func TestUtxosByAddressManyZeroArgBranches(t *testing.T) {
-	db := openTestDB(t)
-	raw := rawSQLiteMetadataFixture(t, db)
-
 	zeroPayment := bytes.Repeat([]byte{0x00}, lcommon.AddressHashSize)
-	const numAddrs = 2000
-	addrs := make([]lcommon.Address, numAddrs)
-	txIds := make([][]byte, numAddrs)
-	for i := range addrs {
-		payload := make([]byte, 4)
-		binary.BigEndian.PutUint32(payload, uint32(i)+1)
-		addr, err := lcommon.NewByronAddressFromParts(
-			0,
-			zeroPayment,
-			lcommon.ByronAddressAttributes{Payload: payload},
-		)
-		require.NoError(t, err)
-		require.Equal(
-			t, lcommon.NewBlake2b224(nil), addr.PaymentKeyHash(),
-			"fixture invariant: payment hash must be zero",
-		)
-		require.Equal(
-			t, lcommon.NewBlake2b224(nil), addr.StakeKeyHash(),
-			"fixture invariant: staking hash must be zero",
-		)
-		addrs[i] = addr
-
-		txID := uint(i + 1)
-		txHash := make([]byte, 32)
-		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
-		txIds[i] = txHash
-		amount := uint64(i+1) * 1_000_000
-
-		_, err = raw.Exec(`
-INSERT INTO "transaction" (
-    id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
-) VALUES (?, ?, ?, 0, 0, '0', '0', '0', TRUE)`,
-			txID, txHash, uint64(i+1),
-		)
-		require.NoError(t, err)
-		_, err = raw.Exec(`
-INSERT INTO utxo (
-    transaction_id, tx_id, payment_key, staking_key, credential_tag,
-    added_slot, deleted_slot, amount, output_idx, payment_script
-) VALUES (?, ?, NULL, NULL, 0, ?, 0, ?, 0, FALSE)`,
-			txID, txHash, uint64(i+1),
-			strconv.FormatUint(amount, 10),
-		)
-		require.NoError(t, err)
-
-		encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
-			OutputAddress: addr,
-			OutputAmount:  amount,
-		})
-		require.NoError(t, err)
-		require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
-			return db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded)
-		}))
-	}
-
-	got, err := db.UtxosByAddress(addrs, nil)
-	require.NoError(t, err)
-	require.Len(t, got, numAddrs)
-
-	gotIDs := make([][]byte, len(got))
-	for i := range got {
-		gotIDs[i] = got[i].TxId
-	}
-	assert.ElementsMatch(t, txIds, gotIDs)
+	zeroHash := lcommon.NewBlake2b224(nil)
+	seedManyUtxoAddressesAndAssertRoundTrip(
+		t, 2000, func(i int) lcommon.Address {
+			payload := make([]byte, 4)
+			binary.BigEndian.PutUint32(payload, uint32(i)+1)
+			addr, err := lcommon.NewByronAddressFromParts(
+				0,
+				zeroPayment,
+				lcommon.ByronAddressAttributes{Payload: payload},
+			)
+			require.NoError(t, err)
+			require.Equal(
+				t, zeroHash, addr.PaymentKeyHash(),
+				"fixture invariant: payment hash must be zero",
+			)
+			require.Equal(
+				t, zeroHash, addr.StakeKeyHash(),
+				"fixture invariant: staking hash must be zero",
+			)
+			return addr
+		},
+	)
 }

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -183,7 +183,7 @@ func BenchmarkUtxoLookupByAddressNoData(b *testing.B) {
 
 	// Benchmark lookup (on empty database for now)
 	for b.Loop() {
-		_, err := db.UtxosByAddress(testAddr, nil)
+		_, err := db.UtxosByAddress([]ledger.Address{testAddr}, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -223,7 +223,7 @@ func BenchmarkUtxoLookupByAddressRealData(b *testing.B) {
 
 	// Benchmark lookup against real seeded data
 	for b.Loop() {
-		_, err := db.UtxosByAddress(testAddr, nil)
+		_, err := db.UtxosByAddress([]ledger.Address{testAddr}, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -2829,7 +2829,7 @@ func BenchmarkConcurrentQueries(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				res, err := db.UtxosByAddress(testAddr, nil)
+				res, err := db.UtxosByAddress([]ledger.Address{testAddr}, nil)
 				_ = res
 				_ = err // Ignore errors for benchmark
 

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -984,8 +984,7 @@ func (ls *LedgerState) queryShelleyUtxoByAddress(
 	if len(addrs) == 0 {
 		return []any{ret}, nil
 	}
-	// TODO: support multiple addresses (#391)
-	utxos, err := ls.db.UtxosByAddress(addrs[0], nil)
+	utxos, err := ls.db.UtxosByAddress(addrs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/ledger/eras"
@@ -34,6 +35,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -166,6 +168,66 @@ func TestQueryShelleyUtxoByAddress_EmptySlice(t *testing.T) {
 	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
 	require.True(t, ok, "expected UtxoId map")
 	require.Empty(t, m)
+}
+
+// TestQueryShelleyUtxoByAddress_MultipleAddresses proves the local-state-query
+// handler resolves UTxOs for every address in the request, not just the
+// first (#391) -- the wire query already carries the full set via q.Addrs.
+func TestQueryShelleyUtxoByAddress_MultipleAddresses(t *testing.T) {
+	db := newTestDB(t)
+
+	seedAddressUtxo := func(
+		addr lcommon.Address,
+		txId []byte,
+		amount uint64,
+	) {
+		require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+			TxId:       txId,
+			OutputIdx:  0,
+			PaymentKey: addr.PaymentKeyHash().Bytes(),
+			AddedSlot:  1,
+			Amount:     types.Uint64(amount),
+		}))
+		encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+			OutputAddress: addr,
+			OutputAmount:  amount,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.BlobTxn(true).Do(func(txn *database.Txn) error {
+			return db.Blob().SetUtxo(txn.Blob(), txId, 0, encoded)
+		}))
+	}
+
+	addr1, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0xa1}, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+	addr2, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0xa2}, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+
+	txId1 := bytes.Repeat([]byte{0x01}, 32)
+	txId2 := bytes.Repeat([]byte{0x02}, 32)
+	seedAddressUtxo(addr1, txId1, 1_000_000)
+	seedAddressUtxo(addr2, txId2, 2_000_000)
+
+	ls := &LedgerState{db: db}
+	result, err := ls.queryShelleyUtxoByAddress([]ledger.Address{addr1, addr2})
+	require.NoError(t, err)
+
+	arr, ok := result.([]any)
+	require.True(t, ok, "expected []any result")
+	require.Len(t, arr, 1)
+	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	require.True(t, ok, "expected UtxoId map")
+	require.Len(t, m, 2, "must include UTxOs for both addresses, not just addrs[0]")
 }
 
 func TestQueryShelleyUtxoByTxIn_EmptySlice(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -7106,11 +7106,11 @@ func (ls *LedgerState) UtxoByRef(
 	return ls.db.UtxoByRef(txId, outputIdx, nil)
 }
 
-// UtxosByAddress returns all UTxOs that belong to the specified address
+// UtxosByAddress returns all UTxOs that belong to any of the specified addresses
 func (ls *LedgerState) UtxosByAddress(
-	addr ledger.Address,
+	addrs []ledger.Address,
 ) ([]models.Utxo, error) {
-	utxos, err := ls.db.UtxosByAddress(addr, nil)
+	utxos, err := ls.db.UtxosByAddress(addrs, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`ls.db.UtxosByAddress` — the handler backing the Ouroboros n2c local-state query `GetUTxOByAddress` — only ever looked up the first address in a multi-address request and silently dropped the rest, despite the wire protocol already carrying the full set (`q.Addrs`). This threads a real address-set (`[]ledger.Address`) all the way down through the ledger and database layers, reusing the OR-branch idiom `GetUtxosByAddressWithOrdering` already uses for its multi-pattern support, so a single SQL query now resolves UTxOs for every requested address instead of issuing N round trips.

## Changes

**Core fix**
- `ledger/queries.go` — `queryShelleyUtxoByAddress` now passes the full `addrs` slice to `ls.db.UtxosByAddress` instead of `addrs[0]`; removed the `// TODO: support multiple addresses (#391)` comment.

**Plumbing (`Database` → `LedgerState` → API)**
- `database/utxo.go` — `Database.UtxosByAddress` now takes `[]ledger.Address`, builds one exact-address pattern per input address, and filters candidates against the full pattern set. Empty input returns `nil, nil`.
- `database/plugin/metadata/store.go` — `MetadataStore.GetUtxosByAddress` interface now takes `[]models.UtxoAddressPattern` instead of a single pattern.
- `database/plugin/metadata/sqlstore/utxo.go` — `GetUtxosByAddress` loops over all patterns, OR-joining their branches into one SQL predicate (same pattern as `GetUtxosByAddressWithOrdering`), instead of only ever using `predicates[0]`.
- `ledger/state.go` — `LedgerState.UtxosByAddress` signature updated to `[]ledger.Address`; doc comment updated ("any of the specified addresses").
- `api/mesh/node_interface.go` — `MeshLedgerState.UtxosByAddress` interface updated to `[]lcommon.Address` to match. Mesh/Rosetta itself stays single-address by protocol design.
- `api/mesh/account.go` — both call sites (`handleAccountBalance`, `handleAccountCoins`) wrap their single address in a one-element slice.

**Tests**
- `ledger/queries_test.go` — new `TestQueryShelleyUtxoByAddress_MultipleAddresses`: seeds two UTxOs on two different addresses (metadata + blob CBOR), queries both in one call, asserts both come back — the direct regression test for the bug.
- `database/utxo_exact_address_test.go` — new "multiple addresses" subtest asserting the union of two addresses' UTxOs is returned from a single call, without picking up unrelated pointer/base addresses sharing the same payment key.
- `database/plugin/metadata/sqlite/shared_sqlstore_utxo_parity_test.go`, `ledger/benchmark_test.go`, `api/mesh/testsupport_test.go`, `api/mesh/account_test.go` — updated call sites and the fake `MeshLedgerState.UtxosByAddress` mock to the new signature.

**Docs**
- `DATABASE.md` — documented that `GetUtxosByAddress` now accepts multiple patterns and OR-joins them, and notes it backs the n2c `GetUTxOByAddress` handler.

Closes #391 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return UTxOs for all addresses in Ouroboros `GetUTxOByAddress`; previously only the first address was queried. Queries now OR-join all address patterns and chunk large sets to avoid SQLite limits.

- Key changes:
  - Thread `[]ledger.Address` through the stack: `Database.UtxosByAddress(addrs []ledger.Address)` and `MetadataStore.GetUtxosByAddress(patterns []models.UtxoAddressPattern)` OR-join all patterns.
  - Chunk by bound-parameter and OR-branch counts; deduplicate by (tx id, output index) across chunks.
  - Load UTxO assets once on the final deduplicated set. Preserve exact-address CBOR filtering. Empty input returns `nil, nil`.
  - Mesh/Rosetta remain single-address by protocol and now wrap the address.

- Migration:
  - Update callers/mocks to new signatures: `LedgerState.UtxosByAddress([]ledger.Address)`, `MeshLedgerState.UtxosByAddress([]lcommon.Address)`, `MetadataStore.GetUtxosByAddress([]models.UtxoAddressPattern)`. Wrap single-address calls in a one-element slice.

<sup>Written for commit d9324b2ded10067cd036c20d84822a249ab96f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving UTxOs associated with multiple addresses in a single request.
  * Multi-address queries now return the combined results for all supplied addresses.
  * Added exact address matching to ensure only intended UTxOs are returned.
* **Bug Fixes**
  * Fixed local state queries that previously handled only the first address in multi-address requests.
* **Documentation**
  * Documented multi-address UTxO query support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->