### PR TITLE
fix(peergov): bound shutdown during ledger discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2534,7 +2534,7 @@ Two Prometheus metrics capture the outcome: `dingo_leios_ntc_certrb_total{outcom
 
 The `PeerGovernor` (`peergov/peergov.go`) manages peer selection and topology:
 
-`Start()` owns its inbound-connection and connection-closed EventBus subscriptions, and `Stop()` removes them with `UnsubscribeAndWait`. This is required when live restore/truncate replaces the governor while retaining the EventBus: a stopped governor must not process delayed events or publish stale chain-selection updates after the replacement reconnects.
+`Start()` owns its inbound-connection and connection-closed EventBus subscriptions, and `Stop(ctx)` removes them with `UnsubscribeAndWaitContext`. This is required when live restore/truncate replaces the governor while retaining the EventBus: a stopped governor must not process delayed events or publish stale chain-selection updates after the replacement reconnects. The unsubscribe itself always happens; only the wait for a handler already in flight is bounded by `ctx`, so one stuck handler cannot overrun the shutdown deadline. A deadline expiry is returned as an error, unprefixed — every caller adds its own `peer governor shutdown:` prefix, as it does for the other components.
 
 Outbound-dial goroutines are registered with the governor's wait group while
 holding the same mutex `Stop()` uses to clear `stopCh`. Runtime peer additions,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -964,9 +964,12 @@ Phase 4: Cleanup resources
 The node creates one shutdown context from the configured `shutdownTimeout`
 and passes it through every phase. PeerGovernor shutdown cancels its internal
 run context, which interrupts ledger-peer DNS discovery and outbound work,
-then waits for its tracked workers until that deadline. A deadline expiry is
-returned as a shutdown error while the remaining teardown continues, so a
-slow peer-governor operation cannot hold phase 1 indefinitely.
+then waits for its tracked workers until that deadline. Its connection-event
+handlers are removed with `EventBus.UnsubscribeAndWaitContext`, so the
+unsubscribe still happens unconditionally but an already-running handler is
+waited for only until that same deadline. A deadline expiry is returned as a
+shutdown error while the remaining teardown continues, so a slow peer-governor
+operation cannot hold phase 1 indefinitely.
 
 The terminal EventBus close occurs after mempool teardown and runs concurrently
 with `ConnectionManager.Stop`. Lossless event delivery can backpressure a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -961,6 +961,13 @@ Phase 4: Cleanup resources
   Registered shutdown functions
 ```
 
+The node creates one shutdown context from the configured `shutdownTimeout`
+and passes it through every phase. PeerGovernor shutdown cancels its internal
+run context, which interrupts ledger-peer DNS discovery and outbound work,
+then waits for its tracked workers until that deadline. A deadline expiry is
+returned as a shutdown error while the remaining teardown continues, so a
+slow peer-governor operation cannot hold phase 1 indefinitely.
+
 The terminal EventBus close occurs after mempool teardown and runs concurrently
 with `ConnectionManager.Stop`. Lossless event delivery can backpressure a
 network protocol callback on a full ledger subscriber, while a blockfetch

--- a/event/event.go
+++ b/event/event.go
@@ -15,6 +15,7 @@
 package event
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -321,6 +322,22 @@ func (c *channelSubscriber) waitDone() {
 	<-c.done
 }
 
