### PR TITLE
test(mithril): gate the swap tests on a platform that allows the swap

### DIFF
--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -1194,8 +1194,9 @@ func TestFetchImmutableArchiveSurvivesArchiveDirSwapAfterDownload(
 ) {
 	probeLink := filepath.Join(t.TempDir(), "probe")
 	requireSymlinkSupport(t, t.TempDir(), probeLink)
-	// The swap is staged from the transport's goroutine, so the platform's
-	// willingness to rename a held-open directory has to be settled here.
+	// The response-body callback stages the swap synchronously through io.Copy
+	// on this calling test goroutine. Probe before arming it so an unsupported
+	// platform skips instead of reporting a scenario failure.
 	requireDirectorySwapSupport(t)
 
 	const num = 0
@@ -1301,8 +1302,9 @@ func TestFetchImmutableArchiveCleansUpThroughRootOnExtractionFailure(
 ) {
 	probeLink := filepath.Join(t.TempDir(), "probe")
 	requireSymlinkSupport(t, t.TempDir(), probeLink)
-	// The swap is staged from the transport's goroutine, so the platform's
-	// willingness to rename a held-open directory has to be settled here.
+	// The response-body callback stages the swap synchronously through io.Copy
+	// on this calling test goroutine. Probe before arming it so an unsupported
+	// platform skips instead of reporting a scenario failure.
 	requireDirectorySwapSupport(t)
 
 	const num = 0

--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -1194,6 +1194,9 @@ func TestFetchImmutableArchiveSurvivesArchiveDirSwapAfterDownload(
 ) {
 	probeLink := filepath.Join(t.TempDir(), "probe")
 	requireSymlinkSupport(t, t.TempDir(), probeLink)
+	// The swap is staged from the transport's goroutine, so the platform's
+	// willingness to rename a held-open directory has to be settled here.
+	requireDirectorySwapSupport(t)
 
 	const num = 0
 	archiveContent := buildTarZst(t, map[string][]byte{
@@ -1298,6 +1301,9 @@ func TestFetchImmutableArchiveCleansUpThroughRootOnExtractionFailure(
 ) {
 	probeLink := filepath.Join(t.TempDir(), "probe")
 	requireSymlinkSupport(t, t.TempDir(), probeLink)
+	// The swap is staged from the transport's goroutine, so the platform's
+	// willingness to rename a held-open directory has to be settled here.
+	requireDirectorySwapSupport(t)
 
 	const num = 0
 	// Deliberately not a valid zstd stream, so extraction fails.

--- a/mithril/extract_hardening_test.go
+++ b/mithril/extract_hardening_test.go
@@ -69,6 +69,35 @@ func requireDirectorySwap(t *testing.T, oldpath, newpath string) {
 	}
 }
 
+// requireDirectorySwapSupport reports the same constraint as
+// requireDirectorySwap without performing the caller's swap.
+//
+// A test that stages its swap from another goroutine — the download
+// transport's, say — cannot use requireDirectorySwap, because t.Skip is only
+// valid on the goroutine running the test. Probing the capability here, before
+// the scenario is armed, keeps the skip on the test goroutine and keeps the
+// reason identical: where the platform refuses the rename, the manoeuvre cannot
+// be staged at all, which bounds the attack rather than the guarantee.
+func requireDirectorySwapSupport(t *testing.T) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "swap-probe")
+	require.NoError(t, os.Mkdir(dir, 0o750))
+	// A handle *beneath* the directory, which is the shape the extraction path
+	// holds open while the swap is attempted.
+	held, err := os.Create(filepath.Join(dir, "held"))
+	require.NoError(t, err)
+	defer held.Close()
+	if err := os.Rename(dir, dir+".moved"); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf(
+				"cannot swap a directory with open handles beneath it: %v",
+				err,
+			)
+		}
+		require.NoError(t, err)
+	}
+}
+
 // TestExtractArchiveRefusesNonEmptyDestination covers the default exclusive
 // mode: a destination that already holds content is not extracted into, so
 // archive contents can never be merged with files placed there by someone

--- a/mithril/extract_hardening_test.go
+++ b/mithril/extract_hardening_test.go
@@ -72,12 +72,13 @@ func requireDirectorySwap(t *testing.T, oldpath, newpath string) {
 // requireDirectorySwapSupport reports the same constraint as
 // requireDirectorySwap without performing the caller's swap.
 //
-// A test that stages its swap from another goroutine — the download
-// transport's, say — cannot use requireDirectorySwap, because t.Skip is only
-// valid on the goroutine running the test. Probing the capability here, before
-// the scenario is armed, keeps the skip on the test goroutine and keeps the
-// reason identical: where the platform refuses the rename, the manoeuvre cannot
-// be staged at all, which bounds the attack rather than the guarantee.
+// The archive swap tests stage their swap from a response-body Read callback.
+// io.Copy calls that Read synchronously on the calling test goroutine. Probing
+// the capability here, before the scenario is armed, lets a platform limitation
+// skip cleanly; once armed, the callback records any failure as scenario
+// evidence instead of using testing APIs. Where the platform refuses the
+// rename, the manoeuvre cannot be staged at all, which bounds the attack rather
+// than the guarantee.
 func requireDirectorySwapSupport(t *testing.T) {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "swap-probe")


### PR DESCRIPTION
## Problem

Two archive-directory swap tests added by #3303 fail at their setup assertion on Windows. The tests hold an `os.Root` handle beneath the directory, and Windows refuses the rename needed to construct the TOCTOU scenario.

## Changes

- Probe directory-swap support on the test goroutine before the archive download callback stages the swap.
- Skip only when the platform cannot rename a directory with an open handle beneath it.
- Preserve the existing symlink capability check and full Linux coverage.

## Validation

The focused Mithril race suite and lint pass. Both tests still run on Linux, and a forced unsupported probe skips them with the platform limitation. Windows CI passes on the current head.

Refs #3228.

Merge note: this session intentionally skipped GPG signing; the new commits must be re-signed before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform handling for directory-swap regression tests.
  * Tests now skip unsupported scenarios on Windows instead of reporting false failures.
  * Added capability checks to distinguish unsupported platform behavior from genuine test errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->