### PR TITLE
fix(forging): admit local blocks synchronously

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -521,6 +521,7 @@ sequenceDiagram
     participant MP as Mempool
     participant LS as LedgerState
     participant ChM as ChainManager
+    participant PC as Chain (primary)
     participant EB as EventBus
 
     Note over SC,EB: Epoch Preparation
@@ -544,10 +545,10 @@ sequenceDiagram
         BB->>BB: assemble block body + header
         BB->>BB: sign with KES key, attach VRF proof
         BB-->>BF: block + CBOR
-        BF->>ChM: AddLocalBlock(forgedBlock)
-        BF->>MP: remove confirmed transactions
-        ChM->>EB: publish ChainUpdateEvent
+        BF->>PC: AddLocalBlock(forgedBlock) via BlockBroadcaster
+        PC->>EB: publish ChainUpdateEvent (before AddLocalBlock returns)
         BF->>EB: publish BlockForgedEvent
+        BF->>MP: remove confirmed transactions (RemoveTxsByHash)
     end
 
     Note over SC,EB: Slot Battle Detection
@@ -2969,9 +2970,13 @@ script validation and large forging snapshots. Add/remove events remain
 published outside all locks, and candidate rejection emits only the same
 removal event and gauge changes as the former in-place rebuild.
 
-After a locally forged block is accepted by the chain manager through
-`Chain.AddLocalBlock`, the production forger synchronously removes that block's
-transaction hashes through the backend-neutral `RemoveTxsByHash` adapter. The chain-update rebuild remains
+A locally forged block is admitted by `Chain.AddLocalBlock` on the primary
+chain, which the `BlockBroadcaster` the forger holds calls
+(`chainManager.PrimaryChain()`), not by `ChainManager` itself; the
+`ChainUpdateEvent` is published inside that call, before it returns. The forger
+then runs its `blockForged` observer, and only after that — and only if
+admission succeeded — synchronously removes the block's transaction hashes
+through the backend-neutral `RemoveTxsByHash` adapter. The chain-update rebuild remains
 responsible for transactions confirmed by peer blocks. This local fast path
 prevents confirmed transactions from accumulating when sustained admissions
 make a long rebuild repeatedly lose its pinned ledger generation.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2985,7 +2985,12 @@ Both halves of sigma come from the same Mark row set for the same snapshot epoch
 3. Reads the parent ranking block's `LeiosAnnouncement`, selects only the matching eligible Leios endorser-block certificate, and independently produces and broadcasts a new endorser block for the current slot when eligible
 4. Assembles a block from a neutral pending-transaction provider using `DefaultBlockBuilder`
 5. Optionally self-validates the forged block before adoption (see below)
-6. Broadcasts the forged block through the chain manager
+6. Submits the forged block directly to the primary chain for synchronous local
+   admission, before running observability callbacks. Local admission validates
+   the actual chain tip and contiguous block number, but does not compare the
+   block with peer-delivered pending headers. Successful adoption clears those
+   now-conflicting headers; a genuinely stale parent is still rejected without
+   changing the queued headers.
 7. After successful local adoption, synchronously removes the block's confirmed transactions from the mempool
 
 The forger tracks slot battles (competing blocks at the same slot) and skips forging when the node is not sufficiently synced, controlled by `forgeSyncToleranceSlots` and `forgeStaleGapThresholdSlots`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -520,8 +520,7 @@ sequenceDiagram
     participant BB as BlockBuilder
     participant MP as Mempool
     participant LS as LedgerState
-    participant ChM as ChainManager
-    participant PC as Chain (primary)
+    participant PC as PrimaryChain
     participant EB as EventBus
 
     Note over SC,EB: Epoch Preparation
@@ -546,7 +545,7 @@ sequenceDiagram
         BB->>BB: sign with KES key, attach VRF proof
         BB-->>BF: block + CBOR
         BF->>PC: AddLocalBlock(forgedBlock) via BlockBroadcaster
-        PC->>EB: publish ChainUpdateEvent (before AddLocalBlock returns)
+        PC->>EB: publish ChainUpdateEvent, before AddLocalBlock returns
         BF->>EB: publish BlockForgedEvent
         BF->>MP: remove confirmed transactions (RemoveTxsByHash)
     end

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -544,7 +544,7 @@ sequenceDiagram
         BB->>BB: assemble block body + header
         BB->>BB: sign with KES key, attach VRF proof
         BB-->>BF: block + CBOR
