### PR TITLE
fix(ledger): apply bootstrap voting thresholds

### DIFF
--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -334,6 +335,65 @@ func TestProcessEpochReturnsMissingRewardAccountRefundToTreasury(
 	require.NotNil(t, proposal.ExpiredSlot)
 	assert.Equal(t, uint64(5), *proposal.ExpiredEpoch)
 	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
+}
+
+// TestProcessEpochBootstrapZeroVoteParameterChangeRatifies verifies that the
+// epoch-boundary caller uses PV9's per-body decision: an eligible,
+// non-security parameter change has no SPO gate, and with no seated committee
+// the CC body is NoVotingThreshold. The bootstrap DRep threshold is zero, so
+// the proposal can ratify with no votes at all.
+func TestProcessEpochBootstrapZeroVoteParameterChangeRatifies(t *testing.T) {
+	db, _ := newTallyTestDB(t)
+	poolDeposit := uint(1234)
+	actionCbor, err := cbor.Encode(&conway.ConwayParameterChangeGovAction{
+		Type: uint(lcommon.GovActionTypeParameterChange),
+		ParamUpdate: conway.ConwayProtocolParameterUpdate{
+			PoolDeposit: &poolDeposit,
+		},
+	})
+	require.NoError(t, err)
+
+	txHash := testBytes(32, 0x61)
+	require.NoError(t, db.SetGovernanceProposal(&models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeParameterChange),
+		ProposedEpoch: stabilityTestEpoch - 1,
+		ExpiresEpoch:  stabilityTestEpoch + 10,
+		AnchorURL:     "https://example.invalid/bootstrap-boundary",
+		AnchorHash:    testBytes(32, 0x62),
+		ReturnAddress: testBytes(29, 0x63),
+		GovActionCbor: actionCbor,
+		AddedSlot:     100,
+		Deposit:       1_000,
+	}, nil))
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    stabilityTestEpoch - 1,
+		NewEpoch:     stabilityTestEpoch,
+		BoundarySlot: 500,
+		PParams:      conwayPParamsFixture(9),
+		UpdateFn: func(
+			pparams lcommon.ProtocolParameters,
+			_ any,
+		) (lcommon.ProtocolParameters, error) {
+			return pparams, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	assert.Equal(t, 1, out.RatifiedCount)
+	proposal, err := db.GetGovernanceProposal(txHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, proposal.RatifiedEpoch)
+	require.NotNil(t, proposal.RatifiedSlot)
+	assert.Equal(t, stabilityTestEpoch, *proposal.RatifiedEpoch)
+	assert.Equal(t, uint64(500), *proposal.RatifiedSlot)
 }
 
 func TestProcessEpochReplaysBoundaryTreasuryWithdrawalAfterStakeRewardReset(

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -337,12 +337,12 @@ func TestProcessEpochReturnsMissingRewardAccountRefundToTreasury(
 	assert.Equal(t, uint64(500), *proposal.ExpiredSlot)
 }
 
-// TestProcessEpochBootstrapZeroVoteParameterChangeRatifies verifies that the
-// epoch-boundary caller uses PV9's per-body decision: an eligible,
-// non-security parameter change has no SPO gate, and with no seated committee
-// the CC body is NoVotingThreshold. The bootstrap DRep threshold is zero, so
-// the proposal can ratify with no votes at all.
-func TestProcessEpochBootstrapZeroVoteParameterChangeRatifies(t *testing.T) {
+// TestProcessEpochBootstrapParameterChangeWithoutCommitteeDoesNotRatify
+// verifies that the epoch-boundary caller does not treat PV9's committee
+// minimum-size exception as approval from an absent committee.
+func TestProcessEpochBootstrapParameterChangeWithoutCommitteeDoesNotRatify(
+	t *testing.T,
+) {
 	db, _ := newTallyTestDB(t)
 	poolDeposit := uint(1234)
 	actionCbor, err := cbor.Encode(&conway.ConwayParameterChangeGovAction{
@@ -387,13 +387,11 @@ func TestProcessEpochBootstrapZeroVoteParameterChangeRatifies(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, txn.Commit())
 
-	assert.Equal(t, 1, out.RatifiedCount)
+	assert.Equal(t, 0, out.RatifiedCount)
 	proposal, err := db.GetGovernanceProposal(txHash, 0, nil)
 	require.NoError(t, err)
-	require.NotNil(t, proposal.RatifiedEpoch)
-	require.NotNil(t, proposal.RatifiedSlot)
-	assert.Equal(t, stabilityTestEpoch, *proposal.RatifiedEpoch)
-	assert.Equal(t, uint64(500), *proposal.RatifiedSlot)
+	assert.Nil(t, proposal.RatifiedEpoch)
+	assert.Nil(t, proposal.RatifiedSlot)
 }
 
 func TestProcessEpochReplaysBoundaryTreasuryWithdrawalAfterStakeRewardReset(

--- a/ledger/governance/ratify.go
+++ b/ledger/governance/ratify.go
@@ -27,8 +27,9 @@ import (
 // bootstrapProtocolVersion is the Conway protocol major version during which
 // the bootstrap governance rules apply. Bootstrap changes the DRep threshold
 // and committee minimum-size behavior, but keeps the per-body SPO and CC
-// requirements for each eligible action. A missing CC is represented by its
-// NoVotingThreshold and therefore cannot block an eligible action.
+// requirements for each eligible action. Bootstrap waives the committee
+// minimum-size requirement, but an absent committee still cannot approve a
+// committee-gated action.
 const bootstrapProtocolVersion = 9
 
 // RatifyDecision holds the outcome of evaluating a proposal's tally
@@ -136,17 +137,11 @@ func ShouldRatify(in RatifyInputs) RatifyDecision {
 		decision.CCApproved = false
 		decision.FailureReason = "cc in no-confidence state"
 	case in.ActiveCCCount == 0:
-		if inBootstrap {
-			// With no seated committee there is no CC voting body. Conway
-			// represents that body with NoVotingThreshold, so it does not
-			// block an otherwise eligible bootstrap action. A seated CC still
-			// follows the normal quorum path below.
-			decision.CCApproved = true
-			break
-		}
 		// Check zero-members before the min-size comparison so the
 		// failure reason distinguishes "no members" from "below
-		// minimum" even when MinCommitteeSize >= 1.
+		// minimum" even when MinCommitteeSize >= 1. Bootstrap bypasses
+		// only the minimum-size gate; it does not create committee approval
+		// when no active members exist.
 		decision.CCApproved = false
 		decision.FailureReason = "cc has no active members"
 	case !inBootstrap && in.ActiveCCCount < int(in.PParams.MinCommitteeSize): //nolint:gosec

--- a/ledger/governance/ratify.go
+++ b/ledger/governance/ratify.go
@@ -24,9 +24,11 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
 
-// bootstrapProtocolVersion is the highest protocol major version during
-// the Conway bootstrap phase where governance voting thresholds are not
-// yet enforced and any yes vote ratifies a proposal.
+// bootstrapProtocolVersion is the Conway protocol major version during which
+// the bootstrap governance rules apply. Bootstrap changes the DRep threshold
+// and committee minimum-size behavior, but keeps the per-body SPO and CC
+// requirements for each eligible action. A missing CC is represented by its
+// NoVotingThreshold and therefore cannot block an eligible action.
 const bootstrapProtocolVersion = 9
 
 // RatifyDecision holds the outcome of evaluating a proposal's tally
@@ -57,8 +59,9 @@ type RatifyInputs struct {
 // its current tally, the protocol parameters, and the active state of
 // DReps and CC. Follows CIP-1694 bootstrap and post-bootstrap logic.
 //
-// MajorVersion is the current protocol major version; before and
-// including version 9 (bootstrap), thresholds are effectively zero.
+// MajorVersion is the current protocol major version. During PV9 bootstrap,
+// DRep thresholds are effectively zero for eligible non-Info actions, while
+// action-specific SPO and constitutional-committee requirements remain.
 func ShouldRatify(in RatifyInputs) RatifyDecision {
 	decision := RatifyDecision{}
 	if in.Tally == nil || in.PParams == nil {
@@ -73,20 +76,28 @@ func ShouldRatify(in RatifyInputs) RatifyDecision {
 		return decision
 	}
 
-	// Bootstrap phase: any yes vote ratifies.
-	if in.MajorVersion <= bootstrapProtocolVersion {
-		// #nosec G115 -- CCYesCount is bounded by CC size (< 100).
-		yes := in.Tally.DRepYesStake + in.Tally.SPOYesStake +
-			uint64(in.Tally.CCYesCount)
-		if yes == 0 {
-			decision.FailureReason = "bootstrap: no yes vote"
+	inBootstrap := in.MajorVersion == bootstrapProtocolVersion
+	if inBootstrap {
+		// Conway validation admits only InfoAction, ParameterChange, and
+		// HardForkInitiation proposals during bootstrap. Keep this guard in
+		// the ratification path as well so imported or otherwise malformed
+		// state cannot ratify a disabled action.
+		switch actionType {
+		case lcommon.GovActionTypeParameterChange,
+			lcommon.GovActionTypeHardForkInitiation:
+			// Eligible bootstrap actions continue through the per-body
+			// DRep, SPO, and CC checks below.
+		case lcommon.GovActionTypeTreasuryWithdrawal,
+			lcommon.GovActionTypeNoConfidence,
+			lcommon.GovActionTypeUpdateCommittee,
+			lcommon.GovActionTypeNewConstitution,
+			lcommon.GovActionTypeInfo:
+			decision.FailureReason = "action is not eligible during bootstrap"
+			return decision
+		default:
+			decision.FailureReason = "action is not eligible during bootstrap"
 			return decision
 		}
-		decision.Ratified = true
-		decision.DRepApproved = true
-		decision.SPOApproved = true
-		decision.CCApproved = true
-		return decision
 	}
 
 	// DRep approval: actions with no DRep gate or a zero threshold pass
@@ -95,8 +106,7 @@ func ShouldRatify(in RatifyInputs) RatifyDecision {
 	drepThreshold := getDRepThreshold(
 		actionType, in.PParams, in.ParamUpdate, in.CommitteeNoConfidence,
 	)
-	if drepThreshold == nil ||
-		drepThreshold.Sign() == 0 {
+	if inBootstrap || drepThreshold == nil || drepThreshold.Sign() == 0 {
 		decision.DRepApproved = true
 	} else {
 		ratio := in.Tally.DRepYesRatio()
@@ -126,12 +136,20 @@ func ShouldRatify(in RatifyInputs) RatifyDecision {
 		decision.CCApproved = false
 		decision.FailureReason = "cc in no-confidence state"
 	case in.ActiveCCCount == 0:
+		if inBootstrap {
+			// With no seated committee there is no CC voting body. Conway
+			// represents that body with NoVotingThreshold, so it does not
+			// block an otherwise eligible bootstrap action. A seated CC still
+			// follows the normal quorum path below.
+			decision.CCApproved = true
+			break
+		}
 		// Check zero-members before the min-size comparison so the
 		// failure reason distinguishes "no members" from "below
 		// minimum" even when MinCommitteeSize >= 1.
 		decision.CCApproved = false
 		decision.FailureReason = "cc has no active members"
-	case in.ActiveCCCount < int(in.PParams.MinCommitteeSize): //nolint:gosec
+	case !inBootstrap && in.ActiveCCCount < int(in.PParams.MinCommitteeSize): //nolint:gosec
 		decision.CCApproved = false
 		decision.FailureReason = "cc below minimum committee size"
 	case in.CCQuorum == nil || in.CCQuorum.Sign() == 0:

--- a/ledger/governance/ratify_test.go
+++ b/ledger/governance/ratify_test.go
@@ -93,19 +93,19 @@ func TestShouldRatify_BootstrapDRepOnlyDoesNotSubstituteForSPO(t *testing.T) {
 	assert.False(t, d.Ratified)
 }
 
-func TestShouldRatify_BootstrapNoVotingBodiesPassWithoutVotes(t *testing.T) {
+func TestShouldRatify_BootstrapMissingCommitteeDoesNotRatify(t *testing.T) {
 	pparams := conwayPParamsFixture(9)
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeParameterChange),
 	}
-	// Non-security parameter changes have NoVotingAllowed for SPOs. With
-	// no seated CC, its body is NoVotingThreshold, so the DRep's bootstrap
-	// zero threshold is enough even when the tally contains no votes.
+	// Non-security parameter changes have no SPO gate and bootstrap waives
+	// the DRep threshold, but an absent committee still cannot approve a
+	// committee-gated action.
 	d := ShouldRatify(ratifyInputs(tally, pparams, 5, 0, nil, 9, false))
-	assert.True(t, d.Ratified)
+	assert.False(t, d.Ratified)
 	assert.True(t, d.DRepApproved)
 	assert.True(t, d.SPOApproved)
-	assert.True(t, d.CCApproved)
+	assert.False(t, d.CCApproved)
 }
 
 func TestShouldRatify_BootstrapPerBodyRequirements(t *testing.T) {
@@ -418,8 +418,8 @@ func TestShouldRatify_BootstrapCCChecksRemainRequired(t *testing.T) {
 		}
 	}
 
-	assert.True(t, ShouldRatify(inputs(0, nil)).Ratified,
-		"bootstrap must not require a vote from a non-seated committee")
+	assert.False(t, ShouldRatify(inputs(0, nil)).Ratified,
+		"bootstrap must not approve an action without a seated committee")
 	assert.False(t, ShouldRatify(inputs(1, nil)).Ratified,
 		"a seated committee still requires a quorum")
 }

--- a/ledger/governance/ratify_test.go
+++ b/ledger/governance/ratify_test.go
@@ -15,6 +15,7 @@
 package governance
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -81,24 +82,346 @@ func ratifyInputs(
 	}
 }
 
-func TestShouldRatify_BootstrapAnyYesPasses(t *testing.T) {
+func TestShouldRatify_BootstrapDRepOnlyDoesNotSubstituteForSPO(t *testing.T) {
 	pparams := conwayPParamsFixture(9)
 	tally := &ProposalTally{
-		ActionType:     uint8(lcommon.GovActionTypeParameterChange),
+		ActionType:     uint8(lcommon.GovActionTypeHardForkInitiation),
 		DRepYesStake:   1,
 		DRepTotalStake: 100,
 	}
-	d := ShouldRatify(ratifyInputs(tally, pparams, 5, 0, nil, 9, false))
-	assert.True(t, d.Ratified)
+	d := ShouldRatify(ratifyInputs(tally, pparams, 5, 1, big.NewRat(2, 3), 9, false))
+	assert.False(t, d.Ratified)
 }
 
-func TestShouldRatify_BootstrapZeroYesFails(t *testing.T) {
+func TestShouldRatify_BootstrapNoVotingBodiesPassWithoutVotes(t *testing.T) {
 	pparams := conwayPParamsFixture(9)
 	tally := &ProposalTally{
 		ActionType: uint8(lcommon.GovActionTypeParameterChange),
 	}
+	// Non-security parameter changes have NoVotingAllowed for SPOs. With
+	// no seated CC, its body is NoVotingThreshold, so the DRep's bootstrap
+	// zero threshold is enough even when the tally contains no votes.
 	d := ShouldRatify(ratifyInputs(tally, pparams, 5, 0, nil, 9, false))
-	assert.False(t, d.Ratified)
+	assert.True(t, d.Ratified)
+	assert.True(t, d.DRepApproved)
+	assert.True(t, d.SPOApproved)
+	assert.True(t, d.CCApproved)
+}
+
+func TestShouldRatify_BootstrapPerBodyRequirements(t *testing.T) {
+	pparams := conwayPParamsFixture(9)
+	quorum := big.NewRat(2, 3)
+	securityValue := uint(1)
+	securityUpdate := &conway.ConwayProtocolParameterUpdate{
+		MaxTxSize: &securityValue,
+	}
+
+	base := func(action lcommon.GovActionType) *ProposalTally {
+		return &ProposalTally{ActionType: uint8(action)}
+	}
+	withCC := func(tally *ProposalTally) *ProposalTally {
+		tally.CCYesCount = 2
+		tally.CCTotalCount = 3
+		return tally
+	}
+	withSPO := func(tally *ProposalTally) *ProposalTally {
+		tally.SPOYesStake = 51
+		tally.SPOTotalStake = 100
+		return tally
+	}
+
+	tests := []struct {
+		name       string
+		action     lcommon.GovActionType
+		tally      *ProposalTally
+		param      *conway.ConwayProtocolParameterUpdate
+		activeCC   int
+		wantRatify bool
+	}{
+		{
+			name:       "parameter change uses CC only",
+			action:     lcommon.GovActionTypeParameterChange,
+			tally:      withCC(base(lcommon.GovActionTypeParameterChange)),
+			activeCC:   2,
+			wantRatify: true,
+		},
+		{
+			name:       "security parameter change requires SPO",
+			action:     lcommon.GovActionTypeParameterChange,
+			tally:      withSPO(withCC(base(lcommon.GovActionTypeParameterChange))),
+			param:      securityUpdate,
+			activeCC:   2,
+			wantRatify: true,
+		},
+		{
+			name:       "hard fork requires CC and SPO",
+			action:     lcommon.GovActionTypeHardForkInitiation,
+			tally:      withSPO(withCC(base(lcommon.GovActionTypeHardForkInitiation))),
+			activeCC:   2,
+			wantRatify: true,
+		},
+		{
+			name:       "hard fork CC only fails",
+			action:     lcommon.GovActionTypeHardForkInitiation,
+			tally:      withCC(base(lcommon.GovActionTypeHardForkInitiation)),
+			activeCC:   2,
+			wantRatify: false,
+		},
+		{
+			name:       "hard fork SPO only fails",
+			action:     lcommon.GovActionTypeHardForkInitiation,
+			tally:      withSPO(base(lcommon.GovActionTypeHardForkInitiation)),
+			activeCC:   2,
+			wantRatify: false,
+		},
+		{
+			name:   "hard fork DRep only fails",
+			action: lcommon.GovActionTypeHardForkInitiation,
+			tally: &ProposalTally{
+				ActionType:     uint8(lcommon.GovActionTypeHardForkInitiation),
+				DRepYesStake:   100,
+				DRepTotalStake: 100,
+			},
+			activeCC:   2,
+			wantRatify: false,
+		},
+		{
+			name:       "info remains non-ratifiable",
+			action:     lcommon.GovActionTypeInfo,
+			tally:      withSPO(withCC(base(lcommon.GovActionTypeInfo))),
+			activeCC:   2,
+			wantRatify: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := ShouldRatify(RatifyInputs{
+				Tally:           tt.tally,
+				PParams:         pparams,
+				ParamUpdate:     tt.param,
+				ActiveCCCount:   tt.activeCC,
+				CCQuorum:        quorum,
+				MajorVersion:    9,
+				ActiveDRepCount: 0,
+			})
+			assert.Equal(t, tt.wantRatify, d.Ratified)
+		})
+	}
+}
+
+func TestShouldRatify_BootstrapUnsupportedActionsDoNotRatify(t *testing.T) {
+	pparams := conwayPParamsFixture(9)
+	unsupported := []lcommon.GovActionType{
+		lcommon.GovActionTypeTreasuryWithdrawal,
+		lcommon.GovActionTypeNoConfidence,
+		lcommon.GovActionTypeUpdateCommittee,
+		lcommon.GovActionTypeNewConstitution,
+	}
+	for _, action := range unsupported {
+		t.Run(fmt.Sprintf("action-%d", action), func(t *testing.T) {
+			tally := &ProposalTally{
+				ActionType:     uint8(action),
+				DRepYesStake:   100,
+				DRepTotalStake: 100,
+				SPOYesStake:    100,
+				SPOTotalStake:  100,
+				CCYesCount:     3,
+				CCTotalCount:   3,
+			}
+			d := ShouldRatify(RatifyInputs{
+				Tally:         tally,
+				PParams:       pparams,
+				ActiveCCCount: 3,
+				CCQuorum:      big.NewRat(2, 3),
+				MajorVersion:  9,
+			})
+			assert.False(t, d.Ratified)
+		})
+	}
+}
+
+func TestShouldRatify_ActionBodyMatrixAcrossBootstrapBoundary(t *testing.T) {
+	securityValue := uint(1)
+	securityUpdate := &conway.ConwayProtocolParameterUpdate{
+		MaxTxSize: &securityValue,
+	}
+
+	type body uint8
+	const (
+		drepBody body = 1 << iota
+		spoBody
+		ccBody
+	)
+
+	makeTally := func(action lcommon.GovActionType, votes body) *ProposalTally {
+		tally := &ProposalTally{ActionType: uint8(action)}
+		if votes&drepBody != 0 {
+			tally.DRepYesStake, tally.DRepTotalStake = 100, 100
+		}
+		if votes&spoBody != 0 {
+			tally.SPOYesStake, tally.SPOTotalStake = 100, 100
+		}
+		if votes&ccBody != 0 {
+			tally.CCYesCount, tally.CCTotalCount = 2, 3
+		}
+		return tally
+	}
+
+	type actionCase struct {
+		name      string
+		action    lcommon.GovActionType
+		param     *conway.ConwayProtocolParameterUpdate
+		required  body
+		bootstrap bool
+	}
+
+	bootstrapCases := []actionCase{
+		{
+			name:      "parameter change",
+			action:    lcommon.GovActionTypeParameterChange,
+			required:  ccBody,
+			bootstrap: true,
+		},
+		{
+			name:      "security parameter change",
+			action:    lcommon.GovActionTypeParameterChange,
+			param:     securityUpdate,
+			required:  spoBody | ccBody,
+			bootstrap: true,
+		},
+		{
+			name:      "hard fork initiation",
+			action:    lcommon.GovActionTypeHardForkInitiation,
+			required:  spoBody | ccBody,
+			bootstrap: true,
+		},
+		{
+			name:      "info",
+			action:    lcommon.GovActionTypeInfo,
+			bootstrap: true,
+		},
+		{
+			name:      "treasury withdrawal",
+			action:    lcommon.GovActionTypeTreasuryWithdrawal,
+			bootstrap: true,
+		},
+		{
+			name:      "no confidence",
+			action:    lcommon.GovActionTypeNoConfidence,
+			bootstrap: true,
+		},
+		{
+			name:      "update committee",
+			action:    lcommon.GovActionTypeUpdateCommittee,
+			bootstrap: true,
+		},
+		{
+			name:      "new constitution",
+			action:    lcommon.GovActionTypeNewConstitution,
+			bootstrap: true,
+		},
+	}
+
+	postBootstrapCases := []actionCase{
+		{
+			name:     "parameter change",
+			action:   lcommon.GovActionTypeParameterChange,
+			required: drepBody | ccBody,
+		},
+		{
+			name:     "security parameter change",
+			action:   lcommon.GovActionTypeParameterChange,
+			param:    securityUpdate,
+			required: drepBody | spoBody | ccBody,
+		},
+		{
+			name:     "hard fork initiation",
+			action:   lcommon.GovActionTypeHardForkInitiation,
+			required: drepBody | spoBody | ccBody,
+		},
+		{
+			name:     "treasury withdrawal",
+			action:   lcommon.GovActionTypeTreasuryWithdrawal,
+			required: drepBody | ccBody,
+		},
+		{
+			name:     "no confidence",
+			action:   lcommon.GovActionTypeNoConfidence,
+			required: drepBody | spoBody,
+		},
+		{
+			name:     "update committee",
+			action:   lcommon.GovActionTypeUpdateCommittee,
+			required: drepBody | spoBody,
+		},
+		{
+			name:     "new constitution",
+			action:   lcommon.GovActionTypeNewConstitution,
+			required: drepBody | ccBody,
+		},
+		{
+			name:   "info",
+			action: lcommon.GovActionTypeInfo,
+		},
+	}
+
+	for _, tc := range append(bootstrapCases, postBootstrapCases...) {
+		major := uint(10)
+		if tc.bootstrap {
+			major = 9
+		}
+		pparams := conwayPParamsFixture(major)
+		for _, votes := range []body{0, drepBody, spoBody, ccBody,
+			drepBody | spoBody, drepBody | ccBody, spoBody | ccBody,
+			drepBody | spoBody | ccBody} {
+			name := fmt.Sprintf("PV%d/%s/votes-%d", major, tc.name, votes)
+			t.Run(name, func(t *testing.T) {
+				want := tc.required != 0 && votes&tc.required == tc.required
+				if tc.bootstrap && tc.action != lcommon.GovActionTypeParameterChange &&
+					tc.action != lcommon.GovActionTypeHardForkInitiation {
+					want = false
+				}
+				if tc.action == lcommon.GovActionTypeInfo {
+					want = false
+				}
+				d := ShouldRatify(RatifyInputs{
+					Tally:         makeTally(tc.action, votes),
+					PParams:       pparams,
+					ParamUpdate:   tc.param,
+					ActiveCCCount: 3,
+					CCQuorum:      big.NewRat(2, 3),
+					MajorVersion:  major,
+				})
+				assert.Equal(t, want, d.Ratified)
+			})
+		}
+	}
+}
+
+func TestShouldRatify_BootstrapCCChecksRemainRequired(t *testing.T) {
+	pparams := conwayPParamsFixture(9)
+	tally := &ProposalTally{
+		ActionType:    uint8(lcommon.GovActionTypeHardForkInitiation),
+		SPOYesStake:   100,
+		SPOTotalStake: 100,
+		CCYesCount:    3,
+		CCTotalCount:  3,
+	}
+	inputs := func(activeCC int, quorum *big.Rat) RatifyInputs {
+		return RatifyInputs{
+			Tally:         tally,
+			PParams:       pparams,
+			ActiveCCCount: activeCC,
+			CCQuorum:      quorum,
+			MajorVersion:  9,
+		}
+	}
+
+	assert.True(t, ShouldRatify(inputs(0, nil)).Ratified,
+		"bootstrap must not require a vote from a non-seated committee")
+	assert.False(t, ShouldRatify(inputs(1, nil)).Ratified,
+		"a seated committee still requires a quorum")
 }
 
 func TestShouldRatify_InfoActionCannotRatify(t *testing.T) {

--- a/ledger/governance/stability_test.go
+++ b/ledger/governance/stability_test.go
@@ -37,9 +37,9 @@ const (
 
 // stabilityConwayPParams returns Conway pparams configured for the
 // requested protocol major version. Threshold values are realistic so
-// post-bootstrap tests exercise the same code path as production. The
-// bootstrap branch in ShouldRatify (major <= 9) ignores thresholds
-// entirely; only one yes vote of any kind is required.
+// post-bootstrap tests exercise the same code path as production. During
+// bootstrap, DRep thresholds are zero but the action-specific SPO and CC
+// requirements still apply.
 func stabilityConwayPParams(major uint) *conway.ConwayProtocolParameters {
 	p := mockledger.NewMockConwayProtocolParams()
 	p.ProtocolVersion.Major = major
@@ -143,6 +143,47 @@ func seedDRepYesVote(
 	}, nil))
 }
 
+func seedHardForkCommitteeAndSPOVotes(
+	t *testing.T,
+	db *database.Database,
+	store *tallyTestStore,
+	proposals ...*models.GovernanceProposal,
+) {
+	t.Helper()
+	coldCred := testBytes(28, 0xD1)
+	hotCred := testBytes(28, 0xD2)
+	require.NoError(t, db.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: coldCred, ExpiresEpoch: stabilityTestEpoch + 10},
+	}, nil))
+	seedTallyCommitteeAuth(t, store, models.AuthCommitteeHot{
+		ColdCredential: coldCred,
+		HotCredential:  hotCred,
+		CertificateID:  1,
+		AddedSlot:      1,
+	})
+	poolCred := testBytes(28, 0xD3)
+	seedPoolWithStake(
+		t, store, poolCred, testBytes(29, 0xD4), 100,
+		stakeEpochFor(stabilityTestEpoch),
+	)
+	for _, proposal := range proposals {
+		require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+			ProposalID:      proposal.ID,
+			VoterType:       models.VoterTypeCC,
+			VoterCredential: hotCred,
+			Vote:            models.VoteYes,
+			AddedSlot:       2,
+		}, nil))
+		require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+			ProposalID:      proposal.ID,
+			VoterType:       models.VoterTypeSPO,
+			VoterCredential: poolCred,
+			Vote:            models.VoteYes,
+			AddedSlot:       2,
+		}, nil))
+	}
+}
+
 func TestEvaluateRatifiableHardForkInitiation_PreConway_ReturnsNil(
 	t *testing.T,
 ) {
@@ -205,30 +246,27 @@ func TestEvaluateRatifiableHardForkInitiation_OnlyOtherActionType_ReturnsNil(
 	assert.Nil(t, got, "non-HardForkInitiation actions must be ignored")
 }
 
-// TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote pins
-// the bootstrap ratification semantic: in pparams with major <= 9 a
-// single yes vote of any non-zero magnitude suffices to make a proposal
-// ratifiable, regardless of thresholds. The mid-epoch helper must
-// surface this as an upcoming transition with the correct target major
-// version (extracted from the proposal's encoded action).
-func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(
+// TestEvaluateRatifiableHardForkInitiation_BootstrapRequiresCommitteeAndSPO
+// pins the bootstrap hard-fork requirement in the mid-epoch helper: a DRep
+// vote alone is not sufficient, while the required CC and SPO votes surface
+// the transition with the target major version from the encoded action.
+func TestEvaluateRatifiableHardForkInitiation_BootstrapRequiresCommitteeAndSPO(
 	t *testing.T,
 ) {
-	db, _ := newTallyTestDB(t)
+	db, store := newTallyTestDB(t)
 
 	const targetMajor uint = 11
 	proposal := seedHardForkInitiationProposal(
 		t, db, stabilityTestEpoch, targetMajor, 1, stabilityProposalTx,
 	)
-	drepCred := seedDRepWithStake(t, db, 1_000)
-	seedDRepYesVote(t, db, proposal.ID, drepCred)
+	seedHardForkCommitteeAndSPOVotes(t, db, store, proposal)
 
 	in := NewStabilityCheckInputs(
 		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
-	require.NotNil(t, got, "bootstrap + yes vote must be ratifiable")
+	require.NotNil(t, got, "bootstrap CC + SPO votes must be ratifiable")
 	assert.Equal(t, targetMajor, got.NewMajor,
 		"target major must come from the proposal's encoded action")
 	assert.Equal(t, proposal.ID, got.Proposal.ID,
@@ -238,13 +276,14 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapWithDRepYesVote(
 func TestEvaluateRatifiableHardForkInitiation_DelegatorInactivityParity(
 	t *testing.T,
 ) {
-	db, _ := newTallyTestDB(t)
+	db, store := newTallyTestDB(t)
 
 	proposal := seedHardForkInitiationProposal(
 		t, db, stabilityTestEpoch, 11, 1, stabilityProposalTx,
 	)
 	drepCred := seedDRepWithStake(t, db, 1_000)
 	seedDRepYesVote(t, db, proposal.ID, drepCred)
+	seedHardForkCommitteeAndSPOVotes(t, db, store, proposal)
 	rewardCred := models.NewStakeCredentialRef(
 		0,
 		testBytes(28, stabilityStakeCred),
@@ -256,14 +295,14 @@ func TestEvaluateRatifiableHardForkInitiation_DelegatorInactivityParity(
 	))
 
 	gateOff := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(10), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(gateOff)
 	require.NoError(t, err)
 	require.NotNil(t, got, "gate off must preserve the expired account's vote")
 
 	gateOn := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, true, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, true, stabilityConwayPParams(10), nil, nil,
 	)
 	got, err = EvaluateRatifiableHardForkInitiation(gateOn)
 	require.NoError(t, err)
@@ -274,15 +313,14 @@ func TestEvaluateRatifiableHardForkInitiation_DelegatorInactivityParity(
 	)
 }
 
-// TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable
-// pins the negative side of bootstrap: even though thresholds are zero,
-// at least ONE yes vote (DRep, SPO, or CC) is required. With zero votes
-// of any kind, the proposal does not ratify.
-func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(
+// TestEvaluateRatifiableHardForkInitiation_BootstrapDRepOnly_NotRatifiable
+// pins the negative side of bootstrap: a DRep yes vote does not substitute
+// for the required CC and SPO votes on a hard-fork proposal.
+func TestEvaluateRatifiableHardForkInitiation_BootstrapDRepOnly_NotRatifiable(
 	t *testing.T,
 ) {
 	db, _ := newTallyTestDB(t)
-	seedHardForkInitiationProposal(
+	proposal := seedHardForkInitiationProposal(
 		t,
 		db,
 		stabilityTestEpoch,
@@ -290,13 +328,15 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(
 		1,
 		stabilityProposalTx,
 	)
+	drepCred := seedDRepWithStake(t, db, 1_000)
+	seedDRepYesVote(t, db, proposal.ID, drepCred)
 
 	in := NewStabilityCheckInputs(
 		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)
-	assert.Nil(t, got, "no votes means no ratification, even in bootstrap")
+	assert.Nil(t, got, "DRep-only vote must not ratify a bootstrap hard fork")
 }
 
 // When two HardForkInitiation proposals are simultaneously ratifiable,
@@ -307,7 +347,7 @@ func TestEvaluateRatifiableHardForkInitiation_BootstrapNoVotes_NotRatifiable(
 func TestEvaluateRatifiableHardForkInitiation_MultipleRatifiable_PicksLowestAddedSlot(
 	t *testing.T,
 ) {
-	db, _ := newTallyTestDB(t)
+	db, store := newTallyTestDB(t)
 
 	const (
 		earlyMajor    uint   = 11
@@ -328,9 +368,10 @@ func TestEvaluateRatifiableHardForkInitiation_MultipleRatifiable_PicksLowestAdde
 	drepCred := seedDRepWithStake(t, db, 1_000)
 	seedDRepYesVote(t, db, early.ID, drepCred)
 	seedDRepYesVote(t, db, late.ID, drepCred)
+	seedHardForkCommitteeAndSPOVotes(t, db, store, early, late)
 
 	in := NewStabilityCheckInputs(
-		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(9), nil, nil,
+		db, nil, stabilityTestEpoch, false, stabilityConwayPParams(10), nil, nil,
 	)
 	got, err := EvaluateRatifiableHardForkInitiation(in)
 	require.NoError(t, err)

--- a/ledger/transition_stability_test.go
+++ b/ledger/transition_stability_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -81,21 +82,24 @@ const (
 
 // stabilityFixtureLedgerState assembles a LedgerState wired with
 // real-shaped Shelley genesis (so calculateStabilityWindowForEra returns
-// the expected 25_920) and an in-memory DB. The caller seeds proposal /
+// the expected 25_920) and a file-backed SQLite DB. The caller seeds proposal /
 // vote rows on db, sets currentTip and transitionInfo, and invokes
 // evaluateHardForkInitiationStability.
 //
 // Setting currentPParams to Conway pparams with the supplied major
 // version exercises the post-Conway code path inside the helper.
-// Bootstrap (major <= 9) waives the DRep threshold but preserves the
-// action-specific SPO threshold, so ratifiable fixtures must include an
-// SPO stake snapshot and vote.
+// Bootstrap (major 9) waives the DRep threshold but preserves the
+// action-specific SPO and committee thresholds, so ratifiable fixtures must
+// include both voting bodies.
 func stabilityFixtureLedgerState(
 	t *testing.T,
 	major uint,
 ) (*LedgerState, *database.Database) {
 	t.Helper()
-	db := newTestDB(t)
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
 	pparams := mockledger.NewMockConwayProtocolParams()
 	pparams.ProtocolVersion.Major = major
 	ls := &LedgerState{
@@ -120,8 +124,8 @@ func stabilityFixtureLedgerState(
 
 // seedRatifiableBootstrapHardForkInitiation primes the DB so that the
 // governance ratifiability helper returns a non-nil result when the
-// bootstrap (major<=9) ratification rule is in effect — a HardForkInitiation
-// proposal in the active set plus the required SPO stake and yes vote.
+// bootstrap (major 9) ratification rule is in effect — a HardForkInitiation
+// proposal in the active set plus the required CC and SPO yes votes.
 func seedRatifiableBootstrapHardForkInitiation(
 	t *testing.T,
 	db *database.Database,
@@ -178,6 +182,25 @@ func seedRatifiableBootstrapHardForkInitiation(
 		ProposalID:      loaded.ID,
 		VoterType:       models.VoterTypeDRep,
 		VoterCredential: drepCred,
+		Vote:            models.VoteYes,
+		AddedSlot:       2,
+	}, nil))
+	coldCred := repeatByte(28, 0xCE)
+	hotCred := repeatByte(28, 0xCF)
+	require.NoError(t, db.SetCommitteeMembers([]*models.CommitteeMember{
+		{ColdCredHash: coldCred, ExpiresEpoch: currentEpoch + 10},
+	}, nil))
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	_, err = raw.Exec(`
+INSERT INTO auth_committee_hot (
+    cold_credential, host_credential, certificate_id, added_slot
+) VALUES (?, ?, ?, ?)`, coldCred, hotCred, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      loaded.ID,
+		VoterType:       models.VoterTypeCC,
+		VoterCredential: hotCred,
 		Vote:            models.VoteYes,
 		AddedSlot:       2,
 	}, nil))

--- a/ledger/transition_stability_test.go
+++ b/ledger/transition_stability_test.go
@@ -87,9 +87,9 @@ const (
 //
 // Setting currentPParams to Conway pparams with the supplied major
 // version exercises the post-Conway code path inside the helper.
-// Bootstrap (major <= 9) uses the simplest ratification semantics
-// (single yes vote suffices) so a typical test only needs one DRep
-// fixture.
+// Bootstrap (major <= 9) waives the DRep threshold but preserves the
+// action-specific SPO threshold, so ratifiable fixtures must include an
+// SPO stake snapshot and vote.
 func stabilityFixtureLedgerState(
 	t *testing.T,
 	major uint,
@@ -121,7 +121,7 @@ func stabilityFixtureLedgerState(
 // seedRatifiableBootstrapHardForkInitiation primes the DB so that the
 // governance ratifiability helper returns a non-nil result when the
 // bootstrap (major<=9) ratification rule is in effect — a HardForkInitiation
-// proposal in the active set plus a single DRep yes vote.
+// proposal in the active set plus the required SPO stake and yes vote.
 func seedRatifiableBootstrapHardForkInitiation(
 	t *testing.T,
 	db *database.Database,
@@ -178,6 +178,23 @@ func seedRatifiableBootstrapHardForkInitiation(
 		ProposalID:      loaded.ID,
 		VoterType:       models.VoterTypeDRep,
 		VoterCredential: drepCred,
+		Vote:            models.VoteYes,
+		AddedSlot:       2,
+	}, nil))
+	poolCred := repeatByte(28, 0xDD)
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshot(
+		&models.PoolStakeSnapshot{
+			Epoch:        currentEpoch - 2,
+			SnapshotType: models.PoolStakeSnapshotTypeMark,
+			PoolKeyHash:  poolCred,
+			TotalStake:   types.Uint64(1_000),
+		},
+		nil,
+	))
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      loaded.ID,
+		VoterType:       models.VoterTypeSPO,
+		VoterCredential: poolCred,
 		Vote:            models.VoteYes,
 		AddedSlot:       2,
 	}, nil))


### PR DESCRIPTION
## Summary

- apply the PV9 bootstrap DRep threshold without bypassing action-specific SPO and committee bodies
- keep unsupported bootstrap actions non-ratifiable and handle seated and absent committees separately
- cover the complete vote-body matrix plus epoch-boundary and mid-epoch callers

## Checks

- `go test -race -timeout 20m ./ledger/governance`
- `golangci-lint run --allow-parallel-runners ./ledger/governance`
- `nilaway ./ledger/governance`
- `modernize ./ledger/governance`
- `go test ./internal/architecture ./internal/docsparity`
- `git diff --check`

Fixes #3434

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies PV9 bootstrap voting semantics to governance ratification without weakening SPO or constitutional-committee approvals. Previously any yes vote ratified during bootstrap; now the DRep threshold is zero, eligible actions still require their SPO/CC gates, and unsupported actions cannot ratify.

- PV9 eligibility: only ParameterChange and HardForkInitiation can ratify; Info never ratifies; TreasuryWithdrawal/NoConfidence/UpdateCommittee/NewConstitution are rejected.
- CC behavior: bootstrap waives the minimum-size gate only; an absent CC blocks; a seated CC must meet quorum.
- HardForkInitiation requires both CC and SPO in PV9; DRep-only votes do not ratify.
- ParameterChange (non-security) has no SPO gate but still requires CC approval; epoch-boundary callers do not ratify without a seated CC.
- Tests cover the PV9→PV10 action-by-body matrix and seed required bootstrap SPO/CC votes.
- Scope: behavior change is limited to PV9; PV10+ logic is unchanged; no migrations or external API changes.

Fixes #3434

<sup>Written for commit 19011070118aee89c58eb5e14ed91eb0d84bac8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

