### PR TITLE
fix(database): keep witness transaction_id indexes out of bulk deferral

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4094,8 +4094,12 @@ indexes during bulk load. Deferred indexes are classified as critical or lazy in
 and rollback predicates, while lazy indexes cover secondary query paths. Only
 indexes no import path filters on are eligible at all — an index a per-row
 import predicate needs stays resident, since dropping it turns that predicate
-into a full scan of a table the import is still growing. `DATABASE.md` records
-which indexes that rule keeps out of the manifest. The metadata plugin exposes
+into a full scan of a table the import is still growing. Those indexes are
+named in `deferred.Retained`, and the drop and full-rebuild paths create any of
+them that is absent, which repairs a database an older binary's manifest had
+already dropped them from — the versioned migration that created them is
+recorded complete and never re-runs. `DATABASE.md` records which indexes that
+rule keeps out of the manifest. The metadata plugin exposes
 `BuildCriticalDeferredIndexes` for the critical subset and
 `BuildDeferredIndexes` for the full manifest. Mithril sync rebuilds the
 critical subset before clearing `sync_status`, then leaves the pending

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4091,9 +4091,13 @@ nonce is passed through unchanged.
 In API storage mode, the shared SQL metadata providers can defer selected query
 indexes during bulk load. Deferred indexes are classified as critical or lazy in
 `database/plugin/metadata/deferred`: critical indexes cover startup API queries
-and rollback predicates, while lazy indexes cover secondary query paths. The
-metadata plugin exposes `BuildCriticalDeferredIndexes` for the critical subset
-and `BuildDeferredIndexes` for the full manifest. Mithril sync rebuilds the
+and rollback predicates, while lazy indexes cover secondary query paths. Only
+indexes no import path filters on are eligible at all — an index a per-row
+import predicate needs stays resident, since dropping it turns that predicate
+into a full scan of a table the import is still growing. `DATABASE.md` records
+which indexes that rule keeps out of the manifest. The metadata plugin exposes
+`BuildCriticalDeferredIndexes` for the critical subset and
+`BuildDeferredIndexes` for the full manifest. Mithril sync rebuilds the
 critical subset before clearing `sync_status`, then leaves the pending
 sync-state marker set. API-mode `serve` verifies the critical subset before
 startup and runs the full lazy rebuild as background maintenance; the marker is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4095,11 +4095,13 @@ and rollback predicates, while lazy indexes cover secondary query paths. Only
 indexes no import path filters on are eligible at all — an index a per-row
 import predicate needs stays resident, since dropping it turns that predicate
 into a full scan of a table the import is still growing. Those indexes are
-named in `deferred.Retained`, and the drop and full-rebuild paths create any of
-them that is absent, which repairs a database an older binary's manifest had
-already dropped them from — the versioned migration that created them is
-recorded complete and never re-runs. `DATABASE.md` records which indexes that
-rule keeps out of the manifest. The metadata plugin exposes
+named in `deferred.Retained`, and every drop and rebuild path creates any of
+them that is absent — the critical rebuild included, since it is the last step
+before the node serves API writes and the full rebuild can finish much later.
+That repairs a database an older binary's manifest had already dropped them
+from; the versioned migration that created them is recorded complete and never
+re-runs. `DATABASE.md` records which indexes that rule keeps out of the
+manifest. The metadata plugin exposes
 `BuildCriticalDeferredIndexes` for the critical subset and
 `BuildDeferredIndexes` for the full manifest. Mithril sync rebuilds the
 critical subset before clearing `sync_status`, then leaves the pending

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -543,6 +543,15 @@ which query paths it also serves. `SetTransaction` clears `key_witness`,
 b-tree descent with a full scan of a table the same import is still growing,
 which makes historical backfill quadratic rather than merely slower.
 
+Those seven indexes are named in `deferred.Retained`, and the drop and
+full-rebuild paths create any of them that is absent before touching the
+manifest. Excluding an index from the manifest does not restore it on databases
+already on disk: a binary whose manifest still carried it dropped it at the
+start of a bulk-load cycle and recreates it only in the full rebuild, and the
+versioned migration that created it is recorded complete, so its
+`CREATE INDEX IF NOT EXISTS` never runs again. Taking an index out of the
+manifest therefore means adding it to `Retained`.
+
 ### Midnight Indexer
 
 | Table | Columns | Keys / indexes | Relationships and notes |

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -543,11 +543,15 @@ which query paths it also serves. `SetTransaction` clears `key_witness`,
 b-tree descent with a full scan of a table the same import is still growing,
 which makes historical backfill quadratic rather than merely slower.
 
-Those seven indexes are named in `deferred.Retained`, and the drop and
-full-rebuild paths create any of them that is absent before touching the
-manifest. Excluding an index from the manifest does not restore it on databases
-already on disk: a binary whose manifest still carried it dropped it at the
-start of a bulk-load cycle and recreates it only in the full rebuild, and the
+Those seven indexes are named in `deferred.Retained`, and every drop and
+rebuild path creates any of them that is absent before touching the manifest.
+That includes the critical rebuild: it is the last step before `serve` clears
+`sync_status` and the node accepts API writes, while the full rebuild that
+clears the pending marker can run as background maintenance long afterwards.
+
+Excluding an index from the manifest does not restore it on databases already
+on disk: a binary whose manifest still carried it dropped it at the start of a
+bulk-load cycle and recreates it only in the full rebuild, and the
 versioned migration that created it is recorded complete, so its
 `CREATE INDEX IF NOT EXISTS` never runs again. Taking an index out of the
 manifest therefore means adding it to `Retained`.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -518,11 +518,11 @@ post-Mithril-boundary strictness (see below).
 | `asset_mint_burn` | `id`, `tx_hash`, `policy_id`, `name`, `fingerprint`, `slot`, `quantity`, `tx_index` | PK `id`; unique `(tx_hash, policy_id, name)` (`idx_asset_mint_burn_unique`); composite `(policy_id, name, slot)` (`idx_asset_mint_burn_lookup`); indexes `fingerprint`, `slot` | API-mode-only mint/burn history: one row per `(transaction, asset)` for every tx that mints or burns the asset. Populated from `tx.AssetMint()` during indexing; `quantity` is a signed decimal string (negative for burns). Unlike `asset` (live holdings), this preserves full history so Blockfrost `/assets/{asset}` can derive `initial_mint_tx_hash` (earliest event by `(slot, tx_index, id)`) and `mint_or_burn_count` (row count). The unique key makes re-applying a transaction after a rollback idempotent. Rows with `slot > rollback_slot` are deleted alongside `transaction` on rollback. |
 | `address_transaction` | `id`, `payment_key`, `credential_tag`, `staking_key`, `transaction_id`, `slot`, `tx_index` | PK `id`; indexes `payment_key`, `transaction_id`, `slot`; composite `(credential_tag, staking_key, slot, tx_index, payment_key)` | API-mode address-to-transaction index. Join to `transaction.id`. `credential_tag`: 0 key hash, 1 script hash for stake-bearing addresses. The composite index supports credential-scoped pagination and its leading columns cover simple credential lookups. |
 | `transaction_metadata_label` | `id`, `transaction_id`, `label`, `slot`, `cbor_value`, `json_value` | PK `id`; unique `(transaction_id, label)`; indexes `label`, `slot` | API-mode per-label metadata index. Join to `transaction.id`. |
-| `key_witness` | `id`, `transaction_id`, `type`, `vkey`, `signature`, `public_key`, `chain_code`, `attributes` | PK `id`; indexes `transaction_id`, `type` | API-mode vkey/bootstrap witnesses. Join to `transaction.id`. |
-| `witness_scripts` | `id`, `transaction_id`, `script_hash`, `type` | PK `id`; indexes `transaction_id`, `script_hash`, `type` | API-mode witness-script references. Join `script_hash = script.hash`. |
+| `key_witness` | `id`, `transaction_id`, `type`, `vkey`, `signature`, `public_key`, `chain_code`, `attributes` | PK `id`; indexes `transaction_id`, `type` | API-mode vkey/bootstrap witnesses. Join to `transaction.id`. `transaction_id` is never deferred during bulk load: every API-mode `SetTransaction` clears this table by `transaction_id` before re-inserting. |
+| `witness_scripts` | `id`, `transaction_id`, `script_hash`, `type` | PK `id`; indexes `transaction_id`, `script_hash`, `type` | API-mode witness-script references. Join `script_hash = script.hash`. `transaction_id` is never deferred during bulk load, for the same reason as `key_witness`. |
 | `script` | `id`, `hash`, `content`, `created_slot`, `type` | PK `id`; unique/index `hash`; index `type` | API-mode de-duplicated script content by hash. |
-| `plutus_data` | `id`, `transaction_id`, `data` | PK `id`; index `transaction_id` | API-mode Plutus data from witness sets. Join to `transaction.id`. |
-| `redeemer` | `id`, `transaction_id`, `tag`, `index`, `data`, `ex_units_memory`, `ex_units_cpu` | PK `id`; indexes `transaction_id`, `tag`, `index` | API-mode redeemers. Join to `transaction.id`. |
+| `plutus_data` | `id`, `transaction_id`, `data` | PK `id`; index `transaction_id` | API-mode Plutus data from witness sets. Join to `transaction.id`. `transaction_id` is never deferred during bulk load, for the same reason as `key_witness`. |
+| `redeemer` | `id`, `transaction_id`, `tag`, `index`, `data`, `ex_units_memory`, `ex_units_cpu` | PK `id`; indexes `transaction_id`, `tag`, `index` | API-mode redeemers. Join to `transaction.id`. `transaction_id` is never deferred during bulk load, for the same reason as `key_witness`. |
 | `datum` | `id`, `hash`, `raw_datum`, `added_slot` | PK `id`; unique/index `hash`; index `added_slot` | API-mode datum hash index. UTxOs can reference it with `utxo.datum_hash = datum.hash`. |
 | `certs` | `id`, `transaction_id`, `cert_index`, `cert_type`, `certificate_id`, `slot`, `block_hash` | PK `id`; unique `(transaction_id, cert_index)`; indexes `transaction_id`, `certificate_id`, `cert_type`, `slot`, `block_hash` | Unified certificate index. `certificate_id` points to one specialized certificate table according to `cert_type`; this is logical, not DB-enforced. |
 
