### PR TITLE
fix(shutdown): log discarded close/stop errors in node, connmanager, peergov, and GCS blob store

### DIFF
--- a/cmd/dingo/database.go
+++ b/cmd/dingo/database.go
@@ -66,7 +66,10 @@ func databaseSnapshotCommand() *cobra.Command {
 			if destDir == "" {
 				return errors.New("--dir is required")
 			}
-			logger := commonRun(cfg)
+			logger, err := commonRun(cfg)
+			if err != nil {
+				return err
+			}
 			svc := dblifecycle.NewService(
 				cfg,
 				newCLIDestinationRegistry(),
@@ -123,7 +126,10 @@ func databaseRestoreCommand() *cobra.Command {
 			if cfg == nil {
 				return errors.New("no config found in context")
 			}
-			logger := commonRun(cfg)
+			logger, err := commonRun(cfg)
+			if err != nil {
+				return err
+			}
 			svc := dblifecycle.NewService(
 				cfg,
 				newCLIDestinationRegistry(),
@@ -203,7 +209,10 @@ from the target point.`,
 			if cmd.Flags().Changed("block-number") {
 				target.BlockNumber = &blockNumber
 			}
-			logger := commonRun(cfg)
+			logger, err := commonRun(cfg)
+			if err != nil {
+				return err
+			}
 			// Truncate never resolves a cloud destination, so a nil
 			// registry here is fine — see DestinationRegistry's doc
 			// comment.

--- a/cmd/dingo/load.go
+++ b/cmd/dingo/load.go
@@ -16,15 +16,15 @@ package main
 
 import (
 	"context"
-	"log/slog"
-	"os"
+	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/internal/config"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/spf13/cobra"
 )
 
-func loadRun(ctx context.Context, args []string, cfg *config.Config) {
+func loadRun(ctx context.Context, args []string, cfg *config.Config) error {
 	var immutablePath string
 
 	// CLI argument takes priority over config
@@ -33,30 +33,31 @@ func loadRun(ctx context.Context, args []string, cfg *config.Config) {
 	} else if cfg.ImmutableDbPath != "" {
 		immutablePath = cfg.ImmutableDbPath
 	} else {
-		slog.Error(
+		return errors.New(
 			"path to ImmutableDB required (via argument or immutableDbPath config)",
 		)
-		os.Exit(1)
 	}
 
-	logger := commonRun(cfg)
-	if err := node.Load(ctx, cfg, logger, immutablePath); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+	logger, err := commonRun(cfg)
+	if err != nil {
+		return err
 	}
+	if err := node.Load(ctx, cfg, logger, immutablePath); err != nil {
+		return fmt.Errorf("loading ImmutableDB: %w", err)
+	}
+	return nil
 }
 
 func loadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "load [db-path]",
 		Short: "Load blocks from ImmutableDB (path via arg or immutableDbPath config)",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
 			if cfg == nil {
-				slog.Error("no config found in context")
-				os.Exit(1)
+				return errors.New("no config found in context")
 			}
-			loadRun(cmd.Context(), args, cfg)
+			return loadRun(cmd.Context(), args, cfg)
 		},
 	}
 	return cmd

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -49,7 +49,7 @@ var (
 	configFile string
 )
 
-func commonRun(cfg *config.Config) *slog.Logger {
+func commonRun(cfg *config.Config) (*slog.Logger, error) {
 	// Configure logger from config. The --debug flag is the highest-precedence
 	// override (CLI > env > YAML > defaults): it forces debug level and source
 	// locations regardless of the configured level.
@@ -80,15 +80,13 @@ func commonRun(cfg *config.Config) *slog.Logger {
 	// Configure max processes with our logger wrapper, toss undo func
 	_, err := maxprocs.Set(maxprocs.Logger(slogPrintf))
 	if err != nil {
-		// If we hit this, something really wrong happened
-		slog.Error(err.Error())
-		os.Exit(1)
+		return nil, fmt.Errorf("configuring max processes: %w", err)
 	}
 	logger.Info(
 		"version: "+version.GetVersionString(),
 		"component", programName,
 	)
-	return logger
+	return logger, nil
 }
 
 // newLogger builds a slog.Logger writing to w. format selects the handler
@@ -332,8 +330,9 @@ func run() int {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:   programName,
-		Short: "Dingo - a Go Cardano node",
+		Use:           programName,
+		Short:         "Dingo - a Go Cardano node",
+		SilenceErrors: true,
 		Long: `Dingo - a Go Cardano node by Blink Labs.
 
 Configuration Precedence (highest to lowest):
@@ -383,15 +382,14 @@ Database Workers:
 			case config.RunModeLoad:
 				// Validate() has already enforced that ImmutableDbPath
 				// is set for load mode
-				loadRun(cmd.Context(), []string{cfg.ImmutableDbPath}, cfg)
+				return loadRun(cmd.Context(), []string{cfg.ImmutableDbPath}, cfg)
 			case config.RunModeServe, config.RunModeDev, config.RunModeLeios:
 				// serve, dev, and leios modes all run the server
-				serveRun(cmd, args, cfg)
+				return serveRun(cmd, args, cfg)
 			default:
 				// Empty or unrecognized RunMode defaults to serve mode
-				serveRun(cmd, args, cfg)
+				return serveRun(cmd, args, cfg)
 			}
-			return nil
 		},
 	}
 
@@ -488,6 +486,7 @@ Database Workers:
 	// Execute cobra command
 	exitCode := 0
 	if err := rootCmd.Execute(); err != nil {
+		slog.Error(err.Error())
 		exitCode = 1
 	}
 

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -260,6 +261,13 @@ func closeProfileFile(stderr io.Writer, f *os.File, kind string) {
 }
 
 func main() {
+	// run's body executes as a normal function return -- not os.Exit --
+	// specifically so its deferred CPU-profile cleanup always runs before
+	// the process actually terminates, on every path out of run().
+	os.Exit(run())
+}
+
+func run() int {
 	// Parse profiling flags before cobra setup (handle both --flag=value and --flag value syntax)
 	cpuprofile := ""
 	memprofile := ""
@@ -310,12 +318,12 @@ func main() {
 		) //nolint:gosec // user-specified profiling output path
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not create CPU profile: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		defer closeProfileFile(os.Stderr, f, "CPU")
 		if err := pprof.StartCPUProfile(f); err != nil {
 			fmt.Fprintf(os.Stderr, "could not start CPU profile: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		defer func() {
 			pprof.StopCPUProfile()
@@ -361,11 +369,10 @@ Database Workers:
 		// PersistentPreRunE, not explicit `--help` or `-h` output, so this
 		// does not touch the help text itself.
 		SilenceUsage: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
 			if cfg == nil {
-				slog.Error("no config found in context")
-				os.Exit(1)
+				return errors.New("no config found in context")
 			}
 
 			// When no subcommand given, check RunMode from config.
@@ -384,6 +391,7 @@ Database Workers:
 				// Empty or unrecognized RunMode defaults to serve mode
 				serveRun(cmd, args, cfg)
 			}
+			return nil
 		},
 	}
 
@@ -503,7 +511,5 @@ Database Workers:
 		}
 	}
 
