### PR TITLE
fix(ci): make Windows tests filesystem-safe

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,11 @@ jobs:
   go-test-other:
     name: go-test (${{ matrix.platform }}) (${{ matrix.go-version }})
     needs: [ci, create-draft-release]
+    # The only job in this workflow without an explicit grant, so it inherited
+    # repository or organization defaults. It builds and runs tests and needs
+    # nothing else; matches build-image-manifest's read-only grant.
+    permissions:
+      contents: read
     if: always() && github.ref_type == 'tag' && needs.ci.result == 'success' && needs.create-draft-release.result == 'success'
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,14 @@ jobs:
           - platform: windows-latest
             cache_path: ~\AppData\Local\go-build
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
+    # Generous on purpose. Hang protection comes from the per-package
+    # `-timeout 20m` below; this cap only has to exceed a legitimate full-suite
+    # run, which here means checkout, setup-go, a build, and `go test ./...`
+    # across 100+ packages on a slower runner. The equivalent Linux job sets no
+    # job cap at all, so a tight one here is the outlier and would fail
+    # `go-test-other` with no single stuck package, blocking build-binaries and
+    # finalize-release.
+    timeout-minutes: 90
     env:
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,6 +144,7 @@ jobs:
           - platform: windows-latest
             cache_path: ~\AppData\Local\go-build
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
     env:
       CGO_ENABLED: 0
     steps:
@@ -162,7 +163,11 @@ jobs:
       - name: go-build
         run: go build ./cmd/dingo
       - name: go-test
-        run: go test ./...
+        # Windows runners are substantially slower for this suite. Keep the
+        # same link-size optimization and explicit package timeout used by the
+        # Linux release validation job, and cap the job so a stuck test cannot
+        # hold the release indefinitely.
+        run: go test -ldflags="-s -w" -timeout 20m ./...
 
   build-binaries:
     strategy:

--- a/database/plugin/metadata/sqlstore/backup_publish_test.go
+++ b/database/plugin/metadata/sqlstore/backup_publish_test.go
@@ -19,8 +19,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -141,9 +143,10 @@ func TestPublishBackupFileFailureDoesNotClobberConcurrentDestination(
 // making the staging directory itself undeletable (chmod 0o500, no write
 // permission) right after the file is written into it -- os.Link into
 // dstDir still succeeds since that's a different directory, but the later
-// os.RemoveAll(tmpDir) then fails.
+// os.RemoveAll(tmpDir) then fails. The test helper uses chmod on Unix and a
+// deny DACL on Windows.
 func TestPublishBackupFileCleansUpDestinationOnLateFailure(t *testing.T) {
-	if os.Geteuid() == 0 {
+	if os.Geteuid() == 0 && runtime.GOOS != "windows" {
 		t.Skip("root ignores directory permission bits")
 	}
 	dst := filepath.Join(t.TempDir(), "backup.bin")
@@ -153,9 +156,9 @@ func TestPublishBackupFileCleansUpDestinationOnLateFailure(t *testing.T) {
 		if err := os.WriteFile(stagedPath, []byte("hello"), 0o600); err != nil {
 			return err
 		}
-		return os.Chmod(tmpDir, 0o500)
+		testutil.MakeDirectoryUnwritable(t, tmpDir)
+		return nil
 	})
-	t.Cleanup(func() { _ = os.Chmod(tmpDir, 0o700) })
 	require.Error(t, err)
 	_, statErr := os.Stat(dst)
 	require.True(

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -740,9 +740,11 @@ func TestValidateDatabaseLifecycleSnapshotDirWritability(t *testing.T) {
 			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "snapshotDir")
-			if runtime.GOOS != "windows" {
-				assert.Contains(t, err.Error(), "1000:1000")
-			}
+			// Asserted on every platform: the hint is a static string in
+			// validate.go's snapshotDir wrap, so if the error is produced at
+			// all it carries the hint, and that hint is the actionable half of
+			// the message.
+			assert.Contains(t, err.Error(), "1000:1000")
 		},
 	)
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -18,9 +18,11 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	hostplugin "github.com/blinklabs-io/dingo/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -727,14 +729,20 @@ func TestValidateDatabaseLifecycleSnapshotDirWritability(t *testing.T) {
 			parent := t.TempDir()
 			dir := filepath.Join(parent, "readonly")
 			require.NoError(t, os.Mkdir(dir, 0o555))
-			t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+			if runtime.GOOS == "windows" {
+				testutil.MakeDirectoryUnwritable(t, dir)
+			} else {
+				t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+			}
 			cfg := validTestConfig()
 			cfg.DatabaseLifecycle.SnapshotEnabled = true
 			cfg.DatabaseLifecycle.SnapshotDir = dir
 			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "snapshotDir")
