### PR TITLE
feat(ledger): Support multiple TxIns in UtxosByTxIn query

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1193,6 +1193,30 @@ WHERE u.tx_id = decode($1, 'hex')
   AND u.output_idx = $2;
 ```
 
+### `GetUtxosByRefs`
+
+Batched live-UTxO lookup by a list of (tx hash, output index) references —
+used by the `GetUTxOByTxIn` n2c query and the `utxorpc` `ReadUtxos` RPC to
+resolve multiple TxIns/keys in one round trip instead of one query per input
+(#392). Refs with no matching live UTxO are simply absent from the result;
+callers must not treat a partial result as an error. Builds an OR-chain of
+`(tx_id = ? AND output_idx = ?)` predicates — the same portable pattern used
+by `MarkUtxosDeletedAtSlot`/`utxoIDPredicate` elsewhere in this file — chunked
+at 400 refs (800 bind variables) to stay within SQLite's conservative
+999-parameter limit:
+
+```sql
+SELECT u.*, a.*
+FROM utxo u
+LEFT JOIN asset a ON a.utxo_id = u.id
+WHERE u.deleted_slot = 0
+  AND (
+    (u.tx_id = decode($1, 'hex') AND u.output_idx = $2)
+    OR (u.tx_id = decode($3, 'hex') AND u.output_idx = $4)
+    -- ... one pair of bind variables per requested ref
+  );
+```
+
 ### `GetTransactionsByAddress` and `CountTransactionsByAddress`
 
 Recent transactions for an address key pair:

--- a/api/utxorpc/node_interface.go
+++ b/api/utxorpc/node_interface.go
@@ -64,6 +64,7 @@ type UtxorpcLedgerState interface {
 	Tip() ochainsync.Tip
 	TransactionByHash(hash []byte) (*models.Transaction, error)
 	UtxoByRef(txId []byte, outputIdx uint32) (*models.Utxo, error)
+	UtxosByRefs(refs []models.UtxoId) ([]models.Utxo, error)
 	UtxosByAddressWithOrdering(
 		q *models.UtxoWithOrderingQuery,
 	) ([]models.UtxoWithOrdering, error)

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -408,6 +408,13 @@ func (s *queryServiceServer) ReadEraSummary(
 	return connect.NewResponse(resp), nil
 }
 
+// utxoRefKey builds a comparable map key for a (tx hash, output index) UTxO
+// reference; models.UtxoId embeds a []byte and so cannot be used as a map
+// key directly.
+func utxoRefKey(hash []byte, idx uint32) string {
+	return string(hash) + ":" + strconv.FormatUint(uint64(idx), 10)
+}
+
 // ReadUtxos
 func (s *queryServiceServer) ReadUtxos(
 	ctx context.Context,
@@ -433,14 +440,26 @@ func (s *queryServiceServer) ReadUtxos(
 
 	resp := &query.ReadUtxosResponse{}
 
+	// Resolve all requested refs in a single batch, then correlate results
+	// back to each requested key below.
+	refs := make([]models.UtxoId, len(keys))
+	for i, txo := range keys {
+		refs[i] = models.UtxoId{Hash: txo.GetHash(), Idx: txo.GetIndex()}
+	}
+	utxos, err := s.utxorpc.config.LedgerState.UtxosByRefs(refs)
+	if err != nil {
+		return nil, err
+	}
+	utxoByRef := make(map[string]*models.Utxo, len(utxos))
+	for i := range utxos {
+		utxoByRef[utxoRefKey(utxos[i].TxId, utxos[i].OutputIdx)] = &utxos[i]
+	}
+
 	// Get UTxOs from ledger
 	for _, txo := range keys {
-		utxo, err := s.utxorpc.config.LedgerState.UtxoByRef(
-			txo.GetHash(),
-			txo.GetIndex(),
-		)
-		if err != nil {
-			return nil, err
+		utxo, ok := utxoByRef[utxoRefKey(txo.GetHash(), txo.GetIndex())]
+		if !ok {
+			return nil, database.ErrUtxoNotFound
 		}
 		var aud query.AnyUtxoData
 		ret, err := utxo.Decode()

--- a/api/utxorpc/rpc_connect_test.go
+++ b/api/utxorpc/rpc_connect_test.go
@@ -644,10 +644,14 @@ func TestConnect_ReadUtxos_MultipleKeys(t *testing.T) {
 		"fixture should expose at least two live UTxOs",
 	)
 	keys := make([]*query.TxoRef, 0, len(searchOut.Msg.GetItems()))
+	wantNativeBytes := make([][]byte, 0, len(searchOut.Msg.GetItems()))
 	for _, item := range searchOut.Msg.GetItems() {
 		ref := item.GetTxoRef()
 		require.NotNil(t, ref)
+		nativeBytes := item.GetNativeBytes()
+		require.NotNil(t, nativeBytes)
 		keys = append(keys, ref)
+		wantNativeBytes = append(wantNativeBytes, nativeBytes)
 	}
 	out, err := cli.ReadUtxos(
 		ctx,
@@ -660,6 +664,18 @@ func TestConnect_ReadUtxos_MultipleKeys(t *testing.T) {
 		require.NotNil(t, gotRef)
 		require.Equal(t, keys[i].GetHash(), gotRef.GetHash())
 		require.Equal(t, keys[i].GetIndex(), gotRef.GetIndex())
+		// ReadUtxos echoes the requested TxoRef regardless of which UTxO
+		// it resolved, so also compare the resolved content itself
+		// (NativeBytes) against what SearchUtxos independently found for
+		// this same key: a mis-correlated batch lookup would still pass
+		// the ref-only checks above but fail this one.
+		require.NotEmpty(t, item.GetNativeBytes())
+		require.Equal(
+			t,
+			wantNativeBytes[i],
+			item.GetNativeBytes(),
+			"ReadUtxos should return the same UTxO content SearchUtxos found for this key",
+		)
 	}
 }
 

--- a/api/utxorpc/rpc_connect_test.go
+++ b/api/utxorpc/rpc_connect_test.go
@@ -620,6 +620,86 @@ func TestConnect_ReadUtxos(t *testing.T) {
 	require.NotNil(t, out.Msg.GetLedgerTip())
 }
 
+// TestConnect_ReadUtxos_MultipleKeys proves ReadUtxos resolves several keys
+// in a single request via the batched UTxO lookup (#392), returning exactly
+// one item per requested key.
+func TestConnect_ReadUtxos_MultipleKeys(t *testing.T) {
+	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{numBlocks: 20})
+	cli := queryconnect.NewQueryServiceClient(
+		h.Client,
+		h.Server.URL,
+		connect.WithGRPC(),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	searchOut, err := cli.SearchUtxos(
+		ctx,
+		connect.NewRequest(&query.SearchUtxosRequest{MaxItems: 5}),
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(
+		t,
+		len(searchOut.Msg.GetItems()),
+		2,
+		"fixture should expose at least two live UTxOs",
+	)
+	keys := make([]*query.TxoRef, 0, len(searchOut.Msg.GetItems()))
+	for _, item := range searchOut.Msg.GetItems() {
+		ref := item.GetTxoRef()
+		require.NotNil(t, ref)
+		keys = append(keys, ref)
+	}
+	out, err := cli.ReadUtxos(
+		ctx,
+		connect.NewRequest(&query.ReadUtxosRequest{Keys: keys}),
+	)
+	require.NoError(t, err)
+	require.Len(t, out.Msg.GetItems(), len(keys))
+	for i, item := range out.Msg.GetItems() {
+		gotRef := item.GetTxoRef()
+		require.NotNil(t, gotRef)
+		require.Equal(t, keys[i].GetHash(), gotRef.GetHash())
+		require.Equal(t, keys[i].GetIndex(), gotRef.GetIndex())
+	}
+}
+
+// TestConnect_ReadUtxos_MissingKey proves a request that includes a ref
+// with no matching live UTxO still errors the whole call, preserving the
+// pre-existing ReadUtxos error-on-miss contract (unlike the ledger-level
+// GetUTxOByTxIn query, which silently omits misses for batch lookups).
+func TestConnect_ReadUtxos_MissingKey(t *testing.T) {
+	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{numBlocks: 20})
+	cli := queryconnect.NewQueryServiceClient(
+		h.Client,
+		h.Server.URL,
+		connect.WithGRPC(),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	searchOut, err := cli.SearchUtxos(
+		ctx,
+		connect.NewRequest(&query.SearchUtxosRequest{MaxItems: 1}),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(
+		t,
+		searchOut.Msg.GetItems(),
+		"fixture should expose at least one live UTxO",
+	)
+	ref := searchOut.Msg.GetItems()[0].GetTxoRef()
+	bogusRef := &query.TxoRef{
+		Hash:  bytes.Repeat([]byte{0}, 32),
+		Index: 9999,
+	}
+	_, err = cli.ReadUtxos(
+		ctx,
+		connect.NewRequest(&query.ReadUtxosRequest{
+			Keys: []*query.TxoRef{ref, bogusRef},
+		}),
+	)
+	require.Error(t, err)
+}
+
 func TestConnect_ReadData_EmptyKeys(t *testing.T) {
 	h := newUtxorpcConnectHarness(t, utxorpcHarnessOptions{numBlocks: 5})
 	cli := queryconnect.NewQueryServiceClient(

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -768,12 +768,14 @@ func (s *Store) getUtxo(
 
 // GetUtxosByRefs retrieves multiple live UTxOs by their (tx_id, output_idx)
 // references in a single batch. Refs with no matching live UTxO are simply
-// absent from the result.
+// absent from the result. A ref repeated in the input yields at most one
+// row, keeping one-row-per-requested-ref semantics for callers.
 func (s *Store) GetUtxosByRefs(
 	refs []models.UtxoId,
 	txn types.Txn,
 ) ([]models.Utxo, error) {
 	ret := []models.Utxo{}
+	refs = dedupeUtxoIDs(refs)
 	// Two bind variables per reference; 400 keeps this portable to
 	// SQLite's conservative 999-parameter configuration.
 	for start := 0; start < len(refs); start += 400 {
@@ -791,6 +793,22 @@ func (s *Store) GetUtxosByRefs(
 		ret = append(ret, utxos...)
 	}
 	return ret, nil
+}
+
+// dedupeUtxoIDs returns ids with duplicate (Hash, Idx) pairs removed,
+// preserving the order of first occurrence.
+func dedupeUtxoIDs(ids []models.UtxoId) []models.UtxoId {
+	seen := make(map[string]struct{}, len(ids))
+	ret := make([]models.UtxoId, 0, len(ids))
+	for _, id := range ids {
+		key := fmt.Sprintf("%s:%d", id.Hash, id.Idx)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		ret = append(ret, id)
+	}
+	return ret
 }
 
 func (s *Store) GetUtxosAddedAfterSlot(

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -766,6 +766,33 @@ func (s *Store) getUtxo(
 	return ret, nil
 }
 
+// GetUtxosByRefs retrieves multiple live UTxOs by their (tx_id, output_idx)
+// references in a single batch. Refs with no matching live UTxO are simply
+// absent from the result.
+func (s *Store) GetUtxosByRefs(
+	refs []models.UtxoId,
+	txn types.Txn,
+) ([]models.Utxo, error) {
+	ret := []models.Utxo{}
+	// Two bind variables per reference; 400 keeps this portable to
+	// SQLite's conservative 999-parameter configuration.
+	for start := 0; start < len(refs); start += 400 {
+		end := min(start+400, len(refs))
+		predicate, args := utxoIDPredicate(refs[start:end])
+		utxos, err := s.queryUtxosWithAssets(
+			txn,
+			"deleted_slot = 0 AND ("+predicate+")",
+			args,
+			"",
+		)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, utxos...)
+	}
+	return ret, nil
+}
+
 func (s *Store) GetUtxosAddedAfterSlot(
 	slot uint64,
 	txn types.Txn,

--- a/database/plugin/metadata/sqlstore/utxo_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDedupeUtxoIDs proves GetUtxosByRefs' input deduplication removes
+// repeated (Hash, Idx) pairs, including a repeat that would otherwise land
+// in a different 400-ref chunk, while preserving order of first occurrence
+// and leaving distinct refs (including a same-hash-different-index pair)
+// untouched (#392).
+func TestDedupeUtxoIDs(t *testing.T) {
+	hashA := []byte{0x01, 0x02, 0x03}
+	hashB := []byte{0x04, 0x05, 0x06}
+
+	ids := []models.UtxoId{
+		{Hash: hashA, Idx: 0},
+		{Hash: hashB, Idx: 0},
+		{Hash: hashA, Idx: 0}, // duplicate of the first
+		{Hash: hashA, Idx: 1}, // same hash, different index: distinct
+	}
+
+	got := dedupeUtxoIDs(ids)
+	require.Equal(t, []models.UtxoId{
+		{Hash: hashA, Idx: 0},
+		{Hash: hashB, Idx: 0},
+		{Hash: hashA, Idx: 1},
+	}, got)
+}
+
+// TestDedupeUtxoIDs_CrossChunkDuplicate proves a duplicate ref is removed
+// even when the two occurrences would fall into different 400-ref chunks
+// inside GetUtxosByRefs.
+func TestDedupeUtxoIDs_CrossChunkDuplicate(t *testing.T) {
+	dup := models.UtxoId{Hash: []byte{0xAA}, Idx: 42}
+
+	ids := make([]models.UtxoId, 0, 401)
+	ids = append(ids, dup)
+	for i := range 399 {
+		ids = append(ids, models.UtxoId{
+			Hash: []byte{byte(i), byte(i >> 8)},
+			Idx:  uint32(i),
+		})
+	}
+	// Placed at index 400, past the first 400-ref chunk boundary.
+	ids = append(ids, dup)
+
+	got := dedupeUtxoIDs(ids)
+	require.Len(t, got, 400, "cross-chunk duplicate should be removed")
+
+	count := 0
+	for _, id := range got {
+		if id.Idx == dup.Idx && string(id.Hash) == string(dup.Hash) {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "duplicate ref must appear exactly once")
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -976,6 +976,14 @@ type MetadataStore interface {
 		types.Txn,
 	) (*models.Utxo, error)
 
+	// GetUtxosByRefs retrieves multiple live unspent transaction outputs
+	// by their (transaction ID, index) references in a single batch.
+	// Refs with no matching live UTxO are simply absent from the result.
+	GetUtxosByRefs(
+		[]models.UtxoId, // refs
+		types.Txn,
+	) ([]models.Utxo, error)
+
 	// GetTransactionByHash retrieves a transaction by its hash.
 	GetTransactionByHash(
 		[]byte, // hash

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -477,6 +477,29 @@ func (d *Database) UtxoByRef(
 	return utxo, nil
 }
 
+// UtxosByRefs returns the live UTxOs matching the given references in a
+// single batch. Refs with no matching live UTxO are simply absent from the
+// result.
+func (d *Database) UtxosByRefs(
+	refs []models.UtxoId,
+	txn *Txn,
+) ([]models.Utxo, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	utxos, err := d.metadata.GetUtxosByRefs(refs, txn.Metadata())
+	if err != nil {
+		return nil, err
+	}
+	for i := range utxos {
+		if err := loadCbor(&utxos[i], txn); err != nil {
+			return nil, err
+		}
+	}
+	return utxos, nil
+}
+
 // CreateUtxo inserts a Utxo row directly. The normal block-application
 // path uses AddUtxos with UtxoSlot inputs; this is the simple-insert
 // variant for callers that already have a populated model. When txn

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -1278,23 +1278,27 @@ func (ls *LedgerState) queryShelleyUtxoByTxIn(
 	if len(txIns) == 0 {
 		return []any{ret}, nil
 	}
-	// TODO: support multiple TxIns (#392)
-	utxo, err := ls.db.UtxoByRef(
-		txIns[0].Id().Bytes(),
-		txIns[0].Index(),
-		nil,
-	)
+	refs := make([]models.UtxoId, len(txIns))
+	for i, txIn := range txIns {
+		refs[i] = models.UtxoId{
+			Hash: txIn.Id().Bytes(),
+			Idx:  txIn.Index(),
+		}
+	}
+	utxos, err := ls.db.UtxosByRefs(refs, nil)
 	if err != nil {
 		return nil, err
 	}
-	txOut, err := utxo.Decode()
-	if err != nil {
-		return nil, err
+	for _, utxo := range utxos {
+		txOut, err := utxo.Decode()
+		if err != nil {
+			return nil, err
+		}
+		utxoId := olocalstatequery.UtxoId{
+			Hash: ledger.NewBlake2b256(utxo.TxId),
+			Idx:  int(utxo.OutputIdx),
+		}
+		ret[utxoId] = txOut
 	}
-	utxoId := olocalstatequery.UtxoId{
-		Hash: ledger.NewBlake2b256(utxo.TxId),
-		Idx:  int(utxo.OutputIdx),
-	}
-	ret[utxoId] = txOut
 	return []any{ret}, nil
 }

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -17,21 +17,17 @@ package ledger
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"log/slog"
 	"math"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
-	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
-	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -190,97 +186,47 @@ func TestQueryShelleyUtxoByTxIn_EmptySlice(t *testing.T) {
 // resolves every requested TxIn in one call (#392), not just the first, and
 // silently omits a requested TxIn that has no matching live UTxO instead of
 // failing the whole query.
+//
+// The two real TxIns are deliberately drawn from two distinct blocks'
+// (rather than a single transaction's) produced outputs so the test does
+// not depend on any one fixture transaction producing more than one UTxO:
+// with only one genuinely resolvable input, a regression back to resolving
+// just txIns[0] would still pass a count-based assertion.
 func TestQueryShelleyUtxoByTxIn_MultipleInputs(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "query_utxo_by_txin_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	db := newUtxoStorageTestDB(t)
+	iter := newUtxoStorageTestIterator(t)
 
-	db, err := dbtest.NewDatabase(t, &database.Config{
-		DataDir: tmpDir,
-		Logger:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
-	})
-	require.NoError(t, err)
-	defer dbtest.CloseDatabase(db)
-
-	imm, err := immutable.New("../database/immutable/testdata")
-	require.NoError(t, err)
-	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
-	require.NoError(t, err)
-	defer iter.Close()
-
-	var block lcommon.Block
-	var blockCbor []byte
-	for {
-		immBlock, err := iter.Next()
-		require.NoError(t, err)
-		if immBlock == nil {
-			t.Skip("No blocks with transactions found")
-		}
-		block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
-		require.NoError(t, err)
-		if len(block.Transactions()) > 0 {
-			blockCbor = immBlock.Cbor
-			break
-		}
-	}
-
-	point := ocommon.Point{
-		Slot: block.SlotNumber(),
-		Hash: block.Hash().Bytes(),
-	}
-
-	txn := db.Transaction(true)
-	err = txn.Do(func(txn *database.Txn) error {
-		blockRecord := models.Block{
-			Slot:     point.Slot,
-			Hash:     point.Hash,
-			Number:   block.BlockNumber(),
-			Type:     uint(block.Type()),
-			PrevHash: block.PrevHash().Bytes(),
-			Cbor:     blockCbor,
-		}
-		if err := db.BlockCreate(blockRecord, txn); err != nil {
-			return err
-		}
-		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
-		offsets, err := indexer.ComputeOffsets(blockCbor, block)
+	var realTxIns []ledger.ShelleyTransactionInput
+	for len(realTxIns) < 2 {
+		block, blockCbor := nextProducingBlock(t, iter)
+		txn := db.Transaction(true)
+		var produced lcommon.Utxo
+		err := txn.Do(func(txn *database.Txn) error {
+			tx, err := tryStoreBlockFirstTx(db, txn, block, blockCbor)
+			if err != nil {
+				return err
+			}
+			produced = tx.Produced()[0]
+			return nil
+		})
 		if err != nil {
-			return fmt.Errorf("compute offsets: %w", err)
+			// Some fixture transactions need additional context this
+			// minimal setup doesn't provide (e.g. a deposit-bearing
+			// certificate needs certDeposits, passed as nil here); skip
+			// them and try the next producing block instead of failing
+			// the whole test.
+			continue
 		}
-		tx := block.Transactions()[0]
-		return db.SetTransaction(
-			tx,
-			point,
-			0,
-			0,
-			nil,
-			nil,
-			&database.BlockIngestionResult{
-				TxOffsets:   offsets.TxOffsets,
-				UtxoOffsets: offsets.UtxoOffsets,
-			},
-			txn,
-		)
-	})
-	require.NoError(t, err)
-
-	produced := block.Transactions()[0].Produced()
-	require.NotEmpty(t, produced, "test transaction should produce UTxOs")
-
-	txIns := make([]ledger.ShelleyTransactionInput, 0, len(produced)+1)
-	for _, utxo := range produced {
-		txIns = append(
-			txIns,
-			ledger.NewShelleyTransactionInput(
-				utxo.Id.Id().String(),
-				int(utxo.Id.Index()),
-			),
-		)
+		realTxIns = append(realTxIns, ledger.NewShelleyTransactionInput(
+			produced.Id.Id().String(),
+			int(produced.Id.Index()),
+		))
 	}
+
 	// A TxIn with no matching live UTxO must be silently omitted from the
 	// result, not fail the whole batch.
-	txIns = append(
-		txIns,
+	txIns := append(
+		realTxIns,
 		ledger.NewShelleyTransactionInput(strings.Repeat("00", 32), 9999),
 	)
 
@@ -293,20 +239,25 @@ func TestQueryShelleyUtxoByTxIn_MultipleInputs(t *testing.T) {
 	require.Len(t, arr, 1)
 	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
 	require.True(t, ok, "expected UtxoId map")
-	require.Len(t, m, len(produced), "bogus TxIn should be silently omitted")
+	require.Len(
+		t,
+		m,
+		len(realTxIns),
+		"exactly the real TxIns should resolve; bogus TxIn should be silently omitted",
+	)
 
-	for _, utxo := range produced {
+	for _, txIn := range realTxIns {
 		utxoId := olocalstatequery.UtxoId{
-			Hash: ledger.NewBlake2b256(utxo.Id.Id().Bytes()),
-			Idx:  int(utxo.Id.Index()),
+			Hash: ledger.NewBlake2b256(txIn.Id().Bytes()),
+			Idx:  int(txIn.Index()),
 		}
 		_, ok := m[utxoId]
 		require.True(
 			t,
 			ok,
 			"missing result for %s#%d",
-			utxo.Id.Id().String(),
-			utxo.Id.Index(),
+			txIn.Id().String(),
+			txIn.Index(),
 		)
 	}
 }

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -17,16 +17,21 @@ package ledger
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log/slog"
 	"math"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -179,6 +184,131 @@ func TestQueryShelleyUtxoByTxIn_EmptySlice(t *testing.T) {
 	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
 	require.True(t, ok, "expected UtxoId map")
 	require.Empty(t, m)
+}
+
+// TestQueryShelleyUtxoByTxIn_MultipleInputs proves the GetUTxOByTxIn query
+// resolves every requested TxIn in one call (#392), not just the first, and
+// silently omits a requested TxIn that has no matching live UTxO instead of
+// failing the whole query.
+func TestQueryShelleyUtxoByTxIn_MultipleInputs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "query_utxo_by_txin_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: tmpDir,
+		Logger:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	defer dbtest.CloseDatabase(db)
+
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var block lcommon.Block
+	var blockCbor []byte
+	for {
+		immBlock, err := iter.Next()
+		require.NoError(t, err)
+		if immBlock == nil {
+			t.Skip("No blocks with transactions found")
+		}
+		block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		if len(block.Transactions()) > 0 {
+			blockCbor = immBlock.Cbor
+			break
+		}
+	}
+
+	point := ocommon.Point{
+		Slot: block.SlotNumber(),
+		Hash: block.Hash().Bytes(),
+	}
+
+	txn := db.Transaction(true)
+	err = txn.Do(func(txn *database.Txn) error {
+		blockRecord := models.Block{
+			Slot:     point.Slot,
+			Hash:     point.Hash,
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     blockCbor,
+		}
+		if err := db.BlockCreate(blockRecord, txn); err != nil {
+			return err
+		}
+		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+		offsets, err := indexer.ComputeOffsets(blockCbor, block)
+		if err != nil {
+			return fmt.Errorf("compute offsets: %w", err)
+		}
+		tx := block.Transactions()[0]
+		return db.SetTransaction(
+			tx,
+			point,
+			0,
+			0,
+			nil,
+			nil,
+			&database.BlockIngestionResult{
+				TxOffsets:   offsets.TxOffsets,
+				UtxoOffsets: offsets.UtxoOffsets,
+			},
+			txn,
+		)
+	})
+	require.NoError(t, err)
+
+	produced := block.Transactions()[0].Produced()
+	require.NotEmpty(t, produced, "test transaction should produce UTxOs")
+
+	txIns := make([]ledger.ShelleyTransactionInput, 0, len(produced)+1)
+	for _, utxo := range produced {
+		txIns = append(
+			txIns,
+			ledger.NewShelleyTransactionInput(
+				utxo.Id.Id().String(),
+				int(utxo.Id.Index()),
+			),
+		)
+	}
+	// A TxIn with no matching live UTxO must be silently omitted from the
+	// result, not fail the whole batch.
+	txIns = append(
+		txIns,
+		ledger.NewShelleyTransactionInput(strings.Repeat("00", 32), 9999),
+	)
+
+	ls := &LedgerState{db: db}
+	result, err := ls.queryShelleyUtxoByTxIn(txIns)
+	require.NoError(t, err)
+
+	arr, ok := result.([]any)
+	require.True(t, ok, "expected []any result")
+	require.Len(t, arr, 1)
+	m, ok := arr[0].(map[olocalstatequery.UtxoId]ledger.TransactionOutput)
+	require.True(t, ok, "expected UtxoId map")
+	require.Len(t, m, len(produced), "bogus TxIn should be silently omitted")
+
+	for _, utxo := range produced {
+		utxoId := olocalstatequery.UtxoId{
+			Hash: ledger.NewBlake2b256(utxo.Id.Id().Bytes()),
+			Idx:  int(utxo.Id.Index()),
+		}
+		_, ok := m[utxoId]
+		require.True(
+			t,
+			ok,
+			"missing result for %s#%d",
+			utxo.Id.Id().String(),
+			utxo.Id.Index(),
+		)
+	}
 }
 
 // --- GetStakePools (ShelleyStakePoolsQuery) ---------------------------------

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -211,25 +211,15 @@ func TestQueryShelleyUtxoByTxIn_MultipleInputs(t *testing.T) {
 	var candidates []models.UtxoId
 	var live []models.UtxoId
 	for len(live) < 2 {
-		block, blockCbor := nextProducingBlock(t, iter)
+		block, blockCbor := nextProducingBlock(t, db, iter)
 		txn := db.Transaction(true)
 		var produced lcommon.Utxo
 		err := txn.Do(func(txn *database.Txn) error {
-			tx, err := tryStoreBlockFirstTx(db, txn, block, blockCbor)
-			if err != nil {
-				return err
-			}
+			tx := storeBlockFirstTx(t, db, txn, block, blockCbor)
 			produced = tx.Produced()[0]
 			return nil
 		})
-		if err != nil {
-			// Some fixture transactions need additional context this
-			// minimal setup doesn't provide (e.g. a deposit-bearing
-			// certificate needs certDeposits, passed as nil here); skip
-			// them and try the next producing block instead of failing
-			// the whole test.
-			continue
-		}
+		require.NoError(t, err)
 		candidates = append(candidates, models.UtxoId{
 			Hash: produced.Id.Id().Bytes(),
 			Idx:  produced.Id.Index(),

--- a/ledger/queries_test.go
+++ b/ledger/queries_test.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log/slog"
 	"math"
@@ -192,12 +193,24 @@ func TestQueryShelleyUtxoByTxIn_EmptySlice(t *testing.T) {
 // not depend on any one fixture transaction producing more than one UTxO:
 // with only one genuinely resolvable input, a regression back to resolving
 // just txIns[0] would still pass a count-based assertion.
+//
+// Blocks are stored in chain order, so a later block's transaction could
+// spend an earlier block's collected candidate output before the test gets
+// to use it. Liveness of every collected candidate is re-checked after each
+// new block is stored, and only candidates still live at that point are
+// kept; the loop stops as soon as two remain, so no further block storage
+// (and thus no further spends) can happen before they're used below.
 func TestQueryShelleyUtxoByTxIn_MultipleInputs(t *testing.T) {
 	db := newUtxoStorageTestDB(t)
 	iter := newUtxoStorageTestIterator(t)
 
-	var realTxIns []ledger.ShelleyTransactionInput
-	for len(realTxIns) < 2 {
+	utxoIdKey := func(id models.UtxoId) string {
+		return fmt.Sprintf("%x:%d", id.Hash, id.Idx)
+	}
+
+	var candidates []models.UtxoId
+	var live []models.UtxoId
+	for len(live) < 2 {
 		block, blockCbor := nextProducingBlock(t, iter)
 		txn := db.Transaction(true)
 		var produced lcommon.Utxo
@@ -217,10 +230,32 @@ func TestQueryShelleyUtxoByTxIn_MultipleInputs(t *testing.T) {
 			// the whole test.
 			continue
 		}
-		realTxIns = append(realTxIns, ledger.NewShelleyTransactionInput(
-			produced.Id.Id().String(),
-			int(produced.Id.Index()),
-		))
+		candidates = append(candidates, models.UtxoId{
+			Hash: produced.Id.Id().Bytes(),
+			Idx:  produced.Id.Index(),
+		})
+
+		results, err := db.UtxosByRefs(candidates, nil)
+		require.NoError(t, err)
+		liveSet := make(map[string]struct{}, len(results))
+		for _, u := range results {
+			liveSet[utxoIdKey(models.UtxoId{Hash: u.TxId, Idx: u.OutputIdx})] = struct{}{}
+		}
+		live = live[:0]
+		for _, c := range candidates {
+			if _, ok := liveSet[utxoIdKey(c)]; ok {
+				live = append(live, c)
+			}
+		}
+	}
+	live = live[:2]
+
+	realTxIns := make([]ledger.ShelleyTransactionInput, len(live))
+	for i, ref := range live {
+		realTxIns[i] = ledger.NewShelleyTransactionInput(
+			hex.EncodeToString(ref.Hash),
+			int(ref.Idx),
+		)
 	}
 
 	// A TxIn with no matching live UTxO must be silently omitted from the

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -7106,6 +7106,15 @@ func (ls *LedgerState) UtxoByRef(
 	return ls.db.UtxoByRef(txId, outputIdx, nil)
 }
 
+// UtxosByRefs returns the live UTxOs matching the given references in a
+// single batch. Refs with no matching live UTxO are simply absent from the
+// result.
+func (ls *LedgerState) UtxosByRefs(
+	refs []models.UtxoId,
+) ([]models.Utxo, error) {
+	return ls.db.UtxosByRefs(refs, nil)
+}
+
 // UtxosByAddress returns all UTxOs that belong to the specified address
 func (ls *LedgerState) UtxosByAddress(
 	addr ledger.Address,

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -480,6 +480,142 @@ func TestUtxoByRefAfterSetTransaction(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestUtxosByRefsAfterSetTransaction verifies the batched UTxO lookup
+// returns every produced UTxO for a transaction in one call, and silently
+// omits a ref that doesn't correspond to any live UTxO rather than erroring
+// the whole batch (see #392).
+func TestUtxosByRefsAfterSetTransaction(t *testing.T) {
+	// Create temp directory for database
+	tmpDir, err := os.MkdirTemp("", "utxos_byrefs_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := slog.New(
+		slog.NewTextHandler(
+			os.Stdout,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+
+	// Create database
+	dbConfig := &database.Config{
+		DataDir: tmpDir,
+		Logger:  logger,
+	}
+	db, err := dbtest.NewDatabase(t, dbConfig)
+	require.NoError(t, err)
+	defer dbtest.CloseDatabase(db)
+
+	// Load blocks from immutable testdata
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+
+	// Start from genesis
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Find a block with transactions
+	var block lcommon.Block
+	var blockCbor []byte
+	for {
+		immBlock, err := iter.Next()
+		require.NoError(t, err)
+		if immBlock == nil {
+			t.Skip("No blocks with transactions found")
+		}
+
+		block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+
+		if len(block.Transactions()) > 0 {
+			blockCbor = immBlock.Cbor
+			break
+		}
+	}
+
+	point := ocommon.Point{
+		Slot: block.SlotNumber(),
+		Hash: block.Hash().Bytes(),
+	}
+
+	txn := db.Transaction(true)
+	err = txn.Do(func(txn *database.Txn) error {
+		blockRecord := models.Block{
+			Slot:     point.Slot,
+			Hash:     point.Hash,
+			Number:   block.BlockNumber(),
+			Type:     uint(block.Type()),
+			PrevHash: block.PrevHash().Bytes(),
+			Cbor:     blockCbor,
+		}
+		if err := db.BlockCreate(blockRecord, txn); err != nil {
+			return err
+		}
+
+		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+		offsets, err := indexer.ComputeOffsets(blockCbor, block)
+		if err != nil {
+			return fmt.Errorf("compute offsets: %w", err)
+		}
+
+		tx := block.Transactions()[0]
+		err = db.SetTransaction(
+			tx,
+			point,
+			0,
+			0,
+			nil,
+			nil,
+			&database.BlockIngestionResult{
+				TxOffsets:   offsets.TxOffsets,
+				UtxoOffsets: offsets.UtxoOffsets,
+			},
+			txn,
+		)
+		if err != nil {
+			return err
+		}
+
+		produced := tx.Produced()
+		require.NotEmpty(t, produced, "test transaction should produce UTxOs")
+
+		refs := make([]models.UtxoId, 0, len(produced)+1)
+		for _, utxo := range produced {
+			refs = append(refs, models.UtxoId{
+				Hash: utxo.Id.Id().Bytes(),
+				Idx:  utxo.Id.Index(),
+			})
+		}
+		// A ref with no matching live UTxO should be silently omitted,
+		// not cause the whole batch to fail.
+		bogusHash := make([]byte, 32)
+		refs = append(refs, models.UtxoId{Hash: bogusHash, Idx: 9999})
+
+		results, err := db.UtxosByRefs(refs, txn)
+		require.NoError(t, err)
+		require.Len(t, results, len(produced))
+
+		byRef := make(map[string]models.Utxo, len(results))
+		for _, utxo := range results {
+			key := hex.EncodeToString(utxo.TxId) + ":" +
+				fmt.Sprint(utxo.OutputIdx)
+			byRef[key] = utxo
+		}
+		for _, utxo := range produced {
+			txId := utxo.Id.Id().Bytes()
+			key := hex.EncodeToString(txId) + ":" +
+				fmt.Sprint(utxo.Id.Index())
+			got, ok := byRef[key]
+			require.True(t, ok, "missing UTxO %s", key)
+			require.NotEmpty(t, got.Cbor)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestUtxoByRefRecoversMissingBlobFromProducerBlock(t *testing.T) {
 	for _, deleteTxBlob := range []bool{false, true} {
 		t.Run(

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -385,13 +385,27 @@ func newUtxoStorageTestIterator(t *testing.T) *immutable.BlockIterator {
 	return iter
 }
 
+// errNextProducingBlockValidated is returned from the scratch transaction
+// nextProducingBlock uses to check storability, forcing a rollback so the
+// caller's own (real) store starts from a clean slate regardless of
+// whether that check succeeded or failed.
+var errNextProducingBlockValidated = errors.New(
+	"nextProducingBlock: storability validated, rolling back",
+)
+
 // nextProducingBlock advances iter to the next block whose first
-// transaction produces at least one UTxO, decodes it, and returns the
-// decoded block along with its raw CBOR. It skips the test if the fixture
-// is exhausted before finding one, so callers never need to separately
-// assert that a produced-UTxO set is non-empty.
+// transaction produces at least one UTxO and can actually be stored with
+// this package's minimal SetTransaction call (nil pparamUpdates and
+// certDeposits) — some fixture transactions carry a deposit-bearing
+// certificate that needs certDeposits this helper doesn't supply, and
+// those are skipped too, in a scratch transaction that is always rolled
+// back. It decodes the block and returns it along with its raw CBOR. It
+// skips the test if the fixture is exhausted before finding one, so
+// callers never need to separately handle a non-producing or un-storable
+// first transaction.
 func nextProducingBlock(
 	t *testing.T,
+	db *database.Database,
 	iter *immutable.BlockIterator,
 ) (lcommon.Block, []byte) {
 	t.Helper()
@@ -400,7 +414,7 @@ func nextProducingBlock(
 		require.NoError(t, err)
 		if immBlock == nil {
 			t.Skip(
-				"no block with a producing first transaction found in testdata",
+				"no storable block with a producing first transaction found in testdata",
 			)
 		}
 
@@ -409,6 +423,20 @@ func nextProducingBlock(
 
 		if len(block.Transactions()) == 0 ||
 			len(block.Transactions()[0].Produced()) == 0 {
+			continue
+		}
+
+		txn := db.Transaction(true)
+		err = txn.Do(func(txn *database.Txn) error {
+			if _, err := tryStoreBlockFirstTx(db, txn, block, immBlock.Cbor); err != nil {
+				return err
+			}
+			return errNextProducingBlockValidated
+		})
+		if !errors.Is(err, errNextProducingBlockValidated) {
+			// A real storage error (e.g. a deposit-bearing certificate
+			// needing certDeposits this helper doesn't supply); try the
+			// next producing block instead.
 			continue
 		}
 		return block, immBlock.Cbor
@@ -492,7 +520,7 @@ func tryStoreBlockFirstTx(
 func TestUtxoByRefAfterSetTransaction(t *testing.T) {
 	db := newUtxoStorageTestDB(t)
 	iter := newUtxoStorageTestIterator(t)
-	block, blockCbor := nextProducingBlock(t, iter)
+	block, blockCbor := nextProducingBlock(t, db, iter)
 
 	// Store block and verify UTxO retrieval in same transaction
 	txn := db.Transaction(true)
@@ -531,7 +559,7 @@ func TestUtxoByRefAfterSetTransaction(t *testing.T) {
 func TestUtxosByRefsAfterSetTransaction(t *testing.T) {
 	db := newUtxoStorageTestDB(t)
 	iter := newUtxoStorageTestIterator(t)
-	block, blockCbor := nextProducingBlock(t, iter)
+	block, blockCbor := nextProducingBlock(t, db, iter)
 
 	txn := db.Transaction(true)
 	err := txn.Do(func(txn *database.Txn) error {

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -351,110 +351,153 @@ func TestUtxoStorageAndRetrieval(t *testing.T) {
 	)
 }
 
-// TestUtxoByRefAfterSetTransaction verifies that UtxoByRef works immediately
-// after SetTransaction within the same transaction.
-func TestUtxoByRefAfterSetTransaction(t *testing.T) {
-	// Create temp directory for database
-	tmpDir, err := os.MkdirTemp("", "utxo_byref_test")
+// newUtxoStorageTestDB creates a temp-directory database for tests that
+// load real blocks from the immutable testdata fixture.
+func newUtxoStorageTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "utxo_storage_test")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
-	logger := slog.New(
-		slog.NewTextHandler(
-			os.Stdout,
-			&slog.HandlerOptions{Level: slog.LevelDebug},
-		),
-	)
-
-	// Create database
-	dbConfig := &database.Config{
+	db, err := dbtest.NewDatabase(t, &database.Config{
 		DataDir: tmpDir,
-		Logger:  logger,
-	}
-	db, err := dbtest.NewDatabase(t, dbConfig)
+		Logger: slog.New(
+			slog.NewTextHandler(
+				io.Discard,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	})
 	require.NoError(t, err)
-	defer dbtest.CloseDatabase(db)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) })
+	return db
+}
 
-	// Load blocks from immutable testdata
+// newUtxoStorageTestIterator opens the shared immutable testdata fixture
+// and returns an iterator positioned at genesis.
+func newUtxoStorageTestIterator(t *testing.T) *immutable.BlockIterator {
+	t.Helper()
 	imm, err := immutable.New("../database/immutable/testdata")
 	require.NoError(t, err)
-
-	// Start from genesis
 	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
 	require.NoError(t, err)
-	defer iter.Close()
+	t.Cleanup(func() { iter.Close() })
+	return iter
+}
 
-	// Find a block with transactions
-	var block lcommon.Block
-	var blockCbor []byte
+// nextProducingBlock advances iter to the next block whose first
+// transaction produces at least one UTxO, decodes it, and returns the
+// decoded block along with its raw CBOR. It skips the test if the fixture
+// is exhausted before finding one, so callers never need to separately
+// assert that a produced-UTxO set is non-empty.
+func nextProducingBlock(
+	t *testing.T,
+	iter *immutable.BlockIterator,
+) (lcommon.Block, []byte) {
+	t.Helper()
 	for {
 		immBlock, err := iter.Next()
 		require.NoError(t, err)
 		if immBlock == nil {
-			t.Skip("No blocks with transactions found")
+			t.Skip(
+				"no block with a producing first transaction found in testdata",
+			)
 		}
 
-		block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		block, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
 		require.NoError(t, err)
 
-		if len(block.Transactions()) > 0 {
-			blockCbor = immBlock.Cbor
-			break
+		if len(block.Transactions()) == 0 ||
+			len(block.Transactions()[0].Produced()) == 0 {
+			continue
 		}
+		return block, immBlock.Cbor
 	}
+}
 
+// storeBlockFirstTx stores block (and its raw CBOR) plus its first
+// transaction into db within txn, computing the offsets SetTransaction
+// requires, and returns the stored transaction.
+func storeBlockFirstTx(
+	t *testing.T,
+	db *database.Database,
+	txn *database.Txn,
+	block lcommon.Block,
+	blockCbor []byte,
+) lcommon.Transaction {
+	t.Helper()
+	tx, err := tryStoreBlockFirstTx(db, txn, block, blockCbor)
+	require.NoError(t, err)
+	return tx
+}
+
+// tryStoreBlockFirstTx is the non-asserting form of storeBlockFirstTx, for
+// callers that want to skip a block that fails to store (e.g. one whose
+// first transaction carries a deposit-bearing certificate, which needs
+// certDeposits this minimal helper doesn't supply) rather than failing the
+// test outright.
+func tryStoreBlockFirstTx(
+	db *database.Database,
+	txn *database.Txn,
+	block lcommon.Block,
+	blockCbor []byte,
+) (lcommon.Transaction, error) {
 	point := ocommon.Point{
 		Slot: block.SlotNumber(),
 		Hash: block.Hash().Bytes(),
 	}
+	blockRecord := models.Block{
+		Slot:     point.Slot,
+		Hash:     point.Hash,
+		Number:   block.BlockNumber(),
+		Type:     uint(block.Type()),
+		PrevHash: block.PrevHash().Bytes(),
+		Cbor:     blockCbor,
+	}
+	if err := db.BlockCreate(blockRecord, txn); err != nil {
+		return nil, err
+	}
 
-	t.Logf(
-		"Using block at slot %d with %d transactions",
-		point.Slot,
-		len(block.Transactions()),
-	)
+	indexer := database.NewBlockIndexer(point.Slot, point.Hash)
+	offsets, err := indexer.ComputeOffsets(blockCbor, block)
+	if err != nil {
+		return nil, err
+	}
+
+	txs := block.Transactions()
+	if len(txs) == 0 {
+		return nil, errors.New("block has no transactions")
+	}
+	tx := txs[0]
+	if err := db.SetTransaction(
+		tx,
+		point,
+		0,
+		0,
+		nil,
+		nil,
+		&database.BlockIngestionResult{
+			TxOffsets:   offsets.TxOffsets,
+			UtxoOffsets: offsets.UtxoOffsets,
+		},
+		txn,
+	); err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+// TestUtxoByRefAfterSetTransaction verifies that UtxoByRef works immediately
+// after SetTransaction within the same transaction.
+func TestUtxoByRefAfterSetTransaction(t *testing.T) {
+	db := newUtxoStorageTestDB(t)
+	iter := newUtxoStorageTestIterator(t)
+	block, blockCbor := nextProducingBlock(t, iter)
 
 	// Store block and verify UTxO retrieval in same transaction
 	txn := db.Transaction(true)
-	err = txn.Do(func(txn *database.Txn) error {
-		// Store block CBOR
-		blockRecord := models.Block{
-			Slot:     point.Slot,
-			Hash:     point.Hash,
-			Number:   block.BlockNumber(),
-			Type:     uint(block.Type()),
-			PrevHash: block.PrevHash().Bytes(),
-			Cbor:     blockCbor,
-		}
-		if err := db.BlockCreate(blockRecord, txn); err != nil {
-			return err
-		}
-
-		// Compute offsets - offsets MUST be available
-		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
-		offsets, err := indexer.ComputeOffsets(blockCbor, block)
-		if err != nil {
-			return fmt.Errorf("compute offsets: %w", err)
-		}
-
-		// Process first transaction - offsets MUST be available
-		tx := block.Transactions()[0]
-		err = db.SetTransaction(
-			tx,
-			point,
-			0,
-			0,
-			nil,
-			nil,
-			&database.BlockIngestionResult{
-				TxOffsets:   offsets.TxOffsets,
-				UtxoOffsets: offsets.UtxoOffsets,
-			},
-			txn,
-		)
-		if err != nil {
-			return err
-		}
+	err := txn.Do(func(txn *database.Txn) error {
+		tx := storeBlockFirstTx(t, db, txn, block, blockCbor)
 
 		// Try to retrieve UTxOs immediately (within same transaction)
 		for _, utxo := range tx.Produced() {
@@ -481,120 +524,45 @@ func TestUtxoByRefAfterSetTransaction(t *testing.T) {
 }
 
 // TestUtxosByRefsAfterSetTransaction verifies the batched UTxO lookup
-// returns every produced UTxO for a transaction in one call, and silently
-// omits a ref that doesn't correspond to any live UTxO rather than erroring
-// the whole batch (see #392).
+// returns every produced UTxO for a transaction in one call, exactly once
+// even when a ref is requested more than once, and silently omits a ref
+// that doesn't correspond to any live UTxO rather than erroring the whole
+// batch (see #392).
 func TestUtxosByRefsAfterSetTransaction(t *testing.T) {
-	// Create temp directory for database
-	tmpDir, err := os.MkdirTemp("", "utxos_byrefs_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	logger := slog.New(
-		slog.NewTextHandler(
-			os.Stdout,
-			&slog.HandlerOptions{Level: slog.LevelDebug},
-		),
-	)
-
-	// Create database
-	dbConfig := &database.Config{
-		DataDir: tmpDir,
-		Logger:  logger,
-	}
-	db, err := dbtest.NewDatabase(t, dbConfig)
-	require.NoError(t, err)
-	defer dbtest.CloseDatabase(db)
-
-	// Load blocks from immutable testdata
-	imm, err := immutable.New("../database/immutable/testdata")
-	require.NoError(t, err)
-
-	// Start from genesis
-	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
-	require.NoError(t, err)
-	defer iter.Close()
-
-	// Find a block with transactions
-	var block lcommon.Block
-	var blockCbor []byte
-	for {
-		immBlock, err := iter.Next()
-		require.NoError(t, err)
-		if immBlock == nil {
-			t.Skip("No blocks with transactions found")
-		}
-
-		block, err = ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
-		require.NoError(t, err)
-
-		if len(block.Transactions()) > 0 {
-			blockCbor = immBlock.Cbor
-			break
-		}
-	}
-
-	point := ocommon.Point{
-		Slot: block.SlotNumber(),
-		Hash: block.Hash().Bytes(),
-	}
+	db := newUtxoStorageTestDB(t)
+	iter := newUtxoStorageTestIterator(t)
+	block, blockCbor := nextProducingBlock(t, iter)
 
 	txn := db.Transaction(true)
-	err = txn.Do(func(txn *database.Txn) error {
-		blockRecord := models.Block{
-			Slot:     point.Slot,
-			Hash:     point.Hash,
-			Number:   block.BlockNumber(),
-			Type:     uint(block.Type()),
-			PrevHash: block.PrevHash().Bytes(),
-			Cbor:     blockCbor,
-		}
-		if err := db.BlockCreate(blockRecord, txn); err != nil {
-			return err
-		}
-
-		indexer := database.NewBlockIndexer(point.Slot, point.Hash)
-		offsets, err := indexer.ComputeOffsets(blockCbor, block)
-		if err != nil {
-			return fmt.Errorf("compute offsets: %w", err)
-		}
-
-		tx := block.Transactions()[0]
-		err = db.SetTransaction(
-			tx,
-			point,
-			0,
-			0,
-			nil,
-			nil,
-			&database.BlockIngestionResult{
-				TxOffsets:   offsets.TxOffsets,
-				UtxoOffsets: offsets.UtxoOffsets,
-			},
-			txn,
-		)
-		if err != nil {
-			return err
-		}
-
+	err := txn.Do(func(txn *database.Txn) error {
+		tx := storeBlockFirstTx(t, db, txn, block, blockCbor)
 		produced := tx.Produced()
-		require.NotEmpty(t, produced, "test transaction should produce UTxOs")
 
-		refs := make([]models.UtxoId, 0, len(produced)+1)
+		refs := make([]models.UtxoId, 0, len(produced)+2)
 		for _, utxo := range produced {
 			refs = append(refs, models.UtxoId{
 				Hash: utxo.Id.Id().Bytes(),
 				Idx:  utxo.Id.Index(),
 			})
 		}
+		// Requesting the first produced UTxO's ref a second time must not
+		// duplicate it in the result.
+		refs = append(refs, refs[0])
 		// A ref with no matching live UTxO should be silently omitted,
 		// not cause the whole batch to fail.
 		bogusHash := make([]byte, 32)
 		refs = append(refs, models.UtxoId{Hash: bogusHash, Idx: 9999})
 
 		results, err := db.UtxosByRefs(refs, txn)
-		require.NoError(t, err)
-		require.Len(t, results, len(produced))
+		if err != nil {
+			return err
+		}
+		require.Len(
+			t,
+			results,
+			len(produced),
+			"duplicate ref should not duplicate its result row",
+		)
 
 		byRef := make(map[string]models.Utxo, len(results))
 		for _, utxo := range results {


### PR DESCRIPTION
## Summary

Implements #392 — the `GetUTxOByTxIn` n2c query only ever resolved the first of the requested `TxIns`, since batch resolution was never implemented (a `// TODO: support multiple TxIns (#392)` marked the gap). This adds a real batched UTxO lookup and threads it through the stack, and applies it to `api/utxorpc`'s `ReadUtxos` as well, per the issue's ask to use it "throughout the codebase, particularly in the API layers."