@@ -532,6 +532,16 @@ so the MySQL dialect keeps those specific indexes resident while dropping and
 rebuilding the rest of the deferred manifest. The durable `sync_state` marker
 still covers the complete cycle and is cleared only after all rebuildable
 indexes are present.
+
+An index the import path itself filters on is never deferred, regardless of
+which query paths it also serves. `SetTransaction` clears `key_witness`,
+`witness_scripts`, `redeemer`, `plutus_data`, and `address_transaction` by
+`transaction_id` before re-inserting, so each of those tables keeps its
+`transaction_id` index resident through bulk load; the same rule keeps
+`idx_utxo_staking_deleted_amount` (per-batch live-stake sums) and
+`idx_certs_transaction_id` out of the manifest. Deferring one of them replaces a
+b-tree descent with a full scan of a table the same import is still growing,
+which makes historical backfill quadratic rather than merely slower.
 
 ### Midnight Indexer
 

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -37,6 +37,9 @@ package deferred
 //     (import_checkpoint.import_key, backfill_checkpoint.phase).
 //   - The utxo (tx_id, output_idx) lookup index, required to
 //     resolve transaction inputs during backfill UTxO spending.
+//   - Indexes the import path's own idempotency deletes filter on
+//     (key_witness, witness_scripts, redeemer, plutus_data by
+//     transaction_id; address_transaction by transaction_id).
 //   - Cross-row uniqueness constraints used by ledger-state import
 //     (pool_stake_snapshot, reward_snapshot, reward_pool_input,
 //     network_state, account.staking_key, drep.credential, etc.).
@@ -46,8 +49,11 @@ package deferred
 //
 //  1. Does any import path (ledger-state import, immutable blob
 //     load, backfill block replay) rely on the index for an ON
-//     CONFLICT target, FK enforcement, or constraint lookup? If
-//     yes, leave it out of the manifest.
+//     CONFLICT target, FK enforcement, constraint lookup, or the
+//     WHERE clause of a per-row idempotency delete or aggregate
+//     refresh? If yes, leave it out of the manifest. A predicate an
+//     import path runs once per transaction cannot afford a scan of
+//     a table the same import path is growing.
 //  2. Does the index only serve API/query/rollback paths that do
 //     not run during Mithril sync? If yes, add it here.
 //  3. Composite indexes share state with their constituent columns. If a field
@@ -242,12 +248,19 @@ var Manifest = []Index{
 		Columns: []string{"cert_type"},
 		Notes:   "Certificate type filter",
 	},
-	{
-		Name:    "idx_redeemer_transaction_id",
-		Table:   "redeemer",
-		Columns: []string{"transaction_id"},
-		Notes:   "Redeemer transaction lookup",
-	},
+	// idx_redeemer_transaction_id, idx_key_witness_transaction_id, and
+	// idx_witness_scripts_transaction_id are deliberately NOT deferred.
+	// storeTransactionWitnesses (database/plugin/metadata/sqlstore) rewrites
+	// the witness tables on every API-mode SetTransaction, and clears the
+	// previous attempt's rows first with an unconditional
+	// DELETE ... WHERE transaction_id = ? per table. With those indexes
+	// dropped each delete is a full scan of a table that gains a row per
+	// transaction written, so per-transaction cost grows with the rows
+	// already present and historical backfill turns quadratic: measured on
+	// preview, Mithril backfill fell from 3311 to 9 blocks/sec by 2%
+	// progress while its own ETA climbed from 30m to 177h (issue #3253).
+	// plutus_data, the fourth table the same loop clears, was never
+	// deferred; these three now match it.
 	{
 		Name:    "idx_redeemer_index",
 		Table:   "redeemer",
@@ -261,12 +274,6 @@ var Manifest = []Index{
 		Notes:   "Redeemer tag filter",
 	},
 	{
-		Name:    "idx_key_witness_transaction_id",
-		Table:   "key_witness",
-		Columns: []string{"transaction_id"},
-		Notes:   "Witness transaction lookup",
-	},
-	{
 		Name:    "idx_key_witness_type",
 		Table:   "key_witness",
 		Columns: []string{"type"},
@@ -277,12 +284,6 @@ var Manifest = []Index{
 		Table:   "witness_scripts",
 		Columns: []string{"script_hash"},
 		Notes:   "Script hash lookup",
-	},
-	{
-		Name:    "idx_witness_scripts_transaction_id",
-		Table:   "witness_scripts",
-		Columns: []string{"transaction_id"},
-		Notes:   "Script transaction lookup",
 	},
 	{
 		Name:    "idx_witness_scripts_type",

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -37,9 +37,9 @@ package deferred
 //     (import_checkpoint.import_key, backfill_checkpoint.phase).
 //   - The utxo (tx_id, output_idx) lookup index, required to
 //     resolve transaction inputs during backfill UTxO spending.
-//   - Indexes the import path's own idempotency deletes filter on
-//     (key_witness, witness_scripts, redeemer, plutus_data by
-//     transaction_id; address_transaction by transaction_id).
+//   - Indexes the import path's own predicates filter on. Those are
+//     listed in Retained, which the drop and rebuild paths keep
+//     present rather than dropping.
 //   - Cross-row uniqueness constraints used by ledger-state import
 //     (pool_stake_snapshot, reward_snapshot, reward_pool_input,
 //     network_state, account.staking_key, drep.credential, etc.).
@@ -60,6 +60,9 @@ package deferred
 //     has both a deferrable single-column query index and a protected composite
 //     unique index, give the single-column index an explicit name and list that
 //     name here instead of the field.
+//  4. Taking an index back out of the manifest means adding it to
+//     Retained. Deleting the entry alone leaves it missing on every
+//     database an older binary had already dropped it from.
 //
 // See deferred_test.go for manifest invariants.
 type Index struct {
@@ -290,5 +293,73 @@ var Manifest = []Index{
 		Table:   "witness_scripts",
 		Columns: []string{"type"},
 		Notes:   "Script type filter",
+	},
+}
+
+// Retained names the indexes deliberately excluded from Manifest because an
+// import path's own predicates need them resident during bulk load.
+//
+// Removing an entry from Manifest does not restore it on databases already on
+// disk. A shipped binary whose manifest still held the entry drops it at the
+// start of a bulk-load cycle and recreates it only in the full rebuild, so a
+// database interrupted inside that window -- a multi-hour Mithril backfill,
+// for issue #3253 -- still has the index missing. The newer binary's
+// BuildDeferredIndexes no longer carries the entry, and the versioned
+// migration that created it is already recorded complete, so
+// CREATE INDEX IF NOT EXISTS never runs again: the full-table scan the
+// exclusion exists to prevent becomes permanent.
+//
+// The drop and full-rebuild paths therefore create any absent entry here
+// before touching the manifest, which repairs such a database at the start of
+// the next cycle -- including the cycle the operator starts by upgrading to
+// the binary that carries the exclusion. Entries already present cost one
+// catalog lookup each.
+var Retained = []Index{
+	{
+		Name:  "idx_utxo_staking_deleted_amount",
+		Table: "utxo",
+		Columns: []string{
+			"credential_tag",
+			"staking_key",
+			"deleted_slot",
+			"amount",
+		},
+		Notes: "Per-batch live-stake SUM during API-mode backfill",
+	},
+	{
+		Name:    "idx_key_witness_transaction_id",
+		Table:   "key_witness",
+		Columns: []string{"transaction_id"},
+		Notes:   "SetTransaction witness idempotency delete",
+	},
+	{
+		Name:    "idx_witness_scripts_transaction_id",
+		Table:   "witness_scripts",
+		Columns: []string{"transaction_id"},
+		Notes:   "SetTransaction witness idempotency delete",
+	},
+	{
+		Name:    "idx_redeemer_transaction_id",
+		Table:   "redeemer",
+		Columns: []string{"transaction_id"},
+		Notes:   "SetTransaction witness idempotency delete",
+	},
+	{
+		Name:    "idx_plutus_data_transaction_id",
+		Table:   "plutus_data",
+		Columns: []string{"transaction_id"},
+		Notes:   "SetTransaction witness idempotency delete",
+	},
+	{
+		Name:    "idx_address_transaction_transaction_id",
+		Table:   "address_transaction",
+		Columns: []string{"transaction_id"},
+		Notes:   "SetTransaction address index idempotency delete",
+	},
+	{
+		Name:    "idx_certs_transaction_id",
+		Table:   "certs",
+		Columns: []string{"transaction_id"},
+		Notes:   "SetTransaction certificate idempotency delete subquery",
 	},
 }

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -108,3 +108,36 @@ func TestSyncStateConstants(t *testing.T) {
 		t.Errorf("SyncStateValue changed: got %q", SyncStateValue)
 	}
 }
+
+// TestManifestKeepsImportIdempotencyIndexes covers issue #3253.
+//
+// The import path clears each of these tables by transaction_id once per
+// transaction before re-inserting, so deferring the index the predicate needs
+// turns a b-tree descent into a scan of a table the same import path is
+// growing. Two of the four tables listed here were never deferred; the other
+// two were, and that is what made Mithril's API-mode backfill quadratic.
+//
+// Pinned by name because the manifest is data: nothing fails to compile when a
+// contributor adds one of these back, and the cost only shows up on a
+// multi-hour bootstrap.
+func TestManifestKeepsImportIdempotencyIndexes(t *testing.T) {
+	retained := map[string]string{
+		"idx_key_witness_transaction_id":         "key_witness",
+		"idx_witness_scripts_transaction_id":     "witness_scripts",
+		"idx_redeemer_transaction_id":            "redeemer",
+		"idx_plutus_data_transaction_id":         "plutus_data",
+		"idx_address_transaction_transaction_id": "address_transaction",
+	}
+	for _, idx := range Manifest {
+		if table, ok := retained[idx.Name]; ok {
+			t.Errorf(
+				"manifest defers %q, but SetTransaction filters %s by "+
+					"transaction_id on every transaction it writes; "+
+					"dropping it makes that delete a full scan of a table "+
+					"the import is still growing (issue #3253)",
+				idx.Name,
+				table,
+			)
+		}
+	}
+}

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -141,3 +141,76 @@ func TestManifestKeepsImportIdempotencyIndexes(t *testing.T) {
 		}
 	}
 }
