### PR TITLE
fix(ledger): ignore historical primary-chain headers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2455,12 +2455,19 @@ replay can be behind that chain's tip while the applied ledger catches up after
 a restart; it is treated as a duplicate and does not contribute to mismatch or
 resync state. Only a point confirmed as present in the current primary-chain
 index bypasses fork resolution: a lookup failure is logged and treated as a
-non-match, so it proceeds through normal fork handling. That lookup reads the
-block store while `chainsyncMutex` is held, so it is skipped for the origin
-point and for any header beyond the primary-chain tip, neither of which can
-carry a primary-chain index entry. Fork resolution reconstructs the peer's
-fetched header path with `findPeerForkPath`, locates the exact common ancestor,
-and counts both the peer and primary-chain blocks in
+non-match, so it proceeds through normal fork handling. An O(1) local hash-index
+prefilter rejects an unknown fork header before a point lookup can fall through
+to a configured Bark archive. On a hit, the block ID's current `bi` value is
+parsed directly into its slot and hash, avoiding a second block-CBOR read. The
+lookup runs while `chainsyncMutex` is held, so it is skipped for the origin
+point and for a header beyond the `localTip` snapshot taken by the handler; the
+latter is not observed in that snapshot even though concurrent blockfetch may
+advance the primary-chain index afterward. A confirmed historical replay does
+not clear an existing queued-header fragment because it did not discover a
+competing chain; ordinary blockfetch completion or connection handoff retains
+ownership of that queue. Fork resolution reconstructs the peer's fetched
+header path with `findPeerForkPath`, locates the exact common ancestor, and
+counts both the peer and primary-chain blocks in
 `(intersectionSlot, intersectionSlot + genesisWindow]`. Greater density wins;
 equal density falls back to the normal Praos length/select-view comparison.
 Node composition injects an atomic Genesis-mode/window query from

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2456,10 +2456,12 @@ a restart; it is treated as a duplicate and does not contribute to mismatch or
 resync state. Only a point confirmed as present in the current primary-chain
 index bypasses fork resolution: a lookup failure is logged and treated as a
 non-match, so it proceeds through normal fork handling. An O(1) local hash-index
-prefilter rejects an unknown fork header before a point lookup can fall through
-to a configured Bark archive. On a hit, the block ID's current `bi` value is
-parsed directly into its slot and hash, avoiding a second block-CBOR read. The
-lookup runs while `chainsyncMutex` is held, so it is skipped for the origin
+prefilter handles current databases. On a miss, an exact local point probe
+preserves compatibility with blocks written before the hash index existed;
+that bounded probe bypasses Bark's remote archive fallback, so an unknown fork
+still returns immediately. On a hit, the block ID's current `bi` value is parsed
+directly into its slot and hash, avoiding a second block-CBOR read. The lookup
+runs while `chainsyncMutex` is held, so it is skipped for the origin
 point and for a header beyond the `localTip` snapshot taken by the handler; the
 latter is not observed in that snapshot even though concurrent blockfetch may
 advance the primary-chain index afterward. A confirmed historical replay does

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2448,14 +2448,19 @@ genesis params (`GenesisWindowSlotsForParams`) or overridden by
 `observedSlots` used for density), trimmed to the window and on rollback.
 That rolling frontier ranks peers before a fork is available locally; it is not
 the authoritative fork-choice measurement. When an incoming header conflicts
-with the primary chain, the handler first checks whether the header point is
-already on the authoritative primary chain. A historical replay can be behind
-that chain's tip while the applied ledger catches up after a restart; it is
-treated as a duplicate and does not contribute to mismatch or resync state.
-Only a point absent from the current primary-chain index enters fork
-resolution, which reconstructs the peer's fetched header path with
-`findPeerForkPath`, locates the exact common ancestor, and counts both the peer
-and primary-chain blocks in
+with the primary chain, the handler discards it through the in-memory duplicate
+and stale-header checks first, then asks whether the header point is still on
+the authoritative primary chain (`headerAlreadyOnPrimaryChain`). A historical
+replay can be behind that chain's tip while the applied ledger catches up after
+a restart; it is treated as a duplicate and does not contribute to mismatch or
+resync state. Only a point confirmed as present in the current primary-chain
+index bypasses fork resolution: a lookup failure is logged and treated as a
+non-match, so it proceeds through normal fork handling. That lookup reads the
+block store while `chainsyncMutex` is held, so it is skipped for the origin
+point and for any header beyond the primary-chain tip, neither of which can
+carry a primary-chain index entry. Fork resolution reconstructs the peer's
+fetched header path with `findPeerForkPath`, locates the exact common ancestor,
+and counts both the peer and primary-chain blocks in
 `(intersectionSlot, intersectionSlot + genesisWindow]`. Greater density wins;
 equal density falls back to the normal Praos length/select-view comparison.
 Node composition injects an atomic Genesis-mode/window query from

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2448,9 +2448,14 @@ genesis params (`GenesisWindowSlotsForParams`) or overridden by
 `observedSlots` used for density), trimmed to the window and on rollback.
 That rolling frontier ranks peers before a fork is available locally; it is not
 the authoritative fork-choice measurement. When an incoming header conflicts
-with the primary chain, ledger fork resolution reconstructs the peer's fetched
-header path with `findPeerForkPath`, locates the exact common ancestor, and
-counts both the peer and primary-chain blocks in
+with the primary chain, the handler first checks whether the header point is
+already on the authoritative primary chain. A historical replay can be behind
+that chain's tip while the applied ledger catches up after a restart; it is
+treated as a duplicate and does not contribute to mismatch or resync state.
+Only a point absent from the current primary-chain index enters fork
+resolution, which reconstructs the peer's fetched header path with
+`findPeerForkPath`, locates the exact common ancestor, and counts both the peer
+and primary-chain blocks in
 `(intersectionSlot, intersectionSlot + genesisWindow]`. Greater density wins;
 equal density falls back to the normal Praos length/select-view comparison.
 Node composition injects an atomic Genesis-mode/window query from

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -948,7 +948,9 @@ this point-only path after obtaining the candidate block ID.
 uses the optional `blob.LocalBlockReader` path when a wrapper provides it. Bark
 implements that extension by bypassing archive fallback, which lets ledger
 probe exact points from pre-hash-index databases without turning an unknown
