### PR TITLE
fix(bark): allow long-running streaming responses

### DIFF
--- a/bark/bark.go
+++ b/bark/bark.go
@@ -309,7 +309,6 @@ func (b *Bark) Start(ctx context.Context) error {
 			Addr:              listenAddr,
 			Handler:           handler,
 			ReadHeaderTimeout: 60 * time.Second,
-			WriteTimeout:      30 * time.Second,
 			IdleTimeout:       120 * time.Second,
 		}
 	} else {
@@ -321,7 +320,6 @@ func (b *Bark) Start(ctx context.Context) error {
 			Handler:           handler,
 			Protocols:         unencryptedHTTP2Protocols(),
 			ReadHeaderTimeout: 60 * time.Second,
-			WriteTimeout:      30 * time.Second,
 			IdleTimeout:       120 * time.Second,
 		}
 	}

--- a/bark/bark_test.go
+++ b/bark/bark_test.go
@@ -40,6 +40,43 @@ func TestBarkListenAddrSupportsIPv6(t *testing.T) {
 	require.Equal(t, "127.0.0.1:9091", barkListenAddr("127.0.0.1", 9091))
 }
 
+func TestBarkServerTimeoutsSupportStreaming(t *testing.T) {
+	testCases := []struct {
+		name   string
+		useTLS bool
+	}{
+		{name: "cleartext"},
+		{name: "TLS", useTLS: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := BarkConfig{
+				DB:   newTestDB(t),
+				Host: "127.0.0.1",
+				Port: freeTCPPort(t),
+			}
+			if testCase.useTLS {
+				cfg.TlsCertFilePath, cfg.TlsKeyFilePath = writeTestTLSCertKey(t)
+			}
+
+			b, err := NewBark(cfg)
+			require.NoError(t, err)
+			require.NoError(t, b.Start(context.Background()))
+			t.Cleanup(func() { _ = b.Stop(context.Background()) })
+
+			b.mu.Lock()
+			server := b.server
+			b.mu.Unlock()
+			require.NotNil(t, server)
+			require.Zero(t, server.WriteTimeout,
+				"streaming responses must not have an overall write deadline")
+			require.Equal(t, 60*time.Second, server.ReadHeaderTimeout)
+			require.Equal(t, 120*time.Second, server.IdleTimeout)
+		})
+	}
+}
+
 // TestAcquireReturnsCurrentDB verifies the ordinary, uncontended path: a
 // database was set at construction time, so Acquire hands it back with a
 // working release func.

--- a/bark/bark_test.go
+++ b/bark/bark_test.go
@@ -51,6 +51,7 @@ func TestBarkServerTimeoutsSupportStreaming(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			serverCtx, cancelServer := context.WithCancel(t.Context())
 			cfg := BarkConfig{
 				DB:   newTestDB(t),
 				Host: "127.0.0.1",
@@ -62,8 +63,15 @@ func TestBarkServerTimeoutsSupportStreaming(t *testing.T) {
 
 			b, err := NewBark(cfg)
 			require.NoError(t, err)
-			require.NoError(t, b.Start(context.Background()))
-			t.Cleanup(func() { _ = b.Stop(context.Background()) })
+			t.Cleanup(func() {
+				cancelServer()
+				require.Eventually(t, func() bool {
+					return b.Addr() == ""
+				}, 5*time.Second, 10*time.Millisecond,
+					"Bark server must finish context-triggered shutdown")
+				require.NoError(t, b.Stop(context.Background()))
+			})
+			require.NoError(t, b.Start(serverCtx))
 
 			b.mu.Lock()
 			server := b.server


### PR DESCRIPTION
Removes the fixed response write deadline from both TLS and cleartext Bark HTTP servers so server-streaming RPCs can remain active. Read-header and idle timeouts remain unchanged.

Adds regression coverage for both transport configurations.

Closes #3448
