### PR TITLE
docs(leios): correct peer vote diffusion description

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1164,7 +1164,7 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `forging.slot_battle` | SlotTracker | Competing blocks at same slot |
 | `leios.eb_quorum` | Leios VoteManager | Endorser block reached stake quorum; certificate built (consumed by the Leios PipelineManager for inclusion eligibility) |
 | `leios.vote_emitted` | Leios VoteManager | Locally signed prototype vote ready for node wiring to enqueue on each peer's LeiosNotify stream |
-| `leios.vote_received` | Leios VoteManager | Newly accepted prototype vote from a peer, re-queued for node wiring to enqueue on each *other* peer's LeiosNotify stream so a relay forwards it instead of stopping it at the connection that delivered it (issue #3288) |
+| `leios.vote_received` | Leios VoteManager | Newly accepted prototype vote from a peer, re-queued for node wiring to enqueue on each peer's LeiosNotify stream so a relay forwards it instead of stopping it at the connection that delivered it (issue #3288) |
 | `peergov.outbound_conn` | PeerGov | Outbound connection initiated |
 | `peergov.peer_demoted` | PeerGov | Peer demoted |
 | `peergov.peer_promoted` | PeerGov | Peer promoted |


### PR DESCRIPTION
## Summary

Correct the Leios vote-relay documentation to match the implemented diffusion behavior.

Received votes are appended to a shared diffusion log read by every peer, including the peer that originally sent the vote. The resulting one-hop echo terminates because the receiving node rejects the vote as a duplicate.

Final leftover part of #3370 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Leios vote-relay docs to match the implemented diffusion behavior. Previously we documented `leios.vote_received` as re-queued to each other peer; now we state it is re-queued to each peer, including the sender, producing a one-hop echo that terminates via duplicate rejection.

<sup>Written for commit a2a66eddb2af775652b2991da9bcca8fad3c357f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

