### PR TITLE
fix(peergov): serialize ledger discovery refreshes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3110,12 +3110,14 @@ first place. While the node has fewer chain-selection-eligible upstreams than
 its hot-peer target (`MinHotPeers`), replenishment is treated as urgent: a
 dedicated emergency ticker (default 30s via
 `EmergencyDiscoveryCheckInterval`, far more frequent than the 5-minute
-reconcile) pulls fresh stake-pool relays on a short emergency interval (default
-30s via `EmergencyLedgerPeerRefreshInterval`) instead of the normal hourly
-`LedgerPeerRefreshInterval`, so a run of dead or flaky relays can never wedge
-sync while the ledger still lists plenty of registered relays. Once the node is
-at its hot-peer target the emergency path is a no-op and the normal hourly
-cadence applies.
+reconcile) initially pulls fresh stake-pool relays on a short emergency
+interval (default 30s via `EmergencyLedgerPeerRefreshInterval`) instead of the
+normal hourly `LedgerPeerRefreshInterval`. Persistent completed rounds double
+that interval up to the normal cadence, while recovery resets the next shortage
+to the fast floor. Each provider query and relay-candidate pass is single-flight
+across reconcile and emergency ticks: its generation remains claimed until the
+round completes, errors, is canceled, or panics, so a slow provider cannot
+overlap the next tick or leave an artificial retry delay behind.
 
 Each outbound dial attempt re-resolves a hostname-based peer's address fresh,
 narrows the records to the address families the local host can route to

--- a/peergov/emergency_ledger_discovery_test.go
+++ b/peergov/emergency_ledger_discovery_test.go
@@ -16,15 +16,67 @@ package peergov
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"net"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type countingLedgerPeerProvider struct {
+	calls atomic.Int32
+}
+
+func (p *countingLedgerPeerProvider) GetPoolRelays() ([]PoolRelay, error) {
+	p.calls.Add(1)
+	return nil, nil
+}
+
+func (*countingLedgerPeerProvider) CurrentSlot() uint64 {
+	return 1
+}
+
+type slowLedgerPeerProvider struct {
+	started chan struct{}
+	release <-chan struct{}
+	calls   atomic.Int32
+}
+
+func (p *slowLedgerPeerProvider) GetPoolRelays() ([]PoolRelay, error) {
+	p.calls.Add(1)
+	p.started <- struct{}{}
+	<-p.release
+	return nil, nil
+}
+
+func (*slowLedgerPeerProvider) CurrentSlot() uint64 {
+	return 1
+}
+
+type panicLedgerPeerProvider struct {
+	panicOnCall atomic.Bool
+	calls       atomic.Int32
+}
+
+func (p *panicLedgerPeerProvider) GetPoolRelays() ([]PoolRelay, error) {
+	p.calls.Add(1)
+	if p.panicOnCall.Load() {
+		panic("ledger provider panic")
+	}
+	return nil, nil
+}
+
+func (*panicLedgerPeerProvider) CurrentSlot() uint64 {
+	return 1
+}
 
 // addEligibleUpstreamPeers appends n connected, chain-selection-eligible
 // upstream peers (client connections from a topology source).
@@ -218,4 +270,148 @@ func TestDiscoverLedgerPeers_NoBypassWhenNotUrgent(t *testing.T) {
 		countPeersBySource(pg, PeerSourceP2PLedger),
 		"non-urgent node must respect the refresh interval and add no ledger peers",
 	)
