### PR TITLE
chore: update Musashi cardano configs image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /antithesis/customer
 RUN make build
 
 FROM ghcr.io/blinklabs-io/cardano-cli:11.0.0.0-1 AS cardano-cli
-FROM ghcr.io/blinklabs-io/cardano-configs:20260707-2 AS cardano-configs
+FROM ghcr.io/blinklabs-io/cardano-configs:20260817-1 AS cardano-configs
 FROM ghcr.io/blinklabs-io/nview:0.15.0 AS nview
 FROM ghcr.io/blinklabs-io/txtop:0.15.0 AS txtop
 


### PR DESCRIPTION
## Summary

- update the Dockerfile cardano-configs image to v20260817-1 for Musashi

## Validation

- git show --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Dockerfile to use `ghcr.io/blinklabs-io/cardano-configs:20260817-1` for Musashi instead of `20260707-2`, ensuring the build uses current Cardano network parameters. No other base images or build steps change.

**Review notes**
- Verify the new `cardano-configs` tag pulls and the Docker build completes; expect only configuration updates at runtime.
- No migration actions required; rebuild and deploy the Musashi image.

<sup>Written for commit d5c2b6a381ff3631ae2a4dd643ba111193388f72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

