### PR TITLE
fix(ledger): bound consumed UTxO cleanup batches

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1268,8 +1268,9 @@ In core mode, the ledger's background consumed-UTxO pruner is advisory: it
 defers while the local tip is materially behind the known upstream tip, so its
 potentially large SQLite write transaction cannot compete with blockfetch
 state persistence during historical catch-up. The timer and epoch-boundary
-triggers are single-flight; once the node is near the upstream tip, one run
-drains eligible rows using the era's stability window.
+triggers are single-flight; once the node is near the upstream tip, each run
+deletes at most one bounded batch of eligible rows using the era's stability
+window. Later runs continue the cleanup, keeping SQLite occupancy bounded.
 
 ### Midnight gRPC Server
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1158,7 +1158,10 @@ All event types follow the `subsystem.snake_case_name` convention.
   batch and arms its timer under the mutex, releases the mutex for the primary
   and shadow requests, then reacquires it before inspecting state. If a
   callback completed or replaced the batch while the request was outside the
-  lock, the stale request result is ignored.
+  lock, the stale request result is ignored. A prior-request drain also
+  observes `LedgerState`'s shutdown context, so a chainsync subscriber already
+  waiting for a reused connection can return before the terminal EventBus close
+  waits for in-flight handlers.
 - The blast radius of such a stall is not local. `LedgerState.handleConnectionClosedEvent`
   takes `chainsyncMutex`, so a stall there stops `ledger.conn_closed` draining;
   the `node.go` handler translating `connmanager.conn_closed` into

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -270,9 +270,10 @@ upstream tip and is single-flight across its timer and epoch-boundary
 triggers. The deferral needs a known upstream tip: a node with no connected
 peer has no catch-up distance to measure, so cleanup falls back to running
 off the local tip alone rather than deferring for as long as the node stays
