### PR TITLE
fix(ouroboros): share block/header decode cache across peer connections

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2284,6 +2284,51 @@ The `Ouroboros` struct (`ouroboros/ouroboros.go`) manages all protocol handlers:
     -------------------------------------------
 ```
 
+### Shared Block/Header Decode Cache
+
+Several peer connections routinely deliver byte-identical block or header
+bytes within a short window of each other (multiple peers relaying the same
+freshly-produced block), so `Ouroboros` holds two shared, content-hash-keyed
+caches (`blockDecodeCache`, `headerDecodeCache`, `ouroboros/decode_cache.go`)
+that `blockfetchClientBlockRaw` and `chainsyncClientRollForwardRaw` check
+before calling `decodeBlockfetchBlock`/`decodeChainsyncHeader`. The key is a
+hash of `(blockType, raw bytes)`, not the chain point: two connections
+delivering identical bytes always share one decode and one cache entry, while
+two connections delivering *different* bytes for what is nominally "the same
+block" (corruption, tampering, a buggy peer) hash to different keys and are
+decoded, cached, and reported on completely independently, so a bad delivery
+from one peer can never contaminate the answer another peer's good delivery
+produces.
+
+Concurrent callers submitting the same key at nearly the same instant share
+one decode rather than each doing the work: the first caller claims the
+key and runs the decode with the cache lock released (so concurrent decodes
+for different keys never serialize against each other); every other caller
+registers a wait channel and is woken with the identical result once the
+decode finishes, whether it succeeded or failed. A failed decode is cached
+the same as a successful one, bounded by the same TTL/size eviction — since
+decoding is a pure function of its input bytes, a cached failure is simply a
+correct remembered fact ("these bytes do not decode"), not a permanent
+poison. This mirrors the existing `leiosEndorserBlocks` cache's bounded,
+waiter-channel design (see Leios CertRB Serving below), applied to ordinary
+block/header decoding rather than Leios EB closures.
+
+A decode function that panics (adversarial/malformed peer bytes could in
+principle trigger this) does not strand the key: `getOrDecode` recovers the
+panic just long enough to record it as an ordinary cached failure and wake
+every waiter, then re-raises it, so the decoding goroutine's own
+crash-or-recover behavior is unchanged but no other connection is left
+permanently blocked on that key, and a later identical delivery fails fast
+from cache instead of panicking again.
+
+A waiting caller's decode outcome is delivered directly through its wait
+channel rather than by re-reading the shared entry map after waking: the
+entry it is waiting on can be evicted by unrelated churn (many other keys
+being inserted, past `decodeCacheMaxEntries`) in the window between "the
+decode finishes" and "a descheduled waiter resumes," so re-reading the map
+at that point could silently hand back a zero-value/nil "success" instead of
+the real outcome.
+
 ### Connection Management
 
 The `ConnectionManager` (`connmanager/connection_manager.go`) handles connection lifecycle:

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -135,19 +135,42 @@ func (o *Ouroboros) decodeBlockfetchBlock(
 }
 
 // blockfetchClientBlockRaw decodes the raw fetched block (via
-// decodeBlockfetchBlock) and forwards the decoded block to the shared block
-// handler.
+// decodeBlockfetchBlock, through the shared decode cache) and forwards the
+// decoded block to the shared block handler.
+//
+// Multiple connections routinely deliver byte-identical block bytes around
+// the same time (several peers relaying the same freshly-produced block), so
+// the decode is keyed by content hash and shared across connections: the
+// first connection to submit a given block's bytes decodes it, and every
+// other connection submitting the identical bytes -- concurrently or
+// afterward -- reuses that result instead of redoing the parse. See #489.
 func (o *Ouroboros) blockfetchClientBlockRaw(
 	ctx blockfetch.CallbackContext,
 	blockType uint,
 	blockData []byte,
 ) error {
-	block, err := o.decodeBlockfetchBlock(blockType, blockData)
+	key := hashDecodeInput(blockType, blockData)
+	block, err, decoded := o.blockDecodeCache.getOrDecode(
+		key,
+		func() (gledger.Block, error) {
+			return o.decodeBlockfetchBlock(blockType, blockData)
+		},
+	)
+	o.recordBlockDecodeCacheOutcome(decoded)
 	if err != nil {
 		return fmt.Errorf(
 			"decode block-fetch block (block type %d): %w",
 			blockType,
 			err,
+		)
+	}
+	if block == nil {
+		// decodeCache's contract is (nil value, non-nil err) on failure, but
+		// that is a convention on decodeFn, not something the generic cache
+		// itself enforces -- guard explicitly rather than trust it silently.
+		return fmt.Errorf(
+			"decode block-fetch block (block type %d): decoded nil block with no error",
+			blockType,
 		)
 	}
 	return o.blockfetchClientBlock(ctx, blockType, block)

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -150,11 +150,13 @@ func (o *Ouroboros) blockfetchClientBlockRaw(
 	blockData []byte,
 ) error {
 	key := hashDecodeInput(blockType, blockData)
-	block, err, decoded := o.blockDecodeCache.getOrDecode(
+	block, err, decoded := decodeWithPanicSafeMetrics(
+		o.blockDecodeCache,
 		key,
 		func() (gledger.Block, error) {
 			return o.decodeBlockfetchBlock(blockType, blockData)
 		},
+		func() { o.recordBlockDecodeCacheOutcome(true) },
 	)
 	o.recordBlockDecodeCacheOutcome(decoded)
 	if err != nil {

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -150,15 +150,14 @@ func (o *Ouroboros) blockfetchClientBlockRaw(
 	blockData []byte,
 ) error {
 	key := hashDecodeInput(blockType, blockData)
-	block, err, decoded := decodeWithPanicSafeMetrics(
+	block, err := decodeWithPanicSafeMetrics(
 		o.blockDecodeCache,
 		key,
 		func() (gledger.Block, error) {
 			return o.decodeBlockfetchBlock(blockType, blockData)
 		},
-		func() { o.recordBlockDecodeCacheOutcome(true) },
+		o.recordBlockDecodeCacheOutcome,
 	)
-	o.recordBlockDecodeCacheOutcome(decoded)
 	if err != nil {
 		return fmt.Errorf(
 			"decode block-fetch block (block type %d): %w",

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1447,22 +1447,44 @@ func (o *Ouroboros) decodeChainsyncHeader(
 }
 
 // chainsyncClientRollForwardRaw decodes the raw header itself (via
-// decodeChainsyncHeader) and forwards the decoded header to the shared
-// RollForward handler. dingo takes the raw callback so it can apply the
-// Musashi-scoped Conway-with-Leios-header decode; using the decoded callback
-// would let gouroboros' strict decode fail before dingo can intervene.
+// decodeChainsyncHeader, through the shared decode cache) and forwards the
+// decoded header to the shared RollForward handler. dingo takes the raw
+// callback so it can apply the Musashi-scoped Conway-with-Leios-header
+// decode; using the decoded callback would let gouroboros' strict decode fail
+// before dingo can intervene.
+//
+// Every chainsync-connected peer delivers a header for each new point at
+// roughly the same time, so -- like blockfetchClientBlockRaw -- the decode is
+// keyed by content hash and shared across connections instead of repeated
+// once per connection. See #489.
 func (o *Ouroboros) chainsyncClientRollForwardRaw(
 	ctx ochainsync.CallbackContext,
 	blockType uint,
 	blockData []byte,
 	tip ochainsync.Tip,
 ) error {
-	header, err := o.decodeChainsyncHeader(blockType, blockData)
+	key := hashDecodeInput(blockType, blockData)
+	header, err, decoded := o.headerDecodeCache.getOrDecode(
+		key,
+		func() (gledger.BlockHeader, error) {
+			return o.decodeChainsyncHeader(blockType, blockData)
+		},
+	)
+	o.recordHeaderDecodeCacheOutcome(decoded)
 	if err != nil {
 		return fmt.Errorf(
 			"decode chain-sync header (block type %d): %w",
 			blockType,
 			err,
+		)
+	}
+	if header == nil {
+		// decodeCache's contract is (nil value, non-nil err) on failure, but
+		// that is a convention on decodeFn, not something the generic cache
+		// itself enforces -- guard explicitly rather than trust it silently.
+		return fmt.Errorf(
+			"decode chain-sync header (block type %d): decoded nil header with no error",
+			blockType,
 		)
 	}
 	return o.chainsyncClientRollForward(ctx, blockType, header, tip)

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1464,15 +1464,14 @@ func (o *Ouroboros) chainsyncClientRollForwardRaw(
 	tip ochainsync.Tip,
 ) error {
 	key := hashDecodeInput(blockType, blockData)
-	header, err, decoded := decodeWithPanicSafeMetrics(
+	header, err := decodeWithPanicSafeMetrics(
 		o.headerDecodeCache,
 		key,
 		func() (gledger.BlockHeader, error) {
 			return o.decodeChainsyncHeader(blockType, blockData)
 		},
-		func() { o.recordHeaderDecodeCacheOutcome(true) },
+		o.recordHeaderDecodeCacheOutcome,
 	)
-	o.recordHeaderDecodeCacheOutcome(decoded)
 	if err != nil {
 		return fmt.Errorf(
 			"decode chain-sync header (block type %d): %w",

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1464,11 +1464,13 @@ func (o *Ouroboros) chainsyncClientRollForwardRaw(
 	tip ochainsync.Tip,
 ) error {
 	key := hashDecodeInput(blockType, blockData)
-	header, err, decoded := o.headerDecodeCache.getOrDecode(
+	header, err, decoded := decodeWithPanicSafeMetrics(
+		o.headerDecodeCache,
 		key,
 		func() (gledger.BlockHeader, error) {
 			return o.decodeChainsyncHeader(blockType, blockData)
 		},
+		func() { o.recordHeaderDecodeCacheOutcome(true) },
 	)
 	o.recordHeaderDecodeCacheOutcome(decoded)
 	if err != nil {

--- a/ouroboros/decode_cache.go
+++ b/ouroboros/decode_cache.go
@@ -143,8 +143,18 @@ func (c *decodeCache[T]) getOrDecode(
 ) (value T, err error, decoded bool) {
 	c.mu.Lock()
 	if entry, ok := c.entries[key]; ok {
-		c.mu.Unlock()
-		return entry.value, entry.err, false
+		if time.Since(entry.insertedAt) < decodeCacheTTL {
+			c.mu.Unlock()
+			return entry.value, entry.err, false
+		}
+		// Past its TTL: eviction is otherwise insertion-triggered (only
+		// evictLocked, called from finishDecode, ever prunes), so a hot key
+		// that keeps getting hit with no other key ever decoded again would
+		// otherwise never re-evaluate its own age and could be served
+		// indefinitely. Remove it here and fall through as a genuine miss,
+		// so the documented TTL holds on the read path too, not only when
+		// some unrelated key's insert happens to trigger a sweep.
+		c.removeLocked(key)
 	}
 	if waiters, claimed := c.inFlight[key]; claimed {
 		// Buffered so finishDecode's send never blocks on a waiter that
@@ -249,6 +259,28 @@ func (c *decodeCache[T]) finishDecode(key decodeCacheKey, value T, err error) {
 	result := decodeCacheResult[T]{value: value, err: err}
 	for _, ch := range waiters {
 		ch <- result
+	}
+}
+
+// removeLocked deletes key from both entries and order together, keeping
+// them in lockstep -- evictLocked assumes every order node has a matching
+// entries row and stops pruning entirely the first time that is not true
+// (see its "!ok" check), so any removal outside evictLocked's own
+// pop-from-front loop must remove from both sides, never just one.
+//
+// This is only ever reached from getOrDecode's TTL-on-lookup check, an
+// intentionally rare path (an expired hit resets that one key, not a
+// sweep), so the O(n) scan for key's position -- there is no per-entry
+// element pointer to remove in O(1), unlike evictLocked's own front-only
+// access -- is an acceptable cost bounded by decodeCacheMaxEntries. The
+// caller must hold mu.
+func (c *decodeCache[T]) removeLocked(key decodeCacheKey) {
+	delete(c.entries, key)
+	for e := c.order.Front(); e != nil; e = e.Next() {
+		if e.Value.(decodeCacheKey) == key { //nolint:forcetypeassert
+			c.order.Remove(e)
+			return
+		}
 	}
 }
 

--- a/ouroboros/decode_cache.go
+++ b/ouroboros/decode_cache.go
@@ -69,15 +69,10 @@ func hashDecodeInput(blockType uint, raw []byte) decodeCacheKey {
 // failure is simply a correct remembered fact ("these bytes do not decode"),
 // not a permanent poison -- it is bounded and evicted by the same TTL/size
 // rules as every other entry, same as a success.
-//
-// order holds this entry's *list.Element in the cache's insertion-order
-// list, so eviction can remove it in O(1) instead of re-deriving position
-// from insertedAt every time (see decodeCache.evictLocked).
 type decodeCacheEntry[T any] struct {
 	value      T
 	err        error
 	insertedAt time.Time
-	order      *list.Element
 }
 
 // decodeCacheResult carries a decode outcome directly to a waiting caller
@@ -195,20 +190,50 @@ func (c *decodeCache[T]) getOrDecode(
 	return value, err, true
 }
 
+// decodeWithPanicSafeMetrics wraps getOrDecode so a panicking decodeFn still
+// gets its hit/miss outcome recorded. getOrDecode's own panic recovery
+// re-raises after cleaning up the cache (see its doc comment), so this call
+// never returns normally on that path -- the caller's usual
+// "record based on the returned decoded bool" pattern never runs, and a
+// genuine decode attempt (a miss) that happened to panic would silently go
+// uncounted. recordMiss is invoked from a recover here, before the panic is
+// re-raised again, so it always sees exactly the same attempts a
+// non-panicking decodeFn would have reported via decoded=true.
+func decodeWithPanicSafeMetrics[T any](
+	cache *decodeCache[T],
+	key decodeCacheKey,
+	decodeFn func() (T, error),
+	recordMiss func(),
+) (value T, err error, decoded bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			recordMiss()
+			panic(r)
+		}
+	}()
+	return cache.getOrDecode(key, decodeFn)
+}
+
 // finishDecode records key's decode outcome, releases its in-flight claim,
 // and wakes every waiter with it. Shared by getOrDecode's normal-return path
 // and its panic-recovery path so both leave the cache in the same
 // consistent state -- a waiter never observes the difference between "the
 // leader's decodeFn returned an error" and "the leader's decodeFn panicked".
 func (c *decodeCache[T]) finishDecode(key decodeCacheKey, value T, err error) {
-	now := time.Now()
 	c.mu.Lock()
-	elem := c.order.PushBack(key)
+	// now is captured under the lock, not before it: two concurrent
+	// finishDecode calls (for two different keys) acquire the lock in some
+	// order that need not match the order in which they would have called
+	// time.Now() beforehand. order (the eviction FIFO) and insertedAt must
+	// agree on which entry is older, or evictLocked's TTL loop can stop at
+	// a front entry that looks fresh while a truly-older, later-positioned
+	// entry never gets checked.
+	now := time.Now()
+	c.order.PushBack(key)
 	c.entries[key] = decodeCacheEntry[T]{
 		value:      value,
 		err:        err,
 		insertedAt: now,
-		order:      elem,
 	}
 	waiters := c.inFlight[key]
 	delete(c.inFlight, key)

--- a/ouroboros/decode_cache.go
+++ b/ouroboros/decode_cache.go
@@ -1,0 +1,322 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"container/list"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// decodeCacheMaxEntries and decodeCacheTTL bound the shared block/header
+// decode caches the same way leiosEndorserBlockCacheMaxEntries/TTL bound the
+// Leios EB cache: a two-stage prune (age first, then size) keeps memory
+// bounded on a long-running node. Decoding is a pure function of (blockType,
+// bytes), so unlike the Leios cache TTL is not a freshness concern here --
+// it exists purely to bound memory, not to invalidate stale-but-still-valid
+// answers.
+const (
+	decodeCacheMaxEntries = 1024
+	decodeCacheTTL        = 2 * time.Minute
+)
+
+// decodeCacheKey identifies raw decode input by content hash (block type plus
+// raw bytes), not by chain point. This is the key correctness property: two
+// connections delivering byte-identical data always share one decode and one
+// cache entry, while two connections delivering different bytes for what is
+// nominally "the same block" (corruption, tampering, a buggy peer) hash to
+// different keys and are decoded, cached, and reported on completely
+// independently. A bad delivery from one peer can therefore never poison the
+// answer another peer's good delivery produces. See dingo #489.
+type decodeCacheKey [sha256.Size]byte
+
+// hashDecodeInput computes the cache key for a decode input. blockType is
+// mixed in ahead of the raw bytes so a (rare, currently theoretical) same-byte
+// encoding under two different block types cannot collide.
+func hashDecodeInput(blockType uint, raw []byte) decodeCacheKey {
+	h := sha256.New()
+	var typeBuf [8]byte
+	binary.LittleEndian.PutUint64(typeBuf[:], uint64(blockType))
+	h.Write(typeBuf[:])
+	h.Write(raw)
+	var key decodeCacheKey
+	copy(key[:], h.Sum(nil))
+	return key
+}
+
+// decodeCacheEntry holds the outcome of decoding one input. Exactly one of
+// value/err is meaningful, matching the wrapped decode function's own
+// (value, error) contract. Failed decodes are cached the same as successful
+// ones: decoding is deterministic given fixed input bytes, so a cached
+// failure is simply a correct remembered fact ("these bytes do not decode"),
+// not a permanent poison -- it is bounded and evicted by the same TTL/size
+// rules as every other entry, same as a success.
+//
+// order holds this entry's *list.Element in the cache's insertion-order
+// list, so eviction can remove it in O(1) instead of re-deriving position
+// from insertedAt every time (see decodeCache.evictLocked).
+type decodeCacheEntry[T any] struct {
+	value      T
+	err        error
+	insertedAt time.Time
+	order      *list.Element
+}
+
+// decodeCacheResult carries a decode outcome directly to a waiting caller
+// through its wait channel, instead of the waiter re-reading c.entries after
+// waking. An entry can be evicted by unrelated churn (many other keys being
+// inserted) in the window between "the leader signals its waiters" and "a
+// descheduled waiter resumes and re-acquires the lock" -- delivering the
+// result inline means a waiter always receives the actual outcome it waited
+// for, never a zero-value/"miss" masquerading as a successful empty decode
+// because its entry happened to age out of the map in that window.
+type decodeCacheResult[T any] struct {
+	value T
+	err   error
+}
+
+// decodeCache is a shared, bounded cache of decode outcomes keyed by content
+// hash, with a waiter mechanism so concurrent callers submitting identical
+// bytes at nearly the same instant share one decode instead of each doing the
+// work independently. One instance covers one decode "kind" (blocks or
+// headers); Ouroboros holds one of each. See dingo #489.
+//
+// Eviction is insertion-order FIFO via order, not a sort: entries are never
+// mutated or re-inserted once written (a given key's decode outcome is
+// immutable), so the oldest-inserted entry is always both the correct
+// TTL-expiry candidate and the correct size-cap eviction candidate -- there
+// is no "recently used" concept to track separately. An earlier version
+// re-sorted the entire map by insertedAt on every insert once the cache was
+// at capacity; benchmarking a sustained no-duplicates workload (every insert
+// a genuine miss, the realistic case when peers are not delivering
+// duplicates) showed that made decoding through the cache 7-80x slower than
+// not caching at all. Keeping an explicit insertion-order list turns
+// eviction into an O(1)-amortized pop from the front instead.
+type decodeCache[T any] struct {
+	mu       sync.Mutex
+	entries  map[decodeCacheKey]decodeCacheEntry[T]
+	order    *list.List // decodeCacheKey values, oldest-inserted at Front()
+	inFlight map[decodeCacheKey][]chan decodeCacheResult[T]
+}
+
+func newDecodeCache[T any]() *decodeCache[T] {
+	return &decodeCache[T]{
+		entries:  make(map[decodeCacheKey]decodeCacheEntry[T]),
+		order:    list.New(),
+		inFlight: make(map[decodeCacheKey][]chan decodeCacheResult[T]),
+	}
+}
+
+// getOrDecode returns the decoded value for key, running decodeFn at most
+// once per key no matter how many goroutines call concurrently for the same
+// key. The returned decoded flag is true only for the caller whose goroutine
+// actually executed decodeFn (a genuine cache miss); every other caller --
+// whether served from an already-populated entry or woken after waiting on
+// this call's in-flight attempt -- gets decoded=false. Callers use that flag
+// only for hit/miss metrics; the returned (value, err) is identical for every
+// caller regardless of how it was obtained.
+//
+// decodeFn is never called while mu is held: the lock only ever guards map
+// bookkeeping, never the decode itself, so concurrent decodes for different
+// keys never serialize against each other.
+//
+// A decodeFn that panics does not strand this key: the panic is recovered
+// long enough to record it as a normal cached failure and release every
+// waiter, then re-raised so the calling goroutine's own crash-or-recover
+// behavior is unchanged from before this cache existed. See finishDecode.
+func (c *decodeCache[T]) getOrDecode(
+	key decodeCacheKey,
+	decodeFn func() (T, error),
+) (value T, err error, decoded bool) {
+	c.mu.Lock()
+	if entry, ok := c.entries[key]; ok {
+		c.mu.Unlock()
+		return entry.value, entry.err, false
+	}
+	if waiters, claimed := c.inFlight[key]; claimed {
+		// Buffered so finishDecode's send never blocks on a waiter that
+		// hasn't reached the receive yet.
+		ch := make(chan decodeCacheResult[T], 1)
+		c.inFlight[key] = append(waiters, ch)
+		c.mu.Unlock()
+		result := <-ch
+		return result.value, result.err, false
+	}
+	// Claim the in-flight slot (present-but-empty means "claimed, no
+	// waiters yet") and release the lock before doing the actual work.
+	c.inFlight[key] = []chan decodeCacheResult[T]{}
+	c.mu.Unlock()
+
+	// A panicking decodeFn (CBOR decode on adversarial bytes can, in
+	// principle, panic instead of erroring -- gouroboros' own cbor.Value
+	// decoder recovers only one specific panic class and re-panics for
+	// every other one) must not leave this key's claim held and its
+	// waiters parked forever. Recover, record the panic as a normal
+	// (cacheable) decode failure via finishDecode -- exactly like any
+	// other failure, so every current waiter is woken and any future
+	// submission of the identical bytes fails fast instead of panicking
+	// again -- then re-panic so this goroutine's own crash-or-recover
+	// behavior is unchanged from before this cache existed.
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		var panicErr error
+		if asErr, ok := r.(error); ok {
+			panicErr = fmt.Errorf("decode panicked: %w", asErr)
+		} else {
+			panicErr = fmt.Errorf("decode panicked: %v", r)
+		}
+		c.finishDecode(key, value, panicErr)
+		panic(r)
+	}()
+
+	value, err = decodeFn()
+	c.finishDecode(key, value, err)
+	return value, err, true
+}
+
+// finishDecode records key's decode outcome, releases its in-flight claim,
+// and wakes every waiter with it. Shared by getOrDecode's normal-return path
+// and its panic-recovery path so both leave the cache in the same
+// consistent state -- a waiter never observes the difference between "the
+// leader's decodeFn returned an error" and "the leader's decodeFn panicked".
+func (c *decodeCache[T]) finishDecode(key decodeCacheKey, value T, err error) {
+	now := time.Now()
+	c.mu.Lock()
+	elem := c.order.PushBack(key)
+	c.entries[key] = decodeCacheEntry[T]{
+		value:      value,
+		err:        err,
+		insertedAt: now,
+		order:      elem,
+	}
+	waiters := c.inFlight[key]
+	delete(c.inFlight, key)
+	c.evictLocked(now)
+	c.mu.Unlock()
+
+	// Send the outcome directly rather than closing a signal channel and
+	// letting each waiter re-read c.entries[key]: eviction (just run above,
+	// and always possible again before a descheduled waiter resumes) can
+	// remove this key from entries at any time after this point, and a
+	// waiter reading a since-evicted key would silently observe a
+	// zero-value/nil "success" instead of the real outcome.
+	result := decodeCacheResult[T]{value: value, err: err}
+	for _, ch := range waiters {
+		ch <- result
+	}
+}
+
+// evictLocked evicts entries older than decodeCacheTTL, then -- if still over
+// decodeCacheMaxEntries -- pops additional oldest-inserted entries down to
+// the cap. The caller must hold mu.
+//
+// Because order is a FIFO of insertion order and entries are immutable once
+// written, the front of order is always both the oldest entry (the correct
+// TTL-expiry candidate) and the correct next victim for size-cap eviction, so
+// both stages are a simple pop-from-front loop -- O(1) amortized per
+// eviction, no re-sorting the cache on every insert.
+func (c *decodeCache[T]) evictLocked(now time.Time) {
+	cutoff := now.Add(-decodeCacheTTL)
+	for {
+		front := c.order.Front()
+		if front == nil {
+			break
+		}
+		key := front.Value.(decodeCacheKey) //nolint:forcetypeassert
+		entry, ok := c.entries[key]
+		if !ok || !entry.insertedAt.Before(cutoff) {
+			break
+		}
+		c.order.Remove(front)
+		delete(c.entries, key)
+	}
+	for len(c.entries) > decodeCacheMaxEntries {
+		front := c.order.Front()
+		if front == nil {
+			break
+		}
+		key := front.Value.(decodeCacheKey) //nolint:forcetypeassert
+		c.order.Remove(front)
+		delete(c.entries, key)
+	}
+}
+
+// decodeCacheMetrics tracks hit/miss counts for the block and header decode
+// caches, following the same promauto pattern as blockfetchMetrics.
+type decodeCacheMetrics struct {
+	blockCacheHits    prometheus.Counter
+	blockCacheMisses  prometheus.Counter
+	headerCacheHits   prometheus.Counter
+	headerCacheMisses prometheus.Counter
+}
+
+func (o *Ouroboros) initDecodeCacheMetrics() {
+	factory := promauto.With(o.config.PromRegistry)
+	o.decodeCacheMetrics = &decodeCacheMetrics{
+		blockCacheHits: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_decode_cache_block_hits_total",
+			Help: "blocks served from the shared decode cache instead of being re-decoded",
+		}),
+		blockCacheMisses: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_decode_cache_block_misses_total",
+			Help: "blocks actually decoded (cache miss)",
+		}),
+		headerCacheHits: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_decode_cache_header_hits_total",
+			Help: "headers served from the shared decode cache instead of being re-decoded",
+		}),
+		headerCacheMisses: factory.NewCounter(prometheus.CounterOpts{
+			Name: "dingo_decode_cache_header_misses_total",
+			Help: "headers actually decoded (cache miss)",
+		}),
+	}
+}
+
+// recordBlockDecodeCacheOutcome updates the block cache hit/miss counters if
+// metrics are enabled. decoded matches decodeCache.getOrDecode's return value:
+// true means this call actually decoded (miss), false means it reused a
+// cache entry or an in-flight wait (hit).
+func (o *Ouroboros) recordBlockDecodeCacheOutcome(decoded bool) {
+	if o.decodeCacheMetrics == nil {
+		return
+	}
+	if decoded {
+		o.decodeCacheMetrics.blockCacheMisses.Inc()
+	} else {
+		o.decodeCacheMetrics.blockCacheHits.Inc()
+	}
+}
+
+// recordHeaderDecodeCacheOutcome is recordBlockDecodeCacheOutcome's header
+// counterpart.
+func (o *Ouroboros) recordHeaderDecodeCacheOutcome(decoded bool) {
+	if o.decodeCacheMetrics == nil {
+		return
+	}
+	if decoded {
+		o.decodeCacheMetrics.headerCacheMisses.Inc()
+	} else {
+		o.decodeCacheMetrics.headerCacheHits.Inc()
+	}
+}

--- a/ouroboros/decode_cache.go
+++ b/ouroboros/decode_cache.go
@@ -180,11 +180,19 @@ func (c *decodeCache[T]) getOrDecode(
 	// submission of the identical bytes fails fast instead of panicking
 	// again -- then re-panic so this goroutine's own crash-or-recover
 	// behavior is unchanged from before this cache existed.
+	//
+	// completed (not recover()'s return value) is what decides whether
+	// decodeFn panicked: recover() returns nil both when there is no panic
+	// in flight AND when the panic value itself is literally nil (e.g. a
+	// bare panic(nil)), so testing "r == nil" alone would mistake that
+	// panic for normal completion and leave this key's claim stuck forever,
+	// stranding every current and future waiter for these bytes.
+	completed := false
 	defer func() {
-		r := recover()
-		if r == nil {
+		if completed {
 			return
 		}
+		r := recover()
 		var panicErr error
 		if asErr, ok := r.(error); ok {
 			panicErr = fmt.Errorf("decode panicked: %w", asErr)
@@ -196,32 +204,53 @@ func (c *decodeCache[T]) getOrDecode(
 	}()
 
 	value, err = decodeFn()
+	completed = true
 	c.finishDecode(key, value, err)
 	return value, err, true
 }
 
-// decodeWithPanicSafeMetrics wraps getOrDecode so a panicking decodeFn still
-// gets its hit/miss outcome recorded. getOrDecode's own panic recovery
-// re-raises after cleaning up the cache (see its doc comment), so this call
-// never returns normally on that path -- the caller's usual
-// "record based on the returned decoded bool" pattern never runs, and a
-// genuine decode attempt (a miss) that happened to panic would silently go
-// uncounted. recordMiss is invoked from a recover here, before the panic is
-// re-raised again, so it always sees exactly the same attempts a
-// non-panicking decodeFn would have reported via decoded=true.
+// decodeWithPanicSafeMetrics wraps getOrDecode and owns recording its
+// hit/miss outcome entirely, covering three cases in one place so a future
+// change to one can't drift out of sync with the others:
+//
+//   - decodeFn panics: getOrDecode's own panic recovery re-raises after
+//     cleaning up the cache (see its doc comment), so this call never
+//     returns normally -- recordOutcome(true) runs from a recover here,
+//     before the panic is re-raised again.
+//   - decodeFn returns an error, or a waiter/cached-hit shares an
+//     already-failed outcome: recordOutcome(true). A failed delivery never
+//     represents an actual decode being successfully reused, whether this
+//     call ran decodeFn itself or reused another caller's failure, so it
+//     must never be counted as a hit -- getOrDecode's own decoded flag
+//     alone would undercount this, since it is false for every hit
+//     (including a hit on a cached failure) and every waiter (including one
+//     woken by a failing in-flight decode).
+//   - a genuine successful decode or hit: recordOutcome(decoded), matching
+//     getOrDecode's own contract exactly.
+//
+// completed, not recover()'s return value, decides whether getOrDecode
+// panicked -- see getOrDecode's own doc comment on why testing "r == nil"
+// alone would mistake a bare panic(nil) for normal completion.
 func decodeWithPanicSafeMetrics[T any](
 	cache *decodeCache[T],
 	key decodeCacheKey,
 	decodeFn func() (T, error),
-	recordMiss func(),
-) (value T, err error, decoded bool) {
+	recordOutcome func(isMiss bool),
+) (value T, err error) {
+	completed := false
 	defer func() {
-		if r := recover(); r != nil {
-			recordMiss()
-			panic(r)
+		if completed {
+			return
 		}
+		r := recover()
+		recordOutcome(true)
+		panic(r)
 	}()
-	return cache.getOrDecode(key, decodeFn)
+	var decoded bool
+	value, err, decoded = cache.getOrDecode(key, decodeFn)
+	completed = true
+	recordOutcome(decoded || err != nil)
+	return value, err
 }
 
 // finishDecode records key's decode outcome, releases its in-flight claim,

--- a/ouroboros/decode_cache_bench_test.go
+++ b/ouroboros/decode_cache_bench_test.go
@@ -156,8 +156,13 @@ func BenchmarkBlockDecodeConcurrentDirect(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			// testing.TB's FailNow/Fatal family must only be called from the
+			// goroutine running the benchmark, not from a RunParallel worker
+			// goroutine (it would only runtime.Goexit that one goroutine,
+			// not reliably fail the benchmark). Error/Errorf are safe from
+			// any goroutine.
 			if _, err := o.decodeBlockfetchBlock(blockType, raw); err != nil {
-				b.Fatalf("decode: %v", err)
+				b.Errorf("decode: %v", err)
 			}
 		}
 	})
@@ -188,7 +193,7 @@ func BenchmarkBlockDecodeConcurrentCacheAllUnique(b *testing.B) {
 			key[2] ^= byte(n >> 16)
 			key[3] ^= byte(n >> 24)
 			if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
-				b.Fatalf("decode: %v", err)
+				b.Errorf("decode: %v", err)
 			}
 		}
 	})
@@ -254,8 +259,10 @@ func BenchmarkHeaderDecodeConcurrentDirect(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			// See BenchmarkBlockDecodeConcurrentDirect on why Errorf, not
+			// Fatalf, is required inside a RunParallel worker goroutine.
 			if _, err := o.decodeChainsyncHeader(headerType, raw); err != nil {
-				b.Fatalf("decode: %v", err)
+				b.Errorf("decode: %v", err)
 			}
 		}
 	})
@@ -280,7 +287,7 @@ func BenchmarkHeaderDecodeConcurrentCacheAllUnique(b *testing.B) {
 			key[2] ^= byte(n >> 16)
 			key[3] ^= byte(n >> 24)
 			if _, err, _ := o.headerDecodeCache.getOrDecode(key, decodeFn); err != nil {
-				b.Fatalf("decode: %v", err)
+				b.Errorf("decode: %v", err)
 			}
 		}
 	})

--- a/ouroboros/decode_cache_bench_test.go
+++ b/ouroboros/decode_cache_bench_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+)
+
+// benchConwayBlockFixture and benchConwayHeaderFixture mirror
+// conwayBlockFixtureBytes/conwayHeaderFixtureBytes but accept testing.TB so
+// the same real fixture loading works from both Test and Benchmark
+// functions.
+func benchConwayBlockFixture(b *testing.B) (blockType uint, raw []byte) {
+	b.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(b.TempDir())
+	if err != nil {
+		b.Fatalf("extract fixtures: %v", err)
+	}
+	fixture, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/Block_Conway",
+	)
+	if err != nil {
+		b.Fatalf("load fixture: %v", err)
+	}
+	blockType, err = fixture.LedgerBlockType()
+	if err != nil {
+		b.Fatalf("block type: %v", err)
+	}
+	raw, err = fixture.LedgerBlockBytes()
+	if err != nil {
+		b.Fatalf("block bytes: %v", err)
+	}
+	return blockType, raw
+}
+
+func benchConwayHeaderFixture(b *testing.B) (headerType uint, raw []byte) {
+	b.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(b.TempDir())
+	if err != nil {
+		b.Fatalf("extract fixtures: %v", err)
+	}
+	fixture, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/Header_Conway",
+	)
+	if err != nil {
+		b.Fatalf("load fixture: %v", err)
+	}
+	headerType, err = fixture.LedgerHeaderType()
+	if err != nil {
+		b.Fatalf("header type: %v", err)
+	}
+	raw, err = fixture.LedgerHeaderBytes()
+	if err != nil {
+		b.Fatalf("header bytes: %v", err)
+	}
+	return headerType, raw
+}
+
+// --- Blocks -----------------------------------------------------------
+
+// BenchmarkBlockDecodeDirect is the pre-#489 baseline: decode every delivery
+// directly, no cache, no hashing, no locking. Every other block benchmark
+// below should be read relative to this number.
+func BenchmarkBlockDecodeDirect(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	blockType, raw := benchConwayBlockFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := o.decodeBlockfetchBlock(blockType, raw); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}
+
+// BenchmarkBlockDecodeCacheAllDuplicate is the best case for the cache: every
+// delivery is byte-identical (the real-world "several peers relay the same
+// block" scenario). Only the first call should actually decode.
+func BenchmarkBlockDecodeCacheAllDuplicate(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	blockType, raw := benchConwayBlockFixture(b)
+	key := hashDecodeInput(blockType, raw)
+	decodeFn := func() (gledger.Block, error) {
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}
+
+// BenchmarkBlockDecodeCacheAllUnique is the worst case for the cache: every
+// delivery is a genuine miss (no duplication ever happens), so this measures
+// the pure tax the cache adds -- hashing plus locking plus bookkeeping --
+// with zero benefit, on top of the same real decode cost every iteration.
+// Compare directly against BenchmarkBlockDecodeDirect: the delta is the cost
+// of adding this cache when duplicates never occur.
+func BenchmarkBlockDecodeCacheAllUnique(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	blockType, raw := benchConwayBlockFixture(b)
+	decodeFn := func() (gledger.Block, error) {
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		key := hashDecodeInput(blockType, raw)
+		// Perturb the key per iteration so every call is a genuine miss,
+		// while decodeFn still does the same real decode work each time --
+		// isolating cache overhead from decode cost.
+		key[0] ^= byte(i)
+		key[1] ^= byte(i >> 8)
+		key[2] ^= byte(i >> 16)
+		if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}
+
+// BenchmarkBlockDecodeConcurrentDirect is the concurrent pre-#489 baseline:
+// many simulated peer connections decoding in parallel with no shared state
+// at all, so it should scale cleanly with GOMAXPROCS.
+func BenchmarkBlockDecodeConcurrentDirect(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	blockType, raw := benchConwayBlockFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := o.decodeBlockfetchBlock(blockType, raw); err != nil {
+				b.Fatalf("decode: %v", err)
+			}
+		}
+	})
+}
+
+// BenchmarkBlockDecodeConcurrentCacheAllUnique is the concurrency-specific
+// worst case: many simulated peer connections all hitting the shared cache
+// lock at once, with every call a genuine miss (no benefit from caching at
+// all). This isolates lock contention cost under real concurrent peer load,
+// which BenchmarkBlockDecodeCacheAllUnique (single-goroutine) cannot show.
+func BenchmarkBlockDecodeConcurrentCacheAllUnique(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	blockType, raw := benchConwayBlockFixture(b)
+	decodeFn := func() (gledger.Block, error) {
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var counter int64
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter++
+			key := hashDecodeInput(blockType, raw)
+			key[0] ^= byte(counter)
+			key[1] ^= byte(counter >> 8)
+			key[2] ^= byte(counter >> 16)
+			key[3] ^= byte(counter >> 24)
+			if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
+				b.Fatalf("decode: %v", err)
+			}
+		}
+	})
+}
+
+// --- Headers ------------------------------------------------------------
+//
+// Headers are the case most likely to be a losing trade (small, cheap to
+// decode, so the hashing+locking tax is proportionally larger).
+
+func BenchmarkHeaderDecodeDirect(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	headerType, raw := benchConwayHeaderFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := o.decodeChainsyncHeader(headerType, raw); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}
+
+func BenchmarkHeaderDecodeCacheAllDuplicate(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	headerType, raw := benchConwayHeaderFixture(b)
+	key := hashDecodeInput(headerType, raw)
+	decodeFn := func() (gledger.BlockHeader, error) {
+		return o.decodeChainsyncHeader(headerType, raw)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err, _ := o.headerDecodeCache.getOrDecode(key, decodeFn); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}
+
+func BenchmarkHeaderDecodeCacheAllUnique(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	headerType, raw := benchConwayHeaderFixture(b)
+	decodeFn := func() (gledger.BlockHeader, error) {
+		return o.decodeChainsyncHeader(headerType, raw)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		key := hashDecodeInput(headerType, raw)
+		key[0] ^= byte(i)
+		key[1] ^= byte(i >> 8)
+		key[2] ^= byte(i >> 16)
+		if _, err, _ := o.headerDecodeCache.getOrDecode(key, decodeFn); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}
+
+func BenchmarkHeaderDecodeConcurrentDirect(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	headerType, raw := benchConwayHeaderFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := o.decodeChainsyncHeader(headerType, raw); err != nil {
+				b.Fatalf("decode: %v", err)
+			}
+		}
+	})
+}
+
+func BenchmarkHeaderDecodeConcurrentCacheAllUnique(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	headerType, raw := benchConwayHeaderFixture(b)
+	decodeFn := func() (gledger.BlockHeader, error) {
+		return o.decodeChainsyncHeader(headerType, raw)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var counter int64
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter++
+			key := hashDecodeInput(headerType, raw)
+			key[0] ^= byte(counter)
+			key[1] ^= byte(counter >> 8)
+			key[2] ^= byte(counter >> 16)
+			key[3] ^= byte(counter >> 24)
+			if _, err, _ := o.headerDecodeCache.getOrDecode(key, decodeFn); err != nil {
+				b.Fatalf("decode: %v", err)
+			}
+		}
+	})
+}
+
+// BenchmarkBlockDecodeCacheMixedRatio sits between the two extremes already
+// covered above (BenchmarkBlockDecodeCacheAllDuplicate: 100% duplicate,
+// BenchmarkBlockDecodeCacheAllUnique: 0% duplicate). Real peer traffic is
+// neither: a handful of distinct in-flight blocks, each delivered by several
+// peers. This cycles through 5 distinct keys (derived from the same real
+// block bytes) so 4 out of every 5 calls are a cache hit, giving a more
+// representative estimate of steady-state overhead/benefit than either pure
+// extreme does alone.
+func BenchmarkBlockDecodeCacheMixedRatio(b *testing.B) {
+	o := testOuroborosForDecodeCache(b)
+	blockType, raw := benchConwayBlockFixture(b)
+	decodeFn := func() (gledger.Block, error) {
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+	const distinctKeys = 5
+	keys := make([]decodeCacheKey, distinctKeys)
+	for i := range keys {
+		keys[i] = hashDecodeInput(blockType, raw)
+		keys[i][0] ^= byte(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		key := keys[i%distinctKeys]
+		if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
+			b.Fatalf("decode: %v", err)
+		}
+	}
+}

--- a/ouroboros/decode_cache_bench_test.go
+++ b/ouroboros/decode_cache_bench_test.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"sync/atomic"
 	"testing"
 
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -98,13 +99,19 @@ func BenchmarkBlockDecodeDirect(b *testing.B) {
 func BenchmarkBlockDecodeCacheAllDuplicate(b *testing.B) {
 	o := testOuroborosForDecodeCache(b)
 	blockType, raw := benchConwayBlockFixture(b)
-	key := hashDecodeInput(blockType, raw)
 	decodeFn := func() (gledger.Block, error) {
 		return o.decodeBlockfetchBlock(blockType, raw)
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
+		// Hash inside the timed loop: the real entry point
+		// (blockfetchClientBlockRaw) hashes every delivery's bytes before
+		// the cache lookup, even when -- as here -- the bytes are
+		// byte-identical to the previous delivery. Precomputing the key
+		// once outside the loop would omit that per-delivery cost from the
+		// reported numbers.
+		key := hashDecodeInput(blockType, raw)
 		if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
 			b.Fatalf("decode: %v", err)
 		}
@@ -172,12 +179,14 @@ func BenchmarkBlockDecodeConcurrentCacheAllUnique(b *testing.B) {
 	var counter int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			counter++
+			// atomic: RunParallel's callback runs concurrently across
+			// goroutines, so a plain counter++ here is a data race.
+			n := atomic.AddInt64(&counter, 1)
 			key := hashDecodeInput(blockType, raw)
-			key[0] ^= byte(counter)
-			key[1] ^= byte(counter >> 8)
-			key[2] ^= byte(counter >> 16)
-			key[3] ^= byte(counter >> 24)
+			key[0] ^= byte(n)
+			key[1] ^= byte(n >> 8)
+			key[2] ^= byte(n >> 16)
+			key[3] ^= byte(n >> 24)
 			if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
 				b.Fatalf("decode: %v", err)
 			}
@@ -205,13 +214,14 @@ func BenchmarkHeaderDecodeDirect(b *testing.B) {
 func BenchmarkHeaderDecodeCacheAllDuplicate(b *testing.B) {
 	o := testOuroborosForDecodeCache(b)
 	headerType, raw := benchConwayHeaderFixture(b)
-	key := hashDecodeInput(headerType, raw)
 	decodeFn := func() (gledger.BlockHeader, error) {
 		return o.decodeChainsyncHeader(headerType, raw)
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
+		// Hash inside the timed loop -- see BenchmarkBlockDecodeCacheAllDuplicate.
+		key := hashDecodeInput(headerType, raw)
 		if _, err, _ := o.headerDecodeCache.getOrDecode(key, decodeFn); err != nil {
 			b.Fatalf("decode: %v", err)
 		}
@@ -262,12 +272,13 @@ func BenchmarkHeaderDecodeConcurrentCacheAllUnique(b *testing.B) {
 	var counter int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			counter++
+			// atomic: see BenchmarkBlockDecodeConcurrentCacheAllUnique.
+			n := atomic.AddInt64(&counter, 1)
 			key := hashDecodeInput(headerType, raw)
-			key[0] ^= byte(counter)
-			key[1] ^= byte(counter >> 8)
-			key[2] ^= byte(counter >> 16)
-			key[3] ^= byte(counter >> 24)
+			key[0] ^= byte(n)
+			key[1] ^= byte(n >> 8)
+			key[2] ^= byte(n >> 16)
+			key[3] ^= byte(n >> 24)
 			if _, err, _ := o.headerDecodeCache.getOrDecode(key, decodeFn); err != nil {
 				b.Fatalf("decode: %v", err)
 			}
@@ -289,16 +300,25 @@ func BenchmarkBlockDecodeCacheMixedRatio(b *testing.B) {
 	decodeFn := func() (gledger.Block, error) {
 		return o.decodeBlockfetchBlock(blockType, raw)
 	}
-	const distinctKeys = 5
-	keys := make([]decodeCacheKey, distinctKeys)
-	for i := range keys {
-		keys[i] = hashDecodeInput(blockType, raw)
-		keys[i][0] ^= byte(i)
+	// Five distinct real inputs (copies of the fixture bytes, each with one
+	// byte perturbed), hashed inside the timed loop below -- not five
+	// precomputed keys derived by flipping a byte of an already-hashed
+	// digest. The real entry point always hashes the actual delivery bytes
+	// it was just handed, so this measures that per-delivery hashing cost
+	// on genuinely different byte content, matching production instead of
+	// precomputing the (cheaper) key lookup alone before ResetTimer.
+	const distinctInputs = 5
+	rawVariants := make([][]byte, distinctInputs)
+	for i := range rawVariants {
+		variant := make([]byte, len(raw))
+		copy(variant, raw)
+		variant[0] ^= byte(i)
+		rawVariants[i] = variant
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := range b.N {
-		key := keys[i%distinctKeys]
+		key := hashDecodeInput(blockType, rawVariants[i%distinctInputs])
 		if _, err, _ := o.blockDecodeCache.getOrDecode(key, decodeFn); err != nil {
 			b.Fatalf("decode: %v", err)
 		}

--- a/ouroboros/decode_cache_test.go
+++ b/ouroboros/decode_cache_test.go
@@ -72,11 +72,10 @@ func decodeCacheInsertForTest[T any](
 ) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	elem := c.order.PushBack(key)
+	c.order.PushBack(key)
 	c.entries[key] = decodeCacheEntry[T]{
 		value:      value,
 		insertedAt: insertedAt,
-		order:      elem,
 	}
 }
 
@@ -481,6 +480,61 @@ func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 	require.Contains(t, err.Error(), "decode panicked")
 }
 
+// TestDecodeWithPanicSafeMetricsRecordsMissOnPanic is the regression test for
+// a real bug found in code review: getOrDecode's own panic recovery
+// re-raises after cleaning up the cache (see
+// TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey above), so it
+// never returns normally to blockfetchClientBlockRaw/
+// chainsyncClientRollForwardRaw -- their usual "record the outcome based on
+// the returned decoded bool" line never runs, and a genuine decode attempt
+// (a miss) that happened to panic went uncounted in the hit/miss metrics.
+// This confirms decodeWithPanicSafeMetrics -- the helper both wrappers now
+// call through -- invokes recordMiss exactly once before re-raising the
+// panic, and that the panic still propagates to the caller unchanged.
+func TestDecodeWithPanicSafeMetricsRecordsMissOnPanic(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x08}
+	var missCount atomic.Int64
+
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "the panic must still propagate to the caller")
+			require.Equal(t, "simulated decode panic", r)
+		}()
+		_, _, _ = decodeWithPanicSafeMetrics(
+			c,
+			key,
+			func() (int, error) { panic("simulated decode panic") },
+			func() { missCount.Add(1) },
+		)
+		t.Fatal("decodeWithPanicSafeMetrics must not return normally on panic")
+	}()
+
+	require.EqualValues(
+		t,
+		1,
+		missCount.Load(),
+		"a genuine decode attempt that panicked must still be recorded as a miss",
+	)
+
+	// The panic is cached like any other failure (see
+	// TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey): a later
+	// call for the same key must not invoke decodeFn or recordMiss again.
+	_, err, decoded := decodeWithPanicSafeMetrics(
+		c,
+		key,
+		func() (int, error) {
+			t.Fatal("decodeFn must not run again for an already-cached panic")
+			return 0, nil
+		},
+		func() { missCount.Add(1) },
+	)
+	require.False(t, decoded)
+	require.Error(t, err)
+	require.EqualValues(t, 1, missCount.Load())
+}
+
 // TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes is the
 // deterministic regression test for a second real bug found by re-auditing
 // this file for a narrow/stress gap: a waiter used to be woken by a closed
@@ -518,7 +572,7 @@ func TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes(
 	c.mu.Lock()
 	elem := c.order.PushBack(key)
 	c.entries[key] = decodeCacheEntry[int]{
-		value: 999, err: nil, insertedAt: time.Now(), order: elem,
+		value: 999, err: nil, insertedAt: time.Now(),
 	}
 	delete(c.inFlight, key)
 	// Simulate a flood of unrelated churn evicting this exact entry before

--- a/ouroboros/decode_cache_test.go
+++ b/ouroboros/decode_cache_test.go
@@ -1,0 +1,1144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeCacheTestConnId returns a ConnectionId with valid net.Addr values
+// (mirrors testConnId in blockfetch_test.go). The real chainsync/blockfetch
+// handlers call ConnectionId.String() for logging, which dereferences
+// LocalAddr/RemoteAddr directly and panics on the zero value -- a bare
+// ConnectionId{} is not a safe stand-in for "no particular connection" here.
+func decodeCacheTestConnId() ouroboros_conn.ConnectionId {
+	return ouroboros_conn.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3001},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3002},
+	}
+}
+
+// --- Part 1: pure decodeCache[T] unit tests -------------------------------
+//
+// These exercise the generic cache mechanism in isolation from any real CBOR
+// decoding, so the correctness properties (hit/miss, collision safety,
+// eviction, concurrency) are proven independently of what T happens to be.
+
+// decodeCacheLen reports the current entry count. Test-only introspection
+// into cache internals, kept out of the production file since nothing there
+// needs it.
+func decodeCacheLen[T any](c *decodeCache[T]) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// decodeCacheInsertForTest inserts an entry the same way getOrDecode does --
+// into both entries and the order list -- so tests exercising eviction
+// directly (bypassing getOrDecode) still populate the FIFO order eviction
+// relies on. The caller must not hold c.mu.
+func decodeCacheInsertForTest[T any](
+	c *decodeCache[T],
+	key decodeCacheKey,
+	value T,
+	insertedAt time.Time,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem := c.order.PushBack(key)
+	c.entries[key] = decodeCacheEntry[T]{
+		value:      value,
+		insertedAt: insertedAt,
+		order:      elem,
+	}
+}
+
+// countingDecoder returns a decode function that counts how many times it
+// actually runs, and a pointer to the live count.
+func countingDecoder(
+	value int,
+	err error,
+	delay time.Duration,
+) (func() (int, error), *atomic.Int64) {
+	var calls atomic.Int64
+	return func() (int, error) {
+		calls.Add(1)
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		return value, err
+	}, &calls
+}
+
+// TestDecodeCacheHitAvoidsRedecode checks the basic promise of the cache:
+// decode something once, then ask for the same thing again, and confirm the
+// second time reuses the answer instead of doing the work again.
+func TestDecodeCacheHitAvoidsRedecode(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x01}
+	decodeFn, calls := countingDecoder(42, nil, 0)
+
+	value, err, decoded := c.getOrDecode(key, decodeFn)
+	require.NoError(t, err)
+	require.Equal(t, 42, value)
+	require.True(t, decoded, "first call for a new key must be a real decode")
+	require.EqualValues(t, 1, calls.Load())
+
+	value, err, decoded = c.getOrDecode(key, decodeFn)
+	require.NoError(t, err)
+	require.Equal(t, 42, value)
+	require.False(
+		t,
+		decoded,
+		"second call for the same key must be a cache hit",
+	)
+	require.EqualValues(
+		t, 1, calls.Load(),
+		"decodeFn must not run again on a cache hit",
+	)
+}
+
+// TestDecodeCacheDifferentKeysDecodeIndependently checks that two different
+// pieces of data never get mixed up with each other: each one is decoded
+// and remembered on its own, with no cross-contamination between them.
+func TestDecodeCacheDifferentKeysDecodeIndependently(t *testing.T) {
+	c := newDecodeCache[int]()
+	keyA := decodeCacheKey{0xAA}
+	keyB := decodeCacheKey{0xBB}
+	decodeA, callsA := countingDecoder(1, nil, 0)
+	decodeB, callsB := countingDecoder(2, nil, 0)
+
+	valueA, errA, decodedA := c.getOrDecode(keyA, decodeA)
+	valueB, errB, decodedB := c.getOrDecode(keyB, decodeB)
+
+	require.NoError(t, errA)
+	require.NoError(t, errB)
+	require.Equal(t, 1, valueA)
+	require.Equal(t, 2, valueB)
+	require.True(t, decodedA)
+	require.True(t, decodedB)
+	require.EqualValues(
+		t, 1, callsA.Load(),
+		"a different key must never be satisfied from another key's entry",
+	)
+	require.EqualValues(t, 1, callsB.Load())
+}
+
+// TestDecodeCacheFailureIsCachedAndNotRetried checks what happens when
+// something fails to decode (bad/broken data): a repeat of that same broken
+// data must not be retried -- it should just remember "this one failed" and
+// return the same answer again without redoing the work.
+func TestDecodeCacheFailureIsCachedAndNotRetried(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x02}
+	wantErr := errors.New("malformed input")
+	decodeFn, calls := countingDecoder(0, wantErr, 0)
+
+	_, err, decoded := c.getOrDecode(key, decodeFn)
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, decoded)
+	require.EqualValues(t, 1, calls.Load())
+
+	// A second submission of the identical (bad) bytes must reuse the
+	// cached failure, not re-attempt a decode that -- since decoding is a
+	// pure function of its input -- can only ever fail the same way again.
+	_, err, decoded = c.getOrDecode(key, decodeFn)
+	require.ErrorIs(t, err, wantErr)
+	require.False(t, decoded)
+	require.EqualValues(t, 1, calls.Load())
+}
+
+// TestDecodeCachePrunesExpiredEntries checks that old entries actually get
+// cleared out after enough time passes, so the cache doesn't just grow
+// forever.
+func TestDecodeCachePrunesExpiredEntries(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x03}
+	decodeCacheInsertForTest(
+		c, key, 7, time.Now().Add(-decodeCacheTTL-time.Second),
+	)
+	require.Equal(t, 1, decodeCacheLen(c))
+
+	c.mu.Lock()
+	c.evictLocked(time.Now())
+	c.mu.Unlock()
+
+	require.Zero(t, decodeCacheLen(c), "expired entry must be pruned")
+}
+
+// TestDecodeCachePrunesBySizeWhenOverCapacity checks the other cleanup
+// rule: if the cache gets too full, it removes the oldest entries to make
+// room, instead of growing without limit.
+func TestDecodeCachePrunesBySizeWhenOverCapacity(t *testing.T) {
+	c := newDecodeCache[int]()
+	now := time.Now()
+	// Insert one more than the cap, all fresh (no TTL pruning triggers),
+	// with strictly increasing insertedAt so eviction order is
+	// deterministic: the single oldest entry must be the one dropped.
+	for i := range decodeCacheMaxEntries + 1 {
+		var key decodeCacheKey
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		decodeCacheInsertForTest(
+			c, key, i, now.Add(time.Duration(i)*time.Millisecond),
+		)
+	}
+	require.Equal(t, decodeCacheMaxEntries+1, decodeCacheLen(c))
+
+	c.mu.Lock()
+	c.evictLocked(
+		now.Add(time.Duration(decodeCacheMaxEntries) * time.Millisecond),
+	)
+	c.mu.Unlock()
+
+	require.Equal(
+		t, decodeCacheMaxEntries, decodeCacheLen(c),
+		"size-based pruning must trim down to exactly the cap",
+	)
+	var oldestKey decodeCacheKey
+	oldestKey[0] = 0
+	oldestKey[1] = 0
+	_, stillPresent := c.entries[oldestKey]
+	require.False(
+		t,
+		stillPresent,
+		"the single oldest entry must be evicted first",
+	)
+}
+
+// TestDecodeCacheConcurrentCallersShareOneDecode is the core correctness
+// property: many goroutines submitting the identical key at the same time
+// must trigger exactly one real decode, and every goroutine -- whether it
+// ran the decode, hit the cache, or waited on the in-flight attempt -- must
+// receive the identical, correct result. Run with -race.
+func TestDecodeCacheConcurrentCallersShareOneDecode(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x04}
+	const wantValue = 123
+	const numCallers = 50
+	// A small delay widens the race window so concurrent callers reliably
+	// land on the in-flight-wait path rather than the already-cached path.
+	decodeFn, calls := countingDecoder(wantValue, nil, 5*time.Millisecond)
+
+	var wg sync.WaitGroup
+	results := make([]int, numCallers)
+	errs := make([]error, numCallers)
+	for i := range numCallers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx], _ = c.getOrDecode(key, decodeFn)
+		}(i)
+	}
+	wg.Wait()
+
+	require.EqualValues(
+		t, 1, calls.Load(),
+		"concurrent callers for the same key must share exactly one decode",
+	)
+	for i := range numCallers {
+		require.NoError(t, errs[i])
+		require.Equal(
+			t,
+			wantValue,
+			results[i],
+			"caller %d got a wrong result",
+			i,
+		)
+	}
+}
+
+// TestDecodeCacheConcurrentDifferentKeysDoNotSerialize proves the lock is
+// never held across the decode call itself: two distinct keys whose decode
+// functions each block until released must be able to be in flight at the
+// same time, not forced one-after-another by a shared lock.
+func TestDecodeCacheConcurrentDifferentKeysDoNotSerialize(t *testing.T) {
+	c := newDecodeCache[int]()
+	keyA := decodeCacheKey{0xA1}
+	keyB := decodeCacheKey{0xB1}
+
+	bothStarted := make(chan struct{})
+	var startedOnce sync.Once
+	var started atomic.Int32
+	release := make(chan struct{})
+
+	blockingDecoder := func(value int) func() (int, error) {
+		return func() (int, error) {
+			if started.Add(1) == 2 {
+				startedOnce.Do(func() { close(bothStarted) })
+			}
+			<-release
+			return value, nil
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _, _ = c.getOrDecode(keyA, blockingDecoder(1))
+	}()
+	go func() {
+		defer wg.Done()
+		_, _, _ = c.getOrDecode(keyB, blockingDecoder(2))
+	}()
+
+	select {
+	case <-bothStarted:
+		// Both decodes are concurrently in flight, proving the cache lock
+		// was released before either decode ran.
+	case <-time.After(5 * time.Second):
+		close(release)
+		wg.Wait()
+		t.Fatal(
+			"decodes for different keys serialized instead of overlapping " +
+				"-- the cache is holding its lock across the decode call",
+		)
+	}
+	close(release)
+	wg.Wait()
+}
+
+// TestDecodeCacheNoGoroutineLeakOnFailure covers the failure-fan-out case
+// discussed for #489: when N callers are waiting on one in-flight decode and
+// it fails, every waiter must be woken with that failure, not left hanging.
+func TestDecodeCacheNoGoroutineLeakOnFailure(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x05}
+	wantErr := errors.New("bad bytes")
+	release := make(chan struct{})
+	leaderStarted := make(chan struct{})
+	var leaderOnce sync.Once
+
+	const numWaiters = 4
+	results := make([]error, numWaiters)
+	var wg sync.WaitGroup
+	wg.Add(numWaiters)
+	for i := range numWaiters {
+		go func(idx int) {
+			defer wg.Done()
+			_, err, _ := c.getOrDecode(key, func() (int, error) {
+				leaderOnce.Do(func() { close(leaderStarted) })
+				<-release
+				return 0, wantErr
+			})
+			results[idx] = err
+		}(i)
+	}
+
+	<-leaderStarted
+	// Give the non-leader goroutines time to register as waiters before
+	// the leader's decode is released.
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.inFlight[key]) == numWaiters-1
+	}, 2*time.Second, 5*time.Millisecond)
+	close(release)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a waiter never woke up after the in-flight decode failed")
+	}
+
+	for i, err := range results {
+		require.ErrorIsf(
+			t, err, wantErr,
+			"waiter %d did not receive the shared failure", i,
+		)
+	}
+	require.Zero(
+		t, len(c.inFlight),
+		"in-flight bookkeeping must be cleared after the attempt resolves",
+	)
+}
+
+// TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey is the regression
+// test for a real bug found by proactively auditing this file for remaining
+// gaps: decodeFn panicking (CBOR decode on adversarial bytes can, in
+// principle, panic instead of erroring) used to leave the key's in-flight
+// claim held and any concurrent waiters parked forever, since nothing ever
+// closed their channels or released the claim. This confirms the fix: the
+// leader's own panic still propagates to its immediate caller (unchanged
+// crash-or-recover behavior for that goroutine), but every concurrent
+// waiter is woken with a normal error instead of hanging, the in-flight
+// claim is released, and -- since the panic is now a cached failure like
+// any other -- a later call for the identical bytes fails fast without
+// invoking decodeFn (and therefore without panicking) again.
+func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x06}
+	release := make(chan struct{})
+	leaderStarted := make(chan struct{})
+	var leaderOnce sync.Once
+
+	const numWaiters = 3
+	results := make([]error, numWaiters)
+	var wg sync.WaitGroup
+	wg.Add(numWaiters)
+	leaderPanicked := make(chan struct{})
+	for i := range numWaiters {
+		go func(idx int) {
+			defer wg.Done()
+			defer func() {
+				// Only the leader (the one goroutine that actually calls
+				// decodeFn) observes the panic here; recovering it mimics
+				// whatever, if anything, sits upstream of the cache in
+				// production, and lets this test assert on the effect on
+				// the OTHER waiters without crashing the test binary.
+				if r := recover(); r != nil {
+					close(leaderPanicked)
+				}
+			}()
+			_, err, _ := c.getOrDecode(key, func() (int, error) {
+				leaderOnce.Do(func() { close(leaderStarted) })
+				<-release
+				panic("simulated decode panic")
+			})
+			results[idx] = err
+		}(i)
+	}
+
+	<-leaderStarted
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.inFlight[key]) == numWaiters-1
+	}, 2*time.Second, 5*time.Millisecond)
+	close(release)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a waiter never woke up after the in-flight decode panicked")
+	}
+	<-leaderPanicked
+
+	nonLeaderErrs := 0
+	for _, err := range results {
+		if err != nil {
+			nonLeaderErrs++
+			require.Contains(t, err.Error(), "decode panicked")
+		}
+	}
+	require.Equal(
+		t, numWaiters-1, nonLeaderErrs,
+		"every non-leader waiter must be woken with the recorded panic error",
+	)
+	require.Zero(
+		t,
+		len(c.inFlight),
+		"in-flight bookkeeping must be cleared after a panic, not left claimed forever",
+	)
+
+	// The panic is now a cached failure like any other: a later call for
+	// the identical key must return it immediately without invoking
+	// decodeFn (and therefore without panicking) again.
+	_, err, decoded := c.getOrDecode(key, func() (int, error) {
+		t.Fatal("decodeFn must not run again for an already-cached panic")
+		return 0, nil
+	})
+	require.False(t, decoded)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode panicked")
+}
+
+// TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes is the
+// deterministic regression test for a second real bug found by re-auditing
+// this file for a narrow/stress gap: a waiter used to be woken by a closed
+// signal channel and then re-read its answer from c.entries[key]. But an
+// entry can be evicted by unrelated churn (many other keys being inserted)
+// in the window between "the leader signals waiters" and "a descheduled
+// waiter resumes and re-acquires the lock" -- so a waiter could silently
+// observe a zero-value/nil "success" instead of the real decode outcome,
+// with no error and no panic to reveal anything went wrong. This
+// reconstructs that exact race deterministically (no reliance on scheduler
+// timing) by manually evicting the entry in the gap between "insert" and
+// "signal", and confirms the waiter still gets the real answer -- because
+// finishDecode now sends the result directly through the wait channel
+// instead of the waiter re-reading the (possibly-since-evicted) map.
+func TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes(
+	t *testing.T,
+) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x77}
+
+	c.mu.Lock()
+	ch := make(chan decodeCacheResult[int], 1)
+	c.inFlight[key] = []chan decodeCacheResult[int]{ch}
+	c.mu.Unlock()
+
+	waiterDone := make(chan struct{})
+	var gotValue int
+	var gotErr error
+	go func() {
+		defer close(waiterDone)
+		result := <-ch
+		gotValue, gotErr = result.value, result.err
+	}()
+
+	c.mu.Lock()
+	elem := c.order.PushBack(key)
+	c.entries[key] = decodeCacheEntry[int]{
+		value: 999, err: nil, insertedAt: time.Now(), order: elem,
+	}
+	delete(c.inFlight, key)
+	// Simulate a flood of unrelated churn evicting this exact entry before
+	// the waiter goroutine above gets scheduled to do anything with it.
+	c.order.Remove(elem)
+	delete(c.entries, key)
+	c.mu.Unlock()
+
+	ch <- decodeCacheResult[int]{value: 999, err: nil}
+
+	select {
+	case <-waiterDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter never returned")
+	}
+	require.Equal(
+		t,
+		999,
+		gotValue,
+		"waiter must get the real decode result even though its entry was evicted before it read anything",
+	)
+	require.NoError(t, gotErr)
+}
+
+// TestDecodeCacheStressConcurrentChurnWithSharedKeys is a stress test
+// combining the two properties every other test above exercises in
+// isolation: many goroutines racing on a handful of SHARED keys (so
+// concurrent waiter registration/wake-up is exercised) while simultaneously
+// churning through unique keys fast enough to force continuous eviction
+// well past decodeCacheMaxEntries. This is exactly the condition under
+// which TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes
+// reproduces deterministically; running it under -race additionally checks
+// for data races in the eviction/wake-up bookkeeping under real concurrent
+// load. Every call's returned value is checked against the only value its
+// key could ever have decoded to, so a silently wrong result (not just a
+// hang or panic) would fail the test.
+func TestDecodeCacheStressConcurrentChurnWithSharedKeys(t *testing.T) {
+	c := newDecodeCache[int]()
+	const numSharedKeys = 8
+	sharedKeys := make([]decodeCacheKey, numSharedKeys)
+	for i := range sharedKeys {
+		sharedKeys[i] = decodeCacheKey{byte(i + 1)}
+	}
+
+	const numGoroutines = 64
+	const itersPerGoroutine = 300
+	var wg sync.WaitGroup
+	type failure struct {
+		goroutine, iter  int
+		wantValue, value int
+		err              error
+	}
+	failures := make(chan failure, numGoroutines*itersPerGoroutine)
+
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range itersPerGoroutine {
+				if i%2 == 0 {
+					// Shared key: exercises concurrent waiter registration
+					// -- many goroutines competing for the same in-flight
+					// decode -- while eviction churn runs alongside it.
+					idx := i % numSharedKeys
+					want := (idx + 1) * 1000
+					value, err, _ := c.getOrDecode(
+						sharedKeys[idx],
+						func() (int, error) { return want, nil },
+					)
+					if err != nil || value != want {
+						failures <- failure{g, i, want, value, err}
+					}
+				} else {
+					// Unique key: never reused anywhere else in this test,
+					// so it forces a genuine miss every time and drives
+					// sustained eviction once the cache is past capacity.
+					var key decodeCacheKey
+					key[0] = 0xF0
+					key[1] = byte(g)
+					key[2] = byte(i)
+					key[3] = byte(i >> 8)
+					want := g*100000 + i
+					value, err, _ := c.getOrDecode(
+						key,
+						func() (int, error) { return want, nil },
+					)
+					if err != nil || value != want {
+						failures <- failure{g, i, want, value, err}
+					}
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(failures)
+
+	var bad []failure
+	for f := range failures {
+		bad = append(bad, f)
+	}
+	require.Empty(
+		t, bad,
+		"silently wrong decode results under concurrent churn: %+v", bad,
+	)
+	require.LessOrEqual(t, decodeCacheLen(c), decodeCacheMaxEntries)
+}
+
+// --- Part 2: real-decode-function integration tests ------------------------
+//
+// These run the actual decodeBlockfetchBlock/decodeChainsyncHeader functions
+// (via a real *Ouroboros) against real Conway fixture bytes from
+// ouroboros-mock, through the shared caches, proving the wiring -- not just
+// the generic mechanism -- behaves correctly on genuine chain data.
+
+func testOuroborosForDecodeCache(tb testing.TB) *Ouroboros {
+	tb.Helper()
+	return &Ouroboros{
+		config:            OuroborosConfig{},
+		blockDecodeCache:  newDecodeCache[gledger.Block](),
+		headerDecodeCache: newDecodeCache[gledger.BlockHeader](),
+	}
+}
+
+func conwayBlockFixtureBytes(t *testing.T) (blockType uint, raw []byte) {
+	t.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(t.TempDir())
+	require.NoError(t, err)
+	fixture, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/Block_Conway",
+	)
+	require.NoError(t, err)
+	blockType, err = fixture.LedgerBlockType()
+	require.NoError(t, err)
+	raw, err = fixture.LedgerBlockBytes()
+	require.NoError(t, err)
+	return blockType, raw
+}
+
+func conwayHeaderFixtureBytes(t *testing.T) (headerType uint, raw []byte) {
+	t.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(t.TempDir())
+	require.NoError(t, err)
+	fixture, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/Header_Conway",
+	)
+	require.NoError(t, err)
+	headerType, err = fixture.LedgerHeaderType()
+	require.NoError(t, err)
+	raw, err = fixture.LedgerHeaderBytes()
+	require.NoError(t, err)
+	return headerType, raw
+}
+
+func TestBlockDecodeCacheIntegrationRealConwayBlock(t *testing.T) {
+	o := testOuroborosForDecodeCache(t)
+	blockType, raw := conwayBlockFixtureBytes(t)
+	key := hashDecodeInput(blockType, raw)
+	var decodeCalls atomic.Int64
+
+	decodeOnce := func() (gledger.Block, error) {
+		decodeCalls.Add(1)
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+
+	block1, err, decoded1 := o.blockDecodeCache.getOrDecode(key, decodeOnce)
+	require.NoError(t, err)
+	require.True(t, decoded1)
+	require.NotNil(t, block1)
+
+	block2, err, decoded2 := o.blockDecodeCache.getOrDecode(key, decodeOnce)
+	require.NoError(t, err)
+	require.False(t, decoded2, "identical real block bytes must hit the cache")
+	require.NotNil(t, block2)
+	require.EqualValues(t, 1, decodeCalls.Load())
+	require.Equal(
+		t, block1.Hash(), block2.Hash(),
+		"cached result must decode to the same block",
+	)
+}
+
+func TestHeaderDecodeCacheIntegrationRealConwayHeader(t *testing.T) {
+	o := testOuroborosForDecodeCache(t)
+	headerType, raw := conwayHeaderFixtureBytes(t)
+	key := hashDecodeInput(headerType, raw)
+	var decodeCalls atomic.Int64
+
+	decodeOnce := func() (gledger.BlockHeader, error) {
+		decodeCalls.Add(1)
+		return o.decodeChainsyncHeader(headerType, raw)
+	}
+
+	header1, err, decoded1 := o.headerDecodeCache.getOrDecode(key, decodeOnce)
+	require.NoError(t, err)
+	require.True(t, decoded1)
+	require.NotNil(t, header1)
+
+	header2, err, decoded2 := o.headerDecodeCache.getOrDecode(key, decodeOnce)
+	require.NoError(t, err)
+	require.False(t, decoded2, "identical real header bytes must hit the cache")
+	require.NotNil(t, header2)
+	require.EqualValues(t, 1, decodeCalls.Load())
+	require.Equal(
+		t, header1.Hash(), header2.Hash(),
+		"cached result must decode to the same header",
+	)
+}
+
+// TestBlockDecodeCacheCorruptedDeliveryDoesNotContaminateGoodEntry covers the
+// "4 peers, one sends a corrupted copy" scenario discussed for #489: a
+// tampered copy of a real block hashes to a different key than the genuine
+// bytes, so it is decoded (and fails) completely independently, and can
+// never poison the cache entry the honest bytes produce.
+func TestBlockDecodeCacheCorruptedDeliveryDoesNotContaminateGoodEntry(
+	t *testing.T,
+) {
+	o := testOuroborosForDecodeCache(t)
+	blockType, goodRaw := conwayBlockFixtureBytes(t)
+	badRaw := make([]byte, len(goodRaw))
+	copy(badRaw, goodRaw)
+	badRaw[len(badRaw)/2] ^= 0xFF // flip a byte in the middle of the CBOR
+
+	goodKey := hashDecodeInput(blockType, goodRaw)
+	badKey := hashDecodeInput(blockType, badRaw)
+	require.NotEqual(
+		t, goodKey, badKey,
+		"corrupted bytes must hash to a different cache key than the original",
+	)
+
+	goodBlock, goodErr, _ := o.blockDecodeCache.getOrDecode(
+		goodKey,
+		func() (gledger.Block, error) {
+			return o.decodeBlockfetchBlock(blockType, goodRaw)
+		},
+	)
+	require.NoError(t, goodErr)
+	require.NotNil(t, goodBlock)
+
+	// The corrupted delivery decodes (and most likely fails) on its own,
+	// independent entry -- it must not be able to overwrite or be confused
+	// with the good entry already cached above.
+	_, badErr, badDecoded := o.blockDecodeCache.getOrDecode(
+		badKey,
+		func() (gledger.Block, error) {
+			return o.decodeBlockfetchBlock(blockType, badRaw)
+		},
+	)
+	require.True(
+		t,
+		badDecoded,
+		"the corrupted bytes must be a genuine cache miss",
+	)
+
+	// Whatever the outcome for the corrupted bytes, the good entry must be
+	// completely unaffected.
+	goodBlockAgain, goodErrAgain, decodedAgain := o.blockDecodeCache.getOrDecode(
+		goodKey,
+		func() (gledger.Block, error) {
+			return o.decodeBlockfetchBlock(blockType, goodRaw)
+		},
+	)
+	require.NoError(t, goodErrAgain)
+	require.False(t, decodedAgain, "the good entry must still be cached")
+	require.NotNil(t, goodBlockAgain)
+	require.Equal(t, goodBlock.Hash(), goodBlockAgain.Hash())
+	t.Logf("corrupted-bytes decode outcome: %v", badErr)
+}
+
+// TestHeaderDecodeCacheCorruptedDeliveryDoesNotContaminateGoodEntry is
+// TestBlockDecodeCacheCorruptedDeliveryDoesNotContaminateGoodEntry's header
+// counterpart. Headers go through a meaningfully different decode path
+// (decodeChainsyncHeader has its own extra Byron-EBB fallback branch that
+// decodeBlockfetchBlock does not), so this is checked independently rather
+// than assumed to follow from the block version.
+func TestHeaderDecodeCacheCorruptedDeliveryDoesNotContaminateGoodEntry(
+	t *testing.T,
+) {
+	o := testOuroborosForDecodeCache(t)
+	headerType, goodRaw := conwayHeaderFixtureBytes(t)
+	badRaw := make([]byte, len(goodRaw))
+	copy(badRaw, goodRaw)
+	badRaw[len(badRaw)/2] ^= 0xFF
+
+	goodKey := hashDecodeInput(headerType, goodRaw)
+	badKey := hashDecodeInput(headerType, badRaw)
+	require.NotEqual(t, goodKey, badKey)
+
+	goodHeader, goodErr, _ := o.headerDecodeCache.getOrDecode(
+		goodKey,
+		func() (gledger.BlockHeader, error) {
+			return o.decodeChainsyncHeader(headerType, goodRaw)
+		},
+	)
+	require.NoError(t, goodErr)
+	require.NotNil(t, goodHeader)
+
+	_, badErr, badDecoded := o.headerDecodeCache.getOrDecode(
+		badKey,
+		func() (gledger.BlockHeader, error) {
+			return o.decodeChainsyncHeader(headerType, badRaw)
+		},
+	)
+	require.True(
+		t,
+		badDecoded,
+		"the corrupted bytes must be a genuine cache miss",
+	)
+
+	goodHeaderAgain, goodErrAgain, decodedAgain := o.headerDecodeCache.getOrDecode(
+		goodKey,
+		func() (gledger.BlockHeader, error) {
+			return o.decodeChainsyncHeader(headerType, goodRaw)
+		},
+	)
+	require.NoError(t, goodErrAgain)
+	require.False(t, decodedAgain, "the good entry must still be cached")
+	require.NotNil(t, goodHeaderAgain)
+	require.Equal(t, goodHeader.Hash(), goodHeaderAgain.Hash())
+	t.Logf("corrupted header decode outcome: %v", badErr)
+}
+
+// --- Part 3: gap-closing tests ---------------------------------------------
+//
+// These cover the specific gaps identified when reviewing the suite: real
+// production wiring (not just the cache mechanism in isolation), the
+// Musashi/Leios decode branch, the defensive nil-guard, cache-key
+// correctness, metrics, real-data concurrency, sustained-churn size bounds,
+// and an empty-input edge case.
+
+// TestBlockfetchClientBlockRawRoutesThroughSharedCache is the permanent
+// regression test for the actual production wiring, not just the cache
+// mechanism by itself. It calls the real blockfetchClientBlockRaw entry
+// point -- what a peer connection's callback really invokes -- twice with
+// identical real block bytes, and checks the cache's own hit/miss metrics
+// (not timing, which would be flaky in CI) to confirm the second call was
+// served from the cache. This is the test that would catch a future edit
+// accidentally breaking the glue between blockfetchClientBlockRaw and the
+// cache (wrong key, skipped call, wrong metric), which none of the other
+// tests in this file can see since they all call the pieces separately.
+func TestBlockfetchClientBlockRawRoutesThroughSharedCache(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{PromRegistry: prometheus.NewRegistry()})
+	blockType, raw := conwayBlockFixtureBytes(t)
+	ctx := blockfetch.CallbackContext{}
+
+	require.NoError(t, o.blockfetchClientBlockRaw(ctx, blockType, raw))
+	require.NoError(t, o.blockfetchClientBlockRaw(ctx, blockType, raw))
+
+	require.InDelta(
+		t, 1, testutil.ToFloat64(o.decodeCacheMetrics.blockCacheMisses), 0,
+		"the first delivery must be a real decode",
+	)
+	require.InDelta(
+		t, 1, testutil.ToFloat64(o.decodeCacheMetrics.blockCacheHits), 0,
+		"the second, identical delivery must be served from the cache",
+	)
+}
+
+// TestChainsyncClientRollForwardRawRoutesThroughSharedCache is
+// TestBlockfetchClientBlockRawRoutesThroughSharedCache's header/ChainSync
+// counterpart, covering the real chainsyncClientRollForwardRaw entry point.
+func TestChainsyncClientRollForwardRawRoutesThroughSharedCache(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{PromRegistry: prometheus.NewRegistry()})
+	headerType, raw := conwayHeaderFixtureBytes(t)
+	ctx := ochainsync.CallbackContext{ConnectionId: decodeCacheTestConnId()}
+	tip := ochainsync.Tip{}
+
+	require.NoError(
+		t,
+		o.chainsyncClientRollForwardRaw(ctx, headerType, raw, tip),
+	)
+	require.NoError(
+		t,
+		o.chainsyncClientRollForwardRaw(ctx, headerType, raw, tip),
+	)
+
+	require.InDelta(
+		t, 1, testutil.ToFloat64(o.decodeCacheMetrics.headerCacheMisses), 0,
+		"the first delivery must be a real decode",
+	)
+	require.InDelta(
+		t, 1, testutil.ToFloat64(o.decodeCacheMetrics.headerCacheHits), 0,
+		"the second, identical delivery must be served from the cache",
+	)
+}
+
+// TestBlockDecodeCacheWorksWithMusashiLeiosDecodeBranch covers the one
+// decode path this whole feature exists around: on the Musashi network,
+// decodeBlockfetchBlock routes Conway blocks through
+// models.DecodeConwayBlock instead of the strict gouroboros decoder --
+// that special case is the entire reason dingo takes the raw callback
+// instead of the decoded one (see decodeBlockfetchBlock's doc comment).
+// Every other test in this file exercises the default (non-Musashi) path;
+// this confirms the cache works correctly when that branch is the one
+// actually running.
+func TestBlockDecodeCacheWorksWithMusashiLeiosDecodeBranch(t *testing.T) {
+	o := testOuroborosForDecodeCache(t)
+	o.config.NetworkMagic = ouroboros.NetworkCardanoMusashi.NetworkMagic
+	blockType, raw := conwayBlockFixtureBytes(t)
+	require.EqualValues(
+		t, gledger.BlockTypeConway, blockType,
+		"fixture must be Conway to exercise the Musashi-specific decode branch",
+	)
+
+	key := hashDecodeInput(blockType, raw)
+	decodeFn := func() (gledger.Block, error) {
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+
+	block1, err, decoded1 := o.blockDecodeCache.getOrDecode(key, decodeFn)
+	require.NoError(t, err)
+	require.True(t, decoded1)
+	require.NotNil(t, block1)
+
+	block2, err, decoded2 := o.blockDecodeCache.getOrDecode(key, decodeFn)
+	require.NoError(t, err)
+	require.False(
+		t,
+		decoded2,
+		"identical bytes must hit the cache on the Musashi branch too",
+	)
+	require.NotNil(t, block2)
+	require.Equal(t, block1.Hash(), block2.Hash())
+}
+
+// TestBlockfetchClientBlockRawRejectsNilBlockWithNoError exercises the
+// defensive guard added after nilaway flagged that the generic cache cannot
+// itself guarantee "a nil value only ever accompanies a non-nil error" --
+// that contract is only a convention on decodeFn, not something the cache
+// type enforces. This forces exactly that violated state directly into the
+// cache (bypassing decodeFn, which in real use never produces it) and
+// confirms blockfetchClientBlockRaw returns an error instead of silently
+// passing a nil block down to the rest of the pipeline.
+func TestBlockfetchClientBlockRawRejectsNilBlockWithNoError(t *testing.T) {
+	o := testOuroborosForDecodeCache(t)
+	blockType, raw := conwayBlockFixtureBytes(t)
+	key := hashDecodeInput(blockType, raw)
+
+	decodeCacheInsertForTest[gledger.Block](
+		o.blockDecodeCache,
+		key,
+		nil,
+		time.Now(),
+	)
+
+	ctx := blockfetch.CallbackContext{}
+	err := o.blockfetchClientBlockRaw(ctx, blockType, raw)
+	require.Error(
+		t, err,
+		"a nil block with no error must be rejected, not passed downstream",
+	)
+}
+
+// TestChainsyncClientRollForwardRawRejectsNilHeaderWithNoError is
+// TestBlockfetchClientBlockRawRejectsNilBlockWithNoError's header
+// counterpart.
+func TestChainsyncClientRollForwardRawRejectsNilHeaderWithNoError(
+	t *testing.T,
+) {
+	o := testOuroborosForDecodeCache(t)
+	headerType, raw := conwayHeaderFixtureBytes(t)
+	key := hashDecodeInput(headerType, raw)
+
+	decodeCacheInsertForTest[gledger.BlockHeader](
+		o.headerDecodeCache,
+		key,
+		nil,
+		time.Now(),
+	)
+
+	ctx := ochainsync.CallbackContext{}
+	err := o.chainsyncClientRollForwardRaw(
+		ctx,
+		headerType,
+		raw,
+		ochainsync.Tip{},
+	)
+	require.Error(
+		t, err,
+		"a nil header with no error must be rejected, not passed downstream",
+	)
+}
+
+// TestHashDecodeInputMixesInBlockType covers the claim in hashDecodeInput's
+// doc comment directly: identical bytes under two different block types
+// must never collide to the same cache key.
+func TestHashDecodeInputMixesInBlockType(t *testing.T) {
+	_, raw := conwayBlockFixtureBytes(t)
+	keyA := hashDecodeInput(1, raw)
+	keyB := hashDecodeInput(2, raw)
+	require.NotEqual(
+		t,
+		keyA,
+		keyB,
+		"identical bytes under different block types must hash to different cache keys",
+	)
+}
+
+// TestDecodeCacheOutcomeMetricsCountHitsAndMissesCorrectly confirms the
+// Prometheus hit/miss counters actually reflect what happened, not just that
+// they exist. Two calls for one key (a miss then a hit) and one call for a
+// different key (a miss) should leave the counters at exactly 2 misses, 1
+// hit -- if the decoded flag were ever recorded backwards, this would catch
+// it, which nothing else in the suite checks.
+func TestDecodeCacheOutcomeMetricsCountHitsAndMissesCorrectly(t *testing.T) {
+	o := NewOuroboros(OuroborosConfig{PromRegistry: prometheus.NewRegistry()})
+	require.NotNil(t, o.decodeCacheMetrics)
+
+	keyA := decodeCacheKey{0x10}
+	keyB := decodeCacheKey{0x20}
+	decodeFn := func() (gledger.Block, error) { return nil, nil }
+
+	_, _, decodedA1 := o.blockDecodeCache.getOrDecode(keyA, decodeFn)
+	o.recordBlockDecodeCacheOutcome(decodedA1)
+	_, _, decodedA2 := o.blockDecodeCache.getOrDecode(keyA, decodeFn)
+	o.recordBlockDecodeCacheOutcome(decodedA2)
+	_, _, decodedB1 := o.blockDecodeCache.getOrDecode(keyB, decodeFn)
+	o.recordBlockDecodeCacheOutcome(decodedB1)
+
+	require.InDelta(
+		t, 2, testutil.ToFloat64(o.decodeCacheMetrics.blockCacheMisses), 0,
+		"keyA's first call and keyB's first call are both misses",
+	)
+	require.InDelta(
+		t, 1, testutil.ToFloat64(o.decodeCacheMetrics.blockCacheHits), 0,
+		"keyA's second call is a hit",
+	)
+}
+
+// TestBlockDecodeCacheConcurrentCallersShareOneRealDecode is
+// TestDecodeCacheConcurrentCallersShareOneDecode's real-data counterpart:
+// the earlier test proves the generic mechanism is race-safe using a
+// synthetic int payload; this repeats the same concurrent-race shape against
+// the actual gouroboros decode function and a real Conway block, so the
+// race guarantee is also demonstrated on genuine chain data end to end.
+func TestBlockDecodeCacheConcurrentCallersShareOneRealDecode(t *testing.T) {
+	o := testOuroborosForDecodeCache(t)
+	blockType, raw := conwayBlockFixtureBytes(t)
+	key := hashDecodeInput(blockType, raw)
+	var decodeCalls atomic.Int64
+
+	decodeFn := func() (gledger.Block, error) {
+		decodeCalls.Add(1)
+		return o.decodeBlockfetchBlock(blockType, raw)
+	}
+
+	const numCallers = 20
+	var wg sync.WaitGroup
+	results := make([]gledger.Block, numCallers)
+	errs := make([]error, numCallers)
+	for i := range numCallers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx], _ = o.blockDecodeCache.getOrDecode(
+				key,
+				decodeFn,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	require.EqualValues(
+		t, 1, decodeCalls.Load(),
+		"many concurrent callers for the same real block must share one decode",
+	)
+	for i := range numCallers {
+		require.NoError(t, errs[i])
+		require.NotNil(t, results[i])
+		require.Equal(t, results[0].Hash(), results[i].Hash())
+	}
+}
+
+// TestDecodeCacheNeverExceedsCapDuringSustainedChurn is a soak-style check
+// beyond TestDecodeCachePrunesBySizeWhenOverCapacity's single before/after
+// snapshot: it inserts several times the cache's capacity worth of distinct
+// keys and asserts the cap holds at every single step along the way, not
+// just once at the end, guarding against an eviction bug that only shows up
+// under sustained churn.
+func TestDecodeCacheNeverExceedsCapDuringSustainedChurn(t *testing.T) {
+	c := newDecodeCache[int]()
+	decodeFn := func() (int, error) { return 1, nil }
+
+	for i := range decodeCacheMaxEntries * 3 {
+		var key decodeCacheKey
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[2] = byte(i >> 16)
+		_, _, _ = c.getOrDecode(key, decodeFn)
+		require.LessOrEqual(
+			t,
+			decodeCacheLen(c),
+			decodeCacheMaxEntries,
+			"cache must never exceed its cap, at any point during churn, not just at the end",
+		)
+	}
+}
+
+// TestBlockDecodeCacheHandlesEmptyInputWithoutPanicking covers the edge case
+// of a zero-length delivery: it must fail to decode like any other garbage
+// input, not panic, and the failure must still be cached like any other
+// result.
+func TestBlockDecodeCacheHandlesEmptyInputWithoutPanicking(t *testing.T) {
+	o := testOuroborosForDecodeCache(t)
+	key := hashDecodeInput(0, nil)
+	decodeFn := func() (gledger.Block, error) {
+		return o.decodeBlockfetchBlock(0, nil)
+	}
+
+	_, err, decoded := o.blockDecodeCache.getOrDecode(key, decodeFn)
+	require.True(t, decoded)
+	require.Error(t, err, "empty input should fail to decode, not panic")
+
+	_, err2, decoded2 := o.blockDecodeCache.getOrDecode(key, decodeFn)
+	require.False(
+		t,
+		decoded2,
+		"the cached failure must be reused, not panic again",
+	)
+	require.Error(t, err2)
+}

--- a/ouroboros/decode_cache_test.go
+++ b/ouroboros/decode_cache_test.go
@@ -192,6 +192,47 @@ func TestDecodeCachePrunesExpiredEntries(t *testing.T) {
 	require.Zero(t, decodeCacheLen(c), "expired entry must be pruned")
 }
 
+// TestDecodeCacheExpiredEntryIsNotServedOnLookup is the regression test for
+// a real gap found in code review: eviction was entirely insertion-
+// triggered (evictLocked only ever ran from finishDecode, i.e. on a genuine
+// miss completing), so a key that keeps getting hit -- with no other key
+// ever decoded again in the meantime -- would never have its own age
+// re-checked and could be served from cache long past decodeCacheTTL. This
+// inserts an already-expired entry directly (bypassing getOrDecode, the
+// same way TestDecodeCachePrunesExpiredEntries does) and confirms a lookup
+// for that exact key detects the expiry itself, discards the stale entry,
+// and falls through to a genuine fresh decode instead of returning the
+// past-TTL cached value.
+func TestDecodeCacheExpiredEntryIsNotServedOnLookup(t *testing.T) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x09}
+	decodeCacheInsertForTest(
+		c, key, 111, time.Now().Add(-decodeCacheTTL-time.Second),
+	)
+	require.Equal(t, 1, decodeCacheLen(c))
+
+	decodeFn, calls := countingDecoder(222, nil, 0)
+	value, err, decoded := c.getOrDecode(key, decodeFn)
+	require.NoError(t, err)
+	require.True(
+		t, decoded,
+		"a lookup past the entry's TTL must be a genuine decode, not a hit",
+	)
+	require.Equal(
+		t, 222, value,
+		"the stale cached value must not be returned once past its TTL",
+	)
+	require.EqualValues(t, 1, calls.Load())
+
+	// The fresh decode is now the current cached entry: a second lookup
+	// immediately afterward must be a normal hit again.
+	value, err, decoded = c.getOrDecode(key, decodeFn)
+	require.NoError(t, err)
+	require.False(t, decoded)
+	require.Equal(t, 222, value)
+	require.EqualValues(t, 1, calls.Load())
+}
+
 // TestDecodeCachePrunesBySizeWhenOverCapacity checks the other cleanup
 // rule: if the cache gets too full, it removes the oldest entries to make
 // room, instead of growing without limit.

--- a/ouroboros/decode_cache_test.go
+++ b/ouroboros/decode_cache_test.go
@@ -521,6 +521,56 @@ func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 	require.Contains(t, err.Error(), "decode panicked")
 }
 
+// TestDecodeCachePanicNilDuringDecodeDoesNotStrandWaitersOrKey is the
+// regression test for a P1 bug found in code review: getOrDecode used to
+// decide "did decodeFn panic" by testing recover()'s return value for
+// nilness. recover() also returns nil when there is no panic at all, so a
+// bare panic(nil) inside decodeFn was indistinguishable from normal
+// completion -- the recovery branch would never run, this key's in-flight
+// claim would never be released, and every current and future waiter for
+// these exact bytes would block forever. This confirms a panic(nil)
+// decodeFn is still detected, still finishes the entry and wakes waiters,
+// and still re-raises to the caller, exactly like panicking with any other
+// value.
+func TestDecodeCachePanicNilDuringDecodeDoesNotStrandWaitersOrKey(
+	t *testing.T,
+) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x0E}
+
+	func() {
+		defer func() {
+			// recover() here returns the runtime's substituted, non-nil
+			// *runtime.PanicNilError on modern Go rather than literal nil,
+			// but the fix does not depend on that: it is unconditional on
+			// completed, not on recover()'s value, so this holds either way.
+			_ = recover()
+		}()
+		_, _, _ = c.getOrDecode(key, func() (int, error) {
+			panic(nil)
+		})
+		t.Fatal("getOrDecode must still panic for a panic(nil) decodeFn")
+	}()
+
+	require.Zero(
+		t,
+		len(c.inFlight),
+		"the in-flight claim must be released even when decodeFn panics with nil",
+	)
+
+	_, err, decoded := c.getOrDecode(key, func() (int, error) {
+		t.Fatal("decodeFn must not run again for an already-cached panic")
+		return 0, nil
+	})
+	require.False(t, decoded)
+	require.Error(
+		t,
+		err,
+		"the panic(nil) must still be recorded as a cached failure",
+	)
+	require.Contains(t, err.Error(), "decode panicked")
+}
+
 // TestDecodeWithPanicSafeMetricsRecordsMissOnPanic is the regression test for
 // a real bug found in code review: getOrDecode's own panic recovery
 // re-raises after cleaning up the cache (see
@@ -530,12 +580,13 @@ func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 // the returned decoded bool" line never runs, and a genuine decode attempt
 // (a miss) that happened to panic went uncounted in the hit/miss metrics.
 // This confirms decodeWithPanicSafeMetrics -- the helper both wrappers now
-// call through -- invokes recordMiss exactly once before re-raising the
-// panic, and that the panic still propagates to the caller unchanged.
+// call through -- invokes recordOutcome(true) exactly once before
+// re-raising the panic, and that the panic still propagates to the caller
+// unchanged.
 func TestDecodeWithPanicSafeMetricsRecordsMissOnPanic(t *testing.T) {
 	c := newDecodeCache[int]()
 	key := decodeCacheKey{0x08}
-	var missCount atomic.Int64
+	var outcomes []bool
 
 	func() {
 		defer func() {
@@ -543,86 +594,177 @@ func TestDecodeWithPanicSafeMetricsRecordsMissOnPanic(t *testing.T) {
 			require.NotNil(t, r, "the panic must still propagate to the caller")
 			require.Equal(t, "simulated decode panic", r)
 		}()
-		_, _, _ = decodeWithPanicSafeMetrics(
+		_, _ = decodeWithPanicSafeMetrics(
 			c,
 			key,
 			func() (int, error) { panic("simulated decode panic") },
-			func() { missCount.Add(1) },
+			func(isMiss bool) { outcomes = append(outcomes, isMiss) },
 		)
 		t.Fatal("decodeWithPanicSafeMetrics must not return normally on panic")
 	}()
 
-	require.EqualValues(
+	require.Equal(
 		t,
-		1,
-		missCount.Load(),
+		[]bool{true},
+		outcomes,
 		"a genuine decode attempt that panicked must still be recorded as a miss",
 	)
 
 	// The panic is cached like any other failure (see
 	// TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey): a later
-	// call for the same key must not invoke decodeFn or recordMiss again.
-	_, err, decoded := decodeWithPanicSafeMetrics(
+	// call for the same key must not invoke decodeFn again, but must still
+	// be recorded as a miss (not a hit) -- see
+	// TestDecodeWithPanicSafeMetricsNeverRecordsAFailureAsAHit.
+	_, err := decodeWithPanicSafeMetrics(
 		c,
 		key,
 		func() (int, error) {
 			t.Fatal("decodeFn must not run again for an already-cached panic")
 			return 0, nil
 		},
-		func() { missCount.Add(1) },
+		func(isMiss bool) { outcomes = append(outcomes, isMiss) },
 	)
-	require.False(t, decoded)
 	require.Error(t, err)
-	require.EqualValues(t, 1, missCount.Load())
+	require.Equal(t, []bool{true, true}, outcomes)
+}
+
+// TestDecodeWithPanicSafeMetricsNeverRecordsAFailureAsAHit is the
+// regression test for a real bug found in code review: getOrDecode's
+// decoded flag is false for both a genuine cache hit AND a waiter woken by
+// -- or a lookup hitting -- an already-failed outcome (corrupted/tampered
+// bytes, or a panic another goroutine already recorded). Recording purely
+// on decoded would inflate the hit counter with one entry per caller that
+// ever touches a failed delivery, when no successful decode was ever
+// reused. This confirms decodeWithPanicSafeMetrics reports every failed
+// outcome as a miss regardless of which internal path produced it (a fresh
+// failing decode, or a repeat hit on that same now-cached failure), and
+// still reports a genuine successful hit as a hit.
+func TestDecodeWithPanicSafeMetricsNeverRecordsAFailureAsAHit(t *testing.T) {
+	c := newDecodeCache[int]()
+	failKey := decodeCacheKey{0x0C}
+	okKey := decodeCacheKey{0x0D}
+	wantErr := errors.New("bad bytes")
+	var outcomes []bool
+	record := func(isMiss bool) { outcomes = append(outcomes, isMiss) }
+
+	// Fresh failure: a genuine miss, correctly true regardless of the fix.
+	_, err := decodeWithPanicSafeMetrics(
+		c, failKey, func() (int, error) { return 0, wantErr }, record,
+	)
+	require.ErrorIs(t, err, wantErr)
+
+	// Repeat of the identical bad bytes: served from the cached failure
+	// (decoded=false internally), but must still be a miss, not a hit --
+	// this is the specific case the fix addresses.
+	_, err = decodeWithPanicSafeMetrics(
+		c, failKey, func() (int, error) {
+			t.Fatal("decodeFn must not run again for a cached failure")
+			return 0, nil
+		}, record,
+	)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(
+		t, []bool{true, true}, outcomes,
+		"both the fresh failure and the repeat hit on it must count as misses",
+	)
+
+	// A genuine success, then a genuine hit on it: true then false, exactly
+	// matching getOrDecode's own decoded contract -- the fix must not touch
+	// this case.
+	outcomes = nil
+	_, err = decodeWithPanicSafeMetrics(
+		c, okKey, func() (int, error) { return 7, nil }, record,
+	)
+	require.NoError(t, err)
+	_, err = decodeWithPanicSafeMetrics(
+		c, okKey, func() (int, error) {
+			t.Fatal("decodeFn must not run again for a cache hit")
+			return 0, nil
+		}, record,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []bool{true, false}, outcomes)
 }
 
 // TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes is the
-// deterministic regression test for a second real bug found by re-auditing
-// this file for a narrow/stress gap: a waiter used to be woken by a closed
-// signal channel and then re-read its answer from c.entries[key]. But an
-// entry can be evicted by unrelated churn (many other keys being inserted)
-// in the window between "the leader signals waiters" and "a descheduled
-// waiter resumes and re-acquires the lock" -- so a waiter could silently
-// observe a zero-value/nil "success" instead of the real decode outcome,
-// with no error and no panic to reveal anything went wrong. This
-// reconstructs that exact race deterministically (no reliance on scheduler
-// timing) by manually evicting the entry in the gap between "insert" and
-// "signal", and confirms the waiter still gets the real answer -- because
-// finishDecode now sends the result directly through the wait channel
-// instead of the waiter re-reading the (possibly-since-evicted) map.
+// regression test for a real bug found by re-auditing this file for a
+// narrow/stress gap: a waiter used to be woken by a closed signal channel
+// and then re-read its answer from c.entries[key]. But an entry can be
+// evicted by unrelated churn (many other keys being inserted) in the window
+// between "the leader signals waiters" and "a descheduled waiter resumes and
+// re-acquires the lock" -- so a waiter could silently observe a
+// zero-value/nil "success" instead of the real decode outcome, with no
+// error and no panic to reveal anything went wrong.
+//
+// An earlier version of this test constructed the in-flight map by hand and
+// sent the result to the waiter's channel itself, never calling getOrDecode
+// or finishDecode at all -- it could not have caught a regression to the
+// old closed-signal-channel design, since the delivery it asserted on was
+// the test's own code, not production code. This version drives both
+// participants through the real getOrDecode (the leader via a real
+// in-flight decode, the waiter by genuinely registering as a waiter on it)
+// so finishDecode's real channel-send is what delivers the result; the map
+// is only touched afterward, to simulate the "evicted by unrelated churn"
+// condition itself, which is external to the delivery mechanism being
+// tested.
 func TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes(
 	t *testing.T,
 ) {
 	c := newDecodeCache[int]()
 	key := decodeCacheKey{0x77}
+	release := make(chan struct{})
+	leaderStarted := make(chan struct{})
 
-	c.mu.Lock()
-	ch := make(chan decodeCacheResult[int], 1)
-	c.inFlight[key] = []chan decodeCacheResult[int]{ch}
-	c.mu.Unlock()
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _, _ = c.getOrDecode(key, func() (int, error) {
+			close(leaderStarted)
+			<-release
+			return 999, nil
+		})
+	}()
+	<-leaderStarted
 
 	waiterDone := make(chan struct{})
 	var gotValue int
 	var gotErr error
+	var gotDecoded bool
 	go func() {
 		defer close(waiterDone)
-		result := <-ch
-		gotValue, gotErr = result.value, result.err
+		gotValue, gotErr, gotDecoded = c.getOrDecode(
+			key,
+			func() (int, error) {
+				t.Error("the waiter must not run decodeFn itself")
+				return 0, nil
+			},
+		)
 	}()
+	// Confirm the waiter has genuinely registered itself in c.inFlight[key]
+	// -- the real waiter-registration code path in getOrDecode -- before
+	// releasing the leader.
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.inFlight[key]) == 1
+	}, 2*time.Second, 5*time.Millisecond)
 
-	c.mu.Lock()
-	elem := c.order.PushBack(key)
-	c.entries[key] = decodeCacheEntry[int]{
-		value: 999, err: nil, insertedAt: time.Now(),
+	close(release)
+	select {
+	case <-leaderDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader never returned")
 	}
-	delete(c.inFlight, key)
-	// Simulate a flood of unrelated churn evicting this exact entry before
-	// the waiter goroutine above gets scheduled to do anything with it.
-	c.order.Remove(elem)
+	// The leader's getOrDecode call has now returned, which only happens
+	// after finishDecode has already inserted the entry AND sent the result
+	// to the waiter's (buffered) channel. Deleting the entry here simulates
+	// unrelated churn evicting it before the waiter goroutine gets around
+	// to reading its already-delivered value -- it must have no effect on
+	// what the waiter receives, since finishDecode delivers the result
+	// directly rather than the waiter re-reading this map.
+	c.mu.Lock()
 	delete(c.entries, key)
 	c.mu.Unlock()
-
-	ch <- decodeCacheResult[int]{value: 999, err: nil}
 
 	select {
 	case <-waiterDone:
@@ -636,6 +778,7 @@ func TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes(
 		"waiter must get the real decode result even though its entry was evicted before it read anything",
 	)
 	require.NoError(t, gotErr)
+	require.False(t, gotDecoded, "the waiter itself never ran decodeFn")
 }
 
 // TestDecodeCacheStressConcurrentChurnWithSharedKeys is a stress test
@@ -1000,6 +1143,99 @@ func TestChainsyncClientRollForwardRawRoutesThroughSharedCache(t *testing.T) {
 		t, 1, testutil.ToFloat64(o.decodeCacheMetrics.headerCacheHits), 0,
 		"the second, identical delivery must be served from the cache",
 	)
+}
+
+// TestBlockfetchClientBlockRawRecordsRepeatedFailureAsMissesNotHits is the
+// regression test, through the real production wrapper and real Prometheus
+// counters, for a bug found in code review: a delivery that never decodes
+// successfully -- fresh, or replayed from the cached failure, exactly like
+// a second peer relaying the same tampered/corrupted bytes -- was recorded
+// as a hit whenever getOrDecode's own decoded flag was false, which is true
+// for every repeat lookup regardless of whether the cached outcome was a
+// success or a failure. Two calls with identical corrupted bytes must both
+// count as misses; neither ever represents a successful decode being
+// reused.
+func TestBlockfetchClientBlockRawRecordsRepeatedFailureAsMissesNotHits(
+	t *testing.T,
+) {
+	o := NewOuroboros(OuroborosConfig{PromRegistry: prometheus.NewRegistry()})
+	blockType, raw := conwayBlockFixtureBytes(t)
+	badRaw := make([]byte, len(raw))
+	copy(badRaw, raw)
+	badRaw[len(badRaw)/2] ^= 0xFF
+	ctx := blockfetch.CallbackContext{}
+
+	require.Error(t, o.blockfetchClientBlockRaw(ctx, blockType, badRaw))
+	require.Error(t, o.blockfetchClientBlockRaw(ctx, blockType, badRaw))
+
+	require.InDelta(
+		t, 2, testutil.ToFloat64(o.decodeCacheMetrics.blockCacheMisses), 0,
+		"both calls represent a failed decode and must count as misses",
+	)
+	require.Zero(
+		t,
+		testutil.ToFloat64(o.decodeCacheMetrics.blockCacheHits),
+		"a failed decode -- fresh or replayed from the cached failure -- must never count as a hit",
+	)
+}
+
+// TestDecodeCacheConcurrentWaitersOnFailureAreAllRecordedAsMisses proves the
+// same fix for the concurrent-waiter case specifically: N callers racing on
+// one in-flight decode that ultimately fails all get decoded=false from
+// getOrDecode (none of them ran decodeFn themselves), but none of them ever
+// represents a successful decode being reused either. Applying
+// decoded||err!=nil -- the formula decodeWithPanicSafeMetrics now uses --
+// to every participant (the leader included) must classify all of them as
+// misses.
+func TestDecodeCacheConcurrentWaitersOnFailureAreAllRecordedAsMisses(
+	t *testing.T,
+) {
+	c := newDecodeCache[int]()
+	key := decodeCacheKey{0x0A}
+	wantErr := errors.New("bad bytes")
+	release := make(chan struct{})
+	leaderStarted := make(chan struct{})
+	var leaderOnce sync.Once
+
+	const numWaiters = 4
+	type outcome struct {
+		decoded bool
+		err     error
+	}
+	results := make([]outcome, numWaiters)
+	var wg sync.WaitGroup
+	wg.Add(numWaiters)
+	for i := range numWaiters {
+		go func(idx int) {
+			defer wg.Done()
+			_, err, decoded := c.getOrDecode(key, func() (int, error) {
+				leaderOnce.Do(func() { close(leaderStarted) })
+				<-release
+				return 0, wantErr
+			})
+			results[idx] = outcome{decoded, err}
+		}(i)
+	}
+
+	<-leaderStarted
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.inFlight[key]) == numWaiters-1
+	}, 2*time.Second, 5*time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, r := range results {
+		require.ErrorIs(t, r.err, wantErr, "caller %d", i)
+		isMiss := r.decoded || r.err != nil
+		require.True(
+			t,
+			isMiss,
+			"caller %d: a failed delivery must never be recorded as a hit, whether it ran decodeFn itself or shared a failing in-flight decode",
+			i,
+		)
+	}
 }
 
 // TestBlockDecodeCacheWorksWithMusashiLeiosDecodeBranch covers the one

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/dingo/mempool"
 	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	oprotocol "github.com/blinklabs-io/gouroboros/protocol"
 	oblockfetch "github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -75,17 +76,24 @@ func blockfetchConfig(
 }
 
 type Ouroboros struct {
-	ConnManager              *connmanager.ConnectionManager
-	PeerGov                  *peergov.PeerGovernor
-	ChainsyncState           *chainsync.State
-	EventBus                 *event.EventBus
-	Mempool                  mempool.Service
-	LedgerState              *ledger.LedgerState
-	LeiosVotes               LeiosVoteHandler
-	LeiosPipeline            LeiosPipelineHandler
-	config                   OuroborosConfig
-	blockfetchMetrics        *blockfetchMetrics
-	protocolMetrics          *protocolMetrics
+	ConnManager       *connmanager.ConnectionManager
+	PeerGov           *peergov.PeerGovernor
+	ChainsyncState    *chainsync.State
+	EventBus          *event.EventBus
+	Mempool           mempool.Service
+	LedgerState       *ledger.LedgerState
+	LeiosVotes        LeiosVoteHandler
+	LeiosPipeline     LeiosPipelineHandler
+	config            OuroborosConfig
+	blockfetchMetrics *blockfetchMetrics
+	protocolMetrics   *protocolMetrics
+	// Shared cache of decoded blocks/headers keyed by content hash, so
+	// multiple connections delivering byte-identical data (the common case
+	// when several peers relay the same block) decode once instead of once
+	// per connection. See #489 and decode_cache.go.
+	blockDecodeCache         *decodeCache[gledger.Block]
+	headerDecodeCache        *decodeCache[gledger.BlockHeader]
+	decodeCacheMetrics       *decodeCacheMetrics
 	blockFetchStarts         map[ouroboros.ConnectionId]time.Time
 	blockFetchMutex          sync.Mutex
 	blockfetchNoBlocksCounts map[ouroboros.ConnectionId]blockfetchNoBlocksState
@@ -293,6 +301,8 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		chainsyncStats: make(
 			map[ouroboros.ConnectionId]*chainsyncPeerStats,
 		),
+		blockDecodeCache:           newDecodeCache[gledger.Block](),
+		headerDecodeCache:          newDecodeCache[gledger.BlockHeader](),
 		leiosEndorserBlocks:        make(map[string]*leiosEndorserBlockData),
 		leiosClosureWaiters:        make(map[string][]chan struct{}),
 		leiosEBLog:                 newLeiosForgedEBLog(),
@@ -315,6 +325,7 @@ func NewOuroboros(cfg OuroborosConfig) *Ouroboros {
 		o.initBlockfetchMetrics()
 		o.initProtocolMetrics()
 		o.initLeiosMetrics()
+		o.initDecodeCacheMetrics()
 	}
 	o.subscribeLeiosAnnouncementRetries()
 	return o


### PR DESCRIPTION
### Summary

Issue #489 ("move decoding of blocks/headers into ledger/consensus") turned out, after investigation, to really be about a confirmed real defect: dingo decoded identical block/header bytes independently for every peer connection that delivered them, even when several peers relayed the exact same freshly-produced block. This adds a shared, content-hash-keyed decode cache so identical deliveries are decoded once, while corrupted/tampered deliveries are always decoded and reported on independently — with no cross-contamination between the two.

### Changes made

**`ouroboros/decode_cache.go` (new)**

- `decodeCacheKey` — SHA-256 hash of `(blockType, raw bytes)`, not chain point, so a corrupted delivery from one peer can never poison the cache entry a good delivery from another peer produced.
- `decodeCache[T any]` (generic, one instance each for `gledger.Block` and `gledger.BlockHeader`) — bounded (1024 entries / 2 min TTL) cache of decode outcomes, with a waiter mechanism (mirroring the existing `leiosEndorserBlocks`/`leiosClosureWaiters` pattern) so concurrent callers submitting identical bytes share one decode.
- `getOrDecode` — runs `decodeFn` at most once per key; every other concurrent caller for that key blocks on a channel and is woken with the result.
  - Panic safety: a `defer`/`recover` around the decode call records a panic as a normal cached failure and wakes every waiter, then re-raises it — so a panicking decode (malformed/adversarial peer bytes) no longer permanently strands other connections waiting on that key.
  - Waiter-delivery safety: the result is sent directly through each waiter's channel (`decodeCacheResult[T]`), not re-read from the shared map after waking — closing a race where a waiter's entry could be evicted by unrelated churn in the gap between being signaled and re-acquiring the lock, which would otherwise silently hand back a zero-value/nil "success."
- `evictLocked` — O(1)-amortized FIFO eviction via `container/list.List` (age-based, then size-based). An earlier full-resort-per-insert version was found via benchmarking to be 7–80x slower under sustained no-duplicate load; replaced before merge.
- `decodeCacheMetrics` — Prometheus hit/miss counters (`dingo_decode_cache_{block,header}_{hits,misses}_total`), initialized only when `PromRegistry` is configured.

**`ouroboros/blockfetch.go`**

- `blockfetchClientBlockRaw` now hashes the incoming bytes, calls `o.blockDecodeCache.getOrDecode` (wrapping the existing `decodeBlockfetchBlock`), and records the hit/miss outcome.
- Added an explicit `block == nil` guard (nilaway-flagged: the generic cache can't statically prove non-nil-value-implies-nil-err) that returns a clear error instead of forwarding a nil block downstream.

**`ouroboros/chainsync.go`**

- `chainsyncClientRollForwardRaw` gets the identical treatment via `o.headerDecodeCache.getOrDecode` wrapping `decodeChainsyncHeader`, plus the same `header == nil` guard.

**`ouroboros/ouroboros.go`**

- Added `blockDecodeCache *decodeCache[gledger.Block]`, `headerDecodeCache *decodeCache[gledger.BlockHeader]`, `decodeCacheMetrics *decodeCacheMetrics` fields to `Ouroboros`.
- `NewOuroboros` initializes both caches unconditionally and calls `initDecodeCacheMetrics()` when `PromRegistry` is set.

**`ARCHITECTURE.md`**

- New "Shared Block/Header Decode Cache" section documenting the design, the content-hash keying rationale, the waiter mechanism, panic-safety, and the waiter-delivery race fix.

### Tests

**`ouroboros/decode_cache_test.go` (36 test functions)**

Pure cache mechanism (isolated from real CBOR decoding):

- `TestDecodeCacheHitAvoidsRedecode` — a second call for the same key reuses the cached result instead of decoding again
- `TestDecodeCacheDifferentKeysDecodeIndependently` — distinct keys never cross-contaminate each other
- `TestDecodeCacheFailureIsCachedAndNotRetried` — a failed decode is cached and not retried on a repeat submission
- `TestDecodeCachePrunesExpiredEntries` — TTL eviction removes entries older than the cutoff
- `TestDecodeCachePrunesBySizeWhenOverCapacity` — size-cap eviction removes the oldest entry first
- `TestDecodeCacheConcurrentCallersShareOneDecode` — 50 concurrent callers on one key share exactly one decode
- `TestDecodeCacheConcurrentDifferentKeysDoNotSerialize` — the lock is never held across the decode call itself, so different keys decode in parallel
- `TestDecodeCacheNoGoroutineLeakOnFailure` — all waiters wake with a shared failure instead of being left hanging
- `TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey` — a panicking decode still wakes every waiter and clears the in-flight claim instead of stranding them forever
- `TestDecodeCacheWaiterGetsResultEvenIfItsEntryIsEvictedBeforeItWakes` — deterministic reproduction proving a waiter still gets the real result even if its entry is evicted before it wakes
- `TestDecodeCacheStressConcurrentChurnWithSharedKeys` — stress test: 64 goroutines hammering 8 contended shared keys plus thousands of unique keys churning past the cap, all at once, under `-race`
- `TestHashDecodeInputMixesInBlockType` — identical bytes under different block types never collide to the same key
- `TestDecodeCacheOutcomeMetricsCountHitsAndMissesCorrectly` — the Prometheus counters reflect exact hit/miss counts, not just their existence
- `TestDecodeCacheNeverExceedsCapDuringSustainedChurn` — the cap holds at every single step of sustained churn, not just at the end

Real-decode-function integration (real Conway fixtures via `ouroboros-mock`):

- `TestBlockDecodeCacheIntegrationRealConwayBlock` / `TestHeaderDecodeCacheIntegrationRealConwayHeader` — the cache works correctly against genuine chain data, not just synthetic values
- `TestBlockDecodeCacheCorruptedDeliveryDoesNotContaminateGoodEntry` and its header counterpart — a corrupted delivery never poisons a good entry for the same nominal block
- `TestBlockfetchClientBlockRawRoutesThroughSharedCache` / `TestChainsyncClientRollForwardRawRoutesThroughSharedCache` — the real production entry points actually route through the cache, verified via Prometheus counters rather than timing (to avoid flakiness)
- `TestBlockDecodeCacheWorksWithMusashiLeiosDecodeBranch` — the cache works correctly on the Musashi/Leios-header decode branch, the actual reason dingo takes the raw callback at all
- `TestBlockfetchClientBlockRawRejectsNilBlockWithNoError` and its header counterpart — the nilaway-flagged nil-guard actually fires when forced
- `TestBlockDecodeCacheConcurrentCallersShareOneRealDecode` — the concurrency-sharing guarantee holds against real block bytes, not just a synthetic int
- `TestBlockDecodeCacheHandlesEmptyInputWithoutPanicking` — zero-length input fails cleanly with an error instead of panicking

**`ouroboros/decode_cache_bench_test.go` (11 benchmarks)**

Direct-decode baseline versus all-duplicate, all-unique, mixed-ratio (80% hit), and concurrent variants, for both blocks and headers. These caught the 7–80x eviction regression before merge and characterize the worst-case (all-unique) overhead at roughly 1–15%.

Closes #489 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares a content-hash decode cache for blocks and headers across peer connections to eliminate redundant CBOR decoding. Before: each connection decoded identical bytes. Now: the first identical payload decodes once and others reuse it; corrupted/tampered bytes and panics are isolated and cached as failures; TTL is enforced on lookup.

- New `ouroboros/decode_cache.go`: generic, bounded cache (1024 entries/2‑min TTL) keyed by SHA‑256 of `(blockType, raw bytes)` with per‑key waiters; decodes run outside the lock; FIFO eviction; TTL checked on lookup; failures and panics (including panic(nil)) are cached; waiters receive results directly to avoid eviction races.
- `decodeWithPanicSafeMetrics`: ensures a miss is recorded when a decode panics and that any failure (fresh or cached) is never counted as a hit.
- `ouroboros/blockfetch.go` and `ouroboros/chainsync.go`: route raw bytes through the shared cache; add guards that error on nil decoded values; wire Prometheus counters.
- `ouroboros/ouroboros.go`: `Ouroboros` now holds `blockDecodeCache`/`headerDecodeCache`; initializes `dingo_decode_cache_{block,header}_{hits,misses}_total`.
- Docs/tests/benchmarks: `ARCHITECTURE.md` documents design; extensive tests cover concurrency, TTL-on-lookup, panic(nil), metrics correctness, and real Conway fixtures; benchmarks added (and fixed `testing.B.RunParallel` Fatalf misuse).

<sup>Written for commit ee506afd2de9382278db575ec877daa2580fd59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Added shared caching for block and header decoding, reducing repeated work for identical data.
  - Concurrent requests for the same content now share a single decode operation.
  - Added bounded, time-limited cache behavior to control resource usage.

- **Reliability**
  - Improved handling of decoding failures, panics, corrupted data, and invalid empty results.
  - Added Prometheus metrics for cache hits and misses.

- **Testing**
  - Added comprehensive coverage for caching, concurrency, eviction, failures, metrics, and real block/header decoding scenarios.
  - Added benchmarks comparing direct and cached decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->