### PR TITLE
test(devnet): preserve per-scenario failure evidence in canonical runs

### DIFF
--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -374,7 +374,12 @@ which captures explicitly through `NodeControl.CaptureFailureArtifacts`,
 and the Go test name for every canonical scenario, which
 `NewTestHarness` wires up on its own. A subtest renders as
 `parent/child`, so the separator is percent-escaped to keep the evidence
-in one directory per test; a name without one is used as written.
+in one directory per test, as is anything a filesystem would reject or
+rewrite -- Windows refuses `: * ? " < > |` and strips a trailing dot or
+space, which would otherwise put two scenarios in one directory. A name
+built from Go identifiers is used as written. Case is left alone, so
+directories stay readable; on a filesystem that folds case, two scenario
+names differing only in case would share one.
 
 Observation and writing happen at different times. Chain observers run
 for the whole of a scenario, so `observed-chains.json` is a continuous

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -372,7 +372,9 @@ deleting it. On success the directory is removed.
 `<scenario>` is `accelerated-timeline` for the accelerated timeline,
 which captures explicitly through `NodeControl.CaptureFailureArtifacts`,
 and the Go test name for every canonical scenario, which
-`NewTestHarness` wires up on its own.
+`NewTestHarness` wires up on its own. A subtest renders as
+`parent/child`, so the separator is percent-escaped to keep the evidence
+in one directory per test; a name without one is used as written.
 
 Observation and writing happen at different times. Chain observers run
 for the whole of a scenario, so `observed-chains.json` is a continuous

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -374,12 +374,19 @@ which captures explicitly through `NodeControl.CaptureFailureArtifacts`,
 and the Go test name for every canonical scenario, which
 `NewTestHarness` wires up on its own.
 
-Each scenario captures the moment it fails, rather than at teardown. The
-`network/` entries are collected once, after the whole run, by which
-point a chain that stalled and then recovered looks healthy again;
-`observed-chains.json` records what each node's chain actually did while
-the scenario was failing, which is what separates a stall nobody forged
-through from one nobody propagated.
+Observation and writing happen at different times. Chain observers run
+for the whole of a scenario, so `observed-chains.json` is a continuous
+record of what every node's chain did while that scenario was failing.
+The files themselves are written from the scenario's `t.Cleanup`, which
+runs once that test finishes and before the network is torn down, so
+container status and the service logs describe the network as it stood
+at the end of the failing scenario rather than at the instant of the
+failure.
+
+The `network/` entries, by contrast, are collected once after the whole
+run, by which point a chain that stalled and then recovered looks
+healthy again. That is the difference that separates a stall nobody
+forged through from one nobody propagated.
 
 The per-scenario service logs are capped, because a DevNet node logs at
 debug level and emits tens of megabytes a minute; `network/compose.log`

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -365,14 +365,30 @@ deleting it. On success the directory is removed.
 | `network/compose.log` | Full compose logs for every service |
 | `network/generated-configs/` | The genesis and node configuration the configurator generated |
 | `network/testnet*.yaml` | The network spec the run used |
-| `accelerated-timeline/observed-chains.json` | Every node's observed chain: tip, retained headers, roll-forward/roll-backward counts, deepest rollback, connect/disconnect churn |
-| `accelerated-timeline/container-status.txt` | Container status as the scenario saw it |
-| `accelerated-timeline/<service>.log` | Per-service logs captured by the scenario |
+| `<scenario>/observed-chains.json` | Every node's observed chain: tip, retained headers, roll-forward/roll-backward counts, deepest rollback, connect/disconnect churn |
+| `<scenario>/container-status.txt` | Container status as the scenario saw it |
+| `<scenario>/<service>.log` | Per-service logs captured by the scenario, capped at the last `CapturedLogTailLines` lines |
 
