### PR TITLE
fix(ledger): retarget blockfetch selection when a retry switches peers

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3202,6 +3202,48 @@ func (ls *LedgerState) noteBlockfetchRangeUnavailable(
 	return true
 }
 
+// startQueuedBlockfetchOnLocked starts the queued range on connId and, if that
+// succeeds, retargets the blockfetch selection to it.
+//
+// Every path that moves the fetch to a different connection has to go through
+// this rather than calling startQueuedBlockfetchLocked directly:
+// nextBlockfetchConnId prefers selectedBlockfetchConnId over
+// activeBlockfetchConnId, and the batch-completion continuation uses it to pick
+// the connection for the next batch. Starting on one connection while the
+// selection still names another therefore recovers a single batch from the
+// working peer and sends the next one back to the peer that just failed.
+//
+// Callers that already own the selection (handoffPipelineOnSwitchLocked,
+// handleEventChainsyncBlockHeaderWithPending, and the recovery replay, each of
+// which assigns it first) may call startQueuedBlockfetchLocked directly. Note
+// that selectInitialBlockfetchConn is the identity function today, so that path
+// starts on the connection it just selected; if it ever returns a different
+// connection it needs this helper too.
+//
+// One current caller gains nothing from it: the timeout handler's alternate
+// connection comes from nextBlockfetchConnIdExcept, which can only return a
+// connection other than the excluded one when that connection already is the
+// selection -- a failed attempt has by then overwritten activeBlockfetchConnId
+// with the excluded connection, so the retarget there cannot change anything. It
+// is routed through here anyway so the invariant lives in one place rather than
+// depending on that reachability argument staying true.
+func (ls *LedgerState) startQueuedBlockfetchOnLocked(
+	connId ouroboros.ConnectionId,
+	pending *pendingPublishes,
+) error {
+	// Retarget only once the start has actually succeeded. Moving the selection
+	// on an attempt would discard what the caller's own fallback needs:
+	// nextBlockfetchConnIdExcept picks the next candidate by excluding the
+	// connection that just failed and preferring the current selection, so
+	// pointing the selection at the failed connection first collapses that
+	// lookup onto activeBlockfetchConnId instead.
+	if err := ls.startQueuedBlockfetchLocked(connId, pending); err != nil {
+		return err
+	}
+	ls.selectedBlockfetchConnId = connId
+	return nil
+}
+
 func (ls *LedgerState) startQueuedBlockfetchLocked(
 	connId ouroboros.ConnectionId,
 	pending *pendingPublishes,
@@ -3472,7 +3514,7 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 			return
 		}
 		ls.blockfetchContinuationPending = false
