### PR TITLE
fix(ledger): preserve transaction event ordering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -375,23 +375,56 @@ sequenceDiagram
 `ledger.tx` is published with `PublishOrdered`, not `PublishAsync`, so a
 subscriber deriving state from it sees a block's transactions in index order
 and sees a rollback's undo events (`Rollback: true`) before any transaction
-event the ledger emits afterwards. Both halves of that contract are required:
-`handleEventChainUpdate` (`ledger/block_event.go`) emits the per-transaction
-undo events on its own goroutine rather than a detached one — it is a
-`SubscribeFunc` dispatch, so its invocations are already serialized in
-chain-update order — and the ordered lane carries that order through to
-subscribers. Until #2287 the undo events were emitted from a `go` statement
-onto the reordering shared pool, so a subscriber could apply an undo after the
-redo that followed it and stay inconsistent with no later event to correct it.
-`LedgerState.Close` therefore no longer drains in-flight rollback goroutines;
-the `UnsubscribeAndWait` on `chain.ChainUpdateEventType` is what guarantees no
-emission is in flight.
+event the ledger emits afterwards.
 
-The forward path keeps async semantics deliberately: `LedgerDelta.apply`
-(`ledger/delta.go`) publishes from inside the block-apply database
-transaction, so a synchronous publish would hold that transaction open under
-subscriber backpressure. `ledger.block` remains `PublishBlocking` on the
-handler's own goroutine.
+Two producers feed that lane, on different goroutines: `LedgerDelta.apply`
+(`ledger/delta.go`) publishes forward events from the `ledgerProcessBlocks`
+goroutine, and the rollback path publishes undo events from whichever
+goroutine performs the rollback. Nothing serializes those two, so the ordering
+comes from a happens-before rather than from a lock:
+`rollbackChainAndState` calls `emitRollbackTransactionEvents` **before**
+`chain.Rollback` truncates. The apply goroutine can only apply a
+post-rollback block after it observes that truncation, so an undo enqueued
+ahead of the truncation is necessarily ahead of any forward event for a block
+applied after it.
+
+Getting this wrong is subtle, so the constraint is worth stating plainly:
+**the undo events must be emitted before the truncation, by the rollback
+path.** `handleEventChainUpdate` deliberately does *not* emit them, even
+though it receives `ChainRollbackEvent` with the rolled-back blocks. It is a
+`SubscribeFunc` dispatch reached only after `chain.Rollback` has published and
+returned, by which point the apply goroutine is already free to publish
+forward events — emitting there loses the race reproducibly. It still emits
+the `ledger.block` undo events, which are a different event type and so a
+different lane. Before #2287 the undo events were emitted from a `go`
+statement onto the reordering shared pool, which lost the same race twice
+over.
+
+The forward path keeps async semantics deliberately: it publishes from inside
+the block-apply database transaction, so a synchronous publish would hold that
+transaction open under subscriber backpressure. `ledger.block` remains
+`PublishBlocking` on the handler's own goroutine.
+
+Because a publisher parked on a full lane is released only by the EventBus
+stopping, and a live restore/truncate closes the `LedgerState` while keeping
+the bus running, ledger publishes go through `PublishOrderedContext` with a
+context `LedgerState.Close` cancels first thing. Without it `Close` waits
+unbounded on a `ledger.tx` subscriber that stopped draining.
+
+This is also the one deliberate exception to the publish-under-lock rule
+above. `rollbackChainAndState` runs under `chainsyncMutex` — it is reached
+through the `pendingPublishes` call chain — and emits undo events from there,
+because the ordering requires them to be enqueued before the truncation and
+the truncation happens under that same lock; deferring them to
+`pendingPublishes`' post-unlock flush would put them after it and lose the
+guarantee. What makes it safe is narrower than the general rule: the emit only
+*enqueues* onto a 10000-entry lane and never runs a subscriber callback
+inline, so it can block only if a `ledger.tx` subscriber stops draining long
+enough to fill the lane. **A `ledger.tx` subscriber must therefore not call
+back into `LedgerState` methods that take `chainsyncMutex`** (in practice
+`RecoverAfterLocalRollback` and anything reaching it). Subscribers that need
+to do real work should hand off to their own goroutine, which
+`event/doc.go` already requires of every subscriber callback.
 
 The BlockFetch server path mirrors the retrieval flow for downstream peers:
 when a peer requests a range, `ouroboros/blockfetch.go` validates the bounds,
@@ -1003,7 +1036,7 @@ All event types follow the `subsystem.snake_case_name` convention.
   on it — every parked publisher observes the same stall, so a per-delivery
   limit made the log volume scale with publisher count rather than with time
 - **Never `Publish`, `PublishAsync`, `PublishOrdered`, or `PublishBlocking`
