### PR TITLE
fix(mithril): rename and remove Windows extraction targets by handle

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -131,6 +131,46 @@ jobs:
         # validation runs in the publish workflow before draft creation.
         run: go test -tags dingo_extra_plugins -ldflags="-s -w" -timeout 20m ./...
 
+  # windows-latest also runs the full ./... suite in publish.yml's
+  # go-test-other, but only at release-tag time, after a change has already
+  # merged -- which is why the Windows-specific extraction code this job
+  # targets (mithril's NtCreateFile/NtSetInformationFile handle-relative
+  # rename and removal, see extract_handlerelative_windows.go and issue
+  # #3228) went unverified on real Windows CI before now. This job runs it on
+  # every PR instead.
+  #
+  # It stays scoped to ./mithril/... rather than ./..., deliberately: the
+  # release job's full-suite run currently fails on windows-latest for
+  # unrelated reasons (internal/test/devnet asserts a Unix-only UID:GID
+  # mapping; tracked separately), and running the same full suite here would
+  # block every PR on that pre-existing, unrelated breakage rather than on
+  # anything this job is meant to check. Widening this job's scope is
+  # follow-up work gated on auditing and fixing the rest of the suite for
+  # Windows, not something to do incidentally here.
+  go-test-windows:
+    name: go-test (Windows)
+    strategy:
+      matrix:
+        go-version: [1.26.x]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
+      - name: go-build
+        run: go build ./cmd/dingo
+      - name: go-test
+        run: go test -timeout 10m ./mithril/...
+
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3782,14 +3782,16 @@ Destinations come in two shapes, selected by the caller:
   it unlinks a regular file as readily as it removes a directory, which is
   exactly the behaviour that made such a swap costly.
 
