### PR TITLE
fix(ledger): defer consumed UTxO cleanup during catch-up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1186,6 +1186,13 @@ Dingo supports two storage modes, configured via `storageMode`:
 - `core` (default): Minimal storage for chain following and block production.
 - `api`: Extended storage with transaction indexes, address lookups, and asset tracking. Required when any client-facing API server (Blockfrost, Mesh, UTxO RPC) is enabled. Bark is a separate Dingo-to-Dingo protocol and is not part of that API surface.
 
+In core mode, the ledger's background consumed-UTxO pruner is advisory: it
+defers while the local tip is materially behind the known upstream tip, so its
+potentially large SQLite write transaction cannot compete with blockfetch
+state persistence during historical catch-up. The timer and epoch-boundary
+triggers are single-flight; once the node is near the upstream tip, one run
+drains eligible rows using the era's stability window.
+
 ### Midnight gRPC Server
 
 In `storageMode: api` with `midnight.port > 0`, `node.go` starts

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -269,8 +269,8 @@ That cleanup is deferred while the local tip is materially behind the known
 upstream tip and is single-flight across its timer and epoch-boundary
 triggers. This keeps the potentially large `utxo`/stake-reference scan from
 holding SQLite's single write connection during historical catch-up; the
-rows remain eligible and are reclaimed once the node reaches the tip. API
-mode retains spent UTxO metadata for historical transaction queries.
+rows remain eligible and are reclaimed once the node is near the upstream tip.
+API mode retains spent UTxO metadata for historical transaction queries.
 
 ## ER Diagrams
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -263,6 +263,15 @@ flowchart LR
 - Certificate history ordering must use `added_slot DESC`, the producing transaction's `block_index DESC`, and `cert_index DESC`. `cert_index` resets per transaction.
 - Storage mode is persisted in `node_settings_gate` (the `storage_mode` gate; `node_settings.storage_mode` is a read-only compatibility fallback, see below). `core` mode stores consensus and ledger state. `api` mode additionally populates address, witness, datum, redeemer, script, metadata-label indexes, and the best-effort `offchain_metadata` cache. API-only tables are still migrated in `core` mode but may be empty.
 
+In core mode, consumed UTxO rows are hard-deleted only by the background
+ledger cleanup after they are outside the current era's stability window.
+That cleanup is deferred while the local tip is materially behind the known
+upstream tip and is single-flight across its timer and epoch-boundary
+triggers. This keeps the potentially large `utxo`/stake-reference scan from
+holding SQLite's single write connection during historical catch-up; the
+rows remain eligible and are reclaimed once the node reaches the tip. API
+mode retains spent UTxO metadata for historical transaction queries.
+
 ## ER Diagrams
 
 ### Transactions and UTxO

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -265,9 +265,12 @@ flowchart LR
 
 In core mode, consumed UTxO rows are hard-deleted only by the background
 ledger cleanup after they are outside the current era's stability window.
-That cleanup is deferred while the local tip is materially behind the known
+That cleanup is deferred while the local tip is materially behind a known
 upstream tip and is single-flight across its timer and epoch-boundary
-triggers. This keeps the potentially large `utxo`/stake-reference scan from
+triggers. The deferral needs a known upstream tip: a node with no connected
+peer has no catch-up distance to measure, so cleanup falls back to running
+off the local tip alone rather than deferring for as long as the node stays
+peerless. This keeps the potentially large `utxo`/stake-reference scan from
 holding SQLite's single write connection during historical catch-up; the
 rows remain eligible and are reclaimed once the node is near the upstream tip.
 API mode retains spent UTxO metadata for historical transaction queries.

--- a/ledger/cleanup_consumed_utxos_test.go
+++ b/ledger/cleanup_consumed_utxos_test.go
@@ -145,6 +145,44 @@ func TestCleanupConsumedUtxos_DefersDuringCatchup(t *testing.T) {
 	assert.NotNil(t, post, "cleanup must defer while the ledger is catching up")
 }
 
