### PR TITLE
fix(peergov): reduce ledger discovery log volume and DNS churn

### DIFF
--- a/peergov/connections.go
+++ b/peergov/connections.go
@@ -86,8 +86,26 @@ func isExpectedNetworkDialError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// ENETUNREACH and EAFNOSUPPORT are siblings of the cases below: on a
+	// host with no IPv6 route, every AAAA relay record the ledger publishes
+	// produces one. They are facts about local reachability, not node
+	// faults, and logging them at ERROR buries the genuine ones. Matched by
+	// errno first, like isAddrInUseError, so a wrapped *os.SyscallError is
+	// classified without depending on the message text. The errno and
+	// message forms below both target Unix-like platforms, matching the
+	// existing classifiers in this file; Windows reports these as WSA codes
+	// with different message text and is not covered.
+	if errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.EAFNOSUPPORT) {
+		return true
+	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "no such host") ||
+	return strings.Contains(msg, "network is unreachable") ||
+		strings.Contains(
+			msg,
+			"address family not supported by protocol family",
+		) ||
+		strings.Contains(msg, "no such host") ||
 		strings.Contains(msg, "server misbehaving") ||
 		strings.Contains(msg, "connect: connection refused") ||
 		strings.Contains(msg, "no route to host") ||
@@ -993,7 +1011,6 @@ func (p *PeerGovernor) handleConnectionClosedEvent(evt event.Event) {
 							"hot peer pool critically low; capping reconnect backoff to replenish faster",
 							"address", peer.Address,
 							"capped_delay", peer.ReconnectDelay,
-							"component", "peergov",
 						)
 					} else {
 						p.config.Logger.Warn(

--- a/peergov/connections_test.go
+++ b/peergov/connections_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"strings"
 	"syscall"
 	"testing"
@@ -188,6 +189,48 @@ func TestIsExpectedNetworkDialError(t *testing.T) {
 			want: true,
 		},
 		{
+			// ENETUNREACH: an IPv6 relay record on a host with no IPv6
+			// route. A local reachability fact, not a node fault.
+			name: "net op error wrapping ENETUNREACH",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{
+					Syscall: "connect",
+					Err:     syscall.ENETUNREACH,
+				},
+			},
+			want: true,
+		},
+		{
+			// EAFNOSUPPORT: same cause, reported by the socket call
+			// instead of the route lookup.
+			name: "net op error wrapping EAFNOSUPPORT",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{
+					Syscall: "socket",
+					Err:     syscall.EAFNOSUPPORT,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "network is unreachable string",
+			err: errors.New(
+				"dial tcp [2001:db8::1]:3001: connect: network is unreachable",
+			),
+			want: true,
+		},
+		{
+			name: "address family not supported string",
+			err: errors.New(
+				"dial tcp: connect: address family not supported by protocol family",
+			),
+			want: true,
+		},
+		{
 			name: "net op error wrapping no route",
 			err: &net.OpError{
 				Op:  "dial",
@@ -270,7 +313,10 @@ func TestIsPermanentNetworkMagicMismatch(t *testing.T) {
 		},
 		{
 			name: "same magic version data mismatch",
-			err:  &handshake.RefusedError{Version: 13, Message: sameMagicMessage},
+			err: &handshake.RefusedError{
+				Version: 13,
+				Message: sameMagicMessage,
+			},
 			want: false,
 		},
 		{
@@ -348,7 +394,10 @@ func TestPermanentNetworkMagicMismatchDenialSuppressesRediscoveryUntilRestart(
 		t.Fatal("permanent denial expired with the transient deny list")
 	}
 	if peerCount != 0 {
-		t.Fatalf("ledger peer count = %d, want 0 after permanent denial", peerCount)
+		t.Fatalf(
+			"ledger peer count = %d, want 0 after permanent denial",
+			peerCount,
+		)
 	}
 
 	if pg.addLedgerPeer(address) {
@@ -1034,6 +1083,63 @@ func TestHandleConnectionClosedEvent_CriticalHotPeersCapsBackoff(
 		t.Fatalf(
 			"final ReconnectDelay = %s, want %s (emergency cap)",
 			got, emergencyReconnectDelay,
+		)
+	}
+}
+
+// The peergov logger already carries component=peergov, so a call site that
+// passes the attribute again emits it twice in every record. See issue #3262.
+func TestHandleConnectionClosedEvent_CriticalHotPeerLogHasSingleComponent(
+	t *testing.T,
+) {
+	var logBuf bytes.Buffer
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(&logBuf, nil)),
+	})
+	connId := outboundTestConnId()
+	peer := &Peer{
+		Address:           "192.168.12.102:3003",
+		NormalizedAddress: "192.168.12.102:3003",
+		Source:            PeerSourceTopologyLocalRoot,
+		// Suppress reconnect goroutine; this test only checks the log record.
+		Reconnecting: true,
+	}
+	pg.mu.Lock()
+	pg.peers = []*Peer{peer}
+	pg.mu.Unlock()
+
+	// Repeated short-lived closes escalate the backoff past
+	// emergencyReconnectDelay, which is what engages the critically-low cap
+	// and emits the log line under test.
+	for range 6 {
+		pg.mu.Lock()
+		peer.ReconnectDelay = 0
+		peer.Connection = &PeerConnection{Id: connId, IsClient: true}
+		peer.State = PeerStateWarm
+		peer.ConnectedAt = time.Now().Add(-600 * time.Millisecond)
+		pg.mu.Unlock()
+
+		pg.handleConnectionClosedEvent(event.NewEvent(
+			connmanager.ConnectionClosedEventType,
+			connmanager.ConnectionClosedEvent{ConnectionId: connId},
+		))
+	}
+
+	var found string
+	for line := range strings.SplitSeq(logBuf.String(), "\n") {
+		if strings.Contains(line, "hot peer pool critically low") {
+			found = line
+			break
+		}
+	}
+	if found == "" {
+		t.Fatal("expected the critically-low backoff cap log line")
+	}
+	if got := strings.Count(found, `"component"`); got != 1 {
+		t.Fatalf(
+			"component attribute appears %d times, want 1: %s",
+			got,
+			found,
 		)
 	}
 }

--- a/peergov/doc.go
+++ b/peergov/doc.go
@@ -31,6 +31,25 @@
 // modeled as their own governed source with explicit budget controls
 // (InboundWarmTarget, InboundHotQuota) and validation policy knobs.
 //
+// # Ledger peer discovery
+//
+// Ledger discovery re-offers the full on-chain relay set on every round, so
+// the per-candidate path is deliberately cheap: the deny list and the known-
+// peer set are consulted before any DNS lookup, and a relay hostname that
+// fails to resolve is negatively cached (negativeDNSCacheTTL) so it is not
+// re-resolved every round. A pool publishing a dead relay hostname is a fact
+// about the chain rather than an operator-actionable fault, so the failure is
+// logged at debug level.
+//
+// Discovery normally runs at LedgerPeerRefreshInterval. While the node has
+// fewer eligible upstreams than MinHotPeers it switches to the emergency
+// cadence (EmergencyLedgerPeerRefreshInterval) so a collapsed peer pool
+// recovers in seconds. That cadence doubles for each consecutive round the
+// node stays short of upstreams, capped at LedgerPeerRefreshInterval, and
+// resets on recovery: a transient collapse is still served immediately, while
+// a persistently unusable relay set (dead hostnames, wrong-network relays)
+// stops re-walking the whole set every emergency interval indefinitely.
+//
 // # Churn
 //
 // A reconcile loop periodically compares the current active set to

--- a/peergov/emergency_backoff_test.go
+++ b/peergov/emergency_backoff_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func urgentDiscoveryGovernor(target int) *PeerGovernor {
+	return NewPeerGovernor(PeerGovernorConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           newMockEventBus(),
+		UseLedgerAfterSlot: 0,
+		MinHotPeers:        10,
+		LedgerPeerTarget:   target,
+		LedgerPeerProvider: &mockLedgerPeerProvider{
+			relays:      fiftyLedgerRelays(),
+			currentSlot: 1000,
+		},
+	})
+}
+
+// Emergency discovery exists for transient starvation. Sustained starvation
+// must escalate its cadence toward the normal refresh interval instead of
+// running at the base emergency cadence indefinitely.
+func TestEmergencyLedgerRefreshInterval_EscalatesAndCaps(t *testing.T) {
+	pg := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(
+			slog.NewJSONHandler(io.Discard, nil),
+		),
+		MinHotPeers:                        10,
+		LedgerPeerTarget:                   20,
+		LedgerPeerRefreshInterval:          time.Hour,
+		EmergencyLedgerPeerRefreshInterval: 30 * time.Second,
+	})
+
+	want := []time.Duration{
+		30 * time.Second,
+		1 * time.Minute,
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		16 * time.Minute,
+		32 * time.Minute,
+		time.Hour, // 64m would exceed the normal interval; capped there
+		time.Hour,
+		time.Hour,
+	}
+	for rounds, expected := range want {
+		//nolint:gosec // bounded loop index
+		pg.emergencyRefreshRounds.Store(uint32(rounds))
+		assert.Equal(t, expected, pg.emergencyLedgerRefreshInterval(),
+			"interval after %d consecutive emergency rounds", rounds)
+	}
+}
+
+// The escalated interval must actually gate discovery: a second round inside
+// the interval the first one earned is suppressed, and a round past it runs.
+func TestDiscoverLedgerPeers_EmergencyBackoffThrottlesRepeatRounds(
+	t *testing.T,
+) {
+	pg := urgentDiscoveryGovernor(5)
+
+	// Round one runs at the base emergency cadence.
+	pg.discoverLedgerPeers()
+	first := countPeersBySource(pg, PeerSourceP2PLedger)
+	require.Positive(t, first, "urgent node must replenish on the first round")
+	require.Equal(t, uint32(1), pg.emergencyRefreshRounds.Load())
+
+	// 40s later: past the 30s base interval, inside the 60s round one earned.
+	pg.lastLedgerPeerRefresh.Store(
+		time.Now().Add(-40 * time.Second).UnixNano(),
+	)
+	pg.discoverLedgerPeers()
+	assert.Equal(t, first, countPeersBySource(pg, PeerSourceP2PLedger),
+		"a round inside the escalated interval must be suppressed")
+	assert.Equal(t, uint32(1), pg.emergencyRefreshRounds.Load(),
+		"a suppressed round must not count toward the backoff")
+
+	// 90s later: past the escalated interval, so discovery runs again.
+	pg.lastLedgerPeerRefresh.Store(
+		time.Now().Add(-90 * time.Second).UnixNano(),
+	)
+	pg.discoverLedgerPeers()
+	assert.Greater(t, countPeersBySource(pg, PeerSourceP2PLedger), first,
+		"a round past the escalated interval must replenish")
+	assert.Equal(t, uint32(2), pg.emergencyRefreshRounds.Load())
+}
+
+// Recovery resets the backoff, so the next starvation event is served at the
+// base emergency cadence rather than an hour later.
+func TestDiscoverLedgerPeers_EmergencyBackoffResetsWhenNotUrgent(
+	t *testing.T,
+) {
+	pg := urgentDiscoveryGovernor(5)
+	pg.emergencyRefreshRounds.Store(5)
+	addEligibleUpstreamPeers(pg, pg.config.MinHotPeers)
+
+	require.False(t, pg.ledgerPeersUrgent())
+	pg.discoverLedgerPeers()
+
+	assert.Equal(t, uint32(0), pg.emergencyRefreshRounds.Load(),
+		"a recovered node must return to the base emergency cadence")
+}
+
+// The first emergency round after startup must not be delayed: a collapsed
+// peer pool still recovers in seconds.
+func TestDiscoverLedgerPeers_EmergencyFirstRoundUsesBaseInterval(
+	t *testing.T,
+) {
+	pg := urgentDiscoveryGovernor(5)
+	assert.Equal(t,
+		pg.config.EmergencyLedgerPeerRefreshInterval,
+		pg.emergencyLedgerRefreshInterval(),
+		"the first emergency round must use the base cadence",
+	)
+}

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -39,7 +39,6 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 	if p.config.LedgerPeerProvider == nil {
 		p.config.Logger.Debug(
 			"ledger peer discovery skipped: provider is nil",
-			"component", "peergov",
 		)
 		return
 	}