-  while holding a lock that a subscriber of that event acquires.** Because all three wait for
+  while holding a lock that a subscriber of that event acquires.** Because all four wait for
   capacity rather than dropping, this is a deadlock, not merely a slow path:
   once the subscriber's buffer fills, the subscriber waits for the lock the
   publisher holds while the publisher waits for the capacity the subscriber

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -372,6 +372,27 @@ sequenceDiagram
     LS->>EB: publish TransactionEvent(rollback: true) per tx
 ```
 
+`ledger.tx` is published with `PublishOrdered`, not `PublishAsync`, so a
+subscriber deriving state from it sees a block's transactions in index order
+and sees a rollback's undo events (`Rollback: true`) before any transaction
+event the ledger emits afterwards. Both halves of that contract are required:
+`handleEventChainUpdate` (`ledger/block_event.go`) emits the per-transaction
+undo events on its own goroutine rather than a detached one — it is a
+`SubscribeFunc` dispatch, so its invocations are already serialized in
+chain-update order — and the ordered lane carries that order through to
+subscribers. Until #2287 the undo events were emitted from a `go` statement
+onto the reordering shared pool, so a subscriber could apply an undo after the
+redo that followed it and stay inconsistent with no later event to correct it.
+`LedgerState.Close` therefore no longer drains in-flight rollback goroutines;
+the `UnsubscribeAndWait` on `chain.ChainUpdateEventType` is what guarantees no
+emission is in flight.
+
+The forward path keeps async semantics deliberately: `LedgerDelta.apply`
+(`ledger/delta.go`) publishes from inside the block-apply database
+transaction, so a synchronous publish would hold that transaction open under
+subscriber backpressure. `ledger.block` remains `PublishBlocking` on the
+handler's own goroutine.
+
 The BlockFetch server path mirrors the retrieval flow for downstream peers:
 when a peer requests a range, `ouroboros/blockfetch.go` validates the bounds,
 opens a chain iterator at the requested start point, sends `StartBatch`, then
@@ -930,7 +951,7 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `mempool.add_tx` | Mempool | Transaction added |
 | `mempool.remove_tx` | Mempool | Transaction removed |
 | `ledger.block` | LedgerState | Block applied or rolled back |
-| `ledger.tx` | LedgerState | Transaction processed |
+| `ledger.tx` | LedgerState | Transaction processed (ordered lane — see below) |
 | `ledger.error` | LedgerState | Ledger error occurred |
 | `ledger.blockfetch` | Ouroboros | Block fetch event received |
 | `ledger.chainsync` | Ouroboros | Chainsync event received |
@@ -954,6 +975,17 @@ All event types follow the `subsystem.snake_case_name` convention.
 ### EventBus Features
 
 - Asynchronous delivery via worker pool (4 workers, 1000-entry async queue)
+- **Ordering.** `Publish` and `PublishBlocking` deliver on the caller's
+  goroutine, so one publisher's events reach a subscriber in call order.
+  `PublishAsync` does **not** preserve order: the shared queue is drained by
+  4 workers that race each other into `Publish`, so events enqueued in order
+  can be delivered in either order. `PublishOrdered` (`event/ordered.go`) is
+  the order-preserving async path — one FIFO per event type
+  (`OrderedQueueSize`, 10000 entries) drained by exactly one worker, created
+  lazily on first publish and torn down by `Stop`/`Close`. Its guarantee is
+  per event type and covers only publishes that are themselves sequenced;
+  concurrent publishers still race to enqueue. Per-type lanes also isolate a
+  slow subscriber to its own event type, unlike the shared pool
 - Default subscriber buffers of 1024 events, with opt-in 100000-entry burst
   buffers for high-volume ledger chainsync and chain-update paths. The
   payload-heavy ledger blockfetch path uses an eight-entry buffer and relies
@@ -970,8 +1002,8 @@ All event types follow the `subsystem.snake_case_name` convention.
   per subscriber, not per delivery, and reports how many publishers are parked
   on it — every parked publisher observes the same stall, so a per-delivery
   limit made the log volume scale with publisher count rather than with time
-- **Never `Publish`, `PublishAsync`, or `PublishBlocking` while holding a lock
-  that a subscriber of that event acquires.** Because all three wait for
+- **Never `Publish`, `PublishAsync`, `PublishOrdered`, or `PublishBlocking`
+  while holding a lock that a subscriber of that event acquires.** Because all three wait for
   capacity rather than dropping, this is a deadlock, not merely a slow path:
   once the subscriber's buffer fills, the subscriber waits for the lock the
   publisher holds while the publisher waits for the capacity the subscriber

--- a/event/doc.go
+++ b/event/doc.go
@@ -62,6 +62,17 @@
 // detached goroutine, a subscriber could apply an undo after the redo
 // that followed it and stay wrong indefinitely.
 //
+// A lane orders what reaches it; it cannot order two publishers racing
+// to reach it. Where events for one stream come from more than one
+// goroutine, as ledger.tx does, the publishers need their own
+// happens-before -- see the ledger.tx section of ARCHITECTURE.md for how
+// the rollback and block-apply paths establish theirs.
+//
+// Only shutdown releases a publisher waiting on a full lane. A caller on
+// a goroutine something else waits for before the bus stops must use
+// PublishOrderedContext and cancel that context, or the wait is
+// unbounded.
+//
 // # Delivery guarantees
 //
 // The bus does not drop events. When a subscriber's channel buffer or

--- a/event/doc.go
+++ b/event/doc.go
@@ -30,7 +30,37 @@
 //	)
 //
 // Use PublishAsync for events that do not need to be delivered
-// synchronously with the publisher's call stack.
+// synchronously with the publisher's call stack, and PublishOrdered
+// for those that additionally need to reach subscribers in the order
+// they were published.
+//
+// # Ordering guarantees
+//
+// Publish and PublishBlocking deliver on the caller's goroutine, so a
+// single publisher's events reach each subscriber in call order.
+//
+// PublishAsync does not preserve order. It hands the event to a shared
+// queue drained by AsyncWorkerPoolSize workers that race each other
+// into Publish, so two events enqueued in order can be delivered in
+// either order -- observed as several inversions per few hundred
+// events, even from one publishing goroutine. Use it only where
+// subscribers treat each event independently.
+//
+// PublishOrdered is the async path that does preserve order. Each event
+// type gets its own FIFO drained by exactly one worker, so events
+// published to one type arrive in publish order, and a slow subscriber
+// delays only its own event type rather than every async event. The
+// guarantee is per event type and only over publishes that are
+// themselves sequenced: concurrent publishers still race to enqueue,
+// and nothing is promised across different event types.
+//
+// ledger.tx uses PublishOrdered. A subscriber deriving state from it can
+// rely on a block's transactions arriving in index order, and on a
+// rollback's undo events (Rollback: true) arriving before any
+// transaction event the ledger emits afterwards. See
+// blinklabs-io/dingo#2287: while those undo events were emitted from a
+// detached goroutine, a subscriber could apply an undo after the redo
+// that followed it and stay wrong indefinitely.
 //
 // # Delivery guarantees
 //
@@ -68,6 +98,10 @@
 // A slow subscriber backpressures the bus and delays delivery of
 // unrelated events: the async workers are a shared pool, so a
 // subscriber that parks them holds up every async event type.
+// PublishOrdered's per-type lanes are exempt from that specific
+// coupling -- a parked lane worker holds up only its own event type --
+// but they are single workers, so a slow subscriber stalls that type
+// more readily than four shared workers would.
 //
 // Event type constants live alongside the package that owns the
 // event: ChainForkEventType in chain, ChainSwitchEventType in

--- a/event/event.go
+++ b/event/event.go
@@ -127,8 +127,15 @@ type EventBus struct {
 	// Async publishing infrastructure
 	asyncQueue chan asyncEvent
 	asyncWg    sync.WaitGroup
-	stopCh     chan struct{}
-	closed     bool
+	// orderedLanes holds the per-event-type FIFOs behind PublishOrdered,
+	// created lazily on first use and torn down by shutdown. See
+	// ordered.go: they exist because the shared asyncQueue above is
+	// drained by AsyncWorkerPoolSize workers concurrently and so cannot
+	// preserve publisher order.
+	orderedLanes map[EventType]*orderedLane
+	orderedMu    sync.Mutex
+	stopCh       chan struct{}
+	closed       bool
 	// terminalClosing is set before Close begins quiescing the bus. Callback
 	// dispatchers use it to discard events already buffered in their channels;
 	// Stop remains reusable and does not discard buffered callback events.
@@ -1092,6 +1099,13 @@ func (e *EventBus) shutdown(restart bool) {
 	if e.metrics != nil {
 		e.metrics.subscribers.Reset()
 	}
+
+	// Every ordered-lane worker watched the stop channel closed above and
+	// has exited (asyncWg.Wait covered them alongside the shared pool), so
+	// the lanes are inert. Drop them: a restart swaps in a new stop channel
+	// and a lane still bound to the old, already-closed one would make its
+	// rebuilt worker exit immediately.
+	e.resetOrderedLanes()
 
 	if !restart {
 		return

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -14,6 +14,8 @@
 
 package event
 
+import "context"
+
 // OrderedQueueSize is the per-event-type buffer behind PublishOrdered. It is
 // larger than AsyncQueueSize because an ordered lane is drained by exactly one
 // worker rather than by the shared pool, so it has to absorb the same bursts
@@ -57,6 +59,23 @@ type orderedLane struct {
 // event type instead of holding up every async event as it would on the shared
 // pool.
 func (e *EventBus) PublishOrdered(eventType EventType, evt Event) bool {
+	return e.PublishOrderedContext(context.Background(), eventType, evt)
+}
+
+// PublishOrderedContext is PublishOrdered that also abandons the publish when
+// ctx is done. Only shutdown otherwise releases a publisher waiting on a full
+// lane, so a caller on a shutdown-critical goroutine -- one something else
+// waits for before the EventBus itself stops, such as a LedgerState the node
+// closes while keeping the bus running for a live restore -- must pass a
+// context it cancels, or that wait is unbounded.
+//
+// Abandoning is not a drop in the delivery-guarantee sense: the event was
+// never accepted, and the false return says so.
+func (e *EventBus) PublishOrderedContext(
+	ctx context.Context,
+	eventType EventType,
+	evt Event,
+) bool {
 	e.stopMu.RLock()
 	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
@@ -79,6 +98,8 @@ func (e *EventBus) PublishOrdered(eventType EventType, evt Event) bool {
 		select {
 		case lane.queue <- evt:
 		case <-stopCh:
+			return false
+		case <-ctx.Done():
 			return false
 		}
 	}

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+// OrderedQueueSize is the per-event-type buffer behind PublishOrdered. It is
+// larger than AsyncQueueSize because an ordered lane is drained by exactly one
+// worker rather than by the shared pool, so it has to absorb the same bursts
+// with less drain throughput. The ledger publishes ledger.tx from inside its
+// block-apply database transaction, and a publisher that parks holds that
+// transaction open, so the buffer is sized to swallow a bulk-sync batch's
+// transactions rather than to bound memory tightly. It is still bounded:
+// past this point the publisher waits, exactly as it already did on a full
+// shared async queue.
+const OrderedQueueSize = 10000
+
+// orderedLane is one event type's FIFO plus the single worker that drains it.
+// One worker is the whole mechanism: the shared async pool cannot preserve
+// order because AsyncWorkerPoolSize workers dequeue concurrently and race each
+// other into Publish, so two events enqueued in order can be delivered to a
+// subscriber in either order (blinklabs-io/dingo#2287).
+type orderedLane struct {
+	queue chan Event
+	// stopCh is the bus stop channel captured when the lane was created.
+	// e.stopCh is swapped by a Stop/restart cycle, so the worker must watch
+	// the generation it was started under rather than re-reading the field.
+	stopCh chan struct{}
+}
+
+// PublishOrdered enqueues an event for asynchronous delivery that preserves
+// publisher order. Events published to the same event type are delivered to
+// each subscriber in the order they were published, which PublishAsync does
+// not promise.
+//
+// Ordering holds per event type, and only among publishes that are themselves
+// ordered: two goroutines publishing concurrently to one type still race to
+// enqueue, and nothing is promised across different event types. A single
+// producer sequence -- a ledger rollback's transaction undo events followed by
+// the next block's transaction events -- is exactly the case this is for.
+//
+// Like PublishAsync it does not drop: a full lane makes the publisher wait for
+// capacity rather than discarding the event, and only shutdown releases that
+// wait. Returns false when the EventBus is stopped or closed.
+//
+// Each event type gets its own lane, so a slow subscriber delays only its own
+// event type instead of holding up every async event as it would on the shared
+// pool.
+func (e *EventBus) PublishOrdered(eventType EventType, evt Event) bool {
+	e.stopMu.RLock()
+	if e.stopped || e.closed {
+		e.stopMu.RUnlock()
+		return false
+	}
+	lane := e.orderedLane(eventType)
+	stopCh := lane.stopCh
+	// Released before waiting on the lane: shutdown needs stopMu for write,
+	// and it is shutdown that releases us.
+	e.stopMu.RUnlock()
+
+	select {
+	case lane.queue <- evt:
+	default:
+		// Lane is full: wait for space rather than losing the event.
+		if e.metrics != nil {
+			e.metrics.asyncEnqueueBlocked.WithLabelValues(string(eventType)).
+				Inc()
+		}
+		select {
+		case lane.queue <- evt:
+		case <-stopCh:
+			return false
+		}
+	}
+
+	// shutdown closes stopCh before it marks the bus stopped, so an enqueue
+	// can still land in a lane whose worker has already exited. Report that
+	// as a failed publish rather than as a delivery that never happens.
+	select {
+	case <-stopCh:
+		return false
+	default:
+	}
+	return true
+}
+
+// orderedLane returns the lane for an event type, creating it and starting its
+// worker on first use. The caller must hold stopMu for read and must have
+// observed the bus as neither stopped nor closed: that is what makes the
+// asyncWg.Add here safe against shutdown's asyncWg.Wait, since shutdown cannot
+// take stopMu for write until the caller releases it.
+func (e *EventBus) orderedLane(eventType EventType) *orderedLane {
+	e.orderedMu.Lock()
+	defer e.orderedMu.Unlock()
+	if lane, ok := e.orderedLanes[eventType]; ok {
+		return lane
+	}
+	if e.orderedLanes == nil {
+		e.orderedLanes = make(map[EventType]*orderedLane)
+	}
+	lane := &orderedLane{
+		queue:  make(chan Event, OrderedQueueSize),
+		stopCh: e.stopCh,
+	}
+	e.orderedLanes[eventType] = lane
+	e.asyncWg.Add(1)
+	go e.orderedWorker(lane, eventType)
+	return lane
+}
+
+// orderedWorker drains one lane. There is exactly one per lane, so the order it
+// calls Publish in is the order events were enqueued in, and Publish itself
+// hands each event to every subscriber before returning.
+func (e *EventBus) orderedWorker(lane *orderedLane, eventType EventType) {
+	defer e.asyncWg.Done()
+	for {
+		// Prioritize shutdown before attempting to receive queued work.
+		select {
+		case <-lane.stopCh:
+			return
+		default:
+		}
+
+		select {
+		case <-lane.stopCh:
+			return
+		case evt := <-lane.queue:
+			// Drop queued work if shutdown began after the dequeue but
+			// before Publish ran, so Stop/Close do not deliver buffered
+			// events. This matches asyncWorker.
+			select {
+			case <-lane.stopCh:
+				return
+			default:
+			}
+			// A slow in-memory subscriber parks this worker until it
+			// drains, which is the backpressure that keeps events from
+			// being dropped; shutdown closes stopCh first, releasing any
+			// parked delivery.
+			e.Publish(eventType, evt)
+		}
+	}
+}
+
+// resetOrderedLanes drops every lane so the next PublishOrdered rebuilds them
+// against the current stop channel. Called from shutdown once the previous
+// generation's workers have exited.
+func (e *EventBus) resetOrderedLanes() {
+	e.orderedMu.Lock()
+	defer e.orderedMu.Unlock()
+	e.orderedLanes = nil
+}

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -76,6 +76,15 @@ func (e *EventBus) PublishOrderedContext(
 	eventType EventType,
 	evt Event,
 ) bool {
+	// Check cancellation before accepting anything. Deferring it to the
+	// full-lane wait below would let a publish on an already-cancelled
+	// context still be enqueued and delivered whenever the lane happens to
+	// have room, which is the common case.
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+	}
 	e.stopMu.RLock()
 	if e.stopped || e.closed {
 		e.stopMu.RUnlock()

--- a/event/ordered_test.go
+++ b/event/ordered_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// collectOrdered drains n events from ch and returns their int payloads in
+// arrival order.
+func collectOrdered(t *testing.T, ch <-chan Event, n int) []int {
+	t.Helper()
+	got := make([]int, 0, n)
+	deadline := time.After(10 * time.Second)
+	for len(got) < n {
+		select {
+		case evt := <-ch:
+			v, ok := evt.Data.(int)
+			if !ok {
+				t.Fatalf("unexpected payload type %T", evt.Data)
+			}
+			got = append(got, v)
+		case <-deadline:
+			t.Fatalf("timed out after %d of %d events", len(got), n)
+		}
+	}
+	return got
+}
+
+func requireAscending(t *testing.T, got []int) {
+	t.Helper()
+	for i := range got {
+		if got[i] != i {
+			t.Fatalf(
+				"event %d delivered out of order: got %d, want %d (sequence %v)",
+				i,
+				got[i],
+				i,
+				got,
+			)
+		}
+	}
+}
+
+// TestPublishOrderedPreservesPublisherOrder is the core ordering contract:
+// events published to one event type from one goroutine reach a subscriber in
+// publish order. PublishAsync cannot promise this because AsyncWorkerPoolSize
+// workers drain the shared queue concurrently and race each other into
+// Publish; a single 200-event run reordered 3-8 of them. See
+// blinklabs-io/dingo#2287.
+func TestPublishOrderedPreservesPublisherOrder(t *testing.T) {
+	const n = 500
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	subId, ch := eb.SubscribeWithBuffer("ordered.seq", n)
+	if subId == 0 {
+		t.Fatal("subscribe failed")
+	}
+
+	for i := range n {
+		if !eb.PublishOrdered("ordered.seq", NewEvent("ordered.seq", i)) {
+			t.Fatalf("PublishOrdered returned false at %d", i)
+		}
+	}
+	requireAscending(t, collectOrdered(t, ch, n))
+}
+
+// TestPublishOrderedPreservesOrderUnderConcurrentAsyncTraffic keeps the shared
+// async pool busy with an unrelated event type while the ordered lane runs, so
+// a regression that routed ordered events back onto the shared pool is caught
+// rather than passing on an idle bus.
+func TestPublishOrderedPreservesOrderUnderConcurrentAsyncTraffic(
+	t *testing.T,
+) {
+	const n = 500
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	subId, ch := eb.SubscribeWithBuffer("ordered.seq", n)
+	if subId == 0 {
+		t.Fatal("subscribe failed")
+	}
+	// Unrelated async traffic occupying the shared worker pool.
+	noiseDone := make(chan struct{})
+	eb.SubscribeFunc("ordered.noise", func(Event) {})
+	go func() {
+		defer close(noiseDone)
+		for i := range n * 4 {
+			eb.PublishAsync("ordered.noise", NewEvent("ordered.noise", i))
+		}
+	}()
+
+	for i := range n {
+		if !eb.PublishOrdered("ordered.seq", NewEvent("ordered.seq", i)) {
+			t.Fatalf("PublishOrdered returned false at %d", i)
+		}
+	}
+	requireAscending(t, collectOrdered(t, ch, n))
+	<-noiseDone
+}
+
+// TestPublishOrderedWaitsForCapacityRatherThanDropping holds the no-drop
+// guarantee documented for the rest of the bus: a full ordered lane
+// backpressures its publisher instead of discarding events.
+func TestPublishOrderedWaitsForCapacityRatherThanDropping(t *testing.T) {
+	// More events than the lane buffer can hold, with a subscriber that
+	// only starts draining once the publisher is demonstrably parked.
+	total := OrderedQueueSize + 64
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	release := make(chan struct{})
+	var mu sync.Mutex
+	got := make([]int, 0, total)
+	done := make(chan struct{})
+	eb.SubscribeFuncWithBuffer("ordered.full", 1, func(evt Event) {
+		<-release
+		mu.Lock()
+		got = append(got, evt.Data.(int))
+		if len(got) == total {
+			close(done)
+		}
+		mu.Unlock()
+	})
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		for i := range total {
+			if !eb.PublishOrdered("ordered.full", NewEvent("ordered.full", i)) {
+				t.Errorf("PublishOrdered returned false at %d", i)
+				return
+			}
+		}
+	}()
+
+	// The publisher must still be parked: nothing is draining yet.
+	select {
+	case <-published:
+		t.Fatal("publisher completed without backpressure from a full lane")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		mu.Lock()
+		n := len(got)
+		mu.Unlock()
+		t.Fatalf(
+			"only %d of %d events delivered: lane dropped events",
+			n,
+			total,
+		)
+	}
+	<-published
+	mu.Lock()
+	defer mu.Unlock()
+	requireAscending(t, got)
+}
+
+// TestPublishOrderedReturnsFalseWhenStopped mirrors PublishAsync's contract:
+// a stopped or closed bus reports the failed publish rather than accepting an
+// event nothing will deliver.
+func TestPublishOrderedReturnsFalseWhenStopped(t *testing.T) {
+	eb := NewEventBus(nil, nil)
+	eb.Close()
+	if eb.PublishOrdered("ordered.stopped", NewEvent("ordered.stopped", 0)) {
+		t.Fatal("PublishOrdered returned true on a closed bus")
+	}
+}
+
+// TestPublishOrderedPreservesOrderAfterStopRestart covers the reusable-bus
+// path: Stop tears the lanes down, and the next publish must rebuild them
+// bound to the new stop channel rather than to the torn-down one.
+func TestPublishOrderedPreservesOrderAfterStopRestart(t *testing.T) {
+	const n = 200
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	subId, ch := eb.SubscribeWithBuffer("ordered.restart", n)
+	if subId == 0 {
+		t.Fatal("subscribe failed")
+	}
+	for i := range n {
+		if !eb.PublishOrdered(
+			"ordered.restart",
+			NewEvent("ordered.restart", i),
+		) {
+			t.Fatalf("PublishOrdered returned false at %d", i)
+		}
+	}
+	requireAscending(t, collectOrdered(t, ch, n))
+
+	eb.Stop()
+
+	subId, ch = eb.SubscribeWithBuffer("ordered.restart", n)
+	if subId == 0 {
+		t.Fatal("subscribe after restart failed")
+	}
+	for i := range n {
+		if !eb.PublishOrdered(
+			"ordered.restart",
+			NewEvent("ordered.restart", i),
+		) {
+			t.Fatalf("PublishOrdered returned false at %d after restart", i)
+		}
+	}
+	requireAscending(t, collectOrdered(t, ch, n))
+}
+
+// TestPublishOrderedIsolatesEventTypes checks that one lane's slow subscriber
+// cannot stall an unrelated lane. Per-type lanes are what make this true; the
+// shared async pool explicitly does not promise it.
+func TestPublishOrderedIsolatesEventTypes(t *testing.T) {
+	const n = 100
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	block := make(chan struct{})
+	eb.SubscribeFuncWithBuffer("ordered.slow", 1, func(Event) { <-block })
+	t.Cleanup(func() { close(block) })
+
+	fastId, fastCh := eb.SubscribeWithBuffer("ordered.fast", n)
+	if fastId == 0 {
+		t.Fatal("subscribe failed")
+	}
+	// Park the slow lane's worker and fill its buffer.
+	for i := range 4 {
+		eb.PublishOrdered("ordered.slow", NewEvent("ordered.slow", i))
+	}
+	for i := range n {
+		if !eb.PublishOrdered("ordered.fast", NewEvent("ordered.fast", i)) {
+			t.Fatalf("PublishOrdered returned false at %d", i)
+		}
+	}
+	requireAscending(t, collectOrdered(t, fastCh, n))
+}

--- a/event/ordered_test.go
+++ b/event/ordered_test.go
@@ -15,6 +15,7 @@
 package event
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -251,4 +252,37 @@ func TestPublishOrderedIsolatesEventTypes(t *testing.T) {
 		}
 	}
 	requireAscending(t, collectOrdered(t, fastCh, n))
+}
+
+// TestPublishOrderedContextRejectsCancelledContextWithRoomInLane covers the
+// common case: a cancelled context must be honoured even when the lane has
+// capacity. Checking ctx only in the full-lane wait let a publish on an
+// already-cancelled context be accepted and delivered whenever there happened
+// to be room, which is almost always.
+func TestPublishOrderedContextRejectsCancelledContextWithRoomInLane(
+	t *testing.T,
+) {
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Close)
+
+	subId, ch := eb.SubscribeWithBuffer("ordered.cancelled", 16)
+	if subId == 0 {
+		t.Fatal("subscribe failed")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The lane is empty, so the enqueue would succeed on capacity alone.
+	if eb.PublishOrderedContext(
+		ctx, "ordered.cancelled", NewEvent("ordered.cancelled", 0),
+	) {
+		t.Fatal("PublishOrderedContext accepted a cancelled publish")
+	}
+
+	select {
+	case evt := <-ch:
+		t.Fatalf("cancelled publish was delivered: %v", evt.Data)
+	case <-time.After(200 * time.Millisecond):
+	}
 }

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -203,6 +203,32 @@ func (ls *LedgerState) publishBlockEvent(
 	}
 }
 
+// validateAndEmitRollbackUndo rejects a rollback that the chain will not
+// accept, then emits the undo events for the blocks it is about to discard.
+//
+// The two steps belong together and callers must use this rather than pairing
+// them by hand. The emit has to happen before the truncation for ordering (see
+// emitRollbackTransactionEvents), which means emitting first and letting
+// chain.Rollback reject afterwards tells every ledger.tx consumer to undo
+// blocks that are still applied -- the exact corruption the ordering exists to
+// prevent. Keeping the validate inseparable from the emit is what stops a new
+// rollback path from acquiring the emit without the guard, which is how
+// rollbackPrimaryChainInSecurityParamWindows initially shipped it.
+//
+// It does not close the window completely: the chain can still grow between
+// this validation and the rollback and push the rollback past the security
+// parameter, and an I/O failure mid-truncation is not predictable at all.
+// Both leave the chain needing recovery regardless.
+func (ls *LedgerState) validateAndEmitRollbackUndo(
+	point ocommon.Point,
+) error {
+	if err := ls.chain.ValidateRollback(point); err != nil {
+		return err
+	}
+	ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(point.Slot))
+	return nil
+}
+
 // blocksAboveSlot returns the blocks a rollback to slot would discard,
 // newest first, or nil when they cannot be read.
 //

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -34,27 +34,33 @@ func (ls *LedgerState) handleEventChainUpdate(evt event.Event) {
 		for _, blk := range data.RolledBackBlocks {
 			ls.publishBlockEvent(BlockActionUndo, blk)
 		}
-		// Emit per-transaction rollback events.
-		// Hold rollbackMu so Close cannot start Wait between our
-		// closed check and Add(1).
-		ls.rollbackMu.Lock()
 		if ls.closed.Load() {
-			ls.rollbackMu.Unlock()
 			return
 		}
-		ls.rollbackWG.Add(1)
-		ls.rollbackMu.Unlock()
-		go ls.emitTransactionRollbackEvents(data)
+		// Emit per-transaction rollback events on this goroutine, not a
+		// detached one. handleEventChainUpdate is a SubscribeFunc
+		// dispatch, so its invocations are already serialized in
+		// chain-update order; emitting inline is what puts the undo
+		// events ahead of whatever the ledger publishes for the next
+		// chain update. See the ordering contract on
+		// emitTransactionRollbackEvents (blinklabs-io/dingo#2287).
+		ls.emitTransactionRollbackEvents(data)
 	}
 }
 
 // emitTransactionRollbackEvents emits TransactionEvent for each transaction
 // in the rolled-back blocks, allowing subscribers to undo any state changes.
+//
+// Ordering contract: the events for one rollback are emitted newest block
+// first and, within a block, in reverse transaction order -- the reverse of
+// how they were applied -- and all of them are handed to the bus before this
+// returns, so every one of them precedes any transaction event the ledger
+// emits for a later chain update. publishTransactionEvent carries that order
+// through to subscribers. A subscriber maintaining derived state can therefore
+// apply the undos and the next block's redos in the order they happened.
 func (ls *LedgerState) emitTransactionRollbackEvents(
 	rollbackEvt chain.ChainRollbackEvent,
 ) {
-	defer ls.rollbackWG.Done()
-
 	if ls.config.EventBus == nil {
 		return
 	}
@@ -102,21 +108,36 @@ func (ls *LedgerState) emitTransactionRollbackEvents(
 			continue
 		}
 		for i, tx := range slices.Backward(txs) {
-			ls.config.EventBus.PublishAsync(
-				TransactionEventType,
-				event.NewEvent(
-					TransactionEventType,
-					TransactionEvent{
-						Transaction: tx,
-						Point:       blockPoint,
-						BlockNumber: block.Number,
-						TxIndex:     uint32(i), //nolint:gosec
-						Rollback:    true,
-					},
-				),
-			)
+			ls.publishTransactionEvent(TransactionEvent{
+				Transaction: tx,
+				Point:       blockPoint,
+				BlockNumber: block.Number,
+				TxIndex:     uint32(i), //nolint:gosec
+				Rollback:    true,
+			})
 		}
 	}
+}
+
+// publishTransactionEvent publishes a TransactionEvent on the ledger.tx
+// ordered lane. Ordering is the point: subscribers derive state from these
+// events, and applying a block's transactions out of order -- or applying a
+// rollback's undo after the redo that followed it -- leaves that state wrong
+// in ways no later event corrects. PublishAsync cannot be used here because
+// the shared worker pool reorders (blinklabs-io/dingo#2287).
+//
+// This stays asynchronous rather than becoming a PublishBlocking like
+// publishBlockEvent: the forward-path caller runs inside the block-apply
+// database transaction, so parking it on subscriber backpressure would hold
+// that transaction open.
+func (ls *LedgerState) publishTransactionEvent(evt TransactionEvent) {
+	if ls.config.EventBus == nil {
+		return
+	}
+	ls.config.EventBus.PublishOrdered(
+		TransactionEventType,
+		event.NewEvent(TransactionEventType, evt),
+	)
 }
 
 func (ls *LedgerState) publishBlockEvent(

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -15,12 +15,14 @@
 package ledger
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -34,38 +36,44 @@ func (ls *LedgerState) handleEventChainUpdate(evt event.Event) {
 		for _, blk := range data.RolledBackBlocks {
 			ls.publishBlockEvent(BlockActionUndo, blk)
 		}
-		if ls.closed.Load() {
-			return
-		}
-		// Emit per-transaction rollback events on this goroutine, not a
-		// detached one. handleEventChainUpdate is a SubscribeFunc
-		// dispatch, so its invocations are already serialized in
-		// chain-update order; emitting inline is what puts the undo
-		// events ahead of whatever the ledger publishes for the next
-		// chain update. See the ordering contract on
-		// emitTransactionRollbackEvents (blinklabs-io/dingo#2287).
-		ls.emitTransactionRollbackEvents(data)
+		// Per-transaction undo events are deliberately NOT emitted here.
+		// This handler is a SubscribeFunc dispatch on its own goroutine,
+		// reached only after chain.Rollback has already published and
+		// returned, so anything it emits races the block-apply goroutine
+		// that publishes forward transaction events -- and loses, since
+		// that goroutine is free to apply the post-rollback chain the
+		// moment the truncation lands. emitRollbackTransactionEvents is
+		// called from the rollback path instead, before the truncation.
+		// See blinklabs-io/dingo#2287.
 	}
 }
 
-// emitTransactionRollbackEvents emits TransactionEvent for each transaction
-// in the rolled-back blocks, allowing subscribers to undo any state changes.
+// emitRollbackTransactionEvents emits a TransactionEvent for every
+// transaction in blocks, letting subscribers undo the state those
+// transactions produced.
 //
-// Ordering contract: the events for one rollback are emitted newest block
-// first and, within a block, in reverse transaction order -- the reverse of
-// how they were applied -- and all of them are handed to the bus before this
-// returns, so every one of them precedes any transaction event the ledger
-// emits for a later chain update. publishTransactionEvent carries that order
-// through to subscribers. A subscriber maintaining derived state can therefore
-// apply the undos and the next block's redos in the order they happened.
-func (ls *LedgerState) emitTransactionRollbackEvents(
-	rollbackEvt chain.ChainRollbackEvent,
+// # Ordering contract
+//
+// Events are emitted newest block first and, within a block, in reverse
+// transaction order -- the reverse of how they were applied -- and every one
+// of them is on the ledger.tx lane before this returns.
+//
+// The caller must invoke this *before* the chain is truncated, which is what
+// orders these events against the forward transaction events published by the
+// block-apply goroutine. That goroutine can only apply a post-rollback block
+// after it observes the truncation, so an undo enqueued before the truncation
+// is necessarily already ahead of any forward event for a block applied after
+// it. Emitting after the truncation -- or from a different goroutine that
+// merely learns of it later, as the chain-update handler does -- loses that
+// race and lets a subscriber apply an undo after the redo that followed it.
+func (ls *LedgerState) emitRollbackTransactionEvents(
+	blocks []models.Block,
 ) {
 	if ls.config.EventBus == nil {
 		return
 	}
 
-	for _, block := range rollbackEvt.RolledBackBlocks {
+	for _, block := range blocks {
 		blk, err := block.Decode()
 		if err != nil {
 			blockPoint := ocommon.Point{
@@ -134,7 +142,17 @@ func (ls *LedgerState) publishTransactionEvent(evt TransactionEvent) {
 	if ls.config.EventBus == nil {
 		return
 	}
-	ls.config.EventBus.PublishOrdered(
+	// publishCtx is cancelled as Close begins. Without it a publish parked
+	// on a full lane is released only by the EventBus stopping, and a live
+	// restore/truncate closes the LedgerState while deliberately keeping
+	// the bus running -- so Close would wait unbounded on a subscriber that
+	// stopped draining.
+	ctx := ls.publishCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ls.config.EventBus.PublishOrderedContext(
+		ctx,
 		TransactionEventType,
 		event.NewEvent(TransactionEventType, evt),
 	)
@@ -183,4 +201,54 @@ func (ls *LedgerState) publishBlockEvent(
 			ls.config.FatalErrorFunc(publishErr)
 		}
 	}
+}
+
+// blocksAboveSlot returns the blocks a rollback to slot would discard,
+// newest first, or nil when they cannot be read.
+//
+// The descending order matters: it is the reverse of the order the blocks
+// were applied in, which is the order their effects have to be undone in, and
+// it matches the order chain.rollbackLocked itself reports rolled-back blocks
+// (it walks the chain down from the tip). BlocksAfterSlotTxn returns ascending
+// slot order, so the result is reversed here.
+//
+// It must be called before the chain is truncated, while those blocks still
+// exist. A read failure is logged and yields no undo events rather than
+// failing the rollback: the rollback itself is what keeps the ledger correct,
+// and refusing to roll back because a notification could not be built would
+// trade a subscriber's derived state for the node's own.
+func (ls *LedgerState) blocksAboveSlot(slot uint64) []models.Block {
+	if ls.config.EventBus == nil || ls.db == nil {
+		return nil
+	}
+	// Skip the read entirely when nothing consumes ledger.tx, which is the
+	// default node: this runs under chainsyncMutex on every rollback, and
+	// reading plus decoding up to a security parameter's worth of blocks
+	// there to build events for no one is pure cost on the rollback path.
+	//
+	// A subscriber attaching between this check and the publish misses the
+	// events, but it would have missed them anyway -- it was not subscribed
+	// when the rollback began, and Publish to zero subscribers is already a
+	// no-op. So this weakens no guarantee that existed.
+	if !ls.config.EventBus.HasSubscribers(TransactionEventType) {
+		return nil
+	}
+	var blocks []models.Block
+	txn := ls.db.Transaction(false)
+	err := txn.Do(func(txn *database.Txn) error {
+		var err error
+		blocks, err = database.BlocksAfterSlotTxn(txn, slot)
+		return err
+	})
+	if err != nil {
+		ls.config.Logger.Warn(
+			"failed to read rolled-back blocks for tx undo events",
+			"component", "ledger",
+			"error", err,
+			"slot", slot,
+		)
+		return nil
+	}
+	slices.Reverse(blocks)
+	return blocks
 }

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -230,7 +230,11 @@ func (ls *LedgerState) blocksAboveSlot(slot uint64) []models.Block {
 	// events, but it would have missed them anyway -- it was not subscribed
 	// when the rollback began, and Publish to zero subscribers is already a
 	// no-op. So this weakens no guarantee that existed.
-	if !ls.config.EventBus.HasSubscribers(TransactionEventType) {
+	// LedgerErrorEventType counts too: a decode failure while building the
+	// undo events is reported there, and a consumer subscribed only to
+	// ledger.error would otherwise stop seeing rollback decode failures.
+	if !ls.config.EventBus.HasSubscribers(TransactionEventType) &&
+		!ls.config.EventBus.HasSubscribers(LedgerErrorEventType) {
 		return nil
 	}
 	var blocks []models.Block

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -354,3 +354,80 @@ func TestRollbackChainAndStateEmitsUndoEventsBeforeTruncating(t *testing.T) {
 		"undo events must cover the block the rollback discards",
 	)
 }
+
+// TestRejectedRollbackEmitsNoUndoEvents covers the corruption window: a
+// rollback the chain will reject must not tell subscribers to undo blocks that
+// stay applied. Emitting has to happen before the truncation for ordering, so
+// the rejection is checked first.
+func TestRejectedRollbackEmitsNoUndoEvents(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	ls.config.EventBus = bus
+
+	txSubID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), txSubID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, txSubID) })
+
+	errSubID, errCh := bus.SubscribeWithBuffer(LedgerErrorEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), errSubID)
+	t.Cleanup(func() { bus.Unsubscribe(LedgerErrorEventType, errSubID) })
+
+	// A point at the ancestor's slot but carrying a hash no block has:
+	// ValidateRollback rejects it, and crucially it sits *below* the tip,
+	// so blocksAboveSlot would find the block at the tip and emit undo
+	// events for it if the rejection were not checked first. A point above
+	// the tip would not exercise this at all -- there is nothing above it
+	// to emit for.
+	badPoint := ocommon.NewPoint(
+		fixture.ancestorTip.Point.Slot,
+		testHashBytes("no-such-block"),
+	)
+	require.Error(t, ls.rollbackChainAndState(badPoint))
+
+	testutil.RequireNoReceive(
+		t, txCh, 250*time.Millisecond,
+		"a rejected rollback must not publish undo events",
+	)
+	testutil.RequireNoReceive(
+		t, errCh, 250*time.Millisecond,
+		"a rejected rollback must not publish undo decode errors",
+	)
+
+	// The chain still holds the block the rollback would have discarded.
+	require.Equal(
+		t,
+		fixture.currentTip.Point.Slot,
+		ls.chain.Tip().Point.Slot,
+		"chain must be untouched by a rejected rollback",
+	)
+}
+
+// TestBlocksAboveSlotServesLedgerErrorOnlySubscribers guards the
+// no-subscriber fast path against suppressing decode failures: a consumer
+// watching only ledger.error still needs to see them.
+func TestBlocksAboveSlotServesLedgerErrorOnlySubscribers(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	ls.config.EventBus = bus
+
+	// Deliberately no ledger.tx subscriber.
+	errSubID, errCh := bus.SubscribeWithBuffer(LedgerErrorEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), errSubID)
+	t.Cleanup(func() { bus.Unsubscribe(LedgerErrorEventType, errSubID) })
+
+	require.NoError(t, ls.rollbackChainAndState(fixture.ancestorTip.Point))
+
+	evt := testutil.RequireReceive(
+		t, errCh, 2*time.Second,
+		"decode error must reach a ledger.error-only subscriber",
+	)
+	le, ok := evt.Data.(LedgerErrorEvent)
+	require.True(t, ok, "unexpected payload %T", evt.Data)
+	require.Equal(t, "rollback_tx_undo_decode", le.Operation)
+}

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -430,4 +431,93 @@ func TestBlocksAboveSlotServesLedgerErrorOnlySubscribers(t *testing.T) {
 	le, ok := evt.Data.(LedgerErrorEvent)
 	require.True(t, ok, "unexpected payload %T", evt.Data)
 	require.Equal(t, "rollback_tx_undo_decode", le.Operation)
+}
+
+// TestRejectedWindowedRollbackEmitsNoUndoEvents is the
+// rollbackPrimaryChainInSecurityParamWindows counterpart to
+// TestRejectedRollbackEmitsNoUndoEvents.
+//
+// That function shipped the emit-before-truncate pattern without the
+// validate guard, so a rewind the chain rejects published undo events for
+// blocks it then left fully applied. Its own doc comment notes the chain can
+// move between reading the tip and rewinding to it, so the rejection is
+// reachable rather than theoretical.
+//
+// The chain manager's security parameter (2 here) is what ValidateRollback
+// enforces, while the function's own window comes from the ledger's genesis
+// and is much larger. A rewind past 2 blocks therefore reaches the emit and is
+// then rejected -- exactly the shape the guard exists for.
+func TestRejectedWindowedRollbackEmitsNoUndoEvents(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 2}))
+
+	// Five blocks, so a rewind to the first exceeds the chain's k of 2.
+	const blockCount = 5
+	raw := make([]chain.RawBlock, 0, blockCount)
+	var prev []byte
+	for i := 1; i <= blockCount; i++ {
+		h := testHashBytes(fmt.Sprintf("windowed-block-%d", i))
+		raw = append(raw, chain.RawBlock{
+			Slot:        uint64(i * 10),
+			Hash:        h,
+			BlockNumber: uint64(i),
+			Type:        1,
+			PrevHash:    prev,
+			Cbor:        []byte{0x80},
+		})
+		prev = h
+	}
+	require.Len(t, raw, blockCount)
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(raw))
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		EventBus:          bus,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	txSubID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), txSubID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, txSubID) })
+
+	errSubID, errCh := bus.SubscribeWithBuffer(LedgerErrorEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), errSubID)
+	t.Cleanup(func() { bus.Unsubscribe(LedgerErrorEventType, errSubID) })
+
+	// The window comes from the ledger, not the chain, so no intermediate
+	// step is taken and the single rewind is rejected on fork depth.
+	require.Greater(
+		t,
+		ls.SecurityParam(),
+		2,
+		"ledger window must exceed the chain's k",
+	)
+
+	target := ocommon.NewPoint(raw[0].Slot, raw[0].Hash)
+	require.Error(t, ls.rollbackPrimaryChainInSecurityParamWindows(target))
+
+	testutil.RequireNoReceive(
+		t, txCh, 250*time.Millisecond,
+		"a rejected windowed rewind must not publish undo events",
+	)
+	testutil.RequireNoReceive(
+		t, errCh, 250*time.Millisecond,
+		"a rejected windowed rewind must not publish undo decode errors",
+	)
+
+	require.Equal(
+		t,
+		raw[4].Slot,
+		ls.chain.Tip().Point.Slot,
+		"chain must be untouched by a rejected rewind",
+	)
 }

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -1,0 +1,279 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database/immutable"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// loadTestBlocksWithTxs returns the first want blocks from the immutable
+// testdata that actually carry transactions, so a rollback over them produces
+// TransactionEvents to assert ordering on.
+func loadTestBlocksWithTxs(t *testing.T, want int) []models.Block {
+	t.Helper()
+
+	imm, err := immutable.New("../database/immutable/testdata")
+	require.NoError(t, err)
+	iter, err := imm.BlocksFromPoint(ocommon.Point{Slot: 0, Hash: nil})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = iter.Close() })
+
+	blocks := make([]models.Block, 0, want)
+	for len(blocks) < want {
+		immBlock, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+				break
+			}
+			t.Fatalf("iterate testdata blocks: %v", err)
+		}
+		if immBlock == nil {
+			break
+		}
+		blk, err := ledger.NewBlockFromCbor(immBlock.Type, immBlock.Cbor)
+		require.NoError(t, err)
+		if len(blk.Transactions()) == 0 {
+			continue
+		}
+		blocks = append(blocks, models.Block{
+			Slot:   blk.SlotNumber(),
+			Hash:   blk.Hash().Bytes(),
+			Number: blk.BlockNumber(),
+			Type:   uint(blk.Type()),
+			Cbor:   immBlock.Cbor,
+		})
+	}
+	require.Len(t, blocks, want, "immutable testdata blocks carrying txs")
+	return blocks
+}
+
+// TestRollbackTxEventsPrecedeLaterForwardTxEvents is the regression test for
+// blinklabs-io/dingo#2287. handleEventChainUpdate used to emit per-transaction
+// rollback events from a detached goroutine, so a forward transaction event
+// published after the rollback returned could reach a subscriber first. A
+// subscriber maintaining derived state then applied the undo after the redo
+// and was left permanently inconsistent.
+//
+// The contract asserted here: every TransactionEvent for a rollback is
+// delivered before any transaction event the ledger emits afterwards, and the
+// rollback's own events keep their reverse-of-application order.
+func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
+	t.Parallel()
+
+	blocks := loadTestBlocksWithTxs(t, 2)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	subID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 4096)
+	require.NotEqual(t, event.EventSubscriberId(0), subID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, subID) })
+
+	// Block events share the handler's goroutine; drain them so the
+	// handler is never blocked by an unread subscriber.
+	blockSubID, blockCh := bus.SubscribeWithBuffer(BlockEventType, 4096)
+	require.NotEqual(t, event.EventSubscriberId(0), blockSubID)
+	t.Cleanup(func() { bus.Unsubscribe(BlockEventType, blockSubID) })
+	go func() {
+		for range blockCh {
+		}
+	}()
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+
+	// Count the transactions the rollback will undo.
+	wantRollback := 0
+	for _, b := range blocks {
+		blk, err := b.Decode()
+		require.NoError(t, err)
+		wantRollback += len(blk.Transactions())
+	}
+	require.Positive(t, wantRollback, "rolled-back transactions")
+
+	// Roll back both blocks, then immediately emit a forward transaction
+	// event the way a newly applied block does.
+	ls.handleEventChainUpdate(event.NewEvent(
+		chain.ChainUpdateEventType,
+		chain.ChainRollbackEvent{RolledBackBlocks: blocks},
+	))
+
+	forwardBlk, err := blocks[0].Decode()
+	require.NoError(t, err)
+	forwardTxs := forwardBlk.Transactions()
+	require.NotEmpty(t, forwardTxs)
+	ls.publishTransactionEvent(TransactionEvent{
+		Transaction: forwardTxs[0],
+		Point: ocommon.Point{
+			Slot: blocks[0].Slot,
+			Hash: blocks[0].Hash,
+		},
+		BlockNumber: blocks[0].Number,
+		TxIndex:     0,
+		Rollback:    false,
+	})
+
+	got := make([]TransactionEvent, 0, wantRollback+1)
+	deadline := time.After(10 * time.Second)
+	for len(got) < wantRollback+1 {
+		select {
+		case evt := <-txCh:
+			te, ok := evt.Data.(TransactionEvent)
+			require.True(t, ok, "unexpected payload %T", evt.Data)
+			got = append(got, te)
+		case <-deadline:
+			t.Fatalf(
+				"timed out after %d of %d transaction events",
+				len(got),
+				wantRollback+1,
+			)
+		}
+	}
+
+	for i, te := range got[:wantRollback] {
+		require.True(
+			t,
+			te.Rollback,
+			"event %d: forward event overtook the rollback (got slot %d idx %d)",
+			i,
+			te.Point.Slot,
+			te.TxIndex,
+		)
+	}
+	require.False(t, got[wantRollback].Rollback, "trailing forward event")
+
+	// Rollback events undo each block in reverse transaction order.
+	pos := 0
+	for _, b := range blocks {
+		blk, err := b.Decode()
+		require.NoError(t, err)
+		txs := blk.Transactions()
+		for i := range slices.Backward(txs) {
+			require.Equal(
+				t,
+				b.Slot,
+				got[pos].Point.Slot,
+				"rollback event %d block", pos,
+			)
+			require.Equal(
+				t,
+				uint32(i),
+				got[pos].TxIndex,
+				"rollback event %d tx index", pos,
+			)
+			pos++
+		}
+	}
+}
+
+// TestRollbackAndForwardTxEventsStayOrderedAcrossRepeatedCycles guards the
+// mechanism rather than one lucky interleaving. Reintroducing a detached
+// goroutine for the rollback emission can win a single race by chance; it
+// cannot win a hundred consecutive ones, because the goroutine has to decode
+// each rolled-back block before it publishes while the forward event that
+// follows is published immediately.
+func TestRollbackAndForwardTxEventsStayOrderedAcrossRepeatedCycles(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const cycles = 100
+	blocks := loadTestBlocksWithTxs(t, 1)
+	blk, err := blocks[0].Decode()
+	require.NoError(t, err)
+	cycleTxs := blk.Transactions()
+	require.NotEmpty(t, cycleTxs)
+	txsPerRollback := len(cycleTxs)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	subID, txCh := bus.SubscribeWithBuffer(
+		TransactionEventType,
+		cycles*(txsPerRollback+1)+16,
+	)
+	require.NotEqual(t, event.EventSubscriberId(0), subID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, subID) })
+
+	blockSubID, blockCh := bus.SubscribeWithBuffer(BlockEventType, cycles+16)
+	require.NotEqual(t, event.EventSubscriberId(0), blockSubID)
+	t.Cleanup(func() { bus.Unsubscribe(BlockEventType, blockSubID) })
+	go func() {
+		for range blockCh {
+		}
+	}()
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+
+	point := ocommon.Point{Slot: blocks[0].Slot, Hash: blocks[0].Hash}
+	for range cycles {
+		ls.handleEventChainUpdate(event.NewEvent(
+			chain.ChainUpdateEventType,
+			chain.ChainRollbackEvent{RolledBackBlocks: blocks},
+		))
+		ls.publishTransactionEvent(TransactionEvent{
+			Transaction: cycleTxs[0],
+			Point:       point,
+			BlockNumber: blocks[0].Number,
+			TxIndex:     0,
+			Rollback:    false,
+		})
+	}
+
+	// Each cycle must appear as its rollback events followed by its one
+	// forward event, with no bleed between cycles.
+	want := cycles * (txsPerRollback + 1)
+	deadline := time.After(10 * time.Second)
+	for i := range want {
+		wantRollback := i%(txsPerRollback+1) != txsPerRollback
+		select {
+		case evt := <-txCh:
+			te, ok := evt.Data.(TransactionEvent)
+			require.True(t, ok, "unexpected payload %T", evt.Data)
+			require.Equal(
+				t,
+				wantRollback,
+				te.Rollback,
+				"event %d of cycle %d out of order",
+				i%(txsPerRollback+1),
+				i/(txsPerRollback+1),
+			)
+		case <-deadline:
+			t.Fatalf("timed out after %d of %d transaction events", i, want)
+		}
+	}
+}

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"slices"
@@ -26,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
@@ -72,17 +74,17 @@ func loadTestBlocksWithTxs(t *testing.T, want int) []models.Block {
 	return blocks
 }
 
-// TestRollbackTxEventsPrecedeLaterForwardTxEvents is the regression test for
-// blinklabs-io/dingo#2287. handleEventChainUpdate used to emit per-transaction
-// rollback events from a detached goroutine, so a forward transaction event
-// published after the rollback returned could reach a subscriber first. A
-// subscriber maintaining derived state then applied the undo after the redo
-// and was left permanently inconsistent.
+// TestChainUpdateHandlerPublishesNoTransactionEvents pins the structural
+// invariant the ordering guarantee rests on: the chain-update handler must not
+// be a ledger.tx producer.
 //
-// The contract asserted here: every TransactionEvent for a rollback is
-// delivered before any transaction event the ledger emits afterwards, and the
-// rollback's own events keep their reverse-of-application order.
-func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
+// The handler is a SubscribeFunc dispatch on its own goroutine, reached only
+// after chain.Rollback has published and returned. By then the block-apply
+// goroutine is already free to apply the post-rollback chain and publish
+// forward transaction events on the same lane, so anything the handler emits
+// races it and loses. Emitting undo events here reproducibly delivered the
+// forward event first. See blinklabs-io/dingo#2287.
+func TestChainUpdateHandlerPublishesNoTransactionEvents(t *testing.T) {
 	t.Parallel()
 
 	blocks := loadTestBlocksWithTxs(t, 2)
@@ -90,19 +92,13 @@ func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(bus.Stop)
 
-	subID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 4096)
-	require.NotEqual(t, event.EventSubscriberId(0), subID)
-	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, subID) })
+	txSubID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 4096)
+	require.NotEqual(t, event.EventSubscriberId(0), txSubID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, txSubID) })
 
-	// Block events share the handler's goroutine; drain them so the
-	// handler is never blocked by an unread subscriber.
 	blockSubID, blockCh := bus.SubscribeWithBuffer(BlockEventType, 4096)
 	require.NotEqual(t, event.EventSubscriberId(0), blockSubID)
 	t.Cleanup(func() { bus.Unsubscribe(BlockEventType, blockSubID) })
-	go func() {
-		for range blockCh {
-		}
-	}()
 
 	ls := &LedgerState{
 		config: LedgerStateConfig{
@@ -111,21 +107,66 @@ func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
 		},
 	}
 
-	// Count the transactions the rollback will undo.
-	wantRollback := 0
-	for _, b := range blocks {
-		blk, err := b.Decode()
-		require.NoError(t, err)
-		wantRollback += len(blk.Transactions())
-	}
-	require.Positive(t, wantRollback, "rolled-back transactions")
-
-	// Roll back both blocks, then immediately emit a forward transaction
-	// event the way a newly applied block does.
 	ls.handleEventChainUpdate(event.NewEvent(
 		chain.ChainUpdateEventType,
 		chain.ChainRollbackEvent{RolledBackBlocks: blocks},
 	))
+
+	// Block undo events are still the handler's job, one per block.
+	for i := range blocks {
+		evt := testutil.RequireReceive(
+			t, blockCh, 2*time.Second,
+			fmt.Sprintf("block undo event %d", i),
+		)
+		be, ok := evt.Data.(BlockEvent)
+		require.True(t, ok)
+		require.Equal(t, BlockActionUndo, be.Action)
+	}
+
+	// Transaction events are not.
+	testutil.RequireNoReceive(
+		t, txCh, 250*time.Millisecond,
+		"chain-update handler must not publish ledger.tx events",
+	)
+}
+
+// TestRollbackTxEventsPrecedeLaterForwardTxEvents is the ordering contract
+// itself, asserted on the emission path the rollback actually uses: undo
+// events are on the lane before the block-apply goroutine's forward events,
+// and they carry the reverse of application order.
+func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
+	t.Parallel()
+
+	blocks := loadTestBlocksWithTxs(t, 2)
+	// Newest first, as blocksAboveSlot yields them.
+	undoOrder := []models.Block{blocks[1], blocks[0]}
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	subID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 4096)
+	require.NotEqual(t, event.EventSubscriberId(0), subID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, subID) })
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+
+	wantRollback := 0
+	for _, b := range undoOrder {
+		blk, err := b.Decode()
+		require.NoError(t, err)
+		wantRollback += len(blk.Transactions())
+	}
+	require.Positive(t, wantRollback)
+
+	// The rollback path emits before chain.Rollback truncates; the
+	// block-apply goroutine publishes forward events only after it
+	// observes that truncation, i.e. strictly afterwards.
+	ls.emitRollbackTransactionEvents(undoOrder)
 
 	forwardBlk, err := blocks[0].Decode()
 	require.NoError(t, err)
@@ -153,42 +194,35 @@ func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
 		case <-deadline:
 			t.Fatalf(
 				"timed out after %d of %d transaction events",
-				len(got),
-				wantRollback+1,
+				len(got), wantRollback+1,
 			)
 		}
 	}
 
 	for i, te := range got[:wantRollback] {
 		require.True(
-			t,
-			te.Rollback,
-			"event %d: forward event overtook the rollback (got slot %d idx %d)",
-			i,
-			te.Point.Slot,
-			te.TxIndex,
+			t, te.Rollback,
+			"event %d: forward event overtook the rollback (slot %d idx %d)",
+			i, te.Point.Slot, te.TxIndex,
 		)
 	}
 	require.False(t, got[wantRollback].Rollback, "trailing forward event")
 
-	// Rollback events undo each block in reverse transaction order.
+	// Undo order is the reverse of application order: newest block first,
+	// and within each block the last transaction first.
 	pos := 0
-	for _, b := range blocks {
+	for _, b := range undoOrder {
 		blk, err := b.Decode()
 		require.NoError(t, err)
 		txs := blk.Transactions()
 		for i := range slices.Backward(txs) {
 			require.Equal(
-				t,
-				b.Slot,
-				got[pos].Point.Slot,
-				"rollback event %d block", pos,
+				t, b.Slot, got[pos].Point.Slot,
+				"undo event %d block", pos,
 			)
 			require.Equal(
-				t,
-				uint32(i),
-				got[pos].TxIndex,
-				"rollback event %d tx index", pos,
+				t, uint32(i), got[pos].TxIndex,
+				"undo event %d tx index", pos,
 			)
 			pos++
 		}
@@ -241,10 +275,7 @@ func TestRollbackAndForwardTxEventsStayOrderedAcrossRepeatedCycles(
 
 	point := ocommon.Point{Slot: blocks[0].Slot, Hash: blocks[0].Hash}
 	for range cycles {
-		ls.handleEventChainUpdate(event.NewEvent(
-			chain.ChainUpdateEventType,
-			chain.ChainRollbackEvent{RolledBackBlocks: blocks},
-		))
+		ls.emitRollbackTransactionEvents(blocks)
 		ls.publishTransactionEvent(TransactionEvent{
 			Transaction: cycleTxs[0],
 			Point:       point,
@@ -276,4 +307,50 @@ func TestRollbackAndForwardTxEventsStayOrderedAcrossRepeatedCycles(
 			t.Fatalf("timed out after %d of %d transaction events", i, want)
 		}
 	}
+}
+
+// TestRollbackChainAndStateEmitsUndoEventsBeforeTruncating pins the wiring the
+// whole ordering guarantee depends on: the rollback path itself emits the
+// per-transaction undo events, and does so while the discarded blocks are
+// still readable -- i.e. before chain.Rollback truncates them away.
+//
+// The fixture's blocks carry stub CBOR, so the emitter takes its decode-failure
+// branch and reports a LedgerErrorEvent per block. That is precisely the
+// signal wanted here: the event can only be produced if blocksAboveSlot found
+// the block, which it can only do before the truncation. Wire the emitter in
+// after chain.Rollback instead and no event is produced at all.
+func TestRollbackChainAndStateEmitsUndoEventsBeforeTruncating(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	ls.config.EventBus = bus
+
+	// A ledger.tx subscriber must exist: with none, the rollback path
+	// deliberately skips reading the discarded blocks at all.
+	txSubID, _ := bus.SubscribeWithBuffer(TransactionEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), txSubID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, txSubID) })
+
+	errSubID, errCh := bus.SubscribeWithBuffer(LedgerErrorEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), errSubID)
+	t.Cleanup(func() { bus.Unsubscribe(LedgerErrorEventType, errSubID) })
+
+	require.NoError(t, ls.rollbackChainAndState(fixture.ancestorTip.Point))
+
+	// The block above the rollback point was visited by the undo emitter.
+	evt := testutil.RequireReceive(
+		t, errCh, 2*time.Second,
+		"undo-event decode error for the rolled-back block",
+	)
+	le, ok := evt.Data.(LedgerErrorEvent)
+	require.True(t, ok, "unexpected payload %T", evt.Data)
+	require.Equal(t, "rollback_tx_undo_decode", le.Operation)
+	require.Equal(
+		t,
+		fixture.currentTip.Point.Slot,
+		le.Point.Slot,
+		"undo events must cover the block the rollback discards",
+	)
 }

--- a/ledger/block_event_test.go
+++ b/ledger/block_event_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
@@ -50,26 +49,24 @@ func TestEmitTransactionRollbackEvents_decodeFailureEmitsLedgerErrorPerBlock(
 			Logger:   logger,
 		},
 	}
-	rollbackEvt := chain.ChainRollbackEvent{
-		RolledBackBlocks: []models.Block{
-			{
-				Slot:   100,
-				Hash:   []byte{0x01, 0x02},
-				Number: 10,
-				Type:   0,
-				Cbor:   []byte{0xff},
-			},
-			{
-				Slot:   200,
-				Hash:   []byte{0x03, 0x04},
-				Number: 20,
-				Type:   0,
-				Cbor:   []byte{0xfe},
-			},
+	rolledBack := []models.Block{
+		{
+			Slot:   100,
+			Hash:   []byte{0x01, 0x02},
+			Number: 10,
+			Type:   0,
+			Cbor:   []byte{0xff},
+		},
+		{
+			Slot:   200,
+			Hash:   []byte{0x03, 0x04},
+			Number: 20,
+			Type:   0,
+			Cbor:   []byte{0xfe},
 		},
 	}
 
-	ls.emitTransactionRollbackEvents(rollbackEvt)
+	ls.emitRollbackTransactionEvents(rolledBack)
 
 	for i, wantSlot := range []uint64{100, 200} {
 		evt := testutil.RequireReceive(

--- a/ledger/block_event_test.go
+++ b/ledger/block_event_test.go
@@ -50,8 +50,6 @@ func TestEmitTransactionRollbackEvents_decodeFailureEmitsLedgerErrorPerBlock(
 			Logger:   logger,
 		},
 	}
-	ls.rollbackWG.Add(1)
-
 	rollbackEvt := chain.ChainRollbackEvent{
 		RolledBackBlocks: []models.Block{
 			{

--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/blinklabs-io/dingo/database"
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger/governance"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
@@ -245,25 +244,21 @@ func (d *LedgerDelta) applyWithDonationRecording(
 	// Emit transaction events only after all processing succeeds,
 	// so subscribers never see an "applied" event for a transaction
 	// whose governance processing failed and caused the apply to abort.
-	if ls.config.EventBus != nil {
-		for i, tr := range d.Transactions {
-			if !appliedTxs[i] {
-				continue
-			}
-			ls.config.EventBus.PublishAsync(
-				TransactionEventType,
-				event.NewEvent(
-					TransactionEventType,
-					TransactionEvent{
-						Transaction: tr.Tx,
-						Point:       d.Point,
-						BlockNumber: d.BlockNumber,
-						TxIndex:     uint32(tr.Index), //nolint:gosec
-						Rollback:    false,
-					},
-				),
-			)
+	// Emitted on the ledger.tx ordered lane so a subscriber sees this
+	// block's transactions in index order, and sees them after the undo
+	// events of any rollback that preceded them. See
+	// publishTransactionEvent.
+	for i, tr := range d.Transactions {
+		if !appliedTxs[i] {
+			continue
 		}
+		ls.publishTransactionEvent(TransactionEvent{
+			Transaction: tr.Tx,
+			Point:       d.Point,
+			BlockNumber: d.BlockNumber,
+			TxIndex:     uint32(tr.Index), //nolint:gosec
+			Rollback:    false,
+		})
 	}
 
 	return nil

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -45,10 +45,14 @@ var guardedMutexes = []string{
 // knownNilQueuePublishersUnderLock is intentionally empty. A guarded caller
 // must always pass its pending queue; a nil queue would publish inline.
 //
-// The ledger.tx undo emit reached from rollbackChainAndState is deliberately
-// not listed here: this scan is intra-procedural and that path holds neither
-// the lock nor the publish in the same function, so it is enumerated by
-// TestChainsyncResyncPublishPathsUnderLock instead.
+// The ledger.tx undo emit reached from rollbackChainAndState is covered by
+// neither test, and deliberately so. This scan is intra-procedural and that
+// path holds the lock and the publish in different functions, so it does not
+// match here; TestChainsyncResyncPublishPathsUnderLock does not match it
+// either, since that one parses only chainsync.go and only fires on
+// ChainsyncResyncEventType. The path is a documented exception rather than a
+// checked one -- see the ledger.tx section of ARCHITECTURE.md for why it has
+// to publish under chainsyncMutex and what that requires of subscribers.
 var knownNilQueuePublishersUnderLock []string
 
 // TestNoEventBusPublishWhileHoldingChainsyncMutex enforces that nothing in

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -44,6 +44,11 @@ var guardedMutexes = []string{
 
 // knownNilQueuePublishersUnderLock is intentionally empty. A guarded caller
 // must always pass its pending queue; a nil queue would publish inline.
+//
+// The ledger.tx undo emit reached from rollbackChainAndState is deliberately
+// not listed here: this scan is intra-procedural and that path holds neither
+// the lock nor the publish in the same function, so it is enumerated by
+// TestChainsyncResyncPublishPathsUnderLock instead.
 var knownNilQueuePublishersUnderLock []string
 
 // TestNoEventBusPublishWhileHoldingChainsyncMutex enforces that nothing in
@@ -271,7 +276,8 @@ func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
 			events = append(events, lockEvent{
 				pos: call.Pos(), kind: kind, mutex: inner.Sel.Name,
 			})
-		case "Publish", "PublishBlocking", "PublishAsync":
+		case "Publish", "PublishBlocking", "PublishAsync",
+			"PublishOrdered", "PublishOrderedContext":
 			// Only EventBus publishes; other types have Publish methods.
 			// PublishAsync is included: it does not park on a
 			// subscriber's buffer, but it does wait for room in the
@@ -279,7 +285,9 @@ func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
 			// queue is drained by a worker pool whose workers run
 			// subscriber handlers. A handler that needs the publisher's
 			// mutex parks a worker, the queue fills, and the same cycle
-			// closes.
+			// closes. PublishOrdered and PublishOrderedContext are
+			// included for the same reason against their per-event-type
+			// lane.
 			if inner.Sel.Name != "EventBus" {
 				return true
 			}

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -458,6 +458,9 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 			)
 		}
 		nextPoint := ocommon.NewPoint(nextBlock.Slot, nextBlock.Hash)
+		// Emit undo events before each window's truncation, for the
+		// ordering reason documented on emitRollbackTransactionEvents.
+		ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(nextPoint.Slot))
 		if err := ls.chain.Rollback(nextPoint); err != nil {
 			return fmt.Errorf(
 				"rollback primary chain to intermediate point %d: %w",
@@ -467,6 +470,7 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 		}
 		tipIndex = nextIndex
 	}
+	ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(point.Slot))
 	if err := ls.chain.Rollback(point); err != nil {
 		return fmt.Errorf("rollback primary chain to recovery point: %w", err)
 	}

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -458,9 +458,19 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 			)
 		}
 		nextPoint := ocommon.NewPoint(nextBlock.Slot, nextBlock.Hash)
-		// Emit undo events before each window's truncation, for the
-		// ordering reason documented on emitRollbackTransactionEvents.
-		ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(nextPoint.Slot))
+		// Validate, then emit undo events, before each window's
+		// truncation. This function's own doc comment notes the chain can
+		// move between reading the tip and rewinding to it, so the
+		// rejection here is reachable, not theoretical: emitting without
+		// it would tell subscribers to undo blocks the failed rewind
+		// leaves applied. See validateAndEmitRollbackUndo.
+		if err := ls.validateAndEmitRollbackUndo(nextPoint); err != nil {
+			return fmt.Errorf(
+				"rollback primary chain to intermediate point %d: %w",
+				nextIndex,
+				err,
+			)
+		}
 		if err := ls.chain.Rollback(nextPoint); err != nil {
 			return fmt.Errorf(
 				"rollback primary chain to intermediate point %d: %w",
@@ -470,7 +480,9 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 		}
 		tipIndex = nextIndex
 	}
-	ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(point.Slot))
+	if err := ls.validateAndEmitRollbackUndo(point); err != nil {
+		return fmt.Errorf("rollback primary chain to recovery point: %w", err)
+	}
 	if err := ls.chain.Rollback(point); err != nil {
 		return fmt.Errorf("rollback primary chain to recovery point: %w", err)
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2603,29 +2603,15 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	if mithrilLedgerSlot > 0 && point.Slot < mithrilLedgerSlot {
 		return ErrRollbackExceedsMithrilBoundary
 	}
-	// Reject the rollback before emitting anything. The undo events have
-	// to be enqueued before the truncation (see below), so emitting first
-	// and having chain.Rollback then reject the point would tell every
-	// ledger.tx consumer to undo blocks that are still applied --
-	// corrupting exactly the derived state this ordering exists to
-	// protect. ValidateRollback runs the same deterministic checks
-	// rollbackLocked does (reconcile, security parameter, block lookup,
-	// fork depth) and returns the same errors, so this only moves the
-	// rejection earlier. It does not close the window completely: the
-	// chain can still grow between the two calls and push the rollback
-	// past the security parameter, and an I/O failure mid-truncation is
-	// not predictable at all. Both leave the chain needing recovery
-	// regardless.
-	if err := ls.chain.ValidateRollback(point); err != nil {
+	// Reject before emitting, then emit before truncating: the block-apply
+	// goroutine can start applying the post-rollback chain the moment
+	// chain.Rollback lands and publishes forward events on the same
+	// ledger.tx lane, so the undos have to be enqueued first -- but only
+	// once the rollback is known to be acceptable. See
+	// validateAndEmitRollbackUndo.
+	if err := ls.validateAndEmitRollbackUndo(point); err != nil {
 		return err
 	}
-	// Emit the per-transaction undo events before the truncation, not
-	// after: the block-apply goroutine can start applying the
-	// post-rollback chain the moment chain.Rollback lands, and it
-	// publishes its forward transaction events on the same ledger.tx
-	// lane. Enqueuing the undos first is what keeps them ahead of it.
-	// See emitRollbackTransactionEvents (blinklabs-io/dingo#2287).
-	ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(point.Slot))
 	if err := ls.chain.Rollback(point); err != nil {
 		return err
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -754,7 +754,7 @@ type LedgerState struct {
 	// node_lifecycle.go's package doc). Without a way to signal this
 	// goroutine specifically, it keeps applying incoming blocks with no
 	// awareness that Close is about to run — Close waited for every other
-	// background goroutine (rollbackWG, replayWG, rewardPrecomputeWG below)
+	// background goroutine (replayWG, rewardPrecomputeWG below)
 	// but not this one, the actual pipeline that writes blocks to the
 	// database. A block landing mid-write exactly as Close proceeds to
 	// shut down dbWorkerPool leaves the persisted block-ID index
@@ -764,7 +764,7 @@ type LedgerState struct {
 	// transient condition a retry can recover from.
 	processBlocksCancel context.CancelFunc
 	// processBlocksWG tracks that same goroutine so Close can wait for it
-	// to actually exit before proceeding, the same way rollbackWG/replayWG/
+	// to actually exit before proceeding, the same way replayWG/
 	// rewardPrecomputeWG already do for the others.
 	processBlocksWG sync.WaitGroup
 
@@ -784,12 +784,6 @@ type LedgerState struct {
 	// loop's doc comment.
 	blockPipeline *pipeline.BlockPipeline
 
-	// rollbackMu serializes rollbackWG.Add with Close's rollbackWG.Wait
-	// to prevent Add-after-Wait panics from the TOCTOU race between
-	// closed.Load() and Add(1) in handleEventChainUpdate.
-	rollbackMu sync.Mutex
-	// rollbackWG tracks in-flight rollback event emission goroutines
-	rollbackWG sync.WaitGroup
 	// replayMu serializes replayWG.Add with Close's replayWG.Wait to
 	// prevent Add-after-Wait panics from the TOCTOU race between
 	// closed.Load() and Add(1) in replayBufferedHeadersAsync (#2107).
@@ -1549,14 +1543,13 @@ func (ls *LedgerState) Datum(hash []byte) (*models.Datum, error) {
 	return ls.db.GetDatum(hash, nil)
 }
 
-// CloseRollbackDrainTimeout, CloseDBWorkerPoolShutdownTimeout,
-// CloseProcessBlocksDrainTimeout, and CloseBlockfetchDrainTimeout bound the
-// corresponding waits in Close() below. Exported (not local consts) so tests — including cross-package
+// CloseDBWorkerPoolShutdownTimeout, CloseProcessBlocksDrainTimeout, and
+// CloseBlockfetchDrainTimeout bound the corresponding waits in Close()
+// below. Exported (not local consts) so tests — including cross-package
 // node-level tests exercising how a caller reacts to Close failing to
 // confirm drain — can shrink them instead of running real multi-second
 // timeouts.
 var (
-	CloseRollbackDrainTimeout        = 10 * time.Second
 	CloseDBWorkerPoolShutdownTimeout = 15 * time.Second
 	// A Leios block-processing transaction can include a large endorser
 	// closure and legitimately outlive the short blockfetch waits. Keep this
@@ -1748,37 +1741,10 @@ func (ls *LedgerState) Close() error {
 		)
 	}
 
-	// Wait for in-flight rollback event emission goroutines.
-	// Hold rollbackMu so no new goroutine can Add(1) between our
-	// closed flag and this Wait.
-	ls.config.Logger.Info("waiting for in-flight rollback goroutines")
-	rollbackStart := time.Now()
-	ls.rollbackMu.Lock()
-	rollbackDone := make(chan struct{})
-	go func() {
-		ls.rollbackWG.Wait()
-		close(rollbackDone)
-	}()
-	select {
-	case <-rollbackDone:
-		ls.config.Logger.Info(
-			"rollback goroutines finished",
-			"elapsed", time.Since(rollbackStart).Round(time.Millisecond),
-		)
-	case <-time.After(CloseRollbackDrainTimeout):
-		ls.config.Logger.Warn(
-			"timed out waiting for rollback goroutines",
-			"elapsed", time.Since(rollbackStart).Round(time.Millisecond),
-		)
-		err = errors.Join(
-			err,
-			fmt.Errorf(
-				"timed out after %s waiting for in-flight rollback goroutines",
-				time.Since(rollbackStart).Round(time.Millisecond),
-			),
-		)
-	}
-	ls.rollbackMu.Unlock()
+	// Rollback transaction events no longer need a drain wait here.
+	// They are emitted inline by handleEventChainUpdate (see
+	// block_event.go), so the UnsubscribeAndWait on ChainUpdateEventType
+	// above already guarantees none is in flight by this point.
 
 	// Drain in-flight replayBufferedHeadersAsync goroutines so they
 	// finish issuing DB reads before the owner closes the database

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -784,6 +784,16 @@ type LedgerState struct {
 	// loop's doc comment.
 	blockPipeline *pipeline.BlockPipeline
 
+	// publishCtx is cancelled at the top of Close so a ledger.tx publish
+	// parked on a full ordered lane cannot outlive shutdown. Only the
+	// EventBus stopping otherwise releases such a publisher, and a live
+	// restore/truncate closes the LedgerState while keeping the bus
+	// running, so without this the Close waits below are unbounded.
+	// Nil on a bare-struct LedgerState (tests), which reads as "no
+	// cancellation" and matches the pre-existing behaviour.
+	publishCtx    context.Context
+	publishCancel context.CancelFunc
+
 	// replayMu serializes replayWG.Add with Close's replayWG.Wait to
 	// prevent Add-after-Wait panics from the TOCTOU race between
 	// closed.Load() and Add(1) in replayBufferedHeadersAsync (#2107).
@@ -899,6 +909,7 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 		epochNonceHexCache: make(map[uint64]string),
 		validationEnabled:  cfg.ValidateHistorical,
 	}
+	ls.publishCtx, ls.publishCancel = context.WithCancel(context.Background())
 	ls.timeConverter = ls.newTimeConverter()
 	ls.publishSnapshotsLocked()
 	// Cache configured chain checkpoints (keyed by block height) so the
@@ -1561,6 +1572,11 @@ var (
 )
 
 func (ls *LedgerState) Close() error {
+	// Release any ledger.tx publish parked on a full ordered lane before
+	// waiting on the goroutines that might be doing the publishing.
+	if ls.publishCancel != nil {
+		ls.publishCancel()
+	}
 	if !ls.closed.CompareAndSwap(false, true) {
 		return nil
 	}
@@ -2587,6 +2603,13 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	if mithrilLedgerSlot > 0 && point.Slot < mithrilLedgerSlot {
 		return ErrRollbackExceedsMithrilBoundary
 	}
+	// Emit the per-transaction undo events before the truncation, not
+	// after: the block-apply goroutine can start applying the
+	// post-rollback chain the moment chain.Rollback lands, and it
+	// publishes its forward transaction events on the same ledger.tx
+	// lane. Enqueuing the undos first is what keeps them ahead of it.
+	// See emitRollbackTransactionEvents (blinklabs-io/dingo#2287).
+	ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(point.Slot))
 	if err := ls.chain.Rollback(point); err != nil {
 		return err
 	}
@@ -4263,7 +4286,13 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// applied after commit to avoid mutating in-memory state on txn failure)
 			var wantEnableValidation bool
 
-			err = ls.SubmitAsyncDBTxn(func(txn *database.Txn) error {
+			// The transaction events this eventually publishes are
+			// bounded by ls.publishCtx, not by this loop's ctx, on
+			// purpose: that ctx is re-derived whenever the pipeline
+			// restarts (errRestartLedgerPipeline), and abandoning a
+			// publish on a restart would drop events subscribers
+			// derive state from. Only Close cancels publishCtx.
+			err = ls.SubmitAsyncDBTxn(func(txn *database.Txn) error { //nolint:contextcheck
 				deltaBatch = NewLedgerDeltaBatch()
 				for offset, next := range nextBatch[i:end] {
 					tmpPoint := ocommon.Point{
@@ -4490,7 +4519,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				return nil
 			}, true)
 			if err != nil {
-				recovered, recoverErr := ls.tryRecoverFromTxValidationError(
+				// Undo events published down this recovery path are
+				// bounded by ls.publishCtx, not this loop's ctx, for the
+				// same reason as the apply path above.
+				recovered, recoverErr := ls.tryRecoverFromTxValidationError( //nolint:contextcheck
 					err,
 				)
 				if recoverErr != nil {
@@ -4509,7 +4541,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// the same block and fails identically. Rewind past it so
 				// chain selection can offer another candidate. The block is
 				// still rejected.
-				recovered, recoverErr = ls.tryRecoverFromHeaderValidationError(
+				recovered, recoverErr = ls.tryRecoverFromHeaderValidationError( //nolint:contextcheck
 					err,
 				)
 				if recoverErr != nil {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2603,6 +2603,22 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	if mithrilLedgerSlot > 0 && point.Slot < mithrilLedgerSlot {
 		return ErrRollbackExceedsMithrilBoundary
 	}
+	// Reject the rollback before emitting anything. The undo events have
+	// to be enqueued before the truncation (see below), so emitting first
+	// and having chain.Rollback then reject the point would tell every
+	// ledger.tx consumer to undo blocks that are still applied --
+	// corrupting exactly the derived state this ordering exists to
+	// protect. ValidateRollback runs the same deterministic checks
+	// rollbackLocked does (reconcile, security parameter, block lookup,
+	// fork depth) and returns the same errors, so this only moves the
+	// rejection earlier. It does not close the window completely: the
+	// chain can still grow between the two calls and push the rollback
+	// past the security parameter, and an I/O failure mid-truncation is
+	// not predictable at all. Both leave the chain needing recovery
+	// regardless.
+	if err := ls.chain.ValidateRollback(point); err != nil {
+		return err
+	}
 	// Emit the per-transaction undo events before the truncation, not
 	// after: the block-apply goroutine can start applying the
 	// post-rollback chain the moment chain.Rollback lands, and it

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4318,31 +4318,6 @@ func TestLogLeiosEndorserBlockApplyResultDistinguishesEmptyBlock(
 	}
 }
 
-// TestCloseReturnsErrorWhenRollbackGoroutinesDoNotDrainInTime covers Close()'s
-// rollback-goroutine wait: previously this only logged a Warn on timeout and
-// let Close() return nil regardless, which live restore/truncate's caller
-// (closeStorageForLiveLifecycleOp) took as a green light to proceed to
-// physically close/reopen the data directory even though a rollback
-// goroutine might still be running against it.
-func TestCloseReturnsErrorWhenRollbackGoroutinesDoNotDrainInTime(t *testing.T) {
-	origTimeout := CloseRollbackDrainTimeout
-	CloseRollbackDrainTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { CloseRollbackDrainTimeout = origTimeout })
-
-	ls := &LedgerState{
-		config: LedgerStateConfig{
-			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		},
-	}
-	// Simulate an in-flight rollback goroutine that outlives the timeout.
-	ls.rollbackWG.Add(1)
-	t.Cleanup(func() { ls.rollbackWG.Done() })
-
-	err := ls.Close()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "rollback")
-}
-
 // TestCloseReturnsErrorWhenDBWorkerPoolDoesNotShutdownInTime covers Close()'s
 // database-worker-pool wait, which had the same silent-timeout gap as the
 // rollback wait above.

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4319,8 +4319,10 @@ func TestLogLeiosEndorserBlockApplyResultDistinguishesEmptyBlock(
 }
 
 // TestCloseReturnsErrorWhenDBWorkerPoolDoesNotShutdownInTime covers Close()'s
-// database-worker-pool wait, which had the same silent-timeout gap as the
-// rollback wait above.
+// database-worker-pool wait: a timeout there used to be logged as a Warn while
+// Close() still returned nil, which let live restore/truncate's caller
+// (closeStorageForLiveLifecycleOp) treat an unconfirmed drain as a green light
+// to close and reopen the data directory.
 func TestCloseReturnsErrorWhenDBWorkerPoolDoesNotShutdownInTime(t *testing.T) {
 	origTimeout := CloseDBWorkerPoolShutdownTimeout
 	CloseDBWorkerPoolShutdownTimeout = 10 * time.Millisecond


### PR DESCRIPTION
Fixes #2287.

## Problem

Two independent defects left `ledger.tx` subscribers with permanently wrong derived state.

**1. Rollback undo events were not ordered against forward events.** They were emitted from a detached goroutine, so a forward transaction event published afterwards could overtake them and a subscriber applied the undo *after* the redo that followed it. This is what the issue reports.

**2. `PublishAsync` does not preserve order at all.** `AsyncWorkerPoolSize = 4` workers drain one shared queue and race each other into `Publish`, so even a single publisher's events get reordered. Measured, 200 events published in sequence from one goroutine:

```
first 20 delivered: [0 3 5 6 7 8 9 10 4 11 12 13 14 15 16 17 18 19 20 21]
inversions: 3-8 per run
```

Forward events (`ledger/delta.go`) used `PublishAsync`, so a block's transactions were **already** delivered out of index order. Nothing documented ordering either way.

## Fix

`PublishOrdered` (`event/ordered.go`): one FIFO per event type drained by exactly one worker, created lazily and rebuilt across a `Stop`/restart cycle. It keeps the no-drop backpressure, and per-type lanes isolate a slow subscriber to its own event type.

A lane orders what reaches it; it cannot order two publishers racing to reach it. `ledger.tx` has two, on unrelated goroutines: `LedgerDelta.apply` publishes forward events from the `ledgerProcessBlocks` goroutine (`state.go:1224`), and the rollback path publishes undo events from whichever goroutine performs the rollback. Nothing serializes them, so the ordering is a **happens-before**, not a lock:

> `rollbackChainAndState` emits the undo events **before** `chain.Rollback` truncates. The apply goroutine can only apply a post-rollback block after it observes that truncation, so an undo enqueued ahead of the truncation is necessarily ahead of any forward event for a block applied after it.

`handleEventChainUpdate` deliberately emits no `ledger.tx` events. It is a `SubscribeFunc` dispatch reached only after `chain.Rollback` has published and returned, so it can only lose that race — reproducibly, 5 of 5 runs. It still emits the `ledger.block` undo events, a different type and lane.

All three `chain.Rollback` sites emit, not just the chainsync one: the two deep corrective rewinds in `replay_recovery.go` previously produced undo events via the handler, and covering only `rollbackChainAndState` would have dropped them silently.

The read of the discarded blocks is skipped entirely when nothing subscribes to `ledger.tx` (the default node) — it runs under `chainsyncMutex` on every rollback, and building events for no one is pure cost on that path.

### Contract

> `ledger.tx` events are delivered in emission order. A block's transactions arrive in index order, and a rollback's undo events (`Rollback: true`) arrive before any transaction event the ledger emits afterwards.

Documented in `event/doc.go` and `ARCHITECTURE.md`, including the caveat that a lane orders delivery but not two racing publishers.

### Two constraints worth reviewer attention

**Publish under `chainsyncMutex`.** The rollback emit is a deliberate exception to the publish-under-lock rule: the ordering needs the enqueue before a truncation that happens under that lock, so `pendingPublishes`' post-unlock flush would place it after. The residual risk is narrower than the general rule — the emit only enqueues onto a bounded lane and never runs a subscriber callback inline — but **a `ledger.tx` subscriber must not call back into `LedgerState` methods taking `chainsyncMutex`**. Documented in `ARCHITECTURE.md` and beside the allowlist in `publish_under_lock_test.go`; the AST scan there now recognises `PublishOrdered`/`PublishOrderedContext` so a future direct violation is caught.

**Bounded shutdown.** Only shutdown releases a publisher waiting on a full lane, and a live restore/truncate closes the `LedgerState` while keeping the bus running. Ledger publishes therefore use `PublishOrderedContext` with a context `Close` cancels first thing.

## Tests

Five groups, each verified to *discriminate* by reverting its fix:

| Reverted | Failure |
|---|---|
| `PublishOrdered` → `PublishAsync` | `event 0 delivered out of order: got 2, want 0` |
| Emit from the handler again | `chain-update handler must not publish ledger.tx events` |
| Emit *after* `chain.Rollback` | wiring test times out — no event produced |

`event/ordered_test.go` — order preservation, order under concurrent shared-pool traffic, no-drop backpressure, stopped-bus return, order across `Stop`/restart, per-type isolation.

`ledger/block_event_ordering_test.go` — the handler publishes no `ledger.tx`; undo events precede forward ones in reverse application order; a 100-cycle interleaving guard; and a DB-backed test that the rollback path emits while the discarded blocks are still readable, i.e. before the truncation.

## Verification

- `go test -race ./...` — pass
- Conformance — pass
- DevNet canonical suite — **1 fail / 2 passes**, see below
- `golangci-lint` 0 issues · `nilaway` · `modernize` · `golines` · `make import-boundaries` · `make docs-parity` · `make gorm-check` — pass (`make sql-check` N/A)

The one DevNet failure was `TestSustainedConsensus` with the #3180 signature: all four nodes frozen at an identical tip (slot 154 / block 55), no fork, and the harness's log window did not reach the stall. #3180 documents that same test failing 1-in-3 on clean `main`, a control run of clean `main` (68d2625e) passed 51/0, and this branch then passed 51/0 twice more. No evidence implicating this change; flagging it rather than burying it.

## Docs

- `ARCHITECTURE.md` — ordering bullet in EventBus Features, the publish-under-lock rule and its one exception, the `ledger.tx` table entry, and the happens-before rationale after the rollback sequence diagram
- `event/doc.go` — "Ordering guarantees", including that lanes do not order racing publishers
- `DATABASE.md` — checked, not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
