### PR TITLE
fix(ledger): defer chainsync resync publishes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -974,18 +974,15 @@ All event types follow the `subsystem.snake_case_name` convention.
   `LedgerState.chainsyncMutex` and `chainsyncBlockfetchMutex` count:
   `RecoverAfterLocalRollback` takes the first and nests the second inside it,
   so holding either while publishing is enough to deadlock.
-- The rule is not yet fully enforced in `ledger`. Several helpers reachable
-  from a lock holder still publish `ChainsyncResyncEventType` inline; they are
-  pinned in `knownResyncPublishPathsUnderLock`
-  (`ledger/publish_under_lock_test.go`) and tracked for conversion, which has
-  to happen as one change because a helper flushing on its own return still
-  publishes while a parent frame holds the lock. Read the rule as the target
-  state plus an explicit exception list, not as an invariant already holding
-  everywhere in that package. `ledger`'s `pendingPublishes`
-  (`ledger/pending_publish.go`) is the pattern for this — queue the event under
-  the lock and flush after the unlock, registering the flush with `defer`
-  *before* taking the lock so LIFO order runs it last. The invariant is
-  enforced for `chainsyncMutex` by `TestNoEventBusPublishWhileHoldingChainsyncMutex`
+- `ledger` enforces this rule for both `chainsyncMutex` and
+  `chainsyncBlockfetchMutex`. The chainsync and blockfetch call chains thread
+  a `pendingPublishes` queue through every guarded helper and flush it after
+  the outermost lock is released; a helper must not flush its own queue while
+  a parent still holds either mutex. The invariant is checked by
+  `TestNoEventBusPublishWhileHoldingChainsyncMutex` and
+  `TestChainsyncResyncPublishPathsUnderLock` in
+  `ledger/publish_under_lock_test.go`. Register the flush with `defer`
+  *before* taking the lock so LIFO order runs it last.
 - The blast radius of such a stall is not local. `LedgerState.handleConnectionClosedEvent`
   takes `chainsyncMutex`, so a stall there stops `ledger.conn_closed` draining;
   the `node.go` handler translating `connmanager.conn_closed` into

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -198,7 +198,7 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 		return
 	}
 	if e.Rollback {
-		if err := ls.handleEventChainsyncRollback(e); err != nil {
+		if err := ls.handleEventChainsyncRollback(e, &pending); err != nil {
 			if errors.Is(err, ErrRollbackLoopDetected) {
 				// The rollback was skipped to break a pathological
 				// loop. Trigger a chainsync re-sync so the peer
@@ -235,7 +235,7 @@ func (ls *LedgerState) handleEventChainsync(evt event.Event) {
 			return
 		}
 	} else if e.BlockHeader != nil {
-		if err := ls.handleEventChainsyncBlockHeader(e); err != nil {
+		if err := ls.handleEventChainsyncBlockHeaderWithPending(e, &pending); err != nil {
 			// Header queue full is expected during bulk sync when
 			// pipelined headers arrive faster than blockfetch can
 			// drain them. Log at DEBUG to avoid log spam.
@@ -456,7 +456,7 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 		return
 	}
 	if e.BatchDone {
-		if err := ls.handleEventBlockfetchBatchDone(e); err != nil {
+		if err := ls.handleEventBlockfetchBatchDone(e, &pending); err != nil {
 			ls.config.Logger.Error(
 				"failed to handle blockfetch batch done",
 				"component", "ledger",
@@ -554,6 +554,7 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 	ls.chainsyncBlockfetchMutex.Lock()
 	replayConnId, err := ls.handoffPipelineOnSwitchLocked(
 		e.NewConnectionId,
+		&pending,
 	)
 	if err != nil {
 		// The target connection may have closed between chain selection
@@ -573,7 +574,7 @@ func (ls *LedgerState) handleChainSwitchEvent(evt event.Event) {
 					"error",
 					err,
 				)
-				if retryConnId, retryErr := ls.handoffPipelineOnSwitchLocked(*activeConnId); retryErr == nil {
+				if retryConnId, retryErr := ls.handoffPipelineOnSwitchLocked(*activeConnId, &pending); retryErr == nil {
 					replayConnId = retryConnId
 					effectiveConnId = *activeConnId
 					err = nil
@@ -725,7 +726,7 @@ func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
 		"header_count",
 		ls.chain.HeaderCount(),
 	)
-	if err := ls.startQueuedBlockfetchLocked(e.ConnectionId); err != nil {
+	if err := ls.startQueuedBlockfetchLocked(e.ConnectionId, &pending); err != nil {
 		ls.config.Logger.Error(
 			"failed to start blockfetch after await reply",
 			"component", "ledger",
@@ -750,7 +751,9 @@ func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
 // summary of dropped rollback events when a switch is detected. It returns the
 // current active connection ID and whether connection filtering is configured.
 // When configured is false, callers should skip all connection-based filtering.
-func (ls *LedgerState) detectConnectionSwitch() (
+func (ls *LedgerState) detectConnectionSwitch(
+	pending *pendingPublishes,
+) (
 	activeConnId *ouroboros.ConnectionId,
 	configured bool,
 ) {
@@ -774,6 +777,7 @@ func (ls *LedgerState) detectConnectionSwitch() (
 			ls.chainsyncBlockfetchMutex.Lock()
 			replayConnId, err := ls.handoffPipelineOnSwitchLocked(
 				*activeConnId,
+				pending,
 			)
 			if err != nil {
 				ls.config.Logger.Warn(
@@ -811,6 +815,7 @@ func (ls *LedgerState) detectConnectionSwitch() (
 
 func (ls *LedgerState) handoffPipelineOnSwitchLocked(
 	newConnId ouroboros.ConnectionId,
+	pending *pendingPublishes,
 ) (ouroboros.ConnectionId, error) {
 	ls.selectedBlockfetchConnId = newConnId
 	headerCount := 0
@@ -877,7 +882,7 @@ func (ls *LedgerState) handoffPipelineOnSwitchLocked(
 			"connection_id", newConnId.String(),
 			"header_count", headerCount,
 		)
-		if err := ls.startQueuedBlockfetchLocked(newConnId); err != nil {
+		if err := ls.startQueuedBlockfetchLocked(newConnId, pending); err != nil {
 			return ouroboros.ConnectionId{}, fmt.Errorf(
 				"restart queued blockfetch on switch: %w",
 				err,
@@ -1440,6 +1445,8 @@ func (ls *LedgerState) replayBufferedHeadersAsync(
 	ls.replayMu.Unlock()
 	go func() {
 		defer ls.replayWG.Done()
+		var pending pendingPublishes
+		defer pending.flush()
 		ls.chainsyncMutex.Lock()
 		defer ls.chainsyncMutex.Unlock()
 		// Re-check after acquiring the mutex in case Close started
@@ -1453,7 +1460,7 @@ func (ls *LedgerState) replayBufferedHeadersAsync(
 			ls.chain.HeaderCount() > 0 {
 			return
 		}
-		if err := ls.replayBufferedHeaderEvents(connId); err != nil {
+		if err := ls.replayBufferedHeaderEvents(connId, &pending); err != nil {
 			ls.config.Logger.Warn(
 				"failed to replay buffered header events",
 				"component", "ledger",
@@ -1466,6 +1473,7 @@ func (ls *LedgerState) replayBufferedHeadersAsync(
 
 func (ls *LedgerState) replayBufferedHeaderEvents(
 	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
 ) error {
 	key := connIdKey(connId)
 	if len(ls.bufferedHeaderEvents[key]) == 0 {
@@ -1477,7 +1485,7 @@ func (ls *LedgerState) replayBufferedHeaderEvents(
 	)
 	delete(ls.bufferedHeaderEvents, key)
 	for _, evt := range events {
-		if err := ls.handleEventChainsyncBlockHeader(evt); err != nil {
+		if err := ls.handleEventChainsyncBlockHeaderWithPending(evt, pending); err != nil {
 			return err
 		}
 	}
@@ -1502,9 +1510,12 @@ func (ls *LedgerState) discardBufferedPeerHeaders(
 	}
 }
 
-func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
+func (ls *LedgerState) handleEventChainsyncRollback(
+	e ChainsyncEvent,
+	pending *pendingPublishes,
+) error {
 	// Filter events from non-active connections when chain selection is enabled
-	if activeConnId, configured := ls.detectConnectionSwitch(); configured {
+	if activeConnId, configured := ls.detectConnectionSwitch(pending); configured {
 		if activeConnId == nil {
 			// No active connection selected yet. Allow the rollback
 			// to proceed — the downstream security-parameter-K check
@@ -1664,18 +1675,17 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 		)
 		ls.resetChainsyncResyncState()
 		ls.setChainsyncState(SyncingChainsyncState)
-		if ls.config.EventBus != nil {
-			ls.config.EventBus.Publish(
+		pending.add(
+			ls.config.EventBus,
+			event.ChainsyncResyncEventType,
+			event.NewEvent(
 				event.ChainsyncResyncEventType,
-				event.NewEvent(
-					event.ChainsyncResyncEventType,
-					event.ChainsyncResyncEvent{
-						ConnectionId: e.ConnectionId,
-						Reason:       event.ChainsyncResyncReasonRollbackAhead,
-					},
-				),
-			)
-		}
+				event.ChainsyncResyncEvent{
+					ConnectionId: e.ConnectionId,
+					Reason:       event.ChainsyncResyncReasonRollbackAhead,
+				},
+			),
+		)
 		return nil
 	}
 
@@ -1718,18 +1728,17 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			)
 			ls.resetChainsyncResyncState()
 			ls.setChainsyncState(SyncingChainsyncState)
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
 					event.ChainsyncResyncEventType,
-					event.NewEvent(
-						event.ChainsyncResyncEventType,
-						event.ChainsyncResyncEvent{
-							ConnectionId: e.ConnectionId,
-							Reason:       event.ChainsyncResyncReasonRollbackNotFound,
-						},
-					),
-				)
-			}
+					event.ChainsyncResyncEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       event.ChainsyncResyncReasonRollbackNotFound,
+					},
+				),
+			)
 			return nil
 		}
 		if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) {
@@ -1773,18 +1782,17 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			// would cause a spurious "switched to fork" log and
 			// fork metric increment on the next block header.
 			ls.setChainsyncState(SyncingChainsyncState)
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
 					event.ChainsyncResyncEventType,
-					event.NewEvent(
-						event.ChainsyncResyncEventType,
-						event.ChainsyncResyncEvent{
-							ConnectionId: e.ConnectionId,
-							Reason:       event.ChainsyncResyncReasonRollbackExceedsK,
-						},
-					),
-				)
-			}
+					event.ChainsyncResyncEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       event.ChainsyncResyncReasonRollbackExceedsK,
+					},
+				),
+			)
 			return nil
 		}
 		if errors.Is(err, ErrRollbackExceedsMithrilBoundary) {
@@ -1844,18 +1852,17 @@ func (ls *LedgerState) handleEventChainsyncRollback(e ChainsyncEvent) error {
 			)
 			ls.resetChainsyncResyncState()
 			ls.setChainsyncState(SyncingChainsyncState)
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
 					event.ChainsyncResyncEventType,
-					event.NewEvent(
-						event.ChainsyncResyncEventType,
-						event.ChainsyncResyncEvent{
-							ConnectionId: e.ConnectionId,
-							Reason:       reason,
-						},
-					),
-				)
-			}
+					event.ChainsyncResyncEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       reason,
+					},
+				),
+			)
 			return nil
 		}
 		return fmt.Errorf("chain rollback failed: %w", err)
@@ -2128,6 +2135,8 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 	connIds []ouroboros.ConnectionId,
 	point ocommon.Point,
 ) LocalRollbackRecoveryResult {
+	var pending pendingPublishes
+	defer pending.flush()
 	ls.chainsyncMutex.Lock()
 	defer ls.chainsyncMutex.Unlock()
 
@@ -2199,7 +2208,7 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 		)
 		ls.chainsyncBlockfetchMutex.Lock()
 		if ls.chainsyncBlockfetchReadyChan == nil {
-			if err := ls.startQueuedBlockfetchLocked(connId); err != nil {
+			if err := ls.startQueuedBlockfetchLocked(connId, &pending); err != nil {
 				// Recovery connection may have closed. Retry with
 				// the current active best peer before giving up,
 				// otherwise the pipeline stalls until restart.
@@ -2217,7 +2226,7 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 							"error",
 							err,
 						)
-						if retryErr := ls.startQueuedBlockfetchLocked(*activeConnId); retryErr == nil {
+						if retryErr := ls.startQueuedBlockfetchLocked(*activeConnId, &pending); retryErr == nil {
 							err = nil
 						} else {
 							err = retryErr
@@ -2243,13 +2252,26 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 	return LocalRollbackRecoveryResult{}
 }
 
+// handleEventChainsyncBlockHeader preserves the direct helper used by focused
+// tests. It owns a queue for the locks it may take internally; production
+// lock holders call handleEventChainsyncBlockHeaderWithPending so their outer
+// queue is threaded through the whole call chain.
 func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
+	var pending pendingPublishes
+	defer pending.flush()
+	return ls.handleEventChainsyncBlockHeaderWithPending(e, &pending)
+}
+
+func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
+	e ChainsyncEvent,
+	pending *pendingPublishes,
+) error {
 	// Detect connection switch so pipeline ownership is handed off
 	// even when the first post-switch event is a header rather than
 	// a rollback. Without this, headers from a newly-selected active
 	// connection are buffered indefinitely because the pipeline owner
 	// still points to the old (dead) connection.
-	ls.detectConnectionSwitch()
+	ls.detectConnectionSwitch(pending)
 
 	// Track upstream tip for sync progress reporting
 	if e.Tip.Point.Slot > ls.syncUpstreamTipSlot.Load() {
@@ -2287,7 +2309,8 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 						"slot", e.Point.Slot,
 						"hash", hex.EncodeToString(e.Point.Hash),
 					)
-					ls.config.EventBus.Publish(
+					pending.add(
+						ls.config.EventBus,
 						ConnectionRecycleRequestedEventType,
 						event.NewEvent(
 							ConnectionRecycleRequestedEventType,
@@ -2407,7 +2430,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 			// chain and the peer's chain is ahead, we roll back to
 			// the common ancestor so chainsync can continue.
 			resolved, resolveErr := ls.tryResolveFork(
-				e, notFitErr,
+				e, notFitErr, pending,
 			)
 			if resolveErr != nil {
 				if ls.headerMismatchCount > 0 {
@@ -2440,7 +2463,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 				ls.requestChainsyncResync(
 					e.ConnectionId,
 					event.ChainsyncResyncReasonPersistentFork,
-					nil,
+					pending,
 				)
 			}
 			return nil
@@ -2521,7 +2544,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		"connection_id", initialConnId.String(),
 		"header_count", ls.chain.HeaderCount(),
 	)
-	err = ls.startQueuedBlockfetchLocked(initialConnId)
+	err = ls.startQueuedBlockfetchLocked(initialConnId, pending)
 	if err != nil {
 		// The chosen connection's blockfetch protocol may have shut
 		// down. Try the header source connection if it's different;
@@ -2534,7 +2557,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 				"retry_connection_id", e.ConnectionId.String(),
 				"error", err,
 			)
-			if retryErr := ls.startQueuedBlockfetchLocked(e.ConnectionId); retryErr == nil {
+			if retryErr := ls.startQueuedBlockfetchLocked(e.ConnectionId, pending); retryErr == nil {
 				return nil
 			}
 		}
@@ -2558,7 +2581,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 					err,
 				)
 				ls.selectedBlockfetchConnId = *activeConnId
-				if retryErr := ls.startQueuedBlockfetchLocked(*activeConnId); retryErr == nil {
+				if retryErr := ls.startQueuedBlockfetchLocked(*activeConnId, pending); retryErr == nil {
 					return nil
 				}
 			}
@@ -2570,7 +2593,7 @@ func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
 		ls.requestChainsyncResync(
 			initialConnId,
 			fmt.Sprintf("blockfetch start failed: %v", err),
-			nil,
+			pending,
 		)
 		return nil
 	}
@@ -2608,6 +2631,7 @@ func (ls *LedgerState) hasCachedEpochNonceForSlot(slot uint64) bool {
 func (ls *LedgerState) tryResolveFork(
 	e ChainsyncEvent,
 	notFitErr chain.BlockNotFitChainTipError,
+	pending *pendingPublishes,
 ) (bool, error) {
 	localTip := ls.chain.Tip()
 	praosComparison := ls.compareIncomingHeaderToLocalTip(
@@ -2667,7 +2691,7 @@ func (ls *LedgerState) tryResolveFork(
 		ls.requestChainsyncResync(
 			e.ConnectionId,
 			event.ChainsyncResyncReasonRollbackNotFound,
-			nil,
+			pending,
 		)
 		return true, nil
 	}
@@ -2745,7 +2769,7 @@ func (ls *LedgerState) tryResolveFork(
 		if ls.config.BlockfetchRequestRangeFunc != nil &&
 			ls.chain.HeaderCount() > 0 {
 			ls.chainsyncBlockfetchMutex.Lock()
-			if err := ls.restartQueuedBlockfetchAfterForkLocked(e.ConnectionId); err != nil {
+			if err := ls.restartQueuedBlockfetchAfterForkLocked(e.ConnectionId, pending); err != nil {
 				ls.config.Logger.Warn(
 					"failed to start blockfetch after fork extension",
 					"component", "ledger",
@@ -2794,7 +2818,7 @@ func (ls *LedgerState) tryResolveFork(
 			ls.requestChainsyncResync(
 				e.ConnectionId,
 				event.ChainsyncResyncReasonRollbackNotFound,
-				nil,
+				pending,
 			)
 			return true, nil
 		}
@@ -2833,18 +2857,17 @@ func (ls *LedgerState) tryResolveFork(
 			// caller does not fire a duplicate resync event.
 			ls.headerMismatchCount = 0
 			ls.rollbackHistory = nil
-			if ls.config.EventBus != nil {
-				ls.config.EventBus.Publish(
+			pending.add(
+				ls.config.EventBus,
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
 					event.ChainsyncResyncEventType,
-					event.NewEvent(
-						event.ChainsyncResyncEventType,
-						event.ChainsyncResyncEvent{
-							ConnectionId: e.ConnectionId,
-							Reason:       event.ChainsyncResyncReasonForkResolutionExceedsK,
-						},
-					),
-				)
-			}
+					event.ChainsyncResyncEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       event.ChainsyncResyncReasonForkResolutionExceedsK,
+					},
+				),
+			)
 			return true, nil
 		} else {
 			ls.config.Logger.Error(
@@ -2891,7 +2914,7 @@ func (ls *LedgerState) tryResolveFork(
 	if ls.config.BlockfetchRequestRangeFunc != nil &&
 		ls.chain.HeaderCount() > 0 {
 		ls.chainsyncBlockfetchMutex.Lock()
-		if err := ls.restartQueuedBlockfetchAfterForkLocked(e.ConnectionId); err != nil {
+		if err := ls.restartQueuedBlockfetchAfterForkLocked(e.ConnectionId, pending); err != nil {
 			ls.config.Logger.Warn(
 				"failed to start blockfetch after fork rollback",
 				"component", "ledger",
@@ -3040,6 +3063,7 @@ func (ls *LedgerState) nextBlockfetchConnIdExcept(
 
 func (ls *LedgerState) restartQueuedBlockfetchAfterForkLocked(
 	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
 ) error {
 	if ls.chainsyncBlockfetchReadyChan != nil {
 		if ls.chainsyncBlockfetchTimeoutTimer != nil {
@@ -3064,7 +3088,7 @@ func (ls *LedgerState) restartQueuedBlockfetchAfterForkLocked(
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 	}
 	ls.selectedBlockfetchConnId = connId
-	return ls.startQueuedBlockfetchLocked(connId)
+	return ls.startQueuedBlockfetchLocked(connId, pending)
 }
 
 // blockfetchNoBlocksErrorText is the error text emitted by the gouroboros
@@ -3125,6 +3149,7 @@ func (ls *LedgerState) noteBlockfetchRangeUnavailable(
 	connId ouroboros.ConnectionId,
 	start ocommon.Point,
 	reason string,
+	pending *pendingPublishes,
 ) bool {
 	if ls.chain == nil || ls.chain.HeaderCount() == 0 {
 		return false
@@ -3171,13 +3196,14 @@ func (ls *LedgerState) noteBlockfetchRangeUnavailable(
 	ls.requestChainsyncResync(
 		connId,
 		event.ChainsyncResyncReasonBlockfetchRangeUnavailable,
-		nil,
+		pending,
 	)
 	return true
 }
 
 func (ls *LedgerState) startQueuedBlockfetchLocked(
 	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
 ) error {
 	if ls.chain.HeaderCount() == 0 {
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
@@ -3217,6 +3243,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 				connId,
 				headerStart,
 				fmt.Sprintf("blockfetch request returned NoBlocks: %v", err),
+				pending,
 			)
 		}
 		return err
@@ -4898,13 +4925,15 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 	ls.chainsyncBlockfetchTimeoutTimer = time.AfterFunc(
 		blockfetchBusyTimeout,
 		func() {
+			var pending pendingPublishes
+			defer pending.flush()
 			ls.chainsyncBlockfetchMutex.Lock()
 			defer ls.chainsyncBlockfetchMutex.Unlock()
 			// Check if this timer callback is stale (a newer timer was started)
 			if ls.chainsyncBlockfetchTimerGeneration != currentGeneration {
 				return
 			}
-			ls.handleBlockfetchTimeoutLocked(connId)
+			ls.handleBlockfetchTimeoutLocked(connId, &pending)
 		},
 	)
 	return nil
@@ -4934,6 +4963,7 @@ func (ls *LedgerState) blockfetchRequestRangeCleanup() {
 
 func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 	currentConnId ouroboros.ConnectionId,
+	pending *pendingPublishes,
 ) {
 	headerCount := ls.chain.HeaderCount()
 	if headerCount == 0 {
@@ -4965,7 +4995,7 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 		"header_end_slot", headerEnd.Slot,
 		"header_count", headerCount,
 	)
-	if err := ls.startQueuedBlockfetchLocked(retryConnId); err != nil {
+	if err := ls.startQueuedBlockfetchLocked(retryConnId, pending); err != nil {
 		ls.config.Logger.Error(
 			"failed to retry blockfetch range after timeout",
 			"component", "ledger",
@@ -4980,7 +5010,7 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 				"retry_connection_id", nextConnId.String(),
 				"header_count", ls.chain.HeaderCount(),
 			)
-			if retryErr := ls.startQueuedBlockfetchLocked(nextConnId); retryErr != nil {
+			if retryErr := ls.startQueuedBlockfetchLocked(nextConnId, pending); retryErr != nil {
 				ls.config.Logger.Error(
 					"failed to restart queued blockfetch after timeout retry failure",
 					"component",
@@ -4990,8 +5020,9 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 					"error",
 					retryErr,
 				)
-				if ls.chain.HeaderCount() > 0 && ls.config.EventBus != nil {
-					ls.config.EventBus.Publish(
+				if ls.chain.HeaderCount() > 0 {
+					pending.add(
+						ls.config.EventBus,
 						event.ChainsyncResyncEventType,
 						event.NewEvent(
 							event.ChainsyncResyncEventType,
@@ -5007,7 +5038,10 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 	}
 }
 
-func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
+func (ls *LedgerState) handleEventBlockfetchBatchDone(
+	e BlockfetchEvent,
+	pending *pendingPublishes,
+) error {
 	// Drop batch-done from a stale connection (e.g., after connection switch).
 	// Accept it from either the primary or the shadow peer: in the near-tip
 	// shadow path the shadow can win the race and emit BatchDone before the
@@ -5064,6 +5098,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 			e.ConnectionId,
 			batchStart,
 			"batch completed without delivering a block",
+			pending,
 		) {
 			return nil
 		}
@@ -5088,7 +5123,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 				"remaining_headers",
 				remainingHeaders,
 			)
-			if err := ls.startQueuedBlockfetchLocked(retryConnId); err != nil {
+			if err := ls.startQueuedBlockfetchLocked(retryConnId, pending); err != nil {
 				ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 				ls.clearQueuedHeaders()
 				ls.requestChainsyncResync(
@@ -5097,7 +5132,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 						"empty blockfetch batch alternate retry failed: %v",
 						err,
 					),
-					nil,
+					pending,
 				)
 				return nil
 			}
@@ -5114,7 +5149,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		ls.requestChainsyncResync(
 			e.ConnectionId,
 			"empty blockfetch batch",
-			nil,
+			pending,
 		)
 		return nil
 	}
@@ -5143,7 +5178,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		return nil
 	}
 	// Mark blockfetch as in progress for next batch
-	err := ls.startQueuedBlockfetchLocked(nextConnId)
+	err := ls.startQueuedBlockfetchLocked(nextConnId, pending)
 	if err != nil {
 		// The connection's blockfetch protocol may have shut down
 		// (e.g. peer disconnected mid-batch). Try an alternate
@@ -5163,7 +5198,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 				"error",
 				err,
 			)
-			if retryErr := ls.startQueuedBlockfetchLocked(retryConnId); retryErr == nil {
+			if retryErr := ls.startQueuedBlockfetchLocked(retryConnId, pending); retryErr == nil {
 				return nil
 			}
 		}
@@ -5172,7 +5207,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(e BlockfetchEvent) error {
 		ls.requestChainsyncResync(
 			nextConnId,
 			fmt.Sprintf("blockfetch continuation failed: %v", err),
-			nil,
+			pending,
 		)
 		return nil
 	}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2252,16 +2252,6 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 	return LocalRollbackRecoveryResult{}
 }
 
-// handleEventChainsyncBlockHeader preserves the direct helper used by focused
-// tests. It owns a queue for the locks it may take internally; production
-// lock holders call handleEventChainsyncBlockHeaderWithPending so their outer
-// queue is threaded through the whole call chain.
-func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
-	var pending pendingPublishes
-	defer pending.flush()
-	return ls.handleEventChainsyncBlockHeaderWithPending(e, &pending)
-}
-
 func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	e ChainsyncEvent,
 	pending *pendingPublishes,

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -113,7 +113,7 @@ func TestStartQueuedBlockfetchDropsHeadersAfterRepeatedNoBlocks(t *testing.T) {
 	for range attempts {
 		// Callers treat this error as advisory (several only log it), so
 		// the recovery cannot depend on any caller acting on it.
-		_ = ls.startQueuedBlockfetchLocked(connId)
+		_ = ls.startQueuedBlockfetchLocked(connId, nil)
 	}
 
 	assert.LessOrEqual(
@@ -187,7 +187,7 @@ func TestStartQueuedBlockfetchTransientErrorsDoNotAccumulate(t *testing.T) {
 
 			connId := testChainsyncConnId(6110, 3001)
 			for range blockfetchMaxSameRangeFailures * 3 {
-				err := ls.startQueuedBlockfetchLocked(connId)
+				err := ls.startQueuedBlockfetchLocked(connId, nil)
 				require.Error(t, err)
 			}
 
@@ -229,7 +229,7 @@ func TestRestartQueuedBlockfetchAfterForkDropsHeadersOnRepeatedNoBlocks(
 	for range attempts {
 		// Mirrors the fork-resolution call sites, which discard the error
 		// after logging it.
-		_ = ls.restartQueuedBlockfetchAfterForkLocked(connId)
+		_ = ls.restartQueuedBlockfetchAfterForkLocked(connId, nil)
 	}
 
 	assert.LessOrEqual(
@@ -263,7 +263,7 @@ func TestBlockfetchRangeFailureClearedWhenRangeIsDelivered(t *testing.T) {
 	stuckStart, _ := ls.chain.HeaderRange(blockfetchBatchSize)
 
 	for range blockfetchMaxSameRangeFailures * 3 {
-		_ = ls.startQueuedBlockfetchLocked(connId)
+		_ = ls.startQueuedBlockfetchLocked(connId, nil)
 		require.Positive(
 			t,
 			ls.chain.HeaderCount(),
@@ -313,7 +313,7 @@ func TestBlockfetchRangeFailuresAccumulatePerRangeDespiteInterleavedActivity(
 			"stuck header must be queued for attempt %d",
 			attempt,
 		)
-		_ = ls.startQueuedBlockfetchLocked(connId)
+		_ = ls.startQueuedBlockfetchLocked(connId, nil)
 		if attempt == blockfetchMaxSameRangeFailures {
 			break
 		}
@@ -359,7 +359,7 @@ func TestBlockfetchRangeFailuresDoNotAccumulateAcrossDifferentRanges(
 	connId := testChainsyncConnId(6106, 3001)
 
 	for attempt := range blockfetchMaxSameRangeFailures * 3 {
-		_ = ls.startQueuedBlockfetchLocked(connId)
+		_ = ls.startQueuedBlockfetchLocked(connId, nil)
 		// Each attempt is against a different queued header, as happens
 		// when the chain keeps moving and every miss is a one-off.
 		ls.clearQueuedHeaders()
@@ -460,7 +460,7 @@ func TestHandleEventBlockfetchBatchDoneStopsRepeatingEmptyBatches(
 			ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 				ConnectionId: connId,
 				BatchDone:    true,
-			}),
+			}, nil),
 			"batch done %d", i,
 		)
 	}
@@ -537,7 +537,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchStreakResetsOnProgress(
 			ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 				ConnectionId: connId,
 				BatchDone:    true,
-			}),
+			}, nil),
 		)
 		// Stand in for a delivered block: handleEventBlockfetchBlock both
 		// counts the block and discards that range's failure record.
@@ -548,7 +548,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchStreakResetsOnProgress(
 			ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 				ConnectionId: connId,
 				BatchDone:    true,
-			}),
+			}, nil),
 		)
 	}
 

--- a/ledger/chainsync_pinned_tip_test.go
+++ b/ledger/chainsync_pinned_tip_test.go
@@ -92,6 +92,7 @@ func TestHandleEventChainsyncRollbackToBlockTipDoesNotPublishLedgerRollback(
 			ConnectionId: fixture.connId,
 			Point:        fixture.currentTip.Point,
 		},
+		nil,
 	))
 
 	assert.Equal(t, fixture.currentTip, fixture.ls.currentTip)

--- a/ledger/chainsync_rollback_loop_test.go
+++ b/ledger/chainsync_rollback_loop_test.go
@@ -36,7 +36,7 @@ func TestHandleEventChainsyncRollbackClearsLoopHistoryForCrossedPoint(
 	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: fixture.connId,
 		Point:        fixture.ancestorTip.Point,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
 
@@ -61,7 +61,7 @@ func TestHandleEventChainsyncRollbackAppliesRepeatedCrossableRollback(
 	require.NoError(t, fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: fixture.connId,
 		Point:        fixture.ancestorTip.Point,
-	}))
+	}, nil))
 	require.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
 
 	// Re-extend the chain past the fork point so a second rollback to it is
@@ -85,7 +85,7 @@ func TestHandleEventChainsyncRollbackAppliesRepeatedCrossableRollback(
 	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: fixture.connId,
 		Point:        fixture.ancestorTip.Point,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.NotErrorIs(t, err, ErrRollbackLoopDetected)
 	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
@@ -125,7 +125,7 @@ func TestHandleEventChainsyncRollbackSkipReportsUnrecoverableRollback(
 	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: fixture.connId,
 		Point:        uncrossablePoint,
-	})
+	}, nil)
 	require.ErrorIs(t, err, ErrRollbackLoopDetected)
 
 	_, ok := fixture.ls.unrecoverableRollbacks[unrecoverableRollbackKey(
@@ -164,7 +164,7 @@ func TestHandleEventChainsyncRollbackAppliesCrossableRollbackAtLoopThreshold(
 	err := fixture.ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: fixture.connId,
 		Point:        fixture.ancestorTip.Point,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.NotErrorIs(t, err, ErrRollbackLoopDetected)
 	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -65,6 +65,7 @@ func TestHandleEventChainsyncRollbackSynchronizesLedgerTip(t *testing.T) {
 			ConnectionId: fixture.connId,
 			Point:        fixture.ancestorTip.Point,
 		},
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -126,6 +127,7 @@ func TestHandleEventChainsyncRollbackRejectsBelowMithrilBoundary(
 			ConnectionId: fixture.connId,
 			Point:        fixture.ancestorTip.Point,
 		},
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -193,6 +195,7 @@ func TestHandleEventChainsyncRollbackPrunesStaleBlockNonces(
 			ConnectionId: fixture.connId,
 			Point:        fixture.ancestorTip.Point,
 		},
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -306,6 +309,7 @@ func TestHandleEventChainsyncRollbackDoesNotSkipDifferentPeerHistory(
 			ConnectionId: fixture.connId,
 			Point:        fixture.ancestorTip.Point,
 		},
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -350,6 +354,7 @@ func TestHandleEventChainsyncRollbackSkipsSamePeerLoop(
 			ConnectionId: fixture.connId,
 			Point:        uncrossablePoint,
 		},
+		nil,
 	)
 	require.ErrorIs(t, err, ErrRollbackLoopDetected)
 
@@ -368,6 +373,7 @@ func TestHandleEventChainsyncRollbackExceedsKReconcilesDivergedLedgerTip(
 			ConnectionId: fixture.connId,
 			Point:        ocommon.Point{},
 		},
+		nil,
 	))
 
 	assert.Equal(t, fixture.ancestorTip, fixture.ls.chain.Tip())
@@ -428,6 +434,7 @@ func TestTryResolveForkSynchronizesLedgerTip(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 	require.NoError(t, err)
 	require.True(t, resolved)
@@ -476,6 +483,7 @@ func TestTryResolveForkGenesisRejectsLongerSparseCandidate(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 
 	require.NoError(t, err)
@@ -586,6 +594,7 @@ func TestTryResolveForkUsesPraosAfterGenesisExit(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 
 	require.NoError(t, err)
@@ -732,6 +741,7 @@ func TestTryResolveForkExceedsKReconcilesDivergedLedgerTip(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 	require.NoError(t, err)
 	require.True(t, resolved)
@@ -787,6 +797,7 @@ func TestTryResolveForkPropagatesAncestorLookupError(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 
 	require.False(t, resolved)
@@ -919,6 +930,7 @@ func TestTryResolveForkDoesNotAdvanceLaggingLedgerTip(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 	require.NoError(t, err)
 	require.True(t, resolved)
@@ -995,6 +1007,7 @@ func TestTryResolveForkQueuesKnownPeerForkSegment(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 	require.NoError(t, err)
 	require.True(t, resolved)
@@ -1080,6 +1093,7 @@ func TestTryResolveForkUsesObservedPeerHistoryFallback(t *testing.T) {
 			},
 		},
 		notFitErr,
+		nil,
 	)
 	require.NoError(t, err)
 	require.True(t, resolved)
@@ -2106,6 +2120,7 @@ func TestHandleEventChainsyncRollbackClassifiesStalePeerBelowMithrilBoundary(
 			// The peer's own tip sits below our trust boundary.
 			Tip: fixture.ancestorTip,
 		},
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -2171,6 +2186,7 @@ func TestHandleEventChainsyncRollbackRejectsDivergentPeerTipAboveMithrilBoundary
 				BlockNumber: fixture.currentTip.BlockNumber + 1,
 			},
 		},
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/ledger/chainsync_shadow_test.go
+++ b/ledger/chainsync_shadow_test.go
@@ -81,7 +81,7 @@ func TestHandleEventBlockfetchBatchDoneAcceptsShadowCompletion(t *testing.T) {
 	require.NoError(t, ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: shadow,
 		BatchDone:    true,
-	}))
+	}, nil))
 
 	// The shadow's BatchDone is accepted, so the batch advances and a
 	// follow-up RequestRange is dispatched for the still-queued header.
@@ -151,7 +151,7 @@ func TestHandleEventBlockfetchBatchDoneDropsStaleShadowAfterCleanup(
 	require.NoError(t, ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: primary,
 		BatchDone:    true,
-	}))
+	}, nil))
 	assert.Equal(t, 1, requestCount)
 	assert.Equal(t, ouroboros.ConnectionId{}, ls.shadowBlockfetchConnId)
 
@@ -160,7 +160,7 @@ func TestHandleEventBlockfetchBatchDoneDropsStaleShadowAfterCleanup(
 	require.NoError(t, ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: shadow,
 		BatchDone:    true,
-	}))
+	}, nil))
 	assert.Equal(
 		t,
 		1,
@@ -223,7 +223,7 @@ func TestStartQueuedBlockfetchAfterForkRestartClearsShadowState(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ls.restartQueuedBlockfetchAfterForkLocked(primary))
+	require.NoError(t, ls.restartQueuedBlockfetchAfterForkLocked(primary, nil))
 
 	// Stale per-batch shadow state must be cleared by the restart so that
 	// the new batch starts in a known state.

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -130,7 +130,7 @@ func TestDetectConnectionSwitchHandsOffQueuedHeadersToNewActiveConnection(
 		},
 	}
 
-	activeConnId, configured := ls.detectConnectionSwitch()
+	activeConnId, configured := ls.detectConnectionSwitch(nil)
 	require.True(t, configured)
 	require.NotNil(t, activeConnId)
 	assert.Equal(t, connId2, *activeConnId)
@@ -251,7 +251,7 @@ func TestHandoffPipelineOnSwitchDropsStaleQueuedHeadersForNewBufferedPeer(
 		},
 	}
 
-	replayConnId, err := ls.handoffPipelineOnSwitchLocked(connId2)
+	replayConnId, err := ls.handoffPipelineOnSwitchLocked(connId2, nil)
 	require.NoError(t, err)
 	assert.Equal(t, connId2, replayConnId)
 	assert.Equal(t, 0, testChain.HeaderCount())
@@ -477,7 +477,7 @@ func TestHandleEventBlockfetchBatchDoneUsesSelectedConnectionAfterSwitch(
 	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId1,
 		BatchDone:    true,
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, requestCount)
 	assert.Equal(t, connId2, requestedConnId)
@@ -528,7 +528,7 @@ func TestHandleEventBlockfetchBatchDoneFallsBackToCurrentConnection(
 	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId,
 		BatchDone:    true,
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, requestCount)
 	assert.Equal(t, connId, requestedConnId)
@@ -1328,7 +1328,7 @@ func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
 	err := ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId1,
 		BatchDone:    true,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		ls.chainsyncMutex.Lock()
@@ -1555,7 +1555,7 @@ func TestHandleEventChainsyncRollbackClearsBufferedHeadersForNonActivePeer(
 	err := ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: bufferedConn,
 		Point:        ocommon.NewPoint(0, nil),
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Empty(t, ls.bufferedHeaderEvents[connIdKey(bufferedConn)])
 }
@@ -1788,7 +1788,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchRetriesAlternateConnection(
 	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId1,
 		BatchDone:    true,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, []ouroboros.ConnectionId{connId2}, requestedConnIds)
 	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
@@ -1836,7 +1836,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchNearTipRetries(
 	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
 		ConnectionId: connId,
 		BatchDone:    true,
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, requestCount)
 	assert.Equal(t, 1, testChain.HeaderCount())
@@ -1889,7 +1889,7 @@ func TestHandleBlockfetchTimeoutLocked_RetriesQueuedRangeUsingActivePeer(
 		},
 	}
 
-	ls.handleBlockfetchTimeoutLocked(connId1)
+	ls.handleBlockfetchTimeoutLocked(connId1, nil)
 
 	assert.Equal(t, connId2, requestedConn)
 	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
@@ -1913,7 +1913,7 @@ func TestHandleBlockfetchTimeoutLocked_ClearsActiveConnectionWithoutHeaders(
 		},
 	}
 
-	ls.handleBlockfetchTimeoutLocked(connId)
+	ls.handleBlockfetchTimeoutLocked(connId, nil)
 
 	assert.Equal(t, ouroboros.ConnectionId{}, ls.activeBlockfetchConnId)
 	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
@@ -1972,7 +1972,7 @@ func TestHandleBlockfetchTimeoutLocked_RetryFailureUsesAlternateSelectedPeer(
 		},
 	}
 
-	ls.handleBlockfetchTimeoutLocked(connId1)
+	ls.handleBlockfetchTimeoutLocked(connId1, nil)
 
 	require.Equal(
 		t,

--- a/ledger/chainsync_test.go
+++ b/ledger/chainsync_test.go
@@ -28,6 +28,15 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/eras"
 )
 
+// handleEventChainsyncBlockHeader preserves the direct helper used by focused
+// tests. Production callers use handleEventChainsyncBlockHeaderWithPending so
+// their outer pending-publish queue is threaded through the whole call chain.
+func (ls *LedgerState) handleEventChainsyncBlockHeader(e ChainsyncEvent) error {
+	var pending pendingPublishes
+	defer pending.flush()
+	return ls.handleEventChainsyncBlockHeaderWithPending(e, &pending)
+}
+
 func TestDesiredBlockfetchBatchHeaders(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/ledger/crossfork_splice_test.go
+++ b/ledger/crossfork_splice_test.go
@@ -77,7 +77,7 @@ func TestChainsyncRollbackToAbandonedForkDoesNotSpliceChain(t *testing.T) {
 	err = ls.handleEventChainsyncRollback(ChainsyncEvent{
 		ConnectionId: fixture.connId,
 		Point:        abandonedPoint,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(

--- a/ledger/pending_publish_test.go
+++ b/ledger/pending_publish_test.go
@@ -100,7 +100,7 @@ func TestPendingPublishesBreaksLockCycle(t *testing.T) {
 	// ChainsyncResyncEventType's subscriber does via
 	// RecoverAfterLocalRollback.
 	bus.SubscribeFuncWithBuffer(
-		LedgerErrorEventType, 1,
+		event.ChainsyncResyncEventType, 1,
 		func(event.Event) {
 			chainsyncMutex.Lock()
 			chainsyncMutex.Unlock() //nolint:staticcheck // lock/unlock is the point
@@ -110,7 +110,8 @@ func TestPendingPublishesBreaksLockCycle(t *testing.T) {
 
 	newEvt := func(op string) event.Event {
 		return event.NewEvent(
-			LedgerErrorEventType, LedgerErrorEvent{Operation: op},
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{Reason: op},
 		)
 	}
 
@@ -124,7 +125,11 @@ func TestPendingPublishesBreaksLockCycle(t *testing.T) {
 		// Enough to overrun the subscriber's buffer while it is parked on
 		// the lock we hold. Publishing these directly is the deadlock.
 		for i := range 4 {
-			pending.add(bus, LedgerErrorEventType, newEvt(string(rune('a'+i))))
+			pending.add(
+				bus,
+				event.ChainsyncResyncEventType,
+				newEvt(string(rune('a'+i))),
+			)
 		}
 	}()
 

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -42,22 +42,9 @@ var guardedMutexes = []string{
 	"chainsyncBlockfetchMutex",
 }
 
-// knownNilQueuePublishersUnderLock are lock holders that still hand nil to
-// a queue-taking helper, publishing inline while they hold a guarded
-// mutex.
-//
-// These cannot be converted in isolation. Giving one its own queue and
-// flushing on its own return does not help, because a parent frame still
-// holds a guarded mutex when it runs -- handleEventChainsyncBlockHeader is
-// called from handleEventChainsync, which holds chainsyncMutex. Fixing
-// them is the same threading described in
-// knownResyncPublishPathsUnderLock and tracked for one atomic change.
-//
-// Listed rather than silently tolerated, and checked in both directions
-// below so the list cannot rot.
-var knownNilQueuePublishersUnderLock = []string{
-	"handleEventChainsyncBlockHeader",
-}
+// knownNilQueuePublishersUnderLock is intentionally empty. A guarded caller
+// must always pass its pending queue; a nil queue would publish inline.
+var knownNilQueuePublishersUnderLock []string
 
 // TestNoEventBusPublishWhileHoldingChainsyncMutex enforces that nothing in
 // this package publishes to the EventBus while holding a mutex that an
@@ -176,7 +163,11 @@ func queueParamPositions(files []*ast.File) map[string]int {
 			idx := 0
 			for _, field := range fn.Type.Params.List {
 				isQueue := false
-				if star, ok := field.Type.(*ast.StarExpr); ok {
+				queueType := field.Type
+				if ellipsis, ok := queueType.(*ast.Ellipsis); ok {
+					queueType = ellipsis.Elt
+				}
+				if star, ok := queueType.(*ast.StarExpr); ok {
 					if id, ok := star.X.(*ast.Ident); ok &&
 						id.Name == "pendingPublishes" {
 						isQueue = true
@@ -328,31 +319,10 @@ func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
 	return found
 }
 
-// knownResyncPublishPathsUnderLock records every helper that can publish
-// ChainsyncResyncEventType while one of guardedMutexes is held.
-//
-// That event is the dangerous one: its subscriber calls
-// RecoverAfterLocalRollback, which takes the same mutex, so a publish
-// reaching it from under the lock is the deadlock pendingPublishes
-// exists to break. handleChainSwitchEvent was converted because a review
-// demonstrated it concretely; the rest are pre-existing paths that
-// predate this change.
-//
-// Converting them means threading a queue through roughly ten functions
-// in the hottest consensus path, which belongs in its own change with its
-// own DevNet and soak validation rather than riding along here. This list
-// is the honest alternative to silence: the guard above is
-// intra-procedural, so without it the remaining exposure would look like
-// it had been handled.
-var knownResyncPublishPathsUnderLock = []string{
-	"handleBlockfetchTimeoutLocked",
-	"handleEventBlockfetchBatchDone",
-	"handleEventChainsyncRollback",
-	"handoffPipelineOnSwitchLocked",
-	"replayBufferedHeaderEvents",
-	"restartQueuedBlockfetchAfterForkLocked",
-	"startQueuedBlockfetchLocked",
-}
+// knownResyncPublishPathsUnderLock is intentionally empty. Every resync
+// publish reachable from a guarded lock holder must be queued and flushed
+// after the lock is released.
+var knownResyncPublishPathsUnderLock []string
 
 // TestChainsyncResyncPublishPathsUnderLock pins the set of helpers that
 // can publish ChainsyncResyncEventType while the mutex is held.


### PR DESCRIPTION
Fixes #3167

## Problem

ChainsyncResync EventBus delivery could block while chainsync or blockfetch
mutexes were held, deadlocking rollback recovery under subscriber backpressure.

## Changes

- Thread `pendingPublishes` through all guarded chainsync/blockfetch paths.
- Add regression coverage for deferred publishing and lock ownership.
- Update `ARCHITECTURE.md` with the publish/lock invariant.

## Tests

- `go test -race ./ledger -run '^(TestChainsync|TestPendingPublishes|TestNoEventBusPublishWhileHoldingChainsyncMutex)' -count=1`
- `go test -run '^$' ./...`
- `go vet ./ledger`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `EventBus` publishes of `ChainsyncResyncEventType` while `chainsyncMutex` or `chainsyncBlockfetchMutex` are held to prevent rollback recovery deadlocks. Previously, resync events could publish inline under these locks; now they queue in `pendingPublishes` and flush after the outermost lock releases, preserving delivery without blocking lock holders.

- Threads a `pendingPublishes` queue through all guarded chainsync/blockfetch helpers and uses `handleEventChainsyncBlockHeaderWithPending`; production callers pass the same queue down and never flush under a parent lock.
- Enforces the rule for both mutexes: removes the exception lists, and pins it with `TestNoEventBusPublishWhileHoldingChainsyncMutex` and `TestChainsyncResyncPublishPathsUnderLock`; updates `ARCHITECTURE.md` accordingly.
- Converts resync publishes in rollback, fork-resolution, blockfetch timeout/empty-batch handling, connection handoff, and buffered header replay to deferred queueing. Internal helpers gain a `*pendingPublishes` parameter; no external API changes.
- Moves the test-only `handleEventChainsyncBlockHeader` helper out of production; tests use a wrapper in `ledger/chainsync_test.go`.

<sup>Written for commit e11790b97a7ba1acda2248b0bcebbc9d0d04dd92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

