### PR TITLE
fix(ledger): publish apply events after commit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7668,8 +7668,8 @@ immediately in practice.
 `rollbackChainAndState` sequences three steps in order, and the ordering is
 load-bearing in both directions: `drainBlockPipelineBeforeRollback` first,
 then, while holding `transactionEventMutex`,
-`validateAndEmitRollbackUndo` (reject-then-emit-undo-events, from issue
-#2287/#3209's ordering fix, `ledger/block_event.go`) and
+`validateAndEmitRollbackUndo` (reject-then-emit-undo-events, from the
+ordering fix for issues #2287/#3209 in `ledger/block_event.go`) and
 `ls.chain.Rollback`. Draining before taking the transaction-event serializer
 avoids waiting for pipeline work whose commit needs that same serializer.
 Draining before validating/emitting matters because

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -380,8 +380,10 @@ sequenceDiagram
     LS->>ChM: chain.AddBlocks(batch) — 50 blocks max
     ChM->>DB: blob.SetBlock(slot, hash, cbor)
     ChM->>DB: metadata: UTxOs, txs, certs, governance
+    DB-->>LS: durable commit succeeds
+    LS->>EB: publish TransactionEvent per tx (AfterCommit)
     ChM->>EB: publish ChainUpdateEvent
-    LS->>EB: publish BlockEvent, TransactionEvent per tx
+    LS->>EB: publish BlockEvent
 
     Note over Peer,DB: Rollback Path
     Peer->>OB: RollBackward(point)
@@ -401,15 +403,19 @@ and sees a rollback's undo events (`Rollback: true`) before any transaction
 event the ledger emits afterwards.
 
 Two producers feed that lane, on different goroutines: `LedgerDelta.apply`
-(`ledger/delta.go`) publishes forward events from the `ledgerProcessBlocks`
-goroutine, and the rollback path publishes undo events from whichever
-goroutine performs the rollback. Nothing serializes those two, so the ordering
-comes from a happens-before rather than from a lock:
-`rollbackChainAndState` calls `emitRollbackTransactionEvents` **before**
-`chain.Rollback` truncates. The apply goroutine can only apply a
-post-rollback block after it observes that truncation, so an undo enqueued
-ahead of the truncation is necessarily ahead of any forward event for a block
-applied after it.
+(`ledger/delta.go`) registers forward events on the database transaction's
+`AfterCommit` drain from the `ledgerProcessBlocks` goroutine, and the rollback
+path publishes undo events from whichever goroutine performs the rollback.
+`AfterCommit` runs callbacks in registration order only after durable commit;
+an apply error, rollback, or failed commit discards them. The database commit
+becomes visible before its `AfterCommit` callbacks finish, so the two producer
+goroutines share `transactionEventMutex`: `submitBlockApplyDBTxn` holds it from
+the stale-tip recheck through commit and Apply enqueue, while primary-chain
+rollback paths hold it across rollback validation, Undo enqueue, and chain
+truncation. If Apply wins, its events reach the ordered lane before an Undo can
+be read from the committed state. If rollback wins, truncation and the ledger
+rewind make the waiting block batch stale, and the tip recheck rejects it
+instead of publishing Apply after Undo.
 
 Getting this wrong is subtle, so the constraint is worth stating plainly:
 **the undo events must be emitted before the truncation, by the rollback
@@ -423,10 +429,10 @@ different lane. Before #2287 the undo events were emitted from a `go`
 statement onto the reordering shared pool, which lost the same race twice
 over.
 
-The forward path keeps async semantics deliberately: it publishes from inside
-the block-apply database transaction, so a synchronous publish would hold that
-transaction open under subscriber backpressure. `ledger.block` remains
-`PublishBlocking` on the handler's own goroutine.
+The forward path keeps async semantics deliberately: its after-commit callback
+only enqueues onto the ordered lane, so subscribers cannot observe an Apply
+before storage is durable and their work never runs inline in `Commit`.
+`ledger.block` remains `PublishBlocking` on the handler's own goroutine.
 
 Because a publisher parked on a full lane is released only by the EventBus
 stopping, and a live restore/truncate closes the `LedgerState` while keeping
@@ -7661,9 +7667,12 @@ immediately in practice.
 
 `rollbackChainAndState` sequences three steps in order, and the ordering is
 load-bearing in both directions: `drainBlockPipelineBeforeRollback` first,
-then `validateAndEmitRollbackUndo` (reject-then-emit-undo-events, from
-issue #2287/#3209's ordering fix, `ledger/block_event.go`), then
-`ls.chain.Rollback`. Draining before validating/emitting matters because
+then, while holding `transactionEventMutex`,
+`validateAndEmitRollbackUndo` (reject-then-emit-undo-events, from issue
+#2287/#3209's ordering fix, `ledger/block_event.go`) and
+`ls.chain.Rollback`. Draining before taking the transaction-event serializer
+avoids waiting for pipeline work whose commit needs that same serializer.
+Draining before validating/emitting matters because
 `validateAndEmitRollbackUndo`'s emit reads what is already committed to the
 db (`blocksAboveSlot`) — a block the pipeline is still decoding/validating/
 applying for the fork about to be abandoned is not there yet, so emitting

--- a/event/doc.go
+++ b/event/doc.go
@@ -57,7 +57,9 @@
 // ledger.tx uses PublishOrdered. A subscriber deriving state from it can
 // rely on a block's transactions arriving in index order, and on a
 // rollback's undo events (Rollback: true) arriving before any
-// transaction event the ledger emits afterwards. See
+// transaction event the ledger emits afterwards. Forward Apply events are
+// registered with the database transaction's AfterCommit hook, so a rollback
+// or failed commit publishes none. See
 // blinklabs-io/dingo#2287: while those undo events were emitted from a
 // detached goroutine, a subscriber could apply an undo after the redo
 // that followed it and stay wrong indefinitely.

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -19,12 +19,12 @@ import "context"
 // OrderedQueueSize is the per-event-type buffer behind PublishOrdered. It is
 // larger than AsyncQueueSize because an ordered lane is drained by exactly one
 // worker rather than by the shared pool, so it has to absorb the same bursts
-// with less drain throughput. The ledger publishes ledger.tx from inside its
-// block-apply database transaction, and a publisher that parks holds that
-// transaction open, so the buffer is sized to swallow a bulk-sync batch's
-// transactions rather than to bound memory tightly. It is still bounded:
-// past this point the publisher waits, exactly as it already did on a full
-// shared async queue.
+// with less drain throughput. The ledger publishes ledger.tx from an
+// after-commit callback, and a publisher that parks delays the block-apply
+// pipeline even though the transaction is already durable, so the buffer is
+// sized to swallow a bulk-sync batch's transactions rather than to bound
+// memory tightly. It is still bounded: past this point the publisher waits,
+// exactly as it already did on a full shared async queue.
 const OrderedQueueSize = 10000
 
 // orderedLane is one event type's FIFO plus the single worker that drains it.

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -135,9 +135,9 @@ func (ls *LedgerState) emitRollbackTransactionEvents(
 // the shared worker pool reorders (blinklabs-io/dingo#2287).
 //
 // This stays asynchronous rather than becoming a PublishBlocking like
-// publishBlockEvent: the forward-path caller runs inside the block-apply
-// database transaction, so parking it on subscriber backpressure would hold
-// that transaction open.
+// publishBlockEvent: the forward path calls it from a database AfterCommit
+// callback. Enqueueing here keeps subscriber work out of Commit while still
+// ensuring the transaction is durable before any Apply becomes visible.
 func (ls *LedgerState) publishTransactionEvent(evt TransactionEvent) {
 	if ls.config.EventBus == nil {
 		return

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -20,10 +20,12 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
@@ -228,6 +230,125 @@ func TestRollbackTxEventsPrecedeLaterForwardTxEvents(t *testing.T) {
 			pos++
 		}
 	}
+}
+
+// TestRollbackWaitsForCommittedApplyPublication pins the post-commit race:
+// storage becomes visible before database.Txn starts draining AfterCommit
+// callbacks. A rollback in that window can read the new block and enqueue Undo
+// before its Apply unless block-apply commit and rollback emission share a
+// serializer.
+func TestRollbackWaitsForCommittedApplyPublication(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	ls.config.EventBus = bus
+	subID, txCh := bus.SubscribeWithBuffer(TransactionEventType, 64)
+	require.NotEqual(t, event.EventSubscriberId(0), subID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, subID) })
+
+	commitReached := make(chan struct{})
+	allowPublish := make(chan struct{})
+	var releaseOnce sync.Once
+	releasePublish := func() { releaseOnce.Do(func() { close(allowPublish) }) }
+	ls.beforeTransactionApplyPublish = func() {
+		close(commitReached)
+		<-allowPublish
+	}
+
+	delta := newTransactionEventTestDelta(t, 7, 0)
+	defer delta.Release()
+	applyDone := make(chan error, 1)
+	applyFinished := false
+	defer func() {
+		releasePublish()
+		if !applyFinished {
+			select {
+			case <-applyDone:
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}()
+	go func() {
+		applyDone <- ls.submitBlockApplyDBTxn(
+			fixture.currentTip,
+			fixture.currentTip.Point,
+			func(txn *database.Txn) error {
+				return delta.apply(ls, txn)
+			},
+		)
+	}()
+	testutil.RequireReceive(
+		t,
+		commitReached,
+		2*time.Second,
+		"database commit before Apply publication",
+	)
+
+	rollbackDone := make(chan error, 1)
+	go func() {
+		rollbackDone <- ls.rollbackChainAndState(fixture.ancestorTip.Point)
+	}()
+	testutil.RequireNoReceive(
+		t,
+		rollbackDone,
+		100*time.Millisecond,
+		"rollback while committed Apply publication is pending",
+	)
+	require.Equal(t, fixture.currentTip, ls.chain.Tip())
+	testutil.RequireNoReceive(
+		t,
+		txCh,
+		100*time.Millisecond,
+		"Apply while after-commit callback is held",
+	)
+
+	releasePublish()
+	require.NoError(t, testutil.RequireReceive(
+		t,
+		applyDone,
+		2*time.Second,
+		"block apply transaction",
+	))
+	applyFinished = true
+	applyEvt := testutil.RequireReceive(
+		t,
+		txCh,
+		2*time.Second,
+		"committed Apply event",
+	)
+	txEvt, ok := applyEvt.Data.(TransactionEvent)
+	require.True(t, ok, "unexpected payload %T", applyEvt.Data)
+	require.False(t, txEvt.Rollback)
+	require.NoError(t, testutil.RequireReceive(
+		t,
+		rollbackDone,
+		2*time.Second,
+		"rollback after Apply publication",
+	))
+	require.Equal(t, fixture.ancestorTip, ls.chain.Tip())
+}
+
+func TestBlockApplyRejectsRolledBackCandidate(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	rolledBackCandidate := fixture.currentTip.Point
+	require.NoError(
+		t,
+		fixture.ls.rollbackChainAndState(fixture.ancestorTip.Point),
+	)
+
+	operationCalled := false
+	err := fixture.ls.submitBlockApplyDBTxn(
+		fixture.ancestorTip,
+		rolledBackCandidate,
+		func(*database.Txn) error {
+			operationCalled = true
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, errStaleChainIterator)
+	require.False(t, operationCalled)
 }
 
 // TestRollbackAndForwardTxEventsStayOrderedAcrossRepeatedCycles guards the

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -251,9 +251,10 @@ func TestRollbackWaitsForCommittedApplyPublication(t *testing.T) {
 	commitReached := make(chan struct{})
 	allowPublish := make(chan struct{})
 	var releaseOnce sync.Once
+	var commitOnce sync.Once
 	releasePublish := func() { releaseOnce.Do(func() { close(allowPublish) }) }
 	ls.beforeTransactionApplyPublish = func() {
-		close(commitReached)
+		commitOnce.Do(func() { close(commitReached) })
 		<-allowPublish
 	}
 
@@ -328,6 +329,63 @@ func TestRollbackWaitsForCommittedApplyPublication(t *testing.T) {
 		"rollback after Apply publication",
 	))
 	require.Equal(t, fixture.ancestorTip, ls.chain.Tip())
+}
+
+func TestBlockApplyCandidatePointUsesLastExaminedBlock(t *testing.T) {
+	blockHash := func(value byte) []byte {
+		ret := make([]byte, 32)
+		ret[0] = value
+		return ret
+	}
+	blocks := []ledger.Block{
+		&readChainMockBlock{slot: 9, hash: blockHash(9)},
+		&readChainMockBlock{slot: 10, hash: blockHash(10)},
+		&readChainMockBlock{slot: 11, hash: blockHash(11)},
+	}
+
+	testCases := []struct {
+		name     string
+		blocks   []ledger.Block
+		epoch    models.Epoch
+		wantSlot uint64
+		wantHash []byte
+	}{
+		{
+			name:     "chunk without boundary",
+			blocks:   blocks,
+			epoch:    models.Epoch{StartSlot: 0, LengthInSlots: 20, SlotLength: 1},
+			wantSlot: 11,
+			wantHash: blockHash(11),
+		},
+		{
+			name:     "boundary before suffix",
+			blocks:   blocks,
+			epoch:    models.Epoch{StartSlot: 0, LengthInSlots: 10, SlotLength: 1},
+			wantSlot: 10,
+			wantHash: blockHash(10),
+		},
+		{
+			name:     "boundary at offset zero",
+			blocks:   blocks[1:],
+			epoch:    models.Epoch{StartSlot: 0, LengthInSlots: 10, SlotLength: 1},
+			wantSlot: 10,
+			wantHash: blockHash(10),
+		},
+		{
+			name:     "missing epoch examines first block",
+			blocks:   blocks,
+			epoch:    models.Epoch{},
+			wantSlot: 9,
+			wantHash: blockHash(9),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := blockApplyCandidatePoint(testCase.blocks, testCase.epoch)
+			require.Equal(t, testCase.wantSlot, got.Slot)
+			require.Equal(t, testCase.wantHash, got.Hash)
+		})
+	}
 }
 
 func TestBlockApplyRejectsRolledBackCandidate(t *testing.T) {

--- a/ledger/delta.go
+++ b/ledger/delta.go
@@ -241,23 +241,34 @@ func (d *LedgerDelta) applyWithDonationRecording(
 		d.accumulateNetworkDonations(appliedTxs)
 	}
 
-	// Emit transaction events only after all processing succeeds,
-	// so subscribers never see an "applied" event for a transaction
-	// whose governance processing failed and caused the apply to abort.
-	// Emitted on the ledger.tx ordered lane so a subscriber sees this
-	// block's transactions in index order, and sees them after the undo
-	// events of any rollback that preceded them. See
+	// Stage transaction events only after all delta processing succeeds, then
+	// publish them once the database transaction commits durably. A later delta
+	// failure, rollback, or commit failure discards the callback, so subscribers
+	// never derive state from an Apply that did not persist. AfterCommit runs
+	// callbacks in registration order, and this callback walks transactions in
+	// index order before handing each event to the ledger.tx ordered lane. See
 	// publishTransactionEvent.
+	applyEvents := make([]TransactionEvent, 0, len(d.Transactions))
 	for i, tr := range d.Transactions {
 		if !appliedTxs[i] {
 			continue
 		}
-		ls.publishTransactionEvent(TransactionEvent{
+		applyEvents = append(applyEvents, TransactionEvent{
 			Transaction: tr.Tx,
 			Point:       d.Point,
 			BlockNumber: d.BlockNumber,
 			TxIndex:     uint32(tr.Index), //nolint:gosec
 			Rollback:    false,
+		})
+	}
+	if len(applyEvents) > 0 {
+		txn.AfterCommit(func() {
+			if ls.beforeTransactionApplyPublish != nil {
+				ls.beforeTransactionApplyPublish()
+			}
+			for _, evt := range applyEvents {
+				ls.publishTransactionEvent(evt)
+			}
 		})
 	}
 

--- a/ledger/delta_after_commit_test.go
+++ b/ledger/delta_after_commit_test.go
@@ -1,0 +1,280 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/event"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+type commitFailingBlobStore struct {
+	blob.BlobStore
+	err error
+}
+
+func (s commitFailingBlobStore) NewTransaction(readWrite bool) dbtypes.Txn {
+	txn := s.BlobStore.NewTransaction(readWrite)
+	if !readWrite {
+		return txn
+	}
+	return &commitFailingBlobTxn{Txn: txn, err: s.err}
+}
+
+func (s commitFailingBlobStore) SetTx(
+	txn dbtypes.Txn,
+	txHash []byte,
+	offsetData []byte,
+) error {
+	return s.BlobStore.SetTx(unwrapCommitFailingBlobTxn(txn), txHash, offsetData)
+}
+
+func (s commitFailingBlobStore) SetCommitTimestamp(
+	timestamp int64,
+	txn dbtypes.Txn,
+) error {
+	return s.BlobStore.SetCommitTimestamp(
+		timestamp,
+		unwrapCommitFailingBlobTxn(txn),
+	)
+}
+
+type commitFailingBlobTxn struct {
+	dbtypes.Txn
+	err error
+}
+
+func (t *commitFailingBlobTxn) Commit() error {
+	_ = t.Txn.Rollback()
+	return t.err
+}
+
+func unwrapCommitFailingBlobTxn(txn dbtypes.Txn) dbtypes.Txn {
+	if wrapped, ok := txn.(*commitFailingBlobTxn); ok {
+		return wrapped.Txn
+	}
+	return txn
+}
+
+func newTransactionEventTestLedger(
+	t *testing.T,
+) (*LedgerState, *database.Database, <-chan event.Event) {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	subID, events := bus.SubscribeWithBuffer(TransactionEventType, 16)
+	require.NotEqual(t, event.EventSubscriberId(0), subID)
+	t.Cleanup(func() { bus.Unsubscribe(TransactionEventType, subID) })
+
+	return &LedgerState{
+		db: db,
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}, db, events
+}
+
+func newTransactionEventTestDelta(
+	t *testing.T,
+	seed byte,
+	index int,
+) *LedgerDelta {
+	t.Helper()
+
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithId(bytes.Repeat([]byte{seed}, 32))
+	tx.WithType(gledger.TxTypeDijkstra)
+	tx.WithValid(true)
+
+	point := ocommon.Point{
+		Slot: uint64(seed),
+		Hash: bytes.Repeat([]byte{seed + 1}, 32),
+	}
+	var txHash [32]byte
+	copy(txHash[:], tx.Hash().Bytes())
+	var blockHash [32]byte
+	copy(blockHash[:], point.Hash)
+
+	delta := NewLedgerDelta(
+		point,
+		uint(dijkstra.EraIdDijkstra),
+		uint64(seed),
+	)
+	delta.Offsets = &database.BlockIngestionResult{
+		TxOffsets:   make(map[[32]byte]database.CborOffset),
+		UtxoOffsets: make(map[database.UtxoRef]database.CborOffset),
+	}
+	delta.Offsets.TxOffsets[txHash] = database.CborOffset{
+		BlockSlot:  point.Slot,
+		BlockHash:  blockHash,
+		ByteLength: 1,
+	}
+	delta.addTransaction(tx, index)
+	return delta
+}
+
+func addTransactionEventTestTransaction(
+	t *testing.T,
+	delta *LedgerDelta,
+	seed byte,
+	index int,
+) {
+	t.Helper()
+
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithId(bytes.Repeat([]byte{seed}, 32))
+	tx.WithType(gledger.TxTypeDijkstra)
+	tx.WithValid(true)
+	var txHash [32]byte
+	copy(txHash[:], tx.Hash().Bytes())
+	var blockHash [32]byte
+	copy(blockHash[:], delta.Point.Hash)
+	delta.Offsets.TxOffsets[txHash] = database.CborOffset{
+		BlockSlot:  delta.Point.Slot,
+		BlockHash:  blockHash,
+		ByteLength: 1,
+	}
+	delta.addTransaction(tx, index)
+}
+
+func requireTransactionEvent(
+	t *testing.T,
+	events <-chan event.Event,
+	wantIndex uint32,
+) TransactionEvent {
+	t.Helper()
+	evt := testutil.RequireReceive(
+		t,
+		events,
+		2*time.Second,
+		"post-commit transaction event",
+	)
+	txEvt, ok := evt.Data.(TransactionEvent)
+	require.True(t, ok, "unexpected payload %T", evt.Data)
+	require.Equal(t, wantIndex, txEvt.TxIndex)
+	require.False(t, txEvt.Rollback)
+	return txEvt
+}
+
+func TestLedgerDeltaPublishesApplyEventsOnlyAfterCommit(t *testing.T) {
+	t.Run("commit publishes in transaction order", func(t *testing.T) {
+		ls, db, events := newTransactionEventTestLedger(t)
+		delta := newTransactionEventTestDelta(t, 1, 0)
+		defer delta.Release()
+		addTransactionEventTestTransaction(t, delta, 2, 1)
+
+		txn := db.Transaction(true)
+		require.NoError(t, delta.apply(ls, txn))
+		testutil.RequireNoReceive(
+			t,
+			events,
+			100*time.Millisecond,
+			"apply event before commit",
+		)
+		require.NoError(t, txn.Commit())
+
+		firstEvt := requireTransactionEvent(t, events, 0)
+		secondEvt := requireTransactionEvent(t, events, 1)
+		require.Equal(t, delta.Transactions[0].Tx.Hash(), firstEvt.Transaction.Hash())
+		require.Equal(t, delta.Transactions[1].Tx.Hash(), secondEvt.Transaction.Hash())
+	})
+
+	t.Run("rollback publishes nothing", func(t *testing.T) {
+		ls, db, events := newTransactionEventTestLedger(t)
+		delta := newTransactionEventTestDelta(t, 3, 0)
+		defer delta.Release()
+
+		txn := db.Transaction(true)
+		require.NoError(t, delta.apply(ls, txn))
+		require.NoError(t, txn.Rollback())
+		testutil.RequireNoReceive(
+			t,
+			events,
+			100*time.Millisecond,
+			"apply event after rollback",
+		)
+	})
+
+	t.Run("later delta failure publishes nothing", func(t *testing.T) {
+		ls, db, events := newTransactionEventTestLedger(t)
+		first := newTransactionEventTestDelta(t, 4, 0)
+		second := newTransactionEventTestDelta(t, 5, -1)
+		batch := NewLedgerDeltaBatch()
+		batch.addDelta(first)
+		batch.addDelta(second)
+		defer batch.Release()
+
+		err := db.Transaction(true).Do(func(txn *database.Txn) error {
+			return batch.apply(ls, txn)
+		})
+		require.ErrorContains(t, err, "transaction index out of range")
+		testutil.RequireNoReceive(
+			t,
+			events,
+			100*time.Millisecond,
+			"apply event after later delta failure",
+		)
+	})
+
+	t.Run("commit failure publishes nothing", func(t *testing.T) {
+		ls, baseDB, events := newTransactionEventTestLedger(t)
+		commitErr := errors.New("injected blob commit failure")
+		failingDB, err := database.New(
+			baseDB.Config(),
+			database.Stores{
+				Blob: commitFailingBlobStore{
+					BlobStore: baseDB.Blob(),
+					err:       commitErr,
+				},
+				Metadata: baseDB.Metadata(),
+			},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, failingDB.Close()) })
+		ls.db = failingDB
+		delta := newTransactionEventTestDelta(t, 6, 0)
+		defer delta.Release()
+
+		err = failingDB.Transaction(true).Do(func(txn *database.Txn) error {
+			return delta.apply(ls, txn)
+		})
+		require.ErrorIs(t, err, commitErr)
+		testutil.RequireNoReceive(
+			t,
+			events,
+			100*time.Millisecond,
+			"apply event after commit failure",
+		)
+	})
+}

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -91,8 +91,9 @@ type PoolStateRestoredEvent struct {
 	Slot uint64 // The slot to which pool state was restored
 }
 
-// TransactionEvent is emitted when a transaction is applied or rolled back.
-// Check the Rollback field to determine direction.
+// TransactionEvent is emitted after a transaction Apply commits durably, or
+// before an applied transaction is rolled back. Check the Rollback field to
+// determine direction.
 type TransactionEvent struct {
 	Transaction ledger.Transaction
 	Point       ocommon.Point

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -419,6 +419,10 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 	if securityParam <= 0 {
 		return chain.ErrSecurityParamNotConfigured
 	}
+	// Keep every Undo enqueue and its corresponding chain truncation atomic
+	// with respect to a block-apply commit's AfterCommit Apply publication.
+	ls.transactionEventMutex.Lock()
+	defer ls.transactionEventMutex.Unlock()
 
 	targetIndex := uint64(0)
 	if point.Slot > 0 || len(point.Hash) > 0 {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -314,12 +314,34 @@ func (ls *LedgerState) handleDBTxnResult(err error) error {
 	return err
 }
 
+// blockApplyCandidatePoint returns the last block that the block-apply
+// callback will examine. A block at the next epoch boundary is examined and
+// cached, but the suffix after it is not touched until the next loop.
+func blockApplyCandidatePoint(
+	blocks []ledger.Block,
+	epoch models.Epoch,
+) ocommon.Point {
+	candidate := blocks[0]
+	epochEnd := epoch.StartSlot + uint64(epoch.LengthInSlots)
+	for _, block := range blocks {
+		candidate = block
+		if epoch.SlotLength == 0 || block.SlotNumber() >= epochEnd {
+			break
+		}
+	}
+	return ocommon.NewPoint(
+		candidate.SlotNumber(),
+		candidate.Hash().Bytes(),
+	)
+}
+
 // submitBlockApplyDBTxn serializes a block-apply commit and its after-commit
 // transaction events against every primary-chain rollback that emits undo
-// events. The expected ledger tip and candidate batch tip are captured before
-// waiting for the serializer. If a rollback wins the race, either the ledger
-// tip changes or the candidate block disappears from the primary chain, and
-// the stale batch is rejected rather than published after the undo.
+// events. The expected ledger tip and last block the batch will examine are
+// captured before waiting for the serializer. If a rollback wins the race,
+// either the ledger tip changes or the examined block disappears from the
+// primary chain, and the stale batch is rejected rather than published after
+// the undo.
 func (ls *LedgerState) submitBlockApplyDBTxn(
 	expectedTip ochainsync.Tip,
 	candidateTip ocommon.Point,
@@ -5199,9 +5221,9 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// restarts (errRestartLedgerPipeline), and abandoning a
 			// publish on a restart would drop events subscribers
 			// derive state from. Only Close cancels publishCtx.
-			candidateTip := ocommon.NewPoint(
-				nextBatch[end-1].SlotNumber(),
-				nextBatch[end-1].Hash().Bytes(),
+			candidateTip := blockApplyCandidatePoint(
+				nextBatch[i:end],
+				snapshotEpoch,
 			)
 			err = ls.submitBlockApplyDBTxn(
 				snapshotTip,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -250,10 +250,21 @@ func (ls *LedgerState) SubmitAsyncDBTxn(
 	opFunc func(txn *database.Txn) error,
 	readWrite bool,
 ) error {
-	err := ls.SubmitAsyncDBOperation(func(db *database.Database) error {
+	err := ls.submitDBTxnOperation(opFunc, readWrite)
+	return ls.handleDBTxnResult(err)
+}
+
+func (ls *LedgerState) submitDBTxnOperation(
+	opFunc func(txn *database.Txn) error,
+	readWrite bool,
+) error {
+	return ls.SubmitAsyncDBOperation(func(db *database.Database) error {
 		txn := db.Transaction(readWrite)
 		return txn.Do(opFunc)
 	})
+}
+
+func (ls *LedgerState) handleDBTxnResult(err error) error {
 	// Check for partial commit and trigger recovery if needed.
 	// Guard against recursive recovery: if we're already in recovery and another
 	// PartialCommitError occurs, don't attempt recovery again to prevent unbounded recursion.
@@ -301,6 +312,42 @@ func (ls *LedgerState) SubmitAsyncDBTxn(
 		)
 	}
 	return err
+}
+
+// submitBlockApplyDBTxn serializes a block-apply commit and its after-commit
+// transaction events against every primary-chain rollback that emits undo
+// events. The expected ledger tip and candidate batch tip are captured before
+// waiting for the serializer. If a rollback wins the race, either the ledger
+// tip changes or the candidate block disappears from the primary chain, and
+// the stale batch is rejected rather than published after the undo.
+func (ls *LedgerState) submitBlockApplyDBTxn(
+	expectedTip ochainsync.Tip,
+	candidateTip ocommon.Point,
+	opFunc func(txn *database.Txn) error,
+) error {
+	err := func() error {
+		ls.transactionEventMutex.Lock()
+		defer ls.transactionEventMutex.Unlock()
+
+		ls.RLock()
+		currentTip := ls.currentTip
+		ls.RUnlock()
+		if currentTip.BlockNumber != expectedTip.BlockNumber ||
+			!pointMatches(currentTip.Point, expectedTip.Point) {
+			return errStaleChainIterator
+		}
+		if _, err := database.BlockByPoint(ls.db, candidateTip); err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				return errStaleChainIterator
+			}
+			return fmt.Errorf("check block-apply candidate tip: %w", err)
+		}
+		return ls.submitDBTxnOperation(opFunc, true)
+	}()
+	// Partial-commit recovery can itself rewind the primary chain, so it must
+	// run after releasing transactionEventMutex rather than recursively trying
+	// to acquire it from rollbackPrimaryChainInSecurityParamWindows.
+	return ls.handleDBTxnResult(err)
 }
 
 // SubmitAsyncDBReadTxn submits a read-only database transaction operation for execution on the worker pool.
@@ -886,6 +933,13 @@ type LedgerState struct {
 	// closes the narrower, earlier window between gathering raw blocks and
 	// submitting them, which has no other guard at all.
 	blockPipelineGatherMutex sync.RWMutex
+	// transactionEventMutex serializes block-apply commits (including their
+	// database AfterCommit Apply publication) against rollback validation,
+	// Undo publication, and primary-chain truncation. Without it, a rollback
+	// can observe a newly committed block before its AfterCommit callback has
+	// reached the ordered lane, publishing Undo before Apply. See
+	// submitBlockApplyDBTxn and rollbackChainAndState.
+	transactionEventMutex sync.Mutex
 
 	// publishCtx is cancelled at the top of Close so a ledger.tx publish
 	// parked on a full ordered lane cannot outlive shutdown. Only the
@@ -896,6 +950,10 @@ type LedgerState struct {
 	// cancellation" and matches the pre-existing behaviour.
 	publishCtx    context.Context
 	publishCancel context.CancelFunc
+	// beforeTransactionApplyPublish is a test-only sequencing hook. Nil in
+	// production; tests use it to hold the exact post-commit/pre-publication
+	// window without relying on scheduler timing.
+	beforeTransactionApplyPublish func()
 
 	// replayMu serializes replayWG.Add with Close's replayWG.Wait to
 	// prevent Add-after-Wait panics from the TOCTOU race between
@@ -3015,10 +3073,18 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 		context.Background(),
 		"chainsync rollback",
 	)
-	if err := ls.validateAndEmitRollbackUndo(point); err != nil {
-		return err
-	}
-	if err := ls.chain.Rollback(point); err != nil {
+	// A database commit becomes visible before its AfterCommit callbacks run.
+	// Exclude that window so blocksAboveSlot can never publish an Undo for the
+	// new state before the matching Apply reaches the ordered lane.
+	err := func() error {
+		ls.transactionEventMutex.Lock()
+		defer ls.transactionEventMutex.Unlock()
+		if err := ls.validateAndEmitRollbackUndo(point); err != nil {
+			return err
+		}
+		return ls.chain.Rollback(point)
+	}()
+	if err != nil {
 		return err
 	}
 	if err := ls.rollback(point); err != nil {
@@ -5133,7 +5199,13 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// restarts (errRestartLedgerPipeline), and abandoning a
 			// publish on a restart would drop events subscribers
 			// derive state from. Only Close cancels publishCtx.
-			err = ls.SubmitAsyncDBTxn(
+			candidateTip := ocommon.NewPoint(
+				nextBatch[end-1].SlotNumber(),
+				nextBatch[end-1].Hash().Bytes(),
+			)
+			err = ls.submitBlockApplyDBTxn(
+				snapshotTip,
+				candidateTip,
 				func(txn *database.Txn) error { //nolint:contextcheck
 					deltaBatch = NewLedgerDeltaBatch()
 					for offset, next := range nextBatch[i:end] {
@@ -5369,7 +5441,6 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 					}
 					return nil
 				},
-				true,
 			)
 			if err != nil {
 				// Undo events published down this recovery path are


### PR DESCRIPTION
Closes #3283.

## Summary

- stage ledger Apply events at the database after-commit boundary so subscribers cannot observe state that later rolls back
- serialize durable Apply publication with rollback and reject stale candidates using the last block each epoch-bounded batch examines
- compose the event-ordering change with current-main partial-commit recovery and Mithril swap hardening
- document the ordering contract and cover pre-commit publication, Apply/Undo ordering, epoch boundaries, stale candidates, and recovery interactions

## Validation

Focused event and recovery race suites, the full race-enabled ledger package (926.5s), golangci-lint, NilAway, import boundaries, and docs parity pass on the composed head. The original implementation head passed a fresh accelerated conformance DevNet. The composed-head DevNet was not run because its Docker/process/port preflight hung twice before launch; no runner, container, or artifact was created.
