### PR TITLE
fix(network): continue transaction ingestion after rejection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3439,11 +3439,13 @@ watermark-evicts transactions. Its TxSubmission intake waits for sufficient
 admission headroom, while direct submissions receive `MempoolFullError` above
 the rejection watermark. A transaction that repeatedly loses the available
 headroom race to another peer is dropped after a bounded retry streak so that
-one offer cannot stall the connection indefinitely. DAG intake currently
-requests one transaction ID per TxSubmission round trip, which can reduce
-inbound throughput on high-latency peer links. This is required because
-gouroboros acknowledges every ID returned by a peer; support for acknowledging
-only the fetched prefix would permit batched requests.
+one offer cannot stall the connection indefinitely. Per-item CBOR decode and
+mempool validation rejections are likewise logged and dropped without stopping
+the peer's intake pump; peer, protocol, or mempool shutdown still terminates the
+pump. DAG intake currently requests one transaction ID per TxSubmission round
+trip, which can reduce inbound throughput on high-latency peer links. This is
+required because gouroboros acknowledges every ID returned by a peer; support
+for acknowledging only the fetched prefix would permit batched requests.
 
 The selected pool manages pending transactions:
 

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -383,13 +383,19 @@ func (o *Ouroboros) txsubmissionServerInit(
 					)
 					return
 				}