+}
+
+func TestDiscoverLedgerPeers_SlowProviderRemainsSingleFlight(t *testing.T) {
+	release := make(chan struct{})
+	provider := &slowLedgerPeerProvider{
+		started: make(chan struct{}, 2),
+		release: release,
+	}
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger:                             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		UseLedgerAfterSlot:                 0,
+		MinHotPeers:                        2,
+		LedgerPeerTarget:                   1,
+		LedgerPeerProvider:                 provider,
+		EmergencyLedgerPeerRefreshInterval: time.Nanosecond,
+		LedgerPeerRefreshInterval:          4 * time.Minute,
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		pg.discoverLedgerPeers()
+	}()
+	defer func() {
+		testutil.RequireReceive(t, firstDone, time.Second,
+			"first discovery must finish after its provider is released")
+	}()
+	defer close(release)
+
+	testutil.RequireReceive(t, provider.started, time.Second,
+		"first discovery must enter the provider")
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		pg.discoverLedgerPeers()
+	}()
+	testutil.RequireReceive(t, secondDone, time.Second,
+		"a later emergency tick must return while discovery is in flight")
+	require.Equal(t, int32(1), provider.calls.Load(),
+		"a slow provider must not be entered by overlapping discoveries")
+}
+
+func TestDiscoverLedgerPeers_CanceledRefreshReleasesClaimAndDelay(
+	t *testing.T,
+) {
+	provider := &countingLedgerPeerProvider{}
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		UseLedgerAfterSlot:                 0,
+		MinHotPeers:                        2,
+		LedgerPeerTarget:                   1,
+		LedgerPeerProvider:                 provider,
+		EmergencyLedgerPeerRefreshInterval: time.Nanosecond,
+		LedgerPeerRefreshInterval:          4 * time.Minute,
+	})
+	lastRefresh := time.Now().Add(-time.Minute).UnixNano()
+	pg.lastLedgerPeerRefresh.Store(lastRefresh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pg.discoverLedgerPeersContext(ctx)
+	require.Equal(t, int32(0), provider.calls.Load())
+	require.Zero(t, pg.ledgerDiscoveryInFlight.Load())
+	require.Equal(t, lastRefresh, pg.lastLedgerPeerRefresh.Load())
+
+	pg.discoverLedgerPeers()
+	require.Equal(t, int32(1), provider.calls.Load(),
+		"the next discovery must retry immediately after cancellation")
+}
+
+func TestDiscoverLedgerPeers_CanceledSlowProviderReleasesClaimAndDelay(
+	t *testing.T,
+) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProvider := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	defer releaseProvider()
+	provider := &slowLedgerPeerProvider{
+		started: make(chan struct{}, 2),
+		release: release,
+	}
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		UseLedgerAfterSlot:                 0,
+		MinHotPeers:                        2,
+		LedgerPeerTarget:                   1,
+		LedgerPeerProvider:                 provider,
+		EmergencyLedgerPeerRefreshInterval: time.Nanosecond,
+		LedgerPeerRefreshInterval:          4 * time.Minute,
+	})
+	lastRefresh := time.Now().Add(-time.Minute).UnixNano()
+	pg.lastLedgerPeerRefresh.Store(lastRefresh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pg.discoverLedgerPeersContext(ctx)
+	}()
+	testutil.RequireReceive(t, provider.started, time.Second,
+		"discovery must enter the slow provider")
+	cancel()
+	releaseProvider()
+	testutil.RequireReceive(t, done, time.Second,
+		"canceled discovery must finish after its provider returns")
+	require.Equal(t, int32(1), provider.calls.Load())
+	require.Zero(t, pg.ledgerDiscoveryInFlight.Load())
+	require.Equal(t, lastRefresh, pg.lastLedgerPeerRefresh.Load())
+
+	pg.discoverLedgerPeers()
+	require.Equal(t, int32(2), provider.calls.Load(),
+		"the next discovery must retry immediately after cancellation")
+}
+
+func TestDiscoverLedgerPeers_PanickingProviderReleasesClaimAndDelay(
+	t *testing.T,
+) {
+	provider := &panicLedgerPeerProvider{}
+	provider.panicOnCall.Store(true)
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		UseLedgerAfterSlot:                 0,
+		MinHotPeers:                        2,
+		LedgerPeerTarget:                   1,
+		LedgerPeerProvider:                 provider,
+		EmergencyLedgerPeerRefreshInterval: time.Nanosecond,
+		LedgerPeerRefreshInterval:          4 * time.Minute,
+	})
+	lastRefresh := time.Now().Add(-time.Minute).UnixNano()
+	pg.lastLedgerPeerRefresh.Store(lastRefresh)
+
+	func() {
+		defer func() {
+			require.Equal(t, "ledger provider panic", recover())
+		}()
+		pg.discoverLedgerPeers()
+	}()
+	require.Zero(t, pg.ledgerDiscoveryInFlight.Load())
+	require.Equal(t, lastRefresh, pg.lastLedgerPeerRefresh.Load())
+
+	provider.panicOnCall.Store(false)
+	pg.discoverLedgerPeers()
+	require.Equal(t, int32(2), provider.calls.Load(),
+		"the next discovery must retry immediately after a provider panic")
 }

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -99,10 +99,31 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 	if time.Duration(now-lastRefresh) < refreshInterval {
 		return
 	}