-  Both platforms have a directory-only primitive, reached differently. Unix
-  uses `unlinkat` with `AT_REMOVEDIR`, addressed through the parent handle, so
-  neither the entry nor the parent can be redirected. Windows uses
-  `RemoveDirectory`, which fails on a file and on a populated directory but
-  addresses the entry by name, because Windows has no handle-relative removal;
-  a substituted parent could redirect it, which Windows makes hard by refusing
-  to move a directory while handles are open beneath it, and the parent is held
-  open for the whole extraction.
+  Both platforms have a directory-only primitive, addressed through the parent
+  handle so neither the entry nor the parent can be redirected. Unix uses
+  `unlinkat` with `AT_REMOVEDIR`. Windows has no directory-only removal in the
+  standard library, but `NtSetInformationFile`'s `FileDispositionInformation`
+  applied to a handle opened relative to the verified parent gets the same
+  guarantee: the entry is opened as a single component under that handle,
+  NTFS enforces emptiness the same way it does for `RemoveDirectory`, and
+  nothing here resolves the parent's name again the way the older
+  `RemoveDirectory`-by-path implementation did (`extract_handlerelative_windows.go`;
+  issue #3228).
 
   `WithReplaceDestination` remains the only path that removes a destination
   holding content, which is what that option exists to authorise.
@@ -3933,10 +3935,12 @@ stays inside it, which is enough to unlink a different file in the tree — and
 extraction's symlink checks run once, before the work, so the window is real.
 `openVerifiedParent` therefore opens each component through the one above it
 and confirms the handle refers to the entry the name denotes, holding those
-handles across the removal. On Windows only the immediate parent's own name is
-resolved a second time, since it has no handle-relative removal; that is the
-same residue `removeEmptyExtractDir` carries, now narrowed to one component and
-mitigated by the handle held on it.
+handles across the removal. Windows has no handle-relative rename or unlink
+through the standard library, but does through `NtSetInformationFile`: the
+final component is opened relative to the verified parent's own handle rather
+than resolved from a path, and the rename or deletion is applied to that open
+handle, so nothing here resolves any component's name a second time on either
+platform (`extract_handlerelative_windows.go`; issue #3228).
 
 After that, an in-place write needs write permission on a `0640` file owned by
 the node's user — which is the node's own user, and no filesystem check defends

--- a/mithril/extract_handlerelative_windows.go
+++ b/mithril/extract_handlerelative_windows.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package mithril
+
+import (
+	"errors"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// This file gives the three Windows extraction operations (rename, file
+// removal, directory removal) a way to address their target through a handle
+// rather than a path, closing the gap described in issue #3228.
+//
+// MoveFile, DeleteFile and RemoveDirectory all take a string and resolve it
+// themselves, which is a second, independent resolution of names
+// openVerifiedParent already walked and verified — a component swapped in the
+// instant between the walk and that second resolution is followed, not
+// rejected. NtCreateFile can instead open a name as a single component
+// relative to an already-open, already-verified directory handle
+// (OBJECT_ATTRIBUTES.RootDirectory), and NtSetInformationFile can then rename
+// or mark that same open object for deletion without ever handing the kernel
+// a path to resolve on its own. That is the same guarantee unlinkat/renameat
+// give on Unix, applied through the lower-level API Windows requires to get
+// it: golang.org/x/sys/windows exposes NtCreateFile and NtSetInformationFile
+// directly, but not the FILE_RENAME_INFORMATION/FILE_DISPOSITION_INFORMATION
+// request buffers those take, which this file builds by hand.
+//
+// The open itself still resolves one name — the final component, under the
+// verified parent — so it carries FILE_OPEN_REPARSE_POINT and an explicit
+// reparse-point check afterward, the same rejection openVerifiedRoot applies
+// to every component above it. A symlink planted at the leaf between the walk
+// finishing and this open running is refused here rather than followed, which
+// is the residual window the walk alone cannot close.
+
+// rootDirHandle returns a raw handle to root's own directory, obtained by
+// reopening "." relative to root's existing handle rather than by resolving
+// root's name again — the same operation openVerifiedRoot already performs
+// when it calls root.Stat("."). The returned file must be kept open, and
+// closed, for as long as the handle is used.
+func rootDirHandle(root *os.Root) (*os.File, windows.Handle, error) {
+	f, err := root.Open(".")
+	if err != nil {
+		return nil, 0, err
+	}
+	return f, windows.Handle(f.Fd()), nil
+}
+
+// ntStatusErrno converts an NTSTATUS failure from NtCreateFile or
+// NtSetInformationFile into the same syscall.Errno DeleteFile, MoveFile and
+// RemoveDirectory would have returned, so callers that check errors.Is against
+// fs.ErrNotExist / fs.ErrExist keep working unchanged.
+func ntStatusErrno(err error) error {
+	if status, ok := errors.AsType[windows.NTStatus](err); ok {
+		return status.Errno()
+	}
+	return err
+}
+
+// openRelativeForDeletion opens name as a single component relative to dir,
+// with DELETE access and no path of its own to resolve, then confirms the
+// result is neither a reparse point nor the wrong type. typeOption is
+// windows.FILE_NON_DIRECTORY_FILE or windows.FILE_DIRECTORY_FILE, matching the
+// type refusal DeleteFile/RemoveDirectory each already carry.
+func openRelativeForDeletion(
+	dir windows.Handle,
+	name string,
+	typeOption uint32,
+) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	oa := windows.OBJECT_ATTRIBUTES{
+		RootDirectory: dir,
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+	oa.Length = uint32(unsafe.Sizeof(oa))
+	var handle windows.Handle
+	var iosb windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&handle,
+		windows.DELETE|windows.SYNCHRONIZE,
+		&oa,
+		&iosb,
+		nil,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN,
+		windows.FILE_SYNCHRONOUS_IO_NONALERT|
+			windows.FILE_OPEN_REPARSE_POINT|
+			typeOption,
+		0,
+		0,
+	)
+	if err != nil {
+		return 0, ntStatusErrno(err)
+	}
+	if err := rejectReparsePoint(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+// rejectReparsePoint reports an error if handle refers to a reparse point
+// (symlink, junction, or similar). openRelativeForDeletion and
+// openRelativeForRename both pass FILE_OPEN_REPARSE_POINT so a reparse point
+// at the target opens the link itself rather than being followed; this is
+// what turns that non-following open into an outright refusal, matching what
+// openVerifiedRoot already does for every component above the leaf.
+func rejectReparsePoint(handle windows.Handle) error {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return err
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return ErrExtractUnsafePath
+	}
+	return nil
+}
+
+// setDeleteDisposition marks handle's underlying file or empty directory for
+// deletion. The removal becomes visible once every handle on the object,
+// including this one, is closed; closing it immediately after this call is
+// what makes the deletion effective before the caller returns.
+func setDeleteDisposition(handle windows.Handle) error {
+	var info fileDispositionInformation
+	info.DeleteFile = true
+	var iosb windows.IO_STATUS_BLOCK
+	err := windows.NtSetInformationFile(
+		handle,
+		&iosb,
+		(*byte)(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+		windows.FileDispositionInformation,
+	)
+	if err != nil {
+		return ntStatusErrno(err)
+	}
+	return nil
+}
+
+// fileDispositionInformation mirrors the classic (non-Ex) FILE_DISPOSITION_INFORMATION
+// the FileDispositionInformation class expects: a single BOOLEAN. Available
+// since Windows Vista, which covers every currently supported release,
+// unlike the newer FileDispositionInformationEx this deliberately does not
+// need.
+type fileDispositionInformation struct {
+	DeleteFile bool
+}
+
+// openRelativeForRename opens name as a single component relative to dir,
+// with the access NtSetInformationFile's FileRenameInformation requires, and
+// refuses a reparse point at the leaf for the same reason
+// openRelativeForDeletion does. The rename always moves a directory here
+// (renameExtractedDirectory's only callers move the staging directory), so
+// the open requires FILE_DIRECTORY_FILE.
+func openRelativeForRename(dir windows.Handle, name string) (windows.Handle, error) {
+	return openRelativeForDeletion(dir, name, windows.FILE_DIRECTORY_FILE)
+}
+
+// renameRelativeHandle renames the object source refers to, using
+// destDir/destName as the new location. Both endpoints are handle-relative:
+// source was opened through the verified parent above, and destDir is the
+// verified destination parent's own handle, so nothing here resolves a path
+// from the volume root. replaceIfExists mirrors MoveFile's behavior when
+// false: the call fails rather than replacing an existing destination.
+func renameRelativeHandle(
+	source windows.Handle,
+	destDir windows.Handle,
+	destName string,
+	replaceIfExists bool,
+) error {
+	info, err := buildRenameInformation(destDir, destName, replaceIfExists)
+	if err != nil {
+		return err
+	}
+	var iosb windows.IO_STATUS_BLOCK
+	err = windows.NtSetInformationFile(
+		source,
+		&iosb,
+		&info[0],
+		uint32(len(info)), //nolint:gosec // G115: a rename request buffer never approaches 4GiB
+		windows.FileRenameInformation,
+	)
+	if err != nil {
+		return ntStatusErrno(err)
+	}
+	return nil
+}
+
+// fileRenameInformationHeader mirrors the fixed portion of the classic
+// (non-Ex) FILE_RENAME_INFORMATION the FileRenameInformation class expects,
+// up to and including FileNameLength. The variable-length FileName that
+// follows it in the real structure is appended separately by
+// buildRenameInformation rather than declared here: Go, like the C struct
+// this mirrors, would pad the type out to RootDirectory's 8-byte alignment if
+// FileName were included, putting padding between FileNameLength and FileName
+// instead of the flush layout NtSetInformationFile requires. Declaring only
+// the fields up to FileNameLength and computing the FileName offset
+// explicitly (via unsafe.Offsetof, not unsafe.Sizeof) avoids that trap.
+type fileRenameInformationHeader struct {
+	ReplaceIfExists bool
+	RootDirectory   windows.Handle
+	FileNameLength  uint32
+}
+
+// buildRenameInformation lays out a FILE_RENAME_INFORMATION request buffer:
+// the fixed header immediately followed by newName encoded as UTF-16, with no
+// gap between FileNameLength and the name it describes.
+func buildRenameInformation(
+	destDir windows.Handle,
+	newName string,
+	replaceIfExists bool,
+) ([]byte, error) {
+	name16, err := windows.UTF16FromString(newName)
+	if err != nil {
+		return nil, err
+	}
+	// UTF16FromString appends a trailing NUL; FileNameLength must not count it.
+	name16 = name16[:len(name16)-1]
+	nameBytes := len(name16) * 2
+
+	var probe fileRenameInformationHeader
+	nameOffset := int(
+		unsafe.Offsetof(probe.FileNameLength) + unsafe.Sizeof(probe.FileNameLength),
+	)
+	buf := make([]byte, nameOffset+nameBytes)
+	hdr := (*fileRenameInformationHeader)(unsafe.Pointer(&buf[0]))
+	hdr.ReplaceIfExists = replaceIfExists
+	hdr.RootDirectory = destDir
+	//nolint:gosec // G115: nameBytes is a path component length, far below uint32 range
+	hdr.FileNameLength = uint32(nameBytes)
+	if nameBytes > 0 {
+		dst := unsafe.Slice((*uint16)(unsafe.Pointer(&buf[nameOffset])), len(name16))
+		copy(dst, name16)
+	}
+	return buf, nil
+}

--- a/mithril/extract_handlerelative_windows.go
+++ b/mithril/extract_handlerelative_windows.go
@@ -209,11 +209,14 @@ type fileDispositionInformation struct {
 // directory), so the open requires FILE_DIRECTORY_FILE. SYNCHRONIZE alongside
 // DELETE, and FILE_SYNCHRONOUS_IO_NONALERT alongside
 // FILE_OPEN_FOR_BACKUP_INTENT, mirror the access Renameat opens its rename
-// source with.
+// source with; that reference has no reparse-point check of its own, so
+// FILE_READ_ATTRIBUTES is added beyond it for the same reason
+// openRelativeForDeletion needs it: rejectReparsePoint's
+// GetFileInformationByHandle call below requires it.
 func openRelativeForRename(dir windows.Handle, name string) (windows.Handle, error) {
 	handle, err := openRelative(
 		dir, name,
-		windows.DELETE|windows.SYNCHRONIZE,
+		windows.DELETE|windows.SYNCHRONIZE|windows.FILE_READ_ATTRIBUTES,
 		windows.FILE_OPEN_REPARSE_POINT|
 			windows.FILE_OPEN_FOR_BACKUP_INTENT|
 			windows.FILE_SYNCHRONOUS_IO_NONALERT|

--- a/mithril/extract_handlerelative_windows.go
+++ b/mithril/extract_handlerelative_windows.go
@@ -83,6 +83,46 @@ func openRelativeForDeletion(
 	name string,
 	typeOption uint32,
 ) (windows.Handle, error) {
+	// FILE_OPEN_FOR_BACKUP_INTENT is what makes a minimal-access, handle-
+	// relative open like this one work at all: without it, NtCreateFile
+	// applies the normal traversal/listing access check a directory open
+	// otherwise needs, which DELETE (and, for a directory, FILE_DIRECTORY_FILE
+	// alone) does not satisfy. FILE_READ_ATTRIBUTES is requested alongside
+	// DELETE so rejectReparsePoint's GetFileInformationByHandle call below has
+	// what it needs. This mirrors the recipe Go's own os.Root uses internally
+	// on Windows for the same operations (internal/syscall/windows,
+	// Deleteat/Renameat) -- unimportable from here, but the reference this was
+	// built against. Every entry this touches is one extraction created or is
+	// about to replace, so the restrictive-ACL case that recipe's own
+	// DELETE-only fallback exists for does not apply here.
+	handle, err := openRelative(
+		dir, name,
+		windows.FILE_READ_ATTRIBUTES|windows.DELETE,
+		windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|typeOption,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if err := rejectReparsePoint(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+// openRelative opens name as a single component relative to dir using
+// NtCreateFile, addressing the entry through dir's handle rather than
+// resolving any part of a path. FILE_OPEN_FOR_BACKUP_INTENT and
+// OBJ_CASE_INSENSITIVE are always applied: the former is required for a
+// minimal-access open like this to succeed at all (see
+// openRelativeForDeletion), and NT native APIs are case-sensitive by default,
+// unlike every Win32 path-based API this replaces.
+func openRelative(
+	dir windows.Handle,
+	name string,
+	access uint32,
+	options uint32,
+) (windows.Handle, error) {
 	objectName, err := windows.NewNTUnicodeString(name)
 	if err != nil {
 		return 0, err
@@ -97,25 +137,19 @@ func openRelativeForDeletion(
 	var iosb windows.IO_STATUS_BLOCK
 	err = windows.NtCreateFile(
 		&handle,
-		windows.DELETE|windows.SYNCHRONIZE,
+		access,
 		&oa,
 		&iosb,
 		nil,
 		windows.FILE_ATTRIBUTE_NORMAL,
 		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
 		windows.FILE_OPEN,
-		windows.FILE_SYNCHRONOUS_IO_NONALERT|
-			windows.FILE_OPEN_REPARSE_POINT|
-			typeOption,
+		options,
 		0,
 		0,
 	)
 	if err != nil {
 		return 0, ntStatusErrno(err)
-	}
-	if err := rejectReparsePoint(handle); err != nil {
-		_ = windows.CloseHandle(handle)
-		return 0, err
 	}
 	return handle, nil
 }
@@ -168,13 +202,31 @@ type fileDispositionInformation struct {
 }
 
 // openRelativeForRename opens name as a single component relative to dir,
-// with the access NtSetInformationFile's FileRenameInformation requires, and
-// refuses a reparse point at the leaf for the same reason
-// openRelativeForDeletion does. The rename always moves a directory here
-// (renameExtractedDirectory's only callers move the staging directory), so
-// the open requires FILE_DIRECTORY_FILE.
+// with the access and options NtSetInformationFile's FileRenameInformation
+// requires of the handle it renames, and refuses a reparse point at the leaf
+// for the same reason openRelativeForDeletion does. The rename always moves a
+// directory here (renameExtractedDirectory's only callers move the staging
+// directory), so the open requires FILE_DIRECTORY_FILE. SYNCHRONIZE alongside
+// DELETE, and FILE_SYNCHRONOUS_IO_NONALERT alongside
+// FILE_OPEN_FOR_BACKUP_INTENT, mirror the access Renameat opens its rename
+// source with.
 func openRelativeForRename(dir windows.Handle, name string) (windows.Handle, error) {
-	return openRelativeForDeletion(dir, name, windows.FILE_DIRECTORY_FILE)
+	handle, err := openRelative(
+		dir, name,
+		windows.DELETE|windows.SYNCHRONIZE,
+		windows.FILE_OPEN_REPARSE_POINT|
+			windows.FILE_OPEN_FOR_BACKUP_INTENT|
+			windows.FILE_SYNCHRONOUS_IO_NONALERT|
+			windows.FILE_DIRECTORY_FILE,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if err := rejectReparsePoint(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
 }
 
 // renameRelativeHandle renames the object source refers to, using

--- a/mithril/extract_handlerelative_windows_layout_test.go
+++ b/mithril/extract_handlerelative_windows_layout_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package mithril
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// TestBuildRenameInformationLayout decodes the buffer by hand, at the byte
+// level, rather than casting it back through fileRenameInformationHeader —
+// the whole risk here is that Go's struct layout and NtSetInformationFile's
+// expected wire layout could silently disagree, and reinterpreting the same
+// bytes through the same struct would not catch that; only an independent,
+// offset-by-offset reading would.
+//
+// The layout is: ReplaceIfExists (1 byte), 7 bytes of alignment padding on a
+// 64-bit target, RootDirectory (pointer-sized), FileNameLength (4 bytes,
+// little-endian), then FileName immediately after with no further padding.
+func TestBuildRenameInformationLayout(t *testing.T) {
+	const destDir = windows.Handle(0x1234)
+	buf, err := buildRenameInformation(destDir, "dest.tmp", true)
+	require.NoError(t, err)
+
+	handleSize := int(unsafe.Sizeof(windows.Handle(0)))
+	// A 1-byte bool pads out to the handle's own alignment, which for a
+	// power-of-two size no larger than the handle equals the handle size
+	// itself.
+	rootDirOffset := handleSize
+	nameOffset := rootDirOffset + handleSize + 4
+
+	require.GreaterOrEqual(t, len(buf), nameOffset)
+	assert.Equal(t, byte(1), buf[0], "ReplaceIfExists must be TRUE")
+
+	var gotHandle uint64
+	for i := range handleSize {
+		gotHandle |= uint64(buf[rootDirOffset+i]) << (8 * i)
+	}
+	assert.Equal(t, uint64(destDir), gotHandle,
+		"RootDirectory must round-trip through the buffer")
+
+	nameLen := binary.LittleEndian.Uint32(buf[rootDirOffset+handleSize:])
+	assert.Equal(t, uint32(len("dest.tmp")*2), nameLen,
+		"FileNameLength must count UTF-16 bytes, excluding any terminator")
+	assert.Len(t, buf, nameOffset+int(nameLen),
+		"the buffer must hold exactly the header plus the encoded name, no extra padding")
+
+	gotName := windows.UTF16ToString(
+		unsafe.Slice((*uint16)(unsafe.Pointer(&buf[nameOffset])), nameLen/2),
+	)
+	assert.Equal(t, "dest.tmp", gotName)
+}
+
+func TestBuildRenameInformationReplaceIfExistsFalse(t *testing.T) {
+	buf, err := buildRenameInformation(windows.Handle(1), "x", false)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0), buf[0], "ReplaceIfExists must be FALSE")
+}
+
+func TestBuildRenameInformationEmptyName(t *testing.T) {
+	handleSize := int(unsafe.Sizeof(windows.Handle(0)))
+	rootDirOffset := handleSize
+	nameOffset := rootDirOffset + handleSize + 4
+	buf, err := buildRenameInformation(windows.Handle(1), "", true)
+	require.NoError(t, err)
+	assert.Len(t, buf, nameOffset)
+	assert.Equal(
+		t, uint32(0), binary.LittleEndian.Uint32(buf[rootDirOffset+handleSize:]),
+	)
+}

--- a/mithril/extract_handlerelative_windows_test.go
+++ b/mithril/extract_handlerelative_windows_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package mithril
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// These tests cover the case issue #3228 says the directory-component walk
+// (openVerifiedParent/openVerifiedRoot) cannot catch by itself: a component
+// the walk already verified is substituted afterward, while the walk's own
+// handle on it is still held. Under the old MoveFile/DeleteFile/RemoveDirectory
+// implementation that substitution was followed, because those APIs address
+// their target by resolving a path a second time. Each test therefore walks
+// and verifies a component first, substitutes it on disk exactly as a writer
+// with access to the parent could, and only then performs the operation —
+// reproducing the gap between verification and the act that a single,
+// uninterrupted call cannot exercise from outside.
+//
+// If any of these regress to a path-based resolution, they fail by acting on
+// the substituted tree instead of the one the walk verified.
+
+func TestHandleRelativeDeletionSurvivesParentSubstitution(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "real"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "real", "00000.chunk"), []byte("ours"), 0o640,
+	))
+
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	// This is exactly removeExtractedFile's own first step: walk and verify
+	// "real", holding the resulting handle open across what follows.
+	parent, base, release, err := openVerifiedParent(root, "real/00000.chunk")
+	require.NoError(t, err)
+	defer release()
+	require.Equal(t, "00000.chunk", base)
+	dirFile, dirHandle, err := rootDirHandle(parent)
+	require.NoError(t, err)
+	defer dirFile.Close()
+
+	// A writer with access to dir substitutes "real" after the walk above
+	// already verified and held it.
+	elsewhere := filepath.Join(dir, "elsewhere")
+	require.NoError(t, os.MkdirAll(elsewhere, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(elsewhere, "00000.chunk"), []byte("theirs"), 0o640,
+	))
+	requireDirectorySwap(
+		t, filepath.Join(dir, "real"), filepath.Join(dir, "real.moved-aside"),
+	)
+	requireSymlinkSupport(t, elsewhere, filepath.Join(dir, "real"))
+
+	// Addressed through dirHandle, obtained before the substitution — not
+	// through the name "real", which now refers to the symlink above.
+	handle, err := openRelativeForDeletion(
+		dirHandle, base, windows.FILE_NON_DIRECTORY_FILE,
+	)
+	require.NoError(t, err)
+	require.NoError(t, setDeleteDisposition(handle))
+	require.NoError(t, windows.CloseHandle(handle))
+
+	_, err = os.Lstat(filepath.Join(dir, "real.moved-aside", "00000.chunk"))
+	assert.True(t, os.IsNotExist(err),
+		"the file the walk verified must be removed through the held handle")
+	_, err = os.Lstat(filepath.Join(elsewhere, "00000.chunk"))
+	assert.NoError(t, err,
+		"the substituted tree must not be reachable through the held handle")
+}
+
+func TestHandleRelativeRmdirSurvivesParentSubstitution(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "real"), 0o750))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "real", "empty"), 0o750))
+
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	parent, base, release, err := openVerifiedParent(root, "real/empty")
+	require.NoError(t, err)
+	defer release()
+	require.Equal(t, "empty", base)
+	dirFile, dirHandle, err := rootDirHandle(parent)
+	require.NoError(t, err)
+	defer dirFile.Close()
+
+	elsewhere := filepath.Join(dir, "elsewhere")
+	require.NoError(t, os.MkdirAll(filepath.Join(elsewhere, "empty"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(elsewhere, "empty", "sentinel"), []byte("theirs"), 0o640,
+	))
+	requireDirectorySwap(
+		t, filepath.Join(dir, "real"), filepath.Join(dir, "real.moved-aside"),
+	)
+	requireSymlinkSupport(t, elsewhere, filepath.Join(dir, "real"))
+
+	handle, err := openRelativeForDeletion(
+		dirHandle, base, windows.FILE_DIRECTORY_FILE,
+	)
+	require.NoError(t, err)
+	require.NoError(t, setDeleteDisposition(handle))
+	require.NoError(t, windows.CloseHandle(handle))
+
+	_, err = os.Lstat(filepath.Join(dir, "real.moved-aside", "empty"))
+	assert.True(t, os.IsNotExist(err),
+		"the empty directory the walk verified must be removed")
+	_, err = os.Lstat(filepath.Join(elsewhere, "empty", "sentinel"))
+	assert.NoError(t, err,
+		"the substituted, non-empty directory must survive untouched")
+}
+
+func TestHandleRelativeRenameSurvivesParentSubstitution(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "real", "staging"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "destreal"), 0o750))
+
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	oldParent, oldBase, releaseOld, err := openVerifiedParent(root, "real/staging")
+	require.NoError(t, err)
+	defer releaseOld()
+	newParent, newBase, releaseNew, err := openVerifiedParent(root, "destreal/moved")
+	require.NoError(t, err)
+	defer releaseNew()
+	oldDirFile, oldDir, err := rootDirHandle(oldParent)
+	require.NoError(t, err)
+	defer oldDirFile.Close()
+	newDirFile, newDir, err := rootDirHandle(newParent)
+	require.NoError(t, err)
+	defer newDirFile.Close()
+
+	// A writer with access to dir substitutes both endpoints' parents after
+	// the walks above already verified and held them.
+	elsewhereOld := filepath.Join(dir, "elsewhere-old")
+	require.NoError(t, os.MkdirAll(elsewhereOld, 0o750))
+	requireDirectorySwap(
+		t, filepath.Join(dir, "real"), filepath.Join(dir, "real.moved-aside"),
+	)
+	requireSymlinkSupport(t, elsewhereOld, filepath.Join(dir, "real"))
+
+	elsewhereNew := filepath.Join(dir, "elsewhere-new")
+	require.NoError(t, os.MkdirAll(elsewhereNew, 0o750))
+	requireDirectorySwap(
+		t, filepath.Join(dir, "destreal"), filepath.Join(dir, "destreal.moved-aside"),
+	)
+	requireSymlinkSupport(t, elsewhereNew, filepath.Join(dir, "destreal"))
+
+	source, err := openRelativeForRename(oldDir, oldBase)
+	require.NoError(t, err)
+	defer func() { _ = windows.CloseHandle(source) }()
+	require.NoError(t, renameRelativeHandle(source, newDir, newBase, false))
+
+	_, err = os.Lstat(filepath.Join(dir, "destreal.moved-aside", "moved"))
+	assert.NoError(t, err,
+		"the rename must land beside the destination the walk verified")
+	entries, err := os.ReadDir(elsewhereNew)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "the substituted destination must receive nothing")
+
+	_, err = os.Lstat(filepath.Join(dir, "real.moved-aside", "staging"))
+	assert.True(t, os.IsNotExist(err),
+		"the directory the walk verified as the source must have moved")
+	entries, err = os.ReadDir(elsewhereOld)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "the substituted source parent must be untouched")
+}

