### PR TITLE
fix(mithril): validate fetched gap ranges

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4423,7 +4423,10 @@ network-block validation.
 for databases produced by older releases that advanced
 `mithril_ledger_slot` across an unvalidated gap. New imports do not create that
 shape: nonce folding and transaction effects after the stable anchor are
-produced by ordinary ledger replay.
+produced by ordinary ledger replay. Compatibility gap fetches accept a relay
+batch only when it is non-empty, hash-linked from the requested start point,
+and terminates at the exact requested end point; a mismatch falls through to
+the next bootstrap peer before any block is stored.
 
 The epoch nonce for the boundary into epoch N+1 is
 `candidateNonce(N) ⭒ epoch(N).LastEpochBlockNonce`, where the carried

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -958,10 +958,10 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 		// the volatile fetch path below pull the remainder.
 		var validateErr error
 		if resumeGapEnd == ledgerStateSlot {
-			validateErr = validateStoredGapBlocks(
+			validateErr = validateCompleteGapBlocks(
 				storedGapBlocks,
-				immutableTip,
-				ledgerStateHash,
+				ocommon.NewPoint(immutableTip.Slot, immutableTip.Hash),
+				ocommon.NewPoint(ledgerStateSlot, ledgerStateHash),
 			)
 		} else {
 			validateErr = validateStoredGapContinuity(

--- a/mithril/sync_gap.go
+++ b/mithril/sync_gap.go
@@ -62,17 +62,51 @@ func fetchGapBlocks(
 		)
 	}
 
-	var lastErr error
-	for i, peer := range netInfo.BootstrapPeers {
-		peerAddr := net.JoinHostPort(
+	peerAddrs := make([]string, 0, len(netInfo.BootstrapPeers))
+	for _, peer := range netInfo.BootstrapPeers {
+		peerAddrs = append(peerAddrs, net.JoinHostPort(
 			peer.Address,
 			strconv.FormatUint(uint64(peer.Port), 10),
-		)
+		))
+	}
+	return fetchGapBlocksFromPeers(
+		ctx,
+		logger,
+		netInfo.NetworkMagic,
+		peerAddrs,
+		start,
+		end,
+		fetchGapBlocksFromPeer,
+	)
+}
 
-		blocks, err := fetchGapBlocksFromPeer(
-			ctx, logger, netInfo.NetworkMagic,
+type gapBlockPeerFetcher func(
+	context.Context,
+	*slog.Logger,
+	uint32,
+	string,
+	ocommon.Point,
+	ocommon.Point,
+) ([]models.Block, error)
+
+func fetchGapBlocksFromPeers(
+	ctx context.Context,
+	logger *slog.Logger,
+	networkMagic uint32,
+	peerAddrs []string,
+	start ocommon.Point,
+	end ocommon.Point,
+	fetchFromPeer gapBlockPeerFetcher,
+) ([]models.Block, error) {
+	var lastErr error
+	for i, peerAddr := range peerAddrs {
+		blocks, err := fetchFromPeer(
+			ctx, logger, networkMagic,
 			peerAddr, start, end,
 		)
+		if err == nil {
+			err = validateCompleteGapBlocks(blocks, start, end)
+		}
 		if err == nil {
 			return blocks, nil
 		}
@@ -88,14 +122,14 @@ func fetchGapBlocks(
 			"component", "mithril",
 			"peer", peerAddr,
 			"peer_index", i,
-			"total_peers", len(netInfo.BootstrapPeers),
+			"total_peers", len(peerAddrs),
 			"error", err,
 		)
 	}
 
 	return nil, fmt.Errorf(
 		"all %d bootstrap peers failed: %w",
-		len(netInfo.BootstrapPeers),
+		len(peerAddrs),
 		lastErr,
 	)
 }
@@ -394,6 +428,13 @@ func validateStoredGapContinuity(
 			immutableTip.Slot,
 		)
 	}
+	if blocks[0].Slot <= immutableTip.Slot {
+		return fmt.Errorf(
+			"gap first block slot %d does not follow start slot %d",
+			blocks[0].Slot,
+			immutableTip.Slot,
+		)
+	}
 	if !bytes.Equal(blocks[0].PrevHash, immutableTip.Hash) {
 		return fmt.Errorf(
 			"stored gap first block at slot %d prev hash %x does not match immutable tip slot %d hash %x",
@@ -404,6 +445,13 @@ func validateStoredGapContinuity(
 		)
 	}
 	for i := 1; i < len(blocks); i++ {
+		if blocks[i].Slot <= blocks[i-1].Slot {
+			return fmt.Errorf(
+				"gap block slot %d does not follow previous block slot %d",
+				blocks[i].Slot,
+				blocks[i-1].Slot,
+			)
+		}
 		if bytes.Equal(blocks[i].PrevHash, blocks[i-1].Hash) {
 			continue
 		}
@@ -418,27 +466,35 @@ func validateStoredGapContinuity(
 	return nil
 }
 
-func validateStoredGapBlocks(
+func validateCompleteGapBlocks(
 	blocks []models.Block,
-	immutableTip models.Block,
-	ledgerStateHash []byte,
+	start ocommon.Point,
+	end ocommon.Point,
 ) error {
+	if len(blocks) == 0 {
+		return fmt.Errorf(
+			"gap is empty after start slot %d",
+			start.Slot,
+		)
+	}
+	immutableTip := models.Block{Slot: start.Slot, Hash: start.Hash}
 	if err := validateStoredGapContinuity(blocks, immutableTip); err != nil {
 		return err
 	}
-	if len(blocks) == 0 {
+	last := blocks[len(blocks)-1]
+	if last.Slot != end.Slot {
 		return fmt.Errorf(
-			"stored volatile gap is empty after immutable tip slot %d",
-			immutableTip.Slot,
+			"gap terminal block slot %d does not match requested end slot %d",
+			last.Slot,
+			end.Slot,
 		)
 	}
-	last := blocks[len(blocks)-1]
-	if !bytes.Equal(last.Hash, ledgerStateHash) {
+	if !bytes.Equal(last.Hash, end.Hash) {
 		return fmt.Errorf(
-			"stored gap terminal block at slot %d hash %x does not match ledger state hash %x",
+			"gap terminal block at slot %d hash %x does not match requested end hash %x",
 			last.Slot,
 			last.Hash,
-			ledgerStateHash,
+			end.Hash,
 		)
 	}
 	return nil

--- a/mithril/sync_gap_test.go
+++ b/mithril/sync_gap_test.go
@@ -235,6 +235,20 @@ func TestValidateCompleteGapBlocks(t *testing.T) {
 		"does not match immutable tip",
 	)
 
+	for _, slot := range []uint64{start.Slot, start.Slot - 1} {
+		nonIncreasingFirst := first
+		nonIncreasingFirst.Slot = slot
+		require.ErrorContains(
+			t,
+			validateCompleteGapBlocks(
+				[]models.Block{nonIncreasingFirst, second},
+				start,
+				end,
+			),
+			"does not follow start slot",
+		)
+	}
+
 	brokenSecond := second
 	brokenSecond.PrevHash = testGapHash32("wrong-link")
 	require.ErrorContains(
@@ -246,6 +260,20 @@ func TestValidateCompleteGapBlocks(t *testing.T) {
 		),
 		"does not match previous block",
 	)
+
+	for _, slot := range []uint64{first.Slot, first.Slot - 1} {
+		nonIncreasingSecond := second
+		nonIncreasingSecond.Slot = slot
+		require.ErrorContains(
+			t,
+			validateCompleteGapBlocks(
+				[]models.Block{first, nonIncreasingSecond},
+				start,
+				end,
+			),
+			"does not follow previous block slot",
+		)
+	}
 
 	require.ErrorContains(
 		t,

--- a/mithril/sync_gap_test.go
+++ b/mithril/sync_gap_test.go
@@ -15,6 +15,7 @@
 package mithril
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"math/big"
@@ -189,7 +190,7 @@ func testGapHash28(seed string) []byte {
 	return hash
 }
 
-func TestValidateStoredGapBlocks(t *testing.T) {
+func TestValidateCompleteGapBlocks(t *testing.T) {
 	immutableTip := models.Block{
 		Slot: 10,
 		Hash: testGapHash32("immutable-tip"),
@@ -204,13 +205,21 @@ func TestValidateStoredGapBlocks(t *testing.T) {
 		Hash:     testGapHash32("second-gap"),
 		PrevHash: first.Hash,
 	}
+	start := ocommon.NewPoint(immutableTip.Slot, immutableTip.Hash)
+	end := ocommon.NewPoint(second.Slot, second.Hash)
+
+	require.ErrorContains(
+		t,
+		validateCompleteGapBlocks(nil, start, end),
+		"gap is empty",
+	)
 
 	require.NoError(
 		t,
-		validateStoredGapBlocks(
+		validateCompleteGapBlocks(
 			[]models.Block{first, second},
-			immutableTip,
-			second.Hash,
+			start,
+			end,
 		),
 	)
 
@@ -218,10 +227,10 @@ func TestValidateStoredGapBlocks(t *testing.T) {
 	brokenFirst.PrevHash = testGapHash32("wrong-prev")
 	require.ErrorContains(
 		t,
-		validateStoredGapBlocks(
+		validateCompleteGapBlocks(
 			[]models.Block{brokenFirst, second},
-			immutableTip,
-			second.Hash,
+			start,
+			end,
 		),
 		"does not match immutable tip",
 	)
@@ -230,23 +239,80 @@ func TestValidateStoredGapBlocks(t *testing.T) {
 	brokenSecond.PrevHash = testGapHash32("wrong-link")
 	require.ErrorContains(
 		t,
-		validateStoredGapBlocks(
+		validateCompleteGapBlocks(
 			[]models.Block{first, brokenSecond},
-			immutableTip,
-			second.Hash,
+			start,
+			end,
 		),
 		"does not match previous block",
 	)
 
 	require.ErrorContains(
 		t,
-		validateStoredGapBlocks(
+		validateCompleteGapBlocks(
 			[]models.Block{first, second},
-			immutableTip,
-			testGapHash32("ledger-hash"),
+			start,
+			ocommon.NewPoint(second.Slot, testGapHash32("ledger-hash")),
 		),
-		"does not match ledger state hash",
+		"does not match requested end hash",
 	)
+
+	require.ErrorContains(
+		t,
+		validateCompleteGapBlocks(
+			[]models.Block{first},
+			start,
+			end,
+		),
+		"does not match requested end slot",
+	)
+}
+
+func TestFetchGapBlocksFromPeersFallsThroughOnMismatchedRange(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	start := ocommon.NewPoint(10, testGapHash32("start"))
+	end := ocommon.NewPoint(12, testGapHash32("end"))
+	middleHash := testGapHash32("middle")
+	valid := []models.Block{
+		{
+			Slot:     11,
+			Hash:     middleHash,
+			PrevHash: start.Hash,
+		},
+		{
+			Slot:     end.Slot,
+			Hash:     end.Hash,
+			PrevHash: middleHash,
+		},
+	}
+	short := []models.Block{valid[0]}
+	var called []string
+
+	got, err := fetchGapBlocksFromPeers(
+		t.Context(),
+		logger,
+		1,
+		[]string{"first", "second"},
+		start,
+		end,
+		func(
+			_ context.Context,
+			_ *slog.Logger,
+			_ uint32,
+			peerAddr string,
+			_ ocommon.Point,
+			_ ocommon.Point,
+		) ([]models.Block, error) {
+			called = append(called, peerAddr)
+			if peerAddr == "first" {
+				return short, nil
+			}
+			return valid, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"first", "second"}, called)
+	assert.Equal(t, valid, got)
 }
 
 func testGapConwayProtocolParameters() *conway.ConwayProtocolParameters {


### PR DESCRIPTION
## Summary

- validate fetched Mithril gap batches against both requested boundary points
- fall through to the next bootstrap peer when a batch is incomplete or mismatched
- reject non-monotonic and internally disconnected block ranges before persistence
- document the gap-fetch trust boundary

## Testing

- `go test -tags dingo_extra_plugins -race ./mithril`
- `go test -tags dingo_extra_plugins -race ./internal/test/conformance/`
- architecture and documentation parity checks
- `go vet ./...`
- `nilaway ./...`
- `modernize ./...`
- scoped `golangci-lint` (0 issues)

Closes #3471


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates `mithril` gap fetches against both the requested start and end points to prevent storing incomplete or mismatched ranges. Previously a peer’s partial or mismatched batch could be accepted; now we reject it and fall through to the next bootstrap peer before any block is persisted.

**Review notes**
- `fetchGapBlocks` delegates to `fetchGapBlocksFromPeers`, which validates batches against `start` and `end`; empty, non-monotonic, or hash-disconnected ranges cause immediate fallthrough to the next peer.
- Replaces `validateStoredGapBlocks` with `validateCompleteGapBlocks(start, end)`; enforces non-empty batch, first block linked to the start hash, strictly increasing slots, and exact end slot/hash match.
- `Sync` constructs `ocommon.Point` for immutable tip and ledger state and uses complete-range validation; ARCHITECTURE doc clarifies the gap-fetch trust boundary.

<sup>Written for commit 7c783b65950b7a5d5127fc4403f7e1ceff786be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization reliability when fetching missing blockchain data.
  * Rejects empty, incomplete, incorrectly linked, or improperly ordered data ranges.
  * Verifies fetched ranges begin and end at the requested points.
  * Automatically tries the next available peer when a response is invalid.
  * Prevents invalid data from being stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->