### PR TITLE
fix(ledger): return AVVM value to reserves

### DIFF
--- a/ledger/avvm_removal.go
+++ b/ledger/avvm_removal.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -27,9 +28,9 @@ import (
 // Allegra/Translation.hs:returnRedeemAddrsToReserves to the dingo
 // ledger. At the Shelley→Allegra boundary every live UTxO at a Byron
 // redeem (AVVM) address must leave the active UTxO set; its lovelace
-// is conceptually returned to reserves (full reserves accounting is
-// tracked separately and is out of scope here — we log the reclaimed
-// total instead).
+// is returned to reserves by the hard-fork rule. This helper classifies
+// and marks the rows and returns the reclaimed total so the caller can
+// update NetworkState atomically.
 //
 // The database layer exposes only era-agnostic primitives: an
 // iterator over live UTxO rows (with CBOR populated) and a bulk
@@ -79,11 +80,25 @@ func (ls *LedgerState) removeAvvmUtxos(
 		if addr.ByronType() != lcommon.ByronAddressTypeRedeem {
 			return nil
 		}
+		amount := out.Amount()
+		if amount == nil || amount.Sign() < 0 || !amount.IsUint64() {
+			return fmt.Errorf(
+				"AVVM UTxO %x#%d has invalid amount %v",
+				u.TxId[:8], u.OutputIdx, amount,
+			)
+		}
+		amountUint64 := amount.Uint64()
 		refs = append(refs, types.UtxoKey{
 			TxId:      u.TxId,
 			OutputIdx: u.OutputIdx,
 		})
-		totalLovelace += uint64(u.Amount)
+		if totalLovelace > math.MaxUint64-amountUint64 {
+			return fmt.Errorf(
+				"AVVM lovelace total overflows uint64 at tx %x#%d",
+				u.TxId[:8], u.OutputIdx,
+			)
+		}
+		totalLovelace += amountUint64
 		return nil
 	}); err != nil {
 		return 0, 0, fmt.Errorf("scan live utxos: %w", err)

--- a/ledger/hardfork_rule.go
+++ b/ledger/hardfork_rule.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/dingo/database"
 )
