### PR TITLE
fix(ledger): halt on unrepairable trust-window validation failures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3057,6 +3057,48 @@ no rewind can fix) rather than a peer/fork problem, it surfaces the
 operator warning; a node in this state needs the underlying validation
 divergence resolved.
 
+Both recovery paths refuse a rewind target below the Mithril anchor, and that
+refusal has its own terminal bound (issues #3261 and #3301). Refusing rewinds
+instead to the applied ledger tip and asks ChainSync for a fresh intersection,
+which is an escape only while some peer offers a different chain; for a
+canonical block every peer offers the same one. When the failing block sits a
+short distance past the anchor, every target the rewind schedule produces falls
+inside the protected window, so the refusal fires on all of them and the node
+cycles the peer set indefinitely without moving its tip.
+`observeMithrilBoundaryRejection` therefore tallies successful boundary
+recovery attempts that do not advance the applied ledger high-water mark and,
+once they exceed
+`maxMithrilBoundaryRecoveryRejections` — one per scheduled rewind depth plus
+the capped retry the schedule settles on — declares the failure unrepairable.
+The applied tip, not the reported failing `(block, tx)`, is the convergence
+signal: replay can report different slowly advancing failures while rebuilding
+to the same state, and changing identities must not rearm the budget. A local
+rollback error does not count because no replay attempt completed.
+This is a decision about repairability rather than a list of error types:
+recovery's only lever for any validation rule is to rewind and replay, so once
+every legal target has been replayed and returned the same verdict, no local
+history remains that could change it. A Conway rule 45 delegation failure
+against imported account state reaches that point exactly as a structural error
+would. Deepening the rewind to the anchor itself is not an alternative: it costs
+a full replay of the protected window and still reads the same imported state.
+Exhaustion increments
+`dingo_ledger_mithril_trust_window_unrepairable_total`, logs the operator
+action (re-bootstrap from a newer Mithril snapshot, or resync from genesis) at
+ERROR, and returns `errHaltLedgerPipeline`. The tally clears when block
+application advances past the applied high-water mark, so a wedge broken by
+peer rotation leaves a later failure a fresh budget.
+
+`errHaltLedgerPipeline` is terminal in `ledgerProcessBlocks`: the restart loop
+announces the halt at ERROR, sets `dingo_ledger_pipeline_halted`, and returns,
+so the pipeline goroutine exits and `Close` still joins it through
+`processBlocksWG`. The node keeps serving queries and metrics, which is why the
+gauge matters — nothing clears it, so it, and not the absence of new log lines,
+is the signal that the node has permanently stopped following the chain. The
+loop body lives in `ledgerProcessBlocksWithAttempt` with the per-attempt work
+injected, so back-off, announcement, and halt decisions are testable without a
+chain reader and block pipeline behind them. Recovery raises the halt; the
+ledger neither denies peers nor stops the node itself.
+
 Topology configuration is loaded from an explicit topology file when provided,
 otherwise from the embedded `network/topology.json` for built-in networks,
 falling back to the legacy network bootstrap-peer list only when no embedded
@@ -7810,14 +7852,20 @@ the pipeline neither recovers nor stops. After `noProgressStuckThreshold`
 consecutive no-progress
 restarts the loop treats the failure as deterministic rather than
 transient, escalating the wait beyond the transient ceiling (bounded by
-`noProgressStuckBackoffMax`), logging the transition once at ERROR, and
+`noProgressStuckBackoffMax`), announcing the condition at ERROR, and
 exporting `dingo_ledger_pipeline_stuck` alongside
 `dingo_ledger_pipeline_no_progress_restarts` so a node that has silently
 stopped following the chain is visible to monitoring instead of only to
 whoever reads a repeating WARN. Both reset as soon as the tip advances.
