### PR TITLE
fix(shutdown): protect storage after ledger drain timeout

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1038,6 +1038,13 @@ already-closed bus as idempotent. `EventBus.Close` discards queued in-memory
 events after waiting for in-flight handlers; ordinary `Unsubscribe` and
 reusable `EventBus.Stop` preserve queued events.
 
+If `LedgerState.Close` cannot confirm that its block-processing and database
+workers have drained, normal shutdown does not close the database or storage
+providers afterward. The process may terminate with those resources still
+open, but closing them while an unconfirmed ledger worker can still access
+state risks a use-after-close and on-disk corruption. Live Restore/Truncate
+uses the same fail-closed rule and escalates to a supervised restart.
+
 ## Event-Driven Communication
 
 Components use the `EventBus` (`event/event.go`) for asynchronous

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -277,6 +277,7 @@ func (n *Node) shutdown() error {
 	// Phase 3: Flush state and close database
 	n.config.logger.Info("shutdown phase 3: flushing state")
 	phase3Start := time.Now()
+	ledgerStateDrainConfirmed := true
 
 	if n.ledgerState != nil {
 		n.config.logger.Info("closing ledger state")
@@ -286,6 +287,7 @@ func (n *Node) shutdown() error {
 			shutdownTimeout,
 			n.ledgerState.Close,
 		); closeErr != nil {
+			ledgerStateDrainConfirmed = false
 			err = errors.Join(
 				err,
 				fmt.Errorf("ledger state close: %w", closeErr),
@@ -317,21 +319,37 @@ func (n *Node) shutdown() error {
 	}
 
 	if n.db != nil {
-		n.config.logger.Info("closing database")
-		if closeErr := n.closeWithShutdownTimeout(
-			ctx,
-			"database",
-			shutdownTimeout,
-			n.db.Close,
-		); closeErr != nil {
+		if !ledgerStateDrainConfirmed {
+			n.config.logger.Error(
+				"skipping database close because ledger state drain was not confirmed",
+			)
 			err = errors.Join(
 				err,
-				fmt.Errorf("database close: %w", closeErr),
+				errors.New(
+					"database close skipped: ledger state drain unconfirmed",
+				),
 			)
+		} else {
+			n.config.logger.Info("closing database")
+			if closeErr := n.closeWithShutdownTimeout(
+				ctx,
+				"database",
+				shutdownTimeout,
+				n.db.Close,
+			); closeErr != nil {
+				err = errors.Join(
+					err,
+					fmt.Errorf("database close: %w", closeErr),
+				)
+			}
 		}
 	}
 	if n.pluginHost != nil {
-		if stopErr := n.pluginHost.Stop(ctx); stopErr != nil {
+		if !ledgerStateDrainConfirmed {
+			n.config.logger.Error(
+				"skipping plugin host shutdown because ledger state drain was not confirmed",
+			)
+		} else if stopErr := n.pluginHost.Stop(ctx); stopErr != nil {
 			err = errors.Join(
 				err,
 				fmt.Errorf("plugin host shutdown: %w", stopErr),

--- a/node_test.go
+++ b/node_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/blinklabs-io/dingo/event"
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/peergov"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -429,6 +430,51 @@ func TestCloseWithShutdownTimeoutReturnsTimeoutError(t *testing.T) {
 		time.Second,
 		"close function completion",
 	)
+}
+
+// TestShutdownDoesNotCloseDatabaseWhenLedgerDrainIsUnconfirmed protects the
+// storage safety boundary shared with live Restore/Truncate. LedgerState.Close
+// can time out while a database worker is still using the database; normal
+// shutdown must not close the database or its provider-owned stores in that
+// state.
+func TestShutdownDoesNotCloseDatabaseWhenLedgerDrainIsUnconfirmed(t *testing.T) {
+	n, _ := newLiveLifecycleTestNodeWithGenesis(
+		t,
+		1,
+		nil,
+		ledger.DatabaseWorkerPoolConfig{WorkerPoolSize: 1, TaskQueueSize: 1},
+	)
+
+	origTimeout := ledger.CloseDBWorkerPoolShutdownTimeout
+	ledger.CloseDBWorkerPoolShutdownTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { ledger.CloseDBWorkerPoolShutdownTimeout = origTimeout })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	workerDone := make(chan struct{})
+	defer func() {
+		close(release)
+		testutil.RequireReceive(t, workerDone, time.Second, "database worker drain")
+	}()
+	go func() {
+		defer close(workerDone)
+		_ = n.ledgerState.SubmitAsyncDBOperation(func(*database.Database) error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	<-started
+
+	shutdownErr := n.shutdown()
+	require.Error(t, shutdownErr)
+	require.ErrorContains(t, shutdownErr, "database worker pool")
+	require.ErrorContains(t, shutdownErr, "database close skipped")
+
+	// The ledger worker is still blocked, so the database must remain usable.
+	require.NoError(t, n.db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(1, make([]byte, 32)),
+	}, nil))
 }
 
 // newChainSelectorSubscriptionTestNode builds the minimal node


### PR DESCRIPTION
## Problem

A Musashi Leios shutdown timed out waiting for the ledger block-processing pipeline while a large transaction batch was still applying. Normal shutdown then proceeded toward database and provider close, which could race an unconfirmed ledger worker.

## Changes

- fail closed when LedgerState drain is not confirmed;
- skip database and storage-provider close in that case;
- add a real worker-drain regression test and document the lifecycle invariant.

## Validation

- `go test -race ./ -run 'TestShutdownDoesNotCloseDatabaseWhenLedgerDrainIsUnconfirmed|TestCloseWithShutdownTimeoutReturnsTimeoutError' -count=1`
- `go test ./ -count=1`
- `go test ./ledger/... -count=1`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects the database and plugin host during shutdown when ledger drain times out. Previously, shutdown could close these while a ledger DB worker was still active, risking use-after-close and corruption.

- Close `ledgerState` with a timeout; if drain is unconfirmed, set a flag, skip `db.Close` and `pluginHost.Stop`, log the skips, and return joined errors including “database close skipped: ledger state drain unconfirmed”.
- Document the fail-closed lifecycle invariant in `ARCHITECTURE.md` and align Live Restore/Truncate with the same rule; the process may exit under supervision with resources still open.
- Add regression test `TestShutdownDoesNotCloseDatabaseWhenLedgerDrainIsUnconfirmed` that forces a DB worker-pool timeout, asserts error text, and verifies the database remains usable.
- No config or API changes.

<sup>Written for commit 096fcc29a7eccb102ef082968a1dfe8ba5d974fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

