### PR TITLE
fix(devnet): restore txpump cooldown cadence

### DIFF
--- a/internal/test/devnet/config_test.go
+++ b/internal/test/devnet/config_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -137,6 +138,41 @@ func TestScriptsAndComposeAgreeOnSpecFiles(t *testing.T) {
 		"start.sh and run-tests.sh must select the same accelerated specs;"+
 			" if they drift, the harness and the running network resolve"+
 			" different timings")
+}
+
+// TestComposeTxPumpCooldownUsesMilliseconds keeps the DevNet load profile in
+// agreement with txpump's millisecond-valued configuration contract and the
+// 5-15 second cadence documented in README.md. A value copied as seconds
+// makes txpump open a fresh NtC connection and submit 10-50 transactions every
+// 5-15 milliseconds. That saturates the mempool and can starve the persistent
+// ChainSync observers which drive the accelerated scenario.
+func TestComposeTxPumpCooldownUsesMilliseconds(t *testing.T) {
+	compose, err := os.ReadFile("docker-compose.yml")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{name: "MIN", want: 5_000},
+		{name: "MAX", want: 15_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			re := regexp.MustCompile(
+				`TXPUMP_COOLDOWN_` + tc.name + `:\s*"(\d+)"`,
+			)
+			matches := re.FindAllStringSubmatch(string(compose), -1)
+			require.Len(t, matches, 2,
+				"both DevNet profiles must configure the txpump cooldown")
+			for _, match := range matches {
+				got, parseErr := strconv.Atoi(match[1])
+				require.NoError(t, parseErr)
+				require.Equal(t, tc.want, got,
+					"txpump cooldown values are milliseconds; the DevNet"+
+						" profile documents a 5-15 second cadence")
+			}
+		})
+	}
 }
 
 func TestLoadDevNetConfigFromMissingFile(t *testing.T) {

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -245,8 +245,10 @@ services:
       TXPUMP_NETWORK_MAGIC: "42"
       TXPUMP_TX_COUNT_MIN: "10"
       TXPUMP_TX_COUNT_MAX: "50"
-      TXPUMP_COOLDOWN_MIN: "5"
-      TXPUMP_COOLDOWN_MAX: "15"
+      # txpump interprets cooldowns as milliseconds. Keep this at the
+      # 5-15 second cadence documented in README.md.
+      TXPUMP_COOLDOWN_MIN: "5000"
+      TXPUMP_COOLDOWN_MAX: "15000"
       TXPUMP_TYPES: "payment"
       TXPUMP_LOG_DIR: "/logs"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
@@ -370,8 +372,10 @@ services:
       TXPUMP_NETWORK_MAGIC: "42"
       TXPUMP_TX_COUNT_MIN: "10"
       TXPUMP_TX_COUNT_MAX: "50"
-      TXPUMP_COOLDOWN_MIN: "5"
-      TXPUMP_COOLDOWN_MAX: "15"
+      # txpump interprets cooldowns as milliseconds. Keep this at the
+      # 5-15 second cadence documented in README.md.
+      TXPUMP_COOLDOWN_MIN: "5000"
+      TXPUMP_COOLDOWN_MAX: "15000"
       TXPUMP_TYPES: "payment"
       TXPUMP_LOG_DIR: "/logs"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"


### PR DESCRIPTION
## Summary

- correct both DevNet txpump profiles from a 5-15 ms loop to the documented 5-15 second cadence
- add a regression guard for txpump's millisecond-valued Compose boundary
- retain regular transaction traffic without the connection churn and mempool saturation behind the intermittent observer stall

## Validation

The full race-enabled Dingo suite, repository lint, and both Compose profile validations pass. A fresh accelerated DevNet was unavailable because preserved fixed-name conformance containers occupy the required Compose names; those external containers were not changed.

Closes #3333.