-				for _, txBody := range txs {
+				for txIdx, txBody := range txs {
 					// Decode TX from CBOR
 					tx, err := ledger.NewTransactionFromCbor(
 						uint(txBody.EraId),
 						txBody.TxBody,
 					)
 					if err != nil {
+						var txId string
+						if txIdx < len(requestTxIds) {
+							txId = hex.EncodeToString(
+								requestTxIds[txIdx].TxId[:],
+							)
+						}
 						o.config.Logger.Error(
 							fmt.Sprintf(
 								"failed to parse transaction CBOR: %s",
@@ -399,8 +405,9 @@ func (o *Ouroboros) txsubmissionServerInit(
 							"protocol", "tx-submission",
 							"role", "server",
 							"connection_id", ctx.ConnectionId.String(),
+							"tx_id", txId,
 						)
-						return
+						continue
 					}
 					o.config.Logger.Debug(
 						"received tx",
@@ -441,6 +448,9 @@ func (o *Ouroboros) txsubmissionServerInit(
 					) {
 						return
 					}
+					if errors.Is(err, mempool.ErrMempoolStopped) {
+						return
+					}
 					if errors.Is(
 						err,
 						errTxsubmissionAdmissionRetriesExhausted,
@@ -476,7 +486,7 @@ func (o *Ouroboros) txsubmissionServerInit(
 							"role", "server",
 							"connection_id", ctx.ConnectionId.String(),
 						)
-						return
+						continue
 					}
 				}
 			}

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -391,7 +391,7 @@ func (o *Ouroboros) txsubmissionServerInit(
 					)
 					if err != nil {
 						var txId string
-						if txIdx < len(requestTxIds) {
+						if len(txs) == len(requestTxIds) {
 							txId = hex.EncodeToString(
 								requestTxIds[txIdx].TxId[:],
 							)

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,22 +69,88 @@ func (txsubmissionTestValidator) ValidateTxWithOverlay(
 	return nil
 }
 
-// txsubmissionRejectingValidator rejects every transaction, so that
-// AddTransaction fails the way it would for a real mempool policy
-// violation (e.g. an invalid or already-spent UTxO), letting tests observe
-// how txsubmissionServerInit handles a mempool error during relay.
-type txsubmissionRejectingValidator struct{}
-
-func (txsubmissionRejectingValidator) ValidateTx(gledger.Transaction) error {
-	return errors.New("txsubmissionRejectingValidator: rejected")
+// txsubmissionSelectiveRejectingValidator rejects one transaction while
+// allowing later offers from the same peer to exercise the relay pump.
+type txsubmissionSelectiveRejectingValidator struct {
+	rejectedHash string
 }
 
-func (txsubmissionRejectingValidator) ValidateTxWithOverlay(
-	gledger.Transaction,
-	map[string]struct{},
-	map[string]lcommon.Utxo,
+func (v txsubmissionSelectiveRejectingValidator) ValidateTx(
+	tx gledger.Transaction,
 ) error {
-	return errors.New("txsubmissionRejectingValidator: rejected")
+	if tx.Hash().String() == v.rejectedHash {
+		return errors.New("txsubmissionSelectiveRejectingValidator: rejected")
+	}
+	return nil
+}
+
+func (v txsubmissionSelectiveRejectingValidator) ValidateTxWithOverlay(
+	tx gledger.Transaction,
+	_ map[string]struct{},
+	_ map[string]lcommon.Utxo,
+) error {
+	return v.ValidateTx(tx)
+}
+
+type txsubmissionCorruptingConsumer struct {
+	mempool.Consumer
+	corruptHash string
+}
+
+func (c *txsubmissionCorruptingConsumer) GetTxFromCache(
+	hash string,
+) *mempool.MempoolTransaction {
+	tx := c.Consumer.GetTxFromCache(hash)
+	if tx == nil || hash != c.corruptHash {
+		return tx
+	}
+	corrupted := *tx
+	corrupted.Cbor = []byte{0xff}
+	return &corrupted
+}
+
+type txsubmissionCorruptingService struct {
+	mempool.Service
+	corruptHash string
+	mu          sync.Mutex
+	consumers   map[ouroboros.ConnectionId]mempool.Consumer
+}
+
+func (s *txsubmissionCorruptingService) NewConsumer(
+	connId ouroboros.ConnectionId,
+) mempool.Consumer {
+	consumer := s.Service.NewConsumer(connId)
+	if consumer == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing := s.consumers[connId]; existing != nil {
+		return existing
+	}
+	wrapped := &txsubmissionCorruptingConsumer{
+		Consumer:    consumer,
+		corruptHash: s.corruptHash,
+	}
+	s.consumers[connId] = wrapped
+	return wrapped
+}
+
+func (s *txsubmissionCorruptingService) FindConsumer(
+	connId ouroboros.ConnectionId,
+) mempool.Consumer {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.consumers[connId]
+}
+
+func (s *txsubmissionCorruptingService) RemoveConsumer(
+	connId ouroboros.ConnectionId,
+) {
+	s.mu.Lock()
+	delete(s.consumers, connId)
+	s.mu.Unlock()
+	s.Service.RemoveConsumer(connId)
 }
 
 func TestRetryTxsubmissionAdmissionBoundsContention(t *testing.T) {
@@ -547,11 +614,12 @@ func newTxSubmissionRelayHarness(t *testing.T) *txSubmissionRelayHarness {
 // original behavior (a shared discard logger and permissive validators on
 // both nodes).
 type txSubmissionRelayHarnessOpts struct {
-	logger     *slog.Logger
-	validatorA mempool.TxValidator
-	validatorB mempool.TxValidator
-	capacityA  int64
-	dagA       bool
+	logger           *slog.Logger
+	validatorA       mempool.TxValidator
+	validatorB       mempool.TxValidator
+	capacityA        int64
+	dagA             bool
+	corruptOfferHash string
 }
 
 func newTxSubmissionRelayHarnessWithOpts(
@@ -614,7 +682,17 @@ func newTxSubmissionRelayHarnessWithOpts(
 	nodeA := newOuroboros(OuroborosConfig{ConnManager: cmA, Logger: logger})
 	nodeA.mempool = nodeAMempool
 	nodeB := newOuroboros(OuroborosConfig{ConnManager: cmB, Logger: logger})
-	nodeB.mempool = &mempool.FIFO{Mempool: mB}
+	nodeBMempool := mempool.Service(&mempool.FIFO{Mempool: mB})
+	if opts.corruptOfferHash != "" {
+		nodeBMempool = &txsubmissionCorruptingService{
+			Service:     nodeBMempool,
+			corruptHash: opts.corruptOfferHash,
+			consumers: make(
+				map[ouroboros.ConnectionId]mempool.Consumer,
+			),
+		}
+	}
+	nodeB.mempool = nodeBMempool
 
 	serverPipe, clientPipe := net.Pipe()
 
@@ -883,15 +961,14 @@ func TestTxSubmissionClientRequestTxsExpiredTransactionNotServed(t *testing.T) {
 	require.Empty(t, bodies)
 }
 
-// TestTxSubmissionServerInitMempoolRejectionLogsAndStopsCleanly verifies
-// that a mempool error while admitting a relayed transaction -- e.g. a
-// validator rejection -- is logged and the relay goroutine returns cleanly
-// instead of panicking or wedging the connection. Node A's mempool rejects
-// every transaction so a real, well-formed relay reaches
-// Mempool.AddTransaction's error path inside txsubmissionServerInit.
-func TestTxSubmissionServerInitMempoolRejectionLogsAndStopsCleanly(
+// TestTxSubmissionServerInitContinuesAfterMempoolRejection verifies a rejected
+// transaction does not stop later offers on the same connection.
+func TestTxSubmissionServerInitContinuesAfterMempoolRejection(
 	t *testing.T,
 ) {
+	fixtures := txsubmissionTestFixtures(t)
+	rejected := fixtures[0]
+	accepted := fixtures[1]
 	logBuf := &lockedBuffer{}
 	logger := slog.New(
 		slog.NewJSONHandler(
@@ -901,14 +978,14 @@ func TestTxSubmissionServerInitMempoolRejectionLogsAndStopsCleanly(
 	)
 
 	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
-		logger:     logger,
-		validatorA: txsubmissionRejectingValidator{},
+		logger: logger,
+		validatorA: txsubmissionSelectiveRejectingValidator{
+			rejectedHash: rejected.hash,
+		},
 	})
 	defer h.close(t)
 
-	txBytes, err := hex.DecodeString(txsubmissionRelayTestTxHex)
-	require.NoError(t, err)
-	require.NoError(t, h.mB.AddTransaction(txsubmissionRelayTestEraId, txBytes))
+	addTxSubmissionTestFixtures(t, h.mB, rejected, accepted)
 
 	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
 
@@ -921,10 +998,68 @@ func TestTxSubmissionServerInitMempoolRejectionLogsAndStopsCleanly(
 		10*time.Millisecond,
 		"expected the mempool rejection to be logged",
 	)
+	require.Contains(t, logBuf.String(), rejected.hash)
+	require.Contains(t, logBuf.String(), h.connA.Id().String())
 
-	require.Empty(
+	require.Eventually(
 		t,
-		h.mA.Transactions(),
-		"rejected transaction must not be admitted to the mempool",
+		func() bool {
+			_, ok := h.mA.GetTransaction(accepted.hash)
+			return ok
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected a valid transaction after a rejection to be processed on the same connection",
 	)
+	_, rejectedPresent := h.mA.GetTransaction(rejected.hash)
+	require.False(t, rejectedPresent)
+}
+
+// TestTxSubmissionServerInitContinuesAfterDecodeFailure verifies malformed
+// transaction CBOR does not stop later offers on the same connection.
+func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)
+	malformed := fixtures[0]
+	accepted := fixtures[1]
+	logBuf := &lockedBuffer{}
+	logger := slog.New(
+		slog.NewJSONHandler(
+			logBuf,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		logger:           logger,
+		corruptOfferHash: malformed.hash,
+	})
+	defer h.close(t)
+
+	addTxSubmissionTestFixtures(t, h.mB, malformed, accepted)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+
+	require.Eventually(
+		t,
+		func() bool {
+			return strings.Contains(
+				logBuf.String(),
+				"failed to parse transaction CBOR",
+			)
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected the malformed transaction to be logged",
+	)
+	require.Eventually(
+		t,
+		func() bool {
+			_, ok := h.mA.GetTransaction(accepted.hash)
+			return ok
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected a valid transaction after malformed CBOR to be processed on the same connection",
+	)
+	require.Contains(t, logBuf.String(), malformed.hash)
+	require.Contains(t, logBuf.String(), h.connA.Id().String())
 }

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -95,11 +95,15 @@ func (v txsubmissionSelectiveRejectingValidator) ValidateTxWithOverlay(
 type txsubmissionCorruptingConsumer struct {
 	mempool.Consumer
 	corruptHash string
+	omitHash    string
 }
 
 func (c *txsubmissionCorruptingConsumer) GetTxFromCache(
 	hash string,
 ) *mempool.MempoolTransaction {
+	if hash == c.omitHash {
+		return nil
+	}
 	tx := c.Consumer.GetTxFromCache(hash)
 	if tx == nil || hash != c.corruptHash {
 		return tx
@@ -112,8 +116,15 @@ func (c *txsubmissionCorruptingConsumer) GetTxFromCache(
 type txsubmissionCorruptingService struct {
 	mempool.Service
 	corruptHash string
+	omitHash    string
 	mu          sync.Mutex
 	consumers   map[ouroboros.ConnectionId]mempool.Consumer
+}
+
+// txsubmissionServiceWithoutHeadroom limits the wrapped service's method set
+// to mempool.Service so the relay pump uses its batched-request path.
+type txsubmissionServiceWithoutHeadroom struct {
+	mempool.Service
 }
 
 func (s *txsubmissionCorruptingService) NewConsumer(
@@ -131,6 +142,7 @@ func (s *txsubmissionCorruptingService) NewConsumer(
 	wrapped := &txsubmissionCorruptingConsumer{
 		Consumer:    consumer,
 		corruptHash: s.corruptHash,
+		omitHash:    s.omitHash,
 	}
 	s.consumers[connId] = wrapped
 	return wrapped
@@ -620,6 +632,8 @@ type txSubmissionRelayHarnessOpts struct {
 	capacityA        int64
 	dagA             bool
 	corruptOfferHash string
+	omitOfferHash    string
+	batchRequestsA   bool
 }
 
 func newTxSubmissionRelayHarnessWithOpts(
@@ -664,6 +678,11 @@ func newTxSubmissionRelayHarnessWithOpts(
 		require.NoError(t, err)
 		nodeAMempool = &mempool.FIFO{Mempool: mA}
 	}
+	if opts.batchRequestsA {
+		nodeAMempool = &txsubmissionServiceWithoutHeadroom{
+			Service: nodeAMempool,
+		}
+	}
 	mB, err := mempool.NewMempool(mempool.MempoolConfig{
 		Logger:          logger,
 		PromRegistry:    prometheus.NewRegistry(),
@@ -683,10 +702,11 @@ func newTxSubmissionRelayHarnessWithOpts(
 	nodeA.mempool = nodeAMempool
 	nodeB := newOuroboros(OuroborosConfig{ConnManager: cmB, Logger: logger})
 	nodeBMempool := mempool.Service(&mempool.FIFO{Mempool: mB})
-	if opts.corruptOfferHash != "" {
+	if opts.corruptOfferHash != "" || opts.omitOfferHash != "" {
 		nodeBMempool = &txsubmissionCorruptingService{
 			Service:     nodeBMempool,
 			corruptHash: opts.corruptOfferHash,
+			omitHash:    opts.omitOfferHash,
 			consumers: make(
 				map[ouroboros.ConnectionId]mempool.Consumer,
 			),
@@ -1072,4 +1092,49 @@ func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
 		10*time.Millisecond,
 		"expected a valid transaction after malformed CBOR to be processed on the same connection",
 	)
+}
+
+// TestTxSubmissionServerInitDoesNotMislabelPartialMalformedResponse verifies
+// a body shifted forward by an earlier cache miss is not labeled with the
+// missing transaction's ID when its CBOR cannot be decoded.
+func TestTxSubmissionServerInitDoesNotMislabelPartialMalformedResponse(
+	t *testing.T,
+) {
+	fixtures := txsubmissionTestFixtures(t)
+	omitted := fixtures[0]
+	malformed := fixtures[1]
+	logBuf := &lockedBuffer{}
+	logger := slog.New(
+		slog.NewJSONHandler(
+			logBuf,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		logger:           logger,
+		corruptOfferHash: malformed.hash,
+		omitOfferHash:    omitted.hash,
+		batchRequestsA:   true,
+	})
+	defer h.close(t)
+
+	addTxSubmissionTestFixtures(t, h.mB, omitted, malformed)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+
+	require.Eventually(
+		t,
+		func() bool {
+			return strings.Contains(
+				logBuf.String(),
+				"failed to parse transaction CBOR",
+			)
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected the partial malformed response to be logged",
+	)
+	logOutput := logBuf.String()
+	require.Contains(t, logOutput, `"tx_id":""`)
+	require.NotContains(t, logOutput, `"tx_id":"`+omitted.hash+`"`)
 }

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -985,7 +985,7 @@ func TestTxSubmissionServerInitContinuesAfterMempoolRejection(
 	})
 	defer h.close(t)
 
-	addTxSubmissionTestFixtures(t, h.mB, rejected, accepted)
+	addTxSubmissionTestFixtures(t, h.mB, rejected)
 
 	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
 
@@ -1000,6 +1000,13 @@ func TestTxSubmissionServerInitContinuesAfterMempoolRejection(
 	)
 	require.Contains(t, logBuf.String(), rejected.hash)
 	require.Contains(t, logBuf.String(), h.connA.Id().String())
+	_, rejectedPresent := h.mA.GetTransaction(rejected.hash)
+	require.False(t, rejectedPresent)
+
+	// Offer the valid transaction only after the rejected item completed its
+	// own round trip. This proves the same per-peer pump requests another batch
+	// instead of merely processing a later item from the first batch.
+	addTxSubmissionTestFixtures(t, h.mB, accepted)
 
 	require.Eventually(
 		t,
@@ -1011,8 +1018,6 @@ func TestTxSubmissionServerInitContinuesAfterMempoolRejection(
 		10*time.Millisecond,
 		"expected a valid transaction after a rejection to be processed on the same connection",
 	)
-	_, rejectedPresent := h.mA.GetTransaction(rejected.hash)
-	require.False(t, rejectedPresent)
 }
 
 // TestTxSubmissionServerInitContinuesAfterDecodeFailure verifies malformed
@@ -1035,7 +1040,7 @@ func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
 	})
 	defer h.close(t)
 
-	addTxSubmissionTestFixtures(t, h.mB, malformed, accepted)
+	addTxSubmissionTestFixtures(t, h.mB, malformed)
 	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
 
 	require.Eventually(
@@ -1050,6 +1055,13 @@ func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
 		10*time.Millisecond,
 		"expected the malformed transaction to be logged",
 	)
+	require.Contains(t, logBuf.String(), malformed.hash)
+	require.Contains(t, logBuf.String(), h.connA.Id().String())
+
+	// Offer the valid transaction only after the malformed item completed its
+	// own round trip. This proves the same per-peer pump requests another batch.
+	addTxSubmissionTestFixtures(t, h.mB, accepted)
+
 	require.Eventually(
 		t,
 		func() bool {
@@ -1060,6 +1072,4 @@ func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
 		10*time.Millisecond,
 		"expected a valid transaction after malformed CBOR to be processed on the same connection",
 	)
-	require.Contains(t, logBuf.String(), malformed.hash)
-	require.Contains(t, logBuf.String(), h.connA.Id().String())
 }


### PR DESCRIPTION
- Continue the per-peer transaction intake pump after individual CBOR decode or mempool validation rejections.
- Preserve terminal shutdown behavior for peer, protocol, and mempool shutdown.
- Cover malformed and validation-rejected transactions followed by a valid transaction on the same connection.

Closes #3449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction submission now continues processing after malformed or rejected transactions.
  * Subsequent valid transactions can still be relayed on the same connection.
  * Mempool shutdown errors now stop processing cleanly.
  * Improved logging identifies the affected transaction when available.

* **Documentation**
  * Reformatted transaction mempool documentation without changing its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->