### PR TITLE
fix(ledger): persist extra genesis staking

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -810,6 +810,9 @@ When `Node.Run()` is called, components are initialized in this order:
     across any Mithril "gap blocks" (see Mithril Bootstrap) before header
     verification computes an epoch nonce; only then does LedgerState subscribe
     to chainsync/blockfetch/chain-update EventBus events.
+    Fresh genesis initialization persists both genesis UTxOs and the effective
+    Shelley staking declarations, including network-specific `extraConfig`
+    pools and delegations, before snapshot capture.
 10. Snapshot manager creation, then `LedgerState.SetEpochBoundarySnapshotHook`
     wiring (authoritative epoch-boundary capture), then genesis snapshot capture
     (or reuse of an existing post-Mithril Mark snapshot window), then manager

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3431,15 +3431,33 @@ func GenesisBlockHash(cfg *cardano.CardanoNodeConfig) ([32]byte, error) {
 // sync.
 func genesisStakeDelegations(
 	poolDelegators map[string][]lcommon.Address,
-) map[string]string {
+) (map[string]string, error) {
 	ret := make(map[string]string)
-	for poolID, delegators := range poolDelegators {
+	poolIDs := make([]string, 0, len(poolDelegators))
+	for poolID := range poolDelegators {
+		poolIDs = append(poolIDs, poolID)
+	}
+	slices.Sort(poolIDs)
+	for _, poolID := range poolIDs {
+		delegators := poolDelegators[poolID]
 		for _, delegator := range delegators {
 			stakeKeyHash := (&delegator).StakeKeyHash()
-			ret[hex.EncodeToString(stakeKeyHash[:])] = poolID
+			stakeKeyHex := hex.EncodeToString(stakeKeyHash[:])
+			if existingPoolID, ok := ret[stakeKeyHex]; ok {
+				if existingPoolID == poolID {
+					continue
+				}
+				return nil, fmt.Errorf(
+					"stake key hash %s delegated to multiple genesis pools %s and %s",
+					stakeKeyHex,
+					existingPoolID,
+					poolID,
+				)
+			}
+			ret[stakeKeyHex] = poolID
 		}
 	}
-	return ret
+	return ret, nil
 }
 
 func (ls *LedgerState) createGenesisBlock() error {
@@ -3633,7 +3651,10 @@ func (ls *LedgerState) createGenesisBlock() error {
 		if err != nil {
 			return fmt.Errorf("parse genesis staking: %w", err)
 		}
-		genesisStake := genesisStakeDelegations(poolDelegators)
+		genesisStake, err := genesisStakeDelegations(poolDelegators)
+		if err != nil {
+			return fmt.Errorf("parse genesis stake delegations: %w", err)
+		}
 		if len(genesisPools) > 0 ||
 			len(genesisStake) > 0 {
 			ls.config.Logger.Info(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3424,6 +3424,24 @@ func GenesisBlockHash(cfg *cardano.CardanoNodeConfig) ([32]byte, error) {
 	return hash, nil
 }
 
+// genesisStakeDelegations converts the delegators returned by the Shelley
+// genesis parser into the metadata representation used by SetGenesisStaking.
+// InitialPools includes both the legacy staking fields and the Musashi
+// extraConfig fields, so using its result keeps those bootstrap formats in
+// sync.
+func genesisStakeDelegations(
+	poolDelegators map[string][]lcommon.Address,
+) map[string]string {
+	ret := make(map[string]string)
+	for poolID, delegators := range poolDelegators {
+		for _, delegator := range delegators {
+			stakeKeyHash := (&delegator).StakeKeyHash()
+			ret[hex.EncodeToString(stakeKeyHash[:])] = poolID
+		}
+	}
+	return ret
+}
+
 func (ls *LedgerState) createGenesisBlock() error {
 	// Get the Byron genesis hash to use as the synthetic block hash.
 	// This mirrors how the Shelley epoch nonce uses the Shelley genesis hash.
@@ -3611,23 +3629,24 @@ func (ls *LedgerState) createGenesisBlock() error {
 		)
 
 		// Load genesis staking data (pool registrations + delegations)
-		genesisPools, _, err := shelleyGenesis.InitialPools()
+		genesisPools, poolDelegators, err := shelleyGenesis.InitialPools()
 		if err != nil {
 			return fmt.Errorf("parse genesis staking: %w", err)
 		}
+		genesisStake := genesisStakeDelegations(poolDelegators)
 		if len(genesisPools) > 0 ||
-			len(shelleyGenesis.Staking.Stake) > 0 {
+			len(genesisStake) > 0 {
 			ls.config.Logger.Info(
 				fmt.Sprintf(
 					"loading genesis staking: %d pools, %d delegations",
 					len(genesisPools),
-					len(shelleyGenesis.Staking.Stake),
+					len(genesisStake),
 				),
 				"component", "ledger",
 			)
 			if err := ls.db.SetGenesisStaking(
 				genesisPools,
-				shelleyGenesis.Staking.Stake,
+				genesisStake,
 				genesisHash[:],
 				txn,
 			); err != nil {

--- a/ledger/genesis_network_state_test.go
+++ b/ledger/genesis_network_state_test.go
@@ -89,6 +89,16 @@ func TestCreateGenesisBlockPersistsMusashiExtraConfigStaking(t *testing.T) {
 	}
 	poolKeyHash, err := hex.DecodeString(poolID)
 	require.NoError(t, err)
+	delegators, ok := poolDelegators[poolID]
+	require.True(t, ok)
+	require.Len(t, delegators, 1)
+	delegatorHash := delegators[0].StakeKeyHash()
+	expectedStakeDelegations := map[string]string{
+		hex.EncodeToString(delegatorHash[:]): poolID,
+	}
+	actualStakeDelegations, err := genesisStakeDelegations(poolDelegators)
+	require.NoError(t, err)
+	require.Equal(t, expectedStakeDelegations, actualStakeDelegations)
 
 	ls := &LedgerState{
 		db: db,
@@ -108,6 +118,22 @@ func TestCreateGenesisBlockPersistsMusashiExtraConfigStaking(t *testing.T) {
 	_, delegatorCount, err := db.Metadata().GetStakeByPool(poolKeyHash, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), delegatorCount)
+}
+
+func TestGenesisStakeDelegationsRejectsConflictingPools(t *testing.T) {
+	delegator, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		make([]byte, lcommon.AddressHashSize),
+		make([]byte, lcommon.AddressHashSize),
+	)
+	require.NoError(t, err)
+
+	_, err = genesisStakeDelegations(map[string][]lcommon.Address{
+		"01": {delegator},
+		"02": {delegator},
+	})
+	require.ErrorContains(t, err, "delegated to multiple genesis pools")
 }
 
 func TestCreateGenesisBlockBackfillsMissingNetworkState(t *testing.T) {

--- a/ledger/genesis_network_state_test.go
+++ b/ledger/genesis_network_state_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"testing"
@@ -62,6 +63,51 @@ func TestCreateGenesisBlockInitializesMusashiNetworkState(t *testing.T) {
 		uint64(14_999_999_100_000_000),
 		uint64(state.Reserves),
 	)
+}
+
+func TestCreateGenesisBlockPersistsMusashiExtraConfigStaking(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	nodeCfg, err := cardano.LoadCardanoNodeConfigWithFallback(
+		"musashi/config.json",
+		"musashi",
+		cardano.EmbeddedConfigFS,
+	)
+	require.NoError(t, err)
+	genesisPools, poolDelegators, err := nodeCfg.ShelleyGenesis().InitialPools()
+	require.NoError(t, err)
+	require.Len(t, genesisPools, 1)
+	require.Len(t, poolDelegators, 1)
+
+	var poolID string
+	for id := range genesisPools {
+		poolID = id
+	}
+	poolKeyHash, err := hex.DecodeString(poolID)
+	require.NoError(t, err)
+
+	ls := &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			Database:          db,
+			CardanoNodeConfig: nodeCfg,
+			Logger: slog.New(
+				slog.NewTextHandler(io.Discard, nil),
+			),
+		},
+	}
+	require.NoError(t, ls.createGenesisBlock())
+
+	pool, err := db.GetPool(lcommon.PoolKeyHash(poolKeyHash), false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	_, delegatorCount, err := db.Metadata().GetStakeByPool(poolKeyHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), delegatorCount)
 }
 
 func TestCreateGenesisBlockBackfillsMissingNetworkState(t *testing.T) {


### PR DESCRIPTION
## Problem
Musashi respin staking is declared under Shelley genesis `extraConfig`, but genesis initialization discarded the parser's effective delegators and passed the empty legacy staking map. The node therefore created no genesis stake snapshot and failed at slot 0.

## Changes
- Persist delegations returned by `ShelleyGenesis.InitialPools`, including `extraConfig` data.
- Add Musashi regression coverage and document the startup flow.

Tests: `go test ./ledger -run ... -race`, `go test ./internal/node -run TestLoadWithDBCapturesGenesisMarkSnapshotForShelleyGenesisStaking -race`, `go vet ./ledger`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist genesis delegations from `ShelleyGenesis.InitialPools` (including Musashi `extraConfig`) and reject ambiguous delegations. Previously we only wrote the legacy `Staking.Stake` map, dropping `extraConfig` delegators and causing Musashi nodes to fail at slot 0; now we store both pools and delegations, and fail fast if a stake key maps to multiple pools.

- Convert parser-returned pool→delegators into a stake-key-hash→pool map and pass it to `SetGenesisStaking`, keeping legacy and `extraConfig` formats in sync.
- Reject ambiguous genesis staking with a clear error when one stake key delegates to multiple pools.
- Add tests for Musashi `extraConfig` persistence and for conflict rejection; update architecture docs to state staking persists before snapshot capture.
- Rollout: no schema changes. Restart is sufficient; nodes that attempted Musashi genesis with a previous build will backfill missing staking at startup.

<sup>Written for commit 30ad7493c1bb416d21febf315b0679dd9db073ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Genesis initialization now preserves effective staking declarations alongside genesis UTxOs.
  - Network-specific initial staking pools and delegations are included in the initialized ledger state.
  - Stake snapshots now capture configured genesis staking data accurately.

- **Bug Fixes**
  - Corrected genesis staking information so initial pools and their delegators are consistently recorded during network startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->