### PR TITLE
fix(ledger): gate continuation audit on applied tip

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3041,9 +3041,12 @@ hold and restores the normal fallback budget.
 
 That hold bounds the damage but cannot explain where an unresolvable producer
 came from, so a bounded diagnostic attributes it
-(`ledger/continuation_audit.go`). A local rollback — chainsync rollback via
+(`ledger/continuation_audit.go`). A local rollback that leaves the primary chain
+and applied ledger at the same point — chainsync rollback via
 `rollbackChainAndState`, or a replay-recovery rewind — arms a
-`continuationAuditWindow` at the rollback point. While armed, every body
+`continuationAuditWindow` there. A chainsync rollback point ahead of the applied
+ledger instead disarms any prior window because its fork point no longer
+describes the continuation being fetched. While armed, every body
 delivered by blockfetch above that point is checked input by input: an input
 resolves when its producing transaction was created by a block already seen in
 the window (fetched and on the chain, not yet applied), when the ledger still
@@ -3054,10 +3057,10 @@ and the fork point the node had rolled back to, and increments
 `dingo_ledger_continuation_input_unresolved_total`. The audit never rejects a
 block; the splice it detects is prevented upstream in the chain layer, and
 bodies that still fail reach the ordinary validation and recovery guards
-unchanged. Arming on rollback is both the cost gate — a healthy node never runs
-the per-input probes on the steady-state blockfetch path — and what makes the
-check sound, since a rollback leaves the chain and the ledger at the same point
-so every later block arrives through the window. Each arming inspects at most
+unchanged. Arming only after an aligned rollback is both the cost gate — a
+healthy node never runs the per-input probes on the steady-state blockfetch
+path — and what makes the check sound, since every later block then arrives
+through the window. Each arming inspects at most
 `continuationAuditBlockBudget` bodies and retains at most
 `continuationAuditMaxProducedTxs` in-window producers. The audit is also skipped
 while block validation is off, which is how historical catch-up runs: the splice

--- a/ledger/crossfork_splice_test.go
+++ b/ledger/crossfork_splice_test.go
@@ -274,6 +274,8 @@ func TestContinuationAuditReportsUnresolvableProducer(t *testing.T) {
 func TestRollbackAheadOfLedgerDoesNotArmContinuationAudit(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 	ls := fixture.ls
+	ls.armContinuationAudit(fixture.ancestorTip.Point, "prior rollback")
+	require.NotNil(t, ls.continuationAudit.Load())
 
 	ls.Lock()
 	ls.currentTip = fixture.ancestorTip
@@ -287,7 +289,7 @@ func TestRollbackAheadOfLedgerDoesNotArmContinuationAudit(t *testing.T) {
 	assert.Nil(
 		t,
 		ls.continuationAudit.Load(),
-		"a rollback ahead of the applied ledger must not arm the audit",
+		"a rollback ahead of the applied ledger must disarm any prior audit",
 	)
 	assert.Equal(t, fixture.ancestorTip, ls.currentTip)
 }

--- a/ledger/crossfork_splice_test.go
+++ b/ledger/crossfork_splice_test.go
@@ -266,6 +266,32 @@ func TestContinuationAuditReportsUnresolvableProducer(t *testing.T) {
 	assert.Equal(t, "test rollback", report["fork_reason"])
 }
 
+// TestRollbackAheadOfLedgerDoesNotArmContinuationAudit covers genesis and
+// snapshot catch-up, where the primary chain may already contain blocks beyond
+// the applied ledger tip. A rollback to that primary-chain point does not move
+// the ledger, so the continuation audit must remain disarmed rather than
+// reporting unapplied history as missing producers.
+func TestRollbackAheadOfLedgerDoesNotArmContinuationAudit(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+
+	ls.Lock()
+	ls.currentTip = fixture.ancestorTip
+	ls.currentTipBlockNonce = append([]byte(nil), fixture.ancestorNonce...)
+	ls.publishSnapshotsLocked()
+	ls.Unlock()
+	require.NoError(t, ls.db.SetTip(fixture.ancestorTip, nil))
+
+	require.NoError(t, ls.rollbackChainAndState(fixture.currentTip.Point))
+
+	assert.Nil(
+		t,
+		ls.continuationAudit.Load(),
+		"a rollback ahead of the applied ledger must not arm the audit",
+	)
+	assert.Equal(t, fixture.ancestorTip, ls.currentTip)
+}
+
 // TestContinuationAuditAcceptsProducerInSameWindow guards the audit against
 // false positives: blockfetch runs ahead of ledger application, so a producer
 // delivered earlier in the same audit window is on the local chain even though

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3038,10 +3038,14 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	if err := ls.rollback(point); err != nil {
 		return fmt.Errorf("synchronize ledger rollback state: %w", err)
 	}
-	// Chain and ledger now sit at the same point, so every block above it
-	// arrives through blockfetch and the continuation audit can resolve
-	// producers without a chain scan.
-	ls.armContinuationAudit(point, "chainsync rollback")
+	// A primary chain can be ahead of the applied ledger during genesis or
+	// snapshot catch-up. In that case ls.rollback intentionally leaves the
+	// ledger at its existing tip, so arming the audit at the primary-chain
+	// rollback point would report every unapplied continuation as missing a
+	// producer. Arm only when both sides actually reached the rollback point.
+	if pointMatches(ls.Tip().Point, point) {
+		ls.armContinuationAudit(point, "chainsync rollback")
+	}
 	return nil
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3042,9 +3042,12 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	// snapshot catch-up. In that case ls.rollback intentionally leaves the
 	// ledger at its existing tip, so arming the audit at the primary-chain
 	// rollback point would report every unapplied continuation as missing a
-	// producer. Arm only when both sides actually reached the rollback point.
+	// producer. Arm only when both sides actually reached the rollback point,
+	// and discard any window left by an earlier rollback when they did not.
 	if pointMatches(ls.Tip().Point, point) {
 		ls.armContinuationAudit(point, "chainsync rollback")
+	} else {
+		ls.continuationAudit.Store(nil)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- arm the continuation audit only when the applied ledger tip matches the chainsync rollback point
- disarm a stale prior audit when catch-up leaves the ledger behind that rollback point
- cover both the nil-window and already-armed lifecycle cases
- document the aligned-rollback requirement

## Validation

- controlled fail-before regression: stale audit remains on the prior head
- focused ledger race test passes on the fixed head
- ledger golangci-lint reports zero issues
- ledger NilAway passes
- docs parity passes
