### PR TITLE
test(event): stop the unsubscribe test leaking its async worker

### DIFF
--- a/event/event_test.go
+++ b/event/event_test.go
@@ -331,6 +331,10 @@ func TestEventBusCloseDiscardsQueuedSubscriberEvents(t *testing.T) {
 func TestEventBusUnsubscribePreservesQueuedSubscriberEvents(t *testing.T) {
 	const testEvtType event.EventType = "test.unsubscribe.preserves"
 	eb := event.NewEventBus(nil, nil)
+	// Close, not Stop: NewEventBus starts an async worker unconditionally, and
+	// Stop reinitializes it (restart=true) rather than leaving it stopped, so
+	// only Close lets the worker goroutine exit when the test ends.
+	defer eb.Close()
 
 	entered := make(chan struct{})
 	release := make(chan struct{})


### PR DESCRIPTION
`TestEventBusUnsubscribePreservesQueuedSubscriberEvents` creates an EventBus and never shuts it down, so the async worker `NewEventBus` starts unconditionally outlives the test and lingers for the rest of the package run.

Raised by cubic on #3203 (https://github.com/blinklabs-io/dingo/pull/3203#discussion_r3805376890) after that PR was approved; split out rather than pushed onto an approved head.

**Close, not Stop.** The sibling tests use `defer eb.Stop()`, but `Stop` is `shutdown(restart: true)` and reinitializes the async infrastructure at the end, so it leaves a fresh worker running. Only `Close` (`shutdown(restart: false)`) lets the goroutine exit. `Close` is also the right semantic here: this test asserts queued subscriber events are *preserved*, and all its assertions complete before the deferred cleanup runs.

**Measured**, running only this test plus a probe that reports `runtime.NumGoroutine()` after a GC and settle:

| | goroutines at end |
|---|---|
| before | 6 |
| after | 2 |

**Validation:** `go test -race ./event/...` passes (172s); `golangci-lint` and `nilaway` clean on `./event/...`; `make import-boundaries` and `make docs-parity` pass. Not run: the full tree, since this is a one-line test-only change confined to `event/`.

**Follow-up, not changed here:** the same reasoning applies to the other `defer eb.Stop()` deferrals in this file — each leaves a restarted worker behind. They are left alone to keep this minor fix scoped; some may rely on the bus staying reusable, so converting them needs a per-test read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a goroutine leak in `TestEventBusUnsubscribePreservesQueuedSubscriberEvents` by deferring `eb.Close()` instead of `eb.Stop()`. Previously the test left a restarted async worker running after completion; now `Close` shuts the worker down so no goroutines linger.

- Scope: test-only change in `event/event_test.go`; no production behavior.
- Why: `NewEventBus` always starts a worker; `Stop` performs `shutdown(restart: true)` (restarts the worker); `Close` performs `shutdown(restart: false)` (lets the worker exit).
- Functional effect: test semantics remain; it still verifies queued subscriber events are preserved before cleanup runs.
- Evidence: goroutines at end drop from 6 to 2 when running this test in isolation.
- Follow-up: other tests still use `eb.Stop()` and may leave a worker; not changed here.

<sup>Written for commit 7e9593b1fbb48ce901bb6accbc3930c8a4d772fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup by ensuring asynchronous event processing shuts down after the test completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->