### PR TITLE
ci: preserve attestations in release manifests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -425,6 +425,8 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.3.0
       - name: Login to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0 https://github.com/docker/login-action/releases/tag/v4.6.0
         with:
@@ -459,27 +461,10 @@ jobs:
           set -euo pipefail
           while IFS= read -r image_tag; do
             [ -n "$image_tag" ] || continue
-            image_repository="${image_tag%:*}"
-            amd64_refs="$(
-              docker manifest inspect "${image_tag}-amd64" |
-                jq -er --arg repository "$image_repository" \
-                  '.manifests[] | select(.digest | type == "string" and length > 0) | "\($repository)@\(.digest)"'
-            )"
-            arm64_refs="$(
-              docker manifest inspect "${image_tag}-arm64" |
-                jq -er --arg repository "$image_repository" \
-                  '.manifests[] | select(.digest | type == "string" and length > 0) | "\($repository)@\(.digest)"'
-            )"
-            mapfile -t amd64_manifests <<< "$amd64_refs"
-            mapfile -t arm64_manifests <<< "$arm64_refs"
-            if (( ${#amd64_manifests[@]} == 0 || ${#arm64_manifests[@]} == 0 )); then
-              echo "both amd64 and arm64 manifests are required" >&2
-              exit 1
-            fi
-            docker manifest create "$image_tag" \
-              "${amd64_manifests[@]}" \
-              "${arm64_manifests[@]}"
-            docker manifest push "$image_tag"
+            docker buildx imagetools create \
+              --tag "$image_tag" \
+              "${image_tag}-amd64" \
+              "${image_tag}-arm64"
           done <<< "$IMAGE_TAGS"
       # Checkout repo so README.md is available for next step
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1


### PR DESCRIPTION
The manifest job passes provenance descriptors from per-architecture OCI
indexes to the legacy manifest command, which rejects their `unknown/unknown`
platform.

- assemble final indexes with Buildx Imagetools
- preserve both platform images and their attestation descriptors
- initialize Buildx explicitly in the manifest job

Validated with `actionlint`, the documentation parity test, and a live
Imagetools dry run against both release registries.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves attestation/provenance descriptors in release manifests by assembling multi-arch indexes with Buildx Imagetools. Previously, `docker manifest create` rejected `unknown/unknown` descriptors and dropped them; now `docker buildx imagetools create` keeps both platform images and their attestations. Manifest list digests will change due to preserved descriptors.

- Replace `docker manifest create/push` with `docker buildx imagetools create --tag ...` for multi-arch assembly.
- Initialize Buildx in the manifest job via `docker/setup-buildx-action@v4.3.0`.
- Preserve amd64 and arm64 images and their attestation descriptors in the final index.
- Validated with `actionlint`, the documentation parity test, and an `imagetools` dry run against both release registries.

<sup>Written for commit 102f04436e14c47ce6eba5c540e585b573e6bf68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

