### PR TITLE
test: define Koios parity coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3578,6 +3578,37 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   count, delegator count), `reward_ada_pots` (treasury, reserves, fees,
   rewards — Dingo's full AdaPots).
 
+  **Coverage contract.** A `PASS` means only that every **exact-match** and
+  **derived-match** field below matched. It does not claim parity for fields
+  classified as **intentionally-incomparable** or **unsupported**. The same
+  field-level matrix is emitted in every JSON report, and human-readable
+  status output reports the class counts. `internal/koiosparity/coverage_test.go`
+  requires every field in the consumed Koios response structs to remain
+  classified when those structs change. Account rewards are outside this
+  matrix until #3097 and #3099 are implemented.
+
+  | Koios endpoint | Classification | Fields | Dingo mapping / reason |
+  |---|---|---|---|
+  | `/tip` | derived-match | `epoch_no` | `tip - 1` bounds the safely closed epoch range. |
+  | `/pool_list` | derived-match | `pool_id_bech32` | Decode to pool key hash and compare complete pool membership. |
+  | `/pool_updates` | derived-match | `pool_id_bech32`, `active_epoch_no` | Derive each pool's earliest possible history request. These control fetching, not value parity. |
+  | `/epoch_info` | exact-match | `epoch_no` | The filtered response must contain exactly the requested reporting epoch K. |
+  | `/epoch_info` | derived-match | `active_stake` | Exact lovelace match to `epoch_summary.total_active_stake` at K-1. |
+  | `/epoch_info` | derived-match | `end_time` | Establishes closure and the reference-lag window; not a Dingo value assertion. |
+  | `/epoch_info` | unsupported | `era`, `out_sum`, `fees`, `tx_count`, `blk_count`, `start_time`, `first_block_time`, `last_block_time`, `total_rewards`, `avg_blk_reward` | Dingo has no matching persisted per-epoch aggregate. In particular, raw `fees`/`total_rewards` are not AdaPots balances. |
+  | `/epoch_info` | unsupported | `pool_cnt`, `delegator_cnt` | Documented fields are not returned by Koios preview/preprod and are omitted from the response projection. |
+  | `/totals` | exact-match | `epoch_no`, `treasury`, `reserves`, `fees` | Require the requested epoch and exact equality with K's `reward_ada_pots` boundary balances. |
+  | `/totals` | intentionally-incomparable | `reward` | Koios reports a lagged cumulative accumulator; Dingo stores a per-epoch flow. |
+  | `/totals` | unsupported | `circulation`, `supply`, `deposits_stake`, `deposits_drep`, `deposits_proposal`, `treasury_donation`, `treasury_withdrawal`, `reserves_withdrawal` | No matching persisted Dingo network aggregate. |
+  | `/pool_history` | exact-match | `epoch_no` | The filtered response must contain exactly the requested reporting epoch K. |
+  | `/pool_history` | derived-match | `pool_id_bech32` | Request identity is decoded to Dingo's pool key hash for set membership. |
+  | `/pool_history` | derived-match | `active_stake`, `delegator_cnt` | Exact values against `reward_pool_input` at stake epoch K-1. |
+  | `/pool_history` | derived-match | `block_cnt`, `fixed_cost` | Exact values against `reward_pool_input` at parameter epoch K+1. |
+  | `/pool_history` | derived-match | `margin` | K+1 values compared as equivalent rational numbers. |
+  | `/pool_history` | derived-match | `member_rewards` | Exact lovelace equality with aggregated `reward_pool_output.member_reward_total` at K-1. |
+  | `/pool_history` | intentionally-incomparable | `pool_fees`, `deleg_rewards` | Koios derives these from an approximation that omits the pledge/owner-stake bonus and rounds components. |
+  | `/pool_history` | unsupported | `active_stake_pct`, `saturation_pct`, `epoch_ros` | Dingo has no matching persisted pool aggregate. |
+
   **Epoch alignment.** Koios reports everything for a reporting epoch K, but
   Dingo's `epoch_summary`/`reward_pool_input`/`reward_pool_output` rows do not
   all use K for the same ledger period, so `checkEpoch` (`check.go`) never

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -37,8 +37,8 @@ type KoiosEpochInfo struct {
 	// raw block/tx accounting quantities — stored for reference only. Dingo has
 	// no matching aggregate, so CompareEpochAggregates does not compare them;
 	// see that function's doc comment and KoiosTotalsResp for why /totals.fees
-	// and /totals.reward (compared in CompareEpochTotals) are the correct
-	// counterpart to reward_ada_pots.Fees/Rewards instead.
+	// is the correct counterpart to reward_ada_pots.Fees. /totals.reward has no
+	// matching Dingo aggregate and is intentionally not compared.
 	Fees         string
 	TotalRewards string
 	EpochEndTime time.Time // when the epoch actually closed (from Koios end_time); zero for old cache rows

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -55,9 +55,9 @@ type EpochCompareResult struct {
 // Only total_active_stake is compared here — koios.Fees and koios.TotalRewards
 // (/epoch_info.fees and /epoch_info.total_rewards) are raw block/tx accounting
 // quantities that have no corresponding Dingo aggregate; see the comment below
-// and KoiosTotalsResp's doc comment. The AdaPots pot values Dingo does track
-// (reward_ada_pots.Fees/Rewards) are compared against their correct Koios
-// counterpart, /totals, in CompareEpochTotals instead.
+// and KoiosTotalsResp's doc comment. Dingo's reward_ada_pots.Fees is compared
+// against its correct /totals.fees counterpart in CompareEpochTotals;
+// reward_ada_pots.Rewards has no matching Koios per-epoch field.
 // dingoEpoch may be nil when the epoch_summary row is absent (not yet computed).
 // fetchErr is set when the DB query itself failed.
 // graceHours: if the Koios row was fetched within this many hours and Dingo's
@@ -122,11 +122,10 @@ func CompareEpochAggregates(
 	// are deliberately NOT compared here. Both are raw block/tx accounting
 	// quantities (the sum of transaction fees for txs included in that epoch's
 	// blocks, and total rewards earned in the epoch) — Dingo has no matching
-	// aggregate; reward_ada_pots.Fees/Rewards are AdaPots *pot* values (balances
-	// at the epoch boundary), a different quantity entirely (see
-	// KoiosTotalsResp's doc comment). reward_ada_pots is compared against its
-	// correct Koios counterpart, /totals.fees and /totals.reward, in
-	// CompareEpochTotals instead.
+	// aggregate; reward_ada_pots.Fees/Rewards are different quantities (see
+	// KoiosTotalsResp's doc comment). reward_ada_pots.Fees is compared against
+	// /totals.fees in CompareEpochTotals; Rewards remains explicitly
+	// unsupported.
 
 	return out
 }

--- a/internal/koiosparity/coverage.go
+++ b/internal/koiosparity/coverage.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+// CoverageClass describes how one Koios field participates in epoch/pool
+// parity. A PASS applies only to exact-match and derived-match entries.
+type CoverageClass string
+
+const (
+	CoverageExactMatch                CoverageClass = "exact-match"
+	CoverageDerivedMatch              CoverageClass = "derived-match"
+	CoverageIntentionallyIncomparable CoverageClass = "intentionally-incomparable"
+	CoverageUnsupported               CoverageClass = "unsupported"
+)
+
+// KoiosFieldCoverage documents one field in the Koios endpoints used by the
+// epoch/pool checker. Account reward fields are deliberately out of scope
+// until #3097 and #3099 are implemented.
+type KoiosFieldCoverage struct {
+	Endpoint   string        `json:"endpoint"`
+	Field      string        `json:"field"`
+	Class      CoverageClass `json:"class"`
+	DingoField string        `json:"dingo_field,omitempty"`
+	Reason     string        `json:"reason"`
+}
+
+// KoiosCoverageMatrix returns the complete field contract for the Koios
+// endpoints consumed by epoch/pool parity. Return a copy so report callers
+// cannot mutate the package contract.
+func KoiosCoverageMatrix() []KoiosFieldCoverage {
+	return append([]KoiosFieldCoverage(nil), koiosCoverageMatrix...)
+}
+
+var koiosCoverageMatrix = []KoiosFieldCoverage{
+	// /tip and pool discovery control the reference range and pool universe.
+	{Endpoint: "/tip", Field: "epoch_no", Class: CoverageDerivedMatch, DingoField: "closed epoch range", Reason: "tip minus one selects safely closed epochs"},
+	{Endpoint: "/pool_list", Field: "pool_id_bech32", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.pool_key_hash", Reason: "bech32 IDs are decoded and compared as complete set membership"},
+	{Endpoint: "/pool_updates", Field: "pool_id_bech32", Class: CoverageDerivedMatch, DingoField: "pool history request universe", Reason: "identifies the pool whose first active epoch bounds history requests"},
+	{Endpoint: "/pool_updates", Field: "active_epoch_no", Class: CoverageDerivedMatch, DingoField: "pool history request lower bound", Reason: "minimum update epoch avoids requests before a pool existed"},
+
+	// /epoch_info.
+	{Endpoint: "/epoch_info", Field: "epoch_no", Class: CoverageExactMatch, DingoField: "reporting epoch", Reason: "response identity must equal the requested Koios epoch K"},
+	{Endpoint: "/epoch_info", Field: "era", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-epoch era aggregate"},
+	{Endpoint: "/epoch_info", Field: "out_sum", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-epoch transaction output sum"},
+	{Endpoint: "/epoch_info", Field: "fees", Class: CoverageUnsupported, Reason: "raw transaction fees differ from Dingo's boundary fee-pot balance"},
+	{Endpoint: "/epoch_info", Field: "tx_count", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-epoch transaction count aggregate"},
+	{Endpoint: "/epoch_info", Field: "blk_count", Class: CoverageUnsupported, Reason: "Dingo has no persisted network-wide per-epoch block count aggregate"},
+	{Endpoint: "/epoch_info", Field: "start_time", Class: CoverageUnsupported, Reason: "Dingo has no persisted epoch wall-clock range aggregate"},
+	{Endpoint: "/epoch_info", Field: "end_time", Class: CoverageDerivedMatch, DingoField: "closed/reference-lag state", Reason: "establishes closure and the configured grace window; it is not a value-parity assertion"},
+	{Endpoint: "/epoch_info", Field: "first_block_time", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-epoch first-block time aggregate"},
+	{Endpoint: "/epoch_info", Field: "last_block_time", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-epoch last-block time aggregate"},
+	{Endpoint: "/epoch_info", Field: "active_stake", Class: CoverageDerivedMatch, DingoField: "epoch_summary.total_active_stake at K-1", Reason: "exact lovelace equality after the established stake-epoch alignment"},
+	{Endpoint: "/epoch_info", Field: "total_rewards", Class: CoverageUnsupported, Reason: "Dingo has no matching raw per-performance-epoch reward aggregate"},
+	{Endpoint: "/epoch_info", Field: "avg_blk_reward", Class: CoverageUnsupported, Reason: "Dingo has no persisted average block reward aggregate"},
+	{Endpoint: "/epoch_info", Field: "pool_cnt", Class: CoverageUnsupported, Reason: "Koios preview/preprod do not return this documented field"},
+	{Endpoint: "/epoch_info", Field: "delegator_cnt", Class: CoverageUnsupported, Reason: "Koios preview/preprod do not return this documented field"},
+
+	// /totals.
+	{Endpoint: "/totals", Field: "epoch_no", Class: CoverageExactMatch, DingoField: "reporting epoch", Reason: "response identity must equal the requested epoch"},
+	{Endpoint: "/totals", Field: "circulation", Class: CoverageUnsupported, Reason: "requires a network-wide live UTxO-set aggregate"},
+	{Endpoint: "/totals", Field: "treasury", Class: CoverageExactMatch, DingoField: "reward_ada_pots.treasury", Reason: "point-in-time boundary pot balance"},
+	{Endpoint: "/totals", Field: "reward", Class: CoverageIntentionallyIncomparable, Reason: "Koios exposes a lagged cumulative accumulator; Dingo stores a per-epoch reward flow"},
+	{Endpoint: "/totals", Field: "supply", Class: CoverageUnsupported, Reason: "requires a network-wide live UTxO-set aggregate"},
+	{Endpoint: "/totals", Field: "reserves", Class: CoverageExactMatch, DingoField: "reward_ada_pots.reserves", Reason: "point-in-time boundary pot balance"},
+	{Endpoint: "/totals", Field: "fees", Class: CoverageExactMatch, DingoField: "reward_ada_pots.fees", Reason: "point-in-time boundary fee-pot balance"},
+	{Endpoint: "/totals", Field: "deposits_stake", Class: CoverageUnsupported, Reason: "Dingo has no persisted stake-deposit pot aggregate"},
+	{Endpoint: "/totals", Field: "deposits_drep", Class: CoverageUnsupported, Reason: "Dingo has no persisted DRep-deposit pot aggregate"},
+	{Endpoint: "/totals", Field: "deposits_proposal", Class: CoverageUnsupported, Reason: "Dingo has no persisted proposal-deposit pot aggregate"},
+	{Endpoint: "/totals", Field: "treasury_donation", Class: CoverageUnsupported, Reason: "Dingo has no matching persisted cumulative governance aggregate"},
+	{Endpoint: "/totals", Field: "treasury_withdrawal", Class: CoverageUnsupported, Reason: "Dingo has no matching persisted cumulative governance aggregate"},
+	{Endpoint: "/totals", Field: "reserves_withdrawal", Class: CoverageUnsupported, Reason: "Dingo has no matching persisted cumulative reserve-withdrawal aggregate"},
+
+	// /pool_history. pool_id_bech32 is supplied as a request parameter and
+	// excluded from the projection, but remains part of the parity identity.
+	{Endpoint: "/pool_history", Field: "pool_id_bech32", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.pool_key_hash", Reason: "requested bech32 ID is decoded to Dingo's pool key hash"},
+	{Endpoint: "/pool_history", Field: "epoch_no", Class: CoverageExactMatch, DingoField: "reporting epoch", Reason: "response identity must equal the requested Koios epoch K"},
+	{Endpoint: "/pool_history", Field: "active_stake", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.delegated_stake at K-1", Reason: "exact lovelace equality after stake-epoch alignment"},
+	{Endpoint: "/pool_history", Field: "active_stake_pct", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-pool active-stake percentage"},
+	{Endpoint: "/pool_history", Field: "saturation_pct", Class: CoverageUnsupported, Reason: "Dingo has no persisted per-pool saturation percentage"},
+	{Endpoint: "/pool_history", Field: "block_cnt", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.blocks_produced at K+1", Reason: "exact integer equality after parameter-epoch alignment"},
+	{Endpoint: "/pool_history", Field: "delegator_cnt", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.delegator_count at K-1", Reason: "exact integer equality after stake-epoch alignment"},
+	{Endpoint: "/pool_history", Field: "margin", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.margin at K+1", Reason: "compared as equivalent rational numbers"},
+	{Endpoint: "/pool_history", Field: "fixed_cost", Class: CoverageDerivedMatch, DingoField: "reward_pool_input.cost at K+1", Reason: "exact lovelace equality after parameter-epoch alignment"},
+	{Endpoint: "/pool_history", Field: "pool_fees", Class: CoverageIntentionallyIncomparable, Reason: "Koios approximation omits the pledge/owner-stake bonus"},
+	{Endpoint: "/pool_history", Field: "deleg_rewards", Class: CoverageIntentionallyIncomparable, Reason: "derived from Koios's approximate pool fee and rounded components"},
+	{Endpoint: "/pool_history", Field: "member_rewards", Class: CoverageDerivedMatch, DingoField: "reward_pool_output.member_reward_total at K-1", Reason: "exact lovelace equality against Dingo's per-member aggregate"},
+	{Endpoint: "/pool_history", Field: "epoch_ros", Class: CoverageUnsupported, Reason: "Dingo has no persisted annualised return-on-stake aggregate"},
+}

--- a/internal/koiosparity/coverage_test.go
+++ b/internal/koiosparity/coverage_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestKoiosCoverageMatrixIsComplete makes a Koios response-shape change fail
+// until the new field is assigned an explicit coverage class. This prevents a
+// report from continuing to say PASS while silently omitting a new field.
+func TestKoiosCoverageMatrixIsComplete(t *testing.T) {
+	matrix := KoiosCoverageMatrix()
+	byKey := make(map[string]KoiosFieldCoverage, len(matrix))
+	validClasses := map[CoverageClass]bool{
+		CoverageExactMatch:                true,
+		CoverageDerivedMatch:              true,
+		CoverageIntentionallyIncomparable: true,
+		CoverageUnsupported:               true,
+	}
+	for _, field := range matrix {
+		key := field.Endpoint + "." + field.Field
+		require.NotEmpty(t, field.Endpoint)
+		require.NotEmpty(t, field.Field)
+		require.True(t, validClasses[field.Class], "invalid coverage class for %s", key)
+		require.NotEmpty(t, field.Reason, "coverage reason is required for %s", key)
+		_, duplicate := byKey[key]
+		require.False(t, duplicate, "duplicate coverage entry for %s", key)
+		byKey[key] = field
+	}
+
+	requireResponseFieldsCovered(t, byKey, "/tip", KoiosTipResp{})
+	requireResponseFieldsCovered(t, byKey, "/epoch_info", KoiosEpochInfoResp{})
+	requireResponseFieldsCovered(t, byKey, "/totals", KoiosTotalsResp{})
+	requireResponseFieldsCovered(t, byKey, "/pool_history", KoiosPoolHistoryItem{})
+
+	// Fields selected by the pool-discovery helpers use function-local response
+	// structs, and documented fields omitted from preview/preprod responses are
+	// pinned explicitly here.
+	for _, key := range []string{
+		"/pool_list.pool_id_bech32",
+		"/pool_updates.pool_id_bech32",
+		"/pool_updates.active_epoch_no",
+		"/pool_history.pool_id_bech32",
+		"/epoch_info.pool_cnt",
+		"/epoch_info.delegator_cnt",
+	} {
+		require.Contains(t, byKey, key)
+	}
+}
+
+func requireResponseFieldsCovered(
+	t *testing.T,
+	coverage map[string]KoiosFieldCoverage,
+	endpoint string,
+	response any,
+) {
+	t.Helper()
+	typ := reflect.TypeOf(response)
+	for field := range typ.Fields() {
+		jsonName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		require.Contains(t, coverage, endpoint+"."+jsonName)
+	}
+}
+
+func TestKoiosCoverageMatrixReturnsCopy(t *testing.T) {
+	first := KoiosCoverageMatrix()
+	require.NotEmpty(t, first)
+	first[0].Field = "mutated"
+	require.NotEqual(t, "mutated", KoiosCoverageMatrix()[0].Field)
+}

--- a/internal/koiosparity/fetch_test.go
+++ b/internal/koiosparity/fetch_test.go
@@ -41,12 +41,12 @@ func withTestKoiosBaseURL(t *testing.T, url string) {
 	t.Cleanup(func() { koiosBaseURLs["preview"] = orig })
 }
 
-const validEpochInfoTmpl = `[{"epoch_no":%d,"era":"conway","out_sum":"100","fees":"10",` +
+const validEpochInfoTmpl = `[{"epoch_no":%s,"era":"conway","out_sum":"100","fees":"10",` +
 	`"tx_count":1,"blk_count":1,"start_time":1000,"end_time":2000,` +
 	`"first_block_time":1000,"last_block_time":1999,"active_stake":"12345",` +
 	`"total_rewards":"100","avg_blk_reward":"1"}]`
 
-const validTotalsTmpl = `[{"epoch_no":%d,"treasury":"1","reserves":"1","fees":"1","reward":"1"}]`
+const validTotalsTmpl = `[{"epoch_no":%s,"treasury":"1","reserves":"1","fees":"1","reward":"1"}]`
 
 // TestFetchAbortsOnPermanentEpochInfoError guards against the bug where every
 // Koios client error was wrapped as transient regardless of cause: a
@@ -73,10 +73,10 @@ func TestFetchAbortsOnPermanentEpochInfoError(t *testing.T) {
 					return
 				}
 				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(w, validEpochInfoTmpl, 0)
+				_, _ = fmt.Fprintf(w, validEpochInfoTmpl, epoch)
 			case r.URL.Path == "/totals":
 				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(w, validTotalsTmpl, 0)
+				_, _ = fmt.Fprintf(w, validTotalsTmpl, r.URL.Query().Get("_epoch_no"))
 			default:
 				t.Errorf("unexpected request path %s", r.URL.Path)
 				w.WriteHeader(http.StatusNotFound)
@@ -136,10 +136,10 @@ func TestFetchTransient503LandsInFailedEpochs(t *testing.T) {
 					return
 				}
 				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(w, validEpochInfoTmpl, 0)
+				_, _ = fmt.Fprintf(w, validEpochInfoTmpl, epoch)
 			case r.URL.Path == "/totals":
 				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(w, validTotalsTmpl, 0)
+				_, _ = fmt.Fprintf(w, validTotalsTmpl, r.URL.Query().Get("_epoch_no"))
 			default:
 				t.Errorf("unexpected request path %s", r.URL.Path)
 				w.WriteHeader(http.StatusNotFound)
@@ -198,10 +198,10 @@ func TestFetchEpochStopsSchedulingPoolsAfterPermanentError(t *testing.T) {
 				_, _ = w.Write([]byte(`[]`))
 			case r.URL.Path == "/epoch_info":
 				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(w, validEpochInfoTmpl, 0)
+				_, _ = fmt.Fprintf(w, validEpochInfoTmpl, r.URL.Query().Get("_epoch_no"))
 			case r.URL.Path == "/totals":
 				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(w, validTotalsTmpl, 0)
+				_, _ = fmt.Fprintf(w, validTotalsTmpl, r.URL.Query().Get("_epoch_no"))
 			case r.URL.Path == "/pool_history":
 				poolHistoryAttempts.Add(1)
 				if r.URL.Query().Get("_pool_bech32") == "pool0" {

--- a/internal/koiosparity/koios_client.go
+++ b/internal/koiosparity/koios_client.go
@@ -131,9 +131,10 @@ type KoiosTipResp struct {
 //     actually stores. Verified empirically against a live preview node: for
 //     the same epoch, totals.fees matched Dingo's reward_ada_pots.Fees
 //     exactly while epoch_info.fees did not.
-//   - Similarly, totals.reward ("rewards accumulated as of given epoch", the
-//     AdaPots reward-pot value) is compared against reward_ada_pots.Rewards
-//     independently of epoch_info.total_rewards — see CompareEpochTotals.
+//   - totals.reward ("rewards accumulated as of given epoch") is a lagged
+//     cumulative accumulator, while reward_ada_pots.Rewards is a per-epoch
+//     flow. It is cached but intentionally not compared; see
+//     CompareEpochTotals.
 type KoiosTotalsResp struct {
 	EpochNo uint64 `json:"epoch_no"`
 	// Circulation, Supply, DepositsStake, DepositsDRep, DepositsProposal,
@@ -487,6 +488,14 @@ func (k *KoiosClient) GetEpochInfo(
 	if len(items) == 0 {
 		return nil, fmt.Errorf("koios /epoch_info: no data for epoch %d", epoch)
 	}
+	if len(items) != 1 || items[0].EpochNo != epoch {
+		return nil, fmt.Errorf(
+			"koios /epoch_info: requested epoch %d, got %d row(s) beginning with epoch %d",
+			epoch,
+			len(items),
+			items[0].EpochNo,
+		)
+	}
 	return &items[0], nil
 }
 
@@ -514,6 +523,14 @@ func (k *KoiosClient) GetTotals(
 	}
 	if len(items) == 0 {
 		return nil, fmt.Errorf("koios /totals: no data for epoch %d", epoch)
+	}
+	if len(items) != 1 || items[0].EpochNo != epoch {
+		return nil, fmt.Errorf(
+			"koios /totals: requested epoch %d, got %d row(s) beginning with epoch %d",
+			epoch,
+			len(items),
+			items[0].EpochNo,
+		)
 	}
 	return &items[0], nil
 }
@@ -671,6 +688,15 @@ func (k *KoiosClient) GetPoolEpochHistory(
 	}
 	if len(items) == 0 {
 		return nil, nil
+	}
+	if len(items) != 1 || items[0].EpochNo != epoch {
+		return nil, fmt.Errorf(
+			"koios /pool_history: pool %s requested epoch %d, got %d row(s) beginning with epoch %d",
+			poolBech32,
+			epoch,
+			len(items),
+			items[0].EpochNo,
+		)
 	}
 	return &items[0], nil
 }

--- a/internal/koiosparity/koios_client_test.go
+++ b/internal/koiosparity/koios_client_test.go
@@ -245,6 +245,64 @@ func TestGetPoolFirstActiveEpochsTakesMinAcrossUpdates(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestFilteredKoiosResponsesRequireRequestedEpoch(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		call func(*KoiosClient) error
+	}{
+		{
+			name: "epoch_info",
+			path: "/epoch_info",
+			call: func(k *KoiosClient) error {
+				_, err := k.GetEpochInfo(context.Background(), 10)
+				return err
+			},
+		},
+		{
+			name: "totals",
+			path: "/totals",
+			call: func(k *KoiosClient) error {
+				_, err := k.GetTotals(context.Background(), 10)
+				return err
+			},
+		},
+		{
+			name: "pool_history",
+			path: "/pool_history",
+			call: func(k *KoiosClient) error {
+				_, err := k.GetPoolEpochHistory(context.Background(), "pool1test", 10)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, test.path, r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[{"epoch_no":11}]`))
+			}))
+			defer srv.Close()
+
+			err := test.call(newTestKoiosClient(srv.URL))
+			require.ErrorContains(t, err, "requested epoch 10")
+		})
+	}
+}
+
+func TestFilteredKoiosResponsesRejectMultipleRows(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"epoch_no":10},{"epoch_no":10}]`))
+	}))
+	defer srv.Close()
+
+	_, err := newTestKoiosClient(srv.URL).GetEpochInfo(context.Background(), 10)
+	require.ErrorContains(t, err, "got 2 row(s)")
+}
+
 func TestRationalsEqual(t *testing.T) {
 	require.True(t, rationalsEqual("0.1", "1/10"))
 	require.True(t, rationalsEqual("1/20", "0.05"))

--- a/internal/koiosparity/koios_client_test.go
+++ b/internal/koiosparity/koios_client_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -280,7 +281,7 @@ func TestFilteredKoiosResponsesRequireRequestedEpoch(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, test.path, r.URL.Path)
+				assert.Equal(t, test.path, r.URL.Path)
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`[{"epoch_no":11}]`))
 			}))

--- a/internal/koiosparity/report.go
+++ b/internal/koiosparity/report.go
@@ -109,6 +109,15 @@ func PrintStatus(
 	statuses []CheckEpochStatus,
 ) {
 	fmt.Fprintf(w, "%s parity status\n", s.Network)
+	exact, derived, incomparable, unsupported := coverageCounts()
+	fmt.Fprintf(
+		w,
+		"  scope:    epoch/pool fields (exact %d / derived %d / intentionally incomparable %d / unsupported %d)\n",
+		exact,
+		derived,
+		incomparable,
+		unsupported,
+	)
 	if s.TotalFetched > 0 {
 		fmt.Fprintf(w, "  cache:    epochs %d–%d fetched (%d total)\n",
 			s.MinFetched, s.MaxFetched, s.TotalFetched)
@@ -166,11 +175,12 @@ func PrintStatus(
 
 // JSONReport is the machine-readable report format written by `run`.
 type JSONReport struct {
-	Network     string            `json:"network"`
-	GeneratedAt string            `json:"generated_at"`
-	Summary     JSONReportSummary `json:"summary"`
-	FailEpochs  []JSONEpochEntry  `json:"fail_epochs,omitempty"`
-	ErrorEpochs []JSONEpochEntry  `json:"error_epochs,omitempty"`
+	Network     string               `json:"network"`
+	GeneratedAt string               `json:"generated_at"`
+	Coverage    []KoiosFieldCoverage `json:"coverage"`
+	Summary     JSONReportSummary    `json:"summary"`
+	FailEpochs  []JSONEpochEntry     `json:"fail_epochs,omitempty"`
+	ErrorEpochs []JSONEpochEntry     `json:"error_epochs,omitempty"`
 }
 
 // JSONReportSummary holds aggregate counts.
@@ -210,6 +220,7 @@ func BuildJSONReport(
 	report := &JSONReport{
 		Network:     network,
 		GeneratedAt: generatedAt,
+		Coverage:    KoiosCoverageMatrix(),
 		Summary: JSONReportSummary{
 			TotalFetched: len(fetchedEpochs),
 		},
@@ -263,6 +274,22 @@ func BuildJSONReport(
 	}
 
 	return report, nil
+}
+
+func coverageCounts() (exact, derived, incomparable, unsupported int) {
+	for _, field := range koiosCoverageMatrix {
+		switch field.Class {
+		case CoverageExactMatch:
+			exact++
+		case CoverageDerivedMatch:
+			derived++
+		case CoverageIntentionallyIncomparable:
+			incomparable++
+		case CoverageUnsupported:
+			unsupported++
+		}
+	}
+	return
 }
 
 // WriteJSONReport serialises the report and writes it to w.

--- a/internal/koiosparity/report_test.go
+++ b/internal/koiosparity/report_test.go
@@ -15,6 +15,8 @@
 package koiosparity
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,4 +36,26 @@ func TestBuildStatusSummaryChecksEpochZero(t *testing.T) {
 	require.Equal(t, uint64(0), summary.CheckedMin,
 		"epoch 0 is a real checked epoch and must remain the reported minimum")
 	require.Equal(t, uint64(2), summary.CheckedMax)
+}
+
+func TestReportsMakeCoverageScopeExplicit(t *testing.T) {
+	report, err := BuildJSONReport("preview", "2026-08-17", nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, KoiosCoverageMatrix(), report.Coverage)
+	require.Contains(t, report.Coverage, KoiosFieldCoverage{
+		Endpoint: "/totals",
+		Field:    "reward",
+		Class:    CoverageIntentionallyIncomparable,
+		Reason:   "Koios exposes a lagged cumulative accumulator; Dingo stores a per-epoch reward flow",
+	})
+
+	var output bytes.Buffer
+	PrintStatus(&output, StatusSummary{Network: "preview"}, false, nil)
+	require.Contains(t, output.String(), "intentionally incomparable")
+	require.Contains(t, output.String(), "unsupported")
+
+	output.Reset()
+	require.NoError(t, WriteJSONReport(&output, report))
+	require.True(t, strings.Contains(output.String(), `"coverage"`))
+	require.True(t, strings.Contains(output.String(), `"intentionally-incomparable"`))
 }


### PR DESCRIPTION
## Summary

- define the epoch/pool Koios field coverage matrix
- include coverage classifications in reports and status output
- reject mismatched response epochs and document intentional omissions
- leave per-account parity for #3097 and #3099

Relates to #1903.

## Tests

- go test ./internal/koiosparity
- go test -race ./internal/koiosparity
- go vet ./internal/koiosparity

make docs-parity could not run because the environment Go build cache is read-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines an explicit Koios epoch/pool coverage contract and tightens filtered Koios response validation. PASS now only asserts exact-match and derived-match fields; `reward_ada_pots.Rewards` parity is removed where no true Koios counterpart exists.

Adds a matrix-backed contract and emits it in JSON reports; status output shows coverage class counts. `coverage_test.go` forces every consumed Koios field to be classified. `GetEpochInfo`, `GetTotals`, and `GetPoolEpochHistory` now require exactly one row for the requested epoch. Compares fees against `/totals.fees` only and classifies `/totals.reward` as intentionally incomparable. Tests also assert expected Koios handler paths to catch misrouted requests.

- Migration notes
  - If you strictly parse the JSON report, allow the new `coverage` field.
  - Update tests or mocks for filtered requests to return exactly one row with the requested `epoch_no`.
  - Remove any dashboards or assumptions that compared rewards; only fees are compared.

<sup>Written for commit c6eba431d4948af4cd2fc6814c02db2801f1e6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

