### PR TITLE
fix(ledger): reset recovery budget on progress

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3075,18 +3075,21 @@ window deeper every cycle and the node would fall unboundedly behind the wall
 clock, recoverable only by restart. `maxAtTipRecoveryDescents` consecutive
 distinct failures that fail to advance latch recovery into a hold-at-tip mode
 that suppresses deep rewinds — rewinding only to the ledger tip so ChainSync
-re-delivers rather than descending. The latch clears when the ledger makes
-forward progress past the failing region (`resetAtTipRecoveryDescent`, called
-from the block-apply success path). Because a hold usually indicates local
-ledger validation diverging from the network (a false-positive rejection that
-no rewind can fix) rather than a peer/fork problem, it surfaces the
+re-delivers rather than descending. The latch and the same-`(block, tx)` rewind
+depth both clear only when the ledger makes forward progress past the failing
+region (`resetAtTipRecoveryDescent`, called from the post-commit block-apply
+success path); replaying back to the same tip preserves both. Because a hold
+usually indicates local ledger validation diverging from the network (a
+false-positive rejection that no rewind can fix) rather than a peer/fork
+problem, it surfaces the
 `dingo_ledger_attip_recovery_nonconverging_total` metric and a throttled
 operator warning; a node in this state needs the underlying validation
 divergence resolved.
 
 Both recovery paths refuse a rewind target below the Mithril anchor, and that