-		err := ls.startQueuedBlockfetchLocked(connId, &pending)
+		err := ls.startQueuedBlockfetchOnLocked(connId, &pending)
 		if err != nil {
 			// A continuation can race a peer disconnect just as the previous
 			// batch completes. Try the next tracked peer before abandoning the
@@ -3480,7 +3522,7 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 			retryConnId := ls.selectRetryBlockfetchConn(connId)
 			if connIdKey(retryConnId) != "" &&
 				!sameConnectionId(retryConnId, connId) {
-				err = ls.startQueuedBlockfetchLocked(
+				err = ls.startQueuedBlockfetchOnLocked(
 					retryConnId,
 					&pending,
 				)
@@ -5303,7 +5345,10 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 		"header_end_slot", headerEnd.Slot,
 		"header_count", headerCount,
 	)
-	if err := ls.startQueuedBlockfetchLocked(retryConnId, pending); err != nil {
+	if err := ls.startQueuedBlockfetchOnLocked(
+		retryConnId,
+		pending,
+	); err != nil {
 		ls.config.Logger.Error(
 			"failed to retry blockfetch range after timeout",
 			"component", "ledger",
@@ -5318,7 +5363,10 @@ func (ls *LedgerState) handleBlockfetchTimeoutLocked(
 				"retry_connection_id", nextConnId.String(),
 				"header_count", ls.chain.HeaderCount(),
 			)
-			if retryErr := ls.startQueuedBlockfetchLocked(nextConnId, pending); retryErr != nil {
+			if retryErr := ls.startQueuedBlockfetchOnLocked(
+				nextConnId,
+				pending,
+			); retryErr != nil {
 				ls.config.Logger.Error(
 					"failed to restart queued blockfetch after timeout retry failure",
 					"component",

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3237,10 +3237,19 @@ func (ls *LedgerState) startQueuedBlockfetchOnLocked(
 	// connection that just failed and preferring the current selection, so
 	// pointing the selection at the failed connection first collapses that
 	// lookup onto activeBlockfetchConnId instead.
+	//
+	// Captured first because startQueuedBlockfetchLocked releases
+	// chainsyncBlockfetchMutex around the network request: a connection switch
+	// or close can install a newer selection while we are outside it, and this
+	// retarget must not overwrite that. If the selection moved, the concurrent
+	// writer's choice is the current one and wins.
+	before := ls.selectedBlockfetchConnId
 	if err := ls.startQueuedBlockfetchLocked(connId, pending); err != nil {
 		return err
 	}
-	ls.selectedBlockfetchConnId = connId
+	if sameConnectionId(ls.selectedBlockfetchConnId, before) {
+		ls.selectedBlockfetchConnId = connId
+	}
 	return nil
 }
 

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -298,9 +298,11 @@ func TestBlockfetchContinuationRetargetsSelection(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		// fail reports whether a request on this connection should fail,
-		// letting the subtest drive either the primary start or its retry.
+		// letting the subtest drive the primary start, its retry, or neither.
 		fail func(ouroboros.ConnectionId, ouroboros.ConnectionId) bool
-		want func(primary, retry ouroboros.ConnectionId) ouroboros.ConnectionId
+		want func(
+			stale, primary, retry ouroboros.ConnectionId,
+		) ouroboros.ConnectionId
 	}{
 		{
 			name: "primary start",
@@ -308,9 +310,24 @@ func TestBlockfetchContinuationRetargetsSelection(t *testing.T) {
 				return false
 			},
 			want: func(
-				primary, _ ouroboros.ConnectionId,
+				_, primary, _ ouroboros.ConnectionId,
 			) ouroboros.ConnectionId {
 				return primary
+			},
+		},
+		{
+			// Pins the other half of the contract: a failed attempt must not
+			// move the selection. Without this case a regression that
+			// retargeted on the attempt would still pass, because the
+			// following successful retry puts the expected value back.
+			name: "neither the primary nor its retry succeeds",
+			fail: func(ouroboros.ConnectionId, ouroboros.ConnectionId) bool {
+				return true
+			},
+			want: func(
+				stale, _, _ ouroboros.ConnectionId,
+			) ouroboros.ConnectionId {
+				return stale
 			},
 		},
 		{
@@ -319,7 +336,7 @@ func TestBlockfetchContinuationRetargetsSelection(t *testing.T) {
 				return sameConnectionId(connId, primary)
 			},
 			want: func(
-				_, retry ouroboros.ConnectionId,
+				_, _, retry ouroboros.ConnectionId,
 			) ouroboros.ConnectionId {
 				return retry
 			},
@@ -383,12 +400,63 @@ func TestBlockfetchContinuationRetargetsSelection(t *testing.T) {
 			ls.chainsyncBlockfetchMutex.Unlock()
 
 			assert.True(
-				t, sameConnectionId(got, test.want(primary, retry)),
+				t, sameConnectionId(got, test.want(stale, primary, retry)),
 				"the selection must name the connection that served the "+
 					"continuation, got %s", got.String(),
 			)
 		})
 	}
+}
+
+// TestBlockfetchRetargetPreservesConcurrentSelection asserts the retarget does
+// not overwrite a newer selection installed while the start was outside the
+// mutex. startQueuedBlockfetchLocked releases chainsyncBlockfetchMutex around
+// the network request, so a connection switch or close can land in that window;
+// its choice is the current one and has to win. The request callback stands in
+// for that concurrent writer, since it runs with the mutex released.
+func TestBlockfetchRetargetPreservesConcurrentSelection(t *testing.T) {
+	stale := testChainsyncConnId(6300, 3001)
+	starting := testChainsyncConnId(6300, 3002)
+	switched := testChainsyncConnId(6300, 3003)
+
+	testChain := &chain.Chain{}
+	require.NoError(t, testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("concurrent-switch")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}))
+
+	ls := &LedgerState{
+		chain:                    testChain,
+		selectedBlockfetchConnId: stale,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.config.BlockfetchRequestRangeFunc = func(
+		ouroboros.ConnectionId,
+		ocommon.Point,
+		ocommon.Point,
+	) error {
+		// Runs with the mutex released, exactly where a real connection
+		// switch would install its own selection.
+		ls.selectedBlockfetchConnId = switched
+		return nil
+	}
+
+	ls.chainsyncBlockfetchMutex.Lock()
+	require.NoError(t, ls.startQueuedBlockfetchOnLocked(starting, nil))
+	got := ls.selectedBlockfetchConnId
+	ls.blockfetchRequestRangeCleanup()
+	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+	ls.chainsyncBlockfetchMutex.Unlock()
+
+	assert.True(
+		t, sameConnectionId(got, switched),
+		"a selection installed while the request was outside the mutex must "+
+			"survive the retarget, got %s", got.String(),
+	)
 }
 
 // newNoBlocksLedgerState builds a LedgerState with one queued header whose

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -288,6 +288,109 @@ func TestBlockfetchBatchDoneDoesNotBlockSubscriberOnContinuation(t *testing.T) {
 	ls.chainsyncBlockfetchMutex.Unlock()
 }
 
+// TestBlockfetchContinuationRetargetsSelection covers the continuation path's
+// two starts. handleEventBlockfetchBatchDone hands this function a connection
+// chosen by selectRetryBlockfetchConn, which need not be the current selection,
+// and nextBlockfetchConnId prefers the selection when picking the next batch's
+// connection. So a selection left behind here sends the following batch back to
+// the connection the continuation just moved away from.
+func TestBlockfetchContinuationRetargetsSelection(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		// fail reports whether a request on this connection should fail,
+		// letting the subtest drive either the primary start or its retry.
+		fail func(ouroboros.ConnectionId, ouroboros.ConnectionId) bool
+		want func(primary, retry ouroboros.ConnectionId) ouroboros.ConnectionId
+	}{
+		{
+			name: "primary start",
+			fail: func(ouroboros.ConnectionId, ouroboros.ConnectionId) bool {
+				return false
+			},
+			want: func(
+				primary, _ ouroboros.ConnectionId,
+			) ouroboros.ConnectionId {
+				return primary
+			},
+		},
+		{
+			name: "retry after the primary fails",
+			fail: func(connId, primary ouroboros.ConnectionId) bool {
+				return sameConnectionId(connId, primary)
+			},
+			want: func(
+				_, retry ouroboros.ConnectionId,
+			) ouroboros.ConnectionId {
+				return retry
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stale := testChainsyncConnId(6200, 3001)
+			primary := testChainsyncConnId(6200, 3002)
+			retry := testChainsyncConnId(6200, 3003)
+
+			testChain := &chain.Chain{}
+			require.NoError(t, testChain.AddBlockHeader(mockHeader{
+				hash:        lcommon.NewBlake2b256([]byte("cont-retarget")),
+				prevHash:    lcommon.NewBlake2b256(nil),
+				blockNumber: 1,
+				slot:        1,
+			}))
+
+			ls := &LedgerState{
+				chain: testChain,
+				// The selection starts on a connection this continuation is
+				// moving away from, so neither expected value can be reached
+				// without the retarget.
+				selectedBlockfetchConnId: stale,
+				config: LedgerStateConfig{
+					Logger: slog.New(
+						slog.NewJSONHandler(io.Discard, nil),
+					),
+					GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+						return &retry
+					},
+					BlockfetchRequestRangeFunc: func(
+						connId ouroboros.ConnectionId,
+						_ ocommon.Point,
+						_ ocommon.Point,
+					) error {
+						if test.fail(connId, primary) {
+							return errors.New("request failed")
+						}
+						return nil
+					},
+				},
+			}
+
+			ls.chainsyncBlockfetchMutex.Lock()
+			ls.startQueuedBlockfetchFromEventLocked(
+				primary,
+				primary,
+				"test continuation",
+			)
+			ls.chainsyncBlockfetchMutex.Unlock()
+
+			ls.blockfetchContinuationMu.Lock()
+			ls.blockfetchContinuationWG.Wait()
+			ls.blockfetchContinuationMu.Unlock()
+
+			ls.chainsyncBlockfetchMutex.Lock()
+			got := ls.selectedBlockfetchConnId
+			ls.blockfetchRequestRangeCleanup()
+			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
+			ls.chainsyncBlockfetchMutex.Unlock()
+
+			assert.True(
+				t, sameConnectionId(got, test.want(primary, retry)),
+				"the selection must name the connection that served the "+
+					"continuation, got %s", got.String(),
+			)
+		})
+	}
+}
+
 // newNoBlocksLedgerState builds a LedgerState with one queued header whose
 // range every peer refuses with a NoBlocks error, and returns it alongside the
 // request counter and a channel of published resync events.

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1896,6 +1896,64 @@ func TestHandleBlockfetchTimeoutLocked_RetriesQueuedRangeUsingActivePeer(
 	assert.Equal(t, 1, testChain.HeaderCount())
 }
 
+// TestHandleBlockfetchTimeoutLocked_RetryRetargetsSelection asserts a timeout
+// retry moves the blockfetch selection to the connection it retries on.
+// nextBlockfetchConnId prefers selectedBlockfetchConnId, and the
+// batch-completion continuation uses it to choose the next batch's connection,
+// so a selection left on the timed-out peer recovers one batch from the working
+// peer and sends the next straight back to the one that just timed out.
+func TestHandleBlockfetchTimeoutLocked_RetryRetargetsSelection(
+	t *testing.T,
+) {
+	connId1 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	connId2 := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3002},
+	}
+	testChain := &chain.Chain{}
+	require.NoError(t, testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("hdr-retarget-1")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}))
+
+	var requestedConn ouroboros.ConnectionId
+	ls := &LedgerState{
+		chain:                  testChain,
+		activeBlockfetchConnId: connId1,
+		// Starts on the connection that is about to time out, so the
+		// assertion below cannot pass without the retarget.
+		selectedBlockfetchConnId: connId1,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+				return &connId2
+			},
+			BlockfetchRequestRangeFunc: func(
+				connId ouroboros.ConnectionId,
+				_ ocommon.Point,
+				_ ocommon.Point,
+			) error {
+				requestedConn = connId
+				return nil
+			},
+		},
+	}
+
+	handleBlockfetchTimeoutForTest(ls, connId1, nil)
+
+	require.Equal(t, connId2, requestedConn)
+	assert.Equal(
+		t, connId2, ls.selectedBlockfetchConnId,
+		"the selection must follow the retry, so the next batch does not "+
+			"return to the timed-out connection",
+	)
+}
+
 func TestHandleBlockfetchTimeoutLocked_ClearsActiveConnectionWithoutHeaders(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## Problem

`nextBlockfetchConnId` prefers `selectedBlockfetchConnId` over
`activeBlockfetchConnId`, and the batch-completion continuation uses it to pick
the connection for the next batch. `startQueuedBlockfetchLocked` never assigns
that field itself, so a retry path that moves the fetch to a different
connection had to retarget the selection or the next batch went back to the
connection that just failed. A multi-batch queued range therefore recovered its
first batch from the working peer and sent the next one to the failed peer;
single-batch ranges were unaffected, which is likely why it was not obvious.

Fixes #3220.

## Changes

- `startQueuedBlockfetchOnLocked` starts the queued range on a connection and,
  **only if that succeeds**, retargets the selection to it. Retargeting on the
  attempt instead would break the callers' own fallback:
  `nextBlockfetchConnIdExcept` picks the next candidate by excluding the failed
  connection and preferring the current selection, so pointing the selection at
  the failed connection collapses that lookup onto `activeBlockfetchConnId`. A
  pre-existing test (`TestHandleBlockfetchTimeoutLocked_RetryFailureUsesAlternateSelectedPeer`)
  catches that, and it does.
- Routed through it: the timeout handler's first retry and alternate retry, and
  both starts in the batch-continuation goroutine.
- Left calling `startQueuedBlockfetchLocked` directly: the paths that already own
  the selection — `handoffPipelineOnSwitchLocked` (assigns it as its first
  statement), `handleEventChainsyncBlockHeaderWithPending`, the recovery replay
  (assigns it inside the helper that gates the loop), and
  `restartQueuedBlockfetchAfterForkLocked`.

## Scope notes

- Every `startQueuedBlockfetch*` call site was audited, not only the three named
  in the issue: the issue's list was incomplete (four calls needed routing) and
  imprecise (two sites it would have implicated are already covered).
- **One of the four routed calls cannot change anything today.** The timeout
  handler's alternate comes from `nextBlockfetchConnIdExcept`, which only returns
  a connection other than the excluded one when that connection already *is* the
  selection — a failed attempt has by then overwritten `activeBlockfetchConnId`
  with the excluded connection. It is routed through the helper anyway so the
  invariant lives in one place, and the helper's doc comment says so rather than
  letting the call read as a fixed defect. No test claims coverage of it; I
  deleted the one I had written rather than contrive an unreachable arrangement.
- `RecoverAfterLocalRollback`'s own fallback is the same class and is fixed
  separately in #3219, which is not merged yet. Its inline assignment can fold
  into this helper once it lands.

## Checks

- `go test ./ledger/ -race -count=1 -timeout 40m`
- `go build ./ledger/`, `go vet ./ledger/`, `gofmt -l ledger/`
- `golangci-lint run ./ledger/` — 0 issues
- Each new test verified to fail with the retarget removed, naming the stale
  connection: `TestHandleBlockfetchTimeoutLocked_RetryRetargetsSelection` and
  both subtests of `TestBlockfetchContinuationRetargetsSelection`.

Not run: devnet, Antithesis, and conformance-with-live-infrastructure — none
available in this environment. No Docker validation: the change has no image or
runtime-packaging surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blockfetch retries that sent the next batch back to the failed peer. Now, when a retry or continuation starts on a different peer, the selection switches to that peer only after the start succeeds and only if no newer selection was installed concurrently, keeping subsequent batches on the working connection.

- Add startQueuedBlockfetchOnLocked: starts the queued range, then retargets selection on success; captures the prior selection and updates it only if unchanged to avoid overwriting a concurrent switch while the mutex is released.
- Route timeout retries and both batch-continuation starts through the helper; keep direct calls in paths that already set the selection (handoffPipelineOnSwitchLocked, handleEventChainsyncBlockHeaderWithPending, recovery replay, restartQueuedBlockfetchAfterForkLocked).
- The timeout handler’s alternate path remains functionally unchanged today but goes through the helper to centralize the invariant.
- Tests cover continuation retargeting (primary, retry, and “no success” cases), timeout retry retargeting, and preserving a concurrent selection.

<sup>Written for commit 6c3beae6a6a301013b5dad3d3664e9c2e8f4e0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block synchronization retries to consistently use the connection that successfully handles the request.
  * Prevented subsequent blockfetch batches from returning to a peer that previously timed out or failed.

* **Tests**
  * Added coverage for connection selection during continuation requests, failures, and timeout retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->