### PR TITLE
fix(database): release the commit barrier on every terminal Txn path

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -844,6 +844,16 @@ blob transaction is committed and carries the new commit timestamp while metadat
 does not — the same inconsistency a failed metadata commit leaves, and the same
 recovery (trim the blob store back to the metadata tip) applies.
 
+Every terminal path out of `Txn.Commit` — including that failed-`Sync` partial
+commit — releases the commit barrier hold exactly once, via `Txn.finishLocked`.
+It has to be the same step that sets `finished`, because `finished` is also what
+makes a subsequent `Rollback`/`Release` a no-op: a path that marked the
+transaction finished without releasing would strand the shared hold for the
+process's lifetime, with no later call able to repair it, and the next
+`PauseCommits`/`PauseCommitsContext` would then wait on a reader that never
+releases while the barrier's writer preference blocked every read-write `Txn`
+constructed behind it.
+
 Plugins whose writes are already durable on commit implement `Sync` as a no-op:
 an S3 object is durable once `PutObject` is acknowledged, and a GCS object once
 its writer closes successfully.

--- a/database/txn.go
+++ b/database/txn.go
@@ -114,6 +114,23 @@ func (t *Txn) releaseCommitBarrierLocked() {
 	}
 }
 
+// finishLocked marks the transaction terminal and releases its commit
+// barrier hold. Every path in Commit and rollback that sets finished must
+// go through it, because finished is also what makes a later
+// Rollback/Release a no-op: a terminal path that sets the flag without
+// releasing strands the shared hold for the process's lifetime, and the
+// caller's deferred Release cannot repair it. That is not a bounded cost —
+// PauseCommits then waits forever for a reader that will never release,
+// and the barrier's writer preference blocks every read-write Txn
+// constructed behind it. Releasing exactly once is safe to route
+// everywhere because releaseCommitBarrierLocked clears barrierHeld before
+// unlocking, so a repeat call is a no-op rather than an unmatched RUnlock
+// (which cancellableBarrier panics on). Callers must hold t.lock.
+func (t *Txn) finishLocked() {
+	t.finished = true
+	t.releaseCommitBarrierLocked()
+}
+
 func NewTxn(db *Database, readWrite bool) *Txn {
 	t := &Txn{db: db, readWrite: readWrite}
 	acquireCommitBarrier(t, db.Metadata() != nil)
@@ -331,8 +348,7 @@ func (t *Txn) Commit() error {
 	}
 	// Fail fast if neither store is available for a read-write transaction
 	if t.readWrite && t.blobTxn == nil && t.metadataTxn == nil {
-		t.finished = true
-		t.releaseCommitBarrierLocked()
+		t.finishLocked()
 		t.lock.Unlock()
 		return types.ErrNoStoreAvailable
 	}
@@ -351,8 +367,7 @@ func (t *Txn) Commit() error {
 			// Rollback both transactions on timestamp update failure
 			_ = t.blobTxn.Rollback()
 			_ = t.metadataTxn.Rollback()
-			t.finished = true
-			t.releaseCommitBarrierLocked()
+			t.finishLocked()
 			t.lock.Unlock()
 			return fmt.Errorf("failed to update commit timestamp: %w", err)
 		}
@@ -365,8 +380,7 @@ func (t *Txn) Commit() error {
 			if t.metadataTxn != nil {
 				_ = t.metadataTxn.Rollback()
 			}
-			t.finished = true
-			t.releaseCommitBarrierLocked()
+			t.finishLocked()
 			t.lock.Unlock()
 			return fmt.Errorf("blob commit failed: %w", err)
 		}
@@ -386,7 +400,7 @@ func (t *Txn) Commit() error {
 		if blobStore := t.db.Blob(); blobStore != nil && t.metadataTxn != nil {
 			if syncErr := blobStore.Sync(); syncErr != nil {
 				_ = t.metadataTxn.Rollback()
-				t.finished = true
+				t.finishLocked()
 				// The blob transaction is committed and carries the new commit
 				// timestamp while metadata does not, which is the same
 				// inconsistency a failed metadata commit leaves behind. Report
@@ -413,7 +427,7 @@ func (t *Txn) Commit() error {
 	if t.metadataTxn != nil {
 		if err := t.metadataTxn.Commit(); err != nil {
 			_ = t.metadataTxn.Rollback()
-			t.finished = true
+			t.finishLocked()
 			// Only return PartialCommitError when blob was actually committed.
 			// Per docstring, this error type signifies "blob commits but metadata fails."
 			// When t.blobTxn == nil (metadata-only txn), no blob was committed.
@@ -429,19 +443,16 @@ func (t *Txn) Commit() error {
 					MetadataErr:     err,
 					CommitTimestamp: commitTimestamp,
 				}
-				t.releaseCommitBarrierLocked()
 				t.lock.Unlock()
 				return ret
 			}
-			t.releaseCommitBarrierLocked()
 			t.lock.Unlock()
 			return fmt.Errorf("metadata commit failed: %w", err)
 		}
 	}
-	t.finished = true
 	t.committed = true
 	t.dispatching = true
-	t.releaseCommitBarrierLocked()
+	t.finishLocked()
 	t.lock.Unlock()
 	t.dispatchAfterCommit()
 	return nil
@@ -468,8 +479,7 @@ func (t *Txn) rollback() error {
 			errs = append(errs, fmt.Errorf("metadata rollback: %w", err))
 		}
 	}
-	t.finished = true
-	t.releaseCommitBarrierLocked()
+	t.finishLocked()
 	return errors.Join(errs...)
 }
 

--- a/database/txn_commit_barrier_test.go
+++ b/database/txn_commit_barrier_test.go
@@ -15,7 +15,6 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -23,40 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
-	metadataSqlite "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
-
-// newCommitBarrierTestDB is newSyncBarrierTestDB over an arbitrary blob
-// store, so a case can inject a store whose Sync or SetCommitTimestamp
-// fails without changing the shared mockBlobStore.
-func newCommitBarrierTestDB(
-	t *testing.T,
-	blobStore blob.BlobStore,
-) *Database {
-	t.Helper()
-	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	sqliteStore, err := metadataSqlite.NewSQLStore(
-		metadataSqlite.Config{},
-		metadata.ProviderDependencies{Logger: logger},
-	)
-	require.NoError(t, err)
-	require.NoError(t, sqliteStore.Start(context.Background()))
-	db := &Database{
-		blob:     blobStore,
-		metadata: sqliteStore,
-		logger:   logger,
-		config:   &Config{Logger: logger},
-	}
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
-	return db
-}
 
 // timestampFailingBlobStore fails SetCommitTimestamp, which is what
 // Commit's updateCommitTimestamp step calls before either store commits.
@@ -175,7 +145,7 @@ func requireCommitBarrierFree(t *testing.T, db *Database) {
 func TestFailedBlobSyncDoesNotBlockTheNextWriter(t *testing.T) {
 	syncErr := errors.New("fsync failed")
 	store := &mockBlobStore{syncErr: syncErr}
-	db := newCommitBarrierTestDB(t, store)
+	db := newSyncBarrierTestDB(t, store)
 
 	txn := db.Transaction(true)
 	require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
@@ -225,7 +195,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "successful combined commit",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{})
+				return newSyncBarrierTestDB(t, &mockBlobStore{})
 			},
 			run: func(t *testing.T, db *Database) *Txn {
 				txn := db.Transaction(true)
@@ -237,7 +207,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "successful metadata-only commit",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{})
+				return newSyncBarrierTestDB(t, &mockBlobStore{})
 			},
 			run: func(t *testing.T, db *Database) *Txn {
 				txn := db.MetadataTxn(true)
@@ -249,7 +219,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "read-only commit",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{})
+				return newSyncBarrierTestDB(t, &mockBlobStore{})
 			},
 			run: func(t *testing.T, db *Database) *Txn {
 				txn := db.Transaction(false)
@@ -260,7 +230,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "rollback",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{})
+				return newSyncBarrierTestDB(t, &mockBlobStore{})
 			},
 			run: func(t *testing.T, db *Database) *Txn {
 				txn := db.Transaction(true)
@@ -272,7 +242,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "release",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{})
+				return newSyncBarrierTestDB(t, &mockBlobStore{})
 			},
 			run: func(t *testing.T, db *Database) *Txn {
 				txn := db.Transaction(true)
@@ -283,7 +253,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "commit timestamp failure",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &timestampFailingBlobStore{
+				return newSyncBarrierTestDB(t, &timestampFailingBlobStore{
 					mockBlobStore: &mockBlobStore{},
 					err:           injected,
 				})
@@ -304,7 +274,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "blob commit failure",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{
+				return newSyncBarrierTestDB(t, &mockBlobStore{
 					commitErrs: []error{injected},
 				})
 			},
@@ -320,7 +290,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 		{
 			name: "blob sync failure",
 			newDB: func(t *testing.T) *Database {
-				return newCommitBarrierTestDB(t, &mockBlobStore{
+				return newSyncBarrierTestDB(t, &mockBlobStore{
 					syncErr: injected,
 				})
 			},
@@ -421,7 +391,7 @@ func TestCommitBarrierSurvivesConcurrentFailingCommits(t *testing.T) {
 	store := &serializedBlobStore{
 		mockBlobStore: &mockBlobStore{syncErr: errors.New("fsync failed")},
 	}
-	db := newCommitBarrierTestDB(t, store)
+	db := newSyncBarrierTestDB(t, store)
 
 	const writers = 8
 	done := make(chan struct{}, writers)

--- a/database/txn_commit_barrier_test.go
+++ b/database/txn_commit_barrier_test.go
@@ -1,0 +1,450 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	metadataSqlite "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// newCommitBarrierTestDB is newSyncBarrierTestDB over an arbitrary blob
+// store, so a case can inject a store whose Sync or SetCommitTimestamp
+// fails without changing the shared mockBlobStore.
+func newCommitBarrierTestDB(
+	t *testing.T,
+	blobStore blob.BlobStore,
+) *Database {
+	t.Helper()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	sqliteStore, err := metadataSqlite.NewSQLStore(
+		metadataSqlite.Config{},
+		metadata.ProviderDependencies{Logger: logger},
+	)
+	require.NoError(t, err)
+	require.NoError(t, sqliteStore.Start(context.Background()))
+	db := &Database{
+		blob:     blobStore,
+		metadata: sqliteStore,
+		logger:   logger,
+		config:   &Config{Logger: logger},
+	}
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db
+}
+
+// timestampFailingBlobStore fails SetCommitTimestamp, which is what
+// Commit's updateCommitTimestamp step calls before either store commits.
+type timestampFailingBlobStore struct {
+	*mockBlobStore
+	err error
+}
+
+func (s *timestampFailingBlobStore) SetCommitTimestamp(
+	int64,
+	types.Txn,
+) error {
+	return s.err
+}
+
+// commitFailingMetadata is a metadata store whose write transactions fail
+// to commit. Only the handful of methods Txn.Commit reaches are
+// implemented; the embedded nil interface would panic on anything else,
+// which is the intent — a case that starts touching a different method
+// should fail loudly rather than silently exercise a different path.
+type commitFailingMetadata struct {
+	metadata.MetadataStore
+	err error
+}
+
+func (m *commitFailingMetadata) Transaction() types.Txn {
+	return &commitFailingTxn{err: m.err}
+}
+
+func (m *commitFailingMetadata) ReadTransaction() types.Txn {
+	return &commitFailingTxn{}
+}
+
+func (m *commitFailingMetadata) SetCommitTimestamp(
+	int64,
+	types.Txn,
+) error {
+	return nil
+}
+
+type commitFailingTxn struct {
+	err error
+}
+
+func (t *commitFailingTxn) Commit() error   { return t.err }
+func (t *commitFailingTxn) Rollback() error { return nil }
+
+// serializedBlobStore guards mockBlobStore's unsynchronized counters so
+// the concurrent case below measures the commit barrier rather than
+// reporting a data race in the test double. Sync is reimplemented instead
+// of delegated: mockBlobStore.Sync also reads the first blob
+// transaction's commit counter, which a different goroutine's Commit
+// writes outside this mutex.
+type serializedBlobStore struct {
+	*mockBlobStore
+	mu sync.Mutex
+}
+
+func (s *serializedBlobStore) NewTransaction(readWrite bool) types.Txn {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mockBlobStore.NewTransaction(readWrite)
+}
+
+func (s *serializedBlobStore) Sync() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.syncCount++
+	return s.syncErr
+}
+
+// barrierReaders reports the commit barrier's current shared-holder
+// count. A terminal Txn that leaked its barrier hold leaves this above
+// zero; one that released twice would already have panicked inside
+// cancellableBarrier.RUnlock.
+func barrierReaders(db *Database) int {
+	db.commitBarrier.mu.Lock()
+	defer db.commitBarrier.mu.Unlock()
+	return db.commitBarrier.readers
+}
+
+// requireCommitBarrierFree proves no shared hold survives a terminal
+// path: the reader count is back to zero and the exclusive side can
+// actually be acquired. PauseCommits blocks forever against a leaked
+// reader, so it runs in a goroutine bounded by RequireReceive rather than
+// inline — a regression must fail fast instead of hanging the package.
+func requireCommitBarrierFree(t *testing.T, db *Database) {
+	t.Helper()
+	require.Zero(
+		t,
+		barrierReaders(db),
+		"terminal path leaked its commit barrier hold",
+	)
+	paused := make(chan func(), 1)
+	go func() {
+		paused <- db.PauseCommits()
+	}()
+	resume := testutil.RequireReceive(
+		t,
+		paused,
+		5*time.Second,
+		"PauseCommits must acquire the barrier after a terminal path",
+	)
+	resume()
+}
+
+// TestFailedBlobSyncDoesNotBlockTheNextWriter is the regression this
+// commit fixes. Commit's blob-sync failure path marked the transaction
+// finished without releasing the commit barrier's shared side. Because
+// the release only ever happened under that finished flag, the caller's
+// deferred Rollback/Release was then a no-op, so the hold survived for
+// the process's lifetime: the next PauseCommits (database/lifecycle's
+// Snapshot, Restore, and Truncate all take it) waited forever for a
+// reader that would never release, and writer preference then blocked
+// every read-write Txn constructed behind it.
+func TestFailedBlobSyncDoesNotBlockTheNextWriter(t *testing.T) {
+	syncErr := errors.New("fsync failed")
+	store := &mockBlobStore{syncErr: syncErr}
+	db := newCommitBarrierTestDB(t, store)
+
+	txn := db.Transaction(true)
+	require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+	err := txn.Commit()
+	require.ErrorIs(t, err, types.ErrPartialCommit)
+	require.ErrorIs(t, err, syncErr)
+	// What a caller's defer does. It cannot repair the leak: rollback
+	// returns early on an already-finished transaction.
+	txn.Release()
+
+	requireCommitBarrierFree(t, db)
+
+	// The next writer must still be able to open and commit.
+	store.syncErr = nil
+	next := make(chan *Txn, 1)
+	go func() {
+		next <- db.Transaction(true)
+	}()
+	nextTxn := testutil.RequireReceive(
+		t,
+		next,
+		5*time.Second,
+		"a new read-write Txn must open after a failed blob sync",
+	)
+	require.NoError(t, db.SetTip(syncBarrierTestTip(), nextTxn))
+	require.NoError(t, nextTxn.Commit())
+	requireCommitBarrierFree(t, db)
+}
+
+// TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce audits every way a
+// Txn can end, not just the blob-sync failure that motivated the fix.
+// Each case runs its terminal path and then calls Rollback and Release
+// again: a path that releases the barrier twice drives the reader count
+// negative, which cancellableBarrier.RUnlock panics on, so the "exactly
+// once" invariant is checked in both directions.
+func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
+	injected := errors.New("injected failure")
+
+	for _, tc := range []struct {
+		name string
+		// newDB builds the database for the case.
+		newDB func(t *testing.T) *Database
+		// run performs the terminal path and returns the Txn it ended,
+		// so the shared double-release check below can re-terminate it.
+		run func(t *testing.T, db *Database) *Txn
+	}{
+		{
+			name: "successful combined commit",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+				require.NoError(t, txn.Commit())
+				return txn
+			},
+		},
+		{
+			name: "successful metadata-only commit",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.MetadataTxn(true)
+				require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+				require.NoError(t, txn.Commit())
+				return txn
+			},
+		},
+		{
+			name: "read-only commit",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(false)
+				require.NoError(t, txn.Commit())
+				return txn
+			},
+		},
+		{
+			name: "rollback",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+				require.NoError(t, txn.Rollback())
+				return txn
+			},
+		},
+		{
+			name: "release",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				txn.Release()
+				return txn
+			},
+		},
+		{
+			name: "commit timestamp failure",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &timestampFailingBlobStore{
+					mockBlobStore: &mockBlobStore{},
+					err:           injected,
+				})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+				err := txn.Commit()
+				require.ErrorIs(t, err, injected)
+				require.ErrorContains(
+					t,
+					err,
+					"failed to update commit timestamp",
+				)
+				return txn
+			},
+		},
+		{
+			name: "blob commit failure",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{
+					commitErrs: []error{injected},
+				})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+				err := txn.Commit()
+				require.ErrorIs(t, err, injected)
+				require.ErrorContains(t, err, "blob commit failed")
+				return txn
+			},
+		},
+		{
+			name: "blob sync failure",
+			newDB: func(t *testing.T) *Database {
+				return newCommitBarrierTestDB(t, &mockBlobStore{
+					syncErr: injected,
+				})
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				require.NoError(t, db.SetTip(syncBarrierTestTip(), txn))
+				err := txn.Commit()
+				require.ErrorIs(t, err, types.ErrPartialCommit)
+				require.ErrorIs(t, err, injected)
+				return txn
+			},
+		},
+		{
+			name: "partial commit: metadata commit failure",
+			newDB: func(t *testing.T) *Database {
+				logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+				return &Database{
+					blob:     &mockBlobStore{},
+					metadata: &commitFailingMetadata{err: injected},
+					logger:   logger,
+					config:   &Config{Logger: logger},
+				}
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				err := txn.Commit()
+				require.ErrorIs(t, err, types.ErrPartialCommit)
+				require.ErrorIs(t, err, injected)
+				return txn
+			},
+		},
+		{
+			name: "metadata-only commit failure",
+			newDB: func(t *testing.T) *Database {
+				logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+				return &Database{
+					metadata: &commitFailingMetadata{err: injected},
+					logger:   logger,
+					config:   &Config{Logger: logger},
+				}
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.MetadataTxn(true)
+				err := txn.Commit()
+				require.ErrorIs(t, err, injected)
+				require.ErrorContains(t, err, "metadata commit failed")
+				require.NotErrorIs(
+					t,
+					err,
+					types.ErrPartialCommit,
+					"no blob was committed, so this is not partial",
+				)
+				return txn
+			},
+		},
+		{
+			name: "no store available",
+			newDB: func(t *testing.T) *Database {
+				logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+				return &Database{
+					logger: logger,
+					config: &Config{Logger: logger},
+				}
+			},
+			run: func(t *testing.T, db *Database) *Txn {
+				txn := db.Transaction(true)
+				require.ErrorIs(
+					t,
+					txn.Commit(),
+					types.ErrNoStoreAvailable,
+				)
+				return txn
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := tc.newDB(t)
+			txn := tc.run(t, db)
+			requireCommitBarrierFree(t, db)
+			// Re-terminating an already finished Txn must not release a
+			// second time. RUnlock panics on an unmatched release, so a
+			// double release fails this test rather than silently
+			// unblocking a live PauseCommits elsewhere.
+			require.NoError(t, txn.Rollback())
+			txn.Release()
+			requireCommitBarrierFree(t, db)
+		})
+	}
+}
+
+// TestCommitBarrierSurvivesConcurrentFailingCommits pins the invariant
+// under concurrency, which is where a miscounted barrier actually bites:
+// the reader count must return to exactly zero after a batch of
+// read-write transactions that each fail their blob sync, so a
+// PauseCommits issued afterwards still acquires. A leak leaves the count
+// high; an over-release panics in RUnlock.
+func TestCommitBarrierSurvivesConcurrentFailingCommits(t *testing.T) {
+	store := &serializedBlobStore{
+		mockBlobStore: &mockBlobStore{syncErr: errors.New("fsync failed")},
+	}
+	db := newCommitBarrierTestDB(t, store)
+
+	const writers = 8
+	done := make(chan struct{}, writers)
+	for range writers {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			txn := db.Transaction(true)
+			defer txn.Release()
+			// The commit result is not asserted here: only one writer at
+			// a time holds the metadata write connection, so the others
+			// can fail earlier than the blob sync. Either way the
+			// barrier accounting must balance.
+			_ = txn.Commit()
+		}()
+	}
+	for range writers {
+		testutil.RequireReceive(
+			t,
+			done,
+			30*time.Second,
+			"every writer must finish its transaction",
+		)
+	}
+
+	requireCommitBarrierFree(t, db)
+}