-fork hash into a remote request.
+fork hash into a remote request. Tombstones retain `bp..._metadata` in every
+backend so the local ID remains available; a legacy cloud tombstone that has
+already lost that metadata is a non-match rather than block ID zero.
 
 `Database.CountBlocksAndOldestSlot` (`database/block.go`) is a full forward scan of the `bp` keyspace that answers "how many blocks are retained, and what's the oldest one" — there is no maintained counter for either, so this is a genuine scan, not a cheap lookup. It relies on two properties of the layout above: `bp` keys sort in ascending slot order (the big-endian slot encoding), so the oldest slot is whichever is seen first, no separate MIN pass needed; and a tombstoned entry (history-expiry pruned its content but kept the `bp` key alive per `TombstoneBlock`'s doc comment) surfaces as `types.ErrHistoryExpired` from `ValueCopy` rather than the raw `DBT1` marker bytes — the blob plugin's own read path already does that translation (matching `GetBlock`'s convention), so this checks for that error rather than re-parsing the magic itself, and excludes any such entry from both the count and the oldest-slot search. This backs bark's `GetDatabaseInfo` RPC (`block_count`/`oldest_slot`), which is exactly why it's a full scan: an operator-facing diagnostic called occasionally, not a hot path — a maintained counter would need touching every block insert/delete/prune path across the codebase for a query this infrequent.
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -944,6 +944,11 @@ flowchart LR
 directly into the canonical slot and hash. It deliberately does not load the
 referenced block CBOR or metadata; ledger primary-chain membership checks use
 this point-only path after obtaining the candidate block ID.
+`Database.BlockIDByPointLocal` retrieves that ID from local block metadata and
+uses the optional `blob.LocalBlockReader` path when a wrapper provides it. Bark
+implements that extension by bypassing archive fallback, which lets ledger
+probe exact points from pre-hash-index databases without turning an unknown
+fork hash into a remote request.
 
 `Database.CountBlocksAndOldestSlot` (`database/block.go`) is a full forward scan of the `bp` keyspace that answers "how many blocks are retained, and what's the oldest one" — there is no maintained counter for either, so this is a genuine scan, not a cheap lookup. It relies on two properties of the layout above: `bp` keys sort in ascending slot order (the big-endian slot encoding), so the oldest slot is whichever is seen first, no separate MIN pass needed; and a tombstoned entry (history-expiry pruned its content but kept the `bp` key alive per `TombstoneBlock`'s doc comment) surfaces as `types.ErrHistoryExpired` from `ValueCopy` rather than the raw `DBT1` marker bytes — the blob plugin's own read path already does that translation (matching `GetBlock`'s convention), so this checks for that error rather than re-parsing the magic itself, and excludes any such entry from both the count and the oldest-slot search. This backs bark's `GetDatabaseInfo` RPC (`block_count`/`oldest_slot`), which is exactly why it's a full scan: an operator-facing diagnostic called occasionally, not a hot path — a maintained counter would need touching every block insert/delete/prune path across the codebase for a query this infrequent.
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -940,6 +940,11 @@ flowchart LR
 | `metadata_commit_timestamp` | Big-endian timestamp integer bytes | Commit consistency check with SQL `commit_timestamp` |
 | `nodesettings/storeid` | Opaque `uuid.NewString()` bytes, minted on first use and never overwritten thereafter | This blob store's identity for the `blob_store_id` node settings gate (`Database.blobStoreID`), compared only for equality against the value latched in `node_settings_gate` |
 
+`Database.BlockPointByIndex` resolves a `bi` entry by parsing its `bp` value
+directly into the canonical slot and hash. It deliberately does not load the
+referenced block CBOR or metadata; ledger primary-chain membership checks use
+this point-only path after obtaining the candidate block ID.
+
 `Database.CountBlocksAndOldestSlot` (`database/block.go`) is a full forward scan of the `bp` keyspace that answers "how many blocks are retained, and what's the oldest one" — there is no maintained counter for either, so this is a genuine scan, not a cheap lookup. It relies on two properties of the layout above: `bp` keys sort in ascending slot order (the big-endian slot encoding), so the oldest slot is whichever is seen first, no separate MIN pass needed; and a tombstoned entry (history-expiry pruned its content but kept the `bp` key alive per `TombstoneBlock`'s doc comment) surfaces as `types.ErrHistoryExpired` from `ValueCopy` rather than the raw `DBT1` marker bytes — the blob plugin's own read path already does that translation (matching `GetBlock`'s convention), so this checks for that error rather than re-parsing the magic itself, and excludes any such entry from both the count and the oldest-slot search. This backs bark's `GetDatabaseInfo` RPC (`block_count`/`oldest_slot`), which is exactly why it's a full scan: an operator-facing diagnostic called occasionally, not a hot path — a maintained counter would need touching every block insert/delete/prune path across the codebase for a query this infrequent.
 
 `DOFF` references are 52 bytes:

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -343,6 +343,19 @@ func (b *BlobStoreBark) GetBlock(
 	return archiveCbor, merged, nil
 }
 
+// GetBlockLocal bypasses Bark's archive fallback. Nested wrappers are
+// unwrapped through the same optional interface.
+func (b *BlobStoreBark) GetBlockLocal(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
+	if reader, ok := b.upstream.(blob.LocalBlockReader); ok {
+		return reader.GetBlockLocal(txn, slot, hash)
+	}
+	return b.upstream.GetBlock(txn, slot, hash)
+}
+
 // fetchBlockFromArchive resolves a (slot, hash) block via the bark archive
 // service: requests a signed URL, downloads the CBOR, and returns it along
 // with the metadata carried in the archive response.

--- a/database/block.go
+++ b/database/block.go
@@ -490,6 +490,56 @@ func BlockBySlotTxn(txn *Txn, slot uint64) (models.Block, error) {
 	return ret, nil
 }
 
+func (d *Database) blockKeyByIndex(
+	blockIndex uint64,
+	txn *Txn,
+) ([]byte, error) {
+	indexKey := types.BlockBlobIndexKey(blockIndex)
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return nil, types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return nil, types.ErrBlobStoreUnavailable
+	}
+	val, err := blob.Get(blobTxn, indexKey)
+	if err != nil {
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return nil, models.ErrBlockNotFound
+		}
+		return nil, err
+	}
+	return val, nil
+}
+
+// BlockPointByIndex returns the point encoded in the current block-index
+// entry without loading the referenced block CBOR or metadata. It is intended
+// for primary-chain membership checks that need only the canonical slot and
+// hash at an internal block index.
+func (d *Database) BlockPointByIndex(
+	blockIndex uint64,
+	txn *Txn,
+) (ocommon.Point, error) {
+	if txn == nil {
+		txn = d.BlobTxn(false)
+		defer txn.Rollback() //nolint:errcheck
+	}
+	blockKey, err := d.blockKeyByIndex(blockIndex, txn)
+	if err != nil {
+		return ocommon.Point{}, err
+	}
+	point, err := BlockBlobKeyToPoint(blockKey)
+	if err != nil {
+		return ocommon.Point{}, fmt.Errorf(
+			"parsing block index %d value: %w",
+			blockIndex,
+			err,
+		)
+	}
+	return point, nil
+}
+
 func (d *Database) BlockByIndex(
 	blockIndex uint64,
 	txn *Txn,
@@ -498,23 +548,11 @@ func (d *Database) BlockByIndex(
 		txn = d.BlobTxn(false)
 		defer txn.Rollback() //nolint:errcheck
 	}
-	indexKey := types.BlockBlobIndexKey(blockIndex)
-	blobTxn := txn.Blob()
-	if blobTxn == nil {
-		return models.Block{}, types.ErrNilTxn
-	}
-	blob := txn.DB().Blob()
-	if blob == nil {
-		return models.Block{}, types.ErrBlobStoreUnavailable
-	}
-	val, err := blob.Get(blobTxn, indexKey)
+	blockKey, err := d.blockKeyByIndex(blockIndex, txn)
 	if err != nil {
-		if errors.Is(err, types.ErrBlobKeyNotFound) {
-			return models.Block{}, models.ErrBlockNotFound
-		}
 		return models.Block{}, err
 	}
-	return blockByKey(txn, val)
+	return blockByKey(txn, blockKey)
 }
 
 // BlockAtOrAfterIndex returns the first block whose chain index is greater

--- a/database/block.go
+++ b/database/block.go
@@ -304,6 +304,13 @@ func BlockIDByPointLocal(
 		}
 		return 0, err
 	}
+	if metadata.ID == 0 && errors.Is(err, types.ErrHistoryExpired) {
+		return 0, fmt.Errorf(
+			"%w: expired block at slot %d has no local metadata ID",
+			models.ErrBlockNotFound,
+			point.Slot,
+		)
+	}
 	return metadata.ID, nil
 }
 

--- a/database/block.go
+++ b/database/block.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -266,6 +267,44 @@ func BlockByPoint(db *Database, point ocommon.Point) (models.Block, error) {
 		return err
 	})
 	return ret, err
+}
+
+// BlockIDByPointLocal returns the locally stored metadata ID for point without
+// allowing a blob-store wrapper to fall through to a remote archive. Retained
+// tombstones still carry the metadata needed for this lookup.
+func BlockIDByPointLocal(
+	db *Database,
+	point ocommon.Point,
+) (uint64, error) {
+	txn := db.BlobTxn(false)
+	defer txn.Rollback() //nolint:errcheck
+	if txn.Blob() == nil {
+		return 0, types.ErrNilTxn
+	}
+	store := db.Blob()
+	if store == nil {
+		return 0, types.ErrBlobStoreUnavailable
+	}
+	var (
+		metadata types.BlockMetadata
+		err      error
+	)
+	if reader, ok := store.(blob.LocalBlockReader); ok {
+		_, metadata, err = reader.GetBlockLocal(
+			txn.Blob(), point.Slot, point.Hash,
+		)
+	} else {
+		_, metadata, err = store.GetBlock(
+			txn.Blob(), point.Slot, point.Hash,
+		)
+	}
+	if err != nil && !errors.Is(err, types.ErrHistoryExpired) {
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return 0, models.ErrBlockNotFound
+		}
+		return 0, err
+	}
+	return metadata.ID, nil
 }
 
 func BlockByHash(db *Database, hash []byte) (models.Block, error) {

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,6 +36,28 @@ func (s *countingBlockReadStore) GetBlock(
 	hash []byte,
 ) ([]byte, types.BlockMetadata, error) {
 	s.getBlockCalls++
+	return s.BlobStore.GetBlock(txn, slot, hash)
+}
+
+type localBlockReadStore struct {
+	blob.BlobStore
+	archiveFallbackCalls int
+}
+
+func (s *localBlockReadStore) GetBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
+	s.archiveFallbackCalls++
+	return s.BlobStore.GetBlock(txn, slot, hash)
+}
+
+func (s *localBlockReadStore) GetBlockLocal(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
 	return s.BlobStore.GetBlock(txn, slot, hash)
 }
 
