### PR TITLE
fix(keystore): distinguish an unresolvable DACL trustee from a foreign one

### DIFF
--- a/keystore/keyfile_windows.go
+++ b/keystore/keyfile_windows.go
@@ -19,7 +19,6 @@ package keystore
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
 	"golang.org/x/sys/windows"
@@ -64,9 +63,10 @@ func isKnownNonGrantACEType(aceType string) bool {
 // SDDL string and rejects files that grant access to Everyone,
 // the BUILTIN\Users group, or Authenticated Users.
 //
-// The implementation intentionally avoids the unsafe package to
-// prevent heap corruption caused by Go 1.24+ GC interacting with
-// uintptr-based SID handles (see https://go.dev/issue/73199).
+// The implementation stays inside golang.org/x/sys/windows and does not use
+// the unsafe package, so security descriptor and SID lifetimes stay owned by
+// that package. https://go.dev/issue/73199 was a dangling pointer inside
+// those helpers and was fixed there; hand-rolling them here would reopen it.
 func checkFilePermissions(path string) error {
 	sd, err := windows.GetNamedSecurityInfo(
 		path,
@@ -80,12 +80,8 @@ func checkFilePermissions(path string) error {
 			err,
 		)
 	}
-	// sd is Windows-allocated (LocalAlloc). Freeing it requires
-	// unsafe.Pointer, which we avoid due to Go 1.24+ heap
-	// corruption (go.dev/issue/73199). The ~200 B leak per call
-	// is acceptable: checkFilePermissions runs only at startup
-	// for a handful of key files.
-
+	// GetNamedSecurityInfo frees the Windows heap descriptor itself and
+	// returns a Go-heap copy, so sd needs no explicit free here.
 	return checkSecurityDescriptor(path, sd)
 }
 
@@ -207,20 +203,21 @@ func checkOpenDACL(path, owner, dacl string) error {
 			continue
 		}
 		isOwner, resolveErr := trusteeOwnerMatch(fields[5], owner)
-		if isOwner {
-			continue
-		}
 		if resolveErr != nil {
-			// The trustee could not be resolved to a SID, so we cannot tell
-			// an owner alias from a third party. Say so rather than
-			// reporting it as an unexpected trustee: the two need different
-			// fixes and the message is the only signal available when the
-			// failure only reproduces on another platform.
+			// One side did not resolve to a SID, so an owner alias cannot be
+			// told from a third party. Report that instead of an unexpected
+			// trustee: the two need different fixes, and the wrapped cause
+			// names which side failed, because an owner string that does not
+			// parse arrives here too. Checked before isOwner so that a
+			// future (true, err) return cannot turn a denial into a grant.
 			return fmt.Errorf(
-				"key file %q has DACL trustee %s that could not be resolved "+
-					"to a SID (owner %s): %v: %w",
+				"key file %q has DACL trustee %s that could not be compared "+
+					"with owner %s: %w: %w",
 				path, fields[5], owner, resolveErr, ErrInsecureFileMode,
 			)
+		}
+		if isOwner {
+			continue
 		}
 		return fmt.Errorf(
 			"key file %q grants access to unexpected trustee %s, "+
@@ -249,7 +246,8 @@ func ownerIsBuiltinAdministrators(owner string) bool {
 // A failed resolution is returned as an error rather than folded into a false
 // result, because "could not resolve this alias" and "this trustee is not the
 // owner" need different fixes and the caller's message is the only diagnostic
-// available when the failure reproduces on Windows CI and nowhere else.
+// available when the failure reproduces on Windows CI and nowhere else. It
+// never returns (true, non-nil), so a caller may treat any error as no match.
 //
 // An alias is resolved by asking Windows, not by matching its well-known RID.
 // The local administrator alias (LA) and a domain Administrator share RID 500
@@ -265,41 +263,53 @@ func trusteeOwnerMatch(trustee, owner string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("parse owner SID %q: %w", owner, err)
 	}
-	trusteeSID, keepAlive, err := resolveTrusteeSID(trustee)
+	trusteeSID, err := resolveTrusteeSID(trustee)
 	if err != nil {
 		return false, err
 	}
-	equal := windows.EqualSid(trusteeSID, ownerSID)
-	// trusteeSID may point into keepAlive's allocation; see go.dev/issue/73199.
-	runtime.KeepAlive(keepAlive)
-	runtime.KeepAlive(ownerSID)
-	return equal, nil
+	// No runtime.KeepAlive is needed for either SID. StringToSid returns
+	// (*SID).Copy, a pointer to the base of a Go []byte, and the alias path
+	// returns an interior pointer into a Go-heap descriptor copy; the GC
+	// tracks both. windows.EqualSid then passes both through
+	// syscall.SyscallN, which is //go:uintptrkeepalive, so the compiler
+	// retains both arguments for the duration of the call.
+	return windows.EqualSid(trusteeSID, ownerSID), nil
 }
 
 // resolveTrusteeSID converts an SDDL trustee to a SID, accepting either a SID
 // string or an alias such as LA. Aliases are machine-relative, so they are
 // resolved by Windows rather than reconstructed here.
-func resolveTrusteeSID(
-	trustee string,
-) (*windows.SID, *windows.SECURITY_DESCRIPTOR, error) {
+//
+// ConvertStringSidToSid, behind windows.StringToSid, already accepts the SID
+// string constants, so the first branch handles both canonical SIDs and every
+// alias Windows renders into SDDL. The descriptor round-trip is a fallback for
+// a token that only the SDDL parser accepts, and the error return is for a
+// token neither accepts, which the caller must not treat as a non-owner.
+func resolveTrusteeSID(trustee string) (*windows.SID, error) {
 	if sid, err := windows.StringToSid(trustee); err == nil {
-		return sid, nil, nil
+		return sid, nil
 	}
 	sd, err := windows.SecurityDescriptorFromString("O:" + trustee)
 	if err != nil {
-		return nil, nil, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"resolve trustee alias %q via security descriptor: %w",
 			trustee, err,
 		)
 	}
 	sid, _, err := sd.Owner()
 	if err != nil {
-		return nil, nil, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"read owner from resolved trustee alias %q: %w", trustee, err,
 		)
 	}
-	// The caller must keep sd alive for as long as sid is used.
-	return sid, sd, nil
+	if sid == nil {
+		return nil, fmt.Errorf(
+			"resolved trustee alias %q has no owner SID", trustee,
+		)
+	}
+	// sid is an interior pointer into sd's Go-heap allocation, which keeps
+	// that allocation reachable, so sd need not be returned alongside it.
+	return sid, nil
 }
 
 func sddlSection(sddl, section string) string {

--- a/keystore/keyfile_windows.go
+++ b/keystore/keyfile_windows.go
@@ -19,6 +19,7 @@ package keystore
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"golang.org/x/sys/windows"
@@ -187,22 +188,44 @@ func checkOpenDACL(path, owner, dacl string) error {
 				path, fields[0], ErrInsecureFileMode,
 			)
 		}
-		if allowed[fields[5]] || trusteeIsOwner(fields[5], owner) {
+		if allowed[fields[5]] {
 			continue
 		}
+		isOwner, resolveErr := trusteeOwnerMatch(fields[5], owner)
+		if isOwner {
+			continue
+		}
+		if resolveErr != nil {
+			// The trustee could not be resolved to a SID, so we cannot tell
+			// an owner alias from a third party. Say so rather than
+			// reporting it as an unexpected trustee: the two need different
+			// fixes and the message is the only signal available when the
+			// failure only reproduces on another platform.
+			return fmt.Errorf(
+				"key file %q has DACL trustee %s that could not be resolved "+
+					"to a SID (owner %s): %v: %w",
+				path, fields[5], owner, resolveErr, ErrInsecureFileMode,
+			)
+		}
 		return fmt.Errorf(
-			"key file %q grants access to unexpected trustee %s: %w",
-			path, fields[5], ErrInsecureFileMode,
+			"key file %q grants access to unexpected trustee %s, "+
+				"which is not the owner %s: %w",
+			path, fields[5], owner, ErrInsecureFileMode,
 		)
 	}
 	return nil
 }
 