-	if exitCode != 0 {
-		os.Exit(exitCode)
-	}
+	return exitCode
 }

--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -250,6 +250,15 @@ func listCommand() *cobra.Command {
 	return cmd
 }
 
+// closeProfileFile closes f, reporting a close failure to stderr instead of
+// silently dropping it -- a truncated profile file is otherwise
+// indistinguishable from a clean one until someone tries to load it.
+func closeProfileFile(stderr io.Writer, f *os.File, kind string) {
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(stderr, "could not close %s profile file: %v\n", kind, err)
+	}
+}
+
 func main() {
 	// Parse profiling flags before cobra setup (handle both --flag=value and --flag value syntax)
 	cpuprofile := ""
@@ -303,7 +312,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "could not create CPU profile: %v\n", err)
 			os.Exit(1)
 		}
-		defer f.Close()
+		defer closeProfileFile(os.Stderr, f, "CPU")
 		if err := pprof.StartCPUProfile(f); err != nil {
 			fmt.Fprintf(os.Stderr, "could not start CPU profile: %v\n", err)
 			os.Exit(1)
@@ -490,7 +499,7 @@ Database Workers:
 			} else {
 				fmt.Fprintf(os.Stderr, "Memory profiling complete\n")
 			}
-			f.Close()
+			closeProfileFile(os.Stderr, f, "memory")
 		}
 	}
 

--- a/cmd/dingo/mithril.go
+++ b/cmd/dingo/mithril.go
@@ -381,7 +381,10 @@ func mithrilSyncRunE(
 	if cfg.DelegatorInactivityEnabled {
 		return errMithrilInactivityIncompatible()
 	}
-	logger := commonRun(cfg)
+	logger, err := commonRun(cfg)
+	if err != nil {
+		return err
+	}
 	network := cfg.Network
 	if network == "" {
 		network = "preview"

--- a/cmd/dingo/profile_test.go
+++ b/cmd/dingo/profile_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// A profile file that fails to close must be reported to stderr, not
+// silently dropped -- a truncated CPU/memory profile is otherwise
+// indistinguishable from a clean one until someone tries to load it. The
+// second Close() is forced to fail by closing f once already, ahead of the
+// call under test, which deterministically exhausts the file descriptor.
+func TestCloseProfileFileReportsCloseError(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "profile-*")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("unexpected error on first close: %v", err)
+	}
+
+	var buf bytes.Buffer
+	closeProfileFile(&buf, f, "CPU")
+
+	out := buf.String()
+	if !strings.Contains(out, "could not close CPU profile file") {
+		t.Fatalf("expected close error to be reported, got: %q", out)
+	}
+}
+
+// The common case -- a clean close -- must stay silent. Reporting on every
+// successful profile write would bury the genuine failures this exists to
+// surface.
+func TestCloseProfileFileStaysQuietOnSuccess(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "profile-*")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	closeProfileFile(&buf, f, "memory")
+
+	if buf.Len() != 0 {
+		t.Fatalf(
+			"expected no output on successful close, got: %q",
+			buf.String(),
+		)
+	}
+}

--- a/cmd/dingo/serve.go
+++ b/cmd/dingo/serve.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 
 	dingo "github.com/blinklabs-io/dingo"
 	"github.com/blinklabs-io/dingo/config/cardano"