-			assert.Contains(t, err.Error(), "1000:1000")
+			if runtime.GOOS != "windows" {
+				assert.Contains(t, err.Error(), "1000:1000")
+			}
 		},
 	)
 
@@ -769,7 +777,11 @@ func TestValidateDatabaseLifecycleSnapshotDirWritability(t *testing.T) {
 			parent := t.TempDir()
 			dir := filepath.Join(parent, "readonly")
 			require.NoError(t, os.Mkdir(dir, 0o555))
-			t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+			if runtime.GOOS == "windows" {
+				testutil.MakeDirectoryUnwritable(t, dir)
+			} else {
+				t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+			}
 			cfg := validTestConfig()
 			cfg.DatabaseLifecycle.SnapshotEnabled = false
 			cfg.DatabaseLifecycle.SnapshotDir = dir
@@ -780,7 +792,9 @@ func TestValidateDatabaseLifecycleSnapshotDirWritability(t *testing.T) {
 			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "snapshotDir")
-			assert.Contains(t, err.Error(), "1000:1000")
+			if runtime.GOOS != "windows" {
+				assert.Contains(t, err.Error(), "1000:1000")
+			}
 		},
 	)
 }

--- a/internal/test/testutil/directory_permissions_unix.go
+++ b/internal/test/testutil/directory_permissions_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MakeDirectoryUnwritable removes write permission from a test directory and
+// restores it before the test's temporary-directory cleanup runs.
+func MakeDirectoryUnwritable(t testing.TB, path string) {
+	t.Helper()
+	require.NoError(t, os.Chmod(path, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o755) })
+}

--- a/internal/test/testutil/directory_permissions_unix.go
+++ b/internal/test/testutil/directory_permissions_unix.go
@@ -19,8 +19,20 @@ import (
 
 // MakeDirectoryUnwritable removes write permission from a test directory and
 // restores it before the test's temporary-directory cleanup runs.
+//
+// Both modes are derived from what the directory already has rather than
+// written literally: t.TempDir() creates 0o700, so restoring a fixed 0o755
+// would hand the caller a more permissive directory than it passed in, and
+// clearing to a fixed 0o555 would do the same for anything created stricter.
 func MakeDirectoryUnwritable(t testing.TB, path string) {
 	t.Helper()
-	require.NoError(t, os.Chmod(path, 0o555))
-	t.Cleanup(func() { _ = os.Chmod(path, 0o755) })
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	original := info.Mode().Perm()
+	require.NoError(t, os.Chmod(path, original&^0o222))
+	t.Cleanup(func() {
+		if err := os.Chmod(path, original); err != nil {
+			t.Logf("restoring mode on %s: %v", path, err)
+		}
+	})
 }

--- a/internal/test/testutil/directory_permissions_windows.go
+++ b/internal/test/testutil/directory_permissions_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package testutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// MakeDirectoryUnwritable denies the current user access to a test directory
+// and restores an owner-only DACL before the test's temporary-directory
+// cleanup runs. Windows does not use Unix mode bits for access checks.
+func MakeDirectoryUnwritable(t testing.TB, path string) {
+	t.Helper()
+	userSID := currentUserSID(t)
+	setDirectoryDACL(t, path, fmt.Sprintf(
+		"D:P(D;;FA;;;%s)(A;;FA;;;SY)", userSID,
+	))
+	t.Cleanup(func() {
+		setDirectoryDACL(t, path, fmt.Sprintf(
+			"D:P(A;;FA;;;%s)", userSID,
+		))
+	})
+}
+
+func currentUserSID(t testing.TB) string {
+	t.Helper()
+	var token windows.Token
+	require.NoError(t, windows.OpenProcessToken(
+		windows.CurrentProcess(), windows.TOKEN_QUERY, &token,
+	))
+	defer token.Close()
+	tokenUser, err := token.GetTokenUser()
+	require.NoError(t, err)
+	return tokenUser.User.Sid.String()
+}
+
+func setDirectoryDACL(t testing.TB, path, sddl string) {
+	t.Helper()
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	require.NoError(t, err)
+	dacl, _, err := sd.DACL()
+	require.NoError(t, err)
+	require.NoError(t, windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|
+			windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	))
+}

--- a/internal/test/testutil/directory_permissions_windows.go
+++ b/internal/test/testutil/directory_permissions_windows.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/windows"
 )
 
 // MakeDirectoryUnwritable denies the current user access to a test directory
