### PR TITLE
fix(api): release the listening port before Stop returns

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4143,9 +4143,15 @@ Two consequences worth noting. `Publish` takes a build callback that runs under
 the listener's lock once the already-started check has passed, so each server
 installs its credential verifier atomically with the server it belongs to and a
 rejected second `Start` cannot replace a running server's. `Bind` reports
-whether it actually served the socket rather than closing it, so a `Start`
+whether it handed the socket to `Serve` rather than closing it, so a `Start`
 whose server was detached mid-bind returns without logging that a listener
-came up when none did. And because
+came up when none did. One window stays open by construction: a `Stop` landing
+between the ownership check and `Serve` being entered leaves `Serve` an
+already-closed socket. It is inert — `Serve` reports `ErrServerClosed`, which
+the error filter drops, and the port is released by the `Stop` that closed it —
+so the only trace is the log line. Closing it would require `Serve` to signal
+that it registered the listener, which `net/http` does not expose, and any such
+signal would still lose to a `Stop` landing an instant later. And because
 `api/utxorpc`'s context monitor now detaches rather than holding its mutex
 across the shutdown it runs, a concurrent `Stop` is answered by the teardown
 wait instead of blocking on that mutex for as long as a stuck stream keeps

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4107,7 +4107,16 @@ that safely needs three pieces that only make sense together:
   the context monitor its `Start` launched both race to detach the running
   server and its listener. The winner gets a `Job` and owns completing it; the
   loser gets the winner's completion channel and waits on it (`AwaitTeardown`)
-  rather than reporting the server down while the port is still bound.
+  rather than reporting the server down while the port is still bound. A
+  monitor uses `TakeIf`, which detaches only while the server it published is
+  still the current one: a monitor sits on `ctx.Done()` until its caller's
+  context ends, which can be long after its own server was stopped and a
+  restart published another on the same `Listener`, and an unconditional
+  detach there would tear down a replacement it never published. Today every
+  production caller passes the node's `n.ctx` to both the initial start and
+  every restart (`node.go`, `node_lifecycle.go`), so the two contexts are the
+  same one and the cross-detach is not reachable; `TakeIf` closes it at the
+  protocol level rather than relying on that continuing to hold.
 - **`bindDone` — `Stop` cannot outrun a bind still in flight.** `Bind` closes
   this channel on every exit path, including the one where it finds its server
   already detached and closes its own socket instead of serving it. `Shutdown`
@@ -4133,7 +4142,10 @@ listeners `Serve` registered, which is exactly the set that may be missing ours.
 Two consequences worth noting. `Publish` takes a build callback that runs under
 the listener's lock once the already-started check has passed, so each server
 installs its credential verifier atomically with the server it belongs to and a
-rejected second `Start` cannot replace a running server's. And because
+rejected second `Start` cannot replace a running server's. `Bind` reports
+whether it actually served the socket rather than closing it, so a `Start`
+whose server was detached mid-bind returns without logging that a listener
+came up when none did. And because
 `api/utxorpc`'s context monitor now detaches rather than holding its mutex
 across the shutdown it runs, a concurrent `Stop` is answered by the teardown
 wait instead of blocking on that mutex for as long as a stuck stream keeps

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1575,7 +1575,12 @@ not to the caller actually calling `cancel()` ahead of it — so `Stop`'s
 the same hard `Close` immediately if the caller gives up before either the
 timer or a graceful `Shutdown` completes; a live database restore/truncate
 quiesce cancelling its own `ctx` to abandon a slow shutdown no longer
-stalls for the rest of `ShutdownTimeout`.
+stalls for the rest of `ShutdownTimeout`. That escalation is now supplied to
+the shared listener lifecycle as `api/utxorpc`'s own `ShutdownFunc` rather
+than being `Stop`'s whole body — the surrounding protocol, including
+releasing the listening socket before `Stop` returns so this same
+reinitialization can rebind the port, is `internal/apilistener`'s; see "API
+listener lifecycle" below.
 
 A caller-supplied `connmanager.ListenerConfig.Listener` (a test harness binding an OS-assigned port up front and handing the listener object itself to the node, rather than an address string, so a peer can be told the exact port with no discovery race — see `node_lifecycle_multinode_test.go`'s `newLoopbackListener`) needs its own handling across this quiesce/reinit cycle: `ConnectionManager.Stop`'s `stopListeners` closes every listener it is tracking unconditionally, with no way to distinguish one it created itself from one a caller handed it, and a closed `net.Listener` can never be reused. `reinitializeNetworkingCore` rebuilds `connManager` from `n.config.listeners` via `ouroboros.ConfigureListeners`, which only appends connection options and never touches `.Listener` — so without further handling, the same now-closed listener object would be fed straight back in, `connmanager.startListener` would skip rebinding (it only binds fresh when `.Listener == nil`), and the accept loop launched on it would exit immediately on `net.ErrClosed` while `connManager.Start` still returned successfully, silently leaving that listener permanently deaf to new inbound connections after the very first live Restore/Truncate. `ConnectionManager.ResolvedListeners` (called right after every successful `connManager.Start`, both at initial startup in `node.go` and after every reinit in `node_lifecycle.go`) closes this gap: for any listener config entry that came in with a caller-supplied `Listener`, it replaces that field with the concrete `ListenNetwork`/`ListenAddress` the listener actually resolved to (nil-ing `Listener` out), so the next reinit rebinds a fresh listener at that same address instead of trying to reuse the dead object — exactly the self-healing behavior an address-configured entry already had. Entries that started address-configured are left untouched entirely. A caller-supplied Windows named-pipe listener is a special case even though it does get its `Listener` field cleared here: `ListenNetwork` is deliberately *not* overwritten with the resolved listener's own `Addr().Network()` when it is already `"unix"`, because on Windows that value is a cross-platform sentinel meaning "reconstruct via `createPipeListener`" (checked by `startListener`'s pipe-creation branch), while the real `go-winio` pipe listener's `Addr().Network()` reports `"pipe"` — copying that raw value in would silently break the sentinel and make the next reinit's rebind fail.
 
@@ -4075,6 +4080,70 @@ without one.
   Authentication has no legacy root field at all — its default is simply
   `"disabled"` everywhere, so existing reverse-proxy/no-auth deployments
   are unaffected regardless.
