### PR TITLE
docs(examples): advance Dingo image pins

### DIFF
--- a/examples/dingo-blockfrost-explorer/README.md
+++ b/examples/dingo-blockfrost-explorer/README.md
@@ -64,7 +64,7 @@ Dingo from this checkout, so it has both.
 
 ### Kubernetes
 
-The example Helm values use `ghcr.io/blinklabs-io/dingo:0.69.0`, enable all
+The example Helm values use `ghcr.io/blinklabs-io/dingo:0.70.0`, enable all
 API ports, and keep the chart-created Dingo Service internal to the cluster.
 Apply the separate API Service when the frontend proxy needs a Kubernetes
 LoadBalancer:

--- a/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
+++ b/examples/dingo-blockfrost-explorer/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.69.0"
+  tag: "0.70.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-gov-lens/k8s/dingo-values.yaml
+++ b/examples/dingo-gov-lens/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.69.0"
+  tag: "0.70.0"
   pullPolicy: IfNotPresent
 
 mithril:

--- a/examples/dingo-sundae-preview/README.md
+++ b/examples/dingo-sundae-preview/README.md
@@ -26,7 +26,7 @@ cd examples/dingo-sundae-preview
 ./scripts/port-forward-dingo.sh
 ```
 
-The example values pin Dingo `0.69.0`. The chart uses a `LoadBalancer` service
+The example values pin Dingo `0.70.0`. The chart uses a `LoadBalancer` service
 and enables only `DINGO_PLUGINS_API_UTXORPC_CONFIG_PORT`.
 If the load balancer is not reachable from the dev host, keep the port-forward
 open while running the frontend.

--- a/examples/dingo-sundae-preview/k8s/dingo-values.yaml
+++ b/examples/dingo-sundae-preview/k8s/dingo-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/blinklabs-io/dingo
-  tag: "0.69.0"
+  tag: "0.70.0"
   pullPolicy: IfNotPresent
 
 mithril:


### PR DESCRIPTION
## Summary

- pin all three deployable example Helm values to Dingo 0.70.0
- align the Blockfrost Explorer and Sundae Preview README text
- retain 0.69.0 only in excluded OpenTelemetry dependency versions

Closes #3235

## Validation

- GOCACHE=/tmp/dingo-3235-gocache.z6QXVe make docs-parity
- git diff --check origin/main...HEAD
- targeted git grep checks for 0.70.0 pins and non-dependency 0.69.0 matches

## Skipped

- full Go, devnet, and conformance suites: no Go, protocol, or runtime behavior changed
- Helm rendering: the chart is external to this repository and the existing values shape is unchanged