@@ -33,16 +32,18 @@ import (
 
 func serveRun(
 	cmd *cobra.Command, _ []string, cfg *config.Config,
-) {
-	logger := commonRun(cfg)
+) error {
+	logger, err := commonRun(cfg)
+	if err != nil {
+		return err
+	}
 
 	// Check for an in-progress sync. If the "sync_status" key in
 	// the sync_state table holds a non-empty value, a previous sync
 	// did not complete. The user must finish (or re-run) the sync
 	// before starting the node.
 	if err := checkSyncState(cfg, logger); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	// CIP-0163: refuse to serve a Mithril-bootstrapped database with the
@@ -51,8 +52,7 @@ func serveRun(
 	// sync command cannot see; a bootstrapped node cannot reproduce a
 	// genesis-synced node's expiration state.
 	if err := checkMithrilInactivityCompat(cfg, logger); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	// Historical metadata backfill is only needed for API mode.
@@ -66,11 +66,7 @@ func serveRun(
 		if err := resumeBackfill(
 			cmd.Context(), cfg, logger,
 		); err != nil {
-			slog.Error(
-				"backfill resume failed",
-				"error", err,
-			)
-			os.Exit(1)
+			return fmt.Errorf("backfill resume failed: %w", err)
 		}
 	} else {
 		// Core mode: if a Mithril sync interrupted between drop
@@ -78,19 +74,15 @@ func serveRun(
 		// secondary-index-backed queries return correct
 		// cardinalities.
 		if err := repairDeferredIndexes(cfg, logger); err != nil {
-			slog.Error(
-				"deferred-index repair failed",
-				"error", err,
-			)
-			os.Exit(1)
+			return fmt.Errorf("deferred-index repair failed: %w", err)
 		}
 	}
 
 	// Run node
 	if err := node.Run(cfg, logger); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
 func checkSyncState(
@@ -425,13 +417,12 @@ func serveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run as a node",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.FromContext(cmd.Context())
 			if cfg == nil {
-				slog.Error("no config found in context")
-				os.Exit(1)
+				return errors.New("no config found in context")
 			}
-			serveRun(cmd, args, cfg)
+			return serveRun(cmd, args, cfg)
 		},
 	}
 	return cmd

--- a/cmd/dingo/version.go
+++ b/cmd/dingo/version.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/blinklabs-io/dingo/internal/version"
 	"github.com/spf13/cobra"
@@ -24,7 +23,6 @@ import (
 
 func versionRun(_ *cobra.Command, _ []string) {
 	fmt.Println(version.GetVersionString())
-	os.Exit(0)
 }
 
 func versionCommand() *cobra.Command {

--- a/connmanager/close.go
+++ b/connmanager/close.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+)
+
+// closeConnAndLog closes conn, logging at Debug level if it fails. Every
+// caller already logs the reason the connection is being torn down, so a
+// close failure here is a secondary diagnostic, not the primary event.
+func closeConnAndLog(
+	logger *slog.Logger,
+	conn io.Closer,
+	msg string,
+	attrs ...any,
+) {
+	if conn == nil {
+		return
+	}
+	if err := conn.Close(); err != nil {
+		logger.Debug(msg, append(attrs, "error", err)...)
+	}
+}
+
+// joinCloseErr closes closer and folds any close error into err, so a
+// connection that fails to close on an already-failing setup path isn't
+// silently lost.
+func joinCloseErr(err error, closer io.Closer) error {
+	if closeErr := closer.Close(); closeErr != nil {
+		return errors.Join(err, closeErr)
+	}
+	return err
+}

--- a/connmanager/close_test.go
+++ b/connmanager/close_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// fakeCloser stands in for a real *ouroboros.Connection, whose Close()
+// unconditionally returns nil -- there is no way to drive a genuine close
+// failure through the real type, so closeConnAndLog and joinCloseErr are
+// tested against this controllable io.Closer instead.
+type fakeCloser struct {
+	err error
+}
+
+func (f *fakeCloser) Close() error {
+	return f.err
+}
+
+// A close failure must still surface: the message, the underlying error, and
+// any caller-supplied attributes (e.g. the peer address) all need to make it
+// into the log line, or a real cleanup failure would be undiagnosable.
+func TestCloseConnAndLogLogsOnCloseError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+	closeErr := errors.New("connection reset")
+
+	closeConnAndLog(
+		logger,
+		&fakeCloser{err: closeErr},
+		"error closing connection",
+		"peer_addr", "10.0.0.1:3001",
+	)
+
+	out := buf.String()
+	if !strings.Contains(out, "error closing connection") {
+		t.Fatalf("expected log message in output, got: %s", out)
+	}
+	if !strings.Contains(out, "connection reset") {
+		t.Fatalf("expected close error in output, got: %s", out)
+	}
+	if !strings.Contains(out, "10.0.0.1:3001") {
+		t.Fatalf("expected caller-supplied attrs in output, got: %s", out)
+	}
+}
+
+// The common case -- Close() succeeds -- must stay silent. Logging on every
+// routine connection teardown would bury the genuine failures this helper
+// exists to surface.
+func TestCloseConnAndLogStaysQuietOnSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+
+	closeConnAndLog(
+		logger,
+		&fakeCloser{err: nil},
+		"error closing connection",
+		"peer_addr", "10.0.0.1:3001",
+	)
+
+	if buf.Len() != 0 {
+		t.Fatalf(
+			"expected no log output on successful close, got: %s",
+			buf.String(),
+		)
+	}
+}
+
+// Several callers pass a *ouroboros.Connection straight from
+// GetConnectionById, which returns nil for an unknown connection ID.
+// closeConnAndLog must treat a nil closer as a no-op rather than panic.
+func TestCloseConnAndLogHandlesNilCloser(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	closeConnAndLog(logger, nil, "error closing connection")
+
+	if buf.Len() != 0 {
+		t.Fatalf(
+			"expected no log output for a nil closer, got: %s",
+			buf.String(),
+		)
+	}
+}
+
+// When the original operation already failed and the connection also fails
+// to close, both errors matter: the close failure can be the only sign that
+// the socket was never actually released. Neither may be dropped for the
+// other.
+func TestJoinCloseErrJoinsOnCloseFailure(t *testing.T) {
+	origErr := errors.New("dial failed")
+	closeErr := errors.New("already closed")
+
+	got := joinCloseErr(origErr, &fakeCloser{err: closeErr})
+
+	if !errors.Is(got, origErr) {
+		t.Fatalf("expected joined error to wrap original error: %v", got)
+	}
+	if !errors.Is(got, closeErr) {
+		t.Fatalf("expected joined error to wrap close error: %v", got)
+	}
+}
+
+// A clean close must not manufacture a joined error out of nothing -- the
+// caller's original error should come back unwrapped.
+func TestJoinCloseErrReturnsOriginalOnCloseSuccess(t *testing.T) {
+	origErr := errors.New("dial failed")
+
+	got := joinCloseErr(origErr, &fakeCloser{err: nil})
+
+	if !errors.Is(got, origErr) {
+		t.Fatalf("expected original error, got: %v", got)
+	}
+	if errors.Unwrap(got) != nil {
+		t.Fatalf("expected no joined error when close succeeds, got: %v", got)
+	}
+}

--- a/connmanager/close_test.go
+++ b/connmanager/close_test.go
@@ -92,7 +92,9 @@ func TestCloseConnAndLogStaysQuietOnSuccess(t *testing.T) {
 // closeConnAndLog must treat a nil closer as a no-op rather than panic.
 func TestCloseConnAndLogHandlesNilCloser(t *testing.T) {
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger := slog.New(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
 
 	closeConnAndLog(logger, nil, "error closing connection")
 
@@ -129,10 +131,7 @@ func TestJoinCloseErrReturnsOriginalOnCloseSuccess(t *testing.T) {
 
 	got := joinCloseErr(origErr, &fakeCloser{err: nil})
 
-	if !errors.Is(got, origErr) {
-		t.Fatalf("expected original error, got: %v", got)
-	}
-	if errors.Unwrap(got) != nil {
-		t.Fatalf("expected no joined error when close succeeds, got: %v", got)
+	if got != origErr {
+		t.Fatalf("expected original error identity, got: %v", got)
 	}
 }

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -624,7 +624,12 @@ func (c *ConnectionManager) addConnectionImpl(
 		// Shutting down - release IP slot and close connection
 		c.releaseIPSlot(ipKey)
 		if conn != nil {
-			conn.Close()
+			closeConnAndLog(
+				c.config.Logger,
+				conn,
+				"error closing connection rejected during shutdown",
+				"peer_addr", peerAddr,
+			)
 		}
 		return false
 	}
@@ -651,7 +656,12 @@ func (c *ConnectionManager) addConnectionImpl(
 				"peer_addr",
 				peerAddr,
 			)
-			conn.Close()
+			closeConnAndLog(
+				c.config.Logger,
+				conn,
+				"error closing colliding inbound connection",
+				"peer_addr", peerAddr,
+			)
 			c.releaseIPSlot(ipKey)
 			c.goroutineWg.Done()
 			return false
@@ -683,7 +693,12 @@ func (c *ConnectionManager) addConnectionImpl(
 			// metrics via RemoveConnection.
 			delete(c.connections, connId)
 			c.connectionsMutex.Unlock()
-			existingConn.Close()
+			closeConnAndLog(
+				c.config.Logger,
+				existingConn,
+				"error closing evicted inbound connection",
+				"peer_addr", peerAddr,
+			)
 			if existingIPKey != "" {
 				c.releaseIPSlot(existingIPKey)
 			}
@@ -713,7 +728,12 @@ func (c *ConnectionManager) addConnectionImpl(
 			existingIPKey := existing.ipKey
 			delete(c.connections, connId)
 			c.connectionsMutex.Unlock()
-			existingConn.Close()
+			closeConnAndLog(
+				c.config.Logger,
+				existingConn,
+				"error closing replaced connection",
+				"peer_addr", peerAddr,
+			)
 			if existingIPKey != "" {
 				c.releaseIPSlot(existingIPKey)
 			}

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -687,6 +687,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			}
 			c.updateConnectionMetricsLocked(existing, false)
 			existingConn := existing.conn
+			existingPeerAddr := existing.peerAddr
 			existingIPKey := existing.ipKey
 			// Remove the old entry so the evicted connection's
 			// error-watcher goroutine cannot double-decrement
@@ -697,7 +698,7 @@ func (c *ConnectionManager) addConnectionImpl(
 				c.config.Logger,
 				existingConn,
 				"error closing evicted inbound connection",
-				"peer_addr", peerAddr,
+				"peer_addr", existingPeerAddr,
 			)
 			if existingIPKey != "" {
 				c.releaseIPSlot(existingIPKey)
@@ -725,6 +726,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			}
 			c.updateConnectionMetricsLocked(existing, false)
 			existingConn := existing.conn
+			existingPeerAddr := existing.peerAddr
 			existingIPKey := existing.ipKey
 			delete(c.connections, connId)
 			c.connectionsMutex.Unlock()
@@ -732,7 +734,7 @@ func (c *ConnectionManager) addConnectionImpl(
 				c.config.Logger,
 				existingConn,
 				"error closing replaced connection",
-				"peer_addr", peerAddr,
+				"peer_addr", existingPeerAddr,
 			)
 			if existingIPKey != "" {
 				c.releaseIPSlot(existingIPKey)

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -216,6 +216,10 @@ func (c *ConnectionManager) startListener(
 						c.config.Logger.Error(
 							fmt.Sprintf("listener: accept failed: %s", err),
 						)
+						// Close errors on this reject path are intentionally
+						// discarded throughout this loop: the connection is
+						// already being torn down, and the reason is the
+						// logged error above, not whatever Close() reports.
 						_ = conn.Close()
 						continue
 					}
@@ -239,7 +243,7 @@ func (c *ConnectionManager) startListener(
 							err,
 						),
 					)
-					conn.Close()
+					_ = conn.Close()
 					continue
 				}
 				peerAddr := "unknown"
@@ -298,7 +302,7 @@ func (c *ConnectionManager) startListener(
 						conn.RemoteAddr(),
 					),
 				)
-				conn.Close()
+				_ = conn.Close()
 				continue
 			}
 			// From here on, we hold a reserved inbound slot.
@@ -328,7 +332,7 @@ func (c *ConnectionManager) startListener(
 						c.config.MaxConnectionsPerIP,
 					),
 				)
-				conn.Close()
+				_ = conn.Close()
 				c.releaseInboundSlot()
 				continue
 			}
@@ -348,7 +352,7 @@ func (c *ConnectionManager) startListener(
 				)
 				// Release the IP slot since the connection failed
 				c.releaseIPSlot(ipKey)
-				conn.Close()
+				_ = conn.Close()
 				c.releaseInboundSlot()
 				continue
 			}

--- a/connmanager/outbound.go
+++ b/connmanager/outbound.go
@@ -97,8 +97,7 @@ func (c *ConnectionManager) CreateOutboundConn(
 		connOpts...,
 	)
 	if err != nil {
-		tmpConn.Close()
-		return nil, err
+		return nil, joinCloseErr(err, tmpConn)
 	}
 	c.config.Logger.Info(
 		"connected ouroboros to "+address,
@@ -120,11 +119,11 @@ func (c *ConnectionManager) CreateOutboundConn(
 		"connection_id", oConn.Id().String(),
 	)
 	if !c.AddConnection(oConn, false, peerAddr) {
-		oConn.Close()
-		return nil, fmt.Errorf(
+		rejectErr := fmt.Errorf(
 			"connection rejected (shutdown or collision): %s",
 			address,
 		)
+		return nil, joinCloseErr(rejectErr, oConn)
 	}
 	return oConn, nil
 }

--- a/database/plugin/blob/gcs/close_test.go
+++ b/database/plugin/blob/gcs/close_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package gcs
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeCloser stands in for the real *storage.Writer, which needs a live GCS
+// bucket (or credentials) to construct at all. joinCloseErr is tested against
+// this controllable io.Closer instead of standing up real cloud storage.
+type fakeCloser struct {
+	err error
+}
+
+func (f *fakeCloser) Close() error {
+	return f.err
+}
+
+// When the write already failed and the writer also fails to close, both
+// errors matter: the close failure can be the only signal that the partial
+// upload was never aborted cleanly. Neither may be dropped in favor of the
+// other.
+func TestJoinCloseErrJoinsOnCloseFailure(t *testing.T) {
+	writeErr := errors.New("write failed")
+	closeErr := errors.New("upload aborted")
+
+	got := joinCloseErr(writeErr, &fakeCloser{err: closeErr})
+
+	if !errors.Is(got, writeErr) {
+		t.Fatalf("expected joined error to wrap the write error: %v", got)
+	}
+	if !errors.Is(got, closeErr) {
+		t.Fatalf("expected joined error to wrap the close error: %v", got)
+	}
+}
+
+// A clean close must not manufacture a joined error out of nothing -- the
+// caller's original write error should come back unwrapped.
+func TestJoinCloseErrReturnsOriginalOnCloseSuccess(t *testing.T) {
+	writeErr := errors.New("write failed")
+
+	got := joinCloseErr(writeErr, &fakeCloser{err: nil})
+
+	if !errors.Is(got, writeErr) {
+		t.Fatalf("expected original error, got: %v", got)
+	}
+	if errors.Unwrap(got) != nil {
+		t.Fatalf("expected no joined error when close succeeds, got: %v", got)
+	}
+}

--- a/database/plugin/blob/gcs/close_test.go
+++ b/database/plugin/blob/gcs/close_test.go
@@ -57,10 +57,7 @@ func TestJoinCloseErrReturnsOriginalOnCloseSuccess(t *testing.T) {
 
 	got := joinCloseErr(writeErr, &fakeCloser{err: nil})
 
-	if !errors.Is(got, writeErr) {
-		t.Fatalf("expected original error, got: %v", got)
-	}
-	if errors.Unwrap(got) != nil {
-		t.Fatalf("expected no joined error when close succeeds, got: %v", got)
+	if got != writeErr {
+		t.Fatalf("expected original error identity, got: %v", got)
 	}
 }

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -299,8 +299,7 @@ func (d *BlobStoreGCS) writeObject(
 ) error {
 	w := d.object(key).NewWriter(ctx)
 	if _, err := w.Write(value); err != nil {
-		_ = w.Close()
-		return err
+		return joinCloseErr(err, w)
 	}
 	return w.Close()
 }
@@ -315,10 +314,19 @@ func (d *BlobStoreGCS) writeObjectStream(
 ) error {
 	w := d.object(key).NewWriter(ctx)
 	if _, err := io.Copy(w, body); err != nil {
-		_ = w.Close()
-		return err
+		return joinCloseErr(err, w)
 	}
 	return w.Close()
+}
+
+// joinCloseErr closes closer and folds any close error into err, so a
+// writer that fails to close on an already-failing write path isn't
+// silently lost.
+func joinCloseErr(err error, closer io.Closer) error {
+	if closeErr := closer.Close(); closeErr != nil {
+		return errors.Join(err, closeErr)
+	}
+	return err
 }
 
 func (d *BlobStoreGCS) deleteObject(

--- a/node.go
+++ b/node.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/http"
 	"slices"
@@ -1718,7 +1719,11 @@ func (n *Node) Run(ctx context.Context) error {
 				n.blockForger.Stop()
 			}
 			if n.leaderElection != nil {
-				_ = n.leaderElection.Stop()
+				logErrIfNotNil(
+					n.config.logger,
+					"failed to stop leader election during cleanup",
+					n.leaderElection.Stop(),
+				)
 			}
 		})
 	}
@@ -1736,6 +1741,14 @@ func (n *Node) Run(ctx context.Context) error {
 	// Wait for shutdown signal
 	<-n.ctx.Done()
 	return nil
+}
+
+// logErrIfNotNil logs err at Error level if non-nil, so a cleanup step run
+// from the startup failure/shutdown unwind stack doesn't fail silently.
+func logErrIfNotNil(logger *slog.Logger, msg string, err error) {
+	if err != nil {
+		logger.Error(msg, "error", err)
+	}
 }
 
 // taintValue encodes a taint bit for EnforceNodeSettings. A taint records

--- a/node_test.go
+++ b/node_test.go
@@ -15,11 +15,13 @@
 package dingo
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -382,7 +384,9 @@ func TestShutdownClosesEventBusBeforeFinalCleanup(t *testing.T) {
 				case <-publishDone:
 					return nil
 				case <-time.After(time.Second):
-					return errors.New("event bus was not closed before final cleanup")
+					return errors.New(
+						"event bus was not closed before final cleanup",
+					)
 				}
 			},
 		},
