### PR TITLE
fix(ledger): harden block pipeline validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7357,175 +7357,60 @@ batch-oriented apply contract or a restart-signal mechanism, or redesigning
 dingo's apply loop to be per-block and restart-tolerant — tracked
 separately in #3227, not folded into #1894's decode/validate phases.
 
-**Phase 3: parallel VRF/KES validation.** `LedgerStateConfig.BlockPipelineValidateEnabled`
-(config `blockPipelineValidateEnabled` / `DINGO_BLOCK_PIPELINE_VALIDATE_ENABLED`
-/ `--block-pipeline-validate-enabled`; default off; requires
-`BlockPipelineEnabled` too — `configValidate` rejects the combination
-otherwise) turns on the pipeline's validate stage
-(`gouroboros/pipeline.WithValidateWorkers`) alongside decode, using
-`blockPipelineValidateWorkers` (2) parallel workers. Each block
-`decodeReadChainBatch` decodes is independently re-verified — VRF proof and
-KES signature only, via `gouroboros/ledger.VerifyBlock`'s block-local
-checks — before being handed to `ledgerProcessBlocksFromSource`, exactly as
-decode-only phase 1 already did for CBOR decode.
+**Phase 3: parallel header-crypto validation.**
+`LedgerStateConfig.BlockPipelineValidateEnabled` (config
+`blockPipelineValidateEnabled` / `DINGO_BLOCK_PIPELINE_VALIDATE_ENABLED` /
+`--block-pipeline-validate-enabled`; default off) requires
+`BlockPipelineEnabled` and adds two checks to replay:
 
-Wiring, in `NewLedgerState`:
+- gouroboros validate workers verify the block-local VRF proof and KES
+  signature with `ledger.VerifyBlock`;
+- after an item passes that stage, `decodeReadChainBatch` verifies Dingo's
+  remaining stateless OpCert contract: the cold-key Ed25519 signature and
+  `MaxKESEvolutions` expiry. OpCert counter monotonicity remains a stateful
+  read-before-write check in `ledgerProcessBlock`.
 