@@ -67,8 +68,24 @@ func (ls *LedgerState) applyIntraEraHardForkRule(
 	boundarySlot uint64,
 	newEpoch uint64,
 ) error {
+	if txn == nil {
+		return ls.db.Transaction(true).Do(func(txn *database.Txn) error {
+			return ls.applyIntraEraHardForkRule(
+				txn, newMajor, boundarySlot, newEpoch,
+			)
+		})
+	}
 	switch newMajor {
 	case 3:
+		state, err := ls.db.Metadata().GetNetworkState(txn.Metadata())
+		if err != nil {
+			return fmt.Errorf("get network state before AVVM return: %w", err)
+		}
+		var treasury, reserves uint64
+		if state != nil {
+			treasury = uint64(state.Treasury)
+			reserves = uint64(state.Reserves)
+		}
 		count, total, err := ls.removeAvvmUtxos(txn, boundarySlot)
 		if err != nil {
 			return fmt.Errorf(
@@ -76,12 +93,23 @@ func (ls *LedgerState) applyIntraEraHardForkRule(
 				boundarySlot, err,
 			)
 		}
+		if count > 0 {
+			if total > math.MaxUint64-reserves {
+				return fmt.Errorf(
+					"AVVM reserve credit overflows uint64: reserves %d, credit %d",
+					reserves, total,
+				)
+			}
+			if err := ls.db.Metadata().SetNetworkState(
+				treasury, reserves+total, boundarySlot, txn.Metadata(),
+			); err != nil {
+				return fmt.Errorf("credit AVVM value to reserves: %w", err)
+			}
+		}
 		// Reserves are not maintained on every epoch-rollover in dingo
-		// today — governance enactment is the only caller that writes
-		// NetworkState — so we log the reclaimed total rather than
-		// writing a partial, likely-misleading reserves value. When
-		// full reserves tracking lands, consume the reclaimed total
-		// from removeAvvmUtxos here.
+		// today — this transition is the exception because the reclaimed
+		// value is a direct return to reserves. Keep the write in the
+		// enclosing transition transaction so rollback is atomic.
 		ls.config.Logger.Info(
 			"applied Allegra HARDFORK rule (pv3 AVVM return)",
 			"removed_avvm_utxos", count,

--- a/ledger/hardfork_rule_test.go
+++ b/ledger/hardfork_rule_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 	"log/slog"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -183,10 +184,20 @@ func seedByronUtxo(
 	txIdSeed byte,
 	addr lcommon.Address,
 ) []byte {
+	return seedByronUtxoWithAmount(t, db, txIdSeed, addr, 1000)
+}
+
+func seedByronUtxoWithAmount(
+	t *testing.T,
+	db *database.Database,
+	txIdSeed byte,
+	addr lcommon.Address,
+	amount uint64,
+) []byte {
 	t.Helper()
 	out := byron.ByronTransactionOutput{
 		OutputAddress: addr,
-		OutputAmount:  1000,
+		OutputAmount:  amount,
 	}
 	cborBytes, err := cbor.Encode(out)
 	require.NoError(t, err)
@@ -236,6 +247,149 @@ func TestApplyIntraEraHardForkRule_Pv3_RemovesAvvm(t *testing.T) {
 	require.NotNil(t, pubkey)
 	assert.Equal(t, uint64(0), pubkey.DeletedSlot,
 		"non-AVVM Byron UTxO must survive the pv3 rule")
+}
+
+func TestApplyIntraEraHardForkRule_Pv3_CreditsAvvmToReserves(t *testing.T) {
+	db := newTestDB(t)
+	avvmTxId, pubkeyTxId := seedByronAvvmFixtures(t, db)
+	const (
+		initialReserves  = uint64(5_000)
+		initialAvvmValue = uint64(1_000)
+	)
+	require.NoError(t, db.Metadata().SetNetworkState(
+		7_000, initialReserves, 100, nil,
+	))
+
+	ls := newTestLSForHardForkRule(t, db)
+	const boundarySlot uint64 = 4_492_800
+	require.NoError(t, ls.applyIntraEraHardForkRule(
+		nil, 3, boundarySlot, 208,
+	))
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(7_000), uint64(state.Treasury))
+	assert.Equal(t, uint64(6_000), uint64(state.Reserves))
+	assert.Equal(t, initialReserves+initialAvvmValue, uint64(state.Reserves),
+		"reserves plus live AVVM value must be conserved when AVVM is removed")
+	assert.Equal(t, boundarySlot, state.Slot)
+
+	_, err = db.UtxoByRef(avvmTxId, 0, nil)
+	assert.ErrorIs(t, err, database.ErrUtxoNotFound)
+	pubkey, err := db.UtxoByRef(pubkeyTxId, 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, pubkey)
+
+	// A replay sees no live AVVM rows and must not credit the same value again.
+	require.NoError(t, ls.applyIntraEraHardForkRule(
+		nil, 3, boundarySlot, 208,
+	))
+	state, err = db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(6_000), uint64(state.Reserves))
+}
+
+func TestApplyIntraEraHardForkRule_Pv3_CreditsOnlyAvvmValue(t *testing.T) {
+	db := newTestDB(t)
+	redeemAddr, err := lcommon.NewByronAddressRedeem(
+		bytes.Repeat([]byte{0x42}, 32),
+		lcommon.ByronAddressAttributes{},
+	)
+	require.NoError(t, err)
+	pubkeyAddr, err := lcommon.NewByronAddressFromParts(
+		lcommon.ByronAddressTypePubkey,
+		bytes.Repeat([]byte{0x55}, lcommon.AddressHashSize),
+		lcommon.ByronAddressAttributes{},
+	)
+	require.NoError(t, err)
+	avvmTxID := seedByronUtxoWithAmount(t, db, 0xAA, redeemAddr, 1)
+	pubkeyTxID := seedByronUtxoWithAmount(
+		t, db, 0xBB, pubkeyAddr, math.MaxUint64,
+	)
+	require.NoError(t, db.Metadata().SetNetworkState(0, 0, 100, nil))
+
+	ls := newTestLSForHardForkRule(t, db)
+	require.NoError(t, ls.applyIntraEraHardForkRule(nil, 3, 200, 1))
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(1), uint64(state.Reserves))
+	_, err = db.UtxoByRef(pubkeyTxID, 0, nil)
+	require.NoError(t, err)
+	_, err = db.UtxoByRef(avvmTxID, 0, nil)
+	assert.ErrorIs(t, err, database.ErrUtxoNotFound)
+}
+
+func TestApplyIntraEraHardForkRule_Pv3_RollbackRestoresReserveAndAvvm(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+	avvmTxID, _ := seedByronAvvmFixtures(t, db)
+	require.NoError(t, db.Metadata().SetNetworkState(7_000, 5_000, 100, nil))
+
+	ls := newTestLSForHardForkRule(t, db)
+	txn := db.Transaction(true)
+	require.NoError(t, ls.applyIntraEraHardForkRule(txn, 3, 200, 1))
+	require.NoError(t, txn.Rollback())
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(7_000), uint64(state.Treasury))
+	assert.Equal(t, uint64(5_000), uint64(state.Reserves))
+	assert.Equal(t, uint64(100), state.Slot)
+	_, err = db.UtxoByRef(avvmTxID, 0, nil)
+	require.NoError(t, err)
+}
+
+func TestApplyIntraEraHardForkRule_Pv3_RejectsOverflow(t *testing.T) {
+	t.Run("sum", func(t *testing.T) {
+		db := newTestDB(t)
+		redeemAddr, err := lcommon.NewByronAddressRedeem(
+			bytes.Repeat([]byte{0x42}, 32),
+			lcommon.ByronAddressAttributes{},
+		)
+		require.NoError(t, err)
+		first := seedByronUtxoWithAmount(t, db, 0xAA, redeemAddr, math.MaxUint64)
+		second := seedByronUtxoWithAmount(t, db, 0xBB, redeemAddr, 1)
+		require.NoError(t, db.Metadata().SetNetworkState(7_000, 5_000, 100, nil))
+
+		ls := newTestLSForHardForkRule(t, db)
+		err = ls.applyIntraEraHardForkRule(nil, 3, 200, 1)
+		require.ErrorContains(t, err, "AVVM lovelace total overflows uint64")
+		for _, txID := range [][]byte{first, second} {
+			_, lookupErr := db.UtxoByRef(txID, 0, nil)
+			require.NoError(t, lookupErr)
+		}
+		state, stateErr := db.Metadata().GetNetworkState(nil)
+		require.NoError(t, stateErr)
+		require.NotNil(t, state)
+		assert.Equal(t, uint64(5_000), uint64(state.Reserves))
+	})
+
+	t.Run("reserve", func(t *testing.T) {
+		db := newTestDB(t)
+		redeemAddr, err := lcommon.NewByronAddressRedeem(
+			bytes.Repeat([]byte{0x43}, 32),
+			lcommon.ByronAddressAttributes{},
+		)
+		require.NoError(t, err)
+		txID := seedByronUtxoWithAmount(t, db, 0xCC, redeemAddr, 1)
+		require.NoError(t, db.Metadata().SetNetworkState(7_000, math.MaxUint64, 100, nil))
+
+		ls := newTestLSForHardForkRule(t, db)
+		err = ls.applyIntraEraHardForkRule(nil, 3, 200, 1)
+		require.ErrorContains(t, err, "AVVM reserve credit overflows uint64")
+		_, lookupErr := db.UtxoByRef(txID, 0, nil)
+		require.NoError(t, lookupErr)
+		state, stateErr := db.Metadata().GetNetworkState(nil)
+		require.NoError(t, stateErr)
+		require.NotNil(t, state)
+		assert.Equal(t, uint64(math.MaxUint64), uint64(state.Reserves))
+	})
 }
 
 // A non-pv3 major-version dispatch must not touch AVVM UTxOs — the


### PR DESCRIPTION
## Summary

- credit the value of removed redeem-address UTxOs to reserves in the hard-fork transaction
- reject value and reserve overflows without partially applying the transition
- cover conservation, replay, rollback, address classification, and overflow behavior

## Checks

- `go test -race -timeout 20m ./ledger -run '^(TestApplyIntraEraHardForkRule_Pv3_(CreditsAvvmToReserves|CreditsOnlyAvvmValue|RollbackRestoresReserveAndAvvm|RejectsOverflow))$' -count=1`
- `golangci-lint run ./ledger/...`
- `nilaway ./ledger/...`
- `go test ./internal/architecture ./internal/docsparity`
- `git diff --check`

Fixes #3433


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Credits the value of removed Byron redeem (AVVM) UTxOs to reserves during the Shelley→Allegra hard-fork transition. Previously we removed AVVM UTxOs and only logged the reclaimed total; now we update `NetworkState` reserves atomically and reject overflow instead of partially applying.

**Review notes**
- `ledger.applyIntraEraHardForkRule` (pv3) now reads `NetworkState`, calls `removeAvvmUtxos`, checks uint64 overflow on the AVVM sum and on `reserves+credit`, and writes `SetNetworkState` in the same DB transaction; supports a `nil` txn by creating one; replay-safe (no double credit) and rollback-safe.
- `ledger.removeAvvmUtxos` validates AVVM output amounts are non-negative `uint64`, sums with overflow checks, collects refs, and returns the reclaimed total; errors on invalid amounts.
- Tests cover conservation, idempotent replays, rollback restoring reserves and AVVM UTxOs, overflow on sum and reserve addition, and that only AVVM value is credited.

<sup>Written for commit eeb3c3e4edb236027fae12585389bb5e729b4de8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AVVM funds reclaimed during the Shelley-to-Allegra transition are now credited to reserves.
  * Transition processing is atomic and safe to retry without duplicating credits.
  * Invalid amounts and numeric overflows are detected and reported without partially applying changes.
  * Failed transitions now preserve the original reserves and unspent outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->