### PR TITLE
fix(connmanager): preserve occupied socket paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2785,6 +2785,13 @@ The `ConnectionManager` (`connmanager/connection_manager.go`) handles connection
     -------------------------------------------------
 ```
 
+Before binding a filesystem-backed Unix listener, the connection manager uses
+non-following metadata and a local connection probe to distinguish a stale
+socket from a live listener. It removes only a socket that refuses the probe
+and still has the same file identity when rechecked. Regular files, symlinks,
+directories, live sockets, ambiguous probe failures, and removal errors all
+fail startup without removing the path.
+
 ### Multi-Client Chainsync
 
 The `chainsync.State` tracks multiple concurrent chainsync clients:

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/blinklabs-io/dingo/event"
@@ -29,9 +30,10 @@ import (
 
 // Accept loop backoff constants
 const (
-	acceptBackoffMin = 10 * time.Millisecond // Initial backoff duration
-	acceptBackoffMax = 1 * time.Second       // Maximum backoff duration
-	acceptBackoffCap = 6                     // Max consecutive errors before capping (2^6 * 10ms = 640ms)
+	acceptBackoffMin       = 10 * time.Millisecond // Initial backoff duration
+	acceptBackoffMax       = 1 * time.Second       // Maximum backoff duration
+	acceptBackoffCap       = 6                     // Max consecutive errors before capping (2^6 * 10ms = 640ms)
+	unixSocketProbeTimeout = 250 * time.Millisecond
 )
 
 type ListenerConfig struct {
@@ -48,6 +50,68 @@ func (c *ConnectionManager) startListeners(ctx context.Context) error {
 		if err := c.startListener(ctx, l); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func prepareUnixSocketPath(path string) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to check socket file %s: %w", path, err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf(
+			"listen address %s exists and is not a unix socket",
+			path,
+		)
+	}
+
+	conn, dialErr := net.DialTimeout("unix", path, unixSocketProbeTimeout)
+	if dialErr == nil {
+		_ = conn.Close()
+		return fmt.Errorf(
+			"listen address %s is already in use by a live unix socket",
+			path,
+		)
+	}
+	if errors.Is(dialErr, os.ErrNotExist) {
+		// The path disappeared after Lstat. There is nothing left to remove;
+		// the subsequent bind remains authoritative.
+		return nil
+	}
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return fmt.Errorf(
+			"failed to determine whether unix socket %s is stale: %w",
+			path,
+			dialErr,
+		)
+	}
+
+	// Re-read non-following metadata after the failed connection attempt. A
+	// replacement at the path must never inherit the stale verdict from the
+	// socket that was probed.
+	currentFi, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to recheck socket file %s: %w", path, err)
+	}
+	if currentFi.Mode()&os.ModeSocket == 0 || !os.SameFile(fi, currentFi) {
+		return fmt.Errorf(
+			"listen address %s changed while checking for a stale unix socket",
+			path,
+		)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf(
+			"failed to remove existing socket file %s: %w",
+			path,
+			err,
+		)
 	}
 	return nil
 }
@@ -77,28 +141,11 @@ func (c *ConnectionManager) startListener(
 			}
 			l.Listener = listener
 		} else {
-			// For Unix domain sockets, remove any stale socket file before binding
+			// For Unix domain sockets, remove only a confirmed stale socket file
+			// before binding.
 			if l.ListenNetwork == "unix" {
-				if fi, err := os.Lstat(l.ListenAddress); err == nil {
-					if fi.Mode()&os.ModeSocket == 0 {
-						return fmt.Errorf(
-							"listen address %s exists and is not a unix socket",
-							l.ListenAddress,
-						)
-					}
-					if err := os.Remove(l.ListenAddress); err != nil {
-						return fmt.Errorf(
-							"failed to remove existing socket file %s: %w",
-							l.ListenAddress,
-							err,
-						)
-					}
-				} else if !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf(
-						"failed to check socket file %s: %w",
-						l.ListenAddress,
-						err,
-					)
+				if err := prepareUnixSocketPath(l.ListenAddress); err != nil {
+					return err
 				}
 			}
 			listenConfig := net.ListenConfig{}

--- a/connmanager/listener_unix_test.go
+++ b/connmanager/listener_unix_test.go
@@ -156,6 +156,8 @@ func TestStartListener_UnixSocket_ErrorOnNonSocketFile(t *testing.T) {
 		"Start should fail when socket path is a non-socket file",
 	)
 	assert.Contains(t, err.Error(), "exists and is not a unix socket")
+	_, statErr := os.Lstat(socketPath)
+	require.NoError(t, statErr, "regular file should not be removed")
 }
 
 // TestStartListener_UnixSocket_ErrorOnDirectory verifies that an error is
@@ -182,4 +184,121 @@ func TestStartListener_UnixSocket_ErrorOnDirectory(t *testing.T) {
 	err := cm.Start(ctx)
 	require.Error(t, err, "Start should fail when socket path is a directory")
 	assert.Contains(t, err.Error(), "exists and is not a unix socket")
+	fi, statErr := os.Lstat(socketPath)
+	require.NoError(t, statErr, "directory should not be removed")
+	assert.True(t, fi.IsDir())
+}
+
+// TestStartListener_UnixSocket_ErrorOnSymlink verifies that socket-path
+// inspection does not follow symlinks, even when the link target is itself a
+// Unix socket.
+func TestStartListener_UnixSocket_ErrorOnSymlink(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	tempDir := unixTestTempDir(t)
+	targetPath := filepath.Join(tempDir, "target.sock")
+	staleLn, err := net.Listen("unix", targetPath)
+	require.NoError(t, err)
+	staleLn.(*net.UnixListener).SetUnlinkOnClose(false)
+	require.NoError(t, staleLn.Close())
+
+	socketPath := filepath.Join(tempDir, "link.sock")
+	require.NoError(t, os.Symlink(targetPath, socketPath))
+
+	cfg := ConnectionManagerConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry: prometheus.NewRegistry(),
+		Listeners: []ListenerConfig{
+			{
+				ListenNetwork: "unix",
+				ListenAddress: socketPath,
+			},
+		},
+	}
+
+	cm := NewConnectionManager(cfg)
+	err = cm.Start(context.Background())
+	require.Error(t, err, "Start should fail when socket path is a symlink")
+	assert.Contains(t, err.Error(), "exists and is not a unix socket")
+	fi, statErr := os.Lstat(socketPath)
+	require.NoError(t, statErr, "symlink should not be removed")
+	assert.NotZero(t, fi.Mode()&os.ModeSymlink)
+	targetInfo, statErr := os.Lstat(targetPath)
+	require.NoError(t, statErr, "symlink target should not be removed")
+	assert.NotZero(t, targetInfo.Mode()&os.ModeSocket)
+}
+
+// TestStartListener_UnixSocket_ErrorOnLiveSocket verifies that startup does
+// not unlink and replace a socket owned by a running process.
+func TestStartListener_UnixSocket_ErrorOnLiveSocket(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	socketPath := filepath.Join(unixTestTempDir(t), "live.sock")
+	liveLn, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, liveLn.Close()) })
+
+	cfg := ConnectionManagerConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry: prometheus.NewRegistry(),
+		Listeners: []ListenerConfig{
+			{
+				ListenNetwork: "unix",
+				ListenAddress: socketPath,
+			},
+		},
+	}
+
+	cm := NewConnectionManager(cfg)
+	err = cm.Start(context.Background())
+	if err == nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		require.NoError(t, cm.Stop(stopCtx))
+	}
+	require.Error(t, err, "Start should fail when socket path is live")
+	assert.Contains(t, err.Error(), "live unix socket")
+
+	conn, dialErr := net.DialTimeout("unix", socketPath, time.Second)
+	require.NoError(t, dialErr, "incumbent live socket should remain reachable")
+	require.NoError(t, conn.Close())
+}
+
+// TestStartListener_UnixSocket_PropagatesRemovalError verifies that a stale
+// socket is not treated as successfully removed when the parent directory
+// denies unlinking it.
+func TestStartListener_UnixSocket_PropagatesRemovalError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can unlink from a non-writable directory")
+	}
+	defer goleak.VerifyNone(t)
+
+	tempDir := unixTestTempDir(t)
+	socketPath := filepath.Join(tempDir, "stale.sock")
+	staleLn, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	staleLn.(*net.UnixListener).SetUnlinkOnClose(false)
+	require.NoError(t, staleLn.Close())
+
+	require.NoError(t, os.Chmod(tempDir, 0o500))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(tempDir, 0o700)) })
+
+	cfg := ConnectionManagerConfig{
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry: prometheus.NewRegistry(),
+		Listeners: []ListenerConfig{
+			{
+				ListenNetwork: "unix",
+				ListenAddress: socketPath,
+			},
+		},
+	}
+
+	cm := NewConnectionManager(cfg)
+	err = cm.Start(context.Background())
+	require.Error(t, err, "Start should propagate stale-socket removal errors")
+	assert.Contains(t, err.Error(), "failed to remove existing socket file")
+	require.NoError(t, os.Chmod(tempDir, 0o700))
+	_, statErr := os.Lstat(socketPath)
+	require.NoError(t, statErr, "socket should remain when removal fails")
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -21,9 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/pprof"
-	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -155,12 +153,6 @@ func Run(cfg *config.Config, logger *slog.Logger) error {
 		fmt.Sprintf("topology: %+v", config.GetTopologyConfig()),
 		"component", "node",
 	)
-	// TODO: make this safer, check PID, create parent, etc. (#276)
-	if runtime.GOOS != "windows" {
-		if _, err := os.Stat(cfg.SocketPath); err == nil {
-			os.Remove(cfg.SocketPath)
-		}
-	}
 	// Derive default config path from cfg.Network when cfg.CardanoConfig is empty
 	cardanoConfigPath := cfg.CardanoConfig
 	network := cfg.Network

--- a/internal/node/node_unix_test.go
+++ b/internal/node/node_unix_test.go
@@ -1,0 +1,103 @@
+//go:build !windows
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunDoesNotPreRemoveSocketPath verifies that Run leaves socket-path
+// handling to the connection manager at bind time. In particular, unrelated
+// startup validation must not delete an existing filesystem entry first.
+func TestRunDoesNotPreRemoveSocketPath(t *testing.T) {
+	testCases := []struct {
+		name   string
+		create func(*testing.T, string)
+	}{
+		{
+			name: "regular file",
+			create: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte("keep"), 0o600))
+			},
+		},
+		{
+			name: "symlink",
+			create: func(t *testing.T, path string) {
+				t.Helper()
+				target := path + ".target"
+				require.NoError(t, os.WriteFile(target, []byte("keep"), 0o600))
+				require.NoError(t, os.Symlink(target, path))
+			},
+		},
+		{
+			name: "directory",
+			create: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.Mkdir(path, 0o700))
+			},
+		},
+		{
+			name: "live socket",
+			create: func(t *testing.T, path string) {
+				t.Helper()
+				listener, err := net.Listen("unix", path)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, listener.Close()) })
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "dn*")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, os.RemoveAll(tempDir)) })
+
+			socketPath := filepath.Join(tempDir, "existing")
+			testCase.create(t, socketPath)
+
+			cfg := &config.Config{
+				SocketPath: socketPath,
+				CardanoConfig: filepath.Join(
+					tempDir,
+					"missing-config.json",
+				),
+				Network: "missing",
+			}
+			err = Run(
+				cfg,
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+			)
+			require.Error(t, err, "missing Cardano config should fail startup")
+			_, statErr := os.Lstat(socketPath)
+			require.NoError(
+				t,
+				statErr,
+				"Run should not remove the configured socket path before binding",
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- move Unix socket-path cleanup to the connection manager immediately before bind
- reject non-socket, live, ambiguous, and replaced paths while removing only confirmed stale sockets
- preserve removal errors and cover startup path types

Closes #3289