+// waitDoneContext is waitDone bounded by ctx, returning ctx.Err() if the
+// dispatch goroutine is still running when ctx is done. A subscriber with no
+// dispatch goroutine has nothing to wait for and reports success even for an
+// already-canceled ctx.
+func (c *channelSubscriber) waitDoneContext(ctx context.Context) error {
+	if c.done == nil {
+		return nil
+	}
+	select {
+	case <-c.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // deliverWait hands evt to the subscriber channel, waiting for buffer capacity
 // instead of dropping the event. It returns errChannelSubscriberClosed when
 // the subscriber is closed or the bus stops before the event can be handed
@@ -609,7 +626,7 @@ func (e *EventBus) safeHandlerCall(
 
 // Unsubscribe stops delivery of events for a particular type for an existing subscriber
 func (e *EventBus) Unsubscribe(eventType EventType, subId EventSubscriberId) {
-	e.unsubscribe(eventType, subId, false)
+	e.unsubscribe(eventType, subId)
 }
 
 // UnsubscribeAndWait is like Unsubscribe, but for SubscribeFunc/
@@ -637,14 +654,43 @@ func (e *EventBus) UnsubscribeAndWait(
 	eventType EventType,
 	subId EventSubscriberId,
 ) {
-	e.unsubscribe(eventType, subId, true)
+	if chSub := e.unsubscribe(eventType, subId); chSub != nil {
+		chSub.waitDone()
+	}
 }
 
+// UnsubscribeAndWaitContext is UnsubscribeAndWait with the wait for an
+// in-flight handler bounded by ctx, returning ctx.Err() if the handler is
+// still running when ctx is done.
+//
+// The unsubscribe itself is never skipped or bounded: it is synchronous and
+// runs even for an already-canceled ctx, so future deliveries stop either
+// way and only the wait can be cut short. A caller that gets a non-nil error
+// therefore knows the handler may still be executing concurrently with
+// whatever it does next, which is the whole reason to wait -- prefer
+// UnsubscribeAndWait wherever there is no deadline to honor.
+//
+// Use this from a shutdown path that must respect a deadline: plain
+// UnsubscribeAndWait blocks for as long as the handler runs, which lets a
+// single stuck handler overrun a bounded shutdown.
+func (e *EventBus) UnsubscribeAndWaitContext(
+	ctx context.Context,
+	eventType EventType,
+	subId EventSubscriberId,
+) error {
+	if chSub := e.unsubscribe(eventType, subId); chSub != nil {
+		return chSub.waitDoneContext(ctx)
+	}
+	return nil
+}
+
+// unsubscribe removes the subscriber and, when it is a channelSubscriber,
+// closes it and returns it so a caller that needs to can wait for its
+// dispatch goroutine to exit. Returns nil when there is nothing to wait for.
 func (e *EventBus) unsubscribe(
 	eventType EventType,
 	subId EventSubscriberId,
-	wait bool,
-) {
+) *channelSubscriber {
 	e.mu.Lock()
 	var subToClose Subscriber
 	if evtTypeSubs, ok := e.subscribers[eventType]; ok {
@@ -702,10 +748,8 @@ func (e *EventBus) unsubscribe(
 		// Close is idempotent, so this is safe even if a concurrent
 		// caller already closed the same subscriber via subToClose above.
 		chSub.close(false)
-		if wait {
-			chSub.waitDone()
-		}
 	}
+	return chSub
 }
 
 // deliverWithTimeout calls sub.Deliver with a timeout for non-channel

--- a/event/event.go
+++ b/event/event.go
@@ -334,7 +334,16 @@ func (c *channelSubscriber) waitDoneContext(ctx context.Context) error {
 	case <-c.done:
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		// Recheck: when the handler finishes concurrently with
+		// cancellation both cases are ready and select picks at random,
+		// so reporting ctx.Err() here without looking would turn a
+		// completed teardown into a spurious shutdown error.
+		select {
+		case <-c.done:
+			return nil
+		default:
+			return ctx.Err()
+		}
 	}
 }
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -405,12 +405,16 @@ func TestUnsubscribeAndWaitContextBoundsTheWait(t *testing.T) {
 	// The wait, not the unsubscribe, is what ctx bounds: this must return
 	// while the handler is still blocked, or a bounded shutdown path can be
 	// held open indefinitely by one stuck handler.
-	select {
-	case err := <-returned:
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-	case <-time.After(5 * time.Second):
-		t.Fatal("UnsubscribeAndWaitContext did not honor the context deadline")
-	}
+	require.ErrorIs(
+		t,
+		testutil.RequireReceive(
+			t,
+			returned,
+			5*time.Second,
+			"UnsubscribeAndWaitContext did not honor the context deadline",
+		),
+		context.DeadlineExceeded,
+	)
 
 	// Delivery stopped even though the wait was cut short.
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, "after-unsubscribe"))

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -15,6 +15,7 @@
 package event_test
 
 import (
+	"context"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -365,6 +366,80 @@ func TestEventBusUnsubscribePreservesQueuedSubscriberEvents(t *testing.T) {
 	close(release)
 	testutil.RequireReceive(t, unsubscribed, time.Second, "UnsubscribeAndWait did not finish")
 	require.Equal(t, int32(3), handled.Load(), "ordinary unsubscribe discarded queued events")
+}
+
+func TestUnsubscribeAndWaitContextBoundsTheWait(t *testing.T) {
+	const testEvtType event.EventType = "test.unsubscribe.ctx"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Close()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	// Registered after the deferred Close so it runs first: a failure here
+	// leaves the handler blocked, and Close would otherwise wait on it
+	// forever instead of letting the test report the failure.
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseHandler()
+
+	var handled atomic.Int32
+	subID := eb.SubscribeFunc(testEvtType, func(event.Event) {
+		if handled.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+	})
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "in-flight"))
+	testutil.RequireReceive(t, entered, time.Second, "handler did not start")
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		50*time.Millisecond,
+	)
+	defer cancel()
+	returned := make(chan error, 1)
+	go func() {
+		returned <- eb.UnsubscribeAndWaitContext(ctx, testEvtType, subID)
+	}()
+	// The wait, not the unsubscribe, is what ctx bounds: this must return
+	// while the handler is still blocked, or a bounded shutdown path can be
+	// held open indefinitely by one stuck handler.
+	select {
+	case err := <-returned:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("UnsubscribeAndWaitContext did not honor the context deadline")
+	}
+
+	// Delivery stopped even though the wait was cut short.
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "after-unsubscribe"))
+	releaseHandler()
+	require.Eventually(
+		t,
+		func() bool { return handled.Load() == 1 },
+		time.Second,
+		10*time.Millisecond,
+		"unsubscribe must still take effect when the wait is cut short",
+	)
+}
+
+func TestUnsubscribeAndWaitContextReturnsNilOnceHandlerFinishes(t *testing.T) {
+	const testEvtType event.EventType = "test.unsubscribe.ctx.ok"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Close()
+
+	handled := make(chan struct{})
+	subID := eb.SubscribeFunc(testEvtType, func(event.Event) {
+		close(handled)
+	})
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "handled"))
+	testutil.RequireReceive(t, handled, time.Second, "handler did not run")
+
+	require.NoError(
+		t,
+		eb.UnsubscribeAndWaitContext(t.Context(), testEvtType, subID),
+	)
 }
 
 func TestSubscribeFuncPanicRecovery(t *testing.T) {

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -415,9 +415,12 @@ func TestUnsubscribeAndWaitContextBoundsTheWait(t *testing.T) {
 	// Delivery stopped even though the wait was cut short.
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, "after-unsubscribe"))
 	releaseHandler()