--- a/database/txn_sync_test.go
+++ b/database/txn_sync_test.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
 	metadataSqlite "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlite"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -30,12 +31,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newSyncBarrierTestDB builds a Database pairing a mock blob store with a real
-// in-memory sqlite metadata store, which is the combination the combined-commit
-// durability barrier applies to.
+// newSyncBarrierTestDB builds a Database pairing the given blob store with a
+// real in-memory sqlite metadata store, which is the combination the
+// combined-commit durability barrier applies to. The parameter is the
+// interface so a case can inject a store whose Sync or SetCommitTimestamp
+// fails without changing the shared mockBlobStore.
 func newSyncBarrierTestDB(
 	t *testing.T,
-	store *mockBlobStore,
+	store blob.BlobStore,
 ) *Database {
 	t.Helper()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))


### PR DESCRIPTION
Closes #3276.

`Txn.Commit`'s blob-sync failure path set `t.finished = true` and returned without `releaseCommitBarrierLocked()`. Because `finished` also short-circuits `rollback()`, the caller's deferred `Release()` could not repair it, so the shared barrier hold leaked for the process lifetime.

Every terminal path out of `Commit` and `rollback` was audited, not just the one the issue named. Only the blob-sync path leaked, and no path could double-release. `database/lifecycle/snapshot.go` is the only non-test consumer of the barrier: after a single failed `Sync`, every later snapshot fails permanently, and each attempt stalls read-write `Txn` construction behind the queued writer.

