### PR TITLE
fix(ledger): cap restrictive Plutus evaluation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2138,12 +2138,14 @@ For the current respun prototype, the notify vote dialect is specifically the th
 
 During accepted block replay, Alonzo-and-newer validation runs the UTXO/Phase 1 rule set and keeps declared ExUnit limit checks. Plutus Phase 2 execution is skipped only for blocks at or before the immutable tip (`tipBlockNo - securityParam`), where the block producer's `isValid` flag is treated as authoritative until the local Plutus VM is consensus-equivalent. Volatile block replay, local transaction validation for mempool submission, and forging continue to run Plutus execution.
 
-Restrictive Phase 2 validation runs the CEK machine against an enormous internal
-budget and compares the complete measured cost with the redeemer's declared
-ExUnits afterward. The measured cost includes the accumulated trailing
-slippage batch that the Haskell CEK machine spends on a successful return;
-omitting that batch under-reports script cost and can admit a transaction the
-reference node rejects.
+Restrictive Phase 2 validation runs the CEK machine against the protocol's
+per-transaction `MaxTxExUnits` limit and compares the complete measured cost
+with the redeemer's declared ExUnits afterward. This permits the machine's
+intermediate slippage batching without allowing evaluation beyond the
+transaction-wide protocol envelope. The measured cost includes the accumulated
+trailing slippage batch that the Haskell CEK machine spends on a successful
+return; omitting that batch under-reports script cost and can admit a
+transaction the reference node rejects.
 
 Where Phase 2 does run, the Plutus script context (`TxInfo`) is constructed only for transactions that carry at least one redeemer (`txHasRedeemers`, `ledger/eras/validation.go`); `ValidateTxAlonzo`, `ValidateTxBabbage`, `EvaluateTxAlonzo`, `EvaluateTxBabbage`, and `EvaluateTxConway` skip the build for the rest, and `ValidateTxConway` already returned early for them. Redeemers are what drive Phase 2, so a transaction without any runs no Plutus script, and the context is not merely unused work for it: the context embeds the transaction's validity interval translated to wall-clock time, so building it converts the transaction's TTL through the bounded HFC forecast horizon (see "Header Forecast Horizon") and returns `hardfork.ErrPastHorizon` for a TTL past that horizon. A script-free transaction was therefore rejected during replay whenever its TTL reached past the current era's safe zone, and the tx-validation recovery path read that as inconsistent local ledger state. cardano-ledger performs the translation only while assembling the context for the Plutus scripts a transaction actually needs (`collectPlutusScriptsWithContext`). The horizon itself is unchanged: a transaction that does carry redeemers still translates its validity interval per redeemer language and still fails past the horizon, matching cardano-ledger's `TimeTranslationPastHorizon`.
 

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -310,8 +310,8 @@ func ValidateTxAlonzo(
 				redeemer.Data,
 				sc.ToPlutusData(),
 				lcommon.ExUnits{
-					Steps:  restrictiveEnormousBudget,
-					Memory: restrictiveEnormousBudget,
+					Steps:  tmpPparams.MaxTxExUnits.Steps,
+					Memory: tmpPparams.MaxTxExUnits.Memory,
 				},
 				evalContext,
 			)

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -336,8 +336,8 @@ func ValidateTxBabbage(
 				redeemer.Data,
 				sc.ToPlutusData(),
 				lcommon.ExUnits{
-					Steps:  restrictiveEnormousBudget,
-					Memory: restrictiveEnormousBudget,
+					Steps:  tmpPparams.MaxTxExUnits.Steps,
+					Memory: tmpPparams.MaxTxExUnits.Memory,
 				},
 				evalContext,
 			)
@@ -387,8 +387,8 @@ func ValidateTxBabbage(
 				redeemer.Data,
 				sc.ToPlutusData(),
 				lcommon.ExUnits{
-					Steps:  restrictiveEnormousBudget,
-					Memory: restrictiveEnormousBudget,
+					Steps:  tmpPparams.MaxTxExUnits.Steps,
+					Memory: tmpPparams.MaxTxExUnits.Memory,
 				},
 				evalContext,
 			)

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"slices"
 	"strings"
@@ -1054,23 +1053,6 @@ func (c *conwayTxInfoCache) v3() (script.TxInfoV3, error) {
 	return c.txInfoV3, nil
 }
 
