### PR TITLE
build: restore analyzer cleanliness

### DIFF
--- a/database/plugin/metadata/sqlite/shared_sqlstore_busy_timeout_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_busy_timeout_test.go
@@ -71,7 +71,7 @@ func TestBackupDSNSetsBusyTimeoutFirst(t *testing.T) {
 func parsePragmas(t *testing.T, dsn string) []string {
 	t.Helper()
 	var out []string
-	for _, part := range strings.Split(dsn, "&") {
+	for part := range strings.SplitSeq(dsn, "&") {
 		if v, ok := strings.CutPrefix(part, "_pragma="); ok {
 			out = append(out, v)
 		}

--- a/event/stall_warn_ratelimit_test.go
+++ b/event/stall_warn_ratelimit_test.go
@@ -88,11 +88,9 @@ func stallWarningsForPublishers(
 
 	var wg sync.WaitGroup
 	for i := range publishers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_ = sub.Deliver(NewEvent("test.stalled", i))
-		}()
+		})
 	}
 	// Park everyone before the first interval elapses, so both runs are
 	// measured from the same starting condition.
@@ -131,11 +129,9 @@ func TestDeliverStallWarningReportsBlockedPublishers(t *testing.T) {
 	const blockedPublishers = 3
 	var wg sync.WaitGroup
 	for i := range blockedPublishers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_ = sub.Deliver(NewEvent("test.stalled", i))
-		}()
+		})
 	}
 
 	// Every warning carries the field, so asserting the key is present

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4518,11 +4518,9 @@ func TestCloseDoesNotHoldBlockfetchContinuationMutexWhileWaiting(t *testing.T) {
 	// does not touch the mutex: the point is what Close holds, not what the
 	// worker can acquire.
 	proceed := make(chan struct{})
-	ls.blockfetchContinuationWG.Add(1)
-	go func() {
-		defer ls.blockfetchContinuationWG.Done()
+	ls.blockfetchContinuationWG.Go(func() {
 		<-proceed
-	}()
+	})
 
 	ls.blockfetchContinuationMu.Lock()
 	closeDone := make(chan error, 1)
@@ -4619,12 +4617,10 @@ func TestCloseStopsDecodePipelineBeforeWaitingForBlockProcessing(t *testing.T) {
 	}
 	require.NoError(t, ls.blockPipeline.Start(t.Context()))
 	ls.processBlocksCancel = func() {}
-	ls.processBlocksWG.Add(1)
-	go func() {
-		defer ls.processBlocksWG.Done()
+	ls.processBlocksWG.Go(func() {
 		for range ls.blockPipeline.Results() {
 		}
-	}()
+	})
 
 	require.NoError(t, ls.Close())
 }

--- a/ledgerstate/import_reward_seeding_order_test.go
+++ b/ledgerstate/import_reward_seeding_order_test.go
@@ -86,9 +86,13 @@ func TestImportSnapShotsSeedsAfterEveryPoolImportStage(t *testing.T) {
 			"round will be skipped and its rewards never credited"
 	)
 	messages := recorder.snapshot()
+	if len(messages) == 0 {
+		t.Fatal("the seeding did not run at all, so this test proves nothing")
+	}
 	seedIdx := firstIndexContaining(messages, seededMsg, droppedMsg)
-	require.GreaterOrEqual(t, seedIdx, 0,
-		"the seeding did not run at all, so this test proves nothing")
+	if seedIdx < 0 {
+		t.Fatal("the seeding did not run at all, so this test proves nothing")
+	}
 	// Which one fires is a claim worth pinning: the snapshots carry their own
 	// pool parameters, so the basis must actually be seeded here. If that
 	// ever regresses to a drop, this says so rather than leaving the

--- a/ledgerstate/imported_reward_inputs.go
+++ b/ledgerstate/imported_reward_inputs.go
@@ -93,13 +93,13 @@ func deriveRewardInputs(
 		ownerStake uint64
 		delegators uint64
 	}
