### PR TITLE
fix(ledger): recover after unavailable blockfetch range

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2238,6 +2238,13 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 							"error",
 							startErr,
 						)
+						// Retarget the selection too, not just this
+						// request: nextBlockfetchConnId prefers
+						// selectedBlockfetchConnId, so leaving it on the
+						// failed recovery connection sends the next batch
+						// of a multi-batch replay straight back to it.
+						// Matches the fallback in handleEventChainsync.
+						ls.selectedBlockfetchConnId = *activeConnId
 						startErr = ls.startQueuedBlockfetchLocked(
 							*activeConnId,
 							&pending,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2273,6 +2273,14 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 		}
 		return LocalRollbackRecoveryResult{Recovered: true}
 	}
+	// Every preferred connection failed. Clear the selection rather than
+	// leaving it on a connection known not to serve this range, matching what
+	// handleEventChainsync does when its own fallbacks are exhausted. Each
+	// successful replay reassigns this field before its blockfetch attempt, so
+	// nothing downstream currently reads a stale value -- but that makes the
+	// invariant depend on every future writer reassigning first, which is not a
+	// property worth relying on.
+	ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 	return LocalRollbackRecoveryResult{}
 }
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2216,9 +2216,11 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 			"header_count", headerCount,
 		)
 		ls.chainsyncBlockfetchMutex.Lock()
+		var startErr error
 		if ls.chainsyncBlockfetchReadyChan == nil &&
 			!ls.blockfetchContinuationPending {
-			if err := ls.startQueuedBlockfetchLocked(connId, &pending); err != nil {
+			startErr = ls.startQueuedBlockfetchLocked(connId, &pending)
+			if startErr != nil {
 				// Recovery connection may have closed. Retry with
 				// the current active best peer before giving up,
 				// otherwise the pipeline stalls until restart.
@@ -2234,16 +2236,15 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 							"active_connection_id",
 							activeConnId.String(),
 							"error",
-							err,
+							startErr,
 						)
-						if retryErr := ls.startQueuedBlockfetchLocked(*activeConnId, &pending); retryErr == nil {
-							err = nil
-						} else {
-							err = retryErr
-						}
+						startErr = ls.startQueuedBlockfetchLocked(
+							*activeConnId,
+							&pending,
+						)
 					}
 				}
-				if err != nil {
+				if startErr != nil {
 					ls.config.Logger.Warn(
 						"failed to start blockfetch after local rollback recovery",
 						"component",
@@ -2251,12 +2252,18 @@ func (ls *LedgerState) RecoverAfterLocalRollback(
 						"connection_id",
 						connId.String(),
 						"error",
-						err,
+						startErr,
 					)
 				}
 			}
 		}
 		ls.chainsyncBlockfetchMutex.Unlock()
+		if startErr != nil {
+			// Do not report recovery when the replayed headers could not
+			// be fetched. The caller must close these sessions so peer
+			// governance can establish a fresh chainsync intersection.
+			continue
+		}
 		return LocalRollbackRecoveryResult{Recovered: true}
 	}
 	return LocalRollbackRecoveryResult{}

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1345,6 +1345,54 @@ func TestRecoverAfterLocalRollbackReplaysPeerHeaderHistory(
 	fixture.ls.blockfetchRequestRangeCleanup()
 }
 
+func TestRecoverAfterLocalRollbackReportsBlockfetchFailure(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.db.SetTip(fixture.ancestorTip, nil))
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+	requestCount := 0
+	fixture.ls.config.BlockfetchRequestRangeFunc = func(
+		ouroboros.ConnectionId,
+		ocommon.Point,
+		ocommon.Point,
+	) error {
+		requestCount++
+		return errBlockfetchNoBlocks
+	}
+
+	header := mockHeader{
+		hash:        lcommon.NewBlake2b256(testHashBytes("rollback-no-blocks")),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        fixture.ancestorTip.Point.Slot + 1,
+	}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        ocommon.NewPoint(header.SlotNumber(), header.Hash().Bytes()),
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(header.SlotNumber(), header.Hash().Bytes()),
+			BlockNumber: header.BlockNumber(),
+		},
+		BlockHeader: header,
+	})
+
+	result := fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+
+	assert.False(t, result.Recovered)
+	assert.False(t, result.SkipConnectionClose)
+	assert.Equal(t, 1, requestCount)
+	assert.Equal(t, 1, fixture.ls.chain.HeaderCount())
+}
+
 func TestRecoverAfterLocalRollbackResetsStateWithoutTrackedClients(
 	t *testing.T,
 ) {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1345,6 +1345,93 @@ func TestRecoverAfterLocalRollbackReplaysPeerHeaderHistory(
 	fixture.ls.blockfetchRequestRangeCleanup()
 }
 
+// TestRecoverAfterLocalRollbackRetargetsSelectedBlockfetchConn asserts the
+// active-peer fallback moves the blockfetch selection, not just the one request
+// it issues. nextBlockfetchConnId prefers selectedBlockfetchConnId, so a
+// selection left on the failed recovery connection sends the next batch of a
+// multi-batch replay straight back to the connection that just failed, and the
+// first batch is the only one that ever arrives.
+func TestRecoverAfterLocalRollbackRetargetsSelectedBlockfetchConn(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.db.SetTip(fixture.ancestorTip, nil))
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+
+	activeConnId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	fixture.ls.config.GetActiveConnectionFunc = func() *ouroboros.ConnectionId {
+		return &activeConnId
+	}
+	// The recovery connection is gone; only the active best peer answers.
+	var requested []ouroboros.ConnectionId
+	fixture.ls.config.BlockfetchRequestRangeFunc = func(
+		connId ouroboros.ConnectionId,
+		_ ocommon.Point,
+		_ ocommon.Point,
+	) error {
+		requested = append(requested, connId)
+		if sameConnectionId(connId, activeConnId) {
+			return nil
+		}
+		return errBlockfetchNoBlocks
+	}
+
+	header := mockHeader{
+		hash: lcommon.NewBlake2b256(
+			testHashBytes("rollback-retarget"),
+		),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        fixture.ancestorTip.Point.Slot + 1,
+	}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			header.SlotNumber(),
+			header.Hash().Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockNumber: header.BlockNumber(),
+		},
+		BlockHeader: header,
+	})
+
+	fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+
+	require.Len(
+		t, requested, 2,
+		"the failed recovery connection then the active best peer",
+	)
+	assert.True(
+		t, sameConnectionId(requested[1], activeConnId),
+		"the fallback request must go to the active best peer",
+	)
+	assert.True(
+		t,
+		sameConnectionId(
+			fixture.ls.selectedBlockfetchConnId,
+			activeConnId,
+		),
+		"the blockfetch selection must follow the fallback, so the next "+
+			"batch does not return to the failed connection",
+	)
+}
+
 func TestRecoverAfterLocalRollbackReportsBlockfetchFailure(
 	t *testing.T,
 ) {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -1432,6 +1432,77 @@ func TestRecoverAfterLocalRollbackRetargetsSelectedBlockfetchConn(
 	)
 }
 