-- `pipeline.WithEta0Provider(ls.blockPipelineEta0Provider)`:
-  `blockPipelineEta0Provider` (`ledger/verify_header.go`) looks up the epoch
-  nonce for a block's slot using the same epoch-cache machinery as the
-  serial header-crypto path (`headerVerificationEpoch`, `epochNonceHex`),
-  but with `allowEpochCacheAdvance=false` — unlike the chainsync-header
-  path, which must forecast ahead of ledger apply for freshly-arriving live
-  headers, the pipeline only ever validates blocks already committed to
-  `ls.chain`, so the epoch cache should already cover them, and not
-  advancing it avoids mutating shared epoch-cache state concurrently from
-  multiple validate-stage worker goroutines (none of which are otherwise
-  synchronized with each other).
-- `pipeline.WithSlotsPerKesPeriod(ls.SlotsPerKESPeriod())` and
-  `pipeline.WithVerifyConfig(lcommon.VerifyConfig{SkipBodyHashValidation:
-  true, SkipTransactionValidation: true, SkipStakePoolValidation: true})` —
-  matching the scope of the existing serial header-only check
-  (`verifyBlockHeaderHex`): VRF/KES only, not body hash, transaction, or
-  stake-pool validation, which dingo performs separately elsewhere
-  (`ledgerProcessBlock`'s tx/UTxO validation; the registered-VRF-key and
-  leader-eligibility checks in `verifyBlockHeaderState` that stand in for
-  gouroboros' generic stake-pool check).
-- gouroboros' `ApplyStage.SetRequireValidation` is wired automatically by
-  `pipeline.BlockPipeline.Start` whenever `ValidateWorkers > 0` — dingo does
-  not call it directly.
+`NewLedgerState` fails startup when this stage is enabled without a nonzero
+Shelley `slotsPerKESPeriod`; otherwise the generic stage would reject every
+Praos block with a captured zero value.
 
-Byron-era blocks have no VRF/KES fields and no Praos epoch nonce
-(`blockPipelineEta0Provider` always fails the nonce lookup for them, and
-gouroboros' generic `ValidateStage` has no Byron short-circuit of its own —
-unlike the serial path's `verifyBlockHeaderHex`, which explicitly skips
-Byron blocks). `decodeReadChainBatch` therefore ignores the pipeline's
-validation outcome specifically (and only) for blocks whose decoded
-`Era().Id == byron.EraIdByron`, mirroring `verifyBlockHeaderHex`'s own
-skip. For every other era, a validation failure (crypto rejection, or the
-Eta0Provider erroring because the epoch cache does not yet cover the
-block's slot) is treated exactly like a decode failure: the whole batch is
-discarded and `decodeReadChainBatch` returns `ok=false`, letting the
-existing `ledgerProcessBlocks` retry-with-backoff loop (see below) recover
-once the epoch cache catches up, or surface as a stuck pipeline if the
-rejection is deterministic.
+This replay check is defense in depth, not a substitute for admission-time
+validation. `handleEventChainsyncBlockHeaderWithPending` and
+`handleEventBlockfetchBlock` retain the serial header gate. This ordering is
+required because blockfetch persistence advances `ls.chain` before the
+ledger reader reaches the validate stage, and `ls.chain` is consumed by the
+downstream blockfetch server and UTxO RPC sync/watch readers. A block that has
+not passed admission crypto must therefore never enter that chain.
 
-**`errorsChan` must be continuously drained for the pipeline's whole
-lifetime, or every real chain sync deadlocks.** `gouroboros/pipeline`'s
-`StageWorkerPool.worker` pushes *every* non-nil stage error onto a
-fixed-capacity `errorsChan` (`PipelineConfig.PrefetchBufferSize`, 1000 by
-default) *before* forwarding the item onward to `Results()` —
-unconditionally, regardless of whether the error is one `decodeReadChainBatch`
-will later ignore when it reads the same item back (as it does for
-Byron-era blocks, above). Nothing else in gouroboros drains that channel.
-Since every from-genesis or pre-Shelley-boundary sync submits far more than
-1000 Byron-era blocks, `errorsChan` fills permanently after roughly that
-many, and every validate worker then blocks forever on `errors <- err`
-(its only escape is the pipeline's own long-lived `Start` context, not a
-per-block one) — cascading backpressure through
-`validatedChan`/`decodedChan`/`submitChan` into `decodeReadChainBatch`'s
-`Submit()` calls, which run on `context.Background()` by design (see
-above) and therefore hang forever with no log line, no error, and no
-timeout. `LedgerState.Start` closes this gap by launching
-`drainBlockPipelineErrors` immediately after `ls.blockPipeline.Start`
-succeeds: a goroutine that ranges over `ls.blockPipeline.Errors()` for the
-pipeline's entire lifetime, so `errorsChan` never fills regardless of how
-many validate/decode/apply errors flow through it. It exits once `Close`'s
-`ls.blockPipeline.Stop()` closes the channel (`Stop` closes `errorsChan`
-only after every stage has fully drained), and `Close` waits for that exit
-(`ls.blockPipelineErrorsDone`) as part of the same bounded
-`CloseBlockPipelineDrainTimeout` wait already used for `Stop` itself, so
-this goroutine cannot outlive the `LedgerState`.
+`blockPipelineEta0Provider` reads the immutable epoch-cache snapshot directly;
+it does not forecast, mutate the cache, or rebuild `HardForkSummary` per
+block. `decodeReadChainBatch` enforces pipeline results only when the serial
+path has enough state to make the same decision: validation is enabled, the
+slot is above the Mithril trust boundary, and the published epoch cache has a
+nonce for the slot. Byron, trusted historical replay, Mithril-covered blocks,
+and missing/deferred nonce states ignore the generic stage's validation
+outcome and continue through their existing trust/deferred-validation paths.
+This keeps pipeline mode acceptance-equivalent to serial mode instead of
+turning an unavailable nonce into a rejected chain.
 
-Each drained error is classified by `recordBlockPipelineError`
-(`ledger/state.go`) on error identity, not era: `errorsChan` carries a bare
-`error` with no item context, so only `decodeReadChainBatch` — which holds
-the decoded block — can and does gate enforcement on `block.Era().Id`; this
-classification only affects operator visibility.
+The pipeline's bounded `errorsChan` is continuously drained by
+`drainBlockPipelineErrors` for the lifetime of `LedgerState`; otherwise the
+workers would deadlock after enough deferred nonce-state errors. The drain
+classifies `errBlockPipelineEta0Unavailable` and
+`errHeaderVerificationDeferred` at debug level and reports other stage errors
+at error level. Enforcement happens from each `BlockItem`, where the decoded
+era and slot are available; the bare errors channel is observability only.
 
-- `errBlockPipelineEta0Unavailable` (`ledger/verify_header.go`):
-  `blockPipelineEta0Provider` wraps `headerVerificationEpoch`'s
-  `errEpochNonceUnavailable` in this sentinel — raised solely by that
-  function's empty-nonce branch (epoch data covers the slot, but that epoch
-  has no Praos nonce). This is how every Byron-era slot fails the lookup,
-  but the underlying condition (epoch rollover not yet processed) is not
-  verified to be Byron-specific here, so the debug log this produces does
-  not claim Byron specifically. It is counted in
-  `dingo_ledger_block_pipeline_expected_eta0_errors_total`.
-- `errHeaderVerificationDeferred` (past-horizon/missing-epoch-data): the
-  pipeline's epoch cache has not yet caught up with a block already
-  committed to `ls.chain`. This is the same transient, self-healing race
-  described above ("resolves once the epoch cache catches up"), so it is
-  logged at debug level and counted separately in
-  `dingo_ledger_block_pipeline_deferred_epoch_cache_errors_total`, not
-  folded into the unexpected-error bucket below.
-- Everything else reaching `errorsChan` (decode errors, non-Byron validation
-  failures, hard-fork-summary lookup failures, forecast-build errors,
-  `pipeline.ErrBlockNotValidated` and other apply-stage invariant
-  violations) is logged at error level and counted in
-  `dingo_ledger_block_pipeline_unexpected_errors_total` — a nonzero value
-  there indicates a genuine decode/validate/apply problem worth
-  investigating, distinct from the two expected/transient counters above.
-
-These three are independent counters from the pre-existing
-`dingo_ledger_block_pipeline_decode_errors` / `_validation_errors` gauges
-(which snapshot `pipeline.PipelineStats` and already conflate expected and
-unexpected causes).
-
-**Admission-time crypto re-check is skipped once the pipeline will redo
-it.** Earlier revisions of this phase left the existing serial VRF/KES
-checks that gate what is admitted to `ls.chain`
-(`handleEventChainsyncBlockHeaderWithPending` for headers,
-`handleEventBlockfetchBlock` for bodies, in `chainsync.go`, both gated on
-`validationEnabled`/`ValidateHistorical`) completely unchanged, so with
-`ValidateHistorical=true` (the default) every block was cryptographically
-verified twice: once at admission, once more by the pipeline's validate
-stage before apply. `blockPipelineRevalidatesCrypto` (`ledger/chainsync.go`)
-now reports whether every block reaching admission will independently pass
-through the pipeline's validate stage before ledger apply
-(`ls.blockPipeline != nil && LedgerStateConfig.BlockPipelineValidateEnabled`
-— nil `blockPipeline` correctly keeps this false whenever
-`BlockPipelineEnabled` is off or `ManualBlockProcessing` bypasses the
-pipeline entirely, matching `NewLedgerState`'s construction rule). When
-true:
-
-- `shouldVerifyChainsyncHeaderCrypto` returns `false`, so
-  `handleEventChainsyncBlockHeaderWithPending` skips the chainsync-header-time
-  stateless crypto pre-check (`verifyBlockHeaderOnlyCrypto`) and queues the
-  header via `AddBlockHeader` (unverified) rather than
-  `AddVerifiedBlockHeader`.
-- `handleEventBlockfetchBlock` skips the crypto half of
-  `verifyBlockHeaderCryptoBeforeApply` and calls
-  `verifyBlockHeaderStateWithEpochAdvance(block, true, true)` directly
-  instead — the same function already used for the "header already
-  verified by chainsync" fast path. This still runs, unconditionally:
-  the registered-VRF-key and leader-eligibility state checks
-  (`verifyBlockHeaderState`, not performed by the pipeline's validate stage,
-  which is scoped to VRF/KES only) and the epoch-cache-advance side effect
-  (`headerVerificationEpoch`'s `ensureEpochForSlot`, `allowEpochCacheAdvance
-  = true`) that the pipeline's own `Eta0Provider` deliberately does not
-  perform (see below) — only the redundant stateless VRF/KES crypto
-  verification itself is skipped.
-
-The actual gate on ledger application is unchanged: `decodeReadChainBatch`
-still aborts the whole read batch if the pipeline's validate stage rejects
-any block in it (treated exactly like a decode failure), so a block that
-skips admission-time crypto re-verification is still cryptographically
-verified, exactly once, before it can ever be applied to the ledger.
-
-The trade-off this formalizes: for a brief window between header/body
-admission to `ls.chain` and that block being read back out for pipeline
-validation, a not-yet-crypto-verified block can influence in-memory
-chain-selection bookkeeping (fork/rollback resolution, header-queue
-ordering) — the same class of trust window already accepted, unconditionally,
-for `ValidateHistorical=false` historical sync. `ls.chain` is purely an
-internal candidate/queue structure feeding ledger apply (see
-`ledgerReadChainIterator`); it is not consulted by any downstream
-chainsync-server/relay path, so this window does not cause dingo to relay
-an unverified block to other peers. With `ValidateHistorical=false`, nothing
-changes: admission was already skipping this check before
-`BlockPipelineValidateEnabled` existed, and the pipeline continues to close
-that coverage gap as described above.
+A genuine VRF/KES/OpCert rejection after persistence is returned as a
+`headerValidationError` carrying the rejected block point.
+`ledgerReadChainIterator` forwards it in `readChainResult.err`, and
+`ledgerProcessBlocksFromSource` calls
+`tryRecoverFromHeaderValidationError`: the primary chain and ledger rewind to
+the last applied tip, chainsync receives a resync event, and the pipeline
+restarts on a chain that no longer contains the rejected block. The reader
+still drains every result from a submitted batch before reporting the first
+failure, so the shared ordered pipeline cannot leak stale results into the
+next attempt.
 
 **Fork-resolution header-queue overflow must still restart blockfetch.**
 Bursty near-tip conditions (many peers racing small competing forks in quick

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -486,16 +486,12 @@ validateHistorical: true
 # CLI: --block-pipeline-enabled
 blockPipelineEnabled: false
 
-# Also VRF/KES-validate blocks in the block-pipeline replay loop with a
-# parallel worker pool (default: false). Requires blockPipelineEnabled to
-# also be set. This moves the VRF/KES crypto check to run in parallel,
-# immediately before ledger apply, instead of serially at admission: once
-# every admitted block is guaranteed to pass through this check, the
-# existing serial admission-time VRF/KES crypto check is skipped as
-# redundant. Admission-time checks that the pipeline's validate stage does
-# not perform -- the registered-VRF-key/leader-eligibility state checks and
-# the epoch-cache-advance side effect -- still run unconditionally. See
-# ARCHITECTURE.md ("Block Processing Pipeline").
+# Also validate VRF/KES and OpCert crypto during block-pipeline replay with a
+# parallel worker pool (default: false). Requires blockPipelineEnabled.
+# Admission-time crypto remains authoritative because persisted chain blocks
+# are available to downstream readers before replay reaches this stage. The
+# replay check follows the serial path's historical, Mithril, and epoch-nonce
+# availability gates. See ARCHITECTURE.md ("Block Processing Pipeline").
 #
 # Can be overridden with the DINGO_BLOCK_PIPELINE_VALIDATE_ENABLED
 # environment variable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -575,18 +575,12 @@ type Config struct {
 	// defaults off until throughput and stability are proven (issue #1894
 	// phase 1). See ARCHITECTURE.md ("Block Processing Pipeline").
 	BlockPipelineEnabled bool `yaml:"blockPipelineEnabled"         envconfig:"DINGO_BLOCK_PIPELINE_ENABLED"`
-	// BlockPipelineValidateEnabled turns on the block pipeline's VRF/KES
-	// validate stage (issue #1894 phase 3), in addition to decode. Has no
-	// effect unless BlockPipelineEnabled is also set. This moves the
-	// VRF/KES crypto check to run in parallel, immediately before ledger
-	// apply, instead of serially at admission: once every admitted block is
-	// guaranteed to pass through this check, the existing serial
-	// admission-time VRF/KES crypto check is skipped as redundant (see
-	// blockPipelineRevalidatesCrypto). Admission-time checks the pipeline's
-	// validate stage does not perform -- the registered-VRF-key/
-	// leader-eligibility state checks and the epoch-cache-advance side
-	// effect -- still run unconditionally. See ARCHITECTURE.md ("Block
-	// Processing Pipeline").
+	// BlockPipelineValidateEnabled adds parallel VRF/KES and OpCert checks to
+	// block-pipeline replay (issue #1894 phase 3). It requires
+	// BlockPipelineEnabled. Admission-time header validation remains the
+	// authoritative gate because ls.chain is visible to downstream readers
+	// before replay reaches this stage. See ARCHITECTURE.md ("Block Processing
+	// Pipeline").
 	BlockPipelineValidateEnabled bool `yaml:"blockPipelineValidateEnabled" envconfig:"DINGO_BLOCK_PIPELINE_VALIDATE_ENABLED"`
 
 	// Peer targets (0 = use default, -1 = unlimited)

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -187,6 +187,15 @@ Plain `docker compose` invocations are not location-independent — pass
 compose file's `build.context` paths (`.` and `../../..`) are resolved
 relative to the compose file itself, not your shell's CWD.
 
+The block replay validation path is opt-in, matching production defaults.
+Set both passthroughs when a change needs that path in either DevNet profile:
+
+```bash
+DEVNET_BLOCK_PIPELINE_ENABLED=true \
+DEVNET_BLOCK_PIPELINE_VALIDATE_ENABLED=true \
+  ./run-tests.sh --accelerated
+```
+
 The scripts must, however, stay at this path inside the repo: the compose
 file references `../../..` to pick up the Dingo source tree for its build
 context, and the `topology/*.json` and `testnet*.yaml` files are mounted by

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -110,6 +110,8 @@ services:
       DINGO_PLEDGE_LEVERAGE: "${DEVNET_DINGO_PLEDGE_LEVERAGE:-100}"
       DINGO_MIN_POOL_MARGIN: "${DEVNET_DINGO_MIN_POOL_MARGIN:-0}"
       DINGO_PLUGINS_MEMPOOL_PROVIDER: "${DEVNET_MEMPOOL_PROVIDER:-fifo}"
+      DINGO_BLOCK_PIPELINE_ENABLED: "${DEVNET_BLOCK_PIPELINE_ENABLED:-false}"
+      DINGO_BLOCK_PIPELINE_VALIDATE_ENABLED: "${DEVNET_BLOCK_PIPELINE_VALIDATE_ENABLED:-false}"
       # Expose node-to-client over TCP (private port 3002) so the host test
       # harness can run LocalStateQuery. Avoids a cross-uid host socket mount:
       # the dingo image runs as uid 1000 and cannot bind a socket in a
@@ -275,6 +277,8 @@ services:
       CARDANO_SHELLEY_VRF_KEY: /configs/keys/vrf.skey
       CARDANO_SHELLEY_KES_KEY: /configs/keys/kes.skey
       CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE: /configs/keys/opcert.cert
+      DINGO_BLOCK_PIPELINE_ENABLED: "${DEVNET_BLOCK_PIPELINE_ENABLED:-false}"
+      DINGO_BLOCK_PIPELINE_VALIDATE_ENABLED: "${DEVNET_BLOCK_PIPELINE_VALIDATE_ENABLED:-false}"
       # Expose node-to-client over TCP (private port 3002) on all interfaces
       # so the in-network txpump can submit transactions without a cross-uid
       # unix-socket mount (the socket is owned by the dingo uid).

--- a/internal/test/testutil/validated_conway_block.go
+++ b/internal/test/testutil/validated_conway_block.go
@@ -88,6 +88,46 @@ func BuildValidatedConwayBlockBytes(
 	slotRangeStart uint64,
 	blockNumber uint64,
 ) ValidatedConwayBlock {
+	return buildValidatedConwayBlockBytes(
+		t,
+		seed,
+		nonceSeed,
+		slotRangeStart,
+		blockNumber,
+		false,
+	)
+}
+
+// BuildValidatedConwayBlockBytesWithInvalidOpCert generates a block whose
+// VRF proof and KES signature are genuine but whose operational certificate
+// was signed by an unrelated cold key. The KES signature is computed after
+// substituting the unrelated signature, so rejecting this block specifically
+// exercises the cold-key OpCert check rather than failing KES verification.
+func BuildValidatedConwayBlockBytesWithInvalidOpCert(
+	t *testing.T,
+	seed [32]byte,
+	nonceSeed byte,
+	slotRangeStart uint64,
+	blockNumber uint64,
+) ValidatedConwayBlock {
+	return buildValidatedConwayBlockBytes(
+		t,
+		seed,
+		nonceSeed,
+		slotRangeStart,
+		blockNumber,
+		true,
+	)
+}
+
+func buildValidatedConwayBlockBytes(
+	t *testing.T,
+	seed [32]byte,
+	nonceSeed byte,
+	slotRangeStart uint64,
+	blockNumber uint64,
+	invalidOpCert bool,
+) ValidatedConwayBlock {
 	t.Helper()
 
 	vrfPk, vrfSk, err := vrf.KeyGen(seed[:])
@@ -125,6 +165,12 @@ func BuildValidatedConwayBlockBytes(
 	binary.BigEndian.PutUint64(opCertBody[32:40], uint64(opCertSeqNum))
 	binary.BigEndian.PutUint64(opCertBody[40:48], uint64(opCertKesPeriod))
 	opCertSig := ed25519.Sign(coldPrivKey, opCertBody[:])
+	if invalidOpCert {
+		unrelatedSeed := seed
+		unrelatedSeed[0] ^= 0xCC
+		unrelatedColdKey := ed25519.NewKeyFromSeed(unrelatedSeed[:])
+		opCertSig = ed25519.Sign(unrelatedColdKey, opCertBody[:])
+	}
 
 	bodyHash := conwayEmptyBodyHash(t)
 	activeSlotCoeff := big.NewRat(99, 100)

--- a/ledger/block_pipeline_errors_drain_test.go
+++ b/ledger/block_pipeline_errors_drain_test.go
@@ -32,10 +32,9 @@ import (
 // buildNoNonceValidateBatch returns numBlocks decodable (but not
 // cryptographically valid) Conway blocks at distinct slots, all falling
 // inside a single epoch whose cached Nonce is empty. Every one of them
-// makes blockPipelineEta0Provider fail identically to how it always fails
-// for real Byron-era blocks (see its doc comment) -- Byron itself is not
-// needed to reproduce the bug; any slot range with no cached Praos nonce
-// triggers the same validate-stage error path.
+// makes blockPipelineEta0Provider fail for a covered slot whose cached Praos
+// nonce is unavailable. Byron epochs always have that shape, and a later-era
+// epoch can have it transiently while published state catches up.
 func buildNoNonceValidateBatch(t *testing.T, numBlocks int) []models.Block {
 	t.Helper()
 	batch := make([]models.Block, 0, numBlocks)
@@ -235,9 +234,9 @@ func TestRecordBlockPipelineErrorClassificationDeferredIsNotUnexpected(
 }
 
 // TestRecordBlockPipelineErrorClassification confirms
-// recordBlockPipelineError distinguishes the expected Byron-era
-// eta0-unavailable case (errBlockPipelineEta0Unavailable) from every other
-// error, incrementing the matching counter for each.
+// recordBlockPipelineError distinguishes a covered epoch without a nonce
+// (errBlockPipelineEta0Unavailable) from every other error, incrementing the
+// matching counter for each.
 func TestRecordBlockPipelineErrorClassification(t *testing.T) {
 	ls := &LedgerState{
 		config: LedgerStateConfig{Logger: testLogger()},

--- a/ledger/block_pipeline_validate_test.go
+++ b/ledger/block_pipeline_validate_test.go
@@ -90,6 +90,17 @@ func buildValidatedTestModelsBlock(
 	}, vb
 }
 
+func wrongNonceHexFor(t *testing.T, nonceHex string) string {
+	t.Helper()
+	require.GreaterOrEqual(t, len(nonceHex), 2)
+
+	wrongNonceHex := nonceHex[:len(nonceHex)-2] + "00"
+	if wrongNonceHex == nonceHex {
+		wrongNonceHex = nonceHex[:len(nonceHex)-2] + "11"
+	}
+	return wrongNonceHex
+}
+
 func newValidatedPipelineTestLedger(
 	t *testing.T,
 	vb testutil.ValidatedConwayBlock,
@@ -349,14 +360,10 @@ func TestDecodeReadChainBatchMirrorsSerialValidationGates(t *testing.T) {
 			ls.publishSnapshotsLocked()
 
 			require.NoError(t, ls.blockPipeline.Stop())
-			wrongNonceHex := vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "00"
-			if wrongNonceHex == vb.EpochNonceHex {
-				wrongNonceHex = vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "11"
-			}
 			ls.blockPipeline = pipeline.NewBlockPipeline(
 				pipeline.WithDecodeWorkers(1),
 				pipeline.WithValidateWorkers(1),
-				pipeline.WithEta0(wrongNonceHex),
+				pipeline.WithEta0(wrongNonceHexFor(t, vb.EpochNonceHex)),
 				pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
 				pipeline.WithVerifyConfig(productionValidateVerifyConfig),
 			)
@@ -443,14 +450,10 @@ func TestDecodeReadChainBatchRejectsFailedValidationWhenEnabled(t *testing.T) {
 	// block was actually proven against, so VRF verification genuinely
 	// fails (rather than tampering CBOR bytes, which risks failing decode
 	// instead of validation and testing the wrong thing).
-	wrongNonceHex := vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "00"
-	if wrongNonceHex == vb.EpochNonceHex {
-		wrongNonceHex = vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "11"
-	}
 	ls.blockPipeline = pipeline.NewBlockPipeline(
 		pipeline.WithDecodeWorkers(2),
 		pipeline.WithValidateWorkers(2),
-		pipeline.WithEta0(wrongNonceHex),
+		pipeline.WithEta0(wrongNonceHexFor(t, vb.EpochNonceHex)),
 		pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
 		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
 	)
@@ -559,14 +562,10 @@ func TestDecodeReadChainBatchIgnoresValidationOutcomeWhenDisabled(
 	// Wire a nonce that will fail validation -- if decodeReadChainBatch
 	// incorrectly consulted the validation outcome anyway, this would flip
 	// the assertion below from ok=true to ok=false.
-	wrongNonceHex := vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "00"
-	if wrongNonceHex == vb.EpochNonceHex {
-		wrongNonceHex = vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "11"
-	}
 	ls.blockPipeline = pipeline.NewBlockPipeline(
 		pipeline.WithDecodeWorkers(2),
 		pipeline.WithValidateWorkers(2),
-		pipeline.WithEta0(wrongNonceHex),
+		pipeline.WithEta0(wrongNonceHexFor(t, vb.EpochNonceHex)),
 		pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
 		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
 	)

--- a/ledger/block_pipeline_validate_test.go
+++ b/ledger/block_pipeline_validate_test.go
@@ -16,27 +16,51 @@ package ledger
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/pipeline"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// productionValidateVerifyConfig mirrors the VerifyConfig NewLedgerState
-// wires onto the block pipeline's validate stage: VRF/KES only, matching
-// the scope of the existing serial header-only check (verifyBlockHeaderHex).
+// productionValidateVerifyConfig mirrors the generic VRF/KES portion of
+// NewLedgerState's pipeline wiring. Dingo adds OpCert verification after the
+// generic stage succeeds.
 var productionValidateVerifyConfig = lcommon.VerifyConfig{
 	SkipBodyHashValidation:    true,
 	SkipTransactionValidation: true,
 	SkipStakePoolValidation:   true,
+}
+
+func TestNewLedgerStateRejectsPipelineValidationWithoutKesConfig(
+	t *testing.T,
+) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) }) //nolint:errcheck
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	_, err = NewLedgerState(LedgerStateConfig{
+		ChainManager:                 cm,
+		Database:                     db,
+		Logger:                       testLogger(),
+		BlockPipelineEnabled:         true,
+		BlockPipelineValidateEnabled: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slotsPerKESPeriod")
 }
 
 // buildValidatedTestModelsBlock wraps testutil.BuildValidatedConwayBlockBytes
@@ -66,6 +90,288 @@ func buildValidatedTestModelsBlock(
 	}, vb
 }
 
+func newValidatedPipelineTestLedger(
+	t *testing.T,
+	vb testutil.ValidatedConwayBlock,
+) *LedgerState {
+	t.Helper()
+	nonce, err := hex.DecodeString(vb.EpochNonceHex)
+	require.NoError(t, err)
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				LengthInSlots: 1_000_000,
+				Nonce:         nonce,
+			},
+		},
+		validationEnabled: true,
+		config: LedgerStateConfig{
+			CardanoNodeConfig:            newTestShelleyGenesisCfg(t),
+			Logger:                       testLogger(),
+			BlockPipelineValidateEnabled: true,
+		},
+	}
+	ls.slotsPerKESPeriod.Store(ls.loadSlotsPerKESPeriod())
+	ls.publishSnapshotsLocked()
+	ls.blockPipeline = pipeline.NewBlockPipeline(
+		pipeline.WithDecodeWorkers(1),
+		pipeline.WithValidateWorkers(1),
+		pipeline.WithEta0(vb.EpochNonceHex),
+		pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
+		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
+	)
+	require.NoError(t, ls.blockPipeline.Start(t.Context()))
+	t.Cleanup(func() {
+		if ls.blockPipeline != nil {
+			require.NoError(t, ls.blockPipeline.Stop())
+		}
+	})
+	return ls
+}
+
+// loadRealByronMainBlock returns a genuine Byron main block from the shared
+// ouroboros-consensus golden fixtures. The pipeline regression needs actual
+// Byron CBOR rather than a mock whose Era method merely reports Byron.
+func loadRealByronMainBlock(t *testing.T) models.Block {
+	t.Helper()
+	root, err := fixtures.ExtractEmbeddedFixtures(t.TempDir())
+	require.NoError(t, err)
+	fixture, err := fixtures.NewFixture(
+		root,
+		root+"/ouroboros-consensus/ouroboros-consensus-cardano/golden/"+
+			"cardano/CardanoNodeToNodeVersion2/Block_Byron_regular",
+	)
+	require.NoError(t, err)
+	raw, err := fixture.ConsensusLedgerBlockBytes()
+	require.NoError(t, err)
+	blockType, err := fixture.LedgerBlockType()
+	require.NoError(t, err)
+	require.Equal(t, uint(gledger.BlockTypeByronMain), blockType)
+	decoded, err := gledger.NewBlockFromCbor(blockType, raw)
+	require.NoError(t, err)
+	return models.Block{
+		Slot:   decoded.SlotNumber(),
+		Hash:   decoded.Hash().Bytes(),
+		Number: decoded.BlockNumber(),
+		Type:   blockType,
+		Cbor:   raw,
+	}
+}
+
+func TestDecodeReadChainBatchAcceptsRealByronWithValidation(t *testing.T) {
+	block := loadRealByronMainBlock(t)
+	ls := &LedgerState{
+		validationEnabled: true,
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				LengthInSlots: 432000,
+				Nonce:         nil,
+			},
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig:            newTestShelleyGenesisCfg(t),
+			Logger:                       testLogger(),
+			BlockPipelineValidateEnabled: true,
+		},
+	}
+	ls.slotsPerKESPeriod.Store(ls.loadSlotsPerKESPeriod())
+	ls.publishSnapshotsLocked()
+	ls.blockPipeline = pipeline.NewBlockPipeline(
+		pipeline.WithDecodeWorkers(1),
+		pipeline.WithValidateWorkers(1),
+		pipeline.WithEta0Provider(ls.blockPipelineEta0Provider),
+		pipeline.WithSlotsPerKesPeriod(ls.SlotsPerKESPeriod()),
+		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
+	)
+	require.NoError(t, ls.blockPipeline.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, ls.blockPipeline.Stop()) })
+
+	decoded, ok := ls.decodeReadChainBatch(
+		t.Context(),
+		[]models.Block{block},
+	)
+	require.True(t, ok)
+	require.Len(t, decoded, 1)
+	require.Equal(t, gledger.BlockTypeByronMain, decoded[0].Type())
+}
+
+func TestDecodeReadChainBatchRejectsInvalidOpCertWhenEnabled(t *testing.T) {
+	var seed [32]byte
+	seed[0] = 91
+	vb := testutil.BuildValidatedConwayBlockBytesWithInvalidOpCert(
+		t,
+		seed,
+		17,
+		100,
+		1,
+	)
+	block := models.Block{
+		Slot:   vb.Slot,
+		Hash:   vb.Hash,
+		Number: vb.BlockNumber,
+		Type:   gledger.BlockTypeConway,
+		Cbor:   vb.Cbor,
+	}
+	ls := newValidatedPipelineTestLedger(t, vb)
+
+	_, ok := ls.decodeReadChainBatch(t.Context(), []models.Block{block})
+	assert.False(
+		t,
+		ok,
+		"VRF/KES-valid block with an unrelated OpCert signer must be rejected",
+	)
+}
+
+func TestDecodeReadChainBatchReturnsRecoverableValidationError(t *testing.T) {
+	var seed [32]byte
+	seed[0] = 94
+	vb := testutil.BuildValidatedConwayBlockBytesWithInvalidOpCert(
+		t,
+		seed,
+		20,
+		100,
+		1,
+	)
+	block := models.Block{
+		Slot:   vb.Slot,
+		Hash:   vb.Hash,
+		Number: vb.BlockNumber,
+		Type:   gledger.BlockTypeConway,
+		Cbor:   vb.Cbor,
+	}
+	ls := newValidatedPipelineTestLedger(t, vb)
+
+	_, err := ls.decodeReadChainBatchWithError(
+		t.Context(),
+		[]models.Block{block},
+	)
+	require.Error(t, err)
+	var validationErr *headerValidationError
+	require.ErrorAs(t, err, &validationErr)
+	require.NotNil(t, validationErr)
+	assert.Equal(t, block.Slot, validationErr.BlockPoint.Slot)
+	assert.Equal(t, block.Hash, validationErr.BlockPoint.Hash)
+	assert.Contains(t, validationErr.Cause.Error(), "operational certificate")
+}
+
+func TestDecodeReadChainBatchRejectsExpiredOpCertWhenEnabled(t *testing.T) {
+	var seed [32]byte
+	seed[0] = 92
+	const slotsPerKesPeriod = uint64(129600)
+	block, vb := buildValidatedTestModelsBlock(
+		t,
+		seed,
+		18,
+		2*slotsPerKesPeriod,
+		1,
+	)
+	ls := newValidatedPipelineTestLedger(t, vb)
+	ls.config.CardanoNodeConfig.ShelleyGenesis().MaxKESEvolutions = 1
+
+	_, ok := ls.decodeReadChainBatch(t.Context(), []models.Block{block})
+	assert.False(
+		t,
+		ok,
+		"block beyond the OpCert's maximum KES evolutions must be rejected",
+	)
+}
+
+func TestDecodeReadChainBatchSkipsValidationWithoutCachedNonce(
+	t *testing.T,
+) {
+	var seed [32]byte
+	seed[0] = 93
+	block, vb := buildValidatedTestModelsBlock(t, seed, 19, 100, 1)
+	ls := newValidatedPipelineTestLedger(t, vb)
+	ls.epochCache = []models.Epoch{
+		{
+			EpochId:       0,
+			StartSlot:     0,
+			LengthInSlots: 1_000_000,
+			Nonce:         nil,
+		},
+	}
+	ls.publishSnapshotsLocked()
+	require.NoError(t, ls.blockPipeline.Stop())
+	ls.blockPipeline = pipeline.NewBlockPipeline(
+		pipeline.WithDecodeWorkers(1),
+		pipeline.WithValidateWorkers(1),
+		pipeline.WithEta0Provider(ls.blockPipelineEta0Provider),
+		pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
+		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
+	)
+	require.NoError(t, ls.blockPipeline.Start(t.Context()))
+
+	decoded, ok := ls.decodeReadChainBatch(t.Context(), []models.Block{block})
+	require.True(
+		t,
+		ok,
+		"the read path must mirror admission's nonce-availability gate",
+	)
+	require.Len(t, decoded, 1)
+}
+
+func TestDecodeReadChainBatchMirrorsSerialValidationGates(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*LedgerState, models.Block)
+	}{
+		{
+			name: "historical validation disabled",
+			mutate: func(ls *LedgerState, _ models.Block) {
+				ls.validationEnabled = false
+			},
+		},
+		{
+			name: "inside Mithril trust boundary",
+			mutate: func(ls *LedgerState, block models.Block) {
+				ls.mithrilLedgerSlot = block.Slot
+			},
+		},
+	}
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seed [32]byte
+			seed[0] = byte(95 + index) //nolint:gosec
+			block, vb := buildValidatedTestModelsBlock(
+				t,
+				seed,
+				21,
+				100,
+				1,
+			)
+			ls := newValidatedPipelineTestLedger(t, vb)
+			tt.mutate(ls, block)
+			ls.publishSnapshotsLocked()
+
+			require.NoError(t, ls.blockPipeline.Stop())
+			wrongNonceHex := vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "00"
+			if wrongNonceHex == vb.EpochNonceHex {
+				wrongNonceHex = vb.EpochNonceHex[:len(vb.EpochNonceHex)-2] + "11"
+			}
+			ls.blockPipeline = pipeline.NewBlockPipeline(
+				pipeline.WithDecodeWorkers(1),
+				pipeline.WithValidateWorkers(1),
+				pipeline.WithEta0(wrongNonceHex),
+				pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
+				pipeline.WithVerifyConfig(productionValidateVerifyConfig),
+			)
+			require.NoError(t, ls.blockPipeline.Start(t.Context()))
+
+			decoded, ok := ls.decodeReadChainBatch(
+				t.Context(),
+				[]models.Block{block},
+			)
+			require.True(t, ok)
+			require.Len(t, decoded, 1)
+		})
+	}
+}
+
 func TestDecodeReadChainBatchValidatesBlocksWhenEnabled(t *testing.T) {
 	var seed1, seed2 [32]byte
 	seed1[0], seed2[0] = 1, 2
@@ -75,23 +381,7 @@ func TestDecodeReadChainBatchValidatesBlocksWhenEnabled(t *testing.T) {
 	block2, _ := buildValidatedTestModelsBlock(t, seed2, nonceSeed, 500, 2)
 	rawBatch := []models.Block{block1, block2}
 
-	ls := &LedgerState{
-		config: LedgerStateConfig{
-			Logger:                       testLogger(),
-			BlockPipelineValidateEnabled: true,
-		},
-	}
-	ls.blockPipeline = pipeline.NewBlockPipeline(
-		pipeline.WithDecodeWorkers(2),
-		pipeline.WithValidateWorkers(2),
-		pipeline.WithEta0(vb1.EpochNonceHex),
-		pipeline.WithSlotsPerKesPeriod(vb1.SlotsPerKesPeriod),
-		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
-	)
-	require.NoError(t, ls.blockPipeline.Start(t.Context()))
-	defer func() {
-		require.NoError(t, ls.blockPipeline.Stop())
-	}()
+	ls := newValidatedPipelineTestLedger(t, vb1)
 
 	decoded, ok := ls.decodeReadChainBatch(t.Context(), rawBatch)
 	require.True(t, ok)
@@ -128,23 +418,7 @@ func TestDecodeReadChainBatchValidatesBlockAcrossKesPeriodBoundary(
 	)
 	require.GreaterOrEqual(t, vb.Slot, uint64(slotsPerKesPeriod))
 
-	ls := &LedgerState{
-		config: LedgerStateConfig{
-			Logger:                       testLogger(),
-			BlockPipelineValidateEnabled: true,
-		},
-	}
-	ls.blockPipeline = pipeline.NewBlockPipeline(
-		pipeline.WithDecodeWorkers(1),
-		pipeline.WithValidateWorkers(1),
-		pipeline.WithEta0(vb.EpochNonceHex),
-		pipeline.WithSlotsPerKesPeriod(vb.SlotsPerKesPeriod),
-		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
-	)
-	require.NoError(t, ls.blockPipeline.Start(t.Context()))
-	defer func() {
-		require.NoError(t, ls.blockPipeline.Stop())
-	}()
+	ls := newValidatedPipelineTestLedger(t, vb)
 
 	decoded, ok := ls.decodeReadChainBatch(t.Context(), []models.Block{block})
 	require.True(
@@ -163,12 +437,8 @@ func TestDecodeReadChainBatchRejectsFailedValidationWhenEnabled(t *testing.T) {
 	seed[0] = 3
 	block, vb := buildValidatedTestModelsBlock(t, seed, 7, 100, 1)
 
-	ls := &LedgerState{
-		config: LedgerStateConfig{
-			Logger:                       testLogger(),
-			BlockPipelineValidateEnabled: true,
-		},
-	}
+	ls := newValidatedPipelineTestLedger(t, vb)
+	require.NoError(t, ls.blockPipeline.Stop())
 	// Configure the pipeline with a *different* epoch nonce than the one the
 	// block was actually proven against, so VRF verification genuinely
 	// fails (rather than tampering CBOR bytes, which risks failing decode
@@ -185,9 +455,6 @@ func TestDecodeReadChainBatchRejectsFailedValidationWhenEnabled(t *testing.T) {
 		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
 	)
 	require.NoError(t, ls.blockPipeline.Start(t.Context()))
-	defer func() {
-		require.NoError(t, ls.blockPipeline.Stop())
-	}()
 
 	_, ok := ls.decodeReadChainBatch(t.Context(), []models.Block{block})
 	assert.False(t, ok, "batch with a VRF-invalid block must be rejected")
@@ -233,12 +500,8 @@ func TestDecodeReadChainBatchDrainsRemainingResultsAfterEarlyFailure(
 		t, seed4, correctNonceSeed, 700, 4,
 	)
 
-	ls := &LedgerState{
-		config: LedgerStateConfig{
-			Logger:                       testLogger(),
-			BlockPipelineValidateEnabled: true,
-		},
-	}
+	ls := newValidatedPipelineTestLedger(t, vb2)
+	require.NoError(t, ls.blockPipeline.Stop())
 	ls.blockPipeline = pipeline.NewBlockPipeline(
 		pipeline.WithDecodeWorkers(2),
 		pipeline.WithValidateWorkers(2),
@@ -247,9 +510,6 @@ func TestDecodeReadChainBatchDrainsRemainingResultsAfterEarlyFailure(
 		pipeline.WithVerifyConfig(productionValidateVerifyConfig),
 	)
 	require.NoError(t, ls.blockPipeline.Start(t.Context()))
-	defer func() {
-		require.NoError(t, ls.blockPipeline.Stop())
-	}()
 
 	_, ok := ls.decodeReadChainBatch(
 		t.Context(),
@@ -432,13 +692,10 @@ func TestBlockPipelineEta0Provider_ReturnsNonceHex(t *testing.T) {
 }
 
 // TestBlockPipelineEta0Provider_EmptyCache is a regression test for
-// blockPipelineEta0Provider previously wrapping *every* error
-// headerVerificationEpoch can return in errBlockPipelineEta0Unavailable.
-// An empty epoch cache makes epochForSlot fail to find any epoch at all --
-// errHeaderVerificationDeferred, not the Byron-only "epoch found but has no
-// nonce" case (errEpochNonceUnavailable) -- so drainBlockPipelineErrors must
-// classify it as an unexpected error, not silently as the harmless Byron
-// case.
+// blockPipelineEta0Provider previously wrapping *every* lookup error in
+// errBlockPipelineEta0Unavailable. An empty epoch cache means the published
+// state does not cover the slot at all, so it must be classified as deferred
+// rather than as the distinct "covered epoch has no nonce" case.
 func TestBlockPipelineEta0Provider_EmptyCache(t *testing.T) {
 	ls := &LedgerState{
 		config: LedgerStateConfig{
@@ -450,22 +707,18 @@ func TestBlockPipelineEta0Provider_EmptyCache(t *testing.T) {
 
 	_, err := ls.blockPipelineEta0Provider(1000)
 	require.Error(t, err)
+	assert.True(t, errors.Is(err, errHeaderVerificationDeferred))
 	assert.False(
 		t,
 		errors.Is(err, errBlockPipelineEta0Unavailable),
-		"a missing-epoch-data error must not be classified as the "+
-			"expected Byron-only eta0-unavailable case",
+		"a slot outside the cache must not be classified as a covered epoch without a nonce",
 	)
 }
 
-// TestBlockPipelineEta0Provider_NoNonceForEpoch simulates a Byron-era epoch
-// (present in the cache but with no Praos nonce yet) and confirms the
-// provider fails rather than returning a bogus nonce -- decodeReadChainBatch
-// relies on this to ignore validation failures specifically (and only) for
-// Byron-era blocks. It also confirms drainBlockPipelineErrors' classifying
-// sentinel is present on the error, since only this specific "epoch has no
-// nonce" case is meant to be wrapped in it (see
-// TestBlockPipelineEta0Provider_EmptyCache for the contrasting case).
+// TestBlockPipelineEta0Provider_NoNonceForEpoch covers an epoch present in the
+// cache without a published Praos nonce. This is permanent for Byron and can
+// be transient later; the provider must fail rather than inventing a nonce,
+// while preserving the sentinel that lets enforcement defer to admission.
 func TestBlockPipelineEta0Provider_NoNonceForEpoch(t *testing.T) {
 	ls := &LedgerState{
 		epochCache: []models.Epoch{
@@ -488,7 +741,6 @@ func TestBlockPipelineEta0Provider_NoNonceForEpoch(t *testing.T) {
 	assert.True(
 		t,
 		errors.Is(err, errBlockPipelineEta0Unavailable),
-		"the Byron-only epoch-has-no-nonce case must be classified as "+
-			"the expected eta0-unavailable error",
+		"a covered epoch without a nonce must retain the eta0-unavailable sentinel",
 	)
 }

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2624,6 +2624,15 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 }
 
 func (ls *LedgerState) shouldVerifyChainsyncHeaderCrypto(slot uint64) bool {
+	return ls.shouldEnforceBlockPipelineCrypto(slot)
+}
+
+// shouldEnforceBlockPipelineCrypto mirrors the serial header path's
+// validation-state gates for blocks read back from the primary chain. The
+// pipeline workers still run for every submitted block, but their result must
+// not reject trusted historical/Mithril data or a block whose epoch nonce is
+// intentionally unavailable until ledger apply catches up.
+func (ls *LedgerState) shouldEnforceBlockPipelineCrypto(slot uint64) bool {
 	validationEnabled, mithrilLedgerSlot := ls.validationStateSnapshot()
 	if !validationEnabled {
 		return false
@@ -2631,40 +2640,7 @@ func (ls *LedgerState) shouldVerifyChainsyncHeaderCrypto(slot uint64) bool {
 	if mithrilLedgerSlot != 0 && slot <= mithrilLedgerSlot {
 		return false
 	}
-	if ls.blockPipelineRevalidatesCrypto() {
-		return false
-	}
 	return ls.hasCachedEpochNonceForSlot(slot)
-}
-
-// blockPipelineRevalidatesCrypto reports whether every block admitted here
-// will independently pass through the block-decode pipeline's VRF/KES
-// validate stage (LedgerStateConfig.BlockPipelineValidateEnabled) before
-// ledger apply -- see decodeReadChainBatch, which aborts the whole read
-// batch on a pipeline validation failure exactly as it does on a decode
-// failure. When that is true, the serial admission-time stateless VRF/KES
-// crypto check (verifyBlockHeaderOnlyCrypto / the crypto half of
-// verifyBlockHeaderCryptoBeforeApply) is redundant: the same block would be
-// cryptographically re-verified a second time, uselessly, before every
-// sync's steady-state admission path even finishes. Callers must still run
-// the non-crypto parts of admission-time verification unconditionally --
-// the registered-VRF-key and leader-eligibility state checks
-// (verifyBlockHeaderState) and the epoch-cache-advance side effect
-// (headerVerificationEpoch's ensureEpochForSlot) -- neither of which the
-// pipeline's validate stage performs (it is scoped to VRF/KES only, per
-// NewLedgerState's VerifyConfig) or can perform (the pipeline validates
-// blocks already committed to ls.chain, well after any admission-time
-// epoch-cache forecast would need to happen for a live, arriving header).
-//
-// ls.blockPipeline is nil whenever BlockPipelineEnabled is off or
-// ManualBlockProcessing bypasses ledgerReadChainIterator entirely (see
-// NewLedgerState), so checking it directly -- rather than only the config
-// flag -- also correctly keeps this false in both of those cases. The
-// pointer itself is set once at construction and never reassigned, so
-// reading it without ls.RLock() here is safe, matching every other
-// unguarded ls.blockPipeline read (e.g. decodeReadChainBatch).
-func (ls *LedgerState) blockPipelineRevalidatesCrypto() bool {
-	return ls.blockPipeline != nil && ls.config.BlockPipelineValidateEnabled
 }
 
 func (ls *LedgerState) hasCachedEpochNonceForSlot(slot uint64) bool {
@@ -3045,49 +3021,31 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	validationEnabled, _ := ls.validationStateSnapshot()
 	if validationEnabled {
 		var verifyErr error
-		if ls.blockPipelineRevalidatesCrypto() {
-			// The block-decode pipeline's validate stage will
-			// independently re-verify VRF/KES for this block before
-			// ledger apply (decodeReadChainBatch aborts the batch on
-			// failure exactly as it would for a crypto failure here), so
-			// redoing the same stateless crypto check at admission would
-			// only verify it twice. Run the non-crypto half of admission
-			// verification unconditionally: registered-VRF-key and
-			// leader-eligibility state checks, and the epoch-cache-advance
-			// side effect the pipeline's own Eta0Provider deliberately
-			// does not perform (see blockPipelineRevalidatesCrypto).
+		// Chainsync may already have verified the queued header before
+		// blockfetch started. When the fetched block matches that first
+		// verified queued header by point, a second verification is
+		// redundant. Chain insertion still checks that the block matches the
+		// queued header hash before accepting it.
+		headerAlreadyVerified := ls.chain.FirstVerifiedHeaderMatchesPoint(
+			e.Point,
+		)
+		if !headerAlreadyVerified &&
+			!ls.hasCachedEpochNonceForSlot(e.Point.Slot) {
+			if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+				return err
+			}
+			headerAlreadyVerified = ls.chain.FirstVerifiedHeaderMatchesPoint(
+				e.Point,
+			)
+		}
+		if !headerAlreadyVerified {
+			verifyErr = ls.verifyBlockHeaderCryptoBeforeApply(e.Block)
+		} else {
 			verifyErr = ls.verifyBlockHeaderStateWithEpochAdvance(
 				e.Block,
 				true,
 				true,
 			)
-		} else {
-			// Chainsync may already have verified the queued header before
-			// blockfetch started. When the fetched block matches that first
-			// verified queued header by point, a second VRF/KES verification is
-			// redundant. Chain insertion still checks that the block matches the
-			// queued header hash before accepting it.
-			headerAlreadyVerified := ls.chain.FirstVerifiedHeaderMatchesPoint(
-				e.Point,
-			)
-			if !headerAlreadyVerified &&
-				!ls.hasCachedEpochNonceForSlot(e.Point.Slot) {
-				if err := ls.flushPendingBlockfetchBlocks(); err != nil {
-					return err
-				}
-				headerAlreadyVerified = ls.chain.FirstVerifiedHeaderMatchesPoint(
-					e.Point,
-				)
-			}
-			if !headerAlreadyVerified {
-				verifyErr = ls.verifyBlockHeaderCryptoBeforeApply(e.Block)
-			} else {
-				verifyErr = ls.verifyBlockHeaderStateWithEpochAdvance(
-					e.Block,
-					true,
-					true,
-				)
-			}
 		}
 		if verifyErr != nil {
 			if errors.Is(verifyErr, errHeaderVerificationDeferred) {

--- a/ledger/chainsync_fork_queue_full_test.go
+++ b/ledger/chainsync_fork_queue_full_test.go
@@ -278,6 +278,42 @@ func TestEnsureBlockfetchDrainingAfterForkQueueFailureRecoversWhenStartFails(
 func TestTryResolveForkExtensionDoesNotThrashAlreadyRunningBlockfetch(
 	t *testing.T,
 ) {
+	// Positive control: prove this test reaches the recovery body when no
+	// batch is active. Without this control, replacing the whole body of
+	// ensureBlockfetchDrainingAfterForkQueueFailure with `return` would make
+	// the absence-only assertions below pass.
+	control := newChainsyncRollbackFixture(t)
+	controlConnId := testChainsyncConnId(6204, 3001)
+	controlHeader := mockHeader{
+		hash: lcommon.NewBlake2b256(
+			testHashBytes("fork-overflow-drain-positive-control"),
+		),
+		prevHash:    lcommon.NewBlake2b256(control.currentTip.Point.Hash),
+		blockNumber: control.currentTip.BlockNumber + 1,
+		slot:        control.currentTip.Point.Slot + 1,
+	}
+	require.NoError(t, control.ls.chain.AddBlockHeader(controlHeader))
+	controlRequests := 0
+	control.ls.config.BlockfetchRequestRangeFunc = func(
+		_ ouroboros.ConnectionId,
+		_ ocommon.Point,
+		_ ocommon.Point,
+	) error {
+		controlRequests++
+		return nil
+	}
+	control.ls.ensureBlockfetchDrainingAfterForkQueueFailure(
+		controlConnId,
+		nil,
+	)
+	require.Equal(
+		t,
+		1,
+		controlRequests,
+		"positive control must start a fetch when no batch is active",
+	)
+	require.NotNil(t, control.ls.chainsyncBlockfetchReadyChan)
+
 	fixture := newChainsyncRollbackFixture(t)
 	maxHeaders := fixture.ls.chain.MaxQueuedHeaders()
 	connId := testChainsyncConnId(6202, 3001)

--- a/ledger/chainsync_pipeline_validate_admission_test.go
+++ b/ledger/chainsync_pipeline_validate_admission_test.go
@@ -26,43 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBlockPipelineRevalidatesCrypto exercises blockPipelineRevalidatesCrypto
-// directly: it must be true only when a block-decode pipeline is actually
-// constructed (ls.blockPipeline != nil -- nil whenever BlockPipelineEnabled
-// is off or ManualBlockProcessing bypasses it, per NewLedgerState) AND its
-// VRF/KES validate stage is enabled.
-func TestBlockPipelineRevalidatesCrypto(t *testing.T) {
-	ls := &LedgerState{config: LedgerStateConfig{Logger: testLogger()}}
-	assert.False(
-		t,
-		ls.blockPipelineRevalidatesCrypto(),
-		"no pipeline constructed",
-	)
-
-	ls.blockPipeline = pipeline.NewBlockPipeline()
-	assert.False(
-		t,
-		ls.blockPipelineRevalidatesCrypto(),
-		"pipeline constructed but its validate stage is not enabled",
-	)
-
-	ls.config.BlockPipelineValidateEnabled = true
-	assert.True(
-		t,
-		ls.blockPipelineRevalidatesCrypto(),
-		"pipeline constructed with its validate stage enabled",
-	)
-}
-
-// TestShouldVerifyChainsyncHeaderCryptoSkipsWhenPipelineRevalidates verifies
-// that the chainsync-header-time stateless VRF/KES pre-check
-// (shouldVerifyChainsyncHeaderCrypto, consumed by
-// handleEventChainsyncBlockHeaderWithPending) is skipped once the
-// block-decode pipeline's validate stage will independently re-verify the
-// same block before ledger apply -- even though every other condition that
-// would otherwise require the check (validationEnabled and a cached epoch
-// nonce for the slot) still holds.
-func TestShouldVerifyChainsyncHeaderCryptoSkipsWhenPipelineRevalidates(
+// TestShouldVerifyChainsyncHeaderCryptoKeepsAdmissionGate verifies that a
+// later pipeline stage does not weaken the chainsync admission gate. Once a
+// header is queued, the corresponding block can be persisted and served
+// before the ledger reader reaches the pipeline validation stage.
+func TestShouldVerifyChainsyncHeaderCryptoKeepsAdmissionGate(
 	t *testing.T,
 ) {
 	tb := createTestBlock(t, [32]byte{60}, 0, tamperNone)
@@ -79,16 +47,16 @@ func TestShouldVerifyChainsyncHeaderCryptoSkipsWhenPipelineRevalidates(
 
 	ls.blockPipeline = pipeline.NewBlockPipeline()
 	ls.config.BlockPipelineValidateEnabled = true
-	assert.False(
+	assert.True(
 		t,
 		ls.shouldVerifyChainsyncHeaderCrypto(slot),
-		"redundant admission-time crypto pre-check must be skipped once "+
-			"the pipeline will re-verify VRF/KES before apply",
+		"pipeline validation must not replace the admission-time crypto gate",
 	)
 }
 
-// TestHandleEventBlockfetchBlockSkipsRedundantCryptoWhenPipelineValidates
-// proves the blockfetch-time half of the same de-duplication end to end.
+// TestHandleEventBlockfetchBlockKeepsAdmissionCryptoWhenPipelineValidates
+// proves the blockfetch-time admission gate remains fail-closed when the
+// later pipeline validate stage is enabled.
 // The test block's VRF proof is deliberately tampered (a genuine crypto
 // failure, not a deferred one) while the ledger tip is left one slot behind
 // the block so that the non-crypto state checks
@@ -97,13 +65,10 @@ func TestShouldVerifyChainsyncHeaderCryptoSkipsWhenPipelineRevalidates(
 // TestVerifyBlockHeaderCryptoBeforeApplyDefersMissingPoolState's fixture.
 //
 // Without a validating pipeline, handleEventBlockfetchBlock must still catch
-// the tampered VRF proof directly (a real, non-deferred error). Once the
-// pipeline's validate stage is wired in, the same block must be accepted at
-// admission (its state checks legitimately defer) because the pipeline will
-// independently reject the bad VRF proof before ledger apply
-// (decodeReadChainBatch) -- proving the serial crypto re-check is no longer
-// performed for it here.
-func TestHandleEventBlockfetchBlockSkipsRedundantCryptoWhenPipelineValidates(
+// the tampered VRF proof directly (a real, non-deferred error). The pipeline
+// cannot replace this gate because the block becomes visible to downstream
+// readers before its later validate stage runs.
+func TestHandleEventBlockfetchBlockKeepsAdmissionCryptoWhenPipelineValidates(
 	t *testing.T,
 ) {
 	tb := createTestBlock(t, [32]byte{61}, 0, tamperVRFProof)
@@ -136,16 +101,46 @@ func TestHandleEventBlockfetchBlockSkipsRedundantCryptoWhenPipelineValidates(
 	assert.Empty(t, ls.pendingBlockfetchEvents)
 
 	// Reset the per-block dedup/bookkeeping state the failed call above
-	// touched, then enable the pipeline's validate stage: the identical
-	// tampered block must now be admitted (deferred to state-only checks)
-	// because the pipeline, not this admission path, is now responsible
-	// for catching the bad VRF proof before ledger apply.
+	// touched, then enable the pipeline's validate stage. The identical
+	// tampered block must still be rejected before persistence.
 	ls.pendingBlockfetchEvents = nil
 	ls.shadowBlockReceivedHashes = nil
 	ls.blockPipeline = pipeline.NewBlockPipeline()
 	ls.config.BlockPipelineValidateEnabled = true
 
 	err = ls.handleEventBlockfetchBlock(evt)
-	require.NoError(t, err)
-	assert.Len(t, ls.pendingBlockfetchEvents, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "crypto verification failed")
+	assert.Empty(t, ls.pendingBlockfetchEvents)
+}
+
+func TestHandleEventBlockfetchBlockRejectsInvalidOpCertWhenPipelineValidates(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{62}, 0, tamperOpCertSig)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.validationEnabled = true
+	ls.currentTip.Point.Slot = tb.block.SlotNumber() - 1
+	ls.chain = &chain.Chain{}
+	connId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6001},
+		RemoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3001},
+	}
+	ls.activeBlockfetchConnId = connId
+	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	ls.blockPipeline = pipeline.NewBlockPipeline()
+	ls.config.BlockPipelineValidateEnabled = true
+	ls.publishSnapshotsLocked()
+
+	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+		ConnectionId: connId,
+		Block:        tb.block,
+		Point: ocommon.Point{
+			Slot: tb.block.SlotNumber(),
+			Hash: tb.block.Hash().Bytes(),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opcert cold-key signature invalid")
+	assert.Empty(t, ls.pendingBlockfetchEvents)
 }

--- a/ledger/header_validation_recovery.go
+++ b/ledger/header_validation_recovery.go
@@ -23,11 +23,10 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
-// headerValidationError marks a stateful header check that failed while
-// applying a block the chain store already holds — the deferred
-// registered-VRF-key and Praos leader-eligibility checks that blockfetch
-// could not run because the facts they need were still ahead of the apply
-// cursor.
+// headerValidationError marks a header check that failed after the chain
+// store already persisted the block. This includes deferred registered-VRF-
+// key and Praos leader-eligibility checks at ledger apply, plus stateless
+// VRF/KES/OpCert rejection by the block pipeline's validate path.
 //
 // It exists to make that failure recoverable in the same sense transaction
 // validation failures already are. Rejecting the block is correct and stays
@@ -56,8 +55,8 @@ func (e *headerValidationError) Error() string {
 
 func (e *headerValidationError) Unwrap() error { return e.Cause }
 
-// tryRecoverFromHeaderValidationError rewinds past a block whose deferred
-// stateful header checks failed, so the pipeline stops re-reading it.
+// tryRecoverFromHeaderValidationError rewinds past a block whose header
+// checks failed after persistence, so the pipeline stops re-reading it.
 //
 // This does not accept the block and does not soften the check: the block is
 // dropped from the primary chain and the ledger is rolled back to the last
@@ -163,7 +162,7 @@ func (ls *LedgerState) tryRecoverFromHeaderValidationError(
 
 	if ls.config.Logger != nil {
 		ls.config.Logger.Warn(
-			"deferred header validation rejected a block already on the primary chain; rewinding so chain selection can offer another candidate",
+			"header validation rejected a block already on the primary chain; rewinding so chain selection can offer another candidate",
 			"component",
 			"ledger",
 			"failing_block_slot",

--- a/ledger/header_validation_recovery_test.go
+++ b/ledger/header_validation_recovery_test.go
@@ -178,6 +178,65 @@ func TestHeaderValidationRecoveryRewindsPastRejectedBlock(t *testing.T) {
 	}
 }
 
+func TestLedgerProcessBlocksRecoversReadChainValidationFailure(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) }) //nolint:errcheck
+
+	blocks := make([]models.Block, 0, 4)
+	for slot := uint64(1); slot <= 4; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 2}))
+
+	ledgerTipBlock := blocks[1]
+	ledgerTip := ochainsync.Tip{
+		Point:       makeTestPoint(ledgerTipBlock),
+		BlockNumber: ledgerTipBlock.Number,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+
+	ls := &LedgerState{
+		db:                db,
+		chain:             cm.PrimaryChain(),
+		currentTip:        ledgerTip,
+		validationEnabled: true,
+		config: LedgerStateConfig{
+			ChainManager: cm,
+			Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	require.NoError(t, ls.reconcilePrimaryChainTipWithLedgerTip())
+
+	done := make(chan struct{})
+	results := make(chan readChainResult, 1)
+	results <- readChainResult{
+		err: &headerValidationError{
+			BlockPoint: makeTestPoint(blocks[2]),
+			Cause:      errors.New("invalid operational certificate"),
+		},
+		done: done,
+	}
+	close(results)
+
+	err = ls.ledgerProcessBlocksFromSource(t.Context(), results)
+	require.ErrorIs(t, err, errRestartLedgerPipeline)
+	require.Equal(t, ledgerTipBlock.Slot, cm.PrimaryChain().Tip().Point.Slot)
+	select {
+	case <-done:
+	default:
+		t.Fatal("reader result was not released after validation recovery")
+	}
+}
+
 // A rejected block at or behind the ledger tip has no rewind target that
 // precedes it, so both the chain rewind and the ledger rollback would be
 // no-ops against their own position and the block would survive. Reporting

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -408,7 +408,8 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	m.blockPipelineExpectedEta0Errors = promautoFactory.NewCounter(
 		prometheus.CounterOpts{
 			Name: "dingo_ledger_block_pipeline_expected_eta0_errors_total",
-			Help: "block-processing pipeline validate-stage errors drained from errorsChan classified as expected (no cached Praos epoch nonce yet; always true for Byron-era blocks, but not verified to be Byron-specific here)",
+			Help: "block-processing pipeline validate-stage errors drained " +
+				"from errorsChan because a cached epoch has no Praos nonce",
 		},
 	)
 	m.blockPipelineDeferredEpochCacheErrors = promautoFactory.NewCounter(

--- a/ledger/read_chain_pipeline_test.go
+++ b/ledger/read_chain_pipeline_test.go
@@ -34,6 +34,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// decodeReadChainBatch retains the former boolean test surface while
+// production uses decodeReadChainBatchWithError to route persisted validation
+// failures into chain recovery.
+func (ls *LedgerState) decodeReadChainBatch(
+	ctx context.Context,
+	rawBatch []models.Block,
+) (decoded []gledger.Block, ok bool) {
+	decoded, err := ls.decodeReadChainBatchWithError(ctx, rawBatch)
+	return decoded, err == nil
+}
+
 // buildDecodableTestBlock returns a models.Block wrapping a real, decodable
 // Conway block at the given slot/block number, along with its canonical
 // point. The block bytes themselves come from the shared

--- a/ledger/read_chain_pipeline_test.go
+++ b/ledger/read_chain_pipeline_test.go
@@ -154,6 +154,45 @@ func TestDecodeReadChainBatchPropagatesDecodeErrorBothModes(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestLedgerReadChainIteratorForwardsDecodeError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	badPoint := ocommon.Point{
+		Slot: 20,
+		Hash: []byte("bad-hash-bad-hash-bad-hash-32by"),
+	}
+	iter := &scriptedLedgerReadIterator{
+		ctx: ctx,
+		results: []*chain.ChainIteratorResult{{
+			Point: badPoint,
+			Block: models.Block{
+				Slot: badPoint.Slot,
+				Hash: badPoint.Hash,
+				Type: gledger.BlockTypeConway,
+				Cbor: []byte{0xff, 0xff, 0xff},
+			},
+		}},
+	}
+	ls := &LedgerState{config: LedgerStateConfig{Logger: testLogger()}}
+	resultCh := make(chan readChainResult)
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		ls.ledgerReadChainIterator(ctx, iter, resultCh)
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.Error(t, result.err)
+		assert.Contains(t, result.err.Error(), "decode block at slot 20")
+		close(result.done)
+	case <-readerDone:
+		t.Fatal("reader returned without forwarding the decode error")
+	}
+	cancel()
+	<-readerDone
+}
+
 // TestLedgerReadChainIteratorPipelineMatchesSerial exercises the full
 // ledgerReadChainIterator loop (gather -> decode -> rollback trim -> emit)
 // with a real chain iterator script, once with the block-decode pipeline

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3646,10 +3646,6 @@ func (ls *LedgerState) ledgerReadChainIterator(
 		nextBatch, decodeErr := ls.decodeReadChainBatchWithError(ctx, rawBatch)
 		releaseGatherLock()
 		if decodeErr != nil {
-			var validationErr *headerValidationError
-			if !errors.As(decodeErr, &validationErr) {
-				return
-			}
 			result = readChainResult{
 				err:  decodeErr,
 				done: make(chan struct{}),
@@ -4777,7 +4773,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 						return errRestartLedgerPipeline
 					}
 					return fmt.Errorf(
-						"read-chain validation: %w",
+						"read-chain decode or validation: %w",
 						result.err,
 					)
 				}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -531,41 +531,18 @@ type LedgerStateConfig struct {
 	// applied after the rollback. See ARCHITECTURE.md ("Phase 5: rollback
 	// coordination").
 	BlockPipelineEnabled bool
-	// BlockPipelineValidateEnabled turns on the pipeline's VRF/KES validate
-	// stage (issue #1894 phase 3), in addition to decode. It has no effect
-	// unless BlockPipelineEnabled is also set. Each block decoded by
-	// decodeReadChainBatch is independently re-verified (VRF proof + KES
-	// signature, via gouroboros' pipeline.ValidateStage) by a small worker
-	// pool before being handed to ledgerProcessBlocksFromSource, exactly as
-	// with decode-only phase 1.
+	// BlockPipelineValidateEnabled adds parallel VRF/KES validation to the
+	// decode pipeline (issue #1894 phase 3). Dingo supplements the generic
+	// stage with the OpCert cold-key signature and MaxKESEvolutions checks,
+	// and enforces results only where the serial path has validation state:
+	// not trusted historical/Mithril replay and only with a cached epoch
+	// nonce. A rejection is returned as headerValidationError so the already-
+	// persisted chain can be rewound rather than retried forever.
 	//
-	// When this is enabled, the serial admission-time checks that run
-	// before a block is admitted to the primary chain
-	// (handleEventChainsyncBlockHeaderWithPending,
-	// handleEventBlockfetchBlock in chainsync.go) skip only their
-	// stateless VRF/KES crypto re-check (blockPipelineRevalidatesCrypto),
-	// since the pipeline will independently re-verify the same block
-	// before ledger apply and decodeReadChainBatch aborts the whole read
-	// batch on a pipeline validation failure exactly as it would on a
-	// decode failure. Those admission paths still run their non-crypto
-	// checks unconditionally: the registered-VRF-key and
-	// leader-eligibility state checks (verifyBlockHeaderState, which the
-	// pipeline's validate stage does not perform -- it is scoped to
-	// VRF/KES only) and the epoch-cache-advance side effect
-	// (headerVerificationEpoch's ensureEpochForSlot) that the pipeline's
-	// own Eta0Provider deliberately does not perform. For historical sync
-	// with ValidateHistorical=false (blocks admitted without any crypto
-	// check until near the tip, unaffected by this flag), enabling this
-	// closes a real coverage gap for the historical backlog, in parallel,
-	// cheaply. For ValidateHistorical=true (the default), enabling this
-	// flag removes the double crypto check a naive additive wiring would
-	// otherwise leave in place, at the cost of a brief window where a
-	// not-yet-crypto-verified block can influence in-memory chain-selection
-	// bookkeeping in ls.chain (an internal candidate queue, not consulted
-	// by any downstream relay path) before the pipeline verifies it -- the
-	// same class of trust window already accepted, unconditionally, for
-	// ValidateHistorical=false. See ARCHITECTURE.md ("Block Processing
-	// Pipeline").
+	// This is defense in depth, not a replacement for admission validation.
+	// Headers and blocks remain fully checked before entering ls.chain because
+	// that chain is served to downstream clients before ledger apply. See
+	// ARCHITECTURE.md ("Block Processing Pipeline").
 	//
 	// This flag's extra CPU cost (two dedicated VRF/KES workers) can make
 	// block-apply throughput fall behind header arrival during bursty
@@ -1051,6 +1028,13 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 	// counters.
 	ls.metrics.init(cfg.PromRegistry)
 	ls.slotsPerKESPeriod.Store(ls.loadSlotsPerKESPeriod())
+	if cfg.BlockPipelineEnabled && cfg.BlockPipelineValidateEnabled &&
+		!cfg.ManualBlockProcessing && ls.SlotsPerKESPeriod() == 0 {
+		ls.publishCancel()
+		return nil, errors.New(
+			"block pipeline validation requires slotsPerKESPeriod from Shelley genesis",
+		)
+	}
 	ls.storeForgedBlockChecker(cfg.ForgedBlockChecker)
 	ls.storeSlotBattleRecorder(cfg.SlotBattleRecorder)
 	ls.leiosBackfill = newLeiosBackfiller(cfg)
@@ -1069,25 +1053,16 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 			pipeline.WithDecodeWorkers(blockPipelineDecodeWorkers),
 		}
 		if cfg.BlockPipelineValidateEnabled {
-			// Wire VRF/KES validation (phase 3). Eta0Provider looks up the
-			// epoch nonce for a block's slot using the same epoch-cache
-			// machinery as the serial header-crypto path
-			// (headerVerificationEpoch/epochNonceHex), but never advances
-			// the epoch cache itself (allowEpochCacheAdvance=false):
-			// unlike the chainsync-header path, which must forecast ahead
-			// of ledger apply for freshly-arriving live headers, this
-			// pipeline only ever validates blocks already committed to
-			// ls.chain, so the epoch cache should already cover them. Not
-			// advancing it here also avoids mutating shared epoch-cache
-			// state concurrently from multiple validate workers.
+			// Wire VRF/KES validation (phase 3). Eta0Provider reads the
+			// published epoch cache without forecasting or mutation; a
+			// missing nonce is handled by the serial-equivalence gate in
+			// decodeReadChainBatch.
 			//
-			// VerifyConfig matches the scope of the existing serial
-			// header-only check (verifyBlockHeaderHex): VRF/KES only, not
-			// body hash, transaction, or stake-pool validation, which
-			// dingo performs separately (body/tx validation in
-			// ledgerProcessBlock; the registered-VRF-key and leader-
-			// eligibility checks that stand in for gouroboros' generic
-			// stake-pool check in verifyBlockHeaderState).
+			// VerifyConfig scopes gouroboros' generic stage to VRF/KES.
+			// decodeReadChainBatch supplements a successful result with
+			// Dingo's OpCert signature/expiry checks. Body/transaction and
+			// registered-pool state validation remain in their existing
+			// ledger paths.
 			pipelineOpts = append(
 				pipelineOpts,
 				pipeline.WithValidateWorkers(blockPipelineValidateWorkers),
@@ -3445,6 +3420,7 @@ func (ls *LedgerState) StabilityWindow() uint64 {
 type readChainResult struct {
 	rollbackPoint ocommon.Point
 	blocks        []ledger.Block
+	err           error
 	rollback      bool
 	done          chan struct{}
 }
@@ -3667,9 +3643,26 @@ func (ls *LedgerState) ledgerReadChainIterator(
 				break
 			}
 		}
-		nextBatch, ok := ls.decodeReadChainBatch(ctx, rawBatch)
+		nextBatch, decodeErr := ls.decodeReadChainBatchWithError(ctx, rawBatch)
 		releaseGatherLock()
-		if !ok {
+		if decodeErr != nil {
+			var validationErr *headerValidationError
+			if !errors.As(decodeErr, &validationErr) {
+				return
+			}
+			result = readChainResult{
+				err:  decodeErr,
+				done: make(chan struct{}),
+			}
+			select {
+			case resultCh <- result:
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case <-result.done:
+			case <-ctx.Done():
+			}
 			return
 		}
 		if rollbackNext != nil {
@@ -3717,16 +3710,16 @@ func (ls *LedgerState) ledgerReadChainIterator(
 // observability: gouroboros' StageWorkerPool.worker pushes every non-nil
 // stage error onto errorsChan *before* forwarding the item onward to
 // Results(), unconditionally and regardless of whether the error is
-// "expected" for this item (e.g. blockPipelineEta0Provider always fails for
-// Byron-era slots, which decodeReadChainBatch deliberately ignores when it
-// later reads the same item back from Results() -- but by then the error has
-// already been pushed here). errorsChan's capacity is bounded
+// "expected" for this item (e.g. blockPipelineEta0Provider can fail while
+// cached epoch nonce state is unavailable, which decodeReadChainBatch
+// deliberately defers when it later reads the same item back from Results()
+// -- but by then the error has already been pushed here). errorsChan's
+// capacity is bounded
 // (PipelineConfig.PrefetchBufferSize, 1000 by default) with nothing else in
-// this codebase ever reading from it; on any real chain sync including
-// Byron-era blocks (i.e. every from-genesis or pre-Shelley-boundary sync),
-// it fills permanently after roughly that many blocks, and every validate
-// worker then blocks forever on `errors <- err` inside worker(), cascading
-// backpressure through validatedChan/decodedChan/submitChan into
+// this codebase ever reading from it; during a long interval without cached
+// nonce state it fills permanently after roughly that many blocks, and every
+// validate worker then blocks forever on `errors <- err` inside worker(),
+// cascading backpressure through validatedChan/decodedChan/submitChan into
 // ls.blockPipeline.Submit() -- which decodeReadChainBatch calls with
 // context.Background() deliberately, so it also blocks forever with no log
 // line, no error, and no timeout. This goroutine is what prevents that:
@@ -3750,13 +3743,9 @@ func (ls *LedgerState) drainBlockPipelineErrors() {
 //
 // Two cases are expected/transient and logged at debug level under their
 // own counters so a full sync does not spam the logs at error level:
-//   - errBlockPipelineEta0Unavailable (blockPipelineEta0Provider's wrapping
-//     of errEpochNonceUnavailable): no cached Praos epoch nonce yet. This is
-//     how every Byron-era slot fails the lookup, but headerVerificationEpoch's
-//     own doc comment describes the underlying condition -- epoch rollover
-//     not yet processed -- as one that is not exclusively Byron-specific;
-//     this function cannot verify the block's era, so the log message does
-//     not claim Byron specifically.
+//   - errBlockPipelineEta0Unavailable: the cached epoch entry has no Praos
+//     nonce. This is expected for Byron and can be transient for later eras;
+//     this function cannot inspect the item's era, so the log remains neutral.
 //   - errHeaderVerificationDeferred: the pipeline's epoch cache has not yet
 //     caught up with a block already committed to ls.chain. ARCHITECTURE.md
 //     ("Block Processing Pipeline") documents this as a transient race that
@@ -3779,7 +3768,7 @@ func (ls *LedgerState) recordBlockPipelineError(err error) {
 	case errors.Is(err, errBlockPipelineEta0Unavailable):
 		ls.metrics.incBlockPipelineExpectedEta0Error()
 		ls.config.Logger.Debug(
-			"block-processing pipeline: no cached epoch nonce yet for validate stage (epoch rollover not complete)",
+			"block-processing pipeline: cached epoch has no Praos nonce for validate stage",
 			"error",
 			err,
 		)
@@ -3808,11 +3797,9 @@ func (ls *LedgerState) recordBlockPipelineError(err error) {
 // regardless of which worker finishes first). Otherwise it decodes serially,
 // exactly as ledgerReadChainIterator did before the pipeline existed.
 //
-// Either way, a single decode failure anywhere in the batch discards the
-// whole batch and returns ok=false, matching pre-pipeline behavior of never
-// handing a partially-decoded batch downstream; the caller should return
-// immediately in that case. All errors are logged here so callers don't need
-// to log again.
+// A decode failure or an enforced validation failure anywhere in the batch
+// discards the whole batch. The preserved error lets a persisted-block
+// validation failure be recovered with its exact block point.
 //
 // Once a pipeline submission has started, it always runs to completion --
 // submit-and-drain is all-or-nothing, using a background context for the
@@ -3828,12 +3815,16 @@ func (ls *LedgerState) recordBlockPipelineError(err error) {
 // the first Submit call is safe because nothing has been submitted yet;
 // once started, only genuine pipeline shutdown (Stop(), which closes the
 // Results channel) can still interrupt the drain.
-func (ls *LedgerState) decodeReadChainBatch(
+// decodeReadChainBatchWithError is the error-preserving form used by the
+// ledger reader. Keeping the cause lets a validation failure on an already
+// persisted block enter header-validation recovery instead of silently
+// closing the reader and restarting on the same block forever.
+func (ls *LedgerState) decodeReadChainBatchWithError(
 	ctx context.Context,
 	rawBatch []models.Block,
-) (decoded []ledger.Block, ok bool) {
+) (decoded []ledger.Block, retErr error) {
 	if len(rawBatch) == 0 {
-		return nil, true
+		return nil, nil
 	}
 	if ls.blockPipeline == nil {
 		decoded = make([]ledger.Block, 0, len(rawBatch))
@@ -3844,15 +3835,15 @@ func (ls *LedgerState) decodeReadChainBatch(
 					"failed to decode block",
 					"error", err,
 				)
-				return nil, false
+				return nil, fmt.Errorf("decode block at slot %d: %w", raw.Slot, err)
 			}
 			decoded = append(decoded, block)
 		}
-		return decoded, true
+		return decoded, nil
 	}
 	select {
 	case <-ctx.Done():
-		return nil, false
+		return nil, ctx.Err()
 	default:
 	}
 	// Refresh the block-pipeline gauges on every exit from here on,
@@ -3877,13 +3868,13 @@ func (ls *LedgerState) decodeReadChainBatch(
 				"failed to submit block to decode pipeline",
 				"error", err,
 			)
-			return nil, false
+			return nil, fmt.Errorf("submit block to decode pipeline: %w", err)
 		}
 	}
 	results := ls.blockPipeline.Results()
 	decoded = make([]ledger.Block, 0, len(rawBatch))
-	// batchFailed remembers a decode or validation failure anywhere in the
-	// batch. Once set, every remaining iteration below still reads its
+	// retErr remembers a decode or validation failure anywhere in the batch.
+	// Once set, every remaining iteration below still reads its
 	// expected Results() entry (so this call fully drains what it
 	// Submitted) but discards it rather than appending to decoded or
 	// returning early. Returning as soon as the first failure is seen
@@ -3894,16 +3885,17 @@ func (ls *LedgerState) decodeReadChainBatch(
 	// notion of "whose submission is whose" beyond result order (see this
 	// function's doc comment on why a submission always runs to
 	// completion).
-	batchFailed := false
 	for range rawBatch {
 		item, chOk := <-results
 		if !chOk {
 			ls.config.Logger.Error(
 				"decode pipeline results channel closed unexpectedly",
 			)
-			return nil, false
+			return nil, errors.New(
+				"decode pipeline results channel closed unexpectedly",
+			)
 		}
-		if batchFailed {
+		if retErr != nil {
 			continue
 		}
 		if decodeErr := item.DecodeError(); decodeErr != nil {
@@ -3911,7 +3903,7 @@ func (ls *LedgerState) decodeReadChainBatch(
 				"failed to decode block",
 				"error", decodeErr,
 			)
-			batchFailed = true
+			retErr = fmt.Errorf("decode block: %w", decodeErr)
 			continue
 		}
 		block := item.Block()
@@ -3922,14 +3914,33 @@ func (ls *LedgerState) decodeReadChainBatch(
 		// than trying to validate them. Ignore any validation outcome for
 		// them here for the same reason.
 		if ls.config.BlockPipelineValidateEnabled &&
-			block.Era().Id != byron.EraIdByron {
+			block.Era().Id != byron.EraIdByron &&
+			ls.shouldEnforceBlockPipelineCrypto(block.SlotNumber()) {
 			if valErr := item.ValidationError(); valErr != nil {
+				// The validation-state snapshot can change between the gate
+				// above and the provider's lookup. A missing/deferred nonce is
+				// not evidence that the block is invalid; admission or the
+				// deferred apply-time check remains authoritative.
+				if errors.Is(valErr, errBlockPipelineEta0Unavailable) ||
+					errors.Is(valErr, errHeaderVerificationDeferred) {
+					decoded = append(decoded, block)
+					continue
+				}
 				ls.config.Logger.Error(
 					"failed to validate block",
 					"error", valErr,
 					"slot", block.SlotNumber(),
 				)
-				batchFailed = true
+				retErr = &headerValidationError{
+					BlockPoint: ocommon.NewPoint(
+						block.SlotNumber(),
+						block.Hash().Bytes(),
+					),
+					Cause: fmt.Errorf(
+						"block pipeline VRF/KES validation: %w",
+						valErr,
+					),
+				}
 				continue
 			}
 			if !item.IsValid() {
@@ -3937,16 +3948,47 @@ func (ls *LedgerState) decodeReadChainBatch(
 					"block failed pipeline VRF/KES validation",
 					"slot", block.SlotNumber(),
 				)
-				batchFailed = true
+				retErr = &headerValidationError{
+					BlockPoint: ocommon.NewPoint(
+						block.SlotNumber(),
+						block.Hash().Bytes(),
+					),
+					Cause: errors.New(
+						"block failed pipeline VRF/KES validation",
+					),
+				}
+				continue
+			}
+			if opCertErr := verifyOpCertHeaderCrypto(
+				block.Header(),
+				block.SlotNumber(),
+				ls.SlotsPerKESPeriod(),
+				ls.maxKESEvolutions(),
+			); opCertErr != nil {
+				ls.config.Logger.Error(
+					"failed to validate block operational certificate",
+					"error", opCertErr,
+					"slot", block.SlotNumber(),
+				)
+				retErr = &headerValidationError{
+					BlockPoint: ocommon.NewPoint(
+						block.SlotNumber(),
+						block.Hash().Bytes(),
+					),
+					Cause: fmt.Errorf(
+						"block pipeline operational certificate validation: %w",
+						opCertErr,
+					),
+				}
 				continue
 			}
 		}
 		decoded = append(decoded, block)
 	}
-	if batchFailed {
-		return nil, false
+	if retErr != nil {
+		return nil, retErr
 	}
-	return decoded, true
+	return decoded, nil
 }
 
 // noProgressBackoffBase/Max bound the delay applied when consecutive
@@ -4720,6 +4762,25 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					return nil
 				}
 				currentReadResultDone = result.done
+				if result.err != nil {
+					completeReadResult()
+					recovered, recoverErr := ls.tryRecoverFromHeaderValidationError( //nolint:contextcheck
+						result.err,
+					)
+					if recoverErr != nil {
+						return fmt.Errorf(
+							"recover read-chain header validation failure: %w",
+							recoverErr,
+						)
+					}
+					if recovered {
+						return errRestartLedgerPipeline
+					}
+					return fmt.Errorf(
+						"read-chain validation: %w",
+						result.err,
+					)
+				}
 				nextBatch = result.blocks
 				// Process rollback
 				// Note: We do NOT hold ls.Lock() here because rollback() calls

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -76,6 +76,31 @@ func TestLedgerProcessBlocksFromSourceReturnsNilWhenReaderCloses(
 	require.NoError(t, err)
 }
 
+func TestLedgerProcessBlocksFromSourceReturnsReadChainError(t *testing.T) {
+	ls := &LedgerState{
+		validationEnabled: true,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	resultDone := make(chan struct{})
+	readChainResultCh := make(chan readChainResult, 1)
+	readChainResultCh <- readChainResult{
+		err:  errors.New("decode block at slot 20"),
+		done: resultDone,
+	}
+	close(readChainResultCh)
+
+	err := ls.ledgerProcessBlocksFromSource(t.Context(), readChainResultCh)
+	require.ErrorContains(t, err, "read-chain decode or validation")
+	select {
+	case <-resultDone:
+	default:
+		t.Fatal("reader result was not released after decode failure")
+	}
+}
+
 func TestHandleLedgerProcessBlocksErrorLogsPersistentValidationFailure(
 	t *testing.T,
 ) {

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -62,27 +62,18 @@ var (
 	errLeaderStakeSnapshotUnavailable = errors.New(
 		"leader stake snapshot unavailable",
 	)
-	// errEpochNonceUnavailable is raised only by headerVerificationEpoch's
-	// empty-nonce branch: epoch data covers the slot, but that epoch has no
-	// Praos nonce recorded. In practice this only ever happens for
-	// Byron-era slots, which have no Praos nonce at all -- every other
-	// error headerVerificationEpoch can return (deferred/past-horizon,
-	// hard-fork-summary lookup failures, forecast-build errors, missing
-	// epoch data) is a genuinely unexpected condition, not this
-	// Byron-specific case, and must not be confused with it.
+	// errEpochNonceUnavailable marks an epoch-cache entry that covers the
+	// requested slot but has no published Praos nonce. Byron epochs always
+	// have this shape; a post-Byron entry can also have it transiently while
+	// nonce state catches up. It is distinct from a slot that is outside the
+	// published cache entirely.
 	errEpochNonceUnavailable = errors.New(
 		"epoch has no nonce for slot",
 	)
-	// errBlockPipelineEta0Unavailable is what blockPipelineEta0Provider
-	// wraps errEpochNonceUnavailable in -- the expected, Byron-only "no
-	// Praos nonce for this slot" case (see blockPipelineEta0Provider's doc
-	// comment). Every other error headerVerificationEpoch can return is
-	// returned by blockPipelineEta0Provider unchanged, not wrapped in this
-	// sentinel, so drainBlockPipelineErrors's classification (which uses
-	// this sentinel to log/count the expected case below error level)
-	// correctly buckets a genuine deferred/forecast failure on a
-	// non-Byron block as unexpected instead of silently treating it as
-	// the harmless Byron case.
+	// errBlockPipelineEta0Unavailable marks an epoch-cache entry with no
+	// Praos nonce. This is expected for Byron and can be transient for later
+	// eras; slots outside the published cache use
+	// errHeaderVerificationDeferred instead.
 	errBlockPipelineEta0Unavailable = errors.New(
 		"block-processing pipeline: epoch nonce unavailable",
 	)
@@ -1354,42 +1345,42 @@ func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {
 
 // blockPipelineEta0Provider implements gouroboros' pipeline.Eta0Provider for
 // the block-processing pipeline's validate stage (issue #1894 phase 3). It
-// looks up the epoch nonce for a block's slot using the same epoch-cache
-// machinery as the serial header-crypto path (headerVerificationEpoch,
-// epochNonceHex), but never advances the epoch cache
-// (allowEpochCacheAdvance=false): the pipeline only ever validates blocks
-// already committed to ls.chain (read back by ledgerReadChainIterator), so
-// unlike the chainsync-header path -- which must forecast ahead of ledger
-// apply for freshly-arriving live headers -- the epoch cache should already
-// cover them. Not advancing it also avoids mutating shared epoch-cache state
-// concurrently from multiple validate-stage worker goroutines, which all
-// call this function without any external synchronization between them.
+// reads only the already-published epoch cache. Unlike the admission path it
+// must neither forecast nor rebuild the hard-fork summary: validate workers
+// run concurrently over blocks already committed to ls.chain, and a missing
+// cached nonce means this later validation is deferred under the same gate as
+// the serial path. Avoiding headerVerificationEpoch here also keeps the hot
+// path O(logical cache scan) instead of rebuilding the full era summary for
+// every block.
 //
-// Byron-era slots have no Praos epoch nonce and always fail this lookup
-// with errEpochNonceUnavailable (headerVerificationEpoch rejects an epoch
-// with an empty nonce); callers must treat that specific failure on a
-// Byron-era block as expected, exactly as the serial path's
-// verifyBlockHeaderHex explicitly skips Byron blocks rather than trying to
-// validate them.
+// Byron-era slots have no Praos epoch nonce. Callers skip VRF/KES validation
+// for decoded Byron blocks, exactly as the serial path's verifyBlockHeaderHex
+// does. A missing nonce for any decoded post-Byron block is handled by the
+// same validation-state gate as admission rather than treated as a
+// cryptographic rejection.
 //
-// Only errEpochNonceUnavailable is wrapped in errBlockPipelineEta0Unavailable
-// below. Every other error headerVerificationEpoch can return --
-// errHeaderVerificationDeferred, hard-fork-summary lookup failures,
-// forecast-build errors -- is none of them Byron-specific and is returned
-// unchanged, so drainBlockPipelineErrors's classification (which keys off
-// errBlockPipelineEta0Unavailable) does not misclassify a genuine failure
-// on a non-Byron block as the expected, harmless case.
+// An epoch without a nonce is wrapped in errBlockPipelineEta0Unavailable.
+// A slot outside the published cache is wrapped in
+// errHeaderVerificationDeferred, so the error drain and enforcement path can
+// distinguish missing state from a cryptographic rejection.
 func (ls *LedgerState) blockPipelineEta0Provider(slot uint64) (string, error) {
-	epoch, err := ls.headerVerificationEpoch(slot, false)
+	epoch, err := ls.epochForSlot(slot)
 	if err != nil {
-		if errors.Is(err, errEpochNonceUnavailable) {
-			return "", fmt.Errorf(
-				"%w: %w",
-				errBlockPipelineEta0Unavailable,
-				err,
-			)
-		}
-		return "", err
+		return "", fmt.Errorf(
+			"%w: block-processing pipeline nonce lookup for slot %d: %w",
+			errHeaderVerificationDeferred,
+			slot,
+			err,
+		)
+	}
+	if len(epoch.Nonce) == 0 {
+		return "", fmt.Errorf(
+			"%w: %w: epoch %d has no nonce for slot %d",
+			errBlockPipelineEta0Unavailable,
+			errEpochNonceUnavailable,
+			epoch.EpochId,
+			slot,
+		)
 	}
 	return ls.epochNonceHex(epoch.EpochId, epoch.Nonce), nil
 }


### PR DESCRIPTION
## Summary

- Keeps header cryptography at admission so invalid blocks never enter the downstream-served primary chain.
- Adds pipeline OpCert signature and KES-lifetime checks with the same historical, Mithril, and nonce gates as serial validation.
- Converts persisted validation failures into chain rewind and resync instead of retrying the same block indefinitely.
- Reads published epoch nonces directly and rejects unusable pipeline KES configuration at startup.
- Adds regressions for OpCert rejection, validation recovery, Byron replay, decode-error propagation, and fork handling.

Closes #3244.