@@ -535,4 +539,41 @@ func TestNodePeerPriorityEventUpdatesChainSelector(t *testing.T) {
 		5*time.Millisecond,
 		"higher-priority peer must win equal-tip selection after priority event",
 	)
+}
+
+// A close/stop failure surfaced during the startup-cleanup unwind must
+// actually reach the log, not just be swallowed by the caller's `_ =`.
+func TestLogErrIfNotNilLogsOnError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	logErrIfNotNil(
+		logger,
+		"failed to stop leader election during cleanup",
+		errors.New("epoch transition in flight"),
+	)
+
+	out := buf.String()
+	if !strings.Contains(out, "failed to stop leader election during cleanup") {
+		t.Fatalf("expected log message in output, got: %s", out)
+	}
+	if !strings.Contains(out, "epoch transition in flight") {
+		t.Fatalf("expected error detail in output, got: %s", out)
+	}
+}
+
+// The common case -- a clean stop -- must stay silent, or every successful
+// shutdown would log a spurious error line.
+func TestLogErrIfNotNilStaysQuietOnNil(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	logErrIfNotNil(logger, "failed to stop leader election during cleanup", nil)
+
+	if buf.Len() != 0 {
+		t.Fatalf(
+			"expected no log output for a nil error, got: %s",
+			buf.String(),
+		)
+	}
 }