-refusal has its own terminal bound (issues #3261 and #3301). Refusing rewinds
-instead to the applied ledger tip and asks ChainSync for a fresh intersection,
+refusal has its own terminal bound (issues #3261, #3301, and #3318). A refusal
+rewinds instead to the applied ledger tip and asks ChainSync for a fresh
+intersection,
 which is an escape only while some peer offers a different chain; for a
 canonical block every peer offers the same one. When the failing block sits a
 short distance past the anchor, every target the rewind schedule produces falls

--- a/ledger/pipeline_halt_test.go
+++ b/ledger/pipeline_halt_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -204,4 +205,36 @@ func TestResetMithrilBoundaryRejectionsRequiresAppliedTipProgress(
 		exhausted,
 		"the tally must be exhausted once every legal rewind depth has been refused",
 	)
+}
+
+func TestResetAtTipRecoveryDescentClearsSameFailureOnProgress(
+	t *testing.T,
+) {
+	failure := &txValidationError{
+		BlockPoint: ocommon.NewPoint(510, []byte("failure-block")),
+		TxHash:     []byte("failure-tx"),
+	}
+	ls := &LedgerState{
+		lastAtTipRecovery:         newAtTipRecoveryAttempt(failure),
+		atTipRecoveryLastFailSlot: failure.BlockPoint.Slot,
+		atTipRecoveryDescentCount: 1,
+		atTipRecoveryHolding:      true,
+	}
+	ls.lastAtTipRecovery.Attempts = 2
+	require.Nil(t, ls.mithrilBoundaryRecovery)
+
+	// Replaying to the same applied tip is not progress. Preserve both the
+	// same-failure depth and distinct-failure convergence state.
+	ls.resetAtTipRecoveryDescent(failure.BlockPoint.Slot)
+	require.Equal(t, 2, ls.lastAtTipRecovery.Attempts)
+	require.Equal(t, 1, ls.atTipRecoveryDescentCount)
+	require.True(t, ls.atTipRecoveryHolding)
+
+	// A committed block past the failing region proves recovery converged.
+	// A later at-tip failure must start at the shallow first attempt.
+	ls.resetAtTipRecoveryDescent(failure.BlockPoint.Slot + 1)
+	require.Nil(t, ls.lastAtTipRecovery)
+	require.Zero(t, ls.atTipRecoveryLastFailSlot)
+	require.Zero(t, ls.atTipRecoveryDescentCount)
+	require.False(t, ls.atTipRecoveryHolding)
 }

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -101,7 +101,7 @@ const maxReplayRecoveryNoProgress = 2
 // maxMithrilBoundaryRecoveryRejections bounds how many successful validation
 // recovery attempts may refuse a rewind at the Mithril trust boundary without
 // advancing the applied ledger tip before the failure is declared
-// unrepairable (issues #3261 and #3301).
+// unrepairable (issues #3261, #3301, and #3318).
 //
 // The bound covers the whole legal rewind space. A boundary rejection rewinds
 // to the applied ledger tip -- the deepest point recovery may reach without
@@ -560,9 +560,10 @@ func (ls *LedgerState) rejectReplayRecoveryAtMithrilBoundary(
 // the ledger has made forward progress past the failing region. Called from the
 // block-apply success path when the tip advances beyond the last recorded
 // at-tip failure slot, so a later, unrelated at-tip failure starts with a fresh
-// recovery budget instead of inheriting a stale hold. Runs on the ledger
-// pipeline goroutine, the same goroutine that mutates these fields during
-// recovery, so no additional locking is required.
+// recovery budget instead of inheriting a stale hold or same-failure rewind
+// depth. Same-tip replay preserves both schedules. Runs on the ledger pipeline
+// goroutine, the same goroutine that mutates these fields during recovery, so
+// no additional locking is required.
 func (ls *LedgerState) resetAtTipRecoveryDescent(newTipSlot uint64) {
 	if ls.atTipRecoveryLastFailSlot == 0 {
 		return
@@ -573,6 +574,7 @@ func (ls *LedgerState) resetAtTipRecoveryDescent(newTipSlot uint64) {
 	ls.atTipRecoveryLastFailSlot = 0
 	ls.atTipRecoveryDescentCount = 0
 	ls.atTipRecoveryHolding = false
+	ls.lastAtTipRecovery = nil
 }
 
 func (ls *LedgerState) recoverAtTipFromTxValidationError(
@@ -830,7 +832,8 @@ func (ls *LedgerState) rejectAtTipRecoveryAtMithrilBoundary(
 // The applied tip is the convergence signal rather than the failing block or
 // transaction identity. Replay can encounter different, slowly advancing
 // failures while rebuilding to the same applied tip; rearming the budget on
-// each identity would let that sequence retry forever (issue #3301).
+// each identity would let that sequence retry forever (issues #3301 and
+// #3318).
 //
 // Runs on the ledger pipeline goroutine, like its at-tip and replay siblings,
 // so the tally needs no additional locking. Callers record an attempt only

--- a/ledger/replay_recovery_trust_window_test.go
+++ b/ledger/replay_recovery_trust_window_test.go
@@ -278,11 +278,11 @@ func TestAtTipRecoveryAboveMithrilTrustWindowKeepsRecovering(t *testing.T) {
 }
 
 // TestReplayRecoveryBelowMithrilTrustBoundaryReachesTerminalState covers the
-// post-bootstrap replay path from issue #3301. The producer is canonical but
-// below the imported anchor, so its parent can never be a legal local rewind
-// target. Changing failing block/transaction identities must not rearm the
-// budget while the applied tip remains fixed; replay failures can creep
-// forward in exactly that shape.
+// post-bootstrap replay path from issues #3301 and #3318. The producer is
+// canonical but below the imported anchor, so its parent can never be a legal
+// local rewind target. Changing failing block/transaction identities must not
+// rearm the budget while the applied tip remains fixed; replay failures can
+// creep forward in exactly that shape.
 func TestReplayRecoveryBelowMithrilTrustBoundaryReachesTerminalState(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## Summary

- preserve the tip-keyed Mithril boundary convergence bound already landed through #3297
- clear stale same-failure rewind depth only after committed tip progress while preserving it on same-tip replay
- cover the boundary-nil reset path and document the recovery invariant

## Validation

- focused recovery tests under `-race` (5 repeats), plus a post-format repeat
- SQLite rules conformance under `-race`
- golangci-lint, nilaway, modernize, import boundaries, docs parity, GORM guard, and diff checks

Accelerated DevNet was not rerun because this change only resets in-memory recovery bookkeeping after an already-committed tip advance; the focused race and rules conformance checks cover the affected path.

Closes #3318
