### PR TITLE
feat(ci): add benchmark regression detection

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,7 +80,13 @@ jobs:
           set -euo pipefail
           date_stamp=$(date -u +%Y-%m-%d)
           short_sha=$(git rev-parse --short HEAD)
-          run_file="../benchmark-data-branch/runs/${date_stamp}-${short_sha}.txt"
+          # GITHUB_RUN_ID-GITHUB_RUN_ATTEMPT makes the filename unique even
+          # when the same commit is re-run on the same day (a failed run
+          # retried, or a manual workflow_dispatch shortly after a scheduled
+          # run) -- otherwise a rerun's `tee` truncates the very file a
+          # concurrent or prior run is using as its baseline, and the
+          # comparison silently degrades to "compare a file against itself".
+          run_file="../benchmark-data-branch/runs/${date_stamp}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${short_sha}.txt"
           echo "run_file=${run_file}" >> "$GITHUB_OUTPUT"
           make bench-ci | tee "${run_file}"
 
@@ -92,12 +98,29 @@ jobs:
         # and latest.txt together, but tolerate it rather than hard-failing
         # on a manually-tampered branch).
         if: steps.benchmark-data.outputs.bootstrap == 'false' && steps.benchmark-data.outputs.baseline_file != ''
+        # baseline_file/run_file are passed through env instead of interpolated
+        # directly into the script below: a `${{ ... }}` expansion splices its
+        # value into the generated shell script as literal text before bash
+        # ever parses it, so an unexpected value (e.g. a tampered
+        # benchmark-data branch) could inject shell syntax rather than being
+        # treated as a plain argument. Referencing "$BASELINE_FILE"/"$RUN_FILE"
+        # is normal variable expansion and cannot re-parse as script.
+        env:
+          BASELINE_FILE: ${{ steps.benchmark-data.outputs.baseline_file }}
+          RUN_FILE: ${{ steps.run-bench.outputs.run_file }}
         shell: bash
         run: |
           set -euo pipefail
+          # Belt-and-suspenders: reject anything that isn't a filename this
+          # workflow could have produced itself, in case benchmark-data was
+          # tampered with between runs.
+          if [[ ! "$(basename "${BASELINE_FILE}")" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-[0-9]+-[0-9a-f]{4,40}\.txt$ ]]; then
+            echo "baseline_file has an unexpected name: ${BASELINE_FILE}" >&2
+            exit 1
+          fi
           go run ./internal/benchci/cmd/benchcheck \
-            "${{ steps.benchmark-data.outputs.baseline_file }}" \
-            "${{ steps.run-bench.outputs.run_file }}" \
+            "${BASELINE_FILE}" \
+            "${RUN_FILE}" \
             report.md | tee -a "$GITHUB_OUTPUT"
 
       - name: write-step-summary
@@ -123,10 +146,14 @@ jobs:
       # benchmark-data worktree created above (checked out one level above
       # the main checkout, so Go tooling in earlier steps never scans it).
       - name: publish-benchmark-data
+        # Same reasoning as check-regression: pass the step output through
+        # env rather than interpolating it directly into the script.
+        env:
+          RUN_FILE: ${{ steps.run-bench.outputs.run_file }}
         shell: bash
         run: |
           set -euo pipefail
-          run_file="${{ steps.run-bench.outputs.run_file }}"
+          run_file="${RUN_FILE}"
           basename "${run_file}" > ../benchmark-data-branch/runs/latest.txt
 
           cutoff=$(date -u -d '104 weeks ago' +%Y-%m-%d)