--- a/mithril/extract_rename_windows.go
+++ b/mithril/extract_rename_windows.go
@@ -11,34 +11,33 @@
 package mithril
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/windows"
 )
 
-// MoveFile refuses an existing destination, unlike os.Root.Rename on
-// Windows, which uses MoveFileEx with replacement semantics. Exclusive
-// publication must never replace a non-directory destination implicitly.
+// Exclusive publication must never replace a non-directory destination
+// implicitly, so this refuses an existing destination the way MoveFile does,
+// unlike os.Root.Rename on Windows, which uses MoveFileEx with replacement
+// semantics.
 //
-// Both names are resolved the way removeExtractedFile resolves its target,
-// and for the same reason: MoveFile addresses paths, so handing it a path
-// rebuilt from root.Name() lets it follow a reparse point substituted for any
-// component after extraction's symlink checks ran. Each component is instead
-// walked through its parent's handle and confirmed to be the entry the name
-// denotes (openVerifiedParent), and those handles are held across the move.
+// Both endpoints are resolved the way removeExtractedFile resolves its
+// target, and for the same reason: a path handed to the kernel to resolve on
+// its own would let it follow a reparse point substituted for any component
+// after extraction's symlink checks ran. Each component is instead walked
+// through its parent's handle and confirmed to be the entry the name denotes
+// (openVerifiedParent), and those handles are held across the move.
 //
