### PR TITLE
fix(peergov): permanently deny wrong-network peers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2959,6 +2959,18 @@ trust-boundary reasons) place the peer on the deny list for a cooldown in
 addition to closing the connection, so the node does not redial a peer that
 will deterministically be rejected again moments later.
 
+An outbound handshake refusal that proves the remote address belongs to a
+different Cardano network is denied for the lifetime of the in-memory peer
+governor rather than the ordinary cooldown. The classifier requires the typed
+gouroboros `handshake.RefusedError` and two different `unNetworkMagic` values
+in cardano-node's `version data mismatch` rendering; a same-magic mismatch in
+diffusion mode, peer sharing, or query mode remains transient. The permanent
+keys cover both the configured relay address and its normalized dial address,
+so ledger discovery cannot re-offer the same peer after the timed deny list
+would have expired. The list is not persisted and clears when the governor is
+reconstructed or the node restarts, allowing a corrected relay to be tried in
+a later run.
+
 The per-connection rollback loop detector (`rollbackHistory` in
 `LedgerState`) records recent rollback points per connection and breaks a
 loop if the same point recurs past a threshold within a window. Two rules keep

--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -27,7 +29,44 @@ import (
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol/handshake"
 )
+
+var networkMagicFieldPattern = regexp.MustCompile(
+	`\bunNetworkMagic\s*=\s*([0-9]+)\b`,
+)
+
+// isPermanentNetworkMagicMismatch reports whether err is a typed handshake
+// refusal whose Haskell version-data rendering proves the two peers use
+// different network magic values. Other version-data mismatches remain
+// transient because diffusion mode, peer sharing, and query mode can be
+// negotiated without changing networks.
+func isPermanentNetworkMagicMismatch(err error) bool {
+	var refusedErr *handshake.RefusedError
+	if !errors.As(err, &refusedErr) ||
+		!strings.Contains(
+			strings.ToLower(refusedErr.Message),
+			"version data mismatch",
+		) {
+		return false
+	}
+	matches := networkMagicFieldPattern.FindAllStringSubmatch(
+		refusedErr.Message,
+		-1,
+	)
+	if len(matches) != 2 {
+		return false
+	}
+	left, err := strconv.ParseUint(matches[0][1], 10, 32)
+	if err != nil {
+		return false
+	}
+	right, err := strconv.ParseUint(matches[1][1], 10, 32)
+	if err != nil {
+		return false
+	}
+	return left != right
+}
 
 func isConnectionCancellationError(err error) bool {
 	if err == nil {
@@ -489,6 +528,9 @@ func (p *PeerGovernor) createOutboundConnection(
 			case <-time.After(reconnectDelay):
 			}
 			continue
+		}
+		if p.permanentlyDenyNetworkMagicMismatch(peer, dialTarget, err) {
+			return
 		}
 		failMsg := fmt.Sprintf(
 			"outbound: failed to establish connection to %s: %s",
@@ -1042,6 +1084,9 @@ func (p *PeerGovernor) IsDenied(address string) bool {
 // isDeniedLocked checks if a peer is on the deny list.
 // This method assumes the mutex is already held by the caller.
 func (p *PeerGovernor) isDeniedLocked(address string) bool {
+	if _, exists := p.permanentDenyList[address]; exists {
+		return true
+	}
 	expiry, exists := p.denyList[address]
 	if !exists {
 		return false
@@ -1052,6 +1097,92 @@ func (p *PeerGovernor) isDeniedLocked(address string) bool {
 		return false
 	}
 	return true
+}
+
+// permanentlyDenyNetworkMagicMismatch records an address-scoped denial for a
+// peer that proved it belongs to another Cardano network. The denial is held
+// only in PeerGovernor memory and therefore clears when the node restarts.
+func (p *PeerGovernor) permanentlyDenyNetworkMagicMismatch(
+	peer *Peer,
+	dialTarget string,
+	err error,
+) bool {
+	if !isPermanentNetworkMagicMismatch(err) {
+		return false
+	}
+
+	p.mu.Lock()
+	if p.permanentDenyList == nil {
+		p.permanentDenyList = make(map[string]struct{})
+	}
+	// The peer can be removed or replaced while its dial and handshake run.
+	// Record the immutable attempt identity first so that a stale completion
+	// still suppresses rediscovery of the proven wrong-network address.
+	p.addPermanentPeerDenyKeysLocked(
+		peer,
+		connmanager.NormalizePeerAddr(dialTarget),
+		p.normalizeAddress(dialTarget),
+	)
+	peerAddress := dialTarget
+	peerSource := PeerSource(PeerSourceUnknown)
+	if peer != nil {
+		peerAddress = peer.Address
+		peerSource = peer.Source
+	}
+	peerIdx := -1
+	if peer != nil {
+		peerIdx = p.peerIndexByAddress(peer.NormalizedAddress)
+	}
+	removed := false
+	if peerIdx != -1 && p.peers[peerIdx] != nil {
+		currentPeer := p.peers[peerIdx]
+		p.addPermanentPeerDenyKeysLocked(currentPeer)
+		peerAddress = currentPeer.Address
+		peerSource = currentPeer.Source
+		removed = dropIfNeverConnected(peerSource)
+		if removed {
+			p.peers = append(p.peers[:peerIdx], p.peers[peerIdx+1:]...)
+			p.updatePeerMetrics()
+		}
+	}
+	p.mu.Unlock()
+
+	p.config.Logger.Info(
+		"outbound: permanently denying peer on a different Cardano network",
+		"address", peerAddress,
+		"source", peerSource.String(),
+		"error", err,
+	)
+	if removed {
+		p.publishEvent(
+			PeerRemovedEventType,
+			PeerStateChangeEvent{
+				Address: peerAddress,
+				Reason:  "network magic mismatch",
+			},
+		)
+	}
+	return true
+}
+
+func (p *PeerGovernor) addPermanentPeerDenyKeysLocked(
+	peer *Peer,
+	addresses ...string,
+) {
+	for _, address := range addresses {
+		if address != "" {
+			p.permanentDenyList[address] = struct{}{}
+		}
+	}
+	if peer == nil {
+		return
+	}
+	if peer.NormalizedAddress != "" {
+		p.permanentDenyList[peer.NormalizedAddress] = struct{}{}
+	}
+	if peer.Address != "" {
+		p.permanentDenyList[p.normalizeAddress(peer.Address)] = struct{}{}
+	}
 }
 
 func (p *PeerGovernor) peerIndexByConnectionRemoteAddressLocked(

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol/handshake"
 )
 
 func TestIsExpectedConnectionCloseError(t *testing.T) {
@@ -240,6 +241,224 @@ func TestIsExpectedNetworkDialError(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsPermanentNetworkMagicMismatch(t *testing.T) {
+	mismatchMessage := "version data mismatch: " +
+		"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+		"{unNetworkMagic = 764824073}, diffusionMode = InitiatorOnlyDiffusionMode} " +
+		"/= NodeToNodeVersionData {networkMagic = NetworkMagic " +
+		"{unNetworkMagic = 2}, diffusionMode = InitiatorAndResponderDiffusionMode}"
+	sameMagicMessage := "version data mismatch: " +
+		"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+		"{unNetworkMagic = 2}, peerSharing = PeerSharingDisabled} " +
+		"/= NodeToNodeVersionData {networkMagic = NetworkMagic " +
+		"{unNetworkMagic = 2}, peerSharing = PeerSharingEnabled}"
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "wrapped typed refusal with different magic",
+			err: fmt.Errorf(
+				"outbound handshake: %w",
+				&handshake.RefusedError{Version: 13, Message: mismatchMessage},
+			),
+			want: true,
+		},
+		{
+			name: "same magic version data mismatch",
+			err:  &handshake.RefusedError{Version: 13, Message: sameMagicMessage},
+			want: false,
+		},
+		{
+			name: "untyped lookalike",
+			err:  errors.New(mismatchMessage),
+			want: false,
+		},
+		{
+			name: "sanitized refusal without both values",
+			err: &handshake.RefusedError{
+				Version: 13,
+				Message: "network magic mismatch",
+			},
+			want: false,
+		},
+		{
+			name: "other refusal containing two magic fields",
+			err: &handshake.RefusedError{
+				Version: 13,
+				Message: strings.Replace(
+					mismatchMessage,
+					"version data mismatch",
+					"connection not allowed",
+					1,
+				),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPermanentNetworkMagicMismatch(tc.err); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPermanentNetworkMagicMismatchDenialSuppressesRediscoveryUntilRestart(
+	t *testing.T,
+) {
+	const address = "44.0.0.10:3001"
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	pg := NewPeerGovernor(PeerGovernorConfig{Logger: logger})
+	peer := &Peer{
+		Address:           address,
+		NormalizedAddress: address,
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateCold,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	err := &handshake.RefusedError{
+		Version: 13,
+		Message: "version data mismatch: " +
+			"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+			"{unNetworkMagic = 764824073}} /= " +
+			"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+			"{unNetworkMagic = 2}}",
+	}
+	if !pg.permanentlyDenyNetworkMagicMismatch(peer, address, err) {
+		t.Fatal("different-network refusal was not handled as permanent")
+	}
+
+	pg.mu.Lock()
+	pg.denyList[address] = time.Now().Add(-time.Minute)
+	pg.cleanupDenyList()
+	deniedAfterTransientExpiry := pg.isDeniedLocked(address)
+	peerCount := len(pg.peers)
+	pg.mu.Unlock()
+	if !deniedAfterTransientExpiry {
+		t.Fatal("permanent denial expired with the transient deny list")
+	}
+	if peerCount != 0 {
+		t.Fatalf("ledger peer count = %d, want 0 after permanent denial", peerCount)
+	}
+
+	if pg.addLedgerPeer(address) {
+		t.Fatal("ledger discovery reported adding permanently denied peer")
+	}
+	pg.mu.Lock()
+	peerCount = len(pg.peers)
+	pg.mu.Unlock()
+	if peerCount != 0 {
+		t.Fatalf("ledger rediscovery re-added permanently denied peer")
+	}
+
+	restarted := NewPeerGovernor(PeerGovernorConfig{Logger: logger})
+	if !restarted.addLedgerPeer(address) {
+		t.Fatal("ledger discovery did not add peer after restart")
+	}
+	restarted.mu.Lock()
+	restartedPeerCount := len(restarted.peers)
+	restarted.mu.Unlock()
+	if restartedPeerCount != 1 {
+		t.Fatalf(
+			"peer count after restart = %d, want 1",
+			restartedPeerCount,
+		)
+	}
+}
+
+func TestPermanentNetworkMagicMismatchDeniesPeerRemovedDuringHandshake(
+	t *testing.T,
+) {
+	const (
+		configuredAddress = "relay.invalid:3001"
+		dialAddress       = "44.0.0.12:3001"
+	)
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	stalePeer := &Peer{
+		Address:           configuredAddress,
+		NormalizedAddress: dialAddress,
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateCold,
+	}
+	// Model removal while CreateOutboundConn is still completing its handshake.
+	pg.mu.Lock()
+	pg.peers = nil
+	pg.mu.Unlock()
+
+	err := &handshake.RefusedError{
+		Version: 13,
+		Message: "version data mismatch: " +
+			"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+			"{unNetworkMagic = 1}} /= " +
+			"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+			"{unNetworkMagic = 2}}",
+	}
+	if !pg.permanentlyDenyNetworkMagicMismatch(stalePeer, dialAddress, err) {
+		t.Fatal("different-network refusal was not handled as permanent")
+	}
+
+	pg.mu.Lock()
+	_, configuredDenied := pg.permanentDenyList[configuredAddress]
+	_, normalizedDenied := pg.permanentDenyList[dialAddress]
+	pg.mu.Unlock()
+	if !configuredDenied || !normalizedDenied {
+		t.Fatalf(
+			"stale refusal keys: configured=%v normalized=%v, want both true",
+			configuredDenied,
+			normalizedDenied,
+		)
+	}
+	if pg.addLedgerPeer(dialAddress) {
+		t.Fatal("ledger discovery re-added peer removed during its handshake")
+	}
+}
+
+func TestSameMagicVersionDataMismatchRemainsTransient(t *testing.T) {
+	const address = "44.0.0.11:3001"
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	peer := &Peer{
+		Address:           address,
+		NormalizedAddress: address,
+		Source:            PeerSourceP2PLedger,
+		State:             PeerStateCold,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+	err := &handshake.RefusedError{
+		Version: 13,
+		Message: "version data mismatch: " +
+			"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+			"{unNetworkMagic = 2}, peerSharing = PeerSharingDisabled} /= " +
+			"NodeToNodeVersionData {networkMagic = NetworkMagic " +
+			"{unNetworkMagic = 2}, peerSharing = PeerSharingEnabled}",
+	}
+	if pg.permanentlyDenyNetworkMagicMismatch(peer, address, err) {
+		t.Fatal("same-magic negotiation mismatch was treated as permanent")
+	}
+	pg.mu.Lock()
+	_, permanentlyDenied := pg.permanentDenyList[address]
+	peerCount := len(pg.peers)
+	pg.mu.Unlock()
+	if permanentlyDenied {
+		t.Fatal("same-magic mismatch populated permanent deny list")
+	}
+	if peerCount != 1 {
+		t.Fatalf("same-magic mismatch removed peer, count = %d", peerCount)
 	}
 }
 

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -145,6 +145,7 @@ type PeerGovernor struct {
 	ctx                   context.Context      // Context for cancellation
 	cancel                context.CancelFunc   // Cancels the context owned by Start
 	denyList              map[string]time.Time // address -> expiry time
+	permanentDenyList     map[string]struct{}  // address -> process-lifetime denial
 	peers                 []*Peer
 	config                PeerGovernorConfig
 	lastLedgerPeerRefresh atomic.Int64        // UnixNano timestamp of last ledger peer discovery
@@ -415,10 +416,11 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 	}
 	cfg.Logger = cfg.Logger.With("component", "peergov")
 	p := &PeerGovernor{
-		config:           cfg,
-		peers:            []*Peer{},
-		denyList:         make(map[string]time.Time),
-		ledgerKnownAddrs: make(map[string]struct{}),
+		config:            cfg,
+		peers:             []*Peer{},
+		denyList:          make(map[string]time.Time),
+		permanentDenyList: make(map[string]struct{}),
+		ledgerKnownAddrs:  make(map[string]struct{}),
 	}
 	if cfg.PromRegistry != nil {
 		p.initMetrics()


### PR DESCRIPTION
## Summary

- recognize typed handshake refusals that report two different network magic values
- deny both configured and normalized dial addresses for the lifetime of the in-memory peer governor
- suppress ledger rediscovery after the transient deny window while allowing corrected relays after restart
- keep same-magic diffusion, peer-sharing, and query mismatches on the normal transient retry path

## Validation

- fail-before controls reproduced both repeated rediscovery and the removed-during-handshake race
- focused network-magic regressions passed 10 race-enabled repetitions
- full peergov race suite and conformance vectors passed
- repository lint, vet, docs parity, ORM guard, and diff checks passed
- accelerated DevNet was not rerun because its fixed container names are occupied by an unrelated preserved run; those containers were not touched

## Merge

Closes #3315