-// restrictiveEnormousBudget is used when evaluating Plutus scripts in
-// restrictive (phase-2 ledger validation) mode. Instead of limiting the CEK
-// machine to the declared redeemer budget during execution — which causes
-// intermediate slippage-batch flush failures — we run with a virtually
-// unlimited budget and compare the full consumed amount against the declared
-// budget after execution. This mirrors cardano-node's restrictingEnormous
-// semantics: the machine runs unconstrained, flushes its accumulated step
-// budget when evaluation succeeds, and then the complete usedBudget must fit
-// within the declared redeemer budget.
-//
-// math.MaxInt64/2 avoids overflow in ExBudget arithmetic (consumed = enormous - remaining).
-//
-// The Alonzo and Babbage phase-2 script validation helpers in this package use
-// the same value, so changing it changes script validation in every era from
-// Alonzo onward.
-const restrictiveEnormousBudget = int64(math.MaxInt64 / 2)
-
 func evaluateConwayPlutusScript(
 	plutusScript lcommon.Script,
 	purpose script.ScriptPurpose,
@@ -1081,12 +1063,11 @@ func evaluateConwayPlutusScript(
 	txInfos *conwayTxInfoCache,
 	restrictive bool,
 ) (lcommon.ExUnits, error, error) {
-	// In restrictive mode, ignore the budget argument as a machine limit and
-	// pass an enormous budget to gouroboros/plutigo so intermediate
-	// slippage-batch flushes never exhaust the budget mid-execution. After
+	// In restrictive mode, use the protocol transaction budget as the machine
+	// limit so intermediate slippage-batch flushes do not reject a script just
+	// because they temporarily exceed its declared redeemer budget. After
 	// execution we compare the complete consumed amount, including the final
-	// accumulated step batch, against the budget argument. Callers set that
-	// argument to the declared redeemer budget.
+	// accumulated step batch, against the declared redeemer budget.
 	//
 	// In exact mode the caller-supplied budget argument is itself the machine
 	// limit, and no post-execution comparison is done. EvaluateTxConway uses
@@ -1095,10 +1076,7 @@ func evaluateConwayPlutusScript(
 	// budget.
 	evalBudget := budget
 	if restrictive {
-		evalBudget = lcommon.ExUnits{
-			Steps:  restrictiveEnormousBudget,
-			Memory: restrictiveEnormousBudget,
-		}
+		evalBudget = pp.MaxTxExUnits
 	}
 	switch s := plutusScript.(type) {
 	case lcommon.PlutusV3Script:

--- a/ledger/eras/conway_plutus_budget_test.go
+++ b/ledger/eras/conway_plutus_budget_test.go
@@ -46,10 +46,10 @@ import (
 // and so a three-argument program, whose cost nothing external pins.
 //
 // The declared budget is zero on purpose. Restrictive validation runs the
-// script against the enormous budget and compares afterwards, so the entire
-// measured cost appears in the overage — including the trailing batch the
-// Haskell machine flushes on a successful return. Under-reporting that batch
-// lowers these figures and fails this test.
+// script against the protocol transaction budget and compares afterwards, so
+// the entire measured cost appears in the overage — including the trailing
+// batch the Haskell machine flushes on a successful return. Under-reporting
+// that batch lowers these figures and fails this test.
 func TestConwayPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 	program := &syn.Program[syn.DeBruijn]{
 		Version: lang.LanguageVersionV1,
@@ -119,6 +119,10 @@ func TestConwayPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 			ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
 				Major: 9,
 			},
+			MaxTxExUnits: lcommon.ExUnits{
+				Steps:  1_000_000,
+				Memory: 1_000_000,
+			},
 		},
 	)
 	require.Error(t, err)
@@ -133,4 +137,23 @@ func TestConwayPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 		plutusErr.Err.Error(),
 		"script exceeded declared budget: used (112100 cpu, 800 mem)",
 	)
+
+	t.Run("restrictive evaluation is capped by protocol transaction budget", func(t *testing.T) {
+		err := ValidateTxConway(
+			tx,
+			0,
+			newMockLedgerState(),
+			&conway.ConwayProtocolParameters{
+				ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+					Major: 9,
+				},
+				MaxTxExUnits: lcommon.ExUnits{
+					Steps:  1_000,
+					Memory: 100,
+				},
+			},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of budget")
+	})
 }

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -276,6 +276,7 @@ type mockRedeemers struct {
 		key lcommon.RedeemerKey
 		val lcommon.RedeemerValue
 	}
+	valueOverride *lcommon.RedeemerValue
 }
 
 func (m *mockRedeemers) Indexes(
@@ -288,6 +289,9 @@ func (m *mockRedeemers) Value(
 	_ uint,
 	_ lcommon.RedeemerTag,
 ) lcommon.RedeemerValue {
+	if m.valueOverride != nil {
+		return *m.valueOverride
+	}
 	return lcommon.RedeemerValue{}
 }
 
@@ -343,10 +347,11 @@ func TestBabbageValidationRulesUseLocalPlutusExecution(t *testing.T) {
 
 func TestPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 	// A zero declared budget is intentional: restrictive validation should
-	// execute this script with the enormous budget and classify the resulting
-	// overage as a Plutus disagreement. The script is small enough that its CEK
-	// steps remain in the trailing slippage batch. Haskell flushes that batch on
-	// a successful return, producing the complete 112100 CPU / 800 memory cost.
+	// execute this script with the protocol transaction budget and classify the
+	// resulting overage as a Plutus disagreement. The script is small enough
+	// that its CEK steps remain in the trailing slippage batch. Haskell flushes
+	// that batch on a successful return, producing the complete 112100 CPU / 800
+	// memory cost.
 	program := &syn.Program[syn.DeBruijn]{
 		Version: lang.LanguageVersionV1,
 		Term: &syn.Lambda[syn.DeBruijn]{
@@ -364,18 +369,19 @@ func TestPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		validate func(lcommon.Transaction, lcommon.LedgerState) error
+		validate func(lcommon.Transaction, lcommon.LedgerState, lcommon.ExUnits) error
 		reset    func()
 	}{
 		{
 			name: "alonzo",
-			validate: func(tx lcommon.Transaction, ls lcommon.LedgerState) error {
+			validate: func(tx lcommon.Transaction, ls lcommon.LedgerState, maxTxExUnits lcommon.ExUnits) error {
 				return ValidateTxAlonzo(
 					tx,
 					0,
 					ls,
 					&alonzo.AlonzoProtocolParameters{
 						ProtocolMajor: 5,
+						MaxTxExUnits:  maxTxExUnits,
 					},
 				)
 			},
@@ -385,13 +391,14 @@ func TestPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 		},
 		{
 			name: "babbage",
-			validate: func(tx lcommon.Transaction, ls lcommon.LedgerState) error {
+			validate: func(tx lcommon.Transaction, ls lcommon.LedgerState, maxTxExUnits lcommon.ExUnits) error {
 				return ValidateTxBabbage(
 					tx,
 					0,
 					ls,
 					&babbage.BabbageProtocolParameters{
 						ProtocolMajor: 7,
+						MaxTxExUnits:  maxTxExUnits,
 					},
 				)
 			},
@@ -462,7 +469,10 @@ func TestPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 					addr:       addr,
 				},
 			)
-			err = tc.validate(tx, ls)
+			err = tc.validate(tx, ls, lcommon.ExUnits{
+				Steps:  1_000_000,
+				Memory: 1_000_000,
+			})
 			require.Error(t, err)
 
 			var plutusErr conway.PlutusScriptFailedError
@@ -475,6 +485,27 @@ func TestPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 				plutusErr.Err.Error(),
 				"script exceeded declared budget: used (112100 cpu, 800 mem)",
 			)
+
+			t.Run("restrictive evaluation is capped by protocol transaction budget", func(t *testing.T) {
+				err := tc.validate(tx, ls, lcommon.ExUnits{
+					Steps:  1_000,
+					Memory: 100,
+				})
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "out of budget")
+			})
+
+			t.Run("valid execution remains accepted within both budgets", func(t *testing.T) {
+				value := lcommon.RedeemerValue{ExUnits: lcommon.ExUnits{
+					Steps:  112_100,
+					Memory: 800,
+				}}
+				witnesses.redeemers.(*mockRedeemers).valueOverride = &value
+				require.NoError(t, tc.validate(tx, ls, lcommon.ExUnits{
+					Steps:  1_000_000,
+					Memory: 1_000_000,
+				}))
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- cap restrictive Plutus evaluation at the protocol transaction resource limit in Alonzo, Babbage, and Conway
- retain the post-execution comparison against each redeemer's declared budget
- cover protocol-cap exhaustion, valid execution, and final slippage-batch accounting

## Checks

- `go test -race -timeout 20m ./ledger/eras`
- `go test -race -timeout 20m ./internal/test/conformance`
- `golangci-lint run --allow-parallel-runners ./ledger/eras`
- `nilaway ./ledger/eras`
- `modernize ./ledger/eras`
- `go test ./internal/architecture ./internal/docsparity`
- `make golines`
- `git diff --check`

Fixes #3435
