### PR TITLE
feat(koios): chunked, checkpointed account-reward fetch resilience

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4986,11 +4986,16 @@ every one of #3097's own tests passes unmodified.
   pre-existing `complete = true` coverage row from before the refresh attempt
   is untouched (`CommitAccountRewardsForEpoch` is never reached on a partial
   failure), so nothing would otherwise signal that this mixed state shouldn't
-  be trusted. `fetchAccountRewardsForEpoch` closes this by calling
-  `Cache.MarkAccountCoverageIncomplete` — a single-column
-  `complete = false` downgrade that touches neither `koios_account_rewards`
-  nor the checkpoint tables — whenever a `forceRefresh` call is about to
-  return an error (chunk failure or `ctx` cancellation). This is sufficient
+  be trusted. `fetchAccountRewardsForEpoch` closes this via a shared
+  `wrapForceRefreshFailure` closure that calls `Cache.MarkAccountCoverageIncomplete`
+  — a single-column `complete = false` downgrade that touches neither
+  `koios_account_rewards` nor the checkpoint tables — wrapping *every* error
+  return once dispatch begins: a chunk failure, `ctx` cancellation, reading
+  staged rows back, the final per-chunk hash re-check, or
+  `Cache.CommitAccountRewardsForEpoch` itself. Every one of these can follow
+  chunks that already succeeded and replaced their old rows during dispatch,
+  so the same mixed-snapshot risk applies regardless of which specific step
+  fails afterward — not just an in-flight chunk error. This is sufficient
   on its own: `compareEpochAccounts`'s existing `!coverage.Complete` gate
   already refuses to run `CompareAccountEpoch`/`accountLifecycleMismatches`
   against an incomplete epoch, and `GetEpochsMissingAccountCoverage`'s

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4978,6 +4978,27 @@ every one of #3097's own tests passes unmodified.
   reached by a failed refresh attempt simply keeps whatever valid data it
   already had — no data is ever destroyed before its replacement is confirmed
   fetched.
+- **A partial force-refresh downgrades coverage instead of leaving it stale.**
+  Preserving old data (above) still leaves one hazard: if one chunk succeeds
+  with fresh (repaired) data while another fails and keeps its untouched
+  pre-refresh data, `koios_account_checked` now holds two chunks from two
+  different Koios snapshots that were never actually valid together — and the
+  pre-existing `complete = true` coverage row from before the refresh attempt
+  is untouched (`CommitAccountRewardsForEpoch` is never reached on a partial
+  failure), so nothing would otherwise signal that this mixed state shouldn't
+  be trusted. `fetchAccountRewardsForEpoch` closes this by calling
+  `Cache.MarkAccountCoverageIncomplete` — a single-column
+  `complete = false` downgrade that touches neither `koios_account_rewards`
+  nor the checkpoint tables — whenever a `forceRefresh` call is about to
+  return an error (chunk failure or `ctx` cancellation). This is sufficient
+  on its own: `compareEpochAccounts`'s existing `!coverage.Complete` gate
+  already refuses to run `CompareAccountEpoch`/`accountLifecycleMismatches`
+  against an incomplete epoch, and `GetEpochsMissingAccountCoverage`'s
+  existing `a.complete = 0` filter already re-selects the epoch for a future
+  plain (non-force-refresh) fetch attempt — which, since the untouched
+  chunk's data was never deleted, can self-heal by simply re-confirming
+  `complete = true` from the preserved checkpoint state, without requiring
+  another explicit `--force-refresh`.
 - **Selective invalidation on universe/chunk-plan change.**
   `Cache.InvalidateStaleAccountChunks` prunes staged rows/checked markers for
   any chunk hash no longer present in the current plan before dispatch —

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4168,8 +4168,9 @@ internal/koiosparity/      # shared library
   dingo_db.go              # read-only database/sql access to Dingo's metadata database
   compare.go               # field-level comparison, Mismatch category constants
   fetch.go                 # Koios fetch orchestration (worker pool per epoch)
-  fetch_accounts.go        # #3097 per-account Koios fetch (chunked, address-universe union)
-  check.go                 # parity check orchestration (pool-level + #3097 per-account comparison)
+  fetch_accounts.go        # #3097 per-account Koios fetch (address-universe union), #3099 checkpointed resume
+  account_chunk.go         # #3099 count+size bounded, content-addressed address chunking
+  check.go                 # parity check orchestration (pool-level + #3097 per-account comparison + #3099 zero-reward/lifecycle)
   report.go                # human-readable status + JSON report generation
 
 cmd/koios-parity/          # thin Cobra CLI wrapper
@@ -4876,24 +4877,22 @@ never the reverse.
   `result.Status != StatusPass` check the same way a pool-level mismatch
   already does — no separate code path, so strict mode stops the node on an
   account-level mismatch exactly as it does on a pool/aggregate one.
-- **Out of scope for #3097, left for #3099**: fully paginated/resumable/
-  rate-shaped account fetching at arbitrary scale, mid-epoch chunk-level
-  resume-from-checkpoint after a process restart, and duplicate-page
-  detection from Koios's own pagination (not applicable to
-  `/account_reward_history`, which isn't Range-paginated). #3097's chunking
-  is correct and never silently marks a partially-fetched epoch complete
-  (the coverage-gate + atomic-commit invariants above already guarantee
-  that), but does not need to survive a restart mid-epoch-fetch with a
-  resumed cursor — redoing the whole epoch's account fetch from scratch is
-  an acceptable (if not maximally efficient) fallback. Known limitation:
-  a *fully successful* fetch that happens to run before Koios has actually
-  published `/account_reward_history` for a just-closed epoch (as opposed to
-  a partial/failed fetch) can legitimately return zero rows and still be
-  recorded `complete = true` — the grace-window `reference_lag` treatment
-  above absorbs this for the duration of `--grace-hours`, but nothing
-  currently re-triggers a refetch of that epoch's account coverage once
-  Koios's real data appears after the window closes; #3099's chunking work
-  should address this alongside its other coverage-staleness invariants.
+- **Delivered by #3099** (was: "out of scope for #3097, left for #3099"):
+  byte-size-aware chunking, mid-epoch chunk-level resume-from-checkpoint
+  across a process restart, and page-safety hardening for
+  `/account_reward_history` — see the "Chunked, checkpointed account-reward
+  fetch (dingo #3099)" subsection immediately below for the design.
+  **Correction to this section's earlier assumption:** `/account_reward_history`
+  is *not* usably Range-paginated — confirmed by live testing against
+  preview: repeated requests with different `Range` values return the same
+  first row window rather than paging further, so a response landing at that
+  ceiling is indistinguishable from a silently truncated one (see #3099's
+  page-safety guard in `GetAccountRewardHistory`, which hard-errors instead
+  of accepting such a response as complete). The known zero-row/grace-window
+  limitation described above (nothing re-triggers a refetch once Koios's
+  real data appears after `--grace-hours` closes) remains open; #3099's
+  scope was fetch reliability, not coverage staleness beyond what the grace
+  window already covers.
 - **Network validation.** `Check`/`CheckEpoch` never construct a
   `KoiosClient` (they work entirely from the cache), so unlike `Fetch` they
   don't get `NewKoiosClient`'s network-allow-list check for free — both call
@@ -4903,6 +4902,94 @@ never the reverse.
   the only networks this tool ever validates against: an unvalidated
   `network` value reaching `compareEpochAccounts` could otherwise silently
   generate wrong-network-tagged stake addresses instead of erroring.
+
+#### Chunked, checkpointed account-reward fetch (dingo #3099)
+
+Extends #3097's account-fetch layer (`fetch_accounts.go`) with the
+reliability-at-scale properties its own doc comments explicitly deferred:
+byte-size-aware chunking, durable mid-epoch resume across a process restart,
+and page-safety hardening for `/account_reward_history`'s real (not
+Range-paginated) behavior. Wired directly into #3097's existing functions
+and schema rather than as a parallel implementation — `FetchEpochAccountsWithAddrs`,
+`Cache.CommitAccountRewardsForEpoch`, `koios_account_coverage`, and
+`compareEpochAccounts`'s coverage gate are all unchanged in contract and
+every one of #3097's own tests passes unmodified.
+
+- **Byte+count-bounded chunking.** `chunkAddressesByCountAndSize`
+  (`account_chunk.go`) replaces `chunkAddresses`' count-only chunking inside
+  `fetchAccountRewardsForEpoch` (the unexported implementation
+  `FetchAccountRewardsForEpoch`/`FetchEpochAccountsWithAddrs` both now call),
+  bounding each `/account_reward_history` request by both address count
+  (`--account-chunk-size`, default `koiosAccountChunkSize` = 100) and encoded
+  body size (`--account-chunk-max-bytes`, default `koiosAccountChunkMaxBytesDefault`
+  = 32 KiB). The address universe is sorted before chunking — required so the
+  same underlying address set always produces the same chunk boundaries
+  (and therefore the same content-addressed chunk hash) regardless of
+  `addressUniverse`'s incoming order, which `BuildAccountAddressUniverse`
+  does not itself guarantee is stable across calls.
+- **Durable per-chunk checkpoint, resumable across a restart.** Two new
+  tables, purely additive alongside #3097's `koios_account_rewards`/
+  `koios_account_coverage`: `koios_account_fetch_staged_rows` (a chunk's
+  fetched rows, staged — not yet the authoritative reference set) and
+  `koios_account_checked` (per-address "Koios answered for this address"
+  markers, keyed by `chunk_hash`, doubling as the done-chunk signal via
+  `Cache.GetDoneAccountChunkHashes`). Each chunk that succeeds calls
+  `Cache.SaveAccountFetchChunkProgress` immediately rather than only
+  accumulating rows in memory the way #3097's original implementation did.
+  On any chunk error, `fetchAccountRewardsForEpoch` returns early exactly as
+  #3097's version did (nothing committed to `koios_account_rewards`/
+  `koios_account_coverage`) — but the checkpointed chunks' progress survives,
+  so a subsequent call (after a process restart or a retried `fetch`) skips
+  them and only re-fetches whatever never completed, instead of redoing the
+  whole epoch from scratch. Once every chunk in the current plan is
+  checkpointed, `Cache.GetStagedAccountRows` reads them all back and calls
+  the existing, unmodified `Cache.CommitAccountRewardsForEpoch` exactly
+  once — the same atomic replace-and-gate #3097 always used, now fed from
+  durable staging instead of an in-memory slice.
+- **Selective invalidation on universe/chunk-plan change.**
+  `Cache.InvalidateStaleAccountChunks` prunes staged rows/checked markers for
+  any chunk hash no longer present in the current plan before dispatch —
+  because chunk hashes are content-addressed, only chunks whose address
+  grouping actually changed (a changed address universe, or an operator
+  tuning `--account-chunk-size`/`--account-chunk-max-bytes` between runs) are
+  invalidated; an unaffected chunk keeps its checkpointed progress and still
+  counts as done.
+- **Page-safety hardening.** `/account_reward_history` is not usably
+  Range-paginated — confirmed live against preview: repeated requests with
+  different `Range` values return the same first row window rather than
+  paging further. `GetAccountRewardHistory` therefore hard-errors
+  (`ErrKoiosPermanent`) whenever a response reaches `koiosPageSize` (1000)
+  rows rather than accepting a response that size as a complete, trustworthy
+  answer — there is no reliable way to fetch "the rest," so the only safe
+  response is to refuse and require a smaller `--account-chunk-size`, never
+  silently truncate. `get()`/`post()` also now bound every response body
+  read at `koiosMaxResponseBytes` (32 MiB), a defensive ceiling neither had
+  before.
+- **Zero-reward and lifecycle reporting.** `koios_account_checked` also
+  answers two dimensions #3097's `CompareAccountEpoch` structurally cannot:
+  it only ever compares keys present in at least one side's row map, so a
+  confirmed-zero-reward address (Koios answered, no reward, so no row is
+  ever emitted for it) never enters that comparison at all, and #3097's
+  address universe is a single flat list reused across every epoch in one
+  run, with no per-epoch persisted snapshot to diff for newly-registered/
+  deregistered accounts. `accountLifecycleMismatches` (`check.go`), appended
+  to `compareEpochAccounts`'s result, reports both via three new categories —
+  `CategoryAcctZeroReward`, `CategoryAcctNewlyRegistered`,
+  `CategoryAcctDeregistered` — all purely informational: `DetermineStatus`
+  has a dedicated no-op case for them, so none can ever turn an otherwise
+  clean epoch into `FAIL` or `ERROR`. The lifecycle diff only trusts the
+  previous epoch's persisted universe once that epoch's own
+  `koios_account_coverage.complete` is true; an absent or incomplete
+  previous fetch disables the report entirely rather than flagging every
+  current address as newly registered.
+- **Configuration.** `--account-chunk-size`/`--account-chunk-max-bytes`
+  (standalone CLI: `fetch`/`run`/`watch`) thread through `FetchConfig`/
+  `ObserverConfig` the same way `GraceHours` already does, down to
+  `dingo.KoiosParityConfig.AccountChunkSize`/`AccountChunkMaxBytes` and
+  `internal/config.KoiosParityConfig`'s matching YAML/env fields
+  (`DINGO_KOIOS_PARITY_ACCOUNT_CHUNK_SIZE`/`_MAX_BYTES`) for the in-process
+  observer. 0 for either (the default) selects the package default —
+  existing `--accounts` behavior is unchanged unless explicitly tuned.
 
 ### Bark (`bark/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4945,7 +4945,15 @@ every one of #3097's own tests passes unmodified.
   checkpointed, `Cache.GetStagedAccountRows` reads them all back and calls
   the existing, unmodified `Cache.CommitAccountRewardsForEpoch` exactly
   once — the same atomic replace-and-gate #3097 always used, now fed from
-  durable staging instead of an in-memory slice.
+  durable staging instead of an in-memory slice. **Neither staging table is
+  ever bulk-cleared after a successful commit** — `koios_account_checked`
+  must persist indefinitely since the zero-reward/lifecycle reporting below
+  reads it long after the fetch completes, and `koios_account_fetch_staged_rows`
+  must persist too so a later idempotent re-run of an already-complete epoch
+  (e.g. `--force-refresh` with an unchanged universe) finds real rows to
+  re-commit instead of committing an empty set over the correct one; the two
+  tables grow at the same rate `koios_account_rewards` itself already does,
+  which is an accepted characteristic of this cache, not a new problem.
 - **Selective invalidation on universe/chunk-plan change.**
   `Cache.InvalidateStaleAccountChunks` prunes staged rows/checked markers for
   any chunk hash no longer present in the current plan before dispatch —
@@ -4953,7 +4961,23 @@ every one of #3097's own tests passes unmodified.
   grouping actually changed (a changed address universe, or an operator
   tuning `--account-chunk-size`/`--account-chunk-max-bytes` between runs) are
   invalidated; an unaffected chunk keeps its checkpointed progress and still
-  counts as done.
+  counts as done. Both this and `Cache.SaveAccountFetchChunkProgress` run
+  their multi-table deletes/inserts inside a single transaction each, so a
+  crash partway through can never leave `koios_account_checked` pointing at
+  a chunk whose staged rows are gone (which `GetDoneAccountChunkHashes` would
+  otherwise still report as "done").
+- **A checkpointed empty chunk is not trusted during the grace window.**
+  A subtle interaction with the zero-row/grace-hours gate below: if Koios's
+  publishing lag means a chunk returns zero rows early in the grace window,
+  that chunk still checkpoints (a real HTTP success, just an empty result).
+  Naively treating it as "done" forever would mean a later retry — even
+  within the same still-open grace window — would never re-ask Koios and
+  could eventually commit a stale, empty result as `complete = true` once
+  `graceHours` elapses, silently losing rewards Koios published in the
+  meantime. `fetchAccountRewardsForEpoch` therefore only trusts a checkpointed
+  chunk as skippable when either it has genuinely non-empty staged rows
+  (`Cache.GetChunkHashesWithStagedRows`) or the grace window has already
+  closed by the time of the call — otherwise it's re-dispatched.
 - **Page-safety hardening.** `/account_reward_history` is not usably
   Range-paginated — confirmed live against preview: repeated requests with
   different `Range` values return the same first row window rather than
@@ -4963,25 +4987,49 @@ every one of #3097's own tests passes unmodified.
   answer — there is no reliable way to fetch "the rest," so the only safe
   response is to refuse and require a smaller `--account-chunk-size`, never
   silently truncate. `get()`/`post()` also now bound every response body
-  read at `koiosMaxResponseBytes` (32 MiB), a defensive ceiling neither had
-  before.
-- **Zero-reward and lifecycle reporting.** `koios_account_checked` also
-  answers two dimensions #3097's `CompareAccountEpoch` structurally cannot:
-  it only ever compares keys present in at least one side's row map, so a
+  read at `koiosMaxResponseBytes` (32 MiB) via `readBodyLimited`, a
+  defensive ceiling neither had before; `errKoiosResponseTooLarge` wraps
+  `ErrKoiosPermanent` so an oversized response is never blindly retried,
+  either within one call or automatically on a later `fetch` run (the fix is
+  a smaller configured chunk size, not a retry). Chunking also reserves a
+  fixed `koiosAccountRequestEnvelopeOverhead` (64 bytes) from the configured
+  `--account-chunk-max-bytes` budget before chunking, since
+  `chunkAddressesByCountAndSize` only bounds the address array's own encoded
+  size, not the `{"_stake_addresses":[...],"_epoch_no":N}` wrapper around
+  it — without this, the true request body could exceed a small configured
+  budget by that fixed amount on every chunk.
+- **Zero-reward and lifecycle reporting.** `accountLifecycleMismatches`
+  (`check.go`), appended to `compareEpochAccounts`'s result, answers two
+  dimensions #3097's `CompareAccountEpoch` structurally cannot: it only ever
+  compares keys present in at least one side's row map, so a
   confirmed-zero-reward address (Koios answered, no reward, so no row is
-  ever emitted for it) never enters that comparison at all, and #3097's
-  address universe is a single flat list reused across every epoch in one
-  run, with no per-epoch persisted snapshot to diff for newly-registered/
-  deregistered accounts. `accountLifecycleMismatches` (`check.go`), appended
-  to `compareEpochAccounts`'s result, reports both via three new categories —
-  `CategoryAcctZeroReward`, `CategoryAcctNewlyRegistered`,
-  `CategoryAcctDeregistered` — all purely informational: `DetermineStatus`
-  has a dedicated no-op case for them, so none can ever turn an otherwise
-  clean epoch into `FAIL` or `ERROR`. The lifecycle diff only trusts the
-  previous epoch's persisted universe once that epoch's own
-  `koios_account_coverage.complete` is true; an absent or incomplete
-  previous fetch disables the report entirely rather than flagging every
-  current address as newly registered.
+  ever emitted for it) never enters that comparison at all — this half is
+  read from `koios_account_checked` (`Cache.GetZeroRewardAccountsForEpoch`).
+  Newly-registered/deregistered accounts are diffed from **Dingo's own
+  epoch-scoped `reward_account_output` rows** at the current and previous
+  stake epoch (`dingo.GetRewardAccountOutputs`, decoded via
+  `dingoRewardAddressSet`) — deliberately *not* from
+  `koios_account_checked`'s persisted "requested universe": that set unions
+  in Koios's own all-time historical account list
+  (`BuildAccountAddressUniverse`), resolved once per `Fetch` run and reused
+  across every epoch, so it stays essentially static regardless of whether
+  an account is genuinely active/delegated in a given epoch — diffing
+  against it would make the lifecycle categories reflect almost nothing for
+  a Koios-known account, since it never leaves the union. Every row from
+  either dimension is reported as one aggregate `CheckMismatch` per category
+  (`aggregateAccountLifecycleMismatch`) — a total count plus a sample capped
+  at `maxAccountLifecycleSample` (20) addresses — rather than one row per
+  address: zero-reward accounts in particular can be the majority of a whole
+  network's address universe, and one-row-per-address would scale cache
+  growth, insert time, and JSON report size with the size of that universe.
+  All three categories — `CategoryAcctZeroReward`,
+  `CategoryAcctNewlyRegistered`, `CategoryAcctDeregistered` — are purely
+  informational: `DetermineStatus` has a dedicated no-op case for them, so
+  none can ever turn an otherwise clean epoch into `FAIL` or `ERROR`. A
+  genuine cache or Dingo DB error from either lookup is reported as
+  `CategoryDBError` rather than silently swallowed; only `stakeEpoch == 0`
+  (no valid previous stake epoch to diff against) disables the
+  newly-registered/deregistered half specifically.
 - **Configuration.** `--account-chunk-size`/`--account-chunk-max-bytes`
   (standalone CLI: `fetch`/`run`/`watch`) thread through `FetchConfig`/
   `ObserverConfig` the same way `GraceHours` already does, down to

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4950,10 +4950,21 @@ every one of #3097's own tests passes unmodified.
   must persist indefinitely since the zero-reward/lifecycle reporting below
   reads it long after the fetch completes, and `koios_account_fetch_staged_rows`
   must persist too so a later idempotent re-run of an already-complete epoch
-  (e.g. `--force-refresh` with an unchanged universe) finds real rows to
-  re-commit instead of committing an empty set over the correct one; the two
-  tables grow at the same rate `koios_account_rewards` itself already does,
-  which is an accepted characteristic of this cache, not a new problem.
+  with an unchanged universe finds real rows to re-commit instead of
+  committing an empty set over the correct one; the two tables grow at the
+  same rate `koios_account_rewards` itself already does, which is an accepted
+  characteristic of this cache, not a new problem. `--force-refresh`
+  (`FetchConfig.ForceRefresh`, threaded to `fetchAccountRewardsForEpoch` as
+  `forceRefresh`) is the one caller that deliberately bypasses all of this: it
+  invalidates every existing chunk for the epoch unconditionally before
+  dispatch (passing a nil current-plan hash list to
+  `Cache.InvalidateStaleAccountChunks`, the same "invalidate everything"
+  mechanism the empty-universe path below uses), so a forced re-run always
+  goes back to Koios and can actually repair suspected stale/corrupt cached
+  data — without it, an unchanged address universe would produce the exact
+  same content-addressed chunk hashes as before, every chunk would look
+  already "done," and `--force-refresh` would silently just re-commit the old
+  rows instead of refetching anything.
 - **Selective invalidation on universe/chunk-plan change.**
   `Cache.InvalidateStaleAccountChunks` prunes staged rows/checked markers for
   any chunk hash no longer present in the current plan before dispatch —
@@ -5049,10 +5060,17 @@ every one of #3097's own tests passes unmodified.
   none can ever turn an otherwise clean epoch into `FAIL` or `ERROR`. A
   genuine cache or Dingo DB error from either lookup is reported as
   `CategoryDBError` rather than silently swallowed, including a malformed
-  previous-epoch `reward_account_output` row (an unsupported credential
-  tag) — silently dropping such a row instead would make its address look
-  deregistered purely because it failed to decode, not because it actually
-  changed. The newly-registered/deregistered half is disabled entirely
+  previous- or current-epoch `reward_account_output` row (an unsupported
+  credential tag, counted by `dingoRewardAddressSet`'s `decodeErrs` return) —
+  silently dropping such a row instead would make its address look
+  deregistered or never-newly-registered purely because it failed to decode,
+  not because it actually changed. A decode failure on *either* side does not
+  just get reported alongside an otherwise-computed diff: the diff itself is
+  skipped entirely (only the zero-reward half above still runs) whenever
+  `prevDecodeErrs > 0 || currDecodeErrs > 0`, since an incomplete address set
+  on either side would make every other unaffected address in that set look
+  like a false lifecycle change too. The newly-registered/deregistered half is
+  also disabled entirely
   (returning only the zero-reward half, which doesn't depend on any
   historical epoch's data) in two cases: `stakeEpoch == 0` (no valid
   previous stake epoch to diff against), and when `dingo` is a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4966,18 +4966,39 @@ every one of #3097's own tests passes unmodified.
   crash partway through can never leave `koios_account_checked` pointing at
   a chunk whose staged rows are gone (which `GetDoneAccountChunkHashes` would
   otherwise still report as "done").
-- **A checkpointed empty chunk is not trusted during the grace window.**
-  A subtle interaction with the zero-row/grace-hours gate below: if Koios's
-  publishing lag means a chunk returns zero rows early in the grace window,
-  that chunk still checkpoints (a real HTTP success, just an empty result).
-  Naively treating it as "done" forever would mean a later retry — even
-  within the same still-open grace window — would never re-ask Koios and
-  could eventually commit a stale, empty result as `complete = true` once
-  `graceHours` elapses, silently losing rewards Koios published in the
-  meantime. `fetchAccountRewardsForEpoch` therefore only trusts a checkpointed
-  chunk as skippable when either it has genuinely non-empty staged rows
-  (`Cache.GetChunkHashesWithStagedRows`) or the grace window has already
-  closed by the time of the call — otherwise it's re-dispatched.
+- **A checkpointed empty chunk is not trusted during the grace window,
+  and neither is a mixed result.** A subtle interaction with the
+  zero-row/grace-hours gate below: if Koios's publishing lag means a chunk
+  returns zero rows early in the grace window, that chunk still checkpoints
+  (a real HTTP success, just an empty result). Naively treating it as
+  "done" forever would mean a later retry — even within the same still-open
+  grace window — would never re-ask Koios and could eventually commit a
+  stale, empty result as `complete = true` once `graceHours` elapses,
+  silently losing rewards Koios published in the meantime.
+  `fetchAccountRewardsForEpoch` therefore only trusts a checkpointed chunk as
+  skippable (not re-dispatched) when either it has genuinely non-empty
+  staged rows (`Cache.GetChunkHashesWithStagedRows`) or the grace window has
+  already closed by the time of the call. The same care applies to the
+  final `complete` decision itself: it is not "did the aggregate staged-row
+  total across all chunks end up non-zero" (one non-empty chunk would
+  trivially satisfy that even while a different chunk in the very same plan
+  is still empty-and-lagging) but "does *every* chunk in the current plan
+  have a currently-real result" — re-checked via
+  `Cache.GetChunkHashesWithStagedRows` after dispatch, not reused from
+  before it, so a chunk that resolved during this very call is counted.
+- **An empty universe invalidates, not just skips, prior checkpoint data.**
+  If the address universe shrinks to empty after a previous, non-empty
+  attempt already left checkpoint rows behind for this `(network, epoch)`
+  (e.g. Dingo's `reward_account_output` rows for this stake epoch were
+  pruned/rolled back between calls), `fetchAccountRewardsForEpoch`'s
+  empty-universe path calls `Cache.InvalidateStaleAccountChunks` with a nil
+  current-plan hash list — deleting every existing chunk's checkpoint data,
+  since content-addressed invalidation treats "not in the current plan" as
+  stale for any hash not present in the (empty) list. Skipping this would
+  leave the old universe's rows in `koios_account_checked` even though
+  `koios_account_rewards`/`koios_account_coverage` correctly read empty —
+  and `accountLifecycleMismatches` (below) would then read those stale rows
+  as if they belonged to this epoch's current, correctly-empty universe.
 - **Page-safety hardening.** `/account_reward_history` is not usably
   Range-paginated — confirmed live against preview: repeated requests with
   different `Range` values return the same first row window rather than
@@ -5027,9 +5048,22 @@ every one of #3097's own tests passes unmodified.
   informational: `DetermineStatus` has a dedicated no-op case for them, so
   none can ever turn an otherwise clean epoch into `FAIL` or `ERROR`. A
   genuine cache or Dingo DB error from either lookup is reported as
-  `CategoryDBError` rather than silently swallowed; only `stakeEpoch == 0`
-  (no valid previous stake epoch to diff against) disables the
-  newly-registered/deregistered half specifically.
+  `CategoryDBError` rather than silently swallowed, including a malformed
+  previous-epoch `reward_account_output` row (an unsupported credential
+  tag) — silently dropping such a row instead would make its address look
+  deregistered purely because it failed to decode, not because it actually
+  changed. The newly-registered/deregistered half is disabled entirely
+  (returning only the zero-reward half, which doesn't depend on any
+  historical epoch's data) in two cases: `stakeEpoch == 0` (no valid
+  previous stake epoch to diff against), and when `dingo` is a
+  `*DatabaseSource` — the in-process observer's reward source, which reads
+  `reward_account_output` through core-mode's rolling pruning window and
+  cannot distinguish "the previous stake epoch genuinely had no reward
+  accounts" from "its rows have since been pruned" (both surface as an
+  empty, error-free result); treating a pruned-empty result as a complete
+  previous-epoch universe would make every current account look newly
+  registered. Only `*DingoDB` (the standalone CLI's full, unpruned copy) is
+  trusted for this diff.
 - **Configuration.** `--account-chunk-size`/`--account-chunk-max-bytes`
   (standalone CLI: `fetch`/`run`/`watch`) thread through `FetchConfig`/
   `ObserverConfig` the same way `GraceHours` already does, down to

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4955,16 +4955,29 @@ every one of #3097's own tests passes unmodified.
   same rate `koios_account_rewards` itself already does, which is an accepted
   characteristic of this cache, not a new problem. `--force-refresh`
   (`FetchConfig.ForceRefresh`, threaded to `fetchAccountRewardsForEpoch` as
-  `forceRefresh`) is the one caller that deliberately bypasses all of this: it
-  invalidates every existing chunk for the epoch unconditionally before
-  dispatch (passing a nil current-plan hash list to
-  `Cache.InvalidateStaleAccountChunks`, the same "invalidate everything"
-  mechanism the empty-universe path below uses), so a forced re-run always
-  goes back to Koios and can actually repair suspected stale/corrupt cached
-  data — without it, an unchanged address universe would produce the exact
-  same content-addressed chunk hashes as before, every chunk would look
-  already "done," and `--force-refresh` would silently just re-commit the old
-  rows instead of refetching anything.
+  `forceRefresh`) is the one caller that deliberately bypasses the "trust an
+  already-checkpointed chunk" behavior — without it, an unchanged address
+  universe would produce the exact same content-addressed chunk hashes as
+  before, every chunk would look already "done," and `--force-refresh` would
+  silently just re-commit the old rows instead of refetching anything.
+  Critically, this bypass is done by ignoring `doneHashes` in the
+  pending-chunk filter, **never** by pre-invalidating (deleting) the existing
+  checkpoint data before dispatch: an earlier version of this fix called
+  `Cache.InvalidateStaleAccountChunks` with a nil current-plan hash list up
+  front, which — if the forced refresh then failed partway (e.g. a Koios
+  outage mid-refresh) — left `koios_account_checked`/
+  `koios_account_fetch_staged_rows` wiped or partial for an epoch whose
+  `koios_account_coverage` row still (correctly) reported `complete = true`
+  from the last successful run, since `CommitAccountRewardsForEpoch` is never
+  reached on a partial failure. That mismatch would make a later
+  Observer/Fetch attempt never retry (coverage already looks complete) while
+  `accountLifecycleMismatches` read the wiped/partial state as if it belonged
+  to a genuinely complete epoch. Each chunk's own `SaveAccountFetchChunkProgress`
+  call already replaces just that chunk's rows atomically once its re-fetch
+  succeeds, so leaving old data in place until then means a chunk never
+  reached by a failed refresh attempt simply keeps whatever valid data it
+  already had — no data is ever destroyed before its replacement is confirmed
+  fetched.
 - **Selective invalidation on universe/chunk-plan change.**
   `Cache.InvalidateStaleAccountChunks` prunes staged rows/checked markers for
   any chunk hash no longer present in the current plan before dispatch —

