### PR TITLE
docs: add discoverable documentation index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ make gorm-check
 
 ## Documentation requirements
 
+- Start repository research at `docs/README.md`. It maps the versioned project
+  documents, package `doc.go` comments, `go doc` commands, and public
+  documentation sources.
 - Treat `DATABASE.md` and `ARCHITECTURE.md` as part of the change bar, like tests. Before finishing any code change, decide whether either document needs an update; update it in the same change when it does.
 - Update `DATABASE.md` for any change to metadata schemas, migrated tables, table relationships, SQL query/API surfaces in `metadata.MetadataStore`, blob-store key layout, CBOR/offset encodings, storage plugins, pruning/tombstone behavior, or anything external Postgres/MySQL/SQLite/blob users rely on.
 - Update `ARCHITECTURE.md` for any change to component responsibilities, package boundaries, startup/composition, EventBus topics/payloads, plugin interfaces, lifecycle/concurrency behavior, or cross-component flows among ledger, database, mempool, networking, API, and node wiring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ Go Cardano node (Ouroboros). Derivable info (build targets, flags, package layou
 
 ## Documentation
 
+- Start repository research at `docs/README.md`. It maps the versioned project
+  documents, package `doc.go` comments, `go doc` commands, and public
+  documentation sources.
 - Treat `DATABASE.md` and `ARCHITECTURE.md` as part of the change bar, like tests. Before finishing any code change, decide whether either document needs an update; update it in the same change when it does.
 - Update `DATABASE.md` for any change to metadata schemas, table relationships, SQL query/API surfaces in `metadata.MetadataStore`, blob-store key layout, CBOR/offset encodings, storage plugins, pruning/tombstone behavior, or anything external Postgres/MySQL/SQLite/blob users rely on.
 - Update `ARCHITECTURE.md` for any change to component responsibilities, package boundaries, startup/composition, EventBus topics/payloads, plugin interfaces, lifecycle/concurrency behavior, or cross-component flows among ledger, database, mempool, networking, API, and node wiring.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Note: On Windows systems, named pipes are used instead of Unix sockets for node-
   <img src="./.github/dingo-20241210.png" alt="dingo screenshot" width="640">
 </div>
 
+## Documentation
+
+Start with the [Dingo documentation index](docs/README.md). It maps the
+versioned documentation in this repository, the package comments exposed by
+`go doc`, and the public operator guides at
+[docs.blinklabs.io](https://docs.blinklabs.io/guides/dingo/001-dingo/).
+
+For code-level questions, use the [Go code reference](docs/code-reference.md)
+to find package `doc.go` files and commands that render documentation from the
+exact revision checked out. Automated tools can also use the public
+[LLM documentation index](https://docs.blinklabs.io/llms.txt) or the focused
+[Cardano nodes and operations set](https://docs.blinklabs.io/_llms-txt/cardano-nodes-and-operations.txt).
+
 ## Running
 
 Dingo supports configuration via a YAML config file (`dingo.yaml`), environment variables, and command-line flags. Priority: CLI flags > environment variables > YAML config > defaults.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,79 @@
+# Dingo documentation
+
+This directory is the documentation entry point for the Dingo source tree. It
+is intended for people, coding agents, and other tools that inspect a checkout
+before changing it.
+
+Dingo is under active development. For code behavior, prefer documentation
+from the revision you have checked out. The public site describes supported
+installation and operation and may track a released version rather than the
+current branch.
+
+## Find the right documentation
+
+| Question | Source |
+| --- | --- |
+| How do I build, configure, or run Dingo? | The repository [README](../README.md) and [`dingo.yaml.example`](../dingo.yaml.example) |
+| How are components wired and what owns a behavior? | [Architecture](../ARCHITECTURE.md) |
+| How are storage, schemas, and persisted formats designed? | [Database reference](../DATABASE.md) |
+| How does secure from-origin synchronization work? | [Ouroboros Genesis operator guide](../GENESIS_SYNC.md) |
+| What does a Go package or exported symbol do? | [Go code reference](code-reference.md), package `doc.go` files, and `go doc` |
+| How do I add a compiled-in provider? | [Plugin development](../database/plugin/PLUGIN_DEVELOPMENT.md) |
+| How do I run conformance or end-to-end tests? | [Conformance tests](../internal/test/conformance/README.md) and [DevNet](../internal/test/devnet/README.md) |
+| How do I exercise archive and history-expiry behavior? | [Archive node demo](../internal/test/archive-demo/README.md) |
+| Where are runnable API examples? | [Examples](../examples/README.md) |
+| How do I install the Grafana dashboards? | [Dashboards](dashboards/README.md) |
+
+Contributor rules live in [`AGENTS.md`](../AGENTS.md) and
+[`CLAUDE.md`](../CLAUDE.md). The repository `Makefile` is the source of truth
+for build and validation targets.
+
+## Code documentation
+
+Go package comments live beside the implementation, usually in a `doc.go`
+file. This makes them available to source browsers, language servers,
+[pkg.go.dev](https://pkg.go.dev/github.com/blinklabs-io/dingo), and the `go doc`
+command. Render them from the current checkout instead of relying on a cached
+copy:
+
+```sh
+go doc ./ledger
+go doc ./ledger LedgerState
+go doc -all ./database
+```
+
+The [Go code reference](code-reference.md) maps the main documented packages
+and includes commands for discovering additional package and symbol docs.
+
+## Public documentation
+
+Operator-facing installation, quick-start, Cardano CLI, stake-pool, monitoring,
+and release documentation is published in the
+[Dingo guide on docs.blinklabs.io](https://docs.blinklabs.io/guides/dingo/001-dingo/).
+
+The same public documentation is available in machine-readable forms:
+
+- [`llms.txt`](https://docs.blinklabs.io/llms.txt) indexes every documentation
+  set.
+- The [Cardano nodes and operations set](https://docs.blinklabs.io/_llms-txt/cardano-nodes-and-operations.txt)
+  contains the focused Dingo and node-operations material.
+- [`llms-full.txt`](https://docs.blinklabs.io/llms-full.txt) contains the full
+  public documentation corpus.
+
+Use repository documentation and `go doc` for details tied to the checked-out
+source. Use the public site for released installation and operational guidance;
+release notes are historical context, not the current code contract.
+
+## Source priority for code changes
+
+When sources overlap, use this order:
+
+1. The checked-out implementation and its tests.
+2. Package comments and exported-symbol comments rendered with `go doc`.
+3. Versioned repository documents such as `ARCHITECTURE.md`, `DATABASE.md`, and
+   the relevant test or subsystem README.
+4. Public documentation for the supported operator experience.
+
+Update the closest source of truth with a change. Link to it from this index
+when a new documentation area is added instead of copying a large explanation
+here.

--- a/docs/code-reference.md
+++ b/docs/code-reference.md
@@ -1,0 +1,73 @@
+# Go code reference
+
+Dingo's code-level documentation is maintained with the code it describes.
+Package comments are normally in `doc.go`; comments on exported types,
+functions, methods, and fields remain beside those declarations. Go tooling
+combines both into a reference for the exact revision checked out.
+
+## Read documentation with `go doc`
+
+Run these commands from the repository root:
+
+```sh
+# Package overview and exported API
+go doc ./ledger
+
+# Package overview plus documentation for every exported declaration
+go doc -all ./ledger
+
+# One exported type or symbol
+go doc ./ledger LedgerState
+
+# A package by its full import path
+go doc github.com/blinklabs-io/dingo/database
+```
+
+To discover packages with package comments:
+
+```sh
+go list -buildvcs=false \
+  -f '{{if .Doc}}{{.ImportPath}}: {{.Doc}}{{end}}' ./...
+```
+
+Prefer `go doc` before inferring an API from call sites. It combines package
+documentation with the current exported surface and avoids documentation from
+a different branch or release.
+
+## Documented package map
+
+| Area | Package documentation | Responsibility |
+| --- | --- | --- |
+| Client API | [`api/utxorpc/doc.go`](../api/utxorpc/doc.go) | UTxO RPC v1alpha and v1beta server behavior |
+| Chain state | [`chain/doc.go`](../chain/doc.go) | Primary and candidate chains, forks, and rollback orchestration |
+| Chain choice | [`chainselection/doc.go`](../chainselection/doc.go) | Multi-peer Praos and Genesis chain selection |
+| Sync state | [`chainsync/doc.go`](../chainsync/doc.go) | Per-peer chain-sync state and stall recovery signals |
+| Connections | [`connmanager/doc.go`](../connmanager/doc.go) | Inbound and outbound connection lifecycle |
+| Storage | [`database/doc.go`](../database/doc.go) | Blob and metadata stores, CBOR offsets, and query guidance |
+| Events | [`event/doc.go`](../event/doc.go) | EventBus publishing, ordering, delivery, and subscription contracts |
+| Ledger | [`ledger/doc.go`](../ledger/doc.go) | Consensus-critical state, validation, rollback, epochs, and nonces |
+| Leios | [`ledger/leios/doc.go`](../ledger/leios/doc.go) | CIP-0164 committees, votes, quorum, and certificates |
+| Mempool | [`mempool/doc.go`](../mempool/doc.go) | Transaction admission, validation, ordering, and watermarks |
+| Ouroboros | [`ouroboros/doc.go`](../ouroboros/doc.go) | NtN/NtC mini-protocol handlers and message routing |
+| Peer governance | [`peergov/doc.go`](../peergov/doc.go) | Peer sources, tiers, churn, and ingress eligibility |
+
+This table points to package-level entry points, not every package. Use
+`go list ./...`, repository search, and `go doc` to discover subpackages and
+symbol documentation relevant to a task.
+
+## Published reference
+
+[pkg.go.dev](https://pkg.go.dev/github.com/blinklabs-io/dingo) renders the Go
+reference for published module versions. It is useful when no checkout is
+available. For development work, use the local `go doc` output so the reference
+matches the branch being changed.
+
+## Maintaining package documentation
+
+- Keep one package comment for each package and start it with `Package <name>`.
+- Put package-level concepts and contracts in `doc.go`; keep symbol-specific
+  behavior on the declaration it governs.
+- Link to the implementation or a versioned repository document for details
+  that would drift if repeated.
+- Run `go doc` for the changed package and confirm the rendered text still
+  describes its exported surface.


### PR DESCRIPTION
## Summary

- add a conventional docs directory entry point for versioned project documentation
- map package doc.go sources and local go doc workflows
- connect repository and agent entry points to the public Dingo guides and machine-readable documentation sets

## Result

Repository readers can find branch-matched code documentation from standard discovery paths without duplicating the underlying sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a discoverable documentation index under docs/ with a Go code reference, and update README and contributor guides to point to it. This centralizes branch-matched docs and standardizes use of `go doc`, replacing ad‑hoc discovery via scattered files and the public site.

- docs/README.md is the entry point for versioned repo docs, package `doc.go` comments, `go doc` commands, and links to the public guides and LLM indexes.
- docs/code-reference.md maps main documented packages and shows `go doc` usage.
- README.md, AGENTS.md, and CLAUDE.md now direct readers to docs/README.md.
- No runtime changes. Contributors should start research at docs/README.md and keep package `doc.go` comments current.

Review notes:
- Verify intra-repo links in docs/README.md and docs/code-reference.md resolve.
- Confirm external links to docs.blinklabs.io and LLM indexes are correct.
- Spot-check that listed packages reflect current structure; propose additions if gaps exist.

<sup>Written for commit 8236c18a22ee4369b6c58357830289e5c0825445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a central documentation index for repository guides, code references, operational resources, testing information, and dashboards.
  - Added guidance for locating and viewing Go package documentation.
  - Added links to public operator guides and machine-readable documentation resources.
  - Updated project guidance and the README to direct readers to the new documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->