@@ -24,39 +23,16 @@ import (
 func MakeDirectoryUnwritable(t testing.TB, path string) {
 	t.Helper()
 	userSID := currentUserSID(t)
-	setDirectoryDACL(t, path, fmt.Sprintf(
+	require.NoError(t, applyDACL(path, fmt.Sprintf(
 		"D:P(D;;FA;;;%s)(A;;FA;;;SY)", userSID,
-	))
+	)))
 	t.Cleanup(func() {
-		setDirectoryDACL(t, path, fmt.Sprintf(
+		// Logged rather than required: a failure here must not abort the
+		// cleanup loop, or the temporary directory's own removal never runs.
+		if err := applyDACL(path, fmt.Sprintf(
 			"D:P(A;;FA;;;%s)", userSID,
-		))
+		)); err != nil {
+			t.Logf("restoring DACL on %s: %v", path, err)
+		}
 	})
-}
-
-func currentUserSID(t testing.TB) string {
-	t.Helper()
-	var token windows.Token
-	require.NoError(t, windows.OpenProcessToken(
-		windows.CurrentProcess(), windows.TOKEN_QUERY, &token,
-	))
-	defer token.Close()
-	tokenUser, err := token.GetTokenUser()
-	require.NoError(t, err)
-	return tokenUser.User.Sid.String()
-}
-
-func setDirectoryDACL(t testing.TB, path, sddl string) {
-	t.Helper()
-	sd, err := windows.SecurityDescriptorFromString(sddl)
-	require.NoError(t, err)
-	dacl, _, err := sd.DACL()
-	require.NoError(t, err)
-	require.NoError(t, windows.SetNamedSecurityInfo(
-		path,
-		windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION|
-			windows.PROTECTED_DACL_SECURITY_INFORMATION,
-		nil, nil, dacl, nil,
-	))
 }

--- a/internal/test/testutil/file_permissions_windows.go
+++ b/internal/test/testutil/file_permissions_windows.go
@@ -21,34 +21,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/windows"
 )
 
 // RestrictFileToCurrentUser applies a protected, owner-only DACL to a test
 // fixture so inherited temp-directory permissions cannot make it insecure.
 func RestrictFileToCurrentUser(t testing.TB, path string) {
 	t.Helper()
-
-	var token windows.Token
-	require.NoError(t, windows.OpenProcessToken(
-		windows.CurrentProcess(),
-		windows.TOKEN_QUERY,
-		&token,
-	))
-	defer token.Close()
-
-	tokenUser, err := token.GetTokenUser()
-	require.NoError(t, err)
-	sddl := fmt.Sprintf("D:P(A;;GA;;;%s)", tokenUser.User.Sid.String())
-	sd, err := windows.SecurityDescriptorFromString(sddl)
-	require.NoError(t, err)
-	dacl, _, err := sd.DACL()
-	require.NoError(t, err)
-	require.NoError(t, windows.SetNamedSecurityInfo(
-		path,
-		windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION|
-			windows.PROTECTED_DACL_SECURITY_INFORMATION,
-		nil, nil, dacl, nil,
-	))
+	require.NoError(t, applyDACL(path, fmt.Sprintf(
+		"D:P(A;;GA;;;%s)", currentUserSID(t),
+	)))
 }

--- a/internal/test/testutil/permissions_windows.go
+++ b/internal/test/testutil/permissions_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// currentUserSID returns the SID of the account running the test, as SDDL
+// spells it.
+func currentUserSID(t testing.TB) string {
+	t.Helper()
+	var token windows.Token
+	require.NoError(t, windows.OpenProcessToken(
+		windows.CurrentProcess(), windows.TOKEN_QUERY, &token,
+	))
+	defer token.Close()
+	tokenUser, err := token.GetTokenUser()
+	require.NoError(t, err)
+	return tokenUser.User.Sid.String()
+}
+
+// applyDACL replaces path's DACL with the one described by sddl, protected so
+// inherited permissions cannot widen it.
+//
+// It returns the error rather than failing the test, because one caller runs
+// inside t.Cleanup: require there aborts the cleanup loop through
+// runtime.Goexit, so a later-registered cleanup — including the temporary
+// directory's own removal — would never run, orphaning the directory. Callers
+// on a setup path wrap this in require themselves.
+func applyDACL(path, sddl string) error {
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		return err
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|
+			windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	)
+}

--- a/keystore/keyfile_windows.go
+++ b/keystore/keyfile_windows.go
@@ -199,21 +199,48 @@ func checkOpenDACL(path, owner, dacl string) error {
 }
 
 // trusteeIsOwner compares a DACL trustee with the descriptor owner. SDDL