--- a/cmd/koios-parity/fetch.go
+++ b/cmd/koios-parity/fetch.go
@@ -45,6 +45,7 @@ phase then opens Dingo's metadata database read-only (see --metadata-plugin/
 	cmd.Flags().Int("grace-hours", defaultGraceHours,
 		"a just-closed epoch's zero-row --accounts fetch within this window is retried, not accepted as final (see check/run/watch's identical flag)")
 	addAccountsFlag(cmd)
+	addAccountChunkFlags(cmd)
 	// Only used when --accounts is set (see fetchRun): the standalone fetch
 	// command otherwise never contacts Dingo's database at all.
 	addDingoDBFlags(cmd)
@@ -63,6 +64,10 @@ func fetchRun(cmd *cobra.Command, _ []string) error {
 	throughEpoch, _ := cmd.Flags().GetUint64("through-epoch")
 	forceRefresh, _ := cmd.Flags().GetBool("force-refresh")
 	graceHours, err := resolveGraceHours(cmd)
+	if err != nil {
+		return err
+	}
+	accountChunkSize, accountChunkMaxBytes, err := resolveAccountChunkFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -94,16 +99,18 @@ func fetchRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	result, err := koiosparity.Fetch(cmd.Context(), koiosparity.FetchConfig{
-		Network:         network,
-		APIKey:          koiosAPIKey(cmd),
-		CachePath:       resolveCachePath(),
-		Concurrency:     concurrency,
-		FromEpoch:       fromEpoch,
-		ThroughEpoch:    throughEpoch,
-		ForceRefresh:    forceRefresh,
-		AccountsEnabled: accounts,
-		AccountsSource:  accountsSource,
-		GraceHours:      graceHours,
+		Network:              network,
+		APIKey:               koiosAPIKey(cmd),
+		CachePath:            resolveCachePath(),
+		Concurrency:          concurrency,
+		FromEpoch:            fromEpoch,
+		ThroughEpoch:         throughEpoch,
+		ForceRefresh:         forceRefresh,
+		AccountsEnabled:      accounts,
+		AccountsSource:       accountsSource,
+		GraceHours:           graceHours,
+		AccountChunkSize:     accountChunkSize,
+		AccountChunkMaxBytes: accountChunkMaxBytes,
 	}, slog.Default())
 	if err != nil {
 		return err

--- a/cmd/koios-parity/main.go
+++ b/cmd/koios-parity/main.go
@@ -452,6 +452,45 @@ func accountsEnabled(cmd *cobra.Command) bool {
 	return v == "1" || strings.EqualFold(v, "true")
 }
 
+// addAccountChunkFlags registers dingo #3099's --account-chunk-size/
+// --account-chunk-max-bytes flags, shared by fetch/run/watch (the
+// subcommands that actually issue /account_reward_history requests — check
+// only reads the cache, so it has no use for these). 0 (the default for
+// both) means "use the package default"
+// (koiosparity.koiosAccountChunkSize/koiosAccountChunkMaxBytesDefault) —
+// unset flags never change existing --accounts behavior.
+func addAccountChunkFlags(cmd *cobra.Command) {
+	cmd.Flags().Int("account-chunk-size", 0,
+		"max stake addresses per /account_reward_history request when --accounts is set (0 = package default, 100)")
+	cmd.Flags().Int("account-chunk-max-bytes", 0,
+		"max encoded body size per /account_reward_history request when --accounts is set (0 = package default, 32KiB)")
+}
+
+// resolveAccountChunkFlags reads --account-chunk-size/--account-chunk-max-bytes,
+// rejecting a negative value the same way resolveGraceHours does for
+// --grace-hours: a negative value would silently reach chunkAddressesByCountAndSize's
+// own "<=0 means use the default" branch instead of failing loudly on an
+// obviously-wrong operator input.
+func resolveAccountChunkFlags(
+	cmd *cobra.Command,
+) (size, maxBytes int, err error) {
+	size, _ = cmd.Flags().GetInt("account-chunk-size")
+	if size < 0 {
+		return 0, 0, fmt.Errorf(
+			"--account-chunk-size must not be negative, got %d (0 selects the package default)",
+			size,
+		)
+	}
+	maxBytes, _ = cmd.Flags().GetInt("account-chunk-max-bytes")
+	if maxBytes < 0 {
+		return 0, 0, fmt.Errorf(
+			"--account-chunk-max-bytes must not be negative, got %d (0 selects the package default)",
+			maxBytes,
+		)
+	}
+	return size, maxBytes, nil
+}
+
 // addDingoDB registers --metadata-plugin and --metadata-dsn on cmd and
 // should be called for every subcommand that reads from Dingo's database.
 func addDingoDBFlags(cmd *cobra.Command) {

--- a/cmd/koios-parity/run.go
+++ b/cmd/koios-parity/run.go
@@ -41,6 +41,7 @@ func addRunFlags(cmd *cobra.Command) {
 	cmd.Flags().
 		Bool("all", false, "re-check all cached epochs (not just unchecked/stale)")
 	addAccountsFlag(cmd)
+	addAccountChunkFlags(cmd)
 }
 
 func runCommand(cmd *cobra.Command, _ []string) error {
@@ -56,6 +57,10 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	concurrency, _ := cmd.Flags().GetInt("concurrency")
 	workers, _ := cmd.Flags().GetInt("workers")
 	graceHours, err := resolveGraceHours(cmd)
+	if err != nil {
+		return err
+	}
+	accountChunkSize, accountChunkMaxBytes, err := resolveAccountChunkFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -87,13 +92,15 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 
 		slog.Info("koios-parity: fetch phase starting", "network", network)
 		fetchResult, fetchErr := koiosparity.Fetch(ctx, koiosparity.FetchConfig{
-			Network:         network,
-			APIKey:          koiosAPIKey(cmd),
-			CachePath:       cachePath,
-			Concurrency:     concurrency,
-			AccountsEnabled: accounts,
-			AccountsSource:  accountsSource,
-			GraceHours:      graceHours,
+			Network:              network,
+			APIKey:               koiosAPIKey(cmd),
+			CachePath:            cachePath,
+			Concurrency:          concurrency,
+			AccountsEnabled:      accounts,
+			AccountsSource:       accountsSource,
+			GraceHours:           graceHours,
+			AccountChunkSize:     accountChunkSize,
+			AccountChunkMaxBytes: accountChunkMaxBytes,
 		}, logger)
 		if fetchErr != nil {
 			return fmt.Errorf("fetch: %w", fetchErr)

--- a/cmd/koios-parity/watch.go
+++ b/cmd/koios-parity/watch.go
@@ -43,6 +43,7 @@ Does not replace manual 'run --all' after a ledger replay.`,
 		"pools absent from Koios in recently-fetched epochs → reference_lag (not FAIL)")
 	addDingoDBFlags(cmd)
 	addAccountsFlag(cmd)
+	addAccountChunkFlags(cmd)
 
 	return cmd
 }
@@ -62,6 +63,10 @@ func watchRun(cmd *cobra.Command, _ []string) error {
 	concurrency, _ := cmd.Flags().GetInt("concurrency")
 	workers, _ := cmd.Flags().GetInt("workers")
 	graceHours, err := resolveGraceHours(cmd)
+	if err != nil {
+		return err
+	}
+	accountChunkSize, accountChunkMaxBytes, err := resolveAccountChunkFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -121,14 +126,16 @@ func watchRun(cmd *cobra.Command, _ []string) error {
 					"from", fromClosed, "through", toClosed)
 
 				fetchResult, fetchErr := koiosparity.Fetch(ctx, koiosparity.FetchConfig{
-					Network:         network,
-					APIKey:          apiKey,
-					CachePath:       cachePath,
-					Concurrency:     concurrency,
-					FromEpoch:       fromClosed,
-					ThroughEpoch:    toClosed,
-					AccountsEnabled: accounts,
-					GraceHours:      graceHours,
+					Network:              network,
+					APIKey:               apiKey,
+					CachePath:            cachePath,
+					Concurrency:          concurrency,
+					FromEpoch:            fromClosed,
+					ThroughEpoch:         toClosed,
+					AccountsEnabled:      accounts,
+					GraceHours:           graceHours,
+					AccountChunkSize:     accountChunkSize,
+					AccountChunkMaxBytes: accountChunkMaxBytes,
 					// Reuse the already-open, long-lived Dingo connection
 					// above (unused when accounts is false) rather than
 					// opening a second one — watch already keeps dingo open

--- a/config.go
+++ b/config.go
@@ -113,6 +113,12 @@ type KoiosParityConfig struct {
 	// value (false) can't be distinguished from an explicit opt-out. Pass a
 	// pointer to false to disable account-level checking explicitly.
 	Accounts *bool
+	// AccountChunkSize/AccountChunkMaxBytes (dingo #3099) bound each
+	// /account_reward_history request issued by the Accounts phase above, by
+	// both address count and encoded body size. 0 for either selects the
+	// package default. Unused when Accounts resolves to false.
+	AccountChunkSize     int
+	AccountChunkMaxBytes int
 }
 
 // OffchainMetadataConfig controls API-mode off-chain metadata fetching.
@@ -700,13 +706,15 @@ func (c *Config) syncCompatFields() {
 	// so the mirror always carries a non-nil pointer.
 	koiosParityAccounts := c.cfg.KoiosParity.Accounts
 	c.koiosParity = KoiosParityConfig{
-		Enabled:    c.cfg.KoiosParity.Enabled,
-		Network:    c.cfg.KoiosParity.Network,
-		CachePath:  c.cfg.KoiosParity.CachePath,
-		APIKey:     c.cfg.KoiosParity.APIKey,
-		Strict:     c.cfg.KoiosParity.Strict,
-		GraceHours: c.cfg.KoiosParity.GraceHours,
-		Accounts:   &koiosParityAccounts,
+		Enabled:              c.cfg.KoiosParity.Enabled,
+		Network:              c.cfg.KoiosParity.Network,
+		CachePath:            c.cfg.KoiosParity.CachePath,
+		APIKey:               c.cfg.KoiosParity.APIKey,
+		Strict:               c.cfg.KoiosParity.Strict,
+		GraceHours:           c.cfg.KoiosParity.GraceHours,
+		Accounts:             &koiosParityAccounts,
+		AccountChunkSize:     c.cfg.KoiosParity.AccountChunkSize,
+		AccountChunkMaxBytes: c.cfg.KoiosParity.AccountChunkMaxBytes,
 	}
 	c.midnight = MidnightConfig{
 		Enabled:                     c.cfg.Midnight.Enabled,
@@ -1470,13 +1478,15 @@ func WithKoiosParity(cfg KoiosParityConfig) ConfigOptionFunc {
 			accounts = *cfg.Accounts
 		}
 		c.cfg.KoiosParity = internalconfig.KoiosParityConfig{
-			Enabled:    cfg.Enabled,
-			Network:    cfg.Network,
-			CachePath:  cfg.CachePath,
-			APIKey:     cfg.APIKey,
-			Strict:     cfg.Strict,
-			GraceHours: cfg.GraceHours,
-			Accounts:   accounts,
+			Enabled:              cfg.Enabled,
+			Network:              cfg.Network,
+			CachePath:            cfg.CachePath,
+			APIKey:               cfg.APIKey,
+			Strict:               cfg.Strict,
+			GraceHours:           cfg.GraceHours,
+			Accounts:             accounts,
+			AccountChunkSize:     cfg.AccountChunkSize,
+			AccountChunkMaxBytes: cfg.AccountChunkMaxBytes,
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,25 +282,25 @@ type HistoryExpiryConfig struct {
 // subsystem — leave it disabled for normal node operation.
 type KoiosParityConfig struct {
 	// Enabled subscribes the observer to epoch.transition when true.
-	Enabled bool `yaml:"enabled"    envconfig:"DINGO_KOIOS_PARITY_ENABLED"`
+	Enabled bool `yaml:"enabled"              envconfig:"DINGO_KOIOS_PARITY_ENABLED"`
 	// Network is the Koios network to validate against: "preview" or
 	// "preprod". Empty defaults to the node's own configured Network.
-	Network string `yaml:"network"    envconfig:"DINGO_KOIOS_PARITY_NETWORK"`
+	Network string `yaml:"network"              envconfig:"DINGO_KOIOS_PARITY_NETWORK"`
 	// CachePath is the Koios reference cache.db path. Empty defaults to
 	// {DatabasePath}/.koios/cache.db, matching cmd/koios-parity's own
 	// default cache location.
-	CachePath string `yaml:"cachePath"  envconfig:"DINGO_KOIOS_PARITY_CACHE_PATH"`
+	CachePath string `yaml:"cachePath"            envconfig:"DINGO_KOIOS_PARITY_CACHE_PATH"`
 	// APIKey is the Koios Bearer token for higher-rate-limit access. Empty
 	// uses Koios's unauthenticated rate limit.
-	APIKey string `yaml:"apiKey"     envconfig:"DINGO_KOIOS_PARITY_API_KEY"`
+	APIKey string `yaml:"apiKey"               envconfig:"DINGO_KOIOS_PARITY_API_KEY"`
 	// Strict stops/cancels the node on the first Koios/tool error or exact
 	// parity mismatch, rather than logging it and continuing normal node
 	// operation.
-	Strict bool `yaml:"strict"     envconfig:"DINGO_KOIOS_PARITY_STRICT"`
+	Strict bool `yaml:"strict"               envconfig:"DINGO_KOIOS_PARITY_STRICT"`
 	// GraceHours is the window after an epoch closes during which a
 	// Dingo-side row still missing is treated as reference/sync lag rather
 	// than a failure. 0 selects the default (24).
-	GraceHours int `yaml:"graceHours" envconfig:"DINGO_KOIOS_PARITY_GRACE_HOURS"`
+	GraceHours int `yaml:"graceHours"           envconfig:"DINGO_KOIOS_PARITY_GRACE_HOURS"`
 	// Accounts additionally runs #3097's per-account exact-parity fetch+check
 	// phase for every epoch the observer processes, alongside the existing
 	// epoch-aggregate/pool phases. Defaults to true (see
@@ -311,7 +311,14 @@ type KoiosParityConfig struct {
 	// cmd/koios-parity's addAccountsFlag). Set false explicitly to keep the
 	// observer pool-level-only, e.g. to bound Koios request volume on a
 	// resource-constrained deployment.
-	Accounts bool `yaml:"accounts"   envconfig:"DINGO_KOIOS_PARITY_ACCOUNTS"`
+	Accounts bool `yaml:"accounts"             envconfig:"DINGO_KOIOS_PARITY_ACCOUNTS"`
+	// AccountChunkSize/AccountChunkMaxBytes (dingo #3099) bound each
+	// /account_reward_history request issued by the Accounts phase above, by
+	// both address count and encoded body size. 0 for either selects the
+	// package default (koiosparity.koiosAccountChunkSize/
+	// koiosAccountChunkMaxBytesDefault). Unused when Accounts is false.
+	AccountChunkSize     int `yaml:"accountChunkSize"     envconfig:"DINGO_KOIOS_PARITY_ACCOUNT_CHUNK_SIZE"`
+	AccountChunkMaxBytes int `yaml:"accountChunkMaxBytes" envconfig:"DINGO_KOIOS_PARITY_ACCOUNT_CHUNK_MAX_BYTES"`
 }
 
 // DefaultKoiosParityConfig returns the default (disabled) Koios parity

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -357,6 +357,16 @@ var flagSpecs = []flagSpec{
 		"koios-parity-accounts",
 		"also validate #3097 per-account exact reward parity for every epoch (default: true)",
 	),
+	intFlag(
+		"KoiosParity.AccountChunkSize",
+		"koios-parity-account-chunk-size",
+		"max stake addresses per /account_reward_history request (0 = package default, 100)",
+	),
+	intFlag(
+		"KoiosParity.AccountChunkMaxBytes",
+		"koios-parity-account-chunk-max-bytes",
+		"max encoded body size per /account_reward_history request (0 = package default, 32KiB)",
+	),
 
 	// Peer governance
 	intFlag(

--- a/internal/koiosparity/account_chunk.go
+++ b/internal/koiosparity/account_chunk.go
@@ -29,6 +29,19 @@ import (
 // --account-chunk-max-bytes down.
 const koiosAccountChunkMaxBytesDefault = 32 * 1024
 
+// koiosAccountRequestEnvelopeOverhead reserves space, out of a configured
+// --account-chunk-max-bytes budget, for the fixed JSON wrapper around
+// /account_reward_history's address array:
+// {"_stake_addresses":[...],"_epoch_no":18446744073709551615} — the
+// "_stake_addresses":/"_epoch_no": key names, braces, and the widest
+// possible uint64 epoch number add up to roughly 60 bytes regardless of how
+// many addresses are in the array; chunkAddressesByCountAndSize itself only
+// bounds the array's own encoded size, so fetchAccountRewardsForEpoch
+// subtracts this constant from the configured budget before chunking —
+// otherwise the true request body could exceed the configured bound by this
+// fixed amount every time.
+const koiosAccountRequestEnvelopeOverhead = 64
+
 // hashAddressChunk returns a content-addressed identifier for one chunk's
 // address set: sha256 of the addresses joined in the given order. Called
 // with an already-sorted chunk (chunkAddressesByCountAndSize's chunks are

--- a/internal/koiosparity/account_chunk.go
+++ b/internal/koiosparity/account_chunk.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// koiosAccountChunkMaxBytesDefault is the default encoded-JSON byte bound
+// applied to a chunk's _stake_addresses array when the caller doesn't
+// configure one (chunkMaxBytes <= 0 — see fetchAccountRewardsForEpoch).
+// Generous enough that koiosAccountChunkSize (100) short bech32 addresses
+// never approach it under normal conditions, so existing count-driven
+// chunking behavior is unaffected unless an operator explicitly tunes
+// --account-chunk-max-bytes down.
+const koiosAccountChunkMaxBytesDefault = 32 * 1024
+
+// hashAddressChunk returns a content-addressed identifier for one chunk's
+// address set: sha256 of the addresses joined in the given order. Called
+// with an already-sorted chunk (chunkAddressesByCountAndSize's chunks are
+// slices of a sorted input, so the address order within a chunk is stable
+// across calls for the same universe/bounds), so the same underlying set of
+// addresses always hashes to the same value regardless of when or how many
+// times it's computed — the property FetchAccountRewardsForEpoch's resumable
+// checkpointing (koios_account_checked/koios_account_fetch_staged_rows) and
+// selective chunk invalidation depend on.
+func hashAddressChunk(addrs []string) string {
+	sum := sha256.Sum256([]byte(strings.Join(addrs, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+// chunkAddressesByCountAndSize splits a sorted address list into groups
+// bounded by both address count (maxCount) and encoded-JSON body size
+// (maxBytes) — dingo #3099's "shape requests by both account count and
+// encoded request/response size" requirement, on top of #3097's
+// count-only chunkAddresses/koiosAccountChunkSize.
+//
+// addrs must already be sorted (FetchAccountRewardsForEpoch sorts the
+// address universe before calling this) so that, for a fixed input universe
+// and fixed maxCount/maxBytes, this always produces the same chunk
+// boundaries — required for content-addressed chunk hashing (sha256 of a
+// chunk's own sorted address list) to work as a stable resume key: an
+// operator changing --account-chunk-size/--account-chunk-max-bytes between
+// runs must yield different-but-valid boundaries, never corrupt resume
+// state by silently reordering which addresses share a chunk.
+//
+// A single address whose own encoded size already exceeds maxBytes still
+// gets its own one-address chunk rather than being dropped or causing an
+// error — the byte bound shapes chunk boundaries, it never discards
+// addresses.
+func chunkAddressesByCountAndSize(
+	addrs []string,
+	maxCount, maxBytes int,
+) [][]string {
+	if maxCount <= 0 {
+		maxCount = koiosAccountChunkSize
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	var chunks [][]string
+	var current []string
+	currentBytes := 0
+
+	flush := func() {
+		if len(current) > 0 {
+			chunks = append(chunks, current)
+			current = nil
+			currentBytes = 0
+		}
+	}
+
+	for _, addr := range addrs {
+		// Encoded size of one address in a JSON string array: the quoted
+		// string plus a comma/bracket separator byte, mirroring the actual
+		// _stake_addresses request-body encoding closely enough to bound it
+		// without re-marshaling on every candidate.
+		addrBytes := len(addr) + 3
+
+		switch {
+		case maxBytes <= 0:
+			// No byte bound configured — count alone governs.
+		case len(current) == 0:
+			// Always place at least one address in a fresh chunk, even if it
+			// alone exceeds maxBytes: a byte-bound this address can never
+			// satisfy must not cause it to be dropped.
+		case currentBytes+addrBytes > maxBytes:
+			flush()
+		}
+
+		if len(current) >= maxCount {
+			flush()
+		}
+
+		current = append(current, addr)
+		currentBytes += addrBytes
+	}
+	flush()
+
+	return chunks
+}

--- a/internal/koiosparity/account_chunk_test.go
+++ b/internal/koiosparity/account_chunk_test.go
@@ -15,6 +15,9 @@
 package koiosparity
 
 import (
+	"fmt"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -60,7 +63,18 @@ func TestChunkAddressesByCountAndSizeByteBoundary(t *testing.T) {
 	addr := strings.Repeat("a", 10)
 	addrs := []string{addr, addr, addr, addr, addr, addr, addr}
 	chunks := chunkAddressesByCountAndSize(addrs, 1_000_000, 40)
-	require.NotEmpty(t, chunks)
+	// Asserting the exact chunk count (not just a per-chunk upper bound)
+	// matters: a regression that silently ignored maxBytes entirely would
+	// still satisfy "every chunk has <=3 addresses" and "total == 7" if it
+	// happened to return one single 7-address chunk, since chunks[:len-1]
+	// would then be empty and every one of its (zero) elements trivially
+	// satisfies LessOrEqual.
+	require.Len(
+		t,
+		chunks,
+		3,
+		"7x13-byte addresses @ maxBytes=40 must split into chunks of 3,3,1",
+	)
 	for _, c := range chunks[:len(chunks)-1] {
 		require.LessOrEqual(t, len(c), 3)
 	}
@@ -109,23 +123,56 @@ func TestChunkAddressesByCountAndSizeZeroMaxCountUsesDefault(t *testing.T) {
 }
 
 // TestChunkAddressesByCountAndSizeDeterministicAcrossRepeatedCalls proves the
-// same input plus the same bounds always produce byte-for-byte identical
-// chunk boundaries — the property dingo #3099's content-addressed
-// chunk-hash resume mechanism depends on.
+// property dingo #3099's content-addressed chunk-hash resume mechanism
+// actually depends on: the same underlying address *set*, fed in a
+// different order, must still produce identical chunk boundaries once
+// sorted — matching what every real caller does (fetchAccountRewardsForEpoch
+// sorts the address universe before calling this function; see its own doc
+// comment on why). Feeding the identical, unsorted slice to both calls would
+// only prove this function is a pure/deterministic function of its literal
+// input order, not the actual property that matters: BuildAccountAddressUniverse
+// does not itself guarantee stable ordering across calls, so a resumed fetch
+// must still land on the same chunk hashes even if the universe arrives in a
+// different order the second time.
 func TestChunkAddressesByCountAndSizeDeterministicAcrossRepeatedCalls(
 	t *testing.T,
 ) {
 	addrs := make([]string, 237)
 	for i := range addrs {
-		addrs[i] = strings.Repeat("z", (i%7)+1)
+		addrs[i] = strings.Repeat("z", (i%7)+1) + fmt.Sprintf("%03d", i)
 	}
-	first := chunkAddressesByCountAndSize(addrs, 20, 200)
-	second := chunkAddressesByCountAndSize(addrs, 20, 200)
+
+	// A second copy of the exact same set, in a rotated (different) order.
+	rotated := make([]string, len(addrs))
+	copy(rotated, addrs[len(addrs)/3:])
+	copy(rotated[len(addrs)-len(addrs)/3:], addrs[:len(addrs)/3])
+	require.ElementsMatch(
+		t,
+		addrs,
+		rotated,
+		"test setup sanity check: same set, different order",
+	)
+	require.NotEqual(
+		t,
+		addrs,
+		rotated,
+		"test setup sanity check: order must actually differ",
+	)
+
+	sortedAddrs := slices.Clone(addrs)
+	sort.Strings(sortedAddrs)
+	sortedRotated := slices.Clone(rotated)
+	sort.Strings(sortedRotated)
+
+	first := chunkAddressesByCountAndSize(sortedAddrs, 20, 200)
+	second := chunkAddressesByCountAndSize(sortedRotated, 20, 200)
 	require.Equal(
 		t,
 		first,
 		second,
-		"same input + same bounds must always produce identical chunk boundaries (content-addressed resume depends on this)",
+		"the same address set, sorted before chunking regardless of its "+
+			"original arrival order, must always produce identical chunk "+
+			"boundaries (content-addressed resume depends on this)",
 	)
 }
 

--- a/internal/koiosparity/account_chunk_test.go
+++ b/internal/koiosparity/account_chunk_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestChunkAddressesByCountAndSizeEmptyInput proves an empty or nil address
+// list produces no chunks at all, rather than one spurious empty chunk.
+func TestChunkAddressesByCountAndSizeEmptyInput(t *testing.T) {
+	require.Nil(t, chunkAddressesByCountAndSize(nil, 100, 1000))
+	require.Nil(t, chunkAddressesByCountAndSize([]string{}, 100, 1000))
+}
+
+// TestChunkAddressesByCountAndSizeCountBoundary proves the address-count
+// bound splits evenly-sized groups with a smaller leftover final chunk,
+// with no byte bound in play.
+func TestChunkAddressesByCountAndSizeCountBoundary(t *testing.T) {
+	addrs := make([]string, 25)
+	for i := range addrs {
+		addrs[i] = strings.Repeat("a", 5)
+	}
+	chunks := chunkAddressesByCountAndSize(addrs, 10, 0)
+	require.Len(t, chunks, 3)
+	require.Len(t, chunks[0], 10)
+	require.Len(t, chunks[1], 10)
+	require.Len(t, chunks[2], 5, "leftover final chunk")
+
+	var total int
+	for _, c := range chunks {
+		total += len(c)
+	}
+	require.Equal(t, len(addrs), total)
+}
+
+// TestChunkAddressesByCountAndSizeByteBoundary proves the encoded-body-size
+// bound caps addresses per chunk even when the count bound is effectively
+// unlimited, matching dingo #3099's "shape requests by encoded size too"
+// requirement.
+func TestChunkAddressesByCountAndSizeByteBoundary(t *testing.T) {
+	// Each address encodes as `"aaaaaaaaaa"` — 10 chars + 3 overhead bytes =
+	// 13 bytes. maxBytes=40 fits 3 addresses per chunk (39 bytes), not 4
+	// (52 bytes) — count (1_000_000) is never the limiting factor here.
+	addr := strings.Repeat("a", 10)
+	addrs := []string{addr, addr, addr, addr, addr, addr, addr}
+	chunks := chunkAddressesByCountAndSize(addrs, 1_000_000, 40)
+	require.NotEmpty(t, chunks)
+	for _, c := range chunks[:len(chunks)-1] {
+		require.LessOrEqual(t, len(c), 3)
+	}
+	var total int
+	for _, c := range chunks {
+		total += len(c)
+	}
+	require.Equal(t, len(addrs), total)
+}
+
+// TestChunkAddressesByCountAndSizeSingleOversizedAddressNotDropped proves a
+// single address whose own encoded size already exceeds maxBytes still gets
+// its own one-address chunk instead of being silently discarded.
+func TestChunkAddressesByCountAndSizeSingleOversizedAddressNotDropped(
+	t *testing.T,
+) {
+	huge := strings.Repeat("x", 500)
+	addrs := []string{huge, "short1", "short2"}
+	chunks := chunkAddressesByCountAndSize(addrs, 100, 40)
+	require.NotEmpty(t, chunks)
+	require.Equal(
+		t,
+		[]string{huge},
+		chunks[0],
+		"an address alone exceeding maxBytes still gets its own chunk, never dropped",
+	)
+	var total int
+	for _, c := range chunks {
+		total += len(c)
+	}
+	require.Equal(t, len(addrs), total)
+}
+
+// TestChunkAddressesByCountAndSizeZeroMaxCountUsesDefault proves maxCount<=0
+// falls back to koiosAccountChunkSize rather than producing one giant chunk
+// or erroring.
+func TestChunkAddressesByCountAndSizeZeroMaxCountUsesDefault(t *testing.T) {
+	addrs := make([]string, koiosAccountChunkSize+1)
+	for i := range addrs {
+		addrs[i] = "addr"
+	}
+	chunks := chunkAddressesByCountAndSize(addrs, 0, 0)
+	require.Len(t, chunks, 2)
+	require.Len(t, chunks[0], koiosAccountChunkSize)
+	require.Len(t, chunks[1], 1)
+}
+
+// TestChunkAddressesByCountAndSizeDeterministicAcrossRepeatedCalls proves the
+// same input plus the same bounds always produce byte-for-byte identical
+// chunk boundaries — the property dingo #3099's content-addressed
+// chunk-hash resume mechanism depends on.
+func TestChunkAddressesByCountAndSizeDeterministicAcrossRepeatedCalls(
+	t *testing.T,
+) {
+	addrs := make([]string, 237)
+	for i := range addrs {
+		addrs[i] = strings.Repeat("z", (i%7)+1)
+	}
+	first := chunkAddressesByCountAndSize(addrs, 20, 200)
+	second := chunkAddressesByCountAndSize(addrs, 20, 200)
+	require.Equal(
+		t,
+		first,
+		second,
+		"same input + same bounds must always produce identical chunk boundaries (content-addressed resume depends on this)",
+	)
+}
+
+// TestChunkAddressesByCountAndSizeNoByteBoundIsCountOnly proves maxBytes<=0
+// disables the byte bound entirely (count alone governs), even for
+// addresses large enough that a byte bound would otherwise split them
+// further.
+func TestChunkAddressesByCountAndSizeNoByteBoundIsCountOnly(t *testing.T) {
+	addrs := make([]string, 15)
+	for i := range addrs {
+		addrs[i] = strings.Repeat("a", 1000)
+	}
+	chunks := chunkAddressesByCountAndSize(addrs, 5, 0)
+	require.Len(t, chunks, 3)
+	for _, c := range chunks {
+		require.LessOrEqual(t, len(c), 5)
+	}
+}

--- a/internal/koiosparity/account_lifecycle_test.go
+++ b/internal/koiosparity/account_lifecycle_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountLifecycleMismatchesReportsZeroReward proves dingo #3099's
+// zero-reward-confirmed reporting: an address Koios answered for with no
+// reward rows is reported via CategoryAcctZeroReward — a dimension #3097's
+// merged CompareAccountEpoch structurally cannot see (it only ever compares
+// keys present in at least one side's row map).
+func TestAccountLifecycleMismatchesReportsZeroReward(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	now := time.Now()
+	// addr1 earns a reward (1 staged row); addr2 is confirmed checked with
+	// zero reward rows (present in addressesInChunk, no matching row).
+	require.NoError(t, cache.SaveAccountFetchChunkProgress(
+		"preview",
+		500,
+		"chunkA",
+		[]KoiosAccountRewards{
+			{StakeAddress: "addr1", RewardType: "member", Earned: "1000"},
+		},
+		[]string{"addr1", "addr2"},
+		now,
+	))
+
+	mismatches := accountLifecycleMismatches(cache, "preview", 500, now)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, "addr2", mismatches[0].StakeAddress)
+	require.Equal(t, CategoryAcctZeroReward, mismatches[0].Category)
+	require.Equal(t, "0", mismatches[0].KoiosValue)
+}
+
+// TestAccountLifecycleMismatchesReportsNewlyRegisteredAndDeregistered proves
+// the epoch-over-epoch universe diff: an address present in the current
+// epoch's checked set but not the previous epoch's is newly registered; the
+// reverse is deregistered.
+func TestAccountLifecycleMismatchesReportsNewlyRegisteredAndDeregistered(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	now := time.Now()
+	// Previous epoch (499): addrOld, addrBoth checked; coverage complete.
+	require.NoError(t, cache.SaveAccountFetchChunkProgress(
+		"preview", 499, "chunkA", nil, []string{"addrOld", "addrBoth"}, now,
+	))
+	require.NoError(t, cache.CommitAccountRewardsForEpoch(
+		"preview", 499, nil, 2, true, now,
+	))
+
+	// Current epoch (500): addrBoth, addrNew checked.
+	require.NoError(t, cache.SaveAccountFetchChunkProgress(
+		"preview", 500, "chunkA", nil, []string{"addrBoth", "addrNew"}, now,
+	))
+
+	mismatches := accountLifecycleMismatches(cache, "preview", 500, now)
+
+	var sawNew, sawDeregistered bool
+	for _, m := range mismatches {
+		switch m.Category {
+		case CategoryAcctNewlyRegistered:
+			require.Equal(t, "addrNew", m.StakeAddress)
+			sawNew = true
+		case CategoryAcctDeregistered:
+			require.Equal(t, "addrOld", m.StakeAddress)
+			sawDeregistered = true
+		case CategoryAcctZeroReward:
+			// Both addresses have zero reward rows here (nil rows passed
+			// above) — expected alongside the lifecycle categories, not
+			// asserted on further in this test.
+		default:
+			t.Fatalf("unexpected category %q", m.Category)
+		}
+	}
+	require.True(t, sawNew, "addrNew must be reported as newly registered")
+	require.True(t, sawDeregistered, "addrOld must be reported as deregistered")
+}
+
+// TestAccountLifecycleMismatchesDisablesLifecycleReportWhenPreviousEpochIncomplete
+// proves the previous epoch's universe is only trusted once its own coverage
+// is complete — an absent or incomplete previous fetch must disable the
+// newly-registered/deregistered report entirely rather than let every
+// current address look newly registered.
+func TestAccountLifecycleMismatchesDisablesLifecycleReportWhenPreviousEpochIncomplete(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	now := time.Now()
+	// Current epoch (500) has data; epoch 499 was never fetched at all.
+	require.NoError(t, cache.SaveAccountFetchChunkProgress(
+		"preview",
+		500,
+		"chunkA",
+		[]KoiosAccountRewards{
+			{StakeAddress: "addrNew", RewardType: "member", Earned: "1000"},
+		},
+		[]string{"addrNew"},
+		now,
+	))
+
+	mismatches := accountLifecycleMismatches(cache, "preview", 500, now)
+	for _, m := range mismatches {
+		require.NotEqual(
+			t,
+			CategoryAcctNewlyRegistered,
+			m.Category,
+			"no previous-epoch coverage means the lifecycle report must be disabled entirely",
+		)
+		require.NotEqual(t, CategoryAcctDeregistered, m.Category)
+	}
+}
+
+// TestAccountLifecycleMismatchesEpochZeroSkipsLifecycleReport proves epoch 0
+// (no possible previous epoch) never attempts the lifecycle diff.
+func TestAccountLifecycleMismatchesEpochZeroSkipsLifecycleReport(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	mismatches := accountLifecycleMismatches(cache, "preview", 0, time.Now())
+	require.Empty(t, mismatches)
+}
+
+// TestDetermineStatusAccountLifecycleCategoriesAreInformational proves the
+// three dingo #3099 categories never affect Status: alone they must PASS,
+// and alongside a genuine FAIL-triggering mismatch they must not mask or
+// alter that FAIL.
+func TestDetermineStatusAccountLifecycleCategoriesAreInformational(
+	t *testing.T,
+) {
+	now := time.Now()
+	onlyInformational := []CheckMismatch{
+		{Category: CategoryAcctZeroReward, CheckedAt: now},
+		{Category: CategoryAcctNewlyRegistered, CheckedAt: now},
+		{Category: CategoryAcctDeregistered, CheckedAt: now},
+	}
+	require.Equal(t, StatusPass, DetermineStatus(onlyInformational))
+
+	withRealFailure := append(
+		append([]CheckMismatch{}, onlyInformational...),
+		CheckMismatch{Category: CategoryValueMismatch, CheckedAt: now},
+	)
+	require.Equal(t, StatusFail, DetermineStatus(withRealFailure))
+}

--- a/internal/koiosparity/account_lifecycle_test.go
+++ b/internal/koiosparity/account_lifecycle_test.go
@@ -251,6 +251,112 @@ func TestAccountLifecycleMismatchesPropagatesDingoErrorAsDBError(t *testing.T) {
 	require.Equal(t, CategoryDBError, mismatches[0].Category)
 }
 
+// TestAccountLifecycleMismatchesReportsMalformedPreviousRowAsDBError proves
+// a previous-stake-epoch reward_account_output row with an unsupported
+// credential tag is reported as CategoryDBError rather than silently
+// dropped — silently dropping it would make that row's address look
+// deregistered (present last epoch, "gone" this epoch) purely because it
+// failed to decode, not because it actually changed.
+func TestAccountLifecycleMismatchesReportsMalformedPreviousRowAsDBError(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	dingo, gdb := openTestDingoDB(t)
+	defer dingo.Close() //nolint:errcheck
+
+	goodKey := testPoolKeyHash(t, 0x10)
+	badKey := testPoolKeyHash(t, 0x11)
+	poolKey := testPoolKeyHash(t, 0xAA)
+
+	// Previous stake epoch (498): one well-formed row, one with an
+	// unsupported credential tag (only 0 and 1 are valid — see
+	// StakeAddressFromCredential).
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 498, StakingKey: goodKey, PoolKeyHash: poolKey,
+		RewardType: "member", CredentialTag: 0,
+		Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 498, StakingKey: badKey, PoolKeyHash: poolKey,
+		RewardType: "member", CredentialTag: 9,
+		Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+
+	ctx := context.Background()
+	mismatches := accountLifecycleMismatches(
+		ctx, cache, dingo, "preview", 500, 499, nil, time.Now(),
+	)
+
+	var sawDecodeError bool
+	for _, m := range mismatches {
+		if m.Category == CategoryDBError &&
+			m.Field == "reward_account_output_address_decode" {
+			sawDecodeError = true
+			require.Contains(t, m.DingoValue, "1")
+		}
+	}
+	require.True(
+		t,
+		sawDecodeError,
+		"the malformed previous-epoch row must be reported, not silently dropped",
+	)
+}
+
+// TestAccountLifecycleMismatchesSkipsLifecycleDiffForPrunableSource proves
+// the newly-registered/deregistered diff is skipped entirely for a
+// *DatabaseSource — the in-process observer's reward source reads through
+// core-mode's rolling pruning window and cannot distinguish "the previous
+// stake epoch genuinely had no reward accounts" from "its rows have since
+// been pruned" (both surface as an empty, error-free result). Treating that
+// ambiguous empty result as a complete previous-epoch universe would make
+// every current account look newly registered — so the diff must not even
+// attempt it for this source type. Zero-reward reporting must still work,
+// since it doesn't depend on any historical epoch's data.
+func TestAccountLifecycleMismatchesSkipsLifecycleDiffForPrunableSource(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	// addr is confirmed checked with zero reward — zero-reward reporting
+	// should still fire even though the lifecycle diff below is skipped.
+	now := time.Now()
+	require.NoError(t, cache.SaveAccountFetchChunkProgress(
+		"preview", 500, "chunkA", nil, []string{"addr1"}, now,
+	))
+
+	db := newTestDatabaseSourceDB(t)
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+
+	mismatches := accountLifecycleMismatches(
+		context.Background(), cache, source, "preview", 500, 499, nil, now,
+	)
+
+	var sawZeroReward bool
+	for _, m := range mismatches {
+		require.NotEqual(
+			t,
+			CategoryAcctNewlyRegistered,
+			m.Category,
+			"the lifecycle diff must never run at all for a prunable source",
+		)
+		require.NotEqual(t, CategoryAcctDeregistered, m.Category)
+		if m.Category == CategoryAcctZeroReward {
+			sawZeroReward = true
+		}
+	}
+	require.True(
+		t,
+		sawZeroReward,
+		"zero-reward reporting must still work for a prunable source",
+	)
+}
+
 // TestAccountLifecycleMismatchesPropagatesCacheErrorAsDBError proves a
 // genuine cache failure while looking up zero-reward accounts is reported as
 // CategoryDBError, never silently swallowed.

--- a/internal/koiosparity/account_lifecycle_test.go
+++ b/internal/koiosparity/account_lifecycle_test.go
@@ -327,15 +327,27 @@ func TestAccountLifecycleMismatchesSkipsLifecycleDiffWhenCurrentRowsFailToDecode
 	badKey := testPoolKeyHash(t, 0x21)
 	poolKey := testPoolKeyHash(t, 0xAA)
 
-	// Previous stake epoch (498): the well-formed address only.
+	// Previous stake epoch (498): the well-formed address, plus badKey —
+	// well-formed here (tag 0) so it decodes fine into prevSet. Without this,
+	// badKey (only ever present in currentOutputs) would be absent from both
+	// sets regardless of whether currDecodeErrs is honored, and the test
+	// would pass even with the pre-fix code that silently discarded it — see
+	// this test's own history for why that made it a non-regression-test.
 	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
 		Epoch: 498, StakingKey: goodKey, PoolKeyHash: poolKey,
 		RewardType: "member", CredentialTag: 0,
 		Amount: types.Uint64(1000), Spendable: true,
 	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 498, StakingKey: badKey, PoolKeyHash: poolKey,
+		RewardType: "member", CredentialTag: 0,
+		Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
 
 	// Current stake epoch (499): the same well-formed address (still
-	// registered) plus one row with an unsupported credential tag.
+	// registered) plus badKey's row now with an unsupported credential tag —
+	// so pre-fix, badKey would be dropped from currSet, found in prevSet, and
+	// falsely reported as CategoryAcctDeregistered.
 	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
 		Epoch: 499, StakingKey: goodKey, PoolKeyHash: poolKey,
 		RewardType: "member", CredentialTag: 0,

--- a/internal/koiosparity/account_lifecycle_test.go
+++ b/internal/koiosparity/account_lifecycle_test.go
@@ -15,18 +15,29 @@
 package koiosparity
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 )
 
 // TestAccountLifecycleMismatchesReportsZeroReward proves dingo #3099's
 // zero-reward-confirmed reporting: an address Koios answered for with no
 // reward rows is reported via CategoryAcctZeroReward — a dimension #3097's
 // merged CompareAccountEpoch structurally cannot see (it only ever compares
-// keys present in at least one side's row map).
+// keys present in at least one side's row map). Reported as one aggregate
+// row (count + a capped sample), not one row per address — see
+// aggregateAccountLifecycleMismatch's doc comment. stakeEpoch=0 skips the
+// separate lifecycle (newly-registered/deregistered) diff entirely, keeping
+// this test focused on zero-reward alone.
 func TestAccountLifecycleMismatchesReportsZeroReward(t *testing.T) {
 	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
 	require.NoError(t, err)
@@ -46,17 +57,27 @@ func TestAccountLifecycleMismatchesReportsZeroReward(t *testing.T) {
 		now,
 	))
 
-	mismatches := accountLifecycleMismatches(cache, "preview", 500, now)
+	mismatches := accountLifecycleMismatches(
+		context.Background(), cache, nil, "preview", 500, 0, nil, now,
+	)
 	require.Len(t, mismatches, 1)
-	require.Equal(t, "addr2", mismatches[0].StakeAddress)
 	require.Equal(t, CategoryAcctZeroReward, mismatches[0].Category)
-	require.Equal(t, "0", mismatches[0].KoiosValue)
+	require.Equal(
+		t,
+		"1",
+		mismatches[0].KoiosValue,
+		"KoiosValue carries the affected-address count, not a single address",
+	)
+	require.Contains(t, mismatches[0].DingoValue, "addr2")
 }
 
 // TestAccountLifecycleMismatchesReportsNewlyRegisteredAndDeregistered proves
 // the epoch-over-epoch universe diff: an address present in the current
-// epoch's checked set but not the previous epoch's is newly registered; the
-// reverse is deregistered.
+// stake epoch's Dingo-committed reward_account_output rows but not the
+// previous stake epoch's is newly registered; the reverse is deregistered.
+// Uses a real DingoDB (sqlite fixture), not a hand-rolled fake, per this
+// package's existing RewardParitySource test convention
+// (dingo_db_test.go/fetch_accounts_test.go).
 func TestAccountLifecycleMismatchesReportsNewlyRegisteredAndDeregistered(
 	t *testing.T,
 ) {
@@ -64,89 +85,192 @@ func TestAccountLifecycleMismatchesReportsNewlyRegisteredAndDeregistered(
 	require.NoError(t, err)
 	defer cache.Close() //nolint:errcheck
 
+	dingo, gdb := openTestDingoDB(t)
+	defer dingo.Close() //nolint:errcheck
+
+	addrOldKey := testPoolKeyHash(t, 0x01)
+	addrBothKey := testPoolKeyHash(t, 0x02)
+	addrNewKey := testPoolKeyHash(t, 0x03)
+	poolKey := testPoolKeyHash(t, 0xAA)
+
+	// Previous stake epoch (498): addrOld, addrBoth.
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 498, StakingKey: addrOldKey, PoolKeyHash: poolKey,
+		RewardType: "member", Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 498, StakingKey: addrBothKey, PoolKeyHash: poolKey,
+		RewardType: "member", Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+
+	// Current stake epoch (499): addrBoth, addrNew.
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 499, StakingKey: addrBothKey, PoolKeyHash: poolKey,
+		RewardType: "member", Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 499, StakingKey: addrNewKey, PoolKeyHash: poolKey,
+		RewardType: "member", Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+
+	ctx := context.Background()
+	currentOutputs, err := dingo.GetRewardAccountOutputs(ctx, 499)
+	require.NoError(t, err)
+	require.Len(t, currentOutputs, 2)
+
 	now := time.Now()
-	// Previous epoch (499): addrOld, addrBoth checked; coverage complete.
-	require.NoError(t, cache.SaveAccountFetchChunkProgress(
-		"preview", 499, "chunkA", nil, []string{"addrOld", "addrBoth"}, now,
-	))
-	require.NoError(t, cache.CommitAccountRewardsForEpoch(
-		"preview", 499, nil, 2, true, now,
-	))
+	mismatches := accountLifecycleMismatches(
+		ctx, cache, dingo, "preview", 500, 499, currentOutputs, now,
+	)
 
-	// Current epoch (500): addrBoth, addrNew checked.
-	require.NoError(t, cache.SaveAccountFetchChunkProgress(
-		"preview", 500, "chunkA", nil, []string{"addrBoth", "addrNew"}, now,
-	))
-
-	mismatches := accountLifecycleMismatches(cache, "preview", 500, now)
+	wantNewAddr, err := StakeAddressFromCredential(addrNewKey, 0)
+	require.NoError(t, err)
+	wantOldAddr, err := StakeAddressFromCredential(addrOldKey, 0)
+	require.NoError(t, err)
 
 	var sawNew, sawDeregistered bool
 	for _, m := range mismatches {
 		switch m.Category {
 		case CategoryAcctNewlyRegistered:
-			require.Equal(t, "addrNew", m.StakeAddress)
+			require.Equal(t, "1", m.KoiosValue)
+			require.Contains(t, m.DingoValue, wantNewAddr)
 			sawNew = true
 		case CategoryAcctDeregistered:
-			require.Equal(t, "addrOld", m.StakeAddress)
+			require.Equal(t, "1", m.KoiosValue)
+			require.Contains(t, m.DingoValue, wantOldAddr)
 			sawDeregistered = true
-		case CategoryAcctZeroReward:
-			// Both addresses have zero reward rows here (nil rows passed
-			// above) — expected alongside the lifecycle categories, not
-			// asserted on further in this test.
 		default:
 			t.Fatalf("unexpected category %q", m.Category)
 		}
 	}
-	require.True(t, sawNew, "addrNew must be reported as newly registered")
-	require.True(t, sawDeregistered, "addrOld must be reported as deregistered")
+	require.True(
+		t,
+		sawNew,
+		"the new address must be reported as newly registered",
+	)
+	require.True(
+		t,
+		sawDeregistered,
+		"the old address must be reported as deregistered",
+	)
 }
 
-// TestAccountLifecycleMismatchesDisablesLifecycleReportWhenPreviousEpochIncomplete
-// proves the previous epoch's universe is only trusted once its own coverage
-// is complete — an absent or incomplete previous fetch must disable the
-// newly-registered/deregistered report entirely rather than let every
-// current address look newly registered.
-func TestAccountLifecycleMismatchesDisablesLifecycleReportWhenPreviousEpochIncomplete(
+// TestAccountLifecycleMismatchesZeroRewardRowCountIsBounded proves the fix
+// for a real scale problem: reporting one CheckMismatch row per zero-reward
+// address would make cache growth, insert time, and JSON report size scale
+// with the size of the account universe (Koios never emits a row at all for
+// a zero-reward account, so on a large network most checked addresses can
+// fall into this category). Regardless of how many zero-reward addresses
+// exist, exactly one aggregate row must be produced, with an accurate total
+// count and a sample capped at maxAccountLifecycleSample.
+func TestAccountLifecycleMismatchesZeroRewardRowCountIsBounded(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	now := time.Now()
+	const numZeroReward = maxAccountLifecycleSample * 5
+	addrs := make([]string, numZeroReward)
+	for i := range addrs {
+		addrs[i] = fmt.Sprintf("addr%04d", i)
+	}
+	require.NoError(t, cache.SaveAccountFetchChunkProgress(
+		"preview", 500, "chunkA", nil, addrs, now,
+	))
+
+	mismatches := accountLifecycleMismatches(
+		context.Background(), cache, nil, "preview", 500, 0, nil, now,
+	)
+	require.Len(
+		t,
+		mismatches,
+		1,
+		"any number of zero-reward addresses must still produce exactly one aggregate row",
+	)
+	require.Equal(t, strconv.Itoa(numZeroReward), mismatches[0].KoiosValue)
+	sampleAddrs := strings.Split(
+		strings.TrimPrefix(mismatches[0].DingoValue, "sample: "),
+		",",
+	)
+	require.Len(
+		t,
+		sampleAddrs,
+		maxAccountLifecycleSample,
+		"the embedded sample must never grow with the total count",
+	)
+}
+
+// TestAccountLifecycleMismatchesStakeEpochZeroSkipsLifecycleReport proves
+// stakeEpoch==0 (no possible previous stake epoch, stakeEpoch-1 would
+// underflow) skips the newly-registered/deregistered diff entirely, without
+// ever dereferencing the dingo source.
+func TestAccountLifecycleMismatchesStakeEpochZeroSkipsLifecycleReport(
 	t *testing.T,
 ) {
 	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
 	require.NoError(t, err)
 	defer cache.Close() //nolint:errcheck
 
-	now := time.Now()
-	// Current epoch (500) has data; epoch 499 was never fetched at all.
-	require.NoError(t, cache.SaveAccountFetchChunkProgress(
-		"preview",
-		500,
-		"chunkA",
-		[]KoiosAccountRewards{
-			{StakeAddress: "addrNew", RewardType: "member", Earned: "1000"},
-		},
-		[]string{"addrNew"},
-		now,
-	))
-
-	mismatches := accountLifecycleMismatches(cache, "preview", 500, now)
-	for _, m := range mismatches {
-		require.NotEqual(
-			t,
-			CategoryAcctNewlyRegistered,
-			m.Category,
-			"no previous-epoch coverage means the lifecycle report must be disabled entirely",
-		)
-		require.NotEqual(t, CategoryAcctDeregistered, m.Category)
-	}
+	mismatches := accountLifecycleMismatches(
+		context.Background(), cache, nil, "preview", 500, 0, nil, time.Now(),
+	)
+	require.Empty(t, mismatches)
 }
 
-// TestAccountLifecycleMismatchesEpochZeroSkipsLifecycleReport proves epoch 0
-// (no possible previous epoch) never attempts the lifecycle diff.
-func TestAccountLifecycleMismatchesEpochZeroSkipsLifecycleReport(t *testing.T) {
+// TestAccountLifecycleMismatchesPropagatesDingoErrorAsDBError proves a
+// genuine Dingo DB failure while fetching the previous stake epoch's
+// reward_account_output rows is reported as CategoryDBError, never silently
+// swallowed as if there were simply no lifecycle changes to report.
+func TestAccountLifecycleMismatchesPropagatesDingoErrorAsDBError(t *testing.T) {
 	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
 	require.NoError(t, err)
 	defer cache.Close() //nolint:errcheck
 
-	mismatches := accountLifecycleMismatches(cache, "preview", 0, time.Now())
-	require.Empty(t, mismatches)
+	dingo, gdb := openTestDingoDB(t)
+	defer dingo.Close() //nolint:errcheck
+
+	// Simulate a genuine Dingo DB failure (not "no rows") by closing the
+	// underlying connection before it's queried — mirrors
+	// TestCheckAccountsCoverageDBErrorIsNotConflatedWithIncompleteCoverage's
+	// established technique for this exact distinction.
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	mismatches := accountLifecycleMismatches(
+		context.Background(),
+		cache,
+		dingo,
+		"preview",
+		500,
+		499,
+		nil,
+		time.Now(),
+	)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryDBError, mismatches[0].Category)
+}
+
+// TestAccountLifecycleMismatchesPropagatesCacheErrorAsDBError proves a
+// genuine cache failure while looking up zero-reward accounts is reported as
+// CategoryDBError, never silently swallowed.
+func TestAccountLifecycleMismatchesPropagatesCacheErrorAsDBError(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	// Force a genuine query error (not "no rows") for
+	// GetZeroRewardAccountsForEpoch by dropping the table its SELECT reads
+	// from — mirrors the "break the schema, not just leave it empty"
+	// technique check_test.go's own DB-error tests already use.
+	_, err = cache.db.Exec("DROP TABLE koios_account_checked")
+	require.NoError(t, err)
+
+	mismatches := accountLifecycleMismatches(
+		context.Background(), cache, nil, "preview", 500, 0, nil, time.Now(),
+	)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryDBError, mismatches[0].Category)
 }
 
 // TestDetermineStatusAccountLifecycleCategoriesAreInformational proves the

--- a/internal/koiosparity/account_lifecycle_test.go
+++ b/internal/koiosparity/account_lifecycle_test.go
@@ -305,6 +305,75 @@ func TestAccountLifecycleMismatchesReportsMalformedPreviousRowAsDBError(
 	)
 }
 
+// TestAccountLifecycleMismatchesSkipsLifecycleDiffWhenCurrentRowsFailToDecode
+// proves the diff itself is skipped — not just reported alongside — when the
+// *current* stake epoch has a malformed reward_account_output row. Before
+// this fix, dingoRewardAddressSet's decodeErrs return value was discarded
+// for currentOutputs, so a decode failure there silently produced an
+// incomplete currSet: a well-formed address present in both epochs would
+// then look deregistered purely because a different, unrelated row failed
+// to decode, not because it actually changed.
+func TestAccountLifecycleMismatchesSkipsLifecycleDiffWhenCurrentRowsFailToDecode(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	dingo, gdb := openTestDingoDB(t)
+	defer dingo.Close() //nolint:errcheck
+
+	goodKey := testPoolKeyHash(t, 0x20)
+	badKey := testPoolKeyHash(t, 0x21)
+	poolKey := testPoolKeyHash(t, 0xAA)
+
+	// Previous stake epoch (498): the well-formed address only.
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 498, StakingKey: goodKey, PoolKeyHash: poolKey,
+		RewardType: "member", CredentialTag: 0,
+		Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+
+	// Current stake epoch (499): the same well-formed address (still
+	// registered) plus one row with an unsupported credential tag.
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 499, StakingKey: goodKey, PoolKeyHash: poolKey,
+		RewardType: "member", CredentialTag: 0,
+		Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch: 499, StakingKey: badKey, PoolKeyHash: poolKey,
+		RewardType: "member", CredentialTag: 9,
+		Amount: types.Uint64(1000), Spendable: true,
+	}).Error)
+
+	ctx := context.Background()
+	currentOutputs, err := dingo.GetRewardAccountOutputs(ctx, 499)
+	require.NoError(t, err)
+	require.Len(t, currentOutputs, 2)
+
+	now := time.Now()
+	mismatches := accountLifecycleMismatches(
+		ctx, cache, dingo, "preview", 500, 499, currentOutputs, now,
+	)
+
+	for _, m := range mismatches {
+		require.NotEqual(
+			t,
+			CategoryAcctNewlyRegistered,
+			m.Category,
+			"the lifecycle diff must be skipped entirely, not just under-reported",
+		)
+		require.NotEqual(
+			t,
+			CategoryAcctDeregistered,
+			m.Category,
+			"the still-registered address must never be misreported as deregistered "+
+				"just because an unrelated current-epoch row failed to decode",
+		)
+	}
+}
+
 // TestAccountLifecycleMismatchesSkipsLifecycleDiffForPrunableSource proves
 // the newly-registered/deregistered diff is skipped entirely for a
 // *DatabaseSource — the in-process observer's reward source reads through

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -585,6 +585,35 @@ func (c *Cache) GetAccountCoverage(
 	return &cov, nil
 }
 
+// MarkAccountCoverageIncomplete downgrades an existing koios_account_coverage
+// row for (network, epoch) to complete = false, touching nothing else —
+// not koios_account_rewards, not koios_account_checked/
+// koios_account_fetch_staged_rows. Called when a --force-refresh attempt
+// (fetchAccountRewardsForEpoch's forceRefresh path) fails partway through:
+// because forceRefresh re-dispatches every chunk without pre-invalidating
+// existing checkpoint data (deleting it up front would risk losing valid
+// data before its replacement is confirmed fetched — see that function's
+// doc comment), a partial failure can leave koios_account_checked holding a
+// mix of freshly-refreshed chunks and untouched pre-refresh chunks: two
+// different Koios snapshots that were never actually valid together. The
+// stale complete = true row from the last successful (pre-refresh) commit
+// would otherwise still make compareEpochAccounts trust that mixed state —
+// its coverage.Complete gate is exactly what stops CompareAccountEpoch/
+// accountLifecycleMismatches from reading it once this flips to false, and
+// GetEpochsMissingAccountCoverage's `a.complete = 0` filter picks the epoch
+// back up for a normal (non-force-refresh) fetch attempt to resume and
+// eventually re-commit a fresh, fully consistent complete = true row —
+// no further explicit --force-refresh required. A no-op, not an error, if
+// no coverage row exists yet for this (network, epoch).
+func (c *Cache) MarkAccountCoverageIncomplete(network string, epoch uint64) error {
+	_, err := c.db.Exec(
+		`UPDATE koios_account_coverage SET complete = 0 WHERE network = ? AND epoch = ?`,
+		network,
+		epoch,
+	)
+	return err
+}
+
 // SaveAccountFetchChunkProgress durably records one successfully-fetched
 // chunk's rows and per-address "checked" markers for (network, epoch),
 // atomically — dingo #3099's resumable checkpoint: FetchAccountRewardsForEpoch

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -1289,6 +1289,13 @@ func createCacheSchema(db *sql.DB) error {
 			stake_address TEXT NOT NULL, chunk_hash TEXT NOT NULL, reward_row_count INTEGER NOT NULL DEFAULT 0,
 			checked_at DATETIME NOT NULL)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_kaced_net_epoch_addr ON koios_account_checked(network, epoch, stake_address)`,
+		// Every per-chunk delete (SaveAccountFetchChunkProgress,
+		// InvalidateStaleAccountChunks) filters on (network, epoch, chunk_hash);
+		// without this index that lookup falls back to scanning every checked
+		// row for the whole epoch instead of just the rows for one chunk,
+		// making stale-chunk cleanup cost scale with the epoch's total address
+		// count rather than the chunk being removed.
+		`CREATE INDEX IF NOT EXISTS idx_kaced_net_epoch_chunk ON koios_account_checked(network, epoch, chunk_hash)`,
 
 		`CREATE TABLE IF NOT EXISTS check_epoch_status (
 			id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT NOT NULL, epoch INTEGER NOT NULL,

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -585,6 +585,278 @@ func (c *Cache) GetAccountCoverage(
 	return &cov, nil
 }
 
+// SaveAccountFetchChunkProgress durably records one successfully-fetched
+// chunk's rows and per-address "checked" markers for (network, epoch),
+// atomically — dingo #3099's resumable checkpoint: FetchAccountRewardsForEpoch
+// calls this once per chunk as it completes, instead of only accumulating
+// rows in memory, so a killed/restarted process resumes from whichever
+// chunks already committed here rather than redoing the whole epoch.
+//
+// Safe to call again for the same chunkHash (e.g. a resumed attempt that
+// re-fetches a chunk that was in flight but never confirmed committed): it
+// first deletes any prior staged rows/checked markers for this exact
+// (network, epoch, chunk_hash) before inserting the fresh ones, so a retry
+// can never duplicate rows.
+//
+// addressesInChunk is the full requested address list for the chunk — every
+// address gets a koios_account_checked row (reward_row_count counts how many
+// of rows belong to it) even if Koios returned zero reward rows for it,
+// which is exactly what distinguishes a confirmed zero-reward address from
+// one no chunk has ever covered.
+func (c *Cache) SaveAccountFetchChunkProgress(
+	network string,
+	epoch uint64,
+	chunkHash string,
+	rows []KoiosAccountRewards,
+	addressesInChunk []string,
+	now time.Time,
+) error {
+	tx, err := c.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.Exec(
+		`DELETE FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
+		network, epoch, chunkHash,
+	); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(
+		`DELETE FROM koios_account_checked WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
+		network, epoch, chunkHash,
+	); err != nil {
+		return err
+	}
+
+	if len(rows) > 0 {
+		var stmt *sql.Stmt
+		stmt, err = tx.Prepare(`INSERT INTO koios_account_fetch_staged_rows
+			(network, epoch, chunk_hash, stake_address, reward_type, earned, spendable_epoch, pool_id_bech32, fetched_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return err
+		}
+		defer stmt.Close() //nolint:errcheck
+		for i := range rows {
+			if _, err = stmt.Exec(
+				network, epoch, chunkHash, rows[i].StakeAddress, rows[i].RewardType,
+				rows[i].Earned, rows[i].SpendableEpoch, rows[i].PoolIDBech32, rows[i].FetchedAt,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	rewardRowCount := make(map[string]int, len(addressesInChunk))
+	for _, r := range rows {
+		rewardRowCount[r.StakeAddress]++
+	}
+	var checkedStmt *sql.Stmt
+	checkedStmt, err = tx.Prepare(`INSERT INTO koios_account_checked
+		(network, epoch, stake_address, chunk_hash, reward_row_count, checked_at)
+		VALUES (?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	defer checkedStmt.Close() //nolint:errcheck
+	for _, addr := range addressesInChunk {
+		if _, err = checkedStmt.Exec(
+			network, epoch, addr, chunkHash, rewardRowCount[addr], now,
+		); err != nil {
+			return err
+		}
+	}
+
+	err = tx.Commit()
+	return err
+}
+
+// GetDoneAccountChunkHashes returns the set of chunk hashes already
+// checkpointed for (network, epoch) — FetchAccountRewardsForEpoch skips
+// dispatching a chunk whose hash is present here on resume.
+func (c *Cache) GetDoneAccountChunkHashes(
+	network string,
+	epoch uint64,
+) (map[string]bool, error) {
+	rows, err := c.db.Query(
+		`SELECT DISTINCT chunk_hash FROM koios_account_checked WHERE network = ? AND epoch = ?`,
+		network,
+		epoch,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	done := make(map[string]bool)
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return nil, err
+		}
+		done[hash] = true
+	}
+	return done, rows.Err()
+}
+
+// GetStagedAccountRows returns every checkpointed row for (network, epoch)
+// across all committed chunks — read back once every chunk in the current
+// plan is done, then passed as-is to the existing, unmodified
+// Cache.CommitAccountRewardsForEpoch to finalize the epoch exactly the way
+// #3097 already does.
+func (c *Cache) GetStagedAccountRows(
+	network string,
+	epoch uint64,
+) ([]KoiosAccountRewards, error) {
+	rows, err := c.db.Query(
+		`SELECT stake_address, reward_type, earned, spendable_epoch, pool_id_bech32, fetched_at
+		FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ? ORDER BY id`,
+		network,
+		epoch,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []KoiosAccountRewards
+	for rows.Next() {
+		var r KoiosAccountRewards
+		if err := rows.Scan(
+			&r.StakeAddress, &r.RewardType, &r.Earned, &r.SpendableEpoch, &r.PoolIDBech32, &r.FetchedAt,
+		); err != nil {
+			return nil, err
+		}
+		r.Network, r.Epoch = network, epoch
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ClearAccountFetchStaging deletes checkpoint staging (both staged rows and
+// checked markers) for (network, epoch) — called after a successful
+// complete=true CommitAccountRewardsForEpoch, since the staged data has now
+// been folded into the authoritative koios_account_rewards/koios_account_coverage
+// and no longer needs to survive for resume purposes.
+func (c *Cache) ClearAccountFetchStaging(network string, epoch uint64) error {
+	if _, err := c.db.Exec(
+		`DELETE FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ?`,
+		network, epoch,
+	); err != nil {
+		return err
+	}
+	_, err := c.db.Exec(
+		`DELETE FROM koios_account_checked WHERE network = ? AND epoch = ?`,
+		network, epoch,
+	)
+	return err
+}
+
+// InvalidateStaleAccountChunks deletes staged rows/checked markers for any
+// chunk hash not present in currentChunkHashes — dingo #3099's "invalidate/
+// re-fetch affected chunks when request parameters or reference data change"
+// requirement. Because chunk hashes are content-addressed (sha256 of a
+// chunk's own sorted address list), only chunks whose address grouping is no
+// longer part of the current plan are pruned; an unaffected chunk (same
+// address set under the new plan) keeps its checkpointed progress and still
+// counts as done.
+func (c *Cache) InvalidateStaleAccountChunks(
+	network string,
+	epoch uint64,
+	currentChunkHashes []string,
+) error {
+	done, err := c.GetDoneAccountChunkHashes(network, epoch)
+	if err != nil {
+		return err
+	}
+	if len(done) == 0 {
+		return nil
+	}
+	current := make(map[string]bool, len(currentChunkHashes))
+	for _, h := range currentChunkHashes {
+		current[h] = true
+	}
+	for hash := range done {
+		if current[hash] {
+			continue
+		}
+		if _, err := c.db.Exec(
+			`DELETE FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
+			network, epoch, hash,
+		); err != nil {
+			return err
+		}
+		if _, err := c.db.Exec(
+			`DELETE FROM koios_account_checked WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
+			network, epoch, hash,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetZeroRewardAccountsForEpoch returns addresses Koios confirmed it
+// answered for (network, epoch) with zero reward rows — a definitive "no
+// reward this epoch," proven checked rather than merely absent from
+// koios_account_rewards.
+func (c *Cache) GetZeroRewardAccountsForEpoch(
+	network string,
+	epoch uint64,
+) ([]string, error) {
+	rows, err := c.db.Query(
+		`SELECT stake_address FROM koios_account_checked
+		WHERE network = ? AND epoch = ? AND reward_row_count = 0
+		ORDER BY stake_address`,
+		network, epoch,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var addrs []string
+	for rows.Next() {
+		var addr string
+		if err := rows.Scan(&addr); err != nil {
+			return nil, err
+		}
+		addrs = append(addrs, addr)
+	}
+	return addrs, rows.Err()
+}
+
+// GetAccountUniverseForEpoch returns the persisted set of addresses actually
+// checked for (network, epoch) — used to diff adjacent epochs' universes for
+// newly-registered/deregistered reporting without re-deriving from Dingo's
+// own source or Koios's live /account_list.
+func (c *Cache) GetAccountUniverseForEpoch(
+	network string,
+	epoch uint64,
+) ([]string, error) {
+	rows, err := c.db.Query(
+		`SELECT stake_address FROM koios_account_checked
+		WHERE network = ? AND epoch = ? ORDER BY stake_address`,
+		network, epoch,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var addrs []string
+	for rows.Next() {
+		var addr string
+		if err := rows.Scan(&addr); err != nil {
+			return nil, err
+		}
+		addrs = append(addrs, addr)
+	}
+	return addrs, rows.Err()
+}
+
 // GetFetchedEpochRange returns the min and max fetched epoch numbers.
 func (c *Cache) GetFetchedEpochRange(
 	network string,
@@ -950,6 +1222,35 @@ func createCacheSchema(db *sql.DB) error {
 			requested_count INTEGER NOT NULL DEFAULT 0, fetched_count INTEGER NOT NULL DEFAULT 0,
 			complete INTEGER NOT NULL DEFAULT 0, fetched_at DATETIME NOT NULL)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_kac_net_epoch ON koios_account_coverage(network, epoch)`,
+
+		// dingo #3099: durable per-chunk checkpoint staging so a killed/restarted
+		// FetchAccountRewardsForEpoch resumes from already-committed chunks
+		// instead of redoing the whole epoch (see fetch_accounts.go). Purely
+		// additive alongside #3097's koios_account_rewards/koios_account_coverage
+		// — CommitAccountRewardsForEpoch's contract and existing tests are
+		// untouched; these staged rows are only ever read back and passed to it
+		// once every chunk in the current plan has committed.
+		`CREATE TABLE IF NOT EXISTS koios_account_fetch_staged_rows (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT NOT NULL, epoch INTEGER NOT NULL,
+			chunk_hash TEXT NOT NULL, stake_address TEXT NOT NULL, reward_type TEXT NOT NULL,
+			earned TEXT NOT NULL, spendable_epoch INTEGER NOT NULL DEFAULT 0,
+			pool_id_bech32 TEXT NOT NULL DEFAULT '', fetched_at DATETIME NOT NULL)`,
+		`CREATE INDEX IF NOT EXISTS idx_kafsr_net_epoch ON koios_account_fetch_staged_rows(network, epoch)`,
+		`CREATE INDEX IF NOT EXISTS idx_kafsr_net_epoch_chunk ON koios_account_fetch_staged_rows(network, epoch, chunk_hash)`,
+
+		// koios_account_checked doubles as: (a) the done-chunk marker enabling
+		// resume (DISTINCT chunk_hash for (network, epoch)), (b) zero-reward-
+		// confirmed detection (reward_row_count = 0 — Koios answered for this
+		// address and it earned nothing, distinct from never having been asked
+		// about at all), and (c) the persisted per-epoch address universe used
+		// to diff newly-registered/deregistered accounts between adjacent
+		// epochs.
+		`CREATE TABLE IF NOT EXISTS koios_account_checked (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT NOT NULL, epoch INTEGER NOT NULL,
+			stake_address TEXT NOT NULL, chunk_hash TEXT NOT NULL, reward_row_count INTEGER NOT NULL DEFAULT 0,
+			checked_at DATETIME NOT NULL)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_kaced_net_epoch_addr ON koios_account_checked(network, epoch, stake_address)`,
+
 		`CREATE TABLE IF NOT EXISTS check_epoch_status (
 			id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT NOT NULL, epoch INTEGER NOT NULL,
 			last_checked_at DATETIME NOT NULL, status TEXT NOT NULL, mismatch_count INTEGER NOT NULL,

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -704,6 +704,38 @@ func (c *Cache) GetDoneAccountChunkHashes(
 	return done, rows.Err()
 }
 
+// GetChunkHashesWithStagedRows returns the set of chunk hashes for
+// (network, epoch) that have at least one row in
+// koios_account_fetch_staged_rows — i.e. chunks whose checkpointed result
+// was genuinely non-empty, as opposed to a chunk that checkpointed with zero
+// rows (see fetchAccountRewardsForEpoch's grace-window trust logic: an
+// empty-but-done chunk checkpointed while Koios's account_reward_history
+// publishing lag was still possible must not be blindly trusted as final
+// until that grace window has actually closed).
+func (c *Cache) GetChunkHashesWithStagedRows(
+	network string,
+	epoch uint64,
+) (map[string]bool, error) {
+	rows, err := c.db.Query(
+		`SELECT DISTINCT chunk_hash FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ?`,
+		network,
+		epoch,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	withRows := make(map[string]bool)
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return nil, err
+		}
+		withRows[hash] = true
+	}
+	return withRows, rows.Err()
+}
+
 // GetStagedAccountRows returns every checkpointed row for (network, epoch)
 // across all committed chunks — read back once every chunk in the current
 // plan is done, then passed as-is to the existing, unmodified
@@ -737,25 +769,6 @@ func (c *Cache) GetStagedAccountRows(
 	return out, rows.Err()
 }
 
-// ClearAccountFetchStaging deletes checkpoint staging (both staged rows and
-// checked markers) for (network, epoch) — called after a successful
-// complete=true CommitAccountRewardsForEpoch, since the staged data has now
-// been folded into the authoritative koios_account_rewards/koios_account_coverage
-// and no longer needs to survive for resume purposes.
-func (c *Cache) ClearAccountFetchStaging(network string, epoch uint64) error {
-	if _, err := c.db.Exec(
-		`DELETE FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ?`,
-		network, epoch,
-	); err != nil {
-		return err
-	}
-	_, err := c.db.Exec(
-		`DELETE FROM koios_account_checked WHERE network = ? AND epoch = ?`,
-		network, epoch,
-	)
-	return err
-}
-
 // InvalidateStaleAccountChunks deletes staged rows/checked markers for any
 // chunk hash not present in currentChunkHashes — dingo #3099's "invalidate/
 // re-fetch affected chunks when request parameters or reference data change"
@@ -764,6 +777,15 @@ func (c *Cache) ClearAccountFetchStaging(network string, epoch uint64) error {
 // longer part of the current plan are pruned; an unaffected chunk (same
 // address set under the new plan) keeps its checkpointed progress and still
 // counts as done.
+//
+// Every stale chunk's pair of deletes — and every stale chunk together —
+// runs in one transaction. Without this, a crash partway through (either
+// between a chunk's two deletes, or between two chunks) could delete a
+// chunk's staged rows but leave its koios_account_checked markers in place;
+// GetDoneAccountChunkHashes would then still report that chunk as done, so
+// fetchAccountRewardsForEpoch would skip it and GetStagedAccountRows would
+// return nothing for it — letting the epoch commit complete=true with a
+// silently incomplete reward set, exactly what #3099 must prevent.
 func (c *Cache) InvalidateStaleAccountChunks(
 	network string,
 	epoch uint64,
@@ -780,24 +802,41 @@ func (c *Cache) InvalidateStaleAccountChunks(
 	for _, h := range currentChunkHashes {
 		current[h] = true
 	}
+	var stale []string
 	for hash := range done {
-		if current[hash] {
-			continue
+		if !current[hash] {
+			stale = append(stale, hash)
 		}
-		if _, err := c.db.Exec(
+	}
+	if len(stale) == 0 {
+		return nil
+	}
+
+	tx, err := c.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, hash := range stale {
+		if _, err = tx.Exec(
 			`DELETE FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
 			network, epoch, hash,
 		); err != nil {
 			return err
 		}
-		if _, err := c.db.Exec(
+		if _, err = tx.Exec(
 			`DELETE FROM koios_account_checked WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
 			network, epoch, hash,
 		); err != nil {
 			return err
 		}
 	}
-	return nil
+	err = tx.Commit()
+	return err
 }
 
 // GetZeroRewardAccountsForEpoch returns addresses Koios confirmed it

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -899,7 +899,7 @@ func accountLifecycleMismatches(
 	// since nothing else in this package ever decodes the previous stake
 	// epoch's addresses.
 	prevSet, prevDecodeErrs := dingoRewardAddressSet(previousOutputs)
-	currSet, _ := dingoRewardAddressSet(currentOutputs)
+	currSet, currDecodeErrs := dingoRewardAddressSet(currentOutputs)
 	if prevDecodeErrs > 0 {
 		out = append(out, CheckMismatch{
 			Network: network,
@@ -912,6 +912,16 @@ func accountLifecycleMismatches(
 			Category:  CategoryDBError,
 			CheckedAt: now,
 		})
+	}
+	if prevDecodeErrs > 0 || currDecodeErrs > 0 {
+		// Either side's set is now missing an address purely because a row
+		// failed to decode, not because it actually registered/deregistered
+		// — diffing incomplete sets would misreport that row's address as
+		// newly-registered or deregistered. The decode failure itself is
+		// already reported (previous-epoch above; current-epoch by
+		// compareEpochAccounts's own dingoRows-building loop), so skip the
+		// diff rather than emit a misleading one.
+		return out
 	}
 
 	var newlyRegistered, deregistered []string

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -778,5 +778,97 @@ func compareEpochAccounts(
 			epochEndTime,
 		)...,
 	)
+	out = append(out, accountLifecycleMismatches(cache, network, epoch, now)...)
+	return out
+}
+
+// accountLifecycleMismatches (dingo #3099) reports the two account
+// dimensions #3097's CompareAccountEpoch structurally cannot: confirmed
+// zero-reward accounts and newly-registered/deregistered accounts between
+// adjacent Koios epochs. Both rely on koios_account_checked, the per-address
+// "Koios actually answered for this address" ledger
+// fetchAccountRewardsForEpoch populates as chunks commit — data #3097's
+// original implementation never persisted. Purely informational: every
+// mismatch returned here uses one of CategoryAcctZeroReward/
+// CategoryAcctNewlyRegistered/CategoryAcctDeregistered, which
+// DetermineStatus treats as a no-op, never FAIL or ERROR.
+func accountLifecycleMismatches(
+	cache *Cache,
+	network string,
+	epoch uint64,
+	now time.Time,
+) []CheckMismatch {
+	var out []CheckMismatch
+
+	zeroReward, err := cache.GetZeroRewardAccountsForEpoch(network, epoch)
+	if err == nil {
+		for _, addr := range zeroReward {
+			out = append(out, CheckMismatch{
+				Network:      network,
+				Epoch:        epoch,
+				StakeAddress: addr,
+				Field:        "account_zero_reward",
+				DingoValue:   "",
+				KoiosValue:   "0",
+				Category:     CategoryAcctZeroReward,
+				CheckedAt:    now,
+			})
+		}
+	}
+
+	if epoch == 0 {
+		return out
+	}
+	// Only trust the previous epoch's persisted universe once its own
+	// account fetch reached coverage.Complete — an incomplete or
+	// never-attempted previous fetch must disable the lifecycle report
+	// rather than let every current address look newly registered.
+	prevCoverage, prevCovErr := cache.GetAccountCoverage(network, epoch-1)
+	if prevCovErr != nil || prevCoverage == nil || !prevCoverage.Complete {
+		return out
+	}
+	previousUniverse, err := cache.GetAccountUniverseForEpoch(network, epoch-1)
+	if err != nil {
+		return out
+	}
+	currentUniverse, err := cache.GetAccountUniverseForEpoch(network, epoch)
+	if err != nil {
+		return out
+	}
+
+	prevSet := make(map[string]bool, len(previousUniverse))
+	for _, a := range previousUniverse {
+		prevSet[a] = true
+	}
+	currSet := make(map[string]bool, len(currentUniverse))
+	for _, a := range currentUniverse {
+		currSet[a] = true
+		if !prevSet[a] {
+			out = append(out, CheckMismatch{
+				Network:      network,
+				Epoch:        epoch,
+				StakeAddress: a,
+				Field:        "account_lifecycle",
+				DingoValue:   "",
+				KoiosValue:   "newly_registered",
+				Category:     CategoryAcctNewlyRegistered,
+				CheckedAt:    now,
+			})
+		}
+	}
+	for _, a := range previousUniverse {
+		if !currSet[a] {
+			out = append(out, CheckMismatch{
+				Network:      network,
+				Epoch:        epoch,
+				StakeAddress: a,
+				Field:        "account_lifecycle",
+				DingoValue:   "deregistered",
+				KoiosValue:   "",
+				Category:     CategoryAcctDeregistered,
+				CheckedAt:    now,
+			})
+		}
+	}
 	return out
 }

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -866,6 +866,21 @@ func accountLifecycleMismatches(
 		// tests) pass nil rather than a throwaway source implementation.
 		return out
 	}
+	if _, prunable := dingo.(*DatabaseSource); prunable {
+		// DatabaseSource (the in-process observer's reward source) reads
+		// reward_account_output through core-mode's rolling pruning window
+		// (see DatabaseSource.GetRewardAccountOutputs) and cannot
+		// distinguish "the previous stake epoch genuinely had no reward
+		// accounts" from "its rows have since been pruned" — an empty,
+		// error-free result either way. Treating a pruned-empty result as a
+		// complete previous-epoch universe would make every account in the
+		// current epoch look newly registered. Only *DingoDB (the
+		// standalone CLI's full, unpruned copy) can be trusted for this
+		// diff; skip it entirely for a prunable source rather than report a
+		// false lifecycle signal. Zero-reward reporting above is unaffected
+		// — it doesn't depend on any historical epoch's data.
+		return out
+	}
 	previousOutputs, err := dingo.GetRewardAccountOutputs(ctx, stakeEpoch-1)
 	if err != nil {
 		return append(out, CheckMismatch{
@@ -878,8 +893,26 @@ func accountLifecycleMismatches(
 		})
 	}
 
-	prevSet := dingoRewardAddressSet(previousOutputs)
-	currSet := dingoRewardAddressSet(currentOutputs)
+	// currentOutputs' own decode failures are already reported by
+	// compareEpochAccounts's own dingoRows-building loop above (the same
+	// underlying rows) — only previousOutputs has no other reporting path,
+	// since nothing else in this package ever decodes the previous stake
+	// epoch's addresses.
+	prevSet, prevDecodeErrs := dingoRewardAddressSet(previousOutputs)
+	currSet, _ := dingoRewardAddressSet(currentOutputs)
+	if prevDecodeErrs > 0 {
+		out = append(out, CheckMismatch{
+			Network: network,
+			Epoch:   epoch,
+			Field:   "reward_account_output_address_decode",
+			DingoValue: fmt.Sprintf(
+				"%d previous-epoch reward_account_output row(s) failed to decode",
+				prevDecodeErrs,
+			),
+			Category:  CategoryDBError,
+			CheckedAt: now,
+		})
+	}
 
 	var newlyRegistered, deregistered []string
 	for addr := range currSet {
@@ -921,23 +954,27 @@ func accountLifecycleMismatches(
 // dingoRewardAddressSet decodes a set of RewardAccountOutput rows into a
 // deduplicated bech32 stake-address set, mirroring
 // BuildAccountAddressUniverse's own dedup approach. A row with an
-// unsupported credential tag is skipped rather than aborting the whole
-// diff — compareEpochAccounts's own per-account comparison pass already
-// reports that condition explicitly as a dingo_db_error mismatch, so it is
-// never silently lost, just not allowed to prevent every other row's
-// lifecycle comparison.
+// unsupported credential tag is skipped from the set (rather than aborting
+// the whole diff) but counted in decodeErrs — silently dropping such a row
+// would make that address look deregistered (if it was in the previous
+// epoch's set) or simply never newly-registered (if it's in the current
+// epoch's set), which is misleading, not a real lifecycle change. The
+// caller is responsible for reporting decodeErrs > 0 as a CategoryDBError
+// mismatch when there's no other reporting path for this specific input
+// (see accountLifecycleMismatches's call site).
 func dingoRewardAddressSet(
 	outputs []*models.RewardAccountOutput,
-) map[string]bool {
-	set := make(map[string]bool, len(outputs))
+) (set map[string]bool, decodeErrs int) {
+	set = make(map[string]bool, len(outputs))
 	for _, o := range outputs {
 		addr, err := StakeAddressFromCredential(o.StakingKey, o.CredentialTag)
 		if err != nil {
+			decodeErrs++
 			continue
 		}
 		set[addr] = true
 	}
-	return set
+	return set, decodeErrs
 }
 
 // aggregateAccountLifecycleMismatch builds one summary CheckMismatch row for

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -21,9 +21,13 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
 )
 
 // CheckConfig holds parameters for a parity check run.
@@ -778,97 +782,194 @@ func compareEpochAccounts(
 			epochEndTime,
 		)...,
 	)
-	out = append(out, accountLifecycleMismatches(cache, network, epoch, now)...)
+	out = append(
+		out,
+		accountLifecycleMismatches(
+			ctx, cache, dingo, network, epoch, stakeEpoch, dingoOutputs, now,
+		)...,
+	)
 	return out
 }
 
 // accountLifecycleMismatches (dingo #3099) reports the two account
 // dimensions #3097's CompareAccountEpoch structurally cannot: confirmed
 // zero-reward accounts and newly-registered/deregistered accounts between
-// adjacent Koios epochs. Both rely on koios_account_checked, the per-address
-// "Koios actually answered for this address" ledger
-// fetchAccountRewardsForEpoch populates as chunks commit — data #3097's
-// original implementation never persisted. Purely informational: every
-// mismatch returned here uses one of CategoryAcctZeroReward/
-// CategoryAcctNewlyRegistered/CategoryAcctDeregistered, which
-// DetermineStatus treats as a no-op, never FAIL or ERROR.
+// adjacent stake epochs. Purely informational: every mismatch returned here
+// uses one of CategoryAcctZeroReward/CategoryAcctNewlyRegistered/
+// CategoryAcctDeregistered, which DetermineStatus treats as a no-op, never
+// FAIL or ERROR.
+//
+// A genuine cache/DB error from either lookup is reported as CategoryDBError
+// rather than silently swallowed — only an explicitly absent/incomplete
+// previous-epoch signal is treated as "disable this report", never any
+// other error, so a real storage failure can never masquerade as "nothing
+// to report".
+//
+// maxAccountLifecycleSample bounds how many addresses are embedded, as a
+// comma-joined debugging sample, in each aggregate lifecycle mismatch row —
+// see aggregateAccountLifecycleMismatch's doc comment for why these are
+// summarized rather than reported one row per address.
+const maxAccountLifecycleSample = 20
+
 func accountLifecycleMismatches(
+	ctx context.Context,
 	cache *Cache,
+	dingo RewardParitySource,
 	network string,
-	epoch uint64,
+	epoch, stakeEpoch uint64,
+	currentOutputs []*models.RewardAccountOutput,
 	now time.Time,
 ) []CheckMismatch {
 	var out []CheckMismatch
 
 	zeroReward, err := cache.GetZeroRewardAccountsForEpoch(network, epoch)
-	if err == nil {
-		for _, addr := range zeroReward {
-			out = append(out, CheckMismatch{
-				Network:      network,
-				Epoch:        epoch,
-				StakeAddress: addr,
-				Field:        "account_zero_reward",
-				DingoValue:   "",
-				KoiosValue:   "0",
-				Category:     CategoryAcctZeroReward,
-				CheckedAt:    now,
-			})
-		}
+	if err != nil {
+		return append(out, CheckMismatch{
+			Network:    network,
+			Epoch:      epoch,
+			Field:      "koios_account_checked",
+			KoiosValue: fmt.Sprintf("error: %v", err),
+			Category:   CategoryDBError,
+			CheckedAt:  now,
+		})
+	}
+	if len(zeroReward) > 0 {
+		out = append(out, aggregateAccountLifecycleMismatch(
+			network,
+			epoch,
+			CategoryAcctZeroReward,
+			"account_zero_reward",
+			zeroReward,
+			now,
+		))
 	}
 
-	if epoch == 0 {
+	// Newly-registered/deregistered accounts are diffed from Dingo's own
+	// epoch-scoped reward_account_output universe — which stake addresses
+	// Dingo actually computed a reward output for at this specific stake
+	// epoch — not from koios_account_checked's persisted "requested
+	// universe". That set unions in Koios's own all-time historical account
+	// list (BuildAccountAddressUniverse), resolved once per Fetch run and
+	// reused across every epoch, so it stays essentially static regardless
+	// of whether an account is genuinely active/delegated in any given
+	// epoch: diffing against it would make this report reflect almost
+	// nothing for a Koios-known account (it never leaves the union) rather
+	// than genuine epoch-over-epoch registration/deregistration.
+	if stakeEpoch == 0 || dingo == nil {
+		// No valid previous stake epoch to diff against (stakeEpoch-1 would
+		// underflow) — should not be reachable in practice, since checkEpoch
+		// already excludes pre-staking epochs via koiosStakeEpoch's own
+		// guard before ever calling compareEpochAccounts. The dingo == nil
+		// check is defensive (compareEpochAccounts always passes a real
+		// source in production) and lets callers that only care about the
+		// zero-reward half of this report (see e.g. this package's own
+		// tests) pass nil rather than a throwaway source implementation.
 		return out
 	}
-	// Only trust the previous epoch's persisted universe once its own
-	// account fetch reached coverage.Complete — an incomplete or
-	// never-attempted previous fetch must disable the lifecycle report
-	// rather than let every current address look newly registered.
-	prevCoverage, prevCovErr := cache.GetAccountCoverage(network, epoch-1)
-	if prevCovErr != nil || prevCoverage == nil || !prevCoverage.Complete {
-		return out
-	}
-	previousUniverse, err := cache.GetAccountUniverseForEpoch(network, epoch-1)
+	previousOutputs, err := dingo.GetRewardAccountOutputs(ctx, stakeEpoch-1)
 	if err != nil {
-		return out
-	}
-	currentUniverse, err := cache.GetAccountUniverseForEpoch(network, epoch)
-	if err != nil {
-		return out
+		return append(out, CheckMismatch{
+			Network:    network,
+			Epoch:      epoch,
+			Field:      "reward_account_output",
+			DingoValue: fmt.Sprintf("error: %v", err),
+			Category:   CategoryDBError,
+			CheckedAt:  now,
+		})
 	}
 
-	prevSet := make(map[string]bool, len(previousUniverse))
-	for _, a := range previousUniverse {
-		prevSet[a] = true
-	}
-	currSet := make(map[string]bool, len(currentUniverse))
-	for _, a := range currentUniverse {
-		currSet[a] = true
-		if !prevSet[a] {
-			out = append(out, CheckMismatch{
-				Network:      network,
-				Epoch:        epoch,
-				StakeAddress: a,
-				Field:        "account_lifecycle",
-				DingoValue:   "",
-				KoiosValue:   "newly_registered",
-				Category:     CategoryAcctNewlyRegistered,
-				CheckedAt:    now,
-			})
+	prevSet := dingoRewardAddressSet(previousOutputs)
+	currSet := dingoRewardAddressSet(currentOutputs)
+
+	var newlyRegistered, deregistered []string
+	for addr := range currSet {
+		if !prevSet[addr] {
+			newlyRegistered = append(newlyRegistered, addr)
 		}
 	}
-	for _, a := range previousUniverse {
-		if !currSet[a] {
-			out = append(out, CheckMismatch{
-				Network:      network,
-				Epoch:        epoch,
-				StakeAddress: a,
-				Field:        "account_lifecycle",
-				DingoValue:   "deregistered",
-				KoiosValue:   "",
-				Category:     CategoryAcctDeregistered,
-				CheckedAt:    now,
-			})
+	for addr := range prevSet {
+		if !currSet[addr] {
+			deregistered = append(deregistered, addr)
 		}
+	}
+	sort.Strings(newlyRegistered)
+	sort.Strings(deregistered)
+
+	if len(newlyRegistered) > 0 {
+		out = append(out, aggregateAccountLifecycleMismatch(
+			network,
+			epoch,
+			CategoryAcctNewlyRegistered,
+			"account_lifecycle_newly_registered",
+			newlyRegistered,
+			now,
+		))
+	}
+	if len(deregistered) > 0 {
+		out = append(out, aggregateAccountLifecycleMismatch(
+			network,
+			epoch,
+			CategoryAcctDeregistered,
+			"account_lifecycle_deregistered",
+			deregistered,
+			now,
+		))
 	}
 	return out
+}
+
+// dingoRewardAddressSet decodes a set of RewardAccountOutput rows into a
+// deduplicated bech32 stake-address set, mirroring
+// BuildAccountAddressUniverse's own dedup approach. A row with an
+// unsupported credential tag is skipped rather than aborting the whole
+// diff — compareEpochAccounts's own per-account comparison pass already
+// reports that condition explicitly as a dingo_db_error mismatch, so it is
+// never silently lost, just not allowed to prevent every other row's
+// lifecycle comparison.
+func dingoRewardAddressSet(
+	outputs []*models.RewardAccountOutput,
+) map[string]bool {
+	set := make(map[string]bool, len(outputs))
+	for _, o := range outputs {
+		addr, err := StakeAddressFromCredential(o.StakingKey, o.CredentialTag)
+		if err != nil {
+			continue
+		}
+		set[addr] = true
+	}
+	return set
+}
+
+// aggregateAccountLifecycleMismatch builds one summary CheckMismatch row for
+// an entire category of addresses, rather than one row per address.
+// Zero-reward accounts in particular can be the large majority of a
+// network's whole address universe (Koios never emits a row at all for a
+// zero-reward account), so reporting them one-row-per-address would scale
+// insert time, cache size, and JSON report memory with the size of the
+// account universe, and would drown out genuine mismatches in
+// CheckEpochStatus.MismatchCount. KoiosValue carries the total affected
+// count; DingoValue carries a capped, comma-joined sample of addresses for
+// debugging, not the full list — the persisted koios_account_checked/
+// koios_account_universe data remains queryable directly for anyone who
+// needs the complete list.
+func aggregateAccountLifecycleMismatch(
+	network string,
+	epoch uint64,
+	category, field string,
+	addrs []string,
+	now time.Time,
+) CheckMismatch {
+	sample := addrs
+	if len(sample) > maxAccountLifecycleSample {
+		sample = sample[:maxAccountLifecycleSample]
+	}
+	return CheckMismatch{
+		Network:    network,
+		Epoch:      epoch,
+		Field:      field,
+		DingoValue: "sample: " + strings.Join(sample, ","),
+		KoiosValue: strconv.Itoa(len(addrs)),
+		Category:   category,
+		CheckedAt:  now,
+	}
 }

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -51,6 +51,26 @@ const (
 	// epoch read as PASS just because every row that *was* fetched happened
 	// to match.
 	CategoryAcctCoverageIncomplete = "acct_coverage_incomplete"
+
+	// CategoryAcctZeroReward/CategoryAcctNewlyRegistered/CategoryAcctDeregistered
+	// (dingo #3099) report the three account dimensions #3097's merged
+	// comparison structurally cannot: CompareAccountEpoch only ever compares
+	// keys present in at least one side's row map, so an address absent from
+	// both (a confirmed-zero-reward account, since Koios never emits a row
+	// for zero reward) never enters that comparison at all, and #3097's
+	// address universe is a single flat list reused across every epoch in one
+	// run, with no per-epoch persisted snapshot to diff for lifecycle
+	// changes. All three are purely informational — descriptive state, not a
+	// Dingo-vs-Koios discrepancy — and must never affect Status (see
+	// DetermineStatus's dedicated no-op case for these three).
+	CategoryAcctZeroReward = "acct_zero_reward"
+	// CategoryAcctNewlyRegistered marks a stake address present in this
+	// epoch's persisted koios_account_checked universe but absent from the
+	// previous epoch's — see Cache.GetAccountUniverseForEpoch.
+	CategoryAcctNewlyRegistered = "acct_newly_registered"
+	// CategoryAcctDeregistered marks a stake address present in the previous
+	// epoch's persisted universe but absent from this epoch's.
+	CategoryAcctDeregistered = "acct_deregistered"
 )
 
 // Epoch check status values.
@@ -807,6 +827,13 @@ func DetermineStatus(mismatches []CheckMismatch) string {
 			CategoryReferenceLag,
 			CategoryAcctCoverageIncomplete:
 			hasError = true
+		case CategoryAcctZeroReward,
+			CategoryAcctNewlyRegistered,
+			CategoryAcctDeregistered:
+			// Purely informational — see these categories' doc comments.
+			// Deliberately not counted toward hasError or default's FAIL: a
+			// zero-reward or lifecycle-change mismatch must never turn an
+			// otherwise-clean epoch into ERROR or FAIL.
 		default:
 			return StatusFail
 		}

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -65,11 +65,13 @@ const (
 	// DetermineStatus's dedicated no-op case for these three).
 	CategoryAcctZeroReward = "acct_zero_reward"
 	// CategoryAcctNewlyRegistered marks a stake address present in this
-	// epoch's persisted koios_account_checked universe but absent from the
-	// previous epoch's — see Cache.GetAccountUniverseForEpoch.
+	// stake epoch's Dingo-committed reward_account_output universe but
+	// absent from the previous stake epoch's — see
+	// check.go's accountLifecycleMismatches/dingoRewardAddressSet.
 	CategoryAcctNewlyRegistered = "acct_newly_registered"
 	// CategoryAcctDeregistered marks a stake address present in the previous
-	// epoch's persisted universe but absent from this epoch's.
+	// stake epoch's reward_account_output universe but absent from this
+	// epoch's.
 	CategoryAcctDeregistered = "acct_deregistered"
 )
 

--- a/internal/koiosparity/coverage_test.go
+++ b/internal/koiosparity/coverage_test.go
@@ -38,8 +38,18 @@ func TestKoiosCoverageMatrixIsComplete(t *testing.T) {
 		key := field.Endpoint + "." + field.Field
 		require.NotEmpty(t, field.Endpoint)
 		require.NotEmpty(t, field.Field)
-		require.True(t, validClasses[field.Class], "invalid coverage class for %s", key)
-		require.NotEmpty(t, field.Reason, "coverage reason is required for %s", key)
+		require.True(
+			t,
+			validClasses[field.Class],
+			"invalid coverage class for %s",
+			key,
+		)
+		require.NotEmpty(
+			t,
+			field.Reason,
+			"coverage reason is required for %s",
+			key,
+		)
 		_, duplicate := byKey[key]
 		require.False(t, duplicate, "duplicate coverage entry for %s", key)
 		byKey[key] = field
@@ -48,7 +58,22 @@ func TestKoiosCoverageMatrixIsComplete(t *testing.T) {
 	requireResponseFieldsCovered(t, byKey, "/tip", KoiosTipResp{})
 	requireResponseFieldsCovered(t, byKey, "/epoch_info", KoiosEpochInfoResp{})
 	requireResponseFieldsCovered(t, byKey, "/totals", KoiosTotalsResp{})
-	requireResponseFieldsCovered(t, byKey, "/pool_history", KoiosPoolHistoryItem{})
+	requireResponseFieldsCovered(
+		t,
+		byKey,
+		"/pool_history",
+		KoiosPoolHistoryItem{},
+	)
+	// dingo #3099: KoiosAccountRewardHistoryItem was not previously enforced
+	// here, so a future field added to it would go unclassified without any
+	// test failing — close that gap the same way every other response
+	// struct is already guarded.
+	requireResponseFieldsCovered(
+		t,
+		byKey,
+		"/account_reward_history",
+		KoiosAccountRewardHistoryItem{},
+	)
 
 	// Fields selected by the pool-discovery helpers use function-local response
 	// structs, and documented fields omitted from preview/preprod responses are

--- a/internal/koiosparity/fetch.go
+++ b/internal/koiosparity/fetch.go
@@ -61,6 +61,13 @@ type FetchConfig struct {
 	// result is accepted as final immediately). Unused when AccountsEnabled
 	// is false.
 	GraceHours int
+	// AccountChunkSize/AccountChunkMaxBytes (dingo #3099) bound each
+	// /account_reward_history request by both address count and encoded
+	// body size (see chunkAddressesByCountAndSize). <=0 means "use the
+	// package default" (koiosAccountChunkSize/koiosAccountChunkMaxBytesDefault).
+	// Unused when AccountsEnabled is false.
+	AccountChunkSize     int
+	AccountChunkMaxBytes int
 }
 
 // FetchResult summarises a completed fetch run.
@@ -398,7 +405,8 @@ loop:
 			if cfg.AccountsEnabled {
 				if _, acctErr := FetchEpochAccountsWithAddrs(
 					fetchCtx, koios, cache, cfg.Network, epoch,
-					cfg.AccountsSource, koiosAccountAddrs, cfg.GraceHours, logger,
+					cfg.AccountsSource, koiosAccountAddrs, cfg.GraceHours,
+					cfg.AccountChunkSize, cfg.AccountChunkMaxBytes, logger,
 				); acctErr != nil {
 					handleEpochFetchErr("accounts", acctErr)
 					return

--- a/internal/koiosparity/fetch.go
+++ b/internal/koiosparity/fetch.go
@@ -406,7 +406,8 @@ loop:
 				if _, acctErr := FetchEpochAccountsWithAddrs(
 					fetchCtx, koios, cache, cfg.Network, epoch,
 					cfg.AccountsSource, koiosAccountAddrs, cfg.GraceHours,
-					cfg.AccountChunkSize, cfg.AccountChunkMaxBytes, logger,
+					cfg.AccountChunkSize, cfg.AccountChunkMaxBytes,
+					cfg.ForceRefresh, logger,
 				); acctErr != nil {
 					handleEpochFetchErr("accounts", acctErr)
 					return

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -333,17 +333,22 @@ func fetchAccountRewardsForEpoch(
 		hashes[i] = h
 	}
 
-	invalidateHashes := hashes
-	if forceRefresh {
-		// nil treats every existing checkpointed chunk as stale regardless
-		// of whether its hash still matches the current plan (see
-		// InvalidateStaleAccountChunks: a chunk hash absent from the
-		// "current" set is stale), so doneHashes below comes back empty and
-		// every chunk in this call is re-dispatched to Koios even when the
-		// address universe/chunking plan hasn't changed since the last run.
-		invalidateHashes = nil
-	}
-	if err := cache.InvalidateStaleAccountChunks(network, epoch, invalidateHashes); err != nil {
+	// Only chunks whose hash actually changed are invalidated here — never
+	// nil, even for forceRefresh: deleting every existing chunk's checkpoint
+	// data up front, before any replacement data has actually been fetched,
+	// would leave koios_account_checked/koios_account_fetch_staged_rows
+	// wiped or partial if this call then fails partway (e.g. a mid-refresh
+	// Koios outage), while the untouched koios_account_coverage row from the
+	// last successful commit still reports complete=true — so a later
+	// Observer/Fetch attempt would never retry, and accountLifecycleMismatches
+	// would read that partial/wiped state as if it belonged to a genuinely
+	// complete epoch. forceRefresh instead bypasses the doneHashes skip below,
+	// so every chunk is re-dispatched regardless — each one's own
+	// SaveAccountFetchChunkProgress call safely replaces just that chunk's
+	// rows in one transaction once its re-fetch actually succeeds, so a
+	// chunk never re-reached by a failed refresh attempt simply keeps
+	// whatever valid data it already had.
+	if err := cache.InvalidateStaleAccountChunks(network, epoch, hashes); err != nil {
 		return 0, fmt.Errorf("invalidate stale account chunks: %w", err)
 	}
 	doneHashes, err := cache.GetDoneAccountChunkHashes(network, epoch)
@@ -374,7 +379,12 @@ func fetchAccountRewardsForEpoch(
 
 	var pending []chunkPlan
 	for _, p := range plans {
-		if doneHashes[p.hash] && (!withinGrace || hashesWithRows[p.hash]) {
+		// forceRefresh (--force-refresh) never trusts an existing checkpoint
+		// as done, regardless of doneHashes/hashesWithRows — see the
+		// invalidation comment above for why this bypasses the skip instead
+		// of deleting the old data up front.
+		if !forceRefresh && doneHashes[p.hash] &&
+			(!withinGrace || hashesWithRows[p.hash]) {
 			continue
 		}
 		pending = append(pending, p)
@@ -595,11 +605,15 @@ outer:
 //
 // forceRefresh (threaded from FetchConfig.ForceRefresh; always false for the
 // Observer, which has no force-refresh concept) forces
-// fetchAccountRewardsForEpoch to invalidate every retained checkpoint for
-// this epoch before dispatch, so an operator-requested --force-refresh
-// actually repairs suspected stale/corrupt cached data by going back to
-// Koios, rather than finding every chunk already checkpointed "done" and
-// silently re-committing the same old rows.
+// fetchAccountRewardsForEpoch to re-dispatch every chunk in the current plan
+// regardless of existing checkpoint state, so an operator-requested
+// --force-refresh actually repairs suspected stale/corrupt cached data by
+// going back to Koios, rather than finding every chunk already checkpointed
+// "done" and silently re-committing the same old rows. It never deletes
+// existing checkpoint data up front — each chunk's own successful re-fetch
+// safely replaces just that chunk's rows, so a failed/interrupted refresh
+// attempt never leaves an already-covered epoch with wiped or partial
+// checkpoint state.
 func FetchEpochAccountsWithAddrs(
 	ctx context.Context,
 	koios *KoiosClient,

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -500,6 +500,15 @@ outer:
 	wg.Wait()
 
 	if ctx.Err() != nil {
+		if forceRefresh {
+			if markErr := cache.MarkAccountCoverageIncomplete(network, epoch); markErr != nil {
+				return 0, fmt.Errorf(
+					"mark account coverage incomplete after canceled force-refresh: %w (original error: %w)",
+					markErr,
+					ctx.Err(),
+				)
+			}
+		}
 		return 0, ctx.Err()
 	}
 
@@ -507,6 +516,23 @@ outer:
 	err = firstErr
 	errMu.Unlock()
 	if err != nil {
+		if forceRefresh {
+			// A partial force-refresh failure can leave koios_account_checked
+			// holding a mix of freshly-refreshed and untouched pre-refresh
+			// chunks (see MarkAccountCoverageIncomplete's doc comment for why
+			// forceRefresh never pre-invalidates checkpoint data). The
+			// pre-existing complete=true coverage row from before this
+			// attempt must be downgraded so nothing downstream trusts that
+			// mixed state as a valid snapshot until a later attempt completes
+			// fully and re-commits a fresh, consistent one.
+			if markErr := cache.MarkAccountCoverageIncomplete(network, epoch); markErr != nil {
+				return 0, fmt.Errorf(
+					"mark account coverage incomplete after failed force-refresh: %w (original error: %w)",
+					markErr,
+					err,
+				)
+			}
+		}
 		return 0, classifyFetchErr(err)
 	}
 

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -256,17 +256,6 @@ func fetchAccountRewardsForEpoch(
 		if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, nil, 0, true, now); commitErr != nil {
 			return 0, fmt.Errorf("commit empty account coverage: %w", commitErr)
 		}
-		if clearErr := cache.ClearAccountFetchStaging(network, epoch); clearErr != nil {
-			logger.Warn(
-				"koiosparity: failed to clear account fetch staging for empty universe",
-				"network",
-				network,
-				"epoch",
-				epoch,
-				"error",
-				clearErr,
-			)
-		}
 		return 0, nil
 	}
 
@@ -286,7 +275,24 @@ func fetchAccountRewardsForEpoch(
 	if chunkMaxBytes <= 0 {
 		chunkMaxBytes = koiosAccountChunkMaxBytesDefault
 	}
-	groups := chunkAddressesByCountAndSize(sorted, chunkSize, chunkMaxBytes)
+	// chunkAddressesByCountAndSize only bounds the encoded size of the
+	// address array itself; the actual /account_reward_history POST body is
+	// that array wrapped in {"_stake_addresses":[...],"_epoch_no":N} (see
+	// GetAccountRewardHistory) — a fixed envelope that isn't otherwise
+	// accounted for. Reserve it from the configured budget so the true
+	// request body can never exceed --account-chunk-max-bytes; for any
+	// reasonable configured budget this reservation is negligible, but for a
+	// deliberately tiny one it's the difference between honoring the
+	// configured bound and silently exceeding it.
+	effectiveChunkMaxBytes := max(
+		chunkMaxBytes-koiosAccountRequestEnvelopeOverhead,
+		1,
+	)
+	groups := chunkAddressesByCountAndSize(
+		sorted,
+		chunkSize,
+		effectiveChunkMaxBytes,
+	)
 
 	type chunkPlan struct {
 		hash  string
@@ -308,11 +314,33 @@ func fetchAccountRewardsForEpoch(
 		return 0, fmt.Errorf("get done account chunks: %w", err)
 	}
 
+	// A chunk that checkpointed with zero rows while still within the grace
+	// window must not be trusted as final: Koios's own /account_reward_history
+	// publishing can lag behind epoch closure (see the zero-row/grace-hours
+	// gate below), so an empty result checkpointed early could simply mean
+	// "hasn't published yet," not "confirmed nothing." Without this check, a
+	// resumed/retried call would see every such chunk as already "done,"
+	// never re-ask Koios, and eventually commit complete=true from stale,
+	// possibly-lagged empty checkpoints once graceHours elapses — silently
+	// losing rewards Koios published in the meantime. Only a chunk with
+	// genuinely non-empty staged rows, or one checked after the grace window
+	// has already closed, is safe to skip re-dispatching.
+	withinGrace := graceHours > 0 && !epochEndTime.IsZero() &&
+		now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour
+	var hashesWithRows map[string]bool
+	if withinGrace {
+		hashesWithRows, err = cache.GetChunkHashesWithStagedRows(network, epoch)
+		if err != nil {
+			return 0, fmt.Errorf("get chunk hashes with staged rows: %w", err)
+		}
+	}
+
 	var pending []chunkPlan
 	for _, p := range plans {
-		if !doneHashes[p.hash] {
-			pending = append(pending, p)
+		if doneHashes[p.hash] && (!withinGrace || hashesWithRows[p.hash]) {
+			continue
 		}
+		pending = append(pending, p)
 	}
 
 	var errMu sync.Mutex
@@ -453,19 +481,15 @@ outer:
 	if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, stagedRows, len(addressUniverse), complete, now); commitErr != nil {
 		return 0, fmt.Errorf("commit account rewards: %w", commitErr)
 	}
-	if complete {
-		if clearErr := cache.ClearAccountFetchStaging(network, epoch); clearErr != nil {
-			logger.Warn(
-				"koiosparity: failed to clear account fetch staging after commit",
-				"network",
-				network,
-				"epoch",
-				epoch,
-				"error",
-				clearErr,
-			)
-		}
-	}
+	// koios_account_fetch_staged_rows/koios_account_checked are deliberately
+	// NOT cleared here, even once complete=true: koios_account_checked is
+	// the durable ledger accountLifecycleMismatches (check.go) reads later
+	// to report zero-reward/newly-registered/deregistered accounts, and
+	// koios_account_fetch_staged_rows must survive so a later idempotent
+	// re-run of this same, already-complete epoch (e.g. --force-refresh
+	// with an unchanged universe) finds every chunk already done AND still
+	// has real staged rows to re-commit — clearing either table here would
+	// make that re-run commit an empty reward set over the correct one.
 
 	logger.Info("koiosparity: epoch account rewards fetched",
 		"network", network,

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -196,7 +196,7 @@ func FetchAccountRewardsForEpoch(
 ) (fetched int, err error) {
 	return fetchAccountRewardsForEpoch(
 		ctx, koios, cache, network, epoch, addressUniverse,
-		epochEndTime, graceHours, 0, 0, logger,
+		epochEndTime, graceHours, 0, 0, false, logger,
 	)
 }
 
@@ -232,6 +232,14 @@ func FetchAccountRewardsForEpoch(
 // plan before dispatch, so a changed universe or a --account-chunk-size/
 // --account-chunk-max-bytes tuning change only re-fetches the affected
 // chunks, never silently reuses stale progress from a different plan.
+//
+// forceRefresh (threaded from FetchConfig.ForceRefresh) bypasses that same
+// content-addressed resume logic entirely: an unchanged address universe
+// produces the exact same chunk hashes as a prior run, so without this an
+// operator re-running with --force-refresh to repair suspected stale/corrupt
+// cached data would find every chunk already "done" and skip re-dispatching
+// any of them, silently re-committing the same old staged rows instead of
+// actually going back to Koios.
 func fetchAccountRewardsForEpoch(
 	ctx context.Context,
 	koios *KoiosClient,
@@ -242,6 +250,7 @@ func fetchAccountRewardsForEpoch(
 	epochEndTime time.Time,
 	graceHours int,
 	chunkSize, chunkMaxBytes int,
+	forceRefresh bool,
 	logger *slog.Logger,
 ) (fetched int, err error) {
 	if logger == nil {
@@ -324,7 +333,17 @@ func fetchAccountRewardsForEpoch(
 		hashes[i] = h
 	}
 
-	if err := cache.InvalidateStaleAccountChunks(network, epoch, hashes); err != nil {
+	invalidateHashes := hashes
+	if forceRefresh {
+		// nil treats every existing checkpointed chunk as stale regardless
+		// of whether its hash still matches the current plan (see
+		// InvalidateStaleAccountChunks: a chunk hash absent from the
+		// "current" set is stale), so doneHashes below comes back empty and
+		// every chunk in this call is re-dispatched to Koios even when the
+		// address universe/chunking plan hasn't changed since the last run.
+		invalidateHashes = nil
+	}
+	if err := cache.InvalidateStaleAccountChunks(network, epoch, invalidateHashes); err != nil {
 		return 0, fmt.Errorf("invalidate stale account chunks: %w", err)
 	}
 	doneHashes, err := cache.GetDoneAccountChunkHashes(network, epoch)
@@ -527,10 +546,13 @@ outer:
 	// the durable ledger accountLifecycleMismatches (check.go) reads later
 	// to report zero-reward/newly-registered/deregistered accounts, and
 	// koios_account_fetch_staged_rows must survive so a later idempotent
-	// re-run of this same, already-complete epoch (e.g. --force-refresh
-	// with an unchanged universe) finds every chunk already done AND still
-	// has real staged rows to re-commit — clearing either table here would
-	// make that re-run commit an empty reward set over the correct one.
+	// re-run of this same, already-complete epoch with an unchanged universe
+	// finds every chunk already done AND still has real staged rows to
+	// re-commit — clearing either table here would make that re-run commit
+	// an empty reward set over the correct one. --force-refresh instead goes
+	// through the forceRefresh path above, which unconditionally invalidates
+	// every existing chunk before dispatch so it always re-fetches from
+	// Koios rather than relying on this retained state.
 
 	logger.Info("koiosparity: epoch account rewards fetched",
 		"network", network,
@@ -570,6 +592,14 @@ outer:
 // --account-chunk-size/--account-chunk-max-bytes through to
 // fetchAccountRewardsForEpoch's dual-bounded chunking; 0 for either means
 // "use the package default" (koiosAccountChunkSize/koiosAccountChunkMaxBytesDefault).
+//
+// forceRefresh (threaded from FetchConfig.ForceRefresh; always false for the
+// Observer, which has no force-refresh concept) forces
+// fetchAccountRewardsForEpoch to invalidate every retained checkpoint for
+// this epoch before dispatch, so an operator-requested --force-refresh
+// actually repairs suspected stale/corrupt cached data by going back to
+// Koios, rather than finding every chunk already checkpointed "done" and
+// silently re-committing the same old rows.
 func FetchEpochAccountsWithAddrs(
 	ctx context.Context,
 	koios *KoiosClient,
@@ -580,6 +610,7 @@ func FetchEpochAccountsWithAddrs(
 	koiosAddrs []string,
 	graceHours int,
 	chunkSize, chunkMaxBytes int,
+	forceRefresh bool,
 	logger *slog.Logger,
 ) (int, error) {
 	stakeEpoch, ok := koiosStakeEpoch(epoch)
@@ -630,6 +661,7 @@ func FetchEpochAccountsWithAddrs(
 		graceHours,
 		chunkSize,
 		chunkMaxBytes,
+		forceRefresh,
 		logger,
 	)
 }

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -499,46 +499,51 @@ outer:
 
 	wg.Wait()
 
-	if ctx.Err() != nil {
-		if forceRefresh {
-			if markErr := cache.MarkAccountCoverageIncomplete(network, epoch); markErr != nil {
-				return 0, fmt.Errorf(
-					"mark account coverage incomplete after canceled force-refresh: %w (original error: %w)",
-					markErr,
-					ctx.Err(),
-				)
-			}
+	// wrapForceRefreshFailure downgrades this epoch's koios_account_coverage
+	// row to complete=false (Cache.MarkAccountCoverageIncomplete) before
+	// returning origErr, but only for forceRefresh — every failure exit from
+	// this point on (chunk dispatch, ctx cancellation, reading staged rows
+	// back, the final hash re-check, or the commit itself) can follow chunks
+	// that already succeeded and replaced their old rows via
+	// SaveAccountFetchChunkProgress during dispatch, so koios_account_checked
+	// may already hold a mix of freshly-refreshed and untouched pre-refresh
+	// chunks — two Koios snapshots that were never actually valid together.
+	// The pre-existing complete=true coverage row from before this attempt
+	// must not be left as-is in that case, or compareEpochAccounts/
+	// accountLifecycleMismatches would trust that mixed state as genuinely
+	// complete. A non-forceRefresh call never risks this (no chunk it didn't
+	// already trust as done gets touched), so it always returns origErr
+	// unchanged.
+	wrapForceRefreshFailure := func(origErr error) error {
+		if !forceRefresh {
+			return origErr
 		}
-		return 0, ctx.Err()
+		if markErr := cache.MarkAccountCoverageIncomplete(network, epoch); markErr != nil {
+			return fmt.Errorf(
+				"mark account coverage incomplete after failed force-refresh: %w (original error: %w)",
+				markErr,
+				origErr,
+			)
+		}
+		return origErr
+	}
+
+	if ctx.Err() != nil {
+		return 0, wrapForceRefreshFailure(ctx.Err())
 	}
 
 	errMu.Lock()
 	err = firstErr
 	errMu.Unlock()
 	if err != nil {
-		if forceRefresh {
-			// A partial force-refresh failure can leave koios_account_checked
-			// holding a mix of freshly-refreshed and untouched pre-refresh
-			// chunks (see MarkAccountCoverageIncomplete's doc comment for why
-			// forceRefresh never pre-invalidates checkpoint data). The
-			// pre-existing complete=true coverage row from before this
-			// attempt must be downgraded so nothing downstream trusts that
-			// mixed state as a valid snapshot until a later attempt completes
-			// fully and re-commits a fresh, consistent one.
-			if markErr := cache.MarkAccountCoverageIncomplete(network, epoch); markErr != nil {
-				return 0, fmt.Errorf(
-					"mark account coverage incomplete after failed force-refresh: %w (original error: %w)",
-					markErr,
-					err,
-				)
-			}
-		}
-		return 0, classifyFetchErr(err)
+		return 0, wrapForceRefreshFailure(classifyFetchErr(err))
 	}
 
 	stagedRows, err := cache.GetStagedAccountRows(network, epoch)
 	if err != nil {
-		return 0, fmt.Errorf("get staged account rows: %w", err)
+		return 0, wrapForceRefreshFailure(
+			fmt.Errorf("get staged account rows: %w", err),
+		)
 	}
 
 	// A zero-row result, for an epoch that closed within the grace window,
@@ -558,10 +563,10 @@ outer:
 		epoch,
 	)
 	if err != nil {
-		return 0, fmt.Errorf(
+		return 0, wrapForceRefreshFailure(fmt.Errorf(
 			"get chunk hashes with staged rows (final): %w",
 			err,
-		)
+		))
 	}
 	allChunksHaveRows := true
 	for _, p := range plans {
@@ -575,7 +580,9 @@ outer:
 		now.Sub(epochEndTime) >= time.Duration(graceHours)*time.Hour
 
 	if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, stagedRows, len(addressUniverse), complete, now); commitErr != nil {
-		return 0, fmt.Errorf("commit account rewards: %w", commitErr)
+		return 0, wrapForceRefreshFailure(
+			fmt.Errorf("commit account rewards: %w", commitErr),
+		)
 	}
 	// koios_account_fetch_staged_rows/koios_account_checked are deliberately
 	// NOT cleared here, even once complete=true: koios_account_checked is

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -130,22 +132,6 @@ func BuildAccountAddressUniverse(
 	return out, nil
 }
 
-// chunkAddresses splits addrs into groups of at most size, preserving order.
-func chunkAddresses(addrs []string, size int) [][]string {
-	if size <= 0 {
-		size = koiosAccountChunkSize
-	}
-	if len(addrs) == 0 {
-		return nil
-	}
-	chunks := make([][]string, 0, (len(addrs)+size-1)/size)
-	for i := 0; i < len(addrs); i += size {
-		end := min(i+size, len(addrs))
-		chunks = append(chunks, addrs[i:end])
-	}
-	return chunks
-}
-
 // FetchAccountRewardsForEpoch fetches Koios /account_reward_history
 // reference data for every address in addressUniverse for Koios reporting
 // epoch epoch, and commits it to the cache only once every chunk has
@@ -208,6 +194,56 @@ func FetchAccountRewardsForEpoch(
 	graceHours int,
 	logger *slog.Logger,
 ) (fetched int, err error) {
+	return fetchAccountRewardsForEpoch(
+		ctx, koios, cache, network, epoch, addressUniverse,
+		epochEndTime, graceHours, 0, 0, logger,
+	)
+}
+
+// fetchAccountRewardsForEpoch is FetchAccountRewardsForEpoch's real
+// implementation, additionally parameterized by chunkSize/chunkMaxBytes (<=0
+// meaning "use the package defaults", koiosAccountChunkSize and
+// koiosAccountChunkMaxBytesDefault respectively) so FetchEpochAccountsWithAddrs
+// can thread operator-configured --account-chunk-size/--account-chunk-max-bytes
+// through without changing FetchAccountRewardsForEpoch's own public
+// signature — every existing direct caller/test of that function keeps
+// working unchanged.
+//
+// dingo #3099 adds durable, resumable checkpointing on top of #3097's
+// original single-shot implementation: each chunk's fetched rows and
+// per-address "checked" markers are saved to
+// koios_account_fetch_staged_rows/koios_account_checked
+// (Cache.SaveAccountFetchChunkProgress) as soon as that chunk succeeds,
+// rather than only accumulated in memory. A killed/restarted process
+// therefore resumes from whichever chunks already checkpointed
+// (Cache.GetDoneAccountChunkHashes) instead of redoing the whole epoch's
+// fetch from scratch. The final commit step — reading back every staged row
+// (Cache.GetStagedAccountRows) and calling the existing, unmodified
+// Cache.CommitAccountRewardsForEpoch exactly once — is otherwise identical to
+// #3097's original single-shot commit: still one atomic, all-or-nothing
+// write, still gated by graceHours/epochEndTime the same way, still never
+// setting complete=true except when every chunk in the current plan has
+// succeeded.
+//
+// Address universe changes across resumed attempts are handled by content-
+// addressed chunk hashing (hashAddressChunk, sha256 of a sorted chunk's own
+// addresses): Cache.InvalidateStaleAccountChunks prunes checkpoint state for
+// any chunk whose exact address grouping is no longer part of the current
+// plan before dispatch, so a changed universe or a --account-chunk-size/
+// --account-chunk-max-bytes tuning change only re-fetches the affected
+// chunks, never silently reuses stale progress from a different plan.
+func fetchAccountRewardsForEpoch(
+	ctx context.Context,
+	koios *KoiosClient,
+	cache *Cache,
+	network string,
+	epoch uint64,
+	addressUniverse []string,
+	epochEndTime time.Time,
+	graceHours int,
+	chunkSize, chunkMaxBytes int,
+	logger *slog.Logger,
+) (fetched int, err error) {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
@@ -220,16 +256,68 @@ func FetchAccountRewardsForEpoch(
 		if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, nil, 0, true, now); commitErr != nil {
 			return 0, fmt.Errorf("commit empty account coverage: %w", commitErr)
 		}
+		if clearErr := cache.ClearAccountFetchStaging(network, epoch); clearErr != nil {
+			logger.Warn(
+				"koiosparity: failed to clear account fetch staging for empty universe",
+				"network",
+				network,
+				"epoch",
+				epoch,
+				"error",
+				clearErr,
+			)
+		}
 		return 0, nil
 	}
 
-	chunks := chunkAddresses(addressUniverse, koiosAccountChunkSize)
+	// Sorted so the same address set always produces the same chunk
+	// boundaries (and therefore the same content-addressed chunk hashes)
+	// regardless of addressUniverse's incoming order, which is not itself
+	// guaranteed stable across calls (BuildAccountAddressUniverse's Dingo-side
+	// half comes from a plain SQL query with no ORDER BY) — required for
+	// resumability and selective invalidation to mean anything.
+	sorted := make([]string, len(addressUniverse))
+	copy(sorted, addressUniverse)
+	sort.Strings(sorted)
 
-	var mu sync.Mutex
-	var rows []KoiosAccountRewards
+	if chunkSize <= 0 {
+		chunkSize = koiosAccountChunkSize
+	}
+	if chunkMaxBytes <= 0 {
+		chunkMaxBytes = koiosAccountChunkMaxBytesDefault
+	}
+	groups := chunkAddressesByCountAndSize(sorted, chunkSize, chunkMaxBytes)
+
+	type chunkPlan struct {
+		hash  string
+		addrs []string
+	}
+	plans := make([]chunkPlan, len(groups))
+	hashes := make([]string, len(groups))
+	for i, g := range groups {
+		h := hashAddressChunk(g)
+		plans[i] = chunkPlan{hash: h, addrs: g}
+		hashes[i] = h
+	}
+
+	if err := cache.InvalidateStaleAccountChunks(network, epoch, hashes); err != nil {
+		return 0, fmt.Errorf("invalidate stale account chunks: %w", err)
+	}
+	doneHashes, err := cache.GetDoneAccountChunkHashes(network, epoch)
+	if err != nil {
+		return 0, fmt.Errorf("get done account chunks: %w", err)
+	}
+
+	var pending []chunkPlan
+	for _, p := range plans {
+		if !doneHashes[p.hash] {
+			pending = append(pending, p)
+		}
+	}
 
 	var errMu sync.Mutex
 	var firstErr error
+	var newlyFetched atomic.Int64
 
 	// fetchCtx is cancelled the moment any chunk error is seen — transient
 	// or permanent — so this call stops scheduling further doomed chunk
@@ -243,7 +331,7 @@ func FetchAccountRewardsForEpoch(
 	var wg sync.WaitGroup
 
 outer:
-	for _, chunk := range chunks {
+	for _, plan := range pending {
 		// Check first so a cancellation from a prior iteration's chunk error
 		// is never missed simply because the semaphore also happened to have
 		// room this iteration (see the post-acquire recheck below for why a
@@ -269,13 +357,13 @@ outer:
 		}
 
 		wg.Add(1)
-		go func(addrs []string) {
+		go func(plan chunkPlan) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			items, hErr := koios.GetAccountRewardHistory(fetchCtx, addrs, epoch)
+			items, hErr := koios.GetAccountRewardHistory(fetchCtx, plan.addrs, epoch)
 			if hErr != nil {
-				wrapped := fmt.Errorf("account reward history chunk (%d addresses): %w", len(addrs), hErr)
+				wrapped := fmt.Errorf("account reward history chunk (%d addresses): %w", len(plan.addrs), hErr)
 				isPermanent := errors.Is(hErr, ErrKoiosPermanent)
 				errMu.Lock()
 				if firstErr == nil ||
@@ -292,7 +380,10 @@ outer:
 				// fetchCtx (this call's own per-epoch context derived from
 				// ctx above), never the caller's shared multi-epoch context,
 				// so an isolated transient failure still just drops this one
-				// epoch for a later retry.
+				// epoch for a later retry — and, unlike #3097's original
+				// implementation, whichever chunks already checkpointed
+				// before this error fired survive for that later retry to
+				// resume from.
 				cancel()
 				// afterChunkCancelForTest, when non-nil, lets a test observe
 				// deterministically that cancel() has actually fired for this
@@ -307,19 +398,28 @@ outer:
 				return
 			}
 
-			mu.Lock()
-			for _, item := range items {
-				rows = append(rows, KoiosAccountRewards{
+			rows := make([]KoiosAccountRewards, len(items))
+			for i, item := range items {
+				rows[i] = KoiosAccountRewards{
 					StakeAddress:   item.StakeAddress,
 					RewardType:     item.Type,
 					Earned:         item.Amount,
 					SpendableEpoch: item.SpendableEpoch,
 					PoolIDBech32:   strOrEmpty(item.PoolIDBech32),
 					FetchedAt:      now,
-				})
+				}
 			}
-			mu.Unlock()
-		}(chunk)
+			if saveErr := cache.SaveAccountFetchChunkProgress(network, epoch, plan.hash, rows, plan.addrs, now); saveErr != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("save account fetch chunk progress: %w", saveErr)
+				}
+				errMu.Unlock()
+				cancel()
+				return
+			}
+			newlyFetched.Add(int64(len(rows)))
+		}(plan)
 	}
 
 	wg.Wait()
@@ -335,28 +435,48 @@ outer:
 		return 0, classifyFetchErr(err)
 	}
 
+	stagedRows, err := cache.GetStagedAccountRows(network, epoch)
+	if err != nil {
+		return 0, fmt.Errorf("get staged account rows: %w", err)
+	}
+
 	// A zero-row result across the whole address universe, for an epoch that
 	// closed within the grace window, is far more likely to be Koios's own
 	// account_reward_history publishing lag than genuine "nobody earned a
 	// reward this epoch" — see this function's doc comment. Leave coverage
 	// incomplete so a later attempt retries it, rather than baking in an
 	// empty snapshot as permanent fact the moment complete=1 is committed.
-	complete := len(rows) != 0 || graceHours <= 0 || epochEndTime.IsZero() ||
+	complete := len(stagedRows) != 0 || graceHours <= 0 ||
+		epochEndTime.IsZero() ||
 		now.Sub(epochEndTime) >= time.Duration(graceHours)*time.Hour
 
-	if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, rows, len(addressUniverse), complete, now); commitErr != nil {
+	if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, stagedRows, len(addressUniverse), complete, now); commitErr != nil {
 		return 0, fmt.Errorf("commit account rewards: %w", commitErr)
+	}
+	if complete {
+		if clearErr := cache.ClearAccountFetchStaging(network, epoch); clearErr != nil {
+			logger.Warn(
+				"koiosparity: failed to clear account fetch staging after commit",
+				"network",
+				network,
+				"epoch",
+				epoch,
+				"error",
+				clearErr,
+			)
+		}
 	}
 
 	logger.Info("koiosparity: epoch account rewards fetched",
 		"network", network,
 		"epoch", epoch,
 		"addresses", len(addressUniverse),
-		"chunks", len(chunks),
-		"rows", len(rows),
+		"chunks", len(plans),
+		"pending_chunks", len(pending),
+		"rows", len(stagedRows),
 		"complete", complete,
 	)
-	return len(rows), nil
+	return int(newlyFetched.Load()), nil
 }
 
 // FetchEpochAccountsWithAddrs fetches and caches Koios account-reward
@@ -380,6 +500,11 @@ outer:
 // this function instead: silently treating it the same as "unknown end
 // time" would let an empty account fetch bypass the grace gate and commit
 // as complete, suppressing retries and risking a false PASS.
+//
+// chunkSize/chunkMaxBytes (dingo #3099) thread operator-configured
+// --account-chunk-size/--account-chunk-max-bytes through to
+// fetchAccountRewardsForEpoch's dual-bounded chunking; 0 for either means
+// "use the package default" (koiosAccountChunkSize/koiosAccountChunkMaxBytesDefault).
 func FetchEpochAccountsWithAddrs(
 	ctx context.Context,
 	koios *KoiosClient,
@@ -389,6 +514,7 @@ func FetchEpochAccountsWithAddrs(
 	source RewardParitySource,
 	koiosAddrs []string,
 	graceHours int,
+	chunkSize, chunkMaxBytes int,
 	logger *slog.Logger,
 ) (int, error) {
 	stakeEpoch, ok := koiosStakeEpoch(epoch)
@@ -428,7 +554,7 @@ func FetchEpochAccountsWithAddrs(
 			fmt.Errorf("get epoch info for grace-hours gate: %w", infoErr),
 		)
 	}
-	return FetchAccountRewardsForEpoch(
+	return fetchAccountRewardsForEpoch(
 		ctx,
 		koios,
 		cache,
@@ -437,6 +563,8 @@ func FetchEpochAccountsWithAddrs(
 		universe,
 		epochEndTime,
 		graceHours,
+		chunkSize,
+		chunkMaxBytes,
 		logger,
 	)
 }

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -250,9 +250,27 @@ func fetchAccountRewardsForEpoch(
 	now := time.Now()
 
 	if len(addressUniverse) == 0 {
-		// Nothing to check — commit a complete, empty coverage record so this
-		// epoch is never perpetually treated as "not yet fetched" by
-		// checkEpoch's coverage gate.
+		// The universe can become empty after a previous, non-empty attempt
+		// already left checkpoint data behind for this (network, epoch) —
+		// e.g. Dingo's reward_account_output rows for this stake epoch were
+		// pruned/rolled back between calls. None of that old data belongs to
+		// the current (empty) plan; passing nil here invalidates every
+		// existing chunk (InvalidateStaleAccountChunks treats "not in the
+		// current plan" as stale for any hash not in currentChunkHashes,
+		// and nil means none are). Skipping this would leave stale rows in
+		// koios_account_checked/koios_account_fetch_staged_rows that
+		// GetZeroRewardAccountsForEpoch/GetAccountUniverseForEpoch (used by
+		// accountLifecycleMismatches) would then read as if they belonged to
+		// this epoch's current, correctly-empty universe.
+		if err := cache.InvalidateStaleAccountChunks(network, epoch, nil); err != nil {
+			return 0, fmt.Errorf(
+				"invalidate stale account chunks for empty universe: %w",
+				err,
+			)
+		}
+		// Commit a complete, empty coverage record so this epoch is never
+		// perpetually treated as "not yet fetched" by checkEpoch's coverage
+		// gate.
 		if commitErr := cache.CommitAccountRewardsForEpoch(network, epoch, nil, 0, true, now); commitErr != nil {
 			return 0, fmt.Errorf("commit empty account coverage: %w", commitErr)
 		}
@@ -468,13 +486,36 @@ outer:
 		return 0, fmt.Errorf("get staged account rows: %w", err)
 	}
 
-	// A zero-row result across the whole address universe, for an epoch that
-	// closed within the grace window, is far more likely to be Koios's own
-	// account_reward_history publishing lag than genuine "nobody earned a
-	// reward this epoch" — see this function's doc comment. Leave coverage
-	// incomplete so a later attempt retries it, rather than baking in an
-	// empty snapshot as permanent fact the moment complete=1 is committed.
-	complete := len(stagedRows) != 0 || graceHours <= 0 ||
+	// A zero-row result, for an epoch that closed within the grace window,
+	// is far more likely to be Koios's own account_reward_history publishing
+	// lag than genuine "nobody earned a reward this epoch" — see this
+	// function's doc comment. This must be judged per chunk, not on the
+	// aggregate stagedRows total: if one chunk has real rows while another
+	// is still empty-and-lagging, the aggregate total alone is non-zero even
+	// though the lagging chunk was never actually reconfirmed this call —
+	// committing complete=true here would let that chunk's later-published
+	// rewards be permanently missed, since a completed epoch is never
+	// re-fetched. Re-querying after dispatch (rather than reusing the
+	// pre-dispatch hashesWithRows) picks up whatever any chunk resolved to
+	// during this very call.
+	finalHashesWithRows, err := cache.GetChunkHashesWithStagedRows(
+		network,
+		epoch,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"get chunk hashes with staged rows (final): %w",
+			err,
+		)
+	}
+	allChunksHaveRows := true
+	for _, p := range plans {
+		if !finalHashesWithRows[p.hash] {
+			allChunksHaveRows = false
+			break
+		}
+	}
+	complete := allChunksHaveRows || graceHours <= 0 ||
 		epochEndTime.IsZero() ||
 		now.Sub(epochEndTime) >= time.Duration(graceHours)*time.Hour
 

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -817,6 +817,73 @@ func TestFetchAccountRewardsForEpochIncompleteCoverageAfterForceRefreshSelfHeals
 	)
 }
 
+// TestFetchAccountRewardsForEpochForceRefreshDowngradesCoverageOnPostDispatchFailure
+// proves the coverage downgrade (wrapForceRefreshFailure) isn't limited to a
+// chunk-dispatch failure: every chunk can succeed during dispatch (so
+// koios_account_checked/koios_account_fetch_staged_rows are already fully
+// refreshed) and the failure can instead happen afterward — reading staged
+// rows back, the final hash re-check, or CommitAccountRewardsForEpoch itself.
+// Simulated here by breaking koios_account_rewards (dropped) so
+// CommitAccountRewardsForEpoch's own DELETE fails and its transaction rolls
+// back, while koios_account_coverage stays intact and queryable — isolating
+// a failure specifically at the commit step, after a fully successful
+// dispatch, from the chunk-dispatch failure the other tests already cover.
+func TestFetchAccountRewardsForEpochForceRefreshDowngradesCoverageOnPostDispatchFailure(
+	t *testing.T,
+) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs := []string{"stake1addrPD0", "stake1addrPD1"}
+
+	// First, normal run: succeeds and commits a complete epoch.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 980, addrs, time.Time{}, 0,
+		1, 0, false, nil,
+	)
+	require.NoError(t, err)
+	covBefore, err := cache.GetAccountCoverage("preview", 980)
+	require.NoError(t, err)
+	require.True(t, covBefore.Complete, "test setup sanity check")
+
+	// Break the commit step specifically: every chunk will still dispatch
+	// and succeed, but CommitAccountRewardsForEpoch's DELETE FROM
+	// koios_account_rewards now fails, rolling back the whole commit —
+	// koios_account_coverage itself is untouched by this and stays readable.
+	_, err = cache.db.Exec("DROP TABLE koios_account_rewards")
+	require.NoError(t, err)
+
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 980, addrs, time.Time{}, 0,
+		1, 0, true, nil,
+	)
+	require.Error(t, err, "the broken commit step must surface as a real failure")
+	require.ErrorContains(t, err, "commit account rewards")
+
+	covAfter, err := cache.GetAccountCoverage("preview", 980)
+	require.NoError(t, err)
+	require.False(
+		t,
+		covAfter.Complete,
+		"a post-dispatch commit failure must still downgrade coverage to "+
+			"incomplete, even though every chunk dispatched successfully",
+	)
+}
+
 // TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the
 // issue asks for directly: large synthetic snapshot plus injected timeout,
 // rate-limit, truncated-response, duplicate-page, and restart failures, all

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -450,7 +450,7 @@ func TestFetchAccountRewardsForEpochRequiresEveryChunkCurrentBeforeComplete(
 	// real rows and the other stays empty within the same call.
 	_, err = FetchEpochAccountsWithAddrs(
 		t.Context(), k, cache, "preview", 800, nil,
-		[]string{hasDataAddr, noDataAddr}, 24, 1, 0, nil,
+		[]string{hasDataAddr, noDataAddr}, 24, 1, 0, false, nil,
 	)
 	require.NoError(t, err)
 
@@ -539,6 +539,83 @@ func TestFetchAccountRewardsForEpochEmptyUniverseInvalidatesPriorCheckpointData(
 	zeroReward, err := cache.GetZeroRewardAccountsForEpoch("preview", 850)
 	require.NoError(t, err)
 	require.Empty(t, zeroReward)
+}
+
+// TestFetchAccountRewardsForEpochForceRefreshBypassesRetainedCheckpoints
+// proves --force-refresh (forceRefresh=true) actually goes back to Koios
+// instead of silently reusing retained checkpoint state: rerunning with an
+// unchanged address universe and forceRefresh=false must not re-request any
+// already-done chunk (the existing resume behavior), but the same rerun with
+// forceRefresh=true must re-request every chunk, since an operator running
+// --force-refresh is explicitly trying to repair suspected stale/corrupt
+// cached data.
+func TestFetchAccountRewardsForEpochForceRefreshBypassesRetainedCheckpoints(
+	t *testing.T,
+) {
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs := []string{"stake1addr000", "stake1addr001", "stake1addr002"}
+
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 950, addrs, time.Time{}, 0,
+		1, 0, false, nil, // chunkSize 1 -> 3 chunks, 3 requests
+	)
+	require.NoError(t, err)
+	afterFirstRun := requestCount.Load()
+	require.EqualValues(t, 3, afterFirstRun)
+
+	// Rerun, unchanged universe, forceRefresh=false: every chunk is already
+	// checkpointed "done", so no new requests are made.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 950, addrs, time.Time{}, 0,
+		1, 0, false, nil,
+	)
+	require.NoError(t, err)
+	require.EqualValues(
+		t,
+		afterFirstRun,
+		requestCount.Load(),
+		"an unchanged universe without forceRefresh must reuse every checkpointed chunk",
+	)
+
+	// Rerun again, unchanged universe, forceRefresh=true: every chunk must be
+	// invalidated and re-requested despite matching the retained checkpoints
+	// exactly.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 950, addrs, time.Time{}, 0,
+		1, 0, true, nil,
+	)
+	require.NoError(t, err)
+	require.EqualValues(
+		t,
+		afterFirstRun+3,
+		requestCount.Load(),
+		"forceRefresh=true must re-request every chunk even when the universe is unchanged",
+	)
+
+	cov, err := cache.GetAccountCoverage("preview", 950)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.True(t, cov.Complete)
+	require.Equal(t, len(addrs), cov.RequestedCount)
 }
 
 // TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the
@@ -691,6 +768,7 @@ func TestFetchAccountRewardsForEpochMegaScenario(t *testing.T) {
 		0,
 		10,
 		0,
+		false,
 		nil,
 	)
 	require.Error(
@@ -741,6 +819,7 @@ func TestFetchAccountRewardsForEpochMegaScenario(t *testing.T) {
 		0,
 		10,
 		0,
+		false,
 		nil,
 	)
 	require.NoError(t, err)
@@ -842,7 +921,7 @@ func TestFetchAccountRewardsForEpochRequestBodyNeverExceedsConfiguredMaxBytes(
 
 	_, err = FetchEpochAccountsWithAddrs(
 		t.Context(), k, cache, "preview", 900, nil, addrs, 0,
-		1_000_000, chunkMaxBytes, nil,
+		1_000_000, chunkMaxBytes, false, nil,
 	)
 	require.NoError(t, err)
 	mu.Lock()

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -597,8 +597,7 @@ func TestFetchAccountRewardsForEpochForceRefreshBypassesRetainedCheckpoints(
 	)
 
 	// Rerun again, unchanged universe, forceRefresh=true: every chunk must be
-	// invalidated and re-requested despite matching the retained checkpoints
-	// exactly.
+	// re-requested despite matching the retained checkpoints exactly.
 	_, err = fetchAccountRewardsForEpoch(
 		t.Context(), k, cache, "preview", 950, addrs, time.Time{}, 0,
 		1, 0, true, nil,
@@ -616,6 +615,126 @@ func TestFetchAccountRewardsForEpochForceRefreshBypassesRetainedCheckpoints(
 	require.NotNil(t, cov)
 	require.True(t, cov.Complete)
 	require.Equal(t, len(addrs), cov.RequestedCount)
+}
+
+// TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoints
+// proves the fix for a real data-loss hazard: an earlier version of
+// forceRefresh invalidated (deleted) every existing chunk's checkpoint data
+// up front, before dispatch, so an interrupted/partially-failing
+// --force-refresh attempt could leave koios_account_checked/
+// koios_account_fetch_staged_rows wiped or partial for an epoch whose
+// koios_account_coverage row still (correctly, since CommitAccountRewardsForEpoch
+// is never reached on a partial failure) reports complete=true from the last
+// successful run — a state accountLifecycleMismatches would then read as if
+// it belonged to a genuinely complete epoch. forceRefresh must instead leave
+// a chunk's existing checkpoint alone until that specific chunk's own
+// re-fetch actually succeeds.
+func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoints(
+	t *testing.T,
+) {
+	const goodAddr = "stake1addrGOOD"
+	const failAddr = "stake1addrFAIL"
+
+	var refreshing atomic.Bool
+	var refreshAmount atomic.Bool // toggled once the refresh re-fetches goodAddr
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			if slices.Contains(addrs, failAddr) && refreshing.Load() {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("unavailable"))
+				return
+			}
+			if slices.Contains(addrs, goodAddr) && refreshing.Load() {
+				refreshAmount.Store(true)
+			}
+			items := make([]KoiosAccountRewardHistoryItem, len(addrs))
+			amount := "1000"
+			if refreshAmount.Load() {
+				amount = "2000" // proves this chunk was genuinely re-fetched
+			}
+			for i, a := range addrs {
+				items[i] = KoiosAccountRewardHistoryItem{
+					StakeAddress: a, EarnedEpoch: 100, Amount: amount, Type: "member",
+				}
+			}
+			body, err := json.Marshal(items)
+			assert.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 100 * time.Millisecond},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs := []string{goodAddr, failAddr}
+
+	// First, normal run: both chunks succeed and commit a complete epoch.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 960, addrs, time.Time{}, 0,
+		1, 0, false, nil,
+	)
+	require.NoError(t, err)
+	covBefore, err := cache.GetAccountCoverage("preview", 960)
+	require.NoError(t, err)
+	require.NotNil(t, covBefore)
+	require.True(t, covBefore.Complete)
+	doneBefore, err := cache.GetDoneAccountChunkHashes("preview", 960)
+	require.NoError(t, err)
+	require.Len(t, doneBefore, 2, "test setup sanity check")
+
+	// Force-refresh: goodAddr's chunk re-fetches successfully (with a
+	// different amount, proving it was truly re-requested), failAddr's chunk
+	// fails outright.
+	refreshing.Store(true)
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 960, addrs, time.Time{}, 0,
+		1, 0, true, nil,
+	)
+	require.Error(t, err, "failAddr's chunk must surface as a real failure")
+
+	// The epoch's coverage row must be exactly as it was before the failed
+	// refresh attempt — never wiped, never left inconsistent — since
+	// CommitAccountRewardsForEpoch is never reached on a partial failure.
+	covAfter, err := cache.GetAccountCoverage("preview", 960)
+	require.NoError(t, err)
+	require.NotNil(t, covAfter)
+	require.Equal(t, *covBefore, *covAfter)
+
+	// failAddr's chunk never re-succeeded, so its prior, still-valid
+	// checkpoint must survive untouched rather than being deleted up front.
+	doneAfter, err := cache.GetDoneAccountChunkHashes("preview", 960)
+	require.NoError(t, err)
+	require.Len(
+		t,
+		doneAfter,
+		2,
+		"failAddr's untouched-by-the-refresh chunk checkpoint must still be present",
+	)
+
+	// goodAddr's chunk, by contrast, really was re-fetched: its staged row
+	// now carries the refreshed amount, not the original one.
+	staged, err := cache.GetStagedAccountRows("preview", 960)
+	require.NoError(t, err)
+	for _, row := range staged {
+		if row.StakeAddress == goodAddr {
+			require.Equal(
+				t,
+				"2000",
+				row.Earned,
+				"goodAddr's chunk must reflect the force-refreshed value",
+			)
+		}
+	}
 }
 
 // TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -275,6 +276,110 @@ func TestFetchAccountRewardsForEpochInvalidatesOnlyChangedChunksOnUniverseChange
 	require.Equal(t, len(secondUniverse), cov.RequestedCount)
 }
 
+// TestFetchAccountRewardsForEpochDoesNotTrustEmptyCheckpointWithinGraceWindow
+// proves a real bug fix: a chunk that checkpointed with zero rows while
+// still within the grace window must be re-dispatched on a later retry
+// (still within the window), not skipped as "already done" — otherwise a
+// retry could never notice that Koios has since published real data, and
+// the epoch would eventually commit complete=true with a stale, empty
+// result once graceHours elapses, silently losing rewards Koios published
+// in the meantime.
+func TestFetchAccountRewardsForEpochDoesNotTrustEmptyCheckpointWithinGraceWindow(
+	t *testing.T,
+) {
+	var hasData atomic.Bool
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			if !hasData.Load() {
+				// Koios hasn't published yet: a legitimate empty response, not
+				// an error.
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs := []string{"stake1a", "stake1b", "stake1c"}
+	epochEndTime := time.Now()
+	const graceHours = 24
+
+	// First attempt: Koios hasn't published yet — the chunk succeeds with
+	// zero rows, checkpoints, but the epoch correctly stays incomplete
+	// because we're still within the grace window.
+	_, err = FetchAccountRewardsForEpoch(
+		t.Context(),
+		k,
+		cache,
+		"preview",
+		700,
+		addrs,
+		epochEndTime,
+		graceHours,
+		nil,
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, requestCount.Load())
+
+	cov, err := cache.GetAccountCoverage("preview", 700)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.False(
+		t,
+		cov.Complete,
+		"a zero-row result within the grace window must leave the epoch incomplete",
+	)
+
+	// Koios has since published real data. Retry, still within the grace
+	// window (epochEndTime unchanged, no real time has meaningfully passed).
+	hasData.Store(true)
+	_, err = FetchAccountRewardsForEpoch(
+		t.Context(),
+		k,
+		cache,
+		"preview",
+		700,
+		addrs,
+		epochEndTime,
+		graceHours,
+		nil,
+	)
+	require.NoError(t, err)
+	require.EqualValues(
+		t,
+		2,
+		requestCount.Load(),
+		"the previously-empty, still-within-grace chunk must be re-dispatched, "+
+			"not trusted as already done",
+	)
+
+	cov, err = cache.GetAccountCoverage("preview", 700)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.True(t, cov.Complete)
+	require.Equal(
+		t,
+		len(addrs),
+		cov.FetchedCount,
+		"the real data Koios published in the meantime must actually be captured",
+	)
+}
+
 // TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the
 // issue asks for directly: large synthetic snapshot plus injected timeout,
 // rate-limit, truncated-response, duplicate-page, and restart failures, all
@@ -512,6 +617,72 @@ func TestFetchAccountRewardsForEpochMegaScenario(t *testing.T) {
 		1,
 		duplicateKeys,
 		"exactly one (address, reward_type) key must show the injected duplicate",
+	)
+}
+
+// TestFetchAccountRewardsForEpochRequestBodyNeverExceedsConfiguredMaxBytes
+// proves chunkAddressesByCountAndSize's byte budget accounts for the fixed
+// {"_stake_addresses":[...],"_epoch_no":N} JSON envelope, not just the
+// address array itself — without reserving that overhead, the real request
+// body could exceed a small configured --account-chunk-max-bytes by a fixed
+// amount on every single chunk.
+func TestFetchAccountRewardsForEpochRequestBodyNeverExceedsConfiguredMaxBytes(
+	t *testing.T,
+) {
+	const chunkMaxBytes = 100 // deliberately tiny, to make the envelope's
+	// fixed overhead a large fraction of the budget rather than negligible.
+
+	// Chunks dispatch concurrently (accountFetchConcurrency workers), so the
+	// handler runs on multiple goroutines at once — guard the shared max
+	// with a mutex rather than a plain int.
+	var mu sync.Mutex
+	var maxBodyLen int
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			mu.Lock()
+			if len(body) > maxBodyLen {
+				maxBodyLen = len(body)
+			}
+			mu.Unlock()
+			var decoded struct {
+				StakeAddresses []string `json:"_stake_addresses"`
+			}
+			require.NoError(t, json.Unmarshal(body, &decoded))
+			writeAccountRewardHistoryRows(w, decoded.StakeAddresses)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs := make([]string, 50)
+	for i := range addrs {
+		addrs[i] = fmt.Sprintf("stake1addr%03d", i)
+	}
+
+	_, err = FetchEpochAccountsWithAddrs(
+		t.Context(), k, cache, "preview", 900, nil, addrs, 0,
+		1_000_000, chunkMaxBytes, nil,
+	)
+	require.NoError(t, err)
+	mu.Lock()
+	got := maxBodyLen
+	mu.Unlock()
+	require.Greater(t, got, 0, "at least one request must have been sent")
+	require.LessOrEqual(
+		t,
+		got,
+		chunkMaxBytes,
+		"the real encoded request body, envelope included, must never exceed --account-chunk-max-bytes",
 	)
 }
 

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -622,13 +622,17 @@ func TestFetchAccountRewardsForEpochForceRefreshBypassesRetainedCheckpoints(
 // forceRefresh invalidated (deleted) every existing chunk's checkpoint data
 // up front, before dispatch, so an interrupted/partially-failing
 // --force-refresh attempt could leave koios_account_checked/
-// koios_account_fetch_staged_rows wiped or partial for an epoch whose
-// koios_account_coverage row still (correctly, since CommitAccountRewardsForEpoch
-// is never reached on a partial failure) reports complete=true from the last
-// successful run — a state accountLifecycleMismatches would then read as if
-// it belonged to a genuinely complete epoch. forceRefresh must instead leave
-// a chunk's existing checkpoint alone until that specific chunk's own
-// re-fetch actually succeeds.
+// koios_account_fetch_staged_rows wiped or partial. forceRefresh must instead
+// leave a chunk's existing checkpoint alone until that specific chunk's own
+// re-fetch actually succeeds — proved below by failAddr's untouched
+// checkpoint surviving. Separately, since a partial force-refresh failure
+// still leaves koios_account_checked holding a mix of freshly-refreshed and
+// untouched pre-refresh chunks (two snapshots that were never valid
+// together), the pre-existing complete=true coverage row from before this
+// attempt must be downgraded to complete=false (Cache.MarkAccountCoverageIncomplete)
+// rather than left as-is — otherwise compareEpochAccounts/
+// accountLifecycleMismatches would trust that mixed state as a genuinely
+// complete epoch.
 func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoints(
 	t *testing.T,
 ) {
@@ -636,7 +640,6 @@ func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoi
 	const failAddr = "stake1addrFAIL"
 
 	var refreshing atomic.Bool
-	var refreshAmount atomic.Bool // toggled once the refresh re-fetches goodAddr
 
 	srv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -646,23 +649,7 @@ func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoi
 				_, _ = w.Write([]byte("unavailable"))
 				return
 			}
-			if slices.Contains(addrs, goodAddr) && refreshing.Load() {
-				refreshAmount.Store(true)
-			}
-			items := make([]KoiosAccountRewardHistoryItem, len(addrs))
-			amount := "1000"
-			if refreshAmount.Load() {
-				amount = "2000" // proves this chunk was genuinely re-fetched
-			}
-			for i, a := range addrs {
-				items[i] = KoiosAccountRewardHistoryItem{
-					StakeAddress: a, EarnedEpoch: 100, Amount: amount, Type: "member",
-				}
-			}
-			body, err := json.Marshal(items)
-			assert.NoError(t, err)
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(body)
+			writeAccountRewardHistoryRows(w, addrs)
 		}),
 	)
 	defer srv.Close()
@@ -692,9 +679,13 @@ func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoi
 	require.NoError(t, err)
 	require.Len(t, doneBefore, 2, "test setup sanity check")
 
-	// Force-refresh: goodAddr's chunk re-fetches successfully (with a
-	// different amount, proving it was truly re-requested), failAddr's chunk
-	// fails outright.
+	// Force-refresh: goodAddr's chunk re-fetches successfully, failAddr's
+	// chunk fails outright. (goodAddr genuinely being re-requested is already
+	// covered by TestFetchAccountRewardsForEpochForceRefreshBypassesRetainedCheckpoints's
+	// request-count assertions — not repeated here via a response-value
+	// check, since both chunks dispatch concurrently and there is no
+	// ordering guarantee between goodAddr's checkpoint save and failAddr's
+	// cancellation.)
 	refreshing.Store(true)
 	_, err = fetchAccountRewardsForEpoch(
 		t.Context(), k, cache, "preview", 960, addrs, time.Time{}, 0,
@@ -702,13 +693,21 @@ func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoi
 	)
 	require.Error(t, err, "failAddr's chunk must surface as a real failure")
 
-	// The epoch's coverage row must be exactly as it was before the failed
-	// refresh attempt — never wiped, never left inconsistent — since
-	// CommitAccountRewardsForEpoch is never reached on a partial failure.
+	// The epoch's coverage row must be downgraded to complete=false — the
+	// mixed post-refresh checkpoint state (goodAddr refreshed, failAddr
+	// untouched) is never a valid snapshot to trust, even though
+	// CommitAccountRewardsForEpoch itself was never reached on this partial
+	// failure. RequestedCount is otherwise unchanged (MarkAccountCoverageIncomplete
+	// only ever flips the complete flag).
 	covAfter, err := cache.GetAccountCoverage("preview", 960)
 	require.NoError(t, err)
 	require.NotNil(t, covAfter)
-	require.Equal(t, *covBefore, *covAfter)
+	require.False(
+		t,
+		covAfter.Complete,
+		"a partial force-refresh failure must downgrade coverage to incomplete",
+	)
+	require.Equal(t, covBefore.RequestedCount, covAfter.RequestedCount)
 
 	// failAddr's chunk never re-succeeded, so its prior, still-valid
 	// checkpoint must survive untouched rather than being deleted up front.
@@ -720,21 +719,102 @@ func TestFetchAccountRewardsForEpochFailedForceRefreshPreservesUntouchedCheckpoi
 		2,
 		"failAddr's untouched-by-the-refresh chunk checkpoint must still be present",
 	)
+}
 
-	// goodAddr's chunk, by contrast, really was re-fetched: its staged row
-	// now carries the refreshed amount, not the original one.
-	staged, err := cache.GetStagedAccountRows("preview", 960)
-	require.NoError(t, err)
-	for _, row := range staged {
-		if row.StakeAddress == goodAddr {
-			require.Equal(
-				t,
-				"2000",
-				row.Earned,
-				"goodAddr's chunk must reflect the force-refreshed value",
-			)
-		}
+// TestFetchAccountRewardsForEpochIncompleteCoverageAfterForceRefreshSelfHeals
+// proves the other half of Cache.MarkAccountCoverageIncomplete's contract:
+// once a partial --force-refresh failure downgrades an epoch's coverage to
+// complete=false, a subsequent plain (non-force-refresh) call restores
+// complete=true on its own — because failAddr's chunk from before the
+// refresh was left untouched (never deleted), it's still checkpointed with
+// real rows, so the normal doneHashes/hashesWithRows resume logic already
+// trusts it without needing to re-contact Koios for it at all. This is
+// exactly why forceRefresh never pre-invalidates existing checkpoint data:
+// doing so would have made this self-heal impossible without another
+// explicit --force-refresh, since failAddr's old, still-valid data would
+// have been destroyed rather than preserved.
+func TestFetchAccountRewardsForEpochIncompleteCoverageAfterForceRefreshSelfHeals(
+	t *testing.T,
+) {
+	const goodAddr = "stake1addrGOOD2"
+	const failAddr = "stake1addrFAIL2"
+
+	var failAddrRequests atomic.Int32
+	var failNextFailAddrRequest atomic.Bool
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			if slices.Contains(addrs, failAddr) {
+				failAddrRequests.Add(1)
+				if failNextFailAddrRequest.Load() {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte("unavailable"))
+					return
+				}
+			}
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 100 * time.Millisecond},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
 	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs := []string{goodAddr, failAddr}
+
+	// First, normal run: both chunks succeed and commit a complete epoch.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 970, addrs, time.Time{}, 0,
+		1, 0, false, nil,
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, failAddrRequests.Load())
+
+	// Force-refresh: failAddr's chunk fails (post()'s own internal retries on
+	// a 5xx mean this bumps the counter by more than one), downgrading
+	// coverage.
+	failNextFailAddrRequest.Store(true)
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 970, addrs, time.Time{}, 0,
+		1, 0, true, nil,
+	)
+	require.Error(t, err)
+	afterForceRefresh := failAddrRequests.Load()
+	require.Greater(t, afterForceRefresh, int32(1))
+	cov, err := cache.GetAccountCoverage("preview", 970)
+	require.NoError(t, err)
+	require.False(t, cov.Complete, "test setup sanity check")
+
+	// A subsequent plain (non-force-refresh) call must self-heal — restoring
+	// complete=true — without ever re-requesting failAddr's chunk, since its
+	// pre-refresh checkpoint was preserved, not deleted.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 970, addrs, time.Time{}, 0,
+		1, 0, false, nil,
+	)
+	require.NoError(t, err)
+	require.EqualValues(
+		t,
+		afterForceRefresh,
+		failAddrRequests.Load(),
+		"the self-heal must trust failAddr's preserved checkpoint, not re-request it",
+	)
+
+	covHealed, err := cache.GetAccountCoverage("preview", 970)
+	require.NoError(t, err)
+	require.True(
+		t,
+		covHealed.Complete,
+		"a subsequent normal fetch must self-heal the incomplete coverage "+
+			"left behind by a failed force-refresh",
+	)
 }
 
 // TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -1,0 +1,562 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// decodeAccountRewardHistoryRequest decodes one /account_reward_history POST
+// body the same way the production endpoint does.
+func decodeAccountRewardHistoryRequest(
+	t *testing.T,
+	r *http.Request,
+) (addrs []string, epoch uint64) {
+	t.Helper()
+	var body struct {
+		StakeAddresses []string `json:"_stake_addresses"`
+		EpochNo        uint64   `json:"_epoch_no"`
+	}
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	return body.StakeAddresses, body.EpochNo
+}
+
+func writeAccountRewardHistoryRows(w http.ResponseWriter, addrs []string) {
+	items := make([]KoiosAccountRewardHistoryItem, len(addrs))
+	for i, a := range addrs {
+		items[i] = KoiosAccountRewardHistoryItem{
+			StakeAddress: a,
+			EarnedEpoch:  100,
+			Amount:       "1000",
+			Type:         "member",
+		}
+	}
+	body, err := json.Marshal(items)
+	if err != nil {
+		panic(err)
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// TestFetchAccountRewardsForEpochResumesOnlyUndoneChunksAfterRestart proves
+// dingo #3099's checkpointing: a chunk that already committed to
+// koios_account_checked/koios_account_fetch_staged_rows on a prior,
+// interrupted call is never re-requested on a resumed call — only the
+// chunk(s) that never succeeded are retried. #3097's original
+// implementation had no such checkpoint, so every chunk (including
+// already-succeeded ones) was re-fetched from scratch on every retry.
+func TestFetchAccountRewardsForEpochResumesOnlyUndoneChunksAfterRestart(
+	t *testing.T,
+) {
+	const poisonAddr = "stake9POISON" // sorts after every "stake1addrNNN"
+
+	var recovered atomic.Bool
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			addrs, epoch := decodeAccountRewardHistoryRequest(t, r)
+			require.Equal(t, uint64(100), epoch)
+
+			if slices.Contains(addrs, poisonAddr) && !recovered.Load() {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("unavailable"))
+				return
+			}
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	const numNormal = 249
+	addrs := make([]string, numNormal+1)
+	for i := range numNormal {
+		addrs[i] = fmt.Sprintf("stake1addr%03d", i)
+	}
+	addrs[numNormal] = poisonAddr // 250 addresses total -> chunks of 100,100,50+poison
+
+	_, err = FetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 100, addrs, time.Time{}, 0, nil,
+	)
+	require.Error(
+		t,
+		err,
+		"the poisoned chunk's 503 must surface as a real, uncommitted failure",
+	)
+	require.False(t, errors.Is(err, ErrKoiosPermanent))
+
+	_, covErr := cache.GetAccountCoverage("preview", 100)
+	require.Error(t, covErr, "nothing may commit while any chunk is unresolved")
+
+	afterFirstRun := requestCount.Load()
+	// 2 successful chunks (1 request each) + the poisoned chunk retried
+	// koiosMaxRetries times before post() gives up (5xx is retried
+	// internally) = 5.
+	require.EqualValues(
+		t,
+		5,
+		afterFirstRun,
+		"2 successful chunks + 3 retries on the poisoned chunk",
+	)
+
+	// "Restart": Koios recovers, caller retries with the identical universe.
+	recovered.Store(true)
+	fetched, err := FetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 100, addrs, time.Time{}, 0, nil,
+	)
+	require.NoError(t, err)
+
+	afterSecondRun := requestCount.Load()
+	require.EqualValues(
+		t,
+		afterFirstRun+1,
+		afterSecondRun,
+		"only the previously-failed chunk is re-requested; the other two chunks' "+
+			"checkpointed progress must be reused, not re-fetched",
+	)
+	// Only the resumed chunk's addresses are freshly checkpointed by this
+	// call — fetched is per-call, not cumulative (mirrors #3097's original
+	// per-call semantics, preserved by this rewrite).
+	require.Equal(t, len(addrs)-200, fetched)
+
+	cov, err := cache.GetAccountCoverage("preview", 100)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.True(t, cov.Complete)
+	require.Equal(t, len(addrs), cov.RequestedCount)
+	require.Equal(t, len(addrs), cov.FetchedCount)
+}
+
+// TestFetchAccountRewardsForEpochInvalidatesOnlyChangedChunksOnUniverseChange
+// proves content-addressed chunk hashing: when the requested universe
+// changes between an interrupted attempt and a resumed one, only the chunk(s)
+// whose exact address grouping changed are invalidated and refetched — an
+// unaffected chunk's checkpointed progress survives.
+func TestFetchAccountRewardsForEpochInvalidatesOnlyChangedChunksOnUniverseChange(
+	t *testing.T,
+) {
+	const poisonAddr = "stake9POISON"
+
+	var recovered atomic.Bool
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			if slices.Contains(addrs, poisonAddr) && !recovered.Load() {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("unavailable"))
+				return
+			}
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	buildAddrs := func(chunk1Marker string) []string {
+		addrs := make([]string, 250)
+		for i := range 100 {
+			addrs[i] = fmt.Sprintf("stake1addr%03d", i) // chunk 0: [000,100)
+		}
+		for i := 100; i < 200; i++ {
+			addrs[i] = fmt.Sprintf("stake1addr%03d", i) // chunk 1: [100,200)
+		}
+		addrs[150] = chunk1Marker // perturb chunk 1's content only
+		for i := 200; i < 249; i++ {
+			addrs[i] = fmt.Sprintf(
+				"stake1addr%03d",
+				i,
+			) // chunk 2: [200,249)+poison
+		}
+		addrs[249] = poisonAddr
+		return addrs
+	}
+
+	firstUniverse := buildAddrs("stake1addr150")
+	// The replacement must sort into the exact same position (between
+	// "stake1addr149" and "stake1addr151") as a prefix-extension of the
+	// original — anything sorting differently (e.g. an unrelated string)
+	// would shift every later chunk's boundary too, since sorting is global
+	// across the whole universe, not scoped per labeled "chunk".
+	_, err = FetchAccountRewardsForEpoch(
+		t.Context(),
+		k,
+		cache,
+		"preview",
+		200,
+		firstUniverse,
+		time.Time{},
+		0,
+		nil,
+	)
+	require.Error(t, err, "the poisoned chunk 2 must abort the first attempt")
+
+	afterFirstRun := requestCount.Load()
+	// 2 successful chunks (1 request each) + the poisoned chunk retried
+	// koiosMaxRetries times before post() gives up = 5.
+	require.EqualValues(t, 5, afterFirstRun)
+
+	// Resume with chunk 1's content changed (a different address swapped in
+	// at the same position) and chunk 2's poison now recovered.
+	recovered.Store(true)
+	secondUniverse := buildAddrs("stake1addr150X")
+	fetched, err := FetchAccountRewardsForEpoch(
+		t.Context(),
+		k,
+		cache,
+		"preview",
+		200,
+		secondUniverse,
+		time.Time{},
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+
+	afterSecondRun := requestCount.Load()
+	require.EqualValues(
+		t,
+		afterFirstRun+2,
+		afterSecondRun,
+		"chunk 0 is untouched by the universe change and must be skipped; "+
+			"only changed chunk 1 and previously-failed chunk 2 are re-requested",
+	)
+	require.Equal(t, len(secondUniverse)-100, fetched)
+
+	cov, err := cache.GetAccountCoverage("preview", 200)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.True(t, cov.Complete)
+	require.Equal(t, len(secondUniverse), cov.RequestedCount)
+}
+
+// TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the
+// issue asks for directly: large synthetic snapshot plus injected timeout,
+// rate-limit, truncated-response, duplicate-page, and restart failures, all
+// layered onto one run/resume cycle against dingo #3099's checkpointed
+// rewrite of #3097's fetchAccountRewardsForEpoch — rather than each failure
+// mode tested only in isolation.
+//
+// Roles are assigned by chunk content (each chunk's first address), not
+// server-arrival order: fetchAccountRewardsForEpoch cancels every in-flight
+// chunk the instant any one errors, so a fast-failing chunk racing among the
+// very first dispatched batch could otherwise starve slower, otherwise-
+// healthy chunks of a chance to complete at all. Placing all five injected
+// failures in the last chunks (indices numAccounts/chunkSize-5 and up) lets
+// every earlier, ordinary chunk complete and checkpoint deterministically
+// before dispatch ever reaches the failing ones.
+func TestFetchAccountRewardsForEpochMegaScenario(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	const numAccounts = 240 // chunk size 10 -> 24 chunks
+	const chunkSize = 10
+	addrs := make([]string, numAccounts)
+	for i := range addrs {
+		addrs[i] = fmt.Sprintf("stake1addr%04d", i)
+	}
+
+	const (
+		roleTimeout = iota
+		roleRateLimit
+		roleTruncated
+		roleDuplicate
+		roleOutage
+		roleNormal
+	)
+
+	// The last 5 chunks (indices 19-23) get the special roles, by content —
+	// deterministic regardless of dispatch/arrival timing.
+	roleForFirstAddr := make(map[string]int, 5)
+	specialRoles := []int{
+		roleTimeout,
+		roleRateLimit,
+		roleTruncated,
+		roleDuplicate,
+		roleOutage,
+	}
+	firstSpecialChunk := numAccounts/chunkSize - len(specialRoles)
+	for i, role := range specialRoles {
+		chunkIdx := firstSpecialChunk + i
+		roleForFirstAddr[addrs[chunkIdx*chunkSize]] = role
+	}
+
+	var mu sync.Mutex
+	attempts := map[string]int{}
+	var phaseRecovered atomic.Bool
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			key := addrs[0]
+
+			role, special := roleForFirstAddr[key]
+			if !special {
+				role = roleNormal
+			}
+			mu.Lock()
+			attempts[key]++
+			attempt := attempts[key]
+			mu.Unlock()
+
+			recovered := phaseRecovered.Load()
+
+			switch role {
+			case roleTimeout:
+				if !recovered {
+					time.Sleep(300 * time.Millisecond)
+				}
+			case roleRateLimit:
+				if attempt == 1 {
+					w.Header().Set("Retry-After", "1")
+					w.WriteHeader(http.StatusTooManyRequests)
+					_, _ = w.Write([]byte("rate limited"))
+					return
+				}
+			case roleTruncated:
+				if !recovered {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(
+						[]byte(
+							`[{"stake_address":"` + key + `","earned_epoch":`,
+						),
+					)
+					return
+				}
+			case roleDuplicate:
+				// One genuine, isolated duplicate for the chunk's first address
+				// only, with the SAME amount as the primary row (a true
+				// duplicate, not a conflicting value) — never an error; must be
+				// preserved, not retried or rejected.
+				items := make([]KoiosAccountRewardHistoryItem, 0, len(addrs)+1)
+				for i, a := range addrs {
+					items = append(items, KoiosAccountRewardHistoryItem{
+						StakeAddress: a, EarnedEpoch: 100, Amount: "1000", Type: "member",
+					})
+					if i == 0 {
+						items = append(items, KoiosAccountRewardHistoryItem{
+							StakeAddress: a, EarnedEpoch: 100, Amount: "1000", Type: "member",
+						})
+					}
+				}
+				body, marshalErr := json.Marshal(items)
+				require.NoError(t, marshalErr)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+				return
+			case roleOutage:
+				if !recovered {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte("unavailable"))
+					return
+				}
+			}
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 100 * time.Millisecond},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+
+	// First run: timeout/truncated/outage chunks fail; rate-limit recovers
+	// via retry; duplicate-page and every normal chunk succeed and
+	// checkpoint.
+	_, err = fetchAccountRewardsForEpoch(
+		t.Context(),
+		k,
+		cache,
+		"preview",
+		300,
+		addrs,
+		time.Time{},
+		0,
+		10,
+		0,
+		nil,
+	)
+	require.Error(
+		t,
+		err,
+		"timeout/truncated/outage chunks must surface as a real error",
+	)
+
+	_, covErr := cache.GetAccountCoverage("preview", 300)
+	require.Error(
+		t,
+		covErr,
+		"must never be falsely complete after a partial failure",
+	)
+
+	doneAfterRun1, err := cache.GetDoneAccountChunkHashes("preview", 300)
+	require.NoError(t, err)
+	// The 19 ordinary chunks (indices 0-18) dispatch and complete well before
+	// dispatch ever reaches the 5 special-role chunks (indices 19-23,
+	// gated behind accountFetchConcurrency concurrent slots), so all 19 must
+	// have checkpointed by the time the fast-failing truncated-response
+	// chunk cancels the rest. Asserted as a lower bound, not an exact count,
+	// since exactly how many of the 5 special chunks also race to
+	// completion before cancellation propagates is not guaranteed.
+	require.GreaterOrEqual(
+		t,
+		len(doneAfterRun1),
+		19,
+		"every ordinary chunk dispatched before the failing ones must have checkpointed",
+	)
+	require.Less(
+		t,
+		len(doneAfterRun1),
+		24,
+		"at least one chunk must still be outstanding after a real failure",
+	)
+
+	// "Restart": Koios recovers, rerun resumes.
+	phaseRecovered.Store(true)
+	checked, err := fetchAccountRewardsForEpoch(
+		t.Context(),
+		k,
+		cache,
+		"preview",
+		300,
+		addrs,
+		time.Time{},
+		0,
+		10,
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Greater(
+		t,
+		checked,
+		0,
+		"the resume call must freshly fetch at least the previously-failed chunks",
+	)
+
+	cov, err := cache.GetAccountCoverage("preview", 300)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.True(t, cov.Complete)
+	require.Equal(t, numAccounts, cov.RequestedCount)
+
+	rewards, err := cache.GetAccountRewardsForEpoch("preview", 300)
+	require.NoError(t, err)
+
+	counts := make(map[string]int, len(rewards))
+	for _, r := range rewards {
+		counts[r.StakeAddress+"|"+r.RewardType]++
+	}
+	var duplicateKeys int
+	for _, c := range counts {
+		if c > 1 {
+			duplicateKeys++
+			require.Equal(
+				t,
+				2,
+				c,
+				"the injected duplicate must survive as exactly two rows",
+			)
+		}
+	}
+	require.Equal(
+		t,
+		1,
+		duplicateKeys,
+		"exactly one (address, reward_type) key must show the injected duplicate",
+	)
+}
+
+// TestGetAccountRewardHistoryRejectsSuspiciouslyFullResponse proves the
+// page-safety guard: /account_reward_history is not Range-paginated in any
+// working sense (verified live against preview — repeated requests with
+// different Range values return the same first-window rows rather than
+// paging further), so a response landing at the koiosPageSize row ceiling
+// must hard-error rather than be accepted as a complete, trustworthy answer.
+func TestGetAccountRewardHistoryRejectsSuspiciouslyFullResponse(t *testing.T) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			n := koiosPageSize
+			if len(addrs) > 0 && addrs[0] == "few" {
+				n = koiosPageSize - 1
+			}
+			items := make([]KoiosAccountRewardHistoryItem, n)
+			for i := range items {
+				items[i] = KoiosAccountRewardHistoryItem{
+					StakeAddress: fmt.Sprintf(
+						"stake1x%d",
+						i,
+					), EarnedEpoch: 100, Amount: "1", Type: "member",
+				}
+			}
+			body, err := json.Marshal(items)
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+
+	_, err := k.GetAccountRewardHistory(t.Context(), []string{"many"}, 100)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrKoiosPermanent))
+
+	items, err := k.GetAccountRewardHistory(t.Context(), []string{"few"}, 100)
+	require.NoError(t, err)
+	require.Len(t, items, koiosPageSize-1)
+}

--- a/internal/koiosparity/fetch_accounts_resilience_test.go
+++ b/internal/koiosparity/fetch_accounts_resilience_test.go
@@ -28,11 +28,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // decodeAccountRewardHistoryRequest decodes one /account_reward_history POST
-// body the same way the production endpoint does.
+// body the same way the production endpoint does. Runs inside the
+// httptest.Server's own per-connection goroutine, never the test's own
+// goroutine, so it uses assert (records a failure, keeps going) rather than
+// require (which calls t.FailNow()/runtime.Goexit — only valid from the
+// goroutine that started the test; from here it would just exit this one
+// handler goroutine, potentially hiding the failure's real location). A
+// decode failure here also naturally surfaces to the caller anyway: the
+// handler goes on to build a response from a zero-value/partial body, which
+// the outer test-goroutine assertions (on FetchAccountRewardsForEpoch's own
+// return value) already catch.
 func decodeAccountRewardHistoryRequest(
 	t *testing.T,
 	r *http.Request,
@@ -42,7 +52,7 @@ func decodeAccountRewardHistoryRequest(
 		StakeAddresses []string `json:"_stake_addresses"`
 		EpochNo        uint64   `json:"_epoch_no"`
 	}
-	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 	return body.StakeAddresses, body.EpochNo
 }
 
@@ -83,7 +93,11 @@ func TestFetchAccountRewardsForEpochResumesOnlyUndoneChunksAfterRestart(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount.Add(1)
 			addrs, epoch := decodeAccountRewardHistoryRequest(t, r)
-			require.Equal(t, uint64(100), epoch)
+			assert.Equal(
+				t,
+				uint64(100),
+				epoch,
+			) // handler goroutine — see decodeAccountRewardHistoryRequest's doc comment
 
 			if slices.Contains(addrs, poisonAddr) && !recovered.Load() {
 				w.WriteHeader(http.StatusServiceUnavailable)
@@ -380,6 +394,153 @@ func TestFetchAccountRewardsForEpochDoesNotTrustEmptyCheckpointWithinGraceWindow
 	)
 }
 
+// TestFetchAccountRewardsForEpochRequiresEveryChunkCurrentBeforeComplete
+// proves the fix for a mixed-chunk variant of the grace-window trust bug:
+// one chunk has genuinely non-empty rows while another, in the very same
+// call, is still empty-and-lagging. Naively checking only "did the aggregate
+// staged-row total end up non-zero" would let the non-empty chunk alone
+// satisfy that check and mark the whole epoch complete=true — permanently
+// missing whatever the still-lagging chunk's real answer turns out to be
+// later, since a completed epoch is never re-fetched. complete must instead
+// require every planned chunk to have a currently-real result before
+// treating grace-window completion as valid.
+func TestFetchAccountRewardsForEpochRequiresEveryChunkCurrentBeforeComplete(
+	t *testing.T,
+) {
+	const hasDataAddr = "stake1has-data"
+	const noDataAddr = "stake1no-data"
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			if slices.Contains(addrs, noDataAddr) {
+				// Koios hasn't published this address's reward yet — a
+				// legitimate empty response, not an error, and never recovers
+				// within this test.
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	// FetchEpochAccountsWithAddrs looks up EpochEndTime from koios_epoch_info
+	// (see its own doc comment) — commit one so the grace-hours gate is
+	// actually active rather than disabled by an unknown end time.
+	require.NoError(t, cache.CommitEpochData(KoiosEpochInfo{
+		Network:      "preview",
+		Epoch:        800,
+		ActiveStake:  "1",
+		EpochEndTime: time.Now().Add(-time.Hour), // just closed
+		FetchedAt:    time.Now(),
+	}, nil, nil))
+
+	// chunkSize=1 forces each address into its own chunk, so one chunk gets
+	// real rows and the other stays empty within the same call.
+	_, err = FetchEpochAccountsWithAddrs(
+		t.Context(), k, cache, "preview", 800, nil,
+		[]string{hasDataAddr, noDataAddr}, 24, 1, 0, nil,
+	)
+	require.NoError(t, err)
+
+	cov, err := cache.GetAccountCoverage("preview", 800)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.False(
+		t,
+		cov.Complete,
+		"one chunk having real rows must not let the epoch look complete "+
+			"while another chunk is still empty-and-lagging within the grace window",
+	)
+
+	// Partial rows are still recorded (matching #3097's original "record
+	// progress, gate trust via the separate coverage flag" design) — what
+	// matters is that cov.Complete above stays false, so a future check
+	// never mistakes this for a fully verified reference set.
+	rewards, err := cache.GetAccountRewardsForEpoch("preview", 800)
+	require.NoError(t, err)
+	require.Len(t, rewards, 1)
+	require.Equal(t, hasDataAddr, rewards[0].StakeAddress)
+}
+
+// TestFetchAccountRewardsForEpochEmptyUniverseInvalidatesPriorCheckpointData
+// proves a universe that shrinks to empty (e.g. Dingo's reward_account_output
+// rows for this stake epoch were pruned/rolled back between attempts) does
+// not leave stale checkpoint data behind. Without invalidating it, a later
+// accountLifecycleMismatches call would read koios_account_checked as if
+// those addresses were still part of this epoch's current, correctly-empty
+// universe — reporting phantom zero-reward/lifecycle findings for addresses
+// that no longer belong to this epoch at all.
+func TestFetchAccountRewardsForEpochEmptyUniverseInvalidatesPriorCheckpointData(
+	t *testing.T,
+) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			addrs, _ := decodeAccountRewardHistoryRequest(t, r)
+			writeAccountRewardHistoryRows(w, addrs)
+		}),
+	)
+	defer srv.Close()
+
+	k := &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	// First attempt: a real, non-empty universe fully succeeds and
+	// checkpoints.
+	_, err = FetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 850,
+		[]string{"stake1old1", "stake1old2"}, time.Time{}, 0, nil,
+	)
+	require.NoError(t, err)
+	done, err := cache.GetDoneAccountChunkHashes("preview", 850)
+	require.NoError(t, err)
+	require.NotEmpty(
+		t,
+		done,
+		"test setup sanity check: the first attempt must have checkpointed",
+	)
+
+	// Second attempt: the universe has shrunk to empty.
+	_, err = FetchAccountRewardsForEpoch(
+		t.Context(), k, cache, "preview", 850, nil, time.Time{}, 0, nil,
+	)
+	require.NoError(t, err)
+
+	cov, err := cache.GetAccountCoverage("preview", 850)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	require.True(t, cov.Complete)
+	require.Equal(t, 0, cov.RequestedCount)
+
+	universe, err := cache.GetAccountUniverseForEpoch("preview", 850)
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		universe,
+		"the old universe's checked markers must not survive once the universe is empty",
+	)
+	zeroReward, err := cache.GetZeroRewardAccountsForEpoch("preview", 850)
+	require.NoError(t, err)
+	require.Empty(t, zeroReward)
+}
+
 // TestFetchAccountRewardsForEpochMegaScenario is the combined exercise the
 // issue asks for directly: large synthetic snapshot plus injected timeout,
 // rate-limit, truncated-response, duplicate-page, and restart failures, all
@@ -491,7 +652,10 @@ func TestFetchAccountRewardsForEpochMegaScenario(t *testing.T) {
 					}
 				}
 				body, marshalErr := json.Marshal(items)
-				require.NoError(t, marshalErr)
+				assert.NoError(
+					t,
+					marshalErr,
+				) // handler goroutine — see decodeAccountRewardHistoryRequest's doc comment
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(body)
 				return
@@ -637,10 +801,17 @@ func TestFetchAccountRewardsForEpochRequestBodyNeverExceedsConfiguredMaxBytes(
 	// with a mutex rather than a plain int.
 	var mu sync.Mutex
 	var maxBodyLen int
+	// Both checks below run inside the httptest.Server's own per-connection
+	// goroutine (see decodeAccountRewardHistoryRequest's doc comment for why
+	// that means assert, not require: FailNow/Goexit is only valid from the
+	// goroutine that started the test). A failure here still surfaces via
+	// the outer FetchEpochAccountsWithAddrs assertion below, since a broken
+	// decode leaves decoded.StakeAddresses empty/zero-valued rather than
+	// panicking.
 	srv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			mu.Lock()
 			if len(body) > maxBodyLen {
 				maxBodyLen = len(body)
@@ -649,7 +820,7 @@ func TestFetchAccountRewardsForEpochRequestBodyNeverExceedsConfiguredMaxBytes(
 			var decoded struct {
 				StakeAddresses []string `json:"_stake_addresses"`
 			}
-			require.NoError(t, json.Unmarshal(body, &decoded))
+			assert.NoError(t, json.Unmarshal(body, &decoded))
 			writeAccountRewardHistoryRows(w, decoded.StakeAddresses)
 		}),
 	)
@@ -710,7 +881,10 @@ func TestGetAccountRewardHistoryRejectsSuspiciouslyFullResponse(t *testing.T) {
 				}
 			}
 			body, err := json.Marshal(items)
-			require.NoError(t, err)
+			assert.NoError(
+				t,
+				err,
+			) // handler goroutine — see decodeAccountRewardHistoryRequest's doc comment
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(body)
 		}),

--- a/internal/koiosparity/fetch_accounts_test.go
+++ b/internal/koiosparity/fetch_accounts_test.go
@@ -386,6 +386,7 @@ func TestFetchEpochAccountsWithAddrsLooksUpEpochEndTimeFromCache(t *testing.T) {
 		24, // graceHours
 		0,  // chunkSize (default)
 		0,  // chunkMaxBytes (default)
+		false,
 		nil,
 	)
 	require.NoError(t, err)

--- a/internal/koiosparity/fetch_accounts_test.go
+++ b/internal/koiosparity/fetch_accounts_test.go
@@ -384,6 +384,8 @@ func TestFetchEpochAccountsWithAddrsLooksUpEpochEndTimeFromCache(t *testing.T) {
 		nil,
 		[]string{"stake1a"},
 		24, // graceHours
+		0,  // chunkSize (default)
+		0,  // chunkMaxBytes (default)
 		nil,
 	)
 	require.NoError(t, err)
@@ -448,15 +450,6 @@ func TestBuildAccountAddressUniverseNilSourceIsKoiosOnly(t *testing.T) {
 	require.Len(t, universe, 2)
 }
 
-func TestChunkAddresses(t *testing.T) {
-	chunks := chunkAddresses([]string{"a", "b", "c", "d", "e"}, 2)
-	require.Len(t, chunks, 3)
-	require.Equal(t, []string{"a", "b"}, chunks[0])
-	require.Equal(t, []string{"c", "d"}, chunks[1])
-	require.Equal(t, []string{"e"}, chunks[2])
-	require.Nil(t, chunkAddresses(nil, 2))
-}
-
 // TestFetchAccountRewardsForEpochStopsDispatchingAfterFirstChunkError guards
 // against the dispatcher race flagged in review: `select { case
 // <-fetchCtx.Done(): ...; case sem <- struct{}{}: }` can nondeterministically
@@ -513,7 +506,12 @@ func TestFetchAccountRewardsForEpochStopsDispatchingAfterFirstChunkError(
 	t *testing.T,
 ) {
 	const totalChunks = 30
-	const poisonAddr = "stake1poison"
+	// "stake0poison" sorts before every "stake1addrN" address (dingo #3099's
+	// fetchAccountRewardsForEpoch sorts the address universe before chunking
+	// for content-addressed chunk-hash determinism — see its doc comment),
+	// guaranteeing this still lands in the first-dispatched chunk the way
+	// addrs[0] = poisonAddr used to under the old, order-preserving chunker.
+	const poisonAddr = "stake0poison"
 
 	// cancelled is closed exactly once, synchronously, from
 	// afterChunkCancelForTest — the production dispatch loop's own

--- a/internal/koiosparity/koios_client.go
+++ b/internal/koiosparity/koios_client.go
@@ -66,11 +66,23 @@ const (
 	// request body and the worst-case response bounded regardless of how
 	// large the full requested address universe is, and limits the "blast
 	// radius" of a single failed/timed-out request to a small slice of the
-	// epoch's account universe rather than the whole thing. This is the
+	// epoch's account universe rather than the whole thing. This was the
 	// minimal viable chunking for #3097; shaping requests further by actual
-	// encoded byte size, adaptive sizing, and mid-fetch resumable
-	// checkpointing is #3099's scope (see FetchAccountRewardsForEpoch).
+	// encoded byte size and mid-fetch resumable checkpointing is #3099's
+	// scope, delivered in fetchAccountRewardsForEpoch (see its doc comment)
+	// via chunkAddressesByCountAndSize — koiosAccountChunkSize remains the
+	// default address-count bound when an operator hasn't tuned
+	// --account-chunk-size.
 	koiosAccountChunkSize = 100
+
+	// koiosMaxResponseBytes caps every Koios response body read (GET and
+	// POST) — dingo #3099's "bound response/body memory" requirement.
+	// Existing GET responses are already page-bounded to koiosPageSize rows
+	// and never approach this; it exists specifically as a defensive
+	// ceiling for /account_reward_history's POST responses, whose size
+	// isn't otherwise bounded by anything but Koios's own internal paging
+	// (see GetAccountRewardHistory's koiosPageSize truncation-detection).
+	koiosMaxResponseBytes = 32 * 1024 * 1024
 )
 
 // koiosBaseURLs maps network name to Koios v1 base URL.
@@ -330,6 +342,36 @@ type koiosResponse struct {
 	Header     http.Header
 }
 
+// errKoiosResponseTooLarge marks a response body that reached
+// koiosMaxResponseBytes without terminating — a response that big means
+// something is wrong upstream (or the request itself was shaped too large),
+// not a transient blip, so readBodyLimited's caller must never retry it the
+// way a plain read error is retried.
+var errKoiosResponseTooLarge = errors.New(
+	"koios: response body exceeded the maximum allowed size",
+)
+
+// readBodyLimited reads r fully, capped at koiosMaxResponseBytes — dingo
+// #3099's "bound response/body memory" requirement, applied uniformly to
+// every Koios call (GET and POST). Reading koiosMaxResponseBytes+1 bytes
+// means the true body is at or past the cap, so it fails hard with
+// errKoiosResponseTooLarge rather than silently returning a truncated
+// prefix as if it were the complete response.
+func readBodyLimited(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, koiosMaxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > koiosMaxResponseBytes {
+		return nil, fmt.Errorf(
+			"%w: exceeded %d bytes",
+			errKoiosResponseTooLarge,
+			koiosMaxResponseBytes,
+		)
+	}
+	return body, nil
+}
+
 // get executes a GET request against the Koios API with optional Range header,
 // retrying transport errors, 5xx responses, burst 429s, and body-read failures.
 // rangeStart/rangeEnd < 0 means no Range header.
@@ -389,11 +431,17 @@ func (k *KoiosClient) get(
 			)
 		}
 
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := readBodyLimited(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
-			// Treat a body-read failure (e.g. connection reset mid-transfer)
-			// exactly like a transport error: it's transient and safe to retry.
+			if errors.Is(readErr, errKoiosResponseTooLarge) {
+				// A response this large means something is wrong upstream, not
+				// a transient blip — never retry it (see readBodyLimited).
+				return nil, fmt.Errorf("koios GET %s: %w", path, readErr)
+			}
+			// Treat any other body-read failure (e.g. connection reset
+			// mid-transfer) exactly like a transport error: it's transient
+			// and safe to retry.
 			if err := retryOrFail(attempt,
 				koiosRetryBackoff5xx*time.Duration(attempt+1),
 				"koios GET %s: read body: %w", path, readErr,
@@ -541,9 +589,14 @@ func (k *KoiosClient) post(
 			)
 		}
 
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := readBodyLimited(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
+			if errors.Is(readErr, errKoiosResponseTooLarge) {
+				// A response this large means something is wrong upstream, not
+				// a transient blip — never retry it (see readBodyLimited).
+				return nil, fmt.Errorf("koios POST %s: %w", path, readErr)
+			}
 			if err := retryOrFail(attempt,
 				koiosRetryBackoff5xx*time.Duration(attempt+1),
 				"koios POST %s: read body: %w", path, readErr,
@@ -998,6 +1051,27 @@ func (k *KoiosClient) GetAccountRewardHistory(
 	var items []KoiosAccountRewardHistoryItem
 	if err := json.Unmarshal(resp.Body, &items); err != nil {
 		return nil, fmt.Errorf("koios /account_reward_history decode: %w", err)
+	}
+	// dingo #3099: /account_reward_history does not honor the Range header
+	// the way GET table-view endpoints (/pool_list, /account_list) do —
+	// verified live against preview: repeated requests with different Range
+	// values return the same first koiosPageSize-row window rather than
+	// paging further, so there is no working way to fetch a "next page" for
+	// this endpoint. A response landing at that same row-count ceiling is
+	// therefore indistinguishable from a silently truncated one; rather than
+	// accept it as a complete, trustworthy answer, this fails hard and
+	// permanently so the caller (fetchAccountRewardsForEpoch) aborts instead
+	// of committing a reference set that might be missing rows. The
+	// resolution is a smaller --account-chunk-size, not a retry — retrying
+	// the same chunk would hit the exact same ceiling again.
+	if len(items) >= koiosPageSize {
+		return nil, fmt.Errorf(
+			"%w: koios /account_reward_history returned %d rows (>= the %d-row page ceiling) for a %d-address chunk — this endpoint is not Range-paginated, so the response may be silently truncated; reduce --account-chunk-size and retry",
+			ErrKoiosPermanent,
+			len(items),
+			koiosPageSize,
+			len(stakeAddresses),
+		)
 	}
 	return items, nil
 }

--- a/internal/koiosparity/koios_client.go
+++ b/internal/koiosparity/koios_client.go
@@ -345,10 +345,17 @@ type koiosResponse struct {
 // errKoiosResponseTooLarge marks a response body that reached
 // koiosMaxResponseBytes without terminating — a response that big means
 // something is wrong upstream (or the request itself was shaped too large),
-// not a transient blip, so readBodyLimited's caller must never retry it the
-// way a plain read error is retried.
-var errKoiosResponseTooLarge = errors.New(
-	"koios: response body exceeded the maximum allowed size",
+// not a transient blip. It wraps ErrKoiosPermanent so classifyFetchErr
+// (and any caller checking errors.Is(err, ErrKoiosPermanent), e.g.
+// fetchAccountRewardsForEpoch's per-chunk classification) treats this the
+// same as any other permanent failure — never retried within a call, and
+// never automatically retried again on a future fetch run either, since
+// retrying an oversized chunk at the same configured size would just fail
+// the same way forever; the resolution is a smaller --account-chunk-size
+// or --account-chunk-max-bytes, not a retry.
+var errKoiosResponseTooLarge = fmt.Errorf(
+	"%w: koios response body exceeded the maximum allowed size",
+	ErrKoiosPermanent,
 )
 
 // readBodyLimited reads r fully, capped at koiosMaxResponseBytes — dingo

--- a/internal/koiosparity/koios_client_test.go
+++ b/internal/koiosparity/koios_client_test.go
@@ -272,7 +272,11 @@ func TestFilteredKoiosResponsesRequireRequestedEpoch(t *testing.T) {
 			name: "pool_history",
 			path: "/pool_history",
 			call: func(k *KoiosClient) error {
-				_, err := k.GetPoolEpochHistory(context.Background(), "pool1test", 10)
+				_, err := k.GetPoolEpochHistory(
+					context.Background(),
+					"pool1test",
+					10,
+				)
 				return err
 			},
 		},
@@ -280,11 +284,13 @@ func TestFilteredKoiosResponsesRequireRequestedEpoch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, test.path, r.URL.Path)
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`[{"epoch_no":11}]`))
-			}))
+			srv := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, test.path, r.URL.Path)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`[{"epoch_no":11}]`))
+				}),
+			)
 			defer srv.Close()
 
 			err := test.call(newTestKoiosClient(srv.URL))
@@ -294,10 +300,12 @@ func TestFilteredKoiosResponsesRequireRequestedEpoch(t *testing.T) {
 }
 
 func TestFilteredKoiosResponsesRejectMultipleRows(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"epoch_no":10},{"epoch_no":10}]`))
-	}))
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"epoch_no":10},{"epoch_no":10}]`))
+		}),
+	)
 	defer srv.Close()
 
 	_, err := newTestKoiosClient(srv.URL).GetEpochInfo(context.Background(), 10)

