### PR TITLE
ci: run Windows tests off the release path with runaway guards

### DIFF
--- a/.github/workflows/go-test-windows.yml
+++ b/.github/workflows/go-test-windows.yml
@@ -1,0 +1,72 @@
+name: go-test-windows
+
+# Windows was dropped from PR CI in #3070 to reduce Actions usage, and it had a
+# history of getting stuck rather than failing. Both are addressed here: this
+# does not run per-PR, and a stuck run is bounded at three levels instead of
+# inheriting GitHub's 360-minute default.
+#
+# Windows-only breakage previously became visible only when a release tag was
+# pushed, because publish.yml is the only workflow that runs Windows. That cost
+# the v0.70.0 tag: PR CI was green, the tag's go-test (windows-latest) failed,
+# and build-binaries, build-images and finalize-release were all skipped.
+# Running on pushes to main puts that signal before the tag.
+on:
+  # Validate a branch before merging it, without paying on every PR.
+  workflow_dispatch:
+  # Catch Windows-only breakage after merge and before anyone tags.
+  push:
+    branches: ['main']
+
+# A force-push or a run of pushes must not accumulate Windows runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go-test-windows:
+    name: go-test (windows-latest) (${{ matrix.go-version }})
+    strategy:
+      matrix:
+        go-version: [1.26.x]
+    runs-on: windows-latest
+    # Outermost backstop. The observed full Windows suite runs about 22 minutes,
+    # so this is roughly double a legitimate run. Its real job is replacing
+    # GitHub's 360-minute default: a wedged run costs 45 minutes of a shared
+    # Windows runner instead of six hours.
+    timeout-minutes: 45
+    env:
+      CGO_ENABLED: 0
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
+      - name: go-build
+        run: go build ./...
+      - name: go-test
+        # Three nested bounds, innermost first, so the most informative one
+        # fires soonest:
+        #
+        #   go -timeout 20m  per test binary; panics with a goroutine dump that
+        #                    names the stuck test. A runner-level kill gives no
+        #                    such diagnostic, which is why a stuck Windows job
+        #                    was previously hard to attribute.
+        #   step 35m         bounds the whole suite if several packages are slow
+        #                    without any single one exceeding its own timeout.
+        #   job  45m         above, covers checkout, setup-go and the build too.
+        #
+        # 20m matches the Linux PR job. It is not tight on Windows: the root
+        # dingo package alone took 937s in the v0.70.0 tag run.
+        timeout-minutes: 35
+        run: go test -ldflags="-s -w" -timeout 20m ./...

--- a/.github/workflows/go-test-windows.yml
+++ b/.github/workflows/go-test-windows.yml
@@ -32,11 +32,12 @@ jobs:
       matrix:
         go-version: [1.26.x]
     runs-on: windows-latest
-    # Outermost backstop. The observed full Windows suite runs about 22 minutes,
-    # so this is roughly double a legitimate run. Its real job is replacing
-    # GitHub's 360-minute default: a wedged run costs 45 minutes of a shared
-    # Windows runner instead of six hours.
-    timeout-minutes: 45
+    # Only backstop, and deliberately generous. It matches the Windows job in
+    # publish.yml, which is the same command on the same runner, so this job
+    # cannot false-fail on timing where the release job passes. Its purpose is
+    # replacing GitHub's 360-minute default: a wedged run holds a shared Windows
+    # runner for 90 minutes rather than six hours.
+    timeout-minutes: 90
     env:
       CGO_ENABLED: 0
     steps:
@@ -55,18 +56,14 @@ jobs:
       - name: go-build
         run: go build ./...
       - name: go-test
-        # Three nested bounds, innermost first, so the most informative one
-        # fires soonest:
+        # -timeout is the diagnostic: it panics with a goroutine dump naming the
+        # stuck test, which a runner-level kill does not produce. 20m matches
+        # both the Linux PR job and the Windows job in publish.yml.
         #
-        #   go -timeout 20m  per test binary; panics with a goroutine dump that
-        #                    names the stuck test. A runner-level kill gives no
-        #                    such diagnostic, which is why a stuck Windows job
-        #                    was previously hard to attribute.
-        #   step 35m         bounds the whole suite if several packages are slow
-        #                    without any single one exceeding its own timeout.
-        #   job  45m         above, covers checkout, setup-go and the build too.
-        #
-        # 20m matches the Linux PR job. It is not tight on Windows: the root
-        # dingo package alone took 937s in the v0.70.0 tag run.
-        timeout-minutes: 35
+        # There is deliberately no step-level cap. A step or job kill reports no
+        # stuck test, so an intermediate bound tight enough to be useful is also
+        # tight enough to kill a slow-but-healthy run and destroy the
+        # attribution this workflow exists to provide. The slowest package took
+        # 937s in the v0.70.0 tag run, on a run that was failing, so the margin
+        # on a shared runner is thinner than it looks.
         run: go test -ldflags="-s -w" -timeout 20m ./...


### PR DESCRIPTION
Adds a Windows test job outside the release path.

Windows previously ran only in publish.yml, gated on a tag. A Windows-only
failure was therefore not visible until a release was cut, and the v0.70.0 tag
failed on go-test (windows-latest), skipping build-binaries, build-images and
finalize-release.

Triggers are push to main and workflow_dispatch, not pull_request, so this does
not restore the per-PR Actions usage removed in #3070.

Bounds on a stuck run:

- go test -timeout 20m per test binary, which panics with a goroutine dump
  naming the stuck test. Matches the Linux PR job and the Windows job in
  publish.yml.
- job timeout-minutes 90, matching publish.yml's Windows job so this job cannot
  fail on timing where the release job passes. Replaces GitHub's 360-minute
  default.
- concurrency with cancel-in-progress, so a force-push or a run of merges does
  not accumulate Windows runners.

There is no step-level cap. A step or job kill reports no stuck test, so an
intermediate bound tight enough to be useful is also tight enough to kill a slow
but healthy run.

Validated with actionlint, a YAML parse, and GOOS=windows GOARCH=amd64
CGO_ENABLED=0 go build ./... plus go vet over the packages that failed the tag
run. The workflow cannot execute until it is on the default branch.
