### PR TITLE
test(chainsync): make arrival ordering deterministic

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1708,7 +1708,11 @@ func (o *Ouroboros) chainsyncClientRollForwardRaw(
 	// Record arrival at the raw network callback boundary. Header decoding can
 	// block behind another peer's in-flight decode of the same bytes, so a
 	// timestamp taken by the decoded handler would already include local work.
-	arrivalTime := time.Now()
+	arrivalNow := o.chainsyncArrivalNow
+	if arrivalNow == nil {
+		arrivalNow = time.Now
+	}
+	arrivalTime := arrivalNow()
 	key := hashDecodeInput(blockType, blockData)
 	header, err := decodeWithPanicSafeMetrics(
 		o.headerDecodeCache,

--- a/ouroboros/chainsync_arrival_test.go
+++ b/ouroboros/chainsync_arrival_test.go
@@ -106,6 +106,12 @@ func TestChainsyncClientRollForwardRawRecordsArrivalBeforeDecodeWait(
 	header, err := o.decodeChainsyncHeader(headerType, raw)
 	require.NoError(t, err)
 	key := hashDecodeInput(headerType, raw)
+	expectedArrival := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	arrivalCaptured := make(chan struct{}, 1)
+	o.chainsyncArrivalNow = func() time.Time {
+		arrivalCaptured <- struct{}{}
+		return expectedArrival
+	}
 
 	// Claim this decode key so the real raw callback has to wait. The arrival
 	// timestamp must already be captured before it joins that wait.
@@ -134,12 +140,17 @@ func TestChainsyncClientRollForwardRawRecordsArrivalBeforeDecodeWait(
 			ochainsync.Tip{},
 		)
 	}()
+	testutil.RequireReceive(
+		t,
+		arrivalCaptured,
+		2*time.Second,
+		"raw callback should capture arrival before waiting on decode",
+	)
 	testutil.WaitForCondition(t, func() bool {
 		o.headerDecodeCache.mu.Lock()
 		defer o.headerDecodeCache.mu.Unlock()
 		return len(o.headerDecodeCache.inFlight[key]) == 1
 	}, 2*time.Second, "raw callback should wait on the claimed decode")
-	releasedAt := time.Now()
 	release()
 	require.NoError(t, testutil.RequireReceive(
 		t,
@@ -156,7 +167,7 @@ func TestChainsyncClientRollForwardRawRecordsArrivalBeforeDecodeWait(
 	)
 	data, ok := evt.Data.(ledger.ChainsyncEvent)
 	require.True(t, ok)
-	require.True(t, data.ArrivalTime.Before(releasedAt))
+	require.Equal(t, expectedArrival, data.ArrivalTime)
 }
 
 func TestChainsyncHeaderAdmissionIsPreObservationAndPeerLocal(t *testing.T) {

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -124,6 +124,9 @@ type Ouroboros struct {
 	chainsyncHeaderAdmission chainsyncHeaderAdmissionFunc
 	chainsyncHeaderSlotTime  func(uint64) (time.Time, error)
 	chainsyncScheduleAt      chainsyncScheduleAtFunc
+	// chainsyncArrivalNow is an instance-local clock seam for deterministic
+	// arrival-order tests. Production instances use time.Now.
+	chainsyncArrivalNow      func() time.Time
 	futureHeaderResyncMu     sync.Mutex
 	futureHeaderResyncs      map[ouroboros.ConnectionId]*scheduledChainsyncResync
 	futureHeaderResyncCtx    context.Context
@@ -392,6 +395,7 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 			map[ouroboros.ConnectionId]*chainsyncPeerStats,
 		),
 		chainsyncScheduleAt: defaultChainsyncScheduleAt,
+		chainsyncArrivalNow: time.Now,
 		futureHeaderResyncs: make(
 			map[ouroboros.ConnectionId]*scheduledChainsyncResync,
 		),


### PR DESCRIPTION
Inject the ChainSync arrival clock and synchronize capture-before-decode ordering without relying on wall-clock resolution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ChainSync arrival ordering deterministic by injecting a clock and capturing arrival before any decode wait. This removes wall-clock dependence that caused flaky Windows tests; production behavior stays the same.

- Add `chainsyncArrivalNow` to `ouroboros.Ouroboros`, defaulting to `time.Now`, and use it in the ChainSync raw callback to timestamp arrivals before decode waits.
- Update `ouroboros/chainsync_arrival_test.go` to inject a fixed time and assert arrival is captured before waiting and equals the injected value.
- No API or runtime behavior change; only tests depend on the injected clock.

<sup>Written for commit 84efcc223391f04f521d388783b43f7c67c43ec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy and consistency of recorded ChainSync header arrival times.
  - Ensured arrival timestamps are captured before decoding begins, improving timing-sensitive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->