## Changes

- **`database/plugin/metadata/store.go`** — added `MetadataStore.GetUtxosByRefs([]models.UtxoId, txn) ([]models.Utxo, error)` to the interface, next to `GetUtxo`/`GetUtxoIncludingSpent`.
- **`database/plugin/metadata/sqlstore/utxo.go`** — implemented `GetUtxosByRefs`, reusing the existing `utxoIDPredicate` OR-predicate builder and `queryUtxosWithAssets` helper, chunked at 400 refs to stay within SQLite's parameter limit. Shared by all three engine backends (sqlite/postgres/mysql).
- **`database/utxo.go`** — added `Database.UtxosByRefs`, wrapping the metadata call and resolving each result's CBOR via `loadCbor` (same offset-based resolution `UtxoByRef` does).
- **`ledger/state.go`** — added `LedgerState.UtxosByRefs` as a thin public wrapper.
- **`ledger/queries.go`** — rewrote `queryShelleyUtxoByTxIn` to resolve all of `txIns` via the batched call instead of just `txIns[0]`; removed the `// TODO: support multiple TxIns (#392)` marker. TxIns with no matching live UTxO are now silently omitted from the result map instead of failing the whole query, matching cardano-node's reference behavior for `GetUTxOByTxIn`.
- **`api/utxorpc/node_interface.go`** — added `UtxosByRefs` to the `UtxorpcLedgerState` interface.
- **`api/utxorpc/query.go`** — rewrote `ReadUtxos` to resolve all requested keys in one batched call (via a new `utxoRefKey` helper for map correlation, since `models.UtxoId` isn't map-key-safe) instead of looping one key at a time. The existing error-on-missing-key contract is preserved — a request with any unresolvable key still fails the whole call, unlike the ledger-level query above.
- **`DATABASE.md`** — documented the new `GetUtxosByRefs` query pattern in a new subsection alongside `GetUtxo`/`GetUtxoIncludingSpent`.
- **Tests:**
  - `ledger/queries_test.go` — `TestQueryShelleyUtxoByTxIn_MultipleInputs` proves multi-input resolution and silent-omit-on-miss.
  - `ledger/utxo_storage_test.go` — `TestUtxosByRefsAfterSetTransaction` proves `Database.UtxosByRefs` batch-resolves real stored UTxOs and drops unmatched refs.
  - `api/utxorpc/rpc_connect_test.go` — `TestConnect_ReadUtxos_MultipleKeys` and `TestConnect_ReadUtxos_MissingKey` prove `ReadUtxos` batches correctly and still errors on a missing key.

Closes #392 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch UTxO lookup now resolves multiple TxIns in one call across the ledger and `utxorpc`. Previously `GetUTxOByTxIn` returned only the first input; now it returns all live inputs and silently omits misses, while `ReadUtxos` batches resolution but still errors the whole request if any key is missing.

- Adds `GetUtxosByRefs([]models.UtxoId, types.Txn) ([]models.Utxo, error)` to `MetadataStore` with a SQL implementation that deduplicates refs and chunks at 400 to stay within SQLite limits; `database.UtxosByRefs` loads CBOR and `ledger.UtxosByRefs` wraps it.
- Updates the Shelley `GetUTxOByTxIn` path to build a full result map from the batch; `utxorpc` `ReadUtxos` now batches and correlates results by ref key. Documents the query in `DATABASE.md`.
- Tests cover multi-input resolution, error-on-missing for `ReadUtxos`, cross-chunk dedupe, and add helpers that re-check liveness and validate block storability to skip deposit-certificate blocks, preventing flaky/hard-fail cases.

**Migration**
- Implement `GetUtxosByRefs([]models.UtxoId, types.Txn) ([]models.Utxo, error)` in any custom `MetadataStore` backend.
- Add `UtxosByRefs(refs []models.UtxoId) ([]models.Utxo, error)` to any `UtxorpcLedgerState` implementation.
- Update callers that assumed `GetUTxOByTxIn` returned only the first input or errored on missing to handle partial results.

<sup>Written for commit 41a33eb0e9f2319b92b15143eb1b614398eb6b30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched UTxO lookup by transaction and output references.
  * Multiple references can now be resolved in a single request while preserving the requested order.
  * Results include only live, unspent UTxOs and associated asset data.
* **Bug Fixes**
  * Missing references now produce consistent behavior: database lookups omit them, while API requests report an error when any requested reference is unavailable.
* **Tests**
  * Added coverage for multiple-reference requests, ordering, missing references, and newly submitted transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->