### PR TITLE
build: move gouroboros back to a release version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.27.8
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.193.4-0.20260821025747-7f9fce84e569
+	github.com/blinklabs-io/gouroboros v0.194.0
 	github.com/blinklabs-io/ouroboros-mock v0.16.0
 	github.com/blinklabs-io/plutigo v0.3.0
 	github.com/blockfrost/blockfrost-go v0.5.0
@@ -54,7 +54,7 @@ require (
 	google.golang.org/api v0.293.0
 	google.golang.org/grpc v1.83.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.56.0
 )

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.193.4-0.20260821025747-7f9fce84e569 h1:I5imoujonJLufV7HmExlfBl4k172arV8P6lVzoXZq6c=
-github.com/blinklabs-io/gouroboros v0.193.4-0.20260821025747-7f9fce84e569/go.mod h1:wCrv86t7VsYhW36JliNeaoqypbxU/WsB1Cq/9OMg0NA=
+github.com/blinklabs-io/gouroboros v0.194.0 h1:bSVql0a+J/lxZrKiyU4EwFDkOjCrJDwpBK6sH7C1DME=
+github.com/blinklabs-io/gouroboros v0.194.0/go.mod h1:DlEr37DxujCOKnT7aIZONg/Wxx1DxkmrP8riKCa41LM=
 github.com/blinklabs-io/ouroboros-mock v0.16.0 h1:uAPoFE+WOXX9hct1Kb725gYS/8SKzATrwCF7XKOZ0Xs=
 github.com/blinklabs-io/ouroboros-mock v0.16.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.3.0 h1:lUl7q96a+XSxpd7iEh0AxvnyMNp9s1wZITv/3RuCfkA=
@@ -615,8 +615,8 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
Merging #3259 left `main` depending on gouroboros pseudo-version `v0.193.4-0.20260821025747-7f9fce84e569`. That commit — `fix(ledger): drop the PlutusV1 reference-script rejection` — exists only on the un-deleted PR branch `origin/fix/plutusv1-needed-scripts` in gouroboros. It is not on gouroboros `main` and was not in any tag, so deleting that branch would break `go mod download` for anyone without a warm module-proxy cache. The equivalent work is on gouroboros `main` as `c8eb077`, the squash of gouroboros#1980, under a different SHA.

gouroboros v0.194.0 has since been tagged at `c8eb077`, so this moves the dependency back onto a release.

v0.194.0 also carries `fix(consensus)!`: Genesis density-first chain selection for deep forks, which is why this ran the full suite rather than a narrow slice.

`go mod tidy` also pulled `google.golang.org/protobuf` 1.36.11 → 1.36.12.

Validation:

- `go build ./...` — exit 0
- `make test` (`-tags dingo_extra_plugins -v -race -timeout 20m ./...`) — 79 packages ok, 0 FAIL, 0 panics. The consensus- and ledger-relevant packages pass under the breaking selection change: `ledger` 843.9s, `ledgerstate` 271.5s, `ledger/governance` 147.6s, `ledger/snapshot` 148.8s, `consensus/praos`, `ledger/leader`, `ledger/leios`, `ledger/hardfork`, `ledger/eras`, `ledger/forging`.

`internal/test/antithesis` is a separate module and still pins gouroboros v0.163.4; #3304 moves it to v0.194.0 independently, so the large transitive delta lands on its own.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `github.com/blinklabs-io/gouroboros` from a pseudo-version tied to a PR branch to the released `v0.194.0` to ensure stable `go mod download` and align with upstream. Also bumps `google.golang.org/protobuf` to `v1.36.12`.

- Consensus behavior change: deep-fork chain selection now uses genesis density-first (replaces the previous logic). Full suite passed across consensus and ledger packages.
- Only `go.mod` and `go.sum` changed; no code changes.
- The `internal/test/antithesis` module remains on `gouroboros v0.163.4` and will be upgraded separately in #3304.

<sup>Written for commit c18c8d216a0030f723b1ca173eb6b244fecca7d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