-// trusteeIsOwner compares a DACL trustee with the descriptor owner. SDDL
+// trusteeOwnerMatch compares a DACL trustee with the descriptor owner. SDDL
 // renders some account SIDs as two-letter aliases, while the owner returned by
 // the security descriptor is a canonical SID, so the strings differ for the
 // same principal — which would reject a valid owner-only DACL on a runner
 // using such an account.
+//
+// A failed resolution is returned as an error rather than folded into a false
+// result, because "could not resolve this alias" and "this trustee is not the
+// owner" need different fixes and the caller's message is the only diagnostic
+// available when the failure reproduces on Windows CI and nowhere else.
 //
 // An alias is resolved by asking Windows, not by matching its well-known RID.
 // The local administrator alias (LA) and a domain Administrator share RID 500
@@ -210,37 +233,49 @@ func checkOpenDACL(path, owner, dacl string) error {
 // domain Administrator owner as satisfying an LA ace and admits a trustee who
 // is not the owner. Round-tripping the alias through a minimal descriptor
 // resolves it against this machine and covers every other alias for free.
-func trusteeIsOwner(trustee, owner string) bool {
+func trusteeOwnerMatch(trustee, owner string) (bool, error) {
 	if trustee == owner {
-		return true
+		return true, nil
 	}
 	ownerSID, err := windows.StringToSid(owner)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("parse owner SID %q: %w", owner, err)
 	}
-	trusteeSID, err := resolveTrusteeSID(trustee)
+	trusteeSID, keepAlive, err := resolveTrusteeSID(trustee)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return windows.EqualSid(trusteeSID, ownerSID)
+	equal := windows.EqualSid(trusteeSID, ownerSID)
+	// trusteeSID may point into keepAlive's allocation; see go.dev/issue/73199.
+	runtime.KeepAlive(keepAlive)
+	runtime.KeepAlive(ownerSID)
+	return equal, nil
 }
 
 // resolveTrusteeSID converts an SDDL trustee to a SID, accepting either a SID
 // string or an alias such as LA. Aliases are machine-relative, so they are
 // resolved by Windows rather than reconstructed here.
-func resolveTrusteeSID(trustee string) (*windows.SID, error) {
+func resolveTrusteeSID(
+	trustee string,
+) (*windows.SID, *windows.SECURITY_DESCRIPTOR, error) {
 	if sid, err := windows.StringToSid(trustee); err == nil {
-		return sid, nil
+		return sid, nil, nil
 	}
 	sd, err := windows.SecurityDescriptorFromString("O:" + trustee)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf(
+			"resolve trustee alias %q via security descriptor: %w",
+			trustee, err,
+		)
 	}
 	sid, _, err := sd.Owner()
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf(
+			"read owner from resolved trustee alias %q: %w", trustee, err,
+		)
 	}
-	return sid, nil
+	// The caller must keep sd alive for as long as sid is used.
+	return sid, sd, nil
 }
 
 func sddlSection(sddl, section string) string {

--- a/keystore/keyfile_windows.go
+++ b/keystore/keyfile_windows.go
@@ -154,23 +154,25 @@ func checkOpenDACL(path, owner, dacl string) error {
 	allowed := map[string]bool{
 		owner: true,
 		"BA":  true, // Built-in Administrators
-		"LA":  true, // Built-in Administrator account
 		"SY":  true, // Local System
 		"CO":  true, // Creator Owner
 		"OW":  true, // Owner Rights
 	}
-	// LA is allowed for the same reason BA is. It is the built-in
-	// Administrator account and a member of Built-in Administrators, so it
-	// reaches the file through BA whether or not its own ACE is present, and
-	// an administrator can take ownership of any file regardless of the DACL.
-	// Admitting BA while rejecting LA rejected a file no less protected than
-	// one the check already accepts.
+	// An ACE for the built-in Administrator account is accepted only when the
+	// file is owned by Built-in Administrators. In that case every member of
+	// that group already has owner-equivalent access, so the LA ace grants
+	// nothing the owner does not already have, and BA itself is allowed above.
 	//
-	// This is not hypothetical: where a file is owned by the Administrators
-	// group (S-1-5-32-544) and carries an ACE for the Administrator account,
-	// owner and trustee are different principals, so the owner comparison does
-	// not cover it. Windows hosts administered that way, and GitHub's Windows
-	// runners, both produce that combination.
+	// The condition is what keeps this narrow. An LA ace on a file owned by
+	// some other principal stays rejected, including the case a domain
+	// Administrator shares RID 500 with the local one and differs only in the
+	// domain part, which trusteeOwnerMatch must not conflate.
+	//
+	// Hosts where files are owned by the Administrators group produce owner BA
+	// with an LA ace, and so do GitHub's Windows runners.
+	if ownerIsBuiltinAdministrators(owner) {
+		allowed["LA"] = true
+	}
 	for {
 		start := strings.IndexByte(dacl, '(')
 		if start < 0 {
@@ -227,6 +229,15 @@ func checkOpenDACL(path, owner, dacl string) error {
 		)
 	}
 	return nil
+}
+
+// ownerIsBuiltinAdministrators reports whether the descriptor owner is the
+// Built-in Administrators group. The group SID is resolved through Windows
+// rather than compared against a literal, matching how trustee aliases are
+// resolved elsewhere in this file.
+func ownerIsBuiltinAdministrators(owner string) bool {
+	match, err := trusteeOwnerMatch("BA", owner)
+	return err == nil && match
 }
 
 // trusteeOwnerMatch compares a DACL trustee with the descriptor owner. SDDL

--- a/keystore/keyfile_windows.go
+++ b/keystore/keyfile_windows.go
@@ -154,10 +154,23 @@ func checkOpenDACL(path, owner, dacl string) error {
 	allowed := map[string]bool{
 		owner: true,
 		"BA":  true, // Built-in Administrators
+		"LA":  true, // Built-in Administrator account
 		"SY":  true, // Local System
 		"CO":  true, // Creator Owner
 		"OW":  true, // Owner Rights
 	}
+	// LA is allowed for the same reason BA is. It is the built-in
+	// Administrator account and a member of Built-in Administrators, so it
+	// reaches the file through BA whether or not its own ACE is present, and
+	// an administrator can take ownership of any file regardless of the DACL.
+	// Admitting BA while rejecting LA rejected a file no less protected than
+	// one the check already accepts.
+	//
+	// This is not hypothetical: where a file is owned by the Administrators
+	// group (S-1-5-32-544) and carries an ACE for the Administrator account,
+	// owner and trustee are different principals, so the owner comparison does
+	// not cover it. Windows hosts administered that way, and GitHub's Windows
+	// runners, both produce that combination.
 	for {
 		start := strings.IndexByte(dacl, '(')
 		if start < 0 {

--- a/keystore/keyfile_windows_test.go
+++ b/keystore/keyfile_windows_test.go
@@ -210,10 +210,19 @@ func TestAdministratorAccountACEAcceptedWindows(t *testing.T) {
 	require.NoError(t, err)
 	ownerSID, _, err := sd.Owner()
 	require.NoError(t, err)
+	// PROTECTED_DACL_SECURITY_INFORMATION, matching setOwnerOnlyDACL. Without
+	// it SetNamedSecurityInfo re-propagates inheritable ACEs from the parent of
+	// t.TempDir(), so the DACL validated below would not be the protected
+	// O:BAD:P(A;;GA;;;LA) written here. On a host whose test account is a named
+	// admin rather than the built-in Administrator, an inherited ACE carries
+	// that account's SID and this "accepted" case would fail for the wrong
+	// reason.
 	require.NoError(t, windows.SetNamedSecurityInfo(
 		testFile,
 		windows.SE_FILE_OBJECT,
-		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+		windows.OWNER_SECURITY_INFORMATION|
+			windows.DACL_SECURITY_INFORMATION|
+			windows.PROTECTED_DACL_SECURITY_INFORMATION,
 		ownerSID, nil, dacl, nil,
 	))
 
@@ -223,7 +232,9 @@ func TestAdministratorAccountACEAcceptedWindows(t *testing.T) {
 	assert.NoError(t, checkOpenFilePermissions(file))
 }
 
-func TestAdministratorAccountACERejectedWhenOwnerIsNotAdministratorsWindows(t *testing.T) {
+func TestAdministratorAccountACERejectedWhenOwnerIsNotAdministratorsWindows(
+	t *testing.T,
+) {
 	// The LA allowance is conditional on the owner being Built-in
 	// Administrators. A file owned by an ordinary principal must not gain an
 	// LA ace for free.
@@ -231,6 +242,57 @@ func TestAdministratorAccountACERejectedWhenOwnerIsNotAdministratorsWindows(t *t
 		"test.skey",
 		"S-1-5-21-999999999-888888888-777777777-1001",
 		"(A;;GR;;;LA)",
+	), ErrInsecureFileMode)
+}
+
+// TestUnresolvableTrusteeDistinguishedFromForeignWindows pins the two error
+// branches this file distinguishes. Both inputs are host-independent: "@@" is
+// neither a SID string nor an SDDL constant, so no host resolves it, and the
+// two account SIDs below are literals no host owns.
+func TestUnresolvableTrusteeDistinguishedFromForeignWindows(t *testing.T) {
+	const owner = "S-1-5-21-1-2-3-1001"
+
+	unresolvable := checkOpenDACL("k.skey", owner, "(A;;FA;;;@@)")
+	require.ErrorIs(t, unresolvable, ErrInsecureFileMode)
+	assert.Contains(t, unresolvable.Error(), "could not be compared")
+	assert.NotContains(t, unresolvable.Error(), "unexpected trustee")
+
+	foreign := checkOpenDACL("k.skey", owner, "(A;;FA;;;S-1-5-21-1-2-3-1002)")
+	require.ErrorIs(t, foreign, ErrInsecureFileMode)
+	assert.Contains(t, foreign.Error(), "unexpected trustee")
+	assert.NotContains(t, foreign.Error(), "could not be compared")
+}
+
+// TestOwnerSIDParseFailureNotBlamedOnTrusteeWindows pins that an owner string
+// that does not parse is reported as such. The trustee here resolves fine, so
+// naming it as the unresolvable side would misdirect the diagnostic.
+func TestOwnerSIDParseFailureNotBlamedOnTrusteeWindows(t *testing.T) {
+	err := checkOpenDACL(
+		"k.skey", "not-a-sid", "(A;;FA;;;S-1-5-21-1-2-3-1002)",
+	)
+	require.ErrorIs(t, err, ErrInsecureFileMode)
+	assert.Contains(t, err.Error(), "parse owner SID")
+
+	// The cause must stay unwrappable rather than be flattened into the
+	// message by %v, so a caller can inspect it with errors.Is or errors.As.
+	var multi interface{ Unwrap() []error }
+	require.ErrorAs(t, err, &multi)
+	assert.Len(t, multi.Unwrap(), 2)
+}
+
+// TestAdministratorsOwnerRejectsForeignTrusteeWindows pins that the
+// conditional LA allowance stays narrow: a file owned by Built-in
+// Administrators admits the LA ace and nothing else new.
+func TestAdministratorsOwnerRejectsForeignTrusteeWindows(t *testing.T) {
+	sd, err := windows.SecurityDescriptorFromString("O:BA")
+	require.NoError(t, err)
+	administrators, _, err := sd.Owner()
+	require.NoError(t, err)
+	owner := administrators.String()
+
+	assert.NoError(t, checkOpenDACL("k.skey", owner, "(A;;GA;;;LA)"))
+	assert.ErrorIs(t, checkOpenDACL(
+		"k.skey", owner, "(A;;GA;;;S-1-5-21-1-2-3-1001)",
 	), ErrInsecureFileMode)
 }
 

--- a/keystore/keyfile_windows_test.go
+++ b/keystore/keyfile_windows_test.go
@@ -223,6 +223,17 @@ func TestAdministratorAccountACEAcceptedWindows(t *testing.T) {
 	assert.NoError(t, checkOpenFilePermissions(file))
 }
 
+func TestAdministratorAccountACERejectedWhenOwnerIsNotAdministratorsWindows(t *testing.T) {
+	// The LA allowance is conditional on the owner being Built-in
+	// Administrators. A file owned by an ordinary principal must not gain an
+	// LA ace for free.
+	assert.ErrorIs(t, checkOpenDACL(
+		"test.skey",
+		"S-1-5-21-999999999-888888888-777777777-1001",
+		"(A;;GR;;;LA)",
+	), ErrInsecureFileMode)
+}
+
 func TestNullDACLFileModeWindows(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.skey")

--- a/keystore/keyfile_windows_test.go
+++ b/keystore/keyfile_windows_test.go
@@ -195,6 +195,34 @@ func TestSecureFileModeWindows(t *testing.T) {
 	assert.NoError(t, checkOpenFilePermissions(file))
 }
 
+func TestAdministratorAccountACEAcceptedWindows(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.skey")
+	require.NoError(t, os.WriteFile(testFile, []byte("test"), 0o600))
+
+	// Owned by the Administrators group with an ACE for the Administrator
+	// account, which is the combination GitHub's Windows runners produce and
+	// which a host administered that way also produces. Owner and trustee are
+	// then different principals, so the owner comparison does not cover it.
+	sd, err := windows.SecurityDescriptorFromString("O:BAD:P(A;;GA;;;LA)")
+	require.NoError(t, err)
+	dacl, _, err := sd.DACL()
+	require.NoError(t, err)
+	ownerSID, _, err := sd.Owner()
+	require.NoError(t, err)
+	require.NoError(t, windows.SetNamedSecurityInfo(
+		testFile,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+		ownerSID, nil, dacl, nil,
+	))
+
+	file, err := os.Open(testFile)
+	require.NoError(t, err)
+	defer file.Close()
+	assert.NoError(t, checkOpenFilePermissions(file))
+}
+
 func TestNullDACLFileModeWindows(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.skey")


### PR DESCRIPTION
The Windows job in the v0.70.0 tag's publish run failed with 69 copies of one
error across the dingo, keystore, ledger/forging and ledger/leios packages:

```
key file "...\vrf.skey" grants access to unexpected trustee LA: insecure file mode
```

`insecure file mode` was the only error text in the job. It also failed
`TestSecureFileModeWindows`, which builds an owner-only DACL from the process
token and then asserts `checkOpenFilePermissions` accepts it, so the trustee
comparison was rejecting a DACL the same package built to be owner-only.

## Changes

`LA` is allowed only when the file is owned by Built-in Administrators. On that
owner every member of the group already has owner-equivalent access and `BA`
itself is allowed, so the ACE grants nothing new; the runners produce exactly
that pairing. An `LA` ace on a file owned by any other principal is still
rejected, including a domain Administrator that shares RID 500 with the local
account and differs only in the domain part.

`trusteeIsOwner` returned a bare bool, so `resolveTrusteeSID` failing to
resolve an SDDL alias was indistinguishable from the trustee genuinely not
being the owner. `trusteeOwnerMatch` now returns the resolution error and the
caller reports the two cases separately, naming the owner SID. The old message
named the trustee but never what it was compared against, which is what
separates an alias that failed to resolve from a real third-party ACE.

Aliases are resolved by asking Windows, not by matching a well-known RID. A
suffix match on `-500` would treat a domain Administrator owner as satisfying
an `LA` ace.

The three `runtime.KeepAlive` calls are removed rather than extended.
`syscall.SyscallN` is `//go:uintptrkeepalive`, so `windows.EqualSid` already
retains both arguments across the call, and both SID paths point into
Go-managed memory: `StringToSid` returns a pointer to the base of a Go
`[]byte`, and the alias path returns an interior pointer into a Go-heap
descriptor copy. A caller-side `KeepAlive` adds nothing on either.

## Validation

`GOOS=windows GOARCH=amd64 go build ./...` and `go vet ./keystore/`, which
compiles the `_test.go` files, plus `gofmt`, `golines` and `golangci-lint`.
Linux `go build ./...` and `go test ./keystore/` are unaffected.

Skipped: the Windows code is behind a build tag and cannot run on the
development host, so its runtime behaviour is unverified here. The Windows CI
job is the first execution of these tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows keystore security validation by accurately matching owners and trustees.
  * Added clearer error messages when Windows account or trustee resolution fails.
  * Improved handling of security descriptor resources to prevent validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
