### PR TITLE
fix(logging): redact secret-bearing configuration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6423,16 +6423,55 @@ Two classes are not simple pass/redact. A URI field -- `barkBaseUrl`,
 `tokenRegistry.sourceUrl`, `offchainMetadata.ipfsGatewayUrl`, and
 `databaseLifecycle.snapshotCloudDestination` -- keeps its scheme, host,
 port, path, and non-credential parameters and loses only its userinfo
-password and any credential-shaped parameter, because "which host and
-database was this node pointed at" is most of the reason the configuration
-is logged at all; the same handling covers both URL-form and keyword-form
-database DSNs. A
-provider-config field (`plugins.*.config`, a free-form `map[string]any`
-whose keys belong to the selected provider, not to `Config`) is walked
-recursively and classified per key name, so a secret nested at any depth
-under a provider section is still redacted; unrecognized keys default to
-redacted, which means an out-of-tree provider's benign key is
-over-redacted until it is added to the key table.
+password and the value of every credential-named parameter, because "which
+host and database was this node pointed at" is most of the reason the
+configuration is logged at all; the same handling covers both URL-form and
+keyword-form database DSNs. A provider-config field (`plugins.*.config`, a
+free-form `map[string]any` whose keys belong to the selected provider, not
+to `Config`) is walked recursively and classified per key name, so a
+secret nested at any depth under a provider section is still redacted;
+unrecognized keys default to redacted, which means an out-of-tree
+provider's benign key is over-redacted until it is added to the key table.
+A secret classification -- including the unrecognized-key default --
+covers the whole subtree beneath the key and is applied before any
+recursion, because walking into it would reclassify the inner keys by
+their own names and an inner key classified plain (`host`, `mode`) would
+then render part of a secret-bearing value. The API providers' nested
+`tls` and `auth` sections are classified as renderable containers so their
+own policy keys are still walked and classified individually.
+
+Both the URI parameters and the provider keys are decided by one
+credential classifier, `isCredentialKeyName`, which works per key-name
+word rather than per substring. A `\b`-anchored pattern over a raw key
+name is the wrong shape for this: `_` is a word character, so `\bsecret`
+cannot match `client_secret` and `\btoken` cannot match `api_token`, and
+`access[-_]?key` cannot reach the `=` of `accessKeyId=` past the `Id`
+suffix. Enumerating spellings instead only moves the next miss further
+out. So a key name is split into words at separators, at camelCase and
+acronym boundaries (`accessKeyId`, `IPFSGatewayURL`), and -- for a
+run-together spelling such as `apikey` -- by segmenting the word against
+the classifier's own vocabulary, which succeeds only when known words
+cover the word completely, so `monkey` and `keyspace` do not become
+credentials. The verdict is then set membership over four small word
+groups: words that name a credential outright (`password`, `secret`,
+`token`, `signature`, ...), `key`/`keys`, the qualifiers that make a key a
+credential (`api`, `access`, `private`, `client`, `shared`, ...), and the
+location words (`path`, `file`, `dir`, ...) that mean the value is where a
+credential is kept rather than the credential -- `tokenFilePath` and
+`signingKeyFile` name paths an operator needs to see. `TestIsCredentialKeyName`
+holds the term set against a table of camelCase, snake_case, kebab-case,
+prefixed, suffixed, and run-together spellings.
+
+Query strings are located with `net/url` and then scanned pair by pair, so
+the decision is per parameter name; keyword-form DSNs are scanned by the
+same routine with whitespace separators, optional whitespace around `=`,
+and quoted values, so a quoted password containing whitespace is redacted
+whole. The two classification tables and the classifier are held to one
+answer by tests: no provider key or `Config` field path classified
+renderable may read as a credential, apart from an explicitly listed
+review exception (`midnight.authTokenPolicyId` and
+`midnight.authTokenAssetName` name public on-chain data, not a token), and
+every path classified secret must read as one.
 
 The walk is deliberately uniform and does not defer to a nested type's own
 `slog.LogValuer` (`apiconfig.AuthPolicy` has one). One table with one

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6436,9 +6436,18 @@ A secret classification -- including the unrecognized-key default --
 covers the whole subtree beneath the key and is applied before any
 recursion, because walking into it would reclassify the inner keys by
 their own names and an inner key classified plain (`host`, `mode`) would
-then render part of a secret-bearing value. The API providers' nested
-`tls` and `auth` sections are classified as renderable containers so their
-own policy keys are still walked and classified individually.
+then render part of a secret-bearing value. The API providers nest their
+`tls` and `auth` policies, so those two keys carry a container
+classification of their own: the section beneath them is walked and its
+policy keys are classified individually, while a value of any other shape
+at the same key -- a scalar, a slice, a map this walk cannot key into --
+is redacted whole. The key says only that a container belongs there, so it
+classifies nothing about what a scalar there would hold. The key's class
+and the value's shape are reconciled in one place, which is what keeps
+every container key from needing its own shape check. The URI class is
+held to the same rule: only a shape that holds strings can have its
+credentials removed, so any other shape under a URI field is redacted
+rather than rendered untransformed.
 
 Both the URI parameters and the provider keys are decided by one
 credential classifier, `isCredentialKeyName`, which works per key-name