+// TestRecoverAfterLocalRollbackClearsSelectionWhenEveryConnectionFails asserts
+// the blockfetch selection is not left pointing at a connection that just failed
+// to serve the replayed range. handleEventChainsync clears it when its own
+// fallbacks are exhausted; this path now does the same, so nothing downstream
+// has to depend on being the next writer of the field.
+func TestRecoverAfterLocalRollbackClearsSelectionWhenEveryConnectionFails(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	require.NoError(t, fixture.ls.chain.Rollback(fixture.ancestorTip.Point))
+	require.NoError(t, fixture.ls.db.SetTip(fixture.ancestorTip, nil))
+	fixture.ls.currentTip = fixture.ancestorTip
+	fixture.ls.currentTipBlockNonce = append(
+		[]byte(nil),
+		fixture.ancestorNonce...,
+	)
+
+	activeConnId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6002},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3003},
+	}
+	fixture.ls.config.GetActiveConnectionFunc = func() *ouroboros.ConnectionId {
+		return &activeConnId
+	}
+	// Nothing can serve the range: neither the recovery connection nor the
+	// active best peer the fallback reaches for.
+	fixture.ls.config.BlockfetchRequestRangeFunc = func(
+		ouroboros.ConnectionId,
+		ocommon.Point,
+		ocommon.Point,
+	) error {
+		return errBlockfetchNoBlocks
+	}
+
+	header := mockHeader{
+		hash: lcommon.NewBlake2b256(
+			testHashBytes("rollback-clear-selection"),
+		),
+		prevHash:    lcommon.NewBlake2b256(fixture.ancestorTip.Point.Hash),
+		blockNumber: fixture.ancestorTip.BlockNumber + 1,
+		slot:        fixture.ancestorTip.Point.Slot + 1,
+	}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point: ocommon.NewPoint(
+			header.SlotNumber(),
+			header.Hash().Bytes(),
+		),
+		Tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				header.SlotNumber(),
+				header.Hash().Bytes(),
+			),
+			BlockNumber: header.BlockNumber(),
+		},
+		BlockHeader: header,
+	})
+
+	result := fixture.ls.RecoverAfterLocalRollback(
+		[]ouroboros.ConnectionId{fixture.connId},
+		fixture.ancestorTip.Point,
+	)
+	require.False(t, result.Recovered)
+
+	assert.Empty(
+		t, connIdKey(fixture.ls.selectedBlockfetchConnId),
+		"an exhausted recovery must not leave the selection on a "+
+			"connection that failed to serve the range",
+	)
+}
+
 func TestRecoverAfterLocalRollbackReportsBlockfetchFailure(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## Problem

Local rollback recovery reported success after every replayed blockfetch start failed, including `block(s) not found`. The caller therefore kept the affected chainsync sessions alive instead of establishing a fresh intersection.

## Changes

- Retry replayed headers on the active connection when the recovery connection fails.
- Report recovery only after a blockfetch starts successfully.
- Add regression coverage for an unavailable blockfetch range.

## Checks

- `go test -race -count=1 -run 'Test(RecoverAfterLocalRollback|RestartQueuedBlockfetchAfterForkDropsHeadersOnRepeatedNoBlocks|BlockfetchRange|StartQueuedBlockfetch|HandleEventBlockfetchBatchDone)' ./ledger`
- `go vet ./ledger/...`
- `golangci-lint run ./ledger/...`
- `make import-boundaries`
- `make golines`
- `make docs-parity`

Closes #3212

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rollback recovery when the replayed blockfetch range is unavailable. Previously it reported success after failed starts and multi-batch replays returned to the failed connection; now it retries on the active best peer, retargets the selection, and clears it when every connection fails to prevent stale routing.

- Retries start on the active best peer and moves selectedBlockfetchConnId to that peer so subsequent batches use the active connection.
- If all attempts fail, does not report recovery and clears selectedBlockfetchConnId to avoid sending future batches to a known-bad connection; logs the failure.
- Callers must close the affected chainsync sessions to establish a fresh intersection. Adds regression tests for unavailable ranges, selection retargeting/clearing, and failure reporting.

<sup>Written for commit b3ffd443017a44d85c7d79d5f8582a22460ec3d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

