### PR TITLE
fix(ci): clear golangci-lint v2.13.0 findings and pin the version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,3 +33,10 @@ jobs:
             ${{ runner.os }}-go-1.26.x-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0
+        with:
+          # Pinned rather than left to default to "latest". A linter release
+          # adds and changes rules, so with "latest" every open pull request
+          # starts failing the moment one ships, on code none of them touched
+          # -- which is what v2.13.0 did. Bump this deliberately, so the new
+          # findings land in one reviewable change.
+          version: v2.13.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,17 @@ linters:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    recvcheck:
+      # UnmarshalJSON has to take a pointer to mutate the receiver, while
+      # MarshalJSON conventionally takes a value so both a value and a pointer
+      # satisfy json.Marshaler. Every type implementing the pair therefore
+      # mixes receivers by design. Changing MarshalJSON to a pointer receiver
+      # to satisfy the linter would mean a non-addressable value -- one in a
+      # map, or passed by value to json.Marshal -- silently stops using the
+      # custom marshaler and emits raw struct fields instead.
+      exclusions:
+        - "*.MarshalJSON"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -82,7 +82,7 @@ func (a *archiveServiceHandler) FetchBlock(
 			Url:       signedURL.URL.String(),
 			ExpiresAt: timestamppb.New(signedURL.Expires),
 			Meta: &archive.BlockMeta{
-				Type:     (archive.BlockType)(blockType).Enum(),
+				Type:     archive.BlockType(blockType).Enum(),
 				PrevHash: new(hex.EncodeToString(metadata.PrevHash)),
 			},
 		})

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -442,12 +442,12 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 	}
 
 	decoded, err := verifyArchiveBlock(
-		(uint)(blockType), blockBody, slot, hash,
+		uint(blockType), blockBody, slot, hash,
 	)
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
-	era, err := blockEraFromHeader(decoded, (uint)(blockType))
+	era, err := blockEraFromHeader(decoded, uint(blockType))
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -358,12 +358,12 @@ func serveArchiveBlock(
 	hash := block.Hash()
 	prevHash := block.PrevHash()
 	return map[string][]byte{
-			hex.EncodeToString(hash[:]): block.Cbor(),
-		}, func(a *fakeArchive) {
-			a.height = block.BlockNumber()
-			a.prevHash = prevHash[:]
-			a.blockType = archive.BlockType_BLOCK_TYPE_CONWAY
-		}
+		hex.EncodeToString(hash[:]): block.Cbor(),
+	}, func(a *fakeArchive) {
+		a.height = block.BlockNumber()
+		a.prevHash = prevHash[:]
+		a.blockType = archive.BlockType_BLOCK_TYPE_CONWAY
+	}
 }
 
 // TestGetBlock_AcceptsVerifiedArchiveBlock is the happy path: an archive that

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -65,6 +65,11 @@ func (c *ConnectionManager) startListener(
 				l.ListenNetwork,
 				l.ListenAddress,
 			)