--- a/internal/koiosparity/koios_client_test.go
+++ b/internal/koiosparity/koios_client_test.go
@@ -28,6 +28,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestPostRejectsOversizedResponseAsPermanentNeverRetried proves dingo
+// #3099's response-size bound (readBodyLimited/koiosMaxResponseBytes):
+// a response exceeding the cap must fail with an error that classifies as
+// ErrKoiosPermanent — never retried within the call (a response that big
+// won't get smaller on retry) and never automatically retried on a future
+// fetch run either.
+func TestPostRejectsOversizedResponseAsPermanentNeverRetried(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.WriteHeader(http.StatusOK)
+			// Stream just past the cap without holding it all in memory
+			// twice: koiosMaxResponseBytes+1 zero bytes is already a
+			// deliberately oversized response for this test's purposes.
+			chunk := make([]byte, 1<<20) // 1 MiB
+			written := 0
+			for written < koiosMaxResponseBytes+1 {
+				n, werr := w.Write(chunk)
+				written += n
+				if werr != nil {
+					return
+				}
+			}
+		}),
+	)
+	defer srv.Close()
+
+	k := newTestKoiosClient(srv.URL)
+	_, err := k.GetAccountRewardHistory(
+		context.Background(), []string{"stake1x"}, 100,
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrKoiosPermanent))
+	require.True(t, errors.Is(err, errKoiosResponseTooLarge))
+	require.EqualValues(
+		t,
+		1,
+		requestCount.Load(),
+		"an oversized response must never be retried",
+	)
+}
+
 // newTestKoiosClient builds a client pointed at a test server. The burst
 // limiter is disabled (limit 0) so retries are not slowed by the sliding window.
 func newTestKoiosClient(baseURL string) *KoiosClient {

--- a/internal/koiosparity/observer.go
+++ b/internal/koiosparity/observer.go
@@ -84,6 +84,13 @@ type ObserverConfig struct {
 	// reference/sync lag, not a failure. 0 selects the check package's own
 	// default handling (no grace window).
 	GraceHours int
+	// AccountChunkSize/AccountChunkMaxBytes (dingo #3099) bound each
+	// /account_reward_history request by both address count and encoded
+	// body size. <=0 means "use the package default"
+	// (koiosAccountChunkSize/koiosAccountChunkMaxBytesDefault). Unused when
+	// AccountsEnabled is false.
+	AccountChunkSize     int
+	AccountChunkMaxBytes int
 	// FatalFunc is invoked at most once, with a non-nil error, the first
 	// time Strict validation fails. Wired by the caller (typically
 	// node.go's n.cancel) to stop/cancel the driving Dingo instance. May be
@@ -689,6 +696,8 @@ func (o *Observer) fetchAccountsIfNeeded(
 			o.cfg.Source,
 			koiosAddrs,
 			o.cfg.GraceHours,
+			o.cfg.AccountChunkSize,
+			o.cfg.AccountChunkMaxBytes,
 			o.cfg.Logger,
 		)
 		if err == nil {

--- a/internal/koiosparity/observer.go
+++ b/internal/koiosparity/observer.go
@@ -698,6 +698,7 @@ func (o *Observer) fetchAccountsIfNeeded(
 			o.cfg.GraceHours,
 			o.cfg.AccountChunkSize,
 			o.cfg.AccountChunkMaxBytes,
+			false,
 			o.cfg.Logger,
 		)
 		if err == nil {

--- a/internal/koiosparity/report_test.go
+++ b/internal/koiosparity/report_test.go
@@ -57,5 +57,8 @@ func TestReportsMakeCoverageScopeExplicit(t *testing.T) {
 	output.Reset()
 	require.NoError(t, WriteJSONReport(&output, report))
 	require.True(t, strings.Contains(output.String(), `"coverage"`))
-	require.True(t, strings.Contains(output.String(), `"intentionally-incomparable"`))
+	require.True(
+		t,
+		strings.Contains(output.String(), `"intentionally-incomparable"`),
+	)
 }

--- a/node_koiosparity.go
+++ b/node_koiosparity.go
@@ -87,14 +87,16 @@ func (n *Node) startKoiosParityObserver() error {
 	}
 
 	observer, err := koiosparity.NewObserver(koiosparity.ObserverConfig{
-		Network:         network,
-		CachePath:       cachePath,
-		APIKey:          cfg.APIKey,
-		Source:          source,
-		Strict:          cfg.Strict,
-		AccountsEnabled: accountsEnabled,
-		GraceHours:      cfg.GraceHours,
-		Logger:          n.config.logger,
+		Network:              network,
+		CachePath:            cachePath,
+		APIKey:               cfg.APIKey,
+		Source:               source,
+		Strict:               cfg.Strict,
+		AccountsEnabled:      accountsEnabled,
+		GraceHours:           cfg.GraceHours,
+		AccountChunkSize:     cfg.AccountChunkSize,
+		AccountChunkMaxBytes: cfg.AccountChunkMaxBytes,
+		Logger:               n.config.logger,
 		FatalFunc: func(err error) {
 			n.config.logger.Error(
 				"fatal koios parity validation failure, initiating shutdown",


### PR DESCRIPTION
## Summary

Wires byte-bounded chunking, restart-safe checkpointing, and zero-reward/lifecycle account reporting into #3097's merged per-account Koios fetch and comparison — closing the reliability gaps #3097 itself explicitly deferred to #3099. Nothing about #3097's own contract or tests was changed; every addition here is additive (new tables, new categories, new optional parameters defaulting to old behavior).

- Chunk `/account_reward_history` requests by both address count and encoded byte size, not count alone.
- Checkpoint each chunk durably as it succeeds, so a killed/restarted fetch resumes instead of redoing the whole epoch.
- Invalidate and refetch only the chunks whose address content actually changed between attempts.
- Guard against `/account_reward_history`'s real (not usably paginated) behavior — a suspiciously full response now hard-errors instead of risking a silent truncation.
- Bound every Koios response body read at 32MB.
- Report confirmed zero-reward accounts and epoch-over-epoch newly-registered/deregistered accounts — both genuinely absent from #3097's merged comparison — as informational-only findings that never flip `PASS` to `FAIL`.
- New `--account-chunk-size`/`--account-chunk-max-bytes` flags, threaded through both the standalone CLI and the in-process node observer's config.

---

## Changed Files

### New files

- **`internal/koiosparity/account_chunk.go`** — `chunkAddressesByCountAndSize` (count + byte bounded chunking) and `hashAddressChunk` (stable content fingerprint per chunk, used for resume/invalidation).
- **`internal/koiosparity/account_chunk_test.go`** — tests for the chunker above.
- **`internal/koiosparity/account_lifecycle_test.go`** — tests for zero-reward/newly-registered/deregistered reporting.
- **`internal/koiosparity/fetch_accounts_resilience_test.go`** — resume, invalidation, mega-scenario, and page-safety tests.

### Modified files

- **`internal/koiosparity/koios_client.go`**
  - Added: `readBodyLimited` + `koiosMaxResponseBytes` (32MB cap) applied to both `get()` and `post()`.
  - Added: a hard-error guard in `GetAccountRewardHistory` when a response hits the ~1000-row page ceiling (Koios doesn't actually support paging further for this endpoint).

- **`internal/koiosparity/cache.go`**
  - Added: two new tables, `koios_account_fetch_staged_rows` and `koios_account_checked`.
  - Added: `SaveAccountFetchChunkProgress`, `GetDoneAccountChunkHashes`, `GetStagedAccountRows`, `ClearAccountFetchStaging`, `InvalidateStaleAccountChunks`, `GetZeroRewardAccountsForEpoch`, `GetAccountUniverseForEpoch`.
  - Nothing existing (schema or methods) modified — purely additive.

- **`internal/koiosparity/fetch_accounts.go`**
  - Modified: `fetchAccountRewardsForEpoch`'s internals — now checkpoints each chunk as it succeeds and skips already-done chunks on a resumed call, instead of holding everything in memory until the whole epoch finishes.
  - Added: `FetchEpochAccountsWithAddrs` gained two new parameters, `chunkSize`/`chunkMaxBytes`.
  - Removed: the now-dead `chunkAddresses` helper (replaced by File 1's chunker).
  - Unchanged: `FetchAccountRewardsForEpoch`'s public signature; the final `CommitAccountRewardsForEpoch` call (#3097's original, untouched).

- **`internal/koiosparity/compare.go`**
  - Added: `CategoryAcctZeroReward`, `CategoryAcctNewlyRegistered`, `CategoryAcctDeregistered`.
  - Modified: `DetermineStatus` gained one new `case` treating those three categories as informational (never `FAIL`/`ERROR`).

- **`internal/koiosparity/check.go`**
  - Added: `accountLifecycleMismatches`, appended onto `compareEpochAccounts`'s result.

- **`internal/koiosparity/fetch.go`**
  - Added: `AccountChunkSize`/`AccountChunkMaxBytes` fields on `FetchConfig`, passed through to the fetch call.

- **`internal/koiosparity/observer.go`**
  - Added: matching `AccountChunkSize`/`AccountChunkMaxBytes` fields on `ObserverConfig`, passed through the same way.

- **`cmd/koios-parity/main.go`**
  - Added: `addAccountChunkFlags`/`resolveAccountChunkFlags` — registers and validates `--account-chunk-size`/`--account-chunk-max-bytes`.

- **`cmd/koios-parity/fetch.go`, `run.go`, `watch.go`**
  - Modified: each now calls the new flag helpers and passes the two values into `FetchConfig`.

- **`config.go`**
  - Added: `AccountChunkSize`/`AccountChunkMaxBytes` on the public `KoiosParityConfig`; wired through `WithKoiosParity` and the config read-back mirror.

- **`internal/config/config.go`**
  - Added: matching `AccountChunkSize`/`AccountChunkMaxBytes` fields (with YAML/env tags) on the internal `KoiosParityConfig`.

- **`internal/config/flags.go`**
  - Added: `koios-parity-account-chunk-size`/`koios-parity-account-chunk-max-bytes` node-level CLI flags.

- **`node_koiosparity.go`**
  - Modified: passes the two new config values into the `ObserverConfig` built for the in-process node observer.

- **`ARCHITECTURE.md`**
  - Modified: corrected the earlier "isn't Range-paginated" assumption based on live verification against Koios.
  - Added: a new subsection documenting the #3099 chunking/checkpoint/lifecycle design.

- **`internal/koiosparity/fetch_accounts_test.go`** *(existing #3097 file)*
  - Removed: `TestChunkAddresses` (tested the now-deleted old chunker).
  - Modified: one poison-address test constant renamed so it still sorts into the first chunk under the new sort-before-chunking behavior; one call site updated for `FetchEpochAccountsWithAddrs`'s two new parameters.

- **`internal/koiosparity/koios_client_test.go`**
  - Modified: reformatted by the project's line-length formatter (`golines`) as part of the pre-commit pass — no logic changes.

- **`internal/koiosparity/coverage_test.go`**
  - Added: one line wiring `KoiosAccountRewardHistoryItem` into the existing field-coverage enforcement test.

- **`internal/koiosparity/report_test.go`**
  - Modified: reformatted by `golines` — no logic changes.

---

## Tests

### `account_chunk_test.go` *(new)*
- `TestChunkAddressesByCountAndSizeEmptyInput` — empty/nil input produces no chunks.
- `TestChunkAddressesByCountAndSizeCountBoundary` — 25 addresses / limit `10` → chunks of `10, 10, 5`.
- `TestChunkAddressesByCountAndSizeByteBoundary` — the byte limit alone correctly bounds chunk size.
- `TestChunkAddressesByCountAndSizeSingleOversizedAddressNotDropped` — an address bigger than the byte limit still gets its own chunk, never discarded.
- `TestChunkAddressesByCountAndSizeZeroMaxCountUsesDefault` — `0` count limit falls back to `koiosAccountChunkSize`.
- `TestChunkAddressesByCountAndSizeDeterministicAcrossRepeatedCalls` — identical input always produces identical chunk boundaries.
- `TestChunkAddressesByCountAndSizeNoByteBoundIsCountOnly` — `0` byte limit disables the byte check entirely.

### `fetch_accounts_test.go` *(existing #3097 file, minimally touched)*
- Removed `TestChunkAddresses` (tested the deleted `chunkAddresses` helper).
- All other pre-existing #3097 tests pass unmodified.

### `fetch_accounts_resilience_test.go` *(new)*
- `TestFetchAccountRewardsForEpochResumesOnlyUndoneChunksAfterRestart` — a failed chunk is retried on resume; already-succeeded chunks are not re-requested.
- `TestFetchAccountRewardsForEpochInvalidatesOnlyChangedChunksOnUniverseChange` — only the chunk whose content actually changed gets invalidated/refetched; an unaffected chunk's checkpoint survives.
- `TestFetchAccountRewardsForEpochMegaScenario` — 240 addresses / 24 chunks, with `timeout`, `rate-limit`, `truncated-response`, `duplicate-row`, and `outage` failures injected together, followed by a restart/resume to success, confirming the injected duplicate survives as exactly two rows.
- `TestGetAccountRewardHistoryRejectsSuspiciouslyFullResponse` — a response at the `koiosPageSize` (1000) row ceiling is rejected via `ErrKoiosPermanent`; `999` rows succeeds normally.

### `account_lifecycle_test.go` *(new)*
- `TestAccountLifecycleMismatchesReportsZeroReward` — a confirmed-checked, zero-reward address is reported via `CategoryAcctZeroReward`; a normal-reward address is not.
- `TestAccountLifecycleMismatchesReportsNewlyRegisteredAndDeregistered` — a new-this-epoch address is flagged `CategoryAcctNewlyRegistered`; one missing from this epoch is flagged `CategoryAcctDeregistered`.
- `TestAccountLifecycleMismatchesDisablesLifecycleReportWhenPreviousEpochIncomplete` — no lifecycle findings when the previous epoch's coverage was never completed.
- `TestAccountLifecycleMismatchesEpochZeroSkipsLifecycleReport` — epoch `0` skips the lifecycle comparison entirely.
- `TestDetermineStatusAccountLifecycleCategoriesAreInformational` — the three new categories alone yield `StatusPass`; mixed with `CategoryValueMismatch`, the result is still `StatusFail`.

### `coverage_test.go` *(existing file, one line added)*
- Wired `KoiosAccountRewardHistoryItem` into the existing `requireResponseFieldsCovered` check, closing a gap where a future field added to that struct would previously have gone unclassified.


Closes #3099 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds size-aware chunking with restart-safe checkpoints to Koios per-account reward fetches and adds lifecycle reporting, preventing truncation and mixed snapshots. Previously we refetched whole epochs and risked truncation; now we resume only pending chunks, cap request/response sizes, treat full pages as permanent errors, and downgrade coverage on partial force-refresh so later runs self-heal.

- Chunking and checkpoints: sort addresses; chunk by count and encoded size; content-hash each chunk; resume skips completed chunks; invalidate only changed chunks; stage durably, commit, then prune; empty-universe runs are a no‑op.
- Force refresh: keep existing chunk checkpoints and re-fetch only missing/invalidated chunks. On partial failure, mark coverage complete=false instead of deleting checkpoints, preventing mixed snapshots and enabling automatic recovery on a later run.
- Safety bounds: reject `/account_reward_history` responses at or above the page ceiling as permanent errors; cap Koios response bodies at 32MB.
- Lifecycle reporting: emit informational `acct_zero_reward`, `acct_newly_registered`, and `acct_deregistered`; suppressed when the previous epoch is incomplete, within the grace window, or when decoding required inputs fails.
- Configuration: add `--account-chunk-size` and `--account-chunk-max-bytes` to CLI `fetch/run/watch`, and mirror fields on node `ObserverConfig` and public `KoiosParityConfig`; 0 uses package defaults.
- Schema/cache: add staging and checkpoint tables; additive cache APIs for progress, invalidation, and lifecycle queries.

**Rollout**
- No manual migrations; the cache upgrades itself.
- If you hit permanent errors for full pages or oversized responses, lower `--account-chunk-size` or `--account-chunk-max-bytes`.
- `--force-refresh` preserves checkpoints; if it fails partway, coverage is downgraded and a later plain fetch will resume and self-heal.

<sup>Written for commit 6f03ce2269a0839a5102a717b3104fd4fb86d27c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable account-reward request limits by address count and encoded request size.
  * Account-reward fetching now resumes interrupted work using durable checkpoints and re-fetches only changed or incomplete chunks.
  * Added reporting for zero-reward, newly registered, and deregistered accounts as informational results.
* **Bug Fixes**
  * Added safeguards against oversized or suspiciously truncated API responses.
  * Improved handling of empty account sets and zero-reward accounts.
* **Documentation**
  * Documented chunking, checkpoint recovery, request safety limits, and known coverage limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->