-// What that does and does not buy is worth stating exactly, because an earlier
-// version of this comment overstated it. The walk rejects a symlink or reparse
-// point that is already in place when it runs, which is the planted-component
-// case. It does not make the parents unswappable: os.Root opens every handle
-// with FILE_SHARE_DELETE (see internal/syscall/windows/at_windows.go), so
-// holding them does not stop another process renaming or deleting a verified
-// directory, and MoveFile resolves the parents' own names a second time.
-//
-// The race between the walk and the call therefore remains. Closing it needs
-// NtSetInformationFile with FileRenameInformation against the parent handle,
-// which is genuinely handle-relative; see issue #3228.
+// The rename itself is then handle-relative rather than path-based:
+// NtSetInformationFile's FileRenameInformation renames the object an
+// already-open handle refers to, naming the destination by its verified
+// parent's own handle and a single component rather than a path the kernel
+// resolves again — see extract_handlerelative_windows.go. That closes the gap
+// an earlier version of this comment described and issue #3228 tracked: this
+// no longer resolves either parent's name a second time, so a directory
+// renamed or deleted out from under a held parent handle no longer redirects
+// the move.
 func renameExtractedDirectory(root *os.Root, oldname, newname string) error {
 	oldParent, oldBase, releaseOld, err := openVerifiedParent(root, oldname)
 	if err != nil {
@@ -51,17 +50,25 @@ func renameExtractedDirectory(root *os.Root, oldname, newname string) error {
 	}
 	defer releaseNew()
 
-	oldpath, err := windows.UTF16PtrFromString(
-		filepath.Join(oldParent.Name(), oldBase),
-	)
+	oldDirFile, oldDir, err := rootDirHandle(oldParent)
 	if err != nil {
-		return err
+		return fmt.Errorf("opening rename source directory: %w", err)
 	}
-	newpath, err := windows.UTF16PtrFromString(
-		filepath.Join(newParent.Name(), newBase),
-	)
+	defer oldDirFile.Close()
+	newDirFile, newDir, err := rootDirHandle(newParent)
 	if err != nil {
-		return err
+		return fmt.Errorf("opening rename destination directory: %w", err)
 	}
-	return windows.MoveFile(oldpath, newpath)
+	defer newDirFile.Close()
+
+	source, err := openRelativeForRename(oldDir, oldBase)
+	if err != nil {
+		return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: err}
+	}
+	defer func() { _ = windows.CloseHandle(source) }()
+
+	if err := renameRelativeHandle(source, newDir, newBase, false); err != nil {
+		return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: err}
+	}
+	return nil
 }