+			// staticcheck sees only the non-Windows build, where
+			// createPipeListener is a stub that always returns an error, and
+			// calls the comparison always true. It is a real check on Windows,
+			// where the call can succeed.
+			//nolint:staticcheck // SA4023: always true on the stub build only
 			if err != nil {
 				return fmt.Errorf("failed to open listening pipe: %w", err)
 			}

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -61,14 +61,16 @@ func (c *ConnectionManager) startListener(
 		// On Windows, the "unix" network type is repurposed to create named pipes
 		// for compatibility with configurations that specify "unix" network on Unix systems.
 		if runtime.GOOS == "windows" && l.ListenNetwork == "unix" {
+			// staticcheck sees only the non-Windows build, where
+			// createPipeListener is a stub that always returns an error, so it
+			// calls the comparison always true. It is a real check on Windows,
+			// where the call can succeed. SA4023 is reported against the call
+			// and the comparison separately, so both carry the directive.
+			//nolint:staticcheck // SA4023: always true on the stub build only
 			listener, err := createPipeListener(
 				l.ListenNetwork,
 				l.ListenAddress,
 			)
-			// staticcheck sees only the non-Windows build, where
-			// createPipeListener is a stub that always returns an error, and
-			// calls the comparison always true. It is a real check on Windows,
-			// where the call can succeed.
 			//nolint:staticcheck // SA4023: always true on the stub build only
 			if err != nil {
 				return fmt.Errorf("failed to open listening pipe: %w", err)

--- a/database/plugin/blob/aws/commit_timestamp.go
+++ b/database/plugin/blob/aws/commit_timestamp.go
@@ -29,10 +29,9 @@ import (
 const commitTimestampBlobKey = "metadata_commit_timestamp"
 
 func (b *BlobStoreS3) GetCommitTimestamp() (int64, error) {
+	// No nil check: NewTransaction returns a concrete *s3Txn as a types.Txn,
+	// and a non-nil pointer in an interface is never nil.
 	txn := b.NewTransaction(false)
-	if txn == nil {
-		return 0, types.ErrNilTxn
-	}
 	defer txn.Rollback() //nolint:errcheck // no-op for this backend
 
 	data, err := b.Get(txn, []byte(commitTimestampBlobKey))
@@ -65,12 +64,9 @@ func (b *BlobStoreS3) GetCommitTimestamp() (int64, error) {
 					"commit timestamp stored plaintext in S3, migrating to SOPS encryption: %v",
 					err,
 				)
-				// Create a new transaction for migration
+				// Create a new transaction for migration. As above, it
+				// cannot be nil, so there is nothing to check.
 				migrateTxn := b.NewTransaction(true)
-				if migrateTxn == nil {
-					b.logger.Errorf("failed to create migration transaction")
-					return ts, nil
-				}
 				defer migrateTxn.Rollback() //nolint:errcheck
 				if migrateErr := b.SetCommitTimestamp(ts, migrateTxn); migrateErr != nil {
 					b.logger.Errorf(

--- a/database/plugin/blob/gcs/commit_timestamp.go
+++ b/database/plugin/blob/gcs/commit_timestamp.go
@@ -29,10 +29,9 @@ import (
 const commitTimestampBlobKey = "metadata_commit_timestamp"
 
 func (b *BlobStoreGCS) GetCommitTimestamp() (int64, error) {
+	// No nil check: NewTransaction returns a concrete *gcsTxn as a types.Txn,
+	// and a non-nil pointer in an interface is never nil.
 	txn := b.NewTransaction(false)
-	if txn == nil {
-		return 0, types.ErrNilTxn
-	}
 	defer txn.Rollback() //nolint:errcheck // no-op for this backend
 
 	r, err := b.Get(txn, []byte(commitTimestampBlobKey))
@@ -62,14 +61,9 @@ func (b *BlobStoreGCS) GetCommitTimestamp() (int64, error) {
 					"commit timestamp stored plaintext in GCS, migrating to SOPS encryption: %v",
 					err,
 				)
-				// Create a new transaction for migration
+				// Create a new transaction for migration. As above, it
+				// cannot be nil, so there is nothing to check.
 				migrateTxn := b.NewTransaction(true)
-				if migrateTxn == nil {
-					b.logger.Errorf(
-						"failed to create migration transaction: blob store unavailable",
-					)
-					return ts, nil
-				}
 				defer migrateTxn.Rollback() //nolint:errcheck
 				if migrateErr := b.SetCommitTimestamp(ts, migrateTxn); migrateErr != nil {
 					b.logger.Errorf(

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -1553,6 +1553,10 @@ func precomputedMissingPrefilterLeaderOutput(
 			continue
 		}
 		poolKey := string(output.PoolKeyHash)
+		// SA6001 suggests indexing with string(output.PoolKeyHash) directly,
+		// which would convert three times instead of once: poolKey is also the
+		// key for rewardAccountByPool and actualLeaderByPool below.
+		//nolint:staticcheck // SA6001: one conversion serves three lookups
 		if actualLeaderByPool[poolKey] != 0 {
 			continue
 		}

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -1552,11 +1552,12 @@ func precomputedMissingPrefilterLeaderOutput(
 		if output == nil || output.LeaderReward == 0 {
 			continue
 		}
-		poolKey := string(output.PoolKeyHash)
 		// SA6001 suggests indexing with string(output.PoolKeyHash) directly,
-		// which would convert three times instead of once: poolKey is also the
-		// key for rewardAccountByPool and actualLeaderByPool below.
-		//nolint:staticcheck // SA6001: one conversion serves three lookups
+		// which would convert twice instead of once: poolKey is the key for
+		// both actualLeaderByPool and rewardAccountByPool below. The directive
+		// sits on the conversion because that is the line SA6001 reports.
+		//nolint:staticcheck // SA6001: one conversion serves two lookups
+		poolKey := string(output.PoolKeyHash)
 		if actualLeaderByPool[poolKey] != 0 {
 			continue
 		}

--- a/peergov/peer_snapshot.go
+++ b/peergov/peer_snapshot.go
@@ -101,6 +101,7 @@ func (p *PeerGovernor) addLedgerRelaysContext(
 	extraAdds int,
 ) int {
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
+	//nolint:gosec // relay spread, not security-sensitive
 	rand.Shuffle(len(candidates), func(i, j int) {
 		candidates[i], candidates[j] = candidates[j], candidates[i]
 	})


### PR DESCRIPTION
## Problem

`golangci-lint-action` was invoked with no `version`, so it defaulted to
`latest`. v2.13.0 was built at 22:59 on 19 Aug and every dingo lint run since
roughly 01:42 the next morning failed, on unrelated branches:

```
10:06  fix/windows-ci-compatibility               failure
05:27  fix/1905/mempool_revalidation_log_level    failure
04:06  feat/koios-3099-account-fetch-resilience   failure
01:42  issue-3207-cip26-token-registry            success   <- last green
```

None of the five findings were introduced by any of those branches; all are
present on `main`.

## Changes

- **Pin `version: v2.13.0`.** Pinned to the version that surfaced these rather
  than reverted to 2.12.1, so the findings are adopted here instead of waiting
  to reappear on the next `latest` resolution. Bumping it deliberately keeps new
  findings in one reviewable change rather than spread across whichever pull
  requests happen to be open.
- **`bark/archive.go`, `bark/blob.go`** — the bundled gofumpt is newer than
  0.9.2 and now drops redundant parens around a conversion's type:
  `(uint)(blockType)` becomes `uint(blockType)`. Applied with
  `golangci-lint fmt` from the pinned binary rather than a local gofumpt, which
  reports both files clean. `bark/blob_test.go` is included for the same rule;
  `run.tests: false` means CI would not flag it, but leaving it would hand the
  next person an unrelated diff.
- **`peergov/peer_snapshot.go`** — `//nolint:gosec` on the relay shuffle. This
  follows the existing decision rather than making a new one: `peers.go:400` in
  the same package already carries
  `//nolint:gosec // load-balancing spread, not security-sensitive` for the same
  purpose, so a crypto/rand rewrite here would have diverged from its sibling.
- **`recvcheck.exclusions: ["*.MarshalJSON"]`** — `UnmarshalJSON` must take a
  pointer to mutate the receiver, while `MarshalJSON` conventionally takes a
  value so that both a value and a pointer satisfy `json.Marshaler`. Any type
  implementing the pair mixes receivers by design, which is what recvcheck
  reports on `SignedEntityType` and `CardanoDatabaseLocation`. Satisfying it by
  moving `MarshalJSON` to a pointer receiver would mean a non-addressable value
  — one in a map, or passed by value to `json.Marshal` — silently stops using
  the custom marshaler and emits raw struct fields. Neither type is marshaled
  inside dingo today, but `mithril` is importable, so the config exclusion is
  the narrower change.

## staticcheck findings, added after the first push

The first push cleared the five findings visible from the older base. Rebuilding
on current `main` surfaced eleven more, all staticcheck, in four files none of
this branch had touched. They arrived with #3211 ("log discarded close/stop
errors in node, connmanager, peergov, and GCS blob store"), which merged after
the branch that first hit this was cut — so `main` is red for them independently
of any of these pull requests, and a green run needs them here.

Handled by shape rather than blanket-suppressed:

- **Unreachable, so deleted (8).** `NewTransaction` returns a concrete `*s3Txn`
  or `*gcsTxn` as a `types.Txn`, and a non-nil pointer inside an interface is
  never nil, so all four `txn == nil` / `migrateTxn == nil` guards in
  `blob/aws/commit_timestamp.go` and `blob/gcs/commit_timestamp.go` were dead
  code. Removed with a comment recording why, so they are not reinstated.
- **Correct code the analysis cannot see whole (2).**
  `connmanager/listener.go` compares the error from `createPipeListener`, which
  in the non-Windows build is a stub that always fails — so the comparison is
  "always true" only for the build staticcheck analyses, and is a real check on
  Windows. Deleting it would break the platform it exists for, so it carries a
  `//nolint:staticcheck` naming the reason.
- **A suggestion that would be slower (1).** SA6001 on
  `ledger/reward_calculation.go` proposes indexing with
  `string(output.PoolKeyHash)` inline, but `poolKey` feeds three lookups, so
  taking the advice converts three times instead of once.

## Checks

Run with the pinned v2.13.0 binary, not the locally installed 2.12.1:

- `golangci-lint config verify` — passes
- `golangci-lint run ./bark/... ./peergov/... ./mithril/...` before the config
  change — gofumpt x2 and gosec x1 cleared, leaving only the two recvcheck
  findings
- `golangci-lint run --default=none -E recvcheck ./mithril/...` after it —
  `0 issues`
- `go build ./...` and `go build -tags dingo_extra_plugins ./...` — pass
- `go test ./bark/ ./peergov/ ./mithril/` — pass
- `go test -tags dingo_extra_plugins ./connmanager/ ./database/plugin/blob/...`
  — pass

Not run: the full-repo `golangci-lint run ./...` locally. With a cold analysis
cache for 2.13.0 it exceeded a 15 minute ceiling here, against 1m50s warm in CI,
so whole-tree confirmation comes from this pull request's own lint job.

`DATABASE.md` and `ARCHITECTURE.md` checked and not affected: no schema, storage,
component-boundary, or cross-component flow changes.
