### PR TITLE
test(ledger): cover Byron Shelley boundary recovery

### DIFF
--- a/ledger/byron_shelley_boundary_test.go
+++ b/ledger/byron_shelley_boundary_test.go
@@ -15,13 +15,26 @@
 package ledger
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -237,4 +250,242 @@ func TestByronBlockHeaderProtocolVersionSkippedWithoutPParams(t *testing.T) {
 			)
 		})
 	}
+}
+
+func newByronShelleyBoundaryLedger(
+	t *testing.T,
+) (*LedgerState, gledger.Block, gledger.Block) {
+	t.Helper()
+
+	const byronGenesisJSON = `{
+		"protocolConsts": {"k": 2160, "protocolMagic": 764824073},
+		"blockVersionData": {"slotDuration": "20000"}
+	}`
+	const shelleyGenesisJSON = `{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": 2160,
+		"epochLength": 432000,
+		"slotLength": 1,
+		"networkId": "Mainnet",
+		"networkMagic": 764824073,
+		"protocolParams": {
+			"protocolVersion": {"major": 2, "minor": 0},
+			"decentralisationParam": 1,
+			"maxBlockBodySize": 65536,
+			"maxBlockHeaderSize": 1100,
+			"maxTxSize": 16384,
+			"minFeeA": 44,
+			"minFeeB": 155381,
+			"minUTxOValue": 1000000,
+			"keyDeposit": 2000000,
+			"poolDeposit": 500000000,
+			"eMax": 18,
+			"nOpt": 150,
+			"a0": 0.3,
+			"rho": 0.003,
+			"tau": 0.2,
+			"minPoolCost": 340000000
+		},
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`
+
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: strings.Repeat("42", 32),
+	}
+	require.NoError(t, cfg.LoadByronGenesisFromReader(
+		strings.NewReader(byronGenesisJSON),
+	))
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(
+		strings.NewReader(shelleyGenesisJSON),
+	))
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{
+		securityParam: 2,
+	}))
+
+	lastByron := loadBoundaryBlock(
+		t,
+		"mainnet-byron-last-4492799.cbor",
+		1,
+	)
+	firstShelley := loadBoundaryBlock(
+		t,
+		"mainnet-shelley-first-4492800.cbor",
+		2,
+	)
+	rawBlocks := []chain.RawBlock{{
+		Slot:        lastByron.SlotNumber(),
+		Hash:        lastByron.Hash().Bytes(),
+		BlockNumber: lastByron.BlockNumber(),
+		Type:        1,
+		Cbor:        lastByron.Cbor(),
+	}}
+	rawBlocks = append(rawBlocks, chain.RawBlock{
+		Slot:        firstShelley.SlotNumber(),
+		Hash:        firstShelley.Hash().Bytes(),
+		BlockNumber: firstShelley.BlockNumber(),
+		Type:        2,
+		PrevHash:    firstShelley.PrevHash().Bytes(),
+		Cbor:        firstShelley.Cbor(),
+	})
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(rawBlocks))
+
+	const (
+		byronEpoch       = uint64(207)
+		byronEpochStart  = uint64(4_471_200)
+		byronEpochLength = uint(21_600)
+	)
+	require.NoError(t, db.SetEpoch(
+		byronEpochStart,
+		byronEpoch,
+		nil,
+		nil,
+		nil,
+		nil,
+		eras.ByronEraDesc.Id,
+		20_000,
+		byronEpochLength,
+		nil,
+	))
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: cfg,
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		ValidateHistorical: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ls.Close()) })
+
+	byronTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			lastByron.SlotNumber(),
+			lastByron.Hash().Bytes(),
+		),
+		BlockNumber: lastByron.BlockNumber(),
+	}
+	require.NoError(t, db.SetTip(byronTip, nil))
+	byronNonce := bytes.Repeat([]byte{0x42}, 32)
+	require.NoError(t, db.SetBlockNonce(
+		byronTip.Point.Hash,
+		byronTip.Point.Slot,
+		byronNonce,
+		true,
+		nil,
+	))
+	ls.currentTip = byronTip
+	ls.currentTipBlockNonce = byronNonce
+	ls.currentEpoch = models.Epoch{
+		EpochId:       byronEpoch,
+		StartSlot:     byronEpochStart,
+		SlotLength:    20_000,
+		LengthInSlots: byronEpochLength,
+		EraId:         eras.ByronEraDesc.Id,
+	}
+	ls.epochCache = []models.Epoch{ls.currentEpoch}
+	ls.currentEra = eras.ByronEraDesc
+	ls.currentPParams = nil
+	ls.transitionInfo = hardfork.NewTransitionUnknown()
+	ls.publishSnapshotsLocked()
+
+	return ls, lastByron, firstShelley
+}
+
+func TestByronShelleyBoundaryProcessesFirstShelleyBlockWithPParams(
+	t *testing.T,
+) {
+	ls, _, firstShelley := newByronShelleyBoundaryLedger(t)
+	require.True(t, ls.validationEnabled)
+
+	results := make(chan readChainResult, 1)
+	results <- readChainResult{blocks: []gledger.Block{firstShelley}}
+	close(results)
+
+	require.NoError(t, ls.ledgerProcessBlocksFromSource(
+		context.Background(),
+		results,
+	))
+	// Historical validation is enabled above, so the normal processing path
+	// calls validateInboundBlockEnvelope before applying this block. That call
+	// rejects a Shelley block with nil pparams; reaching the new tip therefore
+	// proves the boundary rollover installed them before validation.
+	require.Equal(t, eras.ShelleyEraDesc.Id, ls.currentEra.Id)
+	pparams, ok := ls.currentPParams.(*shelley.ShelleyProtocolParameters)
+	require.True(t, ok, "the first Shelley block must install Shelley pparams")
+	assert.Equal(t, uint(2), pparams.ProtocolMajor)
+	assert.Equal(t, firstShelley.SlotNumber(), ls.currentTip.Point.Slot)
+}
+
+func TestRollbackChainAndStateClearsShelleyPParamsInsideByronPrefix(
+	t *testing.T,
+) {
+	ls, lastByron, firstShelley := newByronShelleyBoundaryLedger(t)
+
+	const shelleyEpoch = uint64(208)
+	shelleyPParams := &shelley.ShelleyProtocolParameters{
+		ProtocolMajor:      2,
+		ProtocolMinor:      0,
+		MaxBlockBodySize:   65_536,
+		MaxBlockHeaderSize: 1_100,
+	}
+	pparamsCbor, err := cbor.Encode(shelleyPParams)
+	require.NoError(t, err)
+	require.NoError(t, ls.db.SetEpoch(
+		firstShelley.SlotNumber(),
+		shelleyEpoch,
+		nil,
+		nil,
+		nil,
+		nil,
+		eras.ShelleyEraDesc.Id,
+		1_000,
+		432_000,
+		nil,
+	))
+	require.NoError(t, ls.db.SetPParams(
+		pparamsCbor,
+		firstShelley.SlotNumber(),
+		shelleyEpoch,
+		eras.ShelleyEraDesc.Id,
+		nil,
+	))
+	shelleyTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			firstShelley.SlotNumber(),
+			firstShelley.Hash().Bytes(),
+		),
+		BlockNumber: firstShelley.BlockNumber(),
+	}
+	require.NoError(t, ls.db.SetTip(shelleyTip, nil))
+	ls.currentTip = shelleyTip
+	ls.currentEpoch = models.Epoch{
+		EpochId:       shelleyEpoch,
+		StartSlot:     firstShelley.SlotNumber(),
+		SlotLength:    1_000,
+		LengthInSlots: 432_000,
+		EraId:         eras.ShelleyEraDesc.Id,
+	}
+	ls.epochCache = append(ls.epochCache, ls.currentEpoch)
+	ls.currentEra = eras.ShelleyEraDesc
+	ls.currentPParams = shelleyPParams
+	ls.transitionInfo = hardfork.NewTransitionKnown(shelleyEpoch)
+	ls.publishSnapshotsLocked()
+
+	byronPoint := ocommon.NewPoint(
+		lastByron.SlotNumber(),
+		lastByron.Hash().Bytes(),
+	)
+	require.NoError(t, ls.rollbackChainAndState(byronPoint))
+
+	assert.Equal(t, byronPoint, ls.currentTip.Point)
+	assert.Equal(t, eras.ByronEraDesc.Id, ls.currentEra.Id)
+	assert.Nil(t, ls.currentPParams)
+	assert.Nil(t, ls.prevEraPParams)
+	assert.Equal(t, hardfork.NewTransitionUnknown(), ls.transitionInfo)
 }


### PR DESCRIPTION
Closes #3316.

## Problem

Existing Byron-prefix coverage did not drive the normal Byron-to-Shelley block-processing boundary or a rollback from Shelley into the Byron prefix.

## Change

- Process the canonical mainnet boundary block through the normal validated ledger pipeline and require Shelley parameters before the block advances the tip.
- Roll back from the first Shelley block to the last Byron block and require nil current/previous parameters with no reconstructed transition.

## Validation

- Race-enabled ledger coverage for the complete Byron/Shelley boundary test file.
- Race-enabled conformance package coverage.
- Exact-head race coverage for both added regression scenarios after merging the latest `main`.
- `make`, `make import-boundaries`, `make docs-parity`, `make gorm-check`, and `make golines`.
- `make lint` passed before the latest `main` refresh; the test-only baseline static-analysis failures introduced by that refresh are isolated in #3445.
- Controlled reversions proved the tests detect both the stale-parameter rollback gate and a missing boundary transition.
