### PR TITLE
fix(chainsync): reject future headers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7845,6 +7845,16 @@ ledger reader reaches the validate stage, and `ls.chain` is consumed by the
 downstream blockfetch server and UTxO RPC sync/watch readers. A block that has
 not passed admission crypto must therefore never enter that chain.
 
+ChainSync admission also enforces the Ouroboros future-header rule before a
+header enters that queue. The network callback records `ChainsyncEvent`'s
+`ArrivalTime` immediately, before chain-selection and EventBus work can delay
+delivery. Ledger admission converts the header slot to its wall-clock onset
+using the active hard-fork summary. A header received no more than two seconds
+early (the `ouroboros-consensus` default clock-skew allowance) waits until its
+slot begins; a header received earlier is rejected and its connection is
+recycled. Judging the recorded arrival rather than the later handler time means
+EventBus or scheduler delay cannot make an invalid early header appear timely.
+
 `blockPipelineEta0Provider` reads the immutable epoch-cache snapshot directly;
 it does not forecast, mutate the cache, or rebuild `HardForkSummary` per
 block. `decodeReadChainBatch` enforces pipeline results only when the serial

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7848,13 +7848,23 @@ not passed admission crypto must therefore never enter that chain.
 ChainSync admission also enforces the Ouroboros future-header rule before a
 header enters that queue. The raw network callback records `ChainsyncEvent`'s
 `ArrivalTime` immediately, before header decoding, chain-selection, and
-EventBus work can delay delivery. Ledger admission converts the header slot to
-its wall-clock onset using the active hard-fork summary. A header received no
-more than two seconds early (the `ouroboros-consensus` default clock-skew
-allowance) waits until its slot begins; a header received earlier is rejected
-and its connection is recycled. Judging the recorded arrival rather than the
-later handler time means local decode, EventBus, or scheduler delay cannot make
-an invalid early header appear timely.
+EventBus work can delay delivery. The per-peer protocol callback asks ledger
+admission to convert the header slot to its wall-clock onset using the active
+hard-fork summary before observed-tip, dedup, or ledger state changes. A header
+received no more than two seconds early (the `ouroboros-consensus` default
+clock-skew allowance) waits on that peer callback until its slot begins; it
+never sleeps under the node-wide ChainSync dispatch mutex. A resolvable header
+received earlier is dropped without recycling or penalizing the peer, because
+the node cannot distinguish peer skew from a slow local clock. One coalesced
+timer per connection re-intersects the mini-protocol at the earliest dropped
+header's onset so the remote cursor cannot strand the accepted chain; later
+headers from that peer remain withheld until the old mini-protocol has stopped
+and the re-intersection can replay from ledger-accepted points. A slot
+past the hard-fork forecast is deferred to the normal header-verification path,
+which already treats `ErrPastHorizon` as unavailable state rather than peer
+fault. Judging the recorded arrival rather than the later handler time means
+local decode, EventBus, or scheduler delay cannot make an invalid early header
+appear timely.
 
 `blockPipelineEta0Provider` reads the immutable epoch-cache snapshot directly;
 it does not forecast, mutate the cache, or rebuild `HardForkSummary` per

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7846,14 +7846,15 @@ downstream blockfetch server and UTxO RPC sync/watch readers. A block that has
 not passed admission crypto must therefore never enter that chain.
 
 ChainSync admission also enforces the Ouroboros future-header rule before a
