### PR TITLE
fix(mempool): cancel removed consumers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3499,8 +3499,9 @@ dropping one already advertised would silently omit a transaction the peer
 legitimately requested. A non-blocking `NextTx` returns nil once the cache is
 full; a blocking one parks until a slot frees rather than answering empty, since
 the peer's pull loop has no backoff for an empty reply and would spin
-request/reply without pacing. Shutdown releases a parked waiter. Serving a
-body or the peer acknowledging its ids frees slots and reopens the window. The
+request/reply without pacing. Shutdown or connection cleanup releases a parked
+waiter. Serving a body or the peer acknowledging its ids frees slots and
+reopens the window. The
 protocol request window is far below the default limit, so this bounds an
 aggressive peer rather than affecting normal relay. Explicit cache removal and
 clearing preserve the same per-consumer semantics while preventing an idle

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -19,8 +19,10 @@ import (
 )
 
 type MempoolConsumer struct {
-	mempool *Mempool
-	cache   map[string]*MempoolTransaction
+	mempool  *Mempool
+	cache    map[string]*MempoolTransaction
+	done     chan struct{}
+	doneOnce sync.Once
 	// cacheSlot signals that a cache slot was freed, waking a blocking NextTx
 	// that parked on a full cache. Buffered by one and signaled without
 	// blocking: a pending wake-up is all a waiter needs, since it re-checks the
@@ -31,6 +33,9 @@ type MempoolConsumer struct {
 	nextTxIdx   int
 	cacheMutex  sync.Mutex
 	nextTxIdxMu sync.Mutex
+	// onWaitForTx is a test-only hook invoked after a blocking NextTx has
+	// subscribed for additions and is ready to be cancelled.
+	onWaitForTx func()
 }
 
 func newConsumer(mempool *Mempool, cacheLimit int) *MempoolConsumer {
@@ -40,8 +45,18 @@ func newConsumer(mempool *Mempool, cacheLimit int) *MempoolConsumer {
 	return &MempoolConsumer{
 		mempool:    mempool,
 		cache:      make(map[string]*MempoolTransaction),
+		done:       make(chan struct{}),
 		cacheSlot:  make(chan struct{}, 1),
 		cacheLimit: cacheLimit,
+	}
+}
+
+// cancel releases a blocking NextTx when its connection no longer owns the
+// consumer. It is safe to call more than once because connection cleanup can
+// race with other lifecycle paths.
+func (m *MempoolConsumer) cancel() {
+	if m != nil {
+		m.doneOnce.Do(func() { close(m.done) })
 	}
 }
 
@@ -51,6 +66,12 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 	}
 
 	for {
+		select {
+		case <-m.done:
+			return nil
+		default:
+		}
+
 		// Stop handing out transactions once the body cache is full. NextTx is
 		// what puts a tx id on the wire, and the body is served to the peer
 		// later from this cache only. Dropping a cached body to make room would
@@ -75,6 +96,8 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 			select {
 			case <-m.cacheSlot:
 				continue
+			case <-m.done:
+				return nil
 			case <-m.mempool.done:
 				return nil
 			}
@@ -127,6 +150,9 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 		addTxSubId, addTxChan := m.mempool.eventBus.Subscribe(
 			AddTransactionEventType,
 		)
+		if m.onWaitForTx != nil {
+			m.onWaitForTx()
+		}
 		m.nextTxIdxMu.Unlock()
 		m.mempool.RUnlock()
 
@@ -136,6 +162,9 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 			m.mempool.eventBus.Unsubscribe(AddTransactionEventType, addTxSubId)
 			// Loop back to check if transaction is available
 			// This naturally handles the case of multiple rapid additions
+		case <-m.done:
+			m.mempool.eventBus.Unsubscribe(AddTransactionEventType, addTxSubId)
+			return nil
 		case <-m.mempool.done:
 			// Mempool is shutting down, unsubscribe and exit
 			m.mempool.eventBus.Unsubscribe(AddTransactionEventType, addTxSubId)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -718,8 +718,10 @@ func (m *Mempool) NewConsumer(connId ouroboros.ConnectionId) Consumer {
 
 func (m *Mempool) RemoveConsumer(connId ouroboros.ConnectionId) {
 	m.consumersMutex.Lock()
+	consumer := m.consumers[connId]
 	delete(m.consumers, connId)
 	m.consumersMutex.Unlock()
+	consumer.cancel()
 }
 
 func (m *Mempool) Stop(ctx context.Context) error {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -4036,6 +4036,27 @@ func TestMempoolConsumer_BlockingNextTxReleasedOnStop(t *testing.T) {
 	), "shutdown returns nil rather than a transaction")
 }
 
+// Removing a connection-owned consumer must release a blocking NextTx. The
+// TxSubmission callback owns no goroutine beyond this wait, so retaining it
+// after a connection closes would leak the callback indefinitely.
+func TestMempoolConsumer_BlockingNextTxReleasedOnConsumerRemoval(t *testing.T) {
+	m := newTestMempool(t)
+	connId := newTestConnectionId(0)
+	consumer := m.AddConsumer(connId)
+	require.NotNil(t, consumer)
+	waiting := make(chan struct{})
+	consumer.onWaitForTx = func() { close(waiting) }
+
+	got := make(chan *MempoolTransaction, 1)
+	go func() { got <- consumer.NextTx(true) }()
+	dingotestutil.RequireReceive(t, waiting, 2*time.Second, "blocking NextTx")
+
+	m.RemoveConsumer(connId)
+	assert.Nil(t, dingotestutil.RequireReceive(
+		t, got, 2*time.Second, "blocking NextTx released by consumer removal",
+	))
+}
+
 // blockingRejectingValidator blocks until released like
 // blockingSessionValidator, then reports one designated transaction invalid so
 // a test can observe whether revalidation actually published its result.


### PR DESCRIPTION
## Summary

- give each transaction relay consumer an idempotent connection-lifecycle cancellation signal
- release blocking empty-pool and full-cache waits when the consumer is removed
- preserve active consumer wait and transaction-delivery behavior
- document connection cleanup at the mempool boundary

## Testing

- focused cancellation race regression (100 repetitions)
- `go test -tags dingo_extra_plugins -race ./mempool`
- repeated TxSubmission connection-cleanup race test
- `go vet -tags dingo_extra_plugins ./mempool`
- `go test -tags dingo_extra_plugins ./internal/test/conformance/`
- `make docs-parity`
- `make import-boundaries`
- `make golines`

Closes #3475


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel removed `mempool` consumers so blocking `NextTx` calls return nil instead of leaking after connection close (addresses #3475). Previously, a removed consumer could stay parked; now per-consumer cancellation signals release without changing active delivery semantics.

- Review notes
  - Add idempotent cancellation to `MempoolConsumer` via `done` and `cancel()`, and check `done` in `NextTx` during cache-full and add-tx waits.
  - `Mempool.RemoveConsumer` now cancels the consumer after removing it from the map.
  - Behavior change: removing a consumer releases any blocked waiters; shutdown behavior is unchanged; transaction selection and cache semantics are unchanged.
  - Update `ARCHITECTURE.md` to state connection cleanup releases parked waiters.
  - Add test to assert `NextTx(true)` is released on consumer removal; race/conformance suites exercised.

<sup>Written for commit 851f942cd3052103d04d1ca71521e15aaf7745f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

