### PR TITLE
fix: postgres metadata SSL default

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3535,7 +3535,7 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
     DSN is assembled from discrete host/port/user/password/database/sslMode/
     timeZone fields, defaulting any field left unset to that provider's own
     `RegisterProvider` descriptor default (e.g. postgres:
-    `host=localhost user=postgres dbname=postgres sslmode=disable`; mysql:
+    `host=localhost user=postgres dbname=postgres sslmode=require`; mysql:
     `host=localhost user=root database=dingo`) and building the connection
     string the same way `database/plugin/metadata/{postgres,mysql}`'s own
     `Start()` does (mysql via `go-sql-driver/mysql`'s own `Config`/

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -35,6 +35,12 @@ Dingo stores chain state in two sibling stores:
   `poolMaxOpenConns`, `poolMaxIdleConns`, and `poolConnMaxLifetime`.
 - The blob store is a key/value object store managed by the blob plugins in `database/plugin/blob/`. The always-built plugin is `badger`; `gcs` and `s3` are optional and are built only with the `dingo_extra_plugins` build tag.
 
+The PostgreSQL metadata provider defaults `sslMode` to `require`, so new
+connections negotiate TLS unless an operator explicitly selects another mode
+(for example, `disable` for a loopback-only database). This is an intentional
+security-sensitive default change for existing deployments that omit
+`sslMode`; remote PostgreSQL deployments must support TLS before upgrading.
+
 The providers open their direct database/sql drivers and return the shared
 `database/plugin/metadata/sqlstore.Store`. Schema ownership is explicit:
 versioned DDL lives under `database/plugin/metadata/sqlstore/migrations`,

--- a/cmd/koios-parity/main.go
+++ b/cmd/koios-parity/main.go
@@ -239,7 +239,7 @@ func dsnFromMetadataConfig(plugin string, cfg map[string]any) string {
 	case "postgres":
 		// Defaults match postgres.RegisterProvider's descriptor default
 		// (Config{Host: "localhost", Port: 5432, User: "postgres", Database:
-		// "postgres", SSLMode: "disable", TimeZone: "UTC"}), which is what a
+		// "postgres", SSLMode: "require", TimeZone: "UTC"}), which is what a
 		// bare `provider: postgres` config section resolves to before
 		// Start() builds its connection string the same way below.
 		if host == "" {
@@ -252,7 +252,7 @@ func dsnFromMetadataConfig(plugin string, cfg map[string]any) string {
 			database = "postgres"
 		}
 		if sslMode == "" {
-			sslMode = "disable"
+			sslMode = "require"
 		}
 		if timeZone == "" {
 			timeZone = "UTC"

--- a/cmd/koios-parity/main_test.go
+++ b/cmd/koios-parity/main_test.go
@@ -68,7 +68,7 @@ func TestCheckResultErrNilResult(t *testing.T) {
 // all) and an empty-but-non-nil map must both resolve to that same working
 // default DSN.
 func TestDsnFromMetadataConfigPostgresProviderOnly(t *testing.T) {
-	want := "host=localhost user=postgres password= dbname=postgres port=5432 sslmode=disable TimeZone=UTC"
+	want := "host=localhost user=postgres password= dbname=postgres port=5432 sslmode=require TimeZone=UTC"
 
 	require.Equal(t, want, dsnFromMetadataConfig("postgres", nil))
 	require.Equal(t, want, dsnFromMetadataConfig("postgres", map[string]any{}))
@@ -84,7 +84,7 @@ func TestDsnFromMetadataConfigPostgresPartialOverride(t *testing.T) {
 	)
 	require.Equal(
 		t,
-		"host=db.example.com user=postgres password= dbname=postgres port=5432 sslmode=disable TimeZone=UTC",
+		"host=db.example.com user=postgres password= dbname=postgres port=5432 sslmode=require TimeZone=UTC",
 		dsn,
 	)
 }

--- a/database/plugin/metadata/postgres/provider.go
+++ b/database/plugin/metadata/postgres/provider.go
@@ -45,6 +45,17 @@ type Config struct {
 	PoolConnMaxLifetime time.Duration `yaml:"poolConnMaxLifetime"`
 }
 
+func defaultConfig() Config {
+	return Config{
+		Host:     "localhost",
+		Port:     5432,
+		User:     "postgres",
+		Database: "postgres",
+		SSLMode:  "require",
+		TimeZone: "UTC",
+	}
+}
+
 func RegisterProvider(host *plugin.Host) error {
 	return plugin.Register(
 		host,
@@ -53,16 +64,7 @@ func RegisterProvider(host *plugin.Host) error {
 			Name:        "postgres",
 			Description: "PostgreSQL relational database",
 		},
-		func() Config {
-			return Config{
-				Host:     "localhost",
-				Port:     5432,
-				User:     "postgres",
-				Database: "postgres",
-				SSLMode:  "disable",
-				TimeZone: "UTC",
-			}
-		},
+		defaultConfig,
 		func(
 			_ context.Context,
 			cfg Config,
@@ -91,27 +93,7 @@ func openStore(
 		cfg.PoolConnMaxLifetime < 0 {
 		return nil, errors.New("PostgreSQL pool limits must not be negative")
 	}
-	dsn := cfg.DSN
-	if dsn == "" {
-		connectionURL := &url.URL{
-			Scheme: "postgres",
-			User:   url.UserPassword(cfg.User, cfg.Password),
-			Host: net.JoinHostPort(
-				cfg.Host,
-				strconv.FormatUint(uint64(cfg.Port), 10),
-			),
-			Path: cfg.Database,
-		}
-		query := connectionURL.Query()
-		if cfg.SSLMode != "" {
-			query.Set("sslmode", cfg.SSLMode)
-		}
-		if cfg.TimeZone != "" {
-			query.Set("timezone", cfg.TimeZone)
-		}
-		connectionURL.RawQuery = query.Encode()
-		dsn = connectionURL.String()
-	}
+	dsn := assembleDSN(cfg)
 	db, err := sqlstore.OpenDB("pgx", dsn, "postgresql")
 	if err != nil {
 		return nil, err
@@ -167,4 +149,28 @@ func openStore(
 		return nil, err
 	}
 	return store, nil
+}
+
+func assembleDSN(cfg Config) string {
+	if cfg.DSN != "" {
+		return cfg.DSN
+	}
+	connectionURL := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(cfg.User, cfg.Password),
+		Host: net.JoinHostPort(
+			cfg.Host,
+			strconv.FormatUint(uint64(cfg.Port), 10),
+		),
+		Path: cfg.Database,
+	}
+	query := connectionURL.Query()
+	if cfg.SSLMode != "" {
+		query.Set("sslmode", cfg.SSLMode)
+	}
+	if cfg.TimeZone != "" {
+		query.Set("timezone", cfg.TimeZone)
+	}
+	connectionURL.RawQuery = query.Encode()
+	return connectionURL.String()
 }

--- a/database/plugin/metadata/postgres/provider_test.go
+++ b/database/plugin/metadata/postgres/provider_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultAssembledDSNRequiresSSL(t *testing.T) {
+	dsn := assembleDSN(defaultConfig())
+
+	require.Contains(t, dsn, "sslmode=require")
+}

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -30,6 +30,16 @@ plugins:
       config:
         # Optional SQLite data directory. When unset, databasePath applies.
         # dataDir: ".dingo"
+    # PostgreSQL metadata alternative (replace the metadata block above):
+    # metadata:
+    #   provider: "postgres"
+    #   config:
+    #     host: "localhost"
+    #     port: 5432
+    #     user: "postgres"
+    #     database: "postgres"
+    #     sslMode: "require"
+    #     timeZone: "UTC"
   mempool:
     # "fifo" preserves successful-admission order. "dag" additionally indexes
     # transaction dependencies and uses deterministic topological ordering.


### PR DESCRIPTION
Default PostgreSQL metadata connections to sslmode=require and cover the assembled DSN.

Closes #2437 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default PostgreSQL metadata connections now use sslmode=require instead of disable to enforce TLS by default. Deployments that omit sslMode may fail to connect unless the database supports TLS; set sslMode=disable to retain prior behavior.

- Review notes
  - `database/plugin/metadata/postgres`: add `defaultConfig()` with SSLMode=require; factor DSN building into `assembleDSN()` and use it in `openStore()`.
  - `cmd/koios-parity`: `dsnFromMetadataConfig` now defaults sslMode to require; tests updated.
  - Docs/examples updated in `ARCHITECTURE.md`, `DATABASE.md`, and `dingo.yaml.example`; new `provider_test.go` (build tag `dingo_extra_plugins`) asserts assembled DSN includes sslmode=require.

- Migration
  - If your PostgreSQL server does not support TLS and you relied on the implicit default, set `sslMode: disable` in your metadata config or enable TLS before upgrading. Explicit `DSN` values continue to bypass defaults.

<sup>Written for commit 5988f9084bc61940fa06f559e4aba917ee5d2709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