@@ -157,6 +184,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # gh issue create fails outright if the label doesn't exist yet;
+          # this repo doesn't have "performance-regression" pre-provisioned,
+          # so create it on first use. Idempotent: gh label create fails
+          # (non-fatal here) if it already exists.
+          gh label create performance-regression \
+            --color b60205 \
+            --description "Weekly benchmark run flagged a >5% significant regression" \
+            2>/dev/null || true
           existing=$(gh issue list \
             --search 'in:title "Benchmark regression tracker"' \
             --label performance-regression \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,6 +68,17 @@ jobs:
           fi
           mkdir -p ../benchmark-data-branch/runs
 
+          # Checked here, unconditionally, rather than only in check-regression:
+          # run-bench-ci writes the new result into runs/ on every invocation
+          # (including bootstrap, where check-regression does not even run),
+          # so a tampered benchmark-data branch that replaced runs/ with a
+          # symlink would have its target written to by `tee` before any
+          # later guard could reject it.
+          if [[ -L ../benchmark-data-branch/runs ]]; then
+            echo "../benchmark-data-branch/runs is unexpectedly a symlink; refusing to continue" >&2
+            exit 1
+          fi
+
           if [ -f ../benchmark-data-branch/runs/latest.txt ]; then
             baseline=$(cat ../benchmark-data-branch/runs/latest.txt)
             echo "baseline_file=../benchmark-data-branch/runs/${baseline}" >> "$GITHUB_OUTPUT"
@@ -116,12 +127,11 @@ jobs:
           # was tampered with between runs. Validating only the basename is
           # not enough -- runs/latest.txt containing "../other/<valid-name>"
           # would still pass a basename-only check while resolving outside
-          # runs/, so the full path is matched here instead. A path that
-          # matches the pattern textually can still escape runs/ if the
-          # branch replaced the runs/ directory or the target file itself
-          # with a symlink, so both are rejected too.
+          # runs/, so the full path is matched here instead. runs/ itself
+          # being a symlink is already rejected in prepare-benchmark-data-branch
+          # (before run-bench-ci ever writes into it); this only needs to
+          # additionally reject the target file itself being a symlink.
           if [[ ! "${BASELINE_FILE}" =~ ^\.\./benchmark-data-branch/runs/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-[0-9]+-[0-9a-f]{4,40}\.txt$ ]] \
-            || [[ -L ../benchmark-data-branch/runs ]] \
             || [[ -L "${BASELINE_FILE}" ]]; then
             echo "baseline_file has an unexpected path: ${BASELINE_FILE}" >&2
             exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,173 @@
+name: benchmark
+
+# Runs the curated CI benchmark suite (blinklabs-io/dingo#1895) weekly rather
+# than per-PR/per-merge: a statistically meaningful pass (`-count=10` for
+# benchstat) takes well over an hour, which would make every merge slow.
+# Because there is no PR to comment on, regression alerts go to a persistent
+# tracking issue instead (see the "report-regression" job below).
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Monday 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark
+  cancel-in-progress: false # never kill a multi-hour run partway through
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: write # push results to the benchmark-data branch
+      issues: write # open/comment on the regression tracking issue
+    steps:
+      - name: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+        with:
+          ref: main
+
+      - name: setup-go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: 1.26.x
+
+      - name: cache-go-modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-1.26.x-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-1.26.x-
+
+      # Prepares a linked worktree (sharing the main checkout's authenticated
+      # `origin` remote, so a plain `git push` later just works) checked out
+      # to the benchmark-data branch. First-run bootstrap: if the branch
+      # doesn't exist on origin yet, create it locally as an empty orphan
+      # branch instead of failing.
+      - name: prepare-benchmark-data-branch
+        id: benchmark-data
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin benchmark-data >/dev/null 2>&1; then
+            git fetch origin benchmark-data:refs/remotes/origin/benchmark-data
+            git worktree add ../benchmark-data-branch origin/benchmark-data
+            echo "bootstrap=false" >> "$GITHUB_OUTPUT"
+          else
+            git worktree add --detach ../benchmark-data-branch HEAD
+            git -C ../benchmark-data-branch checkout --orphan benchmark-data
+            git -C ../benchmark-data-branch rm -rf . >/dev/null 2>&1 || true
+            git -C ../benchmark-data-branch clean -fdx
+            echo "bootstrap=true" >> "$GITHUB_OUTPUT"
+          fi
+          mkdir -p ../benchmark-data-branch/runs
+
+          if [ -f ../benchmark-data-branch/runs/latest.txt ]; then
+            baseline=$(cat ../benchmark-data-branch/runs/latest.txt)
+            echo "baseline_file=../benchmark-data-branch/runs/${baseline}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: run-bench-ci
+        id: run-bench
+        shell: bash
+        run: |
+          set -euo pipefail
+          date_stamp=$(date -u +%Y-%m-%d)
+          short_sha=$(git rev-parse --short HEAD)
+          run_file="../benchmark-data-branch/runs/${date_stamp}-${short_sha}.txt"
+          echo "run_file=${run_file}" >> "$GITHUB_OUTPUT"
+          make bench-ci | tee "${run_file}"
+
+      - name: check-regression
+        id: benchcheck
+        # baseline_file is only unset when bootstrap=false but runs/latest.txt
+        # is missing from an existing benchmark-data branch (a state this
+        # workflow never produces itself, since it always writes the run file
+        # and latest.txt together, but tolerate it rather than hard-failing
+        # on a manually-tampered branch).
+        if: steps.benchmark-data.outputs.bootstrap == 'false' && steps.benchmark-data.outputs.baseline_file != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          go run ./internal/benchci/cmd/benchcheck \
+            "${{ steps.benchmark-data.outputs.baseline_file }}" \
+            "${{ steps.run-bench.outputs.run_file }}" \
+            report.md | tee -a "$GITHUB_OUTPUT"
+
+      - name: write-step-summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f report.md ]; then
+            {
+              echo "## Benchmark regression report"
+              echo
+              cat report.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Benchmark regression report"
+              echo
+              echo "No prior baseline available on the \`benchmark-data\` branch (first run, or a missing \`runs/latest.txt\`). This run was recorded as a new baseline; regression detection resumes next run."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Commits and pushes the new run file (and updated runs/latest.txt,
+      # with entries older than 104 weeks pruned) in one commit, using the
+      # benchmark-data worktree created above (checked out one level above
+      # the main checkout, so Go tooling in earlier steps never scans it).
+      - name: publish-benchmark-data
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_file="${{ steps.run-bench.outputs.run_file }}"
+          basename "${run_file}" > ../benchmark-data-branch/runs/latest.txt
+
+          cutoff=$(date -u -d '104 weeks ago' +%Y-%m-%d)
+          for f in ../benchmark-data-branch/runs/*.txt; do
+            base=$(basename "${f}")
+            [ "${base}" = "latest.txt" ] && continue
+            file_date="${base:0:10}"
+            if [[ "${file_date}" < "${cutoff}" ]]; then
+              rm -f "${f}"
+            fi
+          done
+
+          cd ../benchmark-data-branch
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add runs
+          if git diff --cached --quiet; then
+            echo "no benchmark-data changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(benchmark-data): add run $(basename "${run_file}")"
+          git push origin HEAD:benchmark-data
+
+      - name: report-regression
+        if: steps.benchcheck.outputs.regression == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list \
+            --search 'in:title "Benchmark regression tracker"' \
+            --label performance-regression \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file report.md
+          else
+            gh issue create \
+              --title "Benchmark regression tracker" \
+              --label performance-regression \
+              --body-file report.md
+          fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -116,8 +116,13 @@ jobs:
           # was tampered with between runs. Validating only the basename is
           # not enough -- runs/latest.txt containing "../other/<valid-name>"
           # would still pass a basename-only check while resolving outside
-          # runs/, so the full path is matched here instead.
-          if [[ ! "${BASELINE_FILE}" =~ ^\.\./benchmark-data-branch/runs/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-[0-9]+-[0-9a-f]{4,40}\.txt$ ]]; then
+          # runs/, so the full path is matched here instead. A path that
+          # matches the pattern textually can still escape runs/ if the
+          # branch replaced the runs/ directory or the target file itself
+          # with a symlink, so both are rejected too.
+          if [[ ! "${BASELINE_FILE}" =~ ^\.\./benchmark-data-branch/runs/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-[0-9]+-[0-9a-f]{4,40}\.txt$ ]] \
+            || [[ -L ../benchmark-data-branch/runs ]] \
+            || [[ -L "${BASELINE_FILE}" ]]; then
             echo "baseline_file has an unexpected path: ${BASELINE_FILE}" >&2
             exit 1
           fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,11 +111,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Belt-and-suspenders: reject anything that isn't a filename this
-          # workflow could have produced itself, in case benchmark-data was
-          # tampered with between runs.
-          if [[ ! "$(basename "${BASELINE_FILE}")" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-[0-9]+-[0-9a-f]{4,40}\.txt$ ]]; then
-            echo "baseline_file has an unexpected name: ${BASELINE_FILE}" >&2
+          # Belt-and-suspenders: reject anything that isn't exactly the path
+          # this workflow could have produced itself, in case benchmark-data
+          # was tampered with between runs. Validating only the basename is
+          # not enough -- runs/latest.txt containing "../other/<valid-name>"
+          # would still pass a basename-only check while resolving outside
+          # runs/, so the full path is matched here instead.
+          if [[ ! "${BASELINE_FILE}" =~ ^\.\./benchmark-data-branch/runs/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-[0-9]+-[0-9a-f]{4,40}\.txt$ ]]; then
+            echo "baseline_file has an unexpected path: ${BASELINE_FILE}" >&2
             exit 1
           fi
           go run ./internal/benchci/cmd/benchcheck \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ GO_TAG_FLAGS=$(if $(strip $(BUILD_TAGS)),-tags "$(BUILD_TAGS)",)
 # run modernize only against hand-written packages to avoid generator drift.
 MODERNIZE_PACKAGES=$(shell go list $(GO_TAG_FLAGS) -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... | grep -Ev '/database/plugin/(blob/(aws|gcs)|metadata/(mysql|postgres)|metadata/sqlstore/internal/query/(mysql|postgres|sqlite))$$|/midnight$$')
 
-.PHONY: all build help install uninstall mod-tidy clean format golines lint import-boundaries docs-parity proto sql sql-check gorm-check test bench bench-mempool bench-mempool-normal bench-mempool-degenerate bench-mempool-revalidation test-load test-load-log test-load-profile test-devnet
+.PHONY: all build help install uninstall mod-tidy clean format golines lint import-boundaries docs-parity proto sql sql-check gorm-check test bench bench-ci bench-mempool bench-mempool-normal bench-mempool-degenerate bench-mempool-revalidation test-load test-load-log test-load-profile test-devnet
 
 # Default target
 all: format build ## Format and build (default)
@@ -127,6 +127,10 @@ test: mod-tidy ## Run mod-tidy, then all tests with race detection
 
 bench: mod-tidy ## Run mod-tidy, then benchmarks
 	go test $(GO_TAG_FLAGS) -run=^$$ -bench=. -benchmem ./...
+
+bench-ci: mod-tidy ## Run mod-tidy, then the curated CI benchmark suite (count=10) plus a GOMAXPROCS lock-contention sweep
+	go test $(GO_TAG_FLAGS) -run=^$$ -bench='^Benchmark(BlockProcessingThroughput|BlockProcessingThroughputPredecoded|BlockBatchProcessingThroughput|RawBlockBatchProcessingThroughput|VerifyBlockHeader|TransactionValidation|ChainSyncFromGenesis|RealBlockProcessing|EraTransitionPerformanceRealData|TestLoad|BlockfetchNearTipThroughput|BlockfetchNearTipThroughputPredecoded|BlockfetchNearTipFlushOnlyPredecoded|BlockfetchNearTipQueuedHeaderPredecoded|BlockfetchVerifiedHeaderDispatch|BlockfetchClientBlockMetrics|UpdateConnectionMetrics|HasInboundPeerAddress|Reconcile|PublishSubscribers|BlockMemoryUsage|HotCacheGet|HotCachePut|HotCacheGetMiss|BlockLRUCacheGet|BlockLRUCachePut|TieredCacheHotHit|CachedBlockExtract|CborOffsetEncode|CborOffsetDecode|StorageModeIngest|StorageModeIngestSteadyState)$$' -benchmem -count=10 -timeout=90m ./...
+	go test $(GO_TAG_FLAGS) -run=^$$ -bench='^Benchmark(BlockLRUParallelReadHeavy|BlockLRUParallelBalanced|BlockLRUParallelReadOnly|HotCacheParallelGet|TryReserveInboundSlotParallel|ConcurrentQueries|TipSnapshotReadOnly|TipSnapshotReadUnderWriter)$$' -benchmem -count=10 -cpu=1,4,8,16 -timeout=30m ./...
 
 bench-mempool-revalidation: ## Benchmark FIFO admission during normal and degenerate rebuilds
 	go test $(GO_TAG_FLAGS) -run=^$$ -bench='^BenchmarkFIFO(AdmissionNoRevalidation|Revalidation)$$' -benchmem ./mempool

--- a/internal/benchci/benchci.go
+++ b/internal/benchci/benchci.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package benchci implements CI benchmark regression detection for Dingo's
+// weekly benchmark workflow (blinklabs-io/dingo#1895). It shells out to
+// golang.org/x/perf/cmd/benchstat to compare two `go test -bench`-format
+// result files, restricts the comparison to a curated set of benchmark
+// names, and flags a benchmark as regressed only when both:
+//
+//   - its "sec/op" delta exceeds RegressionThresholdPercent, and
+//   - benchstat marked that delta statistically significant (i.e. it did
+//     not print the "~" marker).
+//
+// The AND-of-both-signals is a deliberate mitigation for GitHub-hosted
+// runner timing noise: a large delta with high variance (not significant)
+// and a small statistically-clean delta (below threshold) are both treated
+// as non-regressions.
+package benchci
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// BenchstatVersion pins golang.org/x/perf/cmd/benchstat, mirroring the
+	// Makefile's one-shot-CLI convention for sqlc
+	// (`SQLC = go run github.com/sqlc-dev/sqlc/cmd/sqlc@$(SQLC_VERSION)`):
+	// invoked via `go run <module>@<version>` with no go.mod entry.
+	//
+	// golang.org/x/perf has never published a semver-tagged release --
+	// https://proxy.golang.org/golang.org/x/perf/@v/list returns an empty
+	// body, confirming there is no vX.Y.Z tag to pin to -- so the pin here
+	// is necessarily a commit pseudo-version rather than a tagged version.
+	BenchstatVersion = "v0.0.0-20260819171926-ebcb4798430d"
+
+	benchstatModule = "golang.org/x/perf/cmd/benchstat@" + BenchstatVersion
+
+	// RegressionThresholdPercent is the minimum "sec/op" delta, in percent,
+	// that (combined with benchstat-reported statistical significance)
+	// flags a curated benchmark as regressed. Matches the 5% figure from
+	// issue #1895.
+	RegressionThresholdPercent = 5.0
+
+	// secOpMetric is the metric name benchstat prints in the CSV header of
+	// its primary timing table (its other tables are "B/op" and
+	// "allocs/op" when the benchmarks call b.ReportAllocs(), which our
+	// curated benchmarks do not track for regression purposes).
+	secOpMetric = "sec/op"
+
+	// nonSignificantMarker is the exact string benchstat prints in the
+	// delta column instead of a percentage when it did not consider the
+	// change statistically significant at its alpha level (default 0.05).
+	nonSignificantMarker = "~"
+)
+
+// gomaxprocsSuffix matches the trailing "-<GOMAXPROCS>" go test appends to
+// every benchmark name (e.g. "BenchmarkFoo-8"), including under a -cpu
+// sweep where the same base name recurs once per swept value.
+var gomaxprocsSuffix = regexp.MustCompile(`-[0-9]+$`)
+
+// Row is one curated benchmark's old-vs-new "sec/op" comparison.
+type Row struct {
+	// Name is the full benchstat row name, including any trailing
+	// "-<GOMAXPROCS>" suffix (e.g. "BenchmarkConcurrentQueries-16").
+	Name string
+	// Old and New are human-readable durations (e.g. "634.9ns"), empty
+	// when Found is false.
+	Old, New string
+	// DeltaPercent is the signed percent change benchstat reported.
+	// Meaningless (and zero) when Significant is false.
+	DeltaPercent float64
+	// Significant reports whether benchstat did not print "~" for this
+	// row's delta.
+	Significant bool
+	// Found reports whether this benchmark appeared in benchstat's
+	// "sec/op" table at all. False means it was skipped, renamed, removed,
+	// or otherwise absent from one or both input files.
+	Found bool
+	// Flagged reports whether this row counts as a regression: Found,
+	// Significant, and DeltaPercent > RegressionThresholdPercent.
+	Flagged bool
+}
+
+// Compare shells out to benchstat to compare oldFile against newFile (both
+// in `go test -bench`/benchstat text format), restricts the result to the
+// given curated benchmark names, and renders a markdown report. It returns
+// the report text and whether any curated row regressed.
+//
+// curated names are matched against benchstat's row names tolerating a
+// trailing "-<GOMAXPROCS>" suffix, so a single curated name (e.g.
+// "BenchmarkConcurrentQueries") matches every GOMAXPROCS variant present in
+// the input (e.g. under -cpu=1,4,8,16) and each variant is reported as its
+// own row.
+func Compare(oldFile, newFile string, curated []string) (string, bool, error) {
+	csv, err := runBenchstat(oldFile, newFile)
+	if err != nil {
+		return "", false, err
+	}
+	return Report(csv, curated)
+}
+
+// Report parses raw `benchstat -format=csv` output and renders the curated
+// markdown regression report. It is split out from Compare so tests can
+// exercise the parsing/flagging logic against fixture CSV text without
+// shelling out to benchstat.
+func Report(csv string, curated []string) (string, bool, error) {
+	rows, err := parseSecOpTable(csv)
+	if err != nil {
+		return "", false, err
+	}
+	results := evaluateCurated(rows, curated)
+	return renderMarkdown(results), anyFlagged(results), nil
+}
+
+func anyFlagged(results []Row) bool {
+	for _, r := range results {
+		if r.Flagged {
+			return true
+		}
+	}
+	return false
+}
+
+func runBenchstat(oldFile, newFile string) (string, error) {
+	// oldFile/newFile are workflow-controlled local file paths (a prior
+	// benchmark-data run file and this run's fresh output), not
+	// attacker-influenced input; benchstatModule is a compile-time constant.
+	cmd := exec.Command("go", "run", benchstatModule, "-format=csv", oldFile, newFile) //nolint:gosec // G204: paths are workflow-controlled, not attacker input
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf(
+			"benchci: benchstat %s %s: %w (stderr: %s)",
+			oldFile, newFile, err, strings.TrimSpace(stderr.String()),
+		)
+	}
+	return stdout.String(), nil
+}
+
+// benchstatRow is one raw data row parsed from benchstat's CSV "sec/op"
+// table.
+type benchstatRow struct {
+	old, new     string
+	deltaPercent float64
+	significant  bool
+}
+
+// parseSecOpTable extracts every data row from benchstat's "sec/op" CSV
+// table(s), keyed by full row name (including any "-<GOMAXPROCS>" suffix).
+//
+// benchstat's CSV output (verified directly against
+// `go run golang.org/x/perf/cmd/benchstat@<BenchstatVersion> -format=csv`)
+// is organized as blocks separated by a single blank line. A block may open
+// with zero or more bare "key: value" metadata lines (goos/goarch/pkg/cpu --
+// "pkg:" alone recurs before each new package's tables when the input spans
+// multiple packages), followed by a ",<old file>,,<new file>,,," header row
+// and a ",<metric>,CI,<metric>,CI,vs base,P" row identifying the table's
+// metric ("sec/op", "B/op", or "allocs/op"), then one data row per
+// benchmark, then a trailing "geomean" row. Only "sec/op" blocks are kept.
+func parseSecOpTable(csv string) (map[string]benchstatRow, error) {
+	csv = strings.ReplaceAll(csv, "\r\n", "\n")
+	blocks := strings.Split(strings.TrimRight(csv, "\n"), "\n\n")
+
+	rows := make(map[string]benchstatRow)
+	foundSecOpTable := false
+	for _, block := range blocks {
+		lines := strings.Split(block, "\n")
+		for len(lines) > 0 && !strings.Contains(lines[0], ",") {
+			lines = lines[1:]
+		}
+		if len(lines) < 2 {
+			continue
+		}
+		metricHeader := strings.Split(lines[1], ",")
+		if len(metricHeader) < 2 || metricHeader[1] != secOpMetric {
+			continue
+		}
+		foundSecOpTable = true
+		for _, line := range lines[2:] {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			fields := strings.Split(line, ",")
+			if len(fields) < 6 {
+				continue
+			}
+			name := fields[0]
+			if name == "geomean" {
+				continue
+			}
+			oldSeconds, oldErr := strconv.ParseFloat(fields[1], 64)
+			newSeconds, newErr := strconv.ParseFloat(fields[3], 64)
+			deltaPercent, significant, deltaOK := parseDelta(fields[5])
+			if oldErr != nil || newErr != nil || !deltaOK {
+				// benchstat couldn't compute a clean comparison for this
+				// row (e.g. one side missing); leave it out so the
+				// corresponding curated benchmark reports Found=false
+				// rather than a fabricated value.
+				continue
+			}
+			rows[name] = benchstatRow{
+				old:          formatSeconds(oldSeconds),
+				new:          formatSeconds(newSeconds),
+				deltaPercent: deltaPercent,
+				significant:  significant,
+			}
+		}
+	}
+	if !foundSecOpTable {
+		return nil, fmt.Errorf("benchci: no %q table found in benchstat output", secOpMetric)
+	}
+	return rows, nil
+}
+
+// parseDelta parses benchstat's "vs base" delta column: either the literal
+// non-significant marker "~", or a signed percentage such as "+49.27%" or
+// "-50.60%".
+func parseDelta(field string) (percent float64, significant bool, ok bool) {
+	field = strings.TrimSpace(field)
+	if field == nonSignificantMarker {
+		return 0, false, true
+	}
+	v, err := strconv.ParseFloat(strings.TrimSuffix(field, "%"), 64)
+	if err != nil {
+		return 0, false, false
+	}
+	return v, true, true
+}
+
+// formatSeconds renders a benchstat "sec/op" value (a raw float64 number of
+// seconds) as a human-readable duration, e.g. 6.3495e-07 -> "634.95ns" ->
+// (rounded to the nearest nanosecond) "635ns".
+func formatSeconds(seconds float64) string {
+	return time.Duration(math.Round(seconds * float64(time.Second))).String()
+}
+
+// evaluateCurated matches every curated benchmark name against benchstat's
+// parsed row names, tolerating a trailing "-<GOMAXPROCS>" suffix and a
+// "/<subname>" sub-benchmark path.
+//
+// Two real-world wrinkles, both verified directly against real `go test`
+// runs rather than assumed:
+//
+//   - benchstat's default row naming strips the leading "Benchmark"
+//     (`go test -bench=BenchmarkHotCacheGet` compared with benchstat prints
+//     its row as "HotCacheGet-10", not "BenchmarkHotCacheGet-10"), so
+//     curated names (which carry the prefix, as they appear in Go source
+//     and the Makefile -bench regex) are compared with "Benchmark" trimmed
+//     from both sides.
+//   - Several curated benchmarks (e.g. BenchmarkUpdateConnectionMetrics,
+//     BenchmarkVerifyBlockHeader, BenchmarkStorageModeIngest,
+//     BenchmarkTestLoad) call b.Run internally, so their rows appear as
+//     "UpdateConnectionMetrics/1000-10", never as a bare
+//     "UpdateConnectionMetrics-10". A curated name therefore matches a row
+//     whose GOMAXPROCS-stripped name equals it exactly OR starts with it
+//     plus "/", and every matching sub-benchmark is reported as its own Row.
+//
+// A curated name can match multiple rows (one per swept GOMAXPROCS value,
+// one per sub-benchmark, or both); every match is reported as its own Row,
+// in ascending row-name order, with its display Name reconstructed with the
+// "Benchmark" prefix restored for readability. A curated name with no match
+// at all is reported as a single not-found Row so missing data is visible
+// rather than silently dropped.
+func evaluateCurated(rows map[string]benchstatRow, curated []string) []Row {
+	names := make([]string, 0, len(rows))
+	for name := range rows {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	results := make([]Row, 0, len(curated))
+	for _, base := range curated {
+		shortBase := strings.TrimPrefix(base, "Benchmark")
+		matched := false
+		for _, name := range names {
+			// nameNoPrefix strips a "Benchmark" prefix if present (real
+			// benchstat output never has one, but tolerate it for
+			// robustness) without touching the "-<GOMAXPROCS>" suffix or
+			// any "/<subname>" path, so it can be compared directly
+			// against shortBase.
+			nameNoPrefix := strings.TrimPrefix(name, "Benchmark")
+			shortName := gomaxprocsSuffix.ReplaceAllString(nameNoPrefix, "")
+			if shortName != shortBase && !strings.HasPrefix(shortName, shortBase+"/") {
+				continue
+			}
+			matched = true
+			// rest is whatever follows shortBase in the actual row name:
+			// "", "-<GOMAXPROCS>", "/<subname>", or "/<subname>-<GOMAXPROCS>".
+			rest := strings.TrimPrefix(nameNoPrefix, shortBase)
+			row := rows[name]
+			results = append(results, Row{
+				Name:         base + rest,
+				Old:          row.old,
+				New:          row.new,
+				DeltaPercent: row.deltaPercent,
+				Significant:  row.significant,
+				Found:        true,
+				Flagged:      row.significant && row.deltaPercent > RegressionThresholdPercent,
+			})
+		}
+		if !matched {
+			results = append(results, Row{Name: base, Found: false})
+		}
+	}
+	return results
+}
+
+func renderMarkdown(results []Row) string {
+	var b strings.Builder
+	b.WriteString("| Benchmark | Old | New | Delta | Significant | Flagged |\n")
+	b.WriteString("|---|---|---|---|---|---|\n")
+	for _, r := range results {
+		if !r.Found {
+			fmt.Fprintf(&b, "| %s | - | - | - | - | not found |\n", r.Name)
+			continue
+		}
+		delta := nonSignificantMarker
+		if r.Significant {
+			delta = fmt.Sprintf("%+.2f%%", r.DeltaPercent)
+		}
+		flagged := "no"
+		if r.Flagged {
+			flagged = "**yes**"
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %t | %s |\n", r.Name, r.Old, r.New, delta, r.Significant, flagged)
+	}
+	return b.String()
+}

--- a/internal/benchci/benchci_test.go
+++ b/internal/benchci/benchci_test.go
@@ -1,0 +1,396 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchci
+
+import (
+	"strings"
+	"testing"
+)
+
+// fixtureCSV mirrors the exact structure of real
+// `go run golang.org/x/perf/cmd/benchstat@<BenchstatVersion> -format=csv`
+// output, verified by running benchstat against real `go test -bench
+// -count=10` result files: a metadata header, a "sec/op" table, then "B/op"
+// and "allocs/op" tables (present whenever the benchmarks call
+// b.ReportAllocs(), as ours do), each block separated by exactly one blank
+// line and ending in a "geomean" row. Row names drop the "Benchmark" prefix
+// entirely (a real `go test -bench=BenchmarkFoo` result compared with
+// benchstat prints its row as "Foo-8", not "BenchmarkFoo-8"); the fixture
+// benchmark names below (NoRegression, Regressed, ...) are deliberately
+// written without the prefix to match, and the tests pass the "Benchmark"
+// -prefixed form to Report to exercise evaluateCurated's un-prefixing.
+//
+// It covers all four regression-detection cases in one comparison:
+//   - BenchmarkNoRegression: tiny delta, not significant -> not flagged.
+//   - BenchmarkRegressed: >5% delta, significant -> flagged.
+//   - BenchmarkNoisyRegression: >5% apparent delta but benchstat printed
+//     "~" (not significant, e.g. too few samples or too much variance) ->
+//     not flagged. This is the noise-suppression case the AND-of-both
+//     -signals logic exists for.
+//   - BenchmarkImproved: significant, but a negative (faster) delta ->
+//     never flagged regardless of magnitude.
+const fixtureCSV = `goos: linux
+goarch: amd64
+pkg: github.com/blinklabs-io/dingo/ledger
+cpu: AMD EPYC 7763
+,old.txt,,new.txt,,,
+,sec/op,CI,sec/op,CI,vs base,P
+NoRegression-8,6.352e-07,1%,6.379e-07,0%,~,p=0.287 n=10
+Regressed-8,6.349e-07,0%,7.13e-07,1%,+12.34%,p=0.000 n=10
+NoisyRegression-8,1e-06,5%,1.2e-06,5%,~,p=0.200 n=10
+Improved-8,1.2875e-06,7%,1.1845e-06,1%,-8.00%,p=0.000 n=10
+geomean,8.501e-07,,7.8e-07,,-8.25%,
+
+,old.txt,,new.txt,,,
+,B/op,CI,B/op,CI,vs base,P
+NoRegression-8,0,0%,0,0%,~,p=1.000 n=10
+Regressed-8,0,0%,0,0%,~,p=1.000 n=10
+NoisyRegression-8,0,0%,0,0%,~,p=1.000 n=10
+Improved-8,0,0%,0,0%,~,p=1.000 n=10
+geomean,,,,,+0.00%,
+
+,old.txt,,new.txt,,,
+,allocs/op,CI,allocs/op,CI,vs base,P
+NoRegression-8,0,0%,0,0%,~,p=1.000 n=10
+Regressed-8,0,0%,0,0%,~,p=1.000 n=10
+NoisyRegression-8,0,0%,0,0%,~,p=1.000 n=10
+Improved-8,0,0%,0,0%,~,p=1.000 n=10
+geomean,,,,,+0.00%,
+`
+
+// A tiny, non-significant delta must never be flagged.
+func TestReport_NoRegression(t *testing.T) {
+	report, regressed, err := Report(fixtureCSV, []string{"BenchmarkNoRegression"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if regressed {
+		t.Fatalf("expected no regression, report:\n%s", report)
+	}
+	if !strings.Contains(report, "BenchmarkNoRegression-8") {
+		t.Fatalf("report missing benchmark row:\n%s", report)
+	}
+}
+
+// The core positive case: a >5% delta that benchstat also marks
+// statistically significant must be flagged.
+func TestReport_RegressedAndSignificant_Flagged(t *testing.T) {
+	report, regressed, err := Report(fixtureCSV, []string{"BenchmarkRegressed"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if !regressed {
+		t.Fatalf("expected a regression to be flagged, report:\n%s", report)
+	}
+	if !strings.Contains(report, "**yes**") {
+		t.Fatalf("report should mark the row flagged:\n%s", report)
+	}
+}
+
+// The noise-suppression case the AND-of-both-signals rule exists for: a large
+// apparent delta that benchstat did not consider significant (printed "~")
+// must not be flagged, since it's most likely CI runner noise rather than a
+// real regression.
+func TestReport_RegressedButNotSignificant_NotFlagged(t *testing.T) {
+	report, regressed, err := Report(fixtureCSV, []string{"BenchmarkNoisyRegression"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if regressed {
+		t.Fatalf("a non-significant delta must not be flagged, report:\n%s", report)
+	}
+}
+
+// A significant improvement (a negative, faster delta) must never be
+// flagged, regardless of how large the improvement is.
+func TestReport_Improvement_NotFlagged(t *testing.T) {
+	report, regressed, err := Report(fixtureCSV, []string{"BenchmarkImproved"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if regressed {
+		t.Fatalf("a significant improvement must not be flagged, report:\n%s", report)
+	}
+}
+
+// With all four fixture benchmarks curated together (the shape a real
+// bench-ci run produces), exactly the one that actually regressed must be
+// flagged, and every curated name must still appear in the report -- the
+// no-regression/noisy/improved rows should not be silently dropped.
+func TestReport_MixedSet_OnlyRegressedFlags(t *testing.T) {
+	curated := []string{
+		"BenchmarkNoRegression",
+		"BenchmarkRegressed",
+		"BenchmarkNoisyRegression",
+		"BenchmarkImproved",
+	}
+	report, regressed, err := Report(fixtureCSV, curated)
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if !regressed {
+		t.Fatalf("expected overall regression=true because BenchmarkRegressed flags, report:\n%s", report)
+	}
+	// Exactly one row should be marked flagged.
+	if got := strings.Count(report, "**yes**"); got != 1 {
+		t.Fatalf("expected exactly 1 flagged row, got %d, report:\n%s", got, report)
+	}
+	for _, name := range curated {
+		if !strings.Contains(report, name) {
+			t.Fatalf("report missing %s:\n%s", name, report)
+		}
+	}
+}
+
+// A curated name absent from benchstat's output (renamed, removed, or a
+// typo) must be reported as a visible "not found" row rather than silently
+// dropped or treated as a false regression.
+func TestReport_UnknownBenchmark_ReportedNotFound(t *testing.T) {
+	report, regressed, err := Report(fixtureCSV, []string{"BenchmarkDoesNotExist"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if regressed {
+		t.Fatalf("a missing benchmark must not be flagged, report:\n%s", report)
+	}
+	if !strings.Contains(report, "BenchmarkDoesNotExist") || !strings.Contains(report, "not found") {
+		t.Fatalf("report should note the benchmark was not found:\n%s", report)
+	}
+}
+
+// The parser must read timing values from the "sec/op" table specifically,
+// not accidentally pick up the "B/op" or "allocs/op" tables that follow it.
+func TestReport_IgnoresNonSecOpTables(t *testing.T) {
+	// B/op and allocs/op both show 0 -> ~0.00% for every row in the
+	// fixture; if the parser accidentally picked up one of those tables
+	// instead of sec/op, none of the below assertions about the sec/op
+	// deltas would hold.
+	report, _, err := Report(fixtureCSV, []string{"BenchmarkRegressed"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if !strings.Contains(report, "635ns") || !strings.Contains(report, "713ns") {
+		t.Fatalf("expected sec/op values in report:\n%s", report)
+	}
+}
+
+// fixtureMultiPkgCSV exercises benchstat's behavior when the input spans
+// multiple packages: only the very first block carries the full
+// goos/goarch/pkg/cpu metadata header; later blocks for a new package carry
+// just a bare "pkg: ..." line (no blank line separating it from the
+// metadata that would otherwise be expected), still followed by its own
+// sec/op, B/op, and allocs/op tables. This mirrors `make bench-ci`'s output,
+// which spans ledger, database, connmanager, event, peergov, ouroboros, and
+// internal/integration.
+const fixtureMultiPkgCSV = `goos: linux
+goarch: amd64
+pkg: github.com/blinklabs-io/dingo/database
+cpu: AMD EPYC 7763
+,old.txt,,new.txt,,,
+,sec/op,CI,sec/op,CI,vs base,P
+HotCacheGet-8,5e-08,1%,5.01e-08,1%,~,p=0.900 n=10
+geomean,5e-08,,5.01e-08,,+0.20%,
+
+,old.txt,,new.txt,,,
+,B/op,CI,B/op,CI,vs base,P
+HotCacheGet-8,0,0%,0,0%,~,p=1.000 n=10
+geomean,,,,,+0.00%,
+
+pkg: github.com/blinklabs-io/dingo/connmanager
+,old.txt,,new.txt,,,
+,sec/op,CI,sec/op,CI,vs base,P
+UpdateConnectionMetrics-8,1e-07,1%,1.2e-07,1%,+20.00%,p=0.001 n=10
+geomean,1e-07,,1.2e-07,,+20.00%,
+
+,old.txt,,new.txt,,,
+,B/op,CI,B/op,CI,vs base,P
+UpdateConnectionMetrics-8,0,0%,0,0%,~,p=1.000 n=10
+geomean,,,,,+0.00%,
+`
+
+// bench-ci's output spans several packages (ledger, database, connmanager,
+// ...); the parser must read every package's sec/op table, not just the
+// first one, even though only the first block carries the full metadata
+// header.
+func TestReport_MultiPackageInput(t *testing.T) {
+	curated := []string{"BenchmarkHotCacheGet", "BenchmarkUpdateConnectionMetrics"}
+	report, regressed, err := Report(fixtureMultiPkgCSV, curated)
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if !regressed {
+		t.Fatalf("expected BenchmarkUpdateConnectionMetrics to flag a regression, report:\n%s", report)
+	}
+	if !strings.Contains(report, "BenchmarkHotCacheGet-8") {
+		t.Fatalf("report missing row from the first package's block:\n%s", report)
+	}
+	if !strings.Contains(report, "BenchmarkUpdateConnectionMetrics-8") {
+		t.Fatalf("report missing row from the second package's block:\n%s", report)
+	}
+}
+
+// fixtureCPUSweepCSV exercises the GOMAXPROCS lock-contention sweep, where
+// -cpu=1,4,8,16 makes the same base benchmark name recur once per swept
+// value in the same sec/op table. Verified directly against a real `go test
+// -cpu=1,4,8,16` run: go test's testing package only appends the
+// "-<GOMAXPROCS>" suffix when GOMAXPROCS != 1, so the -cpu=1 row carries no
+// suffix at all while -cpu=4/8/16 do.
+const fixtureCPUSweepCSV = `goos: linux
+goarch: amd64
+pkg: github.com/blinklabs-io/dingo/database
+cpu: AMD EPYC 7763
+,old.txt,,new.txt,,,
+,sec/op,CI,sec/op,CI,vs base,P
+BlockLRUParallelReadHeavy,1e-07,1%,1.01e-07,1%,~,p=0.500 n=10
+BlockLRUParallelReadHeavy-4,1.2e-07,1%,1.22e-07,1%,~,p=0.400 n=10
+BlockLRUParallelReadHeavy-8,1.5e-07,1%,1.58e-07,1%,~,p=0.200 n=10
+BlockLRUParallelReadHeavy-16,2e-07,1%,6.5e-07,1%,+225.00%,p=0.000 n=10
+geomean,1.406e-07,,2.293e-07,,+63.09%,
+`
+
+// Under a -cpu=1,4,8,16 sweep, one curated name matches four separate rows
+// (one per core count, including the suffix-less -cpu=1 row); each must be
+// reported and evaluated independently, so a regression that only appears at
+// high core counts (the actual shape of the lock-contention bug this
+// benchmark family exists to catch) still gets flagged.
+func TestReport_CPUSweep_PerCoreCountRows(t *testing.T) {
+	report, regressed, err := Report(fixtureCPUSweepCSV, []string{"BenchmarkBlockLRUParallelReadHeavy"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if !regressed {
+		t.Fatalf("expected the -16 row's contention regression to flag, report:\n%s", report)
+	}
+	// The -cpu=1 row carries no suffix at all (see fixtureCPUSweepCSV). Match
+	// on "| <name> |" so the bare-name row can't be satisfied by a
+	// substring match against the "-4"/"-8"/"-16" rows.
+	for _, name := range []string{
+		"BenchmarkBlockLRUParallelReadHeavy",
+		"BenchmarkBlockLRUParallelReadHeavy-4",
+		"BenchmarkBlockLRUParallelReadHeavy-8",
+		"BenchmarkBlockLRUParallelReadHeavy-16",
+	} {
+		if !strings.Contains(report, "| "+name+" |") {
+			t.Fatalf("report missing row %s:\n%s", name, report)
+		}
+	}
+	// Only the -16 row should be flagged.
+	if got := strings.Count(report, "**yes**"); got != 1 {
+		t.Fatalf("expected exactly 1 flagged row across the sweep, got %d, report:\n%s", got, report)
+	}
+}
+
+// fixtureSubBenchmarkCSV mirrors a real capture of
+// `go test -bench=BenchmarkUpdateConnectionMetrics -count=3` piped through
+// benchstat: BenchmarkUpdateConnectionMetrics calls b.Run(strconv.Itoa(n),
+// ...) internally, so it never appears as a bare row -- only as
+// "UpdateConnectionMetrics/<n>-10" once per table-driven case. Several other
+// curated benchmarks (BenchmarkVerifyBlockHeader, BenchmarkStorageModeIngest,
+// BenchmarkTestLoad, BenchmarkReconcile, BenchmarkPublishSubscribers,
+// BenchmarkHasInboundPeerAddress, BenchmarkTryReserveInboundSlotParallel)
+// share this shape.
+const fixtureSubBenchmarkCSV = `goos: darwin
+goarch: arm64
+pkg: github.com/blinklabs-io/dingo/connmanager
+cpu: Apple M1 Pro
+,old.txt,,new.txt,,,
+,sec/op,CI,sec/op,CI,vs base,P
+UpdateConnectionMetrics/10-10,1.364e-08,∞,1.397e-08,∞,~,p=0.100 n=3
+UpdateConnectionMetrics/100-10,1.364e-08,∞,1.368e-08,∞,~,p=0.500 n=3
+UpdateConnectionMetrics/500-10,1.363e-08,∞,1.7e-08,∞,+24.72%,p=0.001 n=3
+UpdateConnectionMetrics/1000-10,1.364e-08,∞,1.401e-08,∞,~,p=0.100 n=3
+geomean,1.364e-08,,1.466e-08,,+7.48%,
+`
+
+// A curated name that only ever appears as "<name>/<subname>-<N>" (because
+// the benchmark calls b.Run internally) must match every sub-benchmark row,
+// and a curated name with no matching rows at all must still report exactly
+// one not-found row -- not one per swept dimension it could have matched.
+func TestReport_SubBenchmarkFamily(t *testing.T) {
+	report, regressed, err := Report(fixtureSubBenchmarkCSV, []string{"BenchmarkUpdateConnectionMetrics"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if !regressed {
+		t.Fatalf("expected the /500 sub-benchmark's regression to flag, report:\n%s", report)
+	}
+	for _, sub := range []string{"/10-10", "/100-10", "/500-10", "/1000-10"} {
+		name := "BenchmarkUpdateConnectionMetrics" + sub
+		if !strings.Contains(report, "| "+name+" |") {
+			t.Fatalf("report missing sub-benchmark row %s:\n%s", name, report)
+		}
+	}
+	if got := strings.Count(report, "**yes**"); got != 1 {
+		t.Fatalf("expected exactly 1 flagged sub-benchmark, got %d, report:\n%s", got, report)
+	}
+	// A curated name with no sub-benchmark rows at all in the input must
+	// still report a single not-found row, not one per swept dimension.
+	report2, regressed2, err := Report(fixtureSubBenchmarkCSV, []string{"BenchmarkDoesNotExist"})
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if regressed2 {
+		t.Fatalf("unrelated missing benchmark must not flag, report:\n%s", report2)
+	}
+	if strings.Count(report2, "not found") != 1 {
+		t.Fatalf("expected exactly 1 not-found row, report:\n%s", report2)
+	}
+}
+
+// parseDelta must handle benchstat's non-significant marker ("~"), a signed
+// percentage in either direction, and reject unparseable input.
+func TestParseDelta(t *testing.T) {
+	cases := []struct {
+		in          string
+		wantPercent float64
+		wantSig     bool
+		wantOK      bool
+	}{
+		{"~", 0, false, true},
+		{"+12.34%", 12.34, true, true},
+		{"-8.00%", -8, true, true},
+		{"not-a-number", 0, false, false},
+	}
+	for _, c := range cases {
+		gotPercent, gotSig, gotOK := parseDelta(c.in)
+		if gotOK != c.wantOK {
+			t.Fatalf("parseDelta(%q) ok = %v, want %v", c.in, gotOK, c.wantOK)
+		}
+		if !c.wantOK {
+			continue
+		}
+		if gotSig != c.wantSig {
+			t.Fatalf("parseDelta(%q) significant = %v, want %v", c.in, gotSig, c.wantSig)
+		}
+		if gotPercent != c.wantPercent {
+			t.Fatalf("parseDelta(%q) percent = %v, want %v", c.in, gotPercent, c.wantPercent)
+		}
+	}
+}
+
+// formatSeconds must render benchstat's raw seconds float as a readable
+// duration at nanosecond, millisecond, and second scales.
+func TestFormatSeconds(t *testing.T) {
+	cases := map[float64]string{
+		6.3495e-07: "635ns",
+		1e-03:      "1ms",
+		1.5:        "1.5s",
+	}
+	for in, want := range cases {
+		if got := formatSeconds(in); got != want {
+			t.Fatalf("formatSeconds(%v) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/benchci/benchmarks.go
+++ b/internal/benchci/benchmarks.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchci
+
+// CuratedBenchmarks lists the fixed-GOMAXPROCS benchmarks tracked across
+// issue #1895's four dimensions: block validation throughput, sync speed,
+// network throughput, and resource usage. Keep this in sync with the
+// Makefile bench-ci target's first `go test -bench` regex.
+var CuratedBenchmarks = []string{
+	// Block validation throughput (ledger/benchmark_test.go).
+	"BenchmarkBlockProcessingThroughput",
+	"BenchmarkBlockProcessingThroughputPredecoded",
+	"BenchmarkBlockBatchProcessingThroughput",
+	"BenchmarkRawBlockBatchProcessingThroughput",
+	"BenchmarkVerifyBlockHeader",
+	"BenchmarkTransactionValidation",
+
+	// Sync speed.
+	"BenchmarkChainSyncFromGenesis",             // ledger/benchmark_test.go
+	"BenchmarkRealBlockProcessing",              // ledger/benchmark_test.go
+	"BenchmarkEraTransitionPerformanceRealData", // ledger/benchmark_test.go
+	"BenchmarkTestLoad",                         // internal/integration/benchmark_test.go
+
+	// Network throughput.
+	"BenchmarkBlockfetchNearTipThroughput",             // ledger/benchmark_test.go
+	"BenchmarkBlockfetchNearTipThroughputPredecoded",   // ledger/benchmark_test.go
+	"BenchmarkBlockfetchNearTipFlushOnlyPredecoded",    // ledger/benchmark_test.go
+	"BenchmarkBlockfetchNearTipQueuedHeaderPredecoded", // ledger/benchmark_test.go
+	"BenchmarkBlockfetchVerifiedHeaderDispatch",        // ledger/benchmark_test.go
+	"BenchmarkBlockfetchClientBlockMetrics",            // ouroboros/blockfetch_test.go
+	"BenchmarkUpdateConnectionMetrics",                 // connmanager/benchmark_test.go
+	"BenchmarkHasInboundPeerAddress",                   // connmanager/benchmark_test.go
+	"BenchmarkReconcile",                               // peergov/benchmark_test.go
+	"BenchmarkPublishSubscribers",                      // event/benchmark_test.go
+
+	// Resource usage.
+	"BenchmarkBlockMemoryUsage",             // ledger/benchmark_test.go
+	"BenchmarkHotCacheGet",                  // database/cbor_cache_bench_test.go
+	"BenchmarkHotCachePut",                  // database/cbor_cache_bench_test.go
+	"BenchmarkHotCacheGetMiss",              // database/cbor_cache_bench_test.go
+	"BenchmarkBlockLRUCacheGet",             // database/cbor_cache_bench_test.go
+	"BenchmarkBlockLRUCachePut",             // database/cbor_cache_bench_test.go
+	"BenchmarkTieredCacheHotHit",            // database/cbor_cache_bench_test.go
+	"BenchmarkCachedBlockExtract",           // database/cbor_cache_bench_test.go
+	"BenchmarkCborOffsetEncode",             // database/cbor_cache_bench_test.go
+	"BenchmarkCborOffsetDecode",             // database/cbor_cache_bench_test.go
+	"BenchmarkStorageModeIngest",            // ledger/benchmark_test.go
+	"BenchmarkStorageModeIngestSteadyState", // ledger/benchmark_test.go
+}
+
+// LockContentionBenchmarks lists the GOMAXPROCS lock-contention sweep
+// benchmarks, run under -cpu=1,4,8,16 by the Makefile bench-ci target's
+// second `go test -bench` invocation. BenchmarkBlockLRUParallel* is the
+// literal LRU-cache incident (a single mutex made the cache ~8x slower at 16
+// cores before sharding). BenchmarkTipSnapshotReadOnly and
+// BenchmarkTipSnapshotReadUnderWriter are the dedicated #2601 sentinel: they
+// exercise the exact atomic.Pointer[consensusSnapshot]/[tipSnapshot]
+// read-under-concurrent-writer pattern that #2601 fixed (a plain RWMutex on
+// that path scaled backwards -- ~591ns at 16 cores with a concurrent writer
+// vs ~133ns read-only). BenchmarkConcurrentQueries is kept alongside them as
+// a broader database-query-under-concurrency check, not a substitute. Keep
+// this list in sync with that invocation's -bench regex.
+var LockContentionBenchmarks = []string{
+	"BenchmarkBlockLRUParallelReadHeavy",     // database/block_lru_cache_parallel_bench_test.go
+	"BenchmarkBlockLRUParallelBalanced",      // database/block_lru_cache_parallel_bench_test.go
+	"BenchmarkBlockLRUParallelReadOnly",      // database/block_lru_cache_parallel_bench_test.go
+	"BenchmarkHotCacheParallelGet",           // database/cbor_cache_bench_test.go
+	"BenchmarkTryReserveInboundSlotParallel", // connmanager/benchmark_test.go
+	"BenchmarkConcurrentQueries",             // ledger/benchmark_test.go
+	"BenchmarkTipSnapshotReadOnly",           // ledger/snapshot_parallel_bench_test.go
+	"BenchmarkTipSnapshotReadUnderWriter",    // ledger/snapshot_parallel_bench_test.go
+}
+
+// TrackedBenchmarks is the full set of benchmarks compared for CI regression
+// detection: CuratedBenchmarks plus LockContentionBenchmarks. The Makefile
+// bench-ci target concatenates both `go test` invocations' output into a
+// single run file, so benchcheck compares against this combined list.
+var TrackedBenchmarks = append(
+	append([]string{}, CuratedBenchmarks...),
+	LockContentionBenchmarks...,
+)

--- a/internal/benchci/cmd/benchcheck/main.go
+++ b/internal/benchci/cmd/benchcheck/main.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command benchcheck compares two `go test -bench` result files (produced
+// by `make bench-ci`) via internal/benchci and writes a markdown regression
+// report. It is invoked by the weekly benchmark.yml workflow.
+//
+// Usage:
+//
+//	benchcheck <old-file> <new-file> <report-output-path>
+//
+// benchcheck always exits 0 when it successfully compares the two files and
+// writes the report, regardless of whether a regression was found --
+// regression is data for the caller to act on, not a program failure. It
+// prints exactly one of "regression=true" or "regression=false" as its
+// final stdout line so the calling shell/workflow step can capture it. A
+// genuine I/O or parse error is reported on stderr with a non-zero exit.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/blinklabs-io/dingo/internal/benchci"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "benchcheck: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) != 3 {
+		return errors.New("usage: benchcheck <old-file> <new-file> <report-output-path>")
+	}
+	oldFile, newFile, reportPath := args[0], args[1], args[2]
+
+	report, regressed, err := benchci.Compare(oldFile, newFile, benchci.TrackedBenchmarks)
+	if err != nil {
+		return fmt.Errorf("comparing %s to %s: %w", oldFile, newFile, err)
+	}
+
+	// reportPath is a CLI argument supplied by the trusted benchmark
+	// workflow invoking this command, not attacker-controlled input.
+	if err := os.WriteFile(reportPath, []byte(report), 0o600); err != nil { //nolint:gosec // G703: reportPath is a trusted CLI argument, not attacker input
+		return fmt.Errorf("writing report to %s: %w", reportPath, err)
+	}
+
+	fmt.Printf("regression=%t\n", regressed)
+	return nil
+}

--- a/ledger/snapshot_parallel_bench_test.go
+++ b/ledger/snapshot_parallel_bench_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/test/dbtest"
+)
+
+// BenchmarkTipSnapshotReadOnly and BenchmarkTipSnapshotReadUnderWriter are the
+// regression sentinel for issue #2601: LedgerState.Tip, GetCurrentPParams,
+// CurrentEpoch, and IsAtTip are read constantly from API handlers, chainsync,
+// forging, and block validation, and used to take the embedded RWMutex's read
+// lock. A concurrent writer stalled every reader (RWMutex with 1% concurrent
+// writer measured ~591ns at 16 cores in #2601's prototype, versus ~133ns
+// read-only), because each writer Lock blocks the shared reader counter. The
+// fix (already landed, see LedgerState.consensus/tip atomic.Pointer fields
+// and publishSnapshotsLocked) moved these fields behind immutable
+// copy-on-write snapshots so reads never block on a concurrent writer.
+//
+// Comparing these two benchmarks' ns/op across -cpu=1,4,8,16 is the
+// regression signal: on the current atomic.Pointer implementation both should
+// stay flat and close to each other as core count rises. A reintroduced
+// RWMutex (or any lock) on this read path would show
+// BenchmarkTipSnapshotReadUnderWriter degrading sharply relative to
+// BenchmarkTipSnapshotReadOnly as cores increase, exactly the negative
+// scaling issue #1895 asks this framework to catch.
+//
+// BenchmarkConcurrentQueries (see benchmark_test.go) exercises database query
+// load under concurrency; it is not a substitute for this benchmark, which
+// targets the specific in-memory snapshot read/publish path #2601 describes.
+
+func benchmarkTipSnapshotReaders(b *testing.B, ledgerState *LedgerState) {
+	b.Helper()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = ledgerState.Tip()
+			_ = ledgerState.GetCurrentPParams()
+			_ = ledgerState.CurrentEpoch()
+			_ = ledgerState.IsAtTip()
+		}
+	})
+}
+
+// BenchmarkTipSnapshotReadOnly is the baseline: readers only, no concurrent
+// writer. Run with -cpu=1,4,8,16 to see the scaling curve.
+func BenchmarkTipSnapshotReadOnly(b *testing.B) {
+	db, ledgerState := newBatchBenchmarkLedgerState(b, nil)
+	defer dbtest.CloseDatabase(db)
+
+	benchmarkTipSnapshotReaders(b, ledgerState)
+}
+
+// BenchmarkTipSnapshotReadUnderWriter adds a background writer that
+// continuously republishes the consensus/tip snapshots (the same
+// publishSnapshotsLocked call a real per-block writer makes), while readers
+// run concurrently. Run with -cpu=1,4,8,16 to see the scaling curve; per
+// #2601's regression, an implementation using a plain RWMutex here would
+// degrade sharply at higher core counts, while the atomic.Pointer
+// implementation should stay close to BenchmarkTipSnapshotReadOnly.
+//
+// The writer runs as fast as possible (deliberately more aggressive than a
+// real per-block cadence) so a reintroduced lock's contention shows up
+// clearly rather than being diluted by a realistic, much lower write rate.
+func BenchmarkTipSnapshotReadUnderWriter(b *testing.B) {
+	db, ledgerState := newBatchBenchmarkLedgerState(b, nil)
+	defer dbtest.CloseDatabase(db)
+
+	done := make(chan struct{})
+	writerStopped := make(chan struct{})
+	go func() {
+		defer close(writerStopped)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				ledgerState.Lock()
+				ledgerState.publishSnapshotsLocked()
+				ledgerState.Unlock()
+			}
+		}
+	}()
+	defer func() {
+		close(done)
+		<-writerStopped
+	}()
+
+	benchmarkTipSnapshotReaders(b, ledgerState)
+}


### PR DESCRIPTION
## Summary
Dingo has 30+ benchmarks but no CI integration, so performance regressions
can land unnoticed. This adds a weekly (not per-merge, to keep the job
under ~2 hours) benchmark workflow with historical comparison and
regression alerting, per #1895.

## Changes
- `.github/workflows/benchmark.yml` — new workflow, runs weekly
  (`schedule`) or on demand (`workflow_dispatch`). Stores results on a
  dedicated `benchmark-data` branch, compares against the prior run via
  `benchstat`, and opens/comments on a persistent "Benchmark regression
  tracker" issue when a benchmark is >5% slower **and** statistically
  significant.
- `Makefile` — new `bench-ci` target: the curated benchmark set at
  `-count=10` (for statistically valid comparisons), plus a separate
  `-cpu=1,4,8,16` sweep for lock-contention regressions.
- `internal/benchci/` — new package: parses `benchstat` output, applies the
  5%-and-significant regression rule, renders the markdown report; plus
  `cmd/benchcheck`, the CLI the workflow invokes.
- `ledger/snapshot_parallel_bench_test.go` — new benchmark pair
  (`BenchmarkTipSnapshotReadOnly` / `BenchmarkTipSnapshotReadUnderWriter`)
  exercising the ledger read-under-concurrent-writer pattern from #2601
  directly, closing the one tracked benchmark this framework didn't
  already have.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./internal/benchci/...` — 12 unit tests covering
      regression / no-regression / noisy-non-significant / improvement /
      multi-package / CPU-sweep / sub-benchmark cases
- [x] `golangci-lint run` clean on `internal/benchci/...` and `ledger/...`
- [x] `make docs-parity`
- [x] New `ledger` benchmarks verified under `-race` and across a CPU sweep
- [x] `actionlint` clean on the new workflow
- [x] Verified the `bench-ci` regexes match exactly the intended curated
      benchmark names (no extras, none missing)
- [x] Dry-ran the workflow's git/gh branch-publishing logic (bootstrap,
      steady-state, pruning) against a local scratch git repo
- [ ] Live run of `benchmark.yml` on GitHub Actions (only verifiable after
      merge, since it can't be triggered from a draft PR branch push)

Closes #1895


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a weekly benchmark CI that detects statistically significant >5% sec/op regressions and reports them without gating merges. Stores and compares runs in a dedicated `benchmark-data` branch to surface performance drift over time.

- Workflow `benchmark.yml`: runs weekly or on demand; executes `make bench-ci` (~2h).
- Publishes results to `benchmark-data/runs/` with unique per-run filenames; maintains `latest.txt`; prunes data older than 104 weeks.
- Compares against the prior run using pinned `golang.org/x/perf/cmd/benchstat` via `internal/benchci`/`cmd/benchcheck`; flags only when delta >5% and statistically significant; writes a markdown table to the step summary and posts to a persistent “Benchmark regression tracker” issue (`performance-regression` label, auto-created).
- Hardening: passes paths via env, validates the full baseline path, rejects a symlinked `runs/` directory before any write, and rejects symlinked baseline files; uses run ID/attempt to avoid rerun overwrites.
- First run bootstraps the baseline; detection starts on the second run. Regressions do not fail the job.
- Code: adds `internal/benchci` (parses benchstat CSV, matches curated and CPU-sweep sub-benchmarks, renders markdown; unit tests included); adds `bench-ci` Makefile target (`-count=10` curated set plus `-cpu=1,4,8,16` contention sweep); adds `BenchmarkTipSnapshotReadOnly` and `BenchmarkTipSnapshotReadUnderWriter` to catch read-under-writer contention from #2601.

<sup>Written for commit 8a0a3724289487c65bc0ac4c3e2b0301db57cc04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated benchmark comparisons to identify statistically significant performance regressions.
  - Added curated benchmarks covering concurrency, networking, resource usage, database queries, and snapshot access.
  - Added reporting that highlights regressions, improvements, unavailable comparisons, and benchmark results.

- **Chores**
  - Added scheduled and manually triggered benchmark runs with stored historical results.
  - Added persistent regression reporting and automatic cleanup of older benchmark data.

- **Tests**
  - Added benchmarks for parallel snapshot reads, including reads during concurrent snapshot updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->