+
+// TestRetainedIsDisjointFromManifest guards the contract the repair rests on:
+// an index cannot be both dropped for bulk load and restored before the drop.
+func TestRetainedIsDisjointFromManifest(t *testing.T) {
+	deferredNames := map[string]bool{}
+	for _, idx := range Manifest {
+		deferredNames[idx.Name] = true
+	}
+	for _, idx := range Retained {
+		if deferredNames[idx.Name] {
+			t.Errorf(
+				"%q is in both Manifest and Retained; an index is either "+
+					"deferrable or kept resident, not both",
+				idx.Name,
+			)
+		}
+	}
+}
+
+// TestRetainedEntriesAreResolvable confirms each entry carries what the shared
+// SQL store needs to recreate it, since a Retained entry is only ever used to
+// issue CREATE INDEX for an index that is already missing.
+func TestRetainedEntriesAreResolvable(t *testing.T) {
+	if len(Retained) == 0 {
+		t.Fatal("Retained is empty; the exclusion rule names entries")
+	}
+	seen := map[string]int{}
+	for i, idx := range Retained {
+		if idx.Name == "" || idx.Table == "" || len(idx.Columns) == 0 {
+			t.Errorf(
+				"retained entry %d is incomplete (name=%q table=%q columns=%v)",
+				i, idx.Name, idx.Table, idx.Columns,
+			)
+		}
+		if prev, ok := seen[idx.Name]; ok {
+			t.Errorf(
+				"duplicate retained entry %q at indices %d and %d",
+				idx.Name, prev, i,
+			)
+		}
+		seen[idx.Name] = i
+	}
+}
+
+// TestRetainedCoversImportIdempotencyIndexes is the other half of
+// TestManifestKeepsImportIdempotencyIndexes: keeping an index out of the
+// manifest only helps a database an older manifest already dropped it from if
+// the drop and rebuild paths restore it, and they read this list to do so.
+func TestRetainedCoversImportIdempotencyIndexes(t *testing.T) {
+	want := []string{
+		"idx_key_witness_transaction_id",
+		"idx_witness_scripts_transaction_id",
+		"idx_redeemer_transaction_id",
+		"idx_plutus_data_transaction_id",
+		"idx_address_transaction_transaction_id",
+		"idx_certs_transaction_id",
+		"idx_utxo_staking_deleted_amount",
+	}
+	present := map[string]bool{}
+	for _, idx := range Retained {
+		present[idx.Name] = true
+	}
+	for _, name := range want {
+		if !present[name] {
+			t.Errorf(
+				"%q is excluded from Manifest for an import predicate but "+
+					"missing from Retained, so a database an older "+
+					"manifest dropped it from never gets it back",
+				name,
+			)
+		}
+	}
+}

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -114,8 +114,8 @@ func TestSyncStateConstants(t *testing.T) {
 // The import path clears each of these tables by transaction_id once per
 // transaction before re-inserting, so deferring the index the predicate needs
 // turns a b-tree descent into a scan of a table the same import path is
-// growing. Two of the four tables listed here were never deferred; the other
-// two were, and that is what made Mithril's API-mode backfill quadratic.
+// growing. Two of the five tables listed here were never deferred; the other
+// three were, and that is what made Mithril's API-mode backfill quadratic.
 //
 // Pinned by name because the manifest is data: nothing fails to compile when a
 // contributor adds one of these back, and the cost only shows up on a

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore"
 	"github.com/blinklabs-io/dingo/database/types"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -55,7 +56,12 @@ func newAPIModeSQLStore(t *testing.T) (*sqlstore.Store, *sql.DB) {
 	require.NoError(t, err)
 	require.NoError(t, store.Start(t.Context()))
 	t.Cleanup(func() {
-		require.NoError(t, store.Close())
+		// Logged rather than asserted: require calls FailNow, which stops
+		// the remaining cleanup callbacks and leaks the t.TempDir removal
+		// registered before this one.
+		if err := store.Close(); err != nil {
+			t.Logf("closing store: %v", err)
+		}
 	})
 	return store, writeDB
 }
@@ -149,55 +155,58 @@ func TestTransactionWitnessCleanupStaysIndexedAfterDeferredIndexDrop(
 	store, db := newAPIModeSQLStore(t)
 	seedWitnessRows(t, db, 0, 2000)
 
-	assertIndexed := func(t *testing.T, when string) {
-		t.Helper()
-		for _, table := range sqlstore.TransactionWitnessTables() {
-			index, ok := transactionWitnessCleanupIndexes[table]
-			require.True(
-				t,
-				ok,
-				"table %q has no expected cleanup index; a new witness "+
-					"table needs its transaction_id index classified for "+
-					"bulk load",
-				table,
-			)
-			plan := queryPlan(
-				t,
-				db,
-				sqlstore.TransactionWitnessCleanupSQL(table),
-				1,
-			)
-			// SQLite reports a covering index as "USING COVERING INDEX",
-			// so the index name and the equality it resolves are matched
-			// rather than one literal spelling of the whole node.
-			require.Contains(
-				t,
-				plan,
-				"SEARCH "+table+" USING",
-				"%s: the %s idempotency delete must be an indexed search:\n%s",
-				when, table, plan,
-			)
-			require.Contains(
-				t,
-				plan,
-				"INDEX "+index+" (transaction_id=?)",
-				"%s: the %s idempotency delete must resolve transaction_id "+
-					"through %s:\n%s",
-				when, table, index, plan,
-			)
-			require.NotContains(
-				t,
-				plan,
-				"SCAN "+table,
-				"%s: the %s idempotency delete must not scan the table:\n%s",
-				when, table, plan,
-			)
-		}
-	}
-
-	assertIndexed(t, "before deferring indexes")
+	requireWitnessCleanupIndexed(t, db, "before deferring indexes")
 	require.NoError(t, store.DropDeferredIndexes())
-	assertIndexed(t, "after DropDeferredIndexes")
+	requireWitnessCleanupIndexed(t, db, "after DropDeferredIndexes")
+}
+
+// requireWitnessCleanupIndexed asserts that every witness-table idempotency
+// delete resolves transaction_id through its index, quoting the plan and the
+// caller's stage description when it does not.
+func requireWitnessCleanupIndexed(t *testing.T, db *sql.DB, when string) {
+	t.Helper()
+	for _, table := range sqlstore.TransactionWitnessTables() {
+		index, ok := transactionWitnessCleanupIndexes[table]
+		require.True(
+			t,
+			ok,
+			"table %q has no expected cleanup index; a new witness "+
+				"table needs its transaction_id index classified for "+
+				"bulk load",
+			table,
+		)
+		plan := queryPlan(
+			t,
+			db,
+			sqlstore.TransactionWitnessCleanupSQL(table),
+			1,
+		)
+		// SQLite reports a covering index as "USING COVERING INDEX",
+		// so the index name and the equality it resolves are matched
+		// rather than one literal spelling of the whole node.
+		require.Contains(
+			t,
+			plan,
+			"SEARCH "+table+" USING",
+			"%s: the %s idempotency delete must be an indexed search:\n%s",
+			when, table, plan,
+		)
+		require.Contains(
+			t,
+			plan,
+			"INDEX "+index+" (transaction_id=?)",
+			"%s: the %s idempotency delete must resolve transaction_id "+
+				"through %s:\n%s",
+			when, table, index, plan,
+		)
+		require.NotContains(
+			t,
+			plan,
+			"SCAN "+table,
+			"%s: the %s idempotency delete must not scan the table:\n%s",
+			when, table, plan,
+		)
+	}
 }
 
 // witnessCleanupSweep returns the median duration of one full witness-cleanup
@@ -382,5 +391,125 @@ func TestSetTransactionCostFlatAfterDeferredIndexDrop(t *testing.T) {
 		"per-transaction write cost must not track the rows already "+
 			"written: rows grew %.0fx, median cost grew %.1fx (%v)",
 		growth, ratio, medians,
+	)
+}
+
+// preChangeDeferredWitnessIndexes names the witness transaction_id indexes a
+// binary shipped before issue #3253 still carried in its deferred-index
+// manifest, and therefore dropped at the start of every bulk-load cycle.
+var preChangeDeferredWitnessIndexes = []string{
+	"idx_key_witness_transaction_id",
+	"idx_witness_scripts_transaction_id",
+	"idx_redeemer_transaction_id",
+}
+
+// seedPreChangeDeferredCycle leaves the store in the state a binary whose
+// manifest still deferred these three indexes leaves on disk when its cycle is
+// interrupted: the indexes dropped, and the durable recovery marker still set.
+//
+// Dropping the indexes directly is the whole point. The schema migration that
+// created them is already recorded complete, so its
+// CREATE INDEX IF NOT EXISTS never runs again, and a manifest that no longer
+// names them cannot rebuild them either.
+func seedPreChangeDeferredCycle(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, index := range preChangeDeferredWitnessIndexes {
+		_, err := db.Exec("DROP INDEX IF EXISTS " + index)
+		require.NoError(t, err)
+		require.False(
+			t,
+			sqliteIndexExists(t, db, index),
+			"%s must be absent for this to test the upgrade path",
+			index,
+		)
+	}
+	_, err := db.Exec(
+		`INSERT INTO sync_state (sync_key, value) VALUES (?, ?)
+		 ON CONFLICT (sync_key) DO UPDATE SET value = excluded.value`,
+		deferred.SyncStateKey,
+		deferred.SyncStateValue,
+	)
+	require.NoError(t, err)
+}
+
+// TestRetainedIndexesRepairPreChangeDeferredCycle covers the upgrade path for
+// issue #3253.
+//
+// Taking the three witness transaction_id indexes out of the manifest fixes
+// databases the fixed binary bootstraps itself, but not one already on disk.
+// A binary whose manifest still held them dropped them before backfill and
+// rebuilds them only in the full rebuild, and #3253's own reporter ran that
+// backfill for hours across restarts, so an interrupted cycle is the expected
+// state rather than a corner case. On such a database the newer manifest can
+// no longer name the indexes to rebuild them and migration v1 is recorded
+// complete, so without the repair the full scans this fix removes become
+// permanent.
+//
+// Both entry points a restarted node takes are covered: another bulk-load
+// cycle, and the pending-marker repair a plain serve runs.
+func TestRetainedIndexesRepairPreChangeDeferredCycle(t *testing.T) {
+	t.Parallel()
+	for name, repair := range map[string]func(*sqlstore.Store) error{
+		"next bulk-load cycle": (*sqlstore.Store).DropDeferredIndexes,
+		"pending-marker repair": (*sqlstore.Store).
+			BuildDeferredIndexes,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store, db := newAPIModeSQLStore(t)
+			seedWitnessRows(t, db, 0, 500)
+			seedPreChangeDeferredCycle(t, db)
+
+			require.NoError(t, repair(store))
+
+			for _, index := range preChangeDeferredWitnessIndexes {
+				require.True(
+					t,
+					sqliteIndexExists(t, db, index),
+					"%s must be restored: nothing else recreates an index "+
+						"the manifest no longer names",
+					index,
+				)
+			}
+			requireWitnessCleanupIndexed(t, db, "after "+name)
+		})
+	}
+}
+
+// TestBuildDeferredIndexesKeepsMarkerUntilRetainedIndexesExist pins the
+// ordering the repair depends on: the durable marker asserts that every index
+// an older manifest may have dropped is back, so it may not be cleared while
+// one of them is still missing.
+func TestBuildDeferredIndexesKeepsMarkerUntilRetainedIndexesExist(
+	t *testing.T,
+) {
+	t.Parallel()
+	store, db := newAPIModeSQLStore(t)
+	seedPreChangeDeferredCycle(t, db)
+
+	pending, err := store.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.True(t, pending, "the seeded cycle must look interrupted")
+
+	require.NoError(t, store.BuildCriticalDeferredIndexes())
+	pending, err = store.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.True(
+		t,
+		pending,
+		"the critical rebuild must leave the marker for the full rebuild",
+	)
+
+	require.NoError(t, store.BuildDeferredIndexes())
+	for _, index := range preChangeDeferredWitnessIndexes {
+		require.True(t, sqliteIndexExists(t, db, index))
+	}
+	pending, err = store.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.False(
+		t,
+		pending,
+		"the marker must clear once the full manifest and the retained "+
+			"indexes are present",
 	)
 }

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
@@ -410,23 +410,39 @@ func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
 	scanCost := func(step int) float64 {
 		return float64(control[step] - fixed[step])
 	}