+The announcement is not once-only: `pipelineStuckShouldAnnounce` repeats it
+every `noProgressStuckReannounceInterval` further no-progress restarts, roughly
+every ten minutes at the stuck backoff ceiling. Announcing the transition alone
+and then dropping to WARN left log-level alerting seeing a wedged node as
+healthy — one ERROR line covered eighteen hours in the field, buried among
+unrelated warnings (issue #3261).
 This still changes only the retry rate and the operator signal, never
 whether a block is accepted — a node wedged on a rejected block is equally
-wedged either way, but it now says so once, loudly, and stops spinning.
+wedged either way, but it now keeps saying so, loudly, and stops spinning.
 
 ### CIP-0163 Bookkeeping Shared Between Ledger Rollback and Lifecycle Truncate
 

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -82,6 +82,17 @@ type stateMetrics struct {
 	// wedged node is visible only as a repeating WARN. See issue #3165.
 	pipelineNoProgressRestarts prometheus.Gauge
 	pipelineStuck              prometheus.Gauge
+	// Set to 1 once the ledger pipeline has stopped retrying altogether.
+	// Unlike pipelineStuck this is terminal: the pipeline goroutine has
+	// returned and nothing will clear it short of a restart, so it is the
+	// signal to alert on for a node that has permanently stopped following
+	// the chain. See issue #3261.
+	pipelineHalted prometheus.Gauge
+	// Incremented when validation recovery declares a failure unrepairable
+	// because every rewind target it may legally reach lies inside the
+	// Mithril protected window. Each increment is one node that can no
+	// longer follow the chain without being re-bootstrapped.
+	mithrilTrustWindowUnrepairable prometheus.Counter
 	// Incremented for each epoch-boundary reward round that could not be
 	// applied because one of its inputs was absent. Every increment leaves
 	// reward balances -- and the leadership stake derived from them --
@@ -180,6 +191,24 @@ func (m *stateMetrics) incBlockPipelineUnexpectedError() {
 		return
 	}
 	m.blockPipelineUnexpectedErrors.Inc()
+}
+
+// setPipelineHalted records that the ledger pipeline has stopped retrying.
+// Terminal by design: nothing clears it, because nothing restarts the pipeline.
+func (m *stateMetrics) setPipelineHalted() {
+	if m == nil || m.pipelineHalted == nil {
+		return
+	}
+	m.pipelineHalted.Set(1)
+}
+
+// incMithrilTrustWindowUnrepairable records a validation failure that no legal
+// rewind can repair because the trust anchor blocks every deeper target.
+func (m *stateMetrics) incMithrilTrustWindowUnrepairable() {
+	if m == nil || m.mithrilTrustWindowUnrepairable == nil {
+		return
+	}
+	m.mithrilTrustWindowUnrepairable.Inc()
 }
 
 func (m *stateMetrics) setPipelineNoProgress(restarts int, stuck bool) {
@@ -373,6 +402,18 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.GaugeOpts{
 			Name: "dingo_ledger_pipeline_stuck",
 			Help: "1 while the ledger pipeline has restarted without tip progress often enough to be treated as stuck on a deterministic failure (operator intervention required), 0 otherwise",
+		},
+	)
+	m.pipelineHalted = promautoFactory.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "dingo_ledger_pipeline_halted",
+			Help: "1 once the ledger pipeline has stopped retrying on an unrepairable validation failure; terminal, so the node is no longer following the chain and requires operator intervention",
+		},
+	)
+	m.mithrilTrustWindowUnrepairable = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_ledger_mithril_trust_window_unrepairable_total",
+			Help: "validation failures declared unrepairable because every legal rewind target lay inside the Mithril protected window; the state the failing block needs predates the anchor and cannot be re-derived without crossing it",
 		},
 	)
 	m.blockPipelineBlocksDecoded = promautoFactory.NewGauge(

--- a/ledger/pipeline_halt_test.go
+++ b/ledger/pipeline_halt_test.go
@@ -68,7 +68,7 @@ func TestLedgerProcessBlocksStopsRetryingOnUnrepairableFailure(t *testing.T) {
 	testutil.RequireReceive(
 		t,
 		done,
-		10*time.Second,
+		5*time.Second,
 		"an unrepairable validation failure must stop the ledger pipeline",
 	)
 
@@ -109,7 +109,7 @@ func TestLedgerProcessBlocksKeepsRetryingRecoverableFailures(t *testing.T) {
 	testutil.WaitForCondition(
 		t,
 		func() bool { return attempts.Load() >= 3 },
-		10*time.Second,
+		5*time.Second,
 		"a recoverable failure must keep restarting the pipeline",
 	)
 	assert.Zero(
@@ -122,7 +122,7 @@ func TestLedgerProcessBlocksKeepsRetryingRecoverableFailures(t *testing.T) {
 	testutil.RequireReceive(
 		t,
 		done,
-		10*time.Second,
+		5*time.Second,
 		"the pipeline loop must exit when its context is cancelled",
 	)
 }

--- a/ledger/pipeline_halt_test.go
+++ b/ledger/pipeline_halt_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPipelineLoopLedger(t *testing.T) *LedgerState {
+	t.Helper()
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+	return ls
+}
+
+// TestLedgerProcessBlocksStopsRetryingOnUnrepairableFailure covers the terminal
+// half of issue #3261. Recovery raises errHaltLedgerPipeline once it has
+// established that no local replay can change a block's verdict; the restart
+// loop must then stop rather than restart into the same block forever, and must
+// leave a terminal signal behind for an operator.
+func TestLedgerProcessBlocksStopsRetryingOnUnrepairableFailure(t *testing.T) {
+	ls := newPipelineLoopLedger(t)
+
+	var attempts atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ls.ledgerProcessBlocksWithAttempt(
+			t.Context(),
+			func(context.Context) error {
+				attempts.Add(1)
+				return fmt.Errorf(
+					"process block batch: %w",
+					errHaltLedgerPipeline,
+				)
+			},
+		)
+	}()
+	testutil.RequireReceive(
+		t,
+		done,
+		10*time.Second,
+		"an unrepairable validation failure must stop the ledger pipeline",
+	)
+
+	assert.Equal(
+		t,
+		int64(1),
+		attempts.Load(),
+		"a halted pipeline must not run another attempt",
+	)
+	assert.Equal(
+		t,
+		1.0,
+		promtestutil.ToFloat64(ls.metrics.pipelineHalted),
+		"a halted pipeline must report its terminal state",
+	)
+}
+
+// TestLedgerProcessBlocksKeepsRetryingRecoverableFailures is the negative case:
+// an ordinary failure must keep restarting the pipeline. Treating every failure
+// as terminal would turn a transient database or peer problem into an outage.
+func TestLedgerProcessBlocksKeepsRetryingRecoverableFailures(t *testing.T) {
+	ls := newPipelineLoopLedger(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var attempts atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ls.ledgerProcessBlocksWithAttempt(
+			ctx,
+			func(context.Context) error {
+				attempts.Add(1)
+				return errors.New("transient read failure")
+			},
+		)
+	}()
+	testutil.WaitForCondition(
+		t,
+		func() bool { return attempts.Load() >= 3 },
+		10*time.Second,
+		"a recoverable failure must keep restarting the pipeline",
+	)
+	assert.Zero(
+		t,
+		promtestutil.ToFloat64(ls.metrics.pipelineHalted),
+		"a retrying pipeline must not report itself halted",
+	)
+
+	cancel()
+	testutil.RequireReceive(
+		t,
+		done,
+		10*time.Second,
+		"the pipeline loop must exit when its context is cancelled",
+	)
+}
+
+// TestPipelineStuckAnnouncementStaysVisible covers the third ask of issue
+// #3261. The stuck condition was announced at ERROR exactly once and then only
+// at WARN, so a node that had stopped following the chain looked quiet to
+// log-level alerting for as long as it stayed wedged.
+func TestPipelineStuckAnnouncementStaysVisible(t *testing.T) {
+	for consecutive := range noProgressStuckThreshold {
+		assert.False(
+			t,
+			pipelineStuckShouldAnnounce(consecutive),
+			"restart %d is not stuck yet and must not announce",
+			consecutive,
+		)
+	}
+	assert.True(
+		t,
+		pipelineStuckShouldAnnounce(noProgressStuckThreshold),
+		"the transition into stuck must be announced",
+	)
+
+	announcements := 0
+	for consecutive := noProgressStuckThreshold; consecutive <= noProgressStuckThreshold+
+		4*noProgressStuckReannounceInterval; consecutive++ {
+		if pipelineStuckShouldAnnounce(consecutive) {
+			announcements++
+		}
+	}
+	assert.Equal(
+		t,
+		5,
+		announcements,
+		"a persistently stuck pipeline must keep announcing itself at a fixed cadence",
+	)
+}
+
+// TestResetMithrilBoundaryRejectionsRequiresAppliedTipProgress verifies that
+// the trust-window tally is keyed on applied ledger progress rather than on a
+// reported failing-block identity. Replay can report changing failures while
+// rebuilding to the same applied tip; those are still one non-converging run.
+func TestResetMithrilBoundaryRejectionsRequiresAppliedTipProgress(
+	t *testing.T,
+) {
+	ls := &LedgerState{}
+
+	rejections, exhausted := ls.observeMithrilBoundaryRejection(500)
+	require.Equal(t, 1, rejections)
+	require.False(t, exhausted)
+
+	// Replaying to the same or an older applied tip is not progress.
+	ls.resetMithrilBoundaryRejections(500)
+	rejections, exhausted = ls.observeMithrilBoundaryRejection(499)
+	require.Equal(t, 2, rejections)
+	require.False(t, exhausted)
+
+	// Advancing the applied high-water mark is real progress and starts a
+	// later recovery run with a fresh budget.
+	ls.resetMithrilBoundaryRejections(501)
+	rejections, exhausted = ls.observeMithrilBoundaryRejection(501)
+	assert.Equal(t, 1, rejections)
+	assert.False(t, exhausted)
+
+	// Every scheduled rewind depth refused, plus the capped retry the
+	// schedule settles on: the legal rewind space is exhausted.
+	for rejections < maxMithrilBoundaryRecoveryRejections {
+		rejections, exhausted = ls.observeMithrilBoundaryRejection(501)
+		require.False(
+			t,
+			exhausted,
+			"%d refusals is still inside the bound",
+			rejections,
+		)
+	}
+	_, exhausted = ls.observeMithrilBoundaryRejection(501)
+	require.True(
+		t,
+		exhausted,
+		"the tally must be exhausted once every legal rewind depth has been refused",
+	)
+}

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -98,6 +98,25 @@ const maxAtTipRecoveryDescents = 2
 // ChainSync connection (issue #3005).
 const maxReplayRecoveryNoProgress = 2
 
+// maxMithrilBoundaryRecoveryRejections bounds how many successful validation
+// recovery attempts may refuse a rewind at the Mithril trust boundary without
+// advancing the applied ledger tip before the failure is declared
+// unrepairable (issues #3261 and #3301).
+//
+// The bound covers the whole legal rewind space. A boundary rejection rewinds
+// to the applied ledger tip -- the deepest point recovery may reach without
+// crossing the anchor -- and asks ChainSync for a fresh intersection, so one
+// rejection per scheduled rewind depth exhausts every target the schedule can
+// produce, plus one for the capped retry the schedule settles on. Past that,
+// every legal target has been replayed and returned the same verdict.
+const maxMithrilBoundaryRecoveryRejections = maxAtTipRecoveryAttempts + 1
+
+type mithrilBoundaryRecoveryProgress struct {
+	highWaterTipSlot uint64
+	rejections       int
+	halted           bool
+}
+
 type atTipRecoveryAttempt struct {
 	BlockPoint ocommon.Point
 	TxHash     []byte
@@ -504,6 +523,7 @@ func (ls *LedgerState) rejectReplayRecoveryAtMithrilBoundary(
 ) error {
 	return ls.rejectRecoveryAtMithrilBoundary(
 		"replay recovery rollback exceeds Mithril trust boundary",
+		validationErr,
 		func(mithrilLedgerSlot uint64, rewindPoint ocommon.Point) {
 			ls.config.Logger.Warn(
 				"detected replay recovery below Mithril trust boundary, rejecting peer chain",
@@ -745,6 +765,7 @@ func (ls *LedgerState) rejectAtTipRecoveryAtMithrilBoundary(
 ) error {
 	return ls.rejectRecoveryAtMithrilBoundary(
 		"at-tip recovery rollback exceeds Mithril trust boundary",
+		validationErr,
 		func(mithrilLedgerSlot uint64, rewindPoint ocommon.Point) {
 			ls.config.Logger.Warn(
 				"at-tip validation recovery would cross Mithril trust boundary, rejecting peer chain",
@@ -781,8 +802,74 @@ func (ls *LedgerState) rejectAtTipRecoveryAtMithrilBoundary(
 	)
 }
 
+// observeMithrilBoundaryRejection tallies consecutive successful boundary
+// recovery attempts that do not advance the applied ledger high-water mark and
+// reports whether the legal rewind space is exhausted.
+//
+// This is the repairability decision for a validation failure, and it is
+// deliberately not a list of error types (issue #3261). Recovery has exactly
+// one lever for any validation rule: rewind below the failing block and replay,
+// so the ledger re-derives the state that block reads. The Mithril trust
+// boundary is a hard floor on that lever -- blocks at or below
+// mithrilLedgerSlot were accepted on certificate evidence rather than replay,
+// so their state cannot be re-derived at all. When the failing block sits only
+// a short distance past the anchor, every target the rewind schedule produces
+// falls inside the protected window and is refused; the only legal target left
+// is the applied ledger tip, which each refusal already rewinds to. Once that
+// has been replayed for every scheduled depth and the same failure comes back,
+// no local history remains that could change the verdict, whatever rule
+// rejected the block -- a Conway rule 45 delegation failure against imported
+// account state reaches this point exactly as a structural error would.
+//
+// The escape a refusal offers is peer rotation, and that is what makes the loop
+// unbounded rather than merely slow: it cannot help when the block is
+// canonical, because the next peer serves the same block. Deepening the rewind
+// to the anchor itself is not an alternative -- it costs a full replay of the
+// protected window and still reads the same imported state.
+//
+// The applied tip is the convergence signal rather than the failing block or
+// transaction identity. Replay can encounter different, slowly advancing
+// failures while rebuilding to the same applied tip; rearming the budget on
+// each identity would let that sequence retry forever (issue #3301).
+//
+// Runs on the ledger pipeline goroutine, like its at-tip and replay siblings,
+// so the tally needs no additional locking. Callers record an attempt only
+// after the local rewind succeeds, so a rollback mechanics error cannot consume
+// the validation-recovery budget.
+func (ls *LedgerState) observeMithrilBoundaryRejection(
+	tipSlot uint64,
+) (int, bool) {
+	if ls.mithrilBoundaryRecovery == nil ||
+		tipSlot > ls.mithrilBoundaryRecovery.highWaterTipSlot {
+		ls.mithrilBoundaryRecovery = &mithrilBoundaryRecoveryProgress{
+			highWaterTipSlot: tipSlot,
+			rejections:       1,
+		}
+	} else {
+		ls.mithrilBoundaryRecovery.rejections++
+	}
+	rejections := ls.mithrilBoundaryRecovery.rejections
+	if rejections > maxMithrilBoundaryRecoveryRejections {
+		ls.mithrilBoundaryRecovery.halted = true
+	}
+	return rejections, ls.mithrilBoundaryRecovery.halted
+}
+
+// resetMithrilBoundaryRejections clears the boundary-rejection tally once the
+// applied ledger tip advances beyond the high-water mark the refusals could
+// not cross. Peer rotation found a chain this node can follow, so the trust
+// window is no longer wedged and a later failure starts with a fresh budget.
+func (ls *LedgerState) resetMithrilBoundaryRejections(newTipSlot uint64) {
+	if ls.mithrilBoundaryRecovery == nil ||
+		newTipSlot <= ls.mithrilBoundaryRecovery.highWaterTipSlot {
+		return
+	}
+	ls.mithrilBoundaryRecovery = nil
+}
+
 func (ls *LedgerState) rejectRecoveryAtMithrilBoundary(
 	errContext string,
+	validationErr *txValidationError,
 	logRejection func(mithrilLedgerSlot uint64, rewindPoint ocommon.Point),
 ) error {
 	ls.RLock()
@@ -796,12 +883,46 @@ func (ls *LedgerState) rejectRecoveryAtMithrilBoundary(
 			ErrRollbackExceedsMithrilBoundary,
 		)
 	}
+	if ls.mithrilBoundaryRecovery != nil &&
+		ls.mithrilBoundaryRecovery.halted {
+		return fmt.Errorf("%s: %w", errContext, errHaltLedgerPipeline)
+	}
 	logRejection(mithrilLedgerSlot, rewindPoint)
 	if err := ls.rollbackPrimaryChainInSecurityParamWindows(rewindPoint); err != nil {
 		return fmt.Errorf(
 			"rewind primary chain to Mithril trust boundary: %w",
 			err,
 		)
+	}
+	rejections, exhausted := ls.observeMithrilBoundaryRejection(
+		rewindPoint.Slot,
+	)
+	if exhausted {
+		ls.metrics.incMithrilTrustWindowUnrepairable()
+		ls.config.Logger.Error(
+			"validation failure inside the Mithril trust window cannot be repaired by replaying local history, halting ledger pipeline",
+			"component",
+			"ledger",
+			"tx_hash",
+			hex.EncodeToString(validationErr.TxHash),
+			"failing_block_slot",
+			validationErr.BlockPoint.Slot,
+			"failing_block_hash",
+			hex.EncodeToString(validationErr.BlockPoint.Hash),
+			"ledger_tip_slot",
+			rewindPoint.Slot,
+			"ledger_tip_hash",
+			hex.EncodeToString(rewindPoint.Hash),
+			"mithril_ledger_slot",
+			mithrilLedgerSlot,
+			"boundary_rejections",
+			rejections,
+			"error",
+			validationErr.Cause,
+			"hint",
+			"the node has stopped following the chain; the state this block needs was established at or before the Mithril anchor and cannot be re-derived without crossing it, so re-bootstrap from a newer Mithril snapshot or resync from genesis",
+		)
+		return fmt.Errorf("%s: %w", errContext, errHaltLedgerPipeline)
 	}
 	ls.chainsyncMutex.Lock()
 	ls.resetChainsyncResyncState()

--- a/ledger/replay_recovery_trust_window_test.go
+++ b/ledger/replay_recovery_trust_window_test.go
@@ -1,0 +1,384 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/event"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trustWindowLedger is a LedgerState sitting at tip with a Mithril trust
+// anchor, plus the resync events its recovery publishes.
+type trustWindowLedger struct {
+	ls        *LedgerState
+	ledgerTip ochainsync.Tip
+	failing   *txValidationError
+	resyncs   chan event.ChainsyncResyncEvent
+}
+
+// newTrustWindowLedger builds the shape of issue #3261: the applied ledger tip
+// sits exactly on the Mithril trust anchor and the failing block is a short
+// distance past it, so the only rewind target at or above the anchor is the tip
+// itself. Every deeper target the at-tip recovery schedule produces lands on
+// the one earlier block, far below the anchor, and is refused by the trust
+// boundary guard.
+func newTrustWindowLedger(
+	t *testing.T,
+	anchorSlot uint64,
+) *trustWindowLedger {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	parentBlock := testRawBlock("trust-window-parent", 100, 1, nil)
+	ledgerTipBlock := testRawBlock(
+		"trust-window-ledger-tip",
+		200000,
+		2,
+		parentBlock.Hash,
+	)
+	failingBlock := testRawBlock(
+		"trust-window-failing",
+		200020,
+		3,
+		ledgerTipBlock.Hash,
+	)
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks([]chain.RawBlock{
+		parentBlock,
+		ledgerTipBlock,
+		failingBlock,
+	}))
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	resyncs := make(chan event.ChainsyncResyncEvent, 64)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			resync, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncs <- resync:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+	activeConnId := ouroboros.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 32610},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(192, 0, 2, 61), Port: 32611},
+	}
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		EventBus:          bus,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		GetActiveConnectionFunc: func() *ouroboros.ConnectionId {
+			return &activeConnId
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(ls))
+	ls.metrics.init(prometheus.NewRegistry())
+
+	ledgerTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			ledgerTipBlock.Slot,
+			ledgerTipBlock.Hash,
+		),
+		BlockNumber: ledgerTipBlock.BlockNumber,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+	ls.currentTip = ledgerTip
+	ls.currentTipBlockNonce = []byte("nonce-trust-window-tip")
+	ls.mithrilLedgerSlot = anchorSlot
+	ls.validationEnabled = true
+	ls.reachedTip.Store(true)
+	ls.publishSnapshotsLocked()
+	producerTxHash := testHashBytes("trust-window-producer-tx")
+	seedReplayRecoveryTransaction(
+		t,
+		db,
+		producerTxHash,
+		parentBlock.Hash,
+		parentBlock.Slot,
+	)
+
+	return &trustWindowLedger{
+		ls:        ls,
+		ledgerTip: ledgerTip,
+		resyncs:   resyncs,
+		failing: &txValidationError{
+			BlockPoint: ocommon.NewPoint(
+				failingBlock.Slot,
+				failingBlock.Hash,
+			),
+			TxHash: testHashBytes("trust-window-failing-tx"),
+			Inputs: []lcommon.TransactionInput{
+				&replayRecoveryInput{
+					txId:  producerTxHash,
+					index: 0,
+				},
+			},
+			// Conway rule 45. Deterministic in the same sense as a
+			// duplicate input, but state-dependent, so no fixed error
+			// list classifies it.
+			Cause: errors.New(
+				"conway certificate rule 45: delegate to an unregistered stake credential",
+			),
+		},
+	}
+}
+
+func (f *trustWindowLedger) drainResyncs() int {
+	count := 0
+	for {
+		select {
+		case <-f.resyncs:
+			count++
+		default:
+			return count
+		}
+	}
+}
+
+// TestAtTipRecoveryInsideMithrilTrustWindowReachesTerminalState covers issue
+// #3261: when every rewind target the at-tip recovery schedule produces lies
+// inside the Mithril protected window, the trust boundary guard refuses all of
+// them. Each refusal rewinds to the applied tip and asks ChainSync for a fresh
+// intersection, which cannot help for a canonical block -- every peer serves
+// the same one. Recovery must therefore stop and surface a terminal condition
+// instead of rejecting peers forever.
+func TestAtTipRecoveryInsideMithrilTrustWindowReachesTerminalState(
+	t *testing.T,
+) {
+	// Anchor exactly at the applied tip: rewinding to the tip is legal,
+	// everything deeper is not.
+	fixture := newTrustWindowLedger(t, 200000)
+
+	const maxAttempts = 32
+	halted := false
+	recoveries := 0
+	for range maxAttempts {
+		recovered, err := fixture.ls.tryRecoverFromTxValidationError(
+			fixture.failing,
+		)
+		if err != nil {
+			require.ErrorIs(
+				t,
+				err,
+				errHaltLedgerPipeline,
+				"the only terminal error recovery may raise is a pipeline halt",
+			)
+			assert.False(
+				t,
+				recovered,
+				"a halted recovery must not report itself recovered",
+			)
+			halted = true
+			break
+		}
+		require.True(t, recovered)
+		recoveries++
+	}
+	require.True(
+		t,
+		halted,
+		"recovery inside the Mithril trust window must reach a terminal state, not retry forever",
+	)
+	assert.Less(
+		t,
+		recoveries,
+		maxAttempts,
+		"the terminal state must be reached in a bounded number of attempts",
+	)
+	assert.Positive(
+		t,
+		recoveries,
+		"the existing recovery path must be tried before declaring a halt",
+	)
+
+	// The terminal state is sticky and quiet: further deliveries of the same
+	// block keep halting and must not ask for yet another fresh intersection.
+	fixture.drainResyncs()
+	for range 3 {
+		recovered, err := fixture.ls.tryRecoverFromTxValidationError(
+			fixture.failing,
+		)
+		assert.False(t, recovered)
+		require.ErrorIs(t, err, errHaltLedgerPipeline)
+	}
+	assert.Zero(
+		t,
+		fixture.drainResyncs(),
+		"a halted recovery must not keep rotating peers",
+	)
+}
+
+// TestAtTipRecoveryAboveMithrilTrustWindowKeepsRecovering is the negative case.
+// A failure whose rewind targets stay at or above the trust anchor is still
+// repairable by replaying a different local history, so it must keep taking the
+// existing recovery path however often it repeats. Short-circuiting it into a
+// halt would turn an ordinary fork-selection problem into an outage.
+func TestAtTipRecoveryAboveMithrilTrustWindowKeepsRecovering(t *testing.T) {
+	// Anchor far below the earliest block, so no rewind target the schedule
+	// produces is ever refused by the trust boundary guard.
+	fixture := newTrustWindowLedger(t, 50)
+
+	for i := range 32 {
+		recovered, err := fixture.ls.tryRecoverFromTxValidationError(
+			fixture.failing,
+		)
+		require.NoError(
+			t,
+			err,
+			"attempt %d: a repairable failure must not halt the pipeline",
+			i+1,
+		)
+		require.True(t, recovered, "attempt %d must still recover", i+1)
+	}
+}
+
+// TestReplayRecoveryBelowMithrilTrustBoundaryReachesTerminalState covers the
+// post-bootstrap replay path from issue #3301. The producer is canonical but
+// below the imported anchor, so its parent can never be a legal local rewind
+// target. Changing failing block/transaction identities must not rearm the
+// budget while the applied tip remains fixed; replay failures can creep
+// forward in exactly that shape.
+func TestReplayRecoveryBelowMithrilTrustBoundaryReachesTerminalState(
+	t *testing.T,
+) {
+	fixture := newTrustWindowLedger(t, 200000)
+	fixture.ls.reachedTip.Store(false)
+
+	var halted bool
+	for attempt := range maxMithrilBoundaryRecoveryRejections + 2 {
+		failure := *fixture.failing
+		failure.BlockPoint = ocommon.NewPoint(
+			fixture.failing.BlockPoint.Slot+uint64(attempt),
+			testHashBytes(fmt.Sprintf("replay-failing-block-%d", attempt)),
+		)
+		failure.TxHash = testHashBytes(
+			fmt.Sprintf("replay-failing-tx-%d", attempt),
+		)
+
+		recovered, err := fixture.ls.tryRecoverFromTxValidationError(&failure)
+		if errors.Is(err, errHaltLedgerPipeline) {
+			assert.False(t, recovered)
+			halted = true
+			break
+		}
+		require.NoError(t, err)
+		require.True(t, recovered)
+	}
+	require.True(
+		t,
+		halted,
+		"replay recovery must halt even when failure identities vary at a fixed applied tip",
+	)
+	assert.Equal(t, fixture.ledgerTip, fixture.ls.currentTip)
+	assert.Equal(
+		t,
+		1.0,
+		promtestutil.ToFloat64(
+			fixture.ls.metrics.mithrilTrustWindowUnrepairable,
+		),
+		"the terminal replay state must be operator-visible",
+	)
+}
+
+// TestMithrilBoundaryRollbackFailureDoesNotConsumeRecoveryBudget covers the
+// chain-selection race called out in review: a local rollback failure is not a
+// successful replay attempt and must not count toward declaring validation
+// unrepairable.
+func TestMithrilBoundaryRollbackFailureDoesNotConsumeRecoveryBudget(
+	t *testing.T,
+) {
+	fixture := newTrustWindowLedger(t, 200000)
+
+	// Establish one successful boundary recovery, which removes the failing
+	// block from the primary chain while keeping its point available to this
+	// synthetic validation error.
+	require.NoError(
+		t,
+		fixture.ls.rejectRecoveryAtMithrilBoundary(
+			"test boundary recovery",
+			fixture.failing,
+			func(uint64, ocommon.Point) {},
+		),
+	)
+	require.Equal(
+		t,
+		1,
+		fixture.ls.mithrilBoundaryRecovery.rejections,
+	)
+
+	// Model chain selection moving off the captured ledger tip before the
+	// local rollback begins. The point no longer exists on the primary chain,
+	// so every attempt fails in rollback mechanics rather than completing a
+	// validation-recovery replay.
+	fixture.ls.currentTip = ochainsync.Tip{Point: fixture.failing.BlockPoint}
+	for range maxMithrilBoundaryRecoveryRejections + 2 {
+		err := fixture.ls.rejectRecoveryAtMithrilBoundary(
+			"test boundary recovery",
+			fixture.failing,
+			func(uint64, ocommon.Point) {},
+		)
+		require.Error(t, err)
+		require.NotErrorIs(
+			t,
+			err,
+			errHaltLedgerPipeline,
+			"rollback mechanics failures must not exhaust validation recovery",
+		)
+	}
+	assert.Equal(
+		t,
+		1,
+		fixture.ls.mithrilBoundaryRecovery.rejections,
+	)
+	assert.Zero(
+		t,
+		promtestutil.ToFloat64(
+			fixture.ls.metrics.mithrilTrustWindowUnrepairable,
+		),
+	)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -779,6 +779,13 @@ type LedgerState struct {
 	replayRecoveryHighWaterSlot   uint64
 	replayRecoveryNoProgressCount int
 	replayRecoveryHolding         bool
+	// Consecutive successful recovery attempts refused at the Mithril trust
+	// boundary without advancing the applied tip (issues #3261 and #3301).
+	// The refusal's only escape is peer rotation, which cannot help for a
+	// canonical block, so the applied high-water tally turns an unbounded
+	// reject-and-retry loop into a terminal condition even when replay reports
+	// changing failing block or transaction identities.
+	mithrilBoundaryRecovery *mithrilBoundaryRecoveryProgress
 	// Cross-fork continuation audit (issue #3005). Armed by a local
 	// rollback and consumed by the blockfetch handler; see
 	// ledger/continuation_audit.go for the cost and soundness argument.
@@ -4014,7 +4021,29 @@ const (
 	// outside (a peer serving a different chain, an operator repairing
 	// state), but at a rate that neither burns CPU nor buries the logs.
 	noProgressStuckBackoffMax = 30 * time.Second
+	// noProgressStuckReannounceInterval is how many further no-progress
+	// restarts pass between ERROR announcements once the pipeline is stuck.
+	// Announcing the transition once and then dropping to WARN every 100
+	// restarts made a node that had stopped following the chain look quiet
+	// to log-level alerting: one ERROR line covered 18 hours, mixed into
+	// 129k WARN lines from everything else (issue #3261). At the stuck
+	// backoff ceiling this re-announces roughly every ten minutes, which is
+	// often enough to alert on and rare enough not to become the noise it
+	// replaces.
+	noProgressStuckReannounceInterval = 20
 )
+
+// pipelineStuckShouldAnnounce reports whether a stuck no-progress restart
+// warrants an ERROR announcement. True on the transition into stuck and every
+// noProgressStuckReannounceInterval restarts after it, so the condition stays
+// visible for as long as it lasts rather than only when it began.
+func pipelineStuckShouldAnnounce(consecutiveNoProgress int) bool {
+	if consecutiveNoProgress < noProgressStuckThreshold {
+		return false
+	}
+	return (consecutiveNoProgress-noProgressStuckThreshold)%
+		noProgressStuckReannounceInterval == 0
+}
 
 // runLedgerReadChainAttempt runs one read+process attempt: it launches
 // readChain on a fresh child context of ctx, hands the result channel to
@@ -4155,23 +4184,76 @@ func (ls *LedgerState) trackPipelineProgress(
 // consecutive no-progress restarts (trackPipelineProgress/
 // ledgerPipelineBackoff) to back off and surface a stuck-pipeline signal
 // when a failure is deterministic rather than transient.
+//
+// errHaltLedgerPipeline is the one error class that is not retried. Recovery
+// raises it once it has established that no local replay can change a block's
+// verdict, at which point restarting would only rediscover the same block, so
+// the loop announces the terminal condition and returns instead (issue #3261).
 func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
+	ls.ledgerProcessBlocksWithAttempt(
+		ctx,
+		func(attemptCtx context.Context) error {
+			return ls.runLedgerReadChainAttempt(
+				attemptCtx,
+				ls.ledgerReadChain,
+				ls.ledgerProcessBlocksFromSource,
+			)
+		},
+	)
+}
+
+// ledgerProcessBlocksWithAttempt is ledgerProcessBlocks' restart loop with the
+// per-attempt work injected, so the loop's own decisions -- back off, announce,
+// or stop for good -- can be exercised without standing up a chain reader and a
+// block pipeline behind them.
+func (ls *LedgerState) ledgerProcessBlocksWithAttempt(
+	ctx context.Context,
+	attempt func(context.Context) error,
+) {
 	// Clear the no-progress gauges however this loop exits — normal return,
 	// or a shutdown cancelling one of the retry timers. Deferred rather than
 	// cleared at each return so a path added later cannot strand a stale
 	// "stuck" reading in monitoring for the life of the process.
-	defer ls.metrics.setPipelineNoProgress(0, false)
+	// A halted pipeline is not a pipeline making no progress -- it is one
+	// that has stopped -- so its own terminal gauge stands instead of a
+	// zeroed no-progress reading that would look healthy.
+	halted := false
+	defer func() {
+		if halted {
+			return
+		}
+		ls.metrics.setPipelineNoProgress(0, false)
+	}()
 	var progress pipelineProgress
 	for {
-		err := ls.runLedgerReadChainAttempt(
-			ctx,
-			ls.ledgerReadChain,
-			ls.ledgerProcessBlocksFromSource,
-		)
+		err := attempt(ctx)
 		if err == nil || ctx.Err() != nil {
 			return
 		}
 		ls.handleLedgerProcessBlocksError(err)
+		if errors.Is(err, errHaltLedgerPipeline) {
+			// Recovery has established that no local replay can change
+			// this verdict, so restarting the pipeline would only
+			// rediscover the same block. Stop, and leave a terminal
+			// signal behind: the announcement is the last log line this
+			// pipeline writes, and the gauge is what an operator alerts
+			// on afterwards.
+			halted = true
+			ls.metrics.setPipelineHalted()
+			ls.RLock()
+			haltTipSlot := ls.currentTip.Point.Slot
+			ls.RUnlock()
+			ls.config.Logger.Error(
+				"ledger pipeline halted on an unrepairable validation failure; the node has stopped following the chain and will not resume without operator intervention",
+				"component",
+				"ledger",
+				"tip_slot",
+				haltTipSlot,
+				"error",
+				err,
+			)
+			return
+		}
 		if errors.Is(err, errCertifiedEndorserBlockUnavailable) {
 			// This retry has its own delay and used to skip the no-progress
 			// accounting entirely, so an endorser block that never becomes
@@ -4185,7 +4267,9 @@ func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 				endorserStuck,
 			)
 			if endorserStuck &&
-				progress.consecutiveNoProgress == noProgressStuckThreshold {
+				pipelineStuckShouldAnnounce(
+					progress.consecutiveNoProgress,
+				) {
 				ls.config.Logger.Error(
 					"ledger pipeline stuck: a certified endorser block has stayed unavailable across repeated restarts without advancing the tip; the node is no longer following the chain",
 					"component",
@@ -4219,12 +4303,16 @@ func (ls *LedgerState) ledgerProcessBlocks(ctx context.Context) {
 			stuck,
 		)
 		if progress.consecutiveNoProgress > 0 {
-			// Announce the transition into stuck exactly once, at ERROR: a
-			// deterministic failure is not going to clear on its own, so it
-			// is an operator-actionable condition rather than another line
-			// in a repeating WARN.
+			// Announce the stuck condition at ERROR on the transition and
+			// periodically for as long as it lasts: a deterministic failure
+			// is not going to clear on its own, and a node that has stopped
+			// following the chain must not fall silent at ERROR after one
+			// line while the WARN below is buried among unrelated warnings
+			// (issue #3261).
 			if stuck &&
-				progress.consecutiveNoProgress == noProgressStuckThreshold {
+				pipelineStuckShouldAnnounce(
+					progress.consecutiveNoProgress,
+				) {
 				ls.config.Logger.Error(
 					"ledger pipeline stuck: repeated restarts are not advancing the tip, so the failure is deterministic and will not clear on its own; the node is no longer following the chain",
 					"component",
@@ -4274,7 +4362,7 @@ func (ls *LedgerState) handleLedgerProcessBlocksError(err error) {
 	}
 	if errors.Is(err, errHaltLedgerPipeline) {
 		ls.config.Logger.Warn(
-			"block processing hit persistent validation failure, restarting pipeline",
+			"block processing hit persistent validation failure, halting ledger pipeline",
 			"error",
 			err,
 		)
@@ -5210,6 +5298,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				// failure gets a fresh recovery budget (issues #2939, #3005).
 				ls.resetAtTipRecoveryDescent(pendingTip.Point.Slot)
 				ls.resetReplayRecoveryNonProgress(pendingTip.Point.Slot)
+				ls.resetMithrilBoundaryRejections(pendingTip.Point.Slot)
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				if wantEnableValidation {
 					ls.validationEnabled = true


### PR DESCRIPTION
Closes #3261.
Closes #3301.

## Problem

Validation recovery at a Mithril trust boundary could rotate peers indefinitely when every legal rewind target was below the imported anchor. Replay could also rearm the recovery budget by reporting a different failing block or transaction without advancing the applied ledger tip.

## Changes

- Bound trust-boundary recovery by applied-tip progress rather than failure identity.
- Count only attempts whose local rollback completed successfully.
- Halt the ledger pipeline with persistent metrics and operator guidance once the legal recovery space is exhausted.
- Keep stuck pipelines visible through periodic ERROR announcements.
- Cover at-tip and replay recovery, rollback-mechanics failures, sticky terminal state, and pipeline shutdown under race-enabled tests.

`ARCHITECTURE.md` documents the terminal state and recovery signal. `DATABASE.md` was checked and is unaffected. There is no API, wire-format, or dependency change.

## Composition

Trial composition with #3251 conflicts only at two additive `ledger/state.go` sites: both recovery trackers and both applied-tip reset calls must be retained.

---

## Summary by Cubic

Halts the ledger pipeline when Mithril trust-window validation failures are unrepairable, preventing infinite peer rotation on canonical blocks and improving stuck-state visibility. Boundary refusals are tallied per applied tip; exhausting the legal recovery space logs the operator action, increments `dingo_ledger_mithril_trust_window_unrepairable_total`, returns terminal `errHaltLedgerPipeline`, and sets `dingo_ledger_pipeline_halted`.

- The tally clears only after the applied tip advances, records only after a successful local rewind, and remains terminal once exhausted.
- ERROR announcements repeat for general and certified-endorser stuck paths so wedges stay visible.
- Nodes halt the ledger pipeline but keep serving stale queries; recovery requires a newer Mithril snapshot or a genesis resync.
- Tests cover terminal halts, recoverable retries, stuck-announcement cadence, applied-tip-keyed budgets, and rollback failures that must not consume the budget.

No wire-format or era-semantics changes.