### PR TITLE
fix(mempool): log re-validation failures at warn level

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1291,8 +1291,8 @@ func (m *Mempool) revalidateAppliedTx(
 		candidate.overlay.created,
 	); err != nil {
 		candidate.reject(at, tx)
-		m.logger.Debug(
-			"transaction failed re-validation",
+		m.logger.Warn(
+			"transaction failed re-validation and was dropped from the mempool",
 			"component", "mempool",
 			"tx_hash", at.hash,
 			"error", err,


### PR DESCRIPTION
## Summary

Part of #1905. Re-validation failures during the mempool's periodic
overlay rebuild were logged at `Debug`, so a transaction silently
dropped from the pool (e.g. invalidated by a conflicting transaction
that confirmed first) left no trace an operator would normally see.

The fee-density eviction-priority half of #1905 is intentionally not
included here — per the #2905 FIFO-vs-DAG follow-up, FIFO is now the
explicit compatibility baseline and should not gain priority-based
eviction; that work belongs in the DAG backend instead. `mempool/doc.go`
already documents FIFO's oldest-first eviction accurately (fixed as
part of #2905), so no doc changes are needed here.

## Changes

- **`mempool/mempool.go`** — in `revalidateAppliedTx`, the "transaction
  failed re-validation" log on a dropped transaction is now emitted at
  `Warn` instead of `Debug`, with a clarified message
  ("...and was dropped from the mempool") so the log line is
  self-explanatory without additional context.

Closes #1905 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs mempool re-validation failures at Warn instead of Debug and clarifies that the transaction was dropped. This makes drops during periodic overlay rebuilds visible to operators without changing mempool behavior.

- Change is limited to `mempool/mempool.go` in `revalidateAppliedTx`; the log now emits at Warn with the tx hash and error.
- Expect higher Warn volume when conflicts invalidate pending transactions; adjust alerts as needed. No config, API, or docs changes.

<sup>Written for commit 9877318abd97ec13b4261fb6e2164416d1a9190f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of transaction revalidation failures by logging them as warnings.
  * Clarified that affected transactions are dropped from the mempool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->