--- a/peergov/churn.go
+++ b/peergov/churn.go
@@ -109,7 +109,13 @@ func (p *PeerGovernor) gossipChurn() {
 					peer.Connection.Id,
 				)
 				if conn != nil {
-					conn.Close()
+					closeConnAndLog(
+						p.config.Logger,
+						conn,
+						"gossip churn: error closing connection for demoted peer",
+						"address",
+						peer.Address,
+					)
 				}
 			}
 			peer.Connection = nil

--- a/peergov/churn.go
+++ b/peergov/churn.go
@@ -120,7 +120,7 @@ func (p *PeerGovernor) gossipChurn() {
 			}
 			peer.Connection = nil
 			p.config.Logger.Debug(
-				"gossip churn: closed connection for demoted peer",
+				"gossip churn: cleared connection for demoted peer",
 				"address", peer.Address,
 			)
 		}

--- a/peergov/close.go
+++ b/peergov/close.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"io"
+	"log/slog"
+)
+
+// closeConnAndLog closes conn, logging at Debug level if it fails. Every
+// caller already logs the reason the connection is being torn down, so a
+// close failure here is a secondary diagnostic, not the primary event.
+func closeConnAndLog(
+	logger *slog.Logger,
+	conn io.Closer,
+	msg string,
+	attrs ...any,
+) {
+	if conn == nil {
+		return
+	}
+	if err := conn.Close(); err != nil {
+		logger.Debug(msg, append(attrs, "error", err)...)
+	}
+}