@@ -64,10 +63,14 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 
 	// Count existing ledger peers to determine how many we need.
 	urgent := p.ledgerPeersUrgent()
+	if !urgent {
+		// Recovered: the next starvation event starts again at the base
+		// emergency cadence rather than an escalated one.
+		p.emergencyRefreshRounds.Store(0)
+	}
 	needed := p.ledgerPeerDeficit()
 	p.config.Logger.Debug(
 		"ledger peer discovery starting",
-		"component", "peergov",
 		"use_ledger_after_slot", p.config.UseLedgerAfterSlot,
 		"needed", needed,
 		"emergency", urgent,
@@ -89,7 +92,7 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 	// collapsed peer pool while the ledger still lists plenty of relays.
 	refreshInterval := p.config.LedgerPeerRefreshInterval
 	if urgent {
-		refreshInterval = p.config.EmergencyLedgerPeerRefreshInterval
+		refreshInterval = p.emergencyLedgerRefreshInterval()
 	}
 	now := time.Now().UnixNano()
 	lastRefresh := p.lastLedgerPeerRefresh.Load()
@@ -116,6 +119,13 @@ func (p *PeerGovernor) discoverLedgerPeersContext(ctx context.Context) {
 		// rather than waiting for the full refresh interval
 		p.lastLedgerPeerRefresh.Store(lastRefresh)
 		return
+	}
+
+	if urgent {
+		// Counted only once the round is actually going ahead, so a round
+		// suppressed by the interval gate or a failed provider fetch does
+		// not escalate the backoff.
+		p.emergencyRefreshRounds.Add(1)
 	}
 
 	candidates := dedupeRelayCandidates(flattenRelayCandidates(relays))
@@ -158,6 +168,36 @@ func (p *PeerGovernor) ledgerPeersUrgent() bool {
 	upstreams := p.countEligibleUpstreamsLocked()
 	p.mu.Unlock()
 	return upstreams < p.config.MinHotPeers
+}
+
+// emergencyLedgerRefreshInterval returns the refresh interval for an urgent
+// ledger-discovery round. It starts at the configured emergency cadence and
+// doubles for each consecutive round the node has spent short of upstreams,
+// capped at the normal refresh interval so an urgent node never discovers
+// less often than a healthy one. The counter resets on recovery, so a
+// genuinely transient collapse is still served at the base cadence.
+//
+// Without the escalation a node whose relay pool is polluted (dead
+// hostnames, wrong-network relays) never leaves the urgent state and runs
+// discovery at the base cadence indefinitely, re-walking the whole relay set
+// every round for as long as the node is up.
+func (p *PeerGovernor) emergencyLedgerRefreshInterval() time.Duration {
+	base := p.config.EmergencyLedgerPeerRefreshInterval
+	normal := p.config.LedgerPeerRefreshInterval
+	if normal <= 0 || base >= normal {
+		return base
+	}
+	interval := base
+	for range p.emergencyRefreshRounds.Load() {
+		if interval >= normal {
+			break
+		}
+		interval *= emergencyLedgerRefreshBackoffFactor
+	}
+	if interval > normal {
+		return normal
+	}
+	return interval
 }
 
 // ledgerPeerDeficit returns how many more ledger peers are needed to reach
@@ -240,6 +280,16 @@ func (p *PeerGovernor) addLedgerPeerContext(
 	address string,
 ) bool {
 	if err := ctx.Err(); err != nil {
+		return false
+	}
+	// Decide what can be decided without DNS first. Discovery re-offers the
+	// full relay set on every round, so resolving ahead of the deny and
+	// exists checks re-resolves every already-connected peer and every dead
+	// hostname every round; neither lookup can change the outcome. Deny
+	// entries for an unresolvable hostname are keyed on exactly the
+	// lock-free normalized form, which is what makes the dead-hostname case
+	// answerable here.
+	if p.ledgerPeerRejectedWithoutDNS(address) {
 		return false
 	}
 	// Resolve address (with DNS lookup) before acquiring lock to avoid
@@ -354,4 +404,38 @@ func (p *PeerGovernor) addLedgerPeerContext(
 	p.publishEvent(evt.eventType, evt.data)
 
 	return added
+}
+
+// ledgerPeerRejectedWithoutDNS reports whether a ledger relay candidate can
+// be rejected from the raw address alone, before any DNS lookup.
+//
+// Only rejection is decided here: a peer is never added without a
+// resolution, so a candidate that survives this check still goes through the
+// full post-resolution deny and exists checks under the lock.
+func (p *PeerGovernor) ledgerPeerRejectedWithoutDNS(address string) bool {
+	hostnameNormalized := p.normalizeAddress(address)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// A deny entry recorded for an unresolvable hostname is keyed on the
+	// lowercased hostname, so this catches exactly the candidates whose
+	// resolution would fail anyway.
+	if p.isDeniedLocked(hostnameNormalized) {
+		return true
+	}
+	for _, peer := range p.peers {
+		if peer == nil {
+			continue
+		}
+		if peer.Address != address &&
+			peer.NormalizedAddress != hostnameNormalized {
+			continue
+		}
+		// Record the peer's own normalized address rather than a fresh
+		// resolution: countLedgerPeersLocked matches ledgerKnownAddrs
+		// against Peer.NormalizedAddress, so this is what makes a peer
+		// known from another source count toward the ledger target.
+		p.ledgerKnownAddrs[peer.NormalizedAddress] = struct{}{}
+		return true
+	}
+	return false
 }

--- a/peergov/ledger_discovery.go
+++ b/peergov/ledger_discovery.go
@@ -325,9 +325,11 @@ func (p *PeerGovernor) addLedgerPeerContext(
 		return false
 	}
 
+	hostnameNormalized := p.normalizeAddress(address)
+
 	// Check deny list
 	if p.isDeniedLocked(normalized) ||
-		p.isDeniedLocked(p.normalizeAddress(address)) {
+		p.isDeniedLocked(hostnameNormalized) {
 		p.mu.Unlock()
 		return false
 	}
@@ -336,13 +338,17 @@ func (p *PeerGovernor) addLedgerPeerContext(
 	// sources at the same address count toward the ledger target.
 	p.ledgerKnownAddrs[normalized] = struct{}{}
 
-	// Check for existing peer using cached NormalizedAddress
+	// Check for existing peer using cached NormalizedAddress. The address
+	// comparison is normalized on both sides, as in AddPeer, so a peer
+	// holding the same hostname under different casing is not duplicated.
 	exists := false
 	for _, peer := range p.peers {
 		if peer == nil {
 			continue
 		}
-		if peer.NormalizedAddress == normalized || peer.Address == address {
+		if peer.NormalizedAddress == normalized ||
+			peer.NormalizedAddress == hostnameNormalized ||
+			p.normalizeAddress(peer.Address) == hostnameNormalized {
 			exists = true
 			break
 		}
@@ -426,8 +432,11 @@ func (p *PeerGovernor) ledgerPeerRejectedWithoutDNS(address string) bool {
 		if peer == nil {
 			continue
 		}
-		if peer.Address != address &&
-			peer.NormalizedAddress != hostnameNormalized {
+		// Both sides are normalized, matching AddPeer: Peer.Address is
+		// stored verbatim, so a topology or gossip peer can hold the same
+		// relay hostname under different casing.
+		if peer.NormalizedAddress != hostnameNormalized &&
+			p.normalizeAddress(peer.Address) != hostnameNormalized {
 			continue
 		}
 		// Record the peer's own normalized address rather than a fresh

--- a/peergov/ledger_discovery_resolution_test.go
+++ b/peergov/ledger_discovery_resolution_test.go
@@ -87,6 +87,35 @@ func TestAddLedgerPeer_KnownPeerSkipsDNSResolution(t *testing.T) {
 		"skipping resolution must still record the peer as ledger-known")
 }
 
+// Peer.Address is stored verbatim, so a topology or gossip peer can hold the
+// same relay hostname under different casing. Matching it case-sensitively
+// adds a second peer for one relay, which AddPeer already avoids by
+// normalizing both sides.
+func TestAddLedgerPeer_KnownPeerMatchedCaseInsensitively(t *testing.T) {
+	// A different IP than the known peer's, so a missed match here is not
+	// rescued by the post-resolution check either.
+	calls := countingResolver(t, []net.IP{net.ParseIP("44.0.0.8")}, nil)
+	pg := discardGovernor()
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "Relay.Example.com:3001",
+		NormalizedAddress: "44.0.0.7:3001",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateCold,
+	})
+	pg.mu.Unlock()
+
+	require.False(t, pg.addLedgerPeer("relay.example.com:3001"),
+		"the same relay under different casing must not be added twice")
+	assert.Equal(t, int64(0), calls.Load(),
+		"a case-insensitive match must be decided without DNS")
+
+	pg.mu.Lock()
+	peerCount := len(pg.peers)
+	pg.mu.Unlock()
+	assert.Equal(t, 1, peerCount, "no duplicate peer for the same relay")
+}
+
 // A relay hostname already on the deny list must not be resolved. Deny
 // entries for unresolvable hostnames are keyed on the lowercased hostname,
 // which is exactly what the pre-resolution check can compare against.

--- a/peergov/ledger_discovery_resolution_test.go
+++ b/peergov/ledger_discovery_resolution_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingResolver installs a lookupIPAddr stub that counts calls and returns
+// a fixed result, restoring the previous resolver on cleanup.
+func countingResolver(
+	t *testing.T,
+	ips []net.IP,
+	err error,
+) *atomic.Int64 {
+	t.Helper()
+	calls := new(atomic.Int64)
+	old := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls.Add(1)
+		return ips, err
+	}
+	t.Cleanup(func() { lookupIPAddr = old })
+	return calls
+}
+
+func discardGovernor() *PeerGovernor {
+	return NewPeerGovernor(PeerGovernorConfig{
+		Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus: newMockEventBus(),
+	})
+}
+
+func nxdomain(host string) error {
+	return errors.New("lookup " + host + ": no such host")
+}
+
+// A relay address that already belongs to a known peer must not be resolved
+// again. Ledger discovery re-offers the full relay set every round, so
+// resolving before the exists check re-resolves every healthy connected peer
+// and every dead hostname on every round.
+func TestAddLedgerPeer_KnownPeerSkipsDNSResolution(t *testing.T) {
+	calls := countingResolver(t, nil, nxdomain("relay.example.com"))
+	pg := discardGovernor()
+	pg.mu.Lock()
+	pg.peers = append(pg.peers, &Peer{
+		Address:           "relay.example.com:3001",
+		NormalizedAddress: "44.0.0.7:3001",
+		Source:            PeerSourceTopologyLocalRoot,
+		State:             PeerStateCold,
+	})
+	pg.mu.Unlock()
+
+	require.False(t, pg.addLedgerPeer("relay.example.com:3001"),
+		"an already-known relay must not be added twice")
+	assert.Equal(t, int64(0), calls.Load(),
+		"an already-known ledger relay must not be re-resolved")
+
+	pg.mu.Lock()
+	_, known := pg.ledgerKnownAddrs["44.0.0.7:3001"]
+	pg.mu.Unlock()
+	assert.True(t, known,
+		"skipping resolution must still record the peer as ledger-known")
+}
+
+// A relay hostname already on the deny list must not be resolved. Deny
+// entries for unresolvable hostnames are keyed on the lowercased hostname,
+// which is exactly what the pre-resolution check can compare against.
+func TestAddLedgerPeer_DeniedHostnameSkipsDNSResolution(t *testing.T) {
+	calls := countingResolver(t, nil, nxdomain("dead.example.com"))
+	pg := discardGovernor()
+	pg.mu.Lock()
+	pg.denyList["dead.example.com:3001"] = time.Now().
+		Add(defaultDenyDuration)
+	pg.mu.Unlock()
+
+	require.False(t, pg.addLedgerPeer("DEAD.example.com:3001"),
+		"a denied relay must not be added")
+	assert.Equal(t, int64(0), calls.Load(),
+		"a denied ledger relay must not be resolved")
+}
+
+// The negative case for the two above: an unknown, undenied relay must still
+// be resolved and added, so the reordering cannot silently stop discovery.
+func TestAddLedgerPeer_UnknownRelayStillResolves(t *testing.T) {
+	calls := countingResolver(t, []net.IP{net.ParseIP("44.0.0.9")}, nil)
+	pg := discardGovernor()
+
+	require.True(t, pg.addLedgerPeer("fresh.example.com:3001"))
+	assert.Equal(t, int64(1), calls.Load(),
+		"a fresh relay hostname must still be resolved once")
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+	require.Len(t, pg.peers, 1)
+	assert.Equal(t, "44.0.0.9:3001", pg.peers[0].NormalizedAddress,
+		"the peer must be keyed on the resolved address")
+}
+
+// A hostname that failed to resolve is cached as a negative result, so the
+// next discovery round skips the lookup entirely rather than repeating it.
+func TestResolveLedgerDiscoveryAddress_NegativeCacheSuppressesLookups(
+	t *testing.T,
+) {
+	calls := countingResolver(t, nil, nxdomain("dead.example.com"))
+	pg := discardGovernor()
+	ctx := context.Background()
+
+	first := pg.resolveLedgerDiscoveryAddress(ctx, "dead.example.com:3001")
+	second := pg.resolveLedgerDiscoveryAddress(ctx, "dead.example.com:3001")
+
+	assert.Equal(t, "dead.example.com:3001", first,
+		"a failed resolution still falls back to the bare hostname")
+	assert.Equal(t, first, second,
+		"a cached failure must return the same fallback address")
+	assert.Equal(t, int64(1), calls.Load(),
+		"a cached resolution failure must not be looked up again")
+}
+
+// The negative cache is bounded in time: once an entry expires the hostname
+// is resolved for real again, so a relay that starts resolving recovers
+// instead of staying pinned as dead.
+func TestResolveLedgerDiscoveryAddress_NegativeCacheExpiresAndRecovers(
+	t *testing.T,
+) {
+	failing := new(atomic.Bool)
+	failing.Store(true)
+	calls := new(atomic.Int64)
+	old := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls.Add(1)
+		if failing.Load() {
+			return nil, nxdomain("flaky.example.com")
+		}
+		return []net.IP{net.ParseIP("44.0.0.4")}, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = old })
+
+	pg := discardGovernor()
+	ctx := context.Background()
+	require.Equal(t, "flaky.example.com:3001",
+		pg.resolveLedgerDiscoveryAddress(ctx, "flaky.example.com:3001"))
+	require.Equal(t, int64(1), calls.Load())
+
+	pg.negativeDNSMu.Lock()
+	pg.negativeDNS["flaky.example.com"] = time.Now().Add(-time.Second)
+	pg.negativeDNSMu.Unlock()
+	failing.Store(false)
+
+	got := pg.resolveLedgerDiscoveryAddress(ctx, "flaky.example.com:3001")
+	assert.Equal(t, int64(2), calls.Load(),
+		"an expired negative-cache entry must be re-resolved")
+	assert.Equal(t, "44.0.0.4:3001", got,
+		"a recovered hostname must resolve to its real address")
+
+	pg.negativeDNSMu.Lock()
+	_, cached := pg.negativeDNS["flaky.example.com"]
+	pg.negativeDNSMu.Unlock()
+	assert.False(t, cached,
+		"a successful resolution must leave no cached failure behind")
+}
+
+// The cache is bounded in size: pool-published relay hostnames are untrusted
+// input, so an unbounded map would be a memory sink.
+func TestNegativeDNSCacheIsBounded(t *testing.T) {
+	countingResolver(t, nil, errors.New("no such host"))
+	pg := discardGovernor()
+	ctx := context.Background()
+
+	for i := range negativeDNSCacheMaxEntries + 64 {
+		host := "dead" + strconv.Itoa(i) + ".example.com"
+		pg.resolveLedgerDiscoveryAddress(ctx, host+":3001")
+	}
+
+	pg.negativeDNSMu.Lock()
+	size := len(pg.negativeDNS)
+	pg.negativeDNSMu.Unlock()
+	assert.LessOrEqual(t, size, negativeDNSCacheMaxEntries,
+		"the negative DNS cache must stay bounded")
+}
+
+// A pool publishing a dead relay hostname is a fact about the chain, not an
+// operator-actionable fault, so it must not be logged at WARN.
+func TestResolveLedgerDiscoveryAddress_FailureNotLoggedAtWarn(t *testing.T) {
+	countingResolver(t, nil, nxdomain("dead.example.com"))
+
+	var infoBuf bytes.Buffer
+	pgInfo := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(&infoBuf, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		})),
+	})
+	pgInfo.resolveLedgerDiscoveryAddress(
+		context.Background(),
+		"dead.example.com:3001",
+	)
+	assert.NotContains(t, infoBuf.String(),
+		"failed to resolve ledger relay hostname",
+		"a dead pool-published relay must not warn the operator")
+
+	var debugBuf bytes.Buffer
+	pgDebug := NewPeerGovernor(PeerGovernorConfig{
+		Logger: slog.New(slog.NewJSONHandler(&debugBuf, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	})
+	pgDebug.resolveLedgerDiscoveryAddress(
+		context.Background(),
+		"other-dead.example.com:3001",
+	)
+	assert.Contains(t, debugBuf.String(),
+		"failed to resolve ledger relay hostname",
+		"the failure must stay observable at debug level")
+}

--- a/peergov/peergov.go
+++ b/peergov/peergov.go
@@ -48,6 +48,16 @@ const (
 	defaultEmergencyLedgerPeerRefreshInterval = 30 * time.Second
 	defaultEmergencyDiscoveryCheckInterval    = 30 * time.Second
 
+	// emergencyLedgerRefreshBackoffFactor escalates the emergency refresh
+	// interval once starvation stops being transient. The emergency cadence
+	// exists to recover a collapsed peer pool in seconds; a node that is
+	// still short of upstreams after many rounds is not going to be rescued
+	// by a faster cadence, and re-running discovery every base interval for
+	// hours re-walks the whole relay set each time. The escalated interval
+	// is capped at LedgerPeerRefreshInterval, so an urgent node never
+	// discovers less often than a healthy one.
+	emergencyLedgerRefreshBackoffFactor = 2
+
 	// Default peer targets match cardano-node config.json defaults.
 	defaultTargetNumberOfKnownPeers       = 150
 	defaultTargetNumberOfEstablishedPeers = 50
@@ -124,6 +134,17 @@ const (
 	// remain stale after interface or routing changes while avoiding a
 	// per-dial interface scan.
 	dialFamilyCacheTTL = 1 * time.Minute
+	// negativeDNSCacheTTL bounds how long a failed ledger-relay resolution
+	// suppresses further lookups for the same hostname. Ledger discovery
+	// re-offers the full relay set every round, and a pool that published a
+	// dead hostname usually keeps publishing it, so without this every dead
+	// entry is re-resolved on every round forever. The TTL keeps a hostname
+	// that starts resolving from being pinned as dead.
+	negativeDNSCacheTTL = 15 * time.Minute
+	// negativeDNSCacheMaxEntries bounds the negative cache. Relay hostnames
+	// come from on-chain pool registrations and are untrusted input, so the
+	// cache must not be able to grow without limit.
+	negativeDNSCacheMaxEntries = 1024
 )
 
 // Peer source priority values for removal decisions.
@@ -150,9 +171,19 @@ type PeerGovernor struct {
 	config                PeerGovernorConfig
 	lastLedgerPeerRefresh atomic.Int64        // UnixNano timestamp of last ledger peer discovery
 	ledgerKnownAddrs      map[string]struct{} // addresses seen from ledger discovery
-	bootstrapExited       bool                // Whether bootstrap peers have been exited
-	lastBootstrapExit     time.Time           // Timestamp of most recent bootstrap exit
-	inboundPruned         int                 // cumulative inbound prunes since start
+	// emergencyRefreshRounds counts consecutive emergency ledger-discovery
+	// rounds since the node last had enough upstreams. It drives the
+	// escalating emergency refresh interval and resets on recovery.
+	emergencyRefreshRounds atomic.Uint32
+	// negativeDNS caches ledger relay hostnames that failed to resolve,
+	// keyed by lowercased hostname, valued by cache expiry. Guarded by
+	// negativeDNSMu rather than mu: resolution happens outside the peer
+	// lock, and must stay that way.
+	negativeDNSMu     sync.Mutex
+	negativeDNS       map[string]time.Time
+	bootstrapExited   bool      // Whether bootstrap peers have been exited
+	lastBootstrapExit time.Time // Timestamp of most recent bootstrap exit
+	inboundPruned     int       // cumulative inbound prunes since start
 	// lastEligibleUpstreamSkipLogged edge-triggers the gossip-churn log
 	// that fires when the node is down to its last eligible upstream. The
 	// condition persists across churn intervals, so the INFO line is
@@ -421,6 +452,7 @@ func NewPeerGovernor(cfg PeerGovernorConfig) *PeerGovernor {
 		denyList:          make(map[string]time.Time),
 		permanentDenyList: make(map[string]struct{}),
 		ledgerKnownAddrs:  make(map[string]struct{}),
+		negativeDNS:       make(map[string]time.Time),
 	}
 	if cfg.PromRegistry != nil {
 		p.initMetrics()

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -318,22 +318,89 @@ func (p *PeerGovernor) resolveLedgerDiscoveryAddress(
 		return net.JoinHostPort(ip.String(), port)
 	}
 
+	lowerHost := strings.ToLower(host)
+	// A hostname that just failed to resolve is not retried until its
+	// negative-cache entry expires. Discovery re-offers the whole relay set
+	// every round, so without this a dead hostname costs a lookup (and, for
+	// a timing-out resolver, dialDNSResolveTimeout of the discovery loop) on
+	// every round for as long as the pool keeps publishing it.
+	if p.negativeDNSCached(lowerHost) {
+		return net.JoinHostPort(lowerHost, port)
+	}
+
 	lookupCtx, cancel := context.WithTimeout(ctx, dialDNSResolveTimeout)
 	defer cancel()
 	ips, err := lookupIPAddr(lookupCtx, host)
 	if err != nil || len(ips) == 0 {
-		p.config.Logger.Warn(
+		// Debug, not Warn: a pool publishing a dead relay hostname is a fact
+		// about the chain, not a fault in this node, and there is no
+		// operator action it implies.
+		p.config.Logger.Debug(
 			"failed to resolve ledger relay hostname",
 			"address", address,
 			"host", host,
 			"error", err,
 		)
-		return net.JoinHostPort(strings.ToLower(host), port)
+		// A cancellation from the caller's context says nothing about the
+		// hostname, only about this node's shutdown, so it must not poison
+		// the cache. A lookup that hit dialDNSResolveTimeout is a real
+		// resolution failure and is cached like any other.
+		if ctx.Err() == nil {
+			p.recordNegativeDNS(lowerHost)
+		}
+		return net.JoinHostPort(lowerHost, port)
 	}
 
 	hasV4, hasV6 := p.supportedDialFamilies()
 	ips = filterDialFamilies(ips, hasV4, hasV6)
 	return net.JoinHostPort(ips[0].String(), port)
+}
+
+// negativeDNSCached reports whether host has an unexpired negative-cache
+// entry, deleting the entry when it has expired. Deleting on read is what
+// lets a hostname that starts resolving again recover: the next lookup runs
+// for real, and a success simply writes nothing back.
+func (p *PeerGovernor) negativeDNSCached(host string) bool {
+	p.negativeDNSMu.Lock()
+	defer p.negativeDNSMu.Unlock()
+	expiry, ok := p.negativeDNS[host]
+	if !ok {
+		return false
+	}
+	if time.Now().Before(expiry) {
+		return true
+	}
+	delete(p.negativeDNS, host)
+	return false
+}
+
+// recordNegativeDNS caches a resolution failure for host. The cache is
+// bounded: expired entries are swept first, and if that does not free a slot
+// the entry closest to expiry is evicted, so untrusted on-chain relay
+// hostnames cannot grow the map without limit.
+func (p *PeerGovernor) recordNegativeDNS(host string) {
+	now := time.Now()
+	p.negativeDNSMu.Lock()
+	defer p.negativeDNSMu.Unlock()
+	if _, ok := p.negativeDNS[host]; !ok &&
+		len(p.negativeDNS) >= negativeDNSCacheMaxEntries {
+		for cached, expiry := range p.negativeDNS {
+			if !now.Before(expiry) {
+				delete(p.negativeDNS, cached)
+			}
+		}
+		if len(p.negativeDNS) >= negativeDNSCacheMaxEntries {
+			var oldestHost string
+			var oldestExpiry time.Time
+			for cached, expiry := range p.negativeDNS {
+				if oldestHost == "" || expiry.Before(oldestExpiry) {
+					oldestHost, oldestExpiry = cached, expiry
+				}
+			}
+			delete(p.negativeDNS, oldestHost)
+		}
+	}
+	p.negativeDNS[host] = now.Add(negativeDNSCacheTTL)
 }
 
 // resolveDialAddress returns the concrete transport target to dial for an


### PR DESCRIPTION
Fixes the three defects in #3262, plus the root cause identified in its second comment.

## Changes

**Ledger relay hostnames re-resolved every discovery round.** `addLedgerPeerContext` resolved before the deny-list and exists checks, so denied, already-connected, and permanently dead hostnames were all re-resolved on every round. `ledgerPeerRejectedWithoutDNS` now answers both from the raw address first. Deny entries for an unresolvable hostname are keyed on the lock-free normalized form, which is what makes the dead-hostname case decidable without DNS.

Note one semantic change: when the precheck matches an existing peer it records that peer's own `NormalizedAddress` in `ledgerKnownAddrs`, not a fresh resolution. `countLedgerPeersLocked` matches `ledgerKnownAddrs` against `Peer.NormalizedAddress`, so recording an address no peer holds could never satisfy the "peers from another source count toward the ledger target" intent.

**Emergency discovery had no backoff.** `emergencyLedgerRefreshInterval()` doubles per consecutive urgent round, capped at `LedgerPeerRefreshInterval` so an urgent node never discovers less often than a healthy one, and resets when urgency clears. The round counter increments only after the relay fetch succeeds, so a gated or failed round does not escalate.

**No negative DNS caching.** Failed relay-hostname resolutions are cached for 15 minutes, bounded at 1024 entries (sweep expired, then evict nearest-expiry). Relay hostnames are untrusted on-chain input, so the bound is required. Delete-on-read is what lets a recovered hostname resolve again. A caller-context cancellation is not cached: that is shutdown, not a fact about the hostname.

**Resolution failure logged at WARN.** Now `Debug`. A pool publishing a dead relay hostname is a fact about the chain, not an operator-actionable fault.

**Unreachable-network dials logged at ERROR.** `isExpectedNetworkDialError` now matches `syscall.ENETUNREACH` and `syscall.EAFNOSUPPORT` via `errors.Is`, mirroring `isAddrInUseError` in the same file, plus the message forms. Scoped to Unix-like platforms; Windows reports these as WSA codes with different message text and is not covered.

**Duplicated `component=peergov`.** Three call sites passed the attribute on a logger that already carries it, not one: `connections.go` plus two Debug calls in `ledger_discovery.go` that did not surface in the WARN-level run.

`peergov/doc.go` gains a Ledger peer discovery section covering the cadence, backoff, and negative caching.

## Validation

| Check | Result |
| --- | --- |
| `go test -race -count=1 ./peergov/` | pass |
| `go test -race -timeout 30m ./...` | pass, 76 packages, 0 failures |
| `internal/test/conformance` | pass, 11.2s |
| `internal/test/devnet/run-tests.sh --accelerated` | pass, `TestAcceleratedScenarioTimeline` 118.6s |
| `golangci-lint run ./...` | 0 issues |
| `nilaway`, `modernize ./peergov/` | clean |
| `make import-boundaries`, `docs-parity`, `gorm-check`, `golines` | pass, no reformat |
| Cross-build windows/linux/darwin x amd64/arm64 | pass |

Each of the eight fixes was reverted individually and the corresponding test failed without it. `./peergov/` was green on `origin/main` beforehand, so no failure here is pre-existing.

## Not covered

- **The devnet does not exercise ledger discovery.** All four dingo topologies set `useLedgerAfterSlot: -1`, so this run is a no-regression check, not coverage of the discovery changes.
- No live long-run reproduction. The 105k-warning figure in the issue comes from a 22.7h preview node; no equivalent run was performed here.
- Windows dial-error classification is untested and deliberately uncovered.
- `--conformance` devnet mode not run; no wire or era compatibility change.
- `make govulncheck` not run (requires network). `make sql-check` not applicable.

`DATABASE.md` and `ARCHITECTURE.md` checked and unaffected: no schema, package boundary, EventBus, or composition change.

Out of scope, as the issue suggests: the peer-pool health question (63 hot promotions against 14933 drops), #2018, and #3315.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces DNS churn and warning volume in `peergov` ledger discovery, adds emergency backoff, and avoids duplicate peers by matching ledger relay hostnames case-insensitively. Previously each round re-resolved denied/dead/already-connected hostnames and warned on failures; now pre-DNS filters and a bounded negative cache avoid repeats, failures log at debug, emergency refresh escalates then caps at the normal interval, and hostname casing no longer creates duplicate peers.

- Ledger discovery
  - Checks deny list and known peers before DNS; records an existing peer’s normalized address so peers from other sources count toward the target.
  - Matches relay hostnames case-insensitively (normalized on both sides) in pre- and post-resolution checks to prevent duplicate peers for the same relay.
  - Caches failed hostname resolutions for 15 minutes (max 1024 entries), sweeps/evicts oldest, and deletes on read so recovered hosts resolve again; does not cache caller cancellations.

- Cadence, logging, and errors
  - Emergency interval doubles per consecutive urgent round, capped at the normal refresh interval, reset on recovery; counter increments only after a successful relay fetch.
  - Resolution failures move from WARN to Debug.
  - Treats `ENETUNREACH` and `EAFNOSUPPORT` as expected dial errors (Unix-like), including message-text variants.
  - Removes duplicated `component=peergov` logger attribute.

- Docs/tests and impact
  - Documents discovery cadence, backoff, and negative DNS caching; adds focused tests (backoff, negative caching, case-insensitive matching, dial-error classification, log attribute).
  - No config, schema, or wire compatibility changes; no operator action required.

<sup>Written for commit e68d4e6678bd2ede2fc7f54e5256ab41eea7c18f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ledger peer discovery by skipping DNS lookups for known or denied peers.
  * Added caching for failed hostname lookups, with expiration and bounded storage.
  * Added adaptive backoff for repeated emergency peer-discovery refreshes, resetting after recovery.
* **Bug Fixes**
  * Improved handling of expected network connection errors.
  * Removed duplicate information from short-lived connection warnings.
  * Reduced noisy logging for unresolved relay hostnames.
* **Documentation**
  * Documented ledger peer discovery, refresh timing, emergency backoff, and hostname resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->