### PR TITLE
fix(ledger): restore post-Mithril leader checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4074,11 +4074,14 @@ Those rows store the consensus stake fraction as `total_stake /
 stake_denominator` and are required for block-header leader eligibility checks
 until the node leaves the imported epoch. The regular Mark snapshot window is
 kept for epoch-offset consumers, but it does not substitute for `"actv"` rows in
-the imported epoch. Historical Mark rows imported from the same ledger-state
-bundle can have a `captured_slot` after their target epoch's boundary; inbound
-header validation recognizes that shape as unsuitable for hard stake-threshold
-rejection and skips that portion of validation until live boundary-captured Mark
-rows are available.
+the imported epoch. The importer preserves the certified
+`NewEpochState.SnapShots` provenance on that window: each Dingo Mark row records
+the SNAP slot immediately before its target epoch, regardless of the later slot
+that exported the ledger-state file. Existing databases from the older importer
+carry the exact Mithril anchor instead; inbound header validation recognizes
+that legacy provenance as the same certified bundle. Only historical Mark rows
+reconstructed from current live state after their target boundary remain
+unsuitable for hard stake-threshold rejection and keep the conservative bypass.
 
 Mithril sync only uses a ledger state as the local trust anchor when its point
 is at or below the certificate-backed ImmutableDB tip. Ancillary archives can

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4076,10 +4076,12 @@ until the node leaves the imported epoch. The regular Mark snapshot window is
 kept for epoch-offset consumers, but it does not substitute for `"actv"` rows in
 the imported epoch. The importer preserves the certified
 `NewEpochState.SnapShots` provenance on that window: each Dingo Mark row records
