### PR TITLE
fix(mithril): require verified genesis anchor

### DIFF
--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -715,7 +715,8 @@ mithril:
   # Remove temporary files after loading completes
   # Default: true
   cleanupAfterLoad: true
-  # Verify the Mithril certificate chain from snapshot back to genesis
+  # Verify STM certificates back to the pinned Mithril genesis key from the
+  # selected Cardano network config. Set false only for an unverified bootstrap.
   # Default: true
   verifyCertificates: true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -970,10 +970,10 @@ type MithrilConfig struct {
 	// CleanupAfterLoad controls whether temporary files are removed
 	// after the ImmutableDB has been loaded.
 	CleanupAfterLoad bool `yaml:"cleanupAfterLoad"       envconfig:"DINGO_MITHRIL_CLEANUP"`
-	// VerifyCertificates enables certificate chain verification
-	// during bootstrap. When true, the bootstrap process walks
-	// the Mithril certificate chain from the snapshot back to the
-	// genesis certificate to verify the chain is unbroken.
+	// VerifyCertificates enables STM certificate-chain verification during
+	// bootstrap. When true, bootstrap requires the Cardano network config's
+	// pinned Mithril genesis verification key and verifies the chain back to it.
+	// False explicitly selects the unverified bootstrap flow.
 	VerifyCertificates bool `yaml:"verifyCertificates"     envconfig:"DINGO_MITHRIL_VERIFY_CERTS"`
 }
 

