### PR TITLE
test(devnet): make user mapping assertion portable

### DIFF
--- a/internal/test/devnet/run_tests_script_test.go
+++ b/internal/test/devnet/run_tests_script_test.go
@@ -88,16 +88,6 @@ const fakeGoScript = `#!/usr/bin/env bash
 exit "${FAKE_GO_EXIT}"
 `
 
-const fakeIDScript = `#!/usr/bin/env bash
-set -euo pipefail
-
-case "${1:-}" in
-  -u) printf '1234\n' ;;
-  -g) printf '5678\n' ;;
-  *) exit 2 ;;
-esac
-`
-
 const failingRmScript = `#!/usr/bin/env bash
 exit 42
 `
@@ -133,6 +123,8 @@ func TestRunTestsKeepUpPreservesSuccess(t *testing.T) {
 }
 
 func TestRunTestsCleansContainerCreatedTemporaryFiles(t *testing.T) {
+	wantUserMapping := bashUserMapping(t)
+
 	for _, test := range []struct {
 		name              string
 		testExit          int
@@ -145,7 +137,7 @@ func TestRunTestsCleansContainerCreatedTemporaryFiles(t *testing.T) {
 			result := runFakeDevnet(t, test.testExit, false)
 			assert.Equal(t, test.testExit, result.exitCode, result.output)
 			assert.Contains(t, result.dockerLog,
-				"run --rm --user 1234:5678",
+				"run --rm --user "+wantUserMapping,
 				"stake-key copy did not use the host uid:gid")
 			assert.Empty(t, result.stakeDirs,
 				"runner left its stake-key temp tree behind\n%s", result.output)
@@ -180,7 +172,6 @@ func runFakeDevnet(
 	require.NoError(t, os.Mkdir(fakeBin, 0o700))
 	writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerScript)
 	writeExecutable(t, filepath.Join(fakeBin, "go"), fakeGoScript)
-	writeExecutable(t, filepath.Join(fakeBin, "id"), fakeIDScript)
 	if failRm {
 		writeExecutable(t, filepath.Join(fakeBin, "rm"), failingRmScript)
 	}
@@ -231,6 +222,14 @@ func runFakeDevnet(
 		stakeDirs:    stakeDirs,
 		artifactDirs: artifactDirs,
 	}
+}
+
+func bashUserMapping(t *testing.T) string {
+	t.Helper()
+	cmd := exec.Command("bash", "-c", `printf '%s:%s' "$(id -u)" "$(id -g)"`)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return string(output)
 }
 
 func cleanRunnerEnv(overrides map[string]string) []string {

--- a/internal/test/devnet/run_tests_script_test.go
+++ b/internal/test/devnet/run_tests_script_test.go
@@ -88,6 +88,16 @@ const fakeGoScript = `#!/usr/bin/env bash
 exit "${FAKE_GO_EXIT}"
 `
 
+const fakeIDScript = `#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  -u) printf '1234\n' ;;
+  -g) printf '5678\n' ;;
+  *) exit 2 ;;
+esac
+`
+
 const failingRmScript = `#!/usr/bin/env bash
 exit 42
 `
@@ -134,9 +144,9 @@ func TestRunTestsCleansContainerCreatedTemporaryFiles(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result := runFakeDevnet(t, test.testExit, false)
 			assert.Equal(t, test.testExit, result.exitCode, result.output)
-			assert.Contains(t, result.dockerLog, fmt.Sprintf(
-				"run --rm --user %d:%d", os.Getuid(), os.Getgid(),
-			), "stake-key copy did not use the host uid:gid")
+			assert.Contains(t, result.dockerLog,
+				"run --rm --user 1234:5678",
+				"stake-key copy did not use the host uid:gid")
 			assert.Empty(t, result.stakeDirs,
 				"runner left its stake-key temp tree behind\n%s", result.output)
 			assert.Len(t, result.artifactDirs, test.wantArtifactCount,
@@ -170,6 +180,7 @@ func runFakeDevnet(
 	require.NoError(t, os.Mkdir(fakeBin, 0o700))
 	writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerScript)
 	writeExecutable(t, filepath.Join(fakeBin, "go"), fakeGoScript)
+	writeExecutable(t, filepath.Join(fakeBin, "id"), fakeIDScript)
 	if failRm {
 		writeExecutable(t, filepath.Join(fakeBin, "rm"), failingRmScript)
 	}


### PR DESCRIPTION
Go reports `-1` for UID/GID on Windows, while Git Bash reports MSYS IDs. The DevNet script constructs Docker's user mapping from Bash's `id` builtin.

Derive the test expectation from the same Bash environment that runs the script. This keeps the cleanup assertion portable across Linux, macOS, and Windows.