+
+### API listener lifecycle (`internal/apilistener`)
+
+All three API servers (`api/blockfrost`, `api/mesh`, `api/utxorpc`) share one
+start/stop protocol rather than each implementing its own, because the way they
+bind makes a correct `Stop` genuinely subtle and the subtlety is identical in
+all three.
+
+The problem is that `http.Server.Shutdown` closes only the listeners `Serve`
+has already registered, and each server opens its socket synchronously — so a
+port conflict surfaces as an error from `Start` rather than a log line from a
+goroutine nobody is watching — then hands it to `Serve` in a goroutine it does
+not wait for. A `Stop` landing inside that window finds a server with nothing
+registered and returns with the port still bound. This is not a test-only
+concern: `quiesceForLiveLifecycleOp` stops these capabilities and
+`reinitializeAPIServers` re-resolves them on the same configured port
+(`node_lifecycle.go`), so any live Restore or Truncate could fail to rebind
+with `EADDRINUSE`. An instrumented 500-iteration probe left the port accepting
+in roughly 9% of runs before the fix.
+
+Releasing the port is therefore something `Stop` has to do itself, and doing
+that safely needs three pieces that only make sense together:
+
+- **`Take` — exactly one caller tears a server down.** A server's `Stop` and
+  the context monitor its `Start` launched both race to detach the running
+  server and its listener. The winner gets a `Job` and owns completing it; the
+  loser gets the winner's completion channel and waits on it (`AwaitTeardown`)
+  rather than reporting the server down while the port is still bound.
+- **`bindDone` — `Stop` cannot outrun a bind still in flight.** `Bind` closes
+  this channel on every exit path, including the one where it finds its server
+  already detached and closes its own socket instead of serving it. `Shutdown`
+  waits on it, which is what lets `Stop` promise the port is free when it
+  returns rather than merely that closing has started. A bind wait that times
+  out still tears down what it detached — the detach made this caller the only
+  remaining reference to that socket — but deliberately does *not* signal
+  completion to a waiting second caller, because `Bind` still owns a socket it
+  could not close.
+- **`teardown` — the loser's wait is honest.** Only a genuinely finished
+  teardown closes it, so a caller that reads it as "the port is free" is right.
+
+`ShutdownFunc` is the one axis the three servers differ on. `apilistener.Graceful`
+(plain `http.Server.Shutdown`) covers Blockfrost and Mesh. `api/utxorpc` supplies
+its own, keeping the escalation described under "Live database lifecycle
+operations" above: `WatchTx`/`WatchMempool` are unbounded streaming RPCs, so a
+connected client can keep `Shutdown` blocked indefinitely, and a `ShutdownTimeout`
+timer (or the caller `ctx`'s own deadline, or its cancellation) escalates to a
+hard `Close`. The socket close runs after whichever path that function takes, so
+the escalation paths release the port too — `server.Close()` reaches only the
+listeners `Serve` registered, which is exactly the set that may be missing ours.
+
+Two consequences worth noting. `Publish` takes a build callback that runs under
+the listener's lock once the already-started check has passed, so each server
+installs its credential verifier atomically with the server it belongs to and a
+rejected second `Start` cannot replace a running server's. And because
+`api/utxorpc`'s context monitor now detaches rather than holding its mutex
+across the shutdown it runs, a concurrent `Stop` is answered by the teardown
+wait instead of blocking on that mutex for as long as a stuck stream keeps
+`Shutdown` busy.
+
+The protocol's own tests live with it in `internal/apilistener`, including the
+paths that need a bind still in flight when a wait expires — a real bind settles
+far too quickly to race, so those windows are constructed. Each API package
+keeps the black-box checks that it is wired to the protocol: the port is free
+when `Stop` returns, and the address is rebindable afterwards.
 
 ### Blockfrost API (`api/blockfrost/`)
 

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -320,10 +320,11 @@ func (b *Blockfrost) Start(
 	// server down: Take is what makes an in-flight bind close its own socket.
 	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
-		job, _ := b.listener.Take()
-		// A concurrent Stop may have won the detach. It owns the teardown
-		// and its caller is already waiting on it, so there is nothing to
-		// do and nothing to wait for here.
+		job, _ := b.listener.TakeIf(server)
+		// Nil when a concurrent Stop won the detach -- it owns the teardown
+		// and its caller is already waiting on it -- or when this server was
+		// already stopped and a restart published another one, which is not
+		// this monitor's to touch. Either way there is nothing to do here.
 		if job != nil {
 			b.logger.Debug(
 				"context cancelled, shutting down " +
@@ -352,9 +353,16 @@ func (b *Blockfrost) Start(
 	// Bound with deterministic error detection: the socket is opened
 	// synchronously so a port conflict surfaces here rather than in a log line
 	// from a goroutine nobody is watching.
-	if err := b.listener.Bind(server, bindDone, b.config.TLS); err != nil {
+	served, err := b.listener.Bind(server, bindDone, b.config.TLS)
+	if err != nil {
 		b.listener.Unpublish(server)
 		return err
+	}
+	if !served {
+		// A concurrent Stop or context cancellation detached this server while
+		// it was binding, so Bind closed the socket rather than serving it.
+		// Saying the listener came up would be false.
+		return nil
 	}
 
 	b.logger.Info(

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -16,18 +16,15 @@ package blockfrost
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/blinklabs-io/dingo/internal/apiauth"
+	"github.com/blinklabs-io/dingo/internal/apilistener"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
-	"github.com/blinklabs-io/dingo/internal/tlsutil"
 )
 
 // blockfrostProjectIDHeader is the header real Blockfrost clients send
@@ -39,12 +36,14 @@ const blockfrostProjectIDHeader = "project_id"
 
 // Blockfrost is the Blockfrost-compatible REST API server.
 type Blockfrost struct {
-	config     BlockfrostConfig
-	logger     *slog.Logger
-	node       BlockfrostNode
-	httpServer *http.Server
-	verifier   *apiauth.Verifier
-	mu         sync.Mutex
+	config BlockfrostConfig
+	logger *slog.Logger
+	node   BlockfrostNode
+	// listener owns the start/stop protocol, including releasing the
+	// listening socket as part of what Stop waits for -- see
+	// internal/apilistener.
+	listener *apilistener.Listener
+	verifier *apiauth.Verifier
 }
 
 // New creates a new Blockfrost API server instance.
@@ -63,9 +62,10 @@ func New(
 		cfg.ListenAddress = ":3000"
 	}
 	return &Blockfrost{
-		config: cfg,
-		logger: logger,
-		node:   node,
+		config:   cfg,
+		logger:   logger,
+		node:     node,
+		listener: apilistener.New("Blockfrost API", logger),
 	}
 }
 
@@ -299,45 +299,32 @@ func (b *Blockfrost) Start(
 	if err != nil {
 		return fmt.Errorf("blockfrost: %w", err)
 	}
-	b.mu.Lock()
-	if b.httpServer != nil {
-		b.mu.Unlock()
-		return errors.New("server already started")
-	}
-	b.verifier = verifier
-
-	server := &http.Server{
-		Addr:              b.config.ListenAddress,
-		Handler:           b.handler(),
-		ReadHeaderTimeout: 60 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       120 * time.Second,
-	}
-	b.httpServer = server
-	b.mu.Unlock()
-
-	// Start the server with deterministic error detection
-	if err := b.startServer(server); err != nil {
-		b.mu.Lock()
-		b.httpServer = nil
-		b.mu.Unlock()
+	// The verifier is installed inside the build callback so it is published
+	// with the server it belongs to: a second Start is rejected before the
+	// callback runs, and so cannot replace a running server's verifier.
+	server, bindDone, err := b.listener.Publish(func() *http.Server {
+		b.verifier = verifier
+		return &http.Server{
+			Addr:              b.config.ListenAddress,
+			Handler:           b.handler(),
+			ReadHeaderTimeout: 60 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+	})
+	if err != nil {
 		return err
 	}
 
-	b.logger.Info(
-		"Blockfrost API listener started on " +
-			b.config.ListenAddress,
-	)
-
-	// Monitor context for cancellation
+	// Launched before the bind so a context cancelled mid-bind still tears the
+	// server down: Take is what makes an in-flight bind close its own socket.
 	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
-		b.mu.Lock()
-		srv := b.httpServer
-		b.httpServer = nil
-		b.mu.Unlock()
-
-		if srv != nil {
+		job, _ := b.listener.Take()
+		// A concurrent Stop may have won the detach. It owns the teardown
+		// and its caller is already waiting on it, so there is nothing to
+		// do and nothing to wait for here.
+		if job != nil {
 			b.logger.Debug(
 				"context cancelled, shutting down " +
 					"Blockfrost API server",
@@ -349,8 +336,8 @@ func (b *Blockfrost) Start(
 			)
 			defer cancel()
 			//nolint:contextcheck
-			if err := srv.Shutdown(
-				shutdownCtx,
+			if err := b.listener.Shutdown(
+				shutdownCtx, job, apilistener.Graceful,
 			); err != nil {
 				b.logger.Error(
 					"failed to shutdown Blockfrost "+
@@ -362,75 +349,31 @@ func (b *Blockfrost) Start(
 		}
 	}()
 
+	// Bound with deterministic error detection: the socket is opened
+	// synchronously so a port conflict surfaces here rather than in a log line
+	// from a goroutine nobody is watching.
+	if err := b.listener.Bind(server, bindDone, b.config.TLS); err != nil {
+		b.listener.Unpublish(server)
+		return err
+	}
+
+	b.logger.Info(
+		"Blockfrost API listener started on " +
+			b.config.ListenAddress,
+	)
+
 	return nil
 }
 
-// Stop gracefully shuts down the HTTP server.
+// Stop gracefully shuts down the HTTP server, and does not return until the
+// listening socket has been released -- see internal/apilistener.
 func (b *Blockfrost) Stop(
 	ctx context.Context,
 ) error {
-	b.mu.Lock()
-	srv := b.httpServer
-	b.httpServer = nil
-	b.mu.Unlock()
-
-	if srv != nil {
-		b.logger.Debug(
-			"shutting down Blockfrost API server",
-		)
-		if err := srv.Shutdown(ctx); err != nil {
-			return fmt.Errorf(
-				"failed to shutdown Blockfrost API "+
-					"server: %w",
-				err,
-			)
-		}
+	job, inFlight := b.listener.Take()
+	if job == nil {
+		return b.listener.AwaitTeardown(ctx, inFlight)
 	}
-	return nil
-}
-
-// startServer starts the HTTP server with deterministic
-// error detection. It binds the listening socket first so
-// port conflicts are detected immediately, then serves in
-// a background goroutine.
-func (b *Blockfrost) startServer(
-	server *http.Server,
-) error {
-	useTLS := b.config.TLS.Enabled
-	if useTLS {
-		if err := tlsutil.ConfigureServerTLS(
-			server,
-			b.config.TLS.CertFilePath,
-			b.config.TLS.KeyFilePath,
-		); err != nil {
-			return fmt.Errorf(
-				"failed to load TLS keypair for Blockfrost API server: %w",
-				err,
-			)
-		}
-	}
-	ln, err := net.Listen("tcp", server.Addr)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to listen for Blockfrost API "+
-				"server: %w",
-			err,
-		)
-	}
-	go func() {
-		var serveErr error
-		if useTLS {
-			serveErr = server.ServeTLS(ln, "", "")
-		} else {
-			serveErr = server.Serve(ln)
-		}
-		if serveErr != nil &&
-			!errors.Is(serveErr, http.ErrServerClosed) {
-			b.logger.Error(
-				"Blockfrost API server error",
-				"error", serveErr,
-			)
-		}
-	}()
-	return nil
+	b.logger.Debug("shutting down Blockfrost API server")
+	return b.listener.Shutdown(ctx, job, apilistener.Graceful)
 }

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -563,9 +563,7 @@ func TestStartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify server is running
-	b.mu.Lock()
-	assert.NotNil(t, b.httpServer)
-	b.mu.Unlock()
+	assert.NotNil(t, b.listener.Server())
 
 	// Stop the server
 	stopCtx, stopCancel := context.WithTimeout(
@@ -577,9 +575,7 @@ func TestStartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify server is stopped
-	b.mu.Lock()
-	assert.Nil(t, b.httpServer)
-	b.mu.Unlock()
+	assert.Nil(t, b.listener.Server())
 }
 
 func TestStartAlreadyStarted(t *testing.T) {
@@ -3272,8 +3268,11 @@ func TestNodeAdapterAddressRejectsInvalidInput(t *testing.T) {
 		)
 		require.True(t, strings.HasPrefix(err.Error(), prefix),
 			"unexpected wrapper shape: %s", err)
-		assert.NotEmpty(t, strings.TrimSpace(strings.TrimPrefix(err.Error(), prefix)),
-			"the underlying parse error is retained, not discarded")
+		assert.NotEmpty(
+			t,
+			strings.TrimSpace(strings.TrimPrefix(err.Error(), prefix)),
+			"the underlying parse error is retained, not discarded",
+		)
 	})
 
 	t.Run("this network resolves to not found", func(t *testing.T) {

--- a/api/blockfrost/listener_test.go
+++ b/api/blockfrost/listener_test.go
@@ -15,12 +15,25 @@
 package blockfrost
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// stopNow shuts srv down under a bounded context, matching the package's
+// existing convention (tls_auth_test.go): a hang in the teardown path should
+// fail the test rather than stall the suite until go test's own timeout.
+func stopNow(t *testing.T, srv *Blockfrost) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 5*time.Second,
+	)
+	defer cancel()
+	return srv.Stop(ctx)
+}
 
 // The shutdown protocol these two tests exercise is covered in depth, with the
 // windows constructed rather than raced, in internal/apilistener. What is
@@ -37,7 +50,7 @@ func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
 			t, t.Context(), BlockfrostConfig{},
 		)
 
-		require.NoError(t, srv.Stop(t.Context()))
+		require.NoError(t, stopNow(t, srv))
 
 		require.False(
 			t, portAccepts(addr),
@@ -54,7 +67,7 @@ func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
 // left that restart failing with EADDRINUSE.
 func TestServerRebindsAfterStop(t *testing.T) {
 	srv, addr := startOnFreePort(t, t.Context(), BlockfrostConfig{})
-	require.NoError(t, srv.Stop(t.Context()))
+	require.NoError(t, stopNow(t, srv))
 
 	restarted := New(
 		BlockfrostConfig{ListenAddress: addr}, &mockNode{}, nil,
@@ -63,7 +76,7 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		t, restarted.Start(t.Context()),
 		"a capability restart must rebind the port Stop released",
 	)
-	require.NoError(t, restarted.Stop(t.Context()))
+	require.NoError(t, stopNow(t, restarted))
 }
 
 // portAccepts reports whether a TCP connection to addr succeeds.

--- a/api/blockfrost/listener_test.go
+++ b/api/blockfrost/listener_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The shutdown protocol these two tests exercise is covered in depth, with the
+// windows constructed rather than raced, in internal/apilistener. What is
+// checked here is that this package is wired to it -- that a Blockfrost server
+// keeps the promise its Stop makes.
+
+// TestServerStopReleasesPortBeforeServeRegisters covers the window between
+// net.Listen and Serve registering that listener with the http.Server.
+// http.Server.Shutdown closes only registered listeners, so a Stop landing
+// inside the window used to return with the port still bound.
+func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
+	for i := range 100 {
+		srv, addr := startOnFreePort(
+			t, t.Context(), BlockfrostConfig{},
+		)
+
+		require.NoError(t, srv.Stop(t.Context()))
+
+		require.False(
+			t, portAccepts(addr),
+			"listener still accepting when Stop returned "+
+				"(iteration %d)", i,
+		)
+	}
+}
+
+// TestServerRebindsAfterStop is the production path this fix exists for: a
+// live database restore or truncate quiesces the API capabilities and
+// reinitializeAPIServers brings them back up on the same configured port (see
+// node_lifecycle.go). A Stop that returned while the socket was still bound
+// left that restart failing with EADDRINUSE.
+func TestServerRebindsAfterStop(t *testing.T) {
+	srv, addr := startOnFreePort(t, t.Context(), BlockfrostConfig{})
+	require.NoError(t, srv.Stop(t.Context()))
+
+	restarted := New(
+		BlockfrostConfig{ListenAddress: addr}, &mockNode{}, nil,
+	)
+	require.NoError(
+		t, restarted.Start(t.Context()),
+		"a capability restart must rebind the port Stop released",
+	)
+	require.NoError(t, restarted.Stop(t.Context()))
+}
+
+// portAccepts reports whether a TCP connection to addr succeeds.
+func portAccepts(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -236,8 +236,13 @@ func TestServerBindFailure(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to listen")
-	// A failed start must leave the server restartable.
-	require.Nil(t, srv.httpServer)
+
+	// A failed start must leave the server restartable rather than holding a
+	// server it never brought up, so a retry once the address frees up is not
+	// refused as "already started".
+	require.NoError(t, occupied.Close())
+	require.NoError(t, srv.Start(t.Context()))
+	require.NoError(t, srv.Stop(t.Context()))
 }
 
 // TestServerDoubleStart asserts a second Start is refused rather than
@@ -302,192 +307,6 @@ func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
 	}
 }
 
-// TestStartServerReleasesListenerWhenServerAlreadyDetached covers the
-// window between Start publishing s.httpServer and startServer recording
-// the listener. A Stop landing inside it detaches the server, so takeServer
-// later hands back a nil server and shutdownServer never runs -- meaning
-// startServer must not leave its own socket bound, and must not overwrite
-// the listener of whichever server is current now.
-func TestStartServerReleasesListenerWhenServerAlreadyDetached(t *testing.T) {
-	srv := newTestServer(t, newTestDeps())
-	addr := testutil.FreePort(t)
-
-	// Stands in for the server a concurrent restart already published;
-	// it must survive this call untouched.
-	currentListener, err := net.Listen("tcp", testutil.FreePort(t))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = currentListener.Close() })
-	current := &http.Server{Addr: currentListener.Addr().String()}
-	srv.mu.Lock()
-	srv.httpServer = current
-	srv.listener = currentListener
-	srv.mu.Unlock()
-
-	// The detached server this startServer call is bringing up.
-	detached := &http.Server{Addr: addr}
-	bindDone := make(chan struct{})
-	require.NoError(t, srv.startServer(detached, bindDone))
-	testutil.RequireReceive(
-		t, bindDone, time.Second,
-		"startServer must signal that the bind settled",
-	)
-
-	require.False(
-		t, portAccepts(addr),
-		"startServer must not leave a stopped server's port bound",
-	)
-	srv.mu.Lock()
-	defer srv.mu.Unlock()
-	require.Same(
-		t, current, srv.httpServer,
-		"startServer must not disturb the current server",
-	)
-	require.Same(
-		t, currentListener, srv.listener,
-		"startServer must not overwrite the current server's listener",
-	)
-}
-
-// TestStopWaitsForAnInFlightBind asserts Stop does not report the server
-// down while a startServer call is still between net.Listen and releasing
-// its socket. Detaching the server is what makes that bind close its own
-// listener, so without waiting here Stop could return -- and a caller could
-// rebind the same port -- while the old socket was still open.
-func TestStopWaitsForAnInFlightBind(t *testing.T) {
-	srv := newTestServer(t, newTestDeps())
-
-	// Stands in for Start having published a server and a bind that has
-	// not finished yet.
-	bindDone := make(chan struct{})
-	srv.mu.Lock()
-	srv.httpServer = &http.Server{Addr: testutil.FreePort(t)}
-	srv.bindDone = bindDone
-	srv.mu.Unlock()
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
-	err := srv.Stop(ctx)
-	require.ErrorIs(
-		t, err, context.DeadlineExceeded,
-		"Stop must wait for the in-flight bind rather than returning",
-	)
-
-	// Once the bind settles, Stop completes.
-	close(bindDone)
-	require.NoError(t, srv.Stop(t.Context()))
-}
-
-// TestStopTearsDownEvenWhenTheBindWaitTimesOut asserts a Stop whose context
-// expires mid-wait still releases the socket it detached. The detach is what
-// makes Stop the only remaining reference to that listener, so returning the
-// wait error without tearing down would leave the port bound with nothing left
-// able to close it.
-func TestStopTearsDownEvenWhenTheBindWaitTimesOut(t *testing.T) {
-	srv := newTestServer(t, newTestDeps())
-	addr := testutil.FreePort(t)
-	ln, err := net.Listen("tcp", addr)
-	require.NoError(t, err)
-
-	// A published listener plus a bind that never settles.
-	srv.mu.Lock()
-	srv.httpServer = &http.Server{Addr: addr}
-	srv.listener = ln
-	srv.bindDone = make(chan struct{})
-	srv.mu.Unlock()
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
-	require.ErrorIs(t, srv.Stop(ctx), context.DeadlineExceeded)
-
-	require.False(
-		t, portAccepts(addr),
-		"Stop must release the socket it detached even when the bind "+
-			"wait times out",
-	)
-}
-
-// TestStopWaitsForATeardownItLost asserts the loser of the takeServer race
-// does not report the server down early. Stop and the context monitor both
-// detach; only one wins, and a Stop that returned nil while the winner was
-// still releasing the port would let an immediate restart fail to bind.
-func TestStopWaitsForATeardownItLost(t *testing.T) {
-	srv := newTestServer(t, newTestDeps())
-
-	// Stands in for another caller having already detached the server and
-	// still being mid-teardown.
-	teardown := make(chan struct{})
-	srv.mu.Lock()
-	srv.httpServer = nil
-	srv.teardown = teardown
-	srv.mu.Unlock()
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
-	require.ErrorIs(
-		t, srv.Stop(ctx), context.DeadlineExceeded,
-		"Stop must wait for the teardown it lost rather than returning nil",
-	)
-
-	close(teardown)
-	require.NoError(t, srv.Stop(t.Context()))
-}
-
-// TestAwaitTeardownPrefersACompletedTeardown asserts a finished teardown is
-// never reported as a timeout. When the completion channel and the context are
-// both ready, select picks at random, so the loop is what makes the absence of
-// a recheck fail rather than flake.
-func TestAwaitTeardownPrefersACompletedTeardown(t *testing.T) {
-	done := make(chan struct{})
-	close(done)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	for i := range 200 {
-		require.NoError(
-			t, awaitTeardown(ctx, done),
-			"a completed teardown must not be reported as a timeout "+
-				"(iteration %d)", i,
-		)
-	}
-}
-
-// TestTimedOutTeardownDoesNotSignalCompletionEarly asserts a Stop whose bind
-// wait times out does not mark the teardown complete. startServer still owns a
-// socket that Stop cannot close, so a second caller waiting on the teardown has
-// to keep waiting rather than read it as "the port is free".
-func TestTimedOutTeardownDoesNotSignalCompletionEarly(t *testing.T) {
-	srv := newTestServer(t, newTestDeps())
-	bindDone := make(chan struct{})
-
-	srv.mu.Lock()
-	srv.httpServer = &http.Server{Addr: testutil.FreePort(t)}
-	srv.bindDone = bindDone
-	srv.mu.Unlock()
-
-	// First caller detaches and times out waiting for the bind.
-	stopCtx, cancelStop := context.WithTimeout(
-		context.Background(),
-		100*time.Millisecond,
-	)
-	defer cancelStop()
-	require.ErrorIs(t, srv.Stop(stopCtx), context.DeadlineExceeded)
-
-	// Second caller lost the detach and must not be told the teardown is done.
-	loserCtx, cancelLoser := context.WithTimeout(
-		context.Background(),
-		100*time.Millisecond,
-	)
-	defer cancelLoser()
-	require.ErrorIs(
-		t, srv.Stop(loserCtx), context.DeadlineExceeded,
-		"a teardown blocked on an in-flight bind must not report completion",
-	)
-
-	// Once the bind settles the teardown is genuinely complete.
-	close(bindDone)
-	require.NoError(t, srv.Stop(t.Context()))
-}
-
 // TestConcurrentStartStopNeverLeavesThePortBound hammers the interleavings the
 // individual lifecycle tests each pin one of: Start racing Stop, Stop racing the
 // context monitor, and a restart on the same address immediately after.
@@ -498,11 +317,9 @@ func TestTimedOutTeardownDoesNotSignalCompletionEarly(t *testing.T) {
 // What this does NOT cover, verified by running it against the earlier buggy
 // revisions, where it passed: the paths that need a bind still in flight when a
 // wait expires. A real bind settles far too quickly for that, so a stalled bind
-// has to be constructed. Those live in
-// TestStopTearsDownEvenWhenTheBindWaitTimesOut,
-// TestStopWaitsForATeardownItLost, and
-// TestTimedOutTeardownDoesNotSignalCompletionEarly, each checked against the
-// defect it names. Do not read a pass here as covering them.
+// has to be constructed, which needs the protocol's internals. Those tests live
+// with the protocol, in internal/apilistener. Do not read a pass here as
+// covering them.
 func TestConcurrentStartStopNeverLeavesThePortBound(t *testing.T) {
 	addr := testutil.FreePort(t)
 
@@ -712,9 +529,7 @@ func TestRequestBodyAtLimitIsAccepted(t *testing.T) {
 func TestServerTimeoutsAreConfigured(t *testing.T) {
 	srv, _ := startTestServer(t, newTestDeps())
 
-	srv.mu.Lock()
-	httpServer := srv.httpServer
-	srv.mu.Unlock()
+	httpServer := srv.listener.Server()
 
 	require.NotNil(t, httpServer)
 	require.Equal(

--- a/api/mesh/mesh.go
+++ b/api/mesh/mesh.go
@@ -219,10 +219,11 @@ func (s *Server) Start(ctx context.Context) error {
 	// server down: Take is what makes an in-flight bind close its own socket.
 	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
-		job, _ := s.listener.Take()
-		// A concurrent Stop may have won the detach. It owns the teardown
-		// and its caller is already waiting on it, so there is nothing to
-		// do and nothing to wait for here.
+		job, _ := s.listener.TakeIf(server)
+		// Nil when a concurrent Stop won the detach -- it owns the teardown
+		// and its caller is already waiting on it -- or when this server was
+		// already stopped and a restart published another one, which is not
+		// this monitor's to touch. Either way there is nothing to do here.
 		if job != nil {
 			s.logger.Debug(
 				"context cancelled, shutting down " +
@@ -248,9 +249,16 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 
-	if err := s.listener.Bind(server, bindDone, s.config.TLS); err != nil {
+	served, err := s.listener.Bind(server, bindDone, s.config.TLS)
+	if err != nil {
 		s.listener.Unpublish(server)
 		return err
+	}
+	if !served {
+		// A concurrent Stop or context cancellation detached this server while
+		// it was binding, so Bind closed the socket rather than serving it.
+		// Saying the listener came up would be false.
+		return nil
 	}
 
 	s.logger.Info(

--- a/api/mesh/mesh.go
+++ b/api/mesh/mesh.go
@@ -22,15 +22,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/apilistener"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
-	"github.com/blinklabs-io/dingo/internal/tlsutil"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
@@ -85,19 +83,11 @@ type Server struct {
 	genesisID           *BlockIdentifier
 	genesisStartTimeSec int64
 	addrNetworkID       uint8
-	httpServer          *http.Server
-	listener            net.Listener
-	// bindDone is closed by startServer once the listening socket has been
-	// either published on s.listener or closed again. Stop waits on it so a
-	// bind still in flight cannot outlive the Stop that raced it.
-	bindDone chan struct{}
-	// teardown is closed once the caller that detached the server has
-	// finished shutting it down. Stop and the context monitor race to detach;
-	// the loser gets no server back and would otherwise report the server
-	// down while the winner's shutdown was still releasing the port.
-	teardown chan struct{}
+	// listener owns the start/stop protocol, including releasing the
+	// listening socket as part of what Stop waits for -- see
+	// internal/apilistener.
+	listener *apilistener.Listener
 	verifier *apiauth.Verifier
-	mu       sync.Mutex
 }
 
 // NewServer creates a new Mesh API server instance.
@@ -179,6 +169,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		genesisID:           genesisID,
 		genesisStartTimeSec: cfg.GenesisStartTimeSec,
 		addrNetworkID:       addrNetID,
+		listener:            apilistener.New("Mesh API", logger),
 	}, nil
 }
 
@@ -190,47 +181,45 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("mesh: %w", err)
 	}
-	s.mu.Lock()
-	if s.httpServer != nil {
-		s.mu.Unlock()
-		return errors.New("server already started")
+	// The verifier is installed inside the build callback so it is published
+	// with the server it belongs to: a second Start is rejected before the
+	// callback runs, and so cannot replace a running server's verifier.
+	server, bindDone, err := s.listener.Publish(func() *http.Server {
+		s.verifier = verifier
+		mux := http.NewServeMux()
+		s.registerRoutes(mux)
+
+		// CORS must wrap authentication, not the reverse: httpcors.Handler
+		// fully answers an OPTIONS preflight itself and never calls the
+		// handler it wraps for one, so browsers -- which never attach
+		// Authorization to a preflight request -- never need a credential to
+		// pass CORS negotiation. Every other request, including a
+		// non-preflight OPTIONS, still reaches the mux normally. See
+		// internal/apiauth's Middleware doc comment for the general statement
+		// of this ordering rule.
+		authenticated := apiauth.Middleware(s.verifier)(mux)
+		return &http.Server{
+			Addr: s.config.ListenAddress,
+			Handler: httpcors.Handler(
+				authenticated,
+				httpcors.Config{
+					AllowedOrigins: s.config.CORSAllowedOrigins,
+				},
+			),
+			ReadHeaderTimeout: 60 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+	})
+	if err != nil {
+		return err
 	}
-	s.verifier = verifier
 
-	mux := http.NewServeMux()
-	s.registerRoutes(mux)
-
-	// CORS must wrap authentication, not the reverse: httpcors.Handler
-	// fully answers an OPTIONS preflight itself and never calls the
-	// handler it wraps for one, so browsers -- which never attach
-	// Authorization to a preflight request -- never need a credential to
-	// pass CORS negotiation. Every other request, including a
-	// non-preflight OPTIONS, still reaches the mux normally. See
-	// internal/apiauth's Middleware doc comment for the general statement
-	// of this ordering rule.
-	authenticated := apiauth.Middleware(s.verifier)(mux)
-	server := &http.Server{
-		Addr: s.config.ListenAddress,
-		Handler: httpcors.Handler(
-			authenticated,
-			httpcors.Config{
-				AllowedOrigins: s.config.CORSAllowedOrigins,
-			},
-		),
-		ReadHeaderTimeout: 60 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       120 * time.Second,
-	}
-	s.httpServer = server
-	bindDone := make(chan struct{})
-	s.bindDone = bindDone
-
-	// Launch context monitor before unlocking so there
-	// is no window where Stop() could race with the
-	// goroutine not yet existing.
+	// Launched before the bind so a context cancelled mid-bind still tears the
+	// server down: Take is what makes an in-flight bind close its own socket.
 	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
-		job, _ := s.takeServer()
+		job, _ := s.listener.Take()
 		// A concurrent Stop may have won the detach. It owns the teardown
 		// and its caller is already waiting on it, so there is nothing to
 		// do and nothing to wait for here.
@@ -246,7 +235,9 @@ func (s *Server) Start(ctx context.Context) error {
 			)
 			defer cancel()
 			//nolint:contextcheck
-			if err := s.shutdown(shutdownCtx, job); err != nil {
+			if err := s.listener.Shutdown(
+				shutdownCtx, job, apilistener.Graceful,
+			); err != nil {
 				s.logger.Error(
 					"failed to shutdown Mesh API "+
 						"server on context "+
@@ -257,19 +248,8 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 
-	s.mu.Unlock()
-
-	if err := s.startServer(server, bindDone); err != nil {
-		s.mu.Lock()
-		// Guarded: an overlapping Stop or restart may already have
-		// detached or replaced this server, and clearing the fields
-		// unconditionally would discard the newer one. Cleared as a set,
-		// matching takeServer, so "no server present" never leaves a
-		// listener or bind channel behind for the next caller to find.
-		if s.httpServer == server {
-			s.httpServer, s.listener, s.bindDone = nil, nil, nil
-		}
-		s.mu.Unlock()
+	if err := s.listener.Bind(server, bindDone, s.config.TLS); err != nil {
+		s.listener.Unpublish(server)
 		return err
 	}
 
@@ -281,223 +261,15 @@ func (s *Server) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts down the HTTP server.
+// Stop gracefully shuts down the HTTP server, and does not return until the
+// listening socket has been released -- see internal/apilistener.
 func (s *Server) Stop(ctx context.Context) error {
-	job, inFlight := s.takeServer()
+	job, inFlight := s.listener.Take()
 	if job == nil {
-		return awaitTeardown(ctx, inFlight)
+		return s.listener.AwaitTeardown(ctx, inFlight)
 	}
 	s.logger.Debug("shutting down Mesh API server")
-	return s.shutdown(ctx, job)
-}
-
-// shutdownJob is everything one caller detaches from the Server in order to
-// tear it down, including the channel it must close when finished.
-type shutdownJob struct {
-	srv      *http.Server
-	ln       net.Listener
-	bindDone chan struct{}
-	done     chan struct{}
-}
-
-// takeServer detaches the running HTTP server and its listener so exactly one
-// caller shuts them down: Stop and the context monitor started by Start both
-// race for them.
-//
-// The winner gets a job and owns closing job.done. The loser gets a nil job and
-// the winner's completion channel, which it must wait on — returning early
-// would report the server down while the port was still bound, and an immediate
-// restart on the same port would then fail to bind.
-func (s *Server) takeServer() (*shutdownJob, chan struct{}) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.httpServer == nil {
-		// Either never started, or someone else is already tearing it down.
-		return nil, s.teardown
-	}
-	job := &shutdownJob{
-		srv:      s.httpServer,
-		ln:       s.listener,
-		bindDone: s.bindDone,
-		done:     make(chan struct{}),
-	}
-	s.httpServer, s.listener, s.bindDone = nil, nil, nil
-	s.teardown = job.done
-	return job, nil
-}
-
-// shutdown runs one detached job to completion and reports what went wrong.
-// The bind wait is not allowed to skip the teardown: a caller whose context
-// expires mid-wait still holds the only reference to a bound socket, so
-// returning early would leave the port bound with nothing left to close it.
-func (s *Server) shutdown(ctx context.Context, job *shutdownJob) error {
-	waitErr := awaitBind(ctx, job.bindDone)
-	stopErr := shutdownServer(ctx, job.srv, job.ln)
-	if waitErr == nil {
-		close(job.done)
-		return stopErr
-	}
-	// The bind is still in flight, so startServer still owns a socket this
-	// call cannot close. Closing job.done now would let a waiting Stop report
-	// the server down while that socket was still bound. startServer always
-	// closes bindDone on its way out -- and closes its own listener once it
-	// sees the detach -- so hand the signalling off until then, which also
-	// bounds this goroutine.
-	go func() {
-		<-job.bindDone
-		close(job.done)
-	}()
-	return errors.Join(waitErr, stopErr)
-}
-
-// awaitTeardown waits for another caller's in-flight shutdown to finish.
-func awaitTeardown(ctx context.Context, done chan struct{}) error {
-	return awaitSignal(ctx, done, "an in-flight Mesh API shutdown")
-}
-
-// awaitSignal waits for ch to close, bounded by ctx. A nil channel has nothing
-// to wait for and succeeds immediately.
-//
-// One implementation on purpose. Every caller here needs the same recheck: when
-// ch closes at the same moment ctx expires, select picks at random, and
-// reporting a timeout for work that actually finished turns a clean shutdown
-// into a spurious error — and, for the bind, defers the teardown signal that
-// another caller is blocked on. Written once, the recheck cannot be present in
-// one copy and missing from the next.
-func awaitSignal(ctx context.Context, ch chan struct{}, what string) error {
-	if ch == nil {
-		return nil
-	}
-	select {
-	case <-ch:
-		return nil
-	case <-ctx.Done():
-		select {
-		case <-ch:
-			return nil
-		default:
-		}
-		return fmt.Errorf("timed out waiting for %s: %w", what, ctx.Err())
-	}
-}
-
-// awaitBind waits for an in-flight startServer to finish releasing or
-// publishing its socket. Detaching the server first (takeServer) is what makes
-// that bind close its own listener, so waiting here is what lets Stop promise
-// the port is free by the time it returns rather than merely started closing.
-func awaitBind(ctx context.Context, bindDone chan struct{}) error {
-	return awaitSignal(ctx, bindDone, "the Mesh API listener bind to settle")
-}
-
-// shutdownServer drains in-flight requests, then closes the listening
-// socket. http.Server.Shutdown only closes listeners that Serve has
-// registered, and startServer registers ours from a goroutine it does
-// not wait for, so Shutdown on its own can return while the socket is
-// still accepting connections -- leaving the port bound after Stop
-// returns, which a capability restart on the same port (see
-// node_lifecycle.go) then fails to rebind. Closing the listener here
-// makes releasing the port part of what Stop waits for. Closing after
-// Shutdown, not before, keeps Serve's exit quiet: Shutdown marks the
-// server as shutting down first, so the resulting accept failure
-// surfaces as http.ErrServerClosed rather than an error log.
-func shutdownServer(
-	ctx context.Context,
-	srv *http.Server,
-	ln net.Listener,
-) error {
-	err := srv.Shutdown(ctx)
-	if ln != nil {
-		// Serve closes the listener on its own way out, so an
-		// already-closed listener is the expected case, not a failure.
-		if closeErr := ln.Close(); closeErr != nil &&
-			!errors.Is(closeErr, net.ErrClosed) {
-			err = errors.Join(err, closeErr)
-		}
-	}
-	if err != nil {
-		return fmt.Errorf(
-			"failed to shutdown Mesh API server: %w",
-			err,
-		)
-	}
-	return nil
-}
-
-// startServer starts the HTTP server with deterministic
-// error detection.
-func (s *Server) startServer(
-	server *http.Server,
-	bindDone chan struct{},
-) error {
-	// Closed on every exit path -- bind failure, publication, or closing our
-	// own socket after losing the race to Stop -- so a waiting Stop is never
-	// left hanging on a bind that already finished.
-	defer close(bindDone)
-	useTLS := s.config.TLS.Enabled
-	if useTLS {
-		if err := tlsutil.ConfigureServerTLS(
-			server,
-			s.config.TLS.CertFilePath,
-			s.config.TLS.KeyFilePath,
-		); err != nil {
-			return fmt.Errorf(
-				"failed to load TLS keypair for Mesh API server: %w",
-				err,
-			)
-		}
-	}
-	ln, err := net.Listen("tcp", server.Addr)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to listen for Mesh API server: %w",
-			err,
-		)
-	}
-	// Recorded so Stop can close the socket itself rather than relying on
-	// the Serve goroutine below having registered it (see shutdownServer),
-	// but only while this call's server is still the current one. Stop can
-	// detach it between Start publishing the server and this point; a bare
-	// assignment would then strand a bound socket no later Stop can reach,
-	// because takeServer hands back a nil server and shutdownServer never
-	// runs. The same guard stops an overlapping restart from overwriting the
-	// newer server's listener with this one.
-	s.mu.Lock()
-	current := s.httpServer == server
-	if current {
-		s.listener = ln
-	}
-	s.mu.Unlock()
-	if !current {
-		// Already stopped or replaced: close our own socket instead of
-		// leaving it bound, and never hand it to Serve. Reported by log
-		// rather than returned, because Start's error path nils
-		// s.httpServer and would clobber the newer server here.
-		if closeErr := ln.Close(); closeErr != nil &&
-			!errors.Is(closeErr, net.ErrClosed) {
-			s.logger.Error(
-				"failed to close the listener of a "+
-					"stopped Mesh API server",
-				"error", closeErr,
-			)
-		}
-		return nil
-	}
-	go func() {
-		var serveErr error
-		if useTLS {
-			serveErr = server.ServeTLS(ln, "", "")
-		} else {
-			serveErr = server.Serve(ln)
-		}
-		if serveErr != nil &&
-			!errors.Is(serveErr, http.ErrServerClosed) {
-			s.logger.Error(
-				"Mesh API server error",
-				"error", serveErr,
-			)
-		}
-	}()
-	return nil
+	return s.listener.Shutdown(ctx, job, apilistener.Graceful)
 }
 
 // registerRoutes registers all Mesh API endpoints.

--- a/api/utxorpc/listener_test.go
+++ b/api/utxorpc/listener_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utxorpc
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/stretchr/testify/require"
+)
+
+// The shutdown protocol these two tests exercise is covered in depth, with the
+// windows constructed rather than raced, in internal/apilistener. What is
+// checked here is that this package is wired to it -- that a utxorpc server
+// keeps the promise its Stop makes, including on the force-close escalation
+// paths that are this listener's own.
+
+// TestServerStopReleasesPortBeforeServeRegisters covers the window between
+// net.Listen and Serve registering that listener with the http.Server.
+// http.Server.Shutdown closes only registered listeners, so a Stop landing
+// inside the window used to return with the port still bound.
+func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
+	for i := range 100 {
+		u, addr := startOnFreePort(
+			t, t.Context(),
+			apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
+		)
+
+		require.NoError(t, u.Stop(t.Context()))
+
+		require.False(
+			t, portAccepts(addr),
+			"listener still accepting when Stop returned "+
+				"(iteration %d)", i,
+		)
+	}
+}
+
+// TestServerRebindsAfterStop is the production path this fix exists for: a
+// live database restore or truncate quiesces the API capabilities and
+// reinitializeAPIServers brings them back up on the same configured port (see
+// node_lifecycle.go). A Stop that returned while the socket was still bound
+// left that restart failing with EADDRINUSE.
+func TestServerRebindsAfterStop(t *testing.T) {
+	u, addr := startOnFreePort(
+		t, t.Context(),
+		apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
+	)
+	require.NoError(t, u.Stop(t.Context()))
+
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	portNum, err := strconv.ParseUint(port, 10, 16)
+	require.NoError(t, err)
+	restarted := NewUtxorpc(UtxorpcConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: event.NewEventBus(nil, nil),
+		Host:     host,
+		Port:     uint(portNum),
+	})
+	require.NoError(
+		t, restarted.Start(t.Context()),
+		"a capability restart must rebind the port Stop released",
+	)
+	require.NoError(t, restarted.Stop(t.Context()))
+}
+
+// portAccepts reports whether a TCP connection to addr succeeds.
+func portAccepts(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/api/utxorpc/listener_test.go
+++ b/api/utxorpc/listener_test.go
@@ -15,7 +15,6 @@
 package utxorpc
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"net"
@@ -34,18 +33,6 @@ import (
 // keeps the promise its Stop makes, including on the force-close escalation
 // paths that are this listener's own.
 
-// stopNow shuts u down under a bounded context, matching the package's existing
-// convention (stopUtxorpc in tls_auth_test.go): a hang in the teardown path
-// should fail the test rather than stall the suite until go test's own timeout.
-func stopNow(t *testing.T, u *Utxorpc) error {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(
-		context.Background(), 5*time.Second,
-	)
-	defer cancel()
-	return u.Stop(ctx)
-}
-
 // TestServerStopReleasesPortBeforeServeRegisters covers the window between
 // net.Listen and Serve registering that listener with the http.Server.
 // http.Server.Shutdown closes only registered listeners, so a Stop landing
@@ -57,7 +44,7 @@ func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
 			apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
 		)
 
-		require.NoError(t, stopNow(t, u))
+		stopUtxorpc(t, u)
 
 		require.False(
 			t, portAccepts(addr),
@@ -77,7 +64,7 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		t, t.Context(),
 		apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
 	)
-	require.NoError(t, stopNow(t, u))
+	stopUtxorpc(t, u)
 
 	host, port, err := net.SplitHostPort(addr)
 	require.NoError(t, err)
@@ -93,7 +80,7 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		t, restarted.Start(t.Context()),
 		"a capability restart must rebind the port Stop released",
 	)
-	require.NoError(t, stopNow(t, restarted))
+	stopUtxorpc(t, restarted)
 }
 
 // portAccepts reports whether a TCP connection to addr succeeds.

--- a/api/utxorpc/listener_test.go
+++ b/api/utxorpc/listener_test.go
@@ -15,6 +15,7 @@
 package utxorpc
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net"
@@ -33,6 +34,18 @@ import (
 // keeps the promise its Stop makes, including on the force-close escalation
 // paths that are this listener's own.
 
+// stopNow shuts u down under a bounded context, matching the package's existing
+// convention (stopUtxorpc in tls_auth_test.go): a hang in the teardown path
+// should fail the test rather than stall the suite until go test's own timeout.
+func stopNow(t *testing.T, u *Utxorpc) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 5*time.Second,
+	)
+	defer cancel()
+	return u.Stop(ctx)
+}
+
 // TestServerStopReleasesPortBeforeServeRegisters covers the window between
 // net.Listen and Serve registering that listener with the http.Server.
 // http.Server.Shutdown closes only registered listeners, so a Stop landing
@@ -44,7 +57,7 @@ func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
 			apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
 		)
 
-		require.NoError(t, u.Stop(t.Context()))
+		require.NoError(t, stopNow(t, u))
 
 		require.False(
 			t, portAccepts(addr),
@@ -64,7 +77,7 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		t, t.Context(),
 		apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
 	)
-	require.NoError(t, u.Stop(t.Context()))
+	require.NoError(t, stopNow(t, u))
 
 	host, port, err := net.SplitHostPort(addr)
 	require.NoError(t, err)
@@ -80,7 +93,7 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		t, restarted.Start(t.Context()),
 		"a capability restart must rebind the port Stop released",
 	)
-	require.NoError(t, restarted.Stop(t.Context()))
+	require.NoError(t, stopNow(t, restarted))
 }
 
 // portAccepts reports whether a TCP connection to addr succeeds.

--- a/api/utxorpc/utxorpc.go
+++ b/api/utxorpc/utxorpc.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -33,8 +32,8 @@ import (
 	"connectrpc.com/grpcreflect"
 	"github.com/blinklabs-io/dingo/internal/apiauth"
 	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/apilistener"
 	"github.com/blinklabs-io/dingo/internal/httpcors"
-	"github.com/blinklabs-io/dingo/internal/tlsutil"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit/submitconnect"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync/syncconnect"
@@ -66,10 +65,12 @@ const (
 )
 
 type Utxorpc struct {
-	server   *http.Server
+	// listener owns the start/stop protocol, including releasing the
+	// listening socket as part of what Stop waits for -- see
+	// internal/apilistener.
+	listener *apilistener.Listener
 	config   UtxorpcConfig
 	verifier *apiauth.Verifier
-	mu       sync.Mutex
 }
 
 type UtxorpcConfig struct {
@@ -142,6 +143,9 @@ func NewUtxorpc(cfg UtxorpcConfig) *Utxorpc {
 	}
 	return &Utxorpc{
 		config: cfg,
+		listener: apilistener.New(
+			"utxorpc gRPC", cfg.Logger,
+		),
 	}
 }
 
@@ -182,12 +186,65 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("utxorpc: %w", err)
 	}
-	u.mu.Lock()
-	if u.server != nil {
-		u.mu.Unlock()
-		return errors.New("server already started")
+	// The verifier is installed inside the build callback so it is published
+	// with the server it belongs to: a second Start is rejected before the
+	// callback runs, and so cannot replace a running server's verifier.
+	server, bindDone, err := u.listener.Publish(func() *http.Server {
+		u.verifier = verifier
+		return u.buildServer()
+	})
+	if err != nil {
+		return err
 	}
-	u.verifier = verifier
+
+	// Launched before the bind so a context cancelled mid-bind still tears the
+	// server down: Take is what makes an in-flight bind close its own socket.
+	//
+	// The detach also means this no longer holds a lock across the shutdown it
+	// runs, so a concurrent Stop is answered by the teardown wait rather than
+	// blocking on the mutex for as long as a stuck stream keeps Shutdown busy.
+	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
+		<-ctx.Done()
+		job, _ := u.listener.Take()
+		// A concurrent Stop may have won the detach. It owns the teardown and
+		// its caller is already waiting on it, so there is nothing to do and
+		// nothing to wait for here.
+		if job != nil {
+			u.config.Logger.Debug(
+				"context cancelled, shutting down utxorpc gRPC server",
+			)
+			//nolint:contextcheck // shutdownCtx is intentionally created from background to allow shutdown to complete even if ctx is cancelled
+			shutdownCtx, cancel := context.WithTimeout(
+				context.Background(),
+				30*time.Second,
+			)
+			defer cancel()
+			//nolint:contextcheck // see above
+			if err := u.listener.Shutdown(
+				shutdownCtx, job, u.gracefulShutdown,
+			); err != nil {
+				u.config.Logger.Error(
+					"failed to shutdown utxorpc gRPC server on context cancellation",
+					"error",
+					err,
+				)
+			}
+		}
+	}()
+
+	if err := u.listener.Bind(server, bindDone, u.config.TLS); err != nil {
+		u.listener.Unpublish(server)
+		return err
+	}
+
+	return nil
+}
+
+// buildServer assembles the listener's http.Server. The two shapes differ only
+// in how HTTP/2 is reached: over TLS the standard negotiation applies, while
+// the plaintext listener has to opt into unencrypted HTTP/2 explicitly, which
+// gRPC clients require.
+func (u *Utxorpc) buildServer() *http.Server {
 	// CORS must wrap authentication, not the reverse: httpcors.Handler
 	// fully answers an OPTIONS preflight itself and never calls the
 	// handler it wraps for one, so browsers -- which never attach
@@ -246,44 +303,7 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 			// endpoints (FollowTip, WatchTx, WaitForTx).
 		}
 	}
-	u.server = server
-	u.mu.Unlock()
-
-	// Start the server
-	if err := u.startServer(server); err != nil {
-		u.mu.Lock()
-		u.server = nil
-		u.mu.Unlock()
-		return err
-	}
-
-	// Monitor context for cancellation and shutdown server
-	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
-		<-ctx.Done()
-		u.mu.Lock()
-		if u.server != nil {
-			u.config.Logger.Debug(
-				"context cancelled, shutting down utxorpc gRPC server",
-			)
-			//nolint:contextcheck // shutdownCtx is intentionally created from background to allow shutdown to complete even if ctx is cancelled
-			shutdownCtx, cancel := context.WithTimeout(
-				context.Background(),
-				30*time.Second,
-			)
-			defer cancel()
-			if err := u.server.Shutdown(shutdownCtx); err != nil { //nolint:contextcheck // shutdownCtx is intentionally created from background to allow shutdown to complete even if ctx is cancelled
-				u.config.Logger.Error(
-					"failed to shutdown utxorpc gRPC server on context cancellation",
-					"error",
-					err,
-				)
-			}
-			u.server = nil
-		}
-		u.mu.Unlock()
-	}()
-
-	return nil
+	return server
 }
 
 // newServeMux builds the complete routing table this listener serves: both API
@@ -467,25 +487,36 @@ func unencryptedHTTP2Protocols() *http.Protocols {
 	return protocols
 }
 
-// Stop shuts down the server, escalating to a hard Close if it does not
-// complete within u.config.ShutdownTimeout (or the caller ctx's own
-// deadline, if sooner), and also escalates immediately if ctx is cancelled
-// (even when ctx carries no deadline at all), so a caller that wants to
-// give up early is never stuck waiting out the full ShutdownTimeout.
-// WatchTx/WatchMempool are unbounded streaming RPCs, so a connected client
-// can otherwise keep http.Server.Shutdown blocked indefinitely, hanging any
-// live database restore/truncate quiesce that waits on Stop -- matching
-// midnight/server's identical Stop/gracefulStop pattern for a grpc.Server.
+// Stop shuts down the server and does not return until the listening socket
+// has been released, so a capability restart on the same port can rebind --
+// see internal/apilistener.
 func (u *Utxorpc) Stop(ctx context.Context) error {
-	u.mu.Lock()
-	server := u.server
-	u.server = nil
-	u.mu.Unlock()
-
-	if server == nil {
-		return nil
+	job, inFlight := u.listener.Take()
+	if job == nil {
+		return u.listener.AwaitTeardown(ctx, inFlight)
 	}
+	u.config.Logger.Debug("shutting down utxorpc gRPC server")
+	return u.listener.Shutdown(ctx, job, u.gracefulShutdown)
+}
 
+// gracefulShutdown drains server, escalating to a hard Close if it does not
+// complete within u.config.ShutdownTimeout (or the caller ctx's own deadline,
+// if sooner), and also escalates immediately if ctx is cancelled (even when ctx
+// carries no deadline at all), so a caller that wants to give up early is never
+// stuck waiting out the full ShutdownTimeout. WatchTx/WatchMempool are
+// unbounded streaming RPCs, so a connected client can otherwise keep
+// http.Server.Shutdown blocked indefinitely, hanging any live database
+// restore/truncate quiesce that waits on Stop -- matching midnight/server's
+// identical Stop/gracefulStop pattern for a grpc.Server.
+//
+// It is the ShutdownFunc apilistener runs before closing the socket, so every
+// exit path here -- graceful, timed out, or cancelled -- is still followed by
+// that close. server.Close() on the escalation paths only reaches the listeners
+// Serve registered, which is exactly the set that may be missing ours.
+func (u *Utxorpc) gracefulShutdown(
+	ctx context.Context,
+	server *http.Server,
+) error {
 	timeout := u.config.ShutdownTimeout
 	if deadline, ok := ctx.Deadline(); ok {
 		if remaining := time.Until(deadline); remaining > 0 {
@@ -495,14 +526,13 @@ func (u *Utxorpc) Stop(ctx context.Context) error {
 		}
 	}
 
-	u.config.Logger.Debug("shutting down utxorpc gRPC server")
-	// Shutdown itself is given a ctx that never expires (not shutdownCtx
-	// below): it races that ctx internally, and racing it a second time
-	// here too would be nondeterministic about which timeout error wins --
-	// sometimes returning Shutdown's own ctx-expired error instead of
-	// actually escalating to the hard Close this exists for. A plain timer
-	// avoids that, matching midnight/server's gracefulStop, which for the
-	// same reason never passes a ctx into grpc.Server.GracefulStop either.
+	// Shutdown itself is given a ctx that never expires (not the timer below):
+	// it races that ctx internally, and racing it a second time here too would
+	// be nondeterministic about which timeout error wins -- sometimes returning
+	// Shutdown's own ctx-expired error instead of actually escalating to the
+	// hard Close this exists for. A plain timer avoids that, matching
+	// midnight/server's gracefulStop, which for the same reason never passes a
+	// ctx into grpc.Server.GracefulStop either.
 	shutdownErr := make(chan error, 1)
 	//nolint:gosec,contextcheck // G118: intentionally outlives ctx, see comment above
 	go func() {
@@ -511,10 +541,7 @@ func (u *Utxorpc) Stop(ctx context.Context) error {
 
 	select {
 	case err := <-shutdownErr:
-		if err != nil {
-			return fmt.Errorf("failed to shutdown utxorpc gRPC server: %w", err)
-		}
-		return nil
+		return err
 	case <-time.After(timeout):
 		u.config.Logger.Warn(
 			"utxorpc gRPC graceful shutdown timed out; forcing close",
@@ -538,57 +565,13 @@ func (u *Utxorpc) Stop(ctx context.Context) error {
 // forceCloseUtxorpc hard-closes server after a graceful Shutdown failed to
 // finish in time -- whether because ShutdownTimeout (or the caller's own
 // deadline) elapsed or because the caller's ctx was cancelled early -- then
-// drains shutdownErr so the Shutdown goroutine started in Stop never leaks.
+// drains shutdownErr so the Shutdown goroutine started above never leaks.
 func forceCloseUtxorpc(server *http.Server, shutdownErr <-chan error) error {
 	if err := server.Close(); err != nil {
-		return fmt.Errorf("failed to force-close utxorpc gRPC server: %w", err)
+		return fmt.Errorf(
+			"force-close after graceful shutdown failed: %w", err,
+		)
 	}
 	<-shutdownErr
-	return nil
-}
-
-// startServer starts the HTTP server with deterministic error
-// detection. It binds the listening socket and pre-loads any TLS
-// keypair synchronously so port and certificate errors surface before
-// returning, then serves in a background goroutine.
-func (u *Utxorpc) startServer(server *http.Server) error {
-	useTLS := u.config.TLS.Enabled
-	serverType := "non-TLS"
-	if useTLS {
-		serverType = "TLS"
-		if err := tlsutil.ConfigureServerTLS(
-			server,
-			u.config.TLS.CertFilePath,
-			u.config.TLS.KeyFilePath,
-		); err != nil {
-			return fmt.Errorf(
-				"failed to load TLS keypair for utxorpc gRPC %s server: %w",
-				serverType, err,
-			)
-		}
-	}
-	ln, err := net.Listen("tcp", server.Addr)
-	if err != nil {
-		return fmt.Errorf("failed to start utxorpc gRPC %s server: %w",
-			serverType, err)
-	}
-	go func() {
-		var serveErr error
-		if useTLS {
-			serveErr = server.ServeTLS(
-				ln,
-				"",
-				"",
-			)
-		} else {
-			serveErr = server.Serve(ln)
-		}
-		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
-			u.config.Logger.Error(
-				"utxorpc gRPC server error",
-				"error", serveErr,
-			)
-		}
-	}()
 	return nil
 }

--- a/api/utxorpc/utxorpc.go
+++ b/api/utxorpc/utxorpc.go
@@ -205,10 +205,11 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 	// blocking on the mutex for as long as a stuck stream keeps Shutdown busy.
 	go func() { //nolint:gosec // G118: goroutine intentionally outlives ctx to perform graceful shutdown
 		<-ctx.Done()
-		job, _ := u.listener.Take()
-		// A concurrent Stop may have won the detach. It owns the teardown and
-		// its caller is already waiting on it, so there is nothing to do and
-		// nothing to wait for here.
+		job, _ := u.listener.TakeIf(server)
+		// Nil when a concurrent Stop won the detach -- it owns the teardown
+		// and its caller is already waiting on it -- or when this server was
+		// already stopped and a restart published another one, which is not
+		// this monitor's to touch. Either way there is nothing to do here.
 		if job != nil {
 			u.config.Logger.Debug(
 				"context cancelled, shutting down utxorpc gRPC server",
@@ -232,7 +233,9 @@ func (u *Utxorpc) Start(ctx context.Context) error {
 		}
 	}()
 
-	if err := u.listener.Bind(server, bindDone, u.config.TLS); err != nil {
+	if _, err := u.listener.Bind(
+		server, bindDone, u.config.TLS,
+	); err != nil {
 		u.listener.Unpublish(server)
 		return err
 	}

--- a/api/utxorpc/utxorpc_test.go
+++ b/api/utxorpc/utxorpc_test.go
@@ -168,6 +168,20 @@ func TestUtxorpc_StartStop(t *testing.T) {
 	require.NoError(t, err, "failed to stop utxorpc")
 }
 
+// publishServer registers server on u's listener the way Start does, for tests
+// that drive Stop against a hand-built server rather than a real Start. The
+// bind is marked settled immediately because the caller serves the listener
+// itself, so there is none in flight for Stop to wait on.
+func publishServer(t *testing.T, u *Utxorpc, server *http.Server) {
+	t.Helper()
+	published, bindDone, err := u.listener.Publish(
+		func() *http.Server { return server },
+	)
+	require.NoError(t, err)
+	require.Same(t, server, published)
+	close(bindDone)
+}
+
 // TestUtxorpc_StopForcesCloseOnUnboundedStream covers Stop's escalation to
 // a hard Close when a client keeps a connection open, standing in for a
 // WatchTx/WatchMempool stream that never returns.
@@ -188,9 +202,9 @@ func TestUtxorpc_StopForcesCloseOnUnboundedStream(t *testing.T) {
 	})
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	server := &http.Server{Handler: mux}
-	u.server = server
-	go server.Serve(ln)
+	server := &http.Server{Handler: mux} //nolint:gosec // test server
+	publishServer(t, u, server)
+	go server.Serve(ln) //nolint:errcheck // test server
 	t.Cleanup(func() { close(blockHandler) })
 
 	client := &http.Client{}
@@ -235,9 +249,9 @@ func TestUtxorpc_StopObservesCtxCancellation(t *testing.T) {
 	})
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	server := &http.Server{Handler: mux}
-	u.server = server
-	go server.Serve(ln)
+	server := &http.Server{Handler: mux} //nolint:gosec // test server
+	publishServer(t, u, server)
+	go server.Serve(ln) //nolint:errcheck // test server
 	t.Cleanup(func() { close(blockHandler) })
 
 	client := &http.Client{}

--- a/internal/apilistener/listener.go
+++ b/internal/apilistener/listener.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package apilistener owns the start/stop protocol shared by Dingo's HTTP API
+// servers (api/blockfrost, api/mesh, api/utxorpc).
+//
+// The protocol exists because http.Server.Shutdown only closes listeners that
+// Serve has already registered, and each server binds its socket before
+// handing it to Serve in a goroutine it does not wait for. A Stop landing in
+// that window returns with the port still bound, which the capability restart
+// in node_lifecycle.go -- reached by any live database restore or truncate --
+// then fails to rebind with EADDRINUSE.
+//
+// Releasing the port is therefore something Stop has to do itself, and doing
+// it safely needs three pieces that only make sense together: exactly one
+// caller may detach and tear down a server (Take), a Stop must not outrun a
+// bind still in flight (bindDone), and the caller that loses the detach must
+// not report the server down before the winner has finished (teardown).
+//
+// It lives here rather than in each API package because those pieces are
+// subtle in the same way in all three -- see awaitSignal's doc comment for the
+// recheck that a second copy would be most likely to lose.
+package apilistener
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/tlsutil"
+)
+
+// Listener holds the lifecycle state of one API server: the running
+// http.Server, the socket it is bound to, and the channels the shutdown
+// protocol coordinates on.
+//
+// A Listener is reusable. After a completed shutdown it holds no server, so
+// the same instance can bring another one up on the same address -- which is
+// exactly what a capability restart does.
+type Listener struct {
+	// name identifies the server in errors and logs, e.g. "Mesh API". It is
+	// the subject of every message, so it reads as a noun phrase that "server"
+	// can follow.
+	name   string
+	logger *slog.Logger
+
+	mu  sync.Mutex
+	srv *http.Server
+	ln  net.Listener
+	// bindDone is closed by Bind once the listening socket has been either
+	// published on ln or closed again. Shutdown waits on it so a bind still in
+	// flight cannot outlive the Stop that raced it.
+	bindDone chan struct{}
+	// teardown is closed once the caller that detached the server has finished
+	// shutting it down. A server's Stop and the context monitor its Start
+	// launched race to detach; the loser gets no server back and would
+	// otherwise report the server down while the winner was still releasing
+	// the port.
+	teardown chan struct{}
+}
+
+// New returns a Listener that names itself name in errors and logs. A nil
+// logger discards.
+func New(name string, logger *slog.Logger) *Listener {
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	return &Listener{name: name, logger: logger}
+}
+
+// Publish builds a server under the Listener's lock and registers it as the
+// current one, returning it with the bind channel that must be handed to Bind.
+// It reports an error if a server is already running, which is what makes a
+// second Start fail rather than strand the first server's socket.
+//
+// build runs only once that check has passed, so a caller can initialize the
+// state its handler chain reads -- its credential verifier, typically --
+// atomically with publication, and a rejected second Start cannot disturb the
+// running server's. build must not call back into the Listener: the lock is
+// already held.
+func (l *Listener) Publish(
+	build func() *http.Server,
+) (*http.Server, chan struct{}, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.srv != nil {
+		return nil, nil, errors.New("server already started")
+	}
+	srv := build()
+	bindDone := make(chan struct{})
+	l.srv, l.bindDone = srv, bindDone
+	return srv, bindDone, nil
+}
+
+// Unpublish clears srv, for a Start that failed after publishing it.
+//
+// Guarded on purpose: an overlapping Stop or restart may already have detached
+// or replaced this server, and clearing unconditionally would discard the newer
+// one. Cleared as a set, matching Take, so "no server present" never leaves a
+// listener or bind channel behind for the next caller to find.
+func (l *Listener) Unpublish(srv *http.Server) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.srv == srv {
+		l.srv, l.ln, l.bindDone = nil, nil, nil
+	}
+}
+
+// Server returns the running server, or nil when none is published. It is for
+// inspecting what was brought up; taking it down goes through Take, which is
+// what keeps a single caller responsible for the socket.
+func (l *Listener) Server() *http.Server {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.srv
+}
+
+// Job is everything one caller detaches from a Listener in order to tear it
+// down, including the channel it must close when finished.
+type Job struct {
+	srv      *http.Server
+	ln       net.Listener
+	bindDone chan struct{}
+	done     chan struct{}
+}
+
+// Take detaches the running server and its listener so exactly one caller
+// shuts them down: a server's Stop and the context monitor its Start launched
+// both race for them.
+//
+// The winner gets a job and owns closing job.done, via Shutdown. The loser gets
+// a nil job and the winner's completion channel, which it must wait on with
+// AwaitTeardown -- returning early would report the server down while the port
+// was still bound, and an immediate restart on the same port would then fail to
+// bind.
+func (l *Listener) Take() (*Job, chan struct{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.srv == nil {
+		// Either never started, or someone else is already tearing it down.
+		return nil, l.teardown
+	}
+	job := &Job{
+		srv:      l.srv,
+		ln:       l.ln,
+		bindDone: l.bindDone,
+		done:     make(chan struct{}),
+	}
+	l.srv, l.ln, l.bindDone = nil, nil, nil
+	l.teardown = job.done
+	return job, nil
+}
+
+// ShutdownFunc drains a detached server's in-flight requests. It must return
+// only once the server is done with the listeners Serve registered; closing
+// the socket this package recorded is Shutdown's job, not its own.
+//
+// It exists so a server whose graceful shutdown needs more than
+// http.Server.Shutdown can supply it -- api/utxorpc escalates to a hard Close,
+// because an unbounded streaming RPC can otherwise keep Shutdown blocked
+// indefinitely. Errors are returned unwrapped; Shutdown adds the context.
+type ShutdownFunc func(ctx context.Context, srv *http.Server) error
+
+// Graceful is the default ShutdownFunc: http.Server.Shutdown bounded by ctx.
+func Graceful(ctx context.Context, srv *http.Server) error {
+	return srv.Shutdown(ctx)
+}
+
+// Shutdown runs one detached job to completion and reports what went wrong.
+//
+// The bind wait is not allowed to skip the teardown: a caller whose context
+// expires mid-wait still holds the only reference to a bound socket, so
+// returning early would leave the port bound with nothing left to close it.
+func (l *Listener) Shutdown(
+	ctx context.Context,
+	job *Job,
+	fn ShutdownFunc,
+) error {
+	waitErr := l.awaitBind(ctx, job.bindDone)
+	stopErr := l.shutdownServer(ctx, job.srv, job.ln, fn)
+	if waitErr == nil {
+		close(job.done)
+		return stopErr
+	}
+	// The bind is still in flight, so Bind still owns a socket this call cannot
+	// close. Closing job.done now would let a waiting Stop report the server
+	// down while that socket was still bound. Bind always closes bindDone on
+	// its way out -- and closes its own listener once it sees the detach -- so
+	// hand the signalling off until then, which also bounds this goroutine.
+	go func() {
+		<-job.bindDone
+		close(job.done)
+	}()
+	return errors.Join(waitErr, stopErr)
+}
+
+// shutdownServer drains in-flight requests, then closes the listening socket.
+// Closing after the drain, not before, keeps Serve's exit quiet: Shutdown marks
+// the server as shutting down first, so the resulting accept failure surfaces
+// as http.ErrServerClosed rather than an error log.
+func (l *Listener) shutdownServer(
+	ctx context.Context,
+	srv *http.Server,
+	ln net.Listener,
+	fn ShutdownFunc,
+) error {
+	err := fn(ctx, srv)
+	if ln != nil {
+		// Serve closes the listener on its own way out, so an already-closed
+		// listener is the expected case, not a failure.
+		if closeErr := ln.Close(); closeErr != nil &&
+			!errors.Is(closeErr, net.ErrClosed) {
+			err = errors.Join(err, closeErr)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf(
+			"failed to shutdown %s server: %w", l.name, err,
+		)
+	}
+	return nil
+}
+
+// AwaitTeardown waits for another caller's in-flight shutdown to finish. It is
+// what the loser of Take must call before reporting the server down.
+func (l *Listener) AwaitTeardown(
+	ctx context.Context,
+	done chan struct{},
+) error {
+	return awaitSignal(
+		ctx, done, "an in-flight "+l.name+" shutdown",
+	)
+}
+
+// awaitBind waits for an in-flight Bind to finish releasing or publishing its
+// socket. Detaching the server first (Take) is what makes that bind close its
+// own listener, so waiting here is what lets Stop promise the port is free by
+// the time it returns rather than merely started closing.
+func (l *Listener) awaitBind(
+	ctx context.Context,
+	bindDone chan struct{},
+) error {
+	return awaitSignal(
+		ctx, bindDone, "the "+l.name+" listener bind to settle",
+	)
+}
+
+// awaitSignal waits for ch to close, bounded by ctx. A nil channel has nothing
+// to wait for and succeeds immediately.
+//
+// One implementation on purpose. Every caller here needs the same recheck: when
+// ch closes at the same moment ctx expires, select picks at random, and
+// reporting a timeout for work that actually finished turns a clean shutdown
+// into a spurious error -- and, for the bind, defers the teardown signal that
+// another caller is blocked on. Written once, the recheck cannot be present in
+// one copy and missing from the next.
+func awaitSignal(ctx context.Context, ch chan struct{}, what string) error {
+	if ch == nil {
+		return nil
+	}
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		select {
+		case <-ch:
+			return nil
+		default:
+		}
+		return fmt.Errorf(
+			"timed out waiting for %s: %w", what, ctx.Err(),
+		)
+	}
+}
+
+// Bind opens srv's listening socket and serves it in the background, closing
+// bindDone once the socket has been either published or closed again.
+//
+// The socket is opened synchronously so a port conflict -- and, when TLS is
+// enabled, a bad keypair -- surfaces as an error from Start rather than in a
+// log line from a goroutine nobody is watching.
+func (l *Listener) Bind(
+	srv *http.Server,
+	bindDone chan struct{},
+	tls apiconfig.EffectiveTLS,
+) error {
+	// Closed on every exit path -- keypair failure, bind failure, publication,
+	// or closing our own socket after losing the race to Stop -- so a waiting
+	// Stop is never left hanging on a bind that already finished.
+	defer close(bindDone)
+	useTLS := tls.Enabled
+	if useTLS {
+		if err := tlsutil.ConfigureServerTLS(
+			srv, tls.CertFilePath, tls.KeyFilePath,
+		); err != nil {
+			return fmt.Errorf(
+				"failed to load TLS keypair for %s server: %w",
+				l.name, err,
+			)
+		}
+	}
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to listen for %s server: %w", l.name, err,
+		)
+	}
+	// Recorded so Shutdown can close the socket itself rather than relying on
+	// the Serve goroutine below having registered it, but only while this
+	// call's server is still the current one. Stop can detach it between
+	// Publish and this point; a bare assignment would then strand a bound
+	// socket no later Stop can reach, because Take hands back a nil server and
+	// shutdownServer never runs. The same guard stops an overlapping restart
+	// from overwriting the newer server's listener with this one.
+	l.mu.Lock()
+	current := l.srv == srv
+	if current {
+		l.ln = ln
+	}
+	l.mu.Unlock()
+	if !current {
+		// Already stopped or replaced: close our own socket instead of leaving
+		// it bound, and never hand it to Serve. Reported by log rather than
+		// returned, because Start's error path unpublishes and would clobber
+		// the newer server here.
+		if closeErr := ln.Close(); closeErr != nil &&
+			!errors.Is(closeErr, net.ErrClosed) {
+			l.logger.Error(
+				"failed to close the listener of a stopped "+
+					l.name+" server",
+				"error", closeErr,
+			)
+		}
+		return nil
+	}
+	go func() {
+		var serveErr error
+		if useTLS {
+			serveErr = srv.ServeTLS(ln, "", "")
+		} else {
+			serveErr = srv.Serve(ln)
+		}
+		if serveErr != nil &&
+			!errors.Is(serveErr, http.ErrServerClosed) {
+			l.logger.Error(
+				l.name+" server error", "error", serveErr,
+			)
+		}
+	}()
+	return nil
+}

--- a/internal/apilistener/listener.go
+++ b/internal/apilistener/listener.go
@@ -174,12 +174,21 @@ func (l *Listener) TakeIf(srv *http.Server) (*Job, chan struct{}) {
 func (l *Listener) take(match *http.Server) (*Job, chan struct{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.srv == nil {
-		// Either never started, or someone else is already tearing it down.
-		return nil, l.teardown
-	}
+	// The identity check comes first, and deliberately also covers l.srv being
+	// nil. A caller that named a server and did not get it has nothing of its
+	// own left either way -- already detached, or replaced by a later Start --
+	// and the teardown that may be in flight belongs to whoever detached it.
+	// Falling through to the nil-server branch below would hand a monitor that
+	// unrelated teardown to block on.
 	if match != nil && l.srv != match {
 		return nil, nil
+	}
+	if l.srv == nil {
+		// Either never started, or someone else is already tearing it down.
+		// Only an unconditional Take reaches this, and it is the loser of a
+		// genuine race, so the winner's teardown is exactly what it must wait
+		// on.
+		return nil, l.teardown
 	}
 	job := &Job{
 		srv:      l.srv,

--- a/internal/apilistener/listener.go
+++ b/internal/apilistener/listener.go
@@ -325,9 +325,19 @@ func awaitSignal(ctx context.Context, ch chan struct{}, what string) error {
 
 // Bind opens srv's listening socket and serves it in the background, closing
 // bindDone once the socket has been either published or closed again. It
-// reports whether the socket is actually being served: false means srv was
-// detached before the socket could be published, so Bind closed it instead, and
-// the caller must not report that a listener came up.
+// reports whether it handed the socket to Serve: false means srv was detached
+// before the socket could be published, so Bind closed it instead, and the
+// caller must not report that a listener came up.
+//
+// True is a statement about what this call did, not a promise that the listener
+// is still up: a Stop can detach and close the socket between the ownership
+// check below and Serve being entered, leaving Serve nothing to accept. That
+// window is inert -- Serve reports ErrServerClosed, which the goroutine's error
+// filter drops, and the port is released by the Stop that closed it -- so its
+// only trace is the caller having logged that the listener came up. Closing it
+// would need Serve to signal that it registered the listener, which net/http
+// does not expose, and any such signal would still lose to a Stop landing an
+// instant after it. See TestServeEnteredAfterShutdownStaysQuiet.
 //
 // The socket is opened synchronously so a port conflict -- and, when TLS is
 // enabled, a bad keypair -- surfaces as an error from Start rather than in a

--- a/internal/apilistener/listener.go
+++ b/internal/apilistener/listener.go
@@ -151,11 +151,35 @@ type Job struct {
 // was still bound, and an immediate restart on the same port would then fail to
 // bind.
 func (l *Listener) Take() (*Job, chan struct{}) {
+	return l.take(nil)
+}
+
+// TakeIf is Take restricted to srv: it detaches only while srv is still the
+// published server.
+//
+// This is what a context monitor must use. A monitor outlives the server it was
+// launched for -- it sits on ctx.Done() until its caller's context ends, which
+// can be long after that server was stopped and a restart published another one
+// on the same Listener. An unconditional Take there would tear down a
+// replacement the monitor never published.
+//
+// A caller whose server is already gone gets a nil job and nothing to wait on:
+// its own server is down either way, and a teardown in flight belongs to
+// whoever detached it.
+func (l *Listener) TakeIf(srv *http.Server) (*Job, chan struct{}) {
+	return l.take(srv)
+}
+
+// take detaches the current server, optionally only when it is match.
+func (l *Listener) take(match *http.Server) (*Job, chan struct{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.srv == nil {
 		// Either never started, or someone else is already tearing it down.
 		return nil, l.teardown
+	}
+	if match != nil && l.srv != match {
+		return nil, nil
 	}
 	job := &Job{
 		srv:      l.srv,
@@ -291,7 +315,10 @@ func awaitSignal(ctx context.Context, ch chan struct{}, what string) error {
 }
 
 // Bind opens srv's listening socket and serves it in the background, closing
-// bindDone once the socket has been either published or closed again.
+// bindDone once the socket has been either published or closed again. It
+// reports whether the socket is actually being served: false means srv was
+// detached before the socket could be published, so Bind closed it instead, and
+// the caller must not report that a listener came up.
 //
 // The socket is opened synchronously so a port conflict -- and, when TLS is
 // enabled, a bad keypair -- surfaces as an error from Start rather than in a
@@ -300,7 +327,7 @@ func (l *Listener) Bind(
 	srv *http.Server,
 	bindDone chan struct{},
 	tls apiconfig.EffectiveTLS,
-) error {
+) (bool, error) {
 	// Closed on every exit path -- keypair failure, bind failure, publication,
 	// or closing our own socket after losing the race to Stop -- so a waiting
 	// Stop is never left hanging on a bind that already finished.
@@ -310,7 +337,7 @@ func (l *Listener) Bind(
 		if err := tlsutil.ConfigureServerTLS(
 			srv, tls.CertFilePath, tls.KeyFilePath,
 		); err != nil {
-			return fmt.Errorf(
+			return false, fmt.Errorf(
 				"failed to load TLS keypair for %s server: %w",
 				l.name, err,
 			)
@@ -318,7 +345,7 @@ func (l *Listener) Bind(
 	}
 	ln, err := net.Listen("tcp", srv.Addr)
 	if err != nil {
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"failed to listen for %s server: %w", l.name, err,
 		)
 	}
@@ -348,7 +375,7 @@ func (l *Listener) Bind(
 				"error", closeErr,
 			)
 		}
-		return nil
+		return false, nil
 	}
 	go func() {
 		var serveErr error
@@ -364,5 +391,5 @@ func (l *Listener) Bind(
 			)
 		}
 	}()
-	return nil
+	return true, nil
 }

--- a/internal/apilistener/listener_test.go
+++ b/internal/apilistener/listener_test.go
@@ -55,6 +55,33 @@ func publish(
 	})
 }
 
+// publishBound is publish for a server that stands in for one already brought
+// up: it marks the bind settled, so a Stop is not left waiting on a bind that
+// will never happen. Tests that want a bind still in flight set bindDone
+// themselves.
+func publishBound(
+	l *Listener, addr string,
+) (*http.Server, error) {
+	srv, bindDone, err := publish(l, addr)
+	if err != nil {
+		return nil, err
+	}
+	close(bindDone)
+	return srv, nil
+}
+
+// stopNow runs the Stop sequence under a bounded context, so a hang in the
+// teardown path fails the test instead of stalling the suite until go test's
+// own timeout fires.
+func stopNow(t *testing.T, l *Listener) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 5*time.Second,
+	)
+	defer cancel()
+	return stop(ctx, l)
+}
+
 // startOnFreePort publishes and binds a server on a free loopback port,
 // retrying on a lost race for the port, and returns the Listener with the
 // address it bound. The caller owns shutdown.
@@ -66,7 +93,9 @@ func startOnFreePort(t *testing.T) (*Listener, string) {
 		l := newListener()
 		srv, bindDone, err := publish(l, addr)
 		require.NoError(t, err)
-		if err := l.Bind(srv, bindDone, apiconfig.EffectiveTLS{}); err != nil {
+		if _, err := l.Bind(
+			srv, bindDone, apiconfig.EffectiveTLS{},
+		); err != nil {
 			lastErr = err
 			continue
 		}
@@ -162,7 +191,7 @@ func TestShutdownClosesAListenerServeNeverRegistered(t *testing.T) {
 	l.mu.Unlock()
 	close(bindDone)
 
-	require.NoError(t, stop(t.Context(), l))
+	require.NoError(t, stopNow(t, l))
 
 	require.False(
 		t, portAccepts(addr),
@@ -177,7 +206,7 @@ func TestStopReleasesPortBeforeServeRegisters(t *testing.T) {
 	for i := range 100 {
 		l, addr := startOnFreePort(t)
 
-		require.NoError(t, stop(t.Context(), l))
+		require.NoError(t, stopNow(t, l))
 
 		require.False(
 			t, portAccepts(addr),
@@ -214,9 +243,9 @@ func TestBindReleasesListenerWhenServerAlreadyDetached(t *testing.T) {
 	// The detached server this Bind call is bringing up.
 	detached := &http.Server{Addr: addr} //nolint:gosec // test server
 	bindDone := make(chan struct{})
-	require.NoError(
-		t, l.Bind(detached, bindDone, apiconfig.EffectiveTLS{}),
-	)
+	served, err := l.Bind(detached, bindDone, apiconfig.EffectiveTLS{})
+	require.NoError(t, err)
+	require.False(t, served)
 	testutil.RequireReceive(
 		t, bindDone, time.Second,
 		"Bind must signal that the bind settled",
@@ -248,7 +277,7 @@ func TestBindSignalsBindDoneOnKeypairFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	missing := filepath.Join(t.TempDir(), "absent")
-	err = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{
+	_, err = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{
 		Enabled:      true,
 		CertFilePath: missing,
 		KeyFilePath:  missing,
@@ -272,13 +301,92 @@ func TestBindSignalsBindDoneOnListenFailure(t *testing.T) {
 	srv, bindDone, err := publish(l, occupied.Addr().String())
 	require.NoError(t, err)
 
-	err = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
+	_, err = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
 
 	require.ErrorContains(t, err, "failed to listen for Test API server")
 	testutil.RequireReceive(
 		t, bindDone, time.Second,
 		"a failed bind must still signal the bind settled",
 	)
+}
+
+// TestTakeIfIgnoresAServerItDoesNotOwn asserts a context monitor cannot tear
+// down a server its own Start never published. Start's monitor outlives the
+// server it was launched for -- it sits on ctx.Done() until the caller's
+// context ends, which may be long after that server was stopped and a restart
+// published another one on the same Listener. An unconditional detach there
+// would shut the replacement down.
+func TestTakeIfIgnoresAServerItDoesNotOwn(t *testing.T) {
+	l := newListener()
+	first, err := publishBound(l, "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, stopNow(t, l))
+
+	// The restart, on the same Listener.
+	second, err := publishBound(l, "127.0.0.1:0")
+	require.NoError(t, err)
+
+	job, inFlight := l.TakeIf(first)
+
+	require.Nil(t, job, "the first server's monitor must not detach the second")
+	require.Nil(
+		t,
+		inFlight,
+		"a teardown belonging to another server is not this caller's to wait on",
+	)
+	require.Same(
+		t, second, l.Server(),
+		"the replacement must still be published",
+	)
+}
+
+// TestTakeIfDetachesItsOwnServer asserts the identity check does not defeat the
+// case it exists to serve: a monitor whose server is still the current one
+// still tears it down.
+func TestTakeIfDetachesItsOwnServer(t *testing.T) {
+	l := newListener()
+	srv, err := publishBound(l, "127.0.0.1:0")
+	require.NoError(t, err)
+
+	job, _ := l.TakeIf(srv)
+
+	require.NotNil(t, job, "a monitor must detach the server it published")
+	require.Nil(t, l.Server())
+}
+
+// TestBindReportsLostPublication asserts Bind tells its caller when it closed
+// the socket instead of serving it, so Start does not log that a listener came
+// up when a concurrent Stop means none did.
+func TestBindReportsLostPublication(t *testing.T) {
+	l := newListener()
+	addr := testutil.FreePort(t)
+
+	// Stands in for a Stop that detached between Publish and Bind.
+	detached := &http.Server{Addr: addr} //nolint:gosec // test server
+	bindDone := make(chan struct{})
+
+	served, err := l.Bind(detached, bindDone, apiconfig.EffectiveTLS{})
+
+	require.NoError(t, err, "losing the publication is not a bind failure")
+	require.False(
+		t, served,
+		"Bind must report that it closed the socket rather than serving it",
+	)
+	require.False(t, portAccepts(addr))
+}
+
+// TestBindReportsServed asserts the reporting side that Start's success log
+// depends on.
+func TestBindReportsServed(t *testing.T) {
+	l := newListener()
+	srv, bindDone, err := publish(l, testutil.FreePort(t))
+	require.NoError(t, err)
+
+	served, err := l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
+	t.Cleanup(func() { _ = stopNow(t, l) })
+
+	require.NoError(t, err)
+	require.True(t, served)
 }
 
 // --- shutdown coordination ----------------------------------------------
@@ -309,7 +417,7 @@ func TestShutdownWaitsForAnInFlightBind(t *testing.T) {
 
 	// Once the bind settles, Stop completes.
 	close(bindDone)
-	require.NoError(t, stop(t.Context(), l))
+	require.NoError(t, stopNow(t, l))
 }
 
 // TestShutdownTearsDownEvenWhenTheBindWaitTimesOut asserts a Stop whose
@@ -364,7 +472,7 @@ func TestStopWaitsForATeardownItLost(t *testing.T) {
 	)
 
 	close(teardown)
-	require.NoError(t, stop(t.Context(), l))
+	require.NoError(t, stopNow(t, l))
 }
 
 // TestAwaitTeardownPrefersACompletedTeardown asserts a finished teardown is
@@ -421,13 +529,13 @@ func TestTimedOutTeardownDoesNotSignalCompletionEarly(t *testing.T) {
 
 	// Once the bind settles the teardown is genuinely complete.
 	close(bindDone)
-	require.NoError(t, stop(t.Context(), l))
+	require.NoError(t, stopNow(t, l))
 }
 
 // TestStopOnAnUnstartedListenerIsClean asserts Stop before Start is not an
 // error. The node stops capabilities it may never have started.
 func TestStopOnAnUnstartedListenerIsClean(t *testing.T) {
-	require.NoError(t, stop(t.Context(), newListener()))
+	require.NoError(t, stopNow(t, newListener()))
 }
 
 // --- the contract callers rely on ---------------------------------------
@@ -439,15 +547,14 @@ func TestStopOnAnUnstartedListenerIsClean(t *testing.T) {
 // for rather than something Serve gets around to later.
 func TestListenerIsReusableAfterShutdown(t *testing.T) {
 	l, addr := startOnFreePort(t)
-	require.NoError(t, stop(t.Context(), l))
+	require.NoError(t, stopNow(t, l))
 
 	srv, bindDone, err := publish(l, addr)
 	require.NoError(t, err)
-	require.NoError(
-		t, l.Bind(srv, bindDone, apiconfig.EffectiveTLS{}),
-		"rebinding after a clean Stop must succeed",
-	)
-	require.NoError(t, stop(t.Context(), l))
+	served, err := l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
+	require.NoError(t, err, "rebinding after a clean Stop must succeed")
+	require.True(t, served)
+	require.NoError(t, stopNow(t, l))
 }
 
 // TestConcurrentBindStopNeverLeavesThePortBound hammers the interleavings the
@@ -483,12 +590,12 @@ func TestConcurrentBindStopNeverLeavesThePortBound(t *testing.T) {
 			if err != nil {
 				return
 			}
-			_ = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
+			_, _ = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
 		}()
 		for slot := range stopErrs {
 			go func() {
 				defer wg.Done()
-				stopErrs[slot] = stop(t.Context(), l)
+				stopErrs[slot] = stopNow(t, l)
 			}()
 		}
 		wg.Wait()
@@ -501,7 +608,7 @@ func TestConcurrentBindStopNeverLeavesThePortBound(t *testing.T) {
 			continue
 		}
 		require.NoError(
-			t, stop(t.Context(), l),
+			t, stopNow(t, l),
 			"a second Stop must stay clean (iteration %d)", i,
 		)
 		require.False(
@@ -514,10 +621,11 @@ func TestConcurrentBindStopNeverLeavesThePortBound(t *testing.T) {
 		next := newListener()
 		nextSrv, bindDone, err := publish(next, addr)
 		require.NoError(t, err)
+		_, err = next.Bind(nextSrv, bindDone, apiconfig.EffectiveTLS{})
 		require.NoError(
-			t, next.Bind(nextSrv, bindDone, apiconfig.EffectiveTLS{}),
+			t, err,
 			"rebinding after a clean Stop must succeed (iteration %d)", i,
 		)
-		require.NoError(t, stop(t.Context(), next))
+		require.NoError(t, stopNow(t, next))
 	}
 }

--- a/internal/apilistener/listener_test.go
+++ b/internal/apilistener/listener_test.go
@@ -354,6 +354,37 @@ func TestTakeIfDetachesItsOwnServer(t *testing.T) {
 	require.Nil(t, l.Server())
 }
 
+// TestTakeIfHandsBackNoTeardownWhenItsServerIsGone covers the case where the
+// monitor's server has been detached but its teardown is still running, so
+// l.srv is nil rather than pointing at a replacement. The identity check has
+// to come first: a caller landing here must be told there is nothing of its own
+// left, not handed a teardown that belongs to whoever detached it. Waiting on
+// that would block a monitor on an unrelated shutdown.
+func TestTakeIfHandsBackNoTeardownWhenItsServerIsGone(t *testing.T) {
+	l := newListener()
+	srv, err := publishBound(l, "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Another caller detached it and is still tearing it down.
+	winner, _ := l.Take()
+	require.NotNil(t, winner)
+
+	job, inFlight := l.TakeIf(srv)
+
+	require.Nil(t, job)
+	require.Nil(
+		t, inFlight,
+		"a monitor whose server is gone has nothing of its own to wait on",
+	)
+
+	// Take, by contrast, is the loser of a genuine race and must wait.
+	_, loserWait := l.Take()
+	require.NotNil(
+		t, loserWait,
+		"Take must still hand the loser the winner's teardown",
+	)
+}
+
 // TestBindReportsLostPublication asserts Bind tells its caller when it closed
 // the socket instead of serving it, so Start does not log that a listener came
 // up when a concurrent Stop means none did.

--- a/internal/apilistener/listener_test.go
+++ b/internal/apilistener/listener_test.go
@@ -420,6 +420,37 @@ func TestBindReportsServed(t *testing.T) {
 	require.True(t, served)
 }
 
+// TestServeEnteredAfterShutdownStaysQuiet pins the residual window Bind cannot
+// close: a Stop can detach and tear down between Bind recording the listener
+// and its goroutine entering Serve, so Serve is handed an already-closed socket
+// it never serves.
+//
+// What matters is that the window is inert. Serve reports ErrServerClosed --
+// the one value the goroutine's error filter deliberately drops -- so the case
+// produces no spurious error log, and the port is released either way. The only
+// visible artifact is Start having already logged that the listener came up.
+// Closing the window entirely would need Serve to signal that it registered the
+// listener, which net/http does not expose, and would still lose to a Stop
+// landing an instant later.
+func TestServeEnteredAfterShutdownStaysQuiet(t *testing.T) {
+	addr := testutil.FreePort(t)
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	srv := &http.Server{Addr: addr} //nolint:gosec // test server
+
+	// The teardown, landing before Serve is entered.
+	require.NoError(t, srv.Shutdown(context.Background()))
+	require.NoError(t, ln.Close())
+
+	serveErr := srv.Serve(ln)
+
+	require.ErrorIs(
+		t, serveErr, http.ErrServerClosed,
+		"Serve entered after Shutdown must stay within the filtered error",
+	)
+	require.False(t, portAccepts(addr), "the port must still be released")
+}
+
 // --- shutdown coordination ----------------------------------------------
 
 // TestShutdownWaitsForAnInFlightBind asserts Stop does not report the server

--- a/internal/apilistener/listener_test.go
+++ b/internal/apilistener/listener_test.go
@@ -1,0 +1,523 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package apilistener
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// --- helpers ------------------------------------------------------------
+
+// portAccepts reports whether a TCP connection to addr succeeds.
+func portAccepts(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// newListener returns a Listener named for tests, with a discarding logger.
+func newListener() *Listener {
+	return New("Test API", nil)
+}
+
+// publish registers a bare http.Server on addr, matching how each API package
+// publishes the server it built.
+func publish(
+	l *Listener, addr string,
+) (*http.Server, chan struct{}, error) {
+	return l.Publish(func() *http.Server {
+		return &http.Server{Addr: addr} //nolint:gosec // test server
+	})
+}
+
+// startOnFreePort publishes and binds a server on a free loopback port,
+// retrying on a lost race for the port, and returns the Listener with the
+// address it bound. The caller owns shutdown.
+func startOnFreePort(t *testing.T) (*Listener, string) {
+	t.Helper()
+	var lastErr error
+	for range testutil.BindAttempts {
+		addr := testutil.FreePort(t)
+		l := newListener()
+		srv, bindDone, err := publish(l, addr)
+		require.NoError(t, err)
+		if err := l.Bind(srv, bindDone, apiconfig.EffectiveTLS{}); err != nil {
+			lastErr = err
+			continue
+		}
+		return l, addr
+	}
+	t.Fatalf(
+		"could not bind a free loopback port in %d attempts: %v",
+		testutil.BindAttempts, lastErr,
+	)
+	return nil, ""
+}
+
+// stop runs the full Stop sequence an API server's Stop performs.
+func stop(ctx context.Context, l *Listener) error {
+	job, inFlight := l.Take()
+	if job == nil {
+		return l.AwaitTeardown(ctx, inFlight)
+	}
+	return l.Shutdown(ctx, job, Graceful)
+}
+
+// --- publication --------------------------------------------------------
+
+// TestPublishRejectsASecondServer asserts a Listener holds one server at a
+// time, which is what makes a second Start fail rather than strand the first
+// server's socket with nothing left able to reach it.
+func TestPublishRejectsASecondServer(t *testing.T) {
+	l := newListener()
+	_, _, err := publish(l, "127.0.0.1:0")
+	require.NoError(t, err)
+
+	_, _, err = publish(l, "127.0.0.1:0")
+	require.ErrorContains(t, err, "already started")
+}
+
+// TestUnpublishOnlyClearsTheCurrentServer asserts a failed Start does not
+// discard a server that an overlapping Stop or restart already replaced.
+func TestUnpublishOnlyClearsTheCurrentServer(t *testing.T) {
+	l := newListener()
+	current, _, err := publish(l, "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// A stale server from an earlier, already-detached Start.
+	l.Unpublish(&http.Server{Addr: "127.0.0.1:0"}) //nolint:gosec // test server
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	require.Same(
+		t, current, l.srv,
+		"Unpublish must not clear a server it does not own",
+	)
+}
+
+// TestUnpublishClearsTheBindChannelWithTheServer asserts the fields are
+// cleared as a set. A cleared server paired with a surviving bind channel
+// would leave the next Publish's Take handing out a stale channel.
+func TestUnpublishClearsTheBindChannelWithTheServer(t *testing.T) {
+	l := newListener()
+	srv, _, err := publish(l, "127.0.0.1:0")
+	require.NoError(t, err)
+
+	l.Unpublish(srv)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	require.Nil(t, l.srv)
+	require.Nil(t, l.bindDone)
+	require.Nil(t, l.ln)
+}
+
+// --- the defect ---------------------------------------------------------
+
+// TestShutdownClosesAListenerServeNeverRegistered is the defect this package
+// exists for, pinned deterministically rather than by racing a real bind.
+//
+// http.Server.Shutdown closes only the listeners Serve has registered. Bind
+// hands the socket to Serve in a goroutine it does not wait for, so a Stop
+// landing in that window finds a server with nothing registered -- and
+// Shutdown alone leaves the port bound after Stop returns.
+func TestShutdownClosesAListenerServeNeverRegistered(t *testing.T) {
+	l := newListener()
+	addr := testutil.FreePort(t)
+	_, bindDone, err := publish(l, addr)
+	require.NoError(t, err)
+
+	// Stands in for Bind having opened and published the socket, with Serve
+	// not yet registered on it.
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	l.mu.Lock()
+	l.ln = ln
+	l.mu.Unlock()
+	close(bindDone)
+
+	require.NoError(t, stop(t.Context(), l))
+
+	require.False(
+		t, portAccepts(addr),
+		"Stop must release a socket Serve never registered",
+	)
+}
+
+// TestStopReleasesPortBeforeServeRegisters is the same defect through the real
+// bind path, where the window is narrow and the failure probabilistic. It
+// complements the deterministic test above rather than replacing it.
+func TestStopReleasesPortBeforeServeRegisters(t *testing.T) {
+	for i := range 100 {
+		l, addr := startOnFreePort(t)
+
+		require.NoError(t, stop(t.Context(), l))
+
+		require.False(
+			t, portAccepts(addr),
+			"listener still accepting when Stop returned "+
+				"(iteration %d)", i,
+		)
+	}
+}
+
+// --- bind ---------------------------------------------------------------
+
+// TestBindReleasesListenerWhenServerAlreadyDetached covers the window between
+// Publish and Bind recording the listener. A Stop landing inside it detaches
+// the server, so Take later hands back a nil server and shutdownServer never
+// runs -- meaning Bind must not leave its own socket bound, and must not
+// overwrite the listener of whichever server is current now.
+func TestBindReleasesListenerWhenServerAlreadyDetached(t *testing.T) {
+	l := newListener()
+	addr := testutil.FreePort(t)
+
+	// Stands in for the server a concurrent restart already published; it must
+	// survive this call untouched.
+	currentListener, err := net.Listen("tcp", testutil.FreePort(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = currentListener.Close() })
+	current := &http.Server{ //nolint:gosec // test server
+		Addr: currentListener.Addr().String(),
+	}
+	l.mu.Lock()
+	l.srv = current
+	l.ln = currentListener
+	l.mu.Unlock()
+
+	// The detached server this Bind call is bringing up.
+	detached := &http.Server{Addr: addr} //nolint:gosec // test server
+	bindDone := make(chan struct{})
+	require.NoError(
+		t, l.Bind(detached, bindDone, apiconfig.EffectiveTLS{}),
+	)
+	testutil.RequireReceive(
+		t, bindDone, time.Second,
+		"Bind must signal that the bind settled",
+	)
+
+	require.False(
+		t, portAccepts(addr),
+		"Bind must not leave a stopped server's port bound",
+	)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	require.Same(
+		t, current, l.srv,
+		"Bind must not disturb the current server",
+	)
+	require.Same(
+		t, currentListener, l.ln,
+		"Bind must not overwrite the current server's listener",
+	)
+}
+
+// TestBindSignalsBindDoneOnKeypairFailure asserts the bind channel is closed
+// even when Bind fails before it ever reaches net.Listen. A Stop waiting on
+// that channel would otherwise block until its context expired, waiting on a
+// bind that had already given up.
+func TestBindSignalsBindDoneOnKeypairFailure(t *testing.T) {
+	l := newListener()
+	srv, bindDone, err := publish(l, testutil.FreePort(t))
+	require.NoError(t, err)
+
+	missing := filepath.Join(t.TempDir(), "absent")
+	err = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{
+		Enabled:      true,
+		CertFilePath: missing,
+		KeyFilePath:  missing,
+	})
+
+	require.ErrorContains(t, err, "failed to load TLS keypair")
+	testutil.RequireReceive(
+		t, bindDone, time.Second,
+		"a failed keypair load must still signal the bind settled",
+	)
+}
+
+// TestBindSignalsBindDoneOnListenFailure asserts the same for a lost port
+// race, which is the failure an operator actually hits.
+func TestBindSignalsBindDoneOnListenFailure(t *testing.T) {
+	occupied, err := net.Listen("tcp", testutil.FreePort(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = occupied.Close() })
+
+	l := newListener()
+	srv, bindDone, err := publish(l, occupied.Addr().String())
+	require.NoError(t, err)
+
+	err = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
+
+	require.ErrorContains(t, err, "failed to listen for Test API server")
+	testutil.RequireReceive(
+		t, bindDone, time.Second,
+		"a failed bind must still signal the bind settled",
+	)
+}
+
+// --- shutdown coordination ----------------------------------------------
+
+// TestShutdownWaitsForAnInFlightBind asserts Stop does not report the server
+// down while a Bind call is still between net.Listen and releasing its socket.
+// Detaching the server is what makes that bind close its own listener, so
+// without waiting here Stop could return -- and a caller could rebind the same
+// port -- while the old socket was still open.
+func TestShutdownWaitsForAnInFlightBind(t *testing.T) {
+	l := newListener()
+
+	// Stands in for a published server whose bind has not finished yet.
+	bindDone := make(chan struct{})
+	l.mu.Lock()
+	l.srv = &http.Server{
+		Addr: testutil.FreePort(t),
+	} //nolint:gosec // test server
+	l.bindDone = bindDone
+	l.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(
+		t, stop(ctx, l), context.DeadlineExceeded,
+		"Stop must wait for the in-flight bind rather than returning",
+	)
+
+	// Once the bind settles, Stop completes.
+	close(bindDone)
+	require.NoError(t, stop(t.Context(), l))
+}
+
+// TestShutdownTearsDownEvenWhenTheBindWaitTimesOut asserts a Stop whose
+// context expires mid-wait still releases the socket it detached. The detach is
+// what makes Stop the only remaining reference to that listener, so returning
+// the wait error without tearing down would leave the port bound with nothing
+// left able to close it.
+func TestShutdownTearsDownEvenWhenTheBindWaitTimesOut(t *testing.T) {
+	l := newListener()
+	addr := testutil.FreePort(t)
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	// A published listener plus a bind that never settles.
+	l.mu.Lock()
+	l.srv = &http.Server{Addr: addr} //nolint:gosec // test server
+	l.ln = ln
+	l.bindDone = make(chan struct{})
+	l.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, stop(ctx, l), context.DeadlineExceeded)
+
+	require.False(
+		t, portAccepts(addr),
+		"Stop must release the socket it detached even when the bind "+
+			"wait times out",
+	)
+}
+
+// TestStopWaitsForATeardownItLost asserts the loser of the Take race does not
+// report the server down early. A server's Stop and its context monitor both
+// detach; only one wins, and a Stop that returned nil while the winner was
+// still releasing the port would let an immediate restart fail to bind.
+func TestStopWaitsForATeardownItLost(t *testing.T) {
+	l := newListener()
+
+	// Stands in for another caller having already detached the server and
+	// still being mid-teardown.
+	teardown := make(chan struct{})
+	l.mu.Lock()
+	l.srv = nil
+	l.teardown = teardown
+	l.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(
+		t, stop(ctx, l), context.DeadlineExceeded,
+		"Stop must wait for the teardown it lost rather than returning nil",
+	)
+
+	close(teardown)
+	require.NoError(t, stop(t.Context(), l))
+}
+
+// TestAwaitTeardownPrefersACompletedTeardown asserts a finished teardown is
+// never reported as a timeout. When the completion channel and the context are
+// both ready, select picks at random, so the loop is what makes the absence of
+// a recheck fail rather than flake.
+func TestAwaitTeardownPrefersACompletedTeardown(t *testing.T) {
+	l := newListener()
+	done := make(chan struct{})
+	close(done)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := range 200 {
+		require.NoError(
+			t, l.AwaitTeardown(ctx, done),
+			"a completed teardown must not be reported as a timeout "+
+				"(iteration %d)", i,
+		)
+	}
+}
+
+// TestTimedOutTeardownDoesNotSignalCompletionEarly asserts a Stop whose bind
+// wait times out does not mark the teardown complete. Bind still owns a socket
+// that Stop cannot close, so a second caller waiting on the teardown has to
+// keep waiting rather than read it as "the port is free".
+func TestTimedOutTeardownDoesNotSignalCompletionEarly(t *testing.T) {
+	l := newListener()
+	bindDone := make(chan struct{})
+
+	l.mu.Lock()
+	l.srv = &http.Server{
+		Addr: testutil.FreePort(t),
+	} //nolint:gosec // test server
+	l.bindDone = bindDone
+	l.mu.Unlock()
+
+	// First caller detaches and times out waiting for the bind.
+	stopCtx, cancelStop := context.WithTimeout(
+		context.Background(), 100*time.Millisecond,
+	)
+	defer cancelStop()
+	require.ErrorIs(t, stop(stopCtx, l), context.DeadlineExceeded)
+
+	// Second caller lost the detach and must not be told the teardown is done.
+	loserCtx, cancelLoser := context.WithTimeout(
+		context.Background(), 100*time.Millisecond,
+	)
+	defer cancelLoser()
+	require.ErrorIs(
+		t, stop(loserCtx, l), context.DeadlineExceeded,
+		"a teardown blocked on an in-flight bind must not report completion",
+	)
+
+	// Once the bind settles the teardown is genuinely complete.
+	close(bindDone)
+	require.NoError(t, stop(t.Context(), l))
+}
+
+// TestStopOnAnUnstartedListenerIsClean asserts Stop before Start is not an
+// error. The node stops capabilities it may never have started.
+func TestStopOnAnUnstartedListenerIsClean(t *testing.T) {
+	require.NoError(t, stop(t.Context(), newListener()))
+}
+
+// --- the contract callers rely on ---------------------------------------
+
+// TestListenerIsReusableAfterShutdown asserts a completed Stop leaves the
+// Listener able to bring another server up on the same address. This is what a
+// capability restart does -- see reinitializeAPIServers in node_lifecycle.go --
+// and it is the reason releasing the port has to be part of what Stop waits
+// for rather than something Serve gets around to later.
+func TestListenerIsReusableAfterShutdown(t *testing.T) {
+	l, addr := startOnFreePort(t)
+	require.NoError(t, stop(t.Context(), l))
+
+	srv, bindDone, err := publish(l, addr)
+	require.NoError(t, err)
+	require.NoError(
+		t, l.Bind(srv, bindDone, apiconfig.EffectiveTLS{}),
+		"rebinding after a clean Stop must succeed",
+	)
+	require.NoError(t, stop(t.Context(), l))
+}
+
+// TestConcurrentBindStopNeverLeavesThePortBound hammers the interleavings the
+// individual tests each pin one of: a bind racing Stop, two Stops racing each
+// other, and a rebind on the same address immediately after.
+//
+// The invariant is the one every caller relies on: once Stop returns without an
+// error, the address is free, so the next bind on it must succeed.
+//
+// What this does NOT cover: the paths that need a bind still in flight when a
+// wait expires. A real bind settles far too quickly for that, so a stalled bind
+// has to be constructed. Those live in
+// TestShutdownTearsDownEvenWhenTheBindWaitTimesOut,
+// TestStopWaitsForATeardownItLost, and
+// TestTimedOutTeardownDoesNotSignalCompletionEarly. Do not read a pass here as
+// covering them.
+func TestConcurrentBindStopNeverLeavesThePortBound(t *testing.T) {
+	addr := testutil.FreePort(t)
+
+	for i := range 60 {
+		l := newListener()
+
+		// Three-way contention on purpose: the bind, and two Stops. Two Stops
+		// matter -- one of them loses Take and has to wait on the winner's
+		// teardown, which is the path where a premature completion signal
+		// turns into a false "the port is free".
+		var wg sync.WaitGroup
+		stopErrs := make([]error, 2)
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			srv, bindDone, err := publish(l, addr)
+			if err != nil {
+				return
+			}
+			_ = l.Bind(srv, bindDone, apiconfig.EffectiveTLS{})
+		}()
+		for slot := range stopErrs {
+			go func() {
+				defer wg.Done()
+				stopErrs[slot] = stop(t.Context(), l)
+			}()
+		}
+		wg.Wait()
+
+		// Every Stop that returned nil made the same promise, so the strictest
+		// reading applies: if any of them reported clean, the port must be free.
+		if stopErrs[0] != nil && stopErrs[1] != nil {
+			// Both reported a timeout, which is honest: the callers were told
+			// the port may still be held, so neither is licensed to rebind.
+			continue
+		}
+		require.NoError(
+			t, stop(t.Context(), l),
+			"a second Stop must stay clean (iteration %d)", i,
+		)
+		require.False(
+			t, portAccepts(addr),
+			"Stop returned nil but the port is still accepting "+
+				"(iteration %d)", i,
+		)
+
+		// The contract Stop's nil return promises: the address is rebindable.
+		next := newListener()
+		nextSrv, bindDone, err := publish(next, addr)
+		require.NoError(t, err)
+		require.NoError(
+			t, next.Bind(nextSrv, bindDone, apiconfig.EffectiveTLS{}),
+			"rebinding after a clean Stop must succeed (iteration %d)", i,
+		)
+		require.NoError(t, stop(t.Context(), next))
+	}
+}


### PR DESCRIPTION
Closes #3217.

## The defect

`http.Server.Shutdown` closes only the listeners `Serve` has already registered. Each API server opens its socket synchronously — so a port conflict surfaces as an error from `Start` rather than a log line from a goroutine nobody is watching — then hands it to `Serve` in a goroutine it does not wait for. A `Stop` landing inside that window finds a server with nothing registered and returns with the port still bound.

Not test-only. `quiesceForLiveLifecycleOp` stops these capabilities and `reinitializeAPIServers` re-resolves them on the same configured port (`node_lifecycle.go`), so a live Restore or Truncate could fail to rebind with `EADDRINUSE`. An instrumented 500-iteration probe left the port accepting in roughly 9% of runs.

`api/mesh` already carried a fix. `api/blockfrost` and `api/utxorpc` did not.

## Approach: extract, don't copy

The mesh fix is ~150 lines of shutdown protocol whose correctness turns on details a second copy is likely to lose — its own code comments make that argument ("One implementation on purpose... Written once, the recheck cannot be present in one copy and missing from the next"). Copying it twice more would have contradicted the reasoning already written into it.

So it moves to `internal/apilistener`, alongside the existing shared `internal/apiauth`, `internal/tlsutil`, and `internal/httpcors`, and all three servers use it:

- **`Take`** — exactly one caller detaches and tears a server down. `Stop` and the context monitor `Start` launched both race for it; the loser waits on the winner's teardown rather than reporting the server down while the port is still bound.
- **`bindDone`** — `Stop` cannot outrun a bind still in flight. `Bind` closes it on every exit path, including the one where it finds its server already detached and closes its own socket instead of serving it. A bind wait that times out still tears down what it detached, but deliberately does *not* signal completion to a second caller, because `Bind` still owns a socket it could not close.
- **`teardown`** — only a genuinely finished teardown closes it, so a caller reading it as "the port is free" is right.

`ShutdownFunc` is the one axis the three differ on. `apilistener.Graceful` covers Blockfrost and Mesh. `api/utxorpc` supplies its own, keeping the escalation to a hard `Close` that unbounded `WatchTx`/`WatchMempool` streams require — the socket close then runs after the graceful, timed-out, and cancelled paths alike, since `server.Close()` reaches only the listeners `Serve` registered, which is exactly the set that may be missing ours.

`Publish` takes a build callback that runs under the listener's lock once the already-started check has passed, so each server installs its credential verifier atomically with the server it belongs to and a rejected second `Start` cannot replace a running server's.

## Second defect fixed along the way

`api/utxorpc`'s context monitor held `u.mu` across the entire shutdown it ran. A concurrent `Stop` could block on that mutex for as long as a stuck stream kept `Shutdown` busy — up to the full 30s. Detaching via `Take` removes the lock from that path; a concurrent `Stop` is now answered by the teardown wait.

## Testing

Red first, and mutation-checked rather than assumed:

- **Reproduced on unmodified `main`**: the blockfrost loop test fails under `-race` at iteration 27.
- **`api/utxorpc` does not reproduce probabilistically** — 25×100 iterations came back clean, because its `Stop` spawns a goroutine before selecting, which widens the scheduling gap. Its coverage comes from the constructed-window tests instead. Flagging this rather than claiming the loop test proved it.
- **Verified the tests catch the defect** by disabling the listener close: 4 tests fail, one deterministically (`TestShutdownClosesAListenerServeNeverRegistered`). A suite that passed against the buggy code would have been worthless here.

The protocol's own tests live with the protocol in `internal/apilistener`, including the paths needing a bind still in flight when a wait expires — a real bind settles far too quickly to race, so those windows are constructed. Six white-box tests move out of `api/mesh` for that reason; the black-box ones stay and are what prove the refactor. Each API package keeps checks that `Stop` frees the port and the address is rebindable afterwards, the latter being the production path this exists for.

`go test ./... -race` clean. Conformance clean. `golangci-lint` 0 issues; `nilaway`, `modernize`, `golines`, `make import-boundaries`, `make docs-parity` all clean.

DevNet not run — this touches no consensus, block production, or protocol path.

## Docs

`ARCHITECTURE.md` gains an "API listener lifecycle" section, and the existing `Utxorpc.Stop` passage is amended so it does not contradict the new shape. `DATABASE.md` checked and not affected.

## Note for reviewers

Issue #3217 cites `#3214` as the mesh fix. That PR is titled `fix(ledger): prevent mixed Leios transaction blocks` — the mesh listener fix rode along in that squash. The reference implementation was real; only the title is misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release API listener ports before Stop returns so capability restarts can rebind without EADDRINUSE. Old behavior: Stop could return while the socket was still bound if Serve hadn’t registered. New behavior: Stop waits for any in-flight bind, drains the server, and closes the listener; losers in the race wait for teardown.

- Extracts the lifecycle to `internal/apilistener` and wires it into `api/blockfrost`, `api/mesh`, and `api/utxorpc`.
  - `Publish(build)` creates the `http.Server` under lock; `Server()` reads it; guarded `Unpublish` for failed starts.
  - `Take` gives exactly one teardown owner; `TakeIf` detaches only when the caller’s server is still current, with the identity check running before the nil-server branch.
  - `Bind` opens synchronously (surfacing port/TLS errors), reports whether it served the socket or closed it after losing publication, and always closes the bind channel; shutdown waits for the bind, closes the socket, and only then signals completion. Docs clarify that “served” describes what Bind did, not a promise the listener remains up.
  - `Shutdown(ctx, job, ShutdownFunc)` runs a caller-supplied graceful drain, then closes the socket; `Graceful` covers `api/blockfrost` and `api/mesh`.
- Preserves `api/utxorpc`’s escalation: supplies a `ShutdownFunc` that escalates to `Close` on timeout/cancel; its context monitor now uses `TakeIf` and no longer holds a mutex across shutdown. Tests reuse the package’s bounded-stop helper.
- Tests: full protocol coverage in `internal/apilistener` (including constructed bind/teardown windows) and black-box checks in each API package that Stop frees the port and restart rebinds.
- Docs: `ARCHITECTURE.md` documents the shared lifecycle and clarifies `Bind`’s “served” semantics. No external API or config changes.

- Review focus: `internal/apilistener` wiring in the three servers; `Take`/`TakeIf` races and `Bind` reporting; `api/utxorpc` shutdown escalation and ordering.

<sup>Written for commit d720d68b7d6295b232aed080ed1a52c2036f8874. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API server shutdown reliability, ensuring listening ports are released before stopping completes.
  - API servers can now be restarted on the same address after shutdown, including during restore or truncate workflows.
  - Improved handling of concurrent starts and stops to prevent stale servers or port conflicts.
  - Preserved authentication configuration when a server is already running.

- **Documentation**
  - Added architecture documentation describing API server lifecycle, shutdown behavior, and restart guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->