-header enters that queue. The network callback records `ChainsyncEvent`'s
-`ArrivalTime` immediately, before chain-selection and EventBus work can delay
-delivery. Ledger admission converts the header slot to its wall-clock onset
-using the active hard-fork summary. A header received no more than two seconds
-early (the `ouroboros-consensus` default clock-skew allowance) waits until its
-slot begins; a header received earlier is rejected and its connection is
-recycled. Judging the recorded arrival rather than the later handler time means
-EventBus or scheduler delay cannot make an invalid early header appear timely.
+header enters that queue. The raw network callback records `ChainsyncEvent`'s
+`ArrivalTime` immediately, before header decoding, chain-selection, and
+EventBus work can delay delivery. Ledger admission converts the header slot to
+its wall-clock onset using the active hard-fork summary. A header received no
+more than two seconds early (the `ouroboros-consensus` default clock-skew
+allowance) waits until its slot begins; a header received earlier is rejected
+and its connection is recycled. Judging the recorded arrival rather than the
+later handler time means local decode, EventBus, or scheduler delay cannot make
+an invalid early header appear timely.
 
 `blockPipelineEta0Provider` reads the immutable epoch-cache snapshot directly;
 it does not forecast, mutate the cache, or rebuild `HardForkSummary` per

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -177,6 +177,7 @@ type ChainProvider interface {
 type ObservedHeader struct {
 	ConnectionId ouroboros.ConnectionId
 	BlockHeader  gledger.BlockHeader
+	ArrivalTime  time.Time
 	Point        ocommon.Point
 	Tip          ochainsync.Tip
 	BlockNumber  uint64

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1530,6 +1530,7 @@ func TestObservedHeader_RoundTrip(t *testing.T) {
 	prev := []byte("prev-hash")
 	point := ocommon.NewPoint(200, hash)
 	tip := ochainsync.Tip{Point: point, BlockNumber: 5}
+	arrivalTime := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
 	hdr := testBlockHeader{
 		hash:        lcommon.NewBlake2b256(hash),
 		prevHash:    lcommon.NewBlake2b256(prev),
@@ -1542,6 +1543,7 @@ func TestObservedHeader_RoundTrip(t *testing.T) {
 		BlockHeader:  hdr,
 		Point:        point,
 		Tip:          tip,
+		ArrivalTime:  arrivalTime,
 		BlockNumber:  5,
 		Type:         1,
 	})
@@ -1550,6 +1552,7 @@ func TestObservedHeader_RoundTrip(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, point, got.Point)
 	require.Equal(t, tip, got.Tip)
+	require.Equal(t, arrivalTime, got.ArrivalTime)
 	require.Equal(t, uint64(5), got.BlockNumber)
 	require.Equal(t, uint(1), got.Type)
 	require.Equal(t, hdr.PrevHash().Bytes(), gotPrev)

--- a/event/chainsync_resync.go
+++ b/event/chainsync_resync.go
@@ -44,6 +44,11 @@ const (
 	ChainsyncResyncReasonBlockfetchRangeUnavailable        = "blockfetch could not obtain the queued header range"
 	ChainsyncResyncReasonHeaderValidationRecovery          = "deferred header validation recovery"
 	ChainsyncResyncReasonForkQueueOverflowRestartFailed    = "failed to restart blockfetch after fork-resolution header-queue overflow"
+	// ChainsyncResyncReasonFutureHeaderAdmissionRecovery re-intersects the
+	// ChainSync mini-protocol after a resolvable header was deliberately dropped
+	// outside the permitted clock-skew window. It is not a peer-fault signal and
+	// does not require a fresh connection or peer cooldown.
+	ChainsyncResyncReasonFutureHeaderAdmissionRecovery = "future header admission recovery"
 )
 
 // ChainsyncResyncEvent carries the connection ID that should

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -157,7 +157,8 @@ const (
 
 	// Match ouroboros-consensus' default maximum permissible clock skew. A
 	// header within this window is held until its slot begins; an earlier
-	// header is invalid and the connection is recycled.
+	// resolvable header is dropped and recovered by a peer-local re-intersection
+	// without treating ambiguous local clock skew as a peer fault.
 	defaultHeaderClockSkew = 2 * time.Second
 )
 
@@ -172,33 +173,6 @@ var ErrRollbackLoopDetected = errors.New(
 var ErrRollbackExceedsMithrilBoundary = errors.New(
 	"rollback exceeds Mithril trust boundary",
 )
-
-type headerTooFarInFutureError struct {
-	point       ocommon.Point
-	arrivalTime time.Time
-	slotTime    time.Time
-	cause       error
-}
-
-func (e *headerTooFarInFutureError) Error() string {
-	if e.cause != nil {
-		return fmt.Sprintf(
-			"header at slot %d is beyond the current slot forecast: %v",
-			e.point.Slot,
-			e.cause,
-		)
-	}
-	return fmt.Sprintf(
-		"header at slot %d arrived %s before its slot onset, exceeding %s clock skew",
-		e.point.Slot,
-		e.slotTime.Sub(e.arrivalTime),
-		defaultHeaderClockSkew,
-	)
-}
-
-func (e *headerTooFarInFutureError) Unwrap() error {
-	return e.cause
-}
 
 type peerHeaderRecord struct {
 	event    ChainsyncEvent
@@ -1182,10 +1156,14 @@ func (ls *LedgerState) headerAlreadyOnPrimaryChain(
 		if localErr != nil {
 			ls.config.Logger.Debug(
 				"could not check legacy historical header against primary chain",
-				"component", "ledger",
-				"slot", e.Point.Slot,
-				"hash", hex.EncodeToString(e.Point.Hash),
-				"error", localErr,
+				"component",
+				"ledger",
+				"slot",
+				e.Point.Slot,
+				"hash",
+				hex.EncodeToString(e.Point.Hash),
+				"error",
+				localErr,
 			)
 			return false
 		}
@@ -2449,23 +2427,6 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	e ChainsyncEvent,
 	pending *pendingPublishes,
 ) error {
-	if err := ls.checkChainsyncHeaderArrival(e); err != nil {
-		if _, tooFar := errors.AsType[*headerTooFarInFutureError](err); tooFar && ls.config.EventBus != nil {
-			pending.add(
-				ls.config.EventBus,
-				ConnectionRecycleRequestedEventType,
-				event.NewEvent(
-					ConnectionRecycleRequestedEventType,
-					ConnectionRecycleRequestedEvent{
-						ConnectionId: e.ConnectionId,
-						Reason:       "header_too_far_in_future",
-					},
-				),
-			)
-		}
-		return fmt.Errorf("check chainsync header arrival: %w", err)
-	}
-
 	// Detect connection switch so pipeline ownership is handed off
 	// even when the first post-switch event is a header rather than
 	// a rollback. Without this, headers from a newly-selected active
@@ -2815,57 +2776,67 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	return nil
 }
 
-// checkChainsyncHeaderArrival enforces the Ouroboros ChainSync future-header
-// rule against the timestamp recorded at network ingress. Headers that arrived
-// no more than defaultHeaderClockSkew before their slot are delayed until slot
-// onset; headers received earlier are rejected. A zero timestamp is retained
-// for compatibility with synthetic/internal events that never crossed the
-// network ingress path.
-func (ls *LedgerState) checkChainsyncHeaderArrival(e ChainsyncEvent) error {
+// AwaitChainsyncHeaderAdmission enforces the Ouroboros ChainSync future-header
+// rule against the timestamp recorded at network ingress. It must run from the
+// per-peer ChainSync callback before the header updates observed-tip, dedup, or
+// ledger state; callers must not invoke it while holding the node-wide
+// chainsync dispatch mutex.
+//
+// A header received no more than defaultHeaderClockSkew before its slot waits
+// for slot onset and is accepted. A header received earlier is deliberately
+// dropped by returning (false, nil): local clock skew cannot by itself justify
+// penalizing the peer. ErrPastHorizon is also accepted as a deferred decision,
+// matching headerVerificationEpoch; without a forecast the header cannot be
+// proven future. Other conversion failures fail closed. A zero timestamp is
+// retained for compatibility with synthetic/internal events that never crossed
+// the network ingress path. As with other Go APIs that accept a context, ctx
+// must not be nil.
+func (ls *LedgerState) AwaitChainsyncHeaderAdmission(
+	ctx context.Context,
+	e ChainsyncEvent,
+) (bool, error) {
 	if e.ArrivalTime.IsZero() || ls.slotClock == nil || e.BlockHeader == nil {
-		return nil
+		return true, nil
 	}
 	headerSlot := e.BlockHeader.SlotNumber()
-	arrivalSlot, err := ls.slotClock.slotAtTime(e.ArrivalTime)
-	if err != nil {
-		return fmt.Errorf("resolve header arrival slot: %w", err)
-	}
-	if headerSlot <= arrivalSlot {
-		return nil
-	}
-	if headerSlot > math.MaxInt64 {
-		return &headerTooFarInFutureError{
-			point:       e.Point,
-			arrivalTime: e.ArrivalTime,
-			cause:       errors.New("slot exceeds the supported time range"),
-		}
-	}
 	slotTime, err := ls.slotClock.SlotToTime(headerSlot)
 	if err != nil {
 		if errors.Is(err, hardfork.ErrPastHorizon) {
-			return &headerTooFarInFutureError{
-				point:       e.Point,
-				arrivalTime: e.ArrivalTime,
-				cause:       err,
-			}
+			return true, nil
 		}
-		return fmt.Errorf("resolve header slot onset: %w", err)
+		return false, fmt.Errorf("resolve header slot onset: %w", err)
 	}
-	if slotTime.Sub(e.ArrivalTime) > defaultHeaderClockSkew {
-		return &headerTooFarInFutureError{
-			point:       e.Point,
-			arrivalTime: e.ArrivalTime,
-			slotTime:    slotTime,
+	earlyBy := slotTime.Sub(e.ArrivalTime)
+	if earlyBy <= 0 {
+		return true, nil
+	}
+	if earlyBy > defaultHeaderClockSkew {
+		if ls.config.Logger != nil {
+			ls.config.Logger.Warn(
+				"dropping chainsync header received before permitted clock-skew window",
+				"component",
+				"ledger",
+				"connection_id",
+				connIdKey(e.ConnectionId),
+				"slot",
+				headerSlot,
+				"early_by",
+				earlyBy,
+				"permitted_clock_skew",
+				defaultHeaderClockSkew,
+				"possible_local_clock_skew",
+				true,
+			)
 		}
+		return false, nil
 	}
-	waitCtx := ls.ctx
-	if waitCtx == nil {
-		waitCtx = context.Background()
+	if ctx == nil {
+		return false, errors.New("chainsync header admission context is nil")
 	}
-	if err := ls.slotClock.waitUntil(waitCtx, slotTime); err != nil {
-		return fmt.Errorf("wait for header slot onset: %w", err)
+	if err := ls.slotClock.waitUntil(ctx, slotTime); err != nil {
+		return false, fmt.Errorf("wait for header slot onset: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 func (ls *LedgerState) shouldVerifyChainsyncHeaderCrypto(slot uint64) bool {

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/forging"
 	"github.com/blinklabs-io/dingo/ledger/governance"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
@@ -152,6 +154,11 @@ const (
 	headerMismatchResyncThreshold = 20
 
 	maxPeerHeaderHistoryPerConn = 256
+
+	// Match ouroboros-consensus' default maximum permissible clock skew. A
+	// header within this window is held until its slot begins; an earlier
+	// header is invalid and the connection is recycled.
+	defaultHeaderClockSkew = 2 * time.Second
 )
 
 // ErrRollbackLoopDetected is returned by handleEventChainsyncRollback when
@@ -165,6 +172,33 @@ var ErrRollbackLoopDetected = errors.New(
 var ErrRollbackExceedsMithrilBoundary = errors.New(
 	"rollback exceeds Mithril trust boundary",
 )
+
+type headerTooFarInFutureError struct {
+	point       ocommon.Point
+	arrivalTime time.Time
+	slotTime    time.Time
+	cause       error
+}
+
+func (e *headerTooFarInFutureError) Error() string {
+	if e.cause != nil {
+		return fmt.Sprintf(
+			"header at slot %d is beyond the current slot forecast: %v",
+			e.point.Slot,
+			e.cause,
+		)
+	}
+	return fmt.Sprintf(
+		"header at slot %d arrived %s before its slot onset, exceeding %s clock skew",
+		e.point.Slot,
+		e.slotTime.Sub(e.arrivalTime),
+		defaultHeaderClockSkew,
+	)
+}
+
+func (e *headerTooFarInFutureError) Unwrap() error {
+	return e.cause
+}
 
 type peerHeaderRecord struct {
 	event    ChainsyncEvent
@@ -2415,6 +2449,23 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 	e ChainsyncEvent,
 	pending *pendingPublishes,
 ) error {
+	if err := ls.checkChainsyncHeaderArrival(e); err != nil {
+		if _, tooFar := errors.AsType[*headerTooFarInFutureError](err); tooFar && ls.config.EventBus != nil {
+			pending.add(
+				ls.config.EventBus,
+				ConnectionRecycleRequestedEventType,
+				event.NewEvent(
+					ConnectionRecycleRequestedEventType,
+					ConnectionRecycleRequestedEvent{
+						ConnectionId: e.ConnectionId,
+						Reason:       "header_too_far_in_future",
+					},
+				),
+			)
+		}
+		return fmt.Errorf("check chainsync header arrival: %w", err)
+	}
+
 	// Detect connection switch so pipeline ownership is handed off
 	// even when the first post-switch event is a header rather than
 	// a rollback. Without this, headers from a newly-selected active
@@ -2760,6 +2811,59 @@ func (ls *LedgerState) handleEventChainsyncBlockHeaderWithPending(
 			pending,
 		)
 		return nil
+	}
+	return nil
+}
+
+// checkChainsyncHeaderArrival enforces the Ouroboros ChainSync future-header
+// rule against the timestamp recorded at network ingress. Headers that arrived
+// no more than defaultHeaderClockSkew before their slot are delayed until slot
+// onset; headers received earlier are rejected. A zero timestamp is retained
+// for compatibility with synthetic/internal events that never crossed the
+// network ingress path.
+func (ls *LedgerState) checkChainsyncHeaderArrival(e ChainsyncEvent) error {
+	if e.ArrivalTime.IsZero() || ls.slotClock == nil || e.BlockHeader == nil {
+		return nil
+	}
+	headerSlot := e.BlockHeader.SlotNumber()
+	arrivalSlot, err := ls.slotClock.slotAtTime(e.ArrivalTime)
+	if err != nil {
+		return fmt.Errorf("resolve header arrival slot: %w", err)
+	}
+	if headerSlot <= arrivalSlot {
+		return nil
+	}
+	if headerSlot > math.MaxInt64 {
+		return &headerTooFarInFutureError{
+			point:       e.Point,
+			arrivalTime: e.ArrivalTime,
+			cause:       errors.New("slot exceeds the supported time range"),
+		}
+	}
+	slotTime, err := ls.slotClock.SlotToTime(headerSlot)
+	if err != nil {
+		if errors.Is(err, hardfork.ErrPastHorizon) {
+			return &headerTooFarInFutureError{
+				point:       e.Point,
+				arrivalTime: e.ArrivalTime,
+				cause:       err,
+			}
+		}
+		return fmt.Errorf("resolve header slot onset: %w", err)
+	}
+	if slotTime.Sub(e.ArrivalTime) > defaultHeaderClockSkew {
+		return &headerTooFarInFutureError{
+			point:       e.Point,
+			arrivalTime: e.ArrivalTime,
+			slotTime:    slotTime,
+		}
+	}
+	waitCtx := ls.ctx
+	if waitCtx == nil {
+		waitCtx = context.Background()
+	}
+	if err := ls.slotClock.waitUntil(waitCtx, slotTime); err != nil {
+		return fmt.Errorf("wait for header slot onset: %w", err)
 	}
 	return nil
 }

--- a/ledger/chainsync_future_header_test.go
+++ b/ledger/chainsync_future_header_test.go
@@ -97,9 +97,10 @@ func TestCheckChainsyncHeaderArrivalBoundaries(t *testing.T) {
 		require.Equal(t, []time.Duration{2 * time.Second}, *waits)
 	})
 
-	t.Run("one nanosecond beyond skew is rejected", func(t *testing.T) {
+	t.Run("invalid arrival stays rejected after processing delay", func(t *testing.T) {
 		arrival := systemStart.Add(100*time.Second - time.Nanosecond)
-		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+		processTime := systemStart.Add(103 * time.Second)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, processTime)
 
 		err := ls.checkChainsyncHeaderArrival(
 			futureHeaderEvent(102, arrival),

--- a/ledger/chainsync_future_header_test.go
+++ b/ledger/chainsync_future_header_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+type pastHorizonSlotTimeProvider struct {
+	SlotTimeProvider
+	rejectedSlot uint64
+}
+
+func (p pastHorizonSlotTimeProvider) SlotToTime(
+	slot uint64,
+) (time.Time, error) {
+	if slot == p.rejectedSlot {
+		return time.Time{}, hardfork.ErrPastHorizon
+	}
+	return p.SlotTimeProvider.SlotToTime(slot)
+}
+
+func newFutureHeaderTestLedger(
+	t *testing.T,
+	systemStart time.Time,
+	now time.Time,
+) (*LedgerState, *[]time.Duration) {
+	t.Helper()
+	provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+	clock.nowFunc = func() time.Time { return now }
+	waits := make([]time.Duration, 0, 1)
+	clock.waitFunc = func(_ context.Context, delay time.Duration) error {
+		waits = append(waits, delay)
+		return nil
+	}
+	return &LedgerState{
+		slotClock: clock,
+		ctx:       t.Context(),
+	}, &waits
+}
+
+func futureHeaderEvent(slot uint64, arrival time.Time) ChainsyncEvent {
+	header := &envelopeTestHeader{
+		slot: slot,
+		era:  shelley.EraShelley,
+	}
+	return ChainsyncEvent{
+		BlockHeader: header,
+		ArrivalTime: arrival,
+		Point:       ocommon.NewPoint(slot, []byte{byte(slot)}),
+	}
+}
+
+func TestCheckChainsyncHeaderArrivalBoundaries(t *testing.T) {
+	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+
+	t.Run("current header is accepted immediately", func(t *testing.T) {
+		arrival := systemStart.Add(100 * time.Second)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+
+		require.NoError(t, ls.checkChainsyncHeaderArrival(
+			futureHeaderEvent(100, arrival),
+		))
+		require.Empty(t, *waits)
+	})
+
+	t.Run("clock skew boundary waits until onset", func(t *testing.T) {
+		arrival := systemStart.Add(100 * time.Second)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+
+		require.NoError(t, ls.checkChainsyncHeaderArrival(
+			futureHeaderEvent(102, arrival),
+		))
+		require.Equal(t, []time.Duration{2 * time.Second}, *waits)
+	})
+
+	t.Run("one nanosecond beyond skew is rejected", func(t *testing.T) {
+		arrival := systemStart.Add(100*time.Second - time.Nanosecond)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+
+		err := ls.checkChainsyncHeaderArrival(
+			futureHeaderEvent(102, arrival),
+		)
+		var futureErr *headerTooFarInFutureError
+		require.ErrorAs(t, err, &futureErr)
+		require.Empty(t, *waits)
+	})
+
+	t.Run("slot past the forecast horizon is rejected", func(t *testing.T) {
+		arrival := systemStart.Add(100 * time.Second)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+		ls.slotClock.provider = pastHorizonSlotTimeProvider{
+			SlotTimeProvider: ls.slotClock.provider,
+			rejectedSlot:     10_000,
+		}
+
+		err := ls.checkChainsyncHeaderArrival(
+			futureHeaderEvent(10_000, arrival),
+		)
+		var futureErr *headerTooFarInFutureError
+		require.ErrorAs(t, err, &futureErr)
+		require.ErrorIs(t, err, hardfork.ErrPastHorizon)
+		require.Empty(t, *waits)
+	})
+
+	t.Run("processing delay does not change arrival judgment", func(t *testing.T) {
+		arrival := systemStart.Add(101 * time.Second)
+		processTime := systemStart.Add(103 * time.Second)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, processTime)
+
+		require.NoError(t, ls.checkChainsyncHeaderArrival(
+			futureHeaderEvent(102, arrival),
+		))
+		require.Empty(t, *waits)
+	})
+
+	t.Run("synthetic event without arrival remains compatible", func(t *testing.T) {
+		now := systemStart.Add(100 * time.Second)
+		ls, waits := newFutureHeaderTestLedger(t, systemStart, now)
+
+		require.NoError(t, ls.checkChainsyncHeaderArrival(
+			futureHeaderEvent(10_000, time.Time{}),
+		))
+		require.Empty(t, *waits)
+	})
+}
+
+func TestCheckChainsyncHeaderArrivalPropagatesCancellation(t *testing.T) {
+	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	arrival := systemStart.Add(100 * time.Second)
+	ls, _ := newFutureHeaderTestLedger(t, systemStart, arrival)
+	ls.slotClock.waitFunc = func(context.Context, time.Duration) error {
+		return context.Canceled
+	}
+
+	err := ls.checkChainsyncHeaderArrival(futureHeaderEvent(101, arrival))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFutureHeaderRecyclesConnection(t *testing.T) {
+	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	arrival := systemStart.Add(100 * time.Second)
+	ls, _ := newFutureHeaderTestLedger(t, systemStart, arrival)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	ls.config.EventBus = bus
+	_, recycleCh := bus.Subscribe(ConnectionRecycleRequestedEventType)
+
+	var pending pendingPublishes
+	err := ls.handleEventChainsyncBlockHeaderWithPending(
+		futureHeaderEvent(103, arrival),
+		&pending,
+	)
+	require.Error(t, err)
+	var futureErr *headerTooFarInFutureError
+	require.True(t, errors.As(err, &futureErr))
+	pending.flush()
+
+	recycleEvent := testutil.RequireReceive(
+		t,
+		recycleCh,
+		2*time.Second,
+		"far-future header should recycle its ChainSync connection",
+	)
+	recycle, ok := recycleEvent.Data.(ConnectionRecycleRequestedEvent)
+	require.True(t, ok)
+	require.Equal(t, "header_too_far_in_future", recycle.Reason)
+}

--- a/ledger/chainsync_future_header_test.go
+++ b/ledger/chainsync_future_header_test.go
@@ -17,11 +17,11 @@ package ledger
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/dingo/event"
-	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -31,6 +31,29 @@ import (
 type pastHorizonSlotTimeProvider struct {
 	SlotTimeProvider
 	rejectedSlot uint64
+}
+
+type arrivalPastHorizonSlotTimeProvider struct {
+	SlotTimeProvider
+}
+
+func (p arrivalPastHorizonSlotTimeProvider) TimeToSlot(
+	time.Time,
+) (uint64, error) {
+	return 0, hardfork.ErrPastHorizon
+}
+
+type failingSlotTimeProvider struct {
+	SlotTimeProvider
+	rejectedSlot uint64
+	err          error
+}
+
+func (p failingSlotTimeProvider) SlotToTime(slot uint64) (time.Time, error) {
+	if slot == p.rejectedSlot {
+		return time.Time{}, p.err
+	}
+	return p.SlotTimeProvider.SlotToTime(slot)
 }
 
 func (p pastHorizonSlotTimeProvider) SlotToTime(
@@ -59,6 +82,9 @@ func newFutureHeaderTestLedger(
 	return &LedgerState{
 		slotClock: clock,
 		ctx:       t.Context(),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
 	}, &waits
 }
 
@@ -74,16 +100,18 @@ func futureHeaderEvent(slot uint64, arrival time.Time) ChainsyncEvent {
 	}
 }
 
-func TestCheckChainsyncHeaderArrivalBoundaries(t *testing.T) {
+func TestAwaitChainsyncHeaderAdmissionBoundaries(t *testing.T) {
 	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
 
 	t.Run("current header is accepted immediately", func(t *testing.T) {
 		arrival := systemStart.Add(100 * time.Second)
 		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
 
-		require.NoError(t, ls.checkChainsyncHeaderArrival(
+		accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
 			futureHeaderEvent(100, arrival),
-		))
+		)
+		require.NoError(t, err)
+		require.True(t, accepted)
 		require.Empty(t, *waits)
 	})
 
@@ -91,26 +119,31 @@ func TestCheckChainsyncHeaderArrivalBoundaries(t *testing.T) {
 		arrival := systemStart.Add(100 * time.Second)
 		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
 
-		require.NoError(t, ls.checkChainsyncHeaderArrival(
+		accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
 			futureHeaderEvent(102, arrival),
-		))
+		)
+		require.NoError(t, err)
+		require.True(t, accepted)
 		require.Equal(t, []time.Duration{2 * time.Second}, *waits)
 	})
 
-	t.Run("invalid arrival stays rejected after processing delay", func(t *testing.T) {
-		arrival := systemStart.Add(100*time.Second - time.Nanosecond)
-		processTime := systemStart.Add(103 * time.Second)
-		ls, waits := newFutureHeaderTestLedger(t, systemStart, processTime)
+	t.Run(
+		"beyond skew is deliberately dropped despite processing delay",
+		func(t *testing.T) {
+			arrival := systemStart.Add(100*time.Second - time.Nanosecond)
+			processTime := systemStart.Add(103 * time.Second)
+			ls, waits := newFutureHeaderTestLedger(t, systemStart, processTime)
 
-		err := ls.checkChainsyncHeaderArrival(
-			futureHeaderEvent(102, arrival),
-		)
-		var futureErr *headerTooFarInFutureError
-		require.ErrorAs(t, err, &futureErr)
-		require.Empty(t, *waits)
-	})
+			accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
+				futureHeaderEvent(102, arrival),
+			)
+			require.NoError(t, err)
+			require.False(t, accepted)
+			require.Empty(t, *waits)
+		},
+	)
 
-	t.Run("slot past the forecast horizon is rejected", func(t *testing.T) {
+	t.Run("slot past the forecast horizon is deferred", func(t *testing.T) {
 		arrival := systemStart.Add(100 * time.Second)
 		ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
 		ls.slotClock.provider = pastHorizonSlotTimeProvider{
@@ -118,38 +151,65 @@ func TestCheckChainsyncHeaderArrivalBoundaries(t *testing.T) {
 			rejectedSlot:     10_000,
 		}
 
-		err := ls.checkChainsyncHeaderArrival(
+		accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
 			futureHeaderEvent(10_000, arrival),
 		)
-		var futureErr *headerTooFarInFutureError
-		require.ErrorAs(t, err, &futureErr)
-		require.ErrorIs(t, err, hardfork.ErrPastHorizon)
+		require.NoError(t, err)
+		require.True(t, accepted)
 		require.Empty(t, *waits)
 	})
 
-	t.Run("processing delay does not change arrival judgment", func(t *testing.T) {
-		arrival := systemStart.Add(101 * time.Second)
-		processTime := systemStart.Add(103 * time.Second)
-		ls, waits := newFutureHeaderTestLedger(t, systemStart, processTime)
+	t.Run(
+		"processing delay does not change arrival judgment",
+		func(t *testing.T) {
+			arrival := systemStart.Add(101 * time.Second)
+			processTime := systemStart.Add(103 * time.Second)
+			ls, waits := newFutureHeaderTestLedger(t, systemStart, processTime)
 
-		require.NoError(t, ls.checkChainsyncHeaderArrival(
-			futureHeaderEvent(102, arrival),
-		))
-		require.Empty(t, *waits)
-	})
+			accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
+				futureHeaderEvent(102, arrival),
+			)
+			require.NoError(t, err)
+			require.True(t, accepted)
+			require.Empty(t, *waits)
+		},
+	)
 
-	t.Run("synthetic event without arrival remains compatible", func(t *testing.T) {
-		now := systemStart.Add(100 * time.Second)
-		ls, waits := newFutureHeaderTestLedger(t, systemStart, now)
+	t.Run(
+		"historical catch-up does not convert queued arrival time",
+		func(t *testing.T) {
+			arrival := systemStart.Add(1_000_000 * time.Second)
+			ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+			ls.slotClock.provider = arrivalPastHorizonSlotTimeProvider{
+				SlotTimeProvider: ls.slotClock.provider,
+			}
 
-		require.NoError(t, ls.checkChainsyncHeaderArrival(
-			futureHeaderEvent(10_000, time.Time{}),
-		))
-		require.Empty(t, *waits)
-	})
+			accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
+				futureHeaderEvent(900, arrival),
+			)
+			require.NoError(t, err)
+			require.True(t, accepted)
+			require.Empty(t, *waits)
+		},
+	)
+
+	t.Run(
+		"synthetic event without arrival remains compatible",
+		func(t *testing.T) {
+			now := systemStart.Add(100 * time.Second)
+			ls, waits := newFutureHeaderTestLedger(t, systemStart, now)
+
+			accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(),
+				futureHeaderEvent(10_000, time.Time{}),
+			)
+			require.NoError(t, err)
+			require.True(t, accepted)
+			require.Empty(t, *waits)
+		},
+	)
 }
 
-func TestCheckChainsyncHeaderArrivalPropagatesCancellation(t *testing.T) {
+func TestAwaitChainsyncHeaderAdmissionPropagatesCancellation(t *testing.T) {
 	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
 	arrival := systemStart.Add(100 * time.Second)
 	ls, _ := newFutureHeaderTestLedger(t, systemStart, arrival)
@@ -157,36 +217,102 @@ func TestCheckChainsyncHeaderArrivalPropagatesCancellation(t *testing.T) {
 		return context.Canceled
 	}
 
-	err := ls.checkChainsyncHeaderArrival(futureHeaderEvent(101, arrival))
+	accepted, err := ls.AwaitChainsyncHeaderAdmission(
+		t.Context(),
+		futureHeaderEvent(101, arrival),
+	)
+	require.False(t, accepted)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestFutureHeaderRecyclesConnection(t *testing.T) {
+func TestAwaitChainsyncHeaderAdmissionFailsClosedOnNilContext(t *testing.T) {
 	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
 	arrival := systemStart.Add(100 * time.Second)
 	ls, _ := newFutureHeaderTestLedger(t, systemStart, arrival)
-	bus := event.NewEventBus(nil, nil)
-	t.Cleanup(bus.Close)
-	ls.config.EventBus = bus
-	_, recycleCh := bus.Subscribe(ConnectionRecycleRequestedEventType)
 
-	var pending pendingPublishes
-	err := ls.handleEventChainsyncBlockHeaderWithPending(
-		futureHeaderEvent(103, arrival),
-		&pending,
+	accepted, err := ls.AwaitChainsyncHeaderAdmission(
+		nil,
+		futureHeaderEvent(101, arrival),
 	)
-	require.Error(t, err)
-	var futureErr *headerTooFarInFutureError
-	require.True(t, errors.As(err, &futureErr))
-	pending.flush()
+	require.False(t, accepted)
+	require.EqualError(t, err, "chainsync header admission context is nil")
+}
 
-	recycleEvent := testutil.RequireReceive(
-		t,
-		recycleCh,
-		2*time.Second,
-		"far-future header should recycle its ChainSync connection",
+func TestAwaitChainsyncHeaderAdmissionFailsClosedOnConversionError(
+	t *testing.T,
+) {
+	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	arrival := systemStart.Add(100 * time.Second)
+	ls, waits := newFutureHeaderTestLedger(t, systemStart, arrival)
+	wantErr := errors.New("slot conversion unavailable")
+	ls.slotClock.provider = failingSlotTimeProvider{
+		SlotTimeProvider: ls.slotClock.provider,
+		rejectedSlot:     101,
+		err:              wantErr,
+	}
+
+	accepted, err := ls.AwaitChainsyncHeaderAdmission(
+		t.Context(),
+		futureHeaderEvent(101, arrival),
 	)
-	recycle, ok := recycleEvent.Data.(ConnectionRecycleRequestedEvent)
-	require.True(t, ok)
-	require.Equal(t, "header_too_far_in_future", recycle.Reason)
+	require.False(t, accepted)
+	require.ErrorIs(t, err, wantErr)
+	require.Empty(t, *waits)
+}
+
+func TestFutureHeaderWaitDoesNotHoldChainsyncMutex(t *testing.T) {
+	systemStart := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	arrival := systemStart.Add(100 * time.Second)
+	ls, _ := newFutureHeaderTestLedger(t, systemStart, arrival)
+	waiting := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	ls.slotClock.waitFunc = func(context.Context, time.Duration) error {
+		close(waiting)
+		<-release
+		return nil
+	}
+	go func() {
+		e := futureHeaderEvent(101, arrival)
+		accepted, err := ls.AwaitChainsyncHeaderAdmission(t.Context(), e)
+		if err == nil && !accepted {
+			err = errors.New("header was not accepted")
+		}
+		done <- err
+	}()
+
+	<-waiting
+	mutexAvailable := ls.chainsyncMutex.TryLock()
+	if mutexAvailable {
+		ls.chainsyncMutex.Unlock()
+	}
+	close(release)
+	require.NoError(t, <-done)
+	require.True(t, mutexAvailable,
+		"peer-local slot wait must not hold the node-wide chainsync mutex")
+}
+
+func TestAwaitChainsyncHeaderAdmissionUsesCrossEraSlotOnset(t *testing.T) {
+	ls := crossEraLedger(t)
+	provider := newSlotTimeConverterProvider(ls.timeConv())
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+	boundary, err := provider.SlotToTime(200)
+	require.NoError(t, err)
+	arrival := boundary.Add(-defaultHeaderClockSkew)
+	clock.nowFunc = func() time.Time { return arrival }
+	var waited time.Duration
+	clock.waitFunc = func(_ context.Context, delay time.Duration) error {
+		waited = delay
+		return nil
+	}
+	ls.slotClock = clock
+	ls.ctx = t.Context()
+
+	accepted, err := ls.AwaitChainsyncHeaderAdmission(
+		t.Context(),
+		futureHeaderEvent(200, arrival),
+	)
+	require.NoError(t, err)
+	require.True(t, accepted)
+	require.Equal(t, defaultHeaderClockSkew, waited)
 }

--- a/ledger/event.go
+++ b/ledger/event.go
@@ -15,6 +15,8 @@
 package ledger
 
 import (
+	"time"
+
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -65,11 +67,15 @@ type BlockfetchEvent struct {
 type ChainsyncEvent struct {
 	ConnectionId ouroboros.ConnectionId // Connection ID associated with event
 	BlockHeader  ledger.BlockHeader
-	Point        ocommon.Point  // Chain point for roll forward/backward
-	Tip          ochainsync.Tip // Upstream chain tip
-	BlockNumber  uint64
-	Type         uint // Block or header type ID
-	Rollback     bool // Set to true for a Rollback event
+	// ArrivalTime is recorded immediately when the ChainSync callback receives
+	// a roll-forward header. It lets ledger admission judge the peer's clock at
+	// arrival even if event delivery or header processing is delayed.
+	ArrivalTime time.Time
+	Point       ocommon.Point  // Chain point for roll forward/backward
+	Tip         ochainsync.Tip // Upstream chain tip
+	BlockNumber uint64
+	Type        uint // Block or header type ID
+	Rollback    bool // Set to true for a Rollback event
 }
 
 // ChainsyncAwaitReplyEvent is emitted when a chainsync peer explicitly reports

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -110,7 +110,8 @@ type SlotClock struct {
 	behindHorizon bool
 
 	// For testing: allow injection of custom time source
-	nowFunc func() time.Time
+	nowFunc  func() time.Time
+	waitFunc func(context.Context, time.Duration) error
 }
 
 // NewSlotClock creates a new SlotClock with the given provider and configuration
@@ -129,6 +130,21 @@ func NewSlotClock(
 		config:      config,
 		subscribers: make([]chan SlotTick, 0),
 		nowFunc:     time.Now,
+		waitFunc:    waitForDuration,
+	}
+}
+
+func waitForDuration(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -210,6 +226,12 @@ func (sc *SlotClock) CurrentSlot() (uint64, error) {
 	return sc.provider.TimeToSlot(sc.nowFunc())
 }
 
+// slotAtTime returns the slot containing t. Unlike CurrentSlot, it does not
+// read the clock, so callers can classify an observation by its recorded time.
+func (sc *SlotClock) slotAtTime(t time.Time) (uint64, error) {
+	return sc.provider.TimeToSlot(t)
+}
+
 // CurrentEpoch returns the current epoch based on wall-clock time.
 // This works regardless of sync state and can be called during catch up or load.
 func (sc *SlotClock) CurrentEpoch() (EpochInfo, error) {
@@ -230,6 +252,17 @@ func (sc *SlotClock) GetEpochForSlot(slot uint64) (EpochInfo, error) {
 // This works regardless of sync state and can be called during catch up or load.
 func (sc *SlotClock) SlotToTime(slot uint64) (time.Time, error) {
 	return sc.provider.SlotToTime(slot)
+}
+
+// waitUntil blocks until target according to the same clock CurrentSlot uses,
+// or until ctx is cancelled. The injected wait function keeps boundary tests
+// deterministic without sleeping.
+func (sc *SlotClock) waitUntil(ctx context.Context, target time.Time) error {
+	delay := target.Sub(sc.nowFunc())
+	if delay <= 0 {
+		return nil
+	}
+	return sc.waitFunc(ctx, delay)
 }
 
 // NextSlotTime returns the time when the next slot will start

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -226,12 +226,6 @@ func (sc *SlotClock) CurrentSlot() (uint64, error) {
 	return sc.provider.TimeToSlot(sc.nowFunc())
 }
 
-// slotAtTime returns the slot containing t. Unlike CurrentSlot, it does not
-// read the clock, so callers can classify an observation by its recorded time.
-func (sc *SlotClock) slotAtTime(t time.Time) (uint64, error) {
-	return sc.provider.TimeToSlot(t)
-}
-
 // CurrentEpoch returns the current epoch based on wall-clock time.
 // This works regardless of sync state and can be called during catch up or load.
 func (sc *SlotClock) CurrentEpoch() (EpochInfo, error) {

--- a/node_ledger_config.go
+++ b/node_ledger_config.go
@@ -229,6 +229,7 @@ func (n *Node) ledgerStateConfig() ledger.LedgerStateConfig {
 			return ledger.ChainsyncEvent{
 				ConnectionId: h.ConnectionId,
 				BlockHeader:  h.BlockHeader,
+				ArrivalTime:  h.ArrivalTime,
 				Point:        h.Point,
 				Tip:          h.Tip,
 				BlockNumber:  h.BlockNumber,

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -61,6 +61,182 @@ const (
 
 var chainsyncRestartAfter = time.After
 
+type chainsyncHeaderAdmissionFunc func(
+	context.Context,
+	ledger.ChainsyncEvent,
+) (bool, error)
+
+type chainsyncScheduleAtFunc func(time.Time, func()) func()
+
+type scheduledChainsyncResync struct {
+	onset  time.Time
+	cancel func()
+	fired  bool
+}
+
+type chainsyncClientDoneContext struct {
+	done <-chan struct{}
+}
+
+func (c chainsyncClientDoneContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c chainsyncClientDoneContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c chainsyncClientDoneContext) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c chainsyncClientDoneContext) Value(any) any {
+	return nil
+}
+
+func chainsyncAdmissionContext(
+	ctx ochainsync.CallbackContext,
+) context.Context {
+	if ctx.Client == nil || ctx.Client.ProtocolInstance() == nil {
+		return context.Background()
+	}
+	return chainsyncClientDoneContext{done: ctx.Client.DoneChan()}
+}
+
+func defaultChainsyncScheduleAt(onset time.Time, fn func()) func() {
+	timer := time.AfterFunc(time.Until(onset), fn)
+	return func() {
+		timer.Stop()
+	}
+}
+
+// scheduleFutureHeaderResync keeps at most one recovery timer per connection.
+// The earliest resolvable onset wins: every later dropped header is already
+// covered by re-intersecting from the last ledger-accepted point at that time.
+func (o *Ouroboros) scheduleFutureHeaderResync(
+	connId ouroboros.ConnectionId,
+	onset time.Time,
+) {
+	if o.chainsyncScheduleAt == nil || o.eventBus == nil || onset.IsZero() {
+		return
+	}
+	if o.connManager != nil && o.connManager.GetConnectionById(connId) == nil {
+		return
+	}
+	o.futureHeaderResyncMu.Lock()
+	if o.futureHeaderResyncClosed {
+		o.futureHeaderResyncMu.Unlock()
+		return
+	}
+	if current := o.futureHeaderResyncs[connId]; current != nil {
+		if current.fired {
+			o.futureHeaderResyncMu.Unlock()
+			return
+		}
+		if !onset.Before(current.onset) {
+			o.futureHeaderResyncMu.Unlock()
+			return
+		}
+		current.cancel()
+	}
+	scheduled := &scheduledChainsyncResync{onset: onset}
+	// A timer whose onset is already due may invoke its callback before the
+	// scheduler returns. Arm publication only after the marker and cancel
+	// function are installed, or that callback can observe no current timer and
+	// strand the connection in the withheld state without a recovery event.
+	armed := make(chan struct{})
+	scheduled.cancel = o.chainsyncScheduleAt(onset, func() {
+		go func() {
+			<-armed
+			o.futureHeaderResyncMu.Lock()
+			if o.futureHeaderResyncs[connId] != scheduled || scheduled.fired {
+				o.futureHeaderResyncMu.Unlock()
+				return
+			}
+			// Retain the marker until the resync handler stops the old
+			// protocol. Headers received between timer onset and Stop must
+			// stay withheld or they can advance the remote cursor across the
+			// gap being recovered.
+			scheduled.fired = true
+			o.futureHeaderResyncMu.Unlock()
+
+			ctx := o.futureHeaderResyncCtx
+			if ctx == nil {
+				return
+			}
+			o.eventBus.PublishOrderedContext(
+				ctx,
+				event.ChainsyncResyncEventType,
+				event.NewEvent(
+					event.ChainsyncResyncEventType,
+					event.ChainsyncResyncEvent{
+						ConnectionId: connId,
+						Reason:       event.ChainsyncResyncReasonFutureHeaderAdmissionRecovery,
+					},
+				),
+			)
+		}()
+	})
+	o.futureHeaderResyncs[connId] = scheduled
+	// Connection removal publishes its close event only after removing the
+	// connection from connManager. Re-check that authoritative state while the
+	// timer marker is installed and still protected: the close handler may have
+	// run between the optimistic lookup above and this insertion, when there was
+	// not yet a marker for it to cancel.
+	if o.connManager != nil && o.connManager.GetConnectionById(connId) == nil {
+		scheduled.cancel()
+		delete(o.futureHeaderResyncs, connId)
+		close(armed)
+		o.futureHeaderResyncMu.Unlock()
+		return
+	}
+	close(armed)
+	o.futureHeaderResyncMu.Unlock()
+}
+
+func (o *Ouroboros) futureHeaderResyncPending(
+	connId ouroboros.ConnectionId,
+) bool {
+	o.futureHeaderResyncMu.Lock()
+	defer o.futureHeaderResyncMu.Unlock()
+	return o.futureHeaderResyncs[connId] != nil
+}
+
+func (o *Ouroboros) completeFutureHeaderResync(
+	connId ouroboros.ConnectionId,
+) {
+	o.cancelFutureHeaderResync(connId)
+}
+
+func (o *Ouroboros) cancelFutureHeaderResync(
+	connId ouroboros.ConnectionId,
+) {
+	o.futureHeaderResyncMu.Lock()
+	if scheduled := o.futureHeaderResyncs[connId]; scheduled != nil {
+		scheduled.cancel()
+		delete(o.futureHeaderResyncs, connId)
+	}
+	o.futureHeaderResyncMu.Unlock()
+}
+
+func (o *Ouroboros) stopFutureHeaderResyncs() {
+	if o.futureHeaderResyncCancel != nil {
+		o.futureHeaderResyncCancel()
+	}
+	o.futureHeaderResyncMu.Lock()
+	o.futureHeaderResyncClosed = true
+	for connId, scheduled := range o.futureHeaderResyncs {
+		scheduled.cancel()
+		delete(o.futureHeaderResyncs, connId)
+	}
+	o.futureHeaderResyncMu.Unlock()
+}
+
 func effectiveChainsyncBlockTimeout(timeout time.Duration) time.Duration {
 	if timeout < ochainsync.MustReplyTimeoutMax {
 		return ochainsync.MustReplyTimeoutMax
@@ -326,9 +502,10 @@ func (o *Ouroboros) RestartChainsyncClientWithPoints(
 	return nil
 }
 
-func (o *Ouroboros) resyncChainsyncClientWithPoints(
+func (o *Ouroboros) resyncChainsyncClientWithPointsAfterStop(
 	connId ouroboros.ConnectionId,
 	intersectPoints []ocommon.Point,
+	afterStop func(),
 ) error {
 	conn := o.connManager.GetConnectionById(connId)
 	if conn == nil {
@@ -347,6 +524,9 @@ func (o *Ouroboros) resyncChainsyncClientWithPoints(
 			connId.String(),
 			err,
 		)
+	}
+	if afterStop != nil {
+		afterStop()
 	}
 	return o.RestartChainsyncClientWithPoints(connId, intersectPoints)
 }
@@ -761,6 +941,64 @@ func (o *Ouroboros) chainsyncClientRollForwardAt(
 			"connection_id", ctx.ConnectionId.String(),
 			"ingress_eligible", ingressEligible,
 		)
+		chainsyncEvent := ledger.ChainsyncEvent{
+			ConnectionId: ctx.ConnectionId,
+			ArrivalTime:  arrivalTime,
+			Point:        point,
+			Type:         blockType,
+			BlockHeader:  v,
+			Tip:          tip,
+		}
+		// Enforce the future-header boundary on this peer's protocol callback,
+		// before any observed-tip, cursor, dedup, or ledger mutation. A
+		// permitted wait therefore blocks only this peer and never the shared
+		// ledger ChainSync dispatch mutex/goroutine.
+		if ingressEligible && o.chainsyncHeaderAdmission != nil {
+			accepted, err := o.chainsyncHeaderAdmission(
+				chainsyncAdmissionContext(ctx),
+				chainsyncEvent,
+			)
+			if err != nil {
+				o.config.Logger.Warn(
+					"chainsync: future-header admission failed closed",
+					"component", "ouroboros",
+					"slot", blockSlot,
+					"connection_id", ctx.ConnectionId.String(),
+					"error", err,
+				)
+				return err
+			}
+			if !accepted {
+				// Returning nil deliberately drops this header without turning
+				// ambiguous local/remote clock skew into a connection penalty.
+				// Re-intersect at the earliest dropped header's onset so the
+				// protocol cursor cannot permanently strand the accepted chain.
+				if o.chainsyncHeaderSlotTime != nil {
+					onset, onsetErr := o.chainsyncHeaderSlotTime(blockSlot)
+					if onsetErr == nil {
+						o.scheduleFutureHeaderResync(ctx.ConnectionId, onset)
+					} else {
+						o.config.Logger.Error(
+							"chainsync: failed to schedule future-header recovery",
+							"component", "ouroboros",
+							"slot", blockSlot,
+							"connection_id", ctx.ConnectionId.String(),
+							"error", onsetErr,
+						)
+					}
+				}
+				return nil
+			}
+			if o.futureHeaderResyncPending(ctx.ConnectionId) {
+				o.config.Logger.Debug(
+					"chainsync: header withheld pending future-header re-intersection",
+					"component", "ouroboros",
+					"slot", blockSlot,
+					"connection_id", ctx.ConnectionId.String(),
+				)
+				return nil
+			}
+		}
 		// Observe the tip for chain selection FIRST, so the apply-eligibility
 		// decision below reflects this header. Only ingress-eligible peers are
 		// observed; random inbound peers reporting ephemeral tips are filtered
@@ -893,14 +1131,7 @@ func (o *Ouroboros) chainsyncClientRollForwardAt(
 			ledger.ChainsyncEventType,
 			event.NewEvent(
 				ledger.ChainsyncEventType,
-				ledger.ChainsyncEvent{
-					ConnectionId: ctx.ConnectionId,
-					ArrivalTime:  arrivalTime,
-					Point:        point,
-					Type:         blockType,
-					BlockHeader:  v,
-					Tip:          tip,
-				},
+				chainsyncEvent,
 			),
 		); err != nil {
 			return err
@@ -1361,9 +1592,16 @@ func (o *Ouroboros) SubscribeChainsyncResync(ctx context.Context) {
 								err,
 							)
 						}
-						return o.resyncChainsyncClientWithPoints(
+						var afterStop func()
+						if e.Reason == event.ChainsyncResyncReasonFutureHeaderAdmissionRecovery {
+							afterStop = func() {
+								o.completeFutureHeaderResync(connId)
+							}
+						}
+						return o.resyncChainsyncClientWithPointsAfterStop(
 							connId,
 							intersectPoints,
+							afterStop,
 						)
 					},
 				)

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -725,18 +725,15 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	return nil
 }
 
-func (o *Ouroboros) chainsyncClientRollForward(
+func (o *Ouroboros) chainsyncClientRollForwardAt(
 	ctx ochainsync.CallbackContext,
 	blockType uint,
 	blockData any,
 	tip ochainsync.Tip,
+	arrivalTime time.Time,
 ) error {
 	switch v := blockData.(type) {
 	case gledger.BlockHeader:
-		// Record arrival before chain-selection, deduplication, or EventBus
-		// delivery can delay the header. The ledger uses this timestamp for the
-		// Ouroboros future-header check.
-		arrivalTime := time.Now()
 		blockSlot := v.SlotNumber()
 		blockHash := v.Hash().Bytes()
 		point := ocommon.NewPoint(blockSlot, blockHash)
@@ -1470,6 +1467,10 @@ func (o *Ouroboros) chainsyncClientRollForwardRaw(
 	blockData []byte,
 	tip ochainsync.Tip,
 ) error {
+	// Record arrival at the raw network callback boundary. Header decoding can
+	// block behind another peer's in-flight decode of the same bytes, so a
+	// timestamp taken by the decoded handler would already include local work.
+	arrivalTime := time.Now()
 	key := hashDecodeInput(blockType, blockData)
 	header, err := decodeWithPanicSafeMetrics(
 		o.headerDecodeCache,
@@ -1495,7 +1496,13 @@ func (o *Ouroboros) chainsyncClientRollForwardRaw(
 			blockType,
 		)
 	}
-	return o.chainsyncClientRollForward(ctx, blockType, header, tip)
+	return o.chainsyncClientRollForwardAt(
+		ctx,
+		blockType,
+		header,
+		tip,
+		arrivalTime,
+	)
 }
 
 func (o *Ouroboros) instrumentChainsyncRollForwardRaw(

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -733,6 +733,10 @@ func (o *Ouroboros) chainsyncClientRollForward(
 ) error {
 	switch v := blockData.(type) {
 	case gledger.BlockHeader:
+		// Record arrival before chain-selection, deduplication, or EventBus
+		// delivery can delay the header. The ledger uses this timestamp for the
+		// Ouroboros future-header check.
+		arrivalTime := time.Now()
 		blockSlot := v.SlotNumber()
 		blockHash := v.Hash().Bytes()
 		point := ocommon.NewPoint(blockSlot, blockHash)
@@ -828,6 +832,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 					Point:        point,
 					Type:         blockType,
 					BlockHeader:  v,
+					ArrivalTime:  arrivalTime,
 					Tip:          tip,
 				},
 			)
@@ -893,6 +898,7 @@ func (o *Ouroboros) chainsyncClientRollForward(
 				ledger.ChainsyncEventType,
 				ledger.ChainsyncEvent{
 					ConnectionId: ctx.ConnectionId,
+					ArrivalTime:  arrivalTime,
 					Point:        point,
 					Type:         blockType,
 					BlockHeader:  v,

--- a/ouroboros/chainsync_arrival_test.go
+++ b/ouroboros/chainsync_arrival_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/ledger"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainsyncClientRollForwardRecordsHeaderArrival(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	connID := newTestConnId("127.0.0.1:6000", "1.1.1.1:3001")
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	before := time.Now()
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: connID},
+		0,
+		header,
+		tip,
+	))
+	after := time.Now()
+	evt := testutil.RequireReceive(
+		t,
+		ledgerCh,
+		2*time.Second,
+		"roll-forward should publish a ledger ChainSync event",
+	)
+	data, ok := evt.Data.(ledger.ChainsyncEvent)
+	require.True(t, ok)
+	require.False(t, data.ArrivalTime.Before(before))
+	require.False(t, data.ArrivalTime.After(after))
+}

--- a/ouroboros/chainsync_arrival_test.go
+++ b/ouroboros/chainsync_arrival_test.go
@@ -15,16 +15,23 @@
 package ouroboros
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/chainselection"
+	dchainsync "github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -150,4 +157,479 @@ func TestChainsyncClientRollForwardRawRecordsArrivalBeforeDecodeWait(
 	data, ok := evt.Data.(ledger.ChainsyncEvent)
 	require.True(t, ok)
 	require.True(t, data.ArrivalTime.Before(releasedAt))
+}
+
+func TestChainsyncHeaderAdmissionIsPreObservationAndPeerLocal(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+
+	cfg := dchainsync.DefaultConfig()
+	cfg.HeaderSyncStrategy = dchainsync.HeaderSyncStrategyParallel
+	state := dchainsync.NewStateWithConfig(bus, nil, cfg)
+	connA := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	connB := newTestConnId("127.0.0.1:6000", "10.0.0.2:3001")
+	require.True(t, state.AddClientConnId(connA))
+	require.True(t, state.AddClientConnId(connB))
+
+	observed := make(chan ouroboros.ConnectionId, 2)
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		ChainsyncObservePeerTip: func(
+			e chainselection.PeerTipUpdateEvent,
+		) bool {
+			observed <- e.ConnectionId
+			return true
+		},
+	})
+	o.chainsyncState = state
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	o.chainsyncHeaderAdmission = func(
+		ctx context.Context,
+		e ledger.ChainsyncEvent,
+	) (bool, error) {
+		if e.ConnectionId != connA {
+			return true, nil
+		}
+		close(entered)
+		select {
+		case <-release:
+			return true, nil
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+
+	headerA := newTestBlockHeader(100, 1, 0xaa)
+	tipA := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, headerA.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+	headerB := newTestBlockHeader(101, 2, 0xbb)
+	tipB := ochainsync.Tip{
+		Point:       ocommon.NewPoint(101, headerB.Hash().Bytes()),
+		BlockNumber: 2,
+	}
+	doneA := make(chan error, 1)
+	go func() {
+		doneA <- o.chainsyncClientRollForwardAt(
+			ochainsync.CallbackContext{ConnectionId: connA},
+			0,
+			headerA,
+			tipA,
+			time.Now(),
+		)
+	}()
+	<-entered
+	trackedA := state.GetTrackedClient(connA)
+	require.NotNil(t, trackedA)
+	require.Equal(t, uint64(0), trackedA.Cursor.Slot)
+	_, _, found := state.LookupObservedHeader(connA, headerA.Hash().Bytes())
+	require.False(t, found)
+	testutil.RequireNoReceive(
+		t,
+		observed,
+		50*time.Millisecond,
+		"waiting header must not update observed tip",
+	)
+
+	// A different peer must continue through admission and ledger publication
+	// while connA waits; no node-wide ChainSync mutex is held by the wait.
+	require.NoError(t, o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{ConnectionId: connB},
+		0,
+		headerB,
+		tipB,
+		time.Now(),
+	))
+	require.Equal(t, connB, testutil.RequireReceive(
+		t,
+		observed,
+		time.Second,
+		"second peer should be observed while first peer waits",
+	))
+	ledgerEvent := testutil.RequireReceive(
+		t,
+		ledgerCh,
+		time.Second,
+		"second peer should reach ledger while first peer waits",
+	)
+	require.Equal(
+		t,
+		connB,
+		ledgerEvent.Data.(ledger.ChainsyncEvent).ConnectionId,
+	)
+
+	close(release)
+	require.NoError(t, testutil.RequireReceive(
+		t,
+		doneA,
+		time.Second,
+		"first peer should resume after slot onset",
+	))
+}
+
+func TestChainsyncFarFutureDropHasNoStateOrConnectionPenalty(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	_, observedCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+	_, recycleCh := bus.Subscribe(ledger.ConnectionRecycleRequestedEventType)
+
+	cfg := dchainsync.DefaultConfig()
+	cfg.HeaderSyncStrategy = dchainsync.HeaderSyncStrategyParallel
+	state := dchainsync.NewStateWithConfig(bus, nil, cfg)
+	droppedConn := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	honestConn := newTestConnId("127.0.0.1:6000", "10.0.0.2:3001")
+	require.True(t, state.AddClientConnId(droppedConn))
+	require.True(t, state.AddClientConnId(honestConn))
+
+	onset := time.Now().Add(time.Minute)
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.chainsyncState = state
+	dropFuture := true
+	o.chainsyncHeaderAdmission = func(
+		_ context.Context,
+		e ledger.ChainsyncEvent,
+	) (bool, error) {
+		return e.ConnectionId != droppedConn || !dropFuture, nil
+	}
+	o.chainsyncHeaderSlotTime = func(uint64) (time.Time, error) {
+		return onset, nil
+	}
+	var scheduled func()
+	o.chainsyncScheduleAt = func(_ time.Time, fn func()) func() {
+		scheduled = fn
+		return func() {}
+	}
+
+	header := newTestBlockHeader(100, 1, 0xaa)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(100, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+	require.NoError(t, o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{ConnectionId: droppedConn},
+		0,
+		header,
+		tip,
+		time.Now(),
+	))
+	droppedClient := state.GetTrackedClient(droppedConn)
+	require.NotNil(t, droppedClient)
+	require.Equal(t, uint64(0), droppedClient.Cursor.Slot)
+	_, _, found := state.LookupObservedHeader(
+		droppedConn,
+		header.Hash().Bytes(),
+	)
+	require.False(t, found)
+	testutil.RequireNoReceive(t, observedCh, 50*time.Millisecond,
+		"dropped header must not update observed tip")
+	testutil.RequireNoReceive(t, ledgerCh, 50*time.Millisecond,
+		"dropped header must not reach the ledger")
+	testutil.RequireNoReceive(t, recycleCh, 50*time.Millisecond,
+		"ambiguous clock skew must not recycle the peer")
+	require.NotNil(t, scheduled)
+
+	// The dropped point must not enter cross-peer dedup: another admitted peer
+	// can still publish the same point as new.
+	require.NoError(t, o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{ConnectionId: honestConn},
+		0,
+		header,
+		tip,
+		time.Now(),
+	))
+	ledgerEvent := testutil.RequireReceive(
+		t,
+		ledgerCh,
+		time.Second,
+		"same point from admitted peer must not be deduplicated",
+	)
+	require.Equal(t, honestConn,
+		ledgerEvent.Data.(ledger.ChainsyncEvent).ConnectionId)
+
+	// Even after the clock recovers, withhold later headers until the timer's
+	// re-intersection has stopped the old protocol. Otherwise its remote cursor
+	// can advance across the deliberately dropped point and preserve the gap.
+	dropFuture = false
+	header101 := newTestBlockHeader(101, 2, 0xab)
+	require.NoError(t, o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{ConnectionId: droppedConn},
+		0,
+		header101,
+		ochainsync.Tip{},
+		time.Now(),
+	))
+	droppedClient = state.GetTrackedClient(droppedConn)
+	require.NotNil(t, droppedClient)
+	require.Equal(t, uint64(0), droppedClient.Cursor.Slot)
+	scheduled()
+	header102 := newTestBlockHeader(102, 3, 0xac)
+	require.NoError(t, o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{ConnectionId: droppedConn},
+		0,
+		header102,
+		ochainsync.Tip{},
+		time.Now(),
+	))
+	droppedClient = state.GetTrackedClient(droppedConn)
+	require.NotNil(t, droppedClient)
+	require.Equal(t, uint64(0), droppedClient.Cursor.Slot)
+
+	// The production resync handler clears the marker only after Client.Stop
+	// returns. Simulate that boundary and prove the restarted stream can advance.
+	o.completeFutureHeaderResync(droppedConn)
+	header103 := newTestBlockHeader(103, 4, 0xad)
+	require.NoError(t, o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{ConnectionId: droppedConn},
+		0,
+		header103,
+		ochainsync.Tip{},
+		time.Now(),
+	))
+	droppedClient = state.GetTrackedClient(droppedConn)
+	require.NotNil(t, droppedClient)
+	require.Equal(t, uint64(103), droppedClient.Cursor.Slot)
+}
+
+func TestFutureHeaderResyncCoalescesEarliestOnset(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+	o := newOuroboros(OuroborosConfig{EventBus: bus})
+	connID := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	base := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	type timerRecord struct {
+		onset    time.Time
+		fn       func()
+		canceled bool
+	}
+	var timers []*timerRecord
+	o.chainsyncScheduleAt = func(onset time.Time, fn func()) func() {
+		record := &timerRecord{onset: onset, fn: fn}
+		timers = append(timers, record)
+		return func() { record.canceled = true }
+	}
+
+	o.scheduleFutureHeaderResync(connID, base.Add(10*time.Second))
+	o.scheduleFutureHeaderResync(connID, base.Add(12*time.Second))
+	o.scheduleFutureHeaderResync(connID, base.Add(5*time.Second))
+	o.scheduleFutureHeaderResync(connID, base.Add(7*time.Second))
+	require.Len(t, timers, 2)
+	require.True(t, timers[0].canceled)
+	require.False(t, timers[1].canceled)
+	require.Equal(t, base.Add(5*time.Second), timers[1].onset)
+
+	// A canceled superseded callback cannot publish; the active earliest timer
+	// emits exactly one in-place, non-penalizing re-intersection request.
+	timers[0].fn()
+	testutil.RequireNoReceive(t, resyncCh, 50*time.Millisecond,
+		"superseded timer must not publish")
+	timers[1].fn()
+	resyncEvent := testutil.RequireReceive(
+		t,
+		resyncCh,
+		time.Second,
+		"earliest onset should request re-intersection",
+	)
+	data := resyncEvent.Data.(event.ChainsyncResyncEvent)
+	require.Equal(t, connID, data.ConnectionId)
+	require.Equal(t,
+		event.ChainsyncResyncReasonFutureHeaderAdmissionRecovery,
+		data.Reason,
+	)
+	require.False(t, chainsyncResyncRequiresFreshConnection(data.Reason))
+	require.False(t, chainsyncResyncDeniesPeer(data.Reason))
+	testutil.RequireNoReceive(t, resyncCh, 50*time.Millisecond,
+		"one onset must emit one recovery request")
+}
+
+func TestFutureHeaderResyncImmediateOnsetArmsBeforePublish(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+	o := newOuroboros(OuroborosConfig{EventBus: bus})
+	connID := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+	o.chainsyncScheduleAt = func(_ time.Time, fn func()) func() {
+		// Model time.AfterFunc observing an already-due onset before its
+		// scheduling call returns.
+		fn()
+		return func() {}
+	}
+
+	scheduled := make(chan struct{})
+	go func() {
+		o.scheduleFutureHeaderResync(connID, time.Now().Add(-time.Second))
+		close(scheduled)
+	}()
+	testutil.RequireReceive(t, scheduled, time.Second,
+		"an immediate callback must not deadlock timer registration")
+	evt := testutil.RequireReceive(t, resyncCh, time.Second,
+		"an immediate callback must publish after timer registration")
+	data := evt.Data.(event.ChainsyncResyncEvent)
+	require.Equal(t, connID, data.ConnectionId)
+	require.Equal(t,
+		event.ChainsyncResyncReasonFutureHeaderAdmissionRecovery,
+		data.Reason,
+	)
+}
+
+func TestFutureHeaderResyncSuppressesConnectionRemovedDuringArm(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+	manager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{EventBus: bus},
+	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, manager.Stop(ctx))
+	})
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		ouroboros_mock.ConversationKeepAlive,
+	)
+	conn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithKeepAliveConfig(keepalive.NewConfig(
+			keepalive.WithCookie(ouroboros_mock.MockKeepAliveCookie),
+			keepalive.WithPeriod(30*time.Second),
+			keepalive.WithTimeout(15*time.Second),
+		)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	require.True(t, manager.AddConnection(conn, false, "127.0.0.1:1234"))
+
+	o := newOuroboros(OuroborosConfig{EventBus: bus})
+	o.connManager = manager
+	var callback func()
+	canceled := false
+	o.chainsyncScheduleAt = func(_ time.Time, fn func()) func() {
+		callback = fn
+		// Model connManager removing the connection after the optimistic
+		// pre-lock lookup but before the timer marker is fully armed. Its
+		// subsequent close event may already have observed no marker.
+		require.True(t, manager.RemoveConnection(conn.Id(), conn))
+		return func() { canceled = true }
+	}
+
+	o.scheduleFutureHeaderResync(conn.Id(), time.Now().Add(time.Minute))
+	require.True(t, canceled)
+	require.False(t, o.futureHeaderResyncPending(conn.Id()))
+	require.NotNil(t, callback)
+	callback()
+	testutil.RequireNoReceive(t, resyncCh, 50*time.Millisecond,
+		"a timer armed after connection removal must not publish recovery")
+}
+
+func TestFutureHeaderResyncSuppressedAfterConnectionCloseAndClose(
+	t *testing.T,
+) {
+	for _, test := range []struct {
+		name string
+		stop func(*Ouroboros, ouroboros.ConnectionId)
+	}{
+		{
+			name: "connection close",
+			stop: func(o *Ouroboros, connID ouroboros.ConnectionId) {
+				o.HandleConnClosedEvent(event.NewEvent(
+					connmanager.ConnectionClosedEventType,
+					connmanager.ConnectionClosedEvent{ConnectionId: connID},
+				))
+			},
+		},
+		{
+			name: "ouroboros close",
+			stop: func(o *Ouroboros, _ ouroboros.ConnectionId) {
+				require.NoError(t, o.Close())
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bus := event.NewEventBus(nil, nil)
+			t.Cleanup(bus.Close)
+			_, resyncCh := bus.Subscribe(event.ChainsyncResyncEventType)
+			o := newOuroboros(OuroborosConfig{EventBus: bus})
+			connID := newTestConnId(
+				"127.0.0.1:6000",
+				"10.0.0.1:3001",
+			)
+			var callback func()
+			canceled := false
+			scheduleCount := 0
+			o.chainsyncScheduleAt = func(_ time.Time, fn func()) func() {
+				scheduleCount++
+				callback = fn
+				return func() { canceled = true }
+			}
+			o.scheduleFutureHeaderResync(connID, time.Now().Add(time.Minute))
+			require.NotNil(t, callback)
+
+			test.stop(o, connID)
+			require.True(t, canceled)
+			if test.name == "ouroboros close" {
+				o.scheduleFutureHeaderResync(
+					connID,
+					time.Now().Add(2*time.Minute),
+				)
+				require.Equal(t, 1, scheduleCount,
+					"Close must reject timers scheduled by racing callbacks")
+			}
+			callback()
+			testutil.RequireNoReceive(t, resyncCh, 50*time.Millisecond,
+				"stopped timer must not publish recovery")
+		})
+	}
+}
+
+func TestChainsyncHeaderAdmissionErrorFailsClosedBeforeObservation(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, observedCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	wantErr := errors.New("slot conversion failed")
+	o.chainsyncHeaderAdmission = func(
+		context.Context,
+		ledger.ChainsyncEvent,
+	) (bool, error) {
+		return false, wantErr
+	}
+	header := newTestBlockHeader(100, 1, 0xaa)
+	err := o.chainsyncClientRollForwardAt(
+		ochainsync.CallbackContext{
+			ConnectionId: newTestConnId(
+				"127.0.0.1:6000",
+				"10.0.0.1:3001",
+			),
+		},
+		0,
+		header,
+		ochainsync.Tip{},
+		time.Now(),
+	)
+	require.ErrorIs(t, err, wantErr)
+	testutil.RequireNoReceive(t, observedCh, 50*time.Millisecond,
+		"failed-closed admission must precede observation")
 }

--- a/ouroboros/chainsync_arrival_test.go
+++ b/ouroboros/chainsync_arrival_test.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,24 @@ import (
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
+
+// chainsyncClientRollForward retains an explicit decoded-handler entry point
+// for package tests. Production registers the raw callback and records arrival
+// before decoding; direct decoded tests timestamp at their own call boundary.
+func (o *Ouroboros) chainsyncClientRollForward(
+	ctx ochainsync.CallbackContext,
+	blockType uint,
+	blockData any,
+	tip ochainsync.Tip,
+) error {
+	return o.chainsyncClientRollForwardAt(
+		ctx,
+		blockType,
+		blockData,
+		tip,
+		time.Now(),
+	)
+}
 
 func TestChainsyncClientRollForwardRecordsHeaderArrival(t *testing.T) {
 	bus := event.NewEventBus(nil, nil)
@@ -62,4 +81,73 @@ func TestChainsyncClientRollForwardRecordsHeaderArrival(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, data.ArrivalTime.Before(before))
 	require.False(t, data.ArrivalTime.After(after))
+}
+
+func TestChainsyncClientRollForwardRawRecordsArrivalBeforeDecodeWait(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	_, ledgerCh := bus.Subscribe(ledger.ChainsyncEventType)
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	headerType, raw := conwayHeaderFixtureBytes(t)
+	header, err := o.decodeChainsyncHeader(headerType, raw)
+	require.NoError(t, err)
+	key := hashDecodeInput(headerType, raw)
+
+	// Claim this decode key so the real raw callback has to wait. The arrival
+	// timestamp must already be captured before it joins that wait.
+	o.headerDecodeCache.mu.Lock()
+	o.headerDecodeCache.inFlight[key] = nil
+	o.headerDecodeCache.mu.Unlock()
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			o.headerDecodeCache.finishDecode(key, header, nil)
+		})
+	}
+	defer release()
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- o.chainsyncClientRollForwardRaw(
+			ochainsync.CallbackContext{
+				ConnectionId: newTestConnId(
+					"127.0.0.1:6000",
+					"1.1.1.1:3001",
+				),
+			},
+			headerType,
+			raw,
+			ochainsync.Tip{},
+		)
+	}()
+	testutil.WaitForCondition(t, func() bool {
+		o.headerDecodeCache.mu.Lock()
+		defer o.headerDecodeCache.mu.Unlock()
+		return len(o.headerDecodeCache.inFlight[key]) == 1
+	}, 2*time.Second, "raw callback should wait on the claimed decode")
+	releasedAt := time.Now()
+	release()
+	require.NoError(t, testutil.RequireReceive(
+		t,
+		resultCh,
+		2*time.Second,
+		"raw callback should finish after decode release",
+	))
+
+	evt := testutil.RequireReceive(
+		t,
+		ledgerCh,
+		2*time.Second,
+		"raw roll-forward should publish a ledger ChainSync event",
+	)
+	data, ok := evt.Data.(ledger.ChainsyncEvent)
+	require.True(t, ok)
+	require.True(t, data.ArrivalTime.Before(releasedAt))
 }

--- a/ouroboros/lifecycle.go
+++ b/ouroboros/lifecycle.go
@@ -135,6 +135,10 @@ func (o *Ouroboros) subscribeTracked(
 // Close is idempotent, so Run()'s deferred shutdown and an explicit
 // live-restore teardown can both call it.
 func (o *Ouroboros) Close() error {
+	// Cancel admission-recovery publication before waiting for EventBus
+	// handlers. A timer that fired concurrently with Close must not keep
+	// shutdown waiting on an ordered-lane enqueue.
+	o.stopFutureHeaderResyncs()
 	o.subscriptionsMu.Lock()
 	subs := o.subscriptions
 	o.subscriptions = nil

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -116,6 +117,18 @@ type Ouroboros struct {
 	// ChainSync measurement tracking for peer scoring
 	chainsyncStats map[ouroboros.ConnectionId]*chainsyncPeerStats
 	chainsyncMutex sync.Mutex
+	// Future-header admission runs on the per-peer ChainSync callback before
+	// any observed-tip, dedup, or ledger mutation. Resync timers recover the
+	// protocol cursor after a deliberate beyond-skew drop without recycling
+	// the connection; one earliest-onset timer is retained per connection.
+	chainsyncHeaderAdmission chainsyncHeaderAdmissionFunc
+	chainsyncHeaderSlotTime  func(uint64) (time.Time, error)
+	chainsyncScheduleAt      chainsyncScheduleAtFunc
+	futureHeaderResyncMu     sync.Mutex
+	futureHeaderResyncs      map[ouroboros.ConnectionId]*scheduledChainsyncResync
+	futureHeaderResyncCtx    context.Context
+	futureHeaderResyncCancel context.CancelFunc
+	futureHeaderResyncClosed bool
 	// Per-connection mutex to serialize chainsync restarts
 	restartMu sync.Map // ouroboros.ConnectionId → *sync.Mutex
 	// Per-peer rate limiter for TxSubmission server
@@ -359,6 +372,9 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 	cfg.ChainsyncBlockTimeout = effectiveChainsyncBlockTimeout(
 		cfg.ChainsyncBlockTimeout,
 	)
+	futureHeaderResyncCtx, futureHeaderResyncCancel := context.WithCancel(
+		context.Background(),
+	)
 	o := &Ouroboros{
 		config:           cfg,
 		registerer:       newTrackingRegisterer(cfg.PromRegistry),
@@ -375,6 +391,12 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 		chainsyncStats: make(
 			map[ouroboros.ConnectionId]*chainsyncPeerStats,
 		),
+		chainsyncScheduleAt: defaultChainsyncScheduleAt,
+		futureHeaderResyncs: make(
+			map[ouroboros.ConnectionId]*scheduledChainsyncResync,
+		),
+		futureHeaderResyncCtx:      futureHeaderResyncCtx,
+		futureHeaderResyncCancel:   futureHeaderResyncCancel,
 		blockDecodeCache:           newDecodeCache[gledger.Block](),
 		headerDecodeCache:          newDecodeCache[gledger.BlockHeader](),
 		leiosEndorserBlocks:        make(map[string]*leiosEndorserBlockData),
@@ -384,6 +406,10 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 		leiosDeferredAnnouncements: make(map[string]leiosDeferredAnnouncement),
 		leiosAnnouncementSizes:     make(map[string]uint64),
 		leiosAnnouncementElections: make(map[string]map[string]struct{}),
+	}
+	if o.ledgerState != nil {
+		o.chainsyncHeaderAdmission = o.ledgerState.AwaitChainsyncHeaderAdmission
+		o.chainsyncHeaderSlotTime = o.ledgerState.SlotToTime
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond
@@ -635,6 +661,7 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 		return
 	}
 	connId := e.ConnectionId
+	o.cancelFutureHeaderResync(connId)
 
 	// Record connection stability observation for peer scoring
 	// Connection closure indicates reduced stability
@@ -717,8 +744,10 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	if !o.hasDependencies() {
 		o.config.Logger.Error(
 			"dropping outbound connection event received before wiring completed",
-			"component", "network",
-			"connection_id", connId.String(),
+			"component",
+			"network",
+			"connection_id",
+			connId.String(),
 		)
 		return
 	}
@@ -862,8 +891,10 @@ func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	if !o.hasDependencies() {
 		o.config.Logger.Error(
 			"dropping inbound connection event received before wiring completed",
-			"component", "network",
-			"connection_id", connId.String(),
+			"component",
+			"network",
+			"connection_id",
+			connId.String(),
 		)
 		return
 	}


### PR DESCRIPTION
Closes #3287.

- Preserve block-header arrival time from network ingress through ChainSync processing.
- Apply future-header admission before observed-tip, deduplication, and ledger mutation.
- Wait up to two seconds for bounded clock skew; drop later headers without peer penalty or state mutation.
- Re-intersect each affected connection at the earliest dropped header and cancel pending recovery on connection removal or shutdown.
- Cover boundary, conversion, cursor, cancellation, replay, and timer behavior.

## Validation

- Full race-enabled Go suite with a 20-minute package timeout.
- Exact-head race coverage for future-header admission/resync and packages changed by the latest `main` merge.
- Accelerated all-Dingo DevNet with in-process observers: propagation, agreement, epoch transition, peer interruption, and relay restart.
- Accelerated Dingo/cardano-node conformance DevNet with the same observer and recovery phases.
- `make`, `make import-boundaries`, `make docs-parity`, `make gorm-check`, `make golines`, and `make govulncheck`.
- `make lint` passed before the latest `main` refresh; the test-only baseline static-analysis failures introduced by that refresh are isolated in #3445.
