### PR TITLE
fix(database): validate immutable index metadata

### DIFF
--- a/database/immutable/chunk.go
+++ b/database/immutable/chunk.go
@@ -80,11 +80,24 @@ func (c *chunk) Next() (*Block, error) {
 		// This triggers even though we check it above
 		// #nosec G115
 		currOffset := int64(c.currentEntry.BlockOffset)
+		if currOffset > c.fileSize {
+			return nil, fmt.Errorf(
+				"current block offset %d is beyond chunk size %d",
+				currOffset,
+				c.fileSize,
+			)
+		}
 
 		// We've reached the last entry in the chunk, so we calculate
 		// block size based on the size of the file
 		blockSize := c.fileSize - currOffset
-		blockData := make([]byte, blockSize)
+		if blockSize > int64(math.MaxInt) {
+			return nil, fmt.Errorf(
+				"block size %d exceeds platform allocation limit",
+				blockSize,
+			)
+		}
+		blockData := make([]byte, int(blockSize))
 		// Seek to offset
 		if _, err := c.file.Seek(currOffset, 0); err != nil {
 			return nil, err
@@ -129,9 +142,36 @@ func (c *chunk) Next() (*Block, error) {
 		// This triggers even though we check it above
 		// #nosec G115
 		nextOffset := int64(c.nextEntry.BlockOffset)
+		if currOffset > c.fileSize {
+			return nil, fmt.Errorf(
+				"current block offset %d is beyond chunk size %d",
+				currOffset,
+				c.fileSize,
+			)
+		}
+		if nextOffset > c.fileSize {
+			return nil, fmt.Errorf(
+				"next block offset %d is beyond chunk size %d",
+				nextOffset,
+				c.fileSize,
+			)
+		}
+		if nextOffset <= currOffset {
+			return nil, fmt.Errorf(
+				"next block offset %d does not follow current block offset %d",
+				nextOffset,
+				currOffset,
+			)
+		}
 
 		blockSize := nextOffset - currOffset
-		blockData := make([]byte, blockSize)
+		if blockSize > int64(math.MaxInt) {
+			return nil, fmt.Errorf(
+				"block size %d exceeds platform allocation limit",
+				blockSize,
+			)
+		}
+		blockData := make([]byte, int(blockSize))
 		// Seek to offset
 		if _, err := c.file.Seek(currOffset, 0); err != nil {
 			return nil, err

--- a/database/immutable/index_validation_test.go
+++ b/database/immutable/index_validation_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+
+	"github.com/blinklabs-io/dingo/database/immutable"
+)
+
+const secondaryIndexEntrySize = 56
+
+type immutableIndexFixture struct {
+	dir    string
+	points []ocommon.Point
+}
+
+func writeImmutableIndexFixture(
+	t *testing.T,
+	version byte,
+	primaryOffsets []uint32,
+	blockOffsets []uint64,
+) immutableIndexFixture {
+	t.Helper()
+	if len(blockOffsets) == 0 {
+		t.Fatal("fixture requires at least one block")
+	}
+	dir := t.TempDir()
+	primary := make([]byte, 1+4*len(primaryOffsets))
+	primary[0] = version
+	for i, offset := range primaryOffsets {
+		binary.BigEndian.PutUint32(primary[1+i*4:], offset)
+	}
+	secondary := make([]byte, secondaryIndexEntrySize*len(blockOffsets))
+	var chunk []byte
+	points := make([]ocommon.Point, 0, len(blockOffsets))
+	for i, blockOffset := range blockOffsets {
+		base := i * secondaryIndexEntrySize
+		binary.BigEndian.PutUint64(secondary[base:], blockOffset)
+		hash := make([]byte, 32)
+		for j := range hash {
+			hash[j] = byte(i + 1)
+		}
+		copy(secondary[base+16:base+48], hash)
+		slot := uint64(100 + i)
+		binary.BigEndian.PutUint64(secondary[base+48:], slot)
+		points = append(points, ocommon.NewPoint(slot, hash))
+
+		block, err := cbor.Encode([]any{
+			uint64(1),
+			cbor.RawMessage{0x80},
+		})
+		if err != nil {
+			t.Fatalf("encode fixture block: %s", err)
+		}
+		chunk = append(chunk, block...)
+	}
+	for name, data := range map[string][]byte{
+		"00000.chunk":     chunk,
+		"00000.primary":   primary,
+		"00000.secondary": secondary,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o640); err != nil {
+			t.Fatalf("write %s: %s", name, err)
+		}
+	}
+	return immutableIndexFixture{dir: dir, points: points}
+}
+
+func getBlockRecoveringPanic(
+	imm *immutable.ImmutableDb,
+	point ocommon.Point,
+) (block *immutable.Block, err error, panicValue any) {
+	defer func() {
+		panicValue = recover()
+	}()
+	block, err = imm.GetBlock(point)
+	return
+}
+
+func requireGetBlockError(
+	t *testing.T,
+	fixture immutableIndexFixture,
+	want string,
+) {
+	t.Helper()
+	imm, err := immutable.New(fixture.dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	_, err, panicValue := getBlockRecoveringPanic(imm, ocommon.Point{})
+	if panicValue != nil {
+		t.Fatalf(
+			"GetBlock panicked instead of returning an error: %v",
+			panicValue,
+		)
+	}
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("GetBlock error = %v, want an error containing %q", err, want)
+	}
+}
+
+func TestImmutableIndexAcceptsValidSingleAndMultipleBlockChunks(t *testing.T) {
+	tests := []struct {
+		name           string
+		primaryOffsets []uint32
+		blockOffsets   []uint64
+	}{
+		{
+			name:           "single block",
+			primaryOffsets: []uint32{0, secondaryIndexEntrySize},
+			blockOffsets:   []uint64{0},
+		},
+		{
+			name: "multiple blocks",
+			primaryOffsets: []uint32{
+				0,
+				secondaryIndexEntrySize,
+				2 * secondaryIndexEntrySize,
+			},
+			blockOffsets: []uint64{0, 3},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := writeImmutableIndexFixture(
+				t, 1, test.primaryOffsets, test.blockOffsets,
+			)
+			imm, err := immutable.New(fixture.dir)
+			if err != nil {
+				t.Fatalf("open immutable DB: %s", err)
+			}
+			iter, err := imm.BlocksFromPoint(ocommon.Point{})
+			if err != nil {
+				t.Fatalf("BlocksFromPoint returned an error: %s", err)
+			}
+			defer func() { _ = iter.Close() }()
+			block, err := iter.Next()
+			if err != nil {
+				t.Fatalf("iterator returned an error: %s", err)
+			}
+			if block == nil {
+				t.Fatal("iterator returned no block")
+			}
+			if block.Slot != fixture.points[0].Slot {
+				t.Fatalf(
+					"block slot = %d, want %d",
+					block.Slot,
+					fixture.points[0].Slot,
+				)
+			}
+		})
+	}
+}
+
+func TestImmutableIndexRejectsUnsupportedPrimaryVersion(t *testing.T) {
+	fixture := writeImmutableIndexFixture(
+		t, 2, []uint32{0, secondaryIndexEntrySize}, []uint64{0},
+	)
+	requireGetBlockError(t, fixture, "unsupported primary index version")
+}
+
+func TestImmutableIndexRejectsMisalignedSecondaryOffset(t *testing.T) {
+	fixture := writeImmutableIndexFixture(
+		t, 1, []uint32{1, secondaryIndexEntrySize}, []uint64{0},
+	)
+	requireGetBlockError(t, fixture, "not aligned")
+}
+
+func TestImmutableIndexRejectsNonMonotonicSecondaryOffsets(t *testing.T) {
+	fixture := writeImmutableIndexFixture(
+		t,
+		1,
+		[]uint32{0, secondaryIndexEntrySize, 0, 2 * secondaryIndexEntrySize},
+		[]uint64{0, 3},
+	)
+	requireGetBlockError(t, fixture, "non-monotonic")
+}
+
+func TestImmutableIndexRejectsLastBlockOffsetBeyondChunk(t *testing.T) {
+	fixture := writeImmutableIndexFixture(
+		t, 1, []uint32{0, secondaryIndexEntrySize}, []uint64{1000},
+	)
+	requireGetBlockError(t, fixture, "beyond chunk size")
+}
+
+func TestImmutableIndexRejectsDescendingBlockOffsets(t *testing.T) {
+	fixture := writeImmutableIndexFixture(
+		t,
+		1,
+		[]uint32{0, secondaryIndexEntrySize, 2 * secondaryIndexEntrySize},
+		[]uint64{3, 0},
+	)
+	requireGetBlockError(t, fixture, "does not follow current block offset")
+}
+
+func TestImmutableIndexRejectsMisalignedSecondaryFile(t *testing.T) {
+	fixture := writeImmutableIndexFixture(
+		t, 1, []uint32{0, secondaryIndexEntrySize}, []uint64{0},
+	)
+	secondaryPath := filepath.Join(fixture.dir, "00000.secondary")
+	f, err := os.OpenFile(secondaryPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open secondary index: %s", err)
+	}
+	if _, err := f.Write([]byte{0}); err != nil {
+		_ = f.Close()
+		t.Fatalf("extend secondary index: %s", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close secondary index: %s", err)
+	}
+	requireGetBlockError(
+		t,
+		fixture,
+		fmt.Sprintf("not aligned to %d-byte records", secondaryIndexEntrySize),
+	)
+}

--- a/database/immutable/primary.go
+++ b/database/immutable/primary.go
@@ -17,11 +17,13 @@ package immutable
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 )
 
 const (
 	primaryFileExtension = ".primary"
+	primaryIndexVersion  = 1
 )
 
 type primaryIndex struct {
@@ -53,6 +55,12 @@ func (p *primaryIndex) Open(f entryReader) error {
 	if err := binary.Read(f, binary.BigEndian, &p.version); err != nil {
 		return err
 	}
+	if p.version != primaryIndexVersion {
+		return fmt.Errorf(
+			"unsupported primary index version %d",
+			p.version,
+		)
+	}
 	return nil
 }
 
@@ -68,6 +76,20 @@ func (p *primaryIndex) Next() (*primaryIndexEntry, error) {
 			return nil, nil
 		}
 		return nil, err
+	}
+	if tmpOffset%secondaryIndexEntrySize != 0 {
+		return nil, fmt.Errorf(
+			"secondary index offset %d is not aligned to %d-byte records",
+			tmpOffset,
+			secondaryIndexEntrySize,
+		)
+	}
+	if p.seenFirstOffset && tmpOffset < p.lastOffset {
+		return nil, fmt.Errorf(
+			"non-monotonic secondary index offset: %d follows %d",
+			tmpOffset,
+			p.lastOffset,
+		)
 	}
 	empty := true
 	if tmpOffset > p.lastOffset || !p.seenFirstOffset {

--- a/database/immutable/secondary.go
+++ b/database/immutable/secondary.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	secondaryFileExtension = ".secondary"
+	secondaryFileExtension  = ".secondary"
+	secondaryIndexEntrySize = 56
 )
 
 type secondaryIndex struct {
@@ -55,6 +56,13 @@ func (s *secondaryIndex) Open(f entryReader, primary *primaryIndex) error {
 	if err != nil {
 		return err
 	}
+	if size%secondaryIndexEntrySize != 0 {
+		return fmt.Errorf(
+			"secondary index size %d is not aligned to %d-byte records",
+			size,
+			secondaryIndexEntrySize,
+		)
+	}
 	s.fileSize = size
 	return nil
 }
@@ -74,12 +82,20 @@ func (s *secondaryIndex) Next() (*secondaryIndexEntry, error) {
 	if nextOccupied == nil {
 		return nil, nil
 	}
+	secondaryOffset := int64(nextOccupied.SecondaryOffset)
 	// Look for final offset
-	if int64(nextOccupied.SecondaryOffset) == s.fileSize {
+	if secondaryOffset == s.fileSize {
 		return nil, nil
 	}
+	if secondaryOffset > s.fileSize {
+		return nil, fmt.Errorf(
+			"secondary index offset %d is beyond file size %d",
+			secondaryOffset,
+			s.fileSize,
+		)
+	}
 	// Seek to offset
-	if _, err := s.file.Seek(int64(nextOccupied.SecondaryOffset), 0); err != nil {
+	if _, err := s.file.Seek(secondaryOffset, 0); err != nil {
 		return nil, fmt.Errorf("failed while seeking: %w", err)
 	}
 	// Read entry

--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -118,7 +118,7 @@ func validImmutableFiles(
 		2, slot, firstPrev,
 	)
 	primary := make([]byte, 5)
-	primary[0] = 0
+	primary[0] = 1
 	binary.BigEndian.PutUint32(primary[1:], 0)
 	primary = append(primary, make([]byte, 4)...)
 	binary.BigEndian.PutUint32(primary[5:], 56)


### PR DESCRIPTION
## Summary

- Validate immutable primary and secondary index versions, record alignment,
  and offset ordering.
- Return errors for invalid chunk ranges before seeking or allocating.
- Preserve valid single-block and multi-block immutable data.
- Update the Mithril bootstrap fixture to the supported primary-index version.

Closes #3447

## Review summary (Cubic)

- Unsupported versions and malformed index offsets now fail explicitly.
- Out-of-spec immutable files must regenerate their index metadata.