-        BF->>ChM: AddBlock(forgedBlock)
+        BF->>ChM: AddLocalBlock(forgedBlock)
         BF->>MP: remove confirmed transactions
         ChM->>EB: publish ChainUpdateEvent
         BF->>EB: publish BlockForgedEvent
@@ -2173,11 +2173,20 @@ shadow-blockfetch dispatch calls `BlockfetchRequestRangeFunc` directly and is
 intentionally excluded: it is a duplicate request whose failure says nothing
 about the primary still in flight. On reaching the bound the ledger drops the queued headers, clears the
 active blockfetch connection, and emits `chainsync.resync` with reason
-`blockfetch could not obtain the queued header range`. Dropping the headers is
-the purpose rather than a side effect: while a header sits at the head of the
-queue, `Chain.AddBlock` rejects every locally forged block with
-`BlockNotMatchHeaderError`, so a header whose body no peer can serve halts
-block production for as long as it stays queued. The earlier far-behind
+`blockfetch could not obtain the queued header range`. Dropping the headers keeps the
+pipeline moving rather than being a side effect: a header whose body no peer can
+serve otherwise sits at the head of the queue indefinitely, and the ledger
+cannot advance past it.
+
+Block production is no longer among the things it holds up. Peer and local
+admission take different paths into the chain: `Chain.AddBlock` compares the
+block against the queued peer headers and rejects a mismatch with
+`BlockNotMatchHeaderError`, while `Chain.AddLocalBlock` — what
+`node_forging.go` calls for a block this node forged — skips that comparison
+entirely, since a locally forged block invalidates those pending headers rather
+than contradicting them. The chain-tip and block-number checks stay mandatory
+on both paths. Before that split, a single unservable queued header halted
+forging for as long as it stayed queued. The earlier far-behind
 variant of this recovery (gated on a `blockfetchMinBatchGapSlots` tip gap,
 which never applied at tip) still runs for its own case before the bound is
 reached.
@@ -2960,9 +2969,9 @@ script validation and large forging snapshots. Add/remove events remain
 published outside all locks, and candidate rejection emits only the same
 removal event and gauge changes as the former in-place rebuild.
 
-After a locally forged block is accepted by the chain manager, the production
-forger synchronously removes that block's transaction hashes through the
-backend-neutral `RemoveTxsByHash` adapter. The chain-update rebuild remains
+After a locally forged block is accepted by the chain manager through
+`Chain.AddLocalBlock`, the production forger synchronously removes that block's
+transaction hashes through the backend-neutral `RemoveTxsByHash` adapter. The chain-update rebuild remains
 responsible for transactions confirmed by peer blocks. This local fast path
 prevents confirmed transactions from accumulating when sustained admissions
 make a long rebuild repeatedly lose its pinned ledger generation.

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -205,7 +205,7 @@ func (c *Chain) AddBlock(
 	block ledger.Block,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true)
+	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true, true)
 	if err != nil {
 		return err
 	}
@@ -216,18 +216,24 @@ func (c *Chain) AddBlock(
 	return nil
 }
 