--- a/mithril/extract_rmdir_unix.go
+++ b/mithril/extract_rmdir_unix.go
@@ -37,8 +37,8 @@ import (
 // handle, which is exactly that. name is a single path component, so it cannot
 // traverse out of root even before the handle constrains it.
 //
-// fullPath is unused here; the Windows implementation needs it because it has
-// no handle-relative removal to address the entry through.
+// fullPath is unused here; the Windows implementation keeps it only to name
+// the operation in its returned error, not to address the entry.
 func removeEmptyExtractDir(root *os.Root, name, _ string) error {
 	dir, err := root.Open(".")
 	if err != nil {

--- a/mithril/extract_rmdir_windows.go
+++ b/mithril/extract_rmdir_windows.go
@@ -23,30 +23,42 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// removeEmptyExtractDir removes fullPath only if it is an empty directory, and
-// reports an error for anything else.
+// removeEmptyExtractDir removes name from root only if it is an empty
+// directory, and reports an error for anything else.
 //
-// RemoveDirectory is the directory-only removal here. It fails with
-// ERROR_DIRECTORY on a file and ERROR_DIR_NOT_EMPTY on a populated directory,
-// so no separate type check is needed and none is done: establishing the type
-// and then removing would let a writer swap a file in between and have it
-// unlinked, which is the whole reason this is not os.Root.Remove.
+// Refusing a populated directory or a file is the removal itself, not a check
+// in front of it: establishing the type and then removing would let a writer
+// swap a file into the name in between and have it unlinked, which is the
+// whole reason this is not os.Root.Remove. NTFS enforces emptiness on the
+// underlying disposition set below the same way it enforces it for
+// RemoveDirectory, so nothing here checks it separately either.
 //
-// Unlike the Unix path this addresses the entry by name rather than through
-// the parent handle, because Windows has no handle-relative removal. A
-// substituted parent could therefore redirect it. The parent is held open for
-// the whole extraction, which does not prevent that: os.Root opens its handles
-// with FILE_SHARE_DELETE (see internal/syscall/windows/at_windows.go), so an
-// open handle does not stop another process renaming or deleting the
-// directory. The verified walk rejects a component already substituted when it
-// runs; the race against a concurrent substitution is open until the removal
-// is handle-relative. See issue #3228.
-func removeEmptyExtractDir(_ *os.Root, _, fullPath string) error {
-	path, err := windows.UTF16PtrFromString(fullPath)
+// root is the already-verified parent — callers pass the same handle
+// openVerifiedParent would resolve name's parent to, since name is always a
+// direct child of it here — so name is opened as a single component relative
+// to root's own handle rather than resolved from fullPath
+// (openRelativeForDeletion, setDeleteDisposition; see
+// extract_handlerelative_windows.go). That is what closes the gap issue #3228
+// tracked: earlier, only DeleteFile/RemoveDirectory's path was avoided for
+// removeExtractedFile's and renameExtractedDirectory's own final component,
+// while this operation still resolved fullPath directly and a substituted
+// parent could redirect it. Nothing here resolves any component's name a
+// second time now, and a reparse point substituted at name after root was
+// verified is refused at the open rather than followed.
+func removeEmptyExtractDir(root *os.Root, name, fullPath string) error {
+	dirFile, dir, err := rootDirHandle(root)
 	if err != nil {
-		return fmt.Errorf("resolving extraction destination: %w", err)
+		return fmt.Errorf("opening extraction parent: %w", err)
 	}
-	if err := windows.RemoveDirectory(path); err != nil {
+	defer dirFile.Close()
+
+	handle, err := openRelativeForDeletion(dir, name, windows.FILE_DIRECTORY_FILE)
+	if err != nil {
+		return &os.PathError{Op: "rmdir", Path: fullPath, Err: err}
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	if err := setDeleteDisposition(handle); err != nil {
 		return &os.PathError{Op: "rmdir", Path: fullPath, Err: err}
 	}
 	return nil

--- a/mithril/extract_unlink_unix.go
+++ b/mithril/extract_unlink_unix.go
@@ -45,8 +45,8 @@ import (
 // symlink whose target stays inside it, which is enough to unlink a different
 // file in the tree.
 //
-// fullPath is unused here; the Windows implementation needs it because it has
-// no handle-relative removal to address the entry through.
+// fullPath is unused here; the Windows implementation keeps it only to name
+// the operation in its returned error, not to address the entry.
 func removeExtractedFile(root *os.Root, name, _ string) error {
 	parent, base, release, err := openVerifiedParent(root, name)
 	if err != nil {

--- a/mithril/extract_unlink_windows.go
+++ b/mithril/extract_unlink_windows.go
@@ -19,7 +19,6 @@ package mithril
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/windows"
 )
@@ -27,41 +26,40 @@ import (
 // removeExtractedFile removes fullPath only if it is not a directory, and
 // reports an error for anything else.
 //
-// DeleteFile is the file-only removal here: it fails on a directory, so no
-// separate type check is needed and none is done — establishing the type and
-// then removing would let a writer swap a file in between and have it
-// unlinked, which is the whole reason this is not os.Root.Remove.
+// Refusing a directory is the deletion itself here, not a check in front of
+// it: establishing the type and then removing would let a writer swap a file
+// in between and have it unlinked, which is the whole reason this is not
+// os.Root.Remove.
 //
-// Unlike the Unix path the deletion itself is addressed by name, because
-// Windows has no handle-relative removal — the same limit removeEmptyExtractDir
-// carries, for the same reason.
-//
-// What is narrowed is everything above it. Every directory component is walked
-// through its parent's handle and confirmed to be the entry the name denotes
-// (openVerifiedParent), and those handles are held across the deletion, so a
-// reparse point substituted mid-extraction is refused during the walk rather
-// than followed by DeleteFile. Only the immediate parent's own name is
-// resolved a second time. Holding the parent handles does not prevent that
-// substitution: os.Root opens them with FILE_SHARE_DELETE (see
-// internal/syscall/windows/at_windows.go), so another process can still rename
-// or delete a verified directory. The walk rejects a component already
-// substituted when it runs; closing the remaining race needs a
-// handle-relative removal. See issue #3228.
+// Every directory component down to the parent is walked through its own
+// parent's handle and confirmed to be the entry the name denotes
+// (openVerifiedParent), and those handles are held across the deletion. The
+// final component is then opened relative to that verified parent's handle —
+// not resolved from a path — and the deletion is applied to that open handle
+// (openRelativeForDeletion, setDeleteDisposition; see
+// extract_handlerelative_windows.go), which is what closes the residual
+// window issue #3228 tracked: nothing here resolves any component's name a
+// second time, so a reparse point substituted at the leaf after the walk
+// finishes is refused at the open rather than followed.
 func removeExtractedFile(root *os.Root, name, fullPath string) error {
 	parent, base, release, err := openVerifiedParent(root, name)
 	if err != nil {
 		return err
 	}
 	defer release()
-	// Built from the verified walk rather than taken from the caller, so the
-	// name deleted is the one the handles above were checked for. fullPath is
-	// kept for the error, which is what an operator sees.
-	target := filepath.Join(parent.Name(), base)
-	path, err := windows.UTF16PtrFromString(target)
+	dirFile, dir, err := rootDirHandle(parent)
 	if err != nil {
-		return fmt.Errorf("resolving extraction destination: %w", err)
+		return fmt.Errorf("opening extraction directory: %w", err)
 	}
-	if err := windows.DeleteFile(path); err != nil {
+	defer dirFile.Close()
+
+	handle, err := openRelativeForDeletion(dir, base, windows.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		return &os.PathError{Op: "unlink", Path: fullPath, Err: err}
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	if err := setDeleteDisposition(handle); err != nil {
 		return &os.PathError{Op: "unlink", Path: fullPath, Err: err}
 	}
 	return nil


### PR DESCRIPTION
Fixes #3228.

## What

`MoveFile`, `DeleteFile` and `RemoveDirectory` each address their target by
path, which is a second, independent resolution of names `openVerifiedParent`
already walked and verified through parent handles. Since `os.Root` opens
every handle with `FILE_SHARE_DELETE`, any verified component substituted
between that walk finishing and the Windows API's own resolution running was
followed, not rejected — the walk only catches a symlink or reparse point
already in place when it runs, not one planted afterward.

This gives the three Windows extraction operations (rename, file removal,
directory removal) a genuinely handle-relative path instead, using
`NtCreateFile`/`NtSetInformationFile` from `golang.org/x/sys/windows` (which
exposes both functions directly, but not the
`FILE_RENAME_INFORMATION`/`FILE_DISPOSITION_INFORMATION` request buffers they
take — built by hand in `extract_handlerelative_windows.go`, with the offset
computation documented against the trap of using `unsafe.Sizeof` on a struct
with a variable-length trailing field).

`removeEmptyExtractDir` previously ignored its `root`/`name` parameters
entirely and resolved `fullPath` directly; it now takes the same
handle-relative path as the other two, closing a second, independent
resolution that existed there as well.

## Tests

- Per-operation substitution tests: verify a component, swap it on disk
  exactly as a writer with access to the parent could, then perform the
  operation — reproducing the gap between verification and the act that a
  single, uninterrupted call can't exercise from outside. Per the acceptance
  criteria, this is the case the walk alone cannot catch.
- Buffer-layout tests for the hand-built `FILE_RENAME_INFORMATION` encoding,
  decoded independently byte-by-byte rather than by casting back through the
  same struct.

## Verification

I have no Windows runtime available to me, so this is cross-compiled and
vetted clean for `windows/amd64` and `windows/arm64` (`go build`, `go vet`,
`golangci-lint run`, `nilaway`, `modernize`, `go test -c`), but that is
exactly the limit the issue calls out — "not cross-compilation alone." A
`go-test-windows` job (scoped to `./mithril/...`, see its commit for why) is
added alongside this so the fix gets real `windows-latest` execution as part
of this PR's own checks, rather than only at release-tag time. **Leaving this
as a draft until that job has actually run and passed** — will mark ready for
review once it's green, or fix and re-push if it isn't.

## Side finding

While confirming Windows CI actually works today, I found the release-only
`go-test-other (windows-latest)` job currently fails on the latest tag for an
unrelated, pre-existing reason (a Unix-only UID:GID assertion in
`internal/test/devnet`). Filed as #3432 rather than folding into this PR's
scope.

## Docs

`ARCHITECTURE.md` updated: the "Handles bind directories" section and the
publish-destination section both described the now-fixed Windows limitation
(including a "Windows refuses to move a directory while handles are open
beneath it" claim that issue #3228 itself flagged as false). `DATABASE.md` is
unaffected — no schema, query, or storage-plugin surface changes here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames and deletions on Windows now operate by handle instead of path, removing the second name resolution that allowed post-verification substitutions to redirect operations. Previously used `MoveFile`/`DeleteFile`/`RemoveDirectory`; now we open the leaf relative to the verified parent and apply rename/deletion to that handle, refusing leaf reparse points. Unlink remains file-only; rmdir remains directory-only.

- Windows: add handle-relative helpers using `golang.org/x/sys/windows` (`NtCreateFile`/`NtSetInformationFile`) with `FILE_OPEN_REPARSE_POINT`, `FILE_OPEN_FOR_BACKUP_INTENT`, and required access flags (`DELETE`, `FILE_READ_ATTRIBUTES`, plus `SYNCHRONIZE` for rename). Convert `NTSTATUS` to `syscall.Errno`. `removeEmptyExtractDir` now uses the same handle-relative path; errors return as `PathError`/`LinkError` naming the original path.
- Tests: add substitution tests for rename/unlink/rmdir and a byte-level layout test for the built `FILE_RENAME_INFORMATION` buffer.
- CI: add `go-test-windows` on `windows-latest` running `go test ./mithril/...` to exercise these changes on real Windows in PRs.
- Docs: update ARCHITECTURE to document handle-relative rename/unlink on Windows.

<sup>Written for commit 227d97d0d864f5ab0b7c8f4eca5636239db5fabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved Windows extraction safety by performing file, directory, rename, and cleanup operations relative to verified directory handles.
  * Prevented path redirection and symbolic-link substitution during extraction cleanup.

* **Bug Fixes**
  * Ensured operations continue to target the originally verified extraction location even if directory contents change.

* **Tests**
  * Added Windows coverage for deletion, directory removal, renaming, and operation-layout validation.

* **CI**
  * Added Windows pull request checks that build the CLI and run the Go test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->