### PR TITLE
test(ledger): synchronize terminal resync observer

### DIFF
--- a/ledger/replay_recovery_trust_window_test.go
+++ b/ledger/replay_recovery_trust_window_test.go
@@ -42,7 +42,7 @@ type trustWindowLedger struct {
 	ls        *LedgerState
 	ledgerTip ochainsync.Tip
 	failing   *txValidationError
-	resyncs   chan event.ChainsyncResyncEvent
+	resyncs   <-chan event.Event
 }
 
 // newTrustWindowLedger builds the shape of issue #3261: the applied ledger tip
@@ -83,20 +83,15 @@ func newTrustWindowLedger(
 
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(bus.Stop)
-	resyncs := make(chan event.ChainsyncResyncEvent, 64)
-	subId := bus.SubscribeFunc(
+	// Observe the bus-owned subscriber channel directly. Publish hands an
+	// event to this channel before it returns, so draining after a recovery
+	// attempt cannot race a SubscribeFunc dispatch goroutine that has not yet
+	// copied an already-published resync into a second test-only channel.
+	subId, resyncs := bus.SubscribeWithBuffer(
 		event.ChainsyncResyncEventType,
-		func(evt event.Event) {
-			resync, ok := evt.Data.(event.ChainsyncResyncEvent)
-			if !ok {
-				return
-			}
-			select {
-			case resyncs <- resync:
-			default:
-			}
-		},
+		64,
 	)
+	require.NotZero(t, subId)
 	t.Cleanup(func() {
 		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
 	})


### PR DESCRIPTION
## Summary

- observe trust-window recovery resyncs through the event bus's buffered subscriber channel
- remove the extra asynchronous callback copy that could deliver an older resync after the terminal-state drain
- keep the strict no-resync-after-halt assertion without sleeps or a relaxed count

## Validation

- controlled fail-before: gating the old callback copy delivered 5 prior resyncs after the terminal transition and failed the unchanged zero-resync assertion
- `go test -tags dingo_extra_plugins -race -run '^TestAtTipRecoveryInsideMithrilTrustWindowReachesTerminalState$' -count=100 ./ledger`
- `go test -tags dingo_extra_plugins -race -timeout 20m -count=1 ./ledger`
- `make lint`
- `make docs-parity`
- `make import-boundaries`
- `make gorm-check`

Closes #3348