-	require.Eventually(
+	// Never, not Eventually: handled is already 1 from the in-flight event,
+	// so an Eventually would pass on its first poll without ever observing
+	// whether the post-unsubscribe publish got delivered.
+	require.Never(
 		t,
-		func() bool { return handled.Load() == 1 },
+		func() bool { return handled.Load() != 1 },
 		time.Second,
 		10*time.Millisecond,
 		"unsubscribe must still take effect when the wait is cut short",

--- a/node.go
+++ b/node.go
@@ -1440,6 +1440,7 @@ func (n *Node) Run(ctx context.Context) error {
 		n.peerGov.LoadTopologyConfig(topologyConfig)
 		if usePeerSnapshot {
 			added := n.peerGov.LoadPeerSnapshot(
+				n.ctx,
 				n.config.topologyConfig.PeerSnapshot,
 			)
 			if added > 0 {
@@ -1465,7 +1466,7 @@ func (n *Node) Run(ctx context.Context) error {
 	if err := n.peerGov.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("peer governor start failed: %w", err)
 	}
-	started = append(started, func() { n.peerGov.Stop() })
+	started = append(started, func() { _ = n.peerGov.Stop(context.Background()) })
 	// Start listeners
 	if err := n.connManager.Start(n.ctx); err != nil { //nolint:contextcheck
 		return err

--- a/node.go
+++ b/node.go
@@ -1466,7 +1466,23 @@ func (n *Node) Run(ctx context.Context) error {
 	if err := n.peerGov.Start(n.ctx); err != nil { //nolint:contextcheck
 		return fmt.Errorf("peer governor start failed: %w", err)
 	}
-	started = append(started, func() { _ = n.peerGov.Stop(context.Background()) })
+	// Bounded, not context.Background(): Stop waits for an in-flight
+	// GetPoolRelays call, so an unbounded wait here would let a later
+	// startup failure block Node.Run forever instead of returning its
+	// error.
+	started = append(started, func() {
+		stopCtx, cancel := context.WithTimeout(
+			context.Background(),
+			n.configuredShutdownTimeout(),
+		)
+		defer cancel()
+		if err := n.peerGov.Stop(stopCtx); err != nil {
+			n.config.logger.Warn(
+				"peer governor shutdown during startup rollback",
+				"error", err,
+			)
+		}
+	})
 	// Start listeners
 	if err := n.connManager.Start(n.ctx); err != nil { //nolint:contextcheck
 		return err

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -140,7 +140,9 @@ func (n *Node) quiesceForLiveLifecycleOp(ctx context.Context) error {
 		}
 	}
 	if n.peerGov != nil {
-		n.peerGov.Stop()
+		if stopErr := n.peerGov.Stop(ctx); stopErr != nil {
+			err = errors.Join(err, fmt.Errorf("peer governor shutdown: %w", stopErr))
+		}
 	}
 	// reinitializeNetworkingCore constructs a fresh PoolRelayProvider on
 	// every cycle (it has no long-lived identity of its own, unlike
@@ -1073,6 +1075,7 @@ func (n *Node) reinitializeNetworkingCore(ctx context.Context) error {
 		n.peerGov.LoadTopologyConfig(topologyConfig)
 		if usePeerSnapshot {
 			added := n.peerGov.LoadPeerSnapshot(
+				ctx,
 				n.config.topologyConfig.PeerSnapshot,
 			)
 			if added == 0 {

--- a/node_lifecycle_test.go
+++ b/node_lifecycle_test.go
@@ -233,7 +233,7 @@ func newLiveLifecycleTestNodeWithGenesis(
 			_ = n.connManager.Stop(context.Background())
 		}
 		if n.peerGov != nil {
-			n.peerGov.Stop()
+			_ = n.peerGov.Stop(context.Background())
 		}
 		if n.snapshotMgr != nil {
 			_ = n.snapshotMgr.Stop()

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -129,7 +129,9 @@ func (n *Node) shutdown() error {
 	}
 
 	if n.peerGov != nil {
-		n.peerGov.Stop()
+		if stopErr := n.peerGov.Stop(ctx); stopErr != nil {
+			err = errors.Join(err, fmt.Errorf("peer governor shutdown: %w", stopErr))
+		}
 	}
 
 	if n.snapshotMgr != nil {

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -566,7 +566,7 @@ func TestSpawnOutboundConnectionLockedReservesBeforeScheduling(t *testing.T) {
 //
 // This matters beyond a clean shutdown: the live database restore/truncate
 // quiesce path (node_lifecycle.go's quiesceForLiveLifecycleOp) calls
-// PeerGovernor.Stop() expecting every background goroutine -- including
+// PeerGovernor.Stop(context.Background()) expecting every background goroutine -- including
 // in-flight outbound dials -- to have exited before it tears down and
 // replaces the node's ConnectionManager. A dial goroutine not tracked by
 // p.wg could finish its handshake after Stop returns and attach to (or
@@ -636,7 +636,7 @@ func TestStop_WaitsForInFlightOutboundDial(t *testing.T) {
 
 	stopped := make(chan struct{})
 	go func() {
-		pg.Stop()
+		_ = pg.Stop(context.Background())
 		close(stopped)
 	}()
 

--- a/peergov/ledger_dial_security_test.go
+++ b/peergov/ledger_dial_security_test.go
@@ -197,7 +197,7 @@ func TestCreateOutboundConnection_LedgerPeerDialsLockedIPNotRebindTarget(
 	pg.ctx = t.Context()
 	pg.stopCh = make(chan struct{})
 	pg.mu.Unlock()
-	t.Cleanup(pg.Stop)
+	t.Cleanup(func() { _ = pg.Stop(context.Background()) })
 
 	target := &Peer{
 		Address:           "relay.example.com:1",
@@ -313,7 +313,7 @@ func TestCreateOutboundConnection_LedgerPeerFallbackDialsExactRoutabilityChecked
 	pg.ctx = ctx
 	pg.stopCh = make(chan struct{})
 	pg.mu.Unlock()
-	t.Cleanup(pg.Stop)
+	t.Cleanup(func() { _ = pg.Stop(context.Background()) })
 
 	target := &Peer{
 		Address:           "relay5.example.com:3001",
@@ -451,14 +451,14 @@ func TestResolveLedgerDialTarget_DoesNotStealNormalizedAddressFromExistingPeer(
 func TestAddLedgerPeerPrefersLocallySupportedFamily(t *testing.T) {
 	setLocalAddrFamilies(t, true, false) // v4-only host
 
-	oldLookupIP := lookupIP
-	lookupIP = func(string) ([]net.IP, error) {
+	oldLookupIPAddr := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
 		return []net.IP{
 			net.ParseIP("2001:db8::1"), // AAAA returned first
 			net.ParseIP("198.51.100.9"),
 		}, nil
 	}
-	t.Cleanup(func() { lookupIP = oldLookupIP })
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
 
 	pg := newDialSpreadGovernor()
 	require.True(t, pg.addLedgerPeer("relay.example.com:3001"))
@@ -473,4 +473,39 @@ func TestAddLedgerPeerPrefersLocallySupportedFamily(t *testing.T) {
 	got, err := pg.resolveLedgerDialTarget(t.Context(), pg.peers[0])
 	require.NoError(t, err)
 	assert.Equal(t, "198.51.100.9:3001", got)
+}
+
+func TestResolveLedgerDiscoveryAddressHonorsCancellation(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	started := make(chan struct{})
+	lookupIPAddr = func(ctx context.Context, _ string) ([]net.IP, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan string, 1)
+	go func() {
+		result <- pg.resolveLedgerDiscoveryAddress(ctx, "RELAY.EXAMPLE.COM:3001")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ledger DNS lookup did not start")
+	}
+	cancel()
+
+	select {
+	case got := <-result:
+		require.Equal(t, "relay.example.com:3001", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ledger DNS lookup did not honor cancellation")
+	}
 }

--- a/peergov/ledger_dial_security_test.go
+++ b/peergov/ledger_dial_security_test.go
@@ -475,6 +475,61 @@ func TestAddLedgerPeerPrefersLocallySupportedFamily(t *testing.T) {
 	assert.Equal(t, "198.51.100.9:3001", got)
 }
 
+// TestAddLedgerPeerContextRejectsCancellationDuringResolution covers the
+// window after resolution: a canceled DNS lookup falls back to the bare
+// hostname, which isRoutableAddr accepts, so checking ctx only before the
+// lookup let a peer be added -- and its reconnect path started -- by a
+// governor that was already shutting down.
+func TestAddLedgerPeerContextRejectsCancellationDuringResolution(t *testing.T) {
+	oldLookupIPAddr := lookupIPAddr
+	started := make(chan struct{})
+	lookupIPAddr = func(ctx context.Context, _ string) ([]net.IP, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() { lookupIPAddr = oldLookupIPAddr })
+
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		DisableOutbound: true,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	added := make(chan bool, 1)
+	go func() {
+		added <- pg.addLedgerPeerContext(ctx, "relay.example.com:3001")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ledger DNS lookup did not start")
+	}
+	cancel()
+
+	select {
+	case got := <-added:
+		require.False(
+			t,
+			got,
+			"a peer resolved after cancellation must not be added",
+		)
+	case <-time.After(5 * time.Second):
+		t.Fatal("addLedgerPeerContext did not return after cancellation")
+	}
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	require.Empty(t, pg.peers, "no peer may be recorded after cancellation")
+	require.Empty(
+		t,
+		pg.ledgerKnownAddrs,
+		"no ledger address may be recorded after cancellation",
+	)
+}
+
 func TestResolveLedgerDiscoveryAddressHonorsCancellation(t *testing.T) {
 	oldLookupIPAddr := lookupIPAddr
 	started := make(chan struct{})

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -15,6 +15,7 @@
 package peergov
 
 import (
+	"context"
 	"time"
 )
 
@@ -27,7 +28,13 @@ import (
 // unusable peers must not block fresh relay candidates while the node is short
 // of connected upstreams. Candidates are shuffled uniformly so no single pool
 // dominates across refreshes.
+//
+//nolint:unused // Kept as a context-free test helper for existing discovery tests.
 func (p *PeerGovernor) discoverLedgerPeers() {
+	p.discoverLedgerPeersContext(context.Background())
+}
+
+func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 	// Check if ledger peer provider is configured
 	if p.config.LedgerPeerProvider == nil {
 		p.config.Logger.Debug(
@@ -95,6 +102,9 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 	}
 
 	// Get pool relays from ledger
+	if err := ctx.Err(); err != nil {
+		return
+	}
 	relays, err := p.config.LedgerPeerProvider.GetPoolRelays()
 	if err != nil {
 		p.config.Logger.Error(
@@ -113,7 +123,7 @@ func (p *PeerGovernor) discoverLedgerPeers() {
 	if urgent && needed <= 0 {
 		extraAdds = p.config.LedgerPeerTarget
 	}
-	addedCount := p.addLedgerRelays(relays, extraAdds)
+	addedCount := p.addLedgerRelaysContext(ctx, relays, extraAdds)
 
 	if addedCount > 0 {
 		p.config.Logger.Info(
@@ -219,13 +229,25 @@ func dedupeRelayCandidates(candidates []string) []string {
 
 // addLedgerPeer adds a peer from ledger discovery with deduplication.
 // Returns true if the peer was added, false if it already exists or is denied.
+//
+//nolint:unused // Kept as a context-free test helper for existing peer tests.
 func (p *PeerGovernor) addLedgerPeer(address string) bool {
+	return p.addLedgerPeerContext(context.Background(), address)
+}
+
+func (p *PeerGovernor) addLedgerPeerContext(
+	ctx context.Context,
+	address string,
+) bool {
+	if err := ctx.Err(); err != nil {
+		return false
+	}
 	// Resolve address (with DNS lookup) before acquiring lock to avoid
 	// blocking while holding the mutex. Ledger relay hostnames are
 	// attacker-supplied, and resolveLedgerDialTarget's fast path dials
 	// whatever ends up here unchanged for the peer's whole lifetime, so this
 	// (unlike resolveAddress) filters to a locally-dialable address family.
-	normalized := p.resolveLedgerDiscoveryAddress(address)
+	normalized := p.resolveLedgerDiscoveryAddress(ctx, address)
 
 	// Reject non-routable IPs (private, loopback, link-local, etc.)
 	if !isRoutableAddr(normalized) {

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -248,6 +248,13 @@ func (p *PeerGovernor) addLedgerPeerContext(
 	// whatever ends up here unchanged for the peer's whole lifetime, so this
 	// (unlike resolveAddress) filters to a locally-dialable address family.
 	normalized := p.resolveLedgerDiscoveryAddress(ctx, address)
+	// Rechecked after resolution, not just before it: a canceled DNS lookup
+	// falls back to the bare hostname, which isRoutableAddr accepts, so
+	// without this a shutdown that lands during resolution would still add
+	// the peer and let the reconnect path start dialing it.
+	if err := ctx.Err(); err != nil {
+		return false
+	}
 
 	// Reject non-routable IPs (private, loopback, link-local, etc.)
 	if !isRoutableAddr(normalized) {

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -265,6 +265,16 @@ func (p *PeerGovernor) addLedgerPeerContext(
 
 	p.mu.Lock()
 
+	// Rechecked under the lock, which is what actually closes the window:
+	// the pre-resolution and post-resolution checks above both run lock-free,
+	// so a cancellation landing between them and here would otherwise still
+	// mutate peer state and spawn a reconnect. Every mutation below happens
+	// under this same acquisition, so nothing can slip past this point.
+	if err := ctx.Err(); err != nil {
+		p.mu.Unlock()
+		return false
+	}
+
 	// Check deny list
 	if p.isDeniedLocked(normalized) ||
 		p.isDeniedLocked(p.normalizeAddress(address)) {

--- a/peergov/ledger_discovery_test.go
+++ b/peergov/ledger_discovery_test.go
@@ -15,6 +15,7 @@
 package peergov
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net"
@@ -46,7 +47,7 @@ func TestLoadPeerSnapshotSeedsLedgerPeers(t *testing.T) {
 		LedgerPeerTarget: 2,
 	})
 
-	added := pg.LoadPeerSnapshot(snapshot)
+	added := pg.LoadPeerSnapshot(context.Background(), snapshot)
 
 	require.Equal(t, 2, added)
 	require.Len(t, pg.peers, 2)

--- a/peergov/peer_snapshot.go
+++ b/peergov/peer_snapshot.go
@@ -15,6 +15,7 @@
 package peergov
 
 import (
+	"context"
 	"math/rand/v2"
 	"net"
 
@@ -25,6 +26,7 @@ import (
 // It is intended for Ouroboros Genesis startup, where the snapshot provides
 // historical ledger peers before the local ledger can answer relay queries.
 func (p *PeerGovernor) LoadPeerSnapshot(
+	ctx context.Context,
 	snapshot *topology.PeerSnapshotConfig,
 ) int {
 	if p == nil || snapshot == nil || !snapshot.HasRelays() ||
@@ -32,7 +34,7 @@ func (p *PeerGovernor) LoadPeerSnapshot(
 		return 0
 	}
 	relays := PoolRelaysFromPeerSnapshot(snapshot)
-	added := p.addLedgerRelays(relays, 0)
+	added := p.addLedgerRelaysContext(ctx, relays, 0)
 	p.config.Logger.Info(
 		"loaded peer snapshot",
 		"snapshot_slot", snapshot.Point.BlockPointSlot,
@@ -87,7 +89,17 @@ func poolRelayFromSnapshotAccessPoint(
 
 // addLedgerRelays fills the configured ledger-peer target. extraAdds permits a
 // bounded emergency overfill after the target is already satisfied.
+//
+//nolint:unused // Kept as a context-free test helper for existing snapshot tests.
 func (p *PeerGovernor) addLedgerRelays(relays []PoolRelay, extraAdds int) int {
+	return p.addLedgerRelaysContext(context.Background(), relays, extraAdds)
+}
+
+func (p *PeerGovernor) addLedgerRelaysContext(
+	ctx context.Context,
+	relays []PoolRelay,
+	extraAdds int,
+) int {
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
 	rand.Shuffle(len(candidates), func(i, j int) {
 		candidates[i], candidates[j] = candidates[j], candidates[i]
@@ -95,10 +107,13 @@ func (p *PeerGovernor) addLedgerRelays(relays []PoolRelay, extraAdds int) int {
 
 	added := 0
 	for _, addr := range candidates {
+		if err := ctx.Err(); err != nil {
+			break
+		}
 		if p.ledgerPeerDeficit() <= 0 && added >= extraAdds {
 			break
 		}
-		if p.addLedgerPeer(addr) {
+		if p.addLedgerPeerContext(ctx, addr) {
 			added++
 		}
 	}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -16,6 +16,7 @@ package peergov
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -141,6 +142,7 @@ type PeerGovernor struct {
 	publicRootChurnTicker *time.Ticker
 	stopCh                chan struct{}
 	ctx                   context.Context      // Context for cancellation
+	cancel                context.CancelFunc   // Cancels the context owned by Start
 	denyList              map[string]time.Time // address -> expiry time
 	peers                 []*Peer
 	config                PeerGovernorConfig
@@ -424,6 +426,8 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 }
 
 func (p *PeerGovernor) Start(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
+
 	// Setup connmanager event listeners
 	if p.config.EventBus != nil {
 		inboundConnSubId := p.config.EventBus.SubscribeFunc(
@@ -448,7 +452,8 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 	publicRootChurnTicker := time.NewTicker(p.config.PublicRootChurnInterval)
 
 	p.mu.Lock()
-	p.ctx = ctx
+	p.ctx = runCtx
+	p.cancel = cancel
 	p.reconcileTicker = ticker
 	p.gossipChurnTicker = gossipChurnTicker
 	p.publicRootChurnTicker = publicRootChurnTicker
@@ -463,10 +468,10 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 		for {
 			select {
 			case <-t.C:
-				p.reconcile(ctx)
+				p.reconcile(runCtx)
 			case <-stop:
 				return
-			case <-ctx.Done():
+			case <-runCtx.Done():
 				return
 			}
 		}
@@ -483,7 +488,7 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 				p.gossipChurn()
 			case <-stop:
 				return
-			case <-ctx.Done():
+			case <-runCtx.Done():
 				return
 			}
 		}
@@ -500,7 +505,7 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 				p.publicRootChurn()
 			case <-stop:
 				return
-			case <-ctx.Done():
+			case <-runCtx.Done():
 				return
 			}
 		}
@@ -522,11 +527,11 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 			select {
 			case <-t.C:
 				if p.ledgerPeersUrgent() {
-					p.discoverLedgerPeers()
+					p.discoverLedgerPeersContext(runCtx)
 				}
 			case <-stop:
 				return
-			case <-ctx.Done():
+			case <-runCtx.Done():
 				return
 			}
 		}
@@ -543,10 +548,10 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 		defer p.wg.Done()
 		select {
 		case <-time.After(initialReconnectDelay):
-			p.reconcile(ctx)
+			p.reconcile(runCtx)
 		case <-stop:
 			return
-		case <-ctx.Done():
+		case <-runCtx.Done():
 			return
 		}
 	}(stopCh)
@@ -554,8 +559,9 @@ func (p *PeerGovernor) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts down the peer governor
-func (p *PeerGovernor) Stop() {
+// Stop gracefully shuts down the peer governor, waiting for its background
+// workers until ctx is canceled or reaches its deadline.
+func (p *PeerGovernor) Stop(ctx context.Context) error {
 	p.mu.Lock()
 
 	// Stop all tickers
@@ -578,9 +584,14 @@ func (p *PeerGovernor) Stop() {
 	}
 	inboundConnSubId := p.inboundConnSubId
 	connClosedSubId := p.connClosedSubId
+	cancel := p.cancel
+	p.cancel = nil
 	p.inboundConnSubId = 0
 	p.connClosedSubId = 0
 	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 
 	// PeerGovernor instances are replaced during a live database
 	// restore/truncate while the EventBus remains running. Remove the
@@ -606,5 +617,15 @@ func (p *PeerGovernor) Stop() {
 	// take p.mu themselves, so waiting while still holding it would
 	// deadlock. See the wg field's doc comment for why this wait matters
 	// beyond a clean process shutdown.
-	p.wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("peer governor shutdown: %w", ctx.Err())
+	}
 }

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -16,6 +16,7 @@ package peergov
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -598,17 +599,31 @@ func (p *PeerGovernor) Stop(ctx context.Context) error {
 	// old instance's handlers before its replacement starts so a delayed
 	// connection event cannot mutate stale peer state and publish a
 	// conflicting chain-selection update after reconnection.
+	//
+	// Bounded by ctx: the unsubscribe itself always happens, but a handler
+	// already in flight is waited for only until ctx is done, so one stuck
+	// connection-event handler cannot overrun the shutdown deadline here
+	// before the worker wait below even starts.
+	var unsubErr error
 	if p.config.EventBus != nil {
 		if inboundConnSubId != 0 {
-			p.config.EventBus.UnsubscribeAndWait(
-				connmanager.InboundConnectionEventType,
-				inboundConnSubId,
+			unsubErr = errors.Join(
+				unsubErr,
+				p.config.EventBus.UnsubscribeAndWaitContext(
+					ctx,
+					connmanager.InboundConnectionEventType,
+					inboundConnSubId,
+				),
 			)
 		}
 		if connClosedSubId != 0 {
-			p.config.EventBus.UnsubscribeAndWait(
-				connmanager.ConnectionClosedEventType,
-				connClosedSubId,
+			unsubErr = errors.Join(
+				unsubErr,
+				p.config.EventBus.UnsubscribeAndWaitContext(
+					ctx,
+					connmanager.ConnectionClosedEventType,
+					connClosedSubId,
+				),
 			)
 		}
 	}
@@ -624,8 +639,14 @@ func (p *PeerGovernor) Stop(ctx context.Context) error {
 	}()
 	select {
 	case <-done:
-		return nil
+		return unsubErr
 	case <-ctx.Done():
-		return fmt.Errorf("peer governor shutdown: %w", ctx.Err())
+		// Unprefixed: every caller already wraps this with its own
+		// "peer governor shutdown: %w", matching how the other
+		// components' Stop errors are reported.
+		return errors.Join(
+			unsubErr,
+			fmt.Errorf("waiting for background workers: %w", ctx.Err()),
+		)
 	}
 }

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -247,7 +247,7 @@ func TestPeerGovernorStopWaitsForInFlightGoroutines(t *testing.T) {
 
 	stopDone := make(chan struct{})
 	go func() {
-		pg.Stop()
+		_ = pg.Stop(context.Background())
 		close(stopDone)
 	}()
 
@@ -264,6 +264,37 @@ func TestPeerGovernorStopWaitsForInFlightGoroutines(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Stop did not return after the in-flight goroutine finished")
 	}
+}
+
+func TestPeerGovernorStopHonorsContextDeadline(t *testing.T) {
+	eventBus := newMockEventBus()
+	t.Cleanup(eventBus.Stop)
+
+	blocking := &blockingLedgerPeerProvider{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           eventBus,
+		DisableOutbound:    true,
+		LedgerPeerProvider: blocking,
+	})
+	require.NoError(t, pg.Start(context.Background()))
+
+	select {
+	case <-blocking.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("discoverLedgerPeers never reached GetPoolRelays")
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := pg.Stop(stopCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	close(blocking.release)
+	require.NoError(t, pg.Stop(context.Background()))
 }
 
 func TestPeerGovernorStopUnsubscribesConnectionHandlers(t *testing.T) {
@@ -286,7 +317,7 @@ func TestPeerGovernorStopUnsubscribesConnectionHandlers(t *testing.T) {
 		eventBus.HasSubscribers(connmanager.ConnectionClosedEventType),
 	)
 
-	pg.Stop()
+	_ = pg.Stop(context.Background())
 
 	require.False(
 		t,

--- a/peergov/peergov_test.go
+++ b/peergov/peergov_test.go
@@ -288,10 +288,22 @@ func TestPeerGovernorStopHonorsContextDeadline(t *testing.T) {
 		t.Fatal("discoverLedgerPeers never reached GetPoolRelays")
 	}
 
-	stopCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	stopCtx, cancel := context.WithTimeout(
+		context.Background(),
+		50*time.Millisecond,
+	)
 	defer cancel()
 	err := pg.Stop(stopCtx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+	// Every caller wraps this with its own "peer governor shutdown: %w",
+	// matching how the other components' Stop errors are reported, so
+	// self-prefixing here doubles the prefix in the joined shutdown error.
+	require.NotContains(
+		t,
+		err.Error(),
+		"peer governor shutdown",
+		"Stop must not repeat the prefix its callers add",
+	)
 
 	close(blocking.release)
 	require.NoError(t, pg.Stop(context.Background()))

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -287,8 +287,8 @@ func (p *PeerGovernor) resolveAddress(address string) string {
 
 // resolveLedgerDiscoveryAddress resolves a ledger relay hostname at initial
 // discovery time, filtering the resolved records to the locally-supported
-// address families before picking one. This function performs blocking DNS
-// lookups and must NOT be called while holding locks.
+// address families before picking one. The lookup is bounded and honors ctx;
+// this function must NOT be called while holding locks.
 //
 // It is ledger-specific rather than a change to resolveAddress (shared by
 // every peer source — topology, gossip, inbound, TestPeer/DenyPeer lookups)
@@ -304,7 +304,10 @@ func (p *PeerGovernor) resolveAddress(address string) string {
 // unchanged, and a resolution failure or empty result falls back to the
 // lowercased hostname so the peer is still added (with routability decided
 // downstream) rather than dropped.
-func (p *PeerGovernor) resolveLedgerDiscoveryAddress(address string) string {
+func (p *PeerGovernor) resolveLedgerDiscoveryAddress(
+	ctx context.Context,
+	address string,
+) string {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return strings.ToLower(address)
@@ -315,7 +318,9 @@ func (p *PeerGovernor) resolveLedgerDiscoveryAddress(address string) string {
 		return net.JoinHostPort(ip.String(), port)
 	}
 
-	ips, err := lookupIP(host)
+	lookupCtx, cancel := context.WithTimeout(ctx, dialDNSResolveTimeout)
+	defer cancel()
+	ips, err := lookupIPAddr(lookupCtx, host)
 	if err != nil || len(ips) == 0 {
 		p.config.Logger.Warn(
 			"failed to resolve ledger relay hostname",

--- a/peergov/reconcile.go
+++ b/peergov/reconcile.go
@@ -499,7 +499,7 @@ func (p *PeerGovernor) reconcile(ctx context.Context) {
 
 	// Discover peers from ledger (stake pool relays) before peer sharing,
 	// which can block on unresponsive peers.
-	p.discoverLedgerPeers()
+	p.discoverLedgerPeersContext(ctx)
 
 	for i := range eligiblePeersCopy {
 		addrs := p.config.PeerRequestFunc(&eligiblePeersCopy[i])

--- a/peergov/reconnect_gate_test.go
+++ b/peergov/reconnect_gate_test.go
@@ -15,6 +15,7 @@
 package peergov
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
@@ -48,7 +49,7 @@ func newReconnectGateTestGovernor(t *testing.T, threshold int) *PeerGovernor {
 	pg.ctx = t.Context()
 	pg.stopCh = make(chan struct{})
 	pg.mu.Unlock()
-	t.Cleanup(pg.Stop)
+	t.Cleanup(func() { _ = pg.Stop(context.Background()) })
 	return pg
 }
 

--- a/peergov/recovery_test.go
+++ b/peergov/recovery_test.go
@@ -16,6 +16,7 @@ package peergov
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"strings"
@@ -453,7 +454,7 @@ func TestPeerGovernor_Reconcile_RedialsDisconnectedTopologyPeer(t *testing.T) {
 		},
 	}
 	pg.mu.Unlock()
-	t.Cleanup(pg.Stop)
+	t.Cleanup(func() { _ = pg.Stop(context.Background()) })
 
 	pg.reconcile(t.Context())
 
@@ -492,7 +493,7 @@ func TestPeerGovernor_Reconcile_RedialsGossipPeerWhenNoUpstream(t *testing.T) {
 		},
 	}
 	pg.mu.Unlock()
-	t.Cleanup(pg.Stop)
+	t.Cleanup(func() { _ = pg.Stop(context.Background()) })
 
 	pg.reconcile(t.Context())
 


### PR DESCRIPTION
## Summary

- Make PeerGovernor shutdown context- and deadline-aware.
- Propagate shutdown context through ledger-peer discovery, DNS resolution, and peer snapshot loading.
- Continue remaining teardown when the peer governor reaches the shutdown deadline.
- Add regression coverage for DNS cancellation and bounded shutdown.

Closes #3157.

## Validation

- `go test -race ./peergov`
- `go test -race -run 'Test(Node|.*Shutdown|.*Lifecycle|.*LiveLifecycle|.*Quiesce)' .`
- `go vet ./peergov .`
- `golangci-lint run ./peergov ./...`
- `make docs-parity`
- `make import-boundaries`
- `make gorm-check`

The full `make test` suite was not rerun in the clean worktree; an earlier dirty-checkout run was blocked by unrelated nested-worktree docs-parity files and the ledger package reaching Go’s default 10-minute test timeout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds PeerGovernor shutdown and ledger DNS discovery to the caller’s context to prevent hangs. Previously Stop() could block indefinitely and discovery ignored cancellation; now Stop(ctx) cancels internal work, bounds event-handler teardown and worker waits to ctx, and returns a deadline error while Node continues shutdown and startup rollback using the configured timeout.

- Adds EventBus.UnsubscribeAndWaitContext(ctx): always unsubscribes; bounds the wait and avoids reporting ctx.Err() once a handler has finished.
- Makes ledger discovery context-aware with per-lookup DNS timeouts: resolveLedgerDiscoveryAddress(ctx,…), discoverLedgerPeersContext, addLedgerRelaysContext, and addLedgerPeerContext. Rechecks ctx after DNS and again under the mutex to prevent adding peers or spawning reconnects during shutdown.
- Propagates context through snapshot seeding and reconciliation (LoadPeerSnapshot(ctx,…)); Node passes contexts and bounds PeerGovernor shutdown during startup rollback, logging a timeout instead of blocking Run.
- Replaces PeerGovernor.Stop() with Stop(ctx); cancels the run context, unsubscribes with UnsubscribeAndWaitContext, waits for workers only until ctx, and leaves errors unprefixed so callers can add their own “peer governor shutdown” prefix.

**Migration**
- Update calls to PeerGovernor.Stop() to PeerGovernor.Stop(ctx) and handle the returned error.
- Update calls to LoadPeerSnapshot(snapshot) to LoadPeerSnapshot(ctx, snapshot).

<sup>Written for commit 16c2e559c93e3eab6d02eaf1f9b56d8b4a37438a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Shutdown now uses a shared deadline across peer cleanup, event handlers, and background workers.
  * Teardown continues after a deadline expires while reporting shutdown errors.
  * In-flight handlers and workers are given bounded time to finish.

* **Bug Fixes**
  * Canceled peer discovery and DNS lookups no longer add peers or start connections.
  * Ledger discovery now consistently honors cancellation and timeout limits.

* **API Changes**
  * Added context-aware event unsubscription and peer governor shutdown methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->