### PR TITLE
fix(mainnet): remove emurgo bootstrap peers

### DIFF
--- a/config/cardano/mainnet/topology-non-bootstrap-peers.json
+++ b/config/cardano/mainnet/topology-non-bootstrap-peers.json
@@ -17,10 +17,6 @@
         {
           "address": "backbone.mainnet.cardanofoundation.org",
           "port": 3001
-        },
-        {
-          "address": "backbone.mainnet.emurgornd.com",
-          "port": 3001
         }
       ],
       "advertise": false

--- a/config/cardano/mainnet/topology.json
+++ b/config/cardano/mainnet/topology.json
@@ -7,10 +7,6 @@
     {
       "address": "backbone.mainnet.cardanofoundation.org",
       "port": 3001
-    },
-    {
-      "address": "backbone.mainnet.emurgornd.com",
-      "port": 3001
     }
   ],
   "localRoots": [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the Emurgo bootstrap peer from the Cardano mainnet topology to prevent connections to an unavailable endpoint. Previously nodes attempted `backbone.mainnet.emurgornd.com:3001`; now they only use `backbone.mainnet.cardanofoundation.org:3001`, reducing failed connections and timeouts.

- Review: Verify the Emurgo peer is removed in both `config/cardano/mainnet/topology.json` and `config/cardano/mainnet/topology-non-bootstrap-peers.json`.
- Rollout: Restart nodes or redeploy configs to apply the topology change.
- Migration: If you maintain custom topologies that reference `backbone.mainnet.emurgornd.com`, remove that peer.

<sup>Written for commit 5e77bfa974b9a2ed577270726b8603c7b4fbc6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Removed an outdated mainnet network endpoint from the available bootstrap and non-bootstrap peer configurations.
  - Mainnet connections will no longer attempt to use this endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->