--- a/mithril/bootstrap.go
+++ b/mithril/bootstrap.go
@@ -121,14 +121,13 @@ type BootstrapConfig struct {
 	// CleanupAfterLoad controls whether temporary files are removed
 	// after loading completes.
 	CleanupAfterLoad bool
-	// VerifyCertificateChain enables certificate chain verification
-	// against the aggregator. When true, the bootstrap process
-	// walks the certificate chain from the snapshot back to the
-	// genesis certificate to verify the chain is unbroken.
+	// VerifyCertificateChain enables STM certificate verification against the
+	// aggregator. When true, GenesisVerificationKey is required and the
+	// bootstrap process verifies the chain back to that pinned genesis key.
 	VerifyCertificateChain bool
-	// GenesisVerificationKey is the Mithril genesis verification key loaded
-	// from Cardano network config. It is validated for parseability now and
-	// will be used by full STM verification.
+	// GenesisVerificationKey is the pinned Mithril trust anchor used by STM
+	// certificate verification. It is loaded from Cardano network config and
+	// validated for parseability before any aggregator request.
 	GenesisVerificationKey string
 	// AncillaryVerificationKey is the Mithril ancillary verification key loaded
 	// from Cardano network config. It is validated for parseability now and
@@ -342,13 +341,16 @@ func Bootstrap(
 	}
 	cfg.Backend = normalizeBackend(cfg.Backend)
 	if cfg.VerifyCertificateChain {
-		if cfg.GenesisVerificationKey != "" {
-			if _, err := ParseVerificationKey(cfg.GenesisVerificationKey); err != nil {
-				return nil, fmt.Errorf(
-					"parsing Mithril genesis verification key: %w",
-					err,
-				)
-			}
+		if strings.TrimSpace(cfg.GenesisVerificationKey) == "" {
+			return nil, errors.New(
+				"verified Mithril bootstrap requires a genesis verification key",
+			)
+		}
+		if _, err := ParseVerificationKey(cfg.GenesisVerificationKey); err != nil {
+			return nil, fmt.Errorf(
+				"parsing Mithril genesis verification key: %w",
+				err,
+			)
 		}
 		if cfg.AncillaryVerificationKey != "" {
 			if _, err := ParseVerificationKey(cfg.AncillaryVerificationKey); err != nil {
@@ -469,16 +471,12 @@ func Bootstrap(
 			"component", "mithril",
 			"certificate_hash", snapshot.CertificateHash,
 		)
-		verificationMode := VerificationModeStructural
-		if cfg.GenesisVerificationKey != "" {
-			verificationMode = VerificationModeSTM
-		}
 		verificationResult, err := VerifyCertificateChainWithMode(
 			ctx,
 			client,
 			snapshot.CertificateHash,
 			snapshot.Digest,
-			verificationMode,
+			VerificationModeSTM,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -486,22 +484,20 @@ func Bootstrap(
 				err,
 			)
 		}
-		if cfg.GenesisVerificationKey != "" {
-			if verificationResult == nil ||
-				verificationResult.GenesisCertificate == nil {
-				return nil, errors.New(
-					"genesis verification key provided but no genesis certificate found in chain",
-				)
-			}
-			if err := VerifyGenesisCertificateSignature(
-				verificationResult.GenesisCertificate,
-				cfg.GenesisVerificationKey,
-			); err != nil {
-				return nil, fmt.Errorf(
-					"genesis certificate verification failed: %w",
-					err,
-				)
-			}
+		if verificationResult == nil ||
+			verificationResult.GenesisCertificate == nil {
+			return nil, errors.New(
+				"verified certificate chain has no genesis certificate",
+			)
+		}
+		if err := VerifyGenesisCertificateSignature(
+			verificationResult.GenesisCertificate,
+			cfg.GenesisVerificationKey,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"genesis certificate verification failed: %w",
+				err,
+			)
 		}
 		verificationMaterial, err := BuildVerificationMaterial(
 			ctx,

--- a/mithril/bootstrap_test.go
+++ b/mithril/bootstrap_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -95,6 +96,31 @@ func finalizeTestCertificate(t *testing.T, cert *Certificate) {
 	hash, err := cert.ComputeHash()
 	require.NoError(t, err)
 	cert.Hash = hash
+}
+
+func testGenesisKeyPair(t *testing.T) (string, ed25519.PrivateKey) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return fmt.Sprintf(
+		`{"type":"GenesisVerificationKey_ed25519","cborHex":"5820%s"}`,
+		hex.EncodeToString(publicKey),
+	), privateKey
+}
+
+func signTestGenesisCertificate(
+	t *testing.T,
+	cert *Certificate,
+	privateKey ed25519.PrivateKey,
+) {
+	t.Helper()
+	cert.SignedMessage = cert.ProtocolMessage.ComputeHash()
+	cert.GenesisSignature = hex.EncodeToString(
+		ed25519.Sign(privateKey, []byte(cert.SignedMessage)),
+	)
+	finalizeTestCertificate(t, cert)
+	cert.PreviousHash = cert.Hash
+	finalizeTestCertificate(t, cert)
 }
 
 func TestBootstrap(t *testing.T) {
@@ -246,6 +272,7 @@ func TestBootstrapUsesDigestSpecificExtractDir(t *testing.T) {
 }
 
 func TestBootstrapCertVerifyNoCertHash(t *testing.T) {
+	genesisVerificationKey, _ := testGenesisKeyPair(t)
 	snapshots := []SnapshotListItem{
 		{
 			SnapshotBase: SnapshotBase{
@@ -271,6 +298,7 @@ func TestBootstrapCertVerifyNoCertHash(t *testing.T) {
 		AggregatorURL:          server.URL,
 		AllowInsecureHTTP:      true,
 		VerifyCertificateChain: true,
+		GenesisVerificationKey: genesisVerificationKey,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no certificate hash")
@@ -339,6 +367,78 @@ func TestBootstrapInvalidGenesisVerificationKey(t *testing.T) {
 		err.Error(),
 		"parsing Mithril genesis verification key",
 	)
+}
+
+func TestBootstrapRequiresGenesisVerificationKey(t *testing.T) {
+	for _, backend := range []string{BackendV1, BackendV2} {
+		for _, testKey := range []struct {
+			name  string
+			value string
+		}{
+			{name: "empty"},
+			{name: "whitespace", value: " \n\t"},
+		} {
+			t.Run(backend+"/"+testKey.name, func(t *testing.T) {
+				var requests atomic.Int32
+				server := httptest.NewServer(http.HandlerFunc(
+					func(w http.ResponseWriter, _ *http.Request) {
+						requests.Add(1)
+						w.Header().Set("Content-Type", "application/json")
+						_, _ = w.Write([]byte("[]"))
+					},
+				))
+				t.Cleanup(server.Close)
+
+				_, err := Bootstrap(context.Background(), BootstrapConfig{
+					Network:                "preview",
+					Backend:                backend,
+					AggregatorURL:          server.URL,
+					AllowInsecureHTTP:      true,
+					VerifyCertificateChain: true,
+					GenesisVerificationKey: testKey.value,
+				})
+				require.EqualError(
+					t,
+					err,
+					"verified Mithril bootstrap requires a genesis verification key",
+				)
+				assert.Zero(t, requests.Load())
+			})
+		}
+	}
+}
+
+func TestBootstrapWithoutVerificationAllowsMissingGenesisVerificationKey(
+	t *testing.T,
+) {
+	for _, backend := range []string{BackendV1, BackendV2} {
+		t.Run(backend, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte("[]"))
+				},
+			))
+			t.Cleanup(server.Close)
+
+			_, err := Bootstrap(context.Background(), BootstrapConfig{
+				Network:                "preview",
+				Backend:                backend,
+				AggregatorURL:          server.URL,
+				AllowInsecureHTTP:      true,
+				VerifyCertificateChain: false,
+			})
+			require.Error(t, err)
+			assert.NotContains(
+				t,
+				err.Error(),
+				"genesis verification key",
+			)
+			assert.Equal(t, int32(1), requests.Load())
+		})
+	}
 }
 
 func TestBootstrapUnknownNetwork(t *testing.T) {
@@ -991,8 +1091,8 @@ func TestVerifyCertificateChainWithModeReturnsDetails(t *testing.T) {
 }
 
 func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
-	_, _, g1, g2 := bls12381.Generators()
-	g1Hex := hex.EncodeToString(g1.Marshal())
+	genesisVerificationKey, genesisPrivateKey := testGenesisKeyPair(t)
+	_, _, _, g2 := bls12381.Generators()
 	g2Hex := hex.EncodeToString(g2.Marshal())
 	snapshots := []SnapshotListItem{
 		{
@@ -1012,9 +1112,7 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 	}
 	certs := map[string]Certificate{
 		"cert_leaf": {
-			Epoch:                    270,
-			AggregateVerificationKey: g2Hex,
-			MultiSignature:           g1Hex,
+			Epoch: 270,
 			SignedEntityType: SignedEntityType{
 				raw: json.RawMessage(
 					`{"MithrilStakeDistribution":{"epoch":270,"immutable_file_number":5320}}`,
@@ -1022,7 +1120,7 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 			},
 			Metadata: CertificateMetadata{
 				Network:     "preprod",
-				Parameters:  ProtocolParameters{K: 1, M: 2, PhiF: 0.5},
+				Parameters:  ProtocolParameters{K: 1, M: 1, PhiF: 1.0},
 				InitiatedAt: "2026-02-10T00:00:00Z",
 				SealedAt:    "2026-02-10T00:01:00Z",
 				Signers: []StakeDistributionParty{
@@ -1037,32 +1135,34 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 			},
 		},
 		"cert_genesis": {
-			Epoch:            269,
-			GenesisSignature: "genesis",
+			Epoch: 269,
 			Metadata: CertificateMetadata{
-				Parameters:  ProtocolParameters{K: 1, M: 2, PhiF: 0.5},
+				Parameters:  ProtocolParameters{K: 1, M: 1, PhiF: 1.0},
 				InitiatedAt: "2026-02-09T00:00:00Z",
 				SealedAt:    "2026-02-09T00:01:00Z",
 			},
 			ProtocolMessage: ProtocolMessage{
 				MessageParts: map[string]string{
-					"current_epoch":                   "269",
-					"next_aggregate_verification_key": g2Hex,
+					"current_epoch": "269",
 					"next_protocol_parameters": ProtocolParameters{
 						K:    1,
-						M:    2,
-						PhiF: 0.5,
+						M:    1,
+						PhiF: 1.0,
 					}.ComputeHash(),
 				},
 			},
 		},
 	}
-	genesis := certs["cert_genesis"]
-	finalizeTestCertificate(t, &genesis)
-	genesis.PreviousHash = genesis.Hash
-	finalizeTestCertificate(t, &genesis)
-	certs["cert_genesis"] = genesis
 	leaf := certs["cert_leaf"]
+	leaf.SignedMessage = leaf.ProtocolMessage.ComputeHash()
+	leaf.AggregateVerificationKey, leaf.MultiSignature =
+		testCreateEncodedSTMProof(t, []byte(leaf.SignedMessage))
+	genesis := certs["cert_genesis"]
+	genesis.ProtocolMessage.
+		MessageParts["next_aggregate_verification_key"] =
+		leaf.AggregateVerificationKey
+	signTestGenesisCertificate(t, &genesis, genesisPrivateKey)
+	certs["cert_genesis"] = genesis
 	leaf.PreviousHash = genesis.Hash
 	finalizeTestCertificate(t, &leaf)
 	certs["cert_leaf"] = leaf
@@ -1118,6 +1218,7 @@ func TestBootstrapRejectsUnexpectedSignedEntityKind(t *testing.T) {
 		AggregatorURL:          server.URL,
 		AllowInsecureHTTP:      true,
 		VerifyCertificateChain: true,
+		GenesisVerificationKey: genesisVerificationKey,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected signed entity kind")

--- a/mithril/bootstrap_v2.go
+++ b/mithril/bootstrap_v2.go
@@ -443,16 +443,12 @@ func verifyArtifactCertificateV2(
 		"artifact", "cardano_database",
 		"certificate_hash", artifact.CertificateHash,
 	)
-	verificationMode := VerificationModeStructural
-	if cfg.GenesisVerificationKey != "" {
-		verificationMode = VerificationModeSTM
-	}
 	verificationResult, err := VerifyCertificateChainWithMode(
 		ctx,
 		client,
 		artifact.CertificateHash,
 		"", // v2 leaf binding uses cardano_database_merkle_root below
-		verificationMode,
+		VerificationModeSTM,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -460,22 +456,20 @@ func verifyArtifactCertificateV2(
 			err,
 		)
 	}
-	if cfg.GenesisVerificationKey != "" {
-		if verificationResult == nil ||
-			verificationResult.GenesisCertificate == nil {
-			return errors.New(
-				"genesis verification key provided but no genesis certificate found in chain",
-			)
-		}
-		if err := VerifyGenesisCertificateSignature(
-			verificationResult.GenesisCertificate,
-			cfg.GenesisVerificationKey,
-		); err != nil {
-			return fmt.Errorf(
-				"genesis certificate verification failed: %w",
-				err,
-			)
-		}
+	if verificationResult == nil ||
+		verificationResult.GenesisCertificate == nil {
+		return errors.New(
+			"verified certificate chain has no genesis certificate",
+		)
+	}
+	if err := VerifyGenesisCertificateSignature(
+		verificationResult.GenesisCertificate,
+		cfg.GenesisVerificationKey,
+	); err != nil {
+		return fmt.Errorf(
+			"genesis certificate verification failed: %w",
+			err,
+		)
 	}
 	verificationMaterial, err := BuildVerificationMaterial(
 		ctx,

--- a/mithril/bootstrap_v2_test.go
+++ b/mithril/bootstrap_v2_test.go
@@ -256,13 +256,14 @@ type v2Fixture struct {
 	immutableContent     map[string][]byte
 	ancillaryArchive     []byte
 	ancillaryVKey        string
+	genesisVKey          string
 	immutableHits        atomic.Int32
 }
 
 // newV2Fixture fabricates a complete, internally-consistent v2 mock
 // aggregator: immutable archives, certified digest list, ancillary
 // archive with a signed manifest, and a leaf+genesis certificate
-// chain (structural verification).
+// chain with a genuine STM proof and pinned genesis signature.
 func newV2Fixture(t *testing.T, opts v2FixtureOptions) *v2Fixture {
 	t.Helper()
 	fixture := &v2Fixture{
@@ -462,19 +463,18 @@ func newV2Fixture(t *testing.T, opts v2FixtureOptions) *v2Fixture {
 	}
 	fixture.artifact = artifact
 
-	// Certificate chain (genesis <- leaf), structural verification
-	_, _, g1, g2 := bls12381.Generators()
-	g1Hex := hex.EncodeToString(g1.Marshal())
+	// Certificate chain (genesis <- leaf), full STM verification
+	genesisVKey, genesisPrivateKey := testGenesisKeyPair(t)
+	fixture.genesisVKey = genesisVKey
+	_, _, _, g2 := bls12381.Generators()
 	g2Hex := hex.EncodeToString(g2.Marshal())
-	params := ProtocolParameters{K: 1, M: 2, PhiF: 0.5}
+	params := ProtocolParameters{K: 1, M: 1, PhiF: 1.0}
 	certMerkleRoot := merkleRoot
 	if opts.tamperCertMerkleRoot {
 		certMerkleRoot = strings.Repeat("e", 64)
 	}
 	leaf := Certificate{
-		Epoch:                    294,
-		AggregateVerificationKey: g2Hex,
-		MultiSignature:           g1Hex,
+		Epoch: 294,
 		SignedEntityType: SignedEntityType{
 			raw: json.RawMessage(fmt.Sprintf(
 				`{"CardanoDatabase":{"epoch":294,"immutable_file_number":%d}}`,
@@ -498,8 +498,7 @@ func newV2Fixture(t *testing.T, opts v2FixtureOptions) *v2Fixture {
 		},
 	}
 	genesis := Certificate{
-		Epoch:            293,
-		GenesisSignature: "genesis_sig",
+		Epoch: 293,
 		Metadata: CertificateMetadata{
 			Parameters:  params,
 			InitiatedAt: "2026-06-11T00:00:00Z",
@@ -507,15 +506,18 @@ func newV2Fixture(t *testing.T, opts v2FixtureOptions) *v2Fixture {
 		},
 		ProtocolMessage: ProtocolMessage{
 			MessageParts: map[string]string{
-				"current_epoch":                   "293",
-				"next_aggregate_verification_key": g2Hex,
-				"next_protocol_parameters":        params.ComputeHash(),
+				"current_epoch":            "293",
+				"next_protocol_parameters": params.ComputeHash(),
 			},
 		},
 	}
-	finalizeTestCertificate(t, &genesis)
-	genesis.PreviousHash = genesis.Hash
-	finalizeTestCertificate(t, &genesis)
+	leaf.SignedMessage = leaf.ProtocolMessage.ComputeHash()
+	leaf.AggregateVerificationKey, leaf.MultiSignature =
+		testCreateEncodedSTMProof(t, []byte(leaf.SignedMessage))
+	genesis.ProtocolMessage.
+		MessageParts["next_aggregate_verification_key"] =
+		leaf.AggregateVerificationKey
+	signTestGenesisCertificate(t, &genesis, genesisPrivateKey)
 	leaf.PreviousHash = genesis.Hash
 	finalizeTestCertificate(t, &leaf)
 	fixture.certs[genesis.Hash] = genesis
@@ -643,6 +645,7 @@ func (f *v2Fixture) bootstrapConfig(downloadDir string) BootstrapConfig {
 		AllowInsecureHTTP:        true,
 		DownloadDir:              downloadDir,
 		VerifyCertificateChain:   true,
+		GenesisVerificationKey:   f.genesisVKey,
 		AncillaryVerificationKey: f.ancillaryVKey,
 	}
 }


### PR DESCRIPTION
Closes #3465.

- Require a pinned genesis trust anchor before verified bootstrap contacts the aggregator.
- Enforce STM chain and genesis-signature verification for both artifact backends.
- Cover verified and explicitly unverified behavior with real cryptographic fixtures.

Checks:

- Focused Mithril race regressions
- Full race-enabled test suite
- Dingo conformance vectors (315/315)