-	if !p.lastLedgerPeerRefresh.CompareAndSwap(lastRefresh, now) {
-		// Another goroutine claimed the refresh
+
+	// The timestamp gates when discovery may begin, but a slow provider can
+	// outlive that interval. Hold a separate generation-owned claim across the
+	// provider query and candidate pass so a later tick cannot overlap it.
+	generation := p.ledgerDiscoveryGeneration.Add(1)
+	if !p.ledgerDiscoveryInFlight.CompareAndSwap(0, generation) {
 		return
 	}
+	claimedTimestamp := false
+	completed := false
+	defer func() {
+		if claimedTimestamp && !completed {
+			p.lastLedgerPeerRefresh.CompareAndSwap(now, lastRefresh)
+		}
+		p.ledgerDiscoveryInFlight.CompareAndSwap(generation, 0)
+	}()
+
+	// A prior owner may have completed between the first interval check and
+	// this generation obtaining the claim. Recheck while ownership is held.
+	lastRefresh = p.lastLedgerPeerRefresh.Load()
+	if time.Duration(now-lastRefresh) < refreshInterval ||
+		!p.lastLedgerPeerRefresh.CompareAndSwap(lastRefresh, now) {
+		return
+	}
+	claimedTimestamp = true
 
 	// Get pool relays from ledger
 	if err := ctx.Err(); err != nil {
@@ -115,17 +136,10 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 			"error", err,
 			"emergency", urgent,
 		)
-		// Reset timestamp to allow retry on next reconciliation cycle
-		// rather than waiting for the full refresh interval
-		p.lastLedgerPeerRefresh.Store(lastRefresh)
 		return
 	}
-
-	if urgent {
-		// Counted only once the round is actually going ahead, so a round
-		// suppressed by the interval gate or a failed provider fetch does
-		// not escalate the backoff.
-		p.emergencyRefreshRounds.Add(1)
+	if err := ctx.Err(); err != nil {
+		return
 	}
 
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
@@ -151,6 +165,15 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 			"emergency", urgent,
 		)
 	}
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	if urgent {
+		// Count only a complete urgent round. Interval-gated, failed, canceled,
+		// or panicking rounds retain the existing backoff and retry immediately.
+		p.emergencyRefreshRounds.Add(1)
+	}
+	completed = true
 }
 
 // ledgerPeersUrgent reports whether the node is critically short of connected

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -175,6 +175,11 @@ type PeerGovernor struct {
 	// rounds since the node last had enough upstreams. It drives the
 	// escalating emergency refresh interval and resets on recovery.
 	emergencyRefreshRounds atomic.Uint32
+	// ledgerDiscoveryInFlight holds the generation of the discovery currently
+	// querying or processing ledger relays. Zero means idle. A generation keeps
+	// deferred release ownership explicit across cancellation and panic paths.
+	ledgerDiscoveryInFlight   atomic.Uint64
+	ledgerDiscoveryGeneration atomic.Uint64
 	// negativeDNS caches ledger relay hostnames that failed to resolve,
 	// keyed by lowercased hostname, valued by cache expiry. Guarded by
 	// negativeDNSMu rather than mu: resolution happens outside the peer


### PR DESCRIPTION
## Summary

- serialize ledger-peer discovery across the provider query and candidate pass
- restore the prior schedule after canceled, failed, or panicking refreshes
- cover slow-provider overlap and interrupted refresh retries

## Checks

- `go test -race -count=1 ./peergov`
- `go test -race -count=1 ./internal/test/conformance/...`
- `make lint`
- `make import-boundaries docs-parity gorm-check`

Closes #3319