-The `accelerated-timeline/` entries are written by the scenario itself
-through `NodeControl.CaptureFailureArtifacts`, so the observed chain
-events survive even though the network is torn down immediately
-afterwards.
+`<scenario>` is `accelerated-timeline` for the accelerated timeline,
+which captures explicitly through `NodeControl.CaptureFailureArtifacts`,
+and the Go test name for every canonical scenario, which
+`NewTestHarness` wires up on its own.
+
+Each scenario captures the moment it fails, rather than at teardown. The
+`network/` entries are collected once, after the whole run, by which
+point a chain that stalled and then recovered looks healthy again;
+`observed-chains.json` records what each node's chain actually did while
+the scenario was failing, which is what separates a stall nobody forged
+through from one nobody propagated.
+
+The per-scenario service logs are capped, because a DevNet node logs at
+debug level and emits tens of megabytes a minute; `network/compose.log`
+is the complete, uncapped record for the whole run, so the per-scenario
+copy only carries the window around the failure.
+
+Capture stays off unless `DEVNET_ARTIFACT_DIR` is set and the topology
+names containers, so a harness built over endpoints that are never
+dialled does not reach for Docker.
 
 The harness reads endpoint addresses from mode-specific environment
 variables that `run-tests.sh` sets based on the host port mappings (dingo
@@ -533,12 +549,14 @@ harness and the compose port mappings always agree.
 | `start.sh` / `stop.sh`       | Convenience wrappers around `docker compose up -d` / `down -v`; accept `--conformance` |
 | `run-tests.sh`               | Full bring-up → test → tear-down cycle used by CI; accepts `--conformance`, `--keep-up`, and forwards other flags to `go test` |
 | `../antithesis/Dockerfile.txpump`, `../antithesis/cmd/txpump/` | Source for the `txpump` load generator image |
-| `harness.go`                 | Go test harness: Ouroboros NtN client, tip queries, consensus checks, and the `WaitForChainStart` genesis gate (build tag `devnet`) |
+| `harness.go`                 | Go test harness: Ouroboros NtN client, tip queries, consensus checks, the `WaitForChainStart` genesis gate, and per-scenario failure capture (build tag `devnet`) |
 | `config.go`                  | `testnet*.yaml` loader, derived timings, and spec validation (**no build tag** — its tests run in the ordinary `go test ./...`) |
 | `chainstate.go`              | Observed-chain state machine: applies RollForward/RollBackward, tracks tip and retained headers, and exposes cross-node agreement helpers and bounded-context conditions (**no build tag**) |
 | `timeline.go`                | `ScenarioPlan`: derives the accelerated scenario's phases, deadlines, outage length, and hard timeout from the network spec (**no build tag**) |
 | `observer.go`                | Persistent per-node ChainSync sessions feeding `chainstate.go`, with automatic reconnect across container restarts (build tag `devnet`) |
-| `nodectl.go`                 | Stops/starts compose services for the disruption phases and captures failure artifacts (build tag `devnet`) |
+| `nodectl.go`                 | Stops/starts compose services for the disruption phases and supplies the Docker side of failure capture (build tag `devnet`) |
+| `artifacts.go`               | What a failed scenario preserves and where: capture planning and artifact writing (**no build tag** — its tests run in the ordinary `go test ./...`) |
+| `endpoints.go`               | The `NodeEndpoint` description shared by the harness, observers, and failure capture (**no build tag**) |
 | `endpoints_dingo.go`         | Dingo-mode node endpoints and NtC addresses (`//go:build devnet && !devnet_conformance`) |
 | `endpoints_conformance.go`   | Conformance-mode node endpoints (`//go:build devnet && devnet_conformance`) |
 | `lsq.go`                     | `RewardAccountsByNtc` / `RewardAccountsByNtcForCreds`: LocalStateQuery over NtC TCP (build tag `devnet`) |

--- a/internal/test/devnet/artifacts.go
+++ b/internal/test/devnet/artifacts.go
@@ -121,6 +121,17 @@ func PlanFailureCapture(
 // not because they escape the segment, but because the filesystem reads
 // them as something other than the name asked for.
 //
+// Case is the one difference deliberately left unescaped, so the
+// guarantee above is a guarantee on any filesystem that distinguishes
+// case, and not on one that folds it: on macOS or Windows, TestX/a and
+// TestX/A encode differently but land in one directory. Closing that
+// would cost the readable name, which is the thing the encoding exists
+// to protect -- escaping case renders TestSustainedConsensus as
+// %54est%53ustained%43onsensus, and a digest suffix trades the exact
+// name for a probability. DevNet captures on Linux, where case is
+// significant, and two Go test names differing only in case is a naming
+// problem of its own. TestArtifactNameKeepsCase pins this boundary.
+//
 // Only what a filesystem would reject or rewrite is escaped, so a name
 // built from Go identifiers comes back exactly as written. That is every
 // scenario in the canonical suite, and it is what makes the directory

--- a/internal/test/devnet/artifacts.go
+++ b/internal/test/devnet/artifacts.go
@@ -113,10 +113,18 @@ func PlanFailureCapture(
 // rather than a probability, which is what a digest of the name would
 // give instead.
 //
-// Only what would break out of the segment is escaped, so a name with no
-// separator in it comes back exactly as written. That is every scenario
-// in the canonical suite, and it is what makes the directory findable
-// from the name in the failure output.
+// String-level injectivity only delivers that guarantee if the
+// filesystem stores the name it is given. Windows does not: it rejects
+// : * ? " < > | outright, and it strips a trailing dot or space, which
+// would quietly land "." and ".." -- encoded here as %2E and %2E. -- in
+// one directory. Those are escaped for the same reason "." and ".." are:
+// not because they escape the segment, but because the filesystem reads
+// them as something other than the name asked for.
+//
+// Only what a filesystem would reject or rewrite is escaped, so a name
+// built from Go identifiers comes back exactly as written. That is every
+// scenario in the canonical suite, and it is what makes the directory
+// findable from the name in the failure output.
 func ArtifactName(testName string) string {
 	// t.Name() is never empty; this only guards a caller-supplied name.
 	if testName == "" {
@@ -130,10 +138,8 @@ func ArtifactName(testName string) string {
 			// First, so no escape below can be forged by an input that
 			// spells one out literally.
 			encoded.WriteString("%25")
-		case '/':
-			encoded.WriteString("%2F")
-		case '\\':
-			encoded.WriteString("%5C")
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|':
+			encoded.WriteString(escapeByte(byte(r)))
 		default:
 			encoded.WriteRune(r)
 		}
@@ -145,9 +151,26 @@ func ArtifactName(testName string) string {
 	// distinct from every other encoding because a literal % is already
 	// escaped above.
 	if strings.Trim(name, ".") == "" {
-		return "%2E" + name[1:]
+		name = "%2E" + name[1:]
+	}
+	// Windows strips a trailing dot or space, so ".." (encoded just
+	// above as "%2E.") would be stored as "%2E" and share a directory
+	// with ".". Escaping the last character alone is enough, because the
+	// result then ends in a hex digit and there is nothing left to
+	// strip. It stays injective: the escape can only have come from the
+	// character it encodes, since a literal % is already escaped.
+	if last := name[len(name)-1]; last == '.' || last == ' ' {
+		name = name[:len(name)-1] + escapeByte(last)
 	}
 	return name
+}
+
+// escapeByte renders one byte as the percent escape used throughout
+// ArtifactName. Upper-case hex, so the encoding has a single spelling
+// and two names cannot differ only by the case of an escape.
+func escapeByte(b byte) string {
+	const hex = "0123456789ABCDEF"
+	return string([]byte{'%', hex[b>>4], hex[b&0x0F]})
 }
 
 // WriteFailureArtifacts writes the evidence a failed scenario needs to be

--- a/internal/test/devnet/artifacts.go
+++ b/internal/test/devnet/artifacts.go
@@ -17,8 +17,6 @@ package devnet
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,36 +101,53 @@ func PlanFailureCapture(
 	}, true
 }
 
-// ArtifactName reduces a Go test name to one path segment. t.Name()
+// ArtifactName encodes a Go test name as one path segment. t.Name()
 // renders a subtest as parent/child, which would otherwise scatter a
-// scenario's evidence across nested directories, and a name carrying ..
-// would write outside the artifact root.
+// scenario's evidence across nested directories.
 //
-// That flattening is lossy — TestX/a-b and TestX/a/b both reduce to
-// TestX-a-b — so a rewritten name carries a digest of what it came from
-// and two failures cannot land in one directory. A name that needed no
-// rewriting keeps its exact test name, which is every scenario in the
-// canonical suite and is what makes the directory findable from the
-// failure output.
+// The separator is escaped rather than replaced, because replacing it is
+// lossy: with the separator rewritten to an ordinary character, TestX/a-b
+// and TestX/a/b both become TestX-a-b and two failing subtests write into
+// one directory. Escaping keeps the mapping one-to-one, so distinct test
+// names always get distinct directories -- a property of the encoding
+// rather than a probability, which is what a digest of the name would
+// give instead.
+//
+// Only what would break out of the segment is escaped, so a name with no
+// separator in it comes back exactly as written. That is every scenario
+// in the canonical suite, and it is what makes the directory findable
+// from the name in the failure output.
 func ArtifactName(testName string) string {
-	name := strings.Map(func(r rune) rune {
-		switch r {
-		case '/', '\\':
-			return '-'
-		}
-		return r
-	}, testName)
-	name = strings.ReplaceAll(name, "..", "-")
-	name = strings.Trim(name, ". ")
-	if name == "" {
+	// t.Name() is never empty; this only guards a caller-supplied name.
+	if testName == "" {
 		return "scenario"
 	}
-	if name == testName {
-		return name
+	var encoded strings.Builder
+	encoded.Grow(len(testName))
+	for _, r := range testName {
+		switch r {
+		case '%':
+			// First, so no escape below can be forged by an input that
+			// spells one out literally.
+			encoded.WriteString("%25")
+		case '/':
+			encoded.WriteString("%2F")
+		case '\\':
+			encoded.WriteString("%5C")
+		default:
+			encoded.WriteRune(r)
+		}
 	}
-	digest := fnv.New32a()
-	_, _ = digest.Write([]byte(testName))
-	return name + "-" + fmt.Sprintf("%08x", digest.Sum32())
+	name := encoded.String()
+	// A name made only of dots addresses a directory rather than naming
+	// one: "." and ".." would resolve to the artifact root and its
+	// parent. Escaping the leading dot keeps it a name, and stays
+	// distinct from every other encoding because a literal % is already
+	// escaped above.
+	if strings.Trim(name, ".") == "" {
+		return "%2E" + name[1:]
+	}
+	return name
 }
 
 // WriteFailureArtifacts writes the evidence a failed scenario needs to be

--- a/internal/test/devnet/artifacts.go
+++ b/internal/test/devnet/artifacts.go
@@ -17,6 +17,8 @@ package devnet
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,6 +107,13 @@ func PlanFailureCapture(
 // renders a subtest as parent/child, which would otherwise scatter a
 // scenario's evidence across nested directories, and a name carrying ..
 // would write outside the artifact root.
+//
+// That flattening is lossy — TestX/a-b and TestX/a/b both reduce to
+// TestX-a-b — so a rewritten name carries a digest of what it came from
+// and two failures cannot land in one directory. A name that needed no
+// rewriting keeps its exact test name, which is every scenario in the
+// canonical suite and is what makes the directory findable from the
+// failure output.
 func ArtifactName(testName string) string {
 	name := strings.Map(func(r rune) rune {
 		switch r {
@@ -118,7 +127,12 @@ func ArtifactName(testName string) string {
 	if name == "" {
 		return "scenario"
 	}
-	return name
+	if name == testName {
+		return name
+	}
+	digest := fnv.New32a()
+	_, _ = digest.Write([]byte(testName))
+	return name + "-" + fmt.Sprintf("%08x", digest.Sum32())
 }
 
 // WriteFailureArtifacts writes the evidence a failed scenario needs to be

--- a/internal/test/devnet/artifacts.go
+++ b/internal/test/devnet/artifacts.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file carries no build tag on purpose. What a failed scenario
+// preserves, and where, is decided here so it is covered by an ordinary
+// `go test ./...` run; only the Docker calls that supply the evidence
+// need the devnet tag and a live network.
+
+// ArtifactDir returns the directory failure evidence is written to, and
+// whether one is configured. run-tests.sh creates it and preserves it on
+// failure.
+func ArtifactDir() (string, bool) {
+	dir := os.Getenv("DEVNET_ARTIFACT_DIR")
+	return dir, dir != ""
+}
+
+// CapturedLogTailLines bounds the per-service logs a failed scenario
+// copies out. A DevNet node logs at debug level and emits tens of
+// megabytes a minute, so an unbounded copy per failed scenario is a
+// multi-gigabyte artifact directory on a long canonical run.
+// run-tests.sh separately preserves the complete compose log for the
+// whole run under network/, so this copy only has to carry the window
+// around the failure.
+const CapturedLogTailLines = 2000
+
+// ArtifactSource supplies the Docker-side evidence a capture writes out.
+// NodeControl implements it.
+type ArtifactSource interface {
+	ContainerStatus(ctx context.Context) (string, error)
+	// Logs returns a service's container logs, limited to the last
+	// tailLines lines when tailLines is positive.
+	Logs(
+		ctx context.Context,
+		service string,
+		tailLines int,
+	) (string, error)
+}
+
+// FailureCapturePlan is what a scenario preserves when it fails: the
+// directory to write under, the name that separates one scenario's
+// evidence from another's, and the compose services whose logs to keep.
+type FailureCapturePlan struct {
+	Root     string
+	Name     string
+	Services []string
+}
+
+// PlanFailureCapture decides whether a scenario can preserve evidence and
+// what it would preserve. Capture needs somewhere to write and at least
+// one container to read, so an unset DEVNET_ARTIFACT_DIR or a topology of
+// endpoints that name no container disables it rather than producing an
+// empty directory or asking Docker for services that do not exist.
+func PlanFailureCapture(
+	root string,
+	testName string,
+	endpoints []NodeEndpoint,
+) (FailureCapturePlan, bool) {
+	if root == "" {
+		return FailureCapturePlan{}, false
+	}
+	services := make([]string, 0, len(endpoints))
+	seen := make(map[string]struct{}, len(endpoints))
+	for _, ep := range endpoints {
+		if ep.Container == "" {
+			continue
+		}
+		if _, dup := seen[ep.Container]; dup {
+			continue
+		}
+		seen[ep.Container] = struct{}{}
+		services = append(services, ep.Container)
+	}
+	if len(services) == 0 {
+		return FailureCapturePlan{}, false
+	}
+	return FailureCapturePlan{
+		Root:     root,
+		Name:     ArtifactName(testName),
+		Services: services,
+	}, true
+}
+
+// ArtifactName reduces a Go test name to one path segment. t.Name()
+// renders a subtest as parent/child, which would otherwise scatter a
+// scenario's evidence across nested directories, and a name carrying ..
+// would write outside the artifact root.
+func ArtifactName(testName string) string {
+	name := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\':
+			return '-'
+		}
+		return r
+	}, testName)
+	name = strings.ReplaceAll(name, "..", "-")
+	name = strings.Trim(name, ". ")
+	if name == "" {
+		return "scenario"
+	}
+	return name
+}
+
+// WriteFailureArtifacts writes the evidence a failed scenario needs to be
+// diagnosable after the network is gone: what every node's chain actually
+// did, which containers were up, and each service's logs.
+//
+// It is best-effort by design — a capture error must not mask the test
+// failure that triggered it, and one unreadable service must not cost the
+// rest of the evidence — so problems are logged rather than returned. A
+// nil src means the Docker side is unavailable; the observed chains are
+// recorded in-process and are still written.
+func WriteFailureArtifacts(
+	ctx context.Context,
+	src ArtifactSource,
+	plan FailureCapturePlan,
+	snapshots []ChainSnapshot,
+	logf func(format string, args ...any),
+) {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	if plan.Root == "" {
+		logf("devnet: no artifact directory; skipping artifact capture")
+		return
+	}
+	dir := filepath.Join(plan.Root, plan.Name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		logf("devnet: creating %s: %v", dir, err)
+		return
+	}
+
+	if data, err := json.MarshalIndent(snapshots, "", "  "); err != nil {
+		logf("devnet: encoding chain events: %v", err)
+	} else {
+		writeArtifact(dir, "observed-chains.json", data, logf)
+	}
+
+	if src == nil {
+		logf(
+			"devnet: no container source; preserved observed chains only",
+		)
+		return
+	}
+
+	if status, err := src.ContainerStatus(ctx); err != nil {
+		logf("devnet: container status: %v", err)
+	} else {
+		writeArtifact(dir, "container-status.txt", []byte(status), logf)
+	}
+
+	for _, svc := range plan.Services {
+		logs, err := src.Logs(ctx, svc, CapturedLogTailLines)
+		if err != nil {
+			logf("devnet: logs for %s: %v", svc, err)
+			continue
+		}
+		writeArtifact(dir, svc+".log", []byte(logs), logf)
+	}
+	logf("devnet: failure artifacts written to %s", dir)
+}
+
+func writeArtifact(
+	dir, name string,
+	data []byte,
+	logf func(format string, args ...any),
+) {
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		logf("devnet: writing %s: %v", path, err)
+	}
+}

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -387,14 +387,18 @@ func TestArtifactNameLeavesPlainScenarioNamesAlone(t *testing.T) {
 	)
 }
 
-// TestArtifactNamesCreateDistinctDirectories checks the guarantee
-// ArtifactName actually makes -- distinct test names get distinct
-// directories -- against a filesystem instead of against string
-// equality. Lexical injectivity is not the same guarantee: a filesystem
+// TestArtifactNamesCreateDistinctDirectories checks that every name in
+// artifactNameCorpus creates a directory of its own on the filesystem
+// under test, rather than checking that the encodings differ as
+// strings. Lexical injectivity is not the same guarantee: a filesystem
 // that rewrites a name stores two distinct encodings in one directory,
 // and a filesystem that rejects one stores neither. Windows does both,
 // so this is where that shows up rather than in
 // TestArtifactNameIsInjective.
+//
+// The corpus is the scope of the claim. It leaves out names differing
+// only in case, which do share a directory where the filesystem folds
+// case; TestArtifactNameKeepsCase carries that boundary.
 func TestArtifactNamesCreateDistinctDirectories(t *testing.T) {
 	root := t.TempDir()
 	// Report every name rather than stopping at the first, because the

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -288,3 +288,22 @@ func TestWriteFailureArtifactsBoundsCapturedLogs(t *testing.T) {
 		"an unbounded tail is what this guards against",
 	)
 }
+
+func TestArtifactNameDisambiguatesFlattenedNames(t *testing.T) {
+	// Flattening the subtest separator is lossy: TestX/a-b and
+	// TestX/a/b both reduce to TestX-a-b, so two failing subtests would
+	// write their evidence into one directory and mix it.
+	require.NotEqual(t,
+		ArtifactName("TestX/a-b"), ArtifactName("TestX/a/b"),
+		"two distinct test names must not share an artifact directory",
+	)
+}
+
+func TestArtifactNameLeavesPlainScenarioNamesAlone(t *testing.T) {
+	// Every scenario in the canonical suite is a top-level test, and
+	// the directory is found by the name in the failure output, so a
+	// name that needs no rewriting must come back untouched.
+	require.Equal(t, "TestSustainedConsensus",
+		ArtifactName("TestSustainedConsensus"),
+	)
+}

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -312,12 +313,15 @@ func TestWriteFailureArtifactsBoundsCapturedLogs(t *testing.T) {
 // ordinary character, an escape sequence written literally, both
 // separators, and names made only of dots.
 //
-// The last group is what a t.Run name can carry that Windows treats
-// specially. Go rewrites whitespace to '_' before t.Name() returns, so a
-// trailing space cannot reach here, but ':' '*' '?' '"' '<' '>' '|' and a
-// trailing dot all survive. They are here to hold the encoding to its
-// contract on every platform the untagged tests run on: distinct names
-// stay distinct, and each one stays a single path segment.
+// The last group is what Windows treats specially. Go rewrites
+// whitespace to '_' before t.Name() returns, so a trailing space cannot
+// arrive that way, but ArtifactName is exported and NodeControl's
+// caller passes a name of its own, so it is covered too; ':' '*' '?' '"'
+// '<' '>' '|' and a trailing dot all survive t.Run untouched. They are
+// here to hold the encoding to its contract on every platform the
+// untagged tests run on: distinct names stay distinct, each one stays a
+// single path segment, and each one names a directory the filesystem
+// will actually create.
 var artifactNameCorpus = []string{
 	"TestSustainedConsensus",
 	"accelerated-timeline",
@@ -343,6 +347,7 @@ var artifactNameCorpus = []string{
 	"TestX/a>b",
 	"TestX/a|b",
 	"TestX/a.",
+	"TestX/a ",
 }
 
 func TestArtifactNameIsInjective(t *testing.T) {
@@ -380,4 +385,72 @@ func TestArtifactNameLeavesPlainScenarioNamesAlone(t *testing.T) {
 	require.Equal(t, "TestSustainedConsensus",
 		ArtifactName("TestSustainedConsensus"),
 	)
+}
+
+// TestArtifactNamesCreateDistinctDirectories checks the guarantee
+// ArtifactName actually makes -- distinct test names get distinct
+// directories -- against a filesystem instead of against string
+// equality. Lexical injectivity is not the same guarantee: a filesystem
+// that rewrites a name stores two distinct encodings in one directory,
+// and a filesystem that rejects one stores neither. Windows does both,
+// so this is where that shows up rather than in
+// TestArtifactNameIsInjective.
+func TestArtifactNamesCreateDistinctDirectories(t *testing.T) {
+	root := t.TempDir()
+	// Report every name rather than stopping at the first, because the
+	// two ways this breaks look nothing alike: a rejected name is a
+	// loud error, while a rewritten one silently joins another
+	// scenario's directory. Seeing both at once is the point.
+	encoded := make([]string, 0, len(artifactNameCorpus))
+	source := make([]string, 0, len(artifactNameCorpus))
+	for _, name := range artifactNameCorpus {
+		got := ArtifactName(name)
+		if err := os.MkdirAll(filepath.Join(root, got), 0o755); err != nil {
+			t.Errorf(
+				"%q encoded to %q, which the filesystem rejected: %v",
+				name, got, err,
+			)
+			continue
+		}
+		encoded = append(encoded, got)
+		source = append(source, name)
+	}
+
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	made := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		made[entry.Name()] = struct{}{}
+	}
+	for i, got := range encoded {
+		if _, ok := made[got]; !ok {
+			t.Errorf(
+				"%q encoded to %q, which the filesystem stored as "+
+					"something else",
+				source[i], got,
+			)
+		}
+	}
+	// The corpus encodes injectively, so one directory per entry is the
+	// only count that leaves every scenario's evidence separable.
+	require.Len(t, entries, len(encoded),
+		"%d names produced %d directories", len(encoded), len(entries),
+	)
+}
+
+// TestArtifactNameNeverEndsInAStrippedCharacter guards the trailing-dot
+// and trailing-space escapes directly. Windows removes both from the end
+// of a name, so an encoding that ended in either would be stored under a
+// shorter name -- and two encodings that differ only there would become
+// one directory. The filesystem test above only catches this when it runs
+// on Windows; this one holds everywhere.
+func TestArtifactNameNeverEndsInAStrippedCharacter(t *testing.T) {
+	for _, name := range artifactNameCorpus {
+		got := ArtifactName(name)
+		last := got[len(got)-1]
+		require.NotContains(t, ". ", string(last),
+			"%q encoded to %q, which Windows would store as %q",
+			name, got, strings.TrimRight(got, ". "),
+		)
+	}
 }

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -55,6 +55,27 @@ func (f *fakeArtifactSource) Logs(
 	return f.logs[service], nil
 }
 
+// requireSinglePathSegment asserts that name addresses exactly one entry
+// directly inside root, and does so without depending on the platform's
+// separator. A literal would: filepath.Join normalizes through Clean,
+// whose documented last step replaces every slash with filepath.Separator,
+// so on Windows filepath.Dir(filepath.Join("/root", name)) is `\root` and
+// never equals a "/root" literal. This file carries no build tag, so it
+// runs under the untagged `go test ./...` that release validation runs on
+// windows-latest; an assertion that only holds on one separator fails
+// there and blocks the release. Both sides are built with filepath here,
+// so they normalize identically on every platform.
+func requireSinglePathSegment(
+	t *testing.T,
+	root, name string,
+	msgAndArgs ...any,
+) {
+	t.Helper()
+	joined := filepath.Join(root, name)
+	require.Equal(t, filepath.Clean(root), filepath.Dir(joined), msgAndArgs...)
+	require.Equal(t, name, filepath.Base(joined), msgAndArgs...)
+}
+
 func testEndpoints() []NodeEndpoint {
 	return []NodeEndpoint{
 		{Name: "dingo-1", Role: "producer", Container: "dingo-1"},
@@ -123,8 +144,7 @@ func TestPlanFailureCaptureKeepsTheNameInsideTheRoot(t *testing.T) {
 	)
 
 	require.True(t, ok)
-	require.Equal(t, "/artifacts",
-		filepath.Dir(filepath.Join("/artifacts", plan.Name)),
+	requireSinglePathSegment(t, "/artifacts", plan.Name,
 		"the artifact directory must be a direct child of the root",
 	)
 }
@@ -332,8 +352,7 @@ func TestArtifactNameStaysASinglePathSegment(t *testing.T) {
 	for _, name := range artifactNameCorpus {
 		got := ArtifactName(name)
 		require.NotEmpty(t, got, "%q encoded to nothing", name)
-		require.Equal(t, "/root",
-			filepath.Dir(filepath.Join("/root", got)),
+		requireSinglePathSegment(t, "/root", got,
 			"%q encoded to %q, which leaves the root", name, got,
 		)
 	}

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -114,7 +114,7 @@ func TestPlanFailureCaptureSkipsEndpointsWithoutContainers(t *testing.T) {
 	require.Len(t, plan.Services, 3)
 }
 
-func TestPlanFailureCaptureFlattensSubtestNames(t *testing.T) {
+func TestPlanFailureCaptureKeepsTheNameInsideTheRoot(t *testing.T) {
 	// t.Name() renders a subtest as parent/child. Left alone that
 	// scatters one scenario's evidence across nested directories, and a
 	// name that walked upward would escape the artifact root entirely.
@@ -123,11 +123,9 @@ func TestPlanFailureCaptureFlattensSubtestNames(t *testing.T) {
 	)
 
 	require.True(t, ok)
-	require.NotContains(t, plan.Name, "/",
-		"the artifact name has to stay a single path segment",
-	)
-	require.NotContains(t, plan.Name, "..",
-		"the artifact name must not walk out of the artifact root",
+	require.Equal(t, "/artifacts",
+		filepath.Dir(filepath.Join("/artifacts", plan.Name)),
+		"the artifact directory must be a direct child of the root",
 	)
 }
 
@@ -289,14 +287,56 @@ func TestWriteFailureArtifactsBoundsCapturedLogs(t *testing.T) {
 	)
 }
 
-func TestArtifactNameDisambiguatesFlattenedNames(t *testing.T) {
-	// Flattening the subtest separator is lossy: TestX/a-b and
-	// TestX/a/b both reduce to TestX-a-b, so two failing subtests would
-	// write their evidence into one directory and mix it.
-	require.NotEqual(t,
-		ArtifactName("TestX/a-b"), ArtifactName("TestX/a/b"),
-		"two distinct test names must not share an artifact directory",
-	)
+// artifactNameCorpus collects the test names that probe the ways an
+// encoding can lose information: the subtest separator against an
+// ordinary character, an escape sequence written literally, both
+// separators, and names made only of dots.
+var artifactNameCorpus = []string{
+	"TestSustainedConsensus",
+	"accelerated-timeline",
+	"TestX/a-b",
+	"TestX/a/b",
+	"TestX-a-b",
+	"TestX%2Fa",
+	"TestX/a",
+	"TestX%252Fa",
+	`TestX\a`,
+	"TestX/",
+	"/TestX",
+	"TestEpochBoundary/../../etc",
+	".",
+	"..",
+	"...",
+	"TestX/..",
+}
+
+func TestArtifactNameIsInjective(t *testing.T) {
+	// Replacing the separator with an ordinary character is lossy:
+	// TestX/a-b and TestX/a/b would both become TestX-a-b, and two
+	// failing subtests would mix their evidence in one directory.
+	// Escaping keeps the mapping one-to-one, so this is a property of
+	// the encoding rather than a probability.
+	seen := make(map[string]string, len(artifactNameCorpus))
+	for _, name := range artifactNameCorpus {
+		got := ArtifactName(name)
+		if prev, dup := seen[got]; dup {
+			t.Fatalf(
+				"%q and %q both encode to %q", prev, name, got,
+			)
+		}
+		seen[got] = name
+	}
+}
+
+func TestArtifactNameStaysASinglePathSegment(t *testing.T) {
+	for _, name := range artifactNameCorpus {
+		got := ArtifactName(name)
+		require.NotEmpty(t, got, "%q encoded to nothing", name)
+		require.Equal(t, "/root",
+			filepath.Dir(filepath.Join("/root", got)),
+			"%q encoded to %q, which leaves the root", name, got,
+		)
+	}
 }
 
 func TestArtifactNameLeavesPlainScenarioNamesAlone(t *testing.T) {

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -454,3 +454,25 @@ func TestArtifactNameNeverEndsInAStrippedCharacter(t *testing.T) {
 		)
 	}
 }
+
+// TestArtifactNameKeepsCase pins the one place the encoding stops short
+// of a filesystem guarantee. Case is preserved rather than escaped, so
+// two names differing only in case encode differently but share a
+// directory on a filesystem that folds case.
+//
+// The pair is deliberately absent from artifactNameCorpus, which
+// TestArtifactNamesCreateDistinctDirectories creates for real: adding it
+// would fail on macOS and Windows. That is the boundary being recorded,
+// not a defect being hidden -- escaping case would render
+// TestSustainedConsensus as %54est%53ustained%43onsensus, and the
+// directory has to stay findable from the name in the failure output.
+func TestArtifactNameKeepsCase(t *testing.T) {
+	require.NotEqual(t,
+		ArtifactName("TestX/a"), ArtifactName("TestX/A"),
+		"the encoding itself must not fold case",
+	)
+	require.Equal(t, "TestSustainedConsensus",
+		ArtifactName("TestSustainedConsensus"),
+		"escaping case would cost every scenario its readable name",
+	)
+}

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -311,6 +311,13 @@ func TestWriteFailureArtifactsBoundsCapturedLogs(t *testing.T) {
 // encoding can lose information: the subtest separator against an
 // ordinary character, an escape sequence written literally, both
 // separators, and names made only of dots.
+//
+// The last group is what a t.Run name can carry that Windows treats
+// specially. Go rewrites whitespace to '_' before t.Name() returns, so a
+// trailing space cannot reach here, but ':' '*' '?' '"' '<' '>' '|' and a
+// trailing dot all survive. They are here to hold the encoding to its
+// contract on every platform the untagged tests run on: distinct names
+// stay distinct, and each one stays a single path segment.
 var artifactNameCorpus = []string{
 	"TestSustainedConsensus",
 	"accelerated-timeline",
@@ -328,6 +335,14 @@ var artifactNameCorpus = []string{
 	"..",
 	"...",
 	"TestX/..",
+	"TestX/a:b",
+	"TestX/a*b",
+	"TestX/a?b",
+	`TestX/a"b`,
+	"TestX/a<b",
+	"TestX/a>b",
+	"TestX/a|b",
+	"TestX/a.",
 }
 
 func TestArtifactNameIsInjective(t *testing.T) {

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeArtifactSource stands in for NodeControl so the capture path can be
+// exercised without a running DevNet or a Docker daemon.
+type fakeArtifactSource struct {
+	status    string
+	statusErr error
+	logs      map[string]string
+	logErr    map[string]error
+	asked     []string
+	tails     []int
+}
+
+func (f *fakeArtifactSource) ContainerStatus(
+	context.Context,
+) (string, error) {
+	return f.status, f.statusErr
+}
+
+func (f *fakeArtifactSource) Logs(
+	_ context.Context,
+	service string,
+	tailLines int,
+) (string, error) {
+	f.asked = append(f.asked, service)
+	f.tails = append(f.tails, tailLines)
+	if err := f.logErr[service]; err != nil {
+		return "", err
+	}
+	return f.logs[service], nil
+}
+
+func testEndpoints() []NodeEndpoint {
+	return []NodeEndpoint{
+		{Name: "dingo-1", Role: "producer", Container: "dingo-1"},
+		{Name: "dingo-2", Role: "producer", Container: "dingo-2"},
+		{Name: "dingo-relay", Role: "relay", Container: "dingo-relay"},
+	}
+}
+
+func TestPlanFailureCaptureNamesServicesFromEndpoints(t *testing.T) {
+	plan, ok := PlanFailureCapture(
+		"/artifacts", "TestSustainedConsensus", testEndpoints(),
+	)
+
+	require.True(t, ok, "an artifact dir plus containers enables capture")
+	require.Equal(t, "/artifacts", plan.Root)
+	require.Equal(t, "TestSustainedConsensus", plan.Name)
+	require.Equal(t,
+		[]string{"dingo-1", "dingo-2", "dingo-relay"}, plan.Services,
+		"every endpoint with a container contributes its service",
+	)
+}
+
+func TestPlanFailureCaptureDisabledWithoutArtifactDir(t *testing.T) {
+	_, ok := PlanFailureCapture("", "TestSustainedConsensus", testEndpoints())
+
+	require.False(t, ok,
+		"without DEVNET_ARTIFACT_DIR there is nowhere to preserve evidence",
+	)
+}
+
+func TestPlanFailureCaptureDisabledWithoutContainers(t *testing.T) {
+	// The unit-style harness tests construct endpoints that describe no
+	// container. Capturing for them would dial addresses that do not
+	// exist and ask Docker for services it does not have.
+	endpoints := []NodeEndpoint{
+		{Name: "cardano-producer", Role: "producer"},
+		{Name: "cardano-relay", Role: "relay"},
+	}
+
+	_, ok := PlanFailureCapture("/artifacts", "TestX", endpoints)
+
+	require.False(t, ok, "no container means nothing to capture")
+}
+
+func TestPlanFailureCaptureSkipsEndpointsWithoutContainers(t *testing.T) {
+	endpoints := append(
+		testEndpoints(),
+		NodeEndpoint{Name: "observer-only", Role: "relay"},
+	)
+
+	plan, ok := PlanFailureCapture("/artifacts", "TestX", endpoints)
+
+	require.True(t, ok)
+	require.NotContains(t, plan.Services, "",
+		"an endpoint with no container must not become an empty service",
+	)
+	require.Len(t, plan.Services, 3)
+}
+
+func TestPlanFailureCaptureFlattensSubtestNames(t *testing.T) {
+	// t.Name() renders a subtest as parent/child. Left alone that
+	// scatters one scenario's evidence across nested directories, and a
+	// name that walked upward would escape the artifact root entirely.
+	plan, ok := PlanFailureCapture(
+		"/artifacts", "TestEpochBoundary/../../etc", testEndpoints(),
+	)
+
+	require.True(t, ok)
+	require.NotContains(t, plan.Name, "/",
+		"the artifact name has to stay a single path segment",
+	)
+	require.NotContains(t, plan.Name, "..",
+		"the artifact name must not walk out of the artifact root",
+	)
+}
+
+func TestWriteFailureArtifactsPreservesChainsStatusAndLogs(t *testing.T) {
+	root := t.TempDir()
+	src := &fakeArtifactSource{
+		status: "NAME       STATUS\ndingo-1    Up 4 minutes\n",
+		logs: map[string]string{
+			"dingo-1":     "dingo-1 forged block 77\n",
+			"dingo-relay": "dingo-relay received block 77\n",
+		},
+	}
+	snapshots := []ChainSnapshot{
+		{
+			Node:         "dingo-1",
+			Tip:          ChainTip{SlotNumber: 241, BlockNumber: 77},
+			RollForwards: 77,
+		},
+		{
+			Node:         "dingo-relay",
+			Tip:          ChainTip{SlotNumber: 241, BlockNumber: 77},
+			RollForwards: 77,
+		},
+	}
+	plan := FailureCapturePlan{
+		Root:     root,
+		Name:     "TestSustainedConsensus",
+		Services: []string{"dingo-1", "dingo-relay"},
+	}
+
+	WriteFailureArtifacts(
+		context.Background(), src, plan, snapshots, t.Logf,
+	)
+
+	dir := filepath.Join(root, "TestSustainedConsensus")
+
+	// The observed chain events are the evidence that distinguishes a
+	// missed forge from a propagation stall, so they have to survive
+	// teardown in a form something else can read.
+	raw, err := os.ReadFile(filepath.Join(dir, "observed-chains.json"))
+	require.NoError(t, err)
+	var got []ChainSnapshot
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Equal(t, snapshots, got)
+
+	status, err := os.ReadFile(filepath.Join(dir, "container-status.txt"))
+	require.NoError(t, err)
+	require.Equal(t, src.status, string(status))
+
+	for svc, want := range src.logs {
+		logs, err := os.ReadFile(filepath.Join(dir, svc+".log"))
+		require.NoError(t, err, "logs for %s", svc)
+		require.Equal(t, want, string(logs))
+	}
+}
+
+func TestWriteFailureArtifactsWithoutRootWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	src := &fakeArtifactSource{status: "status"}
+	plan := FailureCapturePlan{
+		Name:     "TestSustainedConsensus",
+		Services: []string{"dingo-1"},
+	}
+
+	WriteFailureArtifacts(
+		context.Background(), src, plan, nil, t.Logf,
+	)
+
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	require.Empty(t, entries, "an unset root must not write anywhere")
+	require.Empty(t, src.asked, "and must not shell out to Docker either")
+}
+
+func TestWriteFailureArtifactsContinuesAfterOneServiceFails(t *testing.T) {
+	// Capture is best-effort: it runs because the test already failed,
+	// so losing one service's logs must not cost the rest of the
+	// evidence.
+	root := t.TempDir()
+	src := &fakeArtifactSource{
+		statusErr: errors.New("docker compose ps: daemon gone"),
+		logs:      map[string]string{"dingo-relay": "relay logs\n"},
+		logErr: map[string]error{
+			"dingo-1": errors.New("no such service"),
+		},
+	}
+	plan := FailureCapturePlan{
+		Root:     root,
+		Name:     "TestSustainedConsensus",
+		Services: []string{"dingo-1", "dingo-relay"},
+	}
+
+	WriteFailureArtifacts(
+		context.Background(), src, plan,
+		[]ChainSnapshot{{Node: "dingo-1"}}, t.Logf,
+	)
+
+	dir := filepath.Join(root, "TestSustainedConsensus")
+	require.FileExists(t, filepath.Join(dir, "observed-chains.json"),
+		"the chain record does not depend on Docker",
+	)
+	require.NoFileExists(t, filepath.Join(dir, "container-status.txt"),
+		"a failed status read writes no half-truth",
+	)
+	require.NoFileExists(t, filepath.Join(dir, "dingo-1.log"))
+	require.FileExists(t, filepath.Join(dir, "dingo-relay.log"),
+		"the service that answered is still preserved",
+	)
+	require.Equal(t, []string{"dingo-1", "dingo-relay"}, src.asked,
+		"one service failing must not stop the walk",
+	)
+}
+
+func TestWriteFailureArtifactsWithoutSourceStillWritesChains(t *testing.T) {
+	// The observed chains are recorded in-process, so an unreachable
+	// Docker daemon must not cost the one artifact that does not depend
+	// on it.
+	root := t.TempDir()
+	plan := FailureCapturePlan{
+		Root:     root,
+		Name:     "TestSustainedConsensus",
+		Services: []string{"dingo-1"},
+	}
+
+	WriteFailureArtifacts(
+		context.Background(), nil, plan,
+		[]ChainSnapshot{{Node: "dingo-1", RollForwards: 77}}, t.Logf,
+	)
+
+	dir := filepath.Join(root, "TestSustainedConsensus")
+	raw, err := os.ReadFile(filepath.Join(dir, "observed-chains.json"))
+	require.NoError(t, err)
+	var got []ChainSnapshot
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Len(t, got, 1)
+	require.Equal(t, 77, got[0].RollForwards)
+	require.NoFileExists(t, filepath.Join(dir, "container-status.txt"))
+	require.NoFileExists(t, filepath.Join(dir, "dingo-1.log"))
+}
+
+func TestWriteFailureArtifactsBoundsCapturedLogs(t *testing.T) {
+	// A DevNet node at debug level emits tens of megabytes a minute, and
+	// run-tests.sh already preserves the complete compose log for the
+	// whole run. The per-scenario copy only has to carry the window
+	// around the failure, so it asks for a bounded tail rather than
+	// everything the daemon still holds.
+	src := &fakeArtifactSource{logs: map[string]string{"dingo-1": "x"}}
+	plan := FailureCapturePlan{
+		Root:     t.TempDir(),
+		Name:     "TestSustainedConsensus",
+		Services: []string{"dingo-1"},
+	}
+
+	WriteFailureArtifacts(context.Background(), src, plan, nil, t.Logf)
+
+	require.Equal(t, []int{CapturedLogTailLines}, src.tails)
+	require.Positive(t, CapturedLogTailLines,
+		"an unbounded tail is what this guards against",
+	)
+}

--- a/internal/test/devnet/endpoints.go
+++ b/internal/test/devnet/endpoints.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+// NodeEndpoint describes a node that the test harness can connect to
+// using the Ouroboros Node-to-Node mini-protocol over TCP.
+//
+// This is plain data and carries no build tag, so the failure-capture
+// planning in artifacts.go stays testable without a running DevNet. The
+// code that dials an endpoint lives in the devnet-tagged files.
+type NodeEndpoint struct {
+	Name        string
+	Address     string // host:port
+	Role        string // "producer" or "relay"
+	IsDingo     bool   // node runs Dingo
+	IsReference bool   // node runs the cardano-node reference impl
+	// Container is the compose service name, used by the scenario to
+	// interrupt and restart the node, and by failure capture to name the
+	// service whose logs to preserve. A disruption step against an
+	// endpoint with no container fails rather than being skipped: a run
+	// that quietly omitted its interruption phases would not be the
+	// release evidence it claims to be.
+	Container string
+}

--- a/internal/test/devnet/harness.go
+++ b/internal/test/devnet/harness.go
@@ -18,6 +18,7 @@ package devnet
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"sort"
@@ -39,22 +40,6 @@ const DefaultNetworkMagic = 42
 // as soon as a node opens its socket — well before that. This covers the
 // pre-genesis wait plus the first few slot-leader draws.
 const ChainStartTimeout = 90 * time.Second
-
-// NodeEndpoint describes a node that the test harness can connect to
-// using the Ouroboros Node-to-Node mini-protocol over TCP.
-type NodeEndpoint struct {
-	Name        string
-	Address     string // host:port
-	Role        string // "producer" or "relay"
-	IsDingo     bool   // node runs Dingo
-	IsReference bool   // node runs the cardano-node reference impl
-	// Container is the compose service name, used by the scenario to
-	// interrupt and restart the node. A disruption step against an
-	// endpoint with no container fails rather than being skipped: a run
-	// that quietly omitted its interruption phases would not be the
-	// release evidence it claims to be.
-	Container string
-}
 
 // TestHarness manages connections to DevNet nodes and provides
 // helper methods for querying chain state and verifying consensus.
@@ -81,7 +66,61 @@ func NewTestHarness(
 	for _, opt := range opts {
 		opt(h)
 	}
+	h.startFailureCapture()
 	return h
+}
+
+// captureTimeout bounds the post-failure evidence collection. It runs
+// after the test has already failed, so it must not be able to hold the
+// suite open indefinitely.
+const captureTimeout = time.Minute
+
+// startFailureCapture makes a canonical scenario preserve what the
+// accelerated scenario preserves. Without it a canonical failure leaves
+// only the Go test log and whatever the compose logs still hold after the
+// run: enough to see that every node sat at one frozen tip, not enough to
+// say whether nobody forged, nobody propagated, or block production was
+// briefly held. The observed chain events are what separate those.
+//
+// Capture is wired here rather than in each scenario so a new scenario
+// cannot forget it. It stays off unless run-tests.sh gave it somewhere to
+// write and the topology names containers to read, which keeps it out of
+// the way of tests that construct endpoints they never dial.
+func (h *TestHarness) startFailureCapture() {
+	root, _ := ArtifactDir()
+	plan, ok := PlanFailureCapture(root, h.t.Name(), h.endpoints)
+	if !ok {
+		return
+	}
+	obsCtx, cancelObs := context.WithCancel(context.Background())
+	observers := StartObservers(
+		obsCtx, h.endpoints, h.networkMagic, h.t.Logf,
+	)
+	h.t.Cleanup(func() {
+		// Stop before reading, so no observer goroutine is still
+		// logging once this cleanup returns.
+		cancelObs()
+		observers.Stop()
+		if !h.t.Failed() {
+			return
+		}
+		snapshots := observers.Group().Snapshots()
+		capCtx, cancelCap := context.WithTimeout(
+			context.Background(), captureTimeout,
+		)
+		defer cancelCap()
+		// A nil source still preserves the observed chains, which
+		// are recorded in-process and need no Docker.
+		var src ArtifactSource
+		if ctl, err := NewNodeControl(h.t.Logf); err != nil {
+			h.t.Logf(
+				"harness: docker unusable for failure capture: %v", err,
+			)
+		} else {
+			src = ctl
+		}
+		WriteFailureArtifacts(capCtx, src, plan, snapshots, h.t.Logf)
+	})
 }
 
 // HarnessOptionFunc configures a TestHarness.

--- a/internal/test/devnet/nodectl.go
+++ b/internal/test/devnet/nodectl.go
@@ -19,11 +19,9 @@ package devnet
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"time"
 )
@@ -118,31 +116,29 @@ func (n *NodeControl) ContainerStatus(ctx context.Context) (string, error) {
 	return out, err
 }
 
-// Logs returns a service's container logs.
+// Logs returns a service's container logs. A positive tailLines limits
+// the result to that many trailing lines; see CapturedLogTailLines for
+// why a capture asks for a bound rather than everything the daemon holds.
 func (n *NodeControl) Logs(
 	ctx context.Context,
 	service string,
+	tailLines int,
 ) (string, error) {
-	return runCompose(
-		ctx, n.composeFile, "logs", "--no-color", "--no-log-prefix", service,
-	)
-}
-
-// ArtifactDir returns the directory failure evidence is written to, and
-// whether one is configured. run-tests.sh creates it and preserves it on
-// failure.
-func ArtifactDir() (string, bool) {
-	dir := os.Getenv("DEVNET_ARTIFACT_DIR")
-	return dir, dir != ""
+	args := []string{"logs", "--no-color", "--no-log-prefix"}
+	if tailLines > 0 {
+		args = append(args, "--tail", strconv.Itoa(tailLines))
+	}
+	args = append(args, service)
+	return runCompose(ctx, n.composeFile, args...)
 }
 
 // CaptureFailureArtifacts writes the evidence a failed scenario needs to
 // be diagnosable after the network is gone: what every node's chain
 // actually did, which containers were up, and each service's logs.
 //
-// It is best-effort by design — a capture error must not mask the test
-// failure that triggered it — so problems are logged rather than
-// returned.
+// The writing itself lives in artifacts.go, untagged, so what a failure
+// preserves is covered by an ordinary test run. This method supplies the
+// Docker side of it.
 func (n *NodeControl) CaptureFailureArtifacts(
 	ctx context.Context,
 	name string,
@@ -156,40 +152,17 @@ func (n *NodeControl) CaptureFailureArtifacts(
 		)
 		return
 	}
-	dir = filepath.Join(dir, name)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		n.logf("nodectl: creating %s: %v", dir, err)
-		return
-	}
-
-	if data, err := json.MarshalIndent(snapshots, "", "  "); err != nil {
-		n.logf("nodectl: encoding chain events: %v", err)
-	} else {
-		n.writeArtifact(dir, "observed-chains.json", data)
-	}
-
-	if status, err := n.ContainerStatus(ctx); err != nil {
-		n.logf("nodectl: container status: %v", err)
-	} else {
-		n.writeArtifact(dir, "container-status.txt", []byte(status))
-	}
-
-	for _, svc := range services {
-		logs, err := n.Logs(ctx, svc)
-		if err != nil {
-			n.logf("nodectl: logs for %s: %v", svc, err)
-			continue
-		}
-		n.writeArtifact(dir, svc+".log", []byte(logs))
-	}
-	n.logf("nodectl: failure artifacts written to %s", dir)
-}
-
-func (n *NodeControl) writeArtifact(dir, name string, data []byte) {
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		n.logf("nodectl: writing %s: %v", path, err)
-	}
+	WriteFailureArtifacts(
+		ctx,
+		n,
+		FailureCapturePlan{
+			Root:     dir,
+			Name:     ArtifactName(name),
+			Services: services,
+		},
+		snapshots,
+		n.logf,
+	)
 }
 
 // runCompose invokes docker compose against the DevNet compose file. The


### PR DESCRIPTION
Refs #3180. This does not fix that flake; it makes the next occurrence
diagnosable. The stall has one occurrence and has not recurred in eleven
runs, and the evidence that would identify it was not retained.

## Change

A canonical scenario that fails leaves only the Go test log and the
compose logs collected after teardown. That shows a frozen tip but not
whether nobody forged, nobody propagated, or block production was briefly
held. Only the accelerated scenario recorded per-node chain events.

`NewTestHarness` now follows every node's chain and, when its test fails,
writes the observed chains, container status, and per-service logs under
the test's name. Wiring it in the harness rather than per scenario means a
new scenario cannot omit it. It stays off unless `DEVNET_ARTIFACT_DIR` is
set and the topology names containers, so a harness built over endpoints
that are never dialled does not reach for Docker.

`NodeEndpoint` and the artifact writer move out of the `devnet` build tag.
CI lints and tests untagged, so logic behind that tag is not covered by
`go test ./...`; the new capture planning and writing are.

The per-service log copy is bounded at `CapturedLogTailLines`. Unbounded,
the first verification run wrote 212 MB for a two-minute scenario, on top
of the 246 MB `network/compose.log` the script already writes.
`network/compose.log` remains the complete record for the run.

## Validation

Three DevNet runs, all-dingo topology, on this branch:

| Run | Result |
|---|---|
| Third checkpoint timeout cut to 5s to induce the #3180 failure mode | `--- FAIL: TestSustainedConsensus (89.49s)`; `TestSustainedConsensus/observed-chains.json` recorded all four nodes' tip, server tip, roll-forward/roll-backward counts, retained headers and connect churn |
| Same, after bounding the log copy | scenario directory 212 MB to 3.0 MB, evidence intact |
| Unmodified | `--- PASS: TestSustainedConsensus (130.08s)`, three checkpoints verified, four observers following, artifact directory empty on success |
| `--accelerated` | `--- PASS: TestAcceleratedScenarioTimeline (111.31s)`, artifact directory empty on success; it shares the changed capture path and the `Logs` signature |

`go test ./internal/test/devnet/`, `go test -race`, `go vet -tags devnet`,
`golangci-lint run` (0 issues), `nilaway -tags devnet`, `modernize`,
`golines --dry-run`, `make import-boundaries`, `make docs-parity` all pass.

`ARCHITECTURE.md` and `DATABASE.md` were checked and are unaffected; this
is test-harness only. `internal/test/devnet/README.md` is updated.

## Not run

- No `origin/main` timing baseline. Canonical scenarios now open one extra
  inbound ChainSync client per node. The clean run passed with no fork
  detection and the accelerated scenario has done this since #3166, but
  the comparison was not made. The 130s here against the ~100s in #3180 is
  base-slot difference: `-run TestSustainedConsensus` starts just after
  genesis rather than after the warm-up scenarios.
- Conformance topology (`--conformance`) was not run; it shares the changed
  capture path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves per-scenario failure evidence in canonical DevNet runs so stalls are diagnosable. Previously only Go test output and post-teardown compose logs remained; now the harness observes chains during each scenario and, on failure, writes per-scenario artifacts.

- `NewTestHarness` always starts per-node observers and, on `t.Cleanup` of a failed test, writes `observed-chains.json`, `container-status.txt`, and per-service log tails; capture runs only when `DEVNET_ARTIFACT_DIR` is set and endpoints include a `Container`. Side effect: one extra ChainSync client per node.
- Per-service logs are capped to `CapturedLogTailLines`; `network/compose.log` remains the full run log. Capture is best-effort and continues despite individual errors.
- Artifact naming is path-safe and injective by escaping `%`, separators, and characters filesystems rewrite (including Windows-only rules); dot-only names and trailing dot/space are guarded. Case is preserved, so names differing only by case may collide on case-insensitive disks. README and tests document observation vs write timing and scope these guarantees.
- Refactor: move `NodeEndpoint` to `internal/test/devnet/endpoints.go`; plan and write capture in untagged `internal/test/devnet/artifacts.go`; `nodectl` implements `ArtifactSource` and delegates to the shared writer. Tests cover planning, naming, and filesystem behavior across platforms.
- API change: `NodeControl.Logs` now accepts a tail limit (`Logs(ctx, service, tailLines int)`). Migration: callers must pass an explicit tail (use 0 for unbounded).

<sup>Written for commit 61cd71c12f9a858d77f9f142a9bc4782c4be2117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic failure artifacts for DevNet test scenarios, including chain snapshots, container status, and bounded service log tails.
  - Continuously observes chains and captures evidence during cleanup when a scenario fails.
  - Organizes artifacts by safe, unique scenario names for easier investigation.
  - Continues artifact collection despite individual capture errors without obscuring the original test failure.

- **Documentation**
  - Expanded guidance on artifact naming, captured data, prerequisites, cleanup-time collection, and scenario- versus run-level evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