-the SNAP slot immediately before its target epoch, regardless of the later slot
-that exported the ledger-state file. Existing databases from the older importer
-carry the exact Mithril anchor instead; inbound header validation recognizes
-that legacy provenance as the same certified bundle. Only historical Mark rows
+the SNAP slot immediately before its target epoch when that boundary can be
+resolved from the imported era telescope, regardless of the later slot that
+exported the ledger-state file. If the boundary cannot be resolved, the importer
+retains the exact certified import anchor; existing databases from the older
+importer carry that same anchor. Inbound header validation recognizes this
+anchor provenance as the same certified bundle. Only historical Mark rows
 reconstructed from current live state after their target boundary remain
 unsuitable for hard stake-threshold rejection and keep the conservative bypass.
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -817,6 +817,15 @@ process the same pointer unless the claim expires before a result is recorded.
 | `reward_pool_output` | `id`, `epoch`, `pool_key_hash`, `apparent_performance`, `optimal_reward`, `total_reward`, `leader_reward`, `member_reward_total`, `owner_stake`, `undistributed`, `unspendable`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, pool_key_hash)`; indexes `captured_slot`, `boundary_slot` | Persisted per-pool reward-calculation results. Replacing a provisional reward snapshot invalidates rows for the same epoch. Retained for the life of the database (see the retention note below), so it is the durable per-pool reward result for any closed epoch. |
 | `reward_account_output` | `id`, `epoch`, `credential_tag`, `staking_key`, `pool_key_hash`, `reward_type`, `amount`, `spendable`, `guarded`, `captured_slot`, `boundary_slot` | PK `id`; unique `(epoch, credential_tag, staking_key, pool_key_hash, reward_type)`; credential indexes `(credential_tag, staking_key, spendable, epoch, pool_key_hash, reward_type)` and `(credential_tag, staking_key, spendable, guarded, epoch, pool_key_hash, reward_type)`; indexes `captured_slot`, `boundary_slot` | Persisted per-account reward-calculation results, invalidated together with pool outputs when snapshot inputs are replaced. `spendable = false` records deregistration; `guarded = true` records a CIP-0163 expiry guard. Credential reward-history reads require `spendable = true AND guarded = false`, and the guarded-aware index keeps that lookup bounded. |
 
+For Mithril imports, the certified `NewEpochState.SnapShots` Mark/Set/Go
+members are stored as Mark rows for their rotation epochs. Their
+`captured_slot` is the SNAP slot immediately before each target epoch, not the
+later ledger-state export tip. Databases created by the older importer carry
+the exact Mithril anchor instead; header validation treats that as equivalent
+certified provenance. Startup-reconstructed historical rows retain their
+post-boundary capture slot so they remain distinguishable and are not used for
+hard leader-threshold rejection.
+
 #### Snapshot and Reward-State Retention
 
 Every epoch transition runs `cleanupOldSnapshots`, which prunes to the four

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -819,12 +819,14 @@ process the same pointer unless the claim expires before a result is recorded.
 
 For Mithril imports, the certified `NewEpochState.SnapShots` Mark/Set/Go
 members are stored as Mark rows for their rotation epochs. Their
-`captured_slot` is the SNAP slot immediately before each target epoch, not the
-later ledger-state export tip. Databases created by the older importer carry
-the exact Mithril anchor instead; header validation treats that as equivalent
-certified provenance. Startup-reconstructed historical rows retain their
-post-boundary capture slot so they remain distinguishable and are not used for
-hard leader-threshold rejection.
+`captured_slot` is the SNAP slot immediately before each target epoch when the
+imported era telescope can resolve that boundary, not the later ledger-state
+export tip. If it cannot, the importer retains the exact certified import
+anchor; databases created by the older importer carry that same anchor. Header
+validation treats anchor provenance as equivalent to the certified boundary
+provenance. Startup-reconstructed historical rows retain their post-boundary
+capture slot so they remain distinguishable and are not used for hard
+leader-threshold rejection.
 
 #### Snapshot and Reward-State Retention
 

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1141,10 +1141,10 @@ func (ls *LedgerState) leaderEligibilityStake(
 				diag,
 			)
 	}
-	if ls.isMithrilImportedMarkSnapshot(snapshot, snapshotEpoch) {
+	if ls.shouldSkipPostMithrilMarkEligibility(snapshot, snapshotEpoch) {
 		if ls.config.Logger != nil {
 			ls.config.Logger.Warn(
-				"skipping leader eligibility check: Mithril-imported mark snapshot captured mid-epoch, not at the epoch boundary",
+				"skipping leader eligibility check: post-Mithril mark snapshot was reconstructed after the target boundary",
 				"slot",
 				block.SlotNumber(),
 				"epoch",
@@ -1180,7 +1180,14 @@ func (ls *LedgerState) leaderEligibilityStake(
 		false, nil
 }
 
-func (ls *LedgerState) isMithrilImportedMarkSnapshot(
+// shouldSkipPostMithrilMarkEligibility reports whether a mark row was
+// reconstructed from live state after its target boundary and therefore cannot
+// safely drive hard leader-threshold rejection. New imports retain the
+// certified NewEpochState.SnapShots boundary slot. Older imports used the
+// Mithril anchor itself as CapturedSlot, so that exact legacy provenance is
+// accepted too; startup-synthesized historical rows use another post-boundary
+// slot and remain conservative.
+func (ls *LedgerState) shouldSkipPostMithrilMarkEligibility(
 	snapshot *models.PoolStakeSnapshot,
 	snapshotEpoch uint64,
 ) bool {
@@ -1194,6 +1201,9 @@ func (ls *LedgerState) isMithrilImportedMarkSnapshot(
 	defer ls.RUnlock()
 
 	if ls.mithrilLedgerSlot == 0 {
+		return false
+	}
+	if snapshot.CapturedSlot == ls.mithrilLedgerSlot {
 		return false
 	}
 	for _, ep := range ls.epochCache {

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -2035,7 +2035,7 @@ func TestVerifyBlockHeaderCrypto_EmptyMarkSnapshotDiagnostic(t *testing.T) {
 	assert.Contains(t, err.Error(), "has no stake in epoch")
 }
 
-func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
+func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkChecks(
 	t *testing.T,
 ) {
 	tb := createTestBlock(t, [32]byte{38}, 0, tamperNone)
@@ -2051,10 +2051,11 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 	ls.mithrilLedgerSlot = importedCaptureSlot
 	tb.block.slot = ls.epochCache[2].StartSlot + 50
 
-	// Leader election in epoch 5 uses mark[StakeSnapshotEpoch(5)] = mark[4]
-	// (the end-of-epoch-3 "set" distribution), so the imported mark is seeded
-	// at epoch 4. importedCaptureSlot (epoch4-start+50) is past epoch 4's start,
-	// which is what marks it as Mithril-imported.
+	// Leader election in epoch 5 uses mark[StakeSnapshotEpoch(5)] = mark[4].
+	// Older Dingo imports stamped the certified NewEpochState SnapShots.Mark
+	// row with the mid-epoch Mithril anchor. That provenance is still
+	// authoritative even though the stored capture slot is after epoch 4's
+	// start, so existing databases must run the threshold check.
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	seedPoolStakeSnapshotOfTypeAtSlot(
 		t,
@@ -2085,17 +2086,75 @@ func TestVerifyBlockLeaderEligibility_MithrilImportedHistoricalMarkSkips(
 		nil,
 	)
 	require.NoError(t, err)
-	require.True(t, ls.isMithrilImportedMarkSnapshot(snapshot, 4))
+	require.False(t, ls.shouldSkipPostMithrilMarkEligibility(snapshot, 4))
 	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
-	assert.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(
 		t,
-		logBuf.String(),
-		"Mithril-imported mark snapshot captured mid-epoch, not at the epoch boundary",
+		err.Error(),
+		"VRF leader value exceeds stake-derived threshold",
 	)
-	assert.NotContains(t, logBuf.String(), "total active stake is zero")
+	assert.NotContains(t, logBuf.String(), "skipping leader eligibility check")
+}
+
+func TestVerifyBlockLeaderEligibility_ReconstructedHistoricalMarkSkips(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{40}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	var logBuf bytes.Buffer
+	ls.config.Logger = slog.New(slog.NewTextHandler(&logBuf, nil))
+	ls.epochCache = []models.Epoch{
+		{EpochId: 3, StartSlot: 300, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 4, StartSlot: 400, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 5, StartSlot: 500, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.mithrilLedgerSlot = ls.epochCache[1].StartSlot + 50
+	tb.block.slot = ls.epochCache[2].StartSlot + 50
+
+	// The startup fallback derives historical rows from current live state and
+	// stamps them with the current epoch start. Unlike a certified imported
+	// row, this capture is neither the target boundary nor the Mithril anchor,
+	// so hard threshold rejection remains unsafe.
+	reconstructedCaptureSlot := ls.epochCache[1].StartSlot
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		4,
+		models.PoolStakeSnapshotTypeMark,
+		poolKeyHash[:],
+		1,
+		0,
+		reconstructedCaptureSlot,
+	)
+	dummyHash := make([]byte, 28)
+	dummyHash[0] = 0xFF
+	seedPoolStakeSnapshotOfTypeAtSlot(
+		t,
+		db,
+		4,
+		models.PoolStakeSnapshotTypeMark,
+		dummyHash,
+		1_000_000_000_000_000_000,
+		0,
+		reconstructedCaptureSlot,
+	)
+	snapshot, err := db.Metadata().GetPoolStakeSnapshot(
+		4,
+		models.PoolStakeSnapshotTypeMark,
+		poolKeyHash[:],
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, ls.shouldSkipPostMithrilMarkEligibility(snapshot, 4))
+	ls.publishSnapshotsLocked()
+
+	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.NoError(t, err)
+	assert.Contains(t, logBuf.String(), "skipping leader eligibility check")
 }
 
 func TestVerifyBlockLeaderEligibility_LiveComputedHistoricalMarkStillChecks(
@@ -2140,7 +2199,10 @@ func TestVerifyBlockLeaderEligibility_LiveComputedHistoricalMarkStillChecks(
 		nil,
 	)
 	require.NoError(t, err)
-	require.False(t, ls.isMithrilImportedMarkSnapshot(snapshot, snapshotEpoch))
+	require.False(t, ls.shouldSkipPostMithrilMarkEligibility(
+		snapshot,
+		snapshotEpoch,
+	))
 	ls.publishSnapshotsLocked()
 
 	err = ls.verifyBlockLeaderEligibility(tb.block, 5)

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -1404,9 +1404,11 @@ func importSnapShots(
 	//   - Mark for epoch N-1   = imported set snapshot
 	//   - Mark for epoch N-2   = imported go snapshot
 	//
-	// Import the bundle into those historical epochs so leader
-	// schedule queries (which request epoch-2, "mark") work
-	// immediately after a Mithril restore.
+	// Import the bundle into those historical epochs so leader schedule
+	// queries can read mark[E-1], the stake captured at the end of E-2,
+	// immediately after a Mithril restore. Preserve the semantic boundary
+	// capture slot from NewEpochState.SnapShots rather than stamping the rows
+	// with the mid-epoch ledger-state tip.
 	for _, st := range snapshotImportTargets(epoch, snapshots) {
 		select {
 		case <-ctx.Done():
@@ -1416,11 +1418,16 @@ func importSnapShots(
 		default:
 		}
 
+		capturedSlot := importedSnapshotCaptureSlot(
+			cfg,
+			st.targetEpoch,
+			slot,
+		)
 		poolSnapshots := AggregatePoolStake(
 			st.snap,
 			st.targetEpoch,
 			"mark",
-			slot,
+			capturedSlot,
 		)
 
 		if err := persistImportedSnapshot(
@@ -1446,6 +1453,7 @@ func importSnapShots(
 			"snapshot", st.name,
 			"stored_as", "mark",
 			"target_epoch", st.targetEpoch,
+			"captured_slot", capturedSlot,
 			"pools", len(poolSnapshots),
 			"total_stake", totalStake,
 			"component", "ledgerstate",
@@ -2287,6 +2295,28 @@ func importedEpochStartSlot(
 	}
 	return cfg.State.EraBoundSlot +
 		(epoch-cfg.State.EraBoundEpoch)*uint64(lengthInSlots), true
+}
+
+// importedSnapshotCaptureSlot returns the semantic slot represented by one
+// member of NewEpochState.SnapShots. A Dingo mark row for epoch N records the
+// SNAP distribution taken immediately before the boundary into N, regardless
+// of which later slot exported the ledger-state file. When the imported era
+// history cannot place that boundary, retaining the import tip preserves the
+// older import encoding; header validation recognizes the exact Mithril anchor
+// as certified SnapShots provenance.
+func importedSnapshotCaptureSlot(
+	cfg ImportConfig,
+	epoch uint64,
+	importSlot uint64,
+) uint64 {
+	epochStart, ok := importedEpochStartSlot(cfg, epoch)
+	if !ok {
+		return importSlot
+	}
+	if epochStart == 0 {
+		return 0
+	}
+	return epochStart - 1
 }
 
 // generateAndSaveEpochs creates epoch records for every epoch from

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -126,6 +126,64 @@ func TestSnapshotImportTargetsNilSnapshots(t *testing.T) {
 	}
 }
 
+func TestImportSnapShotsPreservesBoundaryCaptureProvenance(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	state, err := ParseSnapshot(testdataLedgerSnapshot)
+	require.NoError(t, err)
+	require.NotNil(t, state.Tip)
+
+	cfg := ImportConfig{
+		Database: db,
+		State:    state,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 500, nil
+		},
+	}
+	ctx := context.Background()
+	progress := func(ImportProgress) {}
+	_, err = importCertState(ctx, cfg, state.Tip.Slot, progress)
+	require.NoError(t, err)
+	require.NoError(t, importSnapShots(
+		ctx,
+		cfg,
+		state.Tip.Slot,
+		progress,
+		false,
+	))
+
+	snapshots, err := ParseSnapShots(state.SnapShotsData)
+	require.NoError(t, err)
+	for _, target := range snapshotImportTargets(state.Epoch, snapshots) {
+		rows, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+			target.targetEpoch,
+			models.PoolStakeSnapshotTypeMark,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, rows, "%s snapshot has no pool rows", target.name)
+
+		epochStart, ok := importedEpochStartSlot(cfg, target.targetEpoch)
+		require.True(t, ok)
+		wantCaptureSlot := uint64(0)
+		if epochStart > 0 {
+			wantCaptureSlot = epochStart - 1
+		}
+		for _, row := range rows {
+			require.Equal(
+				t,
+				wantCaptureSlot,
+				row.CapturedSlot,
+				"%s snapshot must retain its epoch-boundary provenance",
+				target.name,
+			)
+		}
+	}
+}
+
 func TestImportedEpochSummaryUsesCurrentEpochMetadata(t *testing.T) {
 	nonce := []byte{0x01, 0x02, 0x03}
 


### PR DESCRIPTION
Closes #3320.

## Summary

- Preserve certified `NewEpochState.SnapShots` boundary provenance when
  importing the Mark/Set/Go rotation window.
- Use the exact certified import anchor when an epoch boundary cannot be
  resolved, and recognize exact-anchor rows as legacy Dingo-import
  compatibility.
- Keep the conservative bypass only for historical Mark rows reconstructed
  from current live state after their boundary.
- Restore stake-threshold validation for inbound headers in the first complete
  epoch after a mid-epoch Mithril bootstrap.

## Compatibility

This changes no schema or public API. Existing anchor-stamped imports remain
usable; new imports store each Mark row's semantic boundary slot when the
imported era telescope can resolve it.

## Validation

- The regression fails on the broken revision by skipping the threshold and
  now rejects the deliberately ineligible next-epoch header.
- The import regression fails on the broken revision because it stores the
  export tip and now verifies boundary provenance for Mark/Set/Go.
- Relevant race suites, conformance vectors, go vet, golangci-lint, NilAway,
  modernize, golines, govulncheck, and documentation parity pass.
- Accelerated Dingo/cardano-node conformance DevNet passed epoch transition,
  disruption recovery, agreement, and transaction propagation; txpump recorded
  3,844 accepted submissions and no errors.