-	aggs := make(map[string]*poolAgg, len(params))
+	aggs := make(map[string]poolAgg, len(params))
 	owners := make(map[string]map[string]struct{}, len(params))
 	for poolHex, pool := range params {
 		if pool == nil {
 			continue
 		}
-		aggs[poolHex] = &poolAgg{}
+		aggs[poolHex] = poolAgg{}
 		set := make(map[string]struct{}, len(pool.Owners))
 		for _, owner := range pool.Owners {
 			set[hex.EncodeToString(owner)] = struct{}{}
@@ -169,6 +169,7 @@ func deriveRewardInputs(
 		if isOwner {
 			agg.ownerStake += stake
 		}
+		aggs[poolHex] = agg
 	}
 
 	poolInputs := make([]*models.RewardPoolInput, 0, len(aggs))

--- a/ledgerstate/imported_reward_inputs_epoch_params_test.go
+++ b/ledgerstate/imported_reward_inputs_epoch_params_test.go
@@ -222,7 +222,11 @@ func TestImportSnapShotsPrefersSnapshotPoolParamsOverRegistrations(
 	))
 	require.NoError(t, txn.Commit())
 
-	wantCost := snapshots.Mark.PoolParams[targetKey].Cost
+	snapshotPool, ok := snapshots.Mark.PoolParams[targetKey]
+	if !ok || snapshotPool == nil {
+		t.Fatalf("mark snapshot has no parameters for pool %s", targetKey)
+	}
+	wantCost := snapshotPool.Cost
 	require.NotEqual(t, uint64(registrationCost), wantCost,
 		"the two sources must disagree, or this test cannot tell which one "+
 			"was used")

--- a/ledgerstate/imported_reward_inputs_test.go
+++ b/ledgerstate/imported_reward_inputs_test.go
@@ -150,8 +150,12 @@ func TestDeriveRewardInputsDropsZeroStake(t *testing.T) {
 // rejects it on read, and on that path a rejection fails the rollover.
 func TestDerivedRewardInputsGateRejectsBadMargin(t *testing.T) {
 	snap := twoPoolSnapshot()
-	snap.PoolParams[hex28(0xAA)].MarginNum = 3
-	snap.PoolParams[hex28(0xAA)].MarginDen = 2
+	pool := snap.PoolParams[hex28(0xAA)]
+	if pool == nil {
+		t.Fatal("fixture has no parameters for pool AA")
+	}
+	pool.MarginNum = 3
+	pool.MarginDen = 2
 
 	bundle := deriveRewardInputs(snap, nil, 1385, 1, 0)
 	require.NotNil(t, bundle)
@@ -161,7 +165,11 @@ func TestDerivedRewardInputsGateRejectsBadMargin(t *testing.T) {
 // A pool key of the wrong length is likewise refused rather than written.
 func TestDerivedRewardInputsGateRejectsBadPoolKey(t *testing.T) {
 	snap := twoPoolSnapshot()
-	snap.PoolParams[hex28(0xAA)].PoolKeyHash = []byte{0x01, 0x02}
+	pool := snap.PoolParams[hex28(0xAA)]
+	if pool == nil {
+		t.Fatal("fixture has no parameters for pool AA")
+	}
+	pool.PoolKeyHash = []byte{0x01, 0x02}
 
 	bundle := deriveRewardInputs(snap, nil, 1385, 1, 0)
 	require.NotNil(t, bundle)

--- a/ouroboros/decode_cache_bench_test.go
+++ b/ouroboros/decode_cache_bench_test.go
@@ -181,12 +181,12 @@ func BenchmarkBlockDecodeConcurrentCacheAllUnique(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
-	var counter int64
+	var counter atomic.Int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			// atomic: RunParallel's callback runs concurrently across
 			// goroutines, so a plain counter++ here is a data race.
-			n := atomic.AddInt64(&counter, 1)
+			n := counter.Add(1)
 			key := hashDecodeInput(blockType, raw)
 			key[0] ^= byte(n)
 			key[1] ^= byte(n >> 8)
@@ -276,11 +276,11 @@ func BenchmarkHeaderDecodeConcurrentCacheAllUnique(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
-	var counter int64
+	var counter atomic.Int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			// atomic: see BenchmarkBlockDecodeConcurrentCacheAllUnique.
-			n := atomic.AddInt64(&counter, 1)
+			n := counter.Add(1)
 			key := hashDecodeInput(headerType, raw)
 			key[0] ^= byte(n)
 			key[1] ^= byte(n >> 8)


### PR DESCRIPTION
## Summary

- store imported reward aggregates as non-nil values
- guard test fixtures before dereferencing analyzer-visible values
- apply modern Go forms to hand-written tests and decode-cache benchmarks

## Checks

- `make lint`
- targeted `go test -tags dingo_extra_plugins -race` for ledgerstate, ledger, event, and SQLite
- decode-cache concurrent benchmarks with `-race -benchtime=1x`
- `make golines`
- `make docs-parity`
- `make gorm-check`
- `git diff --check`
- Cubic review: no issues found

## Not run

- CodeRabbit review (rate-limited; completed Cubic review used for bot review)
- full `make test` (targeted analyzer-cleanliness change)
- devnet and conformance suites (no consensus or protocol behavior changed)

`DATABASE.md` and `ARCHITECTURE.md` were checked and are unaffected. No generated sqlc or protobuf output changed.

Closes #3234