### PR TITLE
fix: close event bus before connection drain

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -863,14 +863,21 @@ Phase 1: Stop accepting new work
   Blockfrost API, Mesh API, off-chain metadata fetcher
 
 Phase 2: Drain and close connections
-  Mempool, ConnectionManager
+  Mempool, terminal EventBus close, ConnectionManager
 
 Phase 3: Flush state and close database
   LedgerState, Database
 
 Phase 4: Cleanup resources
-  Registered shutdown functions, EventBus
+  Registered shutdown functions
 ```
+
+The terminal EventBus close occurs after mempool teardown but before
+`ConnectionManager.Stop`. Lossless event delivery can backpressure a network
+protocol callback on a full ledger subscriber; closing the bus at this point
+releases those publishers before connection shutdown waits for their callback
+goroutines. The node context is already cancelled, and later component
+teardown treats the already-closed bus as idempotent.
 
 ## Event-Driven Communication
 

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -227,6 +227,20 @@ func (n *Node) shutdown() error {
 		}
 	}
 
+	// Close the EventBus before draining network connections. Since v0.68,
+	// event delivery applies backpressure instead of dropping events. A
+	// chainsync callback can therefore be blocked waiting for a full ledger
+	// subscriber while ConnectionManager.Stop waits for that callback to
+	// finish. Closing the terminal bus here releases those blocked publishers
+	// before connection teardown begins. The node context is already cancelled
+	// and mempool has stopped, so no component should produce useful work after
+	// this point; later component teardown treats an already-closed bus as
+	// harmless and idempotent.
+	if n.eventBus != nil {
+		n.config.logger.Info("closing event bus before connection drain")
+		n.eventBus.Close()
+	}
+
 	if n.connManager != nil {
 		if stopErr := n.connManager.Stop(ctx); stopErr != nil {
 			err = errors.Join(
@@ -321,12 +335,6 @@ func (n *Node) shutdown() error {
 		}
 	}
 	n.shutdownFuncs = nil
-
-	if n.eventBus != nil {
-		// Close (not Stop): this is a terminal shutdown, and Stop restarts the
-		// async-worker pool, leaking those goroutines past node teardown.
-		n.eventBus.Close()
-	}
 
 	n.config.logger.Info(
 		"graceful shutdown complete",

--- a/node_test.go
+++ b/node_test.go
@@ -352,6 +352,51 @@ func TestStopReturnsSameShutdownErrorAfterFirstCall(t *testing.T) {
 	require.Equal(t, firstErr, secondErr)
 }
 
+func TestShutdownClosesEventBusBeforeFinalCleanup(t *testing.T) {
+	const eventType event.EventType = "test.shutdown.order"
+
+	bus := event.NewEventBus(nil, nil)
+	_, _ = bus.SubscribeWithBuffer(eventType, 1)
+	bus.Publish(eventType, event.NewEvent(eventType, "fill"))
+
+	publishDone := make(chan struct{})
+	go func() {
+		defer close(publishDone)
+		bus.Publish(eventType, event.NewEvent(eventType, "blocked"))
+	}()
+	testutil.RequireNoReceive(
+		t,
+		publishDone,
+		50*time.Millisecond,
+		"event publisher should be backpressured before shutdown",
+	)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		eventBus: bus,
+		shutdownFuncs: []func(context.Context) error{
+			func(context.Context) error {
+				select {
+				case <-publishDone:
+					return nil
+				case <-time.After(time.Second):
+					return errors.New("event bus was not closed before final cleanup")
+				}
+			},
+		},
+	}
+
+	require.NoError(t, n.Stop())
+	testutil.RequireReceive(
+		t,
+		publishDone,
+		time.Second,
+		"backpressured publisher did not exit after node shutdown",
+	)
+}
+
 func TestCloseWithShutdownTimeoutReturnsTimeoutError(t *testing.T) {
 	n := &Node{
 		config: Config{


### PR DESCRIPTION
## Summary
- close the terminal EventBus before draining network connections
- add a regression test for blocked event publishers
- document the shutdown ordering

## Tests
- go test -race ./event . -count=1
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close the terminal `EventBus` before draining network connections to avoid shutdown hangs from backpressured publishers. Previously the bus closed during final cleanup after `ConnectionManager.Stop`; now it closes right after mempool teardown, releasing blocked chainsync callbacks.

- Move bus close ahead of `ConnectionManager.Stop` and remove the late close during final cleanup.
- Add a regression test that a backpressured publisher unblocks during shutdown.
- Document the shutdown order in `ARCHITECTURE.md`; later teardown treats an already-closed bus as idempotent.
- No migration required. Do not rely on event delivery after node context cancellation.

<sup>Written for commit 5766e60feaaff9fe513eea62882946cac876c87a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