--- a/peergov/close_test.go
+++ b/peergov/close_test.go
@@ -68,7 +68,9 @@ func TestCloseConnAndLogLogsOnCloseError(t *testing.T) {
 // exists to surface.
 func TestCloseConnAndLogStaysQuietOnSuccess(t *testing.T) {
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger := slog.New(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
 
 	closeConnAndLog(
 		logger,
@@ -90,7 +92,9 @@ func TestCloseConnAndLogStaysQuietOnSuccess(t *testing.T) {
 // nil closer as a no-op rather than panic.
 func TestCloseConnAndLogHandlesNilCloser(t *testing.T) {
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger := slog.New(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
 
 	closeConnAndLog(logger, nil, "error closing connection")
 

--- a/peergov/close_test.go
+++ b/peergov/close_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// fakeCloser stands in for a real *ouroboros.Connection, whose Close()
+// unconditionally returns nil -- there is no way to drive a genuine close
+// failure through the real type, so closeConnAndLog is tested against this
+// controllable io.Closer instead.
+type fakeCloser struct {
+	err error
+}
+
+func (f *fakeCloser) Close() error {
+	return f.err
+}
+
+// A close failure must still surface: the message, the underlying error, and
+// any caller-supplied attributes (e.g. the peer address) all need to make it
+// into the log line, or a real cleanup failure would be undiagnosable.
+func TestCloseConnAndLogLogsOnCloseError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+	)
+	closeErr := errors.New("connection reset")
+
+	closeConnAndLog(
+		logger,
+		&fakeCloser{err: closeErr},
+		"error closing connection",
+		"address", "10.0.0.1:3001",
+	)
+
+	out := buf.String()
+	if !strings.Contains(out, "error closing connection") {
+		t.Fatalf("expected log message in output, got: %s", out)
+	}
+	if !strings.Contains(out, "connection reset") {
+		t.Fatalf("expected close error in output, got: %s", out)
+	}
+	if !strings.Contains(out, "10.0.0.1:3001") {
+		t.Fatalf("expected caller-supplied attrs in output, got: %s", out)
+	}
+}
+
+// The common case -- Close() succeeds -- must stay silent. Logging on every
+// routine connection teardown would bury the genuine failures this helper
+// exists to surface.
+func TestCloseConnAndLogStaysQuietOnSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	closeConnAndLog(
+		logger,
+		&fakeCloser{err: nil},
+		"error closing connection",
+		"address", "10.0.0.1:3001",
+	)
+
+	if buf.Len() != 0 {
+		t.Fatalf(
+			"expected no log output on successful close, got: %s",
+			buf.String(),
+		)
+	}
+}
+
+// GetConnectionById returns nil for an unknown connection ID, and several
+// callers pass that result straight through. closeConnAndLog must treat a
+// nil closer as a no-op rather than panic.
+func TestCloseConnAndLogHandlesNilCloser(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	closeConnAndLog(logger, nil, "error closing connection")
+
+	if buf.Len() != 0 {
+		t.Fatalf(
+			"expected no log output for a nil closer, got: %s",
+			buf.String(),
+		)
+	}
+}

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -386,7 +386,12 @@ func (p *PeerGovernor) createOutboundConnection(
 			if peerIdx == -1 {
 				p.mu.Unlock()
 				// Peer was removed while connecting, close connection
-				conn.Close()
+				closeConnAndLog(
+					p.config.Logger,
+					conn,
+					"outbound: error closing connection for removed peer",
+					"address", peer.Address,
+				)
 				p.config.Logger.Debug(
 					"outbound: peer removed during connection, closing",
 					"address", peer.Address,
@@ -397,7 +402,12 @@ func (p *PeerGovernor) createOutboundConnection(
 			currentPeer := p.peers[peerIdx]
 			if p.isPeerDeniedLocked(currentPeer) {
 				p.mu.Unlock()
-				conn.Close()
+				closeConnAndLog(
+					p.config.Logger,
+					conn,
+					"outbound: error closing connection for denied peer",
+					"address", peer.Address,
+				)
 				p.config.Logger.Debug(
 					"outbound: peer denied during connection, closing",
 					"address", peer.Address,
@@ -696,7 +706,13 @@ func (p *PeerGovernor) handleInboundConnectionEvent(evt event.Event) {
 					"address", address,
 					"connection_id", connId.String(),
 				)
-				conn.Close()
+				closeConnAndLog(
+					p.config.Logger,
+					conn,
+					"error closing denied inbound peer connection",
+					"address", address,
+					"connection_id", connId.String(),
+				)
 			}
 		}
 		return
@@ -1172,8 +1188,10 @@ func (p *PeerGovernor) TestPeer(address string) (bool, error) {
 		if err != nil {
 			testErr = err
 		} else {
-			// Connection succeeded, close it since this is just a test
-			conn.Close()
+			// Connection succeeded, close it since this is just a test.
+			// Reachability is already established by the successful dial,
+			// so a close error here carries no diagnostic value.
+			_ = conn.Close()
 		}
 	} else {
 		testErr = errors.New("no test function or connection manager configured")

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -105,7 +105,13 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 							peer.Connection.Id,
 						)
 						if conn != nil {
-							conn.Close()
+							closeConnAndLog(
+								p.config.Logger,
+								conn,
+								"error closing connection for bootstrap peer after exit",
+								"address",
+								peer.Address,
+							)
 						}
 					}
 					peer.Connection = nil
@@ -626,7 +632,13 @@ func (p *PeerGovernor) enforceStateLimit(
 		if peer.Connection != nil && p.config.ConnManager != nil {
 			conn := p.config.ConnManager.GetConnectionById(peer.Connection.Id)
 			if conn != nil {
-				conn.Close()
+				closeConnAndLog(
+					p.config.Logger,
+					conn,
+					"error closing connection for peer removed due to limit exceeded",
+					"address",
+					peer.Address,
+				)
 			}
 		}
 		events = append(events, pendingEvent{

--- a/peergov/topology.go
+++ b/peergov/topology.go
@@ -286,7 +286,12 @@ func (p *PeerGovernor) LoadTopologyConfig(
 			if conn := p.config.ConnManager.GetConnectionById(
 				orphanPeer.Connection.Id,
 			); conn != nil {
-				conn.Close()
+				closeConnAndLog(
+					p.config.Logger,
+					conn,
+					"error closing connection for peer removed by topology",
+					"address", orphanPeer.Address,
+				)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Addresses #2289: several low-severity shutdown/close errors (audit findings
L11-L14) were discarded instead of logged or aggregated, which could hide
real cleanup failures during production debugging. This PR reviews every
named finding, makes intentional discards explicit and documented, and adds
targeted unit tests for the decision logic that changed.

## Changes

### L11 — `node.go`
- `leaderElection.Stop()`'s error is now logged (was silently discarded via `_ =`).
- Added `logErrIfNotNil(logger, msg, err)` helper next to `taintValue` for this single call site; covered by new tests in `node_test.go`.

### L12 — `cmd/dingo/main.go`
- CPU profile file `Close()` error is now reported to stderr instead of discarded.
- Memory profile file `Close()` error is now reported to stderr instead of discarded (same class of bug, same file).
- Added `closeProfileFile(stderr, f, kind)` helper in `main.go`; covered by `cmd/dingo/profile_test.go` using a real double-closed `*os.File` to deterministically force the error path.

### L13 — `peergov/` and `connmanager/`
- **`peergov`**: connection-close errors are now logged at Debug level with peer/connection context in `churn.go`, `connections.go` (3 sites), `reconcile.go` (2 sites), and `topology.go`. Added `peergov/close.go` (`closeConnAndLog` helper, shared across all 4 files) with tests in `peergov/close_test.go`.
- The peer-reachability test-connection close in `connections.go` is left as an explicit, commented no-op — closing a connection made purely to test reachability carries no diagnostic value.
- **`connmanager`**: `connection_manager.go`'s shutdown-reject and collision-eviction close paths now log via the same pattern (`connmanager/close.go`, its own `closeConnAndLog`). `outbound.go`'s raw-socket and ouroboros-connection close errors are now joined into the returned error via a new `joinCloseErr` helper instead of being dropped.
- `listener.go`'s bare `conn.Close()` calls on accept-reject paths (already logged via the adjacent Error/Warn/Info call) are normalized to explicit `_ = conn.Close()`, with a comment on the first occurrence documenting that the discard is intentional throughout the loop.
- New tests in `connmanager/close_test.go` cover both helpers via a fake `io.Closer` (since `*ouroboros.Connection.Close()` unconditionally returns `nil` in the vendored library today, making the real type untestable for this branch).

### L14 — `database/plugin/blob/gcs/database.go`
- `writeObject` / `writeObjectStream` now join the writer's `Close()` error into the returned write error via a new `joinCloseErr` helper instead of swallowing it.
- New tests in `database/plugin/blob/gcs/close_test.go` cover the join logic via a fake `io.Closer` (real GCS writer needs live credentials, unavailable in CI per this package's existing test conventions).

Closes #2289 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs previously discarded shutdown/close errors and preserves CPU/memory profile cleanup on all exit paths. Old behavior dropped close/stop errors and could skip deferred CPU-profile cleanup; new behavior logs or returns joined errors and centralizes process exit so defers run. Addresses #2289.

- CLI (`cmd/dingo`): route all command failures through Cobra `RunE` and a `run()` wrapper invoked by `os.Exit(run())`, so profiling defers always run; `commonRun` now returns `(*slog.Logger, error)`; `closeProfileFile` reports profile `Close()` errors; root `SilenceErrors`/`SilenceUsage` set; tests cover close-error reporting.
- `node`: log `leaderElection.Stop()` failures via `logErrIfNotNil`; tests cover error/nil paths.
- `connmanager`: add `closeConnAndLog` and `joinCloseErr`; log close failures on shutdown reject, collision eviction, and replacement; `CreateOutboundConn` now joins close errors on both raw-socket and `ouroboros` paths; listener reject paths explicitly discard close errors with a comment; tests cover helpers.
- `peergov`: add `closeConnAndLog`; log close failures in churn, outbound/inbound deny/removal, reconcile, and topology; explicitly discard the reachability test-connection close error; tests cover helper.
- `database/plugin/blob/gcs`: join writer `Close()` errors into returned errors in `writeObject` and `writeObjectStream`; tests cover join behavior.

Impact: callers of `CreateOutboundConn` and GCS write methods may now receive joined errors; CLI commands now return errors instead of calling `os.Exit`. No migration required.

<sup>Written for commit 3fcd7838802c3ae85463602e28ce819bea08e017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of errors that occur while closing profiling, network, and storage connections.
  * Preserved both primary operation errors and cleanup errors for clearer diagnostics.
  * Added contextual debug logging for failed connection cleanup.
  * Cleanup during shutdown and connection rejection now reports failures instead of silently discarding them.

* **Tests**
  * Added coverage for successful, failed, and nil cleanup scenarios, including combined error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->