### PR TITLE
fix(ledger): prevent blockfetch shutdown stalls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -866,7 +866,8 @@ Phase 1: Stop accepting new work
   Blockfrost API, Mesh API, off-chain metadata fetcher
 
 Phase 2: Drain and close connections
-  Mempool, terminal EventBus close, ConnectionManager
+  Mempool, terminal EventBus close (concurrent with ConnectionManager),
+  ConnectionManager
 
 Phase 3: Flush state and close database
   LedgerState, Database
@@ -875,12 +876,15 @@ Phase 4: Cleanup resources
   Registered shutdown functions
 ```
 
-The terminal EventBus close occurs after mempool teardown but before
-`ConnectionManager.Stop`. Lossless event delivery can backpressure a network
-protocol callback on a full ledger subscriber; closing the bus at this point
-releases those publishers before connection shutdown waits for their callback
-goroutines. The node context is already cancelled, and later component
-teardown treats the already-closed bus as idempotent.
+The terminal EventBus close occurs after mempool teardown and runs concurrently
+with `ConnectionManager.Stop`. Lossless event delivery can backpressure a
+network protocol callback on a full ledger subscriber, while a blockfetch
+continuation can wait for a batch completion event that connection shutdown
+releases; starting both operations together breaks that dependency cycle. The
+node context is already cancelled, and later component teardown treats the
+already-closed bus as idempotent. `EventBus.Close` discards queued in-memory
+events after waiting for in-flight handlers; ordinary `Unsubscribe` and
+reusable `EventBus.Stop` preserve queued events.
 
 ## Event-Driven Communication
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -986,6 +986,15 @@ All event types follow the `subsystem.snake_case_name` convention.
   `TestChainsyncResyncPublishPathsUnderLock` in
   `ledger/publish_under_lock_test.go`. Register the flush with `defer`
   *before* taking the lock so LIFO order runs it last.
+- `ledger` also must not invoke an external `BlockfetchRequestRangeFunc` while
+  holding `chainsyncBlockfetchMutex`. The blockfetch client can wait in
+  `acquireBusy` for the previous request's receive callback to return, while
+  that callback is publishing `ledger.blockfetch` and its subscriber is
+  waiting for the ledger mutex. `startQueuedBlockfetchLocked` reserves the
+  batch and arms its timer under the mutex, releases the mutex for the primary
+  and shadow requests, then reacquires it before inspecting state. If a
+  callback completed or replaced the batch while the request was outside the
+  lock, the stale request result is ignored.
 - The blast radius of such a stall is not local. `LedgerState.handleConnectionClosedEvent`
   takes `chainsyncMutex`, so a stall there stops `ledger.conn_closed` draining;
   the `node.go` handler translating `connmanager.conn_closed` into

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4443,6 +4443,11 @@ The `EventBus` implements publisher/subscriber communication, decoupling compone
 
 Database operations and event delivery use worker pools for controlled concurrency and backpressure.
 
+During shutdown, EventBus closes release backpressured publishers and discard
+events still queued in in-memory subscribers. It still waits for a handler
+that is already executing, but does not replay bulk-sync blockfetch backlog
+into ledger or storage components that are being closed.
+
 The ledger blockfetch subscriber must not synchronously start the next
 `GetBlockRange` from its `ledger.blockfetch` handler: the request completes
 only after the peer's `BatchDone` is delivered through that same EventBus

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4443,6 +4443,13 @@ The `EventBus` implements publisher/subscriber communication, decoupling compone
 
 Database operations and event delivery use worker pools for controlled concurrency and backpressure.
 
+The ledger blockfetch subscriber must not synchronously start the next
+`GetBlockRange` from its `ledger.blockfetch` handler: the request completes
+only after the peer's `BatchDone` is delivered through that same EventBus
+subscription. Batch continuation requests therefore run on tracked workers;
+the blockfetch state mutex protects the handoff and shutdown drains those
+workers before unsubscribing the ledger.
+
 ## Threading and Concurrency
 
 | Pattern | Usage |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4448,7 +4448,11 @@ The ledger blockfetch subscriber must not synchronously start the next
 only after the peer's `BatchDone` is delivered through that same EventBus
 subscription. Batch continuation requests therefore run on tracked workers;
 the blockfetch state mutex protects the handoff and shutdown drains those
-workers before unsubscribing the ledger.
+workers before unsubscribing the ledger. A connection must not be reused for a
+new batch while an older request on that connection is still draining, because
+blockfetch callbacks carry only the connection ID; reuse waits for the older
+request to return and fails boundedly if it remains wedged. Close also bounds
+the continuation drain without holding the scheduling mutex while waiting.
 
 ## Threading and Concurrency
 

--- a/event/event.go
+++ b/event/event.go
@@ -208,10 +208,10 @@ type Subscriber interface {
 // channelSubscriber is the in-memory subscriber adapter that preserves the
 // existing channel-based API. Delivery waits for buffer capacity rather than
 // dropping: a subscriber that falls behind backpressures its publishers
-// instead of silently losing events (blinklabs-io/dingo#2932). Close discards
-// events still queued during shutdown, then closes the channel so
+// instead of silently losing events (blinklabs-io/dingo#2932). Terminal event
+// bus shutdown may discard queued events before closing the channel so
 // SubscribeFunc goroutines exit without replaying a potentially large backlog
-// into components that are closing.
+// into components that are closing; ordinary unsubscribe preserves them.
 type channelSubscriber struct {
 	ch     chan Event
 	logger *slog.Logger
@@ -389,6 +389,10 @@ func (c *channelSubscriber) DeliverBlocking(evt Event) error {
 }
 
 func (c *channelSubscriber) Close() {
+	c.close(false)
+}
+
+func (c *channelSubscriber) close(discardQueued bool) {
 	// Release waiting sends before asking for the write lock; they hold the
 	// read lock, so the write lock would otherwise wait on a wait that only
 	// Close can end.
@@ -401,18 +405,17 @@ func (c *channelSubscriber) Close() {
 		return
 	}
 	c.closed = true
-	// Once shutdown begins, queued events have no useful consumer: replaying
-	// them can keep EventBus.Close waiting behind a bulk-sync backlog while
-	// the component that owns the handler is already being torn down. Normal
-	// delivery remains lossless; this discard is limited to Close/Stop.
-	for {
-		select {
-		case <-c.ch:
-		default:
-			close(c.ch)
-			return
+	if discardQueued {
+		for {
+			select {
+			case <-c.ch:
+			default:
+				close(c.ch)
+				return
+			}
 		}
 	}
+	close(c.ch)
 }
 
 // subscribeInternal does the actual subscription work without checking stopped.
@@ -691,7 +694,7 @@ func (e *EventBus) unsubscribe(
 	if chSub != nil {
 		// Close is idempotent, so this is safe even if a concurrent
 		// caller already closed the same subscriber via subToClose above.
-		chSub.Close()
+		chSub.close(false)
 		if wait {
 			chSub.waitDone()
 		}
@@ -1040,9 +1043,14 @@ func (e *EventBus) shutdown(restart bool) {
 	e.mu.Unlock()
 
 	// Close subscribers outside of lock
+	discardQueued := !restart
 	for _, evtTypeSubs := range subsCopy {
 		for _, sub := range evtTypeSubs {
-			sub.Close()
+			if chSub, ok := sub.(*channelSubscriber); ok {
+				chSub.close(discardQueued)
+			} else {
+				sub.Close()
+			}
 		}
 	}
 

--- a/event/event.go
+++ b/event/event.go
@@ -208,8 +208,10 @@ type Subscriber interface {
 // channelSubscriber is the in-memory subscriber adapter that preserves the
 // existing channel-based API. Delivery waits for buffer capacity rather than
 // dropping: a subscriber that falls behind backpressures its publishers
-// instead of silently losing events (blinklabs-io/dingo#2932). Close closes
-// the channel so SubscribeFunc goroutines exit.
+// instead of silently losing events (blinklabs-io/dingo#2932). Close discards
+// events still queued during shutdown, then closes the channel so
+// SubscribeFunc goroutines exit without replaying a potentially large backlog
+// into components that are closing.
 type channelSubscriber struct {
 	ch     chan Event
 	logger *slog.Logger
@@ -399,7 +401,18 @@ func (c *channelSubscriber) Close() {
 		return
 	}
 	c.closed = true
-	close(c.ch)
+	// Once shutdown begins, queued events have no useful consumer: replaying
+	// them can keep EventBus.Close waiting behind a bulk-sync backlog while
+	// the component that owns the handler is already being torn down. Normal
+	// delivery remains lossless; this discard is limited to Close/Stop.
+	for {
+		select {
+		case <-c.ch:
+		default:
+			close(c.ch)
+			return
+		}
+	}
 }
 
 // subscribeInternal does the actual subscription work without checking stopped.

--- a/event/event.go
+++ b/event/event.go
@@ -129,10 +129,14 @@ type EventBus struct {
 	asyncWg    sync.WaitGroup
 	stopCh     chan struct{}
 	closed     bool
-	stopped    bool
-	stopSeq    uint64
-	stopMu     sync.RWMutex
-	stopOpMu   sync.Mutex // Serializes Stop() calls to prevent duplicate worker pools
+	// terminalClosing is set before Close begins quiescing the bus. Callback
+	// dispatchers use it to discard events already buffered in their channels;
+	// Stop remains reusable and does not discard buffered callback events.
+	terminalClosing atomic.Bool
+	stopped         bool
+	stopSeq         uint64
+	stopMu          sync.RWMutex
+	stopOpMu        sync.Mutex // Serializes Stop() calls to prevent duplicate worker pools
 }
 
 // NewEventBus creates a new EventBus with async worker pool
@@ -566,6 +570,9 @@ func (e *EventBus) SubscribeFuncWithBuffer(
 		for {
 			evt, ok := <-evtCh
 			if !ok {
+				return
+			}
+			if e.terminalClosing.Load() {
 				return
 			}
 			e.safeHandlerCall(handlerFunc, evt)
@@ -1004,6 +1011,9 @@ func (e *EventBus) shutdown(restart bool) {
 	// duplicate worker pools when called concurrently
 	e.stopOpMu.Lock()
 	defer e.stopOpMu.Unlock()
+	if !restart {
+		e.terminalClosing.Store(true)
+	}
 
 	// Signal quiesce before taking stopMu for write. Publishers park on a
 	// full subscriber buffer or a full async queue while holding stopMu for

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -293,6 +293,41 @@ func TestEventBusClose(t *testing.T) {
 	eb.Close()
 }
 
+func TestEventBusCloseDiscardsQueuedSubscriberEvents(t *testing.T) {
+	const testEvtType event.EventType = "test.close.discard"
+	eb := event.NewEventBus(nil, nil)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var handled atomic.Int32
+	eb.SubscribeFuncWithBuffer(testEvtType, 2, func(event.Event) {
+		if handled.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+	})
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "in-flight"))
+	testutil.RequireReceive(t, entered, time.Second, "handler did not start")
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "queued-1"))
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "queued-2"))
+
+	closeDone := make(chan struct{})
+	go func() {
+		eb.Close()
+		close(closeDone)
+	}()
+	testutil.RequireNoReceive(
+		t,
+		closeDone,
+		50*time.Millisecond,
+		"Close should still wait for the in-flight handler",
+	)
+	close(release)
+	testutil.RequireReceive(t, closeDone, time.Second, "Close did not finish")
+	require.Equal(t, int32(1), handled.Load(), "queued events were replayed during Close")
+}
+
 func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	var testEvtType event.EventType = "test.panic"
 	eb := event.NewEventBus(nil, nil)

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -328,6 +328,41 @@ func TestEventBusCloseDiscardsQueuedSubscriberEvents(t *testing.T) {
 	require.Equal(t, int32(1), handled.Load(), "queued events were replayed during Close")
 }
 
+func TestEventBusUnsubscribePreservesQueuedSubscriberEvents(t *testing.T) {
+	const testEvtType event.EventType = "test.unsubscribe.preserves"
+	eb := event.NewEventBus(nil, nil)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var handled atomic.Int32
+	subID := eb.SubscribeFuncWithBuffer(testEvtType, 2, func(event.Event) {
+		if handled.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+	})
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "in-flight"))
+	testutil.RequireReceive(t, entered, time.Second, "handler did not start")
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "queued-1"))
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "queued-2"))
+
+	unsubscribed := make(chan struct{})
+	go func() {
+		eb.UnsubscribeAndWait(testEvtType, subID)
+		close(unsubscribed)
+	}()
+	testutil.RequireNoReceive(
+		t,
+		unsubscribed,
+		50*time.Millisecond,
+		"UnsubscribeAndWait should wait for the in-flight handler",
+	)
+	close(release)
+	testutil.RequireReceive(t, unsubscribed, time.Second, "UnsubscribeAndWait did not finish")
+	require.Equal(t, int32(3), handled.Load(), "ordinary unsubscribe discarded queued events")
+}
+
 func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	var testEvtType event.EventType = "test.panic"
 	eb := event.NewEventBus(nil, nil)

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3232,6 +3232,9 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	ls.activeBlockfetchStart = time.Now()
 	ls.firstBlockReceived = false
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
+	ls.blockfetchRequestGeneration++
+	primaryRequestGeneration := ls.blockfetchRequestGeneration
+	ls.blockfetchPrimaryRequestGeneration = primaryRequestGeneration
 	ls.armBlockfetchTimeoutLocked(connId)
 	batchReadyChan := ls.chainsyncBlockfetchReadyChan
 	ls.chainsyncBlockfetchMutex.Unlock()
@@ -3241,6 +3244,9 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 		headerEnd,
 	); err != nil {
 		ls.chainsyncBlockfetchMutex.Lock()
+		if ls.blockfetchPrimaryRequestGeneration == primaryRequestGeneration {
+			ls.blockfetchPrimaryRequestGeneration = 0
+		}
 		// A blockfetch callback may have completed this batch, or a
 		// callback may have started its continuation, while the request
 		// was outside the lock. In either case the request error is stale
@@ -3269,6 +3275,9 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 		return err
 	}
 	ls.chainsyncBlockfetchMutex.Lock()
+	if ls.blockfetchPrimaryRequestGeneration == primaryRequestGeneration {
+		ls.blockfetchPrimaryRequestGeneration = 0
+	}
 	// The request can synchronously release a completed batch before it
 	// returns (for example when a peer answers with an immediate empty
 	// response). Do not dispatch shadow work for a batch that no longer
@@ -3334,10 +3343,20 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 					sameConnectionId(shadowConn, connId) {
 					continue
 				}
+				if ls.blockfetchShadowRequestsInFlight != nil {
+					if _, inFlight := ls.blockfetchShadowRequestsInFlight[connIdKey(shadowConn)]; inFlight {
+						continue
+					}
+				}
 				// Publish the shadow owner before releasing the mutex so an
 				// immediately returned block is accepted by the blockfetch
 				// handler. Restore it if the request itself fails.
 				ls.shadowBlockfetchConnId = shadowConn
+				if ls.blockfetchShadowRequestsInFlight == nil {
+					ls.blockfetchShadowRequestsInFlight = make(map[string]struct{})
+				}
+				shadowConnKey := connIdKey(shadowConn)
+				ls.blockfetchShadowRequestsInFlight[shadowConnKey] = struct{}{}
 				ls.chainsyncBlockfetchMutex.Unlock()
 				err := ls.config.BlockfetchRequestRangeFunc(
 					shadowConn,
@@ -3345,6 +3364,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 					headerEnd,
 				)
 				ls.chainsyncBlockfetchMutex.Lock()
+				delete(ls.blockfetchShadowRequestsInFlight, shadowConnKey)
 				if ls.chainsyncBlockfetchReadyChan != batchReadyChan {
 					return nil
 				}
@@ -5120,6 +5140,19 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 	currentConnId ouroboros.ConnectionId,
 	pending *pendingPublishes,
 ) {
+	if ls.blockfetchPrimaryRequestGeneration != 0 {
+		// The protocol request is still blocked outside the ledger mutex. Do
+		// not issue a duplicate range request while it is in flight; the
+		// original request may still deliver a valid response. Keep the
+		// watchdog alive so a later timeout can reassess the same request.
+		ls.config.Logger.Debug(
+			"blockfetch request still in flight at timeout; waiting for it to return",
+			"component", "ledger",
+			"connection_id", currentConnId.String(),
+		)
+		ls.armBlockfetchTimeoutLocked(currentConnId)
+		return
+	}
 	headerCount := ls.chain.HeaderCount()
 	if headerCount == 0 {
 		ls.blockfetchRequestRangeCleanup()

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -88,6 +88,12 @@ const (
 	// discards its record entirely.
 	blockfetchMaxSameRangeFailures = 3
 
+	// Warn after this many consecutive watchdog expirations while the same
+	// protocol request is still blocked outside the ledger mutex. The request
+	// remains protected from duplicate retries, but a permanently wedged peer
+	// must become visible at normal log level.
+	blockfetchInFlightTimeoutWarnThreshold = 3
+
 	// Number of received blockfetch blocks to buffer before committing them.
 	// Keep this small so downstream iterators still see fresh blocks promptly.
 	blockfetchCommitBatchSize = 8
@@ -3214,6 +3220,9 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	// The lock is temporarily released around each external request and is
 	// reacquired before any state is inspected or changed. Callers still own
 	// the lock when this function returns.
+	if err := ls.waitForBlockfetchRequestLocked(connId); err != nil {
+		return err
+	}
 	if ls.chain.HeaderCount() == 0 {
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return nil
@@ -3235,6 +3244,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	ls.blockfetchRequestGeneration++
 	primaryRequestGeneration := ls.blockfetchRequestGeneration
 	ls.blockfetchPrimaryRequestGeneration = primaryRequestGeneration
+	primaryRequestDone := ls.beginBlockfetchRequestLocked(connId)
 	ls.armBlockfetchTimeoutLocked(connId)
 	batchReadyChan := ls.chainsyncBlockfetchReadyChan
 	ls.chainsyncBlockfetchMutex.Unlock()
@@ -3244,8 +3254,10 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 		headerEnd,
 	); err != nil {
 		ls.chainsyncBlockfetchMutex.Lock()
+		ls.endBlockfetchRequestLocked(connId, primaryRequestDone)
 		if ls.blockfetchPrimaryRequestGeneration == primaryRequestGeneration {
 			ls.blockfetchPrimaryRequestGeneration = 0
+			ls.resetBlockfetchInFlightTimeoutsLocked()
 		}
 		// A blockfetch callback may have completed this batch, or a
 		// callback may have started its continuation, while the request
@@ -3275,8 +3287,10 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 		return err
 	}
 	ls.chainsyncBlockfetchMutex.Lock()
+	ls.endBlockfetchRequestLocked(connId, primaryRequestDone)
 	if ls.blockfetchPrimaryRequestGeneration == primaryRequestGeneration {
 		ls.blockfetchPrimaryRequestGeneration = 0
+		ls.resetBlockfetchInFlightTimeoutsLocked()
 	}
 	// The request can synchronously release a completed batch before it
 	// returns (for example when a peer answers with an immediate empty
@@ -3357,6 +3371,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 				}
 				shadowConnKey := connIdKey(shadowConn)
 				ls.blockfetchShadowRequestsInFlight[shadowConnKey] = struct{}{}
+				shadowRequestDone := ls.beginBlockfetchRequestLocked(shadowConn)
 				ls.chainsyncBlockfetchMutex.Unlock()
 				err := ls.config.BlockfetchRequestRangeFunc(
 					shadowConn,
@@ -3364,6 +3379,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 					headerEnd,
 				)
 				ls.chainsyncBlockfetchMutex.Lock()
+				ls.endBlockfetchRequestLocked(shadowConn, shadowRequestDone)
 				delete(ls.blockfetchShadowRequestsInFlight, shadowConnKey)
 				if ls.chainsyncBlockfetchReadyChan != batchReadyChan {
 					return nil
@@ -3424,7 +3440,7 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 	resyncConnId ouroboros.ConnectionId,
 	reason string,
 ) {
-	if ls.blockfetchContinuationPending {
+	if ls.closed.Load() || ls.blockfetchContinuationPending {
 		return
 	}
 	ls.blockfetchContinuationPending = true
@@ -5091,6 +5107,78 @@ func (ls *LedgerState) armBlockfetchTimeoutLocked(
 	)
 }
 
+// waitForBlockfetchRequestLocked drains a previous request before allowing
+// the connection to be reused. Blockfetch callbacks identify only their
+// connection, so accepting a late block or BatchDone after the same peer has
+// been assigned to a new batch would apply the old response to new state.
+//
+// The caller owns chainsyncBlockfetchMutex. This function returns with it
+// locked, including after the bounded wait expires.
+func (ls *LedgerState) waitForBlockfetchRequestLocked(
+	connId ouroboros.ConnectionId,
+) error {
+	key := connIdKey(connId)
+	if key == "" {
+		return nil
+	}
+	for {
+		requestDone, ok := ls.blockfetchRequestsInFlight[key]
+		if !ok {
+			return nil
+		}
+		ls.chainsyncBlockfetchMutex.Unlock()
+		timer := time.NewTimer(blockfetchBusyTimeout)
+		select {
+		case <-requestDone:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		case <-timer.C:
+			ls.chainsyncBlockfetchMutex.Lock()
+			return fmt.Errorf(
+				"blockfetch connection %s remains busy after %s",
+				connId.String(),
+				blockfetchBusyTimeout,
+			)
+		}
+		ls.chainsyncBlockfetchMutex.Lock()
+	}
+}
+
+// beginBlockfetchRequestLocked records a request whose callbacks are still
+// allowed to arrive. The caller owns chainsyncBlockfetchMutex.
+func (ls *LedgerState) beginBlockfetchRequestLocked(
+	connId ouroboros.ConnectionId,
+) chan struct{} {
+	if ls.blockfetchRequestsInFlight == nil {
+		ls.blockfetchRequestsInFlight = make(map[string]chan struct{})
+	}
+	done := make(chan struct{})
+	ls.blockfetchRequestsInFlight[connIdKey(connId)] = done
+	return done
+}
+
+// endBlockfetchRequestLocked releases a request's connection for reuse. The
+// caller owns chainsyncBlockfetchMutex.
+func (ls *LedgerState) endBlockfetchRequestLocked(
+	connId ouroboros.ConnectionId,
+	done chan struct{},
+) {
+	key := connIdKey(connId)
+	if current, ok := ls.blockfetchRequestsInFlight[key]; ok && current == done {
+		delete(ls.blockfetchRequestsInFlight, key)
+		close(done)
+	}
+}
+
+func (ls *LedgerState) resetBlockfetchInFlightTimeoutsLocked() {
+	ls.blockfetchInFlightTimeoutGeneration = 0
+	ls.blockfetchInFlightTimeoutCount = 0
+}
+
 // blockfetchRequestRangeStart starts the external request. It must be called
 // without chainsyncBlockfetchMutex held; the blockfetch protocol may wait for
 // a previous request whose receive callback needs that mutex to publish its
@@ -5145,10 +5233,27 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 		// not issue a duplicate range request while it is in flight; the
 		// original request may still deliver a valid response. Keep the
 		// watchdog alive so a later timeout can reassess the same request.
-		ls.config.Logger.Debug(
+		if ls.blockfetchInFlightTimeoutGeneration !=
+			ls.blockfetchPrimaryRequestGeneration {
+			ls.blockfetchInFlightTimeoutGeneration = ls.blockfetchPrimaryRequestGeneration
+			ls.blockfetchInFlightTimeoutCount = 0
+		}
+		if ls.blockfetchInFlightTimeoutCount <
+			blockfetchInFlightTimeoutWarnThreshold {
+			ls.blockfetchInFlightTimeoutCount++
+		}
+		logFn := ls.config.Logger.Debug
+		if ls.blockfetchInFlightTimeoutCount >=
+			blockfetchInFlightTimeoutWarnThreshold {
+			logFn = ls.config.Logger.Warn
+		}
+		logFn(
 			"blockfetch request still in flight at timeout; waiting for it to return",
 			"component", "ledger",
 			"connection_id", currentConnId.String(),
+			"request_generation", ls.blockfetchPrimaryRequestGeneration,
+			"in_flight_timeout_count", ls.blockfetchInFlightTimeoutCount,
+			"in_flight_elapsed", time.Since(ls.activeBlockfetchStart),
 		)
 		ls.armBlockfetchTimeoutLocked(currentConnId)
 		return

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3206,6 +3206,16 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	connId ouroboros.ConnectionId,
 	pending *pendingPublishes,
 ) error {
+	return ls.startQueuedBlockfetchLockedWithWaitSignal(connId, pending, nil)
+}
+
+// startQueuedBlockfetchLockedWithWaitSignal is the same scheduling path with
+// an optional test synchronization signal for the prior-request drain.
+func (ls *LedgerState) startQueuedBlockfetchLockedWithWaitSignal(
+	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
+	waitStarted chan<- struct{},
+) error {
 	// The caller owns chainsyncBlockfetchMutex. Keep the reservation and
 	// timeout state under that lock, but never hold it across the network
 	// request below. BlockFetch delivers blocks from its protocol receive
@@ -3220,7 +3230,7 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	// The lock is temporarily released around each external request and is
 	// reacquired before any state is inspected or changed. Callers still own
 	// the lock when this function returns.
-	if err := ls.waitForBlockfetchRequestLocked(connId); err != nil {
+	if err := ls.waitForBlockfetchRequestLockedWithSignal(connId, waitStarted); err != nil {
 		return err
 	}
 	if ls.chain.HeaderCount() == 0 {
@@ -5114,8 +5124,9 @@ func (ls *LedgerState) armBlockfetchTimeoutLocked(
 //
 // The caller owns chainsyncBlockfetchMutex. This function returns with it
 // locked, including after the bounded wait expires.
-func (ls *LedgerState) waitForBlockfetchRequestLocked(
+func (ls *LedgerState) waitForBlockfetchRequestLockedWithSignal(
 	connId ouroboros.ConnectionId,
+	waitStarted chan<- struct{},
 ) error {
 	key := connIdKey(connId)
 	if key == "" {
@@ -5127,6 +5138,10 @@ func (ls *LedgerState) waitForBlockfetchRequestLocked(
 			return nil
 		}
 		ls.chainsyncBlockfetchMutex.Unlock()
+		if waitStarted != nil {
+			close(waitStarted)
+			waitStarted = nil
+		}
 		timer := time.NewTimer(blockfetchBusyTimeout)
 		select {
 		case <-requestDone:

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -713,7 +713,9 @@ func (ls *LedgerState) handleEventChainsyncAwaitReply(evt event.Event) {
 	}
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
-	if ls.chainsyncBlockfetchReadyChan != nil || ls.chain.HeaderCount() == 0 {
+	if ls.chainsyncBlockfetchReadyChan != nil ||
+		ls.blockfetchContinuationPending ||
+		ls.chain.HeaderCount() == 0 {
 		return
 	}
 	ls.selectedBlockfetchConnId = e.ConnectionId
@@ -875,6 +877,7 @@ func (ls *LedgerState) handoffPipelineOnSwitchLocked(
 	}
 
 	if ls.chainsyncBlockfetchReadyChan == nil &&
+		!ls.blockfetchContinuationPending &&
 		headerCount > 0 {
 		ls.config.Logger.Debug(
 			"restarting queued blockfetch on selected connection",
@@ -2207,7 +2210,8 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 			"header_count", headerCount,
 		)
 		ls.chainsyncBlockfetchMutex.Lock()
-		if ls.chainsyncBlockfetchReadyChan == nil {
+		if ls.chainsyncBlockfetchReadyChan == nil &&
+			!ls.blockfetchContinuationPending {
 			if err := ls.startQueuedBlockfetchLocked(connId, &pending); err != nil {
 				// Recovery connection may have closed. Retry with
 				// the current active best peer before giving up,
@@ -2516,7 +2520,8 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
 	// Don't start fetch if there's already one in progress
-	if ls.chainsyncBlockfetchReadyChan != nil {
+	if ls.chainsyncBlockfetchReadyChan != nil ||
+		ls.blockfetchContinuationPending {
 		ls.config.Logger.Debug(
 			"blockfetch in progress, queuing header",
 			"component", "ledger",
@@ -3382,6 +3387,71 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 		}
 	}
 	return nil
+}
+
+// startQueuedBlockfetchFromEventLocked schedules a continuation without
+// running the synchronous blockfetch request on the ledger.blockfetch
+// subscriber. GetBlockRange does not return until the peer sends BatchDone;
+// invoking it from handleEventBlockfetchBatchDone would block the only
+// subscriber that can consume that BatchDone and the following block events.
+//
+// The caller owns chainsyncBlockfetchMutex. The continuation worker acquires
+// it before entering startQueuedBlockfetchLocked, so the pending flag closes
+// the small gap where a chainsync handler could otherwise start a competing
+// batch after the current handler releases the lock.
+func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
+	connId ouroboros.ConnectionId,
+	resyncConnId ouroboros.ConnectionId,
+	reason string,
+) {
+	if ls.blockfetchContinuationPending {
+		return
+	}
+	ls.blockfetchContinuationPending = true
+	ls.blockfetchContinuationMu.Lock()
+	if ls.closed.Load() {
+		ls.blockfetchContinuationPending = false
+		ls.blockfetchContinuationMu.Unlock()
+		return
+	}
+	ls.blockfetchContinuationWG.Add(1)
+	ls.blockfetchContinuationMu.Unlock()
+	go func() {
+		defer ls.blockfetchContinuationWG.Done()
+		var pending pendingPublishes
+		ls.chainsyncBlockfetchMutex.Lock()
+		if ls.closed.Load() {
+			ls.blockfetchContinuationPending = false
+			ls.chainsyncBlockfetchMutex.Unlock()
+			return
+		}
+		ls.blockfetchContinuationPending = false
+		err := ls.startQueuedBlockfetchLocked(connId, &pending)
+		if err != nil {
+			// A continuation can race a peer disconnect just as the previous
+			// batch completes. Try the next tracked peer before abandoning the
+			// queued headers, matching the synchronous continuation path.
+			retryConnId := ls.selectRetryBlockfetchConn(connId)
+			if connIdKey(retryConnId) != "" &&
+				!sameConnectionId(retryConnId, connId) {
+				err = ls.startQueuedBlockfetchLocked(
+					retryConnId,
+					&pending,
+				)
+			}
+			if err != nil {
+				ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+				ls.clearQueuedHeaders()
+				ls.requestChainsyncResync(
+					resyncConnId,
+					fmt.Sprintf("%s: %v", reason, err),
+					&pending,
+				)
+			}
+		}
+		ls.chainsyncBlockfetchMutex.Unlock()
+		pending.flush()
+	}()
 }
 
 func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
@@ -5208,19 +5278,11 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(
 				"remaining_headers",
 				remainingHeaders,
 			)
-			if err := ls.startQueuedBlockfetchLocked(retryConnId, pending); err != nil {
-				ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
-				ls.clearQueuedHeaders()
-				ls.requestChainsyncResync(
-					e.ConnectionId,
-					fmt.Sprintf(
-						"empty blockfetch batch alternate retry failed: %v",
-						err,
-					),
-					pending,
-				)
-				return nil
-			}
+			ls.startQueuedBlockfetchFromEventLocked(
+				retryConnId,
+				e.ConnectionId,
+				"empty blockfetch batch alternate retry failed",
+			)
 			return nil
 		}
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
@@ -5262,40 +5324,14 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return nil
 	}
-	// Mark blockfetch as in progress for next batch
-	err := ls.startQueuedBlockfetchLocked(nextConnId, pending)
-	if err != nil {
-		// The connection's blockfetch protocol may have shut down
-		// (e.g. peer disconnected mid-batch). Try an alternate
-		// connection; if none available, clear all stale queued
-		// headers and trigger a resync so the pipeline can restart.
-		retryConnId := ls.selectRetryBlockfetchConn(nextConnId)
-		if connIdKey(retryConnId) != "" &&
-			!sameConnectionId(retryConnId, nextConnId) {
-			ls.config.Logger.Warn(
-				"blockfetch continuation failed, retrying on alternate connection",
-				"component",
-				"ledger",
-				"failed_connection_id",
-				nextConnId.String(),
-				"retry_connection_id",
-				retryConnId.String(),
-				"error",
-				err,
-			)
-			if retryErr := ls.startQueuedBlockfetchLocked(retryConnId, pending); retryErr == nil {
-				return nil
-			}
-		}
-		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
-		ls.clearQueuedHeaders()
-		ls.requestChainsyncResync(
-			nextConnId,
-			fmt.Sprintf("blockfetch continuation failed: %v", err),
-			pending,
-		)
-		return nil
-	}
+	// GetBlockRange waits for the BatchDone event that is being handled here.
+	// Continue on a worker so this subscriber remains available to drain the
+	// next batch's block and BatchDone events.
+	ls.startQueuedBlockfetchFromEventLocked(
+		nextConnId,
+		nextConnId,
+		"blockfetch continuation failed",
+	)
 	return nil
 }
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3195,6 +3195,20 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	connId ouroboros.ConnectionId,
 	pending *pendingPublishes,
 ) error {
+	// The caller owns chainsyncBlockfetchMutex. Keep the reservation and
+	// timeout state under that lock, but never hold it across the network
+	// request below. BlockFetch delivers blocks from its protocol receive
+	// goroutine, and that delivery waits for this same mutex in
+	// handleEventBlockfetch. A request on a busy client can wait for the
+	// previous delivery to finish, so calling GetBlockRange while holding the
+	// mutex creates a lock cycle:
+	//
+	//   chainsync -> GetBlockRange.acquireBusy -> blockfetch event -> ledger
+	//   blockfetch mutex
+	//
+	// The lock is temporarily released around each external request and is
+	// reacquired before any state is inspected or changed. Callers still own
+	// the lock when this function returns.
 	if ls.chain.HeaderCount() == 0 {
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return nil
@@ -3213,11 +3227,22 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 	ls.activeBlockfetchStart = time.Now()
 	ls.firstBlockReceived = false
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
+	ls.armBlockfetchTimeoutLocked(connId)
+	batchReadyChan := ls.chainsyncBlockfetchReadyChan
+	ls.chainsyncBlockfetchMutex.Unlock()
 	if err := ls.blockfetchRequestRangeStart(
 		connId,
 		headerStart,
 		headerEnd,
 	); err != nil {
+		ls.chainsyncBlockfetchMutex.Lock()
+		// A blockfetch callback may have completed this batch, or a
+		// callback may have started its continuation, while the request
+		// was outside the lock. In either case the request error is stale
+		// and must not tear down the newer batch.
+		if ls.chainsyncBlockfetchReadyChan != batchReadyChan {
+			return nil
+		}
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		// A peer whose range server rejects the start point answers
@@ -3237,6 +3262,14 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 			)
 		}
 		return err
+	}
+	ls.chainsyncBlockfetchMutex.Lock()
+	// The request can synchronously release a completed batch before it
+	// returns (for example when a peer answers with an immediate empty
+	// response). Do not dispatch shadow work for a batch that no longer
+	// exists.
+	if ls.chainsyncBlockfetchReadyChan != batchReadyChan {
+		return nil
 	}
 	// Near tip: dispatch the same range to one shadow peer if any
 	// tracked peer has already seen the first block header. Whichever
@@ -3296,12 +3329,22 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 					sameConnectionId(shadowConn, connId) {
 					continue
 				}
+				// Publish the shadow owner before releasing the mutex so an
+				// immediately returned block is accepted by the blockfetch
+				// handler. Restore it if the request itself fails.
+				ls.shadowBlockfetchConnId = shadowConn
+				ls.chainsyncBlockfetchMutex.Unlock()
 				err := ls.config.BlockfetchRequestRangeFunc(
 					shadowConn,
 					headerStart,
 					headerEnd,
 				)
+				ls.chainsyncBlockfetchMutex.Lock()
+				if ls.chainsyncBlockfetchReadyChan != batchReadyChan {
+					return nil
+				}
 				if err != nil {
+					ls.shadowBlockfetchConnId = ouroboros.ConnectionId{}
 					ls.config.Logger.Debug(
 						"shadow blockfetch dispatch failed, trying next candidate",
 						"component",
@@ -3313,7 +3356,6 @@ func (ls *LedgerState) startQueuedBlockfetchLocked(
 					)
 					continue
 				}
-				ls.shadowBlockfetchConnId = shadowConn
 				ls.config.Logger.Debug(
 					"dispatched shadow blockfetch",
 					"component", "ledger",
@@ -4922,23 +4964,14 @@ func (ls *LedgerState) selectRetryBlockfetchConn(
 	return currentConnId
 }
 
-func (ls *LedgerState) blockfetchRequestRangeStart(
+// armBlockfetchTimeoutLocked arms the timeout before the request leaves the
+// blockfetch mutex. A peer can send StartBatch and blocks immediately, so the
+// timer must exist before the external request is allowed to run.
+//
+// The caller must hold chainsyncBlockfetchMutex.
+func (ls *LedgerState) armBlockfetchTimeoutLocked(
 	connId ouroboros.ConnectionId,
-	start ocommon.Point,
-	end ocommon.Point,
-) error {
-	if ls.config.BlockfetchRequestRangeFunc == nil {
-		return errors.New("blockfetch request range func not configured")
-	}
-	err := ls.config.BlockfetchRequestRangeFunc(
-		connId,
-		start,
-		end,
-	)
-	if err != nil {
-		return fmt.Errorf("request block range: %w", err)
-	}
-
+) {
 	// Stop any existing timer before creating a new one
 	if ls.chainsyncBlockfetchTimeoutTimer != nil {
 		ls.chainsyncBlockfetchTimeoutTimer.Stop()
@@ -4966,6 +4999,28 @@ func (ls *LedgerState) blockfetchRequestRangeStart(
 			ls.handleBlockfetchTimeoutLocked(connId, &pending)
 		},
 	)
+}
+
+// blockfetchRequestRangeStart starts the external request. It must be called
+// without chainsyncBlockfetchMutex held; the blockfetch protocol may wait for
+// a previous request whose receive callback needs that mutex to publish its
+// final block.
+func (ls *LedgerState) blockfetchRequestRangeStart(
+	connId ouroboros.ConnectionId,
+	start ocommon.Point,
+	end ocommon.Point,
+) error {
+	if ls.config.BlockfetchRequestRangeFunc == nil {
+		return errors.New("blockfetch request range func not configured")
+	}
+	err := ls.config.BlockfetchRequestRangeFunc(
+		connId,
+		start,
+		end,
+	)
+	if err != nil {
+		return fmt.Errorf("request block range: %w", err)
+	}
 	return nil
 }
 

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -43,6 +43,88 @@ var errBlockfetchNoBlocks = errors.New(
 	"request block range: block(s) not found",
 )
 
+// The production helpers named *Locked require their caller to own the
+// blockfetch mutex. Keep direct unit-test calls honest now that the helper
+// briefly releases that mutex around the external request callback.
+func startQueuedBlockfetchForTest(
+	ls *LedgerState,
+	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
+) error {
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	return ls.startQueuedBlockfetchLocked(connId, pending)
+}
+
+func restartQueuedBlockfetchAfterForkForTest(
+	ls *LedgerState,
+	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
+) error {
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	return ls.restartQueuedBlockfetchAfterForkLocked(connId, pending)
+}
+
+func handleEventBlockfetchBatchDoneForTest(
+	ls *LedgerState,
+	e BlockfetchEvent,
+	pending *pendingPublishes,
+) error {
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	return ls.handleEventBlockfetchBatchDone(e, pending)
+}
+
+func handleBlockfetchTimeoutForTest(
+	ls *LedgerState,
+	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
+) {
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	ls.handleBlockfetchTimeoutLocked(connId, pending)
+}
+
+// TestStartQueuedBlockfetchReleasesMutexAroundRequest models the receive-side
+// half of the production deadlock. The real blockfetch callback publishes a
+// ledger.blockfetch event, whose subscriber needs chainsyncBlockfetchMutex;
+// the request callback must therefore be able to run while that mutex is
+// available even when the caller started the batch under the lock.
+func TestStartQueuedBlockfetchReleasesMutexAroundRequest(t *testing.T) {
+	ls, _, _ := newNoBlocksLedgerState(t, "hdr-lock-cycle")
+	defer ls.config.EventBus.Stop()
+	ls.config.BlockfetchRequestRangeFunc = func(
+		_ ouroboros.ConnectionId,
+		_ ocommon.Point,
+		_ ocommon.Point,
+	) error {
+		acquired := make(chan struct{})
+		go func() {
+			ls.chainsyncBlockfetchMutex.Lock()
+			close(acquired)
+			ls.chainsyncBlockfetchMutex.Unlock()
+		}()
+		select {
+		case <-acquired:
+			return nil
+		case <-time.After(time.Second):
+			return errors.New("blockfetch request ran while blockfetch mutex was held")
+		}
+	}
+
+	connId := testChainsyncConnId(6111, 3001)
+	ls.chainsyncBlockfetchMutex.Lock()
+	err := ls.startQueuedBlockfetchLocked(connId, nil)
+	ls.chainsyncBlockfetchMutex.Unlock()
+	require.NoError(t, err)
+
+	ls.chainsyncBlockfetchMutex.Lock()
+	ls.blockfetchRequestRangeCleanup()
+	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+	ls.chainsyncBlockfetchMutex.Unlock()
+}
+
 // newNoBlocksLedgerState builds a LedgerState with one queued header whose
 // range every peer refuses with a NoBlocks error, and returns it alongside the
 // request counter and a channel of published resync events.
@@ -113,7 +195,7 @@ func TestStartQueuedBlockfetchDropsHeadersAfterRepeatedNoBlocks(t *testing.T) {
 	for range attempts {
 		// Callers treat this error as advisory (several only log it), so
 		// the recovery cannot depend on any caller acting on it.
-		_ = ls.startQueuedBlockfetchLocked(connId, nil)
+		_ = startQueuedBlockfetchForTest(ls, connId, nil)
 	}
 
 	assert.LessOrEqual(
@@ -187,7 +269,7 @@ func TestStartQueuedBlockfetchTransientErrorsDoNotAccumulate(t *testing.T) {
 
 			connId := testChainsyncConnId(6110, 3001)
 			for range blockfetchMaxSameRangeFailures * 3 {
-				err := ls.startQueuedBlockfetchLocked(connId, nil)
+				err := startQueuedBlockfetchForTest(ls, connId, nil)
 				require.Error(t, err)
 			}
 
@@ -229,7 +311,7 @@ func TestRestartQueuedBlockfetchAfterForkDropsHeadersOnRepeatedNoBlocks(
 	for range attempts {
 		// Mirrors the fork-resolution call sites, which discard the error
 		// after logging it.
-		_ = ls.restartQueuedBlockfetchAfterForkLocked(connId, nil)
+		_ = restartQueuedBlockfetchAfterForkForTest(ls, connId, nil)
 	}
 
 	assert.LessOrEqual(
@@ -263,7 +345,7 @@ func TestBlockfetchRangeFailureClearedWhenRangeIsDelivered(t *testing.T) {
 	stuckStart, _ := ls.chain.HeaderRange(blockfetchBatchSize)
 
 	for range blockfetchMaxSameRangeFailures * 3 {
-		_ = ls.startQueuedBlockfetchLocked(connId, nil)
+		_ = startQueuedBlockfetchForTest(ls, connId, nil)
 		require.Positive(
 			t,
 			ls.chain.HeaderCount(),
@@ -313,7 +395,7 @@ func TestBlockfetchRangeFailuresAccumulatePerRangeDespiteInterleavedActivity(
 			"stuck header must be queued for attempt %d",
 			attempt,
 		)
-		_ = ls.startQueuedBlockfetchLocked(connId, nil)
+		_ = startQueuedBlockfetchForTest(ls, connId, nil)
 		if attempt == blockfetchMaxSameRangeFailures {
 			break
 		}
@@ -359,7 +441,7 @@ func TestBlockfetchRangeFailuresDoNotAccumulateAcrossDifferentRanges(
 	connId := testChainsyncConnId(6106, 3001)
 
 	for attempt := range blockfetchMaxSameRangeFailures * 3 {
-		_ = ls.startQueuedBlockfetchLocked(connId, nil)
+		_ = startQueuedBlockfetchForTest(ls, connId, nil)
 		// Each attempt is against a different queued header, as happens
 		// when the chain keeps moving and every miss is a one-off.
 		ls.clearQueuedHeaders()
@@ -457,7 +539,7 @@ func TestHandleEventBlockfetchBatchDoneStopsRepeatingEmptyBatches(
 	for i := range emptyBatchAttempts {
 		require.NoError(
 			t,
-			ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+			handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 				ConnectionId: connId,
 				BatchDone:    true,
 			}, nil),
@@ -534,7 +616,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchStreakResetsOnProgress(
 	for range blockfetchMaxSameRangeFailures * 3 {
 		require.NoError(
 			t,
-			ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+			handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 				ConnectionId: connId,
 				BatchDone:    true,
 			}, nil),
@@ -545,7 +627,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchStreakResetsOnProgress(
 		ls.noteBlockfetchRangeProgress(queuedStart)
 		require.NoError(
 			t,
-			ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+			handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 				ConnectionId: connId,
 				BatchDone:    true,
 			}, nil),

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -72,8 +72,12 @@ func handleEventBlockfetchBatchDoneForTest(
 	pending *pendingPublishes,
 ) error {
 	ls.chainsyncBlockfetchMutex.Lock()
-	defer ls.chainsyncBlockfetchMutex.Unlock()
-	return ls.handleEventBlockfetchBatchDone(e, pending)
+	err := ls.handleEventBlockfetchBatchDone(e, pending)
+	ls.chainsyncBlockfetchMutex.Unlock()
+	ls.blockfetchContinuationMu.Lock()
+	ls.blockfetchContinuationWG.Wait()
+	ls.blockfetchContinuationMu.Unlock()
+	return err
 }
 
 func handleBlockfetchTimeoutForTest(
@@ -119,6 +123,74 @@ func TestStartQueuedBlockfetchReleasesMutexAroundRequest(t *testing.T) {
 	ls.chainsyncBlockfetchMutex.Unlock()
 	require.NoError(t, err)
 
+	ls.chainsyncBlockfetchMutex.Lock()
+	ls.blockfetchRequestRangeCleanup()
+	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+	ls.chainsyncBlockfetchMutex.Unlock()
+}
+
+// TestBlockfetchBatchDoneDoesNotBlockSubscriberOnContinuation verifies that
+// the blockfetch EventBus subscriber does not synchronously enter the next
+// GetBlockRange call. GetBlockRange waits for the next BatchDone, so doing so
+// from this subscriber deadlocks once the subscriber buffer fills with the
+// next batch's blocks.
+func TestBlockfetchBatchDoneDoesNotBlockSubscriberOnContinuation(t *testing.T) {
+	testChain := &chain.Chain{}
+	for blockNumber := uint64(1); blockNumber <= 2; blockNumber++ {
+		prevHash := lcommon.NewBlake2b256(nil)
+		if blockNumber > 1 {
+			prevHash = lcommon.NewBlake2b256([]byte{byte(blockNumber - 1)})
+		}
+		require.NoError(t, testChain.AddBlockHeader(mockHeader{
+			hash:        lcommon.NewBlake2b256([]byte{byte(blockNumber)}),
+			prevHash:    prevHash,
+			blockNumber: blockNumber,
+			slot:        blockNumber,
+		}))
+	}
+	connId := testChainsyncConnId(6112, 3001)
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	ls := &LedgerState{
+		chain:                        testChain,
+		activeBlockfetchConnId:       connId,
+		selectedBlockfetchConnId:     connId,
+		chainsyncBlockfetchReadyChan: make(chan struct{}),
+		batchBlocksReceived:          1,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				ouroboros.ConnectionId,
+				ocommon.Point,
+				ocommon.Point,
+			) error {
+				close(requestStarted)
+				<-releaseRequest
+				return nil
+			},
+		},
+	}
+
+	handlerDone := make(chan struct{})
+	go func() {
+		ls.handleEventBlockfetch(event.NewEvent(
+			BlockfetchEventType,
+			BlockfetchEvent{ConnectionId: connId, BatchDone: true},
+		))
+		close(handlerDone)
+	}()
+	testutil.RequireReceive(
+		t,
+		handlerDone,
+		time.Second,
+		"blockfetch subscriber remained blocked in continuation request",
+	)
+	testutil.RequireReceive(t, requestStarted, time.Second, "continuation request did not start")
+
+	close(releaseRequest)
+	ls.blockfetchContinuationMu.Lock()
+	ls.blockfetchContinuationWG.Wait()
+	ls.blockfetchContinuationMu.Unlock()
 	ls.chainsyncBlockfetchMutex.Lock()
 	ls.blockfetchRequestRangeCleanup()
 	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -129,6 +129,70 @@ func TestStartQueuedBlockfetchReleasesMutexAroundRequest(t *testing.T) {
 	ls.chainsyncBlockfetchMutex.Unlock()
 }
 
+// TestStartQueuedBlockfetchDrainsPriorRequestBeforeConnectionReuse verifies
+// that a late shadow request cannot share its connection with a later batch.
+// Blockfetch events carry only a connection ID, so reusing the connection
+// before the prior callback returns would make the old BatchDone ambiguous.
+func TestStartQueuedBlockfetchDrainsPriorRequestBeforeConnectionReuse(
+	t *testing.T,
+) {
+	testChain := &chain.Chain{}
+	require.NoError(t, testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("reuse-header")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}))
+	connId := testChainsyncConnId(6113, 3001)
+	requestStarted := make(chan struct{})
+	requestDone := make(chan struct{})
+	ls := &LedgerState{
+		chain: testChain,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				ouroboros.ConnectionId,
+				ocommon.Point,
+				ocommon.Point,
+			) error {
+				close(requestStarted)
+				return nil
+			},
+		},
+		blockfetchRequestsInFlight: map[string]chan struct{}{
+			connIdKey(connId): requestDone,
+		},
+	}
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- startQueuedBlockfetchForTest(ls, connId, nil)
+	}()
+	select {
+	case <-requestStarted:
+		t.Fatal("reused connection before prior blockfetch request drained")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	ls.chainsyncBlockfetchMutex.Lock()
+	delete(ls.blockfetchRequestsInFlight, connIdKey(connId))
+	close(requestDone)
+	ls.chainsyncBlockfetchMutex.Unlock()
+
+	testutil.RequireReceive(
+		t,
+		requestStarted,
+		time.Second,
+		"blockfetch request did not start after prior request drained",
+	)
+	require.NoError(t, <-startDone)
+
+	ls.chainsyncBlockfetchMutex.Lock()
+	ls.blockfetchRequestRangeCleanup()
+	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+	ls.chainsyncBlockfetchMutex.Unlock()
+}
+
 // TestBlockfetchBatchDoneDoesNotBlockSubscriberOnContinuation verifies that
 // the blockfetch EventBus subscriber does not synchronously enter the next
 // GetBlockRange call. GetBlockRange waits for the next BatchDone, so doing so

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -56,6 +56,21 @@ func startQueuedBlockfetchForTest(
 	return ls.startQueuedBlockfetchLocked(connId, pending)
 }
 
+func startQueuedBlockfetchWithWaitSignalForTest(
+	ls *LedgerState,
+	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
+	waitStarted chan<- struct{},
+) error {
+	ls.chainsyncBlockfetchMutex.Lock()
+	defer ls.chainsyncBlockfetchMutex.Unlock()
+	return ls.startQueuedBlockfetchLockedWithWaitSignal(
+		connId,
+		pending,
+		waitStarted,
+	)
+}
+
 func restartQueuedBlockfetchAfterForkForTest(
 	ls *LedgerState,
 	connId ouroboros.ConnectionId,
@@ -145,6 +160,7 @@ func TestStartQueuedBlockfetchDrainsPriorRequestBeforeConnectionReuse(
 	}))
 	connId := testChainsyncConnId(6113, 3001)
 	requestStarted := make(chan struct{})
+	waitStarted := make(chan struct{})
 	requestDone := make(chan struct{})
 	ls := &LedgerState{
 		chain: testChain,
@@ -166,13 +182,24 @@ func TestStartQueuedBlockfetchDrainsPriorRequestBeforeConnectionReuse(
 
 	startDone := make(chan error, 1)
 	go func() {
-		startDone <- startQueuedBlockfetchForTest(ls, connId, nil)
+		startDone <- startQueuedBlockfetchWithWaitSignalForTest(
+			ls,
+			connId,
+			nil,
+			waitStarted,
+		)
 	}()
 	select {
 	case <-requestStarted:
 		t.Fatal("reused connection before prior blockfetch request drained")
-	case <-time.After(50 * time.Millisecond):
+	case <-waitStarted:
 	}
+	testutil.RequireNoReceive(
+		t,
+		requestStarted,
+		50*time.Millisecond,
+		"blockfetch request started before prior request drained",
+	)
 
 	ls.chainsyncBlockfetchMutex.Lock()
 	delete(ls.blockfetchRequestsInFlight, connIdKey(connId))

--- a/ledger/chainsync_shadow_test.go
+++ b/ledger/chainsync_shadow_test.go
@@ -78,7 +78,7 @@ func TestHandleEventBlockfetchBatchDoneAcceptsShadowCompletion(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	require.NoError(t, handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: shadow,
 		BatchDone:    true,
 	}, nil))
@@ -148,7 +148,7 @@ func TestHandleEventBlockfetchBatchDoneDropsStaleShadowAfterCleanup(
 
 	// Primary completes first; cleanup clears the shadow ID and starts the
 	// next batch on the same primary.
-	require.NoError(t, ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	require.NoError(t, handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: primary,
 		BatchDone:    true,
 	}, nil))
@@ -157,7 +157,7 @@ func TestHandleEventBlockfetchBatchDoneDropsStaleShadowAfterCleanup(
 
 	// The shadow's late BatchDone now arrives. It must not complete the new
 	// batch — neither active nor shadow matches it after cleanup.
-	require.NoError(t, ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	require.NoError(t, handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: shadow,
 		BatchDone:    true,
 	}, nil))
@@ -223,7 +223,7 @@ func TestStartQueuedBlockfetchAfterForkRestartClearsShadowState(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ls.restartQueuedBlockfetchAfterForkLocked(primary, nil))
+	require.NoError(t, restartQueuedBlockfetchAfterForkForTest(ls, primary, nil))
 
 	// Stale per-batch shadow state must be cleared by the restart so that
 	// the new batch starts in a known state.

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -474,7 +474,7 @@ func TestHandleEventBlockfetchBatchDoneUsesSelectedConnectionAfterSwitch(
 		},
 	))
 
-	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	err = handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: connId1,
 		BatchDone:    true,
 	}, nil)
@@ -525,7 +525,7 @@ func TestHandleEventBlockfetchBatchDoneFallsBackToCurrentConnection(
 	}
 	ls.publishSnapshotsLocked()
 
-	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	err = handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: connId,
 		BatchDone:    true,
 	}, nil)
@@ -1325,7 +1325,7 @@ func TestHandleEventBlockfetchBatchDoneReplaysBufferedHeadersAfterDrain(
 		},
 	}
 
-	err := ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	err := handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: connId1,
 		BatchDone:    true,
 	}, nil)
@@ -1785,7 +1785,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchRetriesAlternateConnection(
 	}
 	ls.publishSnapshotsLocked()
 
-	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	err = handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: connId1,
 		BatchDone:    true,
 	}, nil)
@@ -1833,7 +1833,7 @@ func TestHandleEventBlockfetchBatchDoneEmptyBatchNearTipRetries(
 	}
 	ls.publishSnapshotsLocked()
 
-	err = ls.handleEventBlockfetchBatchDone(BlockfetchEvent{
+	err = handleEventBlockfetchBatchDoneForTest(ls, BlockfetchEvent{
 		ConnectionId: connId,
 		BatchDone:    true,
 	}, nil)
@@ -1889,7 +1889,7 @@ func TestHandleBlockfetchTimeoutLocked_RetriesQueuedRangeUsingActivePeer(
 		},
 	}
 
-	ls.handleBlockfetchTimeoutLocked(connId1, nil)
+	handleBlockfetchTimeoutForTest(ls, connId1, nil)
 
 	assert.Equal(t, connId2, requestedConn)
 	assert.Equal(t, connId2, ls.activeBlockfetchConnId)
@@ -1913,7 +1913,7 @@ func TestHandleBlockfetchTimeoutLocked_ClearsActiveConnectionWithoutHeaders(
 		},
 	}
 
-	ls.handleBlockfetchTimeoutLocked(connId, nil)
+	handleBlockfetchTimeoutForTest(ls, connId, nil)
 
 	assert.Equal(t, ouroboros.ConnectionId{}, ls.activeBlockfetchConnId)
 	assert.Nil(t, ls.chainsyncBlockfetchReadyChan)
@@ -1972,7 +1972,7 @@ func TestHandleBlockfetchTimeoutLocked_RetryFailureUsesAlternateSelectedPeer(
 		},
 	}
 
-	ls.handleBlockfetchTimeoutLocked(connId1, nil)
+	handleBlockfetchTimeoutForTest(ls, connId1, nil)
 
 	require.Equal(
 		t,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -839,6 +839,9 @@ type LedgerState struct {
 	peerHeaderHistory    map[string]*peerHeaderChain
 	// Test hook for fork ancestor lookups.
 	lookupBlockByHash func([]byte) (models.Block, error)
+	// Test hook called after Close releases the blockfetch continuation mutex
+	// and before it waits for continuation workers.
+	blockfetchContinuationSchedulingHook func()
 }
 
 // EraTransitionResult holds computed state from an era transition
@@ -1669,6 +1672,9 @@ func (ls *LedgerState) Close() error {
 	ls.blockfetchContinuationMu.Lock()
 	close(continuationSchedulingDone)
 	ls.blockfetchContinuationMu.Unlock()
+	if ls.blockfetchContinuationSchedulingHook != nil {
+		ls.blockfetchContinuationSchedulingHook()
+	}
 	<-continuationSchedulingDone
 	blockfetchContinuationsDone := make(chan struct{})
 	go func() {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1665,15 +1665,11 @@ func (ls *LedgerState) Close() error {
 	// after this synchronization point. Do not hold the mutex across Wait: the
 	// blockfetch subscriber may need it while completing the request that lets a
 	// worker return.
+	continuationSchedulingDone := make(chan struct{})
 	ls.blockfetchContinuationMu.Lock()
-	continuationSchedulingClosed := ls.closed.Load()
+	close(continuationSchedulingDone)
 	ls.blockfetchContinuationMu.Unlock()
-	if !continuationSchedulingClosed {
-		err = errors.Join(
-			err,
-			errors.New("ledger closed state was cleared during continuation drain"),
-		)
-	}
+	<-continuationSchedulingDone
 	blockfetchContinuationsDone := make(chan struct{})
 	go func() {
 		ls.blockfetchContinuationWG.Wait()

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -670,6 +670,14 @@ type LedgerState struct {
 	activeBlockfetchConnId        ouroboros.ConnectionId // connection used for current blockfetch pipeline
 	shadowBlockfetchConnId        ouroboros.ConnectionId // shadow peer dispatched for parallel blockfetch
 	selectedBlockfetchConnId      ouroboros.ConnectionId // latest selected chainsync connection for the next batch
+	// blockfetchContinuationPending prevents a chainsync handler from starting
+	// a competing batch in the short interval after the blockfetch subscriber
+	// schedules its next request on a worker. The worker must run outside the
+	// subscriber goroutine because GetBlockRange waits for BatchDone, which is
+	// delivered back through that same subscriber.
+	blockfetchContinuationPending bool
+	blockfetchContinuationMu      sync.Mutex
+	blockfetchContinuationWG      sync.WaitGroup
 	headerPipelineConnId          ouroboros.ConnectionId // connection that currently owns the queued header/blockfetch pipeline
 	pendingBlockfetchEvents       []BlockfetchEvent
 	activeBlockfetchStart         time.Time           // when RequestRange was issued (for latency measurement)
@@ -1639,6 +1647,13 @@ func (ls *LedgerState) Close() error {
 			)
 		}
 	}
+
+	// Drain blockfetch continuation workers before unsubscribing from the
+	// EventBus. A worker may be waiting for BatchDone from the request it
+	// issued; keeping the subscriber alive lets that request finish cleanly.
+	ls.blockfetchContinuationMu.Lock()
+	ls.blockfetchContinuationWG.Wait()
+	ls.blockfetchContinuationMu.Unlock()
 
 	// Unsubscribe from event bus to stop receiving new events. Use
 	// UnsubscribeAndWait, not Unsubscribe: several of these handlers read

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -669,7 +669,14 @@ type LedgerState struct {
 	chainsyncBlockfetchReadyChan  chan struct{}
 	activeBlockfetchConnId        ouroboros.ConnectionId // connection used for current blockfetch pipeline
 	shadowBlockfetchConnId        ouroboros.ConnectionId // shadow peer dispatched for parallel blockfetch
-	selectedBlockfetchConnId      ouroboros.ConnectionId // latest selected chainsync connection for the next batch
+	// blockfetchPrimaryRequestGeneration identifies the currently running
+	// primary request. A timeout may fire while the request is blocked in the
+	// protocol client; keeping its generation lets the timeout wait instead of
+	// issuing a duplicate request on the same batch.
+	blockfetchRequestGeneration        uint64
+	blockfetchPrimaryRequestGeneration uint64
+	blockfetchShadowRequestsInFlight   map[string]struct{}
+	selectedBlockfetchConnId           ouroboros.ConnectionId // latest selected chainsync connection for the next batch
 	// blockfetchContinuationPending prevents a chainsync handler from starting
 	// a competing batch in the short interval after the blockfetch subscriber
 	// schedules its next request on a worker. The worker must run outside the

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1559,9 +1559,9 @@ var (
 	CloseDBWorkerPoolShutdownTimeout = 15 * time.Second
 	// A Leios block-processing transaction can include a large endorser
 	// closure and legitimately outlive the short blockfetch waits. Keep this
-	// within Node's default 30-second shutdown budget, but long enough to avoid
-	// closing storage while that transaction is still using it.
-	CloseProcessBlocksDrainTimeout = 30 * time.Second
+	// below Node's default 30-second shutdown budget so the later ledger and
+	// database cleanup stages retain time to finish if processing is stuck.
+	CloseProcessBlocksDrainTimeout = 20 * time.Second
 	CloseBlockPipelineDrainTimeout = 10 * time.Second
 	CloseBlockfetchDrainTimeout    = 10 * time.Second
 )

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1557,9 +1557,13 @@ func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 var (
 	CloseRollbackDrainTimeout        = 10 * time.Second
 	CloseDBWorkerPoolShutdownTimeout = 15 * time.Second
-	CloseProcessBlocksDrainTimeout   = 10 * time.Second
-	CloseBlockPipelineDrainTimeout   = 10 * time.Second
-	CloseBlockfetchDrainTimeout      = 10 * time.Second
+	// A Leios block-processing transaction can include a large endorser
+	// closure and legitimately outlive the short blockfetch waits. Keep this
+	// within Node's default 30-second shutdown budget, but long enough to avoid
+	// closing storage while that transaction is still using it.
+	CloseProcessBlocksDrainTimeout = 30 * time.Second
+	CloseBlockPipelineDrainTimeout = 10 * time.Second
+	CloseBlockfetchDrainTimeout    = 10 * time.Second
 )
 
 func (ls *LedgerState) Close() error {
@@ -1600,6 +1604,21 @@ func (ls *LedgerState) Close() error {
 		ls.Scheduler.Stop()
 	}
 
+	// Stop the decode pipeline at the same time as the block-processing
+	// goroutine. decodeReadChainBatch drains the pipeline's Results channel
+	// without a context select once a batch has been submitted; waiting for
+	// ledgerProcessBlocks before stopping the pipeline can therefore deadlock
+	// shutdown until CloseProcessBlocksDrainTimeout expires. Stop cancels
+	// Submit calls and closes Results, which releases that drain so the
+	// block-processing goroutine can exit normally.
+	var blockPipelineStopDone chan error
+	if ls.blockPipeline != nil {
+		blockPipelineStopDone = make(chan error, 1)
+		go func() {
+			blockPipelineStopDone <- ls.blockPipeline.Stop()
+		}()
+	}
+
 	// Stop the normal chainsync-driven block-processing pipeline next, for
 	// the identical reason as Scheduler.Stop above: ledgerProcessBlocks
 	// writes blocks to ls.chain/the database (via dbWorkerPool below), and
@@ -1637,20 +1656,16 @@ func (ls *LedgerState) Close() error {
 		}
 	}
 
-	// Stop the block-decode pipeline (if configured), now that its only
-	// submitter -- the goroutine just drained above -- has exited. Bounded
-	// for the same reason as the wait above: a stuck pipeline must not hang
-	// Close forever, but a timeout here is not silently treated as success,
-	// since it means pipeline worker goroutines may still be running when
-	// Close returns.
-	if ls.blockPipeline != nil {
-		pipelineStopDone := make(chan struct{})
-		go func() {
-			_ = ls.blockPipeline.Stop()
-			close(pipelineStopDone)
-		}()
+	// Wait for the decode pipeline after its block-processing consumer has
+	// drained. Stop was started above so it could release a consumer blocked
+	// waiting for Results; this wait still bounds pipeline teardown and
+	// surfaces a failure to the caller.
+	if blockPipelineStopDone != nil {
 		select {
-		case <-pipelineStopDone:
+		case stopErr := <-blockPipelineStopDone:
+			if stopErr != nil {
+				err = errors.Join(err, fmt.Errorf("block-decode pipeline shutdown: %w", stopErr))
+			}
 		case <-time.After(CloseBlockPipelineDrainTimeout):
 			err = errors.Join(
 				err,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -673,10 +673,13 @@ type LedgerState struct {
 	// primary request. A timeout may fire while the request is blocked in the
 	// protocol client; keeping its generation lets the timeout wait instead of
 	// issuing a duplicate request on the same batch.
-	blockfetchRequestGeneration        uint64
-	blockfetchPrimaryRequestGeneration uint64
-	blockfetchShadowRequestsInFlight   map[string]struct{}
-	selectedBlockfetchConnId           ouroboros.ConnectionId // latest selected chainsync connection for the next batch
+	blockfetchRequestGeneration         uint64
+	blockfetchPrimaryRequestGeneration  uint64
+	blockfetchRequestsInFlight          map[string]chan struct{}
+	blockfetchShadowRequestsInFlight    map[string]struct{}
+	blockfetchInFlightTimeoutGeneration uint64
+	blockfetchInFlightTimeoutCount      uint8
+	selectedBlockfetchConnId            ouroboros.ConnectionId // latest selected chainsync connection for the next batch
 	// blockfetchContinuationPending prevents a chainsync handler from starting
 	// a competing batch in the short interval after the blockfetch subscriber
 	// schedules its next request on a worker. The worker must run outside the
@@ -1542,9 +1545,9 @@ func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 	return ls.db.GetDatum(hash, nil)
 }
 
-// CloseRollbackDrainTimeout, CloseDBWorkerPoolShutdownTimeout, and
-// CloseProcessBlocksDrainTimeout bound the corresponding waits in Close()
-// below. Exported (not local consts) so tests — including cross-package
+// CloseRollbackDrainTimeout, CloseDBWorkerPoolShutdownTimeout,
+// CloseProcessBlocksDrainTimeout, and CloseBlockfetchDrainTimeout bound the
+// corresponding waits in Close() below. Exported (not local consts) so tests — including cross-package
 // node-level tests exercising how a caller reacts to Close failing to
 // confirm drain — can shrink them instead of running real multi-second
 // timeouts.
@@ -1553,6 +1556,7 @@ var (
 	CloseDBWorkerPoolShutdownTimeout = 15 * time.Second
 	CloseProcessBlocksDrainTimeout   = 10 * time.Second
 	CloseBlockPipelineDrainTimeout   = 10 * time.Second
+	CloseBlockfetchDrainTimeout      = 10 * time.Second
 )
 
 func (ls *LedgerState) Close() error {
@@ -1655,12 +1659,37 @@ func (ls *LedgerState) Close() error {
 		}
 	}
 
-	// Drain blockfetch continuation workers before unsubscribing from the
-	// EventBus. A worker may be waiting for BatchDone from the request it
-	// issued; keeping the subscriber alive lets that request finish cleanly.
+	// Synchronize with continuation scheduling before waiting. Close() marks
+	// the ledger closed above; startQueuedBlockfetchFromEventLocked checks that
+	// flag both before and after taking this mutex, so no worker can be added
+	// after this synchronization point. Do not hold the mutex across Wait: the
+	// blockfetch subscriber may need it while completing the request that lets a
+	// worker return.
 	ls.blockfetchContinuationMu.Lock()
-	ls.blockfetchContinuationWG.Wait()
+	continuationSchedulingClosed := ls.closed.Load()
 	ls.blockfetchContinuationMu.Unlock()
+	if !continuationSchedulingClosed {
+		err = errors.Join(
+			err,
+			errors.New("ledger closed state was cleared during continuation drain"),
+		)
+	}
+	blockfetchContinuationsDone := make(chan struct{})
+	go func() {
+		ls.blockfetchContinuationWG.Wait()
+		close(blockfetchContinuationsDone)
+	}()
+	select {
+	case <-blockfetchContinuationsDone:
+	case <-time.After(CloseBlockfetchDrainTimeout):
+		err = errors.Join(
+			err,
+			fmt.Errorf(
+				"timed out after %s waiting for blockfetch continuations to stop",
+				CloseBlockfetchDrainTimeout,
+			),
+		)
+	}
 
 	// Unsubscribe from event bus to stop receiving new events. Use
 	// UnsubscribeAndWait, not Unsubscribe: several of these handlers read

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4528,7 +4528,7 @@ func TestCloseWaitsForBlockProcessingPipelineToActuallyStop(t *testing.T) {
 // waits for the block-processing goroutine.
 func TestCloseStopsDecodePipelineBeforeWaitingForBlockProcessing(t *testing.T) {
 	origTimeout := CloseProcessBlocksDrainTimeout
-	CloseProcessBlocksDrainTimeout = 50 * time.Millisecond
+	CloseProcessBlocksDrainTimeout = time.Second
 	t.Cleanup(func() { CloseProcessBlocksDrainTimeout = origTimeout })
 
 	ls := &LedgerState{

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -53,6 +53,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/pipeline"
 )
 
 func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
@@ -4518,4 +4519,34 @@ func TestCloseWaitsForBlockProcessingPipelineToActuallyStop(t *testing.T) {
 	default:
 		t.Fatal("Close returned without processCtx actually being cancelled")
 	}
+}
+
+// TestCloseStopsDecodePipelineBeforeWaitingForBlockProcessing covers the
+// shutdown ordering required when block processing is draining the decode
+// pipeline's Results channel. That drain has no context select after a batch
+// is submitted, so stopping the pipeline must close Results before Close
+// waits for the block-processing goroutine.
+func TestCloseStopsDecodePipelineBeforeWaitingForBlockProcessing(t *testing.T) {
+	origTimeout := CloseProcessBlocksDrainTimeout
+	CloseProcessBlocksDrainTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { CloseProcessBlocksDrainTimeout = origTimeout })
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+		blockPipeline: pipeline.NewBlockPipeline(
+			pipeline.WithDecodeWorkers(1),
+		),
+	}
+	require.NoError(t, ls.blockPipeline.Start(t.Context()))
+	ls.processBlocksCancel = func() {}
+	ls.processBlocksWG.Add(1)
+	go func() {
+		defer ls.processBlocksWG.Done()
+		for range ls.blockPipeline.Results() {
+		}
+	}()
+
+	require.NoError(t, ls.Close())
 }

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -2342,7 +2342,6 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 
 	// Start the epoch rollover goroutine
 	wg.Go(func() {
-
 		// Capture snapshot
 		ls.RLock()
 		snapshotEra := ls.currentEra
@@ -2388,7 +2387,6 @@ func TestEpochRollover_ConcurrentReaders(t *testing.T) {
 	// Start multiple reader goroutines that try to read during the transaction
 	for range 5 {
 		wg.Go(func() {
-
 			// Wait for transaction to start
 			<-txnStarted
 
@@ -4409,6 +4407,27 @@ func TestCloseReturnsErrorWhenBlockProcessingPipelineDoesNotStopInTime(
 	err := ls.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "block-processing pipeline")
+}
+
+// TestCloseReturnsErrorWhenBlockfetchContinuationsDoNotDrainInTime verifies
+// that Close does not hold the continuation scheduling mutex while waiting
+// for a worker that may need the blockfetch subscriber to finish its request.
+func TestCloseReturnsErrorWhenBlockfetchContinuationsDoNotDrainInTime(t *testing.T) {
+	origTimeout := CloseBlockfetchDrainTimeout
+	CloseBlockfetchDrainTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { CloseBlockfetchDrainTimeout = origTimeout })
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.blockfetchContinuationWG.Add(1)
+	t.Cleanup(ls.blockfetchContinuationWG.Done)
+
+	err := ls.Close()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blockfetch continuations")
 }
 
 // TestCloseWaitsForBlockProcessingPipelineToActuallyStop is the positive

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4410,11 +4410,25 @@ func TestCloseReturnsErrorWhenBlockProcessingPipelineDoesNotStopInTime(
 }
 
 // TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting verifies that
-// Close releases the continuation scheduling mutex before waiting for a worker
-// that needs the same mutex to finish.
+// Close releases the continuation scheduling mutex before waiting for the
+// continuation WaitGroup. A worker may need that mutex to complete the request
+// that lets it return, so holding it across the wait deadlocks shutdown.
+//
+// The invariant is asserted directly -- the mutex must be acquirable *while*
+// Close is parked in the wait -- rather than by having a queued worker finish,
+// which passes whether or not Close ever held the mutex.
+//
+// Sequencing: the test holds the mutex before starting Close, so Close parks in
+// Lock() and is the sole waiter. By the time the test releases it, Close has
+// been queued for longer than the 1ms that puts sync.Mutex into starvation
+// mode, so the unlock hands off directly to Close and a barging TryLock from
+// this goroutine cannot jump ahead of it. Close therefore holds the mutex
+// before the polling below begins.
 func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 	origTimeout := CloseBlockfetchDrainTimeout
-	CloseBlockfetchDrainTimeout = 50 * time.Millisecond
+	// Generous: the worker is released only after the assertion below, so this
+	// bounds the failure mode rather than the happy path.
+	CloseBlockfetchDrainTimeout = 30 * time.Second
 	t.Cleanup(func() { CloseBlockfetchDrainTimeout = origTimeout })
 
 	ls := &LedgerState{
@@ -4422,28 +4436,19 @@ func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
-	ls.blockfetchContinuationMu.Lock()
-	released := false
-	t.Cleanup(func() {
-		if !released {
-			ls.blockfetchContinuationMu.Unlock()
-		}
-	})
-	workerStarted := make(chan struct{})
-	workerDone := make(chan struct{})
-	ls.blockfetchContinuationWG.Go(func() {
-		close(workerStarted)
-		ls.blockfetchContinuationMu.Lock()
-		ls.blockfetchContinuationMu.Unlock()
-		close(workerDone)
-	})
-	testutil.RequireReceive(
-		t,
-		workerStarted,
-		time.Second,
-		"blockfetch continuation worker did not start",
-	)
 
+	// A continuation worker that stays registered until the test releases it,
+	// so Close cannot leave its wait while the assertion runs. It deliberately
+	// does not touch the mutex: the point is what Close holds, not what the
+	// worker can acquire.
+	proceed := make(chan struct{})
+	ls.blockfetchContinuationWG.Add(1)
+	go func() {
+		defer ls.blockfetchContinuationWG.Done()
+		<-proceed
+	}()
+
+	ls.blockfetchContinuationMu.Lock()
 	closeDone := make(chan error, 1)
 	go func() { closeDone <- ls.Close() }()
 	require.Eventually(
@@ -4451,24 +4456,38 @@ func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 		ls.closed.Load,
 		time.Second,
 		time.Millisecond,
-		"Close did not begin before releasing continuation mutex",
+		"Close did not begin before releasing the continuation mutex",
 	)
 	ls.blockfetchContinuationMu.Unlock()
-	released = true
 
+	// Close is now past the scheduling synchronization point and parked waiting
+	// for the worker. The mutex must be free: if Close held it across the wait,
+	// TryLock fails for the whole window and this assertion fails, where the
+	// previous formulation of this test passed.
+	require.Eventually(
+		t,
+		func() bool {
+			if !ls.blockfetchContinuationMu.TryLock() {
+				return false
+			}
+			ls.blockfetchContinuationMu.Unlock()
+			return true
+		},
+		time.Second,
+		time.Millisecond,
+		"Close held blockfetchContinuationMu while waiting for continuations",
+	)
+
+	// Only now let the worker finish, proving Close was genuinely still waiting
+	// throughout the assertion above.
+	close(proceed)
 	err := testutil.RequireReceive(
 		t,
 		closeDone,
-		time.Second,
+		5*time.Second,
 		"Close did not finish after the continuation worker drained",
 	)
 	require.NoError(t, err)
-	testutil.RequireReceive(
-		t,
-		workerDone,
-		time.Second,
-		"blockfetch continuation worker did not drain",
-	)
 }
 
 // TestCloseWaitsForBlockProcessingPipelineToActuallyStop is the positive

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4417,13 +4417,6 @@ func TestCloseReturnsErrorWhenBlockProcessingPipelineDoesNotStopInTime(
 // The invariant is asserted directly -- the mutex must be acquirable *while*
 // Close is parked in the wait -- rather than by having a queued worker finish,
 // which passes whether or not Close ever held the mutex.
-//
-// Sequencing: the test holds the mutex before starting Close, so Close parks in
-// Lock() and is the sole waiter. By the time the test releases it, Close has
-// been queued for longer than the 1ms that puts sync.Mutex into starvation
-// mode, so the unlock hands off directly to Close and a barging TryLock from
-// this goroutine cannot jump ahead of it. Close therefore holds the mutex
-// before the polling below begins.
 func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 	origTimeout := CloseBlockfetchDrainTimeout
 	// Generous: the worker is released only after the assertion below, so this
@@ -4435,6 +4428,10 @@ func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 		config: LedgerStateConfig{
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
+	}
+	schedulingDone := make(chan struct{})
+	ls.blockfetchContinuationSchedulingHook = func() {
+		close(schedulingDone)
 	}
 
 	// A continuation worker that stays registered until the test releases it,
@@ -4460,23 +4457,20 @@ func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 	)
 	ls.blockfetchContinuationMu.Unlock()
 
-	// Close is now past the scheduling synchronization point and parked waiting
-	// for the worker. The mutex must be free: if Close held it across the wait,
-	// TryLock fails for the whole window and this assertion fails, where the
-	// previous formulation of this test passed.
-	require.Eventually(
+	// The hook fires only after Close has completed the scheduling lock/unlock
+	// pair. The worker remains registered, so Close must still be in its wait.
+	testutil.RequireReceive(
 		t,
-		func() bool {
-			if !ls.blockfetchContinuationMu.TryLock() {
-				return false
-			}
-			ls.blockfetchContinuationMu.Unlock()
-			return true
-		},
+		schedulingDone,
 		time.Second,
-		time.Millisecond,
+		"Close did not release blockfetchContinuationMu before waiting",
+	)
+	require.True(
+		t,
+		ls.blockfetchContinuationMu.TryLock(),
 		"Close held blockfetchContinuationMu while waiting for continuations",
 	)
+	ls.blockfetchContinuationMu.Unlock()
 
 	// Only now let the worker finish, proving Close was genuinely still waiting
 	// throughout the assertion above.

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4409,12 +4409,12 @@ func TestCloseReturnsErrorWhenBlockProcessingPipelineDoesNotStopInTime(
 	assert.Contains(t, err.Error(), "block-processing pipeline")
 }
 
-// TestCloseReturnsErrorWhenBlockfetchContinuationsDoNotDrainInTime verifies
-// that Close does not hold the continuation scheduling mutex while waiting
-// for a worker that may need the blockfetch subscriber to finish its request.
-func TestCloseReturnsErrorWhenBlockfetchContinuationsDoNotDrainInTime(t *testing.T) {
+// TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting verifies that
+// Close releases the continuation scheduling mutex before waiting for a worker
+// that needs the same mutex to finish.
+func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 	origTimeout := CloseBlockfetchDrainTimeout
-	CloseBlockfetchDrainTimeout = 10 * time.Millisecond
+	CloseBlockfetchDrainTimeout = 50 * time.Millisecond
 	t.Cleanup(func() { CloseBlockfetchDrainTimeout = origTimeout })
 
 	ls := &LedgerState{
@@ -4422,12 +4422,53 @@ func TestCloseReturnsErrorWhenBlockfetchContinuationsDoNotDrainInTime(t *testing
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
-	ls.blockfetchContinuationWG.Add(1)
-	t.Cleanup(ls.blockfetchContinuationWG.Done)
+	ls.blockfetchContinuationMu.Lock()
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			ls.blockfetchContinuationMu.Unlock()
+		}
+	})
+	workerStarted := make(chan struct{})
+	workerDone := make(chan struct{})
+	ls.blockfetchContinuationWG.Go(func() {
+		close(workerStarted)
+		ls.blockfetchContinuationMu.Lock()
+		ls.blockfetchContinuationMu.Unlock()
+		close(workerDone)
+	})
+	testutil.RequireReceive(
+		t,
+		workerStarted,
+		time.Second,
+		"blockfetch continuation worker did not start",
+	)
 
-	err := ls.Close()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "blockfetch continuations")
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- ls.Close() }()
+	require.Eventually(
+		t,
+		ls.closed.Load,
+		time.Second,
+		time.Millisecond,
+		"Close did not begin before releasing continuation mutex",
+	)
+	ls.blockfetchContinuationMu.Unlock()
+	released = true
+
+	err := testutil.RequireReceive(
+		t,
+		closeDone,
+		time.Second,
+		"Close did not finish after the continuation worker drained",
+	)
+	require.NoError(t, err)
+	testutil.RequireReceive(
+		t,
+		workerDone,
+		time.Second,
+		"blockfetch continuation worker did not drain",
+	)
 }
 
 // TestCloseWaitsForBlockProcessingPipelineToActuallyStop is the positive

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -227,22 +227,27 @@ func (n *Node) shutdown() error {
 		}
 	}
 
-	// Close the EventBus before draining network connections. Since v0.68,
-	// event delivery applies backpressure instead of dropping events. A
-	// chainsync callback can therefore be blocked waiting for a full ledger
-	// subscriber while ConnectionManager.Stop waits for that callback to
-	// finish. Closing the terminal bus here releases those blocked publishers
-	// before connection teardown begins. The node context is already cancelled
-	// and mempool has stopped, so no component should produce useful work after
-	// this point; later component teardown treats an already-closed bus as
-	// harmless and idempotent.
+	// Close the EventBus while draining connections. Since v0.68, event
+	// delivery applies backpressure instead of dropping events. A chainsync
+	// callback can therefore be blocked waiting for a full ledger subscriber,
+	// while a blockfetch continuation can wait for a BatchDone event that only
+	// connection shutdown releases. Run both operations together so neither
+	// side waits indefinitely for the other.
+	var connManagerDone chan error
+	if n.connManager != nil {
+		connManagerDone = make(chan error, 1)
+		go func() {
+			connManagerDone <- n.connManager.Stop(ctx)
+		}()
+	}
+
 	if n.eventBus != nil {
-		n.config.logger.Info("closing event bus before connection drain")
+		n.config.logger.Info("closing event bus while draining connections")
 		n.eventBus.Close()
 	}
 
-	if n.connManager != nil {
-		if stopErr := n.connManager.Stop(ctx); stopErr != nil {
+	if connManagerDone != nil {
+		if stopErr := <-connManagerDone; stopErr != nil {
 			err = errors.Join(
 				err,
 				fmt.Errorf("connection manager shutdown: %w", stopErr),


### PR DESCRIPTION
## Problem

From-genesis sync can wedge when a queued BlockFetch request waits in gouroboros `acquireBusy` while `chainsyncBlockfetchMutex` is held. The previous request cannot finish publishing `ledger.blockfetch` because its ledger subscriber is waiting for that mutex.

## Changes

- Reserve the batch and arm its timeout under the ledger mutex, then release it around primary and shadow range requests.
- Ignore stale request results when a callback completed or replaced the batch.
- Add a focused lock-cycle regression test and document the lock-order invariant.

## Validation

- `go test ./ledger -count=1`
- focused `go test -race ./ledger`
- `go vet ./ledger`
- `go test ./ouroboros -count=1`

The regression test fails on exact `8ee9f2af` and passes with this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ledger blockfetch stalls and shutdown wedges. Previously a range request could wait in acquireBusy while `chainsyncBlockfetchMutex` was held and the subscriber was backpressured; continuations ran inside the subscriber; and terminal event-bus close replayed queued callbacks into closing components. Now requests run outside the mutex, continuations run on workers, and terminal `EventBus.Close` discards queued in‑memory events after in‑flight handlers finish.

- Reserve the batch and arm its timeout under `chainsyncBlockfetchMutex`, then unlock around primary and shadow `GetBlockRange`. Track request generations and in‑flight requests, ignore stale results if the batch changed, wait for prior requests before reusing a connection, and warn after repeated in‑flight watchdog expirations.
- Run batch continuations on workers guarded by `blockfetchContinuationPending`. `Close` waits for them with `CloseBlockfetchDrainTimeout` and never holds the continuation scheduling mutex while waiting.
- Terminal `EventBus.Close` discards queued subscriber events; ordinary `Unsubscribe`/`UnsubscribeAndWait` preserve queues. Node shutdown closes the event bus concurrently with `ConnectionManager.Stop` to break cross‑component waits.
- Shutdown hardening: stop the decode pipeline before waiting for block processing and set `CloseProcessBlocksDrainTimeout` to 20s. Docs and tests updated to cover sequencing and subscriber semantics.

<sup>Written for commit 4ac97c9cedcf20d9e779635cb30acde8a4fb1692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block synchronization reliability during concurrent requests and state changes.
  * Prevented stale responses from disrupting newer blockfetch operations.
  * Avoided duplicate requests during timeouts and improved recovery from empty or failed batches.
  * Improved connection reuse and asynchronous processing to prevent stalls.
  * Ensured shutdown drains in-progress work cleanly and reports delayed completion.

* **Tests**
  * Added regression coverage for request locking, connection reuse, asynchronous processing, retries, failures, and batch recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->