+	// Read the sensitivity check at the largest cardinality, where the scan
+	// term is widest and clears the timing floor by the largest margin. At the
+	// smallest cardinality it asks a 500-row scan to be measurable while the
+	// other sweeps in this package compete for the same CPU, and the two
+	// sweeps are run one after the other rather than interleaved, so the
+	// difference there has been observed going negative on an unchanged store.
 	require.Positive(
 		t,
-		scanCost(0),
-		"the control must be slower than the fixed store at the smallest "+
-			"cardinality already, or the two stores are not differing in "+
-			"the three indexes under test: fixed %v, control %v",
+		scanCost(len(control)-1),
+		"the control must be slower than the fixed store once the tables are "+
+			"large, or the two stores are not differing in the three indexes "+
+			"under test: fixed %v, control %v",
 		fixed, control,
 	)
-	controlRatio := scanCost(len(control)-1) / scanCost(0)
+	// Growth of the control's own medians. Dividing the scan-cost difference
+	// by its value at the smallest cardinality put a floor-dominated, possibly
+	// negative term in the denominator, which inverts the ratio rather than
+	// understating it.
+	controlRatio := float64(control[len(control)-1]) / float64(control[0])
 
+	// Bounded at 2x rather than near-linear: this ratio is taken on the raw
+	// control medians, which carry the cardinality-independent floor at both
+	// ends and so understate the scan growth. A store whose cleanup cost did
+	// not track its row count sits near 1x; the observed range here is 3.4x to
+	// 4.4x across an eightfold spread, which straddles growth/2 and is what
+	// makes that threshold the wrong one for a floor-inclusive ratio.
 	require.Greater(
 		t,
 		controlRatio,
-		growth/2,
+		2.0,
 		"control (three transaction_id indexes dropped) must show the "+
 			"reported decay, or this sweep is too small to measure "+
-			"anything: rows grew %.0fx, scan cost grew %.1fx (fixed %v, "+
+			"anything: rows grew %.0fx, control cost grew %.1fx (fixed %v, "+
 			"control %v)",
 		growth, controlRatio, fixed, control,
 	)