+// TestCleanupConsumedUtxos_RunsWithoutKnownUpstreamTip covers the
+// distinction the catch-up deferral has to make: an upstream tip of 0 means
+// unknown, not "infinitely far behind". A node that has never connected to a
+// peer -- or that lost its last active connection, which zeroes the value in
+// chainsync.go -- would otherwise defer cleanup for as long as it stays
+// peerless, growing the utxo table without bound in core mode, and silently:
+// no error, no crash. Cleanup ran off the local tip alone before the deferral
+// existed, so that is the behavior an unknown upstream tip falls back to.
+func TestCleanupConsumedUtxos_RunsWithoutKnownUpstreamTip(t *testing.T) {
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	txId := bytes.Repeat([]byte{0xB4}, 32)
+	const (
+		addedSlot   uint64 = 1_000
+		deletedSlot uint64 = 5_000
+		// Far past the 50_000 default stability window, so the only
+		// reason to retain the row would be the deferral itself.
+		tipSlot uint64 = 10_000_000
+	)
+	seedSpentUtxoForCleanup(t, db, txId, 0, addedSlot, deletedSlot)
+
+	pre, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pre, "seed must succeed before cleanup")
+
+	ls := newLedgerStateForCleanup(db, tipSlot)
+	// No peer has ever reported a tip.
+	ls.syncUpstreamTipSlot.Store(0)
+	ls.cleanupConsumedUtxos()
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(
+		t, post,
+		"an unknown upstream tip must not defer cleanup: the local tip "+
+			"is already far past the stability window",
+	)
+}
+
 // TestCleanupConsumedUtxos_APIModeRetains is the regression fix for
 // issue #2350: in API storage mode the periodic cleanup must leave
 // spent UTxO metadata rows in place so historical transaction queries

