### PR TITLE
fix(connmanager): bound inbound handshake time

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -548,12 +548,16 @@ The connection manager wraps TCP bearers with an idle-aware write deadline at
 both accept and dial boundaries, for NtC and N2N alike. Each write refreshes the
 two-minute deadline just before the syscall, so a peer that stops reading cannot
 hold a protocol goroutine in `Write` forever while healthy long-lived Ouroboros
-sessions are unaffected. Read deadlines stay with the muxer, which sets its own
-per-segment deadline as slowloris protection; refreshing a read deadline per
-`Read` would override that protocol-managed bound and let a peer dribbling bytes
-keep a segment read open indefinitely. Helpers needing the concrete socket type
-(SO_LINGER, Unix peer credentials) unwrap through the wrapper, so wrapping an
-accepted connection never silently disables them.
+sessions are unaffected. Accepted connections perform their potentially blocking
+handshake in a tracked per-connection goroutine, so a silent peer cannot serialize
+the listener's accept loop. During that unauthenticated window, a generic
+connection wrapper caps the muxer's per-segment read deadline at the listener's
+10-second handshake deadline. The wrapper clears the absolute deadline after
+negotiation, returning read-deadline ownership to the muxer for the normal
+long-lived session. Helpers needing the concrete socket type (SO_LINGER, Unix
+peer credentials) unwrap through the wrapper, so wrapping an accepted connection
+never silently disables them. Cancellation closes an in-flight bearer, and failed
+setup releases its reserved inbound and per-IP slots.
 
 ```mermaid
 graph TB

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -60,6 +60,7 @@ type ConnectionManager struct {
 	peerConnectivity map[string]peerConnectionSummary
 	metrics          *connectionManagerMetrics
 	listeners        []net.Listener
+	pendingConns     map[net.Conn]struct{}
 	config           ConnectionManagerConfig
 	// resolveDeferredOnce guards the one-time evaluation of
 	// ListenersProvider/OutboundConnOptsProvider. Using sync.Once also
@@ -176,6 +177,7 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 		),
 		inboundPeerAddrs: make(map[string]int),
 		peerConnectivity: make(map[string]peerConnectionSummary),
+		pendingConns:     make(map[net.Conn]struct{}),
 		ipConns:          make(map[string]int),
 	}
 	if cfg.PromRegistry != nil {
@@ -557,6 +559,11 @@ func (c *ConnectionManager) stopListeners() {
 		}
 	}
 	c.listeners = nil
+	pendingConns := make([]net.Conn, 0, len(c.pendingConns))
+	for conn := range c.pendingConns {
+		pendingConns = append(pendingConns, conn)
+	}
+	clear(c.pendingConns)
 	c.listenersMutex.Unlock()
 
 	for _, listener := range listeners {
@@ -566,6 +573,13 @@ func (c *ConnectionManager) stopListeners() {
 				"error", err,
 			)
 		}
+	}
+	for _, conn := range pendingConns {
+		closeConnAndLog(
+			c.config.Logger,
+			conn,
+			"error closing pending inbound connection",
+		)
 	}
 }
 

--- a/connmanager/deadline_conn.go
+++ b/connmanager/deadline_conn.go
@@ -16,10 +16,16 @@ package connmanager
 
 import (
 	"net"
+	"sync"
 	"time"
 )
 
 const socketIdleTimeout = 2 * time.Minute
+
+// handshakeTimeout bounds the unauthenticated period for an accepted
+// connection. It is intentionally shorter than the socket idle timeout: the
+// listener must not wait for a peer that never completes the handshake.
+const handshakeTimeout = 10 * time.Second
 
 // deadlineConn bounds how long a single socket write may block. Nothing below
 // the Ouroboros muxer sets a write deadline, so a peer that stops reading can
@@ -49,6 +55,40 @@ func (c *deadlineConn) Write(p []byte) (int, error) {
 // type — SO_LINGER via enableTCPLingerZero, Unix peer credentials — must reach
 // through this wrapper rather than silently no-op on the type assertion.
 func (c *deadlineConn) Unwrap() net.Conn { return c.Conn }
+
+// handshakeDeadlineConn keeps the listener's absolute handshake deadline in
+// force while the muxer installs its per-segment read deadline. Without this
+// cap, the muxer can replace a short handshake deadline with its much longer
+// slowloris deadline before the first read completes.
+type handshakeDeadlineConn struct {
+	net.Conn
+	mu       sync.Mutex
+	deadline time.Time
+}
+
+func withHandshakeDeadline(conn net.Conn) *handshakeDeadlineConn {
+	return &handshakeDeadlineConn{Conn: conn}
+}
+
+func (c *handshakeDeadlineConn) SetDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deadline = deadline
+	return c.Conn.SetDeadline(deadline)
+}
+
+func (c *handshakeDeadlineConn) SetReadDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	handshakeDeadline := c.deadline
+	if !handshakeDeadline.IsZero() &&
+		(deadline.IsZero() || deadline.After(handshakeDeadline)) {
+		deadline = handshakeDeadline
+	}
+	return c.Conn.SetReadDeadline(deadline)
+}
+
+func (c *handshakeDeadlineConn) Unwrap() net.Conn { return c.Conn }
 
 // unwrapConn walks any chain of Unwrap-able wrappers down to the base
 // connection.

--- a/connmanager/deadline_conn_test.go
+++ b/connmanager/deadline_conn_test.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithSocketDeadlinesOnlyWrapsTCP(t *testing.T) {
@@ -77,6 +79,36 @@ func TestDeadlineConnLeavesReadDeadlineToTheMuxer(t *testing.T) {
 		t.Fatalf(
 			"expected only the muxer's SetReadDeadline call, got %d",
 			base.readDeadlineCalls,
+		)
+	}
+}
+
+func TestHandshakeDeadlineConnCapsMuxerReadDeadline(t *testing.T) {
+	base := &recordingConn{}
+	wrapped := withHandshakeDeadline(base)
+	handshakeDeadline := time.Now().Add(time.Second)
+	muxerDeadline := handshakeDeadline.Add(time.Minute)
+
+	require.NoError(t, wrapped.SetDeadline(handshakeDeadline))
+	require.NoError(t, wrapped.SetReadDeadline(muxerDeadline))
+	if !base.readDeadline.Equal(handshakeDeadline) {
+		t.Fatalf(
+			"muxer read deadline should not extend handshake deadline: want %v, got %v",
+			handshakeDeadline,
+			base.readDeadline,
+		)
+	}
+
+	// Once negotiation is complete, normal protocol-managed deadlines are
+	// restored and the wrapper no longer caps the muxer's read deadline.
+	require.NoError(t, wrapped.SetDeadline(time.Time{}))
+	postHandshakeDeadline := time.Now().Add(time.Minute)
+	require.NoError(t, wrapped.SetReadDeadline(postHandshakeDeadline))
+	if !base.readDeadline.Equal(postHandshakeDeadline) {
+		t.Fatalf(
+			"read deadline should be restored after handshake: want %v, got %v",
+			postHandshakeDeadline,
+			base.readDeadline,
 		)
 	}
 }

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -251,82 +251,29 @@ func (c *ConnectionManager) startListener(
 			// Successful accept - reset consecutive error count
 			consecutiveErrors = 0
 
-			// Bound socket writes before either path can hand the
-			// bearer to a protocol goroutine. This must cover NtC as
-			// well as N2N: a local client that stops reading wedges a
-			// write just like a remote peer does. Helpers below that
-			// need the concrete socket type (SO_LINGER, Unix peer
-			// credentials) unwrap through the wrapper.
+			// Bound socket writes before handing the bearer to the
+			// connection setup goroutine. This must cover NtC as well as
+			// N2N: a local client that stops reading wedges a write just
+			// like a remote peer does. Helpers below that need the concrete
+			// socket type (SO_LINGER, Unix peer credentials) unwrap through
+			// the wrapper.
 			conn = withSocketDeadlines(conn)
+			if !c.trackPendingConnection(conn) {
+				continue
+			}
 
-			// NtC (node-to-client) connections bypass the inbound
-			// slot budget and per-IP rate limiting — they are local
-			// clients (wallets, tools), not network peers.
+			// NtC connections bypass the inbound slot budget and per-IP
+			// limiting. Their handshake is still moved off the accept loop.
 			if l.UseNtC {
-				// Wrap UNIX connections
-				if uConn, ok := conn.(*net.UnixConn); ok {
-					tmpConn, err := NewUnixConn(uConn)
-					if err != nil {
-						c.config.Logger.Error(
-							fmt.Sprintf("listener: accept failed: %s", err),
-						)
-						// Close errors on this reject path are intentionally
-						// discarded throughout this loop: the connection is
-						// already being torn down, and the reason is the
-						// logged error above, not whatever Close() reports.
-						_ = conn.Close()
-						continue
-					}
-					conn = tmpConn
-				}
-				c.config.Logger.Info(
-					fmt.Sprintf(
-						"listener: accepted NtC connection from %s",
-						conn.RemoteAddr(),
-					),
-				)
-				connOpts := append(
-					defaultConnOpts,
-					ouroboros.WithConnection(conn),
-				)
-				oConn, err := ouroboros.NewConnection(connOpts...)
-				if err != nil {
-					c.config.Logger.Error(
-						fmt.Sprintf(
-							"listener: failed to setup NtC connection: %s",
-							err,
-						),
+				c.goroutineWg.Go(func() {
+					c.setupAcceptedConnection(
+						ctx,
+						conn,
+						l,
+						defaultConnOpts,
+						false,
 					)
-					_ = conn.Close()
-					continue
-				}
-				peerAddr := "unknown"
-				if conn.RemoteAddr() != nil {
-					peerAddr = conn.RemoteAddr().String()
-				}
-				if !c.addNtCConnectionWithIPKey(
-					oConn, true, peerAddr, "",
-				) {
-					continue
-				}
-				// Generate event
-				if c.config.EventBus != nil {
-					c.config.EventBus.Publish(
-						InboundConnectionEventType,
-						event.NewEvent(
-							InboundConnectionEventType,
-							InboundConnectionEvent{
-								ConnectionId: oConn.Id(),
-								LocalAddr:    conn.LocalAddr(),
-								RemoteAddr:   conn.RemoteAddr(),
-								NormalizedRemoteAddr: NormalizePeerAddr(
-									peerAddr,
-								),
-								IsNtC: true,
-							},
-						),
-					)
-				}
+				})
 				continue
 			}
 
@@ -347,7 +294,9 @@ func (c *ConnectionManager) startListener(
 				}
 			}
 
-			// N2N path: reserve an inbound slot before further processing
+			// N2N path: reserve an inbound slot before spawning setup. The
+			// handshake is intentionally outside this accept loop: one silent
+			// peer must not prevent the listener from accepting another peer.
 			if !c.tryReserveInboundSlot() {
 				c.config.Logger.Warn(
 					fmt.Sprintf(
@@ -359,100 +308,173 @@ func (c *ConnectionManager) startListener(
 				_ = conn.Close()
 				continue
 			}
-			// From here on, we hold a reserved inbound slot.
-			// If setup fails, we must release it.
-
-			// Wrap UNIX connections
-			if uConn, ok := conn.(*net.UnixConn); ok {
-				tmpConn, err := NewUnixConn(uConn)
-				if err != nil {
-					c.config.Logger.Error(
-						fmt.Sprintf("listener: accept failed: %s", err),
-					)
-					_ = conn.Close()
-					c.releaseInboundSlot()
-					continue
-				}
-				conn = tmpConn
-			}
-			// Per-IP rate limiting: reject if this IP has too many
-			// connections already
-			ipKey := ipKeyFromAddr(conn.RemoteAddr())
-			if !c.acquireIPSlot(ipKey) {
-				c.config.Logger.Warn(
-					fmt.Sprintf(
-						"listener: rejected connection from %s: per-IP limit (%d) reached",
-						conn.RemoteAddr(),
-						c.config.MaxConnectionsPerIP,
-					),
+			c.goroutineWg.Go(func() {
+				c.setupAcceptedConnection(
+					ctx,
+					conn,
+					l,
+					defaultConnOpts,
+					true,
 				)
-				_ = conn.Close()
-				c.releaseInboundSlot()
-				continue
-			}
-			// Setup Ouroboros connection
-			connOpts := append(
-				defaultConnOpts,
-				ouroboros.WithConnection(conn),
-			)
-			oConn, err := ouroboros.NewConnection(connOpts...)
-			if err != nil {
-				c.config.Logger.Info(
-					fmt.Sprintf(
-						"listener: inbound connection from %s failed: %s",
-						conn.RemoteAddr(),
-						err,
-					),
-				)
-				// Release the IP slot since the connection failed
-				c.releaseIPSlot(ipKey)
-				_ = conn.Close()
-				c.releaseInboundSlot()
-				continue
-			}
-			c.config.Logger.Info(
-				fmt.Sprintf(
-					"listener: inbound connection from %s",
-					conn.RemoteAddr(),
-				),
-			)
-			// Consume the reserved slot and add to connection manager.
-			// The reservation is released because AddConnection will
-			// add the actual connection entry to the map.
-			c.consumeInboundSlot()
-			peerAddr := "unknown"
-			if conn.RemoteAddr() != nil {
-				peerAddr = conn.RemoteAddr().String()
-			}
-			if !c.addConnectionWithIPKey(
-				oConn, true, peerAddr, ipKey,
-			) {
-				continue
-			}
-			// Generate event. IsDuplex is a best-effort snapshot of the
-			// negotiated diffusion mode at publish time; subscribers that
-			// need an authoritative answer should fall back to
-			// GetConnectionById, because on paths where the handshake has
-			// not yet completed the version data is still nil here.
-			if c.config.EventBus != nil {
-				c.config.EventBus.Publish(
-					InboundConnectionEventType,
-					event.NewEvent(
-						InboundConnectionEventType,
-						InboundConnectionEvent{
-							ConnectionId:         oConn.Id(),
-							LocalAddr:            conn.LocalAddr(),
-							RemoteAddr:           conn.RemoteAddr(),
-							NormalizedRemoteAddr: NormalizePeerAddr(peerAddr),
-							IsNtC:                l.UseNtC,
-							IsDuplex:             connectionIsDuplex(oConn),
-						},
-					),
-				)
-			}
+			})
 		}
 	})
 	return nil
+}
+
+// trackPendingConnection records a bearer accepted before its handshake has
+// completed. Stop closes these bearers as well as registered connections so a
+// shutdown does not wait for the handshake deadline to expire.
+func (c *ConnectionManager) trackPendingConnection(conn net.Conn) bool {
+	c.listenersMutex.Lock()
+	defer c.listenersMutex.Unlock()
+	if c.closing {
+		closeConnAndLog(
+			c.config.Logger,
+			conn,
+			"listener: close connection accepted during shutdown failed",
+		)
+		return false
+	}
+	c.pendingConns[conn] = struct{}{}
+	return true
+}
+
+func (c *ConnectionManager) untrackPendingConnection(conn net.Conn) {
+	c.listenersMutex.Lock()
+	delete(c.pendingConns, conn)
+	c.listenersMutex.Unlock()
+}
+
+// setupAcceptedConnection performs the potentially blocking handshake outside
+// the listener's accept loop. The absolute deadline is capped by
+// handshakeDeadlineConn so the muxer's longer segment deadline cannot extend
+// an unauthenticated connection's lifetime.
+func (c *ConnectionManager) setupAcceptedConnection(
+	ctx context.Context,
+	conn net.Conn,
+	l ListenerConfig,
+	defaultConnOpts []ouroboros.ConnectionOptionFunc,
+	inboundSlotReserved bool,
+) {
+	pendingConn := conn
+	defer c.untrackPendingConnection(pendingConn)
+	stopOnCancel := context.AfterFunc(ctx, func() {
+		_ = conn.Close()
+	})
+	defer func() {
+		stopOnCancel()
+	}()
+
+	// Wrap UNIX connections before applying the handshake wrapper so peer
+	// credentials and the unique Unix remote address remain available.
+	if uConn, ok := conn.(*net.UnixConn); ok {
+		tmpConn, err := NewUnixConn(uConn)
+		if err != nil {
+			c.config.Logger.Error("listener: accept failed", "error", err)
+			closeConnAndLog(c.config.Logger, conn, "listener: close failed")
+			if inboundSlotReserved {
+				c.releaseInboundSlot()
+			}
+			return
+		}
+		conn = tmpConn
+	}
+
+	ipKey := ""
+	if inboundSlotReserved {
+		ipKey = ipKeyFromAddr(conn.RemoteAddr())
+		if !c.acquireIPSlot(ipKey) {
+			c.config.Logger.Warn(
+				"listener: inbound connection rejected by per-IP limit",
+				"remote_addr", conn.RemoteAddr(),
+				"limit", c.config.MaxConnectionsPerIP,
+			)
+			closeConnAndLog(c.config.Logger, conn, "listener: close rejected connection failed")
+			c.releaseInboundSlot()
+			return
+		}
+	}
+
+	deadlineConn := withHandshakeDeadline(conn)
+	if err := deadlineConn.SetDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		c.config.Logger.Info("listener: failed to set handshake deadline", "error", err)
+		closeConnAndLog(c.config.Logger, conn, "listener: close failed")
+		if ipKey != "" {
+			c.releaseIPSlot(ipKey)
+		}
+		if inboundSlotReserved {
+			c.releaseInboundSlot()
+		}
+		return
+	}
+	conn = deadlineConn
+
+	connOpts := append(defaultConnOpts, ouroboros.WithConnection(conn))
+	oConn, err := ouroboros.NewConnection(connOpts...)
+	if err != nil {
+		if l.UseNtC {
+			c.config.Logger.Error("listener: failed to setup NtC connection", "error", err)
+		} else {
+			c.config.Logger.Info("listener: inbound connection failed", "error", err)
+		}
+		closeConnAndLog(c.config.Logger, conn, "listener: close failed")
+		if ipKey != "" {
+			c.releaseIPSlot(ipKey)
+		}
+		if inboundSlotReserved {
+			c.releaseInboundSlot()
+		}
+		return
+	}
+
+	// The handshake is complete; return the bearer to normal protocol-managed
+	// deadlines before registering it with the connection manager.
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		c.config.Logger.Warn("listener: failed to clear handshake deadline", "error", err)
+		closeConnAndLog(c.config.Logger, oConn, "listener: close failed")
+		if ipKey != "" {
+			c.releaseIPSlot(ipKey)
+		}
+		if inboundSlotReserved {
+			c.releaseInboundSlot()
+		}
+		return
+	}
+
+	peerAddr := "unknown"
+	if conn.RemoteAddr() != nil {
+		peerAddr = conn.RemoteAddr().String()
+	}
+	if l.UseNtC {
+		c.config.Logger.Info("listener: accepted NtC connection", "remote_addr", peerAddr)
+		if !c.addNtCConnectionWithIPKey(oConn, true, peerAddr, "") {
+			return
+		}
+	} else {
+		c.config.Logger.Info("listener: inbound connection", "remote_addr", peerAddr)
+		c.consumeInboundSlot()
+		if !c.addConnectionWithIPKey(oConn, true, peerAddr, ipKey) {
+			return
+		}
+	}
+
+	if c.config.EventBus != nil {
+		c.config.EventBus.Publish(
+			InboundConnectionEventType,
+			event.NewEvent(
+				InboundConnectionEventType,
+				InboundConnectionEvent{
+					ConnectionId:         oConn.Id(),
+					LocalAddr:            conn.LocalAddr(),
+					RemoteAddr:           conn.RemoteAddr(),
+					NormalizedRemoteAddr: NormalizePeerAddr(peerAddr),
+					IsNtC:                l.UseNtC,
+					IsDuplex:             connectionIsDuplex(oConn),
+				},
+			),
+		)
+	}
 }
 
 // calculateAcceptBackoff computes an exponential backoff duration based on

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -306,6 +306,7 @@ func (c *ConnectionManager) startListener(
 					),
 				)
 				_ = conn.Close()
+				c.untrackPendingConnection(conn)
 				continue
 			}
 			c.goroutineWg.Go(func() {
@@ -360,7 +361,7 @@ func (c *ConnectionManager) setupAcceptedConnection(
 	pendingConn := conn
 	defer c.untrackPendingConnection(pendingConn)
 	stopOnCancel := context.AfterFunc(ctx, func() {
-		_ = conn.Close()
+		_ = pendingConn.Close()
 	})
 	defer func() {
 		stopOnCancel()

--- a/connmanager/listener_test.go
+++ b/connmanager/listener_test.go
@@ -588,6 +588,45 @@ func TestInboundConnectionLimit_OutboundNotCounted(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAcceptLoopDoesNotBlockOnSilentHandshake(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mockLn := newToggleMockListener()
+	cfg := ConnectionManagerConfig{
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:    prometheus.NewRegistry(),
+		MaxInboundConns: 2,
+		Listeners: []ListenerConfig{{
+			Listener: mockLn,
+			ConnectionOpts: []ouroboros.ConnectionOptionFunc{
+				ouroboros.WithNetworkMagic(1),
+			},
+		}},
+	}
+
+	cm := NewConnectionManager(cfg)
+	ctx := t.Context()
+	require.NoError(t, cm.Start(ctx))
+	// Consume the signal for the initial Accept call. The next signal must
+	// come after the silent peer has been accepted and setup was dispatched.
+	require.True(t, mockLn.WaitForAcceptEntered(2*time.Second))
+
+	silent, peer := net.Pipe()
+	defer peer.Close()
+	mockLn.ProvideConnection(silent)
+	require.True(
+		t,
+		mockLn.WaitForAcceptEntered(2*time.Second),
+		"silent handshake must not serialize the listener accept loop",
+	)
+
+	// Stop must close pending handshakes instead of waiting for the production
+	// timeout. The accept worker is tracked and must exit cleanly.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	require.NoError(t, cm.Stop(stopCtx))
+}
+
 func TestAcceptLoopBackoffOnError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 

--- a/connmanager/listener_test.go
+++ b/connmanager/listener_test.go
@@ -627,6 +627,49 @@ func TestAcceptLoopDoesNotBlockOnSilentHandshake(t *testing.T) {
 	require.NoError(t, cm.Stop(stopCtx))
 }
 
+func TestInboundLimitRejectionUntracksPendingConnection(t *testing.T) {
+	mockLn := newToggleMockListener()
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		Logger:          slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:    prometheus.NewRegistry(),
+		MaxInboundConns: 1,
+		Listeners: []ListenerConfig{{
+			Listener: mockLn,
+		}},
+	})
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	// Occupy the only inbound slot so the accept loop rejects the next bearer
+	// before dispatching its handshake goroutine.
+	require.True(t, cm.tryReserveInboundSlot())
+	t.Cleanup(cm.releaseInboundSlot)
+	require.NoError(t, cm.Start(context.Background()))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		require.NoError(t, cm.Stop(ctx))
+	})
+	require.True(t, mockLn.WaitForAcceptEntered(2*time.Second))
+
+	rejected, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	mockLn.ProvideConnection(rejected)
+	require.True(
+		t,
+		mockLn.WaitForAcceptEntered(2*time.Second),
+		"accept loop must continue after the inbound limit rejection",
+	)
+
+	cm.listenersMutex.Lock()
+	pending := len(cm.pendingConns)
+	cm.listenersMutex.Unlock()
+	require.Zero(
+		t,
+		pending,
+		"a connection closed during admission must not remain pending",
+	)
+}
+
 func TestAcceptLoopBackoffOnError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
Fixes #3455

Inbound connection setup now runs in a tracked worker instead of serializing the listener's accept loop behind the Ouroboros handshake. Accepted bearers have a 10-second absolute handshake deadline that remains effective when the muxer installs its per-segment read deadline, and the deadline is cleared after negotiation. Shutdown closes pending handshakes and failed setup releases reserved inbound and per-IP capacity.

`ARCHITECTURE.md` documents the listener and handshake lifecycle. The regression test uses a silent in-memory peer to prove the accept loop continues accepting connections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds inbound handshake time and moves it off the accept loop so silent peers no longer block new accepts and unauthenticated connections can’t outlive 10s. Previously the accept loop waited for the `ouroboros` handshake and the muxer could extend read deadlines; now each accepted connection handshakes in a worker with a 10s absolute deadline that caps the muxer’s read deadline until negotiation completes.

- Introduces `handshakeDeadlineConn`: caps the muxer’s read deadline during negotiation and clears the absolute deadline after success.
- Tracks pending accepted sockets and closes them on Stop; untracks connections rejected by inbound/per-IP limits so they don’t linger as pending.
- Releases reserved inbound and per-IP capacity on setup failures.
- NtC still bypasses inbound/per-IP limits; Unix connections are unwrapped to preserve credentials and address behavior.
- Updates `ARCHITECTURE.md`; adds tests for deadline capping, a silent peer not blocking accepts, and untracking on limit rejection.

<sup>Written for commit a5982964693880d5071468a35df38280ca075cac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

