### PR TITLE
fix(forging): retain partially evolved KES key

### DIFF
--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -228,11 +228,11 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 		)
 	}
 
-	// Evolve KES key to the target period. kes.Update returns a new SecretKey
-	// with a deep copy of the data, so pc.kesSKey is only replaced on success.
-	evolvedKey := pc.kesSKey
-	for evolvedKey.Period < targetPeriod {
-		newKey, err := kes.Update(evolvedKey)
+	// kes.Update consumes its input key on success. Install each successor
+	// before the next update so a later failure cannot leave pc.kesSKey
+	// pointing at an erased predecessor.
+	for pc.kesSKey.Period < targetPeriod {
+		newKey, err := kes.Update(pc.kesSKey)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to update KES key to period %d (absolute %d): %w",
@@ -241,9 +241,8 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 				err,
 			)
 		}
-		evolvedKey = newKey
+		pc.kesSKey = newKey
 	}
-	pc.kesSKey = evolvedKey
 
 	return nil
 }

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -296,6 +296,28 @@ func TestKESPeriodUpdateExhaustedKey(t *testing.T) {
 	assert.True(t, ok, "key should still be usable after failed evolution")
 }
 
+func TestKESPeriodUpdatePartialFailureRetainsNewestKey(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, pc.UpdateKESPeriod(62))
+
+	// The update to period 64 first succeeds from 62 to 63, then fails
+	// because a depth-6 key cannot evolve beyond period 63. The successful
+	// successor is the only key that remains usable after forward evolution.
+	err := pc.UpdateKESPeriod(64)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "key is exhausted at period 63")
+	require.Equal(t, uint64(63), pc.kesSKey.Period)
+	require.NotEmpty(t, pc.kesSKey.Data)
+
+	message := []byte("test message after partial evolution failure")
+	signature, err := pc.KESSign(63, message)
+	require.NoError(t, err)
+	require.True(t, kes.VerifySignedKES(pc.kesVKey, 63, message, signature))
+}
+
 func TestKESPeriodUpdateBackward(t *testing.T) {
 	vrfPath, kesPath, opCertPath := createTestKeys(t)
 


### PR DESCRIPTION
Closes #3463

- retain every successfully evolved KES successor before the next step
- preserve signing at the last successful period when later evolution fails
- add partial-evolution regression coverage
