### PR TITLE
fix(ledger): preserve reward withdrawal balances

### DIFF
--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -115,6 +115,290 @@ func TestSharedSQLStoreWithdrawalWitnessGate(t *testing.T) {
 	}
 }
 
+func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
+	t.Parallel()
+	store, raw := newSharedSQLStore(t)
+	stakeKey := bytes.Repeat([]byte{0xc1}, lcommon.AddressHashSize)
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		StakingKey: stakeKey,
+		Reward:     1234,
+		Active:     true,
+	}))
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeKey,
+	)
+	require.NoError(t, err)
+	transactionHash := lcommon.Blake2b256{0xd1}
+	transaction := &mockTransaction{
+		hash:        transactionHash,
+		isValid:     true,
+		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(1235)},
+	}
+	err = store.SetTransaction(
+		transaction,
+		ocommon.Point{Slot: 10, Hash: bytes.Repeat([]byte{0xd2}, 32)},
+		0,
+		nil,
+		false,
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "reward withdrawal amount 1235 exceeds")
+
+	account, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), uint64(account.Reward))
+	var deltas int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM account_reward_delta",
+	).Scan(&deltas))
+	require.Zero(t, deltas)
+	var witnesses int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM account_withdrawal_witness",
+	).Scan(&witnesses))
+	require.Zero(t, witnesses)
+	stored, err := store.GetTransactionByHash(transactionHash.Bytes(), nil)
+	require.NoError(t, err)
+	require.Nil(t, stored)
+	excessiveHash := lcommon.Blake2b256{0xd3}
+	excessive := &mockTransaction{
+		hash:        excessiveHash,
+		isValid:     true,
+		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(1236)},
+	}
+	err = store.SetTransaction(
+		excessive,
+		ocommon.Point{Slot: 11, Hash: bytes.Repeat([]byte{0xd4}, 32)},
+		0,
+		nil,
+		true,
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "reward withdrawal amount 1236 exceeds")
+	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), uint64(account.Reward))
+}
+
+func TestSharedSQLStoreWithdrawalCredentialTagsRemainDistinct(t *testing.T) {
+	t.Parallel()
+	store, _ := newSharedSQLStore(t)
+	stakeKey := bytes.Repeat([]byte{0xe1}, lcommon.AddressHashSize)
+	for _, tag := range []uint8{0, 1} {
+		require.NoError(t, store.CreateAccount(nil, &models.Account{
+			StakingKey:    stakeKey,
+			CredentialTag: tag,
+			Reward:        17,
+			Active:        true,
+		}))
+	}
+	for i, tag := range []uint8{0, 1} {
+		addressType := uint8(lcommon.AddressTypeNoneKey)
+		if tag == 1 {
+			addressType = lcommon.AddressTypeNoneScript
+		}
+		address, err := lcommon.NewAddressFromParts(
+			addressType,
+			lcommon.AddressNetworkTestnet,
+			nil,
+			stakeKey,
+		)
+		require.NoError(t, err)
+		hash := lcommon.Blake2b256{byte(0xe2 + i)}
+		transaction := &mockTransaction{
+			hash:        hash,
+			isValid:     true,
+			withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(17)},
+		}
+		require.NoError(t, store.SetTransaction(
+			transaction,
+			ocommon.Point{Slot: uint64(20 + i), Hash: bytes.Repeat([]byte{byte(0xe4 + i)}, 32)},
+			0,
+			nil,
+			true,
+			nil,
+		))
+	}
+	for tag := uint8(0); tag < 2; tag++ {
+		account, err := store.GetAccountByCredential(tag, stakeKey, true, nil)
+		require.NoError(t, err)
+		require.Zero(t, account.Reward)
+	}
+}
+
+func TestSharedSQLStoreWithdrawalAllowsPartialBalance(t *testing.T) {
+	t.Parallel()
+	store, raw := newSharedSQLStore(t)
+	stakeKey := bytes.Repeat([]byte{0xf1}, lcommon.AddressHashSize)
+	require.NoError(t, store.CreateAccount(nil, &models.Account{
+		StakingKey: stakeKey,
+		Reward:     1234,
+		Active:     true,
+	}))
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeKey,
+	)
+	require.NoError(t, err)
+	zero := &mockTransaction{
+		hash:        lcommon.Blake2b256{0xf0},
+		isValid:     true,
+		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(0)},
+	}
+	require.NoError(t, store.SetTransaction(
+		zero,
+		ocommon.Point{Slot: 20, Hash: bytes.Repeat([]byte{0xf6}, 32)},
+		0,
+		nil,
+		true,
+		nil,
+	))
+	account, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), uint64(account.Reward))
+	transactionHash := lcommon.Blake2b256{0xf2}
+	transaction := &mockTransaction{
+		hash:        transactionHash,
+		isValid:     true,
+		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(234)},
+	}
+	point := ocommon.Point{Slot: 30, Hash: bytes.Repeat([]byte{0xf3}, 32)}
+	require.NoError(t, store.SetTransaction(
+		transaction, point, 0, nil, true, nil,
+	))
+	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), uint64(account.Reward))
+
+	// Replaying the same transaction must not debit the remaining balance again.
+	require.NoError(t, store.SetTransaction(
+		transaction, point, 0, nil, true, nil,
+	))
+	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), uint64(account.Reward))
+
+	excessive := &mockTransaction{
+		hash:        lcommon.Blake2b256{0xf4},
+		isValid:     true,
+		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(1001)},
+	}
+	err = store.SetTransaction(
+		excessive,
+		ocommon.Point{Slot: 31, Hash: bytes.Repeat([]byte{0xf5}, 32)},
+		0,
+		nil,
+		true,
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "exceeds account balance 1000")
+	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), uint64(account.Reward))
+
+	// Rollback restores the pre-withdrawal balance from the journal.
+	require.NoError(t, store.DeleteAccountRewardsAfterSlot(29, nil))
+	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), uint64(account.Reward))
+	var deltas int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM account_reward_delta",
+	).Scan(&deltas))
+	require.Zero(t, deltas)
+}
+
+func TestSharedSQLStoreZeroWithdrawalValidatesAccountAndBalance(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		reward     uint64
+		active     bool
+		create     bool
+		wantError  string
+		wantReward uint64
+	}{
+		{
+			name:       "registered nonzero balance",
+			reward:     12,
+			active:     true,
+			create:     true,
+			wantReward: 12,
+		},
+		{
+			name:       "registered zero balance",
+			active:     true,
+			create:     true,
+			wantReward: 0,
+		},
+		{
+			name:      "missing account",
+			wantError: "account not found",
+		},
+		{
+			name:       "inactive account",
+			reward:     12,
+			create:     true,
+			wantError:  "account not found",
+			wantReward: 12,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, _ := newSharedSQLStore(t)
+			stakeKey := bytes.Repeat([]byte{0xf7}, lcommon.AddressHashSize)
+			if tc.create {
+				require.NoError(t, store.CreateAccount(nil, &models.Account{
+					StakingKey: stakeKey,
+					Reward:     types.Uint64(tc.reward),
+					Active:     tc.active,
+				}))
+			}
+			address, err := lcommon.NewAddressFromParts(
+				lcommon.AddressTypeNoneKey,
+				lcommon.AddressNetworkTestnet,
+				nil,
+				stakeKey,
+			)
+			require.NoError(t, err)
+			transaction := &mockTransaction{
+				hash:        lcommon.Blake2b256{0xf8},
+				isValid:     true,
+				withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(0)},
+			}
+			err = store.SetTransaction(
+				transaction,
+				ocommon.Point{Slot: 40, Hash: bytes.Repeat([]byte{0xf9}, 32)},
+				0,
+				nil,
+				true,
+				nil,
+			)
+			if tc.wantError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+			if !tc.create {
+				return
+			}
+			account, accountErr := store.GetAccountByCredential(
+				0, stakeKey, true, nil,
+			)
+			require.NoError(t, accountErr)
+			require.Equal(t, tc.wantReward, uint64(account.Reward))
+		})
+	}
+}
+
 type certificateWriteState struct {
 	CertificateCount int
 	UnlinkedCount    int

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -778,9 +778,6 @@ ON CONFLICT (tx_hash, credential_tag, staking_key) DO NOTHING`,
 				return err
 			}
 		}
-		if amount.Sign() == 0 {
-			continue
-		}
 		var accountID uint
 		var reward sql.NullString
 		err := db.QueryRowContext(ctx, `
@@ -815,8 +812,20 @@ SELECT EXISTS (
 		if err != nil {
 			return err
 		}
+		if amount.Uint64() > previous {
+			return fmt.Errorf(
+				"reward withdrawal amount %s exceeds account balance %d",
+				amount.String(),
+				previous,
+			)
+		}
+		if amount.Sign() == 0 {
+			continue
+		}
+		rewardAfter := previous - amount.Uint64()
 		if _, err := db.ExecContext(ctx, `
-UPDATE account SET reward = '0' WHERE id = ?`,
+UPDATE account SET reward = ? WHERE id = ?`,
+			strconv.FormatUint(rewardAfter, 10),
 			accountID,
 		); err != nil {
 			return err

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -393,12 +393,33 @@ func (lv *LedgerView) IsRewardAccountRegistered(
 }
 
 // RewardAccountBalance returns the current reward balance for a stake credential.
-// TODO: implement reward account balance retrieval. Requires per-account reward
-// balance tracking which is not yet stored in the database.
+// Missing and inactive reward accounts are represented by a nil balance, as
+// required by the gouroboros reward-state contract. A registered account with
+// a zero balance returns a non-nil pointer to zero.
 func (lv *LedgerView) RewardAccountBalance(
 	cred lcommon.Credential,
 ) (*uint64, error) {
-	return nil, ErrNotImplemented
+	credentialTag, err := models.CredentialTagFromUint(cred.CredType)
+	if err != nil {
+		return nil, err
+	}
+	account, err := lv.ls.db.GetAccountByCredential(
+		credentialTag,
+		cred.Credential[:],
+		false,
+		lv.txn,
+	)
+	if errors.Is(err, models.ErrAccountNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if account == nil {
+		return nil, nil
+	}
+	balance := uint64(account.Reward)
+	return &balance, nil
 }
 
 // CostModels returns which Plutus language versions have cost

--- a/ledger/view_test.go
+++ b/ledger/view_test.go
@@ -15,9 +15,16 @@
 package ledger
 
 import (
+	"bytes"
+	"io"
+	"log/slog"
 	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -51,14 +58,85 @@ func TestLedgerViewUnimplementedMethodsReturnSentinelError(t *testing.T) {
 	err = lv.UpdateAdaPots(lcommon.AdaPots{})
 	require.ErrorIs(t, err, ErrNotImplemented)
 
-	balance, err := lv.RewardAccountBalance(lcommon.Credential{})
-	require.ErrorIs(t, err, ErrNotImplemented)
-	require.Nil(t, balance)
-
 	treasury, err := lv.TreasuryValue()
 	require.ErrorIs(t, err, ErrNotImplemented)
 	require.Zero(t, treasury)
 }
+
+func TestLedgerViewRewardAccountBalance(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	key := bytes.Repeat([]byte{0xa1}, lcommon.AddressHashSize)
+	for _, tag := range []uint8{0, 1} {
+		require.NoError(t, db.CreateAccount(nil, &models.Account{
+			StakingKey:    key,
+			CredentialTag: tag,
+			Reward:        types.Uint64(100 + uint64(tag)),
+			Active:        true,
+		}))
+	}
+	inactive := bytes.Repeat([]byte{0xa2}, lcommon.AddressHashSize)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: inactive,
+		Reward:     55,
+		Active:     false,
+	}))
+	lv := &LedgerView{
+		ls: &LedgerState{
+			db: db,
+			config: LedgerStateConfig{
+				Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			},
+		},
+	}
+	credential := func(tag uint, value []byte) lcommon.Credential {
+		return lcommon.Credential{
+			CredType:   tag,
+			Credential: lcommon.NewBlake2b224(value),
+		}
+	}
+	for _, tc := range []struct {
+		name string
+		cred lcommon.Credential
+		want *uint64
+	}{
+		{name: "key credential", cred: credential(0, key), want: ptrUint64(100)},
+		{name: "script credential", cred: credential(1, key), want: ptrUint64(101)},
+		{name: "missing credential", cred: credential(0, bytes.Repeat([]byte{0xa3}, 28))},
+		{name: "inactive credential", cred: credential(0, inactive)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := lv.RewardAccountBalance(tc.cred)
+			require.NoError(t, err)
+			if tc.want == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, *tc.want, *got)
+		})
+	}
+	zero := bytes.Repeat([]byte{0xa4}, lcommon.AddressHashSize)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: zero,
+		Reward:     0,
+		Active:     true,
+	}))
+	got, err := lv.RewardAccountBalance(credential(0, zero))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Zero(t, *got)
+
+	_, err = lv.RewardAccountBalance(lcommon.Credential{CredType: 2})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unsupported stake credential tag")
+
+	require.NoError(t, dbtest.CloseDatabase(db))
+	_, err = lv.RewardAccountBalance(credential(0, key))
+	require.Error(t, err)
+}
+
+func ptrUint64(value uint64) *uint64 { return &value }
 
 func TestLedgerViewSkipPhase2Validation(t *testing.T) {
 	lv := &LedgerView{}


### PR DESCRIPTION
## Summary

- Expose active reward-account balances to ledger validation using full credential identity.
- Reject storage-layer withdrawals above the prior balance and subtract the declared amount.
- Preserve zero-withdrawal validation, idempotent replay, and reward rollback behavior.

## Validation

- `GOWORK=off go test -race ./ledger -run '^TestLedgerViewRewardAccountBalance$'`
- `GOWORK=off go test -race ./database/plugin/metadata/sqlite -run '^(TestSharedSQLStoreWithdrawal.*|TestSharedSQLStoreZeroWithdrawal.*)$'`
- `git diff --check`

Fixes #3379
