### PR TITLE
test: satisfy reward coverage static analysis

### DIFF
--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -60,6 +60,23 @@ type transactionWriteState struct {
 	Outputs          int
 }
 
+func requireTransactionWriteAccount(
+	t *testing.T,
+	store transactionWriteStore,
+	credentialTag uint8,
+	stakingKey []byte,
+) *models.Account {
+	t.Helper()
+	account, err := store.GetAccountByCredential(
+		credentialTag, stakingKey, true, nil,
+	)
+	require.NoError(t, err)
+	if account == nil {
+		t.Fatal("account lookup returned nil without an error")
+	}
+	return account
+}
+
 func TestSharedSQLStoreTransactionWriteParity(t *testing.T) {
 	t.Parallel()
 	store, raw := newSharedSQLStore(t)
@@ -148,8 +165,7 @@ func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "reward withdrawal amount 1235 exceeds")
 
-	account, err := store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account := requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1234), uint64(account.Reward))
 	var deltas int
 	require.NoError(t, raw.QueryRow(
@@ -180,8 +196,7 @@ func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "reward withdrawal amount 1236 exceeds")
-	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1234), uint64(account.Reward))
 }
 
@@ -224,9 +239,8 @@ func TestSharedSQLStoreWithdrawalCredentialTagsRemainDistinct(t *testing.T) {
 			nil,
 		))
 	}
-	for tag := uint8(0); tag < 2; tag++ {
-		account, err := store.GetAccountByCredential(tag, stakeKey, true, nil)
-		require.NoError(t, err)
+	for tag := range uint8(2) {
+		account := requireTransactionWriteAccount(t, store, tag, stakeKey)
 		require.Zero(t, account.Reward)
 	}
 }
@@ -260,8 +274,7 @@ func TestSharedSQLStoreWithdrawalAllowsPartialBalance(t *testing.T) {
 		true,
 		nil,
 	))
-	account, err := store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account := requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1234), uint64(account.Reward))
 	transactionHash := lcommon.Blake2b256{0xf2}
 	transaction := &mockTransaction{
@@ -273,16 +286,14 @@ func TestSharedSQLStoreWithdrawalAllowsPartialBalance(t *testing.T) {
 	require.NoError(t, store.SetTransaction(
 		transaction, point, 0, nil, true, nil,
 	))
-	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1000), uint64(account.Reward))
 
 	// Replaying the same transaction must not debit the remaining balance again.
 	require.NoError(t, store.SetTransaction(
 		transaction, point, 0, nil, true, nil,
 	))
-	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1000), uint64(account.Reward))
 
 	excessive := &mockTransaction{
@@ -300,14 +311,12 @@ func TestSharedSQLStoreWithdrawalAllowsPartialBalance(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "exceeds account balance 1000")
-	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1000), uint64(account.Reward))
 
 	// Rollback restores the pre-withdrawal balance from the journal.
 	require.NoError(t, store.DeleteAccountRewardsAfterSlot(29, nil))
-	account, err = store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
+	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1234), uint64(account.Reward))
 	var deltas int
 	require.NoError(t, raw.QueryRow(
@@ -390,10 +399,7 @@ func TestSharedSQLStoreZeroWithdrawalValidatesAccountAndBalance(t *testing.T) {
 			if !tc.create {
 				return
 			}
-			account, accountErr := store.GetAccountByCredential(
-				0, stakeKey, true, nil,
-			)
-			require.NoError(t, accountErr)
+			account := requireTransactionWriteAccount(t, store, 0, stakeKey)
 			require.Equal(t, tc.wantReward, uint64(account.Reward))
 		})
 	}
@@ -701,9 +707,7 @@ func exerciseTransactionWriteStore(
 	produced, err := store.GetUtxo(transactionHash.Bytes(), 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, produced)
-	account, err := store.GetAccountByCredential(0, stakeKey, true, nil)
-	require.NoError(t, err)
-	require.NotNil(t, account)
+	account := requireTransactionWriteAccount(t, store, 0, stakeKey)
 	deltas, witnesses := counts()
 	return transactionWriteState{
 		Slot:             stored.Slot,

--- a/ledger/view_test.go
+++ b/ledger/view_test.go
@@ -100,8 +100,8 @@ func TestLedgerViewRewardAccountBalance(t *testing.T) {
 		cred lcommon.Credential
 		want *uint64
 	}{
-		{name: "key credential", cred: credential(0, key), want: ptrUint64(100)},
-		{name: "script credential", cred: credential(1, key), want: ptrUint64(101)},
+		{name: "key credential", cred: credential(0, key), want: new(uint64(100))},
+		{name: "script credential", cred: credential(1, key), want: new(uint64(101))},
 		{name: "missing credential", cred: credential(0, bytes.Repeat([]byte{0xa3}, 28))},
 		{name: "inactive credential", cred: credential(0, inactive)},
 	} {
@@ -135,8 +135,6 @@ func TestLedgerViewRewardAccountBalance(t *testing.T) {
 	_, err = lv.RewardAccountBalance(credential(0, key))
 	require.Error(t, err)
 }
-
-func ptrUint64(value uint64) *uint64 { return &value }
 
 func TestLedgerViewSkipPhase2Validation(t *testing.T) {
 	lv := &LedgerView{}


### PR DESCRIPTION
## Problem

The repository pre-commit lint target fails on current `main`:

- NilAway cannot prove that withdrawal parity account lookups are non-nil before reward dereferences.
- `modernize` rejects the reward pointer helper and the credential-tag counting loop.

## Change

- Centralize transaction-write account assertions in a helper with an explicit fatal nil guard.
- Use `new(expr)` for expected reward pointers.
- Range directly over the credential-tag count.

## Validation

- Reproduced the NilAway and `modernize` failures on `main` before the change.
- Race-enabled reward-balance and SQLite withdrawal/transaction parity tests.
- Golangci-lint, NilAway, and `modernize` pass after the change.
- `make import-boundaries`, `make docs-parity`, `make gorm-check`, and `make golines`.

`DATABASE.md` and `ARCHITECTURE.md` were checked; this test-only static-analysis repair does not change either contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes static-analysis failures in reward/withdrawal parity tests. Previously tests assumed non-nil accounts before reward dereference; now they assert and fail fast on nil, satisfying NilAway and modernize rules without changing runtime behavior.

- Centralizes account lookup with requireTransactionWriteAccount(...): calls GetAccountByCredential, asserts no error, and fatals if nil; replaces repeated lookup+require patterns across tests.
- Replaces ptrUint64 helper with new(uint64(...)) in reward balance expectations.
- Iterates credential tags using range over the count to satisfy the loop modernize rule.
- Tests-only change; no production logic or schema changes.

<sup>Written for commit b9c661e2cf44017ae9c85b6aee93e47958e317e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