New `Txn.finishLocked()` sets `finished` and releases the barrier together, and all terminal sites route through it. `releaseCommitBarrierLocked` clears `barrierHeld` before `RUnlock`, so exactly-once holds structurally rather than by inspection.

Tests:

- `TestFailedBlobSyncDoesNotBlockTheNextWriter` — forced sync failure, then `Release()` to prove it cannot repair the leak, then `PauseCommits` must acquire and a second writer must open and commit. Bounded by `testutil.RequireReceive` so a regression fails fast instead of hanging the package.
- `TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce` — 11 subtests covering commit, rollback, release, read-only, metadata-only, both partial-commit variants, blob-commit failure, timestamp failure, and no-store. Each re-terminates the `Txn`, so an over-release trips `RUnlock`'s panic.
- `TestCommitBarrierSurvivesConcurrentFailingCommits` — 8 concurrent writers all failing their sync; the reader count must return to exactly 0.

DATABASE.md updated in the Cross-Store Durability Contract section. ARCHITECTURE.md checked: line 1669 already asserts the barrier is held from construction through `Commit`/`Rollback`/`Release`, which the blob-sync path violated and now honors, so the documented contract needed no change.

Not addressed here: a panic inside `Commit` while `t.lock` is held leaves both the mutex and the barrier held, and `Do`'s recover then self-deadlocks in `Rollback`. That predates the barrier and applies to every panicking store call; fixing it means restructuring `Commit` around a deferred unlock, which changes `dispatchAfterCommit` sequencing. Tracked in #3302.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases the commit barrier on every terminal transaction path to prevent leaked holds that stalled snapshots and blocked writers. Previously, the blob-sync failure path set `finished` without releasing; now all terminal exits call `finishLocked`, which sets `finished` and releases exactly once.

- Replaces direct `finished`/release calls in `Commit` and `rollback` with `finishLocked`; `releaseCommitBarrierLocked` clears `barrierHeld` before `RUnlock` so repeat calls are no-ops, not panics.
- Audits all terminal paths; only the blob-sync path leaked before, and no path can double-release after this change.
- Impact: after a failed blob `Sync`, `PauseCommits` acquires normally and subsequent read-write `Txn`s open/commit as expected. `database/lifecycle/snapshot.go` no longer stalls after a single failed sync.
- Tests: `TestFailedBlobSyncDoesNotBlockTheNextWriter`, `TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce`, and `TestCommitBarrierSurvivesConcurrentFailingCommits`.
- Docs: `DATABASE.md` updated in Cross-Store Durability Contract; `ARCHITECTURE.md` already described the intended invariant and needed no change.
- Not addressed: a panic inside `Commit` while holding `t.lock` still leaves the mutex and barrier held; fixing requires restructuring around a deferred unlock and revisiting `dispatchAfterCommit` sequencing.

<sup>Written for commit e91a043999415f472a57633a99157e25ddea0601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