-// HandleBlockProposedEvent applies locally forged block proposals published on
-// the EventBus and acknowledges the result to the proposer when requested.
-func (c *Chain) HandleBlockProposedEvent(evt event.Event) {
-	proposal, ok := evt.Data.(BlockProposedEvent)
-	if !ok {
-		return
+// AddLocalBlock adds a locally forged block without comparing it to queued
+// peer headers. A successful local block invalidates those pending headers;
+// the actual chain-tip and block-number checks remain mandatory.
+func (c *Chain) AddLocalBlock(block ledger.Block) error {
+	evt, err := c.addBlockInternal(
+		block,
+		ocommon.Point{},
+		nil,
+		true,
+		false,
+	)
+	if err != nil {
+		return err
 	}
-	if proposal.Block == nil {
-		proposal.Respond(errors.New("proposed block is nil"))
-		return
+	if c.eventBus != nil && evt.Type != "" {
+		c.eventBus.Publish(ChainUpdateEventType, evt)
 	}
-	proposal.Respond(c.AddBlock(proposal.Block, nil))
+	return nil
 }
 
 // AddBlockWithPoint adds a block using a caller-supplied point. This avoids
@@ -238,7 +244,7 @@ func (c *Chain) AddBlockWithPoint(
 	point ocommon.Point,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, point, txn, true)
+	evt, err := c.addBlockInternal(block, point, txn, true, true)
 	if err != nil {
 		return err
 	}
@@ -257,6 +263,7 @@ func (c *Chain) addBlockInternal(
 	point ocommon.Point,
 	txn *database.Txn,
 	notifyWaiters bool,
+	matchPendingHeader bool,
 ) (event.Event, error) {
 	if c == nil {
 		return event.Event{}, errors.New("chain is nil")
@@ -270,7 +277,13 @@ func (c *Chain) addBlockInternal(
 	if err := c.reconcile(); err != nil {
 		return event.Event{}, fmt.Errorf("reconcile chain: %w", err)
 	}
-	return c.addBlockLocked(block, point, txn, notifyWaiters)
+	return c.addBlockLocked(
+		block,
+		point,
+		txn,
+		notifyWaiters,
+		matchPendingHeader,
+	)
 }
 
 func (c *Chain) addBlockLocked(
@@ -278,6 +291,7 @@ func (c *Chain) addBlockLocked(
 	point ocommon.Point,
 	txn *database.Txn,
 	notifyWaiters bool,
+	matchPendingHeader bool,
 ) (event.Event, error) {
 	blockHashBytes := point.Hash
 	if len(blockHashBytes) == 0 {
@@ -287,7 +301,7 @@ func (c *Chain) addBlockLocked(
 	blockPrevHashBytes := []byte(nil)
 	blockNumber := block.BlockNumber()
 	// Check that the new block matches our first header, if any
-	if len(c.headers) > 0 {
+	if matchPendingHeader && len(c.headers) > 0 {
 		firstHeader := c.headers[0]
 		if !bytes.Equal(blockHashBytes, firstHeader.point.Hash) {
 			return event.Event{}, NewBlockNotMatchHeaderError(
@@ -344,8 +358,10 @@ func (c *Chain) addBlockLocked(
 		c.blocks = append(c.blocks, tmpPoint)
 	}
 	// Remove matching header entry, if any
-	if len(c.headers) > 0 {
+	if matchPendingHeader && len(c.headers) > 0 {
 		c.headers = slices.Delete(c.headers, 0, 1)
+	} else if !matchPendingHeader {
+		c.headers = c.headers[:0]
 	}
 	// Update tip
 	c.currentTip = ochainsync.Tip{
@@ -404,6 +420,7 @@ func (c *Chain) AddBlocks(blocks []ledger.Block) error {
 					ocommon.Point{},
 					txn,
 					false,
+					true,
 				)
 				if err != nil {
 					return err

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -757,40 +757,78 @@ func TestChainIteratorReverseRollbackToOriginClamps(t *testing.T) {
 	}
 }
 
-func TestHandleBlockProposedEventAddsBlockAndAcks(t *testing.T) {
+func TestAddLocalBlockIgnoresAndClearsPendingPeerHeaders(t *testing.T) {
 	cm, err := chain.NewManager(nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error creating chain manager: %s", err)
 	}
 	c := cm.PrimaryChain()
-	ack := make(chan error, 1)
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	if err := c.AddBlockHeader(testBlocks[3]); err != nil {
+		t.Fatalf("unexpected error adding peer header: %s", err)
+	}
+	localBlock := &MockBlock{
+		MockBlockNumber: testBlocks[3].MockBlockNumber,
+		MockSlot:        testBlocks[3].MockSlot + 1,
+		MockHash:        testHashPrefix + "00ff",
+		MockPrevHash:    testBlocks[2].MockHash,
+	}
 
-	c.HandleBlockProposedEvent(
-		event.NewEvent(
-			chain.BlockProposedEventType,
-			chain.BlockProposedEvent{
-				Block: testBlocks[0],
-				Ack:   ack,
-			},
-		),
-	)
-
-	if err := testutil.RequireReceive(
-		t,
-		ack,
-		time.Second,
-		"block proposal ack",
-	); err != nil {
-		t.Fatalf("unexpected block proposal error: %s", err)
+	if err := c.AddLocalBlock(localBlock); err != nil {
+		t.Fatalf("unexpected error adding local block: %s", err)
 	}
 	tip := c.Tip()
-	if tip.Point.Slot != testBlocks[0].MockSlot ||
-		!bytes.Equal(tip.Point.Hash, testBlocks[0].Hash().Bytes()) {
+	if tip.Point.Slot != localBlock.MockSlot ||
+		!bytes.Equal(tip.Point.Hash, localBlock.Hash().Bytes()) {
 		t.Fatalf(
-			"unexpected tip after block proposal: %d.%x",
+			"unexpected tip after local block: %d.%x",
 			tip.Point.Slot,
 			tip.Point.Hash,
 		)
+	}
+	if got := c.HeaderCount(); got != 0 {
+		t.Fatalf("expected local block to clear pending headers, got %d", got)
+	}
+}
+
+func TestAddLocalBlockRejectsStaleParentAndPreservesPendingHeaders(
+	t *testing.T,
+) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	if err := c.AddBlockHeader(testBlocks[3]); err != nil {
+		t.Fatalf("unexpected error adding peer header: %s", err)
+	}
+	staleBlock := &MockBlock{
+		MockBlockNumber: testBlocks[3].MockBlockNumber,
+		MockSlot:        testBlocks[3].MockSlot + 1,
+		MockHash:        testHashPrefix + "00fe",
+		MockPrevHash:    testBlocks[1].MockHash,
+	}
+
+	err = c.AddLocalBlock(staleBlock)
+	var staleErr chain.BlockNotFitChainTipError
+	if !errors.As(err, &staleErr) {
+		t.Fatalf("expected stale parent error, got %v", err)
+	}
+	if got := c.HeaderCount(); got != 1 {
+		t.Fatalf("expected rejected block to preserve pending header, got %d", got)
+	}
+	tip := c.Tip()
+	if !bytes.Equal(tip.Point.Hash, testBlocks[2].Hash().Bytes()) {
+		t.Fatalf("rejected local block changed tip to %x", tip.Point.Hash)
 	}
 }
 

--- a/chain/event.go
+++ b/chain/event.go
@@ -16,37 +16,17 @@ package chain
 
 import (
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 const (
-	ChainUpdateEventType   = "chain.update"
-	ChainForkEventType     = "chain.fork_detected"
-	BlockProposedEventType = "chain.block_proposed"
+	ChainUpdateEventType = "chain.update"
+	ChainForkEventType   = "chain.fork_detected"
 )
 
 type ChainBlockEvent struct {
 	Point ocommon.Point
 	Block models.Block
-}
-
-// BlockProposedEvent carries a locally forged block to the chain component for
-// adoption. Ack is optional; when set, the chain handler reports the AddBlock
-// result without blocking if the sender has already moved on.
-type BlockProposedEvent struct {
-	Block ledger.Block
-	Ack   chan<- error
-}
-
-func (e BlockProposedEvent) Respond(err error) {
-	if e.Ack == nil {
-		return
-	}
-	select {
-	case e.Ack <- err:
-	default:
-	}
 }
 
 type ChainRollbackEvent struct {

--- a/ledger/forging/events.go
+++ b/ledger/forging/events.go
@@ -17,7 +17,7 @@
 // # Block Propagation
 //
 // Block propagation to peers is handled automatically by the chain package.
-// When a forged block is added via chain.AddBlock(), the method closes
+// When a forged block is added via chain.AddLocalBlock(), the method closes
 // the chain's waitingChan (see chain/chain.go lines 174-180), which signals
 // any blocking ChainIterators. The ouroboros chainsync server (see
 // ouroboros/chainsync.go chainsyncServerRequestNext) waits on these iterators

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -143,8 +143,8 @@ type ConfirmedTxRemover interface {
 	RemoveTxsByHash(hashes []string)
 }
 
-// BlockForgedObserver observes blocks after they are successfully built,
-// before chain adoption is attempted.
+// BlockForgedObserver observes blocks after they are successfully built and
+// chain adoption has been attempted.
 type BlockForgedObserver func(
 	block ledger.Block,
 	cbor []byte,
@@ -771,6 +771,11 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			float64(len(block.Transactions())),
 		)
 	}
+
+	// Attempt local adoption immediately after building and validation. Keep
+	// observability callbacks out of this critical path: subscribers may be
+	// slow, while the block's parent must still be the active chain tip.
+	addErr := f.blockBroadcaster.AddBlock(block, blockCbor)
 	if f.blockForged != nil {
 		func() {
 			defer func() {
@@ -785,13 +790,9 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			f.blockForged(block, blockCbor, time.Since(forgeStartTime))
 		}()
 	}
-
-	// Add block to chain and broadcast
-	if err := f.blockBroadcaster.AddBlock(
-		block, blockCbor,
-	); err != nil {
+	if addErr != nil {
 		f.incCouldNotForge()
-		return fmt.Errorf("failed to add block: %w", err)
+		return fmt.Errorf("failed to add block: %w", addErr)
 	}
 
 	// AddBlock accepted the block, so its transactions are confirmed. Remove

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -286,8 +286,13 @@ func TestCheckAndForgeProductionObservesForgedBlockWhenNotAdopted(
 		block: block,
 		cbor:  blockCbor,
 	}
-	broadcaster := &forgerTestBroadcaster{
+	innerBroadcaster := &forgerTestBroadcaster{
 		err: errors.New("not adopted"),
+	}
+	var callOrder []string
+	broadcaster := &trackingBroadcaster{
+		inner: innerBroadcaster,
+		onAdd: func() { callOrder = append(callOrder, "adopt") },
 	}
 	var (
 		observedBlock   ledger.Block
@@ -307,6 +312,7 @@ func TestCheckAndForgeProductionObservesForgedBlockWhenNotAdopted(
 			cbor []byte,
 			latency time.Duration,
 		) {
+			callOrder = append(callOrder, "observe")
 			observedBlock = block
 			observedCbor = append([]byte(nil), cbor...)
 			observedLatency = latency
@@ -327,8 +333,9 @@ func TestCheckAndForgeProductionObservesForgedBlockWhenNotAdopted(
 	require.Same(t, block, observedBlock)
 	assert.Equal(t, blockCbor, observedCbor)
 	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
+	assert.Equal(t, []string{"adopt", "observe"}, callOrder)
 	assert.Equal(t, 1, builder.calls)
-	assert.Equal(t, 1, broadcaster.calls)
+	assert.Equal(t, 1, innerBroadcaster.calls)
 	assert.Equal(t, float64(1), testutil.ToFloat64(forger.metrics.forgeForged))
 	assert.Equal(t, float64(0), testutil.ToFloat64(forger.metrics.forgeAdopted))
 }

--- a/node.go
+++ b/node.go
@@ -127,10 +127,9 @@ type Node struct {
 	// tracked ID. Captured here (rather than discarded, as Run() otherwise
 	// would) purely so node_lifecycle.go can unsubscribe the stale handler
 	// before rebuilding its component; Run()'s own behavior is unchanged.
-	chainManagerBlockProposedSubId event.EventSubscriberId
-	chainsyncClientRemoveSubId     event.EventSubscriberId
-	connManagerRecycleSubId        event.EventSubscriberId
-	leiosVoteEmittedSubId          event.EventSubscriberId
+	chainsyncClientRemoveSubId event.EventSubscriberId
+	connManagerRecycleSubId    event.EventSubscriberId
+	leiosVoteEmittedSubId      event.EventSubscriberId
 	// koiosParitySubId is tracked for the same reason: observer.
 	// HandleEpochTransitionEvent is bound to the *koiosparity.Observer
 	// instance startKoiosParityObserver creates, which a live database
@@ -625,14 +624,6 @@ func (n *Node) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to load chain manager: %w", err)
 	}
 	n.chainManager = cm
-	primaryChain := n.chainManager.PrimaryChain()
-	// Subscriber ID captured (rather than discarded) so a live database
-	// restore/truncate can unsubscribe this handler before rebuilding
-	// n.chainManager — see node_lifecycle.go.
-	n.chainManagerBlockProposedSubId = n.eventBus.SubscribeFunc(
-		chain.BlockProposedEventType,
-		primaryChain.HandleBlockProposedEvent,
-	)
 	n.chainsyncIngressEligibilityCache = make(
 		map[ouroboros.ConnectionId]bool,
 	)

--- a/node_forging.go
+++ b/node_forging.go
@@ -26,7 +26,6 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/leiosheader"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/forging"
@@ -247,10 +246,10 @@ func (n *Node) initBlockForger(
 		return fmt.Errorf("failed to create block builder: %w", err)
 	}
 
-	// Create block broadcaster (uses the chain manager and event bus)
+	// Create block broadcaster for synchronous local chain adoption.
 	broadcaster := &blockBroadcaster{
-		eventBus: n.eventBus,
-		logger:   n.config.logger,
+		chain:  n.chainManager.PrimaryChain(),
+		logger: n.config.logger,
 	}
 
 	// Create the leader election component
@@ -447,14 +446,13 @@ func (a *forgingMempoolAdapter) RemoveTxsByHash(hashes []string) {
 	a.source.RemoveTxsByHash(hashes)
 }
 
-// blockBroadcaster implements forging.BlockBroadcaster by proposing locally
-// forged blocks to the chain component over the EventBus.
+// blockBroadcaster implements forging.BlockBroadcaster through synchronous
+// local chain admission. Block proposals are requests, not notifications, so
+// they must not wait in the asynchronous EventBus while the chain advances.
 type blockBroadcaster struct {
-	eventBus *event.EventBus
-	logger   *slog.Logger
+	chain  *chain.Chain
+	logger *slog.Logger
 }
-
-const blockProposalAckTimeout = 30 * time.Second
 
 func (b *blockBroadcaster) AddBlock(
 	block gledger.Block,
@@ -463,38 +461,11 @@ func (b *blockBroadcaster) AddBlock(
 	if block == nil {
 		return errors.New("proposed block is nil")
 	}
-	if b.eventBus == nil {
-		return errors.New("event bus unavailable")
+	if b.chain == nil {
+		return errors.New("chain unavailable")
 	}
-	if !b.eventBus.HasSubscribers(chain.BlockProposedEventType) {
-		return errors.New("no chain block proposal subscribers")
-	}
-
-	ack := make(chan error, 1)
-	b.eventBus.Publish(
-		chain.BlockProposedEventType,
-		event.NewEvent(
-			chain.BlockProposedEventType,
-			chain.BlockProposedEvent{
-				Block: block,
-				Ack:   ack,
-			},
-		),
-	)
-
-	timer := time.NewTimer(blockProposalAckTimeout)
-	defer timer.Stop()
-
-	select {
-	case err := <-ack:
-		if err != nil {
-			return fmt.Errorf("chain rejected proposed block: %w", err)
-		}
-	case <-timer.C:
-		return fmt.Errorf(
-			"timed out waiting for proposed block ack after %s",
-			blockProposalAckTimeout,
-		)
+	if err := b.chain.AddLocalBlock(block); err != nil {
+		return fmt.Errorf("chain rejected proposed block: %w", err)
 	}
 
 	b.logger.Info(

--- a/node_forging_admission_test.go
+++ b/node_forging_admission_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockBroadcasterAddsWithoutEventSubscriber(t *testing.T) {
+	blocks, err := fixtures.GenerateConwayChain(
+		0,
+		lcommon.Blake2b256{},
+		1,
+		1,
+		1,
+	)
+	require.NoError(t, err)
+	cm, err := chain.NewManager(nil, nil)
+	require.NoError(t, err)
+	broadcaster := &blockBroadcaster{
+		chain:  cm.PrimaryChain(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	require.NoError(t, broadcaster.AddBlock(blocks[0], blocks[0].Cbor()))
+	require.Equal(t, blocks[0].Hash().Bytes(), cm.PrimaryChain().Tip().Point.Hash)
+}
+
+func TestBlockBroadcasterRejectsUnavailableChain(t *testing.T) {
+	blocks, err := fixtures.GenerateConwayChain(
+		0,
+		lcommon.Blake2b256{},
+		1,
+		1,
+		1,
+	)
+	require.NoError(t, err)
+	broadcaster := &blockBroadcaster{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	err = broadcaster.AddBlock(blocks[0], blocks[0].Cbor())
+	require.EqualError(t, err, "chain unavailable")
+}

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -306,7 +306,7 @@ func (n *Node) quiesceForLiveLifecycleOp(ctx context.Context) error {
 	// Unsubscribe the handlers bound to components being discarded, so the
 	// EventBus (which is never stopped/restarted here) doesn't accumulate a
 	// stale subscriber pointing at an object this function just tore down.
-	// See the Node struct field comments (node.go) for why only these three
+	// See the Node struct field comments (node.go) for why only these two
 	// of Run()'s ~19 direct subscriptions need this.
 	//
 	// UnsubscribeAndWait, not Unsubscribe: closeStorageForLiveLifecycleOp
@@ -315,13 +315,6 @@ func (n *Node) quiesceForLiveLifecycleOp(ctx context.Context) error {
 	// Unsubscribe only stops future deliveries, so a handler goroutine
 	// already dispatched before this loop runs could still be reading
 	// those fields concurrently with that teardown.
-	if n.chainManagerBlockProposedSubId != 0 {
-		n.eventBus.UnsubscribeAndWait(
-			chain.BlockProposedEventType,
-			n.chainManagerBlockProposedSubId,
-		)
-		n.chainManagerBlockProposedSubId = 0
-	}
 	if n.chainsyncClientRemoveSubId != 0 {
 		n.eventBus.UnsubscribeAndWait(
 			chainsync.ClientRemoveRequestedEventType,
@@ -511,12 +504,6 @@ func (n *Node) reinitializeCoreStorage(ctx context.Context) error {
 		return fmt.Errorf("failed to reload chain manager: %w", err)
 	}
 	n.chainManager = cm
-	primaryChain := n.chainManager.PrimaryChain()
-	n.chainManagerBlockProposedSubId = n.eventBus.SubscribeFunc(
-		chain.BlockProposedEventType,
-		primaryChain.HandleBlockProposedEvent,
-	)
-
 	enableDijkstra := n.config.experimentalDijkstraEnabled()
 
 	state, err := ledger.NewLedgerState(


### PR DESCRIPTION
## Problem

Locally forged blocks were submitted through the asynchronous EventBus after observability callbacks, allowing the chain tip to advance before admission. Local blocks were also compared with peer-delivered pending headers.

## Changes

- Admit locally forged blocks synchronously before observer callbacks.
- Skip peer-header matching for local admission and clear queued headers after successful local adoption.
- Preserve stale-parent and contiguous block-number validation.
- Add local-admission regression coverage and document the path.

## Checks

- `go test -race -count=1 ./chain ./ledger/forging`
- `go test -race -count=1 -run 'TestBlockBroadcaster' .`
- `go vet ./chain ./ledger/forging .`
- `make import-boundaries`
- `make golines`
- `make docs-parity`

Closes #3174

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admits locally forged blocks synchronously on the primary chain via `chain.AddLocalBlock`, instead of proposing on the EventBus. Old: proposals were async and compared to queued peer headers, so the tip could advance and create false conflicts; New: admit immediately, skip header matching, publish `chain.update` before returning.

- Local admission keeps tip-hash and contiguous block-number checks; clears pending peer headers on successful adoption; preserves them on stale-parent rejection.
- Broadcaster calls the primary chain directly; removes `chain.BlockProposedEventType`, related Node subscriptions, and proposal ack/timeout flow. Docs and tests updated; forging diagram now targets PrimaryChain and reflects the order: admit → observe → remove confirmed txs.
- New tests cover header-independent local admission and broadcaster behavior without EventBus.

**Migration**
- Replace any `chain.BlockProposedEventType` senders/subscribers with direct calls to `chain.AddLocalBlock`.
- Update observability to run after the adoption attempt; remove proposal ack/timeout logic and EventBus dependencies in broadcasters/tests.

<sup>Written for commit b3465e10f017ea68d6a7620d21ebcb2d1cc4ffbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Locally forged blocks are now submitted directly to the active chain.
  - Local forging can proceed even when queued peer data is unavailable or conflicting.
  - Successfully adopted local blocks clear outdated pending peer headers.

- **Bug Fixes**
  - Invalid locally forged blocks with stale parents are rejected without changing the chain tip or pending peer data.
  - Block-forging notifications now occur after the system attempts to adopt the block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->