### PR TITLE
fix(ledger): scope Conway features to needed scripts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.27.8
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.193.3
+	github.com/blinklabs-io/gouroboros v0.193.4-0.20260821025747-7f9fce84e569
 	github.com/blinklabs-io/ouroboros-mock v0.16.0
 	github.com/blinklabs-io/plutigo v0.3.0
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.193.3 h1:ao2dhsulyZP/Da/a4TgyDkZ/EXMVD3UAgEikKYYYBBs=
-github.com/blinklabs-io/gouroboros v0.193.3/go.mod h1:wCrv86t7VsYhW36JliNeaoqypbxU/WsB1Cq/9OMg0NA=
+github.com/blinklabs-io/gouroboros v0.193.4-0.20260821025747-7f9fce84e569 h1:I5imoujonJLufV7HmExlfBl4k172arV8P6lVzoXZq6c=
+github.com/blinklabs-io/gouroboros v0.193.4-0.20260821025747-7f9fce84e569/go.mod h1:wCrv86t7VsYhW36JliNeaoqypbxU/WsB1Cq/9OMg0NA=
 github.com/blinklabs-io/ouroboros-mock v0.16.0 h1:uAPoFE+WOXX9hct1Kb725gYS/8SKzATrwCF7XKOZ0Xs=
 github.com/blinklabs-io/ouroboros-mock v0.16.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.3.0 h1:lUl7q96a+XSxpd7iEh0AxvnyMNp9s1wZITv/3RuCfkA=

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -269,6 +269,12 @@ func conwayValidationRules(
 func buildConwayValidationRules() []indexedUtxoValidationRule {
 	skips := []utxoValidationRuleSkip{
 		{
+			index: conwayUtxoValidateConwayFeaturesRuleIndex,
+			validationFunc: conway.
+				UtxoValidateConwayFeaturesWithPlutusV1V2,
+			name: "conway.UtxoValidateConwayFeaturesWithPlutusV1V2",
+		},
+		{
 			index:          conwayUtxoValidateFeeTooSmallRuleIndex,
 			validationFunc: conway.UtxoValidateFeeTooSmallUtxo,
 			name:           "conway.UtxoValidateFeeTooSmallUtxo",
@@ -279,10 +285,111 @@ func buildConwayValidationRules() []indexedUtxoValidationRule {
 			name:           "conway.UtxoValidatePlutusScripts",
 		},
 	}
-	return buildIndexedUtxoValidationRulesWithSkips(
+	ret := buildIndexedUtxoValidationRulesWithSkips(
 		conway.UtxoValidationRules,
 		skips,
 	)
+	ret = append(ret, indexedUtxoValidationRule{
+		index:          conwayUtxoValidateConwayFeaturesRuleIndex,
+		validationFunc: validateConwayFeaturesWithNeededPlutusV1V2,
+	})
+	slices.SortFunc(ret, func(a, b indexedUtxoValidationRule) int {
+		return a.index - b.index
+	})
+	return ret
+}
+
+// validateConwayFeaturesWithNeededPlutusV1V2 rejects Conway-only transaction
+// features when a PlutusV1 or PlutusV2 script is required. The upstream rule
+// checks scripts that are merely available instead, so an unrelated reference
+// script can reject an otherwise valid transaction.
+func validateConwayFeaturesWithNeededPlutusV1V2(
+	tx lcommon.Transaction,
+	_ uint64,
+	ls lcommon.LedgerState,
+	_ lcommon.ProtocolParameters,
+) error {
+	view, err := script.NewTxScriptView(tx, ls)
+	if err != nil {
+		if isInputResolutionError(err) {
+			// UtxoValidateBadInputsUtxo owns input-resolution failures.
+			return nil
+		}
+		return err
+	}
+
+	plutusVersion := neededPlutusV1V2Version(view)
+	if plutusVersion == "" {
+		return nil
+	}
+
+	if treasury := tx.CurrentTreasuryValue(); treasury != nil &&
+		treasury.Sign() > 0 {
+		return conway.CurrentTreasuryValueWithPlutusV1V2Error{
+			PlutusVersion: plutusVersion,
+		}
+	}
+	if len(tx.ProposalProcedures()) > 0 {
+		return conway.ProposalProceduresWithPlutusV1V2Error{
+			PlutusVersion: plutusVersion,
+		}
+	}
+	if voting := tx.VotingProcedures(); len(voting) > 0 {
+		return conway.VotingProceduresWithPlutusV1V2Error{
+			PlutusVersion: plutusVersion,
+		}
+	}
+
+	for _, cert := range tx.Certificates() {
+		certType := ""
+		switch cert.(type) {
+		case *lcommon.AuthCommitteeHotCertificate:
+			certType = "AuthCommitteeHot"
+		case *lcommon.ResignCommitteeColdCertificate:
+			certType = "ResignCommitteeCold"
+		case *lcommon.RegistrationDrepCertificate:
+			certType = "DRepRegistration"
+		case *lcommon.DeregistrationDrepCertificate:
+			certType = "DRepDeregistration"
+		case *lcommon.UpdateDrepCertificate:
+			certType = "DRepUpdate"
+		case *lcommon.StakeVoteDelegationCertificate:
+			certType = "StakeVoteDelegation"
+		case *lcommon.StakeRegistrationDelegationCertificate:
+			certType = "StakeRegistrationDelegation"
+		case *lcommon.VoteDelegationCertificate:
+			certType = "VoteDelegation"
+		case *lcommon.VoteRegistrationDelegationCertificate:
+			certType = "VoteRegistrationDelegation"
+		case *lcommon.StakeVoteRegistrationDelegationCertificate:
+			certType = "StakeVoteRegistrationDelegation"
+		}
+		if certType != "" {
+			return conway.ConwayCertificateWithPlutusV1V2Error{
+				PlutusVersion:   plutusVersion,
+				CertificateType: certType,
+			}
+		}
+	}
+
+	return nil
+}
+
+func neededPlutusV1V2Version(view script.TxScriptView) string {
+	needsV2 := false
+	for _, needed := range view.Needed {
+		switch needed.(type) {
+		case lcommon.PlutusV1Script:
+			// Match the upstream rule's V1-before-V2 error precedence.
+			return "PlutusV1"
+		case lcommon.PlutusV2Script:
+			needsV2 = true
+		}
+	}
+	if needsV2 {
+		return "PlutusV2"
+	}
+	return ""
 }
 
 func isInputResolutionError(err error) bool {

--- a/ledger/eras/conway_features_plutus_test.go
+++ b/ledger/eras/conway_features_plutus_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+import (
+	"math/big"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockConwayFeaturesTx struct {
+	mockConwayFeeTx
+	currentTreasuryValue *big.Int
+}
+
+func (m *mockConwayFeaturesTx) CurrentTreasuryValue() *big.Int {
+	return m.currentTreasuryValue
+}
+
+func TestConwayFeaturesRuleAllowsUnneededPlutusV1V2(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		script lcommon.Script
+	}{
+		{name: "PlutusV1", script: lcommon.PlutusV1Script{0x01}},
+		{name: "PlutusV2", script: lcommon.PlutusV2Script{0x02}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := newTestInput(0x81, 0)
+			tx := newConwayFeaturesTestTx(input)
+			ls := newMockLedgerState()
+			ls.addUtxo(input, testAddressScriptOutput{
+				testOutput: newTestOutput(1_000_000),
+				addr:       newConwayFeaturesKeyAddress(t),
+				scriptRef:  tc.script,
+			})
+
+			require.NoError(t, conwayFeaturesRule(t)(
+				tx,
+				0,
+				ls,
+				&conway.ConwayProtocolParameters{},
+			))
+		})
+	}
+}
+
+func TestConwayFeaturesRuleRejectsNeededPlutusV1V2(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		script        lcommon.Script
+		plutusVersion string
+	}{
+		{
+			name:          "PlutusV1",
+			script:        lcommon.PlutusV1Script{0x03},
+			plutusVersion: "PlutusV1",
+		},
+		{
+			name:          "PlutusV2",
+			script:        lcommon.PlutusV2Script{0x04},
+			plutusVersion: "PlutusV2",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := newTestInput(0x82, 0)
+			tx := newConwayFeaturesTestTx(input)
+			ls := newMockLedgerState()
+			ls.addUtxo(input, testAddressScriptOutput{
+				testOutput: newTestOutput(1_000_000),
+				addr:       newConwayFeaturesScriptAddress(t, tc.script),
+				scriptRef:  tc.script,
+			})
+
+			var featureErr conway.ConwayCertificateWithPlutusV1V2Error
+			require.ErrorAs(t, conwayFeaturesRule(t)(
+				tx,
+				0,
+				ls,
+				&conway.ConwayProtocolParameters{},
+			), &featureErr)
+			assert.Equal(t, tc.plutusVersion, featureErr.PlutusVersion)
+			assert.Equal(t, "VoteDelegation", featureErr.CertificateType)
+		})
+	}
+}
+
+func conwayFeaturesRule(t *testing.T) lcommon.UtxoValidationRuleFunc {
+	t.Helper()
+	for _, rule := range conwayUtxoValidationRules {
+		if rule.index == conwayUtxoValidateConwayFeaturesRuleIndex {
+			return rule.validationFunc
+		}
+	}
+	t.Fatal("Conway PlutusV1/V2 feature rule was not installed")
+	return nil
+}
+
+func newConwayFeaturesTestTx(
+	input lcommon.TransactionInput,
+) *mockConwayFeaturesTx {
+	return &mockConwayFeaturesTx{
+		mockConwayFeeTx: mockConwayFeeTx{
+			mockFeeTx: mockFeeTx{},
+			inputs:    []lcommon.TransactionInput{input},
+			certificates: []lcommon.Certificate{
+				&lcommon.VoteDelegationCertificate{
+					StakeCredential: lcommon.Credential{
+						CredType: lcommon.CredentialTypeAddrKeyHash,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newConwayFeaturesKeyAddress(t *testing.T) lcommon.Address {
+	t.Helper()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		make([]byte, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+	return addr
+}
+
+func newConwayFeaturesScriptAddress(
+	t *testing.T,
+	s lcommon.Script,
+) lcommon.Address {
+	t.Helper()
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeScriptNone,
+		lcommon.AddressNetworkTestnet,
+		s.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	return addr
+}

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -106,11 +106,13 @@ type utxoValidationRuleSkip struct {
 const (
 	noUtxoValidationRuleIndex = -1
 
-	// Positions in gouroboros v0.193.3 UtxoValidationRules. Function
+	// Positions in gouroboros v0.193.4-0.20260821025747-7f9fce84e569
+	// UtxoValidationRules. Function
 	// values are not directly comparable in Go, so setup guards compare
 	// their runtime function names before filtering by index.
 	alonzoUtxoValidatePlutusScriptsRuleIndex   = 27
 	babbageUtxoValidatePlutusScriptsRuleIndex  = 31
+	conwayUtxoValidateConwayFeaturesRuleIndex  = 19
 	conwayUtxoValidateFeeTooSmallRuleIndex     = 24
 	conwayUtxoValidateExUnitsTooBigRuleIndex   = 39
 	conwayUtxoValidatePlutusScriptsRuleIndex   = 43

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -437,6 +437,13 @@ func TestConwayValidationRulesUseLocalPlutusExecution(t *testing.T) {
 	requireRuleIndexResolvesToFunc(
 		t,
 		conway.UtxoValidationRules,
+		conwayUtxoValidateConwayFeaturesRuleIndex,
+		conway.UtxoValidateConwayFeaturesWithPlutusV1V2,
+		"conway.UtxoValidateConwayFeaturesWithPlutusV1V2",
+	)
+	requireRuleIndexResolvesToFunc(
+		t,
+		conway.UtxoValidationRules,
 		conwayUtxoValidateFeeTooSmallRuleIndex,
 		conway.UtxoValidateFeeTooSmallUtxo,
 		"conway.UtxoValidateFeeTooSmallUtxo",
@@ -449,6 +456,18 @@ func TestConwayValidationRulesUseLocalPlutusExecution(t *testing.T) {
 		"conway.UtxoValidatePlutusScripts",
 	)
 	require.Len(t, conwayUtxoValidationRules, len(conway.UtxoValidationRules)-2)
+	requireIndexedRulesExcludeFunc(
+		t,
+		conwayUtxoValidationRules,
+		conway.UtxoValidateConwayFeaturesWithPlutusV1V2,
+		"Conway validation must count only needed PlutusV1/V2 scripts",
+	)
+	requireIndexedRulesIncludeFunc(
+		t,
+		conwayUtxoValidationRules,
+		validateConwayFeaturesWithNeededPlutusV1V2,
+		"Conway validation must install Dingo's needed-script rule",
+	)
 	requireIndexedRulesExcludeFunc(
 		t,
 		conwayUtxoValidationRules,


### PR DESCRIPTION
## Summary

- replace Conway rule 19's available-script check with the needed-script view
- preserve Conway feature errors and validation-rule ordering
- cover available-only and needed PlutusV1/V2 script cases

Depends on blinklabs-io/gouroboros#1980 for `TxScriptView`.

Closes #3256

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Conway feature checks to scripts the transaction needs, not those merely available. Previously, any available PlutusV1/V2 script (including unrelated reference scripts) could reject Conway-only features; now only transactions that need PlutusV1/V2 are rejected, preserving error precedence and rule order.

- Replaces upstream rule at index 19: skips `conway.UtxoValidateConwayFeaturesWithPlutusV1V2` and installs local `validateConwayFeaturesWithNeededPlutusV1V2` at the same index.
- Uses `script.NewTxScriptView` to inspect `Needed` scripts; delegates input-resolution errors to existing bad-input validation.
- Preserves error types and precedence (V1 before V2): `CurrentTreasuryValueWithPlutusV1V2Error`, `ProposalProceduresWithPlutusV1V2Error`, `VotingProceduresWithPlutusV1V2Error`, `ConwayCertificateWithPlutusV1V2Error`.
- Adds focused tests for reference-only vs needed PlutusV1/V2 and verifies rule wiring; fee/ex-units rules unchanged.
- Bumps `github.com/blinklabs-io/gouroboros` to `v0.193.4-0.20260821025747-7f9fce84e569` for `TxScriptView`.

<sup>Written for commit c8914afe152e4581ce9960640dcc459f95f1aafc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Conway transaction validation for Plutus V1 and V2 script requirements.
  * Added checks for incompatible treasury values, governance proposals, voting procedures, and certificates.
  * Improved handling and reporting of invalid transaction inputs and required script versions.

* **Tests**
  * Added coverage for valid transactions with unnecessary script references.
  * Added validation tests for transactions requiring incompatible Plutus scripts and certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->