### PR TITLE
fix(ledger): recover canonical inputs after rollback cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3800,35 +3800,29 @@ always expected to be fully recoverable from the snapshot import.
 
 That default recovery is deliberately one-sided: it only fires when the produced
 `utxo` row is *absent* from the metadata store, and it rebuilds it from the
-blob store, which is append-only and retains blocks from abandoned forks. In
-steady-state, at-tip, validated block application that recovery must never run:
-every consumed input's producer is already applied and live in the metadata
-store. An absent metadata row alone does not prove divergence — it is also the
-normal state of an in-flight/intra-block producer whose row has not been flushed
-yet — but the guard runs only after the same-slot repair and the
-`HasInFlightProducer` intra-block check, so by the time it fires the row is
-absent *and* not in-flight/intra-block, which past the Mithril boundary means
-the applied ledger has diverged from the header chain (issue #3005). Recovering
-the producer from a fork block the applied chain never followed would then
-import a UTxO the chain never produced and persist an
-input-conservation violation — which, once it accumulates past the security
-parameter K, wedges the node behind the rollback-exceeds-K guard with no legal
-recovery. The ledger closes this by setting
+blob store, which is append-only and retains blocks from abandoned forks. An
+absent metadata row does not by itself prove divergence: core-mode cleanup can
+remove a spent row while the producer remains canonical, and rollback can later
+need that row restored (issue #3170). The recovery path therefore checks the
+producer block against the applied primary chain. It permits the canonical case
+and refuses a producer from an abandoned fork, preserving input conservation
+and preventing the #3005 rollback-exceeds-K wedge. The ledger sets
 `BatchedTxIngestOpts.StrictAppliedInputConservation` on the delta apply whenever
 the block is validated and the node has reached tip
 (`shouldValidate && (reachedTip || reachesTip)`, `ledgerProcessBlock`, where
 `reachesTip` is the per-block at-tip signal that guards the transition batch —
 the first batch whose blocks cross the tip cutoff — since `reachedTip` is only
 stored true after that batch commits); with that flag and
-`StrictUtxoValidation` both set, `ensureTransactionConsumedUtxos` refuses to
-recover an absent producer past the Mithril boundary and instead errors, which
-aborts the block's transaction so the inconsistent state is never committed and
-the node stalls loudly for resync rather than baking in a beyond-K fork. The
-flag is left off for from-genesis bootstrap and Mithril gap-closure (both run
-before `reachedTip`) and for non-validated/trusted replay and Leios
-endorser-block apply, where an absent producer is legitimately recovered, so
-this is the primary #3005 prevention while the K-guard and the non-convergence
-recovery hold remain as backstops.
+`StrictUtxoValidation` both set, `ensureTransactionConsumedUtxos` performs the
+primary-chain membership check past the Mithril boundary. A canonical producer
+is recovered, including after core-mode cleanup removed its spent row before a
+rollback (issue #3170); an off-primary producer still returns
+`ErrUtxoNotFound`, aborting the block rather than baking in a beyond-K fork
+(issue #3005). The flag is left off for from-genesis bootstrap and Mithril
+gap-closure (both run before `reachedTip`) and for non-validated/trusted replay
+and Leios endorser-block apply, where an absent producer is legitimately
+recovered, so this remains the primary #3005 prevention while the K-guard and
+the non-convergence recovery hold remain as backstops.
 
 Certified immutable blocks after the selected anchor remain in the primary
 chain, but Mithril sync leaves the metadata ledger tip at the anchor. Normal

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1041,23 +1041,14 @@ replayed state; a database produced by an older version that already skipped a
 certified closure must be replayed from before the affected CertRB (normally by
 performing a clean metadata resync).
 
-`BatchedTxIngestOpts.StrictAppliedInputConservation` is the opposite-direction
-toggle on the same consumed-input path. When set (only by the ledger delta apply
-for a validated block once the node has reached tip), and with the database's
-`StrictUtxoValidation` also on, `ensureTransactionConsumedUtxos` refuses to
-recover a consumed input whose produced `utxo` row is absent from the metadata
-store past the `mithril_ledger_slot` boundary (the check keys on the produced
-UTxO row, not the producer `transaction` row, so it fires even when the producer
-transaction row is present): it errors (`ErrUtxoNotFound`) before consulting the
-append-only blob store, instead of rebuilding the row. This
-prevents a near-tip fork churn from importing a producer that lives only on an
-abandoned fork block the applied chain never followed, which would persist an
-input-conservation violation (a UTxO the applied chain never produced, and in
-the field a double-spend across two persisted blocks) and, once it accumulates
-past the security parameter K, wedge the node (issue #3005). The default is off,
-so every existing ingest path — bootstrap, gap-closure, historical/trusted
-replay, and the `SkipConsumedInputRecovery` Leios apply above — keeps its
-recovery behavior unchanged.
+`BatchedTxIngestOpts.StrictAppliedInputConservation` marks the same steady-state
+path. When set with `StrictUtxoValidation` enabled, a missing consumed-input row
+past the `mithril_ledger_slot` boundary is recovered only after the producer
+block is proven to be on the applied primary chain. This repairs a row removed
+by core-mode consumed-UTxO cleanup before rollback restoration needs it (issue
+#3170), while refusing a producer that exists only in an abandoned-fork blob
+(issue #3005). The default remains off for bootstrap, gap-closure,
+historical/trusted replay, and the `SkipConsumedInputRecovery` Leios apply.
 
 `StrictAppliedInputConservation` is armed only at tip, so it does not cover a
 divergence baked in during catch-up (a validated block below the tip stability

--- a/database/batch.go
+++ b/database/batch.go
@@ -79,23 +79,14 @@ type BatchedTxIngestOpts struct {
 	// replay paths where producer rows may be absent.
 	SkipConsumedInputRecovery bool
 
-	// StrictAppliedInputConservation, when true, treats a consumed input whose
-	// producer row is absent from the metadata store as a hard error for blocks
-	// past the Mithril trust boundary, instead of recovering it from the
-	// append-only blob store (which retains abandoned-fork blocks) or silently
-	// skipping it. Set only by the ledger's steady-state, at-tip, validated
-	// block application: there every consumed input's producer must already be
-	// applied and live in the metadata store, so needing blob recovery signals
-	// that the applied ledger has diverged from the header chain (issue #3005).
-	// Recovering a producer from a retained fork block the applied chain never
-	// followed would bake an input-conservation violation into the persisted
-	// chain and, once it accumulates past K, wedge the node behind the security
-	// parameter guard. Erroring here instead aborts the block's transaction so
-	// the inconsistent state is never persisted and the node stalls loudly for
-	// resync. Left false for bootstrap, Mithril gap-closure, historical/trusted
-	// replay, and Leios endorser-block apply, where absent producer rows are
-	// legitimately recovered. Only takes effect when StrictUtxoValidation is
-	// also enabled on the Database.
+	// StrictAppliedInputConservation marks the steady-state, at-tip, validated
+	// path. Past the Mithril trust boundary, a missing producer row is recovered
+	// only when the producer block is still on the applied primary chain. This
+	// allows rollback recovery after core-mode cleanup removed a spent row
+	// (issue #3170), while refusing recovery from a retained abandoned-fork block
+	// (issue #3005). The option is retained for callers that identify this path;
+	// the primary-chain check also protects validated catch-up paths. It takes
+	// effect only when StrictUtxoValidation is enabled on the Database.
 	StrictAppliedInputConservation bool
 
 	// Stats receives hot-path timings and row-ish counts for operator

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -580,36 +580,12 @@ func (d *Database) ensureTransactionConsumedUtxos(
 			inFlight.HasInFlightProducer(inputTxId, input.Index()) {
 			continue
 		}
-		// Steady-state at-tip validated application (issue #3005): a consumed
-		// input whose producer row is absent from the metadata store must never
-		// be recovered from the append-only blob store here. The blob retains
-		// blocks from abandoned forks, so recovering the producer would import a
-		// UTxO the applied chain never produced and persist an
-		// input-conservation violation. Past the Mithril boundary the producer
-		// is guaranteed to already be applied and live, so an absent row means
-		// the applied ledger has diverged from the header chain. Abort the
-		// block's transaction so the inconsistent state is never persisted and
-		// the node stalls loudly for resync rather than baking in a fork that
-		// later requires a rollback deeper than the security parameter K.
-		if opts.StrictAppliedInputConservation &&
-			d.config.StrictUtxoValidation &&
-			point.Slot > mithrilBoundarySlot {
-			return fmt.Errorf(
-				"consumed utxo %s not present in applied ledger at slot %d: "+
-					"refusing to recover it from the blob store and persist an "+
-					"input-conservation violation (issue #3005): %w",
-				input.String(),
-				point.Slot,
-				ErrUtxoNotFound,
-			)
-		}
-		// For a validated block past the Mithril trust boundary, refuse to
-		// blob-recover a producer that is not on the applied primary chain
-		// (issue #3005 cross-fork splice). This covers the catch-up case that
-		// the at-tip StrictAppliedInputConservation guard above does not reach:
-		// there reachedTip is not latched, so the guard is off, and a fork
-		// switched to during catch-up could otherwise silently resurrect an
-		// abandoned-fork producer from the append-only blob store.
+		// For a validated block past the Mithril trust boundary, recover a
+		// missing producer only when its block is still on the applied primary
+		// chain (issue #3005). Core-mode cleanup can remove a spent row before a
+		// rollback needs to restore it, even though the producer itself remains
+		// canonical (issue #3170). The primary-chain check preserves the
+		// input-conservation guard: an abandoned-fork producer is still refused.
 		recoveredUtxo, err := d.recoverConsumedUtxo(
 			input,
 			txn,

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -779,15 +779,10 @@ func TestSetTransactionRecoveryPopulatesProducerFK(t *testing.T) {
 }
 
 // TestEnsureTransactionConsumedUtxosStrictAppliedInputConservation covers
-// issue #3005: in the steady-state, at-tip, validated block-application path,
-// a consumed input whose produced utxo row is absent from the metadata store
-// (the producer transaction row may still be present) must NOT be recovered
-// from the append-only blob store and persisted, even when that recovery would
-// succeed. The blob retains blocks from abandoned forks,
-// so recovering the producer would import a UTxO the applied chain never
-// produced and bake an input-conservation violation into the persisted chain.
-// With StrictAppliedInputConservation the ingest errors instead, so the block's
-// transaction aborts and the node stalls for resync rather than wedging past K.
+// strict at-tip recovery after a consumed UTxO row was pruned. A canonical
+// producer may be reconstructed from the retained block/blob data (issue
+// #3170), while the primary-chain check still rejects an abandoned-fork
+// producer (issue #3005).
 //
 // The fixture stages the producers so that recovery from the blob WOULD
 // otherwise succeed (blob offsets present, metadata Transaction rows present,
@@ -866,30 +861,34 @@ func TestEnsureTransactionConsumedUtxosStrictAppliedInputConservation(
 		require.NoError(t, setConsumer(t, db, BatchedTxIngestOpts{}))
 	})
 
-	t.Run("flag on refuses recovery past boundary", func(t *testing.T) {
-		db := newRecoverableDB(t)
-		// No mithril_ledger_slot recorded (0): every slot is past the boundary.
-		err := setConsumer(t, db, BatchedTxIngestOpts{
-			StrictAppliedInputConservation: true,
-		})
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUtxoNotFound)
-		// The block's transaction must not have persisted the recovered row.
-		for _, input := range candidate.consumerTx.Consumed() {
-			utxo, err := db.Metadata().GetUtxoIncludingSpent(
-				input.Id().Bytes(),
-				input.Index(),
-				nil,
-			)
-			require.NoError(t, err)
-			require.Nil(
-				t,
-				utxo,
-				"input %s must not be recovered/persisted under the gate",
-				input.String(),
-			)
-		}
-	})
+	t.Run(
+		"flag on recovers canonical producer past boundary",
+		func(t *testing.T) {
+			db := newRecoverableDB(t)
+			// No mithril_ledger_slot recorded (0): every slot is past the boundary.
+			require.NoError(t, setConsumer(t, db, BatchedTxIngestOpts{
+				StrictAppliedInputConservation: true,
+			}))
+			// The block's transaction must persist the recovered row and mark it
+			// spent by the consumer, just as if rollback restoration had preserved
+			// the row in the first place.
+			for _, input := range candidate.consumerTx.Consumed() {
+				utxo, err := db.Metadata().GetUtxoIncludingSpent(
+					input.Id().Bytes(),
+					input.Index(),
+					nil,
+				)
+				require.NoError(t, err)
+				require.NotNil(
+					t,
+					utxo,
+					"input %s must be recovered/persisted when its producer is canonical",
+					input.String(),
+				)
+				require.Equal(t, candidate.consumerPoint.Slot, utxo.DeletedSlot)
+			}
+		},
+	)
 
 	t.Run("flag on tolerated at or below boundary", func(t *testing.T) {
 		db := newRecoverableDB(t)


### PR DESCRIPTION
## Summary

Allow validated rollback recovery to rehydrate a missing consumed UTxO when its producer remains on the applied primary chain. Producers retained only on abandoned forks remain rejected.

## Validation

- `go test ./database -count=1`
- Focused database and ledger tests
- Focused database and ledger race tests
- `go vet ./database`
- `golangci-lint run ./database`
- `make import-boundaries docs-parity gorm-check`

Full repository test, devnet, and conformance suites were not run.

Fixes #3170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers missing consumed UTxOs during validated rollback when their producer block is still on the applied primary chain, while still rejecting producers from abandoned forks. Previously, at tip with `StrictAppliedInputConservation`, any missing producer past the Mithril boundary errored; now canonical producers are rebuilt, avoiding false stalls after core-mode cleanup and preserving input conservation.

- Boldline changes: `database/transaction.go` gates recovery in `ensureTransactionConsumedUtxos` on primary-chain membership and returns `ErrUtxoNotFound` for off-primary producers; `DATABASE.md` and `ARCHITECTURE.md` document the updated rule; tests assert canonical recovery and continued fork rejection.
- Scope and rollout: applies to validated paths past `mithril_ledger_slot` when `StrictUtxoValidation` is enabled; `BatchedTxIngestOpts.StrictAppliedInputConservation` still marks the steady-state path and requires no caller changes. No schema or config migrations.

<sup>Written for commit 89c92cb1f2c49a3dd6d1229fde5b2a3a46642f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