@@ -473,47 +489,125 @@ func TestSetTransactionCostFlatAfterDeferredIndexDrop(t *testing.T) {
 	// slot when it attaches witness rows.
 	const timedSlotBase = 1_000_000
 
-	store, db := newAPIModeSQLStore(t)
-	require.NoError(t, store.DropDeferredIndexes())
+	fixedStore, fixedDB := newAPIModeSQLStore(t)
+	require.NoError(t, fixedStore.DropDeferredIndexes())
 
+	controlStore, controlDB := newAPIModeSQLStore(t)
+	require.NoError(t, controlStore.DropDeferredIndexes())
+	for _, index := range preChangeDeferredWitnessIndexes {
+		_, err := controlDB.Exec("DROP INDEX IF EXISTS " + index)
+		require.NoError(t, err)
+	}
+
+	fixed := setTransactionSweep(
+		t, fixedStore, fixedDB, steps, timed, timedSlotBase, "fixed",
+	)
+	control := setTransactionSweep(
+		t, controlStore, controlDB, steps, timed, timedSlotBase, "control",
+	)
+	t.Logf("rows=%v fixed=%v control=%v", steps, fixed, control)
+
+	growth := float64(slices.Max(steps)) / float64(slices.Min(steps))
+	controlLast := control[len(control)-1]
+
+	// The discriminator is the cost regime at the largest cardinality, not a
+	// growth ratio of the fixed store. The fixed store's per-transaction cost
+	// has no trend across these steps -- it alternates around a floor set by
+	// commit and page-cache behavior -- so its own first-to-last ratio is a
+	// ratio of two noise samples and lands either side of 1 from run to run.
+	//
+	// Both terms are read at the same step so both carry whatever contention
+	// the run is under. This package runs several timing sweeps in parallel,
+	// and taking the fixed store's worst step instead imports the single most
+	// contended phase of the run into a comparison against a control measured
+	// under different conditions, which is enough on its own to invert the
+	// result.
+	require.Greater(
+		t,
+		float64(controlLast),
+		float64(fixed[len(fixed)-1])*3,
+		"the control must reach a different cost regime once the tables are "+
+			"large, or the two stores are not differing in the three indexes "+
+			"under test: fixed %v, control %v",
+		fixed, control,
+	)
+	// Sensitivity: the sweep must be wide enough for the control to show the
+	// decay reported in #3253. Without this, a control that was slow at every
+	// cardinality for an unrelated reason would satisfy the check above. The
+	// bound is modest because the control's smallest step is the most
+	// floor-dominated point in the sweep; the separation asserted above is the
+	// strong half of this pair.
+	require.Greater(
+		t,
+		float64(controlLast),
+		float64(control[0])*1.5,
+		"the control must show the reported decay across the sweep, or this "+
+			"sweep is too small to measure anything: rows grew %.0fx "+
+			"(control %v)",
+		growth, control,
+	)
+	// No bound is asserted on the fixed store's own spread across the sweep.
+	// That spread tracks how much of the run each step shared with the other
+	// parallel sweeps in this package, not the row count: it has been observed
+	// falling from 3.8ms at the smallest cardinality to 0.9ms at the largest,
+	// the opposite direction to the effect under test. A store that did track
+	// its row count would fail the separation check above, which is where that
+	// claim belongs.
+}
+
+// setTransactionSweep times a fixed window of SetTransaction calls at each
+// cardinality in steps and returns the median per step. The first window is
+// preceded by an untimed warmup so the smallest cardinality does not carry
+// process warmup the later steps have already paid; charging that cost to the
+// smallest row count alone is enough to move a raw median ratio either side of
+// 1 on an otherwise unchanged store.
+func setTransactionSweep(
+	t *testing.T,
+	store *sqlstore.Store,
+	db *sql.DB,
+	steps []int,
+	timed int,
+	slotBase int,
+	tag string,
+) []time.Duration {
+	t.Helper()
+	const warmup = 16
 	blockHash := bytes.Repeat([]byte{0x5d}, 32)
 	seeded := 0
 	written := 0
+	write := func() time.Duration {
+		transaction := newTestWitnessTransaction(
+			fmt.Sprintf("deferred-index-sweep-%s-%07d", tag, written),
+		)
+		point := ocommon.Point{
+			Slot: uint64(slotBase + written),
+			Hash: blockHash,
+		}
+		start := time.Now()
+		require.NoError(t, store.SetTransaction(
+			transaction, point, 0, nil, true, nil,
+		))
+		elapsed := time.Since(start)
+		written++
+		return elapsed
+	}
 	medians := make([]time.Duration, 0, len(steps))
-	for _, step := range steps {
+	for i, step := range steps {
 		seedWitnessRows(t, db, seeded, step)
 		seeded = step
+		if i == 0 {
+			for range warmup {
+				write()
+			}
+		}
 		samples := make([]time.Duration, 0, timed)
 		for range timed {
-			transaction := newTestWitnessTransaction(
-				fmt.Sprintf("deferred-index-sweep-%07d", written),
-			)
-			point := ocommon.Point{
-				Slot: uint64(timedSlotBase + written),
-				Hash: blockHash,
-			}
-			start := time.Now()
-			require.NoError(t, store.SetTransaction(
-				transaction, point, 0, nil, true, nil,
-			))
-			samples = append(samples, time.Since(start))
-			written++
+			samples = append(samples, write())
 		}
 		slices.Sort(samples)
 		medians = append(medians, samples[len(samples)/2])
 	}
-	t.Logf("rows=%v median SetTransaction=%v", steps, medians)
-
-	growth := float64(slices.Max(steps)) / float64(slices.Min(steps))
-	ratio := float64(medians[len(medians)-1]) / float64(medians[0])
-	require.Less(
-		t,
-		ratio,
-		1.5,
-		"per-transaction write cost must not track the rows already "+
-			"written: rows grew %.0fx, median cost grew %.1fx (%v)",
-		growth, ratio, medians,
-	)
+	return medians
 }
 
 // preChangeDeferredWitnessIndexes names the witness transaction_id indexes a

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
@@ -160,6 +160,107 @@ func TestTransactionWitnessCleanupStaysIndexedAfterDeferredIndexDrop(
 	requireWitnessCleanupIndexed(t, db, "after DropDeferredIndexes")
 }
 
+// TestRetainedIndexesResidentAfterCriticalRebuild covers the repair path a
+// node takes when a prior bulk-load cycle was interrupted.
+//
+// serve calls RepairCriticalDeferredIndexes before it clears sync_status, and
+// Mithril sync calls BuildCritical before it clears its own. Both return with
+// the store about to accept API writes, and neither waits for the lazy
+// remainder that background maintenance finishes later. A database an older
+// binary's manifest had dropped a retained transaction_id index from therefore
+// has to be repaired by the critical rebuild too: otherwise every
+// SetTransaction between that point and the full rebuild clears its witness
+// tables with the full scan the retained set exists to prevent.
+//
+// The state under test is that database, reproduced by dropping the retained
+// set out from under a pending marker.
+func TestRetainedIndexesResidentAfterCriticalRebuild(t *testing.T) {
+	t.Parallel()
+	store, db := newAPIModeSQLStore(t)
+	seedWitnessRows(t, db, 0, 2000)
+
+	require.NoError(t, store.DropDeferredIndexes())
+	dropRetainedIndexes(t, db)
+	requireWitnessCleanupScans(t, db)
+
+	require.NoError(t, store.BuildCriticalDeferredIndexes())
+	requireRetainedIndexesResident(t, db, "after BuildCriticalDeferredIndexes")
+	requireWitnessCleanupIndexed(t, db, "after BuildCriticalDeferredIndexes")
+
+	// The critical rebuild owns only the critical subset, so the marker has
+	// to survive it for background maintenance to finish the rest.
+	pending, err := store.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.True(
+		t,
+		pending,
+		"BuildCriticalDeferredIndexes must leave the marker for the lazy "+
+			"remainder",
+	)
+}
+
+// dropRetainedIndexes removes every deferred.Retained index, reproducing what
+// a binary whose manifest still deferred them leaves on disk.
+//
+// The names are manifest constants, not input, and SQLite takes no bound
+// parameter in DDL.
+func dropRetainedIndexes(t *testing.T, db *sql.DB) {
+	t.Helper()
+	require.NotEmpty(t, deferred.Retained)
+	for _, index := range deferred.Retained {
+		_, err := db.Exec("DROP INDEX IF EXISTS " + index.Name)
+		require.NoError(t, err, "dropping retained index %s", index.Name)
+	}
+}
+
+// requireRetainedIndexesResident asserts that every deferred.Retained index is
+// present in the schema.
+func requireRetainedIndexesResident(t *testing.T, db *sql.DB, when string) {
+	t.Helper()
+	for _, index := range deferred.Retained {
+		var found int
+		require.NoError(t, db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master
+WHERE type = 'index' AND name = ?`,
+			index.Name,
+		).Scan(&found))
+		require.Equal(
+			t,
+			1,
+			found,
+			"%s: retained index %s must be resident whenever the store "+
+				"can serve writes",
+			when,
+			index.Name,
+		)
+	}
+}
+
+// requireWitnessCleanupScans asserts the negative case the repair has to fix:
+// with the retained set absent, the idempotency deletes are full scans. Without
+// it a rebuild that restored nothing would still pass the assertions above if
+// the indexes had never been missing.
+func requireWitnessCleanupScans(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, table := range sqlstore.TransactionWitnessTables() {
+		plan := queryPlan(
+			t,
+			db,
+			sqlstore.TransactionWitnessCleanupSQL(table),
+			1,
+		)
+		require.Contains(
+			t,
+			plan,
+			"SCAN "+table,
+			"the simulated interrupted cycle must leave the %s "+
+				"idempotency delete unindexed:\n%s",
+			table,
+			plan,
+		)
+	}
+}
+
 // requireWitnessCleanupIndexed asserts that every witness-table idempotency
 // delete resolves transaction_id through its index, quoting the plan and the
 // caller's stage description when it does not.
@@ -295,8 +396,29 @@ func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
 		return float64(medians[len(medians)-1]) / float64(medians[0])
 	}
 	fixedRatio := ratio(fixed)
-	controlRatio := ratio(control)
 	growth := float64(slices.Max(steps)) / float64(slices.Min(steps))
+
+	// Both stores execute the same four statements per pass, so both pay the
+	// same cardinality-independent cost per pass: statement preparation and
+	// one commit per table, which no index changes. The fixed store's median
+	// is that cost plus a bounded number of b-tree descents, which is what
+	// makes it a usable estimate of the floor. The control's growth is
+	// therefore measured on the difference -- the scan component, the only
+	// term the row count drives. Dividing the raw medians instead mixes the
+	// floor into both ends of the ratio and understates the decay whenever
+	// the floor is large, which on a loaded machine it is.
+	scanCost := func(step int) float64 {
+		return float64(control[step] - fixed[step])
+	}
+	require.Positive(
+		t,
+		scanCost(0),
+		"the control must be slower than the fixed store at the smallest "+
+			"cardinality already, or the two stores are not differing in "+
+			"the three indexes under test: fixed %v, control %v",
+		fixed, control,
+	)
+	controlRatio := scanCost(len(control)-1) / scanCost(0)
 
 	require.Greater(
 		t,
@@ -304,7 +426,7 @@ func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
 		growth/2,
 		"control (three transaction_id indexes dropped) must show the "+
 			"reported decay, or this sweep is too small to measure "+
-			"anything: rows grew %.0fx, cost grew %.1fx (fixed %v, "+
+			"anything: rows grew %.0fx, scan cost grew %.1fx (fixed %v, "+
 			"control %v)",
 		growth, controlRatio, fixed, control,
 	)

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore"
+	"github.com/blinklabs-io/dingo/database/types"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// transactionWitnessCleanupIndexes names the index that must answer
+// TransactionWitnessCleanupSQL for each witness table.
+//
+// Named here rather than in the store: nothing in the statement mentions an
+// index, since which one answers it is the planner's choice, and that choice
+// is what these tests check.
+var transactionWitnessCleanupIndexes = map[string]string{
+	"key_witness":     "idx_key_witness_transaction_id",
+	"witness_scripts": "idx_witness_scripts_transaction_id",
+	"redeemer":        "idx_redeemer_transaction_id",
+	"plutus_data":     "idx_plutus_data_transaction_id",
+}
+
+// newAPIModeSQLStore opens an API-mode store on its own data directory. Only
+// API mode writes the witness tables at all, so it is the only mode where the
+// cleanup deletes run.
+func newAPIModeSQLStore(t *testing.T) (*sqlstore.Store, *sql.DB) {
+	t.Helper()
+	store, writeDB, _, err := openSQLStore(
+		Config{DataDir: t.TempDir()},
+		metadata.ProviderDependencies{StorageMode: types.StorageModeAPI},
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.Start(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	return store, writeDB
+}
+
+// queryPlan returns the planner's description of stmt, one node per line.
+//
+// The statement carries a bound parameter, so a value is supplied even though
+// EXPLAIN QUERY PLAN never runs the DELETE it describes.
+func queryPlan(t *testing.T, db *sql.DB, stmt string, args ...any) string {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN QUERY PLAN "+stmt, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan.WriteString(detail)
+		plan.WriteString("\n")
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, plan.String(), "the planner must describe %q", stmt)
+	return plan.String()
+}
+
+// seedWitnessRows adds one transaction, and one row in each witness table, for
+// every slot in [from, to).
+//
+// Written as set-based SQL rather than through SetTransaction so a cardinality
+// sweep can reach a table size where a full scan is distinguishable from an
+// index descent without spending the whole test budget on inserts. The columns
+// and foreign keys are the ones the store writes; slot doubles as the seed
+// ordinal so each step can extend the previous one.
+func seedWitnessRows(t *testing.T, db *sql.DB, from, to int) {
+	t.Helper()
+	_, err := db.Exec(`
+WITH RECURSIVE seq(n) AS (
+    SELECT ?
+    UNION ALL
+    SELECT n + 1 FROM seq WHERE n + 1 < ?
+)
+INSERT INTO "transaction" (
+    hash, block_hash, slot, type, fee, collateral_fee, ttl, block_index, valid
+)
+SELECT CAST(n AS BLOB), CAST(n AS BLOB), n, 0, '0', '0', '0', 0, TRUE
+FROM seq`, from, to)
+	require.NoError(t, err)
+	for _, statement := range []string{
+		`INSERT INTO key_witness (vkey, signature, transaction_id, type)
+SELECT hash, hash, id, 0 FROM "transaction" WHERE slot >= ? AND slot < ?`,
+		`INSERT INTO witness_scripts (script_hash, transaction_id, type)
+SELECT hash, id, 0 FROM "transaction" WHERE slot >= ? AND slot < ?`,
+		`INSERT INTO redeemer (
+    data, transaction_id, ex_units_memory, ex_units_cpu, "index", tag
+)
+SELECT hash, id, 0, 0, 0, 0 FROM "transaction" WHERE slot >= ? AND slot < ?`,
+		`INSERT INTO plutus_data (data, transaction_id)
+SELECT hash, id FROM "transaction" WHERE slot >= ? AND slot < ?`,
+	} {
+		_, err := db.Exec(statement, from, to)
+		require.NoError(t, err)
+	}
+	// Mirror node.RunPlannerStats, which Mithril runs immediately before
+	// backfill: the plan asserted below has to be the plan the planner picks
+	// with statistics present, not the one it picks in their absence.
+	_, err = db.Exec("ANALYZE")
+	require.NoError(t, err)
+}
+
+// TestTransactionWitnessCleanupStaysIndexedAfterDeferredIndexDrop covers issue
+// #3253.
+//
+// Mithril drops the deferred-index manifest before API-mode historical
+// backfill, and backfill then calls SetTransaction for every transaction it
+// replays. Each of those calls clears the four witness tables by
+// transaction_id first. With the manifest deferring the transaction_id index on
+// three of those tables, each delete became a full scan of a table that grows
+// with every transaction written, so per-transaction cost rose with the row
+// count already present: measured on preview, backfill fell from 3311 to 9
+// blocks/sec and its own ETA climbed from 30m to 177h.
+//
+// The plan is asserted rather than the index's existence: an index the planner
+// does not choose is a write cost with no read benefit, and it is EXPLAINed
+// from the store's own exported statement so the plan pinned here is the plan
+// of the delete that actually runs.
+func TestTransactionWitnessCleanupStaysIndexedAfterDeferredIndexDrop(
+	t *testing.T,
+) {
+	t.Parallel()
+	store, db := newAPIModeSQLStore(t)
+	seedWitnessRows(t, db, 0, 2000)
+
+	assertIndexed := func(t *testing.T, when string) {
+		t.Helper()
+		for _, table := range sqlstore.TransactionWitnessTables() {
+			index, ok := transactionWitnessCleanupIndexes[table]
+			require.True(
+				t,
+				ok,
+				"table %q has no expected cleanup index; a new witness "+
+					"table needs its transaction_id index classified for "+
+					"bulk load",
+				table,
+			)
+			plan := queryPlan(
+				t,
+				db,
+				sqlstore.TransactionWitnessCleanupSQL(table),
+				1,
+			)
+			// SQLite reports a covering index as "USING COVERING INDEX",
+			// so the index name and the equality it resolves are matched
+			// rather than one literal spelling of the whole node.
+			require.Contains(
+				t,
+				plan,
+				"SEARCH "+table+" USING",
+				"%s: the %s idempotency delete must be an indexed search:\n%s",
+				when, table, plan,
+			)
+			require.Contains(
+				t,
+				plan,
+				"INDEX "+index+" (transaction_id=?)",
+				"%s: the %s idempotency delete must resolve transaction_id "+
+					"through %s:\n%s",
+				when, table, index, plan,
+			)
+			require.NotContains(
+				t,
+				plan,
+				"SCAN "+table,
+				"%s: the %s idempotency delete must not scan the table:\n%s",
+				when, table, plan,
+			)
+		}
+	}
+
+	assertIndexed(t, "before deferring indexes")
+	require.NoError(t, store.DropDeferredIndexes())
+	assertIndexed(t, "after DropDeferredIndexes")
+}
+
+// witnessCleanupSweep returns the median duration of one full witness-cleanup
+// pass at each cardinality in steps.
+//
+// Every delete targets a transaction_id that owns no rows, so the pass removes
+// nothing and the table size stays fixed across repetitions. That makes each
+// measurement the cost of locating the (absent) rows and nothing else: a
+// bounded number of b-tree descents when the predicate column is indexed, a
+// full pass over the table when it is not.
+func witnessCleanupSweep(
+	t *testing.T,
+	db *sql.DB,
+	steps []int,
+	repetitions int,
+) []time.Duration {
+	t.Helper()
+	tables := sqlstore.TransactionWitnessTables()
+	statements := make([]*sql.Stmt, 0, len(tables))
+	for _, table := range tables {
+		stmt, err := db.Prepare(sqlstore.TransactionWitnessCleanupSQL(table))
+		require.NoError(t, err)
+		defer stmt.Close()
+		statements = append(statements, stmt)
+	}
+	medians := make([]time.Duration, 0, len(steps))
+	seeded := 0
+	for _, step := range steps {
+		seedWitnessRows(t, db, seeded, step)
+		seeded = step
+		samples := make([]time.Duration, 0, repetitions)
+		for i := range repetitions {
+			// An id past every seeded transaction: present in no witness
+			// table, so the delete matches nothing at any cardinality.
+			missing := step*2 + i
+			start := time.Now()
+			for _, stmt := range statements {
+				_, err := stmt.Exec(missing)
+				require.NoError(t, err)
+			}
+			samples = append(samples, time.Since(start))
+		}
+		slices.Sort(samples)
+		medians = append(medians, samples[len(samples)/2])
+	}
+	return medians
+}
+
+// TestTransactionWitnessCleanupCostFlatAcrossCardinality is the cardinality
+// sweep behind issue #3253: per-transaction cleanup cost must not grow with the
+// number of transactions already written.
+//
+// The absolute durations are not asserted -- a shared machine makes any
+// wall-clock threshold a coin flip. What is asserted is the growth ratio across
+// an eightfold increase in rows, measured against a control store in the same
+// process that additionally drops the three indexes this fix retains. The
+// control both reproduces the reported decay and proves the measurement can
+// see it, so a flat result from the fixed store is a real result rather than a
+// sweep too small to distinguish the two.
+func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
+	t.Parallel()
+	steps := []int{500, 1000, 2000, 4000}
+	const repetitions = 21
+
+	fixedStore, fixedDB := newAPIModeSQLStore(t)
+	require.NoError(t, fixedStore.DropDeferredIndexes())
+
+	controlStore, controlDB := newAPIModeSQLStore(t)
+	require.NoError(t, controlStore.DropDeferredIndexes())
+	for table, index := range transactionWitnessCleanupIndexes {
+		if table == "plutus_data" {
+			// Retained by the manifest all along, and the control for the
+			// three that were not: leaving it indexed keeps the two stores
+			// different in exactly the three indexes under test.
+			continue
+		}
+		_, err := controlDB.Exec("DROP INDEX IF EXISTS " + index)
+		require.NoError(t, err)
+	}
+
+	fixed := witnessCleanupSweep(t, fixedDB, steps, repetitions)
+	control := witnessCleanupSweep(t, controlDB, steps, repetitions)
+	t.Logf("rows=%v fixed=%v control=%v", steps, fixed, control)
+
+	ratio := func(medians []time.Duration) float64 {
+		return float64(medians[len(medians)-1]) / float64(medians[0])
+	}
+	fixedRatio := ratio(fixed)
+	controlRatio := ratio(control)
+	growth := float64(slices.Max(steps)) / float64(slices.Min(steps))
+
+	require.Greater(
+		t,
+		controlRatio,
+		growth/2,
+		"control (three transaction_id indexes dropped) must show the "+
+			"reported decay, or this sweep is too small to measure "+
+			"anything: rows grew %.0fx, cost grew %.1fx (fixed %v, "+
+			"control %v)",
+		growth, controlRatio, fixed, control,
+	)
+	require.Less(
+		t,
+		fixedRatio,
+		3.0,
+		"cleanup cost must stay flat as rows grow: rows grew %.0fx, cost "+
+			"grew %.1fx (fixed %v)",
+		growth, fixedRatio, fixed,
+	)
+	require.Less(
+		t,
+		fixedRatio*2,
+		controlRatio,
+		"the retained indexes must measurably flatten the curve: fixed "+
+			"grew %.1fx, control grew %.1fx",
+		fixedRatio, controlRatio,
+	)
+}
+
+// TestSetTransactionCostFlatAfterDeferredIndexDrop widens the sweep above from
+// the witness cleanup to the whole API-mode write path, on the schema Mithril
+// backfill actually runs against: every deferred index dropped, statistics
+// analyzed, transactions arriving one after another.
+//
+// The narrow sweep proves the three retained indexes fix the deletes they were
+// added for. This one is the class check behind it: no predicate the
+// per-transaction write path filters on may be answered by an index the
+// manifest defers, and the only way to see that is to write transactions
+// through the store and watch the cost as the tables grow.
+//
+// The tables are grown with the same set-based seeding the narrow sweep uses,
+// and only a fixed window of transactions is timed at each cardinality. Cost
+// here is a function of the rows already present, not of how they arrived, so
+// seeding buys the eightfold spread that makes the difference visible without
+// spending the test budget writing rows nobody measures.
+func TestSetTransactionCostFlatAfterDeferredIndexDrop(t *testing.T) {
+	t.Parallel()
+	steps := []int{2000, 4000, 8000, 16000}
+	// Timed transactions per cardinality. Odd, so the median is a sample.
+	const timed = 121
+	// Slots well clear of the seeded range, which seedWitnessRows selects by
+	// slot when it attaches witness rows.
+	const timedSlotBase = 1_000_000
+
+	store, db := newAPIModeSQLStore(t)
+	require.NoError(t, store.DropDeferredIndexes())
+
+	blockHash := bytes.Repeat([]byte{0x5d}, 32)
+	seeded := 0
+	written := 0
+	medians := make([]time.Duration, 0, len(steps))
+	for _, step := range steps {
+		seedWitnessRows(t, db, seeded, step)
+		seeded = step
+		samples := make([]time.Duration, 0, timed)
+		for range timed {
+			transaction := newTestWitnessTransaction(
+				fmt.Sprintf("deferred-index-sweep-%07d", written),
+			)
+			point := ocommon.Point{
+				Slot: uint64(timedSlotBase + written),
+				Hash: blockHash,
+			}
+			start := time.Now()
+			require.NoError(t, store.SetTransaction(
+				transaction, point, 0, nil, true, nil,
+			))
+			samples = append(samples, time.Since(start))
+			written++
+		}
+		slices.Sort(samples)
+		medians = append(medians, samples[len(samples)/2])
+	}
+	t.Logf("rows=%v median SetTransaction=%v", steps, medians)
+
+	growth := float64(slices.Max(steps)) / float64(slices.Min(steps))
+	ratio := float64(medians[len(medians)-1]) / float64(medians[0])
+	require.Less(
+		t,
+		ratio,
+		1.5,
+		"per-transaction write cost must not track the rows already "+
+			"written: rows grew %.0fx, median cost grew %.1fx (%v)",
+		growth, ratio, medians,
+	)
+}

--- a/database/plugin/metadata/sqlstore/deferred_indexes.go
+++ b/database/plugin/metadata/sqlstore/deferred_indexes.go
@@ -27,9 +27,17 @@ import (
 
 var _ metadata.DeferredIndexManager = (*Store)(nil)
 
-// DropDeferredIndexes records the durable recovery marker and drops the
-// manifest in one SQLite transaction.
-func (s *Store) DropDeferredIndexes() error {
+// withDeferredIndexWrite runs fn in one write transaction, with every
+// deferred.Retained index guaranteed resident before fn sees the database.
+//
+// Every entry point in this file returns with the store able to serve writes,
+// and SetTransaction's per-row idempotency deletes are full scans of a growing
+// table without those indexes. An older binary's manifest may have dropped one
+// that this manifest keeps out; the versioned migration that created it is
+// recorded complete, so restoring it here is its only way back. Enforcing that
+// once, on the path every drop and rebuild takes, is what keeps a rebuild path
+// from being added without it.
+func (s *Store) withDeferredIndexWrite(fn func(db queryer) error) error {
 	if err := s.ensureReady(); err != nil {
 		return err
 	}
@@ -37,13 +45,19 @@ func (s *Store) DropDeferredIndexes() error {
 		context.Background(),
 		nil,
 		func(db queryer) error {
-			// An older binary's manifest may have dropped an index this
-			// one keeps out of the manifest, so restore those before
-			// dropping anything: the cycle about to start is the one whose
-			// per-row predicates need them.
 			if err := s.ensureRetainedIndexes(db); err != nil {
 				return err
 			}
+			return fn(db)
+		},
+	)
+}
+
+// DropDeferredIndexes records the durable recovery marker and drops the
+// manifest in one SQLite transaction.
+func (s *Store) DropDeferredIndexes() error {
+	return s.withDeferredIndexWrite(
+		func(db queryer) error {
 			if _, err := db.ExecContext(
 				context.Background(),
 				`INSERT INTO sync_state (sync_key, value) VALUES (?, ?)
@@ -121,22 +135,8 @@ func (s *Store) buildDeferredIndexes(
 	indexes []deferred.Index,
 	clearPending bool,
 ) error {
-	if err := s.ensureReady(); err != nil {
-		return err
-	}
-	return s.withWriteTransaction(
-		context.Background(),
-		nil,
+	return s.withDeferredIndexWrite(
 		func(db queryer) error {
-			if clearPending {
-				// The marker can outlive the binary that set it. Clearing
-				// it asserts that every index an older manifest may have
-				// dropped is back, including the ones this manifest no
-				// longer carries.
-				if err := s.ensureRetainedIndexes(db); err != nil {
-					return err
-				}
-			}
 			for _, index := range indexes {
 				exists, err := s.deferredIndexExists(db, index)
 				if err != nil {

--- a/database/plugin/metadata/sqlstore/deferred_indexes.go
+++ b/database/plugin/metadata/sqlstore/deferred_indexes.go
@@ -37,6 +37,13 @@ func (s *Store) DropDeferredIndexes() error {
 		context.Background(),
 		nil,
 		func(db queryer) error {
+			// An older binary's manifest may have dropped an index this
+			// one keeps out of the manifest, so restore those before
+			// dropping anything: the cycle about to start is the one whose
+			// per-row predicates need them.
+			if err := s.ensureRetainedIndexes(db); err != nil {
+				return err
+			}
 			if _, err := db.ExecContext(
 				context.Background(),
 				`INSERT INTO sync_state (sync_key, value) VALUES (?, ?)
@@ -121,6 +128,15 @@ func (s *Store) buildDeferredIndexes(
 		context.Background(),
 		nil,
 		func(db queryer) error {
+			if clearPending {
+				// The marker can outlive the binary that set it. Clearing
+				// it asserts that every index an older manifest may have
+				// dropped is back, including the ones this manifest no
+				// longer carries.
+				if err := s.ensureRetainedIndexes(db); err != nil {
+					return err
+				}
+			}
 			for _, index := range indexes {
 				exists, err := s.deferredIndexExists(db, index)
 				if err != nil {
@@ -164,6 +180,40 @@ func (s *Store) buildDeferredIndexes(
 			return nil
 		},
 	)
+}
+
+// ensureRetainedIndexes creates any deferred.Retained index missing from the
+// schema. Present indexes cost one catalog lookup each and are left alone.
+func (s *Store) ensureRetainedIndexes(db queryer) error {
+	for _, index := range deferred.Retained {
+		exists, err := s.deferredIndexExists(db, index)
+		if err != nil {
+			return fmt.Errorf(
+				"check retained index %s: %w",
+				index.Name,
+				err,
+			)
+		}
+		if exists {
+			continue
+		}
+		statement := s.dialect.CreateIndexSQL(
+			index.Name,
+			index.Table,
+			index.Columns,
+		)
+		if _, err := db.ExecContext(
+			context.Background(),
+			statement,
+		); err != nil {
+			return fmt.Errorf(
+				"restore retained index %s: %w",
+				index.Name,
+				err,
+			)
+		}
+	}
+	return nil
 }
 
 func (s *Store) deferredIndexExists(

--- a/database/plugin/metadata/sqlstore/dialect_integration_test.go
+++ b/database/plugin/metadata/sqlstore/dialect_integration_test.go
@@ -340,6 +340,30 @@ INSERT INTO redeemer (
 	pending, err := store.HasDeferredIndexesPending()
 	require.NoError(t, err)
 	require.True(t, pending)
+
+	// The critical rebuild is the last step before the node serves API
+	// writes, so it restores the retained set too. Drop it again to reach the
+	// state a cycle interrupted by an older binary leaves behind.
+	_, err = db.Exec(dialect.DropIndexSQL(retained.Name, retained.Table))
+	require.NoError(t, err)
+	require.NoError(t, store.BuildCriticalDeferredIndexes())
+	exists, err = store.deferredIndexExists(catalog, retained)
+	require.NoError(t, err)
+	require.True(
+		t,
+		exists,
+		"%s must be restored by the critical rebuild on %s",
+		retained.Name,
+		dialect.Name(),
+	)
+	pending, err = store.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.True(
+		t,
+		pending,
+		"the critical rebuild must leave the marker for the lazy remainder",
+	)
+
 	require.NoError(t, store.BuildDeferredIndexes())
 	pending, err = store.HasDeferredIndexesPending()
 	require.NoError(t, err)

--- a/database/plugin/metadata/sqlstore/dialect_integration_test.go
+++ b/database/plugin/metadata/sqlstore/dialect_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore/migrations"
 	"github.com/blinklabs-io/dingo/database/types"
 	mysqldriver "github.com/go-sql-driver/mysql"
@@ -294,10 +295,48 @@ INSERT INTO redeemer (
 	).Scan(&redeemerCount))
 	require.Equal(t, 1, redeemerCount)
 
+	// Restoring a retained index is dialect DDL of its own, so simulate the
+	// state a binary whose manifest still deferred one leaves on disk.
+	// idx_utxo_staking_deleted_amount is the composite case: it is not a
+	// foreign-key child index, so every dialect can drop it, and it includes
+	// columns MySQL can only key with an explicit prefix length.
+	var retained deferred.Index
+	for _, index := range deferred.Retained {
+		if index.Name == "idx_utxo_staking_deleted_amount" {
+			retained = index
+		}
+	}
+	require.NotEmpty(
+		t,
+		retained.Name,
+		"deferred.Retained must still name the composite live-stake index",
+	)
+	catalog := newDialectQueryer(db, dialect.Name())
+	_, err = db.Exec(dialect.DropIndexSQL(retained.Name, retained.Table))
+	require.NoError(t, err)
+	exists, err := store.deferredIndexExists(catalog, retained)
+	require.NoError(t, err)
+	require.False(
+		t,
+		exists,
+		"the simulated pre-change cycle must leave %s absent",
+		retained.Name,
+	)
+
 	// The deferred-index lifecycle is also shared across dialects.  In
 	// particular, MySQL requires `DROP INDEX ... ON table` and a non-IF-NOT-
 	// EXISTS CREATE form, while sync_state has no synthetic id column.
 	require.NoError(t, store.DropDeferredIndexes())
+	exists, err = store.deferredIndexExists(catalog, retained)
+	require.NoError(t, err)
+	require.True(
+		t,
+		exists,
+		"%s must be restored on %s: an index the manifest no longer names "+
+			"has no other path back",
+		retained.Name,
+		dialect.Name(),
+	)
 	pending, err := store.HasDeferredIndexesPending()
 	require.NoError(t, err)
 	require.True(t, pending)

--- a/database/plugin/metadata/sqlstore/transaction_api.go
+++ b/database/plugin/metadata/sqlstore/transaction_api.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -317,21 +318,45 @@ INSERT INTO address_transaction (
 	return nil
 }
 
+// transactionWitnessTables are the per-transaction detail tables
+// storeTransactionWitnesses rewrites wholesale. Every SetTransaction clears
+// the rows the previous attempt left behind before re-inserting, so a
+// re-processed block cannot accumulate duplicate witnesses.
+var transactionWitnessTables = []string{
+	"key_witness",
+	"witness_scripts",
+	"redeemer",
+	"plutus_data",
+}
+
+// TransactionWitnessTables lists the tables TransactionWitnessCleanupSQL is
+// issued against, in the order storeTransactionWitnesses clears them.
+func TransactionWitnessTables() []string {
+	return slices.Clone(transactionWitnessTables)
+}
+
+// TransactionWitnessCleanupSQL is the idempotency delete storeTransactionWitnesses
+// runs against one witness table on every API-mode SetTransaction.
+//
+// Exported so a test can pin its query plan against the statement the store
+// actually runs. The predicate column must stay indexed through bulk load:
+// unindexed, each of these deletes degrades into a full scan of a table that
+// grows with every transaction written, which makes historical backfill
+// quadratic (issue #3253).
+func TransactionWitnessCleanupSQL(table string) string {
+	return "DELETE FROM " + table + " WHERE transaction_id = ?"
+}
+
 func storeTransactionWitnesses(
 	db queryer,
 	transactionID int64,
 	transaction lcommon.Transaction,
 	slot uint64,
 ) error {
-	for _, table := range []string{
-		"key_witness",
-		"witness_scripts",
-		"redeemer",
-		"plutus_data",
-	} {
+	for _, table := range transactionWitnessTables {
 		if _, err := db.ExecContext(
 			context.Background(),
-			"DELETE FROM "+table+" WHERE transaction_id = ?",
+			TransactionWitnessCleanupSQL(table),
 			transactionID,
 		); err != nil {
 			return fmt.Errorf("delete existing %s rows: %w", table, err)


### PR DESCRIPTION
Closes #3253.

`mithril/sync.go` calls `node.WithDeferredIndexes(db, logger)` → `DropDeferredIndexes()` before backfill, and `BuildCritical()` afterwards. None of `idx_key_witness_transaction_id`, `idx_witness_scripts_transaction_id`, or `idx_redeemer_transaction_id` was marked `Critical`, so all three stayed absent for the whole backfill — while `storeTransactionWitnesses` runs an unconditional `DELETE FROM <table> WHERE transaction_id = ?` over `key_witness`, `witness_scripts`, `redeemer`, and `plutus_data` on every API-mode `SetTransaction`.

Measured on the migrated SQLite schema: before the drop, `SEARCH key_witness USING COVERING INDEX idx_key_witness_transaction_id (transaction_id=?)`; after it, `SCAN key_witness`. `plutus_data` keeps an indexed SEARCH throughout — its index was never in the manifest. The deletes therefore become growing full-table scans per transaction, which is the asymptotic decay the issue measured (3311 → 9 blocks/s).

Fix: remove the three entries from `deferred.Manifest` rather than skipping cleanup for newly inserted transactions. Skipping cleanup would require distinguishing insert from upsert behind `INSERT … ON CONFLICT (hash) DO UPDATE … RETURNING id` in three dialects and threading that through `address_transaction` and the certificate tables. Retaining is dialect-neutral and matches the manifest's own eligibility rule, the existing `idx_utxo_staking_deleted_amount` precedent for the same bug class, and the treatment of `plutus_data`, `address_transaction`, and `idx_certs_transaction_id`. Insert-side cost is one b-tree insert per witness row against a growing full scan per transaction.

MySQL was already immune: `mysqlForeignKeyIndexes` in `sqlstore/dialect.go` lists exactly these three as undroppable FK-child indexes, so only SQLite and PostgreSQL ever dropped them. That entry is left in place — the InnoDB fact still holds and it keeps MySQL protected if an entry is ever re-added to the manifest.

Every other `WHERE transaction_id` predicate in the write path was checked against the manifest (`address_transaction`, `plutus_data`, `certs`, `utxo`); none of the others were deferred, and `utxo`'s write predicates are on the protected `(tx_id, output_idx)` unique index.

Tests, all proven failing before the fix:

- `TestManifestKeepsImportIdempotencyIndexes` — names all three.
- `TestTransactionWitnessCleanupStaysIndexedAfterDeferredIndexDrop` — asserts `SEARCH … USING [COVERING] INDEX <name> (transaction_id=?)` and `NOT SCAN <table>` on the post-drop schema after `ANALYZE`.
- `TestTransactionWitnessCleanupCostFlatAcrossCardinality` — growth ratio over an 8× row increase, with an in-process control store that has only these three indexes dropped, so it proves it can see the regression it denies (control 11.4 → 68.7 ms, 6.0×; fixed 3.01/2.98/3.04/2.93 ms, 1.0×).
- `TestSetTransactionCostFlatAfterDeferredIndexDrop` — end-to-end sweep (pre-fix median 39.7 → 273.7 ms, 6.9×; fixed 10.3/8.0/7.0/6.9 ms).

No wall-clock thresholds are asserted, so the sweeps do not flake on a loaded machine.

`transaction_api.go` now uses exported `TransactionWitnessTables()` / `TransactionWitnessCleanupSQL()` so the plan test EXPLAINs the statement the store actually runs, following the `LatestPoolOpCertSequencesSQL` precedent. No behavior change.

`SetTransactionBatched`'s accumulator is a genuine no-op and `FlushBatch` only calls `Reset()`, but `internal/node/backfill.go` already wraps a whole batch in one `database.Txn`, so the missing row batching costs per-statement overhead, not asymptotic cost. Left unchanged; with the deletes indexed, per-transaction cost is flat.

DATABASE.md and ARCHITECTURE.md updated with the general rule and what it keeps out of the manifest.

Only SQLite was exercised. PostgreSQL shares the manifest and is fixed by the same change, but its opt-in backend needs a live server; MySQL never had the defect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep witness-table transaction_id indexes resident during bulk deferral and repair older databases that dropped them, so API-mode backfill keeps indexed per-transaction cleanup. Previously these indexes were deferred and DELETE … WHERE transaction_id degraded into table scans; now they are excluded from the manifest, restored from a retained list, and ensured before any drop or rebuild, including the critical rebuild (SQLite/PostgreSQL affected; MySQL unchanged).

- Review focus:
  - `database/plugin/metadata/deferred/deferred.go`: remove three witness `transaction_id` indexes from `Manifest`; add `Retained` for import-path predicates (`key_witness`, `witness_scripts`, `redeemer`, `plutus_data`, `address_transaction`, `certs`, `idx_utxo_staking_deleted_amount`); document the rule and repair requirement.
  - `database/plugin/metadata/sqlstore/deferred_indexes.go`: add `withDeferredIndexWrite()` and `ensureRetainedIndexes()` to guarantee retained indexes exist before any index drop or rebuild; wrap `DropDeferredIndexes()`, `BuildCriticalDeferredIndexes()`, and `BuildDeferredIndexes()`.
  - `database/plugin/metadata/sqlstore/transaction_api.go`: export `TransactionWitnessTables()` and `TransactionWitnessCleanupSQL()`; no write-path behavior change.
  - Tests: SQLite EXPLAIN and timing sweeps now compare a fixed store against a control store with the pre-change manifest to isolate scan cost; repair tests cover both the critical and full rebuild paths; dialect test verifies cross-dialect DDL for retained-index restoration.
  - Docs: `DATABASE.md` and `ARCHITECTURE.md` record non-deferrable indexes and the retained-index repair behavior.

- Rollout:
  - No migration. Databases that previously dropped these indexes are repaired automatically at the start of the next bulk-load cycle, by the pending-marker repair, or during the critical rebuild; the `sync_state` marker is not cleared until retained indexes exist. MySQL unaffected.

<sup>Written for commit 676155a59842760d391a1f6fb444ad6ec124af5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved critical indexes used during imports and transaction cleanup.
  * Automatically restores missing indexes during deferred-index drops and rebuilds, including upgrades from older database versions.
  * Maintained efficient witness-data cleanup performance as transaction data grows.
  * Improved reliability across supported database dialects and critical-index rebuild workflows.

* **Documentation**
  * Clarified index classifications, retained-index requirements, and database upgrade behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->