### PR TITLE
build: make Dockerfile pass BuildKit checks

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           fetch-depth: '0'
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.2.0
+      - name: check
+        run: docker build --check .
       - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0 https://github.com/docker/metadata-action/releases/tag/v6.2.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN apt-get update -y && \
     postgresql-client-16 \
     sqlite3 && \
   rm -rf /var/lib/apt/lists/*
-ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
 COPY --from=build /code/dingo /bin/
 COPY --from=cardano-cli /usr/local/bin/cardano-cli /usr/local/bin/
 COPY --from=cardano-cli /usr/local/include/ /usr/local/include/


### PR DESCRIPTION
## Summary

Fix the Dockerfile's undefined environment variable expansions and add BuildKit static validation to Docker CI.

## Changes

### `Dockerfile`

- Define `LD_LIBRARY_PATH` as `/usr/local/lib`.
- Define `PKG_CONFIG_PATH` as `/usr/local/lib/pkgconfig`.
- Remove expansions of the previously undefined variables.

### `.github/workflows/ci-docker.yml`

- Run `docker build --check .` before building the Docker image.
- Fail CI when BuildKit detects Dockerfile problems.

Closes #3307

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes BuildKit Dockerfile checks and enforces them in CI. Previously the `Dockerfile` expanded undefined variables; now it sets `LD_LIBRARY_PATH=/usr/local/lib` and `PKG_CONFIG_PATH=/usr/local/lib/pkgconfig`, and the workflow runs `docker build --check .` to fail early.

- Only `ENV` values changed; image content and runtime behavior should be unchanged.
- `.github/workflows/ci-docker.yml` now runs `docker build --check .` before the build; failures block the image build.

<sup>Written for commit 3e4b58d952edcd81dccb27f95ae6ecc6143b129f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime library and package discovery by using the intended `/usr/local` paths.

* **Chores**
  * Added Dockerfile validation to the continuous integration workflow before image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->