### PR TITLE
fix(ledgerstate): support 100M UTxO maps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4039,16 +4039,19 @@ that. That cap does NOT extend to manual header-reading APIs
 (`DecodeMapHeader`, `NewStreamDecoder` combined with manual iteration): those
 read a raw count/byte off the wire with no built-in bound from the decoder
 itself, so every such call site enforces its own explicit check.
-`ledgerstate`'s hand-rolled map/array walkers (`decodeMapEntries`) and the
-UTxO-map streaming decoder enforce the same 10,000,000-entry cap
-independently — the definite-length UTxO map's `DecodeMapHeader`-reported
-count is checked up front (`checkUTxOMapEntryCount`), and the
-indefinite-length UTxO map, which has no header count to check up front, is
-capped with an equivalent running check against every streamed entry
-(`checkUTxOMapRunningEntryCount`). Because there is no upfront count, entries
-below the cap are already streamed to the UTxO import batch callback (and
-therefore committed to the database) by the time the running check rejects
-entry `maxMapEntries`+1 — this is safe rather than a partial-import bug:
+`ledgerstate`'s hand-rolled map/array walkers (`decodeMapEntries`) retain the
+generic 10,000,000-entry cap. The streaming UTxO decoder instead has an
+explicit 100,000,000-entry cap because a valid chain UTxO set can exceed the
+generic map limit; the larger bound still limits work on malformed or
+adversarial input. The definite-length UTxO map's
+`DecodeMapHeader`-reported count is checked up front
+(`checkUTxOMapEntryCount`), and the indefinite-length UTxO map, which has no
+header count to check up front, is capped with an equivalent running check
+against every streamed entry (`checkUTxOMapRunningEntryCount`). Because there
+is no upfront count, entries below the cap are already streamed to the UTxO
+import batch callback (and therefore committed to the database) by the time
+the running check rejects entry `maxUTxOMapEntries`+1 — this is safe rather
+than a partial-import bug:
 every UTxO write is an idempotent "insert if absent" upsert, and
 `ImportLedgerState` never marks the UTxO import phase checkpoint or advances
 the chain tip when this check fails, so a later re-run (checkpoint-resumed or

--- a/ledgerstate/cbor_decode.go
+++ b/ledgerstate/cbor_decode.go
@@ -49,14 +49,16 @@ import (
 //     maxMapEntries (10,000,000 entries, matching gouroboros's map
 //     limit above) for both definite- and indefinite-length maps.
 //   - parseUTxOsStreamingWithProgress (UTxO map streaming decode):
-//     for the definite-length map, the DecodeMapHeader-reported
-//     count is checked against the same maxMapEntries cap
-//     (checkUTxOMapEntryCount) before entries are streamed, so a
-//     corrupted or adversarial header cannot drive an unbounded
-//     loop. The indefinite-length map has no header count to check
-//     up front, so parseIndefiniteUTxOMapWithProgress instead
-//     enforces the same cap as a running check
-//     (checkUTxOMapRunningEntryCount) against every streamed entry.
+//     UTxO maps have their own maxUTxOMapEntries (100,000,000) cap
+//     because valid chain state can exceed the generic 10,000,000-map
+//     limit. For the definite-length map, the DecodeMapHeader-reported
+//     count is checked against that cap (checkUTxOMapEntryCount)
+//     before entries are streamed, so a corrupted or adversarial
+//     header cannot drive an unbounded loop. The indefinite-length
+//     map has no header count to check up front, so
+//     parseIndefiniteUTxOMapWithProgress instead enforces the UTxO cap
+//     as a running check (checkUTxOMapRunningEntryCount) against every
+//     streamed entry.
 //     Unlike the definite-length path, the running check can only
 //     reject after entries below the cap have already been streamed
 //     to importUTxOs's batch callback and committed to the database.
@@ -87,9 +89,9 @@ import (
 //     traversal): recursion capped at MaxTelescopeDepth (16); real
 //     data has at most 7 Cardano eras (Byron through Conway).
 //
-// If any of these limits is ever raised, update this comment and
-// DATABASE.md's CBOR/offset encoding notes together, and extend the
-// regression tests in cbor_decode_test.go to cover the new boundary.
+// If any of these limits is ever raised, update this comment and the
+// corresponding architecture policy, and extend the regression tests in
+// cbor_decode_test.go to cover the new boundary.
 
 // decodeRawArray decodes a CBOR array, returning elements as raw
 // byte slices. Each element's raw CBOR is preserved for deferred

--- a/ledgerstate/cbor_decode_test.go
+++ b/ledgerstate/cbor_decode_test.go
@@ -28,7 +28,7 @@ import (
 // this package, it proves the limit is accepted exactly at the
 // boundary and rejected one past it, using synthetic fixtures rather
 // than mainnet-scale data (which would be impractical to check in or
-// generate at test time for a 10,000,000-entry cap).
+// generate at test time for production-scale caps).
 
 // mustEncodeCbor encodes v and fails the test on error.
 func mustEncodeCbor(t *testing.T, v any) []byte {
@@ -148,7 +148,7 @@ func TestDecodeMapEntriesLimit_IndefiniteLength_OverLimitRejected(
 // TestDecodeMapEntries_ProductionLimitIsExplicit locks the documented
 // production cap. If this constant is ever changed, this test forces
 // an update to both this test and the "Local CBOR decode limits
-// policy" doc comment (and DATABASE.md, per CLAUDE.md doc parity).
+// policy" doc comment.
 func TestDecodeMapEntries_ProductionLimitIsExplicit(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, 10_000_000, maxMapEntries)
@@ -168,23 +168,23 @@ func TestDecodeMapEntries_ProductionCapRejectsOversizedHeader(t *testing.T) {
 	require.Contains(t, err.Error(), "exceeds max (10000000)")
 }
 
-func TestCheckUTxOMapEntryCount(t *testing.T) {
+func TestCheckUTxOMapEntryCountSupportsHundredMillion(t *testing.T) {
 	t.Parallel()
 
 	require.NoError(t, checkUTxOMapEntryCount(0))
-	require.NoError(t, checkUTxOMapEntryCount(maxMapEntries))
+	require.NoError(t, checkUTxOMapEntryCount(100_000_000))
 
-	err := checkUTxOMapEntryCount(maxMapEntries + 1)
+	err := checkUTxOMapEntryCount(100_000_001)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "exceeds max")
+	require.Contains(t, err.Error(), "exceeds max (100000000)")
 }
 
 func TestParseUTxOsStreaming_RejectsOversizedMapHeader(t *testing.T) {
 	t.Parallel()
-	// Header-only fixture claiming one more than maxMapEntries; the
+	// Header-only fixture claiming one more than the UTxO-specific cap; the
 	// new checkUTxOMapEntryCount guard must reject it before the
 	// streaming loop (and therefore the callback) ever runs.
-	header := cborTypeHeader(cborMajorMap, uint64(maxMapEntries+1))
+	header := cborTypeHeader(cborMajorMap, 100_000_001)
 	callbackInvoked := false
 
 	_, err := ParseUTxOsStreaming(

--- a/ledgerstate/utxo.go
+++ b/ledgerstate/utxo.go
@@ -34,16 +34,21 @@ import (
 // PaymentKeyHash/StakeKeyHash returned a meaningful credential.
 var zeroBlake2b224 ledger.Blake2b224
 
+// maxUTxOMapEntries is separate from the generic maxMapEntries limit because
+// the valid chain UTxO set can be much larger than other ledger-state maps.
+// The explicit cap still bounds work on a malformed or adversarial stream.
+const maxUTxOMapEntries = 100_000_000
+
 // checkUTxOMapEntryCount validates a definite-length UTxO map's
-// declared entry count against maxMapEntries before any entries are
-// streamed. See "Local CBOR decode limits policy" in
-// cbor_decode.go for why this cap exists and matches the one used
-// by decodeMapEntries.
+// declared entry count against maxUTxOMapEntries before any entries
+// are streamed. See "Local CBOR decode limits policy" in
+// cbor_decode.go for why UTxO streaming has a larger cap than
+// decodeMapEntries.
 func checkUTxOMapEntryCount(count int) error {
-	if count > maxMapEntries {
+	if count > maxUTxOMapEntries {
 		return fmt.Errorf(
 			"UTxO map claims %d entries, exceeds max (%d)",
-			count, maxMapEntries,
+			count, maxUTxOMapEntries,
 		)
 	}
 	return nil
@@ -54,7 +59,7 @@ func checkUTxOMapEntryCount(count int) error {
 // (unlike the definite-length case checked up front by
 // checkUTxOMapEntryCount) has no declared header count to validate
 // before entries are read. Production code always calls this via
-// parseIndefiniteUTxOMapWithProgress with limit=maxMapEntries; tests
+// parseIndefiniteUTxOMapWithProgress with limit=maxUTxOMapEntries; tests
 // call parseIndefiniteUTxOMapWithProgressLimit directly with a small
 // limit to prove the boundary check accepts exactly `limit` entries
 // and rejects entry `limit`+1 without streaming a mainnet-scale
@@ -84,7 +89,7 @@ func checkUTxOMapRunningEntryCount(entryIndex, limit int) error {
 				"the import checkpoint and chain tip were not "+
 				"advanced, so the database is not left in a usable "+
 				"state — this indicates the map is corrupted or "+
-				"genuinely exceeds the configured cap and needs "+
+				"genuinely exceeds the production cap and needs "+
 				"investigation, not a bare retry",
 			limit,
 		)
@@ -358,8 +363,8 @@ func parseUTxOsStreamingWithProgress(
 	// The map header count comes straight off the wire and is not
 	// otherwise bounds-checked by DecodeMapHeader (unlike a full
 	// cbor.Decode of a map, which is capped internally). Enforce the
-	// same maxMapEntries cap used by decodeMapEntries so a corrupted
-	// or adversarial header can't drive an unbounded loop below.
+	// UTxO-specific cap so a corrupted or adversarial header can't
+	// drive an unbounded loop below.
 	if err := checkUTxOMapEntryCount(count); err != nil {
 		return 0, err
 	}
@@ -734,7 +739,7 @@ func parseUTxOsFromMapped(
 // indefinite-length CBOR map (0xbf ... 0xff). Each entry is a
 // TxIn key and TxOut value decoded using the existing parsers.
 // An optional progress callback receives byte-level progress. The
-// entry count is capped at maxMapEntries; see
+// entry count is capped at maxUTxOMapEntries; see
 // checkUTxOMapRunningEntryCount for why indefinite-length maps need
 // a running check rather than an upfront header check.
 func parseIndefiniteUTxOMapWithProgress(
@@ -743,14 +748,14 @@ func parseIndefiniteUTxOMapWithProgress(
 	progress func(UTxOParseProgress),
 ) (int, error) {
 	return parseIndefiniteUTxOMapWithProgressLimit(
-		data, callback, progress, maxMapEntries,
+		data, callback, progress, maxUTxOMapEntries,
 	)
 }
 
 // parseIndefiniteUTxOMapWithProgressLimit is
 // parseIndefiniteUTxOMapWithProgress parameterized by the maximum
 // allowed entry count. Production code always calls it via
-// parseIndefiniteUTxOMapWithProgress with limit=maxMapEntries; tests
+// parseIndefiniteUTxOMapWithProgress with limit=maxUTxOMapEntries; tests
 // call it directly with a small limit to exercise the boundary
 // check without streaming a mainnet-scale fixture.
 func parseIndefiniteUTxOMapWithProgressLimit(


### PR DESCRIPTION
Fixes #3347.

## Summary

- give streamed ledger-state UTxO maps a dedicated 100,000,000-entry cap
- keep generic manually decoded CBOR maps capped at 10,000,000 entries
- preserve bounded definite/indefinite parsing and duplicate-safe retry behavior
- document the split decode-limit policy in `ARCHITECTURE.md`

## Validation

- regression test fails semantically before the fix and passes after it
- `go test -tags dingo_extra_plugins -race -timeout=20m -count=1 ./ledgerstate`
- `go test -tags dingo_extra_plugins -race -count=1 -timeout=20m ./internal/test/conformance/...`
- `go build -buildvcs=false -tags dingo_extra_plugins ./...`
- `golangci-lint run --allow-parallel-runners ./...`
- `nilaway -tags dingo_extra_plugins ./...`
- `modernize -tags dingo_extra_plugins ./ledgerstate`
- `make docs-parity`
- `make import-boundaries`
- `make gorm-check`
- `govulncheck -tags dingo_extra_plugins ./...`

## Documentation

`ARCHITECTURE.md` now documents the UTxO-specific cap. `DATABASE.md` was checked and is unaffected because no schema, persisted format, key layout, or storage behavior changes.

DevNet was not run because this changes ancillary ledger-state import cardinality, not consensus, block production, or networking behavior.