--- a/ledger/cleanup_consumed_utxos_test.go
+++ b/ledger/cleanup_consumed_utxos_test.go
@@ -74,12 +74,13 @@ func seedSpentUtxoForCleanup(
 // calculateStabilityWindowForEra returns the default
 // (blockfetchBatchSlotThresholdDefault = 50000); the tip slot is then
 // chosen well past that window so consumed-UTxO cleanup is eligible to
-// run in core mode.
+// run in core mode. The upstream tip is initialized to the local tip so the
+// test represents a node that is near the network tip.
 func newLedgerStateForCleanup(
 	db *database.Database,
 	tipSlot uint64,
 ) *LedgerState {
-	return &LedgerState{
+	ls := &LedgerState{
 		db:         db,
 		currentEra: eras.ConwayEraDesc,
 		currentTip: ochainsync.Tip{
@@ -89,6 +90,8 @@ func newLedgerStateForCleanup(
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
+	ls.syncUpstreamTipSlot.Store(tipSlot)
+	return ls
 }
 
 // TestCleanupConsumedUtxos_CoreModePrunes asserts the pre-existing
@@ -120,6 +123,26 @@ func TestCleanupConsumedUtxos_CoreModePrunes(t *testing.T) {
 		"core mode must hard-delete consumed UTxO rows after stability "+
 			"window",
 	)
+}
+
+func TestCleanupConsumedUtxos_DefersDuringCatchup(t *testing.T) {
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	txId := bytes.Repeat([]byte{0xA3}, 32)
+	const (
+		addedSlot   uint64 = 1_000
+		deletedSlot uint64 = 5_000
+		tipSlot     uint64 = 100_000
+		upstreamTip uint64 = 200_000
+	)
+	seedSpentUtxoForCleanup(t, db, txId, 0, addedSlot, deletedSlot)
+
+	ls := newLedgerStateForCleanup(db, tipSlot)
+	ls.syncUpstreamTipSlot.Store(upstreamTip)
+	ls.cleanupConsumedUtxos()
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, post, "cleanup must defer while the ledger is catching up")
 }
 
 // TestCleanupConsumedUtxos_APIModeRetains is the regression fix for

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2231,6 +2231,15 @@ func (ls *LedgerState) isNearTipWithStabilityWindow(
 	if upstreamTip == 0 {
 		return false
 	}
+	return nearUpstreamTip(slot, upstreamTip, stabilityWindow)
+}
+
+// nearUpstreamTip reports whether slot is within stabilityWindow of a KNOWN
+// upstreamTip. Callers that must tell "upstream tip unknown" apart from
+// "known, and we are far behind it" read syncUpstreamTipSlot themselves and
+// call this directly; isNearTipWithStabilityWindow folds unknown into
+// not-near, which is the safe answer for its callers but not for all of them.
+func nearUpstreamTip(slot, upstreamTip, stabilityWindow uint64) bool {
 	if slot >= upstreamTip {
 		return true
 	}
@@ -2280,12 +2289,21 @@ func (ls *LedgerState) cleanupConsumedUtxos() {
 	eraId := ls.currentEra.Id
 	ls.RUnlock()
 	stabilityWindow := ls.calculateStabilityWindowForEra(eraId)
-	if !ls.isNearTipWithStabilityWindow(tipSlot, stabilityWindow) {
+	// Read once and gate on a KNOWN upstream tip only. An unknown one is not
+	// evidence of catching up: no peer has ever connected, or the last active
+	// connection dropped and zeroed it (see handleEventChainsyncBlockfetch's
+	// active-connection handling in chainsync.go). Deferring on that would
+	// retain consumed rows forever on a node without peers, where cleanup
+	// previously ran off the local tip alone -- an unbounded utxo table in
+	// exactly the mode documented as minimal storage.
+	upstreamTip := ls.syncUpstreamTipSlot.Load()
+	if upstreamTip != 0 &&
+		!nearUpstreamTip(tipSlot, upstreamTip, stabilityWindow) {
 		ls.config.Logger.Debug(
 			"deferring consumed UTxO cleanup while catching up",
 			"component", "ledger",
 			"tip_slot", tipSlot,
-			"upstream_tip_slot", ls.syncUpstreamTipSlot.Load(),
+			"upstream_tip_slot", upstreamTip,
 		)
 		return
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -639,6 +639,7 @@ type LedgerState struct {
 	rewardInputRollbackActive          atomic.Int64               // non-zero while rollback can mutate reward calculation inputs
 	mempool                            MempoolProvider
 	timerCleanupConsumedUtxos          *time.Timer
+	cleanupConsumedUtxosRunning        atomic.Bool
 	Scheduler                          *Scheduler
 	chain                              *chain.Chain
 	db                                 *database.Database
@@ -2247,6 +2248,15 @@ func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
 }
 
 func (ls *LedgerState) cleanupConsumedUtxos() {
+	// Cleanup is advisory pruning. Never let the periodic timer and the epoch
+	// transition trigger occupy SQLite's single write connection at the same
+	// time; a second invocation has no additional work to do after the first
+	// one drains the eligible rows.
+	if !ls.cleanupConsumedUtxosRunning.CompareAndSwap(false, true) {
+		return
+	}
+	defer ls.cleanupConsumedUtxosRunning.Store(false)
+
 	// In API storage mode we retain spent UTxO metadata rows past the
 	// stability window so historical transaction queries can resolve
 	// input/collateral/reference-input details via spent_at_tx_id,
@@ -2263,6 +2273,15 @@ func (ls *LedgerState) cleanupConsumedUtxos() {
 	tipSlot := ls.currentTip.Point.Slot
 	eraId := ls.currentEra.Id
 	ls.RUnlock()
+	if !ls.isNearTip(tipSlot) {
+		ls.config.Logger.Debug(
+			"deferring consumed UTxO cleanup while catching up",
+			"component", "ledger",
+			"tip_slot", tipSlot,
+			"upstream_tip_slot", ls.syncUpstreamTipSlot.Load(),
+		)
+		return
+	}
 	stabilityWindow := ls.calculateStabilityWindowForEra(eraId)
 
 	// Delete UTxOs that are marked as deleted and older than our slot window

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2221,6 +2221,12 @@ func (ls *LedgerState) protocolMajorForEvent(
 // the tip they are always on. Returns false when no upstream tip is known yet
 // (no peer connected), since we can't determine proximity.
 func (ls *LedgerState) isNearTip(slot uint64) bool {
+	return ls.isNearTipWithStabilityWindow(slot, ls.calculateStabilityWindow())
+}
+
+func (ls *LedgerState) isNearTipWithStabilityWindow(
+	slot, stabilityWindow uint64,
+) bool {
 	upstreamTip := ls.syncUpstreamTipSlot.Load()
 	if upstreamTip == 0 {
 		return false
@@ -2228,7 +2234,7 @@ func (ls *LedgerState) isNearTip(slot uint64) bool {
 	if slot >= upstreamTip {
 		return true
 	}
-	return upstreamTip-slot <= ls.calculateStabilityWindow()
+	return upstreamTip-slot <= stabilityWindow
 }
 
 func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
@@ -2273,7 +2279,8 @@ func (ls *LedgerState) cleanupConsumedUtxos() {
 	tipSlot := ls.currentTip.Point.Slot
 	eraId := ls.currentEra.Id
 	ls.RUnlock()
-	if !ls.isNearTip(tipSlot) {
+	stabilityWindow := ls.calculateStabilityWindowForEra(eraId)
+	if !ls.isNearTipWithStabilityWindow(tipSlot, stabilityWindow) {
 		ls.config.Logger.Debug(
 			"deferring consumed UTxO cleanup while catching up",
 			"component", "ledger",
@@ -2282,7 +2289,6 @@ func (ls *LedgerState) cleanupConsumedUtxos() {
 		)
 		return
 	}
-	stabilityWindow := ls.calculateStabilityWindowForEra(eraId)
 
 	// Delete UTxOs that are marked as deleted and older than our slot window
 	ls.config.Logger.Debug(

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -1064,6 +1064,16 @@ func TestLedgerStateIsNearTipUsesStabilityWindow(t *testing.T) {
 	assert.False(t, ls.isNearTip(993), "gap above 3k/f should be catch-up")
 	assert.True(t, ls.isNearTip(994), "gap equal to 3k/f should be near tip")
 	assert.True(t, ls.isNearTip(1001), "local tip beyond upstream is near tip")
+	assert.False(
+		t,
+		ls.isNearTipWithStabilityWindow(989, 10),
+		"explicit window must reject a larger upstream gap",
+	)
+	assert.True(
+		t,
+		ls.isNearTipWithStabilityWindow(990, 10),
+		"explicit window must accept an equal upstream gap",
+	)
 }
 
 func TestNextEpochNonceReadyCutoffSlot(t *testing.T) {


### PR DESCRIPTION
## Problem

During historical Musashi sync, consumed-UTxO cleanup can scan 10k IDs inside SQLite's single write transaction. Blockfetch state persistence then waits for that connection, filling the lossless EventBus buffer and emitting subscriber-stalled warnings.

## Changes

- Defer core-mode cleanup while the ledger is materially behind the known upstream tip.
- Make timer and epoch-boundary cleanup single-flight.
- Preserve core pruning and API retention behavior.
- Document the lifecycle and storage policy.

## Checks

- `go test ./ledger -run 'TestCleanupConsumedUtxos|TestIsNearTip' -count=1`
- `go test -race ./ledger -run 'TestCleanupConsumedUtxos|TestIsNearTip' -count=1`
- `go test ./event -run 'Test.*(Stall|Deliver|Backpressure|Subscriber)' -count=1`
- `make docs-parity`

## Summary by Cubic

Defers consumed UTxO cleanup during historical catch-up to avoid SQLite write lock contention and event-bus backpressure. Previously, `core`-mode cleanup ran regardless of catch-up state and could block blockfetch state persistence; now it defers until the node is near the upstream tip and runs single-flight. `api`-mode retention is unchanged.

### Review and rollout

- Introduces a near-tip gate for cleanup and a single-flight guard shared by timer and epoch-boundary triggers.
- Preserves `core` pruning policy and documents lifecycle behavior in `ARCHITECTURE.md` and `DATABASE.md`.
- Adds a deferral test and updates existing tests; no schema changes.
- No operator action. During catch-up, spent UTxOs may persist longer and are pruned once near the tip.

## Summary by CodeRabbit

### Bug Fixes

- Prevented consumed UTxO records from being removed while the ledger is catching up.
- Ensured cleanup runs only once at a time, avoiding overlapping cleanup operations.
- Preserved spent UTxO metadata until it falls outside the current era's stability window.

### Documentation

- Added guidance describing consumed UTxO cleanup behavior in core and API modes.