### PR TITLE
fix(mithril): quiet per-file sync logs

### DIFF
--- a/mithril/download.go
+++ b/mithril/download.go
@@ -802,7 +802,7 @@ func downloadSnapshotOnce(
 					err,
 				)
 			}
-			cfg.Logger.Info(
+			cfg.Logger.Debug(
 				"resuming download",
 				"component", "mithril",
 				"existing_bytes", existingSize,
@@ -846,7 +846,7 @@ func downloadSnapshotOnce(
 				destPath,
 			)
 		}
-		cfg.Logger.Info(
+		cfg.Logger.Debug(
 			"download already complete",
 			"component", "mithril",
 			"path", destPath,
@@ -877,7 +877,7 @@ func downloadSnapshotOnce(
 		}
 	}() // safety net for panics/early returns
 
-	cfg.Logger.Info(
+	cfg.Logger.Debug(
 		"downloading snapshot",
 		"component", "mithril",
 		"url", cfg.URL,
@@ -934,7 +934,7 @@ func downloadSnapshotOnce(
 		})
 	}
 
-	cfg.Logger.Info(
+	cfg.Logger.Debug(
 		"download complete",
 		"component", "mithril",
 		"bytes", pw.written,
@@ -960,7 +960,7 @@ func downloadSnapshotOnce(
 				fi.Size(), cfg.ExpectedSize,
 			)
 		}
-		cfg.Logger.Info(
+		cfg.Logger.Debug(
 			"download size verified",
 			"component", "mithril",
 			"bytes", fi.Size(),

--- a/mithril/download_test.go
+++ b/mithril/download_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,6 +35,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type captureSlogHandler struct {
+	records []slog.Record
+}
+
+func (h *captureSlogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *captureSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *captureSlogHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureSlogHandler) WithGroup(string) slog.Handler {
+	return h
+}
 
 func TestDownloadSnapshot(t *testing.T) {
 	content := []byte("fake-snapshot-archive-data-for-testing")
@@ -81,6 +103,46 @@ func TestDownloadSnapshot(t *testing.T) {
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, content, data)
+}
+
+func TestDownloadSnapshotRoutineLogsAtDebug(t *testing.T) {
+	content := []byte("snapshot")
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+			_, _ = w.Write(content)
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	handler := &captureSlogHandler{}
+	logger := slog.New(handler)
+	_, err := DownloadSnapshot(context.Background(), DownloadConfig{
+		URL:               server.URL + "/snapshot.tar.zst",
+		AllowInsecureHTTP: true,
+		DestDir:           t.TempDir(),
+		Filename:          "snapshot.tar.zst",
+		ExpectedSize:      int64(len(content)),
+		Logger:            logger,
+	})
+	require.NoError(t, err)
+
+	for _, message := range []string{
+		"downloading snapshot",
+		"download complete",
+		"download size verified",
+	} {
+		found := false
+		for _, record := range handler.records {
+			if record.Message != message {
+				continue
+			}
+			assert.Equal(t, slog.LevelDebug, record.Level, message)
+			found = true
+			break
+		}
+		require.True(t, found, "missing log record %q", message)
+	}
 }
 
 func TestNewPooledDownloadTransportUsesHTTP1Connections(t *testing.T) {

--- a/mithril/progress_test.go
+++ b/mithril/progress_test.go
@@ -15,6 +15,7 @@
 package mithril
 
 import (
+	"bytes"
 	"log/slog"
 	"testing"
 
@@ -28,8 +29,9 @@ import (
 // lines like "45.3% (8.2 GB / 14.2 GB)" where 8.2/14.2 is 57.7%.
 func TestNewImmutableProgressByteBased(t *testing.T) {
 	var last DownloadProgress
+	var logs bytes.Buffer
 	cfg := BootstrapConfig{
-		Logger:     slog.New(slog.DiscardHandler),
+		Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
 		OnProgress: func(p DownloadProgress) { last = p },
 	}
 	// 4 archives of uneven size summing to 1000 bytes.
@@ -52,6 +54,7 @@ func TestNewImmutableProgressByteBased(t *testing.T) {
 	onDone(400)
 	assert.Equal(t, int64(1000), last.BytesDownloaded)
 	assert.InDelta(t, 100.0, last.Percent, 0.001)
+	assert.Contains(t, logs.String(), "immutable archives:")
 }
 
 // TestNewImmutableProgressClamp verifies the byte-percent is clamped to 100


### PR DESCRIPTION
Quiet routine Mithril per-file logs at DEBUG while retaining aggregate progress at INFO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiets routine per-file `mithril` download logs by moving them from INFO to DEBUG, while keeping aggregate progress at INFO. This reduces noisy logs without losing visibility into overall progress.

**Review and rollout**
- Moves to DEBUG in `mithril/download.go`: “resuming download”, “download already complete”, “downloading snapshot”, “download complete”, “download size verified”.
- Adds tests to assert these messages log at DEBUG and that aggregate progress logs still appear at INFO (including “immutable archives:”).
- If you rely on per-file INFO logs for monitoring, set the logger level to DEBUG or consume the `OnProgress` callback; no other changes required.

<sup>Written for commit a66ee08b6311ef1d8d474fd47bef9f28d9c181d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

