### PR TITLE
style(bark): restore gofmt formatting in blob_test.go

### DIFF
--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -358,12 +358,12 @@ func serveArchiveBlock(
 	hash := block.Hash()
 	prevHash := block.PrevHash()
 	return map[string][]byte{
-		hex.EncodeToString(hash[:]): block.Cbor(),
-	}, func(a *fakeArchive) {
-		a.height = block.BlockNumber()
-		a.prevHash = prevHash[:]
-		a.blockType = archive.BlockType_BLOCK_TYPE_CONWAY
-	}
+			hex.EncodeToString(hash[:]): block.Cbor(),
+		}, func(a *fakeArchive) {
+			a.height = block.BlockNumber()
+			a.prevHash = prevHash[:]
+			a.blockType = archive.BlockType_BLOCK_TYPE_CONWAY
+		}
 }
 
 // TestGetBlock_AcceptsVerifiedArchiveBlock is the happy path: an archive that


### PR DESCRIPTION
## Problem

#3230 ran `golangci-lint fmt` over `./bark/` to apply the new gofumpt rule that
drops redundant parens from a type conversion. That cleared the two findings CI
reported, in `bark/archive.go` and `bark/blob.go` — and also reformatted
`bark/blob_test.go`, which nothing had asked for.

`run.tests: false` means the linters skip test files, so gofumpt never flagged
that file. Worse, the reformat it applied — re-indenting the multi-value return
in `serveArchiveBlock` — is one plain `gofmt` reverses. The file on `main` is
currently `gofmt -l` dirty, so `make format`, an editor save, or anyone running
`gofmt -w` produces an unrelated diff in a file they did not touch.

My reasoning in #3230 was that leaving it unformatted would hand the next person
a diff from the same tool. That was wrong in both directions: the tool in
question never inspects test files, and the formatting it chose is the one that
does produce a recurring diff.

## Changes

Restore `bark/blob_test.go` to its pre-#3230 bytes, which are what `gofmt`
produces.

## Checks

- `gofmt -l bark/` — clean after, dirty before
- `golangci-lint run ./bark/...` with the pinned v2.13.0 — `0 issues`, both
  before and after the revert, confirming the formatters skip test files just as
  the linters do
- `go test ./bark/` — pass

## Note

The underlying cause is worth a decision beyond this file: the repo runs
`gofumpt` as a formatter but excludes test files from `run`, so a test file
takes whatever formatting the last tool to touch it applied, and nothing checks
it afterwards. Either the formatters should cover test files or nothing should
reformat them. Not changed here, since that is a repository-wide policy call
rather than a papercut fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `gofmt` formatting in `bark/blob_test.go` to stop recurring editor/CI rewrites. Previously `gofumpt` (via `golangci-lint`) re-indented the multi-value return in serveArchiveBlock; now it matches `gofmt`, with no runtime changes.

- Only whitespace changes in a test file; production code unaffected.
- `gofmt -l bark/` is clean after this change.
- `golangci-lint run ./bark/...` remains at 0 issues; formatters and linters skip test files.

<sup>Written for commit 8b4c47bd83c0e30aba618a97cb0f9031d9b595fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and indentation in an internal test helper.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->