### PR TITLE
fix(ledger): preserve Byron EBB parent state

### DIFF
--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -47,13 +47,14 @@ func envelopeParentFromTip(
 	blockNumber uint64,
 	hash []byte,
 	blockType uint,
+	blockTypeLoaded bool,
 ) envelopeParent {
 	origin := len(hash) == 0
 	return envelopeParent{
 		slot:        slot,
 		blockNumber: blockNumber,
 		origin:      origin,
-		byronEbb:    !origin && blockType == uint(gledger.BlockTypeByronEbb),
+		byronEbb:    !origin && blockTypeLoaded && blockType == uint(gledger.BlockTypeByronEbb),
 	}
 }
 

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -38,6 +38,25 @@ type envelopeParent struct {
 	byronEbb    bool
 }
 
+// envelopeParentFromTip reconstructs the envelope metadata for a persisted
+// chain tip. A Tip contains only the point and block number, so callers must
+// provide the stored block type to preserve the Byron EBB exception across
+// ledger-processing batches.
+func envelopeParentFromTip(
+	slot uint64,
+	blockNumber uint64,
+	hash []byte,
+	blockType uint,
+) envelopeParent {
+	origin := len(hash) == 0
+	return envelopeParent{
+		slot:        slot,
+		blockNumber: blockNumber,
+		origin:      origin,
+		byronEbb:    !origin && blockType == uint(gledger.BlockTypeByronEbb),
+	}
+}
+
 func envelopeParentFromBlock(block gledger.Block) envelopeParent {
 	_, isEbb := block.(*byron.ByronEpochBoundaryBlock)
 	return envelopeParent{

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -260,6 +261,28 @@ func TestValidateBlockOrderAllowsByronMainBlockAfterEbb(t *testing.T) {
 		byronEbb:    true,
 	}
 
+	require.NoError(t, validateBlockOrder(block, parent))
+}
+
+// TestEnvelopeParentFromTipPreservesByronEbb verifies that reconstructing a
+// parent from persisted tip metadata keeps the same-slot Byron main-block
+// exception after the EBB has already been committed.
+func TestEnvelopeParentFromTipPreservesByronEbb(t *testing.T) {
+	parent := envelopeParentFromTip(
+		byron.ByronSlotsPerEpoch,
+		5,
+		[]byte{1},
+		uint(gledger.BlockTypeByronEbb),
+	)
+	block := &envelopeTestBlock{
+		header: &envelopeTestHeader{
+			slot:   byron.ByronSlotsPerEpoch,
+			number: 6,
+			era:    byron.EraByron,
+		},
+	}
+
+	require.True(t, parent.byronEbb)
 	require.NoError(t, validateBlockOrder(block, parent))
 }
 

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -273,6 +273,7 @@ func TestEnvelopeParentFromTipPreservesByronEbb(t *testing.T) {
 		5,
 		[]byte{1},
 		uint(gledger.BlockTypeByronEbb),
+		true,
 	)
 	block := &envelopeTestBlock{
 		header: &envelopeTestHeader{
@@ -284,6 +285,32 @@ func TestEnvelopeParentFromTipPreservesByronEbb(t *testing.T) {
 
 	require.True(t, parent.byronEbb)
 	require.NoError(t, validateBlockOrder(block, parent))
+}
+
+func TestEnvelopeParentFromTipDoesNotAssumeByronEbbWhenTypeUnavailable(
+	t *testing.T,
+) {
+	parent := envelopeParentFromTip(
+		byron.ByronSlotsPerEpoch,
+		5,
+		[]byte{1},
+		uint(gledger.BlockTypeByronEbb),
+		false,
+	)
+	block := &envelopeTestBlock{
+		header: &envelopeTestHeader{
+			slot:   byron.ByronSlotsPerEpoch,
+			number: 6,
+			era:    byron.EraByron,
+		},
+	}
+
+	require.False(t, parent.byronEbb)
+	require.ErrorContains(
+		t,
+		validateBlockOrder(block, parent),
+		"does not follow parent slot",
+	)
 }
 
 // TestValidateInboundBlockEnvelopeByronEbbOrdering covers the Byron EBB rule

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4197,11 +4197,28 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// Track expected previous hash for batch processing - updated after each block
 			expectedPrevHash := snapshotTipHash
 			if !parentEnvelopeSet {
-				parentEnvelope = envelopeParent{
-					slot:        snapshotTip.Point.Slot,
-					blockNumber: snapshotTip.BlockNumber,
-					origin:      len(snapshotTip.Point.Hash) == 0,
+				var parentBlockType uint
+				if len(snapshotTip.Point.Hash) > 0 {
+					if storedBlock, err := database.BlockByPoint(
+						ls.db,
+						snapshotTip.Point,
+					); err == nil {
+						parentBlockType = storedBlock.Type
+					} else {
+						ls.config.Logger.Debug(
+							"could not load persisted parent block type for envelope validation",
+							"component", "ledger",
+							"slot", snapshotTip.Point.Slot,
+							"error", err,
+						)
+					}
 				}
+				parentEnvelope = envelopeParentFromTip(
+					snapshotTip.Point.Slot,
+					snapshotTip.BlockNumber,
+					snapshotTip.Point.Hash,
+					parentBlockType,
+				)
 				parentEnvelopeSet = true
 			}
 			// Flag to enable validation after transaction commits (set inside callback,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4198,12 +4198,14 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			expectedPrevHash := snapshotTipHash
 			if !parentEnvelopeSet {
 				var parentBlockType uint
+				var parentBlockTypeLoaded bool
 				if len(snapshotTip.Point.Hash) > 0 {
 					if storedBlock, err := database.BlockByPoint(
 						ls.db,
 						snapshotTip.Point,
 					); err == nil {
 						parentBlockType = storedBlock.Type
+						parentBlockTypeLoaded = true
 					} else {
 						ls.config.Logger.Debug(
 							"could not load persisted parent block type for envelope validation",
@@ -4218,6 +4220,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					snapshotTip.BlockNumber,
 					snapshotTip.Point.Hash,
 					parentBlockType,
+					parentBlockTypeLoaded,
 				)
 				parentEnvelopeSet = true
 			}


### PR DESCRIPTION
## Problem
Genesis bootstrap on mainnet rejected the first Byron main block after the slot-0 EBB with `block slot 0 does not follow parent slot 0`. Persisted tips contain only point/number metadata, so the parent's Byron EBB type was lost between processing batches.

## Changes
- reconstruct persisted parent envelope metadata from the stored block type
- preserve the same-slot Byron main-block exception after an EBB
- add a regression test

## Tests
- go test -race ./ledger -run '^TestValidate|^TestEnvelopeParent' -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mainnet bootstrap rejecting the first Byron main block after the slot‑0 EBB by reconstructing the parent’s EBB state when resuming from a persisted tip. Previously we lost the parent EBB flag and rejected the same‑slot main block; now we derive it from the stored block type and preserve the exception.

- Reconstructs the parent envelope from a persisted tip using the stored block type; queries the database by point and, if the lookup fails, does not assume EBB and logs a debug message.
- Preserves the same‑slot Byron main‑block‑after‑EBB exception in block order validation.
- Adds regression tests for both cases: type available (exception allowed) and type unavailable (no EBB assumed; validation rejects same‑slot main block).

<sup>Written for commit ceae5695f0a6fd2f12b6ead4b27d977bfd40524a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

