### PR TITLE
fix(api): define Byron-era protocol-parameter behavior

### DIFF
--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -706,10 +706,27 @@ func (a *NodeAdapter) EpochProtocolParams(
 		)
 	}
 	if len(pparamRows) == 0 {
+		// The epoch row resolved above, so the epoch itself exists; only
+		// its parameters do not. Byron is the era where that is the norm
+		// rather than a gap, and it stays reachable long after a sync
+		// completes via GET /epochs/0/parameters. Reporting "epoch not
+		// found" would tell the caller something false about what the node
+		// holds.
 		return ProtocolParamsInfo{}, fmt.Errorf(
 			"get protocol parameters for epoch %d: %w",
 			epoch,
-			ErrEpochNotFound,
+			ErrProtocolParamsUnavailable,
+		)
+	}
+	if era.DecodePParamsFunc == nil {
+		// ByronEraDesc defines no decoder because the era has no parameter
+		// CBOR to decode. Unreachable while the empty-rows check above
+		// runs first, but the nil call would panic if that ever reordered.
+		return ProtocolParamsInfo{}, fmt.Errorf(
+			"get protocol parameters for epoch %d: era %d: %w",
+			epoch,
+			era.Id,
+			ErrProtocolParamsUnavailable,
 		)
 	}
 	pparamRow := pparamRows[0]

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -84,7 +84,20 @@ var (
 func drepInactivityFromPParams(
 	pparams lcommon.ProtocolParameters,
 ) (uint64, bool) {
-	return 0, false
+	// Dijkstra embeds ConwayProtocolParameters, but a type switch matches
+	// concrete types, so *Dijkstra never falls into the *Conway case and each
+	// era needs its own arm.
+	switch pp := pparams.(type) {
+	case *dijkstra.DijkstraProtocolParameters:
+		return pp.DRepInactivityPeriod, true
+	case *conway.ConwayProtocolParameters:
+		return pp.DRepInactivityPeriod, true
+	default:
+		// Byron has no protocol parameters at all, and every era before
+		// Conway has parameters but no DRep semantics. Neither can report a
+		// drep_activity value, and neither may borrow one.
+		return 0, false
+	}
 }
 
 // TransactionSubmitter accepts raw transaction CBOR for mempool admission.
@@ -623,9 +636,10 @@ func (a *NodeAdapter) CurrentProtocolParams() (
 ) {
 	pparams := a.ledgerState.GetCurrentPParams()
 	if pparams == nil {
-		return ProtocolParamsInfo{}, errors.New(
-			"protocol parameters not available",
-		)
+		// A Byron prefix has no protocol-parameter CBOR to report. Surface
+		// the sentinel so the handler can answer "not found" rather than
+		// reporting a node fault for an expected stage of a genesis sync.
+		return ProtocolParamsInfo{}, ErrProtocolParamsUnavailable
 	}
 	info, err := protocolParamsInfoFromNative(
 		pparams,
@@ -1227,17 +1241,13 @@ func (a *NodeAdapter) predefinedDRep(
 }
 
 // drepInactivityPeriod returns the Conway-era drep_activity protocol
-// parameter (epochs of inactivity before a DRep expires), or 0 when it
-// is unavailable.
+// parameter (epochs of inactivity before a DRep expires) from the current
+// ledger state. The second return reports whether a value was available; see
+// drepInactivityFromPParams.
 func (a *NodeAdapter) drepInactivityPeriod() (uint64, bool) {
-	switch pp := a.ledgerState.GetCurrentPParams().(type) {
-	case *conway.ConwayProtocolParameters:
-		return pp.DRepInactivityPeriod, true
-	case *dijkstra.DijkstraProtocolParameters:
-		return pp.DRepInactivityPeriod, true
-	default:
-		return 0, false
-	}
+	return drepInactivityFromPParams(
+		a.ledgerState.GetCurrentPParams(),
+	)
 }
 
 // drepStatus derives the Blockfrost retirement/expiry view of a DRep
@@ -1251,6 +1261,7 @@ func drepStatus(
 	registrationEpoch uint64,
 	currentEpoch uint64,
 	inactivityPeriod uint64,
+	inactivityKnown bool,
 ) (retired bool, expired bool, lastActive uint64) {
 	retired = !active
 	lastActive = lastActivityEpoch
@@ -1258,7 +1269,11 @@ func drepStatus(
 		lastActive = registrationEpoch
 	}
 	expiry := expiryEpoch
-	if expiry == 0 && inactivityPeriod > 0 {
+	// Derive an expiry only when the era actually reports drep_activity.
+	// Gating on "inactivityPeriod > 0" instead would conflate an era with no
+	// DRep semantics against a chain that set drep_activity to 0, where a
+	// DRep expires the epoch it last acted.
+	if expiry == 0 && inactivityKnown {
 		expiry = lastActive + inactivityPeriod
 	}
 	expired = !retired && expiry > 0 && expiry <= currentEpoch
@@ -1328,7 +1343,7 @@ func (a *NodeAdapter) drepByCredentialTag(
 		)
 	}
 
-	inactivityPeriod, _ := a.drepInactivityPeriod()
+	inactivityPeriod, inactivityKnown := a.drepInactivityPeriod()
 	retired, expired, lastActive := drepStatus(
 		drep.Active,
 		drep.LastActivityEpoch,
@@ -1336,6 +1351,7 @@ func (a *NodeAdapter) drepByCredentialTag(
 		registrationEpoch.EpochId,
 		a.ledgerState.CurrentEpoch(),
 		inactivityPeriod,
+		inactivityKnown,
 	)
 
 	// Echo the identifier form the caller used: CIP-129 inputs carry
@@ -1423,7 +1439,7 @@ func (a *NodeAdapter) DReps(
 	}
 
 	currentEpoch := a.ledgerState.CurrentEpoch()
-	inactivity, _ := a.drepInactivityPeriod()
+	inactivity, inactivityKnown := a.drepInactivityPeriod()
 
 	type entry struct {
 		predefined *uint64
@@ -1455,6 +1471,7 @@ func (a *NodeAdapter) DReps(
 			epochForSlot(regSlot),
 			currentEpoch,
 			inactivity,
+			inactivityKnown,
 		)
 		entries = append(entries, entry{
 			credential: drep.Credential,
@@ -5012,7 +5029,7 @@ func (a *NodeAdapter) protocolParamsForSlot(
 	if epoch == nil {
 		pparams := a.ledgerState.GetCurrentPParams()
 		if pparams == nil {
-			return nil, errors.New("protocol parameters not available")
+			return nil, ErrProtocolParamsUnavailable
 		}
 		return pparams, nil
 	}

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -1268,15 +1268,24 @@ func drepStatus(
 	if lastActive == 0 {
 		lastActive = registrationEpoch
 	}
+	// Track whether an expiry is known separately from its value. A derived
+	// expiry of 0 is legitimate — drep_activity 0 on a DRep that last acted
+	// in epoch 0 — so testing the number for zero would read a real expiry as
+	// "none known" and report that DRep active forever.
+	//
+	// A stored expiry_epoch of 0 still means "not recorded": the column has
+	// no null, and that convention predates this function.
 	expiry := expiryEpoch
+	expiryKnown := expiry > 0
 	// Derive an expiry only when the era actually reports drep_activity.
 	// Gating on "inactivityPeriod > 0" instead would conflate an era with no
 	// DRep semantics against a chain that set drep_activity to 0, where a
 	// DRep expires the epoch it last acted.
-	if expiry == 0 && inactivityKnown {
+	if !expiryKnown && inactivityKnown {
 		expiry = lastActive + inactivityPeriod
+		expiryKnown = true
 	}
-	expired = !retired && expiry > 0 && expiry <= currentEpoch
+	expired = !retired && expiryKnown && expiry <= currentEpoch
 	return retired, expired, lastActive
 }
 

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -67,7 +67,25 @@ var (
 	ErrMempoolFull         = errors.New("mempool full")
 	ErrTransactionNotFound = errors.New("transaction not found")
 	ErrInvalidStakeAddress = errors.New("invalid stake address")
+	// ErrProtocolParamsUnavailable reports that no protocol parameters exist
+	// for the requested point. Byron carries no protocol-parameter CBOR, so a
+	// genuine Byron prefix reaches this during a from-genesis sync; it is an
+	// expected state rather than a node fault, and callers must not
+	// substitute Shelley-shaped defaults for it.
+	ErrProtocolParamsUnavailable = errors.New(
+		"protocol parameters not available",
+	)
 )
+
+// drepInactivityFromPParams reads the Conway-era drep_activity parameter from
+// pparams. The second return reports whether the era defines the parameter at
+// all, which a bare uint64 cannot express: a chain that genuinely configured
+// drep_activity to 0 and an era with no DRep semantics are different facts.
+func drepInactivityFromPParams(
+	pparams lcommon.ProtocolParameters,
+) (uint64, bool) {
+	return 0, false
+}
 
 // TransactionSubmitter accepts raw transaction CBOR for mempool admission.
 type TransactionSubmitter interface {
@@ -1211,14 +1229,14 @@ func (a *NodeAdapter) predefinedDRep(
 // drepInactivityPeriod returns the Conway-era drep_activity protocol
 // parameter (epochs of inactivity before a DRep expires), or 0 when it
 // is unavailable.
-func (a *NodeAdapter) drepInactivityPeriod() uint64 {
+func (a *NodeAdapter) drepInactivityPeriod() (uint64, bool) {
 	switch pp := a.ledgerState.GetCurrentPParams().(type) {
 	case *conway.ConwayProtocolParameters:
-		return pp.DRepInactivityPeriod
+		return pp.DRepInactivityPeriod, true
 	case *dijkstra.DijkstraProtocolParameters:
-		return pp.DRepInactivityPeriod
+		return pp.DRepInactivityPeriod, true
 	default:
-		return 0
+		return 0, false
 	}
 }
 
@@ -1310,13 +1328,14 @@ func (a *NodeAdapter) drepByCredentialTag(
 		)
 	}
 
+	inactivityPeriod, _ := a.drepInactivityPeriod()
 	retired, expired, lastActive := drepStatus(
 		drep.Active,
 		drep.LastActivityEpoch,
 		drep.ExpiryEpoch,
 		registrationEpoch.EpochId,
 		a.ledgerState.CurrentEpoch(),
-		a.drepInactivityPeriod(),
+		inactivityPeriod,
 	)
 
 	// Echo the identifier form the caller used: CIP-129 inputs carry
@@ -1404,7 +1423,7 @@ func (a *NodeAdapter) DReps(
 	}
 
 	currentEpoch := a.ledgerState.CurrentEpoch()
-	inactivity := a.drepInactivityPeriod()
+	inactivity, _ := a.drepInactivityPeriod()
 
 	type entry struct {
 		predefined *uint64

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -5047,7 +5047,17 @@ func (a *NodeAdapter) protocolParamsForSlot(
 		return nil, err
 	}
 	if pparams == nil {
-		return nil, errors.New("decoded protocol parameters are nil")
+		// GetPParams reports (nil, nil) when the era recorded no
+		// protocol-parameter row. Byron is the era that does so by
+		// construction — it has no parameter CBOR and no decoder — so this
+		// carries the same sentinel as the no-epoch-row branch rather than
+		// an untyped error a caller cannot distinguish.
+		return nil, fmt.Errorf(
+			"epoch %d era %d: %w",
+			epoch.EpochId,
+			era.Id,
+			ErrProtocolParamsUnavailable,
+		)
 	}
 	return pparams, nil
 }

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -257,6 +257,24 @@ func (b *Blockfrost) handleLatestEpochParams(
 ) {
 	info, err := b.node.CurrentProtocolParams()
 	if err != nil {
+		// A Byron prefix carries no protocol parameters, which is an
+		// expected stage of a from-genesis sync rather than a node fault.
+		// Reporting 500 here reads as an outage and trips alerting, so
+		// answer 404 as the absent-epoch path already does.
+		if errors.Is(err, ErrProtocolParamsUnavailable) {
+			b.logger.Debug(
+				"no protocol params for current era",
+				"error", err,
+			)
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"Protocol parameters are not available for the "+
+					"current era.",
+			)
+			return
+		}
 		b.logger.Error(
 			"failed to get protocol params",
 			"error", err,

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -312,12 +312,31 @@ func (b *Blockfrost) handleEpochParams(
 	}
 	info, err := b.node.EpochProtocolParams(epoch)
 	if err != nil {
-		b.logger.Error(
-			"failed to get protocol params for epoch",
-			"epoch", epoch,
-			"error", err,
-		)
+		// Log after classifying, not before: an epoch the node does not
+		// hold and a Byron epoch that has no parameters are both expected
+		// answers, and logging them at error level fills the log with
+		// alerts for ordinary queries. This mirrors handleLatestEpochParams.
+		if errors.Is(err, ErrProtocolParamsUnavailable) {
+			b.logger.Debug(
+				"no protocol params for epoch era",
+				"epoch", epoch,
+				"error", err,
+			)
+			writeError(
+				w,
+				http.StatusNotFound,
+				"Not Found",
+				"Protocol parameters are not available for the "+
+					"requested epoch.",
+			)
+			return
+		}
 		if errors.Is(err, ErrEpochNotFound) {
+			b.logger.Debug(
+				"epoch not found",
+				"epoch", epoch,
+				"error", err,
+			)
 			writeError(
 				w,
 				http.StatusNotFound,
@@ -326,6 +345,11 @@ func (b *Blockfrost) handleEpochParams(
 			)
 			return
 		}
+		b.logger.Error(
+			"failed to get protocol params for epoch",
+			"epoch", epoch,
+			"error", err,
+		)
 		writeError(
 			w,
 			http.StatusInternalServerError,

--- a/api/blockfrost/pparams_byron_test.go
+++ b/api/blockfrost/pparams_byron_test.go
@@ -15,7 +15,10 @@
 package blockfrost
 
 import (
+	"bytes"
+	"database/sql"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -304,4 +307,154 @@ VALUES (?, ?, ?, ?)`,
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrProtocolParamsUnavailable)
 	assert.Nil(t, pparams)
+}
+
+// --- EpochProtocolParams: the Byron consumer that outlives the sync --------
+//
+// Unlike CurrentProtocolParams, this path stays reachable forever: GET
+// /api/v0/epochs/0/parameters on a fully synced mainnet node still resolves
+// the Byron epoch row and finds no parameter row. Raised by @wolf31o2 in
+// review.
+
+// insertByronEpoch records a Byron epoch row with no accompanying parameter
+// row, which is how a synced node genuinely stores the Byron prefix.
+func insertByronEpoch(t *testing.T, store *sql.DB, epochID uint64) {
+	t.Helper()
+	_, err := store.Exec(`
+INSERT INTO epoch (epoch_id, start_slot, length_in_slots, era_id)
+VALUES (?, ?, ?, ?)`,
+		epochID, epochID*100, 100, byron.EraIdByron,
+	)
+	require.NoError(t, err)
+}
+
+// TestEpochProtocolParams_ByronEpochReportsParamsNotEpoch separates the two
+// facts the old sentinel ran together. The epoch exists — the node holds it
+// and will answer other queries about it — and only its parameters do not.
+// Reporting "epoch not found" tells a caller something false about the node's
+// contents.
+func TestEpochProtocolParams_ByronEpochReportsParamsNotEpoch(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+	insertByronEpoch(t, store, 0)
+
+	info, err := adapter.EpochProtocolParams(0)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtocolParamsUnavailable)
+	assert.NotErrorIs(
+		t,
+		err,
+		ErrEpochNotFound,
+		"the epoch exists; only its parameters do not",
+	)
+	assert.Equal(t, ProtocolParamsInfo{}, info)
+}
+
+// TestEpochProtocolParams_MissingEpochStillNotFound keeps the distinction
+// meaningful in the other direction: an epoch the node genuinely does not
+// hold must still report ErrEpochNotFound.
+func TestEpochProtocolParams_MissingEpochStillNotFound(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	_, err := adapter.EpochProtocolParams(999)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEpochNotFound)
+	assert.NotErrorIs(t, err, ErrProtocolParamsUnavailable)
+}
+
+// TestEpochProtocolParams_ByronRowDoesNotCallNilDecoder guards the decode
+// call. ByronEraDesc defines no DecodePParamsFunc, so reaching the decoder
+// with a Byron era would be a nil-func call. The empty-rows return covers
+// that today, which makes this a guard against a future reordering rather
+// than a live defect.
+func TestEpochProtocolParams_ByronRowDoesNotCallNilDecoder(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+	insertByronEpoch(t, store, 0)
+	// A Byron parameter row should never exist, but if one did the decode
+	// call must not be reached with a nil decoder.
+	_, err := store.Exec(`
+INSERT INTO pparams (cbor, added_slot, epoch, era_id)
+VALUES (?, ?, ?, ?)`,
+		[]byte{0xa0}, 0, 0, byron.EraIdByron,
+	)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err := adapter.EpochProtocolParams(0)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrProtocolParamsUnavailable)
+	})
+}
+
+// TestHandleEpochParams_ByronEpochNotFoundNotLoggedAsError covers the
+// operator-facing half. handleLatestEpochParams logs the same expected
+// absence at Debug precisely so a from-genesis sync does not fill the log
+// with errors; this sibling handler logged every Byron-epoch query at Error
+// before reaching its not-found branch.
+func TestHandleEpochParams_ByronEpochNotFoundNotLoggedAsError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "byron params", err: ErrProtocolParamsUnavailable},
+		{name: "missing epoch", err: ErrEpochNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(
+				&buf,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			))
+			b := New(
+				BlockfrostConfig{ListenAddress: ":0"},
+				&mockNode{epochParamsErr: tc.err},
+				logger,
+			)
+
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/api/v0/epochs/0/parameters",
+				nil,
+			)
+			req.SetPathValue("number", "0")
+			w := httptest.NewRecorder()
+			b.handleEpochParams(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.NotContains(
+				t,
+				buf.String(),
+				`"level":"ERROR"`,
+				"an expected absence must not log at error level",
+			)
+		})
+	}
+}
+
+// TestHandleEpochParams_RealFailureStillLogsError keeps that carve-out
+// narrow: a genuine failure must still be a logged 500.
+func TestHandleEpochParams_RealFailureStillLogsError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(
+		&buf,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+	b := New(
+		BlockfrostConfig{ListenAddress: ":0"},
+		&mockNode{epochParamsErr: assert.AnError},
+		logger,
+	)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/5/parameters",
+		nil,
+	)
+	req.SetPathValue("number", "5")
+	w := httptest.NewRecorder()
+	b.handleEpochParams(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, buf.String(), `"level":"ERROR"`)
 }

--- a/api/blockfrost/pparams_byron_test.go
+++ b/api/blockfrost/pparams_byron_test.go
@@ -237,6 +237,34 @@ func TestDrepStatus_UsesAvailabilityNotZeroSentinel(t *testing.T) {
 		assert.Equal(t, lastActivity, lastActive)
 	})
 
+	// The epoch-zero case: a DRep registered in epoch 0 that has never acted,
+	// on a chain with drep_activity 0. The derived expiry is legitimately 0,
+	// and a numeric "expiry > 0" guard reads that as "no expiry known" and
+	// reports the DRep active forever — the same zero-as-sentinel confusion
+	// the inactivityKnown flag exists to end, one level further down.
+	t.Run("configured zero at epoch zero expires", func(t *testing.T) {
+		for _, current := range []uint64{0, 5} {
+			retired, expired, lastActive := drepStatus(
+				true, // active
+				0,    // lastActivityEpoch: never acted
+				0,    // expiryEpoch: none recorded
+				0,    // registrationEpoch: genesis
+				current,
+				0,    // drep_activity configured to 0
+				true, // available
+			)
+
+			assert.False(t, retired)
+			assert.True(
+				t,
+				expired,
+				"derived expiry 0 is a real expiry at epoch %d",
+				current,
+			)
+			assert.Zero(t, lastActive)
+		}
+	})
+
 	t.Run("configured nonzero derives from last activity", func(t *testing.T) {
 		_, expired, _ := drepStatus(
 			true,

--- a/api/blockfrost/pparams_byron_test.go
+++ b/api/blockfrost/pparams_byron_test.go
@@ -184,3 +184,69 @@ func TestDrepInactivityFromPParams_DistinguishesUnavailableFromZero(
 		})
 	}
 }
+
+// TestDrepStatus_UsesAvailabilityNotZeroSentinel is the consequence of the
+// signature change. drepStatus previously guarded expiry derivation on
+// "inactivityPeriod > 0", which conflates two different chains: one whose era
+// defines no drep_activity, and one that set it to 0 so DReps expire the epoch
+// they last acted. Only the availability flag separates them.
+func TestDrepStatus_UsesAvailabilityNotZeroSentinel(t *testing.T) {
+	const (
+		lastActivity = uint64(10)
+		currentEpoch = uint64(12)
+	)
+
+	t.Run("unavailable does not derive expiry", func(t *testing.T) {
+		retired, expired, lastActive := drepStatus(
+			true,         // active
+			lastActivity, // lastActivityEpoch
+			0,            // expiryEpoch: none recorded
+			5,            // registrationEpoch
+			currentEpoch,
+			0,     // inactivityPeriod
+			false, // inactivityKnown
+		)
+
+		assert.False(t, retired)
+		assert.False(
+			t,
+			expired,
+			"no drep_activity parameter means no derived expiry",
+		)
+		assert.Equal(t, lastActivity, lastActive)
+	})
+
+	t.Run("configured zero expires at last activity", func(t *testing.T) {
+		retired, expired, lastActive := drepStatus(
+			true,
+			lastActivity,
+			0,
+			5,
+			currentEpoch,
+			0,    // drep_activity configured to 0
+			true, // available
+		)
+
+		assert.False(t, retired)
+		assert.True(
+			t,
+			expired,
+			"drep_activity of 0 expires a DRep at its last active epoch",
+		)
+		assert.Equal(t, lastActivity, lastActive)
+	})
+
+	t.Run("configured nonzero derives from last activity", func(t *testing.T) {
+		_, expired, _ := drepStatus(
+			true,
+			lastActivity,
+			0,
+			5,
+			currentEpoch,
+			20, // expiry 10+20=30, beyond currentEpoch 12
+			true,
+		)
+
+		assert.False(t, expired)
+	})
+}

--- a/api/blockfrost/pparams_byron_test.go
+++ b/api/blockfrost/pparams_byron_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
@@ -249,4 +250,30 @@ func TestDrepStatus_UsesAvailabilityNotZeroSentinel(t *testing.T) {
 
 		assert.False(t, expired)
 	})
+}
+
+// TestProtocolParamsForSlot_ByronEpochRowSentinel covers the branch a Byron
+// slot actually takes once the chain has recorded epochs.
+//
+// The epoch_id=0 row exists with era_id 0 (Byron), so the lookup does not fall
+// through to GetCurrentPParams; it reaches db.GetPParams, which returns
+// (nil, nil) because Byron never writes a protocol-parameter row — the era
+// defines no DecodePParamsFunc at all. That absence is the same Byron fact the
+// nil-current-pparams branch reports, so it must carry the same sentinel
+// rather than an untyped "decoded protocol parameters are nil".
+func TestProtocolParamsForSlot_ByronEpochRowSentinel(t *testing.T) {
+	adapter, store, _ := newDBBackedAdapter(t)
+
+	_, err := store.Exec(`
+INSERT INTO epoch (epoch_id, start_slot, length_in_slots, era_id)
+VALUES (?, ?, ?, ?)`,
+		0, 0, 100, byron.EraIdByron,
+	)
+	require.NoError(t, err)
+
+	pparams, err := adapter.protocolParamsForSlot(50)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtocolParamsUnavailable)
+	assert.Nil(t, pparams)
 }

--- a/api/blockfrost/pparams_byron_test.go
+++ b/api/blockfrost/pparams_byron_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A freshly constructed LedgerState has never loaded protocol parameters, so
+// GetCurrentPParams returns nil — the same thing it genuinely reports during a
+// Byron prefix, where there is no protocol-parameter CBOR to load.
+
+// TestCurrentProtocolParams_ByronEraSentinel pins the adapter-level contract:
+// Byron-era unavailability surfaces as a sentinel callers can branch on, not
+// as an opaque string that every caller has to treat as an internal fault.
+func TestCurrentProtocolParams_ByronEraSentinel(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+	require.Nil(
+		t,
+		adapter.ledgerState.GetCurrentPParams(),
+		"precondition: ledger reports no current pparams",
+	)
+
+	info, err := adapter.CurrentProtocolParams()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtocolParamsUnavailable)
+	assert.Equal(
+		t,
+		ProtocolParamsInfo{},
+		info,
+		"no Shelley-shaped substitute alongside the error",
+	)
+}
+
+// TestHandleLatestEpochParams_ByronEraNotFound is the behavior change an
+// operator sees. A Byron prefix is an expected point in a from-genesis sync,
+// so GET /epochs/latest/parameters must not report 500 Internal Server Error
+// — that reads as a node fault and trips alerting. 404 matches the
+// ErrEpochNotFound precedent already established for absent epoch data.
+func TestHandleLatestEpochParams_ByronEraNotFound(t *testing.T) {
+	mock := &mockNode{paramsErr: ErrProtocolParamsUnavailable}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/latest/parameters",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestEpochParams(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Not Found", resp["error"])
+}
+
+// TestHandleLatestEpochParams_OtherErrorsStillInternal keeps the Byron carve-
+// out narrow: a genuine conversion or storage failure must still be a 500.
+func TestHandleLatestEpochParams_OtherErrorsStillInternal(t *testing.T) {
+	mock := &mockNode{paramsErr: assert.AnError}
+	b := newTestBlockfrost(mock)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/epochs/latest/parameters",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	b.handleLatestEpochParams(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestProtocolParamsForSlot_ByronEraSentinel covers the certificate-deposit
+// path's fallback. With no epoch row for the slot it consults the current
+// pparams, and a Byron prefix leaves that nil.
+func TestProtocolParamsForSlot_ByronEraSentinel(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	pparams, err := adapter.protocolParamsForSlot(0)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtocolParamsUnavailable)
+	assert.Nil(t, pparams)
+}
+
+// TestDrepInactivityPeriod_UnavailableIsNotZero is the silent-conversion fix.
+// Returning a bare 0 for absent parameters is indistinguishable from a chain
+// that genuinely configured drep_activity to 0, and drepStatus then derives
+// expiry epochs from a value nobody set.
+func TestDrepInactivityPeriod_UnavailableIsNotZero(t *testing.T) {
+	adapter, _, _ := newDBBackedAdapter(t)
+
+	period, ok := adapter.drepInactivityPeriod()
+
+	assert.False(
+		t,
+		ok,
+		"absent protocol parameters must not report a configured value",
+	)
+	assert.Zero(t, period)
+}
+
+// TestDrepInactivityFromPParams_DistinguishesUnavailableFromZero proves the
+// second return reports availability rather than merely restating the first:
+// a Conway chain that genuinely sets drep_activity to 0 reports (0, true),
+// which is what the old bare-uint64 signature could not express.
+func TestDrepInactivityFromPParams_DistinguishesUnavailableFromZero(
+	t *testing.T,
+) {
+	for _, tc := range []struct {
+		name       string
+		pparams    lcommon.ProtocolParameters
+		wantPeriod uint64
+		wantOK     bool
+	}{
+		{
+			name:    "byron reports unavailable",
+			pparams: nil,
+			wantOK:  false,
+		},
+		{
+			name: "conway configured zero",
+			pparams: &conway.ConwayProtocolParameters{
+				DRepInactivityPeriod: 0,
+			},
+			wantPeriod: 0,
+			wantOK:     true,
+		},
+		{
+			name: "conway configured nonzero",
+			pparams: &conway.ConwayProtocolParameters{
+				DRepInactivityPeriod: 20,
+			},
+			wantPeriod: 20,
+			wantOK:     true,
+		},
+		{
+			name: "dijkstra configured nonzero",
+			pparams: &dijkstra.DijkstraProtocolParameters{
+				ConwayProtocolParameters: conway.ConwayProtocolParameters{
+					DRepInactivityPeriod: 31,
+				},
+			},
+			wantPeriod: 31,
+			wantOK:     true,
+		},
+		{
+			name:    "pre-conway era has no drep semantics",
+			pparams: &shelley.ShelleyProtocolParameters{},
+			wantOK:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			period, ok := drepInactivityFromPParams(tc.pparams)
+
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantPeriod, period)
+		})
+	}
+}

--- a/api/mesh/construction_byron_test.go
+++ b/api/mesh/construction_byron_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConstructionMetadataByronEraNoFeeSubstitution traces the Byron-era
+// behavior of the /construction/metadata consumer of GetCurrentPParams.
+//
+// Byron carries no protocol-parameter CBOR, so the ledger reports nil for a
+// genuine Byron prefix. The defined behavior is the retriable ErrUnavailable
+// that TestConstructionMetadataUnavailable already covers; what this adds is
+// the substitution prohibition. A zero-valued fee body would be worse than an
+// error here, because a client that ignored the status would sign a
+// transaction whose fee was computed from parameters nobody configured.
+func TestConstructionMetadataByronEraNoFeeSubstitution(t *testing.T) {
+	deps := newTestDeps()
+	require.Nil(
+		t,
+		deps.ledger.pparams,
+		"precondition: Byron prefix reports no current pparams",
+	)
+	h := newTestHandler(t, deps)
+
+	rec := postJSON(
+		t, h, "/construction/metadata", metadataRequest(),
+	)
+
+	got := requireMeshError(
+		t, rec, ErrUnavailable, http.StatusServiceUnavailable,
+	)
+	require.True(
+		t,
+		got.Retriable,
+		"a Byron prefix resolves once the chain reaches Shelley",
+	)
+
+	// The body must be an error document only — no metadata or fee fields a
+	// lenient client could pick up.
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.NotContains(t, body, "metadata")
+	assert.NotContains(t, body, "suggested_fee")
+}
+
+// TestConstructionMetadataByronEraDescribesCause pins the operator-facing
+// half. "service unavailable" alone sends someone hunting a node fault during
+// what is a normal stage of a from-genesis sync, so the wrapped cause has to
+// name protocol-parameter availability. Mesh already does this; the test locks
+// it against a future refactor that drops the wrapped error on the floor.
+func TestConstructionMetadataByronEraDescribesCause(t *testing.T) {
+	h := newTestHandler(t, newTestDeps())
+
+	rec := postJSON(
+		t, h, "/construction/metadata", metadataRequest(),
+	)
+
+	var got Error
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Contains(t, got.Details, "error")
+	assert.Contains(
+		t,
+		got.Details["error"],
+		"protocol parameters",
+	)
+}

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -258,7 +258,16 @@ func (s *queryServiceServer) ReadParams(
 
 	protoParams := s.utxorpc.config.LedgerState.GetCurrentPParams()
 	if protoParams == nil {
-		return nil, errors.New("current protocol parameters empty")
+		// Byron carries no protocol-parameter CBOR, so a genuine Byron
+		// prefix reaches this during a from-genesis sync. FailedPrecondition
+		// tells the caller the chain is not yet in a state that can answer,
+		// which is the truth; Unavailable would invite a retry loop across
+		// what can be days of synchronization. Return before the tip lookup:
+		// there is no useful tip to pair with an absent parameter set.
+		return nil, connect.NewError(
+			connect.CodeFailedPrecondition,
+			ErrByronProtocolParams,
+		)
 	}
 
 	// Get chain point (slot, hash, and height)

--- a/api/utxorpc/query.go
+++ b/api/utxorpc/query.go
@@ -47,6 +47,15 @@ type queryServiceServer struct {
 	utxorpc *Utxorpc
 }
 
+// ErrByronProtocolParams reports that the ledger holds no current protocol
+// parameters because the chain is still in its Byron prefix. Byron carries no
+// protocol-parameter CBOR, so this is an expected state during a from-genesis
+// synchronization rather than a node fault, and no Shelley-shaped parameters
+// may be substituted for it.
+var ErrByronProtocolParams = errors.New(
+	"protocol parameters unavailable in the Byron era",
+)
+
 func extractSearchPredicatePatterns(
 	predicate *query.UtxoPredicate,
 ) (*utxorpcCardano.AddressPattern, *utxorpcCardano.AssetPattern) {

--- a/api/utxorpc/query_byron_pparams_test.go
+++ b/api/utxorpc/query_byron_pparams_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package utxorpc
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	query "github.com/utxorpc/go-codegen/utxorpc/v1alpha/query"
+)
+
+// byronPParamsLedgerStub implements only what ReadParams reaches. The
+// interface is embedded rather than implemented in full so that a method
+// ReadParams should not be calling panics instead of returning a zero value.
+//
+// GetCurrentPParams returns nil, which is what LedgerState genuinely reports
+// during a Byron prefix: Byron carries no protocol-parameter CBOR, so there is
+// nothing to return and nothing Shelley-shaped may be substituted.
+type byronPParamsLedgerStub struct {
+	UtxorpcLedgerState
+
+	tip ochainsync.Tip
+	// pparamsCalls proves ReadParams consults the ledger rather than
+	// answering from a cached or fabricated value.
+	pparamsCalls int
+	// tipCalls proves the Byron path short-circuits before the tip lookup;
+	// there is no useful ledger tip to report alongside an absent parameter
+	// set, and the lookup is not free.
+	tipCalls int
+}
+
+func (s *byronPParamsLedgerStub) GetCurrentPParams() lcommon.ProtocolParameters {
+	s.pparamsCalls++
+	return nil
+}
+
+func (s *byronPParamsLedgerStub) Tip() ochainsync.Tip {
+	s.tipCalls++
+	return s.tip
+}
+
+func newByronQueryServer(
+	t *testing.T,
+	ls UtxorpcLedgerState,
+) *queryServiceServer {
+	t.Helper()
+	u := NewUtxorpc(UtxorpcConfig{
+		Logger:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		LedgerState: ls,
+	})
+	return &queryServiceServer{utxorpc: u}
+}
+
+// TestReadParams_ByronEraFailedPrecondition locks in the defined Byron-era
+// behavior for utxorpc.v1alpha.query.QueryService/ReadParams. A Byron prefix
+// is an expected state during from-genesis synchronization, not a server
+// fault, so the reply must carry a precondition code the caller can branch on
+// rather than an untyped error that connect reports as CodeUnknown.
+//
+// v1beta ReadParams is served by rewriting the path onto this same alpha
+// handler (see betaVersionedQueryHandler), so this covers both versions.
+func TestReadParams_ByronEraFailedPrecondition(t *testing.T) {
+	stub := &byronPParamsLedgerStub{
+		tip: ochainsync.Tip{
+			Point: ocommon.NewPoint(42, []byte{0xab, 0xcd}),
+		},
+	}
+	srv := newByronQueryServer(t, stub)
+
+	out, err := srv.ReadParams(
+		context.Background(),
+		connect.NewRequest(&query.ReadParamsRequest{}),
+	)
+
+	require.Error(t, err)
+	require.Nil(t, out, "no partial response alongside an error")
+	assert.Equal(
+		t,
+		connect.CodeFailedPrecondition,
+		connect.CodeOf(err),
+		"Byron-era unavailability is a precondition, not an unknown error",
+	)
+	assert.ErrorIs(t, err, ErrByronProtocolParams)
+	assert.Equal(t, 1, stub.pparamsCalls)
+	assert.Zero(
+		t,
+		stub.tipCalls,
+		"Byron path should short-circuit before the tip lookup",
+	)
+}
+
+// TestReadParams_ByronEraDoesNotSubstituteShelley guards the substitution
+// prohibition directly: the error path must not manufacture a params message.
+func TestReadParams_ByronEraDoesNotSubstituteShelley(t *testing.T) {
+	srv := newByronQueryServer(t, &byronPParamsLedgerStub{})
+
+	out, err := srv.ReadParams(
+		context.Background(),
+		connect.NewRequest(&query.ReadParamsRequest{}),
+	)
+
+	require.Error(t, err)
+	require.Nil(t, out)
+	// A caller that ignores the error must not find a usable Cardano params
+	// block; the absence has to be unambiguous.
+	if out != nil {
+		assert.Nil(t, out.Msg.GetValues())
+	}
+}

--- a/api/utxorpc/query_byron_pparams_test.go
+++ b/api/utxorpc/query_byron_pparams_test.go
@@ -16,12 +16,17 @@ package utxorpc
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"math/big"
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -29,14 +34,14 @@ import (
 	query "github.com/utxorpc/go-codegen/utxorpc/v1alpha/query"
 )
 
-// byronPParamsLedgerStub implements only what ReadParams reaches. The
+// byronLedgerStub implements only what ReadParams reaches. The
 // interface is embedded rather than implemented in full so that a method
 // ReadParams should not be calling panics instead of returning a zero value.
 //
 // GetCurrentPParams returns nil, which is what LedgerState genuinely reports
 // during a Byron prefix: Byron carries no protocol-parameter CBOR, so there is
 // nothing to return and nothing Shelley-shaped may be substituted.
-type byronPParamsLedgerStub struct {
+type byronLedgerStub struct {
 	UtxorpcLedgerState
 
 	tip ochainsync.Tip
@@ -49,12 +54,12 @@ type byronPParamsLedgerStub struct {
 	tipCalls int
 }
 
-func (s *byronPParamsLedgerStub) GetCurrentPParams() lcommon.ProtocolParameters {
+func (s *byronLedgerStub) GetCurrentPParams() lcommon.ProtocolParameters {
 	s.pparamsCalls++
 	return nil
 }
 
-func (s *byronPParamsLedgerStub) Tip() ochainsync.Tip {
+func (s *byronLedgerStub) Tip() ochainsync.Tip {
 	s.tipCalls++
 	return s.tip
 }
@@ -80,7 +85,7 @@ func newByronQueryServer(
 // v1beta ReadParams is served by rewriting the path onto this same alpha
 // handler (see betaVersionedQueryHandler), so this covers both versions.
 func TestReadParams_ByronEraFailedPrecondition(t *testing.T) {
-	stub := &byronPParamsLedgerStub{
+	stub := &byronLedgerStub{
 		tip: ochainsync.Tip{
 			Point: ocommon.NewPoint(42, []byte{0xab, 0xcd}),
 		},
@@ -109,21 +114,76 @@ func TestReadParams_ByronEraFailedPrecondition(t *testing.T) {
 	)
 }
 
-// TestReadParams_ByronEraDoesNotSubstituteShelley guards the substitution
-// prohibition directly: the error path must not manufacture a params message.
-func TestReadParams_ByronEraDoesNotSubstituteShelley(t *testing.T) {
-	srv := newByronQueryServer(t, &byronPParamsLedgerStub{})
+// TestReadParams_ShelleyStateUnaffected keeps the Byron guard from
+// over-triggering. The nil check sits ahead of every other step in the
+// handler, so a state that does hold protocol parameters must still take the
+// normal path and answer with them.
+func TestReadParams_ShelleyStateUnaffected(t *testing.T) {
+	stub := &shelleyLedgerStub{
+		byronLedgerStub: byronLedgerStub{
+			tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(42, []byte{0xab, 0xcd}),
+			},
+		},
+		pparams: testShelleyPParams(),
+	}
+	srv := newByronQueryServer(t, stub)
 
 	out, err := srv.ReadParams(
 		context.Background(),
 		connect.NewRequest(&query.ReadParamsRequest{}),
 	)
 
-	require.Error(t, err)
-	require.Nil(t, out)
-	// A caller that ignores the error must not find a usable Cardano params
-	// block; the absence has to be unambiguous.
-	if out != nil {
-		assert.Nil(t, out.Msg.GetValues())
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Msg.GetValues())
+	require.NotNil(t, out.Msg.GetValues().GetCardano())
+	assert.Equal(
+		t,
+		int64(44),
+		out.Msg.GetValues().GetCardano().
+			GetMinFeeCoefficient().GetInt(),
+	)
+	assert.Equal(t, uint64(42), out.Msg.GetLedgerTip().GetSlot())
+}
+
+// shelleyLedgerStub answers with real protocol parameters, overriding
+// the Byron stub's nil.
+type shelleyLedgerStub struct {
+	byronLedgerStub
+
+	pparams lcommon.ProtocolParameters
+}
+
+func (s *shelleyLedgerStub) GetCurrentPParams() lcommon.ProtocolParameters {
+	s.pparamsCalls++
+	return s.pparams
+}
+
+func (s *shelleyLedgerStub) GetBlock(
+	ocommon.Point,
+) (models.Block, error) {
+	// Force the height fallback rather than carrying a block fixture; the
+	// tip slot and hash are what this test checks.
+	return models.Block{}, errors.New("no block")
+}
+
+func testShelleyPParams() *shelley.ShelleyProtocolParameters {
+	rat := func(num, denom int64) *cbor.Rat {
+		return &cbor.Rat{Rat: big.NewRat(num, denom)}
+	}
+	return &shelley.ShelleyProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 rat(3, 10),
+		Rho:                rat(3, 1000),
+		Tau:                rat(2, 10),
 	}
 }


### PR DESCRIPTION
Closes https://github.com/blinklabs-io/dingo/issues/3247

Byron carries no protocol-parameter CBOR, so `GetCurrentPParams()` returns nil for a genuine Byron prefix. Every consumer treated that absence as a fault or, in one case, converted it to a number. This defines what the absence means for each API. No path substitutes Shelley-shaped parameters.

## UTxORPC

`ReadParams` returned a bare `errors.New`, which reaches callers as `CodeUnknown` — indistinguishable from a genuine server fault. It now returns `CodeFailedPrecondition` with a Byron sentinel, and returns before the tip lookup, which has nothing useful to pair with an absent parameter set.

`FailedPrecondition` rather than `Unavailable` because the latter signals a transient condition clients should retry with backoff, and a Byron prefix can persist for days of synchronization.

v1beta `ReadParams` is served by rewriting the path onto the alpha handler, so both versions are covered by the one change.

## Blockfrost

`CurrentProtocolParams` and `protocolParamsForSlot` now return `ErrProtocolParamsUnavailable`, and `GET /epochs/latest/parameters` maps it to **404 rather than 500**, matching the `ErrEpochNotFound` precedent already established for absent epoch data. A Byron prefix is an expected stage of a from-genesis sync; reporting it as an internal error reads as an outage and trips alerting. Genuine conversion and storage failures still return 500, with a test pinning that the carve-out stays narrow.

## drep_activity

`drepInactivityPeriod` now reports availability alongside its value, delegating to a pure `drepInactivityFromPParams` helper.

The consequential half is `drepStatus`, which gated expiry derivation on `inactivityPeriod > 0`. That guard had a second defect beyond the silent-zero conversion the issue describes: a chain that genuinely configures `drep_activity` to 0 — meaning a DRep expires the epoch it last acted — was skipped as though the parameter did not exist. The gate is now the availability flag, and both call sites thread it through.

## Mesh

No behavior change. `/construction/metadata` already returned a retriable `ErrUnavailable` with the cause attached and substituted no fee, which is the correct Byron-era definition. The two added tests lock that contract rather than driving a change.

## Testing

Written test-first: the failing tests are a separate commit, and each asserts no Shelley-shaped substitution alongside its status-code assertion.

- All `api/...` suites pass, as does `ledger/...`.
- `golangci-lint run ./api/...` reports 0 issues; `gofmt` clean; added lines within the 80-character limit.
- Full `go test ./...` is 75 packages ok. `database/plugin/blob/{aws,gcs}` fail to build (`undefined: NewWithOptions` in `tombstone_test.go`); verified identical on a clean `upstream/main` worktree, so pre-existing and unrelated.

## Two points for review

**The code choice is deliberate but inconsistent across protocols.** UTxORPC gets `FailedPrecondition` while Mesh keeps retriable `Unavailable`. Defensible per protocol for the retry-semantics reason above, but flagging it rather than leaving it to be discovered.

**Scope boundary.** `PoolDetail` and `PoolsExtended` also call `CurrentProtocolParams`. They wrap the error with `%w`, so the sentinel stays matchable, but their handlers still map to 500. Stake pools do not exist in Byron either, so those endpoints arguably deserve the same treatment — left for a follow-up, since the issue names five consumers and those are not among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R79vNFGWAWtVVKH32XkN7s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines Byron-era protocol-parameter behavior and fixes DRep expiry derivation. Previously Byron absence surfaced as 500s or coerced zeros; now APIs return explicit sentinels and `drepStatus` tracks expiry knownness to avoid zero-as-sentinel bugs.

- `api/utxorpc`: `ReadParams` returns FailedPrecondition with `ErrByronProtocolParams` and exits before tip lookup. Shelley-era states return parameters unchanged.
- `api/blockfrost`: `CurrentProtocolParams`, `EpochProtocolParams`, and `protocolParamsForSlot` return `ErrProtocolParamsUnavailable` (epoch-backed paths wrap epoch/era for logs and guard a nil decoder). `GET /epochs/latest/parameters` and `GET /epochs/{number}/parameters` map the sentinel to 404 and log at debug; other failures stay 500. DRep logic: `drepInactivityPeriod` returns (value, available), and `drepStatus` derives expiry only when inactivity is known and gates on expiryKnown; `drep_activity=0` expires at last activity, and epoch-zero expiries count.
- `api/mesh`: No behavior change. `/construction/metadata` keeps retriable `ErrUnavailable` and does not substitute fees.
- No path substitutes protocol parameters when unavailable. Intentional inconsistency remains: `api/utxorpc` uses FailedPrecondition while `api/mesh` uses Unavailable; stake-pool endpoints still map to 500 and can be aligned in a follow-up.

<sup>Written for commit f12393679750e3210d69d6c8c2129c0dbcce22e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when protocol parameters are unavailable in the Byron era.
  * Epoch parameter requests now return a clear 404 response instead of an internal server error.
  * Construction metadata requests now return a retriable 503 error without incomplete fee information.
  * UTxO RPC parameter requests now return a clear failed-precondition error when parameters are unavailable.
  * DRep activity and expiry calculations now correctly distinguish unavailable settings from configured zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->