-// renders some account SIDs as aliases, while the owner returned by the
-// security descriptor is a canonical SID. In particular, the local
-// administrator account (LA) is a domain-specific SID whose well-known RID
-// is 500, so comparing the SDDL strings directly rejects a valid owner-only
-// DACL on Windows runners that use that account.
+// renders some account SIDs as two-letter aliases, while the owner returned by
+// the security descriptor is a canonical SID, so the strings differ for the
+// same principal — which would reject a valid owner-only DACL on a runner
+// using such an account.
+//
+// An alias is resolved by asking Windows, not by matching its well-known RID.
+// The local administrator alias (LA) and a domain Administrator share RID 500
+// and differ only in the domain part, so a suffix match on "-500" treats a
+// domain Administrator owner as satisfying an LA ace and admits a trustee who
+// is not the owner. Round-tripping the alias through a minimal descriptor
+// resolves it against this machine and covers every other alias for free.
 func trusteeIsOwner(trustee, owner string) bool {
 	if trustee == owner {
 		return true
 	}
-	trusteeSID, err := windows.StringToSid(trustee)
-	if err == nil {
-		ownerSID, ownerErr := windows.StringToSid(owner)
-		return ownerErr == nil && windows.EqualSid(trusteeSID, ownerSID)
+	ownerSID, err := windows.StringToSid(owner)
+	if err != nil {
+		return false
 	}
-	return trustee == "LA" && strings.HasSuffix(owner, "-500")
+	trusteeSID, err := resolveTrusteeSID(trustee)
+	if err != nil {
+		return false
+	}
+	return windows.EqualSid(trusteeSID, ownerSID)
+}
+
+// resolveTrusteeSID converts an SDDL trustee to a SID, accepting either a SID
+// string or an alias such as LA. Aliases are machine-relative, so they are
+// resolved by Windows rather than reconstructed here.
+func resolveTrusteeSID(trustee string) (*windows.SID, error) {
+	if sid, err := windows.StringToSid(trustee); err == nil {
+		return sid, nil
+	}
+	sd, err := windows.SecurityDescriptorFromString("O:" + trustee)
+	if err != nil {
+		return nil, err
+	}
+	sid, _, err := sd.Owner()
+	if err != nil {
+		return nil, err
+	}
+	return sid, nil
 }
 
 func sddlSection(sddl, section string) string {

--- a/keystore/keyfile_windows.go
+++ b/keystore/keyfile_windows.go
@@ -131,8 +131,8 @@ func checkOpenSecurityDescriptor(path string, sd *windows.SECURITY_DESCRIPTOR) e
 	if sddl == "" {
 		return fmt.Errorf("failed to read security descriptor for %q", path)
 	}
-	owner := sddlSection(sddl, "O:")
-	if owner == "" {
+	ownerSID, _, err := sd.Owner()
+	if err != nil || ownerSID == nil {
 		return fmt.Errorf(
 			"key file %q has no owner in its security descriptor: %w",
 			path, ErrInsecureFileMode,
@@ -146,7 +146,7 @@ func checkOpenSecurityDescriptor(path string, sd *windows.SECURITY_DESCRIPTOR) e
 			path, ErrInsecureFileMode,
 		)
 	}
-	return checkOpenDACL(path, owner, dacl)
+	return checkOpenDACL(path, ownerSID.String(), dacl)
 }
 
 func checkOpenDACL(path, owner, dacl string) error {
@@ -187,7 +187,7 @@ func checkOpenDACL(path, owner, dacl string) error {
 				path, fields[0], ErrInsecureFileMode,
 			)
 		}
-		if allowed[fields[5]] {
+		if allowed[fields[5]] || trusteeIsOwner(fields[5], owner) {
 			continue
 		}
 		return fmt.Errorf(
@@ -196,6 +196,24 @@ func checkOpenDACL(path, owner, dacl string) error {
 		)
 	}
 	return nil
+}
+
+// trusteeIsOwner compares a DACL trustee with the descriptor owner. SDDL
+// renders some account SIDs as aliases, while the owner returned by the
+// security descriptor is a canonical SID. In particular, the local
+// administrator account (LA) is a domain-specific SID whose well-known RID
+// is 500, so comparing the SDDL strings directly rejects a valid owner-only
+// DACL on Windows runners that use that account.
+func trusteeIsOwner(trustee, owner string) bool {
+	if trustee == owner {
+		return true
+	}
+	trusteeSID, err := windows.StringToSid(trustee)
+	if err == nil {
+		ownerSID, ownerErr := windows.StringToSid(owner)
+		return ownerErr == nil && windows.EqualSid(trusteeSID, ownerSID)
+	}
+	return trustee == "LA" && strings.HasSuffix(owner, "-500")
 }
 
 func sddlSection(sddl, section string) string {

--- a/keystore/keyfile_windows_test.go
+++ b/keystore/keyfile_windows_test.go
@@ -237,3 +237,10 @@ func TestUnsupportedACETypeFailsClosedWindows(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInsecureFileMode)
 	assert.Contains(t, err.Error(), "unsupported DACL ACE type")
 }
+
+func TestOwnerAliasMatchesCanonicalOwnerWindows(t *testing.T) {
+	owner := "S-1-5-21-111111111-222222222-333333333-500"
+	assert.NoError(t, checkOpenDACL(
+		"test.skey", owner, "(A;;GR;;;LA)",
+	))
+}

--- a/keystore/keyfile_windows_test.go
+++ b/keystore/keyfile_windows_test.go
@@ -238,9 +238,31 @@ func TestUnsupportedACETypeFailsClosedWindows(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported DACL ACE type")
 }
 
+// TestOwnerAliasMatchesCanonicalOwnerWindows pins both halves of the alias
+// comparison: an alias ace must satisfy the owner it actually denotes on this
+// machine, and must not satisfy a different principal that merely shares its
+// RID.
+//
+// The owner is resolved here rather than written literally. An earlier version
+// asserted against a synthetic "...-500" SID, which passed only because the
+// comparison matched on the RID suffix — the hole this pins shut, since RID 500
+// is the built-in Administrator of every domain, so a domain Administrator
+// owner satisfied a local-administrator ace.
 func TestOwnerAliasMatchesCanonicalOwnerWindows(t *testing.T) {
-	owner := "S-1-5-21-111111111-222222222-333333333-500"
+	sd, err := windows.SecurityDescriptorFromString("O:LA")
+	require.NoError(t, err)
+	localAdmin, _, err := sd.Owner()
+	require.NoError(t, err)
+
 	assert.NoError(t, checkOpenDACL(
-		"test.skey", owner, "(A;;GR;;;LA)",
+		"test.skey", localAdmin.String(), "(A;;GR;;;LA)",
 	))
+
+	// Same RID, different domain: not the same principal, so the ace must not
+	// be accepted as the owner's.
+	assert.ErrorIs(t, checkOpenDACL(
+		"test.skey",
+		"S-1-5-21-111111111-222222222-333333333-500",
+		"(A;;GR;;;LA)",
+	), ErrInsecureFileMode)
 }

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/stretchr/testify/assert"
@@ -69,6 +70,8 @@ func setupTestKeys(t *testing.T) (string, string, string) {
 	require.NoError(t, os.WriteFile(vrfPath, []byte(testVRFSKeyJSON), 0o600))
 	require.NoError(t, os.WriteFile(kesPath, []byte(testKESSKeyJSON), 0o600))
 	require.NoError(t, os.WriteFile(opCertPath, []byte(testOpCertJSON), 0o600))
+	testutil.RestrictFileToCurrentUser(t, vrfPath)
+	testutil.RestrictFileToCurrentUser(t, kesPath)
 
 	return vrfPath, kesPath, opCertPath
 }

--- a/ledger/leios/keys_test.go
+++ b/ledger/leios/keys_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,6 +90,7 @@ func TestLoadVoteSigningKeyFile(t *testing.T) {
 	// Trailing whitespace must be tolerated
 	content := fmt.Sprintf("%064x\n", 42)
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
 	key, err := LoadVoteSigningKeyFile(path)
 	require.NoError(t, err)
 	expected, err := ParseVoteSigningKey(fmt.Sprintf("%064x", 42))
@@ -107,6 +109,7 @@ func TestLoadVoteSigningKeyFileCardanoTextEnvelope(t *testing.T) {
 		hex.EncodeToString(cborBytes),
 	)
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
 
 	key, err := LoadVoteSigningKeyFile(path)
 	require.NoError(t, err)
@@ -127,6 +130,7 @@ func TestLoadVoteSigningKeyFileRejectsTrailingCbor(t *testing.T) {
 		hex.EncodeToString(cborBytes),
 	)
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
 
 	_, err := LoadVoteSigningKeyFile(path)
 	assert.ErrorIs(t, err, ErrInvalidSigningKey)
@@ -137,6 +141,7 @@ func TestLoadVoteSigningKeyFileRejectsUnsupportedEnvelope(t *testing.T) {
 	path := filepath.Join(dir, "node.skey")
 	content := `{"type":"Node KES Signing Key","description":"","cborHex":"582001"}`
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
 
 	_, err := LoadVoteSigningKeyFile(path)
 	assert.ErrorIs(t, err, ErrInvalidSigningKey)
@@ -301,6 +306,7 @@ func TestLoadVoteSigningKeyFileRejectsOversized(t *testing.T) {
 	path := filepath.Join(dir, "vote.skey")
 	content := fmt.Sprintf("%064x", 42) + strings.Repeat(" ", 2048)
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
 	_, err := LoadVoteSigningKeyFile(path)
 	assert.Error(t, err)
 }

--- a/ledgerstate/snapshot_root_test.go
+++ b/ledgerstate/snapshot_root_test.go
@@ -133,6 +133,20 @@ func TestOpenSnapshotAtOrBeforeSurvivesFileSwap(t *testing.T) {
 		); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
+		if runtime.GOOS == "windows" {
+			// Windows refuses to replace an open file. That is the platform's
+			// equivalent protection: the selected name remains ours, and the
+			// writer cannot stage the substitution while discovery holds it.
+			if err := os.Rename(
+				replacement, filepath.Join(slotDir, name),
+			); err == nil {
+				t.Fatal("Windows replaced a file held open by discovery")
+			}
+			if err := os.Remove(replacement); err != nil {
+				t.Fatalf("unexpected error removing replacement: %s", err)
+			}
+			continue
+		}
 		if err := os.Rename(
 			replacement, filepath.Join(slotDir, name),
 		); err != nil {
@@ -140,16 +154,18 @@ func TestOpenSnapshotAtOrBeforeSurvivesFileSwap(t *testing.T) {
 		}
 	}
 
-	// The premise: the names denote the writer's files now.
+	// On POSIX the names now denote the writer's files. On Windows the open
+	// handles prevent the replacement, so the original names remain ours.
 	byName, err := os.ReadFile(filepath.Join(slotDir, "state"))
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if string(byName) != "theirs" {
-		t.Fatal(
-			"the substitution must be observable through the name, or " +
-				"this test proves nothing",
-		)
+	if runtime.GOOS == "windows" {
+		if string(byName) != "ours" {
+			t.Fatalf("open-file sharing must preserve the selected name: got %q", byName)
+		}
+	} else if string(byName) != "theirs" {
+		t.Fatal("the substitution must be observable through the name")
 	}
 
 	for _, tc := range []struct {

--- a/mithril/extract_hardening.go
+++ b/mithril/extract_hardening.go
@@ -559,7 +559,9 @@ func prepareExtractDestination(
 		// Inspecting the destination first and then acting on it — which is
 		// what this used to do — can only be worse than that, however narrow
 		// the gap is made.
-		renameErr := parentRoot.Rename(stagingName, destName)
+		renameErr := renameExtractedDirectory(
+			parentRoot, stagingName, destName,
+		)
 		if renameErr != nil && !cfg.replace {
 			// The destination is occupied. Windows will not rename over an
 			// existing directory even when it is empty, so reaching here does
@@ -576,7 +578,9 @@ func prepareExtractDestination(
 			); err != nil {
 				return err
 			}
-			renameErr = parentRoot.Rename(stagingName, destName)
+			renameErr = renameExtractedDirectory(
+				parentRoot, stagingName, destName,
+			)
 		}
 		if renameErr != nil {
 			return fmt.Errorf("publishing extraction: %w", renameErr)

--- a/mithril/extract_hardening_test.go
+++ b/mithril/extract_hardening_test.go
@@ -1227,6 +1227,16 @@ func TestExtractDoesNotAdoptAPreExistingFile(t *testing.T) {
 	t.Cleanup(func() { _ = theirs.Close() })
 
 	file, err := createExtractedFile(root, "00000.chunk")
+	if runtime.GOOS == "windows" {
+		require.Error(t, err,
+			"Windows refuses to unlink a file held open by another process")
+		assert.ErrorIs(t, err, ErrExtractUnsafePath)
+		contents, readErr := os.ReadFile(planted)
+		require.NoError(t, readErr)
+		assert.Equal(t, "theirs", string(contents),
+			"a locked pre-existing file must remain untouched")
+		return
+	}
 	require.NoError(t, err)
 	_, writeErr := file.WriteString("ours")
 	require.NoError(t, writeErr)

--- a/mithril/extract_rename_unix.go
+++ b/mithril/extract_rename_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package mithril
+
+import "os"
+
+func renameExtractedDirectory(root *os.Root, oldname, newname string) error {
+	return root.Rename(oldname, newname)
+}

--- a/mithril/extract_rename_windows.go
+++ b/mithril/extract_rename_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package mithril
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// MoveFile refuses an existing destination, unlike os.Root.Rename on
+// Windows, which uses MoveFileEx with replacement semantics. Exclusive
+// publication must never replace a non-directory destination implicitly.
+func renameExtractedDirectory(root *os.Root, oldname, newname string) error {
+	oldpath, err := windows.UTF16PtrFromString(filepath.Join(root.Name(), oldname))
+	if err != nil {
+		return err
+	}
+	newpath, err := windows.UTF16PtrFromString(filepath.Join(root.Name(), newname))
+	if err != nil {
+		return err
+	}
+	return windows.MoveFile(oldpath, newpath)
+}

--- a/mithril/extract_rename_windows.go
+++ b/mithril/extract_rename_windows.go
@@ -26,14 +26,19 @@ import (
 // rebuilt from root.Name() lets it follow a reparse point substituted for any
 // component after extraction's symlink checks ran. Each component is instead
 // walked through its parent's handle and confirmed to be the entry the name
-// denotes (openVerifiedParent), and those handles are held across the move --
-// Windows refuses to rename a directory while handles are open on it, so the
-// verified parents cannot be swapped underneath the call.
+// denotes (openVerifiedParent), and those handles are held across the move.
 //
-// The residual limit is the one removeExtractedFile carries: Windows offers no
-// handle-relative rename, so the immediate parents' own names are resolved a
-// second time by MoveFile. Closing that needs NtSetInformationFile with
-// FileRenameInformation against the parent handle; see issue #3228.
+// What that does and does not buy is worth stating exactly, because an earlier
+// version of this comment overstated it. The walk rejects a symlink or reparse
+// point that is already in place when it runs, which is the planted-component
+// case. It does not make the parents unswappable: os.Root opens every handle
+// with FILE_SHARE_DELETE (see internal/syscall/windows/at_windows.go), so
+// holding them does not stop another process renaming or deleting a verified
+// directory, and MoveFile resolves the parents' own names a second time.
+//
+// The race between the walk and the call therefore remains. Closing it needs
+// NtSetInformationFile with FileRenameInformation against the parent handle,
+// which is genuinely handle-relative; see issue #3228.
 func renameExtractedDirectory(root *os.Root, oldname, newname string) error {
 	oldParent, oldBase, releaseOld, err := openVerifiedParent(root, oldname)
 	if err != nil {

--- a/mithril/extract_rename_windows.go
+++ b/mithril/extract_rename_windows.go
@@ -20,12 +20,41 @@ import (
 // MoveFile refuses an existing destination, unlike os.Root.Rename on
 // Windows, which uses MoveFileEx with replacement semantics. Exclusive
 // publication must never replace a non-directory destination implicitly.
+//
+// Both names are resolved the way removeExtractedFile resolves its target,
+// and for the same reason: MoveFile addresses paths, so handing it a path
+// rebuilt from root.Name() lets it follow a reparse point substituted for any
+// component after extraction's symlink checks ran. Each component is instead
+// walked through its parent's handle and confirmed to be the entry the name
+// denotes (openVerifiedParent), and those handles are held across the move --
+// Windows refuses to rename a directory while handles are open on it, so the
+// verified parents cannot be swapped underneath the call.
+//
+// The residual limit is the one removeExtractedFile carries: Windows offers no
+// handle-relative rename, so the immediate parents' own names are resolved a
+// second time by MoveFile. Closing that needs NtSetInformationFile with
+// FileRenameInformation against the parent handle; see issue #3228.
 func renameExtractedDirectory(root *os.Root, oldname, newname string) error {
-	oldpath, err := windows.UTF16PtrFromString(filepath.Join(root.Name(), oldname))
+	oldParent, oldBase, releaseOld, err := openVerifiedParent(root, oldname)
 	if err != nil {
 		return err
 	}
-	newpath, err := windows.UTF16PtrFromString(filepath.Join(root.Name(), newname))
+	defer releaseOld()
+	newParent, newBase, releaseNew, err := openVerifiedParent(root, newname)
+	if err != nil {
+		return err
+	}
+	defer releaseNew()
+
+	oldpath, err := windows.UTF16PtrFromString(
+		filepath.Join(oldParent.Name(), oldBase),
+	)
+	if err != nil {
+		return err
+	}
+	newpath, err := windows.UTF16PtrFromString(
+		filepath.Join(newParent.Name(), newBase),
+	)
 	if err != nil {
 		return err
 	}

--- a/mithril/extract_rmdir_windows.go
+++ b/mithril/extract_rmdir_windows.go
@@ -34,9 +34,13 @@ import (
 //
 // Unlike the Unix path this addresses the entry by name rather than through
 // the parent handle, because Windows has no handle-relative removal. A
-// substituted parent could therefore redirect it, which Windows makes hard by
-// refusing to move a directory while handles are open beneath it — the parent
-// is held open for the whole extraction.
+// substituted parent could therefore redirect it. The parent is held open for
+// the whole extraction, which does not prevent that: os.Root opens its handles
+// with FILE_SHARE_DELETE (see internal/syscall/windows/at_windows.go), so an
+// open handle does not stop another process renaming or deleting the
+// directory. The verified walk rejects a component already substituted when it
+// runs; the race against a concurrent substitution is open until the removal
+// is handle-relative. See issue #3228.
 func removeEmptyExtractDir(_ *os.Root, _, fullPath string) error {
 	path, err := windows.UTF16PtrFromString(fullPath)
 	if err != nil {

--- a/mithril/extract_unlink_windows.go
+++ b/mithril/extract_unlink_windows.go
@@ -41,8 +41,12 @@ import (
 // (openVerifiedParent), and those handles are held across the deletion, so a
 // reparse point substituted mid-extraction is refused during the walk rather
 // than followed by DeleteFile. Only the immediate parent's own name is
-// resolved a second time, and Windows makes substituting it hard by refusing
-// to move a directory while handles are open on it.
+// resolved a second time. Holding the parent handles does not prevent that
+// substitution: os.Root opens them with FILE_SHARE_DELETE (see
+// internal/syscall/windows/at_windows.go), so another process can still rename
+// or delete a verified directory. The walk rejects a component already
+// substituted when it runs; closing the remaining race needs a
+// handle-relative removal. See issue #3228.
 func removeExtractedFile(root *os.Root, name, fullPath string) error {
 	parent, base, release, err := openVerifiedParent(root, name)
 	if err != nil {


### PR DESCRIPTION
Summary: Normalize Windows owner SID aliases and secret-key fixture ACLs; make directory writability, snapshot replacement, and Mithril publication tests honor Windows filesystem semantics; extend the release publish test timeout and use optimized test linking on Windows. Validation: focused go test passed; focused go test -race passed; Windows cross-compilation passed for all touched packages and the root package; git diff --check passed. Not run: Windows runtime CI and full go test ./... remain pending on GitHub. actionlint still reports pre-existing shellcheck warnings outside this diff. DATABASE.md and ARCHITECTURE.md were checked and are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Windows extraction, tests, and key-permission validation filesystem-safe, and align CI with slower Windows runners. Previously `mithril` could follow reparse points and implicitly replace destinations; it now resolves both parents through verified handles and uses `windows.MoveFile` to refuse existing destinations. Windows `keystore` now validates owner-only ACLs by comparing canonical SIDs and resolving SDDL aliases.

- `mithril`: add `renameExtractedDirectory`; on Windows resolve both names via verified parent handles and call `windows.MoveFile` to reject an existing destination; Unix keeps existing rename semantics. Comments/tests now reflect that holding parent handles does not prevent parent swaps on Windows; a handle-relative rename remains future work.
- Tests/util: add `internal/test/testutil.MakeDirectoryUnwritable` (chmod on Unix; deny DACL on Windows, restoring original mode/DACL without aborting cleanup); update snapshot/backup/extract tests for Windows rules on renaming/unlinking open files; share token/DACL helpers; restrict key fixtures to the current user.
- `keystore` (Windows): read the owner SID from the descriptor and compare trustees to the canonical owner using SID equality; resolve aliases (e.g., LA) via Windows; add a test that accepts the alias for the actual owner and rejects same-RID SIDs from other domains.
- CI `publish`: grant `contents: read` to `go-test-other`; increase Windows job cap to 90 minutes and run `go test` with `-ldflags="-s -w"` and `-timeout 20m`.

<sup>Written for commit bbdc5514fcd43593e753de35689c6db09f64edd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction and snapshot handling across Windows and Unix-like systems.
  * Prevented unsafe replacement of files or directories that are already in use.
  * Improved Windows key-permission validation, including administrator owner aliases.
  * Preserved original files when secure extraction cannot safely proceed.

* **Tests**
  * Expanded cross-platform coverage for permissions, file replacement, extraction, and key handling.
  * Added longer timeouts for cross-platform release validation.
  * Improved permission checks for Windows and Unix-like environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->