@@ -6458,15 +6467,26 @@ groups: words that name a credential outright (`password`, `secret`,
 credential (`api`, `access`, `private`, `client`, `shared`, ...), and the
 location words (`path`, `file`, `dir`, ...) that mean the value is where a
 credential is kept rather than the credential -- `tokenFilePath` and
-`signingKeyFile` name paths an operator needs to see. `TestIsCredentialKeyName`
-holds the term set against a table of camelCase, snake_case, kebab-case,
-prefixed, suffixed, and run-together spellings.
+`signingKeyFile` name paths an operator needs to see. A name is also
+decoded before it is split, so a percent- or plus-encoded spelling
+classifies as the name it decodes to, and an encoding cannot move a term
+out of reach either.
+`TestIsCredentialKeyName` holds the term set against a table of camelCase,
+snake_case, kebab-case, prefixed, suffixed, run-together, and encoded
+spellings.
 
 Query strings are located with `net/url` and then scanned pair by pair, so
-the decision is per parameter name; keyword-form DSNs are scanned by the
-same routine with whitespace separators, optional whitespace around `=`,
-and quoted values, so a quoted password containing whitespace is redacted
-whole. The two classification tables and the classifier are held to one
+the decision is per parameter name. A query name carries its percent- and
+plus-escape bytes into the scan, because without them `api%5Fkey` would be
+scanned as the two fragments `api` and `5Fkey` and neither reads as a
+credential; only the classification decodes, so the rendered URI keeps the
+operator's own bytes, and a name whose escapes are malformed decodes
+nowhere and fails closed. Keyword-form DSNs are scanned by the same
+routine with whitespace separators, optional whitespace around `=`, quoted
+values -- so a quoted password containing whitespace is redacted whole --
+and literal keywords, since no DSN parser percent-decodes them.
+
+The two classification tables and the classifier are held to one
 answer by tests: no provider key or `Config` field path classified
 renderable may read as a credential, apart from an explicitly listed
 review exception (`midnight.authTokenPolicyId` and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6397,6 +6397,48 @@ sqlite is opened per-process, and the default blob plugin's exclusive
 per-directory lock already rules out two full database opens racing at
 once regardless of metadata plugin.
 
+### Redacted Configuration Logging
+
+`internal/node`'s `logStartupConfig` debug-logs the whole effective
+configuration at startup, which means the configuration is the one place
+where a Koios API key, an inline API auth token, or a storage provider
+password or DSN would be persisted into an operator's log files. It logs
+through `Config.LogValue` (`internal/config/redact.go`), the explicit
+`slog.LogValuer` representation of a `Config`, rather than formatting the
+struct: unexported fields are never rendered, and every rendered value is
+classified first.
+
+Classification is a fail-safe allow-list, not a deny-list. Each dotted
+`Config` field path is listed in exactly one of four groups -- plain,
+secret, URI, or provider config -- and an unlisted path resolves to the
+zero `logClass`, which is `logSecret`. A field added without a
+classification is therefore redacted rather than leaked, and
+`TestConfigLogClassesCoverEveryConfigField` fails on it, so the silent
+over-redaction that fail-safe default produces turns into a required
+explicit decision instead of a surprise in production logs. The same test
+rejects a classification whose field no longer exists, catching a rename.
+
+Two classes are not simple pass/redact. A URI field -- `barkBaseUrl`,
+`barkBlockDownloadHosts`, `mithril.aggregatorUrl`,
+`tokenRegistry.sourceUrl`, `offchainMetadata.ipfsGatewayUrl`, and
+`databaseLifecycle.snapshotCloudDestination` -- keeps its scheme, host,
+port, path, and non-credential parameters and loses only its userinfo
+password and any credential-shaped parameter, because "which host and
+database was this node pointed at" is most of the reason the configuration
+is logged at all; the same handling covers both URL-form and keyword-form
+database DSNs. A
+provider-config field (`plugins.*.config`, a free-form `map[string]any`
+whose keys belong to the selected provider, not to `Config`) is walked
+recursively and classified per key name, so a secret nested at any depth
+under a provider section is still redacted; unrecognized keys default to
+redacted, which means an out-of-tree provider's benign key is
+over-redacted until it is added to the key table.
+
+The walk is deliberately uniform and does not defer to a nested type's own
+`slog.LogValuer` (`apiconfig.AuthPolicy` has one). One table with one
+exhaustiveness test decides what a configuration log contains, so a nested
+`LogValue` cannot become a second, untested source of truth.
+
 ## Stake Snapshots
 
 Stake snapshots capture the stake distribution at epoch boundaries for use in Ouroboros Praos leader election. The block producer must know the Set distribution — stake at the end of epoch E-2 — to determine if it is the slot leader. The authoritative rollover capture reads the transactionally maintained `reward_live_stake` aggregate at the exact SNAP point — after the delayed reward update and MIR, and before POOLREAP and governance enactment — and before any new-epoch block is applied. A delayed fallback whose transaction tip has already passed the snapshot slot reconstructs slot-aware delegation and UTxO liveness historically. When bootstrapping from Mithril, the imported epoch also needs the active `pool-distr` fraction from the certified ledger state for header validation.

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -51,6 +51,13 @@ const (
 	// logProviderConfig recursively renders a plugin provider's
 	// free-form configuration map, classifying each key by name.
 	logProviderConfig
+	// logProviderSection is the class of a provider configuration key
+	// that names a nested section rather than a value of its own. The
+	// section is walked so its own keys are classified by name, and a
+	// value of any other shape at the same key is redacted: the key says
+	// only that a container belongs there, so it classifies nothing
+	// about a scalar, a slice, or a map this walk cannot key into.
+	logProviderSection
 )
 
 // logSecretConfigFields are the Config field paths (dotted Go field names)
@@ -265,9 +272,7 @@ var configLogClasses = sync.OnceValue(func() map[string]logClass {
 
 // providerConfigPlainKeys are the lower-cased keys a compiled-in plugin
 // provider accepts in its free-form configuration map that carry no
-// secret. "auth" and "tls" are the nested sections of the API providers:
-// they are containers, so classifying them plain is what lets the walk
-// recurse and classify the keys inside them by name.
+// secret.
 var providerConfigPlainKeys = []string{
 	// database/plugin/metadata/sqlite
 	"datadir", "maxconnections",
@@ -283,11 +288,19 @@ var providerConfigPlainKeys = []string{
 	// mempool
 	"capacity", "evictionwatermark", "rejectionwatermark",
 	"revalidationdeltacap",
-	// api/{blockfrost,mesh,utxorpc} tls and auth sections and the
-	// policy keys inside them
-	"auth", "tls",
+	// api/{blockfrost,mesh,utxorpc} policy keys inside the tls and auth
+	// sections
 	"mode", "certfilepath", "keyfilepath", "tokenfilepath",
 }
+
+// providerConfigSectionKeys are provider configuration keys whose value is
+// a nested section of further keys. The API providers nest their tls and
+// auth policies there, so the section has to stay walkable or the whole
+// policy disappears from a startup log -- but only a section is walkable,
+// and classifying these keys separately from the values that carry no
+// secret is what keeps a non-section value at the same key from being
+// rendered as one.
+var providerConfigSectionKeys = []string{"auth", "tls"}
 
 // providerConfigURIKeys are provider configuration keys holding a URI or
 // database DSN, rendered with only their credential components removed.
@@ -306,9 +319,10 @@ var providerConfigSecretKeys = []string{"password", "token"}
 var providerConfigKeyClasses = sync.OnceValue(func() map[string]logClass {
 	classes := make(map[string]logClass)
 	for class, keys := range map[logClass][]string{
-		logPlain:  providerConfigPlainKeys,
-		logURI:    providerConfigURIKeys,
-		logSecret: providerConfigSecretKeys,
+		logPlain:           providerConfigPlainKeys,
+		logProviderSection: providerConfigSectionKeys,
+		logURI:             providerConfigURIKeys,
+		logSecret:          providerConfigSecretKeys,
 	} {
 		for _, key := range keys {
 			classes[key] = class
@@ -400,20 +414,36 @@ func logFieldName(field reflect.StructField) string {
 	return tag
 }
 
-// classedValue renders a non-struct configuration value according to class.
+// classedValue renders a non-struct configuration value according to
+// class. Every class that renders anything states which shapes it can
+// render, and a value of any other shape is redacted rather than rendered
+// through a rule that does not apply to it.
 func classedValue(v reflect.Value, class logClass) slog.Value {
 	switch class {
 	case logProviderConfig:
 		return providerConfigValue(v)
 	case logURI:
-		return mappedValue(v, redactURICredentials)
+		return mappedValue(v, redactURICredentials, redactedValue)
 	case logPlain:
-		return mappedValue(v, func(s string) string { return s })
+		return mappedValue(
+			v,
+			func(s string) string { return s },
+			plainValue,
+		)
+	case logProviderSection:
+		// A section is rendered by providerConfigEntry, which reaches
+		// here only for a value that is not one.
+		return redactedValue(v)
 	case logSecret:
 		return redactedValue(v)
 	default:
 		return redactedValue(v)
 	}
+}
+
+// plainValue renders v as itself.
+func plainValue(v reflect.Value) slog.Value {
+	return slog.AnyValue(v.Interface())
 }
 
 // redactedValue replaces a secret-bearing value with redactedPlaceholder. A
@@ -429,7 +459,16 @@ func redactedValue(v reflect.Value) slog.Value {
 // mappedValue renders v, applying transform to every string it contains so
 // a slice or map of URIs is handled element by element rather than as one
 // opaque value.
-func mappedValue(v reflect.Value, transform func(string) string) slog.Value {
+//
+// A shape holding no strings to transform -- a map of slices, a slice of
+// structs -- cannot be transformed at all, so fallback decides it.
+// Rendering such a value whole is right for a plain field and would leak
+// an untransformed credential under a URI one.
+func mappedValue(
+	v reflect.Value,
+	transform func(string) string,
+	fallback func(reflect.Value) slog.Value,
+) slog.Value {
 	switch v.Kind() { //nolint:exhaustive // reflect.Kind default is intended
 	case reflect.String:
 		return slog.StringValue(transform(v.String()))
@@ -438,7 +477,7 @@ func mappedValue(v reflect.Value, transform func(string) string) slog.Value {
 		for i := range v.Len() {
 			item := v.Index(i)
 			if item.Kind() != reflect.String {
-				return slog.AnyValue(v.Interface())
+				return fallback(v)
 			}
 			items = append(items, transform(item.String()))
 		}
@@ -446,7 +485,7 @@ func mappedValue(v reflect.Value, transform func(string) string) slog.Value {
 	case reflect.Map:
 		if v.Type().Key().Kind() != reflect.String ||
 			v.Type().Elem().Kind() != reflect.String {
-			return slog.AnyValue(v.Interface())
+			return fallback(v)
 		}
 		attrs := make([]slog.Attr, 0, v.Len())
 		for _, key := range sortedStringKeys(v) {
@@ -457,7 +496,7 @@ func mappedValue(v reflect.Value, transform func(string) string) slog.Value {
 		}
 		return slog.GroupValue(attrs...)
 	default:
-		return slog.AnyValue(v.Interface())
+		return fallback(v)
 	}
 }
 
@@ -465,7 +504,7 @@ func mappedValue(v reflect.Value, transform func(string) string) slog.Value {
 // map, classifying each key by name and recursing into nested maps so a
 // secret nested under any depth of provider sections is still redacted.
 func providerConfigValue(v reflect.Value) slog.Value {
-	if v.Kind() != reflect.Map || v.Type().Key().Kind() != reflect.String {
+	if !isProviderConfigSection(v) {
 		return slog.StringValue(redactedPlaceholder)
 	}
 	attrs := make([]slog.Attr, 0, v.Len())
@@ -481,7 +520,7 @@ func providerConfigValue(v reflect.Value) slog.Value {
 }
 
 // providerConfigEntry renders one provider configuration entry. A nested
-// map or slice under a non-secret key is walked so its own keys are
+// section or slice under a non-secret key is walked so its own keys are
 // classified by name; anything else is rendered according to its key's
 // class.
 //
@@ -490,6 +529,12 @@ func providerConfigValue(v reflect.Value) slog.Value {
 // into it would reclassify the inner keys by their own names, and an
 // inner key that happens to be classified plain ("host", "mode") would
 // then render part of a value whose enclosing key is a secret.
+//
+// A logProviderSection class is the one place where the key's class and
+// the value's shape have to agree: the key says a container belongs
+// there, so a section is walked and anything else is redacted. Deciding
+// that here, once, is what keeps every container key from needing its own
+// shape check.
 func providerConfigEntry(v reflect.Value, class logClass) slog.Value {
 	if !v.IsValid() {
 		return slog.AnyValue(nil)
@@ -497,7 +542,14 @@ func providerConfigEntry(v reflect.Value, class logClass) slog.Value {
 	if class == logSecret {
 		return redactedValue(v)
 	}
-	if v.Kind() == reflect.Map && v.Type().Key().Kind() == reflect.String {
+	section := isProviderConfigSection(v)
+	if class == logProviderSection {
+		if !section {
+			return redactedValue(v)
+		}
+		return providerConfigValue(v)
+	}
+	if section {
 		return providerConfigValue(v)
 	}
 	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
@@ -512,6 +564,14 @@ func providerConfigEntry(v reflect.Value, class logClass) slog.Value {
 		return slog.AnyValue(items)
 	}
 	return classedValue(v, class)
+}
+
+// isProviderConfigSection reports whether v is a nested provider
+// configuration section: a map this walk can key into and classify entry
+// by entry.
+func isProviderConfigSection(v reflect.Value) bool {
+	return v.Kind() == reflect.Map &&
+		v.Type().Key().Kind() == reflect.String
 }
 
 // unwrapInterface resolves an interface-typed reflect.Value to the value it
@@ -569,9 +629,43 @@ func redactURICredentials(s string) string {
 // around '=' is optional, and a value containing whitespace is quoted.
 func redactCredentialParams(s string) string {
 	if start, end, ok := uriQuerySpan(s); ok {
-		return s[:start] + redactParams(s[start:end], "&;") + s[end:]
+		return s[:start] +
+			redactParams(s[start:end], uriQuerySyntax) +
+			s[end:]
 	}
-	return redactParams(s, " \t\r\n")
+	return redactParams(s, keywordDSNSyntax)
+}
+
+// paramSyntax describes how one parameter form spells its "name=value"
+// pairs, so one scanner serves both forms and neither can be given the
+// other's rules by accident.
+type paramSyntax struct {
+	// delims are the bytes that separate one pair from the next.
+	delims string
+	// encoded reports whether a name carries percent- and plus-escapes,
+	// as a URI query's names do. Those escape bytes belong to the name:
+	// without them "api%5Fkey" scans as the two fragments "api" and
+	// "5Fkey", and neither of those reads as a credential.
+	encoded bool
+}
+
+var (
+	// uriQuerySyntax is a URI query string: '&' or ';' separates the
+	// pairs and the names are percent-encoded.
+	uriQuerySyntax = paramSyntax{delims: "&;", encoded: true}
+	// keywordDSNSyntax is the keyword-form database DSN: whitespace
+	// separates the pairs and the keywords are literal, because no DSN
+	// parser percent-decodes them.
+	keywordDSNSyntax = paramSyntax{delims: " \t\r\n"}
+)
+
+// isNameByte reports whether b belongs to a parameter name written in this
+// syntax.
+func (syntax paramSyntax) isNameByte(b byte) bool {
+	if syntax.encoded && (b == '%' || b == '+') {
+		return true
+	}
+	return isKeyNameByte(b)
 }
 
 // uriQuerySpan returns the bounds of s's URI query string, if it has one.
@@ -598,21 +692,22 @@ func uriQuerySpan(s string) (int, int, bool) {
 }
 
 // redactParams replaces the value of every credential-named parameter in
-// s, whose parameters are separated by any byte in delims. Separators,
-// ordering, quoting, and every non-credential value are copied through
-// byte for byte, because a redacted DSN is only useful if the host,
-// database, and options it names survive.
-func redactParams(s, delims string) string {
+// s, whose parameters are spelled in syntax. Separators, ordering,
+// quoting, name encoding, and every non-credential value are copied
+// through byte for byte, because a redacted DSN is only useful if the
+// host, database, and options it names survive. Only the classification
+// of a name decodes it; the output keeps the operator's own bytes.
+func redactParams(s string, syntax paramSyntax) string {
 	var out strings.Builder
 	out.Grow(len(s))
 	for i := 0; i < len(s); {
 		skipped := i
-		for i < len(s) && !isKeyNameByte(s[i]) {
+		for i < len(s) && !syntax.isNameByte(s[i]) {
 			i++
 		}
 		out.WriteString(s[skipped:i])
 		nameEnd := i
-		for nameEnd < len(s) && isKeyNameByte(s[nameEnd]) {
+		for nameEnd < len(s) && syntax.isNameByte(s[nameEnd]) {
 			nameEnd++
 		}
 		name := s[i:nameEnd]
@@ -622,11 +717,11 @@ func redactParams(s, delims string) string {
 		}
 		out.WriteString(name)
 		i = nameEnd
-		valueStart, ok := paramValueStart(s, nameEnd)
+		valueStart, ok := paramValueStart(s, nameEnd, syntax)
 		if !ok {
 			continue
 		}
-		valueEnd := paramValueEnd(s, valueStart, delims)
+		valueEnd := paramValueEnd(s, valueStart, syntax)
 		if valueEnd > valueStart && isCredentialKeyName(name) {
 			out.WriteString(s[nameEnd:valueStart])
 			out.WriteString(redactedPlaceholder)
@@ -646,14 +741,14 @@ func redactParams(s, delims string) string {
 // whitespace followed by another "name=" pair instead means this
 // parameter's value is empty; consuming the next pair as the value would
 // hide a non-credential option behind the placeholder.
-func paramValueStart(s string, nameEnd int) (int, bool) {
+func paramValueStart(s string, nameEnd int, syntax paramSyntax) (int, bool) {
 	i := skipParamSpace(s, nameEnd)
 	if i >= len(s) || s[i] != '=' {
 		return 0, false
 	}
 	i++
 	if spaced := skipParamSpace(s, i); spaced != i &&
-		!startsParam(s, spaced) {
+		!startsParam(s, spaced, syntax) {
 		i = spaced
 	}
 	return i, true
@@ -663,7 +758,7 @@ func paramValueStart(s string, nameEnd int) (int, bool) {
 // quoted value ends at its closing quote, so a keyword DSN password
 // containing whitespace is redacted whole rather than up to its first
 // space; an unquoted value ends at the first byte in delims.
-func paramValueEnd(s string, i int, delims string) int {
+func paramValueEnd(s string, i int, syntax paramSyntax) int {
 	if i < len(s) && (s[i] == '\'' || s[i] == '"') {
 		quote := s[i]
 		for j := i + 1; j < len(s); {
@@ -679,7 +774,7 @@ func paramValueEnd(s string, i int, delims string) int {
 		return len(s)
 	}
 	for ; i < len(s); i++ {
-		if strings.IndexByte(delims, s[i]) >= 0 {
+		if strings.IndexByte(syntax.delims, s[i]) >= 0 {
 			return i
 		}
 	}
@@ -687,9 +782,9 @@ func paramValueEnd(s string, i int, delims string) int {
 }
 
 // startsParam reports whether a new "name=" pair begins at i.
-func startsParam(s string, i int) bool {
+func startsParam(s string, i int, syntax paramSyntax) bool {
 	end := i
-	for end < len(s) && isKeyNameByte(s[end]) {
+	for end < len(s) && syntax.isNameByte(s[end]) {
 		end++
 	}
 	if end == i {
@@ -744,14 +839,15 @@ func redactURIUserinfo(s string) string {
 // refreshToken, privateKey, sasToken, SharedAccessSignature -- only moves
 // the next miss one spelling further out.
 //
-// So a name is decomposed into words first: at separators
+// So a name is decoded and then decomposed into words: at separators
 // ("client_secret", "x-api-key", "auth.token"), at camelCase and acronym
 // boundaries ("accessKeyId", "IPFSGatewayURL"), and, for a run-together
 // spelling such as "apikey" or "accesskeyid", by segmenting the word
 // against the vocabulary below -- which succeeds only when known words
 // cover the word completely, so "monkey" and "keyspace" do not become
 // credentials. The decision is then set membership over those words, and
-// no prefix, suffix, or separator can move a term out of reach.
+// no prefix, suffix, separator, or percent-escape can move a term out of
+// reach.
 
 // credentialWords name a credential themselves: one of them anywhere in a
 // key name means the value is a credential.
@@ -813,8 +909,19 @@ var keyNameVocabulary = sync.OnceValue(func() []string {
 
 // isCredentialKeyName reports whether a value stored under the
 // configuration key or URI parameter name is a credential.
+//
+// The name is decoded before it is split, so an encoded spelling
+// classifies as the name it decodes to. Only the classification decodes:
+// every caller renders the operator's original bytes.
 func isCredentialKeyName(name string) bool {
-	words := keyNameWords(name)
+	decoded, ok := decodeKeyNameEscapes(name)
+	if !ok {
+		// An escape that does not decode leaves the name unreadable
+		// here and in whatever else would consume it, so what it names
+		// is unknown and its value fails closed.
+		return true
+	}
+	words := keyNameWords(decoded)
 	switch {
 	case containsWord(words, locationWords):
 		return false
@@ -824,6 +931,21 @@ func isCredentialKeyName(name string) bool {
 		return containsWord(words, keyWords) &&
 			containsWord(words, credentialQualifierWords)
 	}
+}
+
+// decodeKeyNameEscapes decodes the percent- and plus-escapes of a key
+// name, reporting whether every escape in it was well formed. A name
+// carrying no escape is its own decoding, so the common case neither
+// allocates nor changes classification.
+func decodeKeyNameEscapes(name string) (string, bool) {
+	if !strings.ContainsAny(name, "%+") {
+		return name, true
+	}
+	decoded, err := url.QueryUnescape(name)
+	if err != nil {
+		return name, false
+	}
+	return decoded, true
 }
 
 // containsWord reports whether any of words appears in set.

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -1,0 +1,555 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"log/slog"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// redactedPlaceholder replaces a secret-bearing value in a rendered log. It
+// matches internal/apiconfig's own AuthPolicy.LogValue placeholder so an
+// operator sees one spelling everywhere.
+const redactedPlaceholder = "***redacted***"
+
+// logClass says how one configuration value is rendered for logging.
+//
+// logSecret is deliberately the zero value: an unclassified field path or an
+// unrecognized provider-config map key looks up as logSecret, so a value
+// nobody has classified is redacted rather than logged. That makes omission
+// fail safe instead of leaking, and
+// TestConfigLogClassesCoverEveryConfigField turns the resulting silent
+// over-redaction of a newly added benign field into a test failure, forcing
+// an explicit decision.
+type logClass uint8
+
+const (
+	// logSecret replaces a non-zero value with redactedPlaceholder.
+	logSecret logClass = iota
+	// logPlain renders the value as-is.
+	logPlain
+	// logURI renders a URI or database DSN with only its credential
+	// components removed, keeping scheme, host, port, path, and
+	// non-credential parameters so the value stays diagnosable.
+	logURI
+	// logProviderConfig recursively renders a plugin provider's
+	// free-form configuration map, classifying each key by name.
+	logProviderConfig
+)
+
+// logSecretConfigFields are the Config field paths (dotted Go field names)
+// whose values are secrets in themselves and are never rendered.
+var logSecretConfigFields = []string{
+	// Inline shared secret for API token authentication.
+	"API.Auth.Token",
+	// Koios Bearer token.
+	"KoiosParity.APIKey",
+}
+
+// logURIConfigFields are Config field paths holding a URI that an operator
+// may have embedded credentials in, either as userinfo
+// ("scheme://user:password@host") or as a credential-shaped query
+// parameter.
+var logURIConfigFields = []string{
+	"BarkBaseUrl",
+	"BarkBlockDownloadHosts",
+	"DatabaseLifecycle.SnapshotCloudDestination",
+	"Mithril.AggregatorURL",
+	"OffchainMetadata.IPFSGatewayURL",
+	"TokenRegistry.SourceURL",
+}
+
+// logProviderConfigFields are Config field paths holding a plugin
+// provider's free-form configuration map. Their contents are provider
+// defined -- a Postgres or MySQL provider accepts "password" and "dsn", an
+// API provider accepts a nested "auth.token" -- so they are walked
+// recursively and classified per key rather than as a whole.
+var logProviderConfigFields = []string{
+	"Plugins.API.Blockfrost.Config",
+	"Plugins.API.Mesh.Config",
+	"Plugins.API.Utxorpc.Config",
+	"Plugins.Mempool.Config",
+	"Plugins.Storage.Blob.Config",
+	"Plugins.Storage.Metadata.Config",
+}
+
+// logPlainConfigFields are the Config field paths carrying no secret. Every
+// entry is an explicit statement that the value is safe to persist in a
+// debug log. Filesystem paths (including key and certificate file paths),
+// on-chain policy IDs and addresses, network and peer tuning, and public
+// key registries all belong here; the key material behind a path does not
+// pass through Config at all.
+var logPlainConfigFields = []string{
+	"API.Auth.Mode",
+	"API.Auth.TokenFilePath",
+	"API.TLS.CertFilePath",
+	"API.TLS.KeyFilePath",
+	"API.TLS.Mode",
+	"ActivePeersGossipQuota",
+	"ActivePeersLedgerQuota",
+	"ActivePeersTopologyQuota",
+	"BackfillBatchSize",
+	"BarkClientCAFilePath",
+	"BarkHost",
+	"BarkPort",
+	"BindAddr",
+	"BlockPipelineEnabled",
+	"BlockPipelineValidateEnabled",
+	"BlockProducer",
+	"CORSAllowedOrigins",
+	"Cache.BlockLRUEntries",
+	"Cache.HotTxEntries",
+	"Cache.HotTxMaxBytes",
+	"Cache.HotUtxoEntries",
+	"Cache.WarmupBlocks",
+	"Cache.WarmupSync",
+	"CardanoConfig",
+	"Chainsync.MaxClients",
+	"Chainsync.StallTimeout",
+	"Chainsync.Strategy",
+	"DatabaseLifecycle.SnapshotCloudDestinationPrefix",
+	"DatabaseLifecycle.SnapshotDir",
+	"DatabaseLifecycle.SnapshotEnabled",
+	"DatabaseLifecycle.SnapshotEveryNEpochs",
+	"DatabaseLifecycle.SnapshotRetention",
+	"DatabasePath",
+	"DatabaseQueueSize",
+	"DatabaseWorkers",
+	"DebugPort",
+	"DelegatorInactivity",
+	"DelegatorInactivityEnabled",
+	"ForgeStaleGapThresholdSlots",
+	"ForgeSyncToleranceSlots",
+	"FullPotRewardsEnabled",
+	"GenesisBootstrap.CorroborationPeers",
+	"GenesisBootstrap.Enabled",
+	"GenesisBootstrap.PromotionMinDiversityGroups",
+	"GenesisBootstrap.WindowSlots",
+	"HistoryExpiry.Enabled",
+	"HistoryExpiry.Frequency",
+	"ImmutableDbPath",
+	"InactivityTimeout",
+	"InboundCooldown",
+	"InboundDuplexOnlyForHot",
+	"InboundHotQuota",
+	"InboundHotScoreThreshold",
+	"InboundMinTenure",
+	"InboundPruneAfter",
+	"InboundWarmTarget",
+	"IntersectTip",
+	"KoiosParity.AccountChunkMaxBytes",
+	"KoiosParity.AccountChunkSize",
+	"KoiosParity.Accounts",
+	"KoiosParity.CachePath",
+	"KoiosParity.Enabled",
+	"KoiosParity.GraceHours",
+	"KoiosParity.Network",
+	"KoiosParity.Strict",
+	"LedgerCatchupTimeout",
+	"LeiosVoteSigningKeyFile",
+	"LeiosVoterPublicKeys",
+	"Logging.Format",
+	"Logging.Level",
+	"MaxConnectionsPerIP",
+	"MaxInboundConns",
+	"MaxKESEvolutions",
+	"MetricsPort",
+	"Midnight.AuthTokenAssetName",
+	"Midnight.AuthTokenPolicyID",
+	"Midnight.CNightAssetName",
+	"Midnight.CNightPolicyID",
+	"Midnight.CommitteeCandidateAddress",
+	"Midnight.CouncilAddress",
+	"Midnight.CouncilPolicyID",
+	"Midnight.Enabled",
+	"Midnight.Host",
+	"Midnight.MappingValidatorAddress",
+	"Midnight.PermissionedCandidatePolicy",
+	"Midnight.Port",
+	"Midnight.TechnicalCommitteeAddress",
+	"Midnight.TechnicalCommitteePolicyID",
+	"MinHotPeers",
+	"MinPoolMargin",
+	"Mithril.AllowInsecureHTTP",
+	"Mithril.Backend",
+	"Mithril.CleanupAfterLoad",
+	"Mithril.DownloadDir",
+	"Mithril.DownloadIdleTimeout",
+	"Mithril.DownloadMaxIdleRetries",
+	"Mithril.Enabled",
+	"Mithril.VerifyCertificates",
+	"Network",
+	"NetworkMagic",
+	"OffchainMetadata.AllowPrivateAddresses",
+	"OffchainMetadata.BatchSize",
+	"OffchainMetadata.Interval",
+	"OffchainMetadata.MaxBytes",
+	"OffchainMetadata.RequestTimeout",
+	"OffchainMetadata.UserAgent",
+	"PeerSharing",
+	"PledgeLeverage",
+	"PledgeLeverageEnabled",
+	"Plugins.API.Blockfrost.Provider",
+	"Plugins.API.Mesh.Provider",
+	"Plugins.API.Utxorpc.Provider",
+	"Plugins.Mempool.Provider",
+	"Plugins.Storage.Blob.Provider",
+	"Plugins.Storage.Metadata.Provider",
+	"PrivateBindAddr",
+	"PrivatePort",
+	"ReconcileInterval",
+	"RelayPort",
+	"RunMode",
+	"ShelleyKESKey",
+	"ShelleyOperationalCertificate",
+	"ShelleyVRFKey",
+	"ShutdownTimeout",
+	"SlotsPerKESPeriod",
+	"SocketPath",
+	"StartEra",
+	"StorageMode",
+	"StrictUtxoValidation",
+	"TargetNumberOfActivePeers",
+	"TargetNumberOfEstablishedPeers",
+	"TargetNumberOfKnownPeers",
+	"TlsCertFilePath",
+	"TlsKeyFilePath",
+	"TokenRegistry.AllowPrivateAddresses",
+	"TokenRegistry.Enabled",
+	"TokenRegistry.Interval",
+	"TokenRegistry.MaxBytes",
+	"TokenRegistry.MaxEntryBytes",
+	"TokenRegistry.RequestTimeout",
+	"TokenRegistry.StoreLogos",
+	"TokenRegistry.UserAgent",
+	"Topology",
+	"Tracing",
+	"TracingStdout",
+	"UnsafeFullPotRewardsOnStandardNetworks",
+	"ValidateForgedBlock",
+	"ValidateHistorical",
+}
+
+// configLogClasses maps a dotted Config field path to its logClass. A path
+// absent from it resolves to logSecret; see logClass.
+var configLogClasses = sync.OnceValue(func() map[string]logClass {
+	classes := make(map[string]logClass)
+	for class, paths := range map[logClass][]string{
+		logPlain:          logPlainConfigFields,
+		logSecret:         logSecretConfigFields,
+		logURI:            logURIConfigFields,
+		logProviderConfig: logProviderConfigFields,
+	} {
+		for _, path := range paths {
+			classes[path] = class
+		}
+	}
+	return classes
+})
+
+// providerConfigKeyClasses classifies the keys a compiled-in plugin
+// provider accepts in its free-form configuration map. A key absent from it
+// resolves to logSecret, so an out-of-tree or newly added provider key is
+// redacted until it is classified here.
+var providerConfigKeyClasses = sync.OnceValue(func() map[string]logClass {
+	classes := make(map[string]logClass)
+	plain := []string{
+		// database/plugin/metadata/sqlite
+		"datadir", "maxconnections",
+		// database/plugin/metadata/{mysql,postgres}
+		"host", "port", "user", "database", "sslmode", "timezone",
+		"poolmaxopenconns", "poolmaxidleconns", "poolconnmaxlifetime",
+		// database/plugin/blob/{aws,gcs}
+		"bucket", "region", "prefix", "timeout",
+		// database/plugin/blob/badger
+		"blockcachesize", "indexcachesize", "valuelogfilesize",
+		"memtablesize", "valuethreshold", "gc", "compression",
+		"compressionlevel",
+		// mempool
+		"capacity", "evictionwatermark", "rejectionwatermark",
+		"revalidationdeltacap",
+		// api/{blockfrost,mesh,utxorpc} tls and auth policies
+		"mode", "certfilepath", "keyfilepath", "tokenfilepath",
+	}
+	uri := []string{"dsn", "endpoint", "url"}
+	secret := []string{"password", "token"}
+	for class, keys := range map[logClass][]string{
+		logPlain:  plain,
+		logURI:    uri,
+		logSecret: secret,
+	} {
+		for _, key := range keys {
+			classes[key] = class
+		}
+	}
+	return classes
+})
+
+// LogValue renders c for structured logging with every secret-bearing
+// value replaced by redactedPlaceholder, so `slog` never persists a Koios
+// API key, an inline API auth token, a provider password, or a DSN
+// credential. Unexported fields are not rendered at all.
+//
+// The walk is uniform and does not defer to a nested type's own
+// slog.LogValuer implementation: one classification table with one
+// exhaustiveness test is the only thing that decides what is logged, so a
+// nested LogValue cannot become a second, untested source of truth.
+func (c *Config) LogValue() slog.Value {
+	if c == nil {
+		return slog.StringValue("<nil>")
+	}
+	return slog.GroupValue(
+		configLogAttrs(reflect.ValueOf(c).Elem(), "")...,
+	)
+}
+
+// configLogAttrs renders the exported fields of struct value v, whose
+// dotted Config field path is prefix.
+func configLogAttrs(v reflect.Value, prefix string) []slog.Attr {
+	rt := v.Type()
+	attrs := make([]slog.Attr, 0, rt.NumField())
+	for i := range rt.NumField() {
+		field := rt.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		name := logFieldName(field)
+		path := prefix + field.Name
+		value := v.Field(i)
+		for value.Kind() == reflect.Pointer {
+			if value.IsNil() {
+				attrs = append(attrs, slog.Any(name, nil))
+				value = reflect.Value{}
+				break
+			}
+			value = value.Elem()
+		}
+		if !value.IsValid() {
+			continue
+		}
+		if value.Kind() == reflect.Struct {
+			attrs = append(attrs, slog.Attr{
+				Key: name,
+				Value: slog.GroupValue(
+					configLogAttrs(value, path+".")...,
+				),
+			})
+			continue
+		}
+		attrs = append(attrs, slog.Attr{
+			Key:   name,
+			Value: classedValue(value, configLogClasses()[path]),
+		})
+	}
+	return attrs
+}
+
+// logFieldName is the attribute key for a Config field: its yaml key when
+// it has one, matching what an operator writes in dingo.yaml, otherwise the
+// Go field name.
+func logFieldName(field reflect.StructField) string {
+	tag, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+	if tag == "" || tag == "-" {
+		return field.Name
+	}
+	return tag
+}
+
+// classedValue renders a non-struct configuration value according to class.
+func classedValue(v reflect.Value, class logClass) slog.Value {
+	switch class {
+	case logProviderConfig:
+		return providerConfigValue(v)
+	case logURI:
+		return mappedValue(v, redactURICredentials)
+	case logPlain:
+		return mappedValue(v, func(s string) string { return s })
+	case logSecret:
+		return redactedValue(v)
+	default:
+		return redactedValue(v)
+	}
+}
+
+// redactedValue replaces a secret-bearing value with redactedPlaceholder. A
+// zero value is rendered as itself: "the token is unset" is what an
+// operator needs to see, and it discloses nothing.
+func redactedValue(v reflect.Value) slog.Value {
+	if v.IsZero() {
+		return slog.AnyValue(v.Interface())
+	}
+	return slog.StringValue(redactedPlaceholder)
+}
+
+// mappedValue renders v, applying transform to every string it contains so
+// a slice or map of URIs is handled element by element rather than as one
+// opaque value.
+func mappedValue(v reflect.Value, transform func(string) string) slog.Value {
+	switch v.Kind() { //nolint:exhaustive // reflect.Kind default is intended
+	case reflect.String:
+		return slog.StringValue(transform(v.String()))
+	case reflect.Slice, reflect.Array:
+		items := make([]string, 0, v.Len())
+		for i := range v.Len() {
+			item := v.Index(i)
+			if item.Kind() != reflect.String {
+				return slog.AnyValue(v.Interface())
+			}
+			items = append(items, transform(item.String()))
+		}
+		return slog.AnyValue(items)
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String ||
+			v.Type().Elem().Kind() != reflect.String {
+			return slog.AnyValue(v.Interface())
+		}
+		attrs := make([]slog.Attr, 0, v.Len())
+		for _, key := range sortedStringKeys(v) {
+			attrs = append(attrs, slog.String(
+				key,
+				transform(v.MapIndex(reflect.ValueOf(key)).String()),
+			))
+		}
+		return slog.GroupValue(attrs...)
+	default:
+		return slog.AnyValue(v.Interface())
+	}
+}
+
+// providerConfigValue renders a plugin provider's free-form configuration
+// map, classifying each key by name and recursing into nested maps so a
+// secret nested under any depth of provider sections is still redacted.
+func providerConfigValue(v reflect.Value) slog.Value {
+	if v.Kind() != reflect.Map || v.Type().Key().Kind() != reflect.String {
+		return slog.StringValue(redactedPlaceholder)
+	}
+	attrs := make([]slog.Attr, 0, v.Len())
+	for _, key := range sortedStringKeys(v) {
+		entry := unwrapInterface(v.MapIndex(reflect.ValueOf(key)))
+		class := providerConfigKeyClasses()[strings.ToLower(key)]
+		attrs = append(attrs, slog.Attr{
+			Key:   key,
+			Value: providerConfigEntry(entry, class),
+		})
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// providerConfigEntry renders one provider configuration entry. A nested
+// map is recursed into so its own keys are classified by name; anything
+// else is rendered according to its key's class.
+func providerConfigEntry(v reflect.Value, class logClass) slog.Value {
+	if !v.IsValid() {
+		return slog.AnyValue(nil)
+	}
+	if v.Kind() == reflect.Map && v.Type().Key().Kind() == reflect.String {
+		return providerConfigValue(v)
+	}
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		items := make([]any, 0, v.Len())
+		for i := range v.Len() {
+			item := providerConfigEntry(
+				unwrapInterface(v.Index(i)),
+				class,
+			)
+			items = append(items, item.Any())
+		}
+		return slog.AnyValue(items)
+	}
+	return classedValue(v, class)
+}
+
+// unwrapInterface resolves an interface-typed reflect.Value to the value it
+// holds, which is what a map[string]any's entries always are.
+func unwrapInterface(v reflect.Value) reflect.Value {
+	for v.IsValid() && v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return reflect.Value{}
+		}
+		v = v.Elem()
+	}
+	for v.IsValid() && v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return reflect.Value{}
+		}
+		v = v.Elem()
+	}
+	return v
+}
+
+// sortedStringKeys returns v's string keys in sorted order, so a rendered
+// map is stable across log lines.
+func sortedStringKeys(v reflect.Value) []string {
+	keys := make([]string, 0, v.Len())
+	for _, key := range v.MapKeys() {
+		keys = append(keys, key.String())
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// uriCredentialParam matches a credential-shaped parameter in a URI query
+// string or in a keyword-form database DSN
+// ("host=db user=dingo password=hunter2").
+var uriCredentialParam = regexp.MustCompile(
+	`(?i)\b(password|passwd|pwd|secret|token|api[-_]?key|` +
+		`access[-_]?key|secret[-_]?key|sig|signature)\s*=\s*[^\s;&]*`,
+)
+
+// redactURICredentials removes the credential components of a URI or
+// database DSN -- the userinfo password and any credential-shaped
+// parameter -- while keeping scheme, host, port, path, database name, and
+// every other parameter. A DSN redacted whole loses the operational value
+// of knowing which host and database the node was pointed at, which is
+// most of the reason the configuration is logged at all.
+func redactURICredentials(s string) string {
+	if s == "" {
+		return s
+	}
+	s = uriCredentialParam.ReplaceAllString(
+		s,
+		"${1}="+redactedPlaceholder,
+	)
+	return redactURIUserinfo(s)
+}
+
+// redactURIUserinfo replaces the password half of a "user:password@"
+// userinfo component. It handles both "scheme://user:password@host/path"
+// and the schemeless MySQL DSN form "user:password@tcp(host:3306)/db".
+func redactURIUserinfo(s string) string {
+	start := 0
+	if i := strings.Index(s, "://"); i >= 0 {
+		start = i + len("://")
+	}
+	end := len(s)
+	if i := strings.IndexAny(s[start:], "/?#"); i >= 0 {
+		end = start + i
+	}
+	at := strings.LastIndex(s[start:end], "@")
+	if at < 0 {
+		return s
+	}
+	userinfo := s[start : start+at]
+	colon := strings.Index(userinfo, ":")
+	if colon < 0 {
+		// A username with no password is not a credential.
+		return s
+	}
+	return s[:start+colon+1] + redactedPlaceholder + s[start+at:]
+}

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -16,8 +16,8 @@ package config
 
 import (
 	"log/slog"
+	"net/url"
 	"reflect"
-	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -263,36 +263,52 @@ var configLogClasses = sync.OnceValue(func() map[string]logClass {
 	return classes
 })
 
+// providerConfigPlainKeys are the lower-cased keys a compiled-in plugin
+// provider accepts in its free-form configuration map that carry no
+// secret. "auth" and "tls" are the nested sections of the API providers:
+// they are containers, so classifying them plain is what lets the walk
+// recurse and classify the keys inside them by name.
+var providerConfigPlainKeys = []string{
+	// database/plugin/metadata/sqlite
+	"datadir", "maxconnections",
+	// database/plugin/metadata/{mysql,postgres}
+	"host", "port", "user", "database", "sslmode", "timezone",
+	"poolmaxopenconns", "poolmaxidleconns", "poolconnmaxlifetime",
+	// database/plugin/blob/{aws,gcs}
+	"bucket", "region", "prefix", "timeout",
+	// database/plugin/blob/badger
+	"blockcachesize", "indexcachesize", "valuelogfilesize",
+	"memtablesize", "valuethreshold", "gc", "compression",
+	"compressionlevel",
+	// mempool
+	"capacity", "evictionwatermark", "rejectionwatermark",
+	"revalidationdeltacap",
+	// api/{blockfrost,mesh,utxorpc} tls and auth sections and the
+	// policy keys inside them
+	"auth", "tls",
+	"mode", "certfilepath", "keyfilepath", "tokenfilepath",
+}
+
+// providerConfigURIKeys are provider configuration keys holding a URI or
+// database DSN, rendered with only their credential components removed.
+var providerConfigURIKeys = []string{"dsn", "endpoint", "url"}
+
+// providerConfigSecretKeys are provider configuration keys whose value is
+// a secret in itself. isCredentialKeyName reaches the same verdict for
+// each of them, and TestProviderConfigKeyTableAgreesWithClassifier holds
+// the two together.
+var providerConfigSecretKeys = []string{"password", "token"}
+
 // providerConfigKeyClasses classifies the keys a compiled-in plugin
 // provider accepts in its free-form configuration map. A key absent from it
 // resolves to logSecret, so an out-of-tree or newly added provider key is
 // redacted until it is classified here.
 var providerConfigKeyClasses = sync.OnceValue(func() map[string]logClass {
 	classes := make(map[string]logClass)
-	plain := []string{
-		// database/plugin/metadata/sqlite
-		"datadir", "maxconnections",
-		// database/plugin/metadata/{mysql,postgres}
-		"host", "port", "user", "database", "sslmode", "timezone",
-		"poolmaxopenconns", "poolmaxidleconns", "poolconnmaxlifetime",
-		// database/plugin/blob/{aws,gcs}
-		"bucket", "region", "prefix", "timeout",
-		// database/plugin/blob/badger
-		"blockcachesize", "indexcachesize", "valuelogfilesize",
-		"memtablesize", "valuethreshold", "gc", "compression",
-		"compressionlevel",
-		// mempool
-		"capacity", "evictionwatermark", "rejectionwatermark",
-		"revalidationdeltacap",
-		// api/{blockfrost,mesh,utxorpc} tls and auth policies
-		"mode", "certfilepath", "keyfilepath", "tokenfilepath",
-	}
-	uri := []string{"dsn", "endpoint", "url"}
-	secret := []string{"password", "token"}
 	for class, keys := range map[logClass][]string{
-		logPlain:  plain,
-		logURI:    uri,
-		logSecret: secret,
+		logPlain:  providerConfigPlainKeys,
+		logURI:    providerConfigURIKeys,
+		logSecret: providerConfigSecretKeys,
 	} {
 		for _, key := range keys {
 			classes[key] = class
@@ -300,6 +316,19 @@ var providerConfigKeyClasses = sync.OnceValue(func() map[string]logClass {
 	}
 	return classes
 })
+
+// providerConfigKeyClass classifies one key of a provider configuration
+// map. isCredentialKeyName decides first, so a credential-shaped key can
+// never be rendered even if it were added to providerConfigPlainKeys by
+// mistake; the provider key set is open-world, which is why this path
+// carries a name-shape guard while the exhaustively enumerated Config
+// field paths do not.
+func providerConfigKeyClass(key string) logClass {
+	if isCredentialKeyName(key) {
+		return logSecret
+	}
+	return providerConfigKeyClasses()[strings.ToLower(key)]
+}
 
 // LogValue renders c for structured logging with every secret-bearing
 // value replaced by redactedPlaceholder, so `slog` never persists a Koios
@@ -442,7 +471,7 @@ func providerConfigValue(v reflect.Value) slog.Value {
 	attrs := make([]slog.Attr, 0, v.Len())
 	for _, key := range sortedStringKeys(v) {
 		entry := unwrapInterface(v.MapIndex(reflect.ValueOf(key)))
-		class := providerConfigKeyClasses()[strings.ToLower(key)]
+		class := providerConfigKeyClass(key)
 		attrs = append(attrs, slog.Attr{
 			Key:   key,
 			Value: providerConfigEntry(entry, class),
@@ -452,11 +481,21 @@ func providerConfigValue(v reflect.Value) slog.Value {
 }
 
 // providerConfigEntry renders one provider configuration entry. A nested
-// map is recursed into so its own keys are classified by name; anything
-// else is rendered according to its key's class.
+// map or slice under a non-secret key is walked so its own keys are
+// classified by name; anything else is rendered according to its key's
+// class.
+//
+// A logSecret class -- which is also the class of an unrecognized key --
+// covers the whole subtree and is applied before any recursion. Walking
+// into it would reclassify the inner keys by their own names, and an
+// inner key that happens to be classified plain ("host", "mode") would
+// then render part of a value whose enclosing key is a secret.
 func providerConfigEntry(v reflect.Value, class logClass) slog.Value {
 	if !v.IsValid() {
 		return slog.AnyValue(nil)
+	}
+	if class == logSecret {
+		return redactedValue(v)
 	}
 	if v.Kind() == reflect.Map && v.Type().Key().Kind() == reflect.String {
 		return providerConfigValue(v)
@@ -504,29 +543,170 @@ func sortedStringKeys(v reflect.Value) []string {
 	return keys
 }
 
-// uriCredentialParam matches a credential-shaped parameter in a URI query
-// string or in a keyword-form database DSN
-// ("host=db user=dingo password=hunter2").
-var uriCredentialParam = regexp.MustCompile(
-	`(?i)\b(password|passwd|pwd|secret|token|api[-_]?key|` +
-		`access[-_]?key|secret[-_]?key|sig|signature)\s*=\s*[^\s;&]*`,
-)
-
 // redactURICredentials removes the credential components of a URI or
-// database DSN -- the userinfo password and any credential-shaped
-// parameter -- while keeping scheme, host, port, path, database name, and
-// every other parameter. A DSN redacted whole loses the operational value
-// of knowing which host and database the node was pointed at, which is
-// most of the reason the configuration is logged at all.
+// database DSN -- the userinfo password and the value of every
+// credential-named parameter -- while keeping scheme, host, port, path,
+// database name, and every other parameter. A DSN redacted whole loses the
+// operational value of knowing which host and database the node was
+// pointed at, which is most of the reason the configuration is logged at
+// all.
 func redactURICredentials(s string) string {
 	if s == "" {
 		return s
 	}
-	s = uriCredentialParam.ReplaceAllString(
-		s,
-		"${1}="+redactedPlaceholder,
-	)
-	return redactURIUserinfo(s)
+	return redactURIUserinfo(redactCredentialParams(s))
+}
+
+// redactCredentialParams redacts the value of every credential-named
+// "name=value" parameter in s. The decision is made per parameter name
+// through isCredentialKeyName, not by matching credential shapes against
+// the whole string.
+//
+// A URI's parameters live in its query string, where net/url decides
+// where the query begins and '&' or ';' separates the pairs. A
+// keyword-form database DSN ("host=db user=dingo password='hunter 2'")
+// has no query string: its pairs are whitespace separated, whitespace
+// around '=' is optional, and a value containing whitespace is quoted.
+func redactCredentialParams(s string) string {
+	if start, end, ok := uriQuerySpan(s); ok {
+		return s[:start] + redactParams(s[start:end], "&;") + s[end:]
+	}
+	return redactParams(s, " \t\r\n")
+}
+
+// uriQuerySpan returns the bounds of s's URI query string, if it has one.
+// net/url does the parsing, so a keyword DSN -- which is not a URI -- does
+// not get its whitespace-separated keywords treated as query parameters.
+// The span is verified against RawQuery before it is used, so a URI whose
+// '?' net/url located differently is left to the keyword scanner instead
+// of being spliced at the wrong offset.
+func uriQuerySpan(s string) (int, int, bool) {
+	parsed, err := url.Parse(s)
+	if err != nil || parsed.RawQuery == "" {
+		return 0, 0, false
+	}
+	mark := strings.IndexByte(s, '?')
+	if mark < 0 {
+		return 0, 0, false
+	}
+	start := mark + 1
+	end := start + len(parsed.RawQuery)
+	if end > len(s) || s[start:end] != parsed.RawQuery {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// redactParams replaces the value of every credential-named parameter in
+// s, whose parameters are separated by any byte in delims. Separators,
+// ordering, quoting, and every non-credential value are copied through
+// byte for byte, because a redacted DSN is only useful if the host,
+// database, and options it names survive.
+func redactParams(s, delims string) string {
+	var out strings.Builder
+	out.Grow(len(s))
+	for i := 0; i < len(s); {
+		skipped := i
+		for i < len(s) && !isKeyNameByte(s[i]) {
+			i++
+		}
+		out.WriteString(s[skipped:i])
+		nameEnd := i
+		for nameEnd < len(s) && isKeyNameByte(s[nameEnd]) {
+			nameEnd++
+		}
+		name := s[i:nameEnd]
+		if name == "" {
+			// i is at the end of s; the loop condition ends the walk.
+			continue
+		}
+		out.WriteString(name)
+		i = nameEnd
+		valueStart, ok := paramValueStart(s, nameEnd)
+		if !ok {
+			continue
+		}
+		valueEnd := paramValueEnd(s, valueStart, delims)
+		if valueEnd > valueStart && isCredentialKeyName(name) {
+			out.WriteString(s[nameEnd:valueStart])
+			out.WriteString(redactedPlaceholder)
+		} else {
+			out.WriteString(s[nameEnd:valueEnd])
+		}
+		i = valueEnd
+	}
+	return out.String()
+}
+
+// paramValueStart returns the index at which the value of the parameter
+// whose name ends at nameEnd begins, and whether the parameter has a
+// value at all.
+//
+// The keyword DSN form permits whitespace on both sides of '='. Trailing
+// whitespace followed by another "name=" pair instead means this
+// parameter's value is empty; consuming the next pair as the value would
+// hide a non-credential option behind the placeholder.
+func paramValueStart(s string, nameEnd int) (int, bool) {
+	i := skipParamSpace(s, nameEnd)
+	if i >= len(s) || s[i] != '=' {
+		return 0, false
+	}
+	i++
+	if spaced := skipParamSpace(s, i); spaced != i &&
+		!startsParam(s, spaced) {
+		i = spaced
+	}
+	return i, true
+}
+
+// paramValueEnd returns the index one past the value beginning at i. A
+// quoted value ends at its closing quote, so a keyword DSN password
+// containing whitespace is redacted whole rather than up to its first
+// space; an unquoted value ends at the first byte in delims.
+func paramValueEnd(s string, i int, delims string) int {
+	if i < len(s) && (s[i] == '\'' || s[i] == '"') {
+		quote := s[i]
+		for j := i + 1; j < len(s); {
+			switch s[j] {
+			case '\\':
+				j += 2
+			case quote:
+				return j + 1
+			default:
+				j++
+			}
+		}
+		return len(s)
+	}
+	for ; i < len(s); i++ {
+		if strings.IndexByte(delims, s[i]) >= 0 {
+			return i
+		}
+	}
+	return len(s)
+}
+
+// startsParam reports whether a new "name=" pair begins at i.
+func startsParam(s string, i int) bool {
+	end := i
+	for end < len(s) && isKeyNameByte(s[end]) {
+		end++
+	}
+	if end == i {
+		return false
+	}
+	end = skipParamSpace(s, end)
+	return end < len(s) && s[end] == '='
+}
+
+// skipParamSpace returns the index of the first byte at or after i that is
+// not whitespace.
+func skipParamSpace(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' ||
+		s[i] == '\r' || s[i] == '\n') {
+		i++
+	}
+	return i
 }
 
 // redactURIUserinfo replaces the password half of a "user:password@"
@@ -553,3 +733,216 @@ func redactURIUserinfo(s string) string {
 	}
 	return s[:start+colon+1] + redactedPlaceholder + s[start+at:]
 }
+
+// A key name is classified per whole word, never per substring. A
+// \b-anchored regular expression over the raw name is the wrong shape for
+// this job twice over: '_' is a word character, so `\bsecret` cannot match
+// "client_secret" and `\btoken` cannot match "api_token"; and
+// `access[-_]?key` cannot reach the '=' of "accessKeyId=" past the "Id"
+// suffix. Both misses leak. Enumerating spellings instead --
+// accessKeyId, client_secret, api_token, x-api-key, authToken,
+// refreshToken, privateKey, sasToken, SharedAccessSignature -- only moves
+// the next miss one spelling further out.
+//
+// So a name is decomposed into words first: at separators
+// ("client_secret", "x-api-key", "auth.token"), at camelCase and acronym
+// boundaries ("accessKeyId", "IPFSGatewayURL"), and, for a run-together
+// spelling such as "apikey" or "accesskeyid", by segmenting the word
+// against the vocabulary below -- which succeeds only when known words
+// cover the word completely, so "monkey" and "keyspace" do not become
+// credentials. The decision is then set membership over those words, and
+// no prefix, suffix, or separator can move a term out of reach.
+
+// credentialWords name a credential themselves: one of them anywhere in a
+// key name means the value is a credential.
+var credentialWords = []string{
+	"credential", "credentials",
+	"pass", "passphrase", "passwd", "password", "passwords", "pwd",
+	// Azure shared access signature, spelled "sas" in its key names.
+	"sas",
+	"secret", "secrets",
+	"sig", "signature", "signatures",
+	"token", "tokens",
+}
+
+// keyWords name a key, which is a credential only when a qualifier says
+// which key it is: "privateKey" and "accessKeyId" are credentials,
+// "publicKeys" and "shelleyVrfKey" are not.
+var keyWords = []string{"key", "keys"}
+
+// credentialQualifierWords turn an accompanying key word into a
+// credential.
+var credentialQualifierWords = []string{
+	"access", "account", "api", "app", "application", "auth", "bearer",
+	"client", "consumer", "encryption", "master", "private", "refresh",
+	"secret", "service", "session", "shared", "sign", "signing",
+	"subscription",
+}
+
+// locationWords name where a credential is kept rather than the
+// credential itself: "tokenFilePath", "signingKeyFile", and "dataDir"
+// hold a path, and which path was configured is exactly what an operator
+// needs from a startup log. A name containing one of these is therefore
+// not a credential. The trade is that a secret written inline under a
+// "...File" name would be rendered; the alternative redacts every
+// configured path, including the ones this logging exists to show.
+var locationWords = []string{
+	"dir", "directory", "file", "folder", "path",
+}
+
+// keyNameFillerWords carry no classification of their own. They exist so
+// that a run-together spelling segments: "accesskeyid" is access+key+id.
+var keyNameFillerWords = []string{"id", "ids", "name", "names"}
+
+// keyNameVocabulary is every word the classifier knows, used to segment a
+// run-together key name.
+var keyNameVocabulary = sync.OnceValue(func() []string {
+	var vocabulary []string
+	for _, words := range [][]string{
+		credentialWords,
+		credentialQualifierWords,
+		keyNameFillerWords,
+		keyWords,
+		locationWords,
+	} {
+		vocabulary = append(vocabulary, words...)
+	}
+	slices.Sort(vocabulary)
+	return slices.Compact(vocabulary)
+})
+
+// isCredentialKeyName reports whether a value stored under the
+// configuration key or URI parameter name is a credential.
+func isCredentialKeyName(name string) bool {
+	words := keyNameWords(name)
+	switch {
+	case containsWord(words, locationWords):
+		return false
+	case containsWord(words, credentialWords):
+		return true
+	default:
+		return containsWord(words, keyWords) &&
+			containsWord(words, credentialQualifierWords)
+	}
+}
+
+// containsWord reports whether any of words appears in set.
+func containsWord(words, set []string) bool {
+	return slices.ContainsFunc(words, func(word string) bool {
+		return slices.Contains(set, word)
+	})
+}
+
+// keyNameWords is name split into lower-cased words, each then segmented
+// against the vocabulary.
+func keyNameWords(name string) []string {
+	parts := splitKeyName(name)
+	words := make([]string, 0, len(parts))
+	for _, part := range parts {
+		words = append(words, segmentKeyWord(part)...)
+	}
+	return words
+}
+
+// splitKeyName splits name into lower-cased words at every
+// non-alphanumeric byte and at every camelCase or acronym boundary, so
+// "accessKeyId", "access_key_id", "access-key-id", "ACCESS_KEY_ID", and
+// "access.key.id" all yield access, key, id.
+func splitKeyName(name string) []string {
+	var words []string
+	start := -1
+	for i := range len(name) {
+		if !isKeyWordByte(name[i]) {
+			if start >= 0 {
+				words = append(words, strings.ToLower(name[start:i]))
+				start = -1
+			}
+			continue
+		}
+		if start < 0 {
+			start = i
+			continue
+		}
+		if isKeyWordBoundary(name, i) {
+			words = append(words, strings.ToLower(name[start:i]))
+			start = i
+		}
+	}
+	if start >= 0 {
+		words = append(words, strings.ToLower(name[start:]))
+	}
+	return words
+}
+
+// isKeyWordBoundary reports whether the byte at i starts a new camelCase
+// or acronym word: an upper-case byte following a lower-case byte or a
+// digit ("accessKey", "sha256Key"), or the last upper-case byte of an
+// acronym run when a lower-case byte follows it ("APIKey" is api, key).
+func isKeyWordBoundary(name string, i int) bool {
+	if !isUpperByte(name[i]) {
+		return false
+	}
+	prev := name[i-1]
+	if isLowerByte(prev) || isDigitByte(prev) {
+		return true
+	}
+	return isUpperByte(prev) && i+1 < len(name) && isLowerByte(name[i+1])
+}
+
+// segmentKeyWord splits a run-together word into vocabulary words, and
+// only when those words cover it completely: "apikey" is api+key, while
+// "monkey", "keyspace", and "sslmode" do not segment and stay whole.
+// Requiring full coverage is what keeps a benign name from classifying on
+// an embedded substring.
+func segmentKeyWord(word string) []string {
+	if word == "" {
+		return nil
+	}
+	vocabulary := keyNameVocabulary()
+	if slices.Contains(vocabulary, word) {
+		return []string{word}
+	}
+	reachable := make([]bool, len(word)+1)
+	from := make([]int, len(word)+1)
+	reachable[0] = true
+	for end := 1; end <= len(word); end++ {
+		for start := range end {
+			if !reachable[start] {
+				continue
+			}
+			if slices.Contains(vocabulary, word[start:end]) {
+				reachable[end] = true
+				from[end] = start
+				break
+			}
+		}
+	}
+	if !reachable[len(word)] {
+		return []string{word}
+	}
+	var words []string
+	for end := len(word); end > 0; end = from[end] {
+		words = append(words, word[from[end]:end])
+	}
+	slices.Reverse(words)
+	return words
+}
+
+// isKeyNameByte reports whether b can appear in a configuration key or
+// URI parameter name: a word byte, or one of the separators an operator
+// spells a multi-word name with.
+func isKeyNameByte(b byte) bool {
+	return b == '-' || b == '.' || b == '_' || isKeyWordByte(b)
+}
+
+// isKeyWordByte reports whether b belongs to a single word within a key
+// name. Every other byte, including any non-ASCII byte, separates words.
+func isKeyWordByte(b byte) bool {
+	return isDigitByte(b) || isLowerByte(b) || isUpperByte(b)
+}
+
+func isDigitByte(b byte) bool { return b >= '0' && b <= '9' }
+
+func isLowerByte(b byte) bool { return b >= 'a' && b <= 'z' }
+
+func isUpperByte(b byte) bool { return b >= 'A' && b <= 'Z' }

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -135,6 +135,7 @@ var sentinelSecrets = []string{
 	// access[-_]?key pattern cannot reach past the "Id" suffix.
 	"AKIAEXAMPLE",
 	"SENTINEL-NESTED-AUTH-SECRET",
+	"SENTINEL-SCALAR-AUTH-SECTION",
 }
 
 // sentinelSecretConfig plants a sentinel in every secret-bearing field and
@@ -226,6 +227,15 @@ func sentinelSecretConfig() *Config {
 									"PROVIDER-SECRET",
 							},
 						},
+					},
+				},
+				Utxorpc: hostplugin.Selection{
+					Provider: "utxorpc",
+					Config: map[string]any{
+						"port": 9090,
+						// A scalar under a container key is not a
+						// policy this walk can classify key by key.
+						"auth": "SENTINEL-SCALAR-AUTH-SECTION",
 					},
 				},
 				Mesh: hostplugin.Selection{
@@ -394,6 +404,31 @@ func TestRedactURICredentials(t *testing.T) {
 				redactedPlaceholder + "&prefix=dingo",
 		},
 		{
+			name: "percent encoded credential parameter name",
+			in: "https://api.example/v1?api%5Fkey=abc123" +
+				"&page%5Fsize=50",
+			want: "https://api.example/v1?api%5Fkey=" +
+				redactedPlaceholder + "&page%5Fsize=50",
+		},
+		{
+			name: "plus encoded credential parameter name",
+			in:   "https://api.example/v1?api+key=abc123&page=2",
+			want: "https://api.example/v1?api+key=" +
+				redactedPlaceholder + "&page=2",
+		},
+		{
+			name: "undecodable parameter name fails closed",
+			in:   "https://api.example/v1?api%5key=abc123&page=2",
+			want: "https://api.example/v1?api%5key=" +
+				redactedPlaceholder + "&page=2",
+		},
+		{
+			name: "keyword dsn password with an escape in it",
+			in:   "host=db.example password=hunter%202 dbname=dingo",
+			want: "host=db.example password=" + redactedPlaceholder +
+				" dbname=dingo",
+		},
+		{
 			name: "kebab case credential header parameter",
 			in:   "https://api.example/v1?x-api-key=abc123&page=2",
 			want: "https://api.example/v1?x-api-key=" +
@@ -529,6 +564,19 @@ var credentialKeyNameSpellings = map[string]bool{
 	"apitoken":     true,
 	"accesskeyid":  true,
 	"clientsecret": true,
+	// percent- and plus-encoded, the spellings a URI query carries a
+	// parameter name in. The classifier decodes a name before it splits
+	// it, so an encoding cannot move a term out of reach.
+	"api%5Fkey":       true,
+	"api%5fkey":       true,
+	"api+key":         true,
+	"client%2Dsecret": true,
+	"page%5Fsize":     false,
+	// An escape that does not decode leaves the name unreadable, here
+	// and in whatever would consume it, so it is treated as a
+	// credential rather than rendered.
+	"api%5key": true,
+	"100%pure": true,
 	// bare terms
 	"password":  true,
 	"passwd":    true,
@@ -649,6 +697,7 @@ func TestProviderConfigKeyTableAgreesWithClassifier(t *testing.T) {
 
 	for _, key := range slices.Concat(
 		providerConfigPlainKeys,
+		providerConfigSectionKeys,
 		providerConfigURIKeys,
 	) {
 		if isCredentialKeyName(key) {
@@ -816,5 +865,126 @@ func TestProviderConfigNestedSectionsAreWalked(t *testing.T) {
 				rendered,
 			)
 		}
+	}
+}
+
+// TestProviderConfigKeyClassesAreUnambiguous catches a provider key listed
+// under two classes, where the effective class would depend on map
+// iteration order.
+func TestProviderConfigKeyClassesAreUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]int)
+	for _, keys := range [][]string{
+		providerConfigPlainKeys,
+		providerConfigSectionKeys,
+		providerConfigURIKeys,
+		providerConfigSecretKeys,
+	} {
+		for _, key := range keys {
+			seen[key]++
+		}
+	}
+	for key, count := range seen {
+		if count > 1 {
+			t.Errorf("provider key %q is classified %d times", key, count)
+		}
+	}
+}
+
+// TestProviderConfigSectionKeyRequiresASection is the value-shape
+// counterpart to classifying "auth" and "tls" as containers. Those keys
+// name a nested section, so a section is walked and classified key by key
+// while a value of any other shape at the same key is not a policy this
+// walk can classify at all and is redacted whole. Classifying them
+// renderable instead rendered a scalar there as plain text.
+func TestProviderConfigSectionKeyRequiresASection(t *testing.T) {
+	t.Parallel()
+
+	shapes := map[string]any{
+		"scalar": "SENTINEL-SECTION-SCALAR",
+		"slice":  []any{"SENTINEL-SECTION-SLICE"},
+		"sliceOfMaps": []any{
+			map[string]any{"mode": "SENTINEL-SECTION-SLICE-MAP"},
+		},
+		"nonStringKeyedMap": map[int]any{
+			1: "SENTINEL-SECTION-INT-MAP",
+		},
+	}
+	for _, key := range providerConfigSectionKeys {
+		for shape, value := range shapes {
+			t.Run(key+"/"+shape, func(t *testing.T) {
+				t.Parallel()
+
+				rendered := providerConfigValue(reflect.ValueOf(
+					map[string]any{key: value},
+				)).String()
+				if strings.Contains(rendered, "SENTINEL-SECTION") {
+					t.Errorf(
+						"provider key %q renders a %s value: %s",
+						key,
+						shape,
+						rendered,
+					)
+				}
+				if !strings.Contains(rendered, redactedPlaceholder) {
+					t.Errorf(
+						"provider key %q with a %s value is not "+
+							"redacted: %s",
+						key,
+						shape,
+						rendered,
+					)
+				}
+			})
+		}
+	}
+}
+
+// TestProviderConfigSectionKeyNilValue pins that an explicitly empty
+// section renders as itself. A nil discloses nothing, and "auth: " with
+// nothing under it is what an operator needs to see about their file.
+func TestProviderConfigSectionKeyNilValue(t *testing.T) {
+	t.Parallel()
+
+	rendered := providerConfigValue(reflect.ValueOf(
+		map[string]any{"auth": nil},
+	)).String()
+	if !strings.Contains(rendered, "<nil>") {
+		t.Errorf("nil section is not rendered as nil: %s", rendered)
+	}
+}
+
+// TestClassedValueURIShapeFailsClosed covers the same value-shape
+// dimension for a URI-classified value. Only a shape holding strings can
+// have its credentials removed; any other shape cannot be transformed at
+// all, so it is redacted instead of rendered untransformed.
+func TestClassedValueURIShapeFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dsn := "postgres://dingo:SENTINEL-SHAPE-PASSWORD@db.example/dingo"
+	shapes := map[string]any{
+		"sliceOfAny":  []any{dsn},
+		"mapOfAny":    map[string]any{"primary": dsn},
+		"mapOfNonStr": map[string][]string{"primary": {dsn}},
+	}
+	for shape, value := range shapes {
+		t.Run(shape, func(t *testing.T) {
+			t.Parallel()
+
+			rendered := classedValue(
+				reflect.ValueOf(value),
+				logURI,
+			).String()
+			if strings.Contains(rendered, "SENTINEL-SHAPE-PASSWORD") {
+				t.Errorf("URI %s leaks its credential: %s", shape, rendered)
+			}
+			// The same shape under a plain classification is rendered:
+			// failing closed is the URI rule, not a blanket one.
+			plain := classedValue(reflect.ValueOf(value), logPlain).String()
+			if !strings.Contains(plain, "db.example") {
+				t.Errorf("plain %s dropped its value: %s", shape, plain)
+			}
+		})
 	}
 }

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -130,6 +130,11 @@ var sentinelSecrets = []string{
 	"SENTINEL-BLOCKFROST-TOKEN",
 	"SENTINEL-NESTED-PROVIDER-SECRET",
 	"SENTINEL-MEMPOOL-LIST-SECRET",
+	// An AWS access key ID is half of a credential pair, and
+	// "accessKeyId" is exactly the spelling a left-anchored
+	// access[-_]?key pattern cannot reach past the "Id" suffix.
+	"AKIAEXAMPLE",
+	"SENTINEL-NESTED-AUTH-SECRET",
 }
 
 // sentinelSecretConfig plants a sentinel in every secret-bearing field and
@@ -209,8 +214,11 @@ func sentinelSecretConfig() *Config {
 					Config: map[string]any{
 						"port": 3000,
 						"auth": map[string]any{
-							"mode":  "token",
-							"token": "SENTINEL-BLOCKFROST-TOKEN",
+							"mode": "token",
+							"token": map[string]any{
+								"host":  "SENTINEL-NESTED-AUTH-SECRET",
+								"value": "SENTINEL-BLOCKFROST-TOKEN",
+							},
 						},
 						"futureSection": map[string]any{
 							"deeper": map[string]any{
@@ -277,7 +285,6 @@ func TestConfigLogValueRedactsSentinelSecrets(t *testing.T) {
 				"blocks.example",
 				"plain.example",
 				"snapshots/dingo",
-				"AKIAEXAMPLE",
 				"mesh.example:3306",
 				"1024",
 			} {
@@ -347,6 +354,68 @@ func TestRedactURICredentials(t *testing.T) {
 				redactedPlaceholder + "&network=preview",
 		},
 		{
+			name: "quoted keyword dsn password containing whitespace",
+			in: "host=db.example password='hunter 2 three' " +
+				"dbname=dingo",
+			want: "host=db.example password=" + redactedPlaceholder +
+				" dbname=dingo",
+		},
+		{
+			name: "double quoted keyword dsn password",
+			in:   `host=db.example password="hunter 2" dbname=dingo`,
+			want: "host=db.example password=" + redactedPlaceholder +
+				" dbname=dingo",
+		},
+		{
+			name: "keyword dsn with whitespace around equals",
+			in:   "host=db.example password = hunter2 dbname=dingo",
+			want: "host=db.example password = " +
+				redactedPlaceholder + " dbname=dingo",
+		},
+		{
+			name: "empty keyword value does not consume the next pair",
+			in:   "password= dbname=dingo",
+			want: "password= dbname=dingo",
+		},
+		{
+			name: "prefixed credential query parameters",
+			in: "https://idp.example/token?client_secret=hunter2" +
+				"&api_token=abc123&network=preview",
+			want: "https://idp.example/token?client_secret=" +
+				redactedPlaceholder + "&api_token=" +
+				redactedPlaceholder + "&network=preview",
+		},
+		{
+			name: "suffixed credential query parameter",
+			in: "s3://snapshots/dingo?accessKeyId=AKIAEXAMPLE" +
+				"&secretKey=hunter2&prefix=dingo",
+			want: "s3://snapshots/dingo?accessKeyId=" +
+				redactedPlaceholder + "&secretKey=" +
+				redactedPlaceholder + "&prefix=dingo",
+		},
+		{
+			name: "kebab case credential header parameter",
+			in:   "https://api.example/v1?x-api-key=abc123&page=2",
+			want: "https://api.example/v1?x-api-key=" +
+				redactedPlaceholder + "&page=2",
+		},
+		{
+			name: "semicolon separated query parameters",
+			in:   "https://api.example/v1?apiToken=abc123;page=2",
+			want: "https://api.example/v1?apiToken=" +
+				redactedPlaceholder + ";page=2",
+		},
+		{
+			name: "a parameter naming a file is a path not a credential",
+			in:   "https://api.example/v1?tokenFilePath=/etc/dingo/t",
+			want: "https://api.example/v1?tokenFilePath=/etc/dingo/t",
+		},
+		{
+			name: "fragment is not scanned as a query parameter",
+			in:   "https://api.example/v1?page=2#apiKey=abc123",
+			want: "https://api.example/v1?page=2#apiKey=abc123",
+		},
+		{
 			name: "no credentials is unchanged",
 			in:   "https://aggregator.example/aggregator",
 			want: "https://aggregator.example/aggregator",
@@ -410,5 +479,342 @@ func TestProviderConfigUnknownKeyIsRedacted(t *testing.T) {
 	}
 	if !strings.Contains(rendered, "db.example") {
 		t.Errorf("provider config dropped classified host: %s", rendered)
+	}
+}
+
+// credentialKeyNameSpellings is the table that stops the next round of
+// missed spellings. Every entry is one way an operator, a provider, or a
+// cloud SDK spells the same handful of credential terms; the classifier
+// has to reach the same verdict for all of them, and a reviewer can read
+// the term set in redact.go directly against this list.
+var credentialKeyNameSpellings = map[string]bool{
+	// camelCase
+	"apiKey":          true,
+	"apiToken":        true,
+	"accessKeyId":     true,
+	"secretAccessKey": true,
+	"authToken":       true,
+	"refreshToken":    true,
+	"sessionToken":    true,
+	"privateKey":      true,
+	"clientSecret":    true,
+	"sasToken":        true,
+	"accountKey":      true,
+	"signingKey":      true,
+	"subscriptionKey": true,
+	// snake_case
+	"api_key":               true,
+	"api_token":             true,
+	"client_secret":         true,
+	"access_key_id":         true,
+	"aws_secret_access_key": true,
+	"auth_token":            true,
+	// SCREAMING_SNAKE_CASE
+	"API_KEY":               true,
+	"CLIENT_SECRET":         true,
+	"AWS_SECRET_ACCESS_KEY": true,
+	// kebab-case
+	"api-key":       true,
+	"x-api-key":     true,
+	"client-secret": true,
+	"access-key-id": true,
+	// dotted
+	"auth.token": true,
+	// PascalCase and acronym runs
+	"SharedAccessSignature": true,
+	"APIKey":                true,
+	"SASToken":              true,
+	// run together, no separator at all
+	"apikey":       true,
+	"apitoken":     true,
+	"accesskeyid":  true,
+	"clientsecret": true,
+	// bare terms
+	"password":  true,
+	"passwd":    true,
+	"pwd":       true,
+	"secret":    true,
+	"token":     true,
+	"sig":       true,
+	"signature": true,
+	// prefixed and suffixed around the credential term
+	"dingoApiToken": true,
+	"apiKeyValue":   true,
+	// A key naming a location holds a path, which an operator needs.
+	"tokenFilePath":  false,
+	"tokenFile":      false,
+	"secretFile":     false,
+	"passwordFile":   false,
+	"signingKeyFile": false,
+	"keyFilePath":    false,
+	"certFilePath":   false,
+	"dataDir":        false,
+	// A key word with no credential qualifier is not a credential.
+	"publicKeys":    false,
+	"shelleyVrfKey": false,
+	"keyName":       false,
+	// Benign names that embed a credential term as a substring must not
+	// classify on it.
+	"monkey":      false,
+	"keyspace":    false,
+	"passthrough": false,
+	"bypass":      false,
+	// Real provider keys that carry no secret.
+	"host":             false,
+	"port":             false,
+	"user":             false,
+	"database":         false,
+	"sslMode":          false,
+	"timeZone":         false,
+	"dsn":              false,
+	"endpoint":         false,
+	"url":              false,
+	"bucket":           false,
+	"region":           false,
+	"prefix":           false,
+	"timeout":          false,
+	"mode":             false,
+	"maxConnections":   false,
+	"poolMaxOpenConns": false,
+	"capacity":         false,
+	"network":          false,
+	"":                 false,
+}
+
+// TestIsCredentialKeyName runs the credential classifier over every
+// spelling in credentialKeyNameSpellings.
+func TestIsCredentialKeyName(t *testing.T) {
+	t.Parallel()
+
+	for name, want := range credentialKeyNameSpellings {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isCredentialKeyName(name); got != want {
+				t.Errorf(
+					"isCredentialKeyName(%q) = %t, want %t (words %q)",
+					name,
+					got,
+					want,
+					keyNameWords(name),
+				)
+			}
+		})
+	}
+}
+
+// TestKeyNameWords pins the decomposition the classifier decides on, so a
+// failing classification can be read as either a wrong split or a wrong
+// term set rather than one opaque verdict.
+func TestKeyNameWords(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string][]string{
+		"accessKeyId":           {"access", "key", "id"},
+		"access_key_id":         {"access", "key", "id"},
+		"ACCESS-KEY-ID":         {"access", "key", "id"},
+		"accesskeyid":           {"access", "key", "id"},
+		"APIKey":                {"api", "key"},
+		"IPFSGatewayURL":        {"ipfs", "gateway", "url"},
+		"SharedAccessSignature": {"shared", "access", "signature"},
+		"sha256Key":             {"sha256", "key"},
+		"client_secret":         {"client", "secret"},
+		"auth.token":            {"auth", "token"},
+		// No vocabulary segmentation covers these, so they stay whole
+		// instead of matching on an embedded term.
+		"monkey":   {"monkey"},
+		"keyspace": {"keyspace"},
+		"sslmode":  {"sslmode"},
+		"datadir":  {"datadir"},
+	}
+	for name, want := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := keyNameWords(name); !slices.Equal(got, want) {
+				t.Errorf("keyNameWords(%q) = %q, want %q", name, got, want)
+			}
+		})
+	}
+}
+
+// TestProviderConfigKeyTableAgreesWithClassifier holds the hand-written
+// provider key table and the credential classifier to one answer.
+// providerConfigKeyClass consults the classifier first, so a key listed
+// plain or URI that the classifier reads as a credential would be
+// silently over-redacted at runtime, and a key listed secret that the
+// classifier reads as benign would mean the term set has a hole.
+func TestProviderConfigKeyTableAgreesWithClassifier(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range slices.Concat(
+		providerConfigPlainKeys,
+		providerConfigURIKeys,
+	) {
+		if isCredentialKeyName(key) {
+			t.Errorf(
+				"provider key %q is classified renderable but reads as "+
+					"a credential (words %q)",
+				key,
+				keyNameWords(key),
+			)
+		}
+	}
+	for _, key := range providerConfigSecretKeys {
+		if !isCredentialKeyName(key) {
+			t.Errorf(
+				"provider key %q is classified secret but does not read "+
+					"as a credential (words %q)",
+				key,
+				keyNameWords(key),
+			)
+		}
+	}
+}
+
+// credentialShapedPlainConfigFields are the Config field paths that read
+// as credential-shaped but are deliberately rendered. Both name an
+// on-chain Midnight policy ID or asset name for an authorization token --
+// public ledger data, not the token. The Config field paths are
+// exhaustively enumerated and gated by
+// TestConfigLogClassesCoverEveryConfigField, so that path keeps its
+// explicit human decision instead of deferring to a name-shape heuristic;
+// this list is what makes each such decision reviewable.
+var credentialShapedPlainConfigFields = []string{
+	"Midnight.AuthTokenAssetName",
+	"Midnight.AuthTokenPolicyID",
+}
+
+// TestConfigFieldClassesAgreeWithClassifier runs the credential
+// classifier over the leaf name of every classified Config field path. A
+// new secret-bearing field whose name reads as a credential but that was
+// classified plain fails here, which is the audit the provider-key path
+// gets at runtime.
+func TestConfigFieldClassesAgreeWithClassifier(t *testing.T) {
+	t.Parallel()
+
+	var exercised []string
+	for _, path := range slices.Concat(
+		logPlainConfigFields,
+		logURIConfigFields,
+		logProviderConfigFields,
+	) {
+		leaf := path
+		if i := strings.LastIndex(path, "."); i >= 0 {
+			leaf = path[i+1:]
+		}
+		if !isCredentialKeyName(leaf) {
+			continue
+		}
+		if slices.Contains(credentialShapedPlainConfigFields, path) {
+			exercised = append(exercised, path)
+			continue
+		}
+		t.Errorf(
+			"Config field %s is classified renderable but its name "+
+				"reads as a credential (words %q): classify it as a "+
+				"secret, or add it to "+
+				"credentialShapedPlainConfigFields with a reason",
+			path,
+			keyNameWords(leaf),
+		)
+	}
+	for _, path := range credentialShapedPlainConfigFields {
+		if !slices.Contains(exercised, path) {
+			t.Errorf(
+				"credentialShapedPlainConfigFields lists %s, which is "+
+					"no longer a credential-shaped renderable field",
+				path,
+			)
+		}
+	}
+	for _, path := range logSecretConfigFields {
+		leaf := path
+		if i := strings.LastIndex(path, "."); i >= 0 {
+			leaf = path[i+1:]
+		}
+		if !isCredentialKeyName(leaf) {
+			t.Errorf(
+				"Config field %s is classified secret but its name does "+
+					"not read as a credential (words %q)",
+				path,
+				keyNameWords(leaf),
+			)
+		}
+	}
+}
+
+// TestProviderConfigSecretSubtreeIsRedactedWhole pins that a
+// secret-classified or unclassified provider key covers everything under
+// it. Recursing into the subtree would reclassify its inner keys by their
+// own names, and an inner key that happens to be classified plain --
+// "host", "mode" -- would then render part of a secret-bearing value.
+func TestProviderConfigSecretSubtreeIsRedactedWhole(t *testing.T) {
+	t.Parallel()
+
+	value := providerConfigValue(reflect.ValueOf(map[string]any{
+		"host": "db.example",
+		"token": map[string]any{
+			"host": "nested-under-secret-key",
+			"mode": "nested-under-secret-key-mode",
+		},
+		"clientSecret": map[string]any{
+			"mode": "nested-under-credential-shaped-key",
+		},
+		"futureTree": map[string]any{
+			"host": "nested-under-unclassified-key",
+		},
+	}))
+	rendered := value.String()
+	for _, unwanted := range []string{
+		"nested-under-secret-key",
+		"nested-under-secret-key-mode",
+		"nested-under-credential-shaped-key",
+		"nested-under-unclassified-key",
+	} {
+		if strings.Contains(rendered, unwanted) {
+			t.Errorf("provider config leaks %q: %s", unwanted, rendered)
+		}
+	}
+	if !strings.Contains(rendered, "db.example") {
+		t.Errorf("provider config dropped classified host: %s", rendered)
+	}
+}
+
+// TestProviderConfigNestedSectionsAreWalked is the counterweight to
+// redacting a secret subtree whole: the API providers nest their tls and
+// auth policies, so those sections have to stay renderable containers or
+// the whole policy disappears from a startup log.
+func TestProviderConfigNestedSectionsAreWalked(t *testing.T) {
+	t.Parallel()
+
+	value := providerConfigValue(reflect.ValueOf(map[string]any{
+		"auth": map[string]any{
+			"mode":          "token",
+			"tokenFilePath": "/etc/dingo/token",
+			"token":         "nested-auth-token",
+		},
+		"tls": map[string]any{
+			"mode":         "manual",
+			"certFilePath": "/etc/dingo/api.crt",
+		},
+	}))
+	rendered := value.String()
+	if strings.Contains(rendered, "nested-auth-token") {
+		t.Errorf("provider config leaks nested auth token: %s", rendered)
+	}
+	for _, want := range []string{
+		"token",
+		"/etc/dingo/token",
+		"manual",
+		"/etc/dingo/api.crt",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf(
+				"provider config dropped nested policy %q: %s",
+				want,
+				rendered,
+			)
+		}
 	}
 }

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -1,0 +1,414 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
+)
+
+// configLeafFieldPaths returns the dotted Go field path of every exported
+// leaf (non-struct) field reachable from Config, which is exactly the set
+// configLogClasses has to classify.
+func configLeafFieldPaths(t *testing.T) []string {
+	t.Helper()
+
+	var paths []string
+	var walk func(rt reflect.Type, prefix string)
+	walk = func(rt reflect.Type, prefix string) {
+		for field := range rt.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			ft := field.Type
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			path := prefix + field.Name
+			if ft.Kind() == reflect.Struct {
+				walk(ft, path+".")
+				continue
+			}
+			paths = append(paths, path)
+		}
+	}
+	walk(reflect.TypeFor[Config](), "")
+	slices.Sort(paths)
+	return paths
+}
+
+// TestConfigLogClassesCoverEveryConfigField is the fail-safe gate on the
+// redacted representation. An unclassified field resolves to logSecret, so
+// adding one cannot leak a secret -- but it would silently reduce a benign
+// new field to ***redacted*** in every operator's debug log. Failing here
+// forces an explicit classification decision instead.
+func TestConfigLogClassesCoverEveryConfigField(t *testing.T) {
+	t.Parallel()
+
+	classes := configLogClasses()
+	paths := configLeafFieldPaths(t)
+	for _, path := range paths {
+		if _, ok := classes[path]; !ok {
+			t.Errorf(
+				"Config field %s has no logClass: add it to one of "+
+					"the logPlain/logSecret/logURI/logProviderConfig "+
+					"field lists in redact.go",
+				path,
+			)
+		}
+	}
+	// A stale entry means a field was renamed or removed and its
+	// classification no longer applies to anything.
+	for path := range classes {
+		if !slices.Contains(paths, path) {
+			t.Errorf(
+				"redact.go classifies %s, which is not a Config field",
+				path,
+			)
+		}
+	}
+}
+
+// TestConfigLogClassesAreUnambiguous catches a field path listed under two
+// different classes, where the effective class would depend on map
+// iteration order.
+func TestConfigLogClassesAreUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]int)
+	for _, paths := range [][]string{
+		logPlainConfigFields,
+		logSecretConfigFields,
+		logURIConfigFields,
+		logProviderConfigFields,
+	} {
+		for _, path := range paths {
+			seen[path]++
+		}
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("Config field %s is classified %d times", path, count)
+		}
+	}
+}
+
+// sentinelSecrets are the distinctive values planted in the configuration
+// below. None of them may appear in a rendered log line.
+var sentinelSecrets = []string{
+	"SENTINEL-API-AUTH-TOKEN",
+	"SENTINEL-KOIOS-API-KEY",
+	"SENTINEL-BARK-PASSWORD",
+	"SENTINEL-BARK-HOST-PASSWORD",
+	"SENTINEL-MITHRIL-KEY",
+	"SENTINEL-S3-SECRET-KEY",
+	"SENTINEL-TOKEN-REGISTRY-PASSWORD",
+	"SENTINEL-IPFS-PASSWORD",
+	"SENTINEL-PG-PASSWORD",
+	"SENTINEL-DSN-PASSWORD",
+	"SENTINEL-DSN-KEYWORD-PASSWORD",
+	"SENTINEL-UNKNOWN-PROVIDER-KEY",
+	"SENTINEL-BLOCKFROST-TOKEN",
+	"SENTINEL-NESTED-PROVIDER-SECRET",
+	"SENTINEL-MEMPOOL-LIST-SECRET",
+}
+
+// sentinelSecretConfig plants a sentinel in every secret-bearing field and
+// provider-map key, alongside non-secret values that must survive.
+func sentinelSecretConfig() *Config {
+	authToken := "SENTINEL-API-AUTH-TOKEN"
+	certPath := "/etc/dingo/api.crt"
+	return &Config{
+		Network:      "preview",
+		DatabasePath: "/var/lib/dingo",
+		StorageMode:  "api",
+		Logging:      LoggingConfig{Format: "json", Level: "debug"},
+		API: APIConfig{
+			TLS:  apiconfig.TLSPolicy{CertFilePath: &certPath},
+			Auth: apiconfig.AuthPolicy{Token: &authToken},
+		},
+		KoiosParity: KoiosParityConfig{
+			Enabled: true,
+			APIKey:  "SENTINEL-KOIOS-API-KEY",
+		},
+		BarkBaseUrl: "https://bark:SENTINEL-BARK-PASSWORD@bark.example/api",
+		BarkBlockDownloadHosts: []string{
+			"https://blocks:SENTINEL-BARK-HOST-PASSWORD@blocks.example",
+			"https://plain.example",
+		},
+		Mithril: MithrilConfig{
+			AggregatorURL: "https://aggregator.example/aggregator" +
+				"?apiKey=SENTINEL-MITHRIL-KEY&network=preview",
+		},
+		TokenRegistry: TokenRegistryConfig{
+			SourceURL: "https://reg:SENTINEL-TOKEN-REGISTRY-PASSWORD" +
+				"@registry.example/registry.tar.gz",
+		},
+		OffchainMetadata: OffchainMetadataConfig{
+			IPFSGatewayURL: "https://ipfs:SENTINEL-IPFS-PASSWORD" +
+				"@ipfs.example/ipfs/",
+		},
+		DatabaseLifecycle: DatabaseLifecycleConfig{
+			SnapshotCloudDestination: "s3://snapshots/dingo" +
+				"?accessKeyId=AKIAEXAMPLE" +
+				"&secretKey=SENTINEL-S3-SECRET-KEY",
+		},
+		ShelleyVRFKey: "/etc/dingo/vrf.skey",
+		Plugins: PluginsConfig{
+			Storage: StoragePluginsConfig{
+				Blob: hostplugin.Selection{
+					Provider: "badger",
+					Config:   map[string]any{"dataDir": "/var/lib/dingo/blob"},
+				},
+				Metadata: hostplugin.Selection{
+					Provider: "postgres",
+					Config: map[string]any{
+						"host":     "db.example",
+						"port":     5432,
+						"user":     "dingo",
+						"database": "dingo",
+						"sslMode":  "require",
+						"password": "SENTINEL-PG-PASSWORD",
+						"dsn": "postgres://dingo:SENTINEL-DSN-PASSWORD" +
+							"@db.example:5432/dingo?sslmode=require",
+						"futureKey": "SENTINEL-UNKNOWN-PROVIDER-KEY",
+					},
+				},
+			},
+			Mempool: hostplugin.Selection{
+				Provider: "dag",
+				Config: map[string]any{
+					"capacity": 1024,
+					"futureList": []any{
+						"SENTINEL-MEMPOOL-LIST-SECRET",
+					},
+				},
+			},
+			API: APIPluginsConfig{
+				Blockfrost: hostplugin.Selection{
+					Provider: "blockfrost",
+					Config: map[string]any{
+						"port": 3000,
+						"auth": map[string]any{
+							"mode":  "token",
+							"token": "SENTINEL-BLOCKFROST-TOKEN",
+						},
+						"futureSection": map[string]any{
+							"deeper": map[string]any{
+								"anything": "SENTINEL-NESTED-" +
+									"PROVIDER-SECRET",
+							},
+						},
+					},
+				},
+				Mesh: hostplugin.Selection{
+					Provider: "mesh",
+					Config: map[string]any{
+						"dsn": "mysql://mesh:" +
+							"SENTINEL-DSN-KEYWORD-PASSWORD@tcp" +
+							"(mesh.example:3306)/mesh",
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestConfigLogValueRedactsSentinelSecrets renders the configuration
+// through both real slog handlers and asserts that no sentinel secret
+// survives, and that non-secret values still do.
+func TestConfigLogValueRedactsSentinelSecrets(t *testing.T) {
+	t.Parallel()
+
+	cfg := sentinelSecretConfig()
+	handlers := map[string]func(*bytes.Buffer) slog.Handler{
+		"text": func(b *bytes.Buffer) slog.Handler {
+			return slog.NewTextHandler(b, nil)
+		},
+		"json": func(b *bytes.Buffer) slog.Handler {
+			return slog.NewJSONHandler(b, nil)
+		},
+	}
+	for name, newHandler := range handlers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			slog.New(newHandler(&buf)).Info("config", "config", cfg)
+			rendered := buf.String()
+			for _, sentinel := range sentinelSecrets {
+				if strings.Contains(rendered, sentinel) {
+					t.Errorf("rendered log leaks %s", sentinel)
+				}
+			}
+			// Negative case: redaction must not blank the record.
+			for _, want := range []string{
+				"preview",
+				"/var/lib/dingo",
+				"/etc/dingo/api.crt",
+				"/etc/dingo/vrf.skey",
+				"badger",
+				"postgres",
+				"db.example",
+				"5432",
+				"dingo",
+				"require",
+				"aggregator.example",
+				"registry.example",
+				"blocks.example",
+				"plain.example",
+				"snapshots/dingo",
+				"AKIAEXAMPLE",
+				"mesh.example:3306",
+				"1024",
+			} {
+				if !strings.Contains(rendered, want) {
+					t.Errorf(
+						"rendered log dropped non-secret %q:\n%s",
+						want,
+						rendered,
+					)
+				}
+			}
+			if !strings.Contains(rendered, redactedPlaceholder) {
+				t.Errorf("rendered log has no redaction marker:\n%s",
+					rendered)
+			}
+		})
+	}
+}
+
+// TestConfigLogValueNil covers a nil receiver, which slog resolves the same
+// way as any other LogValuer.
+func TestConfigLogValueNil(t *testing.T) {
+	t.Parallel()
+
+	var cfg *Config
+	if got := cfg.LogValue().String(); got != "<nil>" {
+		t.Errorf("nil Config LogValue = %q, want <nil>", got)
+	}
+}
+
+func TestRedactURICredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "postgres url keeps host database and sslmode",
+			in: "postgres://dingo:hunter2@db.example:5432/dingo" +
+				"?sslmode=require",
+			want: "postgres://dingo:" + redactedPlaceholder +
+				"@db.example:5432/dingo?sslmode=require",
+		},
+		{
+			name: "mysql dsn without scheme",
+			in:   "dingo:hunter2@tcp(db.example:3306)/dingo",
+			want: "dingo:" + redactedPlaceholder +
+				"@tcp(db.example:3306)/dingo",
+		},
+		{
+			name: "keyword form dsn",
+			in:   "host=db.example user=dingo password=hunter2 dbname=dingo",
+			want: "host=db.example user=dingo password=" +
+				redactedPlaceholder + " dbname=dingo",
+		},
+		{
+			name: "credential query parameter",
+			in:   "https://aggregator.example/x?apiKey=abc123&network=preview",
+			want: "https://aggregator.example/x?apiKey=" +
+				redactedPlaceholder + "&network=preview",
+		},
+		{
+			name: "no credentials is unchanged",
+			in:   "https://aggregator.example/aggregator",
+			want: "https://aggregator.example/aggregator",
+		},
+		{
+			name: "username without password is not a credential",
+			in:   "https://dingo@bark.example/api",
+			want: "https://dingo@bark.example/api",
+		},
+		{
+			name: "ipv6 host without userinfo is unchanged",
+			in:   "http://[::1]:3000/metrics",
+			want: "http://[::1]:3000/metrics",
+		},
+		{
+			name: "bucket uri is unchanged",
+			in:   "s3://snapshots/dingo",
+			want: "s3://snapshots/dingo",
+		},
+		{
+			name: "at sign in path is not userinfo",
+			in:   "https://registry.example/a@b/registry.tar.gz",
+			want: "https://registry.example/a@b/registry.tar.gz",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := redactURICredentials(tc.in); got != tc.want {
+				t.Errorf(
+					"redactURICredentials(%q) = %q, want %q",
+					tc.in,
+					got,
+					tc.want,
+				)
+			}
+		})
+	}
+}
+
+// TestProviderConfigUnknownKeyIsRedacted pins the fail-safe default for a
+// provider configuration map: a key nobody has classified is redacted, at
+// any nesting depth, rather than logged on the chance that it is benign.
+func TestProviderConfigUnknownKeyIsRedacted(t *testing.T) {
+	t.Parallel()
+
+	value := providerConfigValue(reflect.ValueOf(map[string]any{
+		"host":       "db.example",
+		"futureKey":  "unclassified-secret",
+		"futureTree": map[string]any{"deeper": "unclassified-nested-secret"},
+	}))
+	rendered := value.String()
+	for _, unwanted := range []string{
+		"unclassified-secret",
+		"unclassified-nested-secret",
+	} {
+		if strings.Contains(rendered, unwanted) {
+			t.Errorf("provider config leaks %q: %s", unwanted, rendered)
+		}
+	}
+	if !strings.Contains(rendered, "db.example") {
+		t.Errorf("provider config dropped classified host: %s", rendered)
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -141,8 +141,16 @@ func serveAuxiliaryListener(
 	}
 }
 
+// logStartupConfig debug-logs the effective node configuration through
+// Config's redacted representation (Config.LogValue), so a debug log never
+// persists a Koios API key, an inline API auth token, or a storage provider
+// password or DSN credential.
+func logStartupConfig(logger *slog.Logger, cfg *config.Config) {
+	logger.Debug("config", "component", "node", "config", cfg)
+}
+
 func Run(cfg *config.Config, logger *slog.Logger) error {
-	logger.Debug(fmt.Sprintf("config: %+v", cfg), "component", "node")
+	logStartupConfig(logger, cfg)
 	logger.Debug(
 		fmt.Sprintf("topology: %+v", config.GetTopologyConfig()),
 		"component", "node",

--- a/internal/node/node_config_logging_test.go
+++ b/internal/node/node_config_logging_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	"github.com/blinklabs-io/dingo/internal/config"
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
+)
+
+// sentinelConfig builds a config whose every secret-bearing field carries a
+// distinctive sentinel value, alongside non-secret values that must survive
+// redaction.
+func sentinelConfig() (*config.Config, []string) {
+	token := "SENTINEL-API-AUTH-TOKEN"
+	cfg := &config.Config{
+		Network:      "preview",
+		DatabasePath: "/var/lib/dingo",
+		API: config.APIConfig{
+			Auth: apiconfig.AuthPolicy{Token: &token},
+		},
+		KoiosParity: config.KoiosParityConfig{
+			Enabled: true,
+			APIKey:  "SENTINEL-KOIOS-API-KEY",
+		},
+		BarkBaseUrl: "https://bark:SENTINEL-BARK-PASSWORD@bark.example/api",
+		Mithril: config.MithrilConfig{
+			AggregatorURL: "https://aggregator.example/aggregator" +
+				"?apiKey=SENTINEL-MITHRIL-KEY",
+		},
+		Plugins: config.PluginsConfig{
+			Storage: config.StoragePluginsConfig{
+				Metadata: hostplugin.Selection{
+					Provider: "postgres",
+					Config: map[string]any{
+						"host":     "db.example",
+						"user":     "dingo",
+						"password": "SENTINEL-PG-PASSWORD",
+						"dsn": "postgres://dingo:SENTINEL-DSN-PASSWORD" +
+							"@db.example:5432/dingo?sslmode=require",
+						"futureKey": "SENTINEL-UNKNOWN-PROVIDER-KEY",
+					},
+				},
+			},
+			API: config.APIPluginsConfig{
+				Blockfrost: hostplugin.Selection{
+					Provider: "blockfrost",
+					Config: map[string]any{
+						"auth": map[string]any{
+							"mode":  "token",
+							"token": "SENTINEL-BLOCKFROST-TOKEN",
+						},
+					},
+				},
+			},
+		},
+	}
+	return cfg, []string{
+		"SENTINEL-API-AUTH-TOKEN",
+		"SENTINEL-KOIOS-API-KEY",
+		"SENTINEL-BARK-PASSWORD",
+		"SENTINEL-MITHRIL-KEY",
+		"SENTINEL-PG-PASSWORD",
+		"SENTINEL-DSN-PASSWORD",
+		"SENTINEL-UNKNOWN-PROVIDER-KEY",
+		"SENTINEL-BLOCKFROST-TOKEN",
+	}
+}
+
+// TestLogStartupConfigRedactsSecrets covers the startup debug log that
+// records the effective configuration: no secret-bearing value may reach it.
+func TestLogStartupConfigRedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	cfg, sentinels := sentinelConfig()
+	for _, handler := range []struct {
+		name string
+		make func(*bytes.Buffer) slog.Handler
+	}{
+		{"text", func(b *bytes.Buffer) slog.Handler {
+			return slog.NewTextHandler(b, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			})
+		}},
+		{"json", func(b *bytes.Buffer) slog.Handler {
+			return slog.NewJSONHandler(b, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			})
+		}},
+	} {
+		t.Run(handler.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logStartupConfig(slog.New(handler.make(&buf)), cfg)
+			rendered := buf.String()
+			if rendered == "" {
+				t.Fatal("startup config log produced no output")
+			}
+			for _, sentinel := range sentinels {
+				if strings.Contains(rendered, sentinel) {
+					t.Errorf(
+						"rendered log leaks %s: %s",
+						sentinel,
+						rendered,
+					)
+				}
+			}
+			// Negative case: redaction must not blank the whole record.
+			for _, want := range []string{
+				"preview",
+				"/var/lib/dingo",
+				"db.example",
+				"postgres",
+				"sslmode=require",
+			} {
+				if !strings.Contains(rendered, want) {
+					t.Errorf(
+						"rendered log dropped non-secret %q: %s",
+						want,
+						rendered,
+					)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3284.

`internal/node/node.go` debug-logged the full `*config.Config` with `%+v`, rendering the API auth token, the Koios API key, and provider-map DSN passwords into debug logs.

`Config.LogValue()` in `internal/config/redact.go` replaces that with a reflection walk over a field-path classification table. `logSecret` is the zero value of `logClass`, so an unclassified field renders redacted rather than plain; `TestConfigLogClassesCoverEveryConfigField` fails both on an unclassified path and on a classification whose field no longer exists.

DSN and URL fields keep scheme, host, port, database name, and non-credential parameters, losing only userinfo passwords and credential-shaped parameters. URL, schemeless MySQL, and keyword DSN forms are covered. Provider maps under `plugins.*.config` are walked recursively with per-key classification, defaulting to redacted at any depth. Unexported fields are no longer rendered at all.

`ShelleyVRFKey`, `ShelleyKESKey`, `ShelleyOperationalCertificate`, and `LeiosVoteSigningKeyFile` are file paths, not key material, and stay plain. `Midnight.AuthTokenPolicyID` and `AuthTokenAssetName` are on-chain identifiers and stay plain.

Tests assert sentinel secrets are absent from both the text and JSON handlers, and that non-secret values are still present, so redaction cannot pass by blanking the record.

ARCHITECTURE.md documents the classification table and the URI rule. DATABASE.md checked, unaffected.

The adjacent `%+v` logs for the topology and cardano network config are unchanged: both carry public chain data with no credential surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop logging raw `%+v` `*config.Config` and use a structured, redacted `Config.LogValue()` so API tokens, passwords, and DSN credentials never reach logs. Previously secrets appeared in debug logs; now they are redacted while non-sensitive connection details remain.

- Implementation: `internal/config/redact.go` adds a reflection-based walker with a fail-safe allow-list; unclassified `Config` paths default to secret, and unexported fields are omitted.
- Provider config: `plugins.*.config` is walked per key; unknown keys redact by default. `auth` and `tls` are section containers and must be maps; non-map values at these keys are redacted whole.
- URI/DSN handling: redact userinfo passwords and credential-shaped params; keep scheme/host/port/path and non-credential params. Handles URL-form, schemeless MySQL, and keyword DSNs. Percent/plus-encoded param names are decoded for classification; malformed escapes fail closed.
- Shape safety: URI fields only render when the value holds strings to transform; otherwise they are redacted to avoid leaking untransformed credentials.
- Logging change: `internal/node` now uses `logStartupConfig` to log `cfg` via `LogValue`; topology/network logs unchanged.
- Tests/docs: comprehensive tests for handlers, provider keys, encoded names, containers, and shape rules; `ARCHITECTURE.md` documents the tables and URI rules.

- No configuration changes required.
- When adding `Config` fields or provider keys, update the classification tables; otherwise values redact by default and CI will fail.

<sup>Written for commit 11049c8e6cbed23144e874ff8f970ede27003788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Startup configuration logs now redact secrets by default.
  * Credentials are removed from URIs, provider settings, and nested configuration values.
  * Non-sensitive connection details remain available for troubleshooting.
* **Bug Fixes**
  * Prevented sensitive configuration values from appearing in text and JSON startup logs.
* **Tests**
  * Added coverage for secret redaction, URI credentials, unknown provider settings, nil configurations, and log output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->