-peerless. This keeps the potentially large `utxo`/stake-reference scan from
-holding SQLite's single write connection during historical catch-up; the
-rows remain eligible and are reclaimed once the node is near the upstream tip.
+peerless. Each eligible run deletes at most one bounded batch, so the
+potentially large `utxo`/stake-reference scan cannot hold SQLite's single
+write connection indefinitely; later timer or epoch-boundary runs reclaim the
+remaining rows once the node is near the upstream tip.
 API mode retains spent UTxO metadata for historical transaction queries.
 
 ## ER Diagrams

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -3306,6 +3306,11 @@ func (ls *LedgerState) startQueuedBlockfetchLockedWithWaitSignal(
 	if err := ls.waitForBlockfetchRequestLockedWithSignal(connId, waitStarted); err != nil {
 		return err
 	}
+	if ls.ctx != nil {
+		if err := ls.ctx.Err(); err != nil {
+			return fmt.Errorf("blockfetch request canceled: %w", err)
+		}
+	}
 	if ls.chain.HeaderCount() == 0 {
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return nil
@@ -5205,7 +5210,19 @@ func (ls *LedgerState) waitForBlockfetchRequestLockedWithSignal(
 	if key == "" {
 		return nil
 	}
+	var shutdownDone <-chan struct{}
+	if ls.ctx != nil {
+		if err := ls.ctx.Err(); err != nil {
+			return fmt.Errorf("blockfetch request canceled: %w", err)
+		}
+		shutdownDone = ls.ctx.Done()
+	}
 	for {
+		if ls.ctx != nil {
+			if err := ls.ctx.Err(); err != nil {
+				return fmt.Errorf("blockfetch request canceled: %w", err)
+			}
+		}
 		requestDone, ok := ls.blockfetchRequestsInFlight[key]
 		if !ok {
 			return nil
@@ -5224,6 +5241,15 @@ func (ls *LedgerState) waitForBlockfetchRequestLockedWithSignal(
 				default:
 				}
 			}
+		case <-shutdownDone:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			ls.chainsyncBlockfetchMutex.Lock()
+			return fmt.Errorf("blockfetch request canceled: %w", ls.ctx.Err())
 		case <-timer.C:
 			ls.chainsyncBlockfetchMutex.Lock()
 			return fmt.Errorf(

--- a/ledger/chainsync_blockfetch_range_failure_test.go
+++ b/ledger/chainsync_blockfetch_range_failure_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -142,6 +143,68 @@ func TestStartQueuedBlockfetchReleasesMutexAroundRequest(t *testing.T) {
 	ls.blockfetchRequestRangeCleanup()
 	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 	ls.chainsyncBlockfetchMutex.Unlock()
+}
+
+// TestStartQueuedBlockfetchCancelsPriorRequestWaitDuringShutdown verifies
+// that a chainsync subscriber does not remain in the prior-request drain
+// while the node is shutting down. EventBus.Close waits for an in-flight
+// subscriber callback, so ignoring the ledger context here can leave node
+// shutdown blocked while the blockfetch connection is being torn down.
+func TestStartQueuedBlockfetchCancelsPriorRequestWaitDuringShutdown(
+	t *testing.T,
+) {
+	testChain := &chain.Chain{}
+	require.NoError(t, testChain.AddBlockHeader(mockHeader{
+		hash:        lcommon.NewBlake2b256([]byte("shutdown-header")),
+		prevHash:    lcommon.NewBlake2b256(nil),
+		blockNumber: 1,
+		slot:        1,
+	}))
+	connId := testChainsyncConnId(6114, 3001)
+	ctx, cancel := context.WithCancel(t.Context())
+	ls := &LedgerState{
+		chain: testChain,
+		ctx:   ctx,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			BlockfetchRequestRangeFunc: func(
+				ouroboros.ConnectionId,
+				ocommon.Point,
+				ocommon.Point,
+			) error {
+				t.Fatal("blockfetch request started before shutdown wait was canceled")
+				return nil
+			},
+		},
+		blockfetchRequestsInFlight: map[string]chan struct{}{
+			connIdKey(connId): make(chan struct{}),
+		},
+	}
+
+	waitStarted := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- startQueuedBlockfetchWithWaitSignalForTest(
+			ls,
+			connId,
+			nil,
+			waitStarted,
+		)
+	}()
+	testutil.RequireReceive(
+		t,
+		waitStarted,
+		time.Second,
+		"blockfetch request drain did not start",
+	)
+	cancel()
+
+	select {
+	case err := <-startDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("blockfetch request drain ignored shutdown cancellation")
+	}
 }
 
 // TestStartQueuedBlockfetchDrainsPriorRequestBeforeConnectionReuse verifies

--- a/ledger/cleanup_consumed_utxos_test.go
+++ b/ledger/cleanup_consumed_utxos_test.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"log/slog"
 	"testing"
@@ -123,6 +124,47 @@ func TestCleanupConsumedUtxos_CoreModePrunes(t *testing.T) {
 		"core mode must hard-delete consumed UTxO rows after stability "+
 			"window",
 	)
+}
+
+func TestCleanupConsumedUtxos_ProcessesOneBoundedBatch(t *testing.T) {
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	mdTxn := db.MetadataTxn(true)
+	require.NoError(t, mdTxn.Do(func(txn *database.Txn) error {
+		for idx := 0; idx <= cleanupConsumedUtxoBatchSize; idx++ {
+			txID := bytes.Repeat([]byte{0}, 32)
+			binary.BigEndian.PutUint32(txID[:4], uint32(idx+1))
+			if err := db.CreateUtxo(txn, &models.Utxo{
+				TxId:        txID,
+				OutputIdx:   0,
+				AddedSlot:   1_000,
+				DeletedSlot: 5_000,
+				Amount:      types.Uint64(1),
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	ls := newLedgerStateForCleanup(db, 100_000)
+	ls.cleanupConsumedUtxos()
+
+	remaining, err := db.Metadata().GetUtxosDeletedBeforeSlot(
+		50_000,
+		cleanupConsumedUtxoBatchSize+1,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1, "one eligible row must remain for a later run")
+
+	ls.cleanupConsumedUtxos()
+	remaining, err = db.Metadata().GetUtxosDeletedBeforeSlot(
+		50_000,
+		cleanupConsumedUtxoBatchSize+1,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "the next run must resume the bounded cleanup")
 }
 
 func TestCleanupConsumedUtxos_DefersDuringCatchup(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -61,6 +61,10 @@ import (
 
 const (
 	cleanupConsumedUtxosInterval = 5 * time.Minute
+	// Keep each cleanup transaction short enough that it cannot monopolize
+	// SQLite while blockfetch handlers persist sync state during shutdown or
+	// catch-up. Later timer or epoch-boundary runs continue the cleanup.
+	cleanupConsumedUtxoBatchSize = 1_000
 	batchSize                    = 50 // Number of blocks to process in a single DB transaction
 	ledgerIntersectDenseCount    = 32
 	ledgerAncestorSearchWindow   = 10_000
@@ -2245,12 +2249,19 @@ func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
 func (ls *LedgerState) cleanupConsumedUtxos() {
 	// Cleanup is advisory pruning. Never let the periodic timer and the epoch
 	// transition trigger occupy SQLite's single write connection at the same
-	// time; a second invocation has no additional work to do after the first
-	// one drains the eligible rows.
+	// time. Each invocation handles one bounded batch so cleanup remains
+	// resumable and cannot hold the connection for an unbounded drain.
 	if !ls.cleanupConsumedUtxosRunning.CompareAndSwap(false, true) {
 		return
 	}
 	defer ls.cleanupConsumedUtxosRunning.Store(false)
+	if ls.ctx != nil {
+		select {
+		case <-ls.ctx.Done():
+			return
+		default:
+		}
+	}
 
 	// In API storage mode we retain spent UTxO metadata rows past the
 	// stability window so historical transaction queries can resolve
@@ -2297,26 +2308,20 @@ func (ls *LedgerState) cleanupConsumedUtxos() {
 		return
 	}
 	if tipSlot > stabilityWindow {
-		for {
-			// No lock needed here - the database handles its own consistency
-			// and we're not accessing any in-memory LedgerState fields.
-			// The tipSlot was captured above with a read lock.
-			count, err := ls.db.UtxosDeleteConsumed(
-				tipSlot-stabilityWindow,
-				10000,
-				nil,
+		// No lock needed here - the database handles its own consistency
+		// and we're not accessing any in-memory LedgerState fields.
+		// The tipSlot was captured above with a read lock.
+		_, err := ls.db.UtxosDeleteConsumed(
+			tipSlot-stabilityWindow,
+			cleanupConsumedUtxoBatchSize,
+			nil,
+		)
+		if err != nil {
+			ls.config.Logger.Error(
+				"failed to cleanup consumed UTxOs",
+				"component", "ledger",
+				"error", err,
 			)
-			if count == 0 {
-				break
-			}
-			if err != nil {
-				ls.config.Logger.Error(
-					"failed to cleanup consumed UTxOs",
-					"component", "ledger",
-					"error", err,
-				)
-				break
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

During a near-tip plateau, consumed-UTxO cleanup could drain an unbounded number
of rows in one SQLite write transaction. That could block blockfetch state
persistence and leave shutdown waiting in `EventBus.Close`.

## Changes

- Limit each cleanup invocation to one bounded batch.
- Skip new cleanup work after ledger shutdown cancellation.
- Add a resumability regression test and document the bounded behavior.

## Validation

- `go test -race ./ledger -run 'TestCleanupConsumedUtxos|TestStartQueuedBlockfetch' -count=1`
- `make docs-parity`