@@ -105,6 +128,30 @@ func TestBlockPointByIndexDoesNotReadBlockContent(t *testing.T) {
 		store.getBlockCalls,
 		"point-only lookup must not load block CBOR or trigger archive fallback",
 	)
+}
+
+func TestBlockIDByPointLocalBypassesArchiveFallback(t *testing.T) {
+	db := newTestDB(t)
+	block := testIndexedBlock(42, 7, 0x42)
+	require.NoError(t, db.BlockCreate(block, nil))
+
+	store := &localBlockReadStore{BlobStore: db.blob}
+	db.blob = store
+
+	blockID, err := BlockIDByPointLocal(
+		db,
+		ocommon.NewPoint(block.Slot, block.Hash),
+	)
+	require.NoError(t, err)
+	require.Equal(t, block.ID, blockID)
+	require.Zero(t, store.archiveFallbackCalls)
+
+	_, err = BlockIDByPointLocal(
+		db,
+		ocommon.NewPoint(block.Slot, bytes.Repeat([]byte{0xff}, 32)),
+	)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+	require.Zero(t, store.archiveFallbackCalls)
 }
 
 func TestBlockAtOrAfterIndexSkipsSparseIndexes(t *testing.T) {

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -19,9 +19,24 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
+
+type countingBlockReadStore struct {
+	blob.BlobStore
+	getBlockCalls int
+}
+
+func (s *countingBlockReadStore) GetBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
+	s.getBlockCalls++
+	return s.BlobStore.GetBlock(txn, slot, hash)
+}
 
 func testIndexedBlock(slot, id uint64, hashByte byte) models.Block {
 	return models.Block{
@@ -71,6 +86,25 @@ func TestBlockBySlotSkipsStaleSameSlotIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, lowerIDBlock.ID, block.ID)
 	require.Equal(t, lowerIDBlock.Hash, block.Hash)
+}
+
+func TestBlockPointByIndexDoesNotReadBlockContent(t *testing.T) {
+	db := newTestDB(t)
+	block := testIndexedBlock(42, 7, 0x42)
+	require.NoError(t, db.BlockCreate(block, nil))
+
+	store := &countingBlockReadStore{BlobStore: db.blob}
+	db.blob = store
+
+	point, err := db.BlockPointByIndex(block.ID, nil)
+	require.NoError(t, err)
+	require.Equal(t, block.Slot, point.Slot)
+	require.Equal(t, block.Hash, point.Hash)
+	require.Zero(
+		t,
+		store.getBlockCalls,
+		"point-only lookup must not load block CBOR or trigger archive fallback",
+	)
 }
 
 func TestBlockAtOrAfterIndexSkipsSparseIndexes(t *testing.T) {

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -152,6 +152,38 @@ func TestBlockIDByPointLocalBypassesArchiveFallback(t *testing.T) {
 	)
 	require.ErrorIs(t, err, models.ErrBlockNotFound)
 	require.Zero(t, store.archiveFallbackCalls)
+
+	txn := db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		return db.Blob().TombstoneBlock(
+			txn.Blob(), block.Slot, block.Hash,
+		)
+	}))
+	blockID, err = BlockIDByPointLocal(
+		db,
+		ocommon.NewPoint(block.Slot, block.Hash),
+	)
+	require.NoError(t, err)
+	require.Equal(t, block.ID, blockID)
+	require.Zero(t, store.archiveFallbackCalls)
+
+	// Older cloud tombstones did not retain metadata. They cannot recover a
+	// local ID and must remain a non-match instead of aliasing block ID zero.
+	txn = db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *Txn) error {
+		return db.Blob().Delete(
+			txn.Blob(),
+			types.BlockBlobMetadataKey(
+				types.BlockBlobKey(block.Slot, block.Hash),
+			),
+		)
+	}))
+	_, err = BlockIDByPointLocal(
+		db,
+		ocommon.NewPoint(block.Slot, block.Hash),
+	)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+	require.Zero(t, store.archiveFallbackCalls)
 }
 
 func TestBlockAtOrAfterIndexSkipsSparseIndexes(t *testing.T) {

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -638,18 +638,23 @@ func (d *BlobStoreS3) GetBlock(
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
-	if types.IsBlockTombstone(cborData) {
-		return nil, types.BlockMetadata{},
-			&types.HistoryExpiredError{Slot: slot, Hash: hash}
-	}
+	isTombstone := types.IsBlockTombstone(cborData)
 	metadataKey := types.BlockBlobMetadataKey(key)
 	metadataBytes, err := d.resolveKey(ctx, t, metadataKey)
 	if err != nil {
+		if isTombstone && errors.Is(err, types.ErrBlobKeyNotFound) {
+			return nil, types.BlockMetadata{},
+				&types.HistoryExpiredError{Slot: slot, Hash: hash}
+		}
 		return nil, types.BlockMetadata{}, err
 	}
 	var tmpMetadata types.BlockMetadata
 	if _, err := cbor.Decode(metadataBytes, &tmpMetadata); err != nil {
 		return nil, types.BlockMetadata{}, err
+	}
+	if isTombstone {
+		return nil, tmpMetadata,
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	return cborData, tmpMetadata, nil
 }
@@ -689,11 +694,8 @@ func (d *BlobStoreS3) DeleteBlock(
 //   - bh<hash>: BlockByHash resolves only through this index and treats
 //     a missing entry as a hard miss (ErrBlockNotFound), so the entry
 //     must survive tombstoning to keep the block reachable by hash.
-//
-// What goes:
-//   - bp_metadata: GetBlock short-circuits on the expiry marker before
-//     reading metadata, and no other caller asks for local metadata of an
-//     expired block — bark's archive response carries its own.
+//   - bp_metadata: carries the local block ID, which Bark's archive does not
+//     know and primary-chain membership checks require.
 func (d *BlobStoreS3) TombstoneBlock(
 	txn types.Txn,
 	slot uint64,
@@ -707,9 +709,7 @@ func (d *BlobStoreS3) TombstoneBlock(
 		return err
 	}
 	key := types.BlockBlobKey(slot, hash)
-	metadataKey := types.BlockBlobMetadataKey(key)
 	t.stageSet(key, types.BlockTombstone())
-	t.stageDelete(metadataKey)
 	return nil
 }
 

--- a/database/plugin/blob/aws/tombstone_test.go
+++ b/database/plugin/blob/aws/tombstone_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTombstoneBlockRetainsMetadata(t *testing.T) {
+	store, err := NewWithOptions()
+	require.NoError(t, err)
+	store.client = new(s3.Client)
+	txn := store.NewTransaction(true)
+	slot := uint64(42)
+	hash := []byte("s3-tombstone-metadata")
+
+	require.NoError(t, store.SetBlock(
+		txn, slot, hash, []byte{0x80}, 7, 1, 6, nil,
+	))
+	require.NoError(t, store.TombstoneBlock(txn, slot, hash))
+
+	_, metadata, err := store.GetBlock(txn, slot, hash)
+	require.ErrorIs(t, err, types.ErrHistoryExpired)
+	require.Equal(t, uint64(7), metadata.ID)
+}

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -710,13 +710,14 @@ func (d *BlobStoreGCS) GetBlock(
 	if err != nil {
 		return nil, types.BlockMetadata{}, err
 	}
-	if types.IsBlockTombstone(cborData) {
-		return nil, types.BlockMetadata{},
-			&types.HistoryExpiredError{Slot: slot, Hash: hash}
-	}
+	isTombstone := types.IsBlockTombstone(cborData)
 	metadataKey := types.BlockBlobMetadataKey(key)
 	metadataBytes, err := d.resolveKey(ctx, t, metadataKey)
 	if err != nil {
+		if isTombstone && errors.Is(err, types.ErrBlobKeyNotFound) {
+			return nil, types.BlockMetadata{},
+				&types.HistoryExpiredError{Slot: slot, Hash: hash}
+		}
 		if errors.Is(err, types.ErrBlobKeyNotFound) {
 			// Block content exists but metadata is missing - this indicates a partial write
 			d.logger.Warningf(
@@ -730,6 +731,10 @@ func (d *BlobStoreGCS) GetBlock(
 	var tmpMetadata types.BlockMetadata
 	if _, err := cbor.Decode(metadataBytes, &tmpMetadata); err != nil {
 		return nil, types.BlockMetadata{}, err
+	}
+	if isTombstone {
+		return nil, tmpMetadata,
+			&types.HistoryExpiredError{Slot: slot, Hash: hash}
 	}
 	return cborData, tmpMetadata, nil
 }
@@ -769,11 +774,8 @@ func (d *BlobStoreGCS) DeleteBlock(
 //   - bh<hash>: BlockByHash resolves only through this index and treats
 //     a missing entry as a hard miss (ErrBlockNotFound), so the entry
 //     must survive tombstoning to keep the block reachable by hash.
-//
-// What goes:
-//   - bp_metadata: GetBlock short-circuits on the expiry marker before
-//     reading metadata, and no other caller asks for local metadata of an
-//     expired block — bark's archive response carries its own.
+//   - bp_metadata: carries the local block ID, which Bark's archive does not
+//     know and primary-chain membership checks require.
 func (d *BlobStoreGCS) TombstoneBlock(
 	txn types.Txn,
 	slot uint64,
@@ -787,9 +789,7 @@ func (d *BlobStoreGCS) TombstoneBlock(
 		return err
 	}
 	key := types.BlockBlobKey(slot, hash)
-	metadataKey := types.BlockBlobMetadataKey(key)
 	t.stageSet(key, types.BlockTombstone())
-	t.stageDelete(metadataKey)
 	return nil
 }
 

--- a/database/plugin/blob/gcs/tombstone_test.go
+++ b/database/plugin/blob/gcs/tombstone_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcs
+
+import (
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTombstoneBlockRetainsMetadata(t *testing.T) {
+	store, err := NewWithOptions()
+	require.NoError(t, err)
+	store.client = new(storage.Client)
+	store.bucket = new(storage.BucketHandle)
+	txn := store.NewTransaction(true)
+	slot := uint64(42)
+	hash := []byte("gcs-tombstone-metadata")
+
+	require.NoError(t, store.SetBlock(
+		txn, slot, hash, []byte{0x80}, 7, 1, 6, nil,
+	))
+	require.NoError(t, store.TombstoneBlock(txn, slot, hash))
+
+	_, metadata, err := store.GetBlock(txn, slot, hash)
+	require.ErrorIs(t, err, types.ErrHistoryExpired)
+	require.Equal(t, uint64(7), metadata.ID)
+}

--- a/database/plugin/blob/store.go
+++ b/database/plugin/blob/store.go
@@ -116,3 +116,14 @@ type BlobStore interface {
 	// object stores) may return nil.
 	Sync() error
 }
+
+// LocalBlockReader is an optional extension for wrappers that can bypass a
+// remote archive fallback. Database code uses it for bounded local probes
+// where a cache miss must remain a miss.
+type LocalBlockReader interface {
+	GetBlockLocal(
+		txn types.Txn,
+		slot uint64,
+		hash []byte,
+	) ([]byte, types.BlockMetadata, error)
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1054,6 +1054,30 @@ func (ls *LedgerState) headerAtOrImmediatelyBeforeTip(
 	return false
 }
 
+// headerAlreadyOnPrimaryChain identifies a replayed header that is already
+// present on the authoritative primary chain but is behind its current tip.
+// This shape is normal while a from-genesis ledger catches up after restart:
+// the block store can be far ahead of the applied ledger, and a peer may
+// replay a historical header while the local chain tip has already advanced.
+// It is not a fork and must not contribute to headerMismatchCount.
+func (ls *LedgerState) headerAlreadyOnPrimaryChain(e ChainsyncEvent) bool {
+	if ls.db == nil || e.Point.Slot == 0 || len(e.Point.Hash) == 0 {
+		return false
+	}
+	contains, err := ls.primaryChainContainsPoint(e.Point)
+	if err != nil {
+		ls.config.Logger.Debug(
+			"could not check historical header against primary chain",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"hash", hex.EncodeToString(e.Point.Hash),
+			"error", err,
+		)
+		return false
+	}
+	return contains
+}
+
 func (ls *LedgerState) findPeerForkPath(
 	e ChainsyncEvent,
 	initialPrevHash []byte,
@@ -2392,9 +2416,10 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	}
 	if err != nil {
 		if notFitErr, ok := errors.AsType[chain.BlockNotFitChainTipError](err); ok {
-			if ls.headerAtOrImmediatelyBeforeTip(e) {
+			if ls.headerAtOrImmediatelyBeforeTip(e) ||
+				ls.headerAlreadyOnPrimaryChain(e) {
 				ls.config.Logger.Debug(
-					"ignoring duplicate or reordered roll forward",
+					"ignoring duplicate, reordered, or historical primary-chain roll forward",
 					"component", "ledger",
 					"slot", e.Point.Slot,
 					"connection_id", e.ConnectionId.String(),

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1065,11 +1065,13 @@ func (ls *LedgerState) headerAtOrImmediatelyBeforeTip(
 // handling. A lookup failure is not evidence of a duplicate, so it is logged
 // and reported as a non-match.
 //
-// primaryChainContainsPoint reads the block store twice, and the caller holds
-// chainsyncMutex, so the two in-memory guards below keep those reads off the
-// paths that cannot need them: the origin point carries no hash, and the
-// block-index entries only cover blocks up to localTip, so a header beyond
-// that tip cannot already be on the primary chain.
+// The caller holds chainsyncMutex, so the guards below keep storage reads off
+// paths that cannot need them. The origin point carries no hash, and a header
+// beyond the localTip snapshot is not observed in the primary-chain index at
+// handler entry. The O(1) local hash index then rejects an unknown fork header
+// before a point lookup could fall through to a configured Bark archive. On a
+// hash-index hit, the returned block ID is checked through the point-only
+// primary-chain index path, avoiding a second block-CBOR read.
 func (ls *LedgerState) headerAlreadyOnPrimaryChain(
 	e ChainsyncEvent,
 	localTip ochainsync.Tip,
@@ -1080,7 +1082,21 @@ func (ls *LedgerState) headerAlreadyOnPrimaryChain(
 	if e.Point.Slot > localTip.Point.Slot {
 		return false
 	}
-	contains, err := ls.primaryChainContainsPoint(e.Point)
+	block, err := ls.blockByHash(e.Point.Hash)
+	if errors.Is(err, models.ErrBlockNotFound) {
+		return false
+	}
+	if err != nil {
+		ls.config.Logger.Debug(
+			"could not prefilter historical header by hash index",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"hash", hex.EncodeToString(e.Point.Hash),
+			"error", err,
+		)
+		return false
+	}
+	contains, err := ls.primaryChainContainsBlock(block, e.Point)
 	if err != nil {
 		ls.config.Logger.Debug(
 			"could not check historical header against primary chain",

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1071,7 +1071,9 @@ func (ls *LedgerState) headerAtOrImmediatelyBeforeTip(
 // handler entry. The O(1) local hash index then rejects an unknown fork header
 // before a point lookup could fall through to a configured Bark archive. On a
 // hash-index hit, the returned block ID is checked through the point-only
-// primary-chain index path, avoiding a second block-CBOR read.
+// primary-chain index path, avoiding a second block-CBOR read. A hash-index
+// miss also probes the exact local point key for pre-index databases, but that
+// bounded compatibility lookup cannot fall through to Bark's archive.
 func (ls *LedgerState) headerAlreadyOnPrimaryChain(
 	e ChainsyncEvent,
 	localTip ochainsync.Tip,
@@ -1084,7 +1086,35 @@ func (ls *LedgerState) headerAlreadyOnPrimaryChain(
 	}
 	block, err := ls.blockByHash(e.Point.Hash)
 	if errors.Is(err, models.ErrBlockNotFound) {
-		return false
+		// Blocks written before the hash index was introduced still have an
+		// exact point key and metadata. Probe that local path without allowing
+		// Bark to fall through to its archive on an unknown fork hash.
+		blockID, localErr := database.BlockIDByPointLocal(ls.db, e.Point)
+		if errors.Is(localErr, models.ErrBlockNotFound) {
+			return false
+		}
+		if localErr != nil {
+			ls.config.Logger.Debug(
+				"could not check legacy historical header by local point",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"hash", hex.EncodeToString(e.Point.Hash),
+				"error", localErr,
+			)
+			return false
+		}
+		contains, localErr := ls.primaryChainContainsBlockID(blockID, e.Point)
+		if localErr != nil {
+			ls.config.Logger.Debug(
+				"could not check legacy historical header against primary chain",
+				"component", "ledger",
+				"slot", e.Point.Slot,
+				"hash", hex.EncodeToString(e.Point.Hash),
+				"error", localErr,
+			)
+			return false
+		}
+		return contains
 	}
 	if err != nil {
 		ls.config.Logger.Debug(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1060,8 +1060,24 @@ func (ls *LedgerState) headerAtOrImmediatelyBeforeTip(
 // the block store can be far ahead of the applied ledger, and a peer may
 // replay a historical header while the local chain tip has already advanced.
 // It is not a fork and must not contribute to headerMismatchCount.
-func (ls *LedgerState) headerAlreadyOnPrimaryChain(e ChainsyncEvent) bool {
-	if ls.db == nil || e.Point.Slot == 0 || len(e.Point.Hash) == 0 {
+//
+// Only a point confirmed present in the primary-chain index suppresses fork
+// handling. A lookup failure is not evidence of a duplicate, so it is logged
+// and reported as a non-match.
+//
+// primaryChainContainsPoint reads the block store twice, and the caller holds
+// chainsyncMutex, so the two in-memory guards below keep those reads off the
+// paths that cannot need them: the origin point carries no hash, and the
+// block-index entries only cover blocks up to localTip, so a header beyond
+// that tip cannot already be on the primary chain.
+func (ls *LedgerState) headerAlreadyOnPrimaryChain(
+	e ChainsyncEvent,
+	localTip ochainsync.Tip,
+) bool {
+	if ls.db == nil || len(e.Point.Hash) == 0 {
+		return false
+	}
+	if e.Point.Slot > localTip.Point.Slot {
 		return false
 	}
 	contains, err := ls.primaryChainContainsPoint(e.Point)
@@ -2416,10 +2432,9 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	}
 	if err != nil {
 		if notFitErr, ok := errors.AsType[chain.BlockNotFitChainTipError](err); ok {
-			if ls.headerAtOrImmediatelyBeforeTip(e) ||
-				ls.headerAlreadyOnPrimaryChain(e) {
+			if ls.headerAtOrImmediatelyBeforeTip(e) {
 				ls.config.Logger.Debug(
-					"ignoring duplicate, reordered, or historical primary-chain roll forward",
+					"ignoring duplicate or reordered roll forward",
 					"component", "ledger",
 					"slot", e.Point.Slot,
 					"connection_id", e.ConnectionId.String(),
@@ -2449,6 +2464,20 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 					"local_tip_slot", localTip.Point.Slot,
 					"block_prev_hash", notFitErr.BlockPrevHash(),
 					"chain_tip_hash", notFitErr.TipHash(),
+					"connection_id", e.ConnectionId.String(),
+				)
+				return nil
+			}
+			// A header still on the authoritative primary chain is a
+			// historical replay, not a competing candidate. Checked after
+			// the in-memory discards above because it reads the block
+			// store while chainsyncMutex is held.
+			if ls.headerAlreadyOnPrimaryChain(e, localTip) {
+				ls.config.Logger.Debug(
+					"ignoring historical primary-chain roll forward",
+					"component", "ledger",
+					"slot", e.Point.Slot,
+					"local_tip_slot", localTip.Point.Slot,
 					"connection_id", e.ConnectionId.String(),
 				)
 				return nil

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -2208,7 +2208,74 @@ func TestHandleEventChainsyncBlockHeaderIgnoresHistoricalPrimaryHeader(
 	require.NoError(t, err)
 	assert.Zero(t, fixture.ls.headerMismatchCount)
 	assert.Zero(t, fixture.ls.chain.HeaderCount())
-	assert.Equal(t, uint64(40), fixture.ls.chain.Tip().Point.Slot)
+	assert.Equal(
+		t,
+		ochainsync.Tip{
+			Point:       ocommon.NewPoint(40, block4Hash),
+			BlockNumber: 4,
+		},
+		fixture.ls.chain.Tip(),
+	)
+}
+
+// A Byron epoch-boundary block sits at slot 0 with a real hash, so rejecting
+// every slot-zero point would classify a replay of that block as a fork.
+// Only the origin point, which carries no hash, is rejected outright.
+func TestHeaderAlreadyOnPrimaryChainAcceptsSlotZeroBlock(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{securityParam: 2}),
+	)
+	genesisHash := testHashBytes("byron-boundary-slot-zero")
+	require.NoError(
+		t,
+		cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
+			{
+				Slot:        0,
+				Hash:        genesisHash,
+				BlockNumber: 0,
+				Type:        1,
+				Cbor:        []byte{0x80},
+			},
+		}),
+	)
+	ls, err := NewLedgerState(
+		LedgerStateConfig{
+			Database:          db,
+			ChainManager:      cm,
+			CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+			Logger: slog.New(
+				slog.NewJSONHandler(io.Discard, nil),
+			),
+		},
+	)
+	require.NoError(t, err)
+	localTip := ls.chain.Tip()
+	require.Equal(t, uint64(0), localTip.Point.Slot)
+	require.Equal(t, genesisHash, localTip.Point.Hash)
+
+	assert.True(t, ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{Point: ocommon.NewPoint(0, genesisHash)},
+		localTip,
+	))
+	// The origin point is not a block and is not evidence of a duplicate.
+	assert.False(t, ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{Point: ocommon.NewPointOrigin()},
+		localTip,
+	))
+	// A competing slot-zero block is still a candidate fork.
+	assert.False(t, ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{
+			Point: ocommon.NewPoint(
+				0,
+				testHashBytes("competing-slot-zero"),
+			),
+		},
+		localTip,
+	))
 }
 
 func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -2230,6 +2230,18 @@ func TestHeaderAlreadyOnPrimaryChainAcceptsSlotZeroBlock(t *testing.T) {
 		cm.SetLedger(testSecurityParamLedger{securityParam: 2}),
 	)
 	genesisHash := testHashBytes("byron-boundary-slot-zero")
+	abandonedHash := testHashBytes("abandoned-slot-zero-fork")
+	// Persist the abandoned block first at ID 1. Adding the primary block
+	// below reuses ID 1 for the authoritative index while retaining this blob,
+	// matching the append-only fork shape primaryChainContainsBlock must reject.
+	require.NoError(t, db.BlockCreate(models.Block{
+		ID:     1,
+		Slot:   0,
+		Hash:   abandonedHash,
+		Cbor:   []byte{0x80},
+		Type:   1,
+		Number: 0,
+	}, nil))
 	require.NoError(
 		t,
 		cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
@@ -2261,6 +2273,12 @@ func TestHeaderAlreadyOnPrimaryChainAcceptsSlotZeroBlock(t *testing.T) {
 		ChainsyncEvent{Point: ocommon.NewPoint(0, genesisHash)},
 		localTip,
 	))
+	// Blob presence is insufficient: the abandoned block is still retrievable
+	// by hash, but ID 1 now indexes the primary block above.
+	assert.False(t, ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{Point: ocommon.NewPoint(0, abandonedHash)},
+		localTip,
+	))
 	// The origin point is not a block and is not evidence of a duplicate.
 	assert.False(t, ls.headerAlreadyOnPrimaryChain(
 		ChainsyncEvent{Point: ocommon.NewPointOrigin()},
@@ -2276,6 +2294,48 @@ func TestHeaderAlreadyOnPrimaryChainAcceptsSlotZeroBlock(t *testing.T) {
 		},
 		localTip,
 	))
+}
+
+func TestHeaderAlreadyOnPrimaryChainUsesHashIndexPrefilter(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	localTip := fixture.ls.chain.Tip()
+	lookupCalls := 0
+	fixture.ls.lookupBlockByHash = func([]byte) (models.Block, error) {
+		lookupCalls++
+		return models.Block{}, models.ErrBlockNotFound
+	}
+
+	assert.False(t, fixture.ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{
+			Point: ocommon.NewPoint(
+				localTip.Point.Slot,
+				testHashBytes("unknown-fork-header"),
+			),
+		},
+		localTip,
+	))
+	assert.Equal(t, 1, lookupCalls)
+}
+
+func TestHeaderAlreadyOnPrimaryChainSkipsLookupBeyondLocalTip(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	localTip := fixture.ls.chain.Tip()
+	lookupCalled := false
+	fixture.ls.lookupBlockByHash = func([]byte) (models.Block, error) {
+		lookupCalled = true
+		return models.Block{}, errors.New("unexpected lookup")
+	}
+
+	assert.False(t, fixture.ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{
+			Point: ocommon.NewPoint(
+				localTip.Point.Slot+1,
+				testHashBytes("header-beyond-local-tip"),
+			),
+		},
+		localTip,
+	))
+	assert.False(t, lookupCalled)
 }
 
 func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -28,7 +28,9 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -2315,6 +2317,24 @@ func TestHeaderAlreadyOnPrimaryChainUsesHashIndexPrefilter(t *testing.T) {
 		localTip,
 	))
 	assert.Equal(t, 1, lookupCalls)
+}
+
+func TestHeaderAlreadyOnPrimaryChainSupportsLegacyHashIndexMiss(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	localTip := fixture.ls.chain.Tip()
+
+	txn := fixture.ls.db.BlobTxn(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return fixture.ls.db.Blob().Delete(
+			txn.Blob(),
+			types.BlockHashIndexKey(localTip.Point.Hash),
+		)
+	}))
+
+	assert.True(t, fixture.ls.headerAlreadyOnPrimaryChain(
+		ChainsyncEvent{Point: localTip.Point},
+		localTip,
+	))
 }
 
 func TestHeaderAlreadyOnPrimaryChainSkipsLookupBeyondLocalTip(t *testing.T) {

--- a/ledger/chainsync_rollback_test.go
+++ b/ledger/chainsync_rollback_test.go
@@ -2158,6 +2158,59 @@ func TestLedgerProcessBlocksFromSourceRestartsOnStaleIteratorRollback(
 	require.ErrorIs(t, err, errRestartLedgerPipeline)
 }
 
+func TestHandleEventChainsyncBlockHeaderIgnoresHistoricalPrimaryHeader(
+	t *testing.T,
+) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.config.GenesisSelectionStateFunc = func() (bool, uint64) {
+		return true, 100
+	}
+
+	// Leave the applied ledger at currentTip while extending the authoritative
+	// primary chain two blocks farther. A replayed header for the first of those
+	// blocks is historical relative to the primary tip, but it is not a fork.
+	block3Hash := testHashBytes("historical-primary-block-3")
+	block4Hash := testHashBytes("historical-primary-block-4")
+	require.NoError(t, fixture.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        30,
+			Hash:        block3Hash,
+			BlockNumber: 3,
+			Type:        1,
+			PrevHash:    fixture.currentTip.Point.Hash,
+			Cbor:        []byte{0x80},
+		},
+		{
+			Slot:        40,
+			Hash:        block4Hash,
+			BlockNumber: 4,
+			Type:        1,
+			PrevHash:    block3Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+
+	err := fixture.ls.handleEventChainsyncBlockHeader(ChainsyncEvent{
+		ConnectionId: fixture.connId,
+		Point:        ocommon.NewPoint(30, block3Hash),
+		BlockHeader: mockHeader{
+			hash:        lcommon.NewBlake2b256(block3Hash),
+			prevHash:    lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+			blockNumber: 3,
+			slot:        30,
+		},
+		Tip: ochainsync.Tip{
+			Point:       ocommon.NewPoint(40, block4Hash),
+			BlockNumber: 4,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, fixture.ls.headerMismatchCount)
+	assert.Zero(t, fixture.ls.chain.HeaderCount())
+	assert.Equal(t, uint64(40), fixture.ls.chain.Tip().Point.Slot)
+}
+
 func newChainsyncRollbackFixture(t *testing.T) *chainsyncRollbackFixture {
 	t.Helper()
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -7002,12 +7002,19 @@ func (ls *LedgerState) primaryChainContainsBlock(
 	if block.Slot != point.Slot || !bytes.Equal(block.Hash, point.Hash) {
 		return false, nil
 	}
+	return ls.primaryChainContainsBlockID(block.ID, point)
+}
+
+func (ls *LedgerState) primaryChainContainsBlockID(
+	blockID uint64,
+	point ocommon.Point,
+) (bool, error) {
 	// Blob presence by point is not authoritative: abandoned-fork blocks remain
 	// in the append-only blob store. The current primary chain is identified by
 	// its block-index entry, so compare the point encoded at this ID with the
 	// requested point. Reading only the index value avoids loading the indexed
 	// block's CBOR a second time while chainsyncMutex is held.
-	indexedPoint, err := ls.db.BlockPointByIndex(block.ID, nil)
+	indexedPoint, err := ls.db.BlockPointByIndex(blockID, nil)
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return false, nil

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -6988,18 +6988,33 @@ func (ls *LedgerState) primaryChainContainsPoint(
 		}
 		return false, err
 	}
+	return ls.primaryChainContainsBlock(block, point)
+}
+
+// primaryChainContainsBlock checks whether block's internal ID currently maps
+// to point on the authoritative primary chain. The block itself may come from
+// an abandoned fork retained in the append-only blob store, so blob presence
+// alone is not authoritative.
+func (ls *LedgerState) primaryChainContainsBlock(
+	block models.Block,
+	point ocommon.Point,
+) (bool, error) {
+	if block.Slot != point.Slot || !bytes.Equal(block.Hash, point.Hash) {
+		return false, nil
+	}
 	// Blob presence by point is not authoritative: abandoned-fork blocks remain
 	// in the append-only blob store. The current primary chain is identified by
-	// its block-index entry, so compare the indexed block at this ID with the
-	// requested point.
-	indexedBlock, err := ls.db.BlockByIndex(block.ID, nil)
+	// its block-index entry, so compare the point encoded at this ID with the
+	// requested point. Reading only the index value avoids loading the indexed
+	// block's CBOR a second time while chainsyncMutex is held.
+	indexedPoint, err := ls.db.BlockPointByIndex(block.ID, nil)
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return false, nil
 		}
 		return false, err
 	}
-	return bytes.Equal(indexedBlock.Hash, point.Hash), nil
+	return pointMatches(indexedPoint, point), nil
 }
 
 // durableAppliedFloor returns the point of the highest block whose ledger


### PR DESCRIPTION
## Summary

- Treat chainsync headers already on the authoritative primary chain as historical replays.
- Stop unknown fork hashes at the local hash index before Bark archive fallback.
- Preserve pre-hash-index databases with a local-only point fallback.
- Retain cloud tombstone metadata needed for local block IDs.
- Compare the primary-chain index point without rereading block CBOR.
- Document the local-tip snapshot and queued-header behavior.

## Validation

- `go test -tags dingo_extra_plugins -race -count=1 -timeout 20m ./database ./ledger ./chain`
- `go test -count=1 ./internal/test/conformance/`
- `go build -buildvcs=false -tags dingo_extra_plugins ./...`
- `GOCACHE=/tmp/dingo-pr3250-gocache-lint GOLANGCI_LINT_CACHE=/tmp/dingo-pr3250-golangci-cache GOFLAGS=-buildvcs=false make lint`
- `make docs-parity import-boundaries gorm-check`
- `go test -tags dingo_extra_plugins -race -count=1 ./bark`
- `go test -tags dingo_extra_plugins -race -count=1 -run TestTombstoneBlockRetainsMetadata ./database/plugin/blob/aws ./database/plugin/blob/gcs`
- accelerated DevNet scenario
